### PR TITLE
feat(roles): dynamic time/XP role config + role-id dual-read (PR6)

### DIFF
--- a/disbot/cogs/role_cog.py
+++ b/disbot/cogs/role_cog.py
@@ -129,7 +129,7 @@ class RoleHubPanelView(PersistentView):
             return
         from views.roles.time_roles_panel import TimeRolesPanel
 
-        await _ensure_defaults(interaction.guild.id)
+        await _ensure_defaults(interaction.guild)
         self.message = interaction.message
         panel = TimeRolesPanel(_CtxAdapter(interaction), parent=self)
         panel.message = interaction.message
@@ -281,7 +281,7 @@ class RoleCog(commands.Cog):
         the guild-wide batch shares logic with
         :meth:`on_member_join`.
         """
-        await _ensure_defaults(guild.id)
+        await _ensure_defaults(guild)
         thresholds = await db.get_role_thresholds(guild.id)
         if not thresholds:
             if ctx:
@@ -297,6 +297,7 @@ class RoleCog(commands.Cog):
             role_automation.RoleThreshold(
                 role_name=row["role_name"],
                 days_required=row["days_required"],
+                role_id=row.get("role_id"),
             )
             for row in thresholds
             # XP reward roles (xp_auto_assign) are granted by the XP listener
@@ -601,7 +602,7 @@ class RoleCog(commands.Cog):
     async def on_member_join(self, member: discord.Member) -> None:
         if member.bot:
             return
-        await _ensure_defaults(member.guild.id)
+        await _ensure_defaults(member.guild)
         thresholds = await db.get_role_thresholds(member.guild.id)
         if not thresholds:
             return
@@ -610,6 +611,7 @@ class RoleCog(commands.Cog):
             role_automation.RoleThreshold(
                 role_name=row["role_name"],
                 days_required=row["days_required"],
+                role_id=row.get("role_id"),
             )
             for row in thresholds
             # XP reward roles (xp_auto_assign) are granted by the XP listener

--- a/disbot/cogs/xp/listener.py
+++ b/disbot/cogs/xp/listener.py
@@ -205,7 +205,13 @@ async def _apply_xp_threshold_roles(
         qualifying: list = []  # earned roles (level_required <= new_level)
         configured: list = []  # every configured XP role that resolves
         for role_cfg in xp_roles:
-            discord_role = resources.resolve_role(guild, name=role_cfg["role_name"])
+            # Id-first (PR6 migration 056), normalized-name fallback for legacy
+            # rows — a renamed role keeps its XP tier.
+            discord_role = resources.resolve_role(
+                guild,
+                role_id=role_cfg.get("role_id"),
+                name=role_cfg["role_name"],
+            )
             if discord_role is None:
                 continue
             configured.append(discord_role)

--- a/disbot/migrations/056_role_threshold_role_id.sql
+++ b/disbot/migrations/056_role_threshold_role_id.sql
@@ -1,0 +1,38 @@
+-- Migration 056: role-id groundwork for role_thresholds (server-management PR6).
+--
+-- The time/XP role-automation table ``role_thresholds`` is keyed by
+-- ``(guild_id, role_name)`` and matched against the guild's roles by name.
+-- A role rename silently orphans its threshold, and the free-text "Add" modal
+-- could persist a name for a role that does not exist.
+--
+-- This migration lays the ID groundwork (the original PR5 deferral, landed with
+-- its PR6 selector consumer): two **nullable, additive** columns.
+--
+-- Schema
+-- ------
+-- role_thresholds (existing PK: guild_id, role_name)
+--   role_id       Discord role id captured at configuration time.  Lets the
+--                 readers resolve the role id-first (surviving a rename) and the
+--                 panels diagnose a stale row whose role no longer exists.
+--                 NULL for legacy rows written before the selector UI.
+--   display_name  Snapshot of the role's name at configuration time, for stale
+--                 diagnostics ("stored as X, now Y / gone").  NULL for legacy.
+--
+-- Backward compatibility
+-- ----------------------
+-- Purely additive: existing name-only rows keep working (both columns NULL).
+-- The dual-read is ID-first with a normalized-name fallback, so a NULL role_id
+-- resolves exactly as before.  No destructive name -> id flip happens here; the
+-- PK stays (guild_id, role_name).
+--
+-- Rollback
+-- --------
+-- ALTER TABLE role_thresholds DROP COLUMN IF EXISTS role_id, DROP COLUMN IF
+-- EXISTS display_name;  (Reverting the consuming code without this is harmless —
+-- the columns are simply unread.)
+--
+-- Forward-only and idempotent.
+
+ALTER TABLE role_thresholds
+    ADD COLUMN IF NOT EXISTS role_id BIGINT DEFAULT NULL,
+    ADD COLUMN IF NOT EXISTS display_name TEXT DEFAULT NULL;

--- a/disbot/services/role_automation.py
+++ b/disbot/services/role_automation.py
@@ -49,10 +49,16 @@ logger = logging.getLogger("bot.services.role_automation")
 
 @dataclass(frozen=True)
 class RoleThreshold:
-    """One progression row: ``role_name`` requires ``days_required``."""
+    """One progression row: ``role_name`` requires ``days_required``.
+
+    ``role_id`` (PR6 id-groundwork, migration 056) lets the engine resolve the
+    tier id-first so a role rename never silently orphans it; ``None`` for legacy
+    name-only rows, which fall back to normalized-name resolution.
+    """
 
     role_name: str
     days_required: int
+    role_id: int | None = None
 
 
 @dataclass(frozen=True)
@@ -115,6 +121,22 @@ def _resolve_role(guild: Any, name: str) -> Any | None:
     return None
 
 
+def _resolve_threshold_role(guild: Any, threshold: RoleThreshold) -> Any | None:
+    """Resolve a threshold to its current role — id-first, then normalized name.
+
+    Iterating ``guild.roles`` (never ``guild.get_role``) keeps the cache-only
+    contract and the no-raw-lookup invariant.  Id-first means a renamed role
+    still resolves to the same tier; ``role_id=None`` (legacy rows) falls back to
+    the name lookup, preserving the pre-PR6 behavior exactly.
+    """
+    rid = getattr(threshold, "role_id", None)
+    if rid is not None:
+        for role in getattr(guild, "roles", ()) or ():
+            if getattr(role, "id", None) == rid:
+                return role
+    return _resolve_role(guild, threshold.role_name)
+
+
 def compute_assignments(
     guild: Any,
     thresholds: list[RoleThreshold] | tuple[RoleThreshold, ...],
@@ -139,7 +161,20 @@ def compute_assignments(
     if not thresholds:
         return ()
 
-    role_map = {t.role_name: t.days_required for t in thresholds}
+    # Resolve each tier to its CURRENT role id-first (name fallback), then key
+    # the progression by the resolved current name.  This makes a renamed role
+    # keep its tier (the id resolves, and member roles match on the current
+    # name), while legacy name-only rows behave exactly as before.  Tiers whose
+    # role no longer exists are dropped — they could never assign anything.
+    resolved = [
+        (role, t.days_required)
+        for t in thresholds
+        if (role := _resolve_threshold_role(guild, t)) is not None
+    ]
+    if not resolved:
+        return ()
+    role_map = {role.name: days for role, days in resolved}
+    role_by_name = {role.name: role for role, _ in resolved}
     progression = sorted(role_map, key=lambda r: role_map[r])
 
     out: list[Assignment] = []
@@ -162,7 +197,7 @@ def compute_assignments(
             if days >= role_map[name]:
                 target_name = name
 
-        target_role = _resolve_role(guild, target_name) if target_name else None
+        target_role = role_by_name.get(target_name) if target_name else None
         member_roles = list(getattr(member, "roles", ()) or ())
 
         # Walk through member's existing roles, find any that belong

--- a/disbot/utils/db/roles.py
+++ b/disbot/utils/db/roles.py
@@ -18,19 +18,40 @@ from utils.db import pool
 
 async def get_role_thresholds(guild_id: int) -> list[dict]:
     return await pool.fetchall(
-        "SELECT role_name, days_required, level_required, xp_auto_assign "
+        "SELECT role_name, days_required, level_required, xp_auto_assign, "
+        "role_id, display_name "
         "FROM role_thresholds WHERE guild_id=$1 ORDER BY days_required",
         (guild_id,),
     )
 
 
-async def set_role_threshold(guild_id: int, role_name: str, days: int) -> None:
+async def set_role_threshold(
+    guild_id: int,
+    role_name: str,
+    days: int,
+    *,
+    role_id: int | None = None,
+    display_name: str | None = None,
+) -> None:
+    """Upsert the time tier for a role threshold.
+
+    ``role_id`` / ``display_name`` are the PR6 id-groundwork (migration 056):
+    when supplied (selector-driven writes) they are stored so readers can resolve
+    the role id-first and panels can diagnose stale rows.  On conflict they are
+    ``COALESCE``-preserved, so a later name-only or XP-only update never wipes a
+    previously-captured id.
+    """
     await pool.execute(
-        """INSERT INTO role_thresholds (guild_id, role_name, days_required)
-           VALUES ($1, $2, $3)
-           ON CONFLICT (guild_id, role_name)
-             DO UPDATE SET days_required=EXCLUDED.days_required""",
-        (guild_id, role_name, days),
+        """INSERT INTO role_thresholds
+               (guild_id, role_name, days_required, role_id, display_name)
+           VALUES ($1, $2, $3, $4, $5)
+           ON CONFLICT (guild_id, role_name) DO UPDATE SET
+               days_required = EXCLUDED.days_required,
+               role_id = COALESCE(EXCLUDED.role_id, role_thresholds.role_id),
+               display_name = COALESCE(
+                   EXCLUDED.display_name, role_thresholds.display_name
+               )""",
+        (guild_id, role_name, days, role_id, display_name),
     )
 
 
@@ -90,7 +111,8 @@ async def clear_role_xp_threshold(guild_id: int, role_name: str) -> None:
 async def get_xp_threshold_roles(guild_id: int) -> list[dict]:
     """Rows with xp_auto_assign=TRUE and a configured level_required."""
     return await pool.fetchall(
-        "SELECT role_name, level_required FROM role_thresholds "
+        "SELECT role_name, level_required, role_id, display_name "
+        "FROM role_thresholds "
         "WHERE guild_id=$1 AND xp_auto_assign=TRUE AND level_required IS NOT NULL "
         "ORDER BY level_required",
         (guild_id,),
@@ -102,21 +124,31 @@ async def set_role_xp_threshold(
     role_name: str,
     level_required: int | None,
     auto_assign: bool,
+    *,
+    role_id: int | None = None,
+    display_name: str | None = None,
 ) -> None:
     """Upsert the XP automation columns for a role threshold row.
 
     If no row exists for (guild_id, role_name), inserts one with
     days_required=0.  Only updates the XP columns; existing
