### PR TITLE
Q-0026: snake_case subsystem keys + Phase 0 access read-model contract

### DIFF
--- a/.sessions/2026-06-08-adaptive-setup-phase0-q0026-identity.md
+++ b/.sessions/2026-06-08-adaptive-setup-phase0-q0026-identity.md
@@ -1,0 +1,110 @@
+# 2026-06-08 — Adaptive Setup Phase 0: Q-0026 identity repair + P0B contracts
+
+**Task:** Start implementing the Adaptive Setup/Access/Routine platform
+(`docs/planning/adaptive-setup-access-routine-platform-2026-06-08.md`) from planning into
+safe foundations. The plan's own batch table sequences P0A (Q-0026) → P0B (Opus contract)
+→ P1A (projection service); this session delivered **P0A in code + P0B in docs**, leaving
+the projection *service* to P1A with a precise route.
+
+**Branch:** `claude/compassionate-feynman-x9hlb` · no open PRs at start (clean slate;
+HEAD = #586 planning-doc merge).
+
+## Shipped
+
+1. **Q-0026 identity repair (P0A) — code + tests.**
+   - `cog_name_to_subsystem` now does a two-pass CamelCase → snake_case conversion
+     (`disbot/core/runtime/command_surface_ledger.py`). Acronym runs stay collapsed
+     (`BTD6Cog`→`btd6`, `AICog`→`ai`).
+   - Renamed the subsystem **key** `servermanagement` → `server_management` across the
+     identity surfaces only: `SUBSYSTEMS`, `HUBS`, `KNOWN_PANEL_COMMANDS`, the
+     `PersistentView.SUBSYSTEM` classvar, the hub custom_ids (`server_management:*`), and
+     the `panel_manager.get_or_render_panel` anchor key. The user-facing
+     `!servermanagement` command + aliases + `/server-management` slash + the
+     `entry_points` list are **command names**, not keys — left unchanged.
+   - **Bonus root-cause fix:** the same conversion repaired a *latent* collapse —
+     `ProofChannelCog`→`proof_channel` and `FourTwentyCog`→`four_twenty` were already
+     snake_case registry keys but `cog_name_to_subsystem` had been silently orphaning them
+     (returning `None`). They now resolve; catalogue/ledger findings only shrink.
+   - Added regression tests pinning the snake_case **output contract** so a future
+     multi-word subsystem can't regress (`test_multiword_cog_names_convert_to_snake_case`,
+     `test_acronym_cog_names_stay_collapsed`, `test_snake_case_is_the_output_contract`,
+     `test_build_ledger_resolves_multiword_subsystem_cog`).
+
+2. **P0B contracts (docs).**
+   - **Direct-vs-draft mutation boundary** → binding rule in `docs/ownership.md`
+     § "Direct vs. draft mutation lanes" (elevated from the planning doc's §5 panel map).
+   - **Phase 0 access read-model contract** → planning doc **§16**: service family,
+     composition **precedence** (the 7-axis order, short-circuit on first deny), the
+     decision/`LockedReason` schema that **reuses** `command_access.DecisionReason`/
+     `DecisionSource` (no second permission system), Help Preview simulation limits, drift
+     providers, the **P0C drift selection** (role-threshold direct writes), invalidation,
+     and the negative-architecture guardrails P1A's tests must assert.
+   - Doc reconciliation: server-management folio (the "adding a hub" gotcha was *wrong* —
+     said keys collapse with no underscore), `current-state`, router Q-0026 (→ implemented)
+     + Q-0016 forward-note, both doc-test-pinned maps (`help-command-surface-map`,
+     `settings-customization-command-map`), settings folio pointer.
+
+## Verification
+
+- `python3.10 scripts/check_quality.py --full` → **8053 passed, 16 skipped** (black/isort/
+  ruff + mypy + pytest).
+- `python3.10 scripts/check_architecture.py --mode strict` → exit 0, 0 errors (only
+  pre-existing WARNs).
+- `python3.10 scripts/check_docs.py` → all checks passed; top-level docs still 16 ≤ ratchet.
+- **Live boot** (test bot, `IDENTITY_CONTRACT_STRICT=true`): all 35 cogs loaded,
+  `Identity-contract: clean (all four surfaces agree). STRICT=on.`, 303 command
+  descriptions, 0 errored, no Traceback/CRITICAL.
+- Identity grep: no stale `servermanagement` *key* remains in `disbot/` — the three
+  surviving `"servermanagement"` literals are all legitimate command-name usages.
+
+## Decisions worth remembering
+
+- **Key vs. command name are different strings on purpose.** The subsystem key
+  (`server_management`) ≠ the command (`servermanagement`), exactly like `economy` (key) vs
+  `economymenu` (command). Renaming the command would be user-facing breakage with no
+  identity benefit, so it stayed.
+- **Custom_ids changed too (`server_management:*`).** Reasoning: after the key rename the
+  old DB anchor (`subsystem="servermanagement"`) no longer resolves to the renamed view
+  class, so an already-posted panel dies on restart *regardless* of custom_ids — there is
+  no extra cost to also renaming them, and it keeps the view consistent with its documented
+  `{SUBSYSTEM}:{action}` contract. No migration; the orphaned anchor self-heals and the
+  panel re-posts on next `!servermanagement`.
+- **No migration added.** A `panel_anchors` data migration would only matter if custom_ids
+  were kept *and* the anchor row migrated (to preserve one test-bot panel across one
+  restart) — over-engineering for a fresh-DB test bot. Documented instead.
+
+## Safe defaults used (Q-0028–Q-0033)
+
+Only read-only/contract work this session, so the defaults held without forcing a choice:
+no committed profile catalogue (Q-0028); availability policy owns quiet mode (Q-0029);
+snapshots required for compound/high-risk applies (Q-0030); ambiguous config queues Final
+Review (Q-0031); no new command names reserved — Access Map/Help Preview stay behind staff
+hubs (Q-0032); account links deferred (Q-0033).
+
+## Next (ordered, grounded in the phased roadmap)
+
+1. **P1A — Access Map projection service** (Sonnet): build the side-effect-free composed
+   read model + tests per planning §16. No UI, no persistence, no editing.
+2. **P0C — role-threshold writer normalization** (Sonnet): route the role panel's direct
+   threshold DB writes through an audited `role_automation` seam (planning §16.5 +
+   ownership.md drift note) before any profile/routine targets thresholds.
+3. **P1B** — drift providers + locked-reason denial integration on top of P1A.
+4. Gated/blocked: profile apply (Phase 3), Routine Engine (Phase 4), Personal Setup
+   (Phase 5), AI drafts (Phase 6) — all wait on their named prerequisites.
+
+## Context delta
+
+- **Needed but not pointed to:** that `cog_name_to_subsystem` (the bug's home) is consumed
+  by the **command-surface ledger AND the customization catalogue's `_walk_help_hooks`/
+  `_walk_extras_panels`**, so the fix silently improves catalogue findings too — the
+  context map showed importers but not that two of them re-call the function. Also that the
+  hub's **panel-anchor key** (2nd arg of `get_or_render_panel`) is written to
+  `panel_anchors.subsystem` (an identity surface), which isn't obvious from the cog.
+- **Pointed to but didn't need:** the binding architecture/ownership/runtime trio and most
+  subsystem folios beyond server-management — this was a narrow identity + read-model-
+  contract session, not a layering change; the deep arch docs didn't change what I did.
+- **Discovered by hand:** the `{SUBSYSTEM}:{action}` custom_id convention lives **only** in
+  the `persistent_views.py` base-class docstring (not in any folio), and the fact that
+  `four_twenty`/`proof_channel` were *already* snake_case keys silently orphaning — both
+  reverse-engineered from source, now captured in the server-management folio "adding a hub"
+  gotcha and planning §3.1.

--- a/disbot/cogs/server_management_cog.py
+++ b/disbot/cogs/server_management_cog.py
@@ -44,9 +44,12 @@ class ServerManagementCog(commands.Cog):
     async def servermanagement(self, ctx: commands.Context) -> None:
         """Open the unified Server Management hub."""
         embed, view = await build_server_management_hub(ctx.guild)
+        # Panel-anchor key is the snake_case subsystem identity
+        # (Q-0026 — written to panel_anchors.subsystem, must resolve in
+        # SUBSYSTEMS); the command name above stays ``servermanagement``.
         msg = await panel_manager.get_or_render_panel(
             ctx,
-            "servermanagement",
+            "server_management",
             embed,
             view,
         )

--- a/disbot/core/runtime/command_surface_ledger.py
+++ b/disbot/core/runtime/command_surface_ledger.py
@@ -190,23 +190,52 @@ _CACHED: CommandSurfaceLedger | None = None
 
 _LEDGER_VERSION = 1
 
-# Cog class name normalisation: trim "Cog" suffix + lowercase.
-# `EconomyCog` → `economy`; `ProofChannelCog` → `proofchannel`.
+# Cog class name normalisation: trim the "Cog" suffix, then split
+# CamelCase into snake_case so a *multi-word* cog class resolves to its
+# multi-word subsystem key (Q-0026).  Before the snake_case pass,
+# `ServerManagementCog` collapsed to `servermanagement` and
+# `ProofChannelCog` to `proofchannel` — the latter silently failed to
+# match the registry's real `proof_channel` key.  Now:
+#   EconomyCog          → economy            (single word, unchanged)
+#   ServerManagementCog → server_management
+#   ProofChannelCog     → proof_channel
+#   FourTwentyCog       → four_twenty
+# Acronym runs stay collapsed (no spurious split): BTD6Cog → btd6,
+# AICog → ai.
 _COG_SUFFIX_RE = re.compile(r"cog$", re.IGNORECASE)
+# Standard two-pass CamelCase → snake_case inflection.  Pass 1 inserts a
+# boundary before an "Upper + lower-run" preceded by any char
+# ("ServerManagement" → "Server_Management"); pass 2 catches the
+# "lower/digit → Upper" boundary ("btd6Ops" → "btd6_Ops").  Together
+# they leave all-caps acronym runs ("AI", "BTD6") intact.
+_CAMEL_HEAD_RE = re.compile(r"(.)([A-Z][a-z]+)")
+_CAMEL_TAIL_RE = re.compile(r"([a-z0-9])([A-Z])")
 
 
 def cog_name_to_subsystem(cog_name: str) -> str | None:
-    """Normalise a cog class name to a SUBSYSTEMS key, or None on miss."""
+    """Normalise a cog class name to a SUBSYSTEMS key, or None on miss.
+
+    Strips a trailing ``Cog`` then converts CamelCase to snake_case, so a
+    multi-word cog class resolves to its snake_case subsystem key — e.g.
+    ``ServerManagementCog`` → ``server_management`` (Q-0026).  The output
+    contract is **snake_case**: every multi-word subsystem must register
+    its key in that form so this round-trips (pinned by
+    ``test_multiword_cog_names_convert_to_snake_case`` and the
+    registered-subsystem round-trip identity test).  Returns ``None``
+    when the resulting key is not a registered subsystem.
+    """
     if not cog_name:
         return None
-    normalised = _COG_SUFFIX_RE.sub("", cog_name).lower()
+    stripped = _COG_SUFFIX_RE.sub("", cog_name)
+    snaked = _CAMEL_HEAD_RE.sub(r"\1_\2", stripped)
+    snaked = _CAMEL_TAIL_RE.sub(r"\1_\2", snaked).lower()
     # Function-local: utils.subsystem_registry transitively touches
     # core.runtime, so we keep this import inside the function to
     # match the cycle-sensitive discipline used by other runtime
     # modules.
     from utils.subsystem_registry import SUBSYSTEMS
 
-    return normalised if normalised in SUBSYSTEMS else None
+    return snaked if snaked in SUBSYSTEMS else None
 
 
 def _reset_for_tests() -> None:

--- a/disbot/services/customization_catalogue.py
+++ b/disbot/services/customization_catalogue.py
@@ -86,7 +86,7 @@ KNOWN_PANEL_COMMANDS: tuple[tuple[str, str], ...] = (
     ("moderation", "modmenu"),
     ("proof_channel", "prizemenu"),
     ("role", "rolemenu"),
-    ("servermanagement", "servermanagement"),
+    ("server_management", "servermanagement"),
     ("utility", "utilitymenu"),
     ("xp", "xpmenu"),
 )

--- a/disbot/utils/hub_registry.py
+++ b/disbot/utils/hub_registry.py
@@ -216,7 +216,10 @@ HUBS: tuple[HubEntry, ...] = (
         minimum_tier="administrator",
     ),
     HubEntry(
-        key="servermanagement",
+        # key is the snake_case subsystem key (Q-0026), matching
+        # SUBSYSTEMS["server_management"]; entry_command keeps the
+        # ``!servermanagement`` command name.
+        key="server_management",
         display_name="Server Management",
         emoji="🧭",
         purpose="Moderation, channels, roles, cleanup, and setup in one place.",

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -80,7 +80,12 @@ SUBSYSTEMS: dict[str, dict] = {
             "admin.server.stats",
         ],
     },
-    "servermanagement": {
+    # Key is snake_case (Q-0026): it must equal cog_name_to_subsystem(
+    # "ServerManagementCog") = "server_management".  The ``servermanagement``
+    # *entry_point* below is the prefix command name (``!servermanagement``),
+    # which is a command identifier, not the subsystem key — they differ by
+    # design, exactly like ``economy`` (key) vs ``economymenu`` (command).
+    "server_management": {
         "display_name": "Server Management",
         "description": "Unified hub for moderation, channels, roles, cleanup, setup",
         "emoji": "🧭",

--- a/disbot/views/server_management/hub.py
+++ b/disbot/views/server_management/hub.py
@@ -23,7 +23,7 @@ case (a panel outliving the caller's admin role) and lets the same view back the
 ephemeral ``/server-management`` slash, which has no anchor.
 
 **Restoration.** ``ServerManagementHubView`` is ``@register``-ed with a no-arg
-constructor and static ``servermanagement:*`` custom_ids, so
+constructor and static ``server_management:*`` custom_ids, so
 ``message_anchor_manager.restore_anchors`` re-binds it across restarts for free
 (the prefix command anchors the panel via ``panel_manager.get_or_render_panel``).
 """
@@ -53,7 +53,7 @@ _ROUTED_MANAGERS: dict[str, tuple[str, str]] = {
     "cleanup": ("Cleanup", "Cleanup"),
 }
 
-_BACK_CUSTOM_ID = "servermanagement:back"
+_BACK_CUSTOM_ID = "server_management:back"
 _BACK_LABEL = "↩ Server Management"
 
 
@@ -121,7 +121,7 @@ class ServerManagementHubView(PersistentView):
     docstring. Stateless: every callback recovers context from ``interaction``.
     """
 
-    SUBSYSTEM = "servermanagement"
+    SUBSYSTEM = "server_management"
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction_is_admin(interaction):
@@ -175,7 +175,7 @@ class ServerManagementHubView(PersistentView):
         label="🛡️ Moderation",
         style=discord.ButtonStyle.primary,
         row=0,
-        custom_id="servermanagement:moderation",
+        custom_id="server_management:moderation",
     )
     async def moderation_btn(
         self,
@@ -188,7 +188,7 @@ class ServerManagementHubView(PersistentView):
         label="📺 Channels",
         style=discord.ButtonStyle.primary,
         row=0,
-        custom_id="servermanagement:channels",
+        custom_id="server_management:channels",
     )
     async def channels_btn(
         self,
@@ -201,7 +201,7 @@ class ServerManagementHubView(PersistentView):
         label="🎭 Roles",
         style=discord.ButtonStyle.primary,
         row=0,
-        custom_id="servermanagement:roles",
+        custom_id="server_management:roles",
     )
     async def roles_btn(
         self,
@@ -214,7 +214,7 @@ class ServerManagementHubView(PersistentView):
         label="🧹 Cleanup",
         style=discord.ButtonStyle.secondary,
         row=1,
-        custom_id="servermanagement:cleanup",
+        custom_id="server_management:cleanup",
     )
     async def cleanup_btn(
         self,
@@ -227,7 +227,7 @@ class ServerManagementHubView(PersistentView):
         label="🧩 Setup",
         style=discord.ButtonStyle.success,
         row=1,
-        custom_id="servermanagement:setup",
+        custom_id="server_management:setup",
     )
     async def setup_btn(
         self,
@@ -246,7 +246,7 @@ class ServerManagementHubView(PersistentView):
         label="🔄 Refresh",
         style=discord.ButtonStyle.secondary,
         row=2,
-        custom_id="servermanagement:refresh",
+        custom_id="server_management:refresh",
     )
     async def refresh_btn(
         self,

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -6,9 +6,9 @@
 > live GitHub** before trusting it (two same-session reports already
 > contradicted each other across a single merge).
 >
-> **▶ Next action:** Server-management is structurally complete after merged **#584**. The next source-grounded lane is the [Adaptive Setup, Access, Profile, and Routine Platform](planning/adaptive-setup-access-routine-platform-2026-06-08.md): begin with Phase 0's decided Q-0026 multi-word subsystem identity repair, then an Opus access/read-model contract session before any new mutation surface. Owner decisions Q-0017–Q-0027 are merged via **#585**; Q-0028–Q-0033 route the remaining profile/risk/rollback/UI/privacy choices. The server-management PR13 AI generation layer remains gated by the AI-expansion gate.
+> **▶ Next action:** Phase 0 of the [Adaptive Setup, Access, Profile, and Routine Platform](planning/adaptive-setup-access-routine-platform-2026-06-08.md) is underway. The **Q-0026 multi-word subsystem identity repair is implemented** — `cog_name_to_subsystem` now converts CamelCase → snake_case, the registry key is `server_management`, and the same fix repaired the latent `proof_channel` / `four_twenty` collapse — and the Phase 0 **direct-vs-draft mutation boundary** (`docs/ownership.md` § "Direct vs. draft mutation lanes") and **access read-model contract** (planning doc §4 + §16) are now documented. The next lanes are **P1A** (build the side-effect-free Access Map projection service per the documented contract — no UI, no persistence) and **P0C** (normalize the role-threshold direct-write drift the contract flags). Owner decisions Q-0017–Q-0027 merged via **#585**; Q-0028–Q-0033 hold at their safe defaults. The server-management PR13 AI generation layer remains gated by the AI-expansion gate.
 >
-> **Last updated:** 2026-06-08 · **#584 merged** the first-class Server Management Hub; **#585 merged** Q-0017–Q-0027 for the Adaptive Setup/Access/Routine planning lane. Source and live GitHub state supersede older same-session PR14 wording. This file lists only merged work + the next action; verify open PRs live.
+> **Last updated:** 2026-06-08 · Phase 0 of the Adaptive Setup/Access platform began: the **Q-0026 identity repair is implemented** (snake_case subsystem keys; `servermanagement` → `server_management`) with regression tests, plus the Phase 0 direct-vs-draft and access read-model contracts documented. Earlier the same day **#584 merged** the first-class Server Management Hub and **#585 merged** Q-0017–Q-0027. Source and live GitHub state supersede older wording. This file lists merged work + the next action; verify open PRs live.
 > **Purpose:** the one file that answers "what is true right now?" so a new
 > session does not reconstruct it from the journal + planning docs. Read it
 > **second**, right after `.claude/CLAUDE.md`.
@@ -117,14 +117,11 @@ Source code and merged PRs win over anything written here.
 
 ## Near-term technical debt (decided, not yet implemented)
 
-- **`cog_name_to_subsystem` CamelCase fix (Q-0026).** The function strips "Cog" +
-  lowercases with no CamelCase→snake_case conversion. `servermanagement` is the first
-  multi-word key; the correct output is `server_management`. Fix:
-  (1) update `cog_name_to_subsystem` in `disbot/core/runtime/command_surface_ledger.py`
-  to do a proper CamelCase→snake_case split; (2) rename the `"servermanagement"` key to
-  `"server_management"` everywhere (subsystem_registry, HUBS, KNOWN_PANEL_COMMANDS,
-  any literal references). Run check_architecture + full test suite after rename.
-  Risk: medium — touches identity-contract / diagnostics. **Owner decision Q-0026.**
+- **`cog_name_to_subsystem` CamelCase fix (Q-0026) — IMPLEMENTED 2026-06-08.** The function
+  now converts CamelCase → snake_case and the registry key is `server_management`; the same
+  fix also repaired the latent `proof_channel` / `four_twenty` collapse and added regression
+  tests pinning the snake_case output contract. (Kept here as a one-line record until the next
+  session reconciles the merge into "Recently shipped"; verify the PR live.)
 
 - **`new_subsystem.py` scaffold script (Q-0025).** Adding a hub/subsystem requires
   ~8 coordinated edits with no automation. Decided deliverable: a `new_subsystem.py`

--- a/docs/help-command-surface-map.md
+++ b/docs/help-command-surface-map.md
@@ -43,7 +43,7 @@ Post-PR-#142 routing summary (relevant to every row in §2):
 | `admin` | ⚙️ Admin / Operations | `!adminmenu` | `admin_cog` | `_AdminPanelView` | administrator |
 | `settings` | 🔧 Settings / Configuration | `!settings` | `settings_cog` | `SettingsHubView` | administrator |
 | `diagnostic` | 🩺 Platform / Diagnostics | `!platform` | `diagnostic_cog` | `_PlatformHubView` | administrator |
-| `servermanagement` | 🧭 Server Management | `!servermanagement` | `server_management_cog` | `ServerManagementHubView` (`views/server_management/hub.py`) | administrator |
+| `server_management` | 🧭 Server Management | `!servermanagement` | `server_management_cog` | `ServerManagementHubView` (`views/server_management/hub.py`) | administrator |
 
 ## 2. Subsystem inventory
 
@@ -79,7 +79,7 @@ or raises.
 | `proof_channel` | `proof_channel_cog.py:113` | `prizestatus`, `prizemenu`, `timedprize` | — | `_PrizeManagerView` | `!help proof` → opens Proof Channel panel (shared resolver) | reached via Moderation; `parent_hub="moderation"` since PR #3 | hub child (Moderation) — declared |
 | `role` | `role_cog.py:334` | `roles`, `rolesettings`, `rolemenu` (legacy alias) | 8+ legacy commands: `rolecreator`, `createrole`, `deleterole`, `setrole`, `unsetrole`, `assignroles`, `debugroles`, `refreshmembers`, plus react-role family | `RoleHubPanelView` | `!help roles` → opens Role panel (shared resolver) | reached via Community; `parent_hub="community"` since PR #3 | hub child (Community) — declared; legacy commands remain as hidden compatibility |
 | `rps_tournament` | `rps_tournament_cog.py:118` | `rpsregister`/`rpsreg`, `rpsstart`/`rpsbegin`, `rpsbot`, `rpsmatchup`, `rpshelp`, `rpssettings` | — | `RPSPanelView` | `!help rps` → opens RPS panel (shared resolver) | reached via Games | hub child (Games) |
-| `servermanagement` | `server_management_cog.py` | `servermanagement`, `servermenu`, `guildmenu`, `/server-management` | — | `ServerManagementHubView` | `!help` → Server Management (shared resolver) | dropdown Server Management → panel | hub top-level (operator) — composes moderation/channels/roles/cleanup/setup |
+| `server_management` | `server_management_cog.py` | `servermanagement`, `servermenu`, `guildmenu`, `/server-management` | — | `ServerManagementHubView` | `!help` → Server Management (shared resolver) | dropdown Server Management → panel | hub top-level (operator) — composes moderation/channels/roles/cleanup/setup |
 | `settings` | `settings_cog.py` | (entry via `!settings`) | — | `SettingsHubView` | `!help settings` → opens Settings panel (shared resolver) | dropdown Settings → panel | hub top-level |
 | `utility` | `utility_cog.py` | `utilitymenu`, `clear`/`purge`, `info`, `serverinfo`, `userinfo`, `avatar`, `remind` | — | `_UtilityPanelView` | `!help utility` → opens Utility panel (shared resolver) | dropdown Utility → panel | hub top-level |
 | `xp` | `xp_cog.py` | `xpmenu`, `rank`, `givexp`, `resetxp`, `xpconfig` | — | `_XpHubView` | `!help xp` → opens XP panel (shared resolver) | reached via Community; `parent_hub="community"` since PR #3 | hub child (Community) — declared; admin controls live in panel |

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -1102,6 +1102,11 @@ Implemented this session: SUBSYSTEMS["servermanagement"] + HUBS entry (administr
   KNOWN_PANEL_COMMANDS entry, the hub view/cog/service, and the help/discoverability
   enumerations updated. Live boot: identity-contract clean (STRICT=on), 0 ERROR/CRITICAL.
 Moved/copied on: 2026-06-08 (this session — server-management PR14).
+Superseded note (2026-06-08, Q-0026): the registry key was renamed servermanagement →
+  server_management when cog_name_to_subsystem was fixed to snake_case. The interpretation
+  above (key "follows cog_name_to_subsystem, no underscore") was correct only against the
+  then-buggy collapsing function; the canonical key is now server_management. The
+  !servermanagement command name is unchanged.
 ```
 
 ---
@@ -1532,7 +1537,7 @@ Not yet implemented.
 **Area:** Core runtime / Subsystem registry / Naming convention
 **Type:** Technical debt / Bug fix
 **Priority:** High
-**Status:** Answered in chat (2026-06-08) — **Needs routing**
+**Status:** Answered in chat (2026-06-08) — **Routed / implemented 2026-06-08**
 **Suggested destination after answer:** `disbot/core/runtime/command_surface_ledger.py`
   (function fix) + any doc/comment that describes the subsystem key convention.
 
@@ -1578,7 +1583,14 @@ Run check_architecture.py + full test suite after the rename.
 Destination: implementation task — disbot/core/runtime/command_surface_ledger.py +
   utils/subsystem_registry.py rename.
 Captured: 2026-06-08 (repo friction audit session).
-Not yet implemented — treat as a near-term technical debt fix.
+Implemented 2026-06-08 (Adaptive Setup Phase 0 / P0A): cog_name_to_subsystem now does a
+  two-pass CamelCase → snake_case conversion; the SUBSYSTEMS / HUBS / KNOWN_PANEL_COMMANDS /
+  PersistentView.SUBSYSTEM / panel-anchor key for the hub were renamed servermanagement →
+  server_management; the same fix repaired the pre-existing collapse of ProofChannelCog →
+  proof_channel and FourTwentyCog → four_twenty (both registry keys were already snake_case
+  and had been silently orphaning). The user-facing !servermanagement command + aliases +
+  /server-management slash are unchanged (command names, not subsystem keys). Regression
+  tests pin the snake_case output contract so a future multi-word subsystem cannot regress.
 ```
 
 ---

--- a/docs/ownership.md
+++ b/docs/ownership.md
@@ -308,6 +308,56 @@ Every audited mutation goes through this contract:
 
 ---
 
+## Direct vs. draft mutation lanes (binding)
+
+There are **two** sanctioned write lanes plus a read lane. A mutation lands in
+exactly one; the choice is determined by the *shape* of the change, not by which
+panel the operator happens to be in. This is the canonical rule behind the
+per-surface map in
+[`docs/planning/adaptive-setup-access-routine-platform-2026-06-08.md` §5](planning/adaptive-setup-access-routine-platform-2026-06-08.md)
+— that table is the inventory; this is the rule.
+
+| Lane | When to use it | How it writes | Examples |
+|---|---|---|---|
+| **Direct (focused/runtime)** | A single-domain, reversible, operator-initiated action whose effect the operator can see and undo immediately. | Through the domain's **canonical audited service / mutation pipeline** (the "Mutation semantics" contract above) — synchronously, no staging. | A moderation action (`ModerationService`); one typed setting edit (`SettingsMutationPipeline`); a command-access policy write (`command_access_service`); a role exemption (`role_exemption_service`); a cleanup-policy change; a confirmed channel/role lifecycle op (`ChannelLifecycleService` / `RoleLifecycleService`). |
+| **Draft → Final Review (compound/config)** | A compound, multi-setting, cross-subsystem, generated, or higher-risk configuration change — anything where the operator should preview the whole set and an authority recheck must happen at apply time. | Staged as `SetupOperation` rows via `setup_draft`, applied **only** through `views/setup/final_review.py` (authority recheck → ordered apply → partial recovery → audit). | Setup wizard sections; cog-routing profiles; (future) Guild Feature Profile apply; (future) Access Map edits; (future) medium/high-risk routine config actions. |
+| **Read-only (projection)** | Answering "what is true / who can see what / what is unhealthy" without changing anything. | No writes. Composes existing owners' read models. | `setup_diagnostics`; server-management health badges; the (future) Access Map projection; Help Preview. |
+
+**Hard rules:**
+
+1. **Compound config never takes the direct lane.** If a change spans more than one
+   setting/resource, crosses subsystems, is machine-generated (profile / routine /
+   AI), or is classified medium/high risk, it **must** stage `SetupOperation` rows
+   and apply through Final Review. New op kinds require the dispatcher + DB gate +
+   SQL `CHECK` parity (see `services/setup_operations.py`).
+2. **Direct edits stay focused and reversible.** A direct-lane writer touches one
+   domain through its canonical service and emits its audit row in the same
+   transaction. It never writes another domain's tables (use that domain's service)
+   and never stages a draft on the operator's behalf for a change they did not
+   preview.
+3. **Projections never mutate.** A read model / drift provider / badge computes from
+   existing owners; if it finds something to fix, it returns a *repair proposal*
+   that the operator stages as a draft (the `setup_diagnostics` pattern) — it does
+   not write.
+4. **Prohibited paths (enforced by review + negative tests):** a compiler, routine,
+   or AI adapter must **never** call a view callback or a Discord resource API
+   directly, and must **never** call a canonical mutation service except via the
+   draft/Final-Review or (low-risk only) approved-action seam. They emit
+   `SetupOperation` drafts or dispatch through the canonical executor — never a
+   side-channel write. Cogs/views never write DB directly (the
+   "Direct DB writes — explicit blocklist" above).
+
+**Known drift to normalize before automation (selected for the P0C batch):** role
+**threshold** writes currently take a *direct DB write* path from the role panel
+rather than routing through an audited role-automation service seam, and several
+channel create/edit paths mix direct Discord calls with the lifecycle service.
+These must converge on a canonical audited writer **before** any profile/routine is
+allowed to drive role thresholds or channel lifecycle — otherwise the draft lane
+would have no single seam to compile into. Until then, profiles/routines must not
+target those axes.
+
+---
+
 ## Audit-log semantics
 
 Three audit tables exist, all append-only:

--- a/docs/planning/adaptive-setup-access-routine-platform-2026-06-08.md
+++ b/docs/planning/adaptive-setup-access-routine-platform-2026-06-08.md
@@ -1,6 +1,6 @@
 # Adaptive Setup, Access, Profile, and Routine Platform — source map and roadmap
 
-> **Status:** `plan` · **Not implemented** · **Source-verified 2026-06-08**
+> **Status:** `plan` · **Phase 0 in progress** — P0A (Q-0026 identity repair) implemented and P0B (direct-vs-draft + access read-model contracts) documented on 2026-06-08; Phases 1+ not implemented · **Source-verified 2026-06-08**
 > **Owner decisions:** applies [Q-0017 through Q-0027](../owner/maintainer-question-router.md#q-0017--adaptive-setupaccessroutine-platform-planning-document-structure-2026-06-08).
 > **Authority:** source + binding architecture/ownership/runtime contracts win over this plan. This is the one comprehensive planning home required by Q-0017.
 > **Live-repo check:** PRs [#584](https://github.com/menno420/superbot/pull/584) and [#585](https://github.com/menno420/superbot/pull/585) are merged; the GitHub API reported no open PRs during this source-mapping session.
@@ -60,8 +60,8 @@ SuperBot already has most of the required write seams and several read seams: se
 | `disbot/core/runtime/command_access.py` + `services/command_access_service.py` | Resolves guild channel-access mode, bootstrap/operator exceptions, decision reason/source; canonical audited writer. | Access Map command-access axis and locked reason seed. | Current model is command-entry channel admission, not full capability/time availability. |
 | `disbot/services/command_routing.py` + `cog_routing_profiles.py` | Resolves channel → category → guild → default-true cog routing; existing routing profiles compile to setup operations. | Access Map routing axis and Feature Profile compiler building blocks. | Routing profiles are channel-name heuristics for three cogs, not full Guild Feature Profiles. |
 | `disbot/governance/` (`resolve_visibility`, capability resolvers, snapshots) | Canonical subsystem visibility and capability/authority decisions. | Access Map role/capability/help visibility axes. | Must compose, not duplicate; legacy `governance_service` is only a re-export shim. |
-| `disbot/core/runtime/command_surface_ledger.py` | Runtime command/subsystem identity, classification, help-hidden policy, diagnostics. | Feature inventory, help/access consistency checks. | Q-0026: `cog_name_to_subsystem` drops `Cog` then lowercases; multi-word names become collapsed keys. |
-| `disbot/utils/subsystem_registry.py` | `SUBSYSTEMS`, `HUBS`, visibility/capability/entry-point metadata and identity validation. | Profile catalogue vocabulary and Access Map feature index. | Registry metadata describes identity/discovery, not per-guild desired enablement. Current key is `servermanagement`. |
+| `disbot/core/runtime/command_surface_ledger.py` | Runtime command/subsystem identity, classification, help-hidden policy, diagnostics. | Feature inventory, help/access consistency checks. | **Q-0026 resolved 2026-06-08:** `cog_name_to_subsystem` now CamelCase → snake_cases (also repaired the latent `proof_channel`/`four_twenty` collapse). |
+| `disbot/utils/subsystem_registry.py` | `SUBSYSTEMS`, `HUBS`, visibility/capability/entry-point metadata and identity validation. | Profile catalogue vocabulary and Access Map feature index. | Registry metadata describes identity/discovery, not per-guild desired enablement. Key is now `server_management` (snake_cased per Q-0026). |
 | `disbot/cogs/help_cog.py`, `cogs/help/route.py`, help views | Governance-aware live help, registry/category routes, command classification filtering. | Help Preview must invoke the same visibility and render paths with an explicit audience context. | No single composed help+command-access+routing+availability explanation object today. |
 | `disbot/services/setup_diagnostics.py` | Read-only setup findings; suggested repairs are setup operations, never direct writes. | Setup health/drift detector core. | Needs access/help/routing/routine/identity consistency providers. |
 | `disbot/services/server_management_hub.py` + `views/server_management/hub.py` | Read-only badges and handoffs to moderation/channels/roles/cleanup/setup managers. | Owner landing point for Access Map, health, Help Preview. | It deliberately owns no mutation and should stay that way. |
@@ -106,7 +106,7 @@ The projection should return decisions with source, precedence, allow/deny/unkno
 
 ### 4.2 Required prerequisites
 
-1. **Q-0026 identity fix first:** implement CamelCase → snake_case and rename `servermanagement` to `server_management`, with identity-contract, help, hub, router-prefix, and migration/reference verification. Do not build profile identifiers on collapsed multi-word keys.
+1. **Q-0026 identity fix — DONE (2026-06-08).** `cog_name_to_subsystem` now does a two-pass CamelCase → snake_case conversion and the registry key is `server_management`; the same fix repaired the latent `ProofChannelCog → proof_channel` / `FourTwentyCog → four_twenty` collapse, and regression tests pin the snake_case output contract. The user-facing `!servermanagement` command name is unchanged (command names are not subsystem keys). Profile identifiers may now safely assume snake_case multi-word keys.
 2. **Pin the mutation boundary:** profiles, Access Map editing, and risky routines compile to setup drafts; Final Review applies. Focused manager/runtime actions may remain direct through their canonical audited services.
 3. **Build the composed read model before UI/editing:** Access Map, Help Preview, denial explanations, and drift checks must consume one resolver.
 4. **Normalize high-risk drift before automating it:** especially direct role-threshold DB writes and direct channel creation/edit paths.
@@ -232,11 +232,11 @@ Behind existing AI expansion/readiness gates, AI may suggest profiles/routines, 
 
 ### Phase 0 — foundation and reconciliation
 
-- Implement Q-0026 identity fix/rename in a separate technical-debt session.
-- Turn this panel consistency map into explicit canonical direct-vs-draft rules.
-- Specify structured access decision, locked reason, simulated audience, and drift-provider interfaces.
-- Normalize/audit role-threshold writes and assess channel lifecycle gaps before routine action exposure.
-- Confirm first Guild Feature Profile catalogue and risk/snapshot owner decisions.
+- ✅ **Implement Q-0026 identity fix/rename** (2026-06-08) — `cog_name_to_subsystem` snake_cases; key `server_management`; latent `proof_channel`/`four_twenty` collapse also fixed; regression tests added (P0A).
+- ✅ **Turn this panel consistency map into explicit canonical direct-vs-draft rules** (2026-06-08) — now binding in [`docs/ownership.md` § "Direct vs. draft mutation lanes"](../ownership.md) (P0B).
+- ✅ **Specify structured access decision, locked reason, simulated audience, and drift-provider interfaces** (2026-06-08) — see §16 below (P0B). Reuses the existing `command_access` decision/reason model rather than forking it.
+- ⏳ **Normalize/audit role-threshold writes and assess channel lifecycle gaps** before routine action exposure — selected and scoped for the **P0C** batch (see §16.5 and the drift note in `docs/ownership.md`); not yet implemented.
+- ⏳ Confirm first Guild Feature Profile catalogue and risk/snapshot owner decisions (Q-0028 / Q-0030 / Q-0031 — open; safe defaults hold, no committed catalogue built).
 - No product expansion or new mutation surface.
 
 ### Phase 1 — read-only orchestration foundation
@@ -284,8 +284,8 @@ Behind existing AI expansion/readiness gates, AI may suggest profiles/routines, 
 
 | Batch / target agent | Goal and scope | Likely files | Out of scope | Verification | Risk / stop conditions |
 |---|---|---|---|---|---|
-| **P0A — Codex/Sonnet:** Q-0026 identity repair | Snake-case conversion, `server_management` rename, references/tests/docs. | `command_surface_ledger.py`, `subsystem_registry.py`, help/router/hub tests/docs | Product features | Full quality + strict architecture + live identity check | Medium; stop if key migration affects persisted external contracts unexpectedly. |
-| **P0B — Opus:** access/read-model contract | Finalize precedence, decision/reason schema, audience simulation, owners, invalidation. | Planning/ADR/ownership/runtime docs | Runtime code | Docs/architecture checks | High architecture; stop on unresolved second-permission-system risk. |
+| **P0A — Codex/Sonnet:** Q-0026 identity repair | ✅ **DONE 2026-06-08.** Snake-case conversion, `server_management` rename, references/tests/docs. | `command_surface_ledger.py`, `subsystem_registry.py`, help/router/hub tests/docs | Product features | Full quality + strict architecture + live identity check | Medium; stop if key migration affects persisted external contracts unexpectedly. |
+| **P0B — Opus:** access/read-model contract | ✅ **DONE 2026-06-08** (docs). Precedence, decision/reason schema (reuses `command_access`), audience simulation, owners, invalidation, direct-vs-draft rule — §16 + `docs/ownership.md`. | Planning/ADR/ownership/runtime docs | Runtime code | Docs/architecture checks | High architecture; stop on unresolved second-permission-system risk. |
 | **P0C — Sonnet:** panel writer normalization | Centralize role threshold writer/audit; bounded channel lifecycle gaps selected by Opus. | role/channel services/views/tests | New automation actions | Focused unit/view tests + full quality | Medium/high; stop before behavior-changing destructive flow without owner decision. |
 | **P1A — Sonnet:** Access Map projection | Side-effect-free composed service + tests, no UI. | new service module; governance/access/routing/ledger adapters; tests | Editing/persistence | Unit/service/identity tests + strict architecture | High; stop if owner of any axis cannot be identified. |
 | **P1B — Sonnet:** drift + locked reasons | Diagnostic providers and denial explanation integration. | `setup_diagnostics.py`, command-access/interaction helpers, tests | Editing | Diagnostics/access tests + quality | Medium; stop if explanation leaks sensitive policy. |
@@ -371,7 +371,147 @@ Safe defaults until answered: profile preview only; quiet mode modeled as availa
 
 ## 15. Recommended next destination
 
-1. **First technical debt:** Sonnet/Codex implements Q-0026 (`cog_name_to_subsystem` snake_case + `server_management` rename), then the separately decided `scripts/new_subsystem.py` can safely assume canonical multi-word keys.
-2. **Next Opus planning session:** finalize the Phase 0 access/read-model contract, including precedence, reason schema, drift provider ownership, simulation limits, and direct-vs-draft mutation rule. Resolve Q-0028–Q-0032 as needed.
-3. **First Sonnet product implementation after approval:** the side-effect-free Access Map projection service and tests, followed by drift/locked-reason providers; no UI editing.
+1. ✅ **First technical debt — DONE (2026-06-08):** Q-0026 implemented (`cog_name_to_subsystem` snake_case + `server_management` rename + the latent `proof_channel`/`four_twenty` repair). The decided `scripts/new_subsystem.py` (Q-0025) can now safely assume canonical snake_case multi-word keys.
+2. ✅ **Phase 0 access/read-model contract — DOCUMENTED (2026-06-08):** precedence, reason schema (reusing the `command_access` decision model — no second permission system), drift-provider ownership, simulation limits, and the direct-vs-draft rule are in §16 below + [`docs/ownership.md`](../ownership.md). Q-0028–Q-0032 stay at safe defaults (not blockers for read-only work).
+3. **Next — Sonnet (P1A):** implement the side-effect-free Access Map projection service + tests per §16 (no UI, no persistence), then the drift/locked-reason providers (P1B). **Parallel — Sonnet (P0C):** normalize the role-threshold direct-write drift onto an audited service seam (§16.5) before any profile/routine targets role thresholds.
 4. **Blocked/gated:** controlled profile/access mutation waits for the read model and rollback/risk decisions; Routine Engine waits for condition/safety design; Personal Setup waits for privacy decisions; AI drafts wait for current AI expansion gates.
+
+## 16. Phase 0 access read-model contract (P0B)
+
+> **Status:** contract documented 2026-06-08 (P0B). This section is the spec the
+> **P1A** Access Map projection service is built from. It is *read-only*: it defines
+> how to **compose existing owners**, never a new policy. **Reuse the existing
+> decision/reason vocabulary** (`core.runtime.command_access.DecisionReason` /
+> `DecisionSource`) — do **not** fork a parallel enum. Source types win over this
+> section; verify signatures before coding.
+
+### 16.1 Service family (side-effect-free)
+
+Five read-only collaborators (no god service, no persistence):
+
+1. **Feature inventory adapter** — enumerates features from
+   `utils.subsystem_registry.SUBSYSTEMS` + `core.runtime.command_surface_ledger`
+   (the now-snake_case keys from Q-0026). Yields `(subsystem, command/entry_point,
+   owning cog, visibility_tier)`.
+2. **Access context** — one explicit, fully-specified input record (no implicit
+   globals). Superset of the existing `command_access.CommandAccessContext`
+   (`guild_id`, `channel_id`, `user_id`, `command_name`, `invocation_type`,
+   `is_guild_operator`, `is_bot_owner`, `is_dm`) plus `category_id`,
+   `member_role_ids`, `member_tier`, and an optional `now`/`event_state` for the
+   future availability axis. Building a context performs **no** I/O beyond what the
+   wrapped resolvers already do.
+3. **Projection resolver** — composes the axes below into one structured
+   `AccessDecision` per (feature, context). Pure composition; calls each owner's
+   existing async resolver and records its native decision.
+4. **Explanation renderer** — turns an `AccessDecision` into (a) an Access Map row,
+   (b) a Help Preview annotation, or (c) a user-safe denial string. The renderer is
+   the **only** place a `LockedReason.safe_text` is produced for users.
+5. **Drift providers** — compare two owners' projections and emit read-only findings
+   (§16.5). They never write; repairable findings become `SetupOperation` *proposals*
+   per the `setup_diagnostics` pattern.
+
+The **draft compiler(s)** of §4.1 item 6 are **out of scope** until the projection
+stabilises (Phase 3).
+
+### 16.2 Composition precedence (the axis order)
+
+The projection evaluates axes in this fixed order and **short-circuits on the first
+`deny`/`unavailable`** — matching the order the runtime actually gates so the read
+model can never claim "allow" where the runtime denies (the core
+help-advertises-locked guard). Each axis delegates to its existing owner:
+
+| # | Axis | Owner (existing) | Produces |
+|---|---|---|---|
+| 1 | Hard safety / lifecycle / bootstrap | `command_access.resolve_command_access` (lifecycle-drain, bootstrap-bypass branches) | `deny`(silent) / bypass-`allow` |
+| 2 | Command access (channel admission) | `command_access.resolve_command_access` (`DB_POLICY` / `DEFAULT_UNCONFIGURED`) | `allow` / `deny` + `DecisionReason` |
+| 3 | Cog routing (feature enabled here) | `services.command_routing.is_cog_enabled` | `allow` / `deny` |
+| 4 | Governance visibility + capability/tier | `governance.resolver.resolve_visibility` / `get_visible_subsystems` + capability resolver | `visible+permitted` / `hidden` / `tier-insufficient` |
+| 5 | Availability policy (time/tenure/event) | **future** central resolver (§6.6) — absent today ⇒ axis returns `allow`/`unknown` | `allow` / `deny`(window) |
+| 6 | Help classification (help axis only) | `command_surface_ledger.is_hidden_from_help` | `shown` / `hidden` (does **not** affect execution) |
+| 7 | User preference (Phase 5) | **future** — can hide/sort, **never grant** | re-order / hide only |
+
+Axis 6 is informational for the *help-visibility* column only; it must never turn an
+executable `allow` into a denied execution result. Axis 7 is Phase 5 and likewise
+cannot elevate.
+
+### 16.3 Decision & reason schema
+
+```text
+AccessDecision (frozen):
+    feature:      str            # subsystem key (snake_case) or command name
+    effective:    "allow" | "deny" | "unknown"
+    deciding_axis: AccessAxis    # which numbered axis produced `effective`
+    source:       DecisionSource # REUSE command_access.DecisionSource where the
+                                 # axis is command-access; each other axis maps its
+                                 # native source into a small shared AccessAxisSource
+    reason:       LockedReason | None
+    source_chain: tuple[AxisOutcome, ...]   # every axis evaluated, in order, for "why"
+    remediation:  str | None     # safe pointer to the owning panel/setting, never a write
+
+LockedReason (frozen) — minimum fields (per §6.3):
+    code:        str             # stable id, drawn from the union of DecisionReason
+                                 # values + {routing_disabled, capability_insufficient,
+                                 # subsystem_hidden, availability_window, quiet_mode,
+                                 # setup_stage_required}
+    safe_text:   str             # user-renderable; NEVER leaks role names / channel ids /
+                                 # policy internals
+    source:      str             # command_access | routing | governance | availability |
+                                 # bootstrap | help
+    unlock_hint: str | None      # only when safe to show (e.g. "unlocks after 24h")
+```
+
+Reason `code`s reuse `command_access.DecisionReason` verbatim for axes 1–2
+(`allowed`, `bootstrap_bypass`, `lifecycle_draining`, `dm_not_supported`,
+`channel_not_allowed`, `commands_disabled`); axes 3–5 add the small stable set listed
+above. **Do not invent per-feature codes.**
+
+### 16.4 Simulation limits (Help Preview)
+
+Help Preview (staff/admin only — Q-0023) supplies a **simulated** audience context
+(member tier + role set) to the *same* axes. It must label that it cannot model
+live Discord channel-permission overrides it has not been given, must never imply a
+permission it cannot accurately resolve, and renders axis-6 (`hidden`) honestly
+("shown as locked, with reason"). Normal users get no simulator — only the live
+axis-1→5 denial string from the renderer.
+
+### 16.5 Drift providers and the P0C drift selection
+
+Phase 0/1 drift providers (read-only findings; extend `setup_diagnostics`):
+
+- **`identity_mismatch`** — a subsystem key disagrees across registry / ledger / hub /
+  view / anchor surfaces (the Q-0026 *class* of bug; now guarded by the
+  command-surface-ledger identity tests).
+- **`help_advertises_locked`** — help shows a command the projection says is `deny`
+  for the baseline audience (and not deliberately shown-as-locked).
+- **`routing_access_conflict`** — cog routing enables a cog whose commands command-
+  access denies in every channel (or vice-versa).
+- **`configured_resource_missing`** — a bound channel/role referenced by config no
+  longer exists.
+
+**P0C drift selected for normalization (the answer to §4.2 item 4):** the
+**role-threshold writer**. The role panel writes time/XP thresholds via a *direct DB
+write* rather than an audited role-automation service seam, so there is no single
+canonical seam for a future profile/routine draft to compile into. P0C must route
+those writes through an audited `role_automation` mutation (mirroring
+`set_{time,xp}_threshold`) **before** any profile/routine targets role thresholds.
+Channel create/edit lifecycle is the secondary, larger gap (mixed direct-Discord +
+`ChannelLifecycleService`); assess but do not rewrite wholesale in P0C. See the
+binding rule + drift note in [`docs/ownership.md` § "Direct vs. draft mutation lanes"](../ownership.md).
+
+### 16.6 Invalidation / caching
+
+Compute on demand; **do not persist** the projection (a read model is not a source of
+truth — see §10 and §11). Cache **only** with an explicit invalidation owner: the
+projection cache (if any) must be invalidated on a `command_access_service` write, a
+routing write, a governance/capability write, a settings write, and process restart
+(registry change). Absent an explicit owner for every one of those, do not cache.
+
+### 16.7 Negative-architecture guardrails (P1A tests must assert)
+
+- The projection module performs **no** writes and imports **no** mutation service or
+  Discord resource API (AST/negative test).
+- It defines **no** new permission/visibility *policy* — every `allow`/`deny` traces
+  to an existing owner in the §16.2 table (the source_chain makes this auditable).
+- `LockedReason.safe_text` never contains a role name, channel id, or raw policy field
+  (redaction test over a fixture with sensitive values).
+- Help-visibility (axis 6) can never flip an execution `allow` to a denied result.

--- a/docs/setup-platform/settings-customization-command-map.md
+++ b/docs/setup-platform/settings-customization-command-map.md
@@ -1430,7 +1430,7 @@ Subsystems (22): `admin`, `moderation`, `economy`, `inventory`, `mining`,
     (binding-select) + S7c (provisioning preview/confirm) + S7d
     (panel + Help / Admin integration).
 
-### servermanagement
+### server_management
 
 The unified Server Management mother hub (PR14). A **routing-only** operator
 surface: it composes the moderation / channels / roles / cleanup / setup
@@ -1438,11 +1438,12 @@ managers behind read-only health badges and owns **no** settings, bindings,
 resources, or mutations of its own.
 
 1. **cog_module**: `disbot/cogs/server_management_cog.py`.
-2. **subsystem**: `servermanagement`.
+2. **subsystem**: `server_management` (snake_case key per Q-0026; the
+   `!servermanagement` command keeps its name).
 3. **current_commands**: `!servermanagement` (aliases `!servermenu`,
    `!guildmenu`), `/server-management`.
 4. **current_command_groups**: none.
-5. **current_command_panel_or_menu**: `servermanagement` →
+5. **current_command_panel_or_menu**: `server_management` (panel-anchor key) →
    `views/server_management/hub.py:ServerManagementHubView`.
 6. **help_menu_discoverable**: Yes (mother hub, administrator tier).
 7. **dedicated_panel_command**: `none`.

--- a/docs/subsystems/server-management.md
+++ b/docs/subsystems/server-management.md
@@ -71,10 +71,13 @@ cleanup policy, setup, and the future unified hub. Inspect first:
   `KNOWN_PANEL_COMMANDS` entry, (4) a `build_help_menu_view` hook on the cog, (5)
   help-surface-map §1+§2 rows, (6) a command-map `### <subsystem>` section, and (7) the hub-set
   / help-category / discoverability **enumeration tests**. **Gotcha:** the registry **key must
-  equal `cog_name_to_subsystem(YourCog)`** — it strips `Cog` + lowercases with **no** underscore
-  (so `ServerManagementCog` ⇒ `servermanagement`), and that same string must be the view's
+  equal `cog_name_to_subsystem(YourCog)`** — it strips `Cog` then converts CamelCase → snake_case
+  (Q-0026), so `ServerManagementCog` ⇒ `server_management` and `ProofChannelCog` ⇒ `proof_channel`
+  (an all-caps acronym run stays collapsed: `BTD6Cog` ⇒ `btd6`). That same key must be the view's
   `SUBSYSTEM` classvar **and** the `panel_manager.get_or_render_panel` anchor string, or the
   identity-contract (view), command-surface-ledger (orphan-cog), and db-anchor findings all fire.
+  (The `!servermanagement` *command* name is separate from the `server_management` *key* — the
+  command keeps its spelling, exactly like `economy` (key) vs `economymenu` (command).)
   A registered `PersistentView` whose `SUBSYSTEM` is not in `SUBSYSTEMS` is an `auto_healable`
   orphan the platform self-heal would unregister. Working exemplar:
   `views/server_management/hub.py` + `cogs/server_management_cog.py` (PR14).
@@ -129,7 +132,7 @@ cleanup policy, setup, and the future unified hub. Inspect first:
   migration 059 + a drift-guard test close it). **The unified Server Management Hub (PR14) was
   built 2026-06-08** — a persistent `!servermanagement` + ephemeral `/server-management`
   composing the managers behind read-only health badges, registered **first-class** as the
-  `servermanagement` subsystem + hub (owner decision Q-0016) via
+  `server_management` subsystem + hub (owner decision Q-0016; key snake_cased per Q-0026) via
   `services/server_management_hub.py` + `views/server_management/hub.py` +
   `cogs/server_management_cog.py`. The tracker's only remaining server-management item is the
   **gated PR13 AI template layer**.
@@ -154,8 +157,8 @@ decision Q-0008; governance section deferred). **PR12 (setup diagnostics & repai
 built 2026-06-07** (read-only `setup_diagnostics` service + a Diagnose & repair section;
 `clear_binding` is the one safe auto-repair, everything else advisory/blocked). **PR13's
 deterministic role-templates slice shipped 2026-06-08, and PR14 (the unified Server Management
-Hub) was built 2026-06-08** (registered first-class as the `servermanagement` subsystem + hub,
-owner decision Q-0016). The only remaining item is the gated PR13 AI generation layer. Link to
+Hub) was built 2026-06-08** (registered first-class as the `server_management` subsystem + hub,
+owner decision Q-0016; key snake_cased per Q-0026). The only remaining item is the gated PR13 AI generation layer. Link to
 the tracker for exact order and dependencies rather than copying them here.
 
 ## Ideas (not approved)
@@ -181,7 +184,7 @@ reusable so a web companion is *possible* later, but do not start web work now.
    `role_feasibility` / `cleanup_diagnostics`; `clear_binding` the lone safe auto-repair,
    staged through Final Review). **PR13's deterministic role-templates slice shipped 2026-06-08**
    (`setup_role_templates` + `create_managed_role` + Role-templates section), and **PR14 (the
-   unified Server Management Hub) was built 2026-06-08** (first-class `servermanagement`
+   unified Server Management Hub) was built 2026-06-08** (first-class `server_management`
    subsystem + hub, Q-0016 — composes the managers behind read-only badges, no new mutation
    path). The lane's only remaining item is the **gated PR13 AI generation follow-up**. Reuse
    provisioning previews/confirmation + capability checks; never add a second resource-creation

--- a/docs/subsystems/settings-bindings-provisioning.md
+++ b/docs/subsystems/settings-bindings-provisioning.md
@@ -26,6 +26,11 @@ resource-pointer **bindings**, and confirmed **resource provisioning**. Start in
 - Use `docs/health/platform-consistency-ledger.md` before adding another surface or write
   path. Ownership and allowed write paths remain in `docs/ownership.md` and
   `docs/runtime_contracts.md`.
+- **Direct vs. draft lane choice** is canonical in `docs/ownership.md` §
+  "Direct vs. draft mutation lanes": focused/reversible single-domain edits write
+  directly through their audited service; compound/multi-setting/generated changes
+  stage `SetupOperation` rows and apply through Final Review. Pick the lane by the
+  *shape* of the change, not the panel you're in.
 
 ## Current state
 

--- a/tests/unit/help/test_help_category_view.py
+++ b/tests/unit/help/test_help_category_view.py
@@ -133,7 +133,7 @@ def test_view_has_one_select_with_visible_hubs_plus_all_commands():
         "admin",
         "settings",
         "diagnostic",
-        "servermanagement",
+        "server_management",
         ALL_COMMANDS_KEY,
     }
 

--- a/tests/unit/runtime/test_command_surface_ledger.py
+++ b/tests/unit/runtime/test_command_surface_ledger.py
@@ -52,6 +52,47 @@ def test_cog_name_handles_no_cog_suffix():
     assert cog_name_to_subsystem("Economy") == "economy"
 
 
+def test_multiword_cog_names_convert_to_snake_case():
+    """Q-0026: a multi-word cog class resolves to its snake_case key.
+
+    Before the fix these collapsed to ``servermanagement`` /
+    ``proofchannel`` / ``fourtwenty``; the latter two silently failed to
+    match their already-snake_case registry keys (``proof_channel`` /
+    ``four_twenty``), so their commands were orphaned in the ledger.
+    """
+    assert cog_name_to_subsystem("ServerManagementCog") == "server_management"
+    assert cog_name_to_subsystem("ProofChannelCog") == "proof_channel"
+    assert cog_name_to_subsystem("FourTwentyCog") == "four_twenty"
+
+
+def test_acronym_cog_names_stay_collapsed():
+    """Acronym runs are a single token — no spurious underscore."""
+    assert cog_name_to_subsystem("BTD6Cog") == "btd6"
+    assert cog_name_to_subsystem("AICog") == "ai"
+
+
+def test_snake_case_is_the_output_contract():
+    """The conversion output is snake_case regardless of registration.
+
+    A future ``FooBarBazCog`` must register ``foo_bar_baz`` (not the
+    collapsed ``foobarbaz``) to resolve.  Pinned against a synthetic
+    registry so the contract is documented independently of today's
+    keys — this is the regression guard for new multi-word subsystems.
+    """
+    with patch(
+        "utils.subsystem_registry.SUBSYSTEMS",
+        {"foo_bar_baz": {"visibility_tier": "user"}},
+    ):
+        assert cog_name_to_subsystem("FooBarBazCog") == "foo_bar_baz"
+    # With only the collapsed key registered, the cog no longer resolves —
+    # which is exactly the orphan trap Q-0026 removed.
+    with patch(
+        "utils.subsystem_registry.SUBSYSTEMS",
+        {"foobarbaz": {"visibility_tier": "user"}},
+    ):
+        assert cog_name_to_subsystem("FooBarBazCog") is None
+
+
 # ---------------------------------------------------------------------------
 # Builder
 # ---------------------------------------------------------------------------
@@ -121,6 +162,20 @@ def test_build_ledger_marks_subsystem_none_for_orphan_cog():
     assert ledger.entries[0].subsystem is None
     assert ledger.entries[0].visibility_tier is None
     assert "BogusCog" in ledger.findings.orphan_cog_subsystems
+
+
+def test_build_ledger_resolves_multiword_subsystem_cog():
+    """Q-0026 regression guard (end-to-end): a multi-word cog's command
+    is attributed to its snake_case subsystem and is NOT reported as an
+    orphan.  ``ServerManagementCog`` previously collapsed to
+    ``servermanagement``; the registry key is now ``server_management``.
+    """
+    bot = _make_bot(
+        _make_cmd("servermanagement", cog_name="ServerManagementCog"),
+    )
+    ledger = build_ledger(bot)
+    assert ledger.entries[0].subsystem == "server_management"
+    assert "ServerManagementCog" not in ledger.findings.orphan_cog_subsystems
 
 
 def test_build_ledger_visibility_tier_from_subsystems():

--- a/tests/unit/utils/test_hub_registry.py
+++ b/tests/unit/utils/test_hub_registry.py
@@ -64,7 +64,7 @@ def test_committed_hub_set_matches_promoted_hubs():
         "admin",
         "settings",
         "diagnostic",
-        "servermanagement",
+        "server_management",
     }
 
 
@@ -278,7 +278,7 @@ def test_hubs_for_tier_administrator_sees_all():
         "admin",
         "settings",
         "diagnostic",
-        "servermanagement",
+        "server_management",
     }
 
 
@@ -294,7 +294,7 @@ def test_hubs_for_tier_owner_sees_all():
         "admin",
         "settings",
         "diagnostic",
-        "servermanagement",
+        "server_management",
     }
 
 

