### PR TITLE
Install Q-0089: mandatory one-idea session ender + owner self-description preserved (§6)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -134,6 +134,15 @@ is **per-file**. Full convention: `docs/owner/ai-project-workflow.md` §9.
   route them so **every idea eventually becomes implemented or discussed — never orphaned**.
   Full mechanism (intake → map → route → groom → outcome): `docs/ideas/README.md`. An agent
   should always have a next thing to do.
+- **Contribute one new idea per session — mandatory session ender (owner directive Q-0089,
+  2026-06-10).** Distinct from grooming (which *moves existing* ideas): before writing the
+  session log, add **one new idea you genuinely believe in** — for the bot or for the agent
+  network/workflow, any size (embed wording → new cog → refactor → new memory doc).
+  Dedup-grep `docs/ideas/` + the roadmap first; record it in the session log under a
+  `💡 Session idea` flag with one line of why it's worth having; substantial ones get an
+  idea file + README index entry. Forced filler is worse than none — the owner wants
+  *consistent genuine generation* ("if agents did this consistently, you're pretty much
+  guaranteed to eventually come up with a good idea"), not ceremony.
 - Plans span **2–3 PRs max**: the first PR covers root causes / foundation; subsequent PRs implement on top.
 - **Plan approval = full execution** — once a plan is approved (via **ExitPlanMode**),
   complete it in one session without stopping for confirmation or waiting for merges

--- a/.session-journal.md
+++ b/.session-journal.md
@@ -56,7 +56,7 @@ project state accumulate here.)
 | **Prod down (Railway build failed)** | Read the build log first. `mise … no precompiled python found` = the Python-pin race → [`docs/operations/production-deployment.md`](docs/operations/production-deployment.md) (pin + bump procedure). Postgres "Online" ≠ bot running. |
 | **Start of work** (first push) | **Open the session PR as a DRAFT immediately** (Q-0052) — the real PR # is then available for every doc you touch. Mark it ready at END. |
 | **Session sizing (Q-0088)** | Wrap before **~700K context** (owner-observed quality drop at 700–800K): finish the current task, sharpen the handoff, END — don't start another. **No unguided PRs past declared scope** — late discoveries go into the handoff/queue, not the session. Full protocol: `docs/owner/ai-project-workflow.md` §10 (activates with Stage 0). |
-| **End of session** | Mark the draft PR ready (every session); write a `.sessions/<date>-<slug>.md` log file (Protocol → END). |
+| **End of session** | Mark the draft PR ready (every session); **contribute 1 new idea you believe in** (`💡 Session idea` in the log — Q-0089, dedup-grep `docs/ideas/` first); write a `.sessions/<date>-<slug>.md` log file (Protocol → END). |
 
 **Three rules that bite hardest:** (1) booting is safe — don't treat it as blocked;
 (2) **verify cross-agent output against source** before acting on it; (3) **root-cause,
@@ -97,6 +97,9 @@ one source of truth** over per-panel patches. Full set under **Rules / Conventio
      made alone / weak point of what shipped / one change that would have helped) — and
      fold the answers into the log's **`Context delta`** + flag lines. The maintainer
      used to ask these manually in chat nearly every session; standing since 2026-06-09.
