### PR TITLE
Batch 2 — surface-classification completeness invariant (DT04)

### DIFF
--- a/.sessions/2026-06-10-batch2-surface-classification-invariant.md
+++ b/.sessions/2026-06-10-batch2-surface-classification-invariant.md
@@ -1,0 +1,93 @@
+# 2026-06-10 — Batch 2: surface-classification completeness invariant (DT04)
+
+**PR:** #651 (draft → ready same session). **Queue:** consolidated plan
+(`docs/planning/consolidated-implementation-plan-2026-06-10.md`) §5 Batch 2,
+executed as one of **two parallel sessions** — the sibling ran Batch 1
+(runtime truth/clarity). Per the §9 parallel-lane convention: Batch 1's six
+files untouched, grooming pass skipped, `docs/current-state.md` deliberately
+left for the reconciliation pass (both lanes would edit the same ▶ line —
+the next session should fold "Batch 2 shipped #651" into it).
+
+## Arc
+
+Read the queue + mapping findings (A01/A05/B04/B07, Q-A03) → prototyped the
+AST enumeration to size the real population (40 hidden routes, 2 alias
+piles, 21+6 top-level slash namespaces) → built the ledger rules → declared
+every classification → static CI mirror + runtime bucket → full CI mirror +
+live boot proof.
+
+## Shipped
+
+- `core/runtime/command_surface_ledger.py`: `HIDDEN_ROUTE_CLASSIFICATIONS`,
+  `ALIAS_DELIBERATION_THRESHOLD` (=3), entry fields `discord_hidden` /
+  `classification_declared` / `alias_classification`, and the
+  previously-reserved `findings.unclassified_entry_points` finally populated
+  (`hidden:<name>` / `aliases:<name>`).
+- Declarations: mining 21 (16 panel_action · 4 hidden · mineinv
+  legacy_duplicate), moderation 7 panel_action, role 9 (2 legacy · 5
+  panel_action · 2 internal_admin), utility 3 (2 legacy · avatar hidden),
+  leaderboard aliases → legacy_duplicate (**Q-A03 held default implemented**),
+  deathmatch aliases → power_user_shortcut, `/setup-hub` → legacy_duplicate.
+- Static mirror in `tests/unit/runtime/test_command_surface_ledger.py`:
+  rules V (canonical literals — typo can't silently default), H (hidden ⇒
+  why), A (alias pile ⇒ disposition), S (two-way top-level slash pin),
+  sentinel self-checks; explicit exception sets, empty by design.
+- Verified: `check_quality --full` 8543 passed / 22 skipped; arch strict 0
+  errors; 79 ledger tests; 200 Help/touched-cog tests; **live boot** with
+  `unclassified_entry_points == ()` over the real 255-prefix/60-slash
+  surface (offline `load_extension` rebuild — see gotcha below).
+
+## Context delta
+
+- **Needed but not pointed to:** FIND-B07 claimed "the ledger has no slash
+  classification wiring" — **stale**: `_walk_slash_commands` already reads
+  `extras` via `_classification_from_command`. The fix was a one-line
+  declaration, not a seam. (The "verify cross-agent output vs source" rule
+  earned its keep again — the consolidated plan's "may need a small
+  slash-side seam" hedge was inherited from the unverified finding.)
+- **Pointed to but didn't need:** the mapping reports' per-subsystem §3.1
+  records; only the FIND blocks + command tables mattered for this batch.
+- **Discovered by hand:** (1) ai_cog declares BOTH a prefix group `!ai` and
+  a slash group `/ai` — any "(file, command-name)" key collides; index by
+  kind too. (2) `getattr(cmd, "hidden", False) is True` is the only safe
+  read over MagicMock-based test doubles (truthy Mock attrs). (3) FIND-A01's
+  blanket "21 → panel_action" was wrong for 5 commands: `use`/`equip`/
+  `unequip`/`gear` have no panel surface (grep-verified) and `mineinv`
+  invokes `!inventory` — honest classes differ from the mapper's verdict.
+
+## Decisions made alone (ratify if wrong)
+
+- `ALIAS_DELIBERATION_THRESHOLD = 3`: 1–2 aliases = fluency (repo-wide
+  norm), ≥3 = compatibility surface needing a declared disposition. Only
+  leaderboard (9) and dm_challenge (3) cross it today.
+- Hidden routes may NOT declare `primary_entrypoint`/`power_user_shortcut`
+  (visible-only classes) — a contradictory declaration counts as
+  unclassified.
+- Top-level slash surface pinned name-by-name (27 namespaces); group
+  *subcommands* ride their group's surface decision (documented in-test).
+- Mining `use`/`equip`/`unequip`/`gear` = `hidden` (not panel_action):
+  typed-only equipment interface until an Equipment panel exists.
+
+## Flagged for maintainer / known limits
+
+- The static mirror only sees **inline dict-literal** `extras=` declarations
+  (enforced convention, documented in-test); a dynamically-built extras dict
+  reads as "no declaration" and fails rule H/A — by design, but worth
+  knowing.
+- Q-A03 alias **display** (hiding the 9 leaderboard aliases in Help's two
+  alias-render sites) is deliberately NOT wired — Batch 6's Help projection
+  seam owns render changes; this batch ships the data + policy.
+- The 7 live ledger findings that remain are the pre-existing documented
+  orphan-cog entries (split BTD6 cogs, setup, RPS naming) — Batch-2-adjacent
+  but out of scope (they're identity-contract territory, not
+  classification).
+
+## Gotcha worth keeping (boot-verification pattern)
+
+To prove a build-time finding bucket empty against the REAL surface without
+driving Discord: `await db.pool.init()` → `commands.Bot(...)` →
+`load_extension` over `config.INITIAL_EXTENSIONS` → `build_ledger(bot)` —
+no gateway login needed. One cog (`help_cog`) fails offline because the
+scratch Bot still has the default `help` command (`bot1` uses
+`help_command=None`); harmless for this purpose, but remember it when
+counting.

--- a/disbot/cogs/deathmatch_cog.py
+++ b/disbot/cogs/deathmatch_cog.py
@@ -334,7 +334,12 @@ class Deathmatch(commands.Cog):
         view = DeathmatchPanelView(interaction.user)
         return build_deathmatch_overview_embed(), view
 
-    @commands.command(name="dm_challenge", aliases=["deathmatch", "challenge", "dm"])
+    @commands.command(
+        name="dm_challenge",
+        aliases=["deathmatch", "challenge", "dm"],
+        # Fluency spellings, deliberately advertised — not legacy.
+        extras={"alias_classification": "power_user_shortcut"},
+    )
     @cooldown(1, 30, BucketType.user)
     async def challenge(self, ctx: commands.Context, opponent: discord.Member):
         """Challenge another user to a deathmatch duel."""

--- a/disbot/cogs/leaderboard_cog.py
+++ b/disbot/cogs/leaderboard_cog.py
@@ -137,6 +137,11 @@ class LeaderboardCog(commands.Cog, name="Leaderboard"):  # type: ignore[call-arg
             "countlb",
             "counting_leaderboard",
         ],
+        # Q-A03 (held default, 2026-06-10): the per-game compatibility
+        # aliases stay callable but are legacy routes — `!leaderboard
+        # <category>` is the canonical spelling.  Display integration
+        # rides the Help projection seam (consolidated plan Batch 6).
+        extras={"alias_classification": "legacy_duplicate"},
     )
     async def leaderboard(self, ctx: commands.Context, category: str = ""):
         """Show a leaderboard.  !leaderboard [xp|coins|mining|deathmatch|rps|counting]

--- a/disbot/cogs/mining_cog.py
+++ b/disbot/cogs/mining_cog.py
@@ -108,7 +108,7 @@ class MiningCog(commands.Cog):
         )
         view.message = await ctx.send(embed=embed, view=view)
 
-    @commands.command(hidden=True)
+    @commands.command(hidden=True, extras={"classification": "panel_action"})
     async def chop(self, ctx):
         """Chop wood. If you have an 'axe', you'll collect double."""
         from cogs.mining.rewards import roll_harvest_amount
