### PR TITLE
PR2 — shared role-feasibility model + MultiRoleSelector (server-management foundation)

### DIFF
--- a/disbot/utils/role_feasibility.py
+++ b/disbot/utils/role_feasibility.py
@@ -1,0 +1,187 @@
+"""Pure role-feasibility evaluation shared by selectors, services, and diagnostics.
+
+Answers two questions about a guild role as *structured findings* rather than
+ad-hoc strings:
+
+* **Is it a sensible selection target?** — :func:`not_everyone` (the default
+  filter every role picker should use; ``@everyone`` is almost never a useful
+  pick).
+* **Can the bot (and optionally an acting member) manage it?** —
+  :func:`evaluate_role` / :func:`manageable_roles`, yielding a reason code when
+  not (hierarchy, missing permission, managed integration role, …).
+
+This module is **pure**: no I/O and no service/cog/view imports (``utils`` may
+import stdlib + ``discord`` only).  The manageability checks mirror the logic
+already embedded in ``services.role_automation.check_preflight`` and
+``services.resource_health._inspect_role`` — decomposed here so a single
+source of truth can be reused by the shared selectors (PR2) and the role
+lifecycle / assignment surfaces that follow, instead of each surface
+re-deriving "can I touch this role?".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+import discord
+
+RoleFilter = Callable[[discord.Role], bool]
+
+# ---------------------------------------------------------------------------
+# Reason codes
+# ---------------------------------------------------------------------------
+
+SELECTABLE = "selectable"  # ok=True — nothing blocks managing this role
+EVERYONE = "everyone"  # the @everyone / default role
+MANAGED = "managed"  # integration / bot-managed (not operator-editable)
+ABOVE_BOT = "above_bot"  # at or above the bot's highest role
+BOT_MISSING_MANAGE_ROLES = "bot_missing_manage_roles"  # bot lacks Manage Roles
+ABOVE_ACTOR = "above_actor"  # at or above the acting member's highest role
+
+_REASONS: dict[str, str] = {
+    EVERYONE: "the @everyone role can't be targeted",
+    MANAGED: "managed by an integration — not operator-editable",
+    ABOVE_BOT: "above my highest role — I can't manage it",
+    BOT_MISSING_MANAGE_ROLES: "I lack the Manage Roles permission",
+    ABOVE_ACTOR: "above your highest role",
+}
+
+# Short human labels for exclusion summaries (footers / embeds).
+_SHORT: dict[str, str] = {
+    EVERYONE: "@everyone",
+    MANAGED: "managed",
+    ABOVE_BOT: "above my top role",
+    BOT_MISSING_MANAGE_ROLES: "missing Manage Roles",
+    ABOVE_ACTOR: "above your top role",
+}
+
+
+@dataclass(frozen=True)
+class RoleFeasibility:
+    """Structured verdict for a single role."""
+
+    role_id: int
+    role_name: str
+    ok: bool
+    code: str
+    reason: str
+
+
+def _has_manage_roles(member: object) -> bool:
+    perms = getattr(member, "guild_permissions", None)
+    return bool(getattr(perms, "manage_roles", False))
+
+
+def _position(obj: object) -> int:
+    return int(getattr(obj, "position", 0) or 0)
+
+
+def _is_default(role: object) -> bool:
+    is_default = getattr(role, "is_default", None)
+    if callable(is_default):
+        return bool(is_default())
+    return bool(is_default)
+
+
+def evaluate_role(
+    role: discord.Role,
+    *,
+    bot_member: object | None = None,
+    actor: object | None = None,
+) -> RoleFeasibility:
+    """Return a :class:`RoleFeasibility` for *role*.
+
+    ``bot_member`` (``guild.me``) enables the bot-hierarchy / permission
+    checks; ``actor`` enables the staff-hierarchy check for manual actions.
+    With neither supplied, only the intrinsic checks (``@everyone``,
+    ``managed``) can fail.  The first blocking reason in precedence order
+    (@everyone → managed → bot permission → bot hierarchy → actor hierarchy)
+    is reported.
+    """
+    rid = int(getattr(role, "id", 0) or 0)
+    name = str(getattr(role, "name", "") or "")
+
+    def _verdict(code: str) -> RoleFeasibility:
+        ok = code == SELECTABLE
+        reason = "" if ok else _REASONS.get(code, code)
+        return RoleFeasibility(rid, name, ok, code, reason)
+
+    if _is_default(role):
+        return _verdict(EVERYONE)
+    if bool(getattr(role, "managed", False)):
+        return _verdict(MANAGED)
+    if bot_member is not None:
+        if not _has_manage_roles(bot_member):
+            return _verdict(BOT_MISSING_MANAGE_ROLES)
+        bot_top = getattr(bot_member, "top_role", None)
+        if bot_top is not None and _position(role) >= _position(bot_top):
+            return _verdict(ABOVE_BOT)
+    if actor is not None:
+        actor_top = getattr(actor, "top_role", None)
+        if actor_top is not None and _position(role) >= _position(actor_top):
+            return _verdict(ABOVE_ACTOR)
+    return _verdict(SELECTABLE)
+
+
+def manageable_roles(
+    roles: Iterable[discord.Role],
+    *,
+    bot_member: object,
+    actor: object | None = None,
+) -> tuple[list[discord.Role], list[RoleFeasibility]]:
+    """Partition *roles* into ``(manageable, excluded)``.
+
+    ``manageable`` is the roles the bot (and ``actor`` if given) can act on;
+    ``excluded`` is a :class:`RoleFeasibility` per skipped role carrying the
+    reason.  Intended for assignment / lifecycle surfaces that must only offer
+    roles they can actually mutate.
+    """
+    manageable: list[discord.Role] = []
+    excluded: list[RoleFeasibility] = []
+    for role in roles:
+        verdict = evaluate_role(role, bot_member=bot_member, actor=actor)
+        if verdict.ok:
+            manageable.append(role)
+        else:
+            excluded.append(verdict)
+    return manageable, excluded
+
+
+def not_everyone(role: discord.Role) -> bool:
+    """Default role-picker filter: keep everything except ``@everyone``.
+
+    Shared so every selector agrees on what a "targetable" role is.
+    """
+    return not _is_default(role)
+
+
+def summarize_exclusions(excluded: Iterable[RoleFeasibility]) -> str:
+    """Render a compact "N hidden: …" summary for a footer / embed line.
+
+    Returns an empty string when nothing was excluded.
+    """
+    items = list(excluded)
+    if not items:
+        return ""
+    counts: dict[str, int] = {}
+    for f in items:
+        counts[f.code] = counts.get(f.code, 0) + 1
+    parts = [f"{n} {_SHORT.get(code, code)}" for code, n in counts.items()]
+    return f"{len(items)} hidden: " + ", ".join(parts)
+
+
+__all__ = [
+    "ABOVE_ACTOR",
+    "ABOVE_BOT",
+    "BOT_MISSING_MANAGE_ROLES",
+    "EVERYONE",
+    "MANAGED",
+    "SELECTABLE",
+    "RoleFeasibility",
+    "RoleFilter",
+    "evaluate_role",
+    "manageable_roles",
+    "not_everyone",
+    "summarize_exclusions",
+]

--- a/disbot/views/roles/exemptions_panel.py
+++ b/disbot/views/roles/exemptions_panel.py
@@ -17,28 +17,7 @@ from utils import db
 from utils.ui_constants import ROLE_COLOR
 from views.base import BaseView
 from views.navigation import attach_back_button
-
-
-class _ExemptRoleSelect(discord.ui.RoleSelect):
-    """Multi-role picker — stores the selection on the parent panel."""
-
-    def __init__(self) -> None:
-        super().__init__(
-            placeholder="Select role(s) to configure…",
-            min_values=0,
-            max_values=25,
-            row=0,
-        )
-
-    async def callback(self, interaction: discord.Interaction) -> None:
-        view = self.view
-        if not isinstance(view, RoleExemptionsPanel):
-            return
-        view.selected_role_ids = [role.id for role in self.values]
-        await interaction.response.edit_message(
-            embed=await view.build_embed(),
-            view=view,
-        )
+from views.selectors import MultiRoleSelector
 
 
 class RoleExemptionsPanel(BaseView):
@@ -49,7 +28,18 @@ class RoleExemptionsPanel(BaseView):
         self.ctx = ctx
         self.parent = parent
         self.selected_role_ids: list[int] = []
-        self.add_item(_ExemptRoleSelect())
+        # Shared role picker — converged off the bespoke native RoleSelect
+        # onto the reusable primitive, which excludes @everyone via the
+        # default role_feasibility filter (a no-op exemption target).
+        self.add_item(
+            MultiRoleSelector(
+                list(getattr(ctx.guild, "roles", []) or []),
+                self._on_roles_selected,
+                placeholder="Select role(s) to configure…",
+                min_values=0,
+                row=0,
+            ),
+        )
 
         if parent is not None:
 
@@ -65,6 +55,17 @@ class RoleExemptionsPanel(BaseView):
                 parent_builder=_build_parent,
                 row=4,
             )
+
+    async def _on_roles_selected(
+        self,
+        interaction: discord.Interaction,
+        role_ids: list[int],
+    ) -> None:
+        self.selected_role_ids = role_ids
+        await interaction.response.edit_message(
+            embed=await self.build_embed(),
+            view=self,
+        )
 
     async def build_embed(self) -> discord.Embed:
         from services.settings_resolution import resolve_value

--- a/disbot/views/selectors/__init__.py
+++ b/disbot/views/selectors/__init__.py
@@ -12,6 +12,7 @@ Public surface:
     subsystem.SubsystemSelector — registered-subsystem picker
     multi.MultiSelect           — generic multi-select over caller options
     multi.MultiChannelSelector  — multi-select channel picker (returns ids)
+    multi_role.MultiRoleSelector — multi-select role picker (returns ids)
 
 Adopt these instead of building bespoke ``discord.ui.Select`` widgets
 in cogs.  Adoption is mechanical: replace the local Select subclass
@@ -22,6 +23,7 @@ from __future__ import annotations
 
 from views.selectors.channel import ChannelSelector
 from views.selectors.multi import MultiChannelSelector, MultiSelect
+from views.selectors.multi_role import MultiRoleSelector
 from views.selectors.role import RoleSelector
 from views.selectors.scope import ScopeSelector
 from views.selectors.subsystem import SubsystemSelector
@@ -29,6 +31,7 @@ from views.selectors.subsystem import SubsystemSelector
 __all__ = [
     "ChannelSelector",
     "MultiChannelSelector",
+    "MultiRoleSelector",
     "MultiSelect",
     "RoleSelector",
     "ScopeSelector",

--- a/disbot/views/selectors/multi_role.py
+++ b/disbot/views/selectors/multi_role.py
@@ -1,0 +1,87 @@
+"""Multi-select role picker — the role-typed sibling of
+:class:`views.selectors.multi.MultiChannelSelector`.
+
+Several admin flows pick a *set* of roles (exemptions, bulk assignment,
+templates).  ``MultiRoleSelector`` mirrors ``MultiChannelSelector`` but
+returns role ids and applies a role filter before Discord's 25-option cap,
+defaulting to :func:`utils.role_feasibility.not_everyone` so every surface
+agrees on what a "targetable" role is.  Pass a stricter ``role_filter``
+(e.g. ``utils.role_feasibility``'s manageability partition) when the surface
+may only offer roles the bot can actually mutate.
+
+Paging beyond 25 roles is a deliberate follow-up (see
+:mod:`views.selectors.channel`); the cap is enforced here so callers can pass
+``guild.roles`` of any length without crashing the payload.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Iterable
+
+import discord
+
+from utils.role_feasibility import RoleFilter, not_everyone
+from views.selectors.multi import MultiSelect
+
+OnSelectIds = Callable[[discord.Interaction, list[int]], Awaitable[None]]
+
+
+class MultiRoleSelector(MultiSelect):
+    """Multi-select guild-role picker returning every chosen role id.
+
+    Parameters
+    ----------
+    roles:
+        Any iterable of :class:`discord.Role`.  ``role_filter`` is applied
+        before truncation to 25 entries.
+    on_select:
+        Awaitable invoked with ``(interaction, role_ids)``; unparseable
+        values are skipped defensively.
+    role_filter:
+        Optional predicate.  Defaults to "not @everyone".
+    """
+
+    def __init__(
+        self,
+        roles: Iterable[discord.Role],
+        on_select: OnSelectIds,
+        *,
+        role_filter: RoleFilter | None = None,
+        placeholder: str = "Select one or more roles…",
+        min_values: int = 0,
+        max_values: int | None = None,
+        custom_id: str | None = None,
+        row: int | None = None,
+    ) -> None:
+        flt = role_filter or not_everyone
+        bounded = [r for r in roles if flt(r)][:25]
+        options = [
+            discord.SelectOption(
+                label=(str(getattr(r, "name", "")) or str(r.id))[:100],
+                value=str(r.id),
+            )
+            for r in bounded
+        ]
+        super().__init__(
+            options,
+            self._dispatch_ids,
+            placeholder=placeholder,
+            min_values=min_values,
+            max_values=max_values,
+            custom_id=custom_id,
+            row=row,
+        )
+        self._id_on_select = on_select
+
+    async def _dispatch_ids(
+        self,
+        interaction: discord.Interaction,
+        values: list[str],
+    ) -> None:
+        ids: list[int] = []
+        for v in values:
+            try:
+                ids.append(int(v))
+            except ValueError:
+                continue
+        await self._id_on_select(interaction, ids)

--- a/tests/unit/utils/test_role_feasibility.py
+++ b/tests/unit/utils/test_role_feasibility.py
@@ -1,0 +1,116 @@
+"""Tests for utils.role_feasibility (PR2 shared role-feasibility model)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from utils import role_feasibility as rf
+
+
+def _role(rid, name="R", position=1, default=False, managed=False):
+    return SimpleNamespace(
+        id=rid,
+        name=name,
+        position=position,
+        is_default=lambda: default,
+        managed=managed,
+    )
+
+
+def _member(*, manage_roles=True, top_position=10):
+    return SimpleNamespace(
+        guild_permissions=SimpleNamespace(manage_roles=manage_roles),
+        top_role=SimpleNamespace(position=top_position),
+    )
+
+
+def test_everyone_is_not_selectable():
+    v = rf.evaluate_role(_role(1, "@everyone", default=True))
+    assert not v.ok
+    assert v.code == rf.EVERYONE
+    assert v.reason  # non-empty human reason
+
+
+def test_managed_role_blocked():
+    v = rf.evaluate_role(_role(2, "Booster", managed=True))
+    assert not v.ok
+    assert v.code == rf.MANAGED
+
+
+def test_bot_missing_manage_roles():
+    v = rf.evaluate_role(
+        _role(3, "Member", position=1),
+        bot_member=_member(manage_roles=False),
+    )
+    assert not v.ok
+    assert v.code == rf.BOT_MISSING_MANAGE_ROLES
+
+
+def test_role_above_bot_top():
+    v = rf.evaluate_role(
+        _role(4, "Admin", position=20),
+        bot_member=_member(top_position=10),
+    )
+    assert not v.ok
+    assert v.code == rf.ABOVE_BOT
+
+
+def test_role_above_actor_top():
+    # Bot can manage (top 30), but the acting member's top (5) is below role (10).
+    v = rf.evaluate_role(
+        _role(5, "Staff", position=10),
+        bot_member=_member(top_position=30),
+        actor=SimpleNamespace(top_role=SimpleNamespace(position=5)),
+    )
+    assert not v.ok
+    assert v.code == rf.ABOVE_ACTOR
+
+
+def test_selectable_when_all_clear():
+    v = rf.evaluate_role(
+        _role(6, "Member", position=1),
+        bot_member=_member(top_position=10),
+    )
+    assert v.ok
+    assert v.code == rf.SELECTABLE
+    assert v.reason == ""
+
+
+def test_precedence_everyone_before_managed():
+    v = rf.evaluate_role(_role(7, "x", default=True, managed=True))
+    assert v.code == rf.EVERYONE
+
+
+def test_manageable_roles_partitions():
+    roles = [
+        _role(1, "@everyone", default=True),
+        _role(2, "Admin", position=20),
+        _role(3, "Member", position=1),
+    ]
+    manageable, excluded = rf.manageable_roles(
+        roles,
+        bot_member=_member(top_position=10),
+    )
+    assert [r.id for r in manageable] == [3]
+    assert {f.code for f in excluded} == {rf.EVERYONE, rf.ABOVE_BOT}
+
+
+def test_not_everyone_filter():
+    assert rf.not_everyone(_role(1, "Member")) is True
+    assert rf.not_everyone(_role(2, "@everyone", default=True)) is False
+
+
+def test_summarize_exclusions():
+    excluded = [
+        rf.RoleFeasibility(1, "@everyone", False, rf.EVERYONE, "x"),
+        rf.RoleFeasibility(2, "A", False, rf.ABOVE_BOT, "y"),
+        rf.RoleFeasibility(3, "B", False, rf.ABOVE_BOT, "y"),
+    ]
+    s = rf.summarize_exclusions(excluded)
+    assert s.startswith("3 hidden:")
+    assert "@everyone" in s
+    assert "above my top role" in s
+
+
+def test_summarize_empty_is_blank():
+    assert rf.summarize_exclusions([]) == ""

--- a/tests/unit/views/test_role_exemptions_panel.py
+++ b/tests/unit/views/test_role_exemptions_panel.py
@@ -13,7 +13,10 @@ from views.roles.exemptions_panel import RoleExemptionsPanel
 def _ctx(guild_roles: list | None = None) -> SimpleNamespace:
     guild = MagicMock()
     guild.id = 1
-    roles = {r.id: r for r in (guild_roles or [])}
+    role_list = list(guild_roles or [])
+    # The panel's shared MultiRoleSelector reads guild.roles at construction.
+    guild.roles = role_list
+    roles = {r.id: r for r in role_list}
     guild.get_role.side_effect = lambda rid: roles.get(rid)
     return SimpleNamespace(author=MagicMock(id=99), guild=guild, bot=MagicMock())
 
@@ -65,6 +68,43 @@ async def test_apply_writes_each_selected_role_through_service():
         assert call.kwargs["exempt_xp"] is True
         assert call.kwargs["exempt_time"] is False  # untouched (no prior row)
         assert call.kwargs["actor_id"] == 99
+    interaction.response.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_role_picker_excludes_everyone_and_sets_selection():
+    from views.selectors import MultiRoleSelector
+
+    everyone = SimpleNamespace(
+        id=1,
+        name="@everyone",
+        mention="@everyone",
+        is_default=lambda: True,
+    )
+    member = SimpleNamespace(
+        id=2,
+        name="Member",
+        mention="@Member",
+        is_default=lambda: False,
+    )
+    panel = RoleExemptionsPanel(_ctx([everyone, member]))
+
+    # The bespoke native RoleSelect is gone; the shared picker excludes @everyone.
+    selector = next(c for c in panel.children if isinstance(c, MultiRoleSelector))
+    assert {o.value for o in selector.options} == {"2"}
+
+    interaction = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    with (
+        patch("utils.db.get_role_exemptions", new=AsyncMock(return_value=[])),
+        patch(
+            "services.settings_resolution.resolve_value",
+            new=AsyncMock(return_value=False),
+        ),
+    ):
+        await panel._on_roles_selected(interaction, [2])
+
+    assert panel.selected_role_ids == [2]
     interaction.response.edit_message.assert_awaited_once()
 
 

--- a/tests/unit/views/test_selectors.py
+++ b/tests/unit/views/test_selectors.py
@@ -21,6 +21,7 @@ import pytest
 from views.selectors import (
     ChannelSelector,
     MultiChannelSelector,
+    MultiRoleSelector,
     MultiSelect,
     RoleSelector,
     ScopeSelector,
@@ -264,6 +265,58 @@ async def test_multi_channel_selector_skips_unparseable_values():
     cb = AsyncMock()
     sel = MultiChannelSelector(channels, on_select=cb)
     sel._values = ["11", "not-an-int"]
+    interaction = MagicMock()
+    await sel.callback(interaction)
+    cb.assert_awaited_once_with(interaction, [11])
+
+
+# ---------------------------------------------------------------------------
+# MultiRoleSelector (PR2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_multi_role_selector_filters_everyone_by_default():
+    roles = [_role(1, "@everyone", default=True), _role(2, "Member"), _role(3, "Admin")]
+    sel = MultiRoleSelector(roles, on_select=AsyncMock())
+    assert {o.label for o in sel.options} == {"Member", "Admin"}
+
+
+@pytest.mark.asyncio
+async def test_multi_role_selector_truncates_to_25():
+    roles = [_role(i, f"r{i}") for i in range(40)]
+    sel = MultiRoleSelector(roles, on_select=AsyncMock())
+    assert len(sel.options) == 25
+
+
+@pytest.mark.asyncio
+async def test_multi_role_selector_custom_filter():
+    roles = [_role(1, "Admin"), _role(2, "Mod"), _role(3, "User")]
+    sel = MultiRoleSelector(
+        roles,
+        on_select=AsyncMock(),
+        role_filter=lambda r: r.name in ("Admin", "Mod"),
+    )
+    assert {o.label for o in sel.options} == {"Admin", "Mod"}
+
+
+@pytest.mark.asyncio
+async def test_multi_role_selector_invokes_callback_with_int_ids():
+    roles = [_role(11, "a"), _role(22, "b"), _role(33, "c")]
+    cb = AsyncMock()
+    sel = MultiRoleSelector(roles, on_select=cb)
+    sel._values = ["11", "33"]
+    interaction = MagicMock()
+    await sel.callback(interaction)
+    cb.assert_awaited_once_with(interaction, [11, 33])
+
+
+@pytest.mark.asyncio
+async def test_multi_role_selector_skips_unparseable_values():
+    roles = [_role(11, "a")]
+    cb = AsyncMock()
+    sel = MultiRoleSelector(roles, on_select=cb)
+    sel._values = ["11", "nope"]
     interaction = MagicMock()
     await sel.callback(interaction)
     cb.assert_awaited_once_with(interaction, [11])


### PR DESCRIPTION
## Summary

PR2 of the server-management plan: the **shared resource-safety foundation for roles**. This is the keystone that later role PRs (dynamic time/XP selection, lifecycle, templates) consume so each surface stops re-deriving "can I touch this role?" and agrees on what a selectable role is.

## What changed

- **`utils/role_feasibility.py` (new)** — a pure, structured role-feasibility model:
  - `RoleFeasibility` (frozen) + reason codes (`EVERYONE`, `MANAGED`, `ABOVE_BOT`, `BOT_MISSING_MANAGE_ROLES`, `ABOVE_ACTOR`, `SELECTABLE`).
  - `evaluate_role(role, *, bot_member=None, actor=None)` and `manageable_roles(...)` partition roles into manageable vs. excluded-with-reason. The checks **decompose the logic already embedded in** `services.role_automation.check_preflight` and `services.resource_health._inspect_role` into one reusable source of truth (hierarchy = `role.position >= bot.top_role.position`, perm = Manage Roles, plus `@everyone`/`managed`).
  - Pure module — stdlib + `discord` only — so both `services/` and `views/` can import it (per `helper-policy.md`).
- **`views/selectors/multi_role.py` (new)** — `MultiRoleSelector`, the role-typed sibling of `MultiChannelSelector`. Returns role ids; applies a `role_filter` (default `not_everyone`) before Discord's 25-option cap. Exported from `views/selectors/__init__.py`.
- **Adopted in `views/roles/exemptions_panel.py`** — replaced the bespoke native `discord.ui.RoleSelect` with the shared `MultiRoleSelector`, which also filters out the no-op `@everyone` exemption target. This is the roadmap's selector-convergence in miniature.

## Scope discipline

Per the plan's "ship only what the first consumers need": the **manageability filter** (`manageable_roles`) ships fully tested and ready, but its first *production* consumer is the role assignment/lifecycle surfaces in PR5/PR6 — so it's proven now without being wired speculatively. **Paging/search beyond 25 roles is a deliberate follow-up** (matching the existing channel-selector stance in `views/selectors/channel.py`); for the exemptions adopter, 25 is ample. `resource_health` taxonomy alignment is also deferred (it has its own binding-finding model) to avoid scope creep.

## Tests

- `tests/unit/utils/test_role_feasibility.py` (new) — every reason code, precedence, `manageable_roles` partition, `not_everyone`, exclusion summary.
- `tests/unit/views/test_selectors.py` — `MultiRoleSelector` filtering / 25-cap / id parsing / custom filter.
- `tests/unit/views/test_role_exemptions_panel.py` — the picker excludes `@everyone` and the selection callback wires through.

## Verification

- `python3.10 scripts/check_architecture.py --mode strict` → exit 0, 0 errors, no findings for the new files (utils layer boundary respected — no service imports).
- `python3.10 scripts/check_quality.py --full` → black/isort/ruff + mypy + **7395 passed, 3 skipped**.

## Next

PR3 + PR4 — the mutation/preview/result contract landing with the channel lifecycle service (mirrors `ResourceProvisioningPipeline`). Happy to continue or pause here.

https://claude.ai/code/session_014enNntBBfyuui1Fmm46DqE

---
_Generated by [Claude Code](https://claude.ai/code/session_014enNntBBfyuui1Fmm46DqE)_