### PR TITLE
btd6: cut over mode rules to game data (Mods/ → modes.json rules block)

### DIFF
--- a/.sessions/2026-06-08-btd6-mode-rules-cutover.md
+++ b/.sessions/2026-06-08-btd6-mode-rules-cutover.md
@@ -1,0 +1,98 @@
+# 2026-06-08 — BTD6 mode-rules cutover (Mods/ → modes.json structured rules)
+
+**Branch:** `claude/btd6-mode-rules-cutover` (off post-#601 main). Final build of a
+multi-PR session: not-in-dump re-audit → bosses → bloon-stats (#601) → this.
+
+## Task
+Owner greenlit the mode-rules cutover as the last build, on the standing "map
+**everything**" goal. Then: update docs, reflect on the workflow, leave a
+continuation message.
+
+## What shipped
+A `--modes` overlay in `parse_gamedata.py` that sources structured, game-grounded
+rules from `Mods/<mode>.json` into `modes.json`:
+- **`_parse_mode_rules(raw_mod)`** normalizes `mutatorMods[]` → a clean `rules`
+  dict: `starting_cash`/`starting_lives`, `start_round`/`end_round`,
+  `cost_multiplier`/`speed_multiplier`/`income_multiplier`, `{tag}_health_multiplier`,
+  `round_set`, `locked_tower_classes`/`locked_towers`, and
+  `no_continues`/`no_selling`/`no_monkey_knowledge`/`no_income`/`reverse` flags.
+  The **standard economy curve** (MonkeyMoney / BonusCashPerRound / SellMultiplier /
+  SetHealthForBloon) is deliberately dropped — only what *varies/restricts* is kept.
+- **`overlay_modes`** maps 15 modes (`_MODE_MODS`; note CHIMPS → `Clicks.json`),
+  attaches `rules`, **verifies** `starting_cash`/`starting_lives` against the dump's
+  absolute overrides, and writes `mode_rules_source` provenance.
+- **Caught one real curated typo:** Sandbox `starting_lives` 9999999 → game model's
+  999999. Everything else matched.
+- **Runtime:** added `ModeEntry.rules: dict` (+ `_parse_mode` reads it). Display
+  **unchanged** — wiring `rules` into the embed is the teed-up follow-up.
+- Corrected the old "the dump has no game-mode rules" finding — they live in
+  `Mods/`, same place MK effects do.
+
+## Key facts for next session
+- **Mods/ mutator vocabulary (24 types)** is the raw material; the mapping table +
+  normalizer in `_parse_mode_rules` is the canonical decode. Tower-set bitflags:
+  `_TOWER_SET` (module line ~58, **lowercase** primary/military/magic/support — reuse
+  it, don't redefine: I hit a shadowing collision doing exactly that).
+- `overlay_modes` reads `_DATA_ROOT/modes.json` directly → unit-test by
+  `monkeypatch.setattr(mod, "_DATA_ROOT", tmp)` + a tmp `Mods/` (same pattern as the
+  bloon overlay).
+- `_parse_mode` ignores unknown JSON keys; `_REQUIRED_MODE_FIELDS` only checks
+  presence — so additive `modes.json` fields are safe.
+
+## ▶ Continuation — next steps (in priority order)
+1. **Wire `ModeEntry.rules` into the mode display.** Data is sourced but the embed
+   still shows only prose. Touch points: `cogs/btd6/_embeds.py` ~L280 (restrictions
+   block) and `services/btd6_response_builder.py` ~L234 (cash/lives bits). Show
+   rounds/cost/income structurally. This *completes* this cutover.
+2. **Keep the "map everything" arc going:** boss skull mechanics (decodable:
+   HealthPercentTrigger + SpawnBloonsAction), alternate round sets (ABR 140), then
+   the gated tower-stats cutover (needs buff/zone tails first), then niche/cosmetic
+   (Rogue Legends, Frontier, Achievements, Skins/TrophyStore — owner wants these too).
+3. **Tech-debt flag (capture as idea, not urgent):** `parse_gamedata.py` is ~2700
+   lines holding every domain's overlay. Naming discipline keeps it navigable, but
+   the `_TOWER_SET` near-collision is a warning sign. A `parse_gamedata/` package
+   (one module per domain + shared `_helpers`) would de-risk further growth.
+
+## Verification
+`check_quality.py --full` green (8170 passed, +3 new); `check_architecture --mode
+strict` 0 errors. `--modes` re-run is idempotent (0 corrections after the first).
+
+---
+
+## Workflow reflection (owner-requested: what helped / hindered this session)
+
+**File structure — easy:** The BTD6 work is genuinely turnkey because of *pattern
+discipline*. `parse_gamedata.py` uses consistent `overlay_<domain>` / `_select_*` /
+`_parse_*` naming, so seeing `overlay_bloons` told me exactly where `overlay_modes`
+goes and what shape it takes (parse → verify-scalars → attach → provenance → test).
+The data↔runtime split is clean: `data/btd6/*.json` mirrors a `*Entry` dataclass in
+`btd6_data_service.py`, so "where do I surface a new field" was a 2-minute answer.
+The `docs/btd6/` cluster (decode-status ledger + coverage map) is a *real* single
+source of truth for "cut over vs curated" — I oriented in one read.
+
+**File structure — hard:** `parse_gamedata.py` at ~2700 lines is the friction point.
+It stays navigable only by naming convention, and I *did* collide with a 2500-lines-
+distant module constant (`_TOWER_SET`); the test caught it, but that's luck-adjacent.
+Flagged as continuation item 3.
+
+**Tools — what worked:** The `--dry-run` overlay is the MVP of this workflow — seeing
+the correction surface (the Sandbox typo) *before* writing de-risked the whole change.
+`check_quality.py --full` as a true CI mirror is trustworthy (green local = green CI).
+The `monkeypatch(_DATA_ROOT)` test idiom makes overlays unit-testable without touching
+committed data.
+
+**Tools — gaps:** (a) `context_map.py` is Python-module-only — it *errored* on
+`modes.json`. For a data-cutover-heavy workflow, a "who consumes this JSON" map (loader
+service + dataclass + pinning tests) would save the grep-archaeology I do each time.
+(b) I had to *discover* the 24-entry `Mods/` mutator vocabulary by enumeration — a
+committed "mutator $type catalog" (like the decode-status ledger but for raw dump model
+shapes) would have shaved real time. (c) CodeGraph was near-useless here and correctly
+so — data-shape work isn't call-graph work; the CLAUDE.md tier guidance steered me right.
+
+**Docs / concept clarity:** The BTD6 *subsystem* concept (migrate every wiki value to
+reproducible game-sourced data, ledgered) is legible fast. What's *less* obvious from
+the BTD6 docs alone is how BTD6 sits in the bot as a whole — SuperBot is a Discord
+server-setup/management bot with BTD6 knowledge as one feature, and a fresh agent
+reading only `docs/btd6/` wouldn't infer that. A one-line "where this subsystem sits"
+pointer atop the decode-status ledger would help orient a cold-start agent. (Didn't
+block this task — the cutover is self-contained — but worth a small doc nudge.)

--- a/disbot/data/btd6/modes.json
+++ b/disbot/data/btd6/modes.json
@@ -7,23 +7,39 @@
       "id": "easy",
       "canonical": "Easy",
       "kind": "difficulty",
-      "aliases": ["beginner_difficulty"],
+      "aliases": [
+        "beginner_difficulty"
+      ],
       "starting_cash": 650,
       "starting_lives": 200,
       "description": "Monkeys cost less, Bloons move a little slower, 200 lives. Beating round 40 awards a bronze medal.",
       "difficulties": [],
-      "restrictions": []
+      "restrictions": [],
+      "rules": {
+        "starting_cash": 650,
+        "starting_lives": 200,
+        "cost_multiplier": 0.85,
+        "end_round": 40
+      }
     },
     {
       "id": "medium",
       "canonical": "Medium",
       "kind": "difficulty",
-      "aliases": ["normal"],
+      "aliases": [
+        "normal"
+      ],
       "starting_cash": 650,
       "starting_lives": 150,
       "description": "Monkeys cost normal, Bloons move normal, 150 lives. Beating round 60 awards a silver medal.",
       "difficulties": [],
-      "restrictions": []
+      "restrictions": [],
+      "rules": {
+        "starting_cash": 650,
+        "starting_lives": 150,
+        "speed_multiplier": 1.1,
+        "end_round": 60
+      }
     },
     {
       "id": "hard",
@@ -34,131 +50,259 @@
       "starting_lives": 100,
       "description": "Monkeys cost more, you start at round 3, Bloons move a little faster, 100 lives. Beating round 80 awards a gold medal.",
       "difficulties": [],
-      "restrictions": []
+      "restrictions": [],
+      "rules": {
+        "starting_cash": 650,
+        "starting_lives": 100,
+        "cost_multiplier": 1.08,
+        "speed_multiplier": 1.25,
+        "start_round": 3,
+        "end_round": 80
+      }
     },
     {
       "id": "standard",
       "canonical": "Standard",
       "kind": "mode",
-      "aliases": ["std"],
+      "aliases": [
+        "std"
+      ],
       "starting_cash": 650,
       "starting_lives": 150,
       "description": "The base mode, available in every difficulty — all towers, no special rules. Lives/prices follow the chosen difficulty (Easy 200 / Medium 150 / Hard 100).",
-      "difficulties": ["easy", "medium", "hard"],
+      "difficulties": [
+        "easy",
+        "medium",
+        "hard"
+      ],
       "restrictions": []
     },
     {
       "id": "primary_only",
       "canonical": "Primary Only",
       "kind": "mode",
-      "aliases": ["primary", "primary monkeys only"],
+      "aliases": [
+        "primary",
+        "primary monkeys only"
+      ],
       "starting_cash": 650,
       "starting_lives": 200,
       "description": "Easy-difficulty mode: only Primary-class towers may be placed.",
-      "difficulties": ["easy"],
-      "restrictions": ["Only Primary-class towers (heroes still allowed)"]
+      "difficulties": [
+        "easy"
+      ],
+      "restrictions": [
+        "Only Primary-class towers (heroes still allowed)"
+      ],
+      "rules": {
+        "locked_tower_classes": [
+          "magic",
+          "military",
+          "support"
+        ]
+      }
     },
     {
       "id": "deflation",
       "canonical": "Deflation",
       "kind": "mode",
-      "aliases": ["deflate"],
+      "aliases": [
+        "deflate"
+      ],
       "starting_cash": 20000,
       "starting_lives": 200,
       "description": "Easy-difficulty mode: start at round 31 with $20,000 cash and earn no more — win with what you start with (verified in-game).",
-      "difficulties": ["easy"],
+      "difficulties": [
+        "easy"
+      ],
       "restrictions": [
         "Starts at round 31 with $20,000 cash",
         "No income — you cannot earn any more cash",
         "No selling towers"
-      ]
+      ],
+      "rules": {
+        "no_income": true,
+        "income_multiplier": 0,
+        "starting_cash": 20000,
+        "no_continues": true,
+        "start_round": 31,
+        "end_round": 60,
+        "locked_towers": [
+          "BananaFarm"
+        ]
+      }
     },
     {
       "id": "military_only",
       "canonical": "Military Only",
       "kind": "mode",
-      "aliases": ["military"],
+      "aliases": [
+        "military"
+      ],
       "starting_cash": 650,
       "starting_lives": 150,
       "description": "Medium-difficulty mode: only Military-class towers may be placed.",
-      "difficulties": ["medium"],
-      "restrictions": ["Only Military-class towers (heroes still allowed)"]
+      "difficulties": [
+        "medium"
+      ],
+      "restrictions": [
+        "Only Military-class towers (heroes still allowed)"
+      ],
+      "rules": {
+        "locked_tower_classes": [
+          "magic",
+          "primary",
+          "support"
+        ]
+      }
     },
     {
       "id": "apopalypse",
       "canonical": "Apopalypse",
       "kind": "mode",
-      "aliases": ["apop", "apocalypse"],
+      "aliases": [
+        "apop",
+        "apocalypse"
+      ],
       "starting_cash": 650,
       "starting_lives": 150,
       "description": "Medium-difficulty mode: bloons stream in continuously with no round breaks and rounds cannot be started manually.",
-      "difficulties": ["medium"],
-      "restrictions": ["Continuous bloon stream — no round breaks", "Cannot manually start rounds"]
+      "difficulties": [
+        "medium"
+      ],
+      "restrictions": [
+        "Continuous bloon stream — no round breaks",
+        "Cannot manually start rounds"
+      ],
+      "rules": {
+        "end_round": 60
+      }
     },
     {
       "id": "reverse",
       "canonical": "Reverse",
       "kind": "mode",
-      "aliases": ["reversed", "backwards"],
+      "aliases": [
+        "reversed",
+        "backwards"
+      ],
       "starting_cash": 650,
       "starting_lives": 150,
       "description": "Medium-difficulty mode: bloons enter from the normal exit and travel the track in reverse.",
-      "difficulties": ["medium"],
-      "restrictions": ["Bloons travel the track in reverse (enter from the exit)"]
+      "difficulties": [
+        "medium"
+      ],
+      "restrictions": [
+        "Bloons travel the track in reverse (enter from the exit)"
+      ],
+      "rules": {
+        "reverse": true
+      }
     },
     {
       "id": "magic_monkeys_only",
       "canonical": "Magic Monkeys Only",
       "kind": "mode",
-      "aliases": ["magic", "magic only", "magic monkeys"],
+      "aliases": [
+        "magic",
+        "magic only",
+        "magic monkeys"
+      ],
       "starting_cash": 650,
       "starting_lives": 100,
       "description": "Hard-difficulty mode: only Magic-class towers may be placed.",
-      "difficulties": ["hard"],
-      "restrictions": ["Only Magic-class towers (heroes still allowed)"]
+      "difficulties": [
+        "hard"
+      ],
+      "restrictions": [
+        "Only Magic-class towers (heroes still allowed)"
+      ],
+      "rules": {
+        "locked_tower_classes": [
+          "military",
+          "primary",
+          "support"
+        ]
+      }
     },
     {
       "id": "double_hp_moabs",
       "canonical": "Double HP MOABs",
       "kind": "mode",
-      "aliases": ["double moabs", "double hp", "dhm"],
+      "aliases": [
+        "double moabs",
+        "double hp",
+        "dhm"
+      ],
       "starting_cash": 650,
       "starting_lives": 100,
       "description": "Hard-difficulty mode: all MOAB-class bloons (MOAB, BFB, ZOMG, DDT, BAD) have double health.",
-      "difficulties": ["hard"],
-      "restrictions": ["All MOAB-class bloons have double health"]
+      "difficulties": [
+        "hard"
+      ],
+      "restrictions": [
+        "All MOAB-class bloons have double health"
+      ],
+      "rules": {
+        "moabs_health_multiplier": 2
+      }
     },
     {
       "id": "half_cash",
       "canonical": "Half Cash",
       "kind": "mode",
-      "aliases": ["half", "halfcash"],
+      "aliases": [
+        "half",
+        "halfcash"
+      ],
       "starting_cash": 650,
       "starting_lives": 100,
       "description": "Hard-difficulty mode: all cash earned (from pops and income) is halved.",
-      "difficulties": ["hard"],
-      "restrictions": ["All cash earned is halved"]
+      "difficulties": [
+        "hard"
+      ],
+      "restrictions": [
+        "All cash earned is halved"
+      ],
+      "rules": {
+        "income_multiplier": 0.5
+      }
     },
     {
       "id": "alternate_bloons_rounds",
       "canonical": "Alternate Bloons Rounds",
       "kind": "mode",
-      "aliases": ["abr", "alternate", "alternate bloons"],
+      "aliases": [
+        "abr",
+        "alternate",
+        "alternate bloons"
+      ],
       "starting_cash": 650,
       "starting_lives": 100,
       "description": "Hard-difficulty mode: rounds use an alternate, generally tougher bloon composition than the default round set.",
-      "difficulties": ["hard"],
-      "restrictions": ["Uses the alternate (harder) round set"]
+      "difficulties": [
+        "hard"
+      ],
+      "restrictions": [
+        "Uses the alternate (harder) round set"
+      ],
+      "rules": {
+        "round_set": "AlternateRoundSet"
+      }
     },
     {
       "id": "impoppable",
       "canonical": "Impoppable",
       "kind": "mode",
-      "aliases": ["impop"],
+      "aliases": [
+        "impop"
+      ],
       "starting_cash": 650,
       "starting_lives": 1,
       "description": "Hard-difficulty endgame mode: rounds 6-100, 1 life, full bloon speed, higher tower prices, no continues and no Monkey Knowledge.",
-      "difficulties": ["hard"],
+      "difficulties": [
+        "hard"
+      ],
       "restrictions": [
         "1 life",
         "Rounds 6-100",
@@ -166,17 +310,28 @@
         "100% bloon speed",
         "No continues",
         "No Monkey Knowledge"
-      ]
+      ],
+      "rules": {
+        "start_round": 6,
+        "starting_lives": 1,
+        "cost_multiplier": 1.2,
+        "end_round": 100
+      }
     },
     {
       "id": "chimps",
       "canonical": "CHIMPS",
       "kind": "mode",
-      "aliases": ["chimp", "chimp mode"],
+      "aliases": [
+        "chimp",
+        "chimp mode"
+      ],
       "starting_cash": 650,
       "starting_lives": 1,
       "description": "Hard-difficulty challenge. The acronym: no Continues, Hearts lost (1 life), Income, Monkey knowledge, Powers, or Selling.",
-      "difficulties": ["hard"],
+      "difficulties": [
+        "hard"
+      ],
       "restrictions": [
         "No continues",
         "1 life (any leak loses the run)",
@@ -184,24 +339,52 @@
         "No Monkey Knowledge",
         "No powers",
         "No selling towers"
-      ]
+      ],
+      "rules": {
+        "start_round": 6,
+        "starting_lives": 1,
+        "no_selling": true,
+        "no_continues": true,
+        "no_monkey_knowledge": true,
+        "end_round": 100,
+        "locked_towers": [
+          "BananaFarm"
+        ]
+      }
     },
     {
       "id": "sandbox",
       "canonical": "Sandbox",
       "kind": "mode",
-      "aliases": ["practice", "freeplay sandbox"],
+      "aliases": [
+        "practice",
+        "freeplay sandbox"
+      ],
       "starting_cash": 9999999,
-      "starting_lives": 9999999,
+      "starting_lives": 999999,
       "description": "Practice mode (available in every difficulty) with unlimited cash and lives for testing tower placements and interactions.",
-      "difficulties": ["easy", "medium", "hard"],
-      "restrictions": ["Unlimited cash and lives (practice only — no rewards)"]
+      "difficulties": [
+        "easy",
+        "medium",
+        "hard"
+      ],
+      "restrictions": [
+        "Unlimited cash and lives (practice only — no rewards)"
+      ],
+      "rules": {
+        "starting_cash": 9999999,
+        "starting_lives": 999999
+      }
     },
     {
       "id": "double_cash",
       "canonical": "Double Cash Mode",
       "kind": "modifier",
-      "aliases": ["double cash", "x2 cash", "2x cash"],
+      "aliases": [
+        "double cash",
+        "x2 cash",
+        "2x cash"
+      ],
       "description": "Modifier: get double in-game cash forever (can be de-activated). All cash earned — including the difficulty's starting cash — is ×2 (so Medium's 650 start becomes 1300). Single-player only.",
       "difficulties": [],
       "restrictions": [
@@ -214,7 +397,11 @@
       "id": "fast_track",
       "canonical": "Fast Track",
       "kind": "modifier",
-      "aliases": ["fast track mode", "fast track pack", "fasttrack"],
+      "aliases": [
+        "fast track mode",
+        "fast track pack",
+        "fasttrack"
+      ],
       "description": "Modifier: start roughly 1/4 of the way into the round count on any map, with the cash you would normally have accumulated by that round. Not available in competitive events or CHIMPS.",
       "difficulties": [],
       "restrictions": [
@@ -223,5 +410,6 @@
         "Not available in competitive events or CHIMPS"
       ]
     }
-  ]
+  ],
+  "mode_rules_source": "BTD Mod Helper game data export"
 }

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -114,6 +114,11 @@ class ModeEntry:
     # For a mode: which difficulties it is offered in (Standard/Sandbox span all,
     # the specials are single-difficulty). Empty for difficulties/modifiers.
     difficulties: tuple[str, ...] = ()
