### PR TITLE
docs(journal): cross-agent candidate rules from the parallel-burst session

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -412,6 +412,17 @@ confidence; do not treat booting as gated.
   source" rule applies to your own prior session's notes too, not just Codex/ChatGPT.
 
 ### Cross-agent & git workflow
+- **★ Parallel same-plan execution agents are a sanctioned mode (proven 2026-06-09,
+  N=4: Lanes 2/3/5/6 → #632/#634/#633/#631).** The binding how-to is
+  `docs/owner/ai-project-workflow.md` §9 → "Parallel execution lanes" (subsystem
+  partition + exclusion lists; edit only your own lane card/¶; re-sync `origin/main`
+  before the final docs push; second-to-merge reconciles by UNION; skip the grooming
+  pass). Observed cost at N=4: lane-owned docs all stayed correct; **only the
+  cross-cutting ledgers needed a reconciler afterwards** (#635). Don't add locks.
+- **Remote (web) sessions: don't promise scheduled check-ins.** The `send_later` tool
+  may be absent; PR subscriptions wake the session on CI *failures*, comments, and
+  merge/close — CI *success* and new pushes are never delivered. Run the CI mirror
+  locally before push and rely on the failure webhook, not polling. (2026-06-09.)
 - **★ Treat cross-agent output (Codex / ChatGPT reports) as input to verify, not
   orders.** Verify "rewrite X" plan items against shipped source first — one revision
   item (PR4 "rewrite fingerprints") was wrong and would have broken PR6's dedupe +


### PR DESCRIPTION
Closes the session's journal-tidy obligation with the two durable habits this session earned that weren't yet in the guidebook's cross-agent rules:

1. **Parallel same-plan execution agents are a sanctioned, proven mode** (N=4 today: Lanes 2/3/5/6 → #632/#634/#633/#631) — pointer to the binding how-to in `ai-project-workflow.md` §9, plus the one empirical takeaway: lane-owned docs stayed correct on their own; only the cross-cutting ledgers needed a post-burst reconciler (#635). Don't add locks.
2. **Remote (web) sessions must not promise scheduled check-ins** — `send_later` may be absent; PR subscriptions deliver CI *failures*/comments/merge but never CI success or pushes, so the local CI mirror before push is the success signal.

Two bullets, 11 lines, journal-only. `check_docs` green.

https://claude.ai/code/session_01XfzYcAg2TEQJoCCmQDkmKD

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfzYcAg2TEQJoCCmQDkmKD)_