### PR TITLE
feat(btd6): surface incomplete buff stats — stack caps, temporary-buff triggers, cash-on-leak

### DIFF
--- a/disbot/data/btd6/stats/desperado.json
+++ b/disbot/data/btd6/stats/desperado.json
@@ -1385,10 +1385,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "footprintRadius": 7,
@@ -1510,10 +1512,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "footprintRadius": 7,
@@ -1659,10 +1663,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "footprintRadius": 7,
@@ -1850,10 +1856,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "footprintRadius": 7,
@@ -2230,10 +2238,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "code": "202",
@@ -2486,10 +2496,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "code": "302",
@@ -2750,10 +2762,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "code": "402",
@@ -3142,10 +3156,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "code": "502",
@@ -3394,10 +3410,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "code": "022",
@@ -3907,10 +3925,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "code": "032",
@@ -4960,10 +4980,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "code": "042",
@@ -6145,10 +6167,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "code": "052",
@@ -6209,10 +6233,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "footprintRadius": 7,
@@ -6277,10 +6303,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "footprintRadius": 7,
@@ -6406,10 +6434,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "footprintRadius": 7,
@@ -6539,10 +6569,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "footprintRadius": 7,
@@ -6664,10 +6696,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "footprintRadius": 7,
@@ -6795,10 +6829,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "footprintRadius": 7,
@@ -6946,10 +6982,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "footprintRadius": 7,
@@ -7103,10 +7141,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "footprintRadius": 7,
@@ -7254,10 +7294,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "footprintRadius": 7,
@@ -7411,10 +7453,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "footprintRadius": 7,
@@ -7607,10 +7651,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "footprintRadius": 7,
@@ -7807,10 +7853,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "footprintRadius": 7,
@@ -7998,10 +8046,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "footprintRadius": 7,
@@ -8195,10 +8245,12 @@
       "buffs": [
         {
           "name": "Nomad buff",
-          "lifespan": 15,
-          "cooldown": 60,
+          "trigger": "on_life_lost",
           "rateMultiplier": 0.6,
-          "rangeAdditive": 16
+          "rangeAdditive": 16,
+          "cashOnLeakMultiplier": 2,
+          "lifespan": 15,
+          "cooldown": 60
         }
       ],
       "footprintRadius": 7,

--- a/disbot/data/btd6/stats/engineer_monkey.json
+++ b/disbot/data/btd6/stats/engineer_monkey.json
@@ -1246,8 +1246,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 1
+          "duration_rounds": 1
         }
       ],
       "footprintRadius": 7,
@@ -1373,8 +1374,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 1
+          "duration_rounds": 1
         }
       ],
       "footprintRadius": 7,
@@ -1506,8 +1508,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 1
+          "duration_rounds": 1
         }
       ],
       "footprintRadius": 7,
@@ -5700,8 +5703,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 1
+          "duration_rounds": 1
         }
       ],
       "footprintRadius": 7,
@@ -5886,8 +5890,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 1
+          "duration_rounds": 1
         }
       ],
       "footprintRadius": 7,
@@ -6060,8 +6065,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 1
+          "duration_rounds": 1
         }
       ],
       "footprintRadius": 7,
@@ -6200,8 +6206,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 1
+          "duration_rounds": 1
         }
       ],
       "footprintRadius": 7,
@@ -6339,8 +6346,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 1
+          "duration_rounds": 1
         }
       ],
       "footprintRadius": 7,
@@ -6543,8 +6551,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 1
+          "duration_rounds": 1
         }
       ],
       "footprintRadius": 7,
@@ -6735,8 +6744,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 1
+          "duration_rounds": 1
         }
       ],
       "footprintRadius": 7,
@@ -6893,8 +6903,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 1
+          "duration_rounds": 1
         }
       ],
       "footprintRadius": 7,
@@ -7038,8 +7049,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 1
+          "duration_rounds": 1
         }
       ],
       "footprintRadius": 7,
@@ -7248,8 +7260,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 1
+          "duration_rounds": 1
         }
       ],
       "footprintRadius": 7,
