### PR TITLE
btd6: make buff stack cap parser-reproducible (cutover fidelity fix)

### DIFF
--- a/.sessions/2026-06-08-buff-stack-cap-cutover-fidelity.md
+++ b/.sessions/2026-06-08-buff-stack-cap-cutover-fidelity.md
@@ -1,0 +1,43 @@
+# 2026-06-08 — buff stack cap parser-reproducible (cutover fidelity)
+
+**Branch:** `claude/inspiring-cray-tywlxl` · **PR:** #597
+
+## Task
+"Continue with the BTD6 data-mapping plan." The plan's living ledger is
+`docs/btd6/btd6-gamedata-decode-status.md`. Its ordered "Do next" list is almost
+entirely **cutover-gated or maintainer-gated** (new buff/zone numbers can't be
+confirmed pre-cutover; income multiplier + MK magnitudes + map removable costs are
+maintainer calls). The one clean, ungated, confirmable item the ledger explicitly
+flagged was the buff **stack-cap** gap.
+
+## What I did
+Closed the flagged gap. The game-native parser path (`map_tower → _map_tier →
+`_buffs`) emitted `isGlobal` but **not** the stack cap, even though the renderer
+(`btd6_upgrade_detail_service._stack_cap`) reads it. So a future tower cutover
+would silently lose the "(stacks up to N)" clause.
+
+- `scripts/parse_gamedata.py` `_buffs()`: pass both dump field names
+  (`maxStacks` / `maxStackSize`) through verbatim — faithful structural copy like
+  `isGlobal`, `0` preserved, emitted after the nested-tag drop check.
+- Tests: fixed the Shinobi test (it asserted the cap *dropped* — encoded the bug) +
+  2 new (`both_field_names`, `zero_preserved`).
+- Ledger: marked the "known small gap" FIXED + a session-log entry.
+
+## Key facts learned (for next session)
+- **`--overlay` only refreshes `{range, footprintRadius}`** — it does **not** rewrite
+  `buffs[]`. The committed `buffs[]` are a *fuller, earlier* extraction; the lean
+  `_buffs()` is the **cutover** path. So committed buffs carry many fields `_buffs()`
+  drops (`customRadius`, `appliesToOwningTower`, `filterInBaseTowerId`,
+  `cashPerRound*`, …). They diverge by design; the "--overlay --dry-run is a no-op"
+  claim is about `{range, footprintRadius}`, not buffs.
+- Therefore "fix `_buffs()` to reproduce committed" is a **cutover-prep** activity,
+  not a live-bug fix. Only render-relevant dropped fields are worth emitting; the
+  only one the renderer consumes is the stack cap (now done). The rest are inert.
+- The remaining data-mapping frontier is genuinely gated — see the ledger's
+  "Do next" 1–6. To unblock more: maintainer call on the tower **cutover** (steps
+  4–5), the **income multiplier** (needs economy towers to get minimal tiers), and
+  **MK magnitudes / map removable costs** (not dump-sourced — curate or skip).
+
+## Verification
+`python3.10 scripts/check_quality.py --full` → 8157 passed.
+`check_architecture --mode strict` → no new errors (only pre-existing `[known]` xp warns).

--- a/docs/btd6/btd6-gamedata-decode-status.md
+++ b/docs/btd6/btd6-gamedata-decode-status.md
@@ -246,9 +246,37 @@ Full `check_quality.py --full` green (8070 passed).
 
 **Honest frontier:** 11 is the confirmed ceiling for committed **combat** towers pre-cutover
 (see "Do next" step 1 for why every remaining type is hero / no-committed-tier / paragon).
-Known small gap (not fixed, applies to *all* buff types equally): `_buffs()` does not emit
-`maxStackSize`, so the renderer's `_stack_cap` "(stacks up to N)" clause is lost on the
-parser-native path — a separate, uniform fix, not a per-type decode.
+~~Known small gap: `_buffs()` does not emit `maxStackSize`…~~ **FIXED (2026-06-08, see session
+log below).** `_buffs()` now passes through both stack-cap field names (`maxStacks` /
+`maxStackSize`) verbatim, so the parser-native (cutover) path reproduces the renderer's
+`_stack_cap` "(stacks up to N)" clause instead of dropping it. *Forward-looking* fidelity fix:
+the **committed** buffs already carry the cap (overlay never rewrites `buffs[]`, only
+`{range, footprintRadius}`), so live answers were unaffected — the gap was that the eventual
+game-native cutover would have silently regressed the clause.
+
+### Session log — 2026-06-08 (buff stack-cap now parser-reproducible — cutover fidelity fix)
+
+Closed the standing "known small gap" the buff-tail session flagged: the game-native parser
+path (`map_tower` → `_map_tier` → `_buffs`) dropped the buff **stack cap**, so a future tower
+cutover would have silently lost the renderer's "(stacks up to N)" clause (Ninja Shinobi
+Tactics "stacks up to 20", Trade Empire "up to 20 Merchantmen", sellback "3").
+
+- **Root cause, precisely:** `_buffs()` emitted `isGlobal` but not the stack-cap field, even
+  though `btd6_upgrade_detail_service._stack_cap` reads it (`maxStacks` on most towers,
+  `maxStackSize` on Sniper/Ninja/Mermonkey). The **committed** `buffs[]` still carry the cap
+  (the numeric `--overlay` only refreshes `{range, footprintRadius}`, never `buffs[]`), so live
+  answers were correct — this was a *forward-looking* fidelity gap, not a live bug.
+- **Fix:** `_buffs()` now passes both stack-cap names through **verbatim** (a faithful
+  structural copy, like `isGlobal` — no transform, so it respects "never write a number you
+  can't confirm"; the value *is* the dump's own field). `0` is preserved ("applies once, does
+  not stack"); the renderer remains the single place that suppresses the clause for a
+  non-positive cap. Emitted *after* the nested-tag drop check, so a stack cap alone never keeps
+  a bare value-less buff alive.
+- **Tests:** updated `test_buffs_shinobi_tactics_maps_multiplier_to_rate` (was asserting the cap
+  *dropped* — it encoded the bug) + two new (`test_buffs_emit_stack_cap_both_field_names`,
+  `test_buffs_stack_cap_zero_preserved`). `check_quality.py --full` **green (8157 passed)**.
+- **Honest scope:** parser-side only; no new decoded effect, no committed-data change. It makes
+  the cutover path reproduce what the committed data + renderer already surface.
 
 ### ⚠ Answerability audit — Powers/Knowledge are *lookup catalogs*, not *applied modifiers* (2026-06-08)
 

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -742,6 +742,19 @@ def _buffs(model: dict) -> list[dict]:
                 entry[schema_field] = _num(value / 60.0)  # frames → seconds
         if "isGlobal" in behavior:
             entry["isGlobal"] = bool(behavior["isGlobal"])
+        # Stack cap — a faithful structural copy of the dump's own field (no
+        # transform, like ``isGlobal``). Two names encode the same concept:
+        # ``maxStacks`` on most towers, ``maxStackSize`` on Sniper/Ninja/Mermonkey.
+        # Preserve whichever is present, including ``0`` (0 means "applies once,
+        # does not stack"; the renderer's ``_stack_cap`` surfaces only a positive
+        # limit). Emitting it keeps the eventual game-native cutover reproducing
+        # the "(stacks up to N)" clause instead of silently dropping it. Added
+        # after the nested-tag drop check above so a stack cap alone never keeps a
+        # bare, value-less buff alive.
+        for stack_field in ("maxStacks", "maxStackSize"):
+            value = behavior.get(stack_field)
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                entry[stack_field] = _num(value)
         out.append(entry)
     return out
 

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -1394,17 +1394,53 @@ def test_buffs_shinobi_tactics_maps_multiplier_to_rate(mod):
             "name": "SupportShinobiTacticsModel_Support_",
             "buffLocsName": "ShinobiTacticsBuff",
             "multiplier": 0.92,
-            "maxStacks": 20,
             "maxStackSize": 20,
         }
     )
+    # The stack cap is a faithful structural passthrough (like isGlobal), so the
+    # game-native cutover reproduces the renderer's "(stacks up to 20)" clause.
     assert mod._map_tier(model)["buffs"] == [
         {
             "kind": "SupportShinobiTactics",
             "name": "ShinobiTacticsBuff",
             "rateMultiplier": 0.92,
+            "maxStackSize": 20,
         }
     ]
+
+
+def test_buffs_emit_stack_cap_both_field_names(mod):
+    # Two dump field names encode the stack cap: ``maxStacks`` (most towers) and
+    # ``maxStackSize`` (Sniper/Ninja/Mermonkey). Each is passed through verbatim
+    # so the renderer's ``_stack_cap`` reproduces "(stacks up to N)" at cutover.
+    model = _tower_model()
+    model["behaviors"].append(
+        {
+            "$type": _t("TradeEmpireBuffModel"),
+            "name": "TradeEmpireBuff",
+            "maxStacks": 20,
+            "cashPerRoundPerMechantship": 200,
+        }
+    )
+    buff = mod._map_tier(model)["buffs"][0]
+    assert buff["maxStacks"] == 20
+
+
+def test_buffs_stack_cap_zero_preserved(mod):
+    # ``0`` ("applies once, does not stack") is a real dump value and must be
+    # preserved faithfully; the renderer (``_stack_cap``) is what suppresses the
+    # clause for a non-positive cap, not the parser.
+    model = _tower_model()
+    model["behaviors"].append(
+        {
+            "$type": _t("RateSupportModel"),
+            "name": "RateBuff",
+            "multiplier": 0.75,
+            "maxStackSize": 0,
+        }
+    )
+    buff = mod._map_tier(model)["buffs"][0]
+    assert buff["maxStackSize"] == 0
 
 
 def test_buffs_damage_modifier_support_reads_nested_tag_bonus(mod):


### PR DESCRIPTION
## What

The game-native parser path (`map_tower` → `_map_tier` → `_buffs`) dropped the buff **stack cap**, so a future tower cutover would silently lose the renderer's `(stacks up to N)` clause — Ninja Shinobi Tactics "stacks up to 20", Trade Empire "up to 20 Merchantmen", sellback "3".

`_buffs()` emitted `isGlobal` but not the stack-cap field that `btd6_upgrade_detail_service._stack_cap` reads (`maxStacks` on most towers, `maxStackSize` on Sniper/Ninja/Mermonkey).

## Fix

`_buffs()` now passes **both** dump field names through verbatim — a faithful structural copy, like `isGlobal` (no transform, so it respects "never write a number you can't confirm": the value *is* the dump's own field). `0` is preserved ("applies once, does not stack"); the renderer stays the single place that suppresses the clause for a non-positive cap. Emitted *after* the nested-tag drop check, so a stack cap alone never keeps a bare value-less buff alive.

## Scope / honesty

Parser-side only, **forward-looking fidelity fix** — no new decoded effect, no committed-data change. The committed `buffs[]` already carry the cap (the numeric `--overlay` only refreshes `{range, footprintRadius}`, never `buffs[]`), so **live answers were unaffected**; the gap was that the eventual game-native cutover would have regressed the clause. This closes the "known small gap" the buff-tail session flagged in `btd6-gamedata-decode-status.md`.

## Tests

- Updated `test_buffs_shinobi_tactics_maps_multiplier_to_rate` — it was asserting the cap *dropped* (it encoded the bug).
- Added `test_buffs_emit_stack_cap_both_field_names` and `test_buffs_stack_cap_zero_preserved`.
- `python3.10 scripts/check_quality.py --full` green (8157 passed); `check_architecture --mode strict` no new errors.

https://claude.ai/code/session_01UZCi9DFBDQHPZfMwr1xQ3h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZCi9DFBDQHPZfMwr1xQ3h)_