### PR TITLE
docs: map idea backlog into roadmap drafts

### DIFF
--- a/.sessions/2026-06-08-idea-roadmap-mapping.md
+++ b/.sessions/2026-06-08-idea-roadmap-mapping.md
@@ -1,0 +1,65 @@
+# Idea-to-roadmap mapping session — 2026-06-08
+
+## Goal and result
+
+Consolidated the current idea backlog into one lifecycle inventory and eight roadmap-shaped routing/planning drafts without implementing runtime features. The pass preserves current authorities, keeps server management as the active lane, aligns AI extensions under the authoritative AI roadmap, preserves ADR-002/ADR-006/ADR-007 boundaries, and routes product-sensitive decisions to Q-0038–Q-0042.
+
+## Live PR verification
+
+Attempted before trusting in-repo snapshots. `gh` is unavailable and this checkout has no configured Git remote, so live GitHub open PRs could not be verified from this environment. No live-PR claim was inferred. Future promotion sessions must verify live PRs in a connected checkout.
+
+## Docs created
+
+- `docs/planning/idea-roadmap-inventory-2026-06-08.md`
+- `docs/planning/social-community-progression-roadmap-2026-06-08.md`
+- `docs/planning/economy-marketplace-rewards-roadmap-2026-06-08.md`
+- `docs/planning/games-mining-idle-roadmap-2026-06-08.md`
+- `docs/planning/server-management-extension-routing-2026-06-08.md`
+- `docs/planning/integrations-media-voice-website-roadmap-2026-06-08.md`
+- `docs/planning/ux-discoverability-mobile-roadmap-2026-06-08.md`
+- `docs/ai/ai-product-extension-routing-2026-06-08.md`
+- `docs/btd6/btd6-product-extension-routing-2026-06-08.md`
+
+## Lifecycle outcomes
+
+- New roadmap drafts: social/community/progression; economy/marketplace/rewards; games/mining/idle; integrations/media/voice/website; UX/discoverability/mobile; BTD6 product extensions.
+- Routing addenda, not competing plans: AI product extensions; server-management/setup/access/routine extensions.
+- Existing plans retained: mining wire, adaptive setup/access/routine, authoritative AI roadmap/tool/orchestration plans, server-management trackers, interface/mother-hub/command backlogs, games deferred actionability.
+- Blocked/rejected boundaries retained: no AI action tools now, no BTD6 extraction bypass, no Redis/restart-safe games, no duplicate simulators/panels/helpers/dashboards, no arbitrary automation, no unreviewed provider/media/voice work.
+- Open questions: Q-0038 guild tenancy/identity; Q-0039 VIP/donation fairness; Q-0040 AI DM posture; Q-0041 integrations/voice privacy/provider posture; Q-0042 website product/control-plane posture.
+
+## Source verification notes
+
+Manual source-tree verification confirmed the existing economy, game-state, blackjack, mining, AI, BTD6, access/setup/moderation, and YouTube/media seams named in the drafts. No `disbot/*.py` file was opened or modified, so no source context map was required. CodeGraph tooling was not available as a configured command/resource in this environment; manual `find`/`rg` and the generated context index were used instead.
+
+## Context delta
+
+### needed-not-pointed
+
+- A connected-checkout fallback recipe for mandatory live PR verification when `gh` or a Git remote is absent.
+- A dedicated social/economy subsystem folio only if those domains are later approved; creating one now would prematurely invent ownership.
+- A canonical release-manifest owner for changelog/balance notices.
+
+### pointed-not-needed
+
+- Generated context packs beyond `docs/agent/index.yml`; the index and folios were sufficient, and generated packs were not edited.
+- Most 2026-06-07/08 session journals; current plans/folios and the owner-vision capture already explained the current routing.
+- CodeGraph commands; no usable CodeGraph interface was exposed in this environment.
+
+### discovered-by-hand
+
+- The source tree already contains canonical economy, game-state, mining, AI, BTD6, access, setup, moderation, and shared YouTube/media seams that future plans must extend.
+- There is no approved social/guild or voice owner, which makes owner/architecture decisions mandatory before schema planning.
+- The owner-selected “quick-win” labels do not clear lifecycle promotion gates; most ideas still need balance, privacy, authority, or product decisions.
+
+## Validation
+
+Run after edits:
+
+- `python3.10 scripts/check_docs.py`
+- `python3.10 tools/agent_context/validate_pack.py`
+- `python3.10 scripts/check_architecture.py --mode strict`
+
+## Recommended handoff
+
+First Opus product revision: social/community/progression after Q-0038. First safe executable candidate remains the separately approved mining-wire plan; UX mobile audit/read-only Help routing are possible bounded Sonnet planning/execution candidates only when selected by the authoritative interface lane. AI actions/events/DM, BTD6 extensions, integrations/voice/web, analytics, poker concurrency, and cross-server social identity remain mapping-only or gated.

--- a/docs/ai/ai-product-extension-routing-2026-06-08.md
+++ b/docs/ai/ai-product-extension-routing-2026-06-08.md
@@ -1,0 +1,51 @@
+# AI Product Extensions — routing addendum
+
+> **Status:** `plan` — planning/routing draft; not implementation approval.
+> **Authority:** `docs/planning/ai-roadmap-2026-06-07.md`; this addendum does not compete with it.
+> **Horizon:** Later, fully gated. **Owner decision needed:** Q-0040 for AI dungeon-master posture.
+
+## Planning contract
+
+- **Status:** roadmap draft; routing only, not approval and not an active implementation lane.
+- Source code, merged PRs, binding contracts, subsystem folios, and `docs/current-state.md` outrank this draft.
+- Preserve domain-service mutation ownership, direct-vs-draft lane rules, deterministic event flow, auditability, rollback safety, observability, cache invalidation, and testability.
+- Before implementation, re-verify source, live PRs, the relevant folio, and every named gate.
+
+## Context and objective
+
+Route AI dungeon master, AI-generated game events, wider natural-language intent coverage, and the extra-tool backlog onto the existing AI roadmap. AI remains explanation/orchestration-only until every existing readiness, orchestration, guard, audit, provider, and dedicated action decision clears.
+
+## Scope and routing
+
+- Wider NL intent coverage: route to the central NL-stage/readiness work in the authoritative AI roadmap.
+- AI dungeon master and generated narrative/event concepts: product concepts only; mechanics/rewards/difficulty remain deterministic domain-service decisions. Q-0040 owns modes, persistence, cost, moderation, and retention posture.
+- Web/vision/file/KB/connectors/scheduler/admin tools: already covered by `ai-extra-tool-capability-ideas.md` and `ai-tool-capability-roadmap.md`; sequence only after orchestration foundation.
+- AI-generated setup/moderation/actions: blocked until the dedicated action gates and decisions clear; use drafts/explanations, never direct writes.
+
+## Out of scope
+
+AI write/action tools now, AI-owned game rewards or difficulty authority, raw reasoning/tool-result retention, a second AI roadmap/orchestrator, or bypassing provider/provenance/grounding gates.
+
+## Existing seams and likely roots
+
+Reuse `ai_task_router`, `ai_tools`, orchestration policy/descriptors/budgets, `ai_natural_language_policy`, permission/decision-audit/readiness/diagnostics services, `ai_gateway`, domain-owned read tools, and typed evidence/result contracts. Likely roots are listed in the AI folio and service integration map.
+
+## Proposed sequence
+
+1. Follow the authoritative AI roadmap: readiness and orchestration foundation first.
+2. Improve wider intent classification/explanation without action authority.
+3. Add only approved read-only tools through descriptors, preflight, scopes, budgets, typed results, faithfulness, and safe traces.
+4. Prototype DM/event narrative as text wrapping deterministic domain outputs after Q-0040 and moderation/cost review.
+5. Consider any action/dynamic-scaling capability only after a dedicated owner/architecture decision and domain-service draft/confirmation path.
+
+## Dependencies, risks, and mechanics
+
+All AI gates in `docs/current-state.md` and the AI roadmap; Q-0040; provider cost/availability; prompt/content moderation; privacy/retention; deterministic authority; audit and safe-disable. Generated content cannot mutate rewards/state. Cache/source-health and provenance must be observable.
+
+## Migration, cache, audit, rollback, and test implications
+
+Defer schemas until the authoritative AI plan approves them; never persist raw reasoning or private tool results. Cache/source-health behavior follows approved providers/tools. Audit safe decisions/tool metadata and domain drafts, not hidden reasoning. Rollback is tool/provider/feature disable with domain-owned compensation only after confirmed actions are ever approved. Tests require scope/permission denials, budgets, provider failure, prompt/content safety, faithfulness, redaction, deterministic-domain authority, and no-action invariants.
+
+## Open questions and next session
+
+Q-0040 owns dungeon-master scope and operational posture. **Recommended next model/session:** first Opus AI session remains orchestration-foundation revision; Codex remains mapping-only for net-new AI actions, and Sonnet receives no action-tool implementation.

