### PR TITLE
RS01: atomic shop purchase workflow (Q-0071)

### DIFF
--- a/disbot/services/economy_service.py
+++ b/disbot/services/economy_service.py
@@ -29,14 +29,27 @@ Public API
 All amounts are non-negative.  ``debit`` and ``transfer`` raise
 :class:`InsufficientFundsError` when the user cannot afford the move
 unless ``allow_overdraft=True`` is passed.
+
+Workflow legs (Q-0071)
+----------------------
+``debit_in_txn`` / ``credit_in_txn`` are the transaction-aware variants
+for **domain workflow services** that must commit a coin leg atomically
+with a domain-inventory leg (shop purchase, mining market/repair).  They
+write balance + audit on the caller's connection and **emit no event** —
+the owning workflow emits ``EVT_BALANCE_CHANGED`` after its transaction
+commits (the :func:`transfer` precedent).
 """
 
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 from core.events import bus
 from utils import db
+
+if TYPE_CHECKING:
+    import asyncpg
 
 logger = logging.getLogger("bot.economy_service")
 
@@ -109,6 +122,73 @@ async def debit(
         delta=-amount,
         new_balance=new_balance,
         reason=reason,
+    )
+    return new_balance
+
+
+async def debit_in_txn(
+    conn: asyncpg.Connection,
+    guild_id: int,
+    user_id: int,
+    amount: int,
+    *,
+    reason: str,
+    actor_id: int | None = None,
+) -> int:
+    """Debit inside a caller-owned transaction; return the new balance.
+
+    The conditional UPDATE decides affordability and writes in one
+    statement (no read-then-write race); :class:`InsufficientFundsError`
+    is raised without writing anything when the balance is short — the
+    owning workflow's transaction rolls every other leg back with it.
+    Emits **no event**: the workflow emits after commit.
+    """
+    if amount <= 0:
+        msg = f"debit amount must be positive, got {amount}"
+        raise ValueError(msg)
+    new_balance = await db.try_debit_coins(user_id, guild_id, amount, conn=conn)
+    if new_balance is None:
+        current = await db.get_coins(user_id, guild_id, conn=conn)
+        raise InsufficientFundsError(
+            f"user={user_id} has {current} coins, needs {amount}",
+        )
+    await db.insert_economy_audit(
+        guild_id,
+        user_id,
+        actor_id,
+        -amount,
+        new_balance,
+        reason,
+        conn=conn,
+    )
+    return new_balance
+
+
+async def credit_in_txn(
+    conn: asyncpg.Connection,
+    guild_id: int,
+    user_id: int,
+    amount: int,
+    *,
+    reason: str,
+    actor_id: int | None = None,
+) -> int:
+    """Credit inside a caller-owned transaction; return the new balance.
+
+    Emits **no event**: the owning workflow emits after commit.
+    """
+    if amount <= 0:
+        msg = f"credit amount must be positive, got {amount}"
+        raise ValueError(msg)
+    new_balance = await db.credit_coins(user_id, guild_id, amount, conn=conn)
+    await db.insert_economy_audit(
+        guild_id,
+        user_id,
+        actor_id,
+        amount,
+        new_balance,
+        reason,
+        conn=conn,
     )
     return new_balance
 
@@ -283,9 +363,11 @@ async def _audit(
     reason: str,
 ) -> None:
     """Append a row to economy_audit_log."""
-    await db.execute(
-        """INSERT INTO economy_audit_log
-             (guild_id, user_id, actor_id, delta, new_balance, reason)
-           VALUES ($1, $2, $3, $4, $5, $6)""",
-        (guild_id, user_id, actor_id, delta, new_balance, reason),
+    await db.insert_economy_audit(
+        guild_id,
+        user_id,
+        actor_id,
+        delta,
+        new_balance,
+        reason,
     )

--- a/disbot/services/shop_purchase_workflow.py
+++ b/disbot/services/shop_purchase_workflow.py
@@ -1,0 +1,99 @@
+"""Shop purchase workflow — coins + inventory in ONE transaction (Q-0071).
+
+FIND-RS01: both shop-panel callbacks previously debited coins and granted
+the item as two separately-committed legs *from the view* — a mid-flight
+failure could charge without granting, and the ``has_item``/``get_coins``
+pre-checks were racy (double-click → double charge).  This bounded
+workflow owns the purchase end-to-end:
+
+1. One ``db.transaction()`` wraps the unique-item grant and the audited
+   debit, so both legs commit or roll back together.
+2. The grant runs first (conditional upsert — authoritative ownership
+   check); an unaffordable debit then raises and rolls the grant back.
+3. ``EVT_BALANCE_CHANGED`` is emitted **after commit**, never inside the
+   transaction (the ``economy_service.transfer`` precedent).
+
+Views render copy from the returned :class:`PurchaseResult` flags and
+must not write coins or inventory themselves (AST-enforced by
+``tests/unit/invariants/test_no_view_level_purchase_writes.py``).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from core.events import bus
+from services import economy_service
+from utils import db
+
+logger = logging.getLogger("bot.shop_purchase_workflow")
+
+
+@dataclass(frozen=True)
+class PurchaseResult:
+    """Outcome of one purchase attempt (exactly one flag pattern is set)."""
+
+    ok: bool
+    already_owned: bool = False
+    insufficient: bool = False
+    price: int = 0
+    new_balance: int | None = None
+    #: Current balance, populated on the *insufficient* path for error copy.
+    balance: int | None = None
+
+
+async def purchase_unique_item(
+    guild_id: int,
+    user_id: int,
+    item_name: str,
+    price: int,
+    *,
+    actor_id: int | None = None,
+) -> PurchaseResult:
+    """Buy one unit of a unique (own-at-most-one) shop item atomically.
+
+    Returns a :class:`PurchaseResult`; never partially commits.  *price*
+    must be positive (the catalogue is caller-side — services cannot
+    import the cog-layer ``SHOP_ITEMS``).
+    """
+    if price <= 0:
+        msg = f"price must be positive, got {price}"
+        raise ValueError(msg)
+    reason = f"shop:{item_name}"
+    try:
+        async with db.transaction() as conn:
+            granted = await db.try_grant_unique_item(
+                user_id,
+                guild_id,
+                item_name,
+                conn=conn,
+            )
+            if not granted:
+                # Nothing written — exiting commits an empty transaction.
+                return PurchaseResult(ok=False, already_owned=True, price=price)
+            new_balance = await economy_service.debit_in_txn(
+                conn,
+                guild_id,
+                user_id,
+                price,
+                reason=reason,
+                actor_id=actor_id,
+            )
+    except economy_service.InsufficientFundsError:
+        balance = await db.get_coins(user_id, guild_id)
+        return PurchaseResult(
+            ok=False,
+            insufficient=True,
+            price=price,
+            balance=balance,
+        )
+    await bus.emit(
+        economy_service.EVT_BALANCE_CHANGED,
+        guild_id=guild_id,
+        user_id=user_id,
+        delta=-price,
+        new_balance=new_balance,
+        reason=reason,
+    )
+    return PurchaseResult(ok=True, price=price, new_balance=new_balance)