+     **Also mandatory since 2026-06-10 (Q-0089): one new `💡 Session idea`** you genuinely
+     believe in (bot or network, any size; dedup-grep `docs/ideas/` first; substantial
+     ones get an idea file).
      This is the self-improvement loop (`docs/collaboration-model.md` § "Why this system
      exists"): it's what the REVIEW step mines. Update this journal's guidebook sections
      in place if a preference / rule / runbook fact changed.

--- a/.sessions/2026-06-10-vision-ideation-capture.md
+++ b/.sessions/2026-06-10-vision-ideation-capture.md
@@ -155,6 +155,32 @@ Calibration: this is the second same-day instance of the owner moving
 
 ## Brainstorm round 3: "can the bot test itself?" → idea captured
 
+## Brainstorm round 4: the owner-voice self-description + Q-0089
+
+The owner shared a personal self-portrait (inventor identity since childhood —
+Willy Wortel / Jimmy Neutron; "I see the code in my mind"; no-stress timing
+philosophy; pattern-spotting as his core skill) — preserved **verbatim** in
+`docs/owner/maintainer-working-profile.md` §6 (new). Embedded in it:
+**Q-0089 directed** — the mandatory one-idea-per-session ender (routed:
+CLAUDE.md session-workflow bullet · journal END checklist + QR · router §37,
+verbatim). He also asked for an honest correction on "no other bot has such a
+wide range of functions" — answered in-chat: breadth alone is matched/exceeded
+(Red/Nadeko's plugin ecosystems, MEE6/Dyno suites, big game-economy bots);
+the genuinely rare thing is the *system* (audited-governance config depth +
+grounded AI answerability + the self-improving agent workflow run by a
+non-coder). And he asked for a personality read as his standing new-model
+test — delivered in-chat (not a doc matter beyond §6's facts).
+
+💡 **Session idea (Q-0089's first execution): the owner's morning digest** —
+a small caretaker/bot job that posts "what changed in your bot yesterday"
+(merged-PR titles rendered player-friendly) to his Discord each morning. Why:
+the owner's velocity (nonstop merges) is currently invisible except as GitHub
+noise; a digest turns the network's output into a daily product moment for
+its one operator — and later, reworded, into the public changelog channel for
+servers. Small build (GitHub API → one embed), natural Stage-1 caretaker duty.
+
+## Brainstorm round 3 (earlier): "can the bot test itself?" → idea captured
+
 Owner idea (his own invention, articulated without coding background): every
 command fired in sequence via temporary event-based actions + AI prompts
 injected "at system level" per event. Captured + technically corrected into

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -18,6 +18,11 @@ Pure brainstorm backlogs — capture without commitment. Each file should carry 
 
 Current broad captures:
 
+> **Standing intake note (Q-0089, 2026-06-10):** every session now *generates*
+> one new `💡 Session idea` at END (owner directive — consistent generation
+> beats occasional brilliance). Substantial ones land here as files; small ones
+> live in their session log's 💡 flag. The grooming pass then moves them.
+
 - [`bot-self-test-walker-2026-06-10.md`](./bot-self-test-walker-2026-06-10.md) —
   owner idea (brainstorm round 3): **the bot tests itself** — an owner-gated
   in-process walker that synthetically invokes every ledger-listed command

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -3567,3 +3567,38 @@ once Stage 0 has proven itself. The protocol **activates when Stage 0
 lands** (his conditional, honored). Owner provides: the Anthropic API key as
 a repo secret + a per-run budget choice. Until activation, the ~700K
 guidance + no-unguided-PRs rule apply as journal guidance immediately.
+
+### Q-0089 — Mandatory session ender: every agent contributes ≥1 new idea
+
+**Area:** Collaboration model / agent ecosystem (session END protocol)
+**Type:** Owner directive (unprompted, brainstorm round 4)
+**Priority:** High (changes every session's END protocol immediately)
+**Status:** **Directed** (2026-06-10) — **Routed** → CLAUDE.md § Session & plan workflow (new bullet); journal END checklist + QR row; ideas README intake note
+
+**Owner statement (2026-06-10, verbatim core):** "I noticed that AIs don't
+really come up with many ideas or improvements themselves, while if they did,
+and they would do it consistently, then you are pretty much guaranteed to
+eventually come up with a good idea, so there I have another idea, we should
+make it a mandatory session ender for each agent to come up with 1 new idea
+for the bot or for the AI network, it can be anything as small as a change of
+wording in an embed, or as big as a whole new cog or function, or an
+architectural refractor, maybe a new document for the AI memory, the point
+is, I've been trying to get AI to be more creative and to be part of the
+improvement process."
+
+**The rule as installed:** at session END, before the log is written, the
+agent contributes **one new idea it genuinely believes in** — bot-facing or
+network/workflow-facing, any size (embed wording → new cog → refactor → new
+memory doc). Mechanics: dedup-grep `docs/ideas/` + the roadmap first (a
+duplicate doesn't count); capture it in the session log under a `💡 Session
+idea` flag with one line of *why it's worth having*; if it's substantial,
+give it an idea file / README index entry like any captured idea. Quality
+bar: a forced-feeling filler idea is worse than none — the owner's intent is
+**consistent generation**, volume-over-time, not ceremony; "genuinely
+believes in" is the filter. The grooming pass (Q-0015) *moves existing*
+ideas; this rule *generates new* ones — both run at END.
+
+**First execution:** this session's 💡 idea — the **owner's morning digest**
+(see the session log + ideas README): the bot/caretaker posts a daily
+"what changed in your bot yesterday" summary built from merged PR titles,
+so the owner experiences the network's velocity as a product feature.

--- a/docs/owner/maintainer-working-profile.md
+++ b/docs/owner/maintainer-working-profile.md
@@ -123,3 +123,40 @@ This doc should **not**:
 - require every implementation agent to read a long personal profile by default.
 
 Its only job is to preserve intent and point at the right homes.
+
+## 6. Owner-voice self-description (2026-06-10, verbatim excerpts — preserve as-is)
+
+Late in the vision-capture conversation the owner described himself directly.
+This is primary-source material for how he reasons; quote, don't paraphrase:
+
+> "I've always wanted to be an inventor, like 'Willy Wortel' from Donald Duck,
+> and 'Jimmy Neutron' — as a kid I always thought about all the amazing things
+> I would create, and I'd make drawings of things like a defense bubble for
+> your car, umbrellas for your neck."
+
+> "I never really stress or worry about when something gets done, as long as
+> it gets done when it should, and if it doesn't, there's always tomorrow."
+
+> "Even tho I don't know code it feels like I see the code in my mind whenever
+> I think of a new function, that's how I reason what the possibilities are —
+> if you can put it in code you can build it. I always try to explain things
+> to agents as the literal steps that it needs to function as far as I know."
+
+> "Over the years I've become really good at spotting patterns and asking
+> questions, trying to define the limits of whatever is possible."
+
+> "Human emotion, and nature, are very alike to code — it is all a structured
+> pattern hidden amongst the chaos."
+
+**What agents should take from this:** (1) his specs arrive as *literal
+functional steps* — treat them as mental pseudo-code that is usually
+structurally right and occasionally mechanically wrong (see Q-0014: take the
+better implementation and say why); (2) his calm about timing is a real
+operating principle, not indifference — urgency signals from him are therefore
+*meaningful* when they appear (the 2026-06-10 outage: calm, curious, zero
+panic); (3) he tests the limits of every tool, including agents — expect
+capability probes and answer them honestly; (4) the inventor identity is the
+deep driver: the agent network is the workshop, and the workflow docs are an
+external copy of his own idea-generating habit (he said so himself when
+installing the Q-0089 one-idea rule: agents should generate ideas
+*consistently, like he does*).


### PR DESCRIPTION
## What this is

Brainstorm round 4 — two things from the owner's most personal message of the conversation:

- **Q-0089 installed (owner directive, verbatim in router §37): the mandatory one-idea session ender.** Every agent, at session END, contributes **one new idea it genuinely believes in** — bot-facing or network-facing, any size ("a change of wording in an embed … a whole new cog … an architectural refactor … a new document for the AI memory"). Distinct from the Q-0015 grooming pass (which moves *existing* ideas — this *generates* new ones; both run at END). Mechanics: dedup-grep `docs/ideas/` first, `💡 Session idea` flag in the session log, idea file for substantial ones. Quality bar written into the rule: forced filler is worse than none — the owner's goal is *consistent genuine generation* ("you are pretty much guaranteed to eventually come up with a good idea"). Routed: CLAUDE.md § Session & plan workflow (owner-directed change, Q-0084-style authorization) · journal END checklist + Quick-reference row · ideas README standing intake note.
- **The owner's self-description preserved verbatim** in `maintainer-working-profile.md` **new §6** (inventor identity — Willy Wortel / Jimmy Neutron; "I see the code in my mind"; the no-stress timing philosophy; pattern-spotting and limit-probing as his core skills; "human emotion and nature are very alike to code") plus the four derivations agents should carry (specs = mental pseudo-code, usually structurally right; his calm makes his rare urgency signals meaningful; expect capability probes, answer honestly; the inventor identity is the deep driver).

**First execution of Q-0089 included** (session log 💡): the **owner's morning digest** — a small caretaker/bot job posting "what changed in your bot yesterday" (merged-PR titles, player-friendly wording) to his Discord; later reusable as the public per-server changelog channel.

## Status

`check_docs --strict` + docs-ratchet pytest green locally. Docs-only.

https://claude.ai/code/session_01MTrmCgKfPsQWKXRimCMa8J

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTrmCgKfPsQWKXRimCMa8J)_