### PR TITLE
feat(btd6): correct map roster to 86 + ground/floor map count & list questions

### DIFF
--- a/disbot/data/btd6/maps.json
+++ b/disbot/data/btd6/maps.json
@@ -273,15 +273,6 @@
       "has_water": true
     },
     {
-      "id": "base_editor_map",
-      "canonical": "Base Editor Map",
-      "aliases": [],
-      "difficulty": "Intermediate",
-      "description": "Intermediate map.",
-      "lines_of_sight_notes": "No water tiles — land-only tower placement.",
-      "has_water": false
-    },
-    {
       "id": "bazaar",
       "canonical": "Bazaar",
       "aliases": [],
@@ -409,15 +400,6 @@
     {
       "id": "polyphemus",
       "canonical": "Polyphemus",
-      "aliases": [],
-      "difficulty": "Intermediate",
-      "description": "Intermediate map. Contains water.",
-      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
-      "has_water": true
-    },
-    {
-      "id": "protect_the_yacht",
-      "canonical": "Protect The Yacht",
       "aliases": [],
       "difficulty": "Intermediate",
       "description": "Intermediate map. Contains water.",
@@ -702,15 +684,6 @@
       "description": "Advanced map.",
       "lines_of_sight_notes": "No water tiles — land-only tower placement.",
       "has_water": false
-    },
-    {
-      "id": "blons",
-      "canonical": "Blons",
-      "aliases": [],
-      "difficulty": "Expert",
-      "description": "Expert map. Contains water.",
-      "lines_of_sight_notes": "Has water tiles — naval towers (Monkey Sub, Monkey Buccaneer) can be placed.",
-      "has_water": true
     },
     {
       "id": "bloody_puddles",

--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -1400,6 +1400,26 @@ def _entity_roster_facts(message_text: str) -> list[str]:
                 "primary/military/magic/support",
             ),
         )
+    if "map" in text:
+        # Counts are a single grounded summary (not 89 names): "how many maps",
+        # "by difficulty", and "how many have water" all answer from it. Without
+        # it the model recited stale training counts (25/28/22/14, "~73 water")
+        # and even labelled them "verified" — the real figures are below.
+        maps = dataset.maps
+        water = sum(1 for m in maps if m.has_water)
+        order = ("Beginner", "Intermediate", "Advanced", "Expert")
+        diff_str = ", ".join(
+            f"{c} {d}"
+            for d in order
+            if (c := sum(1 for m in maps if m.difficulty == d))
+        )
+        out.append(
+            _cap(
+                f"[btd6_map] BTD6 has {len(maps)} maps total: {diff_str}. "
+                f"{water} have water (naval towers placeable), "
+                f"{len(maps) - water} are land-only. (source: fixture/btd6_data)",
+            ),
+        )
     return out
 
 

--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -1470,8 +1470,27 @@ def deterministic_roster_reply(message_text: str) -> str | None:
     text = (message_text or "").lower()
     if any(word in text for word in _ROSTER_STRATEGY_WORDS):
         return None
