### PR TITLE
docs(ideas): Claude Code plugin ecosystem evaluation + Q-0096 adoption gate

### DIFF
--- a/.sessions/2026-06-12-claude-code-plugins-research.md
+++ b/.sessions/2026-06-12-claude-code-plugins-research.md
@@ -1,0 +1,74 @@
+# 2026-06-12 — Claude Code plugin ecosystem research (owner question)
+
+**Ask (owner, verbatim):** "Can you find out if there are any good plugins for
+claude that would be useful for us" — research session, no code changes.
+
+## Arc
+
+1. Dedup-checked `docs/` for prior Claude-plugin work — none (all existing
+   "plugin/marketplace" hits are Discord-bot-ecosystem material, e.g. MEE6).
+2. Background web-research agent surveyed the mid-2026 plugin ecosystem
+   (official `anthropics/claude-plugins-official` marketplace, community
+   marketplaces, plugin-bundled MCP servers, supply-chain CVEs).
+3. **Spot-verified the load-bearing claims directly** (journal rule: verify
+   cross-agent output): official marketplace real (29.9k★); Context7 real and
+   hot (57.2k★, release 2026-06-11, hosted MCP now wants an API key);
+   `crystaldba/postgres-mcp` real with a read-only `--access-mode=restricted`;
+   team-pinning settings syntax pulled from the live docs — **the agent's
+   `enabledPlugins` format was wrong** (it's a `"name@marketplace": true` map,
+   not an array). Unverified install/star counts are marked as agent-reported
+   in the capture.
+4. Filtered against our baseline: review/workflow/memory/commit plugin
+   categories all duplicate or actively conflict with the bespoke system
+   (skills, journal, Q-0052/Q-0084 PR flow, CodeGraph).
+
+## Shipped (docs-only)
+
+- [`docs/ideas/claude-code-plugins-evaluation-2026-06-12.md`](../docs/ideas/claude-code-plugins-evaluation-2026-06-12.md)
+  — the evaluation: mechanics (verified pinning syntax incl. `sha` plugin pins
+  and `CLAUDE_CODE_PLUGIN_SEED_DIR` for containers), the
+  duplicates-vs-gaps table, shortlist (**Context7** > read-only Postgres MCP >
+  trial-only `pyright-lsp`), explicit skips (superpowers, claude-mem, review
+  plugins…), supply-chain posture + adoption rules.
+- Router **Q-0096** (open): which of the shortlist, if any, to wire in —
+  plugin/MCP enablement is ask-first executable config, so adoption awaits the
+  owner's pick. Safe default: plugin-free status quo.
+- Ideas README index entry.
+
+## Grooming note (Q-0015)
+
+The new capture was taken through intake → captured → **routed (discuss,
+Q-0096)** in-session — no idea left at `raw`. No other backlog idea moved
+(research session; main deliverable was itself backlog material).
+
+## Context delta
+
+- **Needed but not pointed to:** nothing significant — CLAUDE.md's "ask before
+  changing executable config" line answered the adoption-boundary question
+  directly; orientation route was adequate for a research task.
+- **Pointed to but didn't need:** the full binding-docs route
+  (architecture/ownership/runtime contracts) — irrelevant for a
+  tooling-research session; the task-shaped routing in AGENT_ORIENTATION could
+  name a "research/tooling" lane that skips them explicitly.
+- **Discovered by hand:** `enabledPlugins` settings syntax differs from what a
+  research agent reported (map, not array) — reinforces the standing
+  verify-cross-agent-output rule; now pinned in the capture doc.
+- **Decisions made alone:** recommended *against* the popular workflow/memory
+  plugins on the grounds that our bespoke system is the artifact (CLAUDE.md
+  premise) — owner can override via Q-0096. Chose plain `.mcp.json` wiring
+  over plugin wrappers as the recommended adoption shape (smaller trust
+  surface, matches the CodeGraph precedent).
+- **Flagged for maintainer / weak point:** ecosystem numbers (install counts,
+  CVE ids) are agent-reported web claims, only partially re-verified; anything
+  load-bearing for an adoption decision should be re-checked at wiring time.
+  Context7's hosted endpoint needs a (free) API key — local npx mode avoids it.
+
+💡 **Session idea (Q-0089):** **settings-tamper check in the session hooks** —
+the 2026 CVE class found in this research attacks agents by silently rewriting
+`.claude/settings.json` / `.mcp.json` / `~/.claude.json`. Cheap defense: the
+SessionStart (or Stop) hook diffs the repo's `.claude/settings.json` +
+`.mcp.json` against git HEAD and prints a loud warning when they differ
+uncommitted — tamper-evidence for the exact seam we treat as ask-first.
+Dedup: adjacent to the gap-analysis "toolchain rot watch" but distinct
+(integrity, not staleness). Small; a future session can add it to
+`claude_session_start.sh` (executable config → confirm with owner first).

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -30,6 +30,14 @@ Current broad captures:
 > beats occasional brilliance). Substantial ones land here as files; small ones
 > live in their session log's 💡 flag. The grooming pass then moves them.
 