--- a/disbot/utils/db/__init__.py
+++ b/disbot/utils/db/__init__.py
@@ -52,13 +52,16 @@ from utils.db.anchors import (
 from utils.db.economy import (
     add_coins,
     claim_daily_if_ready,
+    credit_coins,
     ensure_and_get_economy,
     get_coins,
     get_job_times,
     increment_job,
+    insert_economy_audit,
     set_coins,
     set_daily_claim,
     set_last_worked,
+    try_debit_coins,
 )
 
 # ──────────────────────────────────────────────────────────────────────
@@ -113,7 +116,7 @@ from utils.db.governance import (
     set_subsystem_visibility,
     write_governance_audit,
 )
-from utils.db.inventory import add_item, get_inventory, has_item
+from utils.db.inventory import add_item, get_inventory, has_item, try_grant_unique_item
 from utils.db.moderation import (
     add_prohibited_word,
     add_warning,
@@ -128,7 +131,7 @@ from utils.db.moderation import (
 # ──────────────────────────────────────────────────────────────────────
 # Pool lifecycle + primitives  (kept at the package root for back-compat)
 # ──────────────────────────────────────────────────────────────────────
-from utils.db.pool import close, execute, fetchall, fetchone, get, init
+from utils.db.pool import close, execute, fetchall, fetchone, get, init, transaction
 from utils.db.roles import (
     add_reaction_role,
     clear_role_exemption,
@@ -180,6 +183,7 @@ __all__ = [
     "fetchone",
     "get",
     "init",
+    "transaction",
     # xp
     "add_xp",
     "delete_xp",
@@ -217,17 +221,21 @@ __all__ = [
     # economy
     "add_coins",
     "claim_daily_if_ready",
+    "credit_coins",
     "ensure_and_get_economy",
     "get_coins",
     "get_job_times",
     "increment_job",
+    "insert_economy_audit",
     "set_coins",
     "set_daily_claim",
     "set_last_worked",
+    "try_debit_coins",
     # inventory
     "add_item",
     "get_inventory",
     "has_item",
+    "try_grant_unique_item",
     # governance
     "get_all_cleanup_for_guild",
     "get_all_visibility_for_guild",

--- a/disbot/utils/db/economy.py
+++ b/disbot/utils/db/economy.py
@@ -8,19 +8,99 @@ remain supported.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from utils.db import pool
+
+if TYPE_CHECKING:
+    import asyncpg
 
 # ---------------------------------------------------------------------------
 # Coin primitives — wrap via services.economy_service for audited writes.
 # ---------------------------------------------------------------------------
 
 
-async def get_coins(user_id: int, guild_id: int) -> int:
+async def get_coins(
+    user_id: int,
+    guild_id: int,
+    *,
+    conn: asyncpg.Connection | None = None,
+) -> int:
     row = await pool.fetchone(
         "SELECT coins FROM xp WHERE user_id=$1 AND guild_id=$2",
         (user_id, guild_id),
+        conn=conn,
     )
     return row["coins"] if row else 0
+
+
+async def try_debit_coins(
+    user_id: int,
+    guild_id: int,
+    amount: int,
+    *,
+    conn: asyncpg.Connection | None = None,
+) -> int | None:
+    """Conditionally subtract *amount* coins; ``None`` when unaffordable.
+
+    The conditional UPDATE (``coins >= $3``) decides affordability and
+    writes in one statement, eliminating the read-then-write race of the
+    legacy ``get_coins`` + ``add_coins`` pair.  A user with no ``xp`` row
+    matches nothing and is treated as having 0 coins.  Transaction-aware
+    (Q-0071): pass *conn* to join a workflow-owned transaction.
+    """
+    row = await pool.fetchone(
+        """UPDATE xp SET coins = xp.coins - $3
+           WHERE user_id=$1 AND guild_id=$2 AND coins >= $3
+           RETURNING coins""",
+        (user_id, guild_id, amount),
+        conn=conn,
+    )
+    return row["coins"] if row else None
+
+
+async def credit_coins(
+    user_id: int,
+    guild_id: int,
+    amount: int,
+    *,
+    conn: asyncpg.Connection | None = None,
+) -> int:
+    """Add *amount* coins and return the new balance in one statement.
+
+    Transaction-aware (Q-0071) sibling of :func:`add_coins` — same upsert
+    semantics (`GREATEST(0, …)` floor) plus ``RETURNING`` so callers
+    inside a workflow transaction never need a follow-up read.
+    """
+    row = await pool.fetchone(
+        """INSERT INTO xp (user_id, guild_id, coins) VALUES ($1, $2, GREATEST(0, $3))
+           ON CONFLICT (user_id, guild_id) DO UPDATE SET
+               coins=GREATEST(0, xp.coins + $3)
+           RETURNING coins""",
+        (user_id, guild_id, amount),
+        conn=conn,
+    )
+    return row["coins"] if row else 0
+
+
+async def insert_economy_audit(
+    guild_id: int,
+    user_id: int,
+    actor_id: int | None,
+    delta: int,
+    new_balance: int,
+    reason: str,
+    *,
+    conn: asyncpg.Connection | None = None,
+) -> None:
+    """Append one row to ``economy_audit_log`` (transaction-aware)."""
+    await pool.execute(
+        """INSERT INTO economy_audit_log
+             (guild_id, user_id, actor_id, delta, new_balance, reason)
+           VALUES ($1, $2, $3, $4, $5, $6)""",
+        (guild_id, user_id, actor_id, delta, new_balance, reason),
+        conn=conn,
+    )
 
 
 async def add_coins(user_id: int, guild_id: int, amount: int) -> int:

--- a/disbot/utils/db/inventory.py
+++ b/disbot/utils/db/inventory.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from utils.db import pool
+
+if TYPE_CHECKING:
+    import asyncpg
 
 
 async def get_inventory(user_id: int, guild_id: int) -> dict[str, int]:
@@ -18,6 +23,8 @@ async def add_item(
     guild_id: int,
     item_name: str,
     quantity: int = 1,
+    *,
+    conn: asyncpg.Connection | None = None,
 ) -> None:
     await pool.execute(
         """INSERT INTO inventory (user_id, guild_id, item_name, quantity)
@@ -25,13 +32,51 @@ async def add_item(
            ON CONFLICT (user_id, guild_id, item_name)
            DO UPDATE SET quantity=inventory.quantity + $4""",
         (user_id, guild_id, item_name, quantity),
+        conn=conn,
     )
 
 
-async def has_item(user_id: int, guild_id: int, item_name: str) -> bool:
+async def try_grant_unique_item(
+    user_id: int,
+    guild_id: int,
+    item_name: str,
+    *,
+    conn: asyncpg.Connection | None = None,
+) -> bool:
+    """Grant one unit of *item_name* iff the user does not already own it.
+
+    One conditional upsert decides ownership and writes atomically — the
+    decision can't go stale between a ``has_item`` check and the grant,
+    which closes the double-click double-charge race in shop purchases.
+    "Owned" means quantity > 0 (matching :func:`has_item`); a stale
+    zero-quantity row is granted through rather than blocking forever.
+    Returns True when the grant happened, False when already owned.
+    Transaction-aware (Q-0071): pass *conn* to join a workflow transaction.
+    """
+    row = await pool.fetchone(
+        """INSERT INTO inventory (user_id, guild_id, item_name, quantity)
+           VALUES ($1, $2, $3, 1)
+           ON CONFLICT (user_id, guild_id, item_name)
+           DO UPDATE SET quantity = inventory.quantity + 1
+             WHERE inventory.quantity <= 0
+           RETURNING item_name""",
+        (user_id, guild_id, item_name),
+        conn=conn,
+    )
+    return row is not None
+
+
+async def has_item(
+    user_id: int,
+    guild_id: int,
+    item_name: str,
+    *,
+    conn: asyncpg.Connection | None = None,
+) -> bool:
     row = await pool.fetchone(
         "SELECT quantity FROM inventory "
         "WHERE user_id=$1 AND guild_id=$2 AND item_name=$3",
         (user_id, guild_id, item_name),
+        conn=conn,
     )
     return bool(row and row["quantity"] > 0)

--- a/disbot/utils/db/pool.py
+++ b/disbot/utils/db/pool.py
@@ -22,6 +22,8 @@ import logging
 import os
 import re
 import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 import asyncpg
 
@@ -112,10 +114,16 @@ def _query_label(query: str) -> str:
     return f"{op}:{table}"
 
 
-async def fetchone(query: str, params: tuple = ()) -> dict | None:
+async def fetchone(
+    query: str,
+    params: tuple = (),
+    *,
+    conn: asyncpg.Connection | None = None,
+) -> dict | None:
     start = time.monotonic()
     try:
-        row = await get().fetchrow(query, *params)
+        target = conn if conn is not None else get()
+        row = await target.fetchrow(query, *params)
         return dict(row) if row else None
     finally:
         elapsed = time.monotonic() - start
@@ -124,10 +132,16 @@ async def fetchone(query: str, params: tuple = ()) -> dict | None:
         _slow.maybe_record("db_query", label, elapsed * 1000)
 
 
-async def fetchall(query: str, params: tuple = ()) -> list[dict]:
+async def fetchall(
+    query: str,
+    params: tuple = (),
+    *,
+    conn: asyncpg.Connection | None = None,
+) -> list[dict]:
     start = time.monotonic()
     try:
-        rows = await get().fetch(query, *params)
+        target = conn if conn is not None else get()
+        rows = await target.fetch(query, *params)
         return [dict(r) for r in rows]
     finally:
         elapsed = time.monotonic() - start
@@ -136,12 +150,33 @@ async def fetchall(query: str, params: tuple = ()) -> list[dict]:
         _slow.maybe_record("db_query", label, elapsed * 1000)
 
 
-async def execute(query: str, params: tuple = ()) -> None:
+async def execute(
+    query: str,
+    params: tuple = (),
+    *,
+    conn: asyncpg.Connection | None = None,
+) -> None:
     start = time.monotonic()
     try:
-        await get().execute(query, *params)
+        target = conn if conn is not None else get()
+        await target.execute(query, *params)
     finally:
         elapsed = time.monotonic() - start
         label = _query_label(query)
         _metrics.db_query_seconds.labels(query_name=label).observe(elapsed)
         _slow.maybe_record("db_query", label, elapsed * 1000)
+
+
+@asynccontextmanager
+async def transaction() -> AsyncIterator[asyncpg.Connection]:
+    """One connection + one transaction for a cross-domain workflow service.
+
+    Q-0071: a workflow spanning coins + a domain inventory must hold ONE
+    DB transaction — pass the yielded connection into the conn-aware CRUD
+    primitives so every leg commits or rolls back together.  EventBus
+    emission belongs AFTER this context exits (= after commit), never
+    inside it (the ``economy_service.transfer`` precedent).
+    """
+    p = get()
+    async with p.acquire() as conn, conn.transaction():
+        yield conn

--- a/disbot/views/economy/shop_panel.py
+++ b/disbot/views/economy/shop_panel.py
@@ -3,8 +3,12 @@
 ``_ShopView``      — standalone (used by !shop prefix command).
 ``_ShopSubView``   — wrapped in the economy panel flow with a Back button.
 ``_ShopSelect`` / ``_ShopPanelSelect`` — the item-picker dropdowns
-(one each for the two contexts; both perform an audited debit through
-``services.economy_service`` and persist the inventory write).
+(one each for the two contexts; both purchase through the atomic
+``services.shop_purchase_workflow`` — coins + inventory in one
+transaction, Q-0071).  The ``has_item``/``get_coins`` pre-checks here
+are cosmetic fast-paths only; the workflow re-decides authoritatively
+inside its transaction, so a raced click renders an error instead of
+double-charging.
 """
 
 from __future__ import annotations
@@ -13,7 +17,7 @@ import discord
 
 from cogs.economy._helpers import SHOP_ITEMS, _build_economy_embed
 from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
-from services import economy_service
+from services import shop_purchase_workflow
 from utils import db
 from utils.helpers import post_log_embed
 from utils.ui_constants import SUCCESS_COLOR, WARNING_COLOR
@@ -89,18 +93,35 @@ class _ShopSelect(discord.ui.Select):
         if not await safe_defer(interaction):
             return
 
-        new_bal = await economy_service.debit(
+        result = await shop_purchase_workflow.purchase_unique_item(
             gid,
             uid,
+            item_name,
             data["price"],
-            reason=f"shop:{item_name}",
             actor_id=uid,
         )
-        await db.add_item(uid, gid, item_name)
+        if result.already_owned:
+            await safe_followup(
+                interaction,
+                f"You already own a **{item_name}**!",
+                ephemeral=True,
+            )
+            return
+        if result.insufficient:
+            await safe_followup(
+                interaction,
+                f"❌ Need **{data['price']:,}** 🪙 — "
+                f"you only have **{result.balance:,}** 🪙.",
+                ephemeral=True,
+            )
+            return
 
         embed = discord.Embed(
             title=f"✅ Purchased: {data['emoji']} {item_name.replace('_', ' ').title()}",
-            description=f"**-{data['price']:,}** 🪙  |  New balance: **{new_bal:,}** 🪙",
+            description=(
+                f"**-{data['price']:,}** 🪙  |  "
+                f"New balance: **{result.new_balance:,}** 🪙"
+            ),
             color=SUCCESS_COLOR,
         )
         await safe_followup(interaction, embed=embed)
@@ -208,19 +229,34 @@ class _ShopPanelSelect(discord.ui.Select):
         if not await safe_defer(interaction):
             return
 
-        new_bal = await economy_service.debit(
+        result = await shop_purchase_workflow.purchase_unique_item(
             gid,
             uid,
+            item_name,
             data["price"],
-            reason=f"shop:{item_name}",
             actor_id=uid,
         )
-        await db.add_item(uid, gid, item_name)
+        if result.already_owned:
+            await safe_followup(
+                interaction,
+                f"You already own a **{item_name}**!",
+                ephemeral=True,
+            )
+            return
+        if result.insufficient:
+            await safe_followup(
+                interaction,
+                f"❌ Need **{data['price']:,}** 🪙 — "
+                f"you only have **{result.balance:,}** 🪙.",
+                ephemeral=True,
+            )
+            return
 
         embed = discord.Embed(
             title=f"✅ Purchased: {data['emoji']} {item_name.replace('_', ' ').title()}",
             description=(
-                f"**-{data['price']:,}** 🪙  |  New balance: **{new_bal:,}** 🪙\n\n"
+                f"**-{data['price']:,}** 🪙  |  "
+                f"New balance: **{result.new_balance:,}** 🪙\n\n"
                 "Click **↩ Back** to return to the economy panel."
             ),
             color=SUCCESS_COLOR,

--- a/docs/ownership.md
+++ b/docs/ownership.md
@@ -62,7 +62,7 @@ writes must come from the owning cog or a shared service.
 | `moderation`   | `warnings`, `mod_logs`                         | `services/moderation_service.py` (preferred); `utils/db/moderation.py` direct for read-only / legacy callers |
 | `xp`           | `xp.xp`, `xp.level`, `xp.messages`, `xp.last_xp` | `services/xp_service.py` |
 | `economy`      | `economy`, `job_progress`, `economy_audit_log`   | `services/economy_service.py` |
-| `inventory`    | `inventory`                                    | direct via `utils/db/inventory.py` |
+| `inventory`    | `inventory`                                    | direct via `utils/db/inventory.py`; **shop purchases** (coins + item, one transaction) via `services/shop_purchase_workflow.py` (Q-0071/RS01) |
 | `cleanup`      | `prohibited_words`                             | direct via `utils/db/moderation.py` |
 | `chain`        | `chain_channels`                               | direct via `utils/db/games/chain.py` |
 | `counting`     | `counting_state`                               | direct via `utils/db/games/counting.py` |
@@ -91,6 +91,15 @@ writes must come from the owning cog or a shared service.
   is committed separately from a cog/view (the FIND-RS01 two-commit purchase
   shape is the anti-pattern this rule closes). Implementation route:
   `docs/planning/consolidated-implementation-plan-2026-06-10.md` Batch 7.
+- **Shipped (RS01, 2026-06-10):** `services/shop_purchase_workflow.py` owns the
+  shop purchase (`shop:<item>` audit reasons) — one `db.transaction()` wraps the
+  conditional `try_grant_unique_item` upsert + `economy_service.debit_in_txn`;
+  `EVT_BALANCE_CHANGED` emits after commit. The plumbing is reusable: the
+  `utils/db/pool.py` primitives take an optional `conn=`, `db.transaction()`
+  yields the workflow connection, and `economy_service.{debit,credit}_in_txn`
+  are the no-event coin legs for any future domain workflow (mining follows —
+  RS02). View-level purchase writes are AST-fenced
+  (`tests/unit/invariants/test_no_view_level_purchase_writes.py`).
 
 ---
 

--- a/docs/planning/consolidated-implementation-plan-2026-06-10.md
+++ b/docs/planning/consolidated-implementation-plan-2026-06-10.md
@@ -305,6 +305,14 @@ services) without partitioning by module.
 the **workshop-workflow service boundary**. The batch is decision-cleared; it runs
 in plan order (after the smaller batches), not immediately.
 
+> **Execution record (2026-06-10, mining-finalization session):** **RS01 executed
+> in PR #661** (`services/shop_purchase_workflow.py` + conn-aware primitives +
+> `db.transaction()` + the view-write invariant; live-verified incl. the
+> concurrent double-click). RS02 follows in the same session as its two staged
+> PRs (workshop first, then market/remaining writers + ratchet), per the staging
+> below — the maintainer-commissioned mining/tool/gear finalization plan pulled
+> this batch forward of the remaining smaller batches.
+
 - **Objective:** close the two-commit purchase hole first (smallest high-value
   slice), then converge mining writes behind workflow services.
 - **RS01 slice:** purchase **workflow service owning one transaction** (Q-0071=A;

--- a/tests/unit/db/test_economy_db_txn.py
+++ b/tests/unit/db/test_economy_db_txn.py
@@ -1,0 +1,173 @@
+"""Transaction-aware DB primitives (RS01 / Q-0071 plumbing).
+
+Pins the SQL shapes that make the purchase workflow race-free —
+``try_debit_coins`` (conditional UPDATE), ``try_grant_unique_item``
+(conditional upsert) — and the conn-dispatch plumbing: a primitive given
+``conn=`` must run on that connection, never re-acquire the pool, so a
+workflow-owned transaction can never commit a sub-leg independently.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from utils.db import economy, inventory, pool
+
+# ---------------------------------------------------------------------------
+# SQL-shape pins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_try_debit_coins_is_one_conditional_update():
+    with patch(
+        "utils.db.economy.pool.fetchone",
+        new_callable=AsyncMock,
+        return_value={"coins": 7},
+    ) as mock_fetch:
+        result = await economy.try_debit_coins(1, 99, 5)
+    assert result == 7
+    query, params = mock_fetch.await_args.args
+    flat = " ".join(query.split())
+    assert "UPDATE xp SET coins = xp.coins - $3" in flat
+    assert "coins >= $3" in flat
+    assert "RETURNING coins" in flat
+    assert params == (1, 99, 5)
+
+
+@pytest.mark.asyncio
+async def test_try_debit_coins_returns_none_when_unaffordable():
+    with patch(
+        "utils.db.economy.pool.fetchone",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        assert await economy.try_debit_coins(1, 99, 5) is None
+
+
+@pytest.mark.asyncio
+async def test_credit_coins_upserts_with_returning():
+    with patch(
+        "utils.db.economy.pool.fetchone",
+        new_callable=AsyncMock,
+        return_value={"coins": 12},
+    ) as mock_fetch:
+        result = await economy.credit_coins(1, 99, 5)
+    assert result == 12
+    query, params = mock_fetch.await_args.args
+    flat = " ".join(query.split())
+    assert "ON CONFLICT (user_id, guild_id) DO UPDATE" in flat
+    assert "GREATEST(0, xp.coins + $3)" in flat
+    assert "RETURNING coins" in flat
+    assert params == (1, 99, 5)
+
+
+@pytest.mark.asyncio
+async def test_insert_economy_audit_appends_one_row():
+    with patch(
+        "utils.db.economy.pool.execute",
+        new_callable=AsyncMock,
+    ) as mock_exec:
+        await economy.insert_economy_audit(99, 1, None, -5, 7, "shop:car")
+    query, params = mock_exec.await_args.args
+    assert "INSERT INTO economy_audit_log" in query
+    assert params == (99, 1, None, -5, 7, "shop:car")
+
+
+@pytest.mark.asyncio
+async def test_try_grant_unique_item_grants_when_not_owned():
+    with patch(
+        "utils.db.inventory.pool.fetchone",
+        new_callable=AsyncMock,
+        return_value={"item_name": "car"},
+    ) as mock_fetch:
+        assert await inventory.try_grant_unique_item(1, 99, "car") is True
+    query, params = mock_fetch.await_args.args
+    flat = " ".join(query.split())
+    # Conditional upsert: insert when missing, only revive a stale
+    # zero-quantity row — an owned row (> 0) returns nothing.
+    assert "ON CONFLICT (user_id, guild_id, item_name)" in flat
+    assert "WHERE inventory.quantity <= 0" in flat
+    assert "RETURNING item_name" in flat
+    assert params == (1, 99, "car")
+
+
+@pytest.mark.asyncio
+async def test_try_grant_unique_item_already_owned_returns_false():
+    with patch(
+        "utils.db.inventory.pool.fetchone",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        assert await inventory.try_grant_unique_item(1, 99, "car") is False
+
+
+# ---------------------------------------------------------------------------
+# Conn-dispatch plumbing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pool_primitives_dispatch_to_conn_not_pool():
+    conn = MagicMock()
+    conn.fetchrow = AsyncMock(return_value=None)
+    conn.fetch = AsyncMock(return_value=[])
+    conn.execute = AsyncMock()
+    with patch("utils.db.pool.get") as mock_get:
+        await pool.fetchone("SELECT 1 FROM xp", (), conn=conn)
+        await pool.fetchall("SELECT 1 FROM xp", (), conn=conn)
+        await pool.execute("SELECT 1 FROM xp", (), conn=conn)
+    mock_get.assert_not_called()
+    conn.fetchrow.assert_awaited_once()
+    conn.fetch.assert_awaited_once()
+    conn.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_conn_aware_primitives_pass_conn_through():
+    sentinel = MagicMock(name="conn")
+    with patch(
+        "utils.db.economy.pool.fetchone",
+        new_callable=AsyncMock,
+        return_value=None,
+    ) as f:
+        await economy.try_debit_coins(1, 99, 5, conn=sentinel)
+    assert f.await_args.kwargs["conn"] is sentinel
+
+    with patch(
+        "utils.db.inventory.pool.fetchone",
+        new_callable=AsyncMock,
+        return_value=None,
+    ) as f2:
+        await inventory.try_grant_unique_item(1, 99, "car", conn=sentinel)
+    assert f2.await_args.kwargs["conn"] is sentinel
+
+
+@pytest.mark.asyncio
+async def test_transaction_yields_the_acquired_connection_inside_txn():
+    conn = MagicMock(name="conn")
+    txn_state: list[str] = []
+
+    @asynccontextmanager
+    async def _txn():
+        txn_state.append("enter")
+        yield
+        txn_state.append("exit")
+
+    conn.transaction = MagicMock(side_effect=lambda: _txn())
+
+    @asynccontextmanager
+    async def _acquire():
+        yield conn
+
+    fake_pool = MagicMock()
+    fake_pool.acquire = MagicMock(side_effect=lambda: _acquire())
+
+    with patch("utils.db.pool.get", return_value=fake_pool):
+        async with pool.transaction() as got:
+            assert got is conn
+            assert txn_state == ["enter"]
+    assert txn_state == ["enter", "exit"]

--- a/tests/unit/invariants/test_inv_f_economy_service.py
+++ b/tests/unit/invariants/test_inv_f_economy_service.py
@@ -33,7 +33,16 @@ _ALLOWED_PATHS = {
     _DISBOT / "utils" / "db" / "pool.py",
 }
 
-_FORBIDDEN_NAMES = {"add_coins", "set_coins"}
+_FORBIDDEN_NAMES = {
+    "add_coins",
+    "set_coins",
+    # RS01 transaction-aware primitives — same containment as add/set:
+    # only economy_service (debit_in_txn / credit_in_txn) and the DB
+    # layer itself may touch them.
+    "try_debit_coins",
+    "credit_coins",
+    "insert_economy_audit",
+}
 
 # Raw SQL that writes the xp.coins column or the economy table.  We
 # accept SELECTs (read-only) and any reference inside utils/db/*.

--- a/tests/unit/invariants/test_no_view_level_purchase_writes.py
+++ b/tests/unit/invariants/test_no_view_level_purchase_writes.py
@@ -1,0 +1,76 @@
+"""RS01 ratchet — no view may write purchase legs directly.
+
+The shop previously debited coins and granted the item from the view
+callbacks as two separately-committed legs (FIND-RS01).  All purchase
+writes now flow through ``services/shop_purchase_workflow.py``; this AST
+net keeps any future view from reintroducing the pattern.
+
+Receiver-aware on purpose: ``add_item`` is also ``discord.ui.View.add_item``
+(component attach), so it is only flagged when called on a DB-ish receiver
+(``db`` / ``…​.db`` / ``inventory`` / ``pool``).  The transaction-leg names
+are unique to the DB layer and are flagged on any receiver.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_VIEWS = _REPO_ROOT / "disbot" / "views"
+
+# Unique DB-layer names — forbidden in views on ANY receiver.
+_FORBIDDEN_ANY_RECEIVER = {
+    "try_grant_unique_item",
+    "try_debit_coins",
+    "credit_coins",
+    "insert_economy_audit",
+}
+
+# Names that collide with discord.py APIs — forbidden only on a DB-ish
+# receiver (``self.add_item(button)`` is legitimate view code).
+_FORBIDDEN_DB_RECEIVER = {"add_item"}
+
+_DB_RECEIVERS = {"db", "inventory", "economy", "pool"}
+
+
+def _receiver_dotted(node: ast.Attribute) -> str:
+    parts: list[str] = []
+    rcv: ast.expr = node.value
+    while isinstance(rcv, ast.Attribute):
+        parts.append(rcv.attr)
+        rcv = rcv.value
+    if isinstance(rcv, ast.Name):
+        parts.append(rcv.id)
+    return ".".join(reversed(parts))
+
+
+def _violations_in(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    found: list[str] = []
+    for n in ast.walk(tree):
+        if not (isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)):
+            continue
+        name = n.func.attr
+        receiver = _receiver_dotted(n.func)
+        leaf = receiver.rsplit(".", 1)[-1] if receiver else ""
+        if name in _FORBIDDEN_ANY_RECEIVER:
+            found.append(f"{receiver}.{name} (line {n.lineno})")
+        elif name in _FORBIDDEN_DB_RECEIVER and leaf in _DB_RECEIVERS:
+            found.append(f"{receiver}.{name} (line {n.lineno})")
+    return found
+
+
+def test_no_purchase_write_primitives_called_from_views():
+    violations: list[tuple[str, list[str]]] = []
+    for path in sorted(_VIEWS.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        calls = _violations_in(path)
+        if calls:
+            violations.append((str(path.relative_to(_REPO_ROOT)), calls))
+    assert not violations, (
+        "RS01 violation: purchase-leg writes from view code — route through "
+        "services/shop_purchase_workflow.py (Q-0071):\n"
+        + "\n".join(f"  {p}: {calls}" for p, calls in violations)
+    )

--- a/tests/unit/services/test_economy_service.py
+++ b/tests/unit/services/test_economy_service.py
@@ -37,7 +37,7 @@ class TestCredit:
                 return_value=150,
             ),
             patch(
-                "services.economy_service.db.execute",
+                "services.economy_service.db.insert_economy_audit",
                 new_callable=AsyncMock,
             ) as audit,
             patch(
@@ -50,8 +50,7 @@ class TestCredit:
             )
             assert new_bal == 150
             audit.assert_awaited_once()
-            audit_args = audit.call_args.args
-            assert audit_args[1] == (1, 42, None, 50, 150, "daily")
+            assert audit.call_args.args == (1, 42, None, 50, 150, "daily")
             emit.assert_awaited_once_with(
                 EVT_BALANCE_CHANGED,
                 guild_id=1,
@@ -103,7 +102,7 @@ class TestDebit:
                 return_value=0,
             ),
             patch(
-                "services.economy_service.db.execute",
+                "services.economy_service.db.insert_economy_audit",
                 new_callable=AsyncMock,
             ),
             patch(
@@ -134,7 +133,7 @@ class TestDebit:
                 return_value=80,
             ),
             patch(
-                "services.economy_service.db.execute",
+                "services.economy_service.db.insert_economy_audit",
                 new_callable=AsyncMock,
             ) as audit,
             patch(
@@ -147,7 +146,7 @@ class TestDebit:
             )
             assert new_bal == 80
             # negative delta in audit row
-            assert audit.call_args.args[1] == (1, 2, None, -20, 80, "shop:potion")
+            assert audit.call_args.args == (1, 2, None, -20, 80, "shop:potion")
             assert emit.call_args.kwargs["delta"] == -20
 
 
@@ -204,7 +203,7 @@ class TestBetAndSettle:
                 return_value=200,
             ),
             patch(
-                "services.economy_service.db.execute",
+                "services.economy_service.db.insert_economy_audit",
                 new_callable=AsyncMock,
             ),
             patch(
@@ -252,7 +251,10 @@ async def test_refund_credits_amount_with_reason_attribution():
             new_callable=AsyncMock,
             return_value=750,
         ) as add_coins,
-        patch("services.economy_service.db.execute", new_callable=AsyncMock),
+        patch(
+            "services.economy_service.db.insert_economy_audit",
+            new_callable=AsyncMock,
+        ),
         patch(
             "services.economy_service.bus.emit",
             new_callable=AsyncMock,

--- a/tests/unit/services/test_economy_service_concurrent.py
+++ b/tests/unit/services/test_economy_service_concurrent.py
@@ -41,7 +41,7 @@ async def test_credit_under_concurrency_emits_per_call():
             return_value=100,
         ) as add_coins,
         patch(
-            "services.economy_service.db.execute",
+            "services.economy_service.db.insert_economy_audit",
             new_callable=AsyncMock,
         ) as audit,
         patch(
@@ -79,7 +79,7 @@ async def test_debit_under_concurrency_emits_per_call():
             new_callable=AsyncMock,
             return_value=0,
         ),
-        patch("services.economy_service.db.execute", new_callable=AsyncMock),
+        patch("services.economy_service.db.insert_economy_audit", new_callable=AsyncMock),
         patch(
             "services.economy_service.bus.emit",
             new_callable=AsyncMock,
@@ -113,7 +113,7 @@ async def test_debit_insufficient_funds_raises_before_emit():
             "services.economy_service.db.add_coins",
             new_callable=AsyncMock,
         ) as add_coins,
-        patch("services.economy_service.db.execute", new_callable=AsyncMock),
+        patch("services.economy_service.db.insert_economy_audit", new_callable=AsyncMock),
         patch(
             "services.economy_service.bus.emit",
             new_callable=AsyncMock,

--- a/tests/unit/services/test_shop_purchase_workflow.py
+++ b/tests/unit/services/test_shop_purchase_workflow.py
@@ -1,0 +1,176 @@
+"""shop_purchase_workflow — transaction membership + failure injection.
+
+The Q-0071 contract under test: both purchase legs (unique-item grant +
+audited debit) run on the SAME workflow-owned connection; nothing is
+emitted until the transaction context has exited (= committed); any
+failure inside the context leaves no leg committed (rollback is the
+transaction's job — these tests pin that no code path emits or writes
+outside it).
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services import economy_service
+from services import shop_purchase_workflow as wf
+
+
+def _txn(sentinel_conn, events):
+    @asynccontextmanager
+    async def _ctx():
+        events.append("txn_enter")
+        yield sentinel_conn
+        events.append("txn_exit")
+
+    return _ctx
+
+
+@pytest.mark.asyncio
+async def test_success_runs_both_legs_on_one_conn_and_emits_after_commit():
+    sentinel_conn = MagicMock(name="conn")
+    events: list[str] = []
+
+    async def _grant(user_id, guild_id, item_name, *, conn=None):
+        events.append("grant")
+        assert conn is sentinel_conn
+        return True
+
+    async def _debit(conn, guild_id, user_id, amount, *, reason, actor_id=None):
+        events.append("debit")
+        assert conn is sentinel_conn
+        assert reason == "shop:car"
+        assert amount == 10
+        return 58
+
+    async def _emit(event, **payload):
+        events.append(f"emit:{event}")
+
+    with (
+        patch.object(wf.db, "transaction", _txn(sentinel_conn, events)),
+        patch.object(
+            wf.db,
+            "try_grant_unique_item",
+            AsyncMock(side_effect=_grant),
+        ),
+        patch.object(
+            wf.economy_service,
+            "debit_in_txn",
+            AsyncMock(side_effect=_debit),
+        ),
+        patch.object(wf.bus, "emit", AsyncMock(side_effect=_emit)),
+    ):
+        result = await wf.purchase_unique_item(99, 1, "car", 10, actor_id=1)
+
+    assert events == [
+        "txn_enter",
+        "grant",
+        "debit",
+        "txn_exit",
+        "emit:economy.balance_changed",
+    ]
+    assert result.ok is True
+    assert result.new_balance == 58
+    assert result.price == 10
+
+
+@pytest.mark.asyncio
+async def test_already_owned_short_circuits_without_debit_or_emit():
+    sentinel_conn = MagicMock(name="conn")
+    events: list[str] = []
+
+    with (
+        patch.object(wf.db, "transaction", _txn(sentinel_conn, events)),
+        patch.object(
+            wf.db,
+            "try_grant_unique_item",
+            AsyncMock(return_value=False),
+        ),
+        patch.object(wf.economy_service, "debit_in_txn", AsyncMock()) as debit,
+        patch.object(wf.bus, "emit", AsyncMock()) as emit,
+    ):
+        result = await wf.purchase_unique_item(99, 1, "car", 10)
+
+    assert result.already_owned is True
+    assert result.ok is False
+    debit.assert_not_called()
+    emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_insufficient_funds_rolls_back_grant_and_reports_balance():
+    """The debit raising inside the context propagates through it (=
+    rollback in production); the workflow converts it to a result with
+    the current balance and emits nothing."""
+    sentinel_conn = MagicMock(name="conn")
+    events: list[str] = []
+
+    @asynccontextmanager
+    async def _failing_txn():
+        events.append("txn_enter")
+        try:
+            yield sentinel_conn
+        finally:
+            events.append("txn_unwind")
+
+    with (
+        patch.object(wf.db, "transaction", _failing_txn),
+        patch.object(
+            wf.db,
+            "try_grant_unique_item",
+            AsyncMock(return_value=True),
+        ),
+        patch.object(
+            wf.economy_service,
+            "debit_in_txn",
+            AsyncMock(side_effect=economy_service.InsufficientFundsError("no")),
+        ),
+        patch.object(wf.db, "get_coins", AsyncMock(return_value=3)) as get_coins,
+        patch.object(wf.bus, "emit", AsyncMock()) as emit,
+    ):
+        result = await wf.purchase_unique_item(99, 1, "car", 10)
+
+    assert result.insufficient is True
+    assert result.ok is False
+    assert result.balance == 3
+    # The balance read happens after the transaction unwound, on the pool
+    # (no conn kwarg) — the rolled-back transaction must not serve it.
+    assert events == ["txn_enter", "txn_unwind"]
+    assert get_coins.await_args.kwargs.get("conn") is None
+    emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unexpected_failure_propagates_without_emit():
+    sentinel_conn = MagicMock(name="conn")
+    events: list[str] = []
+
+    with (
+        patch.object(wf.db, "transaction", _txn(sentinel_conn, events)),
+        patch.object(
+            wf.db,
+            "try_grant_unique_item",
+            AsyncMock(return_value=True),
+        ),
+        patch.object(
+            wf.economy_service,
+            "debit_in_txn",
+            AsyncMock(side_effect=RuntimeError("db down")),
+        ),
+        patch.object(wf.bus, "emit", AsyncMock()) as emit,
+    ):
+        with pytest.raises(RuntimeError, match="db down"):
+            await wf.purchase_unique_item(99, 1, "car", 10)
+
+    emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_positive_price_is_rejected_before_any_io():
+    with patch.object(wf.db, "transaction", MagicMock()) as txn:
+        with pytest.raises(ValueError, match="price must be positive"):
+            await wf.purchase_unique_item(99, 1, "car", 0)
+    txn.assert_not_called()

--- a/tests/unit/views/test_shop_select_defer.py
+++ b/tests/unit/views/test_shop_select_defer.py
@@ -1,4 +1,4 @@
-"""Regression tests for shop-select interaction ACK safety.
+"""Regression tests for shop-select interaction ACK safety + workflow routing.
 
 Pre-fix `_ShopSelect.callback` and `_ShopPanelSelect.callback` ran
 `db.has_item` + `db.get_coins` + `economy_service.debit` + `db.add_item`
@@ -6,22 +6,26 @@ all before any `interaction.response.*` call. Under realistic
 economy-service latency the 3-second interaction-token window expired
 and the user saw "Interaction Failed".
 
-The fix keeps the cheap balance/has-item checks as immediate
-`response.send_message` replies (they're user-facing validation
-feedback that doesn't need a defer round-trip) and inserts
-`safe_defer` immediately before `economy_service.debit`. Final
-replies route through `safe_followup` (standalone shop) or
-`safe_edit` (panel context).
+The ACK fix keeps the cheap balance/has-item checks as immediate
+`response.send_message` replies (user-facing validation feedback that
+doesn't need a defer round-trip) and defers immediately before the
+purchase. Final replies route through `safe_followup` (standalone shop)
+or `safe_edit` (panel context).
 
-Scope note: these tests pin ACK ordering only. They do NOT assert
-duplicate-purchase prevention — that race exists at the
-read-then-write boundary regardless of ACK behaviour and needs a
-service-level idempotency guard, which is out of scope here.
+RS01 (Q-0071) then replaced the view-level debit+add_item pair with one
+call to ``services.shop_purchase_workflow.purchase_unique_item`` — coins
+and inventory now commit or roll back together, and the duplicate-
+purchase race the old scope note deferred is closed at the SQL level
+(conditional upsert + conditional debit inside one transaction). The
+pre-checks remain as cosmetic fast-paths only; a raced click renders the
+same error copy from the workflow's result flags.
 """
 
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
+
+from services.shop_purchase_workflow import PurchaseResult
 
 
 def _interaction() -> MagicMock:
@@ -94,7 +98,7 @@ async def test_shop_select_insufficient_balance_uses_immediate_response():
     defer.assert_not_called()
 
 
-async def test_shop_select_happy_path_defers_before_debit():
+async def test_shop_select_happy_path_defers_before_purchase():
     from views.economy.shop_panel import _ShopSelect
 
     select = _mock_select("car")
@@ -106,9 +110,9 @@ async def test_shop_select_happy_path_defers_before_debit():
         order.append("defer")
         return True
 
-    async def _debit(*_a, **_kw):
-        order.append("debit")
-        return 0
+    async def _purchase(*_a, **_kw):
+        order.append("purchase")
+        return PurchaseResult(ok=True, price=10, new_balance=0)
 
     async def _followup(*_a, **_kw):
         order.append("followup")
@@ -121,17 +125,56 @@ async def test_shop_select_happy_path_defers_before_debit():
             "views.economy.shop_panel.safe_followup",
             AsyncMock(side_effect=_followup),
         ),
-        patch("views.economy.shop_panel.economy_service") as mock_econ,
+        patch(
+            "views.economy.shop_panel.shop_purchase_workflow",
+        ) as mock_wf,
         patch("views.economy.shop_panel.post_log_embed", AsyncMock()),
     ):
         mock_db.has_item = AsyncMock(return_value=False)
         mock_db.get_coins = AsyncMock(return_value=100000)
-        mock_db.add_item = AsyncMock()
-        mock_econ.debit = AsyncMock(side_effect=_debit)
+        mock_wf.purchase_unique_item = AsyncMock(side_effect=_purchase)
         await _ShopSelect.callback(select, interaction)
 
-    assert order == ["defer", "debit", "followup"], order
+    assert order == ["defer", "purchase", "followup"], order
     interaction.response.send_message.assert_not_called()
+
+
+async def test_shop_select_raced_already_owned_renders_error_after_defer():
+    """Pre-checks passed but the workflow says already-owned (raced click):
+    the same copy is rendered as an ephemeral followup and no success
+    embed is sent."""
+    from views.economy.shop_panel import _ShopSelect
+
+    select = _mock_select("car")
+    interaction = _interaction()
+    followups: list[tuple] = []
+
+    async def _followup(_inter, *args, **kwargs):
+        followups.append((args, kwargs))
+        return MagicMock()
+
+    with (
+        patch("views.economy.shop_panel.db") as mock_db,
+        patch("views.economy.shop_panel.safe_defer", AsyncMock(return_value=True)),
+        patch(
+            "views.economy.shop_panel.safe_followup",
+            AsyncMock(side_effect=_followup),
+        ),
+        patch("views.economy.shop_panel.shop_purchase_workflow") as mock_wf,
+        patch("views.economy.shop_panel.post_log_embed", AsyncMock()) as log,
+    ):
+        mock_db.has_item = AsyncMock(return_value=False)
+        mock_db.get_coins = AsyncMock(return_value=100000)
+        mock_wf.purchase_unique_item = AsyncMock(
+            return_value=PurchaseResult(ok=False, already_owned=True, price=10),
+        )
+        await _ShopSelect.callback(select, interaction)
+
+    assert len(followups) == 1
+    args, kwargs = followups[0]
+    assert "already own" in args[0]
+    assert kwargs.get("ephemeral") is True
+    log.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -168,9 +211,9 @@ async def test_shop_panel_select_happy_path_uses_safe_edit_after_defer():
         order.append("defer")
         return True
 
-    async def _debit(*_a, **_kw):
-        order.append("debit")
-        return 0
+    async def _purchase(*_a, **_kw):
+        order.append("purchase")
+        return PurchaseResult(ok=True, price=10, new_balance=0)
 
     async def _edit(*_a, **_kw):
         order.append("safe_edit")
@@ -180,16 +223,15 @@ async def test_shop_panel_select_happy_path_uses_safe_edit_after_defer():
         patch("views.economy.shop_panel.db") as mock_db,
         patch("views.economy.shop_panel.safe_defer", AsyncMock(side_effect=_defer)),
         patch("views.economy.shop_panel.safe_edit", AsyncMock(side_effect=_edit)),
-        patch("views.economy.shop_panel.economy_service") as mock_econ,
+        patch("views.economy.shop_panel.shop_purchase_workflow") as mock_wf,
         patch("views.economy.shop_panel.post_log_embed", AsyncMock()),
     ):
         mock_db.has_item = AsyncMock(return_value=False)
         mock_db.get_coins = AsyncMock(return_value=100000)
-        mock_db.add_item = AsyncMock()
-        mock_econ.debit = AsyncMock(side_effect=_debit)
+        mock_wf.purchase_unique_item = AsyncMock(side_effect=_purchase)
         await _ShopPanelSelect.callback(select, interaction)
 
-    assert order == ["defer", "debit", "safe_edit"], order
+    assert order == ["defer", "purchase", "safe_edit"], order
     # Panel context must NOT use response.edit_message directly — it
     # always routes through safe_edit so post-defer routing works.
     interaction.response.edit_message.assert_not_called()


### PR DESCRIPTION
## PR 1 of 4 — Mining & Tool/Gear finalization session

Batch 7 RS01 (consolidated plan): close the **two-commit shop purchase** hole and land the Q-0071 transaction plumbing that the mining workflow (RS02, PRs 2a/2b) reuses. **No mining content in this PR** (Batch 7 boundary).

### What changed
- **`utils/db/pool.py`** — optional `conn=` on `fetchone/fetchall/execute` (the `db_query_seconds` metric + slow-path instrumentation is preserved on the conn path) and a new `db.transaction()` async context manager: one connection, one transaction, for Q-0071 workflow services.
- **`utils/db/economy.py`** — `try_debit_coins` (conditional `UPDATE … WHERE coins >= $3 RETURNING` — affordability decided and written in one statement, no read-then-write race), `credit_coins` (upsert `RETURNING`), `insert_economy_audit` (audit SQL moved out of `economy_service._audit`).
- **`utils/db/inventory.py`** — `try_grant_unique_item`: conditional upsert that grants iff not currently owned (quantity > 0 semantics, matching `has_item`).
- **`services/economy_service.py`** — `debit_in_txn` / `credit_in_txn`: transaction-aware coin legs for domain workflows. They write balance + audit on the caller's connection and **emit no event** — the owning workflow emits `EVT_BALANCE_CHANGED` after commit (the `transfer` precedent).
- **NEW `services/shop_purchase_workflow.py`** — `purchase_unique_item`: one `db.transaction()` wraps grant-then-debit, so any failure rolls both legs back; typed `PurchaseResult` flags (`already_owned` / `insufficient` / `ok`).
- **`views/economy/shop_panel.py`** — both select callbacks consume the workflow. The `has_item`/`get_coins` pre-checks stay as cosmetic fast-paths (identical copy); the workflow re-decides authoritatively, so a raced click now renders the normal error instead of double-charging.
- **Invariants** — new receiver-aware AST net (`test_no_view_level_purchase_writes.py`: no view may call purchase-leg write primitives; `add_item` only flagged on DB-ish receivers since `View.add_item` is legitimate); INV-F `_FORBIDDEN_NAMES` extended with the three new primitives.
- **`docs/ownership.md`** — inventory row + Cross-domain transactions section record the shipped seam.

### Verification
- Full CI mirror green (`check_quality.py --full`: 8,624 passed) · `check_architecture.py --mode strict`: 0 errors.
- **Live against real Postgres**: insufficient funds → zero audit/inventory rows leak (rollback proven); success → exactly one audit row (`shop:car`, −500) + one inventory row + correct balance; duplicate purchase blocked without charge; **concurrent double-click → exactly one charge** (`oks=[False, True]`, qty 1).
- Test bot boots clean (0 ERROR/CRITICAL, all cogs load).

Plan context: this session executes the approved mining/tool/gear finalization plan — PR 2a/2b (mining workflow boundary) and PR 3 (game-XP + UX) follow.

https://claude.ai/code/session_01NeGvFiE5Qj6AE7BTagHR3y

---
_Generated by [Claude Code](https://claude.ai/code/session_01NeGvFiE5Qj6AE7BTagHR3y)_