### PR TITLE
docs: Hermes skill pack — 6 SuperBot-specific skill prompts

### DIFF
--- a/docs/operations/hermes-control-plane.md
+++ b/docs/operations/hermes-control-plane.md
@@ -451,3 +451,5 @@ Make Hermes consistently useful for SuperBot repo review, doc consistency checks
 ```
 
 This gives the highest value with the lowest risk because it improves behavior without giving Hermes broader write or production access.
+
+**The skill pack has been implemented** — see [`hermes-skills/`](./hermes-skills/README.md) for the six ready-to-use skill prompts.

--- a/docs/operations/hermes-skills/README.md
+++ b/docs/operations/hermes-skills/README.md
@@ -1,0 +1,45 @@
+# SuperBot — Hermes Skill Pack
+
+> **Status:** `living-ledger` — operational reference for the SuperBot-specific Hermes
+> skills. Each skill is a ready-to-configure prompt for the Hermes agent running on the
+> control-plane VPS. Setup context: `docs/operations/hermes-control-plane.md`.
+
+This pack contains six skills covering the two windows Hermes fills that Claude Code
+cannot: **pre-session orientation** and **between-session monitoring**.
+
+---
+
+## Skills
+
+| Skill | Window | Purpose |
+|---|---|---|
+| [`session-brief`](./session-brief.md) | Pre-session | Compressed orientation brief to paste into Claude Code |
+| [`repo-health`](./repo-health.md) | Between sessions | Traffic-light snapshot — is anything broken? |
+| [`ideas-triage`](./ideas-triage.md) | Downtime | Ideas backlog review with a suggested next move |
+| [`prompt-builder`](./prompt-builder.md) | Pre-session | Turn a spoken idea into a structured Claude Code prompt |
+| [`open-questions`](./open-questions.md) | Between sessions | Surface unanswered Q- blocks from the router |
+| [`btd6-status`](./btd6-status.md) | After live testing | BTD6 data pipeline coverage and open items |
+
+---
+
+## How to install on the VPS
+
+Each skill file contains a ready-to-use prompt block. To add a skill to Hermes:
+
+1. SSH into the VPS as `hermes`.
+2. Create a skill file in `~/.hermes/skills/` (or the path configured in `~/.hermes/config.yaml`).
+3. Paste the prompt block from the skill file into the Hermes skill config.
+4. Alternatively, send the full prompt text directly in Telegram — each skill prompt
+   is self-contained and works as a plain Telegram message too.
+
+The repo-side skill files are the source of truth. If you update a skill prompt here,
+copy the new version to the VPS manually.
+
+---
+
+## Shared operating rule (every skill)
+
+All skills default to **read-only**. None of them modify repo files, commit, push,
+create PRs, or access Railway/Neon/production secrets. If a skill produces an
+implementation prompt, the prompt is an artifact for Claude Code — Hermes does not
+execute it.

--- a/docs/operations/hermes-skills/btd6-status.md
+++ b/docs/operations/hermes-skills/btd6-status.md
@@ -1,0 +1,79 @@
+# Skill: `superbot-btd6-status`
+
+> **Status:** `living-ledger` — ready-to-use Hermes skill prompt. Update when the BTD6 data pipeline or probe script changes.
+
+**Window:** after live testing  
+**Purpose:** Snapshot of the BTD6 data pipeline — what the bot knows, what it doesn't,
+and what's broken. Useful after a live testing session where you hit wrong answers.
+
+**When to use:** after testing BTD6 commands on Discord, or when you want to know
+what grounding coverage exists before opening a bug-fix session.
+
+---
+
+## Prompt
+
+```
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Do not modify any files. Read-only only.
+
+Produce a BTD6 STATUS REPORT. Keep the output under 500 words.
+
+Do the following in order:
+
+1. Read: /home/hermes/repos/superbot/docs/btd6/btd6-gamedata-decode-status.md
+   Extract:
+   - Overall decode progress (what percentage or count is grounded)
+   - Which data areas are complete (✅ or equivalent)
+   - Which data areas are partial or missing (⚠️ / ❌ or equivalent)
+   - Any open items or known gaps listed in the doc
+
+2. Read: /home/hermes/repos/superbot/docs/health/bug-book.md
+   Find any open bugs (not marked FIXED) that mention BTD6, round cash, grounding,
+   resolver, or BTD6-related commands. List each: BUG-NNNN — short description — status.
+
+3. Run: cd /home/hermes/repos/superbot && git log --oneline --all -- disbot/data/btd6/ | head -5
+   Show the 5 most recent commits that touched the BTD6 data files.
+   This tells you how recently the data was updated.
+
+4. Run: cd /home/hermes/repos/superbot && git log --oneline --all -- disbot/services/btd6_*.py | head -5
+   Show the 5 most recent commits that touched BTD6 service files.
+
+5. Check if the probe script exists:
+   ls /home/hermes/repos/superbot/scripts/btd6_probe.py
+   If it exists, run: cd /home/hermes/repos/superbot && python3 scripts/btd6_probe.py --help
+   (read-only — just check what options exist, do not run a full probe)
+
+Format the output as:
+
+---
+## BTD6 Status — [today's date]
+
+### Decode coverage
+[from step 1 — what's grounded vs. missing, compact table or list]
+
+### Open BTD6 bugs
+[from step 2 — or "none open"]
+
+### Recent data changes
+[from steps 3+4 — last 5 commits for data files, last 5 for services]
+
+### Probe tool
+[from step 5 — available options, or "probe script not found"]
+
+### Assessment
+[2–3 sentences: is the BTD6 pipeline in good shape, what's the biggest gap,
+ what would help most in the next session?]
+---
+```
+
+---
+
+## Notes
+
+- The BTD6 data files live in `disbot/data/btd6/` and are updated by `scripts/parse_gamedata.py`.
+- The grounding services are in `disbot/services/btd6_*_service.py`.
+- The decode status doc is the canonical record of what data is parsed and what is not.
+  Source code and the doc should agree — if they don't, the source wins.
+- This skill does not run actual bot commands or test queries — it reads the static record.
+  For live query testing, do that in Discord and report the result to a Claude Code session.

--- a/docs/operations/hermes-skills/ideas-triage.md
+++ b/docs/operations/hermes-skills/ideas-triage.md
@@ -1,0 +1,79 @@
+# Skill: `superbot-ideas-triage`
+
+> **Status:** `living-ledger` — ready-to-use Hermes skill prompt. Update when the ideas lifecycle or backlog structure changes.
+
+**Window:** between sessions / downtime  
+**Purpose:** Review the ideas backlog from mobile without a full Claude Code session.
+Shows what lifecycle state every idea is in and suggests one grooming move.
+
+**When to use:** during downtime when you want to think about what to build next, or
+before a session when you want to know which ideas are ripe to execute.
+
+---
+
+## Prompt
+
+```
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Do not modify any files. Read-only only.
+
+Produce an IDEAS TRIAGE REPORT. Keep the output under 700 words.
+
+Do the following in order:
+
+1. Read: /home/hermes/repos/superbot/docs/ideas/README.md
+   Extract every linked idea file (they are in the bullet list under "Current broad captures").
+   For each idea, note its name and any lifecycle state mentioned (raw / captured / routed /
+   in-progress / or no state = assume captured).
+
+2. Read: /home/hermes/repos/superbot/docs/roadmap.md
+   Note which ideas have a horizon entry (Now / Next / Later / Someday).
+
+3. Read: /home/hermes/repos/superbot/docs/planning/ — list the files (ls only, do not read them).
+   Note which idea topics have a corresponding planning doc.
+
+4. Cross-reference steps 1–3 to assign each idea one of these states:
+   - RAW: in ideas/ but no badge, no roadmap entry, no planning doc
+   - CAPTURED: has ideas/ entry + badge, no further routing
+   - ROUTED: has a roadmap horizon OR a planning doc
+   - IN-PROGRESS: referenced as active in docs/current-state.md
+
+5. Read: /home/hermes/repos/superbot/docs/owner/maintainer-question-router.md
+   Check if any idea has an open Q- block blocking it.
+
+6. Identify:
+   - Ideas stuck at RAW (highest priority to route)
+   - The one idea closest to being executable (CAPTURED, clearly scoped, no blocker)
+   - Any idea with a planning doc but no roadmap entry (planning without a horizon = invisible)
+
+Format the output as:
+
+---
+## SuperBot Ideas Triage — [today's date]
+
+### Backlog by state
+| Idea | State | Roadmap horizon | Planning doc? |
+|------|-------|-----------------|---------------|
+[one row per idea]
+
+### Stuck at RAW
+[list ideas with no routing, one line each — these need a home]
+
+### Best candidate to execute next
+[one idea, one paragraph — why it's ready and what the first step would be]
+
+### Needs grooming attention
+[1–3 specific actions: "route X to roadmap", "link Y to planning doc", etc.]
+---
+```
+
+---
+
+## Notes
+
+- The ideas lifecycle is: raw → captured → routed (roadmap/planning) → in-progress → shipped.
+  An idea that is captured but not routed is not lost, but it will never be executed — routing
+  gives it a destination.
+- The "best candidate to execute next" is just a suggestion. Claude Code weighs it against
+  the active lanes and owner priorities before acting.
+- If an idea has an open Q- block, it cannot be executed until the question is answered.

--- a/docs/operations/hermes-skills/open-questions.md
+++ b/docs/operations/hermes-skills/open-questions.md
@@ -1,0 +1,85 @@
+# Skill: `superbot-open-questions`
+
+> **Status:** `living-ledger` — ready-to-use Hermes skill prompt. Update when the question router format changes.
+
+**Window:** between sessions  
+**Purpose:** Surface all unanswered Q- blocks from the maintainer question router,
+grouped by area and urgency. Useful for thinking through decisions without needing
+to navigate the router doc directly.
+
+**When to use:** during a commute or break when you want to think about open decisions,
+or before a session to know which architectural questions are blocking progress.
+
+---
+
+## Prompt
+
+```
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Do not modify any files. Read-only only.
+
+Produce an OPEN QUESTIONS REPORT from the SuperBot question router.
+Keep the output under 600 words.
+
+Do the following in order:
+
+1. Read: /home/hermes/repos/superbot/docs/owner/maintainer-question-router.md
+   Find every Q-NNNN entry. For each, note:
+   - The Q number
+   - The topic/area (one phrase)
+   - Whether it is marked as Answered / Open / Partially answered
+   - If it is blocking any active work (look for "gated on", "blocked until", "needs Q-")
+
+2. Read: /home/hermes/repos/superbot/docs/current-state.md
+   Check the active lanes for references to open Q- blocks (e.g., "Q-0085 open",
+   "pending Q-", "gate: Q-"). Add any you find that were not already in step 1.
+
+3. Separate the questions into:
+   - BLOCKING: directly gates an active lane or feature
+   - ARCHITECTURAL: affects layer design, ownership, or long-term structure
+   - PRODUCT: owner preference, UX, or business direction
+   - PROCESS: workflow, tooling, or agent-behavior decisions
+
+4. For each blocking question, note in one sentence what is blocked and what the
+   options are (if the router doc mentions them).
+
+Format the output as:
+
+---
+## SuperBot Open Questions — [today's date]
+
+### Blocking (answer these first)
+| Q# | Topic | Blocks |
+|----|-------|--------|
+[rows]
+
+### Architectural
+| Q# | Topic | Short description |
+|----|-------|------------------|
+[rows]
+
+### Product
+| Q# | Topic | Short description |
+|----|-------|------------------|
+[rows]
+
+### Process
+| Q# | Topic | Short description |
+|----|-------|------------------|
+[rows]
+
+### Summary
+[2–3 sentences: how many open total, which areas have the most open questions,
+ and which one question would unblock the most work if answered]
+---
+```
+
+---
+
+## Notes
+
+- The router uses `Q-NNNN` identifiers. Answered questions are usually marked
+  `**Status:** Answered` or have a date stamp and resolution note.
+- Questions marked "partially answered" count as open — they still gate something.
+- This skill is read-only: it surfaces questions but does not answer them. Answer
+  them in a Claude Code session where the full repo context is available.

--- a/docs/operations/hermes-skills/prompt-builder.md
+++ b/docs/operations/hermes-skills/prompt-builder.md
@@ -1,0 +1,96 @@
+# Skill: `superbot-prompt-builder`
+
+> **Status:** `living-ledger` — ready-to-use Hermes skill prompt. Update when the repo's subsystem folios or binding doc structure change.
+
+**Window:** pre-session  
+**Purpose:** Turn a task description (including a spoken voice-mode idea) into a
+structured, oriented Claude Code prompt. Arrive at the session with a prompt ready
+to execute rather than spending context figuring out where to start.
+
+**When to use:** you have an idea while away from the computer and want to prepare a
+complete prompt for Claude Code before the session opens.
+
+---
+
+## Prompt
+
+```
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Do not modify any files. Read-only only.
+
+I want you to build a CLAUDE CODE SESSION PROMPT for the following task:
+
+[TASK DESCRIPTION — replace this with what you want to build or fix]
+
+Do the following in order to build the prompt:
+
+1. IDENTIFY THE AREA
+   Which subsystem(s) does this task touch?
+   Options: ai / setup / settings / mining / games / help / economy / social / btd6 /
+            governance / runtime / views / utils / docs-only
+   Read the matching folio: /home/hermes/repos/superbot/docs/subsystems/<area>.md
+   Note the current state and any active work in that area.
+
+2. IDENTIFY BINDING CONTRACTS
+   Which of these apply to this task? (read only the ones that apply)
+   - /home/hermes/repos/superbot/docs/architecture.md (if touching layer boundaries)
+   - /home/hermes/repos/superbot/docs/ownership.md (if writing to DB or mutations)
+   - /home/hermes/repos/superbot/docs/runtime_contracts.md (if touching bot lifecycle)
+   - /home/hermes/repos/superbot/docs/helper-policy.md (if adding a utility function)
+   List which ones apply and the single most important rule from each.
+
+3. IDENTIFY SOURCE FILES
+   Run: find /home/hermes/repos/superbot/disbot -name "*.py" | xargs grep -l "<relevant keyword>" 2>/dev/null | head -10
+   (Use a keyword from the task — cog name, service name, command name, etc.)
+   List the 2–4 most relevant files. Do not read them — just list paths.
+
+4. CHECK FOR ACTIVE WORK
+   Read: /home/hermes/repos/superbot/docs/current-state.md
+   Does any active lane overlap with this task? Note it if so.
+
+5. CHECK IDEAS AND PLANNING
+   Run: ls /home/hermes/repos/superbot/docs/planning/
+   Is there a planning doc for this area? If yes, note its name.
+
+6. DRAFT THE PROMPT
+   Write a complete prompt using this structure:
+
+---
+## Task: [one-line task title]
+
+### Context
+[2–3 sentences: what this task is, why it matters, what subsystem it touches]
+
+### Read first
+[list of docs to read, in order — binding ones first]
+- docs/architecture.md (rule: ...)
+- docs/ownership.md (rule: ...)  [if applicable]
+- docs/subsystems/<area>.md
+
+### Relevant source files
+[2–4 file paths from step 3]
+
+### Active lane overlap
+[from step 4 — or "none detected"]
+
+### Implementation notes
+[1–3 specific constraints or gotchas from the binding docs — e.g.,
+ "always write through <service>.py", "use settings_keys constants not raw strings"]
+
+### Acceptance criteria
+[2–3 concrete things that should be true when the task is done]
+---
+
+Do not implement anything. Only produce the prompt.
+```
+
+---
+
+## Notes
+
+- Replace `[TASK DESCRIPTION]` in the prompt above with your actual task in plain language.
+  Hermes will orient the rest automatically.
+- The `find | grep` in step 3 may need a different keyword depending on the task — adjust it.
+- If you describe a vague idea (e.g. "make mining more fun"), Hermes will produce a prompt
+  that captures it but also notes what needs to be decided before implementation can begin.
+- The resulting prompt is an artifact. Paste it into Claude Code and let it do the rest.

--- a/docs/operations/hermes-skills/repo-health.md
+++ b/docs/operations/hermes-skills/repo-health.md
@@ -1,0 +1,89 @@
+# Skill: `superbot-repo-health`
+
+> **Status:** `living-ledger` — ready-to-use Hermes skill prompt. Update when the repo's health checks or CI setup change.
+
+**Window:** between sessions  
+**Purpose:** Traffic-light health snapshot. Answers "is anything broken right now?"
+without opening a full Claude Code session.
+
+**When to use:** Monday morning before deciding whether to start a session, after a
+long break, or any time you want confidence the repo is in a good state.
+
+---
+
+## Prompt
+
+```
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Do not modify any files. Read-only only.
+
+Run a REPO HEALTH CHECK and produce a traffic-light report. Use ✅ (green), ⚠️ (warning),
+or ❌ (red) for each dimension. Keep the whole output under 500 words.
+
+Run these checks in order:
+
+1. DOCS CHECK
+   Run: cd /home/hermes/repos/superbot && python3 scripts/check_docs.py --strict
+   ✅ if "all checks passed"
+   ❌ if any issues — list them verbatim (they are short)
+
+2. ARCHITECTURE CHECK
+   Run: cd /home/hermes/repos/superbot && python3 scripts/check_architecture.py --mode strict
+   ✅ if exit 0 with 0 errors
+   ⚠️ if warnings only (list count)
+   ❌ if errors — list them
+
+3. OPEN PRS
+   Run: gh pr list --repo menno420/superbot --state open --json number,title,isDraft,headRefName
+   ✅ if 0 open PRs
+   ⚠️ if 1–2 open (list them)
+   ⚠️ if any are non-draft and older than 2 days (note which)
+   ❌ if 3+ open PRs
+
+4. RECENT CI
+   Run: gh run list --repo menno420/superbot --limit 5 --json status,conclusion,headBranch,displayTitle
+   ✅ if all 5 completed with success
+   ⚠️ if 1 failure (note branch)
+   ❌ if 2+ failures
+
+5. WORKING TREE
+   Run: git -C /home/hermes/repos/superbot status --short
+   ✅ if clean
+   ⚠️ if modified files present (list them — they may be from a previous Hermes run)
+
+6. MAIN SYNC
+   Run: git -C /home/hermes/repos/superbot fetch origin main --dry-run 2>&1
+   Run: git -C /home/hermes/repos/superbot log --oneline origin/main..HEAD
+   ✅ if HEAD is at origin/main (no local commits ahead)
+   ⚠️ if local commits ahead of origin/main (list them — repo clone may be stale)
+
+Format the output as:
+
+---
+## SuperBot Repo Health — [today's date + time]
+
+| Dimension       | Status | Notes |
+|-----------------|--------|-------|
+| Docs            | ✅/⚠️/❌ | ... |
+| Architecture    | ✅/⚠️/❌ | ... |
+| Open PRs        | ✅/⚠️/❌ | ... |
+| Recent CI       | ✅/⚠️/❌ | ... |
+| Working tree    | ✅/⚠️/❌ | ... |
+| Main sync       | ✅/⚠️/❌ | ... |
+
+### Details
+[any ⚠️ or ❌ items expanded here, one paragraph each]
+
+### Verdict
+[one sentence — is the repo ready to work in, or does something need attention first?]
+---
+```
+
+---
+
+## Notes
+
+- If `python3` is not on the path, try `python3.10` (the repo uses Python 3.10 for CI).
+- The architecture check may produce warnings for known violations — these are tracked in
+  `architecture_rules/` YAML files and are expected. Warnings alone are not a blocker.
+- If `gh` is not authenticated, skip steps 3 and 4 and mark them ⚠️ "gh not available".

--- a/docs/operations/hermes-skills/session-brief.md
+++ b/docs/operations/hermes-skills/session-brief.md
@@ -1,0 +1,85 @@
+# Skill: `superbot-session-brief`
+
+> **Status:** `living-ledger` — ready-to-use Hermes skill prompt. Update when the repo's orientation docs or session workflow change.
+
+**Window:** pre-session  
+**Purpose:** Generate a compressed orientation brief that you paste into Claude Code at
+the start of a session. Skips the standard 15-minute orientation read.
+
+**When to use:** before opening a Claude Code session — on the train, in the morning,
+any time you know you're about to work on SuperBot.
+
+---
+
+## Prompt
+
+```
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Do not modify any files. Read-only only.
+
+Produce a SESSION BRIEF for a Claude Code agent about to start work on this repo.
+Keep the entire output under 800 words. Be concrete — no filler.
+
+Do the following steps in order:
+
+1. Run: git -C /home/hermes/repos/superbot log --oneline -5
+   Report the last 5 commits (hash + message only).
+
+2. Run: git -C /home/hermes/repos/superbot status --short
+   If the tree is dirty, list the modified files. If clean, say "working tree clean".
+
+3. Run: gh pr list --repo menno420/superbot --state open --json number,title,isDraft,headRefName
+   List all open PRs as: #NNN [draft?] title (branch). If none, say "no open PRs".
+
+4. Read: /home/hermes/repos/superbot/docs/current-state.md
+   Extract and summarize:
+   - Active implementation lanes (what work is in progress)
+   - Recently shipped (last 3 entries only)
+   - Any gates or blockers mentioned
+
+5. Read: /home/hermes/repos/superbot/docs/owner/maintainer-question-router.md
+   List any Q- blocks marked as open (not answered). One line each: Q-NNNN — topic.
+   If more than 5 open, show the 5 most recent only.
+
+6. Read the most recent file in /home/hermes/repos/superbot/.sessions/ (sort by filename, newest first).
+   Summarize in 3 bullet points: what was done, what was left open, what is next.
+
+7. Based on steps 3–6, suggest ONE focus for the next session in one sentence.
+
+Format the output as:
+
+---
+## SuperBot Session Brief — [today's date]
+
+### Recent commits
+[step 1]
+
+### Repo state
+[step 2]
+
+### Open PRs
+[step 3]
+
+### Active lanes & gates
+[step 4 summary]
+
+### Open questions (Q- blocks)
+[step 5]
+
+### Last session summary
+[step 6]
+
+### Suggested focus
+[step 7]
+---
+```
+
+---
+
+## Notes
+
+- The output is designed to be pasted directly at the start of a Claude Code session
+  as context, replacing the manual orientation read.
+- If `gh` is not authenticated, step 3 will fail — skip it and note "gh not available".
+- The suggested focus is a hint, not an instruction. Claude Code weighs it against its
+  own analysis.


### PR DESCRIPTION
## Summary

Implements the Hermes skill pack referenced in `docs/operations/hermes-control-plane.md` § "Recommended next project phase".

Adds `docs/operations/hermes-skills/` with 6 ready-to-use skill prompts:

| Skill | Window | Purpose |
|---|---|---|
| `session-brief` | Pre-session | Compressed orientation brief to paste into Claude Code |
| `repo-health` | Between sessions | Traffic-light snapshot (docs / arch / CI / open PRs / tree) |
| `ideas-triage` | Downtime | Backlog lifecycle review with a suggested next grooming move |
| `prompt-builder` | Pre-session | Turn a spoken idea into a structured Claude Code prompt |
| `open-questions` | Between sessions | Surface unanswered Q- blocks from the router |
| `btd6-status` | After live testing | BTD6 decode coverage and open bug snapshot |

Each skill is a self-contained prompt block — usable directly as a Telegram message to Hermes, or configured as a named Hermes skill on the VPS. All prompts default to read-only.

## Validation

- Documentation-only change. No code or tests changed.
- `check_docs --strict` passes (all 7 new docs carry status badges, README linked from `hermes-control-plane.md`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPAb4v65JWkfjz2EB1Myu7)_