### PR TITLE
docs: define workflow + doc-hygiene CI gate (check_docs) + per-session journal

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,10 +12,13 @@ The short version that governs how you work:
 - **Session prompts are guidance, not orders.** A prompt (usually drafted via
   ChatGPT) explains the focus and reminds you of things; weigh it against source,
   the roadmaps, and your own judgment. It is one input, never a command list.
-- **Approved plan = execute.** Once a plan is approved, finish it that session —
-  code, tests, commit, push, end-of-session PR — without re-confirming.
-  "Planning only / read-only" text appearing *after* approval is drafting residue
-  and does not override this.
+- **Approved plan = execute.** A planning session stays planning until you approve
+  the plan (**ExitPlanMode**). *Before* approval the agent may do read-only research
+  **and safe local prototyping to validate the plan** (run a tool, test feasibility) —
+  but does not commit. *After* approval it finishes the plan in the **same session**,
+  with the planning context still loaded — code, tests, commit, push, end-of-session PR
+  — without re-confirming. "Planning only / read-only" text appearing *after* approval
+  is drafting residue and does not override this.
 - **Constraints serve the goal.** Generated stop-conditions / do-not-do lists /
   scope fences are safety guidance, not law. When one blocks the approved goal and
   the path is contained, reversible, and test-covered, prefer the goal and note
@@ -87,7 +90,16 @@ status) > the journal.
   user explicitly asks." Treat it as advance consent — do not re-ask before
   opening the end-of-session PR.
 - Plans span **2–3 PRs max**: the first PR covers root causes / foundation; subsequent PRs implement on top.
-- **Plan approval = full execution** — once a plan is approved, complete it in one session without stopping for confirmation or waiting for merges between PRs.
+- **Plan approval = full execution** — once a plan is approved (via **ExitPlanMode**),
+  complete it in one session without stopping for confirmation or waiting for merges
+  between PRs. The planning context stays loaded — execute in the same session you
+  planned in.
+- **PR size is mixed by risk** — small, focused PRs for risky / runtime (`disbot/`)
+  code; larger end-to-end PRs are fine for docs, tooling, and low-risk refactors.
+- **Tooling: custom over new deps.** Prefer small custom tooling built on the repo's
+  own AST + `architecture_rules/` (e.g. `check_architecture.py`, `check_docs.py`,
+  `context_map.py`) over adding a third-party dependency; reach for a library only when
+  it clearly wins, and keep it dev-only (`requirements-dev.txt`) if it isn't bot runtime.
 
 ## Decisions
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -69,14 +69,14 @@ merged PRs win over it, and you must verify in-flight PRs against live GitHub.
 Read it before task-specific docs so you don't act on stale state.
 
 Also read **`.session-journal.md`** (repo root) at the **start** of every
-session — our cross-session working memory: start with its **⚡ Quick reference**
-(boot / run-CI / Postgres-down / kill-bot), then the environment/boot runbook,
-maintainer preferences, recurring problems + fixes, past mistakes to avoid, and
-candidate rules not yet promoted into this file. Older session history lives in
-**`.session-journal-archive.md`** — grep it on demand, don't read it top-to-bottom.
-**Keep the journal lean** — it's a fast-read working set: at the **end** of every
-session append a dated entry **and** roll entries older than the newest ~4 into the
-archive (tidying stale Rules / the Quick reference in place), then commit. Precedence:
+session — our cross-session working memory, now **guidebook-only**: start with its
+**⚡ Quick reference** (boot / run-CI / Postgres-down / kill-bot), then the
+environment/boot runbook, maintainer preferences, recurring problems + fixes, past
+mistakes to avoid, and candidate rules not yet promoted into this file. **Per-session
+logs live in `.sessions/`** (`YYYY-MM-DD-<slug>.md`, newest-first) and older history in
+**`.session-journal-archive.md`** — grep them on demand, don't read top-to-bottom.
+**Keep the guidebook lean** — at the **end** of every session write a new `.sessions/`
+log file and tidy any stale Rules / Quick reference in place, then commit. Precedence:
 source code & merged PRs > this file (CLAUDE.md) > `docs/current-state.md` (live
 status) > the journal.
 <!-- READ_FIRST_END -->

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -52,6 +52,12 @@ jobs:
             echo "code=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Doc-hygiene gate — runs on EVERY PR (incl. docs-only), pure stdlib so it
+      # needs no setup. Hard-fails on missing/invalid Status badges, dead doc
+      # links, and broken read-path references. See scripts/check_docs.py.
+      - name: Run doc hygiene (check_docs)
+        run: python3 scripts/check_docs.py --strict
+
       - name: Set up Python
         if: steps.changes.outputs.code == 'true'
         uses: actions/setup-python@v5

--- a/.session-journal.md
+++ b/.session-journal.md
@@ -53,7 +53,7 @@ project state accumulate here.)
 | **Postgres down** (fresh container / after resume) | Re-run the **Runbook** bring-up recipe — idempotent (`PG_VERSION` check skips re-initdb). |
 | **Run CI locally before push** | `python3.10 scripts/check_quality.py --full` (true CI mirror) **and** `python3.10 scripts/check_architecture.py --mode strict` (0 errors). |
 | **Kill a running bot** | `for pid in $(pgrep -f disbot/bot1); do [ "$(cat /proc/$pid/comm)" = python3.10 ] && kill "$pid"; done` (plain `pkill` self-kills the shell). |
-| **End of session** | Open a PR (every session); append a Session Log entry; roll old entries to the archive (Protocol → END). |
+| **End of session** | Open a PR (every session); write a `.sessions/<date>-<slug>.md` log file (Protocol → END). |
 
 **Three rules that bite hardest:** (1) booting is safe — don't treat it as blocked;
 (2) **verify cross-agent output against source** before acting on it; (3) **root-cause,
@@ -66,8 +66,8 @@ one source of truth** over per-panel patches. Full set under **Rules / Conventio
 - **START:** read `docs/current-state.md` first (project state), then this file
   right after `.claude/CLAUDE.md`. Hit the **⚡ Quick reference** first, then skim the
   **Environment Runbook**, **Operating Preferences**, **Rules/Conventions**, and the
