### PR TITLE
docs: groom the mining backlog — promote `!explore` wiring to a plan + roadmap (Q-0015 demo)

### DIFF
--- a/docs/ideas/mining_exploration_brainstorm.md
+++ b/docs/ideas/mining_exploration_brainstorm.md
@@ -115,6 +115,10 @@ New files only; no existing file modified; nothing wired into a command yet:
 ## 5. Suggested sequencing (future, each its own approved PR)
 
 1. **Wire exploration** — swap `!explore` to build a `Loadout` from inventory and call `exploration.resolve(...)`, applying results through the existing inventory mutation path. Add a depth notion (start at Surface; torch/lantern/depth items push deeper). *Touches `mining_cog.py` — behaviour change, so it's its own PR.*
+   > **→ Routed 2026-06-08 (idea lifecycle / Q-0015 grooming):** promoted to a structured plan,
+   > [`../planning/mining-wire-exploration-plan.md`](../planning/mining-wire-exploration-plan.md),
+   > and onto `docs/roadmap.md` (Games, ready/ungated). Awaiting maintainer go to build. Steps 2–3
+   > below stay captured here.
 2. **Workshop / crafting** — `services/crafting_mutation.py` + `WorkshopView` + tool durability, built on `items.TOOL_LADDERS`.
 3. **AI-active "Guide" + image cards** — renderer + read-only AI tool that narrates the service-owned catalog; opt-in Pillow for art.
 

--- a/docs/planning/mining-wire-exploration-plan.md
+++ b/docs/planning/mining-wire-exploration-plan.md
@@ -1,0 +1,48 @@
+# Mining — wire `!explore` to the depth/loadout engine
+
+> **Status:** `plan` — a small, ready-to-execute slice promoted from the mining brainstorm
+> via the **idea lifecycle** (`docs/ideas/README.md`; owner decision Q-0015 grooming pass,
+> 2026-06-08). **Not yet approved to build** — it is a behaviour change to a user-facing
+> command, so it needs the maintainer's go. Source and merged PRs win over this plan.
+
+## What & why
+
+`!explore` today is flat: `mining_cog.py:225` does
+`text, item, amount = roll_explore_outcome()` over five uniform outcomes that ignore the
+gear you carry. The depth/loadout-aware replacement engine is **already shipped and tested**
+as pure scaffolding (`cogs/mining/exploration.py`), wired into nothing. This slice swaps
+`!explore` onto it — making outcomes gear/depth-aware — while keeping the existing inventory
+write path. It is the brainstorm's own §5 step 1.
+
+## Promotion gates — verified against source (2026-06-08)
+
+| Gate | Finding |
+|---|---|
+| **Ownership** | `cogs/mining_cog.py` (`explore` command) + the existing `update_inventory` → `utils/db/games/mining.py` write path. **No new service** needed for this slice. |
+| **Reuse** | The already-shipped, unit-tested pure engine `cogs/mining/exploration.py` (`resolve()` + `resolve_to_legacy_tuple()` @ L299) and `cogs/mining/items.py` (build a `Loadout` from inventory). `resolve_to_legacy_tuple()` returns the **exact** `(text, item, amount)` tuple `!explore` already unpacks — a near one-line swap, not a rewrite. |
+| **Risk** | Low / contained. Behaviour change = explore outcomes become loadout/depth-aware (a game feature; low stakes). ADR-002 (game state not restart-safe) still holds — this slice adds **no** persistent run state. No new dependency (image cards / Pillow are a separate later step). No layer violation: the engine is pure; writes stay on the existing mutation path. |
+| **Mechanics** | Touches `mining_cog.py` (behaviour change → its own PR). Build a `Loadout` from the user's inventory (pickaxe / torch / lantern / dynamite / lucky charm), start depth at **Surface** (torch/lantern/depth items push deeper), call `exploration.resolve(loadout, depth)`, apply the result through `update_inventory`. **No migration.** Engine unit tests already exist (`tests/unit/cogs/test_mining_exploration.py`); add **one integration test** for the cog wiring. **Rollback** = revert the cog swap; the engine returns to dormant (its state today). |
+| **Promotion** | Routed onto `docs/roadmap.md` (Games — a concrete, ungated, ready slice) + this plan. Awaiting maintainer go. |
+
+## Scope
+
+**In:** swap `!explore` to construct a `Loadout` from inventory + a Surface-start depth notion
+and call `exploration.resolve(...).resolve_to_legacy_tuple()`; apply via the existing
+`update_inventory` path; one integration test; update the games folio + `current-state` on ship.
+
+**Out (later brainstorm steps, each its own approved PR):** the Workshop / crafting mutation
+service (§2.4 / §5 step 2); AI-active "Guide" narration + image cards (§2.6 / §5 step 3 —
+**AI-gated**, waits on the AI orchestration foundation); unifying the two inventory tables
+(explicitly out of scope in the brainstorm).
+
+## Suggested PR shape
+
+One focused PR on `cogs/mining_cog.py` + `tests/unit/cogs/` (the integration test). Behaviour
+change to one user-facing command → small, risk-isolated, easy to review and revert.
+
+## Provenance
+
+Promoted from [`../ideas/mining_exploration_brainstorm.md`](../ideas/mining_exploration_brainstorm.md)
+§5 step 1 on 2026-06-08 as a live demo of the idea-backlog grooming loop
+([`../ideas/README.md`](../ideas/README.md)). The brainstorm remains the home for the
+not-yet-promoted mining ideas (depth/biomes, crafting, AI guide, image cards).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -135,6 +135,13 @@ accepted, not a target).
   leaderboards, bot-duel stats, shared back-button adoption) from the completed
   [actionability roadmap](archive/games-actionability-roadmap.md). Low priority; pick one bounded
   slice.