--- a/docs/btd6/btd6-product-extension-routing-2026-06-08.md
+++ b/docs/btd6/btd6-product-extension-routing-2026-06-08.md
@@ -1,0 +1,51 @@
+# BTD6 Product Extensions — routing draft
+
+> **Status:** `plan` — planning/routing draft; not implementation approval.
+> **Horizon:** Later. **Gate:** ADR-006 provenance/source-health/groundedness requirements and current BTD6 expansion gates.
+
+## Planning contract
+
+- **Status:** roadmap draft; routing only, not approval and not an active implementation lane.
+- Source code, merged PRs, binding contracts, subsystem folios, and `docs/current-state.md` outrank this draft.
+- Preserve domain-service mutation ownership, direct-vs-draft lane rules, deterministic event flow, auditability, rollback safety, observability, cache invalidation, and testability.
+- Before implementation, re-verify source, live PRs, the relevant folio, and every named gate.
+
+## Context and objective
+
+Route owner-selected BTD6 rules/trivia, challenge generation, score/run tracking, and leaderboards without using them to bypass provenance or extraction gates.
+
+## Scope
+
+- Rules/trivia as provenance-backed read surfaces over answerable facts.
+- Challenge generation as deterministic constraints plus provenance-backed facts; AI may explain only after AI gates.
+- Score/run tracking and leaderboards as a separate user-data/product decision with privacy, anti-cheat, and retention review.
+
+## Out of scope
+
+New extraction paths before gates clear; unsupported absence claims; derived values without evidence; AI-invented rules/challenges; BTD6-owned media pipeline; or unreviewed cross-server score profiles.
+
+## Current state and seams to reuse
+
+Reuse BTD6 source registry/provider/data/fact/grounding/cache/readiness/response/view-model services, provenance schema, freshness/source-health rendering, and shared leaderboard/economy patterns only after ownership review. ADR-007 owns media.
+
+Likely roots: `disbot/services/btd6_*`, `disbot/cogs/btd6*`, `disbot/views/btd6/`, `disbot/utils/db/btd6_data.py`, and the BTD6 data/provenance docs.
+
+## Proposed phases
+
+1. Keep provenance/source-health/decode work authoritative; do not expand extraction for these ideas.
+2. Define an answerability-backed rules/trivia read model and freshness UX.
+3. Define deterministic challenge constraints and validation using only supported facts.
+4. Decide score/run ownership, verification, privacy, retention, anti-cheat, and leaderboard scope before schema work.
+5. Consider AI wording/explanation only after AI gates, with deterministic challenge authority retained in BTD6 services.
+
+## Dependencies, risks, and mechanics
+
+ADR-006, provenance schema, source registry/health/cache clarity, groundedness/absence guards, provider parity, and privacy/anti-cheat decisions for user runs. Additive migrations, provenance on every fact, cache invalidation, audit for submissions/moderation, rollback/disable, and source-health tests are required.
+
+## Migration, cache, audit, rollback, and test implications
+
+Any facts or run records require additive provenance-aware migrations and explicit retention. Cache invalidation follows the source registry/ingestion owners and must expose freshness/source health. Audit submissions/moderation and source changes without fabricating evidence. Rollback disables unsupported facts/features and reverts through source-owned pipelines. Tests require provenance, answerability/absence guards, provider parity, stale/degraded sources, deterministic challenge validation, anti-cheat, and privacy.
+
+## Open questions and next session
+
+Score verification and leaderboard scope require owner/product review during a future revision. **Recommended next model/session:** keep Codex mapping-only until BTD6 gates clear; then Opus revises rules/trivia and run-tracking ownership.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -103,3 +103,9 @@ session ends with a grooming pass once the main task + PR are done and capacity 
 
 A **periodic sweep** (the `.session-journal.md` REVIEW cadence) confirms no idea is stuck
 at `raw`/`captured` with no destination — that is the no-orphan guarantee, made checkable.
+
+## Routed planning pass — 2026-06-08
+
+The current cross-source lifecycle outcomes are recorded in
+[`../planning/idea-roadmap-inventory-2026-06-08.md`](../planning/idea-roadmap-inventory-2026-06-08.md).
+That ledger groups ideas by canonical subsystem/platform seam and links the resulting roadmap drafts; it does not approve implementation or replace the preserved capture docs above.

--- a/docs/ideas/ai-extra-tool-capability-ideas.md
+++ b/docs/ideas/ai-extra-tool-capability-ideas.md
@@ -787,3 +787,8 @@ The strongest candidates for a first dedicated planning pass are:
 5. **Approved API connector base** — reusable foundation for GitHub, BTD6 live data, YouTube/Twitch, website checks, and custom APIs.
 
 Recommended next step: convert one of these into a dedicated planning doc that plugs into `AIOrchestrationPolicy`, `AIToolDescriptor`, strict schemas, budget controls, audit traces, and per-guild/channel configuration.
+
+
+## Routing update — 2026-06-08
+
+All tool families are routed as existing-plan or blocked-gate items in [`../planning/idea-roadmap-inventory-2026-06-08.md`](../planning/idea-roadmap-inventory-2026-06-08.md) and [`../ai/ai-product-extension-routing-2026-06-08.md`](../ai/ai-product-extension-routing-2026-06-08.md). The authoritative AI roadmap and orchestration/action gates still control sequencing.

--- a/docs/ideas/future-product-direction-2026-06-07.md
+++ b/docs/ideas/future-product-direction-2026-06-07.md
@@ -325,3 +325,8 @@ reviewed concept summary, not directly to implementation or an active tracker.
 - [x] Architecture boundaries remain explicit: thin cogs, service-owned mutations,
   centralized helpers, deterministic flows, correct authority seams, auditability,
   observability, testability, and rollback safety.
+
+
+## Routing update — 2026-06-08
+
+Its catalog is consolidated by cluster in [`../planning/idea-roadmap-inventory-2026-06-08.md`](../planning/idea-roadmap-inventory-2026-06-08.md). Existing-plan, blocked, rejected, and new-roadmap outcomes are explicit there; this source-aware capture remains canonical historical input, not an implementation queue.

--- a/docs/ideas/mining_exploration_brainstorm.md
+++ b/docs/ideas/mining_exploration_brainstorm.md
@@ -124,3 +124,8 @@ New files only; no existing file modified; nothing wired into a command yet:
 
 ### To activate image rendering
 Add `Pillow` to `requirements.txt`. Until then `utils/mining_render.render_inventory_card` returns `None` by design and the dependency footprint is unchanged.
+
+
+## Routing update — 2026-06-08
+
+The shipped-engine wiring remains owned by [`../planning/mining-wire-exploration-plan.md`](../planning/mining-wire-exploration-plan.md); deeper floors, bosses, events, co-op, idle extension, and crafting handoff are routed to [`../planning/games-mining-idle-roadmap-2026-06-08.md`](../planning/games-mining-idle-roadmap-2026-06-08.md). This brainstorm remains preserved and unapproved.

--- a/docs/ideas/owner-vision-ideas-2026-06-08.md
+++ b/docs/ideas/owner-vision-ideas-2026-06-08.md
@@ -317,3 +317,8 @@ the long-term roadmap even though it is the most complex.**
 | Notifications (DM + channel + inbox + CTAs) | M | Low | Plan |
 | Blueprint-drop crafting (future) | M | Low | Roadmap: Later horizon |
 | Balance change: in-game notice + changelog | S | Low | Quick-win candidate |
+
+
+## Routing update — 2026-06-08
+
+See the single-state routing ledger in [`../planning/idea-roadmap-inventory-2026-06-08.md`](../planning/idea-roadmap-inventory-2026-06-08.md) and its eight linked roadmap drafts. Product-sensitive items are routed to Q-0038–Q-0042; this capture remains preserved and none of its ideas is approved by that routing.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -1794,3 +1794,73 @@ Action owner: maintainer (ChatGPT template).
 **Critical caveat (agent-added, earned this session):** "complete and accurate" requires reading the **right** model. The dump carries template/variant models that look internally consistent but aren't the canonical one — the base `Ddt` template is non-camo (spawns `CeramicRegrow`) while the real in-game DDT is `DdtCamo` (spawns `CeramicRegrowCamo`); and a `DiamondbackDiamondBloon` variant reads health 60 while the canonical `DiamondBloon` is 80. **Both times a naïve "first matching file" pick produced a wrong value the maintainer's domain knowledge caught.** So: trust the dump, but select the model by the bloon's own properties (`_select_bloon_model`) and sanity-check a surprising value against gameplay before asserting it. Net effect this session: the BAD→Camo-DDT correction stands (dump was right, wiki incomplete); the Diamond "60" was withdrawn (variant artifact — canonical is 80, already matching).
 
 **Suggested destination after answer:** `docs/btd6/btd6-gamedata-decode-status.md` (provenance precedence note) + applied by the `--bloons` cutover's model-selection logic.
