### PR TITLE
Live cog audit: fix discord.py 2.7 panel crashes + DiagnosticCog suite

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,6 +19,13 @@ Two more bind common operations:
 - **`docs/helper-policy.md`** — when to create / move / promote a helper. Read this **before** putting a function in `utils/`, `services/`, or `views/base.py`.
 
 When a doc and a source file disagree, the source file wins.
+
+Also read **`.session-journal.md`** (repo root) at the **start** of every
+session — our cross-session working memory: the environment/boot runbook (how to
+boot the test bot, where the env vars live, the local-Postgres setup), maintainer
+preferences, recurring problems + fixes, past mistakes to avoid, and candidate
+rules not yet promoted into this file. Append a dated entry at the **end** of the
+session and commit it. Precedence: source code > this file (CLAUDE.md) > the journal.
 <!-- READ_FIRST_END -->
 
 <!-- SESSION_WORKFLOW_START -->

--- a/.session-journal.md
+++ b/.session-journal.md
@@ -105,6 +105,12 @@
   suite mid-session.
 - **Validate a derivation against ground truth before shipping** — a migration-table
   regex silently missed runtime-created tables.
+- **Run the exact CI lint commands on changed files right before `git push`** —
+  `black --check .` / `isort --check-only .` / `ruff check .` with the workflow's
+  flags/excludes. PR #528's first `code-quality` run failed `black` (a >88-char line in
+  `migrations.py`) + `ruff` D209 (the new `_log_buffer.py` docstring) that weren't
+  surfaced at push time. The PostToolUse auto-format hook may not fire in the
+  remote/web container, so don't rely on it; verify the formatters yourself.
 
 ## Active Blockers / Open Items
 
@@ -153,3 +159,6 @@
 - **Closed:** opened end-of-session PR **#528** (discord.py-2.7 crash fixes +
   DiagnosticCog suite + this journal); `check_quality --full` + `check_architecture`
   green at open.
+- **CI follow-up:** #528's first `code-quality` run failed `black` (migrations.py) +
+  `ruff` D209 (_log_buffer.py); fixed with the pinned linters, re-verified against the
+  exact workflow commands, re-pushed (`73a943f`). → new lint Rule above.

--- a/.session-journal.md
+++ b/.session-journal.md
@@ -1,0 +1,152 @@
+# .session-journal.md — SuperBot working memory
+
+> **What this is:** cross-session memory for how the maintainer + Claude work on
+> SuperBot — process, preferences, recurring problems+fixes, Claude's own
+> mistakes+prevention, the environment/boot runbook, and a holding pen for
+> rules/ideas/blockers not yet promoted into `.claude/CLAUDE.md`.
+>
+> **What this is NOT:** a feature doc. Bot architecture / feature roadmaps live in
+> `docs/` (and `docs/planning/`). Keep those out of here.
+>
+> **Persistence:** the sandbox container is ephemeral — this file only survives if
+> it's committed. Commit it every session.
+
+## Protocol — what to do with this file each session
+
+- **START:** read this right after `.claude/CLAUDE.md`. Skim the **Environment
+  Runbook** (so you don't re-derive how to boot the bot), **Operating
+  Preferences**, **Active Blockers**, and the latest **Session Log** entries. Fold
+  open blockers/actions into your plan.
+- **DURING:** capture as they happen — a non-obvious problem+fix, a mistake worth
+  not repeating, a stated/observed preference, an architecture ask.
+- **END:** append a dated **Session Log** entry; update the curated sections if
+  something changed; commit + push.
+- **REVIEW (every ~3-5 sessions, or on request):** re-order, dedupe, and **propose**
+  promotions of stable items into `.claude/CLAUDE.md` / hooks / `settings.json` for
+  the maintainer's approval. Keep this file lean.
+- **Authority:** items here are strong defaults Claude follows; they become
+  *binding* only once the maintainer approves promotion into CLAUDE.md.
+  **Precedence: source code > `.claude/CLAUDE.md` > this journal.**
+
+---
+
+## Environment Runbook — booting & operating the bot in the sandbox
+
+*So a future session knows the possibilities without re-deriving them.*
+
+**You CAN boot the real test bot in this container and watch live logs.**
+
+- **Entry point:** `python3.10 disbot/bot1.py` (Procfile `worker:`). Run from the
+  repo root — Python puts `disbot/` on `sys.path`, so `import config` etc. resolve.
+- **Credentials (already in the container env):**
+  - `DISCORD_BOT_TOKEN_PRODUCTION` — **misleading name**: it is actually a dedicated
+    **test bot** ("Galaxy Bot#6724") alone with the maintainer in a private server.
+    **Safe to boot — no production double-run risk.**
+  - `DATABASE_URL` — points at **localhost**
+    (`postgresql://superbot:***@localhost:5432/superbot`), i.e. a *local* DB, not a
+    remote prod DB.
+- **Local Postgres is NOT running by default.** Stand one up (binaries at
+  `/usr/lib/postgresql/16/bin`, run as the `postgres` user — Postgres refuses to run
+  as root): `initdb` a data dir → `pg_ctl start` on localhost:5432 → create role
+  `superbot` + database `superbot` matching `DATABASE_URL`.
+- **Schema bootstraps itself on boot:** `pool.init()` → `ensure_migrations_table` →
+  `create_tables` → `run_migrations`. No manual migration step. (Currently 56
+  migrations / 68 tables.)
+- **Network:** Discord gateway + REST are reachable from the sandbox.
+- **One instance only:** a Postgres-backed runtime lock (with heartbeat) lets only
+  one bot be active; a second waits. **On restart, kill the old instance first.**
+- **Logs:** the bot writes `bot.log` (rotating, repo root) + stdout. Working pattern:
+  `nohup python3.10 disbot/bot1.py > /tmp/testbot.log 2>&1 &` then tail
+  `/tmp/testbot.log`; put a Monitor on it filtered to `ERROR/CRITICAL/Traceback`.
+- **Quality gates (green before pushing):**
+  `python3.10 scripts/check_quality.py --full` (CI mirror: black/isort/ruff + mypy +
+  ~7455 tests, ~75s) and `python3.10 scripts/check_architecture.py --mode strict`
+  (0 errors required; pre-existing warnings OK).
+- **Env feature flags (OFF here → expect *degraded*, not *broken*):** `AI_ENABLED`
+  (AI off), `AUTOMATION_SCHEDULER_ENABLED=false` (time/XP auto-assign loop off; manual
+  `!assignroles` / "Run Now" works), `YOUTUBE_API_KEY` / `PARAGON_API_KEY`
+  (off/degraded), `DISCORD_WEBHOOK_URL` (off). Command access fails **OPEN** on a fresh
+  DB (no policy → all channels). Owner-gating uses `bot.is_owner` (Discord app owner =
+  maintainer); `config.BOT_OWNER_USER_ID` only matters for AI personalization.
+
+**Boot gotchas (learned the hard way):**
+
+- `pkill -f "disbot/bot1.py"` matches the *launching shell itself* (its command line
+  contains that string) → it self-kills before relaunching. Use a `/proc` matcher with
+  a **split** target (`"disbot/" + "bot1.py"`), exclude your own PID, and keep the kill
+  in a command that does NOT also contain the launch string. Kill first, **then** launch
+  in a separate step.
+- Running `check_quality`/pytest in the repo leaks test-fixture errors into `bot.log`
+  (importing `bot1` installs the file handler). When mining logs, filter by the live
+  `boot_id` to separate real bot errors from test pollution.
+- The `interaction_router` logs "Unhandled interaction prefix …" on nearly every panel
+  click — **benign**: only the `ai` cog registers a router prefix; every other panel is
+  handled in-memory by its View. Buttons work; it's log noise.
+
+---
+
+## Operating Preferences (maintainer)
+
+- Audits live by clicking panels/commands and asking "should X not be Y?" → diagnose
+  precisely, confirm the root cause, record it; don't wave it off.
+- Wants the test bot booted and live logs watched during sessions.
+- Root cause over symptom — fix the whole class (e.g. central `clamp_embed`, not one
+  panel).
+- Batch fixes by cog; commit + push each coherent chunk.
+- Prefers self-maintaining checks over hardcoded lists.
+- A PR at session end is a standing expectation (also in `.claude/CLAUDE.md`).
+
+## Rules / Conventions (candidate — not yet promoted to CLAUDE.md)
+
+- **Pin churn-prone deps** and audit `discord.ui` overrides on version bumps —
+  unpinned `discord.py>=2.3.0` resolving to 2.7.1 caused `View._refresh` / `Item.parent`
+  collisions that crashed the bot.
+- **Grep ALL references (incl. tests) before a rename** — a missed test mock cost a red
+  suite mid-session.
+- **Validate a derivation against ground truth before shipping** — a migration-table
+  regex silently missed runtime-created tables.
+
+## Active Blockers / Open Items
+
+- **discord.py is unpinned** (`requirements.txt: discord.py>=2.3.0`) — recommend pinning
+  `>=2.7,<2.8` (proposed, not done).
+- **Role UX warts** still open: bulk "Clear missing" on time/XP panels + selector-ize
+  Edit Role (the original task that got superseded by the crash fixes).
+- **DiagnosticCog platform sub-views:** the new total-embed clamp prevents the failure,
+  but dense `platform_*` embeds could be *paginated* for better UX (follow-up).
+- **Audit coverage:** many cogs still `❓` in
+  `docs/planning/cog-functionality-audit-2026-06-05.md` (Channel/Moderation/Economy/
+  games/BTD6/…).
+
+## Ideas / Roadmap (process & tooling — feature ideas go to docs/)
+
+- This journal + its review/promotion cadence.
+- A SessionStart hook to actively surface open blockers at boot (considered; chose the
+  CLAUDE.md pointer for now — revisit if items get missed).
+- `interaction_router` safety-net registration (mirror the `ai` cog) to silence the
+  benign "Unhandled prefix" noise *and* give expired/post-restart panels a graceful reply.
+
+---
+
+## Session Log (newest first)
+
+### 2026-06-05 — server-management audit + discord.py-2.7 crash fixes + diagnostic suite
+- **Context:** maintainer pivoted a role-panel-polish session into a structured,
+  cog-by-cog functionality audit driven by live testing against the booted test bot.
+- **Shipped (branch `claude/charming-ride-7Whiq`):**
+  - `fix(roles)`: two discord.py 2.7.1 internal collisions — `_refresh(self)` shadowing
+    `View._refresh(components)` (crashed the whole bot on MESSAGE_UPDATE) and
+    `self.parent =` on `Select` subclasses hitting the now-read-only `Item.parent`
+    (broke Delete/Remove). Root cause: unpinned discord.py. Regression-pinned by
+    `tests/unit/views/test_role_panels_discordpy_compat.py`.
+  - `fix(diagnostic)`: working "Recent Errors" (in-memory ring buffer instead of a
+    `logs` table nothing wrote to), migration-based "Schema Check" (instead of a
+    16-table hardcoded list that flagged 52 real tables as "unexpected"), and a
+    **total-6000 embed clamp** in `clamp_embed` (fixes the `!platform` "no back button"
+    + any oversized panel bot-wide).
+  - `docs`: seeded `docs/planning/cog-functionality-audit-2026-06-05.md` (full per-cog
+    command/panel inventory + env-gate map + findings).
+- **Problems→fixes & my mistakes:** distilled into the Environment Runbook + Rules
+  above (pkill self-match; schema regex missing runtime tables; rename missing a test
+  ref; benign router noise; pytest polluting `bot.log`).
+- **Preferences observed:** captured in Operating Preferences above.

--- a/.session-journal.md
+++ b/.session-journal.md
@@ -150,3 +150,6 @@
   above (pkill self-match; schema regex missing runtime tables; rename missing a test
   ref; benign router noise; pytest polluting `bot.log`).
 - **Preferences observed:** captured in Operating Preferences above.
+- **Closed:** opened end-of-session PR **#528** (discord.py-2.7 crash fixes +
+  DiagnosticCog suite + this journal); `check_quality --full` + `check_architecture`
+  green at open.