@@ -121,7 +121,12 @@ class MiningCog(commands.Cog):
             f"{ctx.author.mention} chopped wood and collected {wood_amount}x wood!",
         )
 
-    @commands.command(name="mineinv", aliases=["mineinventory"], hidden=True)
+    @commands.command(
+        name="mineinv",
+        aliases=["mineinventory"],
+        hidden=True,
+        extras={"classification": "legacy_duplicate"},
+    )
     async def mineinv(self, ctx):
         """Show your unified inventory (compatibility alias for !inventory)."""
         cmd = ctx.bot.get_command("inventory")
@@ -130,7 +135,11 @@ class MiningCog(commands.Cog):
         else:
             await ctx.send("❌ Inventory system not loaded.", delete_after=10)
 
-    @commands.command(name="minestats", hidden=True)
+    @commands.command(
+        name="minestats",
+        hidden=True,
+        extras={"classification": "panel_action"},
+    )
     async def stats(self, ctx):
         """Shows your total mining items and number of unique items."""
         user_id = str(ctx.author.id)
@@ -155,7 +164,11 @@ class MiningCog(commands.Cog):
 
     # ---------------------------------------------------------- build / crafting
 
-    @commands.command(hidden=True, aliases=["craft"])
+    @commands.command(
+        hidden=True,
+        aliases=["craft"],
+        extras={"classification": "panel_action"},
+    )
     async def build(self, ctx, *, structure: str = None):
         """Build / craft an item from recipes (one shared, atomic implementation).
 
@@ -170,7 +183,7 @@ class MiningCog(commands.Cog):
             logger.exception("build command failed")
             await ctx.send("An unexpected error occurred while trying to build.")
 
-    @commands.command(hidden=True)
+    @commands.command(hidden=True, extras={"classification": "panel_action"})
     async def buildlist(self, ctx):
         """Shows all craftable structures from recipes.json."""
         try:
@@ -198,7 +211,7 @@ class MiningCog(commands.Cog):
                 "An unexpected error occurred while listing buildable structures.",
             )
 
-    @commands.command(hidden=True)
+    @commands.command(hidden=True, extras={"classification": "panel_action"})
     async def buildable(self, ctx):
         """Lists only what the user can currently build based on their inventory."""
         user_id = str(ctx.author.id)
@@ -223,7 +236,7 @@ class MiningCog(commands.Cog):
 
     # ---------------------------------------------------------- explore / use
 
-    @commands.command(hidden=True)
+    @commands.command(hidden=True, extras={"classification": "panel_action"})
     async def explore(self, ctx):
         """Discover random events or items (driven by your gear and depth)."""
         user_id = str(ctx.author.id)
@@ -250,7 +263,7 @@ class MiningCog(commands.Cog):
             message += "\n" + "\n".join(wear.notes)
         await ctx.send(message)
 
-    @commands.command(hidden=True)
+    @commands.command(hidden=True, extras={"classification": "hidden"})
     async def use(self, ctx, *, item: str = None):
         """Use a special item from your inventory (e.g., torch, dynamite)."""
         if not item:
@@ -276,7 +289,7 @@ class MiningCog(commands.Cog):
 
     # ---------------------------------------------------------- gear / equipment
 
-    @commands.command(hidden=True)
+    @commands.command(hidden=True, extras={"classification": "hidden"})
     async def equip(self, ctx, *, item: str = None):
         """Equip a tool, light, or charm so its stats apply to your character."""
         if not item:
@@ -295,7 +308,7 @@ class MiningCog(commands.Cog):
             f"{ctx.author.mention} equipped **{item.title()}** in the **{slot}** slot.",
         )
 
-    @commands.command(hidden=True)
+    @commands.command(hidden=True, extras={"classification": "hidden"})
     async def unequip(self, ctx, *, slot: str = None):
         """Clear an equipment slot (tool / light / charm)."""
         if not slot:
@@ -310,7 +323,7 @@ class MiningCog(commands.Cog):
         await db.unequip_slot(str(ctx.author.id), ctx.guild.id, slot)
         await ctx.send(f"{ctx.author.mention} cleared the **{slot}** slot.")
 
-    @commands.command(hidden=True)
+    @commands.command(hidden=True, extras={"classification": "hidden"})
     async def gear(self, ctx):
         """Show your equipped gear, its condition, and the stats it grants."""
         user_id = str(ctx.author.id)
@@ -348,7 +361,12 @@ class MiningCog(commands.Cog):
         )
         await ctx.send(embed=embed)
 
-    @commands.command(name="character", aliases=["profile", "char"], hidden=True)
+    @commands.command(
+        name="character",
+        aliases=["profile", "char"],
+        hidden=True,
+        extras={"classification": "panel_action"},
+    )
     async def character(self, ctx):
         """Show your full mining character — location, gear, stats, wealth."""
         # cogs→views is allowed; the builder aggregates the existing owners.
@@ -363,7 +381,7 @@ class MiningCog(commands.Cog):
 
     # ---------------------------------------------------------- world / descent
 
-    @commands.command(hidden=True)
+    @commands.command(hidden=True, extras={"classification": "panel_action"})
     async def descend(self, ctx):
         """Descend one mining band deeper (gated by your equipped light)."""
         user_id = str(ctx.author.id)
@@ -382,7 +400,7 @@ class MiningCog(commands.Cog):
             f"{ctx.author.mention} descended to {world.describe_position(new_depth)}.",
         )
 
-    @commands.command(hidden=True)
+    @commands.command(hidden=True, extras={"classification": "panel_action"})
     async def ascend(self, ctx):
         """Climb one mining band back toward the surface."""
         user_id = str(ctx.author.id)
@@ -399,7 +417,7 @@ class MiningCog(commands.Cog):
 
     # ---------------------------------------------------------- market
 
-    @commands.command(hidden=True)
+    @commands.command(hidden=True, extras={"classification": "panel_action"})
     async def sell(self, ctx, item: str = None, amount: int = 1):
         """Sell raw resources for coins (e.g. `!sell diamond 5`)."""
         if not item:
@@ -409,13 +427,17 @@ class MiningCog(commands.Cog):
         result = await market.apply_sell(ctx.author.id, ctx.guild.id, item, amount)
         await ctx.send(f"{ctx.author.mention} {result.message}")
 
-    @commands.command(name="sellall", hidden=True)
+    @commands.command(
+        name="sellall",
+        hidden=True,
+        extras={"classification": "panel_action"},
+    )
     async def sell_all(self, ctx):
         """Sell every raw resource in your inventory for coins."""
         result = await market.apply_sell_all(ctx.author.id, ctx.guild.id)
         await ctx.send(f"{ctx.author.mention} {result.message}")
 
-    @commands.command(hidden=True)
+    @commands.command(hidden=True, extras={"classification": "panel_action"})
     async def buy(self, ctx, *, item: str = None):
         """Buy gear with coins (e.g. `!buy iron sword`)."""
         if not item:
@@ -423,7 +445,11 @@ class MiningCog(commands.Cog):
         result = await market.apply_buy(ctx.author.id, ctx.guild.id, item)
         await ctx.send(f"{ctx.author.mention} {result.message}")
 
-    @commands.command(name="market", hidden=True)
+    @commands.command(
+        name="market",
+        hidden=True,
+        extras={"classification": "panel_action"},
+    )
     async def market_cmd(self, ctx):
         """Show the mining market — sellable resources + the gear shop."""
         inventory = await db.get_mining_inventory(str(ctx.author.id), ctx.guild.id)
@@ -455,7 +481,11 @@ class MiningCog(commands.Cog):
 
     # ---------------------------------------------------------- workshop
 
-    @commands.command(name="workshop", hidden=True)
+    @commands.command(
+        name="workshop",
+        hidden=True,
+        extras={"classification": "panel_action"},
+    )
     async def workshop_cmd(self, ctx):
         """Open the workshop — repair worn gear, craft replacements."""
         # cogs→views is allowed; one builder shared with the hub button.
@@ -468,7 +498,7 @@ class MiningCog(commands.Cog):
         view = await MiningWorkshopView.create(ctx.author, ctx.guild.id)
         await ctx.send(embed=embed, view=view)
 
-    @commands.command(hidden=True)
+    @commands.command(hidden=True, extras={"classification": "panel_action"})
     async def repair(self, ctx, *, item: str = None):
         """Repair a worn gear item for coins (e.g. `!repair pickaxe`)."""
         if not item:
@@ -478,7 +508,11 @@ class MiningCog(commands.Cog):
         result = await workshop.apply_repair(ctx.author.id, ctx.guild.id, item)
         await ctx.send(f"{ctx.author.mention} {result.message}")
 
-    @commands.command(name="quickcraft", hidden=True)
+    @commands.command(
+        name="quickcraft",
+        hidden=True,
+        extras={"classification": "panel_action"},
+    )
     async def quick_craft(self, ctx):
         """Re-craft the last gear item that broke and equip it."""
         result = await workshop.apply_quick_craft(ctx.author.id, ctx.guild.id)

--- a/disbot/cogs/moderation_cog.py
+++ b/disbot/cogs/moderation_cog.py
@@ -118,7 +118,11 @@ class ModerationCog(commands.Cog):
     # ``tests/unit/invariants/test_no_direct_moderation_writes.py``.
     # ------------------------------------------------------------------
 
-    @commands.command(name="warn", hidden=True)
+    @commands.command(
+        name="warn",
+        hidden=True,
+        extras={"classification": "panel_action"},
+    )
     @_require_mod("moderation.warn.apply", "manage_roles")
     async def warn(self, ctx, member: Member, *, reason=""):
         """Warn a user. Escalates at the configured threshold (default: timeout)."""
@@ -141,7 +145,11 @@ class ModerationCog(commands.Cog):
         for line in render_warn_outcome_lines(member.mention, reason, outcome):
             await ctx.send(line)
 
-    @commands.command(name="timeout", hidden=True)
+    @commands.command(
+        name="timeout",
+        hidden=True,
+        extras={"classification": "panel_action"},
+    )
     @_require_mod("moderation.timeout.apply", "moderate_members")
     async def timeout(self, ctx, member: Member, duration: int):
         """Timeout a member for a given number of minutes."""
@@ -163,7 +171,11 @@ class ModerationCog(commands.Cog):
         except discord.HTTPException as e:
             await ctx.send(f"❌ Failed to timeout: {e}")
 
-    @commands.command(name="kick", hidden=True)
+    @commands.command(
+        name="kick",
+        hidden=True,
+        extras={"classification": "panel_action"},
+    )
     @_require_mod("moderation.kick.apply", "kick_members")
     async def kick(self, ctx, member: Member, *, reason=""):
         """Kick a member from the server."""
@@ -191,7 +203,11 @@ class ModerationCog(commands.Cog):
         except discord.HTTPException as e:
             await ctx.send(f"❌ Failed to kick: {e}")
 
-    @commands.command(name="ban", hidden=True)
+    @commands.command(
+        name="ban",
+        hidden=True,
+        extras={"classification": "panel_action"},
+    )
     @_require_mod("moderation.ban.apply", "ban_members")
     async def ban(self, ctx, member: Member, *, reason=""):
         """Ban a member from the server."""
@@ -220,7 +236,11 @@ class ModerationCog(commands.Cog):
         except discord.HTTPException as e:
             await ctx.send(f"❌ Failed to ban: {e}")
 
-    @commands.command(name="unban", hidden=True)
+    @commands.command(
+        name="unban",
+        hidden=True,
+        extras={"classification": "panel_action"},
+    )
     @_require_mod("moderation.ban.remove", "ban_members")
     async def unban(self, ctx, user_id: int):
         """Unban a user by their Discord user ID."""
@@ -247,7 +267,11 @@ class ModerationCog(commands.Cog):
         except discord.HTTPException as e:
             await ctx.send(f"❌ Failed to unban: {e}")
 
-    @commands.command(name="clearwarnings", hidden=True)
+    @commands.command(
+        name="clearwarnings",
+        hidden=True,
+        extras={"classification": "panel_action"},
+    )
     @_require_mod("moderation.warn.apply", "manage_roles")
     async def clearwarnings(self, ctx, member: Member):
         """Clear all warnings for a member."""
@@ -258,7 +282,11 @@ class ModerationCog(commands.Cog):
         )
         await ctx.send(f"✅ Warnings cleared for {member.mention}.")
 
-    @commands.command(name="modlogs", hidden=True)
+    @commands.command(
+        name="modlogs",
+        hidden=True,
+        extras={"classification": "panel_action"},
+    )
     @_require_mod("moderation.log.view", "manage_roles")
     async def modlogs(self, ctx, member: Member):
         """Show moderation log history for a member."""

--- a/disbot/cogs/role_cog.py
+++ b/disbot/cogs/role_cog.py
@@ -366,25 +366,41 @@ class RoleCog(commands.Cog):
 
     # ------------------------------------------------------------------ compatibility aliases (hidden)
 
-    @commands.command(name="rolemenu", hidden=True)
+    @commands.command(
+        name="rolemenu",
+        hidden=True,
+        extras={"classification": "legacy_duplicate"},
+    )
     async def rolemenu(self, ctx: commands.Context) -> None:
         """Open the role hub (use !roles instead)."""
         await ctx.invoke(self.roles_hub)
 
-    @commands.command(name="rolecreator", hidden=True)
+    @commands.command(
+        name="rolecreator",
+        hidden=True,
+        extras={"classification": "legacy_duplicate"},
+    )
     @commands.has_permissions(manage_roles=True)
     async def rolecreator(self, ctx: commands.Context) -> None:
         """Open the role hub (use !roles instead)."""
         await ctx.invoke(self.roles_hub)
 
-    @commands.command(name="assignroles", hidden=True)
+    @commands.command(
+        name="assignroles",
+        hidden=True,
+        extras={"classification": "panel_action"},
+    )
     @commands.has_permissions(administrator=True)
     async def assign_roles_cmd(self, ctx: commands.Context) -> None:
         """Manually run time-based role assignment for all members."""
         await ctx.send("🔄 Running role assignment…")
         await self._assign_roles(ctx.guild, ctx)
 
-    @commands.command(name="createrole", hidden=True)
+    @commands.command(
+        name="createrole",
+        hidden=True,
+        extras={"classification": "panel_action"},
+    )
     @commands.has_permissions(manage_roles=True)
     async def createrole(
         self,
@@ -419,7 +435,11 @@ class RoleCog(commands.Cog):
         else:
             await ctx.send(f"❌ Could not create role: {result.first_error}")
 
-    @commands.command(name="deleterole", hidden=True)
+    @commands.command(
+        name="deleterole",
+        hidden=True,
+        extras={"classification": "panel_action"},
+    )
     @commands.has_permissions(manage_roles=True)
     async def deleterole(self, ctx: commands.Context, *, role: discord.Role) -> None:
         """Delete a role by name or mention."""
@@ -436,7 +456,11 @@ class RoleCog(commands.Cog):
         else:
             await ctx.send(f"❌ Could not delete **{name}**: {result.first_error}")
 
-    @commands.command(name="setrole", hidden=True)
+    @commands.command(
+        name="setrole",
+        hidden=True,
+        extras={"classification": "panel_action"},
+    )
     @commands.has_permissions(administrator=True)
     async def setrole(
         self,
@@ -465,7 +489,11 @@ class RoleCog(commands.Cog):
             f"✅ Role **{store_name}** will be assigned after **{days}** day(s).",
         )
 
-    @commands.command(name="unsetrole", hidden=True)
+    @commands.command(
+        name="unsetrole",
+        hidden=True,
+        extras={"classification": "panel_action"},
+    )
     @commands.has_permissions(administrator=True)
     async def unsetrole(self, ctx: commands.Context, *, role_name: str) -> None:
         """Remove a role from time-based assignment."""
@@ -486,14 +514,22 @@ class RoleCog(commands.Cog):
         invalidate_xp_threshold_roles(ctx.guild.id)
         await ctx.send(f"✅ Removed **{match}** from time-based assignment.")
 
-    @commands.command(name="debugroles", hidden=True)
+    @commands.command(
+        name="debugroles",
+        hidden=True,
+        extras={"classification": "internal_admin"},
+    )
     @commands.has_permissions(administrator=True)
     async def debug_roles(self, ctx: commands.Context) -> None:
         """Print all role names for verification."""
         names = [r.name for r in ctx.guild.roles]
         await ctx.send(f"Roles: {', '.join(names)}")
 
-    @commands.command(name="refreshmembers", hidden=True)
+    @commands.command(
+        name="refreshmembers",
+        hidden=True,
+        extras={"classification": "internal_admin"},
+    )
     @commands.has_permissions(administrator=True)
     async def refresh_members(self, ctx: commands.Context) -> None:
         """Force-fetch all members from Discord."""

--- a/disbot/cogs/setup_cog.py
+++ b/disbot/cogs/setup_cog.py
@@ -113,6 +113,7 @@ class SetupCog(commands.Cog):
     @app_commands.command(
         name="setup-hub",
         description="Open the legacy section-list hub (compat).",
+        extras={"classification": "legacy_duplicate"},
     )
     @app_commands.default_permissions(administrator=True)
     @app_commands.checks.has_permissions(administrator=True)

--- a/disbot/cogs/utility_cog.py
+++ b/disbot/cogs/utility_cog.py
@@ -157,17 +157,29 @@ class UtilityCog(commands.Cog):
                 embed.set_thumbnail(url=guild.icon.url)
         await ctx.send(embed=embed)
 
-    @commands.command(name="serverinfo", hidden=True)
+    @commands.command(
+        name="serverinfo",
+        hidden=True,
+        extras={"classification": "legacy_duplicate"},
+    )
     async def serverinfo(self, ctx):
         """Alias for !info server."""
         await ctx.invoke(self.info, target="server")
 
-    @commands.command(name="userinfo", hidden=True)
+    @commands.command(
+        name="userinfo",
+        hidden=True,
+        extras={"classification": "legacy_duplicate"},
+    )
     async def userinfo(self, ctx, member: discord.Member = None):
         """Alias for !info user [@member]."""
         await ctx.invoke(self.info, target="user", member=member)
 
-    @commands.command(name="avatar", hidden=True)
+    @commands.command(
+        name="avatar",
+        hidden=True,
+        extras={"classification": "hidden"},
+    )
     async def avatar(self, ctx, member: discord.Member = None):
         """Display a user's avatar."""
         member = member or ctx.author

