### PR TITLE
Capture idea: bot self-test walker + AI eval mode (brainstorm round 3)

### DIFF
--- a/.sessions/2026-06-10-vision-ideation-capture.md
+++ b/.sessions/2026-06-10-vision-ideation-capture.md
@@ -153,6 +153,21 @@ Calibration: this is the second same-day instance of the owner moving
 *further* than his earlier stated position once shown a concrete mechanism
 (Q-0084 merge grant, now Q-0088) — consistent with the §35 calibration note.
 
+## Brainstorm round 3: "can the bot test itself?" → idea captured
+
+Owner idea (his own invention, articulated without coding background): every
+command fired in sequence via temporary event-based actions + AI prompts
+injected "at system level" per event. Captured + technically corrected into
+[`docs/ideas/bot-self-test-walker-2026-06-10.md`](../docs/ideas/bot-self-test-walker-2026-06-10.md):
+in-process synthetic invocation (bots ignore bot messages — Discord-level
+self-driving is impossible), driver loop over the command-surface ledger
+instead of event chaining, EventBus as assertion witness, governance
+audience simulation (Q-0045) for tiered walks, scratch test guild +
+lifecycle wipe, AI eval mode through the real pipeline using the Q-0086
+keys, permanent owner-gated infrastructure rather than temporary. Routed:
+ideas README + roadmap queue item 1 pointer (the walker is the checklist
+session's automation follow-on and the Stage 1 caretaker's probe set).
+
 ## Context delta (reflection interview)
 
 - **Route miss:** none serious — CLAUDE.md → current-state → ideas/README →

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -18,6 +18,13 @@ Pure brainstorm backlogs — capture without commitment. Each file should carry 
 
 Current broad captures:
 
+- [`bot-self-test-walker-2026-06-10.md`](./bot-self-test-walker-2026-06-10.md) —
+  owner idea (brainstorm round 3): **the bot tests itself** — an owner-gated
+  in-process walker that synthetically invokes every ledger-listed command
+  (EventBus as witness, governance audience simulation, scratch test guild)
+  + an AI eval mode running scripted prompts through the real pipeline
+  (Q-0086 keys). Pairs with the commissioned untested-surface testing
+  checklist; candidate probe set for the workflow-§10 Stage 1 caretaker.
 - [`superbot-vision-2026-06-10.md`](./superbot-vision-2026-06-10.md) — the
   maintainer's written **product vision statement** (2-minute setup, panel
   navigation doctrine, 4-button help home, per-user preferences, RPG

