### PR TITLE
ci: skip the heavy code-quality suite on docs-only changes

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -12,13 +12,54 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Full history so the docs-only detector can diff against the base.
+          fetch-depth: 0
+
+      # Skip the expensive lint/type/test steps when ONLY docs/markdown changed.
+      # The job still runs and reports success, so a required `code-quality`
+      # status check is satisfied and docs-only PRs stay mergeable (a workflow
+      # skipped via `paths-ignore` would never report and would block merges).
+      # Pure shell — no third-party change-detection action (no supply-chain surface).
+      - name: Detect non-docs changes
+        id: changes
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE='${{ github.event.pull_request.base.sha }}'
+            HEAD='${{ github.event.pull_request.head.sha }}'
+          else
+            BASE='${{ github.event.before }}'
+            HEAD='${{ github.sha }}'
+          fi
+          # Base missing/unknown (new branch, force-push, all-zero SHA) -> run full CI.
+          if [ -z "$BASE" ] || ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+            echo "Base commit unavailable — running full CI."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          FILES="$(git diff --name-only "$BASE" "$HEAD")"
+          echo "Changed files:"
+          printf '%s\n' "$FILES"
+          if [ -z "$FILES" ]; then
+            echo "No file changes — skipping heavy steps."
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          elif printf '%s\n' "$FILES" | grep -qvE '(\.md$|^docs/|^\.session-journal\.md$)'; then
+            echo "Non-docs changes present — running full CI."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Docs-only change — skipping lint/type/test steps."
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Python
+        if: steps.changes.outputs.code == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
       - name: Install dependencies
+        if: steps.changes.outputs.code == 'true'
         run: |
           python -m pip install --upgrade pip
           pip install black==26.5.1 isort==8.0.1 ruff==0.15.14 mypy==2.1.0
@@ -26,16 +67,25 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run Black (check only)
+        if: steps.changes.outputs.code == 'true'
         run: black --check . --exclude '(\.github|tests|venv|env|build|dist)'
 
       - name: Run isort (check only)
+        if: steps.changes.outputs.code == 'true'
         run: isort --check-only . --skip-glob '*/(\.github|tests|venv|env|build|dist)/*'
 
       - name: Run Ruff
+        if: steps.changes.outputs.code == 'true'
         run: ruff check . --exclude .github,tests,venv,env,build,dist
 
       - name: Run mypy
+        if: steps.changes.outputs.code == 'true'
         run: mypy disbot/
 
       - name: Run pytest
+        if: steps.changes.outputs.code == 'true'
         run: pytest tests/ -v --tb=short
+
+      - name: Docs-only change — heavy checks skipped
+        if: steps.changes.outputs.code != 'true'
+        run: echo "Only docs/markdown changed — black/isort/ruff/mypy/pytest were skipped."


### PR DESCRIPTION
## Problem

`code-quality` runs black/isort/ruff + mypy + the **full ~7461-test pytest suite** on *every* PR to `main` — including docs-only PRs (like the planning/journal PRs this session). That's several minutes for a Markdown change.

## Approach — skip the heavy steps in-job (chosen over `paths-ignore`)

The naive fix (`paths-ignore: ['**.md', 'docs/**']`) makes the workflow **not run** on docs-only PRs. If `code-quality` is a **required** status check, a skipped workflow never reports, so the PR is stuck *"waiting for status"* and can't merge. (PR #531 sat at `mergeable_state: blocked` waiting on this check.)

Instead, this keeps the workflow always triggering (so the required check always reports) and gates the expensive steps:

- A pure-shell **"Detect non-docs changes"** step diffs the changed files (PR base→head, or push before→after) and sets `code=true/false`.
- `Set up Python`, `Install dependencies`, Black, isort, Ruff, mypy, and pytest are gated on `if: steps.changes.outputs.code == 'true'`.
- On a docs-only change the job runs, skips the heavy steps, and **reports success in seconds** → required check satisfied → mergeable.
- A trailing step logs "heavy checks skipped" so the run is self-explanatory.

**No third-party change-detection action** — just `git diff`, so there's no new supply-chain surface. Tool versions/excludes are unchanged (still pinned, still matching `check_quality.py`).

## Behaviour (validated locally)
| Change | Result |
|---|---|
| `docs/*.md`, `README.md`, `.session-journal.md`, `docs/*.png` | **skip** heavy steps (fast green) |
| any `.py`, `requirements*.txt`, or `.github/workflows/**` | **full** suite runs |
| mixed docs + code | **full** suite runs |

Edge cases (new branch / force-push / all-zero base SHA) fall back to running the full suite. This PR itself changes a workflow file, so it will exercise the **full** path.

https://claude.ai/code/session_01BG2rSKjyrvJqrUfHKiou7Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01BG2rSKjyrvJqrUfHKiou7Q)_