+- [`claude-code-plugins-evaluation-2026-06-12.md`](./claude-code-plugins-evaluation-2026-06-12.md) —
+  **owner-asked (2026-06-12):** "any good Claude (Code) plugins useful for us?" —
+  ecosystem survey (official + community marketplaces, spot-verified), filtered
+  against our existing hooks/skills/CodeGraph stack. Verdict: most categories
+  duplicate or fight our bespoke workflow; shortlist = **Context7** (live
+  version-pinned library docs, strongest), read-only **Postgres MCP**, trial-only
+  `pyright-lsp`. Supply-chain posture + pinning rules included. Adoption =
+  executable-config change → routed to **Q-0096** (discuss lane).
 - [`ai-panel-inplace-navigation-2026-06-11.md`](./ai-panel-inplace-navigation-2026-06-11.md) —
   **owner-requested (2026-06-11 live session):** the AI settings/panel family
   spawns a new ephemeral message per navigation click, scatters config across seven subpanels + a flat scalar editor (second owner ask: centralize), and extends raw

--- a/docs/ideas/claude-code-plugins-evaluation-2026-06-12.md
+++ b/docs/ideas/claude-code-plugins-evaluation-2026-06-12.md
@@ -1,0 +1,152 @@
+# Claude Code plugins — ecosystem evaluation & adoption shortlist (2026-06-12)
+
+> **Status:** `ideas` — research capture + recommendation. **Nothing here is
+> approved for implementation.** Plugin enablement lives in
+> `.claude/settings.json` (executable config → **ask-first** per the CLAUDE.md
+> working agreement), so adoption is an owner decision: **Q-0096** in
+> `docs/owner/maintainer-question-router.md`.
+>
+> **Provenance:** owner asked "are there any good plugins for claude that would
+> be useful for us?" (2026-06-12). A web-research agent surveyed the ecosystem;
+> the load-bearing claims below were then **spot-verified directly** (marked ✓).
+> Unmarked install counts / star figures are agent-reported — re-verify before
+> citing. Source code and live docs win over this file.
+
+## 1. What a Claude Code plugin is (verified ✓ against code.claude.com docs)
+
+A plugin is a git-distributed bundle that can carry **skills, agents, hooks,
+MCP servers, LSP servers, bin executables, and default settings**. Plugins are
+listed in **marketplaces** (a repo with `.claude-plugin/marketplace.json`);
+users add a marketplace and install from it (`/plugin` UI or
+`claude plugin install <name>@<marketplace>`).
+
+Team-wide pinning in repo `.claude/settings.json` (exact syntax ✓ verified
+2026-06-12 from `code.claude.com/docs/en/plugin-marketplaces`):
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "claude-plugins-official": {
+      "source": { "source": "github", "repo": "anthropics/claude-plugins-official" }
+    }
+  },
+  "enabledPlugins": {
+    "context7@claude-plugins-official": true
+  }
+}
+```
+
+(Note: `enabledPlugins` is a **map** of `"name@marketplace": true` — a prior
+agent report showed an array-of-objects format; that is wrong.)
+
+Version pinning: a plugin entry in `marketplace.json` supports `ref`
+(branch/tag) **and `sha`** (exact commit — the effective pin when both are
+set); the marketplace source itself supports only `ref`. For containers/CI,
+`CLAUDE_CODE_PLUGIN_SEED_DIR` pre-populates plugins at image build time —
+relevant to our remote-sandbox sessions if we ever adopt plugins there.
+
+## 2. Why our baseline changes the answer
+
+Most of the popular plugin categories are things **we already have, better-fitted**:
+
+| Plugin category | Our existing equivalent | Verdict |
+|---|---|---|
+| Code review / PR review plugins | built-in `code-review` + `security-review` skills, repo `/pre-pr`, `/architecture-review` | **Skip** — duplicate |
+| Workflow/process plugins (e.g. obra/superpowers, `feature-dev`) | the whole CLAUDE.md + journal + session-close system | **Skip** — direct conflict with our binding workflow |
+| Memory plugins (claude-mem, memsearch, …) | `.session-journal.md` + `.sessions/` + `docs/current-state.md` (designed, audited, git-versioned) | **Skip** — ours is the artifact; a SQLite side-memory undermines it |
+| Commit/PR helper plugins | Q-0052/Q-0084 PR workflow + GitHub MCP | **Skip** |
+| Code-intelligence | CodeGraph MCP (pinned `@optave/codegraph@3.11.2`) + `context_map.py` | **Skip**; `pyright-lsp` is the one maybe (see §3.3) |
+
+The interesting candidates are the ones that add a capability we **don't** have.
+
+## 3. Shortlist (best → weakest)
+
+### 3.1 Context7 — live, version-pinned library docs (strongest candidate)
+
+- **What:** MCP server that injects up-to-date, version-specific docs for the
+  library under discussion (discord.py, asyncpg, PIL, pytest…), instead of the
+  model's training-data memory of the API.
+- **Verified ✓ (2026-06-12):** `upstash/context7`, 57.2k stars, release
+  `@upstash/context7-mcp@3.2.0` published 2026-06-11 (actively maintained).
+  Hosted endpoint `https://mcp.context7.com/mcp` now wants a `CONTEXT7_API_KEY`
+  header (free tier exists); also runnable locally via npx.
+- **Why us:** our recurring bug class "API used from memory" (e.g. the pinned
+  `youtube-transcript-api<1.0` churn rule) is exactly what this addresses;
+  discord.py is a fast-churning API.
+- **Cost/risk:** third-party MCP server sees prompts/queries (external
+  service); adds context overhead per use. Pin the version like CodeGraph.
+
+### 3.2 Postgres MCP (Postgres MCP Pro) — live schema/EXPLAIN access
+
+- **What:** MCP server giving the agent schema inspection, EXPLAIN/index
+  analysis, health checks, and SQL execution against a running Postgres.
+- **Verified ✓ (2026-06-12):** `crystaldba/postgres-mcp`, 2.9k stars, has a
+  **`--access-mode=restricted`** read-only mode — the only mode we'd consider.
+- **Why us:** sandbox sessions already run a live local Postgres for the test
+  bot; today agents introspect it via ad-hoc `psql` in Bash. A read-only MCP
+  makes migrations/`utils/db` work schema-aware.
+- **Counterpoint:** `psql` via Bash already works and is zero-trust-surface;
+  value-add is modest. Would be `.mcp.json`-level, not a "plugin" per se.
+
+### 3.3 `pyright-lsp` (official marketplace) — language-server intelligence
+
+- **What:** real jump-to-def / type diagnostics in-session via Pyright.
+- **Why us:** could complement CodeGraph (whose caller/dead-code edges have
+  known false positives) with ground-truth symbol resolution.
+- **Counterpoint:** mypy already runs in the CI mirror; LSP overhead on a
+  1,400-file monorepo unknown; CodeGraph + grep discipline already encodes our
+  trust tiers. **Trial-first candidate, not adopt-first.**
+
+### 3.4 `security-guidance` (official) — vuln scan on every edit
+
+- Complements (doesn't conflict with) `/security-review`. Low priority: the
+  bot's attack surface is Discord-side authority checks, which our
+  architecture rules + governance seams already police better than a generic
+  OWASP scanner.
+
+### Explicit skips
+
+`superpowers` (752k installs, real and good — but its workflow would fight our
+binding collaboration model) · claude-mem / memory plugins (journal is
+first-class here) · `code-review`/`pr-review-toolkit`/`feature-dev`/
+`commit-commands` (native or repo-skill duplicates) · `connect-apps`/Composio
+(no SaaS-integration need) · `playwright` (no web dashboard yet — revisit when
+the Q-0042 staged-Someday website moves) · Discord "Channels" plugins (run
+Claude *from* Discord; unrelated to bot development).
+
+## 4. Supply-chain posture (why ask-first is right here)
+
+Plugins can ship **hooks (arbitrary code at session start/edit/stop)** and MCP
+servers (tool access). Public CVEs in 2026 (agent-reported: CVE-2025-59536,
+CVE-2026-21852 — settings-file rewrite → code exec / key exfiltration) target
+exactly the `.claude/settings.json` / `~/.claude.json` seam. Our current
+posture — repo-owned hooks only, one pinned MCP server — is the defensible
+end of the spectrum. Adoption rules if Q-0096 approves anything:
+
+1. **Pin** (sha or exact version) like the CodeGraph pin; auto-update off.
+2. **Audit the bundle** (`claude plugin` details / read the repo) for hooks
+   before enabling — prefer plugins that are MCP/skills-only, no hooks.
+3. **Provenance header discipline** (Q-0014): record why/when/`unverified —
+   confirm output across sessions` in this file + CLAUDE.md if adopted.
+4. Prefer plain `.mcp.json` entries over plugin wrappers when the value is
+   just an MCP server (Postgres, Context7) — smaller trust surface, and it
+   matches how CodeGraph is already wired.
+
+## 5. Recommendation
+
+**Adopt nothing silently.** Proposed to the owner as Q-0096:
+
+- **Yes (trial):** Context7 — as a pinned `.mcp.json` server (not the plugin
+  wrapper), trialed for a few sessions on discord.py/asyncpg work, verified
+  per Q-0014 before being declared trusted.
+- **Optional:** read-only Postgres MCP for sandbox DB work.
+- **Trial-only if curious:** `pyright-lsp`.
+- **No:** workflow/memory/review plugins — they duplicate or fight the system
+  we deliberately built.
+
+## Lifecycle
+
+- **State:** captured → **routed (discuss)** — owner decision **Q-0096**.
+- On approval: a session wires the approved item(s) (`.mcp.json` /
+  `settings.json` edit, pin, provenance note, journal Runbook update) — small,
+  single-PR work.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -3833,3 +3833,41 @@ prod-mirror boot is used for final verification passes. Evidence from this
 session: after the BUG-0005…0008 routing/grounding fixes, gpt-4o-mini
 produced the correct, subject-stable farm-income answers — the pipeline, not
 the model, was the bottleneck.
+
+### Q-0096 — Claude Code plugins: adopt the Context7 / Postgres-MCP shortlist, or stay plugin-free?
+
+**Area:** Agent workflow / tooling / executable config (`.claude/settings.json`, `.mcp.json`)
+**Type:** Owner decision (adoption gate — plugin enablement is ask-first executable config)
+**Priority:** Low-medium (quality-of-life for agent sessions; nothing is blocked)
+**Status:** **Open** (asked 2026-06-12, prompted by the owner's own question
+"are there any good plugins for claude that would be useful for us?")
+
+**Question:** The 2026-06 plugin-ecosystem survey
+([`docs/ideas/claude-code-plugins-evaluation-2026-06-12.md`](../ideas/claude-code-plugins-evaluation-2026-06-12.md))
+found most plugin categories duplicate or conflict with our bespoke
+workflow (review skills, journal memory, PR process, CodeGraph). Three
+candidates add a genuinely missing capability. Which, if any, should a
+session wire in (pinned, provenance-headered, Q-0014 trial discipline)?
+
+- **(a) Context7** — live version-pinned library docs (discord.py / asyncpg
+  API truth instead of model memory). Recommended **yes, as a pinned
+  `.mcp.json` server**, trialed a few sessions before trusted. Note: hosted
+  endpoint wants a free API key; can also run locally via npx.
+- **(b) Read-only Postgres MCP** (`crystaldba/postgres-mcp`,
+  `--access-mode=restricted`) — schema-aware DB work in sandbox sessions.
+  Optional; ad-hoc `psql` already covers most of this.
+- **(c) `pyright-lsp`** (official marketplace) — LSP ground truth beside
+  CodeGraph. Trial-only if curious; unknown overhead on 1,400 files.
+- **(d) none** — stay plugin-free; current posture is the safest
+  supply-chain stance and nothing is blocked today.
+
+**Why agents need this:** plugin/MCP enablement edits `.claude/settings.json` /
+`.mcp.json` — the one seam the working agreement marks ask-first, and the seam
+2026 CVEs target. Silent adoption is off the table by design.
+
+**Safe default until answered:** plugin-free status quo (CodeGraph remains the
+only MCP server beyond the environment's GitHub MCP).
+
+**Suggested destination after answer:** the evaluation doc's §Lifecycle (flip
+state), `.mcp.json` + journal Runbook if anything is adopted, CLAUDE.md
+CodeGraph-style pin note for any new server.


### PR DESCRIPTION
## What

Research session answering the owner's question: **"are there any good plugins for Claude that would be useful for us?"** Docs-only.

- **`docs/ideas/claude-code-plugins-evaluation-2026-06-12.md`** — the evaluation: plugin/marketplace mechanics (team-pinning syntax verified against live docs, incl. `sha` plugin pins and the container seed-dir), a duplicates-vs-gaps table against our existing hooks/skills/CodeGraph stack, the shortlist, explicit skips, and supply-chain adoption rules.
- **Router Q-0096 (open)** — the adoption decision: plugin/MCP enablement edits `.claude/settings.json`/`.mcp.json` (ask-first executable config), so nothing was installed. Safe default = plugin-free status quo.
- Ideas README index entry + session log.

## Verdict (short)

Most popular plugin categories **duplicate or conflict** with our bespoke workflow (review skills, journal memory, PR process, CodeGraph). Genuinely additive shortlist:

1. **Context7** (live version-pinned library docs — discord.py/asyncpg API truth; recommended as a pinned `.mcp.json` server, Q-0014 trial discipline) — strongest.
2. **Read-only Postgres MCP** (`crystaldba/postgres-mcp --access-mode=restricted`) — optional.
3. **`pyright-lsp`** — trial-only.

Load-bearing claims spot-verified (marketplace repos, Context7 activity, restricted mode, settings syntax — one agent-reported syntax error corrected); remaining ecosystem numbers marked agent-reported in the doc.

https://claude.ai/code/session_012HVWN1TbADbySvud1SoiyA

---
_Generated by [Claude Code](https://claude.ai/code/session_012HVWN1TbADbySvud1SoiyA)_