### PR TITLE
Fun & ease-of-use brainstorm capture (24 ideas) + structured pets plan

### DIFF
--- a/.sessions/2026-06-09-fun-ease-brainstorm.md
+++ b/.sessions/2026-06-09-fun-ease-brainstorm.md
@@ -1,0 +1,57 @@
+# 2026-06-09 — Fun & ease-of-use brainstorm capture + pets plan
+
+**PR:** #623 (draft at first push per Q-0052; marked ready at session end)
+**Type:** docs-only (ideas capture + structured plan + routing)
+
+## Arc
+
+Maintainer asked for a creativity test: survey what exists + what's already captured,
+then brainstorm *new* fun/ease ideas. Ran two parallel explorers (feature inventory;
+ideas/backlog survey), read the four product-growth roadmap drafts + owner-vision +
+future-product-direction myself, then **grep-verified every candidate idea against
+docs AND source** before keeping it. Asked the owner three structured questions
+(cluster picks + session scope) — answers recorded as **Q-0053**.
+
+## Shipped
+
+- `docs/ideas/fun-and-ease-brainstorm-2026-06-09.md` — 24 dedup-verified ideas
+  (A social/competition ×7 · B ambient delight ×10 · C member UX ×7), each with
+  verified seams, size/risk, and a routing state (no orphans). §1 lists the
+  candidates *dropped because they already exist* (with citations).
+- `docs/planning/pets-companions-plan-2026-06-09.md` — the owner's ⭐ fun pick
+  structured: P1 egg/hatch → P2 care-loop sink → P3 balance-gated perks (≤1–2%,
+  non-P2W) → P4 showcase; gates = Wave-1 keystone slices + balance review + owner
+  promotion. Roadmap: games **Later** row.
+- Wiring: ideas README, roadmap (×2), games folio, router §24 (Q-0053).
+
+## Findings worth keeping
+
+- **The bot already has** "did-you-mean" fuzzy command resolution
+  (`utils/command_resolution.py`), PvP coin stakes (RPS Bet Match / blackjack),
+  and gifting/prestige captured in the mining brainstorm — brainstorms must
+  grep-verify before proposing; three "obvious" ideas were already done.
+- `!remind` is in-memory by its own admission (`cogs/utility_cog.py:36`) — every
+  restart silently drops reminders. Captured as C4, an owner ⭐ ease pick.
+- ~15 functional mining commands are `hidden=True` and Help-invisible (C5) —
+  cheap active-lane discoverability win.
+- All 7 social ideas were deliberately scoped single-guild so none waits on the
+  open guild/clan tenancy question (Q-0038).
+
+## Next-session candidates (from owner ⭐ picks)
+
+1. **C1 context-menu actions** — first `context_menu` registrations (View
+   Profile / View Rank first); biggest mobile win; routes into existing panels.
+2. **C4 persistent reminders** — small table + delivery on schedule; root-causes
+   a silent-loss bug.
+3. Pets P1 only after the Wave-1 keystone slices (Workshop + durability) ship.
+
+## Context delta
+
+- **Needed but not pointed to:** nothing major — the orientation route +
+  `docs/ideas/README.md` lifecycle covered this session shape well.
+- **Pointed to but didn't need:** CodeGraph symbol tools — a brainstorm/capture
+  session is grep + docs work; the graph never paid off here.
+- **Discovered by hand:** the dedup greps (feature-or-idea novelty checks) are the
+  load-bearing step of a brainstorm session — `command_resolution.py` and the RPS
+  stakes would have been embarrassing re-proposals. Future brainstorm sessions:
+  grep `docs/` *and* `disbot/` for each candidate before capture.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -18,6 +18,12 @@ Pure brainstorm backlogs — capture without commitment. Each file should carry 
 
 Current broad captures:
 
+- [`fun-and-ease-brainstorm-2026-06-09.md`](./fun-and-ease-brainstorm-2026-06-09.md) —
+  24 dedup-verified new ideas for "more fun + easier to use" (social/competition layer,
+  ambient delight, member UX), each grep-checked against docs *and* source before
+  capture. Owner cluster picks recorded (Q-0053): **pets & companions** (structured →
+  [`../planning/pets-companions-plan-2026-06-09.md`](../planning/pets-companions-plan-2026-06-09.md)),
+  context-menu actions, persistent reminders.
 - [`cog-improvement-audit-2026-06-08.md`](./cog-improvement-audit-2026-06-08.md) —
   cog-by-cog improvement audit from a 36-question interactive session (2026-06-08).
   Covers all 35 existing cogs; includes a priority-ranked routing table. Top finding:

--- a/docs/ideas/fun-and-ease-brainstorm-2026-06-09.md
+++ b/docs/ideas/fun-and-ease-brainstorm-2026-06-09.md
@@ -1,0 +1,285 @@
+# Fun & ease-of-use brainstorm — ideas capture (2026-06-09)
+
+> **Status:** `ideas` (captured — not approved for implementation).
+> Source: a brainstorming session with the maintainer on 2026-06-09 ("see what exists,
+> see what's already captured, then come up with *more*"). Every idea below was
+> **dedup-verified against docs *and* source** before capture (see §1). Route each idea
+> through the lifecycle in [`README.md`](./README.md) before implementing.
+> Owner cluster picks from the same session are recorded in §2 and in the router
+> (**Q-0053**); the ⭐ marks below are *his* reactions, not agent ranking.
+
+---
+
+## 1. Dedup check — what this capture does NOT repeat
+
+This brainstorm is **additive** to the existing idea space. Checked against:
+[`owner-vision-ideas-2026-06-08.md`](./owner-vision-ideas-2026-06-08.md) (36-question
+capture), the four product-growth roadmap drafts (social / economy / games-idle / UX),
+[`future-product-direction-2026-06-07.md`](./future-product-direction-2026-06-07.md),
+[`mining_exploration_brainstorm.md`](./mining_exploration_brainstorm.md),
+[`cog-improvement-audit-2026-06-08.md`](./cog-improvement-audit-2026-06-08.md), the
+ideas-lab rejection ledger (§6, binding), and `grep` over `disbot/` + `docs/`.
+
+Candidate ideas **dropped because they already exist or are already captured**:
+
+| Dropped idea | Where it already lives |
+|---|---|
+| "Did you mean?" typo correction | **Shipped** — `disbot/utils/command_resolution.py` (auto-run + suggest, destructive-command guard) |
+| PvP coin-stake challenges | **Shipped** — RPS Bet Match / blackjack Solo Bet + PvP (`views/games/rps_panel.py`, `views/games/blackjack_panel.py`) |
+| Gifting / player-to-player transfer | Captured — mining brainstorm §"Trading & market" + cog-audit Gap 2 |
+| Prestige / rebirth loop | Captured — mining brainstorm ("Prestige + leaderboard and a capped skill tree") |
+| Member onboarding flow / starter pack | Captured — owner-vision §12 |
+| Daily login rewards, streaks, lottery | Shipped (`!daily` streaks) / captured (owner-vision §2b) |
+| General trivia / jokes / 8-ball | Shipped — `general_cog` |
+| Admin digest / notification profiles | Captured — future-product-direction "Notification subscription profiles" |
+
+None of the ideas below conflicts with the binding rejection ledger (no Redis, no
+restart-safe game sessions, no second panel framework, no per-sub-action slash
+commands, no AI write tools).
+
+---
+
+## 2. Owner reactions (2026-06-09, recorded — see router Q-0053)
+
+Asked which clusters resonate most, the maintainer picked:
+
+- **Fun: A1 Pets & companions** ⭐ — structured the same session into
+  [`../planning/pets-companions-plan-2026-06-09.md`](../planning/pets-companions-plan-2026-06-09.md)
+  (state: `structured`, horizon: Later on `docs/roadmap.md`).
+- **Ease: C1 context-menu actions** ⭐ **and C4 persistent reminders** ⭐ — marked
+  top quick-win candidates (small, decided-lane; good next-session picks).
+- Session scope chosen: capture everything + structure the pets cluster (no feature
+  code that session).
+
+---
+
+## 3. Catalog A — social & competition layer
+
+The owner's stated #1 ("more social — players interacting with each other",
+owner-vision §4a). **Every idea here is single-guild scoped on purpose** — none waits
+on the open guild/clan tenancy question (Q-0038).
+
+### A1. Pet companions 🐾 ⭐ *(structured → plan)*
+Rare eggs drop from mining/exploration → hatch into nameable pets that appear on the
+`!character` card. Feeding/care is a **recurring coin/ore sink** (the economy wants
+sinks — owner-vision §15); perks stay tiny and flavor-first (≤1–2%, e.g. explore luck)
+to keep the no-pay-to-win line. Later: pet showcase in Spotlight, marketplace
+tradability once the captured marketplace lands.
+**Seams:** mining drop tables (`cogs/mining/`), audited `economy_service` for coins,
+inventory owner for ore, `utils/equipment.py` `EffectiveStats` composition for any
+stat-touching perk, character panel (#610), Spotlight EventBus feed (#613).
+**Size M-L · Risk low-med (balance) · Route:** structured —
+[`../planning/pets-companions-plan-2026-06-09.md`](../planning/pets-companions-plan-2026-06-09.md).
+
+### A2. Server goals & celebrations 🎯 (+ server mascot variant)
+A weekly server-wide collective target ("the server mines 10,000 ore / wins 500
+games") with a live progress bar in Community Spotlight; completion fires a
+celebration embed + a temporary server-wide perk (e.g. +10% daily bonus weekend) and a
+contributors shoutout. Charming variant: a **shared server mascot** — one tamagotchi
+per guild that members feed (coin sink) and that levels/mood-shifts with collective
+activity, rendered in Spotlight. Generalizes the mining brainstorm's one-line
+"server-wide goals" social scope to the whole bot.
+**Seams:** Spotlight (#613) + the EventBus events already emitted (`xp.awarded`,
+`economy.balance_changed`, game results), `economy_service` for perk payouts.
+**Size M · Risk low · Route:** plan when picked up (games/social lane).
+
+### A3. Bounty board 💰
+Players escrow a coin bounty ("first to beat me at RPS: 500 coins", "first to reach
+depth 4 this week"); claims verified from game-result events, paid from escrow. A
+bounty panel lists open bounties — instant PvP motivation between any two members.
+**Seams:** economy escrow (the RPS Bet Match debit-at-start precedent), EventBus game
+results, a small direct-lane bounty table.
+**Size M · Risk med (verification/abuse review needed) · Route:** plan (economy+games).
+
+### A4. Rivalries — head-to-head records ⚔️
+Per-pair W/L records across games. Challenge embeds gain one line ("Bob leads 5–2 —
+revenge time?"); a "rival of the week" line in Spotlight. Concretizes the mining
+brainstorm's "head-to-head (PvP)" scope marker cross-game. Cheap, durable social glue
+on top of results the bot already stores.
+**Seams:** existing per-game result/leaderboard storage, challenge flows, Spotlight.
+**Size S-M · Risk low · Route:** quick-win candidate (read-model + one embed line).
+
+### A5. King of the Hill titles 👑
+One transferable champion title per game ("Blackjack King"). Beat the current holder
+in a direct challenge to take it. Holder shows in Spotlight and on their profile;
+optionally a cosmetic role via the existing role-automation seam.
+**Seams:** game results, role automation, Spotlight, character/profile card.
+**Size S · Risk low · Route:** quick-win candidate.
+
+### A6. Predictions / betting pools 🔮
+Twitch-style predictions: a host opens "Who wins tonight's RPS tournament?", members
+stake coins on outcomes, the pot splits among winners. Coins-only, tournament-anchored
+first. `docs/architecture.md` already anticipates exactly this shape (matchmaking /
+limited-quantity drops via scope locks).
+**Seams:** tournaments (RPS/BJ), economy escrow, scope-lock transient registries.
+**Size M · Risk med · Route:** **must ride the economy roadmap's chance-reward /
+lottery legality review** (same gate as owner-vision §2b lottery tickets) — not before.
+
+### A7. LFG / party board 📯
+"Looking for players" slots: post a game + time + party size, others tap **Join**,
+auto-ping when full. Generalizes the captured mining co-op parties and BTD6 co-op into
+one reusable surface.
+**Seams:** scope-lock transient-registry pattern (architecture §state-registry),
+games hub, notifications-CTA convention (owner-vision §22).
+**Size S-M · Risk low · Route:** plan (one bounded slice; reusable across games).
+
+---
+
+## 4. Catalog B — ambient fun & delight (the server feels alive daily)
+
+### B1. Starboard / Hall of Fame ⭐(the emoji, not an owner pick)
+N star-reactions on any message → immortalized in #hall-of-fame with a jump link;
+optional small XP bonus to the author. The classic zero-typing community-memory
+feature; SuperBot has the raw-reaction handling precedent in reaction roles.
+**Size S-M · Risk low (dedupe + self-star rules) · Route:** quick-win / plan.
+
+### B2. Quote board 💬
+Save a member's message as a server quote — ideally via right-click → "Save Quote"
+(see C1) — then `!quotes` random recall and a quote-of-the-day that can ride B4's
+seam. Distinct from the existing `!quote` (famous quotes).
+**Size S-M · Risk low (author opt-out posture) · Route:** quick-win / plan, pairs with C1.
+
+### B3. Birthdays & cakedays 🎂
+Opt-in birthday (day + month only — deliberately no year, privacy-light): celebration
+embed + small coin gift + a 24h cosmetic role. Join-anniversary ("cakeday") shoutouts
+come free from member data the bot already has.
+**Seams:** role automation (temp role), economy (gift), a tiny opt-in table + daily tick.
+**Size S-M · Risk low · Route:** quick-win candidate.
+
+### B4. Question of the day ❓
+A daily auto-posted conversation starter / would-you-rather / this-or-that in a
+configured channel, with reaction voting. Zero game mechanics — pure social glue —
+and the content pack is a natural home for the captured funny/sarcastic personality
+(owner-vision §16).
+**Seams:** the captured scheduled-announcements seam (owner-vision §7).
+**Size S · Risk low · Route:** quick-win candidate.
+
+### B5. Daily word game 🟩
+Wordle-style shared daily word per server: guess via button + modal (mobile-friendly,
+no typing in-channel), per-player streaks, and a new leaderboard category — the
+leaderboard provider system is extensible by design. A third ambient channel game
+beside counting and chain.
+**Size M · Risk low · Route:** plan (games lane).
+
+### B6. Treasure hunts 🗺️
+A rare "treasure map" drop from mining/explore starts a 3-step riddle whose clues
+point at bot features ("check the counting channel", "visit depth 2"); the finder
+gets a chest (coins + a captured-idea collectible). Teaches the bot's surface area
+while playing.
+**Size M · Risk low-med · Route:** plan (games lane; pairs with captured collectibles).
+
+### B7. Today's deals — rotating shop stock 🛒
+The shop and mining market gain 2–3 **date-seeded** rotating featured items (small
+discount or limited stock). Deterministic (seeded by date+guild), so no new state —
+and it gives players a reason to peek in daily alongside `!daily`.
+**Seams:** shop catalogue, mining market (#609 — static catalogues today).
+**Size S · Risk low · Route:** quick-win candidate.
+
+### B8. Seasonal theming 🎃
+Month-aware embed accent colors/emoji via one shared styling helper (October spooky,
+December festive). The cheap deterministic sibling of the captured seasonal world
+events (owner-vision §5) — delight without event mechanics.
+**Size S · Risk low · Route:** quick-win candidate (one helper + adoption).
+
+### B9. Easter-egg reaction pack 🥚
+Generalize the existing `four_twenty_cog` listener pattern into a small curated
+trigger → rare reaction/reply pack (per-guild toggle, cooldowns), written in the
+captured sarcastic voice. Rare on purpose — surprise is the point.
+**Size S · Risk low (rate-limit care) · Route:** quick-win candidate.
+
+### B10. Daily contracts 📜
+2–3 deterministic daily tasks ("win 2 blackjack hands", "mine 50 stone", "post a
+valid count") with coin rewards + a weekly mega-contract. The **non-AI sibling** of
+the captured AI procedural quests — shippable now, no LLM cost — and it feeds the
+captured streak system and C2's claim-all hub.
+**Seams:** game-result events, economy, daily-reset pattern from `!daily`.
+**Size M · Risk low-med (reward balance) · Route:** plan (economy/games lane).
+
+---
+
+## 5. Catalog C — easier to use (members; mobile-first per owner-vision §8)
+
+### C1. Context-menu actions 📱 ⭐ *(owner ease pick)*
+The bot's **first** right-click / long-press commands: user → View Profile / View
+Rank / Challenge…; message → Save Quote (B2) / Pin to Hall of Fame (B1). Zero typing,
+ephemeral responses, and **long-press is native on mobile** — the single biggest
+mobile-first win available. The bot has zero `context_menu` registrations today;
+discord.py supports them on the existing slash front-door pattern (they route into
+existing panels, so no per-sub-action command sprawl).
+**Size S-M · Risk low · Route:** quick-win candidate (start with View Profile + View Rank).
+
+### C2. Claim-all daily hub ✅
+One panel that shows everything claimable — daily reward, work cooldown, contracts
+(B10), streak status, today's deals (B7) — each with a claim button, plus a "you have
+3 things to claim" nudge on `!daily`. Pure composition over existing owners; each
+claim still goes through its own service.
+**Size S-M · Risk low · Route:** quick-win / plan (grows as B7/B10 land).
+
+### C3. `!play` quick-launcher 🚀
+Personal recents/favorites: one panel with your last 3 games as instant-launch
+buttons + a "surprise me" button. One tap from "I'm bored" to playing.
+**Size S · Risk low · Route:** quick-win candidate.
+
+### C4. Persistent reminders ⏰ ⭐ *(owner ease pick)*
+`!remind` is **in-memory today and silently loses every reminder on restart**
+(verified in `cogs/utility` — the cog even says so). Persist reminders to a small
+table and deliver on schedule. Distinct from the captured admin scheduled
+announcements (owner-vision §7) — this is the member-facing utility.
+**Size S-M · Risk low · Route:** quick-win candidate (root-causes a real silent-loss bug).
+
+### C5. Mining hub discoverability ⛏️
+~15 functional mining commands are hidden / prefix-only (`!build`, `!buildlist`,
+`!use`, `!equip`, `!unequip`, `!minestats`…) and invisible in Help. Surface them as
+buttons/selects on the existing mining hub (Build menu, Use-item select, Gear panel) —
+the Wave-1 hub buttons (Descend/Market/Character) are the exact precedent.
+**Size S · Risk low · Route:** quick-win in the **active mining lane** (fold into the
+next Wave-1 slice or take standalone).
+
+### C6. Member "what works here?" guide 🧭
+A member-facing sibling of the staff Access Map: one ephemeral "what can I do in this
+channel?" answer (which features respond here, where the others live). Reuses the
+shipped `services/access_projection.py` (P1A) read model and must follow the
+locked-reason copy posture (Q-0036).
+**Size S-M · Risk low · Route:** groom into the Adaptive Setup/Access lane **after**
+P1C ships its staff surfaces (don't fork that lane's sequencing).
+
+### C7. Slash autocomplete arguments ⌨️
+Autocomplete for item/game/category names on the existing slash front doors (shop
+items, game pickers) so phone users never type exact names. Bounded: front doors
+only — no per-sub-action commands (rejection ledger).
+**Size S per surface · Risk low · Route:** groom into the interface-completion lane.
+
+---
+
+## 6. Routing summary (state ledger)
+
+| # | Idea | Size | Risk | Owner ⭐ | State → next destination |
+|---|---|---|---|---|---|
+| A1 | Pet companions | M-L | low-med | ⭐ fun pick | **structured** → [`pets-companions-plan-2026-06-09.md`](../planning/pets-companions-plan-2026-06-09.md) + roadmap Later (games) |
+| A2 | Server goals & mascot | M | low | | captured → plan candidate (games/social) |
+| A3 | Bounty board | M | med | | captured → plan + abuse review |
+| A4 | Rivalries (head-to-head) | S-M | low | | captured → quick-win candidate |
+| A5 | King of the Hill titles | S | low | | captured → quick-win candidate |
+| A6 | Predictions / betting pools | M | med | | captured → **gated**: economy chance-reward review (with lottery) |
+| A7 | LFG / party board | S-M | low | | captured → plan (reusable surface) |
+| B1 | Starboard / Hall of Fame | S-M | low | | captured → quick-win / plan |
+| B2 | Quote board | S-M | low | | captured → quick-win (pairs with C1) |
+| B3 | Birthdays & cakedays | S-M | low | | captured → quick-win candidate |
+| B4 | Question of the day | S | low | | captured → quick-win candidate |
+| B5 | Daily word game | M | low | | captured → plan (games lane) |
+| B6 | Treasure hunts | M | low-med | | captured → plan (games lane) |
+| B7 | Today's deals (rotating stock) | S | low | | captured → quick-win candidate |
+| B8 | Seasonal theming | S | low | | captured → quick-win candidate |
+| B9 | Easter-egg reaction pack | S | low | | captured → quick-win candidate |
+| B10 | Daily contracts | M | low-med | | captured → plan (economy/games) |
+| C1 | Context-menu actions | S-M | low | ⭐ ease pick | captured → **top quick-win candidate** (next session) |
+| C2 | Claim-all daily hub | S-M | low | | captured → quick-win / plan |
+| C3 | `!play` quick-launcher | S | low | | captured → quick-win candidate |
+| C4 | Persistent reminders | S-M | low | ⭐ ease pick | captured → **top quick-win candidate** (silent-loss fix) |
+| C5 | Mining hub discoverability | S | low | | captured → quick-win (active mining lane) |
+| C6 | "What works here?" guide | S-M | low | | captured → groom into Adaptive lane after P1C |
+| C7 | Slash autocomplete | S | low | | captured → groom into interface lane |
+
+**No-orphan guarantee:** every row has a state and a next destination. Grooming
+sessions (the standing secondary task) should pull from the ⭐ rows first, then the
+quick-win column.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -2097,3 +2097,32 @@ Per-lane drafts in multi-lane sessions follow the same rule. The companion
 **Routed to:** `.claude/CLAUDE.md` (SESSION_WORKFLOW block — edited with this explicit
 approval per the Q-0035 propose-first rule), `.session-journal.md`, and
 `docs/planning/multi-lane-execution-plan-2026-06-09.md`.
+
+## 24. Fun & ease brainstorm batch — answered 2026-06-09
+
+### Q-0053 — Fun/ease brainstorm: owner cluster picks + session scope
+
+**Area:** Product direction / games / UX
+**Type:** Owner preference (answered in-session via structured choices)
+**Priority:** Medium (steers idea-backlog grooming order)
+**Status:** Answered (2026-06-09) — **Routed** → `docs/ideas/fun-and-ease-brainstorm-2026-06-09.md` §2 (capture) + `docs/planning/pets-companions-plan-2026-06-09.md` (structure) + `docs/roadmap.md` (games Later row + Someday line)
+
+**Question:** The 2026-06-09 brainstorm produced 24 dedup-verified new fun/ease ideas.
+Which clusters should lead the routing, and what should the session ship beyond the
+capture doc?
+
+**Maintainer answer (2026-06-09, structured choices):**
+- Fun cluster pick: **Pets & companions** (over server goals/mascot, social memory,
+  competition layer).
+- Ease picks: **context-menu actions** and **persistent reminders**.
+- Session scope: **capture + structure the top cluster into a plan** (no feature code
+  that session).
+
+**Decision:** Pets & companions structured into a games-lane plan at **Later** (gated
+behind the Wave-1 keystone slices + balance review + owner promotion). Context-menu
+actions and persistent reminders are marked **top quick-win candidates** in the capture
+doc's routing table — strong next-session picks; both stay `captured`, not approved.
+The other 21 ideas are captured with states/destinations (no orphans). Predictions
+(A6) explicitly rides the existing economy chance-reward review gate.
+
+**Routed to:** the three docs above; grooming sessions pull ⭐ rows first.

--- a/docs/planning/pets-companions-plan-2026-06-09.md
+++ b/docs/planning/pets-companions-plan-2026-06-09.md
@@ -1,0 +1,107 @@
+# Pet Companions — structured plan (mining-platform extension)
+
+> **Status:** `plan` — structured from an idea; **not implementation approval**.
+> **Horizon:** Later (games lane) — behind the Wave-1 keystone slices.
+> **Source idea:** [`../ideas/fun-and-ease-brainstorm-2026-06-09.md`](../ideas/fun-and-ease-brainstorm-2026-06-09.md) §A1
+> — the maintainer's ⭐ fun-cluster pick that session (router **Q-0053**).
+> **Boundary:** ADR-002 unaffected (pets are durable DB state, not game sessions).
+
+## Planning contract
+
+- Source code, merged PRs, binding contracts, subsystem folios, and
+  `docs/current-state.md` outrank this draft.
+- Preserve domain-service mutation ownership, the direct-vs-draft lane rules,
+  auditability, and the no-pay-to-win line (owner-vision §2a/§13).
+- Before implementation, re-verify source, live PRs, the games folio, and the gates
+  below.
+
+## Context and objective
+
+Pets give the mining character platform a **recurring emotional hook** plus the
+economy's most-wanted mechanic: a **likeable coin/ore sink** (owner-vision §15 wants
+sinks; the Workshop+durability slice is the keystone sink — pets are the *charming*
+one). A rare egg found while exploring becomes a nameable companion on your
+`!character` card; keeping it fed and happy costs ore/coins and grants tiny,
+flavor-first perks. Pets are the owner's top pick from the 2026-06-09 fun/ease
+brainstorm.
+
+## Scope
+
+- Egg drops from the existing exploration/mining loot path, rarity scaled by depth
+  (riding "The Descent" #607).
+- Hatch + name + display on the character card (#610).
+- A care loop (feed with ore via the inventory owner, or coins via
+  `economy_service`) with mood/growth — the recurring sink.
+- Tiny non-pay-to-win perks (≤1–2%, e.g. explore luck while happy), composed through
+  the shared pure stat seam.
+- Spotlight showcase + optional pet-level leaderboard category (P4).
+
+## Out of scope (explicit)
+
+- **Pet battles** (would be a new game — separate idea if ever raised).
+- **Breeding / marketplace trading** — deferred to the captured marketplace idea
+  (`economy-marketplace-rewards-roadmap` §4); pets must be *ownable* first.
+- XP multipliers or any gameplay-power perk beyond the flagged ceiling (no-P2W).
+- Background schedulers for mood decay — mood is **computed lazily from
+  `last_fed_at` on read** (no new task, no restart concerns).
+- Cross-guild/account-wide pets — pets are per **(guild, user)** like all mining
+  state (owner-vision §9 multi-tenancy); revisit only with an owner decision.
+
+## Current state and verified seams to reuse
+
+| Need | Existing owner (verified 2026-06-09) |
+|---|---|
+| Loot/drop path | `disbot/cogs/mining/exploration.py` event/loot tables; depth/biome from `cogs/mining/world.py` + `utils/db/games/mining_player_state.py` (#607) |
+| Item taxonomy (eggs/food as non-sellable special items) | `cogs/mining/items.py` — combat gear in #608 set the "non-sellable, grouped" precedent |
+| Coin mutations (feeding with coins) | **`services/economy_service.py` only** (`debit` + audit reason; #609 precedent) |
+| Ore consumption (feeding with ore) | the mining inventory owner (direct-lane, like recipes/build) |
+| Stat composition for perks | `utils/equipment.py` — pure `EffectiveStats` / `compute_stats` (#608); extend the pure function with an optional pet input, never a parallel stat path |
+| Display | `views/mining/character_panel.py` (#610) — aggregates, owns nothing; add a pet line |
+| Social surface | Community Spotlight (#613) EventBus feed — emit hatch/level-up events |
+| Persistence pattern | `utils/db/games/mining_player_state.py` + migration 061 are the direct-lane template |
+
+## Proposed phases (each ≈ one bounded PR)
+
+1. **P1 — Egg & hatch (foundation).** Additive migration `player_pets`
+   (guild_id, user_id, species, name, hatched_at, level, mood inputs `last_fed_at`
+   etc.); egg drop wired into exploration loot with seeded-RNG tests (deeper biome →
+   rarer species); hatch + naming modal; pet line on the character card. Pure species
+   catalogue module (emoji/text presentation first — PIL stays a later idea, same as
+   the character card).
+2. **P2 — Care loop (the sink).** Feed with ore (inventory consume) or coins
+   (`economy_service.debit`, audited reason `pets.feed`); lazy mood from
+   `last_fed_at`; growth stages gated on cumulative care. Balance constants in one
+   tunable table-in-code like `_GEAR`.
+3. **P3 — Perks (balance-reviewed, gated).** Happy-pet bonus ≤1–2% explore
+   luck/rare-find chance, composed via the pure stat seam; simulation-style tests
+   pinning the ceiling; owner sign-off on the exact numbers before merge.
+4. **P4 — Showcase & social.** Spotlight feed entries for hatches/growth; `!pets`
+   showcase subpanel on the mining hub; optional leaderboard provider (pet level).
+   Marketplace handoff stays with the marketplace plan.
+
+## Dependencies and gates
+
+- **Gate 1:** the Wave-1 keystone slices ship first (Workshop + durability, mother-panel
+  live overview — `docs/current-state.md` ▶ Next action). Pets join the games lane
+  *behind* them, or fold P1 into a Wave-2 batch.
+- **Gate 2:** balance review — feeding cost vs. the post-Workshop faucet/sink picture
+  (don't stack two new sinks blind; reuse its tuning evidence).
+- **Gate 3:** owner promotion per `docs/ideas/README.md` (this plan structures; it
+  does not approve).
+
+## Risks and mechanics
+
+Main risks: perk power creep (mitigated by the pinned ≤1–2% ceiling + tests), sink
+mis-sizing (Gate 2), and species-catalogue scope creep (start ~6 species, one rarity
+axis). Migration is additive; rollback = feature-flag the drop + panel (table stays,
+harmless). No caches beyond existing read paths; invalidate nothing new. Tests:
+seeded drop distribution, hatch idempotency, feed-debit through a mocked economy
+seam, mood-from-clock with a fake clock, stat-ceiling pin, card rendering.
+
+## Open questions (for the build/promotion session)
+
+- Species/art direction: emoji-text presentation confirmed cheap; PIL card later?
+- Exact perk ceiling and whether perks apply outside mining (recommend: mining-only
+  first).
+- One pet active at a time vs. a stable (recommend: one active, stable later with
+  the showcase).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -166,6 +166,10 @@ accepted, not a target).
   leaderboards, bot-duel stats, shared back-button adoption) from the completed
   [actionability roadmap](archive/games-actionability-roadmap.md). Low priority; pick one bounded
   slice.
+- **Later** — [**Pet companions**](planning/pets-companions-plan-2026-06-09.md): nameable
+  pets from exploration drops + a care-loop coin/ore sink + tiny non-P2W perks; the
+  owner's ⭐ pick from the 2026-06-09 fun/ease brainstorm (Q-0053). Gate: Wave-1
+  keystone slices (Workshop + durability) + balance review + owner promotion.
 
 ### 📺 Media / YouTube — **Later** (needs an approved plan)
 
@@ -195,6 +199,9 @@ privacy/provenance/moderation review before any public surface.
 > requires the gates in [`ideas/README.md`](ideas/README.md). Do not treat anything here as
 > a priority.
 
+- [fun-and-ease-brainstorm](ideas/fun-and-ease-brainstorm-2026-06-09.md) — 24
+  dedup-verified fun + ease-of-use ideas (social/competition, ambient delight, member
+  UX); owner picks recorded (Q-0053; pets structured → a games-lane plan).
 - [future-product-direction](ideas/future-product-direction-2026-06-07.md) — source-aware
   future product direction (polish, extensions, reusable systems, long-term).
 - [ai-extra-tool-capability-ideas](ideas/ai-extra-tool-capability-ideas.md) — AI capability

--- a/docs/subsystems/games.md
+++ b/docs/subsystems/games.md
@@ -71,7 +71,12 @@ shared back-button adoption. Do **not** propose restart-safe game state.
 
 ## Ideas (not approved)
 
-`docs/ideas/mining_exploration_brainstorm.md` records mining design intent/ideas. Apply the
+`docs/ideas/mining_exploration_brainstorm.md` records mining design intent/ideas;
+`docs/ideas/fun-and-ease-brainstorm-2026-06-09.md` adds the 2026-06-09 fun/ease batch
+(several game-facing: server goals, bounties, rivalries, word game, treasure hunts).
+Its ⭐ pets cluster is structured in
+[`../planning/pets-companions-plan-2026-06-09.md`](../planning/pets-companions-plan-2026-06-09.md)
+(Later horizon — gated behind the Wave-1 keystone slices + balance review). Apply the
 ideas promotion path before implementing unapproved game expansions.
 
 ## Next candidates


### PR DESCRIPTION
## What this session shipped

A brainstorming session ("see what exists + what's captured, then come up with **more** fun/ease ideas") — captured per the `docs/ideas/README.md` lifecycle.

### New docs
- **`docs/ideas/fun-and-ease-brainstorm-2026-06-09.md`** — 24 new ideas in three catalogs: social/competition layer (pets, server goals & mascot, bounty board, rivalries, King-of-the-Hill, predictions, LFG board), ambient delight (starboard, quote board, birthdays/cakedays, question-of-the-day, daily word game, treasure hunts, rotating shop deals, seasonal theming, easter-egg pack, daily contracts), and member UX (context-menu actions, claim-all hub, `!play` quick-launcher, persistent reminders, mining-hub discoverability, "what works here?" guide, slash autocomplete).
  - **Every idea was dedup-verified against docs *and* source first.** Found-already-exists candidates (fuzzy "did you mean" in `utils/command_resolution.py`, PvP coin stakes in RPS/blackjack panels, gifting/prestige in the mining brainstorm) are cited in §1 instead of re-proposed. All social ideas are deliberately single-guild — none waits on Q-0038.
- **`docs/planning/pets-companions-plan-2026-06-09.md`** — the owner's ⭐ cluster structured into a games-lane plan (P1 egg/hatch → P2 care-loop sink → P3 balance-gated perks → P4 showcase), with verified seams (#606–#610, `economy_service`, `EffectiveStats`, Spotlight) and gates (Wave-1 keystone slices + balance review + owner promotion).

### Owner decisions recorded (Q-0053)
Structured in-session choices: **pets & companions** = fun pick (structured now); **context-menu actions** + **persistent reminders** = ease picks (top quick-win candidates for a next session). Routed into the capture doc §2, the router, and `docs/roadmap.md` (games Later row + Someday line).

### Wiring (reachability gate)
`docs/ideas/README.md` capture list · `docs/roadmap.md` (2 entries) · `docs/subsystems/games.md` folio · router §24.

## Verification
- `python3.10 scripts/check_docs.py` ✓ (145 docs, reachability + badges pass)
- `python3.10 scripts/check_quality.py --check-only` ✓
- Docs-only change — no runtime code touched.

https://claude.ai/code/session_01Das8AzfsAWJiYX8B9aDuc6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Das8AzfsAWJiYX8B9aDuc6)_