### PR TITLE
server-management PR14: unified Server Management Hub (first-class subsystem)

### DIFF
--- a/.sessions/2026-06-08-server-management-pr14-hub.md
+++ b/.sessions/2026-06-08-server-management-pr14-hub.md
@@ -66,3 +66,16 @@ Authoritative queue: `docs/planning/server-management-status-2026-06-05.md` (PR1
   `arg-type` ignore). The discoverability invariant derives the cog filename from the
   subsystem key (`{key}_cog.py`), so a module named `server_management_cog.py` with key
   `servermanagement` is invisible to it — resolved via the `KNOWN_PANEL_COMMANDS` floor.
+
+## Idea-backlog grooming (standing secondary task, Q-0015)
+
+Browsed `docs/ideas/`. The three captures are each in a routed state: the mining-brainstorm
+`!explore` wiring was promoted to a plan + roadmap horizon (#581); `ai-extra-tool-capability-ideas`
+stays parked behind the AI-orchestration gate; `future-product-direction-2026-06-07` is an
+explicit **capture-only** doc whose items were nearly all **gated _after_ server-management**.
+**The grooming signal this session:** server-management is now structurally complete (PR14),
+so that gate has cleared — the **next session should re-examine `future-product-direction`'s
+server-management-gated items and route the now-unblocked ones onto a `docs/roadmap.md`
+horizon.** No unilateral promotion this session (the doc is capture-only + I own the live PR
+#584); the trigger is recorded here and the next-lane pointer is in `current-state.md`'s
+▶ Next action. No idea left orphaned.

--- a/.sessions/2026-06-08-server-management-pr14-hub.md
+++ b/.sessions/2026-06-08-server-management-pr14-hub.md
@@ -1,0 +1,68 @@
+# 2026-06-08 — Server-management PR14: the unified Server Management Hub
+
+**Arc:** Orientation session — read the docs, confirmed state (PR13 deterministic +
+the PR14 plan already merged; no open PRs), asked the maintainer which lane to advance.
+He chose **PR14 (the Server Management Hub)** — the capstone. Built it end-to-end, then
+hit an architectural fork mid-build (a registered persistent view with no matching
+subsystem is an `auto_healable` identity-contract orphan), asked, and the maintainer chose
+**"make it a first-class subsystem."** Registered it, re-verified, shipped.
+
+**Shipped (one PR — read-only composition, low risk):**
+- `services/server_management_hub.py` — read-only, **fail-safe** badge composer
+  (`collect_hub_status(guild) -> HubStatus`): per-manager capability glyphs from the
+  existing detectors (`moderation_feasibility`, `role_feasibility`, Manage-Channels perm) +
+  a cross-cutting config-health line from `setup_diagnostics` + a `setup_readiness` %.
+  Never raises (broken detector → ❓). In `services/` so a future web companion reuses it.
+- `views/server_management/hub.py` — `ServerManagementHubView(PersistentView)`: one button
+  per manager + Refresh. Routes via `interaction.client.get_cog(...).build_help_menu_view`
+  (the proven Games-hub pattern) with Back-to-hub attached → **no module-level `cogs`
+  import**. **Admin-floor `interaction_check`** (mirrors `ModPanelView`, not anchor
+  ownership) so the one view backs both the anchored prefix panel and the anchorless
+  ephemeral slash. Setup delegates to `open_wizard_from_slash` (lazy import).
+- `cogs/server_management_cog.py` — thin cog: `!servermanagement` (+ `servermenu`/`guildmenu`)
+  anchored via `panel_manager.get_or_render_panel`, ephemeral `/server-management`, and a
+  `build_help_menu_view` help hook. Added to `INITIAL_EXTENSIONS`.
+- **First-class registration (owner decision Q-0016):** `SUBSYSTEMS["servermanagement"]` +
+  a `HUBS` entry (administrator tier) + a `KNOWN_PANEL_COMMANDS` entry; key is
+  `servermanagement` (no underscore — matches `cog_name_to_subsystem`). Updated the
+  hub-set / help-category / discoverability enumeration tests + the help-surface-map (§1+§2)
+  and the settings-customization command-map (`### servermanagement` section).
+
+**Verification:** full CI mirror green (`check_quality --full`: **8062 passed**, 3 skipped);
+`check_architecture --mode strict`: 0 errors; **live boot clean** — `ServerManagementCog
+loaded`, view registered under `servermanagement`, **`Identity-contract: clean … STRICT=on`**
+(the orphan finding the standalone-view variant produced is gone), 0 ERROR/CRITICAL. New
+tests: `test_server_management_hub.py` (service) + `test_server_management_hub_view.py` (view).
+
+**Gates / next:** Server-management is **structurally complete** — the only remaining item is
+the **gated PR13 AI generation layer** ("Generate with AI" role templates; behind the
+AI-expansion gate + not live-testable here without provider keys). Restart-restoration +
+a real operator click-through remain for the maintainer's bot. With the lane otherwise done,
+the next session should pick the next lane from `docs/roadmap.md` or groom `docs/ideas/`.
+Authoritative queue: `docs/planning/server-management-status-2026-06-05.md` (PR14 subsection).
+
+## Context delta
+- **Needed but not pointed to — the "add an operator hub" wiring is an 8-place contract.**
+  Making a hub first-class touches: (1) `SUBSYSTEMS` + (2) `HUBS` + (3) `KNOWN_PANEL_COMMANDS`,
+  (4) a `build_help_menu_view` cog hook, (5) help-surface-map §1+§2, (6) command-map
+  `### <subsystem>` section, (7) the hub-set / help-category / discoverability **enumeration
+  tests**, and (8) a registry **key that equals `cog_name_to_subsystem(Cog)`** (strips
+  "Cog"+lowercases, **no** underscore insertion → `ServerManagementCog` ⇒ `servermanagement`).
+  That key must also be the view `SUBSYSTEM` + the `get_or_render_panel` anchor string, or the
+  identity-contract (view) + ledger (orphan-cog) + db-anchor findings persist. Nothing names
+  this checklist in one place — captured a short version in the folio debug-router this session.
+- **Needed but not pointed to — the identity contract is the signal that "hubs are
+  subsystems."** A registered `PersistentView` whose `SUBSYSTEM ∉ SUBSYSTEMS` is classified
+  `auto_healable` (`!platform identity --fix` would *unregister* it). That, plus the fact that
+  every existing hub is a subsystem, is why the maintainer chose first-class. The folio /
+  hub-ui-standard don't state this.
+- **Pointed to but didn't need:** CodeGraph (available this session) — grep + the PreToolUse
+  `context_map.py` (importers / blast-radius / lazy-import surfacing) carried the whole
+  investigation, exactly as on 2026-06-08's PR13 session. The PR14 plan's exemplar choice
+  (`RoleHubPanelView`, an ownership panel) needed correcting to `ModPanelView` (the
+  authority-gated exemplar), and the plan didn't anticipate the registration fork.
+- **Discovered by hand:** `interaction.client` is typed `discord.Client` (no `get_cog`) →
+  needs `# type: ignore[attr-defined]` (GamesHubView sidesteps via `_cog_for_subsystem` +
+  `arg-type` ignore). The discoverability invariant derives the cog filename from the
+  subsystem key (`{key}_cog.py`), so a module named `server_management_cog.py` with key
+  `servermanagement` is invisible to it — resolved via the `KNOWN_PANEL_COMMANDS` floor.

--- a/disbot/cogs/server_management_cog.py
+++ b/disbot/cogs/server_management_cog.py
@@ -1,0 +1,97 @@
+"""Server Management hub cog — the unified operator entry point (PR14).
+
+A thin command host for the Server Management hub: one builder
+(:func:`views.server_management.hub.build_server_management_hub`), two front
+doors. The persistent ``!servermanagement`` panel anchors via
+``panel_manager.get_or_render_panel`` (restored across restart by the registered
+:class:`~views.server_management.hub.ServerManagementHubView`); the ephemeral
+``/server-management`` slash renders the same builder for a quick, throwaway
+view.
+
+The cog holds **no domain logic** — every action routes into an existing manager
+inside the hub view. Importing the hub view module here also triggers its
+``@register`` side-effect so the persistent-view registry is populated before
+``on_ready`` runs ``restore_anchors`` (the same pattern moderation uses for
+``ModPanelView``).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from core.runtime import panel_manager
+from views.server_management.hub import build_server_management_hub
+
+logger = logging.getLogger("bot")
+
+
+class ServerManagementCog(commands.Cog):
+    """Hosts the unified Server Management hub command + slash front doors."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @commands.command(
+        name="servermanagement",
+        aliases=["servermenu", "guildmenu"],
+    )
+    @commands.guild_only()
+    @commands.has_permissions(administrator=True)
+    async def servermanagement(self, ctx: commands.Context) -> None:
+        """Open the unified Server Management hub."""
+        embed, view = await build_server_management_hub(ctx.guild)
+        msg = await panel_manager.get_or_render_panel(
+            ctx,
+            "servermanagement",
+            embed,
+            view,
+        )
+        view.message = msg
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook (returns the Server Management hub).
+
+        Raises when invoked outside a guild so the help router falls back to
+        the command-list embed (the hub is guild-only).
+        """
+        guild = interaction.guild
+        if guild is None:
+            raise RuntimeError("Server Management hub requires a guild")
+        return await build_server_management_hub(guild)
+
+    @app_commands.command(
+        name="server-management",
+        description="Open the Server Management hub (moderation, channels, roles, cleanup, setup).",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.guild_only()
+    async def server_management_slash(
+        self,
+        interaction: discord.Interaction,
+    ) -> None:
+        """Ephemeral slash front door for the Server Management hub."""
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "Use `/server-management` from inside a server.",
+                ephemeral=True,
+            )
+            return
+        embed, view = await build_server_management_hub(interaction.guild)
+        await interaction.response.send_message(
+            embed=embed,
+            view=view,
+            ephemeral=True,
+        )
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(ServerManagementCog(bot))
+    logger.info("ServerManagementCog loaded.")

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -85,6 +85,7 @@ INITIAL_EXTENSIONS = [
     "cogs.games_cog",
     "cogs.community_cog",
     "cogs.setup_cog",
+    "cogs.server_management_cog",
 ]
 
 # ==========================

--- a/disbot/services/customization_catalogue.py
+++ b/disbot/services/customization_catalogue.py
@@ -86,6 +86,7 @@ KNOWN_PANEL_COMMANDS: tuple[tuple[str, str], ...] = (
     ("moderation", "modmenu"),
     ("proof_channel", "prizemenu"),
     ("role", "rolemenu"),
+    ("servermanagement", "servermanagement"),
     ("utility", "utilitymenu"),
     ("xp", "xpmenu"),
 )

--- a/disbot/services/server_management_hub.py
+++ b/disbot/services/server_management_hub.py
@@ -1,0 +1,323 @@
+"""Server-management hub status — read-only health-badge composer (PR14).
+
+The unified Server Management Hub (``!servermanagement`` / ``/server-management``)
+is a **navigation** surface: one button per specialised manager (moderation,
+channels, roles, cleanup, setup) plus a compact, read-only health summary so an
+operator sees *what needs attention* before clicking in.
+
+This module owns only the **badge composition** — it does **not** mutate, render
+Discord components, or re-implement any detector.  It *composes* the existing
+read-only signals:
+
+* moderation capability — :func:`utils.moderation_feasibility.evaluate_moderation_readiness`
+* role-management capability — :func:`utils.role_feasibility.manageable_roles`
+* channel-management capability — ``guild.me.guild_permissions.manage_channels``
+* per-guild config health — :func:`services.setup_diagnostics.collect_setup_diagnostics`
+* setup completeness — :func:`services.setup_readiness.collect`
+
+It lives in ``services/`` (not in the view) for the same reason
+:mod:`services.setup_diagnostics` does: the model is UI-agnostic, so the future
+web companion (owner intent Q-0002 — Discord-first, keep read models reusable)
+can render the same :class:`HubStatus` without change.
+
+**Fail-safe by contract.** Every badge is best-effort: a detector that raises is
+logged and degrades that badge to *unknown* (``❓``) — one broken signal can
+never blank the hub or break its render.  ``collect_hub_status`` therefore never
+raises.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import discord
+
+if TYPE_CHECKING:
+    from services.setup_diagnostics import SetupDiagnosticsReport
+
+logger = logging.getLogger("bot.services.server_management_hub")
+
+# ---------------------------------------------------------------------------
+# Glyphs — the at-a-glance status vocabulary (one column per manager).
+# ---------------------------------------------------------------------------
+
+GLYPH_HEALTHY = "🟢"  # works / nothing needs attention
+GLYPH_ATTENTION = "🟡"  # usable but something is incomplete / degraded
+GLYPH_BLOCKED = "⛔"  # the bot cannot act here until a Discord-side fix
+GLYPH_UNKNOWN = "❓"  # a detector failed — surfaced honestly, not hidden
+
+# Manager keys — stable identifiers shared with the view's button custom_ids.
+MOD = "moderation"
+CHANNELS = "channels"
+ROLES = "roles"
+CLEANUP = "cleanup"
+SETUP = "setup"
+
+# Setup-completeness threshold above which setup reads as healthy.
+_SETUP_HEALTHY_PCT = 80
+
+
+@dataclass(frozen=True)
+class ManagerBadge:
+    """A read-only health summary for one manager in the hub.
+
+    ``key`` matches the manager's button custom_id suffix; ``emoji`` + ``label``
+    are display metadata; ``glyph`` is one of the ``GLYPH_*`` constants and
+    ``summary`` is the one-line operator-facing explanation.
+    """
+
+    key: str
+    emoji: str
+    label: str
+    glyph: str
+    summary: str
+
+
+@dataclass(frozen=True)
+class HubStatus:
+    """Composed, render-ready status snapshot for one guild's hub."""
+
+    guild_id: int
+    badges: tuple[ManagerBadge, ...]
+    overall_glyph: str
+    overall_summary: str
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def collect_hub_status(guild: discord.Guild) -> HubStatus:
+    """Compose every manager badge + an overall config-health line for *guild*.
+
+    Read-only and **never raises**: each badge is built fail-safe, and the
+    cross-cutting config-health collector (:mod:`services.setup_diagnostics`)
+    is itself fail-safe.  The cost is paid only on open / explicit refresh —
+    the view caches nothing across button clicks.
+    """
+    # One fail-safe diagnostics pass feeds both the cleanup badge and the
+    # overall line, so we don't fan out to the detectors twice.
+    report = await _safe_collect_diagnostics(guild)
+    setup_pct = await _safe_setup_percentage(guild)
+
+    badges = (
+        _moderation_badge(guild),
+        _channels_badge(guild),
+        _roles_badge(guild),
+        _cleanup_badge(report),
+        _setup_badge(setup_pct, report),
+    )
+    overall_glyph, overall_summary = _overall(report)
+    return HubStatus(
+        guild_id=guild.id,
+        badges=badges,
+        overall_glyph=overall_glyph,
+        overall_summary=overall_summary,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-manager badge builders (each fail-safe — never raises)
+# ---------------------------------------------------------------------------
+
+
+def _moderation_badge(guild: discord.Guild) -> ManagerBadge:
+    """Can the bot ban / kick / timeout in this guild?"""
+    try:
+        from utils.moderation_feasibility import evaluate_moderation_readiness
+
+        readiness = evaluate_moderation_readiness(guild)
+        if readiness.fully_capable:
+            glyph, summary = GLYPH_HEALTHY, "Can ban, kick and timeout members"
+        else:
+            missing = readiness.missing_permissions()
+            if missing:
+                glyph, summary = GLYPH_ATTENTION, f"Missing: {', '.join(missing)}"
+            else:
+                # All perms present but the bot's top role is at the bottom.
+                glyph = GLYPH_ATTENTION
+                summary = "Bot's role is at the bottom — actions may be limited"
+    except Exception:
+        logger.exception("server_management_hub: moderation badge failed")
+        glyph, summary = GLYPH_UNKNOWN, "Readiness check unavailable"
+    return ManagerBadge(MOD, "🛡️", "Moderation", glyph, summary)
+
+
+def _channels_badge(guild: discord.Guild) -> ManagerBadge:
+    """Does the bot hold Manage Channels?"""
+    try:
+        me = guild.me
+        can_manage = bool(me is not None and me.guild_permissions.manage_channels)
+        if can_manage:
+            glyph, summary = (
+                GLYPH_HEALTHY,
+                "Can create, rename, move and delete channels",
+            )
+        else:
+            glyph, summary = GLYPH_BLOCKED, "Missing Manage Channels permission"
+    except Exception:
+        logger.exception("server_management_hub: channels badge failed")
+        glyph, summary = GLYPH_UNKNOWN, "Permission check unavailable"
+    return ManagerBadge(CHANNELS, "📺", "Channels", glyph, summary)
+
+
+def _roles_badge(guild: discord.Guild) -> ManagerBadge:
+    """Can the bot manage roles, and how many of them?"""
+    try:
+        from utils.role_feasibility import manageable_roles
+
+        me = guild.me
+        if me is None or not me.guild_permissions.manage_roles:
+            glyph, summary = GLYPH_BLOCKED, "Missing Manage Roles permission"
+        else:
+            manageable, _excluded = manageable_roles(guild.roles, bot_member=me)
+            total = len(guild.roles)
+            if manageable:
+                glyph = GLYPH_HEALTHY
+                summary = f"Can manage {len(manageable)} of {total} roles"
+            else:
+                glyph = GLYPH_ATTENTION
+                summary = "No roles are below the bot — move its role higher"
+    except Exception:
+        logger.exception("server_management_hub: roles badge failed")
+        glyph, summary = GLYPH_UNKNOWN, "Role feasibility check unavailable"
+    return ManagerBadge(ROLES, "🎭", "Roles", glyph, summary)
+
+
+def _cleanup_badge(report: SetupDiagnosticsReport | None) -> ManagerBadge:
+    """Derive cleanup health from the (fail-safe) diagnostics report.
+
+    Tolerant by design: we filter findings whose ``subsystem`` names cleanup
+    rather than asserting an exact taxonomy string, so a future rename in the
+    detector degrades the *glyph* (never correctness — this is an advisory
+    badge).
+    """
+    try:
+        if report is None:
+            glyph, summary = GLYPH_UNKNOWN, "Diagnostics unavailable"
+        else:
+            cleanup_findings = [
+                f
+                for f in report.findings
+                if "cleanup" in (getattr(f, "subsystem", "") or "").lower()
+            ]
+            glyph, summary = _worst_glyph(
+                cleanup_findings,
+                healthy_summary="No cleanup-policy issues detected",
+            )
+    except Exception:
+        logger.exception("server_management_hub: cleanup badge failed")
+        glyph, summary = GLYPH_UNKNOWN, "Diagnostics unavailable"
+    return ManagerBadge(CLEANUP, "🧹", "Cleanup", glyph, summary)
+
+
+def _setup_badge(
+    percentage: int | None,
+    report: SetupDiagnosticsReport | None,
+) -> ManagerBadge:
+    """How complete is setup, and does anything block it?"""
+    try:
+        # A blocker outranks a completeness percentage.
+        if report is not None and report.counts.get("blocker", 0) > 0:
+            return ManagerBadge(
+                SETUP,
+                "🧩",
+                "Setup",
+                GLYPH_BLOCKED,
+                "Setup has blocking issues",
+            )
+        if percentage is None:
+            glyph, summary = GLYPH_UNKNOWN, "Readiness unavailable"
+        elif percentage >= _SETUP_HEALTHY_PCT:
+            glyph, summary = GLYPH_HEALTHY, f"{percentage}% configured"
+        elif percentage > 0:
+            glyph, summary = GLYPH_ATTENTION, f"{percentage}% configured — more to do"
+        else:
+            glyph, summary = GLYPH_ATTENTION, "Not configured yet — run setup"
+    except Exception:
+        logger.exception("server_management_hub: setup badge failed")
+        glyph, summary = GLYPH_UNKNOWN, "Readiness unavailable"
+    return ManagerBadge(SETUP, "🧩", "Setup", glyph, summary)
+
+
+# ---------------------------------------------------------------------------
+# Overall config-health line
+# ---------------------------------------------------------------------------
+
+
+def _overall(report: SetupDiagnosticsReport | None) -> tuple[str, str]:
+    """Cross-cutting "what needs attention?" summary from the diagnostics report."""
+    if report is None:
+        return GLYPH_UNKNOWN, "Configuration health check unavailable"
+    try:
+        counts = report.counts
+        blockers = counts.get("blocker", 0)
+        warnings = counts.get("warning", 0)
+        advisories = counts.get("advisory", 0)
+        if report.is_healthy:
+            return GLYPH_HEALTHY, "No configuration issues need attention"
+        parts: list[str] = []
+        if blockers:
+            parts.append(f"{blockers} blocker{'s' if blockers != 1 else ''}")
+        if warnings:
+            parts.append(f"{warnings} warning{'s' if warnings != 1 else ''}")
+        if advisories:
+            parts.append(f"{advisories} advisor{'ies' if advisories != 1 else 'y'}")
+        glyph = GLYPH_BLOCKED if blockers else GLYPH_ATTENTION
+        return glyph, ", ".join(parts) if parts else "Needs attention"
+    except Exception:
+        logger.exception("server_management_hub: overall summary failed")
+        return GLYPH_UNKNOWN, "Configuration health check unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+async def _safe_collect_diagnostics(
+    guild: discord.Guild,
+) -> SetupDiagnosticsReport | None:
+    """Run the diagnostics collector, returning ``None`` if it is unavailable."""
+    try:
+        from services import setup_diagnostics
+
+        return await setup_diagnostics.collect_setup_diagnostics(guild)
+    except Exception:
+        logger.exception("server_management_hub: setup_diagnostics failed")
+        return None
+
+
+async def _safe_setup_percentage(guild: discord.Guild) -> int | None:
+    """Return the setup-readiness percentage, or ``None`` if unavailable.
+
+    Calls ``collect(guild_id)`` **without** the ``guild`` kwarg on purpose: the
+    health view is owned by the diagnostics report above, and passing ``guild``
+    would re-run ``resource_health.inspect`` a second time.
+    """
+    try:
+        from services import setup_readiness
+
+        report = await setup_readiness.collect(guild.id)
+        return int(report.percentage)
+    except Exception:
+        logger.exception("server_management_hub: setup_readiness failed")
+        return None
+
+
+def _worst_glyph(findings: list, *, healthy_summary: str) -> tuple[str, str]:
+    """Map the worst severity among *findings* to a (glyph, summary) pair."""
+    severities = {getattr(f, "severity", "") for f in findings}
+    if "blocker" in severities:
+        return GLYPH_BLOCKED, _count_summary(findings)
+    if severities & {"warning", "advisory"}:
+        return GLYPH_ATTENTION, _count_summary(findings)
+    return GLYPH_HEALTHY, healthy_summary
+
+
+def _count_summary(findings: list) -> str:
+    n = len(findings)
+    return f"{n} issue{'s' if n != 1 else ''} need{'s' if n == 1 else ''} attention"

--- a/disbot/utils/hub_registry.py
+++ b/disbot/utils/hub_registry.py
@@ -215,6 +215,14 @@ HUBS: tuple[HubEntry, ...] = (
         entry_command="!platform",
         minimum_tier="administrator",
     ),
+    HubEntry(
+        key="servermanagement",
+        display_name="Server Management",
+        emoji="🧭",
+        purpose="Moderation, channels, roles, cleanup, and setup in one place.",
+        entry_command="!servermanagement",
+        minimum_tier="administrator",
+    ),
 )
 
 

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -80,6 +80,29 @@ SUBSYSTEMS: dict[str, dict] = {
             "admin.server.stats",
         ],
     },