-    days_required is preserved on conflict.
+    days_required is preserved on conflict.  ``role_id`` / ``display_name`` are
+    the PR6 id-groundwork (migration 056), ``COALESCE``-preserved on conflict so
+    a name-only or time-only update never wipes a previously-captured id.
     """
     await pool.execute(
         """INSERT INTO role_thresholds
-               (guild_id, role_name, days_required, level_required, xp_auto_assign)
-           VALUES ($1, $2, 0, $3, $4)
+               (guild_id, role_name, days_required, level_required, xp_auto_assign,
+                role_id, display_name)
+           VALUES ($1, $2, 0, $3, $4, $5, $6)
            ON CONFLICT (guild_id, role_name) DO UPDATE SET
                level_required = EXCLUDED.level_required,
-               xp_auto_assign = EXCLUDED.xp_auto_assign""",
-        (guild_id, role_name, level_required, auto_assign),
+               xp_auto_assign = EXCLUDED.xp_auto_assign,
+               role_id = COALESCE(EXCLUDED.role_id, role_thresholds.role_id),
+               display_name = COALESCE(
+                   EXCLUDED.display_name, role_thresholds.display_name
+               )""",
+        (guild_id, role_name, level_required, auto_assign, role_id, display_name),
     )
 
 

--- a/disbot/views/roles/_helpers.py
+++ b/disbot/views/roles/_helpers.py
@@ -45,14 +45,32 @@ _COLOR_OPTIONS = [
 ]
 
 
