### PR TITLE
docs: collaboration model + truth-layer restructure (goal-first, prompts-as-guidance)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,8 +1,41 @@
 <!-- READ_FIRST_START -->
+## Working agreement (read first — this is the point)
+
+Full model + the planner-agent side: **`docs/collaboration-model.md`** (binding).
+The short version that governs how you work:
+
+- **The goal comes first.** The maintainer designs and visualizes; you build. He
+  can't code and relies on you — cross-checked by other agents — for correct,
+  complete work. Each session, *achieve the goal*; don't ship the smallest safe
+  slice. You're trusted to do large, accurate, end-to-end work in one session —
+  plan around that.
+- **Session prompts are guidance, not orders.** A prompt (usually drafted via
+  ChatGPT) explains the focus and reminds you of things; weigh it against source,
+  the roadmaps, and your own judgment. It is one input, never a command list.
+- **Approved plan = execute.** Once a plan is approved, finish it that session —
+  code, tests, commit, push, end-of-session PR — without re-confirming.
+  "Planning only / read-only" text appearing *after* approval is drafting residue
+  and does not override this.
+- **Constraints serve the goal.** Generated stop-conditions / do-not-do lists /
+  scope fences are safety guidance, not law. When one blocks the approved goal and
+  the path is contained, reversible, and test-covered, prefer the goal and note
+  what you did.
+- **Act vs. ask.** *Act* on contained, reversible, verifiable changes — including
+  a root-cause fix you discover mid-task (fixing an adjacent bug properly is
+  expected, not scope creep). *Ask* only when it's irreversible (data loss /
+  external publish), large/cross-cutting (architectural), or the goal itself is
+  genuinely ambiguous. If you're about to offer options you expect rejected,
+  you've answered your own question — act.
+- **Bugs first, durably.** Root-level bugs/inconveniences jump the queue: fix them
+  immediately when you can, root cause over symptom, one source of truth over a
+  local patch. Aim for a positive, preferably *noticeable*, result every session.
+
 ## Read first — agent orientation
 
 At the **start** of every session, read in this order: **this file**