+    "servermanagement": {
+        "display_name": "Server Management",
+        "description": "Unified hub for moderation, channels, roles, cleanup, setup",
+        "emoji": "🧭",
+        "color": ADMIN_COLOR.value,
+        "visibility_tier": "administrator",
+        "visibility_mode": "normal",
+        "category": "admin",
+        "tags": ["admin", "hub", "navigation", "operations"],
+        "entry_points": ["servermanagement"],
+        "default_channels": ["staff", "bot-spam"],
+        "related_subsystems": ["moderation", "cleanup"],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        # The hub posts a navigation panel but owns no message-cleanup policy.
+        "has_cleanup_rules": False,
+        "ui_priority": 88,
+        # Routing-only hub: it composes other subsystems' panels and holds no
+        # capability of its own (authority is the administrator floor on the
+        # command + the view's interaction_check).
+        "capabilities": [],
+    },
     "moderation": {
         "display_name": "Moderation",
         "description": "Warnings, timeouts, bans, mod logs",

--- a/disbot/views/server_management/__init__.py
+++ b/disbot/views/server_management/__init__.py
@@ -1,0 +1,6 @@
+"""Server Management hub views (PR14).
+
+The unified operator navigation surface that composes the specialised
+managers (moderation, channels, roles, cleanup, setup).  See
+``views/server_management/hub.py``.
+"""

--- a/disbot/views/server_management/hub.py
+++ b/disbot/views/server_management/hub.py
@@ -1,0 +1,267 @@
+"""Server Management Hub — the unified operator navigation surface (PR14).
+
+One persistent panel (``!servermanagement`` + ``/server-management``) that gives
+an operator a single entry point to every specialised manager — moderation,
+channels, roles, cleanup, setup — with read-only health badges summarising what
+needs attention.
+
+**The hub holds zero domain logic.** It *composes* the existing manager panels
+and the read-only :mod:`services.server_management_hub` badge model; it never
+re-implements a manager. Each manager button routes into that manager's own
+``build_help_menu_view`` hook (resolved at click time via
+``interaction.client.get_cog`` — so this view needs **no module-level import of
+any cog**, keeping the ``views → cogs`` arch boundary clean). The exception is
+Setup, which owns its own session/depth lifecycle in a dedicated channel and is
+opened through its reusable wizard entry.
+
+**Authority (ADR-005 / ``docs/capability-authority.md`` §4).** Like
+:class:`views.moderation.main_panel.ModPanelView`, the hub overrides
+``interaction_check`` with an **authority** gate rather than anchor ownership:
+the administrator floor is re-evaluated live on every interaction. Re-evaluating
+``guild_permissions.administrator`` at click time also covers the restored-panel
+case (a panel outliving the caller's admin role) and lets the same view back the
+ephemeral ``/server-management`` slash, which has no anchor.
+
+**Restoration.** ``ServerManagementHubView`` is ``@register``-ed with a no-arg
+constructor and static ``servermanagement:*`` custom_ids, so
+``message_anchor_manager.restore_anchors`` re-binds it across restarts for free
+(the prefix command anchors the panel via ``panel_manager.get_or_render_panel``).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from core.runtime.interaction_helpers import safe_defer, safe_edit
+from core.runtime.persistent_views import PersistentView, register
+from services.server_management_hub import HubStatus, collect_hub_status
+from utils.ui_constants import ADMIN_COLOR
+from views.base import interaction_is_admin
+from views.navigation import attach_back_button
+
+logger = logging.getLogger("bot.views.server_management")
+
+# Managers reachable by routing into another cog's ``build_help_menu_view``
+# hook. Key (custom_id suffix) → (get_cog name, human label). Setup is handled
+# separately (its own wizard entry), so it is not in this table.
+_ROUTED_MANAGERS: dict[str, tuple[str, str]] = {
+    "moderation": ("ModerationCog", "Moderation"),
+    "channels": ("ChannelCog", "Channels"),
+    "roles": ("RoleCog", "Roles"),
+    "cleanup": ("Cleanup", "Cleanup"),
+}
+
+_BACK_CUSTOM_ID = "servermanagement:back"
+_BACK_LABEL = "↩ Server Management"
+
+
+def build_hub_embed(status: HubStatus) -> discord.Embed:
+    """Render a :class:`HubStatus` into the hub embed (read-only badges)."""
+    embed = discord.Embed(
+        title="🧭 Server Management Hub",
+        description=(
+            "Your single entry point to the server's operator tools. "
+            "Pick a manager below — the badges are a read-only health summary."
+        ),
+        color=ADMIN_COLOR,
+    )
+    lines = [
+        f"{badge.glyph} {badge.emoji} **{badge.label}** — {badge.summary}"
+        for badge in status.badges
+    ]
+    embed.add_field(name="Managers", value="\n".join(lines), inline=False)
+    embed.add_field(
+        name="Overall configuration health",
+        value=f"{status.overall_glyph} {status.overall_summary}",
+        inline=False,
+    )
+    embed.set_footer(text="Read-only summary · click a manager to open it")
+    return embed
+
+
+async def build_server_management_hub(
+    guild: discord.Guild,
+) -> tuple[discord.Embed, ServerManagementHubView]:
+    """Single source of truth for opening the hub: compose status → (embed, view).
+
+    Used by the ``!servermanagement`` prefix command, the ``/server-management``
+    slash, and the per-manager "Back to Server Management" button.
+    """
+    status = await collect_hub_status(guild)
+    return build_hub_embed(status), ServerManagementHubView()
+
+
+def _attach_back_to_hub(view: discord.ui.View) -> None:
+    """Append a "Back to Server Management" control to a routed manager panel."""
+
+    async def _hub_parent(
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        guild = interaction.guild
+        if guild is None:  # hub is guild-only; attach_back_button surfaces this
+            raise RuntimeError("Server Management hub requires a guild")
+        return await build_server_management_hub(guild)
+
+    attach_back_button(
+        view,
+        label=_BACK_LABEL,
+        custom_id=_BACK_CUSTOM_ID,
+        parent_builder=_hub_parent,
+        error_message="Couldn't reload the Server Management hub — see logs.",
+    )
+
+
+@register
+class ServerManagementHubView(PersistentView):
+    """Persistent operator hub routing to the specialised managers.
+
+    Authority-gated (administrator floor), not ownership-gated — see the module
+    docstring. Stateless: every callback recovers context from ``interaction``.
+    """
+
+    SUBSYSTEM = "servermanagement"
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction_is_admin(interaction):
+            return True
+        await interaction.response.send_message(
+            "❌ You need **Administrator** permission to use the Server "
+            "Management hub.",
+            ephemeral=True,
+        )
+        return False
+
+    # ------------------------------------------------------------------ routing
+
+    async def _open_manager(
+        self,
+        interaction: discord.Interaction,
+        key: str,
+    ) -> None:
+        """Open a routed manager's panel in place via its help-menu hook."""
+        cog_name, label = _ROUTED_MANAGERS[key]
+        # interaction.client is the live commands.Bot at runtime; Interaction is
+        # typed against discord.Client, which has no get_cog.
+        cog = interaction.client.get_cog(cog_name)  # type: ignore[attr-defined]
+        build = getattr(cog, "build_help_menu_view", None) if cog else None
+        if not callable(build):
+            await interaction.response.send_message(
+                f"The {label} manager isn't available right now.",
+                ephemeral=True,
+            )
+            return
+        try:
+            embed, sub_view = await build(interaction)
+        except Exception as exc:  # noqa: BLE001 — navigation must not crash
+            logger.warning(
+                "server_management hub: build_help_menu_view failed for %s: %s",
+                cog_name,
+                exc,
+                exc_info=True,
+            )
+            await interaction.response.send_message(
+                f"Couldn't open the {label} manager — see bot logs.",
+                ephemeral=True,
+            )
+            return
+        _attach_back_to_hub(sub_view)
+        await interaction.response.edit_message(embed=embed, view=sub_view)
+
+    # ------------------------------------------------------------------ buttons
+
+    @discord.ui.button(
+        label="🛡️ Moderation",
+        style=discord.ButtonStyle.primary,
+        row=0,
+        custom_id="servermanagement:moderation",
+    )
+    async def moderation_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await self._open_manager(interaction, "moderation")
+
+    @discord.ui.button(
+        label="📺 Channels",
+        style=discord.ButtonStyle.primary,
+        row=0,
+        custom_id="servermanagement:channels",
+    )
+    async def channels_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await self._open_manager(interaction, "channels")
+
+    @discord.ui.button(
+        label="🎭 Roles",
+        style=discord.ButtonStyle.primary,
+        row=0,
+        custom_id="servermanagement:roles",
+    )
+    async def roles_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await self._open_manager(interaction, "roles")
+
+    @discord.ui.button(
+        label="🧹 Cleanup",
+        style=discord.ButtonStyle.secondary,
+        row=1,
+        custom_id="servermanagement:cleanup",
+    )
+    async def cleanup_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await self._open_manager(interaction, "cleanup")
+
+    @discord.ui.button(
+        label="🧩 Setup",
+        style=discord.ButtonStyle.success,
+        row=1,
+        custom_id="servermanagement:setup",
+    )
+    async def setup_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        # Setup owns its own session/depth lifecycle in a dedicated channel, so
+        # we hand off to its reusable wizard entry (it owns the response) rather
+        # than editing a panel in place. Lazy import keeps the cogs layer out of
+        # this view's module scope (arch boundary).
+        from cogs.setup._wizard_entry import open_wizard_from_slash
+
+        await open_wizard_from_slash(interaction)
+
+    @discord.ui.button(
+        label="🔄 Refresh",
+        style=discord.ButtonStyle.secondary,
+        row=2,
+        custom_id="servermanagement:refresh",
+    )
+    async def refresh_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "The hub is only available inside a server.",
+                ephemeral=True,
+            )
+            return
+        # Recomposing the badges touches read-only detectors — defer so a slow
+        # guild can't blow the 3s response window, then edit in place.
+        if not await safe_defer(interaction):
+            return
+        status = await collect_hub_status(interaction.guild)
+        await safe_edit(interaction, embed=build_hub_embed(status), view=self)

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -6,11 +6,17 @@
 > live GitHub** before trusting it (two same-session reports already
 > contradicted each other across a single merge).
 >
