### PR TITLE
docs: restructure for cross-session consistency (current-state router · journal split · subsystem folios)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,11 +1,13 @@
 <!-- READ_FIRST_START -->
 ## Read first — agent orientation
 
-Before proposing or implementing **any** non-trivial change, open
-**`docs/AGENT_ORIENTATION.md`** and follow the "Reading order by
-task" section that matches what you are doing. It is short, points
-you at the binding contracts, and distinguishes them from the
-historical roadmap docs.
+At the **start** of every session, read in this order: **this file**
+(`.claude/CLAUDE.md`) → **`docs/current-state.md`** (what's true now) →
+**`.session-journal.md`** (process memory) → **`docs/AGENT_ORIENTATION.md`** for the
+task-specific reading route. Before proposing or implementing **any** non-trivial
+change, follow the "Reading order by task" section in `docs/AGENT_ORIENTATION.md` that
+matches what you are doing — it is short, points you at the binding contracts, and
+distinguishes them from the historical roadmap docs.
 
 Three binding docs underlie almost every decision in this codebase:
 
@@ -20,7 +22,7 @@ Two more bind common operations:
 
 When a doc and a source file disagree, the source file wins.
 
-Then read **`docs/current-state.md`** — the living "what is true right now?"
+**`docs/current-state.md`** (step 2 above) is the living "what is true right now?"
 ledger (stability baseline, in-flight work, recently shipped, gates,
 off-limits, where to read next). It is a **dated snapshot**: source code and
 merged PRs win over it, and you must verify in-flight PRs against live GitHub.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -20,12 +20,19 @@ Two more bind common operations:
 
 When a doc and a source file disagree, the source file wins.
 
+Then read **`docs/current-state.md`** — the living "what is true right now?"
+ledger (stability baseline, in-flight work, recently shipped, gates,
+off-limits, where to read next). It is a **dated snapshot**: source code and
+merged PRs win over it, and you must verify in-flight PRs against live GitHub.
+Read it before task-specific docs so you don't act on stale state.
+
 Also read **`.session-journal.md`** (repo root) at the **start** of every
 session — our cross-session working memory: the environment/boot runbook (how to
 boot the test bot, where the env vars live, the local-Postgres setup), maintainer
 preferences, recurring problems + fixes, past mistakes to avoid, and candidate
 rules not yet promoted into this file. Append a dated entry at the **end** of the
-session and commit it. Precedence: source code > this file (CLAUDE.md) > the journal.
+session and commit it. Precedence: source code & merged PRs > this file
+(CLAUDE.md) > `docs/current-state.md` (live status) > the journal.
 <!-- READ_FIRST_END -->
 
 <!-- SESSION_WORKFLOW_START -->

--- a/.session-journal.md
+++ b/.session-journal.md
@@ -1,85 +1,55 @@
 # .session-journal.md — SuperBot working memory
 
-> **What this is:** cross-session memory for how the maintainer + assistant agents
-> work on SuperBot — process, preferences, recurring problems+fixes, agent
-> mistakes+prevention, the environment/boot runbook, and a holding pen for
-> rules/ideas/blockers not yet promoted into `.claude/CLAUDE.md`.
+> **What this is:** cross-session **process memory** for how the maintainer +
+> assistant agents work on SuperBot. Two parts:
+> - **Guidebook (edit in place)** — the environment/boot Runbook, Operating
+>   Preferences, Cross-Agent Workflow Preferences, and hard-won Rules/Conventions.
+>   Read it every session; the moment you find an entry stale, **correct it in
+>   place** with a dated `(corrected YYYY-MM-DD)` marker — don't just append a note.
+> - **Session Log (append-only)** — one dated entry per session of what happened.
 >
-> **What this is NOT:** a feature doc. Bot architecture / feature roadmaps live in
-> `docs/` (and `docs/planning/`). Keep those out of here.
+> **What this is NOT:** a feature doc, and **not** project state. Bot architecture /
+> roadmaps live in `docs/` (and `docs/planning/`); **"what is true right now"**
+> (stability, in-flight work, gates, blockers) lives in **`docs/current-state.md`**.
+> Link to those — don't restate them here (restatement is where drift breeds).
 >
 > **Persistence:** the sandbox container is ephemeral — this file only survives if
 > it's committed. Commit it every session.
 
-## 📌 NEXT SESSION — start here (updated 2026-06-06)
+## 📌 Current focus — start here (edit in place each session)
 
-> *This is the "current focus" pointer the journal was missing. Keep it at the top and
-> EDIT IT IN PLACE each session — do not append a second one.*
+> **Project state lives in `docs/current-state.md`** — read that first for the
+> stability baseline, in-flight work, gates, off-limits, and next candidates. This
+> journal is **process memory**, not project state. Keep this block to a short
+> pointer; do not re-list shipped PRs / blockers here (that restatement is the drift
+> we're killing). The durable lessons + repo facts that used to live here are now
+> folded into **Rules / Conventions** and the **Runbook** below.
 
-**Where we left off:** the **bot-awareness / AI-assisted diagnostics programme is COMPLETE**
-— PR1–PR3 (#537) + PR4–PR6 (#541), docs reconciled (#542), boot-capability doc fixed (#543,
-may still be open as you read this). No code is in-flight; everything shipped green
-(`check_quality --full`, last suite 7565).
-
-**This session's chosen focus → restructure the docs.** The maintainer wants to improve THIS
-journal + the overall documentation structure. Root problem we diagnosed: **freshness /
-contradiction drift**, not point-in-time structure (e.g. the boot capability was stated 3
-contradictory ways across sessions before #543). Starting brief:
-1. **Split edited-in-place truth from append-only history.** Stable head (Runbook · Rules ·
-   Operating Preferences · this Current-Focus block) edited in place; the Session Log becomes
-   append-only — ideally **one file per session** in a `.sessions/` dir, which kills the
-   union-merge hotspot described in the Protocol below (#540 already landed its entry in the
-   wrong place).
-2. **Keep a Current-Focus / Open-Decisions block at the very top** (this one).
-3. **Freshness rule:** a session that learns something contradicting an authoritative entry
-   must EDIT that entry with a dated `(corrected YYYY-MM-DD)` marker — not just append a note.
-4. **Link, don't restate:** Session Log entries should link to the PR + the authoritative doc
-   instead of duplicating per-PR detail (that duplication is where drift breeds).
-5. **Stamp each doc with its taxonomy** (binding / living-inventory / historical-plan);
-   `docs/AGENT_ORIENTATION.md` already defines the taxonomy — put the badge on each header.
-
-**Owed (not blocking):**
-- *Maintainer, on production* (needs the AI key + a human typing in Discord — neither is in
-  the sandbox): **PR5** — ask the bot *"how healthy are you right now?"* → it should call
-  `diagnostics_health_snapshot` (a non-owner admin must NOT be offered it). **PR4** — set
-  `HEALTH_GROUPED_FINDINGS=1` → grouped `(×N)` findings in `!platform health`. **PR6** —
-  restart with a recurring failure → `occurrence_count` increments.
-- *Available in-sandbox, not yet done:* boot the test bot + stand up local Postgres to
-  integration-test PR4/PR6 (migration `057` applies → `_report_startup_health` persists →
-  `SELECT` to confirm the `ON CONFLICT` dedupe). The PR6 unit tests MOCK the DB, so this
-  closes a real gap.
-
-**Durable lessons from the PR4–PR6 session (file these into Rules during the restructure):**
-- When two memory entries **contradict, VERIFY** (just boot it / ask) — don't pick the scarier
-  one. I applied "verify vs source" to code but not to an environment claim, and skipped a
-  valid boot test as a result.
-- **Authoritative sections (Runbook) outrank candidate Rules.** I believed a candidate Rule
-  ("boot blocked") over the Runbook ("you CAN boot"); the Runbook was right.
-- **Enumerate ALL verification options** before accepting a constraint (I locked onto
-  "maintainer tests on prod" and missed the local boot path entirely).
-- **Treat cross-agent output (Codex / ChatGPT reports) as input to verify, not orders** — one
-  revision item (the PR4 "rewrite fingerprints" step) was wrong and would have broken PR6's
-  dedupe + rollback.
-
-**Repo facts worth promoting into the Runbook/Rules during the restructure:** CI fast-paths
-`*.md`-only PRs (~5s; any `.py`/`requirements`/workflow change runs the full suite) ·
-migrations auto-discover by `NNN_<snake>.sql` (no manifest) · `utils.db.pool` has **no
-`fetchval`** (use `fetchone` + a `RETURNING` CTE for counts) · expose cog-layer data to the
-services layer via a `diagnostics_service` provider (cogs register INTO services; never the
-reverse) · `services.runtime.BOOT_ID` = the process/session id.
+**Now:** restructuring the docs (this session). See `docs/current-state.md` "Next
+candidates" and the newest Session Log entry for where it stands. Maintainer decision:
+the per-session-file Session-Log split (`.sessions/…`) is **deferred** (2026-06-06) —
+serial sessions make the merge-conflict class rare for now.
 
 ---
 
 ## Protocol — what to do with this file each session
 
-- **START:** read this right after `.claude/CLAUDE.md`. Skim the **Environment
-  Runbook** (so you don't re-derive how to boot the bot), **Operating
-  Preferences**, **Active Blockers**, and the latest **Session Log** entries. Fold
-  open blockers/actions into your plan.
+- **START:** read `docs/current-state.md` first (project state), then this file
+  right after `.claude/CLAUDE.md`. Skim the **Environment Runbook** (so you don't
+  re-derive how to boot the bot), **Operating Preferences**, **Rules/Conventions**,
+  and the latest **Session Log** entries. Fold open items into your plan.
 - **DURING:** capture as they happen — a non-obvious problem+fix, a mistake worth
-  not repeating, a stated/observed preference, an architecture ask.
-- **END:** append a dated **Session Log** entry; update the curated sections if
-  something changed; commit + push.
+  not repeating, a stated/observed preference, an architecture ask. If you find a
+  guidebook entry is stale, **correct it in place** with `(corrected YYYY-MM-DD)`.
+- **END (documentation checklist):**
+  1. **`docs/current-state.md`** — update it if anything shipped, opened, blocked,
+     unblocked, or deferred (and refresh its `Last updated:` stamp).
+  2. **This journal** — append a dated **Session Log** entry (link to the PR + the
+     authoritative doc; don't restate per-PR detail); update the guidebook sections
+     in place if a preference / rule / runbook fact changed.
+  3. Banner or update any **plan** whose status changed; file any new **idea** under
+     `docs/ideas/` (marked not-approved).
+  4. Commit + push (docs land with the PR).
 - **MERGE CONFLICTS here are expected — resolve by UNION.** The Session Log is a
   structural hotspot: every branch inserts a new entry at the *same* anchor (top of
   "Session Log (newest first)"), so any two concurrently-open PRs collide there
@@ -98,21 +68,12 @@ reverse) · `services.runtime.BOOT_ID` = the process/session id.
 
 ---
 
-## Current verified state — bot is FULLY TESTED & WORKING (2026-06-06, PR #535)
+## Current verified state → moved to `docs/current-state.md`
 
-**Treat the bot as fully tested and working bot-wide as of PR #535, for the next few
-sessions, unless a specific regression is reported.** This session completed the live cog
-walk against the booted test bot (Galaxy Bot#6724) — server-management, economy,
-moderation, games, and hub navigation were exercised live. The one code defect found (no
-"↩ Back to Help" on directly-invoked hubs + the Economy→Work back-chain drop) was fixed
-and live-confirmed in #535. **Don't re-run a full live audit "to be safe"** — spend effort
-on the maintainer's ask or the open UX items below. Env-gated features (AI / scheduler /
-YouTube / Paragon / webhook) remain degraded-here, **not** broken.
-
-Open follow-ups (UX/feature — **not** stability bugs): moderation member entry wants a
-`discord.ui.UserSelect` quicksearch picker (modal→view restructure; `unban` stays
-ID-based); role UX warts (bulk "Clear missing"; selector-ize Edit Role); dense
-DiagnosticCog `platform_*` subviews could paginate.
+> **Project state now lives in `docs/current-state.md`** (stability baseline, gates,
+> known UX follow-ups). The #535 stability baseline and the open UX follow-ups were
+> moved there on 2026-06-06. Don't restate bot status here — one home for project
+> state.
 
 ---
 
@@ -144,8 +105,9 @@ confidence; do not treat booting as gated.
   as root): `initdb` a data dir → `pg_ctl start` on localhost:5432 → create role
   `superbot` + database `superbot` matching `DATABASE_URL`.
 - **Schema bootstraps itself on boot:** `pool.init()` → `ensure_migrations_table` →
-  `create_tables` → `run_migrations`. No manual migration step. (Currently 56
-  migrations / 68 tables.)
+  `create_tables` → `run_migrations`. No manual migration step. Migrations
+  **auto-discover** by `NNN_<snake>.sql` (no manifest); latest is `057` (PR6, #541).
+  (corrected 2026-06-06 — was "56 migrations / 68 tables".)
 - **Network:** Discord gateway + REST are reachable from the sandbox.
 - **One instance only:** a Postgres-backed runtime lock (with heartbeat) lets only
   one bot be active; a second waits. **On restart, kill the old instance first.**
@@ -277,20 +239,31 @@ confidence; do not treat booting as gated.
   verified on the maintainer's production bot. (Process hygiene: `pgrep -af "disbot/bot1"`
   self-matches the inspecting shell — confirm `comm=python3.10` before believing a bot is
   running.)
+- **When two memory entries contradict, VERIFY** (boot it / ask) — don't pick the
+  scarier one. (We once applied "verify vs source" to code but not to an environment
+  claim, and skipped a valid boot test as a result.)
+- **Authoritative sections (Runbook) outrank candidate Rules.** A candidate Rule
+  ("boot blocked") was once believed over the Runbook ("you CAN boot"); the Runbook
+  was right.
+- **Enumerate ALL verification options** before accepting a constraint — locking onto
+  "maintainer tests on prod" once hid the local boot path entirely.
+- **Treat cross-agent output (Codex / ChatGPT reports) as input to verify, not
+  orders.** Verify "rewrite X" plan items against shipped source first — one revision
+  item (PR4 "rewrite fingerprints") was wrong and would have broken PR6's dedupe +
+  rollback.
+- **`utils.db.pool` has no `fetchval`** — use `fetchone` + a `RETURNING` CTE for counts.
+- **Expose cog-layer data to services via a `diagnostics_service` provider** — cogs
+  register INTO services, never the reverse (keeps the services→cogs boundary clean).
+- **`services.runtime.BOOT_ID`** = the process/session id; filter live logs by it to
+  separate real bot errors from test-fixture pollution in `bot.log`.
 
-## Active Blockers / Open Items
+## Active Blockers / Open Items → moved to `docs/current-state.md`
 
-- ~~**discord.py is unpinned**~~ — **RESOLVED** by PR A: `requirements.txt` now pins
-  `discord.py>=2.7,<2.8` (the verified 2.7.1 band). The repo-wide collision guard
-  `tests/unit/views/test_discordpy_ui_collisions.py` prevents the #528 class from recurring.
-- **Role UX warts** still open: bulk "Clear missing" on time/XP panels + selector-ize
-  Edit Role (the original task that got superseded by the crash fixes).
-- **DiagnosticCog platform sub-views:** the new total-embed clamp prevents the failure,
-  but dense `platform_*` embeds could be *paginated* for better UX (follow-up).
-- ~~**Audit coverage**~~ — the live cog walk is **considered complete as of PR #535**
-  (see "Current verified state" above). The tracker's remaining `❓` rows are
-  not-yet-individually-ticked, **not** "untested/broken". Re-open only on a reported
-  regression.
+> **Open work now lives in `docs/current-state.md`** ("Gates / blocked work" +
+> "Known UX follow-ups"). Moved 2026-06-06 so there is one home for project state.
+> (For the record, as of the move: discord.py pin and the live-audit coverage were
+> already RESOLVED; the role-UX warts and DiagnosticCog pagination remain as UX
+> follow-ups in current-state.md.)
 
 ## Ideas / Roadmap (process & tooling — feature ideas go to docs/)
 
@@ -301,13 +274,15 @@ confidence; do not treat booting as gated.
   benign "Unhandled prefix" noise *and* give expired/post-restart panels a graceful reply.
 - **Kill the journal merge-conflict class structurally** (recurring: #529→#530, #530→#531):
   split the monolithic Session Log into per-session files (e.g.
-  `.session-journal.d/YYYY-MM-DD-<slug>.md`) that the START step globs newest-first, so
+  `.sessions/YYYY-MM-DD-<slug>.md`) that the START step globs newest-first, so
   concurrent sessions never touch the same file. Curated sections stay in the root file.
-  Proposed — needs maintainer approval before changing this file's structure/protocol.
+  **DEFERRED (decided 2026-06-06):** serial sessions make the conflict rare for now, and
+  the doc-restructure did the project-state extraction first. Revisit if concurrent PRs
+  start colliding here again.
 
 ---
 
-## Session Log (newest first)
+## Session Log (newest first — append-only)
 
 ### 2026-06-06 — Bot-awareness programme COMPLETE (PR4–PR6 shipped)
 - **Arc:** attended Opus session finishing the bot-awareness / AI-assisted diagnostics

--- a/.session-journal.md
+++ b/.session-journal.md
@@ -284,6 +284,30 @@ confidence; do not treat booting as gated.
 
 ## Session Log (newest first — append-only)
 
+### 2026-06-06 — Documentation restructure (current-state router · journal split · folios)
+- **Arc:** maintainer asked me to **design and own** a doc structure that streamlines
+  cross-session work — kill stale-doc/preference hunting and the freshness/contradiction
+  drift root cause. Two cross-agent reviews were *input* (verified, not followed on faith:
+  their PR-state reports already contradicted each other across one merge — confirmed #539
+  merged + 0 open PRs via live GitHub).
+- **Shipped (6 commits, this branch, docs-only):** `docs/current-state.md` living router
+  (+ structure-pin test); wired into the read path (`CLAUDE.md` precedence +
+  `AGENT_ORIENTATION` "Any task"); journal split into **guidebook head** + **append-only
+  log** with a correct-in-place freshness rule + an end-of-session documentation checklist
+  (lessons/facts relocated to Rules); status-badge legend + demotion of the source-of-truth
+  index & its chain to `historical`; `docs/ideas/` with a promotion pipeline (AI backlog
+  moved in); `docs/subsystems/` folio template + index with the **AI folio piloted**.
+- **Design model:** Layer 1 cross-cutting (CLAUDE.md → current-state.md → journal →
+  AGENT_ORIENTATION) + Layer 2 per-subsystem folios; drift-guard = one-fact-one-home, global
+  current-state.md stays a thin index over folios.
+- **Decisions (maintainer):** all 3 phases this session; per-session-file split DEFERRED.
+  **My calls:** added the subsystem layer (folio template + AI pilot) and a router
+  structure-pin test; left the pinned `ai-config-ownership.md` + the code-referenced mining
+  brainstorm in place (linked, not moved).
+- **Next:** build out the remaining subsystem folios (self-directed per area). AI live-tests
+  on production still owed — see `docs/current-state.md` "Next candidates".
+- **For project state, see `docs/current-state.md`** — not restated here.
+
 ### 2026-06-06 — Bot-awareness programme COMPLETE (PR4–PR6 shipped)
 - **Arc:** attended Opus session finishing the bot-awareness / AI-assisted diagnostics
   programme. Continued from the #537 foundation (PR1–PR3); reconciled a ChatGPT revision

--- a/.session-journal.md
+++ b/.session-journal.md
@@ -557,3 +557,42 @@ confidence; do not treat booting as gated.
   implementation sequence to the shared orchestration foundation plus bounded public-doc
   knowledge search.
 - No runtime code, migration, PR4–PR6 implementation, connector, or action tool changed.
+
+## 2026-06-06 — PR #544 cross-agent review: verified, then fixed 4 contradictions
+
+Context: asked a sibling chat for feedback on the open doc-restructure PR #544. It
+rated it 8.5/10, flagged 4 "contradictions to fix before merge" + 2 refinements.
+**Verified every claim against source before touching anything** (the "verify
+cross-agent output, don't follow on faith" rule) — all 4 held up; applied them on
+`claude/friendly-babbage-0BkSu`. Doc-only; 53 doc tests + `check_quality --check-only`
+green.
+
+- **Read-order (`.claude/CLAUDE.md`):** opening led with "open AGENT_ORIENTATION first",
+  contradicting the designed spine. Now states the order explicitly: this file →
+  `current-state.md` → `.session-journal.md` → AGENT_ORIENTATION (task routing).
+- **Demoted SoT index:** its internal "Read first" / "trust now (✅ current)" sections
+  still read as live instructions under the new "historical" banner. Reframed both as
+  2026-06-05 historical snapshots.
+- **`ai-tool-capability-roadmap.md`:** header gate + §2.5 stop-conditions + Phase-0
+  checklist + deferral table all still said platform-owner/D1 was *unresolved*, while
+  §1/§2.2 said *resolved (#541)*. Made the whole doc consistently "resolved"; marked
+  §2.1's pre-#541 verification snapshot historical.
+- **`AGENT_ORIENTATION` server-mgmt entry:** restated the tracker as "#520–523 / queue
+  PR5+" — stale. De-brittled to point at the tracker's Shipped/Remaining-queue sections;
+  fixed the tracker's own stale header (body is current through PR7 / queue PR8).
+- **Refinements:** added "don't summarize plans'/trackers' PR numbers here" to
+  current-state's one-fact-one-home rule; split the AI folio's "Plans (pending approval)"
+  from "Ideas (not approved)".
+
+**Two lessons (candidate Rules):**
+1. **Verify a status claim against the tracker's BODY, not its header.** The server-mgmt
+   tracker *header* says "verified @ #523", but its **Shipped/Remaining-queue body** is at
+   PR7 / queue PR8. I almost *rejected* the (valid) review claim #4 on the header alone —
+   the body proved the reviewer right. Read Shipped/Queue sections, not the date stamp.
+2. **Same-dated docs can contradict; SOURCE WINS — check it before "fixing" a contradiction.**
+   This very journal's 2026-06-06 roadmap entry says `_derive_scope()` *can't* return
+   `PLATFORM_OWNER`; the roadmap doc says D1 *resolved*. I nearly aligned the doc the wrong
+   way on the journal's say-so. Source settled it: `natural_language_stage.py:913-914`
+   returns `AIScope.PLATFORM_OWNER` for `BOT_OWNER_USER_ID`, and **#541 is merged**
+   (D1 resolved). The journal entry above was written hours before #541 merged and is the
+   stale one. Journal entries are point-in-time; verify D1-class claims against source.

--- a/docs/AGENT_ORIENTATION.md
+++ b/docs/AGENT_ORIENTATION.md
@@ -190,8 +190,9 @@ top before trusting the contents.
 - `docs/settings-customization-command-map.md`
 - `docs/operator-settings-presets.md`
 - `docs/planning/server-management-status-2026-06-05.md` — live status tracker for
-  the server-management initiative (shipped #520–#523; remaining queue PR5+).
-  Authoritative on *what is done*; start here before reading the roadmap/plan.
+  the server-management initiative. Authoritative on *what is done* + the remaining
+  queue; **trust the tracker's "Shipped" / "Remaining queue" sections over any summary
+  here** — don't restate its PR numbers (they drift). Start here before the roadmap/plan.
 - `docs/games-actionability-roadmap.md` (status: complete — historical now)
 - `docs/helper-debt-inventory.md` (snapshot — companion to `helper-policy.md`)
 - `docs/ui-view-adoption-audit.md` (snapshot — companion to `helper-debt-inventory.md`)

--- a/docs/AGENT_ORIENTATION.md
+++ b/docs/AGENT_ORIENTATION.md
@@ -39,6 +39,10 @@ read **`docs/helper-policy.md`** first.
 
 ## Reading order by task
 
+> **Working in one area?** Start at its folio — `docs/subsystems/<area>.md`
+> (consolidates that area's rules · current state · ideas · next candidates). The
+> routes below are the cross-cutting fallback when no folio fits yet.
+
 ### Any task
 
 | Order | Doc | Why |

--- a/docs/AGENT_ORIENTATION.md
+++ b/docs/AGENT_ORIENTATION.md
@@ -44,9 +44,10 @@ read **`docs/helper-policy.md`** first.
 | Order | Doc | Why |
 |---|---|---|
 | 1 | `.claude/CLAUDE.md` | Session workflow, CI parity rules, CodeGraph quick-reference, and architecture invariants. Auto-loaded every session. |
-| 2 | `docs/codegraph-usage.md` | Full trust matrix behind the short CLAUDE.md rules. Skim once, refer back when CodeGraph surprises you. |
-| 3 | `docs/AGENT_ORIENTATION.md` (this file) | What to read next, based on what you are doing. |
-| 4 | `docs/repo-navigation-map.md` | Where things live in the tree. Use as a folder-to-purpose lookup. |
+| 2 | `docs/current-state.md` | **What is true right now**: stability baseline, in-flight work, recently shipped, gates, off-limits. A dated snapshot — source & merged PRs win; verify in-flight PRs against live GitHub. |
+| 3 | `docs/codegraph-usage.md` | Full trust matrix behind the short CLAUDE.md rules. Skim once, refer back when CodeGraph surprises you. |
+| 4 | `docs/AGENT_ORIENTATION.md` (this file) | What to read next, based on what you are doing. |
+| 5 | `docs/repo-navigation-map.md` | Where things live in the tree. Use as a folder-to-purpose lookup. |
 
 ### Adding a new subsystem / cog
 
@@ -157,6 +158,9 @@ something that conflicts with them.
 Updated as work lands. Always check the date / referenced PRs at the
 top before trusting the contents.
 
+- `docs/current-state.md` — the cross-cutting "what is true right now?"
+  router (read 2nd, after CLAUDE.md): stability baseline, in-flight work,
+  gates, off-limits. Source code and merged PRs win over it.
 - `docs/platform-consistency-ledger.md`
 - `docs/bot-awareness-implementation-plan.md` — the bot-awareness / health-diagnostics
   programme. **Execution authority** for that work + live delivery status (**all 6 PRs

--- a/docs/AGENT_ORIENTATION.md
+++ b/docs/AGENT_ORIENTATION.md
@@ -133,6 +133,20 @@ The taxonomy below is the only reliable way to tell "what does the
 project still care about?" from "what was the plan a year ago?". When
 in doubt, treat the source files as authoritative over any doc.
 
+### Status badges (put one in each doc's header)
+
+So a doc's authority is self-declaring (no inferring from filename/date),
+each major doc should carry a one-line badge in its header. Use one of:
+
+- **`binding`** — authoritative contract; changing it is an architecture change.
+- **`living-ledger`** — current status, updated as work lands (carry a date).
+- **`reference`** — a standard / how-to; stable.
+- **`plan`** — a planned end-state; cross-check source before implementing.
+- **`historical`** — superseded; kept for context. Start at `docs/current-state.md`.
+- **`ideas`** — brainstorm; not approved for implementation.
+
+When a doc has no badge, the classification lists below are authoritative.
+
 ### Binding (treat as authoritative)
 
 These define the platform contract. Changing them is an architecture

--- a/docs/AGENT_ORIENTATION.md
+++ b/docs/AGENT_ORIENTATION.md
@@ -234,6 +234,15 @@ cross-check the source and the consistency ledger first.
   which are binding "do-not-propose"). Read before proposing new
   UX/diagnostics/feature ideas so you don't re-litigate settled rejections.
 
+### Ideas / brainstorms (not approved)
+
+Capture, not commitment. Refine into a plan before implementing.
+
+- `docs/ideas/` — pure idea backlogs (e.g. AI extra-tool capabilities). See
+  `docs/ideas/README.md` for the promotion path + criteria.
+- `docs/planning/superbot-ideas-lab-2026-06-05.md` — brainstorm backlog whose §2
+  (operating decisions) + §6 (rejection ledger) are **binding**.
+
 ### Subsystem-specific scaffold notes
 
 - `disbot/core/runtime/ai/README.md`

--- a/docs/ai-tool-capability-roadmap.md
+++ b/docs/ai-tool-capability-roadmap.md
@@ -85,7 +85,7 @@ GitHub API for `menno420/superbot`:
   `main` by `GET /repos/menno420/superbot/branches/main`.
 - GitHub reported one open pull request: **#539**, branch
   `chatgpt/ai-extra-tool-capability-ideas`, one commit ahead of `main`, adding only
-  `docs/ai-extra-tool-capability-ideas.md`.
+  `docs/ai-extra-tool-capability-ideas.md` (now relocated to `docs/ideas/`).
 - GitHub reported no open PR corresponding to bot-awareness PR4, PR5, or PR6. Branch
   names are not proof of active work, so Phase 0 must query open PRs and compare source
   again before implementation.
@@ -143,7 +143,7 @@ GitHub API for `menno420/superbot`:
 | `docs/bot-awareness-implementation-plan.md` | Approved execution authority for bot-awareness/health PR4–PR6. |
 | `docs/bot-awareness-diagnostics-plan.md` | Repository map/context only; explicitly defers execution authority to the implementation plan. |
 | `docs/ai-complex-request-tool-orchestration-plan.md` | Research-backed planning/design direction for reusable orchestration and BTD6 complex requests; source does not label it approved execution authority. |
-| PR #539 `docs/ai-extra-tool-capability-ideas.md` | Ideas backlog only; useful inventory, not approval or execution authority. |
+| PR #539 `docs/ideas/ai-extra-tool-capability-ideas.md` | Ideas backlog only; useful inventory, not approval or execution authority. |
 | This roadmap | Prioritization/integration proposal for net-new capability families; not runtime approval. |
 | `.session-journal.md` | Cross-session state and cautions; source and binding docs outrank it. |
 
@@ -179,7 +179,7 @@ approve PR4–PR6 changes, migrations, connectors, or action tools.
 | Health snapshots, structured observations, AI diagnostics explanation, persistent findings | `docs/bot-awareness-implementation-plan.md` | Waits for and consumes that work; never duplicates it. |
 | Bot-awareness repository/source context | `docs/bot-awareness-diagnostics-plan.md` | Use as a map only; correct against source and the implementation plan. |
 | Canonical tool catalogue, named toolsets, neutral tool choice, requirements, budgets, evidence, traces, BTD6 complex workflows | `docs/ai-complex-request-tool-orchestration-plan.md` — research-backed planning direction pending explicit implementation approval | Reuses its names and recommends approving/executing its foundation before net-new tools. |
-| Candidate capability inventory | PR #539 `docs/ai-extra-tool-capability-ideas.md` | Keep as backlog with a status/cross-link; this roadmap triages and sequences it. |
+| Candidate capability inventory | PR #539 `docs/ideas/ai-extra-tool-capability-ideas.md` | Keep as backlog with a status/cross-link; this roadmap triages and sequences it. |
 | Cross-session operational state | `.session-journal.md` | Record decisions and verified PR status; do not promote journal assumptions over source. |
 | Reading order and document classes | `docs/AGENT_ORIENTATION.md` | Add this roadmap only as a non-binding planning reference after approval. |
 

--- a/docs/ai-tool-capability-roadmap.md
+++ b/docs/ai-tool-capability-roadmap.md
@@ -4,10 +4,12 @@
 > **Purpose:** refine the open AI extra-tool ideas backlog into a source-verified,
 > implementation-ready sequence without replacing the approved bot-awareness plan or the
 > research-backed BTD6 orchestration planning document.
-> **Current gate:** do not begin implementation from this roadmap until bot-awareness
-> PR4–PR6 have been reconciled and the `PLATFORM_OWNER` reachability decision is made.
-> At verification time, GitHub reported only PR #539 open; source still leaves PR5
-> blocked because `_derive_scope()` cannot return `AIScope.PLATFORM_OWNER`.
+> **Current gate (updated 2026-06-06):** bot-awareness PR4–PR6 shipped (#541) and the
+> `PLATFORM_OWNER` reachability decision (D1) is **resolved** — `_derive_scope()` now
+> returns `AIScope.PLATFORM_OWNER` for the bot owner. The remaining gate is **maintainer
+> approval of the orchestration foundation**
+> (`ai-complex-request-tool-orchestration-plan.md`) before any net-new tool. (The
+> pre-#541 verification snapshot in §2.1 is historical.)
 >
 > **Authority:** this document governs prioritization and integration boundaries for
 > net-new AI tool capability families only. It is subordinate to the binding architecture
@@ -76,7 +78,10 @@
 
 ## 2. Current repo state verification
 
-### 2.1 Verification method and snapshot
+### 2.1 Verification method and snapshot (historical — pre-#541)
+
+> **Historical snapshot.** Captured before #541 merged; PR4–PR6 have since shipped and
+> D1 is resolved (see §1). Kept to show the verification *method*, not current state.
 
 Verified on **2026-06-06** against local `main` equivalent commit `60f1cd2` and the
 GitHub API for `menno420/superbot`:
@@ -149,9 +154,9 @@ GitHub API for `menno420/superbot`:
 
 ### 2.5 Source/doc mismatches and stop conditions
 
-1. **Platform-owner reachability remains unresolved.** `AIScope.PLATFORM_OWNER` exists,
-   but `_derive_scope()` never returns it. This blocks owner-only AI tools and must be a
-   product/security decision, not an incidental roadmap implementation.
+1. **Platform-owner reachability — RESOLVED (#541).** `_derive_scope()` now returns
+   `AIScope.PLATFORM_OWNER` for the bot owner, so owner-only AI tools are no longer
+   blocked on D1. (Pre-#541 this was the blocker: `_derive_scope()` never returned it.)
 2. **Planned orchestration names are not shipped abstractions.** Backlog language can
    sound present-tense, but source has only `AIToolSpec`, `ToolRegistry`, and the current
    provider loops. Implementations must first land or reconcile the BTD6 plan's types.
@@ -382,8 +387,9 @@ facts from model memory where grounding is required.
 - Query open/merged PRs and compare `main` source, not branch names alone.
 - Reconcile PR4 structured observations, PR5 diagnostics tool, and PR6 persistent
   findings against the approved health plan.
-- Decide D1: how, if at all, natural-language AI requests can resolve platform-owner
-  scope. Add tests proving no impersonation or accidental widening.
+- D1 **decided & shipped (#541)**: `_derive_scope()` resolves platform-owner scope for
+  the bot owner. Before building owner-only tools, re-confirm the anti-impersonation /
+  no-widening tests still hold.
 - Decide PR6 retention/history, ownership, deletion, and migration boundaries.
 - Re-run targeted searches for all planned orchestration types; remove roadmap work that
   Claude has already shipped.
@@ -718,7 +724,7 @@ closed for sensitive content.
 | Shell/Python/code execution | Reject | No safe bounded ownership/rollback | None | Remote code execution/outage |
 | Direct destructive Discord actions | Reject | High-impact and often irreversible | Not proposed; service-owned manual workflows remain | Bans/deletes/permission damage |
 | Mass DM/mass messaging/uncontrolled mentions | Reject | Abuse/spam risk | Fixed automation templates/targets with mention suppression | Harassment, Discord enforcement |
-| Platform-owner AI tools before D1 | Defer | Currently unreachable; security decision unresolved | Approved owner resolution + anti-impersonation tests | False sense of protection or privilege widening |
+| Platform-owner AI tools | Unblocked (was Defer) | D1 **resolved (#541)**: owner scope reachable; still needs per-tool owner-gating + anti-impersonation tests | Owner resolution shipped | Privilege widening if scope checks regress |
 | Persistent tool traces/raw results | Defer/reject raw | No retention owner; content is sensitive | Bounded summary schema + retention/deletion approval | Privacy breach and storage growth |
 | Generic connector before registry ADR | Defer | Equivalent to arbitrary network access | Provider/operation registry and egress/credential policy | SSRF, token leakage, uncontrolled cost |
 | Private GitHub/CI lookup | Defer | Private code/log/token scope not approved | Binding/revocation/redaction/retention design | Source/secrets leakage |

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -86,6 +86,7 @@ goes stale the moment a branch is pushed.
 | How to boot/operate the sandbox · maintainer preferences · hard-won rules · gotchas | `.session-journal.md` (guidebook head) |
 | What happened in past sessions | `.session-journal.md` (session log) |
 | Which docs to read for a specific task | `docs/AGENT_ORIENTATION.md` |
+| Deep-dive on one part of the bot (AI, BTD6, server-mgmt…) | `docs/subsystems/<area>.md` (start here for an area) |
 | Architecture / ownership / runtime contracts (binding) | `docs/architecture.md` · `docs/ownership.md` · `docs/runtime_contracts.md` |
 | Brainstorms (not approved) | `docs/ideas/` |
 | Plans / target architecture (historical once shipped) | `docs/planning/` |

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -24,8 +24,9 @@ in the sandbox**, not broken. Known UX follow-ups remain (below).
 
 ## In flight (verify against live GitHub)
 
-As of this stamp: **none — 0 open PRs.** Re-check on every session start; this line
-goes stale the moment a branch is pushed.
+As of this stamp: the **docs-restructure** work on branch
+`claude/friendly-babbage-0BkSu` (PR being opened this session). **Verify open PRs
+against live GitHub** — this line goes stale the moment a branch is pushed or merged.
 
 ## Recently shipped (newest first)
 

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -93,4 +93,6 @@ against live GitHub** — this line goes stale the moment a branch is pushed or 
 | Plans / target architecture (historical once shipped) | `docs/planning/` |
 
 **One-fact-one-home rule:** if a fact belongs in one of the homes above, **link** to
-it — do not restate it here. Restatement across files is where drift breeds.
+it — do not restate it here. Restatement across files is where drift breeds. In
+particular, **don't summarize plans'/trackers' PR numbers or status here** — link to the
+folio or tracker, which is authoritative for its own area.

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -1,0 +1,94 @@
+# SuperBot — Current State
+
+> **Doc type:** living status ledger (project state). **Not binding.**
+> **Source code and merged PRs always win over this file.**
+> The In-flight section below is a dated snapshot — **verify open PRs against
+> live GitHub** before trusting it (two same-session reports already
+> contradicted each other across a single merge).
+>
+> **Last updated:** 2026-06-06 · `147f396` (post-#543) · doc-restructure session.
+>
+> **Purpose:** the one file that answers "what is true right now?" so a new
+> session does not reconstruct it from the journal + planning docs. Read it
+> **second**, right after `.claude/CLAUDE.md`.
+
+---
+
+## Stability baseline
+
+Operational stability **accepted after #535** (live cog walk: server-management,
+economy, moderation, games, hub navigation). **Do not run a broad re-audit unless
+a regression is reported** — this is an *accepted baseline*, not a fresh re-test.
+Env-gated features (AI / scheduler / YouTube / Paragon / webhook) run **degraded
+in the sandbox**, not broken. Known UX follow-ups remain (below).
+
+## In flight (verify against live GitHub)
+
+As of this stamp: **none — 0 open PRs.** Re-check on every session start; this line
+goes stale the moment a branch is pushed.
+
+## Recently shipped (newest first)
+
+- **#543** — boot / test-bot capability doc correction.
+- **#542** — docs reconciled to shipped bot-awareness status.
+- **#541** — bot-awareness **PR4–PR6**: grouped recent-error findings (opt-in),
+  owner-gated `diagnostics_health_snapshot` AI tool (D1 resolved), persistent
+  operational-health findings (migration `057`).
+- **#539** — AI extra-tool capability **ideas backlog** (capture only, not approved work).
+- **#537** — bot-awareness **PR1–PR3**: health contracts + aggregator, `!platform
+  health`, startup-health snapshot.
+- **#535** — back-to-Help navigation fix; stability baseline accepted.
+
+> Older than this: see `docs/planning/*` trackers and `docs/decisions/*` ADRs.
+
+## Next candidates
+
+- **Maintainer live-tests owed** (need a prod AI key + a human in Discord): PR5 — ask
+  the bot "how healthy are you?" → it calls `diagnostics_health_snapshot` (a non-owner
+  admin must NOT be offered it); PR4 — `HEALTH_GROUPED_FINDINGS=1` → grouped `(×N)`
+  findings; PR6 — restart with a recurring failure → `occurrence_count` increments.
+- **In-sandbox integration test** of PR4/PR6: boot the test bot + local Postgres →
+  migration `057` applies → findings persist → `SELECT` to confirm `ON CONFLICT`
+  dedupe (the PR6 unit tests mock the DB, so this closes a real gap).
+- **This doc-restructure** (in progress).
+
+## Gates / blocked work
+
+- **AI / BTD6 feature expansion** is gated on *all* of: bot-wide stability **+**
+  provider/provenance checks **+** caching / source-health clarity **+** AI
+  behavior/config correctness — **not** just the RC-11 guard suite passing.
+- **BTD6 data extraction** stays paused pending the **ADR-006** provenance schema.
+- `_derive_scope` → `PLATFORM_OWNER` (decision D1) — **RESOLVED** in #541; owner-only
+  AI tools are now reachable.
+
+## Known UX follow-ups (not stability bugs)
+
+- Moderation member entry wants a `discord.ui.UserSelect` quicksearch picker
+  (modal→view restructure; `unban` stays ID-based).
+- Role UX: bulk "Clear missing" on time/XP panels; selector-ize Edit Role.
+- DiagnosticCog `platform_*` subviews are dense — could paginate.
+
+## Off-limits / do-not-propose
+
+- No Redis / external state store (**ADR-001**).
+- Game state is **not** restart-safe by design (**ADR-002**) — accepted, not a bug.
+- Do not re-litigate the rejection ledger in
+  `docs/planning/superbot-ideas-lab-2026-06-05.md` §6.
+- Do not restate "bot fully tested & working" as *newly* verified without an actual
+  boot + live walk — cite the #535 baseline instead.
+
+## Where to read next (the read path + what lives where)
+
+| Need | Read |
+|---|---|
+| Rules of engagement (CI parity, CodeGraph, arch invariants, workflow) | `.claude/CLAUDE.md` |
+| **What's true right now** | this file |
+| How to boot/operate the sandbox · maintainer preferences · hard-won rules · gotchas | `.session-journal.md` (guidebook head) |
+| What happened in past sessions | `.session-journal.md` (session log) |
+| Which docs to read for a specific task | `docs/AGENT_ORIENTATION.md` |
+| Architecture / ownership / runtime contracts (binding) | `docs/architecture.md` · `docs/ownership.md` · `docs/runtime_contracts.md` |
+| Brainstorms (not approved) | `docs/ideas/` |
+| Plans / target architecture (historical once shipped) | `docs/planning/` |
+
+**One-fact-one-home rule:** if a fact belongs in one of the homes above, **link** to
+it — do not restate it here. Restatement across files is where drift breeds.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -1,0 +1,39 @@
+# docs/ideas — brainstorms (not approved)
+
+> **Status:** `ideas`. **Nothing here is approved for implementation.** These are
+> capture docs so ideas live in the repo instead of in chat. Source code, the
+> binding contracts, and `docs/current-state.md` always win over anything here.
+
+## What lives here
+
+Pure brainstorm backlogs — capture without commitment. Each file should carry an
+`ideas` badge in its header and state what it is *not* (not a plan, not approval).
+
+Related idea-shaped docs that live elsewhere **by design**:
+
+- `docs/planning/superbot-ideas-lab-2026-06-05.md` — brainstorm backlog, **but** its
+  §2 (operating decisions) and §6 (rejection ledger) are **binding** "do-not-propose"
+  — so it stays in `planning/`, not here.
+- `docs/mining_exploration_brainstorm.md` — design-intent for the mining subsystem,
+  referenced by `disbot/cogs/mining/exploration.py` as design intent — stays in `docs/`.
+
+## Promotion path (idea → shipped)
+
+```text
+chat idea
+  → docs/ideas/<topic>.md                       (captured, not approved)
+  → reviewed concept summary
+  → approved implementation plan                (docs/planning/…)
+  → docs/current-state.md "Next candidates"     (active candidate)
+  → PR execution
+  → shipped  (current-state "Recently shipped" + a Session Log entry)
+```
+
+An idea may graduate to an implementation plan only after **all** of:
+
+1. **Ownership** — the owning service / cog / pipeline is identified (`docs/ownership.md`).
+2. **Reuse check** — existing service/helper/abstraction reuse is confirmed; no
+   duplicate systems (`docs/helper-policy.md`).
+3. **Risk review** — privacy, security/permissions, cost, and moderation risk reviewed.
+4. **Mechanics** — migration / cache / test / rollback needs are listed.
+5. **Promotion** — `docs/current-state.md` marks it an active candidate.

--- a/docs/ideas/ai-extra-tool-capability-ideas.md
+++ b/docs/ideas/ai-extra-tool-capability-ideas.md
@@ -1,5 +1,9 @@
 # AI Extra Tool Capability Ideas Backlog
 
+> **`ideas` — not approved for implementation.** Promotion path + criteria:
+> [`docs/ideas/README.md`](./README.md). For what is true now, see
+> `docs/current-state.md`.
+
 **Status:** ideas backlog — not approved for implementation yet.  
 **Created:** 2026-06-06  
 **Purpose:** capture AI tool/capability ideas that are not already covered by the current bot-awareness diagnostics plan or the BTD6 complex tool-orchestration plan.  

--- a/docs/planning/server-management-status-2026-06-05.md
+++ b/docs/planning/server-management-status-2026-06-05.md
@@ -6,7 +6,9 @@
 > done*, **this tracker (cross-checked against source) wins**; the roadmap remains
 > the target architecture and the implementation plan remains the PR-scope detail.
 >
-> **Date:** 2026-06-05 · **Verified against:** `main` @ `f0f0824` (merge of #523).
+> **Date:** 2026-06-05 (originally verified @ `f0f0824` / #523). **Body is current
+> through PR7; remaining queue starts at PR8** — the "Shipped" + "Remaining queue"
+> sections below are authoritative.
 >
 > **Companion docs (read together):**
 > - `docs/planning/server-management-roadmap-2026-06-05.md` — target architecture

--- a/docs/planning/superbot-architecture-priority-map-2026-06-05.md
+++ b/docs/planning/superbot-architecture-priority-map-2026-06-05.md
@@ -1,5 +1,8 @@
 # SuperBot — Architecture Priority Map
 
+> **`historical` — 2026-06-05.** For *what is true now*, start at
+> **`docs/current-state.md`**. Kept for the RC-n priority / dependency rationale.
+
 > **Status:** planning artifact. Companion to
 > `superbot-audit-consolidation-2026-06-05.md` (the verified findings) and
 > `superbot-next-session-roadmap-2026-06-05.md` (the PR sequence). This doc

--- a/docs/planning/superbot-audit-consolidation-2026-06-05.md
+++ b/docs/planning/superbot-audit-consolidation-2026-06-05.md
@@ -1,5 +1,9 @@
 # SuperBot — Audit Consolidation (Codex + Agent A/B/C/D)
 
+> **`historical` — 2026-06-05.** For *what is true now*, start at
+> **`docs/current-state.md`**. Kept for the RC-1…RC-15 audit reconciliation
+> history (the *why* behind decisions), not current state.
+
 > **Status:** planning / verification artifact (not a binding contract, not
 > implementation approval). Read this before acting on any of the five
 > source audit docs — it supersedes their individual confidence claims

--- a/docs/planning/superbot-next-session-roadmap-2026-06-05.md
+++ b/docs/planning/superbot-next-session-roadmap-2026-06-05.md
@@ -1,5 +1,8 @@
 # SuperBot — Next-Session Roadmap
 
+> **`historical` — 2026-06-05; PR sequence superseded.** For *what is true now*
+> and the next candidates, start at **`docs/current-state.md`**.
+
 > **Status:** planning artifact. Companion to
 > `superbot-audit-consolidation-2026-06-05.md` (verified findings, IDs RC-n)
 > and `superbot-architecture-priority-map-2026-06-05.md` (priority + dependency

--- a/docs/planning/superbot-source-of-truth-index-2026-06-05.md
+++ b/docs/planning/superbot-source-of-truth-index-2026-06-05.md
@@ -14,7 +14,10 @@
 
 ---
 
-## Read first (in this order)
+## Original 2026-06-05 read path (historical — superseded)
+
+> Preserved for history; **not** current startup instructions. Start at
+> `docs/current-state.md`, then `docs/AGENT_ORIENTATION.md`.
 
 1. `.claude/CLAUDE.md` — session workflow + CI parity + CodeGraph + arch invariants.
 2. `docs/AGENT_ORIENTATION.md` — binding "reading order by task".
@@ -58,7 +61,11 @@ server-management state and the remaining queue (PR5+).
 
 ---
 
-## Current planning docs (trust now)
+## Planning docs as classified on 2026-06-05 (historical snapshot)
+
+> The "✅ current" / "trust now" marks below were accurate on 2026-06-05; some have
+> since shipped or been superseded. Use the live trackers + `docs/current-state.md`
+> for current status.
 
 | Doc | Trust | Note |
 |---|---|---|

--- a/docs/planning/superbot-source-of-truth-index-2026-06-05.md
+++ b/docs/planning/superbot-source-of-truth-index-2026-06-05.md
@@ -1,10 +1,10 @@
 # SuperBot — Planning Source-of-Truth Index
 
-> **Status:** planning artifact / navigation aid. Tells a future session which
-> docs to trust *now*, which are historical context, and which contradict
-> current source. It does **not** replace `docs/AGENT_ORIENTATION.md` (the
-> binding orientation) — it layers the 2026-06-05 audit-consolidation outcome
-> on top of it.
+> **`historical` — superseded as a daily router by `docs/current-state.md`.**
+> Start at `docs/current-state.md` for *what is true now*. This file is kept for
+> its RC-1…RC-15 audit-reconciliation history (useful for *why* a decision was
+> made, not *what is current*). It layered the 2026-06-05 audit-consolidation
+> outcome on top of `docs/AGENT_ORIENTATION.md` (the binding orientation).
 >
 > **Date:** 2026-06-05
 >

--- a/docs/subsystems/README.md
+++ b/docs/subsystems/README.md
@@ -1,0 +1,42 @@
+# Subsystems — per-area documentation folios
+
+> **Status:** `reference` (the folio convention) + a living index.
+> Source code and `docs/current-state.md` win over anything here.
+
+A **folio** is the single entry point for one part of the bot, so a session working
+on that area reads *one* page instead of hunting across `docs/`. A good folio also
+lets you spot adjacent work and **self-direct the next session** for that area.
+
+## Folio template (the standard shape)
+
+Each `docs/subsystems/<area>.md` should carry:
+
+1. **What & where** — one-line scope + the key source dirs/files.
+2. **Rules & approved structures** — the binding contracts for this area (link;
+   don't restate) + any approved patterns.
+3. **Current state** — what works / what's degraded *for this area* (links to
+   `docs/current-state.md`).
+4. **Ideas (not approved)** — link to `docs/ideas/…`.
+5. **Next candidates** — ranked, with enough context to self-direct the next session.
+
+**Drift-guard:** a folio's "Current state / Next candidates" is the area's *detail*
+home; the global `docs/current-state.md` stays a *thin index* over them. One fact,
+one home — vertically too.
+
+## Subsystem index
+
+Until an area has a folio, jump straight to its key docs.
+
+| Subsystem | Folio | Key docs |
+|---|---|---|
+| AI | ✅ [`ai.md`](./ai.md) | (see folio) |
+| Health / diagnostics | _todo_ | `bot-awareness-implementation-plan.md` + health source |
+| Server management | _todo_ | `planning/server-management-status-2026-06-05.md` (+ roadmap / impl plan) |
+| Settings / bindings / provisioning | _todo_ | `settings-customization-roadmap.md`, `resource-provisioning-overview.md`, `capability-authority.md`, `platform-consistency-ledger.md` |
+| BTD6 data / tools | _todo_ | `btd6-*.md` (15+), `decisions/006` |
+| Games | _todo_ | `games-actionability-roadmap.md`, `decisions/002` |
+| Media / YouTube | _todo_ | `decisions/007`, `server-logging.md` |
+
+> Building out a folio (consolidating an area's docs into the template above, and
+> physically moving the area's `docs/*.md` under here when safe — mind doc-test-pinned
+> files) is itself a good self-directed **next session**: pick the area you're in.

--- a/docs/subsystems/ai.md
+++ b/docs/subsystems/ai.md
@@ -34,14 +34,18 @@ scoped tools (including owner-gated diagnostics). Source:
   provenance + caching/source-health clarity + AI behavior/config correctness — see
   `docs/current-state.md` "Gates / blocked work".
 
+## Plans (pending approval — not raw ideas)
+
+- `docs/ai-complex-request-tool-orchestration-plan.md` (`plan`) — research-backed
+  reusable tool orchestration (toolsets, tool-choice, budgets, evidence). Approve this
+  foundation **before** net-new tools.
+- `docs/ai-tool-capability-roadmap.md` (`plan`, non-authoritative) — triages/sequences
+  the ideas backlog onto that foundation.
+
 ## Ideas (not approved)
 
 - `docs/ideas/ai-extra-tool-capability-ideas.md` — capability backlog (web/vision/
   file/KB/connectors/scheduler/etc.). Promotion path: `docs/ideas/README.md`.
-- `docs/ai-tool-capability-roadmap.md` — non-authoritative triage/sequencing of that
-  backlog onto the existing orchestration foundation.
-- `docs/ai-complex-request-tool-orchestration-plan.md` (`plan`) — reusable tool
-  orchestration (toolsets, tool-choice, budgets, evidence); pending approval.
 
 ## Next candidates (self-direct from here)
 

--- a/docs/subsystems/ai.md
+++ b/docs/subsystems/ai.md
@@ -1,0 +1,60 @@
+# AI subsystem — folio
+
+> **Status:** `living-ledger` (area index). Source + `docs/current-state.md` win.
+> **Last updated:** 2026-06-06.
+
+## What & where
+
+The AI cog + natural-language stage: setup advisor, tool/loop orchestration, and
+scoped tools (including owner-gated diagnostics). Source:
+`disbot/core/runtime/ai/` (`natural_language_stage.py`, the tool registry/loop),
+`disbot/cogs/ai_cog.py`, `disbot/services/ai_policy_mutation.py`,
+`disbot/utils/settings_keys/ai.py`.
+
+## Rules & approved structures (binding — link, don't restate)
+
+- **`docs/ai-config-ownership.md`** (`binding`, doc-test-pinned) — the AI cog's read
+  model, projection rules, mutation seam, and UI-surface pinning. Read before any
+  AI-cog change.
+- **Scope model:** `_derive_scope` → `AIScope`; `config.BOT_OWNER_USER_ID` →
+  `PLATFORM_OWNER` (decision D1, shipped #541) gates owner-only tools such as
+  `diagnostics_health_snapshot`.
+- **Faithfulness / groundedness guards are confirmed-healthy — preserve** (do not
+  refactor the orchestration choke point). See `docs/ai-guard-coverage-map.md` and
+  `docs/btd6-derived-value-groundedness-finding.md`.
+
+## Current state
+
+- AI runs **degraded in the sandbox** (no provider key): deterministic paths are
+  testable here, but the model actually *calling* a tool must be verified on the
+  maintainer's production bot. See `docs/current-state.md` (stability baseline + gates).
+- **Shipped:** owner-gated `diagnostics_health_snapshot` tool (#541). Setup-advisor
+  integration shape: `docs/ai-service-integration-map.md`.
+- **Gate:** AI feature expansion is gated on *all* of bot-wide stability + provider/
+  provenance + caching/source-health clarity + AI behavior/config correctness — see
+  `docs/current-state.md` "Gates / blocked work".
+
+## Ideas (not approved)
+
+- `docs/ideas/ai-extra-tool-capability-ideas.md` — capability backlog (web/vision/
+  file/KB/connectors/scheduler/etc.). Promotion path: `docs/ideas/README.md`.
+- `docs/ai-tool-capability-roadmap.md` — non-authoritative triage/sequencing of that
+  backlog onto the existing orchestration foundation.
+- `docs/ai-complex-request-tool-orchestration-plan.md` (`plan`) — reusable tool
+  orchestration (toolsets, tool-choice, budgets, evidence); pending approval.
+
+## Next candidates (self-direct from here)
+
+1. Maintainer live-tests the owner-gated diagnostics tool on production
+   (`docs/current-state.md` "Next candidates").
+2. If/when AI expansion is unblocked: **approve the orchestration foundation**
+   (`ai-complex-request-tool-orchestration-plan.md`) *before* any net-new tools — the
+   roadmap sequences the backlog onto it, not as isolated cog features.
+3. Promote a single backlog idea through the `docs/ideas/README.md` gates as the first
+   net-new tool (the roadmap's pick is bounded public-doc knowledge search).
+
+## Related docs
+
+`docs/ai-readiness-plan.md` (`plan`), `docs/ai-readiness-pr-notes.md`,
+`docs/ai-provider-and-grounding-fix-plan.md` (`plan`),
+`disbot/core/runtime/ai/README.md` (package intent).

--- a/tests/unit/docs/test_current_state_doc.py
+++ b/tests/unit/docs/test_current_state_doc.py
@@ -1,0 +1,74 @@
+"""Structure guard for docs/current-state.md (doc-restructure session).
+
+``current-state.md`` is the living "what is true right now?" router — read
+second, right after ``.claude/CLAUDE.md``.  This guard pins its *structure*
+(the canonical section headers, the freshness stamp, and the two trust
+rules) without pinning volatile content (PR numbers, dates), so the file
+can be updated every session without breaking CI yet cannot silently rot
+into a non-router.
+
+Resilient case-insensitive substring assertions, mirroring
+``test_phase_2_readiness_doc.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DOC_PATH = _REPO_ROOT / "docs" / "current-state.md"
+
+# Canonical router sections (substring, case-insensitive). Renaming one is a
+# deliberate act that should update this list in the same commit.
+_REQUIRED_SECTIONS = (
+    "stability baseline",
+    "in flight",
+    "recently shipped",
+    "next candidates",
+    "gates",
+    "known ux follow-ups",
+    "off-limits",
+    "where to read next",
+)
+
+
+@pytest.fixture(scope="module")
+def doc_text() -> str:
+    return _DOC_PATH.read_text(encoding="utf-8")
+
+
+def test_doc_file_exists() -> None:
+    assert _DOC_PATH.is_file(), f"Missing doc file: {_DOC_PATH}"
+
+
+def test_has_last_updated_stamp(doc_text: str) -> None:
+    """Freshness depends on a visible date stamp; without it the snapshot
+    can be neither trusted nor distrusted."""
+    assert "last updated:" in doc_text.lower(), (
+        "current-state.md must carry a 'Last updated:' stamp so readers can "
+        "judge freshness."
+    )
+
+
+def test_has_required_sections(doc_text: str) -> None:
+    lowered = doc_text.lower()
+    missing = [s for s in _REQUIRED_SECTIONS if s not in lowered]
+    assert not missing, (
+        "current-state.md is missing canonical router sections:\n  "
+        + "\n  ".join(missing)
+    )
+
+
+def test_states_source_and_pr_precedence(doc_text: str) -> None:
+    """The router must never become a false authority: source + merged PRs
+    win, and in-flight state is verified against live GitHub."""
+    lowered = doc_text.lower()
+    assert "win" in lowered and "source" in lowered and "merged pr" in lowered, (
+        "current-state.md must state that source code and merged PRs win over it."
+    )
+    assert "github" in lowered, (
+        "current-state.md must tell readers to verify in-flight PRs against live "
+        "GitHub (the snapshot goes stale on every push)."
+    )


### PR DESCRIPTION
## Why

The repo had grown from under-documented to well-documented but **over-distributed**: "what is true right now" was smeared across the journal + several dated planning docs, and the same fact drifted between them (two same-session cross-agent reviews even reported *contradictory* PR state across one merge). This restructures the docs around **freshness** and **one-fact-one-home** so a future session reaches "productive, not acting on stale facts" fast — and reduces the need for directional prompts.

## Design model

- **Layer 1 — cross-cutting read path:** `.claude/CLAUDE.md` → `docs/current-state.md` → `.session-journal.md` → `docs/AGENT_ORIENTATION.md`.
- **Layer 2 — per-subsystem folios:** `docs/subsystems/<area>.md`, each with a standard shape (rules · current state · ideas · next candidates) so you can jump straight to your area, spot adjacent work, and self-direct the next session.
- **Drift-guard:** one fact, one home — the global `current-state.md` stays a *thin index* over the folios.

## What changed (docs-only; 7 commits)

1. **`docs/current-state.md`** — new living "what's true now?" router (dated stamp; source/merged-PRs win; verify in-flight vs **live GitHub**) + a resilient structure-pin test (`tests/unit/docs/test_current_state_doc.py`).
2. **Read-path wiring** — `CLAUDE.md` precedence chain + `AGENT_ORIENTATION` "Any task" step 2 + living-ledger listing.
3. **Journal split** — guidebook head (edit-in-place) vs append-only Session Log; project state moved out to `current-state.md`; a correct-in-place freshness rule + an end-of-session **documentation checklist**; durable lessons/facts relocated into Rules.
4. **Lifecycle labels** — a status-badge legend (`binding`/`living-ledger`/`reference`/`plan`/`historical`/`ideas`); demoted the 2026-06-05 source-of-truth index + its read-first chain to `historical` → start at `current-state.md`.
5. **`docs/ideas/`** — a promotion pipeline + 5-gate criteria; moved the AI ideas backlog in (references updated; historical grounding note kept with a relocation marker).
6. **`docs/subsystems/`** — folio template + subsystem index, with the **AI folio piloted** (links existing AI docs in place — no move of the pinned `ai-config-ownership.md`).
7. **Session close** — Session Log entry + in-flight marker in `current-state.md`.

## Verification

- `python3.10 scripts/check_quality.py --full` → **7569 passed, 3 skipped** (black/isort/ruff + mypy + full pytest).
- `python3.10 scripts/check_architecture.py --mode strict` → **0 errors** (87 pre-existing warnings; no `disbot/` code touched).
- No doc-test enumerates `docs/`, so the new file + the move don't break the six pinned doc-tests.

Docs-only — no runtime behavior changed.

https://claude.ai/code/session_01HKKYYzA4Fqm6NxoLqCNA3h

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKKYYzA4Fqm6NxoLqCNA3h)_