### PR TITLE
fix(roles+health): role-hierarchy (position,id) tiebreak + consistency SKIPPED presentation

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -357,6 +357,39 @@ confidence; do not treat booting as gated.
 
 ## Session Log (newest first — append-only)
 
+### 2026-06-06 — Consistency-warning presentation fix + role-diagnostic live verification
+
+- **Arc:** follow-up to the two merged PRs. Maintainer asked me to push the two open
+  items — live-verify the role-automation diagnostic, and investigate the 3 "consistency
+  warnings" — and combine related ideas/roadmaps. Branch off merged `main` (4d2224b).
+- **Root cause of the consistency noise (source + live verified):** the 3 "blocking
+  sections need attention" in the health screenshot were **2 benign `SKIPPED` states +
+  1 designed warning**, but `health_snapshot_service._build_consistency_subsystem`
+  rendered **every** `iter_blocking_sections` entry (which deliberately includes
+  `SKIPPED`) as a WARNING "needs attention" finding. So "not applicable" read as a
+  problem. Per `platform-consistency-ledger.md`: Bindings SKIPPED = DM invocation (runs
+  CLEAN in a guild); Binding-backfill SKIPPED = no checkpoint rows (no backfill ran);
+  Config-arbitration WARNING `missing=0` = legacy reads pre-`bindings.primary`-flip
+  (designed, ledger §6).
+- **Shipped (`disbot/services/health_snapshot_service.py`):** the consistency subsystem
+  now renders only **WARNING/FATAL** sections as findings; **SKIPPED** go to
+  `facts.skipped_sections` / `skipped_section_names`, and `blocking_sections` counts
+  actionable only. Two regression tests in `test_health_snapshot_service.py`. Folio
+  debug-router updated with the benign-state catalogue (the "document/combine" ask).
+- **Live verification (test bot, both guilds):** role diagnostic confirmed end-to-end —
+  happy path `🟢`, missing-role `⚠️ missing: …`, **and above-bot reproduced live**
+  (`testrole2` at pos 1 ≥ bot top role `Galaxy Bot` at **pos 1** → `⚠️ above my top
+  role: testrole2`). The bot's top role is at **position 1** in both test guilds, so the
+  original 26 prod errors were almost certainly hierarchy blockers — **maintainer action:
+  raise the bot's role** above any threshold role. Consistency collectors live: Bindings
+  CLEAN (in-guild), Binding-backfill SKIPPED, Config-arbitration CLEAN at 0 calls.
+- **Open decision for maintainer:** whether config-arbitration's `fallback>0, missing=0`
+  should stay a visible WARNING (monitoring) or be downgraded to non-degrading (it's the
+  designed pre-flip state). Did **not** change the consistency contract unilaterally.
+- **Gates:** `check_architecture` 0 errors; `check_quality --full` green (7661 passed);
+  booted clean (boot_id `ab97c12b`, 0 ERROR/CRITICAL). **For project state see
+  `docs/current-state.md`.** (PR pending.)
+
 ### 2026-06-06 — Journal made lean + self-maintaining (archive split, Quick reference, reorganize-each-session)
 
 - **Arc:** maintainer asked for an honest opinion of this journal, then — based on it —

--- a/.session-journal.md
+++ b/.session-journal.md
@@ -306,6 +306,12 @@ confidence; do not treat booting as gated.
 - **Pin churn-prone deps** and audit `discord.ui` overrides on version bumps —
   unpinned `discord.py>=2.3.0` resolving to 2.7.1 caused `View._refresh` / `Item.parent`
   collisions that crashed the bot.
+- **Discord role `position` is NOT unique — compare hierarchy by (position, id), never
+  raw `position`.** At equal position the *older* role (smaller id) ranks higher, matching
+  discord.py's `Role` ordering. Bot-created roles commonly all sit at position 1, so a raw
+  `position >=` check mis-flags perfectly manageable roles as "above the bot" (caught live
+  2026-06-06). Route every "can the bot manage this role?" check through
+  `utils.role_feasibility` (the single source of truth; `_at_or_above` does the tiebreak).
 - **A Discord Modal cannot contain a Select** (`UserSelect`/`StringSelect`) — modals are
   text-input only. "Selector-ize a modal" therefore means a **modal→view restructure**
   (pick the member in a view → follow-up modal/inputs), not a component swap.
