### PR TITLE
feat(arch): function-body cross-layer import report mode (RC-1) + per-check summary

### DIFF
--- a/architecture_rules/layers.yaml
+++ b/architecture_rules/layers.yaml
@@ -331,3 +331,43 @@ known_violations:
     reason: XP rank view imports helpers from the cog.
     ticket: arch-fix-13
 
+# ---------------------------------------------------------------------------
+# Known LAZY (function-body) cross-layer imports — RC-1.
+#
+# These are surfaced only by `check_architecture.py --report-lazy-imports`
+# (off by default; lazy reporting is always WARNINGS, never errors).  The
+# module-import graph never saw these because they live inside function
+# bodies, but they ARE real cross-layer call edges.
+#
+# Allowlisted below: the documented runtime lazy-resolution seam.  core/*
+# resolves services / views / governance lazily, on purpose, to break the
+# module-load cycle (services/views import core at module level, so core
+# cannot import them back at module level — see the many "Local import — keep
+# core.runtime out of the module-load cycle" comments in the resolver and
+# friends).  `file_prefix` allowlists the whole seam with one rationale each.
+#
+# Deliberately NOT allowlisted (so the report keeps surfacing them for
+# triage): views → cogs and utils → {core,services,governance}.  Those are
+# helper-policy / thin-cog debt (RC-8 / arch-fix-13 territory), not sanctioned
+# cycle-breakers — they should be migrated, not blessed.
+known_lazy_violations:
+  - file_prefix: core/
+    import: services
+    reason: >-
+      Runtime resolves services lazily to break the core↔services module-load
+      cycle (services import core at import time). Mirrors the tracked
+      module-level core→services seam.
+    ticket: arch-fix-11
+  - file_prefix: core/
+    import: views
+    reason: >-
+      persistent_views resolves views.base's error handler lazily to avoid the
+      core↔views import cycle.
+    ticket: arch-fix-11
+  - file_prefix: core/
+    import: governance
+    reason: >-
+      interaction_router / runtime resolve governance lazily to break the
+      core↔governance import cycle.
+    ticket: arch-fix-11
+

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -86,17 +86,23 @@ def _import_layer(module: str) -> str | None:
 
 
 class _ImportVisitor(ast.NodeVisitor):
-    """Collect module-level absolute imports, tracking TYPE_CHECKING context.
+    """Collect absolute imports, split into module-level vs lazy, tracking
+    TYPE_CHECKING context.
 
