### PR TITLE
fix(btd6): render instant-pop sentinel as ∞ in grounding + live-verification findings

### DIFF
--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -28,6 +28,7 @@ from utils.btd6 import coverage as cov
 from utils.btd6 import tier_codes
 from utils.btd6.body_coerce import coerce_body
 from utils.btd6.grounding_format import DEFAULT_CAP as _FACT_TEXT_CAP
+from utils.btd6.grounding_format import is_infinite as _is_infinite
 from utils.btd6.grounding_format import relative_time as _relative_time
 from utils.btd6.grounding_format import sanitise as _sanitise_helper
 
@@ -724,7 +725,7 @@ def _render_hero_descriptions(hero_id: str, canonical: str) -> list[str]:
 
 def _big(value: int) -> str:
     """Render BTD6's 9,999,999 'infinite' sentinel as ∞."""
-    return "∞" if value >= 9_999_999 else str(value)
+    return "∞" if _is_infinite(value) else str(value)
 
 
 def _tier_name(stats: Any, code: str) -> str:

--- a/disbot/services/btd6_upgrade_detail_service.py
+++ b/disbot/services/btd6_upgrade_detail_service.py
@@ -31,6 +31,7 @@ from services import btd6_stats_service, btd6_upgrade_service
 from services.btd6_stats_service import NormalStats
 from services.btd6_upgrade_service import UpgradeIdentity
 from utils.btd6.damage_types import DAMAGE_MODIFIER_LABELS
+from utils.btd6.grounding_format import is_infinite
 
 _MAX_LINE = 320
 _PATH_LABEL = {"top": "top", "mid": "middle", "bot": "bottom"}
@@ -348,23 +349,23 @@ def _cap(line: str) -> str:
 def _projectile_bits(proj: ProjectileSpec) -> str:
     bits: list[str] = []
     if proj.damage is not None:
-        dmg = (
-            f"{proj.damage:,} dmg"
-            if isinstance(proj.damage, int)
-            else f"{proj.damage} dmg"
-        )
+        if is_infinite(proj.damage):
+            dmg = "∞ dmg"  # 9,999,999 instant-pop sentinel — not a real number
+        elif isinstance(proj.damage, int):
+            dmg = f"{proj.damage:,} dmg"
+        else:
+            dmg = f"{proj.damage} dmg"
         if proj.damage_type and proj.damage_type != "Normal":
             note = f", {proj.cannot_pop}" if proj.cannot_pop else ""
             dmg += f" ({proj.damage_type}{note})"
         bits.append(dmg)
     if proj.pierce is not None:
-        bits.append(
-            (
-                f"{proj.pierce:,} pierce"
-                if isinstance(proj.pierce, int)
-                else f"{proj.pierce} pierce"
-            ),
-        )
+        if is_infinite(proj.pierce):
+            bits.append("∞ pierce")
+        elif isinstance(proj.pierce, int):
+            bits.append(f"{proj.pierce:,} pierce")
+        else:
+            bits.append(f"{proj.pierce} pierce")
     for label, bonus in proj.modifiers:
         # Say "damage" explicitly: next to "210 pierce" a bare "+20 vs Lead" was
         # misread by the model as bonus pierce — these are additive damage.