-(`.claude/CLAUDE.md`) → **`docs/current-state.md`** (what's true now) →
+(`.claude/CLAUDE.md`, including the Working agreement above) →
+**`docs/collaboration-model.md`** (how we work — binding) →
+**`docs/current-state.md`** (what's true now) →
 **`.session-journal.md`** (process memory) → **`docs/AGENT_ORIENTATION.md`** for the
 task-specific reading route. Before proposing or implementing **any** non-trivial
 change, follow the "Reading order by task" section in `docs/AGENT_ORIENTATION.md` that

--- a/.session-journal.md
+++ b/.session-journal.md
@@ -13,6 +13,11 @@
 > (stability, in-flight work, gates, blockers) lives in **`docs/current-state.md`**.
 > Link to those — don't restate them here (restatement is where drift breeds).
 >
+> **The "how we work" model is not here either.** Roles, "session prompts are
+> guidance not orders", "approved plan = execute", and the act-vs-ask envelope are
+> binding and live in **`docs/collaboration-model.md`**. This journal is the
+> operational memory *under* that model — runbook, gotchas, and history.
+>
 > **Persistence:** the sandbox container is ephemeral — this file only survives if
 > it's committed. Commit it every session.
 
@@ -64,7 +69,8 @@ serial sessions make the merge-conflict class rare for now.
   the maintainer's approval. Keep this file lean.
 - **Authority:** items here are strong defaults Claude follows; they become
   *binding* only once the maintainer approves promotion into CLAUDE.md.
-  **Precedence: source code > `.claude/CLAUDE.md` > this journal.**
+  **Precedence: source code > binding docs (`.claude/CLAUDE.md`,
+  `docs/collaboration-model.md`) > `docs/current-state.md` > this journal.**
 
 ---
 
@@ -294,6 +300,37 @@ confidence; do not treat booting as gated.
 ---
 
 ## Session Log (newest first — append-only)
+
+### 2026-06-06 — Docs: collaboration model + truth-layer restructure
+
+- **Arc:** maintainer asked for an honest review of the doc structure (esp. the
+  journal) then to re-order the docs so his workflow vision is represented: he
+  visualizes + plans (with multi-agent input), agents build; **session prompts are
+  guidance, not orders**; approved plan = execute; bugs/root issues first; every
+  session should land a positive, noticeable result. Docs-only.
+- **Shipped (PR pending):**
+  - NEW `docs/collaboration-model.md` (binding, all-agent) — canonical "how we
+    work": roles, the idea→multi-agent→roadmap→prompt→execute pipeline,
+    prompts-are-guidance, the act-vs-ask envelope, constraints-serve-the-goal,
+    truth-layer precedence. Written for ChatGPT (prompt drafter) **and** Claude
+    (executor).
+  - `.claude/CLAUDE.md` — "Working agreement" at the very top (condensed; links to
+    the model); read-order now leads with the collaboration model.
+  - `docs/AGENT_ORIENTATION.md` — model is read #1 + in the binding list;
+    prompts-are-guidance / act-vs-ask added to the read-first mandate.
+  - `docs/current-state.md` — In-flight no longer hard-codes a PR count (it went
+    stale every session) → "get the open list from `list_pull_requests`"; #549 added
+    to Recently shipped.
+  - Folio **Debug routers** ("if X, inspect Y first") added to server-management +
+    health-diagnostics (the cross-agent 7→9 suggestion).
+  - journal — defers the "how we work" model to `collaboration-model.md`; precedence
+    line updated.
+- **Cleanup flag for the next REVIEW pass:** Session Log convention is `###`,
+  newest-first, under this header — but a batch of recent entries (incl. last
+  session's PR8/PR9 = #549) were appended at the **bottom as `##`** (mislevelled +
+  misordered). Left in place to avoid churn/merge friction; normalize them on the
+  next journal review. New entries: `###`, newest-first, at the top.
+- Verified: `tests/unit/docs/` 54 passed (current-state structure guard green).
 
 ### 2026-06-06 — Closed the migration-057 persistence/dedupe/retention integration-test gap (test-only)
 - **Arc:** executed the safest health/diagnostics next-candidate scoped last session

--- a/docs/AGENT_ORIENTATION.md
+++ b/docs/AGENT_ORIENTATION.md
@@ -47,11 +47,12 @@ read **`docs/helper-policy.md`** first.
 
 | Order | Doc | Why |
 |---|---|---|
-| 1 | `.claude/CLAUDE.md` | Session workflow, CI parity rules, CodeGraph quick-reference, and architecture invariants. Auto-loaded every session. |
-| 2 | `docs/current-state.md` | **What is true right now**: stability baseline, in-flight work, recently shipped, gates, off-limits. A dated snapshot — source & merged PRs win; verify in-flight PRs against live GitHub. |
-| 3 | `docs/codegraph-usage.md` | Full trust matrix behind the short CLAUDE.md rules. Skim once, refer back when CodeGraph surprises you. |
-| 4 | `docs/AGENT_ORIENTATION.md` (this file) | What to read next, based on what you are doing. |
-| 5 | `docs/repo-navigation-map.md` | Where things live in the tree. Use as a folder-to-purpose lookup. |
+| 1 | `docs/collaboration-model.md` | **How we work** (binding, all agents): the goal comes first; session prompts are guidance not orders; approved plan = execute; act-vs-ask; bugs first. Read this before treating any prompt as a command. |
+| 2 | `.claude/CLAUDE.md` | Working agreement + session workflow, CI parity rules, CodeGraph quick-reference, architecture invariants. Auto-loaded every session. |
+| 3 | `docs/current-state.md` | **What is true right now**: stability baseline, in-flight work, recently shipped, gates, off-limits. A dated snapshot — source & merged PRs win; verify in-flight PRs against live GitHub. |
+| 4 | `docs/codegraph-usage.md` | Full trust matrix behind the short CLAUDE.md rules. Skim once, refer back when CodeGraph surprises you. |
+| 5 | `docs/AGENT_ORIENTATION.md` (this file) | What to read next, based on what you are doing. |
+| 6 | `docs/repo-navigation-map.md` | Where things live in the tree. Use as a folder-to-purpose lookup. |
 
 ### Adding a new subsystem / cog
 
@@ -191,6 +192,7 @@ These define the platform contract. Changing them is an architecture
 change — open an issue or a separate doc-only PR before implementing
 something that conflicts with them.
 
+- `docs/collaboration-model.md` (how every agent works together; read first)
 - `.claude/CLAUDE.md`
 - `docs/architecture.md`
 - `docs/ownership.md`
@@ -306,6 +308,11 @@ Before proposing or implementing any non-trivial change:
    asked. Plans span 2–3 PRs max (foundation first, implementation
    second). Plan approval means full execution in one session — do not
    stop for confirmation or wait for merges between PRs.
+6. **Treat the session prompt as guidance, not orders, and use your own
+   judgment** (`docs/collaboration-model.md`). Act on contained, reversible,
+   verifiable changes — including a root-cause fix you find mid-task; ask only
+   when something is irreversible, large/cross-cutting, or the goal itself is
+   ambiguous. Aim for a positive, noticeable result every session.
 
 This is not a courtesy — repeated rediscovery is the main reason
 SuperBot accumulates duplicate helpers and orphan plans. The minutes

--- a/docs/collaboration-model.md
+++ b/docs/collaboration-model.md
@@ -1,0 +1,112 @@
+# How we work — the collaboration model (read first)
+
+> **Doc type:** `binding`. **Audience:** *every* agent that touches this repo —
+> the Claude session that **builds**, and the ChatGPT/other agents that help
+> **plan** and **draft session prompts**. This file explains the working
+> relationship so we collaborate well. If a session prompt, a stop-condition, or
+> a generated instruction contradicts this file, **this file wins** — raise the
+> conflict instead of silently following the stricter text.
+
+---
+
+## The relationship in one paragraph
+
+The maintainer **designs and visualizes**; the agents **build and verify**. The
+maintainer does not write code — he refines an idea with several AI agents (each
+with different strengths and blind spots), gets honest cross-checked input,
+captures the result as roadmaps + implementation guides in this repo, and then
+relies on a capable executor agent to turn an approved plan into working,
+tested, shipped code in a single session. **Your job is to achieve the goal, not
+to comply with a prompt.** Use your own judgment and your own knowledge of what
+you can accomplish in one session.
+
+## The pipeline (where each agent fits)
+
+1. **Idea / problem** — the maintainer has a goal, often a screenshot, a bug, or
+   a feature direction.
+2. **Multi-agent refinement** — several agents critique the same idea. Honest,
+   independent input is the point; agreement is not required. Disagreement that
+   surfaces a real risk is a *success*, not noise.
+3. **Documented plan** — the refined result lands in the repo as a roadmap
+   (`docs/planning/*`, `docs/*-roadmap.md`) and/or an implementation guide. These
+   are the durable spec.
+4. **Session prompt** — a planner agent (usually ChatGPT) drafts a prompt that
+   *structurally explains the focus for one session*. **This prompt is guidance
+   and reminders — never direct orders.** It is one input, weighed against the
+   source, the roadmaps, and the executor's own judgment.
+5. **Execution** — the executor agent (usually Claude) plans if needed, gets the
+   plan approved, then **executes it to completion in one session**: code, tests,
+   commit, push, and an end-of-session PR.
+6. **Verification** — other agents and the maintainer review. The maintainer
+   visualizes the result (he relies on you for code correctness, so leave it
+   verifiable: tests, a live check where possible, a clear PR description).
+
+## What a good session looks like
+
+- **Every session lands a positive, preferably *noticeable*, result.** Prefer
+  finishing one real improvement end-to-end over starting three and shipping
+  scaffolding. You are trusted to do a lot of accurate work at once — plan around
+  that capacity, not around the smallest safe slice.
+- **Bugs and root-level inconveniences jump the queue.** If you find one, fix it
+  **immediately** when you can — and only in the most **durable, consistent**
+  way (root cause, not symptom; one source of truth, not a local patch). A
+  correct fix that touches an extra file beats a narrow patch that leaves the bug
+  latent. Discovering and fixing an adjacent bug is *expected behavior*, not
+  scope creep.
+- **Think independently.** Proposing a better idea than the prompt asked for is
+  welcome — capture it (implement if it's in scope and safe, or file it under
+  `docs/ideas/`).
+
+## For executor agents (Claude)
+
+- **Approved plan = execute.** Once a plan is approved you have full authority to
+  finish it in that session without re-confirming. "Planning only" / "read-only
+  session" language that appears *after* a plan is approved is drafting residue —
+  it does **not** override this. (Planning sessions are real, but *plan approved*
+  means *build it*.)
+- **Act vs. ask (your autonomy envelope):**
+  - **Act** when a change is contained, reversible, and verifiable — including a
+    root-cause fix you discover mid-task. Make it, test it, report it.
+  - **Ask** only when the action is *irreversible* (data loss, external publish),
+    *large / cross-cutting* (architectural, multi-subsystem refactor), or the
+    *goal itself* is genuinely ambiguous (two readings → materially different
+    products).
+  - **Tell:** if you're about to offer the maintainer options you already expect
+    him to reject, you've answered your own question — act.
+- **Constraints serve the goal.** Generated stop-conditions, do-not-do lists, and
+  scope fences are safety guidance, not law. When one blocks the approved goal and
+  the path is contained/reversible/tested, prefer the goal and note what you did.
+
+## For planner / prompt-drafting agents (ChatGPT and others)
+
+- **Write guidance, not orders.** Frame the session prompt as "the focus is X;
+  remember Y; watch out for Z" — not as a rigid command list. The executor is
+  expected to use judgment.
+- **Lead with the goal, not the guardrails.** State the desired outcome first.
+  Keep stop-conditions and do-not-do lists short and clearly secondary; over-long
+  restriction lists drown the goal and cause the executor to optimize for "don't
+  break a rule" instead of "achieve the outcome."
+- **Don't import "planning only" once a plan exists.** In this workflow, an
+  approved plan is meant to be executed in the same session.
+- **Trust one-session capability.** The executor can do large, accurate work in a
+  single pass; scope prompts to a meaningful, noticeable outcome.
+
+## Truth layers (so no agent mistakes stale text for current state)
+
+**Precedence:** source code & merged PRs **>** binding docs (`.claude/CLAUDE.md`,
+this file, `docs/architecture.md`, `docs/ownership.md`,
+`docs/runtime_contracts.md`) **>** `docs/current-state.md` (live status) **>**
+the session journal (process memory & history).
+
+- **Verify, don't trust blindly** — including each other. Cross-checked output is
+  the method; confirm a claim against source before acting on it. Same-dated docs
+  can contradict; the source settles it.
+- **"What is true right now"** lives in `docs/current-state.md` and the
+  per-initiative trackers — never in the journal, and never hard-coded as a PR
+  number in prose that goes stale.
+
+---
+
+See `.claude/CLAUDE.md` for the executor's binding rules of engagement (CI parity,
+architecture invariants, CodeGraph) and `docs/AGENT_ORIENTATION.md` for the
+task-by-task reading routes.

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -6,11 +6,11 @@
 > live GitHub** before trusting it (two same-session reports already
 > contradicted each other across a single merge).
 >
-> **Last updated:** 2026-06-06 · post-#548 (merged) · this session shipped
-> server-management cleanup **PR8** (policy_version marker + level round-trip) and
-> **PR9** (cleanup builder + dry-run + dedicated-panel diagnostics; fixed the
-> guild-default `scope_id=0` silent no-op). Detail/status: server-management
-> folio + tracker. Verify open PRs against live GitHub.
+> **Last updated:** 2026-06-06 · #549 merged (server-mgmt cleanup PR8+PR9 +
+> guild-default `scope_id` fix). This session: collaboration-model docs
+> restructure — see **`docs/collaboration-model.md`** (binding, read first).
+> Verify open PRs against live GitHub (`list_pull_requests`); this snapshot
+> names none on purpose.
 >
 > **Purpose:** the one file that answers "what is true right now?" so a new
 > session does not reconstruct it from the journal + planning docs. Read it
