### PR TITLE
btd6: ingest Boss Bloons as a game-data-native lookup catalog

### DIFF
--- a/.sessions/2026-06-08-btd6-not-in-dump-reaudit-and-bosses.md
+++ b/.sessions/2026-06-08-btd6-not-in-dump-reaudit-and-bosses.md
@@ -1,0 +1,49 @@
+# 2026-06-08 — BTD6 "not in the dump" re-audit + Boss Bloons ingest
+
+Four PRs this session, all on the BTD6 data-mapping plan. Theme that emerged:
+**prior "not in the dump / hardcoded" verdicts were repeatedly wrong because a
+session read the top-level model and never opened the nested `mutatorMods[]` /
+`behaviors[]` array.** The maintainer's "it has to be there" instinct was right
+three times.
+
+## PRs
+- **#597 — buff stack cap parser-reproducible** (MERGED). `_buffs()` dropped the
+  stack cap; cutover path would lose "(stacks up to N)". Forward-looking fidelity fix.
+- **#598 — Monkey Knowledge effect magnitudes** (MERGED). The headline correction.
+  Magnitudes live in `mod.mutatorMods[]` (More Cash `StartingCash{addition 200}`,
+  Bonus Monkey `FreeTower{baseTowerID DartMonkey}`, …). `_mk_effect` faithful
+  passthrough → `effect.factors[]` on `btd6_monkey_knowledge_lookup`. 119/134 carry one.
+- **#599 — dump re-audit docs** (open). Swept all 18 domains, re-verified every
+  "not in dump" claim. Corrected: **mode rules** (Mods/ has the full set —
+  CHIMPS = `Clicks.json`!) and **per-pop cash** (`DistributeCashModel{cash:1.0}`).
+  Held: map removables, opaque theme enums, DDT cap. Recorded the missing-data backlog.
+- **#600 — Boss Bloons** (open). The biggest real gap. All 7 bosses (Bloonarius…
+  Diamondback) → `bosses.json` + `BossEntry` + `btd6_boss_lookup`. Per-tier
+  health/speed, derived immunities, game-authored mechanic descriptions.
+
+## Durable facts learned (for next session)
+- **`--overlay` only refreshes `{range, footprintRadius}`** — never `buffs[]`. Committed
+  buffs are a fuller/older extraction; the lean `_buffs()` is the *cutover* path.
+- **Dump nests effects one level down.** Knowledge: `mod.mutatorMods[]`. Game modes:
+  `Mods/<mode>.json` top-level `mutatorMods[]` (file IS the ModModel). Bloons: `behaviors[]`
+  (DistributeCashModel). Bosses: `Bloons/<Boss>/<Boss>{1..5}.json`. Always descend +
+  run `explore_gamedata.py --search <Model> --struct` before declaring data absent.
+- **Bloons/ is dir-per-family** (`Bloons/Bad/Bad.json`, variants alongside), NOT flat.
+  A `glob('Bloons/*.json')` matches nothing — use `Bloons/*/*.json`.
+- **Boss roster = `Bosses/` folder** (7, incl. Diamondback). `BossData.LocsKey` → textTable
+  name/`<key>InfoPanelDescription`/`<key>TagLine{,2}`. Phayze `isCamo` is **False**
+  (camo is a runtime Reality-Shield) — don't derive a camo flag from it.
+- **Still-missing backlog** (in dump, not fetched): mode-rules cutover (Mods/),
+  alternate round sets (Rounds/ has many sets, we use default 140), Achievements (156),
+  Rogue Legends / Frontier (Artifacts/, rogueData.json, frontierData.json — niche).
+  `frontierData.json` is the **Wild-West Frontier** Legends mode (coverage map mislabels
+  it "Boss/Legends scaling").
+
+## Process notes
+- The git stash/branch-off-main dance worked cleanly for splitting independent batches
+  into separate PRs (MK off main, re-audit off main, bosses off main). Verify
+  `git diff origin/main --stat` is the expected file set before pushing.
+- `send_later` is NOT available this env; can't arm the hour-out PR check-in. A Monitor
+  can't reach GitHub (no `gh` CLI). Rely on the webhook subscription for CI-failure/review.
+- Bare `black .` includes `tests/` (out of CI scope) — trust `check_quality.py`. The
+  black↔ruff trailing-comma interaction on a wrapped call: extract a local var instead.

