### PR TITLE
Implement ADR-006 provenance schema + explore_gamedata tooling (RC-10 gate)

### DIFF
--- a/.sessions/2026-06-08-btd6-provenance-schema-rc10-gate.md
+++ b/.sessions/2026-06-08-btd6-provenance-schema-rc10-gate.md
@@ -1,0 +1,103 @@
+# 2026-06-08 — BTD6 provenance schema (RC-10 gate) + explore_gamedata tooling
+
+## Arc
+
+Maintainer asked what was still gating BTD6 data mapping. The single binding gate was
+**ADR-006** — ratified 2026-06-05, but it deferred the actual implementation to "a
+follow-on docs/schema PR" that hadn't been written. That PR is now PR #587.
+
+The session also addressed a second question: whether tooling on the game-data dump
+could make future decode sessions faster. Answer: yes — `explore_gamedata.py`.
+
+## Built
+
+**1. `DataProvenance` / `FactRow` / `extract_provenance`**
+(`disbot/services/btd6_fact_store.py`)
+
+The typed provenance envelope ADR-006 required. Before this, facts returned by
+`fetch_for_intent` were raw dicts — the provenance fields (`source_id`, `source_name`,
+`trust_tier`, `fetched_at`) were present but untyped, unnamed by any contract.
+
+- `DataProvenance` — frozen dataclass: source_id, source_key, source_name, source_kind,
+  trust_tier, fetched_at, game_version, freshness. `.is_official` / `.label` helpers.
+- `extract_provenance(row)` — assembles it from the shape `fetch_for_intent` already
+  returns (joined with `btd6_source_registry`). No DB schema changes needed.
+- `FactRow` — frozen typed wrapper: body_json + provenance. `FactRow.from_row(raw_dict)`.
+  New extraction code should use `FactRow`; `fetch_for_intent` stays raw-dict for the one
+  existing caller (`btd6_context_service`) — no breaking change.
+- `FreshnessBucket` / `bucket_freshness` now imported at module level from
+  `btd6_source_registry` (services → services, architecture-clean).
+
+**2. `docs/btd6/btd6-provenance-schema.md`** — new `binding` doc
+
+The formal schema contract that ADR-006 required before any new extraction. Covers:
+- Why the object exists and what problem it solves
+- Python type definition (canonical spec)
+- How to assemble `DataProvenance` from a fact row
+- Owner matrix: which service writes / reads each fact-type family
+- Hybrid storage: live facts → `btd6_facts`; static stats → committed JSON / `btd6_data_blobs`
+- Relationship to `DataFreshness` in `btd6_view_model_service` (different layers, different purpose)
+- Section on `explore_gamedata.py` with clone + usage examples
+
+This doc, when merged, officially lifts the RC-10 extraction pause.
+
+**3. `scripts/explore_gamedata.py`** — offline dump search tool
+
+The BTD Mod Helper game-data dump is ~320 MB of deeply-nested JSON. Previously, decode
+sessions required manually opening files or writing ad-hoc search scripts to find model
+types or field names. This tool wraps that workflow.
+
+Modes:
+- `--list-types [--in SUBPATH]` — all unique `$type` short names with counts
+- `--search PATTERN [--struct] [--show-path]` — find nodes by $type substring
+- `--field FIELD_NAME` — find nodes that have a specific field
+- `--list-files` — enumerate JSON files (useful to understand folder structure)
+
+Key flags: `--in` narrows to files whose path contains a substring (e.g. `Towers/Village`);
+`--struct` shows field keys only (good for deciding if a type is worth mapping);
+`--show-path` shows the JSON path to each match (good for understanding nesting).
+
+Provenance header per repo convention: unverified — confirm outputs against raw dump a few
+times before trusting fully. The tool is a pure stdlib/pathlib script with no disbot imports.
+
+**4. Supporting doc + state updates**
+
+- `docs/btd6/README.md` — paused-work notice replaced with gate-lifted notice; schema doc
+  linked under "Pipeline / backends / data".
+- `docs/btd6/btd6-gamedata-decode-status.md` — added "Exploration tooling" block before the
+  binding discipline section (the place decode agents read when starting a session), with
+  clone instructions + annotated usage examples for each `explore_gamedata.py` mode.
+  Updated header timestamp + gate status.
+- `docs/subsystems/btd6.md` — current-state section updated from "paused" to gate-lifted.
+- `docs/current-state.md` — BTD6 extraction gate updated from "stays paused" to "now
+  implemented; may resume against the ordered backlog."
+
+## Key decisions / findings
+
+- **No new infrastructure needed.** `btd6_facts` already carries `source_id`, `fetched_at`,
+  `version`, `confidence`, `game_version`. `btd6_source_registry` already tracks
+  `trust_tier`, `source_kind`, etc. The gap was purely a typed envelope + formal doc.
+- **`fetch_for_intent` stays raw-dict.** One caller; no value in breaking it. New code uses
+  `FactRow`; the old path stays untouched.
+- **Static facts are out of scope for `DataProvenance`.** Their provenance is the `source`
+  field stamped inline by `parse_gamedata.py` / `fetch_bloonswiki.py`. The schema doc makes
+  this split explicit to prevent future agents from incorrectly trying to attach
+  `DataProvenance` to committed JSON files.
+- **`explore_gamedata.py` is an offline tool only.** It has no disbot imports, no runtime
+  path. Agents must clone the dump locally first.
+
+## CI / quality
+
+`python3.10 scripts/check_quality.py --full` — green: 8063 passed, 16 skipped, 0 failures.
+mypy clean (585 files). check_docs clean (0 orphans). PR #587 pushed; CI in-progress at
+session end.
+
+## What's next (the now-unblocked backlog)
+
+From `docs/btd6/btd6-gamedata-decode-status.md`, ordered:
+1. Buff decode tail (9 → 38 types) — per-model semantic analysis, use `explore_gamedata.py`
+   to inspect each type before mapping
+2. `SCHEMA_FIRST` buff/zone types — extend the renderer before decoding
+3. Zone effect tail (28 types) + zones nested in sub-towers (Heli `MoabShoveZoneModel` is next)
+4. Economy-tower attack suppression + `paragon_cost`/`paragon_name`
+5. Tower cutover (game-native over wiki)

