### PR TITLE
docs(btd6): smoke-test checklist + refresh stale counts (86 maps, 9 buffs)

### DIFF
--- a/docs/btd6-game-file-extraction-plan.md
+++ b/docs/btd6-game-file-extraction-plan.md
@@ -134,7 +134,7 @@ audit flags as systematically divergent stay curated.
 2. **Damage zones** — `zones[]` (**28** `*ZoneModel` types). 🟡 **Started** —
    `_zones()` emits every top-level zone with decodable numbers (e.g. Ice Arctic
    Wind `speedScale 0.6`). Remaining: the per-type effect tail + nested zones.
-3. **Buffs** — `buffs[]` (**38** support/buff types). 🟡 **Started — 8 of 38**
+3. **Buffs** — `buffs[]` (**38** support/buff types). 🟡 **Started — 9 of 38**
    confirmed in `_BUFF_FIELD_MAP` (each value-verified against committed wiki on
    a matching tier). The cleanly value-confirmable set is now largely exhausted;
    the rest need per-model analysis or have no committed ground truth.

--- a/docs/btd6-gamedata-decode-explainer.md
+++ b/docs/btd6-gamedata-decode-explainer.md
@@ -164,7 +164,7 @@ mapping is **correct**. The data overruled the gut. (It cuts the other way too:
 a value that coincidentally matches but is semantically absurd must be rejected —
 so single-value, single-tower "matches" get extra scrutiny.)
 
-### 5.4 Why it stopped at 8 of 38 (this is a boundary, not a quota)
+### 5.4 Why it stopped at 9 of 38 (this is a boundary, not a quota)
 The 8 confirmed types are the ones where the answer-key method *works*. The
 remaining ~30 can't be confirmed this way, for one of two reasons:
 

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -18,7 +18,11 @@ works** (the traps we hit), and what is still un-decoded.
 **Where the data stands (verified on `main`, full CI green):**
 - **Towers** 25, **Heroes** 17, **Rounds** 140 — towers/rounds/bloons still
   **wiki-sourced** (no cutover yet); the 11 wiki-missing heroes are game-data.
-- **Maps** 89 — **fully cut over to game data** (`--maps`), with `has_water`.
+  Rounds now carry derived **per-round + cumulative cash** (all 140).
+- **Maps** 86 — **fully cut over to game data** (`--maps`), with `has_water`,
+  curated **removables** (18 maps), and aggregate count/list grounding. (89 dump
+  files minus the 3 non-player `IsStandard=False` maps: Blons, Base Editor Map,
+  Protect the Yacht.)
 - **Modes** 18 — **curated** taxonomy: 3 difficulties (Easy/Medium/Hard) + 13
   modes (Standard is the base mode in every difficulty) + 2 modifiers (Double
   Cash, Fast Track; relative-effect, no fixed numbers).