-> **▶ Next action:** server-management **PR13 AI follow-up** — the "Generate with AI"
-> role-template layer on top of the deterministic slice (request → AI gateway → strict
-> structured suggestion → reuse the shipped `setup_role_templates` validation/safety filter
-> → preview/accept/edit → the same `create_managed_role` staging path). Then **PR14**
-> (Server Management Hub, last). **PR13's deterministic slice was built 2026-06-08:**
+> **▶ Next action:** **Server-management is structurally complete — PR14 (Server Management
+> Hub) was built 2026-06-08:** a persistent `!servermanagement` + ephemeral `/server-management`
+> composing the moderation / channels / roles / cleanup / setup managers behind read-only health
+> badges, registered **first-class** as the `servermanagement` subsystem + hub (owner decision
+> **Q-0016**) so it is help-discoverable and the identity contract stays clean (no new mutation /
+> op-kind / migration / settings). Verify merge on live GitHub — authoritative scope is the
+> [status tracker](planning/server-management-status-2026-06-05.md) PR14 subsection. The **only
+> remaining server-management item is the _gated_ PR13 AI generation layer** ("Generate with AI"
+> role templates, behind the AI-expansion gate below + **not** live-testable here without provider
+> keys); with the lane otherwise done, the next session should pick the next lane from
+> [`docs/roadmap.md`](roadmap.md) or groom `docs/ideas/`. **PR13's deterministic slice was built 2026-06-08:**
 > `services/setup_role_templates.py` (built-in, permission-free role bundles + pure
 > `plan_template`) + a new audited **`create_managed_role`** op-kind (routes through
 > `RoleLifecycleService`, optional time/XP tier companion) + a **Role templates** setup
