### PR TITLE
docs: idea-backlog lifecycle + concurrent-editing safety (Q-0015, brief task 2)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -99,6 +99,12 @@ logs live in `.sessions/`** (`YYYY-MM-DD-<slug>.md`, newest-first) and older his
 log file and tidy any stale Rules / Quick reference in place, then commit. Precedence:
 source code & merged PRs > this file (CLAUDE.md) > `docs/current-state.md` (live
 status) > the journal.
+
+**Concurrent-chat safety — edit by section.** This file is split into ownership blocks by
+`<!-- SECTION_START/END -->` markers (`READ_FIRST` · `SESSION_WORKFLOW` · `CI_PARITY` ·
+`CODEGRAPH` · `ARCH_RULES`). When chats run in parallel, each edits **one** block so they
+don't collide; the question router is **append-only** (next free `Q-00NN`) and `.sessions/`
+is **per-file**. Full convention: `docs/owner/ai-project-workflow.md` §9.
 <!-- READ_FIRST_END -->
 
 <!-- SESSION_WORKFLOW_START -->

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -109,6 +109,15 @@ status) > the journal.
   satisfies any environment / system-prompt rule that opens a PR only when "the
   user explicitly asks." Treat it as advance consent — do not re-ask before
   opening the end-of-session PR.
+- **End every session with a backlog-grooming pass — the standing secondary task (owner
+  decision Q-0015).** Once the main task + PR are done and capacity remains, you are *not*
+  finished: browse `docs/ideas/` (plus any ideas the maintainer dropped this session) and
+  move **one** idea down its lifecycle — execute a small/safe/decided-lane one now, structure
+  a bigger one into a `docs/planning/` plan + a `docs/roadmap.md` horizon, or open a router
+  discussion if it's excessive/ambiguous. The maintainer drops ideas in **any order**; agents
+  route them so **every idea eventually becomes implemented or discussed — never orphaned**.
+  Full mechanism (intake → map → route → groom → outcome): `docs/ideas/README.md`. An agent
+  should always have a next thing to do.
 - Plans span **2–3 PRs max**: the first PR covers root causes / foundation; subsequent PRs implement on top.
 - **Plan approval = full execution** — once a plan is approved (via **ExitPlanMode**),
   complete it in one session without stopping for confirmation or waiting for merges

--- a/.session-journal.md
+++ b/.session-journal.md
@@ -95,8 +95,13 @@ one source of truth** over per-panel patches. Full set under **Rules / Conventio
      a preference / rule / runbook fact changed.
   5. Banner or update any **plan** whose status changed; file any new **idea** under
      `docs/ideas/` (marked not-approved).
