### PR TITLE
PR B — live cog audit + back-navigation consistency fix

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -39,6 +39,24 @@
 
 ---
 
+## Current verified state — bot is FULLY TESTED & WORKING (2026-06-06, PR #535)
+
+**Treat the bot as fully tested and working bot-wide as of PR #535, for the next few
+sessions, unless a specific regression is reported.** This session completed the live cog
+walk against the booted test bot (Galaxy Bot#6724) — server-management, economy,
+moderation, games, and hub navigation were exercised live. The one code defect found (no
+"↩ Back to Help" on directly-invoked hubs + the Economy→Work back-chain drop) was fixed
+and live-confirmed in #535. **Don't re-run a full live audit "to be safe"** — spend effort
+on the maintainer's ask or the open UX items below. Env-gated features (AI / scheduler /
+YouTube / Paragon / webhook) remain degraded-here, **not** broken.
+
+Open follow-ups (UX/feature — **not** stability bugs): moderation member entry wants a
+`discord.ui.UserSelect` quicksearch picker (modal→view restructure; `unban` stays
+ID-based); role UX warts (bulk "Clear missing"; selector-ize Edit Role); dense
+DiagnosticCog `platform_*` subviews could paginate.
+
+---
+
 ## Environment Runbook — booting & operating the bot in the sandbox
 
 *So a future session knows the possibilities without re-deriving them.*
@@ -69,7 +87,7 @@
   `/tmp/testbot.log`; put a Monitor on it filtered to `ERROR/CRITICAL/Traceback`.
 - **Quality gates (green before pushing):**
   `python3.10 scripts/check_quality.py --full` (CI mirror: black/isort/ruff + mypy +
-  ~7455 tests, ~75s) and `python3.10 scripts/check_architecture.py --mode strict`
+  ~7470 tests, ~65s) and `python3.10 scripts/check_architecture.py --mode strict`
   (0 errors required; pre-existing warnings OK).
 - **Env feature flags (OFF here → expect *degraded*, not *broken*):** `AI_ENABLED`
   (AI off), `AUTOMATION_SCHEDULER_ENABLED=false` (time/XP auto-assign loop off; manual
@@ -81,10 +99,12 @@
 **Boot gotchas (learned the hard way):**
 
 - `pkill -f "disbot/bot1.py"` matches the *launching shell itself* (its command line
-  contains that string) → it self-kills before relaunching. Use a `/proc` matcher with
-  a **split** target (`"disbot/" + "bot1.py"`), exclude your own PID, and keep the kill
-  in a command that does NOT also contain the launch string. Kill first, **then** launch
-  in a separate step.
+  contains that string) → it self-kills before relaunching. **Working pattern (used all
+  this session):** filter by `comm` — it's `python3.10` for the bot but `bash` for your
+  shell:
+  `for pid in $(pgrep -f "disbot/bot1"); do [ "$(cat /proc/$pid/comm)" = python3.10 ] && kill "$pid"; done`
+  then `sleep 3` and relaunch in a **separate** step. Launch via the harness
+  `run_in_background` so the bot persists across turns and notifies you only if it exits.
 - Running `check_quality`/pytest in the repo leaks test-fixture errors into `bot.log`
   (importing `bot1` installs the file handler). When mining logs, filter by the live
   `boot_id` to separate real bot errors from test pollution.
@@ -107,6 +127,15 @@
 - Prefers planning prompts to be copy-paste-ready and explicit about hidden
   dependencies, forgotten follow-ups, shipped work that must not be duplicated,
   required tests, rollback safety, and stop conditions.
