### PR TITLE
btd6: extract Geraldo item effects as structured factors

### DIFF
--- a/disbot/data/btd6/geraldo_items.json
+++ b/disbot/data/btd6/geraldo_items.json
@@ -25,7 +25,12 @@
       "max_quantity": 4,
       "rounds_to_replenish": 4,
       "amount_to_replenish": 1,
-      "between_rounds": true
+      "between_rounds": true,
+      "effect": {
+        "damage_increase": 1,
+        "attack_speed_scale": 0.75,
+        "rounds": 5
+      }
     },
     {
       "id": "shooty_turret",
@@ -73,7 +78,10 @@
       "max_quantity": 2,
       "rounds_to_replenish": 10,
       "amount_to_replenish": 1,
-      "between_rounds": true
+      "between_rounds": true,
+      "effect": {
+        "rounds": 5
+      }
     },
     {
       "id": "tube_of_amazo_glue",
@@ -97,7 +105,11 @@
       "max_quantity": 3,
       "rounds_to_replenish": 5,
       "amount_to_replenish": 1,
-      "between_rounds": true
+      "between_rounds": true,
+      "effect": {
+        "pierce_increase": 1,
+        "rounds": 10
+      }
     },
     {
       "id": "worn_heros_cape",
@@ -145,7 +157,11 @@
       "max_quantity": 4,
       "rounds_to_replenish": 3,
       "amount_to_replenish": 1,
-      "between_rounds": true
+      "between_rounds": true,
+      "effect": {
+        "cash_scale": 1.2,
+        "rounds": 4
+      }
     },
     {
       "id": "pet_rabbit",
@@ -169,7 +185,10 @@
       "max_quantity": 2,
       "rounds_to_replenish": 5,
       "amount_to_replenish": 1,
-      "between_rounds": true
+      "between_rounds": true,
+      "effect": {
+        "lives_gained": 50
+      }
     },
     {
       "id": "genie_bottle",

--- a/disbot/services/ai_tools.py
+++ b/disbot/services/ai_tools.py
@@ -1177,10 +1177,13 @@ _BTD6_GERALDO_SPEC = AIToolSpec(
         "BTD6 Geraldo shop item info (Blade Trap, Genie Bottle, Sharpening "
         "Stone, Pet Rabbit, Paragon Power Totem, …): each item's effect, in-game "
         "cash cost, the Geraldo level it unlocks at, and how many he stocks. "
-        "Geraldo (the hero) sells these from his shop. Pass an item name to look "
-        "one up, or omit it to list every item. Use for 'what does Geraldo's "
-        "Blade Trap do', 'how much is the Genie Bottle', 'what level does the "
-        "Paragon Power Totem unlock', 'list Geraldo's items'."
+        "Geraldo (the hero) sells these from his shop. Some items carry a "
+        "structured `effect` with exact numbers (Sharpening Stone +1 pierce for "
+        "10 rounds, Jar of Pickles +1 damage at 0.75x attack speed for 5 rounds, "
+        "Fertilizer +20% farm cash for 4 rounds, Rejuv Potion +50 lives). Pass an "
+        "item name to look one up, or omit it to list every item. Use for 'what "
+        "does Geraldo's Sharpening Stone do', 'how much is the Genie Bottle', "
+        "'what level does the Paragon Power Totem unlock', 'list Geraldo's items'."
     ),
     parameters={
         "type": "object",
@@ -1197,7 +1200,7 @@ _BTD6_GERALDO_SPEC = AIToolSpec(
 
 
 def _geraldo_dict(entry: Any) -> dict[str, Any]:
-    return {
+    out: dict[str, Any] = {
         "name": entry.canonical,
         "description": entry.description,
         "cost": entry.cost,
@@ -1208,6 +1211,11 @@ def _geraldo_dict(entry: Any) -> dict[str, Any]:
         "amount_to_replenish": entry.amount_to_replenish,
         "usable_between_rounds": entry.between_rounds,
     }
+    if entry.effect:
+        # Structured factor(s) decoded from the dump — e.g. Sharpening Stone
+        # +1 pierce for 10 rounds; lets the model state the exact numbers.
+        out["effect"] = dict(entry.effect)
+    return out
 
 
 async def _btd6_geraldo_lookup(arguments: dict[str, Any]) -> dict[str, Any]:

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -251,6 +251,11 @@ class GeraldoItemEntry:
     rounds_to_replenish: int
     amount_to_replenish: int
     between_rounds: bool = False
+    # Structured headline effect decoded from the item's behaviour model (e.g.
+    # Sharpening Stone ``{"pierce_increase": 1, "rounds": 10}``). ``{}`` for items
+    # whose effect is a spawned projectile / tower summon / non-numeric — those
+    # stay description-only.
+    effect: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -680,6 +685,7 @@ def _parse_knowledge(raw: dict[str, Any]) -> MonkeyKnowledgeEntry:
 
 def _parse_geraldo_item(raw: dict[str, Any]) -> GeraldoItemEntry:
     _require_keys(raw, _REQUIRED_GERALDO_FIELDS, where=f"geraldo {raw.get('id')!r}")
+    effect = raw.get("effect", {})
     return GeraldoItemEntry(
         id=str(raw["id"]),
         canonical=str(raw["canonical"]),
@@ -691,6 +697,7 @@ def _parse_geraldo_item(raw: dict[str, Any]) -> GeraldoItemEntry:
         rounds_to_replenish=int(raw.get("rounds_to_replenish", 0)),
         amount_to_replenish=int(raw.get("amount_to_replenish", 0)),
         between_rounds=bool(raw.get("between_rounds", False)),
+        effect=dict(effect) if isinstance(effect, dict) else {},
     )
 
 

--- a/docs/btd6/btd6-gamedata-decode-status.md
+++ b/docs/btd6/btd6-gamedata-decode-status.md
@@ -17,6 +17,19 @@ works** (the traps we hit), and what is still un-decoded.
 
 ### Current state & next actions (READ FIRST)
 
+> **Provenance precedence (owner decision Q-0037, 2026-06-08): trust the dump wherever
+> it is complete and accurate** — it's a direct export of the game's internal files and
+> the most recent. Dump > bloonswiki when the dump's value is present and unambiguous.
+> **Caveat earned twice this session:** "accurate" requires reading the *right* model.
+> The dump has template/variant models that look internally consistent but aren't
+> canonical — base `Ddt` is non-camo (children `CeramicRegrow`) vs the real `DdtCamo`
+> (children `CeramicRegrowCamo`); a `DiamondbackDiamondBloon` variant reads health 60 vs
+> the canonical `DiamondBloon` 80. Select by the bloon's own properties
+> (`_select_bloon_model`) and sanity-check a surprising value before asserting it. (Both
+> traps were caught by the maintainer's domain knowledge, not the structural self-check.)
+> Verified: all 23 dump-modelled bloons match the dump on health **and** speed already —
+> our curated bloon stats are correct; only BAD's DDT children needed the camo correction.
+
 **Where the data stands (verified on `main`, full CI green):**
 - **Towers** 25, **Heroes** 17, **Rounds** 140 — towers/rounds still
   **wiki-sourced** (no cutover yet); the 11 wiki-missing heroes are game-data.

--- a/docs/btd6/btd6-gamedata-decode-status.md
+++ b/docs/btd6/btd6-gamedata-decode-status.md
@@ -353,6 +353,14 @@ game-data-native lookup catalog.
 - **AI tool** `btd6_geraldo_lookup` (single + roster) registered + in
   `BTD6_GROUNDING_TOOL_NAMES`. "What does Geraldo's Blade Trap do / how much is the Genie Bottle /
   what level unlocks the Paragon Power Totem" now answer.
+- **Structured effects (follow-on).** Five items whose named behaviour model carries clean,
+  description-confirmable numbers gained a structured `effect` (mirroring `PowerEntry.effect`):
+  Sharpening Stone `{pierce_increase:1, rounds:10}`, Jar of Pickles `{damage_increase:1,
+  attack_speed_scale:0.75, rounds:5}`, Fertilizer `{cash_scale:1.2, rounds:4}`, Rejuv Potion
+  `{lives_gained:50}`, See Invisibility Potion `{rounds:5}`. Items whose effect is a spawned
+  projectile (Blade Trap, Stack of Old Nails, Tube of Amaz-o-Glue), a tower summon (Creepy Idol,
+  Genie Bottle, Shooty Turret), or non-numeric stay description-only — `effect == {}`, never
+  fabricated. Surfaced on `btd6_geraldo_lookup`.
 - **Coverage map:** `GeraldoItems/` fetch-status ⬜ → ✅ (regenerated via `--full-map`).
 - **Tests:** parser (decode + skip-missing-name), data_service (load/resolve/fail-closed), tool
   (single/partial/roster/miss); both registry rosters updated. Full suite green.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -1778,3 +1778,19 @@ Action owner: maintainer (ChatGPT template).
 **Safe default until answered:** Keep `_SAFE_TEXT` an internal draft; do **not** wire it into live denial paths until the wording is confirmed. The read-only drift work proceeds independently.
 
 **Suggested destination after answer:** Q-0017 planning doc §6.3 / §16.3 + the P1B denial-integration step.
+
+### Q-0037 — BTD6 data provenance: dump vs. wiki precedence (2026-06-08)
+
+**Area:** BTD6 data / extraction
+**Type:** Data provenance / decision principle
+**Priority:** Medium (governs every BTD6 cutover)
+**Status:** Answered (2026-06-08) — Routed → `docs/btd6/btd6-gamedata-decode-status.md` provenance note + the `--bloons`/cutover tooling.
+**Question:** When the game-data dump and the curated bloonswiki value disagree on a fact (e.g. BAD's DDT children, a bloon's health), which wins?
+
+**Why agents need this:** BTD6 data is sourced from two places — the BTD Mod Helper dump (a direct export of the game's internal files) and curated bloonswiki prose. Cutovers (children/immunity shipped; tower stats pending) need a precedence rule so an agent doesn't have to ask per-field.
+
+**Maintainer answer (2026-06-08):** **Always trust the dump wherever it is complete and accurate** — it's a direct copy of the game's internal files and is the most recent. So dump > wiki when the dump's value is present and unambiguous.
+
+**Critical caveat (agent-added, earned this session):** "complete and accurate" requires reading the **right** model. The dump carries template/variant models that look internally consistent but aren't the canonical one — the base `Ddt` template is non-camo (spawns `CeramicRegrow`) while the real in-game DDT is `DdtCamo` (spawns `CeramicRegrowCamo`); and a `DiamondbackDiamondBloon` variant reads health 60 while the canonical `DiamondBloon` is 80. **Both times a naïve "first matching file" pick produced a wrong value the maintainer's domain knowledge caught.** So: trust the dump, but select the model by the bloon's own properties (`_select_bloon_model`) and sanity-check a surprising value against gameplay before asserting it. Net effect this session: the BAD→Camo-DDT correction stands (dump was right, wiki incomplete); the Diamond "60" was withdrawn (variant artifact — canonical is 80, already matching).
+
+**Suggested destination after answer:** `docs/btd6/btd6-gamedata-decode-status.md` (provenance precedence note) + applied by the `--bloons` cutover's model-selection logic.

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -2031,6 +2031,64 @@ def map_monkey_knowledge(dump: Path, version: str) -> tuple[list[dict], list[str
     return rows, warnings
 
 
+# Structured headline effect per Geraldo item, read from its named behaviour
+# model (values are the game's own — never hardcoded). Listed only where the
+# effect is a clean, description-confirmable number; items whose effect is a
+# spawned projectile (Blade Trap, Stack of Old Nails, Tube of Amaz-o-Glue), a
+# tower summon/upgrade (Creepy Idol, Genie Bottle, Shooty Turret), or has no
+# numeric model (Pet Rabbit, Hot Sauce, Action Figure, Paragon Power Totem,
+# Worn Hero's Cape) stay description-only — never a fabricated value. Tuple
+# shape: (behaviour_model_type, {dump_field: schema_field}).
+#   * Sharpening Stone: +1 pierce for 10 rounds ("sharper than ever").
+#   * Jar of Pickles: +1 damage but attacks at 0.75x speed for 5 rounds ("hit
+#     harder but shoot slower").
+#   * Fertilizer: +20% farm cash (cashScale 1.2) for 4 rounds ("even more bananas").
+#   * Rejuv Potion: restores 50 lives ("restore lost lives").
+#   * See Invisibility Potion: grants camo detection for 5 rounds.
+_GERALDO_EFFECTS: dict[str, tuple[str, dict[str, str]]] = {
+    "sharpening_stone": (
+        "SharpeningStoneBehaviorModel",
+        {"pierceIncrease": "pierce_increase", "rounds": "rounds"},
+    ),
+    "jar_of_pickles": (
+        "JarOfPicklesBehaviorModel",
+        {
+            "damageIncrease": "damage_increase",
+            "attackSpeedScale": "attack_speed_scale",
+            "rounds": "rounds",
+        },
+    ),
+    "fertilizer": (
+        "FertilizerBehaviorModel",
+        {"cashScale": "cash_scale", "rounds": "rounds"},
+    ),
+    "rejuv_potion": ("RejuvPotionBehaviorModel", {"livesGained": "lives_gained"}),
+    "see_invisibility_potion": (
+        "SeeInvisibilityPotionBehaviorModel",
+        {"rounds": "rounds"},
+    ),
+}
+
+
+def _geraldo_effect(raw: dict[str, Any], gid: str) -> dict[str, Any]:
+    """Structured effect factor(s) for a Geraldo item from its named behaviour
+    model, or ``{}`` when the item isn't in ``_GERALDO_EFFECTS`` (projectile /
+    summon / no numeric effect — description-only, never fabricated).
+    """
+    spec = _GERALDO_EFFECTS.get(gid)
+    if spec is None:
+        return {}
+    model_type, field_map = spec
+    for beh in raw.get("behaviorModels", []) or []:
+        if str(beh.get("$type", "")).split(",")[0].split(".")[-1] == model_type:
+            return {
+                schema: _num(beh[dump_f])
+                for dump_f, schema in field_map.items()
+                if dump_f in beh
+            }
+    return {}
+
+
 def map_geraldo_items(dump: Path, version: str) -> tuple[list[dict], list[str]]:
     """Every Geraldo shop item → catalog rows (id, name, description, in-game
     cash cost, the Geraldo level it unlocks at, starting/max quantity, and
@@ -2058,20 +2116,22 @@ def map_geraldo_items(dump: Path, version: str) -> tuple[list[dict], list[str]]:
             warnings.append(f"duplicate geraldo id {gid!r} ({fp.stem})")
             continue
         seen.add(gid)
-        rows.append(
-            {
-                "id": gid,
-                "canonical": _clean_desc(name),
-                "description": _clean_desc(tt.get(f"{loc} description", "")),
-                "cost": _num(raw.get("cost", 0)),
-                "unlock_level": _num(raw.get("levelUnlockedAt", 0)),
-                "starting_quantity": _num(raw.get("startingQuantity", 0)),
-                "max_quantity": _num(raw.get("maxQuantity", 0)),
-                "rounds_to_replenish": _num(raw.get("roundsToReplenish", 0)),
-                "amount_to_replenish": _num(raw.get("amountToReplenish", 0)),
-                "between_rounds": bool(raw.get("canBeActivatedBetweenRounds", False)),
-            },
-        )
+        row = {
+            "id": gid,
+            "canonical": _clean_desc(name),
+            "description": _clean_desc(tt.get(f"{loc} description", "")),
+            "cost": _num(raw.get("cost", 0)),
+            "unlock_level": _num(raw.get("levelUnlockedAt", 0)),
+            "starting_quantity": _num(raw.get("startingQuantity", 0)),
+            "max_quantity": _num(raw.get("maxQuantity", 0)),
+            "rounds_to_replenish": _num(raw.get("roundsToReplenish", 0)),
+            "amount_to_replenish": _num(raw.get("amountToReplenish", 0)),
+            "between_rounds": bool(raw.get("canBeActivatedBetweenRounds", False)),
+        }
+        effect = _geraldo_effect(raw, gid)
+        if effect:
+            row["effect"] = effect
+        rows.append(row)
     rows.sort(key=lambda g: (g["unlock_level"], g["id"]))
     return rows, warnings
 

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -467,7 +467,56 @@ def test_map_geraldo_items_decodes_name_cost_and_meta(mod, tmp_path):
     assert row["between_rounds"] is True
 
 
-def _bloon_model(bid, *, base=None, props=0, camo=False, grow=False, fort=False, children=None):
+def test_map_geraldo_items_extracts_structured_effect(mod, tmp_path):
+    dump = tmp_path / "dump"
+    # Sharpening Stone's named behaviour model carries the effect numbers; the
+    # mapper reads them into a structured `effect` (values from the dump).
+    _write(
+        dump / "GeraldoItems" / "SharpeningStone.json",
+        {
+            "$type": _t("GeraldoItemModel"),
+            "name": "SharpeningStone",
+            "locsId": "Sharpening stone",
+            "cost": 200,
+            "levelUnlockedAt": 5,
+            "behaviorModels": [
+                {
+                    "$type": "x.SharpeningStoneBehaviorModel, Assembly-CSharp",
+                    "pierceIncrease": 1.0,
+                    "rounds": 10,
+                },
+            ],
+        },
+    )
+    # A projectile item with no named effect model stays description-only.
+    _write(
+        dump / "GeraldoItems" / "BladeTrap.json",
+        {
+            "$type": _t("GeraldoItemModel"),
+            "name": "BladeTrap",
+            "locsId": "Blade trap",
+            "cost": 650,
+            "levelUnlockedAt": 7,
+            "behaviorModels": [{"$type": "x.GeraldoCreateProjectileModel, A"}],
+        },
+    )
+    _write(
+        dump / "textTable.json",
+        {
+            "Sharpening stone name": "Sharpening Stone",
+            "Sharpening stone description": "Sharper than ever!",
+            "Blade trap name": "Blade Trap",
+            "Blade trap description": "Whirling blades!",
+        },
+    )
+    rows = {r["id"]: r for r in mod.map_geraldo_items(dump, "55.1")[0]}
+    assert rows["sharpening_stone"]["effect"] == {"pierce_increase": 1, "rounds": 10}
+    assert "effect" not in rows["blade_trap"]  # never fabricated
+
+
+def _bloon_model(
+    bid, *, base=None, props=0, camo=False, grow=False, fort=False, children=None
+):
     m = {
         "$type": "Il2CppAssets.Scripts.Models.Bloons.BloonModel, Assembly-CSharp",
         "id": bid,
@@ -493,11 +542,15 @@ def test_bloon_children_resolve_base_and_preserve_modifiers(mod, tmp_path):
     dump = tmp_path / "dump"
     # A BAD-like bloon spawning 2 plain ZOMG + 3 *camo* DDT, plus the variant
     # child models that carry the baseId + modifier flags.
-    _write(dump / "Bloons" / "Bad" / "Bad.json",
-           _bloon_model("Bad", children=["Zomg", "Zomg", "DdtCamo", "DdtCamo", "DdtCamo"]))
+    _write(
+        dump / "Bloons" / "Bad" / "Bad.json",
+        _bloon_model("Bad", children=["Zomg", "Zomg", "DdtCamo", "DdtCamo", "DdtCamo"]),
+    )
     _write(dump / "Bloons" / "Zomg" / "Zomg.json", _bloon_model("Zomg"))
-    _write(dump / "Bloons" / "Ddt" / "DdtCamo.json",
-           _bloon_model("DdtCamo", base="Ddt", camo=True))
+    _write(
+        dump / "Bloons" / "Ddt" / "DdtCamo.json",
+        _bloon_model("DdtCamo", base="Ddt", camo=True),
+    )
 
     meta = mod._bloon_variant_meta(dump)
     assert meta["ddtcamo".lower()] == ("Ddt", ["camo"])
@@ -517,14 +570,22 @@ def test_inherently_modified_bloon_selects_its_variant_model(mod, tmp_path):
     # (children CeramicRegrowCamo), NOT the non-camo base Ddt template (children
     # CeramicRegrow) — the base would wrongly drop Camo from DDT's children.
     dump = tmp_path / "dump"
-    _write(dump / "Bloons" / "Ddt" / "Ddt.json",
-           _bloon_model("Ddt", children=["CeramicRegrow"]))
-    _write(dump / "Bloons" / "Ddt" / "DdtCamo.json",
-           _bloon_model("DdtCamo", base="Ddt", camo=True, children=["CeramicRegrowCamo"]))
-    _write(dump / "Bloons" / "Ceramic" / "CeramicRegrow.json",
-           _bloon_model("CeramicRegrow", base="Ceramic", grow=True))
-    _write(dump / "Bloons" / "Ceramic" / "CeramicRegrowCamo.json",
-           _bloon_model("CeramicRegrowCamo", base="Ceramic", camo=True, grow=True))
+    _write(
+        dump / "Bloons" / "Ddt" / "Ddt.json",
+        _bloon_model("Ddt", children=["CeramicRegrow"]),
+    )
+    _write(
+        dump / "Bloons" / "Ddt" / "DdtCamo.json",
+        _bloon_model("DdtCamo", base="Ddt", camo=True, children=["CeramicRegrowCamo"]),
+    )
+    _write(
+        dump / "Bloons" / "Ceramic" / "CeramicRegrow.json",
+        _bloon_model("CeramicRegrow", base="Ceramic", grow=True),
+    )
+    _write(
+        dump / "Bloons" / "Ceramic" / "CeramicRegrowCamo.json",
+        _bloon_model("CeramicRegrowCamo", base="Ceramic", camo=True, grow=True),
+    )
 
     index = mod._bloon_model_index(dump)
     # The inherently-camo bloon resolves to the camo variant...

--- a/tests/unit/services/test_btd6_data_service.py
+++ b/tests/unit/services/test_btd6_data_service.py
@@ -105,6 +105,18 @@ def test_geraldo_items_load_and_resolve():
         assert item.canonical and item.description
         assert item.cost > 0 and item.unlock_level >= 0
         assert item.max_quantity >= item.starting_quantity >= 0
+    # Cleanly-decodable items carry a structured effect (game-sourced numbers);
+    # projectile/summon items stay description-only (effect == {}).
+    assert get_geraldo_item("sharpening_stone").effect == {
+        "pierce_increase": 1,
+        "rounds": 10,
+    }
+    assert get_geraldo_item("jar_of_pickles").effect == {
+        "damage_increase": 1,
+        "attack_speed_scale": 0.75,
+        "rounds": 5,
+    }
+    assert get_geraldo_item("blade_trap").effect == {}  # projectile — no fabricated effect
     # Unknown / ambiguous lookups fail closed rather than guessing.
     assert get_geraldo_item("nope") is None
     assert find_geraldo_item("") is None


### PR DESCRIPTION
Follow-on to the merged Geraldo lookup (#593): the catalog now carries **structured effect numbers** for the items whose effect is cleanly decodable from the dump — so *"what does Geraldo's Sharpening Stone do"* answers with exact figures, not just prose. Mirrors the `PowerEntry.effect` pattern.

## What's extracted

Five items expose a structured `effect` read from their named behaviour model (values are the game's own):

| Item | effect |
|---|---|
| Sharpening Stone | `{pierce_increase: 1, rounds: 10}` |
| Jar of Pickles | `{damage_increase: 1, attack_speed_scale: 0.75, rounds: 5}` |
| Fertilizer | `{cash_scale: 1.2, rounds: 4}` |
| Rejuv Potion | `{lives_gained: 50}` |
| See Invisibility Potion | `{rounds: 5}` |

Each value cross-checks the direction of the item's game-authored description (Jar of Pickles: *"hit harder but shoot slower"* ↔ +1 damage, ×0.75 attack speed).

## What stays description-only (no fabrication)

Items whose effect is a spawned projectile (Blade Trap, Stack of Old Nails, Tube of Amaz-o-Glue), a tower summon (Creepy Idol, Genie Bottle, Shooty Turret), or non-numeric (Pet Rabbit, Hot Sauce, Action Figure, Paragon Power Totem, Worn Hero's Cape) keep `effect == {}` — the prose description already answers them.

## Changes

- `parse_gamedata.py`: `_GERALDO_EFFECTS` table + `_geraldo_effect` extractor.
- `GeraldoItemEntry.effect` + `btd6_geraldo_lookup` surface it; tool description updated.
- Parser + data_service tests; `geraldo_items.json` regenerated.
- `check_quality.py --full` green (8142 passed), arch 0 errors, docs clean.

## ~~Diamond Bloon health~~ — resolved, no discrepancy (correction)

My earlier note here flagged a possible Diamond health discrepancy (dump 60 vs our 80). **Withdrawn — there is no discrepancy.** Re-checking with the parser's proper variant-aware model selection, the canonical `DiamondBloon` model is **80**, matching our data exactly; the "60" was a `DiamondbackDiamondBloon` *variant* (a Diamondback-boss-spawned, degree-scaled Diamond) my ad-hoc check grabbed by mistake — the same template/variant trap as DDT. All 23 bloons with a dump model match the dump on **both health and speed**. Nothing to change.

(Owner decision **Q-0037** recorded separately: trust the dump wherever complete/accurate, but select the model by the bloon's own properties and sanity-check surprising values — both DDT and Diamond showed a naïve "first matching file" pick can read a wrong value.)

https://claude.ai/code/session_016JahGBPpz4hMvyjcL7usRN