+- **Next (ready, ungated)** — **wire `!explore` to the shipped depth/loadout engine.** The
+  pure `cogs/mining/exploration.py` engine is already shipped + unit-tested; the swap reuses
+  `resolve_to_legacy_tuple()` (the exact tuple `!explore` already consumes), so it's a bounded
+  one-command behaviour change. Plan:
+  [mining: wire exploration](planning/mining-wire-exploration-plan.md). Promoted from the
+  [mining brainstorm](ideas/mining_exploration_brainstorm.md) §5 via the idea lifecycle
+  (Q-0015 grooming, 2026-06-08); awaiting maintainer go to build.
 
 ### 📺 Media / YouTube — **Later** (needs an approved plan)
 
@@ -157,6 +164,8 @@ privacy/provenance/moderation review before any public surface.
 - [ai-extra-tool-capability-ideas](ideas/ai-extra-tool-capability-ideas.md) — AI capability
   backlog (web / vision / file / KB / connectors / scheduler).
 - [mining-exploration-brainstorm](ideas/mining_exploration_brainstorm.md) — mining design intent.
+  *(§5 step 1 promoted 2026-06-08 to a [plan](planning/mining-wire-exploration-plan.md) + the
+  Games lane; the rest stays captured.)*
 - [superbot-ideas-lab](planning/superbot-ideas-lab-2026-06-05.md) — broad brainstorm; its
   §2 (operating decisions) + §6 (rejection ledger) are **binding do-not-propose**.
 


### PR DESCRIPTION
## What this is

A **live run of the idea-backlog grooming loop** we just documented (`docs/ideas/README.md`; owner decision **Q-0015**) — the standing end-of-session secondary task, proving the conveyor works end-to-end on a real idea.

## The loop, run for real

1. **Browse** `docs/ideas/` → **pick** the most groomable, *ungated* item: the mining brainstorm §5 step 1 ("wire `!explore` to the shipped depth/loadout engine"). The AI-tool backlog was deliberately skipped — it's correctly parked behind the AI-orchestration gate.
2. **Verify before promoting** (the §7.7 gate): confirmed against source that `cogs/mining/exploration.py` is already shipped + unit-tested with `resolve_to_legacy_tuple()` (L299), and `mining_cog.py:225` already unpacks the exact `(text, item, amount)` tuple it returns — so this really is a near one-line swap, not a rewrite. CodeGraph even flags the engine `dead-unresolved` — the documented false-positive for shipped-but-unwired code.
3. **Route** it through the five promotion gates → a structured, ready-to-execute **plan for the next agent** (`docs/planning/mining-wire-exploration-plan.md`) + a **"Next (ready, ungated)" slice** on `docs/roadmap.md` (Games).
4. **Record the move** back in the brainstorm §5 (step 1 → routed; steps 2–3 stay captured).

## Outcome

A captured idea that was sitting at `raw` now has a **plan and a home** instead of languishing — exactly the "every idea eventually becomes implemented or discussed, never orphaned" guarantee.

**No code change, not approved to build** — wiring `!explore` is a user-facing behaviour change that still needs your go. This PR only *routes* the idea.

## Gates

Docs-only. `check_docs.py --strict` green (top-level still **16**; new `plan` doc reachable + badged).

https://claude.ai/code/session_019icnd9FuSoR68s4f7NwMtb

---
_Generated by [Claude Code](https://claude.ai/code/session_019icnd9FuSoR68s4f7NwMtb)_