@@ -28,14 +28,15 @@ in the sandbox**, not broken. Known UX follow-ups remain (below).
 
 ## In flight (verify against live GitHub)
 
-**1 open PR** as of this snapshot: this session's end-of-session PR —
-server-management cleanup **PR8 + PR9** on `claude/nifty-cerf-59MKG` (see the
-server-management folio/tracker). **#548 has merged.**
-**Always re-verify open PRs against live GitHub** before starting work — this is a dated
-snapshot, and a later PR may have opened since.
+**Do not trust a hard-coded PR count here — it goes stale on every push.** Get the
+real list at session start from live GitHub (`list_pull_requests`, state=open);
+this snapshot deliberately names no open PRs. For an initiative's shipped/queued
+status read its tracker (e.g. the server-management tracker), not this section.
+Source code and merged PRs win over anything written here.
 
 ## Recently shipped (newest first)
 
+- **#549** — server-management cleanup PR8+PR9: `policy_version` marker, presets builder + dry-run + panel diagnostics, and the guild-default `scope_id=0` no-op fix.
 - **#548** — closed the migration-`057` persistence/dedupe/retention integration-test gap (test-only).
 - **#546** — canonical subsystem folios (health/diagnostics, server-mgmt, settings, BTD6, games, media).
 - **#544** — freshness-oriented docs route, lifecycle labels, ideas area, and subsystem-folio model.