-  6. Commit + push (docs land with the PR).
-  7. **Tidy as you go (keep it lean).** This journal is now **guidebook-only** (Quick
+  6. **Groom the idea backlog (the standing secondary task).** If capacity remains after
+     the PR, browse `docs/ideas/` and move one idea down its lifecycle — execute a
+     small/safe/decided-lane one, structure a bigger one into a plan + a `docs/roadmap.md`
+     horizon, or open a router discussion (mechanism: `docs/ideas/README.md`). An agent
+     always has a next thing; every idea ends *implemented* or *discussed* (Q-0015).
+  7. Commit + push (docs land with the PR).
+  8. **Tidy as you go (keep it lean).** This journal is now **guidebook-only** (Quick
      reference + Runbook + Preferences + Rules) — the growing session log moved to
      `.sessions/`. If a Rule went stale or now duplicates the Runbook, fix/merge it **in
      place**; refresh the **⚡ Quick reference** if a boot/CI fact changed. Leave the

--- a/.sessions/2026-06-08-docs-consolidation-and-idea-lifecycle.md
+++ b/.sessions/2026-06-08-docs-consolidation-and-idea-lifecycle.md
@@ -1,0 +1,68 @@
+# 2026-06-08 — Docs consolidation (Q-0010) + idea-backlog lifecycle (Q-0015)
+
+## Arc
+
+Started as a recon/assessment request: map the doc structure against the repo, verify every
+tool works, and judge whether the system is complete enough to run a long, low-supervision
+plan→build→review loop — **before** changing anything. Reported back, then the maintainer
+clarified the real goal twice (see Q-0015) and greenlit execution. Turned into the scheduled
+Q-0010 docs restructure **plus** the idea-lifecycle productivity layer.
+
+**Key reframe (Q-0015):** the goal is **not** full autonomy — the human-verification +
+multi-agent-revision gates are deliberate (keeps it manageable/reviewable). The goal is
+**productivity-per-step + role clarity**, and a **continuous idea conveyor**: random intake →
+map → route (roadmap horizon / plan / discuss-if-excessive) → groom → every idea ends
+implemented or discussed. Grooming the backlog is the standing **end-of-session secondary
+task** so an agent always has a next thing to do. (An earlier draft of this session proposed
+an "unmonitored self-approval mode" — explicitly dropped per the maintainer's clarification.)
+
+## Shipped
+
+- **#579 — restructure.** Top-level `docs/` 41 → 16. Plans/audits/inventories/historical
+  moved into clustered subdirs (`docs/ai/`, `docs/setup-platform/`, `docs/health/`) + type
+  buckets, behind their folios (+ cluster READMEs). All inbound refs rewired (folios,
+  `AGENT_ORIENTATION`, `roadmap`, `repo-navigation-map`, `context-map-overrides.yml`, 7
+  doc-pinning tests, disbot/ comment pointers). `_TOP_LEVEL_DOCS_BUDGET` 41 → 16.
+- **Workflow PR (this batch, 2 commits)** — stacked on #579:
+  - **Idea-backlog lifecycle (Q-0015):** rewrote `docs/ideas/README.md` as intake → map →
+    route → groom → outcome + the no-orphan guarantee; wired the grooming secondary task into
+    `agent-workflow-spec.md` §7.6, the journal END protocol, `collaboration-model.md`,
+    `ai-project-workflow.md` §4, `roadmap.md`, and a CLAUDE.md pointer. Captured Q-0015 in the
+    router (verbatim).
+  - **Concurrent-editing safety + self-review + housekeeping:** documented binding-doc
+    **section-ownership** (`ai-project-workflow.md` §9 + a CLAUDE.md pointer) so parallel chats
+    don't collide; added a self-review checkpoint (`agent-workflow-spec.md` §7.7); refreshed
+    `current-state.md`; this log.
+
+## Gates
+
+All green at each step: `check_docs.py --strict` (census 16 / ratchet 16; reachability +
+links + pinned + freshness), `check_architecture.py --mode strict` (exit 0),
+`check_quality.py --full` (7960 passed, 16 skipped — run after the disbot/ comment-pointer
+edits in #579). The workflow PR is docs-only (CI fast-path).
+
+## Context delta
+
+- **Needed but not pointed to:** that a docs *move* is not link-rewiring alone — **7 of the
+  26 movable docs were pinned by tests and/or `context-map-overrides.yml`**, and ~13 had stale
+  pointers in `disbot/` comments. Nothing in orientation flagged this; I found it by grepping
+  tests/disbot and running the suite. Worth a one-liner in the restructure playbook: *moving a
+  doc may also touch `tests/unit/docs/*` path constants, `context-map-overrides.yml`, and
+  `disbot/` comment references — the gates (`check_docs --strict` + full suite) are the catch-net.*
+- **Pointed to but didn't need:** the deep binding contracts (`architecture` / `ownership` /
+  `runtime_contracts`) — correctly, the orientation says read them only when the task touches
+  them, and a docs-only session doesn't.
+- **Discovered by hand:** (1) a literal `docs/X.md` rewrite covers backtick refs + test string
+  paths + the override YAML, but **markdown relative links** (`](name.md)`, `](../x.md)`) and
+  **`_DOCS / "name.md"` test constants** need separate handling — `check_docs --strict` + the
+  doc-pinning tests reliably flag the remainder. (2) `check_docs` reachability follows **both**
+  markdown links and backtick `docs/X.md` refs, so updating a folio's link is enough to keep a
+  moved doc reachable.
+
+## Next
+
+- Reconcile `current-state.md` "Recently shipped" once #579 + the workflow PR merge (this
+  session can't name them as merged — freshness gate).
+- Server-management **PR13** (role templates) remains the next *implementation* lane.
+- First grooming candidates live in `docs/ideas/` (`future-product-direction`,
+  `ai-extra-tool-capability-ideas`) — now routable via the new lifecycle.

--- a/docs/collaboration-model.md
+++ b/docs/collaboration-model.md
@@ -104,6 +104,14 @@ shared memory, the system converges on *exactly the right context per task*.
   building. The multi-agent pipeline that moves ideas → shipped is
   `docs/owner/ai-project-workflow.md` (per-project roles, handoff templates, idea states);
   the maintainer's working style is `docs/owner/maintainer-working-profile.md`.
+- **The idea backlog is a productive queue, not a graveyard (owner decision Q-0015).** The
+  maintainer drops ideas in *any order, any time*; agents capture them, **route** each to a
+  reasonable home (a `docs/roadmap.md` horizon, a structured plan, or — if it's
+  excessive/ambiguous — a discussion in the question router), and **groom** the backlog as
+  the standing end-of-session secondary task. The guarantee: an agent always has a next
+  thing to do, and **every idea eventually becomes implemented or discussed — never
+  orphaned**. The mechanism (intake → map → route → groom → outcome) is
+  `docs/ideas/README.md`.
 
 ## For executor agents (Claude)
 

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -19,10 +19,13 @@
 > (owner decision **Q-0008**). Authoritative scope + dependencies: the status tracker's
 > Remaining-queue.
 >
-> **Last updated:** 2026-06-08 · **Agent stage spec** (`docs/owner/agent-workflow-spec.md`)
-> created from a 60-question maintainer Q&A batch (Q-0013): operational spec for Analysis,
-> Decisions, Revision, Prompt Forge, and Executor stages. Wired into `AGENT_ORIENTATION.md`,
-> `docs/owner/README.md`, and `docs/owner/ai-project-workflow.md`. Docs-only.
+> **Last updated:** 2026-06-08 · **Docs consolidation (Q-0010) + idea-backlog lifecycle
+> (Q-0015).** Top-level `docs/` shrunk **41 → 16** (plans / audits / inventories / historical
+> moved into clustered subdirs — `docs/ai/`, `docs/setup-platform/`, `docs/health/` — and the
+> type buckets behind their folios; `_TOP_LEVEL_DOCS_BUDGET` lowered 41 → 16). The idea
+> backlog is now a routed **lifecycle + end-of-session grooming secondary task**
+> (`docs/ideas/README.md`); binding-doc **section-ownership** documented for concurrent
+> chats (`docs/owner/ai-project-workflow.md` §9). Docs-only; verify merge status on live GitHub.
 > Most recent merged code: server-management **PR12** (2026-06-07; setup diagnostics &
 > repair). **This file lists only _merged_ work + the ▶ Next action;** get
 > in-flight PRs from live GitHub (`list_pull_requests`) — naming an open PR's status in prose
@@ -101,13 +104,14 @@ Source code and merged PRs win over anything written here.
   queue — don't duplicate it here.
 - Health/diagnostics maintainer live-tests (production AI tool + grouped findings):
   see `docs/subsystems/health-diagnostics.md`.
-- **Docs consolidation (scheduled — owner decision Q-0010, 2026-06-07):** a near-term
-  dedicated docs session shrinks the top-level `docs/` pile (41 → ~15) by moving
-  plans / audits / historical snapshots into subdirs behind the folios, then lowers the
-  `_TOP_LEVEL_DOCS_BUDGET` ratchet in `scripts/check_docs.py`. The census prints the live
-  count every run; the ratchet holds the line until then. **Ready-to-pick handoff:**
-  [`planning/docs-restructure-brief-2026-06-08.md`](planning/docs-restructure-brief-2026-06-08.md)
-  (also covers binding-doc section-ownership to make concurrent-chat edits collision-safe).
+- **Docs consolidation (Q-0010) — executed 2026-06-08.** Top-level `docs/` is now **16**
+  (the 13 binding contracts + `current-state` + `roadmap` + `context-map-tooling`); plans /
+  audits / inventories / historical snapshots moved into clustered subdirs behind their
+  folios, and `_TOP_LEVEL_DOCS_BUDGET` lowered 41 → 16. Paired with the idea-backlog
+  lifecycle + grooming secondary task (Q-0015, `docs/ideas/README.md`) and the binding-doc
+  section-ownership convention (`docs/owner/ai-project-workflow.md` §9). The original handoff
+  was [`planning/docs-restructure-brief-2026-06-08.md`](planning/docs-restructure-brief-2026-06-08.md).
+  Verify merge status on live GitHub.
 - Use the canonical subsystem folios for area-specific implementation/planning. The
   2026-06-06 readiness audit classifies stale, gated, and ready workstreams.
 

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -1,8 +1,15 @@
-# docs/ideas — brainstorms (not approved)
+# docs/ideas — the idea backlog & lifecycle
 
 > **Status:** `ideas`. **Nothing here is approved for implementation.** These are
 > capture docs so ideas live in the repo instead of in chat. Source code, the
 > binding contracts, and `docs/current-state.md` always win over anything here.
+>
+> **This folder is a conveyor, not a graveyard.** The maintainer drops ideas in *any
+> order, any time*; agents capture them, route each to a reasonable home, and keep the
+> backlog moving so **every idea eventually becomes _implemented_ or _discussed_** (or
+> explicitly _rejected_). Grooming this backlog is also the standing **secondary task** —
+> what an agent does with leftover capacity once its main work + PR are done (see §
+> "Backlog grooming").
 
 ## What lives here
 
@@ -14,26 +21,47 @@ Current broad captures:
 - [`future-product-direction-2026-06-07.md`](./future-product-direction-2026-06-07.md) —
   source-aware future product direction across polish, extensions, reusable systems,
   and long-term expansions; capture-only, not a roadmap.
+- [`ai-extra-tool-capability-ideas.md`](./ai-extra-tool-capability-ideas.md) — AI
+  extra-tool capability backlog (capture only, not approved work).
+- [`mining_exploration_brainstorm.md`](./mining_exploration_brainstorm.md) — design-intent
+  for the mining subsystem, referenced by `disbot/cogs/mining/exploration.py`.
 
 Related idea-shaped docs that live elsewhere **by design**:
 
 - `docs/planning/superbot-ideas-lab-2026-06-05.md` — brainstorm backlog, **but** its
   §2 (operating decisions) and §6 (rejection ledger) are **binding** "do-not-propose"
   — so it stays in `planning/`, not here.
-- `docs/ideas/mining_exploration_brainstorm.md` — design-intent for the mining subsystem,
-  referenced by `disbot/cogs/mining/exploration.py` as design intent — stays in `docs/`.
 
-## Promotion path (idea → shipped)
+## The idea lifecycle
 
 ```text
-chat idea
-  → docs/ideas/<topic>.md                       (captured, not approved)
-  → reviewed concept summary
-  → approved implementation plan                (docs/planning/…)
-  → docs/current-state.md "Next candidates"     (active candidate)
-  → PR execution
-  → shipped  (current-state "Recently shipped" + a Session Log entry)
+(1) INTAKE      maintainer drops an idea, any time, any order
+      ↓         → capture it in docs/ideas/<topic>.md (state: raw → captured)
+(2) MAP         name the owning subsystem, rough size, rough risk
+      ↓
+(3) ROUTE       send it to ONE reasonable home:
+      ├─ small + safe + in an active lane → quick-win (execute now or next session)
+      ├─ clear direction, bigger          → structured plan in docs/planning/ + a
+      │                                      horizon on docs/roadmap.md (Now/Next/Later/Someday)
+      └─ excessive / ambiguous / product  → DISCUSS FIRST: a Q-block in
+                                             docs/owner/maintainer-question-router.md
+(4) GROOM       leftover-capacity work: pull one routable idea forward (see below)
+      ↓
+(5) OUTCOME     every idea ends as exactly one of:
+                implemented · on the roadmap at a horizon · in discussion (router) · rejected
 ```
+
+**Routing rule — never auto-promote.** An idea is *captured and routed*, not promoted to
+active work, unless the maintainer says so or it exposes a blocker / safety / architecture
+conflict (`.claude/CLAUDE.md` Working agreement; `docs/collaboration-model.md`). Routing
+just gives every idea a **state** and a **next destination** so none sits at `raw`.
+
+**"Discuss if excessive."** If an idea is large, ambiguous, or a product-vision call,
+the right route is a router Q-block — not silent promotion and not silent drop. The
+maintainer's answer then sends it back onto this lifecycle (roadmap horizon, plan, or the
+rejection ledger).
+
+## Promotion gates (idea → implementation plan)
 
 An idea may graduate to an implementation plan only after **all** of:
 
@@ -42,11 +70,30 @@ An idea may graduate to an implementation plan only after **all** of:
    duplicate systems (`docs/helper-policy.md`).
 3. **Risk review** — privacy, security/permissions, cost, and moderation risk reviewed.
 4. **Mechanics** — migration / cache / test / rollback needs are listed.
-5. **Promotion** — `docs/current-state.md` marks it an active candidate.
+5. **Promotion** — `docs/current-state.md` marks it an active candidate (and/or it lands
+   on `docs/roadmap.md` at a horizon).
 
 > **Idea-state vocabulary maps here.** The shared idea-states used across the AI projects
 > (`raw → captured → … → shipped`, see
 > [`../owner/ai-project-workflow.md`](../owner/ai-project-workflow.md) §5) are just words
-> for an idea's position on *this* promotion path plus the question-router lifecycle. This
-> README owns the `captured → ready-for-planning → shipped` gates; the workflow doc
-> references them — it does not define a parallel tracker.
+> for an idea's position on *this* lifecycle plus the question-router question-lifecycle.
+> This README owns the `captured → ready-for-planning → shipped` gates; the workflow doc
+> references them — it does **not** define a parallel tracker.
+
+## Backlog grooming (the standing secondary task)
+
+So an agent **always has a next thing to do** — and so the backlog actually drains — every
+session ends with a grooming pass once the main task + PR are done and capacity remains:
+
+1. **Browse** `docs/ideas/` (and any new ideas the maintainer dropped this session).
+2. **Pick one** routable idea and move it *one step* down the lifecycle:
+   - **Execute it now** if it is small, safe, reversible, and in an already-decided lane
+     (this is real work, not scope creep — `docs/collaboration-model.md` act-vs-ask).
+   - **Structure it into a plan** for the next agent (`docs/planning/…`) + place it on
+     `docs/roadmap.md` at a horizon, if the direction is clear but the work is bigger.
+   - **Open a discussion** (router Q-block) if it is excessive / ambiguous / a product call.
+3. **Record** the move: update the idea's state, and note the grooming in the `.sessions/`
+   log so the next agent sees the backlog is live.
+
+A **periodic sweep** (the `.session-journal.md` REVIEW cadence) confirms no idea is stuck
+at `raw`/`captured` with no destination — that is the no-orphan guarantee, made checkable.

--- a/docs/owner/agent-workflow-spec.md
+++ b/docs/owner/agent-workflow-spec.md
@@ -342,6 +342,23 @@ Prefer finishing one real improvement end-to-end over starting three and shippin
 scaffolding. You are trusted to do large, accurate work in one session — plan around
 that capacity, not around the smallest safe slice.
 
+### 7.6 End-of-session secondary task — groom the idea backlog
+
+Once the main task + PR are done and capacity remains, you are **not** finished. Spend the
+leftover capacity grooming the idea backlog so it keeps draining and you always have a next
+thing to do:
+
+- **Browse** `docs/ideas/` and any ideas the maintainer raised this session.
+- **Move one idea down its lifecycle** ([`../ideas/README.md`](../ideas/README.md)): execute
+  a small, safe, decided-lane idea now; structure a bigger one into a `docs/planning/` plan +
+  a `docs/roadmap.md` horizon; or open a discussion (router Q-block) if it is excessive,
+  ambiguous, or a product-vision call.
+- **Record** the move — the idea's state + a line in the `.sessions/` log.
+
+This is real work, not scope creep: the maintainer drops ideas in any order on purpose and
+relies on agents to route them so **every idea eventually becomes implemented or discussed,
+never orphaned** (owner decision Q-0015).
+
 ---
 
 ## 8. Cross-cutting rules (all stages)

--- a/docs/owner/agent-workflow-spec.md
+++ b/docs/owner/agent-workflow-spec.md
@@ -359,6 +359,20 @@ This is real work, not scope creep: the maintainer drops ideas in any order on p
 relies on agents to route them so **every idea eventually becomes implemented or discussed,
 never orphaned** (owner decision Q-0015).
 
+### 7.7 Review your own work before you hand off
+
+Before you open the PR (or hand to the next stage), do a quick self-review pass — the
+cheapest place to catch a problem:
+
+- **Re-read your own diff** for correctness, leftover scaffolding, and drift from the goal.
+  Run the gates: `check_quality.py --full` + `check_architecture.py --mode strict` for code;
+  `check_docs.py --strict` for docs.
+- **Verify, don't assume** — confirm a claim against source (and CodeGraph/Grimp against a
+  grep) rather than trusting a tool or a doc; the truth-layer precedence (§8.1) breaks ties.
+- **Improve what you touched** — once the context is loaded and clear, a small adjacent
+  cleanup or a sharper doc pointer is first-class work (§8.5), not scope creep. Leave the
+  area a little better than you found it.
+
 ---
 
 ## 8. Cross-cutting rules (all stages)