--- a/disbot/data/btd6/bosses.json
+++ b/disbot/data/btd6/bosses.json
@@ -1,0 +1,255 @@
+{
+  "data_version": "1.0",
+  "game_version": "55.1",
+  "source": "BTD Mod Helper game data export",
+  "bosses": [
+    {
+      "id": "blastapopoulos",
+      "canonical": "Blastapopoulos",
+      "tagline": "Shrouded in Suffocating Heat — Demon of the Core!",
+      "description": "Blastapopoulos has Purple Bloon properties, and Monkey Towers and Heroes suffer from reduced range and slower ability cooldowns during the fight. At each Skull Blastapopoulos heats up and spews out Fireballs and Pyroclastic Rocks. Fireballs will target Towers and Heroes with pools of magma that prevent selling and ability cooldowns, and reduce tower range and attack speed even more. Pyroclastic Rocks land in a circle, blocking line of sight until they expire. Most projectile hits heat up Blastapopoulos, with fire, plasma, and lasers increasing heat even more, so use those at your own risk! Or you could use some Ice attacks to cool Blastapopoulos down! When the heat bar is completely filled, Blastapopoulos explodes in rage, briefly stunning all Monkeys and increasing ability cooldowns. The leftover heat causes most projectiles to burn up faster than normal. Blastapopoulos passively burns off Sticky Bomb and other damaging effects applied to them, reducing the length of damage over time.",
+      "immune_to": [
+        "Energy",
+        "Fire",
+        "Frigid",
+        "Plasma"
+      ],
+      "tiers": [
+        {
+          "tier": 1,
+          "health": 17500,
+          "speed": 1
+        },
+        {
+          "tier": 2,
+          "health": 65000,
+          "speed": 1.05
+        },
+        {
+          "tier": 3,
+          "health": 300000,
+          "speed": 1.1
+        },
+        {
+          "tier": 4,
+          "health": 650000,
+          "speed": 1.15
+        },
+        {
+          "tier": 5,
+          "health": 3000000,
+          "speed": 1.25
+        }
+      ]
+    },
+    {
+      "id": "bloonarius",
+      "canonical": "Bloonarius",
+      "tagline": "From the Swampy Depths — The Inflator Awakens!",
+      "description": "Sludge-dwelling Bloonarius spews Bloons as it takes damage. When each skull on its health bar is reached, Bloonarius disgorges massive Bloon clusters onto the track. Bloonarius' sludge infused husk makes it slow but extremely tough.",
+      "immune_to": [],
+      "tiers": [
+        {
+          "tier": 1,
+          "health": 20000,
+          "speed": 1.25
+        },
+        {
+          "tier": 2,
+          "health": 75000,
+          "speed": 1.25
+        },
+        {
+          "tier": 3,
+          "health": 350000,
+          "speed": 1.25
+        },
+        {
+          "tier": 4,
+          "health": 750000,
+          "speed": 1.5
+        },
+        {
+          "tier": 5,
+          "health": 3000000,
+          "speed": 1.5
+        }
+      ]
+    },
+    {
+      "id": "diamondback",
+      "canonical": "Diamondback",
+      "tagline": "Snaking Through the Ground — The Village Devourer!",
+      "description": "Diamondback has multiple segments and regularly spits Bloons forwards on the track. Diamondback's head blocks projectiles from piercing through to its body. The Rattle Tail is shielded from damage, break through the shield to stun and debuff Diamondback temporarily! Diamondback releases Diamond Bloons that only take 1 damage at a time. When each skull is reached, Diamondback sheds a middle segment, spawns many Bloons and regenerates the Rattle Tail shield.",
+      "immune_to": [],
+      "tiers": [
+        {
+          "tier": 1,
+          "health": 20000,
+          "speed": 2
+        },
+        {
+          "tier": 2,
+          "health": 95000,
+          "speed": 2
+        },
+        {
+          "tier": 3,
+          "health": 444000,
+          "speed": 2
+        },
+        {
+          "tier": 4,
+          "health": 900000,
+          "speed": 2
+        },
+        {
+          "tier": 5,
+          "health": 3800000,
+          "speed": 2
+        }
+      ]
+    },
+    {
+      "id": "dreadbloon",
+      "canonical": "Dreadbloon",
+      "tagline": "From Deep Within the Dark Earth... — the Armored Behemoth!",
+      "description": "Dreadbloon has Lead properties and reduces all incoming damage by 1. When each skull is reached, Dreadbloon grows a Ceramic Armor Shell and Dreadrock Bloons will begin spawning at the start of the track. When Dreadbloon appears, it is immune to Primary towers. At each skull, this immunity changes to a different tower type: Military, Magic, Support. Dreadrock Bloons and the Ceramic Armor Shell also have these immunities. Dreadrock Bloons have a Strong taunt, be careful what your towers are targeting!",
+      "immune_to": [
+        "Cold",
+        "Energy",
+        "Sharp",
+        "Shatter"
+      ],
+      "tiers": [
+        {
+          "tier": 1,
+          "health": 7500,
+          "speed": 1.25
+        },
+        {
+          "tier": 2,
+          "health": 25000,
+          "speed": 1.3
+        },
+        {
+          "tier": 3,
+          "health": 120000,
+          "speed": 1.4
+        },
+        {
+          "tier": 4,
+          "health": 260000,
+          "speed": 1.5
+        },
+        {
+          "tier": 5,
+          "health": 1000000,
+          "speed": 1.6
+        }
+      ]
+    },
+    {
+      "id": "lych",
+      "canonical": "Lych",
+      "tagline": "The Gravelord — has been Resurrected!",
+      "description": "Gravelord Lych drains buffs from your Monkeys and has regenerative properties. Lych regularly summons Bloon Tombs which summon MOAB-class Bloons. Destroy them asap! When each skull on its health bar is reached, Lych goes ethereal and Lych souls are summoned. When ethereal, Lych cannot be damaged until all Lych souls have been popped. Zombie MOAB-class Bloons do not spawn children. While Lych is on the map, sellback value of all Monkeys is reduced significantly.",
+      "immune_to": [],
+      "tiers": [
+        {
+          "tier": 1,
+          "health": 14000,
+          "speed": 2
+        },
+        {
+          "tier": 2,
+          "health": 52500,
+          "speed": 2.05
+        },
+        {
+          "tier": 3,
+          "health": 220000,
+          "speed": 2.1
+        },
+        {
+          "tier": 4,
+          "health": 525000,
+          "speed": 2.15
+        },
+        {
+          "tier": 5,
+          "health": 2100000,
+          "speed": 2.2
+        }
+      ]
+    },
+    {
+      "id": "phayze",
+      "canonical": "Phayze",
+      "tagline": "The Reality Warper — Invades from the Chaos Rift!",
+      "description": "Phayze has the Camo property and a Reality Shield that increases its speed while the Shield is active. When each skull is reached, Phayze rebuilds the Reality Shield and warps forward, opening a tear in the fabric of reality allowing Bloons to spawn further along the track. Skulls also trigger a slow aura around Phayze, reducing the attack speed of all Monkey Towers. Phayze triggers Radar Jam every 24 seconds, disabling Camo-seeing buffs as well as restoring its Camo property if it has been stripped. Radar Jam also pulls Bloons to Phayze's location and grants them the Camo property.",
+      "immune_to": [],
+      "tiers": [
+        {
+          "tier": 1,
+          "health": 9500,
+          "speed": 0.8
+        },
+        {
+          "tier": 2,
+          "health": 35000,
+          "speed": 0.8
+        },
+        {
+          "tier": 3,
+          "health": 160000,
+          "speed": 0.8
+        },
+        {
+          "tier": 4,
+          "health": 350000,
+          "speed": 0.8
+        },
+        {
+          "tier": 5,
+          "health": 1450000,
+          "speed": 0.8
+        }
+      ]
+    },
+    {
+      "id": "vortex",
+      "canonical": "Vortex",
+      "tagline": "From the skies comes — Deadly Master of Air",
+      "description": "Vortex moves like lightning and speeds other Bloons along! When each health bar skull is reached, Vortex shields itself and sends out a shockwave that stuns nearby Towers before retreating up the track. Vortex emits a regular storm pulse, destroying projectiles, including any non-Powers on the track.",
+      "immune_to": [],
+      "tiers": [
+        {
+          "tier": 1,
+          "health": 20000,
+          "speed": 3.6
+        },
+        {
+          "tier": 2,
+          "health": 62800,
+          "speed": 3.6
+        },
+        {
+          "tier": 3,
+          "health": 294000,
+          "speed": 3.9
+        },
+        {
+          "tier": 4,
+          "health": 628000,
+          "speed": 4.05
+        },
+        {
+          "tier": 5,
+          "health": 2512500,
+          "speed": 4.2
+        }
+      ]
+    }
+  ]
+}

