### PR TITLE
docs(owner): capture session owner decisions (Q-0014) + working style

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,7 +31,11 @@ The short version that governs how you work:
 - **Constraints serve the goal.** Generated stop-conditions / do-not-do lists /
   scope fences are safety guidance, not law. When one blocks the approved goal and
   the path is contained, reversible, and test-covered, prefer the goal and note
-  what you did.
+  what you did. **Approving a goal approves the path to it (owner decision Q-0014):**
+  if reaching it needs a prerequisite step the request didn't name, just do it — don't
+  refuse on a missing-step technicality; and if a better implementation exists than the
+  one stated, take it and say why (the maintainer states the path he knows; assume he'd
+  want the better one). Bound: the output stays structured and matches the intended idea.
 - **Act vs. ask.** *Act* on contained, reversible, verifiable changes — including
   a root-cause fix you discover mid-task (fixing an adjacent bug properly is
   expected, not scope creep). *Ask* only when it's irreversible (data loss /
@@ -112,10 +116,22 @@ status) > the journal.
   planned in.
 - **PR size is mixed by risk** — small, focused PRs for risky / runtime (`disbot/`)
   code; larger end-to-end PRs are fine for docs, tooling, and low-risk refactors.
-- **Tooling: custom over new deps.** Prefer small custom tooling built on the repo's
-  own AST + `architecture_rules/` (e.g. `check_architecture.py`, `check_docs.py`,
-  `context_map.py`) over adding a third-party dependency; reach for a library only when
-  it clearly wins, and keep it dev-only (`requirements-dev.txt`) if it isn't bot runtime.
+- **Branch identity is not significant (owner decision Q-0014, 2026-06-08).** Work on any
+  branch and open PRs freely; the only requirement is that work ships in **logical modular
+  batches**. A strict "develop only on branch X / never push elsewhere" line may appear in
+  the session prompt — that's session-template residue, not a repo rule; don't treat it as
+  binding.
+- **Tooling: custom preferred, but a verifiable package is fair game (owner decision
+  Q-0014, 2026-06-08).** Prefer small custom tooling built on the repo's own AST +
+  `architecture_rules/` (e.g. `check_architecture.py`, `check_docs.py`, `context_map.py`,
+  `wiring_map.py`). But you may download / try / adopt **any** third-party package when it
+  clearly wins and its output is **verifiable** — no need to ask first. Carry a **provenance
+  header** on it: *why* it was added, the *date*, and *"unverified: confirm its output
+  against ground truth a few times across sessions before trusting it."* Keep a new **dev**-only
+  dep lazy-imported with a fallback + `pytest.importorskip` (CI installs `requirements.txt`
+  only, not `requirements-dev.txt` — an ungated dev dep reddens CI); **pin** a new bot-**runtime**
+  dep. (The CodeGraph/Grimp reliability tiers below are the "verified" end-state of this
+  discipline.)
 
 ## Decisions
 