--- a/docs/owner/ai-project-workflow.md
+++ b/docs/owner/ai-project-workflow.md
@@ -160,3 +160,27 @@ Full usage, the trust matrix, and the override-file contract live in
 - **Load context in layers / one-fact-one-home** →
   [`../AGENT_ORIENTATION.md`](../AGENT_ORIENTATION.md) and `docs/current-state.md`.
 - **Idea → shipped promotion gates** → [`../ideas/README.md`](../ideas/README.md).
+
+## 9. Concurrent-editing safety (multiple chats at once)
+
+The maintainer runs several chats in parallel, and `main` can move under you mid-session.
+To keep that productive instead of collision-prone, the shared, frequently-co-edited files
+have **per-section / per-file ownership** so two chats touching different parts never
+conflict:
+
+| Shared file | Collision-safe pattern |
+|---|---|
+| `.claude/CLAUDE.md` | **Section ownership** via `<!-- SECTION_START/END -->` markers (`READ_FIRST` · `SESSION_WORKFLOW` · `CI_PARITY` · `CODEGRAPH` · `ARCH_RULES`). Edit **one** block; two chats in different blocks auto-merge. |
+| `docs/owner/maintainer-question-router.md` | **Append-only.** Add the next free `Q-00NN` block at the end; never renumber or reflow existing ones. |
+| `.sessions/` | **Per-file.** One `YYYY-MM-DD-<slug>.md` per session — no shared anchor, so no structural conflict. |
+| `.session-journal.md` (guidebook) · `docs/current-state.md` | Edit the **smallest** relevant block; on conflict resolve by **UNION** (keep both additions — it's docs, no CI risk). |
+
+Practical rules when several chats are live:
+
+- **Expect `main` to move.** Re-fetch before you push; prefer additive, section-scoped edits
+  over rewrites of a whole shared file.
+- **Ship in logical modular batches** (owner decision Q-0014) — small, self-contained PRs
+  merge around each other cleanly; a sprawling PR that touches every shared file is the one
+  that collides.
+- **One fact, one home.** Route a durable conclusion to its owning doc and link from the rest
+  — restatement across files is exactly what turns a clean merge into a conflict.

--- a/docs/owner/ai-project-workflow.md
+++ b/docs/owner/ai-project-workflow.md
@@ -92,6 +92,12 @@ new idea → classify → capture or ask a question → route to the right home
          → implement only after acceptance
 ```
 
+The full **idea lifecycle** (intake → map → route → groom → *implemented | discussed |
+rejected*) and the end-of-session **grooming** secondary task — what an agent does with
+leftover capacity so the backlog keeps draining — live in
+[`../ideas/README.md`](../ideas/README.md). This section is the pipeline-level view of the
+same loop; that README owns the mechanics (owner decision Q-0015).
+
 > This is binding agent behavior, stated for agents in `.claude/CLAUDE.md` (Working
 > agreement) and [`../collaboration-model.md`](../collaboration-model.md). This section is
 > the workflow-level explanation of the same rule; the binding text wins.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -991,3 +991,70 @@ Notes: routed to CLAUDE.md (binding), NOT only maintainer-working-profile.md (th
   maintainer-working-profile.md §4 + agent-workflow-spec.md §7.2 — not restated. Relax the
   strict-branch rule in the session-prompt template, not the repo.
 ```
+
+### Q-0015 — The system's purpose: productivity-per-step + the idea conveyor (2026-06-08)
+
+**Area:** Workflow / Meta (the self-improving ecosystem)
+**Type:** Vision / Process / Autonomy boundary
+**Priority:** High
+**Status:** Answered in chat (2026-06-08) — **Routed**
+**Suggested destination after answer:** `docs/ideas/README.md` (the lifecycle) +
+`docs/collaboration-model.md` + `.claude/CLAUDE.md` (session workflow) +
+`docs/owner/agent-workflow-spec.md` §7.6 + `.session-journal.md` (END protocol)
+
+**Question:** What is the docs/workflow system actually optimizing for — and how should an
+idea the maintainer drops at random flow to "done"?
+
+**Maintainer answer**
+
+```text
+On the goal (NOT full autonomy):
+"it's not intended to be 100% autonomous ... there are still steps that require my
+verification and multi agent revisions, and that is a deliberate step so this project
+stays managable and reviewable. The goal of this is to make each step more productive, and
+to make the actual building session be able to execute more things in one session because
+similar ideas and problems are mapped and laid out ... prompting them to increase
+productivity by verifying files, coming up with improvements, and generally improving the
+workflow once the context is clear, so an agent knows where to start and where to stop and
+what its role is in the process."
+
+On the idea conveyor:
+"the goal should be for me to be able to enter ideas on a random basis, these ideas should
+be mapped, and then the agents should route these ideas to reasonable places in the
+roadmap, if an idea seems too excessive etc it should first be discussed, but eventually
+all ideas should either be implemented or discussed. So the goal of this is also to guide
+agents into following up with extra tasks once their session is done, like browsing the
+idea folder, finding something that can be promoted into the roadmap, maybe it's something
+small they can execute immediately or create into a more structured plan for the next
+agent ... so an agent always has something to do other than its main task."
+```
+
+**Agent interpretation (not a rewrite of the answer)**
+
+```text
+Two durable rules:
+1. The human-verification + multi-agent-revision gates are DELIBERATE and stay — the
+   system optimizes for productivity-PER-STEP and role clarity (where to start / stop /
+   what's my role), NOT for removing the maintainer from the loop. Do not add
+   "agent self-approves a plan unmonitored" behavior.
+2. The idea backlog is a productive conveyor: random intake → map → route (roadmap horizon
+   / structured plan / discuss-if-excessive via this router) → groom → every idea ends
+   implemented or discussed (never orphaned). Grooming the backlog is the standing
+   end-of-session SECONDARY TASK so an agent always has a next thing to do.
+```
+
+**Routing result**
+
+```text
+Destination: docs/ideas/README.md (rewritten as the canonical idea lifecycle + grooming
+  secondary task); docs/collaboration-model.md ("What a good session looks like" — the
+  productive-queue ethos); .claude/CLAUDE.md (Session & plan workflow — the grooming-pass
+  pointer); docs/owner/agent-workflow-spec.md §7.6 (Executor secondary task);
+  docs/owner/ai-project-workflow.md §4 (pipeline-level link); .session-journal.md END
+  protocol (the grooming step); docs/roadmap.md (ideas route onto a horizon).
+Moved/copied on: 2026-06-08 (this session — the docs-management + idea-lifecycle batch).
+Notes: rule 1 explicitly REPLACES the earlier "unmonitored-mode / self-approval" direction a
+  draft of this session proposed — the maintainer clarified that is not the goal. Uses
+  existing homes (roadmap horizons, this router, the rejection ledger, ai-project-workflow
+  §5 idea-states); NO parallel tracker created.
+```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,6 +25,11 @@
   stability bar). An item doesn't move up until its gate clears.
 - **Authority:** `docs/current-state.md` owns *what is true now*; the **folios** own
   per-area detail; the **trackers/plans** own scope. This page only sequences them.