-async def _ensure_defaults(guild_id: int) -> None:
-    """Seed default time-based thresholds for a guild that has none yet."""
+async def _ensure_defaults(guild: discord.Guild) -> None:
+    """Seed default time tiers for a guild that has none yet — *suggestions only*.
+
+    PR6: only a default whose named role **actually exists** is seeded (capturing
+    its ``role_id`` + name snapshot), so this path never persists a threshold for
+    a nonexistent role.  A brand-new guild without the default-named roles is left
+    empty; operators add tiers via the selector or the panel's "Seed Defaults"
+    button.  Accepts the guild (not just its id) to resolve role existence.
+    """
+    from core.runtime import resources
     from utils import db
 
-    existing = await db.get_role_thresholds(guild_id)
-    if not existing:
-        for name, days in _DEFAULT_THRESHOLDS:
-            await db.set_role_threshold(guild_id, name, days)
+    existing = await db.get_role_thresholds(guild.id)
+    if existing:
+        return
+    for name, days in _DEFAULT_THRESHOLDS:
+        role = resources.resolve_role(guild, name=name)
+        if role is None:
+            continue
+        await db.set_role_threshold(
+            guild.id,
+            role.name,
+            days,
+            role_id=role.id,
+            display_name=role.name,
+        )
 
 
 def _parse_color(value: str) -> discord.Color:

--- a/disbot/views/roles/main_panel.py
+++ b/disbot/views/roles/main_panel.py
@@ -83,7 +83,7 @@ class RoleHubView(BaseView):
             return
         from views.roles.time_roles_panel import TimeRolesPanel
 