@@ -89,6 +90,7 @@ snapshot, and a later PR may have opened since.
 
 | Need | Read |
 |---|---|
+| **How we collaborate** (all agents — the working model, read first) | `docs/collaboration-model.md` |
 | Rules of engagement (CI parity, CodeGraph, arch invariants, workflow) | `.claude/CLAUDE.md` |
 | **What's true right now** | this file |
 | How to boot/operate the sandbox · maintainer preferences · hard-won rules · gotchas | `.session-journal.md` (guidebook head) |

--- a/docs/subsystems/health-diagnostics.md
+++ b/docs/subsystems/health-diagnostics.md
@@ -14,6 +14,29 @@ signals into bounded operator-facing snapshots. Start in
 `disbot/utils/db/health_findings.py` and migration
 `disbot/migrations/057_operational_health_findings.sql`.
 
+## Debug router (if X, inspect Y first)
+
+Health/diagnostics is a **reporting layer**. When it surfaces a problem the root
+cause is almost always in the subsystem it *reports on*, not here — don't "fix" the
+health system for a failure it merely displays.
+
+- **A finding/health card names a failure (e.g. "role automation")** → the bug is in
+  that **execution** subsystem, not health. Jump to that subsystem's folio + debug
+  router (e.g. server-management for role/cleanup) and to the **runtime logs** for the
+  exact exception — grouped findings intentionally scrub/aggregate the raw trace.
+- **A repeated error you can't pinpoint from the snapshot** → findings are
+  fingerprinted in `services/health_findings_service.py` / `utils/db/health_findings.py`
+  (detail redacted); the unredacted exception lives in runtime logs, not the DB row.
+  Use the finding's `related_subsystem` / `related_command` to locate it.
+- **"Consistency" / bindings-backfill / config-arbitration warnings** → a **separate**
+  layer: `services/platform_consistency.py`. Distinguish benign warnings from blockers
+  via `docs/platform-consistency-ledger.md`; they are not health findings.
+- **`diagnostics_health_snapshot` returned nothing for a user** → it's owner-gated and
+  read-only by design; a non-owner getting nothing is correct, not a bug.
+- **A health card itself errors / is empty** → check provider isolation in
+  `health_snapshot_service` (a failing provider must degrade, not crash the card) and
+  the cached-vs-async lane split in `health_contracts`.
+
 ## Rules & approved structures (binding — link, don't restate)
 
 - `docs/bot-awareness-implementation-plan.md` is the execution/status authority;

