### PR TITLE
docs: document the ADR-005 capability-authority system + reconcile stale refs + next-session guidance

### DIFF
--- a/docs/AGENT_ORIENTATION.md
+++ b/docs/AGENT_ORIENTATION.md
@@ -77,6 +77,7 @@ read **`docs/helper-policy.md`** first.
 1. `docs/ownership.md` § "Service ownership" + § "Direct DB writes — explicit blocklist".
 2. `docs/architecture.md` § "Runtime invariants (CI-enforced)" — INV-E, INV-F, INV-G are AST-checked.
 3. `docs/runtime_contracts.md` § 9 (mutation contract checklist).
+4. `docs/capability-authority.md` — how a settings/binding/provisioning mutation is authorized (capability resolver + operator kill-switches + the panel-callback re-check rule).
 
 ### Touching settings / bindings / resource provisioning
 
@@ -84,6 +85,7 @@ read **`docs/helper-policy.md`** first.
 2. `docs/resource-provisioning-overview.md` — the RPM lane.
 3. `docs/platform-consistency-ledger.md` § 1 — current state of each domain.
 4. `docs/building-roadmap/config-input-standard.md` — UI rules for setting widgets.
+5. `docs/capability-authority.md` — authorization (capability resolver), the two operator kill-switches, and the panel-callback re-check rule.
 
 ### Touching tests / docs / smoke
 

