### PR TITLE
feat(moderation): capability-native moderator/trusted roles — PR10 final slice (ADR-008)

### DIFF
--- a/.sessions/2026-06-07-server-management-pr10-6-mod-roles.md
+++ b/.sessions/2026-06-07-server-management-pr10-6-mod-roles.md
@@ -1,0 +1,95 @@
+# 2026-06-07 — Server-management PR10 (final slice): moderator/trusted roles + capabilities
+
+- **Arc:** Autonomous session — maintainer was testing a multi-agent workflow ("find out
+  for yourself what to do, start implementing once you understand the goal, standing by
+  for questions"). Followed the orientation route → the `current-state.md` ▶ Next action
+  was unambiguous: PR10's last item, the **capability-native mod-roles** grant (owner
+  decision Q-0006 → A, the highest-stakes change in the server-management plan — it
+  changes *who can ban members*). Source-verified the whole authority model first, then
+  asked **one** focused product question (config surface) → *"Settings-hub role setting"*.
+  Branch `claude/gifted-planck-HYMqp`. **PR #___.** This completes **PR10**.
+
+- **Decision of record:** **ADR-008**
+  (`docs/decisions/008-moderator-role-capability-native-authority.md`).
+
+- **Key design call (source-grounded):** route the grant through the **tier resolver**,
+  not a new per-capability matrix. `resolve_execution` *already* gates moderation at the
+  `moderator` tier (the moderation subsystem's `visibility_tier`), and
+  `_resolve_member_tier` was *already* role-aware (trusted role, ISSUE-015). So the whole
+  feature is **one tier promotion** + an OR-gate on the surfaces — it reuses the existing
+  capabilities, the existing `resolve_execution`, and the existing `input_hint="role"`
+  Settings widget. The owner picked A (role→tier) over option (b) the per-capability
+  matrix, so `actor_holds_capability` / `capability-authority.md §5` stays **untouched**
+  and that matrix stays deferred.
+
+- **Shipped:**
+  - **`MODERATOR_TIER_ROLE_ID`** key + **`config_arbitration.get_moderator_tier_role`**
+    (mirrors `get_trusted_tier_role`).
+  - **`governance/resolver.py::_resolve_member_tier`** — moderator-role grant symmetric to
+    the trusted-role grant, via a new `_role_grants_tier` helper. Grants only **raise** a
+    tier (never demote a real admin/owner), compose (higher wins), and **fail toward the
+    lower tier** on a config-read error (a role can only ever *add* standing).
+  - **`ui_permissions.can_execute_ctx`** — prefix-`Context` mirror of `can_execute`.
+  - **Mod cog** — eight prefix commands swap `@commands.has_permissions(...)` for
+    `@_require_mod(cap, perm)`: `Discord-perm OR capability`, raising `MissingPermissions`
+    on denial (preserves the exact error UX). **Panel `interaction_check`** OR-gated the
+    same way. `/moderation` slash left as-is (Discord `default_permissions` UI default —
+    documented boundary).
+  - **Settings hub** — `moderator_role` + `trusted_role` role-typed `SettingSpec`s
+    (`input_hint="role"`, schema → **v6**), written through the audited
+    `SettingsMutationPipeline`, gated by `moderation.settings.configure` (admin floor).
+    This also finally un-inerts the trusted role (it had **no** operator surface before).
+
+- **Behaviour-preserving:** the Discord-perm path is unchanged and checked first, so no one
+  who can moderate today loses access; the role grant only *adds*. Configuring the role
+  needs admin. A role-granted moderator can take actions but cannot change mod *config*.
+
+- **Tests / gates:** `test_role_tier_grants.py` (grant-via-role, no-escalation,
+  no-regression, precedence, cross-guild deny, fail-toward-lower, helper) +
+  `test_moderation_role_authority.py` (cog + panel OR-gate) + `test_moderation_schemas.py`
+  v6/role specs. `check_quality --full` **green (7852 passed, 16 skipped)**, mypy clean,
+  `check_architecture --mode strict` **0 errors**, doc-pins green. **Live-booted** (Postgres
+  brought up, Galaxy Bot#6724): clean start, `settings_registry … 0 findings`, ModerationCog
+  loaded, **no ERROR/CRITICAL/Traceback**.
+
+- **Docs routed:** ADR-008 · tracker (PR10 → COMPLETE, queue starts at PR11) · folio ·
+  `capability-authority.md` §5/§6 · `settings-customization-command-map.md` ·
+  `current-state.md` (▶ Next action → PR11) · router Q-0006 (Routed → ADR-008). Project
+  state → `current-state.md`; authoritative queue → the server-management tracker.
+
+## Workflow notes (meta — the maintainer asked for these)
+
+What **helped** (keep):
+- **The orientation chain is excellent.** `CLAUDE.md` → `collaboration-model` →
+  `current-state` (with a single **▶ Next action** pointer) → tracker took me from cold
+  start to "the exact approved next task + the owner's decision verbatim" in ~4 reads. The
+  ▶ Next action line carrying the *decision* (Q-0006 → A) and the *reason it's sensitive*
+  inline is the single highest-leverage thing in the repo for an autonomous start.
+- **Decisions are pre-routed.** The owner answer + agent interpretation living in the
+  router §19 (not just a PR body) meant I didn't have to reconstruct intent or re-ask the
+  architecture — I only had to verify it against source and ask the *one* genuinely-open
+  product question.
+- **CI mirror + arch checker + doc-pins are a real safety net.** `check_quality --full`
+  caught the two doc-pin gaps (new key + SettingSpec names must be documented) and mypy
+  caught the `User|Member` narrowing — both *before* push, exactly as intended.
+- **The "source wins / verify cross-agent output" culture paid off:** the surface area was
+  much larger than the prompt implied (there are two parallel authority resolvers, and the
+  trusted role was *fully* inert with no UI), and only reading source surfaced that.
+
+What **worked against me** (friction):
+- **High doc surface for one change.** A single feature touched ~6 doc homes
+  (current-state, tracker, folio, capability-authority, command-map, router) plus the ADR.
+  The one-fact-one-home rule is right, but a small "where to update when PR-N of an
+  initiative lands" checklist per tracker would cut the rediscovery. (Idea, not done.)
+- **Two same-named authority resolvers** (`resolve_execution` vs `actor_holds_capability`)
+  + a "capability resolver" phrase in the owner decision created a real fork I had to
+  resolve from source. A one-line map in `capability-authority.md` ("executions →
+  resolve_execution; config mutations → actor_holds_capability") would have saved time —
+  I added exactly that note in §5 this session.
+- **Settings keys vs SettingSpec ownership:** the role keys are governance-owned but the
+  SettingSpec lives on the moderation schema; nothing enforced/clarified that this is OK.
+  It works, but a future reader may wonder. Left a comment + doc note.
+
+Improvement ideas (captured, not acted on): a per-initiative "landing checklist" of doc
+homes to refresh when a slice ships; consider promoting the ★ "boot is always safe" +
+"run check_quality --full before push" rules — they held perfectly again this session.

--- a/disbot/cogs/moderation/schemas.py
+++ b/disbot/cogs/moderation/schemas.py
@@ -52,6 +52,8 @@ from utils.settings_keys import (
     MOD_PUBLIC_LOG_CHANNEL,
     MOD_REQUIRE_REASON,
     MOD_WARN_ESCALATION_ACTION,
+    MODERATOR_TIER_ROLE_ID,
+    TRUSTED_TIER_ROLE_ID,
     WARN_THRESHOLD,
     WARN_TIMEOUT_MINS,
 )
@@ -142,6 +144,17 @@ def _validate_public_log_channel(value: object) -> None:
     if text and not text.isdigit():
         raise ValueError(
             f"public_log_channel must be empty or a numeric channel id, got {value!r}",
+        )
+
+
+def _validate_role_id_or_empty(value: object) -> None:
+    """Accept an empty string (unset) or a numeric role id."""
+    if not isinstance(value, str):
+        raise ValueError(f"expected str, got {type(value).__name__}")
+    text = value.strip()
+    if text and not text.isdigit():
+        raise ValueError(
+            f"role setting must be empty or a numeric role id, got {value!r}",
         )
 
 
@@ -322,6 +335,44 @@ MODERATION_SETTINGS: tuple[SettingSpec, ...] = (
         validator=_validate_public_log_channel,
         input_hint="channel",
     ),
+    # PR10 final slice — capability-native moderator / trusted roles (ADR-008).
+    # Setting a role here grants its members the corresponding governance tier
+    # via governance.resolver._resolve_member_tier, so non-admins can moderate
+    # (moderator role) or reach trust-gated surfaces (trusted role).  Stored as
+    # the numeric role id (string), read back through config_arbitration.
+    # Changing them requires the administrator floor (``moderation.settings.
+    # configure``) — only admins decide who moderates.  The grant only ever
+    # *adds* standing; a member keeps any access their Discord permissions
+    # already give them.
+    SettingSpec(
+        name="moderator_role",
+        value_type=str,
+        default="",
+        settings_key=MODERATOR_TIER_ROLE_ID,
+        capability_required=_MODERATION_CAPABILITY,
+        hint=(
+            "Role whose members may use moderation actions (warn, timeout, "
+            "kick, ban) without holding Discord moderation permissions.  Leave "
+            "empty to require Discord permissions only.  This only adds access — "
+            "no one who can moderate today loses it."
+        ),
+        validator=_validate_role_id_or_empty,
+        input_hint="role",
+    ),
+    SettingSpec(
+        name="trusted_role",
+        value_type=str,
+        default="",
+        settings_key=TRUSTED_TIER_ROLE_ID,
+        capability_required=_MODERATION_CAPABILITY,
+        hint=(
+            "Role whose members are treated as the 'trusted' tier — reserved "
+            "for trust-gated features and surfaces.  Leave empty to disable.  "
+            "Like the moderator role, this only ever adds standing."
+        ),
+        validator=_validate_role_id_or_empty,
+        input_hint="role",
+    ),
 )
 
 MODERATION_RESOURCE_REQUIREMENTS: tuple[ResourceRequirement, ...] = (
@@ -352,7 +403,9 @@ MODERATION_CONFIG_SCHEMA = SubsystemSchema(
     # (optional post-kick/ban message sweep, requested from the cleanup service).
     # v5 — PR10 fifth slice added public_log_actions / public_log_channel (optional
     # operator-opt-in public moderation log, delivered by services.server_logging).
-    version=5,
+    # v6 — PR10 final slice added moderator_role / trusted_role (capability-native
+    # authority — a configured role grants the moderator / trusted tier; ADR-008).
+    version=6,
 )
 
 

--- a/disbot/cogs/moderation_cog.py
+++ b/disbot/cogs/moderation_cog.py
@@ -13,6 +13,7 @@ from cogs.moderation._helpers import (
     render_warn_outcome_lines,
 )
 from core.runtime import panel_manager
+from core.runtime.ui_permissions import can_execute_ctx
 from services import moderation_service
 from services.moderation_service import ReasonRequiredError
 from utils import db
@@ -22,6 +23,32 @@ from utils.ui_constants import MOD_COLOR
 # so the persistent-view registry is populated before on_ready runs
 # restore_anchors.  See docs/architecture.md §"PersistentView placement".
 from views.moderation import ModPanelView  # noqa: F401 — re-exported
+
+
+def _require_mod(capability: str, perm_attr: str):
+    """Command check: allow if the invoker holds the Discord permission
+    *perm_attr* **or** the governance *capability* (e.g. via a configured
+    moderator role — ADR-008, capability-native authority).
+
+    Behaviour-preserving: the Discord-permission path is evaluated first and is
+    unchanged, so no one who can moderate today loses access — the capability
+    path only *adds* the configured-role grant.  On denial it raises
+    :class:`discord.ext.commands.MissingPermissions` so the existing
+    ``on_command_error`` handler shows the standard "no permission" message
+    (a bare ``CheckFailure`` would be silent).
+    """
+
+    async def predicate(ctx: commands.Context) -> bool:
+        if ctx.guild is None:
+            raise commands.NoPrivateMessage()
+        perms = getattr(ctx.author, "guild_permissions", None)
+        if perms is not None and getattr(perms, perm_attr, False):
+            return True
+        if await can_execute_ctx(ctx, capability):
+            return True
+        raise commands.MissingPermissions([perm_attr])
+
+    return commands.check(predicate)
 
 
 class ModerationCog(commands.Cog):
@@ -47,7 +74,7 @@ class ModerationCog(commands.Cog):
     # ------------------------------------------------------------------
 
     @commands.command(name="modmenu")
-    @commands.has_permissions(moderate_members=True)
+    @_require_mod("moderation.warn.apply", "moderate_members")
     async def mod_menu(self, ctx):
         """Show the interactive moderation action panel."""
         embed = _build_mod_panel_embed(ctx.guild)
@@ -92,7 +119,7 @@ class ModerationCog(commands.Cog):
     # ------------------------------------------------------------------
 
     @commands.command(name="warn", hidden=True)
-    @commands.has_permissions(manage_roles=True)
+    @_require_mod("moderation.warn.apply", "manage_roles")
     async def warn(self, ctx, member: Member, *, reason=""):
         """Warn a user. Escalates at the configured threshold (default: timeout)."""
         err = self._can_act_on(ctx, member)
@@ -115,7 +142,7 @@ class ModerationCog(commands.Cog):
             await ctx.send(line)
 
     @commands.command(name="timeout", hidden=True)
-    @commands.has_permissions(moderate_members=True)
+    @_require_mod("moderation.timeout.apply", "moderate_members")
     async def timeout(self, ctx, member: Member, duration: int):
         """Timeout a member for a given number of minutes."""
         err = self._can_act_on(ctx, member)
@@ -137,7 +164,7 @@ class ModerationCog(commands.Cog):
             await ctx.send(f"❌ Failed to timeout: {e}")
 
     @commands.command(name="kick", hidden=True)
-    @commands.has_permissions(kick_members=True)
+    @_require_mod("moderation.kick.apply", "kick_members")
     async def kick(self, ctx, member: Member, *, reason=""):
         """Kick a member from the server."""
         err = self._can_act_on(ctx, member)
@@ -165,7 +192,7 @@ class ModerationCog(commands.Cog):
             await ctx.send(f"❌ Failed to kick: {e}")
 
     @commands.command(name="ban", hidden=True)
-    @commands.has_permissions(ban_members=True)
+    @_require_mod("moderation.ban.apply", "ban_members")
     async def ban(self, ctx, member: Member, *, reason=""):
         """Ban a member from the server."""
         err = self._can_act_on(ctx, member)
@@ -194,7 +221,7 @@ class ModerationCog(commands.Cog):
             await ctx.send(f"❌ Failed to ban: {e}")
 
     @commands.command(name="unban", hidden=True)
-    @commands.has_permissions(ban_members=True)
+    @_require_mod("moderation.ban.remove", "ban_members")
     async def unban(self, ctx, user_id: int):
         """Unban a user by their Discord user ID."""
         try:
@@ -221,7 +248,7 @@ class ModerationCog(commands.Cog):
             await ctx.send(f"❌ Failed to unban: {e}")
 
     @commands.command(name="clearwarnings", hidden=True)
-    @commands.has_permissions(manage_roles=True)
+    @_require_mod("moderation.warn.apply", "manage_roles")
     async def clearwarnings(self, ctx, member: Member):
         """Clear all warnings for a member."""
         await moderation_service.clear_warnings(
@@ -232,7 +259,7 @@ class ModerationCog(commands.Cog):
         await ctx.send(f"✅ Warnings cleared for {member.mention}.")
 
     @commands.command(name="modlogs", hidden=True)
-    @commands.has_permissions(manage_roles=True)
+    @_require_mod("moderation.log.view", "manage_roles")
     async def modlogs(self, ctx, member: Member):
         """Show moderation log history for a member."""
         logs = await db.get_mod_logs(member.id, ctx.guild.id, limit=10)

--- a/disbot/core/runtime/config_arbitration.py
+++ b/disbot/core/runtime/config_arbitration.py
@@ -584,6 +584,25 @@ async def get_trusted_tier_role(guild_id: int) -> ConfigReadResult:
     return _coerce_to_int(result)
 
 
+async def get_moderator_tier_role(guild_id: int) -> ConfigReadResult:
+    """Resolve the governance moderator-tier role; value normalized to ``int|None``.
+
+    Symmetric to :func:`get_trusted_tier_role`.  Consumers
+    (``governance.resolver._resolve_member_tier``) check membership of this
+    role id against ``ctx.role_ids`` and, when matched, grant the member the
+    ``moderator`` tier so they may use moderation actions without holding the
+    corresponding Discord permissions (capability-native authority, ADR-008).
+    """
+    result = await read_config(
+        guild_id=guild_id,
+        subsystem="governance",
+        binding_name="moderator_role",
+        legacy_key="moderator_tier_role_id",
+        binding_kind="role",
+    )
+    return _coerce_to_int(result)
+
+
 # ---------------------------------------------------------------------------
 # Diagnostics provider registration (registers at import time)
 # ---------------------------------------------------------------------------
@@ -617,6 +636,7 @@ __all__ = [
     "attribution_snapshot",
     "counters_snapshot",
     "get_economy_log_channel",
+    "get_moderator_tier_role",
     "get_trusted_tier_role",
     "get_xp_announce_channel",
     "read_config",

--- a/disbot/core/runtime/ui_permissions.py
+++ b/disbot/core/runtime/ui_permissions.py
@@ -10,6 +10,7 @@ they call can_execute() here so that the authorization path is unified.
 
 Public surface:
     can_execute(interaction, capability) → bool
+    can_execute_ctx(ctx, capability) → bool        (prefix-command path)
     require_execution(interaction, capability) → None  (raises on denial)
 """
 
@@ -41,6 +42,35 @@ async def can_execute(interaction: discord.Interaction, capability: str) -> bool
         logger.debug(
             "Execution denied | user=%d | capability=%s | reason=%s",
             interaction.user.id,
+            capability,
+            result.reason,
+        )
+
+    return result.allowed
+
+
+async def can_execute_ctx(ctx, capability: str) -> bool:
+    """Return True if the prefix-command invoker may execute *capability*.
+
+    The :class:`~discord.ext.commands.Context` counterpart of
+    :func:`can_execute`: prefix command checks resolve authority through the
+    same governance seam as interaction handlers, so a configured-role grant
+    (e.g. the moderator role, ADR-008) applies identically on both surfaces.
+
+    Permits commands invoked outside a guild (no guild-level governance).
+    """
+    from services import governance_service
+
+    if ctx.guild is None:
+        return True
+
+    gctx = governance_service.GovernanceContext.from_ctx(ctx)
+    result = await governance_service.resolve_execution(gctx, capability)
+
+    if not result.allowed:
+        logger.debug(
+            "Execution denied | user=%s | capability=%s | reason=%s",
+            getattr(ctx.author, "id", None),
             capability,
             result.reason,
         )

--- a/disbot/governance/resolver.py
+++ b/disbot/governance/resolver.py
@@ -8,6 +8,8 @@ and external utils (subsystem_registry, visibility_rules, db, settings_keys).
 from __future__ import annotations
 
 import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 from governance.cache import (
     _CACHE_LOCK,
@@ -27,7 +29,11 @@ from governance.models import (
 )
 from utils import db
 from utils.subsystem_registry import SUBSYSTEMS
-from utils.visibility_rules import get_member_visibility_tier, get_subsystems_for_tier
+from utils.visibility_rules import (
+    get_member_visibility_tier,
+    get_subsystems_for_tier,
+    is_tier_sufficient,
+)
 
 logger = logging.getLogger("bot")
 
@@ -133,12 +139,55 @@ def _resolve_single_subsystem(
 
 
 # ---------------------------------------------------------------------------
-# Trusted tier resolution (ISSUE-015)
+# Configured-role tier grants (trusted: ISSUE-015 / moderator: ADR-008)
 # ---------------------------------------------------------------------------
 
 
+async def _role_grants_tier(
+    guild_id: int,
+    reader: Callable[[int], Awaitable[Any]],
+    role_ids: set[int],
+) -> bool:
+    """True when the guild's configured role (via ``reader``) is one the member holds.
+
+    ``reader`` is a :mod:`core.runtime.config_arbitration` getter returning a
+    ``ConfigReadResult`` whose ``.value`` is the configured role id (or ``None``).
+    A read failure degrades to ``False`` (no grant): a configured role may only
+    ever *add* standing, so a config-store hiccup must fail toward the lower
+    tier and can never escalate authority.
+    """
+    if not role_ids:
+        return False
+    try:
+        result = await reader(guild_id)
+    except Exception:  # noqa: BLE001 — a failed read must never grant a tier
+        return False
+    role_id = result.value
+    return role_id is not None and role_id in role_ids
+
+
 async def _resolve_member_tier(ctx: GovernanceContext) -> str:
-    """Resolve the member's visibility tier, applying trusted role check (ISSUE-015)."""
+    """Resolve the member's effective tier, applying configured-role grants.
+
+    The base tier comes from Discord permissions
+    (:func:`utils.visibility_rules.get_member_visibility_tier`).  Two
+    configured-role grants may then *raise* it — never lower it:
+
+    * the **moderator** role (``moderator_tier_role_id``) grants the
+      ``moderator`` tier, so its holders may use moderation actions without
+      holding the matching Discord permissions (capability-native authority,
+      ADR-008);
+    * the **trusted** role (``trusted_tier_role_id``) grants the ``trusted``
+      tier (ISSUE-015).
+
+    A grant applies only when the base tier is *below* the granted tier, so a
+    real administrator/owner is never demoted and the two grants compose (the
+    higher one wins).  Reads flow through the Phase 2 arbitration helpers so the
+    canary flip of ``bindings.primary`` stays a single change in
+    :mod:`core.runtime.config_arbitration`; this function MUST NOT branch on
+    ``is_enabled("bindings.primary", ...)`` directly (forbidden by the PR-7
+    invariant test).
+    """
     if ctx.member is None:
         return "user"
 
@@ -147,34 +196,27 @@ async def _resolve_member_tier(ctx: GovernanceContext) -> str:
         ctx.member.guild.owner_id if ctx.member.guild else 0,
     )
 
-    # Trusted tier: if the guild has a trusted_role binding (or legacy
-    # TRUSTED_TIER_ROLE_ID setting) AND the member has that role,
-    # promote them to "trusted" (but only if they're currently "user"
-    # — higher tiers like staff/mod/admin take precedence).
-    #
-    # Read flows through the Phase 2 arbitration helper so the canary
-    # flip of ``bindings.primary`` is a single change in
-    # :mod:`core.runtime.config_arbitration`.  This function MUST NOT
-    # branch on ``is_enabled("bindings.primary", ...)`` directly —
-    # that is forbidden by the invariant test in PR-7.
-    if tier == "user":
-        try:
-            # Local import — keep core.runtime out of governance/__init__'s
-            # module-load cycle (PR #74 protection).  resolver.py is a
-            # sibling of __init__.py but follows the same discipline.
-            from core.runtime.config_arbitration import get_trusted_tier_role
+    if ctx.role_ids:
+        # Local import — keep core.runtime out of governance/__init__'s
+        # module-load cycle (PR #74 protection).  resolver.py is a sibling of
+        # __init__.py but follows the same discipline.
+        from core.runtime.config_arbitration import (
+            get_moderator_tier_role,
+            get_trusted_tier_role,
+        )
 
-            trusted_role_result = await get_trusted_tier_role(ctx.guild_id)
-            trusted_role_id = trusted_role_result.value
-            if (
-                trusted_role_id is not None
-                and ctx.role_ids
-                and trusted_role_id in ctx.role_ids
-            ):
-                tier = "trusted"
-        except Exception:
-            # Fail gracefully: if the setting lookup fails, stay at "user"
-            pass
+        if not is_tier_sufficient(tier, "moderator") and await _role_grants_tier(
+            ctx.guild_id,
+            get_moderator_tier_role,
+            ctx.role_ids,
+        ):
+            tier = "moderator"
+        if not is_tier_sufficient(tier, "trusted") and await _role_grants_tier(
+            ctx.guild_id,
+            get_trusted_tier_role,
+            ctx.role_ids,
+        ):
+            tier = "trusted"
 
     return tier
 

--- a/disbot/utils/settings_keys/__init__.py
+++ b/disbot/utils/settings_keys/__init__.py
@@ -42,7 +42,11 @@ from utils.settings_keys.games import (
     DEATHMATCH_TURN_TIMEOUT,
     RPS_DEFAULT_ENTRY_FEE,
 )
-from utils.settings_keys.governance import GOVERNANCE_VERSION, TRUSTED_TIER_ROLE_ID
+from utils.settings_keys.governance import (
+    GOVERNANCE_VERSION,
+    MODERATOR_TIER_ROLE_ID,
+    TRUSTED_TIER_ROLE_ID,
+)
 from utils.settings_keys.logging import (
     DEFAULT_CLEANUP_CHANNEL_NAME,
     DEFAULT_MOD_CHANNEL_NAME,
@@ -101,6 +105,7 @@ __all__ = [
     "LOGGING_CLEANUP_CHANNEL",
     "LOGGING_ENABLED",
     "LOGGING_MOD_CHANNEL",
+    "MODERATOR_TIER_ROLE_ID",
     "MOD_BAN_DELETE_MESSAGE_DAYS",
     "MOD_DM_ON_ACTION",
     "MOD_DM_TEMPLATE",

--- a/disbot/utils/settings_keys/governance.py
+++ b/disbot/utils/settings_keys/governance.py
@@ -5,3 +5,9 @@ GOVERNANCE_VERSION = "governance_version"
 
 # Role ID whose holders are treated as "trusted" tier (ISSUE-015).
 TRUSTED_TIER_ROLE_ID = "trusted_tier_role_id"
+
+# Role ID whose holders are granted the "moderator" tier — i.e. they may use
+# moderation actions (warn/timeout/kick/ban) without holding the corresponding
+# Discord permissions.  The grant only *raises* a member's tier; it never lowers
+# one resolved from real Discord permissions (capability-native authority, ADR-008).
+MODERATOR_TIER_ROLE_ID = "moderator_tier_role_id"

--- a/disbot/views/moderation/main_panel.py
+++ b/disbot/views/moderation/main_panel.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import discord
 
 from core.runtime.persistent_views import PersistentView, register
+from core.runtime.ui_permissions import can_execute
 from views.moderation.modals import (
     _BanModal,
     _ClearWarningsModal,
@@ -42,13 +43,22 @@ class ModPanelView(PersistentView):
     SUBSYSTEM = "moderation"
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
-        if not interaction.user.guild_permissions.moderate_members:  # type: ignore[union-attr]
-            await interaction.response.send_message(
-                "❌ You need Moderate Members permission.",
-                ephemeral=True,
-            )
-            return False
-        return True
+        # Behaviour-preserving OR-gate: the historical Moderate Members check OR
+        # the moderator-tier capability (e.g. a configured moderator role —
+        # ADR-008).  The panel is reachable via the Help menu, which is not
+        # admin-gated, so this is the panel's authority boundary
+        # (docs/capability-authority.md §4).
+        perms = getattr(interaction.user, "guild_permissions", None)
+        if perms is not None and perms.moderate_members:
+            return True
+        if await can_execute(interaction, "moderation.warn.apply"):
+            return True
+        await interaction.response.send_message(
+            "❌ You need Moderate Members permission or the configured "
+            "moderator role to use this panel.",
+            ephemeral=True,
+        )
+        return False
 
     @discord.ui.button(
         label="⚠️ Warn",

--- a/docs/capability-authority.md
+++ b/docs/capability-authority.md
@@ -148,9 +148,19 @@ the authority of the equivalent typed command.
   to the old admin floor; the seam is what changed.
 - **Unblocked follow-on:** the capability-native **settings/bindings UI** (Ideas-Lab
   §4.5) — RC-4 no longer "spreads placeholder authority."
-- **Future policy:** a per-capability tier matrix (e.g. some settings need only
-  `moderator`) replaces `_DEFAULT_REQUIRED_TIER`. Revisit per the ADR-005
-  re-evaluation criteria.
+- **Shipped (ADR-008) — role → tier *grant*, not the matrix.** Moderation authority is
+  now capability-native via a **tier grant**: a configured `moderator_role` (and the
+  symmetric `trusted_role`) promotes a member's tier in the governance tier resolver
+  (`governance.resolver._resolve_member_tier`), so the moderation surfaces — which gate
+  on `resolve_execution` (the moderation subsystem's `visibility_tier` is `moderator`),
+  not on `actor_holds_capability` — admit role-granted moderators. This is a narrower
+  mechanism than the per-capability matrix below and does **not** change this
+  resolver's single-floor policy. See
+  [`docs/decisions/008-moderator-role-capability-native-authority.md`](decisions/008-moderator-role-capability-native-authority.md).
+- **Future policy (still deferred):** a per-capability tier matrix (e.g. some settings
+  need only `moderator`) replaces `_DEFAULT_REQUIRED_TIER` *here*, in
+  `actor_holds_capability`. ADR-008 deliberately did **not** introduce this — it stays
+  deferred per the ADR-005 re-evaluation criteria.
 - **Broaden the guard:** audit other Help-reachable mutating panels and apply the
   `interaction_is_admin` pattern where missing.
 
@@ -166,3 +176,5 @@ the authority of the equivalent typed command.
 | Bindings: capability deny/allow (actor must be a member of the target guild) | `tests/unit/bindings/test_binding_mutation_pipeline.py` |
 | `is_operator_disabled` source discrimination (explicit-OFF only) | `tests/unit/schema/test_feature_flags_declarations.py` |
 | Panel guards: non-admin blocked on chain panel + RPS matchup | `tests/unit/views/test_panel_command_gaps.py` |
+| Moderator/trusted role tier grant (grant-via-role, no-escalation, no-regression, precedence, cross-guild deny, fail-toward-lower) — ADR-008 | `tests/unit/governance/test_role_tier_grants.py` |
+| Moderation surfaces OR-gate (cog `_require_mod` + panel `interaction_check`: permission path, capability path, denial) — ADR-008 | `tests/unit/cogs/test_moderation_role_authority.py` |

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -6,23 +6,24 @@
 > live GitHub** before trusting it (two same-session reports already
 > contradicted each other across a single merge).
 >
-> **▶ Next action:** finish **PR10's last item** — moderator/trusted **roles +
-> capabilities** (owner decision 2026-06-07, preserved in
-> [`owner/maintainer-question-router.md`](owner/maintainer-question-router.md) §19:
-> *capability-native* — a configured role resolves to the `moderator` tier, routed
-> through the capability resolver; this is the per-capability tier matrix
-> `capability-authority.md` §5 defers, so it warrants an ADR + thorough authority
-> tests, a careful security-sensitive change). Authoritative scope + dependencies: the
+> **▶ Next action:** server-management **PR11** — setup role/moderation/governance
+> sections (reuse provisioning previews + capability checks; never add a second
+> resource-creation path). **PR10 is complete:** its final item — capability-native
+> moderator/trusted **roles + capabilities** — landed as
+> **[ADR-008](decisions/008-moderator-role-capability-native-authority.md)** (a
+> configured role grants the `moderator` tier via the governance tier resolver;
+> behaviour-preserving OR-gate that preserves Discord-perm holders; settable in the
+> Settings hub at the administrator floor). Authoritative scope + dependencies: the
 > server-management [status tracker](planning/server-management-status-2026-06-05.md)
 > Remaining-queue.
 >
-> **Last updated:** 2026-06-07 · server-management **PR10's first four slices merged**:
-> config-backed moderation behaviour (#555), require-reason + bot-readiness diagnostics
-> (#556), warn escalation (#558), post-action message cleanup (#567); the cross-area
-> roadmap also merged (#566). Later PR10 slices + the full queue live in the **status
-> tracker** (linked above). **This file lists only _merged_ work + the ▶ Next action;**
-> get in-flight PRs from live GitHub (`list_pull_requests`) — naming an open PR's status
-> in prose here rots on merge (a `scripts/check_docs.py` freshness gate enforces this).
+> **Last updated:** 2026-06-07 · server-management **PR10 completed** — its final slice,
+> capability-native moderator/trusted **roles + capabilities**, was implemented this
+> session (decision of record **ADR-008**; the earlier slices merged as #555/#556/#558/#567,
+> the cross-area roadmap as #566). The full PR10 record + the PR11–PR14 queue live in the
+> **status tracker** (linked above). **This file lists only _merged_ work + the ▶ Next
+> action;** get in-flight PRs from live GitHub (`list_pull_requests`) — naming an open PR's
+> status in prose here rots on merge (a `scripts/check_docs.py` freshness gate enforces this).
 >
 > **Purpose:** the one file that answers "what is true right now?" so a new
 > session does not reconstruct it from the journal + planning docs. Read it
@@ -86,12 +87,12 @@ Source code and merged PRs win over anything written here.
 - **Cross-area sequencing + the plan index now live in [`docs/roadmap.md`](roadmap.md)**
   (by area, with Now / Next / Later / Someday horizons + gates — where to find which plan
   for which part of the code). The picks below are the current top of that list.
-- Highest-value approved implementation lane: server-management. PR10's first four
-  slices are merged (#555/#556/#558/#567), with the optional public log in flight; the
-  next step is the **one remaining PR10 item** — moderator/trusted **roles +
-  capabilities** (owner decision: capability-native role→`moderator`-tier grant; a
-  careful security-sensitive change — see the ▶ Next action at the top) — then PR11–PR14.
-  The `docs/planning/server-management-status-2026-06-05.md` tracker is the authoritative
+- Highest-value approved implementation lane: server-management. **PR10 is complete** —
+  its six slices, ending with capability-native moderator/trusted **roles + capabilities**
+  (ADR-008; a configured role grants the `moderator` tier, OR-gated to preserve Discord-perm
+  holders, settable in the Settings hub). The next step is **PR11** (setup
+  role/moderation/governance sections), then PR12–PR14. The
+  `docs/planning/server-management-status-2026-06-05.md` tracker is the authoritative
   queue — don't duplicate it here.
 - Health/diagnostics maintainer live-tests (production AI tool + grouped findings):
   see `docs/subsystems/health-diagnostics.md`.

--- a/docs/decisions/008-moderator-role-capability-native-authority.md
+++ b/docs/decisions/008-moderator-role-capability-native-authority.md
@@ -1,0 +1,135 @@
+# ADR-008: Capability-native moderator/trusted roles (role → tier grant)
+
+**Status:** Accepted (2026-06-07)
+**Supersedes:** none
+**Superseded by:** none
+**Relates to:** [ADR-005](005-capability-native-authority-and-flag-semantics.md)
+(capability-native authority) · [`docs/capability-authority.md`](../capability-authority.md)
+· owner decision Q-0006 in
+[`docs/owner/maintainer-question-router.md`](../owner/maintainer-question-router.md) §19
+
+> **Accepted.** This ADR is ratified; the implementing change lands in the same
+> session (the governance tier resolver + the moderation surfaces + the
+> Settings-hub role pickers). When this doc and source disagree, source wins
+> (`disbot/governance/resolver.py`).
+
+## Context
+
+This is the final item of the server-management **PR10** moderation workstream:
+let a guild grant moderation authority to **non-administrators**. Today moderation
+is gated entirely by Discord permissions checked at the cog/view layer
+(`@commands.has_permissions(...)` and the panel's `interaction_check`), so the only
+way to let someone ban members is to give them a near-admin Discord permission.
+
+Two pieces of existing infrastructure already point at the answer:
+
+1. **The moderation subsystem already requires the `moderator` tier.** Its
+   `visibility_tier` is `"moderator"` (`utils/subsystem_registry.py`), and
+   `governance.execution.resolve_execution(ctx, "moderation.*.apply")` already
+   gates on that tier via the visibility resolver. The `moderation.*.apply`
+   capabilities already exist.
+2. **The tier resolver is already role-aware.** `governance.resolver._resolve_member_tier`
+   already promotes a `user` to `trusted` when the guild has a configured
+   `trusted_tier_role_id` and the member holds it (ISSUE-015). But the `trusted`
+   tier unlocks nothing today (no subsystem requires exactly `trusted`, and there
+   was **no operator surface** to set the role), so it was inert.
+
+ADR-005 §"Re-evaluation criteria" deferred a general **per-capability authorization
+matrix** (capability → required tier). The owner decision (Q-0006) deliberately did
+**not** ask for that matrix — it asked for a **role → existing-tier grant**, which is
+a narrower, lower-risk mechanism that reuses the tier system already in place.
+
+This is the single highest-stakes change in the server-management plan — it changes
+**who can ban members** — so it warrants this ADR and a thorough authority test
+matrix.
+
+## Options
+
+- **A (chosen): role → `moderator` tier (capability-native).** A configured role
+  resolves to the existing `moderator` tier in the governance tier resolver. The
+  moderation surfaces (cog commands + panel) authorize through the capability
+  resolver, so they admit anyone at `moderator` tier — whether that tier came from
+  a Discord permission or the configured role. Reuses the tier system + the existing
+  `moderation.*.apply` capabilities, scoped to moderation.
+- **B: a general per-capability tier matrix** (capability → required tier). Rejected
+  for now — it is the broad mechanism ADR-005 §5 deferred, far larger than the goal,
+  and the owner explicitly chose A over it. It stays deferred.
+- **C: a cog-level role allowlist beside Discord perms.** Rejected — a parallel
+  authority system divorced from the tier/capability model; every future surface
+  would have to learn about it.
+
+## Decision
+
+**ACCEPTED — A** (owner-ratified 2026-06-07, Q-0006).
+
+1. **Tier grant in the governance tier resolver.** `_resolve_member_tier` gains a
+   **moderator-role** grant symmetric to the existing trusted-role grant: a member
+   holding the guild's configured `moderator_tier_role_id` resolves to the
+   `moderator` tier. Both grants only **raise** a member's tier — never lower one
+   computed from real Discord permissions — and compose (the higher wins). A
+   config-read failure fails toward the **lower** tier, so a configured role can
+   only ever *add* standing, never remove it or escalate on error.
+2. **Behaviour-preserving OR-gate on the surfaces.** The moderation cog commands and
+   the moderation panel authorize on `Discord permission` **OR** the governance
+   capability. The Discord-permission path is unchanged and evaluated first, so
+   **no one who can moderate today loses access**; the capability path only adds the
+   configured-role grant. On denial the cog raises `commands.MissingPermissions` so
+   the existing error UX is preserved.
+3. **Configured via the Settings hub (administrator floor).** The `moderator_role`
+   and `trusted_role` are role-typed `SettingSpec`s on the moderation schema
+   (`input_hint="role"`), written through the audited `SettingsMutationPipeline` and
+   gated by `moderation.settings.configure` — which resolves to the **administrator
+   floor** via `actor_holds_capability`. **Only administrators decide who
+   moderates.** This also finally makes the previously inert trusted role
+   configurable.
+4. **The trusted role is wired symmetrically.** Same read path
+   (`config_arbitration.get_*_tier_role`), same grant shape, same Settings-hub
+   surface.
+
+### Scope / boundaries (deliberate, v1)
+
+- **Moderation *settings* configuration stays at the administrator floor.** A
+  role-granted moderator can take moderation *actions* but cannot change moderation
+  *config* (warn threshold, escalation, the role settings themselves) — those route
+  through `actor_holds_capability`, which is untouched here.
+- **The general per-capability tier matrix (ADR-005 §5) remains deferred.** This ADR
+  introduces a role→tier *grant*, not a capability→tier *matrix*.
+- **Slash-command UI gating is unchanged.** `/moderation` keeps its
+  `default_permissions(moderate_members=True)` (a Discord-side UI default). A
+  role-granted moderator reaches the moderation panel via `!modmenu` or the Help
+  menu (both honour the grant), not necessarily the slash entry. Loosening the
+  slash UI default for everyone was out of scope.
+
+## Consequences
+
+- A guild can grant moderation authority by assigning a role — no near-admin Discord
+  permission required — set from the existing Settings hub with a native role picker.
+- The grant is one tier promotion, so it is consistent everywhere the tier is read:
+  the role-granted moderator also *sees* Moderation in their Help menu and passes the
+  panel gate, with no per-surface special-casing.
+- The previously inert trusted role becomes configurable and behaves symmetrically.
+- No regression: every member who could moderate before still can (the OR keeps the
+  Discord-permission path intact).
+
+## Security properties (pinned by tests)
+
+- **Grant via role:** a member with the configured moderator role (and no mod
+  permission) resolves to the `moderator` tier and is admitted.
+- **No escalation:** the grant only raises a tier; a member at `staff`/`user` is not
+  pushed above `moderator`, an administrator/owner is never demoted, and a
+  config-read failure yields no grant. An explicit DB capability revoke still wins
+  (it is checked downstream in `resolve_execution`).
+- **No regression:** a member with the Discord permission is admitted via the
+  permission path regardless of the role config.
+- **Cross-guild deny:** the configured role id is read for the **target** guild and
+  matched against the member's roles **in that guild**; a role configured in guild A
+  cannot grant the tier in guild B.
+- **Admin-only configuration:** setting the role requires the administrator floor
+  (`moderation.settings.configure`).
+
+## Re-evaluation criteria
+
+Revisit if a general per-capability authorization matrix (ADR-005 §5) is genuinely
+needed (this ADR intentionally does not introduce one), if a tier grant is wanted for
+a surface other than moderation, or if the "grant only ever raises" / "fail toward
+the lower tier" posture proves wrong in practice.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -665,7 +665,7 @@ mod-roles still needs an ADR + the normal review path.
 **Area:** Server management / Architecture / Safety
 **Type:** Architecture
 **Priority:** High (gates the last PR10 item; changes *who can ban members*)
-**Status:** Answered (2026-06-07) — needs routing into an ADR when mod-roles is built
+**Status:** Answered (2026-06-07) — **Routed** → [ADR-008](../decisions/008-moderator-role-capability-native-authority.md) (implemented 2026-06-07)
 **Suggested destination after answer:** `docs/decisions/` (ADR) + server-management folio/tracker
 
 **Question:** Mod/trusted roles + capabilities lets non-admins moderate. Should a
@@ -701,10 +701,14 @@ escalation, no regression, cross-guild deny) when implemented.
 **Routing result**
 
 ```text
-Destination: docs/decisions/ (new ADR, when mod-roles ships) + the server-management
-  tracker's PR10 Remaining-queue + folio (decision already noted in both).
-Moved/copied on: 2026-06-07 (decision captured; ADR pending implementation).
-Notes: current-state.md ▶ Next action links here for the decision of record.
+Destination: docs/decisions/008-moderator-role-capability-native-authority.md (the ADR,
+  implemented 2026-06-07) + the server-management tracker's PR10 record + folio +
+  capability-authority.md §5/§6.
+Moved/copied on: 2026-06-07 — implemented: a configured moderator_role grants the
+  `moderator` tier via governance.resolver._resolve_member_tier; OR-gated on the mod cog +
+  panel (behaviour-preserving); settable in the Settings hub (admin floor); trusted_role
+  wired symmetrically. Answer A built as specified.
+Notes: ADR-008 is the decision of record; current-state.md ▶ Next action now points at PR11.
 ```
 
 ### Q-0007 — What should a PUBLIC moderation-log entry reveal?

--- a/docs/planning/server-management-status-2026-06-05.md
+++ b/docs/planning/server-management-status-2026-06-05.md
@@ -10,9 +10,9 @@
 > for PR8+PR9, then for **PR10's first–fifth slices** — config-backed moderation
 > behaviour, require-reason, bot-readiness diagnostics, configurable warn escalation,
 > the post-action message cleanup sweep, and the optional public moderation log).
-> **Body is current through PR10's fifth slice; the one remaining PR10 item
-> (moderator/trusted roles + capabilities) + PR11–PR14 are the queue** — the
-> "Shipped" + "Remaining queue" sections below are authoritative.
+> **Body is current through PR10's final slice — PR10 is COMPLETE** (all six slices
+> shipped, incl. moderator/trusted roles + capabilities, ADR-008). **PR11–PR14 are the
+> queue** — the "Shipped" + "Remaining queue" sections below are authoritative.
 >
 > **Companion docs (read together):**
 > - `docs/planning/server-management-roadmap-2026-06-05.md` — target architecture
@@ -436,16 +436,52 @@ the acting moderator** (owner decision 2026-06-07: public entries show action + 
   PR10 item (the capability-native tier-grant; owner decision 2026-06-07: a configured
   role resolves to the `moderator` tier, routed through the capability resolver).
 
+### PR10 (final slice) — Moderator/trusted roles + capabilities *(shipped 2026-06-07)*
+
+The **last PR10 item** and the highest-stakes change in the workstream (it changes
+*who can ban members*). Decision of record: **[ADR-008](../decisions/008-moderator-role-capability-native-authority.md)**
+(owner decision Q-0006 → A — capability-native role→tier grant). Scalar/KV,
+**no migration**, **behaviour-preserving by default**.
+
+- **Tier grant in the governance resolver** (`governance/resolver.py`):
+  `_resolve_member_tier` gains a **moderator-role** grant symmetric to the existing
+  trusted-role grant. A member holding the guild's configured
+  `moderator_tier_role_id` resolves to the `moderator` tier. Both grants only
+  **raise** a tier (never demote a real admin/owner) and **fail toward the lower
+  tier** on a config-read error — a configured role can only ever *add* standing.
+  Read via the new `config_arbitration.get_moderator_tier_role` (mirrors
+  `get_trusted_tier_role`).
+- **Behaviour-preserving OR-gate on the surfaces:** the mod cog's eight prefix
+  commands (`_require_mod`) and the panel `interaction_check` admit on
+  `Discord permission` **OR** the moderation capability (via `ui_permissions`,
+  new `can_execute_ctx` for the prefix path). The permission path is unchanged and
+  checked first, so no one who can moderate today loses access; denial raises
+  `MissingPermissions` so the error UX is preserved. The `/moderation` slash keeps
+  its Discord `default_permissions` UI default (documented boundary).
+- **Configured via the Settings hub** (owner decision: Settings-hub role setting):
+  two role-typed `SettingSpec`s (`moderator_role` / `trusted_role`,
+  `input_hint="role"`, schema → **v6**) on the moderation schema, written through the
+  audited `SettingsMutationPipeline` and gated by `moderation.settings.configure`
+  (administrator floor). This also makes the previously inert trusted role
+  configurable.
+- **Pinned by** `tests/unit/governance/test_role_tier_grants.py` (grant-via-role,
+  no-escalation, no-regression, precedence, cross-guild deny, fail-toward-lower),
+  `tests/unit/cogs/test_moderation_role_authority.py` (the cog + panel OR-gate), and
+  the `moderator_role` / `trusted_role` shapes + **v6** in `test_moderation_schemas.py`.
+  Live-booted (clean start, settings registry 0 findings). ADR + command-map +
+  capability-authority + folio docs updated.
+- **PR10 is now complete.** Next: **PR11** (setup role/moderation/governance sections).
+
 ---
 
-## Remaining queue (starts at PR10)
+## Remaining queue (starts at PR11)
 
 Per the implementation plan's dependency order. PR7–PR9 shipped (see above).
 
 | PR | Objective | Depends on |
 |---|---|---|
-| **PR10** | Moderation first-class configuration. **First–fifth slices shipped** (DMs, ban message-purge, timeout ceiling, require-reason, bot-readiness diagnostics, configurable warn escalation, post-action message cleanup, optional public log — see above). Remaining: moderator/trusted roles + capabilities (the last PR10 item). | #521 |
-| **PR11** | Setup role/moderation/governance sections. | PR5, PR8–PR10, #522 |
+| **PR10** | Moderation first-class configuration. **COMPLETE** — all six slices shipped (DMs, ban message-purge, timeout ceiling, require-reason, bot-readiness diagnostics, configurable warn escalation, post-action message cleanup, optional public log, **and moderator/trusted roles + capabilities** — ADR-008, see above). | #521 |
+| **PR11** | Setup role/moderation/governance sections. **← next.** | PR5, PR8–PR10, #522 |
 | **PR12** | Setup diagnostics & repair. | PR5, #522 |
 | **PR13** | Deterministic + AI role templates. | PR5, #523 |
 | **PR14** | Server Management Hub (last). | all managers |

--- a/docs/settings-customization-command-map.md
+++ b/docs/settings-customization-command-map.md
@@ -160,20 +160,25 @@ Subsystems (22): `admin`, `moderation`, `economy`, `inventory`, `mining`,
    `warn_timeout_minutes`, `warn_escalation_action`, `dm_on_action`,
    `dm_template`, `require_reason`, `ban_delete_message_days`,
    `max_timeout_minutes`, `post_action_cleanup`, `post_action_cleanup_limit`,
-   `public_log_actions`, `public_log_channel`
+   `public_log_actions`, `public_log_channel`, `moderator_role`, `trusted_role`
    (`disbot/cogs/moderation/schemas.py`).  All but `warn_threshold` /
    `warn_timeout_minutes` are PR10 behaviour config; `warn_escalation_action` +
    those two are the escalation ladder; `post_action_cleanup` /
    `post_action_cleanup_limit` are the post-kick/ban message sweep; `public_log_actions`
    / `public_log_channel` are the optional public moderation log (delivered by
-   `server_logging`) — all applied at / consumed from the `moderation_service` seam.
+   `server_logging`); `moderator_role` / `trusted_role` are the capability-native
+   tier-grant roles (ADR-008, `input_hint="role"`, admin-floor capability) — all
+   applied at / consumed from the `moderation_service` / governance-tier seam.
 10. **existing_settings_keys**: `WARN_THRESHOLD`, `WARN_TIMEOUT_MINS`,
     `MOD_WARN_ESCALATION_ACTION`, `MOD_DM_ON_ACTION`, `MOD_DM_TEMPLATE`,
     `MOD_REQUIRE_REASON`, `MOD_BAN_DELETE_MESSAGE_DAYS`,
     `MOD_MAX_TIMEOUT_MINUTES`, `MOD_POST_ACTION_CLEANUP`,
     `MOD_POST_ACTION_CLEANUP_LIMIT`, `MOD_PUBLIC_LOG_ACTIONS`,
     `MOD_PUBLIC_LOG_CHANNEL`
-    (`disbot/utils/settings_keys/moderation.py`).
+    (`disbot/utils/settings_keys/moderation.py`); plus the governance-owned
+    `MODERATOR_TIER_ROLE_ID` / `TRUSTED_TIER_ROLE_ID`
+    (`disbot/utils/settings_keys/governance.py`), surfaced in the moderation
+    settings page as the `moderator_role` / `trusted_role` pickers.
 11. **existing_BindingSpec_entries**: none (mod_log promotion planned in
     later milestone).
 12. **existing_ResourceRequirement_entries**: `mod_log` with `binding_name=mod_log`,
@@ -183,7 +188,12 @@ Subsystems (22): `admin`, `moderation`, `economy`, `inventory`, `mining`,
     `moderation.kick.apply`, `moderation.ban.apply`, `moderation.ban.remove`,
     `moderation.log.view`, `moderation.settings.configure`.
 14. **hardcoded_or_env_only_behavior**: moderator/trusted **roles + capabilities**
-    are not yet first-class (the next PR10 item).  PR10 moved DM-on-action
+    are now first-class (ADR-008): a configured `moderator_role` grants the
+    `moderator` tier via the governance tier resolver, so its holders may use
+    moderation actions without Discord moderation permissions; the mod cog + panel
+    authorize on Discord-permission **OR** capability (behaviour-preserving — the
+    permission path is unchanged), and `trusted_role` is wired symmetrically.
+    Earlier, PR10 moved DM-on-action
     (`dm_on_action` / `dm_template`), the ban message-purge window
     (`ban_delete_message_days`), the timeout ceiling (`max_timeout_minutes`),
     `require_reason` (warn/kick/ban must justify; timeout exempt), the **warn

--- a/docs/subsystems/server-management.md
+++ b/docs/subsystems/server-management.md
@@ -69,7 +69,11 @@ cleanup policy, setup, and the future unified hub. Inspect first:
   (`public_log_actions` / `public_log_channel`, default OFF, moderator-redacted,
   delivered by `services/server_logging.py`), all applied at / consumed from the
   `services/moderation_service` seam via `services/moderation_config.py`, plus a
-  read-only bot-readiness panel line from `utils/moderation_feasibility.py`).
+  read-only bot-readiness panel line from `utils/moderation_feasibility.py`), and
+  **capability-native moderator/trusted roles** (PR10 final slice, ADR-008: a configured
+  `moderator_role` grants the `moderator` tier via `governance/resolver.py`, OR-gated on
+  the cog + panel to preserve Discord-perm holders; both roles settable in the Settings
+  hub at the administrator floor).
 - Channel creation remains owned by resource provisioning; clone, overwrites, and
   some category/lifecycle follow-ups remain outside the shipped lifecycle service.
 - Cleanup and setup exist today, but the tracker queues their server-management
@@ -82,18 +86,17 @@ cleanup policy, setup, and the future unified hub. Inspect first:
 
 The status tracker's remaining queue is the only current sequencing authority.
 Cleanup versioning + builder/dry-run/panel diagnostics shipped 2026-06-06 (PR8+PR9,
-presets-only). **PR10 (moderation configuration) is nearly complete**: its first five
-slices have shipped — config-backed behaviour (DM-on-action, ban message-purge,
-timeout ceiling), require-reason + bot-readiness diagnostics, configurable warn
-escalation (`warn_escalation_action`), post-action message cleanup
-(`post_action_cleanup`, requested from the cleanup subsystem), and the optional public
-moderation log (`public_log_actions` / `public_log_channel`, moderator-redacted,
-delivered by `server_logging`). The **one remaining PR10 item** — moderator/trusted
-**roles + capabilities** (capability-native: a configured role resolves to the
-`moderator` tier, routed through the capability resolver) — comes next, then setup
-role/moderation/governance and repair sections, role templates, and finally the unified
-Server Management Hub. Link to the tracker for exact order and dependencies rather than
-copying them here.
+presets-only). **PR10 (moderation configuration) is COMPLETE**: all six slices shipped —
+config-backed behaviour (DM-on-action, ban message-purge, timeout ceiling),
+require-reason + bot-readiness diagnostics, configurable warn escalation
+(`warn_escalation_action`), post-action message cleanup (`post_action_cleanup`,
+requested from the cleanup subsystem), the optional public moderation log
+(`public_log_actions` / `public_log_channel`, moderator-redacted, delivered by
+`server_logging`), and **moderator/trusted roles + capabilities** (ADR-008,
+capability-native: a configured role resolves to the `moderator` tier via the governance
+tier resolver). Next comes **PR11** (setup role/moderation/governance sections), then
+repair sections, role templates, and finally the unified Server Management Hub. Link to
+the tracker for exact order and dependencies rather than copying them here.
 
 ## Ideas (not approved)
 
@@ -107,10 +110,10 @@ reusable so a web companion is *possible* later, but do not start web work now.
 
 ## Next candidates
 
-1. Finish PR10: its first–fifth slices shipped; the **last PR10 item** is
-   moderator/trusted **roles + capabilities** (owner decision 2026-06-07:
-   capability-native — a configured role resolves to the `moderator` tier, routed
-   through the capability resolver). Verify source before using either older planning
+1. **PR10 is complete** (all six slices, ending with moderator/trusted **roles +
+   capabilities** — ADR-008). Next is **PR11** (setup role/moderation/governance
+   sections): reuse provisioning previews/confirmation + capability checks; do not add a
+   second resource-creation path. Verify source before using either older planning
    document.
 2. Take one bounded known UX follow-up (member quicksearch or role selector/cleanup)
    without changing lifecycle ownership.

--- a/tests/unit/cogs/test_moderation_role_authority.py
+++ b/tests/unit/cogs/test_moderation_role_authority.py
@@ -1,0 +1,141 @@
+"""Authority tests for the moderation surfaces' OR-gate (ADR-008).
+
+The moderation cog's prefix commands and the moderation panel admit a member on
+``Discord permission`` **OR** the governance moderation capability (the latter is
+how a configured moderator role grants access).  These tests pin:
+
+* the permission path still admits (no regression);
+* the capability path admits a permission-less member (the role grant);
+* neither path → denial, raised as ``MissingPermissions`` so the existing
+  ``on_command_error`` UX (a visible "no permission" message) is preserved.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from discord.ext import commands
+
+
+def _ctx(*, guild=object(), **perm_kwargs):
+    """A fake prefix Context whose author has the given guild_permissions."""
+    return SimpleNamespace(
+        guild=guild,
+        author=SimpleNamespace(
+            id=1,
+            guild_permissions=SimpleNamespace(**perm_kwargs),
+        ),
+    )
+
+
+def _predicate(capability: str, perm_attr: str):
+    """The predicate inside the _require_mod check decorator."""
+    from cogs.moderation_cog import _require_mod
+
+    return _require_mod(capability, perm_attr).predicate
+
+
+# ---------------------------------------------------------------------------
+# Prefix command OR-gate (_require_mod)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_permission_path_admits(monkeypatch):
+    import cogs.moderation_cog as cog_mod
+
+    # can_execute_ctx must NOT even be consulted when the perm is present.
+    spy = AsyncMock(return_value=False)
+    monkeypatch.setattr(cog_mod, "can_execute_ctx", spy)
+
+    predicate = _predicate("moderation.ban.apply", "ban_members")
+    assert await predicate(_ctx(ban_members=True)) is True
+    spy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_capability_path_admits_without_permission(monkeypatch):
+    import cogs.moderation_cog as cog_mod
+
+    monkeypatch.setattr(cog_mod, "can_execute_ctx", AsyncMock(return_value=True))
+
+    predicate = _predicate("moderation.ban.apply", "ban_members")
+    # No ban_members permission, but the capability (role grant) allows it.
+    assert await predicate(_ctx(ban_members=False)) is True
+
+
+@pytest.mark.asyncio
+async def test_neither_path_raises_missing_permissions(monkeypatch):
+    import cogs.moderation_cog as cog_mod
+
+    monkeypatch.setattr(cog_mod, "can_execute_ctx", AsyncMock(return_value=False))
+
+    predicate = _predicate("moderation.ban.apply", "ban_members")
+    with pytest.raises(commands.MissingPermissions):
+        await predicate(_ctx(ban_members=False))
+
+
+@pytest.mark.asyncio
+async def test_outside_guild_raises_no_private_message(monkeypatch):
+    import cogs.moderation_cog as cog_mod
+
+    monkeypatch.setattr(cog_mod, "can_execute_ctx", AsyncMock(return_value=True))
+
+    predicate = _predicate("moderation.ban.apply", "ban_members")
+    with pytest.raises(commands.NoPrivateMessage):
+        await predicate(_ctx(guild=None, ban_members=True))
+
+
+# ---------------------------------------------------------------------------
+# Panel interaction_check OR-gate
+# ---------------------------------------------------------------------------
+
+
+def _interaction(*, moderate_members: bool):
+    return SimpleNamespace(
+        user=SimpleNamespace(
+            id=1,
+            guild_permissions=SimpleNamespace(moderate_members=moderate_members),
+        ),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_panel_admits_moderate_members_permission(monkeypatch):
+    from views.moderation import main_panel
+
+    spy = AsyncMock(return_value=False)
+    monkeypatch.setattr(main_panel, "can_execute", spy)
+
+    view = main_panel.ModPanelView()
+    interaction = _interaction(moderate_members=True)
+    assert await view.interaction_check(interaction) is True
+    spy.assert_not_awaited()  # perm path short-circuits
+    interaction.response.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_panel_admits_via_capability(monkeypatch):
+    from views.moderation import main_panel
+
+    monkeypatch.setattr(main_panel, "can_execute", AsyncMock(return_value=True))
+
+    view = main_panel.ModPanelView()
+    interaction = _interaction(moderate_members=False)
+    assert await view.interaction_check(interaction) is True
+    interaction.response.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_panel_denies_without_permission_or_capability(monkeypatch):
+    from views.moderation import main_panel
+
+    monkeypatch.setattr(main_panel, "can_execute", AsyncMock(return_value=False))
+
+    view = main_panel.ModPanelView()
+    interaction = _interaction(moderate_members=False)
+    assert await view.interaction_check(interaction) is False
+    interaction.response.send_message.assert_awaited_once()

--- a/tests/unit/cogs/test_moderation_schemas.py
+++ b/tests/unit/cogs/test_moderation_schemas.py
@@ -37,7 +37,7 @@ def test_register_schemas_adds_moderation_to_registry():
     assert "moderation" in schema_mod.registered_subsystems()
     schema = schema_mod.get_schema("moderation")
     assert schema is not None
-    assert schema.version == 5
+    assert schema.version == 6
 
 
 def test_moderation_settings_cover_legacy_plus_pr10():
@@ -57,6 +57,8 @@ def test_moderation_settings_cover_legacy_plus_pr10():
         "post_action_cleanup_limit",
         "public_log_actions",
         "public_log_channel",
+        "moderator_role",
+        "trusted_role",
     }
 
 
@@ -216,6 +218,43 @@ def test_public_log_channel_is_channel_picker():
         spec.validator("not-an-id")
     with pytest.raises(ValueError):
         spec.validator(123)  # must be a string id
+
+
+def test_moderator_role_is_role_picker():
+    """ADR-008 — the moderator role grants the moderator tier; settable via a
+    native role select, admin-floor capability, stored as the numeric role id."""
+    from utils.settings_keys import governance as _gov_keys
+
+    spec = _spec("moderator_role")
+    assert spec.value_type is str
+    assert spec.default == ""  # unset = Discord permissions only
+    assert spec.settings_key == _gov_keys.MODERATOR_TIER_ROLE_ID
+    assert spec.capability_required == "moderation.settings.configure"
+    assert spec.input_hint == "role"  # native role select
+    spec.validator("")  # empty = unset
+    spec.validator("123456789012345678")  # numeric role id
+    with pytest.raises(ValueError):
+        spec.validator("not-an-id")
+    with pytest.raises(ValueError):
+        spec.validator(123)  # must be a string id
+
+
+def test_trusted_role_is_role_picker():
+    """ADR-008 — the trusted role is wired symmetrically to the moderator role."""
+    from utils.settings_keys import governance as _gov_keys
+
+    spec = _spec("trusted_role")
+    assert spec.value_type is str
+    assert spec.default == ""
+    assert spec.settings_key == _gov_keys.TRUSTED_TIER_ROLE_ID
+    assert spec.capability_required == "moderation.settings.configure"
+    assert spec.input_hint == "role"
+    spec.validator("")
+    spec.validator("123456789012345678")
+    with pytest.raises(ValueError):
+        spec.validator("not-an-id")
+    with pytest.raises(ValueError):
+        spec.validator(123)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/governance/test_role_tier_grants.py
+++ b/tests/unit/governance/test_role_tier_grants.py
@@ -1,0 +1,238 @@
+"""Authority tests for the configured-role tier grants (ADR-008).
+
+``governance.resolver._resolve_member_tier`` promotes a member to the
+``moderator`` (or ``trusted``) tier when the guild has the matching role
+configured and the member holds it.  These tests pin the security-critical
+properties of that grant:
+
+* **grant via role** — a permission-less member with the configured moderator
+  role resolves to ``moderator``;
+* **no escalation** — the grant only *raises* a tier (never demotes a real
+  admin/owner) and a failed config read grants nothing;
+* **precedence** — the moderator grant wins over the trusted grant;
+* **cross-guild deny** — the role configured for one guild does not grant the
+  tier in another;
+* **no regression** — a member with real Discord permissions is unaffected.
+
+The moderation surfaces gate on this tier via ``resolve_execution`` (the
+moderation subsystem's ``visibility_tier`` is ``"moderator"``), so a correct
+tier here is the whole authority story for the role grant.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import core.runtime.config_arbitration as cfg
+from governance.resolver import _resolve_member_tier, _role_grants_tier
+from services.governance_service import GovernanceContext
+
+MOD_ROLE_ID = 555
+TRUSTED_ROLE_ID = 444
+GUILD_ID = 100
+OWNER_ID = 999
+
+
+def _member(
+    *,
+    member_id: int = 1,
+    administrator: bool = False,
+    moderate_members: bool = False,
+    manage_guild: bool = False,
+) -> SimpleNamespace:
+    """A fake Discord member with just the attributes the tier resolver reads."""
+    perms = SimpleNamespace(
+        administrator=administrator,
+        moderate_members=moderate_members,
+        manage_guild=manage_guild,
+    )
+    return SimpleNamespace(
+        id=member_id,
+        guild_permissions=perms,
+        guild=SimpleNamespace(owner_id=OWNER_ID),
+    )
+
+
+def _ctx(member: SimpleNamespace | None, role_ids: set[int]) -> GovernanceContext:
+    return GovernanceContext(guild_id=GUILD_ID, member=member, role_ids=role_ids)
+
+
+def _reader(value):
+    """Build a fake config getter returning a ConfigReadResult-shaped object."""
+
+    async def _read(_guild_id: int):
+        return SimpleNamespace(value=value)
+
+    return _read
+
+
+@pytest.fixture
+def _no_roles_configured(monkeypatch):
+    """Default: neither role is configured (both readers return value=None)."""
+    monkeypatch.setattr(cfg, "get_moderator_tier_role", _reader(None))
+    monkeypatch.setattr(cfg, "get_trusted_tier_role", _reader(None))
+
+
+# ---------------------------------------------------------------------------
+# Grant via role
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_moderator_role_grants_moderator_tier(monkeypatch):
+    monkeypatch.setattr(cfg, "get_moderator_tier_role", _reader(MOD_ROLE_ID))
+    monkeypatch.setattr(cfg, "get_trusted_tier_role", _reader(None))
+    # A plain member (no mod permissions) who holds the configured moderator role.
+    tier = await _resolve_member_tier(_ctx(_member(), {MOD_ROLE_ID}))
+    assert tier == "moderator"
+
+
+@pytest.mark.asyncio
+async def test_staff_member_promoted_to_moderator_by_role(monkeypatch):
+    monkeypatch.setattr(cfg, "get_moderator_tier_role", _reader(MOD_ROLE_ID))
+    monkeypatch.setattr(cfg, "get_trusted_tier_role", _reader(None))
+    # manage_guild → base "staff"; the moderator role raises them to "moderator".
+    tier = await _resolve_member_tier(
+        _ctx(_member(manage_guild=True), {MOD_ROLE_ID}),
+    )
+    assert tier == "moderator"
+
+
+@pytest.mark.asyncio
+async def test_trusted_role_grants_trusted_tier(monkeypatch):
+    monkeypatch.setattr(cfg, "get_moderator_tier_role", _reader(None))
+    monkeypatch.setattr(cfg, "get_trusted_tier_role", _reader(TRUSTED_ROLE_ID))
+    tier = await _resolve_member_tier(_ctx(_member(), {TRUSTED_ROLE_ID}))
+    assert tier == "trusted"
+
+
+# ---------------------------------------------------------------------------
+# No escalation / only-raises
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_moderator_role_does_not_demote_administrator(monkeypatch):
+    monkeypatch.setattr(cfg, "get_moderator_tier_role", _reader(MOD_ROLE_ID))
+    monkeypatch.setattr(cfg, "get_trusted_tier_role", _reader(None))
+    # An administrator who also holds the moderator role stays "administrator".
+    tier = await _resolve_member_tier(
+        _ctx(_member(administrator=True), {MOD_ROLE_ID}),
+    )
+    assert tier == "administrator"
+
+
+@pytest.mark.asyncio
+async def test_moderator_grant_takes_precedence_over_trusted(monkeypatch):
+    monkeypatch.setattr(cfg, "get_moderator_tier_role", _reader(MOD_ROLE_ID))
+    monkeypatch.setattr(cfg, "get_trusted_tier_role", _reader(TRUSTED_ROLE_ID))
+    # Holding both configured roles resolves to the higher tier.
+    tier = await _resolve_member_tier(
+        _ctx(_member(), {MOD_ROLE_ID, TRUSTED_ROLE_ID}),
+    )
+    assert tier == "moderator"
+
+
+@pytest.mark.asyncio
+async def test_member_without_the_role_is_not_granted(monkeypatch):
+    monkeypatch.setattr(cfg, "get_moderator_tier_role", _reader(MOD_ROLE_ID))
+    monkeypatch.setattr(cfg, "get_trusted_tier_role", _reader(None))
+    # Configured role exists, but the member holds a different role.
+    tier = await _resolve_member_tier(_ctx(_member(), {12345}))
+    assert tier == "user"
+
+
+@pytest.mark.asyncio
+async def test_no_role_configured_stays_user(_no_roles_configured):
+    tier = await _resolve_member_tier(_ctx(_member(), {MOD_ROLE_ID, TRUSTED_ROLE_ID}))
+    assert tier == "user"
+
+
+@pytest.mark.asyncio
+async def test_failed_read_grants_nothing(monkeypatch):
+    async def _boom(_guild_id: int):
+        raise RuntimeError("config store down")
+
+    monkeypatch.setattr(cfg, "get_moderator_tier_role", _boom)
+    monkeypatch.setattr(cfg, "get_trusted_tier_role", _boom)
+    # A read failure must fail toward the LOWER tier — never grant on error.
+    tier = await _resolve_member_tier(_ctx(_member(), {MOD_ROLE_ID}))
+    assert tier == "user"
+
+
+# ---------------------------------------------------------------------------
+# Cross-guild deny
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_role_configured_for_another_guild_does_not_grant(monkeypatch):
+    # The reader returns the moderator role only for GUILD_ID; any other guild
+    # gets None — modelling per-guild config.  The member here is in GUILD_ID
+    # but we resolve a context for a *different* guild.
+    async def _per_guild_reader(guild_id: int):
+        return SimpleNamespace(value=MOD_ROLE_ID if guild_id == GUILD_ID else None)
+
+    monkeypatch.setattr(cfg, "get_moderator_tier_role", _per_guild_reader)
+    monkeypatch.setattr(cfg, "get_trusted_tier_role", _reader(None))
+
+    other_guild_ctx = GovernanceContext(
+        guild_id=GUILD_ID + 1,
+        member=_member(),
+        role_ids={MOD_ROLE_ID},
+    )
+    tier = await _resolve_member_tier(other_guild_ctx)
+    assert tier == "user"
+
+
+# ---------------------------------------------------------------------------
+# No regression — real Discord permissions are unaffected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_moderate_members_permission_unaffected_by_config(_no_roles_configured):
+    # moderate_members → "moderator" with no role configured at all.
+    tier = await _resolve_member_tier(_ctx(_member(moderate_members=True), set()))
+    assert tier == "moderator"
+
+
+@pytest.mark.asyncio
+async def test_member_none_returns_user(_no_roles_configured):
+    tier = await _resolve_member_tier(_ctx(None, {MOD_ROLE_ID}))
+    assert tier == "user"
+
+
+# ---------------------------------------------------------------------------
+# _role_grants_tier helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_role_grants_tier_matches_when_held():
+    assert await _role_grants_tier(GUILD_ID, _reader(MOD_ROLE_ID), {MOD_ROLE_ID}) is True
+
+
+@pytest.mark.asyncio
+async def test_role_grants_tier_false_when_not_held():
+    assert await _role_grants_tier(GUILD_ID, _reader(MOD_ROLE_ID), {7}) is False
+
+
+@pytest.mark.asyncio
+async def test_role_grants_tier_false_when_unset():
+    assert await _role_grants_tier(GUILD_ID, _reader(None), {MOD_ROLE_ID}) is False
+
+
+@pytest.mark.asyncio
+async def test_role_grants_tier_false_when_no_role_ids():
+    assert await _role_grants_tier(GUILD_ID, _reader(MOD_ROLE_ID), set()) is False
+
+
+@pytest.mark.asyncio
+async def test_role_grants_tier_false_on_read_error():
+    async def _boom(_guild_id: int):
+        raise RuntimeError("db down")
+
+    assert await _role_grants_tier(GUILD_ID, _boom, {MOD_ROLE_ID}) is False


### PR DESCRIPTION
## What & why

Completes **server-management PR10** with its last and highest-stakes item: let a guild grant moderation authority to **non-administrators** via a configured role. Owner decision **Q-0006 → A** (capability-native, "role → moderator tier"); decision of record **[ADR-008](https://github.com/menno420/superbot/blob/claude/gifted-planck-HYMqp/docs/decisions/008-moderator-role-capability-native-authority.md)**.

This is the single highest-stakes change in the server-management plan — it changes *who can ban members* — so it ships with an ADR and a thorough authority test matrix.

## How (source-grounded, minimal)

The clean fit was a **tier promotion**, not a new per-capability matrix — because the infrastructure already existed:
- `resolve_execution` **already** gates moderation at the `moderator` tier (the moderation subsystem's `visibility_tier`), and `_resolve_member_tier` was **already** role-aware (the trusted role, ISSUE-015).

So the feature is one tier grant + an OR-gate on the surfaces:

1. **Tier grant** (`governance/resolver.py`): a configured `moderator_role` resolves to the `moderator` tier, symmetric to the existing — and previously inert — trusted-role grant. Read via new `config_arbitration.get_moderator_tier_role`. Both grants only **raise** a tier (never demote a real admin/owner), compose (higher wins), and **fail toward the lower tier** on a config-read error — a configured role can only ever *add* standing.
2. **OR-gate on the surfaces** (behaviour-preserving): the mod cog's 8 prefix commands (`_require_mod`) and the panel `interaction_check` admit on `Discord permission` **OR** the moderation capability (new `ui_permissions.can_execute_ctx` for the prefix path). The permission path is unchanged and checked first, so **no one who can moderate today loses access**; denial raises `MissingPermissions` to preserve the error UX.
3. **Settings-hub config** (owner-chosen surface): `moderator_role` + `trusted_role` role-typed `SettingSpec`s (`input_hint="role"`, schema → v6), written through the audited `SettingsMutationPipeline` at the administrator floor. This also makes the previously unsettable trusted role configurable.

## Scope / boundaries (deliberate)
- The **per-capability tier matrix** (`capability-authority.md` §5) stays **deferred** — this is a role→tier *grant*, not that matrix. `actor_holds_capability` and mod-*settings* config are untouched (still admin floor).
- `/moderation` slash keeps its Discord `default_permissions` UI default; role-granted moderators reach the panel via `!modmenu` / the Help menu.

## Testing
- `tests/unit/governance/test_role_tier_grants.py` — grant-via-role, no-escalation, no-regression, precedence, cross-guild deny, fail-toward-lower.
- `tests/unit/cogs/test_moderation_role_authority.py` — cog `_require_mod` + panel `interaction_check` OR-gate (perm path / capability path / denial).
- `tests/unit/cogs/test_moderation_schemas.py` — v6 + the two role specs.
- `check_quality --full` **green (7865 passed, 3 skipped)** · mypy clean · `check_architecture --mode strict` **0 errors** · `check_docs` green.
- **Live-booted** (Galaxy Bot#6724): clean start, `settings_registry … 0 findings`, ModerationCog loaded, no ERROR/CRITICAL/Traceback.

## Docs routed
ADR-008 · server-management tracker (PR10 → **COMPLETE**, queue starts at PR11) · folio · `capability-authority.md` §5/§6 · `settings-customization-command-map.md` · `current-state.md` (▶ Next action → PR11) · router Q-0006 (Routed → ADR-008).

https://claude.ai/code/session_01T63d21ht3Ub8Pedc75xb2C

---
_Generated by [Claude Code](https://claude.ai/code/session_01T63d21ht3Ub8Pedc75xb2C)_