--- a/disbot/services/ai_tools.py
+++ b/disbot/services/ai_tools.py
@@ -1242,6 +1242,66 @@ async def _btd6_geraldo_lookup(arguments: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+# --- btd6_boss_lookup --------------------------------------------------------
+
+_BTD6_BOSS_SPEC = AIToolSpec(
+    name="btd6_boss_lookup",
+    description=(
+        "BTD6 Boss Bloon info (Bloonarius, Lych, Vortex, Dreadbloon, "
+        "Blastapopoulos, Phayze, Diamondback): each boss's game-authored mechanic "
+        "description, its damage-type immunities, and the per-tier health + speed "
+        "for all five boss tiers (health scales up sharply by tier; co-op "
+        "multiplies it further). Pass a boss name to look one up, or omit it to "
+        "list every boss. Use for 'how much health does a tier 3 Bloonarius have', "
+        "'what is Dreadbloon immune to', 'how fast is Vortex', 'what does Lych do', "
+        "'list the bosses'."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "boss": {
+                "type": "string",
+                "description": "Boss name (e.g. 'Bloonarius'); omit to list all.",
+            },
+        },
+        "additionalProperties": False,
+    },
+    min_scope=AIScope.USER,
+)
+
+
+def _boss_dict(entry: Any) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "name": entry.canonical,
+        "description": entry.description,
+        # Per-tier {tier, health, speed} for the five boss tiers — the headline
+        # grounded numbers (e.g. tier 3 Bloonarius = 350,000 health).
+        "tiers": [dict(t) for t in entry.tiers],
+    }
+    if entry.tagline:
+        out["tagline"] = entry.tagline
+    if entry.immune_to:
+        out["immune_to"] = list(entry.immune_to)
+    return out
+
+
+async def _btd6_boss_lookup(arguments: dict[str, Any]) -> dict[str, Any]:
+    from services import btd6_data_service
+
+    name = str(arguments.get("boss") or "").strip()
+    if name:
+        entry = btd6_data_service.find_boss(name)
+        if entry is None:
+            return {"found": False, "note": f"unknown boss: {name!r}"}
+        return {"found": True, "boss": _boss_dict(entry)}
+    bosses = btd6_data_service.get_dataset().bosses
+    return {
+        "found": True,
+        "count": len(bosses),
+        "bosses": [_boss_dict(b) for b in bosses],
+    }
+
+
 # --- btd6_bloon_filter -------------------------------------------------------
 
 _BTD6_BLOON_FILTER_SPEC = AIToolSpec(
@@ -1899,6 +1959,7 @@ BTD6_GROUNDING_TOOL_NAMES: frozenset[str] = frozenset(
         "btd6_power_lookup",
         "btd6_monkey_knowledge_lookup",
         "btd6_geraldo_lookup",
+        "btd6_boss_lookup",
         "btd6_bloon_filter",
         "btd6_cumulative_cost",
         "btd6_power_effect",
@@ -1958,6 +2019,7 @@ def build_registry(
         (_BTD6_POWER_LOOKUP_SPEC, _btd6_power_lookup),
         (_BTD6_MK_LOOKUP_SPEC, _btd6_monkey_knowledge_lookup),
         (_BTD6_GERALDO_SPEC, _btd6_geraldo_lookup),
+        (_BTD6_BOSS_SPEC, _btd6_boss_lookup),
         (_BTD6_BLOON_FILTER_SPEC, _btd6_bloon_filter),
         (_BTD6_CUMULATIVE_COST_SPEC, _btd6_cumulative_cost),
         (_BTD6_POWER_EFFECT_SPEC, _btd6_power_effect),

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -266,6 +266,25 @@ class GeraldoItemEntry:
 
 
 @dataclass(frozen=True)
+class BossEntry:
+    """One Boss Bloon (Bloonarius, Lych, Vortex, Dreadbloon, Blastapopoulos,
+    Phayze, Diamondback). Game-native: ``canonical`` and the mechanic
+    ``description`` are the game-authored strings; ``immune_to`` is the derived
+    damage-type immunity set (e.g. Dreadbloon = Lead, Blastapopoulos = Purple);
+    ``tiers`` carries the five boss tiers' ``{tier, health, speed}`` (both scale
+    up per tier — co-op multiplies health further at runtime). ``tagline`` is the
+    flavour line shown on the boss-select panel.
+    """
+
+    id: str
+    canonical: str
+    description: str
+    tiers: tuple[dict[str, Any], ...] = ()
+    tagline: str = ""
+    immune_to: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class BTD6DataSet:
     data_version: str
     game_version: str
@@ -280,6 +299,7 @@ class BTD6DataSet:
     powers: tuple[PowerEntry, ...] = ()
     monkey_knowledge: tuple[MonkeyKnowledgeEntry, ...] = ()
     geraldo_items: tuple[GeraldoItemEntry, ...] = ()
+    bosses: tuple[BossEntry, ...] = ()
 
 
 # ---------------------------------------------------------------------------
@@ -359,6 +379,7 @@ _MK_CATEGORIES = frozenset(
     {"Primary", "Military", "Magic", "Support", "Heroes", "Powers"},
 )
 _REQUIRED_GERALDO_FIELDS = ("id", "canonical", "cost", "unlock_level")
+_REQUIRED_BOSS_FIELDS = ("id", "canonical")
 
 
 def _require_keys(entry: dict[str, Any], keys: tuple[str, ...], where: str) -> None:
@@ -692,6 +713,27 @@ def _parse_knowledge(raw: dict[str, Any]) -> MonkeyKnowledgeEntry:
     )
 
 
+def _parse_boss(raw: dict[str, Any]) -> BossEntry:
+    _require_keys(raw, _REQUIRED_BOSS_FIELDS, where=f"boss {raw.get('id')!r}")
+    tiers = tuple(
+        {
+            "tier": int(t["tier"]),
+            "health": int(t["health"]),
+            "speed": float(t["speed"]),
+        }
+        for t in raw.get("tiers", []) or ()
+        if "tier" in t and "health" in t
+    )
+    return BossEntry(
+        id=str(raw["id"]),
+        canonical=str(raw["canonical"]),
+        description=str(raw.get("description", "")).strip(),
+        tiers=tiers,
+        tagline=str(raw.get("tagline", "")).strip(),
+        immune_to=tuple(str(x) for x in raw.get("immune_to", []) or ()),
+    )
+
+
 def _parse_geraldo_item(raw: dict[str, Any]) -> GeraldoItemEntry:
     _require_keys(raw, _REQUIRED_GERALDO_FIELDS, where=f"geraldo {raw.get('id')!r}")
     effect = raw.get("effect", {})
@@ -732,6 +774,7 @@ _OPTIONAL_FIXTURES = (
     "powers.json",
     "monkey_knowledge.json",
     "geraldo_items.json",
+    "bosses.json",
 )
 
 
@@ -917,6 +960,7 @@ def _load_dataset() -> BTD6DataSet:
     powers_raw = _load_file_optional("powers.json")
     knowledge_raw = _load_file_optional("monkey_knowledge.json")
     geraldo_raw = _load_file_optional("geraldo_items.json")
+    bosses_raw = _load_file_optional("bosses.json")
 
     towers = tuple(_parse_tower(t) for t in towers_raw.get("towers", []))
     heroes = tuple(_parse_hero(h) for h in heroes_raw.get("heroes", []))
@@ -948,6 +992,11 @@ def _load_dataset() -> BTD6DataSet:
         if geraldo_raw is not None
         else ()
     )
+    bosses = (
+        tuple(_parse_boss(b) for b in bosses_raw.get("bosses", []))
+        if bosses_raw is not None
+        else ()
+    )
 
     # Per-category canonical uniqueness.
     _check_unique([t.id for t in towers], where="towers.id")
@@ -973,6 +1022,8 @@ def _load_dataset() -> BTD6DataSet:
     )
     _check_unique([g.id for g in geraldo_items], where="geraldo_items.id")
     _check_unique([g.canonical for g in geraldo_items], where="geraldo_items.canonical")
