### PR TITLE
Help overlay editor UI — PR A: the hide/rename/re-describe editor (audit Phase 5)

### DIFF
--- a/disbot/cogs/help/schemas.py
+++ b/disbot/cogs/help/schemas.py
@@ -1,0 +1,40 @@
+"""Help SubsystemSchema — the "Help appearance" domain panel (audit Phase 5).
+
+Help's guild configuration is the HLP-3 overlay (hide / rename /
+re-describe, stored in ``help_overlay`` behind the audited
+``services/help_overlay_mutation`` seam) — a dedicated-panel domain, not
+scalar settings. Declaring a :class:`DomainPanelSpec` makes the Settings
+hub discover **Help appearance** as a domain-config group (the #654
+declaration model), routing operators to the same editor the staff hub's
+``✏️ Help editor`` button opens.
+"""
+
+from __future__ import annotations
+
+from core.runtime.subsystem_schema import DomainPanelSpec, SubsystemSchema
+
+HELP_CONFIG_SCHEMA = SubsystemSchema(
+    subsystem="help",
+    domain_panels=(
+        DomainPanelSpec(
+            name="Help appearance",
+            description=(
+                "Hide, rename, or re-describe Help entries for this server "
+                "(display-only — never affects permissions or execution). "
+                "Edited in the Help editor panel; every write is audited."
+            ),
+            capability_required="help.settings.configure",
+        ),
+    ),
+    version=1,
+)
+
+
+def register_schemas() -> None:
+    """Register the Help subsystem schema. Idempotent."""
+    from core.runtime import subsystem_schema
+
+    subsystem_schema.register(HELP_CONFIG_SCHEMA)
+
+
+__all__ = ["HELP_CONFIG_SCHEMA", "register_schemas"]

--- a/disbot/cogs/help_cog.py
+++ b/disbot/cogs/help_cog.py
@@ -286,6 +286,11 @@ class HelpCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
 
