### PR TITLE
docs: fix stale roadmap (PR10 done) + docs-restructure next-session brief

### DIFF
--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -105,7 +105,9 @@ Source code and merged PRs win over anything written here.
   dedicated docs session shrinks the top-level `docs/` pile (41 → ~15) by moving
   plans / audits / historical snapshots into subdirs behind the folios, then lowers the
   `_TOP_LEVEL_DOCS_BUDGET` ratchet in `scripts/check_docs.py`. The census prints the live
-  count every run; the ratchet holds the line until then.
+  count every run; the ratchet holds the line until then. **Ready-to-pick handoff:**
+  [`planning/docs-restructure-brief-2026-06-08.md`](planning/docs-restructure-brief-2026-06-08.md)
+  (also covers binding-doc section-ownership to make concurrent-chat edits collision-safe).
 - Use the canonical subsystem folios for area-specific implementation/planning. The
   2026-06-06 readiness audit classifies stale, gated, and ready workstreams.
 

--- a/docs/planning/docs-restructure-brief-2026-06-08.md
+++ b/docs/planning/docs-restructure-brief-2026-06-08.md
@@ -1,0 +1,74 @@
+# Docs restructure — next-session brief (2026-06-08)
+
+> **Status:** `plan` — a focused, ready-to-pick handoff for a dedicated docs-restructure
+> session. Owner-approved direction: **Q-0010** (router) + this session's binding-doc
+> collision finding. **Source / merged PRs win;** this is scope, not approval to change
+> behavior. It's a **meta-task that can run in parallel** with the implementation lane
+> (PR13) — a different chat can take it.
+
+## Why now
+
+Two pressures converged this session:
+
+1. **Top-level `docs/` is too big** (owner decision **Q-0010**, 2026-06-07). The
+   `scripts/check_docs.py` census reports ~41 top-level `docs/*.md`; the agreed target is
+   **~15**. The rest are plans / audits / dated snapshots that belong in subdirs behind
+   their **folios** (`docs/subsystems/*`).
+2. **Binding-doc edits collide across concurrent chats** (observed 2026-06-08). `main`
+   moved mid-session and two chats edited `CLAUDE.md` / the owner docs at once (one shipped
+   `agent-workflow-spec.md` + router Q-0013 while this chat was mid-flight). `.sessions/`
+   already solved this class for the journal (per-file, no shared anchor); the binding
+   docs need the same treatment.
+
+## Goal
+
+Make the docs **navigable + multi-chat-safe** without losing content or breaking the gates.
+
+## Tasks (ordered)
+
+1. **Shrink top-level `docs/` 41 → ~15.** Move plans / audits / dated snapshots into
+   subdirs (`docs/planning/`, `docs/audits/`, `docs/archive/`, or behind a subsystem
+   folio). Every moved doc must stay **reachable** — `check_docs.py`'s reachability gate
+   fails an orphan unless it's badged `historical` / `archive` — so update the linking
+   folio and the `AGENT_ORIENTATION.md` route as you move. Then **lower
+   `_TOP_LEVEL_DOCS_BUDGET`** in `scripts/check_docs.py` to the new count so the ratchet
+   holds the line.
+2. **Make binding-doc edits section-scoped (multi-chat safety).** `CLAUDE.md` already
+   carries `<!-- READ_FIRST/SESSION_WORKFLOW/CODEGRAPH/ARCH_RULES -->` markers — formalize
+   them as **section ownership** so a chat edits one block and two chats touching different
+   blocks never conflict. Document the convention (a short note in `CLAUDE.md` or
+   `docs/owner/`), and confirm the two existing collision-safe patterns are stated: the
+   **router is append-only** (next free `Q-00NN`), and `.sessions/` is **per-file**.
+   Consider the same marker treatment for other frequently co-edited shared docs
+   (`current-state.md`, the journal guidebook).
+3. **Verify the reading route after moves.** `AGENT_ORIENTATION.md` "Reading order by task"
+   and the folios must still resolve to the **moved** paths. Wire in
+   `docs/owner/agent-workflow-spec.md` (the pipeline-stage spec) if a route still points
+   only at the older owner docs.
+4. **Keep the gates green.** `check_docs.py` — census count drops, reachability passes, the
+   freshness `(pending PR)` gate is clean — and no dead links anywhere.
+
+## Constraints
+
+- **One-fact-one-home** — move + link, never duplicate. Source / merged PRs win over any doc.
+- **Don't break** the `check_docs.py` reachability + freshness gates; only lower the docs
+  budget to match the new reality.
+- **Coordinate** with concurrent chats on binding docs — prefer append-only / section-scoped
+  edits; expect `main` to move under you.
+- **Docs-only** — no behavior change, no code, no other gate-rule loosening.
+
+## Done when
+
+- Top-level `docs/*.md` ≈ 15; census + `_TOP_LEVEL_DOCS_BUDGET` updated; reachability green.
+- The binding-doc section-ownership convention is documented.
+- `AGENT_ORIENTATION.md` + the folios resolve to the new layout (no dead links).
+
+## Authoritative context to read first
+
+- `docs/owner/maintainer-question-router.md` **Q-0010** (the consolidation decision) and
+  **Q-0014** (branch/tooling/path latitude — relevant if you add tooling).
+- `scripts/check_docs.py` — the census, the `_TOP_LEVEL_DOCS_BUDGET` ratchet, and the
+  reachability + freshness gates you must keep green.
+- `docs/AGENT_ORIENTATION.md` — the reading route to keep correct.
+- `.sessions/2026-06-08-tooling-reliability-and-owner-memory.md` — the collision finding +
+  the `CLAUDE.md` section markers that motivate task 2.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,8 +30,8 @@
 
 | Horizon | Items |
 |---|---|