@@ -378,13 +384,25 @@ confidence; do not treat booting as gated.
   `facts.skipped_sections` / `skipped_section_names`, and `blocking_sections` counts
   actionable only. Two regression tests in `test_health_snapshot_service.py`. Folio
   debug-router updated with the benign-state catalogue (the "document/combine" ask).
-- **Live verification (test bot, both guilds):** role diagnostic confirmed end-to-end —
-  happy path `🟢`, missing-role `⚠️ missing: …`, **and above-bot reproduced live**
-  (`testrole2` at pos 1 ≥ bot top role `Galaxy Bot` at **pos 1** → `⚠️ above my top
-  role: testrole2`). The bot's top role is at **position 1** in both test guilds, so the
-  original 26 prod errors were almost certainly hierarchy blockers — **maintainer action:
-  raise the bot's role** above any threshold role. Consistency collectors live: Bindings
-  CLEAN (in-guild), Binding-backfill SKIPPED, Config-arbitration CLEAN at 0 calls.
+- **Live verification (test bot, both guilds)** — and it caught a REAL bug: the role
+  diagnostic flagged `testrole2` as `⚠️ above my top role`, but the maintainer pointed
+  out `Galaxy Bot` is the **highest** role (created by the bot, nothing reordered).
+  discord.py agreed (`testrole2 < me.top_role` = manageable). Root cause: **all roles sat
+  at `position=1`** and the hierarchy check used raw `position >=`, which mis-flags ties.
+  Discord role positions are **not unique**; ties break by **id (older = higher)**. I had
+  wrongly told the maintainer to "raise the bot's role" — the setup was fine, the
+  comparison was wrong. (Bindings CLEAN in-guild, Binding-backfill SKIPPED,
+  Config-arbitration CLEAN at 0 calls.)
+- **Role-hierarchy tiebreak fix (`utils/role_feasibility.py` + `services/role_automation.py`):**
+  new `_at_or_above(role, other)` mirrors discord.py's `Role` ordering ((position, id),
+  older-higher); `evaluate_role` uses it for both bot- and actor-hierarchy, and
+  `check_preflight` now delegates its hierarchy verdict to `evaluate_role` (kills the
+  duplicated raw-position compare). Since `apply()`'s pre-empt also uses `evaluate_role`,
+  this fixes a **#551 regression risk**: tied-position-but-manageable threshold roles were
+  being silently pre-empted/skipped. Back-compatible with id-less test fakes (0<=0 → still
+  "at or above"). Re-verified live: `testrole2` now `🟢` manageable. Tests:
+  `test_role_feasibility.py` (tie both directions + strict), `test_role_automation.py`
+  (preflight + apply tie cases).
 - **Config-arbitration is correctly flagging a half-finished migration** (flag ON, rows
   not backfilled) — so it should NOT be downgraded. Resolve by finishing the binding
   backfill (PR-5/6) or turning `bindings.primary` off; both are gated Phase-2 / production

--- a/.session-journal.md
+++ b/.session-journal.md
@@ -369,8 +369,10 @@ confidence; do not treat booting as gated.
   `SKIPPED`) as a WARNING "needs attention" finding. So "not applicable" read as a
   problem. Per `platform-consistency-ledger.md`: Bindings SKIPPED = DM invocation (runs
   CLEAN in a guild); Binding-backfill SKIPPED = no checkpoint rows (no backfill ran);
-  Config-arbitration WARNING `missing=0` = legacy reads pre-`bindings.primary`-flip
-  (designed, ledger §6).
+  Config-arbitration WARNING `missing=0` = **`bindings.primary` is ON for the guild but
+  the binding rows were never backfilled** → legacy fallback (nothing lost). `fallback`
+  is only recorded in the flag-ON branch, so it's a real "migration unfinished" signal,
+  NOT the designed default-off state (corrected after reading `config_arbitration`).
 - **Shipped (`disbot/services/health_snapshot_service.py`):** the consistency subsystem
   now renders only **WARNING/FATAL** sections as findings; **SKIPPED** go to
   `facts.skipped_sections` / `skipped_section_names`, and `blocking_sections` counts
@@ -383,9 +385,11 @@ confidence; do not treat booting as gated.
   original 26 prod errors were almost certainly hierarchy blockers — **maintainer action:
   raise the bot's role** above any threshold role. Consistency collectors live: Bindings
   CLEAN (in-guild), Binding-backfill SKIPPED, Config-arbitration CLEAN at 0 calls.