+
+### Q-0038 — What is the identity and tenancy boundary for player guilds/clans?
+
+**Area:** Social / community / progression
+**Type:** Product + architecture boundary
+**Priority:** High (blocks guild, guild-bank, guild-battle, guild-profile, and guild-leaderboard planning)
+**Status:** Open
+**Question:** Is a player guild/clan scoped independently inside each Discord server, or may one player guild span multiple Discord servers? If cross-server identity is wanted, what consent, discoverability, moderation, ownership-transfer, retention, deletion/export, and main-server behavior should apply?
+
+**Why agents need this:** The answer determines the canonical keys and owner for membership, treasury, battles, profiles, and leaderboards. Guessing would create either a duplicate per-server system or an unapproved cross-server identity system.
+
+**Safe default until answered:** Treat the social roadmap as planning-only. Do not create a guild/clan schema or expose cross-server profiles. Preserve existing Discord-guild scoping.
+
+**Suggested destination after answer:** `docs/planning/social-community-progression-roadmap-2026-06-08.md` and a dedicated ownership/ADR decision if a new social domain is approved.
+
+### Q-0039 — Which VIP/donation benefits are acceptable under the no-pay-to-win rule?
+
+**Area:** Economy / rewards
+**Type:** Product, monetization, and fairness boundary
+**Priority:** High (blocks VIP planning)
+**Status:** Open
+**Question:** Should VIP/donation tiers be limited to cosmetic identity and supporter recognition, or may they include convenience benefits? Which exact benefits are explicitly allowed or forbidden, and should donation status ever be stored or processed by SuperBot itself?
+
+**Why agents need this:** “No pay-to-win” is binding owner intent, but convenience, lottery entries, marketplace privileges, and economy-adjacent perks can still create gameplay advantage or external billing/privacy obligations.
+
+**Safe default until answered:** No paid/donation benefit affects XP, coins, drops, odds, cooldowns, market access/fees, guild power, or game outcomes. Do not add billing/provider integration.
+
+**Suggested destination after answer:** `docs/planning/economy-marketplace-rewards-roadmap-2026-06-08.md` and, if external payment data is approved, the integrations/privacy decision set.
+
+### Q-0040 — What operational posture should an AI dungeon master use?
+
+**Area:** AI / games / social
+**Type:** Product, cost, moderation, and retention boundary
+**Priority:** High (blocks AI dungeon-master and player-prompted event planning)
+**Status:** Open
+**Question:** For thread, persistent-channel, and DM modes, what should persist; who may start/join/control a session; what content/moderation limits apply; what cost/rate limits are acceptable; and may AI ever propose mechanics/rewards beyond narrative wrapping of deterministic game-owned outcomes?
+
+**Why agents need this:** The answer governs state ownership, privacy, content safety, provider spend, and whether the feature remains explanation/narrative-only or requires a future action-authority decision.
+
+**Safe default until answered:** No implementation. AI may not own rewards, difficulty, quests, or state mutations; all current AI expansion/action gates remain binding.
+
+**Suggested destination after answer:** `docs/ai/ai-product-extension-routing-2026-06-08.md` and the authoritative `docs/planning/ai-roadmap-2026-06-07.md`.
+
+### Q-0041 — What privacy and provider posture should integrations and voice use?
+
+**Area:** Integrations / media / voice
+**Type:** Privacy, credentials, moderation, retention, and degraded-provider policy
+**Priority:** High (blocks Twitch, YouTube alerts, Spotify/Last.fm, Steam, music, SFX, and speech commands)
+**Status:** Open
+**Question:** Which provider integrations should be considered first, who supplies/owns credentials, what user/server consent is required, what data/content may be cached and for how long, what moderation rules apply, and how should alerts/voice features behave when providers fail or rate-limit the bot?
+
+**Why agents need this:** These ideas share secrets, personal activity, third-party terms, moderation, retention/deletion, rate-limit, and outage behavior. Implementing one ad hoc would create a parallel provider or delivery path.
+
+**Safe default until answered:** No new provider or voice implementation; retain only the existing ADR-007-owned media seams and require opt-in, bounded retention, and safe degraded behavior in future plans.
+
+**Suggested destination after answer:** `docs/planning/integrations-media-voice-website-roadmap-2026-06-08.md` and the media folio/ADR if the shared platform boundary changes.
+
+### Q-0042 — Should a full web dashboard become a future product surface?
+
+**Area:** Website / cross-cutting UI
+**Type:** Product investment + architecture boundary
+**Priority:** Medium (future-only; blocks website planning)
+**Status:** Open
+**Question:** Is the intended website a read-only companion, a full management surface, or not a priority? If management is wanted, what authentication/authorization model, hosting/operations budget, privacy posture, and limit on website-specific behavior should apply?
+
+**Why agents need this:** A website can easily become a second control plane, duplicate Discord-native panels, or bypass domain mutation/audit/permission paths.
+
+**Safe default until answered:** Keep the website at Someday. Mature Discord-native panels and canonical read/mutation services first; do not create website-specific authority or mutations.
+
+**Suggested destination after answer:** `docs/planning/integrations-media-voice-website-roadmap-2026-06-08.md` and a dedicated architecture decision if promoted.

--- a/docs/planning/economy-marketplace-rewards-roadmap-2026-06-08.md
+++ b/docs/planning/economy-marketplace-rewards-roadmap-2026-06-08.md
@@ -1,0 +1,57 @@
+# Economy, Marketplace, and Rewards — roadmap draft
+
+> **Status:** `plan` — planning/routing draft; not implementation approval.
+> **Horizon:** Later. **Primary source:** `docs/ideas/owner-vision-ideas-2026-06-08.md` §2, §12–15, §23.
+> **Owner decision needed:** Q-0039 for VIP/donation boundaries.
+
+## Planning contract
+
+- **Status:** roadmap draft; routing only, not approval and not an active implementation lane.
+- Source code, merged PRs, binding contracts, subsystem folios, and `docs/current-state.md` outrank this draft.
+- Preserve domain-service mutation ownership, direct-vs-draft lane rules, deterministic event flow, auditability, rollback safety, observability, cache invalidation, and testability.
+- Before implementation, re-verify source, live PRs, the relevant folio, and every named gate.
+
+## Context and objective
+
+This draft groups marketplace trading, mining trade goods, cosmetics/titles, collectibles, streaks, chance rewards, coin sinks, starter onboarding, VIP tiers, and blueprint crafting behind the existing economy authority. The objective is a coherent, auditable economy rather than independent reward and trade mutation paths.
+
+## Scope
+
+Player listings/trades; mining resources as goods; non-gameplay cosmetics/titles and collectibles; currency/cosmetic/lottery streak rewards; transparent coin sinks; starter packs and first-run economy guidance; and future blueprint-drop crafting. VIP is decision-only until Q-0039 clears.
+
+## Out of scope
+
+Pay-to-win boosts, XP multipliers, gameplay advantages from donations, opaque gambling mechanics, or direct balance writes outside `economy_service`.
+
+## Current state and seams to reuse
+
+`disbot/services/economy_service.py` is the mutation seam; existing economy, inventory, mining, leaderboard, and audit DB helpers are the source-verification starting points. Mining recipes/items already exist and must be extended rather than replaced. Existing panel/view standards own UI composition.
+
+Likely roots: `disbot/services/economy_service.py`, `disbot/cogs/economy_cog.py`, `disbot/cogs/inventory_cog.py`, `disbot/cogs/mining/`, `disbot/cogs/mining_cog.py`, `disbot/utils/db/games/`, economy audit migrations, and economy/inventory views.
+
+## Proposed phases
+
+1. **Economy health and vocabulary:** measure faucets/sinks, define item identity/transferability, audit reasons, anti-abuse and rollback contracts.
+2. **Safe onboarding/reward slice:** starter pack and deterministic streak ledger with idempotent claim; lottery remains disabled pending chance-reward review.
+3. **Cosmetic/collectible ownership:** non-gameplay catalog and display bindings.
+4. **Marketplace:** atomic listing/escrow/purchase/cancel flows with fees as explicit sinks.
+5. **Mining/crafting integration:** tradeable resources and blueprint drops only after mining balance and item ownership are stable.
+6. **VIP decision follow-up:** only benefits explicitly approved through Q-0039 and technically enforced as non-pay-to-win.
+
+## Dependencies and gates
+
+Economy balance evidence; item ownership/source-of-truth decision; anti-fraud/rate-limit review; chance-reward legality/product review; Q-0039; and social/guild treasury semantics before shared-bank trading.
+
+## Risks and mechanics
+
+High risk: duplication exploits, race conditions, inflation, fraud, chargeback/donation coupling, and irreversible item transfers. Use transactions/idempotency, append-only audit reasons, explicit cache invalidation, additive migrations, admin reconciliation reads, and feature flags/safe-disable. Rollback must compensate through the economy owner, never rewrite balances ad hoc.
+
+## Migration, cache, audit, rollback, and test implications
+
+Add item/listing/reward schemas incrementally with reconciliation/backfill plans. Invalidate wallet, inventory, listing, and profile reads on canonical mutations. Audit every transfer, claim, fee, sink, and compensation with stable reason codes. Rollback uses disable plus economy-owned compensating entries, never ad hoc balance rewrites. Tests need transaction races, duplicate/retry behavior, fraud limits, odds, balance simulation, and migration rollback.
+
+## Open questions and next session
+
+- Q-0039 owns VIP/donation benefits and strict non-pay-to-win limits.
+- Decide legal/product posture for lottery entries before any executable plan.
+- **Recommended next model/session:** Opus economy architecture/revision; a later Sonnet slice may draft starter-pack or deterministic streak-read planning after economy-health evidence exists.

