### PR TITLE
Capture minebot ancestry: V-16 is a restoration; ancestor features as design material

### DIFF
--- a/.sessions/2026-06-10-vision-ideation-capture.md
+++ b/.sessions/2026-06-10-vision-ideation-capture.md
@@ -173,6 +173,38 @@ in-conversation). Also confirmed: the owner's remembered old fishing cog is
 **pre-GitHub** — no repo archaeology needed (verified: zero fishing code in
 history; the only grep hit is the idiom "fish out" in a comment).
 
+Round-7 tail 2: the owner shared Discord screenshots of **minebot — SuperBot's
+direct ancestor** (March–April 2025, PythonAnywhere `/home/menno/minebot/`,
+27 files; same **Galaxy Bot** identity that is now SuperBot's test bot):
+gear/multiequip/unequip commands (the system today's `gear_panel.py`
+docstring credits as "the old EquipSlotView + MultiEquipView"), a
+`pil_helper.py` (his original render code — may encode intended anchor
+positions for V-16; **owner instruction: when zipping the asset pack, include
+`helpers/` too**), a `!debug` panel with a **Dependencies view** (cog→helper
+import edges — the conceptual ancestor of CodeGraph/context_map), and a
+**`chop` command — woodcutting existed** as a second gathering activity.
+Design echo routed: the survival plan's campfire (P3) has no fuel source
+named — chop/wood is the natural one (open-item line added). No fishing
+commands visible in the ancestor — the ghost cog predates even minebot or
+never existed as committed code.
+
+Round-7 tail 3 (the crown jewel): a second screenshot batch proved **V-16 is
+a restoration** — minebot's `/gear` already rendered the base character image
+with Defense/Damage stats (April 2025); armor item names in live inventories
+match the PNG pack exactly; `pil_helper.py` = the original compositor (port,
+don't reinvent). Ancestor breadth not yet reclaimed by SuperBot, recorded in
+V-16 as design-document material: directional mining (Up/Forward/Down),
+axes/shovels, planks/sticks intermediates, structures-as-items (wooden house
+/ diamond throne / gold statue / giant fortress — §7.5 ancestry).
+
+Owner observation worth promoting someday into "why this system exists"
+(verbatim): looking at his old debug command's many inconsistent shapes —
+"look how many diffrent shapes my debug command had back then, that's the
+direct result of coding in chats without repo access." The pre-repo era's
+fossil record: every chat reinvented the panel because no chat could see the
+last one's work. The entire current workflow (one source of truth + agent
+orientation + routed memory) is the cure for exactly this.
+
 Round-7 tail: the owner's **asset pack surfaced** (PythonAnywhere screenshots
 — 6 families × 5 tiers + base character, 2025-08-10, naming manifest-ready;
 flat-color placeholder style) → V-16 updated with the tier↔ore forge-chain

--- a/docs/ideas/superbot-vision-2026-06-10.md
+++ b/docs/ideas/superbot-vision-2026-06-10.md
@@ -194,6 +194,19 @@ section is new work** — it's the ground the vision stands on.
 - **V-16 — The rendered character: paper-doll gear display (added 2026-06-11,
   round 7).** Owner-voice: "the goal should be to actually render a base
   character and show/display the equipped items on the correct positions."
+  **This is a RESTORATION, not an invention (Discord screenshots, April
+  2025):** the ancestor bot (minebot, same Galaxy Bot identity) **already
+  rendered it** — `/gear` returned "Menno420's Gear / Defense · Damage" with
+  the base-character image in the embed; the armor items were live inventory
+  entries whose names **exactly match the PNG pack** (`boots_gold`,
+  `helmet_iron`, `chestplate_diamond`, …). The original compositor lives in
+  minebot's `helpers/pil_helper.py` on PythonAnywhere — port/modernize it
+  rather than reinvent. Ancestor features SuperBot hasn't reclaimed yet
+  (design-document value): **directional mining** (Mine Up/Forward/Down
+  buttons), axes/shovels as tool families, crafting intermediates
+  (planks/sticks), and **structures-as-items** (wooden house, diamond throne,
+  gold statue, "giant fortress ×4" in live inventories — direct ancestry for
+  the §7.5 structures slice).
   Not a richer text embed — an **image**: base character sprite + equipped
   items composited at per-slot anchor positions (tool→hand, light→belt/head,
   charm→neck, weapon→off-hand, armor→torso). Build notes: the **PIL pipeline

--- a/docs/planning/rpg-survival-difficulty-design-2026-06-10.md
+++ b/docs/planning/rpg-survival-difficulty-design-2026-06-10.md
@@ -199,6 +199,9 @@ outputs, not guesses.
   the 2026-06-10 teardown's verdict, owner ratification pending): P3's design
   should keep its seams ecosystem-ready (own loot ladder, local-currency hook,
   collection-log hook) so promotion extends rather than rewrites it.
+- P3's campfire has no named fuel source — the ancestor bot (minebot, 2025)
+  had a `chop` woodcutting command; wood-as-fuel is the natural echo (and a
+  third gathering verb if fishing becomes ecosystem #2).
 - Whether Medium death (P2) costs a small coin/food penalty or only time.
 - Fishing loot table depth (own ladder vs. reskinned ore weights at v1).
 - Whether cooked food may later be sellable (market interaction — economy


### PR DESCRIPTION
## What this is

The night's closing capture: the owner shared Discord screenshots (March–April 2025) of **minebot** — SuperBot's direct ancestor, running as the same Galaxy Bot identity from PythonAnywhere (`/home/menno/minebot/`, 27 files).

- **V-16 reframed as a restoration:** minebot's `/gear` **already rendered the base character** with Defense/Damage stats; the armor items in live player inventories match the owner's PNG asset pack names exactly (`boots_gold`, `helmet_iron`, `chestplate_diamond`, …); the original compositor is `helpers/pil_helper.py` on PythonAnywhere — the build session should **port/modernize it, not reinvent**.
- **Ancestor breadth recorded as design-document material** (features SuperBot hasn't reclaimed): directional mining (Mine Up/Forward/Down buttons), axes/shovels tool families, crafting intermediates (planks/sticks), and **structures-as-items** (wooden house, diamond throne, gold statue, giant fortress — direct ancestry for the mining §7.5 structures slice).
- **Survival plan open item:** P3's campfire gains its natural fuel source from the ancestor's `chop` woodcutting command (wood-as-fuel; a third gathering verb beside mining/fishing).
- **Session log** preserves the owner's verbatim observation on his old debug command's many inconsistent shapes — "the direct result of coding in chats without repo access" — the clearest owner-voice statement yet of the disease this whole workflow exists to cure (promotion candidate for collaboration-model's "why this system exists").
- No fishing commands in the ancestor: the remembered fishing cog predates even minebot.

Docs-only. `check_docs --strict` green.

https://claude.ai/code/session_01MTrmCgKfPsQWKXRimCMa8J

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTrmCgKfPsQWKXRimCMa8J)_