+- **Ideas flow in here.** A captured idea (`docs/ideas/`) is routed onto a horizon below
+  once it has a clear direction; until then it sits in **Someday** or in discussion (the
+  question router). The intake → route → groom mechanism is
+  [`ideas/README.md`](ideas/README.md) — promoting a backlog idea to a horizon is standing
+  grooming work, not scope creep.
 
 ## At a glance
 


### PR DESCRIPTION
## What & why

The productivity layer on top of the restructure (#579). Captures the maintainer's two clarifications this session as **owner decision Q-0015** and turns them into mechanism:

> The goal is **not** full autonomy — the human-verification + multi-agent-revision gates are deliberate (keeps it manageable/reviewable). The goal is **productivity-per-step + role clarity**, and a **continuous idea conveyor** so an agent always has a next thing to do.

> **Stacked on #579** (base = `claude/modest-goodall-PfdLq`). Two logical commits; the diff here is just the workflow layer. GitHub will retarget to `main` when #579 merges.

## Commit 1 — idea-backlog lifecycle + grooming secondary task (Q-0015)

The idea folder becomes a **conveyor, not a graveyard**: random intake → map → route (a `roadmap.md` horizon / a structured plan / **discuss-if-excessive** via the router) → **groom** → every idea ends *implemented* or *discussed* (never orphaned). Grooming the backlog is the standing **end-of-session secondary task** so leftover capacity always has somewhere to go.

- `docs/ideas/README.md` — rewritten as the canonical lifecycle + the no-orphan guarantee + grooming.
- `agent-workflow-spec.md` §7.6, `.session-journal.md` END protocol, `collaboration-model.md`, `ai-project-workflow.md` §4, `roadmap.md`, a `.claude/CLAUDE.md` pointer — all wired to it.
- `maintainer-question-router.md` — **Q-0015** (answer preserved verbatim).
- **No parallel tracker** — uses existing homes (roadmap horizons, the router, the rejection ledger, the §5 idea-states).

## Commit 2 — concurrent-editing safety + self-review + housekeeping

- **Binding-doc section-ownership** (the brief's task 2): `ai-project-workflow.md` §9 documents CLAUDE.md's `<!-- SECTION_START/END -->` markers as ownership blocks, the append-only router, per-file `.sessions/`, and union-merge — so parallel chats don't collide. A short pointer added in `.claude/CLAUDE.md`.
- **Self-review checkpoint** (`agent-workflow-spec.md` §7.7) — re-read your diff, run the gates, verify-don't-assume, improve what you touched.
- **Housekeeping** — refreshed `current-state.md`; new `.sessions/` log with a Context-delta section.

## Gates

Docs-only (CI fast-path). `check_docs.py --strict` green (16/ratchet 16; reachability + links + pinned + freshness); `tests/unit/docs/` 54 passed.

https://claude.ai/code/session_019icnd9FuSoR68s4f7NwMtb

---
_Generated by [Claude Code](https://claude.ai/code/session_019icnd9FuSoR68s4f7NwMtb)_