@@ -24,15 +30,19 @@
 > roles) merged via **#570**; PR11's **governance** section stays **deferred** (owner decision
 > **Q-0008**). Authoritative scope + dependencies: the status tracker's Remaining-queue.
 >
-> **Last updated:** 2026-06-08 · **Docs consolidation (Q-0010) + idea-backlog lifecycle
-> (Q-0015).** Top-level `docs/` shrunk **41 → 16** (plans / audits / inventories / historical
+> **Last updated:** 2026-06-08 · **Server-management PR14 (Server Management Hub) built and
+> registered first-class as the `servermanagement` subsystem + hub (owner decision Q-0016);
+> live boot reports `Identity-contract: clean … STRICT=on`.** Prior 2026-06-08 work — **docs
+> consolidation (Q-0010) + idea-backlog lifecycle
+> (Q-0015):** Top-level `docs/` shrunk **41 → 16** (plans / audits / inventories / historical
 > moved into clustered subdirs — `docs/ai/`, `docs/setup-platform/`, `docs/health/` — and the
 > type buckets behind their folios; `_TOP_LEVEL_DOCS_BUDGET` lowered 41 → 16). The idea
 > backlog is now a routed **lifecycle + end-of-session grooming secondary task**
 > (`docs/ideas/README.md`); binding-doc **section-ownership** documented for concurrent
 > chats (`docs/owner/ai-project-workflow.md` §9). Docs-only; verify merge status on live GitHub.
-> Most recent merged code: server-management **PR12** (2026-06-07; setup diagnostics &
-> repair). **This file lists only _merged_ work + the ▶ Next action;** get
+> Most recent merged code: server-management **PR13** deterministic role templates + migration
+> 059 (#582, 2026-06-08). **PR14 (the hub) is built but not yet merged — verify on live GitHub.**
+> **This file lists only _merged_ work + the ▶ Next action;** get
 > in-flight PRs from live GitHub (`list_pull_requests`) — naming an open PR's status in prose
 > here rots on merge (a `scripts/check_docs.py` freshness gate enforces this).
 >
@@ -64,6 +74,8 @@ Source code and merged PRs win over anything written here.
 > get it from live GitHub. The newest merge a session sees may not be added yet; that
 > lag is expected (the next session reconciles). A merged PR tagged "pending" is the bug.
 
+- **#582** — server-management **PR13 deterministic slice**: `services/setup_role_templates.py` (built-in permission-free role bundles + pure `plan_template`) + the audited **`create_managed_role`** op-kind (routes through `RoleLifecycleService`, optional time/XP tier companion) + a **Role templates** setup section. Fixed a **latent PR11 regression** (the roles section's `set_role_threshold` op was never added to the DB op-kind gate/CHECK → couldn't stage): **migration 059** + a dispatcher↔gate↔CHECK drift-guard test close it. The **PR13 AI generation layer** + PR14 (hub) remained queued. (PR12 setup diagnostics & repair shipped 2026-06-07.)
+- **#581** — idea-backlog grooming demo (Q-0015): promoted the mining-brainstorm `!explore` wiring into a structured plan + a `docs/roadmap.md` horizon; the standing end-of-session secondary task in action.
 - **#570** — server-management **PR11** (moderation + roles setup sections) + workflow tooling + ecosystem docs (owner decision **Q-0008**: Moderation + Roles now, Governance deferred). The moderation section stages `set_setting` drafts for the PR10 knobs; the roles section adds the `set_role_threshold` op-kind for time/XP auto-role tiers. Setup diagnostics & repair (PR12) builds on top.
 - **#567** — server-management **PR10 fourth slice**: optional post-kick/ban **message cleanup** (`post_action_cleanup`: none/kick/ban/both up to `post_action_cleanup_limit`, **default OFF**), owned at the `moderation_service` kick/ban seam and *requested from* `services/history_cleanup.py` (new author-scoped plan + a shared `apply_history_cleanup_plan` extracted from `!cleanuphistory` — one delete path). Best-effort: a blocked sweep never undoes the action.
 - **#566** (merged) — **cross-area implementation roadmap** (`docs/roadmap.md`): the one by-area "what's planned, in what order" index (relative Now/Next/Later/Someday horizons + gates, not dates), linking each authoritative plan + folio, with a clearly-marked not-approved ideas section. Its AI section defers to the AI roadmap. Re-badged two mis-badged historical plans (`phase_2b_bindings_plan`, BTD6 extraction). Wired into `current-state` + `AGENT_ORIENTATION`.

--- a/docs/help-command-surface-map.md
+++ b/docs/help-command-surface-map.md
@@ -43,6 +43,7 @@ Post-PR-#142 routing summary (relevant to every row in §2):
 | `admin` | ⚙️ Admin / Operations | `!adminmenu` | `admin_cog` | `_AdminPanelView` | administrator |
 | `settings` | 🔧 Settings / Configuration | `!settings` | `settings_cog` | `SettingsHubView` | administrator |
 | `diagnostic` | 🩺 Platform / Diagnostics | `!platform` | `diagnostic_cog` | `_PlatformHubView` | administrator |
+| `servermanagement` | 🧭 Server Management | `!servermanagement` | `server_management_cog` | `ServerManagementHubView` (`views/server_management/hub.py`) | administrator |
 
 ## 2. Subsystem inventory
 
@@ -78,6 +79,7 @@ or raises.
 | `proof_channel` | `proof_channel_cog.py:113` | `prizestatus`, `prizemenu`, `timedprize` | — | `_PrizeManagerView` | `!help proof` → opens Proof Channel panel (shared resolver) | reached via Moderation; `parent_hub="moderation"` since PR #3 | hub child (Moderation) — declared |
 | `role` | `role_cog.py:334` | `roles`, `rolesettings`, `rolemenu` (legacy alias) | 8+ legacy commands: `rolecreator`, `createrole`, `deleterole`, `setrole`, `unsetrole`, `assignroles`, `debugroles`, `refreshmembers`, plus react-role family | `RoleHubPanelView` | `!help roles` → opens Role panel (shared resolver) | reached via Community; `parent_hub="community"` since PR #3 | hub child (Community) — declared; legacy commands remain as hidden compatibility |
 | `rps_tournament` | `rps_tournament_cog.py:118` | `rpsregister`/`rpsreg`, `rpsstart`/`rpsbegin`, `rpsbot`, `rpsmatchup`, `rpshelp`, `rpssettings` | — | `RPSPanelView` | `!help rps` → opens RPS panel (shared resolver) | reached via Games | hub child (Games) |
+| `servermanagement` | `server_management_cog.py` | `servermanagement`, `servermenu`, `guildmenu`, `/server-management` | — | `ServerManagementHubView` | `!help` → Server Management (shared resolver) | dropdown Server Management → panel | hub top-level (operator) — composes moderation/channels/roles/cleanup/setup |
 | `settings` | `settings_cog.py` | (entry via `!settings`) | — | `SettingsHubView` | `!help settings` → opens Settings panel (shared resolver) | dropdown Settings → panel | hub top-level |
 | `utility` | `utility_cog.py` | `utilitymenu`, `clear`/`purge`, `info`, `serverinfo`, `userinfo`, `avatar`, `remind` | — | `_UtilityPanelView` | `!help utility` → opens Utility panel (shared resolver) | dropdown Utility → panel | hub top-level |
 | `xp` | `xp_cog.py` | `xpmenu`, `rank`, `givexp`, `resetxp`, `xpconfig` | — | `_XpHubView` | `!help xp` → opens XP panel (shared resolver) | reached via Community; `parent_hub="community"` since PR #3 | hub child (Community) — declared; admin controls live in panel |

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -1058,3 +1058,48 @@ Notes: rule 1 explicitly REPLACES the earlier "unmonitored-mode / self-approval"
   existing homes (roadmap horizons, this router, the rejection ledger, ai-project-workflow
   §5 idea-states); NO parallel tracker created.
 ```
+
+### Q-0016 — Should the Server Management hub be a first-class subsystem? (2026-06-08)
+
+**Area:** Server management (PR14 hub) / Architecture
+**Type:** Architecture / Product surface
+**Priority:** Medium
+**Status:** Answered in chat (2026-06-08) — **Routed**
+**Suggested destination after answer:** `docs/planning/server-management-status-2026-06-05.md`
+(PR14 subsection) + `docs/subsystems/server-management.md` + this file.
+
+**Question:** PR14's hub was built as a registered `PersistentView`, but a persistent view
+whose `SUBSYSTEM` is not in `SUBSYSTEMS` is an `auto_healable` identity-contract orphan, and
+every other hub (admin/moderation/settings/games/…) is a registered subsystem. Resolve by
+(1) registering `servermanagement` as a first-class subsystem + hub, (2) a non-persistent nav
+`HubView` (drops restart-persistence), or (3) shipping as-is with two advisory diagnostics + the
+self-heal footgun?
+
+**Maintainer answer**
+
+```text
+Make it a first-class subsystem.
+```
+
+**Agent interpretation (not a rewrite of the answer)**
+
+```text
+Durable rule: an operator HUB is a first-class subsystem, consistent with every existing hub
+(admin/moderation/settings/games/community/utility/diagnostic/economy/btd6). A new hub gets a
+SUBSYSTEMS + HUBS entry (administrator tier for operator hubs) so it is help-discoverable and
+the identity-contract / orphan-cog / db-anchor diagnostics stay clean. Do NOT ship a registered
+PersistentView whose SUBSYSTEM has no SUBSYSTEMS entry — that leaves an auto_healable orphan the
+platform's own self-heal would unregister. The registry key follows cog_name_to_subsystem (e.g.
+servermanagement, no underscore); module paths may stay readable (server_management).
+```
+
+**Routing result**
+
+```text
+Destination: server-management status tracker (PR14 subsection, "registered first-class");
+  server-management folio (current state); this Q-block.
+Implemented this session: SUBSYSTEMS["servermanagement"] + HUBS entry (administrator),
+  KNOWN_PANEL_COMMANDS entry, the hub view/cog/service, and the help/discoverability
+  enumerations updated. Live boot: identity-contract clean (STRICT=on), 0 ERROR/CRITICAL.
+Moved/copied on: 2026-06-08 (this session — server-management PR14).
+```

--- a/docs/planning/server-management-pr14-hub-plan.md
+++ b/docs/planning/server-management-pr14-hub-plan.md
@@ -1,8 +1,19 @@
 # Server Management Hub — PR14 implementation plan
 
-> **Status:** `plan` — planned end-state; cross-check source before implementing.
+> **Status:** `historical` — **EXECUTED 2026-06-08.** Built largely as planned;
+> kept for design context. The shipped record is the status tracker's PR14
+> subsection ([`server-management-status-2026-06-05.md`](server-management-status-2026-06-05.md)).
 > **Created:** 2026-06-08 · **Owner area:** server management
 > (folio: [`docs/subsystems/server-management.md`](../subsystems/server-management.md)).
+>
+> **What shipped vs. this plan:** the hub was built as a single PR (14a + 14b
+> folded). Routing uses **`interaction.client.get_cog(...)`** inside the button
+> callbacks (Decision #2 resolved: no registry needed — the get_cog lookup keeps
+> the `views → cogs` boundary clean without a provider). Setup routes to its
+> reusable `open_wizard_from_slash` entry (Decision #3 — the wizard owns its
+> session). The hub cog is **not** a `SUBSYSTEMS` entry (Decision #1: a new thin
+> cog, but deliberately not a governed subsystem — see the tracker). The
+> restart-restoration live-check remains for the maintainer's bot.
 >
 > This is the **last** server-management PR (the implementation plan's PR14). It
 > depends on all the specialized managers, which have shipped. Authoritative

--- a/docs/planning/server-management-status-2026-06-05.md
+++ b/docs/planning/server-management-status-2026-06-05.md
@@ -638,6 +638,56 @@ first). **No second resource path** — creation routes through the audited
   staging path. The deterministic `setup_role_templates` validation is the
   safety filter it will reuse.
 
+### PR14 — Server Management Hub *(built 2026-06-08)*
+
+The capstone: one **navigation** surface — a persistent `!servermanagement`
+(+ aliases `!servermenu` / `!guildmenu`) and an ephemeral `/server-management` —
+composing the specialised managers (moderation, channels, roles, cleanup, setup)
+behind read-only health badges. The hub holds **no domain logic, no new
+mutation / op-kind / migration, and no settings** — every action routes into an
+existing manager's panel. Verify merge status on live GitHub.
+
+- **`services/server_management_hub.py` (new, read-only, fail-safe):**
+  `collect_hub_status(guild) -> HubStatus` composes per-manager badges
+  (🟢/🟡/⛔/❓) from the existing detectors (`utils.moderation_feasibility`,
+  `utils.role_feasibility`, the Manage-Channels perm) plus a cross-cutting
+  config-health line from the already-fail-safe `setup_diagnostics` report and a
+  completeness % from `setup_readiness`. In `services/` so the future web
+  companion (Q-0002) reuses it; **never raises** (a broken detector → ❓ badge).
+- **`views/server_management/hub.py` (new):** `ServerManagementHubView`
+  (`PersistentView`, `@register`, `SUBSYSTEM="servermanagement"`) — one button per
+  manager + Refresh. Routes via
+  `interaction.client.get_cog(...).build_help_menu_view(interaction)` (the proven
+  Games-hub pattern) with a Back-to-hub button, so the view carries **no
+  module-level `cogs` import** (Setup delegates to `open_wizard_from_slash` via a
+  lazy import). **Authority is an administrator floor** re-checked on every
+  interaction (mirrors `ModPanelView`, ADR-005) — not anchor ownership, so the same
+  view backs both the anchored prefix panel and the anchorless ephemeral slash.
+  Restoration is automatic (no-arg constructor + static `servermanagement:*`
+  custom_ids + `restore_anchors`).
+- **`cogs/server_management_cog.py` (new thin cog):** `!servermanagement` (anchored
+  via `panel_manager.get_or_render_panel`) + `/server-management` (ephemeral) + a
+  `build_help_menu_view` help-dropdown hook. Added to `INITIAL_EXTENSIONS`.
+- **Registered first-class (owner decision Q-0016, 2026-06-08):** `servermanagement`
+  is a real `SUBSYSTEMS` + `HUBS` entry (administrator tier) + a `KNOWN_PANEL_COMMANDS`
+  entry — like every other hub — so it is help-discoverable and the
+  identity-contract / orphan-cog / db-anchor diagnostics stay clean. (The
+  alternative — a standalone persistent view with no subsystem — left an
+  `auto_healable` identity finding the platform self-heal would unregister.) The
+  registry **key is `servermanagement`** (no underscore) to match
+  `cog_name_to_subsystem`; module paths stay readable (`server_management`).
+- **Pinned by** `tests/unit/services/test_server_management_hub.py` +
+  `tests/unit/views/test_server_management_hub_view.py` (registration, admin-floor
+  `interaction_check`, manager routing + Back-button, missing-cog / hook-failure,
+  Setup delegation, Refresh, no module-level cogs import, first-class subsystem),
+  plus updated hub / help / discoverability enumerations. Full CI mirror green
+  (8062 passed); arch strict 0 errors; **live-booted clean** (cog loads, view
+  registered under `servermanagement`, `Identity-contract: clean … STRICT=on`,
+  0 ERROR/CRITICAL). **Restart-restoration live-check + a real operator
+  click-through remain for the maintainer's bot.**
+- **Server-management: the PR14 capstone is built. The only remaining queued item
+  is the PR13 AI generation follow-up** (gated/sensitive — see the PR13 subsection).
+
 ---
 
 ## Remaining queue (starts at PR11)
@@ -650,7 +700,7 @@ Per the implementation plan's dependency order. PR7–PR9 shipped (see above).
 | **PR11** | Setup role/moderation/governance sections. **Moderation + Roles sections built in the moderation + roles slices (2026-06-07); Governance section deferred (Q-0008).** | PR5, PR8–PR10, #522 |
 | **PR12** | Setup diagnostics & repair. **Built 2026-06-07** (read-only `setup_diagnostics` service + Diagnose & repair section; `clear_binding` the one safe auto-repair, everything else advisory/blocked — see subsection above). | PR5, #522 |
 | **PR13** | Deterministic + AI role templates. **Deterministic slice built 2026-06-08** (built-in templates + `create_managed_role` op + setup section; see subsection above). **AI generation layer is the remaining PR13 follow-up.** | PR5, #523 |
-| **PR14** | Server Management Hub (last). **← next after the PR13 AI follow-up.** Plan: [`server-management-pr14-hub-plan.md`](server-management-pr14-hub-plan.md). | all managers |
+| **PR14** | Server Management Hub (last). **Built 2026-06-08** (persistent `!servermanagement` + `/server-management` composing the managers behind read-only badges; registered first-class `servermanagement` subsystem + hub — owner decision Q-0016 — see subsection above). | all managers |
 
 Near-term completion items folded into the above: finish PR2's diagnostics/findings
 model and selector paging/search (in PR6 as the first production consumer); finish

--- a/docs/setup-platform/settings-customization-command-map.md
+++ b/docs/setup-platform/settings-customization-command-map.md
@@ -1430,6 +1430,44 @@ Subsystems (22): `admin`, `moderation`, `economy`, `inventory`, `mining`,
     (binding-select) + S7c (provisioning preview/confirm) + S7d
     (panel + Help / Admin integration).
 
+### servermanagement
+
+The unified Server Management mother hub (PR14). A **routing-only** operator
+surface: it composes the moderation / channels / roles / cleanup / setup
+managers behind read-only health badges and owns **no** settings, bindings,
+resources, or mutations of its own.
+
+1. **cog_module**: `disbot/cogs/server_management_cog.py`.
+2. **subsystem**: `servermanagement`.
+3. **current_commands**: `!servermanagement` (aliases `!servermenu`,
+   `!guildmenu`), `/server-management`.
+4. **current_command_groups**: none.
+5. **current_command_panel_or_menu**: `servermanagement` →
+   `views/server_management/hub.py:ServerManagementHubView`.
+6. **help_menu_discoverable**: Yes (mother hub, administrator tier).
+7. **dedicated_panel_command**: `none`.
+8. **help_menu_direct_navigation_hook**: `none` (the cog hosts the command).
+9. **existing_SettingSpec_declarations**: none — routing-only hub.
+10. **existing_settings_keys**: none.
+11. **existing_BindingSpec_entries**: none.
+12. **existing_ResourceRequirement_entries**: none.
+13. **current_access_policy_behavior**: `visibility_tier=administrator`; no
+    capabilities (authority is the administrator floor on the command plus the
+    view's `interaction_check`; per-manager authority is re-checked when routing
+    in — ADR-005).
+14. **hardcoded_or_env_only_behavior**: none — composes existing managers.
+15. **missing_customization_commands**: none (it owns no settings).
+16. **missing_settings_pages**: none.
+17. **missing_menu_buttons_selects_modals**: none planned.
+18. **setting_class_per_value**: n/a.
+19. **target_Settings_Manager_page**: n/a — not a settings-owning subsystem.
+20. **target_mutation_path**: none — every action routes into an existing
+    manager's panel; the hub introduces no op-kind, migration, or pipeline.
+21. **target_help_or_menu_route**: Help mother hub → manager panels.
+22. **provisionable_resources**: none.
+23. **priority**: shipped (server-management PR14).
+24. **recommended_PR_phase**: shipped 2026-06-08.
+
 ## Setting class summary
 
 Cross-cut by class, this is the work distribution implied by the per-cog

--- a/docs/subsystems/server-management.md
+++ b/docs/subsystems/server-management.md
@@ -1,7 +1,7 @@
 # Server management subsystem — folio
 
 > **Status:** `living-ledger` (area index). Source + the status tracker win.
-> **Last updated:** 2026-06-07.
+> **Last updated:** 2026-06-08.
 
 ## What & where
 
@@ -65,6 +65,19 @@ cleanup policy, setup, and the future unified hub. Inspect first:
   write wins.
 - **"Should I add a manager/panel?"** → check the tracker's Remaining queue first;
   reuse selectors + provisioning previews; never add a second resource-creation path.
+- **"Adding a new operator *hub*?"** → an operator hub is a **first-class subsystem** (owner
+  decision Q-0016; every existing hub is one — admin/moderation/settings/games/…). Wire **all**
+  of: (1) a `SUBSYSTEMS` entry + (2) a `HUBS` entry (administrator tier) + (3) a
+  `KNOWN_PANEL_COMMANDS` entry, (4) a `build_help_menu_view` hook on the cog, (5)
+  help-surface-map §1+§2 rows, (6) a command-map `### <subsystem>` section, and (7) the hub-set
+  / help-category / discoverability **enumeration tests**. **Gotcha:** the registry **key must
+  equal `cog_name_to_subsystem(YourCog)`** — it strips `Cog` + lowercases with **no** underscore
+  (so `ServerManagementCog` ⇒ `servermanagement`), and that same string must be the view's
+  `SUBSYSTEM` classvar **and** the `panel_manager.get_or_render_panel` anchor string, or the
+  identity-contract (view), command-surface-ledger (orphan-cog), and db-anchor findings all fire.
+  A registered `PersistentView` whose `SUBSYSTEM` is not in `SUBSYSTEMS` is an `auto_healable`
+  orphan the platform self-heal would unregister. Working exemplar:
+  `views/server_management/hub.py` + `cogs/server_management_cog.py` (PR14).
 
 ## Rules & approved structures (binding — link, don't restate)
 
@@ -113,8 +126,13 @@ cleanup policy, setup, and the future unified hub. Inspect first:
   (routes through `RoleLifecycleService`, optional time/XP tier companion) + a **Role
   templates** setup section. That work also fixed a latent PR11 regression (the roles section's
   `set_role_threshold` op was never added to the DB op-kind gate/CHECK, so it couldn't stage —
-  migration 059 + a drift-guard test close it). The tracker queues the remaining setup work
-  (the PR13 **AI** template layer, then the hub).
+  migration 059 + a drift-guard test close it). **The unified Server Management Hub (PR14) was
+  built 2026-06-08** — a persistent `!servermanagement` + ephemeral `/server-management`
+  composing the managers behind read-only health badges, registered **first-class** as the
+  `servermanagement` subsystem + hub (owner decision Q-0016) via
+  `services/server_management_hub.py` + `views/server_management/hub.py` +
+  `cogs/server_management_cog.py`. The tracker's only remaining server-management item is the
+  **gated PR13 AI template layer**.
 - Known UX follow-ups: moderation member quicksearch via `discord.ui.UserSelect`
   (`unban` remains ID-based); bulk **Clear missing** on time/XP panels; selector-ize
   Edit Role.