--- a/disbot/utils/btd6/grounding_format.py
+++ b/disbot/utils/btd6/grounding_format.py
@@ -93,8 +93,26 @@ def render_grounding_line(
     return f"{safe_body}{suffix}"
 
 
+# BTD6 stores 9,999,999 as an "infinite" sentinel for instant-pop collision
+# layers (Druid's Spirit-of-the-Forest vines, etc.). It must render as ∞, never
+# the raw number — a literal "9,999,999 dmg" in grounding misleads the model into
+# reporting it as the tower's main-attack damage.
+INFINITE_SENTINEL = 9_999_999
+
+
+def is_infinite(value: object) -> bool:
+    """True for BTD6's 9,999,999 'infinite' (instant-pop) sentinel value."""
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and value >= INFINITE_SENTINEL
+    )
+
+
 __all__ = [
     "DEFAULT_CAP",
+    "INFINITE_SENTINEL",
+    "is_infinite",
     "relative_time",
     "render_grounding_line",
     "sanitise",

--- a/docs/btd6-absence-claim-guard-design.md
+++ b/docs/btd6-absence-claim-guard-design.md
@@ -162,6 +162,41 @@ it does not touch Layer B (still design-for-review). Mechanisms 1 (conversationa
 context carry) and 3 (answer-what's-grounded vs. wholesale refuse) are
 prompt/stage-layer and still owe a live repro + verification before building.
 
+## Update 5 (live verification round) — the frontier IS model faithfulness
+
+The maintainer ran a live Discord pass. **The data/render fixes all work live**
+(cash income on Trade Empire, Ice Arctic Wind slow "0.6x speed", Druid thorn-zone
+"+14/+8/+4 vs Ceramic/MOAB", the removable-obstacle limitation stated cleanly, the
+PMFC parent-tower grounding answering instead of refusing). The remaining failures
+are all **the model ignoring/fabricating/dropping despite correct grounding** —
+exactly this doc's family, now with three clean live repros:
+
+1. **PMFC → "Prince of Darkness" (fabrication; severe).** Asked "what is the damage
+   type when pmfc abilities is active", the bot answered with **Prince of
+   Darkness** data (Wizard 0-0-5, Reanimate, 2 dmg Normal, 0.275s) labelled
+   "Prince of Darkness (PMFC)". Verified deterministically: `resolve_upgrade("pmfc")`
+   → Plasma Monkey Fan Club, and `build(…)` grounds **58 PMFC/Dart facts, 0
+   POD/Wizard facts**. So the grounding was 100% correct — the model substituted a
+   similarly-abbreviated upgrade from training (PMFC↔POD) and the faithfulness
+   guard missed the ungrounded proper name + stats. The *same user* got the right
+   answer one turn later when the query said "it's ability" (relying on a prior
+   PMFC=Plasma turn) — so it is phrasing/recall-sensitive, not a resolver bug.
+2. **"which maps have water" dropped 5 maps + miscounted (incomplete list).** Truth
+   is **69** (Beginner 21 / Intermediate 24 / Advanced 12 / Expert 12); the bot
+   answered **64** (17/24/13/10). Full grounding was present; the model summarised
+   a long list lossily and reshuffled the difficulty buckets.
+3. **SOTF "main attack: ∞ dmg" (conflation).** The grounding correctly said "main
+   attack: 6 dmg" and separately "Vine: Collidable (9,999,999 …)", but the model
+   reported the vine's instant-pop sentinel as the *main* attack's damage. Partial
+   fix shipped this round (the grounding now renders the sentinel as ∞, not the raw
+   number — see `grounding_format.is_infinite`), but the conflation itself is the
+   same faithfulness family.
+
+**Takeaway:** continuing data extraction will not move these. The single highest-
+value next step is the faithfulness layer — "answer/list **only** the grounded
+entity, never a similarly-named one from memory; don't drop grounded list items."
+These three are the regression cases to pin before changing behaviour.
+
 ---
 
 ## 1. The problem

--- a/tests/unit/services/test_btd6_upgrade_detail_service.py
+++ b/tests/unit/services/test_btd6_upgrade_detail_service.py
@@ -320,3 +320,20 @@ def test_ice_slow_and_thorn_bonus_surface_end_to_end():
     assert "slows bloons to x0.6 speed" in ice
     druid = " | ".join(det.get_upgrade_detail("druid:050").zones)
     assert "damage vs Ceramic/MOAB" in druid
+
+
+def test_vine_instant_pop_sentinel_renders_as_infinity_not_raw_number():
+    # Live SOTF bug: the grounding showed "9,999,999 dmg" for the vine's instant-
+    # pop collidable (vs the deliberate ∞ convention in the tower-stats path), and
+    # the model then reported it as the MAIN attack's damage. The grounding now
+    # renders ∞ for the sentinel while the real main attack stays 6 dmg.
+    from utils.btd6.grounding_format import is_infinite
+
+    assert is_infinite(9_999_999) and not is_infinite(6)
+    assert not is_infinite(True) and not is_infinite(None)
+
+    lines = det.render_upgrade_grounding(det.get_upgrade_detail("druid:050"))
+    blob = "\n".join(lines)
+    assert "9,999,999" not in blob and "9999999" not in blob
+    assert "∞ dmg" in blob and "∞ pierce" in blob  # the vine collidable
+    assert "main attack: 6 dmg" in blob  # real main attack unaffected


### PR DESCRIPTION
## Summary

Follow-up from the maintainer's **live Discord verification** round. The headline: **all the data/render fixes work live** — and the remaining issues are model faithfulness, not data. This PR ships the one clean code fix it surfaced and records the findings.

## Live verification — what passed ✅

Confirmed working in Discord:
- **Trade Empire** income: *"+$10/round per Merchantman, +$20/round per Favored Trades, +4% sellback"* (cash render fix)
- **Ice Arctic Wind**: *"slows Bloons to 0.6x speed (40% slowdown)"* (zone slow fix)
- **Spirit of the Forest** thorn zones: *"+14/+8/+4 damage vs Ceramic/MOAB"* (zone bonus fix)
- **"list all maps with obstacles"** → clean limitation, no improvising (removables faithfulness fix)
- **PMFC** ("it's ability") → answers with Dart Monkey context instead of refusing (parent-tower grounding)

## The fix in this PR

**SOTF showed "main attack: ∞ dmg".** Root cause: the tower-stats grounding already renders BTD6's `9,999,999` instant-pop sentinel (Druid vine collidables) as ∞, but the **upgrade/projectile** path showed the model the raw `"9,999,999 dmg"`, which it then reported as the main attack.

- Promoted the sentinel check to a shared `grounding_format.is_infinite` (+ `INFINITE_SENTINEL`) and routed both grounding paths through it. SOTF now grounds *"main attack: 6 dmg"* + *"Vine: Collidable (∞ dmg, ∞ pierce)"*. No raw `9,999,999` reaches the model.

## Findings recorded (absence-claim-guard design, Update 5)

The remaining live failures are all **the model ignoring/fabricating/dropping despite correct grounding** — this doc's family, now with clean repros:
1. **PMFC → "Prince of Darkness" (fabrication, severe).** Grounding was **58 Plasma Monkey Fan Club facts, 0 POD facts** — the model substituted a similarly-abbreviated upgrade from training. `resolve_upgrade("pmfc")` is correct (→ PMFC). Phrasing/recall-sensitive (the next turn answered correctly).
2. **"which maps have water" → 64, truth is 69** — model dropped 5 and reshuffled difficulty buckets on a long list.
3. **SOTF vine→main conflation** — partially mitigated by the ∞ fix above; the conflation itself is faithfulness.

**Takeaway:** more data extraction won't move these — the next high-value work is the faithfulness layer ("answer/list only the grounded entity; don't drop grounded items"). These three are the regression cases to pin first.

## Verification
- `python3.10 scripts/check_quality.py --full` → **7257 passed, 3 skipped**; `check_architecture --mode strict` exit 0.

https://claude.ai/code/session_01BsFD9xMzFaPa83Z1dffn7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsFD9xMzFaPa83Z1dffn7p)_