### PR TITLE
Mining: character-platform foundation — explore wiring, typed inventory, equipment + EffectiveStats

### DIFF
--- a/.sessions/2026-06-08-mining-character-platform-foundation.md
+++ b/.sessions/2026-06-08-mining-character-platform-foundation.md
@@ -1,0 +1,56 @@
+# Mining → character-platform foundation
+
+**Branch:** `claude/eloquent-ptolemy-cmusuj` · **Date:** 2026-06-08
+
+A long brainstorm-then-build session. Refined the maintainer's mining idea into a
+whole-bot **character platform** vision, then laid the first foundation slices for it.
+
+## What shipped (commits, newest-first)
+- `6c5c800` — **exploration reads equipped gear's `EffectiveStats`** (scaling: mining_power
+  2→×2 / 4→×3 ore, loot_bonus flat; gating from *equipped* gear, which fixed a latent bug —
+  a lantern in the LIGHT slot now satisfies the torch-gated deep finds). `explore_from_state`
+  replaced `explore_from_inventory`.
+- `dbf7524` — **equipment seam**: migration 060 `mining_equipment` + `utils/db/games/mining_equipment.py`
+  + pure `cogs/mining/equipment.py` (slots tool/light/charm; `EffectiveStats` read model; `compute_stats`)
+  + `!equip`/`!unequip`/`!gear`.
+- `6f5d4ad` — **correction** (see Learnings).
+- `9344a6c` — typed **Inventory** panel + net worth (wired the dormant `items.py`).
+- `50a5a46` — **Wave 0**: `!explore` made loadout/depth-aware (wired the dormant `exploration.py`).
+- `6e5a605` — brainstorm doc §6/§7: the character-platform vision (decisions, roadmap).
+
+All green through `python3.10 scripts/check_quality.py --full` before each push.
+
+## Learnings / gotchas (read before extending mining)
+- **Mining is an *intentional direct-lane domain* — NOT an audit-service gap.** I was about to
+  build an "audited mining mutation service" (my own framing + a wrong §7.5 note said `!build`
+  was an un-audited gap). Reading the binding contracts *first* (the mutation-and-db rule) caught
+  it: `ownership.md` routes `mining_inventory` **"direct via `utils/db/games/mining.py`"**, and the
+  RC-8A ledger (`docs/audits/direct-db-exception-ledger.md`) catalogues it as **`accepted-direct-write`**
+  ("a mutation service is a *future option, not a current violation*"). Lightweight game state
+  (mining/chain/counting/deathmatch/rps) is direct-lane by design; audited services are for
+  value/config/governance (economy, xp, moderation, governance). **A mining service is only
+  warranted when crafting goes cross-domain (spends coins → `economy_service`) or grows durability
+  state.** Don't repeat the mistake.
+- **`views/ → cogs/` is a layer error.** The pure mining engines (`exploration`, `items`,
+  `equipment`) live in `cogs/mining/`, so views import them **lazily inside the handler** (module-level
+  would be a *new* arch-fix-13 violation). The real fix — relocating the pure engines to a shared
+  layer so `services/` can build on them too — is deferred (brainstorm §7.4).
+- **`EffectiveStats` is the platform's "one stat block."** Gear feeds it now (`compute_stats`);
+  skills + combat gear (`damage`/`defense`/`max_health`, reserved) feed it later. Every game reads
+  the subset it cares about — no game imports the item catalog.
+- DB tests **mock the pool** (`patch("...pool.fetchall")` + assert SQL/params); migrations are
+  production-only, not applied under test. CI **excludes `tests/`** from black/isort/ruff — ignore
+  ruff "errors" from running it on a test file directly.
+
+## Next steps (per brainstorm §7.7 roadmap)
+The character spine + Wave-1 inventory/equipment are in. Remaining, each its own slice:
+- **Persistent depth** (Wave 1): `mining_player_state` + a thin owner; explore/mine use the real
+  biome instead of always SURFACE. Needs one owner call: how torch/lantern gate descent (§6.8).
+- **Combat gear + deathmatch reads stats** (Wave 1): add sword/armor items → `damage`/`defense`,
+  make deathmatch read `EffectiveStats` instead of hardcoded HP/dmg. (Fills the reserved combat slots.)
+- **Sell-ore / buy-gear market** (Wave 1): coins integration — *this* leg routes through
+  `economy_service` (genuine cross-domain service).
+- **Game-XP service** (Wave 2): the shared cross-game XP track (mirrors the audited `xp_service`),
+  + the capped 4-branch skill tree feeding `EffectiveStats`.
+- **Profile card / paper-doll** (Wave 3): `utils/mining_render` already exists; Pillow is in
+  `requirements.txt`.

--- a/disbot/cogs/mining/equipment.py
+++ b/disbot/cogs/mining/equipment.py
@@ -1,0 +1,125 @@
+"""Equipment — pure gear→stats model (foundation).
+
+Maps the items a player has *equipped* into slots onto a generic
+:class:`EffectiveStats` block that game logic reads.  This is the cross-game
+"what is my character good at?" read model: a game asks for the stats, never
+for specific item names.  Sibling to ``items.py`` / ``exploration.py`` — no
+Discord, no DB, no state.
+
+Slots and per-item stats are deliberately data (``_GEAR``): extend by adding
+rows.  Combat slots (weapon/armor) and their damage/defense stats are reserved
+in :class:`EffectiveStats` but unused until combat gear exists.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Equipment slots — each holds at most one item.  Weapon/armor are reserved
+# for combat gear and intentionally not in SLOTS until those items exist.
+TOOL = "tool"
+LIGHT = "light"
+CHARM = "charm"
+SLOTS: tuple[str, ...] = (TOOL, LIGHT, CHARM)
+
+
+@dataclass(frozen=True)
+class EffectiveStats:
+    """Generic, game-neutral stat block computed from equipped gear (and,
+    later, skills).  Each game reads only the subset it cares about — no game
+    imports the item catalog.
+    """
+
+    mining_power: int = 0
+    light_radius: int = 0
+    depth_access: int = 0
+    luck: int = 0
+    loot_bonus: int = 0
+    # Reserved for combat gear (deathmatch / PvP); zero until it exists.
+    damage: int = 0
+    defense: int = 0
+    max_health: int = 0
+
+    def __add__(self, other: EffectiveStats) -> EffectiveStats:
+        return EffectiveStats(
+            mining_power=self.mining_power + other.mining_power,
+            light_radius=self.light_radius + other.light_radius,
+            depth_access=self.depth_access + other.depth_access,
+            luck=self.luck + other.luck,
+            loot_bonus=self.loot_bonus + other.loot_bonus,
+            damage=self.damage + other.damage,
+            defense=self.defense + other.defense,
+            max_health=self.max_health + other.max_health,
+        )
+
+
+# Display labels for the stat fields, in display order.  Keys MUST match the
+# EffectiveStats field names (asserted in tests).
+STAT_LABELS: dict[str, str] = {
+    "mining_power": "Mining power",
+    "light_radius": "Light",
+    "depth_access": "Depth access",
+    "luck": "Luck",
+    "loot_bonus": "Loot bonus",
+    "damage": "Damage",
+    "defense": "Defense",
+    "max_health": "Max health",
+}
+
+
+# Which slot each gear item fits, and the stats it contributes.
+_GEAR: dict[str, tuple[str, EffectiveStats]] = {
+    "pickaxe": (TOOL, EffectiveStats(mining_power=2)),
+    "iron pickaxe": (TOOL, EffectiveStats(mining_power=4)),
+    "torch": (LIGHT, EffectiveStats(light_radius=1, depth_access=1)),
+    "lantern": (LIGHT, EffectiveStats(light_radius=2, depth_access=2)),
+    "lucky charm": (CHARM, EffectiveStats(luck=1, loot_bonus=1)),
+}
+
+
+def slot_for(item_name: str) -> str | None:
+    """The slot *item_name* equips into, or None if it is not equippable."""
+    entry = _GEAR.get(item_name.lower())
+    return entry[0] if entry else None
+
+
+def is_equippable(item_name: str) -> bool:
+    return slot_for(item_name) is not None
+
+
+def item_stats(item_name: str) -> EffectiveStats:
+    """Stat contribution of a single gear item (all-zero if unknown)."""
+    entry = _GEAR.get(item_name.lower())
+    return entry[1] if entry else EffectiveStats()
+
+
+def compute_stats(equipped: dict[str, str]) -> EffectiveStats:
+    """Sum the stats of every equipped item.  *equipped* is ``{slot: name}``."""
+    total = EffectiveStats()
+    for item_name in equipped.values():
+        total = total + item_stats(item_name)
+    return total
+
+
+def describe_stats(stats: EffectiveStats) -> list[tuple[str, int]]:
+    """Non-zero ``(label, value)`` pairs in display order — pure (no Discord)."""
+    return [
+        (STAT_LABELS[name], getattr(stats, name))
+        for name in STAT_LABELS
+        if getattr(stats, name)
+    ]
+
+
+__all__ = [
+    "TOOL",
+    "LIGHT",
+    "CHARM",
+    "SLOTS",
+    "EffectiveStats",
+    "STAT_LABELS",
+    "slot_for",
+    "is_equippable",
+    "item_stats",
+    "compute_stats",
+    "describe_stats",
+]

--- a/disbot/cogs/mining/exploration.py
+++ b/disbot/cogs/mining/exploration.py
@@ -33,6 +33,8 @@ import random
 from dataclasses import dataclass, field
 from enum import Enum
 
+from cogs.mining import equipment
+
 
 class Biome(Enum):
     """Depth bands.  Deeper biomes carry richer (and riskier) outcomes."""
@@ -244,20 +246,24 @@ def eligible_outcomes(biome: Biome, loadout: Loadout) -> list[ExploreOutcome]:
     ]
 
 
-def _scale_amount(outcome: ExploreOutcome, loadout: Loadout) -> int:
-    """Apply loadout-driven scaling to a positive payout.
+# Items whose gains scale with mining power (ore — not flavour drops like wood).
+_ORE_ITEMS: frozenset[str] = frozenset({"stone", "iron", "gold", "diamond"})
 
