### PR TITLE
docs(CLAUDE): bump CodeGraph pin 3.10.0 → 3.11.2 (tiers re-verified)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -161,7 +161,7 @@ CI runs **Python 3.10** (`.github/workflows/code-quality.yml`). Running formatte
 
 CodeGraph is a tree-sitter-parsed knowledge graph of every symbol, edge, and file. **Full reference: `docs/codegraph-usage.md`.**
 
-MCP startup: pinned via `npx -y @optave/codegraph@3.10.0 mcp` — no global install required. Build/rebuild index: `npx -y @optave/codegraph@3.10.0 build .` from the project root.
+MCP startup: pinned via `npx -y @optave/codegraph@3.11.2 mcp` — no global install required. Build/rebuild index: `npx -y @optave/codegraph@3.11.2 build .` from the project root. (Bumped 3.10.0 → 3.11.2 on 2026-06-08: 3.11.x fixes duplicate `calls`-edge over-counting and restores receiver/inheritance edges — +25 edges, same 31505 nodes on this repo. The CodeGraph reliability guidance below was **re-verified unchanged** on a 3.11.2 index: the bare-token / `dead-unresolved` behaviour is byte-identical, so the trust tiers still hold. The **runtime MCP server version is env-managed** by the SessionStart hook — this pin documents the target; confirm the environment's MCP config matches.)
 
 ### Use automatically — no prompt required
 


### PR DESCRIPTION
## What & why

Bumps the documented CodeGraph pin **3.10.0 → 3.11.2** (latest). You'd noticed upstream updates — 3.11.0/.1/.2 all shipped since our 3.10.0 pin.

## Verified, not assumed

- **Changelog** (3.11.2): fixes duplicate `calls`-edge over-counting on watch rebuilds and **restores receiver/extends/implements edges**. It does **not** change module-qualified call resolution or `dead-unresolved` classification.
- **Build validation**: a 3.11.2 build of this repo is clean — **31505 nodes (unchanged), 56065 edges vs 3.10.0's 56040** (+25 receiver/inheritance edges, consistent with the changelog).
- **Reliability tiers re-verified**: re-ran the battery against a throwaway 3.11.2 index (`--db /tmp/...`, no clobber of the live one):
  - `apply_operations` → still `[dead-unresolved]`, no resolved callers (its 2 body-import callers still missed).
  - `collect_setup_diagnostics` → still `[dead-unresolved, 0 callers]` (its 4 module-qualified callers still missed).
  - bare-name same-file calls still resolve (`_clear_binding_op [2 callers]`, `_binding_section [2 callers]`).
  - **Byte-identical** to 3.10.0 → the bare-token rule and `dead-unresolved` FP from the trust tiers (#572) hold on 3.11.2.

## Important caveat (needs your env-side action)

The **runtime MCP server version is env-managed** by the SessionStart hook, not the repo — the repo only *documents* the pin (CLAUDE.md). This PR updates that documentation to the target (3.11.2); **the environment's MCP/SessionStart config still needs the matching change on your side** for the running server to actually move to 3.11.2. The CLAUDE.md note says so explicitly.

## Scope

Docs-only (`.claude/CLAUDE.md`, one line). No code, no behavior change. `check_docs` green. Stacks cleanly with #572 (different region of the file).

https://claude.ai/code/session_017QJVjLQcH8P1ox6kAWhy3n

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJVjLQcH8P1ox6kAWhy3n)_