### PR TITLE
docs(CLAUDE): sharpen CodeGraph/Grimp reliability guidance (verified)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -187,19 +187,21 @@ CodeGraph's symbol-level tools: it surfaces module-level **and lazy/function-bod
 (`scripts/claude_pre_edit.py`) shows it automatically once per file per session, but run it
 yourself when planning a change. Full reference: `docs/context-map-tooling.md`.
 
-### Reliable tools
+### What to trust as-is vs. always grep-verify
 
-| Tool | Use for |
+Three reliability tiers, **verified against `grep`/`Read` ground truth on this repo's real call/import patterns (2026-06-08)**. Trust tier 1 without re-checking; never act on tier 2/3 without the grep.
+
+**Tier 1 — trust CodeGraph as-is (accurate):**
+
+| Tool | Trust it for |
 |---|---|
-| `mcp__codegraph__where` | Finding where a symbol is defined |
-| `mcp__codegraph__context` | Source + signature + starting caller list |
-| `mcp__codegraph__list_functions` | All symbols in a file or directory |
-| `mcp__codegraph__complexity` | Complexity score for a function or file |
-| `mcp__codegraph__check` | Which functions exceed complexity thresholds |
-| `mcp__codegraph__triage` | Risk-ranked list (use `level=function`, never `level=directory`) |
-| `mcp__codegraph__fn_impact` | Direct callers as a starting list — always grep-verify |
+| `mcp__codegraph__where` / `context` | Symbol **definition** location (file + line range) and **signature** |
+| `mcp__codegraph__list_functions` | Complete **structural listing** of a file's/dir's symbols |
+| `mcp__codegraph__complexity` / `check` / `triage` | Complexity metrics (AST-local). Use `triage level=function`, never `level=directory` |
 
-**Caller lists and file-import edges are hints only.** SuperBot uses function-body lazy imports, module-alias calls, and Discord decorator callbacks pervasively — roughly half of all real call edges are invisible to CodeGraph. Always grep-verify before acting on a caller list:
+**Tier 1 — for imports/dependencies, trust Grimp (not CodeGraph).** For "who imports X / what does X import / import blast-radius", use **`python3.10 scripts/context_map.py <path>`** (Grimp import graph). **Verified complete, including lazy/function-body imports** (e.g. `utils/role_feasibility.py` → *all 6* importers, incl. the 3 body-import callers CodeGraph's call graph misses). Its import edges are reliable as an **import** lower bound — trust them. `fn_impact` / `context.callers` are **not** the tool for this question.
+
+**Tier 2 — `context.callers` / `fn_impact`: starting list, never the list (the bare-token rule).** CodeGraph resolves a call edge only for a **bare-name** call (`foo(...)`). It **misses** the qualified form `module.foo(...)`, indirect/variable calls (`cb(...)`), and decorator/registry-dispatched calls — which SuperBot uses *everywhere* (`resources.resolve_role`, `db.get_setting`, `setup_diagnostics.collect_…`). That is why CodeGraph's own *caller coverage reads ~20%*. Always grep-verify a caller list:
 ```
 grep -rn "function_name\b" disbot/ --include="*.py"
 ```
@@ -217,6 +219,9 @@ When two functions share the same short name in different classes or modules, Co
 
 **4. `callees` lists are often empty — read the source.**
 Functions that contain `from X import Y` inside their body will show `callees: []` even if they call many things. Always read the source directly to find what a function calls.
+
+**5. Some edges are invisible to *both* tools — read the source / grep the wiring.**
+EventBus `emit`→`bus.on` subscriptions, the setup-section `REGISTRY` callback fields (`run` / `detail_embed_builder` invoked off the registry object), the `interaction_router` prefix dispatch, and `getattr`/dynamic dispatch are **neither import edges (Grimp-blind) nor named call edges (CodeGraph-blind)**. Verified: `audit.action_recorded` is emitted by `audit_events.emit_audit_action` and consumed by `server_logging._on_audit_action` via `bus.on(...)`, and `server_logging` does **not** import `audit_events` — so no tool connects emitter→subscriber. For event/dispatch wiring, grep the event-name string or the registry, never trust a blast radius.
 <!-- CODEGRAPH_END -->
 
 <!-- ARCH_RULES_START -->


### PR DESCRIPTION
## What & why

Sharpens the **CodeGraph / Grimp reliability guidance** in `.claude/CLAUDE.md`. The previous text ("caller edges are hints only… roughly half invisible") was true but so blanket that it taught agents to distrust the *whole* toolkit — including the parts that are reliably accurate — and route around them in favor of `Read`/`grep`. This replaces it with **three reliability tiers, each verified against `grep`/`Read` ground truth on this repo's real call/import patterns** (a controlled battery run this session; 3rd independent session affirming the tools).

## What was verified

**Trust as-is (CodeGraph accurate):**
- Symbol **definition** location + **signatures** (`where`/`context`), **structural listing** (`list_functions`), **complexity** (AST-local).

**Trust Grimp for imports/dependencies/blast-radius** (`scripts/context_map.py`):
- Verified **complete including lazy/function-body imports** — `utils/role_feasibility.py` → *all 6* importers, incl. the 3 body-import callers CodeGraph's call graph misses.

**Grep-verify every time — the bare-token rule:**
- CodeGraph resolves a call edge only for **bare-name** calls `foo(...)`; it misses `module.foo(...)`, indirect/variable, and decorator/registry-dispatched calls — which SuperBot uses pervasively. Evidence: `collect_setup_diagnostics` (4 real callers → `callers: []`), `apply_operations` (2 → `[]`), `node_roles(setup_diagnostics.py)` → 13 `dead-unresolved`, **all 13 live**. This is why CodeGraph's own caller coverage reads ~20%.

**New rule — invisible to *both* tools (read source / grep the wiring):**
- EventBus `emit`→`bus.on`, `REGISTRY` callback fields, `interaction_router`, `getattr` dispatch. Verified with `audit.action_recorded`: emitted by `audit_events.emit_audit_action`, consumed by `server_logging._on_audit_action` via `bus.on(...)`, and `server_logging` does **not** import `audit_events` — so no tool connects emitter→subscriber.

Keeps the three verified-true caveats (`dead-unresolved` ~100% false-positive, name-collision merges, decorator entry points).

## Scope / safety

- Docs-only (`.claude/CLAUDE.md`). No code, no test, no behavior change.
- `check_docs` green. No test/script pins the edited section text or its `CODEGRAPH_*` markers.
- **Maintainer-approved** (chose "Apply the full rewrite"). Split from the merged PR #571 (setup diagnostics & repair) because that PR merged mid-edit — this is a separate change.

https://claude.ai/code/session_017QJVjLQcH8P1ox6kAWhy3n

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJVjLQcH8P1ox6kAWhy3n)_