-- **Open decision for maintainer:** whether config-arbitration's `fallback>0, missing=0`
-  should stay a visible WARNING (monitoring) or be downgraded to non-degrading (it's the
-  designed pre-flip state). Did **not** change the consistency contract unilaterally.
+- **Config-arbitration is correctly flagging a half-finished migration** (flag ON, rows
+  not backfilled) — so it should NOT be downgraded. Resolve by finishing the binding
+  backfill (PR-5/6) or turning `bindings.primary` off; both are gated Phase-2 / production
+  decisions for the maintainer (confirm live flag state via `!platform flags`). Did not
+  touch the consistency contract.
 - **Gates:** `check_architecture` 0 errors; `check_quality --full` green (7661 passed);
   booted clean (boot_id `ab97c12b`, 0 ERROR/CRITICAL). **For project state see
   `docs/current-state.md`.** (PR pending.)

--- a/disbot/services/guild_snapshot.py
+++ b/disbot/services/guild_snapshot.py
@@ -238,10 +238,10 @@ def _collect_categories(guild: Any, me: Any) -> tuple[CategoryMeta, ...]:
 
 
 def _collect_roles(guild: Any, me: Any) -> tuple[RoleMeta, ...]:
+    from utils import role_feasibility
+
     out: list[RoleMeta] = []
-    bot_top_position = (
-        getattr(getattr(me, "top_role", None), "position", 0) if me is not None else 0
-    )
+    bot_top = getattr(me, "top_role", None) if me is not None else None
     bot_can_manage_roles = (
         bool(getattr(getattr(me, "guild_permissions", None), "manage_roles", False))
         if me is not None
@@ -249,8 +249,12 @@ def _collect_roles(guild: Any, me: Any) -> tuple[RoleMeta, ...]:
     )
     for role in getattr(guild, "roles", ()) or ():
         position = getattr(role, "position", 0)
