### PR TITLE
fix(governance): thread cache identity + cleanup scope split + counting swallow (S1 / PR 1)

### DIFF
--- a/disbot/cogs/counting_cog.py
+++ b/disbot/cogs/counting_cog.py
@@ -87,11 +87,18 @@ class CountingCog(commands.Cog):
             self.count_data[str(guild.id)] = await db.get_counting_state(guild.id)
 
     async def _save_guild(self, guild_id_str: str):
-        try:
-            guild_id = int(guild_id_str)
-            await db.set_counting_state(guild_id, self.count_data.get(guild_id_str, {}))
-        except Exception:
-            pass
+        """Persist one guild's counting state.
+
+        RC-15: this MUST NOT swallow persistence errors.  Every caller spawns it
+        through ``core.runtime.tasks.spawn`` ("counting:save:<guild_id>"), whose
+        done-callback already logs failures at ERROR with a traceback and
+        increments ``task_outcome_total{outcome="error"}``.  A bare
+        ``except Exception: pass`` here defeated that built-in observability and
+        let a guild silently lose its counting progress, so errors are allowed to
+        propagate to the managed-task layer instead of being discarded.
+        """
+        guild_id = int(guild_id_str)
+        await db.set_counting_state(guild_id, self.count_data.get(guild_id_str, {}))
 
     # --------------------------------------------
     # Permission Helpers

--- a/disbot/governance/cache.py
+++ b/disbot/governance/cache.py
@@ -62,7 +62,16 @@ def _cache_key(
     channel_id: int | None,
     tier: str,
     role_ids: frozenset[int] = frozenset(),
+    *,
+    thread_id: int | None = None,
 ) -> tuple:
+    # RC-2 (ISSUE-016): thread_id is part of the cache identity.  For a thread
+    # context the resolver passes the *parent* channel id as channel_id
+    # (GovernanceContext.from_* set channel_id = thread.parent_id), so two
+    # sibling threads — and the threadless parent channel itself — would
+    # otherwise collide on a single channel-keyed entry and a thread-scoped
+    # override would bleed across them.  Keying on thread_id keeps each thread
+    # (and the parent, thread_id=None) isolated.
     if _guild_has_role_overrides.get(guild_id, False) and role_ids:
         # Phase 3.1: Include only the stable hash of role IDs rather than the raw
         # frozenset.  Two users with different role sets but identical governance-