@@ -7446,8 +7459,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 1
+          "duration_rounds": 1
         }
       ],
       "footprintRadius": 7,
@@ -7610,8 +7624,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 1
+          "duration_rounds": 1
         }
       ],
       "footprintRadius": 7,

--- a/disbot/data/btd6/stats/spike_factory.json
+++ b/disbot/data/btd6/stats/spike_factory.json
@@ -1016,8 +1016,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "footprintRadius": 8,
@@ -1079,8 +1080,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "footprintRadius": 8,
@@ -1142,8 +1144,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "footprintRadius": 8,
@@ -1205,8 +1208,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 10
+          "duration_rounds": 10
         }
       ],
       "footprintRadius": 8,
@@ -1531,8 +1535,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "targetTypeCloseTrack": true,
@@ -1758,8 +1763,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "targetTypeCloseTrack": true,
@@ -2145,8 +2151,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "targetTypeCloseTrack": true,
@@ -2620,8 +2627,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "targetTypeCloseTrack": true,
@@ -2839,8 +2847,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "targetTypeCloseTrack": true,
@@ -3062,8 +3071,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "targetTypeCloseTrack": true,
@@ -3489,8 +3499,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "targetTypeCloseTrack": true,
@@ -3916,8 +3927,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "targetTypeCloseTrack": true,
@@ -3976,8 +3988,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "footprintRadius": 8,
@@ -4039,8 +4052,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "footprintRadius": 8,
@@ -4102,8 +4116,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "footprintRadius": 8,
@@ -4165,8 +4180,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "footprintRadius": 8,
@@ -4228,8 +4244,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "footprintRadius": 8,
@@ -4291,8 +4308,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "footprintRadius": 8,
@@ -4354,8 +4372,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "footprintRadius": 8,
@@ -4417,8 +4436,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "footprintRadius": 8,
@@ -4480,8 +4500,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "footprintRadius": 8,
@@ -4543,8 +4564,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 3
+          "duration_rounds": 3
         }
       ],
       "footprintRadius": 8,
@@ -4606,8 +4628,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 10
+          "duration_rounds": 10
         }
       ],
       "footprintRadius": 8,
@@ -4669,8 +4692,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 10
+          "duration_rounds": 10
         }
       ],
       "footprintRadius": 8,
@@ -4732,8 +4756,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 10
+          "duration_rounds": 10
         }
       ],
       "footprintRadius": 8,
@@ -4795,8 +4820,9 @@
       "buffs": [
         {
           "name": "Start-of-round buff",
+          "trigger": "start_of_round",
           "rateMultiplier": 0.25,
-          "lifespan": 10
+          "duration_rounds": 10
         }
       ],
       "footprintRadius": 8,