--- a/docs/planning/games-mining-idle-roadmap-2026-06-08.md
+++ b/docs/planning/games-mining-idle-roadmap-2026-06-08.md
@@ -1,0 +1,59 @@
+# Games, Mining, and Idle Growth — roadmap draft
+
+> **Status:** `plan` — planning/routing draft; not implementation approval.
+> **Horizon:** Later, except the already-promoted `!explore` wiring plan. **Boundary:** ADR-002 accepts non-restart-safe game sessions.
+
+## Planning contract
+
+- **Status:** roadmap draft; routing only, not approval and not an active implementation lane.
+- Source code, merged PRs, binding contracts, subsystem folios, and `docs/current-state.md` outrank this draft.
+- Preserve domain-service mutation ownership, direct-vs-draft lane rules, deterministic event flow, auditability, rollback safety, observability, cache invalidation, and testability.
+- Before implementation, re-verify source, live PRs, the relevant folio, and every named gate.
+
+## Context and objective
+
+This draft groups multiplayer poker, blackjack follow-ups, mining depth, an active+idle mining hybrid, bosses/events/co-op, blueprint crafting, and existing deferred games follow-ups. It extends existing game/mining owners and explicitly rejects Redis or restart-safe game-state proposals.
+
+## Scope
+
+- Multiplayer Texas Hold'em tables (3–6), lobby/blinds/hand progression, economy wagers.
+- Blackjack variants/side bets after engine/balance review.
+- Mining deeper floors, bosses, deterministic/random events, co-op, and an offline-resource/active-boost hybrid.
+- Blueprint drops routed to the economy/crafting roadmap.
+- Existing bounded games actionability follow-ups and the already-promoted mining wire plan.
+
+## Out of scope
+
+Redis, cross-process game state, restart-safe sessions/checkpointing, a standalone idle resource loop, or economy effects outside `economy_service`.
+
+## Current state and seams to reuse
+
+Games use `game_state_service`, game-specific engines/cogs/views, `economy_service`, and game DB helpers. Mining has shipped exploration, item, reward, and recipe modules; `docs/planning/mining-wire-exploration-plan.md` already owns the safe wiring slice.
+
+Likely roots: `disbot/services/game_state_service.py`, `disbot/services/blackjack_engine.py`, `disbot/services/economy_service.py`, `disbot/cogs/blackjack/`, `disbot/cogs/mining/`, `disbot/cogs/mining_cog.py`, `disbot/views/games/`, `disbot/views/mining/`, and `disbot/utils/db/games/`.
+
+## Proposed phases
+
+1. **Use existing plans:** wire exploration only after maintainer approval; separately select one bounded archived actionability follow-up.
+2. **Mining progression contract:** define deterministic depth/event/boss/reward boundaries, balance simulation, and co-op ownership without changing persistence assumptions.
+3. **Idle extension:** specify offline accrual caps, anti-abuse, clock handling, active boosts, and economy sink/source effects; extend mining only.
+4. **Blackjack variants:** isolated rules/odds/balance plan with explicit UI and payout audit.
+5. **Poker concept/architecture:** concurrency, table lifecycle, disconnect/refund semantics, moderation, and economy escrow before implementation sequencing.
+6. **Crafting handoff:** blueprint-drop events feed the economy-owned item/crafting contract.
+
+## Dependencies and gates
+
+ADR-002 remains binding; economy ledger/refund safety; deterministic event flow; abuse/balance review; social/guild decisions for guild battles or co-op identity; and owner approval before promoting any raw idea.
+
+## Risks and mechanics
+
+Poker and co-op are high concurrency/moderation risk. Restarts must cancel/refund according to ADR-002, not resume. Offline accrual needs bounded time calculations and test clocks. Additive migrations, idempotent rewards, cache invalidation, reconciliation reads, simulation tests, and safe-disable flags are required.
+
+## Migration, cache, audit, rollback, and test implications
+
+Any progression/item schema is additive; ephemeral game sessions remain non-migrated under ADR-002. Cache invalidation follows mining/economy owners. Audit stakes, rewards, refunds, offline accrual, and balance-sensitive events. Rollback cancels/refunds through existing owners and disables the feature; it never resumes games. Tests require deterministic engines, fake clocks, concurrency/disconnect/restart cases, payout/refund idempotency, simulations, and view flows.
+
+## Open questions and next session
+
+- Product/balance review is required for poker stakes, side bets, idle caps, and co-op rewards.
+- **Recommended next model/session:** Sonnet may execute only the separately approved mining-wire plan; Opus should revise poker/idle/mining-depth architecture. Codex remains mapping-only for game-state persistence proposals.