-  **recent Session Log** entries here (older history is in
-  `.session-journal-archive.md` — grep it on demand, don't read it top-to-bottom).
+  **recent `.sessions/`** files (newest-first by filename; older history is in
+  `.session-journal-archive.md` — grep on demand, don't read top-to-bottom).
   Fold open items into your plan.
 - **DURING:** capture as they happen — a non-obvious problem+fix, a mistake worth
   not repeating, a stated/observed preference, an architecture ask. If you find a
@@ -75,28 +75,22 @@ one source of truth** over per-panel patches. Full set under **Rules / Conventio
 - **END (documentation checklist):**
   1. **`docs/current-state.md`** — update it if anything shipped, opened, blocked,
      unblocked, or deferred (and refresh its `Last updated:` stamp).
-  2. **This journal** — append a dated **Session Log** entry (link to the PR + the
-     authoritative doc; don't restate per-PR detail); update the guidebook sections
-     in place if a preference / rule / runbook fact changed.
+  2. **Session log** — write a new `.sessions/<date>-<slug>.md` file (link to the PR +
+     the authoritative doc; don't restate per-PR detail). Update this journal's guidebook
+     sections in place if a preference / rule / runbook fact changed.
   3. Banner or update any **plan** whose status changed; file any new **idea** under
      `docs/ideas/` (marked not-approved).
   4. Commit + push (docs land with the PR).
-  5. **Tidy as you go (keep it lean) — every session, not just at REVIEW.** This file
-     is a fast-read working set. The guidebook (Runbook + Rules) is fixed overhead; the
-     **Session Log is the part that grows**, so keep it to roughly the **newest ~4
-     entries** — move anything older into `.session-journal-archive.md` (newest-first
-     there too). If a Rule went stale or now duplicates the Runbook, fix/merge it **in
+  5. **Tidy as you go (keep it lean).** This journal is now **guidebook-only** (Quick
+     reference + Runbook + Preferences + Rules) — the growing session log moved to
+     `.sessions/`. If a Rule went stale or now duplicates the Runbook, fix/merge it **in
      place**; refresh the **⚡ Quick reference** if a boot/CI fact changed. Leave the
      journal a little tighter than you found it — never longer for its own sake.
-- **MERGE CONFLICTS here are expected — resolve by UNION.** The Session Log is a
-  structural hotspot: every branch inserts a new entry at the *same* anchor (top of
-  "Session Log (newest first)"), so any two concurrently-open PRs collide there
-  (this hit #529→#530 **and** #530→#531). Mitigate: **before** writing the end-of-session
-  entry, `git fetch origin main` and merge/rebase so you append after the latest entries.
-  When a conflict still happens, **keep BOTH sides** — every conflicting entry *and* any
-  curated-section edits — ordered **newest-first by date**; **never delete the other
-  agent's entry or section.** Curated-section edits (header, preferences) usually
-  auto-merge; if they conflict, keep both additions. Then it's docs-only — no CI risk.
+- **MERGE CONFLICTS:** per-session `.sessions/` files removed the old Session Log
+  hotspot (branches no longer insert at the same anchor). The journal **guidebook**
+  sections (header, preferences, rules) can still conflict if two PRs edit the same line —
+  resolve by **UNION** (keep both additions; never delete the other agent's edit). It's
+  docs-only — no CI risk.
 - **REVIEW (every ~3-5 sessions, or on request):** re-order, dedupe, and **propose**
   promotions of stable items into `.claude/CLAUDE.md` / hooks / `settings.json` for
   the maintainer's approval. Keep this file lean.
@@ -357,169 +351,15 @@ confidence; do not treat booting as gated.
   CLAUDE.md pointer for now — revisit if items get missed).
 - `interaction_router` safety-net registration (mirror the `ai` cog) to silence the
   benign "Unhandled prefix" noise *and* give expired/post-restart panels a graceful reply.
-- **Journal length is handled by the archive split** (2026-06-06): older Session Log
-  entries roll into `.session-journal-archive.md`; the live file keeps only the newest
-  ~4 and a Quick reference. **Still open — the merge-conflict class** (recurring:
-  #529→#530, #530→#531): new entries still insert at the same top anchor, so two
-  concurrently-open PRs can still collide there. The structural fix remains per-session
-  files (`.sessions/YYYY-MM-DD-<slug>.md` globbed newest-first). **DEFERRED** — serial
-  sessions make the conflict rare; revisit if concurrent PRs start colliding again.
+- **Journal length + the merge-conflict class are now handled by per-session files**
+  (DONE 2026-06-07): the Session Log moved to `.sessions/<date>-<slug>.md` (globbed
+  newest-first), so this journal is guidebook-only and branches no longer collide at a
+  shared Session-Log anchor. Pre-migration history stays in `.session-journal-archive.md`.
 
 ---
 
-## Session Log (newest first — append-only)
+## Session history → `.sessions/`
 
-### 2026-06-07 — Docs structure: maintainer-question router + context-map tool + badges
+Per-session logs now live as individual files under **`.sessions/`** (`YYYY-MM-DD-<slug>.md`, one per session, newest-first by filename). This removes the merge-conflict class that came from every session inserting at the same anchor here. **Grep `.sessions/`** for past work; see `.sessions/README.md` for the convention. Pre-`.sessions/` history is in **`.session-journal-archive.md`**.
 
-- **Arc:** broad docs-architecture review + question-prep session. Verified repo state
-  + the two overlapping Codex docs PRs (#557 ideas-only, #559 = superset: router +
-  ideas + read-path), then asked the maintainer 4 gating multiple-choice questions via
-  `AskUserQuestion`. He chose: **consolidate** #557/#559 onto this branch, **build** the
-  context-map tool **with Grimp**, **execute now**, **and** do the badge cleanup → did all
-  three (3 commits) on `claude/laughing-davinci-lP6zv`.
-- **Shipped:**
-  - **Docs consolidation** — `docs/owner/maintainer-question-router.md` (+ `owner/README`),
-    `docs/ideas/future-product-direction-2026-06-07.md` (pulled byte-exact off #559 to avoid
-    transcription drift), lightweight read-path wiring (CLAUDE.md/AGENT_ORIENTATION/current-state),
-    and a new **"load context in layers — don't read the whole docs/ tree"** rule. Supersedes
-    #557/#559 (maintainer to close them).
-  - **`scripts/context_map.py`** — given a file → role, imports (module-level + lazy, labelled),
-    importers, blast radius, ownership, docs/tests, risk, read/verify set. Reuses
-    `check_architecture._ImportVisitor` + `architecture_rules/*.yaml` (one source of truth).
-    Importers/blast-radius via **Grimp** with an **AST fallback**. `docs/context-map-overrides.yml`
-    + `tests/unit/scripts/test_context_map.py` + `docs/context-map-tooling.md`.
-  - **Badge cleanup** — badged the 15 truly-bare docs + normalized the 8 building-roadmap
-    `Status:` lines; extended the badge taxonomy (audit/owner-guidance/archive) in AGENT_ORIENTATION.
-- **Findings worth keeping:**
-  - **CodeGraph file edges are dead here** (verified: `file_deps`/`impact_analysis` → 0). **Grimp**
-    builds the 572-module graph in **0.3s** over the flat `disbot/`-rooted layout and resolves the
-    **7 importers + 60-module blast radius** CodeGraph misses — incl. lazy-importer edges.
-  - **CI does NOT install `requirements-dev.txt`** (see new CI rule) — drove the Grimp-optional design.
-  - **Badge audit refined to 15, not "49 unbadged":** my first scan used `**Status**:` but docs use
-    `**Status:**`; 50 already standard-badged, 34 self-declare non-standard, only **15 truly bare**.
-- **Gates:** `check_quality --full` green (**7749 passed**, 16 skipped); `check_architecture --mode
-  strict` **0 errors**. Docs/tooling only — no `disbot/` runtime change, so no boot needed. **For
-  project state see `docs/current-state.md`.** (PR pending.)
-
-### 2026-06-07 — Server-management PR10 (third slice): configurable warn escalation at the seam
-
-- **Arc:** Opus planning session recommended the **escalation** slice as the safest next
-  PR10 step; maintainer said "continue" → implemented it same session. Branch
-  `claude/practical-mayer-G0zg1` off merged `main` (`b76b320`, #556). The decisive evidence
-  was an **in-source breadcrumb**: `_WarnModal` said escalation "stays orchestrated at the
-  surface … until moderation config owns it", and the warn→auto-timeout→clear block was
-  copy-pasted in **both** `moderation_cog.warn` and `_WarnModal`.
-- **Shipped (PR10 third slice):**
-  - **`warn_escalation_action`** — enum `timeout` (default = today) / `kick` / `ban` / `none`
-    at `warn_threshold`; schema → **v3**; key `MOD_WARN_ESCALATION_ACTION`; `allowed_values`
-    Select. Folded the `warn_threshold` / `warn_timeout_minutes` defaults into
-    `moderation_config` canonical constants (one source of truth, drift-pinned). **No
-    migration** (scalar/KV).
-  - **`moderation_config`** — 3 escalation fields on `ModerationPolicy` + a **pure**
-    `evaluate_escalation(count, policy)` (fail-safe → no-op on an unknown action).
-  - **`moderation_service.warn`** now returns a frozen **`WarnOutcome`** and **owns the
-    ladder** at the seam: at threshold it runs the configured action via the sibling
-    `timeout`/`kick`/`ban` (so it stays audited + DM'd), resets the count on success; a
-    Discord `Forbidden` is reported on the outcome (soft warning), **not raised**. Deleted the
-    duplicated escalation block from the cog **and** the modal; both render via the shared
-    pure `cogs/moderation/_helpers.render_warn_outcome_lines` (the `views→cogs._helpers` edge
-    is the pre-existing `[known]` arch warning — no new violation).
-- **Why escalation first (vs the 3 other remaining PR10 items):** strongest seam fit, no
-  migration, no capability-authority / log-routing / cleanup coupling, and a root-cause dedup
-  the source flagged. **Deferred, each its own future slice:** dedicated/optional **log
-  destinations** (extend `server_logging`'s route table — don't duplicate routing);
-  **post-action cleanup hook** (consume the cleanup contract — don't duplicate policy);
-  **mod/trusted roles + capabilities** (mirror the existing `trusted_role` binding/resolver in
-  `governance/resolver.py` + re-route the cog's raw `has_permissions` authority — largest,
-  verges on PR11).
-- **Tests:** `evaluate_escalation` + policy cases in `test_moderation_config.py`; escalation
-  (timeout/kick/ban/none/below-threshold/Forbidden-blocked) + `WarnOutcome` return-type updates
-  in `test_moderation_service.py`; `warn_escalation_action` shape + drift guard + v3 in
-  `test_moderation_schemas.py`; rewritten warn-modal cases in `test_moderation_modals_defer.py`;
-  command-map doc updated for the doc-pin tests.
-- **Gates:** `check_quality --full` green (**7734 passed**, 16 skipped; black/isort/ruff/mypy);
-  `check_architecture --mode strict` **0 errors**; booted clean (boot_id `166d4f62`,
-  ModerationCog loads the **v3** 8-setting schema, 0 ERROR/CRITICAL). **For project state see
-  `docs/current-state.md`.** (PR pending.)
-
-### 2026-06-07 — Server-management PR10 (second slice): require-reason + bot-readiness diagnostics
-
-- **Arc:** the PR10 first slice (#555) merged mid-session; maintainer picked "continue —
-  contained items" (via `AskUserQuestion`) → ship the two low-risk remaining PR10 items in
-  one PR. Branch `claude/zen-volta-F5xKv` fast-forwarded onto merged `main` (`bfb9ba3`).
-- **Shipped:**
-  - **`require_reason`** (bool setting) enforced **at the seam**: new
-    `moderation_service.ReasonRequiredError` + `_resolve_reason()` raise **before** any side
-    effect (warn/kick/ban); **timeout exempt** (its reason carries the duration). Key
-    insight that avoided a call-site-spread rewrite: `moderation_config.has_reason()` is
-    **placeholder-aware** (treats `"No reason provided"` as no reason), so the cog + the seven
-    modals needed only an `except ReasonRequiredError` catch — surfaces keep passing their
-    existing (defaulted) reason and the seam normalises/enforces.
-  - **Bot-readiness diagnostics:** new pure `utils/moderation_feasibility.py`
-    (`evaluate_moderation_readiness` / `render_readiness_line`, mirrors `role_feasibility`);
-    `_build_mod_panel_embed(guild)` gains a read-only **"🤖 Bot readiness"** field
-    (Ban/Kick/Timeout perms + top-role ceiling) so an operator sees *before* clicking why an
-    action might fail. The no-guild persistent-restore path is unchanged.
-  - Settings: `MOD_REQUIRE_REASON` key + a `require_reason` bool-toggle spec; auto-rendered in
-    `!settings → Moderation`. No migration (KV-backed).
-- **Why these two:** lowest-risk of the remaining PR10 list and need no design decision; the
-  bigger items (mod-roles + capabilities, dedicated log destinations, escalation rules,
-  post-action cleanup) touch capability-authority / other subsystems and were deferred to the
-  maintainer.
-- **Tests:** `test_moderation_feasibility.py` (new), `test_moderation_panel_embed.py` (new),
-  require-reason + `has_reason` cases in `test_moderation_service.py` / `test_moderation_config.py`,
-  `require_reason` spec in `test_moderation_schemas.py`. Doc-pin: command-map updated (new key +
-  spec name).
-- **Gates:** `check_quality --full` green (**7718 passed**, 16 skipped); `check_architecture
-  --mode strict` **0 errors**; booted clean (boot_id `84af5634`, ModerationCog + 7-setting schema,
-  2 servers, 0 ERROR/CRITICAL). Live Discord render of the readiness field / require-reason
-  rejection still owed (no Discord clicks from the shell) — logic is unit-pinned. **For project
-  state see `docs/current-state.md`.** (PR pending.)
-
-### 2026-06-06 — Server-management PR10 (first slice): config-backed moderation behaviour
-
-- **Arc:** maintainer asked to continue the roadmap plans — "finish the remaining
-  plans, or continue as much as possible." The server-management tracker **and** the
-  open docs PR **#554** (Codex readiness review) both point unambiguously at **PR10
-  (moderation first-class configuration)** as the next approved lane ("service-owned,
-  callback-authorized, audited, test-covered; do not start PR11–PR14"). Branch
-  `claude/zen-volta-F5xKv` off `dbe0154` (#553); only #554 open live.
-- **Scope decision (judgment call, per the working agreement → act, don't re-confirm):**
-  PR10's full list is broad (~9 items); shipped the coherent, low-risk **behaviour
-  slice** that maps to real Discord effects and is consumed at the mutation seam — DMs,
-  ban message-purge, timeout ceiling — and queued the rest (mod-roles+capabilities, log
-  destinations, escalation, required-reason, cleanup hook, hierarchy diagnostics) in the
-  tracker.
-- **Shipped:**
-  - `services/moderation_config.py` (new) — `ModerationPolicy` + `load_policy` + a **pure**
-    `render_dm_message`; owns the canonical default constants (shared with the schema).
-  - 4 settings in `cogs/moderation/schemas.py` (schema → v2): `dm_on_action` (bool),
-    `dm_template` (free-text `{guild}`/`{action}`/`{reason}`/`{user}`, plain-replace not
-    `str.format`), `ban_delete_message_days` (presets 0/1/7), `max_timeout_minutes` (presets;
-    default 40320 = Discord's 28-day max). Keys in `utils/settings_keys/moderation.py`. **No
-    migration** (KV-backed; auto-rendered in `!settings → Moderation`).
-  - `services/moderation_service.py` — warn/timeout/kick/ban load policy + apply at the seam
-    (DM **before** removal for kick/ban so the user is still reachable, **after** for
-    warn/timeout; ban `delete_message_seconds` only when configured; timeout clamped down).
-    **Behaviour-preserving by default** — an unconfigured guild gets the exact pre-PR10 calls.
-- **Why the seam, not the call sites:** the journal's **"guard at the mutation seam"** rule —
-  one policy read inside the service protects all surfaces (cog + 7 modals + future hub),
-  exactly as PR1 did for the audit fan-out. Avoided spreading `resolve_value` across 8 sites.
-- **Tests:** `test_moderation_config.py` (new), config cases in `test_moderation_service.py`
-  (autouse default-policy patch keeps the convergence-era exact-call assertions valid),
-  `test_moderation_schemas.py` (new — shapes + a spec-default↔policy-default drift guard).
-  Updated `docs/settings-customization-command-map.md` for the two doc-pin tests (new keys +
-  SettingSpec names).
-- **Gates:** `check_quality --full` green (**7690 passed**, 16 skipped; black/isort/ruff/mypy);
-  `check_architecture --mode strict` **0 errors**; booted clean (boot_id `a6a24aea` —
-  ModerationCog loads the v2 schema, 2 servers, **0 ERROR/CRITICAL**). Live Discord *render* of
-  the new settings widgets / actual DM delivery still owed (can't drive Discord clicks from the
-  shell) — logic is unit-pinned.
-- **Next session:** docs PR **#554** merged ahead of this one; resolved the expected
-  additive **union-merge** in `current-state.md` + the journal (kept both entries). **For
-  project state see `docs/current-state.md`.** (PR pending.)
-
-> **Older sessions → [`.session-journal-archive.md`](.session-journal-archive.md).**
-> Only the most recent sessions stay here so this file is a fast read. Need older
-> history? **grep the archive** — don't read it top-to-bottom. When this live log
-> grows past ~4 entries, roll the oldest into the archive (see Protocol → END).
+At session end, write a new `.sessions/<date>-<slug>.md` (Protocol → END) instead of appending a Session Log entry here.

--- a/.sessions/2026-06-06-server-management-pr10.md
+++ b/.sessions/2026-06-06-server-management-pr10.md
@@ -1,0 +1,42 @@
+# 2026-06-06 — Server-management PR10 (first slice): config-backed moderation behaviour
+
+- **Arc:** maintainer asked to continue the roadmap plans — "finish the remaining
+  plans, or continue as much as possible." The server-management tracker **and** the
+  open docs PR **#554** (Codex readiness review) both point unambiguously at **PR10
+  (moderation first-class configuration)** as the next approved lane ("service-owned,
+  callback-authorized, audited, test-covered; do not start PR11–PR14"). Branch
+  `claude/zen-volta-F5xKv` off `dbe0154` (#553); only #554 open live.
+- **Scope decision (judgment call, per the working agreement → act, don't re-confirm):**
+  PR10's full list is broad (~9 items); shipped the coherent, low-risk **behaviour
+  slice** that maps to real Discord effects and is consumed at the mutation seam — DMs,
+  ban message-purge, timeout ceiling — and queued the rest (mod-roles+capabilities, log
+  destinations, escalation, required-reason, cleanup hook, hierarchy diagnostics) in the
+  tracker.
+- **Shipped:**
+  - `services/moderation_config.py` (new) — `ModerationPolicy` + `load_policy` + a **pure**
+    `render_dm_message`; owns the canonical default constants (shared with the schema).
+  - 4 settings in `cogs/moderation/schemas.py` (schema → v2): `dm_on_action` (bool),
+    `dm_template` (free-text `{guild}`/`{action}`/`{reason}`/`{user}`, plain-replace not
+    `str.format`), `ban_delete_message_days` (presets 0/1/7), `max_timeout_minutes` (presets;
+    default 40320 = Discord's 28-day max). Keys in `utils/settings_keys/moderation.py`. **No
+    migration** (KV-backed; auto-rendered in `!settings → Moderation`).
+  - `services/moderation_service.py` — warn/timeout/kick/ban load policy + apply at the seam
+    (DM **before** removal for kick/ban so the user is still reachable, **after** for
+    warn/timeout; ban `delete_message_seconds` only when configured; timeout clamped down).
+    **Behaviour-preserving by default** — an unconfigured guild gets the exact pre-PR10 calls.
+- **Why the seam, not the call sites:** the journal's **"guard at the mutation seam"** rule —
+  one policy read inside the service protects all surfaces (cog + 7 modals + future hub),
+  exactly as PR1 did for the audit fan-out. Avoided spreading `resolve_value` across 8 sites.
+- **Tests:** `test_moderation_config.py` (new), config cases in `test_moderation_service.py`
+  (autouse default-policy patch keeps the convergence-era exact-call assertions valid),
+  `test_moderation_schemas.py` (new — shapes + a spec-default↔policy-default drift guard).
+  Updated `docs/settings-customization-command-map.md` for the two doc-pin tests (new keys +
+  SettingSpec names).
+- **Gates:** `check_quality --full` green (**7690 passed**, 16 skipped; black/isort/ruff/mypy);
+  `check_architecture --mode strict` **0 errors**; booted clean (boot_id `a6a24aea` —
+  ModerationCog loads the v2 schema, 2 servers, **0 ERROR/CRITICAL**). Live Discord *render* of
+  the new settings widgets / actual DM delivery still owed (can't drive Discord clicks from the
+  shell) — logic is unit-pinned.
+- **Next session:** docs PR **#554** merged ahead of this one; resolved the expected
+  additive **union-merge** in `current-state.md` + the journal (kept both entries). **For
+  project state see `docs/current-state.md`.** (PR pending.)

--- a/.sessions/2026-06-07-doc-hygiene-and-workflow.md
+++ b/.sessions/2026-06-07-doc-hygiene-and-workflow.md
@@ -1,0 +1,28 @@
+# 2026-06-07 — Doc-hygiene gate + workflow definition + per-session journal
+
+- **Arc:** follow-up to #560 (merged). Maintainer ran a 16-question multiple-choice
+  batch (4 waves via `AskUserQuestion`) to define the workflow + scope doc hygiene, then
+  said "execute now." Branch `claude/laughing-davinci-lP6zv`.
+- **Workflow answers → routed** (`.claude/CLAUDE.md` + `docs/collaboration-model.md`):
+  planning stays planning until **ExitPlanMode** approval; before approval, read-only
+  research + safe prototyping (no commits); after approval, execute the whole plan
+  in-session; **PR size mixed by risk**; **custom tooling over new third-party deps**.
+- **Router inbox answers preserved verbatim** (`docs/owner/maintainer-question-router.md`
+  §12–13). Notable: **AI may eventually gain broader actions** — owner intent, but still
+  behind *all* AI gates + a dedicated decision (routed to `docs/subsystems/ai.md` as a
+  not-approval note); Discord-first + later web (→ server-management folio); the rest
+  confirm existing act-vs-ask / routing / reproposal rules.
+- **Shipped — doc hygiene:**
+  - **`scripts/check_docs.py`** (custom, stdlib-only) — hard CI gate, runs on every PR
+    incl. docs-only: valid `> **Status:**` badge per doc (taxonomy pinned to
+    `AGENT_ORIENTATION`; ADRs exempt), relative doc links resolve, read-path path refs
+    exist. Wired into `code-quality.yml` + `check_quality.py`. Tests + a taxonomy pin-test.
+  - **Normalized 60 docs** to the strict badge token (preserving each doc's description);
+    de-linked a dead ADR-003 reference (`.claude/plans/` was never committed).
+  - **Read-path collapsed** → `AGENT_ORIENTATION.md` is the one canonical read path;
+    `current-state.md` now points to it instead of duplicating the table.
+  - **Journal → per-session files** (this convention): migrated the live Session Log into
+    `.sessions/`, slimmed `.session-journal.md` to the guidebook + a pointer.
+- **Gates:** `check_quality --full` green; `check_architecture --mode strict` 0 errors;
+  `check_docs --strict` clean. Docs/tooling only — no `disbot/` runtime change.
+  **Project state: `docs/current-state.md`.**

--- a/.sessions/2026-06-07-docs-structure.md
+++ b/.sessions/2026-06-07-docs-structure.md
@@ -1,0 +1,31 @@
+# 2026-06-07 — Docs structure: maintainer-question router + context-map tool + badges
+
+- **Arc:** broad docs-architecture review + question-prep session. Verified repo state
+  + the two overlapping Codex docs PRs (#557 ideas-only, #559 = superset: router +
+  ideas + read-path), then asked the maintainer 4 gating multiple-choice questions via
+  `AskUserQuestion`. He chose: **consolidate** #557/#559 onto this branch, **build** the
+  context-map tool **with Grimp**, **execute now**, **and** do the badge cleanup → did all
+  three (3 commits) on `claude/laughing-davinci-lP6zv`.
+- **Shipped:**
+  - **Docs consolidation** — `docs/owner/maintainer-question-router.md` (+ `owner/README`),
+    `docs/ideas/future-product-direction-2026-06-07.md` (pulled byte-exact off #559 to avoid
+    transcription drift), lightweight read-path wiring (CLAUDE.md/AGENT_ORIENTATION/current-state),
+    and a new **"load context in layers — don't read the whole docs/ tree"** rule. Supersedes
+    #557/#559 (maintainer to close them).
+  - **`scripts/context_map.py`** — given a file → role, imports (module-level + lazy, labelled),
+    importers, blast radius, ownership, docs/tests, risk, read/verify set. Reuses
+    `check_architecture._ImportVisitor` + `architecture_rules/*.yaml` (one source of truth).
+    Importers/blast-radius via **Grimp** with an **AST fallback**. `docs/context-map-overrides.yml`
+    + `tests/unit/scripts/test_context_map.py` + `docs/context-map-tooling.md`.
+  - **Badge cleanup** — badged the 15 truly-bare docs + normalized the 8 building-roadmap
+    `Status:` lines; extended the badge taxonomy (audit/owner-guidance/archive) in AGENT_ORIENTATION.
+- **Findings worth keeping:**
+  - **CodeGraph file edges are dead here** (verified: `file_deps`/`impact_analysis` → 0). **Grimp**
+    builds the 572-module graph in **0.3s** over the flat `disbot/`-rooted layout and resolves the
+    **7 importers + 60-module blast radius** CodeGraph misses — incl. lazy-importer edges.
+  - **CI does NOT install `requirements-dev.txt`** (see new CI rule) — drove the Grimp-optional design.
+  - **Badge audit refined to 15, not "49 unbadged":** my first scan used `**Status**:` but docs use
+    `**Status:**`; 50 already standard-badged, 34 self-declare non-standard, only **15 truly bare**.
+- **Gates:** `check_quality --full` green (**7749 passed**, 16 skipped); `check_architecture --mode
+  strict` **0 errors**. Docs/tooling only — no `disbot/` runtime change, so no boot needed. **For
+  project state see `docs/current-state.md`.** (PR pending.)

--- a/.sessions/2026-06-07-server-management-pr10-2.md
+++ b/.sessions/2026-06-07-server-management-pr10-2.md
@@ -1,0 +1,33 @@
+# 2026-06-07 — Server-management PR10 (second slice): require-reason + bot-readiness diagnostics
+
+- **Arc:** the PR10 first slice (#555) merged mid-session; maintainer picked "continue —
+  contained items" (via `AskUserQuestion`) → ship the two low-risk remaining PR10 items in
+  one PR. Branch `claude/zen-volta-F5xKv` fast-forwarded onto merged `main` (`bfb9ba3`).
+- **Shipped:**
+  - **`require_reason`** (bool setting) enforced **at the seam**: new
+    `moderation_service.ReasonRequiredError` + `_resolve_reason()` raise **before** any side
+    effect (warn/kick/ban); **timeout exempt** (its reason carries the duration). Key
+    insight that avoided a call-site-spread rewrite: `moderation_config.has_reason()` is
+    **placeholder-aware** (treats `"No reason provided"` as no reason), so the cog + the seven
+    modals needed only an `except ReasonRequiredError` catch — surfaces keep passing their
+    existing (defaulted) reason and the seam normalises/enforces.
+  - **Bot-readiness diagnostics:** new pure `utils/moderation_feasibility.py`
+    (`evaluate_moderation_readiness` / `render_readiness_line`, mirrors `role_feasibility`);
+    `_build_mod_panel_embed(guild)` gains a read-only **"🤖 Bot readiness"** field
+    (Ban/Kick/Timeout perms + top-role ceiling) so an operator sees *before* clicking why an
+    action might fail. The no-guild persistent-restore path is unchanged.
+  - Settings: `MOD_REQUIRE_REASON` key + a `require_reason` bool-toggle spec; auto-rendered in
+    `!settings → Moderation`. No migration (KV-backed).
+- **Why these two:** lowest-risk of the remaining PR10 list and need no design decision; the
+  bigger items (mod-roles + capabilities, dedicated log destinations, escalation rules,
+  post-action cleanup) touch capability-authority / other subsystems and were deferred to the
+  maintainer.
+- **Tests:** `test_moderation_feasibility.py` (new), `test_moderation_panel_embed.py` (new),
+  require-reason + `has_reason` cases in `test_moderation_service.py` / `test_moderation_config.py`,
+  `require_reason` spec in `test_moderation_schemas.py`. Doc-pin: command-map updated (new key +
+  spec name).
+- **Gates:** `check_quality --full` green (**7718 passed**, 16 skipped); `check_architecture
+  --mode strict` **0 errors**; booted clean (boot_id `84af5634`, ModerationCog + 7-setting schema,
+  2 servers, 0 ERROR/CRITICAL). Live Discord render of the readiness field / require-reason
+  rejection still owed (no Discord clicks from the shell) — logic is unit-pinned. **For project
+  state see `docs/current-state.md`.** (PR pending.)

--- a/.sessions/2026-06-07-server-management-pr10.md
+++ b/.sessions/2026-06-07-server-management-pr10.md
@@ -1,0 +1,40 @@
+# 2026-06-07 — Server-management PR10 (third slice): configurable warn escalation at the seam
+
+- **Arc:** Opus planning session recommended the **escalation** slice as the safest next
+  PR10 step; maintainer said "continue" → implemented it same session. Branch
+  `claude/practical-mayer-G0zg1` off merged `main` (`b76b320`, #556). The decisive evidence
+  was an **in-source breadcrumb**: `_WarnModal` said escalation "stays orchestrated at the
+  surface … until moderation config owns it", and the warn→auto-timeout→clear block was
+  copy-pasted in **both** `moderation_cog.warn` and `_WarnModal`.
+- **Shipped (PR10 third slice):**
+  - **`warn_escalation_action`** — enum `timeout` (default = today) / `kick` / `ban` / `none`
+    at `warn_threshold`; schema → **v3**; key `MOD_WARN_ESCALATION_ACTION`; `allowed_values`
+    Select. Folded the `warn_threshold` / `warn_timeout_minutes` defaults into
+    `moderation_config` canonical constants (one source of truth, drift-pinned). **No
+    migration** (scalar/KV).
+  - **`moderation_config`** — 3 escalation fields on `ModerationPolicy` + a **pure**
+    `evaluate_escalation(count, policy)` (fail-safe → no-op on an unknown action).
+  - **`moderation_service.warn`** now returns a frozen **`WarnOutcome`** and **owns the
+    ladder** at the seam: at threshold it runs the configured action via the sibling
+    `timeout`/`kick`/`ban` (so it stays audited + DM'd), resets the count on success; a
+    Discord `Forbidden` is reported on the outcome (soft warning), **not raised**. Deleted the
+    duplicated escalation block from the cog **and** the modal; both render via the shared
+    pure `cogs/moderation/_helpers.render_warn_outcome_lines` (the `views→cogs._helpers` edge
+    is the pre-existing `[known]` arch warning — no new violation).
+- **Why escalation first (vs the 3 other remaining PR10 items):** strongest seam fit, no
+  migration, no capability-authority / log-routing / cleanup coupling, and a root-cause dedup
+  the source flagged. **Deferred, each its own future slice:** dedicated/optional **log
+  destinations** (extend `server_logging`'s route table — don't duplicate routing);
+  **post-action cleanup hook** (consume the cleanup contract — don't duplicate policy);
+  **mod/trusted roles + capabilities** (mirror the existing `trusted_role` binding/resolver in
+  `governance/resolver.py` + re-route the cog's raw `has_permissions` authority — largest,
+  verges on PR11).
+- **Tests:** `evaluate_escalation` + policy cases in `test_moderation_config.py`; escalation
+  (timeout/kick/ban/none/below-threshold/Forbidden-blocked) + `WarnOutcome` return-type updates
+  in `test_moderation_service.py`; `warn_escalation_action` shape + drift guard + v3 in
+  `test_moderation_schemas.py`; rewritten warn-modal cases in `test_moderation_modals_defer.py`;
+  command-map doc updated for the doc-pin tests.
+- **Gates:** `check_quality --full` green (**7734 passed**, 16 skipped; black/isort/ruff/mypy);
+  `check_architecture --mode strict` **0 errors**; booted clean (boot_id `166d4f62`,
+  ModerationCog loads the **v3** 8-setting schema, 0 ERROR/CRITICAL). **For project state see
+  `docs/current-state.md`.** (PR pending.)

--- a/.sessions/README.md
+++ b/.sessions/README.md
@@ -1,0 +1,22 @@
+# Session logs — `.sessions/`
+
+> One file per working session, named `YYYY-MM-DD-<slug>.md`, **newest-first by
+> filename** (reverse-sort the glob). Process memory / history only — **not** project
+> state (that's `docs/current-state.md`) and **not** the working model (that's
+> `docs/collaboration-model.md`).
+
+## Why per-session files
+
+A single shared Session Log meant every session inserted a new entry at the *same* top
+anchor, so any two concurrently-open PRs collided there (it bit #529→#530 and
+#530→#531). Per-session files have no shared anchor → no structural merge conflict.
+
+## Convention
+
+- **Write** a new file at session end: `.sessions/<date>-<short-slug>.md`.
+- Start it with an H1 `# <date> — <title>`, then the usual arc / shipped / findings /
+  gates shape.
+- **Don't** edit older session files — they're history. Durable rules / runbook facts
+  graduate into `.session-journal.md` (the guidebook) or `.claude/CLAUDE.md`.
+- **Find** past work by grepping this directory — don't read it top-to-bottom.
+- Pre-migration history lives in `.session-journal-archive.md`.

--- a/docs/AGENT_ORIENTATION.md
+++ b/docs/AGENT_ORIENTATION.md
@@ -1,6 +1,6 @@
 # SuperBot — Agent Orientation (Read This First)
 
-> **Status:** binding (reference material, not implementation approval).
+> **Status:** `binding` — (reference material, not implementation approval).
 > Future Claude / Codex / human contributors should read this page
 > before proposing or implementing changes. It is the only file in
 > `docs/` that exists to orient a brand-new session; everything else

--- a/docs/ai-complex-request-tool-orchestration-plan.md
+++ b/docs/ai-complex-request-tool-orchestration-plan.md
@@ -1,6 +1,7 @@
 # Configurable AI Tool Orchestration for Complex BTD6 Requests
 
-**Status:** research-backed planning document; assumes the bot-awareness and
+> **Status:** `plan` — research-backed planning document; assumes the bot-awareness and
+
 health-diagnostics roadmap is already delivered  
 **Verified against:** current repository worktree on 2026-06-06  
 **Primary focus:** complex BTD6 lookups and calculations  

--- a/docs/ai-config-ownership.md
+++ b/docs/ai-config-ownership.md
@@ -1,6 +1,6 @@
 # AI configuration ownership (binding)
 
-> **Status:** binding. Records the contract every AI-cog change must
+> **Status:** `binding` — Records the contract every AI-cog change must
 > respect: the operator-facing snapshot is the source of truth, every
 > UI surface reads from it, and every write flows through the existing
 > mutation chokepoint. Doc-pin tests in

--- a/docs/ai-provider-and-grounding-fix-plan.md
+++ b/docs/ai-provider-and-grounding-fix-plan.md
@@ -1,6 +1,6 @@
 # Handoff — AI provider-switch + BTD6 grounding fix plan
 
-> **Status:** working handoff for the *next* session (not a binding contract).
+> **Status:** `plan` — working handoff for the *next* session (not a binding contract).
 > Written 2026‑05‑29 after a long live‑testing session. **The code is always the
 > source of truth — verify before trusting any BTD6 fact stated here.** The prior
 > session made mistakes precisely by trusting memory over the data; don't repeat that.

--- a/docs/ai-readiness-plan.md
+++ b/docs/ai-readiness-plan.md
@@ -1,6 +1,6 @@
 # SuperBot AI Readiness Plan
 
-Status: planning + shipped scaffold. **M1 of the BTD6-top-level + AI-central-policy initiative shipped the AI subsystem's settings foundation** (`disbot/cogs/ai/schemas.py`, `utils/settings_keys/ai.py`, the `audit_log_channel` BindingSpec, and the `!ai settings` / `/ai settings` entry points). The typed AI policy tables and the central natural-language stage land in M2.
+> **Status:** `plan` — planning + shipped scaffold. **M1 of the BTD6-top-level + AI-central-policy initiative shipped the AI subsystem's settings foundation** (`disbot/cogs/ai/schemas.py`, `utils/settings_keys/ai.py`, the `audit_log_channel` BindingSpec, and the `!ai settings` / `/ai settings` entry points). The typed AI policy tables and the central natural-language stage land in M2.
 
 ## Purpose
 

--- a/docs/ai-service-integration-map.md
+++ b/docs/ai-service-integration-map.md
@@ -1,6 +1,6 @@
 # AI Service Integration Map
 
-Status: planning artifact. No runtime behavior is changed by this file.
+> **Status:** `plan` — planning artifact. No runtime behavior is changed by this file.
 
 > **Read first:** `docs/ai-config-ownership.md` (binding) — the
 > operator-facing read model (`AIConfigSnapshot`), projection rules,

--- a/docs/ai-tool-capability-roadmap.md
+++ b/docs/ai-tool-capability-roadmap.md
@@ -1,6 +1,6 @@
 # AI Tool Capability Roadmap
 
-> **Status:** `plan` — **Status (2026-06-06): roadmap proposal; not implementation approval.**
+> **Status:** `plan` — roadmap proposal (2026-06-06); not implementation approval.
 > **Purpose:** refine the open AI extra-tool ideas backlog into a source-verified,
 > implementation-ready sequence without replacing the approved bot-awareness plan or the
 > research-backed BTD6 orchestration planning document.

--- a/docs/ai-tool-capability-roadmap.md
+++ b/docs/ai-tool-capability-roadmap.md
@@ -1,6 +1,6 @@
 # AI Tool Capability Roadmap
 
-> **Status (2026-06-06): roadmap proposal; not implementation approval.**
+> **Status:** `plan` — **Status (2026-06-06): roadmap proposal; not implementation approval.**
 > **Purpose:** refine the open AI extra-tool ideas backlog into a source-verified,
 > implementation-ready sequence without replacing the approved bot-awareness plan or the
 > research-backed BTD6 orchestration planning document.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # SuperBot — Architecture
 
-> **Status:** binding. This document defines the platform's layering
+> **Status:** `binding` — This document defines the platform's layering
 > and dependency rules.  CI invariants (`tests/unit/invariants/`) +
 > ruff config enforce a subset; everything else is enforced by review.
 >

--- a/docs/architecture/service_ownership.md
+++ b/docs/architecture/service_ownership.md
@@ -1,6 +1,6 @@
 # SuperBot — Service Ownership Quick Reference
 
-> **Status:** reference (not binding). This is a quick-lookup companion to
+> **Status:** `reference` — (not binding). This is a quick-lookup companion to
 > `docs/ownership.md`. When this table and `docs/ownership.md` disagree,
 > **`docs/ownership.md` is authoritative.** Update this table when
 > `docs/ownership.md` changes, not the other way around.

--- a/docs/audits/agent-b-governance-control-audit-2026-06-05.md
+++ b/docs/audits/agent-b-governance-control-audit-2026-06-05.md
@@ -1,5 +1,7 @@
 # Agent B governance/control audit — 2026-06-05
 
+> **Status:** `audit`
+
 > **Superseded (2026-06-05):** reconciled into
 > [`../planning/superbot-audit-consolidation-2026-06-05.md`](../planning/superbot-audit-consolidation-2026-06-05.md)
 > (verified, RC-n IDs). Read that first; this raw audit is historical context.

--- a/docs/audits/agent-d-btd6-ai-subsystem-audit-2026-06-05.md
+++ b/docs/audits/agent-d-btd6-ai-subsystem-audit-2026-06-05.md
@@ -1,5 +1,7 @@
 # Agent D — BTD6, AI, Paragon, and Video subsystem audit
 
+> **Status:** `audit`
+
 > **Superseded (2026-06-05):** reconciled into
 > [`../planning/superbot-audit-consolidation-2026-06-05.md`](../planning/superbot-audit-consolidation-2026-06-05.md)
 > (verified, RC-n IDs; drives RC-10/11/12). Read that first; this is historical context.

--- a/docs/audits/general-feature-layer-analysis-2026-06-05.md
+++ b/docs/audits/general-feature-layer-analysis-2026-06-05.md
@@ -1,5 +1,7 @@
 # General Discord Feature Layer Analysis — 2026-06-05
 
+> **Status:** `audit`
+
 > **Superseded (2026-06-05):** reconciled into
 > [`../planning/superbot-audit-consolidation-2026-06-05.md`](../planning/superbot-audit-consolidation-2026-06-05.md)
 > (verified, RC-n IDs). Read that first; this raw audit is historical context.

--- a/docs/audits/implementation-readiness-review-2026-06-06.md
+++ b/docs/audits/implementation-readiness-review-2026-06-06.md
@@ -1,6 +1,6 @@
 # Implementation Readiness Review — 2026-06-06
 
-> **Status:** verified audit snapshot. This review classifies the current plans and
+> **Status:** `audit` — verified audit snapshot. This review classifies the current plans and
 > status documents; it does not replace binding contracts, subsystem folios, or the
 > server-management status tracker. Source code and merged commits win.
 >

--- a/docs/audits/mutation_boundary_audit.md
+++ b/docs/audits/mutation_boundary_audit.md
@@ -1,6 +1,6 @@
 # SuperBot — Mutation Boundary Audit
 
-> **Status:** living inventory. Run against the codebase after the
+> **Status:** `audit` — living inventory. Run against the codebase after the
 > Service Ownership Hardening session (2026-05-24). Update this document
 > when new mutation paths are introduced or existing paths change.
 >

--- a/docs/audits/platform-runtime-data-layer-audit-2026-06-05.md
+++ b/docs/audits/platform-runtime-data-layer-audit-2026-06-05.md
@@ -1,5 +1,7 @@
 # Platform / Runtime / Data-Layer Audit — 2026-06-05
 
+> **Status:** `audit`
+
 > **Superseded (2026-06-05):** reconciled into
 > [`../planning/superbot-audit-consolidation-2026-06-05.md`](../planning/superbot-audit-consolidation-2026-06-05.md)
 > (verified, RC-n IDs). Read that first; this raw audit is historical context.

--- a/docs/audits/repo-wide-audit-2026-05-29.md
+++ b/docs/audits/repo-wide-audit-2026-05-29.md
@@ -1,6 +1,6 @@
 # SuperBot — Repo-Wide Architecture & Consistency Audit
 
-> **Status:** audit snapshot (recommendations only — not implementation approval).
+> **Status:** `audit` — snapshot (recommendations only — not implementation approval).
 > **Date:** 2026-05-29 · **Branch:** `claude/loving-knuth-AQCfs` · **Base commit:** `5609fe8` (post-#392).
 > **Method:** every source file under `disbot/` (510 files), every migration (51), every doc
 > (43), and the test tree (512 files / 6,306 tests) was read in full by a fan-out of 22

--- a/docs/bot-awareness-diagnostics-plan.md
+++ b/docs/bot-awareness-diagnostics-plan.md
@@ -1,6 +1,7 @@
 # AI-Assisted Bot Awareness and Diagnostics: Repository Map and Delivery Plan
 
-**Status:** planning and brainstorming document; no implementation is authorized by
+> **Status:** `reference` — planning and brainstorming document; no implementation is authorized by
+
 this document alone  
 **Verified against:** the current repository worktree on 2026-06-06  
 **Audience:** maintainers and follow-up implementation agents

--- a/docs/bot-awareness-implementation-plan.md
+++ b/docs/bot-awareness-implementation-plan.md
@@ -1,6 +1,6 @@
 # Bot-Awareness / AI-Assisted Diagnostics — Revised Implementation Plan
 
-> **Status (2026-06-06): PROGRAMME COMPLETE — all 6 PRs shipped.** PR1–PR3 merged in
+> **Status:** `living-ledger` — **Status (2026-06-06): PROGRAMME COMPLETE — all 6 PRs shipped.** PR1–PR3 merged in
 > **#537** (typed health read model + deterministic `!platform health` + panel-only
 > startup health); **PR4–PR6 merged in #541** (opt-in grouped recent-error findings,
 > the owner-gated `diagnostics_health_snapshot` AI tool, and persistent findings with

--- a/docs/bot-awareness-implementation-plan.md
+++ b/docs/bot-awareness-implementation-plan.md
@@ -1,6 +1,6 @@
 # Bot-Awareness / AI-Assisted Diagnostics — Revised Implementation Plan
 
-> **Status:** `living-ledger` — **Status (2026-06-06): PROGRAMME COMPLETE — all 6 PRs shipped.** PR1–PR3 merged in
+> **Status:** `living-ledger` — **PROGRAMME COMPLETE (2026-06-06) — all 6 PRs shipped.** PR1–PR3 merged in
 > **#537** (typed health read model + deterministic `!platform health` + panel-only
 > startup health); **PR4–PR6 merged in #541** (opt-in grouped recent-error findings,
 > the owner-gated `diagnostics_health_snapshot` AI tool, and persistent findings with

--- a/docs/btd6-absence-claim-guard-design.md
+++ b/docs/btd6-absence-claim-guard-design.md
@@ -1,6 +1,6 @@
 # BTD6 absence-claim guard — design proposal
 
-> **Status:** DESIGN PROPOSAL — *not* binding, *not* implemented. Written for
+> **Status:** `reference` — DESIGN PROPOSAL — *not* binding, *not* implemented. Written for
 > independent review (ChatGPT / Analysis side) before any guard code is merged,
 > per the v55 hand-off ("Task 1: DESIGN FIRST, do NOT implement blind").
 > The companion status ledger is `btd6-gamedata-decode-status.md`.

--- a/docs/btd6-ai-tool-calling-plan.md
+++ b/docs/btd6-ai-tool-calling-plan.md
@@ -1,6 +1,6 @@
 # Plan: AI tool-calling (BTD6 lookup as the first tool)
 
-> **Status: IMPLEMENTED.** The BTD6 lookup tools described here now ship in
+> **Status:** `reference` — **Status: IMPLEMENTED.** The BTD6 lookup tools described here now ship in
 > `services/ai_tools.py` — `btd6_lookup`, `btd6_list_roster` (the complete
 > heroes/towers/paragons roster, #468), `btd6_capability_lookup`,
 > `btd6_superlative_lookup`, `btd6_difficulty_cost`, and the two paragon tools

--- a/docs/btd6-ai-tool-calling-plan.md
+++ b/docs/btd6-ai-tool-calling-plan.md
@@ -1,6 +1,6 @@
 # Plan: AI tool-calling (BTD6 lookup as the first tool)
 
-> **Status:** `reference` — **Status: IMPLEMENTED.** The BTD6 lookup tools described here now ship in
+> **Status:** `reference` — **IMPLEMENTED.** The BTD6 lookup tools described here now ship in
 > `services/ai_tools.py` — `btd6_lookup`, `btd6_list_roster` (the complete
 > heroes/towers/paragons roster, #468), `btd6_capability_lookup`,
 > `btd6_superlative_lookup`, `btd6_difficulty_cost`, and the two paragon tools

--- a/docs/btd6-cloud-data.md
+++ b/docs/btd6-cloud-data.md
@@ -1,6 +1,6 @@
 # BTD6 cloud data (object-store fixtures)
 
-> **Status:** shipped mechanism (opt-in). The bot reads BTD6 deterministic
+> **Status:** `reference` — shipped mechanism (opt-in). The bot reads BTD6 deterministic
 > fixtures from the local repo by default; setting `BTD6_DATA_BASE_URL` switches
 > it to a cloud object store. The repo-data removal (the audit-cleanliness
 > payoff) is the gated cutover step below.

--- a/docs/btd6-data-pipeline.md
+++ b/docs/btd6-data-pipeline.md
@@ -5,7 +5,7 @@
 > cutover** from the BTD Mod Helper dump — bloonswiki is now a cross-check
 > reference. For current status start at **`btd6-gamedata-decode-status.md`**.
 >
-> **Status (of *this* wiki pipeline):** towers done (data → service → UI → AI);
+> **Status:** `reference` — towers done (data → service → UI → AI);
 > heroes/economy income were its remaining pieces. This is a *working/roadmap*
 > doc, not a binding contract — when it disagrees with the source, the source
 > wins.

--- a/docs/btd6-derived-value-groundedness-finding.md
+++ b/docs/btd6-derived-value-groundedness-finding.md
@@ -1,6 +1,6 @@
 # BTD6 derived-value groundedness — finding + fix
 
-> **Status:** FINDING with a shipped first fix. Distinct from — **do not conflate
+> **Status:** `reference` — FINDING with a shipped first fix. Distinct from — **do not conflate
 > with** — `btd6-absence-claim-guard-design.md`. That doc is about the model
 > asserting a false *"X has no Y"*; **this** is about the faithfulness guard
 > *rejecting a valid answer the model derived by arithmetic over grounded

--- a/docs/btd6-game-file-extraction-plan.md
+++ b/docs/btd6-game-file-extraction-plan.md
@@ -3,8 +3,8 @@
 > **Picking up the work?** Start at **`btd6-gamedata-decode-status.md`** (status,
 > lessons & open items), then this roadmap and `btd6-gamedata-dictionary.md`.
 
-> **Status:** `plan` — **Status (historical roadmap — authoritative status is now
-> `btd6-gamedata-decode-status.md`).** The mapper (`parse_gamedata.py`) maps the
+> **Status:** `plan` — historical roadmap; authoritative status is now
+> `btd6-gamedata-decode-status.md`. The mapper (`parse_gamedata.py`) maps the
 > dump and self-audits (`--audit`). The plan was later **re-directed by the
 > maintainer to a game-native cutover** (game data leads; store the game's own
 > structure — see `btd6-gamedata-native-schema.md`), with the conservative

--- a/docs/btd6-game-file-extraction-plan.md
+++ b/docs/btd6-game-file-extraction-plan.md
@@ -3,7 +3,7 @@
 > **Picking up the work?** Start at **`btd6-gamedata-decode-status.md`** (status,
 > lessons & open items), then this roadmap and `btd6-gamedata-dictionary.md`.
 
-> **Status (historical roadmap — authoritative status is now
+> **Status:** `plan` — **Status (historical roadmap — authoritative status is now
 > `btd6-gamedata-decode-status.md`).** The mapper (`parse_gamedata.py`) maps the
 > dump and self-audits (`--audit`). The plan was later **re-directed by the
 > maintainer to a game-native cutover** (game data leads; store the game's own

--- a/docs/btd6-gamedata-decode-explainer.md
+++ b/docs/btd6-gamedata-decode-explainer.md
@@ -1,5 +1,7 @@
 # BTD6 game-data decode & cutover — the deep explainer
 
+> **Status:** `reference`
+
 > **Who this is for:** anyone (the maintainer, or a future session) who wants to
 > *understand* — not just continue — the effort to source BTD6 data from the
 > game's own files. It explains the **what**, **why**, and **how** from first

--- a/docs/btd6-gamedata-decode-status.md
+++ b/docs/btd6-gamedata-decode-status.md
@@ -1,5 +1,7 @@
 # BTD6 game-data decode — status, lessons & open items
 
+> **Status:** `living-ledger`
+
 The living status of the effort to source BTD6 data from the **BTD Mod Helper
 game-data dump** (`github.com/Btd6ModHelper/btd6-game-data`, v55.0). Start here
 to pick up the work: it records what's done, **how the dump's data actually

--- a/docs/btd6-gamedata-dictionary.md
+++ b/docs/btd6-gamedata-dictionary.md
@@ -1,5 +1,7 @@
 # BTD6 game-data dictionary — what the dump holds & where
 
+> **Status:** `reference`
+
 A map of the **BTD Mod Helper game-data dump**
 (`github.com/Btd6ModHelper/btd6-game-data`, v55.0 verified) so we stop
 rediscovering where each fact lives. The premise behind the BTD6 data work is

--- a/docs/capability-authority.md
+++ b/docs/capability-authority.md
@@ -1,6 +1,7 @@
 # Capability-native authority + mutation kill-switches
 
-**Status:** binding (reference for the implemented system). Decision of record:
+> **Status:** `binding` — (reference for the implemented system). Decision of record:
+
 [`docs/decisions/005-capability-native-authority-and-flag-semantics.md`](decisions/005-capability-native-authority-and-flag-semantics.md)
 (Accepted, implemented in PR #518). When this doc and source disagree, source wins
 (`disbot/governance/capability.py`).

--- a/docs/cog-hub-coverage-audit.md
+++ b/docs/cog-hub-coverage-audit.md
@@ -1,6 +1,6 @@
 # SuperBot — Cog Hub Command-Coverage Audit
 
-> **Status:** inventory snapshot, dated 2026-05-24.
+> **Status:** `audit` — inventory snapshot, dated 2026-05-24.
 > Companion to `docs/ui-view-adoption-audit.md` (per-view adoption)
 > and `docs/help-command-surface-map.md` (Help route structure).
 >

--- a/docs/collaboration-model.md
+++ b/docs/collaboration-model.md
@@ -1,6 +1,6 @@
 # How we work — the collaboration model (read first)
 
-> **Doc type:** `binding`. **Audience:** *every* agent that touches this repo —
+> **Status:** `binding` — **Audience:** *every* agent that touches this repo —
 > the Claude session that **builds**, and the ChatGPT/other agents that help
 > **plan** and **draft session prompts**. This file explains the working
 > relationship so we collaborate well. If a session prompt, a stop-condition, or

--- a/docs/collaboration-model.md
+++ b/docs/collaboration-model.md
@@ -59,11 +59,19 @@ you can accomplish in one session.
 
 ## For executor agents (Claude)
 
-- **Approved plan = execute.** Once a plan is approved you have full authority to
-  finish it in that session without re-confirming. "Planning only" / "read-only
-  session" language that appears *after* a plan is approved is drafting residue —
-  it does **not** override this. (Planning sessions are real, but *plan approved*
-  means *build it*.)
+- **Approved plan = execute — the planning→execute lifecycle.** A planning session
+  **stays planning until the plan is approved via ExitPlanMode.** *Before* approval the
+  executor may do read-only research **and safe local prototyping to validate the plan**
+  (run a tool, test a library's feasibility — as the Grimp check did) but does **not**
+  commit. *Once approved*, the executor has full authority to finish the plan **in the
+  same session** — the planning context is still loaded — without re-confirming.
+  "Planning only" / "read-only session" language that appears *after* approval is
+  drafting residue and does **not** override this. (Planning sessions are real, but
+  *plan approved* means *build it*, in that same session.)
+- **PR size is mixed by risk.** Small, focused PRs for risky / runtime (`disbot/`)
+  changes; larger end-to-end PRs are acceptable for docs, tooling, and low-risk
+  refactors. Prefer custom tooling on the repo's own AST + `architecture_rules/` over
+  new third-party dependencies (reach for a library only when it clearly wins).
 - **Act vs. ask (your autonomy envelope):**
   - **Act** when a change is contained, reversible, and verifiable — including a
     root-cause fix you discover mid-task. Make it, test it, report it.

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -103,23 +103,15 @@ Source code and merged PRs win over anything written here.
 - Do not restate "bot fully tested & working" as *newly* verified without an actual
   boot + live walk — cite the #535 baseline instead.
 
-## Where to read next (the read path + what lives where)
+## Where to read next
 
-| Need | Read |
-|---|---|
-| **How we collaborate** (all agents — the working model, read first) | `docs/collaboration-model.md` |
-| Rules of engagement (CI parity, CodeGraph, arch invariants, workflow) | `.claude/CLAUDE.md` |
-| **What's true right now** | this file |
-| How to boot/operate the sandbox · maintainer preferences · hard-won rules · gotchas | `.session-journal.md` (guidebook head) |
-| Unresolved maintainer-facing questions · preserved owner intent · answer routing | `docs/owner/maintainer-question-router.md` (unanswered questions are not approval) |
-| What happened in past sessions | `.session-journal.md` (session log) |
-| Which docs to read for a specific task | `docs/AGENT_ORIENTATION.md` |
-| Deep-dive on one part of the bot (AI, BTD6, server-mgmt…) | `docs/subsystems/<area>.md` (start here for an area) |
-| Architecture / ownership / runtime contracts (binding) | `docs/architecture.md` · `docs/ownership.md` · `docs/runtime_contracts.md` |
-| Brainstorms (not approved) | `docs/ideas/` |
-| Plans / target architecture (historical once shipped) | `docs/planning/` |
+The **canonical read path + "what lives where"** lives in
+**`docs/AGENT_ORIENTATION.md`** ("Reading order by task" + the document-classification
+lists). This file is *step 3* of that path: read it for **what is true right now**, then
+follow the orientation route for your task. The read-path table is **not** duplicated
+here — one canonical home (`AGENT_ORIENTATION.md`).
 
-**One-fact-one-home rule:** if a fact belongs in one of the homes above, **link** to
-it — do not restate it here. Restatement across files is where drift breeds. In
-particular, **don't summarize plans'/trackers' PR numbers or status here** — link to the
-folio or tracker, which is authoritative for its own area.
+**One-fact-one-home rule:** if a fact belongs in one of those homes, **link** to it —
+do not restate it here. Restatement across files is where drift breeds. In particular,
+**don't summarize plans'/trackers' PR numbers or status here** — link to the folio or
+tracker, which is authoritative for its own area.

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -1,6 +1,6 @@
 # SuperBot — Current State
 
-> **Doc type:** living status ledger (project state). **Not binding.**
+> **Status:** `living-ledger` — living status ledger (project state). **Not binding.**
 > **Source code and merged PRs always win over this file.**
 > The In-flight section below is a dated snapshot — **verify open PRs against
 > live GitHub** before trusting it (two same-session reports already

--- a/docs/decisions/003-deferred-followups-after-refactor-program.md
+++ b/docs/decisions/003-deferred-followups-after-refactor-program.md
@@ -2,8 +2,8 @@
 
 > Status: ADR (PR-07).
 > Supersedes: nothing.
-> Related: [`/home/user/superbot/.claude/plans/1-recommended-target-agent-zazzy-eclipse.md`](../../.claude/plans/1-recommended-target-agent-zazzy-eclipse.md)
-> (the program plan that PR-01a..PR-06c implement).
+> Related: `.claude/plans/1-recommended-target-agent-zazzy-eclipse.md` — the program
+> plan that PR-01a..PR-06c implement (a local planning artifact, not committed to the repo).
 
 The refactor program landed as 13 stacked PRs (#244..#256) plus this
 ADR.  This document records, in this order:

--- a/docs/games-actionability-roadmap.md
+++ b/docs/games-actionability-roadmap.md
@@ -1,10 +1,10 @@
 # Games Actionability Sweep — Operator Handoff
 
-Status: **complete** as of PR 9. This doc captures what shipped
+> **Status:** `historical` — **complete** as of PR 9. This doc captures what shipped
+
 across PRs 1–8 in the Help/Games actionability sweep, the manual
 smoke matrix operators should run after a fresh deploy, and the
 explicitly-deferred work the next session should consider.
-
 
 ## What shipped
 
@@ -118,7 +118,6 @@ collect` walks `all_schemas()` so the new schemas surface in
 Operator-facing roadmap + deferred-inventory note. No code
 changes.
 
-
 ## Manual smoke matrix
 
 Run after a fresh deploy. Each item is either ✅ (verified live)
@@ -191,7 +190,6 @@ live test).
 * [ ] Same for `deathmatch_turn_timeout` + the `_DuelView` timeout.
 * [ ] Defaults (0 fee, 60s timeout) are used when the setting is
   unset.
-
 
 ## Deferred — next session candidates
 
@@ -310,7 +308,6 @@ the original plan §5):
 
 Each requires the runtime read to be wired before the setting lands
 (plan §2.12 hard rule).
-
 
 ## Cross-references
 

--- a/docs/helper-debt-inventory.md
+++ b/docs/helper-debt-inventory.md
@@ -1,6 +1,6 @@
 # SuperBot — Helper Debt Inventory
 
-> **Status:** inventory snapshot, dated 2026-05-24, `main` at `934870e6`.
+> **Status:** `living-ledger` — inventory snapshot, dated 2026-05-24, `main` at `934870e6`.
 > Companion to `docs/helper-policy.md` (the binding rules).
 >
 > **What this is:** a one-shot audit of helpers in the candidate sprawl

--- a/docs/helper-policy.md
+++ b/docs/helper-policy.md
@@ -1,6 +1,6 @@
 # SuperBot — Helper Discipline & Placement Policy
 
-> **Status:** binding. The rules below govern when a helper may exist,
+> **Status:** `binding` — The rules below govern when a helper may exist,
 > where it must live, when it may be promoted, and what review must
 > precede every new helper. Companion to `docs/architecture.md`
 > (layering), `docs/ownership.md` (which service owns which write),

--- a/docs/ideas/ai-extra-tool-capability-ideas.md
+++ b/docs/ideas/ai-extra-tool-capability-ideas.md
@@ -4,7 +4,8 @@
 > [`docs/ideas/README.md`](./README.md). For what is true now, see
 > `docs/current-state.md`.
 
-**Status:** ideas backlog — not approved for implementation yet.  
+> **Status:** `ideas` — backlog — not approved for implementation yet.
+
 **Created:** 2026-06-06  
 **Purpose:** capture AI tool/capability ideas that are not already covered by the current bot-awareness diagnostics plan or the BTD6 complex tool-orchestration plan.  
 **Review required before implementation:** architecture, privacy, Discord permissions/intents, cost controls, model-provider support, data retention, moderation risk, and per-guild configuration.

--- a/docs/loose-ends-audit-roadmap.md
+++ b/docs/loose-ends-audit-roadmap.md
@@ -1,6 +1,7 @@
 # SuperBot Loose Ends Audit Roadmap
 
-Status: doc-only planning PR  
+> **Status:** `plan` — doc-only planning PR
+
 Runtime impact: none  
 Baseline inspected: `main` at Phase 9b merge (`baacf461`)  
 Purpose: define the safest completion pass before feature expansion, with a button-first command surface, complete Help discovery, consistent panel navigation, and a clear slash-front-door strategy.

--- a/docs/mining_exploration_brainstorm.md
+++ b/docs/mining_exploration_brainstorm.md
@@ -1,5 +1,7 @@
 # Mining & Exploration — Brainstorm & Roadmap
 
+> **Status:** `ideas`
+
 > Status: **brainstorm / design notes**, not a binding contract. The
 > binding docs (`architecture.md`, `ownership.md`, `runtime_contracts.md`)
 > win on any conflict. This document captures ideas for growing the

--- a/docs/operator-settings-presets.md
+++ b/docs/operator-settings-presets.md
@@ -1,6 +1,7 @@
 # Operator Settings & Provisioning Presets
 
-Status: Reference only  
+> **Status:** `living-ledger` — Reference only
+
 Scope: Future Settings Manager, Resource Provisioning, Cleanup, Logging, Access, Setup Wizard, and Help/Menu UX  
 Runtime impact: None  
 Owner intent: Capture preferred operator defaults and safe presets before UI/setup implementation begins.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -245,15 +245,16 @@ D. Decide case by case.
 
 ## 11. Question inbox
 
-The starter questions below are deliberately **unanswered**. Recommended directions
-help the maintainer understand the trade-off; they are not approval.
+The starter questions below were **answered by the maintainer on 2026-06-07 — see §12**
+(answers preserved verbatim; durable conclusions routed in §12–§13). The §11 recommended
+directions were *not* approval; the maintainer's answers are the leading owner intent.
 
 ### Q-0001 — Should AI stay explanation-only, or eventually help prepare actions?
 
 **Area:** AI / Server management
 **Type:** Vision / Safety
 **Priority:** High
-**Status:** Awaiting maintainer answer
+**Status:** Answered (2026-06-07) — Routed → `docs/subsystems/ai.md` (see §12)
 **Suggested destination after answer:** decisions / AI folio / ideas
 
 **Question:** Should AI permanently stay read-only and explanation-only, or could it
@@ -275,7 +276,7 @@ after the documented gates and a dedicated decision.
 **Area:** Server management / Product
 **Type:** Vision / UX
 **Priority:** Medium
-**Status:** Awaiting maintainer answer
+**Status:** Answered (2026-06-07) — Routed → `docs/subsystems/server-management.md` (see §12)
 **Suggested destination after answer:** server-management folio / ideas / decisions
 
 **Question:** Should Discord panels remain the primary owner experience even if a web
@@ -295,7 +296,7 @@ reusable, and no web dashboard is started yet.
 **Area:** Workflow / General
 **Type:** Workflow / Safety
 **Priority:** High
-**Status:** Awaiting maintainer answer
+**Status:** Answered (2026-06-07) — Kept as guidance (confirms CLAUDE.md act-vs-ask; see §12)
 **Suggested destination after answer:** CLAUDE.md / keep here
 
 **Question:** When the desired product outcome is unclear, which work should agents
@@ -316,7 +317,7 @@ question and block only the material unresolved decision.
 **Area:** Docs / Workflow
 **Type:** Workflow
 **Priority:** Medium
-**Status:** Awaiting maintainer answer
+**Status:** Answered (2026-06-07) — Kept here (confirms §7/§14; see §12)
 **Suggested destination after answer:** keep here / CLAUDE.md
 
 **Question:** After an answer belongs in another doc, should the original answer stay
@@ -335,7 +336,7 @@ the original entirely. C. Leave everything here only. D. Defer.
 **Area:** Workflow / General
 **Type:** Safety / Workflow
 **Priority:** High
-**Status:** Awaiting maintainer answer
+**Status:** Answered (2026-06-07) — Kept as guidance (confirms §8 reproposal rule; see §12)
 **Suggested destination after answer:** CLAUDE.md / keep here
 
 **Question:** What should an agent do when the maintainer's requested direction cannot
@@ -350,15 +351,61 @@ D. Defer without explanation.
 
 **Safe default / recommended direction:** C.
 
-## 12. Answered but not yet routed
+## 12. Answered — 2026-06-07
 
-No entries yet. Preserve answers here before adding an agent interpretation or routing
-summary.
+The maintainer answered the starter batch on 2026-06-07. Answers are preserved verbatim
+as **leading owner intent**; the §11 recommended directions were *not* approval — these
+answers are. Durable conclusions are routed in §13.
+
+### Q-0001 — AI scope → **C: eventually broader actions**
+
+> *Maintainer answer (2026-06-07):* AI may **eventually** gain broader / action
+> capabilities (beyond explanation-only).
+
+**Interpretation — not an approval.** This is long-term owner intent. Any AI action
+capability stays behind *all* AI-readiness, orchestration, authority, confirmation,
+audit, and rollback gates **and** a dedicated decision before it ships. Today AI stays
+read-only / explanation-only. Routed → `docs/subsystems/ai.md`.
+
+### Q-0002 — Owner control surface → **B: Discord-first, web companion possible later**
+
+> *Maintainer answer (2026-06-07):* Discord panels remain the primary owner surface;
+> keep services / read-models reusable so a web companion is possible later; no web work
+> starts now.
+
+Routed → `docs/subsystems/server-management.md`.
+
+### Q-0003 — Unclear maintainer vision → **B: continue safe, pause material**
+
+> *Maintainer answer (2026-06-07):* Continue safe, reversible, source-verified work;
+> pause and ask on material product, safety, privacy, and architecture decisions.
+
+Kept as guidance — confirms the act-vs-ask envelope in `.claude/CLAUDE.md` and
+`docs/collaboration-model.md`.
+
+### Q-0004 — Answer routing → **A: preserve original + route a conclusion**
+
+> *Maintainer answer (2026-06-07):* Keep the original answer in this router; copy/link a
+> concise durable conclusion to its home.
+
+Kept as guidance — confirms §7 and §14 (this is now how this file operates).
+
+### Q-0005 — Challenging impossible/unsafe answers → **C: explain, cite, propose, confirm**
+
+> *Maintainer answer (2026-06-07):* Explain the conflict plainly, name the source/risk,
+> propose safer alternatives, and ask for confirmation before proceeding.
+
+Kept as guidance — confirms the reproposal rule (§8) and CLAUDE.md act-vs-ask.
 
 ## 13. Routed answers
 
-No entries yet. A routed entry should retain the original answer block and link the
-concise conclusion's destination.
+| Answer | Routed to | Concise conclusion copied |
+|---|---|---|
+| **Q-0001** — AI may eventually gain broader actions (owner intent, still fully gated) | `docs/subsystems/ai.md` | owner-intent note + "stays behind all AI gates + a dedicated decision; not approved now" |
+| **Q-0002** — Discord-first, web companion possible later | `docs/subsystems/server-management.md` | one-line product-direction note |
+
+Original answers stay preserved in §12; these destinations carry only the concise
+durable conclusion (one fact, one home).
 
 ## 14. General owner intent that should stay here
 

--- a/docs/ownership.md
+++ b/docs/ownership.md
@@ -1,6 +1,6 @@
 # SuperBot — Ownership boundaries
 
-> **Status:** binding. Every module/table/event listed here has a
+> **Status:** `binding` — Every module/table/event listed here has a
 > single owner that decides what is or isn't legal to do with it.
 > Touching state owned by another subsystem requires going through
 > that subsystem's service layer (or proposing a contract change).

--- a/docs/phase-2-completion-readiness.md
+++ b/docs/phase-2-completion-readiness.md
@@ -1,6 +1,6 @@
 # Phase 2 — Completion readiness
 
-> **Status:** `historical` — Phase-2 snapshot; superseded as
+> **Status:** `historical` — a **historical Phase-2 snapshot; superseded as
 > a live next-work queue.** PR-10 consistency diagnostics and later setup work shipped
 > after this snapshot. Preserve this file for blocker-name/doc-test and migration
 > history, but use `docs/current-state.md`, subsystem folios, source, and active

--- a/docs/phase-2-completion-readiness.md
+++ b/docs/phase-2-completion-readiness.md
@@ -1,6 +1,6 @@
 # Phase 2 — Completion readiness
 
-> **Status (reconciled 2026-06-06):** **historical Phase-2 snapshot; superseded as
+> **Status:** `historical` — Phase-2 snapshot; superseded as
 > a live next-work queue.** PR-10 consistency diagnostics and later setup work shipped
 > after this snapshot. Preserve this file for blocker-name/doc-test and migration
 > history, but use `docs/current-state.md`, subsystem folios, source, and active

--- a/docs/phase_2b_bindings_plan.md
+++ b/docs/phase_2b_bindings_plan.md
@@ -1,6 +1,6 @@
 # Phase 2b — Guild Bindings (HISTORICAL)
 
-> **Status:** ⛔ **HISTORICAL — shipped in PR #73** (plus PR #74
+> **Status:** `plan` — ⛔ **HISTORICAL — shipped in PR #73** (plus PR #74
 > circular-import hotfix). This document was the pre-implementation
 > plan for Phase 2b; it is preserved unchanged below for historical
 > context, but is no longer the source of truth.

--- a/docs/planning/cog-functionality-audit-2026-06-05.md
+++ b/docs/planning/cog-functionality-audit-2026-06-05.md
@@ -1,6 +1,6 @@
 # Cog-by-Cog Functionality Audit — 2026-06-05
 
-> **Status:** live working document. This is the session tracker for a structured,
+> **Status:** `audit` — live working document. This is the session tracker for a structured,
 > cog-by-cog walkthrough of **every** command (prefix + slash) and command panel,
 > assigning each cog a current status. Built against a **live test bot**
 > (`Galaxy Bot#6724`) booted in the cloud container on a **fresh local Postgres**

--- a/docs/planning/server-management-implementation-plan-2026-06-05.md
+++ b/docs/planning/server-management-implementation-plan-2026-06-05.md
@@ -1,5 +1,7 @@
 # Server Management Implementation Plan
 
+> **Status:** `plan`
+
 > Converts `docs/planning/server-management-roadmap-2026-06-05.md` into a
 > dependency-ordered, repo-grounded, highest-value-first implementation sequence.
 >

--- a/docs/planning/server-management-roadmap-2026-06-05.md
+++ b/docs/planning/server-management-roadmap-2026-06-05.md
@@ -1,6 +1,6 @@
 # Server Management Roadmap
 
-> **Status:** source-grounded planning document; no production behavior is changed by this document.
+> **Status:** `plan` — source-grounded planning document; no production behavior is changed by this document.
 > **Audit date:** 2026-06-05
 > **Intended direction:** evolve SuperBot into a coherent, service-owned, button-first Guild OS without duplicating existing setup, governance, resource, or mutation systems.
 >

--- a/docs/planning/server-management-status-2026-06-05.md
+++ b/docs/planning/server-management-status-2026-06-05.md
@@ -1,6 +1,6 @@
 # Server Management — Status Tracker
 
-> **Status:** living status ledger. This is the **single current record** of what
+> **Status:** `living-ledger` — living status ledger. This is the **single current record** of what
 > the server-management initiative has actually shipped and what is queued next.
 > When this tracker and the roadmap / implementation plan disagree about *what is
 > done*, **this tracker (cross-checked against source) wins**; the roadmap remains

--- a/docs/planning/stability-implementation-plan-refined-2026-06-05.md
+++ b/docs/planning/stability-implementation-plan-refined-2026-06-05.md
@@ -4,7 +4,8 @@
 **Author:** Claude Opus (dedicated planning session)
 **Base verified:** `5e62578` (merge of #529; **== current remote `main`**)
 **Refines:** `docs/planning/stability-preimplementation-plan-2026-06-05.md` (Codex first pass, PR #529)
-**Status:** planning artifact — read-only by design. Intended next for the Revision-project
+> **Status:** `plan` — planning artifact — read-only by design. Intended next for the Revision-project
+
 critique, then a final Opus revision, then execution. **No source was implemented in this pass.**
 
 > **Post-merge update (2026-06-05):** this document was verified **pre-merge** at `5e62578`; it then

--- a/docs/planning/superbot-architecture-priority-map-2026-06-05.md
+++ b/docs/planning/superbot-architecture-priority-map-2026-06-05.md
@@ -3,7 +3,7 @@
 > **`historical` — 2026-06-05.** For *what is true now*, start at
 > **`docs/current-state.md`**. Kept for the RC-n priority / dependency rationale.
 
-> **Status:** planning artifact. Companion to
+> **Status:** `plan` — planning artifact. Companion to
 > `superbot-audit-consolidation-2026-06-05.md` (the verified findings) and
 > `superbot-next-session-roadmap-2026-06-05.md` (the PR sequence). This doc
 > turns the consolidated root-cause findings (RC-1 … RC-15) into an ordered

--- a/docs/planning/superbot-audit-consolidation-2026-06-05.md
+++ b/docs/planning/superbot-audit-consolidation-2026-06-05.md
@@ -4,7 +4,7 @@
 > **`docs/current-state.md`**. Kept for the RC-1…RC-15 audit reconciliation
 > history (the *why* behind decisions), not current state.
 
-> **Status:** planning / verification artifact (not a binding contract, not
+> **Status:** `audit` — planning / verification artifact (not a binding contract, not
 > implementation approval). Read this before acting on any of the five
 > source audit docs — it supersedes their individual confidence claims
 > where local verification disagrees.

--- a/docs/planning/superbot-ideas-lab-2026-06-05.md
+++ b/docs/planning/superbot-ideas-lab-2026-06-05.md
@@ -1,6 +1,6 @@
 # SuperBot — Ideas Lab (brainstorm backlog)
 
-> **Status:** planning artifact / **advisory** backlog — **except** §2 (Operating
+> **Status:** `ideas` — planning artifact / **advisory** backlog — **except** §2 (Operating
 > decisions) and §6 (Rejection ledger), which are **binding** for how this
 > backlog is handled. The rest is a menu of candidate work, not a spec.
 >

--- a/docs/planning/superbot-next-session-roadmap-2026-06-05.md
+++ b/docs/planning/superbot-next-session-roadmap-2026-06-05.md
@@ -3,7 +3,7 @@
 > **`historical` — 2026-06-05; PR sequence superseded.** For *what is true now*
 > and the next candidates, start at **`docs/current-state.md`**.
 
-> **Status:** planning artifact. Companion to
+> **Status:** `historical` — planning artifact. Companion to
 > `superbot-audit-consolidation-2026-06-05.md` (verified findings, IDs RC-n)
 > and `superbot-architecture-priority-map-2026-06-05.md` (priority + dependency
 > graph). This doc converts the consolidated findings into an ordered,

--- a/docs/planning/superbot-source-of-truth-index-2026-06-05.md
+++ b/docs/planning/superbot-source-of-truth-index-2026-06-05.md
@@ -1,5 +1,7 @@
 # SuperBot — Planning Source-of-Truth Index
 
+> **Status:** `historical`
+
 > **`historical` — superseded as a daily router by `docs/current-state.md`.**
 > Start at `docs/current-state.md` for *what is true now*. This file is kept for
 > its RC-1…RC-15 audit-reconciliation history (useful for *why* a decision was

--- a/docs/platform-consistency-ledger.md
+++ b/docs/platform-consistency-ledger.md
@@ -1,6 +1,6 @@
 # SuperBot — Platform Consistency Ledger
 
-> **Status (reconciled 2026-06-06):** reference contract shape + **stale status
+> **Status:** `living-ledger` — reference contract shape + **stale status
 > snapshot**. The ownership/domain shapes remain useful, but many implementation
 > cells below still describe pre-ship Phase-2 state and are **not a current work
 > queue**. Verify every cell against source and the relevant subsystem folio/tracker;

--- a/docs/repo-navigation-map.md
+++ b/docs/repo-navigation-map.md
@@ -1,6 +1,6 @@
 # SuperBot — Repo Navigation Map
 
-> **Status:** binding (reference material). Describes the current
+> **Status:** `binding` — (reference material). Describes the current
 > layout of the bot tree, who owns which directory, and where to put
 > new code. Companion to `docs/architecture.md` (conceptual layering)
 > and `docs/ownership.md` (per-table / per-service ownership). This

--- a/docs/roadmap_setup_platform.md
+++ b/docs/roadmap_setup_platform.md
@@ -1,6 +1,6 @@
 # SuperBot — Setup + Configuration Wizard Platform Roadmap
 
-> **Status:** `plan` — **Status: aspirational roadmap — not a description of shipped behavior.**
+> **Status:** `plan` — aspirational roadmap; not a description of shipped behavior.
 > This document sketches a long-horizon "platform layer / Guild OS" vision in
 > eight phases. The **shipped** setup wizard is a pragmatic subset: a
 > session + draft + operations model (`services/setup_*.py`,

--- a/docs/roadmap_setup_platform.md
+++ b/docs/roadmap_setup_platform.md
@@ -1,6 +1,6 @@
 # SuperBot — Setup + Configuration Wizard Platform Roadmap
 
-> **Status: aspirational roadmap — not a description of shipped behavior.**
+> **Status:** `plan` — **Status: aspirational roadmap — not a description of shipped behavior.**
 > This document sketches a long-horizon "platform layer / Guild OS" vision in
 > eight phases. The **shipped** setup wizard is a pragmatic subset: a
 > session + draft + operations model (`services/setup_*.py`,

--- a/docs/runtime_contracts.md
+++ b/docs/runtime_contracts.md
@@ -1,6 +1,6 @@
 # SuperBot — Runtime contracts
 
-> **Status:** binding. Describes the lifecycle every platform primitive
+> **Status:** `binding` — Describes the lifecycle every platform primitive
 > guarantees, and what subsystems must do to participate.  Failure
 > modes and recovery semantics live here so a new contributor can
 > answer "what happens when X breaks?" without reading source.

--- a/docs/server-logging.md
+++ b/docs/server-logging.md
@@ -1,6 +1,6 @@
 # Server logging foundation
 
-**Status:** shipped in Phase 2 PR-11.  Default: **OFF** per-guild.
+> **Status:** `binding` — shipped in Phase 2 PR-11.  Default: **OFF** per-guild.
 
 The server-logging service (`disbot/services/server_logging.py`)
 subscribes to the catalogued event `moderation.action_taken` emitted

--- a/docs/settings-customization-roadmap.md
+++ b/docs/settings-customization-roadmap.md
@@ -1,6 +1,6 @@
 # Settings & Customization Manager — Roadmap
 
-> **Status (reconciled 2026-06-06):** architectural lane/reference roadmap. The
+> **Status:** `reference` — architectural lane/reference roadmap. The
 > S7–S12 planned/in-progress labels below are **not a verified current queue**; later
 > source contains access, cleanup, setup, and provisioning surfaces that make the
 > milestone sequence incomplete as status reporting. Start at
@@ -12,7 +12,6 @@ Settings & Customization Manager**. Companion to
 (per-cog inventory) and
 [`docs/resource-provisioning-overview.md`](resource-provisioning-overview.md)
 (the RPM lane explainer).
-
 
 ## Three architectural lanes
 
@@ -26,7 +25,6 @@ Settings & Customization Manager**. Companion to
    "select existing **or** create new" UX for any Discord resource. It calls
    `BindingMutationPipeline.set_binding(...)` at step 8 of its 11-step
    contract — it never writes `subsystem_bindings` itself.
-
 
 ## Ownership invariants
 
@@ -50,7 +48,6 @@ Settings & Customization Manager**. Companion to
   in (e.g. `logging.auto_create_channels=true`) AND the operator has
   selected a provisioning policy ahead of time.
 
-
 ## Canonical mutation pipelines
 
 | Pipeline | Owns writes to | Source-of-truth file |
@@ -64,7 +61,6 @@ Settings & Customization Manager**. Companion to
 
 UI **calls** these — never writes a row directly. Setup wizard **calls** them
 via the Settings Manager cog and services — never directly.
-
 
 ## 15 roadmap milestones
 
@@ -100,7 +96,6 @@ kill-switch remains: operators flip it OFF either via the
 the (future) ``!platform flags`` command, and the cog returns the
 disabled embed in that state.
 
-
 ## Execution workflow
 
 - Every PR starts from a fresh `main`.
@@ -110,7 +105,6 @@ disabled embed in that state.
 - Stop on failing tests, migration uncertainty, circular-import risk,
   architecture ambiguity, or unexpected behaviour changes.
 - Never merge PRs without explicit operator approval.
-
 
 ## Dependency graph
 
@@ -138,7 +132,6 @@ disabled embed in that state.
                          cleanup_policies                              (untouched)
   participation_mutation ─ canonical writer for user_*                 (untouched)
 ```
-
 
 ## Module map
 
@@ -169,7 +162,6 @@ disbot/
     032_cleanup_prohibited_words.sql     ← S8 v3 (deferred)
     033_logging_routes.sql               ← future (NOT in v1 scope)
 ```
-
 
 ## See also
 

--- a/docs/setup_wizard_finalization_plan.md
+++ b/docs/setup_wizard_finalization_plan.md
@@ -1,6 +1,6 @@
 # Setup Wizard — Finalization Analysis & Plan
 
-> **Status: 🟢 active (plan).** Repo-state analysis of the *shipped* guild setup
+> **Status:** `plan` — **Status: 🟢 active (plan).** Repo-state analysis of the *shipped* guild setup
 > wizard plus the implementation-ready PR sequence to finalize it. This is the
 > "PR-12 — setup wizard plan refresh (plan only)" anticipated by
 > `docs/platform-consistency-ledger.md`.

--- a/docs/setup_wizard_finalization_plan.md
+++ b/docs/setup_wizard_finalization_plan.md
@@ -1,6 +1,6 @@
 # Setup Wizard — Finalization Analysis & Plan
 
-> **Status:** `plan` — **Status: 🟢 active (plan).** Repo-state analysis of the *shipped* guild setup
+> **Status:** `plan` — 🟢 active. Repo-state analysis of the *shipped* guild setup
 > wizard plus the implementation-ready PR sequence to finalize it. This is the
 > "PR-12 — setup wizard plan refresh (plan only)" anticipated by
 > `docs/platform-consistency-ledger.md`.

--- a/docs/smoke-test-checklist.md
+++ b/docs/smoke-test-checklist.md
@@ -1,6 +1,6 @@
 # Discord smoke-test checklist
 
-> **Status:** SuperBot 2.0 — PR-05.
+> **Status:** `binding` — SuperBot 2.0 — PR-05.
 > Run this checklist before merging anything that touches startup,
 > task ownership, the consistency report, or the readiness snapshot.
 
@@ -179,7 +179,6 @@ migration is caught before it strands fresh guilds again.
       above.  `command_access_decisions_total{decision="allow"}`
       and `…{decision="deny"}` both increment with the correct
       reason/source labels.
-
 
 ## Shutdown drain
 

--- a/docs/subsystems/ai.md
+++ b/docs/subsystems/ai.md
@@ -46,6 +46,11 @@ scoped tools (including owner-gated diagnostics). Source:
 
 - `docs/ideas/ai-extra-tool-capability-ideas.md` — capability backlog (web/vision/
   file/KB/connectors/scheduler/etc.). Promotion path: `docs/ideas/README.md`.
+- **Owner intent (2026-06-07, `docs/owner/maintainer-question-router.md` Q-0001 — not
+  approval):** AI may *eventually* gain broader / action capabilities beyond
+  explanation-only — but only behind *all* AI gates (readiness, orchestration, authority,
+  confirmation, audit, rollback) **and** a dedicated decision. Today AI stays read-only /
+  explanation-only; this note changes no gate.
 
 ## Next candidates (self-direct from here)
 

--- a/docs/subsystems/server-management.md
+++ b/docs/subsystems/server-management.md
@@ -94,6 +94,10 @@ Arbitrary channel before/after positioning, revert-safe-changes UX, first-class
 category management, and broader role/template UX remain follow-ups, not permission
 to bypass lifecycle/provisioning services.
 
+**Owner intent (2026-06-07, `docs/owner/maintainer-question-router.md` Q-0002):** the
+owner-facing control center stays **Discord-first** — keep services / read-models
+reusable so a web companion is *possible* later, but do not start web work now.
+
 ## Next candidates
 
 1. Continue PR10: its first–third slices shipped; the next step is the **remaining

--- a/docs/ui-view-adoption-audit.md
+++ b/docs/ui-view-adoption-audit.md
@@ -1,6 +1,6 @@
 # SuperBot — UI / View Adoption Audit
 
-> **Status:** ⚠️ SUPERSEDED inventory snapshot, dated 2026-05-24, `main` at
+> **Status:** `living-ledger` — ⚠️ SUPERSEDED inventory snapshot, dated 2026-05-24, `main` at
 > `948f539` (post-PR-#289). The PR 1–7 backlog in §7 / §9.3 has all
 > shipped; **`docs/audits/repo-wide-audit-2026-05-29.md` reconciles this
 > snapshot against current code and supersedes its open backlog.** Do

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Doc-hygiene checker for SuperBot ``docs/``.
+
+Hard rules (CI gate — see ``--strict``):
+
+  1. **badge**  — every ``docs/**/*.md`` carries a machine-readable
+     ``> **Status:** `<token>``` line in its first 12 lines, with ``<token>`` from
+     the allowed taxonomy. ADRs (``docs/decisions/NNN-*.md``) are exempt: they use
+     their own ``**Status:** Accepted/Superseded`` convention and are inherently
+     binding.
+  2. **link**   — every *relative* markdown link ``[text](path)`` inside ``docs/``
+     resolves to an existing file/dir (external/anchor-only links are skipped).
+  3. **pinned** — every concrete repo path referenced in backticks inside the
+     read-path docs (``AGENT_ORIENTATION`` / ``current-state`` / ``repo-navigation-map``)
+     exists, so the canonical read path never points at a moved/renamed file.
+
+Pure stdlib (no third-party imports) so CI can run it on every PR — including
+docs-only PRs — without installing anything.
+
+Usage:
+    python scripts/check_docs.py            # report mode (always exit 0)
+    python scripts/check_docs.py --strict   # exit 1 if any violation
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_ROOT = REPO_ROOT / "docs"
+
+# Keep in sync with the "Status badges" list in docs/AGENT_ORIENTATION.md.
+ALLOWED_BADGES = frozenset(
+    {
+        "binding",
+        "living-ledger",
+        "reference",
+        "plan",
+        "historical",
+        "audit",
+        "owner-guidance",
+        "ideas",
+        "archive",
+    },
+)
+
+# The machine-readable badge: `> **Status:** `<token>`` (rich text may follow).
+_BADGE_RE = re.compile(r"\*\*Status:\*\*\s*`([a-z-]+)`")
+# ADR filename: NNN-something.md
+_ADR_RE = re.compile(r"^\d+-.*\.md$")
+# Markdown link target: [text](target)
+_MD_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+# Concrete repo path inside backticks, e.g. `docs/foo.md`, `disbot/x.py`.
+_PATH_REF_RE = re.compile(
+    r"`((?:docs|disbot|tests|scripts|architecture_rules|\.claude|\.github)"
+    r"/[\w./-]+\.(?:py|md|sql|ya?ml|txt|sh|json|toml|cfg|ini))`",
+)
+_READPATH_DOCS = ("AGENT_ORIENTATION.md", "current-state.md", "repo-navigation-map.md")
+
+
+def _docs_files() -> list[Path]:
+    return sorted(DOCS_ROOT.rglob("*.md"))
+
+
+def _is_adr(path: Path) -> bool:
+    return path.parent.name == "decisions" and bool(_ADR_RE.match(path.name))
+
+
+def check_badges() -> list[tuple[Path, str, str]]:
+    """Every doc (non-ADR) must declare a valid Status badge."""
+    violations: list[tuple[Path, str, str]] = []
+    for f in _docs_files():
+        if _is_adr(f):
+            continue
+        rel = f.relative_to(REPO_ROOT)
+        head = "\n".join(f.read_text(encoding="utf-8").splitlines()[:12])
+        match = _BADGE_RE.search(head)
+        if match is None:
+            violations.append(
+                (rel, "badge", "missing `> **Status:** `<token>`` in first 12 lines"),
+            )
+        elif match.group(1) not in ALLOWED_BADGES:
+            violations.append(
+                (
+                    rel,
+                    "badge",
+                    f"invalid badge token `{match.group(1)}` "
+                    f"(allowed: {', '.join(sorted(ALLOWED_BADGES))})",
+                ),
+            )
+    return violations
+
+
+def _link_target(raw: str) -> str:
+    """Normalise a markdown link target to a bare path (drop title, <>, anchor)."""
+    target = raw.strip()
+    if target.startswith("<") and ">" in target:
+        target = target[1:].split(">", 1)[0]
+    target = target.split()[0] if target.split() else target  # drop "title"
+    return target.split("#", 1)[0]  # drop anchor
+
+
+def check_links() -> list[tuple[Path, str, str]]:
+    """Relative markdown links inside docs/ must resolve."""
+    violations: list[tuple[Path, str, str]] = []
+    for f in _docs_files():
+        rel = f.relative_to(REPO_ROOT)
+        for lineno, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
+            for raw in _MD_LINK_RE.findall(line):
+                if raw.startswith(("http://", "https://", "mailto:", "#")):
+                    continue
+                target = _link_target(raw)
+                if not target or target.startswith(("http", "mailto:")):
+                    continue
+                if not (f.parent / target).resolve().exists():
+                    violations.append((rel, "link", f"L{lineno}: dead link -> {raw}"))
+    return violations
+
+
+def check_pinned() -> list[tuple[Path, str, str]]:
+    """Concrete repo paths cited in the read-path docs must exist."""
+    violations: list[tuple[Path, str, str]] = []
+    for name in _READPATH_DOCS:
+        f = DOCS_ROOT / name
+        if not f.exists():
+            continue
+        rel = f.relative_to(REPO_ROOT)
+        text = f.read_text(encoding="utf-8")
+        for ref in sorted(set(_PATH_REF_RE.findall(text))):
+            if any(ch in ref for ch in "<>*"):
+                continue  # placeholder / glob, not a concrete path
+            if not (REPO_ROOT / ref).exists():
+                violations.append((rel, "pinned", f"references missing path `{ref}`"))
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="SuperBot doc-hygiene checker.")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 1 if any violation (CI gate); default reports and exits 0",
+    )
+    args = parser.parse_args(argv)
+
+    violations = check_badges() + check_links() + check_pinned()
+    if not violations:
+        print("check_docs: all checks passed ✓")
+        return 0
+
+    by_kind: dict[str, list[tuple[Path, str]]] = {}
+    for rel, kind, msg in violations:
+        by_kind.setdefault(kind, []).append((rel, msg))
+
+    print(f"\ncheck_docs — {len(violations)} issue(s)\n")
+    print("  by check: " + ", ".join(f"{k}={len(by_kind[k])}" for k in sorted(by_kind)))
+    print()
+    for kind in sorted(by_kind):
+        print(f"[{kind}]")
+        for rel, msg in sorted(by_kind[kind], key=lambda x: str(x[0])):
+            print(f"  {rel}: {msg}")
+        print()
+
+    return 1 if args.strict else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_quality.py
+++ b/scripts/check_quality.py
@@ -132,6 +132,14 @@ def run_pytest() -> int:
     return _run("pytest", _tool("pytest", "tests/", "-q", "--tb=short"))
 
 
+def run_check_docs() -> int:
+    # CI runs `python3 scripts/check_docs.py --strict` on every PR (incl. docs-only).
+    return _run(
+        "check_docs",
+        [_PY, str(REPO_ROOT / "scripts" / "check_docs.py"), "--strict"],
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="SuperBot quality checker")
     parser.add_argument(
@@ -163,6 +171,8 @@ def main() -> int:
             failed.append(name)
 
     if not args.fix_only:
+        if run_check_docs() != 0:
+            failed.append("check_docs")
         if args.full:
             if run_mypy() != 0:
                 failed.append("mypy")

--- a/tests/unit/scripts/test_check_docs.py
+++ b/tests/unit/scripts/test_check_docs.py
@@ -1,0 +1,125 @@
+"""Tests for ``scripts/check_docs.py`` (doc-hygiene checker)."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "check_docs.py"
+
+
+@pytest.fixture(scope="module")
+def cd():
+    spec = importlib.util.spec_from_file_location("check_docs_ut", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Badges
+# ---------------------------------------------------------------------------
+
+
+def test_badge_valid_passes(cd, tmp_path, monkeypatch):
+    docs = tmp_path / "docs"
+    _write(docs / "ok.md", "# Title\n\n> **Status:** `binding`\n\nbody\n")
+    monkeypatch.setattr(cd, "DOCS_ROOT", docs)
+    monkeypatch.setattr(cd, "REPO_ROOT", tmp_path)
+    assert cd.check_badges() == []
+
+
+def test_badge_missing_flagged(cd, tmp_path, monkeypatch):
+    docs = tmp_path / "docs"
+    _write(docs / "bare.md", "# Title\n\nbody only, no badge\n")
+    monkeypatch.setattr(cd, "DOCS_ROOT", docs)
+    monkeypatch.setattr(cd, "REPO_ROOT", tmp_path)
+    viol = cd.check_badges()
+    assert len(viol) == 1
+    assert viol[0][1] == "badge" and "missing" in viol[0][2]
+
+
+def test_badge_invalid_token_flagged(cd, tmp_path, monkeypatch):
+    docs = tmp_path / "docs"
+    _write(docs / "weird.md", "# Title\n\n> **Status:** `bogus`\n")
+    monkeypatch.setattr(cd, "DOCS_ROOT", docs)
+    monkeypatch.setattr(cd, "REPO_ROOT", tmp_path)
+    viol = cd.check_badges()
+    assert len(viol) == 1 and "invalid badge token" in viol[0][2]
+
+
+def test_adr_is_exempt_from_badge(cd, tmp_path, monkeypatch):
+    docs = tmp_path / "docs"
+    _write(docs / "decisions" / "001-no-redis.md", "# ADR-001\n\n**Status:** Accepted\n")
+    monkeypatch.setattr(cd, "DOCS_ROOT", docs)
+    monkeypatch.setattr(cd, "REPO_ROOT", tmp_path)
+    assert cd.check_badges() == []
+
+
+# ---------------------------------------------------------------------------
+# Links
+# ---------------------------------------------------------------------------
+
+
+def test_links_dead_flagged_valid_and_external_ok(cd, tmp_path, monkeypatch):
+    docs = tmp_path / "docs"
+    _write(docs / "target.md", "# Target\n\n> **Status:** `reference`\n")
+    _write(
+        docs / "a.md",
+        "# A\n\n> **Status:** `reference`\n\n"
+        "[good](target.md) [dead](nope.md) "
+        "[ext](https://example.com) [anchor](#x)\n",
+    )
+    monkeypatch.setattr(cd, "DOCS_ROOT", docs)
+    monkeypatch.setattr(cd, "REPO_ROOT", tmp_path)
+    viol = cd.check_links()
+    assert len(viol) == 1
+    assert "nope.md" in viol[0][2]
+
+
+# ---------------------------------------------------------------------------
+# Pinned read-path references
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_missing_path_flagged_placeholder_skipped(cd, tmp_path, monkeypatch):
+    docs = tmp_path / "docs"
+    _write(docs / "real.md", "x")
+    _write(
+        docs / "AGENT_ORIENTATION.md",
+        "# Orientation\n\n> **Status:** `binding`\n\n"
+        "real: `docs/real.md` · ghost: `docs/ghost.md` · "
+        "placeholder: `docs/subsystems/<area>.md`\n",
+    )
+    monkeypatch.setattr(cd, "DOCS_ROOT", docs)
+    monkeypatch.setattr(cd, "REPO_ROOT", tmp_path)
+    viol = cd.check_pinned()
+    assert len(viol) == 1
+    assert "docs/ghost.md" in viol[0][2]
+
+
+# ---------------------------------------------------------------------------
+# Taxonomy pin — the checker must match AGENT_ORIENTATION's badge list
+# ---------------------------------------------------------------------------
+
+
+def test_allowed_badges_match_agent_orientation(cd):
+    text = (_REPO_ROOT / "docs" / "AGENT_ORIENTATION.md").read_text(encoding="utf-8")
+    # Badge bullets look like:  - **`binding`** — ...
+    documented = set(re.findall(r"^- \*\*`([a-z-]+)`\*\*", text, re.MULTILINE))
+    assert documented == set(cd.ALLOWED_BADGES), (
+        "ALLOWED_BADGES in check_docs.py drifted from the badge list in "
+        "docs/AGENT_ORIENTATION.md"
+    )


### PR DESCRIPTION
## Why

Follow-up to merged #560. The maintainer answered a 16-question multiple-choice batch
(4 waves) to **define the working model** and **scope doc hygiene**, then approved
executing it this session. This PR routes every answer into its durable home and builds
the doc-hygiene enforcement we agreed on.

## What changed (3 commits)

### 1. Workflow definition — answers routed
- `.claude/CLAUDE.md` + `docs/collaboration-model.md`: planning stays planning until
  **ExitPlanMode** approval; before approval the agent may do read-only research + safe
  prototyping (no commits); after approval it executes the **whole plan in-session**.
  PR size **mixed by risk**; prefer **custom tooling over new third-party deps**.
- `docs/owner/maintainer-question-router.md` §11–§13: the 5 inbox questions are
  **answered + preserved verbatim**. Notable: **AI may eventually gain broader actions**
  — owner intent, but still behind *all* AI gates + a dedicated decision (routed to
  `docs/subsystems/ai.md` as an explicit *not-approval* note); Discord-first + later web
  (→ server-management folio).

### 2. Doc-hygiene gate — `scripts/check_docs.py`
A custom, **stdlib-only** checker wired as a **hard CI gate** that runs on **every PR
incl. docs-only** (no setup needed). Enforces, per your picks:
- **badge** — every `docs/*.md` has a valid `> **Status:** \`<token>\`` (taxonomy pinned
  to AGENT_ORIENTATION by a test; ADRs exempt);
- **link** — relative markdown links in `docs/` resolve;
- **pinned** — concrete repo paths cited in the read-path docs exist.

To make it green: **normalized 66 docs** to the strict badge token (preserving each
doc's description), de-linked a dead ADR-003 reference, and **collapsed the 3 overlapping
"where to read next" tables** into the one canonical home (`AGENT_ORIENTATION.md`).
Added to `.github/workflows/code-quality.yml` and `scripts/check_quality.py` so local
mirrors CI. Tests in `tests/unit/scripts/test_check_docs.py`.

### 3. Journal → per-session files
Migrated the live Session Log into `.sessions/<date>-<slug>.md` (newest-first) +
`.sessions/README`; slimmed `.session-journal.md` to guidebook-only with a pointer;
updated the protocol in the journal and CLAUDE.md. **Kills the shared-anchor
merge-conflict class** that bit #529→#531.

## Testing
- `python3.10 scripts/check_quality.py --full` → **all checks passed** (black/isort/ruff
  + mypy + **check_docs** + **7756 passed**, 16 skipped).
- `python3.10 scripts/check_architecture.py --mode strict` → **0 errors**.
- `python3.10 scripts/check_docs.py --strict` → clean. Docs/tooling only — no `disbot/`
  runtime change.

https://claude.ai/code/session_01T1z1k7BA4aW3puxJXjXzPw

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1z1k7BA4aW3puxJXjXzPw)_