-    A pickaxe doubles ore gains (mirrors the existing !mine bonus); a
-    lucky charm adds +1 on top.  Penalties (negative amounts) are never
-    scaled — gear protects gains, it does not amplify losses.
+
+def _scale_amount(outcome: ExploreOutcome, stats: equipment.EffectiveStats) -> int:
+    """Apply equipped-gear scaling to a positive payout.
+
+    ``mining_power`` multiplies ore gains — power 2 → ×2 (matching the old
+    pickaxe bonus), power 4 (an iron pickaxe) → ×3; ``loot_bonus`` adds a flat
+    extra to any gain.  Penalties (negative amounts) are never scaled — gear
+    protects gains, it does not amplify losses.
     """
     amount = outcome.amount
     if amount <= 0:
         return amount
-    if loadout.has(PICKAXE) and outcome.item in {"stone", "iron", "gold", "diamond"}:
-        amount *= 2
-    if loadout.has(LUCKY_CHARM):
-        amount += 1
+    if outcome.item in _ORE_ITEMS:
+        amount *= 1 + stats.mining_power // 2
+    amount += stats.loot_bonus
     return amount
 
 
@@ -265,16 +271,18 @@ def resolve(
     biome: Biome,
     loadout: Loadout,
     *,
+    stats: equipment.EffectiveStats | None = None,
     rng: random.Random | None = None,
 ) -> ExploreResult:
     """Pick and resolve one weighted exploration outcome.
 
-    *rng* is injected for deterministic tests; defaults to the module
-    :mod:`random`.  Always returns a result — if nothing is eligible
-    (should not happen given the surface fallbacks), a benign "nothing"
-    result is produced.
+    *loadout* gates which outcomes are reachable; *stats* (from equipped gear)
+    scales the amount.  *rng* is injected for deterministic tests.  Always
+    returns a result — if nothing is eligible (should not happen given the
+    surface fallbacks), a benign "nothing" result is produced.
     """
     chooser = rng or random