--- a/docs/planning/idea-roadmap-inventory-2026-06-08.md
+++ b/docs/planning/idea-roadmap-inventory-2026-06-08.md
@@ -1,0 +1,98 @@
+# Idea-to-roadmap inventory — 2026-06-08
+
+> **Status:** `plan` — planning/routing draft; not implementation approval.
+> **Sources consolidated:** all documents named in the 2026-06-08 idea-to-roadmap mapping request, plus relevant subsystem folios, binding decisions, and 2026-06-07/08 session journals where needed.
+> **Truth order:** source/merged PRs → binding docs → folios → current state → active plans → ideas → sessions/old plans.
+
+## Verification note
+
+Live GitHub open-PR verification was attempted first, but this checkout has neither `gh` nor a configured Git remote. Therefore no live PR claim is made here; every destination must re-check live PRs in a connected environment before promotion. The in-repo current-state/status documents and source tree were used only as the best available fallback.
+
+## How to read the inventory
+
+Each row is the single explicit lifecycle outcome for every idea named in that row. A row may group variants only where they share one owner, seam, gate, and destination. Risk/size are routing estimates, not commitments. “Roots/seams” are inspection starts, not permission to create new ownership.
+
+Lifecycle states used here: **existing plan**, **new roadmap draft**, **small executable plan**, **existing horizon**, **blocked gate**, **owner question**, **rejected**, and **duplicate/superseded**.
+
+## Owner-selected and product-direction inventory
+
+| Ideas (all variants named) | Owner / related areas | Roots and seams to reuse | Risk / size | Gate or question | Explicit state → destination |
+|---|---|---|---|---|---|
+| Guilds/clans; membership; shared bank; officers; upgrades/levels; guild battles; guild leaderboards | New social owner / economy, games | guild lifecycle, economy service, audit/event reads, leaderboard patterns | High / XL | Q-0038; privacy/tenancy; new owner decision | **owner question**, then **new roadmap draft** → [social roadmap](social-community-progression-roadmap-2026-06-08.md) |
+| Persistent achievements/badges: game, social, hidden | Social progression / games, economy | deterministic domain events, audit, existing game owners | Med / M | canonical event vocabulary; hidden disclosure | **new roadmap draft** → [social roadmap](social-community-progression-roadmap-2026-06-08.md) |
+| Profile cards: economy stats + guild membership/rank | Social read model / economy | economy/inventory reads, profile/panel standards | Med / S | privacy; Q-0038 for guild fields | **new roadmap draft** → [social roadmap](social-community-progression-roadmap-2026-06-08.md) |
+| Notifications: DM, channel, inbox/mail, action CTAs | Shared notification/read model / all domains | configured delivery, audit/event paths, panels | Med / M | consent, spam, retention, owner boundary | **new roadmap draft** → [social roadmap](social-community-progression-roadmap-2026-06-08.md); delivery also gated by Q-0041 where provider-backed |
+| Player marketplace; mining resources; cosmetic roles/titles; rare collectibles | Economy / mining, social | economy service, inventory, mining items, audit ledger | High / L | item authority, atomicity, fraud/balance | **new roadmap draft** → [economy roadmap](economy-marketplace-rewards-roadmap-2026-06-08.md) |
+| Streak rewards: coins/gems, cosmetics, lottery entries; daily bonus drops; random treasure drops; seasonal rewards | Economy rewards / games, routines | economy service, deterministic event/routine seam | Med / M | chance-reward/product review; anti-abuse | **new roadmap draft** → [economy roadmap](economy-marketplace-rewards-roadmap-2026-06-08.md) |
+| Coin sinks; starter packs; new-user economy flow | Economy / setup/help | economy service, existing setup/help panels | Med / M | balance evidence, idempotency | **new roadmap draft** → [economy roadmap](economy-marketplace-rewards-roadmap-2026-06-08.md) |
+| VIP tiers: in-game + donation; strict no-pay-to-win | Economy/product | economy authority; external billing only after decision | High / L | Q-0039 | **owner question** → Q-0039; concept routed to [economy roadmap](economy-marketplace-rewards-roadmap-2026-06-08.md) |
+| Blueprint-drop crafting | Economy/mining | existing mining recipes/items + economy item authority | Med / M | item authority and mining balance | **new roadmap draft** → economy Phase 5 + [games/mining roadmap](games-mining-idle-roadmap-2026-06-08.md) handoff |
+| Multiplayer Texas Hold'em (3–6), lobby/blinds/wagers | Games / economy, social | game-state service, game views, economy escrow/refund | High / L | concurrency, moderation, ADR-002 | **new roadmap draft** → [games/mining roadmap](games-mining-idle-roadmap-2026-06-08.md) |
+| Blackjack variants and side bets | Games / economy | blackjack engine/cog/views, economy service | Med / M | odds/balance/product review | **new roadmap draft** → [games/mining roadmap](games-mining-idle-roadmap-2026-06-08.md) |
+| Active+idle mining hybrid; offline accrual; active boosts | Mining/games / economy | existing mining exploration/items/rewards/recipes | High / M | anti-abuse, clocks, balance; no new loop | **new roadmap draft** → [games/mining roadmap](games-mining-idle-roadmap-2026-06-08.md) |
+| Mining bosses, deeper floors, events, co-op | Mining/games / social, economy | mining engine/modules, game-state/economy services | High / L | deterministic flow, balance, co-op identity | **new roadmap draft** → [games/mining roadmap](games-mining-idle-roadmap-2026-06-08.md) |
+| Wire `!explore` to shipped exploration engine | Mining | existing exploration engine and `resolve_to_legacy_tuple()` | Low / S | maintainer promotion/approval | **small executable plan** → existing `mining-wire-exploration-plan.md` (**not executed here**) |
+| Games actionability leftovers: inventory architecture, leaderboards, bot-duel stats, shared back buttons | Games | existing cogs/views/game DB helpers | Low–Med / S–M | choose one bounded slice | **existing horizon** → Games Later in `docs/roadmap.md` / archived actionability roadmap |
+| Restart-safe games, Redis-backed sessions/cache, universal checkpointing | Games/platform | none; ADRs forbid | High / XL | ADR-001 + ADR-002 | **rejected** → binding Ideas Lab rejection ledger / ADR-001 / ADR-002 |
+| AI dungeon master: thread, persistent channel, DM | AI / games, social | AI orchestration + deterministic domain owners | High / XL | Q-0040; all AI gates | **owner question** and **blocked gate** → Q-0040 + [AI routing addendum](../ai/ai-product-extension-routing-2026-06-08.md) |
+| AI-generated event narrative, dynamic difficulty, procedural quests, player-prompted events | AI / games, economy | AI orchestration; deterministic game/reward authority | High / L | AI action/readiness gates; moderation/cost | **blocked gate** → [AI routing addendum](../ai/ai-product-extension-routing-2026-06-08.md); narrative-only earliest |
+| Wider natural-language intent coverage | AI / help/access | central NL stage, task router, permission/readiness | Med / M | authoritative AI roadmap gates | **existing plan** → `ai-roadmap-2026-06-07.md` and [AI routing addendum](../ai/ai-product-extension-routing-2026-06-08.md) |
+| BTD6 rules/trivia; challenge generator; score/run tracking; BTD6 leaderboards | BTD6 / AI, social | BTD6 provider/fact/grounding/cache/source health | High / M–L | ADR-006; provenance; run privacy/anti-cheat | **blocked gate** → [BTD6 routing draft](../btd6/btd6-product-extension-routing-2026-06-08.md) |
+| Resume/expand BTD6 extraction for product ideas now | BTD6 | existing decode/provenance pipeline only | High / L | ADR-006/current gates | **rejected** for now → Ideas Lab rejection ledger and BTD6 folio |
+| Adaptive setup/access/profile/routine; quiet/availability; command-access explanations; setup guidance cards | Setup/access/server management | access projection, command access, setup diagnostics/operations, capability authority | Med–High / L | existing adaptive-plan questions/phases | **existing plan** → `adaptive-setup-access-routine-platform-2026-06-08.md`; summarized in [routing addendum](server-management-extension-routing-2026-06-08.md) |
+| Scheduled announcements/reminders | Routine/server management | future curated Routine Engine action, settings/bindings, audit | Med / M | automation authority/audit decision | **existing plan** → adaptive plan Routine Engine; clarified in [routing addendum](server-management-extension-routing-2026-06-08.md) |
+| Anti-spam/abuse detection: deterministic controls and AI detection | Moderation / AI | moderation service/config, readiness/audit | High / M | active tracker; AI gates for AI detection | deterministic portion **existing plan** → server-management roadmap; AI portion **blocked gate** → AI roadmap |
+| Owner/admin analytics; server insights | Diagnostics/server management | diagnostics/readiness/audit reads | High / L | privacy, retention, aggregation; no second dashboard | **new roadmap draft** routing only → [server-management extension routing](server-management-extension-routing-2026-06-08.md) |
+| Twitch alerts; YouTube alerts; Spotify/Last.fm; Steam/gaming APIs | Shared media/integrations | ADR-007 media services, provider health/cache/settings/delivery | High / M each | Q-0041; privacy/credentials/moderation/retention | **owner question** and **new roadmap draft** → Q-0041 + [integrations roadmap](integrations-media-voice-website-roadmap-2026-06-08.md) |
+| Voice music playback; sound effects; speech commands | New voice boundary / media, moderation | no approved owner; reuse access/settings/audit if approved | High / L | Q-0041; architecture, privacy, cost | **owner question** → Q-0041 + [integrations roadmap](integrations-media-voice-website-roadmap-2026-06-08.md) |
+| Full web dashboard | Web projection / all domains | canonical reads/services/panels only | High / XL | Q-0042; auth/privacy; Discord-native maturity | **owner question** and **blocked gate** → Q-0042 + [integrations roadmap](integrations-media-voice-website-roadmap-2026-06-08.md) |
+| Mobile-first UI; rich help/categories/search; changelog/what's-new; balance notices; funny/sarcastic personality; consistent panel language/action vocabulary | Interface/help/product copy | mother-hub/interface plans, UI standards, help/access routes, existing panels | Low–Med / S–M | Q-0036 for denial copy; release-manifest owner; tone review | **new roadmap draft** → [UX roadmap](ux-discoverability-mobile-roadmap-2026-06-08.md), with bounded slices routed through existing interface plans |
+| One slash command per sub-action; second panel/router/UI framework | Interface | existing hubs/router/persistent views | High / L | binding standards | **rejected** → Ideas Lab rejection ledger / command-integration standard |
+
+## Existing future-product, command, interface, and Ideas Lab inventory
+
+| Idea group | Reuse / owner | Explicit state → destination |
+|---|---|---|
+| Capability explanation, “why can't I edit/use,” access preview, Help locked reasons, moderation policy explainer, setup guidance, server-care checklist | Access projection, capability authority, setup diagnostics, existing Help/managers | **existing plan** → adaptive setup/access plan, server-management plans, command/interface backlogs; UX composition also routed to [UX roadmap](ux-discoverability-mobile-roadmap-2026-06-08.md) |
+| Diagnostics/readiness cards, regression/smoke status, source-health/freshness/provenance cards, migration health, logging route health, architecture warnings, support-report presets | Existing `ReadinessSnapshot`, health/diagnostics owners, BTD6 source health | **existing plan/horizon** → health folio, command/interface backlogs, BTD6/AI plans; smoke runner remains future/gated |
+| Cleanup dry-run/history, counting health/rules, RPS matchup, refund hints/lookups, coin history, inventory filters/search, mod case timeline, panel drift/recovery/anchor hints | Existing domain reads/views and interface plans | **existing plan/horizon** → Ideas Lab quick index, command expansion, interface completion, archived games follow-ups |
+| Unified audit/event timeline read service | Existing audit/event owners / cross-cutting | **blocked gate** → Later concept only; privacy/retention and ownership decision required before a new read service |
+| Workflow recovery/resume and final-review preflight diff | Existing setup workflow/final review | **existing plan/horizon** → setup/adaptive plans; final-review diff remains ADR-003-deferred |
+| Guild template/provisioning model and deterministic role/setup templates | Provisioning/setup/server management | **existing plan** → server-management/adaptive setup plans; AI generation remains gated |
+| Rule/automation builder, arbitrary automation recipes/scripts | Routine/capability authority | **blocked gate** for curated Routine Engine; arbitrary scripts **rejected** by Ideas Lab operating decisions |
+| Shared media/video-reference and channel summary | Shared media owner | **existing horizon** → Media Later + ADR-007; broader providers routed to [integrations roadmap](integrations-media-voice-website-roadmap-2026-06-08.md) |
+| BTD6 strategy workspace, answerability checker, data inventory/provider parity/source health | BTD6 | **existing plan/horizon** and **blocked gate** → BTD6 plans/folio; no extraction bypass |
+| AI admin advisor, decision/guard/tool-coverage explainers, support reports | AI diagnostics/orchestration | **existing plan** and **blocked gate** → authoritative AI roadmap; explanation-only |
+| Cross-process/sharding readiness | Platform | **blocked gate** → Someday only; ADR-001 triggers required |
+| Separate danger dashboard, second governance simulator, global fail-closed, big all-cogs sweep, generic helper module | Existing canonical owners | **rejected** → binding Ideas Lab rejection ledger |
+| Stale UI/helper/status inventories treated as live backlog | Docs/workflow | none | **rejected** → source verification required by current-state/readiness review |
+
+## AI extra-tool capability inventory
+
+| Ideas | Owner/reuse | Risk / gate | Explicit state → destination |
+|---|---|---|---|
+| Web research; image vision; file/log/document reader; OCR; knowledge-base search; chart generation | Existing AI orchestration descriptors, typed results/evidence, scopes/budgets/audit | Med–High; AI readiness/orchestration/privacy/provider gates | **existing plan** → `ai-tool-capability-roadmap.md` after orchestration foundation; summarized in [AI routing addendum](../ai/ai-product-extension-routing-2026-06-08.md) |
+| GitHub/CI reader; website/API status; YouTube/Twitch status; Google Sheets/Docs reader; approved API fetch | AI orchestration + shared provider/media owners | High; credentials, provenance, privacy, provider health | **existing plan** but **blocked gate** → AI tool roadmap; provider product surfaces also Q-0041/integrations roadmap |
+| Scheduler/recurring reports; notification delivery; safe admin actions; moderation recommendations | AI orchestration + domain owners | High; dedicated action decision, confirmation, audit, rollback | **blocked gate** → authoritative AI roadmap/tool roadmap; no write/action tools now |
+| Bot health, BTD6 tools, diagnostics, server context, evidence, trace/audit foundations | Existing canonical services/contracts | Already mapped | **duplicate/superseded** as net-new ideas → extend existing AI orchestration/readiness plans, do not create duplicates |
+
+## Destination summary
+
+| Cluster | Destination | Horizon / gate |
+|---|---|---|
+| Social/community/progression | [social roadmap](social-community-progression-roadmap-2026-06-08.md) | Later; Q-0038 + privacy/new-owner decision |
+| Economy/marketplace/rewards | [economy roadmap](economy-marketplace-rewards-roadmap-2026-06-08.md) | Later; economy health + Q-0039/chance review |
+| Games/mining/idle | [games/mining roadmap](games-mining-idle-roadmap-2026-06-08.md) | Later; ADR-002; mining wire remains separate ready plan |
+| AI extensions | [AI routing addendum](../ai/ai-product-extension-routing-2026-06-08.md) | Later; authoritative AI roadmap and all AI gates |
+| BTD6 extensions | [BTD6 routing draft](../btd6/btd6-product-extension-routing-2026-06-08.md) | Later; ADR-006/provenance gates |
+| Server management/setup/access/routine | [extension routing](server-management-extension-routing-2026-06-08.md) | Existing plans; do not compete with active tracker |
+| Integrations/media/voice/website | [integrations roadmap](integrations-media-voice-website-roadmap-2026-06-08.md) | Later/Someday; Q-0041/Q-0042 + privacy/security/moderation |
+| UX/discoverability/mobile | [UX roadmap](ux-discoverability-mobile-roadmap-2026-06-08.md) | Later; select bounded work through existing interface lane |
+
+## Recommended next sessions
+
+1. **Opus first:** social/community architecture after Q-0038, because it is the owner's top product direction and determines guild/economy/profile/leaderboard semantics.
+2. **Opus next:** economy marketplace/rewards architecture, then integrations privacy/credential decision pack; AI's first Opus target remains its already-recorded orchestration foundation, not these new product ideas.
+3. **Sonnet-safe only after explicit selection:** the already-written mining-wire plan; a bounded mobile-first audit; or a read-only Help/access explanation slice from an existing authoritative plan.
+4. **Codex mapping-only:** AI action tools/events/DM, BTD6 extension/extraction, poker concurrency, voice, website, cross-server social identity, analytics, and provider integrations until their decisions/gates clear.
+5. **Off-limits:** Redis/restart-safe games; duplicate governance/panel/helper/dashboard systems; arbitrary automation; AI writes/actions now; BTD6 extraction bypass; unreviewed provider/media/voice collection.