--- a/disbot/services/btd6_fact_store.py
+++ b/disbot/services/btd6_fact_store.py
@@ -15,8 +15,10 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
+from services.btd6_source_registry import FreshnessBucket, bucket_freshness
 from utils.db import btd6_sources as btd6_db
 
 logger = logging.getLogger("bot.services.btd6_fact_store")
@@ -44,6 +46,91 @@ class BTD6FactQuery:
     fact_type: str | None
     entity_kind: str
     entity_key: str
+
+
+@dataclass(frozen=True)
+class DataProvenance:
+    """Provenance label attached to every live BTD6 fact.
+
+    Assembled from a joined fact row via :func:`extract_provenance`.
+    See ``docs/btd6/btd6-provenance-schema.md`` for the full contract.
+    """
+
+    source_id: int
+    source_key: str
+    source_name: str
+    source_kind: str
+    trust_tier: int
+    fetched_at: datetime
+    game_version: str | None
+    freshness: FreshnessBucket
+
+    @property
+    def is_official(self) -> bool:
+        return self.trust_tier == 1
+
+    @property
+    def label(self) -> str:
+        return f"{self.source_name} (tier {self.trust_tier}, {self.freshness})"
+
+
+def extract_provenance(row: dict[str, Any]) -> DataProvenance:
+    """Assemble a :class:`DataProvenance` from a joined fact row.
+
+    Expects the shape returned by
+    ``btd6_db.fetch_facts_for_intent`` — i.e. the fact columns plus
+    ``source_id``, ``source_key``, ``source_name``, ``source_kind``,
+    ``trust_tier`` joined from ``btd6_source_registry``.
+    """
+    fetched_at: datetime = row["fetched_at"]
+    if fetched_at is None:
+        raise TypeError(
+            "fact row missing fetched_at — column is NOT NULL in btd6_facts",
+        )
+    if isinstance(fetched_at, str):
+        fetched_at = datetime.fromisoformat(fetched_at)
+    return DataProvenance(
+        source_id=int(row["source_id"]),
+        source_key=row.get("source_key") or "",
+        source_name=row.get("source_name") or "",
+        source_kind=row.get("source_kind") or "",
+        trust_tier=int(row.get("trust_tier") or 2),
+        fetched_at=fetched_at,
+        game_version=row.get("game_version"),
+        freshness=bucket_freshness(fetched_at),
+    )
+
+
+@dataclass(frozen=True)
+class FactRow:
+    """Typed wrapper for a fact row with provenance attached.
+
+    Use :meth:`from_row` to lift a raw dict from
+    :func:`fetch_for_intent`.  New extraction code should work with
+    ``FactRow`` rather than raw dicts.
+    """
+
+    fact_id: int
+    fact_type: str
+    entity_kind: str
+    entity_key: str
+    body_json: dict[str, Any]
+    confidence: float
+    version: int
+    provenance: DataProvenance
+
+    @classmethod
+    def from_row(cls, row: dict[str, Any]) -> FactRow:
+        return cls(
+            fact_id=int(row["id"]),
+            fact_type=row["fact_type"],
+            entity_kind=row["entity_kind"],
+            entity_key=row["entity_key"],
+            body_json=row.get("body_json") or {},
+            confidence=float(row.get("confidence") or 1.0),
+            version=int(row.get("version") or 1),
+            provenance=extract_provenance(row),
+        )
 
 
 async def store_fact(
@@ -156,7 +243,10 @@ async def fetch_for_intent(
 
 __all__ = [
     "BTD6FactQuery",
+    "DataProvenance",
+    "FactRow",
     "FactWriteResult",
+    "extract_provenance",
     "fetch_for_intent",
     "store_fact",
     "store_facts",

--- a/docs/btd6/README.md
+++ b/docs/btd6/README.md
@@ -4,10 +4,10 @@
 > [`../subsystems/btd6.md`](../subsystems/btd6.md) is the entry point; ADR-006 and
 > `docs/current-state.md` win over anything here.
 >
-> **Paused work.** BTD6 data extraction is **paused pending the ADR-006 provenance
-> schema** (`../decisions/006-btd6-data-provenance-ownership.md`). These docs capture the
-> decode/extraction/pipeline direction; they are subordinate to ADR-006 and the global
-> AI/BTD6 gate in `docs/current-state.md`. Do not resume extraction from a docs session.
+> **Gate lifted.** The ADR-006 provenance schema is now implemented
+> ([`btd6-provenance-schema.md`](./btd6-provenance-schema.md)). BTD6 data extraction
+> may resume following the ordered backlog in `btd6-gamedata-decode-status.md`. The
+> global AI/BTD6 gate in `docs/current-state.md` still applies.
 
 These were consolidated out of the top level of `docs/` into `docs/btd6/` so the island
 is one folder behind the folio instead of ~14 files scattered at the root.
@@ -27,6 +27,9 @@ is one folder behind the folio instead of ~14 files scattered at the root.
 
 ## Pipeline / backends / data
 
+- [`btd6-provenance-schema.md`](./btd6-provenance-schema.md) — **binding** provenance schema
+  contract (RC-10 gate PR); defines `DataProvenance`, `FactRow`, the owner matrix, and hybrid
+  storage split. Merging this lifts the extraction pause.
 - [`btd6-data-pipeline.md`](./btd6-data-pipeline.md) — the ingestion/data pipeline shape.
 - [`btd6-data-backends.md`](./btd6-data-backends.md) — data backend options and the choice.
 - [`btd6-cloud-data.md`](./btd6-cloud-data.md) — cloud-data backend notes.

--- a/docs/btd6/btd6-gamedata-decode-status.md
+++ b/docs/btd6/btd6-gamedata-decode-status.md
@@ -13,7 +13,7 @@ works** (the traps we hit), and what is still un-decoded.
 
 ---
 
-## ⭐ Next session — start here (updated 2026-06-04, end of v55 session)
+## ⭐ Next session — start here (updated 2026-06-08 — provenance gate lifted, PR #587)
 
 ### Current state & next actions (READ FIRST)
 
@@ -106,6 +106,36 @@ works** (the traps we hit), and what is still un-decoded.
    maps, and **never claim a complete cross-map list** (coverage is partial —
    ~18 of the ~30+ maps that have removables). Extend `_MAP_REMOVABLES` (not the
    parser logic) to cover more maps; costs still need a verified source.
+
+**Exploration tooling — use this before reading dump files manually:**
+
+`scripts/explore_gamedata.py` (added 2026-06-08, PR #587) — a read-only search tool
+for the game-data dump. Clone the dump first, then run it:
+
+```bash
+git clone --depth 1 https://github.com/Btd6ModHelper/btd6-game-data /tmp/btd6gd
+
+# What model types exist under a tower? (use before mapping a new area)
+python3.10 scripts/explore_gamedata.py --dump /tmp/btd6gd --list-types --in Towers/Village
+
+# Find every instance of a model type + its fields (use when a buff/zone type is unknown)
+python3.10 scripts/explore_gamedata.py --dump /tmp/btd6gd --search RangeSupportModel --struct
+
+# Find every node that carries a specific field (use when the field name is known, model is not)
+python3.10 scripts/explore_gamedata.py --dump /tmp/btd6gd --field damageAddative --in Towers
+
+# Show the field values (not just names) for a specific model instance
+python3.10 scripts/explore_gamedata.py --dump /tmp/btd6gd --search MoabShoveZoneModel --in Towers/HeliPilot
+
+# Show the JSON path to each match (use when you need to understand the nesting)
+python3.10 scripts/explore_gamedata.py --dump /tmp/btd6gd --search RangeSupportModel --show-path --limit 5
+```
+
+The tool walks the full nested JSON tree (depth 30 by default). `--struct` shows field
+names only — useful for deciding if a model type is worth decoding before reading values.
+`--in` accepts any case-insensitive substring of the file path. Provenance note: outputs
+are unverified — cross-check a few against the raw JSON before trusting them in a mapping
+decision.
 
 **Binding discipline for every decode step:**
 - Re-validate anchors first (`--validate-anchors`); if they fail the dump moved → stop.

--- a/docs/btd6/btd6-provenance-schema.md
+++ b/docs/btd6/btd6-provenance-schema.md
@@ -1,0 +1,201 @@
+# BTD6 data provenance — schema contract
+
+> **Status:** `binding` — this is the follow-on docs/schema PR that
+> [ADR-006](../decisions/006-btd6-data-provenance-ownership.md) requires.
+> Merging this PR **lifts the RC-10 gate** and allows BTD6 data extraction
+> to resume against a defined provenance contract.
+>
+> **Last updated:** 2026-06-08.
+
+---
+
+## 1. Purpose
+
+Every BTD6 fact surfaced to a user carries an implicit claim: *"this figure
+came from source X, fetched at time T, and is valid for game version V."*
+Without a formal representation that travels with the fact, different services
+make that claim inconsistently — one renders a freshness label, another silently
+drops it, a third re-fetches freshness on demand via a separate query.
+
+This doc defines:
+
+1. The **`DataProvenance`** value object — the single composed envelope every
+   live BTD6 fact carries.
+2. How it is **assembled** from a joined fact row.
+3. The **owner-per-fact-type matrix** — which service writes and which reads
+   each fact domain.
+4. How the **hybrid storage** split works (`btd6_facts` vs `btd6_data_blobs`
+   vs committed JSON).
+
+---
+
+## 2. Scope — live facts vs static blobs
+
+BTD6 data splits cleanly into two families with different freshness models:
+
+| Family | Examples | Freshness model | Storage |
+|---|---|---|---|
+| **Live facts** | Race/boss/CT metadata + leaderboards, active event windows, challenge lists | Regularly re-fetched from NK API or bloonswiki; can become stale | `btd6_facts` table (Postgres) |
+| **Static blobs** | Tower/hero/upgrade/bloon stats, map metadata, round composition | Game-version-locked; only change on a patch | Committed JSON under `disbot/data/btd6/`, optionally mirrored to `btd6_data_blobs` |
+
+**`DataProvenance` applies to live facts only.** Static blob provenance is
+carried inline as a `source` field stamped into each JSON file by
+`parse_gamedata.py` / `fetch_bloonswiki.py` (e.g.
+`"source": "BTD Mod Helper game data export"`). Those scripts are the write
+path; `btd6_stats_service` is the sole runtime reader.
+
+---
+
+## 3. `DataProvenance` value object
+
+Python definition (canonical — lives in
+`disbot/services/btd6_fact_store.py`, exported from `__all__`):
+
+```python
+@dataclass(frozen=True)
+class DataProvenance:
+    source_id: int          # FK → btd6_source_registry.id
+    source_key: str         # e.g. "nk_btd6_races"
+    source_name: str        # e.g. "data.ninjakiwi.com"
+    source_kind: str        # "official_api" | "webpage" | "patch_notes"
+    trust_tier: int         # 1 = highest (official_api), 2 = webpage/patch
+    fetched_at: datetime    # UTC, when the fact was last written
+    game_version: str | None  # e.g. "43.0" or None for non-version-stamped facts
+    freshness: FreshnessBucket  # "fresh" | "aging" | "stale" | "never"
+```
+
+**Rules:**
+
+- `freshness` is computed from `fetched_at` via
+  `btd6_source_registry.bucket_freshness()` — **do not recompute inline**.
+- `trust_tier` 1 means the source is an official NK API endpoint; tier 2 is
+  a third-party page or patch notes. The fact store's ordering
+  (`trust_tier ASC, fetched_at DESC`) puts tier-1 facts first.
+- The object is **frozen** — it must never be mutated after construction.
+- `source_kind` is the raw DB value; callers should compare against the
+  `"official_api"` | `"webpage"` | `"patch_notes"` literals from the
+  schema constraint, not a free string.
+
+### Helper property
+
+`DataProvenance.label` — a short human-readable string for embeds/logs:
+```
+"data.ninjakiwi.com (tier 1, fresh)"
+```
+
+---
+
+## 4. Assembling `DataProvenance` from a fact row
+
+`btd6_db.fetch_facts_for_intent` already joins `btd6_source_registry` and
+returns rows with `source_id`, `source_key`, `source_name`, `source_kind`,
+`trust_tier`, `fetched_at`, `game_version` present. Use `extract_provenance`:
+
+```python
+from services.btd6_fact_store import extract_provenance, FactRow
+
+provenance = extract_provenance(row)     # row is a dict from fetch_for_intent
+typed_row = FactRow.from_row(row)        # body + provenance in one typed object
+```
+
+`FactRow` is the typed wrapper for new code; `fetch_for_intent` continues to
+return raw dicts for backward compatibility with the one existing caller
+(`btd6_context_service`).
+
+---
+
+## 5. Owner matrix
+
+| Fact-type family | Write owner | Read owner | Storage |
+|---|---|---|---|
+| `btd6.races_*`, `btd6.race_*` | `btd6_fetch_service` | `btd6_knowledge_service` | `btd6_facts` |
+| `btd6.boss_*` | `btd6_fetch_service` | `btd6_knowledge_service` | `btd6_facts` |
+| `btd6.ct_*`, `btd6.odyssey_*` | `btd6_fetch_service` | `btd6_knowledge_service` | `btd6_facts` |
+| `btd6.events_index` | `btd6_fetch_service` | `btd6_knowledge_service` | `btd6_facts` |
+| `btd6.challenge_*`, `btd6.map_*` | `btd6_fetch_service` | `btd6_knowledge_service` | `btd6_facts` |
+| Tower/hero/upgrade/bloon/round/map **static stats** | `parse_gamedata.py`, `fetch_bloonswiki.py` (offline scripts) | `btd6_stats_service` | committed JSON + `btd6_data_blobs` |
+| **Cross-cutting composition** (anything the AI or an embed sees) | — | `btd6_view_model_service` | (composed from above) |
+
+**The invariant:** `btd6_view_model_service` is the only service that should
+compose across fact families. It may call `btd6_knowledge_service` and
+`btd6_stats_service` in the same response, but neither of those should call
+the other directly.
+
+---
+
+## 6. Hybrid storage
+
+```
+Live event/race/boss/etc. data
+  → fetched by btd6_fetch_service
+  → written to btd6_facts (source_id FK → btd6_source_registry)
+  → read by btd6_knowledge_service / btd6_fact_store.fetch_for_intent
+  → DataProvenance assembled by extract_provenance()
+
+Static tower/hero stats
+  → extracted offline by parse_gamedata.py / fetch_bloonswiki.py
+  → committed as JSON under disbot/data/btd6/
+  → optionally mirrored to btd6_data_blobs at startup (BTD6_DATA_BACKEND=postgres)
+  → read by btd6_stats_service (file or blob, same interface)
+  → provenance is the inline "source" + "version"/"_last_updated" field in the JSON
+```
+
+No new storage table is introduced. `btd6_data_blobs` already carries a
+`sha256` column for integrity checking; its `updated_at` is the blob-write
+timestamp, not the game-data extraction timestamp (use the JSON's own
+`"version"` field for that).
+
+---
+
+## 7. Relationship to `DataFreshness` in the view-model service
+
+`btd6_view_model_service.DataFreshness` is a **view-model** object — it
+summarises freshness for an embed's footer. It is assembled *from*
+`DataProvenance` or from a `SourceHealth` object returned by
+`btd6_source_registry.list_health()`. The two types are not the same:
+
+| Type | Layer | Scope | Used for |
+|---|---|---|---|
+| `DataProvenance` | service (fact store) | One fact | Carries source attribution through the read pipeline |
+| `DataFreshness` | service (view model) | One embed panel | Renders freshness into a Discord embed footer |
+| `SourceHealth` | service (source registry) | One source row | Operator-facing health dashboard |
+
+When building a new embed that needs a provenance footer, the correct flow is:
+`FactRow.provenance → DataFreshness(state=provenance.freshness, ...)` — not
+re-querying the source registry.
+
+---
+
+## 8. Resuming extraction
+
+This PR implements the provenance contract. The following are now unblocked:
+
+- New BTD6 data extraction (buff decode tail, zone types, subtower mechanisms)
+- New fact-type registrations (any new `fact_type` string)
+- The tower cutover (game-native stats replacing bloonswiki)
+
+**The existing `extracted ≠ reachable ≠ answerable` discipline survives this
+gate.** Provenance is a prerequisite for extraction, not a substitute for
+verifying that extracted data is rendered and answerable live. See
+`btd6-gamedata-decode-status.md` for the ordered decode backlog.
+
+---
+
+## 9. Explore tooling (new)
+
+`scripts/explore_gamedata.py` — added in the same PR. A read-only search tool
+for the BTD Mod Helper game-data dump that makes decode sessions faster: find
+all instances of a model type, search by field name, inspect a tower's
+structure, list all `$type` values. Run with `--help` for full usage.
+
+```bash
+git clone --depth 1 https://github.com/Btd6ModHelper/btd6-game-data /tmp/btd6gd
+python3.10 scripts/explore_gamedata.py --dump /tmp/btd6gd --list-types
+python3.10 scripts/explore_gamedata.py --dump /tmp/btd6gd --search RangeSupportModel
+python3.10 scripts/explore_gamedata.py --dump /tmp/btd6gd --field damageAddative --in "Towers/DartMonkey"
+python3.10 scripts/explore_gamedata.py --dump /tmp/btd6gd --struct MoabShoveZoneModel
+```
+
+Provenance header (per repo convention, 2026-06-08): added to aid BTD6 decode
+work; **unverified — confirm outputs against the raw dump a few times before
+trusting them fully.**

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -104,7 +104,11 @@ Source code and merged PRs win over anything written here.
 - **AI / BTD6 feature expansion** is gated on *all* of: bot-wide stability **+**
   provider/provenance checks **+** caching / source-health clarity **+** AI
   behavior/config correctness — **not** just the RC-11 guard suite passing.
-- **BTD6 data extraction** stays paused pending the **ADR-006** provenance schema.
+- **BTD6 data extraction** — ADR-006 provenance schema **now implemented**
+  (`docs/btd6/btd6-provenance-schema.md`); extraction may resume against the ordered
+  backlog in `docs/btd6/btd6-gamedata-decode-status.md`. The broader AI/BTD6
+  feature-expansion gate (stability + provider/provenance + caching + AI config) still
+  applies.
 - `_derive_scope` → `PLATFORM_OWNER` (decision D1) — **RESOLVED** in #541; owner-only
   AI tools are now reachable.
 

--- a/docs/subsystems/btd6.md
+++ b/docs/subsystems/btd6.md
@@ -29,8 +29,10 @@ files, `disbot/services/btd6_*`, `disbot/views/btd6/`, `disbot/utils/db/btd6_*`,
 
 ## Current state
 
-- BTD6 data extraction is **paused pending implementation of the ADR-006 provenance
-  schema**. Do not resume extraction or add new mappings in a folio/mapping session.
+- ADR-006 provenance schema **implemented** (`docs/btd6/btd6-provenance-schema.md`).
+  BTD6 data extraction may resume against the ordered backlog in
+  `docs/btd6/btd6-gamedata-decode-status.md`. The broader AI/BTD6 feature-expansion
+  gate (stability + caching + AI config) still applies per `docs/current-state.md`.
 - The repo already contains source registry, ingestion, fact-store, data-provider,
   cache, grounding, resolver, live-query, strategy, and ops-readiness services plus
   migrations/data. Their existence is not proof that provenance/source health is

--- a/scripts/explore_gamedata.py
+++ b/scripts/explore_gamedata.py
@@ -1,0 +1,380 @@
+"""Search and explore the BTD Mod Helper game-data dump.
+
+Provenance: added 2026-06-08 to support BTD6 decode sessions. Unverified —
+confirm outputs against the raw dump a few times before trusting them fully.
+
+Point --dump at a local clone of github.com/Btd6ModHelper/btd6-game-data:
+
+    git clone --depth 1 https://github.com/Btd6ModHelper/btd6-game-data /tmp/btd6gd
+
+Modes (pick one):
+
+    --list-types          Print all unique $type short names + occurrence counts.
+    --search PATTERN      Find nodes whose $type contains PATTERN (case-insensitive).
+                          Combine with --struct to show field names only (no values).
+    --field FIELD         Find nodes that have a specific field name (exact match).
+    --list-files          Print all JSON files found under --dump (or --in glob).
+
+Scope filters (optional):
+
+    --in SUBPATH          Restrict to files whose path contains SUBPATH
+                          (e.g. "Towers/DartMonkey", "Heroes/Quincy").
+                          Prefix-matched, case-insensitive.
+
+Display options:
+
+    --show-path           Include the JSON path to each matching node.
+    --struct              Show matching node's keys only (no values). Useful for
+                          understanding what fields a model type exposes.
+    --limit N             Max nodes to print (default 20).
+    --depth N             Max recursion depth when walking JSON (default 30).
+
+Examples:
+    python3.10 scripts/explore_gamedata.py --dump /tmp/btd6gd --list-types
+    python3.10 scripts/explore_gamedata.py --dump /tmp/btd6gd --list-types --in Towers/Village
+
+    python3.10 scripts/explore_gamedata.py --dump /tmp/btd6gd --search RangeSupportModel
+    python3.10 scripts/explore_gamedata.py --dump /tmp/btd6gd --search RangeSupportModel --struct
+    python3.10 scripts/explore_gamedata.py --dump /tmp/btd6gd --search RangeSupportModel --show-path
+
+    python3.10 scripts/explore_gamedata.py --dump /tmp/btd6gd --field damageAddative
+    python3.10 scripts/explore_gamedata.py --dump /tmp/btd6gd --field damageAddative --in Towers/DartMonkey
+
+    python3.10 scripts/explore_gamedata.py --dump /tmp/btd6gd --search MoabShoveZoneModel --struct --in Towers/HeliPilot
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# JSON tree walker
+# ---------------------------------------------------------------------------
+
+
+def _walk(
+    node: Any,
+    *,
+    path: str = "",
+    depth: int = 0,
+    max_depth: int = 30,
+) -> Generator[tuple[str, dict[str, Any]], None, None]:
+    """Yield (json_path, dict_node) for every dict in the JSON tree."""
+    if depth > max_depth:
+        return
+    if isinstance(node, dict):
+        yield path, node
+        for key, value in node.items():
+            child_path = f"{path}.{key}" if path else key
+            yield from _walk(
+                value,
+                path=child_path,
+                depth=depth + 1,
+                max_depth=max_depth,
+            )
+    elif isinstance(node, list):
+        for i, item in enumerate(node):
+            yield from _walk(
+                item,
+                path=f"{path}[{i}]",
+                depth=depth + 1,
+                max_depth=max_depth,
+            )
+
+
+def _short_type(node: dict[str, Any]) -> str:
+    """'Il2Cpp…Behaviors.AttackModel, Assembly-CSharp' → 'AttackModel'."""
+    raw = node.get("$type")
+    if not isinstance(raw, str):
+        return ""
+    return raw.split(",", 1)[0].rsplit(".", 1)[-1]
+
+
+# ---------------------------------------------------------------------------
+# File discovery
+# ---------------------------------------------------------------------------
+
+
+def _find_json_files(dump: Path, *, in_filter: str | None) -> list[Path]:
+    """Return sorted JSON files under dump, optionally filtered by subpath."""
+    all_files = sorted(dump.rglob("*.json"))
+    if not in_filter:
+        return all_files
+    needle = in_filter.lower().replace("\\", "/")
+    return [
+        f
+        for f in all_files
+        if needle in str(f.relative_to(dump)).lower().replace("\\", "/")
+    ]
+
+
+def _load(path: Path) -> Any | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        print(f"  [skip] {path.name}: {exc}", file=sys.stderr)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Display helpers
+# ---------------------------------------------------------------------------
+
+
+def _fmt_node(node: dict[str, Any], *, struct: bool) -> str:
+    if struct:
+        keys = [k for k in node if not k.startswith("$")]
+        return "{ " + ", ".join(keys) + " }"
+    parts: list[str] = []
+    for k, v in node.items():
+        if k == "$type":
+            continue
+        if isinstance(v, (dict, list)):
+            parts.append(f"{k}: <{type(v).__name__}>")
+        else:
+            parts.append(f"{k}: {v!r}")
+    return "{ " + ", ".join(parts) + " }"
+
+
+def _print_match(
+    *,
+    source_file: Path,
+    dump: Path,
+    json_path: str,
+    node: dict[str, Any],
+    show_path: bool,
+    struct: bool,
+    type_label: str = "",
+) -> None:
+    rel = source_file.relative_to(dump)
+    header = f"  [{rel}]"
+    if type_label:
+        header += f"  {type_label}"
+    if show_path and json_path:
+        header += f"  @{json_path}"
+    print(header)
+    print(f"    {_fmt_node(node, struct=struct)}")
+
+
+# ---------------------------------------------------------------------------
+# Modes
+# ---------------------------------------------------------------------------
+
+
+def cmd_list_types(files: list[Path], dump: Path, *, max_depth: int) -> None:
+    counts: Counter[str] = Counter()
+    for path in files:
+        data = _load(path)
+        if data is None:
+            continue
+        for _, node in _walk(data, max_depth=max_depth):
+            t = _short_type(node)
+            if t:
+                counts[t] += 1
+    if not counts:
+        print("No $type values found.")
+        return
+    print(f"{len(counts)} unique $type values across {len(files)} file(s):\n")
+    for name, count in counts.most_common():
+        print(f"  {count:>6}  {name}")
+
+
+def cmd_search(
+    files: list[Path],
+    dump: Path,
+    pattern: str,
+    *,
+    show_path: bool,
+    struct: bool,
+    limit: int,
+    max_depth: int,
+) -> None:
+    needle = pattern.lower()
+    found = 0
+    for path in files:
+        if found >= limit:
+            break
+        data = _load(path)
+        if data is None:
+            continue
+        for json_path, node in _walk(data, max_depth=max_depth):
+            if found >= limit:
+                break
+            t = _short_type(node)
+            if needle in t.lower():
+                _print_match(
+                    source_file=path,
+                    dump=dump,
+                    json_path=json_path,
+                    node=node,
+                    show_path=show_path,
+                    struct=struct,
+                    type_label=t,
+                )
+                found += 1
+    if found == 0:
+        print(f"No nodes found with $type containing '{pattern}'.")
+    elif found >= limit:
+        print(f"\n  (limit {limit} reached — use --limit N to see more)")
+
+
+def cmd_field(
+    files: list[Path],
+    dump: Path,
+    field_name: str,
+    *,
+    show_path: bool,
+    struct: bool,
+    limit: int,
+    max_depth: int,
+) -> None:
+    found = 0
+    for path in files:
+        if found >= limit:
+            break
+        data = _load(path)
+        if data is None:
+            continue
+        for json_path, node in _walk(data, max_depth=max_depth):
+            if found >= limit:
+                break
+            if field_name in node:
+                _print_match(
+                    source_file=path,
+                    dump=dump,
+                    json_path=json_path,
+                    node=node,
+                    show_path=show_path,
+                    struct=struct,
+                    type_label=_short_type(node) or "",
+                )
+                found += 1
+    if found == 0:
+        print(f"No nodes found with field '{field_name}'.")
+    elif found >= limit:
+        print(f"\n  (limit {limit} reached — use --limit N to see more)")
+
+
+def cmd_list_files(files: list[Path], dump: Path) -> None:
+    print(f"{len(files)} file(s) under {dump}:\n")
+    for f in files:
+        print(f"  {f.relative_to(dump)}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--dump",
+        required=True,
+        metavar="PATH",
+        help="Path to the btd6-game-data clone.",
+    )
+
+    mode = p.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--list-types",
+        action="store_true",
+        help="List all unique $type values with counts.",
+    )
+    mode.add_argument(
+        "--search",
+        metavar="PATTERN",
+        help="Find nodes whose $type contains PATTERN.",
+    )
+    mode.add_argument(
+        "--field",
+        metavar="FIELD",
+        help="Find nodes that have a specific field name.",
+    )
+    mode.add_argument(
+        "--list-files",
+        action="store_true",
+        help="List all JSON files found (respecting --in).",
+    )
+
+    p.add_argument(
+        "--in",
+        dest="in_filter",
+        metavar="SUBPATH",
+        help="Restrict search to files whose path contains SUBPATH.",
+    )
+    p.add_argument(
+        "--show-path",
+        action="store_true",
+        help="Print the JSON path to each matching node.",
+    )
+    p.add_argument(
+        "--struct",
+        action="store_true",
+        help="Show field names only (no values).",
+    )
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Max matching nodes to print (default 20).",
+    )
+    p.add_argument(
+        "--depth",
+        type=int,
+        default=30,
+        help="Max recursion depth (default 30).",
+    )
+    return p
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    dump = Path(args.dump)
+    if not dump.is_dir():
+        sys.exit(f"error: --dump path not found or not a directory: {dump}")
+
+    files = _find_json_files(dump, in_filter=args.in_filter)
+    if not files:
+        sys.exit(
+            f"error: no JSON files found under {dump}"
+            + (f" matching '{args.in_filter}'" if args.in_filter else ""),
+        )
+
+    if args.list_types:
+        cmd_list_types(files, dump, max_depth=args.depth)
+    elif args.search:
+        cmd_search(
+            files,
+            dump,
+            args.search,
+            show_path=args.show_path,
+            struct=args.struct,
+            limit=args.limit,
+            max_depth=args.depth,
+        )
+    elif args.field:
+        cmd_field(
+            files,
+            dump,
+            args.field,
+            show_path=args.show_path,
+            struct=args.struct,
+            limit=args.limit,
+            max_depth=args.depth,
+        )
+    elif args.list_files:
+        cmd_list_files(files, dump)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/services/test_btd6_data_provenance.py
+++ b/tests/unit/services/test_btd6_data_provenance.py
@@ -1,0 +1,195 @@
+"""DataProvenance, FactRow, and extract_provenance — unit tests.
+
+Covers the provenance contract defined in
+``docs/btd6/btd6-provenance-schema.md`` (RC-10 gate PR).
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from services.btd6_fact_store import DataProvenance  # noqa: E402
+from services.btd6_fact_store import FactRow  # noqa: E402
+from services.btd6_fact_store import extract_provenance  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _ts(hours_ago: float = 0) -> datetime:
+    return datetime.now(tz=timezone.utc) - timedelta(hours=hours_ago)
+
+
+def _row(
+    *,
+    source_id: int = 1,
+    source_key: str = "nk_btd6_races",
+    source_name: str = "data.ninjakiwi.com",
+    source_kind: str = "official_api",
+    trust_tier: int = 1,
+    fetched_at: datetime | None = None,
+    game_version: str | None = "43.0",
+    fact_type: str = "btd6.race_metadata",
+    entity_kind: str = "btd6_race",
+    entity_key: str = "test_race",
+    body_json: dict | None = None,
+    confidence: float = 1.0,
+    version: int = 1,
+) -> dict:
+    return {
+        "id": 42,
+        "source_id": source_id,
+        "source_key": source_key,
+        "source_name": source_name,
+        "source_kind": source_kind,
+        "trust_tier": trust_tier,
+        "fetched_at": fetched_at or _ts(1),
+        "game_version": game_version,
+        "fact_type": fact_type,
+        "entity_kind": entity_kind,
+        "entity_key": entity_key,
+        "body_json": body_json or {"name": entity_key},
+        "confidence": confidence,
+        "version": version,
+        "validated_at": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# DataProvenance
+# ---------------------------------------------------------------------------
+
+
+def test_extract_provenance_populates_all_fields():
+    ts = _ts(12)  # 12 h ago → aging (fresh < 6 h, aging < 48 h)
+    p = extract_provenance(_row(
+        source_id=7,
+        source_key="nk_btd6_races",
+        source_name="data.ninjakiwi.com",
+        source_kind="official_api",
+        trust_tier=1,
+        fetched_at=ts,
+        game_version="43.0",
+    ))
+    assert p.source_id == 7
+    assert p.source_key == "nk_btd6_races"
+    assert p.source_name == "data.ninjakiwi.com"
+    assert p.source_kind == "official_api"
+    assert p.trust_tier == 1
+    assert p.fetched_at == ts
+    assert p.game_version == "43.0"
+    assert p.freshness == "aging"
+
+
+def test_freshness_bucket_fresh():
+    p = extract_provenance(_row(fetched_at=_ts(0.1)))
+    assert p.freshness == "fresh"
+
+
+def test_freshness_bucket_stale():
+    p = extract_provenance(_row(fetched_at=_ts(72)))
+    assert p.freshness == "stale"
+
+
+def test_freshness_bucket_never_when_missing():
+    row = _row()
+    row["fetched_at"] = None
+    with pytest.raises((KeyError, TypeError)):
+        extract_provenance(row)
+
+
+def test_is_official_true_for_tier1():
+    p = extract_provenance(_row(trust_tier=1))
+    assert p.is_official is True
+
+
+def test_is_official_false_for_tier2():
+    p = extract_provenance(_row(trust_tier=2, source_kind="webpage"))
+    assert p.is_official is False
+
+
+def test_label_format():
+    p = extract_provenance(_row(
+        source_name="bloonswiki.com", trust_tier=2, fetched_at=_ts(0.5)
+    ))
+    assert "bloonswiki.com" in p.label
+    assert "tier 2" in p.label
+    assert "fresh" in p.label
+
+
+def test_data_provenance_is_frozen():
+    p = extract_provenance(_row())
+    with pytest.raises(Exception):
+        p.trust_tier = 99  # type: ignore[misc]
+
+
+def test_extract_provenance_accepts_iso_string_fetched_at():
+    ts = _ts(1)
+    row = _row(fetched_at=ts.isoformat())
+    p = extract_provenance(row)
+    assert abs((p.fetched_at.replace(tzinfo=timezone.utc) - ts).total_seconds()) < 2
+
+
+def test_extract_provenance_missing_optional_fields_defaults_safely():
+    row = _row()
+    for key in ("source_key", "source_name", "source_kind", "game_version"):
+        row.pop(key, None)
+    p = extract_provenance(row)
+    assert p.source_key == ""
+    assert p.source_name == ""
+    assert p.source_kind == ""
+    assert p.game_version is None
+
+
+# ---------------------------------------------------------------------------
+# FactRow
+# ---------------------------------------------------------------------------
+
+
+def test_fact_row_from_row_populates_all_fields():
+    ts = _ts(1)
+    fr = FactRow.from_row(_row(
+        fact_type="btd6.race_metadata",
+        entity_kind="btd6_race",
+        entity_key="the_race",
+        body_json={"name": "Test Race"},
+        fetched_at=ts,
+        confidence=0.9,
+        version=2,
+    ))
+    assert fr.fact_id == 42
+    assert fr.fact_type == "btd6.race_metadata"
+    assert fr.entity_kind == "btd6_race"
+    assert fr.entity_key == "the_race"
+    assert fr.body_json == {"name": "Test Race"}
+    assert fr.confidence == pytest.approx(0.9)
+    assert fr.version == 2
+    assert isinstance(fr.provenance, DataProvenance)
+
+
+def test_fact_row_provenance_trust_tier_matches_row():
+    fr = FactRow.from_row(_row(trust_tier=2, source_kind="webpage"))
+    assert fr.provenance.trust_tier == 2
+    assert fr.provenance.is_official is False
+
+
+def test_fact_row_is_frozen():
+    fr = FactRow.from_row(_row())
+    with pytest.raises(Exception):
+        fr.fact_type = "mutated"  # type: ignore[misc]
+
+
+def test_fact_row_body_json_defaults_to_empty_dict_when_missing():
+    row = _row()
+    row["body_json"] = None
+    fr = FactRow.from_row(row)
+    assert fr.body_json == {}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Lifts the RC-10 gate** — BTD6 data extraction is unblocked. This is the follow-on docs/schema PR that ADR-006 required before any new extraction could resume.
- Adds `DataProvenance`, `FactRow`, and `extract_provenance` to `services/btd6_fact_store.py` — the typed provenance envelope that every live BTD6 fact now carries.
- Adds `docs/btd6/btd6-provenance-schema.md` — the binding schema contract: Python type definition, assembly instructions, owner-per-fact-type matrix, hybrid storage clarification.
- Adds `scripts/explore_gamedata.py` — a read-only search/exploration tool for the BTD Mod Helper game-data dump to make future decode sessions faster.

## What changed

**`disbot/services/btd6_fact_store.py`**
- New `DataProvenance` frozen dataclass: `source_id`, `source_key`, `source_name`, `source_kind`, `trust_tier`, `fetched_at`, `game_version`, `freshness` + `.is_official` / `.label` helpers.
- New `extract_provenance(row)` — assembles `DataProvenance` from the joined fact row shape already returned by `fetch_for_intent`.
- New `FactRow` frozen dataclass — typed wrapper (body + provenance) for new extraction code. `fetch_for_intent` is unchanged for backward compat with its one existing caller.

**`scripts/explore_gamedata.py`** (new, offline tool — no runtime impact)
- `--list-types` — all unique `$type` short names with counts
- `--search PATTERN` — find nodes whose `$type` matches, with optional `--struct` (keys only) and `--show-path`
- `--field FIELD` — find nodes containing a specific field name
- `--in SUBPATH` — scope filter (e.g. `Towers/DartMonkey`)

**Docs**
- `docs/btd6/btd6-provenance-schema.md` — new binding doc
- `docs/btd6/README.md`, `docs/subsystems/btd6.md`, `docs/current-state.md` — gate-lifted notices

## Test plan

- [ ] `python3.10 scripts/check_quality.py --full` — green (8063 passed, 16 skipped)
- [ ] New test file: `tests/unit/services/test_btd6_data_provenance.py` — 14 tests covering `DataProvenance`, `extract_provenance`, and `FactRow.from_row`
- [ ] No changes to `fetch_for_intent` interface — existing callers unaffected
- [ ] `explore_gamedata.py` is a pure offline script with no imports from `disbot/`

https://claude.ai/code/session_01MACaGd1xY1qsMmJ6gNt8og
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MACaGd1xY1qsMmJ6gNt8og)_