+    _check_unique([b.id for b in bosses], where="bosses.id")
+    _check_unique([b.canonical for b in bosses], where="bosses.canonical")
 
     # Alias collision check across every category — the resolver depends
     # on aliases being globally unique.
@@ -1061,6 +1112,7 @@ def _load_dataset() -> BTD6DataSet:
         powers=powers,
         monkey_knowledge=monkey_knowledge,
         geraldo_items=geraldo_items,
+        bosses=bosses,
     )
 
 
@@ -1173,6 +1225,36 @@ def find_geraldo_item(name: str) -> GeraldoItemEntry | None:
     if exact:
         return exact[0]
     partial = [g for g in items if needle in g.canonical.lower()]
+    return partial[0] if len(partial) == 1 else None
+
+
+def get_boss(boss_id: str) -> BossEntry | None:
+    """A Boss Bloon by catalog id (case-insensitive)."""
+    needle = boss_id.strip().lower()
+    for boss in get_dataset().bosses:
+        if boss.id == needle:
+            return boss
+    return None
+
+
+def find_boss(name: str) -> BossEntry | None:
+    """Resolve a Boss Bloon by id / canonical name / unique partial.
+
+    Exact id or canonical match wins; otherwise a single case-insensitive
+    substring of a canonical name is accepted, and an ambiguous one returns
+    ``None`` (the same fuzzy contract as :func:`find_geraldo_item`).
+    """
+    direct = get_boss(name)
+    if direct is not None:
+        return direct
+    needle = (name or "").strip().lower()
+    if not needle:
+        return None
+    bosses = get_dataset().bosses
+    exact = [b for b in bosses if b.canonical.lower() == needle]
+    if exact:
+        return exact[0]
+    partial = [b for b in bosses if needle in b.canonical.lower()]
     return partial[0] if len(partial) == 1 else None
 
 

