### PR TITLE
btd6: cut over bloon health/speed/fortified-health to game data

### DIFF
--- a/.sessions/2026-06-08-btd6-bloon-stats-cutover.md
+++ b/.sessions/2026-06-08-btd6-bloon-stats-cutover.md
@@ -1,0 +1,43 @@
+# 2026-06-08 — BTD6 bloon-stats cutover (health/speed/fortified → game data)
+
+**Branch:** `claude/btd6-bloon-stats-cutover` · follows the not-in-dump re-audit + boss PRs.
+
+## Task
+Owner picked (AskUserQuestion) **bloon-stats cutover** as the next build, and **"Everything"**
+as the completeness target (map every domain incl. cosmetic — captured in the roadmap).
+
+## What shipped
+Extended `overlay_bloons` (the existing children+immunity overlay) to also source
+`health`, `speed`, and `health_fortified` from the dump:
+- `health` ← `maxHealth`, `speed` ← `speed` (the dump speed is **already in the curated
+  units** — Red 25, Ceramic 62.5, BFB 6.25 — so no normalization).
+- `health_fortified` ← the bloon's **Fortified variant** model's `maxHealth`, via a new
+  `_select_bloon_variant_model(bloon, index, extra={"fortified"})` helper.
+- **Verified 23/23 byte-identical** (0 corrections) — pure provenance + reproducibility,
+  exactly like the immunity cutover. The curated combat numbers were already right.
+- `rbe`/`rbe_fortified` stay **derived** (health+children), pinned by `test_btd6_rbe.py`
+  — that test is the tripwire if a future dump health moves without an rbe reconcile.
+- Provenance marker broadened: `children_immunity_source` → `game_sourced_fields` (list)
+  + `game_sourced_fields_source`. Nothing reads it (pure provenance), safe to rename.
+- Coverage map regenerated (Bloons note updated).
+
+## Key facts (for next session)
+- **Curated bloon `speed` == dump `speed` units** (no relative normalization needed).
+- **Fortified variants** live alongside the base in `Bloons/<Family>/` (`CeramicFortified`
+  maxHealth 20, `MoabFortified` 400, `LeadFortified` 4, `BfbFortified` 1400) and match
+  curated `health_fortified` exactly.
+- `overlay_bloons` reads `_DATA_ROOT/bloons.json` directly → unit-test it by
+  `monkeypatch.setattr(mod, "_DATA_ROOT", tmp)` with a tiny bloons.json + tmp dump.
+
+## Remaining "map everything" backlog (owner wants ALL domains; see roadmap)
+- **Cutovers/verify:** tower stats (the big gated one), **mode-rules** (`Mods/` — teed up).
+- **New gameplay:** boss skull mechanics (decodable: `HealthPercentTrigger` +
+  `SpawnBloonsAction`), alternate round sets (ABR 140, Endurance 205).
+- **Niche:** Rogue Legends (`Artifacts/` 568 + `rogueData.json`), Frontier
+  (`frontierData.json`), Achievements (156).
+- **Cosmetic (owner said include):** Skins (51), TrophyStoreItems (424), BloonOverlays
+  (46), `resources.json` (asset GUIDs), `Buffs/` (UI icons). Low Q&A value but in scope.
+
+## Verification
+`check_quality.py --full` green (8167 passed); `check_architecture --mode strict` 0 errors.
+Bloon overlay run: "0 corrections — provenance recorded."

--- a/disbot/data/btd6/bloons.json
+++ b/disbot/data/btd6/bloons.json
@@ -781,5 +781,12 @@
       "description": "A regrow modifier: the bloon regrows its popped outer layers over time unless it is fully destroyed."
     }
   ],
-  "children_immunity_source": "BTD Mod Helper game data export"
+  "game_sourced_fields": [
+    "children",
+    "immune_to",
+    "health",
+    "speed",
+    "health_fortified"
+  ],
+  "game_sourced_fields_source": "BTD Mod Helper game data export"
 }

