### PR TITLE
docs: add Adaptive Setup/Access/Profile/Routine planning doc and route owner questions

### DIFF
--- a/.sessions/2026-06-08-adaptive-setup-platform-source-map.md
+++ b/.sessions/2026-06-08-adaptive-setup-platform-source-map.md
@@ -1,0 +1,31 @@
+# 2026-06-08 — Adaptive setup/access/profile/routine source map
+
+## Arc
+
+- Verified binding workflow/current-state/roadmap/owner decisions, relevant subsystem folios/plans/ideas, live merged PR #584/#585 state, and that no PRs were open.
+- Mapped setup drafts/Final Review, command access, cog routing, governance/help, diagnostics, server-management managers, settings panels, and automation infrastructure.
+- Created the one comprehensive planning document required by Q-0017, routed six genuinely blocking follow-up decisions, and linked the plan from the roadmap and settings/bindings/provisioning folio.
+
+## Result
+
+- Canonical plan: [`docs/planning/adaptive-setup-access-routine-platform-2026-06-08.md`](../docs/planning/adaptive-setup-access-routine-platform-2026-06-08.md).
+- Near-term destination: Q-0026 identity repair, then an Opus access/read-model contract session before new mutation surfaces.
+- No runtime code or schema changed.
+
+## Findings / gates
+
+- Existing panels share UI bases and many canonical services, but not one edit rule: setup sections use drafts/Final Review; focused settings and runtime managers write directly; role thresholds and portions of channel management are notable normalization risks before automation.
+- `context_map.py` initially could not run because the selected Python 3.10 environment lacked PyYAML; after installing PyYAML, maps completed for setup operations, command routing, automation executor, and setup diagnostics.
+- Q-0028–Q-0033 now own unresolved catalogue, quiet-mode ownership, snapshots, risk classification, UI naming, and account-link privacy decisions.
+
+## Verification
+
+- `PYENV_VERSION=3.10.20 python3.10 scripts/check_docs.py` — passed.
+- `PYENV_VERSION=3.10.20 python3.10 scripts/check_architecture.py --mode strict` — 0 errors, 87 known warnings.
+- GitHub API — PR #584/#585 merged; no open PRs.
+
+## Context delta
+
+- **Needed but not pointed to:** the manager-panel write-path comparison required direct source inspection across `views/roles/`, `views/channels/`, `views/cleanup/`, and settings editors; no single current inventory fully captures their direct-vs-draft behavior.
+- **Pointed to but didn't need:** no broad stability audit or live bot boot was needed for this docs-only planning session, consistent with the accepted #535 baseline.
+- **Discovered by hand:** the strongest future unification boundary is not a universal panel base; it is a shared read/explanation model plus explicit direct-vs-draft mutation lanes.

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -6,46 +6,9 @@
 > live GitHub** before trusting it (two same-session reports already
 > contradicted each other across a single merge).
 >
-> **▶ Next action:** **Server-management is structurally complete — PR14 (Server Management
-> Hub) was built 2026-06-08:** a persistent `!servermanagement` + ephemeral `/server-management`
-> composing the moderation / channels / roles / cleanup / setup managers behind read-only health
-> badges, registered **first-class** as the `servermanagement` subsystem + hub (owner decision
-> **Q-0016**) so it is help-discoverable and the identity contract stays clean (no new mutation /
-> op-kind / migration / settings). Verify merge on live GitHub — authoritative scope is the
-> [status tracker](planning/server-management-status-2026-06-05.md) PR14 subsection. The **only
-> remaining server-management item is the _gated_ PR13 AI generation layer** ("Generate with AI"
-> role templates, behind the AI-expansion gate below + **not** live-testable here without provider
-> keys); with the lane otherwise done, the next session should pick the next lane from
-> [`docs/roadmap.md`](roadmap.md) or groom `docs/ideas/`. **PR13's deterministic slice was built 2026-06-08:**
-> `services/setup_role_templates.py` (built-in, permission-free role bundles + pure
-> `plan_template`) + a new audited **`create_managed_role`** op-kind (routes through
-> `RoleLifecycleService`, optional time/XP tier companion) + a **Role templates** setup
-> section that previews a template and stages role creation through the **Final-Review apply
-> gate**. It also fixed a **latent PR11 regression** — the roles section's
-> `set_role_threshold` op could never be staged (the DB op-kind gate + migration CHECK were
-> never widened); **migration 059** closes it, with a drift-guard test pinning the dispatcher
-> ↔ DB-gate ↔ migration CHECK in lockstep. Verify merge status on live GitHub; see the
-> server-management [status tracker](planning/server-management-status-2026-06-05.md) PR13
-> subsection. **PR12 (setup diagnostics & repair) was built 2026-06-07.** PR11 (moderation +
-> roles) merged via **#570**; PR11's **governance** section stays **deferred** (owner decision
-> **Q-0008**). Authoritative scope + dependencies: the status tracker's Remaining-queue.
+> **▶ Next action:** Server-management is structurally complete after merged **#584**. The next source-grounded lane is the [Adaptive Setup, Access, Profile, and Routine Platform](planning/adaptive-setup-access-routine-platform-2026-06-08.md): begin with Phase 0's decided Q-0026 multi-word subsystem identity repair, then an Opus access/read-model contract session before any new mutation surface. Owner decisions Q-0017–Q-0027 are merged via **#585**; Q-0028–Q-0033 route the remaining profile/risk/rollback/UI/privacy choices. The server-management PR13 AI generation layer remains gated by the AI-expansion gate.
 >
