### PR TITLE
docs(btd6): session wrap-up — reconcile decode docs + clear next-session start

### DIFF
--- a/docs/btd6-game-file-extraction-plan.md
+++ b/docs/btd6-game-file-extraction-plan.md
@@ -131,8 +131,14 @@ audit flags as systematically divergent stay curated.
    `MorphTowerModel` (embedded) are mapped (Phoenix, Sentry, Spectre, totems,
    UAV). Still missing: `MorphTowerModel` **named-ref** (Alchemist "Transformed
    Monkey") and `BeastHandlerPetModel` (Beast Handler).
-2. **Damage zones** — `zones[]` (12 model types). 🔴 **Not yet mapped.**
-3. **Buffs** — `buffs[]` (37 support/buff model types). 🔴 **Not yet mapped.**
+2. **Damage zones** — `zones[]` (**28** `*ZoneModel` types). 🟡 **Started** —
+   `_zones()` emits every top-level zone with decodable numbers (e.g. Ice Arctic
+   Wind `speedScale 0.6`). Remaining: the per-type effect tail + nested zones.
+3. **Buffs** — `buffs[]` (**38** support/buff types). 🟡 **Started — 8 of 38**
+   confirmed in `_BUFF_FIELD_MAP` (each value-verified against committed wiki on
+   a matching tier). The cleanly value-confirmable set is now largely exhausted;
+   the rest need per-model analysis or have no committed ground truth.
+   **Authoritative status: `btd6-gamedata-decode-status.md`.**
 4. **Economy-tower attack suppression** — the raw model gives Banana Farm a
    nominal `AttackModel`, so `has_combat_stats` trips true; needs a "no real
    damage ⇒ not combat" filter so the Pro button/embed stay off. 🔴 Not done.

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -9,6 +9,48 @@ works** (the traps we hit), and what is still un-decoded.
 
 ## ⭐ Next session — start here (updated 2026-06-04, end of v55 session)
 
+### Current state & next actions (READ FIRST)
+
+**Where the data stands (verified on `main`, full CI green):**
+- **Towers** 25, **Heroes** 17, **Rounds** 140 — towers/rounds/bloons still
+  **wiki-sourced** (no cutover yet); the 11 wiki-missing heroes are game-data.
+- **Maps** 89 — **fully cut over to game data** (`--maps`), with `has_water`.
+- **Modes** 18 — **curated** taxonomy: 3 difficulties (Easy/Medium/Hard) + 13
+  modes (Standard is the base mode in every difficulty) + 2 modifiers (Double
+  Cash, Fast Track; relative-effect, no fixed numbers).
+- **Mapper** (`scripts/parse_gamedata.py`): faithful — `--audit` is
+  **nothing-SUSPECT**, anchors pass. Decodes attacks/projectiles/sub-projectiles,
+  **subtowers** (2 of 4 mechanisms), **zones** (top-level, started), **buffs**
+  (**8 of 38** confirmed types in `_BUFF_FIELD_MAP`).
+
+**Do next (ordered; correctness over speed — the maintainer's standing rule):**
+1. **Buff decode tail (8 → 38).** The cleanly value-confirmable set is now
+   *exhausted* — every remaining committed buff field either has **no committed
+   ground-truth `buffs[]` entry** to verify against (e.g. `RangeSupportModel` on
+   Village) or needs a **value transformation** (raw multiplier → wiki
+   percentage) that the value-coincidence harness can't confirm. So each
+   remaining type needs **per-model semantic analysis**, and for types with no
+   committed counterpart, correctness can only be validated *at/after the
+   cutover*. Do **not** write a number you can't confirm.
+2. **`SCHEMA_FIRST` buff/zone types** — projectile speed/radius, freeze duration,
+   banana-cash, etc. carry a real number but `_BUFF_FIELDS` /
+   `btd6_upgrade_detail_service` has no field to render it. Extend the renderer
+   first, then decode.
+3. **Zone effect tail** (28 types) + zones **nested in sub-towers**.
+4. **Economy-tower attack suppression** (Banana Farm's nominal `AttackModel`) +
+   preserve `paragon_cost`/`paragon_name` — cutover prerequisites.
+5. **The tower cutover** (overlay numbers, or full game-native) — gated on 1–4
+   plus the `NameDowngradeError` name guard.
+
+**Binding discipline for every decode step:**
+- Re-validate anchors first (`--validate-anchors`); if they fail the dump moved → stop.
+- Confirm each mapping against the **committed wiki value on a matching tier** —
+  the committed value is the arbiter, **not** semantic priors (the
+  `distanceMultiplier`→`lifespanMultiplier` case proved both directions).
+- Buff/zone `name`s are the dump's **internal** ids → audit aligns by name and
+  ignores them (keeps `--audit` nothing-SUSPECT); never downgrade a curated name.
+- `python3.10 scripts/check_quality.py --full` before pushing.
+
 ### Session log — Maps hub button + correct difficulty/mode/modifier taxonomy
 
 - **Maps button added** to the BTD6 hub (`views/btd6/panel.py`, row 2) →
@@ -742,9 +784,11 @@ curator-supplied name is preserved, never regressed to an internal model string.
    >   `heroXpMultiplier`, `cashbackZoneMultiplier`, …). Slice 2 should widen the
    >   schema to surface these too, not just speed/visibility.
    >
-   > **Slice 1 shipped (#477):** the ×100 render fix only — **no buff/zone
-   > numbers were written**, so the 🔴 "0 of 28 / 0 of 38" below still stands for
-   > the *write*; only the rendering of the already-committed buffs is corrected.
+   > **Slice 1 shipped (#477):** the ×100 render fix only — at that time no
+   > buff/zone numbers were written. **Update (later sessions):** zone decode is
+   > now started and **8 of 38 buff types are written** (`_BUFF_FIELD_MAP`); see
+   > the ✅/🟡 completion tables above for the live counts (the old "0 of 28 /
+   > 0 of 38" no longer holds).
 
 **Lower priority — post-#468 AI-answer enhancements (not roadmap-critical)**
 


### PR DESCRIPTION
## Summary

End-of-session verification + documentation reconciliation (docs only — no code/data change).

### Session verification (all confirmed on `main`)
- Full CI mirror **green** (lint + mypy + tests).
- Mapper `--audit` is **nothing-SUSPECT**; anchors pass (Dart 200, Super 2500).
- Data: **25 towers, 17 heroes, 89 maps, 18 modes (3 difficulty + 13 mode + 2 modifier), 140 rounds**; **8 buff types** decoded in `_BUFF_FIELD_MAP`.

### What this session shipped (PRs #462–#492)
- Game-data **mapper** foundation + closing the 11 wiki-missing heroes.
- **Maps** full cutover (89) + hub **Maps button** + `has_water`.
- **Modes** corrected to the real difficulty/mode/modifier taxonomy.
- **Buff decode** 0 → **8 of 38** confirmed types; **zone decode** started.
- Deflation ($20k/round 31) and Double Cash (×2 starting cash) verified from in-game screenshots.

### Docs reconciled
- **`btd6-gamedata-decode-status.md`**: added a **"Current state & next actions (READ FIRST)"** block at the top — where the data stands, the ordered next steps, and the binding verification discipline. Fixed a stale "0 of 28 / 0 of 38" note.
- **`btd6-game-file-extraction-plan.md`**: zones/buffs marked **started** (28/38 types, not the old 12/37); points at decode-status as authoritative.

### Why buff decode stopped at 8/38 (documented)
The cleanly **value-confirmable** set is exhausted: every remaining committed buff field either has **no committed ground-truth entry** to verify against, or needs a **value transformation** the harness can't confirm. Writing more would be guessing — so the next session must do **per-model analysis** (or extend the renderer for `SCHEMA_FIRST` types). Correctness over coverage.

https://claude.ai/code/session_01TJvgoQyKFxXrUUQ9iWsGhn

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJvgoQyKFxXrUUQ9iWsGhn)_