--- a/disbot/core/runtime/command_surface_ledger.py
+++ b/disbot/core/runtime/command_surface_ledger.py
@@ -25,12 +25,24 @@ Public surface:
     CommandSurfaceEntry      — frozen dataclass per command
     Classification           — Literal of canonical classification values
     CLASSIFICATIONS          — tuple of all canonical classification values
+    HIDDEN_ROUTE_CLASSIFICATIONS — classifications valid on a Discord-hidden route
+    ALIAS_DELIBERATION_THRESHOLD — alias count requiring an alias disposition
     RouterPrefixEntry        — frozen dataclass per registered router prefix
     LedgerFindings           — frozen dataclass with orphan/duplicate buckets
     CommandSurfaceLedger     — frozen aggregate snapshot
     build_ledger(bot)        — walks the live surface, caches, returns ledger
     get_cached_ledger()      — last-built ledger, or None if not built
     cog_name_to_subsystem(s) — normalise a cog class name to a SUBSYSTEMS key
+
+Completeness invariant (DT04, consolidated plan 2026-06-10 Batch 2):
+``build_ledger`` reports every route whose *surface contradicts its
+classification state* in ``findings.unclassified_entry_points`` — a
+Discord-hidden command without a deliberate hidden-route
+classification, or an alias pile (>= ALIAS_DELIBERATION_THRESHOLD)
+without a declared alias disposition.  The static mirror of the same
+rules runs in CI over the cog sources
+(``tests/unit/runtime/test_command_surface_ledger.py``), so the
+finding bucket stays empty by construction.
 
 Diagnostics provider name: ``"command_surface_ledger"``.
 """
@@ -87,6 +99,32 @@ Classification = Literal[
 # any classification registry added by PR-06c.
 CLASSIFICATIONS: tuple[Classification, ...] = get_args(Classification)
 
+# Completeness invariant (DT04) — the two deliberateness rules.
+#
+# A command hidden via Discord's ``hidden=True`` decorator flag must say
+# *why* it is hidden by declaring one of these classifications.  The
+# default ``primary_entrypoint`` contradicts a hidden surface (a route
+# cannot be both the canonical operator entrypoint and invisible), and
+# ``power_user_shortcut`` is by contract a *visible* fluency spelling —
+# so neither is acceptable on a hidden route.
+HIDDEN_ROUTE_CLASSIFICATIONS: frozenset[Classification] = frozenset(
+    {
+        "panel_action",
+        "legacy_duplicate",
+        "internal_admin",
+        "hidden",
+        "deprecated",
+    },
+)
+
+# A command carrying this many aliases (or more) is an alias *pile* —
+# a compatibility/fluency surface in its own right — and must declare a
+# deliberate alias disposition via ``extras["alias_classification"]``
+# (e.g. the leaderboard's nine legacy per-game aliases, Q-A03).  One or
+# two abbreviation aliases (``!bal``, ``!lb``) stay below the line and
+# share their command's classification implicitly.
+ALIAS_DELIBERATION_THRESHOLD = 3
+
 
 @dataclass(frozen=True)
 class CommandSurfaceEntry:
@@ -105,6 +143,18 @@ class CommandSurfaceEntry:
     # per-cog declarations (decorator or metadata map) and surfaces
     # the unclassified set as a finding.
     classification: Classification = "primary_entrypoint"
+    # DT04 — deliberateness metadata.  ``classification_declared`` is
+    # True only when the cog carried a *valid* explicit
+    # ``extras["classification"]`` (a silent fallback to the default is
+    # not a declaration).  ``discord_hidden`` mirrors the prefix
+    # decorator's ``hidden=True`` flag so consumers can see when the
+    # Discord surface and the ledger classification disagree.
+    # ``alias_classification`` is the declared disposition of the
+    # entry's aliases (``extras["alias_classification"]``) — ``None``
+    # means the aliases share the command's own classification.
+    classification_declared: bool = False
+    discord_hidden: bool = False
+    alias_classification: Classification | None = None
 
 
 @dataclass(frozen=True)
@@ -124,11 +174,13 @@ class LedgerFindings:
     duplicate_alias_names: tuple[str, ...] = ()
     undeclared_entry_points: tuple[str, ...] = ()
     router_prefix_unknown: tuple[str, ...] = ()
-    # PR-06a: populated by PR-06c once per-cog classification metadata
-    # exists.  Empty in PR-06a because the default classification
-    # (``primary_entrypoint``) means every command is considered
-    # classified out of the box.  Reserved here so the dataclass shape
-    # is stable across the PR-06a → PR-06c sequence.
+    # DT04: routes whose surface contradicts their classification
+    # state — ``hidden:<name>`` (Discord-hidden without a valid
+    # hidden-route classification) and ``aliases:<name>`` (alias pile
+    # without a declared alias disposition).  Kept empty by the static
+    # CI mirror of the same rules; a non-empty bucket on a live bot
+    # means a cog drifted past the invariant (e.g. a hot-loaded
+    # extension CI never saw).
     unclassified_entry_points: tuple[str, ...] = ()
 
     @property
@@ -248,6 +300,26 @@ def _reset_for_tests() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _declared_classification(
+    cmd: object,
+    key: str = "classification",
+) -> Classification | None:
+    """Return the *valid* declared classification under ``extras[key]``.
+
+    ``None`` means "no deliberate declaration" — the key is absent,
+    extras is not a dict, or the value is not a canonical
+    classification.  (The static CI invariant fails loudly on invalid
+    literals so a typo cannot silently demote to ``None`` here.)
+    """
+    extras = getattr(cmd, "extras", None)
+    if not isinstance(extras, dict):
+        return None
+    raw = extras.get(key)
+    if raw in CLASSIFICATIONS:
+        return raw  # type: ignore[return-value]
+    return None
+
+
 def _classification_from_command(cmd: object) -> Classification:
     """Read ``cmd.extras["classification"]`` if present.
 
