### PR TITLE
fix(roles): stop the role-automation degradation — preflight-guard apply() + classify failures

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -301,6 +301,65 @@ confidence; do not treat booting as gated.
 
 ## Session Log (newest first — append-only)
 
+### 2026-06-06 — Role-automation degradation FIXED (preflight-at-mutation + failure classification)
+
+- **Arc:** maintainer reported the bot self-describing **Health: Degraded** in
+  Discord — **26 `role_automation.apply: failed for member` errors** (the main
+  degradation point). A ChatGPT first-pass review was provided as **input**
+  (verified against source per the "don't follow cross-agent output on faith"
+  rule — all 5 of its claims held; it missed the `utils/role_feasibility.py`
+  asset). Branch `claude/epic-tesla-IGJ21` off `main` (9226c65); 0 open PRs live.
+- **Root cause (source-verified):**
+  1. `role_automation.check_preflight()` (manage_roles / hierarchy / missing-role
+     check) was **dead code** — defined + unit-tested but **called from nowhere**.
+     So `_assign_roles` / `on_member_join` ran `apply()` straight into doomed
+     mutations.
+  2. `apply()` caught each per-member failure with `logger.exception` (**ERROR +
+     traceback**). The health `recent_errors` provider is registered
+     **ERROR-only** (`diagnostic_cog.py:738` → `recent_logs(level="ERROR")`), so a
+     roster-wide blocker (bot missing Manage Roles, or a tier role above the bot)
+     became N ERROR logs → the grouped "26 errors" degraded finding.
+  3. `check_preflight()` resolved **name-only** while `compute_assignments` /
+     `apply` resolve **id-first** → a renamed role with a persisted `role_id`
+     would read "missing" in preflight (parity drift).
+  4. `_assign_roles` surfaced only `result.succeeded` ("0 made") and
+     `on_member_join` ignored the result entirely → failures were invisible.
+- **Fix (root-cause, within the role-automation boundary):**
+  - `services/role_automation.py` — `apply()` is now **self-guarding at the
+    mutation seam** (protects every caller, not two call sites): detects a
+    systemic `manage_roles` block **once** (one WARNING, whole batch skipped) and
+    pre-empts per-role hierarchy/managed/@everyone blockers via
+    `utils.role_feasibility.evaluate_role` (**single source of truth** — same
+    primitive the selectors + `check_preflight` use). Failures are **classified**
+    (`ApplyError(member_id, phase, code, detail)` + reason codes reusing
+    role_feasibility's vocabulary). **Predictable** conditions log at **WARNING**
+    (drop out of the ERROR-only health surface) and **unexpected** ones still
+    `logger.exception` (ERROR) as they should. `check_preflight` now resolves
+    **id-first**. Added `summarize_failures()` + `failure_counts()`; kept
+    `errors` as a back-compat property.
+  - `cogs/role_cog.py` — `_assign_roles` surfaces the failure breakdown to the
+    `!assignroles` operator ("0 made, 26 failed (missing Manage Roles: 26)") and
+    `on_member_join` **warns** on failure instead of swallowing it.
+  - `views/roles/diagnostics_panel.py` — new live **"Role Automation"** health
+    line (missing Manage Roles / role above my top role / missing role) so the
+    operator can *see* the cause — directly answers the maintainer's "tell me
+    more about the role problem".
+- **Scope discipline (per the review):** did **not** touch the health/diagnostics
+  aggregator or server-management. The health layer wasn't causal — it correctly
+  surfaced ERROR logs; making the predictable failures non-ERROR is what clears it.
+- **Verification:** `check_architecture --mode strict` = **0 errors**;
+  `check_quality --full` = **green (7646 passed, 16 skipped)**; booted the test
+  bot (boot_id `b45977d7`) — 34 cogs incl. RoleCog, connected to 2 servers,
+  **0 ERROR/CRITICAL**, `findings recorded=0`; the "degraded" line is the
+  env-gated sandbox baseline (webhook/voice only), not role automation. Live
+  Discord *render* of the new panel line / operator message still owed (can't
+  drive Discord clicks from the shell) — logic is unit-pinned.
+- **Lesson → candidate Rule:** a "preflight before mutation" guarantee belongs at
+  the **mutation seam** (`apply`), not at the call sites — it then protects every
+  current and future caller and can't be bypassed by a new one. A dead
+  safety-check (`check_preflight` was never wired) is worse than none: it reads as
+  covered. **For project state see `docs/current-state.md`.** (PR pending.)
+
 ### 2026-06-06 — Docs: collaboration model + truth-layer restructure
 
 - **Arc:** maintainer asked for an honest review of the doc structure (esp. the

--- a/disbot/cogs/role_cog.py
+++ b/disbot/cogs/role_cog.py
@@ -20,6 +20,22 @@ from views.roles._helpers import _ensure_defaults, _find_role_normalized, _parse
 logger = logging.getLogger("bot")
 
 
+def _format_role_check_result(result: role_automation.ApplyResult) -> str:
+    """Operator-facing summary of a time-role reconciliation run.
+
+    Surfaces failures (with their classified cause) instead of the old
+    success-only line that reported "0 assignment(s) made" while every member
+    silently 403'd — the signal that hid the role-automation degradation.
+    """
+    if not result.failed:
+        return f"✅ Role check complete — {result.succeeded} assignment(s) made."
+    return (
+        f"⚠️ Role check complete — {result.succeeded} made, "
+        f"{result.failed} failed ({role_automation.summarize_failures(result)}).\n"
+        "Open **!roles → 🔧 Diagnostics** to see what's blocking role automation."
+    )
+
+
 def _build_role_hub_embed() -> discord.Embed:
     return stats_block(
         "🎭 Role Hub",
@@ -322,9 +338,7 @@ class RoleCog(commands.Cog):
         )
 
         if ctx:
-            await ctx.send(
-                f"✅ Role check complete — {result.succeeded} assignment(s) made.",
-            )
+            await ctx.send(_format_role_check_result(result))
         return result.succeeded
 
     # ------------------------------------------------------------------ primary commands
@@ -634,12 +648,23 @@ class RoleCog(commands.Cog):
         )
         if plan is None:
             return
-        await role_automation.apply(
+        result = await role_automation.apply(
             member.guild,
             (plan,),
             actor_id=None,
             actor_type="system",
         )
+        if result.failed:
+            # Don't swallow a join-time failure: log it (WARNING — a single
+            # member, not a flood) with the classified cause so an operator
+            # isn't left guessing why a new member never got their role.
+            logger.warning(
+                "on_member_join: role assignment failed for member=%s in "
+                "guild=%s — %s",
+                member.id,
+                member.guild.id,
+                role_automation.summarize_failures(result),
+            )
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/disbot/services/role_automation.py
+++ b/disbot/services/role_automation.py
@@ -32,12 +32,18 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any
+from typing import Any
+
+import discord
 
 from services.audit_events import emit_audit_action
-
-if TYPE_CHECKING:
-    pass
+from utils.role_feasibility import (
+    ABOVE_BOT,
+    BOT_MISSING_MANAGE_ROLES,
+    EVERYONE,
+    MANAGED,
+    evaluate_role,
+)
 
 logger = logging.getLogger("bot.services.role_automation")
 
@@ -92,6 +98,48 @@ class PreflightResult:
         )
 
 
+# Reason codes for a classified per-member failure.  The manageability codes
+# (BOT_MISSING_MANAGE_ROLES / ABOVE_BOT / MANAGED / EVERYONE) come from
+# utils.role_feasibility so the pre-mutation guard, check_preflight, and the
+# selector surfaces all classify "can't manage this role" identically; the rest
+# are apply-specific outcomes.
+MEMBER_NOT_CACHED = "member_not_cached"
+FORBIDDEN = "forbidden"
+NOT_FOUND = "not_found"
+HTTP_ERROR = "http_error"
+UNKNOWN = "unknown"
+
+_FAILURE_LABELS: dict[str, str] = {
+    BOT_MISSING_MANAGE_ROLES: "missing Manage Roles",
+    ABOVE_BOT: "role above my top role",
+    MANAGED: "integration-managed role",
+    EVERYONE: "the @everyone role",
+    MEMBER_NOT_CACHED: "member not in cache",
+    FORBIDDEN: "permission denied",
+    NOT_FOUND: "member or role not found",
+    HTTP_ERROR: "Discord API error",
+    UNKNOWN: "unexpected error",
+}
+
+
+@dataclass(frozen=True)
+class ApplyError:
+    """One classified per-member failure from :func:`apply`.
+
+    ``code`` is a stable reason token (the :mod:`utils.role_feasibility` codes
+    for manageability blockers, plus the apply-specific ones above) so operator
+    and diagnostics surfaces can group failures by *cause* instead of parsing
+    free text.  ``phase`` is where it happened: ``"lookup"`` (member not cached),
+    ``"preflight"`` (a role the bot can't manage) or ``"mutate"`` (the Discord
+    call raised).
+    """
+
+    member_id: int
+    phase: str
+    code: str
+    detail: str
+
+
 @dataclass(frozen=True)
 class ApplyResult:
     """Outcome of :func:`apply`."""
@@ -100,7 +148,31 @@ class ApplyResult:
     succeeded: int = 0
     failed: int = 0
     skipped: int = 0
-    errors: tuple[str, ...] = ()
+    failures: tuple[ApplyError, ...] = ()
+
+    @property
+    def errors(self) -> tuple[str, ...]:
+        """Back-compat human-readable failure strings (``failures`` is the
+        structured form).
+        """
+        return tuple(f"member {f.member_id}: {f.detail}" for f in self.failures)
+
+    def failure_counts(self) -> dict[str, int]:
+        """``{reason_code: count}`` over :attr:`failures`, busiest cause first."""
+        counts: dict[str, int] = {}
+        for f in self.failures:
+            counts[f.code] = counts.get(f.code, 0) + 1
+        return dict(sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])))
+
+
+def summarize_failures(result: ApplyResult) -> str:
+    """Compact ``"missing Manage Roles: 26, role above my top role: 2"`` summary
+    of a result's failures (busiest first), or ``""`` when there were none.
+    """
+    return ", ".join(
+        f"{_FAILURE_LABELS.get(code, code)}: {n}"
+        for code, n in result.failure_counts().items()
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -327,6 +399,17 @@ class _SingleMemberGuild:
 # ---------------------------------------------------------------------------
 
 
+def _bot_has_manage_roles(me: Any) -> bool:
+    """Whether ``guild.me`` carries the ``manage_roles`` permission.
+
+    Shared by :func:`check_preflight` and :func:`apply` so the owner-facing
+    report and the mutation guard can never disagree on the permission state.
+    """
+    return bool(
+        getattr(getattr(me, "guild_permissions", None), "manage_roles", False),
+    )
+
+
 def check_preflight(
     guild: Any,
     thresholds: list[RoleThreshold] | tuple[RoleThreshold, ...],
@@ -345,23 +428,16 @@ def check_preflight(
             bot_has_manage_roles=False,
             missing_roles=tuple(t.role_name for t in thresholds),
         )
-    bot_has_manage = bool(
-        getattr(
-            getattr(me, "guild_permissions", None),
-            "manage_roles",
-            False,
-        ),
-    )
-    bot_top_position = getattr(
-        getattr(me, "top_role", None),
-        "position",
-        0,
-    )
+    bot_has_manage = _bot_has_manage_roles(me)
+    bot_top_position = getattr(getattr(me, "top_role", None), "position", 0)
 
     missing: list[str] = []
     blockers: list[str] = []
     for t in thresholds:
-        role = _resolve_role(guild, t.role_name)
+        # Resolve id-first (mirrors compute_assignments / apply) so a renamed
+        # role with a persisted role_id is NOT reported "missing" — the parity
+        # the old name-only lookup silently broke.
+        role = _resolve_threshold_role(guild, t)
         if role is None:
             missing.append(t.role_name)
             continue
@@ -380,6 +456,57 @@ def check_preflight(
 # ---------------------------------------------------------------------------
 
 
+def _classify_exception(exc: Exception) -> tuple[str, bool]:
+    """Map a mutation exception to ``(reason_code, is_unexpected)``.
+
+    Predictable Discord conditions — permission denied, gone member/role, a
+    transient HTTP error — are *expected operational states*, not bot faults,
+    so they return ``is_unexpected=False``: the caller logs them at WARNING and
+    they stay out of the ERROR-only health surface.  Anything else is genuinely
+    unexpected and is logged with a traceback at ERROR.
+    """
+    if isinstance(exc, discord.Forbidden):
+        return FORBIDDEN, False
+    if isinstance(exc, discord.NotFound):
+        return NOT_FOUND, False
+    if isinstance(exc, discord.HTTPException):
+        return HTTP_ERROR, False
+    return UNKNOWN, True
+
+
+def _blocking_verdict(guild: Any, me: Any, plan: Assignment) -> ApplyError | None:
+    """Classified :class:`ApplyError` if any role this plan touches is
+    unmanageable by the bot, else ``None``.
+
+    Delegates the per-role verdict to
+    :func:`utils.role_feasibility.evaluate_role` — the single source of truth
+    for "can the bot manage this role?" — so the pre-mutation guard,
+    :func:`check_preflight`, and the selector surfaces can never drift.  With
+    ``me`` unresolved (``guild.me is None``) the bot hierarchy / permission
+    checks are skipped, so the mutation is attempted and any raise classified;
+    we never assume a failure we cannot prove.
+    """
+    roles_by_id = {
+        r.id: r for r in (getattr(guild, "roles", ()) or ()) if getattr(r, "id", None)
+    }
+    touched: list[Any] = []
+    if plan.add_role_id is not None and plan.add_role_id in roles_by_id:
+        touched.append(roles_by_id[plan.add_role_id])
+    touched.extend(
+        roles_by_id[rid] for rid in plan.remove_role_ids if rid in roles_by_id
+    )
+    for role in touched:
+        verdict = evaluate_role(role, bot_member=me)
+        if not verdict.ok:
+            return ApplyError(
+                member_id=plan.member_id,
+                phase="preflight",
+                code=verdict.code,
+                detail=f"role '{verdict.role_name}': {verdict.reason}",
+            )
+    return None
+
+
 async def apply(
     guild: Any,
     assignments: tuple[Assignment, ...] | list[Assignment],
@@ -390,11 +517,17 @@ async def apply(
 ) -> ApplyResult:
     """Apply ``assignments`` to the live guild.
 
-    Each member is handled in isolation: an exception on one
-    ``add_roles`` / ``remove_roles`` call increments the failure
-    counter but does NOT abort subsequent members. Every successful
-    change emits a ``audit.action_recorded`` event via the Track 1
-    shared helper.
+    Preflight-guarded at the mutation point: before any API call the bot's
+    ability to manage each touched role is checked via
+    :func:`utils.role_feasibility.evaluate_role`.  Predictable blockers — the
+    bot missing ``manage_roles`` or a progression role sitting at/above the
+    bot's top role — are recorded as classified :class:`ApplyError` failures and
+    logged once for the batch, instead of letting every member raise a 403 and
+    flood the ERROR log / health surface (the "26 role automation errors" shape).
+    Each remaining member is still handled in isolation: an unexpected exception
+    increments the failure counter but does NOT abort the batch and is logged
+    with a traceback. Every successful change emits ``audit.action_recorded``
+    via the Track 1 shared helper.
     """
     if dry_run:
         return ApplyResult(
@@ -402,10 +535,37 @@ async def apply(
             skipped=len(assignments),
         )
 
+    me = getattr(guild, "me", None)
+    guild_id = getattr(guild, "id", "?")
+
+    # Systemic guard: if the bot demonstrably lacks Manage Roles, every
+    # add/remove would 403 once per member.  Catch it once, skip the batch, and
+    # return classified failures — no per-member ERROR tracebacks.
+    if me is not None and not _bot_has_manage_roles(me):
+        logger.warning(
+            "role_automation.apply: skipping %d assignment(s) in guild=%s — "
+            "bot lacks the Manage Roles permission.",
+            len(assignments),
+            guild_id,
+        )
+        return ApplyResult(
+            attempted=len(assignments),
+            failed=len(assignments),
+            failures=tuple(
+                ApplyError(
+                    member_id=p.member_id,
+                    phase="preflight",
+                    code=BOT_MISSING_MANAGE_ROLES,
+                    detail="bot lacks the Manage Roles permission",
+                )
+                for p in assignments
+            ),
+        )
+
     attempted = 0
     succeeded = 0
-    failed = 0
-    errors: list[str] = []
+    preflight_blocked = 0
+    failures: list[ApplyError] = []
 
     members_by_id = {m.id: m for m in (getattr(guild, "members", ()) or ())}
 
@@ -413,27 +573,65 @@ async def apply(
         attempted += 1
         member = members_by_id.get(plan.member_id)
         if member is None:
-            failed += 1
-            errors.append(f"member {plan.member_id} not in cache")
+            failures.append(
+                ApplyError(
+                    member_id=plan.member_id,
+                    phase="lookup",
+                    code=MEMBER_NOT_CACHED,
+                    detail="member not in guild cache",
+                ),
+            )
             continue
+
+        blocked = _blocking_verdict(guild, me, plan)
+        if blocked is not None:
+            preflight_blocked += 1
+            failures.append(blocked)
+            continue
+
         try:
             await _apply_single(guild, member, plan, actor_id, actor_type)
             succeeded += 1
         except Exception as exc:  # noqa: BLE001 — per-member boundary
-            logger.exception(
-                "role_automation.apply: failed for member=%d",
-                plan.member_id,
+            code, unexpected = _classify_exception(exc)
+            failures.append(
+                ApplyError(
+                    member_id=plan.member_id,
+                    phase="mutate",
+                    code=code,
+                    detail=f"{type(exc).__name__}: {exc}",
+                ),
             )
-            failed += 1
-            errors.append(
-                f"member {plan.member_id}: {type(exc).__name__}: {exc}",
-            )
+            if unexpected:
+                logger.exception(
+                    "role_automation.apply: failed for member=%d",
+                    plan.member_id,
+                )
+            else:
+                logger.warning(
+                    "role_automation.apply: %s for member=%d: %s",
+                    code,
+                    plan.member_id,
+                    exc,
+                )
+
+    # One WARNING for the whole batch of predictable, pre-empted blockers — keeps
+    # a roster-wide misconfiguration out of the ERROR-only health surface while
+    # still recording it (and the structured result drives the operator surface).
+    if preflight_blocked:
+        logger.warning(
+            "role_automation.apply: skipped %d assignment(s) in guild=%s — "
+            "unmanageable roles (%s).",
+            preflight_blocked,
+            guild_id,
+            summarize_failures(ApplyResult(failures=tuple(failures))),
+        )
 
     return ApplyResult(
         attempted=attempted,
         succeeded=succeeded,
-        failed=failed,
-        errors=tuple(errors),
+        failed=len(failures),
+        failures=tuple(failures),
     )
 
 
@@ -496,6 +694,7 @@ async def _apply_single(
 
 
 __all__ = [
+    "ApplyError",
     "ApplyResult",
     "Assignment",
     "PreflightResult",
@@ -504,4 +703,5 @@ __all__ = [
     "check_preflight",
     "compute_assignments",
     "explain_assignment_for",
+    "summarize_failures",
 ]

--- a/disbot/views/roles/diagnostics_panel.py
+++ b/disbot/views/roles/diagnostics_panel.py
@@ -5,10 +5,31 @@ from discord.ext import commands
 
 from core.runtime import resources
 from core.runtime.interaction_helpers import safe_defer
+from services import role_automation
 from utils import db
 from utils.ui_constants import WARNING_COLOR
 from views.base import BaseView
 from views.navigation import attach_back_button
+
+
+def _format_preflight(pf: role_automation.PreflightResult) -> str:
+    """One-line role-automation health summary from a preflight result.
+
+    Shows the same blockers ``role_automation.apply`` now enforces before
+    mutating, so an operator can *see* why automation is failing (missing
+    permission / role above the bot / configured role gone) instead of finding
+    out only from a degraded health snapshot.
+    """
+    if not pf.bot_has_manage_roles:
+        return "🔴 I'm missing the **Manage Roles** permission."
+    problems: list[str] = []
+    if pf.hierarchy_blockers:
+        problems.append("above my top role: " + ", ".join(pf.hierarchy_blockers))
+    if pf.missing_roles:
+        problems.append("missing: " + ", ".join(pf.missing_roles))
+    if not problems:
+        return "🟢 I can manage all configured progression roles."
+    return "⚠️ " + "; ".join(problems)
 
 
 class DiagnosticsPanel(BaseView):
@@ -77,6 +98,26 @@ class DiagnosticsPanel(BaseView):
             value=str(len(guild.roles) - 1),
             inline=True,
         )
+
+        # Live role-automation health: can the bot actually apply the configured
+        # time-based progression roles?  This is the operator's window into the
+        # "role_automation.apply failed for member" degradation.
+        time_objs = tuple(
+            role_automation.RoleThreshold(
+                role_name=r["role_name"],
+                days_required=r["days_required"],
+                role_id=r.get("role_id"),
+            )
+            for r in thresholds
+            if not r.get("xp_auto_assign") and r.get("days_required") is not None
+        )
+        if time_objs:
+            ra_value = _format_preflight(
+                role_automation.check_preflight(guild, time_objs),
+            )
+        else:
+            ra_value = "*(no time-based roles configured)*"
+        embed.add_field(name="Role Automation", value=ra_value, inline=False)
         return embed
 
     @discord.ui.button(

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -6,9 +6,13 @@
 > live GitHub** before trusting it (two same-session reports already
 > contradicted each other across a single merge).
 >
-> **Last updated:** 2026-06-06 · #549 merged (server-mgmt cleanup PR8+PR9 +
-> guild-default `scope_id` fix). This session: collaboration-model docs
-> restructure — see **`docs/collaboration-model.md`** (binding, read first).
+> **Last updated:** 2026-06-06 · #550 merged (collaboration-model docs +
+> truth-layer restructure). This session: **fixed the role-automation
+> degradation** — `role_automation.apply` now preflight-guards at the mutation
+> seam and classifies failures, so a roster-wide Manage-Roles / hierarchy
+> blocker no longer floods the ERROR-only health surface (the "26 role
+> automation errors"); operator + role-Diagnostics surfaces now show the cause.
+> Branch `claude/epic-tesla-IGJ21` (PR pending) — detail in the session journal.
 > Verify open PRs against live GitHub (`list_pull_requests`); this snapshot
 > names none on purpose.
 >
@@ -36,6 +40,7 @@ Source code and merged PRs win over anything written here.
 
 ## Recently shipped (newest first)
 
+- **#550** — collaboration-model doc + truth-layer restructure (goal-first, prompts-as-guidance); docs-only.
 - **#549** — server-management cleanup PR8+PR9: `policy_version` marker, presets builder + dry-run + panel diagnostics, and the guild-default `scope_id=0` no-op fix.
 - **#548** — closed the migration-`057` persistence/dedupe/retention integration-test gap (test-only).
 - **#546** — canonical subsystem folios (health/diagnostics, server-mgmt, settings, BTD6, games, media).

--- a/tests/unit/cogs/test_role_cog_routing.py
+++ b/tests/unit/cogs/test_role_cog_routing.py
@@ -19,8 +19,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from cogs.role_cog import RoleCog
+from cogs.role_cog import RoleCog, _format_role_check_result
 from services import role_automation
+from utils.role_feasibility import BOT_MISSING_MANAGE_ROLES
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _ROLE_COG = _REPO_ROOT / "disbot" / "cogs" / "role_cog.py"
@@ -347,6 +348,35 @@ def test_role_cog_threshold_paths_do_not_call_member_role_apis_directly():
             "Threshold path must not call member.remove_roles directly — "
             "route through services.role_automation.apply (PR-G)."
         )
+
+
+def test_format_role_check_result_reports_failures():
+    """The operator summary must surface failures + their cause — not the old
+    success-only line that read "0 made" while every member silently 403'd.
+    """
+    ok = role_automation.ApplyResult(attempted=3, succeeded=3, failed=0)
+    assert _format_role_check_result(ok) == (
+        "✅ Role check complete — 3 assignment(s) made."
+    )
+
+    failed = role_automation.ApplyResult(
+        attempted=3,
+        succeeded=0,
+        failed=3,
+        failures=tuple(
+            role_automation.ApplyError(
+                member_id=i,
+                phase="preflight",
+                code=BOT_MISSING_MANAGE_ROLES,
+                detail="no perms",
+            )
+            for i in (1, 2, 3)
+        ),
+    )
+    summary = _format_role_check_result(failed)
+    assert "0 made, 3 failed" in summary
+    assert "missing Manage Roles: 3" in summary
+    assert "Diagnostics" in summary  # points the operator at the fix surface
 
 
 def _extract_method(src: str, name: str) -> str | None:

--- a/tests/unit/services/test_role_automation.py
+++ b/tests/unit/services/test_role_automation.py
@@ -22,23 +22,29 @@ Pins:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
+import discord
 import pytest
 
 from services.role_automation import (
+    FORBIDDEN,
+    UNKNOWN,
+    ApplyError,
     ApplyResult,
     Assignment,
     PreflightResult,
     RoleThreshold,
+    _classify_exception,
     apply,
     check_preflight,
     compute_assignments,
     explain_assignment_for,
+    summarize_failures,
 )
+from utils.role_feasibility import ABOVE_BOT, BOT_MISSING_MANAGE_ROLES
 
 
 def _role(rid: int, name: str, position: int = 1):
@@ -394,3 +400,127 @@ async def test_apply_emits_one_audit_event_per_change():
         await apply(g, plans)
     # Promote = 1 remove + 1 add = 2 audit events
     assert emit_mock.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# check_preflight — id-first parity (must match compute_assignments / apply)
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_resolves_role_by_id_after_rename():
+    """A threshold carrying a persisted role_id must NOT report 'missing' when
+    the role was renamed — preflight has to resolve id-first like the assignment
+    path, or it diverges from what apply() can actually do.
+    """
+    renamed = _role(100, "NewName", position=5)
+    g = _guild(roles=[renamed], me=_me_member(top_position=10))
+    result = check_preflight(g, [RoleThreshold("OldName", 30, role_id=100)])
+    assert result.missing_roles == ()  # resolved by id, not flagged missing
+    assert result.ok is True
+
+
+# ---------------------------------------------------------------------------
+# apply — preflight guard + failure classification (the 26-errors fix)
+# ---------------------------------------------------------------------------
+
+
+def _forbidden() -> discord.Forbidden:
+    resp = SimpleNamespace(status=403, reason="Forbidden")
+    return discord.Forbidden(resp, "Missing Permissions")
+
+
+@pytest.mark.asyncio
+async def test_apply_blocks_entire_batch_when_bot_lacks_manage_roles():
+    """No Manage Roles ⇒ every member would 403. apply() must detect it ONCE,
+    skip the batch, and classify each failure — never call Discord, never emit
+    one ERROR traceback per member (the health-flooding shape).
+    """
+    veteran = _role(100, "Veteran", position=5)
+    members = [
+        _member(mid=i, display=f"u{i}", joined_days_ago=60) for i in (1, 2, 3)
+    ]
+    g = _guild(
+        roles=[veteran],
+        members=members,
+        me=_me_member(manage_roles=False, top_position=10),
+    )
+    plans = compute_assignments(g, [RoleThreshold("Veteran", 30)])
+    assert len(plans) == 3
+    with patch(
+        "services.role_automation.emit_audit_action",
+        new_callable=AsyncMock,
+    ):
+        result = await apply(g, plans)
+    assert result.succeeded == 0
+    assert result.failed == 3
+    assert result.failure_counts() == {BOT_MISSING_MANAGE_ROLES: 3}
+    for m in members:
+        m.add_roles.assert_not_awaited()
+        m.remove_roles.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_apply_skips_role_above_bot_without_calling_discord():
+    """A progression role at/above the bot's top role is pre-empted per-member
+    with an ABOVE_BOT failure instead of a raised 403.
+    """
+    above = _role(100, "Veteran", position=20)  # above the bot's top (10)
+    member = _member(mid=1, display="u1", joined_days_ago=60)
+    g = _guild(roles=[above], members=[member], me=_me_member(top_position=10))
+    plans = compute_assignments(g, [RoleThreshold("Veteran", 30)])
+    assert len(plans) == 1
+    with patch(
+        "services.role_automation.emit_audit_action",
+        new_callable=AsyncMock,
+    ):
+        result = await apply(g, plans)
+    assert result.succeeded == 0
+    assert result.failed == 1
+    assert result.failures[0].code == ABOVE_BOT
+    assert result.failures[0].phase == "preflight"
+    member.add_roles.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_apply_classifies_forbidden_raised_during_mutation():
+    """A Forbidden that slips past the precheck (e.g. integration-managed
+    target) is classified FORBIDDEN, not the catch-all UNKNOWN.
+    """
+    veteran = _role(100, "Veteran", position=5)
+    member = _member(mid=1, display="u1", joined_days_ago=60)
+    member.add_roles = AsyncMock(side_effect=_forbidden())
+    g = _guild(roles=[veteran], members=[member], me=_me_member(top_position=10))
+    plans = compute_assignments(g, [RoleThreshold("Veteran", 30)])
+    with patch(
+        "services.role_automation.emit_audit_action",
+        new_callable=AsyncMock,
+    ):
+        result = await apply(g, plans)
+    assert result.failed == 1
+    assert result.failures[0].code == FORBIDDEN
+    assert result.failures[0].phase == "mutate"
+
+
+def test_classify_exception_maps_discord_errors():
+    """Predictable Discord errors are 'expected' (warn, stay out of ERROR
+    health); anything else is unexpected (ERROR + traceback).
+    """
+    assert _classify_exception(_forbidden()) == (FORBIDDEN, False)
+    assert _classify_exception(RuntimeError("boom")) == (UNKNOWN, True)
+
+
+def test_apply_result_errors_property_and_failure_counts():
+    """The structured ``failures`` drives both the back-compat ``errors`` strings
+    and the grouped ``failure_counts`` / ``summarize_failures`` operator surface.
+    """
+    failures = (
+        ApplyError(1, "preflight", BOT_MISSING_MANAGE_ROLES, "no perms"),
+        ApplyError(2, "preflight", BOT_MISSING_MANAGE_ROLES, "no perms"),
+        ApplyError(3, "mutate", UNKNOWN, "boom"),
+    )
+    r = ApplyResult(attempted=3, failed=3, failures=failures)
+    assert r.failure_counts() == {BOT_MISSING_MANAGE_ROLES: 2, UNKNOWN: 1}
+    assert "member 3: boom" in r.errors
+    # Busiest cause first, human-labelled.
+    assert summarize_failures(r) == "missing Manage Roles: 2, unexpected error: 1"
+    assert summarize_failures(ApplyResult()) == ""

--- a/tests/unit/views/test_role_diagnostics_panel.py
+++ b/tests/unit/views/test_role_diagnostics_panel.py
@@ -1,0 +1,36 @@
+"""Role DiagnosticsPanel — the operator's window into role-automation health.
+
+Pins the pure ``_format_preflight`` summary so the panel surfaces the exact
+blockers ``role_automation.apply`` enforces before mutating (missing Manage
+Roles / role above the bot / configured role gone) — the live diagnostic for
+the "role_automation.apply failed for member" degradation.
+"""
+
+from __future__ import annotations
+
+from services.role_automation import PreflightResult
+from views.roles.diagnostics_panel import _format_preflight
+
+
+def test_format_preflight_flags_missing_manage_roles():
+    out = _format_preflight(PreflightResult(bot_has_manage_roles=False))
+    assert "Manage Roles" in out
+    assert out.startswith("🔴")
+
+
+def test_format_preflight_all_clear():
+    out = _format_preflight(PreflightResult(bot_has_manage_roles=True))
+    assert out.startswith("🟢")
+
+
+def test_format_preflight_reports_hierarchy_and_missing():
+    out = _format_preflight(
+        PreflightResult(
+            bot_has_manage_roles=True,
+            hierarchy_blockers=("Veteran",),
+            missing_roles=("Ghost",),
+        ),
+    )
+    assert out.startswith("⚠️")
+    assert "above my top role: Veteran" in out
+    assert "missing: Ghost" in out


### PR DESCRIPTION
## What & why

The bot self-reported **Health: Degraded** in Discord, driven by **26 × `role_automation.apply: failed for member`** errors — the main degradation point.

**Root cause (source-verified, not guessed):**
1. `role_automation.check_preflight()` — the manage-roles / hierarchy / missing-role safety check — was **dead code**: defined and unit-tested but **wired in nowhere**. So the time-role reconciliation (`_assign_roles`, `on_member_join`) ran straight into doomed mutations.
2. Every per-member failure logged via `logger.exception` (**ERROR + traceback**), and the health `recent_errors` provider is registered **ERROR-only** (`diagnostic_cog.py:738` → `recent_logs(level="ERROR")`). So a *single* roster-wide blocker — the bot missing **Manage Roles**, or a tier role sitting **above the bot's top role** — became N ERROR logs, grouped into the "26 errors" finding.
3. `check_preflight()` resolved roles **name-only** while `compute_assignments`/`apply` resolve **id-first** → a renamed role with a persisted `role_id` would read "missing" (parity drift).
4. `_assign_roles` surfaced only `result.succeeded` ("0 made") and `on_member_join` ignored the result entirely → the failures were invisible to the operator.

> The exact production trigger (no-Manage-Roles vs. hierarchy) needs the raw Railway logs to pin, but the fix is robust to **either** — both are now pre-empted and classified rather than thrown 26 times.

## Changes (all within the role-automation boundary)

- **`services/role_automation.py`** — `apply()` now **guards at the mutation seam**, so every caller (and any future one) is protected, not just two call sites:
  - detects a systemic `manage_roles` block **once** (one WARNING, batch skipped);
  - pre-empts per-role **hierarchy / managed / @everyone** blockers via `utils.role_feasibility.evaluate_role` — the existing **single source of truth** for "can the bot manage this role?";
  - **classifies** failures (`ApplyError(member_id, phase, code, detail)` reusing role_feasibility's reason codes). Predictable conditions log at **WARNING** (so they drop out of the ERROR-only health surface) while genuinely **unexpected** ones still log a traceback at ERROR.
  - `check_preflight()` now resolves **id-first** (parity with the assignment path). Adds `summarize_failures()` / `failure_counts()`; `errors` kept as a back-compat property.
- **`cogs/role_cog.py`** — `_assign_roles` surfaces the failure breakdown to the `!assignroles` operator (`"0 made, 26 failed (missing Manage Roles: 26)"`); `on_member_join` **warns** on failure instead of swallowing it.
- **`views/roles/diagnostics_panel.py`** — a live **"Role Automation"** health line (missing Manage Roles / role above my top role / missing role) so the operator can *see* the cause — directly answering the maintainer's "tell me more about the role problem".

**Out of scope on purpose:** no health/diagnostics-aggregator or server-management changes. The health layer wasn't causal — it correctly surfaced ERROR logs; making the predictable failures non-ERROR is what clears the signal.

## Verification

- `check_architecture.py --mode strict` → **0 errors**.
- `check_quality.py --full` → **green (7659 passed, 3 skipped)** — black/isort/ruff + mypy + pytest.
- New tests pin: the systemic Manage-Roles batch block, the per-member hierarchy pre-empt (no Discord call), Forbidden-vs-unknown classification, id-first preflight after a rename, the operator summary, and the panel health line.
- Booted the test bot (boot_id `b45977d7`): 34 cogs incl. RoleCog, connected, **0 ERROR/CRITICAL**, `findings recorded=0`. (The "degraded" boot line is the env-gated sandbox baseline — webhook/voice — not role automation.)

**Live follow-up still owed to the maintainer** (can't drive Discord clicks from the shell): eyeball the new `!roles → 🔧 Diagnostics` "Role Automation" line and the `!assignroles` failure summary in a guild where the bot is intentionally missing Manage Roles / has a tier role above it.

## Cross-agent review

The ChatGPT first-pass review was treated as **input, verified against source** — all five of its substantive claims held; it missed `utils/role_feasibility.py`, which is the asset this PR routes through for a single source of truth. Its open-PR concern (#549/#550) is moot — both are merged.

https://claude.ai/code/session_01Vx7eaeoaRcG1qExPNFdjio

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vx7eaeoaRcG1qExPNFdjio)_