--- a/disbot/cogs/diagnostic/_helpers.py
+++ b/disbot/cogs/diagnostic/_helpers.py
@@ -196,8 +196,16 @@ def _format_table_set(names: set[str], *, limit: int = 1024) -> str:
 
 
 async def build_check_database_embed() -> discord.Embed:
-    """Verify expected PostgreSQL tables exist."""
-    expected = {
+    """Report schema health: base tables present + every migration applied.
+
+    The DB is migration-managed, so the authoritative signals are (a) the
+    pre-migration base tables exist and (b) every ``NNN_*.sql`` migration has
+    been recorded in ``schema_migrations`` — not a hand-maintained "expected
+    tables" list.  That list went stale and flagged all ~52 migration-added
+    tables as "unexpected"; several tables are also created by runtime code
+    (e.g. ``bot_runtime_lock``), so no static list can stay correct.
+    """
+    base = {
         "economy",
         "job_progress",
         "inventory",
@@ -221,6 +229,8 @@ async def build_check_database_embed() -> discord.Embed:
             (),
         )
         existing = {r["tablename"] for r in rows}
+        applied_rows = await db.fetchall("SELECT version FROM schema_migrations", ())
+        applied = {r["version"] for r in applied_rows}
     except Exception as exc:
         return discord.Embed(
             title="Database Schema Check",
@@ -228,22 +238,42 @@ async def build_check_database_embed() -> discord.Embed:
             color=discord.Color.red(),
         )
 
-    missing = expected - existing
-    extra = existing - expected
+    from utils.db.migrations import migration_versions_on_disk
 
-    embed = discord.Embed(title="Database Schema Check", color=discord.Color.purple())
+    on_disk = migration_versions_on_disk()
+    pending = on_disk - applied
+    missing_base = base - existing
+    healthy = not missing_base and not pending
+
+    embed = discord.Embed(
+        title="Database Schema Check",
+        color=discord.Color.green() if healthy else discord.Color.orange(),
+        description=(
+            "✅ Schema healthy — all base tables present and every migration applied."
+            if healthy
+            else "⚠️ Schema needs attention (details below)."
+        ),
+    )
     embed.add_field(
-        name="Missing Tables",
-        value=_format_table_set(missing),
+        name="Base tables",
+        value=(
+            f"✅ {len(base)}/{len(base)} present"
+            if not missing_base
+            else f"❌ missing {len(missing_base)}: {_format_table_set(missing_base)}"
+        ),
         inline=False,
     )
     embed.add_field(
-        name=f"Unexpected Tables ({len(extra)})",
-        value=_format_table_set(extra),
+        name="Migrations applied",
+        value=(
+            f"✅ {len(on_disk) - len(pending)}/{len(on_disk)}"
+            if not pending
+            else f"⚠️ {len(on_disk) - len(pending)}/{len(on_disk)} — pending: "
+            + ", ".join(f"{v:03d}" for v in sorted(pending))
+        ),
         inline=False,
     )
-    if not missing:
-        embed.description = "✅ All expected tables are present."
+    embed.add_field(name="Tables present", value=str(len(existing)), inline=False)
     return embed
 
 
@@ -333,27 +363,17 @@ async def build_query_logs_embed(
     event_type: str | None = None,
     limit: int = 10,
 ) -> discord.Embed:
-    """Query recent log entries (optionally filtered by level)."""
+    """Show recent in-process log records (optionally filtered by level).
+
+    Reads the in-memory ring buffer installed by ``DiagnosticCog.setup()``.
+    The legacy ``logs`` DB table was never written to (the bot logs to
+    ``bot.log`` + stdout), so the DB-backed version always returned
+    "No logs found matching the criteria".
+    """
+    from cogs.diagnostic._log_buffer import recent
+
     limit = max(1, min(limit, 25))
-    try:
-        if event_type:
-            rows = await db.fetchall(
-                "SELECT timestamp, level, message FROM logs "
-                "WHERE level=$1 ORDER BY timestamp DESC LIMIT $2",
-                (event_type.upper(), limit),
-            )
-        else:
-            rows = await db.fetchall(
-                "SELECT timestamp, level, message FROM logs "
-                "ORDER BY timestamp DESC LIMIT $1",
-                (limit,),
-            )
-    except Exception as exc:
-        return discord.Embed(
-            title="Recent Logs",
-            description=f"❌ Could not query logs: {exc}",
-            color=discord.Color.red(),
-        )
+    rows = recent(level=event_type, limit=limit)
 
     embed = discord.Embed(title="Recent Logs", color=discord.Color.dark_red())
     if not rows:

--- a/disbot/cogs/diagnostic/_log_buffer.py
+++ b/disbot/cogs/diagnostic/_log_buffer.py
@@ -1,0 +1,72 @@
+"""In-memory ring buffer of recent bot log records for the diagnostic
+"Recent Logs / Recent Errors" panel.
+
+History: ``build_query_logs_embed`` read a ``logs`` DB table that **nothing ever
+wrote to** (the bot logs to ``bot.log`` + stdout via Python handlers), so the
+panel always returned "No logs found" — even right after a crash. This handler
+keeps the last ``_MAXLEN`` records of the bot's own loggers in memory — cheap,
+no DB/file I/O, no cross-process pollution — for the panel to read. Installed
+once (idempotent) from :func:`cogs.diagnostic_cog.setup`.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+
+_MAXLEN = 500
+_buffer: deque[dict[str, str]] = deque(maxlen=_MAXLEN)
+
+
+class _RingBufferHandler(logging.Handler):
+    """Append each emitted record to the bounded in-memory buffer."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            _buffer.append(
+                {
+                    "timestamp": time.strftime(
+                        "%Y-%m-%d %H:%M:%S",
+                        time.localtime(record.created),
+                    ),
+                    "level": record.levelname,
+                    "message": record.getMessage(),
+                },
+            )
+        except Exception:  # pragma: no cover — a log handler must never raise
+            self.handleError(record)
+
+
+_installed = False
+
+
+def install() -> None:
+    """Attach the ring-buffer handler to the ``bot`` logger tree (idempotent).
+
+    Records from every ``bot.*`` child propagate up to the ``bot`` logger, so a
+    single handler here captures the whole application's logging without
+    touching :mod:`bot1`'s root-logger setup.
+    """
+    global _installed
+    if _installed:
+        return
+    handler = _RingBufferHandler()
+    handler.setLevel(logging.INFO)
+    logging.getLogger("bot").addHandler(handler)
+    _installed = True
+
+
+def recent(level: str | None = None, limit: int = 10) -> list[dict[str, str]]:
+    """Return up to ``limit`` most-recent buffered records, newest first,
+    optionally filtered to a single level name (e.g. ``"ERROR"``)."""
+    items = list(_buffer)
+    if level:
+        wanted = level.upper()
+        items = [r for r in items if r["level"] == wanted]
+    items.reverse()
+    return items[: max(1, limit)]
+
+
+def _reset_for_tests() -> None:
+    _buffer.clear()

