### PR TITLE
feat(btd6): surface Ice slow + hero-XP + thorn-zone bonus (decoded-but-dropped fields)

### DIFF
--- a/disbot/services/btd6_upgrade_detail_service.py
+++ b/disbot/services/btd6_upgrade_detail_service.py
@@ -198,6 +198,7 @@ _BUFF_FIELDS: tuple[tuple[str, str, int], ...] = (
     ("rangePercentage", "+{}% range", 100),
     ("lifespanMultiplier", "x{} lifespan", 1),
     ("abilityCooldownMultiplier", "x{} ability cooldown", 1),
+    ("heroXpMultiplier", "x{} hero XP", 1),
     # Cash / economy buffs. These were decoded into committed data
     # (TradeEmpireBuffModel, Bucc 0-0-5) but had no render field here, so the
     # renderer surfaced only the damage bonus and silently dropped the income —
@@ -231,6 +232,14 @@ def _buff_text(buff: dict[str, Any]) -> str:
     return f"{name}: {body}" if name else body
 
 
+def _zone_num(zone: dict[str, Any], field: str) -> Any:
+    """A zone's numeric field value, or None (rejecting bools)."""
+    value = zone.get(field)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return value
+    return None
+
+
 def _zone_text(zone: dict[str, Any]) -> str:
     name = str(zone.get("name") or "Zone")
     dmg = zone.get("damage")
@@ -241,6 +250,20 @@ def _zone_text(zone: dict[str, Any]) -> str:
         bits.append(f"{dmg} {dtype} dmg" if dtype else f"{dmg} dmg")
     if interval is not None:
         bits.append(f"every {interval}s")
+    # Ice Monkey's Arctic Wind slow: 'multiplier' is the speed multiplier
+    # (0.6 = bloons move at 60% speed); MOABs are slowed less. Verified
+    # 'multiplier' only ever appears on Ice slow zones, so rendering it as a
+    # speed multiplier can't mislabel a different zone type's number.
+    slow = _zone_num(zone, "multiplier")
+    if slow is not None:
+        bits.append(f"slows bloons to x{_fmt_buff_num(slow)} speed")
+    moab_slow = _zone_num(zone, "multiplierForMoabs")
+    if moab_slow is not None:
+        bits.append(f"MOABs to x{_fmt_buff_num(moab_slow)} speed")
+    # Druid Thorn zone: flat bonus damage vs Ceramic/MOAB-class.
+    cmoab = _zone_num(zone, "damageModifierForCeramicOrMoabs")
+    if cmoab is not None:
+        bits.append(f"+{_fmt_buff_num(cmoab)} damage vs Ceramic/MOAB")
     return f"{name} ({', '.join(bits)})" if bits else name
 
 

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -40,26 +40,34 @@ works** (the traps we hit), and what is still un-decoded.
    banana-cash, etc. carry a real number but `_BUFF_FIELDS` /
    `btd6_upgrade_detail_service` has no field to render it. Extend the renderer
    first, then decode.
-   - **DONE (cash/economy):** `_BUFF_FIELDS` now renders
-     `cashPerRoundPerMechantship` / `cashPerRoundPerFavouredTrades` /
-     `cashbackZoneMultiplier`, so **Trade Empire's income + Favored Trades
-     sellback** (already decoded into committed data, but previously *dropped* by
-     the renderer) now reach the answer — "what does Trade Empire do" surfaces
-     "+$10/round per Merchantman, +$20/round per Favored Trades, +4% sellback".
-   - **NEXT — income multiplier (`incomeMultiplier`).** Banana Farm income buffs
-     are in the dump but NOT in committed data: `CentralMarketBuffModel` ×1.1
-     (10-stack, **wiki-confirmed "+10% income"** on the Central Market page) and
-     `BananaCentralBuffModel` ×1.25 (wiki says "make nearby farms generate more
-     money"; the exact % wasn't on the page — confirm before writing). Also
-     `MonkeyCityIncomeSupportModel` ×1.2 (Monkey City "+20%", wiki-confirmed).
-     Decoding these = add an `incomeMultiplier` render field + the
-     `*SupportModel`/`*BuffModel` → `incomeMultiplier` mapper mappings + author
-     the committed `buffs[]` on the matching tiers (place them so `--audit` stays
-     aligned).
-   - **Other currently-dropped committed buff fields** (separate from cash):
-     `lifespan` (Engineer/Spike start-of-round buff *duration*), `heroXpMultiplier`
-     (Sub global ability-cooldown buff), `cooldown` (Desperado Nomad buff) — each
-     needs a render field + a wiki-confirmed label.
+   - **DONE — render coverage for already-decoded-but-dropped fields** (the safe
+     `extracted ≠ answerable` fix; no new value asserted, just un-dropped):
+     - buff cash/economy: `cashPerRoundPerMechantship` /
+       `cashPerRoundPerFavouredTrades` / `cashbackZoneMultiplier` → **Trade
+       Empire income + Favored Trades sellback** now answer.
+     - buff `heroXpMultiplier` → **Sub Energizer's +50% hero XP**.
+     - zone `multiplier` / `multiplierForMoabs` → **Ice Monkey's Arctic Wind slow**
+       (×0.6/0.4 speed; MOABs ×0.7) — Ice's signature effect was unstated.
+       Verified `multiplier` only ever appears on Ice slow zones, so the generic
+       render can't mislabel another zone type.
+     - zone `damageModifierForCeramicOrMoabs` → **Druid Thorn zone** +14/8/4 vs
+       Ceramic/MOAB.
+   - **BLOCKED — income multiplier (`incomeMultiplier`).** The dump has Banana
+     Farm `CentralMarketBuffModel` ×1.1 (wiki-confirmed "+10%"),
+     `BananaCentralBuffModel` ×1.25, and Monkey Village `MonkeyCityIncomeSupportModel`
+     ×1.2 ("+20%") — but **`banana_farm.json` and `monkey_village.json` have no
+     committed `tiers`** (economy/support towers were curated without per-tier
+     stats), so there is nowhere to attach a `buffs[]` entry for the renderer to
+     surface. Also entangled with prerequisite #4 (Banana Farm's nominal
+     `AttackModel`). Needs the cutover, or a deliberate model extension that gives
+     economy/support towers a minimal tier structure — a maintainer call, not a
+     clean pass.
+   - **DEFERRED — buff duration fields.** `lifespan` (Engineer/Spike
+     start-of-round burst, Desperado Nomad) + `cooldown` (Nomad) are committed but
+     dropped. The raw dump field is `duration` (with `durationFrames`) and the
+     ability renderer already uses **seconds**, but an earlier note said "for N
+     *rounds*" — so the unit is **under-confirmed**. Do not render until
+     seconds-vs-rounds is settled in-game/wiki.
 3. **Zone effect tail** (28 types) + zones **nested in sub-towers**.
 4. **Economy-tower attack suppression** (Banana Farm's nominal `AttackModel`) +
    preserve `paragon_cost`/`paragon_name` — cutover prerequisites.

--- a/tests/unit/services/test_btd6_upgrade_detail_service.py
+++ b/tests/unit/services/test_btd6_upgrade_detail_service.py
@@ -280,3 +280,43 @@ def test_trade_empire_detail_surfaces_income_end_to_end():
     assert "+$10/round per Merchantman" in blob
     assert "+$20/round per Favored Trades" in blob
     assert "+4% sellback value" in blob
+
+
+def test_buff_hero_xp_multiplier_renders():
+    # Sub Energizer's global buff: abilityCooldownMultiplier already rendered, but
+    # heroXpMultiplier was dropped (the +50% hero XP was invisible).
+    text = det._buff_text(
+        {
+            "name": "Ability cooldown buff (global)",
+            "abilityCooldownMultiplier": 1.2,
+            "heroXpMultiplier": 1.5,
+        },
+    )
+    assert "x1.5 hero XP" in text
+
+
+def test_zone_slow_multiplier_renders_as_speed():
+    # Ice Monkey's Arctic Wind: 'multiplier' is a speed multiplier (0.6 = 60%
+    # speed). It was dropped, so Ice's signature slow was unstated. MOABs slow
+    # less via multiplierForMoabs.
+    text = det._zone_text(
+        {"name": "Arctic Wind", "multiplier": 0.6, "multiplierForMoabs": 0.7},
+    )
+    assert "slows bloons to x0.6 speed" in text
+    assert "MOABs to x0.7 speed" in text
+
+
+def test_zone_ceramic_moab_bonus_damage_renders():
+    text = det._zone_text(
+        {"name": "Thorn zone", "damage": 2, "damageModifierForCeramicOrMoabs": 8},
+    )
+    assert "+8 damage vs Ceramic/MOAB" in text
+
+
+def test_ice_slow_and_thorn_bonus_surface_end_to_end():
+    # Real committed data: the slow and the thorn bonus now reach the rendered
+    # detail (and thus AI grounding).
+    ice = " | ".join(det.get_upgrade_detail("ice_monkey:030").zones)
+    assert "slows bloons to x0.6 speed" in ice
+    druid = " | ".join(det.get_upgrade_detail("druid:050").zones)
+    assert "damage vs Ceramic/MOAB" in druid


### PR DESCRIPTION
## Summary

Continuing the decodes. With the v55 dump in hand I worked the next data-mapping items. The high-value *new-value* decode (Banana Farm / Monkey Village income multipliers) turned out **structurally blocked**, so I shipped the remaining safe, wiki-grounded wins instead — surfacing committed buff/zone fields the renderers were silently dropping — and recorded the blocker precisely.

## What landed — render coverage for already-decoded-but-dropped fields

Same zero-risk pattern as the Trade Empire cash fix: these values were confirmed when first committed; the renderers just never showed them (`extracted ≠ answerable`).

- **Ice Monkey slow (the headline):** zone `multiplier` / `multiplierForMoabs` → *"Arctic Wind (slows bloons to x0.6 speed)"*, and at higher tiers *"x0.4 speed, MOABs to x0.7 speed"*. Ice's signature effect was previously unstated. Verified `multiplier` **only ever appears on Ice slow zones**, so the generic render can't mislabel another zone type.
- **Sub Energizer hero XP:** buff `heroXpMultiplier` → *"x1.5 hero XP"* (the +50% XP was invisible).
- **Druid Thorn zone:** zone `damageModifierForCeramicOrMoabs` → *"+14/8/4 damage vs Ceramic/MOAB"*.

Verified end-to-end on the real committed data; 4 new tests (each field + Ice/Druid end-to-end).

## What's blocked / deferred (recorded in decode-status)

- **Income multiplier decode — BLOCKED.** The dump has the values (Central Market ×1.1 = wiki-confirmed +10%, Banana Central ×1.25, Monkey City ×1.2 = +20%), but **`banana_farm.json` and `monkey_village.json` have no committed `tiers`** — those economy/support towers were curated without per-tier stats, so there's nowhere to attach a `buffs[]` entry for the renderer. It's also entangled with cutover-prerequisite #4 (Banana Farm's nominal `AttackModel`). Surfacing income needs the cutover or a deliberate model extension — a maintainer call, not a clean pass.
- **Buff durations — DEFERRED.** `lifespan`/`cooldown` (start-of-round burst, Nomad) are committed but dropped; the raw field is `duration` and the ability renderer uses seconds, but an earlier note said "rounds" — unit under-confirmed, so not rendered.

## Verification

- `python3.10 scripts/check_quality.py --full` → **7256 passed, 3 skipped** (CI mirror, Python 3.10).
- No new value asserted anywhere — only already-committed, already-confirmed fields un-dropped.

https://claude.ai/code/session_01BsFD9xMzFaPa83Z1dffn7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsFD9xMzFaPa83Z1dffn7p)_