+- **During a live walk the maintainer drives the clicks but wants YOU to lead** — give
+  numbered, copy-pasteable command steps + "what to look for", not vague guidance ("tell
+  me which commands you want me to use step by step"). Findings come rapidly and
+  conversationally, usually phrased "X should be Y" / "X is currently Z" — treat each as a
+  precise diagnosis target: confirm the root cause in source, then fix or log it.
+- **Word-cues:** "for now" / "let's forget about that for now" = **defer/drop**, not a
+  permanent kill (e.g. the non-reproducible Wallet bug). "as of this PR" = PRs are used as
+  state markers. They explicitly want the **central / root-cause fix over per-panel
+  patches** ("not 20 patches").
 
 ## Cross-Agent Workflow Preferences
 
@@ -151,6 +180,24 @@
   `migrations.py`) + `ruff` D209 (the new `_log_buffer.py` docstring) that weren't
   surfaced at push time. The PostToolUse auto-format hook may not fire in the
   remote/web container, so don't rely on it; verify the formatters yourself.
+- **Cog files have an 800-LOC hard ceiling** (`tests/unit/invariants/test_cog_size.py`).
+  Adding even ~6 lines to a cog already at the ceiling fails CI — `help_cog.py` was at
+  exactly 800 this session, which broke the first full run. **Check a cog's LOC before
+  adding to it**; wire cross-cutting hooks from `bot1` (the composition root), not from a
+  maxed cog. The invariant's intent is to decompose (move view code to `views/<sub>/`),
+  not to grow the cog.
+- **A Discord Modal cannot contain a Select** (`UserSelect`/`StringSelect`) — modals are
+  text-input only. "Selector-ize a modal" therefore means a **modal→view restructure**
+  (pick the member in a view → follow-up modal/inputs), not a component swap.
+- **GitHub merge-commit shows as "Unverified" — Stop-hook false positive.** After a
+  fast-forward to `main`, your branch tip IS GitHub's merge commit (committer
+  `noreply@github.com`); the stop-hook flags it and suggests `--amend --reset-author`.
+  **Do NOT** — it's the maintainer's merge on `main`, and amending diverges your branch.
+  It clears as soon as a new verified (`noreply@anthropic.com`) commit lands on top.
+- **CI skips the heavy suite on docs-only PRs** (#532): the `code-quality` workflow has an
+  in-job changed-files detector — docs/`*.md`-only PRs finish in seconds; any `.py` /
+  `requirements*` / `.github/workflows/**` change still runs the full suite. A fast green
+  on a docs-only PR is expected, not suspicious.
 
 ## Active Blockers / Open Items
 
@@ -161,9 +208,10 @@
   Edit Role (the original task that got superseded by the crash fixes).
 - **DiagnosticCog platform sub-views:** the new total-embed clamp prevents the failure,
   but dense `platform_*` embeds could be *paginated* for better UX (follow-up).
-- **Audit coverage:** many cogs still `❓` in
-  `docs/planning/cog-functionality-audit-2026-06-05.md` (Channel/Moderation/Economy/
-  games/BTD6/…).
+- ~~**Audit coverage**~~ — the live cog walk is **considered complete as of PR #535**
+  (see "Current verified state" above). The tracker's remaining `❓` rows are
+  not-yet-individually-ticked, **not** "untested/broken". Re-open only on a reported
+  regression.
 
 ## Ideas / Roadmap (process & tooling — feature ideas go to docs/)
 
@@ -181,6 +229,24 @@
 ---
 
 ## Session Log (newest first)
+
+### 2026-06-06 — Session close: PR B nav fix shipped; bot declared fully tested
+- **Arc** (continues the PR A entry below): refined the stability plan through the
+  GPT/Revision pass (**#531**, merged), added the CI docs-skip (**#532**, merged), then
+  ran the **PR B live cog walk** with the maintainer driving the clicks.
+- **PR B (#535, open):** the walk's one real defect was a **back-navigation class** —
+  directly-invoked hubs (`!modmenu`/`!economymenu`/…) had no "↩ Back to Help" and Economy
+  dropped the chain via the Work sub-path. Fixed holistically + layer-clean
+  (`panel_manager.get_or_render_panel` calls a **registered** back-to-help hook wired from
+  `bot1`; Economy Work views `chain_back` the grandparent). **Live-confirmed.** Tracker
+  reconciled (#528 fixes) + UX findings logged.
+- **Maintainer decision:** **bot is fully tested & working as of #535** — no full
+  re-audit for the next few sessions (see "Current verified state" up top).
+- **New lessons → Rules above:** 800-LOC cog ceiling (wire hooks from `bot1`, not a maxed
+  cog); modals can't hold a Select; GitHub merge-commit "Unverified" stop-hook is a false
+  positive (don't amend); CI skips the heavy suite on docs-only PRs.
+- **Checks:** `check_architecture` 0 errors; `check_quality --full` 7470 passed; clean
+  boots throughout (last boot_id `22f8ccee`).
 
 ### 2026-06-06 — GPT Prompt Forge cross-agent workflow clarification
 - **Context:** maintainer clarified that the project is for fun but treated seriously,

--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -861,6 +861,15 @@ async def main() -> None:
 
             game_state_cleanup.install()
 
+            # Navigation: wire the "↩ Back to Help" hook into the hub render
+            # path so directly-invoked subsystem hubs (!modmenu, !economymenu,
+            # …) get a Back button + seeded _back_target, like the !help route.
+            # Composition-root wiring (cogs.help_cog → core.panel_manager).
+            from cogs.help_cog import _attach_back_to_help_button
+            from core.runtime import panel_manager as _panel_manager
+
+            _panel_manager.register_back_to_help_attacher(_attach_back_to_help_button)
+
             # PR-02c: session_gc.start() now uses tasks.spawn
             # internally (PR-02b); calling it once registers the
             # GC loop with the canonical supervisor.

--- a/disbot/core/runtime/panel_manager.py
+++ b/disbot/core/runtime/panel_manager.py
@@ -24,6 +24,7 @@ Public surface:
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 
 import discord
 from discord.ext import commands
@@ -31,6 +32,23 @@ from discord.ext import commands
 from core.runtime import message_anchor_manager
 
 logger = logging.getLogger("bot.runtime.panels")
+
+# Optional hook, registered once at startup by ``HelpCog``, that appends a
+# "↩ Back to Help" button (and seeds ``view._back_target``) on a freshly
+# rendered hub view so directly-invoked hubs (`!modmenu`, `!economymenu`, …)
+# get the same back-navigation as the `!help` route.  Core stays decoupled
+# from the cogs/views layer by holding an opaque callable — the same
+# register-at-startup pattern as ``cleanup_registry``.  A failure in the hook
+# must never break panel rendering.
+_back_to_help_attacher: Callable[[discord.ui.View], None] | None = None
+
+
+def register_back_to_help_attacher(
+    attacher: Callable[[discord.ui.View], None],
+) -> None:
+    """Register the hub back-to-help hook (idempotent; last registration wins)."""
+    global _back_to_help_attacher
+    _back_to_help_attacher = attacher
 
 
 async def get_or_render_panel(
@@ -75,6 +93,18 @@ async def get_or_render_panel(
                 exc,
             )
         await message_anchor_manager.mark_stale(str(anchor["anchor_id"]))
+
+    # Give directly-invoked hubs the same "↩ Back to Help" affordance as the
+    # !help route (and seed view._back_target so sub-panels inherit the chain).
+    if _back_to_help_attacher is not None:
+        try:
+            _back_to_help_attacher(view)
+        except Exception:  # noqa: BLE001 — back-nav must never break rendering
+            logger.warning(
+                "get_or_render_panel: back-to-help attach failed | subsystem=%s",
+                subsystem,
+                exc_info=True,
+            )
 
     msg = await ctx.send(embed=embed, view=view)
     await message_anchor_manager.upsert(

--- a/disbot/views/economy/main_panel.py
+++ b/disbot/views/economy/main_panel.py
@@ -162,7 +162,12 @@ class EconomyPanelView(PersistentView):
         embed.add_field(name="Coins", value=f"{xp_row.get('coins', 0)} 🪙", inline=True)
         embed.set_footer(text="Pick a job from the dropdown, or click ↩ Back.")
 
-        work_view = _WorkSubView(uid, gid, available)
+        work_view = _WorkSubView(
+            uid,
+            gid,
+            available,
+            back_target=getattr(self, "_back_target", None),
+        )
         await safe_edit(interaction, embed=embed, view=work_view)
 
     @discord.ui.button(

--- a/disbot/views/economy/work_panel.py
+++ b/disbot/views/economy/work_panel.py
@@ -26,7 +26,7 @@ from utils import db
 from utils.cooldowns import check_cooldown, format_remaining
 from utils.helpers import post_log_embed
 from utils.ui_constants import SUCCESS_COLOR
-from views.navigation import attach_back_button
+from views.navigation import BackTarget, attach_back_button, chain_back
 
 
 class _WorkView(discord.ui.View):
@@ -156,7 +156,10 @@ class _JobSelect(discord.ui.Select):
         # ↩ Back to Economy button stays enabled. The previous flow
         # disabled every child on ``_work_view`` (including Back),
         # leaving the user on a dead-end result screen.
-        result_view = _WorkResultView(interaction.user)
+        result_view = _WorkResultView(
+            interaction.user,
+            back_target=getattr(self._work_view, "_back_target", None),
+        )
         await safe_edit(interaction, embed=embed, view=result_view)
         result_view.message = interaction.message
         self._work_view.stop()
@@ -177,8 +180,17 @@ class _JobSelect(discord.ui.Select):
 class _WorkSubView(_WorkView):
     """Work sub-panel with a Back button to return to the economy hub."""
 
-    def __init__(self, user_id: int, guild_id: int, available: list[str]):
+    def __init__(
+        self,
+        user_id: int,
+        guild_id: int,
+        available: list[str],
+        back_target: BackTarget | None = None,
+    ):
         super().__init__(user_id, guild_id, available)
+        # AB2: propagate the hub's back chain (e.g. back-to-Help when opened via
+        # !economymenu) so "↩ Back" rebuilds Economy with the chain re-attached.
+        self._back_target = back_target
 
         async def _build_parent(
             interaction: discord.Interaction,
@@ -193,7 +205,7 @@ class _WorkSubView(_WorkView):
             self,
             label="↩ Back",
             custom_id="economy:work:back",
-            parent_builder=_build_parent,
+            parent_builder=chain_back(_build_parent, back_target),
             row=1,
         )
 
@@ -206,10 +218,15 @@ class _WorkResultView(discord.ui.View):
     Back and left the user with no escape).
     """
 
-    def __init__(self, author: discord.Member | discord.User):
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        back_target: BackTarget | None = None,
+    ):
         super().__init__(timeout=60)
         self._author = author
         self.message: discord.Message | None = None
+        self._back_target = back_target
 
         async def _build_parent(
             interaction: discord.Interaction,
@@ -224,7 +241,7 @@ class _WorkResultView(discord.ui.View):
             self,
             label="↩ Back to Economy",
             custom_id="economy:back",
-            parent_builder=_build_parent,
+            parent_builder=chain_back(_build_parent, back_target),
             row=0,
         )
 

--- a/docs/planning/cog-functionality-audit-2026-06-05.md
+++ b/docs/planning/cog-functionality-audit-2026-06-05.md
@@ -58,13 +58,40 @@ keys off the hardcoded `config.BOT_OWNER_USER_ID` (and AI is off anyway).
 
 > 34 cogs loaded at boot. `BootstrapAccessCog` is infrastructure (the command-access
 > guard) and has no user commands. Counts are prefix / slash from the live registry.
+>
+> **Reconciliation (2026-06-05, post-#528):** statuses for cogs whose hard failures
+> already shipped fixes are corrected from source — **DiagnosticCog** `🔴`→`🟡` (its
+> Recent-Errors, schema-check, and oversized-embed failures were fixed in #528 `702cf48`,
+> test-pinned; dense `platform_*` subviews remain a pagination follow-up) and **RoleCog**
+> `🔴→✅`→`🟡` (the two discord.py-2.7 crashes were fixed in #528; the two UX warts remain).
+> Live re-confirmation of these + the remaining `❓` cogs is the ongoing PR B walk.
+>
+> **Cross-cutting findings (live walk, this session) — UX track, beyond PR B's hard-failure remit:**
+> 1. **Hub "↩ Back to Help" missing on direct invoke.** Subsystem hubs opened via their
+>    own command (`!modmenu`, `!economymenu`, `!rolemenu`, `!minemenu`, the Blackjack menu, …)
+>    render the bare view through `panel_manager.get_or_render_panel` and never attach the
+>    `cogs/help_cog.py:_attach_back_to_help_button` that the `!help` route already adds — so a
+>    directly-invoked hub has no way back. **Systemic; candidate for one central fix** in the
+>    direct-invoke render path rather than ~20 per-cog edits.
+> 2. **Moderation member entry is free-text, not a picker** (see ModerationCog) — wants a
+>    `discord.ui.UserSelect` quicksearch across all actions; needs a flow restructure
+>    (modals can't hold a Select). `unban` stays ID-based.
+> 3. **Back nav also breaks *within* hubs.** Economy loses its back/help button as you
+>    descend its sub-panels (a sub-view doesn't re-propagate the `BackTarget`), and the
+>    Wallet sub-view's "Back to Economy" button is **disabled** (concrete bug). Same class
+>    as #1 — back-nav attachment/propagation is inconsistent across the view tree.
+>
+> ⇒ Findings #1 and #3 are one **back-navigation consistency** class (root cause, not
+> per-panel symptoms). Per the maintainer's "root cause over symptom" rule, the fix is a
+> holistic pass over the `attach_back_button` / `BackTarget` / `get_or_render_panel` seam,
+> not 20 patches. Sequencing TBD (its own UX PR, distinct from PR B's hard-failure remit).
 
 ### Core · Admin · Config
 | Cog | Panel / hub | prefix | slash | Env-gate | Status |
 |---|---|---:|---:|---|:--:|
 | BootstrapAccessCog | — (infra guard) | 0 | 0 | — | ✅ infra |
 | AdminCog | `!adminmenu` | 9 | 1 | — | ❓ |
-| DiagnosticCog | `!platform` | 43 | 1 | — | 🔴 |
+| DiagnosticCog | `!platform` | 43 | 1 | — | 🟡 |
 | SettingsCog | `!settings` | 2 | 1 | — | ❓ |
 | SetupCog | `!setup` / `setup-hub` | 1 | 9 | advisor=deterministic | ❓ |
 | LoggingCog | `!logging` | 6 | 0 | webhook off; logging OFF by default | ❓ |
@@ -73,9 +100,9 @@ keys off the hardcoded `config.BOT_OWNER_USER_ID` (and AI is off anyway).
 ### Server management
 | Cog | Panel / hub | prefix | slash | Env-gate | Status |
 |---|---|---:|---:|---|:--:|
-| RoleCog | `!rolemenu` / `!roles` | 14 | 0 | automation scheduler off | 🔴→✅ |
+| RoleCog | `!rolemenu` / `!roles` | 14 | 0 | automation scheduler off | 🟡 |
 | ChannelCog | `!channelmenu` | 15 | 0 | — | ❓ |
-| ModerationCog | `!modmenu` | 8 | 1 | logging dest off by default | ❓ |
+| ModerationCog | `!modmenu` | 8 | 1 | logging dest off by default | 🟡 |
 | Cleanup | `!wordmenu` | 7 | 0 | — | ❓ |
 | CommunityCog | `!community` | 1 | 1 | — | ❓ |
 
@@ -154,7 +181,14 @@ keys off the hardcoded `config.BOT_OWNER_USER_ID` (and AI is off anyway).
 - **Prefix (8):** ban, clearwarnings, kick, modlogs, modmenu, timeout, unban, warn · **slash:** moderation
 - **Notes:** all manual actions route through `moderation_service` (PR1). Audit/mod
   log embeds need a logging destination configured to appear in a channel.
-- **Status:** ❓ · **Notes:** _…_
+- **Finding (live, this session):** every action modal takes the target via a free-text
+  `TextInput` ("User (mention, ID, or name)") + `_parse_member` — the outdated method.
+  Maintainer wants a **selectable member list with quicksearch** (`discord.ui.UserSelect`)
+  across all actions. NB: a Discord **modal cannot contain a Select**, so this is a flow
+  restructure (pick member in a view → reason/duration follow-up), not a component swap;
+  `unban` stays ID-based (banned users aren't guild members). Scope = moderation-UX track.
+- **Status:** 🟡 — actions work + route through `moderation_service`; member entry is the
+  UX gap above.
 
 ### Cleanup — ❓
 - **Panel:** `!wordmenu` · **Prefix (7):** cleanup, cleanuphistory, word, word add,
@@ -172,7 +206,7 @@ keys off the hardcoded `config.BOT_OWNER_USER_ID` (and AI is off anyway).
   `restart` here will kill the container process — test last / with care.
 - **Status:** ❓ · **Notes:** _…_
 
-### DiagnosticCog — ❓
+### DiagnosticCog — 🟡 (hard failures fixed in #528; live re-confirm pending)
 - **Hub:** `!platform` (33 subcommands) · **Prefix (43):** check_database,
   diagnostics, find_command, latency, lifecycle, list_commands_detailed, platform (+
   access, anchors, automation, bindings, caches, cleanup-preview, command-access,

--- a/docs/planning/cog-functionality-audit-2026-06-05.md
+++ b/docs/planning/cog-functionality-audit-2026-06-05.md
@@ -81,10 +81,15 @@ keys off the hardcoded `config.BOT_OWNER_USER_ID` (and AI is off anyway).
 >    Wallet sub-view's "Back to Economy" button is **disabled** (concrete bug). Same class
 >    as #1 — back-nav attachment/propagation is inconsistent across the view tree.
 >
-> ⇒ Findings #1 and #3 are one **back-navigation consistency** class (root cause, not
-> per-panel symptoms). Per the maintainer's "root cause over symptom" rule, the fix is a
-> holistic pass over the `attach_back_button` / `BackTarget` / `get_or_render_panel` seam,
-> not 20 patches. Sequencing TBD (its own UX PR, distinct from PR B's hard-failure remit).
+> ⇒ Findings #1 and #3 are one **back-navigation consistency** class — **FIXED this
+> session** (live-confirmed) by a holistic, layer-clean change at the shared seam:
+> `get_or_render_panel` now calls a registered back-to-help hook (wired from `bot1`'s
+> composition root), so every directly-invoked hub gets "↩ Back to Help" + a seeded
+> `_back_target`; the Economy Work sub-views now `chain_back` the grandparent so the chain
+> survives `Economy → Work → Back`. Verified on `!modmenu`, `!economymenu`, and the Work
+> path. The Wallet "disabled back" (part of #3) was **not reproducible** and is dropped.
+> **Item #2 (moderation member-selector / `UserSelect` quicksearch) remains open** — a
+> feature for the moderation-UX track, needs a modal→view flow restructure.
 
 ### Core · Admin · Config
 | Cog | Panel / hub | prefix | slash | Env-gate | Status |

--- a/tests/unit/runtime/test_panel_manager.py
+++ b/tests/unit/runtime/test_panel_manager.py
@@ -206,3 +206,95 @@ async def test_re_invocation_produces_new_message_id_each_time():
     assert upsert.await_args_list[0].args == (111, 222, 333, "economy", 1001)
     assert upsert.await_args_list[1].args == (111, 222, 333, "economy", 1002)
     old_msg.delete.assert_awaited_once()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_back_to_help_attacher():
+    """Keep the module-global attacher from leaking across tests/modules."""
+    saved = panel_manager._back_to_help_attacher
+    panel_manager._back_to_help_attacher = None
+    try:
+        yield
+    finally:
+        panel_manager._back_to_help_attacher = saved
+
+
+def _anchor_patches():
+    return (
+        patch(
+            "core.runtime.panel_manager.message_anchor_manager.get",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "core.runtime.panel_manager.message_anchor_manager.mark_stale",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "core.runtime.panel_manager.message_anchor_manager.upsert",
+            new_callable=AsyncMock,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_back_to_help_attacher_is_invoked_when_registered():
+    """A registered hook is applied to the hub view before it's sent
+    (directly-invoked hubs get "↩ Back to Help")."""
+    ctx = _make_ctx()
+    embed, view = MagicMock(), MagicMock()
+    attacher = MagicMock()
+    panel_manager.register_back_to_help_attacher(attacher)
+
+    get_p, stale_p, upsert_p = _anchor_patches()
+    with get_p, stale_p, upsert_p:
+        await panel_manager.get_or_render_panel(ctx, "economy", embed, view)
+
+    attacher.assert_called_once_with(view)
+    ctx.send.assert_awaited_once_with(embed=embed, view=view)
+
+
+@pytest.mark.asyncio
+async def test_back_to_help_attacher_failure_never_breaks_render():
+    """A hook that raises is logged + swallowed — the panel still renders."""
+    ctx = _make_ctx()
+    embed, view = MagicMock(), MagicMock()
+    panel_manager.register_back_to_help_attacher(
+        MagicMock(side_effect=RuntimeError("boom")),
+    )
+
+    get_p, stale_p, upsert_p = _anchor_patches()
+    with get_p, stale_p, upsert_p:
+        await panel_manager.get_or_render_panel(ctx, "role", embed, view)
+
+    ctx.send.assert_awaited_once_with(embed=embed, view=view)
+
+
+@pytest.mark.asyncio
+async def test_no_attacher_registered_is_a_noop():
+    ctx = _make_ctx()
+    embed, view = MagicMock(), MagicMock()
+    assert panel_manager._back_to_help_attacher is None
+    get_p, stale_p, upsert_p = _anchor_patches()
+    with get_p, stale_p, upsert_p:
+        await panel_manager.get_or_render_panel(ctx, "mining", embed, view)
+    ctx.send.assert_awaited_once_with(embed=embed, view=view)
+
+
+def test_back_to_help_attacher_is_registerable():
+    """help_cog's back-to-help helper is the registerable hook — the call the
+    bot1 composition root makes at startup."""
+    from cogs.help_cog import _attach_back_to_help_button
+
+    panel_manager.register_back_to_help_attacher(_attach_back_to_help_button)
+    assert panel_manager._back_to_help_attacher is _attach_back_to_help_button
+
+
+def test_bot1_wires_back_to_help_at_startup():
+    """The composition root (bot1) registers the hook so directly-invoked
+    hubs get back-navigation."""
+    from pathlib import Path
+
+    bot1_src = (Path(__file__).resolve().parents[3] / "disbot" / "bot1.py").read_text()
+    assert "register_back_to_help_attacher" in bot1_src
+    assert "_attach_back_to_help_button" in bot1_src

--- a/tests/unit/views/test_economy_work_result.py
+++ b/tests/unit/views/test_economy_work_result.py
@@ -209,3 +209,60 @@ async def test_work_result_back_button_returns_to_economy_panel():
     interaction.response.edit_message.assert_awaited_once()
     kwargs = interaction.response.edit_message.await_args.kwargs
     assert isinstance(kwargs["view"], EconomyPanelView)
+
+
+# ---------------------------------------------------------------------------
+# #2 regression — the Work path propagates the hub back chain (no lost back)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_work_subview_back_re_attaches_grandparent_chain():
+    """Opened with a back_target (e.g. back-to-Help from !economymenu), the
+    Work sub-view's ↩ Back rebuilds Economy with the grandparent re-attached —
+    the back button is no longer dropped mid-navigation.
+    """
+    from views.economy.main_panel import EconomyPanelView
+    from views.navigation import BackTarget
+
+    async def _grandparent_builder(_interaction):  # pragma: no cover - not invoked
+        return discord.Embed(title="Help"), EconomyPanelView()
+
+    grandparent = BackTarget(
+        builder=_grandparent_builder,
+        label="↩ Back to Help",
+        custom_id="help:back",
+    )
+    sub = _WorkSubView(
+        user_id=1, guild_id=2, available=["janitor"], back_target=grandparent
+    )
+    # stored for further-down propagation (e.g. the result view)
+    assert sub._back_target is grandparent
+    back_btn = next(
+        c
+        for c in sub.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == "economy:work:back"
+    )
+
+    interaction = MagicMock()
+    interaction.user = _author(id_=1)
+    interaction.guild_id = 2
+    interaction.response.is_done = MagicMock(return_value=False)
+    interaction.response.defer = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+
+    with patch(
+        "views.economy.work_panel._build_economy_embed",
+        new_callable=AsyncMock,
+        return_value=discord.Embed(title="Economy"),
+    ):
+        await back_btn.callback(interaction)
+
+    rebuilt = interaction.response.edit_message.await_args.kwargs["view"]
+    assert isinstance(rebuilt, EconomyPanelView)
+    # chain_back re-attached the grandparent's back button + target on Economy:
+    assert getattr(rebuilt, "_back_target", None) is grandparent
+    assert any(
+        isinstance(c, discord.ui.Button) and c.custom_id == "help:back"
+        for c in rebuilt.children
+    )


### PR DESCRIPTION
Start of the **PR B live cog audit** (after PR A merged). Driven by live testing against the booted test bot (Galaxy Bot#6724), with the maintainer clicking panels while I watched the logs.

## Navigation-consistency fix (the main code change — live-confirmed)
The walk surfaced one **root-cause class**: back-navigation was applied unevenly. Per the maintainer's "root cause over symptom" rule, this is one holistic, layer-clean fix at the shared seam rather than per-panel patches.

- **"↩ Back to Help" on directly-invoked hubs.** Hubs opened via their own command (`!modmenu`, `!economymenu`, `!rolemenu`, …) had *no* back button — only the `!help` route attached one (`chain_back` deliberately treats direct openers as top-of-stack). `core/runtime/panel_manager.get_or_render_panel` now calls a **registered, decoupled hook** before sending, so every directly-invoked hub gets "↩ Back to Help" **and** a seeded `view._back_target`. Core stays layer-clean by holding an opaque callable (the `cleanup_registry` pattern); `bot1`'s composition root wires `help_cog._attach_back_to_help_button` (kept out of `help_cog`, which is at its 800-LOC ceiling).
- **Economy "loses back mid-nav."** The Work sub-path (`_WorkSubView`/`_WorkResultView`) rebuilt a *bare* Economy, dropping the chain; both now `chain_back` the grandparent + propagate `_back_target` (Shop/Inventory already propagated and now inherit the seeded root).

**Verified live:** `!modmenu` / `!economymenu` show "↩ Back to Help"; `Economy → Work → ↩ Back` keeps it; "↩ Back to Help" returns to the Help menu.

## Audit tracker (`docs/planning/cog-functionality-audit-2026-06-05.md`)
- **Reconciled from source:** DiagnosticCog `🔴`→`🟡` and RoleCog `🔴→✅`→`🟡` (their hard failures shipped fixes in #528).
- **Findings logged:** the back-nav class (now fixed); the Wallet "disabled back" (not reproducible — dropped); **ModerationCog `🟡`** — action modals use free-text member entry, maintainer wants a `discord.ui.UserSelect` quicksearch picker (open UX item; needs a modal→view restructure since modals can't hold a Select).

## Verification
- `python3.10 scripts/check_architecture.py --mode strict` → **0 errors** (the registered-callable hook adds no layer violation).
- `python3.10 scripts/check_quality.py --full` → **green (7470 passed, 3 skipped)**.
- Bot boots clean on this code (boot_id `22f8ccee`).

## Still open (next)
Continue the cog-by-cog walk for the remaining `❓` cogs; the moderation member-selector is a separate UX item.

https://claude.ai/code/session_01BG2rSKjyrvJqrUfHKiou7Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01BG2rSKjyrvJqrUfHKiou7Q)_