+    # Structured, game-sourced rule values parsed from the dump's Mods/<mode>.json
+    # (cash/lives/round bounds, cost/speed/income multipliers, restriction flags).
+    # Grounds the prose ``restrictions``; empty for Standard + modifiers (no Mods
+    # file) and unmapped rows. See ``modes.json:mode_rules_source``.
+    rules: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -559,6 +564,7 @@ def _parse_mode(raw: dict[str, Any]) -> ModeEntry:
             if raw.get("starting_lives") is not None
             else None
         ),
+        rules=dict(raw.get("rules") or {}),
     )
 
 

--- a/docs/btd6/btd6-dump-coverage-map.md
+++ b/docs/btd6/btd6-dump-coverage-map.md
@@ -21,7 +21,7 @@
 | `IncomeSets/` | 7 | 🟡 | decay bands feed the per-round cash derivation |
 | `Knowledge/` | 134 | ✅ | monkey_knowledge.json: name, category, description, MM cost, investment |
 | `Maps/` | 89 | ✅ | full cutover: difficulty, has_water, names (curated removables) |
-| `Mods/` | 22 | ⬜ | not ingested (game-mode rule mods — partially explored) |
+| `Mods/` | 22 | 🟡 | mode rules sourced into modes.json (--modes): cash/lives verified + structured rules block (rounds/cost/speed/income mults + restrictions) for all 15 mapped modes; the curated taxonomy/prose stays curated |
 | `Powers/` | 27 | ✅ | powers.json: name, desc, MM cost, quantity, between-rounds, effect factors |
 | `Rounds/` | 5,181 | 🟡 | composition drives derived RBE + per-round cash; not ingested as-is |
 | `Skins/` | 51 | ⬜ | cosmetic; not ingested |
