### PR TITLE
feat(btd6): per-round cash for rounds 1-80 (cyberquincy) + locate the cash economy

### DIFF
--- a/disbot/data/btd6/rounds.json
+++ b/disbot/data/btd6/rounds.json
@@ -12,6 +12,8 @@
         "Red Bloon"
       ],
       "rbe": 20,
+      "cash": 121,
+      "cumulative_cash": 771,
       "roundset": "default",
       "groups": [
         {
@@ -31,6 +33,8 @@
         "Red Bloon"
       ],
       "rbe": 35,
+      "cash": 137,
+      "cumulative_cash": 908,
       "roundset": "default",
       "groups": [
         {
@@ -51,6 +55,8 @@
         "Blue Bloon"
       ],
       "rbe": 35,
+      "cash": 138,
+      "cumulative_cash": 1046,
       "roundset": "default",
       "groups": [
         {
@@ -85,6 +91,8 @@
         "Blue Bloon"
       ],
       "rbe": 71,
+      "cash": 175,
+      "cumulative_cash": 1221,
       "roundset": "default",
       "groups": [
         {
@@ -119,6 +127,8 @@
         "Red Bloon"
       ],
       "rbe": 59,
+      "cash": 164,
+      "cumulative_cash": 1385,
       "roundset": "default",
       "groups": [
         {
@@ -154,6 +164,8 @@
         "Green Bloon"
       ],
       "rbe": 57,
+      "cash": 163,
+      "cumulative_cash": 1548,
       "roundset": "default",
       "groups": [
         {
@@ -189,6 +201,8 @@
         "Green Bloon"
       ],
       "rbe": 75,
+      "cash": 182,
+      "cumulative_cash": 1730,
       "roundset": "default",
       "groups": [
         {
@@ -231,6 +245,8 @@
         "Red Bloon"
       ],
       "rbe": 92,
+      "cash": 200,
+      "cumulative_cash": 1930,
       "roundset": "default",
       "groups": [
         {
@@ -271,6 +287,8 @@
         "Green Bloon"
       ],
       "rbe": 90,
+      "cash": 199,
+      "cumulative_cash": 2129,
       "roundset": "default",
       "groups": [
         {
@@ -290,6 +308,8 @@
         "Pink"
       ],
       "rbe": 204,
+      "cash": 314,
+      "cumulative_cash": 2443,
       "roundset": "default",
       "groups": [
         {
@@ -326,6 +346,8 @@
         "Yellow Bloon"
       ],
       "rbe": 78,
+      "cash": 189,
+      "cumulative_cash": 2632,
       "roundset": "default",
       "groups": [
         {
@@ -368,6 +390,8 @@
         "Yellow Bloon"
       ],
       "rbe": 80,
+      "cash": 192,
+      "cumulative_cash": 2824,
       "roundset": "default",
       "groups": [
         {
@@ -402,6 +426,8 @@
         "Green Bloon"
       ],
       "rbe": 169,
+      "cash": 282,
+      "cumulative_cash": 3106,
       "roundset": "default",
       "groups": [
         {
@@ -431,6 +457,8 @@
         "Yellow Bloon"
       ],
       "rbe": 145,
+      "cash": 259,
+      "cumulative_cash": 3365,
       "roundset": "default",
       "groups": [
         {
@@ -502,6 +530,8 @@
         "Yellow Bloon"
       ],
       "rbe": 151,
+      "cash": 266,
+      "cumulative_cash": 3631,
       "roundset": "default",
       "groups": [
         {
@@ -550,6 +580,8 @@
         "Yellow Bloon"
       ],
       "rbe": 152,
+      "cash": 268,
+      "cumulative_cash": 3899,
       "roundset": "default",
       "groups": [
         {
@@ -583,6 +615,8 @@
         "Yellow Bloon"
       ],
       "rbe": 48,
+      "cash": 165,
+      "cumulative_cash": 4064,
       "roundset": "default",
       "groups": [
         {
@@ -604,6 +638,8 @@
         "Green Bloon"
       ],
       "rbe": 240,
+      "cash": 358,
+      "cumulative_cash": 4422,
       "roundset": "default",
       "groups": [
         {
@@ -632,6 +668,8 @@
         "Yellow Bloon"
       ],
       "rbe": 141,
+      "cash": 260,
+      "cumulative_cash": 4682,
       "roundset": "default",
       "groups": [
         {
@@ -674,6 +712,8 @@
         "Black Bloon"
       ],
       "rbe": 66,
+      "cash": 186,
+      "cumulative_cash": 4868,
       "roundset": "default",
       "groups": [
         {
@@ -693,6 +733,8 @@
         "Lead"
       ],
       "rbe": 230,
+      "cash": 351,
+      "cumulative_cash": 5219,
       "roundset": "default",
       "groups": [
         {
@@ -726,6 +768,8 @@
         "White Bloon"
       ],
       "rbe": 176,
+      "cash": 298,
+      "cumulative_cash": 5517,
       "roundset": "default",
       "groups": [
         {
@@ -746,6 +790,8 @@
         "White Bloon"
       ],
       "rbe": 154,
+      "cash": 277,
+      "cumulative_cash": 5794,
       "roundset": "default",
       "groups": [
         {
@@ -773,6 +819,8 @@
         "Green Bloon"
       ],
       "rbe": 43,
+      "cash": 167,
+      "cumulative_cash": 5961,
       "roundset": "default",
       "groups": [
         {
@@ -802,6 +850,8 @@
         "Purple Bloon"
       ],
       "rbe": 210,
+      "cash": 335,
+      "cumulative_cash": 6296,
       "roundset": "default",
       "groups": [
         {
@@ -831,6 +881,8 @@
         "Zebra Bloon"
       ],
       "rbe": 207,
+      "cash": 333,
+      "cumulative_cash": 6629,
       "roundset": "default",
       "groups": [
         {
@@ -860,6 +912,8 @@
         "Yellow Bloon"
       ],
       "rbe": 535,
+      "cash": 662,
+      "cumulative_cash": 7291,
       "roundset": "default",
       "groups": [
         {
@@ -900,6 +954,8 @@
         "Ceramic"
       ],
       "rbe": 138,
+      "cash": 266,
+      "cumulative_cash": 7557,
       "roundset": "default",
       "groups": [
         {
@@ -919,6 +975,8 @@
         "Yellow Bloon"
       ],
       "rbe": 260,
+      "cash": 389,
+      "cumulative_cash": 7946,
       "roundset": "default",
       "groups": [
         {
@@ -947,6 +1005,8 @@
         "Lead Bloon"
       ],
       "rbe": 207,
+      "cash": 337,
+      "cumulative_cash": 8283,
       "roundset": "default",
       "groups": [
         {
@@ -968,6 +1028,8 @@
         "White Bloon"
       ],
       "rbe": 406,
+      "cash": 537,
+      "cumulative_cash": 8820,
       "roundset": "default",
       "groups": [
         {
@@ -1012,6 +1074,8 @@
         "Purple Bloon"
       ],
       "rbe": 495,
+      "cash": 627,
+      "cumulative_cash": 9447,
       "roundset": "default",
       "groups": [
         {
@@ -1046,6 +1110,8 @@
         "Yellow Bloon"
       ],
       "rbe": 72,
+      "cash": 205,
+      "cumulative_cash": 9652,
       "roundset": "default",
       "groups": [
         {
@@ -1077,6 +1143,8 @@
         "Zebra Bloon"
       ],
       "rbe": 778,
+      "cash": 912,
+      "cumulative_cash": 10564,
       "roundset": "default",
       "groups": [
         {
@@ -1106,6 +1174,8 @@
         "Rainbow Bloon"
       ],
       "rbe": 1015,
+      "cash": 1150,
+      "cumulative_cash": 11714,
       "roundset": "default",
       "groups": [
         {
@@ -1147,6 +1217,8 @@
         "Green Bloon"
       ],
       "rbe": 760,
+      "cash": 896,
+      "cumulative_cash": 12610,
       "roundset": "default",
       "groups": [
         {
@@ -1203,6 +1275,8 @@
         "Zebra Bloon"
       ],
       "rbe": 1202,
+      "cash": 1339,
+      "cumulative_cash": 13949,
       "roundset": "default",
       "groups": [
         {
@@ -1255,6 +1329,8 @@
         "Zebra Bloon"
       ],
       "rbe": 1157,
+      "cash": 1277,
+      "cumulative_cash": 15226,
       "roundset": "default",
       "groups": [
         {
@@ -1305,6 +1381,8 @@
         "White Bloon"
       ],
       "rbe": 1620,
+      "cash": 1759,
+      "cumulative_cash": 16985,
       "roundset": "default",
       "groups": [
         {
@@ -1354,6 +1432,8 @@
         "BFB"
       ],
       "rbe": 616,
+      "cash": 521,
+      "cumulative_cash": 17506,
       "roundset": "default",
       "groups": [
         {
@@ -1374,6 +1454,8 @@
         "Zebra Bloon"
       ],
       "rbe": 2040,
+      "cash": 2181,
+      "cumulative_cash": 19687,
       "roundset": "default",
       "groups": [
         {
@@ -1400,6 +1482,8 @@
         "Rainbow Bloon"
       ],
       "rbe": 517,
+      "cash": 659,
+      "cumulative_cash": 20346,
       "roundset": "default",
       "groups": [
         {
@@ -1431,6 +1515,8 @@
         "Ceramic Bloon"
       ],
       "rbe": 1198,
+      "cash": 1278,
+      "cumulative_cash": 21624,
       "roundset": "default",
       "groups": [
         {
@@ -1457,6 +1543,8 @@
         "Zebra Bloon"
       ],
       "rbe": 1150,
+      "cash": 1294,
+      "cumulative_cash": 22918,
       "roundset": "default",
       "groups": [
         {
@@ -1507,6 +1595,8 @@
         "Lead Bloon"
       ],
       "rbe": 2289,
+      "cash": 2422,
+      "cumulative_cash": 25340,
       "roundset": "default",
       "groups": [
         {
@@ -1551,6 +1641,8 @@
         "Ceramic Bloon"
       ],
       "rbe": 684,
+      "cash": 716,
+      "cumulative_cash": 26056,
       "roundset": "default",
       "groups": [
         {
@@ -1573,6 +1665,8 @@
         "Ceramic Bloon"
       ],
       "rbe": 1598,
+      "cash": 1637,
+      "cumulative_cash": 27693,
       "roundset": "default",
       "groups": [
         {
@@ -1604,6 +1698,8 @@
         "Ceramic Bloon"
       ],
       "rbe": 2752,
+      "cash": 2843,
+      "cumulative_cash": 30536,
       "roundset": "default",
       "groups": [
         {
@@ -1654,6 +1750,8 @@
         "Ceramic Bloon"
       ],
       "rbe": 4771,
+      "cash": 4758,
+      "cumulative_cash": 35294,
       "roundset": "default",
       "groups": [
         {
@@ -1713,6 +1811,8 @@
         "MOAB"
       ],
       "rbe": 3540,
+      "cash": 3016,
+      "cumulative_cash": 38310,
       "roundset": "default",
       "groups": [
         {
@@ -1763,6 +1863,8 @@
         "Rainbow Bloon"
       ],
       "rbe": 2030,
+      "cash": 1098.5,
+      "cumulative_cash": 39408.5,
       "roundset": "default",
       "groups": [
         {
@@ -1795,6 +1897,8 @@
         "MOAB"
       ],
       "rbe": 3447,
+      "cash": 1595.5,
+      "cumulative_cash": 41004,
       "roundset": "default",
       "groups": [
         {
@@ -1843,6 +1947,8 @@
         "MOAB"
       ],
       "rbe": 2248,
+      "cash": 924.5,
+      "cumulative_cash": 41928.5,
       "roundset": "default",
       "groups": [
         {
@@ -1886,6 +1992,8 @@
         "MOAB"
       ],
       "rbe": 4872,
+      "cash": 2197.5,
+      "cumulative_cash": 44126,
       "roundset": "default",
       "groups": [
         {
@@ -1920,6 +2028,8 @@
         "MOAB"
       ],
       "rbe": 5296,
+      "cash": 2483,
+      "cumulative_cash": 46609,
       "roundset": "default",
       "groups": [
         {
@@ -1968,6 +2078,8 @@
         "MOAB"
       ],
       "rbe": 2496,
+      "cash": 1286.5,
+      "cumulative_cash": 47895.5,
       "roundset": "default",
       "groups": [
         {
@@ -1997,6 +2109,8 @@
         "MOAB"
       ],
       "rbe": 4344,
+      "cash": 1859,
+      "cumulative_cash": 49754.5,
       "roundset": "default",
       "groups": [
         {
@@ -2031,6 +2145,8 @@
         "MOAB"
       ],
       "rbe": 5780,
+      "cash": 2298,
+      "cumulative_cash": 52052.5,
       "roundset": "default",
       "groups": [
         {
@@ -2067,6 +2183,8 @@
         "Ceramic Bloon"
       ],
       "rbe": 4270,
+      "cash": 2159,
+      "cumulative_cash": 54211.5,
       "roundset": "default",
       "groups": [
         {
@@ -2104,6 +2222,8 @@
         "BFB"
       ],
       "rbe": 3164,
+      "cash": 922.5,
+      "cumulative_cash": 55134,
       "roundset": "default",
       "groups": [
         {
@@ -2124,6 +2244,8 @@
         "MOAB"
       ],
       "rbe": 6530,
+      "cash": 1232,
+      "cumulative_cash": 56366,
       "roundset": "default",
       "groups": [
         {
@@ -2154,6 +2276,8 @@
         "MOAB"
       ],
       "rbe": 8247,
+      "cash": 1386.4,
+      "cumulative_cash": 57752.4,
       "roundset": "default",
       "groups": [
         {
@@ -2200,6 +2324,8 @@
         "Camo Lead"
       ],
       "rbe": 14413,
+      "cash": 2826,
+      "cumulative_cash": 60578.4,
       "roundset": "default",
       "groups": [
         {
@@ -2240,6 +2366,8 @@
         "MOAB"
       ],
       "rbe": 6264,
+      "cash": 849.8,
+      "cumulative_cash": 61428.2,
       "roundset": "default",
       "groups": [
         {
@@ -2271,6 +2399,8 @@
         "MOAB"
       ],
       "rbe": 18966,
+      "cash": 3071.6,
+      "cumulative_cash": 64499.8,
       "roundset": "default",
       "groups": [
         {
@@ -2318,6 +2448,8 @@
         "MOAB"
       ],
       "rbe": 7496,
+      "cash": 1004.2,
+      "cumulative_cash": 65504,
       "roundset": "default",
       "groups": [
         {
@@ -2361,6 +2493,8 @@
         "MOAB"
       ],
       "rbe": 6410,
+      "cash": 1023.6,
+      "cumulative_cash": 66527.6,
       "roundset": "default",
       "groups": [
         {
@@ -2399,6 +2533,8 @@
         "BFB"
       ],
       "rbe": 5628,
+      "cash": 777.8,
+      "cumulative_cash": 67305.4,
       "roundset": "default",
       "groups": [
         {
@@ -2427,6 +2563,8 @@
         "Black Bloon"
       ],
       "rbe": 6680,
+      "cash": 1391,
+      "cumulative_cash": 68696.4,
       "roundset": "default",
       "groups": [
         {
@@ -2466,6 +2604,8 @@
         "MOAB"
       ],
       "rbe": 13184,
+      "cash": 2618.8,
+      "cumulative_cash": 71315.2,
       "roundset": "default",
       "groups": [
         {
@@ -2503,6 +2643,8 @@
         "MOAB"
       ],
       "rbe": 9280,
+      "cash": 1503,
+      "cumulative_cash": 72818.2,
       "roundset": "default",
       "groups": [
         {
@@ -2530,6 +2672,8 @@
         "BFB"
       ],
       "rbe": 10280,
+      "cash": 1504,
+      "cumulative_cash": 74322.2,
       "roundset": "default",
       "groups": [
         {
@@ -2566,6 +2710,8 @@
         "BFB"
       ],
       "rbe": 11256,
+      "cash": 1392.6,
+      "cumulative_cash": 75714.8,
       "roundset": "default",
       "groups": [
         {
@@ -2600,6 +2746,8 @@
         "BFB"
       ],
       "rbe": 18054,
+      "cash": 3044,
+      "cumulative_cash": 78758.8,
       "roundset": "default",
       "groups": [
         {
@@ -2648,6 +2796,8 @@
         "MOAB"
       ],
       "rbe": 25402,
+      "cash": 2667.4,
+      "cumulative_cash": 81426.2,
       "roundset": "default",
       "groups": [
         {
@@ -2715,6 +2865,8 @@
         "Ceramic Bloon"
       ],
       "rbe": 6240,
+      "cash": 1316,
+      "cumulative_cash": 82742.2,
       "roundset": "default",
       "groups": [
         {
@@ -2737,6 +2889,8 @@
         "BFB"
       ],
       "rbe": 22596,
+      "cash": 2540.2,
+      "cumulative_cash": 85282.4,
       "roundset": "default",
       "groups": [
         {
@@ -2763,6 +2917,8 @@
         "BAD"
       ],
       "rbe": 26382,
+      "cash": 4862,
+      "cumulative_cash": 90144.4,
       "roundset": "default",
       "groups": [
         {
@@ -2813,6 +2969,8 @@
         "BFB"
       ],
       "rbe": 45804,
+      "cash": 6709,
+      "cumulative_cash": 96853.4,
       "roundset": "default",
       "groups": [
         {
@@ -2850,6 +3008,8 @@
         "ZOMG"
       ],
       "rbe": 16656,
+      "cash": 1400.2,
+      "cumulative_cash": 98253.6,
       "roundset": "default",
       "groups": [
         {
@@ -5747,5 +5907,6 @@
         }
       ]
     }
-  ]
+  ],
+  "cash_source": "standard/Medium per-round cash (pop cash + end-of-round bonus) for rounds 1-80, from the cyberquincy bot data set (github.com/hemisemidemipresent/cyberquincy, jsons/round_sets/regular.json); cross-validated against our v55 RBE (exact match r1-80). Rounds 81+ omitted: their RBE diverges from this source and no v55-current cash source was found (Steam API doesn't expose it; the game files store emissions, not cash)."
 }

--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -920,6 +920,15 @@ def _render_fixture_round(entry: Any) -> list[str]:
         head.append(f"danger: {danger}")
     if isinstance(rbe, int):
         head.append(f"total RBE {rbe:,} (hits to fully clear)")
+    cash = getattr(entry, "cash", None)
+    if isinstance(cash, (int, float)):
+        cumulative = getattr(entry, "cumulative_cash", None)
+        bit = f"cash this round ~${round(cash):,}"
+        if isinstance(cumulative, (int, float)):
+            bit += f", cumulative ~${round(cumulative):,}"
+        # Standard/Medium base economy: ~$1 per bloon pop + end-of-round bonus,
+        # before any income towers, and halved under Half Cash.
+        head.append(bit + " (standard economy, no income towers)")
     if threats:
         head.append(f"threats: {', '.join(_sanitise(t) for t in threats)}")
     headline = " | ".join(head)

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -121,10 +121,15 @@ class RoundEntry:
     common_threats: tuple[str, ...]
     # Extended composition (Module:BTD6_rounds): total RBE (children-inclusive),
     # the ordered spawn groups ({bloon_id, count, start, duration, modifiers}),
-    # and which round set this is ("default"; ABR is a later addition). ``cash``
-    # is reserved but not yet derived (wiki computes it from per-income Lua).
+    # and which round set this is ("default"; ABR is a later addition).
     rbe: int | None = None
-    cash: int | None = None
+    # Standard/Medium per-round cash (pop cash + end-of-round bonus) and the
+    # running total. Float because income decay (rounds 51+) yields .5 values.
+    # Populated for rounds 1-80 (cyberquincy data set, cross-validated vs our
+    # RBE); None for 81+ until a v55-current source is confirmed. See
+    # ``rounds.json:cash_source``.
+    cash: float | None = None
+    cumulative_cash: float | None = None
     roundset: str = "default"
     groups: tuple[dict[str, Any], ...] = ()
 
@@ -449,7 +454,9 @@ def _parse_round(raw: dict[str, Any]) -> RoundEntry:
             f"round {raw['round']!r}: rbe must be >= 0 when present, got {rbe}",
         )
     cash_raw = raw.get("cash")
-    cash = int(cash_raw) if isinstance(cash_raw, (int, float)) else None
+    cash = float(cash_raw) if isinstance(cash_raw, (int, float)) else None
+    cumul_raw = raw.get("cumulative_cash")
+    cumulative_cash = float(cumul_raw) if isinstance(cumul_raw, (int, float)) else None
     groups = tuple(dict(g) for g in raw.get("groups", ()) if isinstance(g, dict))
     return RoundEntry(
         round_number=int(raw["round"]),
@@ -458,6 +465,7 @@ def _parse_round(raw: dict[str, Any]) -> RoundEntry:
         common_threats=tuple(str(t) for t in raw["common_threats"]),
         rbe=rbe,
         cash=cash,
+        cumulative_cash=cumulative_cash,
         roundset=str(raw.get("roundset", "default")),
         groups=groups,
     )

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -96,6 +96,31 @@ works** (the traps we hit), and what is still un-decoded.
   ignores them (keeps `--audit` nothing-SUSPECT); never downgrade a curated name.
 - `python3.10 scripts/check_quality.py --full` before pushing.
 
+### Session log — per-round cash (rounds 1-80) + where the cash economy lives
+
+Traced "cash per pop / per round" end to end:
+- **Per-pop:** flat **$1 per bloon layer** (maintainer-confirmed + BloonsWiki "Cash
+  per pop"), ×0.5 on Half Cash, reduced in late rounds by the income-decay curve.
+  **Not in the asset dump** — it's hardcoded game logic (no `cashPerPop` field;
+  bloon `cash` is null on all bloons; the difficulty `Mods/` only carry `baseCash`
+  = starting cash). Same story as the mode rules.
+- **Per-round *tower* income** IS in the dump as `PerRoundCashBonusTowerModel.
+  cashPerRound` (Benjamin 90→5000 by level, farms, SOTF) — already surfaced for
+  the towers that have committed tiers.
+- **Per-round *game* cash** (pop cash + end-of-round bonus, standard/Medium, no
+  income towers) is NOT in the dump (cash is computed, never stored). Sourced it
+  from the **cyberquincy** data set (`round_sets/regular.json` →
+  `cashThisRound`/`cumulativeCash`). Cross-validated: our RBE matches cyberquincy
+  **exactly for rounds 1-80**, so imported `cash` + `cumulative_cash` into
+  `rounds.json` for **1-80** (now grounded on round questions). `RoundEntry.cash`
+  is now `float` (income decay yields .5 values) + new `cumulative_cash`.
+- **Rounds 81-140 left empty.** Our RBE and cyberquincy's diverge there (matches
+  the maintainer's belief that late-round cash changed), and **no v55-current
+  source was found**: the Steam Web API doesn't expose round economy (needs a key,
+  only has achievements/stats), the game files store emissions not cash, and the
+  cash can't be safely *derived* (it's per pop-event, not per-RBE — diverges once
+  MOAB-class appear). Needs a confirmed v55 source before populating.
+
 ### Session log — 2026-06-04 (dump re-validation: confirmable data mapping is caught up)
 
 Cloned the v55 dump (`Btd6ModHelper/btd6-game-data` @ `a3348a89` — the pinned

--- a/tests/unit/services/test_btd6_context_grounding.py
+++ b/tests/unit/services/test_btd6_context_grounding.py
@@ -589,3 +589,19 @@ def test_fixture_tower_grounding_respects_line_cap_and_budget():
         f"{_MAX_GROUNDING_LINES_PER_TOWER}). Rich auto-grounding has grown — split "
         "it into intent-sensitive packets before raising this ceiling."
     )
+
+
+async def test_build_grounds_per_round_cash():
+    # The per-round cash (rounds 1-80) now reaches the model, so "how much money
+    # by round 80" is groundable instead of free-recalled.
+    ctx = await btd6_context_service.build("how much cash do I have by round 80")
+    line = next(f for f in ctx.facts if f.startswith("[btd6_round] Round 80"))
+    assert "cash this round ~$1,400" in line
+    assert "cumulative ~$98,254" in line
+
+
+async def test_build_round_81_has_no_cash_line():
+    # 81+ has no confirmed v55 cash source, so the round grounds without cash.
+    ctx = await btd6_context_service.build("round 81")
+    line = next(f for f in ctx.facts if f.startswith("[btd6_round] Round 81"))
+    assert "cash this round" not in line

--- a/tests/unit/services/test_btd6_data_service.py
+++ b/tests/unit/services/test_btd6_data_service.py
@@ -340,6 +340,22 @@ def test_rounds_full_composition_loads():
     assert get_round(100).groups[0]["bloon_id"] == "bad"
 
 
+def test_round_cash_populated_for_1_to_80_only():
+    from services.btd6_data_service import get_round
+
+    # Standard/Medium per-round cash (cyberquincy, cross-validated vs our RBE).
+    r1 = get_round(1)
+    assert r1.cash == 121.0 and r1.cumulative_cash == 771.0
+    # Income decay (rounds 51+) yields fractional values — hence float, not int.
+    r80 = get_round(80)
+    assert r80.cash == 1400.2 and r80.cumulative_cash == 98253.6
+    # Cumulative is monotonic non-decreasing across the populated range.
+    cumulatives = [get_round(n).cumulative_cash for n in range(1, 81)]
+    assert all(a <= b for a, b in zip(cumulatives, cumulatives[1:], strict=False))
+    # 81+ deliberately left empty (RBE diverges from the cyberquincy source).
+    assert get_round(81).cash is None and get_round(140).cash is None
+
+
 def test_invalid_round_rbe_fails(tmp_path):
     staged = _stage_data(tmp_path)
     (staged / "rounds.json").write_text(


### PR DESCRIPTION
## Summary

Traced "cash per pop / per round" end to end and populated our long-reserved-but-empty round `cash` field. Maintainer-directed (you pointed me at cyberquincy + confirmed the per-pop rule).

## Where the cash economy lives

- **Per-pop:** flat **$1 per bloon layer** (×0.5 on Half Cash), reduced in late rounds by the income-decay curve. **Not in the dump** — hardcoded game logic (bloon `cash` is null on every bloon; the difficulty `Mods/` only carry `baseCash` = starting cash). Confirmed against the BloonsWiki [Cash](https://www.bloonswiki.com/Cash) "Cash per pop" section.
- **Per-round *tower* income:** in the dump as `PerRoundCashBonusTowerModel.cashPerRound` (Benjamin 90→5000 by level, farms, SOTF) — already surfaced for towers with committed tiers.
- **Per-round *game* cash** (pop cash + end-of-round bonus, standard/Medium): computed, never stored in the game files → sourced from the [cyberquincy](https://github.com/hemisemidemipresent/cyberquincy) data set (`jsons/round_sets/regular.json` → `cashThisRound` / `cumulativeCash`).

## What landed

- **Imported `cash` + `cumulative_cash` into `rounds.json` for rounds 1–80.** Cross-validated first: our `rbe` matches cyberquincy's **exactly** for 1–80. Now grounded on round questions — *"how much money by round 80"* → cash this round ~$1,400, cumulative ~$98,254.
- `RoundEntry.cash` is now `float` (income decay from round 51 yields `.5` values) + new `cumulative_cash`. Attribution recorded in `rounds.json:cash_source`.

## Rounds 81–140 left empty (deliberately)

Our `rbe` and cyberquincy's **diverge** for 81+ (consistent with your note that late-round cash changed), and I found **no v55-current source**:
- **Steam Web API** doesn't expose round economy (needs a key; only achievements/stats/schema).
- The game files store bloon **emissions, not cash**.
- Cash **can't be safely derived** — it's per pop-event, not per-RBE (the round-40 check fails once MOAB-class appear). So I won't write numbers that contradict our own `rbe`.

Needs a confirmed v55 source before populating 81+.

## Verification
- `python3.10 scripts/check_quality.py --full` → **7260 passed, 3 skipped**. +3 tests (round-cash data + grounding, and that 81+ has no cash line).

Sources: [cyberquincy](https://github.com/hemisemidemipresent/cyberquincy), [BloonsWiki Cash](https://www.bloonswiki.com/Cash)

https://claude.ai/code/session_01BsFD9xMzFaPa83Z1dffn7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsFD9xMzFaPa83Z1dffn7p)_