--- a/disbot/cogs/diagnostic/_log_buffer.py
+++ b/disbot/cogs/diagnostic/_log_buffer.py
@@ -59,7 +59,8 @@ def install() -> None:
 
 def recent(level: str | None = None, limit: int = 10) -> list[dict[str, str]]:
     """Return up to ``limit`` most-recent buffered records, newest first,
-    optionally filtered to a single level name (e.g. ``"ERROR"``)."""
+    optionally filtered to a single level name (e.g. ``"ERROR"``).
+    """
     items = list(_buffer)
     if level:
         wanted = level.upper()

--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -640,5 +640,8 @@ def _governance_context_for(ctx, target):
 
 
 async def setup(bot):
+    from cogs.diagnostic._log_buffer import install as install_log_buffer
+
+    install_log_buffer()
     await bot.add_cog(DiagnosticCog(bot))
     logger.info("DiagnosticCog loaded.")

--- a/disbot/core/runtime/interaction_helpers.py
+++ b/disbot/core/runtime/interaction_helpers.py
@@ -71,11 +71,25 @@ _EMBED_FIELD_VALUE_LIMIT = 1024
 _EMBED_FOOTER_LIMIT = 2048
 _EMBED_AUTHOR_LIMIT = 256
 _EMBED_MAX_FIELDS = 25
+# Discord also caps the SUM of title + description + every field name/value +
+# footer + author at 6000; an embed can pass every per-component check above and
+# still be rejected whole on this total.
+_EMBED_TOTAL_LIMIT = 6000
 
 
 def _clip(text: str, limit: int) -> str:
     """Truncate ``text`` to ``limit`` chars (ellipsis-terminated)."""
     return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _embed_total_len(embed: discord.Embed) -> int:
+    """Sum of all text Discord counts toward the 6000-char embed budget."""
+    total = len(embed.title or "") + len(embed.description or "")
+    for field in embed.fields:
+        total += len(field.name or "") + len(field.value or "")
+    total += len(embed.footer.text or "")
+    total += len(embed.author.name or "")
+    return total
 
 
 def clamp_embed(embed: discord.Embed) -> discord.Embed:
@@ -134,6 +148,23 @@ def clamp_embed(embed: discord.Embed) -> discord.Embed:
             url=author.url,
             icon_url=author.icon_url,
         )
+
+    # Total-budget pass — Discord rejects the whole embed when the SUM of all
+    # text exceeds 6000, even when every individual component is within its own
+    # limit (observed: the !platform Runtime panel — many fields each <1024
+    # summing >6000 → 400, the panel edit silently dropped, so its Back button
+    # never rendered).  Trim trailing fields first (least-essential detail),
+    # then the description, so the payload renders truncated instead of
+    # hard-failing.
+    if _embed_total_len(embed) > _EMBED_TOTAL_LIMIT:
+        while embed.fields and _embed_total_len(embed) > _EMBED_TOTAL_LIMIT:
+            embed.remove_field(len(embed.fields) - 1)
+        if embed.description and _embed_total_len(embed) > _EMBED_TOTAL_LIMIT:
+            over = _embed_total_len(embed) - _EMBED_TOTAL_LIMIT
+            embed.description = _clip(
+                embed.description,
+                max(1, len(embed.description) - over),
+            )
     return embed
 
 

--- a/disbot/utils/db/migrations.py
+++ b/disbot/utils/db/migrations.py
@@ -79,6 +79,21 @@ def _ordered_migration_versions(filenames: Iterable[str]) -> list[tuple[int, str
     return ordered
 
 
+def migration_versions_on_disk() -> set[int]:
+    """Return the set of migration versions present as ``NNN_*.sql`` files.
+
+    Used by the diagnostic schema check to report "migrations applied N/N"
+    against the migration chain (the authoritative schema source) instead of a
+    hand-maintained expected-table list that silently goes stale as migrations
+    add tables.
+    """
+    if not os.path.isdir(_MIGRATIONS_DIR):
+        return set()
+    return {
+        version for version, _ in _ordered_migration_versions(os.listdir(_MIGRATIONS_DIR))
+    }
+
+
 async def ensure_migrations_table() -> None:
     await pool.get().execute(
         """CREATE TABLE IF NOT EXISTS schema_migrations (

--- a/disbot/utils/db/migrations.py
+++ b/disbot/utils/db/migrations.py
@@ -90,7 +90,8 @@ def migration_versions_on_disk() -> set[int]:
     if not os.path.isdir(_MIGRATIONS_DIR):
         return set()
     return {
-        version for version, _ in _ordered_migration_versions(os.listdir(_MIGRATIONS_DIR))
+        version
+        for version, _ in _ordered_migration_versions(os.listdir(_MIGRATIONS_DIR))
     }
 
 

--- a/disbot/views/roles/management_panel.py
+++ b/disbot/views/roles/management_panel.py
@@ -174,7 +174,7 @@ class EditRoleModal(discord.ui.Modal, title="Edit Role"):  # type: ignore[call-a
 
 class _DeleteRoleSelect(discord.ui.Select):
     def __init__(self, parent: ManagementPanel, roles: list[discord.Role]) -> None:
-        self.parent = parent  # type: ignore[misc]
+        self._panel = parent
         options = [
             discord.SelectOption(label=r.name[:100], value=str(r.id)) for r in roles
         ][:25]
@@ -201,10 +201,10 @@ class _DeleteRoleSelect(discord.ui.Select):
                 f"🗑️ Deleted role **{name}**.",
                 ephemeral=True,
             )