--- a/tests/unit/views/test_server_management_hub_view.py
+++ b/tests/unit/views/test_server_management_hub_view.py
@@ -33,12 +33,12 @@ from views.server_management.hub import (
 )
 
 _BUTTON_IDS = {
-    "servermanagement:moderation",
-    "servermanagement:channels",
-    "servermanagement:roles",
-    "servermanagement:cleanup",
-    "servermanagement:setup",
-    "servermanagement:refresh",
+    "server_management:moderation",
+    "server_management:channels",
+    "server_management:roles",
+    "server_management:cleanup",
+    "server_management:setup",
+    "server_management:refresh",
 }
 
 
@@ -79,8 +79,8 @@ def _status() -> HubStatus:
 
 
 def test_view_is_registered_for_restoration():
-    assert get_view_class("servermanagement") is ServerManagementHubView
-    assert ServerManagementHubView.SUBSYSTEM == "servermanagement"
+    assert get_view_class("server_management") is ServerManagementHubView
+    assert ServerManagementHubView.SUBSYSTEM == "server_management"
 
 
 def test_view_subsystem_is_registered_first_class():
@@ -186,7 +186,7 @@ async def test_open_manager_routes_and_attaches_back_button():
         c
         for c in child_view.children
         if isinstance(c, discord.ui.Button)