--- a/docs/planning/integrations-media-voice-website-roadmap-2026-06-08.md
+++ b/docs/planning/integrations-media-voice-website-roadmap-2026-06-08.md
@@ -1,0 +1,52 @@
+# Integrations, Media, Voice, and Website — roadmap draft
+
+> **Status:** `plan` — planning/routing draft; not implementation approval.
+> **Horizon:** Later/Someday. **Owner decisions needed:** Q-0041 and Q-0042. **Media boundary:** ADR-007.
+
+## Planning contract
+
+- **Status:** roadmap draft; routing only, not approval and not an active implementation lane.
+- Source code, merged PRs, binding contracts, subsystem folios, and `docs/current-state.md` outrank this draft.
+- Preserve domain-service mutation ownership, direct-vs-draft lane rules, deterministic event flow, auditability, rollback safety, observability, cache invalidation, and testability.
+- Before implementation, re-verify source, live PRs, the relevant folio, and every named gate.
+
+## Context and objective
+
+Group Twitch/YouTube alerts, Spotify/Last.fm, Steam/gaming APIs, music playback, sound effects, speech commands, and a full web dashboard around shared provider/privacy/credential/retention/moderation/degraded-service concerns. This avoids provider-specific pipelines and prevents the website from becoming a second control plane.
+
+## Scope
+
+Read-only provider adapters and status/alert concepts; opt-in delivery; shared credential/health/freshness/provenance behavior; voice/music concept review; and a future web projection of canonical Discord-native reads/actions.
+
+## Out of scope
+
+Implementation before Q-0041, public media surfaces without privacy/provenance/moderation review, a BTD6- or AI-owned YouTube pipeline, storing unnecessary content/transcripts, or a website with independent mutation authority.
+
+## Current state and seams to reuse
+
+ADR-007 makes media a shared platform subsystem. Existing YouTube fetch/context/cache/render seams are the first reuse target. Health/readiness, settings/bindings, audit/event delivery, command access, and canonical panels/services must remain authoritative. Voice has no approved owner and requires an architecture/product decision.
+
+Likely roots: `disbot/services/youtube_context_service.py`, `disbot/services/youtube_fetch_service.py`, `disbot/services/video_reference_cache_service.py`, `disbot/utils/db/youtube_video_cache.py`, `disbot/views/youtube_*`, provider settings/bindings, health/diagnostics, and canonical domain services exposed through panels.
+
+## Proposed phases
+
+1. **Decision pack:** answer Q-0041/Q-0042; define provider allowlist, credential ownership, consent, retention/deletion, moderation, cost/rate limits, and degraded-provider UX.
+2. **Shared provider contract:** health/freshness/provenance/cache/alert-delivery interfaces extending media ownership; no new public command yet.
+3. **One read-only/opt-in alert pilot:** choose YouTube or Twitch only after review, with safe disable and rate limits.
+4. **Additional read integrations:** Spotify/Last.fm and Steam only if the shared contract proves reusable.
+5. **Voice concept:** separate architecture review for playback/SFX/speech privacy, permissions, moderation, and operational cost.
+6. **Website concept:** read-only projection first; reuse canonical authentication/authority/audit and domain mutation services if later approved.
+
+## Dependencies, risks, and mechanics
+
+Q-0041/Q-0042, ADR-007, privacy/security/moderation review, secrets management, provider terms, rate limits/cost, retention/deletion, and abuse controls. Caches need provenance/freshness and bounded retention. Provider outages must degrade safely. Mutations/delivery require audit, permission re-checks, idempotency, and rollback/disable.
+
+## Migration, cache, audit, rollback, and test implications
+
+Provider/account/config schemas must be additive and deletion-aware. Cache only bounded, provenance/freshness-labelled data and invalidate on provider/config changes. Audit credential/config/delivery/control actions without logging secrets or private content. Rollback is provider/feature disable plus deletion/revocation support. Tests need consent, permissions, secret redaction, rate limits, outages, stale caches, duplicate alerts, moderation, and website authority parity.
+
+## Open questions and next session
+
+- Q-0041 owns integration/voice privacy, credentials, moderation, retention, and degraded-provider posture.
+- Q-0042 owns website investment, authentication, and control-plane limits.
+- **Recommended next model/session:** Opus decision/revision after answers; Codex mapping-only until gates clear.

--- a/docs/planning/server-management-extension-routing-2026-06-08.md
+++ b/docs/planning/server-management-extension-routing-2026-06-08.md
@@ -1,0 +1,50 @@
+# Server Management, Setup, Access, and Routine Extensions — routing draft
+
+> **Status:** `plan` — planning/routing draft; not implementation approval.
+> **Horizon:** Existing authoritative plans; this doc is a routing addendum, not a competing server-management tracker.
+
+## Planning contract
+
+- **Status:** roadmap draft; routing only, not approval and not an active implementation lane.
+- Source code, merged PRs, binding contracts, subsystem folios, and `docs/current-state.md` outrank this draft.
+- Preserve domain-service mutation ownership, direct-vs-draft lane rules, deterministic event flow, auditability, rollback safety, observability, cache invalidation, and testability.
+- Before implementation, re-verify source, live PRs, the relevant folio, and every named gate.
+
+## Context and objective
+
+Route owner ideas for scheduled announcements, anti-spam/abuse detection, quiet/availability policy, access explanations, setup guidance, owner analytics, and future automation into the existing server-management and adaptive setup/access/routine authorities.
+
+## Scope and destination
+
+- Adaptive setup, access explanations, Help Preview, locked reasons, central availability/quiet policy, setup guidance, profiles, and routine-engine extension: already covered by `adaptive-setup-access-routine-platform-2026-06-08.md`.
+- Moderation configuration and safe deterministic anti-spam controls: route to the server-management roadmap/status tracker; AI-based detection stays AI-gated.
+- Scheduled announcements/reminders: route as a curated Routine Engine action only after its authority/audit decision.
+- Owner/admin analytics: read-only reviewed concept after privacy/retention/aggregation decisions; reuse diagnostics/audit reads, not a new dashboard.
+
+## Out of scope
+
+A second server-management tracker, arbitrary automation scripts, direct Discord mutations, AI moderation actions, or analytics collection before privacy review.
+
+## Existing seams and likely roots
+
+Reuse `setup_diagnostics`, `setup_operations`, `command_access_service`, `access_projection`, capability/governance resolution, moderation services/config, settings/bindings/provisioning lanes, existing managers/hub, readiness/audit/event reads, and the future Routine Engine seam named by the adaptive plan. Likely roots include `disbot/services/setup_*`, `disbot/services/command_access_service.py`, `disbot/services/access_projection.py`, `disbot/services/moderation_*`, `disbot/services/governance_service.py`, and server-management/setup views.
+
+## Proposed slices
+
+1. Continue only the authoritative active server-management/status sequence.
+2. Revise adaptive-plan read-only access/explanation and availability-policy slices after its existing owner questions clear.
+3. Produce a deterministic scheduled-announcement action contract as part of Routine Engine planning: curated action, preview, confirmation, audit, disable, retry/degraded behavior.
+4. Extend moderation policy/readiness explanations before considering AI detection.
+5. Define privacy-bounded analytics requirements and reuse existing audit/diagnostics reads.
+
+## Dependencies, risks, and mechanics
+
+The server-management tracker remains authoritative. New setup op-kinds require dispatcher + DB gate + migration. Direct-vs-draft choice follows mutation shape. Announcement delivery needs permission checks, rate limits, retry/degraded behavior, audit, and safe disable. Analytics and anti-spam require privacy/moderation/retention review. AI detection is blocked by the AI expansion/action gates.
+
+## Migration, cache, audit, rollback, and test implications
+
+Follow the authoritative plans: additive migrations and the three-place setup-op-kind contract where applicable; canonical settings/binding/capability invalidation; audit previews/applies/delivery/moderation decisions; safe disable and staged-draft rollback; tests for authority re-checks, retries, Discord partial failure, rate limits, privacy, and deterministic scheduling.
+
+## Open questions and next session
+
+Use existing adaptive-platform/router questions; do not add a parallel ownership decision here. **Recommended next model/session:** Opus revises Routine Engine/announcement authority after the active lane and existing questions; Sonnet may take only an explicitly approved deterministic read-only explanation slice.