-    is_list = any(phrase in text for phrase in _ROSTER_LIST_INTENT) or (
-        "all " in text or "every " in text
+    # A map water/land/removables question is a list/count request even without a
+    # generic "list/all" verb ("land-only maps", "which maps have removables").
+    map_list = "map" in text and any(
+        p in text
+        for p in (
+            "water",
+            "naval",
+            "land-only",
+            "land only",
+            "removable",
+            "obstacle",
+            "which",
+            "without water",
+            "no water",
+        )
+    )
+    is_list = (
+        any(phrase in text for phrase in _ROSTER_LIST_INTENT)
+        or "all " in text
+        or "every " in text
+        or map_list
     )
     if not is_list:
         return None
@@ -1528,7 +1547,82 @@ def deterministic_roster_reply(message_text: str) -> str | None:
             out.extend(f"• **{t.canonical}** — ${t.base_cost}" for t in group)
         return "\n".join(out)
 
+    if "map" in text:
+        return _map_roster_reply(text, list(dataset.maps))
+
     return None
+
+
+def _map_roster_reply(text: str, maps: list) -> str:
+    """Deterministic map list/count answers (water / land-only / removables).
+
+    The model proved it cannot restate these — it gave five different water
+    counts (73/75/76/77), each falsely "verified from the tool", while its own
+    land-only list held the right 20. So floor map count/list questions to
+    code-built truth, exactly like the hero/tower rosters. Returns the count
+    alone for a pure "how many", otherwise the grouped name list(s).
+    """
+    water = [m for m in maps if m.has_water]
+    land = [m for m in maps if not m.has_water]
+    removable = [m for m in maps if getattr(m, "removables", "")]
+    order = ("Beginner", "Intermediate", "Advanced", "Expert")
+
+    def grouped(rows: list) -> str:
+        out = []
+        for diff in order:
+            names = sorted(m.canonical for m in rows if m.difficulty == diff)
+            if names:
+                out.append(f"__{diff}__: " + ", ".join(names))
+        return "\n".join(out)
+
+    wants_count = ("how many" in text or "number of" in text) and not any(
+        w in text for w in ("list", "name ", "which", "what are")
+    )
+    want_rem = "removable" in text or "obstacle" in text
+    want_land = any(
+        p in text for p in ("land-only", "land only", "without water", "no water")
+    ) or ("land" in text and "water" not in text)
+    want_water = (not want_land) and ("water" in text or "naval" in text)
+
+    sections: list[str] = []
+    if want_rem:
+        sections.append(
+            f"**Maps with removable obstacles ({len(removable)} of {len(maps)})** "
+            "— ask about a specific map for what's removable:\n" + grouped(removable),
+        )
+    if want_water:
+        if wants_count and not sections:
+            return (
+                f"Of {len(maps)} BTD6 maps, **{len(water)} have water** (naval "
+                f"towers placeable) and **{len(land)} are land-only**."
+            )
+        sections.append(
+            f"**Maps with water ({len(water)} of {len(maps)})** — naval towers "
+            "placeable:\n" + grouped(water),
+        )
+    elif want_land:
+        if wants_count and not sections:
+            return (
+                f"**{len(land)}** of {len(maps)} BTD6 maps are land-only (no "
+                f"water); the other **{len(water)}** have water."
+            )
+        sections.append(
+            f"**Land-only maps ({len(land)} of {len(maps)})** — no water, land "
+            "towers only:\n" + grouped(land),
+        )
+    if sections:
+        return "\n\n".join(sections)
+
+    # Generic "how many maps" / "list all maps".
+    if wants_count:
+        by_diff = ", ".join(
+            f"{sum(1 for m in maps if m.difficulty == d)} {d}" for d in order
+        )
+        return (
+            f"BTD6 has **{len(maps)} maps**: {by_diff}. **{len(water)}** have "
+            f"water, **{len(land)}** are land-only."
+        )
+    return f"**BTD6 Maps ({len(maps)})** by difficulty:\n{grouped(maps)}"
 
 
 def _paragon_name_facts(message_text: str, resolved_tower_ids: set[str]) -> list[str]:

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -1728,6 +1728,11 @@ def map_maps(dump: Path, version: str) -> tuple[list[dict], list[str]]:
                 continue
             if raw.get("isDebug"):
                 continue  # non-player / debug map
+            if raw.get("IsStandard") is False:
+                # Browser-only / editor / dev maps are flagged non-standard
+                # (Blons, Base Editor Map, Protect the Yacht) — exclude them so
+                # the roster is the 86 real player maps, not 89.
+                continue
             stem = fp.stem
             mid = _snake(stem)
             if mid in seen:

--- a/tests/unit/cogs/test_btd6_embed_snapshots.py
+++ b/tests/unit/cogs/test_btd6_embed_snapshots.py
@@ -262,7 +262,7 @@ def test_maps_embed_title() -> None:
 
 
 def test_maps_embed_stays_within_discord_limits() -> None:
-    # The catalogue grew 3 → 89 maps and joins every map in a difficulty into one
+    # The catalogue grew 3 → 86 maps and joins every map in a difficulty into one
     # field value. A future BTD6 version that adds maps to a single difficulty
     # could push that value past Discord's 1024-char cap, and the whole embed
     # would silently fail to send live. Guard every hard limit so map growth

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -762,14 +762,20 @@ def test_snake_and_decamel(mod):
     assert mod._decamel("HighFinance") == "High Finance"
 
 
-def _map_details(*, difficulty: int, has_water: bool, debug: bool = False) -> dict:
+def _map_details(
+    *,
+    difficulty: int,
+    has_water: bool,
+    debug: bool = False,
+    is_standard: bool = True,
+) -> dict:
     return {
         "$type": "Il2Cpp….MapDetails, Assembly-CSharp",
         "difficulty": difficulty,
         "hasWater": has_water,
         "theme": 0,
         "isDebug": debug,
-        "IsStandard": True,
+        "IsStandard": is_standard,
     }
 
 
@@ -790,6 +796,12 @@ def _make_maps_dump(tmp_path: Path) -> Path:
         dump / "Maps" / "Expert" / "DebugMap.json",
         _map_details(difficulty=3, has_water=False, debug=True),
     )