--- a/disbot/services/btd6_upgrade_detail_service.py
+++ b/disbot/services/btd6_upgrade_detail_service.py
@@ -204,8 +204,9 @@ _BUFF_FIELDS: tuple[tuple[str, str, int], ...] = (
     # (TradeEmpireBuffModel, Bucc 0-0-5) but had no render field here, so the
     # renderer surfaced only the damage bonus and silently dropped the income —
     # "what does Trade Empire do" lost its headline effect (extracted, but not
-    # answerable). Labels match the wiki: +$10/round per Merchantman (stacks up
-    # to 20), +$20/round per Favored Trades, +4% sellback value in range.
+    # answerable). Labels match the wiki: +$10/round per Merchantman, +$20/round
+    # per Favored Trades, +4% sellback value in range. The per-buff stack cap
+    # (Merchantman x20, sellback x3) is rendered separately — see ``_stack_cap``.
     ("cashPerRoundPerMechantship", "+${}/round per Merchantman", 1),
     ("cashPerRoundPerFavouredTrades", "+${}/round per Favored Trades", 1),
     ("cashbackZoneMultiplier", "+{}% sellback value", 100),
@@ -221,6 +222,26 @@ def _fmt_buff_num(value: Any) -> str:
     return str(value)
 
 
+def _stack_cap(buff: dict[str, Any]) -> int | None:
+    """A buff's real, positive stack cap, or ``None``.
+
+    Two field names encode the same concept — ``maxStacks`` on most towers,
+    ``maxStackSize`` on Sniper. ``0`` is *not* an unlimited cap: it means the
+    buff applies once and does not stack (a global aura like Pirate Lord's
+    Flagship or Sergeant's attack-speed buff), so we surface "up to N" only for
+    a genuine positive limit — Trade Empire (20 Merchantmen), sellback (3).
+    """
+    for field in ("maxStacks", "maxStackSize"):
+        value = buff.get(field)
+        if (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and value > 0
+        ):
+            return int(value)
+    return None
+
+
 def _buff_text(buff: dict[str, Any]) -> str:
     parts = [
         tmpl.format(_fmt_buff_num(buff[field] * scale))
@@ -230,6 +251,9 @@ def _buff_text(buff: dict[str, Any]) -> str:
     ]
     name = str(buff.get("name") or "").strip()
     body = ", ".join(parts) if parts else "buff"
+    cap = _stack_cap(buff)
+    if cap is not None:
+        body += f" (stacks up to {cap})"
     return f"{name}: {body}" if name else body
 
 

--- a/disbot/services/btd6_upgrade_detail_service.py
+++ b/disbot/services/btd6_upgrade_detail_service.py
@@ -222,6 +222,14 @@ def _fmt_buff_num(value: Any) -> str:
     return str(value)
 
 
+def _num_field(node: dict[str, Any], field: str) -> Any:
+    """A node's numeric field value, or None (rejecting bools); buffs + zones."""
+    value = node.get(field)
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return value
+    return None
+
+
 def _stack_cap(buff: dict[str, Any]) -> int | None:
     """A buff's real, positive stack cap, or ``None``.
 
@@ -242,6 +250,34 @@ def _stack_cap(buff: dict[str, Any]) -> int | None:
     return None
 
 
+# A triggered buff's activation condition, keyed by the ``trigger`` the decoder
+# stamps on it (parser ``_BUFF_TRIGGER``). The trigger also fixes the duration
+# unit: ``on_life_lost`` carries a seconds ``lifespan`` window + ``cooldown``;
+# ``start_of_round`` re-applies every round, so we state the condition rather
+# than a round-count duration that would read as "lasts 3s" and mislead.
+_BUFF_TRIGGER_COND: dict[str, str] = {
+    "on_life_lost": "when a life is lost",
+    "start_of_round": "at the start of each round",
+}
+
+
+def _buff_trigger_clause(buff: dict[str, Any]) -> str:
+    """Activation condition (+ the active/cooldown window for timed triggers)."""
+    trigger = buff.get("trigger")
+    if not isinstance(trigger, str):
+        return ""
+    cond = _BUFF_TRIGGER_COND.get(trigger)
+    if cond is None:
+        return ""
+    if trigger == "on_life_lost":
+        life = _num_field(buff, "lifespan")
+        cooldown = _num_field(buff, "cooldown")
+        window = f"for {_fmt_buff_num(life)}s " if life is not None else ""
+        tail = f" ({_fmt_buff_num(cooldown)}s cooldown)" if cooldown is not None else ""
+        return f"{window}{cond}{tail}"
+    return cond
+
+
 def _buff_text(buff: dict[str, Any]) -> str:
     parts = [
         tmpl.format(_fmt_buff_num(buff[field] * scale))
@@ -251,18 +287,19 @@ def _buff_text(buff: dict[str, Any]) -> str:
     ]
     name = str(buff.get("name") or "").strip()
     body = ", ".join(parts) if parts else "buff"
+    clause = _buff_trigger_clause(buff)
+    if clause:
+        body += f" {clause}"
+    # Cash-on-leak is a permanent passive, not part of the timed window above, so
+    # it gets its own clause. cashOnLeakMultiplier 2 = a leaked bloon grants 2x
+    # its value as cash (Desperado Vigilante line; like Bloon Trap / Obyn trees).
+    leak = _num_field(buff, "cashOnLeakMultiplier")
+    if leak is not None:
+        body += f"; leaked bloons give {_fmt_buff_num(leak)}x their value as cash"
     cap = _stack_cap(buff)
     if cap is not None:
         body += f" (stacks up to {cap})"
     return f"{name}: {body}" if name else body
-
-
-def _zone_num(zone: dict[str, Any], field: str) -> Any:
-    """A zone's numeric field value, or None (rejecting bools)."""
-    value = zone.get(field)
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
-        return value
-    return None
 
 
 def _zone_text(zone: dict[str, Any]) -> str:
@@ -279,14 +316,14 @@ def _zone_text(zone: dict[str, Any]) -> str:
     # (0.6 = bloons move at 60% speed); MOABs are slowed less. Verified
     # 'multiplier' only ever appears on Ice slow zones, so rendering it as a
     # speed multiplier can't mislabel a different zone type's number.
-    slow = _zone_num(zone, "multiplier")
+    slow = _num_field(zone, "multiplier")
     if slow is not None:
         bits.append(f"slows bloons to x{_fmt_buff_num(slow)} speed")
-    moab_slow = _zone_num(zone, "multiplierForMoabs")
+    moab_slow = _num_field(zone, "multiplierForMoabs")
     if moab_slow is not None:
         bits.append(f"MOABs to x{_fmt_buff_num(moab_slow)} speed")
     # Druid Thorn zone: flat bonus damage vs Ceramic/MOAB-class.
-    cmoab = _zone_num(zone, "damageModifierForCeramicOrMoabs")
+    cmoab = _num_field(zone, "damageModifierForCeramicOrMoabs")
     if cmoab is not None:
         bits.append(f"+{_fmt_buff_num(cmoab)} damage vs Ceramic/MOAB")
     return f"{name} ({', '.join(bits)})" if bits else name

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -25,7 +25,9 @@ works** (the traps we hit), and what is still un-decoded.
 - **Mapper** (`scripts/parse_gamedata.py`): faithful — `--audit` is
   **nothing-SUSPECT**, anchors pass. Decodes attacks/projectiles/sub-projectiles,
   **subtowers** (2 of 4 mechanisms), **zones** (top-level, started), **buffs**
-  (**8 of 38** confirmed types in `_BUFF_FIELD_MAP`).
+  (**9 of 38** confirmed types in `_BUFF_FIELD_MAP` — incl. the
+  `VigilanteTowerBehaviorModel` lives-lost buff — each carrying its activation
+  `trigger`, which fixes the duration unit: seconds vs round-count).
 
 **Do next (ordered; correctness over speed — the maintainer's standing rule):**
 1. **Buff decode tail (8 → 38).** The cleanly value-confirmable set is now
@@ -95,6 +97,31 @@ works** (the traps we hit), and what is still un-decoded.
 - Buff/zone `name`s are the dump's **internal** ids → audit aligns by name and
   ignores them (keeps `--audit` nothing-SUSPECT); never downgrade a curated name.
 - `python3.10 scripts/check_quality.py --full` before pushing.
+
+### Session log — temporary-buff triggers (units fixed) + Vigilante de-orphan + cash-on-leak
+
+Decoded the two **time/round-windowed** buffs whose duration field was unit-ambiguous:
+- **Desperado lives-lost buff** (`VigilanteTowerBehaviorModel`, the Nomad/Enforcer/…
+  bottom line) was **orphaned** — not in `_BUFF_FIELD_MAP`, so a re-parse dropped
+  it (committed values were right but unreproducible). Now decoded: raw
+  `loseLifeAttackSpeedBuff`/`loseLifeRangeBuff` → `rateMultiplier`/`rangeAdditive`;
+  `loseLifeBuff{Duration,Cooldown}Frames` ÷60 → `lifespan`/`cooldown` **in seconds**
+  (900f=15s, 3600f=60s); `bloonLeakValueModifier` 2.0 → `cashOnLeakMultiplier`
+  (a leaked bloon grants **2× its value as cash** — maintainer-confirmed, same
+  mechanic as Bloon Trap / Obyn trees). Trigger `on_life_lost`.
+- **Engineer/Spike start-of-round buff** (`StartOfRoundRateBuffModel`): the raw
+  `duration` is a **round count** (`durationFrames` is 0), so it now maps to
+  `duration_rounds` — keeping `lifespan` exclusively for seconds. Trigger
+  `start_of_round`; re-applies every round (effectively permanent), so the renderer
+  states the condition, not a misleading "lasts 3s".
+- **Why it matters:** the committed `lifespan` field was carrying *two units*
+  (15 = seconds on Desperado, 3/10 = rounds on Spike). The new `trigger` field is
+  the discriminator that fixes the unit downstream. `_BUFF_TRIGGER` /
+  `_BUFF_FRAME_FIELDS` in the parser; `_buff_trigger_clause` in
+  `btd6_upgrade_detail_service`. Committed data re-merged (parser-reproducible,
+  coverage unchanged: 26 Desperado + 15 Engineer + 26 Spike tiers). Pinned by
+  `test_buffs_vigilante_lives_lost` / `test_buffs_start_of_round_rate` (parser) and
+  the trigger/cash-on-leak render tests.
 
 ### Session log — per-round cash (all 140, derived) + where the cash economy lives
 

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -590,11 +590,24 @@ _BUFF_FIELD_MAP: dict[str, dict[str, str]] = {
     },
     # rangeMultiplier passes through 1:1 (Mermonkey in-water buff: 1.35).
     "PlacementAreaTypeRangeBuffModel": {"rangeMultiplier": "rangeMultiplier"},
-    # Engineer/Spike start-of-round buff (×0.25 cooldown for N rounds): two-tower
-    # confirmation (modifier 0.25→rateMultiplier; duration 1/3→lifespan).
+    # Engineer/Spike start-of-round buff: modifier 0.25→rateMultiplier; the
+    # ``duration`` is a ROUND count, not seconds (the raw ``durationFrames`` is
+    # 0), so it maps to ``duration_rounds`` — keeping ``lifespan`` exclusively
+    # for second-valued windows. ``trigger`` ("start_of_round") carries the rest.
     "StartOfRoundRateBuffModel": {
         "modifier": "rateMultiplier",
-        "duration": "lifespan",
+        "duration": "duration_rounds",
+    },
+    # Desperado bottom-path lives-lost buff (the Vigilante line: Nomad/Enforcer/
+    # …). Fires when a life leaks — confirmed by the raw field names. The two 1:1
+    # effects + the cash-on-leak multiplier are here; the seconds-valued active /
+    # cooldown windows are *Frames in the dump and live in ``_BUFF_FRAME_FIELDS``.
+    # cashOnLeakMultiplier 2.0 = a leaked bloon grants 2x its value as cash (same
+    # mechanic as Bloon Trap / Obyn's trees).
+    "VigilanteTowerBehaviorModel": {
+        "loseLifeAttackSpeedBuff": "rateMultiplier",
+        "loseLifeRangeBuff": "rangeAdditive",
+        "bloonLeakValueModifier": "cashOnLeakMultiplier",
     },
     # Wizard Necromancer "Undead Bloon buff": the committed wiki data maps
     # distanceMultiplier→lifespanMultiplier (raw 1.5 == wiki 1.5), so it is the
@@ -603,6 +616,26 @@ _BUFF_FIELD_MAP: dict[str, dict[str, str]] = {
         "damageIncrease": "damageAdditive",
         "distanceMultiplier": "lifespanMultiplier",
     },
+}
+
+
+# Buff windows the dump stores as frame counts (60 fps) → seconds. Kept apart
+# from the 1:1 maps above because each needs the /60 conversion. (Only the
+# Vigilante lives-lost windows use this so far.)
+_BUFF_FRAME_FIELDS: dict[str, dict[str, str]] = {
+    "VigilanteTowerBehaviorModel": {
+        "loseLifeBuffDurationFrames": "lifespan",
+        "loseLifeBuffCooldownFrames": "cooldown",
+    },
+}
+
+# A buff's activation trigger — the discriminator that also fixes the duration
+# unit downstream: ``on_life_lost`` windows are seconds (lifespan / cooldown),
+# ``start_of_round`` is a round count (duration_rounds, re-applied every round).
+# Without it the committed numbers would be unit-ambiguous to a renderer.
+_BUFF_TRIGGER: dict[str, str] = {
+    "VigilanteTowerBehaviorModel": "on_life_lost",
+    "StartOfRoundRateBuffModel": "start_of_round",
 }
 
 
@@ -628,10 +661,17 @@ def _buffs(model: dict) -> list[dict]:
             or behavior.get("mutatorId")
             or short[: -len("Model")],
         }
