### PR TITLE
Capture V-16: rendered paper-doll character + gear-lane slice (combat items, renderer, picker previews)

### DIFF
--- a/.sessions/2026-06-10-vision-ideation-capture.md
+++ b/.sessions/2026-06-10-vision-ideation-capture.md
@@ -173,6 +173,16 @@ in-conversation). Also confirmed: the owner's remembered old fishing cog is
 **pre-GitHub** — no repo archaeology needed (verified: zero fishing code in
 history; the only grep hit is the idiom "fish out" in a comment).
 
+Round-7 tail: the owner's **asset pack surfaced** (PythonAnywhere screenshots
+— 6 families × 5 tiers + base character, 2025-08-10, naming manifest-ready;
+flat-color placeholder style) → V-16 updated with the tier↔ore forge-chain
+insight + the slot-mapping question flagged for the build session. A live
+**sprites-as-code demo** (PIL pixel-art pickaxe, 3 palette tiers, composited
+paper-doll) was generated in-session and sent to the owner — answering "can
+Claude create images": no diffusion art, but procedural sprite generation +
+image *reading* both work, and parametric palette-swap variants scale with
+the catalog where hand-drawn assets can't.
+
 ## Brainstorm round 5: the open-world federation + competitive mining (V-13/V-14)
 
 Two new owner statements captured into the vision doc §3: **V-13** — the

--- a/.sessions/2026-06-10-vision-ideation-capture.md
+++ b/.sessions/2026-06-10-vision-ideation-capture.md
@@ -155,6 +155,24 @@ Calibration: this is the second same-day instance of the owner moving
 
 ## Brainstorm round 3: "can the bot test itself?" → idea captured
 
+## Round 7: the gear thread → V-16 rendered character
+
+The owner asked how ready the mining Gear view is "to display items — I
+really want that to work." Source-read of `views/mining/gear_panel.py` +
+`utils/equipment.py` + `character_panel.py` established: panel shipped &
+works (5 slots, durability bars, stat totals, two-step equip, Equip Best);
+the equipment model is **already the cross-game substrate** (pure utils/,
+data-driven, deathmatch reads damage/defense); the ⚔️/🛡️ slots are
+**reserved-but-empty** (no combat items exist yet); the item picker shows
+labels without stats. The owner's actual goal then landed: **render a base
+character with equipped items at correct positions** → captured as **V-16**
+(vision doc §3) with build notes (PIL pipeline proven by #665; manifest-
+driven compositor in utils/; combat-gear item families as sibling slice;
+art-direction = the gating owner decision, structured-choice asked
+in-conversation). Also confirmed: the owner's remembered old fishing cog is
+**pre-GitHub** — no repo archaeology needed (verified: zero fishing code in
+history; the only grep hit is the idiom "fish out" in a comment).
+
 ## Brainstorm round 5: the open-world federation + competitive mining (V-13/V-14)
 
 Two new owner statements captured into the vision doc §3: **V-13** — the

--- a/docs/ideas/superbot-vision-2026-06-10.md
+++ b/docs/ideas/superbot-vision-2026-06-10.md
@@ -191,6 +191,24 @@ section is new work** — it's the ground the vision stands on.
   review per source bot. **Scope rider on the V-14 gateway session:** the
   teardown should also catalog each bot's export/API surface — that catalog
   *is* the migration design's input.