@@ -70,8 +79,15 @@ def _cache_key(
         # benign — a miss just triggers a fresh resolution).  This keeps keys small
         # and prevents combinatorial cache explosion in large guilds.
         role_fingerprint = hash(role_ids)
-        return (guild_id, _cache_ver(guild_id), channel_id, tier, role_fingerprint)
-    return (guild_id, _cache_ver(guild_id), channel_id, tier)
+        return (
+            guild_id,
+            _cache_ver(guild_id),
+            channel_id,
+            thread_id,
+            tier,
+            role_fingerprint,
+        )
+    return (guild_id, _cache_ver(guild_id), channel_id, thread_id, tier)
 
 
 def _cache_get(key: tuple) -> Any:

--- a/disbot/governance/models.py
+++ b/disbot/governance/models.py
@@ -38,7 +38,7 @@ import discord
 
 SCOPE_PRIORITY: list[str] = ["thread", "channel", "category", "guild"]
 SCOPE_PARENT: dict[str, str | None] = {
-    "thread": "channel",  # ISSUE-016
+    "thread": "channel",
     "channel": "category",
     "category": "guild",
     "guild": None,

--- a/disbot/governance/resolver.py
+++ b/disbot/governance/resolver.py
@@ -52,7 +52,7 @@ def _build_scope_chain(ctx: GovernanceContext) -> list[tuple[str, int]]:
     This function is the ONLY place that knows the traversal order.
     """
     scope_id_map: dict[str, int | None] = {
-        "thread": ctx.thread_id,  # ISSUE-016
+        "thread": ctx.thread_id,
         "channel": ctx.channel_id,
         "category": ctx.category_id,
         "guild": ctx.guild_id,
@@ -283,12 +283,20 @@ async def resolve_visibility(ctx: GovernanceContext) -> VisibilityResult:
 
     Scope resolution: thread > channel > category > guild > registry default.
     Dependency rules applied after scope resolution (topological order).
-    Results are cached by (guild_id, version, channel_id, member_tier).
+    Results are cached by (guild_id, version, channel_id, thread_id, member_tier)
+    so a thread context never collides with a sibling thread or the parent
+    channel (RC-2 / ISSUE-016).
     """
     tier = await _resolve_member_tier(ctx)
 
     role_ids = frozenset(ctx.role_ids) if ctx.role_ids else frozenset()
-    cache_key = _cache_key(ctx.guild_id, ctx.channel_id, tier, role_ids)
+    cache_key = _cache_key(
+        ctx.guild_id,
+        ctx.channel_id,
+        tier,
+        role_ids,
+        thread_id=ctx.thread_id,
+    )
     _guild_label = str(ctx.guild_id)
 
     async with _CACHE_LOCK:

--- a/disbot/governance/scopes.py
+++ b/disbot/governance/scopes.py
@@ -2,7 +2,8 @@
 
 The governance runtime historically referred to scopes as bare strings
 (``"guild"``, ``"category"``, ``"channel"``, ``"thread"``) — see
-:data:`governance.writes._VALID_SCOPE_TYPES`.  Phase 1d formalizes the
+:data:`governance.writes._VALID_VISIBILITY_SCOPE_TYPES` /
+:data:`governance.writes._VALID_CLEANUP_SCOPE_TYPES`.  Phase 1d formalizes the
 taxonomy as a typed enum so:
 
 * Phase 4.5's :class:`access_control_service` can statically reason
@@ -32,7 +33,7 @@ class GovernanceScope(Enum):
     Order matters for the implicit hierarchy used by
     :func:`governance.resolver.resolve_visibility`: narrower scopes
     override broader scopes.  The enum value strings match the
-    historical ``_VALID_SCOPE_TYPES`` strings so existing DB rows and
+    historical governance scope strings so existing DB rows and
     cached values continue to work.
 
     Members:

--- a/disbot/governance/writes.py
+++ b/disbot/governance/writes.py
@@ -49,9 +49,20 @@ from utils.visibility_rules import get_member_visibility_tier, is_tier_sufficien
 logger = logging.getLogger("bot")
 
 # Scope types accepted by the pipeline.
-# "thread" is supported since migration 009 added it to subsystem_visibility.
-_VALID_SCOPE_TYPES: frozenset[str] = frozenset(
+#
+# RC-5: visibility and cleanup do NOT share a scope set.
+#   * subsystem_visibility gained "thread" in migration 009 and the resolver
+#     walks thread → channel → category → guild, so visibility overrides may be
+#     thread-scoped.
+#   * cleanup_policies deliberately kept its non-thread CHECK constraint in that
+#     same migration and the cleanup resolver (governance/cleanup.py) skips
+#     thread scope, so a thread cleanup write would pass service validation only
+#     to be rejected late by Postgres.  Reject it here, before the DB.
+_VALID_VISIBILITY_SCOPE_TYPES: frozenset[str] = frozenset(
     {"channel", "category", "guild", "thread"},
+)
+_VALID_CLEANUP_SCOPE_TYPES: frozenset[str] = frozenset(
+    {"channel", "category", "guild"},
 )
 
 # Minimum tier required to mutate governance state.
@@ -116,10 +127,10 @@ class GovernanceMutationPipeline:
         explicitly rejected to prevent silent misconfiguration.
         """
         # 1. Validate inputs
-        if scope_type not in _VALID_SCOPE_TYPES:
+        if scope_type not in _VALID_VISIBILITY_SCOPE_TYPES:
             raise GovernanceError(
                 f"Invalid scope_type {scope_type!r}. "
-                f"Must be one of: {sorted(_VALID_SCOPE_TYPES)}. "
+                f"Must be one of: {sorted(_VALID_VISIBILITY_SCOPE_TYPES)}. "
                 "Role-scoped overrides are not yet supported.",
             )
         if subsystem not in SUBSYSTEMS:
@@ -240,11 +251,18 @@ class GovernanceMutationPipeline:
         delete_failed_commands: bool = True,
         delete_after_seconds: int = 5,
     ) -> None:
-        """Set a cleanup policy override for a scope."""
-        if scope_type not in _VALID_SCOPE_TYPES:
+        """Set a cleanup policy override for a scope.
+
+        scope_type must be one of: channel, category, guild.  Unlike visibility,
+        cleanup policies do not support thread scope — a thread (or otherwise
+        invalid) scope_type raises GovernanceError *before* any DB write (RC-5;
+        cleanup_policies kept its non-thread CHECK constraint in migration 009).
+        """
+        if scope_type not in _VALID_CLEANUP_SCOPE_TYPES:
             raise GovernanceError(
-                f"Invalid scope_type {scope_type!r}. "
-                f"Must be one of: {sorted(_VALID_SCOPE_TYPES)}.",
+                f"Invalid scope_type {scope_type!r} for cleanup policy. "
+                f"Must be one of: {sorted(_VALID_CLEANUP_SCOPE_TYPES)}. "
+                "cleanup_policies does not support thread scope (migration 009).",
             )
 
         _validate_authority(ctx)

--- a/tests/unit/cogs/test_counting_persistence.py
+++ b/tests/unit/cogs/test_counting_persistence.py
@@ -1,0 +1,69 @@
+"""RC-15 — counting state persistence must not swallow failures.
+
+``CountingCog._save_guild`` previously wrapped its DB write in a bare
+``except Exception: pass``, so a guild could silently lose its counting
+progress.  Every caller spawns it through ``core.runtime.tasks.spawn``, whose
+done-callback logs failures at ERROR and increments
+``task_outcome_total{outcome="error"}`` — the swallow defeated that built-in
+observability.
+
+These tests pin that a forced persistence failure is surfaced rather than
+discarded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import cogs.counting_cog as counting_cog
+from cogs.counting_cog import CountingCog
+
+
+def _cog_with_failing_save(monkeypatch) -> CountingCog:
+    cog = CountingCog(MagicMock())
+    cog.count_data = {"123": {"channels": {}}}
+    monkeypatch.setattr(
+        counting_cog.db,
+        "set_counting_state",
+        AsyncMock(side_effect=RuntimeError("db down")),
+    )
+    return cog
+
+
+@pytest.mark.asyncio
+async def test_save_guild_propagates_persistence_failure(monkeypatch):
+    """_save_guild must propagate persistence errors, not swallow them."""
+    cog = _cog_with_failing_save(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="db down"):
+        await cog._save_guild("123")
+
+
+@pytest.mark.asyncio
+async def test_save_guild_failure_surfaced_by_managed_task(monkeypatch, caplog):
+    """Spawned via tasks.spawn, a forced failure is surfaced: the managed-task
+    done-callback records it on the task and logs it at ERROR (instead of the
+    failure being silently swallowed inside _save_guild)."""
+    from core.runtime import tasks
+
+    cog = _cog_with_failing_save(monkeypatch)
+
+    with caplog.at_level(logging.ERROR):
+        task = tasks.spawn("counting:save:123", cog._save_guild("123"))
+        with pytest.raises(RuntimeError, match="db down"):
+            await task
+        # Let the loop run the task's done-callback (scheduled via call_soon).
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+    # The failure reached the managed-task seam...
+    assert isinstance(task.exception(), RuntimeError)
+    # ...and was surfaced at ERROR rather than swallowed.
+    assert any(
+        rec.levelno == logging.ERROR and "counting:save:123" in rec.getMessage()
+        for rec in caplog.records
+    ), "managed-task layer must log the failed counting save at ERROR"

--- a/tests/unit/governance/conftest.py
+++ b/tests/unit/governance/conftest.py
@@ -60,12 +60,19 @@ def make_ctx(
     guild_id: int = 100,
     channel_id: int | None = 200,
     category_id: int | None = 300,
+    thread_id: int | None = None,
 ) -> GovernanceContext:
-    """Build a GovernanceContext with no Discord member (yields tier='user')."""
+    """Build a GovernanceContext with no Discord member (yields tier='user').
+
+    For a thread context, pass ``thread_id`` together with ``channel_id`` set to
+    the thread's *parent* channel — mirroring GovernanceContext.from_* which
+    record channel_id = thread.parent_id.
+    """
     return GovernanceContext(
         guild_id=guild_id,
         channel_id=channel_id,
         category_id=category_id,
+        thread_id=thread_id,
         member=None,
     )
 

--- a/tests/unit/governance/test_cache.py
+++ b/tests/unit/governance/test_cache.py
@@ -169,3 +169,92 @@ async def test_role_override_flag_differentiates_cached_results(mock_db):
     count_after_b = mock_db.fetch.call_count
 
     assert count_after_b > count_after_a
+
+
+# ---------------------------------------------------------------------------
+# RC-2 / ISSUE-016 — thread cache identity (cross-thread / parent bleed)
+# ---------------------------------------------------------------------------
+
+
+def test_cache_key_different_threads_differ():
+    """Two threads sharing a parent channel must get distinct cache keys."""
+    k_a = _cache_key(1, 10, "user", thread_id=111)
+    k_b = _cache_key(1, 10, "user", thread_id=222)
+    assert k_a != k_b
+
+
+def test_cache_key_thread_distinct_from_parent_channel():
+    """A thread context must not share the threadless parent channel's key."""
+    k_thread = _cache_key(1, 10, "user", thread_id=111)
+    k_parent = _cache_key(1, 10, "user")  # thread_id defaults to None
+    assert k_thread != k_parent
+
+
+def test_cache_key_thread_differs_on_role_override_path():
+    """thread_id participates in the key on the role-override branch too."""
+    gs._guild_has_role_overrides[1] = True
+    roles = frozenset({100})
+    k_a = _cache_key(1, 10, "user", roles, thread_id=111)
+    k_b = _cache_key(1, 10, "user", roles, thread_id=222)
+    assert k_a != k_b
+
+
+@pytest.mark.asyncio
+async def test_thread_contexts_do_not_share_cache(mock_db):
+    """Distinct thread_ids under one parent channel each miss the cache, and
+    the threadless parent is a distinct key as well."""
+    guild_id, parent = 900, 123
+    ctx_a = make_ctx(guild_id=guild_id, channel_id=parent, thread_id=111)
+    ctx_b = make_ctx(guild_id=guild_id, channel_id=parent, thread_id=222)
+    ctx_parent = make_ctx(guild_id=guild_id, channel_id=parent)
+
+    await resolve_visibility(ctx_a)
+    c1 = mock_db.fetch.call_count
+    await resolve_visibility(ctx_b)  # sibling thread → distinct key → re-query
+    c2 = mock_db.fetch.call_count
+    assert c2 > c1
+
+    await resolve_visibility(ctx_parent)  # parent (thread_id=None) → distinct
+    c3 = mock_db.fetch.call_count
+    assert c3 > c2
+
+    # Re-resolving thread A is a genuine cache hit (no further DB query).
+    await resolve_visibility(ctx_a)
+    assert mock_db.fetch.call_count == c3
+
+
+@pytest.mark.asyncio
+async def test_thread_scoped_override_does_not_bleed_across_threads(mock_db):
+    """Regression for the RC-2 bleed: a thread-scoped override in one thread must
+    not leak to a sibling thread or to the parent channel via a shared entry.
+
+    Threads 111 and 222 share parent channel 123.  Only thread 111 carries a
+    'economy disabled' thread override.  Before the fix all three contexts
+    collided on the same channel-keyed entry, so whichever resolved first
+    poisoned the others.
+    """
+    guild_id, parent, thread_a, thread_b = 900, 123, 111, 222
+
+    def fetch_side_effect(_sql, _guild, _scope_types, scope_ids):
+        # Only thread 111's scope chain carries the disabling override.
+        if thread_a in scope_ids:
+            return [make_visibility_row("thread", thread_a, "economy", False)]
+        return []
+
+    mock_db.fetch.side_effect = fetch_side_effect
+
+    ctx_thread_a = make_ctx(guild_id=guild_id, channel_id=parent, thread_id=thread_a)
+    ctx_thread_b = make_ctx(guild_id=guild_id, channel_id=parent, thread_id=thread_b)
+    ctx_parent = make_ctx(guild_id=guild_id, channel_id=parent)
+
+    # Resolve thread A first → economy disabled, result cached under A's key.
+    res_a = await resolve_visibility(ctx_thread_a)
+    assert "economy" not in res_a.visible_subsystems
+
+    # Sibling thread B must compute its own result, not inherit A's.
+    res_b = await resolve_visibility(ctx_thread_b)
+    assert "economy" in res_b.visible_subsystems
+
+    # The parent channel (no thread) must be unaffected too.
+    res_parent = await resolve_visibility(ctx_parent)
+    assert "economy" in res_parent.visible_subsystems

--- a/tests/unit/governance/test_cleanup_scope.py
+++ b/tests/unit/governance/test_cleanup_scope.py
@@ -1,0 +1,83 @@
+"""RC-5 — cleanup-policy scope validation.
+
+``GovernanceMutationPipeline`` historically shared one ``_VALID_SCOPE_TYPES``
+set between visibility and cleanup writes.  Visibility supports thread scope
+(migration 009 added it to ``subsystem_visibility``), but ``cleanup_policies``
+deliberately kept its non-thread CHECK constraint, so a thread cleanup write
+passed service validation and then failed late at the DB.
+
+These tests pin the split: visibility keeps thread; cleanup rejects it with a
+clean ``GovernanceError`` *before* any DB access.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import governance.writes as writes
+from governance.models import GovernanceContext
+from services.governance_exceptions import GovernanceError
+
+
+def test_cleanup_scope_set_excludes_thread_but_visibility_includes_it():
+    """The two scope sets differ by exactly the thread scope."""
+    assert "thread" in writes._VALID_VISIBILITY_SCOPE_TYPES
+    assert "thread" not in writes._VALID_CLEANUP_SCOPE_TYPES
+    assert (
+        writes._VALID_CLEANUP_SCOPE_TYPES
+        == writes._VALID_VISIBILITY_SCOPE_TYPES - {"thread"}
+    )
+
+
+def _db_that_must_not_be_touched() -> MagicMock:
+    fake_db = MagicMock()
+    fake_db.get.side_effect = AssertionError(
+        "db.get() must not be called — cleanup scope must be rejected pre-DB",
+    )
+    return fake_db
+
+
+@pytest.mark.asyncio
+async def test_set_cleanup_policy_rejects_thread_before_db(monkeypatch):
+    """A thread scope_type raises GovernanceError before any DB access."""
+    fake_db = _db_that_must_not_be_touched()
+    monkeypatch.setattr(writes, "db", fake_db)
+
+    ctx = GovernanceContext(guild_id=1, member=None)
+    pipeline = writes.GovernanceMutationPipeline()
+
+    with pytest.raises(GovernanceError, match="thread"):
+        await pipeline.set_cleanup_policy(ctx, "thread", 999)
+
+    fake_db.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_cleanup_policy_for_scope_wrapper_rejects_thread(monkeypatch):
+    """The public module-level wrapper rejects thread scope pre-DB as well."""
+    fake_db = _db_that_must_not_be_touched()
+    monkeypatch.setattr(writes, "db", fake_db)
+
+    ctx = GovernanceContext(guild_id=1, member=None)
+
+    with pytest.raises(GovernanceError, match="thread"):
+        await writes.set_cleanup_policy_for_scope(ctx, "thread", 999)
+
+    fake_db.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_cleanup_policy_rejects_unknown_scope_before_db(monkeypatch):
+    """An entirely unknown scope_type is also rejected pre-DB (not just thread)."""
+    fake_db = _db_that_must_not_be_touched()
+    monkeypatch.setattr(writes, "db", fake_db)
+
+    ctx = GovernanceContext(guild_id=1, member=None)
+    pipeline = writes.GovernanceMutationPipeline()
+
+    with pytest.raises(GovernanceError, match="cleanup policy"):
+        await pipeline.set_cleanup_policy(ctx, "galaxy", 999)
+
+    fake_db.get.assert_not_called()


### PR DESCRIPTION
## Summary

Session S1 — PR 1 of the next-session roadmap. Three small, independent,
source-confirmed correctness fixes in the governance / feature-correctness lane,
each isolated by its own test. Scoped exactly to the roadmap's PR 1 (RC-2 + RC-5
+ RC-15); no GOV-2 unification, no AI/BTD6/runtime-lifecycle changes.

Baseline `check_quality.py --full` was confirmed **green** before any code
(7277 passed); after these fixes it is **green** at 7288 passed (+11 new tests).

## Fixes

### RC-2 — thread visibility cache bleed (ISSUE-016) · *the one behavioral change*
`resolve_visibility()` passed only the parent `channel_id` to the cache key. For
a thread context `GovernanceContext` records `channel_id = thread.parent_id`, so
two sibling threads — and the threadless parent channel — collided on one entry,
and a thread-scoped visibility override bled across them until TTL/invalidation.

- `governance/cache.py` `_cache_key` now keys on `thread_id` (both the
  role-override and plain branches); the threadless parent keeps `thread_id=None`
  so it stays a distinct key.
- `resolver.py:291` passes `ctx.thread_id`; docstring updated.
- Resolved the `# ISSUE-016` markers in `resolver.py` / `models.py` (thread scope
  is now fully wired through chain + DB + writes + cache).

### RC-5 — cleanup scope wider than the schema
`GovernanceMutationPipeline` shared one `_VALID_SCOPE_TYPES` set between
visibility and cleanup. Visibility supports `thread` (migration 009), but
`cleanup_policies` deliberately kept its non-thread CHECK constraint — so
`set_cleanup_policy(scope_type="thread")` passed service validation and then
failed late as a raw asyncpg `CheckViolationError`.

- Split into `_VALID_VISIBILITY_SCOPE_TYPES` (incl. `thread`) and
  `_VALID_CLEANUP_SCOPE_TYPES` (excl. `thread`). Cleanup now raises a clean
  `GovernanceError` **before** authority validation and any DB access.
- Updated the stale `_VALID_SCOPE_TYPES` doc references in `governance/scopes.py`.

### RC-15 — counting silent save-swallow
`CountingCog._save_guild` wrapped its DB write in `except Exception: pass`, so a
guild could silently lose counting progress. Every caller already spawns it via
`core.runtime.tasks.spawn` (`counting:save:<guild_id>`), whose done-callback logs
at ERROR with a traceback and increments `task_outcome_total{outcome="error"}` —
the swallow defeated that built-in observability.

- Removed the try/except; errors now propagate to the managed-task seam (no new
  parallel metric — strengthen the existing seam). All 7 call sites spawn via
  `tasks.spawn`; nothing bare-awaits it.

## Tests (11 new)
- **RC-2:** pure-key isolation (sibling threads, thread vs parent, role-override
  branch); cache-miss isolation across `thread_id`s; behavioral
  cross-thread/parent override-bleed regression.
- **RC-5:** scope-set split contract; thread + unknown scope rejected pre-DB
  (`db.get` asserted not called) via both the pipeline method and the
  `set_cleanup_policy_for_scope` wrapper.
- **RC-15:** `_save_guild` propagates a forced failure; via `tasks.spawn` the
  failure reaches the task and is logged at ERROR (surfaced, not swallowed).

## Verification
- `pytest tests/unit/governance tests/unit/runtime` + counting suite + new tests: **821 + green**.
- `check_architecture.py --mode strict`: **0 errors, 88 warnings** (identical to baseline — no new violations).
- `check_quality.py --full` (CI mirror): **7288 passed, 3 skipped — all checks passed ✓**.

## Rollback
Each fix is a separate commit and an independent revert. RC-2 (the cache key) is
the only behavioral change — reverting it restores the prior (buggy but known)
channel-keyed behavior.

## Out of scope (per roadmap)
GOV-2 visibility/execution/exposure unification (hold); RC-3 panel/fail-open
policy (PR 2, decision-gated); AI central stage, BTD6 extraction, runtime
lifecycle/tasks/runtime-lock, ADR-002 game-state checkpointing.

https://claude.ai/code/session_019YBiUGwQjMzdUHoX9vmz2Q

---
_Generated by [Claude Code](https://claude.ai/code/session_019YBiUGwQjMzdUHoX9vmz2Q)_