### PR TITLE
docs(journal): add cross-agent workflow preferences

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -1,7 +1,7 @@
 # .session-journal.md — SuperBot working memory
 
-> **What this is:** cross-session memory for how the maintainer + Claude work on
-> SuperBot — process, preferences, recurring problems+fixes, Claude's own
+> **What this is:** cross-session memory for how the maintainer + assistant agents
+> work on SuperBot — process, preferences, recurring problems+fixes, agent
 > mistakes+prevention, the environment/boot runbook, and a holding pen for
 > rules/ideas/blockers not yet promoted into `.claude/CLAUDE.md`.
 >
@@ -95,6 +95,37 @@
 - Batch fixes by cog; commit + push each coherent chunk.
 - Prefers self-maintaining checks over hardcoded lists.
 - A PR at session end is a standing expectation (also in `.claude/CLAUDE.md`).
+- Prefers planning prompts to be copy-paste-ready and explicit about hidden
+  dependencies, forgotten follow-ups, shipped work that must not be duplicated,
+  required tests, rollback safety, and stop conditions.
+
+## Cross-Agent Workflow Preferences
+
+- This project is for fun, but the maintainer takes root-level workflow memory and
+  planning docs seriously. Persistent notes must be precise: a misconception at this
+  level can mislead future sessions.
+- The normal flow starts in ChatGPT Prompt Forge / the prompt project, where the task
+  is turned into a structured, copy-paste-ready prompt before it is sent elsewhere.
+- Send prompts to **Codex** when broad repo mapping, source verification, first-pass
+  audit work, or clear implementation-plan scaffolding is needed before continuation.
+- Send prompts to specialised **GPT / Revision** projects when an extra verification
+  pass, prompt refinement, or final-plan critique is useful.
+- Use **Claude Opus 4.8 with 1M context** as the normal implementation path. Large
+  sessions are acceptable when the plan is well structured. Do not imply Codex is the
+  default implementation agent.
+- Claude Opus planning sessions are read-only by design. They do not need repeated
+  reminders that they are planning sessions unless the requested task is ambiguous.
+- Typical high-confidence flow: Prompt Forge draft → optional Codex/GPT mapping or
+  verification → Claude Opus dedicated planning → Revision project final-plan critique
+  → Claude Opus final revision → maintainer accepts the plan → Claude Opus executes.
+- Preserve architecture discipline across handoffs: service ownership, centralized
+  helpers, deterministic event flow, observability, tests, rollback safety, migration
+  safety, and no duplicate abstractions.
+- Stability comes before feature expansion. Do not continue broad BTD6 data mapping or
+  AI feature expansion until bot-wide stability, provider/provenance checks,
+  caching/source-health clarity, and AI behavior/config correctness are verified.
+- Docs are expected to be current, but source and recent merged PRs win. Treat roadmap
+  docs as guidance until verified against source.
 
 ## Rules / Conventions (candidate — not yet promoted to CLAUDE.md)
 
@@ -135,6 +166,19 @@
 ---
 
 ## Session Log (newest first)
+
+### 2026-06-06 — GPT Prompt Forge cross-agent workflow clarification
+- **Context:** maintainer clarified that the project is for fun but treated seriously,
+  and that root-level workflow memory must be exact because misconceptions here can
+  confuse future agents.
+- **Captured:** Prompt Forge is the normal starting point for structured prompts;
+  Codex is used for broad mapping / verification / first-pass scaffolding when useful;
+  specialised GPT/Revision projects provide extra checks and final-plan critique;
+  Claude Opus 4.8 1M context is the normal implementation path.
+- **Workflow clarified:** Claude Opus planning sessions are read-only by design;
+  after Opus proposes a plan, the Revision project critiques it, then Opus receives
+  that output for final revision and full execution once the maintainer accepts.
+- **Guardrail:** do not describe Codex as the default implementation agent.
 
 ### 2026-06-05 — stability preimplementation verification pass
 - **Scope:** planning/verification only; wrote `docs/planning/stability-preimplementation-plan-2026-06-05.md` for the Opus refinement session.


### PR DESCRIPTION
## Summary

- Resolve the journal merge conflict against the Codex stability-planning update from #529.
- Preserve Codex's stability preimplementation journal entry and planning doc references.
- Add maintainer cross-agent workflow preferences:
  - Prompt Forge starts the flow with structured prompts.
  - Codex is for broad mapping / source verification / first-pass scaffolding when useful.
  - GPT / Revision projects are for extra verification and final-plan critique.
  - Claude Opus 4.8 1M context is the normal implementation path.
- Add a session log entry recording the clarification and the guardrail that Codex should not be described as the default implementation agent.

## Verification

- Docs-only change; no runtime checks run.
- Manually re-read `.session-journal.md` on the PR branch for wording, ordering, and scope.
- Verified the Codex stability-preimplementation entry remains preserved after conflict resolution.

## Scope notes

- No architecture, roadmap, or feature behavior changed.
- This remains journal-level workflow memory, not a binding contract unless later promoted into `.claude/CLAUDE.md`.