@@ -91,7 +91,7 @@
 - **Model types:** `MapDetails`×89, `SpriteReference`×89, `PrefabReference`×89
 - **Primary model `MapDetails` scalar fields:** `id`, `difficulty`, `coopMapDivisionType`, `unlockDifficulty`, `mapMusic`, `isDebug`, `isBrowserOnly`, `hasWater`, `theme`, `IsStandard`, `IsBrowserOnly`
 
-### `Mods/` — 22 files ⬜
+### `Mods/` — 22 files 🟡
 
 - **Model types:** `ModModel`×22, `StartingCashModModel`×13, `LockTowerSetModModel`×9, `EndRoundModModel`×8, `MonkeyMoneyModModel`×6, `StartingHealthModModel`×5, `StartingRoundModModel`×4, `SellMultiplierModModel`×4, `BonusCashPerRoundModModel`×4, `GlobalCostModModel`×3, `LockTowerModModel`×2, `MaxHealthModModel`×2, `DisableContinueModModel`×2, `ModifyAllCashModModel`×2, `GlobalSpeedModModel`×2, `RoundSetModModel`×1, `ChimpsModModel`×1, `DisableSellTowerModModel`×1, `DisableMonkeyKnowledgeModModel`×1, `DeflationModel`×1
 - **Primary model `ModModel` scalar fields:** `name`

