### PR TITLE
docs(journal): make the session journal lean + self-maintaining

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,12 +62,16 @@ merged PRs win over it, and you must verify in-flight PRs against live GitHub.
 Read it before task-specific docs so you don't act on stale state.
 
 Also read **`.session-journal.md`** (repo root) at the **start** of every
-session — our cross-session working memory: the environment/boot runbook (how to
-boot the test bot, where the env vars live, the local-Postgres setup), maintainer
-preferences, recurring problems + fixes, past mistakes to avoid, and candidate
-rules not yet promoted into this file. Append a dated entry at the **end** of the
-session and commit it. Precedence: source code & merged PRs > this file
-(CLAUDE.md) > `docs/current-state.md` (live status) > the journal.
+session — our cross-session working memory: start with its **⚡ Quick reference**
+(boot / run-CI / Postgres-down / kill-bot), then the environment/boot runbook,
+maintainer preferences, recurring problems + fixes, past mistakes to avoid, and
+candidate rules not yet promoted into this file. Older session history lives in
+**`.session-journal-archive.md`** — grep it on demand, don't read it top-to-bottom.
+**Keep the journal lean** — it's a fast-read working set: at the **end** of every
+session append a dated entry **and** roll entries older than the newest ~4 into the
+archive (tidying stale Rules / the Quick reference in place), then commit. Precedence:
+source code & merged PRs > this file (CLAUDE.md) > `docs/current-state.md` (live
+status) > the journal.
 <!-- READ_FIRST_END -->
 
 <!-- SESSION_WORKFLOW_START -->