--- a/docs/ideas/bot-self-test-walker-2026-06-10.md
+++ b/docs/ideas/bot-self-test-walker-2026-06-10.md
@@ -1,0 +1,70 @@
+# Bot self-testing: the command walker + AI eval mode
+
+> **Status:** `ideas` — owner idea, captured 2026-06-10 (brainstorm round 3, the
+> vision-capture conversation). **Not a plan, not approval.** Natural sequencing:
+> pairs with the commissioned **untested-surface testing checklist** session
+> (roadmap session queue item 1) — the checklist *enumerates*, this *automates*.
+
+## The owner's idea (2026-06-10, lightly condensed)
+
+> "Would it be possible that the bot actually test itself? … you could
+> temporarily create event based actions that would trigger every command to
+> fire in sequence, so one command triggers the next, and for AI you could
+> probably inject prompts at system level, so AI gets prompted on top of its
+> existing harness something like 'what can you tell me about btd6' but that
+> question would also have to be triggered per on event."
+
+Two adjustments from the agent (accepted in-conversation, see the session log):
+**(1)** bots can't drive themselves through Discord messages (the standard
+`author.bot` guard ignores them) — the right mechanism is **in-process synthetic
+invocation**: a driver iterates the command registry and calls each command's
+callback with a synthetic ctx/interaction whose `send` *captures* output.
+**(2)** a **driver loop** beats event-chaining for sequencing (deterministic
+order, per-step timeout, one report); the EventBus is instead the **witness** —
+the walker asserts that each action emitted its expected catalogued event.
+And one upgrade: build it **permanent and owner-gated**, not temporary — wired
+to the command ledger, every future command joins the walk automatically.
+
+## Why SuperBot is unusually well-positioned for this (existing substrate)
+
+- **Command surface ledger** (`test_command_surface_ledger.py` family) — a
+  machine-readable inventory of every command: the walker's worklist.
+- **Help catalogue / projection** (#657) — stable-keyed inventory of every
+  surface + reason-coded availability: tells the walker what *should* be
+  invocable for a given audience.
+- **Governance audience simulation** (Q-0045, #632: `GovernanceContext.member_tier`,
+  simulation-labeled) — walk the same command as member/staff/admin without
+  real accounts.
+- **EventBus + delivery stats (#681)** — assertion by observation: "did
+  `audit.action_recorded` fire?"; per-event delivery stats give the walker a
+  built-in scoreboard.
+- **Audited mutation seams** — every write the walker triggers is recorded;
+  a scratch **test guild** + the `guild_lifecycle` delete hooks give clean
+  setup/teardown.
+- **AI answerability tools (#639)** — `btd6_answerability` / tool catalog =
+  machine-checkable ground truth for AI answers.
+- **Q-0086 provider keys in session env** — the AI eval mode can run the
+  *real* pipeline: scripted prompts (the owner's example: "what can you tell
+  me about btd6") through the natural-language stage, asserting grounding
+  presence, source labels, and no-refusal — cost-bounded by a small fixed
+  prompt set (Q-0082 ceiling applies).
+
+## Shape (when structured into a plan)
+
+1. Synthetic-invocation core: fake ctx/interaction + capture-send + scratch-guild
+   scoping + owner-only `!selftest` entry (env-flagged off in prod by default).
+2. Ledger-driven walk with per-command expectations (responded? embed shape?
+   expected event observed? denial copy for under-tier audiences?).
+3. View/button coverage: invoke callbacks synthetically (authority re-check at
+   callback time is already a repo rule — the walker proves it holds).
+4. AI eval mode: fixed prompt battery through the real pipeline (keys present),
+   property assertions, spend cap per run.
+5. Report: one embed/markdown summary (pass/fail/skipped + event-witness table) —
+   the caretaker's (workflow §10 Stage 1) nightly probe set.
+
+## Honest limits (stays human — feeds the checklist session)
+
+Visual/UX correctness (embed *looks right*, button placement *feels right*),
+true multi-user flows (duels/trades beyond two synthetic members), Discord
+client rendering, and "is it fun". The walker shrinks the untested surface;
+the checklist documents the human-only residue (owner walks + screenshots).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -53,7 +53,8 @@
 > live-tested, as a maintained checklist — extends
 > [production-eval-checklist](audits/production-eval-checklist-2026-06-10.md); pairs
 > with **Q-0086** joint live-testing (provider keys → session env) once the owner
-> sets it up · 2) **Self-driving foundation Stage 0 (Q-0088)** — the one-click
+> sets it up; its automation follow-on is the captured
+> [bot-self-test-walker idea](ideas/bot-self-test-walker-2026-06-10.md) · 2) **Self-driving foundation Stage 0 (Q-0088)** — the one-click
 > continuation workflow (`workflow_dispatch` fresh-context session from the standing
 > handoff; activates the bounded-session protocol —
 > [ai-project-workflow §10](owner/ai-project-workflow.md); owner provides the API-key


### PR DESCRIPTION
## What this is

Docs-only capture of **brainstorm round 3**: the owner's "can the bot test itself?" idea, preserved and technically shaped in [`docs/ideas/bot-self-test-walker-2026-06-10.md`](https://github.com/menno420/superbot/blob/claude/amazing-hawking-ebjbtf/docs/ideas/bot-self-test-walker-2026-06-10.md).

- **Owner's idea:** every command fired in sequence via temporary event-based triggers; AI prompts injected per-event on top of the existing harness ("what can you tell me about btd6").
- **Agent shaping (recorded with the capture):** in-process **synthetic invocation** instead of Discord-level chaining (bots ignore bot messages); a **driver loop** over the command-surface ledger instead of event chaining, with the **EventBus as the assertion witness**; Q-0045 governance audience simulation for tiered walks; scratch test guild + lifecycle wipe; an **AI eval mode** through the real pipeline using the Q-0086 keys; permanent owner-gated infrastructure rather than temporary scaffolding.
- **Routing:** ideas README index entry · roadmap session-queue item 1 pointer (the walker is the commissioned untested-surface checklist's automation follow-on, and the natural probe set for the workflow-§10 Stage 1 caretaker) · session log round-3 section.

Captured only — **not approved, not a plan**.

## Status

`check_docs --strict` + docs-ratchet pytest green locally.

https://claude.ai/code/session_01MTrmCgKfPsQWKXRimCMa8J

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTrmCgKfPsQWKXRimCMa8J)_