@@ -134,9 +152,11 @@ capability-native: a configured role resolves to the `moderator` tier via the go
 tier resolver). **PR11's moderation + roles setup sections are built** (2026-06-07, owner
 decision Q-0008; governance section deferred). **PR12 (setup diagnostics & repair) was
 built 2026-06-07** (read-only `setup_diagnostics` service + a Diagnose & repair section;
-`clear_binding` is the one safe auto-repair, everything else advisory/blocked). Next comes
-**PR13** (role templates), then the unified Server Management Hub. Link to the tracker for
-exact order and dependencies rather than copying them here.
+`clear_binding` is the one safe auto-repair, everything else advisory/blocked). **PR13's
+deterministic role-templates slice shipped 2026-06-08, and PR14 (the unified Server Management
+Hub) was built 2026-06-08** (registered first-class as the `servermanagement` subsystem + hub,
+owner decision Q-0016). The only remaining item is the gated PR13 AI generation layer. Link to
+the tracker for exact order and dependencies rather than copying them here.
 
 ## Ideas (not approved)
 
@@ -160,9 +180,12 @@ reusable so a web companion is *possible* later, but do not start web work now.
    `setup_diagnostics` service + Diagnose & repair section (reuses `resource_health` /
    `role_feasibility` / `cleanup_diagnostics`; `clear_binding` the lone safe auto-repair,
    staged through Final Review). **PR13's deterministic role-templates slice shipped 2026-06-08**