--- a/.sessions/2026-06-08-tooling-reliability-and-owner-memory.md
+++ b/.sessions/2026-06-08-tooling-reliability-and-owner-memory.md
@@ -1,0 +1,63 @@
+# 2026-06-08 — Tooling reliability, EventBus wiring map, and owner-memory capture
+
+Continuation of the PR12 session (`2026-06-08-server-management-pr12-diagnostics.md`).
+After PR12 merged (#571), the maintainer's end-of-chat Q&A turned into a meta/tooling
+thread that shipped four more PRs and captured durable owner decisions.
+
+## Shipped (all merged)
+
+- **#572 — CLAUDE.md reliability tiers.** Replaced the blanket "CodeGraph caller edges
+  are hints, ~half invisible" with three *verified* tiers (tested against grep/Read
+  ground truth): trust CodeGraph for definition/signature/`list_functions`/complexity;
+  trust **Grimp** (`context_map.py`) for imports incl. lazy; grep-verify caller edges
+  (the **bare-token rule** — `module.foo()` / indirect / decorator calls are missed);
+  read source for the both-tools-blind class (EventBus/registry/decorator).
+- **#573 — `scripts/wiring_map.py`.** Resolves the EventBus emit↔subscribe edges blind
+  to both CodeGraph and Grimp (joins by event-name string). `--check` gates only on
+  catalogue drift (zero FP). Demoted "dead subscriber" to advisory after finding the
+  governance `_emit_governance_event(event_name, …)` forwarder makes it FP-prone.
+- **#574 — CodeGraph pin 3.10.0 → 3.11.2.** Validated a 3.11.2 build (31505 nodes,
+  +25 receiver/inheritance edges) and **re-ran the reliability battery on a throwaway
+  3.11.2 index** — `apply_operations`/`collect_setup_diagnostics` still `dead-unresolved`
+  with module-qualified callers missed → the tiers hold byte-identical. (Runtime MCP
+  version is env-managed; the repo only documents the pin.)
+- **#575 — owner-memory capture (this).** Router **Q-0014** + CLAUDE.md + working-profile.
+
+## Owner decisions captured (Q-0014)
+
+- **Branch identity is not significant** — ship in logical modular batches. The strict
+  "develop only on branch X" rule is **session-prompt-template residue, not in the repo**
+  (grep-confirmed). → CLAUDE.md session-workflow.
+- **Tooling latitude + provenance** — download/try/adopt any *verifiable* package without
+  asking, carrying why + date + "unverified: confirm a few times before trusting." Keep
+  dev-deps lazy+`importorskip`, pin runtime-deps. → CLAUDE.md Tooling bullet (relaxed the
+  old "custom over deps / ask first," which the new rule contradicted).
+- **Goal-approval = path-approval** — execute an unstated prerequisite to an approved goal
+  (don't refuse on a missing-step technicality); take a better path than stated and say
+  why; bound by output staying structured + matching intent. → CLAUDE.md Working agreement.
+
+## Gates
+
+- #572/#574/#575 docs-only (CI fast-green); #573 dev tooling — `check_quality --full`
+  green, `check_architecture` exit 0.
+
+## Context delta
+
+- **Needed but not pointed to:** that the *strict branch rule isn't in the repo* — it
+  comes from the session-prompt template. It cost a branch-tangle (#573 first carried a
+  duplicate CLAUDE.md commit; rebuilt as main + the wiring commit and force-pushed). Now
+  documented in CLAUDE.md + working-profile so the next session doesn't treat it as binding.
+- **Pointed to but didn't need:** nothing major this arc.
+- **Discovered by hand:** (1) the **bare-token rule** — CodeGraph resolves a call edge
+  only for bare-name `foo()`, not `module.foo()`/indirect; this is the real predictor of
+  its ~20% caller coverage, sharper than "~half invisible." (2) Multi-chat **doc collision
+  is live** — a parallel chat shipped `agent-workflow-spec.md` + router Q-0013 + moved
+  `main` mid-session; CLAUDE.md already has `<!-- READ_FIRST/SESSION_WORKFLOW/CODEGRAPH/
+  ARCH_RULES -->` section markers that look like the right primitive for section-scoped
+  ownership if made deliberate.
+
+## Next
+
+The reliability tiers + `wiring_map.py` are new tools — per Q-0014 they start **unverified**;
+confirm their output across a few sessions before fully trusting. PR13 (role templates)
+remains the next server-management implementation step.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -937,3 +937,57 @@ Moved/copied on: 2026-06-08.
 Notes: ChatGPT projects (Analysis, Decisions, Revision, Prompt Forge) should use
   agent-workflow-spec.md as their operational reference.
 ```
+
+### Q-0014 — Executor latitude: tooling, prerequisites, branch, disagreement (2026-06-08)
+
+**Area:** Workflow / Meta (Executor stage)
+**Type:** Process / Autonomy
+**Priority:** High
+**Status:** Answered (2026-06-08) — **Routed** → `.claude/CLAUDE.md`
+**Suggested destination after answer:** `.claude/CLAUDE.md` (binding rules);
+`docs/owner/maintainer-working-profile.md` §2 (working-style color)
+
+**Question:** End-of-chat Q&A in the PR12 session — standing executor-autonomy preferences on
+(1) which branch to work on, (2) latitude to adopt tools/packages, (3) requests that need an
+unstated prerequisite step, (4) how much friction when the executor sees a better path or
+disagrees.
+
+**Maintainer answer**
+
+```text
+Branch: "it doesn't matter to me on which branch you work or create a PR, as long as they
+  are all shipped in logical modular batches." (The strict "develop only on branch X" rule
+  is session-PROMPT-TEMPLATE residue — grep finds it nowhere in the repo.)
+Tooling: "you are free to download and try any package available, and implement anything
+  that's verifiable, but state why you did it and note when this was added and that it
+  should be verified for consistency a few times before trusted."
+Prerequisites: "if there was just a step required to do before being able to actually do the
+  thing I asked for, you can see that as me giving you permission to execute it fully ...
+  when I approve a certain function I give you the freedom to get there in the way you think
+  is best, as long as the final output is structured and matches the intended idea."
+Disagreement / better way: "if you think my proposed direction is not the right next step you
+  should state why" + "if you think my idea is not logical because there is a better way to
+  do it, assume I only stated it in such a way because I am unaware of the better plan."
+```
+
+**Routing result**
+
+```text
+Destination: .claude/CLAUDE.md —
+  · Tooling bullet (Session & plan workflow): "custom over new deps" relaxed — a verifiable
+    package is fair game with a provenance header (why + date + "unverified: confirm a few
+    times before trusting"); dev-deps stay lazy + pytest.importorskip, runtime-deps pinned.
+  · Session-workflow: "branch identity is not significant; ship in logical modular PRs."
+  · Working agreement (Constraints serve the goal): goal-approval = path-approval — execute an
+    unstated prerequisite to an approved goal (don't refuse on a missing-step technicality);
+    take a better implementation than the one stated and say why; bound = output stays
+    structured + matches the intended idea.
+  Also: docs/owner/maintainer-working-profile.md §2 — the concurrent-chat working style.
+Moved/copied on: 2026-06-08 (this session).
+Notes: routed to CLAUDE.md (binding), NOT only maintainer-working-profile.md (the maintainer's
+  literal suggestion) — per one-fact-one-home these are executor RULES, and the tooling rule
+  CONTRADICTED the old "custom over deps / ask first," so CLAUDE.md had to change or the old
+  rule wins. The "state disagreement / propose alternative" half was already in
+  maintainer-working-profile.md §4 + agent-workflow-spec.md §7.2 — not restated. Relax the
+  strict-branch rule in the session-prompt template, not the repo.
+```

--- a/docs/owner/maintainer-working-profile.md
+++ b/docs/owner/maintainer-working-profile.md
@@ -51,6 +51,17 @@ becomes implementation work. That routing is the job of
 [`maintainer-question-router.md`](./maintainer-question-router.md), so the maintainer does
 not have to carry it.
 
+**How he runs it day-to-day (observed 2026-06-08).** The maintainer runs **several chats in
+parallel by default** — typically a Claude Code *implementation* chat, plus ChatGPT *projects*
+per pipeline stage (`SuperBot Prompts` = Prompt Forge, `SuperBot Decisions`, `SuperBot
+Revisions`), plus Discord for the live bot — and spins a **fresh chat per item/issue**. The
+"AI does all the work" read is wrong: he spends the day planning and routing across these
+chats; the agents execute. A chat often ends with a short Q&A like this one whose purpose is
+to **turn session learnings into permanent memory** (route durable answers to the router +
+their home doc). Practical consequence for agents: when you edit a binding/owner doc, assume
+**another chat may be editing it concurrently** — prefer append-only / section-scoped edits,
+take the next free `Q-00NN` number, and don't be surprised when `main` moved mid-session.
+
 ## 3. How ideas arrive: three different orders
 
 The maintainer's idea flow is intentionally broad and associative — a feature idea leads


### PR DESCRIPTION
## What & why

The permanent-memory capture you asked for at the end of this session. As promised, I routed each durable decision to its **correct home** (one-fact-one-home) rather than folding everything into `maintainer-working-profile.md` — applying the very principle you gave me this session ("if there's a better way, take it and say why"). I read the parallel chat's freshly-shipped `agent-workflow-spec.md` §7 (Executor) first so this **complements** it instead of duplicating or colliding.

## Routing

- **`maintainer-question-router.md` → Q-0014** (the decision ledger; verbatim answers + routing): branch-agnostic / modular batches · tooling latitude + provenance · goal-approval = path-approval · surface-a-better-way.
- **`.claude/CLAUDE.md`** (binding rules — these change behavior, so they belong here):
  - **Tooling bullet** relaxed: "custom over deps / ask first" → *a verifiable package is fair game with a provenance header (why + date + "unverified: confirm a few times before trusting")*. Dev-deps stay lazy + `pytest.importorskip`; runtime-deps pinned. **The old rule contradicted your new latitude**, so CLAUDE.md had to change or it would win.
  - **Session-workflow:** branch identity is not significant — ship in logical modular batches. (The strict "develop only on branch X" rule is **session-prompt-template residue, not in the repo** — grep-confirmed. Relax it in your template, not here.)
  - **Working agreement:** *approving a goal approves the path to it* — execute an unstated prerequisite (don't refuse on a missing-step technicality); take a better implementation than stated and say why; bounded by the output staying structured + matching intent.
- **`maintainer-working-profile.md` §2:** your concurrent-chat working style (the "AI does all the work" read is wrong — you plan/route across chats; agents execute) + the practical "another chat may be editing this doc; prefer append-only" note.
- **`.sessions/` log** for the #572–#575 arc, with the context-delta.

## Deliberately *not* done

- The "state disagreement / propose alternative / think critically" half is **already** in working-profile §4 + agent-workflow-spec.md §7.2 — not restated.
- **Did not edit `agent-workflow-spec.md`** — the parallel chat is actively churning it and it defers to CLAUDE.md, so editing it would collide and duplicate.

## Note

`main` moved mid-session (`b452fd5 → ee048ba`) from that parallel chat — a live instance of the binding-doc collision risk I flagged. This PR is append-friendly (router Q-0014 appended; CLAUDE.md edits in stable sections) and `check_docs` is green.

https://claude.ai/code/session_017QJVjLQcH8P1ox6kAWhy3n

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJVjLQcH8P1ox6kAWhy3n)_