--- a/docs/planning/social-community-progression-roadmap-2026-06-08.md
+++ b/docs/planning/social-community-progression-roadmap-2026-06-08.md
@@ -1,0 +1,60 @@
+# Social, Community, and Progression — roadmap draft
+
+> **Status:** `plan` — planning/routing draft; not implementation approval.
+> **Horizon:** Later. **Primary source:** `docs/ideas/owner-vision-ideas-2026-06-08.md` §4, §14, §22.
+> **Owner decision needed:** Q-0038 in the maintainer question router.
+
+## Planning contract
+
+- **Status:** roadmap draft; routing only, not approval and not an active implementation lane.
+- Source code, merged PRs, binding contracts, subsystem folios, and `docs/current-state.md` outrank this draft.
+- Preserve domain-service mutation ownership, direct-vs-draft lane rules, deterministic event flow, auditability, rollback safety, observability, cache invalidation, and testability.
+- Before implementation, re-verify source, live PRs, the relevant folio, and every named gate.
+
+## Context and objective
+
+The owner selected social interaction as the highest-value way to make SuperBot feel alive. This draft groups guilds/clans, guild banks, guild battles, guild upgrades, achievements, profile cards, social leaderboards, and notifications around one progression seam rather than creating isolated social tables and commands.
+
+## Scope
+
+- A guild-scoped social identity and membership model; exact cross-server semantics remain open in Q-0038.
+- Guild treasury controls, upgrades/levels, and competitive events.
+- Persistent achievements/badges for game milestones, social actions, and hidden triggers.
+- Read-only player profile cards focused on economy and guild membership/rank.
+- All-time, weekly, and guild leaderboards plus a notification/inbox read surface with DM/channel delivery preferences and action links.
+
+## Out of scope
+
+Guild missions, seasonal achievement expiry, profile XP/W-L presentation, unconsented cross-server profiles, and implementation before Q-0038/privacy/retention decisions.
+
+## Current state and seams to reuse
+
+No canonical guild/clan or achievement owner exists today. Reuse `economy_service` for all coin effects, existing leaderboard/inventory/economy cogs for reads, guild lifecycle scoping, canonical audit/event paths, and existing Discord views/panels. Notifications must extend configured delivery/audit seams rather than become an unaudited message sender.
+
+Likely roots to verify: `disbot/services/economy_service.py`, `disbot/cogs/leaderboard_cog.py`, `disbot/cogs/economy_cog.py`, `disbot/cogs/inventory_cog.py`, `disbot/guild_lifecycle.py`, `disbot/utils/db/`, and existing view/router foundations.
+
+## Proposed phases
+
+1. **Decision and read-model phase:** answer Q-0038; specify tenancy, identity, consent, retention/deletion/export, membership and officer authority; prototype read-only profile/leaderboard composition.
+2. **Achievements foundation:** deterministic event vocabulary, idempotent award service, hidden-achievement disclosure rules, audit and backfill policy.
+3. **Guild core:** membership/roles, treasury ledger through economy ownership, then levels/upgrades; no battles yet.
+4. **Social competition:** guild leaderboards and manually scheduled guild battles using existing game/event owners.
+5. **Notification composition:** inbox/read model first, then opt-in channel/DM delivery and CTA routing.
+
+## Dependencies and gates
+
+Q-0038; privacy/consent/retention decisions; canonical event vocabulary; economy ledger integrity; moderation/abuse controls; and a dedicated ownership decision before adding a new social domain. This work must not compete with the active server-management lane.
+
+## Risks and mechanics
+
+High risk: tenancy ambiguity, officer abuse, treasury races, notification spam, hidden-achievement leaks, and leaderboard privacy. Any schema must be additive with reversible rollout/backfill. Cache keys must include guild/social scope and invalidate on membership/award/ledger changes. Every treasury or award mutation needs idempotency, audit evidence, tests, and a safe-disable path.
+
+## Migration, cache, audit, rollback, and test implications
+
+Use additive schemas and explicit backfill/consent rules; scope and invalidate caches on membership, award, treasury, and preference changes. Audit officer/treasury/award/delivery actions without leaking hidden achievements. Rollback uses feature disable plus compensating domain-service transactions. Tests must cover tenancy, permission races, idempotent awards, treasury concurrency, privacy, and notification opt-out.
+
+## Open questions and next session
+
+- Q-0038 owns guild identity, cross-server behavior, and privacy semantics.
+- Decide whether inbox is bot-wide or feature-owned composition before schema design.
+- **Recommended next model/session:** Opus product/architecture revision after Q-0038; no Sonnet implementation slice until ownership is approved.

--- a/docs/planning/ux-discoverability-mobile-roadmap-2026-06-08.md
+++ b/docs/planning/ux-discoverability-mobile-roadmap-2026-06-08.md
@@ -1,0 +1,50 @@
+# UX, Discoverability, Mobile-First, and Product Copy — roadmap draft
+
+> **Status:** `plan` — planning/routing draft; not implementation approval.
+> **Horizon:** Later; bounded slices may be selected through existing interface plans.
+
+## Planning contract
+
+- **Status:** roadmap draft; routing only, not approval and not an active implementation lane.
+- Source code, merged PRs, binding contracts, subsystem folios, and `docs/current-state.md` outrank this draft.
+- Preserve domain-service mutation ownership, direct-vs-draft lane rules, deterministic event flow, auditability, rollback safety, observability, cache invalidation, and testability.
+- Before implementation, re-verify source, live PRs, the relevant folio, and every named gate.
+
+## Context and objective
+
+Group rich help categories/search, changelog/what's-new and balance notices, mobile-first embeds/buttons/forms, bot personality/copy, panel language/action vocabulary, profile/discovery entry points, and command-access explanations. The objective is consistent composition over existing panels, not a new UI framework.
+
+## Scope
+
+A mobile-first audit rubric; help/search/category and locked-reason routes; consistent action-language/personality copy; release/balance notice concepts; and slash front doors that open existing hubs only.
+
+## Out of scope
+
+A second router/panel framework, one slash command per sub-action, hidden-achievement spoilers, large copy sweeps without owner review, or an operator changelog without a canonical release manifest.
+
+## Current state and seams to reuse
+
+The mother-hub map, interface-completion roadmap, command-expansion backlog, hub UI standard, command-integration standard, config-input standard, Help routes, access projection, existing panels/views, and adaptive setup/access plan already own most mechanics.
+
+Likely roots: `disbot/cogs/help_cog.py`, `disbot/cogs/help/`, `disbot/services/access_projection.py`, `disbot/core/runtime/interaction_helpers.py`, `disbot/views/`, and existing hub/panel renderers.
+
+## Proposed phases
+
+1. **Audit/rubric:** inventory representative mobile embeds/forms/buttons and define measurable limits; route findings to existing interface plans.
+2. **Vocabulary and personality:** owner-reviewed action labels, denial copy, and funny/sarcastic tone boundaries; accessibility and moderation review.
+3. **Discovery:** help categories/search and access explanations using existing command/access metadata; slash commands remain wrappers/front doors.
+4. **What's new:** define canonical release/balance manifest ownership, then render Discord-native notices/changelog.
+5. **Continuous conformance:** add focused checks/tests to existing UI standards rather than creating a new framework.
+
+## Dependencies, risks, and mechanics
+
+Existing interface sequencing; Q-0036 for locked-reason copy; release-manifest ownership; privacy-safe profile/discovery semantics; and owner approval for tone. Main risks are duplication, copy drift, mobile regressions, and over-notification. No new data migration is expected until a release manifest is approved; cache/audit/rollback needs follow the reused owner.
+
+## Migration, cache, audit, rollback, and test implications
+
+Most slices should require no schema; a release manifest needs an explicit additive owner and retention policy. Reuse existing metadata/cache owners and invalidate when commands/access/releases change. Audit only actions that already require audit; do not log private help/profile content. Rollback is copy/render/front-door reversion or feature disable. Tests should cover mobile rendering limits, accessibility, route/authority parity, locked reasons, search, and notification deduplication.
+
+## Open questions and next session
+
+- Q-0036 owns locked-reason copy. Release-manifest ownership and personality boundaries need owner review during revision, not silent decisions.
+- **Recommended next model/session:** Opus UX/release-manifest revision; Sonnet can take a bounded mobile audit or existing-help routing slice only after selection in the authoritative interface lane.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,7 +1,7 @@
 # SuperBot — Implementation Roadmap
 
 > **Status:** `living-ledger` — the one cross-area "what's planned, for which area, in
-> what order" index. **Last updated:** 2026-06-07.
+> what order" index. **Last updated:** 2026-06-08.
 >
 > **What this is:** a thin router over the detailed plans. Each row is a one-line
 > description + a link to the **authoritative plan** and the area **folio** — it restates
@@ -159,6 +159,18 @@ privacy/provenance/moderation review before any public surface.
   first slice and an explicit privacy/security review. No public media command ships today.
 
 ---