--- a/docs/btd6/btd6-dump-coverage-map.md
+++ b/docs/btd6/btd6-dump-coverage-map.md
@@ -15,7 +15,7 @@
 | `Artifacts/` | 568 | ⬜ | not ingested (Rogue Legends artifacts) |
 | `BloonOverlays/` | 46 | ⬜ | cosmetic overlays; not ingested |
 | `Bloons/` | 235 | 🟡 | children + immunity now game-data-sourced (--bloons); rbe/health/speed/category/aliases still wiki |
-| `Bosses/` | 7 | ⬜ | wiki-sourced; cosmetic Bosses/ — combat lives in Bloons/ |
+| `Bosses/` | 7 | ✅ | bosses.json: name, mechanic description, immunities, per-tier health/speed |
 | `Buffs/` | 91 | ⬜ | UI buff ICONS only — effects live inline in Towers/ |
 | `GeraldoItems/` | 16 | ✅ | all 16 shop items: name, description, cash cost, unlock level, quantity |
 | `IncomeSets/` | 7 | 🟡 | decay bands feed the per-round cash derivation |
@@ -61,7 +61,7 @@
 - **Model types:** `AudioClipReference`×2,053, `PrefabReference`×1,291, `Vector2`×510, `CollisionGroupModel+CollisionGroupData`×255, `DisplayModel`×245, `Vector3`×245, `BloonModel`×235, `SpriteReference`×235, `DistributeCashModel`×235, `PopEffectModel`×235, `DamageStateModel`×230, `ShowDamageTextModel`×215, `SpawnBloonsActionModel`×213, `PlayAnimTriggerActionModel`×201, `CreateSoundOnDamageBloonModel`×153, `EffectModel`×152, `BadImmunityModel`×135, `CollisionGroupModel`×126, `ApplyModModel`×107, `SpawnDeathAnimModel`×100
 - **Primary model `BloonModel` scalar fields:** `id`, `baseId`, `overlayClass`, `bloonProperties`, `isMoab`, `isBoss`, `isCamo`, `isGrow`, `isFortified`, `hasChildrenWithDifferentTotalHealths`, `isInvulnerable`, `distributeDamageToChildren`, `disallowCosmetics`, `isSaved`, `isImmuneToSlow`, `isBossSegment`, `radius`, `danger`, `maxHealth`, `coopMultiplier`, `armourMultiplier`, `leakDamage`, `leakDamageSet`, `leakDamageMultiplier`, `layerNumber`, `bonusDamagePerHit`, `dontShowInSandbox`, `dontShowInSandboxOnRelease`, `alwaysRecordsDamage`, `speed`, `speedFrames`, `legendsType`, `basicTypeFlags`, `propertyFlags`, `isFixedMaxHealth`, `updateChildBloonModels`, `Speed`, `IsExclusiveToLegends`, `IsBaseType`, `IsVariant`
 
-### `Bosses/` — 7 files ⬜
+### `Bosses/` — 7 files ✅
 
 - **Model types:** `SpriteReference`×84, `PrefabReference`×70, `BossData`×7, `MusicItem`×7, `AudioClipReference`×7, `AudioClip`×7
 - **Primary model `BossData` scalar fields:** `id`, `bossChildrenOverlay`, `LocsKey`