--- a/docs/btd6/btd6-dump-coverage-map.md
+++ b/docs/btd6/btd6-dump-coverage-map.md
@@ -14,7 +14,7 @@
 | `Achievements/` | 156 | ⬜ | not ingested |
 | `Artifacts/` | 568 | ⬜ | not ingested (Rogue Legends artifacts) |
 | `BloonOverlays/` | 46 | ⬜ | cosmetic overlays; not ingested |
-| `Bloons/` | 235 | 🟡 | children + immunity now game-data-sourced (--bloons); rbe/health/speed/category/aliases still wiki |
+| `Bloons/` | 235 | 🟡 | children/immunity/health/speed/health_fortified now game-data-sourced (--bloons); rbe (derived from health+children) + category/aliases still wiki |
 | `Bosses/` | 7 | ✅ | bosses.json: name, mechanic description, immunities, per-tier health/speed |
 | `Buffs/` | 91 | ⬜ | UI buff ICONS only — effects live inline in Towers/ |
 | `GeraldoItems/` | 16 | ✅ | all 16 shop items: name, description, cash cost, unlock level, quantity |

--- a/docs/btd6/btd6-gamedata-decode-status.md
+++ b/docs/btd6/btd6-gamedata-decode-status.md
@@ -34,12 +34,17 @@ works** (the traps we hit), and what is still un-decoded.
 - **Towers** 25, **Heroes** 17, **Rounds** 140 — towers/rounds still
   **wiki-sourced** (no cutover yet); the 11 wiki-missing heroes are game-data.
   Rounds now carry derived **per-round + cumulative cash** (all 140).