+        trigger = _BUFF_TRIGGER.get(short)
+        if trigger:
+            entry["trigger"] = trigger
         for raw_field, schema_field in field_map.items():
             value = behavior.get(raw_field)
             if isinstance(value, (int, float)) and not isinstance(value, bool):
                 entry[schema_field] = _num(value)
+        for raw_field, schema_field in _BUFF_FRAME_FIELDS.get(short, {}).items():
+            value = behavior.get(raw_field)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                entry[schema_field] = _num(value / 60.0)  # frames → seconds
         if "isGlobal" in behavior:
             entry["isGlobal"] = bool(behavior["isGlobal"])
         out.append(entry)

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -982,8 +982,10 @@ def test_buffs_trade_empire_cash_and_damage(mod):
 
 
 def test_buffs_start_of_round_rate(mod):
-    # Engineer/Spike start-of-round buff: modifier 0.25 -> rateMultiplier,
-    # duration -> lifespan (two-tower confirmed).
+    # Engineer/Spike start-of-round buff: modifier 0.25 -> rateMultiplier; the
+    # ``duration`` is a ROUND count (durationFrames is 0), so it maps to
+    # ``duration_rounds`` (not ``lifespan``, which stays seconds-only) and the
+    # buff is stamped with its ``start_of_round`` trigger.
     model = _tower_model()
     model["behaviors"].append(
         {
@@ -996,7 +998,34 @@ def test_buffs_start_of_round_rate(mod):
     )
     buff = mod._map_tier(model)["buffs"][0]
     assert buff["rateMultiplier"] == 0.25
-    assert buff["lifespan"] == 3
+    assert buff["duration_rounds"] == 3
+    assert buff["trigger"] == "start_of_round"
+    assert "lifespan" not in buff  # rounds, never mislabelled as a seconds window
+
+
+def test_buffs_vigilante_lives_lost(mod):
+    # Desperado bottom-path lives-lost buff: frame windows -> seconds (÷60), the
+    # two 1:1 effects, the ×2 cash-on-leak, and the on_life_lost trigger that
+    # marks the durations as seconds. De-orphans a buff the parser used to drop.
+    model = _tower_model()
+    model["behaviors"].append(
+        {
+            "$type": _t("VigilanteTowerBehaviorModel"),
+            "buffLocsName": "BuffIconVigilante",
+            "loseLifeAttackSpeedBuff": 0.6,
+            "loseLifeRangeBuff": 16.0,
+            "loseLifeBuffDurationFrames": 900,
+            "loseLifeBuffCooldownFrames": 3600,
+            "bloonLeakValueModifier": 2.0,
+        }
+    )
+    buff = mod._map_tier(model)["buffs"][0]
+    assert buff["trigger"] == "on_life_lost"
+    assert buff["rateMultiplier"] == 0.6
+    assert buff["rangeAdditive"] == 16
+    assert buff["cashOnLeakMultiplier"] == 2
+    assert buff["lifespan"] == 15  # 900 frames / 60
+    assert buff["cooldown"] == 60  # 3600 frames / 60
 
 
 def test_buffs_placement_area_range_passthrough(mod):

--- a/tests/unit/services/test_btd6_upgrade_detail_service.py
+++ b/tests/unit/services/test_btd6_upgrade_detail_service.py
@@ -342,6 +342,59 @@ def test_sellback_stack_cap_surfaces_end_to_end():
     assert "(stacks up to 3)" in blob
 
 
+# --- triggered-buff window + cash-on-leak (trigger fixes the duration unit) --
+
+
+def test_buff_lives_lost_trigger_renders_seconds_and_cash_on_leak():
+    # on_life_lost: the window/cooldown are SECONDS, the condition is stated, and
+    # the cash-on-leak is a separate permanent clause (not inside the timed bit).
+    text = det._buff_text(
+        {
+            "name": "Nomad buff",
+            "trigger": "on_life_lost",
+            "rateMultiplier": 0.6,
+            "rangeAdditive": 16,
+            "cashOnLeakMultiplier": 2,
+            "lifespan": 15,
+            "cooldown": 60,
+        },
+    )
+    assert "for 15s when a life is lost (60s cooldown)" in text
+    assert "leaked bloons give 2x their value as cash" in text
+
+
+def test_buff_start_of_round_trigger_renders_each_round_not_seconds():
+    # start_of_round re-applies every round, so we state the condition and never
+    # a fixed duration — duration_rounds must NOT surface as "3s".
+    text = det._buff_text(
+        {
+            "name": "Start-of-round buff",
+            "trigger": "start_of_round",
+            "rateMultiplier": 0.25,
+            "duration_rounds": 3,
+        },
+    )
+    assert text == "Start-of-round buff: x0.25 attack cooldown at the start of each round"
+    assert "3s" not in text and "3 round" not in text
+
+
+def test_lives_lost_buff_surfaces_end_to_end():
+    # Real committed Desperado Enforcer (0-0-3): event-driven buff, seconds, ×2
+    # cash-on-leak — all reaching the rendered detail / AI grounding.
+    d = det.get_upgrade_detail("desperado:003")
+    blob = " | ".join(d.buffs)
+    assert "+16 range for 15s when a life is lost (60s cooldown)" in blob
+    assert "leaked bloons give 2x their value as cash" in blob
+
+
+def test_start_of_round_buff_surfaces_end_to_end():
+    # Real committed Spike Factory Perma-Spike (0-0-5): round-start speed buff.
+    d = det.get_upgrade_detail("spike_factory:005")
+    blob = " | ".join(d.buffs)
+    assert "at the start of each round" in blob
+    assert "lifespan" not in blob
+
+
 def test_zone_slow_multiplier_renders_as_speed():
     # Ice Monkey's Arctic Wind: 'multiplier' is a speed multiplier (0.6 = 60%
     # speed). It was dropped, so Ice's signature slow was unstated. MOABs slow

--- a/tests/unit/services/test_btd6_upgrade_detail_service.py
+++ b/tests/unit/services/test_btd6_upgrade_detail_service.py
@@ -295,6 +295,53 @@ def test_buff_hero_xp_multiplier_renders():
     assert "x1.5 hero XP" in text
 
 
+# --- buff stack cap (maxStacks / maxStackSize) ------------------------------
+
+
+def test_buff_stack_cap_renders_when_positive():
+    # Trade Empire stacks per Merchantman in range, up to 20 — a real cap a
+    # player asks about. It sat in committed data (maxStacks) but never
+    # surfaced; only a code comment hardcoded "up to 20".
+    text = det._buff_text(
+        {
+            "name": "Trade Empire buff",
+            "cashPerRoundPerMechantship": 10,
+            "maxStacks": 20,
+        },
+    )
+    assert "+$10/round per Merchantman" in text
+    assert "(stacks up to 20)" in text
+
+
+def test_buff_stack_cap_zero_means_no_clause():
+    # maxStacks == 0 is "applies once, does not stack" (a global aura), NOT an
+    # unlimited cap — so we render no stack clause for it.
+    text = det._buff_text(
+        {"name": "Flagship buff", "rateMultiplier": 0.8, "maxStacks": 0},
+    )
+    assert "stacks up to" not in text
+    assert text == "Flagship buff: x0.8 attack cooldown"
+
+
+def test_buff_stack_cap_reads_max_stack_size_alias():
+    # Sniper encodes the same concept under the other field name (maxStackSize);
+    # a positive value still surfaces a cap, 0 still renders nothing.
+    assert "(stacks up to 4)" in det._buff_text(
+        {"name": "X", "rateMultiplier": 0.75, "maxStackSize": 4},
+    )
+    assert "stacks up to" not in det._buff_text(
+        {"name": "Attack speed buff", "rateMultiplier": 0.75, "maxStackSize": 0},
+    )
+
+
+def test_sellback_stack_cap_surfaces_end_to_end():
+    # Real committed Buccaneer 0-0-4: +4% sellback, stacks up to 3 (= +12%).
+    d = det.get_upgrade_detail("monkey_buccaneer:004")
+    blob = " | ".join(d.buffs)
+    assert "+4% sellback value" in blob
+    assert "(stacks up to 3)" in blob
+
+
 def test_zone_slow_multiplier_renders_as_speed():
     # Ice Monkey's Arctic Wind: 'multiplier' is a speed multiplier (0.6 = 60%
     # speed). It was dropped, so Ice's signature slow was unstated. MOABs slow


### PR DESCRIPTION
Continues the BTD6 buff/zone decode work: surfaces buff stats that were already
extracted into committed data but never reached the renderer (the `extracted ≠
answerable` gap), and fixes a latent unit-correctness bug along the way. Two
commits, both verified against the v55 game-data dump.

## 1. Render buff stack caps (`81839b2`)
`maxStacks` / `maxStackSize` (the same concept under two field names) were in the
data but dropped — only a code comment hard-coded "up to 20". Now surfaced as
`(stacks up to N)`, **only when N is a real positive cap**:
- Trade Empire (0-0-5) → `+$10/round per Merchantman (stacks up to 20)`
- Sellback (0-0-4) → `+4% sellback value (stacks up to 3)` (= +12%)
- `0` means *applies once / does not stack* (global auras like Pirate Lord,
  Elite Defender), so it renders **no** clause — maintainer-confirmed.

## 2. Decode temporary-buff triggers — fixes a seconds-vs-rounds unit overload (`9a93b0c`)
The committed `lifespan` field was carrying **two different units** under one
name — seconds on Desperado's lives-lost buff (`15`) and a round-count on the
Engineer/Spike start-of-round buff (`3`/`10`) — so it couldn't be rendered
without guessing. Each temporary buff now carries its activation `trigger`,
decoded straight from the source model, which fixes the unit:

- **`VigilanteTowerBehaviorModel`** (Desperado Nomad/Enforcer line) was
  **orphaned** — not in `_BUFF_FIELD_MAP`, so a re-parse silently dropped it
  (values were right but unreproducible). Now decoded: `loseLife*` →
  `rateMultiplier`/`rangeAdditive`, frame windows ÷60 → `lifespan`/`cooldown` in
  **seconds** (900f=15s, 3600f=60s), `trigger=on_life_lost`, and
  `bloonLeakValueModifier 2.0` → `cashOnLeakMultiplier` (a leaked bloon grants
  **2× its value as cash** — maintainer-confirmed, same mechanic as Bloon Trap /
  Obyn trees).
- **`StartOfRoundRateBuffModel`**: raw `duration` is a **round count**
  (`durationFrames` is 0), so it maps to `duration_rounds` — keeping `lifespan`
  seconds-only. `trigger=start_of_round`; re-applies every round, so the renderer
  states the condition, not a misleading "lasts 3s".

Rendered output (verified on real committed data):
- Desperado Enforcer → `Nomad buff: x0.6 attack cooldown, +16 range for 15s when a life is lost (60s cooldown); leaked bloons give 2x their value as cash`
- Spike/Engineer → `Start-of-round buff: x0.25 attack cooldown at the start of each round`

Committed data for the 3 affected towers (desperado / engineer_monkey /
spike_factory) was re-merged from the fixed parser — **parser-reproducible now,
coverage unchanged** (26 + 15 + 26 tiers). `_zone_num` was generalized to a
shared `_num_field` (buffs + zones).

## Testing
- `python3.10 scripts/check_quality.py --full` — green (mypy + **7272** tests + lint).
- `python3.10 scripts/check_architecture.py --mode strict` — no new violations.
- New pins: `test_buffs_vigilante_lives_lost`, updated `test_buffs_start_of_round_rate`
  (parser); trigger/cash-on-leak + end-to-end render tests (`test_btd6_upgrade_detail_service.py`).

https://claude.ai/code/session_01BsFD9xMzFaPa83Z1dffn7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsFD9xMzFaPa83Z1dffn7p)_