@@ -258,13 +330,7 @@ def _classification_from_command(cmd: object) -> Classification:
     so PR-06c is purely additive — every existing command keeps its
     default identity unless its cog opts in.
     """
-    extras = getattr(cmd, "extras", None)
-    if not isinstance(extras, dict):
-        return "primary_entrypoint"
-    raw = extras.get("classification")
-    if raw in CLASSIFICATIONS:
-        return raw  # type: ignore[return-value]
-    return "primary_entrypoint"
+    return _declared_classification(cmd) or "primary_entrypoint"
 
 
 def _walk_commands(bot: object) -> list[CommandSurfaceEntry]:
@@ -295,6 +361,7 @@ def _walk_commands(bot: object) -> list[CommandSurfaceEntry]:
             cmd.qualified_name,
             subsystem,
         )
+        declared = _declared_classification(cmd)
         entries.append(
             CommandSurfaceEntry(
                 name=cmd.qualified_name,
@@ -305,7 +372,15 @@ def _walk_commands(bot: object) -> list[CommandSurfaceEntry]:
                 parent_group=parent_name,
                 is_declared=is_declared,
                 kind="prefix",
-                classification=_classification_from_command(cmd),
+                classification=declared or "primary_entrypoint",
+                classification_declared=declared is not None,
+                # ``is True`` keeps test doubles (MagicMock attributes)
+                # from reading as hidden; a real Command carries a bool.
+                discord_hidden=getattr(cmd, "hidden", False) is True,
+                alias_classification=_declared_classification(
+                    cmd,
+                    key="alias_classification",
+                ),
             ),
         )
     return entries
@@ -371,6 +446,7 @@ def _walk_slash_commands(bot: object) -> list[CommandSurfaceEntry]:
             qualified_name,
             subsystem,
         )
+        declared = _declared_classification(cmd)
         entries.append(
             CommandSurfaceEntry(
                 name=qualified_name,
@@ -381,7 +457,12 @@ def _walk_slash_commands(bot: object) -> list[CommandSurfaceEntry]:
                 parent_group=parent_name,
                 is_declared=is_declared,
                 kind="slash",
-                classification=_classification_from_command(cmd),
+                classification=declared or "primary_entrypoint",
+                classification_declared=declared is not None,
+                # Slash commands have no Discord ``hidden`` flag and no
+                # aliases; both deliberateness rules are prefix-only.
+                discord_hidden=False,
+                alias_classification=None,
             ),
         )
     return entries
@@ -560,12 +641,36 @@ def _compute_findings(
         sorted(p.prefix for p in router_prefixes if p.subsystem is None),
     )
 
+    # DT04 completeness invariant — a route whose surface contradicts
+    # its classification state.  Two rules (the static CI mirror in
+    # tests/unit/runtime/test_command_surface_ledger.py enforces the
+    # same two over the cog sources):
+    #
+    # * ``hidden:<name>``  — Discord-hidden command without a valid
+    #   hidden-route classification (absent, invalid, or a visible-only
+    #   value like the default ``primary_entrypoint``).
+    # * ``aliases:<name>`` — alias pile (>= ALIAS_DELIBERATION_THRESHOLD)
+    #   without a declared ``alias_classification`` disposition.
+    unclassified: list[str] = []
+    for e in entries:
+        if e.discord_hidden and not (
+            e.classification_declared
+            and e.classification in HIDDEN_ROUTE_CLASSIFICATIONS
+        ):
+            unclassified.append(f"hidden:{e.name}")
+        if (
+            len(e.aliases) >= ALIAS_DELIBERATION_THRESHOLD
+            and e.alias_classification is None
+        ):
+            unclassified.append(f"aliases:{e.name}")
+
     return LedgerFindings(
         orphan_cog_subsystems=tuple(sorted(orphans)),
         duplicate_command_names=dup_names,
         duplicate_alias_names=tuple(sorted(dup_aliases)),
         undeclared_entry_points=tuple(undeclared),
         router_prefix_unknown=unknown_prefixes,
+        unclassified_entry_points=tuple(sorted(unclassified)),
     )
 
 
@@ -664,10 +769,12 @@ _register_diagnostics()
 
 
 __all__ = [
+    "ALIAS_DELIBERATION_THRESHOLD",
     "CLASSIFICATIONS",
     "Classification",
     "CommandSurfaceEntry",
     "CommandSurfaceLedger",
+    "HIDDEN_ROUTE_CLASSIFICATIONS",
     "LedgerFindings",
     "RouterPrefixEntry",
     "build_ledger",

--- a/docs/planning/consolidated-implementation-plan-2026-06-10.md
+++ b/docs/planning/consolidated-implementation-plan-2026-06-10.md
@@ -152,7 +152,19 @@ services) without partitioning by module.
   tests) before renaming. Revert = restore module.
 - **Stop:** if the resource shell has a live consumer, deprecate instead of delete.
 
-### Batch 2 — Surface-classification completeness invariant (DT04: FIND-A01/A05/B04/B07) — ready
+### Batch 2 — Surface-classification completeness invariant (DT04: FIND-A01/A05/B04/B07) — SHIPPED PR #651 (2026-06-10)
+
+> **Status:** executed 2026-06-10 (parallel session beside Batch 1), **PR #651** —
+> verify merge state on live GitHub. The invariant runs twice: at build time
+> (`findings.unclassified_entry_points` now populated — hidden-route +
+> alias-pile rules) and as a static AST mirror in
+> `tests/unit/runtime/test_command_surface_ledger.py` (incl. the two-way
+> top-level slash-surface pin + the canonical-literal guard). All 40 hidden
+> routes, both alias piles (leaderboard → legacy per **Q-A03**, deathmatch →
+> power_user_shortcut), and `/setup-hub` → legacy_duplicate (B07 — the slash
+> walker already ingested `extras`; no new seam was needed) are declared.
+> Classification-only; Help output byte-identical; alias *display* integration
+> deliberately deferred to Batch 6's projection seam.
 
 - **Objective:** every surfaced/hidden/panel-action/slash-legacy/alias route has a
   *deliberate* ledger classification or an explicit exception — drift can't recur

--- a/tests/unit/runtime/test_command_surface_ledger.py
+++ b/tests/unit/runtime/test_command_surface_ledger.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import ast
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -9,7 +11,9 @@ import pytest
 
 from core.runtime import command_surface_ledger as ledger_mod
 from core.runtime.command_surface_ledger import (
+    ALIAS_DELIBERATION_THRESHOLD,
     CLASSIFICATIONS,
+    HIDDEN_ROUTE_CLASSIFICATIONS,
     CommandSurfaceEntry,
     CommandSurfaceLedger,
     LedgerFindings,
@@ -863,3 +867,458 @@ class TestClassificationIngestion:
             visibility_tier="user",
         )
         assert is_hidden_from_help(entry) is False
+
+
+# ---------------------------------------------------------------------------
+# DT04 — deliberateness rules at build time (runtime half of the invariant)
+# ---------------------------------------------------------------------------
+
+
+class TestDeliberatenessFindings:
+    """``findings.unclassified_entry_points`` reports surface/classification
+    contradictions: Discord-hidden routes without a valid hidden-route
+    classification, and alias piles without a declared disposition."""
+
+    def test_hidden_without_declaration_is_unclassified_finding(self):
+        cmd = _make_cmd("warn", cog_name="ModerationCog")
+        cmd.hidden = True
+        cmd.extras = None
+        ledger = build_ledger(_make_bot(cmd))
+        assert "hidden:warn" in ledger.findings.unclassified_entry_points
+        assert ledger.entries[0].discord_hidden is True
+        assert ledger.entries[0].classification_declared is False
+
+    def test_hidden_with_hidden_route_classification_is_clean(self):
+        for cls in sorted(HIDDEN_ROUTE_CLASSIFICATIONS):
+            cmd = _make_cmd("warn", cog_name="ModerationCog")
+            cmd.hidden = True
+            cmd.extras = {"classification": cls}
+            ledger = build_ledger(_make_bot(cmd))
+            assert ledger.findings.unclassified_entry_points == (), cls
+            assert ledger.entries[0].classification == cls
+            assert ledger.entries[0].classification_declared is True
+
+    def test_hidden_with_visible_only_classification_is_a_contradiction(self):
+        """``primary_entrypoint`` / ``power_user_shortcut`` are by contract
+        *visible* surface classifications — declaring one on a Discord-hidden
+        command is the exact drift class FIND-B04 found, so it stays a
+        finding even though it is an explicit declaration."""
+        for cls in sorted(set(CLASSIFICATIONS) - HIDDEN_ROUTE_CLASSIFICATIONS):
+            cmd = _make_cmd("warn", cog_name="ModerationCog")
+            cmd.hidden = True
+            cmd.extras = {"classification": cls}
+            ledger = build_ledger(_make_bot(cmd))
+            assert "hidden:warn" in ledger.findings.unclassified_entry_points, cls
+
+    def test_mock_hidden_attribute_does_not_read_as_hidden(self):
+        """``discord_hidden`` requires the literal ``True`` — an arbitrary
+        truthy attribute (a test double, a future non-bool) must not flip
+        a command hidden."""
+        cmd = _make_cmd("daily", cog_name="EconomyCog")  # cmd.hidden = MagicMock
+        ledger = build_ledger(_make_bot(cmd))
+        assert ledger.entries[0].discord_hidden is False
+        assert ledger.findings.unclassified_entry_points == ()
+
+    def test_alias_pile_without_disposition_is_unclassified_finding(self):
+        aliases = tuple(f"a{i}" for i in range(ALIAS_DELIBERATION_THRESHOLD))
+        cmd = _make_cmd("leaderboard", cog_name="LeaderboardCog", aliases=aliases)
+        cmd.extras = None
+        ledger = build_ledger(_make_bot(cmd))
+        assert "aliases:leaderboard" in ledger.findings.unclassified_entry_points
+        assert ledger.entries[0].alias_classification is None
+
+    def test_alias_pile_with_disposition_is_clean(self):
+        aliases = tuple(f"a{i}" for i in range(ALIAS_DELIBERATION_THRESHOLD + 2))
+        cmd = _make_cmd("leaderboard", cog_name="LeaderboardCog", aliases=aliases)
+        cmd.extras = {"alias_classification": "legacy_duplicate"}
+        ledger = build_ledger(_make_bot(cmd))
+        assert ledger.findings.unclassified_entry_points == ()
+        assert ledger.entries[0].alias_classification == "legacy_duplicate"
+        # The command's own classification is untouched by the alias
+        # disposition — `!leaderboard` itself stays primary.
+        assert ledger.entries[0].classification == "primary_entrypoint"
+
+    def test_below_threshold_aliases_need_no_disposition(self):
+        aliases = tuple(
+            f"a{i}" for i in range(ALIAS_DELIBERATION_THRESHOLD - 1)
+        )
+        cmd = _make_cmd("balance", cog_name="EconomyCog", aliases=aliases)
+        cmd.extras = None
+        ledger = build_ledger(_make_bot(cmd))
+        assert ledger.findings.unclassified_entry_points == ()
+
+    def test_invalid_alias_classification_is_not_a_declaration(self):
+        aliases = tuple(f"a{i}" for i in range(ALIAS_DELIBERATION_THRESHOLD))
+        cmd = _make_cmd("leaderboard", cog_name="LeaderboardCog", aliases=aliases)
+        cmd.extras = {"alias_classification": "garbage"}
+        ledger = build_ledger(_make_bot(cmd))
+        assert ledger.entries[0].alias_classification is None
+        assert "aliases:leaderboard" in ledger.findings.unclassified_entry_points
+
+    def test_slash_entries_carry_declared_flag_and_never_hidden(self):
+        cmd = _make_slash_cmd("setup-hub", cog_name="DiagnosticCog")
+        cmd.extras = {"classification": "legacy_duplicate"}
+        bot = _make_bot_with_tree(slash_cmds=(cmd,))
+        ledger = build_ledger(bot)
+        slash = ledger.slash_entries[0]
+        assert slash.classification == "legacy_duplicate"
+        assert slash.classification_declared is True
+        assert slash.discord_hidden is False
+        assert slash.alias_classification is None
+
+    def test_findings_are_sorted_and_prefixed(self):
+        hidden_cmd = _make_cmd("zzz", cog_name="EconomyCog")
+        hidden_cmd.hidden = True
+        hidden_cmd.extras = None
+        pile_cmd = _make_cmd(
+            "aaa",
+            cog_name="EconomyCog",
+            aliases=tuple(f"a{i}" for i in range(ALIAS_DELIBERATION_THRESHOLD)),
+        )
+        pile_cmd.extras = None
+        ledger = build_ledger(_make_bot(hidden_cmd, pile_cmd))
+        assert ledger.findings.unclassified_entry_points == (
+            "aliases:aaa",
+            "hidden:zzz",
+        )
+        # The diagnostics provider surfaces the bucket count.
+        snap = ledger_mod._snapshot()
+        assert snap["findings"]["unclassified_entry_points"] == 2
+
+
+# ---------------------------------------------------------------------------
+# DT04 — surface-classification completeness invariant (static CI mirror)
+# ---------------------------------------------------------------------------
+#
+# ``build_ledger`` reports contradictions on whatever bot is *running*;
+# CI never boots the bot, so this section enforces the same rules over
+# the cog sources by AST.  The population is generated from the
+# decorator declarations themselves — never from a prose inventory —
+# so adding a command automatically enrolls it.
+#
+# Rules (mirrors of the runtime rules in ``_compute_findings``):
+#   V — every ``extras`` classification literal is canonical (a typo
+#       silently falls back to the default at runtime; CI fails loud).
+#   H — every ``hidden=True`` route declares WHY it is hidden with a
+#       classification from HIDDEN_ROUTE_CLASSIFICATIONS.
+#   A — every alias pile (>= ALIAS_DELIBERATION_THRESHOLD) declares an
+#       ``alias_classification`` disposition.
+#   S — the top-level slash surface (``@app_commands.command`` +
+#       ``app_commands.Group`` namespaces) matches the reviewed pin
+#       below, so a new slash route is a deliberate decision.
+#
+# Escape hatch: a route that must deviate goes in the explicit
+# exception sets below ("<file>:<command>"), with a reviewed reason —
+# never by weakening a rule.
+#
+# Convention enforced by construction: declare ``extras`` as an inline
+# dict literal on the decorator.  An extras value built dynamically is
+# invisible to this mirror and reads as "no declaration".
+
+_DISBOT_ROOT = Path(ledger_mod.__file__).resolve().parents[2]
+
+# Explicit, reviewed exceptions to rules H and A.  Keys are
+# "<file basename>:<command name>".  Empty by design — prefer a real
+# classification; an entry here must say why one cannot exist.
+HIDDEN_ROUTE_EXCEPTIONS: frozenset[str] = frozenset()
+ALIAS_PILE_EXCEPTIONS: frozenset[str] = frozenset()
+
+# Rule S pin — every top-level slash namespace, mapped to its declared
+# extras classification (None = deliberately ledger-default, i.e. a
+# primary entrypoint).  Compared exactly in both directions: adding,
+# removing, renaming, or reclassifying a top-level slash route updates
+# this map in the same PR.
+EXPECTED_SLASH_SURFACE: dict[str, str | None] = {
+    # @app_commands.command
+    "admin": None,
+    "aimenu": None,
+    "btd6menu": None,
+    "community": None,
+    "economy": None,
+    "games": None,
+    "help": None,
+    "moderation": None,
+    "platform": None,
+    "server-management": None,
+    "settings": None,
+    "setup": None,
+    "setup-delegate": None,
+    "setup-depth": None,
+    "setup-hub": "legacy_duplicate",  # FIND-B07: explicit compat UI
+    "setup-reset": None,
+    "setup-skip": None,
+    "setup-status": None,
+    "setup-undelegate": None,
+    "setup-unskip": None,
+    "utility": None,
+    # app_commands.Group namespaces (their subcommands ride the
+    # group's surface decision; extend the pin per-subcommand only if
+    # a group ever needs one classified individually)
+    "ai": None,
+    "btd6": None,
+    "btd6events": None,
+    "btd6ops": None,
+    "btd6ref": None,
+    "btd6strat": None,
+}
+
+
+@dataclass(frozen=True)
+class _DeclaredRoute:
+    """One command/group declaration as written in source."""
+
+    file: str  # basename, e.g. "mining_cog.py"
+    line: int
+    name: str
+    kind: str  # "prefix" | "slash" | "slash-group" | "slash-sub"
+    hidden: bool
+    alias_count: int
+    # Raw literals as written (NOT validated/defaulted) — ``None``
+    # means the key is absent or its value is not an inline string
+    # literal, both of which count as "no declaration".
+    classification: str | None
+    alias_classification: str | None
+
+    @property
+    def key(self) -> str:
+        return f"{self.file}:{self.name}"
+
+
+def _const(node: object) -> object:
+    return node.value if isinstance(node, ast.Constant) else None
+
+
+def _extract_route(
+    node: ast.AsyncFunctionDef | ast.FunctionDef,
+    dec: ast.Call,
+    kind: str,
+    file: str,
+) -> _DeclaredRoute:
+    name = node.name
+    hidden = False
+    alias_count = 0
+    classification: str | None = None
+    alias_classification: str | None = None
+    for kw in dec.keywords:
+        if kw.arg == "name" and isinstance(_const(kw.value), str):
+            name = _const(kw.value)  # type: ignore[assignment]
+        elif kw.arg == "hidden":
+            hidden = _const(kw.value) is True
+        elif kw.arg == "aliases" and isinstance(kw.value, (ast.List, ast.Tuple)):
+            alias_count = len(kw.value.elts)
+        elif kw.arg == "extras" and isinstance(kw.value, ast.Dict):
+            for k, v in zip(kw.value.keys, kw.value.values):
+                if _const(k) == "classification":
+                    raw = _const(v)
+                    classification = raw if isinstance(raw, str) else None
+                elif _const(k) == "alias_classification":
+                    raw = _const(v)
+                    alias_classification = raw if isinstance(raw, str) else None
+    return _DeclaredRoute(
+        file=file,
+        line=dec.lineno,
+        name=name,
+        kind=kind,
+        hidden=hidden,
+        alias_count=alias_count,
+        classification=classification,
+        alias_classification=alias_classification,
+    )
+
+
+def _enumerate_declared_routes() -> list[_DeclaredRoute]:
+    """AST-walk every command-bearing source for command declarations.
+
+    Scope: ``disbot/cogs/**/*.py`` plus ``disbot/bot1.py`` (the one
+    bot-level command, ``!force``).  Handles ``@commands.command`` /
+    ``@commands.group``, prefix-group subcommands (``@<grp>.command``),
+    top-level ``@app_commands.command``, ``app_commands.Group``
+    assignments, and app-group subcommands (``@<app_grp>.command``).
+    """
+    sources = sorted((_DISBOT_ROOT / "cogs").rglob("*.py"))
+    sources.append(_DISBOT_ROOT / "bot1.py")
+    routes: list[_DeclaredRoute] = []
+    for path in sources:
+        tree = ast.parse(path.read_text())
+        file = path.name
+
+        # Pass 1 — app-command group assignments in this module
+        # (``x = app_commands.Group(name=...)``): each is a top-level
+        # slash namespace, and its variable name marks ``@x.command``
+        # decorators as slash subcommands.
+        app_group_vars: set[str] = set()
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Assign) and isinstance(node.value, ast.Call)):
+                continue
+            f = node.value.func
+            if not (
+                isinstance(f, ast.Attribute)
+                and f.attr == "Group"
+                and isinstance(f.value, ast.Name)
+                and f.value.id == "app_commands"
+            ):
+                continue
+            group_name = None
+            for kw in node.value.keywords:
+                if kw.arg == "name" and isinstance(_const(kw.value), str):
+                    group_name = _const(kw.value)
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    app_group_vars.add(target.id)
+            if group_name is not None:
+                routes.append(
+                    _DeclaredRoute(
+                        file=file,
+                        line=node.lineno,
+                        name=group_name,  # type: ignore[arg-type]
+                        kind="slash-group",
+                        hidden=False,
+                        alias_count=0,
+                        classification=None,
+                        alias_classification=None,
+                    ),
+                )
+
+        # Pass 2 — decorated command callbacks.
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                continue
+            for dec in node.decorator_list:
+                if not isinstance(dec, ast.Call):
+                    continue
+                f = dec.func
+                if not (
+                    isinstance(f, ast.Attribute) and f.attr in ("command", "group")
+                ):
+                    continue
+                base = f.value.id if isinstance(f.value, ast.Name) else ""
+                if base == "app_commands":
+                    kind = "slash"
+                elif base in app_group_vars:
+                    kind = "slash-sub"
+                else:
+                    # ``commands`` itself, a prefix-group object
+                    # (``platform_grp`` …), or the bot instance.
+                    kind = "prefix"
+                routes.append(_extract_route(node, dec, kind, file))
+    return routes
+
+
+class TestSurfaceClassificationCompleteness:
+    @pytest.fixture(scope="class")
+    def routes(self) -> list[_DeclaredRoute]:
+        return _enumerate_declared_routes()
+
+    def test_enumeration_sees_known_sentinels(self, routes):
+        """Self-check: a broken walker must fail HERE, not silently pass
+        the rules over an empty population.  Sentinels, not counts —
+        counts rot, declarations don't."""
+        by_key = {r.key: r for r in routes}
+        chop = by_key["mining_cog.py:chop"]
+        assert chop.hidden is True
+        assert chop.classification == "panel_action"
+        hub = by_key["setup_cog.py:setup-hub"]
+        assert hub.kind == "slash"
+        assert hub.classification == "legacy_duplicate"
+        lb = by_key["leaderboard_cog.py:leaderboard"]
+        assert lb.alias_count >= ALIAS_DELIBERATION_THRESHOLD
+        assert lb.alias_classification == "legacy_duplicate"
+        force = by_key["bot1.py:force"]
+        assert force.kind == "prefix"
+        # ai_cog declares BOTH a prefix group `!ai` and a slash group
+        # `/ai` — disambiguate by kind (by_key keeps only one).
+        assert any(
+            r.key == "ai_cog.py:ai" and r.kind == "slash-group" for r in routes
+        )
+        # Generous sanity floor — NOT an inventory pin (the real
+        # surface is ~3× this); guards against a walk that silently
+        # enumerates one directory level.
+        assert len(routes) > 100
+
+    def test_every_extras_classification_literal_is_canonical(self, routes):
+        """Rule V — at runtime an unknown literal silently falls back to
+        the default; in CI it fails loud, so a typo cannot demote a
+        deliberate declaration to an accidental default."""
+        offenders = [
+            f"{r.file}:{r.line} {r.name} classification={r.classification!r}"
+            for r in routes
+            if r.classification is not None and r.classification not in CLASSIFICATIONS
+        ] + [
+            f"{r.file}:{r.line} {r.name} "
+            f"alias_classification={r.alias_classification!r}"
+            for r in routes
+            if r.alias_classification is not None
+            and r.alias_classification not in CLASSIFICATIONS
+        ]
+        assert not offenders, (
+            "Non-canonical classification literal(s) — fix the typo or add "
+            f"the value to Classification first:\n  " + "\n  ".join(offenders)
+        )
+
+    def test_every_discord_hidden_route_declares_why(self, routes):
+        """Rule H — FIND-A01/A05/B04: a ``hidden=True`` command without a
+        deliberate hidden-route classification is unclassifiable drift."""
+        offenders = [
+            f"{r.file}:{r.line} {r.name} (classification={r.classification!r})"
+            for r in routes
+            if r.hidden
+            and r.classification not in HIDDEN_ROUTE_CLASSIFICATIONS
+            and r.key not in HIDDEN_ROUTE_EXCEPTIONS
+        ]
+        assert not offenders, (
+            "Discord-hidden command(s) without a hidden-route classification."
+            "\nDeclare WHY each is hidden, e.g. "
+            'extras={"classification": "panel_action"} '
+            f"(valid: {sorted(HIDDEN_ROUTE_CLASSIFICATIONS)}), or add a "
+            "reviewed entry to HIDDEN_ROUTE_EXCEPTIONS:\n  "
+            + "\n  ".join(offenders)
+        )
+
+    def test_every_alias_pile_declares_a_disposition(self, routes):
+        """Rule A — FIND-A04/Q-A03: a command carrying
+        ALIAS_DELIBERATION_THRESHOLD or more aliases is a compatibility
+        surface and must say what its aliases are."""
+        offenders = [
+            f"{r.file}:{r.line} {r.name} ({r.alias_count} aliases)"
+            for r in routes
+            if r.alias_count >= ALIAS_DELIBERATION_THRESHOLD
+            and r.alias_classification not in CLASSIFICATIONS
+            and r.key not in ALIAS_PILE_EXCEPTIONS
+        ]
+        assert not offenders, (
+            "Alias pile(s) without a declared disposition.\nDeclare e.g. "
+            'extras={"alias_classification": "legacy_duplicate"} (compat '
+            'routes) or "power_user_shortcut" (advertised fluency), or add '
+            "a reviewed entry to ALIAS_PILE_EXCEPTIONS:\n  "
+            + "\n  ".join(offenders)
+        )
+
+    def test_top_level_slash_surface_is_pinned(self, routes):
+        """Rule S — FIND-B07: the top-level slash surface is small and
+        every route on it is a deliberate decision.  Exact two-way
+        comparison: a stale pin fails just like a missing one."""
+        actual = {
+            r.name: r.classification
+            for r in routes
+            if r.kind in ("slash", "slash-group")
+        }
+        assert actual == EXPECTED_SLASH_SURFACE, (
+            "Top-level slash surface drifted from the pin.\n"
+            f"Unexpected/changed: "
+            f"{ {k: v for k, v in actual.items() if EXPECTED_SLASH_SURFACE.get(k, '∅') != v} }\n"
+            f"Missing: {sorted(set(EXPECTED_SLASH_SURFACE) - set(actual))}\n"
+            "Update EXPECTED_SLASH_SURFACE in the same PR that changes "
+            "the slash surface."
+        )
+
+    def test_static_rules_match_runtime_constants(self):
+        """The mirror cannot drift from the module: both rules read their
+        thresholds/sets from command_surface_ledger itself."""
+        assert ALIAS_DELIBERATION_THRESHOLD >= 2
+        assert HIDDEN_ROUTE_CLASSIFICATIONS < set(CLASSIFICATIONS)
+        # The two visible-surface classifications are exactly the ones a
+        # hidden route may NOT declare.
+        assert set(CLASSIFICATIONS) - HIDDEN_ROUTE_CLASSIFICATIONS == {
+            "primary_entrypoint",
+            "power_user_shortcut",
+        }