-    Lazy function-body imports (from X import Y inside a def/async def) are
-    NOT collected — they don't create circular import risks and are an
-    established pattern throughout this codebase.
+    Module-level imports land in ``self.imports`` — they are the binding
+    import-graph contract.  Lazy function-body imports (``from X import Y``
+    inside a def / async def) land in ``self.lazy_imports``.  Lazy imports are
+    a legitimate cycle-breaking pattern here, but they still create real
+    cross-layer call edges the module-import graph misses (RC-1), so the
+    boundary check can *report* them on request without treating them as hard
+    errors.
     """
 
     def __init__(self) -> None:
         self._fn_depth = 0  # >0 means we're inside a function body
         self._in_tc = False  # inside `if TYPE_CHECKING:` block
         self.imports: list[tuple[int, str, bool]] = []  # lineno, module, is_tc
+        self.lazy_imports: list[tuple[int, str, bool]] = []  # function-body imports
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         self._fn_depth += 1
@@ -117,20 +123,65 @@ class _ImportVisitor(ast.NodeVisitor):
         self._in_tc = prev
 
     def visit_Import(self, node: ast.Import) -> None:
-        if self._fn_depth > 0:
-            return
+        bucket = self.lazy_imports if self._fn_depth > 0 else self.imports
         for alias in node.names:
-            self.imports.append((node.lineno, alias.name, self._in_tc))
+            bucket.append((node.lineno, alias.name, self._in_tc))
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-        if self._fn_depth > 0 or not node.module or node.level != 0:
+        if not node.module or node.level != 0:
             return
-        self.imports.append((node.lineno, node.module, self._in_tc))
+        bucket = self.lazy_imports if self._fn_depth > 0 else self.imports
+        bucket.append((node.lineno, node.module, self._in_tc))
 
 
-def check_layer_boundaries(files: list[Path], rules: dict) -> list[Violation]:
+def _crosses_layer(
+    module: str,
+    file_layer: str,
+    may_import: set[str],
+    is_tc: bool,
+    tc_exempt: bool,
+) -> str | None:
+    """Return the disallowed target layer for ``module``, or None if allowed."""
+    import_layer = _import_layer(module)
+    if import_layer is None or import_layer == file_layer:
+        return None
+    if import_layer in may_import:
+        return None
+    if is_tc and tc_exempt:
+        return None
+    return import_layer
+
+
+def _is_known(rel_file: str, module: str, known: list[dict]) -> bool:
+    """True if (rel_file, module) is allowlisted.
+
+    An entry matches when ``module`` starts with its ``import`` prefix AND the
+    file matches either ``file`` (exact) or ``file_prefix`` (directory prefix).
+    ``file_prefix`` lets a documented layer-pair seam (e.g. the core → services
+    lazy-resolution cycle-breaker) be allowlisted with one rationale entry
+    instead of one per file.
+    """
+    for kv in known:
+        if not module.startswith(kv.get("import", "")):
+            continue
+        exact = kv.get("file")
+        prefix = kv.get("file_prefix")
+        if exact is not None and rel_file == exact:
+            return True
+        if prefix is not None and rel_file.startswith(prefix):
+            return True
+    return False
+
+
+def check_layer_boundaries(
+    files: list[Path],
+    rules: dict,
+    *,
+    report_lazy: bool = False,
+) -> list[Violation]:
     layers_cfg = rules.get("layers", {})
     known: list[dict] = rules.get("known_violations", [])
+    known_lazy: list[dict] = rules.get("known_lazy_violations", [])
     violations: list[Violation] = []
 
     for filepath in files:
@@ -153,19 +204,18 @@ def check_layer_boundaries(files: list[Path], rules: dict) -> list[Violation]:
 
         rel_file = str(filepath.relative_to(DISBOT_ROOT))
 
+        # Module-level imports — the binding contract (error unless allowlisted).
         for lineno, module, is_tc in visitor.imports:
-            import_layer = _import_layer(module)
-            if import_layer is None or import_layer == file_layer:
-                continue
-            if import_layer in may_import:
-                continue
-            if is_tc and tc_exempt:
-                continue
-
-            is_known = any(
-                rel_file == kv.get("file") and module.startswith(kv.get("import", ""))
-                for kv in known
+            import_layer = _crosses_layer(
+                module,
+                file_layer,
+                may_import,
+                is_tc,
+                tc_exempt,
             )
+            if import_layer is None:
+                continue
+            is_known = _is_known(rel_file, module, known)
             violations.append(
                 Violation(
                     file=filepath,
@@ -178,6 +228,37 @@ def check_layer_boundaries(files: list[Path], rules: dict) -> list[Violation]:
                     severity="warning" if is_known else "error",
                 ),
             )
+
+        # Lazy (function-body) imports — RC-1 report mode.  Reported only when
+        # requested, and ALWAYS as warnings: they break import cycles on purpose
+        # but still form real cross-layer call edges worth surfacing.  Entries
+        # in ``known_lazy_violations`` are the documented cycle-breakers; the
+        # rest are new lazy edges to triage.
+        if report_lazy:
+            for lineno, module, is_tc in visitor.lazy_imports:
+                import_layer = _crosses_layer(
+                    module,
+                    file_layer,
+                    may_import,
+                    is_tc,
+                    tc_exempt,
+                )
+                if import_layer is None:
+                    continue
+                is_known = _is_known(rel_file, module, known_lazy)
+                violations.append(
+                    Violation(
+                        file=filepath,
+                        line=lineno,
+                        check="lazy_layer_boundary",
+                        message=(
+                            f"{'[known] ' if is_known else ''}"
+                            f"{file_layer} → {import_layer}: lazy `{module}` "
+                            "(function-body cross-layer import)"
+                        ),
+                        severity="warning",
+                    ),
+                )
 
     return violations
 
@@ -363,6 +444,19 @@ def _changed_files() -> list[Path]:
 
 
 # ---------------------------------------------------------------------------
+# Summary (RC-1 companion — architecture-warning summary)
+# ---------------------------------------------------------------------------
+
+
+def _counts_by_check(violations: list[Violation]) -> dict[str, int]:
+    """Count violations grouped by check name (for the output summary)."""
+    counts: dict[str, int] = {}
+    for v in violations:
+        counts[v.check] = counts.get(v.check, 0) + 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -384,6 +478,14 @@ def main() -> int:
         "--file",
         type=Path,
         help="Check a single file (relative or absolute)",
+    )
+    parser.add_argument(
+        "--report-lazy-imports",
+        action="store_true",
+        help=(
+            "Also report function-body (lazy) cross-layer imports as warnings "
+            "(RC-1). Off by default; the count is high by design."
+        ),
     )
     parser.add_argument(
         "files",
@@ -415,7 +517,11 @@ def main() -> int:
         return 0
 
     all_violations: list[Violation] = []
-    all_violations += check_layer_boundaries(files, layers_rules)
+    all_violations += check_layer_boundaries(
+        files,
+        layers_rules,
+        report_lazy=args.report_lazy_imports,
+    )
     all_violations += check_raw_sql(files, mutation_rules)
     all_violations += check_settings_key_literals(files, helpers_rules)
     all_violations += check_baseview_inheritance(files, helpers_rules)
@@ -429,6 +535,12 @@ def main() -> int:
 
     label = f"{len(errors)} error(s)  {len(warnings)} warning(s)"
     print(f"\ncheck_architecture — {label}\n")
+
+    # Per-check breakdown so operators can see at a glance which rule is
+    # accumulating findings (RC-1 companion — architecture-warning summary).
+    counts = _counts_by_check(all_violations)
+    print("  by check: " + ", ".join(f"{k}={counts[k]}" for k in sorted(counts)))
+    print()
 
     if errors:
         print("ERRORS — must fix before merge:")

--- a/tests/unit/scripts/test_check_architecture.py
+++ b/tests/unit/scripts/test_check_architecture.py
@@ -1,0 +1,155 @@
+"""Tests for ``scripts/check_architecture.py`` — focus on RC-1 lazy-import
+report mode and the layer-boundary classification.
+
+The checker resolves a file's layer from ``DISBOT_ROOT``, so the synthetic-file
+tests monkeypatch that module global to a ``tmp_path`` tree and drop fake
+``<layer>/<name>.py`` files under it.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "check_architecture.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("check_architecture_ut", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# services may import utils/core/governance/services — but NOT cogs or views.
+_RULES = {
+    "layers": {
+        "services": {
+            "may_import": ["utils", "core", "services", "governance"],
+            "type_checking_exempt": True,
+        },
+    },
+    "known_violations": [],
+    "known_lazy_violations": [],
+}
+
+_MODULE_LEVEL = "from cogs.foo import bar\n"
+_LAZY = "def f():\n    from cogs.foo import bar\n    return bar\n"
+
+
+def _write(mod, tmp_path, monkeypatch, rel, src):
+    monkeypatch.setattr(mod, "DISBOT_ROOT", tmp_path)
+    f = tmp_path / rel
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(src, encoding="utf-8")
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Module-level imports — the binding contract (unchanged behaviour)
+# ---------------------------------------------------------------------------
+
+
+def test_module_level_cross_layer_is_error(mod, tmp_path, monkeypatch):
+    f = _write(mod, tmp_path, monkeypatch, "services/x.py", _MODULE_LEVEL)
+    vs = mod.check_layer_boundaries([f], _RULES)
+    assert [v.check for v in vs] == ["layer_boundary"]
+    assert vs[0].severity == "error"
+
+
+def test_allowed_import_not_flagged(mod, tmp_path, monkeypatch):
+    f = _write(mod, tmp_path, monkeypatch, "services/x.py", "from utils.db import x\n")
+    assert mod.check_layer_boundaries([f], _RULES) == []
+
+
+# ---------------------------------------------------------------------------
+# RC-1 — lazy (function-body) imports
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_cross_layer_not_reported_by_default(mod, tmp_path, monkeypatch):
+    """Default run must ignore lazy imports (back-compat with the old checker)."""
+    f = _write(mod, tmp_path, monkeypatch, "services/y.py", _LAZY)
+    assert mod.check_layer_boundaries([f], _RULES) == []
+
+
+def test_lazy_cross_layer_reported_as_warning_with_flag(mod, tmp_path, monkeypatch):
+    f = _write(mod, tmp_path, monkeypatch, "services/z.py", _LAZY)
+    vs = mod.check_layer_boundaries([f], _RULES, report_lazy=True)
+    assert len(vs) == 1
+    assert vs[0].check == "lazy_layer_boundary"
+    # Lazy findings are ALWAYS warnings → strict mode exit stays 0.
+    assert vs[0].severity == "warning"
+
+
+def test_known_lazy_exact_file_marked_known(mod, tmp_path, monkeypatch):
+    rules = {
+        **_RULES,
+        "known_lazy_violations": [{"file": "services/k.py", "import": "cogs"}],
+    }
+    f = _write(mod, tmp_path, monkeypatch, "services/k.py", _LAZY)
+    vs = mod.check_layer_boundaries([f], rules, report_lazy=True)
+    assert len(vs) == 1
+    assert "[known]" in vs[0].message
+    assert vs[0].severity == "warning"
+
+
+def test_known_lazy_file_prefix_marked_known(mod, tmp_path, monkeypatch):
+    """A directory `file_prefix` entry allowlists the whole seam (RC-1 seam)."""
+    rules = {
+        **_RULES,
+        "known_lazy_violations": [{"file_prefix": "services/", "import": "cogs"}],
+    }
+    f = _write(mod, tmp_path, monkeypatch, "services/deep/mod.py", _LAZY)
+    vs = mod.check_layer_boundaries([f], rules, report_lazy=True)
+    assert len(vs) == 1 and "[known]" in vs[0].message
+
+
+def test_known_lazy_does_not_match_other_target(mod, tmp_path, monkeypatch):
+    """An allowlist for cogs must NOT silence a lazy import of a different layer."""
+    rules = {
+        **_RULES,
+        "known_lazy_violations": [{"file_prefix": "services/", "import": "cogs"}],
+    }
+    src = "def f():\n    import views.base\n    return views.base\n"
+    f = _write(mod, tmp_path, monkeypatch, "services/m.py", src)
+    vs = mod.check_layer_boundaries([f], rules, report_lazy=True)
+    assert len(vs) == 1 and "[known]" not in vs[0].message
+
+
+# ---------------------------------------------------------------------------
+# _ImportVisitor + summary helper
+# ---------------------------------------------------------------------------
+
+
+def test_visitor_separates_lazy_from_module_level(mod):
+    tree = ast.parse("from cogs.a import b\ndef f():\n    from services.c import d\n")
+    v = mod._ImportVisitor()
+    v.visit(tree)
+    assert "cogs.a" in [m for _, m, _ in v.imports]
+    assert "services.c" in [m for _, m, _ in v.lazy_imports]
+    assert "cogs.a" not in [m for _, m, _ in v.lazy_imports]
+
+
+def test_counts_by_check(mod):
+    V = mod.Violation
+    vs = [
+        V(file=Path("a"), line=1, check="layer_boundary", message="m"),
+        V(file=Path("b"), line=2, check="layer_boundary", message="m"),
+        V(
+            file=Path("c"),
+            line=3,
+            check="lazy_layer_boundary",
+            message="m",
+            severity="warning",
+        ),
+    ]
+    assert mod._counts_by_check(vs) == {"layer_boundary": 2, "lazy_layer_boundary": 1}