+    async def cog_load(self) -> None:
+        from cogs.help.schemas import register_schemas
+
+        register_schemas()  # audit Phase 5 — declares the Help-appearance panel.
+
     @commands.cooldown(rate=3, per=10, type=commands.BucketType.user)
     @commands.command(name="help", aliases=["hilfe"])
     async def help_command(self, ctx: commands.Context, *, category: str = None):

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -677,6 +677,7 @@ SUBSYSTEMS: dict[str, dict] = {
         "ui_priority": 1,
         "capabilities": [
             "help.menu.view",
+            "help.settings.configure",
         ],
     },
     "diagnostic": {

--- a/disbot/views/help/__init__.py
+++ b/disbot/views/help/__init__.py
@@ -1,0 +1,9 @@
+"""Help-appearance editor views (audit Phase 5 — PR A).
+
+Operator UI over the HLP-3 overlay store: hide / rename / re-describe
+hubs and subsystems in Help. Every write goes through the audited
+:mod:`services.help_overlay_mutation` seam; these views own zero policy.
+
+Module:
+    editor — the editor view stack (home → entity picker → entity editor).
+"""

--- a/disbot/views/help/editor.py
+++ b/disbot/views/help/editor.py
@@ -1,0 +1,617 @@
+"""Help overlay editor — the operator UI for guild Help appearance (PR A).
+
+Audit Phase 5 over the shipped HLP-3 seams: edit what ``#659`` made
+storable — per-guild **hide / rename / re-describe** of hubs and
+subsystems — with per-field and full reset. The flow is
+``HelpEditorHomeView`` (counts + reset-all) → ``EntityPickerView``
+(paginated catalogue picker) → ``HelpEntityEditorView`` (one entity).
+
+Contract (plan §4, decisions Q-0055/Q-0056/Q-0058 + Q-0032):
+
+* **Writes only through** :mod:`services.help_overlay_mutation` — one
+  service call per editor action; the views never touch
+  ``utils.db.help_overlay`` and never import an admission path (the
+  Q-0055 fence stays untouched: hiding is display-only, and the editor
+  copy says so).
+* **Authority re-checked at every callback** (opening a panel never
+  authorizes later clicks); the mutation seam re-checks again — the view
+  check exists for friendly copy, not as the gate.
+* **Q-0058 rendering:** every entity shows custom + default + stable key.
+* **Entity choice happens in views** — modals carry only text inputs
+  (a Discord modal cannot contain a select).
+* Entry points (Q-0032 — no new command names): the Server-Management
+  staff hub's ``✏️ Help editor`` button and the Settings hub's
+  "Help appearance" domain group. Both open this view **ephemerally**.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from services.help_catalogue import build_help_catalogue
+from services.help_overlay import get_guild_help_overlay
+from services.help_overlay_mutation import (
+    HelpOverlayMutationError,
+    UnauthorizedHelpOverlayMutationError,
+    reset_guild_overlay,
+    set_overlay_fields,
+)
+from utils.ui_constants import ADMIN_COLOR
+from views.base import BaseView, interaction_is_admin
+
+logger = logging.getLogger("bot.views.help.editor")
+
+# Discord's select-option cap; entity lists paginate past it.
+_PAGE_SIZE = 25
+
+_FOOTER = "Changes are live in Help immediately — verify with 👁 Help Preview"
+
+# Q-0055 copy — hiding never carries execution meaning.
+_HIDDEN_NOTE = "hidden from Help but still executable"
+
+
+# ---------------------------------------------------------------------------
+# Read-model helpers (pure renders over catalogue + overlay)
+# ---------------------------------------------------------------------------
+
+
+def _catalogue_entities(kind: str) -> list[tuple[str, str, str]]:
+    """``(key, default_name, default_description)`` rows for one kind,
+    in the catalogue's render order.
+    """
+    catalogue = build_help_catalogue()
+    if kind == "hub":
+        return [
+            (row.key, row.entry.display_name, row.entry.purpose)
+            for row in catalogue.hubs
+        ]
+    return [
+        (row.key, row.display_name, row.description) for row in catalogue.subsystems
+    ]
+
+
+async def build_editor_home_embed(guild_id: int) -> discord.Embed:
+    """The editor landing embed: current override counts + orphan report."""
+    overlay = await get_guild_help_overlay(guild_id)
+    catalogue = build_help_catalogue()
+    hidden = sum(1 for r in overlay.rows if r.display_hidden)
+    renamed = sum(1 for r in overlay.rows if r.display_name is not None)
+    redescribed = sum(1 for r in overlay.rows if r.description is not None)
+    orphans = [
+        r
+        for r in overlay.rows
+        if (
+            catalogue.hub(r.entity_key)
+            if r.entity_kind == "hub"
+            else catalogue.subsystem(r.entity_key)
+        )
+        is None
+    ]
+    embed = discord.Embed(
+        title="✏️ Help appearance editor",
+        description=(
+            "Customize what **Help** shows in this server: hide entries "
+            f"({_HIDDEN_NOTE}), rename them, or re-describe them. "
+            "Changes apply to Help only — never to permissions or execution."
+        ),
+        color=ADMIN_COLOR,
+    )
+    embed.add_field(
+        name="Current overrides",
+        value=(
+            f"🙈 hidden: **{hidden}** · ✏️ renamed: **{renamed}** · "
+            f"📝 re-described: **{redescribed}**"
+            if overlay.rows
+            else "*(none — Help renders its defaults)*"
+        ),
+        inline=False,
+    )
+    if orphans:
+        keys = ", ".join(f"`{r.entity_key}`" for r in orphans)
+        embed.add_field(
+            name=f"⚠️ Orphaned overrides ({len(orphans)})",
+            value=(
+                f"{keys} — these reference retired Help entries and are "
+                "never rendered. **Reset all** clears them."
+            ),
+            inline=False,
+        )
+    embed.set_footer(text=_FOOTER)
+    return embed
+
+
+async def build_entity_editor_embed(
+    guild_id: int,
+    kind: str,
+    key: str,
+) -> discord.Embed:
+    """One entity's edit card — custom + default + stable key (Q-0058)."""
+    overlay = await get_guild_help_overlay(guild_id)
+    row = overlay.get(kind, key)
+    entities = dict((k, (name, desc)) for k, name, desc in _catalogue_entities(kind))
+    default_name, default_desc = entities.get(key, (key, ""))
+
+    custom_name = row.display_name if row else None
+    custom_desc = row.description if row else None
+    hidden = bool(row.display_hidden) if row else False
+
+    embed = discord.Embed(
+        title=f"✏️ {custom_name or default_name}",
+        description=(
+            f"Editing the **{kind}** `{key}` — every field shows the "
+            "custom value and the default it overrides."
+        ),
+        color=ADMIN_COLOR,
+    )
+    embed.add_field(
+        name="Name",
+        value=(
+            f"custom: **{custom_name}**\ndefault: {default_name}"
+            if custom_name
+            else f"default: **{default_name}** *(no override)*"
+        ),
+        inline=False,
+    )
+    embed.add_field(
+        name="Description",
+        value=(
+            f"custom: **{custom_desc}**\ndefault: {default_desc or '*(none)*'}"
+            if custom_desc
+            else f"default: **{default_desc or '*(none)*'}** *(no override)*"
+        ),
+        inline=False,
+    )
+    embed.add_field(
+        name="Visibility",
+        value=(f"🙈 **Hidden** — {_HIDDEN_NOTE}" if hidden else "👁 Shown (default)"),
+        inline=False,
+    )
+    embed.set_footer(text=f"{_FOOTER} · stable key: {key}")
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Shared authority shell
+# ---------------------------------------------------------------------------
+
+
+class _EditorViewBase(BaseView):
+    """Owner-locked ephemeral view + live admin re-check on every click."""
+
+    def __init__(self, author: discord.abc.User, guild_id: int) -> None:
+        super().__init__(author)
+        self.guild_id = guild_id
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if not await super().interaction_check(interaction):
+            return False
+        if interaction_is_admin(interaction):
+            return True
+        await interaction.response.send_message(
+            "❌ You need **Administrator** permission to edit Help appearance.",
+            ephemeral=True,
+        )
+        return False
+
+
+async def _apply_edit(
+    interaction: discord.Interaction,
+    view: HelpEntityEditorView,
+    **fields,
+) -> None:
+    """One editor action → one audited service call → re-render in place.
+
+    Mutation-contract errors surface as ephemeral copy and leave the
+    editor untouched; the re-read after a successful write is truthful
+    because the seam invalidates the overlay cache.
+    """
+    try:
+        await set_overlay_fields(
+            view.guild_id,
+            view.kind,
+            view.key,
+            actor=interaction.user,
+            **fields,
+        )
+    except UnauthorizedHelpOverlayMutationError:
+        await interaction.response.send_message(
+            "❌ You need **Administrator** permission to edit Help appearance.",
+            ephemeral=True,
+        )
+        return
+    except HelpOverlayMutationError as exc:
+        await interaction.response.send_message(f"❌ {exc}", ephemeral=True)
+        return
+    embed = await build_entity_editor_embed(view.guild_id, view.kind, view.key)
+    refreshed = HelpEntityEditorView(
+        interaction.user,
+        view.guild_id,
+        view.kind,
+        view.key,
+        hidden=_embed_says_hidden(embed),
+    )
+    await interaction.response.edit_message(embed=embed, view=refreshed)
+
+
+def _embed_says_hidden(embed: discord.Embed) -> bool:
+    visibility = next((f.value for f in embed.fields if f.name == "Visibility"), "")
+    return "Hidden" in visibility
+
+
+# ---------------------------------------------------------------------------
+# Modals (text inputs only — entity choice already happened in the view)
+# ---------------------------------------------------------------------------
+
+
+class _RenameModal(discord.ui.Modal, title="Rename in Help"):  # type: ignore[call-arg]
+    name_input = discord.ui.TextInput(  # type: ignore[var-annotated]
+        label="Custom display name (Help only)",
+        max_length=100,  # MAX_DISPLAY_NAME_LEN — the seam re-validates
+    )
+
+    def __init__(self, view: HelpEntityEditorView):
+        super().__init__()
+        self.view = view
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        await _apply_edit(interaction, self.view, display_name=self.name_input.value)
+
+
+class _RedescribeModal(discord.ui.Modal, title="Re-describe in Help"):  # type: ignore[call-arg]
+    description_input = discord.ui.TextInput(  # type: ignore[var-annotated]
+        label="Custom description (Help only)",
+        max_length=100,  # MAX_DESCRIPTION_LEN — the seam re-validates
+    )
+
+    def __init__(self, view: HelpEntityEditorView):
+        super().__init__()
+        self.view = view
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        await _apply_edit(
+            interaction,
+            self.view,
+            description=self.description_input.value,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Entity editor (one hub/subsystem)
+# ---------------------------------------------------------------------------
+
+
+class HelpEntityEditorView(_EditorViewBase):
+    """Edit one entity's overlay fields — every button is one seam call."""
+
+    def __init__(
+        self,
+        author: discord.abc.User,
+        guild_id: int,
+        kind: str,
+        key: str,
+        *,
+        hidden: bool = False,
+    ) -> None:
+        super().__init__(author, guild_id)
+        self.kind = kind
+        self.key = key
+        self._relabel_hide_button(hidden)
+
+    def _relabel_hide_button(self, hidden: bool) -> None:
+        self.hide_btn.label = "👁 Unhide" if hidden else "🙈 Hide"
+        self.hide_btn.style = (
+            discord.ButtonStyle.success if hidden else discord.ButtonStyle.secondary
+        )
+        self._hidden = hidden
+
+    @discord.ui.button(label="🙈 Hide", style=discord.ButtonStyle.secondary, row=0)
+    async def hide_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        # Unhide resets the field to inherit (None) — the store keeps only
+        # deviations, so an all-default row disappears entirely.
+        await _apply_edit(
+            interaction,
+            self,
+            display_hidden=None if self._hidden else True,
+        )
+
+    @discord.ui.button(label="✏️ Rename…", style=discord.ButtonStyle.primary, row=0)
+    async def rename_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        await interaction.response.send_modal(_RenameModal(self))
+
+    @discord.ui.button(
+        label="📝 Re-describe…",
+        style=discord.ButtonStyle.primary,
+        row=0,
+    )
+    async def redescribe_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ):
+        await interaction.response.send_modal(_RedescribeModal(self))
+
+    @discord.ui.button(
+        label="♻️ Reset name",
+        style=discord.ButtonStyle.secondary,
+        row=1,
+    )
+    async def reset_name_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ):
+        await _apply_edit(interaction, self, display_name=None)
+
+    @discord.ui.button(
+        label="♻️ Reset description",
+        style=discord.ButtonStyle.secondary,
+        row=1,
+    )
+    async def reset_desc_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ):
+        await _apply_edit(interaction, self, description=None)
+
+    @discord.ui.button(label="🗑 Reset entity", style=discord.ButtonStyle.danger, row=1)
+    async def reset_entity_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ):
+        await _apply_edit(
+            interaction,
+            self,
+            display_hidden=None,
+            display_name=None,
+            description=None,
+        )
+
+    @discord.ui.button(label="◀ Back", style=discord.ButtonStyle.secondary, row=2)
+    async def back_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        picker = EntityPickerView(interaction.user, self.guild_id, self.kind)
+        await interaction.response.edit_message(
+            embed=await picker.build_embed(),
+            view=picker,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Entity picker (paginated catalogue select)
+# ---------------------------------------------------------------------------
+
+
+class _EntitySelect(discord.ui.Select):
+    """One page of catalogue entities; label = effective display (Q-0058)."""
+
+    def __init__(
+        self,
+        kind: str,
+        page_rows: list[tuple[str, str, bool, str]],
+        *,
+        page: int,
+        pages: int,
+    ) -> None:
+        options = [
+            discord.SelectOption(
+                label=(f"🙈 {label}" if hidden else label)[:100],
+                value=key,
+                description=f"default: {default} · {key}"[:100],
+            )
+            for key, label, hidden, default in page_rows
+        ]
+        placeholder = f"Pick a {kind} to edit…"
+        if pages > 1:
+            placeholder += f" (page {page + 1}/{pages})"
+        super().__init__(
+            placeholder=placeholder,
+            options=options
+            or [discord.SelectOption(label="(nothing to edit)", value="-")],
+        )
+        self.kind = kind
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        from core.runtime.interaction_helpers import safe_defer
+
+        view: EntityPickerView = self.view  # type: ignore[assignment]
+        key = self.values[0]
+        if key == "-":
+            await safe_defer(interaction)
+            return
+        embed = await build_entity_editor_embed(view.guild_id, self.kind, key)
+        editor = HelpEntityEditorView(
+            interaction.user,
+            view.guild_id,
+            self.kind,
+            key,
+            hidden=_embed_says_hidden(embed),
+        )
+        await interaction.response.edit_message(embed=embed, view=editor)
+
+
+class EntityPickerView(_EditorViewBase):
+    """Paginated picker over the Help catalogue (hubs or subsystems)."""
+
+    def __init__(
+        self,
+        author: discord.abc.User,
+        guild_id: int,
+        kind: str,
+        *,
+        page: int = 0,
+    ) -> None:
+        super().__init__(author, guild_id)
+        self.kind = kind
+        self.page = page
+
+    async def build_embed(self) -> discord.Embed:
+        """(Re)compose the page: select + nav, embed describing the kind."""
+        overlay = await get_guild_help_overlay(self.guild_id)
+        rows: list[tuple[str, str, bool, str]] = []
+        for key, default_name, _desc in _catalogue_entities(self.kind):
+            override = overlay.get(self.kind, key)
+            label = (
+                override.display_name
+                if override is not None and override.display_name is not None
+                else default_name
+            )
+            hidden = bool(override.display_hidden) if override is not None else False
+            rows.append((key, label, hidden, default_name))
+
+        pages = max(1, -(-len(rows) // _PAGE_SIZE))
+        self.page = max(0, min(self.page, pages - 1))
+        start = self.page * _PAGE_SIZE
+        page_rows = rows[start : start + _PAGE_SIZE]
+
+        self.clear_items()
+        self.add_item(_EntitySelect(self.kind, page_rows, page=self.page, pages=pages))
+        if pages > 1:
+            self.add_item(_PageNavButton(delta=-1, page=self.page, pages=pages))
+            self.add_item(_PageNavButton(delta=+1, page=self.page, pages=pages))
+        self.add_item(_BackToHomeButton())
+
+        plural = "hubs" if self.kind == "hub" else "subsystems"
+        embed = discord.Embed(
+            title=f"✏️ Help editor — {plural}",
+            description=(
+                f"Pick a {self.kind} to hide, rename, or re-describe. "
+                "🙈 marks entries currently hidden from Help."
+            ),
+            color=ADMIN_COLOR,
+        )
+        embed.set_footer(text=_FOOTER)
+        return embed
+
+
+class _PageNavButton(discord.ui.Button):
+    def __init__(self, *, delta: int, page: int, pages: int) -> None:
+        super().__init__(
+            label="◀ Prev" if delta < 0 else "Next ▶",
+            style=discord.ButtonStyle.secondary,
+            disabled=(page + delta) < 0 or (page + delta) >= pages,
+            row=1,
+        )
+        self._delta = delta
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: EntityPickerView = self.view  # type: ignore[assignment]
+        view.page += self._delta
+        await interaction.response.edit_message(
+            embed=await view.build_embed(),
+            view=view,
+        )
+
+
+class _BackToHomeButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(label="◀ Back", style=discord.ButtonStyle.secondary, row=2)
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: EntityPickerView = self.view  # type: ignore[assignment]
+        home = HelpEditorHomeView(interaction.user, view.guild_id)
+        await interaction.response.edit_message(
+            embed=await build_editor_home_embed(view.guild_id),
+            view=home,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Reset-all confirm step
+# ---------------------------------------------------------------------------
+
+
+class _ResetAllConfirmView(_EditorViewBase):
+    """Two-step destructive reset: nothing is written until Confirm."""
+
+    @discord.ui.button(
+        label="🗑 Yes, reset everything",
+        style=discord.ButtonStyle.danger,
+    )
+    async def confirm_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ):
+        try:
+            await reset_guild_overlay(self.guild_id, actor=interaction.user)
+        except HelpOverlayMutationError as exc:
+            await interaction.response.send_message(f"❌ {exc}", ephemeral=True)
+            return
+        home = HelpEditorHomeView(interaction.user, self.guild_id)
+        await interaction.response.edit_message(
+            embed=await build_editor_home_embed(self.guild_id),
+            view=home,
+        )
+
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.secondary)
+    async def cancel_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ):
+        home = HelpEditorHomeView(interaction.user, self.guild_id)
+        await interaction.response.edit_message(
+            embed=await build_editor_home_embed(self.guild_id),
+            view=home,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Editor home
+# ---------------------------------------------------------------------------
+
+
+class HelpEditorHomeView(_EditorViewBase):
+    """Landing view: override counts + the three editing lanes."""
+
+    @discord.ui.button(label="🏛 Hubs", style=discord.ButtonStyle.primary, row=0)
+    async def hubs_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        picker = EntityPickerView(interaction.user, self.guild_id, "hub")
+        await interaction.response.edit_message(
+            embed=await picker.build_embed(),
+            view=picker,
+        )
+
+    @discord.ui.button(label="🧩 Subsystems", style=discord.ButtonStyle.primary, row=0)
+    async def subsystems_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ):
+        picker = EntityPickerView(interaction.user, self.guild_id, "subsystem")
+        await interaction.response.edit_message(
+            embed=await picker.build_embed(),
+            view=picker,
+        )
+
+    @discord.ui.button(label="🗑 Reset all…", style=discord.ButtonStyle.danger, row=1)
+    async def reset_all_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ):
+        embed = discord.Embed(
+            title="Reset ALL Help customizations?",
+            description=(
+                "Every hide, rename, and re-description in this server will "
+                "be removed and Help returns to its defaults. This cannot be "
+                "undone (the audit log keeps the history)."
+            ),
+            color=discord.Color.red(),
+        )
+        await interaction.response.edit_message(
+            embed=embed,
+            view=_ResetAllConfirmView(interaction.user, self.guild_id),
+        )
+
+
+__all__ = [
+    "EntityPickerView",
+    "HelpEditorHomeView",
+    "HelpEntityEditorView",
+    "build_editor_home_embed",
+    "build_entity_editor_embed",
+]