+    effective = stats or equipment.EffectiveStats()
     candidates = eligible_outcomes(biome, loadout)
     if not candidates:
         empty = ExploreOutcome(
@@ -288,7 +296,7 @@ def resolve(
     outcome = chooser.choices(candidates, weights=[o.weight for o in candidates], k=1)[
         0
     ]
-    final_amount = _scale_amount(outcome, loadout)
+    final_amount = _scale_amount(outcome, effective)
     narration = outcome.narration.format(
         amount=abs(final_amount),
         item=outcome.item or "",
@@ -300,33 +308,50 @@ def resolve_to_legacy_tuple(
     biome: Biome = Biome.SURFACE,
     loadout: Loadout | None = None,
     *,
+    stats: equipment.EffectiveStats | None = None,
     rng: random.Random | None = None,
 ) -> tuple[str, str | None, int]:
-    """Drop-in replacement for ``rewards.roll_explore_outcome``.
-
-    Returns ``(text, item_or_None, delta)`` so a future wiring step can
-    swap the call site with no change to the cog's downstream code.
+    """Resolve one step and return the legacy ``(text, item, amount)`` tuple
+    that ``rewards.roll_explore_outcome`` produced — the shape both ``!explore``
+    call sites consume.
     """
-    return resolve(biome, loadout or Loadout(), rng=rng).to_legacy_tuple()
+    return resolve(biome, loadout or Loadout(), stats=stats, rng=rng).to_legacy_tuple()
 
 
-def explore_from_inventory(
+# Equipment slots → the capability token the catalog gates on.  A light in the
+# LIGHT slot (torch *or* lantern) satisfies the deep-find gate — fixing the old
+# behaviour where only a literal "torch" counted; v1 has one tool family, so the
+# TOOL slot maps to PICKAXE.
+_SLOT_TO_TOKEN: dict[str, str] = {
+    equipment.TOOL: PICKAXE,
+    equipment.LIGHT: TORCH,
+    equipment.CHARM: LUCKY_CHARM,
+}
+
+
+def explore_from_state(
+    equipped: dict[str, str],
     inventory: dict[str, int],
     *,
     biome: Biome = Biome.SURFACE,
     rng: random.Random | None = None,
 ) -> tuple[str, str | None, int]:
-    """Resolve one exploration step straight from an ``{item: qty}`` inventory.
+    """Resolve one exploration step from the player's *equipped* gear.
 
-    Convenience seam for the ``!explore`` command and the hub's Explore
-    button: it builds the :class:`Loadout` from the raw inventory and returns
-    the legacy ``(text, item, amount)`` tuple both call sites already consume.
-    It centralises loadout construction and the (currently fixed, ``SURFACE``)
-    starting depth, so a later persistent-position step can thread the
-    player's real biome through this single place.
+    Equipped gear drives both gating (a light unlocks deep finds) and scaling
+    (``mining_power`` → more ore, ``loot_bonus`` → extra) via the equipment
+    :class:`~cogs.mining.equipment.EffectiveStats`.  Consumables that gate
+    outcomes but are not equippable (dynamite) are still read from *inventory*.
+    Returns the legacy ``(text, item, amount)`` tuple both call sites consume;
+    the (currently fixed, ``SURFACE``) starting depth lives here, so a later
+    persistent-position step threads the player's real biome through one place.
     """
-    loadout = Loadout.from_inventory(inventory)
-    return resolve_to_legacy_tuple(biome=biome, loadout=loadout, rng=rng)
+    tokens = {_SLOT_TO_TOKEN[slot] for slot in equipped if slot in _SLOT_TO_TOKEN}
+    if inventory.get(DYNAMITE, 0) > 0:
+        tokens.add(DYNAMITE)
+    loadout = Loadout(tools=frozenset(tokens))
+    stats = equipment.compute_stats(equipped)
+    return resolve(biome, loadout, stats=stats, rng=rng).to_legacy_tuple()
 
 
 # Mutation-application is intentionally NOT here: applying ``final_amount``
@@ -343,7 +368,7 @@ __all__ = [
     "eligible_outcomes",
     "resolve",
     "resolve_to_legacy_tuple",
-    "explore_from_inventory",
+    "explore_from_state",
     "PICKAXE",
     "TORCH",
     "LANTERN",

--- a/disbot/cogs/mining/exploration.py
+++ b/disbot/cogs/mining/exploration.py
@@ -310,6 +310,25 @@ def resolve_to_legacy_tuple(
     return resolve(biome, loadout or Loadout(), rng=rng).to_legacy_tuple()
 
 
+def explore_from_inventory(
+    inventory: dict[str, int],
+    *,
+    biome: Biome = Biome.SURFACE,
+    rng: random.Random | None = None,
+) -> tuple[str, str | None, int]:
+    """Resolve one exploration step straight from an ``{item: qty}`` inventory.
+
+    Convenience seam for the ``!explore`` command and the hub's Explore
+    button: it builds the :class:`Loadout` from the raw inventory and returns
+    the legacy ``(text, item, amount)`` tuple both call sites already consume.
+    It centralises loadout construction and the (currently fixed, ``SURFACE``)
+    starting depth, so a later persistent-position step can thread the
+    player's real biome through this single place.
+    """
+    loadout = Loadout.from_inventory(inventory)
+    return resolve_to_legacy_tuple(biome=biome, loadout=loadout, rng=rng)
+
+
 # Mutation-application is intentionally NOT here: applying ``final_amount``
 # and ``outcome.consumes`` to an inventory is a write, which must flow
 # through the DB/mutation layer the cog already uses.  This module only
@@ -324,6 +343,7 @@ __all__ = [
     "eligible_outcomes",
     "resolve",
     "resolve_to_legacy_tuple",
+    "explore_from_inventory",
     "PICKAXE",
     "TORCH",
     "LANTERN",

--- a/disbot/cogs/mining/items.py
+++ b/disbot/cogs/mining/items.py
@@ -189,6 +189,27 @@ def sort_inventory(inventory: dict[str, int]) -> list[tuple[str, int]]:
     return rows
 
 
+def summarize_inventory(
+    inventory: dict[str, int],
+) -> list[tuple[ItemKind, list[tuple[str, int]]]]:
+    """Group a raw ``{item: qty}`` inventory into ordered display sections.
+
+    Returns ``[(kind, [(name, qty), ...]), ...]`` using the same ordering as
+    :func:`sort_inventory` (kind, then value desc, then name), chunked into one
+    section per :class:`ItemKind` that has at least one positive-quantity item.
+    Pure: no Discord, no DB — call sites turn the sections into embeds/text.
+    """
+    sections: list[tuple[ItemKind, list[tuple[str, int]]]] = []
+    current: ItemKind | None = None
+    for name, qty in sort_inventory(inventory):
+        kind = classify(name)
+        if kind is not current:
+            sections.append((kind, []))
+            current = kind
+        sections[-1][1].append((name, qty))
+    return sections
+
+
 __all__ = [
     "ItemKind",
     "ItemDef",
@@ -202,4 +223,5 @@ __all__ = [
     "total_value",
     "next_tool_upgrade",
     "sort_inventory",
+    "summarize_inventory",
 ]

--- a/disbot/cogs/mining_cog.py
+++ b/disbot/cogs/mining_cog.py
@@ -22,6 +22,7 @@ import discord
 from discord.ext import commands
 
 from cogs.mining.exploration import explore_from_inventory
+from cogs.mining.items import total_value
 from cogs.mining.recipes import load_recipes
 from core.runtime import panel_manager
 from utils import db
@@ -121,6 +122,7 @@ class MiningCog(commands.Cog):
         )
         embed.add_field(name="Total Items Collected", value=str(total_items))
         embed.add_field(name="Unique Items", value=str(unique_items))
+        embed.add_field(name="Net Worth", value=str(total_value(inventory)))
         await ctx.send(embed=embed)
 
     # ---------------------------------------------------------- build / crafting

--- a/disbot/cogs/mining_cog.py
+++ b/disbot/cogs/mining_cog.py
@@ -21,6 +21,7 @@ import logging
 import discord
 from discord.ext import commands
 
+from cogs.mining.exploration import explore_from_inventory
 from cogs.mining.recipes import load_recipes
 from core.runtime import panel_manager
 from utils import db
@@ -223,12 +224,11 @@ class MiningCog(commands.Cog):
 
     @commands.command(hidden=True)
     async def explore(self, ctx):
-        """Discover random events or items."""
-        from cogs.mining.rewards import roll_explore_outcome
-
+        """Discover random events or items (loadout- and depth-aware)."""
         user_id = str(ctx.author.id)
         gid = ctx.guild.id
-        text, item, amount = roll_explore_outcome()
+        inventory = await db.get_mining_inventory(user_id, gid)
+        text, item, amount = explore_from_inventory(inventory)
         if item:
             await self.update_inventory(user_id, gid, item, amount)
         await ctx.send(f"{ctx.author.mention} {text}")

--- a/disbot/cogs/mining_cog.py
+++ b/disbot/cogs/mining_cog.py
@@ -22,7 +22,7 @@ import discord
 from discord.ext import commands
 
 from cogs.mining import equipment
-from cogs.mining.exploration import explore_from_inventory
+from cogs.mining.exploration import explore_from_state
 from cogs.mining.items import total_value
 from cogs.mining.recipes import load_recipes
 from core.runtime import panel_manager
@@ -227,11 +227,12 @@ class MiningCog(commands.Cog):
 
     @commands.command(hidden=True)
     async def explore(self, ctx):
-        """Discover random events or items (loadout- and depth-aware)."""
+        """Discover random events or items (driven by your equipped gear)."""
         user_id = str(ctx.author.id)
         gid = ctx.guild.id
         inventory = await db.get_mining_inventory(user_id, gid)
-        text, item, amount = explore_from_inventory(inventory)
+        equipped = await db.get_equipment(user_id, gid)
+        text, item, amount = explore_from_state(equipped, inventory)
         if item:
             await self.update_inventory(user_id, gid, item, amount)
         await ctx.send(f"{ctx.author.mention} {text}")

--- a/disbot/cogs/mining_cog.py
+++ b/disbot/cogs/mining_cog.py
@@ -21,6 +21,7 @@ import logging
 import discord
 from discord.ext import commands
 
+from cogs.mining import equipment
 from cogs.mining.exploration import explore_from_inventory
 from cogs.mining.items import total_value
 from cogs.mining.recipes import load_recipes
@@ -258,6 +259,71 @@ class MiningCog(commands.Cog):
 
         await self.update_inventory(user_id, gid, item, -1)
         await ctx.send(f"{ctx.author.mention} {message}")
+
+    # ---------------------------------------------------------- gear / equipment
+
+    @commands.command(hidden=True)
+    async def equip(self, ctx, *, item: str = None):
+        """Equip a tool, light, or charm so its stats apply to your character."""
+        if not item:
+            return await ctx.send("Specify what to equip, e.g. `!equip iron pickaxe`.")
+        item = item.strip().lower()
+        slot = equipment.slot_for(item)
+        if slot is None:
+            return await ctx.send(f"**{item.title()}** can't be equipped.")
+        user_id = str(ctx.author.id)
+        gid = ctx.guild.id
+        inventory = await db.get_mining_inventory(user_id, gid)
+        if inventory.get(item, 0) < 1:
+            return await ctx.send(f"You don't own a **{item.title()}** to equip.")
+        await db.equip_item(user_id, gid, slot, item)
+        await ctx.send(
+            f"{ctx.author.mention} equipped **{item.title()}** in the **{slot}** slot.",
+        )
+
+    @commands.command(hidden=True)
+    async def unequip(self, ctx, *, slot: str = None):
+        """Clear an equipment slot (tool / light / charm)."""
+        if not slot:
+            return await ctx.send(
+                f"Specify a slot to clear: {', '.join(equipment.SLOTS)}.",
+            )
+        slot = slot.strip().lower()
+        if slot not in equipment.SLOTS:
+            return await ctx.send(
+                f"Unknown slot **{slot}**. Slots: {', '.join(equipment.SLOTS)}.",
+            )
+        await db.unequip_slot(str(ctx.author.id), ctx.guild.id, slot)
+        await ctx.send(f"{ctx.author.mention} cleared the **{slot}** slot.")
+
+    @commands.command(hidden=True)
+    async def gear(self, ctx):
+        """Show your equipped gear and the stats it grants."""
+        user_id = str(ctx.author.id)
+        equipped = await db.get_equipment(user_id, ctx.guild.id)
+        stats = equipment.compute_stats(equipped)
+        embed = discord.Embed(
+            title=f"🧍 {ctx.author.name}'s Gear",
+            color=MINING_COLOR,
+        )
+        for slot in equipment.SLOTS:
+            held = equipped.get(slot)
+            embed.add_field(
+                name=slot.title(),
+                value=f"**{held.title()}**" if held else "*(empty)*",
+                inline=True,
+            )
+        bonuses = equipment.describe_stats(stats)
+        embed.add_field(
+            name="Stats",
+            value=(
+                "\n".join(f"{label}: +{value}" for label, value in bonuses)
+                if bonuses
+                else "No bonuses yet — equip some gear!"
+            ),
+            inline=False,
+        )
+        await ctx.send(embed=embed)
 
     # ---------------------------------------------------------------- admin
 

--- a/disbot/migrations/060_mining_equipment.sql
+++ b/disbot/migrations/060_mining_equipment.sql
@@ -1,0 +1,13 @@
+-- Mining equipment: which item a player has equipped in each slot.
+-- Direct-lane game state (docs/ownership.md routes mining writes direct via
+-- utils/db/games/; the RC-8A ledger catalogues this as accepted-direct-write).
+-- One row per (user_id, guild_id, slot); user_id is TEXT to match
+-- mining_inventory's legacy column type.
+CREATE TABLE IF NOT EXISTS mining_equipment (
+    user_id     TEXT        NOT NULL,
+    guild_id    BIGINT      NOT NULL,
+    slot        TEXT        NOT NULL,
+    item_name   TEXT        NOT NULL,
+    equipped_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, guild_id, slot)
+);

--- a/disbot/utils/db/__init__.py
+++ b/disbot/utils/db/__init__.py
@@ -85,6 +85,11 @@ from utils.db.games.mining import (
     set_mining_inventory,
     update_mining_item,
 )
+from utils.db.games.mining_equipment import (
+    equip_item,
+    get_equipment,
+    unequip_slot,
+)
 from utils.db.games.rps import rps_ensure_player, rps_get_leaderboard, rps_update_stat
 from utils.db.governance import (
     get_all_cleanup_for_guild,
@@ -257,4 +262,7 @@ __all__ = [
     "set_mining_inventory",
     "update_deathmatch",
     "update_mining_item",
+    "equip_item",
+    "get_equipment",
+    "unequip_slot",
 ]

--- a/disbot/utils/db/games/mining_equipment.py
+++ b/disbot/utils/db/games/mining_equipment.py
@@ -1,0 +1,45 @@
+"""mining_equipment CRUD — which item a player has equipped per slot.
+
+Direct-lane game state: ``docs/ownership.md`` routes mining writes direct via
+``utils/db/games/`` (no audited service — see the RC-8A direct-DB ledger).  One
+row per ``(user_id, guild_id, slot)``.  ``user_id`` is ``TEXT`` to match
+``mining_inventory``'s legacy column type.
+"""
+
+from __future__ import annotations
+
+from utils.db import pool
+
+
+async def get_equipment(user_id: str, guild_id: int) -> dict[str, str]:
+    """Return ``{slot: item_name}`` for the user's equipped gear in a guild."""
+    rows = await pool.fetchall(
+        "SELECT slot, item_name FROM mining_equipment "
+        "WHERE user_id=$1 AND guild_id=$2",
+        (user_id, guild_id),
+    )
+    return {r["slot"]: r["item_name"] for r in rows}
+
+
+async def equip_item(
+    user_id: str,
+    guild_id: int,
+    slot: str,
+    item_name: str,
+) -> None:
+    """Equip *item_name* into *slot* (upsert — one item per slot)."""
+    await pool.execute(
+        """INSERT INTO mining_equipment (user_id, guild_id, slot, item_name)
+           VALUES ($1, $2, $3, $4)
+           ON CONFLICT (user_id, guild_id, slot)
+           DO UPDATE SET item_name=$4, equipped_at=now()""",
+        (user_id, guild_id, slot, item_name),
+    )
+
+
+async def unequip_slot(user_id: str, guild_id: int, slot: str) -> None:
+    """Clear *slot* for the user in a guild."""
+    await pool.execute(
+        "DELETE FROM mining_equipment WHERE user_id=$1 AND guild_id=$2 AND slot=$3",
+        (user_id, guild_id, slot),
+    )

--- a/disbot/views/mining/main_panel.py
+++ b/disbot/views/mining/main_panel.py
@@ -140,12 +140,13 @@ class MiningHubView(PersistentView):
         # in cogs/, and views must not import cogs at module level (layer
         # rule).  A later step relocates the pure engine to a shared layer so
         # this can become a plain import (mining_exploration_brainstorm §7.4).
-        from cogs.mining.exploration import explore_from_inventory
+        from cogs.mining.exploration import explore_from_state
 
         user_id = str(interaction.user.id)
         gid = interaction.guild_id
         inventory = await db.get_mining_inventory(user_id, gid)
-        text, item, amount = explore_from_inventory(inventory)
+        equipped = await db.get_equipment(user_id, gid)
+        text, item, amount = explore_from_state(equipped, inventory)
         if item:
             await db.update_mining_item(user_id, gid, item, amount)
         embed = discord.Embed(

--- a/disbot/views/mining/main_panel.py
+++ b/disbot/views/mining/main_panel.py
@@ -34,6 +34,16 @@ from utils import db
 from utils.ui_constants import ERROR_COLOR, MINING_COLOR, SUCCESS_COLOR
 from views.mining.mine_view import MineView, _build_mine_prompt_embed
 
+# Display labels for the typed Inventory panel, keyed by ItemKind.value so this
+# module need not import the cogs-layer ItemKind enum (views→cogs layer rule).
+_KIND_LABELS: dict[str, str] = {
+    "resource": "⛏️ Resources",
+    "tool": "🛠️ Tools",
+    "consumable": "🧨 Consumables",
+    "structure": "🏛️ Structures",
+    "treasure": "💎 Treasure",
+}
+
 
 @register
 class MiningHubView(PersistentView):
@@ -166,25 +176,38 @@ class MiningHubView(PersistentView):
                 ephemeral=True,
             )
             return
+        # Lazy import: the item taxonomy is game-domain logic in cogs/, and
+        # views must not import cogs at module level (layer rule, as in
+        # explore_btn above).
+        from cogs.mining import items
+
         user_id = str(interaction.user.id)
         inventory = await db.get_mining_inventory(user_id, interaction.guild_id)
+        embed = discord.Embed(
+            title=f"📦 {interaction.user.name}'s Mining Inventory",
+            color=MINING_COLOR,
+        )
         if not inventory:
             # Empty-state UX rule (mother-hub-map.md): explain what the
             # feature does and what the next step is.
-            description = (
+            embed.description = (
                 "Your mining inventory is empty. Use `!mine` in the mining "
                 "channel to start collecting items."
             )
+            embed.set_footer(text="Pick another action above to continue.")
         else:
-            description = "\n".join(
-                f"**{item.title()}**: {qty}" for item, qty in sorted(inventory.items())
+            for kind, rows in items.summarize_inventory(inventory):
+                embed.add_field(
+                    name=_KIND_LABELS.get(kind.value, kind.value.title()),
+                    value="\n".join(f"**{name.title()}** ×{qty}" for name, qty in rows),
+                    inline=False,
+                )
+            embed.set_footer(
+                text=(
+                    f"Net worth: {items.total_value(inventory)}  •  "
+                    "Pick another action above to continue."
+                ),
             )
-        embed = discord.Embed(
-            title=f"📦 {interaction.user.name}'s Mining Inventory",
-            description=description,
-            color=MINING_COLOR,
-        )
-        embed.set_footer(text="Pick another action above to continue.")
         await safe_edit(interaction, embed=embed, view=self)
 
     @discord.ui.button(
@@ -203,6 +226,9 @@ class MiningHubView(PersistentView):
                 ephemeral=True,
             )
             return
+        # Lazy import: cogs-layer taxonomy (layer rule — see explore_btn).
+        from cogs.mining import items
+
         user_id = str(interaction.user.id)
         inventory = await db.get_mining_inventory(user_id, interaction.guild_id)
         total_items = sum(inventory.values())
@@ -213,6 +239,7 @@ class MiningHubView(PersistentView):
         )
         embed.add_field(name="Total Items Collected", value=str(total_items))
         embed.add_field(name="Unique Items", value=str(unique_items))
+        embed.add_field(name="Net Worth", value=str(items.total_value(inventory)))
         embed.set_footer(text="Pick another action above to continue.")
         await safe_edit(interaction, embed=embed, view=self)
 

--- a/disbot/views/mining/main_panel.py
+++ b/disbot/views/mining/main_panel.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import discord
 
 from cogs.mining.recipes import load_recipes
-from cogs.mining.rewards import roll_explore_outcome, roll_harvest_amount
+from cogs.mining.rewards import roll_harvest_amount
 from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
 from core.runtime.persistent_views import PersistentView, register
 from utils import db
@@ -126,9 +126,16 @@ class MiningHubView(PersistentView):
                 ephemeral=True,
             )
             return
+        # Lazy import: the exploration engine is game-domain logic that lives
+        # in cogs/, and views must not import cogs at module level (layer
+        # rule).  A later step relocates the pure engine to a shared layer so
+        # this can become a plain import (mining_exploration_brainstorm §7.4).
+        from cogs.mining.exploration import explore_from_inventory
+
         user_id = str(interaction.user.id)
         gid = interaction.guild_id
-        text, item, amount = roll_explore_outcome()
+        inventory = await db.get_mining_inventory(user_id, gid)
+        text, item, amount = explore_from_inventory(inventory)
         if item:
             await db.update_mining_item(user_id, gid, item, amount)
         embed = discord.Embed(

--- a/docs/ideas/mining_exploration_brainstorm.md
+++ b/docs/ideas/mining_exploration_brainstorm.md
@@ -136,7 +136,9 @@ are purely a content + wiring task.
 > build approval. It consolidates the §2 feature menu and a broader "mother panel + child panels
 > + reusable gear" expansion (maintainer brainstorm, 2026-06-08) into one decided, sequenced
 > shape. Each phase still promotes to its own `docs/planning/` slice and needs the maintainer's
-> go before building (§5 step 1's plan is the template).
+> go before building (§5 step 1's plan is the template). **Update (2026-06-08):** §7 below
+> expands this into the full **character-platform** vision and a revised roadmap — read §7 for
+> the current shape; §6 remains the detailed **mining-mechanics** reference.
 
 The brainstorm widened from "make `!explore` smarter" to a **Mining / Exploration / Crafting /
 Gear platform**: one *mother panel* routing four–five child panels, a reusable equipment system
@@ -260,3 +262,123 @@ foundation first"). P6 is where the original grid/coordinate vision lands, on to
 - **P6:** resource depletion semantics once cells exist (permanent / regenerating / per-player),
   and personal-vs-shared dig sites. The `world_seed` stored back in P2 already makes generation
   deterministic when this lands.
+
+---
+
+## 7. The character platform — expanded vision (brainstorm 2026-06-08)
+
+> **Status:** still `ideas`. This section **expands §6**: where §6 designs "mining as a real
+> game," this round reframed the whole thing — *mining is **activity #1** of a shared **character
+> platform** the entire bot plugs into.* Captured from a multi-round brainstorm with the
+> maintainer (owner taste decisions inline). It **supersedes §6's P0–P8 *ordering*** (see §7.7);
+> §6 stays the detailed reference for **mining mechanics** specifically. Locks nothing; slices
+> still promote to `docs/planning/` individually.
+
+### 7.1 The reframe
+
+The gear system was meant to be referenced by mining, exploration, deathmatch, and future cogs.
+Taken seriously, the artifact isn't a mining game — it's a **persistent character + gear + stats +
+progression layer for the whole bot**. You are a *character on the server*; mining is the first
+(flagship) activity that feeds that character, and deathmatch / blackjack / future games read from
+and contribute to the same character.
+
+**The spine:** `shared character (gear + skills + game-level + coins) → one stat block → many
+activities → social layers on top.` The **Character/Profile** is likely the *mother panel itself*,
+with Mining / Deathmatch / etc. as activities hanging off it.
+
+### 7.2 Owner taste decisions (this brainstorm)
+
+| Topic | Decision |
+|---|---|
+| Pacing | **Active sessions** (click-through now). Idle/passive **parked**. |
+| Social scope | **All four**, sequenced *after* the solo core: solo & cozy · head-to-head (PvP) · co-op & trading · server-wide goals. |
+| XP model | **Two separate tracks bot-wide:** existing **chat XP** (drives auto-roles — keep clean) **+ NEW game XP**, shared across *all* game cogs. |
+| Coins | Mining **sells ore (faucet)** + **buys gear (sink)** — integrated with the existing economy. |
+| Repeat hooks | **Gear progression · leaderboards · build-your-base.** (Not collection/completion.) |
+| Game-XP function | **Prestige + leaderboard** *and* a **capped skill tree**. **Not** content-unlocks (avoids cross-game gating weirdness). |
+| Skill tree | **Four branches:** Mining/gathering · Combat · Fortune/luck · Crafting/utility. **Capped** (can't max all). Respec = coin sink. |
+| Structures | **Forge** (recipes/tiers) · **Vault** (inventory cap + safe stash) · **Home** (hub + profile backdrop). Elevator/fast-travel **parked**. |
+| Profile visual | Ship **composited stat card** (zero art) → grow toward **character with visible gear (paper-doll)** as the dream. Full base-scene **not** the target. |
+| Titles | Earned from **skill mastery + milestones** (permanent, personal). Not rank/seasonal, not hidden. Ship early. |
+
+### 7.3 The three shared layers (what makes it a *platform*)
+
+1. **Gear / equipment** — *horizontal, swappable* power (equip per activity). [§6.5 equipment service]
+2. **Skills** — *vertical, permanent* power; spend capped game-XP points across the 4 branches.
+3. **Coins** — existing currency; mining is faucet **and** sink.
+
+…plus **game XP / level** (the shared progression track) and **identity** (titles, avatar, rank).
+
+**The convergence insight — one stat block.** Gear (swappable) **and** skills (permanent) both add
+modifiers to a single neutral **`EffectiveStats`** read model (§6.6). Every game reads *one number*.
+Adding skills costs almost no new seam — it's another input to a read model gear already feeds. Your
+power = gear + skills (+ later: consumables / structures).
+
+**Build identity — the engine that lights up every social pillar.** Because skill points are
+**capped**, players *specialize* (digger / duelist / tycoon / smith). That single fact makes **solo**
+a real choice, **PvP** varied, **leaderboards** plural (different builds top different boards), and
+**co-op** complementary (an expedition wants a digger *and* a fighter *and* a looter). One mechanic
+powers all four social pillars.
+
+### 7.4 New shared systems (for the next agent — architecture)
+
+- **Game-XP service** — sibling to the existing chat-XP `xp_service`; **own table**, guild-scoped.
+  **Central award policy** so no single game is the optimal XP farm (XP ≈ effort/risk; consider a
+  soft daily cap per game). Other game cogs call it to award XP. *Separate from chat XP on purpose —
+  chat XP already drives the auto-role tiers.*
+- **Skill service** — per-player allocations across 4 branches; computes perk modifiers into
+  `EffectiveStats`; **respec** through an audited path (coin sink).
+- **Equipment service** (§6.5) — gear → `EffectiveStats`; now **merged with** skill modifiers.
+- **Profile read-model + renderer** — composes level, skills, gear→stats, coins, rank, titles;
+  **owns no data**. `utils/mining_render` is the seed but generalizes to a **cross-game character
+  renderer** (no longer mining-specific). Stat-card first; paper-doll later.
+- **Titles / achievements** — skill-mastery + milestone triggers grant equippable titles (text — the
+  cheapest identity feature). Badges = small-art follow-on.
+
+### 7.5 The economic loop (closed, self-balancing)
+
+> mine ore → **sell** some / **craft + repair** gear → go **deeper** → better ore → repeat
+
+**Durability is the keystone** — the recurring ore+coin sink that keeps ore valuable. The sell-ore
+**faucet** is balanced by **sinks**: gear purchases, repairs, structure builds, skill **respec**.
+Design it as *one* loop, not separate features.
+
+### 7.6 Profile & identity (the spine, in detail)
+
+- **What it is:** a read-only card aggregating the whole character — avatar, game level + XP bar,
+  skill spec, equipped gear, coins / net-worth, equipped **title**, leaderboard rank.
+- **Visual roadmap:** **stat card** (avatar + PIL panel, *zero custom art*, ships first) →
+  **paper-doll character** wearing the actual loadout (base character + layered gear sprites,
+  PIL-composited). The character is the **cross-game avatar** — it appears in duels, boards, and
+  future games, which is *why* paper-doll beat the mining-only base-scene.
+- **Titles:** from **skill mastery** ("the Deep", "Ironclad", "Lucky", "Master Smith") and
+  **milestones** ("depth 50", "first diamond"). Permanent, equippable, and depend only on systems
+  we're already building → **ship early**.
+- **Cosmetics** (card themes/frames): optional later **coin sink**; pure expression, never balance.
+
+### 7.7 Revised unified roadmap (supersedes §6's ordering)
+
+Grouped into waves; slices promote to `docs/planning/` individually. **Principle:** build the first
+activity (mining) into a real solo game, *then* extract the shared platform from it — don't build the
+abstraction before its first concrete use.
+
+| Wave | Theme | Contents |
+|---|---|---|
+| **0** | Instant win | Wire `!explore` to the loadout/depth engine (plan ready; no new tables). |
+| **1** | Mining as a real solo game | Hub/mother panel · persistent position + World view · typed inventory · equipment + Gear view (**deathmatch reads stats**) · audited Workshop + durability + functional structures (Forge/Vault/Home) · sell-ore / buy-gear market. |
+| **2** | The platform layers | **Game-XP service** + leaderboards (retrofit other games to award it) · **skill tree** (4 branches, capped) folding into `EffectiveStats` + respec · **Profile** read-model + **stat-card** render + **titles**. |
+| **3** | Visual identity | **Paper-doll** character (layered gear art) · badges · cosmetic card themes. |
+| **4** | The world arc | x/y grid + coordinates + N/S/E/W movement + discovered cells + map render (§6 P6). |
+| **5** | Social systems | Leaderboard depth · **PvP** (arena / coin-wager duels) · **trading / market** (+ anti-alt guardrails) · **server-wide goals** · seasons. |
+| **6** | AI Guide | AI narration layer (AI-orchestration-gated). |
+
+### 7.8 Still-open threads (next brainstorm — not yet decided)
+
+- **PvP shape** — matchmade arena vs. challenge-a-friend **coin-wager duels** vs. gear straight into
+  the existing deathmatch. *(Weapons — sword/bow/dagger — get their purpose here, or from PvE.)*
+- **Server-wide goals** — a shared **dig-bar** toward "the Core" (active contribution) vs. a communal
+  **boss** vs. rotating **events** / seasons.
+- **Trading & market** — player trade / gift / market **and the anti-alt-account guardrails**
+  (level / cooldown gates, audit) so coins / gear / XP can't be laundered through alts.
+- **Smaller open calls:** weapons PvE-vs-PvP purpose · prestige loop at level cap · game-XP
+  normalization / daily-cap specifics · how torch/lantern gate descent (§6.8 P2).

--- a/docs/ideas/mining_exploration_brainstorm.md
+++ b/docs/ideas/mining_exploration_brainstorm.md
@@ -122,5 +122,141 @@ New files only; no existing file modified; nothing wired into a command yet:
 2. **Workshop / crafting** — `services/crafting_mutation.py` + `WorkshopView` + tool durability, built on `items.TOOL_LADDERS`.
 3. **AI-active "Guide" + image cards** — renderer + read-only AI tool that narrates the service-owned catalog; opt-in Pillow for art.
 
-### To activate image rendering
-Add `Pillow` to `requirements.txt`. Until then `utils/mining_render.render_inventory_card` returns `None` by design and the dependency footprint is unchanged.
+### Image rendering is already unblocked
+`Pillow>=10.0,<12` is in `requirements.txt`, so `utils/mining_render.render_inventory_card`
+returns PNG bytes today (it still returns `None` and falls back to an embed if Pillow ever
+fails to import — fallback-by-design is preserved). No dependency step remains; image cards
+are purely a content + wiring task.
+
+---
+
+## 6. Refined design — foundation-first build (decisions locked 2026-06-08)
+
+> **Status:** still `ideas` — this section is *design intent + recommended phasing*, **not** a
+> build approval. It consolidates the §2 feature menu and a broader "mother panel + child panels
+> + reusable gear" expansion (maintainer brainstorm, 2026-06-08) into one decided, sequenced
+> shape. Each phase still promotes to its own `docs/planning/` slice and needs the maintainer's
+> go before building (§5 step 1's plan is the template).
+
+The brainstorm widened from "make `!explore` smarter" to a **Mining / Exploration / Crafting /
+Gear platform**: one *mother panel* routing four–five child panels, a reusable equipment system
+other game cogs (deathmatch, future modes) can read, and a persistent player world. Eight owner
+decisions this session pin the v1 cut to "foundation-first, clean seams, defer the heavy and the
+risky."
+
+### 6.1 Decisions locked (2026-06-08)
+
+| # | Decision | Choice | Why it matters |
+|---|---|---|---|
+| 1 | Spatial fidelity of v1 | **Depth-bands first** (x/y grid is a later phase) | The shipped `exploration.py` already models depth bands; real coordinates are the biggest net-new build, so they sequence last among the core work. |
+| 2 | World scope | **Personal position, per-guild seed** | No griefing, easy reset/balance; a stored `world_seed` makes the later grid deterministic. Shared dig-sites stay a separate future feature. |
+| 3 | Run model | **Persistent position** | Leave at depth 3, return to depth 3. Position is DB state (allowed by ADR-002); only panels are ephemeral. |
+| 4 | Inventory storage | **Keep two bags, overlay types** | No migration now; `items.py` classifies the existing bag; gear is a new table referencing bag item-names. Unifying the bags stays deferred. |
+| 5 | Survival stats | **None in v1** (health/stamina later) | Prove the loop before balancing danger/recovery. |
+| 6 | Character scope | **Guild-scoped** | Consistent with inventory/XP/economy; gear is built from guild-scoped resources. |
+| 7 | Gear ↔ other games | **Generic stats read model** | Deathmatch/future games read computed stats, never the item catalog — the `economy_service` decoupling pattern. |
+| 8 | Crafting depth | **Flat + quick-craft-last-broken**; stations later | Ship the craft→break→recraft loop first; stations are a later progression gate. |
+
+### 6.2 What v1 is (and isn't)
+
+**In v1:** persistent depth/biome position per player · mother panel + child panels · typed
+inventory overlay · equip/unequip with generic stats · durability + "quick-craft the last item
+that broke" · loadout/depth-aware mining & exploration outcomes (the already-shipped engine) ·
+deathmatch reading gear stats.
+
+**Explicitly deferred (each revisits at its phase):** x/y coordinates + N/S/E/W movement +
+per-cell worldgen (→ P6) · health/stamina + hazards (→ post-loop) · crafting stations (→ after
+flat crafting) · inventory-table unification (own migration) · shared guild dig-site · expeditions
+/ push-your-luck · global character · AI "Guide" (AI-gated) · combat that references specific items.
+
+### 6.3 Panel structure (mother + children)
+
+`MiningHubView` (already a `PersistentView`) becomes the **mother panel** — an overview embed
+(location · depth · biome · equipped main tool · net worth) that mostly *routes*:
+
+```
+Mining Mother Panel (persistent)
+├── 🌍 World / Exploration   (surface actions ↔ underground; dynamic by state)
+├── ⛏️ Mine                  (mine current biome; gear/durability aware)
+├── 🔨 Craft (Workshop)      (quick-craft last broken · craftable-now · all recipes)
+├── 🎒 Inventory             (typed, grouped, net worth)
+└── 🧍 Gear                  (equip/unequip · generic stat summary · [later] character card)
+```
+
+Children are **ephemeral** `BaseView`/`HubView` panels (timeout) with a *Back to hub* button;
+the mother panel persists across restarts. **Dynamic buttons come from state, not the view:**
+
+- Surface: `🌲 Chop` · `🪨 Gather` · `⬇️ Mine Down`
+- Underground (v1): `⛏️ Mine Here` · `⬆️ Go Up` · `⬇️ Go Deeper` (gated by light/depth items)
+- **N/S/E/W movement is deferred to P6** (the grid) — v1 underground movement is vertical only.
+
+### 6.4 New persistent state (follows the `utils/db/games/` + guild-scoping conventions)
+
+```
+mining_worlds          (guild_id PK, seed, worldgen_version, created_at)
+  └ per-guild deterministic seed; stored in P2, first *used* by the P6 grid.
+
+mining_player_state    (guild_id, user_id, depth, current_biome, last_broken_item,
+                        last_action_at, updated_at)        PK (guild_id, user_id)
+  └ reserved-for-later columns: health, stamina (added when survival lands).
+
+mining_equipment       (guild_id, user_id, slot, item_name, durability, equipped_at)
+                        PK (guild_id, user_id, slot)
+  └ references item-names in mining_inventory; durability ticks down per use.
+```
+
+`user_id` stays `TEXT` to match legacy `mining_inventory`. No `discovered_cells` table in v1 —
+that arrives with the P6 grid.
+
+### 6.5 New service seams (mirror `economy_service`: write → audit → event)
+
+- **`services/mining/world_service.py`** — owns position: `get_state`, `descend`/`ascend`
+  (depth ± light/depth-item gating), biome selection. Writes player-state; emits audit.
+- **`services/equipment_service.py`** — `get_equipment`, `equip`/`unequip`, `apply_durability`,
+  broken-item tracking. Exposes an **`EffectiveStats`** read model; emits `equipment.item_equipped`
+  / `equipment.item_broken`. The one seam every game reads.
+- **`services/crafting_mutation.py`** — `craft`/`repair`/`upgrade` through an **audited** path,
+  closing today's gap (current `!build` mutates the bag straight from the modal with no audit
+  seam). Powers quick-craft-last-broken via `mining_player_state.last_broken_item`.
+- **Reuse, don't replace:** the pure `cogs/mining/exploration.py` (catalog + selection) and
+  `cogs/mining/items.py` (taxonomy) stay pure; the new services *apply* their results.
+
+### 6.6 The cross-cog stat contract (the "platform" seam)
+
+`equipment_service` computes a **neutral** stat block from equipped items; each game reads only
+the subset it cares about — no game imports mining's items.
+
+```
+EffectiveStats (generic, read-only):
+  mining_power · light_radius · depth_access · hazard_resistance · luck · loot_bonus
+  damage · defense · max_health · durability
+```
+
+Deathmatch reads `damage` / `defense` / `max_health` (replacing today's hardcoded HP 100 /
+dmg 15); mining reads `mining_power` / `light_radius` / `loot_bonus`; future cogs plug in for free.
+
+### 6.7 Phasing (each = its own approved slice → `docs/planning/`)
+
+| Phase | Deliverable | New tables | Risk |
+|---|---|---|---|
+| **P0** | Wire `!explore` to the loadout/depth engine (**plan already written & ready**) | none | low |
+| **P1** | Mother-panel refactor (route 5 children + overview embed) | none | low |
+| **P2** | Persistent depth/biome position + World view (Go Deeper/Up/Mine Here) | `mining_worlds`, `mining_player_state` | med |
+| **P3** | Typed inventory overlay + grouped Inventory view + net worth | none | low |
+| **P4** | Equipment service + Gear view + generic stats; **deathmatch reads stats** | `mining_equipment` | med |
+| **P5** | Audited Workshop: craft/repair/upgrade + durability + quick-craft-last-broken | none (uses P2/P4) | med |
+| **P6** | x/y grid + deterministic cell gen + N/S/E/W + discovered cells (**the big arc**) | `mining_discovered_cells` | high |
+| **P7** | PIL cards (character + local map), embed-first | none | low |
+| **P8** | AI "Guide" narration (**AI-orchestration-gated**) | none | gated |
+
+P0–P1 are immediate, low-risk, noticeable. P2–P5 are the real foundation ("build the whole
+foundation first"). P6 is where the original grid/coordinate vision lands, on top of a proven loop.
+
+### 6.8 Questions to settle at their phase (captured, not blocking v1)
+
+- **P2:** exactly how do torch/lantern/depth-items "push deeper" — own one tool per band, or
+  consume a light per descent?
+- **P5:** durability harshness — a resource sink, not an annoyance (the brainstorm's own caution).
+- **P6:** resource depletion semantics once cells exist (permanent / regenerating / per-player),
+  and personal-vs-shared dig sites. The `world_seed` stored back in P2 already makes generation
+  deterministic when this lands.

--- a/docs/ideas/mining_exploration_brainstorm.md
+++ b/docs/ideas/mining_exploration_brainstorm.md
@@ -217,9 +217,18 @@ that arrives with the P6 grid.
 - **`services/equipment_service.py`** — `get_equipment`, `equip`/`unequip`, `apply_durability`,
   broken-item tracking. Exposes an **`EffectiveStats`** read model; emits `equipment.item_equipped`
   / `equipment.item_broken`. The one seam every game reads.
-- **`services/crafting_mutation.py`** — `craft`/`repair`/`upgrade` through an **audited** path,
-  closing today's gap (current `!build` mutates the bag straight from the modal with no audit
-  seam). Powers quick-craft-last-broken via `mining_player_state.last_broken_item`.
+- **`services/mining/crafting_mutation.py`** — *optional future seam, not a current fix.*
+  **Correction (2026-06-08, verified against binding docs):** mining is an **intentional
+  direct-lane domain** — `ownership.md` routes `mining_inventory` *direct via
+  `utils/db/games/mining.py`*, and the RC-8A direct-DB ledger
+  (`docs/audits/direct-db-exception-ledger.md`) catalogues `!build`'s write as
+  **`accepted-direct-write`**: "a mutation service is a *future option, not a current
+  violation*." So today's `!build` is **correct, not an audit gap** (an earlier draft of this
+  doc wrongly called it one). An audited crafting service becomes warranted only when crafting
+  turns **cross-domain** (e.g. it spends coins — that leg *must* route through `economy_service`)
+  or grows durability / quick-craft state. Until then, crafting writes stay on the db helper;
+  the only robustness nit worth fixing there is making the multi-item build **atomic** (one
+  transaction in `utils/db/games/mining.py`). **Lightweight game state ≠ audited service.**
 - **Reuse, don't replace:** the pure `cogs/mining/exploration.py` (catalog + selection) and
   `cogs/mining/items.py` (taxonomy) stay pure; the new services *apply* their results.
 

--- a/docs/ownership.md
+++ b/docs/ownership.md
@@ -66,7 +66,7 @@ writes must come from the owning cog or a shared service.
 | `cleanup`      | `prohibited_words`                             | direct via `utils/db/moderation.py` |
 | `chain`        | `chain_channels`                               | direct via `utils/db/games/chain.py` |
 | `counting`     | `counting_state`                               | direct via `utils/db/games/counting.py` |
-| `mining`       | `mining_inventory`                             | direct via `utils/db/games/mining.py` |
+| `mining`       | `mining_inventory`, `mining_equipment`         | direct via `utils/db/games/mining*.py` |
 | `deathmatch`   | `deathmatch_stats`                             | direct via `utils/db/games/deathmatch.py` |
 | `rps_tournament` | `rps_players`, `rps_matches`                 | direct via `utils/db/games/rps.py`; balance mutations via economy_service |
 | `blackjack`    | (uses `xp.coins`; tournament state in `guild_settings`) | balance via economy_service |

--- a/docs/planning/mining-wire-exploration-plan.md
+++ b/docs/planning/mining-wire-exploration-plan.md
@@ -1,7 +1,7 @@
 # Mining — wire `!explore` to the depth/loadout engine
 
-> **Status:** `implemented` (2026-06-08, pending PR merge) — `!explore` (both the command and
-> the hub's Explore button) now resolves through the loadout/depth engine via a new pure
+> **Status:** `plan` — **implemented 2026-06-08** (pending PR merge). `!explore` (both the command
+> and the hub's Explore button) now resolves through the loadout/depth engine via a new pure
 > `exploration.explore_from_inventory()` seam, with unit tests; the engine is no longer dormant.
 > Promoted from the mining brainstorm via the **idea lifecycle** (`docs/ideas/README.md`,
 > owner decision Q-0015 grooming pass). Source and merged PRs win over this plan.

--- a/docs/planning/mining-wire-exploration-plan.md
+++ b/docs/planning/mining-wire-exploration-plan.md
@@ -1,8 +1,10 @@
 # Mining — wire `!explore` to the depth/loadout engine
 
 > **Status:** `plan` — **implemented 2026-06-08** (pending PR merge). `!explore` (both the command
-> and the hub's Explore button) now resolves through the loadout/depth engine via a new pure
-> `exploration.explore_from_inventory()` seam, with unit tests; the engine is no longer dormant.
+> and the hub's Explore button) now resolves through the loadout/depth engine via a pure
+> `exploration.explore_from_state()` seam, with unit tests; the engine is no longer dormant.
+> *(The equipment step then evolved the seam to read the player's **equipped** gear — slots →
+> capability tokens + `EffectiveStats` scaling — superseding the original inventory-based helper.)*
 > Promoted from the mining brainstorm via the **idea lifecycle** (`docs/ideas/README.md`,
 > owner decision Q-0015 grooming pass). Source and merged PRs win over this plan.
 >

--- a/docs/planning/mining-wire-exploration-plan.md
+++ b/docs/planning/mining-wire-exploration-plan.md
@@ -1,9 +1,16 @@
 # Mining — wire `!explore` to the depth/loadout engine
 
-> **Status:** `plan` — a small, ready-to-execute slice promoted from the mining brainstorm
-> via the **idea lifecycle** (`docs/ideas/README.md`; owner decision Q-0015 grooming pass,
-> 2026-06-08). **Not yet approved to build** — it is a behaviour change to a user-facing
-> command, so it needs the maintainer's go. Source and merged PRs win over this plan.
+> **Status:** `implemented` (2026-06-08, pending PR merge) — `!explore` (both the command and
+> the hub's Explore button) now resolves through the loadout/depth engine via a new pure
+> `exploration.explore_from_inventory()` seam, with unit tests; the engine is no longer dormant.
+> Promoted from the mining brainstorm via the **idea lifecycle** (`docs/ideas/README.md`,
+> owner decision Q-0015 grooming pass). Source and merged PRs win over this plan.
+>
+> **Implementation note (2026-06-08).** The cog imports the seam at module level (cogs→cogs is
+> allowed); the hub view uses a **lazy** import inside `explore_btn` because `views → cogs` at
+> module level is a layer-rule error (the existing `recipes`/`rewards` module imports are tracked
+> arch-fix-13 debt — no new one was added). Relocating the pure engine to a shared layer so
+> `services/` can build on it is deferred to the platform foundation (brainstorm §7.4).
 
 ## What & why
 

--- a/tests/unit/cogs/test_mining_equipment.py
+++ b/tests/unit/cogs/test_mining_equipment.py
@@ -1,0 +1,82 @@
+"""Tests for cogs.mining.equipment — pure gear→stats model."""
+
+from __future__ import annotations
+
+from dataclasses import fields
+
+from cogs.mining import equipment as eq
+
+
+def test_slots_are_the_three_v1_slots():
+    assert eq.SLOTS == (eq.TOOL, eq.LIGHT, eq.CHARM)
+
+
+def test_slot_for_known_items():
+    assert eq.slot_for("pickaxe") == eq.TOOL
+    assert eq.slot_for("iron pickaxe") == eq.TOOL
+    assert eq.slot_for("torch") == eq.LIGHT
+    assert eq.slot_for("lantern") == eq.LIGHT
+    assert eq.slot_for("lucky charm") == eq.CHARM
+
+
+def test_slot_for_is_case_insensitive():
+    assert eq.slot_for("Iron Pickaxe") == eq.TOOL
+
+
+def test_slot_for_unknown_is_none():
+    assert eq.slot_for("gold") is None
+    assert eq.slot_for("made up thing") is None
+
+
+def test_is_equippable():
+    assert eq.is_equippable("lantern")
+    assert not eq.is_equippable("stone")
+
+
+def test_item_stats_values():
+    assert eq.item_stats("pickaxe").mining_power == 2
+    assert eq.item_stats("iron pickaxe").mining_power == 4
+    lantern = eq.item_stats("lantern")
+    assert lantern.light_radius == 2
+    assert lantern.depth_access == 2
+    charm = eq.item_stats("lucky charm")
+    assert charm.luck == 1
+    assert charm.loot_bonus == 1
+
+
+def test_item_stats_unknown_is_zero():
+    assert eq.item_stats("gold") == eq.EffectiveStats()
+
+
+def test_compute_stats_sums_equipped():
+    equipped = {eq.TOOL: "iron pickaxe", eq.LIGHT: "lantern", eq.CHARM: "lucky charm"}
+    stats = eq.compute_stats(equipped)
+    assert stats.mining_power == 4
+    assert stats.light_radius == 2
+    assert stats.depth_access == 2
+    assert stats.luck == 1
+    assert stats.loot_bonus == 1
+
+
+def test_compute_stats_empty_is_zero():
+    assert eq.compute_stats({}) == eq.EffectiveStats()
+
+
+def test_effectivestats_add():
+    a = eq.EffectiveStats(mining_power=2, luck=1)
+    b = eq.EffectiveStats(mining_power=3, light_radius=1)
+    assert a + b == eq.EffectiveStats(mining_power=5, luck=1, light_radius=1)
+
+
+def test_describe_stats_only_nonzero_in_order():
+    stats = eq.EffectiveStats(mining_power=4, loot_bonus=1)
+    assert eq.describe_stats(stats) == [("Mining power", 4), ("Loot bonus", 1)]
+
+
+def test_describe_stats_empty():
+    assert eq.describe_stats(eq.EffectiveStats()) == []
+
+
+def test_stat_labels_match_dataclass_fields():
+    field_names = {f.name for f in fields(eq.EffectiveStats)}
+    assert set(eq.STAT_LABELS) == field_names

--- a/tests/unit/cogs/test_mining_exploration.py
+++ b/tests/unit/cogs/test_mining_exploration.py
@@ -33,7 +33,8 @@ def test_torch_unlocks_deep_finds():
 def test_dynamite_gated_outcome_requires_dynamite():
     without = exp.eligible_outcomes(exp.Biome.DEEP, exp.Loadout())
     with_dyn = exp.eligible_outcomes(
-        exp.Biome.DEEP, exp.Loadout(tools=frozenset({exp.DYNAMITE})),
+        exp.Biome.DEEP,
+        exp.Loadout(tools=frozenset({exp.DYNAMITE})),
     )
     assert "blasted_vein" not in {o.key for o in without}
     assert "blasted_vein" in {o.key for o in with_dyn}
@@ -44,31 +45,37 @@ def test_deeper_biome_includes_shallower_outcomes():
     assert "secret_chest" in {o.key for o in deep}  # a surface outcome
 
 
-def test_pickaxe_doubles_ore_gain():
-    # abandoned_camp grants gold; pickaxe should double a positive ore gain.
-    base = exp.Loadout()
-    geared = exp.Loadout(tools=frozenset({exp.PICKAXE}))
-    outcome = next(o for o in exp.CATALOG if o.key == "abandoned_camp")
+def test_mining_power_doubles_ore_gain():
+    # abandoned_camp grants gold; mining_power 2 (a pickaxe) doubles a positive
+    # ore gain, and 4 (an iron pickaxe) triples it.
+    from cogs.mining.equipment import EffectiveStats
     from cogs.mining.exploration import _scale_amount
 
-    assert _scale_amount(outcome, geared) == _scale_amount(outcome, base) * 2
+    outcome = next(o for o in exp.CATALOG if o.key == "abandoned_camp")
+    base = _scale_amount(outcome, EffectiveStats())
+    assert _scale_amount(outcome, EffectiveStats(mining_power=2)) == base * 2
+    assert _scale_amount(outcome, EffectiveStats(mining_power=4)) == base * 3
 
 
 def test_penalties_are_never_scaled():
-    geared = exp.Loadout(tools=frozenset({exp.PICKAXE, exp.LUCKY_CHARM}))
+    from cogs.mining.equipment import EffectiveStats
+    from cogs.mining.exploration import _scale_amount
+
     hazard = next(o for o in exp.CATALOG if o.key == "monster_ambush")
-    from cogs.mining.exploration import _scale_amount
-
     # Negative amount stays exactly as authored — gear protects gains only.
-    assert _scale_amount(hazard, geared) == hazard.amount
+    assert (
+        _scale_amount(hazard, EffectiveStats(mining_power=4, loot_bonus=1))
+        == hazard.amount
+    )
 
 
-def test_lucky_charm_adds_one():
-    geared = exp.Loadout(tools=frozenset({exp.LUCKY_CHARM}))
-    outcome = next(o for o in exp.CATALOG if o.key == "secret_chest")
+def test_loot_bonus_adds_flat_extra():
+    from cogs.mining.equipment import EffectiveStats
     from cogs.mining.exploration import _scale_amount
 
-    assert _scale_amount(outcome, geared) == outcome.amount + 1
+    # secret_chest gives wood (not ore): loot_bonus still adds a flat +1.
+    outcome = next(o for o in exp.CATALOG if o.key == "secret_chest")
+    assert _scale_amount(outcome, EffectiveStats(loot_bonus=1)) == outcome.amount + 1
 
 
 def test_resolve_is_deterministic_with_seeded_rng():
@@ -119,32 +126,54 @@ def test_resolve_always_returns_result_even_when_catalog_filtered():
     assert isinstance(result.final_amount, int)
 
 
-def test_explore_from_inventory_returns_legacy_tuple_shape():
-    text, item, amount = exp.explore_from_inventory({}, rng=_rng())
+def test_explore_from_state_returns_legacy_tuple_shape():
+    text, item, amount = exp.explore_from_state({}, {}, rng=_rng())
     assert isinstance(text, str) and text
     assert item is None or isinstance(item, str)
     assert isinstance(amount, int)
 
 
-def test_explore_from_inventory_builds_loadout_and_threads_rng():
-    # The helper must derive the Loadout from the inventory and pass biome +
-    # rng straight through — so it equals calling the engine directly with the
-    # same derived loadout and an identically seeded RNG.
-    inv = {"torch": 1, "pickaxe": 1, "stone": 9, "gold": 4}
-    got = exp.explore_from_inventory(inv, biome=exp.Biome.CAVERN, rng=random.Random(7))
-    expected = exp.resolve_to_legacy_tuple(
-        biome=exp.Biome.CAVERN,
-        loadout=exp.Loadout.from_inventory(inv),
-        rng=random.Random(7),
+def test_explore_from_state_maps_equipped_gear_and_threads_stats():
+    # Equipped slots map to the catalog's capability tokens (TOOL→PICKAXE,
+    # LIGHT→TORCH, CHARM→LUCKY_CHARM); dynamite is read from inventory; and the
+    # equipped stats are threaded — so the helper equals resolving directly with
+    # that loadout + computed stats under an identically seeded RNG.
+    from cogs.mining import equipment
+
+    equipped = {
+        equipment.TOOL: "iron pickaxe",
+        equipment.LIGHT: "lantern",
+        equipment.CHARM: "lucky charm",
+    }
+    inv = {"dynamite": 1, "gold": 4}
+    got = exp.explore_from_state(
+        equipped, inv, biome=exp.Biome.CAVERN, rng=random.Random(7)
     )
+    expected = exp.resolve(
+        exp.Biome.CAVERN,
+        exp.Loadout(
+            tools=frozenset({exp.PICKAXE, exp.TORCH, exp.LUCKY_CHARM, exp.DYNAMITE}),
+        ),
+        stats=equipment.compute_stats(equipped),
+        rng=random.Random(7),
+    ).to_legacy_tuple()
     assert got == expected
 
 
-def test_explore_from_inventory_default_biome_is_surface():
-    # Omitting ``biome`` must behave exactly like passing SURFACE explicitly.
-    inv = {"pickaxe": 1}
-    default = exp.explore_from_inventory(inv, rng=random.Random(3))
-    explicit = exp.explore_from_inventory(
-        inv, biome=exp.Biome.SURFACE, rng=random.Random(3),
+def test_light_slot_satisfies_deep_find_gate():
+    # Regression: a lantern (not a literal "torch") in the LIGHT slot must
+    # unlock the torch-gated deep finds — the old ownership check missed it.
+    from cogs.mining import equipment
+
+    assert exp._SLOT_TO_TOKEN[equipment.LIGHT] == exp.TORCH
+
+
+def test_explore_from_state_default_biome_is_surface():
+    from cogs.mining import equipment
+
+    equipped = {equipment.TOOL: "pickaxe"}
+    default = exp.explore_from_state(equipped, {}, rng=random.Random(3))
+    explicit = exp.explore_from_state(
+        equipped, {}, biome=exp.Biome.SURFACE, rng=random.Random(3)
     )
     assert default == explicit

--- a/tests/unit/cogs/test_mining_exploration.py
+++ b/tests/unit/cogs/test_mining_exploration.py
@@ -117,3 +117,34 @@ def test_resolve_always_returns_result_even_when_catalog_filtered():
     result = exp.resolve(exp.Biome.SURFACE, exp.Loadout(), rng=_rng())
     assert result.narration
     assert isinstance(result.final_amount, int)
+
+
+def test_explore_from_inventory_returns_legacy_tuple_shape():
+    text, item, amount = exp.explore_from_inventory({}, rng=_rng())
+    assert isinstance(text, str) and text
+    assert item is None or isinstance(item, str)
+    assert isinstance(amount, int)
+
+
+def test_explore_from_inventory_builds_loadout_and_threads_rng():
+    # The helper must derive the Loadout from the inventory and pass biome +
+    # rng straight through — so it equals calling the engine directly with the
+    # same derived loadout and an identically seeded RNG.
+    inv = {"torch": 1, "pickaxe": 1, "stone": 9, "gold": 4}
+    got = exp.explore_from_inventory(inv, biome=exp.Biome.CAVERN, rng=random.Random(7))
+    expected = exp.resolve_to_legacy_tuple(
+        biome=exp.Biome.CAVERN,
+        loadout=exp.Loadout.from_inventory(inv),
+        rng=random.Random(7),
+    )
+    assert got == expected
+
+
+def test_explore_from_inventory_default_biome_is_surface():
+    # Omitting ``biome`` must behave exactly like passing SURFACE explicitly.
+    inv = {"pickaxe": 1}
+    default = exp.explore_from_inventory(inv, rng=random.Random(3))
+    explicit = exp.explore_from_inventory(
+        inv, biome=exp.Biome.SURFACE, rng=random.Random(3),
+    )
+    assert default == explicit

--- a/tests/unit/cogs/test_mining_items.py
+++ b/tests/unit/cogs/test_mining_items.py
@@ -67,3 +67,38 @@ def test_sort_inventory_orders_by_kind_then_value():
 def test_sort_inventory_drops_zero_quantities():
     inv = {"gold": 0, "stone": 2}
     assert items.sort_inventory(inv) == [("stone", 2)]
+
+
+def test_summarize_inventory_groups_by_kind_in_display_order():
+    inv = {
+        "diamond": 2,  # resource (high value)
+        "stone": 5,  # resource
+        "pickaxe": 1,  # tool
+        "dynamite": 3,  # consumable
+        "stone hut": 1,  # structure
+        "lucky charm": 1,  # treasure
+        "gone": 0,  # dropped (zero qty)
+    }
+    sections = items.summarize_inventory(inv)
+    assert [kind for kind, _ in sections] == [
+        items.ItemKind.RESOURCE,
+        items.ItemKind.TOOL,
+        items.ItemKind.CONSUMABLE,
+        items.ItemKind.STRUCTURE,
+        items.ItemKind.TREASURE,
+    ]
+    # Resources ordered by value desc: diamond (12) before stone (1).
+    assert sections[0][1] == [("diamond", 2), ("stone", 5)]
+    # Zero-qty item is dropped entirely.
+    all_names = {name for _, rows in sections for name, _ in rows}
+    assert "gone" not in all_names
+
+
+def test_summarize_inventory_empty():
+    assert items.summarize_inventory({}) == []
+
+
+def test_summarize_inventory_only_present_kinds_appear():
+    sections = items.summarize_inventory({"iron": 4})
+    assert [kind for kind, _ in sections] == [items.ItemKind.RESOURCE]
+    assert sections[0][1] == [("iron", 4)]

--- a/tests/unit/db/test_mining_equipment_db.py
+++ b/tests/unit/db/test_mining_equipment_db.py
@@ -1,0 +1,48 @@
+"""mining_equipment CRUD — mock-pool tests (mirrors test_mining_guild_scope)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from utils.db.games import mining_equipment as me
+
+
+@pytest.mark.asyncio
+async def test_get_equipment_filters_by_user_and_guild():
+    with patch(
+        "utils.db.games.mining_equipment.pool.fetchall",
+        new_callable=AsyncMock,
+        return_value=[{"slot": "tool", "item_name": "iron pickaxe"}],
+    ) as mock_fetch:
+        result = await me.get_equipment("123", 999)
+    assert result == {"tool": "iron pickaxe"}
+    query, params = mock_fetch.await_args.args
+    assert "user_id=$1 AND guild_id=$2" in query.replace("  ", " ")
+    assert params == ("123", 999)
+
+
+@pytest.mark.asyncio
+async def test_equip_item_upserts_on_slot_conflict():
+    with patch(
+        "utils.db.games.mining_equipment.pool.execute",
+        new_callable=AsyncMock,
+    ) as mock_exec:
+        await me.equip_item("123", 999, "tool", "iron pickaxe")
+    query, params = mock_exec.await_args.args
+    assert "(user_id, guild_id, slot)" in query
+    assert params == ("123", 999, "tool", "iron pickaxe")
+
+
+@pytest.mark.asyncio
+async def test_unequip_slot_deletes_one_slot():
+    with patch(
+        "utils.db.games.mining_equipment.pool.execute",
+        new_callable=AsyncMock,
+    ) as mock_exec:
+        await me.unequip_slot("123", 999, "light")
+    query, params = mock_exec.await_args.args
+    assert "DELETE FROM mining_equipment" in query
+    assert "slot=$3" in query.replace("  ", " ")
+    assert params == ("123", 999, "light")


### PR DESCRIPTION
## Summary

Refines the maintainer's mining idea into a whole-bot **character-platform** vision, then lays the first foundation slices. Eight commits; each runtime change verified green through the full CI mirror (`scripts/check_quality.py --full`: black/isort/ruff + mypy + the entire ~8.2k-test suite + architecture, 0 errors) before push.

The design is captured in `docs/ideas/mining_exploration_brainstorm.md` §6–§7 (the character-platform vision, owner decisions, and a wave-based roadmap).

## What's in here

**Design**
- `b48b01d` / `6e5a605` — brainstorm → §6 refined design + §7 character-platform vision (gear + skills + game-XP → one `EffectiveStats` → every game; profile as the spine).

**Foundation (runtime / behaviour)**
- `50a5a46` — **`!explore` is loadout/depth-aware** (activates the dormant `exploration.py`).
- `9344a6c` — **typed Inventory panel + net worth** (activates the dormant `items.py`).
- `dbf7524` — **equipment seam**: migration 060 `mining_equipment`, the pure `EffectiveStats` read model, `!equip`/`!unequip`/`!gear`.
- `6c5c800` — **exploration reads equipped gear's stats** (iron pickaxe > plain; a lantern now satisfies deep-find gating — a latent-bug fix).

**Correction**
- `6f5d4ad` — reading the binding contracts *first* showed the "audited mining service" task rested on a false premise: mining is an **intentional direct-lane domain** (`ownership.md` + the RC-8A `accepted-direct-write` ledger). No wrong service was built; the brainstorm note that claimed an audit gap is corrected, and `ownership.md` now lists `mining_equipment`.

## Architecture notes
- The pure mining engines live in `cogs/mining/`; **views import them lazily** inside handlers (`views/ → cogs/` at module level is a layer error). Relocating them to a shared layer so `services/` can build on them is the tracked next step (brainstorm §7.4).
- `EffectiveStats` is the cross-game seam: gear feeds it now; skills + combat gear (`damage`/`defense`/`max_health`, reserved) feed it later.

## Next (brainstorm §7.7)
Persistent depth · combat gear + deathmatch reading stats · sell-ore/buy-gear market (routes through `economy_service`) · game-XP service + skill tree · profile card / paper-doll.

https://claude.ai/code/session_018QTXCtEJCikKtZ6GFzHvor

---
_Generated by [Claude Code](https://claude.ai/code/session_018QTXCtEJCikKtZ6GFzHvor)_