### PR DESCRIPTION
# Batch 2 — surface-classification completeness invariant (DT04)

Consolidated plan: `docs/planning/consolidated-implementation-plan-2026-06-10.md` §5 Batch 2 (FIND-A01 / A05 / B04 / B07 / A04+Q-A03).

> **Parallel session note:** a sibling Claude session is concurrently executing **Batch 1** (low-risk runtime truth/clarity). This PR touches **none** of the Batch 1 files (`binding_mutation.py`, `core/resources/mutation.py`, `diagnostics_service.py`, `customization_catalogue.py`, `utils/db/migrations.py`, `utils/db/economy.py`) and no conflicts arose. Per the §9 parallel-lane convention, `docs/current-state.md` was deliberately left untouched (both lanes would edit the same ▶ line); the next reconciliation pass updates it.

## The invariant

Every surfaced / hidden / panel-action / slash-legacy / alias route now has a **deliberate** classification or an explicit exception — enforced twice, from declarations, never from prose counts:

1. **Runtime** — `build_ledger` populates the (previously reserved) `findings.unclassified_entry_points` bucket: `hidden:<name>` for a Discord-hidden command without a valid hidden-route classification (the new `HIDDEN_ROUTE_CLASSIFICATIONS` set — `primary_entrypoint`/`power_user_shortcut` are visible-only and stay contradictions), `aliases:<name>` for an alias pile (≥ `ALIAS_DELIBERATION_THRESHOLD` = 3) without a declared `alias_classification`. Surfaces in the existing diagnostics provider.
2. **Static CI mirror** — `tests/unit/runtime/test_command_surface_ledger.py` AST-walks `disbot/cogs/**` + `bot1.py` and enforces the same rules, plus: every `extras` classification literal must be canonical (runtime silently defaults a typo; CI fails loud), and the **top-level slash surface is pinned two-way** (21 `@app_commands.command` + 6 `app_commands.Group` namespaces) so a new slash route is a deliberate decision. Escape hatch = explicit, reviewed exception sets (empty today). Sentinel self-checks guard against a silently broken walker.