--- a/docs/subsystems/server-management.md
+++ b/docs/subsystems/server-management.md
@@ -15,6 +15,34 @@ cleanup policy, setup, and the future unified hub. Inspect first:
 `disbot/services/cleanup_profiles.py`, `disbot/cogs/setup_cog.py`, and
 `disbot/views/setup/`.
 
+## Debug router (if X, inspect Y first)
+
+- **Commands aren't deleted / wrong delete timing** → it's cleanup *resolution*,
+  not the cog. Order: `governance/cleanup.py::resolve_cleanup_policy` →
+  `_build_scope_chain` (walks **channel → category → guild → default**; threads
+  inherit — RC-5, no thread scope) → `cleanup_policies` rows. **Gotcha:** a
+  guild-default row must be keyed by `scope_id=guild_id`
+  (`services/cleanup_levels.cleanup_scope_id`) — a row at `scope_id=0` is silently
+  never read. `!cleanup` → **Cleanup Policies** (`services/cleanup_diagnostics.py`)
+  flags stale/ineffective rows. Pins: `tests/unit/governance/test_cleanup_scope.py`,
+  `test_cleanup_resolution_behavior.py`.
+- **A mutation didn't audit / emit an event** → it must route through
+  `governance/writes.py::GovernanceMutationPipeline` (DB + `governance_audit_log` +
+  `EVT_*` + cache invalidation in one txn). A cog/view writing the DB directly is the
+  bug — see `docs/ownership.md` "Direct DB writes — blocklist".
+- **Channel rename/move/delete/reorder misbehaves** →
+  `services/channel_lifecycle_service.py` (owns all four; emits
+  `channel.lifecycle_changed`). Channel *creation* is resource provisioning — a
+  different owner.
+- **Role create/edit/delete or time/XP threshold automation** →
+  `services/role_lifecycle_service.py` + feasibility checks; thresholds are ID-first
+  selectors persisted per guild.
+- **Auto-mod deletion missing from the audit log** → it must go through
+  `moderation_service.auto_delete` (writes `mod_logs` + `EVT_MOD_ACTION`); a raw
+  `message.delete()` in a cog is the gap.
+- **"Should I add a manager/panel?"** → check the tracker's Remaining queue first;
+  reuse selectors + provisioning previews; never add a second resource-creation path.
+
 ## Rules & approved structures (binding — link, don't restate)
 
 - `docs/planning/server-management-status-2026-06-05.md` is authoritative for


