### PR TITLE
Add planning docs for AI tool orchestration (BTD6) and bot-awareness diagnostics

### DIFF
--- a/docs/ai-complex-request-tool-orchestration-plan.md
+++ b/docs/ai-complex-request-tool-orchestration-plan.md
@@ -1,0 +1,1036 @@
+# Configurable AI Tool Orchestration for Complex BTD6 Requests
+
+**Status:** research-backed planning document; assumes the bot-awareness and
+health-diagnostics roadmap is already delivered  
+**Verified against:** current repository worktree on 2026-06-06  
+**Primary focus:** complex BTD6 lookups and calculations  
+**Secondary goal:** reusable configuration/orchestration for future read-only tools
+
+## 1. Executive recommendation
+
+SuperBot already has the difficult foundations: provider-neutral tool contracts,
+bounded multi-hop tool loops, OpenAI and Anthropic adapters, a central scope-gated
+read-only tool registry, BTD6 grounding/faithfulness checks, task routing, behavior
+presets, channel/category AI policy, and an eval harness.
+
+The next improvement should **not** be more prompt text or more tools offered to
+every request. It should be a configurable **tool orchestration policy layer** that
+answers four questions before each model call:
+
+1. Which tool families are allowed in this scope?
+2. Which tools, if any, must run before the model answers?
+3. How much tool/cost/latency budget may this request consume?
+4. Which deterministic workflow should handle this request class?
+
+The target architecture is:
+
+```text
+message + resolved AI policy + routed task + request complexity
+                              |
+                              v
+                 AI orchestration policy resolver
+        (behavior preset + toolset + requirement + budget + workflow)
+                              |
+             +----------------+----------------+
+             |                                 |
+             v                                 v
+ deterministic preflight tools        model-visible allowed tools
+             |                                 |
+             +----------------+----------------+
+                              v
+               bounded plan / execute / verify / answer
+                              |
+                              v
+             BTD6 evidence ledger + response contract + eval trace
+```
+
+The strongest immediate product feature is a channel/category configuration such
+as:
+
+```text
+Behavior: BTD6 Analyst
+Allowed toolsets: btd6_reference, btd6_calculators
+Required preflight: btd6_request_analysis
+Model tool requirement: at_least_one_grounding_tool for factual BTD6 questions
+Tool budget: 4 calls / 2 hops / 8 seconds
+Answer format: calculation_explained
+```
+
+This is materially different from the existing behavior presets. Existing presets
+control reply mode and instruction text; the proposed orchestration profile controls
+what the runtime actually offers, requires, executes, budgets, and verifies.
+
+## 2. Research findings and their implications
+
+This plan uses primary-source provider documentation and published research. The
+recommendations are translated into provider-neutral repository contracts rather
+than binding behavior to one vendor.
+
+### 2.1 Explicit tool choice is stronger than prompt-only nudges
+
+OpenAI supports automatic tool choice, requiring one or more tools, forcing one
+specific function, disabling tools, and restricting calls to an allowed subset.
+It also recommends strict function schemas. Anthropic similarly documents that
+prompt instructions can increase tool use, but a hard guarantee requires
+`tool_choice`.
+
+Sources:
+
+- [OpenAI function calling: tool choice, allowed tools, parallel calls, and strict mode](https://developers.openai.com/api/docs/guides/function-calling#tool-choice)
+- [Anthropic tool use: automatic triggering versus hard tool-choice guarantees](https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview#when-claude-uses-tools)
+
+**Implication for SuperBot:** “always use BTD6 tools in this channel” must be a
+runtime policy represented in provider-neutral request data, not only a behavior
+preset sentence. Prompt text can remain a soft hint, but required behavior needs a
+hard orchestration contract.
+
+### 2.2 Narrow allowed toolsets reduce ambiguity, cost, and context noise
+
+Tool definitions consume prompt tokens. Provider documentation supports restricting
+the currently callable subset. OpenAI's evaluation guidance also notes that as a
+single agent accumulates tools/tasks, correct instruction following and tool
+selection become harder.
+
+Sources:
+
+- [OpenAI function calling: allowed tool subsets](https://developers.openai.com/api/docs/guides/function-calling#tool-choice)
+- [OpenAI evaluation best practices: tool-selection nondeterminism and architecture complexity](https://developers.openai.com/api/docs/guides/evaluation-best-practices#single-agent-architectures)
+- [Anthropic tool-use pricing/context overhead](https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview#pricing)
+
+**Implication for SuperBot:** replace “every scope-allowed tool is offered on every
+request” with an explicit toolset resolver. A BTD6 cost question should see a small
+cost/calculation set, not server-member, audit, map, relic, CT, and unrelated tools.
+Do not jump to multi-agent architecture until evals prove the single orchestrator
+cannot select reliably.
+
+### 2.3 Strict schemas and structured intermediate outputs improve reliability
+
+OpenAI recommends strict tool schemas and Structured Outputs when schema adherence
+matters. Anthropic also supports strict tool use. Structured outputs are useful for
+an intermediate request analysis or calculation plan; function calling remains the
+right mechanism for invoking repository tools.
+
+Sources:
+
+- [OpenAI function calling: strict mode](https://developers.openai.com/api/docs/guides/function-calling#strict-mode)
+- [OpenAI Structured Outputs](https://developers.openai.com/api/docs/guides/structured-outputs)
+- [Anthropic strict tool use](https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview#guarantee-schema-conformance-with-strict-tool-use)
+
+**Implication for SuperBot:** every tool schema should become strict-compatible,
+and complex requests should use typed intermediate contracts such as
+`BTD6RequestAnalysis` and `CalculationEvidence`, rather than asking the model to
+informally decide everything inside prose.
+
+### 2.4 Interleaving reasoning and tools helps multi-step factual tasks
+
+The ReAct paper found benefits from interleaving reasoning and external actions,
+including reduced hallucination/error propagation in question answering. SuperBot
+already has a bounded tool loop, so it does not need a new agent framework to gain
+this benefit.
+
+Source:
+
+- [ReAct: Synergizing Reasoning and Acting in Language Models](https://arxiv.org/abs/2210.03629)
+
+**Implication for SuperBot:** retain bounded multi-hop tool use, but make the
+workflow deliberate: analyze the request, call deterministic tools, inspect missing
+evidence, then synthesize. Do not expose private chain-of-thought; record only safe
+workflow decisions and tool traces.
+
+### 2.5 Complex workflows need trace-level and step-level evals
+
+OpenAI recommends evaluating tool selection and argument precision, and describes
+trace grading as a way to identify workflow-level errors. It recommends using evals
+to decide whether architecture complexity such as multiple agents is justified.
+
+Sources:
+
+- [OpenAI evaluation best practices](https://developers.openai.com/api/docs/guides/evaluation-best-practices)
+- [OpenAI trace grading](https://developers.openai.com/api/docs/guides/trace-grading)
+
+**Implication for SuperBot:** improve the existing eval harness to grade route,
+resolved toolset, requirement satisfaction, arguments, call order, evidence use,
+calculation correctness, restraint, latency budget, and final answer—not only whether
+a tool was called.
+
+### 2.6 Prompt structure and examples still matter, but are not enforcement
+
+OpenAI recommends clear instruction hierarchy, logical sections, relevant context,
+diverse few-shot examples, pinned model snapshots, and evals for prompt/model
+changes. Reasoning models generally need goals and constraints rather than demands
+to reveal step-by-step reasoning.
+
+Sources:
+
+- [OpenAI prompt engineering](https://developers.openai.com/api/docs/guides/prompt-engineering)
+- [OpenAI reasoning best practices](https://developers.openai.com/api/docs/guides/reasoning-best-practices)
+
+**Implication for SuperBot:** behavior presets should become structured, versioned
+orchestration presets with concise task-specific examples. They should not request
+visible chain-of-thought or be relied upon to enforce tool use.
+
+## 3. Current repository state and verified gaps
+
+### 3.1 What already exists
+
+| Existing capability | Current repository behavior | Reuse decision |
+|---|---|---|
+| Provider-neutral tools | `AIToolSpec` plus request `tools` and separate live handlers | Extend, do not replace |
+| Provider tool loops | OpenAI and Anthropic adapters run bounded tool loops | Extend with neutral choice/budget policy |
+| Tool choice | Both providers currently hard-code automatic choice when tools are offered | Replace hard-coded `auto` with resolved policy |
+| Tool registry | `services.ai_tools.build_registry()` filters by `AIScope` and runtime availability | Split catalogue metadata from per-request selection |
+| BTD6 tools | Large set of lookup, roster, capability, cost, round, map, mode, relic, bloon, paragon, and CT tools | Group into declared toolsets and workflow capabilities |
+| Grounding allowlist | `BTD6_GROUNDING_TOOL_NAMES` identifies results allowed to ground replies | Preserve and enrich with typed evidence metadata |
+| Faithfulness guard | BTD6 replies are checked against auto-grounding facts and approved tool results | Keep as final backstop; add earlier evidence completeness checks |
+| Task router | Routes BTD6/general/video request classes | Add complexity/intent analysis without replacing deterministic routing |
+| Behavior presets | Seeded instruction profiles with recommended reply modes | Add separate orchestration presets; do not overload instruction text |
+| Channel/category policy | Resolves reply mode, levels, cooldown, and instruction profile | Extend projection with orchestration profile/tool-policy reference |
+| Eval harness | Covers tool use/restraint, structure, safety, grounding, knowledge, and format | Add orchestration and calculation trace grading |
+
+### 3.2 Gaps that directly cause weaker complex responses
+
+1. **All available tools are broadly offered.** `build_registry()` currently builds
+   one large catalogue and filters primarily by `AIScope` and member-lookup feature
+   availability. It does not narrow by routed task, request intent, behavior preset,
+   channel/category tool policy, or cost budget.
+2. **Provider adapters hard-code `auto`.** A scope cannot require at least one tool,
+   force one specific tool, or disable model-visible tools while still using a
+   deterministic preflight.
+3. **Behavior presets are prompt/mode presets only.** `btd6_focused` asks the model
+   to prioritize grounding but cannot guarantee a grounding tool call or disable
+   unrelated tools.
+4. **No reusable toolset catalogue exists.** Individual tools have names and minimum
+   scopes but no family, capability tags, cost class, factual authority, parallel
+   safety, freshness, or task affinity metadata.
+5. **No per-request tool budget exists beyond provider hop limits.** There is no
+   configured maximum call count, result-byte/token budget, wall-clock budget, or
+   expensive-tool allowance by channel/profile.
+6. **No deterministic complex-request analysis contract exists.** Routing identifies
+   broad tasks, but not whether a BTD6 request is a lookup, comparison, calculation,
+   optimization, multi-entity synthesis, ambiguous request, or unsupported question.
+7. **No workflow distinction exists between deterministic preflight and model-chosen
+   tools.** “Always run this tool” is unsafe/impossible when a tool requires arguments
+   that only the model can infer, while some no-argument/context tools are ideal
+   deterministic preflights.
+8. **Tool result evidence is mostly untyped JSON/string context.** The final guard
+   checks grounding, but there is no shared provenance/evidence contract that states
+   which claim or calculation each result supports.
+9. **Calculations are tools, but there is no calculation-plan contract.** Complex
+   comparisons can require several deterministic calculations and conversions; the
+   model currently decides these ad hoc.
+10. **Audit/evals cannot fully explain bad orchestration.** The current audit can
+    identify task/provider/model/policy, and evals can detect tool calls, but there is
+    no resolved orchestration profile, offered-tool list hash, required-tool outcome,
+    budget-exhaustion reason, or safe tool trace summary.
+
+## 4. Core design: separate behavior from orchestration
+
+A behavioral instruction profile answers:
+
+- Should the bot reply here?
+- What tone, detail level, and domain emphasis should it use?
+
+An orchestration profile answers:
+
+- Which toolsets are available?
+- Which tools are required or pre-run?
+- Which workflow handles complex requests?
+- What budgets and answer/evidence rules apply?
+
+Do not combine these into one free-text profile. Operators should be able to choose
+“concise” behavior with “BTD6 calculator” orchestration, or “teaching” behavior with
+“BTD6 analyst” orchestration.
+
+### 4.1 Proposed resolved contract
+
+```python
+@dataclass(frozen=True)
+class AIOrchestrationPolicy:
+    profile_key: str
+    enabled_toolsets: tuple[str, ...]
+    disabled_tools: tuple[str, ...]
+    preflight_tools: tuple[str, ...]
+    tool_requirement: ToolRequirement
+    workflow: str
+    answer_contract: str
+    budget: AIToolBudget
+    parallel_policy: str
+    source_trace: tuple[str, ...]
+```
+
+This is a read model assembled from built-in defaults plus guild/category/channel
+configuration. It must be included in the AI configuration projection and policy
+decision hash so operators can understand the effective behavior.
+
+### 4.2 Requirement modes
+
+```python
+class ToolRequirementMode(str, Enum):
+    NONE = "none"                  # no model-visible tools
+    AUTO = "auto"                  # model may call zero or more
+    REQUIRED_ANY = "required_any"  # at least one allowed tool
+    REQUIRED_GROUP = "required_group"  # at least one tool from a named group
+    REQUIRED_TOOL = "required_tool"    # force one named tool
+```
+
+`REQUIRED_GROUP` is a SuperBot orchestration rule, not necessarily a native provider
+feature. The resolver narrows the offered tools to the group and uses provider
+“required/any” semantics, then verifies the resulting call belongs to that group.
+
+### 4.3 Preflight versus forced model calls
+
+These must be distinct:
+
+- **Preflight tool:** application calls a known safe tool before the model request.
+  Use when arguments are deterministic from request context or the tool accepts no
+  arguments. Example: a BTD6 data-version/capability summary.
+- **Required model tool:** model must produce arguments for one of the offered tools.
+  Use when the request contains entities/ranges/options that need extraction.
+- **Required group:** model must choose at least one tool from a narrow family. Use
+  for factual BTD6 channels where the exact lookup/calculator depends on the question.
+
+Never configure a specific required tool “for every message in a channel” unless it
+is valid for every message and has deterministic/safe arguments. For most BTD6
+channels, require the `btd6_grounding` group rather than forcing `btd6_lookup`.
+
+## 5. Tool catalogue and toolsets
+
+### 5.1 Enrich tool metadata
+
+Move from a flat list assembled inside `build_registry()` to declared catalogue
+entries. Keep handlers private/read-only, but add metadata used by selection and UI.
+
+```python
+@dataclass(frozen=True)
+class AIToolDescriptor:
+    spec: AIToolSpec
+    handler_factory: ToolHandlerFactory
+    toolsets: frozenset[str]
+    task_affinity: frozenset[AITask]
+    capability_tags: frozenset[str]
+    grounding_domain: str | None
+    cost_class: Literal["cheap", "normal", "expensive"]
+    freshness: Literal["static", "cached", "live"]
+    parallel_safe: bool
+    preflight_safe: bool
+    result_contract: str
+```
+
+The existing `min_scope` remains authoritative. A toolset policy can only remove
+scope-allowed tools; it can never grant a tool above the caller's scope.
+
+### 5.2 Initial built-in toolsets
+
+| Toolset | Purpose | Candidate members |
+|---|---|---|
+| `btd6_reference` | Entity and rule lookup | lookup, roster, capability, maps, modes, relics, bloons |
+| `btd6_rounds` | Round questions and range aggregation | round composition, bloon filter where relevant |
+| `btd6_costs` | Difficulty conversion and cumulative costs | difficulty cost, cumulative cost, lookup |
+| `btd6_paragon` | Paragon requirements/calculation/stat projections | paragon calculate, requirements, stats-at-degree |
+| `btd6_live` | Fresh server/Ninja Kiwi-related state | CT team and future live API tools |
+| `btd6_grounding` | Union of safe BTD6 factual tools | derived from grounding-domain metadata, replacing manual drift-prone grouping where possible |
+| `server_context_basic` | Low-risk server context | overview/time/user standing as policy permits |
+| `server_context_sensitive` | Member/config/audit context | admin/scope-gated tools only |
+| `diagnostics` | Future health snapshot tools | remains independent from BTD6 presets |
+
+### 5.3 Selection precedence
+
+Recommended effective selection:
+
+```text
+base catalogue
+∩ caller AIScope
+∩ runtime/feature availability
+∩ routed-task affinity
+∩ enabled orchestration-profile toolsets
+∩ channel/category allow policy
+− explicit disabled tools
+− tools exceeding budget/freshness rules
+= offered tools
+```
+
+Every exclusion should have a stable reason code for preview/audit:
+
+```text
+scope_denied
+runtime_unavailable
+task_mismatch
+toolset_disabled
+explicitly_disabled
+budget_disallowed
+freshness_disallowed
+```
+
+### 5.4 Keep selection deterministic
+
+Do not ask an LLM to choose which tools the LLM is allowed to see. Initial selection
+must be deterministic and inspectable. A later tool-retrieval index may help when the
+catalogue becomes very large, but it must remain constrained by policy and evaluated
+against a deterministic candidate set.
+
+## 6. Orchestration presets
+
+### 6.1 Preset examples
+
+#### `balanced_helper`
+
+- behavior profile: existing helpful/concise option;
+- toolsets: task-affinity defaults;
+- requirement: `AUTO`;
+- workflow: `direct_or_tool`;
+- budget: 2 calls, 2 hops, low result budget;
+- answer contract: concise factual response.
+
+#### `btd6_grounded_helper`
+
+- toolsets: `btd6_reference`, `btd6_costs`, `btd6_rounds`, `btd6_paragon`;
+- requirement: `REQUIRED_GROUP(btd6_grounding)` for factual BTD6 routes;
+- workflow: `analyze_execute_verify`;
+- budget: 4 calls, 3 hops;
+- answer contract: answer plus short evidence/version note;
+- non-BTD6 requests: normal auto-tool behavior or graceful redirect.
+
+#### `btd6_calculator`
+
+- toolsets: `btd6_costs`, `btd6_paragon`, relevant reference lookup;
+- requirement: required calculator group for calculation/comparison requests;
+- workflow: `calculation_plan_execute_verify`;
+- budget: 6 calls, 3 hops, parallel allowed only for independent calculations;
+- answer contract: inputs, assumptions, result, and deterministic calculation trace
+  summary;
+- forbid unsupported arithmetic from model memory when a deterministic tool exists.
+
+#### `btd6_research_desk`
+
+- toolsets: all BTD6 factual sets including live/cached sources;
+- requirement: required grounding group;
+- workflow: `decompose_gather_synthesize`;
+- budget: higher but bounded;
+- answer contract: comparison table, evidence coverage, ambiguities, and data version;
+- recommended for dedicated expert channels, not general chat.
+
+#### `no_tools_conversational`
+
+- toolsets: none;
+- requirement: `NONE`;
+- workflow: direct answer;
+- answer contract: no claim of live/current/private facts;
+- useful for social channels or cost control.
+
+#### `forced_context_channel`
+
+- deterministic preflight: safe channel-specific context tool(s);
+- model-visible requirement: `AUTO` or required group depending on task;
+- intended for future support/diagnostics channels where a no-argument context snapshot
+  should accompany every request.
+
+### 6.2 Preset composition
+
+A preset should reference separately versioned components:
+
+```text
+behavior profile + toolset policy + requirement policy + workflow + budget + answer contract
+```
+
+This avoids duplicating near-identical presets merely to change tone or budget. The
+UI may expose friendly bundled presets while advanced operators edit components.
+
+### 6.3 Safe defaults
+
+- Existing channels inherit `balanced_helper` behavior equivalent to today.
+- No migration should suddenly force tools or increase provider spend.
+- A preset cannot enable a tool above caller scope or a disabled feature flag.
+- Built-in presets are immutable through normal guild mutation paths.
+- Custom guild presets may only reference catalogue-approved toolsets/tools/workflows.
+
+## 7. Complex BTD6 request workflow
+
+### 7.1 Request analysis
+
+Add a typed, bounded `BTD6RequestAnalysis` produced deterministically where possible
+and by a small structured model call only when needed.
+
+```python
+@dataclass(frozen=True)
+class BTD6RequestAnalysis:
+    intent: Literal[
+        "lookup", "calculation", "comparison", "optimization",
+        "round_analysis", "strategy", "live_state", "ambiguous", "unsupported"
+    ]
+    entities: tuple[EntityRef, ...]
+    requested_outputs: tuple[str, ...]
+    assumptions_needed: tuple[str, ...]
+    required_capabilities: tuple[str, ...]
+    can_parallelize: bool
+    confidence: Literal["high", "medium", "low"]
+```
+
+Prefer deterministic entity extraction/catalogue resolution first. Use structured
+model analysis only for genuinely complex natural language. Analysis output is not a
+fact source and does not ground the answer.
+
+### 7.2 Plan, execute, verify, synthesize
+
+For complex requests:
+
+1. **Analyze:** resolve entities, intent, outputs, assumptions, and required
+   capabilities.
+2. **Clarify or default:** ask one focused question when an omitted assumption would
+   materially change the answer; otherwise use a documented default and state it.
+3. **Plan:** map required capabilities to deterministic tools. This mapping should be
+   mostly application-owned, not free-form model choice.
+4. **Execute:** call independent read-only tools in parallel only when descriptors say
+   they are parallel-safe and results do not depend on each other.
+5. **Verify:** ensure required evidence/calculation outputs exist, are fresh enough,
+   and agree on version/difficulty/entity identity.
+6. **Synthesize:** ask the model to explain already-computed results under a typed
+   answer contract.
+7. **Faithfulness check:** retain the existing BTD6 guard as the final backstop.
+8. **Refuse precisely:** if evidence is insufficient, state exactly which capability
+   or data is missing rather than improvising.
+
+### 7.3 Deterministic calculations first
+
+For BTD6 calculations:
+
+- the model extracts/clarifies inputs and explains results;
+- repository calculator services perform arithmetic;
+- result objects include normalized inputs, assumptions, formula/version identifier,
+  output, warnings, and source version;
+- comparisons call calculators for each candidate, then a deterministic comparison
+  helper ranks results;
+- the model must not recompute or alter returned numeric outputs;
+- if a requested calculation has no deterministic implementation, label it
+  unsupported or estimate-only according to explicit policy.
+
+### 7.4 Calculation evidence contract
+
+```python
+@dataclass(frozen=True)
+class CalculationEvidence:
+    evidence_id: str
+    calculator: str
+    calculator_version: str
+    normalized_inputs: Mapping[str, JsonValue]
+    assumptions: tuple[str, ...]
+    outputs: Mapping[str, JsonValue]
+    warnings: tuple[str, ...]
+    data_version: str | None
+```
+
+The final answer renderer should refer to evidence IDs internally and expose a short
+human-readable calculation summary, not raw internal traces.
+
+### 7.5 Multi-entity comparison helper
+
+Add a reusable deterministic orchestration helper instead of expecting the model to
+manually call the same tool repeatedly and compare prose:
+
+```text
+resolve candidates -> validate shared assumptions -> fan out bounded calculations
+-> normalize outputs -> deterministic rank/diff -> model explains result
+```
+
+This pattern is valuable for:
+
+- tower/upgrade cost comparisons;
+- difficulty cost comparisons;
+- paragon degree/resource scenarios;
+- round-range comparisons;
+- future game/stat/economy functions.
+
+## 8. Provider-neutral request changes
+
+### 8.1 Extend `AIRequest`
+
+Suggested additive fields:
+
+```python
+@dataclass(frozen=True)
+class AIToolChoice:
+    mode: ToolRequirementMode = ToolRequirementMode.AUTO
+    tool_name: str | None = None
+    group_name: str | None = None
+
+@dataclass(frozen=True)
+class AIToolBudget:
+    max_calls: int = 4
+    max_hops: int = 4
+    max_wall_seconds: float = 12.0
+    max_result_chars: int = 24_000
+    allow_expensive: bool = False
+
+@dataclass(frozen=True)
+class AIRequest:
+    ...
+    tools: tuple[AIToolSpec, ...] = ()
+    tool_choice: AIToolChoice = AIToolChoice()
+    tool_budget: AIToolBudget = AIToolBudget()
+    parallel_tool_calls: bool = True
+```
+
+Do not expose provider-specific dictionaries outside provider adapters.
+
+### 8.2 Provider mapping
+
+| Neutral mode | OpenAI mapping | Anthropic mapping | SuperBot verification |
+|---|---|---|---|
+| `NONE` | `tool_choice="none"` or omit tools | omit tools / none | no dispatch occurs |
+| `AUTO` | `auto` | `auto` | zero or more allowed calls |
+| `REQUIRED_ANY` | `required` | `any` | at least one allowed call |
+| `REQUIRED_TOOL` | forced function | forced tool | exact named call occurs |
+| `REQUIRED_GROUP` | offer only group + `required` | offer only group + `any` | at least one call from group |
+
+Provider adapters must enforce the resolved maximum calls/hops/wall time/result size,
+not only their current constant hop limit.
+
+### 8.3 Strict schema migration
+
+Audit every `AIToolSpec.parameters` schema for strict compatibility:
+
+- object schemas set `additionalProperties: false`;
+- required fields are explicit;
+- optional fields use a provider-neutral nullable representation compatible with
+  adapters;
+- enums and ranges are narrow;
+- descriptions explain when **not** to use the tool;
+- tools use stable canonical entity identifiers where possible;
+- handler validation remains authoritative even when provider strict mode is active.
+
+Add a startup/test validator that rejects invalid tool descriptors before they reach
+a provider.
+
+## 9. Configuration and ownership model
+
+### 9.1 Storage direction
+
+Do not store enabled tools as arbitrary free-text instruction profile content. Use
+typed policy state. A reasonable additive design is:
+
+- `ai_orchestration_profile`: named built-in or guild-owned orchestration components;
+- `ai_tool_policy_guild`, `ai_tool_policy_category`, `ai_tool_policy_channel`, or a
+  single typed scope table if repository conventions support it;
+- channel/category policy references an orchestration profile or typed override;
+- optional explicit deny list stored as validated tool keys/toolset keys;
+- every mutation through a dedicated `ai_orchestration_mutation` service;
+- every read through `ai_orchestration_policy.resolve(...)` and the canonical AI
+  config projection.
+
+Before choosing tables, compare extending existing typed policy rows versus a
+separate scope-policy table. Avoid adding many nullable columns to instruction
+profiles because orchestration is not instruction text.
+
+### 9.2 Resolution precedence
+
+Recommended precedence mirrors current policy concepts:
+
+```text
+system safe default
+< guild orchestration profile
+< category orchestration override
+< channel orchestration override
+< task-specific safe constraints
+< caller scope/runtime feature constraints
+```
+
+Lower layers may narrow or tune; they may never bypass scope, runtime kill switches,
+read-only constraints, grounding rules, or hard global budgets.
+
+### 9.3 Channel “always force tools” behavior
+
+Support operator intents with safe typed options:
+
+- `No tools`;
+- `Automatic tools from selected toolsets`;
+- `Require one grounding tool for factual BTD6 requests`;
+- `Require one calculator tool for BTD6 calculation requests`;
+- `Run selected safe preflight context on every allowed request`;
+- `Force one specific tool` only when descriptor metadata marks it safe and valid for
+  the chosen trigger/task.
+
+The configuration UI should reject invalid combinations such as forcing a Paragon
+calculator for general conversation or configuring a preflight tool that requires
+model-derived arguments.
+
+### 9.4 UI additions
+
+Extend the existing AI panel/Behavior workflow rather than creating a new unrelated
+admin island:
+
+- **Behavior** remains tone/reply-mode/instruction configuration;
+- add **Tools & workflows** for orchestration profile selection;
+- show effective toolsets, disabled tools, requirement mode, workflow, and budget;
+- preview the resolved policy for a sample channel/user/task;
+- include “Why is this tool unavailable?” reason codes;
+- add a dry-run request analyzer that shows route, complexity, selected toolsets,
+  requirement, and planned deterministic workflow without calling a provider;
+- make dangerous/cost-increasing changes explicit in confirmation copy.
+
+## 10. Answer contracts and response quality
+
+Behavior presets should select a typed answer contract rather than relying only on
+free-text style instructions.
+
+### 10.1 Initial answer contracts
+
+| Contract | Required visible elements |
+|---|---|
+| `concise_fact` | direct answer, short source/version note when relevant |
+| `calculation_explained` | normalized inputs, assumptions, result, short explanation, warnings |
+| `comparison` | compared entities, shared assumptions, compact table/ranking, key difference |
+| `research_summary` | answer, evidence coverage, uncertainty/missing data, data version |
+| `clarification` | one focused question and why it changes the result |
+| `unsupported` | exact unsupported capability/data and nearest available command/tool |
+
+The model may render prose, but a pre-render structured response object should be
+validated before Discord output. This makes complex responses testable and reusable
+for future functions/panels.
+
+### 10.2 Evidence completeness gate
+
+Before synthesis, verify:
+
+- every requested output has supporting evidence;
+- every compared entity resolved canonically;
+- all calculations share compatible difficulty/version assumptions;
+- required tool/group use was satisfied;
+- no result was truncated in a way that invalidates conclusions;
+- live/cached results meet freshness policy;
+- warnings and unsupported portions are propagated.
+
+If completeness fails, clarify, perform another allowed bounded step, or return a
+precise partial answer. Do not let the model conceal missing evidence.
+
+## 11. Budgeting, parallelism, and failure behavior
+
+### 11.1 Budget dimensions
+
+Each orchestration profile should bound:
+
+- model/tool hops;
+- total tool calls;
+- per-tool and total wall-clock time;
+- tool result characters/tokens;
+- expensive/live tool calls;
+- parallel fan-out width;
+- clarification/retry count;
+- final output size.
+
+### 11.2 Parallelism policy
+
+- parallelize only independent, descriptor-marked `parallel_safe` reads;
+- do not parallelize when a later call needs a prior canonical ID/result;
+- preserve deterministic output ordering after parallel calls;
+- enforce fan-out limits for multi-entity questions;
+- record partial failures per call and allow useful partial answers where policy
+  permits.
+
+### 11.3 Stable failure reasons
+
+Add safe orchestration reason codes:
+
+```text
+tool_required_but_unavailable
+tool_requirement_unsatisfied
+tool_budget_exhausted
+tool_result_too_large
+tool_timeout
+request_ambiguous
+calculation_unsupported
+evidence_incomplete
+version_mismatch
+freshness_requirement_failed
+```
+
+Each should map to deterministic user-facing fallback text and audit/metric labels.
+
+## 12. Audit, metrics, and evals
+
+### 12.1 Safe orchestration trace
+
+Record a bounded trace summary, not private reasoning or raw results:
+
+```python
+@dataclass(frozen=True)
+class AIOrchestrationTrace:
+    profile_key: str
+    workflow: str
+    routed_task: str
+    request_intent: str | None
+    offered_tool_names: tuple[str, ...]
+    requirement: str
+    calls: tuple[SafeToolCallSummary, ...]
+    requirement_satisfied: bool
+    budget_outcome: str
+    evidence_ids: tuple[str, ...]
+    final_status: str
+```
+
+Hash or cap offered-tool lists in durable audit rows if necessary; keep full safe
+traces process-local or in a dedicated bounded observability store according to the
+executed diagnostics plan.
+
+### 12.2 Metrics
+
+Candidate metrics:
+
+- request count by orchestration profile/workflow/intent;
+- offered-tool count histogram;
+- tool calls/results/errors/latency by tool;
+- required-tool satisfaction and fallback reason;
+- budget exhaustion count;
+- evidence completeness failures;
+- BTD6 faithfulness retry/refusal by orchestration profile;
+- clarification rate;
+- deterministic-calculator versus unsupported-calculation rate;
+- answer-contract validation failures.
+
+Avoid labels containing guild/channel/user IDs or arbitrary tool arguments.
+
+### 12.3 Eval expansion
+
+Expand the existing eval harness with categories:
+
+- `toolset_selection`: only relevant tools are offered;
+- `tool_requirement`: required group/tool is actually used;
+- `tool_disable`: disabled tools are never offered/called;
+- `tool_arguments`: canonical entity/path/difficulty/range extraction;
+- `workflow_trace`: expected call sequence/parallel grouping;
+- `calculation_correctness`: exact deterministic output use;
+- `comparison_completeness`: every candidate evaluated under shared assumptions;
+- `clarification`: asks when missing assumptions materially affect result;
+- `budget`: stops/falls back safely at limits;
+- `evidence_completeness`: does not answer beyond results;
+- `answer_contract`: expected visible sections/fields;
+- `preset_resolution`: guild/category/channel precedence and source trace;
+- `provider_parity`: neutral choice modes behave equivalently on OpenAI/Anthropic.
+
+For each complex case, grade separately:
+
+1. route/intent;
+2. resolved toolset;
+3. requirement mode;
+4. tool choice and arguments;
+5. deterministic result/evidence use;
+6. final factual/numeric correctness;
+7. restraint and safety;
+8. latency/call budget.
+
+Use production failures to grow the golden set. Do not judge orchestration quality
+only from final prose; a plausible answer may hide an incorrect or missing tool path.
+
+## 13. Phased implementation plan
+
+### Phase 0 — Contracts and policy decisions
+
+Decide:
+
+- built-in toolsets and descriptor metadata;
+- requirement modes and provider-neutral semantics;
+- which tools are preflight-safe, parallel-safe, expensive, live, or grounding;
+- initial orchestration presets and safe defaults;
+- scope/precedence model and custom-preset permissions;
+- answer contracts and deterministic calculation evidence contract;
+- budgets and failure reason codes.
+
+**Exit criterion:** examples for general lookup, BTD6 lookup, BTD6 calculation,
+comparison, ambiguous request, disabled toolset, and required-tool channel all have
+an unambiguous resolved policy and expected trace.
+
+### Phase 1 — Tool catalogue and per-request selection
+
+Implement:
+
+- enriched `AIToolDescriptor` catalogue;
+- named toolsets;
+- deterministic selector by scope/runtime/task/profile;
+- exclusion reason codes and preview API;
+- strict-schema validator;
+- compatibility adapter so current behavior remains unchanged by default.
+
+**Exit criterion:** existing requests still work, while tests prove a selected
+profile can narrow/disable toolsets without granting additional authority.
+
+### Phase 2 — Neutral tool choice and budgets
+
+Implement:
+
+- neutral tool-choice and budget request contracts;
+- OpenAI/Anthropic mappings;
+- dynamic hop/call/wall/result budgets;
+- required-group verification;
+- safe trace summaries and metrics.
+
+**Exit criterion:** tests prove `NONE`, `AUTO`, `REQUIRED_ANY`, `REQUIRED_GROUP`, and
+`REQUIRED_TOOL` behavior across both provider adapters, including failures and
+budget exhaustion.
+
+### Phase 3 — Typed orchestration policy and admin UX
+
+Implement:
+
+- orchestration policy storage/read/mutation ownership;
+- guild/category/channel resolution and config projection;
+- seeded built-in orchestration presets;
+- AI panel “Tools & workflows” UI, preview, and dry-run analyzer;
+- audit rows/source trace additions.
+
+**Exit criterion:** an operator can safely enable/disable toolsets or require BTD6
+grounding/calculator groups for a channel without editing instruction text.
+
+### Phase 4 — Complex BTD6 workflow
+
+Implement:
+
+- typed BTD6 request analysis;
+- deterministic capability-to-tool planning;
+- clarification/default rules;
+- calculation evidence and multi-entity comparison helper;
+- evidence completeness gate;
+- typed answer contracts;
+- retain existing faithfulness verification as final backstop.
+
+**Exit criterion:** representative multi-step lookup/calculation/comparison requests
+produce correct, grounded, assumption-aware answers under bounded calls.
+
+### Phase 5 — Eval-driven refinement and future-function adoption
+
+Implement:
+
+- orchestration trace graders and expanded golden cases;
+- provider/model/preset comparisons;
+- tune tool descriptions/examples and task affinity from failures;
+- selectively adopt orchestration profiles for future domains;
+- consider retrieval-based tool selection or specialized agents only if evals show
+  the deterministic selector plus single orchestrator no longer scales.
+
+## 14. Suggested PR slices
+
+1. **PR A — Tool catalogue metadata and strict-schema audit.**
+2. **PR B — Named toolsets and deterministic per-request selector.**
+3. **PR C — Provider-neutral tool choice and dynamic budgets.**
+4. **PR D — Orchestration policy resolver, projection, and mutation ownership.**
+5. **PR E — Tools & workflows admin UI, preview, and dry run.**
+6. **PR F — BTD6 request analysis and evidence/calculation contracts.**
+7. **PR G — Complex BTD6 plan/execute/verify workflow and answer contracts.**
+8. **PR H — Trace/eval expansion and provider/preset tuning.**
+
+Do not combine storage, provider protocol changes, complex BTD6 workflows, and UI
+into one PR.
+
+## 15. Tests required before rollout
+
+### Policy and selection
+
+- toolset policies can remove but never grant tools above `AIScope`;
+- task affinity and runtime feature constraints cannot be bypassed by presets;
+- category/channel precedence and inheritance are deterministic;
+- explicit tool disable wins over enabled toolsets;
+- built-in presets are immutable through normal guild paths;
+- preview/dry-run output exactly matches runtime selection;
+- config projection includes effective orchestration source trace.
+
+### Provider/tool execution
+
+- all tool schemas satisfy strict validator rules;
+- `NONE`, `AUTO`, required-any/group/tool map correctly for OpenAI and Anthropic;
+- required-group cannot call outside its narrowed set;
+- max calls/hops/wall/result/fan-out budgets are enforced;
+- preflight tools never require model-derived arguments;
+- only parallel-safe independent calls run concurrently;
+- dispatch/handler validation remains authoritative;
+- tool failures are structured and do not crash the whole pipeline.
+
+### BTD6 quality
+
+- complex entity extraction resolves aliases/canonical names correctly;
+- ambiguous difficulty/path/degree assumptions trigger clarification when material;
+- calculations use deterministic service outputs exactly;
+- comparisons evaluate every candidate under identical assumptions;
+- data-version/freshness mismatch is visible;
+- evidence completeness blocks unsupported claims;
+- existing BTD6 faithfulness tests remain green;
+- disabled BTD6 tools cause precise refusal/fallback rather than model-memory guesses;
+- answer contracts render within Discord limits.
+
+### Eval and observability
+
+- safe traces contain no private reasoning, raw messages, or raw tool results;
+- audit/metrics labels are bounded and contain no IDs/arguments;
+- evals grade selection, arguments, sequence, evidence, final answer, and budget;
+- provider/preset changes cannot ship without running the relevant golden subset.
+
+## 16. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Operators force an irrelevant tool for every channel message. | Descriptor `preflight_safe`/task constraints, UI validation, and prefer required groups over specific tools. |
+| More configuration becomes impossible to understand. | Friendly bundled presets, canonical projection, effective-policy preview, source trace, and safe defaults. |
+| Narrow selection hides a needed tool. | Deterministic reason codes, dry run, eval cases, and precise “tool unavailable” fallback. |
+| Required tools increase latency/cost for trivial questions. | Route/intent-conditional requirements, per-profile budgets, and do not force grounding for conversational/non-factual turns. |
+| Model picks a plausible but wrong calculator. | Capability-to-tool mapping, strict schemas, required groups, argument validation, and trace evals. |
+| Model changes deterministic numeric results in prose. | Calculation evidence contract, typed answer object, exact-output checks, and final faithfulness guard. |
+| Parallel fan-out overloads services. | Descriptor safety metadata, fan-out cap, timeouts, and cost class policy. |
+| Tool catalogue metadata drifts from handlers/grounding allowlist. | One canonical descriptor catalogue plus invariant tests deriving toolsets/grounding sets. |
+| Provider semantics differ. | Neutral contract, adapter conformance tests, and provider-parity evals. |
+| Multi-agent architecture is introduced too early. | Keep one bounded orchestrator; only split when trace evals prove a specific selection/instruction failure. |
+| Prompt presets are mistaken for enforcement. | Keep runtime orchestration policy separate and make hard guarantees in request/provider contracts. |
+
+## 17. Product decisions required
+
+1. Should new channels default to all current scope-allowed tools or task-affinity
+   toolsets? Recommended: task-affinity toolsets after compatibility rollout.
+2. Should factual BTD6 channels require one grounding tool for every factual BTD6
+   request? Recommended: yes, but not for social/conversational BTD6 turns.
+3. Which BTD6 calculations are allowed to return estimates, and how must estimates
+   be labeled?
+4. Which omissions require clarification versus a stated default—for example
+   difficulty, Monkey Knowledge, hero level, degree, crosspath, or game version?
+5. Who may configure toolsets and required tools: administrators, server owner, or
+   platform owner only? Recommended: admins may choose safe built-in presets;
+   server/platform owners may create advanced overrides.
+6. Should custom orchestration profiles be guild-owned, or should v1 allow only
+   built-in presets? Recommended: built-in presets first.
+7. What are the default call/hop/time/result/fan-out budgets for general, grounded
+   BTD6, calculator, and research profiles?
+8. Should live/external BTD6 tools require explicit opt-in separately from static
+   reference/calculator tools? Recommended: yes.
+9. Should an operator be allowed to force a specific tool, or only pre-approved
+   preflight tools/required groups in v1? Recommended: required groups and approved
+   preflights first; specific-tool forcing later.
+
+## 18. Immediate next-agent brief
+
+Start with the tool catalogue and neutral orchestration contracts. Do not start with
+new prompts or UI.
+
+Required first implementation task:
+
+1. inventory every current `AIToolSpec` and handler;
+2. propose `AIToolDescriptor` metadata, named toolsets, and one canonical catalogue;
+3. define strict-schema validation and identify incompatible existing schemas;
+4. define provider-neutral tool choice and budget contracts;
+5. define deterministic selection precedence and exclusion reasons;
+6. add tests proving current default behavior remains compatible and policies can
+   only narrow authority;
+7. add orchestration selection/trace cases to the eval harness design.
+
+Do **not** in the first PR:
+
+- add a multi-agent framework;
+- allow write-capable tools;
+- let operators enter arbitrary tool names or provider-specific `tool_choice` JSON;
+- remove the existing BTD6 faithfulness guard;
+- use prompt instructions as the only enforcement for required tools;
+- force a specific argument-requiring tool on every channel request;
+- expose model chain-of-thought in traces or Discord;
+- add custom guild orchestration profiles before built-in contracts are stable.
+
+## 19. Definition of success
+
+The initiative succeeds when a server operator can choose a clear Tools & Workflows
+preset for a channel; SuperBot deterministically offers only the relevant authorized
+tools; factual or calculation-heavy BTD6 requests reliably call the required lookup
+or calculator family; complex comparisons use consistent assumptions and deterministic
+math; every answer is supported by bounded evidence; disabled tools stay disabled;
+and failures produce precise, inspectable fallbacks instead of plausible guesses.

--- a/docs/bot-awareness-diagnostics-plan.md
+++ b/docs/bot-awareness-diagnostics-plan.md
@@ -1,0 +1,882 @@
+# AI-Assisted Bot Awareness and Diagnostics: Repository Map and Delivery Plan
+
+**Status:** planning and brainstorming document; no implementation is authorized by
+this document alone  
+**Verified against:** the current repository worktree on 2026-06-06  
+**Audience:** maintainers and follow-up implementation agents
+
+## 1. Executive decision
+
+SuperBot should implement **AI-assisted diagnostics over the existing observability
+stack**, not a parallel `bot_awareness_service` and not an AI cog that inspects raw
+internals.
+
+The target architecture is:
+
+```text
+existing diagnostics providers / startup outcomes / metrics / domain health readers
+                                  |
+                                  v
+                    typed health snapshot service
+                (aggregation, severity, bounds, redaction)
+                                  |
+                +-----------------+------------------+
+                |                                    |
+                v                                    v
+     deterministic DiagnosticCog / Platform UI     read-only AI tools
+                |                                    |
+                v                                    v
+       operator-visible facts              optional AI explanation
+```
+
+The AI remains an interpreter. Deterministic services remain the source of facts,
+and deterministic commands remain usable when AI is disabled or unhealthy.
+
+The repository is **foundation-ready but not feature-ready**. It already contains
+most of the collection seams and operator surfaces. It does not yet contain a
+unified operational `HealthSnapshot`, cross-source severity/redaction rules,
+recurring operational finding history, grouped failure fingerprints, or AI tools
+for operational diagnostics.
+
+## 2. Non-negotiable architecture rules
+
+1. Keep `services.diagnostics_service` as the process-local, synchronous,
+   read-only provider registry. Do not add a second registry named
+   `bot_awareness_service`.
+2. Add a typed aggregation/read-model layer above existing sources. It may collect
+   asynchronous checks, but it must not turn `diagnostics_service.snapshot_all()`
+   into a blocking or mutating operation.
+3. Put deterministic operator UX in the existing `DiagnosticCog` / Platform hub.
+   Do not create a separate `/bot` diagnostics island.
+4. AI diagnostic tools must use the existing `services.ai_tools` contract: offered
+   only at sufficient `AIScope`, read-only, bounded, JSON-serializable, and
+   redacted **before** model input.
+5. AI explanations are additive. Snapshot generation, startup reports, findings,
+   and operator commands must work without an AI provider.
+6. Prefer structured provider outputs, startup outcomes, task snapshots, metrics,
+   and domain health readers over parsing log text. Treat log inspection as a
+   bounded fallback/legacy source.
+7. The AI may suggest what to inspect next. It may not restart the bot, alter
+   configuration, edit files, query arbitrary tables, acknowledge findings, or
+   resolve findings.
+8. New durable state must have one service owner, additive/idempotent migrations,
+   bounded retention, and documented readers/writers.
+9. New EventBus events are for durable lifecycle transitions, not every warning or
+   log line. Every event must be catalogued, documented, and tested.
+10. Do not expose raw stack traces, environment values, tokens, message content,
+    or unbounded identifiers to the model or Discord surfaces.
+
+## 3. Verification of the draft claims
+
+### 3.1 Claims that are correct
+
+| Draft claim | Verdict | Repository evidence / implication |
+|---|---|---|
+| AI should interpret structured health rather than inspect internals directly. | Correct | `services.ai_tools` already defines tools as read-only, small, JSON-serializable, and scope-gated. This is the contract diagnostics tools should extend. |
+| One failed diagnostics provider must not break a full snapshot. | Already implemented | `diagnostics_service.snapshot_all()` catches provider exceptions and substitutes an `_error` payload. The future aggregator must preserve this isolation. |
+| Deterministic diagnostics must work without AI. | Correct and repository-aligned | The AI integration map explicitly requires raw platform embeds and deterministic recent-error lists as fallbacks. |
+| Health collection should be reusable by commands, panels, startup reports, and AI. | Correct | Existing provider, platform embed, startup outcome, and AI tool seams support this shape. A typed aggregate is the missing connector. |
+| AI health and whole-bot health are different. | Correct | AI already has separate configuration projections, diagnostics counters, readiness, and decision-audit services. These should feed an AI subsystem summary rather than define global health. |
+| Repeated failures should be grouped by fingerprint. | Correct but absent | The current recent-log ring buffer is bounded but stores only timestamp, level, and message; it does not fingerprint or persist recurrence. |
+| Redaction and permission tiers must be explicit. | Correct but incomplete today | `AIScope` gating exists, but there is no diagnostics-specific redaction policy or unified redacted health snapshot. |
+
+### 3.2 Claims that need correction
+
+| Draft claim | Correction |
+|---|---|
+| “Add a central `bot_awareness_service`.” | Do not add it. `services.diagnostics_service` is already the central process-local provider registry. Add `health_snapshot_service` as an aggregator/read model above it. |
+| “Add a health provider registry.” | A general registry already exists. Add adapters/providers incrementally; do not create a competing `HealthProvider` registry in the first phase. Revisit a typed provider protocol only if normalization proves too fragile. |
+| “Add `/bot health`, `/bot logs recent`, `/bot cogs`, `/bot startup-report`.” | Extend `!platform` and the existing privileged `/platform` entry/panel. Existing commands already include status, runtime, lifecycle, tasks, consistency, readiness, and standalone recent-log/error commands. |
+| “Add a new admin diagnostics panel.” | Extend `views.diagnostic.platform_panel` first. It already groups platform diagnostics and renders existing embed builders. |
+| “Add startup self-review/reporting.” | SuperBot already records a subset of startup outcomes, composes `platform_readiness`, and sends a deterministic startup-summary webhook before Discord connects. The new work is to broaden and normalize that report, not invent it. |
+| “Add recent log inspection.” | Recent logs and recent errors already use a bounded in-process ring buffer. The missing work is safe classification/grouping and structured observations, not basic access. |
+| “Add AI self-awareness.” | AI diagnostics/config/readiness projections already exist. Build an adapter from those canonical read models; do not independently inspect AI configuration/provider state. |
+| “Add structured lifecycle events for every important observation.” | Add only a small set of durable transition events. High-volume observations belong in metrics/logs/providers. |
+| “HealthSnapshot should list all loaded cogs and raw findings.” | Snapshot output must be bounded and scope-redacted. Counts and compact summaries should be default; detailed names/hints should require elevated scope and explicit drilldown. |
+
+### 3.3 Claims that are only partly true
+
+- **Startup report coverage:** a deterministic summary exists, but the recorder only
+  covers four catalogue-build phases. Cog load failures are reported separately by
+  webhook and are not normalized into the startup outcome/readiness model. Gateway
+  readiness, slash sync, DB availability, persistent view registration, and AI
+  state are not all represented in one startup snapshot.
+- **Cog status:** loaded cog names are logged at `on_ready`, and individual load
+  failures trigger webhook reporting, but there is no durable/bounded cog-health
+  read model with expected/missing/failed distinctions.
+- **Metrics health:** Prometheus metrics and HTTP `/health`, `/ready`, `/lifecycle`,
+  and `/metrics` endpoints exist, but there is no safe metric snapshot/derived
+  summary API for Discord or AI use.
+- **Findings:** domain-specific findings already exist, especially
+  `ResourceHealthFinding`, while platform consistency has typed section results.
+  There is no single operational finding contract or persistent finding lifecycle.
+- **Scopes:** `AIScope` supports user, moderator, admin, server owner, platform
+  owner, and system ranks. Existing deterministic platform commands are generally
+  administrator-gated; the proposed diagnostics redaction/access matrix still
+  needs a deliberate product decision.
+
+## 4. Current repository capability map
+
+### 4.1 Collection and observation sources
+
+| Existing source | What it provides now | Readiness for aggregation | Important constraint |
+|---|---|---:|---|
+| `services.diagnostics_service` | Registered synchronous provider snapshots and fail-isolated `snapshot_all()` | High | Providers are sync and process-local; async DB/API probes must live elsewhere. |
+| Registered diagnostics providers | Runtime lock, lifecycle, managed tasks, slow paths, caches, bindings, schemas, feature flags, platform readiness, server logging, automation, and more | High | Shapes are heterogeneous and not all payloads are safe for every scope. |
+| `services.platform_consistency` | Typed consistency report, blocking sections, cached readiness snapshot, startup outcomes, catalogue state, task names | High | Fresh consistency collection is async; provider exposes cached/read-only state. |
+| `core.runtime.startup_outcome` | Bounded, typed, short-error startup phase results and deterministic summary status | High but narrow | Only four known phases are currently recorded. |
+| `core.runtime.lifecycle` | Phase, pending transition, recent events, startup duration observation | High | Process-local lifecycle only. |
+| `core.runtime.tasks` | Managed task state and task outcome metrics | High | Needs safe summary rules; task names can be useful but potentially verbose. |
+| `services.metrics` | Prometheus counters, gauges, and histograms for runtime/platform/AI behavior | Medium | There is no canonical bounded “metrics snapshot” read model. Prometheus collectors are not automatically safe AI context. |
+| `healthserver.py` | HTTP liveness, readiness, lifecycle, and Prometheus endpoints | Medium | It directly knows the bot object; it should consume a shared safe summary later rather than become the aggregation owner. |
+| Diagnostic log ring buffer | Last 500 `bot.*` INFO+ records; recent level-filtered reads | Medium | Plain messages, process-local only, no exception metadata/fingerprint/category, and current helpers can expose message text. |
+| AI config/diagnostics/readiness/audit services | Canonical operator-facing AI configuration and provider counters/readiness | High | Must be adapted from canonical read models, never re-resolved independently. |
+| `services.resource_health` / setup readiness | Typed guild binding/resource findings and summaries | High for guild-local health | This is setup/resource health, not a global operational finding model. Preserve that distinction. |
+| Webhook reporter | Startup summary, cog load failures, identity findings, task failures, lifecycle alerts | Medium | It is an output/reporting surface, not a source of truth. |
+
+### 4.2 Existing deterministic operator surfaces
+
+The existing `DiagnosticCog` and Platform hub already cover much of the proposed
+command set:
+
+- general diagnostics hub;
+- bot status, latency, system information, database checks, command inventory;
+- bounded recent logs and recent errors;
+- `!platform status`, `setup-readiness`, `runtime`, `lifecycle`, `tasks`, `slow`,
+  `consistency`, and many registry/resource/platform diagnostics;
+- a privileged `/platform` slash entry that opens the Platform hub;
+- a Platform panel with categorized read-only selections and shared embed builders.
+
+This means the first UX increment should be small and repo-consistent:
+
+- `!platform health` and a matching Platform panel item;
+- `!platform startup`;
+- `!platform findings` only after a stable finding read model exists;
+- `!platform ai-health` as a normalized subsystem drilldown;
+- `!platform subsystem <name>` only if a bounded generic drilldown is safe.
+
+Do not duplicate existing `runtime`, `lifecycle`, `tasks`, `consistency`,
+`setup-readiness`, `query_logs`, or `recent_errors` behavior. Link or compose it.
+
+### 4.3 Existing AI seam
+
+`services.ai_tools` is the correct tool registry. It already:
+
+- ranks `AIScope` values;
+- omits tools above the caller's privilege entirely;
+- attaches pure `AIToolSpec` data to requests;
+- requires read-only, bounded, JSON-serializable responses;
+- rejects write-capable tools as out of scope.
+
+No operational diagnostics tools exist yet. The documented AI integration map
+already identifies this connector path:
+
+```text
+Platform panel -> AI monitor service -> diagnostics snapshots -> AIGateway
+               -> read-only summary embed
+```
+
+A future `services.ai_monitor_service` should orchestrate optional explanation of
+already-redacted snapshot data. It must not collect raw facts itself.
+
+### 4.4 Existing persistence and ownership seam
+
+The migration sequence currently ends at `056_role_threshold_role_id.sql`.
+Persistent operational findings would therefore need a new additive migration and
+an explicit owner such as `services.health_findings_service`.
+
+The ownership contract requires one write owner. Diagnostic commands, embeds, the
+AI monitor, and tools may read through that service; they must not write the table
+directly.
+
+### 4.5 Existing event and observability seam
+
+The EventBus is in-process and catalogue-enforced. Unknown event use warns and
+increments a metric. New events require:
+
+1. a literal in `core.events_catalogue.KNOWN_EVENTS`;
+2. an ownership/payload row in `docs/ownership.md`;
+3. a payload contract in the emitter module;
+4. tests that prevent catalogue drift;
+5. idempotent/best-effort consumers because event handlers are isolated and timed.
+
+The observability contract already requires managed tasks, warning logs for
+recoverable anomalies, and metrics for silent failure paths. Health work should
+consume and extend this contract, not bypass it.
+
+## 5. Important design collisions to resolve before coding
+
+### 5.1 “Health finding” already means more than one thing
+
+`ResourceHealthFinding` is a mature guild resource/setup contract. A new global
+`HealthFinding` name risks ambiguity. Choose one of these options in the first ADR
+or implementation PR:
+
+- **Recommended:** name the global contract `OperationalHealthFinding`, leaving
+  `ResourceHealthFinding` untouched; or
+- use `HealthFinding` only inside a dedicated `models/operational_health.py` module
+  and document the distinction prominently.
+
+Do not silently retrofit resource findings into a global schema. Adapt them at the
+aggregation boundary.
+
+### 5.2 Severity vocabulary is inconsistent
+
+The drafts use `healthy`, `degraded`, `attention`, and `critical`; existing
+resource findings use `info`, `warn`, and `error`; startup uses `ok`, `degraded`,
+`failed`, and `empty`; platform consistency uses its own section statuses.
+
+Define two separate canonical concepts:
+
+- **snapshot status:** `healthy | degraded | critical | unknown`;
+- **finding severity:** `info | warning | error | critical`.
+
+Then publish deterministic mapping rules from each existing source. Avoid
+`attention` because it blurs status and severity.
+
+### 5.3 Sync provider registry versus async checks
+
+`diagnostics_service` providers are intentionally synchronous. Database ping,
+external API probes, fresh platform consistency checks, and guild-resource health
+are asynchronous. The aggregator must therefore have two lanes:
+
+- `collect_cached_snapshot()` for sync/process-local facts;
+- `async collect_snapshot(request)` for bounded async checks selected by scope and
+  purpose.
+
+The async collector may call `diagnostics_service.snapshot_all()` as one input.
+It must apply timeouts and isolate every async source just as the registry isolates
+sync providers.
+
+### 5.4 Process-local versus durable truth
+
+Diagnostics providers, log ring buffers, lifecycle state, and startup outcomes are
+process-local. A persistent findings table survives restarts. Snapshots and
+findings must label their source and process/session identity so operators do not
+mistake an old durable recurrence count for a current-process error count.
+
+A future design should reuse the existing runtime/session identity where possible
+rather than invent an unrelated boot identifier.
+
+## 6. Proposed contracts
+
+The exact module location should follow existing repository conventions; a single
+`models/` package does not currently appear to be the dominant pattern. Prefer
+service-local frozen dataclasses unless maintainers intentionally establish a
+shared model package.
+
+### 6.1 `SubsystemHealth`
+
+Suggested minimum fields:
+
+```python
+@dataclass(frozen=True)
+class SubsystemHealth:
+    name: str
+    status: SnapshotStatus
+    summary: str
+    generated_at: datetime
+    findings: tuple[OperationalHealthFinding, ...] = ()
+    facts: Mapping[str, JsonValue] = field(default_factory=dict)
+    source: str = "unknown"
+    stale: bool = False
+```
+
+Rules:
+
+- `facts` is bounded and allowlisted, never an arbitrary provider dump;
+- `summary` is deterministic, not AI-generated;
+- a failed provider produces `unknown` or `degraded`, not an exception;
+- source timestamps/staleness are explicit;
+- detailed drilldown is a separate operation, not an unbounded `facts` field.
+
+### 6.2 `OperationalHealthFinding`
+
+Suggested minimum fields:
+
+```python
+@dataclass(frozen=True)
+class OperationalHealthFinding:
+    fingerprint: str
+    severity: FindingSeverity
+    category: str
+    message: str
+    first_seen_at: datetime | None = None
+    last_seen_at: datetime | None = None
+    occurrence_count: int = 1
+    related_subsystem: str | None = None
+    related_command: str | None = None
+    related_provider: str | None = None
+    file_hint: str | None = None
+    suggested_next_step: str | None = None
+    source: str = "unknown"
+```
+
+Rules:
+
+- `message`, `file_hint`, and `suggested_next_step` are short and sanitized;
+- no raw traceback or raw environment/config value;
+- fingerprints are deterministic and exclude volatile IDs/timestamps;
+- file hints should come from trusted mappings/structured exception metadata, not
+  AI guesses presented as facts;
+- persistent status (`open | resolved | ignored`) belongs to the findings service
+  record/read model, not necessarily the immutable observation itself.
+
+### 6.3 `HealthSnapshot`
+
+Suggested minimum fields:
+
+```python
+@dataclass(frozen=True)
+class HealthSnapshot:
+    snapshot_id: str
+    generated_at: datetime
+    purpose: str
+    status: SnapshotStatus
+    summary: str
+    subsystems: tuple[SubsystemHealth, ...]
+    findings: tuple[OperationalHealthFinding, ...]
+    partial: bool = False
+    redaction_scope: AIScope | None = None
+```
+
+Rules:
+
+- stable ordering for deterministic tests and diffs;
+- bounded number of subsystems/findings/facts;
+- `partial=True` if any requested source timed out, failed, or was omitted;
+- do not store raw provider snapshots inside the public object;
+- snapshot IDs should support comparison/persistence without leaking secrets;
+- an AI-facing projection is generated from this object after redaction.
+
+### 6.4 Collection request
+
+Use an explicit request object rather than a loose `scope` string:
+
+```python
+@dataclass(frozen=True)
+class HealthSnapshotRequest:
+    purpose: Literal["summary", "startup", "guild", "subsystem", "ai_context"]
+    ai_scope: AIScope
+    guild_id: int | None = None
+    subsystem: str | None = None
+    include_recent_logs: bool = False
+    include_persistent_findings: bool = True
+```
+
+This makes expensive checks, data boundaries, and redaction intent testable.
+
+## 7. Source adapters and initial health areas
+
+Do not make every subsystem implement a new provider before delivering value.
+Build adapters around existing sources first.
+
+| Health area | Initial source | First-phase output |
+|---|---|---|
+| Runtime/lifecycle | lifecycle diagnostics, runtime lock, uptime/health facts | lifecycle phase, readiness, uptime, pending transition, compact lock state |
+| Diagnostics registry | `registered_names()` + `snapshot_all()` | provider count, provider failures, allowlisted compact facts |
+| Managed tasks | tasks diagnostics + task metrics | active count, known failed outcomes where derivable, compact names at elevated scope |
+| Platform readiness | cached `platform_readiness` provider | startup phase outcomes, catalogue readiness, cached consistency blockers |
+| Platform consistency | existing report/cache | compact blocker summary; fresh async collection only on explicit operator request |
+| Discord/guild | bot/guild cache adapter | guild count, unavailable count, latency; guild-local facts only when authorized |
+| Cogs/extensions | `config.INITIAL_EXTENSIONS` plus a new small recorder/adapter around the load path | loaded count and failed/missing configured extensions; blocking versus optional still needs an explicit contract |
+| Database | bounded ping/schema/migration adapter | reachable/timeout/unknown, migration readiness; no arbitrary table inspection |
+| AI | AI config projection + AI diagnostics/readiness/audit summaries | configured/readiness/provider counters/last bounded failure summary |
+| Logs | ring-buffer grouping adapter | counts and sanitized grouped fingerprints; raw recent messages remain deterministic operator-only fallback initially |
+| Resource/setup | resource health and setup readiness adapters | guild-local blockers summarized separately from process health |
+| External APIs | opt-in subsystem adapters | configured/degraded/unknown and last structured failure; never probe every API on every summary |
+
+## 8. Deterministic severity aggregation
+
+The aggregator must use published rules, not intuition or AI interpretation.
+Recommended initial rules:
+
+1. `critical` if a required runtime invariant is failed: lifecycle failed,
+   database unavailable when required for serving, no gateway readiness after
+   startup, or a required startup phase/cog failure classified as blocking.
+2. `degraded` if at least one non-blocking provider/check fails, a managed task has
+   a recent terminal failure, unavailable guilds are non-zero, AI is unhealthy but
+   AI is optional, or warning/error findings exist without a critical blocker.
+3. `unknown` if no reliable core sources are available or the snapshot is too
+   partial to classify.
+4. `healthy` only if all requested core sources completed and no degraded/critical
+   rule matched.
+
+Open questions that must be encoded explicitly:
+
+- Is database availability always critical, or does it depend on lifecycle/purpose?
+- Which cogs/extensions are required versus optional?
+- Does one unavailable guild degrade global health?
+- How old may a cached consistency/startup/API result be before it becomes unknown?
+- Does an unhealthy optional AI provider degrade whole-bot health? Recommended:
+  report AI as degraded while leaving whole-bot health healthy unless an AI-required
+  capability is being evaluated.
+
+## 9. Redaction and access model
+
+Redaction is a transformation of trusted structured data **before** Discord render
+or model input. It is not a prompt instruction asking the model to hide secrets.
+
+| Scope | Proposed visibility |
+|---|---|
+| Public/user | Basic online/healthy/degraded/offline-style status only; no provider names, IDs, logs, configuration, or findings. |
+| Moderator | Optional guild-local availability/command summary only; no logs, cross-guild data, provider details, or file hints. |
+| Admin | Guild-local setup/resource/command health and bounded findings; no cross-guild data, raw logs, stack traces, env/config values, or sensitive provider internals. |
+| Server owner | Deeper guild-local diagnostics, bounded command/config health, and sanitized fingerprints. |
+| Platform owner/system | Cross-guild/process/provider summaries, sanitized file/function hints, and fingerprints; still no tokens, raw env, raw config, arbitrary DB rows, or raw stack traces in AI context. |
+
+Initial recommendation:
+
+- ship deterministic platform health to current administrator-gated surfaces;
+- ship AI diagnostic tools only for `PLATFORM_OWNER` first;
+- expand to server-owner/admin scopes after redaction tests and live verification;
+- keep stack traces in logs/webhook incident channels, not AI context or normal
+  Discord diagnostic embeds.
+
+Required redaction tests should seed secret-like tokens, Discord IDs, SQL text,
+multiline exceptions, and message content into source payloads and prove that each
+projection removes or replaces them.
+
+## 10. Log grouping and failure fingerprints
+
+The current ring buffer is useful but not a durable observability backbone. Improve
+it incrementally:
+
+### Near-term safe classifier
+
+- classify only bounded recent in-memory records;
+- count levels over a fixed window or available buffer horizon;
+- normalize known structured patterns (provider failure, cog load failure, DB
+  timeout, command failure, AI provider failure, rate limit);
+- strip volatile IDs, timestamps, and quoted user content before fingerprinting;
+- return grouped counts and short sanitized summaries;
+- do not send raw log messages to AI.
+
+### Preferred structured path
+
+Add structured operational observations at the original failure boundaries where
+possible. A structured observation may contain category, exception type, trusted
+subsystem/command/provider identifiers, occurred-at time, and sanitized summary.
+It should feed metrics/current snapshots first. Persistence is a later, explicit
+step.
+
+### Fingerprint shape
+
+```text
+<category>:<subsystem-or-provider>:<operation>:<exception-type>:<normalized-code>
+```
+
+Examples:
+
+```text
+diagnostics.provider_failed:platform_readiness:snapshot:RuntimeError
+cog.load_failed:cogs.btd6_cog:load_extension:ImportError
+database.timeout:btd6_context:get_fact_context:TimeoutError
+ai.provider_failed:openai:request:rate_limit
+```
+
+Never include raw user text, guild/channel/user IDs, tokens, full SQL, or complete
+exception messages in fingerprints.
+
+## 11. Persistent finding lifecycle (later phase)
+
+Persistence should not block the first useful health summary. Once observation and
+fingerprinting contracts are stable, add an additive table owned only by
+`services.health_findings_service`.
+
+Suggested logical fields:
+
+- `id`, `fingerprint`, `status` (`open | resolved | ignored`);
+- severity, category, sanitized message;
+- related subsystem/cog/command/provider;
+- first/last seen timestamps and occurrence count;
+- last process/runtime-session identity and last snapshot ID;
+- bounded `metadata_json` with an explicit schema/version;
+- resolved/ignored timestamps and actor IDs only if manual lifecycle actions are
+  later approved.
+
+Required behavior:
+
+- dedupe recurring open findings by fingerprint;
+- atomically increment count/update last-seen;
+- reopen resolved findings when recurrence policy says so;
+- ignored findings remain hidden by default but keep aggregate counts;
+- TTL-prune detailed history and/or cap per-fingerprint records;
+- keep occurrence aggregates without retaining unbounded raw observations;
+- all writes through the owner service;
+- deterministic commands and AI tools read through bounded service methods.
+
+Recommended retention decision: retain open findings, retain resolved/ignored
+records for a configurable TTL, and preserve only aggregate recurrence counters
+after detail expiry.
+
+## 12. Startup health: extend, do not replace
+
+The repository already posts a deterministic startup-summary webhook before
+`bot.start()` and separately reports cog load failures. A broader startup report
+should unify these facts after the bot reaches a stable readiness point.
+
+### Proposed two-stage startup reporting
+
+1. **Pre-connect boot summary (keep existing):** catalogue-build outcomes and
+   fatal pre-connect failures through the webhook reporter.
+2. **Post-ready startup health snapshot (new):** once on-ready restoration and
+   lifecycle transition settle, collect a bounded `purpose="startup"` snapshot
+   and publish a deterministic report. Optional AI explanation may follow only if
+   AI health and policy permit it.
+
+The post-ready snapshot should cover, where reliable:
+
+- extension load successes/failures;
+- gateway readiness and unavailable guild count;
+- database reachability/migration status;
+- startup outcome phases and cached platform readiness;
+- persistent view/anchor restoration summary;
+- managed task state;
+- slash command sync state only if the repository has a canonical sync recorder;
+- missing required configuration/API keys represented as sanitized subsystem
+  status, not raw environment values;
+- AI health as an optional subsystem;
+- bounded recent startup warnings/errors or structured startup observations.
+
+### Timing decision
+
+Do not use an arbitrary 30–60 second sleep as the primary contract. Prefer a
+specific “startup settled” composition point plus bounded per-source timeouts. A
+short delayed follow-up snapshot may be useful, but it should be explicit and
+managed by `core.runtime.tasks.spawn`.
+
+## 13. Deterministic UX plan
+
+### First useful surface
+
+Add `!platform health` and a Platform panel item that render a compact deterministic
+snapshot:
+
+- overall status and generated time;
+- runtime/lifecycle/gateway/database/platform/AI subsystem statuses;
+- top bounded findings;
+- partial/stale indicators;
+- recommended existing diagnostic commands for drilldown.
+
+### Follow-up surfaces
+
+- `!platform startup`: latest deterministic startup snapshot/report;
+- `!platform ai-health`: canonical AI subsystem projection;
+- `!platform findings [open|resolved|ignored]`: only after persistent findings;
+- `!platform subsystem <name>`: explicit bounded drilldown;
+- Platform panel “Ask AI to explain” button: only after AI tools/context are safe.
+
+The `/platform` slash command currently opens the Platform hub rather than exposing
+one slash subcommand per diagnostic. Keep that pattern unless maintainers choose a
+broader slash-command redesign.
+
+### Embed bounds
+
+Every renderer must account for Discord limits. Summaries should cap subsystem
+rows/findings and offer drilldown rather than truncating arbitrary JSON. Existing
+embed helpers already contain field-length defensive patterns that should be
+reused.
+
+## 14. AI diagnostics plan
+
+### Tool sequence
+
+Start with one coarse, safe tool rather than many overlapping tools:
+
+1. `diagnostics_health_snapshot` (`PLATFORM_OWNER` initially): returns a redacted,
+   bounded summary projection.
+2. `diagnostics_subsystem_health`: explicit allowlisted subsystem drilldown.
+3. `diagnostics_startup_report`: latest deterministic startup projection.
+4. `diagnostics_recent_findings`: only after stable finding persistence.
+5. `diagnostics_recent_grouped_errors`: only after safe grouping/redaction tests.
+
+`diagnostics_ai_health` and `diagnostics_platform_consistency` may be useful, but
+avoid duplicating data already available through the snapshot/subsystem tools
+unless tool selection quality requires them.
+
+### `ai_monitor_service` responsibility
+
+If added, `services.ai_monitor_service` should:
+
+- request an already-redacted AI-context snapshot;
+- submit a stable task identifier such as `platform.explain_status`;
+- require the response to distinguish facts from suggestions;
+- append deterministic “next commands” from allowlisted mappings;
+- fail back to the deterministic embed/report;
+- never collect raw logs/config/database state itself;
+- never execute a recommendation.
+
+### AI response contract
+
+AI explanations should use a simple structure:
+
+1. overall status in plain language;
+2. facts requiring attention, each tied to a snapshot finding/fingerprint;
+3. impact and uncertainty;
+4. suggested existing command or subsystem/file hint to inspect;
+5. explicit statement that no remediation was performed.
+
+The model must not claim a root cause when the snapshot only supports correlation.
+
+## 15. Event strategy
+
+Do not add events in the foundation PR unless a real subscriber or durable
+transition requires one. Candidate later events:
+
+- `platform.health.snapshot_generated` — only if another component must react to
+  generated snapshots; avoid emitting on every interactive refresh if noisy;
+- `platform.health.finding_recorded` — after persistent finding write succeeds;
+- `platform.health.finding_resolved` — after a deterministic lifecycle transition;
+- `platform.startup.health_reported` — after deterministic startup report output;
+- `ai.diagnostics.explained` — audit/metric fact that an explanation completed,
+  with no prompt or sensitive output payload.
+
+Metrics are better for snapshot counts, collection durations, source failures,
+redaction outcomes, and AI explanation failures.
+
+## 16. Phased implementation roadmap
+
+### Phase 0 — Contract/ADR decisions
+
+**Goal:** remove ambiguity before implementation.
+
+Decide and document:
+
+- global operational finding name;
+- snapshot/finding severity vocabularies and deterministic mapping table;
+- required versus optional core health sources;
+- access/redaction matrix and whether AI starts platform-owner-only;
+- startup-settled collection point;
+- whether persistent history is TTL-pruned, capped, or both;
+- whether raw stack traces are ever permitted in Discord (recommend no).
+
+**Exit criteria:** approved contract examples and test matrix; no production code
+required.
+
+### Phase 1 — Typed deterministic read model
+
+**Goal:** deliver useful health without AI or persistence.
+
+Implement:
+
+- frozen typed health contracts;
+- `services.health_snapshot_service` with source adapters, per-source isolation,
+  timeouts for async checks, deterministic severity, stable ordering, bounds, and
+  redaction projections;
+- initial runtime/lifecycle, provider inventory/failure, managed-task,
+  platform-readiness/consistency-cache, gateway/guild, DB, and AI adapters;
+- `!platform health`, shared embed builder, and Platform panel connector;
+- metrics for collection duration/source failures if needed;
+- docs for service ownership/read contracts.
+
+Avoid:
+
+- persistent findings;
+- AI tools/explanation;
+- generalized log parsing;
+- a second provider registry;
+- emitting new events without consumers.
+
+**Exit criteria:** deterministic health works with AI disabled; one source failure
+produces a partial/degraded snapshot without breaking the command; all projections
+are bounded and scope-tested.
+
+### Phase 2 — Startup and structured failure observations
+
+**Goal:** unify existing startup facts and improve current-process diagnosis.
+
+Implement:
+
+- a small extension-load outcome recorder or expansion of the existing startup
+  outcome contract;
+- post-ready startup health snapshot/report while retaining the existing
+  pre-connect webhook summary;
+- deterministic `!platform startup`;
+- structured operational observations at selected high-value failure boundaries;
+- safe grouped-current-error adapter over structured observations and the legacy
+  ring buffer fallback.
+
+**Exit criteria:** startup report works without AI, includes source timestamps and
+partial state, and does not rely on arbitrary raw-log dumps.
+
+### Phase 3 — Read-only AI explanation
+
+**Goal:** allow platform owners to ask safe operational questions.
+
+Implement:
+
+- `diagnostics_health_snapshot` and explicit subsystem/startup tools in
+  `services.ai_tools`;
+- `services.ai_monitor_service` only if it adds reusable orchestration beyond tool
+  calls;
+- Platform panel “Ask AI to explain” flow over the same redacted snapshot;
+- deterministic fallback on AI disabled/error/rate limit;
+- decision-audit/metrics integration without storing sensitive context.
+
+**Exit criteria:** tools are not offered below required scope, model input contains
+only redacted bounded data, and live/manual checks show the model uses tools rather
+than inventing current health.
+
+### Phase 4 — Persistent recurring findings
+
+**Goal:** answer recurrence/change-over-time questions deterministically.
+
+Implement:
+
+- additive migration for operational findings;
+- `services.health_findings_service` as sole writer;
+- fingerprint dedupe, recurrence counts, reopen/resolve/ignore policy, and
+  retention;
+- `!platform findings` and bounded tools/read APIs;
+- events only for durable lifecycle transitions with catalogue/docs/tests.
+
+**Exit criteria:** recurrence is atomic and bounded; old process-local facts are not
+misrepresented as current; direct table writes are prevented by tests/architecture
+rules where practical.
+
+### Phase 5 — Broader subsystem coverage and UX
+
+**Goal:** expand only after the contracts prove stable.
+
+Potential work:
+
+- external API health adapters;
+- command failure aggregation;
+- BTD6/Paragon/scheduler subsystem summaries;
+- health comparison since previous startup;
+- richer Platform panel drilldowns;
+- server-owner/admin AI access after redaction review;
+- optional GitHub issue handoff proposal flow, still with explicit approval and no
+  direct AI remediation.
+
+## 17. Suggested PR slices
+
+Keep PRs reviewable and avoid mixing contracts, storage, UI, and AI in one change.
+
+1. **PR A — Contracts and source map:** typed models, severity/redaction policy,
+   source adapter interfaces, tests, and ownership docs.
+2. **PR B — Snapshot aggregator:** adapters over existing sync/cached sources,
+   async isolation/timeouts, bounded projections, tests.
+3. **PR C — Deterministic Platform health UX:** embed + `!platform health` + panel
+   connector + command/help tests.
+4. **PR D — Startup integration:** extension/startup outcomes and post-ready report.
+5. **PR E — Structured observations/current grouping:** selected high-value failure
+   boundaries and safe grouped errors.
+6. **PR F — AI diagnostics tools/explainer:** platform-owner-only tools, fallback,
+   redaction/tool-scope tests.
+7. **PR G — Persistent findings:** migration, owner service, retention, lifecycle,
+   commands, events/docs/tests.
+
+## 18. Test and verification matrix
+
+### Unit and invariant tests
+
+- diagnostics providers remain read-only;
+- a failed sync provider does not break `snapshot_all()` or the aggregate;
+- every async source has a timeout/failure isolation test;
+- aggregation status and ordering are deterministic;
+- partial/stale state is visible and does not become falsely healthy;
+- severity mappings from startup/resource/consistency/provider failures are pinned;
+- redaction differs by `AIScope` and strips seeded secrets/IDs/content;
+- output bounds cap facts, findings, strings, and subsystem drilldowns;
+- AI diagnostic tools are absent below the required scope;
+- AI tools return JSON-serializable bounded projections only;
+- deterministic health/startup surfaces work when AI is disabled/misconfigured;
+- startup report survives missing/failed sources;
+- fingerprints dedupe normalized repeats and distinguish meaningful differences;
+- persistent finding recurrence/reopen/ignore/retention behavior is deterministic;
+- new EventBus events are catalogued and documented;
+- new table/service ownership is documented and architecture checks updated;
+- Platform panel/command surfaces link to the same embed builders;
+- import-cycle tests cover new service boundaries.
+
+### Live/manual verification required
+
+Source review and unit tests cannot prove:
+
+- the chosen post-ready timing captures real startup failures without racing;
+- live Discord embed limits/layout remain usable;
+- the AI reliably calls diagnostics tools instead of answering from prior context;
+- redaction prevents sensitive leakage in real prompts and provider traces;
+- real logs/structured observations produce useful, stable fingerprints;
+- DB/API health checks have safe latency and do not create incident-time load;
+- the Platform panel remains understandable after new entries;
+- webhook/admin channel routing is correct in production;
+- multi-reconnect behavior does not duplicate startup reports.
+
+## 19. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| A “health god service” learns every subsystem's internals. | Use small adapters over canonical read seams; keep domain logic in domain services. |
+| Heterogeneous provider payloads leak sensitive/unbounded data. | Never expose raw `snapshot_all()` outside trusted aggregation; allowlist facts and redact before render/model input. |
+| Async probes make health commands slow or worsen incidents. | Purpose-based checks, strict per-source/overall timeouts, cached results, and partial snapshots. |
+| AI explanation becomes required for diagnosis. | Deterministic command/embed/report first; AI always optional with explicit fallback. |
+| Log parsing becomes permanent fragile infrastructure. | Use bounded fallback only; add structured observations at high-value failure boundaries. |
+| Severity is arbitrary or unstable. | Publish mapping rules and pin them in deterministic tests. |
+| Persistent findings grow forever. | TTL/caps, aggregate counters, no raw payload retention, explicit owner service. |
+| Existing `ResourceHealthFinding` semantics are broken. | Adapt at boundary; do not rename or silently widen the domain contract. |
+| Startup report duplicates on gateway reconnect. | Tie reporting to a one-shot startup-settled/session guard, not every `on_ready`. |
+| New events create noise and drift. | Emit only durable transitions; catalogue/docs/tests; use metrics for volume. |
+| Platform-owner facts leak to guild admins or model context. | Scope-gated tools plus projection-level redaction; test omission, not only masking. |
+
+## 20. Product decisions still required
+
+1. **Initial access:** platform-owner-only AI diagnostics is recommended. Should
+   deterministic `!platform health` remain administrator-accessible with a
+   guild-local/redacted projection?
+2. **Global health semantics:** should optional AI failure degrade whole-bot health,
+   or only the AI subsystem? Recommended: only AI subsystem unless evaluating an
+   AI-required feature.
+3. **Database criticality:** is DB unavailability globally critical or purpose
+   dependent?
+4. **Required cogs:** `config.INITIAL_EXTENSIONS` is the configured expected list,
+   but which extension failures are blocking versus optional?
+5. **Stack traces:** should Discord ever display them? Recommended: no; retain in
+   existing logs/incident webhook only.
+6. **Finding retention:** recommended TTL plus aggregate recurrence counters. What
+   TTL and per-fingerprint caps are acceptable?
+7. **Startup output destination:** existing webhook, configured admin log channel,
+   Platform panel history, or a combination?
+8. **Freshness:** how stale may cached consistency/API/AI health be before status
+   becomes `unknown`?
+9. **Slash UX:** preserve the current `/platform` hub pattern, or later add typed
+   slash subcommands?
+
+## 21. Immediate next-agent brief
+
+The next implementation agent should begin with **Phase 0 / PR A**, not AI tools
+or persistence.
+
+Required first task:
+
+1. inspect existing repository dataclass/module placement conventions and propose
+   exact module names;
+2. define typed operational snapshot/subsystem/finding contracts without colliding
+   with `ResourceHealthFinding`;
+3. define deterministic status/severity mapping and redaction projections;
+4. define adapter boundaries for `diagnostics_service`, `platform_readiness`,
+   lifecycle/tasks, gateway/guild, DB, and canonical AI read models;
+5. add tests for deterministic aggregation, source isolation, bounds, and scope
+   redaction;
+6. document ownership and async/sync boundaries.
+
+Do **not** in the first implementation PR:
+
+- create `bot_awareness_service`;
+- add AI tools;
+- add the findings table;
+- parse raw files or arbitrary logs;
+- add broad EventBus emissions;
+- add remediation actions;
+- refactor existing domain health contracts unnecessarily.
+
+## 22. Definition of success
+
+The feature is successful when an authorized operator can ask “How healthy is the
+bot?” and receive the same trustworthy, bounded facts through a deterministic
+Platform surface or optional AI explanation; when one provider, database check, or
+AI provider fails, diagnostics remain available; when sensitive data is omitted
+before reaching Discord/model context; and when the recommended next action is
+advisory, traceable to structured facts, and never executed automatically.


### PR DESCRIPTION
### Motivation

- Introduce a provider-neutral orchestration policy for complex BTD6 requests to make tool selection, preflight execution, budgeting, workflows, and evidence contracts deterministic and auditable.  
- Provide a delivery and contract-first plan for AI-assisted operational diagnostics that keeps deterministic services as the source of truth and enforces redaction/scope rules before model input.  
- Capture phased implementation slices, required data contracts, UI/UX constraints, and eval/test matrices to guide subsequent PRs and implementation work.

### Description

- Add `docs/ai-complex-request-tool-orchestration-plan.md` containing a full design for an `AIOrchestrationPolicy`, `AIToolDescriptor` catalogue, toolset presets (e.g. `btd6_grounded_helper`, `btd6_calculator`), provider-neutral `AIRequest` extensions (`AIToolChoice`, `AIToolBudget`), typed BTD6 contracts (`BTD6RequestAnalysis`, `CalculationEvidence`) and an end-to-end `analyze -> plan -> execute -> verify -> synthesize` workflow.  
- Add `docs/bot-awareness-diagnostics-plan.md` defining deterministic health contracts (`HealthSnapshot`, `SubsystemHealth`, `OperationalHealthFinding`), aggregation rules, redaction/access model, phased roadmap (`services.health_snapshot_service`), and safe AI tool usage for explanations.  
- Enumerate selection/failure/reason codes, evidence/answer contracts (`calculation_explained`, `comparison`, etc.), metrics/eval expansion, and suggested small incremental PR slices to keep implementation reviewable.  
- Emphasize non-negotiable architecture rules such as read-only AI tools, strict schema validation, separation of behavior vs orchestration, no raw traces in model input, and platform-owner-first AI diagnostics rollout.

### Testing

- This is a documentation-only change; no production code or unit tests were added or modified as part of this PR.  
- No automated tests were executed for these new docs during the rollout; the change should be safe for the repo and will be validated by the usual CI (linting/markdown checks) when merged.  
- The documents include a comprehensive test and eval matrix that implementers should follow when submitting subsequent PRs that add code (these future PRs must include the unit/integration tests referenced in the plans).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23638cf6f0832289fb957895ad8cd4)