### PR DESCRIPTION
## Summary

Continues the roadmap into **S3**, implementing **RC-1** (the "fix the checker
before leaning on it" keystone) plus the aligned Ideas Lab item **§4.4
arch-warning summary**. RC-1 is the prerequisite the roadmap puts ahead of the
later boundary moves (RC-7 GC ownership, RC-4 authority) so those can be policed.

## RC-1 — close the architecture-checker blind spot

`_ImportVisitor` previously **dropped every function-body import**, so lazy
cross-layer imports — roughly half the real call edges per the CodeGraph
caveats — were invisible. New drift could enter through a lazy import and sail
past the boundary check.

- `_ImportVisitor` now collects lazy (function-body) imports into a separate
  bucket instead of discarding them.
- New `lazy_layer_boundary` check, surfaced via a `--report-lazy-imports` flag
  (**off by default**). Lazy findings are **always warnings, never errors**, so
  `--mode strict` still exits 0 — the count is high by design.
- The default run is **unchanged**: `0 errors, 88 warnings`.
- `_is_known` gains `file_prefix` support, so a documented layer-pair seam is
  allowlisted with one rationale entry. Seeded `known_lazy_violations` with the
  **core → {services, views, governance}** lazy-resolution cycle-breakers
  (arch-fix-11).

With the flag, the report splits cleanly:
- **31 known** — the sanctioned core→* runtime lazy seam.
- **48 to triage** — `28 views→cogs`, `16 utils→{core,services,governance}`,
  `2 views→governance`, `1 services→cogs`. These are real helper-policy / thin-cog
  debt (RC-8 territory) that were previously invisible — now surfaced, not blessed.

## Ideas Lab §4.4 — architecture-warning summary

The checker now prints a per-check breakdown so operators see which rule is
accumulating findings:

```
check_architecture — 0 error(s)  88 warning(s)
  by check: baseview_inheritance=17, layer_boundary=54, raw_sql=17
```

## Tests

First-ever unit test for the checker (`tests/unit/scripts/test_check_architecture.py`,
9 cases): module-level cross-layer = error; lazy off-by-default; lazy
reported-as-warning with the flag; exact-file + `file_prefix` allowlisting;
target isolation (a cogs allowlist doesn't silence a views import); visitor
module-vs-lazy split; summary counts.

## RC-6 status (the other half of S3)

RC-6's **static integrity invariants already exist and pass** in
`tests/unit/db/test_migrations_structure.py` (no-gaps, no-duplicates, filename
format, non-empty, terminator, runner-dir). So PR 4's main deliverable is
already in the tree — I did **not** duplicate it. Remaining RC-6 items:
- **optional historical checksum** (forward-only-edit guard) — a real protection,
  but it imposes a permanent per-migration workflow step; left as a maintainer
  call (happy to add it on request).
- **live fresh-DB bootstrap** — needs a Postgres in CI, which the unit suite
  doesn't have.

## Verification
- `check_architecture.py --mode strict` → **0 errors, 88 warnings** (unchanged baseline).
- `check_architecture.py --mode strict --report-lazy-imports` → still **exit 0**.
- `check_quality.py --full` (CI mirror) → **7297 passed, 3 skipped, all checks passed ✓**.

## Rollback
Single-purpose commit; revert restores the prior checker (lazy imports invisible).
The lazy report is additive + flag-gated, so it cannot regress existing runs.

https://claude.ai/code/session_019YBiUGwQjMzdUHoX9vmz2Q

---
_Generated by [Claude Code](https://claude.ai/code/session_019YBiUGwQjMzdUHoX9vmz2Q)_