-   (`setup_role_templates` + `create_managed_role` + Role-templates section). Next is the
-   **PR13 AI generation follow-up**, then the hub (PR14). Reuse provisioning
-   previews/confirmation + capability checks; never add a second resource-creation path.
+   (`setup_role_templates` + `create_managed_role` + Role-templates section), and **PR14 (the
+   unified Server Management Hub) was built 2026-06-08** (first-class `servermanagement`
+   subsystem + hub, Q-0016 — composes the managers behind read-only badges, no new mutation
+   path). The lane's only remaining item is the **gated PR13 AI generation follow-up**. Reuse
+   provisioning previews/confirmation + capability checks; never add a second resource-creation
+   path.
 2. Take one bounded known UX follow-up (member quicksearch or role selector/cleanup)
    without changing lifecycle ownership.
 3. When extending setup, reuse provisioning previews/confirmation and capability

--- a/tests/unit/help/test_help_category_view.py
+++ b/tests/unit/help/test_help_category_view.py
@@ -133,6 +133,7 @@ def test_view_has_one_select_with_visible_hubs_plus_all_commands():
         "admin",
         "settings",
         "diagnostic",
+        "servermanagement",
         ALL_COMMANDS_KEY,
     }
 

--- a/tests/unit/services/test_server_management_hub.py
+++ b/tests/unit/services/test_server_management_hub.py
@@ -1,0 +1,330 @@
+"""Tests for services.server_management_hub — the PR14 hub badge composer.
+
+The read-only model behind the Server Management hub's health badges.  Pins:
+
+* per-manager glyph mapping (moderation / channels / roles capability),
+* the cleanup + setup badges derived from the (fail-safe) diagnostics report,
+* the overall config-health line,
+* the fail-safe contract: a broken detector degrades one badge to ``❓`` and
+  ``collect_hub_status`` never raises.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services import server_management_hub as hub
+from services.server_management_hub import (
+    GLYPH_ATTENTION,
+    GLYPH_BLOCKED,
+    GLYPH_HEALTHY,
+    GLYPH_UNKNOWN,
+    collect_hub_status,
+)
+from services.setup_diagnostics import SetupDiagnosticFinding, SetupDiagnosticsReport
+
+
+def _guild(
+    *,
+    manage_channels: bool = True,
+    manage_roles: bool = True,
+    ban: bool = True,
+    kick: bool = True,
+    timeout: bool = True,
+    admin: bool = False,
+    me_is_none: bool = False,
+) -> MagicMock:
+    guild = MagicMock()
+    guild.id = 99
+    if me_is_none:
+        guild.me = None
+        guild.roles = []
+        return guild
+    perms = MagicMock()
+    perms.manage_channels = manage_channels
+    perms.manage_roles = manage_roles
+    perms.ban_members = ban
+    perms.kick_members = kick
+    perms.moderate_members = timeout
+    perms.administrator = admin
+    guild.me.guild_permissions = perms
+    guild.me.top_role.position = 5
+    guild.me.top_role.name = "Galaxy Bot"
+    guild.roles = [MagicMock() for _ in range(6)]
+    return guild
+
+
+def _finding(severity: str, subsystem: str = "moderation") -> SetupDiagnosticFinding:
+    return SetupDiagnosticFinding(
+        code="x",
+        severity=severity,
+        subsystem=subsystem,
+        section_slug=None,
+        resource_type=None,
+        resource_id=None,
+        summary="s",
+        detail="d",
+        repairability="advisory_only",
+    )
+
+
+def _report(*findings: SetupDiagnosticFinding) -> SetupDiagnosticsReport:
+    return SetupDiagnosticsReport(guild_id=99, findings=tuple(findings))
+
+
+def _badge(status, key):
+    return next(b for b in status.badges if b.key == key)
+
+
+def _patch_detectors(report: SetupDiagnosticsReport | None, percentage: int | None):
+    """Patch both async detectors the composer fans out to."""
+    diag = (
+        AsyncMock(return_value=report)
+        if report is not None
+        else AsyncMock(side_effect=RuntimeError("diag down"))
+    )
+    readiness_report = MagicMock()
+    readiness_report.percentage = percentage if percentage is not None else 0
+    ready = (
+        AsyncMock(return_value=readiness_report)
+        if percentage is not None
+        else AsyncMock(side_effect=RuntimeError("readiness down"))
+    )
+    return patch.multiple(
+        "services.setup_diagnostics",
+        collect_setup_diagnostics=diag,
+    ), patch("services.setup_readiness.collect", ready)
+
+
+# ---------------------------------------------------------------------------
+# Shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_collect_returns_five_manager_badges():
+    diag_p, ready_p = _patch_detectors(_report(), 100)
+    with diag_p, ready_p, patch(
+        "utils.role_feasibility.manageable_roles",
+        return_value=([MagicMock(), MagicMock()], []),
+    ):
+        status = await collect_hub_status(_guild())
+    assert {b.key for b in status.badges} == {
+        hub.MOD,
+        hub.CHANNELS,
+        hub.ROLES,
+        hub.CLEANUP,
+        hub.SETUP,
+    }
+    assert status.guild_id == 99
+
+
+# ---------------------------------------------------------------------------
+# Capability badges
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_moderation_badge_healthy_when_fully_capable():
+    diag_p, ready_p = _patch_detectors(_report(), 100)
+    with diag_p, ready_p, patch(
+        "utils.role_feasibility.manageable_roles", return_value=([MagicMock()], [])
+    ):
+        status = await collect_hub_status(_guild())
+    assert _badge(status, hub.MOD).glyph == GLYPH_HEALTHY
+
+
+@pytest.mark.asyncio
+async def test_moderation_badge_attention_when_missing_permission():
+    diag_p, ready_p = _patch_detectors(_report(), 100)
+    with diag_p, ready_p, patch(
+        "utils.role_feasibility.manageable_roles", return_value=([MagicMock()], [])
+    ):
+        status = await collect_hub_status(_guild(ban=False))
+    badge = _badge(status, hub.MOD)
+    assert badge.glyph == GLYPH_ATTENTION
+    assert "Ban Members" in badge.summary
+
+
+@pytest.mark.asyncio
+async def test_channels_badge_blocked_without_manage_channels():
+    diag_p, ready_p = _patch_detectors(_report(), 100)
+    with diag_p, ready_p, patch(
+        "utils.role_feasibility.manageable_roles", return_value=([MagicMock()], [])
+    ):
+        status = await collect_hub_status(_guild(manage_channels=False))
+    assert _badge(status, hub.CHANNELS).glyph == GLYPH_BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_roles_badge_blocked_without_manage_roles():
+    diag_p, ready_p = _patch_detectors(_report(), 100)
+    with diag_p, ready_p:
+        status = await collect_hub_status(_guild(manage_roles=False))
+    assert _badge(status, hub.ROLES).glyph == GLYPH_BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_roles_badge_healthy_reports_manageable_count():
+    diag_p, ready_p = _patch_detectors(_report(), 100)
+    with diag_p, ready_p, patch(
+        "utils.role_feasibility.manageable_roles",
+        return_value=([MagicMock(), MagicMock(), MagicMock()], [MagicMock()]),
+    ):
+        status = await collect_hub_status(_guild())
+    badge = _badge(status, hub.ROLES)
+    assert badge.glyph == GLYPH_HEALTHY
+    assert "3 of 6" in badge.summary
+
+
+# ---------------------------------------------------------------------------
+# Cleanup + setup badges (diagnostics-derived)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cleanup_badge_attention_on_cleanup_finding():
+    report = _report(_finding("warning", subsystem="cleanup"))
+    diag_p, ready_p = _patch_detectors(report, 100)
+    with diag_p, ready_p, patch(
+        "utils.role_feasibility.manageable_roles", return_value=([MagicMock()], [])
+    ):
+        status = await collect_hub_status(_guild())
+    assert _badge(status, hub.CLEANUP).glyph == GLYPH_ATTENTION
+
+
+@pytest.mark.asyncio
+async def test_cleanup_badge_healthy_when_no_cleanup_findings():
+    report = _report(_finding("warning", subsystem="moderation"))
+    diag_p, ready_p = _patch_detectors(report, 100)
+    with diag_p, ready_p, patch(
+        "utils.role_feasibility.manageable_roles", return_value=([MagicMock()], [])
+    ):
+        status = await collect_hub_status(_guild())
+    assert _badge(status, hub.CLEANUP).glyph == GLYPH_HEALTHY
+
+
+@pytest.mark.asyncio
+async def test_setup_badge_blocked_when_report_has_blocker():
+    report = _report(_finding("blocker", subsystem="moderation"))
+    diag_p, ready_p = _patch_detectors(report, 95)
+    with diag_p, ready_p, patch(
+        "utils.role_feasibility.manageable_roles", return_value=([MagicMock()], [])
+    ):
+        status = await collect_hub_status(_guild())
+    assert _badge(status, hub.SETUP).glyph == GLYPH_BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_setup_badge_healthy_at_high_percentage():
+    diag_p, ready_p = _patch_detectors(_report(), 88)
+    with diag_p, ready_p, patch(
+        "utils.role_feasibility.manageable_roles", return_value=([MagicMock()], [])
+    ):
+        status = await collect_hub_status(_guild())
+    badge = _badge(status, hub.SETUP)
+    assert badge.glyph == GLYPH_HEALTHY
+    assert "88%" in badge.summary
+
+
+@pytest.mark.asyncio
+async def test_setup_badge_attention_when_unconfigured():
+    diag_p, ready_p = _patch_detectors(_report(), 0)
+    with diag_p, ready_p, patch(
+        "utils.role_feasibility.manageable_roles", return_value=([MagicMock()], [])
+    ):
+        status = await collect_hub_status(_guild())
+    assert _badge(status, hub.SETUP).glyph == GLYPH_ATTENTION
+
+
+# ---------------------------------------------------------------------------
+# Overall config-health line
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_overall_healthy_when_report_clean():
+    diag_p, ready_p = _patch_detectors(_report(), 100)
+    with diag_p, ready_p, patch(
+        "utils.role_feasibility.manageable_roles", return_value=([MagicMock()], [])
+    ):
+        status = await collect_hub_status(_guild())
+    assert status.overall_glyph == GLYPH_HEALTHY
+
+
+@pytest.mark.asyncio
+async def test_overall_counts_warnings_and_advisories():
+    report = _report(
+        _finding("warning", "moderation"),
+        _finding("warning", "cleanup"),
+        _finding("advisory", "roles"),
+    )
+    diag_p, ready_p = _patch_detectors(report, 100)
+    with diag_p, ready_p, patch(
+        "utils.role_feasibility.manageable_roles", return_value=([MagicMock()], [])
+    ):
+        status = await collect_hub_status(_guild())
+    assert status.overall_glyph == GLYPH_ATTENTION
+    assert "2 warnings" in status.overall_summary
+    assert "1 advisory" in status.overall_summary
+
+
+@pytest.mark.asyncio
+async def test_overall_blocked_when_blocker_present():
+    report = _report(_finding("blocker", "moderation"))
+    diag_p, ready_p = _patch_detectors(report, 100)
+    with diag_p, ready_p, patch(
+        "utils.role_feasibility.manageable_roles", return_value=([MagicMock()], [])
+    ):
+        status = await collect_hub_status(_guild())
+    assert status.overall_glyph == GLYPH_BLOCKED
+
+
+# ---------------------------------------------------------------------------
+# Fail-safe contract — never raises, degrades to unknown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_collect_never_raises_when_diagnostics_down():
+    diag_p, ready_p = _patch_detectors(None, None)  # both detectors raise
+    with diag_p, ready_p, patch(
+        "utils.role_feasibility.manageable_roles", return_value=([MagicMock()], [])
+    ):
+        status = await collect_hub_status(_guild())
+    # The composer still returns a full set of badges.
+    assert {b.key for b in status.badges} == {
+        hub.MOD,
+        hub.CHANNELS,
+        hub.ROLES,
+        hub.CLEANUP,
+        hub.SETUP,
+    }
+    assert status.overall_glyph == GLYPH_UNKNOWN
+    assert _badge(status, hub.CLEANUP).glyph == GLYPH_UNKNOWN
+    assert _badge(status, hub.SETUP).glyph == GLYPH_UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_roles_badge_unknown_when_feasibility_raises():
+    diag_p, ready_p = _patch_detectors(_report(), 100)
+    with diag_p, ready_p, patch(
+        "utils.role_feasibility.manageable_roles",
+        side_effect=RuntimeError("boom"),
+    ):
+        status = await collect_hub_status(_guild())
+    assert _badge(status, hub.ROLES).glyph == GLYPH_UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_collect_handles_missing_guild_me():
+    diag_p, ready_p = _patch_detectors(_report(), 100)
+    with diag_p, ready_p:
+        status = await collect_hub_status(_guild(me_is_none=True))
+    # No guild.me → moderation degrades to unknown, channels/roles blocked,
+    # and nothing raises.
+    assert _badge(status, hub.MOD).glyph == GLYPH_UNKNOWN
+    assert _badge(status, hub.CHANNELS).glyph == GLYPH_BLOCKED
+    assert _badge(status, hub.ROLES).glyph == GLYPH_BLOCKED

--- a/tests/unit/utils/test_hub_registry.py
+++ b/tests/unit/utils/test_hub_registry.py
@@ -64,6 +64,7 @@ def test_committed_hub_set_matches_promoted_hubs():
         "admin",
         "settings",
         "diagnostic",
+        "servermanagement",
     }
 
 
@@ -277,6 +278,7 @@ def test_hubs_for_tier_administrator_sees_all():
         "admin",
         "settings",
         "diagnostic",
+        "servermanagement",
     }
 
 
@@ -292,6 +294,7 @@ def test_hubs_for_tier_owner_sees_all():
         "admin",
         "settings",
         "diagnostic",
+        "servermanagement",
     }
 
 

--- a/tests/unit/views/test_server_management_hub_view.py
+++ b/tests/unit/views/test_server_management_hub_view.py
@@ -1,0 +1,336 @@
+"""Tests for views.server_management.hub — the PR14 Server Management hub view.
+
+Pins the shape + behaviour contract:
+
+* persistent-view registration (restoration works for free),
+* static, namespaced, actionable button custom_ids,
+* admin-floor ``interaction_check`` (authority, not ownership — works for the
+  anchored prefix panel AND the ephemeral slash),
+* manager routing into each cog's ``build_help_menu_view`` hook with
+  Back-to-hub attached, plus graceful missing-cog / hook-failure handling,
+* the Setup button delegating to the wizard entry,
+* the Refresh button recomposing in place,
+* no module-level ``cogs`` import (the ``views → cogs`` arch boundary).
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from core.runtime.persistent_views import get_view_class
+from services.server_management_hub import HubStatus, ManagerBadge
+from views.server_management import hub as hub_mod
+from views.server_management.hub import (
+    _ROUTED_MANAGERS,
+    ServerManagementHubView,
+    build_hub_embed,
+    build_server_management_hub,
+)
+
+_BUTTON_IDS = {
+    "servermanagement:moderation",
+    "servermanagement:channels",
+    "servermanagement:roles",
+    "servermanagement:cleanup",
+    "servermanagement:setup",
+    "servermanagement:refresh",
+}
+
+
+def _interaction(*, admin: bool = True, guild: bool = True) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.user.guild_permissions.administrator = admin
+    interaction.guild = MagicMock() if guild else None
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    return interaction
+
+
+def _button(view: ServerManagementHubView, custom_id: str) -> discord.ui.Button:
+    return next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id == custom_id
+    )
+
+
+def _status() -> HubStatus:
+    return HubStatus(
+        guild_id=1,
+        badges=(
+            ManagerBadge("moderation", "🛡️", "Moderation", "🟢", "ok"),
+            ManagerBadge("setup", "🧩", "Setup", "🟡", "64% configured"),
+        ),
+        overall_glyph="🟡",
+        overall_summary="1 warning",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration + shape
+# ---------------------------------------------------------------------------
+
+
+def test_view_is_registered_for_restoration():
+    assert get_view_class("servermanagement") is ServerManagementHubView
+    assert ServerManagementHubView.SUBSYSTEM == "servermanagement"
+
+
+def test_view_subsystem_is_registered_first_class():
+    """The hub is a first-class subsystem — its SUBSYSTEM must resolve in
+    SUBSYSTEMS so the identity-contract validator finds no orphan view and
+    restoration maps the anchor back to this class.
+    """
+    from utils.subsystem_registry import SUBSYSTEMS
+
+    assert ServerManagementHubView.SUBSYSTEM in SUBSYSTEMS
+
+
+def test_view_constructs_with_no_args_for_restoration():
+    # restore_anchors calls view_cls() with no args — must not raise.
+    view = ServerManagementHubView()
+    assert view.timeout is None  # PersistentView
+
+
+def test_view_has_expected_button_custom_ids():
+    view = ServerManagementHubView()
+    actual = {
+        c.custom_id
+        for c in view.children
+        if isinstance(c, discord.ui.Button)
+    }
+    assert actual == _BUTTON_IDS
+
+
+def test_buttons_are_actionable_no_placeholders():
+    view = ServerManagementHubView()
+    forbidden = ("coming soon", "todo", "wip", "placeholder", "tbd")
+    for btn in view.children:
+        if not isinstance(btn, discord.ui.Button):
+            continue
+        assert btn.disabled is False
+        lower = (btn.label or "").lower()
+        assert not any(tok in lower for tok in forbidden)
+
+
+def test_component_count_under_discord_cap_with_back_to_help():
+    view = ServerManagementHubView()
+    view.add_item(
+        discord.ui.Button(
+            label="↩ Back to Help",
+            style=discord.ButtonStyle.secondary,
+            custom_id="help:back",
+            row=4,
+        ),
+    )
+    assert len(view.children) <= 25
+
+
+def test_routed_managers_cover_four_specialised_cogs():
+    assert set(_ROUTED_MANAGERS) == {"moderation", "channels", "roles", "cleanup"}
+    assert _ROUTED_MANAGERS["moderation"][0] == "ModerationCog"
+    assert _ROUTED_MANAGERS["cleanup"][0] == "Cleanup"
+
+
+# ---------------------------------------------------------------------------
+# Authority — admin floor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_interaction_check_admits_admin():
+    view = ServerManagementHubView()
+    assert await view.interaction_check(_interaction(admin=True)) is True
+
+
+@pytest.mark.asyncio
+async def test_interaction_check_denies_non_admin_with_ephemeral():
+    view = ServerManagementHubView()
+    interaction = _interaction(admin=False)
+    assert await view.interaction_check(interaction) is False
+    interaction.response.send_message.assert_awaited_once()
+    _args, kwargs = interaction.response.send_message.call_args
+    assert kwargs.get("ephemeral") is True
+
+
+# ---------------------------------------------------------------------------
+# Manager routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_manager_routes_and_attaches_back_button():
+    view = ServerManagementHubView()
+    interaction = _interaction()
+    child_view = discord.ui.View()
+    child_embed = discord.Embed(title="Mod")
+    fake_cog = MagicMock()
+    fake_cog.build_help_menu_view = AsyncMock(return_value=(child_embed, child_view))
+    interaction.client.get_cog.return_value = fake_cog
+
+    await view._open_manager(interaction, "moderation")
+
+    interaction.client.get_cog.assert_called_once_with("ModerationCog")
+    interaction.response.edit_message.assert_awaited_once()
+    _args, kwargs = interaction.response.edit_message.call_args
+    assert kwargs["embed"] is child_embed
+    assert kwargs["view"] is child_view
+    back = [
+        c
+        for c in child_view.children
+        if isinstance(c, discord.ui.Button)
+        and c.custom_id == "servermanagement:back"
+    ]
+    assert len(back) == 1
+
+
+@pytest.mark.asyncio
+async def test_open_manager_resolves_each_routed_cog_name():
+    for key, (cog_name, _label) in _ROUTED_MANAGERS.items():
+        view = ServerManagementHubView()
+        interaction = _interaction()
+        fake_cog = MagicMock()
+        fake_cog.build_help_menu_view = AsyncMock(
+            return_value=(discord.Embed(), discord.ui.View())
+        )
+        interaction.client.get_cog.return_value = fake_cog
+        await view._open_manager(interaction, key)
+        interaction.client.get_cog.assert_called_once_with(cog_name)
+
+
+@pytest.mark.asyncio
+async def test_open_manager_missing_cog_sends_ephemeral():
+    view = ServerManagementHubView()
+    interaction = _interaction()
+    interaction.client.get_cog.return_value = None
+
+    await view._open_manager(interaction, "moderation")
+
+    interaction.response.send_message.assert_awaited_once()
+    interaction.response.edit_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_open_manager_hook_failure_sends_ephemeral_not_crash():
+    view = ServerManagementHubView()
+    interaction = _interaction()
+    fake_cog = MagicMock()
+    fake_cog.build_help_menu_view = AsyncMock(side_effect=RuntimeError("boom"))
+    interaction.client.get_cog.return_value = fake_cog
+
+    await view._open_manager(interaction, "roles")
+
+    interaction.response.send_message.assert_awaited_once()
+    interaction.response.edit_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_manager_buttons_delegate_to_open_manager():
+    expected = {
+        "servermanagement:moderation": "moderation",
+        "servermanagement:channels": "channels",
+        "servermanagement:roles": "roles",
+        "servermanagement:cleanup": "cleanup",
+    }
+    for custom_id, key in expected.items():
+        view = ServerManagementHubView()
+        interaction = _interaction()
+        with patch.object(
+            ServerManagementHubView, "_open_manager", new=AsyncMock()
+        ) as mock_open:
+            await _button(view, custom_id).callback(interaction)
+        mock_open.assert_awaited_once_with(interaction, key)
+
+
+@pytest.mark.asyncio
+async def test_setup_button_opens_wizard_entry():
+    view = ServerManagementHubView()
+    interaction = _interaction()
+    with patch(
+        "cogs.setup._wizard_entry.open_wizard_from_slash",
+        new=AsyncMock(),
+    ) as mock_open:
+        await _button(view, "servermanagement:setup").callback(interaction)
+    mock_open.assert_awaited_once_with(interaction)
+
+
+# ---------------------------------------------------------------------------
+# Refresh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_recomposes_in_place():
+    view = ServerManagementHubView()
+    interaction = _interaction()
+    with patch.object(
+        hub_mod, "collect_hub_status", new=AsyncMock(return_value=_status())
+    ), patch.object(
+        hub_mod, "safe_defer", new=AsyncMock(return_value=True)
+    ), patch.object(hub_mod, "safe_edit", new=AsyncMock()) as mock_edit:
+        await _button(view, "servermanagement:refresh").callback(interaction)
+    mock_edit.assert_awaited_once()
+    _args, kwargs = mock_edit.call_args
+    assert kwargs["view"] is view
+
+
+@pytest.mark.asyncio
+async def test_refresh_outside_guild_sends_ephemeral():
+    view = ServerManagementHubView()
+    interaction = _interaction(guild=False)
+    await _button(view, "servermanagement:refresh").callback(interaction)
+    interaction.response.send_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_server_management_hub_returns_embed_and_view():
+    with patch.object(
+        hub_mod, "collect_hub_status", new=AsyncMock(return_value=_status())
+    ):
+        embed, view = await build_server_management_hub(MagicMock())
+    assert isinstance(embed, discord.Embed)
+    assert isinstance(view, ServerManagementHubView)
+
+
+def test_build_hub_embed_renders_badges_and_overall():
+    embed = build_hub_embed(_status())
+    assert embed.title is not None and "Server Management" in embed.title
+    text = "\n".join(f"{f.name}\n{f.value}" for f in embed.fields)
+    assert "Moderation" in text
+    assert "Setup" in text
+    assert "configuration health" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Arch boundary — no module-level cogs import
+# ---------------------------------------------------------------------------
+
+
+def test_no_module_level_cogs_import():
+    """The hub view must reach cogs only via lazy (function-body) imports or
+    ``interaction.client.get_cog`` — never a module-level ``views → cogs`` edge.
+    """
+    src = inspect.getsource(hub_mod)
+    tree = ast.parse(src)
+    for node in tree.body:  # module-level statements only
+        if isinstance(node, ast.ImportFrom) and (node.module or "").startswith(
+            "cogs"
+        ):
+            pytest.fail(f"module-level cogs import: from {node.module}")
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert not alias.name.startswith(
+                    "cogs"
+                ), f"module-level cogs import: {alias.name}"


### PR DESCRIPTION
## What

The capstone of the server-management initiative (the implementation plan's **PR14**): one **navigation** surface — a persistent `!servermanagement` (+ aliases `!servermenu` / `!guildmenu`) and an ephemeral `/server-management` — giving an operator a single entry point to the moderation / channels / roles / cleanup / setup managers, with **read-only health badges** summarising what needs attention.

The hub holds **zero domain logic, no new mutation / op-kind / migration, and no settings** — every action routes into an existing manager's panel.

## How

- **`services/server_management_hub.py`** (new, read-only, **fail-safe**) — `collect_hub_status(guild) -> HubStatus` composes per-manager badges (🟢/🟡/⛔/❓) from the existing detectors (`utils.moderation_feasibility`, `utils.role_feasibility`, the Manage-Channels perm) + a cross-cutting config-health line from `setup_diagnostics` + a `setup_readiness` %. Lives in `services/` so a future web companion (owner intent Q-0002) reuses it; **never raises** (a broken detector → ❓).
- **`views/server_management/hub.py`** (new) — `ServerManagementHubView(PersistentView)`: one button per manager + Refresh. Routes via `interaction.client.get_cog(...).build_help_menu_view(interaction)` (the proven Games-hub pattern) with a Back-to-hub button, so the view has **no module-level `views → cogs` import**; Setup delegates to its `open_wizard_from_slash` entry (lazy import). **Authority is an administrator floor** re-checked on every interaction (mirrors `ModPanelView`, ADR-005) — not anchor ownership — so the one view backs both the anchored prefix panel and the anchorless ephemeral slash.
- **`cogs/server_management_cog.py`** (new thin cog) — the two front doors + a `build_help_menu_view` help hook; added to `INITIAL_EXTENSIONS`.

## First-class registration (owner decision Q-0016)

Mid-build, a registered `PersistentView` whose `SUBSYSTEM` isn't in `SUBSYSTEMS` turned out to be an `auto_healable` identity-contract orphan (the platform self-heal would *unregister* it), and **every other hub is a registered subsystem**. The maintainer chose **make it first-class**: `servermanagement` is now a real `SUBSYSTEMS` + `HUBS` entry (administrator tier) + a `KNOWN_PANEL_COMMANDS` entry — help-discoverable, with the identity-contract / orphan-cog / db-anchor diagnostics clean. (Key is `servermanagement` to match `cog_name_to_subsystem`; module paths stay readable as `server_management`.)

## Verification

- `python3.10 scripts/check_quality.py --full` — **green, 8062 passed**, 3 skipped (lint + mypy + full pytest).
- `python3.10 scripts/check_architecture.py --mode strict` — **0 errors**.
- **Live boot** (test bot) — `ServerManagementCog loaded`, view registered under `servermanagement`, **`Identity-contract: clean … STRICT=on`**, 0 ERROR/CRITICAL.
- New tests: `tests/unit/services/test_server_management_hub.py`, `tests/unit/views/test_server_management_hub_view.py`.

**Not verifiable in the sandbox** (for the maintainer's bot): persistent-view **restoration across a real restart**, and a real operator click-through of the routing.

## Scope / what remains

Server-management is now **structurally complete**. The only remaining item is the **gated PR13 AI generation layer** ("Generate with AI" role templates), which stays behind the AI-expansion gate and isn't live-testable here (no provider keys).

Authoritative record: the [status tracker](docs/planning/server-management-status-2026-06-05.md) PR14 subsection. Owner decision preserved as **Q-0016** in the question router; the PR14 plan is re-badged `historical` (executed).

https://claude.ai/code/session_01V48N81i3iM6uJ6sBqTGGeg

---
_Generated by [Claude Code](https://claude.ai/code/session_01V48N81i3iM6uJ6sBqTGGeg)_