+    # Browser-only / editor / dev map (IsStandard=False) — must be filtered too,
+    # like the real Blons / Base Editor Map / Protect the Yacht.
+    _write(
+        dump / "Maps" / "Expert" / "Blons.json",
+        _map_details(difficulty=3, has_water=False, is_standard=False),
+    )
     (dump / "Maps" / "Intermediate").mkdir(parents=True)  # present but empty
     _write(
         dump / "textTable.json", {"MushroomGrotto": "Mushroom Grotto", "Logs": "Logs"}
@@ -803,8 +815,9 @@ def test_map_maps_extracts_difficulty_water_and_names(mod, tmp_path, monkeypatch
     rows, warnings = mod.map_maps(dump, "55.0")
     assert warnings == []
     by_id = {r["id"]: r for r in rows}
-    # debug map filtered out
-    assert "debug_map" not in by_id and len(rows) == 2
+    # debug map AND non-standard (browser-only/dev) map filtered out
+    assert "debug_map" not in by_id and "blons" not in by_id
+    assert len(rows) == 2
     assert by_id["logs"]["difficulty"] == "Beginner"
     assert by_id["logs"]["has_water"] is True
     assert "naval" in by_id["logs"]["lines_of_sight_notes"].lower()

--- a/tests/unit/services/test_btd6_context_grounding.py
+++ b/tests/unit/services/test_btd6_context_grounding.py
@@ -501,12 +501,14 @@ async def test_build_grounds_map_summary_counts():
     # The summary now grounds the real figures (total, by-difficulty, water/land).
     ctx = await btd6_context_service.build("how many maps have water")
     blob = "\n".join(f for f in ctx.facts if "[btd6_map]" in f)
-    assert "89 maps total" in blob
-    assert "69 have water" in blob and "20 are land-only" in blob
-    assert "26 Beginner" in blob and "27 Intermediate" in blob
+    # 86 real player maps — the 3 non-standard (Blons / Base Editor Map / Protect
+    # the Yacht, IsStandard=False) are filtered out of the catalogue.
+    assert "86 maps total" in blob
+    assert "67 have water" in blob and "19 are land-only" in blob
+    assert "26 Beginner" in blob and "25 Intermediate" in blob
     # A specific-map question must NOT dump the summary.
     specific = await btd6_context_service.build("does Cargo have water")
-    assert "89 maps total" not in "\n".join(specific.facts)
+    assert "86 maps total" not in "\n".join(specific.facts)
 
 
 def test_deterministic_roster_reply_lists_full_rosters():
@@ -535,6 +537,29 @@ def test_deterministic_roster_reply_skips_strategy_and_specific_questions():
         is None
     )
     assert btd6_context_service.deterministic_roster_reply("dart monkey stats") is None
+
+
+def test_deterministic_roster_reply_maps_water_land_removables():
+    # The model gave FIVE different water counts (73/75/76/77), each falsely
+    # "verified from the tool", while its own land-only list held the right 20.
+    # Floor map count/list questions to code-built truth (69 water / 20 land /
+    # 18 removables) so they can't be fabricated.
+    r = btd6_context_service.deterministic_roster_reply
+    count = r("how many maps have water")
+    assert count is not None and "67 have water" in count and "19 are land-only" in count
+    water = r("list all maps with water")
+    assert water is not None and "67 of 86" in water and "Cubism" in water
+    land = r("land-only maps")  # fires without a generic list verb
+    assert land is not None and "19 of 86" in land
+    assert "Monkey Meadow" in land and "Cornfield" in land
+    rem = r("list maps with removables")
+    assert rem is not None and "18 of 86" in rem
+    assert "Cargo" in rem and "Bazaar" in rem
+    # Combined request returns both sections.
+    both = r("list all maps with water and all maps with removables")
+    assert both is not None and "Maps with water" in both and "removable obstacles" in both
+    # Strategy / opinion still reaches the model.
+    assert r("which water map is best for beginners") is None
 
 
 # --- hero per-level game descriptions (step 4b) -----------------------------

--- a/tests/unit/services/test_btd6_context_grounding.py
+++ b/tests/unit/services/test_btd6_context_grounding.py
@@ -494,6 +494,21 @@ async def test_build_grounds_tower_roster_with_costs_and_category():
     assert not any("tower_roster" in f for f in specific.facts)
 
 
+@pytest.mark.asyncio
+async def test_build_grounds_map_summary_counts():
+    # Live test: the bot recited stale training counts (25/28/22/14, "~73"/"76"
+    # water — even labelled "verified") because no aggregate count was grounded.
+    # The summary now grounds the real figures (total, by-difficulty, water/land).
+    ctx = await btd6_context_service.build("how many maps have water")
+    blob = "\n".join(f for f in ctx.facts if "[btd6_map]" in f)
+    assert "89 maps total" in blob
+    assert "69 have water" in blob and "20 are land-only" in blob
+    assert "26 Beginner" in blob and "27 Intermediate" in blob
+    # A specific-map question must NOT dump the summary.
+    specific = await btd6_context_service.build("does Cargo have water")
+    assert "89 maps total" not in "\n".join(specific.facts)
+
+
 def test_deterministic_roster_reply_lists_full_rosters():
     # The model can't restate 17+ costs verbatim, so a list request floors to a
     # code-built roster that is always correct (it IS the source).


### PR DESCRIPTION
Makes map count/list questions answerable from real data instead of fabrication, and fixes the map count itself. Two commits.

## 1. Aggregate map-count grounding
Live test — *"how many maps"* / *"how many have water"* — the bot recited stale training counts (25/28/22/14, "~73"/"76 verified" water) because the per-map `[btd6_map]` fact only fires for a *specific* map; an aggregate question grounded nothing. Added a map branch to `_entity_roster_facts` that grounds a compact `[btd6_map]` summary (total, by-difficulty, water/land).

## 2. Deterministic map lists + the 86-map correction
Grounding alone wasn't enough — across one session the bot gave **five different water counts** (73→77→75→76→77), each falsely *"verified from the tool"*, while its own land-only list held the right set. So, like the hero/tower rosters, map count/list questions now floor to a **deterministic, code-built reply** (`_map_roster_reply`) that bypasses the model:
- *"how many maps have water"* → `Of 86 maps, 67 have water, 19 are land-only.`
- *"list maps with water" / "land-only maps" / "list maps with removables"* → the grouped name lists (67 / 19 / 18).
- strategy/opinion questions ("which water map is best") still reach the model.

**Catalogue correction (maintainer-caught):** 3 non-player maps — **Blons**, **Base Editor Map**, **Protect the Yacht** (all `IsStandard=False` / browser-only) — were being counted, inflating the total to 89. `map_maps` now filters `IsStandard=False`, giving the **86** real player maps:

| | value |
|---|---|
| total | **86** (26 Beginner, 25 Intermediate, 22 Advanced, 13 Expert) |
| water | **67** |
| land-only | **19** |
| removables | 18 |

## Testing
- `test_build_grounds_map_summary_counts` (86/67/19), `test_deterministic_roster_reply_maps_water_land_removables` (lists + counts + strategy-passthrough), parser test pins the `IsStandard=False` filter.
- `python3.10 scripts/check_quality.py --full` — green (mypy + **7277** tests + lint).

https://claude.ai/code/session_01BsFD9xMzFaPa83Z1dffn7p