### PR TITLE
Working profile: the 40–50 session interviews — the origin of the system's maturity

### DIFF
--- a/docs/owner/maintainer-working-profile.md
+++ b/docs/owner/maintainer-working-profile.md
@@ -172,4 +172,13 @@ isn't. Derivation (5): **measure maturity in PRs, decisions, and survived
 incidents — never in calendar time.** The conventions are real (they've
 survived hundreds of merges and parallel-agent collisions); they are also
 young — when one chafes, propose the improvement rather than assuming it's
-load-tested ancient law.
+load-tested ancient law. **How it matured this fast (owner, 2026-06-11):**
+he personally interviewed **40–50 sessions** about their experience — what
+they could find, what conflicted, what would help the next session —
+"doubling the time each session took," and folded the answers back into the
+structure. The standing six-question reflection interview is the
+protocolized fossil of those interviews: user research where the users were
+AIs. He also notes the inversion every agent should sit with once: a fresh
+session can never perceive the youth of its own world — "each new session
+would never know that this system was someday not there yet" — which is
+precisely why this paragraph exists.


### PR DESCRIPTION
## What this is

One paragraph appended to the working profile's timeline calibration: **how the system matured in days** — the owner personally interviewed 40–50 sessions about their experience working in the repo (findability, conflicts, suggestions for the next session), at the cost of roughly doubling each session's length, and folded every answer back into the structure. The standing six-question reflection interview is the protocolized fossil of that practice: **user research where the users were AIs.**

Also preserves his inversion, verbatim in spirit: a fresh session can never perceive the youth of its own world — "each new session would never know that this system was someday not there yet" — which is precisely why the calibration paragraph exists.

Docs-only. `check_docs --strict` green.

https://claude.ai/code/session_01MTrmCgKfPsQWKXRimCMa8J

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTrmCgKfPsQWKXRimCMa8J)_