### PR TITLE
Moderation require-reason + bot-readiness diagnostics — server-management PR10 (second slice)

### DIFF
--- a/.session-journal-archive.md
+++ b/.session-journal-archive.md
@@ -18,6 +18,38 @@
 
 ## Session Log archive (newest first)
 
+### 2026-06-06 — Journal made lean + self-maintaining (archive split, Quick reference, reorganize-each-session)
+
+- **Arc:** maintainer asked for an honest opinion of this journal, then — based on it —
+  to **improve it and make future sessions keep it that way** ("functional and quick to
+  read and remember; reorganize where possible after a session"). Same session as the
+  role-automation fix, separate docs-only PR off merged `main` (89da9ad, incl. #551).
+- **Shipped (docs-only):**
+  - **Archive split** — older Session Log entries moved to NEW
+    `.session-journal-archive.md` (grep-on-demand history); the live journal dropped
+    **843 → ~400 lines**, keeping only the newest ~3-4 entries + the guidebook.
+  - **⚡ Quick reference** added near the top — a 5-row "boot / Postgres-down / run-CI /
+    kill-bot / end-of-session" table + the 3 rules that bite hardest. The 80% you need,
+    scannable in seconds (my #1 suggestion: the load-bearing facts were buried at the
+    bottom).
+  - **Rules / Conventions regrouped** into Boot & environment / CI & quality / Architecture,
+    data & coding / Cross-agent & git, with **★ promotion-candidate** markers. Every prior
+    rule preserved verbatim; folded in two earned lessons (guard-at-the-mutation-seam from
+    the role fix; a-test-can-encode-a-bug from the cleanup session).
+  - **Protocol** now makes "**tidy as you go**" an explicit **END** step (every session,
+    not just the 3-5-session REVIEW): roll old entries to the archive, fix/merge stale
+    Rules in place, refresh the Quick reference. START now says read the Quick reference
+    first + grep the archive for old history. Intro reframed: "fast-read working set, not
+    an archive."
+  - `.claude/CLAUDE.md` — the journal pointer now states the lean/archive expectation so
+    every session inherits it (auto-loaded).
+- **Why (my honest review, acted on):** the guidebook (Runbook + Rules) earned its keep
+  every session; the Session Log's long tail did not and only grew. Bounding the live
+  file's length was the one metric trending the wrong way.
+- **Verified:** no test/script references the journal (`grep tests/ scripts/` — none), so
+  the restructure can't break CI; `tests/unit/docs/` still green. Docs-only.
+- **For project state see `docs/current-state.md`.** (PR pending.)
+
 ### 2026-06-06 — Role-automation degradation FIXED (preflight-at-mutation + failure classification)
 
 - **Arc:** maintainer reported the bot self-describing **Health: Degraded** in

--- a/.session-journal.md
+++ b/.session-journal.md
@@ -363,6 +363,40 @@ confidence; do not treat booting as gated.
 
 ## Session Log (newest first — append-only)
 
+### 2026-06-07 — Server-management PR10 (second slice): require-reason + bot-readiness diagnostics
+
+- **Arc:** the PR10 first slice (#555) merged mid-session; maintainer picked "continue —
+  contained items" (via `AskUserQuestion`) → ship the two low-risk remaining PR10 items in
+  one PR. Branch `claude/zen-volta-F5xKv` fast-forwarded onto merged `main` (`bfb9ba3`).
+- **Shipped:**
+  - **`require_reason`** (bool setting) enforced **at the seam**: new
+    `moderation_service.ReasonRequiredError` + `_resolve_reason()` raise **before** any side
+    effect (warn/kick/ban); **timeout exempt** (its reason carries the duration). Key
+    insight that avoided a call-site-spread rewrite: `moderation_config.has_reason()` is
+    **placeholder-aware** (treats `"No reason provided"` as no reason), so the cog + the seven
+    modals needed only an `except ReasonRequiredError` catch — surfaces keep passing their
+    existing (defaulted) reason and the seam normalises/enforces.
+  - **Bot-readiness diagnostics:** new pure `utils/moderation_feasibility.py`
+    (`evaluate_moderation_readiness` / `render_readiness_line`, mirrors `role_feasibility`);
+    `_build_mod_panel_embed(guild)` gains a read-only **"🤖 Bot readiness"** field
+    (Ban/Kick/Timeout perms + top-role ceiling) so an operator sees *before* clicking why an
+    action might fail. The no-guild persistent-restore path is unchanged.
+  - Settings: `MOD_REQUIRE_REASON` key + a `require_reason` bool-toggle spec; auto-rendered in
+    `!settings → Moderation`. No migration (KV-backed).
+- **Why these two:** lowest-risk of the remaining PR10 list and need no design decision; the
+  bigger items (mod-roles + capabilities, dedicated log destinations, escalation rules,
+  post-action cleanup) touch capability-authority / other subsystems and were deferred to the
+  maintainer.
+- **Tests:** `test_moderation_feasibility.py` (new), `test_moderation_panel_embed.py` (new),
+  require-reason + `has_reason` cases in `test_moderation_service.py` / `test_moderation_config.py`,
+  `require_reason` spec in `test_moderation_schemas.py`. Doc-pin: command-map updated (new key +
+  spec name).
+- **Gates:** `check_quality --full` green (**7718 passed**, 16 skipped); `check_architecture
+  --mode strict` **0 errors**; booted clean (boot_id `84af5634`, ModerationCog + 7-setting schema,
+  2 servers, 0 ERROR/CRITICAL). Live Discord render of the readiness field / require-reason
+  rejection still owed (no Discord clicks from the shell) — logic is unit-pinned. **For project
+  state see `docs/current-state.md`.** (PR pending.)
+
 ### 2026-06-06 — Server-management PR10 (first slice): config-backed moderation behaviour
 
 - **Arc:** maintainer asked to continue the roadmap plans — "finish the remaining
@@ -470,38 +504,6 @@ confidence; do not treat booting as gated.
 - **Gates:** `check_architecture` 0 errors; `check_quality --full` green (7661 passed);
   booted clean (boot_id `ab97c12b`, 0 ERROR/CRITICAL). **For project state see
   `docs/current-state.md`.** (PR pending.)
-
-### 2026-06-06 — Journal made lean + self-maintaining (archive split, Quick reference, reorganize-each-session)
-
-- **Arc:** maintainer asked for an honest opinion of this journal, then — based on it —
-  to **improve it and make future sessions keep it that way** ("functional and quick to
-  read and remember; reorganize where possible after a session"). Same session as the
-  role-automation fix, separate docs-only PR off merged `main` (89da9ad, incl. #551).
-- **Shipped (docs-only):**
-  - **Archive split** — older Session Log entries moved to NEW
-    `.session-journal-archive.md` (grep-on-demand history); the live journal dropped
-    **843 → ~400 lines**, keeping only the newest ~3-4 entries + the guidebook.
-  - **⚡ Quick reference** added near the top — a 5-row "boot / Postgres-down / run-CI /
-    kill-bot / end-of-session" table + the 3 rules that bite hardest. The 80% you need,
-    scannable in seconds (my #1 suggestion: the load-bearing facts were buried at the
-    bottom).
-  - **Rules / Conventions regrouped** into Boot & environment / CI & quality / Architecture,
-    data & coding / Cross-agent & git, with **★ promotion-candidate** markers. Every prior
-    rule preserved verbatim; folded in two earned lessons (guard-at-the-mutation-seam from
-    the role fix; a-test-can-encode-a-bug from the cleanup session).
-  - **Protocol** now makes "**tidy as you go**" an explicit **END** step (every session,
-    not just the 3-5-session REVIEW): roll old entries to the archive, fix/merge stale
-    Rules in place, refresh the Quick reference. START now says read the Quick reference
-    first + grep the archive for old history. Intro reframed: "fast-read working set, not
-    an archive."
-  - `.claude/CLAUDE.md` — the journal pointer now states the lean/archive expectation so
-    every session inherits it (auto-loaded).
-- **Why (my honest review, acted on):** the guidebook (Runbook + Rules) earned its keep
-  every session; the Session Log's long tail did not and only grew. Bounding the live
-  file's length was the one metric trending the wrong way.
-- **Verified:** no test/script references the journal (`grep tests/ scripts/` — none), so
-  the restructure can't break CI; `tests/unit/docs/` still green. Docs-only.
-- **For project state see `docs/current-state.md`.** (PR pending.)
 
 > **Older sessions → [`.session-journal-archive.md`](.session-journal-archive.md).**
 > Only the most recent sessions stay here so this file is a fast read. Need older

--- a/disbot/cogs/moderation/_helpers.py
+++ b/disbot/cogs/moderation/_helpers.py
@@ -24,8 +24,17 @@ from core.runtime.component_registry import stats_block
 from utils.ui_constants import MOD_COLOR
 
 
-def _build_mod_panel_embed() -> discord.Embed:
-    return stats_block(
+def _build_mod_panel_embed(guild: discord.Guild | None = None) -> discord.Embed:
+    """Build the moderation panel embed.
+
+    When *guild* is supplied (the live ``!modmenu`` / slash / help routes), a
+    read-only **Bot readiness** field reports whether the bot actually holds
+    Ban / Kick / Timeout and where its role sits in the hierarchy — so an
+    operator can see *before* clicking why an action might fail (PR10).
+    Restored persistent panels keep their original embed (no guild at restore
+    time), so the field simply isn't shown there until the panel is reopened.
+    """
+    embed = stats_block(
         "🔨 Moderation Panel",
         [
             ("⚠️ Warn", "Issue a warning (auto-timeout at 3)", True),
@@ -43,6 +52,19 @@ def _build_mod_panel_embed() -> discord.Embed:
         ),
         footer="Any staff member with Moderate Members permission may use this panel.",
     )
+    if guild is not None:
+        from utils.moderation_feasibility import (
+            evaluate_moderation_readiness,
+            render_readiness_line,
+        )
+
+        readiness = evaluate_moderation_readiness(guild)
+        embed.add_field(
+            name="🤖 Bot readiness",
+            value=render_readiness_line(readiness),
+            inline=False,
+        )
+    return embed
 
 
 def _can_act_on_interaction(

--- a/disbot/cogs/moderation/schemas.py
+++ b/disbot/cogs/moderation/schemas.py
@@ -23,6 +23,7 @@ from services.moderation_config import (
     DEFAULT_DM_ON_ACTION,
     DEFAULT_DM_TEMPLATE,
     DEFAULT_MAX_TIMEOUT_MINUTES,
+    DEFAULT_REQUIRE_REASON,
     MAX_BAN_DELETE_MESSAGE_DAYS,
     MAX_TIMEOUT_MINUTES,
     MIN_BAN_DELETE_MESSAGE_DAYS,
@@ -33,6 +34,7 @@ from utils.settings_keys import (
     MOD_DM_ON_ACTION,
     MOD_DM_TEMPLATE,
     MOD_MAX_TIMEOUT_MINUTES,
+    MOD_REQUIRE_REASON,
     WARN_THRESHOLD,
     WARN_TIMEOUT_MINS,
 )
@@ -135,6 +137,19 @@ MODERATION_SETTINGS: tuple[SettingSpec, ...] = (
             "{user}."
         ),
         validator=_validate_dm_template,
+    ),
+    SettingSpec(
+        name="require_reason",
+        value_type=bool,
+        default=DEFAULT_REQUIRE_REASON,
+        settings_key=MOD_REQUIRE_REASON,
+        capability_required=_MODERATION_CAPABILITY,
+        hint=(
+            "Require a non-empty reason for warn / kick / ban.  When on, the "
+            "action is rejected (at the moderation_service seam) if no reason "
+            "is given.  Timeout is exempt — its reason carries the duration."
+        ),
+        validator=_validate_bool,
     ),
     SettingSpec(
         name="ban_delete_message_days",

--- a/disbot/cogs/moderation_cog.py
+++ b/disbot/cogs/moderation_cog.py
@@ -9,6 +9,7 @@ from discord.ext import commands
 from cogs.moderation._helpers import _build_mod_panel_embed
 from core.runtime import panel_manager
 from services import moderation_service
+from services.moderation_service import ReasonRequiredError
 from utils import db
 from utils.ui_constants import MOD_COLOR
 
@@ -44,7 +45,7 @@ class ModerationCog(commands.Cog):
     @commands.has_permissions(moderate_members=True)
     async def mod_menu(self, ctx):
         """Show the interactive moderation action panel."""
-        embed = _build_mod_panel_embed()
+        embed = _build_mod_panel_embed(ctx.guild)
         view = ModPanelView()
         await panel_manager.get_or_render_panel(ctx, "moderation", embed, view)
 
@@ -53,7 +54,7 @@ class ModerationCog(commands.Cog):
         interaction: discord.Interaction,
     ) -> tuple[discord.Embed, discord.ui.View]:
         """Help-menu direct-navigation hook (returns the moderation panel)."""
-        return _build_mod_panel_embed(), ModPanelView()
+        return _build_mod_panel_embed(interaction.guild), ModPanelView()
 
     @app_commands.command(
         name="moderation",
@@ -87,7 +88,7 @@ class ModerationCog(commands.Cog):
 
     @commands.command(name="warn", hidden=True)
     @commands.has_permissions(manage_roles=True)
-    async def warn(self, ctx, member: Member, *, reason="No reason provided"):
+    async def warn(self, ctx, member: Member, *, reason=""):
         """Warn a user. Auto-timeouts at the configured threshold (default: 3)."""
         err = self._can_act_on(ctx, member)
         if err:
@@ -110,13 +111,20 @@ class ModerationCog(commands.Cog):
             "warn_timeout_minutes",
             10,
         )
-        count = await moderation_service.warn(
-            member,
-            reason=reason,
-            actor_id=ctx.author.id,
-        )
+        # The raw reason is passed through; the service enforces require_reason
+        # at the seam and defaults an empty reason for the log.
+        try:
+            count = await moderation_service.warn(
+                member,
+                reason=reason,
+                actor_id=ctx.author.id,
+            )
+        except ReasonRequiredError as exc:
+            await ctx.send(f"❌ {exc}")
+            return
         await ctx.send(
-            f"⚠️ {member.mention} warned ({count}/{threshold}). Reason: {reason}",
+            f"⚠️ {member.mention} warned ({count}/{threshold}). "
+            f"Reason: {reason or 'No reason provided'}",
         )
         if count >= threshold:
             try:
@@ -165,7 +173,7 @@ class ModerationCog(commands.Cog):
 
     @commands.command(name="kick", hidden=True)
     @commands.has_permissions(kick_members=True)
-    async def kick(self, ctx, member: Member, *, reason="No reason provided"):
+    async def kick(self, ctx, member: Member, *, reason=""):
         """Kick a member from the server."""
         err = self._can_act_on(ctx, member)
         if err:
@@ -177,7 +185,11 @@ class ModerationCog(commands.Cog):
                 reason=reason,
                 actor_id=ctx.author.id,
             )
-            await ctx.send(f"👢 {member.mention} kicked. Reason: {reason}")
+            await ctx.send(
+                f"👢 {member.mention} kicked. Reason: {reason or 'No reason provided'}",
+            )
+        except ReasonRequiredError as exc:
+            await ctx.send(f"❌ {exc}")
         except discord.Forbidden:
             await ctx.send("❌ I don't have permission to kick that user.")
         except discord.HTTPException as e:
@@ -185,7 +197,7 @@ class ModerationCog(commands.Cog):
 
     @commands.command(name="ban", hidden=True)
     @commands.has_permissions(ban_members=True)
-    async def ban(self, ctx, member: Member, *, reason="No reason provided"):
+    async def ban(self, ctx, member: Member, *, reason=""):
         """Ban a member from the server."""
         err = self._can_act_on(ctx, member)
         if err:
@@ -198,7 +210,11 @@ class ModerationCog(commands.Cog):
                 reason=reason,
                 actor_id=ctx.author.id,
             )
-            await ctx.send(f"🚫 {member.mention} banned. Reason: {reason}")
+            await ctx.send(
+                f"🚫 {member.mention} banned. Reason: {reason or 'No reason provided'}",
+            )
+        except ReasonRequiredError as exc:
+            await ctx.send(f"❌ {exc}")
         except discord.Forbidden:
             await ctx.send("❌ I don't have permission to ban that user.")
         except discord.HTTPException as e:

--- a/disbot/services/moderation_config.py
+++ b/disbot/services/moderation_config.py
@@ -44,6 +44,7 @@ SUBSYSTEM = "moderation"
 
 DEFAULT_DM_ON_ACTION = False
 DEFAULT_DM_TEMPLATE = ""
+DEFAULT_REQUIRE_REASON = False
 DEFAULT_BAN_DELETE_MESSAGE_DAYS = 0
 # Discord caps a member timeout at 28 days; the default ceiling is that hard
 # maximum, so an unconfigured guild keeps today's behaviour exactly.
@@ -82,6 +83,7 @@ class ModerationPolicy:
 
     dm_on_action: bool = DEFAULT_DM_ON_ACTION
     dm_template: str = DEFAULT_DM_TEMPLATE
+    require_reason: bool = DEFAULT_REQUIRE_REASON
     ban_delete_message_days: int = DEFAULT_BAN_DELETE_MESSAGE_DAYS
     max_timeout_minutes: int = DEFAULT_MAX_TIMEOUT_MINUTES
 
@@ -129,6 +131,12 @@ async def load_policy(guild_id: int) -> ModerationPolicy:
         "dm_template",
         DEFAULT_DM_TEMPLATE,
     )
+    require_reason = await resolve_value(
+        guild_id,
+        SUBSYSTEM,
+        "require_reason",
+        DEFAULT_REQUIRE_REASON,
+    )
     ban_delete_message_days = await resolve_value(
         guild_id,
         SUBSYSTEM,
@@ -144,6 +152,7 @@ async def load_policy(guild_id: int) -> ModerationPolicy:
     return ModerationPolicy(
         dm_on_action=bool(dm_on_action),
         dm_template=str(dm_template),
+        require_reason=bool(require_reason),
         ban_delete_message_days=int(ban_delete_message_days),
         max_timeout_minutes=int(max_timeout_minutes),
     )
@@ -155,6 +164,17 @@ def _clean_reason(reason: str | None) -> str:
     if not text or text.lower() == _PLACEHOLDER_REASON:
         return ""
     return text
+
+
+def has_reason(reason: str | None) -> bool:
+    """True if *reason* is a real operator-supplied reason.
+
+    Empty, whitespace-only, and the ``"No reason provided"`` placeholder all
+    count as **no** reason — this is the single placeholder-aware check the
+    ``require_reason`` enforcement (at the ``moderation_service`` seam) and the
+    DM renderer share, so "has a reason" means the same thing everywhere.
+    """
+    return _clean_reason(reason) != ""
 
 
 def render_dm_message(
@@ -197,12 +217,14 @@ __all__ = [
     "DEFAULT_DM_ON_ACTION",
     "DEFAULT_DM_TEMPLATE",
     "DEFAULT_MAX_TIMEOUT_MINUTES",
+    "DEFAULT_REQUIRE_REASON",
     "MAX_BAN_DELETE_MESSAGE_DAYS",
     "MAX_TIMEOUT_MINUTES",
     "MIN_BAN_DELETE_MESSAGE_DAYS",
     "MIN_TIMEOUT_MINUTES",
     "ModerationPolicy",
     "SUBSYSTEM",
+    "has_reason",
     "load_policy",
     "render_dm_message",
 ]

--- a/disbot/services/moderation_service.py
+++ b/disbot/services/moderation_service.py
@@ -80,6 +80,44 @@ logger = logging.getLogger("bot.moderation_service")
 # on payload["action"].  Also listed in core/events_catalogue.KNOWN_EVENTS.
 EVT_MOD_ACTION = "moderation.action_taken"
 
+# The token written to mod_logs when a (non-required) action has no reason —
+# keeps the historical display text every surface used before PR10.
+_DEFAULT_REASON = "No reason provided"
+
+
+class ReasonRequiredError(Exception):
+    """Raised when ``require_reason`` is on but no reason was supplied.
+
+    Surfaced at the mutation seam **before** any side effect (DB write, DM,
+    Discord call) so the cog/modal surfaces can tell the operator a reason is
+    required without anything having happened.  Applies to warn / kick / ban;
+    timeout is exempt (its reason carries the duration).
+    """
+
+    def __init__(self, action: str) -> None:
+        self.action = action
+        super().__init__(f"A reason is required to {action} a member.")
+
+
+def _resolve_reason(
+    reason: str,
+    policy: moderation_config.ModerationPolicy,
+    *,
+    action: str,
+) -> str:
+    """Enforce ``require_reason`` and normalise an empty reason for logging.
+
+    Raises :class:`ReasonRequiredError` when the guild requires a reason and
+    none was given (placeholder-aware via :func:`moderation_config.has_reason`);
+    otherwise returns the reason, defaulting empty/placeholder input to
+    ``"No reason provided"`` so the ``mod_logs`` row keeps its historical text.
+    """
+    if not moderation_config.has_reason(reason):
+        if policy.require_reason:
+            raise ReasonRequiredError(action)
+        return _DEFAULT_REASON
+    return reason
+
 
 def _now_utc() -> datetime:
     """Return a tz-aware "now" — INV-N forbids bare datetime.utcnow."""
@@ -211,8 +249,9 @@ async def warn(
     Returns:
         The post-increment warning count.
     """
-    new_count = await db.add_warning(member.id, member.guild.id)
     policy = await moderation_config.load_policy(member.guild.id)
+    reason = _resolve_reason(reason, policy, action="warn")
+    new_count = await db.add_warning(member.id, member.guild.id)
     await _record_action(
         guild_id=member.guild.id,
         action="warn",
@@ -278,6 +317,7 @@ async def kick(
     guild_id = member.guild.id
     target_id = member.id
     policy = await moderation_config.load_policy(guild_id)
+    reason = _resolve_reason(reason, policy, action="kick")
     # DM before removal — a kicked member is no longer DM-reachable.
     await _notify_target(
         member,
@@ -313,6 +353,7 @@ async def ban(
     a purge is actually configured.
     """
     policy = await moderation_config.load_policy(guild.id)
+    reason = _resolve_reason(reason, policy, action="ban")
     # DM before the ban — a banned user no longer shares the guild and is
     # not DM-reachable afterward.
     await _notify_target(

--- a/disbot/utils/moderation_feasibility.py
+++ b/disbot/utils/moderation_feasibility.py
@@ -1,0 +1,104 @@
+"""Pure moderation-readiness evaluation for the mod panel + diagnostics.
+
+Answers "can the bot actually moderate in this guild?" as a structured
+result rather than ad-hoc strings — which of ban / kick / timeout the bot's
+permissions allow, plus its role-hierarchy ceiling (Discord only lets the bot
+action members **below** its own top role).
+
+This module is **pure**: no I/O and no service/cog/view imports (``utils`` may
+import stdlib + ``discord`` only).  It mirrors :mod:`utils.role_feasibility`'s
+shape so a single source of truth answers "can the bot moderate?" for the
+moderation panel today and the Server-Management hub later.
+
+It deliberately reports only what is knowable from ``guild.me`` alone — the
+bot's own guild permissions and top role.  Per-target hierarchy/owner checks
+(can *this* moderator act on *that* member) stay in
+``cogs.moderation._helpers._can_act_on_interaction``; this is the guild-wide
+"is the bot even able to act?" summary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import discord
+
+
+@dataclass(frozen=True)
+class ModerationReadiness:
+    """Structured snapshot of the bot's moderation capability in one guild."""
+
+    can_ban: bool
+    can_kick: bool
+    can_timeout: bool
+    top_role_name: str
+    # The bot's top role sits at the bottom of the hierarchy (``@everyone`` /
+    # position 0) → it cannot action anyone until the role is moved up.
+    top_role_is_lowest: bool
+
+    @property
+    def fully_capable(self) -> bool:
+        """True when the bot holds ban + kick + timeout and can out-rank someone."""
+        return (
+            self.can_ban
+            and self.can_kick
+            and self.can_timeout
+            and not self.top_role_is_lowest
+        )
+
+    def missing_permissions(self) -> tuple[str, ...]:
+        """Human-readable names of the moderation permissions the bot lacks."""
+        missing: list[str] = []
+        if not self.can_ban:
+            missing.append("Ban Members")
+        if not self.can_kick:
+            missing.append("Kick Members")
+        if not self.can_timeout:
+            missing.append("Timeout Members")
+        return tuple(missing)
+
+
+def evaluate_moderation_readiness(guild: discord.Guild) -> ModerationReadiness:
+    """Evaluate the bot's moderation capability in *guild* from ``guild.me``.
+
+    ``administrator`` implies every permission, so it satisfies each capability.
+    """
+    me = guild.me
+    perms = me.guild_permissions
+    admin = bool(perms.administrator)
+    top_role = me.top_role
+    return ModerationReadiness(
+        can_ban=admin or bool(perms.ban_members),
+        can_kick=admin or bool(perms.kick_members),
+        can_timeout=admin or bool(perms.moderate_members),
+        top_role_name=top_role.name,
+        top_role_is_lowest=top_role.position == 0,
+    )
+
+
+def render_readiness_line(readiness: ModerationReadiness) -> str:
+    """Render a short operator-facing status block for the mod panel."""
+    missing = readiness.missing_permissions()
+    if missing:
+        lines = ["⚠️ Missing permission(s): " + ", ".join(missing) + "."]
+    else:
+        lines = ["🟢 I can warn, timeout, kick, and ban."]
+
+    if readiness.top_role_is_lowest:
+        lines.append(
+            "⚠️ My top role is at the bottom of the list — I can't action "
+            "anyone until it is moved up.",
+        )
+    else:
+        lines.append(
+            f"I can only action members below my top role "
+            f"(**{readiness.top_role_name}**).",
+        )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "ModerationReadiness",
+    "evaluate_moderation_readiness",
+    "render_readiness_line",
+]

--- a/disbot/utils/settings_keys/__init__.py
+++ b/disbot/utils/settings_keys/__init__.py
@@ -56,6 +56,7 @@ from utils.settings_keys.moderation import (
     MOD_DM_ON_ACTION,
     MOD_DM_TEMPLATE,
     MOD_MAX_TIMEOUT_MINUTES,
+    MOD_REQUIRE_REASON,
     WARN_THRESHOLD,
     WARN_TIMEOUT_MINS,
 )
@@ -99,6 +100,7 @@ __all__ = [
     "MOD_DM_ON_ACTION",
     "MOD_DM_TEMPLATE",
     "MOD_MAX_TIMEOUT_MINUTES",
+    "MOD_REQUIRE_REASON",
     "RPS_DEFAULT_ENTRY_FEE",
     "SKIP_ROLES",
     "TIME_ROLES_STACK",

--- a/disbot/utils/settings_keys/moderation.py
+++ b/disbot/utils/settings_keys/moderation.py
@@ -10,5 +10,6 @@ WARN_TIMEOUT_MINS = "warn_timeout_minutes"
 # keep the shared guild-settings KV namespace collision-free.
 MOD_DM_ON_ACTION = "moderation_dm_on_action"
 MOD_DM_TEMPLATE = "moderation_dm_template"
+MOD_REQUIRE_REASON = "moderation_require_reason"
 MOD_BAN_DELETE_MESSAGE_DAYS = "moderation_ban_delete_message_days"
 MOD_MAX_TIMEOUT_MINUTES = "moderation_max_timeout_minutes"

--- a/disbot/views/moderation/modals.py
+++ b/disbot/views/moderation/modals.py
@@ -34,6 +34,7 @@ import discord
 from cogs.moderation._helpers import _can_act_on_interaction
 from core.runtime.interaction_helpers import safe_defer, safe_followup
 from services import moderation_service
+from services.moderation_service import ReasonRequiredError
 from utils import db
 from utils.helpers import _parse_member
 from utils.ui_constants import MOD_COLOR
@@ -87,11 +88,15 @@ class _WarnModal(discord.ui.Modal, title="Warn Member"):  # type: ignore[call-ar
             "warn_timeout_minutes",
             10,
         )
-        count = await moderation_service.warn(
-            member,
-            reason=reason,
-            actor_id=interaction.user.id,
-        )
+        try:
+            count = await moderation_service.warn(
+                member,
+                reason=reason,
+                actor_id=interaction.user.id,
+            )
+        except ReasonRequiredError as exc:
+            await safe_followup(interaction, f"❌ {exc}", ephemeral=True)
+            return
         await safe_followup(
             interaction,
             f"⚠️ {member.mention} warned ({count}/{threshold}). Reason: {reason}",
@@ -232,6 +237,8 @@ class _KickModal(discord.ui.Modal, title="Kick Member"):  # type: ignore[call-ar
                 interaction,
                 f"👢 {member.mention} kicked. Reason: {reason}",
             )
+        except ReasonRequiredError as exc:
+            await safe_followup(interaction, f"❌ {exc}", ephemeral=True)
         except discord.Forbidden:
             await safe_followup(
                 interaction,
@@ -282,6 +289,8 @@ class _BanModal(discord.ui.Modal, title="Ban Member"):  # type: ignore[call-arg]
                 interaction,
                 f"🚫 {member.mention} banned. Reason: {reason}",
             )
+        except ReasonRequiredError as exc:
+            await safe_followup(interaction, f"❌ {exc}", ephemeral=True)
         except discord.Forbidden:
             await safe_followup(
                 interaction,

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -6,16 +6,15 @@
 > live GitHub** before trusting it (two same-session reports already
 > contradicted each other across a single merge).
 >
-> **Last updated:** 2026-06-07 · #554 merged (implementation-readiness reconciliation
-> — `docs/audits/implementation-readiness-review-2026-06-06.md`; #553's consistency-warning
-> + role-hierarchy fixes also landed — see Recently shipped). This PR (pending):
-> **server-management PR10 — config-backed moderation behaviour (first slice)**: a
-> `moderation_config` policy read model + four operator settings (`dm_on_action`,
-> `dm_template`, `ban_delete_message_days`, `max_timeout_minutes`) applied at the
-> `moderation_service` mutation seam — member DMs on action, ban message-purge, and a
-> timeout ceiling, behaviour-preserving by default. See the server-management tracker's
-> PR10 entry for the remaining queue. Verify open PRs against live GitHub
-> (`list_pull_requests`); this snapshot names none on purpose.
+> **Last updated:** 2026-06-07 · #555 merged (server-management **PR10 first slice** —
+> config-backed moderation behaviour: DM-on-action, ban message-purge, timeout ceiling;
+> #554 implementation-readiness reconciliation also landed — see Recently shipped). This
+> PR (pending): **server-management PR10 second slice** — `require_reason` enforcement at
+> the `moderation_service` seam (warn/kick/ban; timeout exempt) + a read-only bot-readiness
+> diagnostics line on the mod panel (`utils/moderation_feasibility.py`). See the
+> server-management tracker's PR10 entry for the remaining queue (mod-roles + capabilities,
+> dedicated log destinations, escalation rules, post-action cleanup). Verify open PRs against
+> live GitHub (`list_pull_requests`); this snapshot names none on purpose.
 >
 > **Purpose:** the one file that answers "what is true right now?" so a new
 > session does not reconstruct it from the journal + planning docs. Read it
@@ -41,6 +40,7 @@ Source code and merged PRs win over anything written here.
 
 ## Recently shipped (newest first)
 
+- **#555** — server-management **PR10 first slice**: config-backed moderation behaviour (`moderation_config` policy + `dm_on_action` / `dm_template` / `ban_delete_message_days` / `max_timeout_minutes`) applied at the `moderation_service` mutation seam; behaviour-preserving by default.
 - **#554** — implementation-readiness reconciliation: source-grounded readiness audit (`docs/audits/implementation-readiness-review-2026-06-06.md`) + reclassified stale Phase-2 / platform-consistency status cells so they aren't mistaken for current work queues; docs-only.
 - **#553** — consistency-warning presentation fix (the health snapshot no longer flags benign `SKIPPED` consistency sections — bindings-from-DM / no-backfill-rows — as "needs attention") + role-hierarchy tiebreak (`role_feasibility` / `role_automation` compare hierarchy by (position, id) like discord.py, not raw `position`).
 - **#552** — session journal made lean + self-maintaining: archive split (`.session-journal-archive.md`), a Quick reference, Rules regrouped, and a "tidy-each-session" protocol step (mirrored in `.claude/CLAUDE.md`); docs-only.
@@ -65,10 +65,10 @@ Source code and merged PRs win over anything written here.
 ## Next candidates
 
 - Highest-value approved implementation lane: server-management. PR10's **first slice**
-  (config-backed moderation behaviour — DMs / ban message-purge / timeout ceiling) is
-  shipping in the current PR; the next step is the **remaining PR10 slice** (mod-roles +
-  capabilities, log destinations, escalation rules, required-reason, post-action cleanup,
-  hierarchy diagnostics), then PR11–PR14. The
+  (config-backed moderation behaviour, #555) and **second slice** (require-reason +
+  bot-readiness diagnostics, the current PR) have shipped; the next step is the
+  **remaining PR10 items** (mod-roles + capabilities, dedicated log destinations,
+  escalation rules, post-action cleanup hook), then PR11–PR14. The
   `docs/planning/server-management-status-2026-06-05.md` tracker is the authoritative
   queue — don't duplicate it here.
 - Health/diagnostics maintainer live-tests (production AI tool + grouped findings):

--- a/docs/planning/server-management-status-2026-06-05.md
+++ b/docs/planning/server-management-status-2026-06-05.md
@@ -7,9 +7,10 @@
 > the target architecture and the implementation plan remains the PR-scope detail.
 >
 > **Date:** 2026-06-05 (originally verified @ `f0f0824` / #523; updated 2026-06-06
-> for PR8+PR9, then for **PR10's first slice** — config-backed moderation behaviour).
-> **Body is current through PR10's first slice; the remaining PR10 items + PR11–PR14
-> are the queue** — the "Shipped" + "Remaining queue" sections below are authoritative.
+> for PR8+PR9, then for **PR10's first + second slices** — config-backed moderation
+> behaviour, require-reason, and bot-readiness diagnostics). **Body is current through
+> PR10's second slice; the remaining PR10 items + PR11–PR14 are the queue** — the
+> "Shipped" + "Remaining queue" sections below are authoritative.
 >
 > **Companion docs (read together):**
 > - `docs/planning/server-management-roadmap-2026-06-05.md` — target architecture
@@ -307,12 +308,31 @@ widget dispatcher.
   `tests/unit/cogs/test_moderation_schemas.py` (incl. a spec-default ↔ policy-default
   drift guard). Booted live (boot_id `a6a24aea`) — ModerationCog loads with the v2
   schema, 0 ERROR/CRITICAL.
-- **Remaining PR10 queue (next slice):** moderator/trusted **roles + capabilities**,
-  dedicated **log destinations** (today rides `logging_mod_channel` + the generic
-  audit channel), **required/optional reason** enforcement, **escalation-rule**
-  config, **post-action cleanup** hook, and **hierarchy diagnostics**. These either
-  touch the capability-authority seam or other subsystems and are the natural second
-  PR10 slice.
+- **Remaining PR10 queue:** moderator/trusted **roles + capabilities**, dedicated
+  **log destinations** (today rides `logging_mod_channel` + the generic audit
+  channel), **escalation-rule** config, and a **post-action cleanup** hook. These
+  touch the capability-authority seam or other subsystems.
+
+### PR10 (second slice) — Required-reason enforcement + bot-readiness diagnostics *(shipped 2026-06-07)*
+
+Two contained remaining PR10 items, kept consistent with the first slice's
+service-seam discipline:
+
+- **`require_reason`** (bool setting; warn / kick / ban) — enforced at the
+  `moderation_service` seam via a new `ReasonRequiredError` raised **before** any side
+  effect; the cog + the seven modals catch it and tell the operator a reason is
+  required. **Timeout is exempt** (its reason carries the duration). Placeholder-aware
+  (`moderation_config.has_reason` treats `"No reason provided"` as no reason), so the
+  surfaces needed only the catch — no reason-handling rewrite.
+- **Bot-readiness diagnostics** — new pure `utils/moderation_feasibility.py`
+  (`evaluate_moderation_readiness` / `render_readiness_line`, mirroring
+  `utils/role_feasibility.py`); the mod panel embed gains a read-only **"🤖 Bot
+  readiness"** field (has Ban/Kick/Timeout? where does my top role sit?) so an operator
+  sees *before* clicking why an action might fail.
+- **Pinned by** `tests/unit/utils/test_moderation_feasibility.py`,
+  `tests/unit/cogs/test_moderation_panel_embed.py`, require-reason cases in
+  `test_moderation_service.py`, and `has_reason` / `require_reason` cases in
+  `test_moderation_config.py` + `test_moderation_schemas.py`.
 
 ---
 
@@ -322,7 +342,7 @@ Per the implementation plan's dependency order. PR7–PR9 shipped (see above).
 
 | PR | Objective | Depends on |
 |---|---|---|
-| **PR10** | Moderation first-class configuration. **First slice shipped** (DMs, ban message-purge, timeout ceiling — see above). Remaining: mod-roles + capabilities, log destinations, escalation rules, required-reason, post-action cleanup, hierarchy diagnostics. | #521 |
+| **PR10** | Moderation first-class configuration. **First + second slices shipped** (DMs, ban message-purge, timeout ceiling, require-reason, bot-readiness diagnostics — see above). Remaining: mod-roles + capabilities, dedicated log destinations, escalation rules, post-action cleanup hook. | #521 |
 | **PR11** | Setup role/moderation/governance sections. | PR5, PR8–PR10, #522 |
 | **PR12** | Setup diagnostics & repair. | PR5, #522 |
 | **PR13** | Deterministic + AI role templates. | PR5, #523 |

--- a/docs/settings-customization-command-map.md
+++ b/docs/settings-customization-command-map.md
@@ -161,13 +161,13 @@ Subsystems (22): `admin`, `moderation`, `economy`, `inventory`, `mining`,
 7. **dedicated_panel_command**: `none`.
 8. **help_menu_direct_navigation_hook**: `none`.
 9. **existing_SettingSpec_declarations**: `warn_threshold`,
-   `warn_timeout_minutes`, `dm_on_action`, `dm_template`,
+   `warn_timeout_minutes`, `dm_on_action`, `dm_template`, `require_reason`,
    `ban_delete_message_days`, `max_timeout_minutes`
-   (`disbot/cogs/moderation/schemas.py`).  The last four are PR10's
+   (`disbot/cogs/moderation/schemas.py`).  The last five are PR10's
    first-class behaviour config (applied at the `moderation_service` seam).
 10. **existing_settings_keys**: `WARN_THRESHOLD`, `WARN_TIMEOUT_MINS`,
-    `MOD_DM_ON_ACTION`, `MOD_DM_TEMPLATE`, `MOD_BAN_DELETE_MESSAGE_DAYS`,
-    `MOD_MAX_TIMEOUT_MINUTES`
+    `MOD_DM_ON_ACTION`, `MOD_DM_TEMPLATE`, `MOD_REQUIRE_REASON`,
+    `MOD_BAN_DELETE_MESSAGE_DAYS`, `MOD_MAX_TIMEOUT_MINUTES`
     (`disbot/utils/settings_keys/moderation.py`).
 11. **existing_BindingSpec_entries**: none (mod_log promotion planned in
     later milestone).
@@ -177,12 +177,14 @@ Subsystems (22): `admin`, `moderation`, `economy`, `inventory`, `mining`,
     capabilities `moderation.warn.apply`, `moderation.timeout.apply`,
     `moderation.kick.apply`, `moderation.ban.apply`, `moderation.ban.remove`,
     `moderation.log.view`, `moderation.settings.configure`.
-14. **hardcoded_or_env_only_behavior**: escalation rules and timeout presets
-    remain inline constants; mod roles / log destinations are not yet
-    first-class.  PR10 moved DM-on-action (`dm_on_action` / `dm_template`),
-    the ban message-purge window (`ban_delete_message_days`), and the
-    timeout ceiling (`max_timeout_minutes`) out of code into settings applied
-    at the `moderation_service` mutation seam.
+14. **hardcoded_or_env_only_behavior**: escalation rules remain inline
+    constants; mod roles / dedicated log destinations are not yet first-class.
+    PR10 moved DM-on-action (`dm_on_action` / `dm_template`), the ban
+    message-purge window (`ban_delete_message_days`), the timeout ceiling
+    (`max_timeout_minutes`), and `require_reason` (warn/kick/ban must justify;
+    timeout exempt) out of code into settings applied at the
+    `moderation_service` mutation seam.  The mod panel also shows a read-only
+    bot-readiness line (`utils/moderation_feasibility.py`).
 15. **missing_customization_commands**: `!settings moderation`
     edit/reset surface; `!moderation timeoutpresets`.
 16. **missing_settings_pages**: Settings Manager moderation page.
@@ -190,8 +192,9 @@ Subsystems (22): `admin`, `moderation`, `economy`, `inventory`, `mining`,
     timeout-presets list editor, mod-log channel BindingSelectView.
 18. **setting_class_per_value**: `warn_threshold` scalar, `warn_timeout_minutes`
     scalar, `dm_on_action` bool toggle, `dm_template` free-text,
-    `ban_delete_message_days` numeric-presets, `max_timeout_minutes`
-    numeric-presets; `mod_log` binding (after S10 promotion).
+    `require_reason` bool toggle, `ban_delete_message_days` numeric-presets,
+    `max_timeout_minutes` numeric-presets; `mod_log` binding (after S10
+    promotion).
 19. **target_Settings_Manager_page**: `!settings subsystem moderation`.
 20. **target_mutation_path**: `SettingsMutationPipeline` (scalars);
     `BindingMutationPipeline` (mod_log); `ResourceProvisioningPipeline`

--- a/docs/subsystems/server-management.md
+++ b/docs/subsystems/server-management.md
@@ -61,9 +61,10 @@ cleanup policy, setup, and the future unified hub. Inspect first:
 - Shipped foundations include moderation service convergence, shared role feasibility
   + multi-role selection, audited channel rename/move/delete/reorder lifecycle,
   audited role create/edit/delete lifecycle, selector-driven ID-first time/XP
-  role thresholds, and **config-backed moderation behaviour** (PR10 first slice —
-  DM-on-action, ban message-purge, and a timeout ceiling, applied at the
-  `services/moderation_service` mutation seam via `services/moderation_config.py`).
+  role thresholds, and **config-backed moderation** (PR10 first + second slices —
+  DM-on-action, ban message-purge, timeout ceiling, and require-reason, all applied at
+  the `services/moderation_service` mutation seam via `services/moderation_config.py`,
+  plus a read-only bot-readiness panel line from `utils/moderation_feasibility.py`).
 - Channel creation remains owned by resource provisioning; clone, overwrites, and
   some category/lifecycle follow-ups remain outside the shipped lifecycle service.
 - Cleanup and setup exist today, but the tracker queues their server-management
@@ -76,11 +77,11 @@ cleanup policy, setup, and the future unified hub. Inspect first:
 
 The status tracker's remaining queue is the only current sequencing authority.
 Cleanup versioning + builder/dry-run/panel diagnostics shipped 2026-06-06 (PR8+PR9,
-presets-only). **PR10 (moderation configuration) is underway**: its first slice —
-config-backed behaviour (DM-on-action, ban message-purge, timeout ceiling) — is
-shipping in the current PR; the **remaining PR10 items** (moderator/trusted roles +
-capabilities, dedicated log destinations, escalation rules, required-reason,
-post-action cleanup hook, hierarchy diagnostics) come next, then setup
+presets-only). **PR10 (moderation configuration) is underway**: its first slice
+(config-backed behaviour — DM-on-action, ban message-purge, timeout ceiling) and
+second slice (require-reason enforcement + bot-readiness diagnostics) have shipped;
+the **remaining PR10 items** (moderator/trusted roles + capabilities, dedicated log
+destinations, escalation rules, post-action cleanup hook) come next, then setup
 role/moderation/governance and repair sections, role templates, and finally the
 unified Server Management Hub. Link to the tracker for exact order and dependencies
 rather than copying them here.
@@ -93,10 +94,10 @@ to bypass lifecycle/provisioning services.
 
 ## Next candidates
 
-1. Continue PR10: its first slice (config-backed moderation behaviour) is shipping
-   now; the next step is the **remaining PR10 slice** (mod-roles + capabilities, log
-   destinations, escalation rules, required-reason, post-action cleanup, hierarchy
-   diagnostics). Verify source before using either older planning document.
+1. Continue PR10: its first + second slices shipped; the next step is the **remaining
+   PR10 items** (mod-roles + capabilities, dedicated log destinations, escalation
+   rules, post-action cleanup hook). Verify source before using either older planning
+   document.
 2. Take one bounded known UX follow-up (member quicksearch or role selector/cleanup)
    without changing lifecycle ownership.
 3. When extending setup, reuse provisioning previews/confirmation and capability

--- a/tests/unit/cogs/test_moderation_panel_embed.py
+++ b/tests/unit/cogs/test_moderation_panel_embed.py
@@ -1,0 +1,51 @@
+"""Tests for the mod panel embed's Bot-readiness field (server-management PR10).
+
+``_build_mod_panel_embed(guild)`` appends a read-only readiness field; the
+no-guild call (persistent-view restore) must not.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from cogs.moderation._helpers import _build_mod_panel_embed
+
+_READINESS = "🤖 Bot readiness"
+
+
+def _guild(
+    *,
+    ban: bool = True,
+    kick: bool = True,
+    timeout: bool = True,
+    top_position: int = 5,
+    top_name: str = "Galaxy Bot",
+) -> MagicMock:
+    guild = MagicMock()
+    perms = MagicMock()
+    perms.ban_members = ban
+    perms.kick_members = kick
+    perms.moderate_members = timeout
+    perms.administrator = False
+    guild.me.guild_permissions = perms
+    guild.me.top_role.position = top_position
+    guild.me.top_role.name = top_name
+    return guild
+
+
+def test_embed_without_guild_has_no_readiness_field():
+    embed = _build_mod_panel_embed()
+    assert _READINESS not in [f.name for f in embed.fields]
+
+
+def test_embed_with_guild_adds_readiness_field():
+    embed = _build_mod_panel_embed(_guild())
+    field = next(f for f in embed.fields if f.name == _READINESS)
+    assert "🟢" in field.value
+    assert "**Galaxy Bot**" in field.value
+
+
+def test_embed_readiness_field_flags_missing_permission():
+    embed = _build_mod_panel_embed(_guild(ban=False))
+    field = next(f for f in embed.fields if f.name == _READINESS)
+    assert "Ban Members" in field.value

--- a/tests/unit/cogs/test_moderation_schemas.py
+++ b/tests/unit/cogs/test_moderation_schemas.py
@@ -49,6 +49,7 @@ def test_moderation_settings_cover_legacy_plus_pr10():
         "warn_timeout_minutes",
         "dm_on_action",
         "dm_template",
+        "require_reason",
         "ban_delete_message_days",
         "max_timeout_minutes",
     }
@@ -70,6 +71,18 @@ def test_dm_on_action_is_bool_toggle():
     assert spec.value_type is bool
     assert spec.default is False
     assert spec.settings_key == _mod_keys.MOD_DM_ON_ACTION
+    assert spec.capability_required == "moderation.settings.configure"
+    spec.validator(True)
+    spec.validator(False)
+    with pytest.raises(ValueError):
+        spec.validator(1)  # int is not bool
+
+
+def test_require_reason_is_bool_toggle():
+    spec = _spec("require_reason")
+    assert spec.value_type is bool
+    assert spec.default is False
+    assert spec.settings_key == _mod_keys.MOD_REQUIRE_REASON
     assert spec.capability_required == "moderation.settings.configure"
     spec.validator(True)
     spec.validator(False)
@@ -133,6 +146,7 @@ def test_spec_defaults_match_policy_defaults():
     behave differently than the settings panel claims."""
     assert _spec("dm_on_action").default == moderation_config.DEFAULT_DM_ON_ACTION
     assert _spec("dm_template").default == moderation_config.DEFAULT_DM_TEMPLATE
+    assert _spec("require_reason").default == moderation_config.DEFAULT_REQUIRE_REASON
     assert (
         _spec("ban_delete_message_days").default
         == moderation_config.DEFAULT_BAN_DELETE_MESSAGE_DAYS

--- a/tests/unit/services/test_moderation_config.py
+++ b/tests/unit/services/test_moderation_config.py
@@ -22,11 +22,28 @@ def test_default_policy_is_behaviour_preserving():
     policy = ModerationPolicy()
     assert policy.dm_on_action is False
     assert policy.dm_template == ""
+    assert policy.require_reason is False
     assert policy.ban_delete_message_days == 0
     assert policy.max_timeout_minutes == 40320  # 28 days, Discord's max
     # Default ban purge is a no-op; default ceiling is Discord's hard max.
     assert policy.ban_delete_message_seconds == 0
     assert policy.effective_max_timeout_minutes == 40320
+
+
+@pytest.mark.parametrize(
+    ("reason", "expected"),
+    [
+        ("spam", True),
+        ("  trailing  ", True),
+        ("", False),
+        ("   ", False),
+        (None, False),
+        ("No reason provided", False),  # placeholder counts as no reason
+        ("no reason provided", False),
+    ],
+)
+def test_has_reason_is_placeholder_aware(reason, expected):
+    assert moderation_config.has_reason(reason) is expected
 
 
 def test_ban_delete_seconds_clamps_into_discord_window():
@@ -67,6 +84,7 @@ async def test_load_policy_maps_resolved_values():
     resolved = {
         "dm_on_action": True,
         "dm_template": "bye {user}",
+        "require_reason": True,
         "ban_delete_message_days": 3,
         "max_timeout_minutes": 120,
     }
@@ -84,6 +102,7 @@ async def test_load_policy_maps_resolved_values():
     assert policy == ModerationPolicy(
         dm_on_action=True,
         dm_template="bye {user}",
+        require_reason=True,
         ban_delete_message_days=3,
         max_timeout_minutes=120,
     )

--- a/tests/unit/services/test_moderation_service.py
+++ b/tests/unit/services/test_moderation_service.py
@@ -11,7 +11,7 @@ import pytest
 from core.events_catalogue import KNOWN_EVENTS
 from services import moderation_service
 from services.moderation_config import ModerationPolicy
-from services.moderation_service import EVT_MOD_ACTION
+from services.moderation_service import EVT_MOD_ACTION, ReasonRequiredError
 
 
 @pytest.fixture(autouse=True)
@@ -471,6 +471,137 @@ async def test_timeout_within_ceiling_is_not_clamped(_default_policy):
         await moderation_service.timeout(member, until=requested, reason="x")
 
     member.timeout.assert_awaited_once_with(requested, reason="x")
+
+
+# ---------------------------------------------------------------------------
+# PR10 — require_reason enforcement (warn / kick / ban; timeout exempt)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_warn_requires_reason_raises_before_side_effects(_default_policy):
+    _default_policy.return_value = ModerationPolicy(require_reason=True)
+    member = _make_member()
+    with (
+        patch(
+            "services.moderation_service.db.add_warning",
+            new_callable=AsyncMock,
+        ) as add,
+        patch(
+            "services.moderation_service.db.log_mod_action",
+            new_callable=AsyncMock,
+        ) as log_mod,
+        patch("services.moderation_service.bus.emit", new_callable=AsyncMock),
+    ):
+        with pytest.raises(ReasonRequiredError):
+            await moderation_service.warn(member, reason="", actor_id=1)
+
+    # Raised at the seam before incrementing the count or writing the log.
+    add.assert_not_awaited()
+    log_mod.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_kick_requires_reason_raises_before_removal(_default_policy):
+    _default_policy.return_value = ModerationPolicy(require_reason=True)
+    member = _make_member()
+    with (
+        patch("services.moderation_service.db.log_mod_action", new_callable=AsyncMock),
+        patch("services.moderation_service.bus.emit", new_callable=AsyncMock),
+    ):
+        with pytest.raises(ReasonRequiredError):
+            await moderation_service.kick(member, reason="   ", actor_id=1)
+
+    member.kick.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ban_requires_reason_raises_before_ban(_default_policy):
+    _default_policy.return_value = ModerationPolicy(require_reason=True)
+    guild = _make_guild()
+    user = _make_user()
+    with (
+        patch("services.moderation_service.db.log_mod_action", new_callable=AsyncMock),
+        patch("services.moderation_service.bus.emit", new_callable=AsyncMock),
+    ):
+        with pytest.raises(ReasonRequiredError):
+            await moderation_service.ban(guild, user, reason="", actor_id=1)
+
+    guild.ban.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_placeholder_reason_treated_as_missing_when_required(_default_policy):
+    """The "No reason provided" placeholder counts as no reason."""
+    _default_policy.return_value = ModerationPolicy(require_reason=True)
+    member = _make_member()
+    with (
+        patch("services.moderation_service.db.add_warning", new_callable=AsyncMock),
+        patch("services.moderation_service.db.log_mod_action", new_callable=AsyncMock),
+        patch("services.moderation_service.bus.emit", new_callable=AsyncMock),
+    ):
+        with pytest.raises(ReasonRequiredError):
+            await moderation_service.warn(
+                member, reason="No reason provided", actor_id=1,
+            )
+
+
+@pytest.mark.asyncio
+async def test_action_with_reason_passes_when_required(_default_policy):
+    _default_policy.return_value = ModerationPolicy(require_reason=True)
+    member = _make_member()
+    with (
+        patch(
+            "services.moderation_service.db.add_warning",
+            new_callable=AsyncMock,
+            return_value=1,
+        ),
+        patch(
+            "services.moderation_service.db.log_mod_action",
+            new_callable=AsyncMock,
+        ) as log_mod,
+        patch("services.moderation_service.bus.emit", new_callable=AsyncMock),
+    ):
+        count = await moderation_service.warn(member, reason="spam", actor_id=1)
+
+    assert count == 1
+    assert log_mod.await_args.args[4] == "spam"  # reason logged verbatim
+
+
+@pytest.mark.asyncio
+async def test_empty_reason_defaults_to_placeholder_when_not_required():
+    """Default policy (require_reason off): an empty reason logs the placeholder."""
+    member = _make_member()
+    with (
+        patch(
+            "services.moderation_service.db.add_warning",
+            new_callable=AsyncMock,
+            return_value=1,
+        ),
+        patch(
+            "services.moderation_service.db.log_mod_action",
+            new_callable=AsyncMock,
+        ) as log_mod,
+        patch("services.moderation_service.bus.emit", new_callable=AsyncMock),
+    ):
+        await moderation_service.warn(member, reason="", actor_id=1)
+
+    assert log_mod.await_args.args[4] == "No reason provided"
+
+
+@pytest.mark.asyncio
+async def test_timeout_exempt_from_require_reason(_default_policy):
+    """Timeout's reason carries the duration, so require_reason never blocks it."""
+    _default_policy.return_value = ModerationPolicy(require_reason=True)
+    member = _make_member()
+    until = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    with (
+        patch("services.moderation_service.db.log_mod_action", new_callable=AsyncMock),
+        patch("services.moderation_service.bus.emit", new_callable=AsyncMock),
+    ):
+        await moderation_service.timeout(member, until=until, reason="", actor_id=1)
+
+    member.timeout.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/utils/test_moderation_feasibility.py
+++ b/tests/unit/utils/test_moderation_feasibility.py
@@ -1,0 +1,108 @@
+"""Tests for utils.moderation_feasibility (server-management PR10).
+
+The pure 'can the bot moderate here?' evaluator behind the mod panel's
+read-only Bot-readiness line.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from utils.moderation_feasibility import (
+    ModerationReadiness,
+    evaluate_moderation_readiness,
+    render_readiness_line,
+)
+
+
+def _guild(
+    *,
+    ban: bool = True,
+    kick: bool = True,
+    timeout: bool = True,
+    admin: bool = False,
+    top_position: int = 5,
+    top_name: str = "Galaxy Bot",
+) -> MagicMock:
+    guild = MagicMock()
+    perms = MagicMock()
+    perms.ban_members = ban
+    perms.kick_members = kick
+    perms.moderate_members = timeout
+    perms.administrator = admin
+    guild.me.guild_permissions = perms
+    guild.me.top_role.position = top_position
+    guild.me.top_role.name = top_name
+    return guild
+
+
+# ---------------------------------------------------------------------------
+# evaluate_moderation_readiness
+# ---------------------------------------------------------------------------
+
+
+def test_full_capability():
+    r = evaluate_moderation_readiness(_guild())
+    assert (r.can_ban, r.can_kick, r.can_timeout) == (True, True, True)
+    assert r.fully_capable
+    assert r.missing_permissions() == ()
+    assert r.top_role_name == "Galaxy Bot"
+    assert r.top_role_is_lowest is False
+
+
+def test_missing_single_permission():
+    r = evaluate_moderation_readiness(_guild(ban=False))
+    assert r.can_ban is False
+    assert r.fully_capable is False
+    assert r.missing_permissions() == ("Ban Members",)
+
+
+def test_missing_multiple_permissions_order():
+    r = evaluate_moderation_readiness(_guild(ban=False, timeout=False))
+    assert r.missing_permissions() == ("Ban Members", "Timeout Members")
+
+
+def test_administrator_implies_every_capability():
+    r = evaluate_moderation_readiness(
+        _guild(ban=False, kick=False, timeout=False, admin=True),
+    )
+    assert (r.can_ban, r.can_kick, r.can_timeout) == (True, True, True)
+    assert r.fully_capable
+    assert r.missing_permissions() == ()
+
+
+def test_top_role_at_bottom_is_not_fully_capable():
+    r = evaluate_moderation_readiness(_guild(top_position=0))
+    assert r.top_role_is_lowest is True
+    # Has every permission but can't out-rank anyone → not fully capable.
+    assert r.fully_capable is False
+
+
+# ---------------------------------------------------------------------------
+# render_readiness_line
+# ---------------------------------------------------------------------------
+
+
+def test_render_all_ok_mentions_top_role():
+    line = render_readiness_line(
+        ModerationReadiness(True, True, True, "Galaxy Bot", False),
+    )
+    assert "🟢" in line
+    assert "below my top role" in line
+    assert "**Galaxy Bot**" in line
+
+
+def test_render_missing_permissions_lists_them():
+    line = render_readiness_line(
+        ModerationReadiness(False, True, False, "Galaxy Bot", False),
+    )
+    assert "Missing permission(s)" in line
+    assert "Ban Members" in line
+    assert "Timeout Members" in line
+
+
+def test_render_top_role_lowest_warns():
+    line = render_readiness_line(
+        ModerationReadiness(True, True, True, "@everyone", True),
+    )
+    assert "bottom of the list" in line


### PR DESCRIPTION
## Motivation

Continues **server-management PR10** after the first slice (#555, config-backed moderation behaviour) merged. This ships the two **contained, low-risk** remaining PR10 items — chosen because the bigger items (mod-roles + capabilities, dedicated log destinations, escalation rules) touch the capability-authority seam / other subsystems and warrant their own design pass. Kept on the first slice's "guard at the mutation seam" discipline.

## What changed

### `require_reason` — enforced at the service seam
- New `moderation_service.ReasonRequiredError` + `_resolve_reason()` raise **before any side effect** (DB write, DM, Discord call) for **warn / kick / ban** when the guild requires a reason and none was given. **Timeout is exempt** — its reason carries the duration.
- `moderation_config.has_reason()` is **placeholder-aware** (`"No reason provided"` counts as no reason), so the cog + the seven modals needed only an `except ReasonRequiredError` catch — the surfaces keep passing their existing reason and the seam normalises/enforces. No reason-handling rewrite across 8 call sites.
- New `MOD_REQUIRE_REASON` key + a `require_reason` bool-toggle `SettingSpec`, operator-editable in `!settings → Moderation`. **No migration** (KV-backed).

### Bot-readiness diagnostics — a read-only "can the bot act?" panel line
- New **pure** `utils/moderation_feasibility.py` (`evaluate_moderation_readiness` / `render_readiness_line`), mirroring `utils/role_feasibility.py`.
- `_build_mod_panel_embed(guild)` gains a read-only **"🤖 Bot readiness"** field — which of Ban / Kick / Timeout the bot holds, and where its top role sits (it can only action members below it) — so an operator sees *before* clicking why an action might fail. The no-guild persistent-restore path is unchanged.

### Out of scope (remaining PR10, queued in the tracker)
Moderator/trusted **roles + capabilities**, dedicated **log destinations**, **escalation-rule** config, and a **post-action cleanup** hook. PR11–PR14 untouched.

## Testing
- `tests/unit/utils/test_moderation_feasibility.py` (new) — the pure evaluator + renderer (perm combos, admin-implies-all, top-role-at-bottom, line rendering).
- `tests/unit/cogs/test_moderation_panel_embed.py` (new) — the readiness field is added with a guild and absent without one.
- `tests/unit/services/test_moderation_service.py` — require-reason raises before side effects for warn/kick/ban, placeholder counts as missing, reason passes through, empty defaults to the placeholder when not required, timeout exempt.
- `tests/unit/services/test_moderation_config.py` — `has_reason` (placeholder-aware) + `require_reason` in the policy/loader.
- `tests/unit/cogs/test_moderation_schemas.py` — `require_reason` spec + the spec-default ↔ policy-default drift guard.
- `docs/settings-customization-command-map.md` updated for the two doc-pin tests (new key + SettingSpec name).
- Gates: `python3.10 scripts/check_quality.py --full` green (**7718 passed**, 16 skipped; black/isort/ruff/mypy); `python3.10 scripts/check_architecture.py --mode strict` **0 errors**; booted the test bot clean (ModerationCog + the 7-setting schema register, 2 servers, **0 ERROR/CRITICAL**). Live Discord render of the readiness field / a require-reason rejection still owed (no Discord clicks from the shell) — logic is unit-pinned.

https://claude.ai/code/session_015XQNST7ViELYPhedPzFQGu

---
_Generated by [Claude Code](https://claude.ai/code/session_015XQNST7ViELYPhedPzFQGu)_