-> **Last updated:** 2026-06-08 · **Server-management PR14 (Server Management Hub) built and
-> registered first-class as the `servermanagement` subsystem + hub (owner decision Q-0016);
-> live boot reports `Identity-contract: clean … STRICT=on`.** Prior 2026-06-08 work — **docs
-> consolidation (Q-0010) + idea-backlog lifecycle
-> (Q-0015):** Top-level `docs/` shrunk **41 → 16** (plans / audits / inventories / historical
-> moved into clustered subdirs — `docs/ai/`, `docs/setup-platform/`, `docs/health/` — and the
-> type buckets behind their folios; `_TOP_LEVEL_DOCS_BUDGET` lowered 41 → 16). The idea
-> backlog is now a routed **lifecycle + end-of-session grooming secondary task**
-> (`docs/ideas/README.md`); binding-doc **section-ownership** documented for concurrent
-> chats (`docs/owner/ai-project-workflow.md` §9). Docs-only; verify merge status on live GitHub.
-> Most recent merged code: server-management **PR13** deterministic role templates + migration
-> 059 (#582, 2026-06-08). **PR14 (the hub) is built but not yet merged — verify on live GitHub.**
-> **This file lists only _merged_ work + the ▶ Next action;** get
-> in-flight PRs from live GitHub (`list_pull_requests`) — naming an open PR's status in prose
-> here rots on merge (a `scripts/check_docs.py` freshness gate enforces this).
->
+> **Last updated:** 2026-06-08 · **#584 merged** the first-class Server Management Hub; **#585 merged** Q-0017–Q-0027 for the Adaptive Setup/Access/Routine planning lane. Source and live GitHub state supersede older same-session PR14 wording. This file lists only merged work + the next action; verify open PRs live.
 > **Purpose:** the one file that answers "what is true right now?" so a new
 > session does not reconstruct it from the journal + planning docs. Read it
 > **second**, right after `.claude/CLAUDE.md`.
@@ -74,6 +37,8 @@ Source code and merged PRs win over anything written here.
 > get it from live GitHub. The newest merge a session sees may not be added yet; that
 > lag is expected (the next session reconciles). A merged PR tagged "pending" is the bug.
 
+- **#585** — captured and routed owner decisions Q-0017–Q-0027 for the Adaptive Setup/Access/Routine planning lane.
+- **#584** — merged the unified Server Management Hub as a first-class subsystem and completed the non-AI server-management lane.
 - **#582** — server-management **PR13 deterministic slice**: `services/setup_role_templates.py` (built-in permission-free role bundles + pure `plan_template`) + the audited **`create_managed_role`** op-kind (routes through `RoleLifecycleService`, optional time/XP tier companion) + a **Role templates** setup section. Fixed a **latent PR11 regression** (the roles section's `set_role_threshold` op was never added to the DB op-kind gate/CHECK → couldn't stage): **migration 059** + a dispatcher↔gate↔CHECK drift-guard test close it. The **PR13 AI generation layer** + PR14 (hub) remained queued. (PR12 setup diagnostics & repair shipped 2026-06-07.)
 - **#581** — idea-backlog grooming demo (Q-0015): promoted the mining-brainstorm `!explore` wiring into a structured plan + a `docs/roadmap.md` horizon; the standing end-of-session secondary task in action.
 - **#570** — server-management **PR11** (moderation + roles setup sections) + workflow tooling + ecosystem docs (owner decision **Q-0008**: Moderation + Roles now, Governance deferred). The moderation section stages `set_setting` drafts for the PR10 knobs; the roles section adds the `set_role_threshold` op-kind for time/XP auto-role tiers. Setup diagnostics & repair (PR12) builds on top.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -1631,3 +1631,94 @@ Destination: kept here — the fix is external (ChatGPT template update by the m
 Captured: 2026-06-08 (repo friction audit session).
 Action owner: maintainer (ChatGPT template).
 ```
+
+---
+
+## 20. Adaptive Setup/Access/Routine follow-up batch — 2026-06-08
+
+> **Planning home:** [`docs/planning/adaptive-setup-access-routine-platform-2026-06-08.md`](../planning/adaptive-setup-access-routine-platform-2026-06-08.md).
+> These questions begin where answered Q-0017–Q-0027 end. Safe defaults allow Phase 0/read-only work to continue; answers are required before the named mutation/privacy surfaces ship.
+
+### Q-0028 — Which Guild Feature Profiles should form the first catalogue?
+
+**Area:** Setup / Guild Feature Profiles
+**Type:** Product definition
+**Priority:** Medium
+**Status:** Open
+**Question:** After source mapping, should the first preview catalogue be **Essential Utility, Community Core, Games Community, Moderation Focused**, with **BTD6 Community** experimental/gated; or should any be added, removed, or renamed?
+
+**Why agents need this:** The catalogue determines the versioned compiler contract, tests, and UI language. Registry presence alone is not enough to infer owner intent.
+
+**Safe default until answered:** Build only catalogue/compiler infrastructure and previews; use the proposed set as examples, not a committed public catalogue.
+
+**Suggested destination after answer:** Q-0017 planning doc §6.1 and future profile catalogue source.
+
+### Q-0029 — Where does quiet mode belong?
+
+**Area:** Access / Automation
+**Type:** Ownership / Product behavior
+**Priority:** Medium
+**Status:** Open
+**Question:** Should quiet mode be a central availability policy that routines may request, a routine-owned setting, or both with availability policy as the sole owner?
+
+**Why agents need this:** Two owners would create disagreement between command availability, help, and routine state.
+
+**Safe default until answered:** Availability policy owns effective quiet mode; a routine may only request a change through that canonical owner.
+
+**Suggested destination after answer:** Q-0017 planning doc §6.5–6.6 and ownership/runtime contracts if implemented.
+
+### Q-0030 — When are rollback snapshots mandatory?
+
+**Area:** Setup / Safety
+**Type:** Safety / Mutation contract
+**Priority:** High
+**Status:** Open
+**Question:** Must every setup-draft apply capture an immutable before-state snapshot, only compound profile/routine applies, or only medium/high-risk applies?
+
+**Why agents need this:** This changes Phase 3 storage, Final Review UX, audit linkage, and what “rollback” can honestly promise.
+
+**Safe default until answered:** Require snapshots for compound profile/routine applies and any high-risk apply; retain explicit manual rollback notes elsewhere.
+
+**Suggested destination after answer:** Q-0017 planning doc §8 Phase 3, data model, observability; ownership/runtime contracts.
+
+### Q-0031 — Approve the first profile/routine risk policy?
+
+**Area:** Automation / Setup safety
+**Type:** Safety classification
+**Priority:** High
+**Status:** Open
+**Question:** Is this starting policy correct: bounded messages/panels/notifications/checklists may auto-apply; routing, bindings, channel creation, thresholds, and multi-setting changes require approval; broad access/capability changes, role creation, and full profiles require high-risk approval; destructive role/permission/mass-channel changes never auto-apply?
+
+**Why agents need this:** Q-0019 sets progressive posture but not the classification of each new action.
+
+**Safe default until answered:** Any ambiguous configuration action queues Final Review; only clearly bounded messaging/notification actions auto-apply.
+
+**Suggested destination after answer:** Q-0017 planning doc §6.5 and future automation registry/risk policy.
+
+### Q-0032 — What should the Discord entry points be called?
+
+**Area:** Access / Help UX
+**Type:** Naming / Information architecture
+**Priority:** Low
+**Status:** Open
+**Question:** Should Access Map and Help Preview be subpanels linked only from Server Management/Settings, named slash commands (for example `/access-map` and `/help-preview`), or both?
+
+**Why agents need this:** Command names become subsystem/help/ledger identity contracts and should not be casually renamed later.
+
+**Safe default until answered:** Build services first and expose later through existing staff hubs; do not reserve new command names.
+
+**Suggested destination after answer:** Q-0017 planning doc Phase 1 and future command/help maps.
+
+### Q-0033 — How should Personal Setup account links begin?
+
+**Area:** Personal Setup / Privacy
+**Type:** Privacy / Product scope
+**Priority:** High (before Phase 5)
+**Status:** Open
+**Question:** Should Personal Setup eventually support a generic account-link framework, begin with specific domain-owned links (such as game profiles), or defer all account links until after preferences/onboarding ship?
+
+**Why agents need this:** Generic links introduce cross-domain ownership, privacy, deletion/export, credential, and cross-guild questions that simple preferences do not.
+
+**Safe default until answered:** Defer account links; ship privacy-bounded preferences/onboarding first when Phase 5 is approved.
+
+**Suggested destination after answer:** Q-0017 planning doc §6.7 and a future privacy/data-ownership decision.

--- a/docs/planning/adaptive-setup-access-routine-platform-2026-06-08.md
+++ b/docs/planning/adaptive-setup-access-routine-platform-2026-06-08.md
@@ -45,6 +45,7 @@ SuperBot already has most of the required write seams and several read seams: se
 - **Condition:** deterministic predicate evaluated before an action; false/failed evaluations are observable.
 - **Action:** canonical executor dispatch target; config actions either use an approved canonical mutation or queue a draft.
 - **Availability policy:** central policy layer for time/event/stage/user-age availability, composed after hard safety and guild policy.
+- **Quiet mode:** a time-window or manually-triggered state that suppresses non-essential bot commands and bot-initiated outbound posts for a configured duration or until lifted. Non-essential commands return a quiet-mode denial with a locked reason and end time. Commands stay visible in help, labelled "currently quiet" — not hidden. Staff/admin/essential commands (moderation, diagnostics, help, management) are exempt. Triggered by routine (`enable_quiet_mode(until=)`) or manual staff action; lifted by time expiry, manual lift, or `disable_quiet_mode()`. Availability policy layer owns the per-command check; the routine engine sets/clears a guild-scoped quiet state flag (a reversible settings key or DB column, risk: low).
 - **Locked reason:** structured, safely renderable explanation of a denial and, where appropriate, the unlock requirement.
 
 ## 3. Current-state source map
@@ -153,7 +154,11 @@ A profile is declarative intent compiled against the current guild into grouped 
 4. **Moderation Focused** — moderation/roles/cleanup/logging with stricter access intent; broad permission changes stay draft-only/high risk.
 5. **BTD6 Community (experimental/gated)** — only after BTD6 readiness and setup coverage are verified; not an initial generally available promise.
 
+**Phase 2 design note (Q-0028):** Essential Utility and Community Core may consolidate during the Phase 2 profile catalogue design session into one Foundation profile plus an optional Community add-on (moderation, roles, cleanup, logging). Do not implement two overlapping profiles without reviewing this first. The distinction should be settled before the profile compiler is built.
+
 Do not start with “Private/Friends” until its policy differences are explicit, or “Game Server” as a blanket profile when registry readiness varies by game. Profiles should use registry metadata to enumerate features but require explicit profile-owned intent; registry presence alone must not enable a feature.
+
+**Open gap for Phase 2:** the compiler spec must decide what a profile does when it would logically require removing a resource (e.g. a channel belonging to a disabled feature). The current plan forbids auto-delete but does not specify whether profiles should surface this as a "manual action required" finding, a no-op with a warning, or a separate cleanup suggestion. Resolve in the Phase 2 design session before implementing the profile compiler.
 
 ### 6.2 Unified Access Map
 
@@ -164,6 +169,8 @@ Phase 3 editing changes intent into grouped setup operations and opens Final Rev
 ### 6.3 Help Preview and locked reasons
 
 Staff/admin Help Preview supplies an explicit simulated audience (normal member, trusted user, moderator, admin, owner/operator where meaningful) to the same live help visibility/rendering path. It must label simulation limits and never imply Discord permissions it cannot accurately model. Normal users do not receive audience simulation; they receive a structured denial message from the live access/availability decision, with unlock guidance only where safe.
+
+**Locked reason structure (minimum fields for Phase 1B):** `code` (stable string identifier, e.g. `quiet_mode`, `command_access_deny`, `availability_window`, `setup_stage_required`), `safe_text` (user-renderable string, never leaks sensitive policy details), `source` (which policy layer produced it: `command_access` | `routing` | `availability` | `capability` | `bootstrap`), `unlock_hint` (optional — only included when the unlock path is safe to show, e.g. "unlocks after 24h membership"). The renderer must never expose role names, channel IDs, or policy internals in `safe_text`.
 
 ### 6.4 Setup health and drift detection
 

--- a/docs/planning/adaptive-setup-access-routine-platform-2026-06-08.md
+++ b/docs/planning/adaptive-setup-access-routine-platform-2026-06-08.md
@@ -1,0 +1,370 @@
+# Adaptive Setup, Access, Profile, and Routine Platform — source map and roadmap
+
+> **Status:** `plan` · **Not implemented** · **Source-verified 2026-06-08**
+> **Owner decisions:** applies [Q-0017 through Q-0027](../owner/maintainer-question-router.md#q-0017--adaptive-setupaccessroutine-platform-planning-document-structure-2026-06-08).
+> **Authority:** source + binding architecture/ownership/runtime contracts win over this plan. This is the one comprehensive planning home required by Q-0017.
+> **Live-repo check:** PRs [#584](https://github.com/menno420/superbot/pull/584) and [#585](https://github.com/menno420/superbot/pull/585) are merged; the GitHub API reported no open PRs during this source-mapping session.
+
+## 1. Executive summary
+
+The Adaptive Setup, Access, Profile, and Routine Platform should be an **orchestration and explanation layer over existing primitives**, not a new configuration, permission, help, or scheduler stack. Its central product promise is one owner/staff-facing answer to:
+
+> What should the bot do here; who can use and see it; where and when does it work; what is unhealthy; and what would change if this draft were approved?
+
+SuperBot already has most of the required write seams and several read seams: setup drafts and Final Review, typed settings mutation, binding/resource pipelines, command-access resolution, cog-routing resolution, governance visibility/capabilities, the command-surface ledger, setup diagnostics, server-management health badges, and an audited automation scheduler/executor. The missing foundation is a **composed, side-effect-free access/setup read model** plus consistent locked reasons and drift findings. Product mutation must wait until that read model is trustworthy.
+
+**Ready now:** reconcile subsystem identity debt; specify/build the read-only Access Map projection; extend deterministic diagnostics; add staff-only Help Preview using the live help resolver; catalogue the panel consistency gaps.
+
+**Later:** Guild Feature Profiles can generate previewable setup drafts once the read model and profile catalogue are settled. Access Map editing, profile application, and configuration routines must route through setup drafts/Final Review and audited canonical services. Personal Setup is Phase 5. AI assistance is Phase 6 and remains gated; it may explain or draft, never mutate.
+
+## 2. Binding decisions and terminology
+
+| Decision | Applied consequence |
+|---|---|
+| Q-0017 | This document is the single comprehensive plan; no parallel concept docs. |
+| Q-0018 | Starter Guild Feature Profiles are derived from real registry/routing/setup support, not the prompt's six examples. |
+| Q-0019 | Routine actions use progressive risk: low risk may auto-apply; medium/high risk queue approval/Final Review; every run is auditable. |
+| Q-0020 | Personal Setup stays Phase 5 but is fully specified here. |
+| Q-0021 | Routines extend `automation_scheduler`, `automation_executor`, `automation_registry`, templates, and mutation pipeline. |
+| Q-0022 | **Guild Feature Profile** is the server configuration bundle. **Automation Preset / `ServerPreset`** remains an automation rule template. |
+| Q-0023 | Help Preview is staff/admin-only. Normal users receive clear denial/locked-reason messages instead. |
+| Q-0024 | Access Map is read-only before Phase 3. |
+| Q-0025 | `scripts/new_subsystem.py` is decided backlog, not part of this plan's product implementation. |
+| Q-0026 | Fix CamelCase → snake_case subsystem conversion and rename `servermanagement` → `server_management` before building multi-word-profile identity assumptions. |
+| Q-0027 | Binding repo docs override prompt/template wording. |
+
+### Concept glossary
+
+- **Guild Feature Profile:** named, versioned server-configuration intent that compiles into previewable setup operations. Never call it a preset.
+- **Automation Preset / `ServerPreset`:** existing template that installs one automation rule through `AutomationMutationPipeline`.
+- **Setup draft:** persisted, provenance-bearing list of `SetupOperation` rows for a guild.
+- **Final Review:** authority-rechecked, ordered, audited apply/recovery gate for setup operations.
+- **Access Map:** composed read model explaining who can use/see what, where, and why.
+- **Help Preview:** staff-only rendering of live help for a selected audience context.
+- **Routine:** automation rule plus optional conditions, risk classification, and an action.
+- **Condition:** deterministic predicate evaluated before an action; false/failed evaluations are observable.
+- **Action:** canonical executor dispatch target; config actions either use an approved canonical mutation or queue a draft.
+- **Availability policy:** central policy layer for time/event/stage/user-age availability, composed after hard safety and guild policy.
+- **Locked reason:** structured, safely renderable explanation of a denial and, where appropriate, the unlock requirement.
+
+## 3. Current-state source map
+
+### 3.1 Canonical services, registries, and runtime paths
+
+| File/module | Current responsibility | Reuse candidate | Risk / missing piece |
+|---|---|---|---|
+| `disbot/services/setup_draft.py` + `utils/db/setup_draft.py` | Persists ordered operations with section/staging/group provenance, risk, reason, source, and rollback note. | Profile previews, Access Map edits, routine approval drafts. | Public staging kinds are fixed; profile/routine provenance may need additive kinds or metadata conventions. |
+| `disbot/services/setup_operations.py` + `views/setup/final_review.py` | Typed operation dispatcher; ordered, locked, authority-rechecked apply with partial recovery. | Only controlled mutation seam for compound profile/access/routine changes. | New op kinds are a dispatcher + DB gate + SQL CHECK contract. Do not bypass it. |
+| `disbot/services/settings_mutation.py`, `binding_mutation.py`, provisioning/lifecycle services | Canonical audited writers for settings, bindings, resources, roles/channels. | Underlying operation executors and direct single-setting manager edits. | Not all panels use the same writer or preview model. |
+| `disbot/core/runtime/command_access.py` + `services/command_access_service.py` | Resolves guild channel-access mode, bootstrap/operator exceptions, decision reason/source; canonical audited writer. | Access Map command-access axis and locked reason seed. | Current model is command-entry channel admission, not full capability/time availability. |
+| `disbot/services/command_routing.py` + `cog_routing_profiles.py` | Resolves channel → category → guild → default-true cog routing; existing routing profiles compile to setup operations. | Access Map routing axis and Feature Profile compiler building blocks. | Routing profiles are channel-name heuristics for three cogs, not full Guild Feature Profiles. |
+| `disbot/governance/` (`resolve_visibility`, capability resolvers, snapshots) | Canonical subsystem visibility and capability/authority decisions. | Access Map role/capability/help visibility axes. | Must compose, not duplicate; legacy `governance_service` is only a re-export shim. |
+| `disbot/core/runtime/command_surface_ledger.py` | Runtime command/subsystem identity, classification, help-hidden policy, diagnostics. | Feature inventory, help/access consistency checks. | Q-0026: `cog_name_to_subsystem` drops `Cog` then lowercases; multi-word names become collapsed keys. |
+| `disbot/utils/subsystem_registry.py` | `SUBSYSTEMS`, `HUBS`, visibility/capability/entry-point metadata and identity validation. | Profile catalogue vocabulary and Access Map feature index. | Registry metadata describes identity/discovery, not per-guild desired enablement. Current key is `servermanagement`. |
+| `disbot/cogs/help_cog.py`, `cogs/help/route.py`, help views | Governance-aware live help, registry/category routes, command classification filtering. | Help Preview must invoke the same visibility and render paths with an explicit audience context. | No single composed help+command-access+routing+availability explanation object today. |
+| `disbot/services/setup_diagnostics.py` | Read-only setup findings; suggested repairs are setup operations, never direct writes. | Setup health/drift detector core. | Needs access/help/routing/routine/identity consistency providers. |
+| `disbot/services/server_management_hub.py` + `views/server_management/hub.py` | Read-only badges and handoffs to moderation/channels/roles/cleanup/setup managers. | Owner landing point for Access Map, health, Help Preview. | It deliberately owns no mutation and should stay that way. |
+| `disbot/services/automation_registry.py` | Typed trigger/action metadata aligned with migration 032. | Extend with conditions and config-oriented action metadata/risk. | Registry ↔ SQL CHECK lockstep makes additions migration-bearing. |
+| `disbot/services/automation_templates.py` | `ServerPreset` catalogue and installability filtering. | Keep as Automation Presets; possibly add safe routine templates. | Must not be renamed/reused as Guild Feature Profiles. |
+| `disbot/services/automation_scheduler.py`, `automation_executor.py`, `automation_mutation.py`, `utils/db/automation.py` | Claim/run lifecycle, dispatch, owner-gated rule writes, run/error/audit state. | Routine Engine foundation. | No general condition model; several triggers/actions exist but installability and execution support differ. |
+
+### 3.2 Existing setup and management surfaces
+
+| Surface | Current behavior and reusable seam | Planning conclusion |
+|---|---|---|
+| Setup launcher/wizard/hub/depth (`views/setup/launcher.py`, `wizard.py`, `hub.py`, `depth_panel.py`) | Shared `BaseView`; depth/progress/session model; depth panel explicitly stages no operations. | Reuse for guided first-run flow; do not overload it with the entire Access Map/routine platform. |
+| Setup sections (`views/setup/sections/`) | Channels, moderation, roles, cleanup, cog routing, presets, diagnostics, role templates, AI review, etc. stage recommended/custom/preset/repair operations. | Strongest shared controlled-mutation pattern; Feature Profile compiler should produce the same operations. |
+| Final Review/recovery (`views/setup/final_review.py`, `recovery.py`) | Preview, authority recheck, ordered apply, audit outcome, partial recovery. | Mandatory for profile apply and medium/high-risk routine/config changes. |
+| Server Management Hub | Persistent/ephemeral read-only router with health badges. | Keep as composition/navigation; add links/cards, not write logic. |
+| Settings Hub/editors (`views/settings/`) | `HubView`; typed editors write directly through `SettingsMutationPipeline`; command access writes through `command_access_service`; audit/invalid/missing views are read-only. | Canonical direct-edit lane, but not setup-draft/Final Review. Appropriate for isolated reversible settings; compound edits need draft mode. |
+| Moderation manager (`views/moderation/`) | Runtime moderation actions through `ModerationService`; persistent panel; capability checks. Setup moderation section stages config separately. | Runtime actions should remain direct/audited and outside Final Review; moderation configuration should converge on canonical setting writers/drafts. |
+| Role manager (`views/roles/`) | Mix of `RoleLifecycleService`, `role_exemption_service`, and direct DB threshold writers. | Largest consistency drift: lifecycle operations are audited but destructive/direct; threshold panels bypass setup draft and some canonical service seams. Normalize before routine/profile role mutations. |
+| Channel manager (`views/channels/`) | Mix of direct Discord creation, audited `ChannelLifecycleService` deletion, direct channel edits, and governance visibility writer. | Mixed lane. Keep deliberate confirmed runtime management, but profiles/routines must never call panels/direct Discord methods. Centralize create/edit lifecycle/audit before automation. |
+| Cleanup manager (`cogs/cleanup/panel.py`, `views/cleanup/policy_panel.py`) | Router is read-only; policy panel previews and confirms canonical policy changes; setup cleanup stages operations. | Good confirmation model, but separate from setup Final Review. Reuse diagnostics/policy service and preserve direct focused workflow. |
+| Setup diagnostics/repair | Findings are read-only; repair proposals stage `SetupOperation` rows. | Model for all future drift repair. |
+| Help/admin/operator surfaces | Help uses registry/governance/classification; operator/server-management surfaces compose health and handoffs. | Help Preview and Access Map should be diagnostics on the same resolvers, not alternate policy. |
+
+### 3.3 Tests and contracts to preserve
+
+Key existing guards include `tests/unit/services/test_setup_operations*.py`, `test_setup_draft.py`, `test_preset_to_setup_operations.py`, `test_command_access_service.py`, `test_command_routing.py`, `test_cog_routing_profiles.py`, `test_setup_diagnostics.py`, automation registry/executor/scheduler/template/mutation tests, command-surface ledger and subsystem-registry tests, plus setup/settings/server-management view tests. Binding boundaries remain [architecture](../architecture.md), [ownership](../ownership.md), [runtime contracts](../runtime_contracts.md), [capability authority](../capability-authority.md), and the [settings customization roadmap](../setup-platform/settings-customization-roadmap.md).
+
+## 4. Foundation first
+
+### 4.1 Target boundaries
+
+Create a read-oriented service family, not a god service:
+
+1. **Feature inventory adapter** — reads subsystem registry + command-surface ledger.
+2. **Access context** — explicit guild/channel/category/member/role/time/event/setup-stage inputs.
+3. **Access projection resolver** — composes command access, cog routing, governance visibility/capabilities, bootstrap exceptions, AI gates, and later availability policies into structured decisions.
+4. **Explanation renderer** — converts structured reasons into Access Map rows, Help Preview annotations, and user-safe denial messages.
+5. **Drift providers** — compare projections, configured resources, help exposure, routine references, and identity contracts without writing.
+6. **Draft compiler(s)** — only after read projection stabilizes; convert profile/access edits or risky routine actions into `SetupOperation` drafts.
+
+The projection should return decisions with source, precedence, allow/deny/unknown state, locked reason code, safe explanation, and optional remediation pointer. It should not persist initially. Caching is optional only after invalidation owners are explicit.
+
+### 4.2 Required prerequisites
+
+1. **Q-0026 identity fix first:** implement CamelCase → snake_case and rename `servermanagement` to `server_management`, with identity-contract, help, hub, router-prefix, and migration/reference verification. Do not build profile identifiers on collapsed multi-word keys.
+2. **Pin the mutation boundary:** profiles, Access Map editing, and risky routines compile to setup drafts; Final Review applies. Focused manager/runtime actions may remain direct through their canonical audited services.
+3. **Build the composed read model before UI/editing:** Access Map, Help Preview, denial explanations, and drift checks must consume one resolver.
+4. **Normalize high-risk drift before automating it:** especially direct role-threshold DB writes and direct channel creation/edit paths.
+5. **Extend automation, never fork it:** add conditions/actions/risk/approval behavior around the existing registry, scheduler, executor, mutation pipeline, and runs.
+
+> **Do not build on top of drift:** no profile catalogue that hard-codes stale subsystem keys; no Help Preview with copied visibility logic; no Access Map editor before the read model; no routine action that calls Discord APIs or manager-panel callbacks directly.
+
+## 5. Settings/manage-panel consistency map
+
+The panels **do not all follow the same edit rules or base**. They share UI foundations (`BaseView`, `HubView`, `PersistentView`) and often use canonical services, but there are intentionally different lanes and several real drifts.
+
+| Surface | Read/write | Draft + Final Review? | Gate / audit / rollback | Shared base / canonical seam | Classification and follow-up |
+|---|---|---|---|---|---|
+| Setup hub/depth/progress | Read/session write | No config mutation in depth; sections draft | Setup access; session audit/progress | `BaseView`, setup session/progress | Keep as setup orchestration. |
+| Setup sections | Draft mutation | **Yes** | Apply-time authority; operation metadata, apply outcome, partial recovery | `BaseView`, `setup_draft`, `SetupOperation` | Canonical compound-change model. |
+| Final Review/recovery | Applies drafts | **Yes** | Rechecks `can_apply_setup`; apply lock; audit/recovery | `BaseView`, canonical operation dispatcher | Mandatory controlled-mutation gate. |
+| Server Management Hub | Read-only/router | N/A | Administrator/capability gating; no mutation | `PersistentView`, badge composer | Keep direct read-only. |
+| Settings typed editors/reset | Direct setting write | No | Callback authority; `SettingsMutationPipeline` audit; previous/new values | `HubView`/editor views | Valid focused direct lane; add optional “add to draft” only when compound workflows need it. |
+| Settings command access | Direct access-policy write | No | Canonical service invalidation + audit; bootstrap warning | `HubView`, `command_access_service` | Read model can consume now; editing moves behind draft in Access Map Phase 3, while focused editor may remain direct. |
+| Settings audit/invalid/missing/needs-setup | Read-only | N/A | Redaction/authority by parent route | `HubView` | Keep read-only. |
+| Cog-routing setup section/profiles | Draft write | **Yes** | Final Review; operation risk currently medium | `BaseView`, `cog_routing_profiles`, `command_routing` apply seam | Reuse for Feature Profiles. |
+| Setup diagnostics/repair | Read + repair draft | **Yes for repair** | Findings are read-only; repairs reviewed | `BaseView`, `setup_diagnostics` | Ideal drift pattern. |
+| Moderation action panel | Runtime mutation | No | Per-action capability; `ModerationService` audited writer | `PersistentView` + service | Keep direct: these are runtime moderation actions, not configuration. |
+| Moderation setup section | Config draft | **Yes** | Final Review | setup section + `set_setting` ops | Keep and expand via canonical settings metadata. |
+| Role create/edit/delete | Direct resource mutation | No | Confirmation varies; `RoleLifecycleService` audit/result | `BaseView`, lifecycle service | Keep operator workflow, but require snapshots/strong confirmation for destructive flows; never routine-direct. |
+| Role thresholds | Direct DB write | No | Capability at route; audit consistency varies | `BaseView`, role DB helpers | **Drift:** centralize behind audited role-automation service before profiles/routines. |
+| Role exemptions | Direct service write | No | Audited/cache-invalidated service | `BaseView`, `role_exemption_service` | Valid focused direct lane. |
+| Channel create/edit/move/restrict/visibility/delete | Direct Discord/service/governance mix | No | Confirmation strongest for delete; audit varies | `HubView`/`BaseView`; lifecycle/governance services | **Drift:** centralize create/edit/move/restrict lifecycle and audit before automation; runtime direct manager can remain. |
+| Cleanup hub/policy | Read-only router + confirmed policy write | No | Preview/confirm; governance/canonical cleanup services | `HubView`, `BaseView` | Good focused workflow; setup/profile changes should still draft. |
+| Help | Read-only | N/A | Live visibility resolver/classification | Help views + registry/governance | Preview must use same resolver; do not fork. |
+
+**Centralize before future work:** structured access decisions/reasons; role-threshold writer; channel lifecycle/audit coverage; draft provenance for profile/routine origins; setup-operation risk policy; read-model drift providers. **Remain direct:** runtime moderation actions, diagnostic/read-only panels, focused reversible typed setting edits, and deliberate resource-manager actions through canonical audited lifecycle services.
+
+## 6. Product concept specifications
+
+### 6.1 Guild Feature Profiles
+
+A profile is declarative intent compiled against the current guild into grouped setup operations. It has a stable slug/version, display text, intended audience, supported subsystem keys, assumptions, setup depth, operations/builders, risk summary, and compatibility findings. Preview shows no-op/already-matching/blocked/proposed rows and never mutates.
+
+**Source-grounded starter recommendation (owner confirmation required):**
+
+1. **Essential Utility** — setup/health/settings/help/server-management foundations; avoids claiming domain cogs are configured.
+2. **Community Core** — moderation, roles, cleanup, logging/bindings, sensible command access; only where setup sections and canonical writers exist.
+3. **Games Community** — Games hub plus existing game/economy routing heuristics; uses detected channels and reports missing prerequisites.
+4. **Moderation Focused** — moderation/roles/cleanup/logging with stricter access intent; broad permission changes stay draft-only/high risk.
+5. **BTD6 Community (experimental/gated)** — only after BTD6 readiness and setup coverage are verified; not an initial generally available promise.
+
+Do not start with “Private/Friends” until its policy differences are explicit, or “Game Server” as a blanket profile when registry readiness varies by game. Profiles should use registry metadata to enumerate features but require explicit profile-owned intent; registry presence alone must not enable a feature.
+
+### 6.2 Unified Access Map
+
+Phase 1/2 read-only rows should cover feature/subsystem/cog, command group/entry point, channel/category routing, command-access mode, capability/role authority, help visibility, setup visibility, AI visibility/gates, bootstrap/recovery exceptions, and later availability locks. Each row includes effective result, source chain, reason, safe remediation, and inconsistencies. It creates no second permission system: it is a projection over existing owners.
+
+Phase 3 editing changes intent into grouped setup operations and opens Final Review. Direct editing is forbidden from the read-only surface.
+
+### 6.3 Help Preview and locked reasons
+
+Staff/admin Help Preview supplies an explicit simulated audience (normal member, trusted user, moderator, admin, owner/operator where meaningful) to the same live help visibility/rendering path. It must label simulation limits and never imply Discord permissions it cannot accurately model. Normal users do not receive audience simulation; they receive a structured denial message from the live access/availability decision, with unlock guidance only where safe.
+
+### 6.4 Setup health and drift detection
+
+Extend `setup_diagnostics` with providers for: incomplete/skipped advanced setup; deleted configured channels/roles; command access that blocks all non-admin users; help exposure of disabled/unavailable features; routing/access conflicts; routine references to missing resources; bootstrap/recovery path availability; and subsystem/ledger/help identity mismatch. Findings remain side-effect-free. Repairable findings produce setup-operation drafts. Non-repairable findings link to the owning panel or explanation.
+
+### 6.5 Automation Presets and Routine Engine extension
+
+Existing triggers are `scheduled_time`, `interval`, `member_join`, `setup_readiness_below`, `binding_missing`, `channel_inactive`, and `manual`; `scheduled_time` is currently blocked for new installs until cron support. Existing actions include messaging, role assignment/removal, readiness/leaderboard summaries, binding/channel actions, and owner notification (verify executor support before exposing any template). Existing `ServerPreset` remains an Automation Preset.
+
+Add a typed **condition model** to rules or an associated table/JSON envelope, evaluated by the executor before dispatch: `role_present`, `setup_stage_completed`, `event_active`, `cooldown_state`, `account_age`, `join_age`, and channel/category state. Add configuration-oriented actions only via canonical seams: `apply_feature_profile` should normally mean “compile/queue draft,” `switch_cog_routing_profile`, `enable_quiet_mode`, `hide_show_help_category`, `queue_final_review_draft`, post/update panel, notify staff, and start setup checklist.
+
+| Risk | Default behavior | Examples |
+|---|---|---|
+| Low | May auto-apply through audited canonical service | Send/update a bounded message/panel; staff notification; start checklist; reversible narrow quiet-mode/help-display change if owner classifies it low. |
+| Medium | Queue approval draft / Final Review | Routing profile switch, multi-setting profile subset, binding change, role threshold, channel creation. |
+| High | Queue approval draft; stronger summary/snapshot | Broad access/capability change, role creation, full Guild Feature Profile application. |
+| Forbidden automatic | Never auto-apply | Role deletion, permission-overwrite mutation without preview, mass channel changes, physical cog load/unload, AI-generated direct mutation. |
+
+Every execution records trigger, condition outcomes, action risk, actor/rule/profile version, proposed/applied operation IDs, result/error, notifications, and rollback/snapshot references.
+
+### 6.6 Central availability policy and time-based unlocks
+
+Add one policy resolver after global safety → guild → channel → role/capability and before user preferences. Rules may reference member tenure, account age, setup stage, accepted-rules/event state, quiet hours, or domain event windows. Commands and help both consume the same decision. No command-specific time checks. Locked reasons identify the policy source and safe unlock condition; sensitive policies may return a generic reason.
+
+### 6.7 Personal Setup Wizard (Phase 5 full spec)
+
+Commands: `/my-setup` for guided onboarding/checklist and `/my-preferences` for ongoing controls. Likely preferences: guild-scoped timezone override, notification subscriptions, DM permission/preference, help ordering, favorite/hidden features, onboarding steps, and optional account links.
+
+Invariant:
+
+```text
+global safety policy → guild policy → channel policy → role/capability policy → user preference
+```
+
+Preferences can hide, sort, personalize, or subscribe; they never grant access. Data must distinguish global vs guild scope, default/explicit/unknown values, consent timestamp/source, retention/deletion/export, and visibility. Account links should wait for Q-0033 because generic cross-domain links materially change privacy and ownership.
+
+### 6.8 AI-assisted setup suggestions (Phase 6)
+
+Behind existing AI expansion/readiness gates, AI may suggest profiles/routines, explain deterministic health findings, draft role/channel/settings operations, and summarize an owner-facing change plan. AI output is untrusted proposal data: deterministic schema validation, canonical compiler, preview, risk classification, and owner Final Review are mandatory. AI never directly calls a mutation service.
+
+## 7. Readiness matrix
+
+| Capability | Readiness | Why / prerequisite |
+|---|---|---|
+| Setup wizard improvements | Ready now, selectively | Mature session/draft/review paths; avoid adding advanced controls to first-run flow. |
+| Settings/manage-panel consistency baseline | Ready now | Source map exists; normalize role thresholds/channel lifecycle before automation. |
+| Unified Access Map (read-only) | Needs foundation | Requires Q-0026 and composed resolver/reason model. |
+| Help Preview | Needs foundation | Same resolver as live help + explicit staff simulation context. |
+| Setup health/drift detection | Ready now / iterative | Existing diagnostics pattern; new cross-axis providers depend on Access Map projection. |
+| Guild Feature Profile preview | Needs foundation + owner decision | Needs profile catalogue decision, Q-0026, compiler contract, compatibility report. |
+| Profile apply / Access Map editing | Needs foundation | Phase 3 only; draft/Final Review, snapshots, audit. |
+| Automation/routines | Needs foundation + owner decisions | Existing substrate; requires condition/risk/approval design and SQL migrations. |
+| Time/event unlocks | Needs foundation | Central availability resolver and locked reasons first. |
+| Personal Setup Wizard | Future only + privacy decisions | Phase 5 migrations, privacy/retention/export design. |
+| AI-assisted setup suggestions | Gated | Existing AI expansion/readiness gates plus deterministic drafts. |
+| `scripts/new_subsystem.py` | Ready backlog, separate | Q-0025 decided; useful after Q-0026 naming fix. |
+
+## 8. Phased roadmap
+
+### Phase 0 — foundation and reconciliation
+
+- Implement Q-0026 identity fix/rename in a separate technical-debt session.
+- Turn this panel consistency map into explicit canonical direct-vs-draft rules.
+- Specify structured access decision, locked reason, simulated audience, and drift-provider interfaces.
+- Normalize/audit role-threshold writes and assess channel lifecycle gaps before routine action exposure.
+- Confirm first Guild Feature Profile catalogue and risk/snapshot owner decisions.
+- No product expansion or new mutation surface.
+
+### Phase 1 — read-only orchestration foundation
+
+- Build Access Map projection service and tests.
+- Add read-only Access Map operator surface, likely linked from Server Management/Settings.
+- Add deterministic access/setup drift providers.
+- Add staff/admin-only Help Preview using live help resolver.
+- Add clear user-safe locked reasons to denial paths.
+- No Access Map editing.
+
+### Phase 2 — Guild Feature Profile preview
+
+- Add versioned profile catalogue based on supported registry/setup/routing capabilities.
+- Compile profile intent to in-memory operations and compatibility findings.
+- Render dry-run/no-op/blocked/risk/grouped preview.
+- No direct apply and no profile mutation UI.
+
+### Phase 3 — controlled mutation
+
+- Persist profile and Access Map edits as grouped setup drafts.
+- Open Final Review with provenance, staff-facing summary, risk grouping, and snapshot/rollback references.
+- Expand operation kinds only through dispatcher/DB/CHECK parity.
+- Preserve focused direct manager lanes where appropriate.
+
+### Phase 4 — Routine Engine extension
+
+- Extend existing automation schema/registry/executor with conditions, action risk, and approval-draft outcomes.
+- Add safe configuration action adapters that call canonical compilers/services.
+- Auto-apply only owner-approved low-risk actions; queue medium/high-risk drafts.
+- Add run/condition/draft/audit/operator-notification observability.
+
+### Phase 5 — Personal Setup Wizard
+
+- Add privacy-reviewed global/guild user-preference model, `/my-setup`, `/my-preferences`, onboarding, timezone, notification/DM preferences, personalized help ordering, favorites/hiding, and later account links.
+- Prove preferences cannot elevate access.
+
+### Phase 6 — AI-assisted setup drafts
+
+- Only after AI gates clear.
+- Add suggestion/explanation/draft-generation adapters; validate deterministically and require preview/approval.
+- No AI mutation tool.
+
+## 9. Future session batch plan
+
+| Batch / target agent | Goal and scope | Likely files | Out of scope | Verification | Risk / stop conditions |
+|---|---|---|---|---|---|
+| **P0A — Codex/Sonnet:** Q-0026 identity repair | Snake-case conversion, `server_management` rename, references/tests/docs. | `command_surface_ledger.py`, `subsystem_registry.py`, help/router/hub tests/docs | Product features | Full quality + strict architecture + live identity check | Medium; stop if key migration affects persisted external contracts unexpectedly. |
+| **P0B — Opus:** access/read-model contract | Finalize precedence, decision/reason schema, audience simulation, owners, invalidation. | Planning/ADR/ownership/runtime docs | Runtime code | Docs/architecture checks | High architecture; stop on unresolved second-permission-system risk. |
+| **P0C — Sonnet:** panel writer normalization | Centralize role threshold writer/audit; bounded channel lifecycle gaps selected by Opus. | role/channel services/views/tests | New automation actions | Focused unit/view tests + full quality | Medium/high; stop before behavior-changing destructive flow without owner decision. |
+| **P1A — Sonnet:** Access Map projection | Side-effect-free composed service + tests, no UI. | new service module; governance/access/routing/ledger adapters; tests | Editing/persistence | Unit/service/identity tests + strict architecture | High; stop if owner of any axis cannot be identified. |
+| **P1B — Sonnet:** drift + locked reasons | Diagnostic providers and denial explanation integration. | `setup_diagnostics.py`, command-access/interaction helpers, tests | Editing | Diagnostics/access tests + quality | Medium; stop if explanation leaks sensitive policy. |
+| **P1C — Sonnet:** Access Map + Help Preview UI | Staff-only read-only panels using P1A; Server Management link. | server-management/help/views/cogs/tests | Mutation | View/authority/help tests + live smoke | Medium. |
+| **P2 — Opus then Sonnet:** Feature Profile preview | Decide starter set/schema, implement catalogue/compiler/dry-run preview. | new profile service, setup operations/read model/views/tests | Apply | Compiler/view tests; no DB writes in preview | High; stop on unresolved profile/risk questions. |
+| **P3 — Opus then Sonnet:** controlled profile/access mutation | Draft generation, provenance, snapshots, Final Review summaries. | setup draft/operations/final review/migrations/views/tests | Routines/AI | Migration, apply/recovery/audit/capability tests | High; stop if any path bypasses Final Review. |
+| **P4A — Opus:** Routine schema/safety design | Conditions, action risk, approval outcomes, observability contract. | plan/ADR/ownership/runtime docs | Implementation | Docs/architecture checks | High; blocked by Q-0029–Q-0031. |
+| **P4B — Sonnet:** Routine Engine extension | Schema/registry/executor/mutation/UI batches after approved design. | automation services/DB/migrations/tests | AI-generated routines | Registry parity, scheduler/executor/migration/audit tests | High; stop on destructive/direct mutation. |
+| **P5 — Opus then Sonnet:** Personal Setup | Privacy/data design, then preferences and commands. | new DB/service/views/cogs/help/tests | Access grants, cross-guild admin data | Privacy invariants, migration, permission, deletion/export tests | High; blocked by Q-0033. |
+| **P6 — Opus then Sonnet:** AI drafts | Gate review, deterministic draft adapters and summaries. | AI gateway/orchestration, profile/routine compiler adapters, tests | Direct mutation | AI gate, redaction, schema, deterministic approval tests | High/gated; stop until AI readiness gates clear. |
+
+Each implementation batch is independently reviewable. Opus owns cross-cutting contract/final-plan sessions; Sonnet owns coherent implementation batches after approval; Codex is a good fit for source mapping, bounded debt, drift guards, and docs/tooling.
+
+## 10. Architecture boundaries
+
+- Do not create a second permission system; compose command access, routing, governance, Discord permissions, and availability.
+- Do not physically unload/load cogs for guild customization; routing/visibility are policy.
+- Do not let AI mutate settings directly.
+- Do not add one-off command-specific time checks.
+- Do not build routines as ad-hoc background tasks; use scheduler/executor/run lifecycle.
+- Do not overload first-run setup with every advanced control.
+- Do not duplicate help visibility, command access, cog routing, or role/capability logic.
+- Do not call view callbacks from compilers/routines; call canonical services or queue operations.
+- Do not auto-apply destructive or broad permission/resource changes.
+- Do not persist a read model merely because a UI needs it; compute first, cache only with explicit invalidation.
+
+## 11. Data model and migration considerations
+
+| Concern | Compute first? | Likely persistence / migration later |
+|---|---|---|
+| Access Map projection | **Yes** from registry/ledger/policies/resources | Optional cache only after invalidation contract; no source-of-truth table. |
+| Guild Feature Profile catalogue | Built-ins can be source-owned/versioned | Guild-selected/default profile and applied-version/history only if product needs it; profile draft provenance may fit metadata first. |
+| Profile preview | **Yes**, in memory | Draft rows only on explicit “add to Final Review.” |
+| Routine conditions | No, rules need durable config | Add normalized condition JSON/schema/version or child table; registry/SQL parity and validation required. |
+| Routine action risk/approval outcome | Derived default + explicit versioned policy | Store risk/policy version and queued-draft/result linkage in rules/runs. |
+| Routine audit entries | No | Extend automation runs/audit payload with condition results, proposal/draft/apply IDs, snapshot reference. |
+| Rollback snapshots | N/A | Add snapshot entity or immutable serialized before-state references if Q-0030 requires them. Avoid pretending free-text rollback notes are executable rollback. |
+| Availability rules/locked reasons | Resolver can start with source-owned rules | Guild-configurable rules need versioned table/JSON, scope, precedence, safe explanation, activation window, audit. |
+| User preferences | No | Global/guild-scoped preference tables with consent/source/timestamps, privacy scope, deletion/export, nullable/default semantics. |
+| Account links | No | Separate privacy-reviewed ownership/domain table; never bury credentials/secrets in preferences. |
+
+All schema additions are additive, versioned, cache-aware, auditable, and tested for migration parity. Cross-guild user data requires explicit privacy decisions before implementation.
+
+## 12. Observability and audit
+
+Required events/records:
+
+- Access projection/locked-reason metrics by reason code without sensitive identifiers.
+- Setup/profile change summary: compiler/profile version, grouped operations, actor, risk, before/snapshot reference, Final Review outcome, partial recovery.
+- Routine run: trigger, every condition outcome, dispatch/approval decision, canonical action result, error class, retry/disable behavior, draft/apply linkage.
+- Drift findings: stable code, severity, owner, first/last seen where health framework supports it, safe repair/link.
+- Operator/staff notification for queued approval, repeated failure, auto-disable, high-risk proposal, or partial apply.
+- Rollback traceability from applied operation/run back to immutable before-state or explicit manual rollback instructions.
+
+Reuse audit events, settings mutation audit, lifecycle results, automation runs, diagnostics providers, and health surfaces. Do not add a parallel generic log table until a concrete gap is proven.
+
+## 13. Testing strategy
+
+- **Unit:** decision precedence, reason safety, audience simulation, profile compiler, condition predicates, risk classifier.
+- **Service:** composed Access Map against command access/routing/governance/ledger; diagnostic providers; canonical writer adapters.
+- **View:** staff-only Help Preview, read-only Access Map, profile dry run, Final Review summaries, callback authority rechecks.
+- **Migration/parity:** automation condition/action constraints, setup operation kinds, snapshot/preferences/availability schemas.
+- **Drift guards:** registry ↔ ledger/help/hubs/router keys; automation registry ↔ SQL; operation dispatcher ↔ DB gate ↔ SQL CHECK.
+- **Identity contracts:** multi-word subsystem snake-case behavior and `server_management` discovery.
+- **Permission/capability:** bootstrap/recovery, moderator/admin/owner tiers, simulated vs actual contexts, user preferences never grant access.
+- **Draft/Final Review:** grouping, provenance, replace conflicts, no-op/blocked rows, apply lock, partial recovery, snapshot linkage.
+- **Automation:** claim-once, conditions false/error, progressive apply vs queue, audit/error/notification/auto-disable.
+- **Locked reasons/help agreement:** every denial maps to safe text; help never advertises a command as available when the shared projection says locked, unless deliberately shown as locked with reason.
+- **Negative architecture tests:** previews are side-effect-free; AI/routines cannot import direct mutation/Discord resource APIs where prohibited.
+
+## 14. Open owner questions
+
+This session added Q-0028–Q-0033 to the [maintainer question router](../owner/maintainer-question-router.md). They do not repeat Q-0017–Q-0027:
+
+- Q-0028: approve/revise the source-grounded first Guild Feature Profile catalogue.
+- Q-0029: classify quiet mode as availability policy, routine action, or both with one owner.
+- Q-0030: define required rollback snapshot coverage.
+- Q-0031: approve the initial routine/profile action risk matrix.
+- Q-0032: choose Discord UI command/entry-point names for Access Map and Help Preview.
+- Q-0033: decide whether Personal Setup account links start generic or domain-specific later.
+
+Safe defaults until answered: profile preview only; quiet mode modeled as availability policy with routines requesting it; snapshots required for profile/routine compound applies; ambiguous actions queue approval; UI remains linked from existing staff hubs without committing command names; account links deferred.
+
+## 15. Recommended next destination
+
+1. **First technical debt:** Sonnet/Codex implements Q-0026 (`cog_name_to_subsystem` snake_case + `server_management` rename), then the separately decided `scripts/new_subsystem.py` can safely assume canonical multi-word keys.
+2. **Next Opus planning session:** finalize the Phase 0 access/read-model contract, including precedence, reason schema, drift provider ownership, simulation limits, and direct-vs-draft mutation rule. Resolve Q-0028–Q-0032 as needed.
+3. **First Sonnet product implementation after approval:** the side-effect-free Access Map projection service and tests, followed by drift/locked-reason providers; no UI editing.
+4. **Blocked/gated:** controlled profile/access mutation waits for the read model and rollback/risk decisions; Routine Engine waits for condition/safety design; Personal Setup waits for privacy decisions; AI drafts wait for current AI expansion gates.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -69,6 +69,7 @@ Folio: [settings-bindings-provisioning](subsystems/settings-bindings-provisionin
 - **Next** — settings coverage: pick a *verified* inconsistency from the
   [consistency ledger](health/platform-consistency-ledger.md); the three-lane model is
   [settings-customization-roadmap](setup-platform/settings-customization-roadmap.md).
+- **Later** — [Adaptive Setup, Access, Profile, and Routine Platform](planning/adaptive-setup-access-routine-platform-2026-06-08.md): one source-grounded orchestration roadmap; Phase 0 identity/read-model foundations and owner questions precede product mutation.
 - **Later** — [setup-platform roadmap](setup-platform/roadmap_setup_platform.md) is the *aspirational*
   8-phase vision; the shipped wizard is a pragmatic subset. Direction, not queue.
 

--- a/docs/subsystems/settings-bindings-provisioning.md
+++ b/docs/subsystems/settings-bindings-provisioning.md
@@ -1,7 +1,7 @@
 # Settings / bindings / provisioning subsystem — folio
 
 > **Status:** `living-ledger` (area index). Source + binding contracts win.
-> **Last updated:** 2026-06-06.
+> **Last updated:** 2026-06-08.
 
 ## What & where
 
@@ -44,7 +44,7 @@ resource-pointer **bindings**, and confirmed **resource provisioning**. Start in
 ## Plans / pending approval
 
 `docs/setup-platform/settings-customization-roadmap.md` and its command map are the starting plans
-for coverage work. Future changes must identify the lane and owner first, then state
+for coverage work. The comprehensive [Adaptive Setup, Access, Profile, and Routine Platform plan](../planning/adaptive-setup-access-routine-platform-2026-06-08.md) maps the longer-lived read-model, profile, routine, and Personal Setup sequence; it is planning, not implemented. Future changes must identify the lane and owner first, then state
 migration/backfill needs, cache invalidation, audit behavior, tests, and rollback or
 safe-disable behavior before implementation.
 
@@ -66,6 +66,7 @@ mutation/provisioning services and preserve operator confirmation.
 ## Related docs
 
 `docs/setup-platform/settings-customization-roadmap.md`, `docs/setup-platform/settings-customization-command-map.md`,
+`docs/planning/adaptive-setup-access-routine-platform-2026-06-08.md`,
 `docs/setup-platform/resource-provisioning-overview.md`, `docs/capability-authority.md`,
 `docs/health/platform-consistency-ledger.md`, `docs/setup-platform/operator-settings-presets.md`,
 `docs/ownership.md`, `docs/runtime_contracts.md`.


### PR DESCRIPTION
### Motivation

- Consolidate the Adaptive Setup, Access, Preset (Profile), and Routine planning work into one comprehensive, source-grounded plan as required by Q-0017 and to preserve Q-0018–Q-0027 owner decisions. 
- Capture a repo-verified map of existing services/views/cogs/helpers to show what can be reused, where drift exists, and which foundations must land before mutation features roll out. 
- Surface the smallest set of blocking maintainer decisions (Q-0028–Q-0033) so Opus/Sonnet sessions can proceed in safe, reviewable batches.

### Description

- Add a single comprehensive plan at `docs/planning/adaptive-setup-access-routine-platform-2026-06-08.md` that: enumerates the read-model/orchestration foundation, maps source files and services to product concepts, provides a glossary, readiness matrix, phased roadmap (Phase 0–6), session batch plan, data/migration notes, observability/audit requirements, and a testing strategy. 
- Record a follow-up question batch (`Q-0028`–`Q-0033`) in `docs/owner/maintainer-question-router.md` to capture the remaining owner decisions that block mutation surfaces. 
- Link and surface the new plan from canonical places: update `docs/roadmap.md` (added a “Later” row linking the new plan), update `docs/subsystems/settings-bindings-provisioning.md` (link + last-updated), and reconcile `docs/current-state.md` to reflect merged PRs `#584` and `#585` and to point to the new plan as the next destination. 
- Add a session record `.sessions/2026-06-08-adaptive-setup-platform-source-map.md` capturing the mapping work and context delta. 
- Preserve one-fact-one-home and avoid changing runtime code: all edits are docs-only and reference the existing codebase (setup drafts, `setup_operations`, `command_access`, `command_routing`, automation registry/scheduler/executor, `setup_diagnostics`, `server_management_hub`, etc.). 

### Testing

- Ran `python3.10 scripts/check_docs.py` and verified doc reachability and badge rules; the new plan uses the allowed `plan` badge and `check_docs.py` passed. 
- Ran `python3.10 scripts/check_architecture.py --mode strict` with Python deps installed; the run produced `0` errors and a set of known, tracked warnings (87 warnings) consistent with existing repository state. 
- Verified `scripts/context_map.py` runs for the key service files used as anchors (`disbot/services/setup_operations.py`, `disbot/services/command_routing.py`, `disbot/services/automation_executor.py`, `disbot/services/setup_diagnostics.py`) after installing `PyYAML`. 
- Ran `git diff --check` and ensured no whitespace or diff-check problems remained. 
- Committed the doc changes in one PR branch (`docs: plan adaptive setup and access platform`) and prepared the PR record (title/body captured).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26a9c95448832298c11dd17f8baa5d)