### PR TITLE
docs: standing end-of-session reflection interview (formalizes the maintainer's manual habit)

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -89,12 +89,15 @@ one source of truth** over per-panel patches. Full set under **Rules / Conventio
      link to the tracker's Remaining-queue rather than re-enumerating (the restatement is
      the drift). The tracker is authoritative for shipped/queued.
   4. **Session log** — write a new `.sessions/<date>-<slug>.md` file (link to the PR +
-     the authoritative doc; don't restate per-PR detail). **Include the `Context delta`
-     section** (`.sessions/README.md`) — what you needed but weren't pointed to, what you
-     were pointed to but didn't need, what you discovered by hand. This is the
-     self-improvement loop (`docs/collaboration-model.md` § "Why this system exists"):
-     it's what the REVIEW step mines. Update this journal's guidebook sections in place if
-     a preference / rule / runbook fact changed.
+     the authoritative doc; don't restate per-PR detail). Before writing it, **run the
+     reflection interview** — the standing six-question self-interview in
+     `.sessions/README.md` (route miss / route excess / discovered-by-hand / decisions
+     made alone / weak point of what shipped / one change that would have helped) — and
+     fold the answers into the log's **`Context delta`** + flag lines. The maintainer
+     used to ask these manually in chat nearly every session; standing since 2026-06-09.
+     This is the self-improvement loop (`docs/collaboration-model.md` § "Why this system
+     exists"): it's what the REVIEW step mines. Update this journal's guidebook sections
+     in place if a preference / rule / runbook fact changed.
   5. Banner or update any **plan** whose status changed; file any new **idea** under
      `docs/ideas/` (marked not-approved). **If `current-state`'s ▶ Next action changed a
      lane's horizon, touch `docs/roadmap.md` in the same commit** (repo-review R5 —

--- a/.sessions/README.md
+++ b/.sessions/README.md
@@ -17,16 +17,33 @@ anchor, so any two concurrently-open PRs collided there (it bit #529→#530 and
 - Start it with an H1 `# <date> — <title>`, then the usual arc / shipped / findings /
   gates shape.
 - **Always include a `Context delta` section** (this is the self-improvement loop — see
-  `docs/collaboration-model.md` § "Why this system exists"). Three short bullets:
-  - **Needed but not pointed to** — context you had to find that orientation/folios
-    didn't route you to (a file, a contract, a gotcha).
-  - **Pointed to but didn't need** — reading the route sent you to that didn't pay off
-    (candidate to de-emphasize).
-  - **Discovered by hand** — tribal knowledge you reverse-engineered from source that
-    deserves a home (e.g. a rule only living in a code comment).
-  A periodic REVIEW (`.session-journal.md`) mines these deltas and promotes recurring
-  gaps into the orientation route / folios. Keep it to what you'd want the *next* agent
-  to have known.
+  `docs/collaboration-model.md` § "Why this system exists"). Produce it — and the two
+  flag lines below — by running the **reflection interview** before writing the log: a
+  standing six-question self-interview the maintainer used to run manually in chat
+  nearly every session (formalized at his request, 2026-06-09, after the Lane-3/#634
+  session's answers proved their value).
+  1. **Where did the orientation route fail to cover you?** — context you had to find
+     that orientation/folios didn't route you to (a file, a contract, a gotcha).
+     → `Context delta`: **Needed but not pointed to**.
+  2. **What were you pointed to that didn't pay off?** — reading the route sent you to
+     that wasn't needed (candidate to de-emphasize).
+     → `Context delta`: **Pointed to but didn't need**.
+  3. **What did you reverse-engineer from source?** — tribal knowledge that deserves a
+     home (e.g. a rule only living in a code comment).
+     → `Context delta`: **Discovered by hand**.
+  4. **What consequential decision did you make alone** that the maintainer should
+     consciously ratify (a default you picked, a contract shape, a gate keyed on a
+     label)? → a short **Decisions made alone** line in the log; if it's product
+     intent, also a router entry.
+  5. **What is the genuine weak point of what shipped** — the limitation or unverified
+     half you'd want the next agent (or the prod check) to know?
+     → the log's **Flagged for maintainer** / known-limits line.
+  6. **What one docs/tooling change would have most helped this session?**
+     → execute it in the grooming pass if small, else file it under `docs/ideas/`.
+  Answer honestly and specifically — a near-miss is more valuable written down than a
+  success story. A periodic REVIEW (`.session-journal.md`) mines these deltas and
+  promotes recurring gaps into the orientation route / folios. Keep it to what you'd
+  want the *next* agent to have known.
 - **Don't** edit older session files — they're history. Durable rules / runbook facts
   graduate into `.session-journal.md` (the guidebook) or `.claude/CLAUDE.md`.
 - **Find** past work by grepping this directory — don't read it top-to-bottom.


### PR DESCRIPTION
# Standing reflection interview — encode the maintainer's manual end-of-session habit

**Docs/process only** (`.sessions/README.md` + `.session-journal.md`); no runtime, no tests changed.

## Summary

After the Lane-3 (#634) session, the maintainer asked the executing agent to self-interview about how the session actually went ("what did the route miss, what did you decide alone, where's the weak point") and confirmed the answers were valuable — **and that he has been asking these questions manually in nearly every session.** This PR makes that interview a standing protocol step so it happens without prompting:

- **`.sessions/README.md`** (the canonical home of the session-log convention): the existing `Context delta` requirement is now produced by a **six-question reflection interview**, with each answer's destination spelled out —
  1. route miss → *Needed but not pointed to*
  2. route excess → *Pointed to but didn't need*
  3. reverse-engineered from source → *Discovered by hand*
  4. consequential decisions made alone → a *Decisions made alone* line (+ router entry if product intent)
  5. genuine weak point of what shipped → the *Flagged for maintainer* line
  6. one docs/tooling change that would have helped most → execute in the grooming pass or file under `docs/ideas/`
- **`.session-journal.md`** END checklist step 4: one pointer to the question set (one-fact-one-home — the set lives only in the README).

Questions 1–3 are the existing context delta unchanged; 4–6 are the new ones the maintainer was asking by hand. Provenance (owner request, 2026-06-09, post-#634) is carried in both files.

## Test plan

- `python3.10 scripts/check_docs.py` — green
- `python3.10 -m pytest tests/unit/docs/ -q` — 67 passed (no doc-pin touches these files; verified anyway)

https://claude.ai/code/session_016pGmDL6Wn8UqdzD48efVJY

---
_Generated by [Claude Code](https://claude.ai/code/session_016pGmDL6Wn8UqdzD48efVJY)_