+
+## Product-growth roadmap drafts — **Later / Someday** (not approved)
+
+- **Later** — [social/community/progression](planning/social-community-progression-roadmap-2026-06-08.md): guilds, achievements, profiles, leaderboards, and notifications; gate: Q-0038 + privacy/new-owner decision.
+- **Later** — [economy/marketplace/rewards](planning/economy-marketplace-rewards-roadmap-2026-06-08.md): trade, rewards, sinks, onboarding, and crafting; gate: economy-health review + Q-0039/chance-reward review.
+- **Later** — [games/mining/idle growth](planning/games-mining-idle-roadmap-2026-06-08.md): poker, blackjack follow-ups, mining depth/co-op/idle; gate: ADR-002 + balance/ownership review.
+- **Later (fully gated)** — [AI product-extension routing](ai/ai-product-extension-routing-2026-06-08.md): DM/events/NL/tool ideas routed under the authoritative AI roadmap; gate: all AI readiness/orchestration/action decisions + Q-0040.
+- **Later (gated)** — [BTD6 product-extension routing](btd6/btd6-product-extension-routing-2026-06-08.md): rules/trivia, challenges, runs, leaderboards; gate: ADR-006/provenance/source-health.
+- **Existing plans** — [server-management/setup/access/routine extension routing](planning/server-management-extension-routing-2026-06-08.md): announcements, anti-spam, availability, explanations, analytics; gate: authoritative trackers and privacy/AI decisions.
+- **Someday / Later** — [integrations/media/voice/website](planning/integrations-media-voice-website-roadmap-2026-06-08.md): provider alerts, activity, voice, and web projection; gate: Q-0041/Q-0042 + privacy/security/moderation.
+- **Later** — [UX/discoverability/mobile-first](planning/ux-discoverability-mobile-roadmap-2026-06-08.md): help, changelog, copy, and mobile conformance through existing UI standards; gate: authoritative interface sequencing and copy/release-manifest decisions.
+- Routing ledger: [idea-to-roadmap inventory](planning/idea-roadmap-inventory-2026-06-08.md).
 
 ## Someday / ideas (NOT approved — capture only)
 

--- a/docs/subsystems/ai.md
+++ b/docs/subsystems/ai.md
@@ -74,3 +74,7 @@ scoped tools (including owner-gated diagnostics). Source:
 `docs/ai/ai-readiness-plan.md` (`plan`), `docs/ai/ai-readiness-pr-notes.md`,
 `docs/ai/ai-provider-and-grounding-fix-plan.md` (`plan`),
 `disbot/core/runtime/ai/README.md` (package intent).
+
+## Product-extension routing (not approved)
+
+The [AI product-extension routing addendum](../ai/ai-product-extension-routing-2026-06-08.md) routes dungeon-master, generated-event, wider-intent, and extra-tool ideas under the existing authoritative AI roadmap. It does not change the fully gated status or permit write/action tools.

--- a/docs/subsystems/btd6.md
+++ b/docs/subsystems/btd6.md
@@ -70,3 +70,7 @@ behavior/config gates are satisfied.
 [`../btd6/README.md`](../btd6/README.md),
 `docs/audits/agent-d-btd6-ai-subsystem-audit-2026-06-05.md`,
 `docs/current-state.md`, `docs/subsystems/ai.md`, `docs/subsystems/media-youtube.md`.
+
+## Product-extension routing (not approved)
+
+The [BTD6 product-extension routing draft](../btd6/btd6-product-extension-routing-2026-06-08.md) routes rules/trivia, challenge generation, score/run tracking, and leaderboards without bypassing ADR-006, provenance, source-health, provider, or groundedness gates.

--- a/docs/subsystems/games.md
+++ b/docs/subsystems/games.md
@@ -66,3 +66,7 @@ ideas promotion path before implementing unapproved game expansions.
 `docs/decisions/002-game-state-not-restart-safe.md`,
 `docs/archive/games-actionability-roadmap.md`, `docs/ideas/mining_exploration_brainstorm.md`,
 `docs/current-state.md`, `docs/runtime_contracts.md`.
+
+## Product-growth roadmap drafts (not approved)
+
+The [games/mining/idle roadmap draft](../planning/games-mining-idle-roadmap-2026-06-08.md) routes poker, blackjack variants, mining depth/co-op/idle, and crafting handoffs while preserving ADR-002. Cross-cutting game-facing ideas are routed through the [social/community/progression](../planning/social-community-progression-roadmap-2026-06-08.md) and [economy/marketplace/rewards](../planning/economy-marketplace-rewards-roadmap-2026-06-08.md) drafts. The [idea inventory](../planning/idea-roadmap-inventory-2026-06-08.md) owns lifecycle outcomes; none of these drafts is an active implementation lane.

--- a/docs/subsystems/media-youtube.md
+++ b/docs/subsystems/media-youtube.md
@@ -61,3 +61,7 @@ media command.
 `docs/decisions/007-media-youtube-ownership.md`, `docs/server-logging.md`,
 `docs/current-state.md`, `docs/subsystems/ai.md`, `docs/subsystems/btd6.md`,
 `docs/ideas/ai-extra-tool-capability-ideas.md`.
+
+## Broader integration routing (not approved)
+
+The [integrations/media/voice/website roadmap draft](../planning/integrations-media-voice-website-roadmap-2026-06-08.md) routes provider-alert, activity, voice, and website concepts around ADR-007 and the required privacy/credential/moderation/retention decisions. It does not approve a new provider or public media surface.

--- a/docs/subsystems/server-management.md
+++ b/docs/subsystems/server-management.md
@@ -202,3 +202,7 @@ reusable so a web companion is *possible* later, but do not start web work now.
 `docs/planning/server-management-pr14-hub-plan.md` (PR14 hub plan),
 `docs/setup-platform/resource-provisioning-overview.md`, `docs/capability-authority.md`,
 `docs/server-logging.md`.
+
+## Extension routing (not a competing tracker)
+
+The [server-management/setup/access/routine extension routing draft](../planning/server-management-extension-routing-2026-06-08.md) sends scheduled announcements, anti-spam, availability/explanation, guidance, and analytics ideas back to this tracker and the adaptive setup/access plan. It creates no new active sequence or mutation path.

--- a/docs/subsystems/settings-bindings-provisioning.md
+++ b/docs/subsystems/settings-bindings-provisioning.md
@@ -75,3 +75,7 @@ mutation/provisioning services and preserve operator confirmation.
 `docs/setup-platform/resource-provisioning-overview.md`, `docs/capability-authority.md`,
 `docs/health/platform-consistency-ledger.md`, `docs/setup-platform/operator-settings-presets.md`,
 `docs/ownership.md`, `docs/runtime_contracts.md`.
+
+## Cross-area extension routing (not approved)
+
+The [server-management/setup/access/routine extension routing draft](../planning/server-management-extension-routing-2026-06-08.md) preserves this folio's three mutation lanes while routing announcement/routine and guidance ideas. The [UX/mobile-first roadmap draft](../planning/ux-discoverability-mobile-roadmap-2026-06-08.md) routes presentation work through existing panels and standards rather than a new UI framework.


### PR DESCRIPTION
### Motivation
- Consolidate scattered idea captures into a single repo-grounded routing inventory so every idea ends in exactly one explicit lifecycle state. 
- Group related ideas by owning subsystem / shared architecture seam and produce roadmap-shaped planning drafts that a future Opus/Sonnet session can revise into implementation plans. 
- Preserve source-of-truth ownership, existing gates (AI/BTD6/ADR rules), and the one-fact-one-home rule while surfacing product-sensitive questions for the maintainer. 

### Description
- Added a routed inventory and eight roadmap/routing drafts under `docs/planning/` plus AI/BTD6 routing addenda: `docs/planning/idea-roadmap-inventory-2026-06-08.md`, `docs/planning/social-community-progression-roadmap-2026-06-08.md`, `docs/planning/economy-marketplace-rewards-roadmap-2026-06-08.md`, `docs/planning/games-mining-idle-roadmap-2026-06-08.md`, `docs/planning/server-management-extension-routing-2026-06-08.md`, `docs/planning/integrations-media-voice-website-roadmap-2026-06-08.md`, `docs/planning/ux-discoverability-mobile-roadmap-2026-06-08.md`, `docs/ai/ai-product-extension-routing-2026-06-08.md`, and `docs/btd6/btd6-product-extension-routing-2026-06-08.md`. 
- Updated `docs/roadmap.md` and multiple subsystem folios to link these drafts, and appended routing notes into the preserved idea captures and `docs/ideas/README.md` so nothing was deleted or auto-promoted. 
- Wrote `.sessions/2026-06-08-idea-roadmap-mapping.md` with a Context-delta (needed-not-pointed / pointed-not-needed / discovered-by-hand) and added five maintainer Q-blocks to `docs/owner/maintainer-question-router.md` (Q-0038–Q-0042) for product-sensitive decisions. 
- No runtime/source code or production behavior was modified; all changes are docs/planning-only and reuse existing service seams as noted in each draft. 

### Testing
- Ran `python3.10 scripts/check_docs.py` which completed successfully and reported no blocking doc-badge errors. 
- Ran `python3.10 tools/agent_context/validate_pack.py` which validated the agent context index and generated packs for the covered subsystems. 
- Ran `python3.10 scripts/check_architecture.py --mode strict` which completed with zero errors and only the repository’s existing tracked warnings (no new architecture errors introduced). 
- Attempted live GitHub PR/remote verification (GitHub CLI / remote URL) but the environment lacked a configured `gh`/remote, so live open-PR verification could not be performed here and is recorded in the session journal as a required step for the next connected session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a274975885083228a888f0c9411e9d0)