--- a/docs/btd6/btd6-gamedata-decode-status.md
+++ b/docs/btd6/btd6-gamedata-decode-status.md
@@ -7,6 +7,13 @@ game-data dump** (`github.com/Btd6ModHelper/btd6-game-data`, v55.0). Start here
 to pick up the work: it records what's done, **how the dump's data actually
 works** (the traps we hit), and what is still un-decoded.
 
+> **Where this sits in the bot:** SuperBot is a Discord server-setup/management
+> bot; the BTD6 knowledge base is *one* feature. This subsystem migrates every
+> curated/wiki BTD6 value to **reproducible, game-sourced** data
+> (`disbot/data/btd6/*.json` ← `parse_gamedata.py` overlays ← the dump), each
+> mirrored by a `*Entry` dataclass in `services/btd6_data_service.py` and surfaced
+> through AI lookup tools + the `cogs/btd6/` embeds.
+
 > **New to this effort? Read `btd6-gamedata-decode-explainer.md` first** — a
 > from-first-principles deep explanation of the what/why/how (buffs, the audit,
 > the cutover), with worked examples. *This* doc is the live status + to-do list.
@@ -49,9 +56,20 @@ works** (the traps we hit), and what is still un-decoded.
   curated **removables** (18 maps), and aggregate count/list grounding. (89 dump
   files minus the 3 non-player `IsStandard=False` maps: Blons, Base Editor Map,
   Protect the Yacht.)
