### PR TITLE
docs(health): scope migration-057 integration-test gap + record workflow-validation session

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -284,6 +284,34 @@ confidence; do not treat booting as gated.
 
 ## Session Log (newest first — append-only)
 
+### 2026-06-06 — New-workflow validation run + health/diagnostics next-task scoping (read-only planning)
+- **Arc:** first real test of the cross-session read path. Used it exactly as intended —
+  `CLAUDE.md` → `current-state.md` → journal → `AGENT_ORIENTATION` ("Touching health/
+  diagnostics") → `subsystems/README` → `health-diagnostics.md` folio → linked source +
+  `bot-awareness-implementation-plan.md` → **live GitHub**. Path worked end-to-end with no
+  spoon-feeding; the folio listed the exact source files needed.
+- **Live GitHub verified:** **0 open PRs**, **#546 newest merged** (#545 was a closed dup of
+  #546). Confirms #537 (PR1–PR3) + #541 (PR4–PR6) merged and D1 resolved; nothing newer than
+  #546 open or merged. Cleared the "overlapping open PR" stop condition.
+- **Scoped the safest next task** (folio next-candidate): **close the migration-`057`
+  persistence/dedupe integration gap** — test-only, deterministic (no AI key), sandbox-live-
+  verifiable, no runtime/architecture/migration change. See `docs/subsystems/health-diagnostics.md`
+  "Next candidates" #1 (sharpened this session) for the ready-to-implement spec + handoff prompt.
+- **Findings to preserve (3):**
+  1. **False docstring** — `tests/unit/services/test_health_findings_service.py:4-7` claims the
+     `ON CONFLICT` dedupe "is integration-tested against real Postgres", but **no such test
+     exists** (it monkeypatches `svc._db`). Fix it in the PR that makes it true.
+  2. `tests/conftest.py` has **no Postgres fixture**, and **CI (`code-quality.yml`) runs no
+     Postgres service** — a real-DB test must `skip` cleanly in CI; only the sandbox/local can
+     run it. (`test_migrations_runner.py:11-14` already documents the deferred-fixture decision.)
+  3. All existing migration tests are **static SQL-text** assertions (e.g. `test_migration_051`);
+     none execute SQL. The CI-lane companion for `057` should follow that same static pattern.
+- **New lesson → candidate Rule:** a test docstring's "integration-tested" claim is not proof —
+  grep `tests/` for an actual executing test before trusting it (this one was aspirational).
+- **No source/docs/migration/runtime change to features.** Docs-only this session: sharpened the
+  health/diagnostics folio "Next candidates", refreshed `current-state.md` (date + 0-open-PRs +
+  #546), and this entry. **For project state, see `docs/current-state.md`.**
+
 ### 2026-06-06 — Documentation restructure (current-state router · journal split · folios)
 - **Arc:** maintainer asked me to **design and own** a doc structure that streamlines
   cross-session work — kill stale-doc/preference hunting and the freshness/contradiction

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -6,7 +6,8 @@
 > live GitHub** before trusting it (two same-session reports already
 > contradicted each other across a single merge).
 >
-> **Last updated:** 2026-06-06 · post-#544 · subsystem-folio mapping session.
+> **Last updated:** 2026-06-06 · post-#546 · workflow-validation / next-task scoping session
+> (verified live: **0 open PRs**, #546 newest merged).
 >
 > **Purpose:** the one file that answers "what is true right now?" so a new
 > session does not reconstruct it from the journal + planning docs. Read it
@@ -24,12 +25,13 @@ in the sandbox**, not broken. Known UX follow-ups remain (below).
 
 ## In flight (verify against live GitHub)
 
-The docs-restructure work recorded here previously is no longer in flight: **PR #544
-is merged**. **Verify open PRs against live GitHub** before starting work; this dated
-snapshot does not claim that no other PR is open.
+**0 open PRs** as of this snapshot (verified live against GitHub, post-#546).
+**Always re-verify open PRs against live GitHub** before starting work — this is a dated
+snapshot, and a later PR may have opened since.
 
 ## Recently shipped (newest first)
 
+- **#546** — canonical subsystem folios (health/diagnostics, server-mgmt, settings, BTD6, games, media).
 - **#544** — freshness-oriented docs route, lifecycle labels, ideas area, and subsystem-folio model.
 - **#543** — boot / test-bot capability doc correction.
 - **#542** — docs reconciled to shipped bot-awareness status.

--- a/docs/subsystems/health-diagnostics.md
+++ b/docs/subsystems/health-diagnostics.md
@@ -54,12 +54,25 @@ path rather than adding ad-hoc diagnostics tools.
 
 ## Next candidates
 
-1. Maintainer live-test the production AI path: owner receives
-   `diagnostics_health_snapshot`; a non-owner admin does not.
-2. Maintainer live-test grouped findings and recurring-failure count behavior.
-3. Boot the sandbox with local Postgres and integration-test migration `057`,
-   persistence, and `ON CONFLICT` dedupe/counting; existing PR4/PR6 unit coverage
-   mocks the DB and leaves this integration gap.
+1. **Close the migration-`057` persistence/dedupe integration gap (ready — test-only,
+   sandbox-verifiable, no runtime/architecture change).** Existing coverage mocks the
+   DB: `tests/unit/services/test_health_findings_service.py` monkeypatches `svc._db`,
+   and its docstring **wrongly** claims the `ON CONFLICT` path "is integration-tested
+   against real Postgres" — no such test exists. Two blockers the implementer must know:
+   `tests/conftest.py` has **no** Postgres fixture, and CI (`code-quality.yml`) runs
+   **no** Postgres service, so a real-DB test must **skip cleanly** in CI. Deliver, in
+   one PR: a CI-safe static SQL-shape test for migration `057` (mirror
+   `tests/unit/db/test_migration_051_main_server_backfill.py`) + a real-Postgres
+   integration test (module-local `postgres_pool` fixture, `pytest.skip` when
+   `DATABASE_URL` is unreachable) exercising upsert → occurrence delta-add → reopen-on-
+   recurrence → keep-ignored → `list`/`count` → roll-up-then-prune, and correct the
+   false docstring. Boot local Postgres per the journal runbook to run it live.
+2. Maintainer live-test the production AI path: owner receives
+   `diagnostics_health_snapshot`; a non-owner admin does not. **Sandbox cannot do
+   this** (no AI-provider key) — it is owed to the maintainer on production.
+3. Maintainer live-test grouped findings and recurring-failure count behavior
+   (`HEALTH_GROUPED_FINDINGS=1` + induced repeated errors; recurrence count across a
+   restart overlaps candidate #1's persistence path).
 
 ## Related docs
 


### PR DESCRIPTION
## Motivation

First real run of the new cross-session read path. The goal was to **validate the workflow** (does the docs routing let an agent self-direct?) and **scope the next bounded task** — not to re-audit the repo.

The read path worked end-to-end with no spoon-feeding:
`.claude/CLAUDE.md` → `docs/current-state.md` → `.session-journal.md` → `docs/AGENT_ORIENTATION.md` ("Touching health/diagnostics") → `docs/subsystems/README.md` → `docs/subsystems/health-diagnostics.md` → linked source + `docs/bot-awareness-implementation-plan.md` → **live GitHub**.

**Live GitHub verified:** 0 open PRs, #546 newest merged (#545 was a closed dup). #537 (PR1–PR3) + #541 (PR4–PR6) merged; D1 resolved. Nothing newer than #546 open or merged.

## What this PR does (docs-only)

- **`docs/subsystems/health-diagnostics.md`** — sharpen "Next candidates" into a ready-to-implement spec for **closing the migration-`057` persistence/dedupe integration gap**, and record the implementer blockers discovered in source.
- **`docs/current-state.md`** — refresh stamp to post-#546; note 0 open PRs (verified live).
- **`.session-journal.md`** — append a dated Session Log entry + findings + a new candidate lesson.

## Findings preserved for the next session

1. **False docstring** — `tests/unit/services/test_health_findings_service.py:4-7` claims the `ON CONFLICT` dedupe "is integration-tested against real Postgres", but **no such test exists** (it monkeypatches `svc._db`). This *is* the folio's flagged gap.
2. `tests/conftest.py` has **no Postgres fixture**, and **CI (`code-quality.yml`) runs no Postgres service** — a real-DB test must `skip` cleanly in CI; only the sandbox/local can run it.
3. All existing migration tests are **static SQL-text** assertions (e.g. `test_migration_051`); the CI-lane companion for `057` should follow that pattern.

The recommended next task (one test-only PR) is fully scoped in the folio, with a copy-paste handoff prompt available from the planning session. It is deterministic (no AI key), sandbox-live-verifiable, and changes no runtime/migration/architecture.

## Testing

- `python3.10 -m pytest tests/unit/docs/ -q` → **54 passed** (incl. `test_current_state_doc.py`, `test_subsystem_folios_doc.py`).
- Docs-only change → CI's heavy suite is skipped by design (`code-quality.yml` docs detector); a fast green is expected.

No runtime code, migration, BTD6/AI expansion, or live-runtime claim in this PR.

https://claude.ai/code/session_017CstxqzffV7SCHN3jUFuCj

---
_Generated by [Claude Code](https://claude.ai/code/session_017CstxqzffV7SCHN3jUFuCj)_