-            if self.parent.message:  # type: ignore[attr-defined]
-                await self.parent.message.edit(  # type: ignore[attr-defined]
-                    embed=await self.parent.build_embed(),  # type: ignore[attr-defined]
-                    view=self.parent,  # type: ignore[attr-defined]
+            if self._panel.message:
+                await self._panel.message.edit(
+                    embed=await self._panel.build_embed(),
+                    view=self._panel,
                 )
         else:
             await interaction.response.send_message(

--- a/disbot/views/roles/time_roles_panel.py
+++ b/disbot/views/roles/time_roles_panel.py
@@ -77,7 +77,7 @@ class TimeRolesPanel(BaseView):
             embed.set_footer(text="Roles auto-assigned based on days in server.")
         return embed
 
-    async def _refresh(self) -> None:
+    async def _rerender(self) -> None:
         if self.message:
             await self.message.edit(embed=await self.build_embed(), view=self)
 
@@ -146,7 +146,7 @@ class TimeRolesPanel(BaseView):
             seeded.append(role.name)
         if not await safe_defer(interaction, ephemeral=True):
             return
-        await self._refresh()
+        await self._rerender()
         parts = []
         if seeded:
             parts.append(f"Seeded {len(seeded)}: {', '.join(seeded)}.")
@@ -233,12 +233,12 @@ class TimeDaysModal(discord.ui.Modal, title="Set Day Threshold"):  # type: ignor
         invalidate_xp_threshold_roles(interaction.guild.id)
         if not await safe_defer(interaction):
             return
-        await self.parent._refresh()
+        await self.parent._rerender()
 
 
 class _TimeRemoveSelect(discord.ui.Select):
     def __init__(self, parent: TimeRolesPanel, thresholds: list[dict]) -> None:
-        self.parent = parent  # type: ignore[misc]
+        self._panel = parent
         options = [
             discord.SelectOption(
                 label=r["role_name"],
@@ -259,7 +259,7 @@ class _TimeRemoveSelect(discord.ui.Select):
             f"✅ Removed **{self.values[0]}** from auto-assignment.",
             ephemeral=True,
         )
-        await self.parent._refresh()  # type: ignore[attr-defined]
+        await self._panel._rerender()
 
 
 class _TimeRemoveView(discord.ui.View):

--- a/disbot/views/roles/xp_roles_panel.py
+++ b/disbot/views/roles/xp_roles_panel.py
@@ -77,7 +77,7 @@ class XpRolesPanel(BaseView):
             embed.set_footer(text="✅ auto-assign active  ⏸️ configured but paused")
         return embed
 
-    async def _refresh(self) -> None:
+    async def _rerender(self) -> None:
         if self.message:
             await self.message.edit(embed=await self.build_embed(), view=self)
 
@@ -199,12 +199,12 @@ class XpLevelModal(discord.ui.Modal, title="Set XP Threshold"):  # type: ignore[
         invalidate_xp_threshold_roles(interaction.guild.id)
         if not await safe_defer(interaction):
             return
-        await self.parent._refresh()
+        await self.parent._rerender()
 
 
 class _XpRemoveSelect(discord.ui.Select):
     def __init__(self, parent: XpRolesPanel, rows: list[dict]) -> None:
-        self.parent = parent  # type: ignore[misc]
+        self._panel = parent
         options = [
             discord.SelectOption(
                 label=r["role_name"],
@@ -230,7 +230,7 @@ class _XpRemoveSelect(discord.ui.Select):
             f"✅ Removed XP threshold for **{self.values[0]}**.",
             ephemeral=True,
         )
-        await self.parent._refresh()  # type: ignore[attr-defined]
+        await self._panel._rerender()
 
 
 class _XpRemoveView(discord.ui.View):

--- a/disbot/views/setup/ai_review/main_panel.py
+++ b/disbot/views/setup/ai_review/main_panel.py
@@ -186,7 +186,7 @@ class AIReviewPanelView(BaseView):
             embed.set_footer(text=self.last_status)
         return embed
 
-    async def _refresh(self, interaction: discord.Interaction) -> None:
+    async def _rerender(self, interaction: discord.Interaction) -> None:
         try:
             await interaction.response.edit_message(
                 embed=self._refresh_embed(),
@@ -194,7 +194,7 @@ class AIReviewPanelView(BaseView):
             )
         except discord.HTTPException:
             logger.warning(
-                "AIReviewPanelView._refresh: edit_message failed.",
+                "AIReviewPanelView._rerender: edit_message failed.",
             )
 
     @discord.ui.button(
@@ -213,7 +213,7 @@ class AIReviewPanelView(BaseView):
             f"Accepted {added} high-confidence recommendation(s); "
             f"total accepted: {self.accepted.count}."
         )
-        await self._refresh(interaction)
+        await self._rerender(interaction)
 
     @discord.ui.button(
         label="Review one-by-one",
@@ -275,7 +275,7 @@ class AIReviewPanelView(BaseView):
             f"Rejected {removed} AI suggestion(s); accepted set "
             f"refreshed to {self.accepted.count}."
         )
-        await self._refresh(interaction)
+        await self._rerender(interaction)
 
     @discord.ui.button(
         label="Rerun deterministic-only",
@@ -315,7 +315,7 @@ class AIReviewPanelView(BaseView):
             f"{len(self.draft.recommendations)} recommendation(s); "
             f"accepted set: {self.accepted.count}."
         )
-        await self._refresh(interaction)
+        await self._rerender(interaction)
 
     @discord.ui.button(
         label="Stage & open Final review",

--- a/disbot/views/xp/config_panel.py
+++ b/disbot/views/xp/config_panel.py
@@ -60,7 +60,7 @@ class XpConfigView(BaseView):
         embed.set_footer(text="Click a button below to change a setting.")
         return embed
 
-    async def _refresh(self, interaction: discord.Interaction):  # type: ignore[override]
+    async def _rerender(self, interaction: discord.Interaction):  # type: ignore[override]
         await safe_edit(interaction, embed=await self.build_embed(), view=self)
 
     @discord.ui.button(label="XP Range", style=discord.ButtonStyle.blurple, row=0)

--- a/disbot/views/xp/modals.py
+++ b/disbot/views/xp/modals.py
@@ -237,7 +237,7 @@ class _XpRangeModal(discord.ui.Modal, title="Set XP Range"):  # type: ignore[cal
             return
         if not await safe_defer(interaction):
             return
-        await self.view._refresh(interaction)
+        await self.view._rerender(interaction)
 
 
 class _XpCooldownModal(discord.ui.Modal, title="Set XP Cooldown"):  # type: ignore[call-arg]
@@ -264,7 +264,7 @@ class _XpCooldownModal(discord.ui.Modal, title="Set XP Cooldown"):  # type: igno
             return
         if not await safe_defer(interaction):
             return
-        await self.view._refresh(interaction)
+        await self.view._rerender(interaction)
 
 
 class _XpChannelModal(discord.ui.Modal, title="Level-up Announcement Channel"):  # type: ignore[call-arg]
@@ -291,4 +291,4 @@ class _XpChannelModal(discord.ui.Modal, title="Level-up Announcement Channel"): 
             return
         if not await safe_defer(interaction):
             return
-        await self.view._refresh(interaction)
+        await self.view._rerender(interaction)

--- a/docs/planning/cog-functionality-audit-2026-06-05.md
+++ b/docs/planning/cog-functionality-audit-2026-06-05.md
@@ -366,6 +366,29 @@ other dense `platform_*` sub-views. **Fix:** truncate/paginate (cap the descript
 detail into fields/pages). No `attach_back_button` 25-cap warnings were logged, so the
 navigation helper itself is fine — this is purely the oversized embed.
 
+### 🔴 DiagnosticCog: "Recent Errors / Recent Logs" panel is permanently empty
+`build_query_logs_embed` (`cogs/diagnostic/_helpers.py:341`) reads
+`SELECT … FROM logs`, but **nothing ever writes to the `logs` table** — the bot logs to
+`bot.log` (file) + stdout via Python handlers (bot1.py); there's no DB log handler and
+no `INSERT INTO logs` anywhere. So "Recent Errors" always shows "No logs found," even
+right after a crash. `logs` is one of the 16 base tables, but its writer was never built
+— a long-standing dead feature. **Fix options:** (a) repoint the panel to tail/parse
+`bot.log` (simple, no new writes); or (b) add an async-safe DB log handler that persists
+ERROR/WARNING records to `logs` (survives restarts, but needs queue/loop plumbing since
+logging handlers are sync and the pool is async).
+
+### 🟡 DiagnosticCog: "Database Schema Check" expected-tables list is 52 stale
+`build_check_database_embed` (`_helpers.py:200`) hardcodes **16 expected tables** — the
+pre-migration `create_tables()` base set — so every migration-added table shows as
+"Unexpected (52)". The DB actually has 68 tables and `Missing: None` (the schema is
+fine); the "Unexpected" list is just a stale comparison. **Fix is non-trivial:**
+hand-adding 52 names re-rots on the next migration, and deriving from `migrations/*.sql`
+is incomplete — validated that ~11 tables (`bot_runtime_lock`, `setup_session`,
+`guild_command_access_*`, `automation_*`, …) are created by **runtime Python code**, not
+a `.sql` file, so no regex over migrations is complete. Cleanest: reframe to "migrations
+applied N/N" (compare `schema_migrations` to the migration files) and drop the brittle
+"Unexpected" field — or maintain a complete list guarded by a fresh-DB-bootstrap CI test.
+
 ### interaction_router warnings = benign noise (with a latent gap)
 Only **`ai`** registers a router prefix (`ai_cog.py:322`). Every other panel handles its
 components **in-memory** via the View, but discord.py fires the global `on_interaction`

--- a/docs/planning/cog-functionality-audit-2026-06-05.md
+++ b/docs/planning/cog-functionality-audit-2026-06-05.md
@@ -64,7 +64,7 @@ keys off the hardcoded `config.BOT_OWNER_USER_ID` (and AI is off anyway).
 |---|---|---:|---:|---|:--:|
 | BootstrapAccessCog | — (infra guard) | 0 | 0 | — | ✅ infra |
 | AdminCog | `!adminmenu` | 9 | 1 | — | ❓ |
-| DiagnosticCog | `!platform` | 43 | 1 | — | ❓ |
+| DiagnosticCog | `!platform` | 43 | 1 | — | 🔴 |
 | SettingsCog | `!settings` | 2 | 1 | — | ❓ |
 | SetupCog | `!setup` / `setup-hub` | 1 | 9 | advisor=deterministic | ❓ |
 | LoggingCog | `!logging` | 6 | 0 | webhook off; logging OFF by default | ❓ |
@@ -73,7 +73,7 @@ keys off the hardcoded `config.BOT_OWNER_USER_ID` (and AI is off anyway).
 ### Server management
 | Cog | Panel / hub | prefix | slash | Env-gate | Status |
 |---|---|---:|---:|---|:--:|
-| RoleCog | `!rolemenu` / `!roles` | 14 | 0 | automation scheduler off | 🟡 |
+| RoleCog | `!rolemenu` / `!roles` | 14 | 0 | automation scheduler off | 🔴→✅ |
 | ChannelCog | `!channelmenu` | 15 | 0 | — | ❓ |
 | ModerationCog | `!modmenu` | 8 | 1 | logging dest off by default | ❓ |
 | Cleanup | `!wordmenu` | 7 | 0 | — | ❓ |
@@ -332,5 +332,77 @@ keys off the hardcoded `config.BOT_OWNER_USER_ID` (and AI is off anyway).
   findings**, `resource_provisioning_catalogue` **1 finding**. These are the bot's own
   gap detectors — pull them via `!platform customization` / `!platform consistency`
   while auditing.
+
+## Session findings — live testing 2026-06-05 (supersedes ❓ where noted)
+
+### 🔴→✅ RoleCog: two discord.py 2.7.1 crashes — FOUND & FIXED this session
+The "two warts" from last session were not the real problem. Live testing crashed the
+bot and broke role management because the panels collide with **discord.py 2.7.1**
+internals (`requirements.txt` pins `discord.py>=2.3.0` **unpinned** → resolves to 2.7.x):
+
+1. **Whole-bot crash.** `TimeRolesPanel` / `XpRolesPanel` defined `async def _refresh(self)`,
+   shadowing discord.py's `View._refresh(components)` (called on every MESSAGE_UPDATE).
+   The 1-arg override raised `TypeError` **inside the gateway poll loop** → process exit.
+   **Fix:** renamed the panel re-render helper to `_rerender`. (Same latent collision —
+   2-arg async, warn-only not crash — in `views/xp/config_panel.py` and
+   `views/setup/ai_review/main_panel.py`; also renamed.)
+2. **Delete Role + both Remove dropdowns broken.** `_DeleteRoleSelect` /
+   `_TimeRemoveSelect` / `_XpRemoveSelect` did `self.parent = parent`, colliding with
+   discord.py 2.7.1's **read-only `Item.parent`** property → `AttributeError` on click.
+   **Fix:** store the panel as `self._panel`. (Scan confirmed these 3 selects were the
+   only `self.parent`-on-an-Item assignments in the whole codebase.)
+
+Regression-pinned by `tests/unit/views/test_role_panels_discordpy_compat.py`.
+**Recommendation:** pin `discord.py>=2.7,<2.8` (CLAUDE.md "pin where the API churned")
+and sweep other `discord.ui` overrides for 2.7 collisions. The 2 prior UX warts
+(bulk "Clear missing", selector-ize Edit Role) remain open but are lower priority.
+
+### 🔴 DiagnosticCog: `!platform` Runtime sub-view = your "no back button"
+`!platform` → **Runtime** tab (`platform_hub.runtime`) builds an embed **> Discord's
+6000-char limit** → `safe_edit` returns 400 (50035 "Embed size exceeds maximum size of
+6000") → the message edit (new embed **and** its Back/Help button) never applies, so the
+panel looks frozen and loses its back button. Confirmed in `bot.log` (×2). Likely affects
+other dense `platform_*` sub-views. **Fix:** truncate/paginate (cap the description; push
+detail into fields/pages). No `attach_back_button` 25-cap warnings were logged, so the
+navigation helper itself is fine — this is purely the oversized embed.
+
+### interaction_router warnings = benign noise (with a latent gap)
+Only **`ai`** registers a router prefix (`ai_cog.py:322`). Every other panel handles its
+components **in-memory** via the View, but discord.py fires the global `on_interaction`
+for each click too, so the router logs "Unhandled interaction prefix" once per unseen
+prefix (`role`, `xp`, `help`, `community`, `settings_hub.*`, `platform_hub.*`, plus a new
+hex id per component). **Buttons still work.** Latent gap: after a view times out / on
+restart those clicks fall through to a router that can't answer them. Mirroring the AI
+cog's safety-net registration would silence the spam and let expired panels reply
+gracefully. (`role` is even in the router's `_FAIL_CLOSED_PREFIXES` with no handler, so
+that posture is currently inert.)
+
+### Bot self-audit dump (62 findings) — wiring gaps, not command breakage
+The three startup catalogues introspect the loaded cogs and flag integration gaps:
+
+- **`command_surface_ledger` — 9** · `orphan_cog_subsystems`: BTD6EventsCog, BTD6OpsCog,
+  BTD6ReferenceCog, BTD6StrategyCog, FourTwentyCog, ParagonCog, ProofChannelCog,
+  RockPaperScissorsCog, SetupCog. → work, but not first-class "subsystems" in the
+  settings/governance model.
+- **`customization_catalogue` — 52**:
+  - `subsystems_missing_panel` (4): four_twenty, help, proof_channel, rps_tournament
+  - `subsystems_missing_help_hook` (4): same 4 (not in the Help-menu hook system)
+  - `subsystems_missing_schema` (17): admin, chain, channel, cleanup, community, counting,
+    diagnostic, four_twenty, games, general, help, inventory, leaderboard, mining,
+    proof_channel, settings, utility (no `!settings` schema — some legitimately none;
+    channel/cleanup/counting arguably should have one)
+  - `panels_without_settings` (24): panels with no settings behind them (adminmenu,
+    chainmenu, wordmenu …; `<build_help_menu_view>` = auto help sub-panels)
+  - `settings_without_panel` (1): rps_tournament.default_entry_fee
+  - `regex_inferred_panels` (2): ai.aimenu, btd6.btd6menu (only detected via a fragile
+    regex fallback, not explicitly declared)
+- **`resource_provisioning_catalogue` — 1** · `orphan_requirements`: moderation/mod_log
+  (declares a mod-log channel need with no binding spec to provision/resolve it; ties to
+  logging being OFF by default).
+
+→ Net: the 62 are **integration/wiring gaps** (cogs not fully registered into the
+settings/help/governance framework), not broken commands. Good per-cog "is this fully
+wired in?" checklist; biggest clusters are the 9 orphan subsystems + 17 missing-schema
+cogs.
 
 _(running log of issues found during the walkthrough — append below)_

--- a/docs/planning/cog-functionality-audit-2026-06-05.md
+++ b/docs/planning/cog-functionality-audit-2026-06-05.md
@@ -1,0 +1,336 @@
+# Cog-by-Cog Functionality Audit — 2026-06-05
+
+> **Status:** live working document. This is the session tracker for a structured,
+> cog-by-cog walkthrough of **every** command (prefix + slash) and command panel,
+> assigning each cog a current status. Built against a **live test bot**
+> (`Galaxy Bot#6724`) booted in the cloud container on a **fresh local Postgres**
+> (56 migrations, 68 tables). Updated as we test each surface.
+>
+> **How to use:** for each cog we run the chat commands and open the panels in the
+> private test server, watch the live logs, cross-check the source, and set a status.
+> Fill the **Status** + **Notes** as we go. Source is authoritative over this doc.
+
+---
+
+## Environment caveats — features that are *intentionally* degraded here
+
+The container is **not** a full production environment. Several features are gated
+behind env vars / API keys that are not set here. When one of these "doesn't work,"
+that is the environment, **not a bug** — flag it `⏸️ env-gated`, don't call it broken.
+
+| Env var (this container) | State | What is degraded |
+|---|---|---|
+| `AI_ENABLED` | **unset → off** | The whole AI platform runs in deterministic/disabled mode. `AICog` chat answers, AI setup-advisor suggestions, BTD6 AI strategy generation/grounding → no real LLM calls. |
+| `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` | **empty** | No LLM provider available even if a task is toggled on; factory falls back to `deterministic`. |
+| `SETUP_ADVISOR_PROVIDER` | `deterministic` | Setup advisor uses name-matching rules only (no AI recommendations). |
+| `AUTOMATION_SCHEDULER_ENABLED` | **`false`** | The background **time/XP role auto-assignment loop is not spawned**. Manual triggers (`!assignroles`, panel "▶️ Run Now") still work. |
+| `YOUTUBE_API_KEY` | **unset** | YouTube context / video-reference lookups (BTD6 strategy sourcing) degraded/off. |
+| `PARAGON_API_KEY` (+ `PARAGON_API_BASE_URL`) | key empty, public URL default | Paragon calculator calls the public API **if outbound is reachable**, else falls back to a labelled local estimate. |
+| `BTD6_DATA_BACKEND` | **unset → `file`** | BTD6 data served from committed files under `disbot/data/btd6/`. `postgres`/`cloud` backends inactive. |
+| `DISCORD_WEBHOOK_URL` | **unset** | Webhook startup/log mirroring disabled (cosmetic; no user-facing command). |
+
+**Server logging** is not env-gated but ships **OFF per guild by default** (audit/mod
+log embeds won't post to a channel until enabled via `!settings` / `!logging`).
+
+### Command access — fail-open on this fresh DB ✅
+`resolve_command_access` returns **`ALL_CHANNELS` / `DEFAULT_UNCONFIGURED`** when a
+guild has no policy row (`command_access.py:367`). The fresh local DB has no policy
+for the test guild, so **every command is allowed in every channel** — nothing is
+silently blocked by the access gate. Owner-gating uses `bot.is_owner` (the Discord
+application owner = you), so owner-only commands work. Only AI's owner-personalization
+keys off the hardcoded `config.BOT_OWNER_USER_ID` (and AI is off anyway).
+
+---
+
+## Status legend
+
+| Symbol | Meaning |
+|---|---|
+| ✅ | **finished** — works as intended, complete |
+| 🟡 | **unfinished / wart** — works but has UX gaps, stubs, or partial coverage |
+| 🔴 | **broken** — errors, no-ops, or wrong behavior |
+| ⏸️ | **env-gated** — cannot be fully verified in this container (needs a key/flag) |
+| ❓ | **untested** — not yet walked through |
+
+---
+
+## Master progress table
+
+> 34 cogs loaded at boot. `BootstrapAccessCog` is infrastructure (the command-access
+> guard) and has no user commands. Counts are prefix / slash from the live registry.
+
+### Core · Admin · Config
+| Cog | Panel / hub | prefix | slash | Env-gate | Status |
+|---|---|---:|---:|---|:--:|
+| BootstrapAccessCog | — (infra guard) | 0 | 0 | — | ✅ infra |
+| AdminCog | `!adminmenu` | 9 | 1 | — | ❓ |
+| DiagnosticCog | `!platform` | 43 | 1 | — | ❓ |
+| SettingsCog | `!settings` | 2 | 1 | — | ❓ |
+| SetupCog | `!setup` / `setup-hub` | 1 | 9 | advisor=deterministic | ❓ |
+| LoggingCog | `!logging` | 6 | 0 | webhook off; logging OFF by default | ❓ |
+| HelpCog | `!help` | 1 | 0 | — | ❓ |
+
+### Server management
+| Cog | Panel / hub | prefix | slash | Env-gate | Status |
+|---|---|---:|---:|---|:--:|
+| RoleCog | `!rolemenu` / `!roles` | 14 | 0 | automation scheduler off | 🟡 |
+| ChannelCog | `!channelmenu` | 15 | 0 | — | ❓ |
+| ModerationCog | `!modmenu` | 8 | 1 | logging dest off by default | ❓ |
+| Cleanup | `!wordmenu` | 7 | 0 | — | ❓ |
+| CommunityCog | `!community` | 1 | 1 | — | ❓ |
+
+### Economy · Progression
+| Cog | Panel / hub | prefix | slash | Env-gate | Status |
+|---|---|---:|---:|---|:--:|
+| EconomyCog | `!economymenu` | 7 | 1 | — | ❓ |
+| XpCog | `!xpmenu` | 5 | 0 | automation scheduler off | ❓ |
+| InventoryCog | `!inventory` | 1 | 0 | — | ❓ |
+| MiningCog | `!minemenu` | 12 | 0 | — | ❓ |
+| Leaderboard | `!leaderboard` | 1 | 0 | — | ❓ |
+
+### Games · Social
+| Cog | Panel / hub | prefix | slash | Env-gate | Status |
+|---|---|---:|---:|---|:--:|
+| BlackjackCog | `!blackjack` / `!bjstart` | 4 | 0 | — | ❓ |
+| Rock Paper Scissors | `!rps` / `!rpsstart` | 7 | 0 | — | ❓ |
+| Deathmatch | `!dm_challenge` | 2 | 0 | — | ❓ |
+| GamesCog | `!games` | 1 | 1 | — | ❓ |
+| CountingCog | `!countingmenu` | 9 | 0 | — | ❓ |
+| ChainCog | `!chainmenu` | 7 | 0 | — | ❓ |
+| FourTwentyCog | `!420` | 1 | 0 | — | ❓ |
+| ProofChannelCog | `!prizemenu` | 5 | 0 | — | ❓ |
+
+### BTD6 suite
+| Cog | Panel / hub | prefix | slash | Env-gate | Status |
+|---|---|---:|---:|---|:--:|
+| BTD6Cog | `!btd6menu` | 7 | 1 | data=file; AI off | ❓ |
+| BTD6ReferenceCog | `!btd6ref …` | 6 | 0 | data=file | ❓ |
+| BTD6EventsCog | `!btd6events …` | 9 | 0 | live sources need outbound | ❓ |
+| BTD6StrategyCog | `!btd6strat …` | 9 | 0 | AI off; YouTube off | ❓ |
+| BTD6OpsCog | `!btd6ops …` | 7 | 0 | data backends/ingestion | ❓ |
+| ParagonCog | `!paragon` | 1 | 0 | Paragon API (outbound) | ❓ |
+
+### AI · General · Utility
+| Cog | Panel / hub | prefix | slash | Env-gate | Status |
+|---|---|---:|---:|---|:--:|
+| AICog | `!aimenu` | 12 | 1 | **AI_ENABLED off** | ⏸️ |
+| General | `!generalmenu` | 8 | 0 | — | ❓ |
+| UtilityCog | `!utilitymenu` | 9 | 1 | — | ❓ |
+
+---
+
+## Per-cog detail (seeded inventory — fill Status/Notes as we test)
+
+### RoleCog — 🟡 unfinished (two known warts)
+- **Panels:** `!rolemenu` (hub) · `!roles` · `!rolecreator` · `!rolesettings`
+- **Prefix (14):** assignroles, createrole, debugroles, deleterole, listreactroles,
+  reactroles, refreshmembers, removereactrole, rolecreator, rolemenu, roles,
+  rolesettings, setrole, unsetrole
+- **Env:** `AUTOMATION_SCHEDULER_ENABLED=false` → time/XP auto-assign loop inactive
+  here; `!assignroles` / panel "▶️ Run Now" trigger it manually.
+- **Known findings (prev session, verified in source):**
+  1. Time/XP role panels list **phantom stale rows** (`Neu/Iron/Beacon…` whose role
+     no longer resolves). They're flagged `⚠️ role missing` but can only be removed
+     one-at-a-time — **no bulk "Clear missing"** (`time_roles_panel.py` /
+     `xp_roles_panel.py`).
+  2. **Edit Role** uses a **free-text role-name** TextInput + `_find_role_normalized`
+     instead of a selector — inconsistent with Delete (which is selector-driven) and
+     with PR6's pick-then-modal pattern (`management_panel.py:EditRoleModal`).
+  - The "panel can no longer be verified" message is **by design** (fail-closed on a
+    stale post-redeploy anchor; ADR-004/RC-3) — re-run `!roles`. Not a bug.
+- **Status:** 🟡 — core works; the two warts above are the candidate fix.
+- **Notes:** _…_
+
+### ChannelCog — ❓
+- **Panel:** `!channelmenu` (hub → list / create / move-reorder / etc.)
+- **Prefix (15):** bulkcreate, bulkdelete, channelinfo, channelmenu, clone, create,
+  del, evt, list, lock, move, permissions, rename, set, unlock
+- **Notes:** rename/move/delete/reorder route through `ChannelLifecycleService`
+  (PR3/4/7). create/clone/lock/permissions still on cog paths.
+- **Status:** ❓ · **Notes:** _…_
+
+### ModerationCog — ❓
+- **Panel:** `!modmenu`
+- **Prefix (8):** ban, clearwarnings, kick, modlogs, modmenu, timeout, unban, warn · **slash:** moderation
+- **Notes:** all manual actions route through `moderation_service` (PR1). Audit/mod
+  log embeds need a logging destination configured to appear in a channel.
+- **Status:** ❓ · **Notes:** _…_
+
+### Cleanup — ❓
+- **Panel:** `!wordmenu` · **Prefix (7):** cleanup, cleanuphistory, word, word add,
+  word list, word remove, wordmenu
+- **Status:** ❓ · **Notes:** _…_
+
+### CommunityCog — ❓
+- **Entry:** `!community` (prefix + slash)
+- **Status:** ❓ · **Notes:** _…_
+
+### AdminCog — ❓
+- **Panel:** `!adminmenu` · **Prefix (9):** adminmenu, cog, loadall, loglevel,
+  restart, serverstats, slashes, syncslash, unloadall · **slash:** admin
+- **Notes:** `restart`/`loadall`/`unloadall`/`cog` are owner-gated (`bot.is_owner`).
+  `restart` here will kill the container process — test last / with care.
+- **Status:** ❓ · **Notes:** _…_
+
+### DiagnosticCog — ❓
+- **Hub:** `!platform` (33 subcommands) · **Prefix (43):** check_database,
+  diagnostics, find_command, latency, lifecycle, list_commands_detailed, platform (+
+  access, anchors, automation, bindings, caches, cleanup-preview, command-access,
+  consistency, counting-health, customization, flag, flags, identity, lifecycle,
+  locks, migrations, participation-schemas, provisioning, resource-requirements,
+  resources, runtime, schemas, sessions, setting, settings-registry, setup-readiness,
+  slow, status, tasks, views), query_logs, recent_errors, system_info,
+  test_notification, validate_json_files · **slash:** platform
+- **Notes:** read-only diagnostics — great for cross-checking other cogs' state.
+- **Status:** ❓ · **Notes:** _…_
+
+### SettingsCog — ❓
+- **Panel:** `!settings` (+ `!settings access`) · **slash:** settings
+- **Notes:** settings registry = 24 entries across 9 subsystems (from boot).
+- **Status:** ❓ · **Notes:** _…_
+
+### SetupCog — ❓
+- **Hub:** `!setup` / `setup-hub` · **slash (9):** setup, setup-delegate, setup-depth,
+  setup-hub, setup-reset, setup-skip, setup-status, setup-undelegate, setup-unskip
+- **Env:** advisor deterministic (no AI suggestions).
+- **Status:** ❓ · **Notes:** _…_
+
+### LoggingCog — ❓
+- **Hub:** `!logging` · **Prefix (6):** logging, logging create, logging routes,
+  logging set, logging status, logging test
+- **Env:** webhook mirror off; server-logging policy OFF by default (enable to see
+  embeds post to a channel).
+- **Status:** ❓ · **Notes:** _…_
+
+### HelpCog — ❓
+- **Entry:** `!help` (dynamic help surface; 298 command descriptions at boot)
+- **Status:** ❓ · **Notes:** _…_
+
+### EconomyCog — ❓
+- **Panel:** `!economymenu` · **Prefix (7):** balance, daily, economymenu, joblist,
+  setlogchannel, shop, work · **slash:** economy
+- **Status:** ❓ · **Notes:** _…_
+
+### XpCog — ❓
+- **Panel:** `!xpmenu` · **Prefix (5):** givexp, rank, resetxp, xpconfig, xpmenu
+- **Env:** XP→role auto-assign tied to the (disabled) automation scheduler; XP gain on
+  messages still works.
+- **Status:** ❓ · **Notes:** _…_
+
+### InventoryCog — ❓
+- **Entry:** `!inventory`
+- **Status:** ❓ · **Notes:** _…_
+
+### MiningCog — ❓
+- **Panel:** `!minemenu` · **Prefix (12):** build, buildable, buildlist, chop,
+  explore, give, mine, mineinv, minemenu, minestats, reset_inventory, use
+- **Status:** ❓ · **Notes:** _…_
+
+### Leaderboard — ❓
+- **Entry:** `!leaderboard`
+- **Status:** ❓ · **Notes:** _…_
+
+### BlackjackCog — ❓
+- **Entry:** `!blackjack` / `!bjstart` · **Prefix (4):** bjstart, bjstatus,
+  bjtournament, blackjack
+- **Status:** ❓ · **Notes:** _…_
+
+### Rock Paper Scissors — ❓
+- **Entry:** `!rps` / `!rpsstart` · **Prefix (7):** rps, rpsbot, rpshelp, rpsmatchup,
+  rpsregister, rpssettings, rpsstart
+- **Status:** ❓ · **Notes:** _…_
+
+### Deathmatch — ❓
+- **Entry:** `!dm_challenge` · **Prefix (2):** dm_challenge, dm_help
+- **Status:** ❓ · **Notes:** _…_
+
+### GamesCog — ❓
+- **Hub:** `!games` (prefix + slash) — game launcher hub
+- **Status:** ❓ · **Notes:** _…_
+
+### CountingCog — ❓
+- **Panel:** `!countingmenu` · **Prefix (9):** count_info, count_rules, countingmenu,
+  end_match, reset_count, set_skip_numbers, start_match,
+  toggle_reset_on_wrong_count, toggle_turns
+- **Status:** ❓ · **Notes:** _…_
+
+### ChainCog — ❓
+- **Panel:** `!chainmenu` · **Prefix (7):** chain, chain create, chain delete,
+  chain list, chain removelimit, chain setlimit, chainmenu
+- **Status:** ❓ · **Notes:** _…_
+
+### FourTwentyCog — ❓
+- **Entry:** `!420`
+- **Status:** ❓ · **Notes:** _…_
+
+### ProofChannelCog — ❓
+- **Panel:** `!prizemenu` · **Prefix (5):** +prize, -prize, prizemenu, prizestatus,
+  timedprize
+- **Status:** ❓ · **Notes:** _…_
+
+### BTD6Cog — ❓
+- **Panel:** `!btd6menu` · **Prefix (7):** btd6, btd6 ask, btd6 ctteam,
+  btd6 diagnostics, btd6 status, btd6 test-intent, btd6menu · **slash:** btd6menu
+- **Env:** data=file; `btd6 ask` AI grounding off (AI disabled).
+- **Status:** ❓ · **Notes:** _…_
+
+### BTD6ReferenceCog — ❓
+- **Group:** `!btd6ref` · **Prefix (6):** btd6ref ct, btd6ref hero, btd6ref relic,
+  btd6ref round, btd6ref tower
+- **Status:** ❓ · **Notes:** _…_
+
+### BTD6EventsCog — ❓
+- **Group:** `!btd6events` (9): event, grounding, latest-data, leaderboard, live,
+  refresh-source, source-health, sources
+- **Env:** live/refresh need outbound to sources.
+- **Status:** ❓ · **Notes:** _…_
+
+### BTD6StrategyCog — ❓
+- **Group:** `!btd6strat` (9): browse, mine, pending, strategies, strategy,
+  strategy-audit, submit, why-no-response
+- **Env:** AI off; YouTube off → mining/generation degraded.
+- **Status:** ❓ · **Notes:** _…_
+
+### BTD6OpsCog — ❓
+- **Group:** `!btd6ops` (7): announcechannel, readiness, runs, seed-data,
+  source_disable, source_enable
+- **Status:** ❓ · **Notes:** _…_
+
+### ParagonCog — ❓
+- **Entry:** `!paragon`
+- **Env:** Paragon calc API (outbound); local estimate fallback.
+- **Status:** ❓ · **Notes:** _…_
+
+### AICog — ⏸️ env-gated
+- **Panel:** `!aimenu` · **Prefix (12):** ai, ai diagnostics, ai forget, ai policy,
+  ai providers, ai readiness, ai routing, ai settings, ai status, ai support-report,
+  ai why-no-response, aimenu · **slash:** aimenu
+- **Env:** `AI_ENABLED` off → chat answers won't call an LLM. The **config/diagnostic**
+  subcommands (status, readiness, providers, policy, routing, settings) should still
+  render — they describe the (disabled) platform. Distinguish "answer path off" from
+  "panel broken."
+- **Status:** ⏸️ — verify the config/diagnostic surface; answer path is expected off.
+
+### General — ❓
+- **Panel:** `!generalmenu` · **Prefix (8):** eightball, fact, generalmenu, greet,
+  joke, motivate, quote, trivia
+- **Status:** ❓ · **Notes:** _…_
+
+### UtilityCog — ❓
+- **Panel:** `!utilitymenu` · **Prefix (9):** avatar, clear, info, invite, poll,
+  remind, serverinfo, userinfo, utilitymenu · **slash:** utility
+- **Status:** ❓ · **Notes:** _…_
+
+---
+
+## Cross-cutting findings (env / infra, not per-cog bugs)
+
+- `AUTOMATION_SCHEDULER_ENABLED=false` — confirmed in boot log: *"automation_scheduler:
+  spawn skipped."* Affects Role + XP auto-assignment loops.
+- Boot-time self-catalogue findings worth reviewing: `customization_catalogue` reported
+  **52 findings** across 27 subsystems / 40 panels, `command_surface_ledger` **9
+  findings**, `resource_provisioning_catalogue` **1 finding**. These are the bot's own
+  gap detectors — pull them via `!platform customization` / `!platform consistency`
+  while auditing.
+
+_(running log of issues found during the walkthrough — append below)_

--- a/tests/unit/cogs/test_diagnostic_panels_data.py
+++ b/tests/unit/cogs/test_diagnostic_panels_data.py
@@ -1,0 +1,94 @@
+"""Diagnostic panel data-source fixes (live-audit 2026-06-05).
+
+- "Recent Errors / Recent Logs" reads an in-memory ring buffer instead of the
+  legacy ``logs`` DB table (which nothing ever wrote to → always "No logs
+  found").
+- "Database Schema Check" reports migrations-applied N/N + base tables instead
+  of a hard-coded "expected tables" list (which flagged every migration-added
+  table as "unexpected").
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+def test_log_buffer_captures_and_filters_by_level():
+    from cogs.diagnostic import _log_buffer
+
+    _log_buffer._reset_for_tests()
+    _log_buffer.install()  # idempotent
+
+    log = logging.getLogger("bot.test_log_buffer")
+    log.setLevel(logging.DEBUG)
+    log.error("ring-buffer boom")
+    log.info("ring-buffer info")
+
+    errors = _log_buffer.recent(level="ERROR", limit=10)
+    assert errors and errors[0]["level"] == "ERROR"
+    assert any("ring-buffer boom" in r["message"] for r in errors)
+    assert all(r["level"] == "ERROR" for r in errors)
+
+    everything = _log_buffer.recent(limit=10)
+    assert any("ring-buffer info" in r["message"] for r in everything)
+
+
+@pytest.mark.asyncio
+async def test_query_logs_embed_reads_ring_buffer():
+    from cogs.diagnostic import _helpers, _log_buffer
+
+    _log_buffer._reset_for_tests()
+    _log_buffer.install()
+    logging.getLogger("bot.test_query_logs").error("a query_logs error")
+
+    embed = await _helpers.build_query_logs_embed(event_type="ERROR", limit=10)
+    blob = (embed.description or "") + " ".join(
+        f"{f.name} {f.value}" for f in embed.fields
+    )
+    assert "a query_logs error" in blob
+
+
+@pytest.mark.asyncio
+async def test_check_database_embed_uses_migrations_not_expected_list(monkeypatch):
+    from cogs.diagnostic import _helpers
+    from utils.db.migrations import migration_versions_on_disk
+
+    on_disk = migration_versions_on_disk()
+    assert on_disk  # sanity: the migration files exist and parse
+
+    base = {
+        "economy",
+        "job_progress",
+        "inventory",
+        "xp",
+        "warnings",
+        "mod_logs",
+        "role_thresholds",
+        "guild_settings",
+        "logs",
+        "reaction_roles",
+        "rps_players",
+        "mining_inventory",
+        "prohibited_words",
+        "deathmatch_stats",
+        "chain_channels",
+        "counting_state",
+    }
+
+    async def fake_fetchall(query, params=()):
+        if "pg_tables" in query:
+            # base tables + a migration-added table that used to read "unexpected"
+            return [{"tablename": t} for t in base | {"role_automation_exemptions"}]
+        return [{"version": v} for v in on_disk]
+
+    monkeypatch.setattr(_helpers.db, "fetchall", fake_fetchall)
+
+    embed = await _helpers.build_check_database_embed()
+    names = [f.name for f in embed.fields]
+    # The stale "Unexpected Tables" field is gone; the check is migration-based.
+    assert not any("Unexpected" in n for n in names)
+    assert any("Migrations applied" in n for n in names)
+    assert any("Base tables" in n for n in names)
+    assert "healthy" in (embed.description or "").lower()

--- a/tests/unit/runtime/test_interaction_helpers.py
+++ b/tests/unit/runtime/test_interaction_helpers.py
@@ -42,6 +42,33 @@ def _make_interaction(*, responded: bool = False) -> MagicMock:
     return interaction
 
 
+class TestClampEmbedTotalBudget:
+    """Discord rejects an embed whose total text exceeds 6000 even when every
+    individual component is within its own limit (the !platform Runtime panel:
+    many fields each <1024 summing >6000 → 400, edit silently dropped)."""
+
+    def test_over_budget_via_many_fields_is_clamped_under_6000(self):
+        embed = discord.Embed(title="T", description="D")
+        for i in range(10):  # 10 × 800 = ~8000, each field value < the 1024 cap
+            embed.add_field(name=f"f{i}", value="x" * 800, inline=False)
+        assert ih._embed_total_len(embed) > ih._EMBED_TOTAL_LIMIT
+        ih.clamp_embed(embed)
+        assert ih._embed_total_len(embed) <= ih._EMBED_TOTAL_LIMIT
+
+    def test_over_budget_via_description_and_footer_is_clamped(self):
+        embed = discord.Embed(title="T", description="x" * 8000)
+        embed.set_footer(text="y" * 2000)
+        ih.clamp_embed(embed)
+        assert ih._embed_total_len(embed) <= ih._EMBED_TOTAL_LIMIT
+
+    def test_wellformed_embed_passes_through_unchanged(self):
+        embed = discord.Embed(title="T", description="small")
+        embed.add_field(name="a", value="b")
+        before = ih._embed_total_len(embed)
+        ih.clamp_embed(embed)
+        assert ih._embed_total_len(embed) == before
+
+
 class TestSafeDefer:
     @pytest.mark.asyncio
     async def test_defers_when_not_responded(self):

--- a/tests/unit/views/test_role_panels_discordpy_compat.py
+++ b/tests/unit/views/test_role_panels_discordpy_compat.py
@@ -1,0 +1,54 @@
+"""Regression: role/XP panels must not collide with discord.py internals.
+
+discord.py 2.7 (components-v2) ships two internals these panels previously
+shadowed — both reachable only at runtime, so the mocked unit tests missed them:
+
+* ``discord.ui.View._refresh(components)`` is called on every MESSAGE_UPDATE.
+  A panel defining its own ``_refresh(self)`` shadowed it; discord.py then
+  called the override with the components list and the 1-arg signature raised
+  ``TypeError`` **inside the gateway poll loop**, crashing the whole bot. The
+  panels' re-render helper is now ``_rerender``.
+* ``discord.ui.Item.parent`` is a read-only property. A ``Select`` subclass
+  doing ``self.parent = parent`` raised ``AttributeError: can't set attribute``
+  the moment it was constructed (i.e. the Remove / Delete dropdowns). The panel
+  reference is now stored as ``self._panel``.
+
+Both regressions entered via the unpinned ``discord.py>=2.3.0`` (requirements.txt)
+resolving to 2.7.x in a fresh install.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def test_panels_do_not_shadow_view_refresh():
+    from views.roles.time_roles_panel import TimeRolesPanel
+    from views.roles.xp_roles_panel import XpRolesPanel
+
+    for panel in (TimeRolesPanel, XpRolesPanel):
+        # Defining _refresh shadows discord.ui.View._refresh(components) and
+        # crashes the bot on MESSAGE_UPDATE — the panel must not own one.
+        assert "_refresh" not in vars(panel), f"{panel.__name__} shadows View._refresh"
+        assert "_rerender" in vars(panel), f"{panel.__name__} lost its _rerender helper"
+
+
+def test_remove_and_delete_selects_construct_without_parent_collision():
+    # discord.ui.Item.parent is read-only in discord.py 2.7; a select that
+    # assigned self.parent raised AttributeError at construction time.
+    from views.roles.management_panel import _DeleteRoleSelect
+    from views.roles.time_roles_panel import _TimeRemoveSelect
+    from views.roles.xp_roles_panel import _XpRemoveSelect
+
+    panel = MagicMock()
+    role = SimpleNamespace(id=7, name="Veteran")
+
+    drs = _DeleteRoleSelect(panel, [role])
+    assert drs._panel is panel
+
+    trs = _TimeRemoveSelect(panel, [{"role_name": "Veteran", "days_required": 30}])
+    assert trs._panel is panel
+
+    xrs = _XpRemoveSelect(panel, [{"role_name": "Veteran", "level_required": 5}])
+    assert xrs._panel is panel

--- a/tests/unit/views/test_role_threshold_selectors.py
+++ b/tests/unit/views/test_role_threshold_selectors.py
@@ -28,7 +28,7 @@ async def test_time_days_modal_persists_role_id_and_name():
     from views.roles.time_roles_panel import TimeDaysModal
 
     parent = MagicMock()
-    parent._refresh = AsyncMock()
+    parent._rerender = AsyncMock()
     modal = TimeDaysModal(parent, SimpleNamespace(id=100, name="Veteran"))
     modal.days = MagicMock(value="30")
     interaction = _interaction()
@@ -42,7 +42,7 @@ async def test_time_days_modal_persists_role_id_and_name():
     db.set_role_threshold.assert_awaited_once_with(
         99, "Veteran", 30, role_id=100, display_name="Veteran"
     )
-    parent._refresh.assert_awaited_once()
+    parent._rerender.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -64,7 +64,7 @@ async def test_xp_level_modal_persists_role_id_and_name():
     from views.roles.xp_roles_panel import XpLevelModal
 
     parent = MagicMock()
-    parent._refresh = AsyncMock()
+    parent._rerender = AsyncMock()
     modal = XpLevelModal(parent, SimpleNamespace(id=200, name="Pro"))
     modal.level = MagicMock(value="5")
     modal.auto_assign = MagicMock(value="yes")

--- a/tests/unit/views/test_xp_config_modals_use_pipeline.py
+++ b/tests/unit/views/test_xp_config_modals_use_pipeline.py
@@ -177,7 +177,7 @@ async def test_xp_range_modal_writes_min_and_max():
     from views.xp import modals as xp_modals
 
     fake_view = MagicMock()
-    fake_view._refresh = AsyncMock()
+    fake_view._rerender = AsyncMock()
 
     modal = xp_modals._XpRangeModal(fake_view)
     modal.xp_min = MagicMock()
@@ -203,7 +203,7 @@ async def test_xp_range_modal_writes_min_and_max():
         ("xp_min", 12),
         ("xp_max", 28),
     ]
-    fake_view._refresh.assert_awaited_once()
+    fake_view._rerender.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -239,7 +239,7 @@ async def test_xp_cooldown_modal_writes_cooldown():
     from views.xp import modals as xp_modals
 
     fake_view = MagicMock()
-    fake_view._refresh = AsyncMock()
+    fake_view._rerender = AsyncMock()
     modal = xp_modals._XpCooldownModal(fake_view)
     modal.seconds = MagicMock()
     modal.seconds.value = "45"
@@ -259,7 +259,7 @@ async def test_xp_cooldown_modal_writes_cooldown():
 
     helper.assert_awaited_once()
     assert helper.await_args.args[1:] == ("xp_cooldown", 45)
-    fake_view._refresh.assert_awaited_once()
+    fake_view._rerender.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -267,7 +267,7 @@ async def test_xp_channel_modal_writes_channel_string():
     from views.xp import modals as xp_modals
 
     fake_view = MagicMock()
-    fake_view._refresh = AsyncMock()
+    fake_view._rerender = AsyncMock()
     modal = xp_modals._XpChannelModal(fake_view)
     modal.channel_id = MagicMock()
     modal.channel_id.value = "1234567890"
@@ -287,7 +287,7 @@ async def test_xp_channel_modal_writes_channel_string():
 
     helper.assert_awaited_once()
     assert helper.await_args.args[1:] == ("xp_announce_channel", "1234567890")
-    fake_view._refresh.assert_awaited_once()
+    fake_view._rerender.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -298,7 +298,7 @@ async def test_xp_channel_modal_writes_empty_string_to_clear():
     from views.xp import modals as xp_modals
 
     fake_view = MagicMock()
-    fake_view._refresh = AsyncMock()
+    fake_view._rerender = AsyncMock()
     modal = xp_modals._XpChannelModal(fake_view)
     modal.channel_id = MagicMock()
     modal.channel_id.value = "  "

--- a/tests/unit/views/test_xp_remove_defer.py
+++ b/tests/unit/views/test_xp_remove_defer.py
@@ -32,8 +32,8 @@ async def test_xp_remove_select_defers_ephemeral_before_db_write():
 
     select = MagicMock()
     select.values = ["Veteran"]
-    select.parent = MagicMock()
-    select.parent._refresh = AsyncMock()
+    select._panel = MagicMock()
+    select._panel._rerender = AsyncMock()
     interaction = _interaction()
 
     order: list[str] = []
@@ -71,5 +71,5 @@ async def test_xp_remove_select_defers_ephemeral_before_db_write():
     ], order
     defer.assert_awaited_once()
     inval.assert_called_once_with(99)
-    select.parent._refresh.assert_awaited_once()
+    select._panel._rerender.assert_awaited_once()
     interaction.response.send_message.assert_not_called()


### PR DESCRIPTION
## Summary

A live, cog-by-cog functionality audit (driven by clicking the bot's panels in a booted test instance) that turned up — and fixed — two real crash classes plus a cluster of DiagnosticCog panel gaps, and added tooling to make future audits cheaper.

## Fixes

### 🔴 discord.py 2.7.1 internal collisions (role/XP panels) — were crashing the bot
`requirements.txt` pins `discord.py>=2.3.0` **unpinned** → resolves to 2.7.1, whose components-v2 internals the panels weren't written against:
- `TimeRolesPanel`/`XpRolesPanel` defined `_refresh(self)`, **shadowing** `discord.ui.View._refresh(components)` (called on every MESSAGE_UPDATE). The 1-arg override raised `TypeError` inside the gateway poll loop → **whole-bot crash**. Renamed the panel helper to `_rerender` (same latent collision also fixed in `views/xp/config_panel.py` + `views/setup/ai_review/main_panel.py`).
- The Remove/Delete dropdowns did `self.parent = parent`, colliding with the now **read-only `Item.parent`** → `AttributeError` on click. Store the panel as `self._panel`.
- Pinned by `tests/unit/views/test_role_panels_discordpy_compat.py`.
- **Recommended follow-up:** pin `discord.py>=2.7,<2.8`.

### DiagnosticCog panel suite
- **Recent Errors / Logs** read a `logs` DB table that nothing ever wrote to → always "No logs found". Added an in-memory ring-buffer log handler (installed on cog load) and repointed the panel at it.
- **Database Schema Check** hardcoded 16 "expected" tables → flagged all ~52 migration-added tables as "Unexpected". Reframed to base-tables + migrations-applied N/N (added `migrations.migration_versions_on_disk()`).
- **`!platform` oversized embeds** (>6000 total chars) made `safe_edit` fail silently, so panels lost their back button. `clamp_embed` now enforces the **total 6000-char budget** — a bot-wide fix, not just for `!platform`.

## Docs / tooling
- `docs/planning/cog-functionality-audit-2026-06-05.md` — full per-cog command + panel inventory, env-gate map, and findings (the live audit tracker).
- `.session-journal.md` (+ a `.claude/CLAUDE.md` "Read first" pointer) — cross-session working memory: a boot/environment runbook, maintainer preferences, recurring fixes, my own mistakes-to-avoid, and candidate rules that graduate into CLAUDE.md at a periodic review.

## Testing
- `python3.10 scripts/check_quality.py --full` — green (**7455 passed**, 3 skipped).
- `python3.10 scripts/check_architecture.py --mode strict` — **0 errors**.
- New tests: role discord.py-compat regression, diagnostic-panel data sources, total-embed clamp.

## Verified live
Confirmed against a booted test bot (`Galaxy Bot#6724`): Delete/Remove now work, the role panels survive message-updates, and oversized-embed panels render **with** their back button.

## Out of scope (logged in the audit doc / journal)
The 2 role UX warts (bulk "Clear missing" + selector-ize Edit Role), pinning discord.py, paginating dense platform sub-views, and the remaining `❓` cogs in the audit tracker.

https://claude.ai/code/session_01DyKfZarXVstxpLfWfSQzJ7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyKfZarXVstxpLfWfSQzJ7)_