### PR TITLE
test(health-findings): cover migration 057 persistence/dedupe/retention

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -256,6 +256,17 @@ confidence; do not treat booting as gated.
   register INTO services, never the reverse (keeps the services→cogs boundary clean).
 - **`services.runtime.BOOT_ID`** = the process/session id; filter live logs by it to
   separate real bot errors from test-fixture pollution in `bot.log`.
+- **Real-Postgres test = module-local skip-if-unreachable fixture, never a shared conftest
+  one.** CI (`code-quality.yml`) runs **no** Postgres service and `tests/conftest.py` has
+  **no** DB fixture (by design — every other suite mocks the pool). To exercise real SQL,
+  put a `@pytest_asyncio.fixture` *in the test module* that `pytest.skip()`s when
+  `DATABASE_URL` is unset (CI) or `pool.init()` raises `OSError`/`asyncpg.PostgresError`
+  (DB down), applies schema via `utils.db.pool.init()`, and sweeps a unique fingerprint/key
+  prefix on entry+exit. Canonical example: `tests/unit/db/test_health_findings_integration.py`.
+  Use before/after **count deltas** (not absolute counts) for whole-table aggregates so a
+  booted bot's own rows don't perturb assertions. Pytest runs **serial** here (CI +
+  `check_quality`), so a shared module prefix is safe. A test's setup-only raw `UPDATE`/
+  `DELETE` is fine — the sole-writer AST guards only scan `disbot/`.
 
 ## Active Blockers / Open Items → moved to `docs/current-state.md`
 
@@ -283,6 +294,42 @@ confidence; do not treat booting as gated.
 ---
 
 ## Session Log (newest first — append-only)