+        # Hierarchy via the shared (position, id) tiebreak — raw `position <`
+        # mis-ranks roles that tie the bot's position (the common all-at-1 case).
         manageable = bool(
-            bot_can_manage_roles and position < bot_top_position,
+            bot_can_manage_roles
+            and bot_top is not None
+            and role_feasibility.is_below(role, bot_top),
         )
         out.append(
             RoleMeta(

--- a/disbot/services/health_snapshot_service.py
+++ b/disbot/services/health_snapshot_service.py
@@ -333,6 +333,16 @@ def _build_consistency_subsystem(
         else SnapshotStatus.UNKNOWN
     )
     stale = _is_stale(report_at)
+    # A SKIPPED section means "not applicable / no data / no context" — e.g.
+    # Bindings checked from a DM (no guild), or no `binding_backfill` checkpoint
+    # rows because no backfill has run.  That is NOT something that "needs
+    # attention", so only WARNING/FATAL sections become findings; SKIPPED ones
+    # are recorded in facts.  Otherwise a benign "not applicable" state reads as
+    # a problem and inflates the "N blocking sections need attention" count.
+    actionable = tuple(
+        s for s in blocking if getattr(s.status, "value", "") in ("warning", "fatal")
+    )
+    skipped = tuple(s for s in blocking if getattr(s.status, "value", "") == "skipped")
     findings = tuple(
         OperationalHealthFinding(
             fingerprint=(
@@ -350,7 +360,7 @@ def _build_consistency_subsystem(
             file_hint=_scrub(getattr(s, "summary", "")),  # owner-only
             source=source,
         )
-        for s in blocking[:MAX_SUBSYSTEM_FINDINGS]
+        for s in actionable[:MAX_SUBSYSTEM_FINDINGS]
     )
     age = None if report_at is None else round((_now() - report_at).total_seconds())
     return SubsystemHealth(
@@ -364,7 +374,12 @@ def _build_consistency_subsystem(
         findings=findings,
         facts={
             "consistency_status": overall_value,
-            "blocking_sections": len(blocking),
+            # Only WARNING/FATAL sections count as "needs attention"; SKIPPED
+            # ("not applicable") are reported separately so they never inflate
+            # the actionable count.
+            "blocking_sections": len(actionable),
+            "skipped_sections": len(skipped),
+            "skipped_section_names": ", ".join(s.name for s in skipped),
             "report_age_seconds": age,
         },
         source=source,

--- a/disbot/services/role_automation.py
+++ b/disbot/services/role_automation.py
@@ -429,7 +429,6 @@ def check_preflight(
             missing_roles=tuple(t.role_name for t in thresholds),
         )
     bot_has_manage = _bot_has_manage_roles(me)
-    bot_top_position = getattr(getattr(me, "top_role", None), "position", 0)
 
     missing: list[str] = []
     blockers: list[str] = []
@@ -441,7 +440,11 @@ def check_preflight(
         if role is None:
             missing.append(t.role_name)
             continue
-        if getattr(role, "position", 0) >= bot_top_position:
+        # Delegate the hierarchy verdict to the single source of truth, which
+        # compares with Discord's (position, id) tiebreak — raw `position >=`
+        # mis-flagged roles that merely tie the bot's position (the common case
+        # when every role sits at position 1).
+        if evaluate_role(role, bot_member=me).code == ABOVE_BOT:
             blockers.append(t.role_name)
 
     return PreflightResult(

--- a/disbot/utils/role_feasibility.py
+++ b/disbot/utils/role_feasibility.py
@@ -77,6 +77,40 @@ def _position(obj: object) -> int:
     return int(getattr(obj, "position", 0) or 0)
 
 
+def _at_or_above(role: object, other: object) -> bool:
+    """True when ``role`` sits at or above ``other`` in Discord's role hierarchy
+    (so a member/bot whose top role is ``other`` can **not** manage ``role``).
+
+    Discord role ``position`` values are **not unique**: when two roles share a
+    position, Discord — and discord.py's ``Role`` comparison — break the tie by
+    **id**, ranking the older role (smaller id) higher.  Comparing raw
+    ``position`` alone therefore mis-flags a role that merely *ties* the top
+    role's position (roles created by the bot commonly all sit at position 1,
+    yet the bot's managed role still outranks the ones it created).  This mirrors
+    ``Role.__lt__``: ``role`` is strictly *below* ``other`` iff
+    ``role.position < other.position`` or (equal position and ``role.id >
+    other.id``); "at or above" is the negation.
+    """
+    rp, op = _position(role), _position(other)
+    if rp != op:
+        return rp > op
+    # Equal position → tie broken by id (older/smaller id ranks higher).  With
+    # ids absent (test fakes default to 0) this preserves the legacy ``>=``
+    # behaviour (0 <= 0 → treated as at-or-above).
+    rid = int(getattr(role, "id", 0) or 0)
+    oid = int(getattr(other, "id", 0) or 0)
+    return rid <= oid
+
+
+def is_below(role: object, other: object) -> bool:
+    """True when ``role`` is strictly *below* ``other`` in Discord's role
+    hierarchy — i.e. a member/bot whose top role is ``other`` can manage ``role``
+    (hierarchy-wise).  Inverse of :func:`_at_or_above`; uses the (position, id)
+    tiebreak rather than raw ``position`` so tied positions are ranked correctly.
+    """
+    return not _at_or_above(role, other)
+
+
 def _is_default(role: object) -> bool:
     is_default = getattr(role, "is_default", None)
     if callable(is_default):
@@ -115,11 +149,11 @@ def evaluate_role(
         if not _has_manage_roles(bot_member):
             return _verdict(BOT_MISSING_MANAGE_ROLES)
         bot_top = getattr(bot_member, "top_role", None)
-        if bot_top is not None and _position(role) >= _position(bot_top):
+        if bot_top is not None and _at_or_above(role, bot_top):
             return _verdict(ABOVE_BOT)
     if actor is not None:
         actor_top = getattr(actor, "top_role", None)
-        if actor_top is not None and _position(role) >= _position(actor_top):
+        if actor_top is not None and _at_or_above(role, actor_top):
             return _verdict(ABOVE_ACTOR)
     return _verdict(SELECTABLE)
 
@@ -181,6 +215,7 @@ __all__ = [
     "RoleFeasibility",
     "RoleFilter",
     "evaluate_role",
+    "is_below",
     "manageable_roles",
     "not_everyone",
     "summarize_exclusions",

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -7,13 +7,14 @@
 > contradicted each other across a single merge).
 >
 > **Last updated:** 2026-06-06 · #552 merged (session journal made lean +
-> self-maintaining). This session: **consistency-warning presentation fix** —
-> the health snapshot no longer renders benign `SKIPPED` consistency sections
-> ("not applicable", e.g. bindings-from-DM / no-backfill-rows) as WARNING "needs
-> attention"; only WARNING/FATAL count as blocking. Plus live verification of the
-> role-automation diagnostic (above-bot/missing-role/happy all confirmed). PR
-> pending. Verify open PRs against live GitHub (`list_pull_requests`); this
-> snapshot names none on purpose.
+> self-maintaining). This session (PR pending): (1) **consistency-warning
+> presentation fix** — the health snapshot no longer renders benign `SKIPPED`
+> sections (bindings-from-DM / no-backfill-rows) as WARNING "needs attention";
+> (2) **role-hierarchy tiebreak fix** — `role_feasibility` / `role_automation`
+> now compare role hierarchy by (position, id) like discord.py, not raw
+> `position` (which mis-flagged manageable roles when every role sits at
+> position 1; caught live). Verify open PRs against live GitHub
+> (`list_pull_requests`); this snapshot names none on purpose.
 >
 > **Purpose:** the one file that answers "what is true right now?" so a new
 > session does not reconstruct it from the journal + planning docs. Read it

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -6,12 +6,13 @@
 > live GitHub** before trusting it (two same-session reports already
 > contradicted each other across a single merge).
 >
-> **Last updated:** 2026-06-06 · #551 merged (role-automation degradation fix —
-> `role_automation.apply` preflight-guards at the mutation seam + classifies
-> failures; live health "Errors" surface back to ✅). This session: made the
-> **session journal lean + self-maintaining** (archive split → `.session-journal-
-> archive.md`, a Quick reference, and a "reorganize-each-session" protocol step;
-> PR pending). Verify open PRs against live GitHub (`list_pull_requests`); this
+> **Last updated:** 2026-06-06 · #552 merged (session journal made lean +
+> self-maintaining). This session: **consistency-warning presentation fix** —
+> the health snapshot no longer renders benign `SKIPPED` consistency sections
+> ("not applicable", e.g. bindings-from-DM / no-backfill-rows) as WARNING "needs
+> attention"; only WARNING/FATAL count as blocking. Plus live verification of the
+> role-automation diagnostic (above-bot/missing-role/happy all confirmed). PR
+> pending. Verify open PRs against live GitHub (`list_pull_requests`); this
 > snapshot names none on purpose.
 >
 > **Purpose:** the one file that answers "what is true right now?" so a new
@@ -38,6 +39,7 @@ Source code and merged PRs win over anything written here.
 
 ## Recently shipped (newest first)
 
+- **#552** — session journal made lean + self-maintaining: archive split (`.session-journal-archive.md`), a Quick reference, Rules regrouped, and a "tidy-each-session" protocol step (mirrored in `.claude/CLAUDE.md`); docs-only.
 - **#551** — role-automation degradation fix: `role_automation.apply` preflight-guards at the mutation seam (via `utils.role_feasibility`), classifies failures, and keeps predictable Manage-Roles/hierarchy blockers off the ERROR-only health surface; operator + role-Diagnostics surfaces show the cause.
 - **#550** — collaboration-model doc + truth-layer restructure (goal-first, prompts-as-guidance); docs-only.
 - **#549** — server-management cleanup PR8+PR9: `policy_version` marker, presets builder + dry-run + panel diagnostics, and the guild-default `scope_id=0` no-op fix.

--- a/docs/subsystems/health-diagnostics.md
+++ b/docs/subsystems/health-diagnostics.md
@@ -30,7 +30,14 @@ health system for a failure it merely displays.
   Use the finding's `related_subsystem` / `related_command` to locate it.
 - **"Consistency" / bindings-backfill / config-arbitration warnings** → a **separate**
   layer: `services/platform_consistency.py`. Distinguish benign warnings from blockers
-  via `docs/platform-consistency-ledger.md`; they are not health findings.
+  via `docs/platform-consistency-ledger.md`. The health snapshot renders only
+  **WARNING/FATAL** sections as "needs attention"; **SKIPPED** ("not applicable / no
+  data / no context") go to `facts.skipped_sections`, not findings
+  (`_build_consistency_subsystem`, 2026-06-06). Known-benign states (verified live):
+  **Bindings SKIPPED** = health asked from a **DM** (runs CLEAN inside a guild);
+  **Binding backfill SKIPPED** = no checkpoint rows (no backfill has run — normal);
+  **Config arbitration WARNING with `missing=0`** = legacy reads while
+  `bindings.primary` is not production-flipped (the designed pre-flip state — ledger §6).
 - **`diagnostics_health_snapshot` returned nothing for a user** → it's owner-gated and
   read-only by design; a non-owner getting nothing is correct, not a bug.
 - **A health card itself errors / is empty** → check provider isolation in

--- a/docs/subsystems/health-diagnostics.md
+++ b/docs/subsystems/health-diagnostics.md
@@ -36,8 +36,12 @@ health system for a failure it merely displays.
   (`_build_consistency_subsystem`, 2026-06-06). Known-benign states (verified live):
   **Bindings SKIPPED** = health asked from a **DM** (runs CLEAN inside a guild);
   **Binding backfill SKIPPED** = no checkpoint rows (no backfill has run — normal);
-  **Config arbitration WARNING with `missing=0`** = legacy reads while
-  `bindings.primary` is not production-flipped (the designed pre-flip state — ledger §6).
+  **Config arbitration WARNING with `missing=0`** = a real "migration unfinished"
+  signal, *not* noise: `fallback` is only recorded when `bindings.primary` evaluates
+  **ON** (`config_arbitration` source semantics), so it means the flag is on for the
+  guild but the binding rows were never backfilled — reads fall back to legacy and
+  `missing=0` confirms nothing is lost. Clear it by finishing the binding backfill
+  (PR-5/6) *or* turning `bindings.primary` off; don't just downgrade the warning.
 - **`diagnostics_health_snapshot` returned nothing for a user** → it's owner-gated and
   read-only by design; a non-owner getting nothing is correct, not a bug.
 - **A health card itself errors / is empty** → check provider isolation in

--- a/tests/unit/services/test_health_snapshot_service.py
+++ b/tests/unit/services/test_health_snapshot_service.py
@@ -377,3 +377,77 @@ def test_snapshot_to_payload_is_bounded_and_json_serializable() -> None:
     assert all(isinstance(s["status"], str) for s in payload["subsystems"])
     assert len(payload["subsystems"]) <= 16
     assert len(payload["findings"]) <= 12
+
+
+# --- consistency presentation: SKIPPED != "needs attention" ----------------
+
+
+def test_consistency_subsystem_skipped_sections_are_not_needs_attention() -> None:
+    """A SKIPPED consistency section ("not applicable / no data / no context",
+    e.g. Bindings checked from a DM, or no binding_backfill rows) must NOT be
+    rendered as a WARNING finding or counted as a "blocking section" — only
+    WARNING/FATAL sections are actionable.  Regression for the misleading
+    "3 blocking sections need attention" health surface.
+    """
+    from services import platform_consistency as pc
+
+    blocking = (
+        pc.SectionResult(
+            name="Bindings",
+            status=pc.SectionStatus.SKIPPED,
+            summary="No guild context (DM invocation).",
+            kind=pc.ReadinessKind.BINDINGS,
+        ),
+        pc.SectionResult(
+            name="Binding backfill",
+            status=pc.SectionStatus.SKIPPED,
+            summary="no `binding_backfill` checkpoint rows.",
+            kind=pc.ReadinessKind.BINDING_BACKFILL,
+        ),
+        pc.SectionResult(
+            name="Config arbitration",
+            status=pc.SectionStatus.WARNING,
+            summary="calls_total=2; fallback=2; missing=0.",
+            kind=pc.ReadinessKind.CONFIG_ARBITRATION,
+        ),
+    )
+    sub = hss._build_consistency_subsystem(
+        overall_value="warning",
+        report_at=hss._now(),
+        blocking=blocking,
+        source="test",
+    )
+    # Only the real WARNING section is an actionable finding.
+    assert len(sub.findings) == 1
+    assert sub.findings[0].related_subsystem == "consistency"
+    assert "Config arbitration" in sub.findings[0].message
+    # Facts separate actionable from "not applicable".
+    assert sub.facts["blocking_sections"] == 1
+    assert sub.facts["skipped_sections"] == 2
+    assert "Bindings" in sub.facts["skipped_section_names"]
+    assert "Binding backfill" in sub.facts["skipped_section_names"]
+
+
+def test_consistency_subsystem_all_skipped_has_no_findings() -> None:
+    """If every blocking section is SKIPPED (e.g. health asked from a DM with no
+    backfill rows), the subsystem surfaces zero "needs attention" findings.
+    """
+    from services import platform_consistency as pc
+
+    blocking = (
+        pc.SectionResult(
+            name="Bindings",
+            status=pc.SectionStatus.SKIPPED,
+            summary="No guild context (DM invocation).",
+            kind=pc.ReadinessKind.BINDINGS,
+        ),
+    )
+    sub = hss._build_consistency_subsystem(
+        overall_value="clean",
+        report_at=hss._now(),
+        blocking=blocking,
+        source="test",
+    )
+    assert sub.findings == ()
+    assert sub.facts["blocking_sections"] == 0
+    assert sub.facts["skipped_sections"] == 1

--- a/tests/unit/services/test_role_automation.py
+++ b/tests/unit/services/test_role_automation.py
@@ -419,6 +419,23 @@ def test_preflight_resolves_role_by_id_after_rename():
     assert result.ok is True
 
 
+def test_preflight_tied_position_role_after_bot_is_not_blocked():
+    """A threshold role sharing the bot's top-role position but created later
+    (larger id) is BELOW the bot per Discord's (position, id) ordering — it must
+    not be reported as a hierarchy blocker. Raw `position >=` wrongly flagged it
+    (every role at position 1 — the live test-guild state).
+    """
+    me = SimpleNamespace(
+        guild_permissions=SimpleNamespace(manage_roles=True),
+        top_role=SimpleNamespace(position=1, id=100),
+    )
+    role = _role(200, "testrole2", position=1)  # same pos, newer id → below bot
+    g = _guild(roles=[role], me=me)
+    result = check_preflight(g, [RoleThreshold("testrole2", 30, role_id=200)])
+    assert result.hierarchy_blockers == ()
+    assert result.ok is True
+
+
 # ---------------------------------------------------------------------------
 # apply — preflight guard + failure classification (the 26-errors fix)
 # ---------------------------------------------------------------------------
@@ -457,6 +474,32 @@ async def test_apply_blocks_entire_batch_when_bot_lacks_manage_roles():
     for m in members:
         m.add_roles.assert_not_awaited()
         m.remove_roles.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_apply_does_not_preempt_tied_position_manageable_role():
+    """Regression: a role at the bot's top-role position but created later (larger
+    id) is manageable, so apply() must NOT pre-empt it. Before the (position, id)
+    tiebreak fix the raw `position >=` check skipped it as ABOVE_BOT — silently
+    dropping a legitimate assignment.
+    """
+    role = _role(200, "testrole2", position=1)
+    member = _member(mid=1, display="u1", joined_days_ago=60)
+    me = SimpleNamespace(
+        guild_permissions=SimpleNamespace(manage_roles=True),
+        top_role=SimpleNamespace(position=1, id=100),
+    )
+    g = _guild(roles=[role], members=[member], me=me)
+    plans = compute_assignments(g, [RoleThreshold("testrole2", 30, role_id=200)])
+    assert len(plans) == 1
+    with patch(
+        "services.role_automation.emit_audit_action",
+        new_callable=AsyncMock,
+    ):
+        result = await apply(g, plans)
+    member.add_roles.assert_awaited_once()  # actually assigned, not pre-empted
+    assert result.succeeded == 1
+    assert result.failed == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_role_lifecycle_service.py
+++ b/tests/unit/services/test_role_lifecycle_service.py
@@ -158,9 +158,12 @@ async def test_blocked_when_bot_cannot_manage(svc):
 
 @pytest.mark.asyncio
 async def test_blocked_when_role_above_bot(svc):
-    # role.position >= bot top position → role_feasibility ABOVE_BOT
+    # Role STRICTLY above the bot's top role → role_feasibility ABOVE_BOT.
+    # (Equal positions are not automatically "above" — Discord breaks position
+    # ties by id — so use a strictly-higher position; see the role-hierarchy
+    # (position, id) tiebreak in utils.role_feasibility.)
     role = _role(10, "Admins", position=100)
-    guild = _guild([role], bot_top_position=100)
+    guild = _guild([role], bot_top_position=50)
     result = await svc.apply(
         guild,
         RoleLifecycleRequest(operation="edit", role_id=10, name="x"),

--- a/tests/unit/utils/test_role_feasibility.py
+++ b/tests/unit/utils/test_role_feasibility.py
@@ -76,6 +76,41 @@ def test_selectable_when_all_clear():
     assert v.reason == ""
 
 
+def _member_with_top(*, top_position, top_id, manage_roles=True):
+    return SimpleNamespace(
+        guild_permissions=SimpleNamespace(manage_roles=manage_roles),
+        top_role=SimpleNamespace(position=top_position, id=top_id),
+    )
+
+
+def test_tied_position_role_created_after_bot_is_manageable():
+    """Discord role positions are NOT unique. A role at the SAME position as the
+    bot's top role but created AFTER it (larger id) ranks BELOW the bot, so it is
+    manageable — the raw `position >=` check wrongly flagged it (the live
+    'testrole2 at pos 1, bot Galaxy Bot also pos 1' case).
+    """
+    bot = _member_with_top(top_position=1, top_id=100)
+    v = rf.evaluate_role(_role(200, "testrole2", position=1), bot_member=bot)
+    assert v.ok
+    assert v.code == rf.SELECTABLE
+
+
+def test_tied_position_role_created_before_bot_is_above():
+    """At equal position the OLDER role (smaller id) outranks the bot."""
+    bot = _member_with_top(top_position=1, top_id=200)
+    v = rf.evaluate_role(_role(100, "OldAdmin", position=1), bot_member=bot)
+    assert not v.ok
+    assert v.code == rf.ABOVE_BOT
+
+
+def test_strictly_higher_position_is_above_regardless_of_id():
+    """A higher position always outranks, even with a larger (newer) id."""
+    bot = _member_with_top(top_position=5, top_id=100)
+    v = rf.evaluate_role(_role(999, "Admin", position=9), bot_member=bot)
+    assert not v.ok
+    assert v.code == rf.ABOVE_BOT
+
+
 def test_precedence_everyone_before_managed():
     v = rf.evaluate_role(_role(7, "x", default=True, managed=True))
     assert v.code == rf.EVERYONE


### PR DESCRIPTION
Two correctness fixes found while verifying the role-automation + health work this session.

## 1. Role hierarchy: compare by (position, id), not raw position  ⭐ the important one

**Discord role positions are not unique.** When roles tie on `position`, Discord — and discord.py's `Role` ordering — break the tie by **id** (older/smaller id ranks higher). The bot's managed role and bot-created roles commonly **all sit at position 1**, so the old `role.position >= bot_top.position` check mis-flagged manageable roles as "above the bot."

**Confirmed live** in the test guild (thanks to @menno420 catching it): `Galaxy Bot` is the **highest** role, but `testrole2` (same position=1, newer id) was flagged "above" it — while discord.py's own `testrole2 < me.top_role` correctly says it's **manageable**.

**Impact:** false "above my top role" diagnostics, **and** — because #551's `apply()` pre-empt uses the same evaluator — threshold roles the bot *can* manage were being silently skipped (never assigned). This is the real, code-level bug behind the role-automation confusion (not a server-config issue).

- `utils/role_feasibility.py`: new `_at_or_above` / `is_below` mirror discord.py's (position, id) ordering; `evaluate_role` uses them for bot- and actor-hierarchy.
- `services/role_automation.py`: `check_preflight` delegates its hierarchy verdict to `evaluate_role` (removes the duplicated raw-position compare → one source of truth).
- `services/guild_snapshot.py`: `bot_can_manage` uses `is_below` (same bug class — fixed for completeness).
- Tests: tie both directions + strict-above; preflight + apply tie cases; fixed `test_role_lifecycle_service`'s above-bot test, which had **encoded the tie as "above"**.
- Re-verified live: `testrole2` now reads `🟢 manageable`.

> **Correction to my earlier note:** I'd suggested "raise the bot's role" — that was **wrong**, caused by this bug. Your role setup is fine; `Galaxy Bot` is highest. No action needed on your side.

## 2. Health: SKIPPED consistency sections aren't "needs attention"

The health snapshot rendered benign `SKIPPED` consistency sections (Bindings checked from a **DM**; no `binding_backfill` rows) as `WARNING` "needs attention," inflating "3 blocking sections." Now only WARNING/FATAL are findings; SKIPPED → `facts.skipped_sections`. Your "3 blocking sections" → **1** (config arbitration). Folio debug-router documents the benign-state catalogue.

**Config arbitration** (leaving as-is per your call, flagged for a future session): it's a real "migration unfinished" signal — `bindings.primary` is ON for the guild but the binding rows were never backfilled, so reads fall back to legacy (`missing=0` = nothing lost). Resolve later by finishing the backfill or turning the flag off.

## Verification
`check_architecture --mode strict` → 0 errors. `check_quality --full` → green (**7666 passed**, 3 skipped) — black/isort/ruff/mypy/pytest. Booted the test bot clean (0 ERROR/CRITICAL). Role diagnostic + consistency collectors verified live against both test guilds.

https://claude.ai/code/session_01Vx7eaeoaRcG1qExPNFdjio