-- **Bloons** 26 — **children + immunity cut over to game data** (`--bloons`):
-  `immune_to` is derived from each bloon's `bloonProperties` bitflag (via
-  `utils.btd6.damage_types.immunities_for_bloon_properties`, verified 23/23 vs
-  the curated lists), and `children` from the dump's `SpawnChildrenModel` with
-  variant modifiers preserved (camo/regrow/fortified). The rest
-  (rbe/health/layers/speed/category/aliases/description) stays wiki-curated.
+- **Bloons** 26 — **children + immunity + health + speed + fortified-health cut
+  over to game data** (`--bloons`): `immune_to` derived from each bloon's
+  `bloonProperties` bitflag (via `utils.btd6.damage_types.immunities_for_bloon_properties`,
+  23/23), `children` from the dump's `SpawnChildrenModel` (variant modifiers
+  preserved), and `health`/`speed`/`health_fortified` are direct dump scalars
+  (`maxHealth`/`speed`, + the Fortified variant's `maxHealth`) — **verified
+  byte-identical 23/23 at cutover** (0 corrections), so the curated combat numbers
+  were already right and are now game-sourced + reproducible. `rbe`/`rbe_fortified`
+  stay **derived** from `health`+`children` (not dump scalars; pinned by
+  `test_btd6_rbe.py`, which turns red if a future dump health moves without an rbe
+  reconcile). The rest (layers/category/aliases/description) stays wiki-curated.
 - **Maps** 86 — **fully cut over to game data** (`--maps`), with `has_water`,
   curated **removables** (18 maps), and aggregate count/list grounding. (89 dump
   files minus the 3 non-player `IsStandard=False` maps: Blons, Base Editor Map,

--- a/scripts/btd6_gamedata_inventory.py
+++ b/scripts/btd6_gamedata_inventory.py
@@ -55,8 +55,8 @@ _INGEST_STATUS: dict[str, tuple[str, str]] = {
     "Maps": ("✅", "full cutover: difficulty, has_water, names (curated removables)"),
     "Bloons": (
         "🟡",
-        "children + immunity now game-data-sourced (--bloons); rbe/health/speed/"
-        "category/aliases still wiki",
+        "children/immunity/health/speed/health_fortified now game-data-sourced "
+        "(--bloons); rbe (derived from health+children) + category/aliases still wiki",
     ),
     "Bosses": (
         "✅",

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -2476,12 +2476,43 @@ def _select_bloon_model(
     return None
 
 
+def _select_bloon_variant_model(
+    bloon: dict[str, Any],
+    model_index: dict[tuple[str, frozenset[str]], Path],
+    extra: frozenset[str],
+) -> Path | None:
+    """Like :func:`_select_bloon_model` but for a *modifier variant* — the bloon's
+    own inherent modifiers **plus** ``extra`` (e.g. ``{"fortified"}`` to read a
+    bloon's Fortified ``maxHealth``). ``None`` when that exact variant has no dump
+    model (most bloons cannot be fortified).
+    """
+    bid = bloon["id"]
+    props = {str(p).lower() for p in bloon.get("properties", [])}
+    want = frozenset(m for m in _CHILD_MOD_ORDER if m in props) | extra
+    for base in (bid, f"{bid}_bloon"):
+        fp = model_index.get((base, want))
+        if fp is not None:
+            return fp
+    return None
+
+
 def overlay_bloons(dump: Path, *, dry_run: bool) -> dict[str, list[str]]:
-    """Source ``immune_to`` + ``children`` from the dump for every bloon already
-    in ``bloons.json`` that maps to a dump model. Returns ``{bloon_id: [changes]}``
-    listing only *semantic* corrections (an immunity set or child multiset that
-    differs from the curated value); a value already correct is left untouched so
-    the committed ordering/prose never churns.
+    """Source the dump-reproducible bloon fields — ``immune_to``, ``children``,
+    ``health``, ``speed`` and ``health_fortified`` — for every bloon in
+    ``bloons.json`` that maps to a dump model. Returns ``{bloon_id: [changes]}``
+    listing only *semantic* corrections (a value differing from the curated one);
+    a value already correct is left untouched so the committed ordering/prose
+    never churns.
+
+    Combat stats are direct dump scalars in the **same units** as the curated
+    values (``maxHealth`` -> ``health``, ``speed`` -> ``speed``, the Fortified
+    variant's ``maxHealth`` -> ``health_fortified``) — verified byte-identical at
+    cutover, so this is provenance + reproducibility, not a correction. ``rbe`` /
+    ``rbe_fortified`` stay **derived** from ``health`` + ``children`` (they are not
+    dump scalars); ``tests/unit/services/test_btd6_rbe.py`` recomputes and pins
+    them, so if a future dump pull moves a ``health`` the RBE check turns red and
+    forces a reconcile rather than letting the two drift silently. The rest
+    (rbe/category/aliases/description) stays wiki-curated.
     """
     from utils.btd6.damage_types import immunities_for_bloon_properties
 
@@ -2518,10 +2549,44 @@ def overlay_bloons(dump: Path, *, dry_run: bool) -> dict[str, list[str]]:
             bloon["children_list"] = derived_children
             bloon["children"] = _children_prose(derived_children, canon)
 
+        # Base combat stats — direct dump scalars (same units as curated).
+        for stat, dump_key in (("health", "maxHealth"), ("speed", "speed")):
+            if dump_key not in raw:
+                continue
+            value = _num(raw[dump_key])
+            if value != bloon.get(stat):
+                changes.append(f"{stat} {bloon.get(stat)} -> {value}")
+                bloon[stat] = value
+
+        # Fortified health from the bloon's Fortified variant model — only for the
+        # bloons that have a fortified form (Lead / Ceramic / MOAB-class already
+        # carry a curated ``health_fortified``); never invent the field.
+        if bloon.get("health_fortified") is not None:
+            fort_fp = _select_bloon_variant_model(
+                bloon,
+                model_index,
+                frozenset({"fortified"}),
+            )
+            if fort_fp is not None:
+                fort = _num(json.loads(fort_fp.read_text("utf-8")).get("maxHealth", 0))
+                if fort and fort != bloon.get("health_fortified"):
+                    changes.append(
+                        f"health_fortified {bloon.get('health_fortified')} -> {fort}",
+                    )
+                    bloon["health_fortified"] = fort
+
         if changes:
             report[bid] = changes
 
-    payload["children_immunity_source"] = _SOURCE
+    payload["game_sourced_fields"] = [
+        "children",
+        "immune_to",
+        "health",
+        "speed",
+        "health_fortified",
+    ]
+    payload["game_sourced_fields_source"] = _SOURCE
+    payload.pop("children_immunity_source", None)
     if not dry_run:
         _write(path, payload)
     return report
@@ -2586,7 +2651,7 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument(
         "--bloons",
         action="store_true",
-        help="source bloon children + immunity from the dump (overlay bloons.json)",
+        help="source bloon children/immunity/health/speed from the dump (overlay bloons.json)",
     )
     ap.add_argument("--dry-run", action="store_true", help="print, do not write")
     args = ap.parse_args(argv)
@@ -2614,8 +2679,8 @@ def main(argv: list[str] | None = None) -> int:
         verb = "would correct" if args.dry_run else "corrected"
         if not report:
             print(
-                "bloons: children + immunity already match game data for every "
-                "mapped bloon (0 corrections) — provenance recorded.",
+                "bloons: children/immunity/health/speed already match game data for "
+                "every mapped bloon (0 corrections) — provenance recorded.",
             )
         else:
             print(f"bloons: {verb} {len(report)} bloon(s)\n")

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -515,7 +515,16 @@ def test_map_geraldo_items_extracts_structured_effect(mod, tmp_path):
 
 
 def _bloon_model(
-    bid, *, base=None, props=0, camo=False, grow=False, fort=False, children=None
+    bid,
+    *,
+    base=None,
+    props=0,
+    camo=False,
+    grow=False,
+    fort=False,
+    children=None,
+    health=None,
+    speed=None,
 ):
     m = {
         "$type": "Il2CppAssets.Scripts.Models.Bloons.BloonModel, Assembly-CSharp",
@@ -527,6 +536,10 @@ def _bloon_model(
         "isFortified": fort,
         "behaviors": [],
     }
+    if health is not None:
+        m["maxHealth"] = health
+    if speed is not None:
+        m["speed"] = speed
     if children is not None:
         m["behaviors"].append(
             {
@@ -607,6 +620,81 @@ def test_bloon_immunity_derives_from_property_bitflag(mod, tmp_path):
         "Cold",
         "Frigid",
     }
+
+
+def test_select_bloon_variant_model_picks_fortified(mod, tmp_path):
+    dump = tmp_path / "dump"
+    _write(dump / "Bloons" / "Ceramic" / "Ceramic.json", _bloon_model("Ceramic"))
+    _write(
+        dump / "Bloons" / "Ceramic" / "CeramicFortified.json",
+        _bloon_model("CeramicFortified", base="Ceramic", fort=True),
+    )
+    index = mod._bloon_model_index(dump)
+    bloon = {"id": "ceramic", "properties": []}
+    # The base selector picks the plain model; the variant selector adds fortified.
+    assert mod._select_bloon_model(bloon, index).name == "Ceramic.json"
+    fort = mod._select_bloon_variant_model(bloon, index, frozenset({"fortified"}))
+    assert fort.name == "CeramicFortified.json"
+    # A bloon with no fortified variant in the dump → None (never invented).
+    _write(dump / "Bloons" / "Red" / "Red.json", _bloon_model("Red"))
+    index = mod._bloon_model_index(dump)
+    assert (
+        mod._select_bloon_variant_model(
+            {"id": "red", "properties": []}, index, frozenset({"fortified"})
+        )
+        is None
+    )
+
+
+def test_overlay_bloons_sources_health_speed_and_fortified(mod, tmp_path, monkeypatch):
+    # The stats overlay corrects health/speed/health_fortified from the dump and
+    # leaves rbe alone (rbe is derived + pinned by the RBE test, not a dump scalar).
+    dump = tmp_path / "dump"
+    _write(
+        dump / "Bloons" / "Ceramic" / "Ceramic.json",
+        _bloon_model("Ceramic", health=10, speed=62.5),
+    )
+    _write(
+        dump / "Bloons" / "Ceramic" / "CeramicFortified.json",
+        _bloon_model("CeramicFortified", base="Ceramic", fort=True, health=20),
+    )
+    data_root = tmp_path / "data"
+    _write(
+        data_root / "bloons.json",
+        {
+            "data_version": "1.0",
+            "game_version": "55.1",
+            "source": "wiki",
+            "bloons": [
+                {
+                    "id": "ceramic",
+                    "canonical": "Ceramic",
+                    "properties": [],
+                    "health": 99,  # wrong — dump says 10
+                    "speed": 1.0,  # wrong — dump says 62.5
+                    "health_fortified": 999,  # wrong — fortified model says 20
+                    "rbe": 104,  # derived; overlay must leave it untouched
+                    "immune_to": [],
+                    "children_list": [],
+                },
+            ],
+        },
+    )
+    monkeypatch.setattr(mod, "_DATA_ROOT", data_root)
+    report = mod.overlay_bloons(dump, dry_run=False)
+    assert set(report["ceramic"]) == {
+        "health 99 -> 10",
+        "speed 1.0 -> 62.5",
+        "health_fortified 999 -> 20",
+    }
+    written = json.loads((data_root / "bloons.json").read_text())["bloons"][0]
+    assert written["health"] == 10 and written["speed"] == 62.5
+    assert written["health_fortified"] == 20
+    assert written["rbe"] == 104  # derived value preserved
+    # Provenance marker broadened to list every game-sourced field.
+    payload = json.loads((data_root / "bloons.json").read_text())
+    assert "health" in payload["game_sourced_fields"]
+    assert "children_immunity_source" not in payload
 
 
 def test_map_monkey_knowledge_uses_category_folder(mod, tmp_path):


### PR DESCRIPTION
## What

Extends the existing `--bloons` overlay (which already game-sources `children` + `immune_to`) to also source the **combat scalars** from the dump:

- `health` ← `maxHealth`
- `speed` ← `speed` (the dump speed is **already in the curated units** — Red 25, Ceramic 62.5, BFB 6.25 — so **no normalization**)
- `health_fortified` ← the bloon's **Fortified variant** model's `maxHealth`, via a new `_select_bloon_variant_model(bloon, index, {"fortified"})` helper

**Verified 23/23 byte-identical at cutover (0 corrections)** — the curated combat numbers were already correct, so this is provenance + reproducibility (the same outcome as the immunity cutover), not a data change. The only data diff is the broadened provenance marker.

## rbe stays derived (deliberately)

`rbe`/`rbe_fortified` are **not** dump scalars — they're derived from `health` + `children`. They stay that way, pinned by `tests/unit/services/test_btd6_rbe.py`, which recomputes and asserts them. That test is the **tripwire**: if a future dump pull moves a `health` without an rbe reconcile, RBE CI turns red rather than letting the two drift silently.

## Provenance

`children_immunity_source` → `game_sourced_fields` (a list: children/immune_to/health/speed/health_fortified) + `game_sourced_fields_source`. Nothing reads the marker (pure provenance), so the rename is safe.

## Tests

- `_select_bloon_variant_model` — fortified-variant selection + `None` when a bloon has no fortified form (never invented).
- Full overlay test — `monkeypatch`ed `_DATA_ROOT`, deliberately-wrong curated health/speed/fortified → corrected from the dump, `rbe` left untouched, marker broadened.

`check_quality --full` green (8167 passed); `check_architecture --mode strict` 0 errors. Coverage map regenerated (Bloons note updated).

## Context

This is the next step on the maintainer's **"map everything"** goal. Remaining gameplay cutovers/extractions: mode-rules (`Mods/`, teed up), tower stats (the big gated one), boss skull mechanics, alternate round sets; plus the niche/cosmetic domains the maintainer wants eventually mapped.

https://claude.ai/code/session_01UZCi9DFBDQHPZfMwr1xQ3h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZCi9DFBDQHPZfMwr1xQ3h)_