-- **Modes** 18 — **curated** taxonomy: 3 difficulties (Easy/Medium/Hard) + 13
-  modes (Standard is the base mode in every difficulty) + 2 modifiers (Double
-  Cash, Fast Track; relative-effect, no fixed numbers).
+- **Modes** 18 — **curated taxonomy, game-sourced rules** (`--modes`): 3
+  difficulties (Easy/Medium/Hard) + 13 modes (Standard is the base mode in every
+  difficulty) + 2 modifiers (Double Cash, Fast Track; relative-effect, no fixed
+  numbers). The `kind` / `difficulties` / prose `description`+`restrictions` stay
+  curated (not in the dump), but each of the **15 mapped modes now carries a
+  structured `rules` block sourced from `Mods/<mode>.json`** — starting cash/lives,
+  start/end rounds, cost/speed/income multipliers, MOAB-health mult, locked tower
+  classes/towers, and no-continue/no-sell/no-MK/no-income flags — parsed from
+  `mutatorMods[]` (standard economy-curve mutators dropped). This **corrected the
+  earlier "the dump has no game-mode rules" finding** (the rules live in `Mods/`,
+  the same place MK effects do), and the cutover **caught one real curated typo**:
+  Sandbox `starting_lives` 9999999 → the game model's 999999. `mode_rules_source`
+  records provenance; `ModeEntry.rules` surfaces it at runtime (display unchanged
+  — wiring the block into the mode embed is the teed-up follow-up).
 - **Consumable / meta catalogs — game-data-native lookups:** **Powers** 25,
   **Monkey Knowledge** 134, **Geraldo items** 16 (`--powers` / `--knowledge` /
   `--geraldo`). All player-facing name/description/cost catalogs, each behind an

--- a/scripts/btd6_gamedata_inventory.py
+++ b/scripts/btd6_gamedata_inventory.py
@@ -77,7 +77,12 @@ _INGEST_STATUS: dict[str, tuple[str, str]] = {
     ),
     "Achievements": ("⬜", "not ingested"),
     "Artifacts": ("⬜", "not ingested (Rogue Legends artifacts)"),