@@ -30,7 +34,7 @@ works** (the traps we hit), and what is still un-decoded.
   `trigger`, which fixes the duration unit: seconds vs round-count).
 
 **Do next (ordered; correctness over speed — the maintainer's standing rule):**
-1. **Buff decode tail (8 → 38).** The cleanly value-confirmable set is now
+1. **Buff decode tail (9 → 38).** The cleanly value-confirmable set is now
    *exhausted* — every remaining committed buff field either has **no committed
    ground-truth `buffs[]` entry** to verify against (e.g. `RangeSupportModel` on
    Village) or needs a **value transformation** (raw multiplier → wiki
@@ -64,13 +68,19 @@ works** (the traps we hit), and what is still un-decoded.
      `AttackModel`). Needs the cutover, or a deliberate model extension that gives
      economy/support towers a minimal tier structure — a maintainer call, not a
      clean pass.
-   - **DEFERRED — buff duration fields.** `lifespan` (Engineer/Spike
-     start-of-round burst, Desperado Nomad) + `cooldown` (Nomad) are committed but
-     dropped. The raw dump field is `duration` (with `durationFrames`) and the
-     ability renderer already uses **seconds**, but an earlier note said "for N
-     *rounds*" — so the unit is **under-confirmed**. Do not render until
-     seconds-vs-rounds is settled in-game/wiki.
+   - **DONE — buff duration + trigger (PR #501).** The seconds-vs-rounds overload
+     is resolved by a `trigger` discriminator: `VigilanteTowerBehaviorModel`
+     (Desperado lives-lost line) was de-orphaned with frame→seconds windows
+     (`lifespan` 15 s / `cooldown` 60 s), `cashOnLeakMultiplier` 2.0, and
+     `trigger=on_life_lost`; the start-of-round buff's `duration` is a ROUND count
+     (now `duration_rounds`, `durationFrames`=0, `trigger=start_of_round`).
+     Rendered by `_buff_trigger_clause`.
 3. **Zone effect tail** (28 types) + zones **nested in sub-towers**.
+   - **NEXT — Heli Pilot `MoabShoveZoneModel`.** Decoded but **not rendered**:
+     per-blimp `*PushSpeedScaleCap` (MOAB −0.3…−0.51, BFB ~0, ZOMG 0.75…0.09).
+     Pending a maintainer call on the sign semantics (negative = shoved backward?)
+     and whether DDT should mirror ZOMG (the dump has no DDT field; committed data
+     currently copies ZOMG). See the smoke-test checklist §7.
 4. **Economy-tower attack suppression** (Banana Farm's nominal `AttackModel`) +
    preserve `paragon_cost`/`paragon_name` — cutover prerequisites.
 5. **The tower cutover** (overlay numbers, or full game-native) — gated on 1–4
@@ -79,7 +89,7 @@ works** (the traps we hit), and what is still un-decoded.
    now PARTIALLY sourced from the wiki (18 maps).** Confirmed the v55 dump has
    none: `Maps/<difficulty>/*.json` carry only catalog metadata (`difficulty`,
    `hasWater`, `theme`, `mapMusic`, `mapSprite`, `odysseyStatue`,
-   `coopMapDivisionType`, `unlockDifficulty`) — **0 of 89 maps** name a
+   `coopMapDivisionType`, `unlockDifficulty`) — **0 of the 89 dump map files** name a
    removable, and a whole-dump grep finds only UI strings (`"Removable Cost"`,
    `ft_trackremovable*`) and Unity asset refs (`Removables/*.prefab`). Per-map
    removable placement/cost lives in the AssetBundle map scenes, absent from
@@ -233,7 +243,7 @@ failure there is mechanism 3, not retrieval.
 ### Session log — Maps hub button + correct difficulty/mode/modifier taxonomy
 
 - **Maps button added** to the BTD6 hub (`views/btd6/panel.py`, row 2) →
-  `build_maps_embed()` lists all 89 maps grouped by difficulty with a 💧 water
+  `build_maps_embed()` lists all 86 maps grouped by difficulty with a 💧 water
   marker (surfacing the `has_water` fact from the maps cutover).
 - **Modes corrected to the real BTD6 taxonomy** (from the in-game select
   screens, screenshots verified). `ModeEntry` gained `kind`
@@ -701,7 +711,7 @@ must not be treated as done. Verified against the v55 dump on 2026-06-03.
 | Ability names via **`displayName`** | mapper | #466; 87/87 abilities carry it |
 | Upgrade **descriptions** via `LocsKey`→`textTable` (extraction) | mapper | #466; extracts wherever the game localizes one (≈422 player upgrade cards) |
 | Core per-tier numeric extraction: base_cost, category, upgrade cost/xp/path/tier, damage, pierce, rate, range, radius, speed, lifespan, immunities→type | mapper | audit: roster is DELTA/CLEAN, nothing SUSPECT |
-| **Maps — full game-data cutover (89)** | `parse_gamedata.py --maps` → `maps.json` | this session; difficulty from the dump's folder (corrects stale curated rows, e.g. Cornfield → Advanced), names via `textTable`, `has_water` wired into `MapEntry` + `btd6_map_lookup`. Curated prose preserved where present. 89 maps load + tests green |
+| **Maps — full game-data cutover (86)** | `parse_gamedata.py --maps` → `maps.json` | difficulty from the dump's folder (corrects stale curated rows, e.g. Cornfield → Advanced), names via `textTable`, `has_water` + curated `removables` (18) wired into `MapEntry`. 3 non-player `IsStandard=False` maps filtered (Blons, Base Editor Map, Protect the Yacht) → **86** player maps load + tests green |
 | **Modes — full set (13)** | curated `modes.json` | this session; the dump has **no** game-mode rules (cash/lives/restrictions live in game code, not assets), so authored from established facts: Standard, Primary/Military/Magic Only, Deflation, Apopalypse, Reverse, Double HP MOABs, Half Cash, ABR, Impoppable, CHIMPS, Sandbox |
 
 ### 🟡 Partial — NOT complete
@@ -711,7 +721,7 @@ must not be treated as done. Verified against the v55 dump on 2026-06-03.
 | **Subtowers** (`subtowers[]`) | 3 spawn models: `AbilityCreateTower`/`CreateTower`/`MorphTower`(embedded) → Phoenix, Sentry, Spectre, totems, UAV | `MorphTowerModel` **named-ref** (Alchemist "Transformed Monkey") + `BeastHandlerPetModel` (Beast Handler) — 2 of ~4 mechanisms |
 | **Zones** (`zones[]`) — **started** | `_zones()` emits every top-level `*ZoneModel` as `{kind, name, + decodable numbers}` (e.g. Ice Arctic Wind → `speedScale 0.6`, `zoneRadius 25`); wired into `_map_tier`, audit-safe (internal names don't align with curated, so they're ignored) | the rest of the 28 types' specific effect fields; zones nested inside sub-towers; curated display names (not in the dump — stay wiki-owned); runtime `_zone_text` only renders damage-style zones |
 | **Projectile flattening completeness** | spawn-model coverage (under-emission 177→111) | 111 attacks still differ in projectile count vs wiki; flattening *style* (naming/grouping) differs |
-| **Buffs** (`buffs[]`) — **started (8 of 38)** | `_buffs()` decodes eight types **confirmed exact against committed wiki values on a matching tier**: `RateSupportModel`, `PoplustSupportModel`, `SubCommanderSupportModel`, `PiercePercentageSupportModel`, `TradeEmpireBuffModel`, `PlacementAreaTypeRangeBuffModel`, `StartOfRoundRateBuffModel`, `PrinceOfDarknessZombieBuffModel` (see `_BUFF_FIELD_MAP` for the exact field map + the tier each was verified on). Wired into `_map_tier`, audit-safe (internal names) | the other 30 `*SupportModel`/`*BuffModel` types — each needs same-tier confirmation before its number is written (e.g. `PierceSupportModel.pierce`→`pierceAdditive` is **NOT** confirmed; the wiki's pierce buffs are multipliers from a different model). `SCHEMA_FIRST` types (projectile-speed/radius, freeze-duration, banana-cash) also need a new renderer field. The discovery harness is a lead generator; vet each candidate against the committed value (it is the arbiter, not semantic priors) |
+| **Buffs** (`buffs[]`) — **started (9 of 38)** | `_buffs()` decodes nine types **confirmed exact against committed wiki values on a matching tier**: `RateSupportModel`, `PoplustSupportModel`, `SubCommanderSupportModel`, `PiercePercentageSupportModel`, `TradeEmpireBuffModel`, `PlacementAreaTypeRangeBuffModel`, `StartOfRoundRateBuffModel`, `PrinceOfDarknessZombieBuffModel`, `VigilanteTowerBehaviorModel` (the Desperado lives-lost buff: frame→seconds windows + `cashOnLeakMultiplier` + `trigger`). See `_BUFF_FIELD_MAP` / `_BUFF_TRIGGER`. Wired into `_map_tier`, audit-safe (internal names) | the other 29 `*SupportModel`/`*BuffModel` types — each needs same-tier confirmation before its number is written (e.g. `PierceSupportModel.pierce`→`pierceAdditive` is **NOT** confirmed; the wiki's pierce buffs are multipliers from a different model). `SCHEMA_FIRST` types (projectile-speed/radius, freeze-duration, banana-cash) also need a new renderer field. The discovery harness is a lead generator; vet each candidate against the committed value (it is the arbiter, not semantic priors) |
 | **Numeric overlay applied** | 3 files (Desperado range, mermonkey xp, ace cost), uniquely-keyed only | per-projectile/ability values cannot be safely overlaid (wiki↔dump name mismatch) |
 
 ### 🔴 Not started

--- a/docs/btd6-gamedata-dictionary.md
+++ b/docs/btd6-gamedata-dictionary.md
@@ -47,7 +47,7 @@ knowing where, and which encoding to trust.
 | **Knowledge/** | 134 | `KnowledgeModel` | Monkey Knowledge tree (meta-upgrade mods) | ✗ |
 | **Bosses/** | 7 | `BossData` | **cosmetic only** — portraits/music/icons + `LocsKey`. Boss *stats* are in **Bloons/**, not here | ✗ |
 | **Buffs/** | 91 | `BuffIndicatorModel` | **UI icons only** — buff *effects* are inline in the tower models | ✗ |
-| **Maps/** | 89 | `MapDetails` | map metadata: `difficulty` (== folder), `hasWater`, `theme` | ✓ (`--maps` → all 89; difficulty + `has_water`) |
+| **Maps/** | 89 files (86 player) | `MapDetails` | map metadata: `difficulty` (== folder), `hasWater`, `theme`, `IsStandard` | ✓ (`--maps` → 86 player maps; 3 non-player `IsStandard=False` filtered: Blons, Base Editor Map, Protect the Yacht) |
 | **Artifacts/**, **GeraldoItems/** | 568, 16 | `ItemArtifactData` / mods | Rogue Legends artifacts, Geraldo's shop | ✗ |
 | **Achievements/**, **TrophyStoreItems/**, **Skins/**, **BloonOverlays/**, **Mods/** | — | — | cosmetics / achievements / game-mode mods | ✗ |
 

--- a/docs/btd6-smoke-test-checklist.md
+++ b/docs/btd6-smoke-test-checklist.md
@@ -1,0 +1,146 @@
+# BTD6 Bot — Smoke-Test Checklist
+
+A hands-on script for testing the bot's BTD6 **capabilities** and **limitations**
+after a deploy. It covers everything landed in the data/grounding work of
+PRs #500–#505 plus the earlier upgrade-detail/faithfulness work, and — just as
+importantly — the questions the bot should **honestly decline** rather than
+fabricate.
+
+> **Deployment first.** These behaviours are baked into committed data +
+> instructions, so they only take effect once the **live bot redeploys** with the
+> merged code. If a "✅ expect" answer below is wrong on the live bot, first
+> confirm the deployment is current — several mid-session screenshots showed the
+> bot estimating because it was still running pre-merge code.
+
+> **How to read this.** ✅ rows are *capabilities* — the bot should give the exact
+> grounded value. 🚫 rows are *limitations* — the bot should say it doesn't have
+> that data (and **not** invent a number, name, or list). Values are standard
+> **Medium** economy, no income towers, current game version.
+
+---
+
+## 0. The faithfulness probes (run these first — they caught every bug)
+
+The recurring failure this whole session was the model **inventing numbers and
+calling them "verified."** These probes target that directly:
+
+| Ask | ✅ Expect | 🚩 Red flag |
+|---|---|---|
+| "how many maps have water" — then reply **"try again"** 3× | The **same** answer every time (67 water / 19 land) | Different counts each retry (it gave 73→77→75→76→77 before the deterministic floor) |
+| "how much cash do you earn on round 40" | **$521** (this round) | "$14,600" or any "~$X / typical" estimate |
+| Any answer that says **"verified from the tool"** | Only when it matches the tables below | "verified" attached to a wrong number |
+
+If a count/list answer is unstable across retries or labelled "verified" while
+wrong, that's the model bypassing its grounding — note it for the faithfulness-
+guard work (the systemic open item).
+
+---
+
+## 1. Per-round cash  (PRs #500 · #502 · #504)
+
+| Ask | ✅ Expect |
+|---|---|
+| "how much cash do you earn on round 40" | **$521** this round (the *per-round* figure, **not** cumulative) |
+| "how much cash on round 26" | **$333** |
+| "how much cash on round 50" | **$3,016** |
+| "how much cash on round 1" | **$121** |
+| "cumulative cash by round 80" | **~$98,254** (running total incl. the $650 Medium start) |
+| "how much do you earn from r50 to r60" | **$16,824** ( = cumulative 55,134 − 38,310 ) |
+| "how much from r70 to r80" | **~$26,939** |
+| "how much money total by round 140" | **~$351,267** |
+
+| 🚫 Limitation | ✅ Expect it to decline |
+|---|---|
+| "how much cash on round 50 on **Hard** / with **Half Cash**" | Only standard/Medium is grounded — should flag difficulty/Half-Cash isn't modelled, not give a number |
+| "how much cash on **round 200**" | Rounds 1–140 only — should say it's out of range |
+| "how much does a **0-2-0 farm** add per round" | Tower income only if that tier is grounded; otherwise decline (don't estimate) |
+
+---
+
+## 2. Maps — counts & lists  (PR #505)
+
+| Ask | ✅ Expect |
+|---|---|
+| "how many maps are there" | **86** — 26 Beginner, 25 Intermediate, 22 Advanced, 13 Expert (**not** 89) |
+| "how many maps have water" | **67 have water, 19 land-only** |
+| "list all maps with water" | the 67, grouped by difficulty |
+| "list the land-only maps" | the **19** (incl. Monkey Meadow, Alpine Run, Cornfield, Mesa, Tricky Tracks, Workshop…) |
+| "which maps have removables" | the **18** (see §3) |
+
+| 🚫 Limitation | ✅ Expect |
+|---|---|
+| Look for **Blons / Base Editor Map / Protect the Yacht** in any list | They must **not** appear — non-player (`IsStandard=False`) maps are filtered |
+
+---
+
+## 3. Map removable obstacles  (PR #503 — 18 maps, wiki-sourced)
+
+| Ask | ✅ Expect |
+|---|---|
+| "what removable obstacles does **Cargo** have" | Two trucks (line-of-sight blockers), removable **only after round 39**, opens placeable terrain |
+| "does **Cornfield** have removables" | Thirteen corn patches (LoS blockers) |
+| "what's removable on **Quiet Street**" | Two frozen lakes (→ water terrain) + five cars (LoS, → placeable terrain) |
+| "removables on **Encrypted**" | Four rock-debris groups, each opens terrain exclusive to one tower category |
+
+| 🚫 Limitation | ✅ Expect |
+|---|---|
+| "how much does it **cost** to remove the trucks on Cargo" | Decline — removal **costs** aren't in the data set |
+| "what removables does **Monkey Meadow** have" (a map not in the 18) | Say it doesn't have that map's removable detail — **don't** guess |
+
+---
+
+## 4. Buffs — stack caps  (PR #501)
+
+| Ask | ✅ Expect |
+|---|---|
+| "what does **Trade Empire** do" | +$10/round per Merchantman, +$20/round per Favored Trades, +1 dmg (incl. vs Ceramic/MOAB), **stacks up to 20** |
+| "how many times does the 0-0-4 Buccaneer **sellback** buff stack" | Up to **3** (+4% each → +12%) |
+
+| 🚫 Limitation | ✅ Expect |
+|---|---|
+| "how many times does **Pirate Lord** / **Elite Defender**'s aura stack" | It applies once — should **not** invent a stack count |
+
+---
+
+## 5. Buffs — temporary triggers  (PR #501)
+
+| Ask | ✅ Expect |
+|---|---|
+| "what's the **Desperado Enforcer**'s buff" | +16 range & ×0.6 attack speed **for 15 s when a life is lost** (60 s cooldown); leaked bloons give **2× their value as cash** |
+| "what does the **start-of-round** buff (Spike Factory / Engineer) do" | ×0.25 attack cooldown **at the start of each round** |
+
+> Watch the **units**: Desperado must read **seconds** (15 s / 60 s), the
+> start-of-round buff must read **each round** — never the reverse. (Same field
+> name, two units; the `trigger` disambiguates.)
+
+---
+
+## 6. Upgrades — deep detail & name-collision faithfulness  (earlier session)
+
+| Ask | ✅ Expect |
+|---|---|
+| "Prince of Darkness minion pierce" | **1** (lives on the Reanimate attack, not the main projectile) |
+| "what does **PMFC**'s ability do" | Its actual ability detail |
+
+| 🚩 Faithfulness probe | ✅ Expect |
+|---|---|
+| "pmfc abilities" | Name PMFC's real ability — must **not** substitute "Prince of Darkness" (a past collision bug) |
+
+---
+
+## 7. Not-yet-implemented (should decline honestly)
+
+| Ask | ✅ Expect |
+|---|---|
+| "how far does Heli Pilot's **MOAB Shove** push each blimp class" | Decline — the MoabShove push values are decoded but **not rendered yet** (pending semantics confirmation) |
+| "per-level stats for **\<hero\>** at level 7" | Per-level hero stats aren't modelled — decline |
+| "what bloons is **\<X\>** immune to" beyond camo/lead/black/white/purple | Decline beyond the modelled immunities |
+
+---
+
+## Quick expected-value reference (verified against committed data)
+
+- **Rounds:** r1 $121 · r26 $333 · r40 $521 · r50 $3,016 · r80 $1,400.2 · r140 $1,307.68; cumulative r80 ~$98,254 · r140 ~$351,267.
+- **Maps:** 86 total (26/25/22/13) · 67 water · 19 land-only · 18 with removables.
+- **Buffs:** Trade Empire stacks ×20 · sellback ×3 · Desperado lives-lost 15 s / 60 s cooldown / +16 range / ×0.6 speed / 2× leak cash · start-of-round ×0.25 each round.
+- **Excluded non-player maps:** Blons, Base Editor Map, Protect the Yacht.


### PR DESCRIPTION
Docs-only. Wraps up the session's BTD6 data/grounding work (PRs #500–#505) with a test script and brings stale references up to date.

## New: `docs/btd6-smoke-test-checklist.md`
A hands-on script to test the bot's **capabilities** and **limitations** before next session. Sections cover every feature landed this session, each with the **exact expected value** to verify against:
- **§0 faithfulness probes** (run first) — retry-stability + the "verified-but-wrong" / memory-estimate traps that caught every bug this session.
- **§1 per-round cash** — r40 $521, r50 $3,016, r50→r60 $16,824, etc. (+ Half-Cash/difficulty/round-200 as decline cases).
- **§2 map counts/lists** — 86 total, 67 water, 19 land-only (+ verify Blons / Base Editor Map / Protect the Yacht never appear).
- **§3 removables** — Cargo's R39 trucks, Cornfield, Quiet Street (+ costs / non-18 maps as decline cases).
- **§4 stack caps**, **§5 temporary-buff triggers** (seconds vs each-round), **§6 upgrade detail + PMFC name-collision probe**, **§7 not-yet-implemented** (MOAB Shove, per-level hero stats).

✅ rows = should answer with the grounded value; 🚫 rows = should honestly decline (not fabricate). A quick expected-value reference is at the bottom.

## Stale-doc refresh
Verified all six PRs' changes are correct on `main`, then updated current-state references the merges made stale:
- **Maps 89 → 86** (3 non-player `IsStandard=False` maps filtered) — status summary, completion table, dictionary, embed note.
- **Buffs 8 → 9 of 38** (`VigilanteTowerBehaviorModel`) — summary, table, extraction plan, explainer.
- **"Do next"**: buff duration/trigger marked **DONE** (#501); added rounds-carry-cash + removables to "where the data stands"; flagged **MOAB Shove** as the next decode.

Dated session-log entries keep their historical numbers on purpose (they're a changelog, not current state).

> Note: these behaviours require the live bot to **redeploy** with #500–#505 to take effect — the checklist says so up top.

https://claude.ai/code/session_01BsFD9xMzFaPa83Z1dffn7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsFD9xMzFaPa83Z1dffn7p)_