### PR TITLE
btd6: extract Monkey Knowledge effect magnitudes from game data

### DIFF
--- a/disbot/data/btd6/monkey_knowledge.json
+++ b/disbot/data/btd6/monkey_knowledge.json
@@ -12,7 +12,16 @@
       "investment_required": 5,
       "prerequisites": [
         "crossbow_reach"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "alternate_arc",
+            "increase": 1,
+            "shot_count": 4
+          }
+        ]
+      }
     },
     {
       "id": "aviation_grade_glue",
@@ -23,7 +32,16 @@
       "investment_required": 8,
       "prerequisites": [
         "more_splatty_glue"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "slow_modifier_for_tag",
+            "slow_modifier": 2.2,
+            "tag": "Moabs"
+          }
+        ]
+      }
     },
     {
       "id": "big_cryo_blast",
@@ -34,7 +52,15 @@
       "investment_required": 10,
       "prerequisites": [
         "so_cold"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "projectile_radius",
+            "multiplier_amount": 1.12
+          }
+        ]
+      }
     },
     {
       "id": "big_inferno",
@@ -45,7 +71,16 @@
       "investment_required": 5,
       "prerequisites": [
         "poppy_blades"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "range",
+            "multiplier": 1,
+            "additive": 3
+          }
+        ]
+      }
     },
     {
       "id": "bionic_augmentation",
@@ -56,7 +91,16 @@
       "investment_required": 10,
       "prerequisites": [
         "long_turbo"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "grant_camo_detect_for_ability",
+            "mutator_id": "BionicAugmentation",
+            "use_ability_duration": true
+          }
+        ]
+      }
     },
     {
       "id": "bonus_glue_gunner",
@@ -67,7 +111,16 @@
       "investment_required": 10,
       "prerequisites": [
         "cheaper_solution"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "free_tower",
+            "base_tower_id": "GlueGunner",
+            "charges": 1
+          }
+        ]
+      }
     },
     {
       "id": "bonus_monkey",
@@ -78,7 +131,16 @@
       "investment_required": 10,
       "prerequisites": [
         "come_on_everybody"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "free_tower",
+            "base_tower_id": "DartMonkey",
+            "charges": 1
+          }
+        ]
+      }
     },
     {
       "id": "budget_clusters",
@@ -89,7 +151,16 @@
       "investment_required": 5,
       "prerequisites": [
         "fraggy_frags"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "upgrade_cost",
+            "amount_reduced": 100,
+            "upgrade_name": "Cluster Bombs"
+          }
+        ]
+      }
     },
     {
       "id": "cheap_rangs",
@@ -100,7 +171,17 @@
       "investment_required": 0,
       "prerequisites": [
         "increased_lifespan"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "sim_tower_discount",
+            "tower": "BoomerangMonkey",
+            "use_all_heroes": false,
+            "subtraction": 50
+          }
+        ]
+      }
     },
     {
       "id": "cheaper_solution",
@@ -111,7 +192,16 @@
       "investment_required": 10,
       "prerequisites": [
         "aviation_grade_glue"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "upgrade_cost",
+            "amount_reduced": 1000,
+            "upgrade_name": "Bloon Liquefier"
+          }
+        ]
+      }
     },
     {
       "id": "come_on_everybody",
@@ -122,7 +212,16 @@
       "investment_required": 10,
       "prerequisites": [
         "master_double_cross"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "come_on_everybody",
+            "discount_multiplier": 0.05,
+            "rate_multiplier": 0.95
+          }
+        ]
+      }
     },
     {
       "id": "crossbow_reach",
@@ -133,7 +232,16 @@
       "investment_required": 0,
       "prerequisites": [
         "extra_dart_pops"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "range",
+            "multiplier": 1,
+            "additive": 3
+          }
+        ]
+      }
     },
     {
       "id": "extra_bounce",
@@ -144,7 +252,19 @@
       "investment_required": 5,
       "prerequisites": [
         "cheap_rangs"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "retarget_increase",
+            "amount": 30
+          },
+          {
+            "kind": "projectile_pierce",
+            "amount": 30
+          }
+        ]
+      }
     },
     {
       "id": "extra_dart_pops",
@@ -153,7 +273,15 @@
       "description": "Dart Monkeys get +1 pierce to all shots.",
       "monkey_money_cost": 0,
       "investment_required": 0,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "projectile_pierce",
+            "amount": 1
+          }
+        ]
+      }
     },
     {
       "id": "fast_glue",
@@ -164,7 +292,15 @@
       "investment_required": 0,
       "prerequisites": [
         "fast_tack_attacks"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "weapon_reload_percentage",
+            "multiplier": 0.1
+          }
+        ]
+      }
     },
     {
       "id": "fast_tack_attacks",
@@ -173,7 +309,15 @@
       "description": "Tack Shooter attack speed increased by 8%.",
       "monkey_money_cost": 0,
       "investment_required": 0,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "weapon_reload_percentage",
+            "multiplier": 0.08
+          }
+        ]
+      }
     },
     {
       "id": "force_vs_force",
@@ -184,7 +328,16 @@
       "investment_required": 5,
       "prerequisites": [
         "crossbow_reach"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "damage_modifier_for_tag",
+            "bloon_tag": "Moabs",
+            "addative": 2
+          }
+        ]
+      }
     },
     {
       "id": "fraggy_frags",
@@ -195,7 +348,15 @@
       "investment_required": 0,
       "prerequisites": [
         "increased_lifespan"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "emission_arc_count",
+            "additional_count": 2
+          }
+        ]
+      }
     },
     {
       "id": "hard_press",
@@ -206,7 +367,15 @@
       "investment_required": 8,
       "prerequisites": [
         "extra_bounce"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "push_back_increase",
+            "amount": 0.3
+          }
+        ]
+      }
     },
     {
       "id": "hard_tacks",
@@ -217,7 +386,15 @@
       "investment_required": 0,
       "prerequisites": [
         "fast_tack_attacks"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "damage_type",
+            "can_hitbloon_properties": 16
+          }
+        ]
+      }
     },
     {
       "id": "hypothermia",
@@ -228,7 +405,19 @@
       "investment_required": 10,
       "prerequisites": [
         "so_cold"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "freeze_modifier",
+            "duration_add": 1
+          },
+          {
+            "kind": "freeze_modifier",
+            "duration_add": 1
+          }
+        ]
+      }
     },
     {
       "id": "icy_chill",
@@ -239,7 +428,21 @@
       "investment_required": 5,
       "prerequisites": [
         "hard_tacks"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "range",
+            "multiplier": 1,
+            "additive": 3
+          },
+          {
+            "kind": "projectile_radius",
+            "additive_amount": 3,
+            "multiplier_amount": 1
+          }
+        ]
+      }
     },
     {
       "id": "increased_lifespan",
@@ -248,7 +451,15 @@
       "description": "Longer projectile lifespan for Dart Monkey, Bomb Shooter, Tack Shooter and Glue Gunner.",
       "monkey_money_cost": 0,
       "investment_required": 0,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "projectile_range_percentage",
+            "percent_increase": 0.15
+          }
+        ]
+      }
     },
     {
       "id": "long_turbo",
@@ -259,7 +470,19 @@
       "investment_required": 10,
       "prerequisites": [
         "hard_press"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "turbo_duration_increase",
+            "amount": 5
+          },
+          {
+            "kind": "create_effect_on_ability",
+            "additional_lifespan": 5
+          }
+        ]
+      }
     },
     {
       "id": "master_double_cross",
@@ -270,7 +493,18 @@
       "investment_required": 8,
       "prerequisites": [
         "4_and4"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "tier_five_count",
+            "tower_base_id": "DartMonkey",
+            "path": 2,
+            "tier": 5,
+            "max_count_additive": 1
+          }
+        ]
+      }
     },
     {
       "id": "mega_mauler",
@@ -282,7 +516,16 @@
       "prerequisites": [
         "aviation_grade_glue",
         "hard_press"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "damage_modifier_for_tag",
+            "bloon_tag": "Moabs",
+            "addative": 2
+          }
+        ]
+      }
     },
     {
       "id": "more_cash",
@@ -294,7 +537,16 @@
       "prerequisites": [
         "bonus_glue_gunner",
         "bonus_monkey"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "starting_cash",
+            "addition": 200,
+            "multiplier": 1
+          }
+        ]
+      }
     },
     {
       "id": "more_splatty_glue",
@@ -305,7 +557,15 @@
       "investment_required": 5,
       "prerequisites": [
         "fast_glue"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "projectile_pierce",
+            "amount": 2
+          }
+        ]
+      }
     },
     {
       "id": "poppy_blades",
@@ -316,7 +576,15 @@
       "investment_required": 0,
       "prerequisites": [
         "hard_tacks"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "projectile_pierce",
+            "amount": 2
+          }
+        ]
+      }
     },
     {
       "id": "recurring_rangs",
@@ -327,7 +595,31 @@
       "investment_required": 5,
       "prerequisites": [
         "extra_bounce"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "recurring_rangs",
+            "path1_tier_max": 5,
+            "path2_tier_max": 5,
+            "path3_tier_max": 1
+          },
+          {
+            "kind": "recurring_rangs",
+            "path1_tier_max": 5,
+            "path2_tier_max": 5,
+            "path3_tier_min": 1,
+            "path3_tier_max": 3
+          },
+          {
+            "kind": "recurring_rangs",
+            "path1_tier_max": 5,
+            "path2_tier_max": 5,
+            "path3_tier_min": 3,
+            "path3_tier_max": 5
+          }
+        ]
+      }
     },
     {
       "id": "so_cold",
@@ -338,7 +630,15 @@
       "investment_required": 8,
       "prerequisites": [
         "icy_chill"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "slow_modifier",
+            "slow_modifier": -0.1
+          }
+        ]
+      }
     },
     {
       "id": "violent_impact",
@@ -349,7 +649,15 @@
       "investment_required": 10,
       "prerequisites": [
         "budget_clusters"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "slow_modifier",
+            "duration_modifier": 0.25
+          }
+        ]
+      }
     },
     {
       "id": "accelerated_aerodarts",
@@ -360,7 +668,19 @@
       "investment_required": 0,
       "prerequisites": [
         "airforce_upgrades"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "projectile_speed",
+            "multiplier": 0.5
+          },
+          {
+            "kind": "projectile_track_target",
+            "multiplier_turn_rate": 0.2
+          }
+        ]
+      }
     },
     {
       "id": "advanced_logistics",
@@ -372,7 +692,17 @@
       "prerequisites": [
         "aeronautic_subsidy",
         "door_gunner"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "sim_tower_discount",
+            "tower": "SniperMonkey,MonkeySub,MonkeyBuccaneer,MonkeyAce,HeliPilot,MortarMonkey,DartlingGunner",
+            "use_all_heroes": false,
+            "multiplier": 0.05
+          }
+        ]
+      }
     },
     {
       "id": "aeronautic_subsidy",
@@ -383,7 +713,26 @@
       "investment_required": 8,
       "prerequisites": [
         "gun_coolant"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "upgrade_cost",
+            "percentage_reduced": 0.1,
+            "upgrade_name": "Sky Shredder"
+          },
+          {
+            "kind": "upgrade_cost",
+            "percentage_reduced": 0.1,
+            "upgrade_name": "Tsar Bomba"
+          },
+          {
+            "kind": "upgrade_cost",
+            "percentage_reduced": 0.1,
+            "upgrade_name": "Flying Fortress"
+          }
+        ]
+      }
     },
     {
       "id": "airforce_upgrades",
@@ -392,7 +741,16 @@
       "description": "Monkey Aces and Heli Pilots of Tier 3 or higher get +1 pierce per shot.",
       "monkey_money_cost": 0,
       "investment_required": 0,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "projectile_pierce",
+            "amount": 1,
+            "min_tier": 3
+          }
+        ]
+      }
     },
     {
       "id": "big_bloon_sabotage",
@@ -404,7 +762,15 @@
       "prerequisites": [
         "sub_admiral",
         "master_defender"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "bloon_health",
+            "percentage_health_reduced": 0.1
+          }
+        ]
+      }
     },
     {
       "id": "big_bunch",
@@ -415,7 +781,15 @@
       "investment_required": 0,
       "prerequisites": [
         "naval_upgrades"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "emission_arc_count",
+            "additional_count": 1
+          }
+        ]
+      }
     },
     {
       "id": "breaking_ballistic",
@@ -426,7 +800,16 @@
       "investment_required": 4,
       "prerequisites": [
         "naval_upgrades"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "damage_modifier_for_bloon_type",
+            "additive_bonus": 1,
+            "with_tag": "Ceramic"
+          }
+        ]
+      }
     },
     {
       "id": "budget_battery",
@@ -437,7 +820,16 @@
       "investment_required": 8,
       "prerequisites": [
         "paint_stripper"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "upgrade_cost",
+            "amount_reduced": 600,
+            "upgrade_name": "Artillery Battery"
+          }
+        ]
+      }
     },
     {
       "id": "ceramic_shock",
@@ -459,7 +851,19 @@
       "investment_required": 8,
       "prerequisites": [
         "rapid_razors"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "lives",
+            "percent_bonus": 0.25
+          },
+          {
+            "kind": "cash",
+            "percent_bonus": 0.25
+          }
+        ]
+      }
     },
     {
       "id": "cheaper_maiming",
@@ -470,7 +874,16 @@
       "investment_required": 4,
       "prerequisites": [
         "ceramic_shock"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "upgrade_cost",
+            "amount_reduced": 1000,
+            "upgrade_name": "Maim MOAB"
+          }
+        ]
+      }
     },
     {
       "id": "cross_the_streams",
@@ -481,7 +894,17 @@
       "investment_required": 8,
       "prerequisites": [
         "gorgon_storm"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "cross_the_streams",
+            "rate": 0.5,
+            "position_randomness": 5,
+            "end_point_offset": -2
+          }
+        ]
+      }
     },
     {
       "id": "door_gunner",
@@ -501,7 +924,20 @@
       "description": "All Military Monkeys get a one-off +1000xp and earn xp in-game 5% faster permanently.",
       "monkey_money_cost": 0,
       "investment_required": 0,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "tower_xp",
+            "multiplier": 0.05
+          },
+          {
+            "kind": "on_monkey_knowledge_purchase",
+            "towers": "SniperMonkey,MonkeySub,MonkeyBuccaneer,MonkeyAce,HeliPilot,MortarMonkey,DartlingGunner",
+            "xp_to_add": 1000
+          }
+        ]
+      }
     },
     {
       "id": "emergency_unlock",
@@ -519,7 +955,15 @@
       "description": "Burny Stuff pops every second.",
       "monkey_money_cost": 0,
       "investment_required": 4,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "damage_over_time",
+            "time_reduction_amount": 0.25
+          }
+        ]
+      }
     },
     {
       "id": "faster_takedowns",
@@ -530,7 +974,15 @@
       "investment_required": 4,
       "prerequisites": [
         "big_bunch"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "ability_cooldown_time",
+            "cooldown_time_reduction": 5
+          }
+        ]
+      }
     },
     {
       "id": "flanking_maneuvers",
@@ -542,7 +994,16 @@
       "prerequisites": [
         "quad_burst",
         "trade_agreements"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "weapon_reload_percentage_on_target_prio",
+            "multiplier": 0.1,
+            "target_type": "Last"
+          }
+        ]
+      }
     },
     {
       "id": "gorgon_storm",
@@ -564,7 +1025,15 @@
       "investment_required": 8,
       "prerequisites": [
         "targeted_pineapples"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "weapon_reload_percentage",
+            "multiplier": 0.1
+          }
+        ]
+      }
     },
     {
       "id": "master_defender",
@@ -575,7 +1044,15 @@
       "investment_required": 8,
       "prerequisites": [
         "cheaper_maiming"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "ability_cooldown_percentage",
+            "cooldown_percentage_reduction": 0.5
+          }
+        ]
+      }
     },
     {
       "id": "military_conscription",
@@ -586,7 +1063,23 @@
       "investment_required": 14,
       "prerequisites": [
         "trade_agreements"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "sim_tower_discount",
+            "tower": "SniperMonkey,MonkeySub,MonkeyBuccaneer,MonkeyAce,HeliPilot,MortarMonkey,DartlingGunner",
+            "use_all_heroes": false,
+            "multiplier": 0.33,
+            "charges": 1
+          },
+          {
+            "kind": "on_monkey_knowledge_purchase",
+            "towers": "SniperMonkey,MonkeySub,MonkeyBuccaneer,MonkeyAce,HeliPilot,MortarMonkey,DartlingGunner",
+            "xp_to_add": 1000
+          }
+        ]
+      }
     },
     {
       "id": "naval_upgrades",
@@ -595,7 +1088,15 @@
       "description": "Monkey Buccaneer and Monkey Sub get +1 pierce per shot.",
       "monkey_money_cost": 0,
       "investment_required": 0,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "projectile_pierce",
+            "amount": 1
+          }
+        ]
+      }
     },
     {
       "id": "paint_stripper",
@@ -606,7 +1107,15 @@
       "investment_required": 8,
       "prerequisites": [
         "extra_burny_stuff"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "paint_stripper",
+            "remove_tags_from_exclude_list": "Ddt"
+          }
+        ]
+      }
     },
     {
       "id": "quad_burst",
@@ -617,7 +1126,15 @@
       "investment_required": 8,
       "prerequisites": [
         "breaking_ballistic"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "emission_arc_count",
+            "additional_count": 1
+          }
+        ]
+      }
     },
     {
       "id": "rapid_razors",
@@ -628,7 +1145,15 @@
       "investment_required": 4,
       "prerequisites": [
         "airforce_upgrades"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "weapon_reload_reduction",
+            "reduction_amount": 0.15
+          }
+        ]
+      }
     },
     {
       "id": "sub_admiral",
@@ -661,7 +1186,15 @@
       "investment_required": 8,
       "prerequisites": [
         "faster_takedowns"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "cash_per_round",
+            "additional_money": 20
+          }
+        ]
+      }
     },
     {
       "id": "wingmonkey",
@@ -683,7 +1216,15 @@
       "investment_required": 4,
       "prerequisites": [
         "strong_tonic"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "acid_pool",
+            "additional_time": 5
+          }
+        ]
+      }
     },
     {
       "id": "arcane_impale",
@@ -694,7 +1235,21 @@
       "investment_required": 4,
       "prerequisites": [
         "flame_jet"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "damage_modifier_for_tag",
+            "bloon_tag": "Moabs",
+            "addative": 1
+          },
+          {
+            "kind": "damage_modifier_for_tag",
+            "bloon_tag": "Ceramic",
+            "addative": 1
+          }
+        ]
+      }
     },
     {
       "id": "cheaper_doubles",
@@ -705,7 +1260,16 @@
       "investment_required": 0,
       "prerequisites": [
         "super_range"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "upgrade_cost",
+            "amount_reduced": 100,
+            "upgrade_name": "Double Shot"
+          }
+        ]
+      }
     },
     {
       "id": "cold_front",
@@ -727,7 +1291,15 @@
       "investment_required": 8,
       "prerequisites": [
         "diversion_tactics"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "emission_arc_count",
+            "additional_count": 1
+          }
+        ]
+      }
     },
     {
       "id": "diversion_tactics",
@@ -738,7 +1310,15 @@
       "investment_required": 4,
       "prerequisites": [
         "cheaper_doubles"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "wind",
+            "chance_increase": 0.025
+          }
+        ]
+      }
     },
     {
       "id": "flame_jet",
@@ -750,7 +1330,15 @@
       "prerequisites": [
         "magic_tricks",
         "hot_magic"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "projectile_speed",
+            "multiplier": 0.5
+          }
+        ]
+      }
     },
     {
       "id": "heavy_knockback",
@@ -761,7 +1349,15 @@
       "investment_required": 0,
       "prerequisites": [
         "super_range"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "knockback",
+            "percent_multiplier_added": 0.05
+          }
+        ]
+      }
     },
     {
       "id": "hot_magic",
@@ -772,7 +1368,15 @@
       "investment_required": 0,
       "prerequisites": [
         "lingering_magic"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "damage_type",
+            "can_hitbloon_properties": 16
+          }
+        ]
+      }
     },
     {
       "id": "lingering_magic",
@@ -781,7 +1385,15 @@
       "description": "Longer projectile lifespan for Wizard Monkey, Super Monkey, Ninja Monkey, and Druid.",
       "monkey_money_cost": 0,
       "investment_required": 0,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "projectile_range_percentage",
+            "percent_increase": 0.2
+          }
+        ]
+      }
     },
     {
       "id": "magic_tricks",
@@ -790,7 +1402,21 @@
       "description": "Guided Magic and Intense Magic cost 25 less.",
       "monkey_money_cost": 0,
       "investment_required": 0,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "upgrade_cost",
+            "amount_reduced": 25,
+            "upgrade_name": "Guided Magic"
+          },
+          {
+            "kind": "upgrade_cost",
+            "amount_reduced": 25,
+            "upgrade_name": "Intense Magic"
+          }
+        ]
+      }
     },
     {
       "id": "mana_shield",
@@ -801,7 +1427,17 @@
       "investment_required": 8,
       "prerequisites": [
         "arcane_impale"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "starting_shield",
+            "starting_shield": 25,
+            "max_shield": 25,
+            "shield_per_round": 5
+          }
+        ]
+      }
     },
     {
       "id": "mo_monkey_money",
@@ -812,7 +1448,15 @@
       "investment_required": 0,
       "prerequisites": [
         "speedy_brewing"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "monkey_money",
+            "multiplier": 1.1
+          }
+        ]
+      }
     },
     {
       "id": "speedy_brewing",
@@ -823,7 +1467,15 @@
       "investment_required": 0,
       "prerequisites": [
         "magic_tricks"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "weapon_reload_percentage",
+            "multiplier": 0.05
+          }
+        ]
+      }
     },
     {
       "id": "strike_down_the_false",
@@ -834,7 +1486,15 @@
       "investment_required": 4,
       "prerequisites": [
         "heavy_knockback"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "ignore_immunity_for_bloon_type",
+            "bloon_properties": 8
+          }
+        ]
+      }
     },
     {
       "id": "strong_tonic",
@@ -845,7 +1505,19 @@
       "investment_required": 4,
       "prerequisites": [
         "speedy_brewing"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "activate_attack",
+            "additional_time": 4
+          },
+          {
+            "kind": "increase_range",
+            "additional_frames": 4
+          }
+        ]
+      }
     },
     {
       "id": "super_range",
@@ -854,7 +1526,16 @@
       "description": "Increased range for the Super Range upgrade.",
       "monkey_money_cost": 0,
       "investment_required": 0,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "range",
+            "multiplier": 1,
+            "additive": 3
+          }
+        ]
+      }
     },
     {
       "id": "there_can_be_only_one",
@@ -900,7 +1581,16 @@
       "investment_required": 4,
       "prerequisites": [
         "hot_magic"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "upgrade_cost",
+            "amount_reduced": 100,
+            "upgrade_name": "Heart of Oak"
+          }
+        ]
+      }
     },
     {
       "id": "xray_ultra",
@@ -922,7 +1612,16 @@
       "investment_required": 3,
       "prerequisites": [
         "bigger_banks"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "imf_loan",
+            "additional_loan_amount": 1000,
+            "interest_rate_decrease_amount": 0.1
+          }
+        ]
+      }
     },
     {
       "id": "bank_deposits",
@@ -933,7 +1632,15 @@
       "investment_required": 14,
       "prerequisites": [
         "better_sell_deals"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "bank_deposits",
+            "deposit_percent": 0.5
+          }
+        ]
+      }
     },
     {
       "id": "better_sell_deals",
@@ -944,7 +1651,15 @@
       "investment_required": 8,
       "prerequisites": [
         "backroom_deals"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "tower_sell",
+            "mutltiplier": 0.05
+          }
+        ]
+      }
     },
     {
       "id": "big_traps",
@@ -955,7 +1670,15 @@
       "investment_required": 8,
       "prerequisites": [
         "thicker_foams"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "eat_bloon",
+            "additional_trap_amount": 30
+          }
+        ]
+      }
     },
     {
       "id": "bigger_banks",
@@ -966,7 +1689,15 @@
       "investment_required": 3,
       "prerequisites": [
         "insider_trades"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "bank",
+            "additional_capacity": 2500
+          }
+        ]
+      }
     },
     {
       "id": "farm_subsidy",
@@ -977,7 +1708,18 @@
       "investment_required": 3,
       "prerequisites": [
         "more_valuable_bananas"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "sim_tower_discount",
+            "tower": "BananaFarm",
+            "use_all_heroes": false,
+            "subtraction": 100,
+            "charges": 1
+          }
+        ]
+      }
     },
     {
       "id": "first_last_line_of_defense",
@@ -988,7 +1730,18 @@
       "investment_required": 0,
       "prerequisites": [
         "one_more_spike"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "sim_tower_discount",
+            "tower": "SpikeFactory",
+            "use_all_heroes": false,
+            "subtraction": 150,
+            "charges": 1
+          }
+        ]
+      }
     },
     {
       "id": "flat_pack_buildings",
@@ -997,7 +1750,21 @@
       "description": "Farm and Village cost 2% less and sell for 2% more.",
       "monkey_money_cost": 0,
       "investment_required": 0,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "tower_sell",
+            "mutltiplier": 0.02
+          },
+          {
+            "kind": "sim_tower_discount",
+            "tower": "BananaFarm,MonkeyAcademy,MonkeyVillage",
+            "use_all_heroes": false,
+            "multiplier": 0.02
+          }
+        ]
+      }
     },
     {
       "id": "global_ability_cooldowns",
@@ -1008,7 +1775,15 @@
       "investment_required": 8,
       "prerequisites": [
         "to_arms"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "ability_cooldown_percentage",
+            "cooldown_percentage_reduction": 0.03
+          }
+        ]
+      }
     },
     {
       "id": "healthy_bananas",
@@ -1019,7 +1794,16 @@
       "investment_required": 8,
       "prerequisites": [
         "inland_revenue_streams"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "healthy_bananas",
+            "marketplace_lives": 1,
+            "central_market_lives": 3
+          }
+        ]
+      }
     },
     {
       "id": "hi_value_mines",
@@ -1030,7 +1814,16 @@
       "investment_required": 8,
       "prerequisites": [
         "very_shreddy"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "upgrade_cost",
+            "amount_reduced": 1500,
+            "upgrade_name": "Spiked Mines"
+          }
+        ]
+      }
     },
     {
       "id": "inland_revenue_streams",
@@ -1041,7 +1834,15 @@
       "investment_required": 3,
       "prerequisites": [
         "farm_subsidy"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "cash_increase",
+            "percent_increase": 0.1
+          }
+        ]
+      }
     },
     {
       "id": "insider_trades",
@@ -1052,7 +1853,15 @@
       "investment_required": 0,
       "prerequisites": [
         "flat_pack_buildings"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "discount_zone",
+            "additional_multiplier": 0.02
+          }
+        ]
+      }
     },
     {
       "id": "monkey_education",
@@ -1061,7 +1870,15 @@
       "description": "All Monkeys XP earn rate increased by 8%.",
       "monkey_money_cost": 0,
       "investment_required": 3,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "tower_xp",
+            "multiplier": 0.08
+          }
+        ]
+      }
     },
     {
       "id": "more_valuable_bananas",
@@ -1072,7 +1889,15 @@
       "investment_required": 0,
       "prerequisites": [
         "flat_pack_buildings"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "cash",
+            "bonus_multiplier_buff": 0.05
+          }
+        ]
+      }
     },
     {
       "id": "one_more_spike",
@@ -1081,7 +1906,15 @@
       "description": "Spike Factory stacks get +1 spike.",
       "monkey_money_cost": 0,
       "investment_required": 0,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "projectile_pierce",
+            "amount": 1
+          }
+        ]
+      }
     },
     {
       "id": "paragon_of_power",
@@ -1092,7 +1925,15 @@
       "investment_required": 14,
       "prerequisites": [
         "veteran_monkey_training"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "paragon_of_power",
+            "rate_multiplier": 0.8333
+          }
+        ]
+      }
     },
     {
       "id": "thicker_foams",
@@ -1103,7 +1944,15 @@
       "investment_required": 3,
       "prerequisites": [
         "vigilant_sentries"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "projectile_pierce",
+            "amount": 3
+          }
+        ]
+      }
     },
     {
       "id": "to_arms",
@@ -1114,7 +1963,15 @@
       "investment_required": 3,
       "prerequisites": [
         "monkey_education"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "call_to_arms",
+            "additional_time": 3
+          }
+        ]
+      }
     },
     {
       "id": "very_shreddy",
@@ -1125,7 +1982,16 @@
       "investment_required": 3,
       "prerequisites": [
         "first_last_line_of_defense"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "damage_modifier_for_tag",
+            "bloon_tag": "Moabs",
+            "addative": 1
+          }
+        ]
+      }
     },
     {
       "id": "veteran_monkey_training",
@@ -1136,7 +2002,15 @@
       "investment_required": 8,
       "prerequisites": [
         "to_arms"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "weapon_reload_percentage",
+            "multiplier": 0.03
+          }
+        ]
+      }
     },
     {
       "id": "vigilant_sentries",
@@ -1147,7 +2021,15 @@
       "investment_required": 3,
       "prerequisites": [
         "one_more_spike"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "tower_expire",
+            "aditional_time_bonus": 2
+          }
+        ]
+      }
     },
     {
       "id": "ability_discipline",
@@ -1156,7 +2038,15 @@
       "description": "Hero level 10 Ability cooldowns reduced by 10%.",
       "monkey_money_cost": 0,
       "investment_required": 0,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "ability_cooldown_percentage",
+            "cooldown_percentage_reduction": 0.1
+          }
+        ]
+      }
     },
     {
       "id": "ability_mastery",
@@ -1167,7 +2057,15 @@
       "investment_required": 3,
       "prerequisites": [
         "ability_discipline"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "ability_cooldown_percentage",
+            "cooldown_percentage_reduction": 0.3
+          }
+        ]
+      }
     },
     {
       "id": "big_bloon_blueprints",
@@ -1178,7 +2076,16 @@
       "investment_required": 8,
       "prerequisites": [
         "ability_mastery"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "damage_modifier_for_tag",
+            "bloon_tag": "Moabs",
+            "addative": 1
+          }
+        ]
+      }
     },
     {
       "id": "empowered_heroes",
@@ -1189,7 +2096,16 @@
       "investment_required": 8,
       "prerequisites": [
         "hero_favors"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "hero_xp_injection",
+            "levels": 2,
+            "subtract_hero_cost": false
+          }
+        ]
+      }
     },
     {
       "id": "hero_favors",
@@ -1201,7 +2117,16 @@
       "prerequisites": [
         "self_taught_heroes",
         "quick_hands"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "sim_tower_discount",
+            "use_all_heroes": true,
+            "multiplier": 0.1
+          }
+        ]
+      }
     },
     {
       "id": "heroic_reach",
@@ -1210,7 +2135,16 @@
       "description": "All heroes get slightly increased range.",
       "monkey_money_cost": 0,
       "investment_required": 0,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "range",
+            "multiplier": 1,
+            "additive": 2
+          }
+        ]
+      }
     },
     {
       "id": "heroic_velocity",
@@ -1221,7 +2155,15 @@
       "investment_required": 0,
       "prerequisites": [
         "heroic_reach"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "projectile_speed",
+            "multiplier": 0.15
+          }
+        ]
+      }
     },
     {
       "id": "monkeys_together_strong",
@@ -1232,7 +2174,15 @@
       "investment_required": 8,
       "prerequisites": [
         "empowered_heroes"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "hero_xpbonus",
+            "percent_multiplier": 0.05
+          }
+        ]
+      }
     },
     {
       "id": "more_splody",
@@ -1241,7 +2191,15 @@
       "description": "Heroes' explosives get +2 pierce per shot.",
       "monkey_money_cost": 0,
       "investment_required": 0,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "projectile_pierce",
+            "amount": 2
+          }
+        ]
+      }
     },
     {
       "id": "quick_hands",
@@ -1252,7 +2210,15 @@
       "investment_required": 3,
       "prerequisites": [
         "heroic_velocity"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "weapon_reload_percentage",
+            "multiplier": 0.04
+          }
+        ]
+      }
     },
     {
       "id": "scholarships",
@@ -1263,7 +2229,15 @@
       "investment_required": 0,
       "prerequisites": [
         "more_splody"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "hero_cost_to_level",
+            "cost_multiplier": 0.9
+          }
+        ]
+      }
     },
     {
       "id": "self_taught_heroes",
@@ -1274,7 +2248,15 @@
       "investment_required": 3,
       "prerequisites": [
         "scholarships"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "tower_xp",
+            "multiplier": 0.1
+          }
+        ]
+      }
     },
     {
       "id": "weak_point",
@@ -1286,7 +2268,21 @@
       "prerequisites": [
         "monkeys_together_strong",
         "big_bloon_blueprints"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "damage_modifier_for_tag",
+            "bloon_tag": "Fortified",
+            "addative": 1
+          },
+          {
+            "kind": "damage_modifier_for_tag",
+            "bloon_tag": "Ceramic",
+            "addative": 1
+          }
+        ]
+      }
     },
     {
       "id": "ambush_tech",
@@ -1306,7 +2302,15 @@
       "description": "Camo Trap lasts for 600 Bloons.",
       "monkey_money_cost": 0,
       "investment_required": 0,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "camo_trap",
+            "pierce_increase": 100
+          }
+        ]
+      }
     },
     {
       "id": "budget_cash_drops",
@@ -1317,7 +2321,15 @@
       "investment_required": 3,
       "prerequisites": [
         "fit_farmers"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "power",
+            "cost_decrease": 20
+          }
+        ]
+      }
     },
     {
       "id": "budget_pontoons",
@@ -1328,7 +2340,15 @@
       "investment_required": 0,
       "prerequisites": [
         "cheaper_lakes"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "power",
+            "cost_decrease": 10
+          }
+        ]
+      }
     },
     {
       "id": "cheaper_lakes",
@@ -1337,7 +2357,15 @@
       "description": "Portable Lake costs 40 Monkey Money.",
       "monkey_money_cost": 0,
       "investment_required": 0,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "power",
+            "cost_decrease": 10
+          }
+        ]
+      }
     },
     {
       "id": "fit_farmers",
@@ -1348,7 +2376,15 @@
       "investment_required": 3,
       "prerequisites": [
         "powerful_monkey_storm"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "banana_farmer",
+            "range_multiplier": 1.2
+          }
+        ]
+      }
     },
     {
       "id": "grand_prix_spree",
@@ -1368,7 +2404,15 @@
       "description": "Road Spike piles have 21 spikes in them.",
       "monkey_money_cost": 0,
       "investment_required": 0,
-      "prerequisites": []
+      "prerequisites": [],
+      "effect": {
+        "factors": [
+          {
+            "kind": "road_spikes_pierce",
+            "addition": 1
+          }
+        ]
+      }
     },
     {
       "id": "longer_boosts",
@@ -1379,7 +2423,15 @@
       "investment_required": 3,
       "prerequisites": [
         "longer_dart_time"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "monkey_boost",
+            "duration_increase": 5
+          }
+        ]
+      }
     },
     {
       "id": "longer_dart_time",
@@ -1390,7 +2442,15 @@
       "investment_required": 0,
       "prerequisites": [
         "just_one_more"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "dart_time",
+            "duration_increase": 5
+          }
+        ]
+      }
     },
     {
       "id": "mauling_moab_mines",
@@ -1401,7 +2461,16 @@
       "investment_required": 0,
       "prerequisites": [
         "bigger_camo_trap"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "moab_mine",
+            "damage_increase": 1250,
+            "damage_boss_increase": -1125
+          }
+        ]
+      }
     },
     {
       "id": "powerful_monkey_storm",
@@ -1413,7 +2482,15 @@
       "prerequisites": [
         "budget_pontoons",
         "longer_boosts"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "super_monkey_storm",
+            "damage_increase": 1000
+          }
+        ]
+      }
     },
     {
       "id": "pre_game_prep",
@@ -1424,7 +2501,15 @@
       "investment_required": 3,
       "prerequisites": [
         "longer_boosts"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "pre_game_prep",
+            "dist_from_edge_of_map": 9
+          }
+        ]
+      }
     },
     {
       "id": "supa_thrive",
@@ -1435,7 +2520,15 @@
       "investment_required": 3,
       "prerequisites": [
         "fit_farmers"
-      ]
+      ],
+      "effect": {
+        "factors": [
+          {
+            "kind": "thrive",
+            "cash_multiplier_increase": 0.05
+          }
+        ]
+      }
     },
     {
       "id": "supersize_glue_trap",

--- a/disbot/services/ai_tools.py
+++ b/disbot/services/ai_tools.py
@@ -1125,13 +1125,20 @@ _BTD6_MK_LOOKUP_SPEC = AIToolSpec(
 
 
 def _mk_dict(entry: Any) -> dict[str, Any]:
-    return {
+    out = {
         "name": entry.canonical,
         "category": entry.category,
         "description": entry.description,
         "monkey_money_cost": entry.monkey_money_cost,
         "investment_required": entry.investment_required,
     }
+    # Structured, dump-native magnitude(s) where the knowledge carries them (e.g.
+    # More Cash {"factors": [{"kind": "starting_cash", "addition": 200}]}). Lets
+    # the model state the exact factor, grounded by both the number and the
+    # description. Absent for purely behavioural knowledge (description-only).
+    if entry.effect:
+        out["effect"] = dict(entry.effect)
+    return out
 
 
 def _find_mk(name: str) -> Any:

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -228,6 +228,13 @@ class MonkeyKnowledgeEntry:
     monkey_money_cost: int
     investment_required: int
     prerequisites: tuple[str, ...] = ()
+    # Structured, dump-native effect decoded from the knowledge's
+    # ``mod.mutatorMods[]`` — ``{"factors": [{"kind": ..., <numbers>}, ...]}``
+    # (More Cash ``starting_cash addition 200``, Bonus Monkey
+    # ``free_tower base_tower_id DartMonkey``, …). ``{}`` for the purely
+    # behavioural ones (nested projectile/ability sub-model — Cold Front, Tiny
+    # Tornadoes, …) which stay description-only.
+    effect: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -672,6 +679,7 @@ def _parse_knowledge(raw: dict[str, Any]) -> MonkeyKnowledgeEntry:
             f"knowledge {raw['id']!r}: category {category!r} not one of "
             f"{sorted(_MK_CATEGORIES)}",
         )
+    effect = raw.get("effect", {})
     return MonkeyKnowledgeEntry(
         id=str(raw["id"]),
         canonical=str(raw["canonical"]),
@@ -680,6 +688,7 @@ def _parse_knowledge(raw: dict[str, Any]) -> MonkeyKnowledgeEntry:
         monkey_money_cost=int(raw["monkey_money_cost"]),
         investment_required=int(raw["investment_required"]),
         prerequisites=tuple(str(p) for p in raw.get("prerequisites", []) or ()),
+        effect=dict(effect) if isinstance(effect, dict) else {},
     )
 
 

--- a/docs/btd6/btd6-gamedata-decode-status.md
+++ b/docs/btd6/btd6-gamedata-decode-status.md
@@ -51,8 +51,12 @@ works** (the traps we hit), and what is still un-decoded.
   **Monkey Knowledge** 134, **Geraldo items** 16 (`--powers` / `--knowledge` /
   `--geraldo`). All player-facing name/description/cost catalogs, each behind an
   AI lookup tool. Powers additionally carry decoded effect factors + the
-  `btd6_power_effect` apply-tool (attack-speed-on-a-boost). Geraldo items carry
-  cash cost, Geraldo unlock level, and stock/replenish cadence.
+  `btd6_power_effect` apply-tool (attack-speed-on-a-boost). **Monkey Knowledge now
+  carries dump-native structured `effect` factors** (119/134) decoded from
+  `mod.mutatorMods[]` — More Cash `+200` starting cash, Bonus Monkey free Dart
+  Monkey, etc. (corrected the earlier "not in the dump" finding; see the MK
+  session log). Geraldo items carry cash cost, Geraldo unlock level, and
+  stock/replenish cadence.
 - **Mapper** (`scripts/parse_gamedata.py`): faithful — `--audit` is
   **nothing-SUSPECT**, anchors pass. Decodes attacks/projectiles/sub-projectiles,
   **subtowers** (2 of 4 mechanisms), **zones** (top-level, started), **buffs**
@@ -278,6 +282,37 @@ Tactics "stacks up to 20", Trade Empire "up to 20 Merchantmen", sellback "3").
 - **Honest scope:** parser-side only; no new decoded effect, no committed-data change. It makes
   the cutover path reproduce what the committed data + renderer already surface.
 
+### Session log — 2026-06-08 (Monkey Knowledge magnitudes — they WERE in the dump)
+
+The maintainer pushed back on the prior "MK magnitudes aren't in the dump" verdict — *"it has
+to be there, it's a very important part of the game."* He was right. Re-cloned the v55 dump and
+opened an actual `Knowledge/*.json`: the magnitude is in **`mod.mutatorMods[]`**, a layer the
+earlier check never descended into (it read `mod.name`, saw `ModModel`, and stopped).
+
+- **Evidence (full-roster survey of all 134):** **120** carry flat scalar magnitudes, **13** are
+  nested-only behavioural (Cold Front, Tiny Tornadoes, Wingmonkey, Vine Rupture, …), **1** empty
+  (Grand Prix Spree). Headline confirmations, each matching its committed description exactly:
+  More Cash `StartingCash{addition 200}`, Bonus Monkey/Glue Gunner `FreeTower{baseTowerID, charges 1}`,
+  Charged Chinooks `Lives{percentBonus 0.25}`+`Cash{percentBonus 0.25}`, Mo' Monkey Money
+  `MonkeyMoney{multiplier 1.1}`, Big Bloon Sabotage `BloonHealth{percentageHealthReduced 0.1}`,
+  Mana Shield `StartingShield{25/25/+5}`, Hero Favors/Scholarships 10% off, Supa-Thrive `Thrive{+0.05}`.
+- **Extraction (`parse_gamedata._mk_effect`):** a **faithful structural passthrough** of each
+  mutator's own fields → `effect = {"factors": [{"kind": <snake type>, <numbers>}, ...]}`. No
+  semantic transform that could be wrong (same discipline as the buff decode); internal/display
+  ids dropped, identity no-ops (`0`) and the unlimited-`charges` sentinel dropped. Behavioural /
+  empty → `effect == {}` (description-only), never fabricated. `monkey_knowledge.json` regenerated
+  (verified **0 non-effect churn** — only `effect` added to 119 rows).
+- **Runtime:** `MonkeyKnowledgeEntry.effect` + surfaced on `btd6_monkey_knowledge_lookup`. So
+  "how much cash does More Cash add / what does Bonus Monkey give / how big is the Hero Favors
+  discount" now answer with the exact dump number.
+- **Tests:** parser (`_mk_effect` scalar/multi-factor/noise-drop/behavioural-empty + the existing
+  category test extended), data_service (More Cash effect loads, ≥110 carry a magnitude), ai_tools
+  (lookup surfaces the effect). `check_quality.py --full` green.
+- **Binding lesson (recorded in the correction above):** **descend into nested `*Mods[]` /
+  `behaviors[]` arrays before declaring data absent.** The dump nests effects one level below the
+  obvious model; "bare reference" was an artefact of not opening the array. Trust the domain
+  knowledge that says a core mechanic "has to be there."
+
 ### ⚠ Answerability audit — Powers/Knowledge are *lookup catalogs*, not *applied modifiers* (2026-06-08)
 
 Asked the sharp question: can the bot answer **"what is the attack speed of Crossbow Master
@@ -293,7 +328,21 @@ is exactly where the line falls, so the next session doesn't rediscover it:
 | "List the magic monkey knowledge / 50-MM powers" | ✅ | category/roster filters |
 | "What's Monkey Boost's exact effect factor?" | ✅ | now structured: `rate_scale 0.5` for `15s` (2026-06-08) |
 | **"…attack speed of Crossbow Master *on a Monkey Boost*"** (as a number) | ✅ | `btd6_power_effect` applies the factor to the resolved tier stat (2026-06-08, step 2 DONE) |
-| **"…starting cash / upgrade cost / free monkeys / lives *with knowledge X*"** | ❌ | **no layer applies an MK effect to the economy** |
+| **"…what's the *magnitude* of knowledge X (starting cash / free monkeys / lives / discount)"** | ✅ | **dump-native structured `effect` on `btd6_monkey_knowledge_lookup` (2026-06-08, see correction below)** |
+| **"…starting cash / upgrade cost *with knowledge X*, computed against the economy"** | ❌ | the *magnitude* is now structured, but no layer yet **applies** it (no `btd6_*_effect` apply-tool for MK) |
+
+> **⛔ CORRECTION (2026-06-08) — root-cause point 2 below was WRONG.** "MK magnitudes are NOT in
+> the dump / hardcoded game logic / every `mod` is a bare `ModModel{name}` (134/134)" is **false**.
+> The earlier check stopped at `mod.name` and never opened **`mod.mutatorMods[]`**, where every
+> magnitude lives as a *typed* mutator model: More Cash → `StartingCashModModel{addition 200}`,
+> Bonus Monkey → `FreeTowerModModel{baseTowerID DartMonkey, charges 1}`, Mo' Monkey Money →
+> `MonkeyMoneyModModel{multiplier 1.1}`, Charged Chinooks → `LivesModModel{percentBonus 0.25}` +
+> `CashModModel{percentBonus 0.25}`. **120 of 134 carry flat scalar magnitudes; 13 are nested-only
+> behavioural (Cold Front, Tiny Tornadoes, …); 1 empty (Grand Prix Spree).** Every spot-checked
+> value matches its committed description exactly. Now extracted as a structured `effect`
+> (`{"factors": [...]}`) on each MK row + `btd6_monkey_knowledge_lookup`. **Lesson (binding):
+> descend into nested `*Mods[]`/`behaviors[]` arrays before declaring data absent — the
+> maintainer's "it has to be there" was right.** See the session log "Monkey Knowledge magnitudes".
 
 **Root cause — two missing things, not one:**
 
@@ -304,12 +353,12 @@ is exactly where the line falls, so the next session doesn't rediscover it:
    `0.2375 × 0.5 = 0.119 s` needs a **deterministic apply-tool** (the structured factor × the
    resolved base stat, grounded by construction — the exact `btd6_cumulative_cost` pattern), or
    the faithfulness verifier rejects the derived number as ungrounded.
-2. **Monkey Knowledge effect magnitudes are NOT in the dump.** Every MK `mod` is a bare
-   `ModModel{name}` (134/134) — a named reference whose magnitude (`+X starting cash`,
-   `-Y% cost`, `+1 free Glue Gunner`, `+Z lives`) is **hardcoded game logic**, the same class as
-   mode rules and cash-per-pop. The description prose ("Thrive adds 30% instead of 25%") is the
-   *only* captured form; many are qualitative ("Acid lasts longer"). So MK "apply" can't be
-   sourced from the dump — it needs curated constants or a wiki cross-source.
+2. ~~**Monkey Knowledge effect magnitudes are NOT in the dump.**~~ **FALSE — corrected above.**
+   The magnitudes *are* dump-native, in `mod.mutatorMods[]`, now extracted as structured
+   `effect` factors. (The *prose* is still the only form for the ~13 purely behavioural ones —
+   those legitimately have no scalar magnitude, e.g. "Acid lasts longer".) The remaining gap is
+   only the **apply** step — turning "free Glue Gunner / +$200 cash / -10% hero cost" into a
+   computed economy number — which, like Powers, needs a deterministic apply-tool, not new data.
 
 **Suggested next steps (ordered, for the following session):**
 
@@ -336,12 +385,23 @@ is exactly where the line falls, so the next session doesn't rediscover it:
    resolution was de-duplicated into `btd6_data_service.find_power` (shared by the lookup +
    effect tools). "Crossbow Master on Monkey Boost" now answers **8.42 attacks/sec for 15 s
    (vs 4.21 base)**.
-3. **Monkey Knowledge magnitudes — maintainer call.** Not dump-sourced. Either (a) leave MK as a
-   descriptive catalog (current state — honest, "what it does" answers but no computed economy), or
-   (b) curate the numeric magnitudes (starting cash/lives/discounts) from the wiki into
-   `monkey_knowledge.json` like the map removables. Don't guess; ask before curating.
-4. **Until 1–2 land, the lookup is correct but partial** — it answers "what does X do" and base
-   stats independently; it must NOT be presented as answering combined/applied questions.
+3. **Monkey Knowledge magnitudes — ✅ DONE (2026-06-08), dump-native (NOT curated/maintainer call).**
+   The earlier "not dump-sourced, maintainer call" verdict was wrong (see the correction above):
+   the magnitudes live in `mod.mutatorMods[]`. `parse_gamedata._mk_effect` now decodes them into a
+   structured `effect` (`{"factors": [{"kind": ..., <numbers>}]}`) — a faithful structural
+   passthrough of the dump's own mutator fields (snake-cased, identity no-ops dropped; no semantic
+   transform), the same discipline as the buff decode. Surfaced on `MonkeyKnowledgeEntry.effect` +
+   `btd6_monkey_knowledge_lookup`. 119/134 carry a magnitude; the rest are behavioural (description
+   -only). So "what does Bonus Monkey give / how much cash does More Cash add / how big is the Hero
+   Favors discount" now answer with the exact number.
+   - **Possible follow-ups (not blocking):** (a) a clean *curated relabel* of the long-tail field
+     names (the passthrough keeps the dump's own keys, incl. misspellings like `addative`); (b) an
+     **MK apply-tool** (`btd6_*_effect`) that computes the economy (e.g. "+$200 starting cash" →
+     resulting first-tower affordability), the MK analogue of `btd6_power_effect` — that's the only
+     remaining ❌ in the table above.
+4. **The lookup now answers MK *magnitudes* directly**; the only still-partial case is a *computed*
+   economy ("what's my starting cash *after* More Cash + difficulty"), which needs the apply-tool
+   in 3(b). "What does X do / how much does X give" is fully answerable.
 
 ### Session log — 2026-06-08 (Bloons children + immunity cut over to game data)
 

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -1994,6 +1994,85 @@ def map_powers(dump: Path, version: str) -> tuple[list[dict], list[str]]:
 # rather than decode the opaque integer ``category`` field.
 _MK_CATEGORIES = ("Primary", "Military", "Magic", "Support", "Heroes", "Powers")
 
+# Internal / display / id fields on a Monkey Knowledge mutator model that carry
+# no gameplay magnitude — dropped from the structured effect so only the real
+# numbers and targets surface. (Buff-icon loc keys, internal mutation ids, the
+# mutually-exclusive pairing hint, display lifetimes, etc.)
+_MK_MOD_NOISE_FIELDS: frozenset[str] = frozenset(
+    {
+        "name",
+        "buffLocsName",
+        "buffIconName",
+        "buffLocsNameRate",
+        "buffIconNameRate",
+        "buffLocsNamePrice",
+        "buffIconNamePrice",
+        "mutationId",
+        "slowId",
+        "mutuallyExclusiveWith",
+        "priority",
+        "towerSelectionMenuThemeId",
+        "specificScriptId",
+        "id",
+        "displayLifetime",
+        "displayLifespan",
+        "Lifespan",
+        "lifespanFrames",
+    },
+)
+# A ``charges`` value at/above this is the game's "unlimited" sentinel
+# (999999 / 9999999) — a one-shot knowledge uses a small count (e.g. 1), so we
+# surface only the meaningful small values and drop the sentinel.
+_MK_CHARGES_SENTINEL = 100_000
+
+
+def _mk_effect(raw: dict[str, Any]) -> dict[str, Any]:
+    """Structured, dump-native effect for a Monkey Knowledge point.
+
+    The magnitude lives in ``mod.mutatorMods[]`` — each entry is a *typed* mutator
+    model carrying the real numbers (``StartingCashModModel`` ``addition 200``,
+    ``FreeTowerModModel`` ``baseTowerID DartMonkey`` ``charges 1``,
+    ``MonkeyMoneyModModel`` ``multiplier 1.1``, …). This is a **faithful
+    structural passthrough** — the dump's own field names + values, snake-cased,
+    with no semantic transform that could be wrong (the same discipline the buff
+    decode uses). The model states the exact factor grounded by both the number
+    and the game-authored description.
+
+    Returns ``{"factors": [...]}`` with one factor per mutator that carries a
+    gameplay magnitude. A knowledge whose effect is purely behavioural — a nested
+    projectile / ability sub-model (Cold Front, Tiny Tornadoes, Wingmonkey, Vine
+    Rupture, …) — or that has no mutator (Grand Prix Spree) yields no factor and
+    stays description-only (``{}``), never a fabricated value.
+    """
+    mod = raw.get("mod")
+    if not isinstance(mod, dict):
+        return {}
+    factors: list[dict[str, Any]] = []
+    for mut in mod.get("mutatorMods", []) or []:
+        if not isinstance(mut, dict):
+            continue
+        short = _short_type(mut)
+        base = short[: -len("ModModel")] if short.endswith("ModModel") else short
+        fields: dict[str, Any] = {}
+        for key, value in mut.items():
+            if key == "$type" or key in _MK_MOD_NOISE_FIELDS:
+                continue
+            if isinstance(value, (dict, list)):
+                continue  # nested sub-model (projectile / ability) — not a scalar
+            if isinstance(value, bool):
+                fields[_snake(key)] = value
+            elif isinstance(value, (int, float)):
+                if key == "charges" and value >= _MK_CHARGES_SENTINEL:
+                    continue
+                if value == 0:
+                    continue  # additive identity / disabled flag — a no-op, drop
+                fields[_snake(key)] = _num(value)
+            elif isinstance(value, str) and value:
+                fields[_snake(key)] = value
+        if fields:
+            factors.append({"kind": _snake(base), **fields})
+    return {"factors": factors} if factors else {}
+
 
 def map_monkey_knowledge(dump: Path, version: str) -> tuple[list[dict], list[str]]:
     """Every Monkey Knowledge point → catalog rows (id, name, category,
@@ -2029,17 +2108,19 @@ def map_monkey_knowledge(dump: Path, version: str) -> tuple[list[dict], list[str
             prereqs = [
                 _snake(str(p)) for p in raw.get("prerequisiteIds", []) or [] if p
             ]
-            rows.append(
-                {
-                    "id": kid,
-                    "canonical": name,
-                    "category": category,
-                    "description": _clean_desc(tt.get(f"{internal}Description", "")),
-                    "monkey_money_cost": _num(raw.get("monkeyMoneyCost", 0)),
-                    "investment_required": _num(raw.get("investmentRequired", 0)),
-                    "prerequisites": prereqs,
-                },
-            )
+            row = {
+                "id": kid,
+                "canonical": name,
+                "category": category,
+                "description": _clean_desc(tt.get(f"{internal}Description", "")),
+                "monkey_money_cost": _num(raw.get("monkeyMoneyCost", 0)),
+                "investment_required": _num(raw.get("investmentRequired", 0)),
+                "prerequisites": prereqs,
+            }
+            effect = _mk_effect(raw)
+            if effect:
+                row["effect"] = effect
+            rows.append(row)
     rows.sort(key=lambda k: (_MK_CATEGORIES.index(k["category"]), k["id"]))
     return rows, warnings
 

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -619,6 +619,12 @@ def test_map_monkey_knowledge_uses_category_folder(mod, tmp_path):
             "monkeyMoneyCost": 250,
             "investmentRequired": 8,
             "prerequisiteIds": ["SomePrereq"],
+            "mod": {
+                "mutatorMods": [
+                    {"$type": _t("AcidPoolModModel"), "additionalTime": 5.0},
+                ],
+                "name": "AcidStability",
+            },
         },
     )
     _write(
@@ -638,6 +644,98 @@ def test_map_monkey_knowledge_uses_category_folder(mod, tmp_path):
     assert row["monkey_money_cost"] == 250
     assert row["investment_required"] == 8
     assert row["prerequisites"] == ["some_prereq"]
+    # AcidStability's effect (AcidPool additionalTime 5) decodes into a factor.
+    assert row["effect"] == {"factors": [{"kind": "acid_pool", "additional_time": 5}]}
+
+
+def _mk_mod(*mutators: dict) -> dict:
+    """A KnowledgeModel ``mod`` wrapping the given mutator models."""
+    return {"mutatorMods": [dict(m) for m in mutators], "name": "X"}
+
+
+def test_mk_effect_decodes_scalar_magnitude_and_drops_identity_noise(mod):
+    # More Cash: StartingCashModModel addition 200 is the real magnitude;
+    # changeBase 0.0 (additive identity) is dropped, multiplier 1.0 kept (non-zero).
+    raw = {
+        "mod": _mk_mod(
+            {
+                "$type": _t("StartingCashModModel"),
+                "changeBase": 0.0,
+                "addition": 200.0,
+                "multiplier": 1.0,
+                "name": "MoreCash",
+            },
+        ),
+    }
+    assert mod._mk_effect(raw) == {
+        "factors": [{"kind": "starting_cash", "addition": 200, "multiplier": 1}],
+    }
+
+
+def test_mk_effect_multiple_mutators_become_multiple_factors(mod):
+    # Charged Chinooks stacks two mutators (Lives + Cash) → two factors.
+    raw = {
+        "mod": _mk_mod(
+            {"$type": _t("LivesModModel"), "percentBonus": 0.25},
+            {"$type": _t("CashModModel"), "percentBonus": 0.25, "bonusMultiplierBuff": 0.0},
+        ),
+    }
+    assert mod._mk_effect(raw) == {
+        "factors": [
+            {"kind": "lives", "percent_bonus": 0.25},
+            {"kind": "cash", "percent_bonus": 0.25},  # bonusMultiplierBuff 0 dropped
+        ],
+    }
+
+
+def test_mk_effect_keeps_targets_drops_internal_noise_and_charge_sentinel(mod):
+    # Free-tower / discount mutators: string targets + a small charge count are
+    # real; the unlimited-charge sentinel + pairing/priority hints are dropped.
+    raw = {
+        "mod": _mk_mod(
+            {
+                "$type": _t("FreeTowerModModel"),
+                "baseTowerID": "DartMonkey",
+                "charges": 1,
+                "mutuallyExclusiveWith": "GlueGunner",
+                "priority": -1,
+                "name": "BonusMonkey",
+            },
+            {
+                "$type": _t("SimTowerDiscountModModel"),
+                "tower": "BananaFarm",
+                "useAllHeroes": False,
+                "multiplier": 0.0,
+                "subtraction": 100.0,
+                "charges": 9999999,
+            },
+        ),
+    }
+    assert mod._mk_effect(raw) == {
+        "factors": [
+            {"kind": "free_tower", "base_tower_id": "DartMonkey", "charges": 1},
+            {
+                "kind": "sim_tower_discount",
+                "tower": "BananaFarm",
+                "use_all_heroes": False,
+                "subtraction": 100,
+            },
+        ],
+    }
+
+
+def test_mk_effect_behavioural_or_empty_stays_description_only(mod):
+    # A mutator whose only payload is a nested sub-model (a projectile/ability —
+    # Cold Front, Tiny Tornadoes) carries no scalar magnitude → no factor.
+    nested = {
+        "mod": _mk_mod(
+            {"$type": _t("ColdFrontModModel"), "freeze": {"$type": "X", "layers": 4}},
+        ),
+    }
+    assert mod._mk_effect(nested) == {}
+    # No mutators at all (Grand Prix Spree) → description-only.
+    assert mod._mk_effect({"mod": _mk_mod()}) == {}
+    assert mod._mk_effect({}) == {}
 
 
 def test_validate_anchors(mod, tmp_path):

--- a/tests/unit/services/test_ai_tools.py
+++ b/tests/unit/services/test_ai_tools.py
@@ -770,6 +770,11 @@ async def test_btd6_monkey_knowledge_lookup_single_category_and_roster():
     h = build_registry(scope=AIScope.USER, guild_id=1, actor_id=2).handlers
     one = await h["btd6_monkey_knowledge_lookup"]({"knowledge": "Supa-Thrive"})
     assert one["found"] is True and one["knowledge"]["description"]
+    # The dump-native structured magnitude is surfaced on the lookup payload.
+    cash = await h["btd6_monkey_knowledge_lookup"]({"knowledge": "More Cash"})
+    assert cash["knowledge"]["effect"] == {
+        "factors": [{"kind": "starting_cash", "addition": 200, "multiplier": 1}],
+    }
     magic = await h["btd6_monkey_knowledge_lookup"]({"category": "Magic"})
     assert magic["found"] is True and magic["count"] >= 1
     assert all(k["category"] == "Magic" for k in magic["knowledge"])

--- a/tests/unit/services/test_btd6_data_service.py
+++ b/tests/unit/services/test_btd6_data_service.py
@@ -85,6 +85,15 @@ def test_powers_and_monkey_knowledge_load_and_resolve():
     assert mk is not None
     assert mk.category in {"Primary", "Military", "Magic", "Support", "Heroes", "Powers"}
     assert mk.monkey_money_cost >= 0 and mk.investment_required >= 0
+    # The dump-native structured effect is loaded: More Cash = +$200 starting cash.
+    more_cash = get_monkey_knowledge("more_cash")
+    assert more_cash is not None
+    assert more_cash.effect == {
+        "factors": [{"kind": "starting_cash", "addition": 200, "multiplier": 1}],
+    }
+    # The overwhelming majority carry a magnitude; only behavioural ones are bare.
+    with_effect = [k for k in dataset.monkey_knowledge if k.effect]
+    assert len(with_effect) >= 110
     # Every MK category folder is represented.
     cats = {k.category for k in dataset.monkey_knowledge}
     assert {"Primary", "Military", "Magic", "Support", "Heroes", "Powers"} <= cats


### PR DESCRIPTION
## The finding (corrects a prior verdict)

A previous session concluded **"Monkey Knowledge effect magnitudes are NOT in the dump — every `mod` is a bare `ModModel{name}` (134/134), hardcoded game logic."** The maintainer pushed back ("it's a very important part of the game, it has to be there"). **He was right.**

The magnitudes live one level below where the earlier check stopped — in **`mod.mutatorMods[]`**, a typed mutator model per effect:

| Knowledge | dump model | magnitude |
|---|---|---|
| More Cash | `StartingCashModModel` | `addition 200` (+$200 starting cash) |
| Bonus Monkey | `FreeTowerModModel` | `baseTowerID DartMonkey, charges 1` |
| Mo' Monkey Money | `MonkeyMoneyModModel` | `multiplier 1.1` (+10%) |
| Charged Chinooks | `LivesModModel` + `CashModModel` | `percentBonus 0.25` ×2 |
| Big Bloon Sabotage | `BloonHealthModModel` | `percentageHealthReduced 0.1` |
| Hero Favors / Scholarships | `SimTowerDiscount` / `HeroCostToLevel` | 10% off |

Full-roster survey of all 134: **120 carry flat scalar magnitudes, 13 are nested-only behavioural** (Cold Front, Tiny Tornadoes, Wingmonkey…), **1 empty** (Grand Prix Spree). Every spot-checked value matches its committed description **exactly**.

## What this does

`parse_gamedata._mk_effect` decodes the mutators into a structured `effect`:
```json
{"factors": [{"kind": "starting_cash", "addition": 200, "multiplier": 1}]}
```
A **faithful structural passthrough** of the dump's own mutator fields — snake-cased; internal/display ids, identity no-ops (`0`), and the unlimited-`charges` sentinel dropped; **no semantic transform that could be wrong** (same discipline as the buff decode). Behavioural / empty → `effect == {}` (description-only), never fabricated.

Surfaced on `MonkeyKnowledgeEntry.effect` + `btd6_monkey_knowledge_lookup`, so *"how much cash does More Cash add / what does Bonus Monkey give / how big is the Hero Favors discount"* now answer with the exact dump number. `monkey_knowledge.json` regenerated — **0 non-effect churn**, `effect` added to 119/134 rows.

## Honest scope

This makes the *magnitude* answerable (the same level as Powers/Geraldo `effect`). It does **not** yet *apply* the effect to a computed economy (e.g. starting cash after More Cash + difficulty) — that needs an MK apply-tool, the analogue of `btd6_power_effect`, flagged as a follow-up in the ledger.

## Docs / lesson

Corrected the false claim in `btd6-gamedata-decode-status.md` (answerability audit + next-steps), with the **binding lesson recorded: descend into nested `*Mods[]` / `behaviors[]` arrays before declaring data absent.**

## Tests

Parser (`_mk_effect`: scalar / multi-factor / noise-drop / behavioural-empty), data_service (effect loads, ≥110 carry a magnitude), ai_tools (lookup surfaces it). `python3.10 scripts/check_quality.py --full` green (8161 passed); `check_architecture --mode strict` 0 errors.

https://claude.ai/code/session_01UZCi9DFBDQHPZfMwr1xQ3h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZCi9DFBDQHPZfMwr1xQ3h)_