### PR TITLE
feat(btd6): buff decode 5→8 types + verify Deflation/Double Cash in-game

### DIFF
--- a/disbot/data/btd6/modes.json
+++ b/disbot/data/btd6/modes.json
@@ -65,11 +65,11 @@
       "aliases": ["deflate"],
       "starting_cash": 20000,
       "starting_lives": 200,
-      "description": "Easy-difficulty mode starting at round 31 with a fixed lump of cash and no income — win with what you can afford up front.",
+      "description": "Easy-difficulty mode: start at round 31 with $20,000 cash and earn no more — win with what you start with (verified in-game).",
       "difficulties": ["easy"],
       "restrictions": [
-        "Starts at round 31",
-        "No income — popping bloons earns no cash",
+        "Starts at round 31 with $20,000 cash",
+        "No income — you cannot earn any more cash",
         "No selling towers"
       ]
     },

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -34,15 +34,26 @@ works** (the traps we hit), and what is still un-decoded.
 
 ### Session log — buff decode started (2 confirmed types)
 
-- **Buffs — decode progressing, correctness-first (5 of 38).** Added three more
-  confirmed types this pass: `SubCommanderSupportModel` (pierce/damage add +
-  damage mult, Sub 0-0-5 = 4/0/2), `PiercePercentageSupportModel.percentIncrease`
-  → `pierceMultiplier` (Mermonkey 1.1/1.2/1.4), and `TradeEmpireBuffModel`
-  (cash-per-round + flat damage additives, Buccaneer 0-0-5). A roster-wide
-  value-discovery harness surfaced candidates; each was hand-vetted on its tower
-  (it does produce false positives from value coincidence — e.g.
-  `distanceMultiplier`→`lifespanMultiplier` — so the harness is a lead, not a
-  source of truth). Original 2-type slice below.
+- **Buffs — decode progressing, correctness-first (8 of 38).** Confirmed eight
+  types across two passes (each value hand-vetted exact against committed wiki
+  data on a matching tier): `RateSupportModel`, `PoplustSupportModel`,
+  `SubCommanderSupportModel` (Sub 0-0-5 = 4/0/2), `PiercePercentageSupportModel`
+  (Mermonkey 1.1/1.2/1.4), `TradeEmpireBuffModel` (Buccaneer 0-0-5),
+  `PlacementAreaTypeRangeBuffModel` (Mermonkey in-water 1.35),
+  `StartOfRoundRateBuffModel` (Engineer/Spike: `modifier`→`rateMultiplier` 0.25,
+  `duration`→`lifespan` — two-tower), and `PrinceOfDarknessZombieBuffModel`
+  (Wizard Undead: `damageIncrease`→`damageAdditive` 3, `distanceMultiplier`→
+  `lifespanMultiplier` 1.5).
+  - **Verification discipline note:** the roster-wide discovery harness is a
+    *lead generator*, not truth — it ranks candidates by value coincidence. The
+    **committed wiki data is the arbiter**: e.g. `distanceMultiplier`→
+    `lifespanMultiplier` *looked* like a semantic false positive, but the
+    committed Undead buff carries `lifespanMultiplier 1.5` and the only raw 1.5
+    is `distanceMultiplier`, so it is in fact the correct correspondence. Vet
+    each candidate against the committed value, not against priors.
+  - Also this pass: confirmed **Deflation = start round 31 with $20,000, no
+    income** (in-game screenshots), and that **Double Cash doubles the starting
+    cash** ($40,400 = 2×$20,200 with the ×2 modifier active).
 - **Buffs — decode started, correctness-first (2 of 38).** `_buffs()` now emits a
   `buffs[]` entry per top-level `*SupportModel`/`*BuffModel`, but **only writes a
   number for types confirmed against the committed wiki value on a matching tier**:
@@ -468,7 +479,7 @@ must not be treated as done. Verified against the v55 dump on 2026-06-03.
 | **Subtowers** (`subtowers[]`) | 3 spawn models: `AbilityCreateTower`/`CreateTower`/`MorphTower`(embedded) → Phoenix, Sentry, Spectre, totems, UAV | `MorphTowerModel` **named-ref** (Alchemist "Transformed Monkey") + `BeastHandlerPetModel` (Beast Handler) — 2 of ~4 mechanisms |
 | **Zones** (`zones[]`) — **started** | `_zones()` emits every top-level `*ZoneModel` as `{kind, name, + decodable numbers}` (e.g. Ice Arctic Wind → `speedScale 0.6`, `zoneRadius 25`); wired into `_map_tier`, audit-safe (internal names don't align with curated, so they're ignored) | the rest of the 28 types' specific effect fields; zones nested inside sub-towers; curated display names (not in the dump — stay wiki-owned); runtime `_zone_text` only renders damage-style zones |
 | **Projectile flattening completeness** | spawn-model coverage (under-emission 177→111) | 111 attacks still differ in projectile count vs wiki; flattening *style* (naming/grouping) differs |
-| **Buffs** (`buffs[]`) — **started (5 of 38)** | `_buffs()` decodes the five types **confirmed exact against committed wiki values on a matching tier**: `RateSupportModel`→`rateMultiplier` (Sniper 0.75); `PoplustSupportModel`→`ratePercentage`/`piercePercentage` (Druid 0.15); `SubCommanderSupportModel`→`pierceAdditive`/`damageAdditive`/`damageMultiplier` (Sub 4/0/2); `PiercePercentageSupportModel.percentIncrease`→`pierceMultiplier` (Mermonkey 1.1/1.2/1.4); `TradeEmpireBuffModel`→cash-per-round + `damageAdditive[ForCeramic/ForMoabs]` (Bucc). Wired into `_map_tier`, audit-safe (internal names) | the other 33 `*SupportModel`/`*BuffModel` types — each needs same-tier confirmation before its number is written (e.g. `PierceSupportModel.pierce`→`pierceAdditive` is **NOT** confirmed; the wiki's pierce buffs are multipliers from a different model). `SCHEMA_FIRST` types (projectile-speed/radius, freeze-duration, banana-cash) also need a new renderer field. **A roster-wide value-discovery harness exists** but flags false positives from value coincidence (e.g. `distanceMultiplier`→`lifespanMultiplier`), so each candidate is still hand-vetted |
+| **Buffs** (`buffs[]`) — **started (8 of 38)** | `_buffs()` decodes eight types **confirmed exact against committed wiki values on a matching tier**: `RateSupportModel`, `PoplustSupportModel`, `SubCommanderSupportModel`, `PiercePercentageSupportModel`, `TradeEmpireBuffModel`, `PlacementAreaTypeRangeBuffModel`, `StartOfRoundRateBuffModel`, `PrinceOfDarknessZombieBuffModel` (see `_BUFF_FIELD_MAP` for the exact field map + the tier each was verified on). Wired into `_map_tier`, audit-safe (internal names) | the other 30 `*SupportModel`/`*BuffModel` types — each needs same-tier confirmation before its number is written (e.g. `PierceSupportModel.pierce`→`pierceAdditive` is **NOT** confirmed; the wiki's pierce buffs are multipliers from a different model). `SCHEMA_FIRST` types (projectile-speed/radius, freeze-duration, banana-cash) also need a new renderer field. The discovery harness is a lead generator; vet each candidate against the committed value (it is the arbiter, not semantic priors) |
 | **Numeric overlay applied** | 3 files (Desperado range, mermonkey xp, ace cost), uniquely-keyed only | per-projectile/ability values cannot be safely overlaid (wiki↔dump name mismatch) |
 
 ### 🔴 Not started

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -588,6 +588,21 @@ _BUFF_FIELD_MAP: dict[str, dict[str, str]] = {
         "ceramicDamageBuff": "damageAdditiveForCeramic",
         "moabDamageBuff": "damageAdditiveForMoabs",
     },
+    # rangeMultiplier passes through 1:1 (Mermonkey in-water buff: 1.35).
+    "PlacementAreaTypeRangeBuffModel": {"rangeMultiplier": "rangeMultiplier"},
+    # Engineer/Spike start-of-round buff (×0.25 cooldown for N rounds): two-tower
+    # confirmation (modifier 0.25→rateMultiplier; duration 1/3→lifespan).
+    "StartOfRoundRateBuffModel": {
+        "modifier": "rateMultiplier",
+        "duration": "lifespan",
+    },
+    # Wizard Necromancer "Undead Bloon buff": the committed wiki data maps
+    # distanceMultiplier→lifespanMultiplier (raw 1.5 == wiki 1.5), so it is the
+    # correct field correspondence for this type, not a coincidence.
+    "PrinceOfDarknessZombieBuffModel": {
+        "damageIncrease": "damageAdditive",
+        "distanceMultiplier": "lifespanMultiplier",
+    },
 }
 
 

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -979,3 +979,45 @@ def test_buffs_trade_empire_cash_and_damage(mod):
     assert buff["damageAdditive"] == 1
     assert buff["damageAdditiveForCeramic"] == 1
     assert buff["damageAdditiveForMoabs"] == 1
+
+
+def test_buffs_start_of_round_rate(mod):
+    # Engineer/Spike start-of-round buff: modifier 0.25 -> rateMultiplier,
+    # duration -> lifespan (two-tower confirmed).
+    model = _tower_model()
+    model["behaviors"].append(
+        {
+            "$type": _t("StartOfRoundRateBuffModel"),
+            "modifier": 0.25,
+            "duration": 3.0,
+            "Duration": 3.0,
+            "durationFrames": 0,
+        }
+    )
+    buff = mod._map_tier(model)["buffs"][0]
+    assert buff["rateMultiplier"] == 0.25
+    assert buff["lifespan"] == 3
+
+
+def test_buffs_placement_area_range_passthrough(mod):
+    model = _tower_model()
+    model["behaviors"].append(
+        {"$type": _t("PlacementAreaTypeRangeBuffModel"), "rangeMultiplier": 1.35}
+    )
+    assert mod._map_tier(model)["buffs"][0]["rangeMultiplier"] == 1.35
+
+
+def test_buffs_prince_of_darkness_distance_is_lifespan_multiplier(mod):
+    # The committed wiki data maps distanceMultiplier -> lifespanMultiplier
+    # (Undead buff 1.5), so it is the correct field, not a coincidence.
+    model = _tower_model()
+    model["behaviors"].append(
+        {
+            "$type": _t("PrinceOfDarknessZombieBuffModel"),
+            "damageIncrease": 3.0,
+            "distanceMultiplier": 1.5,
+        }
+    )
+    buff = mod._map_tier(model)["buffs"][0]
+    assert buff["damageAdditive"] == 3
+    assert buff["lifespanMultiplier"] == 1.5


### PR DESCRIPTION
## Summary

Next buff-decode pass (**5 → 8 of 38**), plus the Deflation/Double Cash confirmation from your screenshots.

### Three more confirmed buff types (each hand-vetted exact vs committed wiki)
| Type | Mapping | Confirmation |
|---|---|---|
| `PlacementAreaTypeRangeBuffModel` | `rangeMultiplier→rangeMultiplier` | Mermonkey in-water 1.35 |
| `StartOfRoundRateBuffModel` | `modifier→rateMultiplier`, `duration→lifespan` | Engineer 0.25/1 + Spike 0.25/3 (two-tower) |
| `PrinceOfDarknessZombieBuffModel` | `damageIncrease→damageAdditive`, `distanceMultiplier→lifespanMultiplier` | Wizard Undead 3 / 1.5 |

### A correction worth calling out
Last pass I flagged `distanceMultiplier→lifespanMultiplier` as a likely *false positive* on semantic grounds. It isn't: the committed Undead buff carries `lifespanMultiplier 1.5` and the only raw 1.5 is `distanceMultiplier`, so it's the **correct** correspondence. This reinforces the discipline now written into the doc — **the committed value is the arbiter, not semantic priors.**

### Deflation / Double Cash (your screenshots)
- **Deflation** confirmed: start round 31 with **$20,000**, no income. My `starting_cash: 20000` was already correct; tightened the description.
- **Double Cash** doubling confirmed: the $40,400 shot = 2×$20,200 with the ×2 modifier active — validates the modifier note from PR #489.

## Safety / tests
`--audit` stays **nothing-SUSPECT** (buff names are internal → audit ignores them). 3 hermetic tests added (58 total); lint + architecture clean (no `disbot/` source touched). Docs: buffs 5→8 of 38 + the verification note.

## Remaining
30 buff types (one+ confirmed per pass) + `SCHEMA_FIRST` renderer fields; the zone effect tail; sub-tower-nested zones/buffs; then economy-attack suppression → the tower cutover.

https://claude.ai/code/session_01TJvgoQyKFxXrUUQ9iWsGhn

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJvgoQyKFxXrUUQ9iWsGhn)_