### PR TITLE
PR3+PR4 — lifecycle mutation contract + ChannelLifecycleService (route channel cog)

### DIFF
--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -21,6 +21,11 @@ from discord.ext import commands
 
 from core.runtime import resources
 from core.runtime.interaction_helpers import help_ctx_shim
+from services.channel_lifecycle_service import (
+    ChannelLifecycleRequest,
+    ChannelLifecycleService,
+)
+from services.lifecycle import SUCCESS
 from utils.channels import get_or_create_category, safe_channel_name
 from utils.ui_constants import INFO_COLOR, WARNING_COLOR
 from views.base import send_panel
@@ -124,6 +129,14 @@ class ChannelCog(commands.Cog):
             )
         return formatted or "No overwrites."
 
+    @staticmethod
+    def _channel_result_error(result) -> str:
+        """First human-readable error from a ChannelLifecycleService result."""
+        for step in result.failed:
+            if step.error:
+                return step.error
+        return "operation could not be completed"
+
     # -------------------
     # Commands
     # -------------------
@@ -176,11 +189,23 @@ class ChannelCog(commands.Cog):
             await ctx.send(f'Event channel "{name}" created!')
         elif action.lower() == "delete":
             channel = self._resolve_channel(ctx.guild, evt)
-            if channel:
-                await channel.delete()
-                await ctx.send(f'Event "{channel.name}" deleted!')
-            else:
+            if not channel:
                 await ctx.send(f'Event "{evt}" not found.')
+                return
+            name = channel.name
+            result = await ChannelLifecycleService().apply(
+                ctx.guild,
+                ChannelLifecycleRequest(operation="delete", channel_ids=(channel.id,)),
+                ctx.author,
+                confirmed=True,
+                actor_type="admin",
+            )
+            if result.outcome == SUCCESS:
+                await ctx.send(f'Event "{name}" deleted!')
+            else:
+                await ctx.send(
+                    f'❌ Could not delete "{name}": {self._channel_result_error(result)}',
+                )
         else:
             await ctx.send('Invalid action. Use "create" or "delete".')
 
@@ -241,16 +266,21 @@ class ChannelCog(commands.Cog):
                 self._resolve_channel(ctx.guild, n) for n in channel_names_or_word
             ]
 
-        deleted, failed = [], []
-        for channel in channels_to_delete:
-            if channel:
-                try:
-                    await channel.delete()
-                    deleted.append(channel.name)
-                except Exception:
-                    failed.append(channel.name)
-            else:
-                failed.append("Not found")
+        resolved = [ch for ch in channels_to_delete if ch]
+        not_found = len(channels_to_delete) - len(resolved)
+        result = await ChannelLifecycleService().apply(
+            ctx.guild,
+            ChannelLifecycleRequest(
+                operation="delete",
+                channel_ids=tuple(ch.id for ch in resolved),
+            ),
+            ctx.author,
+            confirmed=True,
+            actor_type="admin",
+        )
+        deleted = [s.target_name for s in result.applied]
+        failed = [s.target_name or "?" for s in result.failed]
+        failed += ["Not found"] * not_found
 
         response = ""
         if deleted:
@@ -266,11 +296,23 @@ class ChannelCog(commands.Cog):
     @is_admin_or_owner()
     async def delete_channel(self, ctx, channel_name: str):
         channel = self._resolve_channel(ctx.guild, channel_name)
-        if channel:
-            await channel.delete()
-            await ctx.send(f'Channel "{channel.name}" deleted.')
-        else:
+        if not channel:
             await ctx.send(f'Channel "{channel_name}" not found.')