+- **V-16 — The rendered character: paper-doll gear display (added 2026-06-11,
+  round 7).** Owner-voice: "the goal should be to actually render a base
+  character and show/display the equipped items on the correct positions."
+  Not a richer text embed — an **image**: base character sprite + equipped
+  items composited at per-slot anchor positions (tool→hand, light→belt/head,
+  charm→neck, weapon→off-hand, armor→torso). Build notes: the **PIL pipeline
+  already exists** (#665's inventory/stat cards prove render→attach→embed);
+  the renderer is a pure-`utils/` compositor driven by a **sprite manifest**
+  (item → sprite asset + anchor offset; graceful badge-row fallback for
+  sprite-less items; cache per loadout-hash). This becomes the **cross-
+  ecosystem character identity** (V-13: the same doll holds the rod when
+  fishing lands). Prerequisite/sibling slice: the ⚔️/🛡️ **combat gear item
+  families** (slots are reserved-but-empty today — `utils/equipment.py`
+  docstring; duels already read damage/defense, so items matter the moment
+  they exist). **Gating decision (owner's, asked 2026-06-11): art
+  direction** — programmatic pixel-art vs AI-generated sprite sheet vs
+  owner-provided assets. Gear-picker stat-preview polish rides along
+  (gear_panel `_ItemSelect` options are label-only today).
 - **V-14 — Competitive feature mining (added 2026-06-10, brainstorm round 5).**
   Owner-endorsed research direction: systematically tear down the big bots'
   ("thousands of features") catalogs, "filter out some of the best ideas and

--- a/docs/ideas/superbot-vision-2026-06-10.md
+++ b/docs/ideas/superbot-vision-2026-06-10.md
@@ -205,10 +205,25 @@ section is new work** — it's the ground the vision stands on.
   fishing lands). Prerequisite/sibling slice: the ⚔️/🛡️ **combat gear item
   families** (slots are reserved-but-empty today — `utils/equipment.py`
   docstring; duels already read damage/defense, so items matter the moment
-  they exist). **Gating decision (owner's, asked 2026-06-11): art
-  direction** — programmatic pixel-art vs AI-generated sprite sheet vs
-  owner-provided assets. Gear-picker stat-preview polish rides along
-  (gear_panel `_ItemSelect` options are label-only today).
+  they exist). **Owner assets EXIST (seen 2026-06-11, screenshots):** a full
+  pack on his PythonAnywhere (`temp/`, dated 2025-08-10 — pre-GitHub era):
+  `base_character.png` + **6 item families × 5 tiers** (helmet, chestplate,
+  leggings, boots, shield, sword × bronze/silver/gold/iron/diamond) — naming
+  already manifest-shaped (`{item}_{tier}.png`). Samples seen: flat-color
+  placeholder style (stick-figure base, solid-cyan items). Two design facts
+  that fall out: (a) **tier names align with mining ores** → forge recipes
+  (smelt ore → craft tier gear) are the natural obtain-path — the federation's
+  first in-ecosystem crafting chain designs itself; (b) his 6 families vs the
+  current 5-slot model (weapon/armor) → **slot-mapping is the build session's
+  first structured-choice round** (one armor slot w/ set pieces vs sub-slots;
+  `equipment.py` slots are data-extensible). **Art direction:** owner's pack =
+  the taxonomy authority; agent can regenerate visuals procedurally
+  (sprites-as-code demo'd live 2026-06-11 — palette-swap tiers from one
+  template) — v1 may ship his assets as-is and reskin later, owner picks
+  per-family. Next concrete step: owner drops the pack (zip) into any
+  session / commits it; agent builds manifest + compositor around it.
+  Gear-picker stat-preview polish rides along (gear_panel `_ItemSelect`
+  options are label-only today).
 - **V-14 — Competitive feature mining (added 2026-06-10, brainstorm round 5).**
   Owner-endorsed research direction: systematically tear down the big bots'
   ("thousands of features") catalogs, "filter out some of the best ideas and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -65,7 +65,11 @@
 > 2026-06-10/11 in-conversation** (the [dossier](ideas/competitive-teardown-2026-06-10.md):
 > 30 scored harvest candidates, retention engines, V-15 surfaces live-verified;
 > **ecosystem-#2 verdict = fishing, owner ratification pending**); remaining work =
-> structure the top harvest picks into plans through the conveyor. Build-ready
+> structure the top harvest picks into plans through the conveyor · 6) **the
+> gear-lane slice (V-16)**: combat-gear item families (⚔️/🛡️ slots are
+> reserved-but-empty today; duels already read the stats) + the **paper-doll
+> character renderer** (PIL compositor over a sprite manifest — gated on the
+> owner's art-direction pick) + gear-picker stat previews. Build-ready
 > alternates: myprofile PR A · survival **P0 balance-simulation harness (Q-0087)**
 > · duel-XP quick-win.
 


### PR DESCRIPTION
## What this is

Round-7 capture: **V-16 — the rendered paper-doll character** (owner goal: "actually render a base character and show/display the equipped items on the correct positions").

- Vision doc gains V-16 with build notes: PIL pipeline proven by #665's cards; pure-`utils/` compositor over a **sprite manifest** (item → asset + per-slot anchor); graceful fallback for sprite-less items; loadout-hash caching; the doll becomes the **cross-ecosystem character identity** (V-13). Sibling slice: the ⚔️/🛡️ **combat-gear item families** — the slots are reserved-but-empty today (`utils/equipment.py`), and duels already read damage/defense, so items matter the instant they exist. Gear-picker stat-preview polish rides along.
- Roadmap session queue item 6 = the gear-lane slice (combat items + renderer + picker previews).
- Session log round 7: the gear-readiness source audit (panel shipped & works; the "not working" feeling = honest emptiness of the combat slots), the V-16 goal, and the pre-GitHub fishing-cog confirmation (no archaeology needed — verified zero fishing code in history).
- Owner context recorded in-conversation: he **already has the item art assets** (pre-existing); agent-side procedural sprite generation (PIL, sprites-as-code, palette-swap tiers) demo'd live — his assets remain the style authority, code-drawn variants fill catalog gaps subject to his visual approval.

Docs-only. `check_docs --strict` green.

https://claude.ai/code/session_01MTrmCgKfPsQWKXRimCMa8J

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTrmCgKfPsQWKXRimCMa8J)_