-| **Now** | Server-management remaining PR10 · health/diagnostics production live-tests (owed) |
-| **Next** | Setup-wizard finalization · Discord-native interface completion · settings consistency coverage |
+| **Now** | Server-management **PR13** (role templates; PR10–PR12 shipped) · health/diagnostics production live-tests (owed) · [docs restructure (Q-0010)](planning/docs-restructure-brief-2026-06-08.md) |
+| **Next** | Server-Management Hub (PR14) · deferred governance setup section · Discord-native interface completion · settings consistency coverage |
 | **Later** | AI expansion (gated) · BTD6 extraction (ADR-006) · media channel-summary (privacy review) · games deferred follow-ups |
 | **Someday** | The ideas backlog — not approved (see [§Someday](#someday--ideas-not-approved--capture-only)) |
 
@@ -44,10 +44,11 @@
 Folio: [server-management](subsystems/server-management.md) · **authoritative sequence:**
 [status tracker](planning/server-management-status-2026-06-05.md)
 
-- **Now** — last **PR10** item: moderator/trusted roles + capabilities (capability-native
-  role→`moderator`-tier grant). (Post-action cleanup + optional public log shipped 2026-06-07.)
-- **Next** — setup role/moderation/governance convergence + repair sections → role
-  templates → the unified **Server Management Hub**.
+- **Now** — **PR13**: deterministic + AI role templates. (PR10 moderation config, PR11
+  moderation + roles setup sections, and PR12 setup diagnostics & repair all shipped; PR11's
+  governance setup section is deferred — owner decision Q-0008.)
+- **Next** — the unified **Server Management Hub** (PR14, last) → the deferred governance
+  setup section (capability overrides + command-access, Q-0011).
 - Plans (context, not sequence): [roadmap](planning/server-management-roadmap-2026-06-05.md)
   (target architecture) · [implementation-plan](planning/server-management-implementation-plan-2026-06-05.md)
   (PR scope; PR1–9 shipped).


### PR DESCRIPTION
## What & why

The docs-hygiene + handoff half of the end-of-session review.

### Stale-state fixes (server-management is well past PR10)

`docs/roadmap.md` still said server-management's **Now** was "remaining PR10" — but PR10 (moderation config), PR11 (moderation + roles setup sections), and PR12 (setup diagnostics & repair) all shipped. Your ChatGPT *PR Analysis* chat flagged this exact drift. Fixed both spots:
- **At-a-glance "Now":** "remaining PR10" → **PR13** (role templates), with a link to the restructure brief.
- **By-area server-management:** "last PR10 item" / "repair sections as Next" → **PR13 now**, Hub (PR14) + the deferred governance section next.

### New: docs-restructure next-session brief

`docs/planning/docs-restructure-brief-2026-06-08.md` — a **ready-to-pick handoff** for the scheduled docs-restructure meta-task you asked me to set up. It's owner-approved direction (**Q-0010**) plus this session's binding-doc collision finding, and it's a meta-task that can run **in parallel** with PR13 (a different chat can take it). Two ordered goals:
1. **Shrink top-level `docs/` 41 → ~15** behind the folios + lower the `_TOP_LEVEL_DOCS_BUDGET` ratchet (keeping the reachability gate green).
2. **Formalize the `CLAUDE.md` `<!-- … -->` section markers as section ownership** so concurrent-chat edits to binding docs stop colliding — which happened live this session (`main` moved under me; two chats edited `CLAUDE.md`/owner docs at once). `.sessions/` already solved this for the journal; the binding docs need the same.

Linked from `current-state.md` (Q-0010 bullet) and the roadmap so the next session finds it.

## Scope

Docs-only. `check_docs` green (the new brief is reachable; plan-badge count 15 → 16). No behavior change.

https://claude.ai/code/session_017QJVjLQcH8P1ox6kAWhy3n

---
_Generated by [Claude Code](https://claude.ai/code/session_017QJVjLQcH8P1ox6kAWhy3n)_