### PR TITLE
server-mgmt cleanup: policy versioning (PR8) + builder/dry-run/panel diagnostics (PR9) + guild-default fix

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -688,3 +688,59 @@ green.
   sessions, promote stable lessons into their permanent homes, and clarify whether each
   item belongs in the journal, `docs/current-state.md`, a subsystem folio, `docs/ideas/`,
   a planning doc, or a binding doc. Keep the journal as process memory, not a second roadmap.
+
+## 2026-06-06 — server-mgmt cleanup PR8 + PR9 (shipped) + guild-default root-cause fix
+
+Planning session (read-only by design) that the maintainer converted to execution
+("plan approval = full execution"). Two ChatGPT-driven scope decisions were locked
+first: **presets-only (lean)** for the policy model, and **dedicated cleanup panel**
+(async helper) for diagnostics. A prior ChatGPT review of the plan had 4 required
+corrections — all verified against source before trusting them (the "verify
+cross-agent output" rule); all 4 held. Shipped both as sequential commits on one
+branch (`claude/nifty-cerf-59MKG`) → one end-of-session PR (the established
+one-PR-per-session pattern, e.g. #541 did PR4→PR6).
+
+- **PR8** (`fbdb3c4`): migration `058` adds `cleanup_policies.policy_version INT NOT
+  NULL DEFAULT 1` (additive; PK + RC-5 CHECK untouched; resolver unchanged →
+  behaviour byte-identical). `cleanup_levels`: `level_for_columns` round-trip +
+  `POLICY_VERSION`. `get_all_cleanup_for_guild` returns the new column.
+- **PR9** (`2b72f3c`): `services/cleanup_diagnostics.py` (async, presets-only) —
+  diagnostics (level naming, stale-scope + ineffective-row detection), dry-run
+  preview (reuses the **real** resolver → preview == runtime, no writes), audited
+  apply through the unchanged pipeline. `views/cleanup/policy_panel.py` builder
+  (scope → level → preview → confirm → apply) + "Cleanup Policies" button on the
+  cleanup hub. Admin re-check at the mutation point.
+
+**Root-cause bug found while building PR9 (and fixed, maintainer chose "fix now"):**
+the setup wizard wrote guild-default cleanup at `scope_id=0`, but the resolver looks
+up guild policy at `scope_id=guild_id` (`_build_scope_chain` maps guild→`ctx.guild_id`)
+— so **guild-default cleanup chosen in setup never took effect** (channel/category
+were fine). Centralised the write-side convention in
+`cleanup_levels.cleanup_scope_id()` and fixed `setup_operations`. The old test
+`test_set_cleanup_policy_routes_through_governance_writer` literally asserted
+`scope_id == 0` — it had **encoded the bug**; updated it.
+
+**Verification:** booted local Postgres (journal runbook worked verbatim) and
+verified live: `058` applies + backfills, the guild-default fix resolves to
+`GUILD_OVERRIDE`, legacy `scope_id=0` confirmed no-op, and diagnostics/preview run
+end-to-end against real rows. `check_architecture --mode strict` 0 errors;
+`check_quality --full` green (7649 passed). Real-PG integration tests skip cleanly
+in CI (module-local `DATABASE_URL`/unreachable skip, per
+`test_health_findings_integration.py`).
+
+**Descope recorded:** the implementation plan's PR8 JSONB "dimensions" column is
+**deferred** (no consumer yet) — only `policy_version` shipped. The next session
+must NOT "follow the doc" and add JSONB. Diagnostics flag legacy `scope_id=0` guild
+rows as ineffective so operators can re-set them.
+
+**Lessons (candidate Rules):**
+1. **A test can encode a bug — read what it asserts, not just whether it's green.**
+   `scope_id == 0` was a passing test that locked in a silent no-op. When a write
+   convention and a read convention must agree, pin the agreement (here: a live
+   resolver round-trip), not one side's current value.
+2. **The ephemeral sandbox Postgres dies on session resume.** A `SessionStart:resume`
+   stopped the `/tmp/pgdata` server mid-session; re-run the boot recipe (it's
+   idempotent — the `PG_VERSION` check skips re-initdb) before live DB work.
+3. **Centralise cross-component conventions in one helper.** `cleanup_scope_id()`
+   now owns the guild→`guild_id` keying so a writer can't silently diverge from the
+   resolver again.

--- a/disbot/cogs/cleanup/panel.py
+++ b/disbot/cogs/cleanup/panel.py
@@ -242,6 +242,35 @@ class CleanupPanelView(HubView):
         await interaction.response.edit_message(embed=embed, view=view)
 
     @discord.ui.button(
+        label="🧹 Cleanup Policies",
+        style=discord.ButtonStyle.blurple,
+        custom_id="cleanup:policies",
+        row=0,
+    )
+    async def btn_policies(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        # Local import keeps this module import-safe (no view-package import at
+        # cleanup-panel load time) and avoids any import cycle.
+        from views.cleanup.policy_panel import (
+            CleanupPolicyPanelView,
+            build_cleanup_diagnostics_embed,
+        )
+
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "Cleanup policies require a server context.",
+                ephemeral=True,
+            )
+            return
+        view = CleanupPolicyPanelView(interaction.user, interaction.guild)
+        _attach_back_to_cleanup_button(view, self)
+        embed = await build_cleanup_diagnostics_embed(interaction.guild)
+        await interaction.response.edit_message(embed=embed, view=view)
+
+    @discord.ui.button(
         label="🔄 Refresh",
         style=discord.ButtonStyle.secondary,
         custom_id="cleanup:refresh",

--- a/disbot/migrations/058_cleanup_policy_version.sql
+++ b/disbot/migrations/058_cleanup_policy_version.sql
@@ -1,0 +1,30 @@
+-- Migration 058: cleanup-policy version marker (server-management PR8).
+--
+-- Adds a lightweight ``policy_version`` column to ``cleanup_policies`` so each
+-- stored policy row is self-describing about which policy schema produced it.
+-- This is the "versioning" half of the server-management cleanup foundation
+-- (docs/planning/server-management-implementation-plan-2026-06-05.md, PR8); the
+-- level *vocabulary* round-trip lives in services/cleanup_levels.py.
+--
+-- Behaviour
+-- ---------
+-- Purely additive and behaviour-neutral. The cleanup resolver
+-- (governance/cleanup.py) does NOT read this column, so resolved cleanup
+-- behaviour is byte-identical before and after this migration. Every existing
+-- row is backfilled to version 1 by the column DEFAULT; new rows inserted by the
+-- unchanged GovernanceMutationPipeline write path also default to 1.
+--
+-- RC-5 is preserved: this migration does not touch the
+-- ``scope_type IN ('guild','category','channel')`` CHECK or the primary key, so
+-- threads keep inheriting cleanup policy from their parent (no thread scope).
+--
+-- Rollback
+-- --------
+-- ALTER TABLE cleanup_policies DROP COLUMN IF EXISTS policy_version;
+-- (Reverting the consuming code without this is harmless — the column is simply
+-- unread.)
+--
+-- Forward-only and idempotent.
+
+ALTER TABLE cleanup_policies
+    ADD COLUMN IF NOT EXISTS policy_version INTEGER NOT NULL DEFAULT 1;

--- a/disbot/services/cleanup_diagnostics.py
+++ b/disbot/services/cleanup_diagnostics.py
@@ -1,0 +1,297 @@
+"""Cleanup-policy operator service: diagnostics, dry-run preview, audited apply.
+
+Backend for the dedicated cleanup panel (server-management PR9).  Three
+read/preview/apply entry points, all presets-only — every write maps to the
+three ``cleanup_policies`` columns via :mod:`services.cleanup_levels` and goes
+through the unchanged :func:`governance.writes.set_cleanup_policy_for_scope`
+pipeline (DB row + governance audit row + ``audit.action_recorded`` +
+``EVT_CLEANUP_CHANGED`` + ``EVT_CACHE_INVALIDATED`` in one transaction).
+
+* :func:`collect_cleanup_diagnostics` — read-only inheritance/health report:
+  every stored policy named back to its level, with stale-scope detection
+  (channel/category deleted) and ineffective-row detection (a legacy guild row
+  keyed by something other than ``guild_id`` is never read by the resolver).
+* :func:`preview_cleanup_change` — side-effect-free dry-run: what a scope
+  currently resolves to (via the real resolver, so preview == runtime) and what
+  it would resolve to after the change.  Emits nothing, writes nothing.
+* :func:`apply_cleanup_change` — the audited apply through the pipeline.
+
+Layer: services → governance + utils (no views/cogs).  The resolver is reused,
+never reimplemented, so the preview can never drift from runtime behaviour.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import discord
+
+from governance.cleanup import resolve_cleanup_policy
+from governance.models import CleanupPolicy, GovernanceContext, PolicySource
+from governance.writes import set_cleanup_policy_for_scope
+from services.cleanup_levels import (
+    cleanup_scope_id,
+    columns_for_level,
+    known_level_names,
+    level_for_columns,
+)
+from utils.db import governance as gov_db
+
+# Cleanup scopes the resolver honours (RC-5: no thread scope).
+CLEANUP_SCOPE_TYPES: frozenset[str] = frozenset({"guild", "category", "channel"})
+
+_SOURCE_FOR_SCOPE: dict[str, PolicySource] = {
+    "guild": PolicySource.GUILD_OVERRIDE,
+    "category": PolicySource.CATEGORY_OVERRIDE,
+    "channel": PolicySource.CHANNEL_OVERRIDE,
+}
+
+CUSTOM_LEVEL_LABEL = "Custom"
+
+
+# ---------------------------------------------------------------------------
+# Read model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CleanupScopeRow:
+    """One stored ``cleanup_policies`` row, named and health-checked."""
+
+    scope_type: str
+    scope_id: int
+    level_name: str | None  # None → operator-tuned ("Custom")
+    delete_invalid_commands: bool
+    delete_failed_commands: bool
+    delete_after_seconds: int
+    policy_version: int
+    target_label: str
+    is_stale: bool  # channel/category no longer exists
+    is_ineffective: bool  # guild row not keyed by guild_id → resolver never reads it
+
+    @property
+    def display_level(self) -> str:
+        return self.level_name or CUSTOM_LEVEL_LABEL
+
+
+@dataclass(frozen=True)
+class CleanupDiagnostics:
+    """Aggregated per-guild cleanup-policy health report."""
+
+    guild_id: int
+    rows: tuple[CleanupScopeRow, ...]
+    level_counts: dict[str, int]
+
+    @property
+    def total(self) -> int:
+        return len(self.rows)
+
+    @property
+    def stale_rows(self) -> tuple[CleanupScopeRow, ...]:
+        return tuple(r for r in self.rows if r.is_stale)
+
+    @property
+    def ineffective_rows(self) -> tuple[CleanupScopeRow, ...]:
+        return tuple(r for r in self.rows if r.is_ineffective)
+
+
+def _target_label(
+    guild: discord.Guild,
+    scope_type: str,
+    scope_id: int,
+) -> tuple[str, bool]:
+    """Return ``(label, is_stale)`` for a scope row."""
+    if scope_type == "guild":
+        return "Guild default", False
+    channel = guild.get_channel(scope_id)
+    if channel is None:
+        return f"{scope_type} {scope_id} (deleted)", True
+    if scope_type == "category":
+        return f"Category {channel.name}", False
+    return f"#{channel.name}", False
+
+
+async def collect_cleanup_diagnostics(guild: discord.Guild) -> CleanupDiagnostics:
+    """Read-only inheritance + health report for a guild's cleanup policies."""
+    raw = await gov_db.get_all_cleanup_for_guild(guild.id)
+    rows: list[CleanupScopeRow] = []
+    level_counts: dict[str, int] = {}
+    for r in raw:
+        scope_type = r["scope_type"]
+        scope_id = int(r["scope_id"])
+        level_name = level_for_columns(
+            delete_invalid_commands=r["delete_invalid_commands"],
+            delete_failed_commands=r["delete_failed_commands"],
+            delete_after_seconds=r["delete_after_seconds"],
+        )
+        label, is_stale = _target_label(guild, scope_type, scope_id)
+        # A guild row keyed by anything other than guild_id (the legacy
+        # scope_id=0 bug) is never read by the resolver — flag it so an
+        # operator can re-apply or clean it up.
+        is_ineffective = scope_type == "guild" and scope_id != guild.id
+        row = CleanupScopeRow(
+            scope_type=scope_type,
+            scope_id=scope_id,
+            level_name=level_name,
+            delete_invalid_commands=r["delete_invalid_commands"],
+            delete_failed_commands=r["delete_failed_commands"],
+            delete_after_seconds=r["delete_after_seconds"],
+            policy_version=int(r.get("policy_version", 1)),
+            target_label=label,
+            is_stale=is_stale,
+            is_ineffective=is_ineffective,
+        )
+        rows.append(row)
+        key = row.display_level
+        level_counts[key] = level_counts.get(key, 0) + 1
+
+    # Stable order: guild first, then category, then channel; by id within.
+    order = {"guild": 0, "category": 1, "channel": 2}
+    rows.sort(key=lambda r: (order.get(r.scope_type, 9), r.scope_id))
+    return CleanupDiagnostics(
+        guild_id=guild.id,
+        rows=tuple(rows),
+        level_counts=level_counts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dry-run preview
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CleanupPolicyPreview:
+    """Side-effect-free preview of setting ``scope`` to ``level``."""
+
+    scope_type: str
+    scope_id: int
+    target_label: str
+    level: str
+    new_delete_message: bool
+    new_delete_after_seconds: int
+    current: CleanupPolicy
+    will_change: bool
+    warnings: tuple[str, ...]
+
+    @property
+    def current_source(self) -> PolicySource:
+        return self.current.resolved_from
+
+
+def _resolve_ctx_for_scope(
+    guild: discord.Guild,
+    scope_type: str,
+    scope_id: int,
+) -> GovernanceContext:
+    """Build the context the resolver needs to evaluate ``scope`` today."""
+    if scope_type == "guild":
+        return GovernanceContext(guild_id=guild.id)
+    if scope_type == "category":
+        return GovernanceContext(guild_id=guild.id, category_id=scope_id)
+    channel = guild.get_channel(scope_id)
+    category_id = getattr(channel, "category_id", None)
+    return GovernanceContext(
+        guild_id=guild.id,
+        channel_id=scope_id,
+        category_id=category_id,
+    )
+
+
+async def preview_cleanup_change(
+    guild: discord.Guild,
+    scope_type: str,
+    scope_id: int,
+    level: str,
+) -> CleanupPolicyPreview:
+    """Compute the dry-run preview for setting ``scope`` to ``level``.
+
+    Reuses the real :func:`resolve_cleanup_policy` for the *current* state so
+    the preview matches runtime exactly.  Writes nothing, emits nothing.
+    """
+    _validate(scope_type, level)
+    cols = columns_for_level(level)
+    new_delete = bool(cols["delete_invalid_commands"])
+    new_after = int(cols["delete_after_seconds"])
+
+    current = await resolve_cleanup_policy(
+        _resolve_ctx_for_scope(guild, scope_type, scope_id),
+    )
+
+    this_source = _SOURCE_FOR_SCOPE[scope_type]
+    effect_differs = (
+        current.delete_message != new_delete
+        or current.delete_after_seconds != new_after
+    )
+    pins_source = current.resolved_from is not this_source
+    will_change = effect_differs or pins_source
+
+    label, is_stale = _target_label(guild, scope_type, scope_id)
+    warnings: list[str] = []
+    if is_stale:
+        warnings.append(
+            f"This {scope_type} no longer exists in the server — the policy "
+            "will be stored but never matched until it is recreated.",
+        )
+    if not effect_differs and pins_source:
+        warnings.append(
+            "Same effect as today, but this pins an explicit override on the "
+            f"{scope_type} (currently inherited from "
+            f"{current.resolved_from.value}).",
+        )
+
+    return CleanupPolicyPreview(
+        scope_type=scope_type,
+        scope_id=scope_id,
+        target_label=label,
+        level=level,
+        new_delete_message=new_delete,
+        new_delete_after_seconds=new_after,
+        current=current,
+        will_change=will_change,
+        warnings=tuple(warnings),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Audited apply
+# ---------------------------------------------------------------------------
+
+
+async def apply_cleanup_change(
+    guild: discord.Guild,
+    member: discord.Member,
+    scope_type: str,
+    scope_id: int | None,
+    level: str,
+) -> None:
+    """Persist ``level`` for ``scope`` via the governance pipeline (audited).
+
+    Guild scope is keyed by ``guild_id`` (see
+    :func:`services.cleanup_levels.cleanup_scope_id`); the pipeline writes the
+    row + governance audit + events in one transaction and enforces authority.
+    """
+    _validate(scope_type, level)
+    cols = columns_for_level(level)
+    effective_id = cleanup_scope_id(scope_type, guild.id, scope_id)
+    ctx = GovernanceContext(guild_id=guild.id, member=member)
+    await set_cleanup_policy_for_scope(
+        ctx,
+        scope_type,
+        effective_id,
+        delete_invalid_commands=cols["delete_invalid_commands"],
+        delete_failed_commands=cols["delete_failed_commands"],
+        delete_after_seconds=cols["delete_after_seconds"],
+    )
+
+
+def _validate(scope_type: str, level: str) -> None:
+    if scope_type not in CLEANUP_SCOPE_TYPES:
+        raise ValueError(
+            f"cleanup scope_type {scope_type!r} is not one of "
+            f"{sorted(CLEANUP_SCOPE_TYPES)} (threads inherit; RC-5)",
+        )
+    if level not in known_level_names():
+        raise ValueError(
+            f"cleanup level {level!r} is not one of {sorted(known_level_names())}",
+        )

--- a/disbot/services/cleanup_levels.py
+++ b/disbot/services/cleanup_levels.py
@@ -24,6 +24,7 @@ from typing import Any
 __all__ = [
     "LEVELS",
     "POLICY_VERSION",
+    "cleanup_scope_id",
     "columns_for_level",
     "known_level_names",
     "level_for_columns",
@@ -97,3 +98,24 @@ def level_for_columns(
         ):
             return name
     return None
+
+
+def cleanup_scope_id(scope_type: str, guild_id: int, scope_id: int | None) -> int:
+    """Return the ``cleanup_policies.scope_id`` to key a write to ``scope_type``.
+
+    Single source of truth for the write-side scope-id convention so writers and
+    the resolver agree.  The cleanup resolver
+    (:func:`governance.resolver._build_scope_chain`) looks up a guild-scope row at
+    ``scope_id == guild_id``; therefore a guild-default policy **must** be stored
+    at ``guild_id``, not at ``0``.  (A guild row written at ``scope_id=0`` is never
+    read by the resolver — the silent-no-op bug this helper exists to prevent.)
+    Category/channel rows are keyed by their snowflake.
+
+    Note: this is the cleanup convention only.  ``cog_routing`` keys guild scope
+    with SQL ``NULL`` and is unrelated.
+    """
+    if scope_type == "guild":
+        return guild_id
+    if scope_id is None:
+        raise ValueError(f"{scope_type} cleanup scope requires a scope_id")
+    return int(scope_id)

--- a/disbot/services/cleanup_levels.py
+++ b/disbot/services/cleanup_levels.py
@@ -21,7 +21,19 @@ from __future__ import annotations
 
 from typing import Any
 
-__all__ = ["LEVELS", "columns_for_level", "known_level_names"]
+__all__ = [
+    "LEVELS",
+    "POLICY_VERSION",
+    "columns_for_level",
+    "known_level_names",
+    "level_for_columns",
+]
+
+# Current cleanup-policy schema version. Stamped on every ``cleanup_policies``
+# row via the column DEFAULT (migration 058) and surfaced by the read model /
+# diagnostics so a stored policy is self-describing. Bump only when the policy
+# shape changes (e.g. a future dimensioned policy), alongside its migration.
+POLICY_VERSION = 1
 
 
 LEVELS: dict[str, dict[str, Any]] = {
@@ -60,3 +72,28 @@ def columns_for_level(name: str) -> dict[str, Any]:
 def known_level_names() -> frozenset[str]:
     """Return the set of operator-facing level names."""
     return frozenset(LEVELS)
+
+
+def level_for_columns(
+    *,
+    delete_invalid_commands: bool,
+    delete_failed_commands: bool,
+    delete_after_seconds: int,
+) -> str | None:
+    """Return the preset level name matching these column values, else ``None``.
+
+    The inverse of :func:`columns_for_level`: given a stored ``cleanup_policies``
+    row's three columns, name it back to its operator-facing level
+    (``Off`` / ``Light`` / ``Standard`` / ``Strict``).  Returns ``None`` when the
+    values match no preset (an operator-tuned policy), so the caller decides how
+    to render it (e.g. as ``"Custom"``).  The four presets have distinct column
+    tuples, so the match is unambiguous.
+    """
+    for name, cols in LEVELS.items():
+        if (
+            cols["delete_invalid_commands"] == delete_invalid_commands
+            and cols["delete_failed_commands"] == delete_failed_commands
+            and cols["delete_after_seconds"] == delete_after_seconds
+        ):
+            return name
+    return None

--- a/disbot/services/setup_operations.py
+++ b/disbot/services/setup_operations.py
@@ -1203,7 +1203,11 @@ async def _apply_set_cleanup_policy(
     """
     from governance.models import GovernanceContext
     from governance.writes import set_cleanup_policy_for_scope
-    from services.cleanup_levels import columns_for_level, known_level_names
+    from services.cleanup_levels import (
+        cleanup_scope_id,
+        columns_for_level,
+        known_level_names,
+    )
 
     scope_kind = (op.target_kind or "").strip().lower()
     if scope_kind not in _CLEANUP_SCOPE_TYPES:
@@ -1229,24 +1233,25 @@ async def _apply_set_cleanup_policy(
             ),
         )
 
-    # Guild-scope writes use scope_id=0 (the column is NOT NULL on the
-    # governance table) — see governance/writes.py.  Category/channel
-    # writes carry the snowflake.
-    scope_id = op.target_id if scope_kind != "guild" else 0
-    if scope_kind != "guild" and scope_id is None:
+    # Category/channel writes need a target_id snowflake.  Guild scope is keyed
+    # by guild_id (NOT 0): the resolver looks up guild policy at
+    # scope_id=guild_id, so a 0 here was a silent no-op — guild-default cleanup
+    # never took effect.  cleanup_scope_id() is the single source of truth.
+    if scope_kind != "guild" and op.target_id is None:
         return SetupOperationResult(
             status="failed",
             operation=op,
             label=label,
             error=f"set_cleanup_policy: {scope_kind} scope requires target_id",
         )
+    scope_id = cleanup_scope_id(scope_kind, guild.id, op.target_id)
 
     columns = columns_for_level(level)
     ctx = GovernanceContext(guild_id=guild.id, member=actor)
     await set_cleanup_policy_for_scope(
         ctx,
         scope_kind,
-        scope_id or 0,
+        scope_id,
         delete_invalid_commands=columns["delete_invalid_commands"],
         delete_failed_commands=columns["delete_failed_commands"],
         delete_after_seconds=columns["delete_after_seconds"],

--- a/disbot/utils/db/governance.py
+++ b/disbot/utils/db/governance.py
@@ -110,10 +110,16 @@ async def get_cleanup_policy(
 
 
 async def get_all_cleanup_for_guild(guild_id: int) -> list[dict]:
-    """All cleanup policy rows for a guild (every scope)."""
+    """All cleanup policy rows for a guild (every scope).
+
+    Includes ``policy_version`` (migration 058) so the read model / cleanup
+    diagnostics can show which policy schema produced each row.  The cleanup
+    resolver does not use this function — it reads via ``get_cleanup_policy`` —
+    so the extra column is purely informational and does not affect resolution.
+    """
     rows = await pool.get().fetch(
         "SELECT scope_type, scope_id, delete_invalid_commands,"
-        " delete_failed_commands, delete_after_seconds"
+        " delete_failed_commands, delete_after_seconds, policy_version"
         " FROM cleanup_policies WHERE guild_id=$1",
         guild_id,
     )

--- a/disbot/views/cleanup/__init__.py
+++ b/disbot/views/cleanup/__init__.py
@@ -1,0 +1,1 @@
+"""Cleanup operator panel views (server-management PR9)."""

--- a/disbot/views/cleanup/policy_panel.py
+++ b/disbot/views/cleanup/policy_panel.py
@@ -1,0 +1,448 @@
+"""Cleanup-policy operator panel — diagnostics + presets builder (PR9).
+
+Reached from the Cleanup hub (``cogs/cleanup/panel.py``).  Two surfaces over the
+:mod:`services.cleanup_diagnostics` backend:
+
+* **Diagnostics** (read-only): every stored policy named by level, with the
+  inheritance reminder, stale-scope flags, and ineffective-row flags.
+* **Builder** (presets-only): pick scope → pick level → **dry-run preview**
+  (resolved effect + inherited source + diff) → **confirm** → audited apply via
+  the governance pipeline.  No custom dimensions, no side-path writes.
+
+Authority: the hub command is admin-gated and ``BaseView(public=False)`` already
+restricts every step to the invoker; the apply button re-checks
+``interaction_is_admin`` at the mutation point (capability-authority.md), with the
+pipeline's ``_validate_authority`` as the infrastructure backstop.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from services.cleanup_diagnostics import (
+    CleanupDiagnostics,
+    CleanupPolicyPreview,
+    apply_cleanup_change,
+    collect_cleanup_diagnostics,
+    preview_cleanup_change,
+)
+from services.cleanup_levels import LEVELS
+from services.governance_exceptions import GovernanceError
+from utils.ui_constants import ADMIN_COLOR
+from views.base import BaseView, HubView, interaction_is_admin
+
+logger = logging.getLogger("bot.views.cleanup.policy_panel")
+
+_EPHEMERAL_TIMEOUT = 180
+_MAX_LISTED_ROWS = 15
+
+
+def _level_options() -> list[discord.SelectOption]:
+    return [
+        discord.SelectOption(
+            label=name,
+            value=name,
+            description=(
+                f"after={cols['delete_after_seconds']}s · "
+                f"invalid={'yes' if cols['delete_invalid_commands'] else 'no'} · "
+                f"failed={'yes' if cols['delete_failed_commands'] else 'no'}"
+            ),
+        )
+        for name, cols in LEVELS.items()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Embeds
+# ---------------------------------------------------------------------------
+
+
+def _format_row(row) -> str:
+    flags = ""
+    if row.is_ineffective:
+        flags = " ⚠️ *legacy key — not applied; re-set to fix*"
+    elif row.is_stale:
+        flags = " ⚠️ *scope deleted*"
+    return f"• **{row.target_label}** → `{row.display_level}` ({row.delete_after_seconds}s){flags}"
+
+
+def diagnostics_embed_from(diag: CleanupDiagnostics) -> discord.Embed:
+    """Build the diagnostics embed from an already-collected report (testable)."""
+    embed = discord.Embed(
+        title="🧹 Cleanup Policies — Diagnostics",
+        description=(
+            "Resolution walks **channel → category → guild → default**; the most "
+            "specific override wins. Threads inherit from their parent channel."
+        ),
+        color=ADMIN_COLOR,
+    )
+    if not diag.rows:
+        embed.add_field(
+            name="Configured policies",
+            value="_None — every scope uses the fallback default (delete after 5s)._",
+            inline=False,
+        )
+        embed.set_footer(text="Use “Set a policy” to add one.")
+        return embed
+
+    counts = ", ".join(f"{name}×{n}" for name, n in sorted(diag.level_counts.items()))
+    embed.add_field(
+        name=f"Configured policies ({diag.total})",
+        value=counts or "_none_",
+        inline=False,
+    )
+
+    listed = diag.rows[:_MAX_LISTED_ROWS]
+    body = "\n".join(_format_row(r) for r in listed)
+    if diag.total > _MAX_LISTED_ROWS:
+        body += f"\n… and {diag.total - _MAX_LISTED_ROWS} more."
+    embed.add_field(name="Overrides", value=body, inline=False)
+
+    if diag.ineffective_rows:
+        embed.add_field(
+            name="⚠️ Ineffective rows",
+            value=(
+                f"{len(diag.ineffective_rows)} guild row(s) are stored under a "
+                "legacy key the resolver never reads. Re-set the guild default to fix."
+            ),
+            inline=False,
+        )
+    if diag.stale_rows:
+        embed.add_field(
+            name="⚠️ Stale overrides",
+            value=(
+                f"{len(diag.stale_rows)} override(s) target a channel/category that "
+                "no longer exists."
+            ),
+            inline=False,
+        )
+    embed.set_footer(text="Read-only summary. Use “Set a policy” to make changes.")
+    return embed
+
+
+async def build_cleanup_diagnostics_embed(guild: discord.Guild) -> discord.Embed:
+    """Collect + render the cleanup diagnostics for ``guild``."""
+    diag = await collect_cleanup_diagnostics(guild)
+    return diagnostics_embed_from(diag)
+
+
+def preview_embed_from(preview: CleanupPolicyPreview) -> discord.Embed:
+    """Render a dry-run preview (no side effects already guaranteed by service)."""
+    cur = preview.current
+    color = discord.Color.orange() if preview.will_change else discord.Color.greyple()
+    embed = discord.Embed(
+        title="🔎 Dry run — review before applying",
+        description=f"Set **{preview.target_label}** to `{preview.level}`?",
+        color=color,
+    )
+    embed.add_field(
+        name="Currently resolves to",
+        value=(
+            f"delete={'yes' if cur.delete_message else 'no'}, "
+            f"after={cur.delete_after_seconds}s\n"
+            f"_source: {cur.resolved_from.value}_"
+        ),
+        inline=True,
+    )
+    embed.add_field(
+        name="After applying",
+        value=(
+            f"delete={'yes' if preview.new_delete_message else 'no'}, "
+            f"after={preview.new_delete_after_seconds}s\n"
+            f"_source: {preview.scope_type} override_"
+        ),
+        inline=True,
+    )
+    if not preview.will_change:
+        embed.add_field(
+            name="No change",
+            value="This scope already resolves exactly this way.",
+            inline=False,
+        )
+    for warning in preview.warnings:
+        embed.add_field(name="⚠️ Note", value=warning, inline=False)
+    embed.set_footer(text="Nothing has been written yet.")
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Builder flow — selects
+# ---------------------------------------------------------------------------
+
+_SCOPE_OPTIONS = [
+    discord.SelectOption(
+        label="Guild default",
+        value="guild",
+        emoji="🌐",
+        description="Baseline level for every channel without an override.",
+    ),
+    discord.SelectOption(
+        label="Category override",
+        value="category",
+        emoji="📁",
+        description="Override one category (its channels inherit unless overridden).",
+    ),
+    discord.SelectOption(
+        label="Channel override",
+        value="channel",
+        emoji="📡",
+        description="Override one specific channel.",
+    ),
+]
+
+
+class _ScopeSelect(discord.ui.Select):
+    def __init__(self, guild: discord.Guild) -> None:
+        super().__init__(
+            placeholder="Pick a scope to set cleanup for…",
+            min_values=1,
+            max_values=1,
+            options=list(_SCOPE_OPTIONS),
+        )
+        self._guild = guild
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        scope = self.values[0]
+        view = BaseView(interaction.user, public=False, timeout=_EPHEMERAL_TIMEOUT)
+        if scope == "guild":
+            view.add_item(
+                _LevelSelect(self._guild, "guild", self._guild.id, "Guild default"),
+            )
+            await interaction.response.send_message(
+                "Pick the guild-default cleanup level:",
+                view=view,
+                ephemeral=True,
+            )
+        elif scope == "category":
+            view.add_item(_CategoryPickSelect(self._guild))
+            await interaction.response.send_message(
+                "Pick a category to override:",
+                view=view,
+                ephemeral=True,
+            )
+        else:
+            view.add_item(_ChannelPickSelect(self._guild))
+            await interaction.response.send_message(
+                "Pick a channel to override:",
+                view=view,
+                ephemeral=True,
+            )
+
+
+class _CategoryPickSelect(discord.ui.ChannelSelect):
+    def __init__(self, guild: discord.Guild) -> None:
+        super().__init__(
+            placeholder="Pick a category…",
+            channel_types=[discord.ChannelType.category],
+            min_values=1,
+            max_values=1,
+        )
+        self._guild = guild
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        picked = self.values[0]
+        view = BaseView(interaction.user, public=False, timeout=_EPHEMERAL_TIMEOUT)
+        view.add_item(
+            _LevelSelect(self._guild, "category", picked.id, f"Category {picked.name}"),
+        )
+        await interaction.response.send_message(
+            f"Pick the cleanup level for category **{picked.name}**:",
+            view=view,
+            ephemeral=True,
+        )
+
+
+class _ChannelPickSelect(discord.ui.ChannelSelect):
+    def __init__(self, guild: discord.Guild) -> None:
+        super().__init__(
+            placeholder="Pick a channel…",
+            channel_types=[discord.ChannelType.text],
+            min_values=1,
+            max_values=1,
+        )
+        self._guild = guild
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        picked = self.values[0]
+        view = BaseView(interaction.user, public=False, timeout=_EPHEMERAL_TIMEOUT)
+        view.add_item(
+            _LevelSelect(self._guild, "channel", picked.id, f"#{picked.name}"),
+        )
+        await interaction.response.send_message(
+            f"Pick the cleanup level for #{picked.name}:",
+            view=view,
+            ephemeral=True,
+        )
+
+
+class _LevelSelect(discord.ui.Select):
+    def __init__(
+        self,
+        guild: discord.Guild,
+        scope_type: str,
+        scope_id: int,
+        label: str,
+    ) -> None:
+        super().__init__(
+            placeholder=f"Level for {label}…",
+            min_values=1,
+            max_values=1,
+            options=_level_options(),
+        )
+        self._guild = guild
+        self._scope_type = scope_type
+        self._scope_id = scope_id
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        level = self.values[0]
+        try:
+            preview = await preview_cleanup_change(
+                self._guild,
+                self._scope_type,
+                self._scope_id,
+                level,
+            )
+        except Exception:  # noqa: BLE001 — preview must never crash the flow
+            logger.exception("cleanup preview failed")
+            await interaction.response.send_message(
+                "Could not build the preview — see logs.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_message(
+            embed=preview_embed_from(preview),
+            view=_ConfirmApplyView(interaction.user, self._guild, preview),
+            ephemeral=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Confirm + apply
+# ---------------------------------------------------------------------------
+
+
+class _ConfirmApplyView(BaseView):
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        guild: discord.Guild,
+        preview: CleanupPolicyPreview,
+    ) -> None:
+        super().__init__(author, public=False, timeout=_EPHEMERAL_TIMEOUT)
+        self._guild = guild
+        self._preview = preview
+
+    @discord.ui.button(label="✅ Apply", style=discord.ButtonStyle.success)
+    async def btn_apply(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        if not interaction_is_admin(interaction):
+            await interaction.response.send_message(
+                "You need the **Administrator** permission to change cleanup policies.",
+                ephemeral=True,
+            )
+            return
+        p = self._preview
+        try:
+            await apply_cleanup_change(
+                self._guild,
+                interaction.user,
+                p.scope_type,
+                p.scope_id,
+                p.level,
+            )
+        except GovernanceError as exc:
+            await interaction.response.edit_message(
+                content=f"❌ Could not apply: {exc}",
+                embed=None,
+                view=None,
+            )
+            return
+        except Exception:  # noqa: BLE001 — surface a clean error, never crash
+            logger.exception("cleanup apply failed")
+            await interaction.response.edit_message(
+                content="❌ Could not apply the policy — see logs.",
+                embed=None,
+                view=None,
+            )
+            return
+        await interaction.response.edit_message(
+            content=(
+                f"✅ Applied `{p.level}` to **{p.target_label}**. "
+                "Resolution updates immediately."
+            ),
+            embed=None,
+            view=None,
+        )
+
+    @discord.ui.button(label="✖ Cancel", style=discord.ButtonStyle.secondary)
+    async def btn_cancel(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        await interaction.response.edit_message(
+            content="Cancelled — nothing was written.",
+            embed=None,
+            view=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Top-level diagnostics panel
+# ---------------------------------------------------------------------------
+
+
+class CleanupPolicyPanelView(HubView):
+    """Diagnostics view + entry to the presets builder."""
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        guild: discord.Guild,
+    ) -> None:
+        super().__init__(author)
+        self.guild = guild
+
+    @discord.ui.button(
+        label="🔧 Set a policy",
+        style=discord.ButtonStyle.success,
+        custom_id="cleanup_policy:build",
+        row=0,
+    )
+    async def btn_build(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        if not interaction_is_admin(interaction):
+            await interaction.response.send_message(
+                "You need the **Administrator** permission to change cleanup policies.",
+                ephemeral=True,
+            )
+            return
+        view = BaseView(interaction.user, public=False, timeout=_EPHEMERAL_TIMEOUT)
+        view.add_item(_ScopeSelect(self.guild))
+        await interaction.response.send_message(
+            "Choose what to set cleanup for:",
+            view=view,
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
+        label="🔄 Refresh",
+        style=discord.ButtonStyle.secondary,
+        custom_id="cleanup_policy:refresh",
+        row=0,
+    )
+    async def btn_refresh(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        embed = await build_cleanup_diagnostics_embed(self.guild)
+        await interaction.response.edit_message(embed=embed, view=self)

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -6,9 +6,11 @@
 > live GitHub** before trusting it (two same-session reports already
 > contradicted each other across a single merge).
 >
-> **Last updated:** 2026-06-06 · post-#547 · closed the health/diagnostics
-> migration-`057` persistence/dedupe/retention integration-test gap (test-only;
-> verified live: 1 open PR — this session's end-of-session PR).
+> **Last updated:** 2026-06-06 · post-#548 (merged) · this session shipped
+> server-management cleanup **PR8** (policy_version marker + level round-trip) and
+> **PR9** (cleanup builder + dry-run + dedicated-panel diagnostics; fixed the
+> guild-default `scope_id=0` silent no-op). Detail/status: server-management
+> folio + tracker. Verify open PRs against live GitHub.
 >
 > **Purpose:** the one file that answers "what is true right now?" so a new
 > session does not reconstruct it from the journal + planning docs. Read it
@@ -26,13 +28,15 @@ in the sandbox**, not broken. Known UX follow-ups remain (below).
 
 ## In flight (verify against live GitHub)
 
-**1 open PR** as of this snapshot: **#548** — closes the migration-`057`
-integration-test gap (test-only — see the health/diagnostics folio).
+**1 open PR** as of this snapshot: this session's end-of-session PR —
+server-management cleanup **PR8 + PR9** on `claude/nifty-cerf-59MKG` (see the
+server-management folio/tracker). **#548 has merged.**
 **Always re-verify open PRs against live GitHub** before starting work — this is a dated
 snapshot, and a later PR may have opened since.
 
 ## Recently shipped (newest first)
 
+- **#548** — closed the migration-`057` persistence/dedupe/retention integration-test gap (test-only).
 - **#546** — canonical subsystem folios (health/diagnostics, server-mgmt, settings, BTD6, games, media).
 - **#544** — freshness-oriented docs route, lifecycle labels, ideas area, and subsystem-folio model.
 - **#543** — boot / test-bot capability doc correction.

--- a/docs/planning/server-management-status-2026-06-05.md
+++ b/docs/planning/server-management-status-2026-06-05.md
@@ -6,9 +6,9 @@
 > done*, **this tracker (cross-checked against source) wins**; the roadmap remains
 > the target architecture and the implementation plan remains the PR-scope detail.
 >
-> **Date:** 2026-06-05 (originally verified @ `f0f0824` / #523). **Body is current
-> through PR7; remaining queue starts at PR8** — the "Shipped" + "Remaining queue"
-> sections below are authoritative.
+> **Date:** 2026-06-05 (originally verified @ `f0f0824` / #523; updated 2026-06-06
+> for PR8+PR9). **Body is current through PR9; remaining queue starts at PR10** —
+> the "Shipped" + "Remaining queue" sections below are authoritative.
 >
 > **Companion docs (read together):**
 > - `docs/planning/server-management-roadmap-2026-06-05.md` — target architecture
@@ -248,16 +248,41 @@ The deferred move/reorder UI from #523, routed through the lifecycle service.
   first-class category create/rename/delete UI (categories are already movable /
   renamable / deletable through the service as `GuildChannel`s).
 
+### PR8 + PR9 — Cleanup versioning, builder, dry-run, panel diagnostics *(shipped 2026-06-06)*
+
+Shipped together on one branch (`claude/nifty-cerf-59MKG`). **Presets-only (lean)**
+per maintainer decision — every write maps to the existing three `cleanup_policies`
+columns through the unchanged governance pipeline.
+
+- **PR8** — migration `058` adds `policy_version INTEGER NOT NULL DEFAULT 1`
+  (additive; PK + RC-5 `scope_type` CHECK untouched; resolved behaviour
+  byte-identical). `services.cleanup_levels`: `level_for_columns` round-trip +
+  `POLICY_VERSION`. `get_all_cleanup_for_guild` returns `policy_version`.
+- **PR9** — `services/cleanup_diagnostics.py` (async, presets-only):
+  `collect_cleanup_diagnostics` (per-scope levels, stale-scope + ineffective-row
+  detection), `preview_cleanup_change` (side-effect-free dry-run via the **real**
+  resolver, so preview == runtime), `apply_cleanup_change` (audited apply through
+  the unchanged pipeline). `views/cleanup/policy_panel.py`: diagnostics view +
+  presets builder (scope → level → dry-run → confirm → apply), admin re-check at
+  the mutation point. Surfaced via a "Cleanup Policies" button on the cleanup hub
+  (`cogs/cleanup/panel.py`).
+- **Root-cause fix (found while building):** the setup wizard wrote guild-default
+  cleanup at `scope_id=0`, but the resolver looks up guild policy at
+  `scope_id=guild_id` — so **guild-default never took effect**. Centralised the
+  write-side convention in `cleanup_levels.cleanup_scope_id()` and fixed
+  `setup_operations._apply_set_cleanup_policy`. Verified live + regression-pinned.
+- **Descope vs the implementation plan:** the plan's PR8 JSONB "dimensions" column
+  is **deferred** (no consumer yet); only `policy_version` shipped. Diagnostics
+  flag legacy `scope_id=0` guild rows as ineffective (re-set to fix).
+
 ---
 
-## Remaining queue (starts at PR8)
+## Remaining queue (starts at PR10)
 
-Per the implementation plan's dependency order. PR7 shipped (see above).
+Per the implementation plan's dependency order. PR7–PR9 shipped (see above).
 
 | PR | Objective | Depends on |
 |---|---|---|
-| **PR8** | Cleanup policy schema + versioning (preserve RC-5 thread-inheritance behavior). | — |
-| **PR9** | Cleanup builder + dry-run + diagnostics. | PR8, #522 |
 | **PR10** | Moderation first-class configuration (mod-roles, log destinations, escalation, DMs). | #521 |
 | **PR11** | Setup role/moderation/governance sections. | PR5, PR8–PR10, #522 |
 | **PR12** | Setup diagnostics & repair. | PR5, #522 |

--- a/docs/subsystems/server-management.md
+++ b/docs/subsystems/server-management.md
@@ -44,11 +44,12 @@ cleanup policy, setup, and the future unified hub. Inspect first:
 
 ## Plans / pending approval
 
-The status tracker's remaining queue is the only current sequencing authority:
-cleanup policy schema/versioning, cleanup builder/dry-run/diagnostics, moderation
-configuration, setup role/moderation/governance and repair sections, role templates,
-and finally the unified Server Management Hub. Link to the tracker for exact order
-and dependencies rather than copying them here.
+The status tracker's remaining queue is the only current sequencing authority.
+Cleanup versioning + builder/dry-run/panel diagnostics shipped 2026-06-06 (PR8+PR9,
+presets-only); the queue now starts at moderation configuration, then setup
+role/moderation/governance and repair sections, role templates, and finally the
+unified Server Management Hub. Link to the tracker for exact order and dependencies
+rather than copying them here.
 
 ## Ideas (not approved)
 

--- a/tests/unit/cogs/test_cleanup_panel.py
+++ b/tests/unit/cogs/test_cleanup_panel.py
@@ -82,7 +82,7 @@ def test_overview_embed_when_guild_unloaded():
 # ---------------------------------------------------------------------------
 
 
-def test_view_has_four_buttons_with_expected_custom_ids():
+def test_view_has_expected_button_custom_ids():
     view = CleanupPanelView(_author(), _cog(), guild_id=42)
     custom_ids = {
         c.custom_id  # type: ignore[attr-defined]
@@ -93,6 +93,7 @@ def test_view_has_four_buttons_with_expected_custom_ids():
         "cleanup:words",
         "cleanup:logging",
         "cleanup:settings",
+        "cleanup:policies",
         "cleanup:refresh",
     }
 
@@ -104,7 +105,7 @@ def test_view_buttons_use_two_rows():
         for c in view.children
         if isinstance(c, discord.ui.Button)
     }
-    # Three top-row routing buttons + the refresh button on a second row.
+    # Top-row routing buttons + the refresh button on a second row.
     assert rows == {0, 1}
 
 
@@ -217,6 +218,41 @@ async def test_logging_button_handles_missing_logging_cog():
 
     interaction.response.send_message.assert_awaited_once()
     interaction.response.edit_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_policies_button_opens_policy_panel_with_diagnostics():
+    cog = _cog()
+    view = CleanupPanelView(_author(), cog, guild_id=42)
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = view._author
+    interaction.client = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.guild.id = 42
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+
+    fake_embed = discord.Embed(title="Cleanup Policies — Diagnostics")
+    with patch(
+        "views.cleanup.policy_panel.build_cleanup_diagnostics_embed",
+        AsyncMock(return_value=fake_embed),
+    ):
+        btn = next(
+            c
+            for c in view.children
+            if isinstance(c, discord.ui.Button) and c.custom_id == "cleanup:policies"
+        )
+        await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    from views.cleanup.policy_panel import CleanupPolicyPanelView
+
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    assert isinstance(kwargs["view"], CleanupPolicyPanelView)
+    assert kwargs["embed"] is fake_embed
+    back = _back_button(kwargs["view"])
+    assert back is not None, "Policy panel must have a cleanup:back button"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/db/test_cleanup_policies_integration.py
+++ b/tests/unit/db/test_cleanup_policies_integration.py
@@ -84,3 +84,35 @@ async def test_get_all_cleanup_returns_policy_version_per_scope(postgres_pool):
     rows = await gov_db.get_all_cleanup_for_guild(_TEST_GUILD)
     assert {r["scope_type"] for r in rows} == {"guild", "channel"}
     assert all(r.get("policy_version") == 1 for r in rows)
+
+
+async def test_guild_default_keyed_by_guild_id_resolves(postgres_pool):
+    """Regression (PR9 root-cause fix): a guild-default policy keyed by guild_id
+    is actually read by the resolver and yields a GUILD_OVERRIDE."""
+    from governance.cleanup import resolve_cleanup_policy
+    from governance.models import GovernanceContext, PolicySource
+    from services.cleanup_levels import cleanup_scope_id
+
+    sid = cleanup_scope_id("guild", _TEST_GUILD, None)
+    assert sid == _TEST_GUILD
+    await gov_db.set_cleanup_policy(_TEST_GUILD, "guild", sid, True, True, 2)
+
+    # A channel with no own/category override inherits the guild default.
+    ctx = GovernanceContext(guild_id=_TEST_GUILD, channel_id=999000111)
+    policy = await resolve_cleanup_policy(ctx)
+    assert policy.resolved_from == PolicySource.GUILD_OVERRIDE
+    assert policy.delete_after_seconds == 2
+
+
+async def test_legacy_guild_scope_zero_is_not_resolved(postgres_pool):
+    """The pre-fix convention (scope_id=0) is a silent no-op: the resolver looks
+    up guild policy at scope_id=guild_id, so a 0 row is never read.  Guards
+    against a regression back to 0."""
+    from governance.cleanup import resolve_cleanup_policy
+    from governance.models import GovernanceContext, PolicySource
+
+    await gov_db.set_cleanup_policy(_TEST_GUILD, "guild", 0, True, True, 2)
+    ctx = GovernanceContext(guild_id=_TEST_GUILD, channel_id=999000111)
+    policy = await resolve_cleanup_policy(ctx)
+    assert policy.resolved_from == PolicySource.FALLBACK_DEFAULT
+    assert policy.delete_after_seconds == 5

--- a/tests/unit/db/test_cleanup_policies_integration.py
+++ b/tests/unit/db/test_cleanup_policies_integration.py
@@ -1,0 +1,86 @@
+"""Real-Postgres integration for the cleanup-policy version marker (PR8).
+
+Migration 058 adds ``cleanup_policies.policy_version`` (NOT NULL DEFAULT 1). This
+suite drives it against a live database via ``utils.db.pool.init()`` (which
+applies the full schema + every migration, including 058), then asserts the
+observable behaviour: a legacy-shape insert that never mentions the column still
+gets version 1 (DEFAULT backfill), and the read model surfaces it.
+
+CI safety
+---------
+There is **no** shared Postgres fixture (``tests/conftest.py`` deliberately has
+none) and CI (``code-quality.yml``) runs **no** Postgres service. The
+module-local ``postgres_pool`` fixture below ``pytest.skip()``s cleanly when
+``DATABASE_URL`` is unset (CI) or the database is unreachable (sandbox before
+local Postgres is up), so this file is a no-op there and only runs where a real
+database is available. Canonical sibling: ``test_health_findings_integration.py``.
+
+Isolation
+---------
+Every row uses the ``_TEST_GUILD`` namespace; the fixture sweeps exactly that
+guild's rows before and after each test. Tests run serially (CI and
+``check_quality`` both invoke pytest without xdist), so this is safe.
+"""
+
+from __future__ import annotations
+
+import os
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from utils.db import governance as gov_db
+from utils.db import pool
+
+_TEST_GUILD = 800000000000000058
+
+
+async def _sweep() -> None:
+    await pool.execute(
+        "DELETE FROM cleanup_policies WHERE guild_id = $1",
+        (_TEST_GUILD,),
+    )
+
+
+@pytest_asyncio.fixture
+async def postgres_pool():
+    """Module-local live-Postgres pool; skips cleanly when none is available."""
+    if not os.environ.get("DATABASE_URL"):
+        pytest.skip("DATABASE_URL unset — real-Postgres integration test skipped (CI)")
+    try:
+        await pool.init()
+    except (OSError, asyncpg.PostgresError) as exc:
+        pytest.skip(
+            f"Postgres unreachable ({type(exc).__name__}) — integration test skipped",
+        )
+    await _sweep()
+    try:
+        yield pool
+    finally:
+        await _sweep()
+        await pool.close()
+
+
+async def test_legacy_insert_backfills_policy_version_to_one(postgres_pool):
+    """A legacy-shape write (the 3 columns, no policy_version) still resolves to
+    version 1 via the column DEFAULT — proving 058 applied and backfills."""
+    await gov_db.set_cleanup_policy(_TEST_GUILD, "guild", _TEST_GUILD, True, True, 5)
+
+    rows = await gov_db.get_all_cleanup_for_guild(_TEST_GUILD)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["policy_version"] == 1
+    assert row["scope_type"] == "guild"
+    assert row["delete_invalid_commands"] is True
+    assert row["delete_after_seconds"] == 5
+
+
+async def test_get_all_cleanup_returns_policy_version_per_scope(postgres_pool):
+    """The read model returns policy_version for every scope row."""
+    await gov_db.set_cleanup_policy(_TEST_GUILD, "guild", _TEST_GUILD, True, True, 5)
+    await gov_db.set_cleanup_policy(_TEST_GUILD, "channel", 111, True, False, 10)
+
+    rows = await gov_db.get_all_cleanup_for_guild(_TEST_GUILD)
+    assert {r["scope_type"] for r in rows} == {"guild", "channel"}
+    assert all(r.get("policy_version") == 1 for r in rows)

--- a/tests/unit/db/test_migration_058_cleanup_policy_version.py
+++ b/tests/unit/db/test_migration_058_cleanup_policy_version.py
@@ -1,0 +1,73 @@
+"""Static SQL-shape pins for migration 058 (server-management PR8).
+
+Mirrors ``test_migration_051_main_server_backfill.py`` /
+``test_migration_057_operational_health_findings.py``: we cannot run Postgres in
+unit CI (``tests/conftest.py`` has no DB fixture, ``code-quality.yml`` runs no
+Postgres service), but we CAN pin the *shape* of the schema change so a drive-by
+edit that turns the additive, behaviour-neutral column into something that
+touches the RC-5 CHECK, the primary key, or existing data fails here instead of
+silently in production.
+
+The live behaviour (column applies, existing rows backfill to 1, the reader
+returns it) is exercised against a real database in
+``test_cleanup_policies_integration.py`` (skipped when no Postgres is reachable).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MIGRATION = _REPO_ROOT / "disbot" / "migrations" / "058_cleanup_policy_version.sql"
+
+
+def _collapse(text: str) -> str:
+    """Collapse whitespace runs to a single space (line-wrap-insensitive)."""
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _migration_sql() -> str:
+    """Migration text with ``-- …`` line comments stripped, then collapsed."""
+    no_comments = "\n".join(
+        line.split("--", 1)[0] for line in _MIGRATION.read_text().splitlines()
+    )
+    return _collapse(no_comments)
+
+
+def test_migration_file_exists():
+    assert _MIGRATION.is_file(), f"{_MIGRATION} missing"
+
+
+def test_adds_policy_version_column_to_cleanup_policies():
+    """The migration adds exactly the ``policy_version`` column."""
+    sql = _migration_sql()
+    assert "ALTER TABLE cleanup_policies" in sql
+    assert "ADD COLUMN IF NOT EXISTS policy_version" in sql
+
+
+def test_policy_version_is_not_null_default_one():
+    """Existing rows must backfill to version 1 via the column DEFAULT, and the
+    column is NOT NULL so every row is self-describing."""
+    assert "policy_version INTEGER NOT NULL DEFAULT 1" in _migration_sql()
+
+
+def test_add_column_is_idempotent():
+    """``IF NOT EXISTS`` keeps the forward-only migration re-runnable; a bare
+    ``ADD COLUMN`` would abort the second apply and take boot down."""
+    sql = _migration_sql()
+    assert re.search(r"ADD COLUMN(?! IF NOT EXISTS)", sql) is None, (
+        "the policy_version ADD COLUMN must use IF NOT EXISTS"
+    )
+
+
+def test_migration_is_additive_only_preserving_rc5_and_pk():
+    """RC-5 + behaviour-identical guard: 058 must ONLY add a column — it must not
+    drop/redefine the scope_type CHECK or the primary key, nor mutate existing
+    rows. Any of those would change cleanup resolution or thread inheritance."""
+    sql = _migration_sql()
+    assert "DROP" not in sql, "058 must not DROP anything"
+    assert "CHECK" not in sql, "058 must not touch the scope_type CHECK (RC-5)"
+    assert "PRIMARY KEY" not in sql, "058 must not touch the primary key"
+    assert "UPDATE " not in sql, "058 must not UPDATE existing rows (DEFAULT backfills)"
+    assert "DELETE " not in sql, "058 must not DELETE rows"

--- a/tests/unit/governance/test_cleanup_resolution_behavior.py
+++ b/tests/unit/governance/test_cleanup_resolution_behavior.py
@@ -1,0 +1,85 @@
+"""Behaviour-identical pin for cleanup resolution (server-management PR8).
+
+PR8 adds a ``policy_version`` column + a level vocabulary but must NOT change how
+a stored policy resolves at runtime. These tests lock the current mapping so any
+future edit to ``governance/cleanup.py`` (or the level table) that would alter
+resolved behaviour fails here.
+
+Pinned facts (the resolver's current contract — preserved, not "fixed"):
+* ``delete_message`` derives ONLY from ``delete_invalid_commands``;
+  ``delete_failed_commands`` does not affect resolution and ``CleanupPolicy`` has
+  no field for it.
+* ``delete_after_seconds`` passes through unchanged; ``send_feedback`` is True for
+  an override; the source is the matched scope.
+* An extra ``policy_version`` key in the row is inert.
+* With no override and a non-whitelisted channel, the hardcoded default is
+  delete=True / 5s / FALLBACK_DEFAULT.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import governance.cleanup as cleanup_mod
+from governance.models import GovernanceContext, PolicySource
+from services.cleanup_levels import LEVELS
+
+
+def _ctx() -> GovernanceContext:
+    # channel_id set, no category/thread → scope chain = [channel, guild].
+    return GovernanceContext(guild_id=789, channel_id=123)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("level", list(LEVELS))
+async def test_each_level_resolves_to_stable_policy(level: str, monkeypatch):
+    cols = LEVELS[level]
+    fake_db = MagicMock()
+    fake_db.get_cleanup_policy = AsyncMock(return_value=dict(cols))
+    monkeypatch.setattr(cleanup_mod, "db", fake_db)
+
+    policy = await cleanup_mod.resolve_cleanup_policy(_ctx())
+
+    assert policy.delete_message == cols["delete_invalid_commands"]
+    assert policy.delete_after_seconds == cols["delete_after_seconds"]
+    assert policy.send_feedback is True
+    assert policy.resolved_from == PolicySource.CHANNEL_OVERRIDE
+
+
+@pytest.mark.asyncio
+async def test_extra_policy_version_key_is_inert(monkeypatch):
+    """A row carrying the new column resolves identically to one without it."""
+    row = {
+        "delete_invalid_commands": True,
+        "delete_failed_commands": True,
+        "delete_after_seconds": 5,
+        "policy_version": 1,
+    }
+    fake_db = MagicMock()
+    fake_db.get_cleanup_policy = AsyncMock(return_value=row)
+    monkeypatch.setattr(cleanup_mod, "db", fake_db)
+
+    policy = await cleanup_mod.resolve_cleanup_policy(_ctx())
+
+    assert policy.delete_message is True
+    assert policy.delete_after_seconds == 5
+    assert policy.resolved_from == PolicySource.CHANNEL_OVERRIDE
+
+
+@pytest.mark.asyncio
+async def test_no_override_falls_back_to_default(monkeypatch):
+    """No row + non-whitelisted channel → hardcoded compat default (unchanged)."""
+    fake_db = MagicMock()
+    fake_db.get_cleanup_policy = AsyncMock(return_value=None)
+    monkeypatch.setattr(cleanup_mod, "db", fake_db)
+    # Ensure the channel is not in the whitelist fallback.
+    monkeypatch.setattr(cleanup_mod._config, "CLEANUP_WHITELIST_CHANNELS", set())
+
+    policy = await cleanup_mod.resolve_cleanup_policy(_ctx())
+
+    assert policy.delete_message is True
+    assert policy.delete_after_seconds == 5
+    assert policy.send_feedback is True
+    assert policy.resolved_from == PolicySource.FALLBACK_DEFAULT

--- a/tests/unit/services/test_cleanup_diagnostics.py
+++ b/tests/unit/services/test_cleanup_diagnostics.py
@@ -1,0 +1,282 @@
+"""Tests for the cleanup-policy operator service (server-management PR9).
+
+Covers the read model (diagnostics), the side-effect-free dry-run preview, and
+the audited apply — all with a fake guild + mocked governance seams, so no
+Discord or DB is required.  The apply path's guild-scope keying (the PR9
+root-cause fix) is pinned here too.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+import services.cleanup_diagnostics as svc
+from governance.models import CleanupPolicy, PolicySource
+
+_GID = 789
+
+
+def _channel(name: str, category_id: int | None = None) -> MagicMock:
+    ch = MagicMock()
+    ch.name = name
+    ch.category_id = category_id
+    return ch
+
+
+def _guild(channels: dict[int, MagicMock] | None = None) -> MagicMock:
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = _GID
+    chans = channels or {}
+    guild.get_channel = lambda cid: chans.get(cid)
+    return guild
+
+
+def _row(scope_type, scope_id, inv, failed, after, version=1):
+    return {
+        "scope_type": scope_type,
+        "scope_id": scope_id,
+        "delete_invalid_commands": inv,
+        "delete_failed_commands": failed,
+        "delete_after_seconds": after,
+        "policy_version": version,
+    }
+
+
+def _patch_rows(monkeypatch, rows):
+    fake_db = MagicMock()
+    fake_db.get_all_cleanup_for_guild = AsyncMock(return_value=rows)
+    monkeypatch.setattr(svc, "gov_db", fake_db)
+
+
+def _policy(delete, after, source):
+    return CleanupPolicy(
+        delete_message=delete,
+        delete_after_seconds=after,
+        send_feedback=True,
+        resolved_from=source,
+    )
+
+
+# ---------------------------------------------------------------------------
+# collect_cleanup_diagnostics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_names_levels_and_counts(monkeypatch):
+    _patch_rows(
+        monkeypatch,
+        [
+            _row("guild", _GID, True, True, 5),  # Standard
+            _row("channel", 111, True, False, 10),  # Light
+            _row("channel", 222, True, False, 3),  # Custom (no preset)
+        ],
+    )
+    guild = _guild({111: _channel("general"), 222: _channel("memes")})
+
+    diag = await svc.collect_cleanup_diagnostics(guild)
+
+    by_id = {r.scope_id: r for r in diag.rows}
+    assert by_id[_GID].level_name == "Standard"
+    assert by_id[111].level_name == "Light"
+    assert by_id[222].level_name is None
+    assert by_id[222].display_level == "Custom"
+    assert diag.total == 3
+    assert diag.level_counts == {"Standard": 1, "Light": 1, "Custom": 1}
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_flags_stale_channel(monkeypatch):
+    _patch_rows(monkeypatch, [_row("channel", 999, True, True, 5)])
+    guild = _guild({})  # channel 999 deleted
+
+    diag = await svc.collect_cleanup_diagnostics(guild)
+
+    assert len(diag.stale_rows) == 1
+    stale = diag.stale_rows[0]
+    assert stale.is_stale is True
+    assert "deleted" in stale.target_label
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_flags_ineffective_legacy_guild_row(monkeypatch):
+    """A guild row keyed by 0 (the legacy bug) is flagged ineffective."""
+    _patch_rows(monkeypatch, [_row("guild", 0, True, True, 5)])
+    guild = _guild({})
+
+    diag = await svc.collect_cleanup_diagnostics(guild)
+
+    assert len(diag.ineffective_rows) == 1
+    assert diag.ineffective_rows[0].is_ineffective is True
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_guild_row_at_guild_id_is_effective(monkeypatch):
+    _patch_rows(monkeypatch, [_row("guild", _GID, True, True, 5)])
+    diag = await svc.collect_cleanup_diagnostics(_guild({}))
+    assert diag.ineffective_rows == ()
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_orders_guild_then_category_then_channel(monkeypatch):
+    _patch_rows(
+        monkeypatch,
+        [
+            _row("channel", 111, True, True, 5),
+            _row("guild", _GID, True, True, 5),
+            _row("category", 50, True, True, 5),
+        ],
+    )
+    guild = _guild({111: _channel("c"), 50: _channel("cat")})
+    diag = await svc.collect_cleanup_diagnostics(guild)
+    assert [r.scope_type for r in diag.rows] == ["guild", "category", "channel"]
+
+
+# ---------------------------------------------------------------------------
+# preview_cleanup_change (dry-run)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_detects_effect_change(monkeypatch):
+    # Currently inherits Off-ish (no delete); previewing Strict (delete, 2s).
+    monkeypatch.setattr(
+        svc,
+        "resolve_cleanup_policy",
+        AsyncMock(return_value=_policy(False, 0, PolicySource.FALLBACK_DEFAULT)),
+    )
+    guild = _guild({111: _channel("general", category_id=None)})
+
+    preview = await svc.preview_cleanup_change(guild, "channel", 111, "Strict")
+
+    assert preview.new_delete_message is True
+    assert preview.new_delete_after_seconds == 2
+    assert preview.will_change is True
+    assert preview.current_source == PolicySource.FALLBACK_DEFAULT
+
+
+@pytest.mark.asyncio
+async def test_preview_same_effect_but_pins_source_is_a_change(monkeypatch):
+    # Channel currently resolves Standard via the GUILD default (inherited).
+    monkeypatch.setattr(
+        svc,
+        "resolve_cleanup_policy",
+        AsyncMock(return_value=_policy(True, 5, PolicySource.GUILD_OVERRIDE)),
+    )
+    guild = _guild({111: _channel("general")})
+
+    preview = await svc.preview_cleanup_change(guild, "channel", 111, "Standard")
+
+    # Same effect (delete=True/5s) but it pins an explicit channel override.
+    assert preview.will_change is True
+    assert any("pins an explicit override" in w for w in preview.warnings)
+
+
+@pytest.mark.asyncio
+async def test_preview_no_change_when_same_override_present(monkeypatch):
+    # Channel already has its own Standard override.
+    monkeypatch.setattr(
+        svc,
+        "resolve_cleanup_policy",
+        AsyncMock(return_value=_policy(True, 5, PolicySource.CHANNEL_OVERRIDE)),
+    )
+    guild = _guild({111: _channel("general")})
+
+    preview = await svc.preview_cleanup_change(guild, "channel", 111, "Standard")
+
+    assert preview.will_change is False
+
+
+@pytest.mark.asyncio
+async def test_preview_warns_on_stale_scope(monkeypatch):
+    monkeypatch.setattr(
+        svc,
+        "resolve_cleanup_policy",
+        AsyncMock(return_value=_policy(True, 5, PolicySource.GUILD_OVERRIDE)),
+    )
+    guild = _guild({})  # channel 999 deleted
+
+    preview = await svc.preview_cleanup_change(guild, "channel", 999, "Light")
+
+    assert any("no longer exists" in w for w in preview.warnings)
+
+
+@pytest.mark.asyncio
+async def test_preview_writes_nothing(monkeypatch):
+    """Dry-run must never call the write path."""
+    monkeypatch.setattr(
+        svc,
+        "resolve_cleanup_policy",
+        AsyncMock(return_value=_policy(True, 5, PolicySource.GUILD_OVERRIDE)),
+    )
+    writer = AsyncMock()
+    monkeypatch.setattr(svc, "set_cleanup_policy_for_scope", writer)
+
+    await svc.preview_cleanup_change(_guild({111: _channel("g")}), "channel", 111, "Off")
+
+    writer.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# apply_cleanup_change
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_guild_scope_keys_on_guild_id(monkeypatch):
+    """The root-cause fix: guild apply writes scope_id=guild_id, not 0."""
+    writer = AsyncMock()
+    monkeypatch.setattr(svc, "set_cleanup_policy_for_scope", writer)
+    member = MagicMock(spec=discord.Member)
+
+    await svc.apply_cleanup_change(_guild({}), member, "guild", None, "Standard")
+
+    writer.assert_awaited_once()
+    ctx_arg, scope_type, scope_id = writer.await_args.args
+    assert scope_type == "guild"
+    assert scope_id == _GID  # guild_id, not 0
+    assert ctx_arg.guild_id == _GID
+    assert ctx_arg.member is member
+    kwargs = writer.await_args.kwargs
+    assert kwargs["delete_invalid_commands"] is True
+    assert kwargs["delete_failed_commands"] is True
+    assert kwargs["delete_after_seconds"] == 5
+
+
+@pytest.mark.asyncio
+async def test_apply_channel_scope_passes_snowflake(monkeypatch):
+    writer = AsyncMock()
+    monkeypatch.setattr(svc, "set_cleanup_policy_for_scope", writer)
+    member = MagicMock(spec=discord.Member)
+
+    await svc.apply_cleanup_change(_guild({}), member, "channel", 555, "Off")
+
+    _ctx, scope_type, scope_id = writer.await_args.args
+    assert scope_type == "channel"
+    assert scope_id == 555
+    assert writer.await_args.kwargs["delete_after_seconds"] == 0
+
+
+@pytest.mark.asyncio
+async def test_apply_rejects_thread_scope(monkeypatch):
+    writer = AsyncMock()
+    monkeypatch.setattr(svc, "set_cleanup_policy_for_scope", writer)
+    with pytest.raises(ValueError, match="thread"):
+        await svc.apply_cleanup_change(
+            _guild({}), MagicMock(spec=discord.Member), "thread", 1, "Off",
+        )
+    writer.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_apply_rejects_unknown_level(monkeypatch):
+    writer = AsyncMock()
+    monkeypatch.setattr(svc, "set_cleanup_policy_for_scope", writer)
+    with pytest.raises(ValueError, match="level"):
+        await svc.apply_cleanup_change(
+            _guild({}), MagicMock(spec=discord.Member), "guild", None, "Nuclear",
+        )
+    writer.assert_not_called()

--- a/tests/unit/services/test_cleanup_levels.py
+++ b/tests/unit/services/test_cleanup_levels.py
@@ -1,0 +1,59 @@
+"""Cleanup-level vocabulary: presets, the columns↔level round-trip, version.
+
+``services.cleanup_levels`` is the single source of truth mapping operator-facing
+cleanup levels (Off/Light/Standard/Strict) to ``cleanup_policies`` column values.
+PR8 adds the inverse (:func:`level_for_columns`) so the read model / diagnostics
+can name a stored policy row back to its level, plus the ``POLICY_VERSION`` marker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.cleanup_levels import (
+    LEVELS,
+    POLICY_VERSION,
+    columns_for_level,
+    known_level_names,
+    level_for_columns,
+)
+
+
+def test_known_level_names_matches_levels():
+    assert known_level_names() == frozenset(LEVELS)
+
+
+def test_policy_version_is_one():
+    """v1 is the only shipped policy shape (no dimensioned policies yet)."""
+    assert POLICY_VERSION == 1
+
+
+def test_preset_column_tuples_are_distinct():
+    """level_for_columns relies on each preset having a unique column tuple."""
+    tuples = {
+        (
+            c["delete_invalid_commands"],
+            c["delete_failed_commands"],
+            c["delete_after_seconds"],
+        )
+        for c in LEVELS.values()
+    }
+    assert len(tuples) == len(LEVELS)
+
+
+@pytest.mark.parametrize("name", list(LEVELS))
+def test_round_trip_each_level(name: str):
+    """columns_for_level → level_for_columns returns the original level name."""
+    assert level_for_columns(**columns_for_level(name)) == name
+
+
+def test_level_for_columns_returns_none_for_custom():
+    """A column combination matching no preset is reported as None (custom)."""
+    assert (
+        level_for_columns(
+            delete_invalid_commands=True,
+            delete_failed_commands=False,
+            delete_after_seconds=3,  # not any preset's delete_after
+        )
+        is None
+    )

--- a/tests/unit/services/test_cleanup_levels.py
+++ b/tests/unit/services/test_cleanup_levels.py
@@ -13,6 +13,7 @@ import pytest
 from services.cleanup_levels import (
     LEVELS,
     POLICY_VERSION,
+    cleanup_scope_id,
     columns_for_level,
     known_level_names,
     level_for_columns,
@@ -57,3 +58,20 @@ def test_level_for_columns_returns_none_for_custom():
         )
         is None
     )
+
+
+def test_cleanup_scope_id_guild_uses_guild_id():
+    """Guild scope must key on guild_id (the resolver's lookup), NOT 0."""
+    assert cleanup_scope_id("guild", guild_id=789, scope_id=None) == 789
+    # Even if a (legacy) scope_id is supplied, guild scope normalises to guild_id.
+    assert cleanup_scope_id("guild", guild_id=789, scope_id=0) == 789
+
+
+def test_cleanup_scope_id_channel_category_use_snowflake():
+    assert cleanup_scope_id("channel", guild_id=789, scope_id=123) == 123
+    assert cleanup_scope_id("category", guild_id=789, scope_id=456) == 456
+
+
+def test_cleanup_scope_id_requires_id_for_non_guild():
+    with pytest.raises(ValueError, match="scope_id"):
+        cleanup_scope_id("channel", guild_id=789, scope_id=None)

--- a/tests/unit/services/test_setup_operations_cleanup_and_routing.py
+++ b/tests/unit/services/test_setup_operations_cleanup_and_routing.py
@@ -122,7 +122,10 @@ async def test_set_cleanup_policy_routes_through_governance_writer():
     # Positional args: ctx, scope_type, scope_id.
     ctx_arg, scope_type, scope_id = writer.await_args.args
     assert scope_type == "guild"
-    assert scope_id == 0  # guild scope uses 0 (column is NOT NULL)
+    # Guild scope is keyed by guild_id (NOT 0): the resolver looks up guild
+    # policy at scope_id=guild_id, so 0 was a silent no-op.  See
+    # services.cleanup_levels.cleanup_scope_id.
+    assert scope_id == 1  # == _guild().id
     assert ctx_arg.guild_id == 1
     assert ctx_arg.member is not None  # actor passed through
 

--- a/tests/unit/views/cleanup/test_policy_panel.py
+++ b/tests/unit/views/cleanup/test_policy_panel.py
@@ -1,0 +1,255 @@
+"""Tests for the cleanup-policy operator panel view (server-management PR9).
+
+The heavy logic lives in services.cleanup_diagnostics (tested separately); here
+we pin the view wiring: embeds render, the admin re-check gates the builder and
+the apply, the dry-run never writes, and confirm routes to the audited apply.
+``discord.ui.Select.values`` falls back to ``self._values``, so we drive select
+callbacks by setting that backing list.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+import views.cleanup.policy_panel as panel
+from governance.models import CleanupPolicy, PolicySource
+from services.cleanup_diagnostics import (
+    CleanupDiagnostics,
+    CleanupPolicyPreview,
+    CleanupScopeRow,
+)
+from services.governance_exceptions import GovernanceError
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _row(**kw):
+    base = dict(
+        scope_type="channel",
+        scope_id=111,
+        level_name="Light",
+        delete_invalid_commands=True,
+        delete_failed_commands=False,
+        delete_after_seconds=10,
+        policy_version=1,
+        target_label="#general",
+        is_stale=False,
+        is_ineffective=False,
+    )
+    base.update(kw)
+    return CleanupScopeRow(**base)
+
+
+def _preview(will_change=True, warnings=()):
+    return CleanupPolicyPreview(
+        scope_type="channel",
+        scope_id=111,
+        target_label="#general",
+        level="Strict",
+        new_delete_message=True,
+        new_delete_after_seconds=2,
+        current=CleanupPolicy(
+            delete_message=False,
+            delete_after_seconds=0,
+            send_feedback=True,
+            resolved_from=PolicySource.FALLBACK_DEFAULT,
+        ),
+        will_change=will_change,
+        warnings=tuple(warnings),
+    )
+
+
+def _interaction(admin: bool = True):
+    it = MagicMock(spec=discord.Interaction)
+    it.user = MagicMock()
+    perms = MagicMock()
+    perms.administrator = admin
+    it.user.guild_permissions = perms
+    it.guild = MagicMock()
+    it.guild.id = 42
+    it.response = MagicMock()
+    it.response.send_message = AsyncMock()
+    it.response.edit_message = AsyncMock()
+    return it
+
+
+def test_diagnostics_embed_empty():
+    diag = CleanupDiagnostics(guild_id=42, rows=(), level_counts={})
+    embed = panel.diagnostics_embed_from(diag)
+    text = " ".join(f.value for f in embed.fields)
+    assert "None" in text
+
+
+def test_diagnostics_embed_lists_rows_and_flags():
+    diag = CleanupDiagnostics(
+        guild_id=42,
+        rows=(
+            _row(scope_type="guild", scope_id=0, target_label="Guild default",
+                 level_name="Standard", is_ineffective=True),
+            _row(scope_type="channel", scope_id=999, target_label="channel 999 (deleted)",
+                 is_stale=True),
+        ),
+        level_counts={"Standard": 1, "Light": 1},
+    )
+    embed = panel.diagnostics_embed_from(diag)
+    names = [f.name for f in embed.fields]
+    assert any("Ineffective" in n for n in names)
+    assert any("Stale" in n for n in names)
+
+
+def test_preview_embed_change_shows_warnings():
+    embed = panel.preview_embed_from(_preview(will_change=True, warnings=("watch out",)))
+    assert any("watch out" in f.value for f in embed.fields)
+
+
+def test_preview_embed_no_change_field():
+    embed = panel.preview_embed_from(_preview(will_change=False))
+    assert any("No change" in f.name for f in embed.fields)
+
+
+# ---------------------------------------------------------------------------
+# CleanupPolicyPanelView buttons
+# ---------------------------------------------------------------------------
+
+
+def _btn(view, custom_id):
+    return next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == custom_id
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_button_requires_admin():
+    view = panel.CleanupPolicyPanelView(MagicMock(), MagicMock())
+    it = _interaction(admin=False)
+    await _btn(view, "cleanup_policy:build").callback(it)
+    it.response.send_message.assert_awaited_once()
+    assert "Administrator" in it.response.send_message.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_build_button_admin_opens_scope_select():
+    guild = MagicMock()
+    view = panel.CleanupPolicyPanelView(MagicMock(), guild)
+    it = _interaction(admin=True)
+    await _btn(view, "cleanup_policy:build").callback(it)
+    it.response.send_message.assert_awaited_once()
+    sent_view = it.response.send_message.call_args.kwargs["view"]
+    assert any(isinstance(c, panel._ScopeSelect) for c in sent_view.children)
+
+
+@pytest.mark.asyncio
+async def test_refresh_button_rerenders_diagnostics():
+    guild = MagicMock()
+    view = panel.CleanupPolicyPanelView(MagicMock(), guild)
+    it = _interaction()
+    fake_embed = discord.Embed(title="diag")
+    with patch.object(
+        panel, "build_cleanup_diagnostics_embed", AsyncMock(return_value=fake_embed),
+    ):
+        await _btn(view, "cleanup_policy:refresh").callback(it)
+    it.response.edit_message.assert_awaited_once()
+    assert it.response.edit_message.call_args.kwargs["embed"] is fake_embed
+    assert it.response.edit_message.call_args.kwargs["view"] is view
+
+
+# ---------------------------------------------------------------------------
+# Builder selects
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scope_select_guild_opens_level_select():
+    sel = panel._ScopeSelect(MagicMock())
+    sel._values = ["guild"]
+    it = _interaction()
+    await sel.callback(it)
+    sent_view = it.response.send_message.call_args.kwargs["view"]
+    assert any(isinstance(c, panel._LevelSelect) for c in sent_view.children)
+
+
+@pytest.mark.asyncio
+async def test_level_select_previews_without_writing():
+    sel = panel._LevelSelect(MagicMock(), "channel", 111, "#general")
+    sel._values = ["Strict"]
+    it = _interaction()
+    with (
+        patch.object(panel, "preview_cleanup_change", AsyncMock(return_value=_preview())),
+        patch.object(panel, "apply_cleanup_change", AsyncMock()) as applier,
+    ):
+        await sel.callback(it)
+    it.response.send_message.assert_awaited_once()
+    assert isinstance(
+        it.response.send_message.call_args.kwargs["view"], panel._ConfirmApplyView,
+    )
+    applier.assert_not_called()  # dry-run only
+
+
+# ---------------------------------------------------------------------------
+# Confirm + apply
+# ---------------------------------------------------------------------------
+
+
+def _confirm_btn(view, label):
+    return next(
+        c for c in view.children if isinstance(c, discord.ui.Button) and c.label == label
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_button_requires_admin():
+    view = panel._ConfirmApplyView(MagicMock(), MagicMock(), _preview())
+    it = _interaction(admin=False)
+    with patch.object(panel, "apply_cleanup_change", AsyncMock()) as applier:
+        await _confirm_btn(view, "✅ Apply").callback(it)
+    applier.assert_not_called()
+    it.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_apply_button_admin_calls_service():
+    guild = MagicMock()
+    view = panel._ConfirmApplyView(MagicMock(), guild, _preview())
+    it = _interaction(admin=True)
+    with patch.object(panel, "apply_cleanup_change", AsyncMock()) as applier:
+        await _confirm_btn(view, "✅ Apply").callback(it)
+    applier.assert_awaited_once()
+    args = applier.await_args.args
+    # (guild, member, scope_type, scope_id, level)
+    assert args[0] is guild
+    assert args[2] == "channel"
+    assert args[3] == 111
+    assert args[4] == "Strict"
+    it.response.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_apply_button_surfaces_governance_error():
+    view = panel._ConfirmApplyView(MagicMock(), MagicMock(), _preview())
+    it = _interaction(admin=True)
+    with patch.object(
+        panel,
+        "apply_cleanup_change",
+        AsyncMock(side_effect=GovernanceError("nope")),
+    ):
+        await _confirm_btn(view, "✅ Apply").callback(it)
+    it.response.edit_message.assert_awaited_once()
+    assert "nope" in it.response.edit_message.call_args.kwargs["content"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_button_writes_nothing():
+    view = panel._ConfirmApplyView(MagicMock(), MagicMock(), _preview())
+    it = _interaction(admin=True)
+    with patch.object(panel, "apply_cleanup_change", AsyncMock()) as applier:
+        await _confirm_btn(view, "✖ Cancel").callback(it)
+    applier.assert_not_called()
+    it.response.edit_message.assert_awaited_once()
+    assert "Cancelled" in it.response.edit_message.call_args.kwargs["content"]


### PR DESCRIPTION
## Summary

Server-management cleanup **PR8 + PR9** (one branch, sequential commits — the established one-PR-per-session pattern). **Presets-only (lean)** per maintainer decision: every write maps to the existing three `cleanup_policies` columns through the **unchanged** governance pipeline. Diagnostics live on the **dedicated cleanup panel** via an **async** read-only helper. Plus a root-cause bug fix discovered while building PR9.

### PR8 — cleanup policy versioning marker (behaviour-neutral) · `fbdb3c4`
- Migration `058`: additive `cleanup_policies.policy_version INTEGER NOT NULL DEFAULT 1` (`IF NOT EXISTS`, idempotent). Existing rows backfill to 1; **PK + RC-5 `scope_type` CHECK untouched**; the resolver is unchanged, so resolved cleanup behaviour is **byte-identical**.
- `services/cleanup_levels.py`: `level_for_columns()` (inverse of `columns_for_level`) + `POLICY_VERSION`.
- `utils/db/governance.py`: `get_all_cleanup_for_guild()` now returns `policy_version` for the read model.

### PR9 — builder + dry-run + dedicated-panel diagnostics · `2b72f3c`
- `services/cleanup_diagnostics.py` (async, presets-only): `collect_cleanup_diagnostics` (per-scope level naming, **stale-scope** + **ineffective-row** detection), `preview_cleanup_change` (**side-effect-free dry-run via the real resolver**, so preview == runtime), `apply_cleanup_change` (audited apply through the unchanged pipeline → DB + governance audit + `EVT_CLEANUP_CHANGED` + `EVT_CACHE_INVALIDATED`).
- `views/cleanup/policy_panel.py`: diagnostics view + presets builder (scope → level → dry-run preview → confirm → apply), admin re-check at the mutation point; nothing written on preview/cancel.
- `cogs/cleanup/panel.py`: "🧹 Cleanup Policies" button into the hub.

### Root-cause fix (found while building, maintainer chose "fix now")
The setup wizard wrote guild-default cleanup at `scope_id=0`, but the resolver looks up guild policy at `scope_id=guild_id` (`_build_scope_chain` maps guild → `ctx.guild_id`) — so **guild-default cleanup chosen in setup never took effect** (channel/category were fine). Verified live against Postgres.
- Centralised the write-side convention in `cleanup_levels.cleanup_scope_id()` (single source of truth) and fixed `setup_operations._apply_set_cleanup_policy`. `cog_routing`'s separate guild→`NULL` convention is untouched.
- The old test asserted `scope_id == 0` — it had **encoded the bug**; updated, plus a real-Postgres regression test proving guild-default now resolves to `GUILD_OVERRIDE` and a guard that legacy `scope_id=0` is a no-op.

### Scope note (divergence from the implementation plan)
The plan's PR8 JSONB "dimensions" column is **deferred** (no consumer yet) — only `policy_version` shipped. Diagnostics flag legacy `scope_id=0` guild rows as **ineffective** so operators can re-set them.

## Testing
- `python3.10 scripts/check_architecture.py --mode strict` → **0 errors**.
- `python3.10 scripts/check_quality.py --full` → **green (7649 passed)**.
- New unit tests: migration static-shape pin; `cleanup_levels` round-trip + `cleanup_scope_id`; resolver per-level + fallback behaviour pin; `cleanup_diagnostics` service (diagnostics/preview/apply incl. guild-scope keying); policy-panel view wiring (admin gate, dry-run-no-write, confirm→apply, error surfacing); cleanup hub button.
- **Live Postgres** (sandbox): `058` applies + backfills; guild-default fix resolves; legacy `scope_id=0` confirmed no-op; diagnostics + preview verified end-to-end. Real-PG integration tests skip cleanly in CI (no DB).

## Docs
`current-state.md`, the server-management tracker (PR8/PR9 shipped; queue → PR10), the folio, and the session journal are updated.

https://claude.ai/code/session_016mNZRTPmSV4cAbWbK5xFfU

---
_Generated by [Claude Code](https://claude.ai/code/session_016mNZRTPmSV4cAbWbK5xFfU)_