--- a/.session-journal-archive.md
+++ b/.session-journal-archive.md
@@ -1,0 +1,469 @@
+# .session-journal-archive.md — SuperBot session-log archive
+
+> **What this is:** the older **Session Log** entries, rolled out of
+> `.session-journal.md` to keep the live journal a fast read. **Newest-first.**
+> The live journal keeps only the most recent few sessions; everything older
+> lands here.
+>
+> **How to use:** don't read this top-to-bottom — **grep it** for a PR number,
+> a symbol, a branch, or a date when you need the history behind a decision.
+> The guidebook (Runbook, Rules, Preferences) and the recent log stay in
+> `.session-journal.md`; this file is history only, never project state
+> (that's `docs/current-state.md`).
+>
+> **Heading levels are historical** — older entries mix `##` and `###`; left
+> as-is on purpose (normalizing archived text is churn for no reader benefit).
+
+---
+
+## Session Log archive (newest first)
+
+### 2026-06-06 — Closed the migration-057 persistence/dedupe/retention integration-test gap (test-only)
+- **Arc:** executed the safest health/diagnostics next-candidate scoped last session
+  (folio "Next candidates" #1). Test-only — no runtime, migration, or architecture change.
+  Branched from current `main` (`8a07617`, post-#547); verified **0 open PRs** live before
+  starting (overlapping-PR stop condition cleared).
+- **Shipped (branch `claude/practical-franklin-mV6Jy`):**
+  - NEW `tests/unit/db/test_migration_057_operational_health_findings.py` — CI-safe static
+    SQL-shape pin (13 tests, mirrors `test_migration_051`): both tables, fingerprint PK on
+    each, status/severity CHECK sets, the `(status, last_seen_at)` index, `CREATE … IF NOT
+    EXISTS` idempotency; and from `utils/db/health_findings.py` the ON CONFLICT occurrence
+    delta-add, the reopen-but-keep-ignored `CASE`, the roll-up `GREATEST`/`LEAST` + summed
+    `total_occurrences`, and the prune `WHERE status IN ('resolved','ignored')`.
+  - NEW `tests/unit/db/test_health_findings_integration.py` — real-Postgres (9 tests) with a
+    **module-local** `postgres_pool` fixture that `pytest.skip()`s when `DATABASE_URL` is
+    unset (CI) or unreachable (sandbox pre-boot). Calls `utils.db.pool.init()` to apply
+    schema+migrations; unique `test:integration:*` fingerprint prefix swept before/after.
+    Covers upsert→open(count=N), re-upsert delta-add + `last_seen` advance + single row,
+    resolved→reopen, ignored→stays-ignored, `list`/`count` by status (before/after deltas
+    so the booted bot's own rows don't perturb it), roll-up→prune (fold w/ summed totals +
+    LEAST/GREATEST window, open rows survive), and `record_findings`/`run_retention` e2e.
+  - EDIT `tests/unit/services/test_health_findings_service.py` docstring — corrected the
+    **false** "integration-tested against real Postgres" claim to point at the two new files.
+- **Invariants held:** `test_inv_health_findings_service.py` green (its raw-SQL/sole-writer
+  AST scan only covers `disbot/`, so the tests' setup-only `UPDATE`/`DELETE` are fine); no
+  services→views; no new events/migrations (chain stays 001→057 contiguous).
+- **Gates + live (all green):** `check_architecture --mode strict` = 0 errors; `check_quality
+  --full` = **7592 passed, 3 skipped**. Brought up local Postgres (runbook recipe) → integration
+  suite 9 passed; with `DATABASE_URL` unset → 9 skipped cleanly (CI parity). Booted the bot
+  (boot_id `258f6e74…`): migration `057` present in `schema_migrations`, `\d` on both tables
+  matches, **0 ERROR/CRITICAL**, and the `Startup health findings: recorded=0 pruned=0` line
+  fired (N=0 expected on a clean boot). **Still owed to maintainer:** the live Discord *render*
+  of `!platform findings`/`health`/`startup` (can't drive the Discord client from the shell).
+- **New lesson → candidate Rule below:** the module-local skip-if-unreachable `postgres_pool`
+  fixture is the repo's pattern for a real-DB test without a shared conftest fixture (CI runs no
+  Postgres). **For project state, see `docs/current-state.md` + the health/diagnostics folio.**
+
+### 2026-06-06 — New-workflow validation run + health/diagnostics next-task scoping (read-only planning)
+- **Arc:** first real test of the cross-session read path. Used it exactly as intended —
+  `CLAUDE.md` → `current-state.md` → journal → `AGENT_ORIENTATION` ("Touching health/
+  diagnostics") → `subsystems/README` → `health-diagnostics.md` folio → linked source +
+  `bot-awareness-implementation-plan.md` → **live GitHub**. Path worked end-to-end with no
+  spoon-feeding; the folio listed the exact source files needed.
+- **Live GitHub verified:** **0 open PRs**, **#546 newest merged** (#545 was a closed dup of
+  #546). Confirms #537 (PR1–PR3) + #541 (PR4–PR6) merged and D1 resolved; nothing newer than
+  #546 open or merged. Cleared the "overlapping open PR" stop condition.
+- **Scoped the safest next task** (folio next-candidate): **close the migration-`057`
+  persistence/dedupe integration gap** — test-only, deterministic (no AI key), sandbox-live-
+  verifiable, no runtime/architecture/migration change. See `docs/subsystems/health-diagnostics.md`
+  "Next candidates" #1 (sharpened this session) for the ready-to-implement spec + handoff prompt.
+- **Findings to preserve (3):**
+  1. **False docstring** — `tests/unit/services/test_health_findings_service.py:4-7` claims the
+     `ON CONFLICT` dedupe "is integration-tested against real Postgres", but **no such test
+     exists** (it monkeypatches `svc._db`). Fix it in the PR that makes it true.
+  2. `tests/conftest.py` has **no Postgres fixture**, and **CI (`code-quality.yml`) runs no
+     Postgres service** — a real-DB test must `skip` cleanly in CI; only the sandbox/local can
+     run it. (`test_migrations_runner.py:11-14` already documents the deferred-fixture decision.)
+  3. All existing migration tests are **static SQL-text** assertions (e.g. `test_migration_051`);
+     none execute SQL. The CI-lane companion for `057` should follow that same static pattern.
+- **New lesson → candidate Rule:** a test docstring's "integration-tested" claim is not proof —
+  grep `tests/` for an actual executing test before trusting it (this one was aspirational).
+- **No source/docs/migration/runtime change to features.** Docs-only this session: sharpened the
+  health/diagnostics folio "Next candidates", refreshed `current-state.md` (date + 0-open-PRs +
+  #546), and this entry. **For project state, see `docs/current-state.md`.**
+
+### 2026-06-06 — Documentation restructure (current-state router · journal split · folios)
+- **Arc:** maintainer asked me to **design and own** a doc structure that streamlines
+  cross-session work — kill stale-doc/preference hunting and the freshness/contradiction
+  drift root cause. Two cross-agent reviews were *input* (verified, not followed on faith:
+  their PR-state reports already contradicted each other across one merge — confirmed #539
+  merged + 0 open PRs via live GitHub).
+- **Shipped (6 commits, this branch, docs-only):** `docs/current-state.md` living router
+  (+ structure-pin test); wired into the read path (`CLAUDE.md` precedence +
+  `AGENT_ORIENTATION` "Any task"); journal split into **guidebook head** + **append-only
+  log** with a correct-in-place freshness rule + an end-of-session documentation checklist
+  (lessons/facts relocated to Rules); status-badge legend + demotion of the source-of-truth
+  index & its chain to `historical`; `docs/ideas/` with a promotion pipeline (AI backlog
+  moved in); `docs/subsystems/` folio template + index with the **AI folio piloted**.
+- **Design model:** Layer 1 cross-cutting (CLAUDE.md → current-state.md → journal →
+  AGENT_ORIENTATION) + Layer 2 per-subsystem folios; drift-guard = one-fact-one-home, global
+  current-state.md stays a thin index over folios.
+- **Decisions (maintainer):** all 3 phases this session; per-session-file split DEFERRED.
+  **My calls:** added the subsystem layer (folio template + AI pilot) and a router
+  structure-pin test; left the pinned `ai-config-ownership.md` + the code-referenced mining
+  brainstorm in place (linked, not moved).
+- **Next:** build out the remaining subsystem folios (self-directed per area). AI live-tests
+  on production still owed — see `docs/current-state.md` "Next candidates".
+- **For project state, see `docs/current-state.md`** — not restated here.
+
+### 2026-06-06 — Bot-awareness programme COMPLETE (PR4–PR6 shipped)
+- **Arc:** attended Opus session finishing the bot-awareness / AI-assisted diagnostics
+  programme. Continued from the #537 foundation (PR1–PR3); reconciled a ChatGPT revision
+  report (verified live on GitHub + against source, **not on faith**) into a revised plan,
+  then executed **PR4 → PR5 → PR6** on `claude/gifted-mayer-LGraE` (branched from current
+  `main` d29705d so it includes #540's docs; #540 + the open #539 are both docs-only).
+- **Key revision catch:** the shipped PR1 adapters ALREADY emit stable per-source
+  fingerprints (`diagnostics.provider_failed:{name}`, …), so the original PR4 ("rewrite
+  fingerprints + fold") was wrong — it would change cardinality for no gain and break
+  rollback. PR4 re-scoped to ADD a grouped recent-error subsystem over the unstructured ring
+  buffer, leaving existing fingerprints untouched.
+- **Shipped (each gated green — `check_architecture` strict 0 errors, `check_quality --full`):**
+  - **PR4 — grouped recent-error findings (opt-in):** NEW `services/health_observations.py`
+    (stdlib-only: owns the redaction regexes + `normalize_text` — `hss._scrub` now delegates —
+    plus a deterministic ID-free `fingerprint()` + `group_log_errors()`).
+    `health_snapshot_service._errors_subsystem` reads a bounded `recent_errors` diagnostics
+    provider (registered from `diagnostic_cog.setup`; cogs register INTO the registry, so no
+    services→cogs import) and groups it; added ONLY when `HEALTH_GROUPED_FINDINGS` is truthy
+    (**default OFF** → legacy `!recent_errors` is the untouched fallback = true rollback).
+    Defensive `_group_findings` fold in `_finalize`; `_render_health_embed` shows `(×N)`.
+  - **PR5 — owner-gated AI tool + D1:** `_derive_scope` maps `config.BOT_OWNER_USER_ID` →
+    `AIScope.PLATFORM_OWNER` (checked first, id-gated; **D1 RESOLVED, option a**). New
+    `diagnostics_health_snapshot` AIToolSpec (min_scope=PLATFORM_OWNER) + handler;
+    `_audience_for_scope` boundary; `build_registry` gains a None-tolerant `bot` kwarg;
+    `snapshot_to_payload` (bounded, JSON-serializable, `schema_version=1`). Owner-recognition
+    pin extended in `test_bot_owner_recognition.py`. #536 descriptor/toolset primitives
+    confirmed **DOC-ONLY** → used the current catalog path + a `TODO(#536)`.
+  - **PR6 — persistent findings:** migration `057` (`operational_health_findings` +
+    `_aggregates`); sole-writer `services/health_findings_service.py` over pool-only
+    `utils/db/health_findings.py` (ON CONFLICT dedupe by fingerprint, reopen-on-recurrence,
+    keep-ignored); recorded + pruned best-effort from `bot1._report_startup_health` (after
+    `record_startup_snapshot`, in the already-managed task) keyed to `services.runtime.BOOT_ID`;
+    30-day TTL with roll-up-to-aggregates; `!platform findings [open|resolved|ignored|all]`
+    (owner-only hints redacted for non-owner admins); **metrics only, no new events**;
+    sole-writer AST guard `test_inv_health_findings_service.py` + readonly-aggregator extension.
+- **Decisions (maintainer):** scope = all remaining; D1 = owner→PLATFORM_OWNER; retention =
+  30d defaults. **My call:** PR4 grouping default flipped to **OFF/opt-in** (production-safe;
+  changed from rev-1's default-on after the revision flagged rollout risk). Panel "Ask AI to
+  explain" button DEFERRED (AI-on render can't be sandbox-tested; the tool alone is reachable).
+- **Verification:** CI gates green per PR (7565 tests). **NOTE (corrected 2026-06-06):** I
+  wrongly believed the sandbox "can't boot" — it CAN (Postgres + Discord test token, Full
+  network), so PR4/PR6's deterministic + DB paths were bootable here and I should have
+  integration-tested them (boot → migration 057 applies → findings persist to Postgres →
+  `SELECT` to confirm). Only the PR5 AI path truly needs production (no AI key here). The
+  maintainer live-tests the AI path on production.
+- **Live-test follow-ups owed (maintainer):** PR4 — `HEALTH_GROUPED_FINDINGS=1`, induce repeated
+  errors → one `(×N)` finding, flip off → legacy fallback. PR5 — owner asks "how healthy are
+  you?" → model calls `diagnostics_health_snapshot`; non-owner admin NOT offered it; AI-off keeps
+  `!platform health` working. PR6 — `!platform findings open`; restart with same failure →
+  occurrence_count increments (dedupe).
+- **New lesson → Rules:** verify "rewrite X" plan items against shipped source first — the PR4
+  fingerprint rewrite would have silently changed PR6's dedupe cardinality and broken rollback.
+
+### 2026-06-06 — Bot-awareness plan revised + executed (PR1–PR3 of the programme)
+- **Arc:** dedicated Opus planning session that (a) reconciled the Codex map (#534)
+  + the newer Codex AI-tool-orchestration successor doc (#536, on `main`) + a ChatGPT
+  revision pass into an approved implementation plan, then (b) — at the maintainer's
+  request to "do as much as can be SAFELY executed unattended (I'm going to sleep)" —
+  **executed the foundation slice PR1→PR3** on `claude/fervent-turing-J1giu`.
+- **Plan:** `docs/bot-awareness-implementation-plan.md` (approved); banner added atop the
+  Codex map `docs/bot-awareness-diagnostics-plan.md`. AI-assisted diagnostics OVER the
+  existing observability stack — no `bot_awareness_service`.
+- **Shipped (3 commits, each gated green — `check_architecture` strict 0 errors,
+  `check_quality --full` 7521 passed):**
+  - **PR1 — contracts + aggregator:** `services/health_contracts.py` (frozen
+    HealthSnapshot/SubsystemHealth/OperationalHealthFinding + SnapshotStatus/
+    FindingSeverity/**HealthAudience**; zero AI dep — deterministic health is decoupled
+    from `AIScope`), `services/health_snapshot_service.py` (two lanes:
+    `collect_cached_snapshot` sync + async `collect_snapshot` with per-source
+    `asyncio.wait_for` isolation; deterministic severity; **pure `project_for_audience`**
+    redaction; heavy adapters imported **function-locally**), `utils/db/health.py`
+    (SELECT 1 ping). Tests: severity table, sync/async source isolation, **per-adapter
+    redaction OMISSION**, import-safety, read-only AST pin.
+  - **PR2 — `!platform health` UX:** `build_health_embed` (reuses `clamp_embed`),
+    admin-gated `!platform health` (owner → full, other admins → guild-redacted via
+    central `resolve_audience`), "health" panel item routing through the SAME builder.
+  - **PR3 — startup health (panel-only):** sibling `ExtensionLoadOutcome` recorder in
+    `startup_outcome` (NOT a `KNOWN_PHASES` entry — that's doc-pinned), `_load_cogs`
+    records per-extension outcomes, `on_ready` spawns ONE settled-startup snapshot via
+    `tasks.spawn` (INV-K) guarded by `_maybe_report_startup_health` (reconnect-safe,
+    unit-proven), `_extensions_subsystem` (only `bootstrap_access_cog` failure is
+    CRITICAL), `!platform startup`. Also a **root-cause fix**: `diagnostics_service.
+    snapshot_all()` now iterates a stable copy (a provider that lazily self-registers
+    another at startup no longer raises "dict changed size during iteration").
+- **Deferred / blockers (for the maintainer when awake):**
+  - **Live boot NOT done this session** — out of (over)caution about the
+    `DISCORD_BOT_TOKEN_PRODUCTION` name, not an actual block. *(Corrected 2026-06-06:
+    booting the dedicated test bot is always allowed and safe — see the Runbook; this
+    session could have booted to integration-test.)* All PR1–PR3 logic is unit-tested +
+    gated; the `on_ready` hook is best-effort/off-path so it cannot break boot.
+  - **PR4 (structured observations / grouped errors)** — intentionally NOT attempted
+    unattended (its stop-condition is "ship grouping disabled rather than tune
+    fingerprint heuristics unattended").
+  - **PR5 (AI diagnostics tool) — BLOCKING DECISION D1:** `_derive_scope`
+    (`natural_language_stage.py:894-922`) ceilings at `AIScope.SERVER_OWNER`; a
+    `PLATFORM_OWNER` tool is unreachable. Same gap as #536's D5. Decide: extend
+    `_derive_scope` to recognize the bot owner, or register at `SERVER_OWNER`.
+  - **PR6 (persistent findings)** — needs the retention/history decision (D8/D11);
+    migration `057` is the next free number.
+- **Live cog audit:** still considered complete as of #535; this session added net-new
+  read-only diagnostics, no behavior change to existing cogs.
+- **Post-merge (same session): #537 MERGED.** Synced the branch to merged `main`
+  (`a4273bd`) and re-verified: `check_quality --full` green, and an integration smoke of
+  the aggregator against **real local Postgres** — async lane `database` subsystem pinged
+  `reachable: True`, both lanes ran, admin projection leaked no owner-only fields. Then
+  reconciled the docs to shipped status (`bot-awareness-implementation-plan.md` header +
+  §5 marked PR1–PR3 ✅ #537; orientation doc lists the plan as the health programme's
+  execution authority).
+
+### 2026-06-06 — Session close: PR B nav fix shipped; bot declared fully tested
+- **Arc** (continues the PR A entry below): refined the stability plan through the
+  GPT/Revision pass (**#531**, merged), added the CI docs-skip (**#532**, merged), then
+  ran the **PR B live cog walk** with the maintainer driving the clicks.
+- **PR B (#535, open):** the walk's one real defect was a **back-navigation class** —
+  directly-invoked hubs (`!modmenu`/`!economymenu`/…) had no "↩ Back to Help" and Economy
+  dropped the chain via the Work sub-path. Fixed holistically + layer-clean
+  (`panel_manager.get_or_render_panel` calls a **registered** back-to-help hook wired from
+  `bot1`; Economy Work views `chain_back` the grandparent). **Live-confirmed.** Tracker
+  reconciled (#528 fixes) + UX findings logged.
+- **Maintainer decision:** **bot is fully tested & working as of #535** — no full
+  re-audit for the next few sessions (see "Current verified state" up top).
+- **New lessons → Rules above:** 800-LOC cog ceiling (wire hooks from `bot1`, not a maxed
+  cog); modals can't hold a Select; GitHub merge-commit "Unverified" stop-hook is a false
+  positive (don't amend); CI skips the heavy suite on docs-only PRs.
+- **Checks:** `check_architecture` 0 errors; `check_quality --full` 7470 passed; clean
+  boots throughout (last boot_id `22f8ccee`).
+
+### 2026-06-06 — GPT Prompt Forge cross-agent workflow clarification
+- **Context:** maintainer clarified that the project is for fun but treated seriously,
+  and that root-level workflow memory must be exact because misconceptions here can
+  confuse future agents.
+- **Captured:** Prompt Forge is the normal starting point for structured prompts;
+  Codex is used for broad mapping / verification / first-pass scaffolding when useful;
+  specialised GPT/Revision projects provide extra checks and final-plan critique;
+  Claude Opus 4.8 1M context is the normal implementation path.
+- **Workflow clarified:** Claude Opus planning sessions are read-only by design;
+  after Opus proposes a plan, the Revision project critiques it, then Opus receives
+  that output for final revision and full execution once the maintainer accepts.
+- **Guardrail:** do not describe Codex as the default implementation agent.
+
+### 2026-06-05 — PR A: pin discord.py + route channel-delete through ChannelLifecycleService
+- **Scope:** first implementation PR of the refined stability plan, after the GPT/Revision pass.
+  Executed on `claude/trusting-curie-zRheM` (fast-forwarded to current `main` `7ffe3c7`).
+- **Shipped:**
+  - `requirements.txt`: `discord.py>=2.3.0` → **`>=2.7,<2.8`** (closes the long-standing pin blocker).
+  - `disbot/views/channels/delete_panel.py::_DeleteConfirmView.confirm_btn` now routes deletes
+    through `ChannelLifecycleService.apply(operation="delete", confirmed=True)` instead of
+    `channel.delete()` directly — panel deletes finally emit the audit companion +
+    `channel.lifecycle_changed` event. Result embed rebuilt from the typed `LifecycleResult`,
+    preserving the deleted / permission-denied / not-found / failed buckets (re-mapping the
+    service's id-named not-found step back to the display name).
+  - Widened `tests/unit/invariants/test_no_direct_channel_mutations.py` to scan
+    `disbot/views/channels/**` (excludes message receivers; doesn't flag the deferred
+    `set_permissions`). Added `tests/unit/views/test_discordpy_ui_collisions.py` — a repo-wide,
+    self-maintaining guard for the #528 collision class (`_refresh` shadowing; `self.parent`/
+    `_parent` on `ui.Item` subclasses). Rewrote `test_delete_panel_multi.py` to the
+    service-routing pattern.
+- **Verification:** `check_architecture --mode strict` = 0 errors; `check_quality --full` = green;
+  targeted view/invariant suite green. Live-checked on the booted test bot (`!channelmenu → Delete`).
+- **Next:** begin PR B (live cog-audit completion) per the accepted plan.
+
+### 2026-06-05 — Opus stability-plan refinement + live boot (env IS available here)
+- **Scope:** dedicated Claude Opus planning session refining Codex's stability pre-impl
+  pass (#529) into an execution-ready **next-3-PR** plan. Wrote
+  `docs/planning/stability-implementation-plan-refined-2026-06-05.md`. No source implemented.
+- **Live env — CORRECTION to the older entry below:** *this* editing container **does** expose the
+  runbook creds (`DISCORD_BOT_TOKEN_PRODUCTION` len 72 / 3-seg; `DATABASE_URL` = localhost
+  `postgresql://…`), and Postgres 16 binaries + the `postgres` user are present. The maintainer
+  confirmed the bot can be booted **only** in the editing environment (hence plan mode was
+  exited). **Booted it clean:** Galaxy Bot#6724, 34 cogs, migrations applied 0 errors,
+  identity-contract clean, connected to 2 servers, 0 ERROR/CRITICAL (only benign
+  webhook/PyNaCl WARNINGs). discord.py 2.7.1 verified good live. ⇒ Codex F2 ("live unavailable")
+  is container-specific, not universal; **PR B's live cog audit is executable here.**
+- **Postgres bring-up recipe (durable):** as root — `initdb -D /tmp/pgdata -A trust -U postgres`
+  (run via `su postgres -s /bin/bash -c …`, dir chowned to `postgres`); start with
+  `pg_ctl -D /tmp/pgdata -o '-p 5432 -k /tmp/pgrun -c listen_addresses=127.0.0.1' -l /tmp/pg.log start`;
+  then create role+db `superbot` parsed from `DATABASE_URL` (trust auth ⇒ password is cosmetic).
+  Verified `psql "$DATABASE_URL"` connects. Then `python3.10 disbot/bot1.py` (schema self-bootstraps).
+- **Checks:** `check_architecture.py --mode strict` = 0 errors; `check_quality.py --full` = GREEN
+  (7461 passed, 3 skipped, 20 warnings).
+- **Codex reconciliations:** delete-panel finding is real but at `disbot/views/channels/delete_panel.py:239`
+  (Codex dropped the `disbot/` prefix); **F12 downgraded** to ledger-text drift (the cleanup
+  prohibited-word write is an *allowed* `accepted-direct-write` per `ownership.md:64`, while
+  `direct-db-exception-ledger.md:37` still calls cleanup reads-only); **F15 reframed** — amending
+  the AI doc is lower-friction than implementing guild presets (doc-pin test doesn't assert scope;
+  guild mutation has no `UNCHANGED` sentinel). Kept AI/BTD6 out of the next-3 scope.
+- **Plan shape:** PR A (pin discord.py + route delete panel through `ChannelLifecycleService` +
+  widen invariant to `views/channels/**` + self-maintaining collision check) → PR B (live cog
+  audit / hard-failure fixes / tracker reconcile) → PR C (cleanup ownership+ledger contract = queued
+  PR8). Opened end-of-session PR **#531**.
+- **Journal conflict (recurring class — now documented):** #530 merged to `main` mid-session and
+  inserted its own Session-Log entry at the same anchor, so #531 hit the same `.session-journal.md`
+  conflict that #529→#530 did. Resolved by **union** (kept both entries, newest-first). Added a
+  prevention/resolution rule to the Protocol + an Ideas entry proposing per-session entry files.
+
+### 2026-06-05 — stability preimplementation verification pass
+- **Scope:** planning/verification only; wrote `docs/planning/stability-preimplementation-plan-2026-06-05.md` for the Opus refinement session.
+- **Confirmed blockers:** unpinned discord.py; `views/channels/delete_panel.py` bypasses `ChannelLifecycleService`; cleanup ownership/config remains split; AI binding doc overstates guild-preset support; ADR-006 provenance/provider-parity gate still blocks BTD6 extraction; live cog tracker remains incomplete/stale after #528.
+- **Checks:** strict architecture passed (0 errors / 87 tracked warnings); broad targeted suite passed (5,831 passed, 3 skipped); full quality rerun completed after installing the missing Python 3.10 dependencies.
+- **Environment difference:** this container did not expose the journal-documented bot token/`DATABASE_URL`, postgres user, or Postgres binaries, so the live bot could not be booted. `gh` was also unavailable, so open PR state remains unverified.
+
+### 2026-06-05 — server-management audit + discord.py-2.7 crash fixes + diagnostic suite
+- **Context:** maintainer pivoted a role-panel-polish session into a structured,
+  cog-by-cog functionality audit driven by live testing against the booted test bot.
+- **Shipped (branch `claude/charming-ride-7Whiq`):**
+  - `fix(roles)`: two discord.py 2.7.1 internal collisions — `_refresh(self)` shadowing
+    `View._refresh(components)` (crashed the whole bot on MESSAGE_UPDATE) and
+    `self.parent =` on `Select` subclasses hitting the now-read-only `Item.parent`
+    (broke Delete/Remove). Root cause: unpinned discord.py. Regression-pinned by
+    `tests/unit/views/test_role_panels_discordpy_compat.py`.
+  - `fix(diagnostic)`: working "Recent Errors" (in-memory ring buffer instead of a
+    `logs` table nothing wrote to), migration-based "Schema Check" (instead of a
+    16-table hardcoded list that flagged 52 real tables as "unexpected"), and a
+    **total-6000 embed clamp** in `clamp_embed` (fixes the `!platform` "no back button"
+    + any oversized panel bot-wide).
+  - `docs`: seeded `docs/planning/cog-functionality-audit-2026-06-05.md` (full per-cog
+    command/panel inventory + env-gate map + findings).
+- **Problems→fixes & my mistakes:** distilled into the Environment Runbook + Rules
+  above (pkill self-match; schema regex missing runtime tables; rename missing a test
+  ref; benign router noise; pytest polluting `bot.log`).
+- **Preferences observed:** captured in Operating Preferences above.
+- **Closed:** opened end-of-session PR **#528** (discord.py-2.7 crash fixes +
+  DiagnosticCog suite + this journal); `check_quality --full` + `check_architecture`
+  green at open.
+- **CI follow-up:** #528's first `code-quality` run failed `black` (migrations.py) +
+  `ruff` D209 (_log_buffer.py); fixed with the pinned linters, re-verified against the
+  exact workflow commands, re-pushed (`73a943f`). → new lint Rule above.
+
+## 2026-06-06 — AI extra-tool capability roadmap refinement
+
+- Verified local `main` equivalent at `60f1cd2` against the GitHub API. Only PR #539
+  (`docs: add AI extra tool capability ideas backlog`) was open; no open bot-awareness
+  PR4–PR6 was visible. PR #539 is docs-only and one commit ahead of `main`.
+- Re-read the binding architecture/orientation docs, approved bot-awareness implementation
+  plan, bot-awareness repository map, BTD6 orchestration plan, PR #539 backlog from its
+  exact branch, current AI provider/tool-loop source, and shipped health source.
+- Confirmed PR1–PR3 are shipped and the health implementation plan remains execution
+  authority. Confirmed `_derive_scope()` still cannot return `AIScope.PLATFORM_OWNER`,
+  so bot-awareness PR5 and other owner-only AI tools remain blocked on D1.
+- Confirmed `AIToolDescriptor`, `AIOrchestrationPolicy`, `AIToolBudget`, `AIToolChoice`,
+  and `ToolRequirementMode` remain planned rather than shipped source types. Existing
+  scheduler/notification capability is owned by the automation services and must not be
+  duplicated by AI tooling.
+- Added `docs/ai-tool-capability-roadmap.md`: a non-authoritative, source-verified roadmap
+  proposal that triages capability families, defines architecture/safety/test gates,
+  merges duplicate ideas into existing authorities, and limits the conditional next
+  implementation sequence to the shared orchestration foundation plus bounded public-doc
+  knowledge search.
+- No runtime code, migration, PR4–PR6 implementation, connector, or action tool changed.
+
+## 2026-06-06 — PR #544 cross-agent review: verified, then fixed 4 contradictions
+
+Context: asked a sibling chat for feedback on the open doc-restructure PR #544. It
+rated it 8.5/10, flagged 4 "contradictions to fix before merge" + 2 refinements.
+**Verified every claim against source before touching anything** (the "verify
+cross-agent output, don't follow on faith" rule) — all 4 held up; applied them on
+`claude/friendly-babbage-0BkSu`. Doc-only; 53 doc tests + `check_quality --check-only`
+green.
+
+- **Read-order (`.claude/CLAUDE.md`):** opening led with "open AGENT_ORIENTATION first",
+  contradicting the designed spine. Now states the order explicitly: this file →
+  `current-state.md` → `.session-journal.md` → AGENT_ORIENTATION (task routing).
+- **Demoted SoT index:** its internal "Read first" / "trust now (✅ current)" sections
+  still read as live instructions under the new "historical" banner. Reframed both as
+  2026-06-05 historical snapshots.
+- **`ai-tool-capability-roadmap.md`:** header gate + §2.5 stop-conditions + Phase-0
+  checklist + deferral table all still said platform-owner/D1 was *unresolved*, while
+  §1/§2.2 said *resolved (#541)*. Made the whole doc consistently "resolved"; marked
+  §2.1's pre-#541 verification snapshot historical.
+- **`AGENT_ORIENTATION` server-mgmt entry:** restated the tracker as "#520–523 / queue
+  PR5+" — stale. De-brittled to point at the tracker's Shipped/Remaining-queue sections;
+  fixed the tracker's own stale header (body is current through PR7 / queue PR8).
+- **Refinements:** added "don't summarize plans'/trackers' PR numbers here" to
+  current-state's one-fact-one-home rule; split the AI folio's "Plans (pending approval)"
+  from "Ideas (not approved)".
+
+**Two lessons (candidate Rules):**
+1. **Verify a status claim against the tracker's BODY, not its header.** The server-mgmt
+   tracker *header* says "verified @ #523", but its **Shipped/Remaining-queue body** is at
+   PR7 / queue PR8. I almost *rejected* the (valid) review claim #4 on the header alone —
+   the body proved the reviewer right. Read Shipped/Queue sections, not the date stamp.
+2. **Same-dated docs can contradict; SOURCE WINS — check it before "fixing" a contradiction.**
+   This very journal's 2026-06-06 roadmap entry says `_derive_scope()` *can't* return
+   `PLATFORM_OWNER`; the roadmap doc says D1 *resolved*. I nearly aligned the doc the wrong
+   way on the journal's say-so. Source settled it: `natural_language_stage.py:913-914`
+   returns `AIScope.PLATFORM_OWNER` for `BOT_OWNER_USER_ID`, and **#541 is merged**
+   (D1 resolved). The journal entry above was written hours before #541 merged and is the
+   stale one. Journal entries are point-in-time; verify D1-class claims against source.
+
+## 2026-06-06 — subsystem folio mapping expansion
+
+- Confirmed the local HEAD is merge commit `508c638` for merged PR #544. This checkout
+  has no configured `origin` and no GitHub CLI, so open-PR enumeration/fetch was not
+  possible; corrected only the provably stale current-state claim that #544 was in flight.
+- Added canonical folios for health/diagnostics, server management, settings/bindings/
+  provisioning, BTD6, games, and media/YouTube. Each separates shipped/current state,
+  degraded or verification-needed behavior, pending plans, unapproved ideas, next
+  candidates, source entry points, and authoritative related docs.
+- Updated the subsystem index and navigation/orientation routes to prefer folios. Kept
+  existing contracts/plans in place to avoid risky reference and doc-test churn.
+- No runtime features, BTD6 extraction, AI expansion, doc moves, or live-runtime claims.
+- Natural next docs-maintenance candidate: perform the existing journal review every 3–5
+  sessions, promote stable lessons into their permanent homes, and clarify whether each
+  item belongs in the journal, `docs/current-state.md`, a subsystem folio, `docs/ideas/`,
+  a planning doc, or a binding doc. Keep the journal as process memory, not a second roadmap.
+
+## 2026-06-06 — server-mgmt cleanup PR8 + PR9 (shipped) + guild-default root-cause fix
+
+Planning session (read-only by design) that the maintainer converted to execution
+("plan approval = full execution"). Two ChatGPT-driven scope decisions were locked
+first: **presets-only (lean)** for the policy model, and **dedicated cleanup panel**
+(async helper) for diagnostics. A prior ChatGPT review of the plan had 4 required
+corrections — all verified against source before trusting them (the "verify
+cross-agent output" rule); all 4 held. Shipped both as sequential commits on one
+branch (`claude/nifty-cerf-59MKG`) → one end-of-session PR (the established
+one-PR-per-session pattern, e.g. #541 did PR4→PR6).
+
+- **PR8** (`fbdb3c4`): migration `058` adds `cleanup_policies.policy_version INT NOT
+  NULL DEFAULT 1` (additive; PK + RC-5 CHECK untouched; resolver unchanged →
+  behaviour byte-identical). `cleanup_levels`: `level_for_columns` round-trip +
+  `POLICY_VERSION`. `get_all_cleanup_for_guild` returns the new column.
+- **PR9** (`2b72f3c`): `services/cleanup_diagnostics.py` (async, presets-only) —
+  diagnostics (level naming, stale-scope + ineffective-row detection), dry-run
+  preview (reuses the **real** resolver → preview == runtime, no writes), audited
+  apply through the unchanged pipeline. `views/cleanup/policy_panel.py` builder
+  (scope → level → preview → confirm → apply) + "Cleanup Policies" button on the
+  cleanup hub. Admin re-check at the mutation point.
+
+**Root-cause bug found while building PR9 (and fixed, maintainer chose "fix now"):**
+the setup wizard wrote guild-default cleanup at `scope_id=0`, but the resolver looks
+up guild policy at `scope_id=guild_id` (`_build_scope_chain` maps guild→`ctx.guild_id`)
+— so **guild-default cleanup chosen in setup never took effect** (channel/category
+were fine). Centralised the write-side convention in
+`cleanup_levels.cleanup_scope_id()` and fixed `setup_operations`. The old test
+`test_set_cleanup_policy_routes_through_governance_writer` literally asserted
+`scope_id == 0` — it had **encoded the bug**; updated it.
+
+**Verification:** booted local Postgres (journal runbook worked verbatim) and
+verified live: `058` applies + backfills, the guild-default fix resolves to
+`GUILD_OVERRIDE`, legacy `scope_id=0` confirmed no-op, and diagnostics/preview run
+end-to-end against real rows. `check_architecture --mode strict` 0 errors;
+`check_quality --full` green (7649 passed). Real-PG integration tests skip cleanly
+in CI (module-local `DATABASE_URL`/unreachable skip, per
+`test_health_findings_integration.py`).
+
+**Descope recorded:** the implementation plan's PR8 JSONB "dimensions" column is
+**deferred** (no consumer yet) — only `policy_version` shipped. The next session
+must NOT "follow the doc" and add JSONB. Diagnostics flag legacy `scope_id=0` guild
+rows as ineffective so operators can re-set them.
+
+**Lessons (candidate Rules):**
+1. **A test can encode a bug — read what it asserts, not just whether it's green.**
+   `scope_id == 0` was a passing test that locked in a silent no-op. When a write
+   convention and a read convention must agree, pin the agreement (here: a live
+   resolver round-trip), not one side's current value.
+2. **The ephemeral sandbox Postgres dies on session resume.** A `SessionStart:resume`
+   stopped the `/tmp/pgdata` server mid-session; re-run the boot recipe (it's
+   idempotent — the `PG_VERSION` check skips re-initdb) before live DB work.
+3. **Centralise cross-component conventions in one helper.** `cleanup_scope_id()`
+   now owns the guild→`guild_id` keying so a writer can't silently diverge from the
+   resolver again.

--- a/.session-journal.md
+++ b/.session-journal.md
@@ -1,12 +1,18 @@
 # .session-journal.md — SuperBot working memory
 
 > **What this is:** cross-session **process memory** for how the maintainer +
-> assistant agents work on SuperBot. Two parts:
+> assistant agents work on SuperBot. It is a **fast-read working set, not an
+> archive** — keep it lean. Three parts:
+> - **⚡ Quick reference** — the "boot + verify" cheat sheet you need most sessions.
+>   Scan it first.
 > - **Guidebook (edit in place)** — the environment/boot Runbook, Operating
 >   Preferences, Cross-Agent Workflow Preferences, and hard-won Rules/Conventions.
 >   Read it every session; the moment you find an entry stale, **correct it in
 >   place** with a dated `(corrected YYYY-MM-DD)` marker — don't just append a note.
 > - **Session Log (append-only)** — one dated entry per session of what happened.
+>   Only the **most recent** sessions stay here; older entries roll into
+>   **`.session-journal-archive.md`** (grep it on demand). At session end, move
+>   entries older than the newest ~4 to the archive so this file stays a fast read.
 >
 > **What this is NOT:** a feature doc, and **not** project state. Bot architecture /
 > roadmaps live in `docs/` (and `docs/planning/`); **"what is true right now"**
@@ -30,19 +36,39 @@
 > we're killing). The durable lessons + repo facts that used to live here are now
 > folded into **Rules / Conventions** and the **Runbook** below.
 
-**Now:** restructuring the docs (this session). See `docs/current-state.md` "Next
-candidates" and the newest Session Log entry for where it stands. Maintainer decision:
-the per-session-file Session-Log split (`.sessions/…`) is **deferred** (2026-06-06) —
-serial sessions make the merge-conflict class rare for now.
+**Now:** see `docs/current-state.md` for project state and the newest **Session Log**
+entry below for the last session's work. (Keep this block a thin pointer — don't let
+project state accumulate here.)
+
+---
+
+## ⚡ Quick reference (the 80% you need every session)
+
+> Booting the test bot is **always allowed and safe** — it's the dedicated test bot
+> *Galaxy Bot#6724*, not prod. Full detail in the **Environment Runbook** below.
+
+| Need | Do |
+|---|---|
+| **Boot the bot** | `python3.10 disbot/bot1.py` (from repo root; launch via `run_in_background`). Watch `/tmp/testbot.log` for `ERROR/CRITICAL/Traceback`. |
+| **Postgres down** (fresh container / after resume) | Re-run the **Runbook** bring-up recipe — idempotent (`PG_VERSION` check skips re-initdb). |
+| **Run CI locally before push** | `python3.10 scripts/check_quality.py --full` (true CI mirror) **and** `python3.10 scripts/check_architecture.py --mode strict` (0 errors). |
+| **Kill a running bot** | `for pid in $(pgrep -f disbot/bot1); do [ "$(cat /proc/$pid/comm)" = python3.10 ] && kill "$pid"; done` (plain `pkill` self-kills the shell). |
+| **End of session** | Open a PR (every session); append a Session Log entry; roll old entries to the archive (Protocol → END). |
+
+**Three rules that bite hardest:** (1) booting is safe — don't treat it as blocked;
+(2) **verify cross-agent output against source** before acting on it; (3) **root-cause,
+one source of truth** over per-panel patches. Full set under **Rules / Conventions**.
 
 ---
 
 ## Protocol — what to do with this file each session
 
 - **START:** read `docs/current-state.md` first (project state), then this file
-  right after `.claude/CLAUDE.md`. Skim the **Environment Runbook** (so you don't
-  re-derive how to boot the bot), **Operating Preferences**, **Rules/Conventions**,
-  and the latest **Session Log** entries. Fold open items into your plan.
+  right after `.claude/CLAUDE.md`. Hit the **⚡ Quick reference** first, then skim the
+  **Environment Runbook**, **Operating Preferences**, **Rules/Conventions**, and the
+  **recent Session Log** entries here (older history is in
+  `.session-journal-archive.md` — grep it on demand, don't read it top-to-bottom).
+  Fold open items into your plan.
 - **DURING:** capture as they happen — a non-obvious problem+fix, a mistake worth
   not repeating, a stated/observed preference, an architecture ask. If you find a
   guidebook entry is stale, **correct it in place** with `(corrected YYYY-MM-DD)`.
@@ -55,6 +81,13 @@ serial sessions make the merge-conflict class rare for now.
   3. Banner or update any **plan** whose status changed; file any new **idea** under
      `docs/ideas/` (marked not-approved).
   4. Commit + push (docs land with the PR).
+  5. **Tidy as you go (keep it lean) — every session, not just at REVIEW.** This file
+     is a fast-read working set. The guidebook (Runbook + Rules) is fixed overhead; the
+     **Session Log is the part that grows**, so keep it to roughly the **newest ~4
+     entries** — move anything older into `.session-journal-archive.md` (newest-first
+     there too). If a Rule went stale or now duplicates the Runbook, fix/merge it **in
+     place**; refresh the **⚡ Quick reference** if a boot/CI fact changed. Leave the
+     journal a little tighter than you found it — never longer for its own sake.
 - **MERGE CONFLICTS here are expected — resolve by UNION.** The Session Log is a
   structural hotspot: every branch inserts a new entry at the *same* anchor (top of
   "Session Log (newest first)"), so any two concurrently-open PRs collide there
@@ -202,38 +235,12 @@ confidence; do not treat booting as gated.
 
 ## Rules / Conventions (candidate — not yet promoted to CLAUDE.md)
 
-- **Pin churn-prone deps** and audit `discord.ui` overrides on version bumps —
-  unpinned `discord.py>=2.3.0` resolving to 2.7.1 caused `View._refresh` / `Item.parent`
-  collisions that crashed the bot.
-- **Grep ALL references (incl. tests) before a rename** — a missed test mock cost a red
-  suite mid-session.
-- **Validate a derivation against ground truth before shipping** — a migration-table
-  regex silently missed runtime-created tables.
-- **Run the exact CI lint commands on changed files right before `git push`** —
-  `black --check .` / `isort --check-only .` / `ruff check .` with the workflow's
-  flags/excludes. PR #528's first `code-quality` run failed `black` (a >88-char line in
-  `migrations.py`) + `ruff` D209 (the new `_log_buffer.py` docstring) that weren't
-  surfaced at push time. The PostToolUse auto-format hook may not fire in the
-  remote/web container, so don't rely on it; verify the formatters yourself.
-- **Cog files have an 800-LOC hard ceiling** (`tests/unit/invariants/test_cog_size.py`).
-  Adding even ~6 lines to a cog already at the ceiling fails CI — `help_cog.py` was at
-  exactly 800 this session, which broke the first full run. **Check a cog's LOC before
-  adding to it**; wire cross-cutting hooks from `bot1` (the composition root), not from a
-  maxed cog. The invariant's intent is to decompose (move view code to `views/<sub>/`),
-  not to grow the cog.
-- **A Discord Modal cannot contain a Select** (`UserSelect`/`StringSelect`) — modals are
-  text-input only. "Selector-ize a modal" therefore means a **modal→view restructure**
-  (pick the member in a view → follow-up modal/inputs), not a component swap.
-- **GitHub merge-commit shows as "Unverified" — Stop-hook false positive.** After a
-  fast-forward to `main`, your branch tip IS GitHub's merge commit (committer
-  `noreply@github.com`); the stop-hook flags it and suggests `--amend --reset-author`.
-  **Do NOT** — it's the maintainer's merge on `main`, and amending diverges your branch.
-  It clears as soon as a new verified (`noreply@anthropic.com`) commit lands on top.
-- **CI skips the heavy suite on docs-only PRs** (#532): the `code-quality` workflow has an
-  in-job changed-files detector — docs/`*.md`-only PRs finish in seconds; any `.py` /
-  `requirements*` / `.github/workflows/**` change still runs the full suite. A fast green
-  on a docs-only PR is expected, not suspicious.
-- **Booting the test bot is ALWAYS allowed and safe — do NOT treat it as blocked.**
+> Grouped for fast scanning. **★ = earned across multiple sessions — propose for
+> promotion into `.claude/CLAUDE.md` at the next REVIEW.** Items here are strong
+> defaults; they become *binding* only once the maintainer approves promotion.
+
+### Boot & environment
+- **★ Booting the test bot is ALWAYS allowed and safe — do NOT treat it as blocked.**
   `DISCORD_BOT_TOKEN_PRODUCTION` is a dedicated *test* bot (Galaxy Bot#6724), not the real
   production token, so it cannot collide with the live bot; no maintainer approval is
   needed as a rule. (Earlier entries that called this "blocked by the auto-classifier" or
@@ -245,23 +252,35 @@ confidence; do not treat booting as gated.
   verified on the maintainer's production bot. (Process hygiene: `pgrep -af "disbot/bot1"`
   self-matches the inspecting shell — confirm `comm=python3.10` before believing a bot is
   running.)
-- **When two memory entries contradict, VERIFY** (boot it / ask) — don't pick the
-  scarier one. (We once applied "verify vs source" to code but not to an environment
-  claim, and skipped a valid boot test as a result.)
 - **Authoritative sections (Runbook) outrank candidate Rules.** A candidate Rule
   ("boot blocked") was once believed over the Runbook ("you CAN boot"); the Runbook
   was right.
+- **When two memory entries contradict, VERIFY** (boot it / ask) — don't pick the
+  scarier one. (We once applied "verify vs source" to code but not to an environment
+  claim, and skipped a valid boot test as a result.)
 - **Enumerate ALL verification options** before accepting a constraint — locking onto
   "maintainer tests on prod" once hid the local boot path entirely.
-- **Treat cross-agent output (Codex / ChatGPT reports) as input to verify, not
-  orders.** Verify "rewrite X" plan items against shipped source first — one revision
-  item (PR4 "rewrite fingerprints") was wrong and would have broken PR6's dedupe +
-  rollback.
-- **`utils.db.pool` has no `fetchval`** — use `fetchone` + a `RETURNING` CTE for counts.
-- **Expose cog-layer data to services via a `diagnostics_service` provider** — cogs
-  register INTO services, never the reverse (keeps the services→cogs boundary clean).
 - **`services.runtime.BOOT_ID`** = the process/session id; filter live logs by it to
   separate real bot errors from test-fixture pollution in `bot.log`.
+
+### CI & quality gates
+- **★ Run the exact CI lint commands on changed files right before `git push`** —
+  `black --check .` / `isort --check-only .` / `ruff check .` with the workflow's
+  flags/excludes. PR #528's first `code-quality` run failed `black` (a >88-char line in
+  `migrations.py`) + `ruff` D209 (the new `_log_buffer.py` docstring) that weren't
+  surfaced at push time. The PostToolUse auto-format hook may not fire in the
+  remote/web container, so don't rely on it; verify the formatters yourself.
+- **Cog files have an 800-LOC hard ceiling** (`tests/unit/invariants/test_cog_size.py`).
+  Adding even ~6 lines to a cog already at the ceiling fails CI — `help_cog.py` was at
+  exactly 800 this session, which broke the first full run. **Check a cog's LOC before
+  adding to it**; wire cross-cutting hooks from `bot1` (the composition root), not from a
+  maxed cog. The invariant's intent is to decompose (move view code to `views/<sub>/`),
+  not to grow the cog.
+- **CI skips the heavy suite on docs-only PRs** (#532): the `code-quality` workflow has an
+  in-job changed-files detector — docs/`*.md`-only PRs finish in seconds; any `.py` /
+  `requirements*` / `.github/workflows/**` change still runs the full suite. A fast green
+  on a docs-only PR is expected, not suspicious. (`tests/` is excluded from
+  black/isort/ruff/mypy — only pytest correctness matters there.)
 - **Real-Postgres test = module-local skip-if-unreachable fixture, never a shared conftest
   one.** CI (`code-quality.yml`) runs **no** Postgres service and `tests/conftest.py` has
   **no** DB fixture (by design — every other suite mocks the pool). To exercise real SQL,
@@ -273,6 +292,43 @@ confidence; do not treat booting as gated.
   booted bot's own rows don't perturb assertions. Pytest runs **serial** here (CI +
   `check_quality`), so a shared module prefix is safe. A test's setup-only raw `UPDATE`/
   `DELETE` is fine — the sole-writer AST guards only scan `disbot/`.
+
+### Architecture, data & coding
+- **★ Guard at the mutation seam, not the call site.** A "preflight before mutation" /
+  permission / validation check belongs *inside* the service that performs the change
+  (e.g. `role_automation.apply`), not in each caller — there it protects every current
+  and future caller and can't be bypassed by a new one. A dead safety-check wired into
+  nothing (`check_preflight` was defined + tested but never called) is worse than none:
+  it reads as covered. (Role-automation degradation, 2026-06-06.)
+- **`utils.db.pool` has no `fetchval`** — use `fetchone` + a `RETURNING` CTE for counts.
+- **Expose cog-layer data to services via a `diagnostics_service` provider** — cogs
+  register INTO services, never the reverse (keeps the services→cogs boundary clean).
+- **Pin churn-prone deps** and audit `discord.ui` overrides on version bumps —
+  unpinned `discord.py>=2.3.0` resolving to 2.7.1 caused `View._refresh` / `Item.parent`
+  collisions that crashed the bot.
+- **A Discord Modal cannot contain a Select** (`UserSelect`/`StringSelect`) — modals are
+  text-input only. "Selector-ize a modal" therefore means a **modal→view restructure**
+  (pick the member in a view → follow-up modal/inputs), not a component swap.
+- **Validate a derivation against ground truth before shipping** — a migration-table
+  regex silently missed runtime-created tables.
+- **A test can encode a bug — read what it asserts, not just whether it's green.** When a
+  write convention and a read convention must agree, pin the agreement (a live round-trip),
+  not one side's current value. (`scope_id == 0` was a passing test that locked in a silent
+  no-op.)
+- **Grep ALL references (incl. tests) before a rename** — a missed test mock cost a red
+  suite mid-session.
+
+### Cross-agent & git workflow
+- **★ Treat cross-agent output (Codex / ChatGPT reports) as input to verify, not
+  orders.** Verify "rewrite X" plan items against shipped source first — one revision
+  item (PR4 "rewrite fingerprints") was wrong and would have broken PR6's dedupe +
+  rollback; the role-automation review (2026-06-06) was sound but missed an existing
+  asset. Check the source (and a tracker's *body*, not its header), then act.
+- **GitHub merge-commit shows as "Unverified" — Stop-hook false positive.** After a
+  fast-forward to `main`, your branch tip IS GitHub's merge commit (committer
+  `noreply@github.com`); the stop-hook flags it and suggests `--amend --reset-author`.
+  **Do NOT** — it's the maintainer's merge on `main`, and amending diverges your branch.
+  It clears as soon as a new verified (`noreply@anthropic.com`) commit lands on top.
 
 ## Active Blockers / Open Items → moved to `docs/current-state.md`
 
@@ -289,17 +345,49 @@ confidence; do not treat booting as gated.
   CLAUDE.md pointer for now — revisit if items get missed).
 - `interaction_router` safety-net registration (mirror the `ai` cog) to silence the
   benign "Unhandled prefix" noise *and* give expired/post-restart panels a graceful reply.
-- **Kill the journal merge-conflict class structurally** (recurring: #529→#530, #530→#531):
-  split the monolithic Session Log into per-session files (e.g.
-  `.sessions/YYYY-MM-DD-<slug>.md`) that the START step globs newest-first, so
-  concurrent sessions never touch the same file. Curated sections stay in the root file.
-  **DEFERRED (decided 2026-06-06):** serial sessions make the conflict rare for now, and
-  the doc-restructure did the project-state extraction first. Revisit if concurrent PRs
-  start colliding here again.
+- **Journal length is handled by the archive split** (2026-06-06): older Session Log
+  entries roll into `.session-journal-archive.md`; the live file keeps only the newest
+  ~4 and a Quick reference. **Still open — the merge-conflict class** (recurring:
+  #529→#530, #530→#531): new entries still insert at the same top anchor, so two
+  concurrently-open PRs can still collide there. The structural fix remains per-session
+  files (`.sessions/YYYY-MM-DD-<slug>.md` globbed newest-first). **DEFERRED** — serial
+  sessions make the conflict rare; revisit if concurrent PRs start colliding again.
 
 ---
 
 ## Session Log (newest first — append-only)
+
+### 2026-06-06 — Journal made lean + self-maintaining (archive split, Quick reference, reorganize-each-session)
+
+- **Arc:** maintainer asked for an honest opinion of this journal, then — based on it —
+  to **improve it and make future sessions keep it that way** ("functional and quick to
+  read and remember; reorganize where possible after a session"). Same session as the
+  role-automation fix, separate docs-only PR off merged `main` (89da9ad, incl. #551).
+- **Shipped (docs-only):**
+  - **Archive split** — older Session Log entries moved to NEW
+    `.session-journal-archive.md` (grep-on-demand history); the live journal dropped
+    **843 → ~400 lines**, keeping only the newest ~3-4 entries + the guidebook.
+  - **⚡ Quick reference** added near the top — a 5-row "boot / Postgres-down / run-CI /
+    kill-bot / end-of-session" table + the 3 rules that bite hardest. The 80% you need,
+    scannable in seconds (my #1 suggestion: the load-bearing facts were buried at the
+    bottom).
+  - **Rules / Conventions regrouped** into Boot & environment / CI & quality / Architecture,
+    data & coding / Cross-agent & git, with **★ promotion-candidate** markers. Every prior
+    rule preserved verbatim; folded in two earned lessons (guard-at-the-mutation-seam from
+    the role fix; a-test-can-encode-a-bug from the cleanup session).
+  - **Protocol** now makes "**tidy as you go**" an explicit **END** step (every session,
+    not just the 3-5-session REVIEW): roll old entries to the archive, fix/merge stale
+    Rules in place, refresh the Quick reference. START now says read the Quick reference
+    first + grep the archive for old history. Intro reframed: "fast-read working set, not
+    an archive."
+  - `.claude/CLAUDE.md` — the journal pointer now states the lean/archive expectation so
+    every session inherits it (auto-loaded).
+- **Why (my honest review, acted on):** the guidebook (Runbook + Rules) earned its keep
+  every session; the Session Log's long tail did not and only grew. Bounding the live
+  file's length was the one metric trending the wrong way.
+- **Verified:** no test/script references the journal (`grep tests/ scripts/` — none), so
+  the restructure can't break CI; `tests/unit/docs/` still green. Docs-only.
+- **For project state see `docs/current-state.md`.** (PR pending.)
 
 ### 2026-06-06 — Role-automation degradation FIXED (preflight-at-mutation + failure classification)
 
@@ -391,452 +479,8 @@ confidence; do not treat booting as gated.
   next journal review. New entries: `###`, newest-first, at the top.
 - Verified: `tests/unit/docs/` 54 passed (current-state structure guard green).
 
-### 2026-06-06 — Closed the migration-057 persistence/dedupe/retention integration-test gap (test-only)
-- **Arc:** executed the safest health/diagnostics next-candidate scoped last session
-  (folio "Next candidates" #1). Test-only — no runtime, migration, or architecture change.
-  Branched from current `main` (`8a07617`, post-#547); verified **0 open PRs** live before
-  starting (overlapping-PR stop condition cleared).
-- **Shipped (branch `claude/practical-franklin-mV6Jy`):**
-  - NEW `tests/unit/db/test_migration_057_operational_health_findings.py` — CI-safe static
-    SQL-shape pin (13 tests, mirrors `test_migration_051`): both tables, fingerprint PK on
-    each, status/severity CHECK sets, the `(status, last_seen_at)` index, `CREATE … IF NOT
-    EXISTS` idempotency; and from `utils/db/health_findings.py` the ON CONFLICT occurrence
-    delta-add, the reopen-but-keep-ignored `CASE`, the roll-up `GREATEST`/`LEAST` + summed
-    `total_occurrences`, and the prune `WHERE status IN ('resolved','ignored')`.
-  - NEW `tests/unit/db/test_health_findings_integration.py` — real-Postgres (9 tests) with a
-    **module-local** `postgres_pool` fixture that `pytest.skip()`s when `DATABASE_URL` is
-    unset (CI) or unreachable (sandbox pre-boot). Calls `utils.db.pool.init()` to apply
-    schema+migrations; unique `test:integration:*` fingerprint prefix swept before/after.
-    Covers upsert→open(count=N), re-upsert delta-add + `last_seen` advance + single row,
-    resolved→reopen, ignored→stays-ignored, `list`/`count` by status (before/after deltas
-    so the booted bot's own rows don't perturb it), roll-up→prune (fold w/ summed totals +
-    LEAST/GREATEST window, open rows survive), and `record_findings`/`run_retention` e2e.
-  - EDIT `tests/unit/services/test_health_findings_service.py` docstring — corrected the
-    **false** "integration-tested against real Postgres" claim to point at the two new files.
-- **Invariants held:** `test_inv_health_findings_service.py` green (its raw-SQL/sole-writer
-  AST scan only covers `disbot/`, so the tests' setup-only `UPDATE`/`DELETE` are fine); no
-  services→views; no new events/migrations (chain stays 001→057 contiguous).
-- **Gates + live (all green):** `check_architecture --mode strict` = 0 errors; `check_quality
-  --full` = **7592 passed, 3 skipped**. Brought up local Postgres (runbook recipe) → integration
-  suite 9 passed; with `DATABASE_URL` unset → 9 skipped cleanly (CI parity). Booted the bot
-  (boot_id `258f6e74…`): migration `057` present in `schema_migrations`, `\d` on both tables
-  matches, **0 ERROR/CRITICAL**, and the `Startup health findings: recorded=0 pruned=0` line
-  fired (N=0 expected on a clean boot). **Still owed to maintainer:** the live Discord *render*
-  of `!platform findings`/`health`/`startup` (can't drive the Discord client from the shell).
-- **New lesson → candidate Rule below:** the module-local skip-if-unreachable `postgres_pool`
-  fixture is the repo's pattern for a real-DB test without a shared conftest fixture (CI runs no
-  Postgres). **For project state, see `docs/current-state.md` + the health/diagnostics folio.**
 
-### 2026-06-06 — New-workflow validation run + health/diagnostics next-task scoping (read-only planning)
-- **Arc:** first real test of the cross-session read path. Used it exactly as intended —
-  `CLAUDE.md` → `current-state.md` → journal → `AGENT_ORIENTATION` ("Touching health/
-  diagnostics") → `subsystems/README` → `health-diagnostics.md` folio → linked source +
-  `bot-awareness-implementation-plan.md` → **live GitHub**. Path worked end-to-end with no
-  spoon-feeding; the folio listed the exact source files needed.
-- **Live GitHub verified:** **0 open PRs**, **#546 newest merged** (#545 was a closed dup of
-  #546). Confirms #537 (PR1–PR3) + #541 (PR4–PR6) merged and D1 resolved; nothing newer than
-  #546 open or merged. Cleared the "overlapping open PR" stop condition.
-- **Scoped the safest next task** (folio next-candidate): **close the migration-`057`
-  persistence/dedupe integration gap** — test-only, deterministic (no AI key), sandbox-live-
-  verifiable, no runtime/architecture/migration change. See `docs/subsystems/health-diagnostics.md`
-  "Next candidates" #1 (sharpened this session) for the ready-to-implement spec + handoff prompt.
-- **Findings to preserve (3):**
-  1. **False docstring** — `tests/unit/services/test_health_findings_service.py:4-7` claims the
-     `ON CONFLICT` dedupe "is integration-tested against real Postgres", but **no such test
-     exists** (it monkeypatches `svc._db`). Fix it in the PR that makes it true.
-  2. `tests/conftest.py` has **no Postgres fixture**, and **CI (`code-quality.yml`) runs no
-     Postgres service** — a real-DB test must `skip` cleanly in CI; only the sandbox/local can
-     run it. (`test_migrations_runner.py:11-14` already documents the deferred-fixture decision.)
-  3. All existing migration tests are **static SQL-text** assertions (e.g. `test_migration_051`);
-     none execute SQL. The CI-lane companion for `057` should follow that same static pattern.
-- **New lesson → candidate Rule:** a test docstring's "integration-tested" claim is not proof —
-  grep `tests/` for an actual executing test before trusting it (this one was aspirational).
-- **No source/docs/migration/runtime change to features.** Docs-only this session: sharpened the
-  health/diagnostics folio "Next candidates", refreshed `current-state.md` (date + 0-open-PRs +
-  #546), and this entry. **For project state, see `docs/current-state.md`.**
-
-### 2026-06-06 — Documentation restructure (current-state router · journal split · folios)
-- **Arc:** maintainer asked me to **design and own** a doc structure that streamlines
-  cross-session work — kill stale-doc/preference hunting and the freshness/contradiction
-  drift root cause. Two cross-agent reviews were *input* (verified, not followed on faith:
-  their PR-state reports already contradicted each other across one merge — confirmed #539
-  merged + 0 open PRs via live GitHub).
-- **Shipped (6 commits, this branch, docs-only):** `docs/current-state.md` living router
-  (+ structure-pin test); wired into the read path (`CLAUDE.md` precedence +
-  `AGENT_ORIENTATION` "Any task"); journal split into **guidebook head** + **append-only
-  log** with a correct-in-place freshness rule + an end-of-session documentation checklist
-  (lessons/facts relocated to Rules); status-badge legend + demotion of the source-of-truth
-  index & its chain to `historical`; `docs/ideas/` with a promotion pipeline (AI backlog
-  moved in); `docs/subsystems/` folio template + index with the **AI folio piloted**.
-- **Design model:** Layer 1 cross-cutting (CLAUDE.md → current-state.md → journal →
-  AGENT_ORIENTATION) + Layer 2 per-subsystem folios; drift-guard = one-fact-one-home, global
-  current-state.md stays a thin index over folios.
-- **Decisions (maintainer):** all 3 phases this session; per-session-file split DEFERRED.
-  **My calls:** added the subsystem layer (folio template + AI pilot) and a router
-  structure-pin test; left the pinned `ai-config-ownership.md` + the code-referenced mining
-  brainstorm in place (linked, not moved).
-- **Next:** build out the remaining subsystem folios (self-directed per area). AI live-tests
-  on production still owed — see `docs/current-state.md` "Next candidates".
-- **For project state, see `docs/current-state.md`** — not restated here.
-
-### 2026-06-06 — Bot-awareness programme COMPLETE (PR4–PR6 shipped)
-- **Arc:** attended Opus session finishing the bot-awareness / AI-assisted diagnostics
-  programme. Continued from the #537 foundation (PR1–PR3); reconciled a ChatGPT revision
-  report (verified live on GitHub + against source, **not on faith**) into a revised plan,
-  then executed **PR4 → PR5 → PR6** on `claude/gifted-mayer-LGraE` (branched from current
-  `main` d29705d so it includes #540's docs; #540 + the open #539 are both docs-only).
-- **Key revision catch:** the shipped PR1 adapters ALREADY emit stable per-source
-  fingerprints (`diagnostics.provider_failed:{name}`, …), so the original PR4 ("rewrite
-  fingerprints + fold") was wrong — it would change cardinality for no gain and break
-  rollback. PR4 re-scoped to ADD a grouped recent-error subsystem over the unstructured ring
-  buffer, leaving existing fingerprints untouched.
-- **Shipped (each gated green — `check_architecture` strict 0 errors, `check_quality --full`):**
-  - **PR4 — grouped recent-error findings (opt-in):** NEW `services/health_observations.py`
-    (stdlib-only: owns the redaction regexes + `normalize_text` — `hss._scrub` now delegates —
-    plus a deterministic ID-free `fingerprint()` + `group_log_errors()`).
-    `health_snapshot_service._errors_subsystem` reads a bounded `recent_errors` diagnostics
-    provider (registered from `diagnostic_cog.setup`; cogs register INTO the registry, so no
-    services→cogs import) and groups it; added ONLY when `HEALTH_GROUPED_FINDINGS` is truthy
-    (**default OFF** → legacy `!recent_errors` is the untouched fallback = true rollback).
-    Defensive `_group_findings` fold in `_finalize`; `_render_health_embed` shows `(×N)`.
-  - **PR5 — owner-gated AI tool + D1:** `_derive_scope` maps `config.BOT_OWNER_USER_ID` →
-    `AIScope.PLATFORM_OWNER` (checked first, id-gated; **D1 RESOLVED, option a**). New
-    `diagnostics_health_snapshot` AIToolSpec (min_scope=PLATFORM_OWNER) + handler;
-    `_audience_for_scope` boundary; `build_registry` gains a None-tolerant `bot` kwarg;
-    `snapshot_to_payload` (bounded, JSON-serializable, `schema_version=1`). Owner-recognition
-    pin extended in `test_bot_owner_recognition.py`. #536 descriptor/toolset primitives
-    confirmed **DOC-ONLY** → used the current catalog path + a `TODO(#536)`.
-  - **PR6 — persistent findings:** migration `057` (`operational_health_findings` +
-    `_aggregates`); sole-writer `services/health_findings_service.py` over pool-only
-    `utils/db/health_findings.py` (ON CONFLICT dedupe by fingerprint, reopen-on-recurrence,
-    keep-ignored); recorded + pruned best-effort from `bot1._report_startup_health` (after
-    `record_startup_snapshot`, in the already-managed task) keyed to `services.runtime.BOOT_ID`;
-    30-day TTL with roll-up-to-aggregates; `!platform findings [open|resolved|ignored|all]`
-    (owner-only hints redacted for non-owner admins); **metrics only, no new events**;
-    sole-writer AST guard `test_inv_health_findings_service.py` + readonly-aggregator extension.
-- **Decisions (maintainer):** scope = all remaining; D1 = owner→PLATFORM_OWNER; retention =
-  30d defaults. **My call:** PR4 grouping default flipped to **OFF/opt-in** (production-safe;
-  changed from rev-1's default-on after the revision flagged rollout risk). Panel "Ask AI to
-  explain" button DEFERRED (AI-on render can't be sandbox-tested; the tool alone is reachable).
-- **Verification:** CI gates green per PR (7565 tests). **NOTE (corrected 2026-06-06):** I
-  wrongly believed the sandbox "can't boot" — it CAN (Postgres + Discord test token, Full
-  network), so PR4/PR6's deterministic + DB paths were bootable here and I should have
-  integration-tested them (boot → migration 057 applies → findings persist to Postgres →
-  `SELECT` to confirm). Only the PR5 AI path truly needs production (no AI key here). The
-  maintainer live-tests the AI path on production.
-- **Live-test follow-ups owed (maintainer):** PR4 — `HEALTH_GROUPED_FINDINGS=1`, induce repeated
-  errors → one `(×N)` finding, flip off → legacy fallback. PR5 — owner asks "how healthy are
-  you?" → model calls `diagnostics_health_snapshot`; non-owner admin NOT offered it; AI-off keeps
-  `!platform health` working. PR6 — `!platform findings open`; restart with same failure →
-  occurrence_count increments (dedupe).
-- **New lesson → Rules:** verify "rewrite X" plan items against shipped source first — the PR4
-  fingerprint rewrite would have silently changed PR6's dedupe cardinality and broken rollback.
-
-### 2026-06-06 — Bot-awareness plan revised + executed (PR1–PR3 of the programme)
-- **Arc:** dedicated Opus planning session that (a) reconciled the Codex map (#534)
-  + the newer Codex AI-tool-orchestration successor doc (#536, on `main`) + a ChatGPT
-  revision pass into an approved implementation plan, then (b) — at the maintainer's
-  request to "do as much as can be SAFELY executed unattended (I'm going to sleep)" —
-  **executed the foundation slice PR1→PR3** on `claude/fervent-turing-J1giu`.
-- **Plan:** `docs/bot-awareness-implementation-plan.md` (approved); banner added atop the
-  Codex map `docs/bot-awareness-diagnostics-plan.md`. AI-assisted diagnostics OVER the
-  existing observability stack — no `bot_awareness_service`.
-- **Shipped (3 commits, each gated green — `check_architecture` strict 0 errors,
-  `check_quality --full` 7521 passed):**
-  - **PR1 — contracts + aggregator:** `services/health_contracts.py` (frozen
-    HealthSnapshot/SubsystemHealth/OperationalHealthFinding + SnapshotStatus/
-    FindingSeverity/**HealthAudience**; zero AI dep — deterministic health is decoupled
-    from `AIScope`), `services/health_snapshot_service.py` (two lanes:
-    `collect_cached_snapshot` sync + async `collect_snapshot` with per-source
-    `asyncio.wait_for` isolation; deterministic severity; **pure `project_for_audience`**
-    redaction; heavy adapters imported **function-locally**), `utils/db/health.py`
-    (SELECT 1 ping). Tests: severity table, sync/async source isolation, **per-adapter
-    redaction OMISSION**, import-safety, read-only AST pin.
-  - **PR2 — `!platform health` UX:** `build_health_embed` (reuses `clamp_embed`),
-    admin-gated `!platform health` (owner → full, other admins → guild-redacted via
-    central `resolve_audience`), "health" panel item routing through the SAME builder.
-  - **PR3 — startup health (panel-only):** sibling `ExtensionLoadOutcome` recorder in
-    `startup_outcome` (NOT a `KNOWN_PHASES` entry — that's doc-pinned), `_load_cogs`
-    records per-extension outcomes, `on_ready` spawns ONE settled-startup snapshot via
-    `tasks.spawn` (INV-K) guarded by `_maybe_report_startup_health` (reconnect-safe,
-    unit-proven), `_extensions_subsystem` (only `bootstrap_access_cog` failure is
-    CRITICAL), `!platform startup`. Also a **root-cause fix**: `diagnostics_service.
-    snapshot_all()` now iterates a stable copy (a provider that lazily self-registers
-    another at startup no longer raises "dict changed size during iteration").
-- **Deferred / blockers (for the maintainer when awake):**
-  - **Live boot NOT done this session** — out of (over)caution about the
-    `DISCORD_BOT_TOKEN_PRODUCTION` name, not an actual block. *(Corrected 2026-06-06:
-    booting the dedicated test bot is always allowed and safe — see the Runbook; this
-    session could have booted to integration-test.)* All PR1–PR3 logic is unit-tested +
-    gated; the `on_ready` hook is best-effort/off-path so it cannot break boot.
-  - **PR4 (structured observations / grouped errors)** — intentionally NOT attempted
-    unattended (its stop-condition is "ship grouping disabled rather than tune
-    fingerprint heuristics unattended").
-  - **PR5 (AI diagnostics tool) — BLOCKING DECISION D1:** `_derive_scope`
-    (`natural_language_stage.py:894-922`) ceilings at `AIScope.SERVER_OWNER`; a
-    `PLATFORM_OWNER` tool is unreachable. Same gap as #536's D5. Decide: extend
-    `_derive_scope` to recognize the bot owner, or register at `SERVER_OWNER`.
-  - **PR6 (persistent findings)** — needs the retention/history decision (D8/D11);
-    migration `057` is the next free number.
-- **Live cog audit:** still considered complete as of #535; this session added net-new
-  read-only diagnostics, no behavior change to existing cogs.
-- **Post-merge (same session): #537 MERGED.** Synced the branch to merged `main`
-  (`a4273bd`) and re-verified: `check_quality --full` green, and an integration smoke of
-  the aggregator against **real local Postgres** — async lane `database` subsystem pinged
-  `reachable: True`, both lanes ran, admin projection leaked no owner-only fields. Then
-  reconciled the docs to shipped status (`bot-awareness-implementation-plan.md` header +
-  §5 marked PR1–PR3 ✅ #537; orientation doc lists the plan as the health programme's
-  execution authority).
-
-### 2026-06-06 — Session close: PR B nav fix shipped; bot declared fully tested
-- **Arc** (continues the PR A entry below): refined the stability plan through the
-  GPT/Revision pass (**#531**, merged), added the CI docs-skip (**#532**, merged), then
-  ran the **PR B live cog walk** with the maintainer driving the clicks.
-- **PR B (#535, open):** the walk's one real defect was a **back-navigation class** —
-  directly-invoked hubs (`!modmenu`/`!economymenu`/…) had no "↩ Back to Help" and Economy
-  dropped the chain via the Work sub-path. Fixed holistically + layer-clean
-  (`panel_manager.get_or_render_panel` calls a **registered** back-to-help hook wired from
-  `bot1`; Economy Work views `chain_back` the grandparent). **Live-confirmed.** Tracker
-  reconciled (#528 fixes) + UX findings logged.
-- **Maintainer decision:** **bot is fully tested & working as of #535** — no full
-  re-audit for the next few sessions (see "Current verified state" up top).
-- **New lessons → Rules above:** 800-LOC cog ceiling (wire hooks from `bot1`, not a maxed
-  cog); modals can't hold a Select; GitHub merge-commit "Unverified" stop-hook is a false
-  positive (don't amend); CI skips the heavy suite on docs-only PRs.
-- **Checks:** `check_architecture` 0 errors; `check_quality --full` 7470 passed; clean
-  boots throughout (last boot_id `22f8ccee`).
-
-### 2026-06-06 — GPT Prompt Forge cross-agent workflow clarification
-- **Context:** maintainer clarified that the project is for fun but treated seriously,
-  and that root-level workflow memory must be exact because misconceptions here can
-  confuse future agents.
-- **Captured:** Prompt Forge is the normal starting point for structured prompts;
-  Codex is used for broad mapping / verification / first-pass scaffolding when useful;
-  specialised GPT/Revision projects provide extra checks and final-plan critique;
-  Claude Opus 4.8 1M context is the normal implementation path.
-- **Workflow clarified:** Claude Opus planning sessions are read-only by design;
-  after Opus proposes a plan, the Revision project critiques it, then Opus receives
-  that output for final revision and full execution once the maintainer accepts.
-- **Guardrail:** do not describe Codex as the default implementation agent.
-
-### 2026-06-05 — PR A: pin discord.py + route channel-delete through ChannelLifecycleService
-- **Scope:** first implementation PR of the refined stability plan, after the GPT/Revision pass.
-  Executed on `claude/trusting-curie-zRheM` (fast-forwarded to current `main` `7ffe3c7`).
-- **Shipped:**
-  - `requirements.txt`: `discord.py>=2.3.0` → **`>=2.7,<2.8`** (closes the long-standing pin blocker).
-  - `disbot/views/channels/delete_panel.py::_DeleteConfirmView.confirm_btn` now routes deletes
-    through `ChannelLifecycleService.apply(operation="delete", confirmed=True)` instead of
-    `channel.delete()` directly — panel deletes finally emit the audit companion +
-    `channel.lifecycle_changed` event. Result embed rebuilt from the typed `LifecycleResult`,
-    preserving the deleted / permission-denied / not-found / failed buckets (re-mapping the
-    service's id-named not-found step back to the display name).
-  - Widened `tests/unit/invariants/test_no_direct_channel_mutations.py` to scan
-    `disbot/views/channels/**` (excludes message receivers; doesn't flag the deferred
-    `set_permissions`). Added `tests/unit/views/test_discordpy_ui_collisions.py` — a repo-wide,
-    self-maintaining guard for the #528 collision class (`_refresh` shadowing; `self.parent`/
-    `_parent` on `ui.Item` subclasses). Rewrote `test_delete_panel_multi.py` to the
-    service-routing pattern.
-- **Verification:** `check_architecture --mode strict` = 0 errors; `check_quality --full` = green;
-  targeted view/invariant suite green. Live-checked on the booted test bot (`!channelmenu → Delete`).
-- **Next:** begin PR B (live cog-audit completion) per the accepted plan.
-
-### 2026-06-05 — Opus stability-plan refinement + live boot (env IS available here)
-- **Scope:** dedicated Claude Opus planning session refining Codex's stability pre-impl
-  pass (#529) into an execution-ready **next-3-PR** plan. Wrote
-  `docs/planning/stability-implementation-plan-refined-2026-06-05.md`. No source implemented.
-- **Live env — CORRECTION to the older entry below:** *this* editing container **does** expose the
-  runbook creds (`DISCORD_BOT_TOKEN_PRODUCTION` len 72 / 3-seg; `DATABASE_URL` = localhost
-  `postgresql://…`), and Postgres 16 binaries + the `postgres` user are present. The maintainer
-  confirmed the bot can be booted **only** in the editing environment (hence plan mode was
-  exited). **Booted it clean:** Galaxy Bot#6724, 34 cogs, migrations applied 0 errors,
-  identity-contract clean, connected to 2 servers, 0 ERROR/CRITICAL (only benign
-  webhook/PyNaCl WARNINGs). discord.py 2.7.1 verified good live. ⇒ Codex F2 ("live unavailable")
-  is container-specific, not universal; **PR B's live cog audit is executable here.**
-- **Postgres bring-up recipe (durable):** as root — `initdb -D /tmp/pgdata -A trust -U postgres`
-  (run via `su postgres -s /bin/bash -c …`, dir chowned to `postgres`); start with
-  `pg_ctl -D /tmp/pgdata -o '-p 5432 -k /tmp/pgrun -c listen_addresses=127.0.0.1' -l /tmp/pg.log start`;
-  then create role+db `superbot` parsed from `DATABASE_URL` (trust auth ⇒ password is cosmetic).
-  Verified `psql "$DATABASE_URL"` connects. Then `python3.10 disbot/bot1.py` (schema self-bootstraps).
-- **Checks:** `check_architecture.py --mode strict` = 0 errors; `check_quality.py --full` = GREEN
-  (7461 passed, 3 skipped, 20 warnings).
-- **Codex reconciliations:** delete-panel finding is real but at `disbot/views/channels/delete_panel.py:239`
-  (Codex dropped the `disbot/` prefix); **F12 downgraded** to ledger-text drift (the cleanup
-  prohibited-word write is an *allowed* `accepted-direct-write` per `ownership.md:64`, while
-  `direct-db-exception-ledger.md:37` still calls cleanup reads-only); **F15 reframed** — amending
-  the AI doc is lower-friction than implementing guild presets (doc-pin test doesn't assert scope;
-  guild mutation has no `UNCHANGED` sentinel). Kept AI/BTD6 out of the next-3 scope.
-- **Plan shape:** PR A (pin discord.py + route delete panel through `ChannelLifecycleService` +
-  widen invariant to `views/channels/**` + self-maintaining collision check) → PR B (live cog
-  audit / hard-failure fixes / tracker reconcile) → PR C (cleanup ownership+ledger contract = queued
-  PR8). Opened end-of-session PR **#531**.
-- **Journal conflict (recurring class — now documented):** #530 merged to `main` mid-session and
-  inserted its own Session-Log entry at the same anchor, so #531 hit the same `.session-journal.md`
-  conflict that #529→#530 did. Resolved by **union** (kept both entries, newest-first). Added a
-  prevention/resolution rule to the Protocol + an Ideas entry proposing per-session entry files.
-
-### 2026-06-05 — stability preimplementation verification pass
-- **Scope:** planning/verification only; wrote `docs/planning/stability-preimplementation-plan-2026-06-05.md` for the Opus refinement session.
-- **Confirmed blockers:** unpinned discord.py; `views/channels/delete_panel.py` bypasses `ChannelLifecycleService`; cleanup ownership/config remains split; AI binding doc overstates guild-preset support; ADR-006 provenance/provider-parity gate still blocks BTD6 extraction; live cog tracker remains incomplete/stale after #528.
-- **Checks:** strict architecture passed (0 errors / 87 tracked warnings); broad targeted suite passed (5,831 passed, 3 skipped); full quality rerun completed after installing the missing Python 3.10 dependencies.
-- **Environment difference:** this container did not expose the journal-documented bot token/`DATABASE_URL`, postgres user, or Postgres binaries, so the live bot could not be booted. `gh` was also unavailable, so open PR state remains unverified.
-
-### 2026-06-05 — server-management audit + discord.py-2.7 crash fixes + diagnostic suite
-- **Context:** maintainer pivoted a role-panel-polish session into a structured,
-  cog-by-cog functionality audit driven by live testing against the booted test bot.
-- **Shipped (branch `claude/charming-ride-7Whiq`):**
-  - `fix(roles)`: two discord.py 2.7.1 internal collisions — `_refresh(self)` shadowing
-    `View._refresh(components)` (crashed the whole bot on MESSAGE_UPDATE) and
-    `self.parent =` on `Select` subclasses hitting the now-read-only `Item.parent`
-    (broke Delete/Remove). Root cause: unpinned discord.py. Regression-pinned by
-    `tests/unit/views/test_role_panels_discordpy_compat.py`.
-  - `fix(diagnostic)`: working "Recent Errors" (in-memory ring buffer instead of a
-    `logs` table nothing wrote to), migration-based "Schema Check" (instead of a
-    16-table hardcoded list that flagged 52 real tables as "unexpected"), and a
-    **total-6000 embed clamp** in `clamp_embed` (fixes the `!platform` "no back button"
-    + any oversized panel bot-wide).
-  - `docs`: seeded `docs/planning/cog-functionality-audit-2026-06-05.md` (full per-cog
-    command/panel inventory + env-gate map + findings).
-- **Problems→fixes & my mistakes:** distilled into the Environment Runbook + Rules
-  above (pkill self-match; schema regex missing runtime tables; rename missing a test
-  ref; benign router noise; pytest polluting `bot.log`).
-- **Preferences observed:** captured in Operating Preferences above.
-- **Closed:** opened end-of-session PR **#528** (discord.py-2.7 crash fixes +
-  DiagnosticCog suite + this journal); `check_quality --full` + `check_architecture`
-  green at open.
-- **CI follow-up:** #528's first `code-quality` run failed `black` (migrations.py) +
-  `ruff` D209 (_log_buffer.py); fixed with the pinned linters, re-verified against the
-  exact workflow commands, re-pushed (`73a943f`). → new lint Rule above.
-
-## 2026-06-06 — AI extra-tool capability roadmap refinement
-
-- Verified local `main` equivalent at `60f1cd2` against the GitHub API. Only PR #539
-  (`docs: add AI extra tool capability ideas backlog`) was open; no open bot-awareness
-  PR4–PR6 was visible. PR #539 is docs-only and one commit ahead of `main`.
-- Re-read the binding architecture/orientation docs, approved bot-awareness implementation
-  plan, bot-awareness repository map, BTD6 orchestration plan, PR #539 backlog from its
-  exact branch, current AI provider/tool-loop source, and shipped health source.
-- Confirmed PR1–PR3 are shipped and the health implementation plan remains execution
-  authority. Confirmed `_derive_scope()` still cannot return `AIScope.PLATFORM_OWNER`,
-  so bot-awareness PR5 and other owner-only AI tools remain blocked on D1.
-- Confirmed `AIToolDescriptor`, `AIOrchestrationPolicy`, `AIToolBudget`, `AIToolChoice`,
-  and `ToolRequirementMode` remain planned rather than shipped source types. Existing
-  scheduler/notification capability is owned by the automation services and must not be
-  duplicated by AI tooling.
-- Added `docs/ai-tool-capability-roadmap.md`: a non-authoritative, source-verified roadmap
-  proposal that triages capability families, defines architecture/safety/test gates,
-  merges duplicate ideas into existing authorities, and limits the conditional next
-  implementation sequence to the shared orchestration foundation plus bounded public-doc
-  knowledge search.
-- No runtime code, migration, PR4–PR6 implementation, connector, or action tool changed.
-
-## 2026-06-06 — PR #544 cross-agent review: verified, then fixed 4 contradictions
-
-Context: asked a sibling chat for feedback on the open doc-restructure PR #544. It
-rated it 8.5/10, flagged 4 "contradictions to fix before merge" + 2 refinements.
-**Verified every claim against source before touching anything** (the "verify
-cross-agent output, don't follow on faith" rule) — all 4 held up; applied them on
-`claude/friendly-babbage-0BkSu`. Doc-only; 53 doc tests + `check_quality --check-only`
-green.
-
-- **Read-order (`.claude/CLAUDE.md`):** opening led with "open AGENT_ORIENTATION first",
-  contradicting the designed spine. Now states the order explicitly: this file →
-  `current-state.md` → `.session-journal.md` → AGENT_ORIENTATION (task routing).
-- **Demoted SoT index:** its internal "Read first" / "trust now (✅ current)" sections
-  still read as live instructions under the new "historical" banner. Reframed both as
-  2026-06-05 historical snapshots.
-- **`ai-tool-capability-roadmap.md`:** header gate + §2.5 stop-conditions + Phase-0
-  checklist + deferral table all still said platform-owner/D1 was *unresolved*, while
-  §1/§2.2 said *resolved (#541)*. Made the whole doc consistently "resolved"; marked
-  §2.1's pre-#541 verification snapshot historical.
-- **`AGENT_ORIENTATION` server-mgmt entry:** restated the tracker as "#520–523 / queue
-  PR5+" — stale. De-brittled to point at the tracker's Shipped/Remaining-queue sections;
-  fixed the tracker's own stale header (body is current through PR7 / queue PR8).
-- **Refinements:** added "don't summarize plans'/trackers' PR numbers here" to
-  current-state's one-fact-one-home rule; split the AI folio's "Plans (pending approval)"
-  from "Ideas (not approved)".
-
-**Two lessons (candidate Rules):**
-1. **Verify a status claim against the tracker's BODY, not its header.** The server-mgmt
-   tracker *header* says "verified @ #523", but its **Shipped/Remaining-queue body** is at
-   PR7 / queue PR8. I almost *rejected* the (valid) review claim #4 on the header alone —
-   the body proved the reviewer right. Read Shipped/Queue sections, not the date stamp.
-2. **Same-dated docs can contradict; SOURCE WINS — check it before "fixing" a contradiction.**
-   This very journal's 2026-06-06 roadmap entry says `_derive_scope()` *can't* return
-   `PLATFORM_OWNER`; the roadmap doc says D1 *resolved*. I nearly aligned the doc the wrong
-   way on the journal's say-so. Source settled it: `natural_language_stage.py:913-914`
-   returns `AIScope.PLATFORM_OWNER` for `BOT_OWNER_USER_ID`, and **#541 is merged**
-   (D1 resolved). The journal entry above was written hours before #541 merged and is the
-   stale one. Journal entries are point-in-time; verify D1-class claims against source.
-
-## 2026-06-06 — subsystem folio mapping expansion
-
-- Confirmed the local HEAD is merge commit `508c638` for merged PR #544. This checkout
-  has no configured `origin` and no GitHub CLI, so open-PR enumeration/fetch was not
-  possible; corrected only the provably stale current-state claim that #544 was in flight.
-- Added canonical folios for health/diagnostics, server management, settings/bindings/
-  provisioning, BTD6, games, and media/YouTube. Each separates shipped/current state,
-  degraded or verification-needed behavior, pending plans, unapproved ideas, next
-  candidates, source entry points, and authoritative related docs.
-- Updated the subsystem index and navigation/orientation routes to prefer folios. Kept
-  existing contracts/plans in place to avoid risky reference and doc-test churn.
-- No runtime features, BTD6 extraction, AI expansion, doc moves, or live-runtime claims.
-- Natural next docs-maintenance candidate: perform the existing journal review every 3–5
-  sessions, promote stable lessons into their permanent homes, and clarify whether each
-  item belongs in the journal, `docs/current-state.md`, a subsystem folio, `docs/ideas/`,
-  a planning doc, or a binding doc. Keep the journal as process memory, not a second roadmap.
-
-## 2026-06-06 — server-mgmt cleanup PR8 + PR9 (shipped) + guild-default root-cause fix
-
-Planning session (read-only by design) that the maintainer converted to execution
-("plan approval = full execution"). Two ChatGPT-driven scope decisions were locked
-first: **presets-only (lean)** for the policy model, and **dedicated cleanup panel**
-(async helper) for diagnostics. A prior ChatGPT review of the plan had 4 required
-corrections — all verified against source before trusting them (the "verify
-cross-agent output" rule); all 4 held. Shipped both as sequential commits on one
-branch (`claude/nifty-cerf-59MKG`) → one end-of-session PR (the established
-one-PR-per-session pattern, e.g. #541 did PR4→PR6).
-
-- **PR8** (`fbdb3c4`): migration `058` adds `cleanup_policies.policy_version INT NOT
-  NULL DEFAULT 1` (additive; PK + RC-5 CHECK untouched; resolver unchanged →
-  behaviour byte-identical). `cleanup_levels`: `level_for_columns` round-trip +
-  `POLICY_VERSION`. `get_all_cleanup_for_guild` returns the new column.
-- **PR9** (`2b72f3c`): `services/cleanup_diagnostics.py` (async, presets-only) —
-  diagnostics (level naming, stale-scope + ineffective-row detection), dry-run
-  preview (reuses the **real** resolver → preview == runtime, no writes), audited
-  apply through the unchanged pipeline. `views/cleanup/policy_panel.py` builder
-  (scope → level → preview → confirm → apply) + "Cleanup Policies" button on the
-  cleanup hub. Admin re-check at the mutation point.
-
-**Root-cause bug found while building PR9 (and fixed, maintainer chose "fix now"):**
-the setup wizard wrote guild-default cleanup at `scope_id=0`, but the resolver looks
-up guild policy at `scope_id=guild_id` (`_build_scope_chain` maps guild→`ctx.guild_id`)
-— so **guild-default cleanup chosen in setup never took effect** (channel/category
-were fine). Centralised the write-side convention in
-`cleanup_levels.cleanup_scope_id()` and fixed `setup_operations`. The old test
-`test_set_cleanup_policy_routes_through_governance_writer` literally asserted
-`scope_id == 0` — it had **encoded the bug**; updated it.
-
-**Verification:** booted local Postgres (journal runbook worked verbatim) and
-verified live: `058` applies + backfills, the guild-default fix resolves to
-`GUILD_OVERRIDE`, legacy `scope_id=0` confirmed no-op, and diagnostics/preview run
-end-to-end against real rows. `check_architecture --mode strict` 0 errors;
-`check_quality --full` green (7649 passed). Real-PG integration tests skip cleanly
-in CI (module-local `DATABASE_URL`/unreachable skip, per
-`test_health_findings_integration.py`).
-
-**Descope recorded:** the implementation plan's PR8 JSONB "dimensions" column is
-**deferred** (no consumer yet) — only `policy_version` shipped. The next session
-must NOT "follow the doc" and add JSONB. Diagnostics flag legacy `scope_id=0` guild
-rows as ineffective so operators can re-set them.
-
-**Lessons (candidate Rules):**
-1. **A test can encode a bug — read what it asserts, not just whether it's green.**
-   `scope_id == 0` was a passing test that locked in a silent no-op. When a write
-   convention and a read convention must agree, pin the agreement (here: a live
-   resolver round-trip), not one side's current value.
-2. **The ephemeral sandbox Postgres dies on session resume.** A `SessionStart:resume`
-   stopped the `/tmp/pgdata` server mid-session; re-run the boot recipe (it's
-   idempotent — the `PG_VERSION` check skips re-initdb) before live DB work.
-3. **Centralise cross-component conventions in one helper.** `cleanup_scope_id()`
-   now owns the guild→`guild_id` keying so a writer can't silently diverge from the
-   resolver again.
+> **Older sessions → [`.session-journal-archive.md`](.session-journal-archive.md).**
+> Only the most recent sessions stay here so this file is a fast read. Need older
+> history? **grep the archive** — don't read it top-to-bottom. When this live log
+> grows past ~4 entries, roll the oldest into the archive (see Protocol → END).

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -6,15 +6,13 @@
 > live GitHub** before trusting it (two same-session reports already
 > contradicted each other across a single merge).
 >
-> **Last updated:** 2026-06-06 · #550 merged (collaboration-model docs +
-> truth-layer restructure). This session: **fixed the role-automation
-> degradation** — `role_automation.apply` now preflight-guards at the mutation
-> seam and classifies failures, so a roster-wide Manage-Roles / hierarchy
-> blocker no longer floods the ERROR-only health surface (the "26 role
-> automation errors"); operator + role-Diagnostics surfaces now show the cause.
-> Branch `claude/epic-tesla-IGJ21` (PR pending) — detail in the session journal.
-> Verify open PRs against live GitHub (`list_pull_requests`); this snapshot
-> names none on purpose.
+> **Last updated:** 2026-06-06 · #551 merged (role-automation degradation fix —
+> `role_automation.apply` preflight-guards at the mutation seam + classifies
+> failures; live health "Errors" surface back to ✅). This session: made the
+> **session journal lean + self-maintaining** (archive split → `.session-journal-
+> archive.md`, a Quick reference, and a "reorganize-each-session" protocol step;
+> PR pending). Verify open PRs against live GitHub (`list_pull_requests`); this
+> snapshot names none on purpose.
 >
 > **Purpose:** the one file that answers "what is true right now?" so a new
 > session does not reconstruct it from the journal + planning docs. Read it
@@ -40,6 +38,7 @@ Source code and merged PRs win over anything written here.
 
 ## Recently shipped (newest first)
 
+- **#551** — role-automation degradation fix: `role_automation.apply` preflight-guards at the mutation seam (via `utils.role_feasibility`), classifies failures, and keeps predictable Manage-Roles/hierarchy blockers off the ERROR-only health surface; operator + role-Diagnostics surfaces show the cause.
 - **#550** — collaboration-model doc + truth-layer restructure (goal-first, prompts-as-guidance); docs-only.
 - **#549** — server-management cleanup PR8+PR9: `policy_version` marker, presets builder + dry-run + panel diagnostics, and the guild-default `scope_id=0` no-op fix.
 - **#548** — closed the migration-`057` persistence/dedupe/retention integration-test gap (test-only).


### PR DESCRIPTION
## Why

You asked for an honest review of `.session-journal.md`, then to act on it — keep it **functional and quick to read and remember**, and have **future sessions keep it that way** ("reorganize where possible after a session"). My review's one real concern was that the value-to-length ratio was trending the wrong way: the guidebook (Runbook + Rules) earns its keep every session, but the append-only Session Log just grows, burying the load-bearing facts.

## What changed (docs-only)

- **Archive split** → new **`.session-journal-archive.md`** holds the older Session Log entries (grep-on-demand history). The live journal drops **843 → ~480 lines**, keeping the guidebook + the newest ~3 sessions.
- **⚡ Quick reference** near the top — a scannable table (boot / Postgres-down / run-CI / kill-bot / end-of-session) + the three rules that bite hardest. The 80% you need, in seconds.
- **Rules/Conventions regrouped** into *Boot & environment / CI & quality / Architecture, data & coding / Cross-agent & git*, with **★ promotion-candidate** markers. Every prior rule preserved verbatim; folded in two earned lessons (guard-at-the-mutation-seam from the role fix; a-test-can-encode-a-bug).
- **Protocol** — "**tidy as you go**" is now an explicit **END** step for *every* session (roll old entries to the archive, fix stale Rules in place, refresh the Quick reference), not just the every-3-5-session REVIEW. START now reads the Quick reference first and greps the archive for old history. Intro reframed: *fast-read working set, not an archive.*
- **`.claude/CLAUDE.md`** — the journal pointer now states the lean/archive expectation, so every session inherits it (it's auto-loaded). **This is the "ask other sessions to do the same" mechanism.**
- **`docs/current-state.md`** — reconciled: #551 moved to Recently shipped; stamp updated.

## How "self-maintaining" works
The rule lives in two places future sessions can't miss: the auto-loaded **CLAUDE.md** read-first block, and the journal's own **Protocol → END** step. Both say: at session end, keep the live Session Log to ~4 entries and roll the rest to the archive.

## Safety
Docs-only. `grep` confirms **no test or script references the journal**, so CI is unaffected; `tests/unit/docs/` green and `check_quality --check-only` green. The archive preserves every older entry verbatim (no history lost).

https://claude.ai/code/session_01Vx7eaeoaRcG1qExPNFdjio

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vx7eaeoaRcG1qExPNFdjio)_