--- a/docs/capability-authority.md
+++ b/docs/capability-authority.md
@@ -1,0 +1,167 @@
+# Capability-native authority + mutation kill-switches
+
+**Status:** binding (reference for the implemented system). Decision of record:
+[`docs/decisions/005-capability-native-authority-and-flag-semantics.md`](decisions/005-capability-native-authority-and-flag-semantics.md)
+(Accepted, implemented in PR #518). When this doc and source disagree, source wins
+(`disbot/governance/capability.py`).
+
+This is the contract for **how a settings / binding / provisioning mutation is
+authorized**, and for the two operator **kill-switches**. It replaced the old
+placeholder "are you an administrator?" floor (ADR-005 A1) and wired the previously
+inert `*_PRIMARY` flags as real kill-switches (ADR-005 F1).
+
+---
+
+## 1. The resolver
+
+```python
+# disbot/governance/capability.py
+async def actor_holds_capability(
+    actor, guild, capability: str, *, actor_type: str = "user",
+) -> CapabilityDecision
+```
+
+`CapabilityDecision` is a frozen dataclass: `allowed`, `capability`,
+`required_tier`, `member_tier`, `reason` (the `reason` becomes the raised error's
+message at the call site).
+
+**Layer:** lives in `governance/` and imports only `utils` / `core`
+(`utils.visibility_rules`, and `governance.execution` for the override read). It is
+called from the service pipelines via a **function-local import** — the established
+cycle-avoidance pattern.
+
+### v1 policy (in order)
+
+1. **`system` / `backfill` bypass.** Scripted ops and migrations are allowed without
+   a member context (never dereferences `actor`/`guild`).
+2. **Target-guild membership.** A non-system actor is **denied** unless it is a
+   member of the **target** `guild` (`actor.guild.id == guild.id`). Authority is
+   bound to the write target, so being privileged in guild A cannot authorize a
+   write to guild B.
+3. **Administrator floor, keyed on the declared capability.** The required tier is
+   `administrator` (`_DEFAULT_REQUIRED_TIER`), computed against the **target**
+   guild's owner via `utils.visibility_rules.get_member_visibility_tier`. An
+   **empty** `capability_required` resolves to this same floor — it does **not**
+   mean "no auth" (the misleading `SettingSpec` docstring was corrected).
+4. **Revoke-only per-guild overlay.** For a declared (non-empty) capability, an
+   explicit `allowed = False` row in `capability_execution_overrides` (read via
+   `governance.execution.get_capability_override`, which reuses the existing cache —
+   no new SQL path) turns an otherwise-allowed actor **off**. An explicit
+   `True` is **never** used to grant a below-floor actor (no privilege escalation via
+   a guild-config row). Overlay read failures degrade to the base (admin-floor)
+   decision.
+
+> **v1 keeps a single administrator floor for every capability.** The
+> `CapabilityDecision.required_tier` field is shaped so a future per-capability
+> tier matrix (capability → required tier) can replace the constant without
+> touching the pipelines. That is the documented next step (see §5).
+
+---
+
+## 2. Who consumes it
+
+The three mutation pipelines delegate their authority check to the resolver, each
+passing **its target guild** and the declared capability:
+
+| Pipeline | Entry | Capability source |
+|---|---|---|
+| `services.settings_mutation.SettingsMutationPipeline.set_value` | `_validate_authority(spec, guild, actor, actor_type)` | `SettingSpec.capability_required` |
+| `services.binding_mutation.BindingMutationPipeline.set_binding` / `clear_binding` | `_validate_authority(spec, guild, actor)` | `BindingSpec.capability_required` |
+| `services.resource_provisioning.ResourceProvisioningPipeline.provision` | `_validate_actor_authority(capability, guild, actor, actor_type)` | the catalogue `ProvisioningOption.capability_required` |
+
+Each raises its own `Unauthorized*Error(decision.reason)` on deny. Audit emission
+and cache invalidation still fire on success exactly as before.
+
+---
+
+## 3. The kill-switches (F1)
+
+Two operator flags become **real** emergency off-switches:
+
+| Flag | Gates | Consulted at |
+|---|---|---|
+| `settings.mutation.primary` (`SETTINGS_MUTATION_PRIMARY`) | all scalar settings writes | `set_value` entry (`_check_mutation_enabled`) |
+| `resource_provisioning.primary` (`RESOURCE_PROVISIONING_PRIMARY`) | all resource provisioning | `provision` entry (`_check_provisioning_enabled`) |
+
+Both go through one helper:
+
+```python
+# disbot/core/runtime/feature_flags.py
+async def is_operator_disabled(flag_name, guild_id=None) -> bool
+```
+
+**Safety contract — the important part:**
+
+- **Default = ALLOW.** `is_operator_disabled` returns `True` **only** when the flag
+  resolves to `False` from an *explicit operator override* (source `env`,
+  `db_guild`, or `db_global`). The declared default (`default_value=False`) and the
+  bootstrap fallback do **not** count as disabled — so untouched guilds keep working.
+- **Fail OPEN.** The pipelines wrap the check in `try/except` and **allow** on error:
+  a flag-store outage must never brick writes. (This is the opposite of
+  `config_arbitration`, which fails toward the legacy-read path — each surface fails
+  to *its* safe state.)
+- The disabled path raises a typed `SettingsMutationDisabledError` /
+  `ResourceProvisioningDisabledError` **before** any DB write, audit row, or Discord
+  call — a disabled pipeline has zero side effects.
+
+Operators disable a pipeline by setting the flag OFF via the usual `SUPERBOT_FF_…`
+env override or a DB flag override; they re-enable by clearing it.
+
+> **Amendment recorded at ratification:** ADR-005's draft placed F1 in
+> `core/runtime/config_arbitration.py`. That file is a read-only config seam, so the
+> kill-switches were wired at the mutation-pipeline entry points instead.
+
+---
+
+## 4. Panel callbacks must re-check authority
+
+`BaseView` only locks a panel to its **invoker** — it does not enforce an authority.
+A mutating panel may be reachable through an entry point that is **not** admin-gated
+(notably the Help menu via `build_help_menu_view`), so its callbacks must re-check.
+
+Use the shared helper:
+
+```python
+# disbot/views/base.py
+def interaction_is_admin(interaction) -> bool   # matches @has_permissions(administrator=True)
+```
+
+Applied so far:
+
+- `cogs.chain_cog._ChainMenuView.interaction_check` — gates **all** chain buttons
+  (create / delete / set / clear), every entry path.
+- `views.games.rps_panel._RpsTournamentMatchupButton` + `_RpsMatchupSelect` — re-check
+  admin before dispatching `!rpsmatchup`.
+
+**Rule for new mutating panels:** if a panel mutates state and is (or could become)
+reachable without an admin-gated entry point, re-check authority in `interaction_check`
+(whole panel) or at the callback (single action) with `interaction_is_admin`. Match
+the authority of the equivalent typed command.
+
+---
+
+## 5. What's v1 vs follow-on
+
+- **Now (v1):** authority is capability-*routed* but the policy is a single
+  administrator floor + per-guild revoke. Behaviour for the common case is identical
+  to the old admin floor; the seam is what changed.
+- **Unblocked follow-on:** the capability-native **settings/bindings UI** (Ideas-Lab
+  §4.5) — RC-4 no longer "spreads placeholder authority."
+- **Future policy:** a per-capability tier matrix (e.g. some settings need only
+  `moderator`) replaces `_DEFAULT_REQUIRED_TIER`. Revisit per the ADR-005
+  re-evaluation criteria.
+- **Broaden the guard:** audit other Help-reachable mutating panels and apply the
+  `interaction_is_admin` pattern where missing.
+
+---
+
+## 6. Where the coverage lives
+
+| Guarantee | Pinned by |
+|---|---|
+| Resolver policy (bypass, target-guild deny, admin/staff, empty-cap floor, revoke overlay, no-escalation, overlay-uses-target-id) | `tests/unit/governance/test_capability.py` |
+| Settings: authorized/denied, revoke overlay, kill-switch default/disabled/fail-open, cross-guild deny | `tests/unit/services/test_settings_mutation_pipeline.py` |
+| Provisioning: authorized, below-admin deny, system bypass, kill-switch trio | `tests/unit/services/test_resource_provisioning_pipeline.py` |
+| Bindings: capability deny/allow (actor must be a member of the target guild) | `tests/unit/bindings/test_binding_mutation_pipeline.py` |
+| `is_operator_disabled` source discrimination (explicit-OFF only) | `tests/unit/schema/test_feature_flags_declarations.py` |
+| Panel guards: non-admin blocked on chain panel + RPS matchup | `tests/unit/views/test_panel_command_gaps.py` |

--- a/docs/ownership.md
+++ b/docs/ownership.md
@@ -130,6 +130,19 @@ Scalar settings are declared as `SettingSpec`s in
 `core.runtime.feature_flags`. `docs/settings-customization-roadmap.md`
 is the authority on the three lanes (settings / binding / provisioning).
 
+### Mutation authority + kill-switches (ADR-005)
+
+Authorizing a settings / binding / provisioning mutation is owned by the governance
+capability resolver — **not** by the pipelines themselves:
+
+| Concern | Owner | Notes |
+|---|---|---|
+| Capability resolution | `governance.capability.actor_holds_capability` | Administrator floor keyed on the declared `capability_required`; bound to the **target** guild; revoke-only per-guild overlay over `capability_execution_overrides`. v1 keeps one floor. |
+| Mutation kill-switches | `core.runtime.feature_flags.is_operator_disabled` | `settings.mutation.primary` / `resource_provisioning.primary`. Default-ALLOW; blocks only on an explicit operator OFF; **fails open**. |
+| Panel-callback re-check | `views.base.interaction_is_admin` | Mutating panels reachable without an admin-gated entry (e.g. via Help) must re-check authority. |
+
+Full contract: [`docs/capability-authority.md`](capability-authority.md).
+
 ---
 
 ## Event ownership

--- a/docs/planning/superbot-ideas-lab-2026-06-05.md
+++ b/docs/planning/superbot-ideas-lab-2026-06-05.md
@@ -127,7 +127,7 @@ sits on the existing architecture per D1.
 | ~~**Architecture-warning summary** (count/categories from RC-1 report mode)~~ | Diagnostics | Med | S/M | Low | ✅ **shipped** in PR #515 — checker prints a `by check:` per-rule breakdown |
 | **Migration health card** (latest migration, gaps/checksum) | Diagnostics | Med | S | Low | After PR 4 / RC-6 (RC-6 invariants already exist; this surfaces them) |
 
-### 4.5 After RC-4 / PR 6 (capability-native authority) — **do not expand settings UI earlier**
+### 4.5 Capability-native authority — **RC-4 shipped (#518); these are now buildable**
 
 | Idea | Feature | Val | Size | Risk | Fit |
 |---|---|---|---|---|---|
@@ -215,7 +215,7 @@ Re-open only by amending the governing doc cited.
 | Global fail-closed for **every** interaction | Reject | priority-map (posture is **per-surface**, not blanket) |
 | Redis-backed sessions/cache | Reject | ADR-001 (no-redis-backed-state) |
 | Universal game checkpointing / restart-safe game state | Reject | ADR-002 (restart cancels games; staked coins refunded) |
-| Expand settings UI before RC-4 | Defer | RC-4 (would spread placeholder authority) |
+| Expand settings UI before RC-4 | **Cleared** | RC-4 shipped (#518): settings UI is now buildable on capability-native authority — see `docs/capability-authority.md` §5 |
 | Big "all-cogs-at-once" thin-cog sweep | Reject | RC-8 (Direct-DB ledger first; staged per-feature) |
 | One slash command per sub-action | Reject | command-integration-standard (slash = front doors to panels only) |
 | Separate "danger" dashboard | Reject | ADR-003 (extend `ReadinessSnapshot` instead) |

--- a/docs/planning/superbot-next-session-roadmap-2026-06-05.md
+++ b/docs/planning/superbot-next-session-roadmap-2026-06-05.md
@@ -450,3 +450,31 @@ Still deferred/gated: BTD6 provenance **schema/extraction** (RC-10, paused until
 follow-on docs/schema PR), ADR-007 media-subsystem **registration** + `ownership.md`
 row (follow-on), capability-native **settings UI** (follow-on after RC-4 code), and
 the broad RC-8 view-move sweep (PR 8).
+
+---
+
+## Addendum 4 (post-#518): documentation + next-session candidates
+
+PR #518 merged ADR-005 (A1 + F1) and the safe Ideas-Lab §4.1 UX. A follow-up docs PR
+added [`docs/capability-authority.md`](../capability-authority.md) (the binding
+reference for the implemented authority system) and reconciled the now-stale
+references (resource-provisioning overview, `ownership.md`, this roadmap, Ideas-Lab
+§4.5/§6).
+
+**Candidate next sessions** — each independently shippable; pick one per session:
+
+| Candidate | What | Gate / readiness | First read |
+|---|---|---|---|
+| **A. Capability-native settings UI** | Ideas-Lab §4.5 (settings capability preview, "why can't I edit this?", provenance cards, capability audit mini-report) | **Unblocked** — RC-4 shipped; build read-only over the authority result first | `docs/capability-authority.md`, Ideas-Lab §4.5 |
+| **B. Per-capability tier matrix** | Replace the v1 single administrator floor with a declared capability → required-tier map | Design decision; extend `_DEFAULT_REQUIRED_TIER`. No security regression (floors only relax with an explicit declaration); add per-tier tests | `docs/capability-authority.md` §5, ADR-005 re-eval criteria |
+| **C. Broaden the panel-authority guard** | Audit other mutating panels reachable without an admin-gated entry (Help `build_help_menu_view`, hub routes) and apply `interaction_is_admin` | Small, mechanical, per-panel; add a non-admin-blocked test each | `docs/capability-authority.md` §4 |
+| **D. ADR-006 BTD6 provenance** | Implement the single `DataProvenance` object + owner matrix; resume extraction against it | **Gated** — ADR-006 Accepted but extraction stays paused until the schema PR lands | ADR-006, `docs/btd6-data-backends.md` |
+| **E. ADR-007 media subsystem** | Add the `docs/ownership.md` media-subsystem row + register `youtube_context_service` / `video_reference_cache_service` under it | **Follow-on** of ADR-007 (Accepted); ownership-doc PR | ADR-007, `docs/ownership.md` |
+| **F. RC-8 staged cleanup** | A *tiny* mechanical view/cog slice (Direct-DB ledger → view moves → service moves), per-feature | Staged; never all-at-once; don't touch capability/BTD6/media in the same slice | priority-map §RC-8, `docs/direct-db-exception-ledger.md` |
+
+**Suggested order:** A or C first (lowest risk, immediate operator value, both build
+directly on what #518 shipped), then B, then the gated D/E when you want to open
+those lanes. F can ride alongside any of them as a small slice.
+
+Out of scope unchanged: no second governance / provenance / media system; no AI
+write/action tools (Ideas-Lab §6); no broad all-cogs thin-cog sweep.

--- a/docs/resource-provisioning-overview.md
+++ b/docs/resource-provisioning-overview.md
@@ -36,8 +36,14 @@ view bypasses it.
 1. **Resolve** `ResourceRequirement` + `BindingSpec` from the
    `ProvisioningCatalogue.find(...)` lookup. Raise `UndeclaredResourceError`
    if missing.
-2. **Validate actor / capability** — admin-tier today; future Phase 4.5
-   uses `BindingSpec.capability_required`.
+2. **Validate actor / capability** — capability-native (ADR-005 A1): the actor must
+   be a member of the target guild and hold the option's `capability_required`,
+   resolved via `governance.capability.actor_holds_capability` (administrator floor
+   in v1; an empty capability resolves to that floor). The
+   `resource_provisioning.primary` operator kill-switch is also consulted here —
+   when explicitly OFF the pipeline raises `ResourceProvisioningDisabledError`
+   before any side effect (fail-open on flag-eval error). See
+   [`docs/capability-authority.md`](capability-authority.md).
 3. **Validate bot Discord permissions** for the requested resource kind
    (`manage_channels` for CHANNEL / CATEGORY, `manage_roles` for ROLE) via
    `guild.me.guild_permissions`. Insufficient permissions →


### PR DESCRIPTION
## Summary

Documentation follow-up to **#518** (ADR-005 implementation). Adds a proper reference for the authority system we shipped, reconciles the docs that the implementation made stale, and records concrete next-session candidates. **Docs-only — no code changes.**

### New
- **`docs/capability-authority.md`** — binding reference for the implemented system:
  - the `governance.capability` resolver (administrator floor keyed on the declared capability, **target-guild binding**, revoke-only per-guild overlay over `capability_execution_overrides`);
  - the two operator kill-switches via `feature_flags.is_operator_disabled` (default-ALLOW, blocks only on an explicit operator OFF, **fails open**);
  - the `views.base.interaction_is_admin` panel-callback re-check rule;
  - the v1-vs-follow-on boundary and where the test coverage lives.

### Stale reconciliation (current/binding docs; dated audit snapshots left as historical record)
- **`resource-provisioning-overview.md`** — step 2 said *"admin-tier today; future Phase 4.5"*; now describes the implemented capability check + the provisioning kill-switch.
- **`ownership.md`** — new *"Mutation authority + kill-switches"* subsection naming the resolver / kill-switch / panel-guard owners.
- **`AGENT_ORIENTATION.md`** — cross-linked the new doc from the "governance / mutation pipelines" and "settings / bindings / provisioning" reading orders.
- **`ideas-lab`** — §4.5 heading and the §6 *"expand settings UI before RC-4"* rejection updated: RC-4 shipped, so the settings UI is now **unblocked**.

### Next-session guidance
- **`next-session-roadmap` Addendum 4** — six independently-shippable candidates (capability-native settings UI, per-capability tier matrix, broaden the panel guard, ADR-006 BTD6 provenance, ADR-007 media registration, staged RC-8), each with its gate, first-read, and a suggested order.

## Verification
- `check_quality.py --check-only` → green; `tests/unit/docs/` (doc-pinning) → **49 passed**.
- Docs-only: no `.py` touched, so mypy/pytest behavior is unchanged (the doc-pinning tests are the only suite a `.md` edit could affect).

https://claude.ai/code/session_01Wb2RP5kNaaoQWrru2puSFS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wb2RP5kNaaoQWrru2puSFS)_