-    "Mods": ("⬜", "not ingested (game-mode rule mods — partially explored)"),
+    "Mods": (
+        "🟡",
+        "mode rules sourced into modes.json (--modes): cash/lives verified + "
+        "structured rules block (rounds/cost/speed/income mults + restrictions) "
+        "for all 15 mapped modes; the curated taxonomy/prose stays curated",
+    ),
     "Skins": ("⬜", "cosmetic; not ingested"),
     "GeraldoItems": (
         "✅",

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -2592,6 +2592,145 @@ def overlay_bloons(dump: Path, *, dry_run: bool) -> dict[str, list[str]]:
     return report
 
 
+# Mode id (modes.json) -> Mods/<stem>.json. The dump names differ from the
+# canonical mode (CHIMPS' internal name is "Clicks"); Standard + the two
+# modifiers (Double Cash / Fast Track) have no standalone Mods file — Standard is
+# the unmutated base, and the modifiers layer onto a chosen mode.
+_MODE_MODS = {
+    "easy": "Easy",
+    "medium": "Medium",
+    "hard": "Hard",
+    "primary_only": "PrimaryOnly",
+    "deflation": "Deflation",
+    "military_only": "MilitaryOnly",
+    "apopalypse": "Apopalypse",
+    "reverse": "Reverse",
+    "magic_monkeys_only": "MagicOnly",
+    "double_hp_moabs": "DoubleMoabHealth",
+    "half_cash": "HalfCash",
+    "alternate_bloons_rounds": "AlternateBloonsRounds",
+    "impoppable": "Impoppable",
+    "chimps": "Clicks",
+    "sandbox": "Sandbox",
+}
+# A LockTowerSet mutator names the class a mode forbids (PrimaryOnly locks
+# {military, magic, support}, leaving primary). Reuses the module's _TOWER_SET
+# bitflag map so a locked class matches a tower's lowercase `category`.
+
+
+def _mod_short(type_str: str) -> str:
+    """``Il2Cpp...Mods.StartingCashModModel, Assembly-CSharp`` -> ``StartingCashModModel``."""
+    return type_str.split(",", 1)[0].rsplit(".", 1)[-1]
+
+
+def _parse_mode_rules(raw_mod: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a ``Mods/<mode>.json`` ``mutatorMods`` list into the structured,
+    game-sourced rule values that ground the curated prose ``restrictions``.
+
+    Only the rule-bearing mutators are kept. The standard economy curve
+    (``MonkeyMoney`` / ``BonusCashPerRound`` / ``SellMultiplier`` — identical
+    across difficulties, and ``SetHealthForBloon`` per-round tuning) is dropped on
+    purpose so the block holds only what *varies* and *restricts*. Returns ``{}``
+    for a base/empty ruleset.
+    """
+    rules: dict[str, Any] = {}
+    locked_classes: list[str] = []
+    locked_towers: list[str] = []
+    for m in raw_mod.get("mutatorMods", []):
+        kind = _mod_short(str(m.get("$type", "")))
+        if (
+            kind == "StartingCashModModel"
+            and not m.get("multiplier")
+            and _num(m.get("changeBase", 0)) > 0
+        ):
+            rules["starting_cash"] = int(m["changeBase"])
+        elif kind == "StartingHealthModModel":
+            rules["starting_lives"] = int(_num(m.get("addition", 0)))
+        elif kind == "MaxHealthModModel" and m.get("set"):
+            # The 1-life cap (Impoppable / CHIMPS) — an absolute lives override.
+            rules["starting_lives"] = int(_num(m["set"]))
+        elif kind == "StartingRoundModModel":
+            rules["start_round"] = int(m["round"])
+        elif kind == "EndRoundModModel":
+            rules["end_round"] = int(m["round"])
+        elif kind == "GlobalCostModModel":
+            rules["cost_multiplier"] = _num(m["multiplier"])
+        elif kind == "GlobalSpeedModModel" and m.get("multiplier"):
+            rules["speed_multiplier"] = _num(m["multiplier"])
+        elif kind == "ModifyAllCashModModel":
+            rules["income_multiplier"] = _num(m["multiplier"])
+        elif kind == "RoundSetModModel":
+            rules["round_set"] = str(m.get("roundsetName", ""))
+        elif kind == "BloonHealthModel":
+            tag = str(m.get("bloonTag", "")).lower()
+            rules[f"{tag}_health_multiplier"] = _num(m["healthMod"])
+        elif kind == "LockTowerSetModModel":
+            locked_classes.append(
+                _TOWER_SET.get(int(m["towerSetToLock"]), str(m["towerSetToLock"])),
+            )
+        elif kind == "LockTowerModModel":
+            locked_towers.append(str(m["towerToLock"]))
+        elif kind == "DisableContinueModModel":
+            rules["no_continues"] = True
+        elif kind == "DisableSellTowerModModel":
+            rules["no_selling"] = True
+        elif kind == "DisableMonkeyKnowledgeModModel":
+            rules["no_monkey_knowledge"] = True
+        elif kind == "DeflationModel":
+            rules["no_income"] = True
+        elif kind == "ReverseModel":
+            rules["reverse"] = True
+    if locked_classes:
+        rules["locked_tower_classes"] = sorted(locked_classes)
+    if locked_towers:
+        rules["locked_towers"] = sorted(locked_towers)
+    return rules
+
+
+def overlay_modes(dump: Path, *, dry_run: bool) -> dict[str, list[str]]:
+    """Source structured, game-grounded rules for every mode in ``modes.json`` that
+    maps to a ``Mods/<mode>.json`` file. Attaches a normalized ``rules`` block
+    (cash/lives/rounds/cost/speed multipliers + the restriction set) and *verifies*
+    the curated ``starting_cash`` / ``starting_lives`` against the dump's absolute
+    overrides — correcting a mismatch. Returns ``{mode_id: [corrections]}`` (a mode
+    with rules attached but no scalar correction maps to ``[]``).
+
+    The curated *taxonomy* (``kind`` / ``difficulties`` / prose ``description`` +
+    ``restrictions``) is **not** in the dump and stays curated; only the numeric
+    rule values + structured restriction flags are game-sourced here. cash/lives
+    are corrected only when the Mods file sets an *absolute* value (``changeBase``
+    for cash; ``addition`` / ``MaxHealth.set`` for lives) — inherited values (a
+    mode that layers on a base difficulty without restating them) are left curated.
+    """
+    mods_dir = dump / "Mods"
+    path = _DATA_ROOT / "modes.json"
+    payload = json.loads(path.read_text("utf-8"))
+    report: dict[str, list[str]] = {}
+
+    for mode in payload["modes"]:
+        stem = _MODE_MODS.get(mode["id"])
+        if stem is None:
+            continue  # Standard (base) + modifiers: no standalone Mods file
+        fp = mods_dir / f"{stem}.json"
+        if not fp.is_file():
+            continue
+        rules = _parse_mode_rules(json.loads(fp.read_text("utf-8")))
+        changes: list[str] = []
+
+        for scalar in ("starting_cash", "starting_lives"):
+            if scalar in rules and rules[scalar] != mode.get(scalar):
+                changes.append(f"{scalar} {mode.get(scalar)} -> {rules[scalar]}")
+                mode[scalar] = rules[scalar]
+
+        mode["rules"] = rules
+        report[mode["id"]] = changes
+
+    payload["mode_rules_source"] = _SOURCE
+    if not dry_run:
+        _write(path, payload)
+    return report
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument(
@@ -2653,6 +2792,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="source bloon children/immunity/health/speed from the dump (overlay bloons.json)",
     )
+    ap.add_argument(
+        "--modes",
+        action="store_true",
+        help="source mode rules (cash/lives/rounds/cost + restrictions) from the dump's Mods/ folder (overlay modes.json)",
+    )
     ap.add_argument("--dry-run", action="store_true", help="print, do not write")
     args = ap.parse_args(argv)
 
@@ -2687,6 +2831,27 @@ def main(argv: list[str] | None = None) -> int:
             for bid in sorted(report):
                 print(f"  {bid}")
                 for change in report[bid]:
+                    print(f"      {change}")
+        return 0
+
+    if args.modes:
+        report = overlay_modes(dump, dry_run=args.dry_run)
+        verb = "would correct" if args.dry_run else "corrected"
+        corrections = {k: v for k, v in report.items() if v}
+        if not corrections:
+            print(
+                f"modes: structured rules sourced from Mods/ for "
+                f"{len(report)} mode(s); cash/lives already match game data "
+                f"(0 corrections) — provenance recorded.",
+            )
+        else:
+            print(
+                f"modes: rules sourced for {len(report)} mode(s); "
+                f"{verb} {len(corrections)} value(s)\n",
+            )
+            for mid in sorted(corrections):
+                print(f"  {mid}")
+                for change in corrections[mid]:
                     print(f"      {change}")
         return 0
 

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -697,6 +697,132 @@ def test_overlay_bloons_sources_health_speed_and_fortified(mod, tmp_path, monkey
     assert "children_immunity_source" not in payload
 
 
+def _mode_mut(short, **fields):
+    """A single mutatorMods entry with the dump's fully-qualified ``$type``."""
+    return {
+        "$type": f"Il2CppAssets.Scripts.Models.Gameplay.Mods.{short}, Assembly-CSharp",
+        **fields,
+    }
+
+
+def test_parse_mode_rules_normalizes_mutators_and_drops_economy_noise(mod):
+    raw = {
+        "mutatorMods": [
+            _mode_mut("StartingCashModModel", changeBase=650.0, multiplier=0.0),
+            _mode_mut("MaxHealthModModel", set=1.0),  # the 1-life cap
+            _mode_mut("StartingRoundModModel", round=6),
+            _mode_mut("EndRoundModModel", round=100),
+            _mode_mut("GlobalCostModModel", multiplier=1.2),
+            _mode_mut("LockTowerModModel", towerToLock="BananaFarm"),
+            _mode_mut("LockTowerSetModModel", towerSetToLock=2),  # Military
+            _mode_mut("DisableContinueModModel"),
+            _mode_mut("DisableMonkeyKnowledgeModModel"),
+            # Standard economy curve — must be dropped, not surfaced as a rule.
+            _mode_mut("MonkeyMoneyModModel", changeBase=1.0, multiplier=0.0),
+            _mode_mut("BonusCashPerRoundModModel", baseCash=5, roundMultiple=1),
+            _mode_mut("SellMultiplierModModel", addition=0.7, multiplier=0.0),
+        ],
+    }
+    assert mod._parse_mode_rules(raw) == {
+        "starting_cash": 650,
+        "starting_lives": 1,
+        "start_round": 6,
+        "end_round": 100,
+        "cost_multiplier": 1.2,
+        "no_continues": True,
+        "no_monkey_knowledge": True,
+        "locked_tower_classes": ["military"],
+        "locked_towers": ["BananaFarm"],
+    }
+    # A HalfCash-style mod sets only the income multiplier; nothing else leaks in.
+    assert mod._parse_mode_rules(
+        {"mutatorMods": [_mode_mut("ModifyAllCashModModel", multiplier=0.5)]},
+    ) == {"income_multiplier": 0.5}
+
+
+def test_overlay_modes_attaches_rules_and_corrects_scalars(mod, tmp_path, monkeypatch):
+    dump = tmp_path / "dump"
+    # Sandbox's absolute lives override differs from a curated typo (extra 9).
+    _write(
+        dump / "Mods" / "Sandbox.json",
+        {
+            "mutatorMods": [
+                _mode_mut("StartingCashModModel", changeBase=9999999.0, multiplier=0.0),
+                _mode_mut("StartingHealthModModel", addition=999999.0, multiplier=0.0),
+            ],
+        },
+    )
+    _write(
+        dump / "Mods" / "Impoppable.json",
+        {
+            "mutatorMods": [
+                _mode_mut("StartingRoundModModel", round=6),
+                _mode_mut("MaxHealthModModel", set=1.0),
+                _mode_mut("GlobalCostModModel", multiplier=1.2),
+                _mode_mut("EndRoundModModel", round=100),
+            ],
+        },
+    )
+    data_root = tmp_path / "data"
+    _write(
+        data_root / "modes.json",
+        {
+            "data_version": "3.0",
+            "game_version": "55.1",
+            "source": "curated",
+            "modes": [
+                {
+                    "id": "sandbox",
+                    "canonical": "Sandbox",
+                    "kind": "mode",
+                    "aliases": [],
+                    "description": "",
+                    "restrictions": [],
+                    "starting_cash": 9999999,
+                    "starting_lives": 9999999,  # curated typo — dump says 999999
+                },
+                {
+                    "id": "impoppable",
+                    "canonical": "Impoppable",
+                    "kind": "mode",
+                    "aliases": [],
+                    "description": "",
+                    "restrictions": [],
+                    "starting_cash": 650,
+                    "starting_lives": 1,  # already correct (MaxHealth.set=1)
+                },
+                {
+                    "id": "standard",  # no Mods file → no rules attached
+                    "canonical": "Standard",
+                    "kind": "mode",
+                    "aliases": [],
+                    "description": "",
+                    "restrictions": [],
+                    "starting_cash": 650,
+                    "starting_lives": 150,
+                },
+            ],
+        },
+    )
+    monkeypatch.setattr(mod, "_DATA_ROOT", data_root)
+    report = mod.overlay_modes(dump, dry_run=False)
+    assert report["sandbox"] == ["starting_lives 9999999 -> 999999"]
+    assert report["impoppable"] == []  # rules attached, no scalar correction
+    assert "standard" not in report  # unmapped → untouched
+
+    written = {m["id"]: m for m in json.loads((data_root / "modes.json").read_text())["modes"]}
+    assert written["sandbox"]["starting_lives"] == 999999
+    assert written["impoppable"]["rules"] == {
+        "start_round": 6,
+        "starting_lives": 1,
+        "cost_multiplier": 1.2,
+        "end_round": 100,
+    }
+    assert "rules" not in written["standard"]
+    payload = json.loads((data_root / "modes.json").read_text())
+    assert payload["mode_rules_source"]
+
+
 def test_map_monkey_knowledge_uses_category_folder(mod, tmp_path):
     dump = tmp_path / "dump"
     _write(

--- a/tests/unit/services/test_btd6_data_service.py
+++ b/tests/unit/services/test_btd6_data_service.py
@@ -203,6 +203,28 @@ def test_chimps_mode_has_no_income_restriction():
     )
 
 
+def test_mode_rules_block_grounds_prose_from_game_data():
+    """The structured ``rules`` block (sourced from Mods/ via parse_gamedata
+    --modes) loads onto ModeEntry and backs the prose restrictions with game
+    values; Standard (no Mods file) carries an empty block."""
+    dataset = get_dataset()
+    by_id = {m.id: m for m in dataset.modes}
+
+    impoppable = by_id["impoppable"]
+    assert impoppable.rules["start_round"] == 6
+    assert impoppable.rules["end_round"] == 100
+    assert impoppable.rules["starting_lives"] == 1
+    assert impoppable.rules["cost_multiplier"] > 1  # higher tower prices
+
+    chimps = by_id["chimps"]
+    assert chimps.rules["no_continues"] is True
+    assert chimps.rules["no_monkey_knowledge"] is True
+    assert "BananaFarm" in chimps.rules["locked_towers"]  # no income
+
+    # Standard is the unmutated base — no Mods file, so no rules attached.
+    assert by_id["standard"].rules == {}
+
+
 def test_alias_collision_fails_loudly(tmp_path):
     """A duplicate alias across categories must abort dataset loading."""
     bad_root = tmp_path / "btd6"


### PR DESCRIPTION
## What

Adds a `--modes` overlay to `parse_gamedata.py` that sources structured, game-grounded **rules** from the dump's `Mods/<mode>.json` into `modes.json` — the next step on the "map everything" goal, and the cutover that finally grounds the mode rules in game data (correcting the old "the dump has no game-mode rules" finding — they live in `Mods/`, same place MK effects do).

- **`_parse_mode_rules(mutatorMods)`** normalizes the 24-type mutator vocabulary into a clean `rules` dict: `starting_cash`/`starting_lives`, `start_round`/`end_round`, `cost_multiplier`/`speed_multiplier`/`income_multiplier`, `{tag}_health_multiplier`, `round_set`, `locked_tower_classes`/`locked_towers`, and `no_continues`/`no_selling`/`no_monkey_knowledge`/`no_income`/`reverse` flags. The **standard economy curve** (MonkeyMoney / BonusCashPerRound / SellMultiplier / SetHealthForBloon) is deliberately dropped — only what *varies* and *restricts*.
- **`overlay_modes`** maps the 15 modes that have a Mods file (`_MODE_MODS` — note CHIMPS' internal name is `Clicks`), attaches the `rules` block, **verifies** `starting_cash`/`starting_lives` against the dump's absolute overrides, and records `mode_rules_source`.
- The curated **taxonomy** (`kind` / `difficulties` / prose `description`+`restrictions`) is *not* in the dump and stays curated.

The rules ground the prose precisely — e.g. Impoppable `start_round:6 end_round:100 cost×1.2`, CHIMPS `no_continues/no_selling/no_monkey_knowledge + lock BananaFarm`, Deflation `no_income/start_round:31`, Hard `cost×1.08/speed×1.25/start_round:3`.

## Found a real curated typo

The cash/lives verification **caught one genuine correction**: Sandbox `starting_lives` was `9999999` (7 nines) vs the game model's `999999` (6 nines). Everything else matched.

## Runtime

Added `ModeEntry.rules: dict` (+ `_parse_mode` reads it). **Display is unchanged** — wiring the structured block into the mode embed (`cogs/btd6/_embeds.py`, `btd6_response_builder.py`) is the teed-up follow-up, kept out of this PR to stay contained.

## Tests

- `_parse_mode_rules` normalizer, including the economy-noise drop.
- Full `overlay_modes` test — `monkeypatch`ed `_DATA_ROOT` + tmp `Mods/`: Sandbox correction, rules attached, unmapped mode (Standard) left untouched.
- Data-service test that `ModeEntry.rules` loads and grounds the prose.

`check_quality --full` green (8170 passed, +3); `check_architecture --mode strict` 0 errors. Coverage map + decode-status ledger updated; the `--modes` re-run is idempotent.

## Note

This was the last build of the session; the session log (`.sessions/2026-06-08-btd6-mode-rules-cutover.md`) carries the continuation plan and a workflow reflection the maintainer asked for.

https://claude.ai/code/session_01UZCi9DFBDQHPZfMwr1xQ3h

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZCi9DFBDQHPZfMwr1xQ3h)_