### PR TITLE
BTD6 data lane: self-applying seed-data + drift surfacing; typo-proof meta floor

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -216,6 +216,15 @@ confidence; do not treat booting as gated.
   DB (no policy → all channels). Owner-gating uses `bot.is_owner` (Discord app owner =
   maintainer); `config.BOT_OWNER_USER_ID` is the AI-side owner identity — it also gates AI **scope** (`_derive_scope` → `PLATFORM_OWNER`, e.g. the `diagnostics_health_snapshot` tool), not just personalization.
 
+**Production (the maintainer's real bot — for diagnosis, never touched from here):**
+Railway service `worker`, **auto-deploys `main` on every merge** (restart policy
+is on-failure — why `!restart` must exit **nonzero**, PR #675). BTD6 data in prod
+is the **postgres blob lane** (`BTD6_DATA_BACKEND=postgres`): merged data PRs do
+NOT change what prod serves until `!btd6ops seed-data` runs (self-applying since
+PR #676; drift surfaced at boot + `!btd6 status`). Full note:
+`docs/subsystems/btd6.md` § Current state. (Learned live 2026-06-10 — the
+"(55.0)" eval ghost-chase.)
+
 **Boot gotchas (learned the hard way):**
 
 - `pkill -f "disbot/bot1.py"` matches the *launching shell itself* (its command line

--- a/.sessions/2026-06-10-eval-checklist-session.md
+++ b/.sessions/2026-06-10-eval-checklist-session.md
@@ -155,3 +155,37 @@ phrasings. Checklist gained **Step 0: verify the build** + live-walk deltas
 - **Weak point:** the §7.5 composition family ("cash left after buying
   N towers") now has live acceptance cases but still no workflow — expect
   honest partials there until §7.5 ships.
+
+---
+
+## Continuation 3 (same session): the 55.0 mystery corrected + the data lane fixed (PR #676)
+
+**Correction of continuation 2:** the "prod deploy predated the burst" claim
+was WRONG — the maintainer challenged it ("my bot auto-deploys every merge")
+and the Railway log proves a new container (the #674 auto-deploy) served a
+"(55.0)" answer at 18:36. The stale thing was the **data, not the code**:
+prod runs `BTD6_DATA_BACKEND=postgres`, fixtures come from `btd6_data_blobs`
+(warmed at boot), and **merged data PRs never refresh that table**. The
+maintainer's own `!btd6ops seed-data` (18:43) is what flipped 55.0 → 55.1;
+the restart they correctly tried next died on the exit-0 bug. Lesson
+recorded: when a hypothesis contradicts a platform behavior the owner
+states, re-derive from the logs before asserting — the "(55.0) on the NEW
+container" line was sitting in the evidence the whole time.
+
+**Shipped (PR #676):** seed-data is now **self-applying** (re-warm + cache
+drop — one command, immediate effect); **drift surfacing** (boot-log warning
++ `!btd6 status` ⚠️ Data-drift field when the store lags the bundled files);
+seed-embed copy rewritten; checklist Step 0 corrected to the data-lane
+truth; prod-operations note added to the BTD6 folio + journal Runbook;
+**Q-0077** (auto-seed-on-boot posture) routed. Plus the post-restart
+screenshots' one holdout: "What **csn** you tell me about btd6" (typo) slips
+the meta-detector's `can you tell` shape — the tell/ask shapes are now
+auxiliary-verb-free and target-anchored ("ask **you/this bot**", so "ask a
+friend" stays out), pinned by the typo'd phrasing in the test matrix.
+
+**Post-restart screenshot verdicts (after seed + manual redeploy):** Navarch
+income ✅ (the #662 fix live-verified: $3,200/round + Trade Empire lines) ·
+crossbow-master cumulative cost ✅ · **the remaining-cash composition ✅**
+($650 + $37,660 − $21,500 = $16,810 — composed correctly without the §7.5
+workflow; better than predicted) · capability meta-question ❌ (the typo +
+possible pre-#675 timing) → the floor now catches it deterministically.

--- a/disbot/cogs/btd6/_embeds.py
+++ b/disbot/cogs/btd6/_embeds.py
@@ -152,6 +152,19 @@ async def build_status_embed() -> discord.Embed:
         value=f"`{btd6_data_service.data_source_label()}`",
         inline=False,
     )
+    drift = btd6_data_service.served_data_drift()
+    if drift is not None:
+        served, bundled = drift
+        embed.add_field(
+            name="⚠️ Data drift",
+            value=(
+                f"The deployed files carry **{bundled}** but this store is "
+                f"serving **{served}** — data PRs do not refresh a "
+                "postgres/cloud store. Run `!btd6ops seed-data` to update "
+                "(applies immediately, no restart)."
+            ),
+            inline=False,
+        )
     from utils.btd6.context_footer import append_context_footer
 
     return append_context_footer(embed, "btd6_status:global")

--- a/disbot/cogs/btd6_cog.py
+++ b/disbot/cogs/btd6_cog.py
@@ -106,6 +106,22 @@ class BTD6Cog(commands.Cog):
             )
             return
 
+        # Data PRs update the bundled files only — a postgres/cloud store
+        # keeps serving its old copy until re-seeded, invisibly (live,
+        # 2026-06-10: code auto-deployed at 55.1 while the blob store served
+        # 55.0). Surface the drift loudly at every boot; `!btd6 status`
+        # shows the same warning.
+        drift = btd6_data_service.served_data_drift()
+        if drift is not None:
+            served, bundled = drift
+            logger.warning(
+                "BTD6 data drift: the deployed files carry %s but the active "
+                "store serves %s — run `!btd6ops seed-data` to update "
+                "(applies immediately, no restart needed).",
+                bundled,
+                served,
+            )
+
         await btd6_ingestion_supervisor.start_supervisor()
 
     async def cog_unload(self) -> None:

--- a/disbot/cogs/btd6_ops_cog.py
+++ b/disbot/cogs/btd6_ops_cog.py
@@ -90,14 +90,20 @@ async def _seed_embed() -> discord.Embed:
             ),
             color=discord.Color.orange(),
         )
+    served = ""
+    try:
+        served = btd6_data_service.get_dataset().game_version
+    except Exception:  # noqa: BLE001 — version is decoration on the receipt
+        pass
+    serving_line = f"\n**Now serving:** game version `{served}`." if served else ""
     return discord.Embed(
         title="🌱 BTD6 data seeded",
         description=(
-            f"Upserted **{count}** blobs into the `btd6_data_blobs` table.\n\n"
-            "**Next steps:**\n"
-            "1. In Railway → your bot service → **Variables**, add "
-            "`BTD6_DATA_BACKEND` = `postgres` (the service redeploys).\n"
-            "2. Run `!btd6 status` — it should read "
+            f"Upserted **{count}** blobs into the `btd6_data_blobs` table and "
+            f"**reloaded the live dataset** — the new data is being served "
+            f"now; no restart needed.{serving_line}\n\n"
+            "First-time setup only: set `BTD6_DATA_BACKEND` = `postgres` in "
+            "Railway → Variables, then confirm `!btd6 status` reads "
             "`Data source: postgres (…)`.\n\n"
             "Safe to re-run any time (it upserts)."
         ),

--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -1748,8 +1748,13 @@ _META_ANCHOR_RE = re.compile(r"\bbtd\s?6\b|\bbloons\b", re.I)
 _META_SHAPE_RES = (
     re.compile(r"\b(?:do|can|does)\s+(?:you|we|i|this bot)\b.{0,40}\bknow\b", re.I),
     re.compile(r"\bknow\s+about\b", re.I),
-    re.compile(r"\bcan\s+(?:you|this bot)\s+tell\s+(?:me|us)\s+about\b", re.I),
-    re.compile(r"\bcan\s+(?:we|i)\s+ask\b", re.I),
+    # No auxiliary-verb requirement: "what CSN you tell me about btd6" (live
+    # typo, 2026-06-10) must still match — "you tell me/us about" + the BTD6
+    # anchor is unambiguous on a floored BTD6-routed message.
+    re.compile(r"\b(?:you|this bot)\s+tell\s+(?:me|us)\s+about\b", re.I),
+    # "ask" must target the bot ("ask you / this bot / the bot / it"), not a
+    # third party ("can I ask a friend to play btd6" is a social turn).
+    re.compile(r"\bask\s+(?:you|it|this\s+bot|the\s+bot)\b", re.I),
     re.compile(r"\bwhat\s+(?:btd\s?6\s+)?(?:data|questions?|topics?)\b", re.I),
     re.compile(r"\bwhat\s+can\s+you\s+(?:do|answer|help)\b", re.I),
 )

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -909,6 +909,13 @@ async def seed_postgres_from_files(root: Path | None = None) -> int:
     the number of blobs seeded. Requires the DB pool to be initialised — it is,
     once the bot is running, so this powers the ``!btd6ops seed-data`` command as
     well as ``scripts/seed_btd6_data.py``.
+
+    **Self-applying:** after seeding, the active provider is re-warmed and the
+    dataset cache dropped, so the new data is served immediately — no restart.
+    (Live miss 2026-06-10: seed-data wrote the blobs but the process kept
+    serving the old warmed copy; the operator had to know to restart, and the
+    restart command had its own relaunch bug. One command now means one
+    outcome.)
     """
     import hashlib
     import json
@@ -928,7 +935,51 @@ async def seed_postgres_from_files(root: Path | None = None) -> int:
         ).hexdigest()
         await btd6_data.upsert_blob(name, body, sha)
         seeded += 1
+    if seeded:
+        await warm_provider()
+        reset_cache()
     return seeded
+
+
+def bundled_game_version() -> str | None:
+    """The ``game_version`` carried by the *committed* fixture files, or ``None``.
+
+    Reads ``towers.json`` (the version-of-record fixture) through a fresh
+    ``FileRawProvider`` regardless of the active backend, so callers can
+    detect drift between what the repo ships and what the store serves.
+    """
+    try:
+        body = FileRawProvider().load("towers.json")
+    except Exception:  # noqa: BLE001 — absent files = no bundled version
+        return None
+    if not isinstance(body, dict):
+        return None
+    version = str(body.get("game_version") or "").strip()
+    return version or None
+
+
+def served_data_drift() -> tuple[str, str] | None:
+    """``(served, bundled)`` when the active store lags the bundled files.
+
+    ``None`` when the file backend is active (it cannot drift), when either
+    version is unknown, or when they agree. The repo's data PRs update the
+    bundled files only — a postgres/cloud store keeps serving its old copy
+    until re-seeded, which is exactly the invisible state this surfaces
+    (live, 2026-06-10: code auto-deployed at 55.1 while the blob store still
+    served 55.0 and an eval chased ghosts).
+    """
+    if isinstance(_PROVIDER, FileRawProvider):
+        return None
+    bundled = bundled_game_version()
+    if not bundled:
+        return None
+    try:
+        served = str(get_dataset().game_version or "").strip()
+    except Exception:  # noqa: BLE001 — unloadable dataset = no comparison
+        return None
+    if not served or served == bundled:
+        return None
+    return served, bundled
 
 
 def _load_file(name: str) -> dict[str, Any]:

--- a/docs/audits/production-eval-checklist-2026-06-10.md
+++ b/docs/audits/production-eval-checklist-2026-06-10.md
@@ -23,16 +23,21 @@ Discord's pace, image quality, and whether the game *feels* right.
 
 ---
 
-## Step 0 — verify the build (learned live, 2026-06-10 evening)
+## Step 0 — verify the build AND the data (learned live, 2026-06-10 evening)
 
-- [ ] `!btd6 status` shows **game version 55.1**. The first walk ran on a
-      pre-#655 deploy that stamped "(55.0)" — the empty boss roster and the
-      stale version in refusals were *yesterday's code*, not today's bugs.
+- [ ] `!btd6 status` shows **game version 55.1** and no **⚠️ Data drift**
+      field. *(Corrected diagnosis:* the first walk's "(55.0)" stamps were
+      **not** a stale code deploy — auto-deploy worked; the Railway log shows
+      the new container serving them. Production runs
+      `BTD6_DATA_BACKEND=postgres`, so BTD6 fixtures come from the
+      `btd6_data_blobs` table, and **data PRs never refresh that store** —
+      it served the old blobs until `!btd6ops seed-data` ran. Since PR #676,
+      seed-data **applies immediately** (no restart) and both boot logs and
+      `!btd6 status` surface the drift loudly.)*
 - [ ] After any `!restart`: confirm the bot actually comes back. On the old
       build `!restart` exited 0 and Railway (on-failure policy) never
-      relaunched it — fixed by the restart exit-code change (PR #675): once
-      *that* is deployed, `!restart` exits nonzero and relaunches. Until then
-      use a Railway redeploy instead.
+      relaunched it — fixed by the restart exit-code change (PR #675):
+      `!restart` now exits nonzero and relaunches.
 
 ### Live-walk deltas (first pass, 2026-06-10 evening — fixes in PR #675)
 

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -3143,3 +3143,35 @@ paper-doll stays Wave 3.
 **Suggested destination after answer:** done — brainstorm §7.6 stays the
 visual-roadmap home; `docs/subsystems/games.md` records the shipped card
 seam.
+
+## 33. Production data-lane batch — 2026-06-10 (eval session live findings)
+
+### Q-0077 — Should the BTD6 blob store auto-sync from the bundled files at boot?
+
+**Area:** BTD6 data lane / production operations
+**Type:** Operational posture (boot-time DB write)
+**Priority:** Medium (the drift class is now *surfaced* — this decides whether it also self-heals)
+**Status:** Open
+
+**Question:** Production serves BTD6 fixtures from the `btd6_data_blobs`
+Postgres table (`BTD6_DATA_BACKEND=postgres`), so a data PR updates the
+bundled files but the store keeps serving its old copy until someone runs
+`!btd6ops seed-data` — this silently confused the 2026-06-10 eval ("(55.0)"
+stamps, empty boss roster, on current code). PR #676 makes the drift loud
+(boot log warning + a `!btd6 status` ⚠️ field) and makes seed-data apply
+immediately. Should the bot go further and **auto-seed at boot when the
+bundled files are newer than the store** (true zero-touch: merge → deploy →
+data current)?
+
+**Why it needs the owner:** auto-seed is a **DB write at boot** and would
+overwrite a blob store that was *deliberately* seeded with newer data than
+the repo (the refresh-workflow direction). Options: **(a)** keep
+surface-only (current after #676 — recommended until the drift recurs),
+**(b)** auto-seed only when the bundled version is strictly newer,
+**(c)** auto-seed whenever versions differ.
+
+**Safe default until answered:** (a) — loud surfacing, manual seed-data
+(now one command, immediate effect).
+
+**Suggested destination after answer:** `docs/subsystems/btd6.md` data-lane
+note + `btd6_cog.cog_load` (if (b)/(c): implement beside the drift warning).

--- a/docs/subsystems/btd6.md
+++ b/docs/subsystems/btd6.md
@@ -45,6 +45,15 @@ files, `disbot/services/btd6_*`, `disbot/views/btd6/`, `disbot/utils/db/btd6_*`,
 - Existing UI direction is visible in live-event, tower, hero, leaderboard, strategy,
   CT-map, and paragon browser/calculator views. Paragon and other env-gated paths may
   run degraded in the sandbox; do not call them broken or production-verified.
+- **Production data lane (learned live 2026-06-10):** prod runs
+  `BTD6_DATA_BACKEND=postgres` — fixtures are served from the `btd6_data_blobs`
+  table (warmed once at boot), **not** the repo files, so a merged data PR does
+  NOT change what prod serves until `!btd6ops seed-data` runs. Since PR #676
+  seed-data **applies immediately** (re-warms + drops the dataset cache; no
+  restart), and version drift between bundled files and the store is surfaced
+  in the boot log + a `!btd6 status` ⚠️ field. Auto-seed-on-boot is **Q-0077
+  (open)**. Code deploys themselves are Railway auto-deploy-on-merge;
+  `!restart` exits nonzero since PR #675 so the platform relaunches it.
 
 ## Plans / pending approval
 

--- a/tests/unit/services/test_btd6_context_grounding.py
+++ b/tests/unit/services/test_btd6_context_grounding.py
@@ -710,6 +710,9 @@ def test_deterministic_meta_reply_answers_capability_questions():
         "What kind of things do you know about btd6",
         "List all the things that you know about btd6",
         "what can you tell me about btd6",
+        # The live typo (2026-06-10, "csn"): the tell-shape must not depend
+        # on the auxiliary verb being spelled right.
+        "What csn you tell me about btd6",
         "wait what things can we ask this bot about btd6?",
     ):
         reply = btd6_context_service.deterministic_meta_reply(question)
@@ -729,6 +732,7 @@ def test_deterministic_meta_reply_skips_entity_and_off_domain_questions():
         "what do you know about cooking",  # off-domain
         "tell me about quincy",  # plain entity
         "what can we ask you",  # general — get_ai_tool_catalog owns it
+        "can I ask a friend to play btd6 with me",  # ask targets a 3rd party
     ):
         assert btd6_context_service.deterministic_meta_reply(question) is None, (
             question

--- a/tests/unit/services/test_btd6_data_service.py
+++ b/tests/unit/services/test_btd6_data_service.py
@@ -614,3 +614,71 @@ def test_find_boss_resolves_qualifier_wrapped_names():
     assert btd6_data_service.find_boss("lych").canonical == "Lych"
     # No boss named → None, never a guess.
     assert btd6_data_service.find_boss("tier 4 elite") is None
+
+
+# ---------------------------------------------------------------------------
+# Data-lane drift + self-applying seed (live miss, 2026-06-10)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_seed_postgres_from_files_reloads_the_live_dataset(monkeypatch):
+    """Seeding must re-warm the provider + drop the dataset cache — the live
+    miss was seed-data writing blobs while the process kept serving the old
+    warmed copy until a (broken) restart."""
+    from services import btd6_data_service as svc
+    from utils.db import btd6_data
+
+    upserts: list[str] = []
+
+    async def _fake_upsert(name, body, sha):
+        upserts.append(name)
+
+    warmed: list[bool] = []
+
+    async def _fake_warm():
+        warmed.append(True)
+        return True
+
+    resets: list[bool] = []
+
+    monkeypatch.setattr(btd6_data, "upsert_blob", _fake_upsert)
+    monkeypatch.setattr(svc, "warm_provider", _fake_warm)
+    monkeypatch.setattr(svc, "reset_cache", lambda: resets.append(True))
+
+    count = await svc.seed_postgres_from_files()
+    assert count == len(upserts) > 0
+    assert warmed and resets  # the new data is served immediately
+
+
+def test_served_data_drift_reports_a_lagging_store(monkeypatch):
+    """A non-file store serving an older game version than the bundled files
+    is exactly the invisible state that confused the 2026-06-10 eval."""
+    from services import btd6_data_service as svc
+
+    class _DummyStore:  # not a FileRawProvider → drift applies
+        pass
+
+    class _DummyDataset:
+        game_version = "55.0"
+
+    monkeypatch.setattr(svc, "_PROVIDER", _DummyStore())
+    monkeypatch.setattr(svc, "bundled_game_version", lambda: "55.1")
+    monkeypatch.setattr(svc, "get_dataset", lambda: _DummyDataset())
+    assert svc.served_data_drift() == ("55.0", "55.1")
+
+    # Agreement → no drift.
+    _DummyDataset.game_version = "55.1"
+    assert svc.served_data_drift() is None
+
+
+def test_served_data_drift_is_silent_for_the_file_backend(monkeypatch):
+    """The file provider serves the bundled files directly — it cannot drift,
+    and the bundled version itself must parse from the committed fixture."""
+    from services import btd6_data_service as svc
+    from services.btd6_data_provider import FileRawProvider
+
+    monkeypatch.setattr(svc, "_PROVIDER", FileRawProvider())
+    assert svc.served_data_drift() is None
+    bundled = svc.bundled_game_version()
+    assert bundled and bundled[0].isdigit()


### PR DESCRIPTION
## What — the corrected 55.0 diagnosis, fixed at the root

The maintainer challenged the "stale deploy" explanation ("my bot auto-deploys every merge") — and he was right. The Railway log shows the #674 auto-deploy's **new container** serving a "(55.0)" answer at 18:36. The stale thing was the **data, not the code**: production runs `BTD6_DATA_BACKEND=postgres`, so BTD6 fixtures are served from the `btd6_data_blobs` table (warmed once at boot) — **merged data PRs never refresh that store**. It kept serving 55.0 blobs until `!btd6ops seed-data` ran at 18:43, and even then the in-process dataset cache needed a restart (which the exit-0 bug then ate — fixed in #675). A whole eval segment chased ghosts because this state was invisible.

### Fixes (the class, not the symptom)

1. **`!btd6ops seed-data` is now self-applying** — after upserting, it re-warms the active provider and drops the dataset cache. One command, immediate effect, no restart; the receipt embed says so and shows the now-serving version.
2. **Drift is loud** — new `served_data_drift()` compares the bundled files' `game_version` against what the store serves: a lagging postgres/cloud store triggers a boot-log warning and a **⚠️ Data drift** field on `!btd6 status` with the exact remedy. File backend is exempt (it cannot drift).
3. **The meta-floor is typo-proof** — the post-restart screenshots' one holdout was "What **csn** you tell me about btd6": the tell/ask shapes no longer depend on the auxiliary verb and the ask-shape is bot-targeted ("ask you/this bot" matches; "can I ask a friend to play btd6" stays out). Pinned with the live typo in the test matrix.

**Deliberately not done:** auto-seeding the store at boot — that's a boot-time DB write that could clobber a store deliberately seeded newer than the repo. Routed as **Q-0077** (recommended: keep surface-only until drift recurs).

### Docs
Checklist **Step 0** rewritten to the data-lane truth (verify build **and** data); the BTD6 folio + journal Runbook gain the production data-lane note (Railway auto-deploy · postgres blob lane · `!restart` exit contract); session log carries the correction honestly.

### Post-restart screenshot verdicts (recorded in the checklist)
Navarch income ✅ (the #662 fix verified live) · crossbow-master cumulative ✅ · **remaining-cash composition ✅** ($650 + $37,660 − $21,500 = $16,810 — composed correctly, better than predicted) · capability meta-question ❌ → now caught deterministically.

## Verification
5 new tests (seed reload spy · drift both ways · file-backend exemption · the typo phrasing · ask-target negatives); CI mirror **8,864 passed / 22 skipped**; arch strict 0 errors; clean sandbox boot (0 errors); drift helper live-verified in both states.

https://claude.ai/code/session_01YBstRF8oY6HmmbqJT8e1B4

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBstRF8oY6HmmbqJT8e1B4)_