+
+### 2026-06-06 — Closed the migration-057 persistence/dedupe/retention integration-test gap (test-only)
+- **Arc:** executed the safest health/diagnostics next-candidate scoped last session
+  (folio "Next candidates" #1). Test-only — no runtime, migration, or architecture change.
+  Branched from current `main` (`8a07617`, post-#547); verified **0 open PRs** live before
+  starting (overlapping-PR stop condition cleared).
+- **Shipped (branch `claude/practical-franklin-mV6Jy`):**
+  - NEW `tests/unit/db/test_migration_057_operational_health_findings.py` — CI-safe static
+    SQL-shape pin (13 tests, mirrors `test_migration_051`): both tables, fingerprint PK on
+    each, status/severity CHECK sets, the `(status, last_seen_at)` index, `CREATE … IF NOT
+    EXISTS` idempotency; and from `utils/db/health_findings.py` the ON CONFLICT occurrence
+    delta-add, the reopen-but-keep-ignored `CASE`, the roll-up `GREATEST`/`LEAST` + summed
+    `total_occurrences`, and the prune `WHERE status IN ('resolved','ignored')`.
+  - NEW `tests/unit/db/test_health_findings_integration.py` — real-Postgres (9 tests) with a
+    **module-local** `postgres_pool` fixture that `pytest.skip()`s when `DATABASE_URL` is
+    unset (CI) or unreachable (sandbox pre-boot). Calls `utils.db.pool.init()` to apply
+    schema+migrations; unique `test:integration:*` fingerprint prefix swept before/after.
+    Covers upsert→open(count=N), re-upsert delta-add + `last_seen` advance + single row,
+    resolved→reopen, ignored→stays-ignored, `list`/`count` by status (before/after deltas
+    so the booted bot's own rows don't perturb it), roll-up→prune (fold w/ summed totals +
+    LEAST/GREATEST window, open rows survive), and `record_findings`/`run_retention` e2e.
+  - EDIT `tests/unit/services/test_health_findings_service.py` docstring — corrected the
+    **false** "integration-tested against real Postgres" claim to point at the two new files.
+- **Invariants held:** `test_inv_health_findings_service.py` green (its raw-SQL/sole-writer
+  AST scan only covers `disbot/`, so the tests' setup-only `UPDATE`/`DELETE` are fine); no
+  services→views; no new events/migrations (chain stays 001→057 contiguous).
+- **Gates + live (all green):** `check_architecture --mode strict` = 0 errors; `check_quality
+  --full` = **7592 passed, 3 skipped**. Brought up local Postgres (runbook recipe) → integration
+  suite 9 passed; with `DATABASE_URL` unset → 9 skipped cleanly (CI parity). Booted the bot
+  (boot_id `258f6e74…`): migration `057` present in `schema_migrations`, `\d` on both tables
+  matches, **0 ERROR/CRITICAL**, and the `Startup health findings: recorded=0 pruned=0` line
+  fired (N=0 expected on a clean boot). **Still owed to maintainer:** the live Discord *render*
+  of `!platform findings`/`health`/`startup` (can't drive the Discord client from the shell).
+- **New lesson → candidate Rule below:** the module-local skip-if-unreachable `postgres_pool`
+  fixture is the repo's pattern for a real-DB test without a shared conftest fixture (CI runs no
+  Postgres). **For project state, see `docs/current-state.md` + the health/diagnostics folio.**
 
 ### 2026-06-06 — New-workflow validation run + health/diagnostics next-task scoping (read-only planning)
 - **Arc:** first real test of the cross-session read path. Used it exactly as intended —

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -26,8 +26,8 @@ in the sandbox**, not broken. Known UX follow-ups remain (below).
 
 ## In flight (verify against live GitHub)
 
-**1 open PR** as of this snapshot: this session's end-of-session PR closing the
-migration-`057` integration-test gap (test-only — see the health/diagnostics folio).
+**1 open PR** as of this snapshot: **#548** — closes the migration-`057`
+integration-test gap (test-only — see the health/diagnostics folio).
 **Always re-verify open PRs against live GitHub** before starting work — this is a dated
 snapshot, and a later PR may have opened since.
 

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -6,8 +6,9 @@
 > live GitHub** before trusting it (two same-session reports already
 > contradicted each other across a single merge).
 >
-> **Last updated:** 2026-06-06 · post-#546 · workflow-validation / next-task scoping session
-> (verified live: **0 open PRs**, #546 newest merged).
+> **Last updated:** 2026-06-06 · post-#547 · closed the health/diagnostics
+> migration-`057` persistence/dedupe/retention integration-test gap (test-only;
+> verified live: 1 open PR — this session's end-of-session PR).
 >
 > **Purpose:** the one file that answers "what is true right now?" so a new
 > session does not reconstruct it from the journal + planning docs. Read it
@@ -25,7 +26,8 @@ in the sandbox**, not broken. Known UX follow-ups remain (below).
 
 ## In flight (verify against live GitHub)
 
-**0 open PRs** as of this snapshot (verified live against GitHub, post-#546).
+**1 open PR** as of this snapshot: this session's end-of-session PR closing the
+migration-`057` integration-test gap (test-only — see the health/diagnostics folio).
 **Always re-verify open PRs against live GitHub** before starting work — this is a dated
 snapshot, and a later PR may have opened since.
 
@@ -47,8 +49,10 @@ snapshot, and a later PR may have opened since.
 
 ## Next candidates
 
-- Health/diagnostics maintainer live-tests and the migration `057` persistence/dedupe
-  integration gap: see `docs/subsystems/health-diagnostics.md`.
+- Health/diagnostics maintainer live-tests (production AI tool + grouped findings):
+  see `docs/subsystems/health-diagnostics.md`. The migration `057`
+  persistence/dedupe/retention integration gap is **closed** (this session — real-PG
+  integration suite + static SQL-shape pin; CI-safe skip).
 - Use the canonical subsystem folios for area-specific implementation/planning; keep
   this global router thin.
 

--- a/docs/subsystems/health-diagnostics.md
+++ b/docs/subsystems/health-diagnostics.md
@@ -35,8 +35,12 @@ signals into bounded operator-facing snapshots. Start in
   the owner-gated AI tool, and persistent operational-health findings.
 - Grouping is controlled by `HEALTH_GROUPED_FINDINGS`; persistent dedupe/counting is
   backed by migration `057` and `health_findings_service`.
-- Deterministic and DB paths are bootable/testable in the sandbox, but the sandbox has
-  no AI provider key and the persistence/dedupe integration walk is still owed. Do **not** claim that the model's live tool selection is verified.
+- Deterministic and DB paths are bootable/testable in the sandbox. The migration-`057`
+  persistence/dedupe/retention SQL is now covered by a real-Postgres integration suite
+  (`tests/unit/db/test_health_findings_integration.py`) plus a CI-safe static SQL-shape
+  pin (`tests/unit/db/test_migration_057_operational_health_findings.py`). The sandbox
+  still has no AI provider key — do **not** claim that the model's live tool selection
+  is verified.
 - The accepted operational baseline is #535; it is not a new live retest. Dense
   DiagnosticCog platform subviews remain a known UX follow-up.
 
@@ -54,25 +58,29 @@ path rather than adding ad-hoc diagnostics tools.
 
 ## Next candidates
 
-1. **Close the migration-`057` persistence/dedupe integration gap (ready — test-only,
-   sandbox-verifiable, no runtime/architecture change).** Existing coverage mocks the
-   DB: `tests/unit/services/test_health_findings_service.py` monkeypatches `svc._db`,
-   and its docstring **wrongly** claims the `ON CONFLICT` path "is integration-tested
-   against real Postgres" — no such test exists. Two blockers the implementer must know:
-   `tests/conftest.py` has **no** Postgres fixture, and CI (`code-quality.yml`) runs
-   **no** Postgres service, so a real-DB test must **skip cleanly** in CI. Deliver, in
-   one PR: a CI-safe static SQL-shape test for migration `057` (mirror
-   `tests/unit/db/test_migration_051_main_server_backfill.py`) + a real-Postgres
-   integration test (module-local `postgres_pool` fixture, `pytest.skip` when
-   `DATABASE_URL` is unreachable) exercising upsert → occurrence delta-add → reopen-on-
-   recurrence → keep-ignored → `list`/`count` → roll-up-then-prune, and correct the
-   false docstring. Boot local Postgres per the journal runbook to run it live.
-2. Maintainer live-test the production AI path: owner receives
+> **DONE (this session):** the migration-`057` persistence/dedupe/retention integration
+> gap is closed — test-only, no runtime/architecture change. New
+> `tests/unit/db/test_health_findings_integration.py` (real-Postgres; module-local
+> `postgres_pool` fixture that `pytest.skip`s when `DATABASE_URL` is unset/unreachable,
+> so CI stays green) exercises upsert → occurrence delta-add + `last_seen` advance →
+> reopen-on-recurrence → keep-ignored → `list`/`count` by status → roll-up-then-prune
+> (summed `total_occurrences`, open rows survive) → `record_findings` /
+> `run_retention` end-to-end. New `tests/unit/db/test_migration_057_operational_health_findings.py`
+> is the CI-safe static SQL-shape pin (tables, fingerprint PKs, status/severity CHECK
+> sets, the `(status, last_seen_at)` index, and the writer's ON CONFLICT delta-add /
+> reopen `CASE` / roll-up `GREATEST`/`LEAST` / prune `WHERE status IN`). The false
+> "integration-tested against real Postgres" docstring in
+> `test_health_findings_service.py` is corrected to point at these files. Verified live:
+> local Postgres boot → migration `057` applies clean → `\d` on both tables → clean bot
+> boot with `Startup health findings: recorded=0 pruned=0`.
+
+1. Maintainer live-test the production AI path: owner receives
    `diagnostics_health_snapshot`; a non-owner admin does not. **Sandbox cannot do
    this** (no AI-provider key) — it is owed to the maintainer on production.
-3. Maintainer live-test grouped findings and recurring-failure count behavior
-   (`HEALTH_GROUPED_FINDINGS=1` + induced repeated errors; recurrence count across a
-   restart overlaps candidate #1's persistence path).
+2. Maintainer live-test grouped findings and recurring-failure count behavior
+   (`HEALTH_GROUPED_FINDINGS=1` + induced repeated errors). The cross-restart recurrence
+   *persistence* path is now integration-tested (see DONE above); the live Discord render
+   of `!platform findings`/`health`/`startup` remains owed to a maintainer walk.
 
 ## Related docs
 

--- a/tests/unit/db/test_health_findings_integration.py
+++ b/tests/unit/db/test_health_findings_integration.py
@@ -1,0 +1,448 @@
+"""Real-Postgres integration for the persistent operational-health findings
+store (bot-awareness PR6) — the SQL no other test executes.
+
+Why this file exists
+--------------------
+``test_health_findings_service.py`` mocks ``svc._db``, so it pins the *service*
+contract but never runs the actual ``ON CONFLICT`` dedupe / reopen / roll-up /
+prune SQL. This suite drives that SQL against a live database via
+``utils.db.pool.init()`` (which applies the full schema + every migration,
+including 057), then asserts the observable behaviour.
+
+CI safety
+---------
+There is **no** shared Postgres fixture (``tests/conftest.py`` deliberately has
+none) and CI (``code-quality.yml``) runs **no** Postgres service. The module-local
+``postgres_pool`` fixture below therefore ``pytest.skip()``s cleanly when
+``DATABASE_URL`` is unset (CI) or the database is unreachable (sandbox before
+local Postgres is up), so this file is a no-op there and only runs where a real
+database is available. It is intentionally NOT promoted to ``conftest.py`` — no
+other suite needs a live DB, and they all mock the pool.
+
+Isolation
+---------
+Every fingerprint this suite writes starts with :data:`_PREFIX`
+(``test:integration:``); the fixture sweeps exactly those rows from both tables
+before and after each test, so it never disturbs (or asserts against) findings
+the booted bot may have recorded. Count assertions use before/after deltas for
+the same reason. Tests run serially (CI and ``check_quality`` both invoke pytest
+without xdist), so the shared prefix is safe.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+from datetime import timedelta
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from services import health_findings_service as svc
+from services.health_contracts import (
+    FindingSeverity,
+    HealthAudience,
+    HealthSnapshot,
+    OperationalHealthFinding,
+    SnapshotStatus,
+)
+from utils.db import health_findings as hf
+from utils.db import pool
+
+_PREFIX = "test:integration:"
+
+
+def _fp(suffix: str) -> str:
+    """A namespaced fingerprint guaranteed to be swept on teardown."""
+    return _PREFIX + suffix
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.now(tz=datetime.timezone.utc)
+
+
+async def _sweep() -> None:
+    """Delete only this suite's rows from both findings tables."""
+    like = _PREFIX + "%"
+    await pool.execute(
+        "DELETE FROM operational_health_finding_aggregates WHERE fingerprint LIKE $1",
+        (like,),
+    )
+    await pool.execute(
+        "DELETE FROM operational_health_findings WHERE fingerprint LIKE $1",
+        (like,),
+    )
+
+
+@pytest_asyncio.fixture
+async def postgres_pool():
+    """Module-local live-Postgres pool; skips cleanly when none is available.
+
+    Applies the schema + migrations via ``pool.init()`` (forward-only and
+    idempotent, so re-running per test is cheap once the DB is provisioned),
+    then yields the pool. Sweeps the ``test:integration:*`` rows on entry and
+    exit and closes the pool afterwards.
+    """
+    if not os.environ.get("DATABASE_URL"):
+        pytest.skip("DATABASE_URL unset — real-Postgres integration test skipped (CI)")
+    try:
+        await pool.init()
+    except (OSError, asyncpg.PostgresError) as exc:
+        pytest.skip(
+            f"Postgres unreachable ({type(exc).__name__}) — integration test skipped",
+        )
+    await _sweep()
+    try:
+        yield pool
+    finally:
+        await _sweep()
+        await pool.close()
+
+
+# ---------------------------------------------------------------------------
+# Low-level helpers (drive the writer SQL under test directly)
+# ---------------------------------------------------------------------------
+
+
+async def _upsert(
+    fp: str,
+    *,
+    count: int = 1,
+    seen_at: datetime.datetime | None = None,
+    severity: str = "error",
+    session_id: str | None = None,
+    snapshot_id: str | None = None,
+) -> None:
+    await hf.upsert_finding(
+        fingerprint=fp,
+        severity=severity,
+        category="runtime.log_error",
+        message="boom",
+        related_subsystem="errors",
+        related_command=None,
+        related_provider=None,
+        file_hint=None,
+        suggested_next_step=None,
+        occurrence_count=count,
+        source="log_buffer",
+        session_id=session_id,
+        snapshot_id=snapshot_id,
+        seen_at=seen_at or _now(),
+    )
+
+
+async def _row(fp: str) -> dict | None:
+    return await pool.fetchone(
+        "SELECT * FROM operational_health_findings WHERE fingerprint = $1",
+        (fp,),
+    )
+
+
+async def _aggregate(fp: str) -> dict | None:
+    return await pool.fetchone(
+        "SELECT * FROM operational_health_finding_aggregates WHERE fingerprint = $1",
+        (fp,),
+    )
+
+
+async def _set_status(
+    fp: str,
+    status: str,
+    *,
+    first_seen: datetime.datetime | None = None,
+    last_seen: datetime.datetime | None = None,
+) -> None:
+    """Move a finding to resolved/ignored (there is no shipped operator write
+    path for this yet, so the test drives it with raw SQL — permitted here
+    because the sole-writer invariant only scans ``disbot/``)."""
+    await pool.execute(
+        """
+        UPDATE operational_health_findings
+        SET status = $2,
+            first_seen_at = COALESCE($3, first_seen_at),
+            last_seen_at = COALESCE($4, last_seen_at)
+        WHERE fingerprint = $1
+        """,
+        (fp, status, first_seen, last_seen),
+    )
+
+
+def _finding(fp: str, *, count: int = 1) -> OperationalHealthFinding:
+    return OperationalHealthFinding(
+        fingerprint=fp,
+        severity=FindingSeverity.ERROR,
+        category="runtime.log_error",
+        message="boom",
+        occurrence_count=count,
+        related_subsystem="errors",
+        source="log_buffer",
+    )
+
+
+def _snapshot(
+    *findings: OperationalHealthFinding,
+    snapshot_id: str = "snap",
+    generated_at: datetime.datetime | None = None,
+) -> HealthSnapshot:
+    return HealthSnapshot(
+        snapshot_id=snapshot_id,
+        generated_at=generated_at or _now(),
+        purpose="startup",
+        status=SnapshotStatus.DEGRADED,
+        summary="x",
+        subsystems=(),
+        findings=tuple(findings),
+        redaction_audience=HealthAudience.PLATFORM_OWNER,
+    )
+
+
+# ---------------------------------------------------------------------------
+# upsert / dedupe / lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_upsert_inserts_open_with_count(postgres_pool):
+    """First sighting inserts a single OPEN row with the given count and equal
+    first/last seen timestamps."""
+    fp = _fp("upsert-open")
+    await _upsert(fp, count=3)
+
+    row = await _row(fp)
+    assert row is not None
+    assert row["status"] == "open"
+    assert row["occurrence_count"] == 3
+    assert row["severity"] == "error"
+    assert row["category"] == "runtime.log_error"
+    assert row["first_seen_at"] == row["last_seen_at"]  # fresh insert
+
+
+async def test_reupsert_delta_adds_count_and_advances_last_seen(postgres_pool):
+    """A recurrence adds to the count, advances last_seen, preserves first_seen,
+    and never creates a second row (dedupe by fingerprint)."""
+    fp = _fp("reupsert")
+    t0 = _now() - timedelta(minutes=5)
+    t1 = _now()
+    await _upsert(fp, count=2, seen_at=t0)
+    await _upsert(fp, count=3, seen_at=t1)
+
+    row = await _row(fp)
+    assert row["occurrence_count"] == 5  # 2 + 3 (delta-add, not overwrite)
+    assert row["status"] == "open"
+    assert row["first_seen_at"] == t0  # preserved
+    assert row["last_seen_at"] == t1  # advanced
+    assert row["last_seen_at"] > row["first_seen_at"]
+
+    rows = await pool.fetchall(
+        "SELECT fingerprint FROM operational_health_findings WHERE fingerprint = $1",
+        (fp,),
+    )
+    assert len(rows) == 1  # exactly one row
+
+
+async def test_resolved_finding_reopens_on_recurrence(postgres_pool):
+    """A recurrence of a RESOLVED finding reopens it (news again) while the
+    occurrence count keeps accumulating across the reopen."""
+    fp = _fp("reopen")
+    await _upsert(fp, count=1)
+    await _set_status(fp, "resolved")
+    assert (await _row(fp))["status"] == "resolved"
+
+    await _upsert(fp, count=2)
+    row = await _row(fp)
+    assert row["status"] == "open"  # reopened
+    assert row["occurrence_count"] == 3  # 1 + 2
+
+
+async def test_ignored_finding_stays_ignored_on_recurrence(postgres_pool):
+    """A recurrence of an IGNORED finding stays ignored (muted noise must not
+    resurface) but still accumulates its occurrence count."""
+    fp = _fp("ignored")
+    await _upsert(fp, count=1)
+    await _set_status(fp, "ignored")
+
+    await _upsert(fp, count=4)
+    row = await _row(fp)
+    assert row["status"] == "ignored"  # stays ignored
+    assert row["occurrence_count"] == 5  # 1 + 4
+
+
+async def test_list_and_count_by_status(postgres_pool):
+    """list_by_status filters correctly and count_by_status reflects each
+    status. Counts use before/after deltas so pre-existing rows (e.g. the
+    booted bot's own findings) do not affect the assertions."""
+    before = await svc.count_by_status()
+
+    await _upsert(_fp("lc-open-1"))
+    await _upsert(_fp("lc-open-2"))
+    await _upsert(_fp("lc-res"))
+    await _set_status(_fp("lc-res"), "resolved")
+    await _upsert(_fp("lc-ign"))
+    await _set_status(_fp("lc-ign"), "ignored")
+
+    after = await svc.count_by_status()
+    assert after.get("open", 0) - before.get("open", 0) == 2
+    assert after.get("resolved", 0) - before.get("resolved", 0) == 1
+    assert after.get("ignored", 0) - before.get("ignored", 0) == 1
+
+    open_fps = {
+        r["fingerprint"]
+        for r in await svc.list_by_status("open", limit=1000)
+        if r["fingerprint"].startswith(_PREFIX)
+    }
+    assert open_fps == {_fp("lc-open-1"), _fp("lc-open-2")}  # resolved/ignored excluded
+
+    resolved_fps = {
+        r["fingerprint"]
+        for r in await svc.list_by_status("resolved", limit=1000)
+        if r["fingerprint"].startswith(_PREFIX)
+    }
+    assert resolved_fps == {_fp("lc-res")}
+
+    # status=None lists across every status.
+    all_fps = {
+        r["fingerprint"]
+        for r in await svc.list_by_status(None, limit=1000)
+        if r["fingerprint"].startswith(_PREFIX)
+    }
+    assert all_fps == {_fp("lc-open-1"), _fp("lc-open-2"), _fp("lc-res"), _fp("lc-ign")}
+
+
+# ---------------------------------------------------------------------------
+# retention: roll-up then prune
+# ---------------------------------------------------------------------------
+
+
+async def test_roll_up_then_prune_folds_resolved_ignored_and_keeps_open(
+    postgres_pool,
+):
+    """Roll-up folds resolved/ignored detail past the cutoff into aggregates;
+    prune then deletes exactly those rows and returns the count. Open rows —
+    even old ones — survive both steps."""
+    old = _now() - timedelta(days=40)
+    cutoff = _now() - timedelta(days=30)
+
+    open_fp = _fp("rp-open")
+    res_fp = _fp("rp-res")
+    ign_fp = _fp("rp-ign")
+
+    await _upsert(open_fp, count=1, seen_at=old)  # OLD but open -> must survive
+    await _upsert(res_fp, count=2, seen_at=old)
+    await _set_status(res_fp, "resolved", last_seen=old)
+    await _upsert(ign_fp, count=3, seen_at=old)
+    await _set_status(ign_fp, "ignored", last_seen=old)
+
+    # prune_expired returns the count of rows matching its own predicate.
+    prunable = await pool.fetchone(
+        "SELECT COUNT(*) AS n FROM operational_health_findings "
+        "WHERE status IN ('resolved', 'ignored') AND last_seen_at < $1",
+        (cutoff,),
+    )
+    expected = int(prunable["n"])
+    assert expected >= 2  # at least our resolved + ignored rows
+
+    await hf.roll_up_to_aggregates(cutoff)
+    pruned = await hf.prune_expired(cutoff)
+
+    assert pruned == expected
+    assert await _row(res_fp) is None  # pruned
+    assert await _row(ign_fp) is None  # pruned
+    assert await _row(open_fp) is not None  # open survives
+
+    res_agg = await _aggregate(res_fp)
+    ign_agg = await _aggregate(ign_fp)
+    assert res_agg is not None and res_agg["total_occurrences"] == 2
+    assert ign_agg is not None and ign_agg["total_occurrences"] == 3
+    assert res_agg["category"] == "runtime.log_error"
+    assert res_agg["severity"] == "error"
+
+
+async def test_roll_up_accumulates_totals_and_widens_window(postgres_pool):
+    """A second fold of the same fingerprint sums total_occurrences and widens
+    the aggregate window via LEAST(first_seen)/GREATEST(last_seen)."""
+    fp = _fp("agg-sum")
+    cutoff = _now() - timedelta(days=30)
+    a, b = _now() - timedelta(days=50), _now() - timedelta(days=49)
+    c, d = _now() - timedelta(days=60), _now() - timedelta(days=31)
+
+    # Fold 1: total=2, window [a, b].
+    await _upsert(fp, count=2, seen_at=a)
+    await _set_status(fp, "resolved", first_seen=a, last_seen=b)
+    await hf.roll_up_to_aggregates(cutoff)
+    await hf.prune_expired(cutoff)
+    agg = await _aggregate(fp)
+    assert agg["total_occurrences"] == 2
+    assert agg["first_seen_at"] == a
+    assert agg["last_seen_at"] == b
+
+    # Fold 2 (recurrence after prune): a fresh row, folded again.
+    await _upsert(fp, count=5, seen_at=c)
+    await _set_status(fp, "ignored", first_seen=c, last_seen=d)
+    await hf.roll_up_to_aggregates(cutoff)
+    await hf.prune_expired(cutoff)
+    agg = await _aggregate(fp)
+    assert agg["total_occurrences"] == 7  # 2 + 5 summed
+    assert agg["first_seen_at"] == c  # LEAST(a, c) = c
+    assert agg["last_seen_at"] == d  # GREATEST(b, d) = d
+
+
+# ---------------------------------------------------------------------------
+# service end-to-end
+# ---------------------------------------------------------------------------
+
+
+async def test_record_findings_end_to_end(postgres_pool):
+    """The sole writer records a snapshot's findings through to Postgres,
+    carrying session/snapshot ids, and dedupes a re-record (count delta-add +
+    refreshed session/snapshot)."""
+    fp = _fp("record-e2e")
+    g1 = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+    g2 = datetime.datetime(2026, 2, 1, tzinfo=datetime.timezone.utc)
+
+    n = await svc.record_findings(
+        _snapshot(_finding(fp, count=2), snapshot_id="snap-xyz", generated_at=g1),
+        session_id="boot-123",
+    )
+    assert n == 1
+
+    row = await _row(fp)
+    assert row["status"] == "open"
+    assert row["occurrence_count"] == 2
+    assert row["source"] == "log_buffer"
+    assert row["related_subsystem"] == "errors"
+    assert row["last_session_id"] == "boot-123"
+    assert row["last_snapshot_id"] == "snap-xyz"
+    assert row["first_seen_at"] == g1
+    assert row["last_seen_at"] == g1
+
+    # Re-record the same fingerprint from a later snapshot -> dedupe + advance.
+    await svc.record_findings(
+        _snapshot(_finding(fp, count=3), snapshot_id="snap-2", generated_at=g2),
+        session_id="boot-456",
+    )
+    row = await _row(fp)
+    assert row["occurrence_count"] == 5  # 2 + 3
+    assert row["last_session_id"] == "boot-456"
+    assert row["last_snapshot_id"] == "snap-2"
+    assert row["first_seen_at"] == g1  # preserved
+    assert row["last_seen_at"] == g2  # advanced
+
+
+async def test_run_retention_end_to_end_via_service(postgres_pool):
+    """The service's run_retention rolls up then prunes resolved/ignored detail
+    older than the TTL, leaving open findings in place."""
+    open_fp = _fp("ret-open")
+    old_fp = _fp("ret-old")
+    old = _now() - timedelta(days=40)
+
+    await _upsert(open_fp, count=1)  # recent + open -> survives
+    await _upsert(old_fp, count=4, seen_at=old)
+    await _set_status(old_fp, "resolved", last_seen=old)
+
+    pruned = await svc.run_retention(ttl_days=30)
+    assert pruned >= 1  # at least our old resolved row
+    assert await _row(old_fp) is None  # pruned
+    assert await _row(open_fp) is not None  # open survives
+
+    agg = await _aggregate(old_fp)
+    assert agg is not None and agg["total_occurrences"] == 4  # rolled up first

--- a/tests/unit/db/test_migration_057_operational_health_findings.py
+++ b/tests/unit/db/test_migration_057_operational_health_findings.py
@@ -1,0 +1,192 @@
+"""Static SQL-shape pins for migration 057 + its writer (bot-awareness PR6).
+
+Mirrors ``test_migration_051_main_server_backfill.py``: we cannot run Postgres
+in unit CI (``tests/conftest.py`` has no DB fixture, ``code-quality.yml`` runs no
+Postgres service), but we CAN pin the *shape* of the schema and the dedupe SQL so
+a drive-by edit that — say — drops the ``ON CONFLICT`` delta-add, loosens a CHECK
+constraint set, removes the reopen ``CASE``, or changes the prune predicate fails
+here instead of silently in production.
+
+The live behaviour these shapes encode is exercised against a real database in
+``test_health_findings_integration.py`` (skipped when no Postgres is reachable).
+
+Two sources are pinned:
+
+* ``disbot/migrations/057_operational_health_findings.sql`` — the two tables,
+  their fingerprint primary keys, the status/severity CHECK sets, the
+  status+last_seen index, and ``CREATE … IF NOT EXISTS`` idempotency.
+* ``disbot/utils/db/health_findings.py`` — the writer's ON CONFLICT occurrence
+  delta-add, the reopen-but-keep-ignored ``CASE``, the roll-up ``GREATEST`` /
+  ``LEAST`` / summed ``total_occurrences``, and the prune ``WHERE status IN``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MIGRATION = (
+    _REPO_ROOT / "disbot" / "migrations" / "057_operational_health_findings.sql"
+)
+_WRITER = _REPO_ROOT / "disbot" / "utils" / "db" / "health_findings.py"
+
+
+def _collapse(text: str) -> str:
+    """Collapse all runs of whitespace to a single space.
+
+    Lets the assertions match the SQL regardless of how it is wrapped across
+    lines, so a purely cosmetic reflow does not produce a false failure.
+    """
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _migration_sql() -> str:
+    """Migration text with ``-- …`` line comments stripped, then collapsed.
+
+    Stripping comments keeps the occurrence counts (e.g. the two
+    ``fingerprint TEXT PRIMARY KEY`` declarations) honest — the file's header
+    prose mentions the tables and columns but must not be mistaken for the
+    executable DDL.
+    """
+    no_comments = "\n".join(
+        line.split("--", 1)[0] for line in _MIGRATION.read_text().splitlines()
+    )
+    return _collapse(no_comments)
+
+
+def _writer_src() -> str:
+    return _collapse(_WRITER.read_text())
+
+
+# ---------------------------------------------------------------------------
+# Migration 057 — schema shape
+# ---------------------------------------------------------------------------
+
+
+def test_migration_file_exists():
+    assert _MIGRATION.is_file(), f"{_MIGRATION} missing"
+
+
+def test_creates_both_findings_tables():
+    """The detail table and its retention-survivor aggregates table must both
+    be created — losing either breaks recording or long-run history."""
+    sql = _migration_sql()
+    assert "CREATE TABLE IF NOT EXISTS operational_health_findings" in sql
+    assert "CREATE TABLE IF NOT EXISTS operational_health_finding_aggregates" in sql
+
+
+def test_tables_are_idempotent_create_if_not_exists():
+    """Both tables and the index use ``IF NOT EXISTS`` so the forward-only,
+    re-runnable migration never aborts on an already-provisioned database.
+
+    A bare ``CREATE TABLE``/``CREATE INDEX`` (no guard) would raise on the
+    second apply and take boot down — pin against that regression.
+    """
+    sql = _migration_sql()
+    assert re.search(r"CREATE TABLE(?! IF NOT EXISTS)", sql) is None, (
+        "every CREATE TABLE in migration 057 must use IF NOT EXISTS"
+    )
+    assert re.search(r"CREATE INDEX(?! IF NOT EXISTS)", sql) is None, (
+        "the findings index must use CREATE INDEX IF NOT EXISTS"
+    )
+
+
+def test_fingerprint_is_primary_key_on_both_tables():
+    """Fingerprint is the natural dedupe key on the detail table and the
+    roll-up key on the aggregates table — both make it the PRIMARY KEY, which
+    is what the writer's ``ON CONFLICT (fingerprint)`` upserts depend on."""
+    sql = _migration_sql()
+    assert sql.count("fingerprint TEXT PRIMARY KEY") == 2, (
+        "both findings tables must key on `fingerprint TEXT PRIMARY KEY`"
+    )
+
+
+def test_status_check_constraint_set():
+    """The lifecycle states are exactly open/resolved/ignored — the writer's
+    reopen CASE and the retention predicate both assume this closed set."""
+    assert (
+        "CHECK (status IN ('open', 'resolved', 'ignored'))" in _migration_sql()
+    )
+
+
+def test_severity_check_constraint_set():
+    """Severity mirrors ``FindingSeverity`` (info/warning/error/critical);
+    a drift here would let an out-of-vocabulary severity reach the store."""
+    assert (
+        "CHECK (severity IN ('info', 'warning', 'error', 'critical'))"
+        in _migration_sql()
+    )
+
+
+def test_status_last_seen_index_present():
+    """The ``(status, last_seen_at)`` index backs both the status-filtered
+    listing (``WHERE status = $1 ORDER BY last_seen_at DESC``) and the
+    retention sweep (``WHERE status IN (…) AND last_seen_at < $1``)."""
+    assert (
+        "CREATE INDEX IF NOT EXISTS ix_health_findings_status_last_seen "
+        "ON operational_health_findings (status, last_seen_at)"
+        in _migration_sql()
+    )
+
+
+# ---------------------------------------------------------------------------
+# utils/db/health_findings.py — dedupe / reopen / roll-up / prune SQL
+# ---------------------------------------------------------------------------
+
+
+def test_writer_file_exists():
+    assert _WRITER.is_file(), f"{_WRITER} missing"
+
+
+def test_upsert_delta_adds_occurrence_count():
+    """A recurrence must ADD to the existing count, not overwrite it — losing
+    the ``+ EXCLUDED.occurrence_count`` would silently reset cross-boot totals."""
+    assert (
+        "occurrence_count = operational_health_findings.occurrence_count "
+        "+ EXCLUDED.occurrence_count" in _writer_src()
+    )
+
+
+def test_upsert_advances_last_seen():
+    """Each recurrence advances ``last_seen_at`` to the new sighting."""
+    assert "last_seen_at = EXCLUDED.last_seen_at" in _writer_src()
+
+
+def test_upsert_reopens_resolved_but_keeps_ignored():
+    """A recurrence reopens a previously-resolved finding (it is news again)
+    while leaving an operator-``ignored`` finding ignored. Dropping the CASE
+    would either resurface muted noise or bury real recurrences."""
+    assert (
+        "status = CASE "
+        "WHEN operational_health_findings.status = 'ignored' THEN 'ignored' "
+        "ELSE 'open' END" in _writer_src()
+    )
+
+
+def test_rollup_sums_and_uses_least_greatest():
+    """Roll-up accumulates ``total_occurrences`` and widens the seen-window
+    with LEAST(first_seen)/GREATEST(last_seen) so pruned detail folds into the
+    aggregates without losing the running totals or the historical span."""
+    src = _writer_src()
+    assert (
+        "total_occurrences = operational_health_finding_aggregates.total_occurrences "
+        "+ EXCLUDED.total_occurrences" in src
+    )
+    assert "first_seen_at = LEAST(" in src
+    assert "last_seen_at = GREATEST(" in src
+
+
+def test_rollup_and_prune_target_resolved_and_ignored_only():
+    """Both the roll-up SELECT and the prune DELETE are scoped to
+    resolved/ignored rows past the cutoff — open findings are never folded or
+    pruned. A predicate change that swept open rows would erase live state."""
+    src = _writer_src()
+    assert (
+        "FROM operational_health_findings "
+        "WHERE status IN ('resolved', 'ignored') AND last_seen_at < $1" in src
+    ), "roll-up must SELECT only resolved/ignored rows past the cutoff"
+    assert (
+        "DELETE FROM operational_health_findings "
+        "WHERE status IN ('resolved', 'ignored') AND last_seen_at < $1" in src
+    ), "prune must DELETE only resolved/ignored rows past the cutoff"

--- a/tests/unit/services/test_health_findings_service.py
+++ b/tests/unit/services/test_health_findings_service.py
@@ -1,10 +1,16 @@
 """Tests for services.health_findings_service — PR6 (bot awareness).
 
-The sole writer of the persistent findings store. The SQL-level dedupe / reopen
-(ON CONFLICT) is integration-tested against real Postgres; here we pin the
-service contract: it records each finding through utils.db.health_findings with
-the right arguments, is best-effort (swallows DB errors), and runs retention as
-roll-up-then-prune.
+The sole writer of the persistent findings store. These tests mock ``svc._db``
+to pin the *service* contract: it records each finding through
+utils.db.health_findings with the right arguments, is best-effort (swallows DB
+errors), and runs retention as roll-up-then-prune.
+
+The SQL itself — the ON CONFLICT dedupe / occurrence delta-add / reopen-on-
+recurrence / keep-ignored / roll-up-then-prune — is exercised against a real
+Postgres in ``tests/unit/db/test_health_findings_integration.py`` (which skips
+cleanly when no database is reachable, e.g. in CI), and the migration's static
+SQL shape is pinned by
+``tests/unit/db/test_migration_057_operational_health_findings.py``.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Why

Closes the migration-`057` persistence/dedupe/retention integration-test gap for the persistent operational-health findings store (bot-awareness PR6, shipped in #541). The dedupe / reopen / roll-up / prune SQL in `utils/db/health_findings.py` + migration `057` had **no executing test** — `tests/unit/services/test_health_findings_service.py` monkeypatches `svc._db`, and its docstring **falsely** claimed the `ON CONFLICT` path "is integration-tested against real Postgres". This makes that claim true.

**Test-only.** No runtime, migration, or architecture change. The migration chain stays `001 → 057` contiguous; the sole-writer invariant (`test_inv_health_findings_service.py`) stays green.

## What

- **NEW `tests/unit/db/test_migration_057_operational_health_findings.py`** — CI-safe **static SQL-shape pin** (mirrors `test_migration_051_main_server_backfill.py`): both tables, fingerprint PK on each, the status/severity CHECK sets, the `(status, last_seen_at)` index, and `CREATE … IF NOT EXISTS` idempotency; plus, from the writer, the ON CONFLICT occurrence delta-add, the reopen-but-keep-ignored `CASE`, the roll-up `GREATEST`/`LEAST` + summed `total_occurrences`, and the prune `WHERE status IN ('resolved','ignored')`.
- **NEW `tests/unit/db/test_health_findings_integration.py`** — **real-Postgres** suite with a **module-local** `postgres_pool` fixture that `pytest.skip()`s cleanly when `DATABASE_URL` is unset (CI) or the DB is unreachable (sandbox before local Postgres is up). It applies schema + migrations via `utils.db.pool.init()`, namespaces every row under a `test:integration:*` fingerprint prefix, and sweeps exactly those rows before/after each test. Cases: upsert → open(count=N); re-upsert → count delta-add + `last_seen` advance + single row; resolved → reopen; ignored → stays ignored; `list_by_status` / `count_by_status` (before/after deltas so the booted bot's own rows don't perturb it); roll-up-then-prune (fold w/ summed totals + LEAST/GREATEST window, open rows survive); and `record_findings` / `run_retention` end-to-end with `last_session_id`/`last_snapshot_id`.
- **EDIT `tests/unit/services/test_health_findings_service.py`** — corrected the false "integration-tested against real Postgres" docstring to point at the two new files.
- **Docs** — refreshed `docs/current-state.md`, the health/diagnostics folio, and the session journal (added the module-local skip-if-unreachable real-Postgres fixture as a candidate convention).

## CI safety

CI (`code-quality.yml`) runs **no** Postgres service and `tests/conftest.py` has **no** DB fixture (by design — every other suite mocks the pool). The integration fixture is therefore module-local and skips when `DATABASE_URL` is unset/unreachable, so this file is a no-op in CI and only runs where a real database is available. Verified: with `DATABASE_URL` unset, all 9 integration tests **skip** cleanly.

## Verification

- `python3.10 scripts/check_architecture.py --mode strict` → **0 errors**
- `python3.10 scripts/check_quality.py --full` → **7592 passed, 3 skipped**
- Integration suite against local Postgres → **9 passed**; with `DATABASE_URL` unset → **9 skipped**
- **Live boot:** local Postgres up → migration `057` present in `schema_migrations`, `\d` on both tables matches the migration; clean bot boot (0 ERROR/CRITICAL) with `Startup health findings: recorded=0 pruned=0` (N=0 expected on a clean boot).

**Still owed to the maintainer** (sandbox can't do these): the live Discord *render* of `!platform findings`/`health`/`startup`, and the production AI-path test (no AI-provider key in the sandbox).

https://claude.ai/code/session_01RqTXF6q9ouvsTbEdYM9FBT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqTXF6q9ouvsTbEdYM9FBT)_