-        await _ensure_defaults(interaction.guild.id)
+        await _ensure_defaults(interaction.guild)
         panel = TimeRolesPanel(self.ctx, parent=self)
         panel.message = self.message
         await interaction.response.edit_message(

--- a/disbot/views/roles/time_roles_panel.py
+++ b/disbot/views/roles/time_roles_panel.py
@@ -3,13 +3,28 @@ from __future__ import annotations
 import discord
 from discord.ext import commands
 
+from core.runtime import resources
 from core.runtime.interaction_helpers import safe_defer
 from utils import db
 from utils.guild_config_accessors import invalidate_xp_threshold_roles
 from utils.ui_constants import ROLE_COLOR
 from views.base import BaseView
 from views.navigation import attach_back_button
-from views.roles._helpers import _DEFAULT_THRESHOLDS, _find_role_normalized
+from views.roles._helpers import _DEFAULT_THRESHOLDS
+from views.selectors import RoleSelector
+
+
+def _row_is_stale(guild: discord.Guild, row: dict) -> bool:
+    """True if a threshold row's role can no longer be resolved.
+
+    Id-first (PR6 migration 056): a row that stored a ``role_id`` is stale only
+    when that id no longer resolves (a rename is fine — the id still resolves).
+    Legacy rows (no id) fall back to a name lookup.
+    """
+    rid = row.get("role_id")
+    if rid is not None:
+        return resources.resolve_role(guild, role_id=rid) is None
+    return resources.resolve_role(guild, name=row["role_name"]) is None
 
 
 class TimeRolesPanel(BaseView):
@@ -39,14 +54,27 @@ class TimeRolesPanel(BaseView):
         thresholds = await db.get_role_thresholds(self.ctx.guild.id)
         embed = discord.Embed(title="⏱️ Time-Based Roles", color=ROLE_COLOR)
         if thresholds:
-            lines = [
-                f"**{r['role_name']}** — {r['days_required']} day(s)"
-                for r in thresholds
-            ]
+            lines = []
+            stale_any = False
+            for r in thresholds:
+                stale = _row_is_stale(self.ctx.guild, r)
+                stale_any = stale_any or stale
+                marker = "⚠️ " if stale else ""
+                suffix = "  — *role missing*" if stale else ""
+                lines.append(
+                    f"{marker}**{r['role_name']}** — {r['days_required']} day(s){suffix}",
+                )
             embed.description = "\n".join(lines)
+            if stale_any:
+                embed.set_footer(
+                    text="⚠️ A configured role no longer exists — remove it or "
+                    "re-add the current role.",
+                )
+            else:
+                embed.set_footer(text="Roles auto-assigned based on days in server.")
         else:
             embed.description = "No thresholds configured."
-        embed.set_footer(text="Roles auto-assigned based on days in server.")
+            embed.set_footer(text="Roles auto-assigned based on days in server.")
         return embed
 
     async def _refresh(self) -> None:
@@ -59,7 +87,18 @@ class TimeRolesPanel(BaseView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        await interaction.response.send_modal(TimeThresholdAddModal(self))
+        roles = [r for r in interaction.guild.roles if not r.is_default()]
+        if not roles:
+            await interaction.response.send_message(
+                "No assignable roles in this server.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_message(
+            "Pick the role to give a time threshold:",
+            view=_TimeRolePickView(self, roles),
+            ephemeral=True,
+        )
 
     @discord.ui.button(label="➖ Remove", style=discord.ButtonStyle.red, row=0)
     async def remove_btn(
@@ -81,17 +120,43 @@ class TimeRolesPanel(BaseView):
             ephemeral=True,
         )
 
-    @discord.ui.button(label="🔄 Reset Defaults", style=discord.ButtonStyle.grey, row=0)
+    @discord.ui.button(label="🔄 Seed Defaults", style=discord.ButtonStyle.grey, row=0)
     async def reset_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
+        # Defaults are suggestions, not phantom rows: seed only the default tiers
+        # whose role actually exists in this guild (capturing its id), and report
+        # which suggestions were skipped because no matching role exists.
+        seeded: list[str] = []
+        skipped: list[str] = []
         for name, days in _DEFAULT_THRESHOLDS:
-            await db.set_role_threshold(self.ctx.guild.id, name, days)
-        await interaction.response.edit_message(
-            embed=await self.build_embed(),
-            view=self,
+            role = resources.resolve_role(interaction.guild, name=name)
+            if role is None:
+                skipped.append(name)
+                continue
+            await db.set_role_threshold(
+                interaction.guild.id,
+                role.name,
+                days,
+                role_id=role.id,
+                display_name=role.name,
+            )
+            seeded.append(role.name)
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        await self._refresh()
+        parts = []
+        if seeded:
+            parts.append(f"Seeded {len(seeded)}: {', '.join(seeded)}.")
+        if skipped:
+            parts.append(
+                f"Skipped {len(skipped)} (no matching role): {', '.join(skipped)}.",
+            )
+        await interaction.followup.send(
+            " ".join(parts) or "No default roles matched this server.",
+            ephemeral=True,
         )
 
     @discord.ui.button(label="▶️ Run Now", style=discord.ButtonStyle.blurple, row=1)
@@ -111,23 +176,40 @@ class TimeRolesPanel(BaseView):
             )
 
 
-class TimeThresholdAddModal(
-    discord.ui.Modal,
-    title="Add / Edit Threshold",
-):  # type: ignore[call-arg]
-    role_name = discord.ui.TextInput(  # type: ignore[var-annotated]
-        label="Role name (must exist in server)",
-        max_length=100,
-    )
+class _TimeRolePickView(BaseView):
+    """Ephemeral one-shot picker: choose a role, then enter the day threshold."""
+
+    def __init__(self, parent: TimeRolesPanel, roles: list[discord.Role]) -> None:
+        super().__init__(parent.ctx.author, timeout=120)
+        self.parent = parent
+        self.add_item(RoleSelector(roles, self._on_select))
+
+    async def _on_select(
+        self,
+        interaction: discord.Interaction,
+        role_id: int,
+    ) -> None:
+        role = resources.resolve_role(interaction.guild, role_id=role_id)
+        if role is None:
+            await interaction.response.send_message(
+                "That role no longer exists.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_modal(TimeDaysModal(self.parent, role))
+
+
+class TimeDaysModal(discord.ui.Modal, title="Set Day Threshold"):  # type: ignore[call-arg]
     days = discord.ui.TextInput(  # type: ignore[var-annotated]
         label="Days in server required",
         placeholder="0",
         max_length=5,
     )
 
-    def __init__(self, parent: TimeRolesPanel) -> None:
+    def __init__(self, parent: TimeRolesPanel, role: discord.Role) -> None:
         super().__init__()
         self.parent = parent
+        self.role = role
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
         try:
@@ -140,12 +222,15 @@ class TimeThresholdAddModal(
                 ephemeral=True,
             )
             return
-        discord_role = _find_role_normalized(
-            interaction.guild,
-            self.role_name.value.strip(),
+        # Selector-sourced: the role exists, so persist its id + name snapshot.
+        await db.set_role_threshold(
+            interaction.guild.id,
+            self.role.name,
+            d,
+            role_id=self.role.id,
+            display_name=self.role.name,
         )
-        store_name = discord_role.name if discord_role else self.role_name.value.strip()
-        await db.set_role_threshold(interaction.guild.id, store_name, d)
+        invalidate_xp_threshold_roles(interaction.guild.id)
         if not await safe_defer(interaction):
             return
         await self.parent._refresh()

--- a/disbot/views/roles/xp_roles_panel.py
+++ b/disbot/views/roles/xp_roles_panel.py
@@ -5,13 +5,15 @@ import logging
 import discord
 from discord.ext import commands
 
+from core.runtime import resources
 from core.runtime.interaction_helpers import safe_defer, safe_followup
 from utils import db
 from utils.guild_config_accessors import invalidate_xp_threshold_roles
 from utils.ui_constants import ECONOMY_COLOR
 from views.base import BaseView
 from views.navigation import attach_back_button
-from views.roles._helpers import _find_role_normalized
+from views.roles.time_roles_panel import _row_is_stale
+from views.selectors import RoleSelector
 
 logger = logging.getLogger("bot")
 
@@ -45,18 +47,34 @@ class XpRolesPanel(BaseView):
         embed = discord.Embed(title="⚡ XP Role Automation", color=ECONOMY_COLOR)
         if xp_rows:
             lines = []
+            stale_any = False
             for r in sorted(xp_rows, key=lambda x: x["level_required"]):
+                stale = _row_is_stale(self.ctx.guild, r)
+                stale_any = stale_any or stale
+                if stale:
+                    lines.append(
+                        f"⚠️ Level **{r['level_required']}** → **{r['role_name']}** "
+                        "— *role missing*",
+                    )
+                    continue
                 status = "✅" if r.get("xp_auto_assign") else "⏸️"
                 lines.append(
                     f"{status} Level **{r['level_required']}** → **{r['role_name']}**",
                 )
             embed.description = "\n".join(lines)
+            embed.set_footer(
+                text=(
+                    "⚠️ a configured role no longer exists — remove or re-add it"
+                    if stale_any
+                    else "✅ auto-assign active  ⏸️ configured but paused"
+                ),
+            )
         else:
             embed.description = (
                 "No XP threshold roles configured.\n"
                 "Use **➕ Add / Edit** to assign a role at a specific XP level."
             )
-        embed.set_footer(text="✅ auto-assign active  ⏸️ configured but paused")
+            embed.set_footer(text="✅ auto-assign active  ⏸️ configured but paused")
         return embed
 
     async def _refresh(self) -> None:
@@ -69,7 +87,18 @@ class XpRolesPanel(BaseView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        await interaction.response.send_modal(XpThresholdModal(self))
+        roles = [r for r in interaction.guild.roles if not r.is_default()]
+        if not roles:
+            await interaction.response.send_message(
+                "No assignable roles in this server.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_message(
+            "Pick the role to assign at an XP level:",
+            view=_XpRolePickView(self, roles),
+            ephemeral=True,
+        )
 
     @discord.ui.button(label="➖ Remove", style=discord.ButtonStyle.red, row=0)
     async def remove_btn(
@@ -93,14 +122,30 @@ class XpRolesPanel(BaseView):
         )
 
 
-class XpThresholdModal(
-    discord.ui.Modal,
-    title="Add / Edit XP Threshold",
-):  # type: ignore[call-arg]
-    role_name = discord.ui.TextInput(  # type: ignore[var-annotated]
-        label="Role name (must exist in server)",
-        max_length=100,
-    )
+class _XpRolePickView(BaseView):
+    """Ephemeral one-shot picker: choose a role, then enter the XP level."""
+
+    def __init__(self, parent: XpRolesPanel, roles: list[discord.Role]) -> None:
+        super().__init__(parent.ctx.author, timeout=120)
+        self.parent = parent
+        self.add_item(RoleSelector(roles, self._on_select))
+
+    async def _on_select(
+        self,
+        interaction: discord.Interaction,
+        role_id: int,
+    ) -> None:
+        role = resources.resolve_role(interaction.guild, role_id=role_id)
+        if role is None:
+            await interaction.response.send_message(
+                "That role no longer exists.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_modal(XpLevelModal(self.parent, role))
+
+
+class XpLevelModal(discord.ui.Modal, title="Set XP Threshold"):  # type: ignore[call-arg]
     level = discord.ui.TextInput(  # type: ignore[var-annotated]
         label="XP Level required",
         placeholder="e.g. 5",
@@ -113,9 +158,10 @@ class XpThresholdModal(
         max_length=3,
     )
 
-    def __init__(self, parent: XpRolesPanel) -> None:
+    def __init__(self, parent: XpRolesPanel, role: discord.Role) -> None:
         super().__init__()
         self.parent = parent
+        self.role = role
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
         try:
@@ -132,18 +178,15 @@ class XpThresholdModal(
         raw_auto = self.auto_assign.value.strip().lower()
         enabled = raw_auto not in ("no", "n", "false", "0")
 
-        discord_role = _find_role_normalized(
-            interaction.guild,
-            self.role_name.value.strip(),
-        )
-        store_name = discord_role.name if discord_role else self.role_name.value.strip()
-
         try:
+            # Selector-sourced: the role exists, so persist its id + name snapshot.
             await db.set_role_xp_threshold(
                 interaction.guild.id,
-                store_name,
+                self.role.name,
                 lvl,
                 enabled,
+                role_id=self.role.id,
+                display_name=self.role.name,
             )
         except Exception as exc:
             logger.error("XP threshold save failed: %s", exc, exc_info=True)

--- a/docs/ownership.md
+++ b/docs/ownership.md
@@ -56,7 +56,7 @@ writes must come from the owning cog or a shared service.
 | `help`         | (none — read-only on registry + governance)  | n/a |
 | `diagnostic`   | (uses `logs` for queries)                    | n/a |
 | `general`      | (loads `data/json/general_content.json`)      | n/a |
-| `role`         | `role_thresholds`, `reaction_roles`            | role create/edit/delete via `services/role_lifecycle_service.py`; `role_thresholds` / `reaction_roles` direct via `utils/db/roles.py` (time/XP tier removal uses the field-specific `clear_role_time_threshold` / `clear_role_xp_threshold` — never the destructive full-row delete) |
+| `role`         | `role_thresholds`, `reaction_roles`            | role create/edit/delete via `services/role_lifecycle_service.py`; `role_thresholds` / `reaction_roles` direct via `utils/db/roles.py`. Time/XP tiers are **id-keyed dual-read** (migration 056: nullable `role_id`/`display_name`; resolved id-first, normalized-name fallback) and tier removal uses the field-specific `clear_role_time_threshold` / `clear_role_xp_threshold` — never the destructive full-row delete |
 | `moderation`   | `warnings`, `mod_logs`                         | `services/moderation_service.py` (preferred); `utils/db/moderation.py` direct for read-only / legacy callers |
 | `xp`           | `xp.xp`, `xp.level`, `xp.messages`, `xp.last_xp` | `services/xp_service.py` |
 | `economy`      | `economy`, `job_progress`, `economy_audit_log`   | `services/economy_service.py` |

--- a/docs/planning/server-management-implementation-plan-2026-06-05.md
+++ b/docs/planning/server-management-implementation-plan-2026-06-05.md
@@ -5,16 +5,16 @@
 >
 > ---
 >
-> **📦 PR1–PR5 shipped (2026-06-05).** This document is the live **scope reference**
+> **📦 PR1–PR6 shipped (2026-06-05).** This document is the live **scope reference**
 > for the PR sequence; for *what has actually landed and what is next*, read the
 > status tracker: **`docs/planning/server-management-status-2026-06-05.md`**.
 > Shipped: **PR1** moderation convergence (#521), **PR2** role feasibility +
 > `MultiRoleSelector` (#522, selectors-only slice), **PR3 + PR4** lifecycle contract +
 > `ChannelLifecycleService` channel rename/move/delete (#523, the `.delete`/`.edit`
 > slice), **PR5** `RoleLifecycleService` (role create/edit/delete) + non-destructive
-> field-specific time/XP threshold deletes (the role-ID migration groundwork was
-> **deferred to PR6**, where the ID-persisting selector is its consumer). The
-> remaining queue starts at **PR6**.
+> field-specific time/XP threshold deletes (#525), and **PR6** selector-driven
+> time/XP role config + the `role_thresholds` `role_id`/`display_name` migration
+> (056) + id-first dual-read resolution. The remaining queue starts at **PR7**.
 >
 > **Rev 2 (external review incorporated):** PR1's moderation audit is stated as **three distinct
 > signals** — `mod_logs` (authoritative history) · `moderation.action_taken` (domain event) ·

--- a/docs/planning/server-management-status-2026-06-05.md
+++ b/docs/planning/server-management-status-2026-06-05.md
@@ -142,7 +142,7 @@ The shared lifecycle-mutation contract landing with its first consumer.
   **panel UI**, and first-class **category lifecycle**. The invariant pins only
   `.delete()` / `.edit()` for now — these other operations are not yet routed.
 
-### PR5 — Role lifecycle service + non-destructive time/XP thresholds *(this PR)*
+### PR5 — Role lifecycle service + non-destructive time/XP thresholds (#525)
 The role-domain sibling of the channel lifecycle service, plus the data-loss fix
 for threshold removal.
 
@@ -177,6 +177,33 @@ for threshold removal.
   the ID-persisting selector is its real consumer); member assignment routing
   (reaction roles / automation `add_roles`/`remove_roles`); role reorder; templates.
 
+### PR6 — Dynamic time/XP role config + role-id dual-read *(this PR)*
+Closes the free-text role-name foot-gun: both automation sections are now
+selector-driven and persist stable role ids.
+
+- **Migration 056** — additive nullable `role_id` / `display_name` on
+  `role_thresholds` (the deferred PR5 groundwork, landed *with* its consumer).
+- **DB layer (`utils/db/roles.py`)** — `set_role_threshold` / `set_role_xp_threshold`
+  take optional `role_id` / `display_name` (COALESCE-preserved on conflict);
+  `get_role_thresholds` / `get_xp_threshold_roles` return them. Backward-compatible
+  for legacy name-only callers.
+- **Selector-driven UI** — the free-text "role name" modals in `time_roles_panel`
+  and `xp_roles_panel` are replaced by a role **picker → numeric modal** flow
+  (`RoleSelector` → `TimeDaysModal` / `XpLevelModal`), so a persisted threshold
+  always references a role that exists, capturing its id + name snapshot.
+- **ID-first (dual-read) resolution** — `role_automation.compute_assignments` and
+  the XP listener resolve each tier id-first (normalized-name fallback), so a role
+  **rename no longer orphans its tier**. `RoleThreshold` gained `role_id`.
+- **Stale diagnostics** — both panels flag a tier whose role can no longer be
+  resolved (`⚠️ role missing`).
+- **Defaults are suggestions** — `_ensure_defaults` and the panel's "Seed Defaults"
+  button only seed defaults whose role **exists** (capturing its id); the phantom
+  `Neu/Iron/Beacon` name rows are no longer auto-persisted.
+- **Pinned by** `tests/unit/db/test_roles_role_id.py`,
+  `tests/unit/views/test_role_threshold_selectors.py`, and new id-first /
+  rename-survival cases in `test_role_automation.py` + `test_xp_listener_roles.py`.
+- **Deferred:** role reorder and templates (PR13); member-assignment routing.
+
 ---
 
 ## Reconciliations applied this pass (source ↔ docs)
@@ -199,14 +226,13 @@ for threshold removal.
 
 ---
 
-## Remaining queue (starts at PR6)
+## Remaining queue (starts at PR7)
 
-Per the implementation plan's dependency order. PR5 shipped (see above); the
-deferred role-ID migration groundwork rolls into PR6 with its real consumer.
+Per the implementation plan's dependency order. PR6 shipped (see above) — the
+deferred role-ID migration + dual-read landed with the selector consumer.
 
 | PR | Objective | Depends on |
 |---|---|---|
-| **PR6** | Dynamic time/XP role configuration: replace free-text role names with selectors, **plus** the deferred `role_thresholds` `role_id`/`display_name` migration + dual-read (the ID-persisting selector is its consumer). | PR5, #522 |
 | **PR7** | Channel/category **move & reorder** panel UI + first-class category lifecycle (the deferred half of channel lifecycle). | #523, #522 |
 | **PR8** | Cleanup policy schema + versioning (preserve RC-5 thread-inheritance behavior). | — |
 | **PR9** | Cleanup builder + dry-run + diagnostics. | PR8, #522 |

--- a/tests/unit/cogs/test_xp_listener_roles.py
+++ b/tests/unit/cogs/test_xp_listener_roles.py
@@ -80,7 +80,9 @@ async def test_xp_roles_stack_adds_all_qualifying():
         ),
         patch("cogs.xp.listener.resources") as res_mock,
     ):
-        res_mock.resolve_role.side_effect = lambda guild, name: roles_by_name.get(name)
+        res_mock.resolve_role.side_effect = (
+            lambda guild, *, role_id=None, name=None: roles_by_name.get(name)
+        )
         await listener._apply_xp_threshold_roles(msg, 10)
 
     member.add_roles.assert_awaited_once()
@@ -108,7 +110,9 @@ async def test_xp_roles_single_mode_keeps_highest_removes_lower():
         ),
         patch("cogs.xp.listener.resources") as res_mock,
     ):
-        res_mock.resolve_role.side_effect = lambda guild, name: roles_by_name.get(name)
+        res_mock.resolve_role.side_effect = (
+            lambda guild, *, role_id=None, name=None: roles_by_name.get(name)
+        )
         await listener._apply_xp_threshold_roles(msg, 10)
 
     member.add_roles.assert_awaited_once()

--- a/tests/unit/db/test_roles_role_id.py
+++ b/tests/unit/db/test_roles_role_id.py
@@ -1,0 +1,98 @@
+"""Role-id groundwork for ``role_thresholds`` (server-management PR6, migration 056).
+
+Pins the additive id-groundwork: migration 056 adds nullable ``role_id`` /
+``display_name``; the setters persist them (``COALESCE``-preserved on conflict)
+and stay backward-compatible for legacy name-only callers; the getters select
+them so readers can resolve id-first.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from utils.db import roles
+
+_MIGRATION = (
+    Path(__file__).resolve().parents[3]
+    / "disbot"
+    / "migrations"
+    / "056_role_threshold_role_id.sql"
+)
+
+
+def test_migration_056_adds_nullable_role_id_columns():
+    sql = _MIGRATION.read_text()
+    assert "ALTER TABLE role_thresholds" in sql
+    assert "ADD COLUMN IF NOT EXISTS role_id BIGINT" in sql
+    assert "ADD COLUMN IF NOT EXISTS display_name TEXT" in sql
+    # additive-only: the executable statement must not drop anything.
+    statement = sql.split("Forward-only")[-1]
+    assert "DROP" not in statement
+
+
+@pytest.fixture
+def exec_calls(monkeypatch):
+    calls: list[tuple[str, tuple]] = []
+
+    async def fake_execute(sql, params):
+        calls.append((sql, params))
+
+    monkeypatch.setattr(roles.pool, "execute", fake_execute)
+    return calls
+
+
+@pytest.fixture
+def fetch_calls(monkeypatch):
+    calls: list[tuple[str, tuple]] = []
+
+    async def fake_fetchall(sql, params):
+        calls.append((sql, params))
+        return []
+
+    monkeypatch.setattr(roles.pool, "fetchall", fake_fetchall)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_set_role_threshold_persists_role_id_and_display_name(exec_calls):
+    await roles.set_role_threshold(7, "Veteran", 30, role_id=123, display_name="Veteran")
+    sql, params = exec_calls[0]
+    assert "role_id" in sql and "display_name" in sql
+    # captured id is preserved on conflict, never wiped by a later update.
+    assert "COALESCE(EXCLUDED.role_id" in sql
+    assert params == (7, "Veteran", 30, 123, "Veteran")
+
+
+@pytest.mark.asyncio
+async def test_set_role_threshold_backward_compatible_without_ids(exec_calls):
+    await roles.set_role_threshold(7, "Veteran", 30)
+    _, params = exec_calls[0]
+    assert params == (7, "Veteran", 30, None, None)
+
+
+@pytest.mark.asyncio
+async def test_set_role_xp_threshold_persists_ids_and_coalesces(exec_calls):
+    await roles.set_role_xp_threshold(
+        7, "Veteran", 5, True, role_id=123, display_name="Veteran"
+    )
+    sql, params = exec_calls[0]
+    assert "role_id" in sql and "COALESCE(EXCLUDED.role_id" in sql
+    assert params == (7, "Veteran", 5, True, 123, "Veteran")
+
+
+@pytest.mark.asyncio
+async def test_set_role_xp_threshold_backward_compatible_without_ids(exec_calls):
+    await roles.set_role_xp_threshold(7, "Veteran", 5, True)
+    _, params = exec_calls[0]
+    assert params == (7, "Veteran", 5, True, None, None)
+
+
+@pytest.mark.asyncio
+async def test_getters_select_role_id_and_display_name(fetch_calls):
+    await roles.get_role_thresholds(7)
+    await roles.get_xp_threshold_roles(7)
+    assert fetch_calls, "expected fetchall to be called"
+    for sql, _ in fetch_calls:
+        assert "role_id" in sql and "display_name" in sql

--- a/tests/unit/services/test_role_automation.py
+++ b/tests/unit/services/test_role_automation.py
@@ -221,6 +221,30 @@ def test_compute_assignments_emits_remove_when_promoting():
     assert plans[0].remove_role_names == ("Veteran",)
 
 
+def test_compute_assignments_resolves_tier_by_role_id_after_rename():
+    """PR6 id-first: a threshold keyed by role_id survives a role rename.
+
+    The row still stores the old name, but the role (id 100) was renamed to
+    "NewName"; resolution is id-first, so the tier resolves to the renamed role
+    and assigns it under its current name.
+    """
+    renamed = _role(100, "NewName")
+    member = _member(mid=1, display="u1", joined_days_ago=45)
+    g = _guild(roles=[renamed], members=[member])
+    plans = compute_assignments(g, [RoleThreshold("OldName", 30, role_id=100)])
+    assert len(plans) == 1
+    assert plans[0].add_role_id == 100
+    assert plans[0].add_role_name == "NewName"
+
+
+def test_compute_assignments_drops_tier_whose_role_is_gone():
+    """A threshold whose role resolves by neither id nor name is dropped."""
+    member = _member(mid=1, display="u1", joined_days_ago=45)
+    g = _guild(roles=[], members=[member])
+    plans = compute_assignments(g, [RoleThreshold("Ghost", 30, role_id=999)])
+    assert plans == ()
+
+
 def test_explain_assignment_for_returns_per_member_plan():
     veteran = _role(100, "Veteran")
     target = _member(mid=42, display="u42", joined_days_ago=60)

--- a/tests/unit/views/test_role_threshold_selectors.py
+++ b/tests/unit/views/test_role_threshold_selectors.py
@@ -1,0 +1,145 @@
+"""Selector-driven time/XP threshold config (server-management PR6).
+
+The free-text role-name modal is replaced by a role picker → numeric modal, so a
+persisted threshold always references a role that exists (capturing its id + name
+snapshot).  Pins: the modals persist ``role_id`` + ``display_name``; the stale
+helper flags a row whose role can no longer be resolved; and ``_ensure_defaults``
+seeds only defaults whose role actually exists (no phantom-name rows).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _interaction() -> MagicMock:
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.guild.id = 99
+    interaction.response.send_message = AsyncMock()
+    return interaction
+
+
+@pytest.mark.asyncio
+async def test_time_days_modal_persists_role_id_and_name():
+    from views.roles.time_roles_panel import TimeDaysModal
+
+    parent = MagicMock()
+    parent._refresh = AsyncMock()
+    modal = TimeDaysModal(parent, SimpleNamespace(id=100, name="Veteran"))
+    modal.days = MagicMock(value="30")
+    interaction = _interaction()
+    with (
+        patch("views.roles.time_roles_panel.db") as db,
+        patch("views.roles.time_roles_panel.invalidate_xp_threshold_roles"),
+        patch("views.roles.time_roles_panel.safe_defer", AsyncMock(return_value=True)),
+    ):
+        db.set_role_threshold = AsyncMock()
+        await modal.on_submit(interaction)
+    db.set_role_threshold.assert_awaited_once_with(
+        99, "Veteran", 30, role_id=100, display_name="Veteran"
+    )
+    parent._refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_time_days_modal_rejects_negative():
+    from views.roles.time_roles_panel import TimeDaysModal
+
+    modal = TimeDaysModal(MagicMock(), SimpleNamespace(id=1, name="X"))
+    modal.days = MagicMock(value="-3")
+    interaction = _interaction()
+    with patch("views.roles.time_roles_panel.db") as db:
+        db.set_role_threshold = AsyncMock()
+        await modal.on_submit(interaction)
+    db.set_role_threshold.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_xp_level_modal_persists_role_id_and_name():
+    from views.roles.xp_roles_panel import XpLevelModal
+
+    parent = MagicMock()
+    parent._refresh = AsyncMock()
+    modal = XpLevelModal(parent, SimpleNamespace(id=200, name="Pro"))
+    modal.level = MagicMock(value="5")
+    modal.auto_assign = MagicMock(value="yes")
+    interaction = _interaction()
+    with (
+        patch("views.roles.xp_roles_panel.db") as db,
+        patch("views.roles.xp_roles_panel.invalidate_xp_threshold_roles"),
+        patch("views.roles.xp_roles_panel.safe_defer", AsyncMock(return_value=True)),
+    ):
+        db.set_role_xp_threshold = AsyncMock()
+        await modal.on_submit(interaction)
+    db.set_role_xp_threshold.assert_awaited_once_with(
+        99, "Pro", 5, True, role_id=200, display_name="Pro"
+    )
+
+
+def test_row_is_stale_by_role_id():
+    from views.roles.time_roles_panel import _row_is_stale
+
+    guild = MagicMock()
+    with patch("views.roles.time_roles_panel.resources") as res:
+        res.resolve_role.return_value = object()  # id resolves → fresh
+        assert _row_is_stale(guild, {"role_id": 100, "role_name": "X"}) is False
+        res.resolve_role.return_value = None  # id no longer resolves → stale
+        assert _row_is_stale(guild, {"role_id": 100, "role_name": "X"}) is True
+
+
+def test_row_is_stale_legacy_name_fallback():
+    from views.roles.time_roles_panel import _row_is_stale
+
+    guild = MagicMock()
+    with patch("views.roles.time_roles_panel.resources") as res:
+        res.resolve_role.return_value = None
+        assert _row_is_stale(guild, {"role_id": None, "role_name": "Ghost"}) is True
+        assert res.resolve_role.call_args.kwargs.get("name") == "Ghost"
+
+
+@pytest.mark.asyncio
+async def test_ensure_defaults_seeds_only_existing_roles():
+    from views.roles._helpers import _DEFAULT_THRESHOLDS, _ensure_defaults
+
+    existing_name = _DEFAULT_THRESHOLDS[0][0]
+
+    def _resolve(_guild, *, name=None, role_id=None):
+        if name == existing_name:
+            return SimpleNamespace(id=500, name=name)
+        return None
+
+    guild = MagicMock()
+    guild.id = 7
+    with (
+        patch("utils.db.get_role_thresholds", new=AsyncMock(return_value=[])),
+        patch("utils.db.set_role_threshold", new=AsyncMock()) as setter,
+        patch("core.runtime.resources.resolve_role", side_effect=_resolve),
+    ):
+        await _ensure_defaults(guild)
+    # Only the one default whose role exists is seeded — with its captured id —
+    # and the phantom-named defaults are skipped (no nonexistent-role rows).
+    setter.assert_awaited_once()
+    assert setter.await_args.args[0] == 7
+    assert setter.await_args.kwargs == {"role_id": 500, "display_name": existing_name}
+
+
+@pytest.mark.asyncio
+async def test_ensure_defaults_noop_when_thresholds_exist():
+    from views.roles._helpers import _ensure_defaults
+
+    guild = MagicMock()
+    guild.id = 7
+    with (
+        patch(
+            "utils.db.get_role_thresholds",
+            new=AsyncMock(return_value=[{"role_name": "X", "days_required": 1}]),
+        ),
+        patch("utils.db.set_role_threshold", new=AsyncMock()) as setter,
+    ):
+        await _ensure_defaults(guild)
+    setter.assert_not_awaited()


### PR DESCRIPTION
## Summary

Server-management **PR6**: replace the free-text role-name threshold modals with **selector-driven** config, persist **stable role ids**, and resolve tiers **id-first** so a role rename no longer orphans its automation. This lands the role-id migration groundwork (deferred from PR5) *together with* its selector consumer — the #523 "extract the primitive with its consumer" rule.

Builds on #522 (`RoleSelector`) and #525 (the threshold DB layer).

## What changed

**Migration + DB (id groundwork)**
- **Migration `056`** — additive **nullable** `role_id` / `display_name` on `role_thresholds`.
- `utils/db/roles.py` — `set_role_threshold` / `set_role_xp_threshold` take optional `role_id` / `display_name` (**COALESCE-preserved** on conflict, so a name-only update never wipes a captured id); the getters return them. **Fully backward-compatible** for legacy name-only callers.

**Selector-driven UI** (the headline fix)
- `RoleSelector` is a Select (can't sit in a modal), so the "role name + days" text modal becomes a role **picker → numeric modal** flow (`TimeDaysModal` / `XpLevelModal`). A persisted tier therefore **always references a role that exists**, capturing its id + name snapshot.
- Panels show **`⚠️` stale markers** for tiers whose role can no longer be resolved.
- **Defaults are suggestions** — `_ensure_defaults` and the "Seed Defaults" button only seed defaults whose role **exists** (capturing its id). The phantom `Neu/Iron/Beacon` name rows that the old auto-seed persisted are gone.

**ID-first (dual-read) resolution** (rename-survival)
- `RoleThreshold` gains `role_id`; `role_automation.compute_assignments` resolves each tier **id-first** (normalized-name fallback) and keys the progression by the resolved *current* name, so a renamed role keeps its tier. Legacy `role_id=None` rows behave exactly as before.
- The XP listener resolves `role_id`-first with a name fallback.

## Tests
- `tests/unit/db/test_roles_role_id.py` — migration 056 + id-aware DB (persist/return/COALESCE, backward-compat).
- `tests/unit/views/test_role_threshold_selectors.py` — modal persistence (id + name), the stale helper, existence-aware defaults.
- New **rename-survival** + **drop-unresolvable** cases in `test_role_automation.py`, and the listener resolve-mock updated for the new id-first signature.

## Scope notes
Role reorder and templates (PR13) and member-assignment routing remain out of scope. The PK stays `(guild_id, role_name)` — no destructive name→id flip (dual-read only), exactly as planned.

## Verification
- `python3.10 scripts/check_architecture.py --mode strict` → exit 0, **0 errors**.
- `python3.10 scripts/check_quality.py --full` → lint + mypy + **7447 passed, 3 skipped**.

## Next
**PR7** — channel/category move & reorder panel UI + first-class category lifecycle (the deferred half of #523).

https://claude.ai/code/session_01XzafDB3CEuQDwi26FRYdvN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzafDB3CEuQDwi26FRYdvN)_