### PR TITLE
docs(health): reconcile bot-awareness docs to shipped reality (post-#537)

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -287,6 +287,13 @@ DiagnosticCog `platform_*` subviews could paginate.
     migration `057` is the next free number.
 - **Live cog audit:** still considered complete as of #535; this session added net-new
   read-only diagnostics, no behavior change to existing cogs.
+- **Post-merge (same session): #537 MERGED.** Synced the branch to merged `main`
+  (`a4273bd`) and re-verified: `check_quality --full` green, and an integration smoke of
+  the aggregator against **real local Postgres** — async lane `database` subsystem pinged
+  `reachable: True`, both lanes ran, admin projection leaked no owner-only fields. Then
+  reconciled the docs to shipped status (`bot-awareness-implementation-plan.md` header +
+  §5 marked PR1–PR3 ✅ #537; orientation doc lists the plan as the health programme's
+  execution authority).
 
 ### 2026-06-06 — Session close: PR B nav fix shipped; bot declared fully tested
 - **Arc** (continues the PR A entry below): refined the stability plan through the

--- a/docs/AGENT_ORIENTATION.md
+++ b/docs/AGENT_ORIENTATION.md
@@ -158,6 +158,12 @@ Updated as work lands. Always check the date / referenced PRs at the
 top before trusting the contents.
 
 - `docs/platform-consistency-ledger.md`
+- `docs/bot-awareness-implementation-plan.md` — the bot-awareness / health-diagnostics
+  programme. **Execution authority** for that work + live delivery status (PR1–PR3
+  shipped in #537; PR4/PR6 queued; PR5 blocked on the `_derive_scope` decision). Read
+  this before touching `services/health_snapshot_service.py`,
+  `services/health_contracts.py`, or the `!platform health` / `!platform startup`
+  surfaces. The Codex map `docs/bot-awareness-diagnostics-plan.md` is context only.
 - `docs/phase-2-completion-readiness.md`
 - `docs/settings-customization-command-map.md`
 - `docs/operator-settings-presets.md`

--- a/docs/bot-awareness-implementation-plan.md
+++ b/docs/bot-awareness-implementation-plan.md
@@ -1,13 +1,19 @@
 # Bot-Awareness / AI-Assisted Diagnostics — Revised Implementation Plan
 
-> **Session type:** dedicated read-only planning/revision session (Opus 4.8). No code changed.
-> **Status:** implementation-ready, pending maintainer approval.
-> **Maintainer constraint folded in:** the maintainer will be asleep during execution,
-> so this plan defines the **maximum slice that is safe to execute UNATTENDED in one
-> structured session** (PR1→PR3, with PR4 as a gated stretch), plus hard stop-conditions.
-> **Inputs reconciled:** Codex map (PR #534), a ChatGPT revision pass, and the newer
-> Codex AI-tool-orchestration plan (PR #536, on `main` but not in this worktree).
-> **Supersedes (execution authority):** `docs/bot-awareness-diagnostics-plan.md`.
+> **Status (2026-06-06): approved → foundation SHIPPED.** PR1–PR3 of this plan are
+> merged to `main` in **#537** (typed health read model + deterministic
+> `!platform health` + panel-only startup health). Verified: `check_architecture
+> --mode strict` 0 errors, `check_quality --full` green, and an integration check of
+> the aggregator against real Postgres (DB ping reachable, redaction clean). The live
+> Discord walk of `!platform health` / `!platform startup` is still pending (the
+> sandbox blocks booting the `*_PRODUCTION`-named test-bot token).
+> **Remaining:** PR4 (structured observations) + PR6 (persistent findings) are queued
+> for an attended session; **PR5 (AI tool) is blocked on decision D1** (`_derive_scope`
+> reachability — see §4).
+> **Inputs reconciled:** Codex map (PR #534), a ChatGPT revision pass, and the Codex
+> AI-tool-orchestration successor plan (PR #536).
+> **Execution authority:** this doc; the Codex map
+> `docs/bot-awareness-diagnostics-plan.md` is the repository map.
 
 ---
 
@@ -234,9 +240,12 @@ Read-only, bounded, JSON-serializable, scope-gated, operates on the **already-re
 
 ## 5. Final PR sequence
 
+> **Delivery status (2026-06-06):** PR1 ✅, PR2 ✅, PR3 ✅ — all shipped in **#537**
+> (commits `1296d25`, `b052a4a`, `aa5b153`). PR4 / PR6 queued; PR5 blocked on D1.
+
 Programme = **6 PRs**. **Unattended overnight slice = PR1 → PR2 → PR3** (+ PR4 gated stretch). Every PR ends with both gates: `python3.10 scripts/check_architecture.py --mode strict` (0 errors) **and** `python3.10 scripts/check_quality.py --full` (CI mirror). **If a gate cannot be made green within a PR's own scope, STOP — commit what is green, leave a note, and do not start the next PR.**
 
-### PR1 — Health contracts + aggregator (Codex A+B merged) — *unattended*
+### PR1 — Health contracts + aggregator (Codex A+B merged) — ✅ SHIPPED (#537)
 
 - **Goal:** frozen typed read-model + two-lane `health_snapshot_service` + deterministic severity + stable ordering + pure `project_for_audience`. No UI/AI/persistence/events.
 - **Files:** NEW `services/health_contracts.py`, `services/health_snapshot_service.py`; read-only **function-local** adapters over the §3.2 sources; `docs/ownership.md` read-contract row.
@@ -244,7 +253,7 @@ Programme = **6 PRs**. **Unattended overnight slice = PR1 → PR2 → PR3** (+ P
 - **Tests:** `test_health_snapshot_service.py` (severity table; one failed sync provider → partial/degraded not exception; per-async-source timeout isolation; stable ordering; bounded facts/findings). `test_health_redaction.py` (**per-adapter planted leaks** → assert omission per audience). **Import-safety test** (mirror `test_consistency_import_cycle.py`: importing the service doesn't eagerly import heavy AI/DB). Read-only AST pin (model on `test_ai_readonly_invariants.py`, **not** the economy INV-F file).
 - **Manual:** none (pure + unit). **Risks:** heterogeneous payloads → allowlist `facts`; LOC creep. **Rollback:** delete two modules + tests. **Stop:** prod LOC > ~700 → split by lane (ship sync lane + redaction first); any arch error; a projection that can't prove omission.
 
-### PR2 — Deterministic `!platform health` UX — *unattended*
+### PR2 — Deterministic `!platform health` UX — ✅ SHIPPED (#537)
 
 - **Goal:** admin-gated, guild-redacted compact health embed, AI-independent.
 - **Files:** `diagnostic_cog.py` (`!platform health`, `@has_permissions(administrator=True)`, **function-local** service import; derive `HealthAudience` from ctx), `_platform_embeds.py` (`build_health_embed`, reuse `clamp_embed`), `platform_panel.py` (Runtime tuple + `_dispatch` case).
@@ -252,7 +261,7 @@ Programme = **6 PRs**. **Unattended overnight slice = PR1 → PR2 → PR3** (+ P
 - **Manual (boot the test bot):** embed within limits after `clamp_embed`; panel readable; degraded snapshot caps rows + drilldown (no JSON truncation); admin view hides cross-guild/provider internals.
 - **Risks:** cog ceiling; accidental module-top heavy import; embed overflow. **Rollback:** revert 3 files. **Stop:** `diagnostic_cog.py` projected > ~760 LOC → **first** extract the `!platform` group into a `cogs/diagnostic/` submodule as a self-contained mechanical commit (test-covered), then add `health`.
 
-### PR3 — Startup integration (panel-only) — *unattended*
+### PR3 — Startup integration (panel-only) — ✅ SHIPPED (#537)
 
 - **Goal:** record extension-load outcomes + reconnect-safe post-ready startup snapshot; `!platform startup`. Pre-connect webhook untouched.
 - **Files:** `startup_outcome.py` (**sibling** `ExtensionLoadSnapshot`/`extension_load_recorder` — **do NOT** add to `KNOWN_PHASES`), `bot1.py` (record per-extension in `_load_cogs()`; collect `purpose="startup"` snapshot at the **end** of `on_ready` after `set_phase(RUNNING)`, guarded by a new module-level one-shot mirroring `_startup_duration_observed`), `diagnostic_cog.py` (`!platform startup`), `_platform_embeds.py` (`build_startup_health_embed`).


### PR DESCRIPTION
Docs-only follow-up to **#537** (bot-awareness foundation PR1–PR3), reconciling the docs to the shipped reality and recording post-merge verification.

## Verification performed (on merged `main`)
- `check_architecture --mode strict` → 0 errors; `check_quality --full` → green; `tests/unit/docs/` → 49 passed.
- **Integration smoke of the aggregator against real local Postgres** (no Discord boot): the async-lane `database` subsystem pinged `reachable: True`, both lanes ran with stable ordering, and the `GUILD_ADMIN` projection leaked no owner-only finding fields. This covers the DB path the (sandbox-blocked) live boot would have checked.

## Doc changes
- `docs/bot-awareness-implementation-plan.md` — status header now **“approved → foundation SHIPPED”** (PR1–PR3 in #537; live Discord walk + PR4/PR6 + the **PR5/D1** `_derive_scope` decision still pending); §5 marks PR1/PR2/PR3 ✅.
- `docs/AGENT_ORIENTATION.md` — lists the implementation plan as the **execution authority + live status** for the health programme (read before touching `health_snapshot_service` / `health_contracts` / `!platform health|startup`).
- `.session-journal.md` — post-merge verification note.

No code changes. Still pending your call: the live Discord walk, and the **PR5 reachability decision (D1)** before any AI diagnostics tool.

https://claude.ai/code/session_01S13UW99woSeHERiD3zY7F5

---
_Generated by [Claude Code](https://claude.ai/code/session_01S13UW99woSeHERiD3zY7F5)_