### PR DESCRIPTION
## Summary

Makes the maintainer's working model the **first thing every agent reads**, and stops generated constraints from drowning the goal. Docs-only; no code touched.

**The problem:** the docs encoded *constraints* (stop-conditions, "planning only", scope fences — mostly ChatGPT drafting residue) louder than they encoded *the goal* and the executor's *authority*. So a fresh session optimized for "don't break a rule" instead of "achieve the outcome," and asked for confirmation it could have inferred.

### Changes

- **NEW `docs/collaboration-model.md`** (binding, all-agent) — the canonical "how we work":
  - Maintainer designs/visualizes; agents build + verify (multi-agent cross-checking is the method).
  - The pipeline: idea → multi-agent refinement → roadmap in repo → **session prompt = guidance, not orders** → execute.
  - Executor rules: approved plan = execute; **act-vs-ask envelope** (act on contained/reversible/verifiable changes incl. root-cause fixes found mid-task; ask only for irreversible / large / goal-ambiguous); constraints serve the goal.
  - Planner rules (for ChatGPT): write guidance not orders; lead with the goal; don't import "planning only" after approval; trust one-session capability.
  - Bugs/root issues first; a positive, **noticeable** result every session; truth-layer precedence.
- **`.claude/CLAUDE.md`** — "Working agreement" at the very top (condensed, links to the model); read-order now leads with the collaboration model.
- **`docs/AGENT_ORIENTATION.md`** — model is read #1 + in the binding list; prompts-as-guidance / act-vs-ask added to the read-first mandate.
- **`docs/current-state.md`** — the "In flight" section no longer hard-codes a PR count (it went stale on every push) → directs to live `list_pull_requests`; `#549` added to Recently shipped. (Structure guard `test_current_state_doc.py` kept green.)
- **Folio "Debug routers"** ("if X, inspect Y first") added to `server-management.md` and `health-diagnostics.md` — the cross-agent 7→9 orientation suggestion.
- **`.session-journal.md`** — defers the "how we work" model to the new doc; precedence line updated; session entry added (newest-first) flagging that a batch of recent log entries were mis-appended at the bottom as `##` for the next review pass to normalize.

## Why this shape
Both Claude (executor) and ChatGPT (prompt drafter) read `docs/`, so the model lives in a discoverable binding doc, not only in `CLAUDE.md`. `current-state.md` / folios **link** to trackers for status rather than restating it (one home per fact).

## Testing
`python3.10 -m pytest tests/unit/docs/` → **54 passed** (current-state structure guard intact). Docs-only — no code paths affected.

https://claude.ai/code/session_016mNZRTPmSV4cAbWbK5xFfU

---
_Generated by [Claude Code](https://claude.ai/code/session_016mNZRTPmSV4cAbWbK5xFfU)_