--- a/scripts/btd6_gamedata_inventory.py
+++ b/scripts/btd6_gamedata_inventory.py
@@ -58,7 +58,10 @@ _INGEST_STATUS: dict[str, tuple[str, str]] = {
         "children + immunity now game-data-sourced (--bloons); rbe/health/speed/"
         "category/aliases still wiki",
     ),
-    "Bosses": ("⬜", "wiki-sourced; cosmetic Bosses/ — combat lives in Bloons/"),
+    "Bosses": (
+        "✅",
+        "bosses.json: name, mechanic description, immunities, per-tier health/speed",
+    ),
     "Rounds": (
         "🟡",
         "composition drives derived RBE + per-round cash; not ingested as-is",

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -2230,6 +2230,87 @@ def map_geraldo_items(dump: Path, version: str) -> tuple[list[dict], list[str]]:
     return rows, warnings
 
 
+def _clean_boss_desc(text: str) -> str:
+    """A boss ``InfoPanelDescription`` → one readable line: strip HTML, drop the
+    leading ``•`` bullets, and collapse newlines/whitespace so the multi-bullet
+    game text reads as a single grounded paragraph.
+    """
+    no_html = re.sub(r"<[^>]+>", "", text)
+    no_bullets = re.sub(r"\s*•\s*", " ", no_html)
+    return re.sub(r"\s+", " ", no_bullets).strip()
+
+
+def map_bosses(dump: Path, version: str) -> tuple[list[dict], list[str]]:
+    """Every Boss Bloon → a catalog row (id, name, tagline, game-authored mechanic
+    description, derived type-immunities, and per-tier health/speed for the five
+    boss tiers). The boss roster is the dump's own ``Bosses/`` folder (each
+    ``BossData`` names the family + its ``LocsKey``); per-tier combat stats come
+    from ``Bloons/<Family>/<Family>{1..5}.json`` (``maxHealth`` / ``speed``), and
+    ``immune_to`` is derived from the base tier's ``bloonProperties`` bitflag via
+    the same inverter the bloon overlay uses (one source of truth for the mask).
+    """
+    from utils.btd6.damage_types import immunities_for_bloon_properties
+
+    tt = _text_table(dump)
+    rows: list[dict] = []
+    warnings: list[str] = []
+    seen: set[str] = set()
+    for fp in sorted((dump / "Bosses").glob("*.json")):
+        try:
+            boss = json.loads(fp.read_text("utf-8"))
+        except (OSError, json.JSONDecodeError):
+            warnings.append(f"unreadable {fp.name}")
+            continue
+        loc = str(boss.get("LocsKey") or fp.stem)
+        name = tt.get(loc)
+        if not name:
+            warnings.append(f"no name string for boss {loc!r}")
+            continue
+        bid = _snake(loc)
+        if bid in seen:
+            warnings.append(f"duplicate boss id {bid!r} ({loc})")
+            continue
+        bdir = dump / "Bloons" / loc
+        tiers: list[dict] = []
+        immune: list[str] = []
+        for tier in range(1, 6):
+            tfp = bdir / f"{loc}{tier}.json"
+            if not tfp.exists():
+                continue
+            model = json.loads(tfp.read_text("utf-8"))
+            tiers.append(
+                {
+                    "tier": tier,
+                    "health": _num(model.get("maxHealth", 0)),
+                    "speed": _num(model.get("speed", 0)),
+                },
+            )
+            if tier == 1:
+                immune = sorted(
+                    immunities_for_bloon_properties(model.get("bloonProperties", 0)),
+                )
+        if not tiers:
+            warnings.append(f"no tier models under Bloons/{loc}/ — skipped")
+            continue
+        seen.add(bid)
+        tagline = " — ".join(
+            _clean_desc(tt[k]) for k in (f"{loc}TagLine", f"{loc}TagLine2") if tt.get(k)
+        )
+        description = _clean_boss_desc(tt.get(f"{loc}InfoPanelDescription", ""))
+        rows.append(
+            {
+                "id": bid,
+                "canonical": name,
+                "tagline": tagline,
+                "description": description,
+                "immune_to": immune,
+                "tiers": tiers,
+            },
+        )
+    rows.sort(key=lambda b: b["id"])
+    return rows, warnings
+
+
 def _write(path: Path, payload: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
@@ -2498,6 +2579,11 @@ def main(argv: list[str] | None = None) -> int:
         help="rebuild geraldo_items.json from the dump's GeraldoItems/ folder",
     )
     ap.add_argument(
+        "--bosses",
+        action="store_true",
+        help="rebuild bosses.json from the dump's Bosses/ + Bloons/<boss>/ folders",
+    )
+    ap.add_argument(
         "--bloons",
         action="store_true",
         help="source bloon children + immunity from the dump (overlay bloons.json)",
@@ -2577,7 +2663,7 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  warning: {w}")
         return 0
 
-    if args.powers or args.knowledge or args.geraldo:
+    if args.powers or args.knowledge or args.geraldo or args.bosses:
         version = _dump_version(dump)
         for flag, fn, key, fname in (
             (args.powers, map_powers, "powers", "powers.json"),
@@ -2593,6 +2679,7 @@ def main(argv: list[str] | None = None) -> int:
                 "geraldo_items",
                 "geraldo_items.json",
             ),
+            (args.bosses, map_bosses, "bosses", "bosses.json"),
         ):
             if not flag:
                 continue

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -738,6 +738,54 @@ def test_mk_effect_behavioural_or_empty_stays_description_only(mod):
     assert mod._mk_effect({}) == {}
 
 
+def test_map_bosses_reads_roster_tiers_and_derives_immunity(mod, tmp_path):
+    dump = tmp_path / "dump"
+    # Boss roster lives in Bosses/ (the BossData names the family + its LocsKey);
+    # per-tier combat stats come from Bloons/<Family>/<Family>{1..5}.json.
+    _write(dump / "Bosses" / "Dreadbloon.json", {"id": 3, "LocsKey": "Dreadbloon"})
+    _write(
+        dump / "Bloons" / "Dreadbloon" / "Dreadbloon1.json",
+        {"id": "Dreadbloon1", "maxHealth": 7500, "speed": 1.25, "bloonProperties": 1},
+    )
+    _write(
+        dump / "Bloons" / "Dreadbloon" / "Dreadbloon2.json",
+        {"id": "Dreadbloon2", "maxHealth": 25000, "speed": 1.3, "bloonProperties": 1},
+    )
+    _write(
+        dump / "textTable.json",
+        {
+            "Dreadbloon": "Dreadbloon",
+            "DreadbloonTagLine": "From Deep Within the Dark Earth...",
+            "DreadbloonTagLine2": "the Armored Behemoth!",
+            "DreadbloonInfoPanelDescription": "• Dreadbloon has Lead properties.\n• Tough.",
+        },
+    )
+    rows, warnings = mod.map_bosses(dump, "55.1")
+    assert warnings == []
+    assert len(rows) == 1
+    boss = rows[0]
+    assert boss["id"] == "dreadbloon"
+    assert boss["canonical"] == "Dreadbloon"
+    assert boss["tagline"] == "From Deep Within the Dark Earth... — the Armored Behemoth!"
+    # Bullets + newlines collapse into one readable grounded line.
+    assert boss["description"] == "Dreadbloon has Lead properties. Tough."
+    # bloonProperties bit 1 (Lead) → the Lead immunity set, via the shared inverter.
+    assert boss["immune_to"] == ["Cold", "Energy", "Sharp", "Shatter"]
+    assert boss["tiers"] == [
+        {"tier": 1, "health": 7500, "speed": 1.25},
+        {"tier": 2, "health": 25000, "speed": 1.3},
+    ]
+
+
+def test_map_bosses_skips_boss_with_no_tier_models(mod, tmp_path):
+    dump = tmp_path / "dump"
+    _write(dump / "Bosses" / "Ghost.json", {"LocsKey": "Ghost"})
+    _write(dump / "textTable.json", {"Ghost": "Ghost"})
+    rows, warnings = mod.map_bosses(dump, "55.1")
+    assert rows == []
+    assert any("no tier models" in w for w in warnings)
+
+
 def test_validate_anchors(mod, tmp_path):
     dump = tmp_path / "dump"
     _write(dump / "Towers" / "DartMonkey" / "DartMonkey.json", _tower_model(cost=200.0))

--- a/tests/unit/services/test_ai_tools.py
+++ b/tests/unit/services/test_ai_tools.py
@@ -39,6 +39,7 @@ def test_build_registry_returns_specs_and_matching_handlers():
         "btd6_power_lookup",
         "btd6_monkey_knowledge_lookup",
         "btd6_geraldo_lookup",
+        "btd6_boss_lookup",
         "btd6_bloon_filter",
         "btd6_cumulative_cost",
         "btd6_power_effect",
@@ -358,6 +359,7 @@ def test_admin_scope_offers_all_read_only_tools():
         "btd6_power_lookup",
         "btd6_monkey_knowledge_lookup",
         "btd6_geraldo_lookup",
+        "btd6_boss_lookup",
         "btd6_bloon_filter",
         "btd6_cumulative_cost",
         "btd6_power_effect",
@@ -803,6 +805,27 @@ async def test_btd6_geraldo_lookup_single_and_roster():
     roster = await h["btd6_geraldo_lookup"]({})
     assert roster["count"] == len(roster["items"]) == 16
     assert (await h["btd6_geraldo_lookup"]({"item": "nope"}))["found"] is False
+
+
+async def test_btd6_boss_lookup_single_and_roster():
+    h = build_registry(scope=AIScope.USER, guild_id=1, actor_id=2).handlers
+    one = await h["btd6_boss_lookup"]({"boss": "Bloonarius"})
+    assert one["found"] is True
+    boss = one["boss"]
+    assert boss["name"] == "Bloonarius" and boss["description"]
+    # Per-tier health is surfaced — tier 3 Bloonarius = 350,000.
+    t3 = next(t for t in boss["tiers"] if t["tier"] == 3)
+    assert t3["health"] == 350_000
+    # Derived immunity surfaces; partial-name match resolves a single boss.
+    assert set((await h["btd6_boss_lookup"]({"boss": "dread"}))["boss"]["immune_to"]) == {
+        "Cold",
+        "Energy",
+        "Sharp",
+        "Shatter",
+    }
+    roster = await h["btd6_boss_lookup"]({})
+    assert roster["count"] == len(roster["bosses"]) == 7
+    assert (await h["btd6_boss_lookup"]({"boss": "nope"}))["found"] is False
 
 
 async def test_btd6_bloon_filter_traits_and_modifier_note():

--- a/tests/unit/services/test_btd6_data_service.py
+++ b/tests/unit/services/test_btd6_data_service.py
@@ -131,6 +131,36 @@ def test_geraldo_items_load_and_resolve():
     assert find_geraldo_item("") is None
 
 
+def test_bosses_load_resolve_and_carry_tiers():
+    from services.btd6_data_service import find_boss, get_boss
+
+    dataset = get_dataset()
+    # All seven Boss Bloons are ingested.
+    assert len(dataset.bosses) == 7
+    ids = {b.id for b in dataset.bosses}
+    assert {"bloonarius", "lych", "vortex", "dreadbloon", "blastapopoulos", "phayze"} <= ids
+    # Resolves by id and (fuzzily) by canonical name / partial.
+    bloonarius = get_boss("bloonarius")
+    assert bloonarius is not None and bloonarius.canonical == "Bloonarius"
+    assert find_boss("Blasta").canonical == "Blastapopoulos"
+    # Five boss tiers, health scaling up; tier 3 Bloonarius = 350,000.
+    assert len(bloonarius.tiers) == 5
+    t3 = next(t for t in bloonarius.tiers if t["tier"] == 3)
+    assert t3["health"] == 350_000
+    assert [t["health"] for t in bloonarius.tiers] == sorted(
+        t["health"] for t in bloonarius.tiers
+    )
+    # Derived type-immunities: Dreadbloon = Lead, Blastapopoulos = Purple.
+    assert set(get_boss("dreadbloon").immune_to) == {"Cold", "Energy", "Sharp", "Shatter"}
+    assert set(get_boss("blastapopoulos").immune_to) == {"Energy", "Fire", "Frigid", "Plasma"}
+    # Every boss carries a game-authored mechanic description.
+    for boss in dataset.bosses:
+        assert boss.canonical and boss.description and boss.tiers
+    # Unknown / empty fail closed.
+    assert get_boss("zzz") is None
+    assert find_boss("") is None
+
+
 def test_map_removables_curated_for_known_maps_only():
     # Removable obstacles are bloonswiki-curated (not in the dump). They must
     # land on the maps we have data for, and stay blank (= "no data", not


### PR DESCRIPTION
## What

The dump-re-audit (#599) flagged **boss bloons as the biggest real data gap** — `bloons.json` had **0** bosses, while the dump carries full boss combat stats. This ingests all **7 Boss Bloons** (Bloonarius, Lych, Vortex, Dreadbloon, Blastapopoulos, Phayze, Diamondback) as a game-data-native lookup, mirroring the Powers/Geraldo/Knowledge pattern.

## How

- **Parser** (`parse_gamedata.py --bosses`): `map_bosses` reads the roster from the dump's `Bosses/` folder (each `BossData` names the family + `LocsKey`), per-tier `health`/`speed` from `Bloons/<Family>/<Family>{1..5}.json`, and the game-authored mechanic description + taglines from `textTable`. `immune_to` is **derived** from the base tier's `bloonProperties` bitflag via the same inverter the bloon overlay uses (one source of truth) → Dreadbloon = Lead, Blastapopoulos = Purple.
- **Data** `bosses.json`: 7 bosses × 5 tiers (e.g. Bloonarius `20,000 → 3,000,000` health).
- **Runtime** (`btd6_data_service`): `BossEntry` (optional, validated, id/canonical-unique) + `get_boss`/`find_boss`.
- **AI tool** `btd6_boss_lookup` (single + roster), registered + in `BTD6_GROUNDING_TOOL_NAMES`.

Now answers: *"how much health does a tier 3 Bloonarius have"* (350,000), *"what is Dreadbloon immune to"* (Cold/Energy/Sharp/Shatter), *"how fast is Vortex"*, *"what does Lych do"*, *"list the bosses"*.

## Correctness notes

- **Phayze's `isCamo` is `False`** in the dump (its camo is a runtime Reality-Shield mechanic), so I deliberately did **not** derive a `camo` field from it — the game-authored description carries it. `immune_to` stays rigorous (derived from the bitflag).
- Descriptions collapse the multi-bullet game text into one readable grounded line.

## Scope

A **lookup catalog** (health/speed/immunities/mechanic per boss+tier) — not an applied-modifier tool. The signature skull-phase mechanics live in behavioural sub-models and are surfaced as prose, not decoded as numbers (same boundary as Geraldo/Powers).

## Tests

Parser (roster/tiers/immunity-derivation + skip-no-tiers), data_service (load/resolve/tiers/immunity/fail-closed), tool (single/partial/roster/miss); both registry drift-guards updated. Coverage map regenerated (Bosses ✅). `check_quality --full` green (8165 passed); `check_architecture --mode strict` 0 errors.

https://claude.ai/code/session_01UZCi9DFBDQHPZfMwr1xQ3h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZCi9DFBDQHPZfMwr1xQ3h)_