+            return
+        name = channel.name
+        result = await ChannelLifecycleService().apply(
+            ctx.guild,
+            ChannelLifecycleRequest(operation="delete", channel_ids=(channel.id,)),
+            ctx.author,
+            confirmed=True,
+            actor_type="admin",
+        )
+        if result.outcome == SUCCESS:
+            await ctx.send(f'Channel "{name}" deleted.')
+        else:
+            await ctx.send(
+                f'❌ Could not delete "{name}": {self._channel_result_error(result)}',
+            )
 
     @commands.command(
         name="list",
@@ -330,11 +372,26 @@ class ChannelCog(commands.Cog):
     async def move_channel(self, ctx, channel_name: str, category_name: str):
         channel = self._resolve_channel(ctx.guild, channel_name)
         category = self._resolve_category(ctx.guild, category_name)
-        if channel and category:
-            await channel.edit(category=category)
-            await ctx.send(f'"{channel.name}" moved to "{category.name}".')
-        else:
+        if not (channel and category):
             await ctx.send("Channel or Category not found.")
+            return
+        name = channel.name
+        result = await ChannelLifecycleService().apply(
+            ctx.guild,
+            ChannelLifecycleRequest(
+                operation="move",
+                channel_ids=(channel.id,),
+                category_id=category.id,
+            ),
+            ctx.author,
+            actor_type="admin",
+        )
+        if result.outcome == SUCCESS:
+            await ctx.send(f'"{name}" moved to "{category.name}".')
+        else:
+            await ctx.send(
+                f'❌ Could not move "{name}": {self._channel_result_error(result)}',
+            )
 
     @commands.command(name="lock", help="Lock a channel. Usage: !lock <name|id>")
     @is_admin_or_owner()
@@ -402,12 +459,26 @@ class ChannelCog(commands.Cog):
     @is_admin_or_owner()
     async def rename_channel(self, ctx, old_name: str, new_name: str):
         channel = self._resolve_channel(ctx.guild, old_name)
-        if channel:
-            old = channel.name
-            await channel.edit(name=new_name)
+        if not channel:
+            await ctx.send(f'"{old_name}" not found.')
+            return
+        old = channel.name
+        result = await ChannelLifecycleService().apply(
+            ctx.guild,
+            ChannelLifecycleRequest(
+                operation="rename",
+                channel_ids=(channel.id,),
+                new_name=new_name,
+            ),
+            ctx.author,
+            actor_type="admin",
+        )
+        if result.outcome == SUCCESS:
             await ctx.send(f'"{old}" renamed to "{new_name}".')
         else:
-            await ctx.send(f'"{old_name}" not found.')
+            await ctx.send(
+                f'❌ Could not rename "{old}": {self._channel_result_error(result)}',
+            )
 
     @commands.command(
         name="permissions",

--- a/disbot/core/events_catalogue.py
+++ b/disbot/core/events_catalogue.py
@@ -76,6 +76,12 @@ KNOWN_EVENTS: frozenset[str] = frozenset(
         # drives cache consistency; subscriber failure is logged and
         # swallowed.
         "resource.provisioned",
+        # ── Channel lifecycle (services/channel_lifecycle_service.py, SM PR4)
+        # Advisory.  Emitted after a rename / move / delete apply (single or
+        # batch).  Payload: mutation_id, guild_id, operation, outcome,
+        # applied[], failed[], occurred_at.  Subscriber failure logged +
+        # swallowed; Discord state is authoritative.
+        "channel.lifecycle_changed",
         # ── Feature flags (services/rollout_mutation.py, Phase 2d PR-3) ───
         # Advisory events emitted after the DB commit + audit row land.
         # Subscriber failure is logged with mutation_id and never raised

--- a/disbot/services/channel_lifecycle_service.py
+++ b/disbot/services/channel_lifecycle_service.py
@@ -1,0 +1,323 @@
+"""Channel/category lifecycle service (server-management PR4).
+
+The canonical owner of the channel *change* operations that
+:class:`services.resource_provisioning.ResourceProvisioningPipeline` does not
+own — **rename**, **move** (to/from a category), and **delete** (single or
+batch).  Cogs and views authorise and render; every Discord mutation flows
+through here, returning a typed :class:`services.lifecycle.LifecycleResult`
+with per-channel :class:`services.lifecycle.StepResult` and a best-effort
+audit companion + ``channel.lifecycle_changed`` event.
+
+Boundaries (this PR):
+
+* Channel *creation* stays with ``utils.channels`` / the provisioning pipeline
+  (the no-silent-auto-create invariant owns that path); this service does not
+  create channels.
+* ``set_permissions``/overwrite changes and ``clone`` are a deliberate
+  follow-up — they keep their current cog paths until routed here in a later
+  PR, so the convergence invariant pins only ``.delete`` / ``.edit`` for now.
+
+Authorisation: the bot's Discord permission (``manage_channels``) is checked
+here; the *actor's* authority stays at the cog/view layer (the channel
+commands are already gated by ``is_admin_or_owner``), mirroring
+``services.moderation_service``.
+
+Reversibility: rename → reversible, move → compensatable, delete →
+irreversible (delete requires ``confirmed=True``; the typed command invocation
+is the operator's confirmation, exactly as provisioning treats an explicit
+selection).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+
+import discord
+
+from services.lifecycle import contracts as lc
+
+logger = logging.getLogger("bot.services.channel_lifecycle")
+
+DOMAIN = "channel"
+EVT_CHANNEL_LIFECYCLE = "channel.lifecycle_changed"
+
+_OPERATIONS = ("rename", "move", "delete")
+_REVERSIBILITY = {
+    "rename": lc.REVERSIBLE,
+    "move": lc.COMPENSATABLE,
+    "delete": lc.IRREVERSIBLE,
+}
+
+
+@dataclass(frozen=True)
+class ChannelLifecycleRequest:
+    """Typed request — one operation over one or more channels."""
+
+    operation: str  # "rename" | "move" | "delete"
+    channel_ids: tuple[int, ...]
+    new_name: str | None = None  # rename
+    category_id: int | None = None  # move (None = remove from category)
+    reason: str | None = None
+
+
+class ChannelLifecycleService:
+    """Stateless coordinator — one instance per request is fine."""
+
+    async def preview(
+        self,
+        guild: discord.Guild,
+        request: ChannelLifecycleRequest,
+    ) -> lc.LifecyclePreview:
+        """Describe what :meth:`apply` would do, with no side effects."""
+        if request.operation not in _OPERATIONS:
+            return lc.LifecyclePreview(
+                allowed=False,
+                operation=request.operation,
+                summary="",
+                reversibility="",
+                warnings=(f"unknown operation {request.operation!r}",),
+            )
+        reversibility = _REVERSIBILITY[request.operation]
+        warnings: list[str] = []
+        if not self._bot_can_manage(guild):
+            return lc.LifecyclePreview(
+                allowed=False,
+                operation=request.operation,
+                summary="",
+                reversibility=reversibility,
+                warnings=("bot lacks the Manage Channels permission",),
+            )
+        resolved = [guild.get_channel(cid) for cid in request.channel_ids]
+        missing = [
+            cid
+            for cid, ch in zip(request.channel_ids, resolved, strict=True)
+            if ch is None
+        ]
+        if missing:
+            warnings.append(f"{len(missing)} channel(s) no longer exist")
+        if request.operation == "delete":
+            warnings.append("deletion is irreversible — message history is lost")
+        summary = self._summary(request, tuple(s for s in resolved if s is not None))
+        return lc.LifecyclePreview(
+            allowed=any(ch is not None for ch in resolved),
+            operation=request.operation,
+            summary=summary,
+            reversibility=reversibility,
+            warnings=tuple(warnings),
+        )
+
+    async def apply(
+        self,
+        guild: discord.Guild,
+        request: ChannelLifecycleRequest,
+        actor: object | None,
+        *,
+        confirmed: bool = False,
+        actor_type: str = "user",
+    ) -> lc.LifecycleResult:
+        """Execute *request*; return a typed, audited result.
+
+        Irreversible operations (delete) require ``confirmed=True``.  Per-channel
+        Discord failures are captured as failed steps rather than raised, so a
+        batch records its actual final state.
+        """
+        operation = request.operation
+        if operation not in _OPERATIONS:
+            raise ValueError(f"unknown channel lifecycle operation {operation!r}")
+        reversibility = _REVERSIBILITY[operation]
+        mutation_id = str(uuid.uuid4())
+        actor_id = getattr(actor, "id", None) if actor is not None else None
+
+        if not self._bot_can_manage(guild):
+            return self._terminal(
+                mutation_id,
+                guild.id,
+                operation,
+                reversibility,
+                lc.BLOCKED,
+                "bot lacks the Manage Channels permission",
+            )
+
+        if reversibility == lc.IRREVERSIBLE and not confirmed:
+            return self._terminal(
+                mutation_id,
+                guild.id,
+                operation,
+                reversibility,
+                lc.DECLINED,
+                "irreversible operation requires confirmation",
+            )
+
+        steps: list[lc.StepResult] = []
+        for cid in request.channel_ids:
+            channel = guild.get_channel(cid)
+            if channel is None:
+                steps.append(lc.StepResult(cid, str(cid), False, "channel not found"))
+                continue
+            try:
+                await self._apply_one(guild, operation, channel, request)
+                steps.append(lc.StepResult(cid, channel.name, True))
+            except discord.Forbidden:
+                steps.append(
+                    lc.StepResult(cid, channel.name, False, "missing permission"),
+                )
+            except discord.HTTPException as exc:
+                steps.append(lc.StepResult(cid, channel.name, False, f"Discord: {exc}"))
+
+        steps_t = tuple(steps)
+        outcome = lc.classify_outcome(steps_t)
+        committed_at = lc.now_utc()
+        summary = self._summary(
+            request,
+            tuple(s for s in (guild.get_channel(c) for c in request.channel_ids) if s),
+            steps=steps_t,
+        )
+        audit_emitted = await lc.emit_lifecycle_audit(
+            mutation_id=mutation_id,
+            domain=DOMAIN,
+            operation=operation,
+            guild_id=guild.id,
+            target=self._target(request),
+            summary=summary,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            occurred_at=committed_at,
+        )
+        event_emitted = await self._emit_event(
+            mutation_id=mutation_id,
+            guild_id=guild.id,
+            operation=operation,
+            outcome=outcome,
+            steps=steps_t,
+            committed_at=committed_at,
+        )
+        return lc.LifecycleResult(
+            mutation_id=mutation_id,
+            guild_id=guild.id,
+            domain=DOMAIN,
+            operation=operation,
+            outcome=outcome,
+            reversibility=reversibility,
+            steps=steps_t,
+            committed_at=committed_at,
+            audit_emitted=audit_emitted,
+            event_emitted=event_emitted,
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _bot_can_manage(self, guild: discord.Guild) -> bool:
+        me = getattr(guild, "me", None)
+        perms = getattr(me, "guild_permissions", None)
+        return bool(getattr(perms, "manage_channels", False))
+
+    async def _apply_one(
+        self,
+        guild: discord.Guild,
+        operation: str,
+        channel: discord.abc.GuildChannel,
+        request: ChannelLifecycleRequest,
+    ) -> None:
+        reason = request.reason
+        if operation == "rename":
+            # .edit lives on the concrete channel subclasses, not the abc.
+            await channel.edit(name=request.new_name, reason=reason)  # type: ignore[attr-defined]
+        elif operation == "move":
+            from core.runtime import guild_resources
+
+            category = (
+                guild_resources.resolve_category(guild, category_id=request.category_id)
+                if request.category_id is not None
+                else None
+            )
+            await channel.edit(category=category, reason=reason)  # type: ignore[attr-defined]
+        elif operation == "delete":
+            await channel.delete(reason=reason)
+
+    def _target(self, request: ChannelLifecycleRequest) -> str:
+        if len(request.channel_ids) == 1:
+            return f"channel:{request.channel_ids[0]}"
+        return f"channels:{len(request.channel_ids)}"
+
+    def _summary(
+        self,
+        request: ChannelLifecycleRequest,
+        channels: tuple[discord.abc.GuildChannel, ...],
+        *,
+        steps: tuple[lc.StepResult, ...] | None = None,
+    ) -> str:
+        n = len(request.channel_ids)
+        if steps is not None:
+            applied = sum(1 for s in steps if s.ok)
+            suffix = f" ({applied}/{len(steps)} applied)"
+        else:
+            suffix = ""
+        if request.operation == "rename":
+            name = getattr(channels[0], "name", "?") if channels else "?"
+            return f"rename channel {name!r} → {request.new_name!r}{suffix}"
+        if request.operation == "move":
+            return f"move {n} channel(s) to category {request.category_id}{suffix}"
+        return f"delete {n} channel(s){suffix}"
+
+    def _terminal(
+        self,
+        mutation_id: str,
+        guild_id: int,
+        operation: str,
+        reversibility: str,
+        outcome: str,
+        reason: str,
+    ) -> lc.LifecycleResult:
+        return lc.LifecycleResult(
+            mutation_id=mutation_id,
+            guild_id=guild_id,
+            domain=DOMAIN,
+            operation=operation,
+            outcome=outcome,
+            reversibility=reversibility,
+            steps=(lc.StepResult(0, "", False, reason),),
+            committed_at=lc.now_utc(),
+        )
+
+    async def _emit_event(
+        self,
+        *,
+        mutation_id: str,
+        guild_id: int,
+        operation: str,
+        outcome: str,
+        steps: tuple[lc.StepResult, ...],
+        committed_at: object,
+    ) -> bool:
+        from core.events import bus
+
+        try:
+            await bus.emit(
+                EVT_CHANNEL_LIFECYCLE,
+                mutation_id=mutation_id,
+                guild_id=guild_id,
+                operation=operation,
+                outcome=outcome,
+                applied=[s.target_id for s in steps if s.ok],
+                failed=[s.target_id for s in steps if not s.ok],
+                occurred_at=getattr(committed_at, "isoformat", lambda: None)(),
+            )
+        except Exception:
+            logger.exception(
+                "ChannelLifecycleService._emit_event: emission failed for "
+                "mutation_id=%s; DB/Discord state is correct, event lost.",
+                mutation_id,
+            )
+            return False
+        return True
+
+
+__all__ = [
+    "EVT_CHANNEL_LIFECYCLE",
+    "ChannelLifecycleRequest",
+    "ChannelLifecycleService",
+]

--- a/disbot/services/lifecycle/__init__.py
+++ b/disbot/services/lifecycle/__init__.py
@@ -1,0 +1,45 @@
+"""Shared lifecycle-mutation primitives (server-management PR3).
+
+The reusable request / preview / result / reversibility / audit contract that
+coordinated domain lifecycle services (channels, roles) build on — the same
+shape :class:`services.resource_provisioning.ResourceProvisioningPipeline`
+already uses for create/reuse, generalised for rename / move / delete /
+overwrite / reorder operations that provisioning does not own.
+
+See :mod:`services.lifecycle.contracts` for the types.  The first consumer is
+:class:`services.channel_lifecycle_service.ChannelLifecycleService`.
+"""
+
+from __future__ import annotations
+
+from services.lifecycle.contracts import (
+    BLOCKED,
+    COMPENSATABLE,
+    DECLINED,
+    DISCORD_FAILED,
+    IRREVERSIBLE,
+    PARTIAL,
+    REVERSIBLE,
+    SUCCESS,
+    LifecyclePreview,
+    LifecycleResult,
+    StepResult,
+    emit_lifecycle_audit,
+    now_utc,
+)
+
+__all__ = [
+    "BLOCKED",
+    "COMPENSATABLE",
+    "DECLINED",
+    "DISCORD_FAILED",
+    "IRREVERSIBLE",
+    "PARTIAL",
+    "REVERSIBLE",
+    "SUCCESS",
+    "LifecyclePreview",
+    "LifecycleResult",
+    "StepResult",
+    "emit_lifecycle_audit",
+    "now_utc",
+]

--- a/disbot/services/lifecycle/contracts.py
+++ b/disbot/services/lifecycle/contracts.py
@@ -1,0 +1,165 @@
+"""Lifecycle mutation contract — request / preview / result / reversibility.
+
+Generalises the :class:`services.resource_provisioning.ResourceProvisioningPipeline`
+contract for the *change* operations provisioning does not own (rename, move,
+delete, overwrite, reorder).  A coordinated domain service (channels, roles)
+builds a typed request, exposes a side-effect-free :class:`LifecyclePreview`,
+then performs an ordered apply whose outcome is a :class:`LifecycleResult`
+carrying a per-target :class:`StepResult` list and a reversibility class.
+
+Reversibility is honest about Discord's lack of transactions:
+
+* **reversible** — restoring a prior name/category while permissions remain
+  (e.g. rename).
+* **compensatable** — undoable by a follow-up mutation, without a transaction
+  guarantee (e.g. move back to the original category).
+* **irreversible** — deleting a channel/role; the id and external references
+  are gone, so recreation is never "rollback".
+
+Audit follows the platform standard: a best-effort ``audit.action_recorded``
+companion (via :func:`services.audit_events.emit_audit_action`) plus a
+domain-owned catalogued event emitted by the service.  This module owns only
+the shared companion helper and the typed result shapes; the domain event name
+and the Discord calls live in the domain service.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from services.audit_events import emit_audit_action
+
+logger = logging.getLogger("bot.services.lifecycle")
+
+# ---------------------------------------------------------------------------
+# Reversibility classes
+# ---------------------------------------------------------------------------
+
+REVERSIBLE = "reversible"
+COMPENSATABLE = "compensatable"
+IRREVERSIBLE = "irreversible"
+
+# ---------------------------------------------------------------------------
+# Outcomes — a partial Discord batch is never a transaction.
+# ---------------------------------------------------------------------------
+
+SUCCESS = "success"  # every step applied
+PARTIAL = "partial"  # some steps applied, some failed
+BLOCKED = "blocked"  # bot lacked permission / feasibility — nothing attempted
+DECLINED = "declined"  # confirmation required for an irreversible op, not given
+DISCORD_FAILED = "discord_failed"  # every attempted step failed at the API
+
+
+@dataclass(frozen=True)
+class StepResult:
+    """Outcome of one target within a (possibly batched) operation."""
+
+    target_id: int
+    target_name: str
+    ok: bool
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class LifecyclePreview:
+    """What an apply *would* do, with no side effects."""
+
+    allowed: bool
+    operation: str
+    summary: str
+    reversibility: str
+    warnings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LifecycleResult:
+    """Outcome of a lifecycle apply."""
+
+    mutation_id: str
+    guild_id: int
+    domain: str
+    operation: str
+    outcome: str
+    reversibility: str
+    steps: tuple[StepResult, ...] = field(default_factory=tuple)
+    committed_at: datetime | None = None
+    audit_emitted: bool = False
+    event_emitted: bool = False
+
+    @property
+    def applied(self) -> tuple[StepResult, ...]:
+        return tuple(s for s in self.steps if s.ok)
+
+    @property
+    def failed(self) -> tuple[StepResult, ...]:
+        return tuple(s for s in self.steps if not s.ok)
+
+
+def classify_outcome(steps: tuple[StepResult, ...]) -> str:
+    """Map per-step results to a batch :data:`SUCCESS`/:data:`PARTIAL`/…."""
+    if not steps:
+        return DISCORD_FAILED
+    ok = sum(1 for s in steps if s.ok)
+    if ok == len(steps):
+        return SUCCESS
+    if ok == 0:
+        return DISCORD_FAILED
+    return PARTIAL
+
+
+def now_utc() -> datetime:
+    """Return a tz-aware "now" — INV-N forbids bare datetime.utcnow."""
+    return datetime.now(timezone.utc)
+
+
+async def emit_lifecycle_audit(
+    *,
+    mutation_id: str,
+    domain: str,
+    operation: str,
+    guild_id: int,
+    target: str,
+    summary: str,
+    actor_id: int | None,
+    actor_type: str,
+    occurred_at: datetime,
+) -> bool:
+    """Best-effort ``audit.action_recorded`` companion for a lifecycle apply.
+
+    Wraps :func:`services.audit_events.emit_audit_action` with the lifecycle
+    field mapping; the helper is failure-safe (returns ``False`` on bus error)
+    so a dropped audit event never invalidates the Discord mutation.
+    """
+    return await emit_audit_action(
+        mutation_id=mutation_id,
+        subsystem=domain,
+        mutation_type=f"{domain}_{operation}",
+        target=target,
+        scope="guild",
+        guild_id=guild_id,
+        prev_value=None,
+        new_value=summary,
+        actor_id=actor_id,
+        actor_type=actor_type,
+        occurred_at=occurred_at,
+    )
+
+
+__all__ = [
+    "BLOCKED",
+    "COMPENSATABLE",
+    "DECLINED",
+    "DISCORD_FAILED",
+    "IRREVERSIBLE",
+    "PARTIAL",
+    "REVERSIBLE",
+    "SUCCESS",
+    "LifecyclePreview",
+    "LifecycleResult",
+    "StepResult",
+    "classify_outcome",
+    "emit_lifecycle_audit",
+    "now_utc",
+]

--- a/tests/unit/invariants/test_no_direct_channel_mutations.py
+++ b/tests/unit/invariants/test_no_direct_channel_mutations.py
@@ -1,0 +1,64 @@
+"""Channel-lifecycle convergence invariant (server-management PR4).
+
+The ``ChannelCog`` command surface must route channel *mutations* through
+``services.channel_lifecycle_service.ChannelLifecycleService`` — no direct
+``channel.delete()`` / ``channel.edit()`` in the cog.
+
+Scope notes:
+
+* Only the ``ChannelCog`` class body is scanned, so the sibling
+  ``_ChannelListPaginatorView`` (which legitimately calls ``self.message.edit``
+  on a *message*, not a channel) is not a false positive.
+* Only ``.delete`` / ``.edit`` are pinned in this PR — the operations routed
+  through the service.  ``.clone`` and ``.set_permissions`` (overwrites) and
+  channel *creation* keep their current paths and will be pinned when routed
+  in a later PR.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CHANNEL_COG = _REPO_ROOT / "disbot" / "cogs" / "channel_cog.py"
+
+# Channel mutations routed through ChannelLifecycleService in this PR.
+_FORBIDDEN = {"delete", "edit"}
+
+
+def _channel_cog_class(tree: ast.AST) -> ast.ClassDef | None:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "ChannelCog":
+            return node
+    return None
+
+
+def _forbidden_calls(node: ast.AST) -> list[str]:
+    found: list[str] = []
+    for n in ast.walk(node):
+        if (
+            isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Attribute)
+            and n.func.attr in _FORBIDDEN
+        ):
+            found.append(f".{n.func.attr}() @ line {n.lineno}")
+    return found
+
+
+def test_channel_cog_routes_mutations_through_service():
+    tree = ast.parse(_CHANNEL_COG.read_text(), filename=str(_CHANNEL_COG))
+    cls = _channel_cog_class(tree)
+    assert cls is not None, "ChannelCog class not found — did the layout change?"
+    violations = _forbidden_calls(cls)
+    assert not violations, (
+        "Channel-lifecycle violation: ChannelCog performs direct channel "
+        "mutations instead of routing through ChannelLifecycleService:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+def test_channel_cog_imports_the_service():
+    """Positive check — the cog actually wires the service it must use."""
+    src = _CHANNEL_COG.read_text()
+    assert "ChannelLifecycleService" in src

--- a/tests/unit/services/test_channel_lifecycle_service.py
+++ b/tests/unit/services/test_channel_lifecycle_service.py
@@ -1,0 +1,209 @@
+"""Tests for services.channel_lifecycle_service (server-management PR4)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from core.events_catalogue import KNOWN_EVENTS
+from services.channel_lifecycle_service import (
+    EVT_CHANNEL_LIFECYCLE,
+    ChannelLifecycleRequest,
+    ChannelLifecycleService,
+)
+from services.lifecycle import (
+    BLOCKED,
+    COMPENSATABLE,
+    DECLINED,
+    IRREVERSIBLE,
+    PARTIAL,
+    REVERSIBLE,
+    SUCCESS,
+)
+
+
+def _channel(cid, name="general", *, fail=None):
+    ch = MagicMock()
+    ch.id = cid
+    ch.name = name
+    ch.edit = AsyncMock(side_effect=fail)
+    ch.delete = AsyncMock(side_effect=fail)
+    return ch
+
+
+def _guild(channels=None, *, manage_channels=True, guild_id=1):
+    chans = {c.id: c for c in (channels or [])}
+    guild = MagicMock()
+    guild.id = guild_id
+    guild.me = SimpleNamespace(
+        guild_permissions=SimpleNamespace(manage_channels=manage_channels),
+    )
+    guild.get_channel.side_effect = lambda cid: chans.get(cid)
+    return guild
+
+
+def _actor(uid=99):
+    return SimpleNamespace(id=uid)
+
+
+@pytest.fixture(autouse=True)
+def _no_side_effects():
+    with (
+        patch(
+            "services.lifecycle.contracts.emit_lifecycle_audit",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as audit,
+        patch("core.events.bus.emit", new_callable=AsyncMock) as event,
+    ):
+        yield SimpleNamespace(audit=audit, event=event)
+
+
+@pytest.fixture
+def svc():
+    return ChannelLifecycleService()
+
+
+def test_event_is_catalogued():
+    assert EVT_CHANNEL_LIFECYCLE in KNOWN_EVENTS
+
+
+@pytest.mark.asyncio
+async def test_rename_calls_edit_and_succeeds(svc):
+    ch = _channel(10, "old")
+    guild = _guild([ch])
+    result = await svc.apply(
+        guild,
+        ChannelLifecycleRequest(operation="rename", channel_ids=(10,), new_name="new"),
+        _actor(),
+    )
+    ch.edit.assert_awaited_once_with(name="new", reason=None)
+    assert result.outcome == SUCCESS
+    assert result.reversibility == REVERSIBLE
+
+
+@pytest.mark.asyncio
+async def test_move_calls_edit_with_resolved_category(svc):
+    ch = _channel(10, "general")
+    guild = _guild([ch])
+    category = MagicMock()
+    with patch(
+        "core.runtime.guild_resources.resolve_category",
+        return_value=category,
+    ):
+        result = await svc.apply(
+            guild,
+            ChannelLifecycleRequest(
+                operation="move",
+                channel_ids=(10,),
+                category_id=55,
+            ),
+            _actor(),
+        )
+    ch.edit.assert_awaited_once_with(category=category, reason=None)
+    assert result.outcome == SUCCESS
+    assert result.reversibility == COMPENSATABLE
+
+
+@pytest.mark.asyncio
+async def test_delete_requires_confirmation(svc):
+    ch = _channel(10)
+    guild = _guild([ch])
+    result = await svc.apply(
+        guild,
+        ChannelLifecycleRequest(operation="delete", channel_ids=(10,)),
+        _actor(),
+        confirmed=False,
+    )
+    assert result.outcome == DECLINED
+    assert result.reversibility == IRREVERSIBLE
+    ch.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_confirmed_succeeds(svc):
+    ch = _channel(10, "to-go")
+    guild = _guild([ch])
+    result = await svc.apply(
+        guild,
+        ChannelLifecycleRequest(operation="delete", channel_ids=(10,)),
+        _actor(),
+        confirmed=True,
+    )
+    ch.delete.assert_awaited_once()
+    assert result.outcome == SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_blocked_when_bot_cannot_manage(svc):
+    ch = _channel(10)
+    guild = _guild([ch], manage_channels=False)
+    result = await svc.apply(
+        guild,
+        ChannelLifecycleRequest(operation="delete", channel_ids=(10,)),
+        _actor(),
+        confirmed=True,
+    )
+    assert result.outcome == BLOCKED
+    ch.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_batch_delete_partial_failure(svc):
+    ok = _channel(1, "ok")
+    bad = _channel(2, "bad", fail=discord.Forbidden(MagicMock(), "no perms"))
+    guild = _guild([ok, bad])
+    result = await svc.apply(
+        guild,
+        ChannelLifecycleRequest(operation="delete", channel_ids=(1, 2)),
+        _actor(),
+        confirmed=True,
+    )
+    assert result.outcome == PARTIAL
+    assert [s.target_id for s in result.applied] == [1]
+    assert [s.target_id for s in result.failed] == [2]
+
+
+@pytest.mark.asyncio
+async def test_missing_channel_becomes_failed_step(svc):
+    guild = _guild([])  # id 10 not present
+    result = await svc.apply(
+        guild,
+        ChannelLifecycleRequest(operation="rename", channel_ids=(10,), new_name="x"),
+        _actor(),
+    )
+    assert result.failed and result.failed[0].error == "channel not found"
+
+
+@pytest.mark.asyncio
+async def test_emits_audit_and_event_with_shared_mutation_id(svc, _no_side_effects):
+    ch = _channel(10, "general")
+    guild = _guild([ch])
+    result = await svc.apply(
+        guild,
+        ChannelLifecycleRequest(operation="rename", channel_ids=(10,), new_name="new"),
+        _actor(),
+    )
+    _no_side_effects.audit.assert_awaited_once()
+    _no_side_effects.event.assert_awaited_once()
+    assert _no_side_effects.audit.await_args.kwargs["mutation_id"] == result.mutation_id
+    assert _no_side_effects.event.await_args.kwargs["mutation_id"] == result.mutation_id
+    assert _no_side_effects.event.await_args.args[0] == EVT_CHANNEL_LIFECYCLE
+
+
+@pytest.mark.asyncio
+async def test_preview_is_side_effect_free(svc):
+    ch = _channel(10, "general")
+    guild = _guild([ch])
+    preview = await svc.preview(
+        guild,
+        ChannelLifecycleRequest(operation="delete", channel_ids=(10,)),
+    )
+    assert preview.allowed is True
+    assert preview.reversibility == IRREVERSIBLE
+    assert any("irreversible" in w for w in preview.warnings)
+    ch.delete.assert_not_awaited()
+    ch.edit.assert_not_awaited()

--- a/tests/unit/services/test_lifecycle_contracts.py
+++ b/tests/unit/services/test_lifecycle_contracts.py
@@ -1,0 +1,37 @@
+"""Tests for services.lifecycle.contracts (server-management PR3)."""
+
+from __future__ import annotations
+
+from services.lifecycle import contracts as lc
+
+
+def test_classify_all_ok_is_success():
+    steps = (lc.StepResult(1, "a", True), lc.StepResult(2, "b", True))
+    assert lc.classify_outcome(steps) == lc.SUCCESS
+
+
+def test_classify_some_ok_is_partial():
+    steps = (lc.StepResult(1, "a", True), lc.StepResult(2, "b", False, "x"))
+    assert lc.classify_outcome(steps) == lc.PARTIAL
+
+
+def test_classify_none_ok_is_discord_failed():
+    assert lc.classify_outcome((lc.StepResult(1, "a", False, "x"),)) == lc.DISCORD_FAILED
+
+
+def test_classify_empty_is_discord_failed():
+    assert lc.classify_outcome(()) == lc.DISCORD_FAILED
+
+
+def test_result_applied_and_failed_partition():
+    result = lc.LifecycleResult(
+        mutation_id="m",
+        guild_id=1,
+        domain="channel",
+        operation="delete",
+        outcome=lc.PARTIAL,
+        reversibility=lc.IRREVERSIBLE,
+        steps=(lc.StepResult(1, "a", True), lc.StepResult(2, "b", False, "x")),
+    )
+    assert [s.target_id for s in result.applied] == [1]
+    assert [s.target_id for s in result.failed] == [2]


### PR DESCRIPTION
## Summary

The shared **lifecycle-mutation foundation** (PR3) landing with its **first consumer** (PR4), per the plan's "extract the primitive *with* a real consumer" rule.

### PR3 — the contract (`services/lifecycle/`)
Generalises the proven `ResourceProvisioningPipeline` shape for the *change* operations provisioning doesn't own:
- `StepResult` / `LifecyclePreview` / `LifecycleResult` (frozen, typed).
- **Reversibility vocabulary** — `reversible` / `compensatable` / `irreversible` (honest about Discord's lack of transactions; recreating a deleted resource is never "rollback").
- **Outcome classifier** — `success` / `partial` / `blocked` / `declined` / `discord_failed`.
- `emit_lifecycle_audit` — best-effort `audit.action_recorded` companion (mirrors the moderation three-signal pattern).
- New catalogued event `channel.lifecycle_changed`.

### PR4 — first consumer (`services/channel_lifecycle_service.py`)
`ChannelLifecycleService` is the canonical owner of channel **rename / move / delete** (single + batch). It:
- checks the bot's **Manage Channels** permission (actor authority stays at the cog, as with `moderation_service`);
- requires `confirmed=True` for irreversible deletes (the typed command invocation *is* the confirmation, exactly as provisioning treats an explicit selection);
- captures per-channel Discord failures as **failed steps** rather than raising, so a batch records its actual final state (partial-failure reporting);
- emits the audit companion + domain event sharing one `mutation_id`.

The `channel_cog` typed commands — `delete`, `bulkdelete`, `move`, `rename`, and `evt …delete` — now route through it. **User-facing messages are preserved**; previously-unhandled Discord failures now degrade gracefully instead of crashing the command.

## Invariant

`tests/unit/invariants/test_no_direct_channel_mutations.py` pins the **`ChannelCog` class body** against direct `channel.delete()` / `channel.edit()` — scoped to the class so the sibling paginator's legitimate `self.message.edit` is not a false positive.

## Scope discipline

`clone`, `set_permissions`/overwrites, and channel **creation** (owned by `utils.channels` / the provisioning pipeline + the no-silent-auto-create invariant) keep their current paths and are **explicit follow-ups** — so this PR routes exactly the `.delete`/`.edit` operations the invariant now pins, no more. The move/reorder *panel UI* and first-class category management remain PR7.

## Tests

- `test_lifecycle_contracts.py` — outcome classification + applied/failed partition.
- `test_channel_lifecycle_service.py` — rename/move/delete dispatch, confirmation gate, bot-permission block, **batch partial-failure**, missing-channel step, audit+event with shared `mutation_id`, side-effect-free preview.
- `test_no_direct_channel_mutations.py` — the convergence invariant.

## Verification

- `python3.10 scripts/check_architecture.py --mode strict` → exit 0, 0 errors, no findings for the new files.
- `python3.10 scripts/check_quality.py --full` → black/isort/ruff + mypy + **7412 passed, 3 skipped**.

## Next

PR5 — the **role lifecycle service** + non-destructive time/XP threshold semantics + role-ID groundwork, consuming PR2's `role_feasibility` and this PR's lifecycle contract. Happy to continue or pause here.

https://claude.ai/code/session_014enNntBBfyuui1Fmm46DqE

---
_Generated by [Claude Code](https://claude.ai/code/session_014enNntBBfyuui1Fmm46DqE)_