--- a/disbot/views/server_management/hub.py
+++ b/disbot/views/server_management/hub.py
@@ -311,6 +311,40 @@ class ServerManagementHubView(PersistentView):
         await safe_edit(interaction, embed=embed, view=sub_view)
 
     @discord.ui.button(
+        label="✏️ Help editor",
+        style=discord.ButtonStyle.secondary,
+        row=2,
+        custom_id="server_management:help_editor",
+    )
+    async def help_editor_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        """Open the Help appearance editor (audit Phase 5) — ephemeral,
+        beside 👁 Help Preview so operators edit and verify side by side.
+        """
+        from views.help.editor import HelpEditorHomeView, build_editor_home_embed
+
+        if interaction.guild is None:
+            await interaction.response.send_message(
+                "The hub is only available inside a server.",
+                ephemeral=True,
+            )
+            return
+        if not interaction_is_admin(interaction):
+            await interaction.response.send_message(
+                "❌ You need **Administrator** permission to edit Help appearance.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_message(
+            embed=await build_editor_home_embed(interaction.guild.id),
+            view=HelpEditorHomeView(interaction.user, interaction.guild.id),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
         label="🔄 Refresh",
         style=discord.ButtonStyle.secondary,
         row=2,

--- a/tests/unit/cogs/test_help_schemas.py
+++ b/tests/unit/cogs/test_help_schemas.py
@@ -1,0 +1,55 @@
+"""Help "Help appearance" domain panel (audit Phase 5, PR A).
+
+Pins the Settings-hub entry point: the schema declares the domain panel,
+the capability is registered (identity contract), and the hub's §6
+inclusion rule discovers Help as a domain-config group.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cogs.help.schemas import HELP_CONFIG_SCHEMA, register_schemas
+from core.runtime import settings_registry
+from core.runtime import subsystem_schema as schema_mod
+
+
+@pytest.fixture(autouse=True)
+def _isolated_schema_state():
+    saved = schema_mod.all_schemas()
+    schema_mod._reset_for_tests()
+    settings_registry._reset_for_tests()
+    yield
+    schema_mod._reset_for_tests()
+    for schema in saved.values():
+        schema_mod.register(schema)
+    settings_registry._reset_for_tests()
+
+
+def test_schema_declares_the_help_appearance_panel():
+    panel = HELP_CONFIG_SCHEMA.domain_panels[0]
+    assert panel.name == "Help appearance"
+    assert panel.capability_required == "help.settings.configure"
+    # Q-0055 — the copy must carry the display-only guarantee.
+    assert "display-only" in panel.description
+
+
+def test_capability_is_declared_in_registry():
+    from utils.subsystem_registry import SUBSYSTEMS
+
+    assert "help.settings.configure" in SUBSYSTEMS["help"]["capabilities"]
+
+
+def test_settings_hub_discovers_help_as_domain_group():
+    from services.customization_catalogue import actionable_settings_groups
+
+    register_schemas()
+    groups = {g.subsystem: g for g in actionable_settings_groups()}
+    assert "help" in groups
+    assert groups["help"].has_domain_panel is True
+
+
+def test_register_schemas_is_idempotent():
+    register_schemas()
+    register_schemas()
+    assert "help" in schema_mod.all_schemas()

--- a/tests/unit/invariants/test_domain_panel_declarations.py
+++ b/tests/unit/invariants/test_domain_panel_declarations.py
@@ -35,9 +35,11 @@ _COGS_DIR = _REPO_ROOT / "disbot" / "cogs"
 # The deliberate contract: subsystems whose Settings group is a domain-config
 # destination. Audit §4 verified cleanup as the one real domain-panel group
 # (governance cleanup-policy tables + dedicated panel; empty scalar page).
+# help joined 2026-06-10 (help audit Phase 5): the "Help appearance" panel —
+# the HLP-3 overlay editor behind the audited help_overlay_mutation seam.
 # Adding a subsystem here requires a real DomainPanelSpec declaration in its
 # cogs/<subsystem>/schemas.py — and vice versa.
-_EXPECTED_DOMAIN_PANELS: frozenset[str] = frozenset({"cleanup"})
+_EXPECTED_DOMAIN_PANELS: frozenset[str] = frozenset({"cleanup", "help"})
 
 
 @pytest.fixture()
@@ -90,15 +92,14 @@ def test_domain_panel_declarations_are_well_formed(_registered_declared_schemas)
     for name, schema in _registered_declared_schemas.items():
         for spec in schema.domain_panels:
             assert name in SUBSYSTEMS, (
-                f"{name!r} declares a domain panel but is not a registered "
-                "subsystem"
+                f"{name!r} declares a domain panel but is not a registered " "subsystem"
             )
-            assert spec.name.strip(), (
-                f"{name!r} domain panel needs an operator-facing name"
-            )
-            assert spec.description.strip(), (
-                f"{name!r} domain panel needs a one-line description"
-            )
+            assert (
+                spec.name.strip()
+            ), f"{name!r} domain panel needs an operator-facing name"
+            assert (
+                spec.description.strip()
+            ), f"{name!r} domain panel needs a one-line description"
 
 
 def test_catalogue_consumes_the_declarations(_registered_declared_schemas):

--- a/tests/unit/views/test_help_editor.py
+++ b/tests/unit/views/test_help_editor.py
@@ -1,0 +1,339 @@
+"""Help overlay editor (audit Phase 5, PR A).
+
+Pins the plan §6 contract: admin re-checked at callback time (non-admin →
+no write), every editor action is exactly one audited mutation-service
+call, reset-all has a mandatory confirm step, pickers render custom +
+default + stable key (Q-0058) with 🙈 hidden markers, and mutation-contract
+errors surface as copy instead of crashes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from services.help_overlay import GuildHelpOverlay, HelpOverlayRow
+from services.help_overlay_mutation import InvalidHelpOverlayValueError
+from views.help.editor import (
+    EntityPickerView,
+    HelpEditorHomeView,
+    HelpEntityEditorView,
+    _EntitySelect,
+    _ResetAllConfirmView,
+    build_editor_home_embed,
+    build_entity_editor_embed,
+)
+
+GUILD = 99
+
+
+def _interaction(*, admin: bool = True, user_id: int = 1) -> MagicMock:
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.guild.id = GUILD
+    interaction.user = MagicMock()
+    interaction.user.id = user_id
+    interaction.user.guild_permissions = MagicMock(administrator=admin)
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.send_modal = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    return interaction
+
+
+def _catalogue() -> MagicMock:
+    hub_entry = MagicMock()
+    hub_entry.display_name = "Games"
+    hub_entry.purpose = "Play games"
+    hub_row = MagicMock(key="games", entry=hub_entry)
+
+    sub_row = MagicMock()
+    sub_row.key = "economy"
+    sub_row.display_name = "Economy"
+    sub_row.description = "Coins and jobs"
+
+    catalogue = MagicMock()
+    catalogue.hubs = (hub_row,)
+    catalogue.subsystems = (sub_row,)
+    catalogue.hub = lambda key: hub_row if key == "games" else None
+    catalogue.subsystem = lambda key: sub_row if key == "economy" else None
+    return catalogue
+
+
+def _overlay(*rows: HelpOverlayRow) -> GuildHelpOverlay:
+    return GuildHelpOverlay(guild_id=GUILD, rows=tuple(rows))
+
+
+def _patched(overlay: GuildHelpOverlay):
+    return (
+        patch(
+            "views.help.editor.get_guild_help_overlay",
+            AsyncMock(return_value=overlay),
+        ),
+        patch("views.help.editor.build_help_catalogue", return_value=_catalogue()),
+        patch(
+            "views.help.editor.set_overlay_fields",
+            AsyncMock(return_value=MagicMock()),
+        ),
+        patch(
+            "views.help.editor.reset_guild_overlay",
+            AsyncMock(return_value=MagicMock()),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Authority — re-checked at callback time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_admin_is_denied_at_callback_time_without_write():
+    author = MagicMock(id=1)
+    for view in (
+        HelpEditorHomeView(author, GUILD),
+        EntityPickerView(author, GUILD, "subsystem"),
+        HelpEntityEditorView(author, GUILD, "subsystem", "economy"),
+        _ResetAllConfirmView(author, GUILD),
+    ):
+        interaction = _interaction(admin=False)
+        allowed = await view.interaction_check(interaction)
+        assert allowed is False
+        assert "Administrator" in interaction.response.send_message.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_admin_passes_callback_check():
+    view = HelpEditorHomeView(MagicMock(id=1), GUILD)
+    assert await view.interaction_check(_interaction(admin=True)) is True
+
+
+# ---------------------------------------------------------------------------
+# Entity editor — one action, one audited service call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hide_button_writes_display_hidden_true():
+    overlay_p, cat_p, set_p, reset_p = _patched(_overlay())
+    view = HelpEntityEditorView(MagicMock(id=1), GUILD, "subsystem", "economy")
+    interaction = _interaction()
+    with overlay_p, cat_p, set_p as set_mock, reset_p:
+        await type(view).hide_btn(view, interaction, MagicMock())
+
+    set_mock.assert_awaited_once()
+    kwargs = set_mock.await_args.kwargs
+    assert kwargs["display_hidden"] is True
+    args = set_mock.await_args.args
+    assert args == (GUILD, "subsystem", "economy")
+    interaction.response.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unhide_resets_field_to_inherit():
+    hidden_row = HelpOverlayRow(
+        entity_kind="subsystem",
+        entity_key="economy",
+        display_hidden=True,
+    )
+    overlay_p, cat_p, set_p, reset_p = _patched(_overlay(hidden_row))
+    view = HelpEntityEditorView(
+        MagicMock(id=1),
+        GUILD,
+        "subsystem",
+        "economy",
+        hidden=True,
+    )
+    with overlay_p, cat_p, set_p as set_mock, reset_p:
+        await type(view).hide_btn(view, _interaction(), MagicMock())
+
+    assert set_mock.await_args.kwargs["display_hidden"] is None
+
+
+@pytest.mark.asyncio
+async def test_reset_entity_resets_all_three_fields():
+    overlay_p, cat_p, set_p, reset_p = _patched(_overlay())
+    view = HelpEntityEditorView(MagicMock(id=1), GUILD, "subsystem", "economy")
+    with overlay_p, cat_p, set_p as set_mock, reset_p:
+        await type(view).reset_entity_btn(view, _interaction(), MagicMock())
+
+    kwargs = set_mock.await_args.kwargs
+    assert kwargs["display_hidden"] is None
+    assert kwargs["display_name"] is None
+    assert kwargs["description"] is None
+
+
+@pytest.mark.asyncio
+async def test_mutation_error_surfaces_as_copy_not_crash():
+    overlay_p, cat_p, set_p, reset_p = _patched(_overlay())
+    view = HelpEntityEditorView(MagicMock(id=1), GUILD, "subsystem", "economy")
+    interaction = _interaction()
+    with overlay_p, cat_p, set_p as set_mock, reset_p:
+        set_mock.side_effect = InvalidHelpOverlayValueError("display_name too long")
+        await type(view).rename_btn(view, interaction, MagicMock())
+        # rename opens a modal; drive its submit directly
+        modal = interaction.response.send_modal.await_args.args[0]
+        modal.name_input = MagicMock(value="x" * 5)
+        submit_interaction = _interaction()
+        await modal.on_submit(submit_interaction)
+
+    msg = submit_interaction.response.send_message.await_args
+    assert "display_name too long" in msg.args[0]
+    assert msg.kwargs["ephemeral"] is True
+    submit_interaction.response.edit_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Reset-all — confirm step is mandatory
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reset_all_first_click_writes_nothing():
+    overlay_p, cat_p, set_p, reset_p = _patched(_overlay())
+    view = HelpEditorHomeView(MagicMock(id=1), GUILD)
+    interaction = _interaction()
+    with overlay_p, cat_p, set_p, reset_p as reset_mock:
+        await type(view).reset_all_btn(view, interaction, MagicMock())
+
+    reset_mock.assert_not_awaited()
+    # ...and the confirm view is now on the message.
+    new_view = interaction.response.edit_message.await_args.kwargs["view"]
+    assert isinstance(new_view, _ResetAllConfirmView)
+
+
+@pytest.mark.asyncio
+async def test_reset_all_confirm_performs_the_audited_reset():
+    overlay_p, cat_p, set_p, reset_p = _patched(_overlay())
+    view = _ResetAllConfirmView(MagicMock(id=1), GUILD)
+    interaction = _interaction()
+    with overlay_p, cat_p, set_p, reset_p as reset_mock:
+        await type(view).confirm_btn(view, interaction, MagicMock())
+
+    reset_mock.assert_awaited_once()
+    assert reset_mock.await_args.args == (GUILD,)
+
+
+# ---------------------------------------------------------------------------
+# Picker + embeds — Q-0058 rendering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_picker_renders_custom_name_hidden_marker_and_default_key():
+    rows = (
+        HelpOverlayRow(
+            entity_kind="subsystem",
+            entity_key="economy",
+            display_hidden=True,
+            display_name="Bank",
+        ),
+    )
+    overlay_p, cat_p, set_p, reset_p = _patched(_overlay(*rows))
+    picker = EntityPickerView(MagicMock(id=1), GUILD, "subsystem")
+    with overlay_p, cat_p, set_p, reset_p:
+        await picker.build_embed()
+
+    select = next(c for c in picker.children if isinstance(c, _EntitySelect))
+    option = select.options[0]
+    assert option.label == "🙈 Bank"  # custom name + hidden marker
+    assert option.value == "economy"
+    assert "default: Economy" in option.description  # Q-0058
+    assert "economy" in option.description  # stable key
+
+
+@pytest.mark.asyncio
+async def test_entity_embed_shows_custom_default_and_key():
+    rows = (
+        HelpOverlayRow(
+            entity_kind="subsystem",
+            entity_key="economy",
+            display_name="Bank",
+        ),
+    )
+    overlay_p, cat_p, set_p, reset_p = _patched(_overlay(*rows))
+    with overlay_p, cat_p, set_p, reset_p:
+        embed = await build_entity_editor_embed(GUILD, "subsystem", "economy")
+
+    name_field = next(f for f in embed.fields if f.name == "Name")
+    assert "Bank" in name_field.value and "Economy" in name_field.value
+    assert "economy" in (embed.footer.text or "")
+
+
+@pytest.mark.asyncio
+async def test_home_embed_counts_and_orphans():
+    rows = (
+        HelpOverlayRow(
+            entity_kind="subsystem",
+            entity_key="economy",
+            display_hidden=True,
+        ),
+        HelpOverlayRow(
+            entity_kind="subsystem",
+            entity_key="retired_thing",
+            display_name="Ghost",
+        ),
+    )
+    overlay_p, cat_p, set_p, reset_p = _patched(_overlay(*rows))
+    with overlay_p, cat_p, set_p, reset_p:
+        embed = await build_editor_home_embed(GUILD)
+
+    counts = next(f for f in embed.fields if f.name == "Current overrides")
+    assert "hidden: **1**" in counts.value
+    assert "renamed: **1**" in counts.value
+    orphan_field = next(f for f in embed.fields if "Orphaned" in f.name)
+    assert "retired_thing" in orphan_field.value
+
+
+@pytest.mark.asyncio
+async def test_select_opens_entity_editor():
+    overlay_p, cat_p, set_p, reset_p = _patched(_overlay())
+    picker = EntityPickerView(MagicMock(id=1), GUILD, "subsystem")
+    with overlay_p, cat_p, set_p, reset_p:
+        await picker.build_embed()
+        select = next(c for c in picker.children if isinstance(c, _EntitySelect))
+        select._values = ["economy"]  # discord.py populates from the payload
+        interaction = _interaction()
+        with patch.object(
+            type(select),
+            "values",
+            property(lambda self: ["economy"]),
+        ):
+            await select.callback(interaction)
+
+    new_view = interaction.response.edit_message.await_args.kwargs["view"]
+    assert isinstance(new_view, HelpEntityEditorView)
+    assert new_view.key == "economy"
+
+
+# ---------------------------------------------------------------------------
+# Display-only guarantee — the editor module imports no admission path
+# ---------------------------------------------------------------------------
+
+
+def test_editor_module_imports_only_the_audited_seam():
+    import ast
+    from pathlib import Path
+
+    src = (
+        Path(__file__).resolve().parents[3] / "disbot" / "views" / "help" / "editor.py"
+    ).read_text()
+    imported: set[str] = set()
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+        elif isinstance(node, ast.Import):
+            imported.update(a.name for a in node.names)
+    # Writes only through the audited seam; no db module, no admission path.
+    assert "services.help_overlay_mutation" in imported
+    assert not any("utils.db" in m for m in imported)
+    assert not any("command_access" in m or "governance" in m for m in imported)
+
+
+def test_editor_copy_says_display_only():
+    """Q-0055: hidden entries are labeled still-executable."""
+    from views.help.editor import _HIDDEN_NOTE
+
+    assert "still executable" in _HIDDEN_NOTE

--- a/tests/unit/views/test_server_management_hub_view.py
+++ b/tests/unit/views/test_server_management_hub_view.py
@@ -40,6 +40,7 @@ _BUTTON_IDS = {
     "server_management:setup",
     "server_management:access_map",
     "server_management:help_preview",
+    "server_management:help_editor",
     "server_management:refresh",
 }
 
@@ -103,11 +104,7 @@ def test_view_constructs_with_no_args_for_restoration():
 
 def test_view_has_expected_button_custom_ids():
     view = ServerManagementHubView()
-    actual = {
-        c.custom_id
-        for c in view.children
-        if isinstance(c, discord.ui.Button)
-    }
+    actual = {c.custom_id for c in view.children if isinstance(c, discord.ui.Button)}
     assert actual == _BUTTON_IDS
 
 
@@ -187,8 +184,7 @@ async def test_open_manager_routes_and_attaches_back_button():
     back = [
         c
         for c in child_view.children
-        if isinstance(c, discord.ui.Button)
-        and c.custom_id == "server_management:back"
+        if isinstance(c, discord.ui.Button) and c.custom_id == "server_management:back"
     ]
     assert len(back) == 1
 
@@ -272,11 +268,13 @@ async def test_setup_button_opens_wizard_entry():
 async def test_refresh_recomposes_in_place():
     view = ServerManagementHubView()
     interaction = _interaction()
-    with patch.object(
-        hub_mod, "collect_hub_status", new=AsyncMock(return_value=_status())
-    ), patch.object(
-        hub_mod, "safe_defer", new=AsyncMock(return_value=True)
-    ), patch.object(hub_mod, "safe_edit", new=AsyncMock()) as mock_edit:
+    with (
+        patch.object(
+            hub_mod, "collect_hub_status", new=AsyncMock(return_value=_status())
+        ),
+        patch.object(hub_mod, "safe_defer", new=AsyncMock(return_value=True)),
+        patch.object(hub_mod, "safe_edit", new=AsyncMock()) as mock_edit,
+    ):
         await _button(view, "server_management:refresh").callback(interaction)
     mock_edit.assert_awaited_once()
     _args, kwargs = mock_edit.call_args
@@ -327,9 +325,7 @@ def test_no_module_level_cogs_import():
     src = inspect.getsource(hub_mod)
     tree = ast.parse(src)
     for node in tree.body:  # module-level statements only
-        if isinstance(node, ast.ImportFrom) and (node.module or "").startswith(
-            "cogs"
-        ):
+        if isinstance(node, ast.ImportFrom) and (node.module or "").startswith("cogs"):
             pytest.fail(f"module-level cogs import: from {node.module}")
         if isinstance(node, ast.Import):
             for alias in node.names:


### PR DESCRIPTION
# Help overlay editor UI — PR A (audit Phase 5)

Executes PR A of the [editor UI plan](docs/planning/help-overlay-editor-ui-plan-2026-06-10.md) (#674 — "ready to execute, no gates"). Operators can now **click-edit** what #659 made storable: per-guild Help hide / rename / re-describe, with per-field and full reset. Closes the eval checklist's "nothing for you to click-edit yet" gap. **No migration** — every write rides the shipped audited `help_overlay_mutation` seam.

## What's in it

- **`views/help/editor.py`** (new): `HelpEditorHomeView` (override counts + orphan report + two-step Reset-all) → `EntityPickerView` (paginated catalogue select; labels show the custom name with 🙈 hidden markers; descriptions carry `default · stable key` per Q-0058) → `HelpEntityEditorView` (Hide/Unhide toggle, Rename…/Re-describe… modals, per-field + whole-entity resets). One audited service call per action; unhide resets to inherit (store keeps only deviations); mutation-contract errors render as ephemeral copy.
- **Entry points (Q-0032 — no new commands):** an `✏️ Help editor` staff-hub button beside 👁 Help Preview (edit and verify side by side, ephemeral open), and a **"Help appearance"** `DomainPanelSpec` (`cogs/help/schemas.py` + the `help.settings.configure` capability) so the Settings hub discovers it as a domain group.
- **Q-0055 honored everywhere:** hidden entries labeled "hidden from Help but still executable"; the editor module imports no admission path (pinned by test); admin re-checked at every callback (opening ≠ authority).
- Deliberate pin updates: `_EXPECTED_DOMAIN_PANELS` += `help`; hub `_BUTTON_IDS` += `server_management:help_editor`.

## Verification

- CI mirror: **8,877 passed / 22 skipped** (+16 new tests); arch strict **0 errors**; `check_docs` green.
- Clean boot; identity contract **clean** (STRICT=on) with the new capability.
- **Live Postgres round-trip driven through the editor's own callbacks:** hide → the live Help projection returns `display_hidden`/`overlay_hidden`; rename → Help renders "Number Train" (default preserved per Q-0058); Reset-all → 0 rows, byte-identical default; audit rows present.

**PR B** (the Q-0059 Home-message embed builder — migration 067, mandatory preview) follows as its own PR per the plan's risk slicing.

https://claude.ai/code/session_01FMzazcQJGMSuLSfE6NUQp3

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMzazcQJGMSuLSfE6NUQp3)_