`CommandSurfaceEntry` gains `discord_hidden` / `classification_declared` / `alias_classification` (additive, defaulted — ready for the Batch 6 Help projection seam).

## Classification declarations (all 40 hidden routes + 2 alias piles + 1 slash)

| Surface | Classification | Finding |
|---|---|---|
| mining: 16 panel-backed typed cmds (chop/explore/descend/market/workshop/…) | `panel_action` | A01 |
| mining: `use`/`equip`/`unequip`/`gear` (no panel surface — source-verified) | `hidden` | A01 |
| mining: `mineinv` ("compatibility alias for !inventory") | `legacy_duplicate` | A01 |
| moderation: warn/timeout/kick/ban/unban/clearwarnings/modlogs | `panel_action` | B04 |
| role: `rolemenu`/`rolecreator` ("use !roles instead") | `legacy_duplicate` | B04 |
| role: createrole/deleterole/setrole/unsetrole/assignroles | `panel_action` | B04 |
| role: `debugroles`/`refreshmembers` | `internal_admin` | B04 |
| utility: `serverinfo`/`userinfo` ("Alias for !info") | `legacy_duplicate` | A05 |
| utility: `avatar` | `hidden` | A05 |
| leaderboard: the 9 per-game compat aliases | `alias_classification=legacy_duplicate` | A04 / **Q-A03 held default implemented** |
| deathmatch: `dm`/`deathmatch`/`challenge` | `alias_classification=power_user_shortcut` | (threshold-caught; advertised fluency) |
| `/setup-hub` ("legacy section-list hub (compat)") | `legacy_duplicate` | B07 — the slash walker already ingests `extras`, no new seam needed |

**Classification-only:** no execution access, governance, or routing change; every route stays callable. All 40 commands were already Discord-hidden (`hidden=True`), so Help output is byte-identical — pinned by the #642 characterization net. Q-A03 alias *display* integration deliberately rides the Batch 6 Help projection seam, not per-path patches.

## Verification

- `python3.10 scripts/check_quality.py --full` — green (**8543 passed, 22 skipped**)
- `python3.10 scripts/check_architecture.py --mode strict` — **0 errors** (86 pre-existing warnings)
- `python3.10 -m pytest tests/unit/runtime/test_command_surface_ledger.py` — 79 passed (17 new runtime-rule tests + 6 static-invariant tests)
- Focused Help/touched-cog suites (`test_help_render_paths` + mining/role/leaderboard/deathmatch/setup/customization-catalogue) — 200 passed
- **Live boot** (test bot, clean, 0 errors): ledger built over the real surface — `unclassified_entry_points == ()`; the 7 remaining findings are the pre-existing documented orphan-cog entries (split BTD6 cogs / setup), untouched by this PR

https://claude.ai/code/session_01MmFRbSYS6MSSbgi27LCddj

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmFRbSYS6MSSbgi27LCddj)_