-        and c.custom_id == "servermanagement:back"
+        and c.custom_id == "server_management:back"
     ]
     assert len(back) == 1
 
@@ -234,10 +234,10 @@ async def test_open_manager_hook_failure_sends_ephemeral_not_crash():
 @pytest.mark.asyncio
 async def test_manager_buttons_delegate_to_open_manager():
     expected = {
-        "servermanagement:moderation": "moderation",
-        "servermanagement:channels": "channels",
-        "servermanagement:roles": "roles",
-        "servermanagement:cleanup": "cleanup",
+        "server_management:moderation": "moderation",
+        "server_management:channels": "channels",
+        "server_management:roles": "roles",
+        "server_management:cleanup": "cleanup",
     }
     for custom_id, key in expected.items():
         view = ServerManagementHubView()
@@ -257,7 +257,7 @@ async def test_setup_button_opens_wizard_entry():
         "cogs.setup._wizard_entry.open_wizard_from_slash",
         new=AsyncMock(),
     ) as mock_open:
-        await _button(view, "servermanagement:setup").callback(interaction)
+        await _button(view, "server_management:setup").callback(interaction)
     mock_open.assert_awaited_once_with(interaction)
 
 
@@ -275,7 +275,7 @@ async def test_refresh_recomposes_in_place():
     ), patch.object(
         hub_mod, "safe_defer", new=AsyncMock(return_value=True)
     ), patch.object(hub_mod, "safe_edit", new=AsyncMock()) as mock_edit:
-        await _button(view, "servermanagement:refresh").callback(interaction)
+        await _button(view, "server_management:refresh").callback(interaction)
     mock_edit.assert_awaited_once()
     _args, kwargs = mock_edit.call_args
     assert kwargs["view"] is view
@@ -285,7 +285,7 @@ async def test_refresh_recomposes_in_place():
 async def test_refresh_outside_guild_sends_ephemeral():
     view = ServerManagementHubView()
     interaction = _interaction(guild=False)
-    await _button(view, "servermanagement:refresh").callback(interaction)
+    await _button(view, "server_management:refresh").callback(interaction)
     interaction.response.send_message.assert_awaited_once()
 
 


### PR DESCRIPTION
## Summary

Advances **Phase 0** of the [Adaptive Setup/Access/Routine platform](https://github.com/menno420/superbot/blob/claude/compassionate-feynman-x9hlb/docs/planning/adaptive-setup-access-routine-platform-2026-06-08.md) from planning into safe foundations. Following the plan's own batch sequencing (P0A → P0B → P1A), this PR delivers **P0A in code+tests** and **P0B in docs**, and leaves the Access Map *projection service* to P1A with a precise route.

### Q-0026 identity repair (P0A) — code + tests
- `cog_name_to_subsystem` now does a two-pass **CamelCase → snake_case** conversion so multi-word cog classes resolve to multi-word keys (acronym runs stay collapsed: `BTD6Cog`→`btd6`, `AICog`→`ai`).
- Renamed the subsystem **identity key** `servermanagement` → `server_management` across the identity surfaces only: `SUBSYSTEMS`, `HUBS`, `KNOWN_PANEL_COMMANDS`, the `PersistentView.SUBSYSTEM` classvar, the hub custom_ids (`server_management:*`), and the `panel_manager.get_or_render_panel` anchor key.
- The user-facing **`!servermanagement` command + aliases + `/server-management` slash + `entry_points`** are *command names*, not subsystem keys, and are left unchanged (exactly like `economy` key vs `economymenu` command).
- **Bonus root-cause fix:** the same conversion repaired a *latent* collapse — `ProofChannelCog`→`proof_channel` and `FourTwentyCog`→`four_twenty` were already snake_case registry keys but the old function had been silently orphaning them (returning `None`). They now resolve; ledger/catalogue findings only shrink.
- Added regression tests pinning the snake_case **output contract** so a future multi-word subsystem cannot regress.

### Phase 0 contracts (P0B) — docs
- **Direct-vs-draft mutation boundary** → binding rule in `docs/ownership.md` § "Direct vs. draft mutation lanes" (elevated from the planning doc's §5 panel map).
- **Access read-model contract** → planning doc **§16**: composition precedence (7-axis order, short-circuit on first deny), decision/`LockedReason` schema that **reuses** `command_access.DecisionReason`/`DecisionSource` (no second permission system), Help Preview simulation limits, drift providers, the **P0C drift selection** (role-threshold direct writes), invalidation, and the negative-architecture guardrails P1A's tests must assert.

## Test plan

| Command | Result |
|---|---|
| `python3.10 scripts/check_quality.py --full` | ✅ **8053 passed, 16 skipped** (black/isort/ruff + mypy + pytest) |
| `python3.10 scripts/check_architecture.py --mode strict` | ✅ exit 0, **0 errors** (pre-existing WARNs only) |
| `python3.10 scripts/check_docs.py` | ✅ all checks passed; top-level docs 16 ≤ ratchet 16 |
| Live boot, `IDENTITY_CONTRACT_STRICT=true` | ✅ 35 cogs loaded; **`Identity-contract: clean (all four surfaces agree). STRICT=on.`**; 303 command descriptions, 0 errored; no Traceback/CRITICAL |
| Identity grep (`"servermanagement"` in `disbot/`) | ✅ only the 3 legitimate command-name usages remain; key is consistently `server_management` |

Targeted suites also run green: `test_command_surface_ledger`, `test_subsystem_registry`, `test_hub_registry`, `test_help_category_view`, `test_server_management_hub_view`, `test_customization_catalogue`, `test_discoverability`, `test_identity_contract_strict`, `test_help_surface_map_doc`, `test_settings_customization_doc`.

## Docs updated
- `docs/ownership.md` — new binding "Direct vs. draft mutation lanes" rule.
- `docs/planning/adaptive-setup-access-routine-platform-2026-06-08.md` — §16 contract; P0A/P0B marked done; Phase 0 checklist, batch plan, and §15 next-destination refreshed.
- `docs/subsystems/server-management.md` — fixed the (now-wrong) "adding a hub" gotcha + current-state key mentions.
- `docs/current-state.md`, `docs/owner/maintainer-question-router.md` (Q-0026 → implemented; Q-0016 forward-note), `docs/help-command-surface-map.md` + `docs/setup-platform/settings-customization-command-map.md` (doc-test-pinned), `docs/subsystems/settings-bindings-provisioning.md` (pointer).
- `.sessions/2026-06-08-adaptive-setup-phase0-q0026-identity.md` (with Context delta).

## Known warnings / deferred
- **One-time panel re-post (test bot only):** after deploy, an already-posted `!servermanagement` hub panel's buttons go dead until the command is re-run — the renamed anchor key no longer resolves the old anchor (the panel re-posts fresh on next invocation). No migration added (over-engineering for a fresh-DB test bot); documented in the session log.
- **Deferred to P0C/P1A:** the role-threshold direct-write normalization and the Access Map projection *service* are scoped (planning §16.5 + §16) but not implemented here.
- Architecture WARNs are all pre-existing (baseview-inheritance / known layer-boundary), untouched by this PR.

## Safe defaults used (Q-0028–Q-0033)
This was read-only/contract work, so the documented safe defaults held without forcing any owner decision: **no committed profile catalogue** (Q-0028); **availability policy owns quiet mode** (Q-0029); **snapshots required for compound/high-risk applies** (Q-0030); **ambiguous config queues Final Review** (Q-0031); **no new command names reserved** — Access Map/Help Preview stay behind staff hubs (Q-0032); **account links deferred** (Q-0033).

## Next (ordered)
1. **P1A** — build the side-effect-free Access Map projection service + tests per planning §16 (no UI, no persistence).
2. **P0C** — route the role panel's direct threshold DB writes through an audited `role_automation` seam (planning §16.5 + ownership.md drift note).
3. **P1B** — drift providers + locked-reason denial integration on top of P1A.

🤖 Session: https://claude.ai/code/session_017qQ4v8r3FLKoAPouQmyj3Y

---
_Generated by [Claude Code](https://claude.ai/code/session_017qQ4v8r3FLKoAPouQmyj3Y)_