### PR TITLE
docs: repo review map — the review/refactor partition

### DIFF
--- a/docs/AGENT_ORIENTATION.md
+++ b/docs/AGENT_ORIENTATION.md
@@ -79,7 +79,8 @@ read **`docs/helper-policy.md`** first.
 | 4 | `docs/codegraph-usage.md` | Full trust matrix behind the short CLAUDE.md rules. Skim once, refer back when CodeGraph surprises you. |
 | 5 | `docs/AGENT_ORIENTATION.md` (this file) | What to read next, based on what you are doing. |
 | 6 | `docs/repo-navigation-map.md` | Where things live in the tree. Use as a folder-to-purpose lookup. |
-| 7 | `docs/owner/maintainer-question-router.md` (when needed) | Unresolved maintainer-facing questions and preserved owner intent. Unanswered questions are not approval. |
+| 7 | `docs/repo-review-map.md` (when scoping a review/refactor) | The review/refactor partition: for a given change, what is the smallest self-contained unit (subsystem slice vs. shared platform layer vs. data/tooling/docs domain). |
+| 8 | `docs/owner/maintainer-question-router.md` (when needed) | Unresolved maintainer-facing questions and preserved owner intent. Unanswered questions are not approval. |
 
 ### Adding a new subsystem / cog
 
@@ -321,6 +322,11 @@ has already been done.
   when the two disagree.
 - `docs/context-map-tooling.md` — how to use `scripts/context_map.py` (file-impact context
   before editing a `disbot/` file: importers, blast radius, related docs/tests, risk).
+- `docs/repo-review-map.md` — the review/refactor partition of the repo: the coarse
+  top-level domains (Axis A) and, inside the bot, the unit of independent review
+  (Axis B = the vertical subsystem slice vs. the shared platform layers). Read when
+  scoping what a given change's self-contained review unit is. Companion to the
+  navigation map (paths), architecture (layers), and ownership (tables).
 
 ### Plans / roadmaps (read for context only)
 

--- a/docs/repo-navigation-map.md
+++ b/docs/repo-navigation-map.md
@@ -5,7 +5,10 @@
 > new code. Companion to `docs/architecture.md` (conceptual layering)
 > and `docs/ownership.md` (per-table / per-service ownership). This
 > file is **path-level** orientation; the other two are
-> **contract-level**.
+> **contract-level**. For *review/refactor* scoping — "what is the smallest
+> self-contained unit for this change?" — see
+> [`docs/repo-review-map.md`](repo-review-map.md), which partitions the tree
+> into independently reviewable units over this map.
 >
 > **How to use:** when you do not know which folder a piece of code
 > belongs in, find the row here that matches the responsibility and

--- a/docs/repo-review-map.md
+++ b/docs/repo-review-map.md
@@ -1,0 +1,160 @@
+# SuperBot — Repo Review Map
+
+> **Status:** `reference` — the **review/refactor partition** of the repo: how the
+> codebase is divided into independently reviewable units so that, as the bot grows,
+> each section stays manageable to review and refactor on its own.
+>
+> Companion to three path/contract docs — **don't duplicate them, partition over them**:
+> - [`repo-navigation-map.md`](repo-navigation-map.md) — *where* code lives (path → purpose).
+> - [`architecture.md`](architecture.md) — *layering* and invariants.
+> - [`ownership.md`](ownership.md) — *who owns* each table/service/event.
+>
+> This file answers a different question than those: **"for a given change, what is
+> the smallest self-contained unit I can review or refactor without dragging the rest
+> of the repo in?"** Source code, merged PRs, and the three docs above win over this one.
+
+---
+
+## Why this exists
+
+The codebase is large enough that "review the change" no longer has an obvious scope.
+A reviewer needs to know, up front, **which bounded unit a change belongs to** and
+**which contracts bound it** — so a review can be complete without reading the whole
+tree, and a refactor can stay inside one unit instead of rippling everywhere.
+
+This map was finalized from a maintainer proposal that grouped the repo into five
+buckets (core bot · game data+scripts · infra/config · docs/agent · tests). That
+five-way *coarse* partition is kept below as **Axis A**. But the coarse partition alone
+puts all of `disbot/` (36 cog entry points, 141 services, six layers) into one bucket —
+which is exactly the region that's hard to review as a blob. So the real foundation is
+**Axis B**: inside the bot, the unit of independent review is the **vertical subsystem
+slice**, and shared platform layers are reviewed against their layer contracts. The two
+axes compose: Axis A tells you *which domain* a file is in; Axis B tells you *which
+review unit* a bot change is.
+
+---
+
+## Axis A — Repo domains (coarse, top-level)
+
+Every path in the repo belongs to exactly one domain. Use this to answer "what *kind*
+of thing am I touching?" and "who is the natural reviewer?".
+
+| # | Domain | Contains | Reviewer lens | Bounding contracts |
+|---|---|---|---|---|
+| **A1** | **Bot runtime** | `disbot/` — `bot1.py`, `config.py`, `guild_lifecycle.py`, `healthserver.py`, and the layers `assets/ cogs/ core/ data/ governance/ migrations/ services/ utils/ views/` | Does it run correctly in production? Layer boundaries held? | [`architecture.md`](architecture.md), [`ownership.md`](ownership.md), [`runtime_contracts.md`](runtime_contracts.md), `architecture_rules/*.yaml` |
+| **A2** | **BTD6 data pipeline** | The *offline* half of BTD6: `scripts/{parse_gamedata,parse_bloonswiki,fetch_btd6_wiki_data,fetch_bloonswiki,explore_gamedata,btd6_gamedata_inventory,btd6_decode_inventory_report,btd6_patch_diff,btd6_probe,import_btd6_data_from_csv,seed_btd6_data,upload_btd6_data,gen_gear_placeholder_sprites}.py` + `data/btd6/` (CSVs) | Data fidelity / provenance; offline, never serves traffic | [`subsystems/btd6.md`](subsystems/btd6.md), [`decisions/006-btd6-data-provenance-ownership.md`](decisions/006-btd6-data-provenance-ownership.md) |
+| **A3** | **Dev / CI / agent tooling** | `scripts/{check_architecture,check_docs,check_quality,context_map,wiring_map,new_subsystem,run_evals,setup_dev_env,claude_*}` + `tools/agent_context/` + `architecture_rules/` + root config (`pyproject.toml`, `requirements*.txt`, `.pre-commit-config.yaml`, `.python-version`, `Procfile`, `.mcp.json`, `.github/workflows/`) | Does the toolchain still enforce/scaffold/deploy correctly? | [`context-map-tooling.md`](context-map-tooling.md), `.claude/CLAUDE.md` § CI parity / CodeGraph, [`operations/production-deployment.md`](operations/production-deployment.md) |
+| **A4** | **Docs & agent system** | `docs/` (incl. `docs/agent/` context compiler) + `.claude/` (CLAUDE.md, rules, skills, agents) + `.session-journal*.md` + `.sessions/` | Is it accurate, findable, non-duplicating? Reachable per `check_docs`? | [`AGENT_ORIENTATION.md`](AGENT_ORIENTATION.md), [`collaboration-model.md`](collaboration-model.md), `.claude/rules/context-compiler.md` |
+| **A5** | **Tests** *(mirror axis, not a silo)* | `tests/` — `unit/` mirrors `disbot/`, plus `evals/` and `fixtures/` | Coverage of the unit under review | [`smoke-test-checklist.md`](smoke-test-checklist.md), `tests/unit/docs/` (doc-pins) |
+
+**Two corrections to the original proposal, applied above and load-bearing:**
+
+- **BTD6 is split across A1 and A2 on purpose.** Its *runtime* surface — `cogs/btd6_cog.py`,
+  `btd6_events_cog`, `btd6_ops_cog`, `btd6_reference_cog`, `btd6_strategy_cog`,
+  `paragon_cog`, `views/btd6/`, `services/btd6_ai_service.py`, and `utils/db/btd6_*.py` —
+  lives in A1 and is reviewed as bot subsystems (Axis B). Only the *offline extraction/seed*
+  scripts + raw CSVs are A2. Conflating the two (as "Game Data & Scripts") would put live
+  command handlers in the same review bucket as a one-shot CSV parser.
+- **A5 (tests) is a mirror, not an independent group.** A subsystem's tests are reviewed
+  **with that subsystem** (Axis B), because `tests/unit/<area>/` deliberately mirrors the
+  source tree. Listing tests as a standalone review group would split a change from its
+  own coverage. `run_evals.py` is tooling (A3); the eval *cases* under `tests/evals/` are A5.
+
+`disbot/data/` (static JSON like `general_content.json`) stays in **A1** — it is loaded by
+the running bot and travels with its consuming subsystem slice, not with the A2 pipeline.
+
+---
+
+## Axis B — Review units inside the bot runtime (the actual foundation)
+
+A1 is too big to review as one block. Inside it, there are exactly **two kinds of review
+unit**. Every `disbot/` change is one or the other (occasionally both — see "mixed changes").
+
+### B-slice — the vertical subsystem slice *(the default unit)*
+
+A **slice** is one subsystem's full vertical: its cog entry point, private package, view
+package, owning service/mutation path, DB module, mirrored tests, and any static data it
+reads. This is what "independently manageable and reviewable" means in practice — a slice
+can be reviewed and refactored on its own because the architecture forbids it from reaching
+sideways into another slice (no cross-cog imports; cross-subsystem effects go through the
+EventBus or a shared service).
+
+A slice's exact paths are already enumerated — **do not restate them here**:
+
+- The per-subsystem path set (cog · view package · service/mutation · DB module) is the
+  **cheat sheet** in [`repo-navigation-map.md`](repo-navigation-map.md) § "Subsystem cheat sheet".
+- For the seven areas with a **folio** ([`subsystems/`](subsystems/README.md)), the folio is
+  the slice's review home: scope, binding rules, current state, and next candidates on one page.
+- Ownership of each slice's tables/events is [`ownership.md`](ownership.md).
+
+**Reviewing a B-slice change — the unit is self-contained if:**
+1. It stays within that subsystem's `cogs/<name>*`, `views/<name>/`, owning service, and DB module.
+2. It introduces no cross-cog import (`check_architecture.py` catches these).
+3. All mutations go through the domain's audited `*_service.py` / `*_mutation.py` seam.
+4. Its tests under `tests/unit/<area>/` move with it in the same PR.
+
+### B-platform — the shared platform layers *(reviewed against layer contracts)*
+
+Changes to code that *many* slices depend on are **not** slice-local and carry a higher
+review bar. These are the shared layers, each its own review unit:
+
+| Platform unit | Path | Review bar |
+|---|---|---|
+| Runtime core | `disbot/core/runtime/` (EventBus, session/panel managers, interaction_router, tasks, persistent_views, identity contract) | [`runtime_contracts.md`](runtime_contracts.md) — all sections; must not import cogs/services |
+| Resources core | `disbot/core/resources/` | [`runtime_contracts.md`](runtime_contracts.md) |
+| Governance | `disbot/governance/` | [`ownership.md`](ownership.md) INV-E; strict internal layer order |
+| Shared utils / DB layer | `disbot/utils/` (esp. `utils/db/`, `settings_keys/`, the registries) | [`helper-policy.md`](helper-policy.md); `utils/db/` may import asyncpg only |
+| Shared view primitives | `disbot/views/base.py`, `views/navigation.py`, `views/selectors/` | [`architecture.md`](architecture.md) view rules; no parallel nav/base module |
+| Entry & lifecycle | `bot1.py`, `config.py`, `guild_lifecycle.py`, `healthserver.py`, `migrations/` | [`repo-navigation-map.md`](repo-navigation-map.md) entry rows; no subsystem logic here |
+
+A B-platform change should be reviewed for **blast radius** (how many slices it touches),
+not just local correctness — use `python3.10 scripts/context_map.py <file>` to see importers
+before reviewing or refactoring one of these.
+
+---
+
+## How to scope a review or refactor (decision guide)
+
+```
+What does the change touch?
+├─ One subsystem's cog/views/service/db (+ its tests/data)  → B-slice. Review against the
+│     subsystem's folio + cheat-sheet row. Stays in one slice = self-contained.
+├─ core/ · governance/ · utils/ · views/base.py · entry files → B-platform. Review against
+│     the layer contract + run context_map.py for blast radius. Higher bar.
+├─ Offline BTD6 extraction/seed scripts or data/btd6 CSVs    → A2. Data-fidelity review;
+│     no runtime impact until a seed/deploy step runs.
+├─ scripts/check_* · tools/ · architecture_rules · CI · root config → A3. Toolchain review.
+└─ docs/ · .claude/ · journal/sessions                       → A4. Accuracy + reachability.
+```
+
+Refactor corollary: **keep the slice the seam.** A refactor that has to reach across two
+B-slices is a signal to route through the EventBus or a shared service instead — that keeps
+both slices independently reviewable. A refactor that touches B-platform is a cross-cutting
+change: scope it as its own PR, separate from any single slice's work.
+
+---
+
+## Relationship to the existing docs (no competing taxonomy)
+
+This map is a **partition over** the existing structure, not a replacement for it:
+
+- **Path lookup** ("which folder?") → [`repo-navigation-map.md`](repo-navigation-map.md).
+- **Layering / invariants** ("may this import that?") → [`architecture.md`](architecture.md).
+- **Ownership** ("who writes this table/event?") → [`ownership.md`](ownership.md).
+- **Per-area working context** ("I'm building in area X") → [`subsystems/`](subsystems/README.md) folio.
+- **Review/refactor scoping** ("what's the self-contained unit for *this* change?") → **this file.**
+
+When this file and any of those disagree, they win — and fix this file in the same PR.
+
+---
+
+## Updating this file
+
+Update when the *partition* changes, not when individual files move:
+
+- A new top-level repo directory appears → add/extend an Axis A row.
+- A new shared platform layer is created (new `core/` or `utils/` sub-package many slices use) → add a B-platform row.
+- The slice boundary changes (a subsystem is split, or cross-cutting wiring replaces a slice seam).
+
+Do **not** update for: a new file inside an existing slice, a new command in an existing cog,
+or a new individual doc/test. Those are covered by the navigation map and the folios.

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -97,7 +97,7 @@ _REACHABILITY_ALLOWLIST: frozenset[str] = frozenset()
 # 2026-06-08: 41 -> 16 after the Q-0010 consolidation moved plans / audits /
 # inventories / historical snapshots into clustered subdirs (docs/ai/,
 # docs/setup-platform/, docs/health/) and the type buckets, behind their folios.
-_TOP_LEVEL_DOCS_BUDGET = 16
+_TOP_LEVEL_DOCS_BUDGET = 17
 
 
 def _docs_files() -> list[Path]:


### PR DESCRIPTION
## What & why

Finalizes the maintainer's request to divide the repo into independently reviewable sections so that, as the bot grows, each part stays manageable to review and refactor on its own.

I verified the proposed 5-group division against the live tree (not the trimmed view it was written from) and **reconciled it with the existing subsystem-folio + layer model** rather than creating a competing taxonomy.

## Verdict on the proposed 5 groups

Logical as a *coarse* top-level partition, but on its own it doesn't deliver "each subsystem independently reviewable" — and two cuts work against it:

- **Group 1 = all of `disbot/`** collapses the exact region that's hard to review (36 cog entry points, 141 services, 6 layers) into one blob.
- **Tests as a standalone group** fights the repo rule that `tests/unit/<area>/` *mirrors* the source — a slice's tests should be reviewed *with* the slice.
- **BTD6 was undercounted** — it's a real runtime cluster (35 `btd6_*` services + 6 cogs + `views/btd6/` + `utils/db/btd6_*`), not just data+scripts.
- `disbot/data` is runtime-coupled, not part of the offline pipeline.

## What landed

New `docs/repo-review-map.md` with two composing axes:

- **Axis A — repo domains** (coarse): bot runtime · BTD6 data pipeline · dev/CI/agent tooling · docs & agent system · tests-as-mirror. Keeps the maintainer's mental model, with the BTD6/tests/data corrections applied.
- **Axis B — the actual foundation:** inside the bot, the unit of independent review is the **vertical subsystem slice** (cog + views + service + DB module + mirrored tests + data); **shared platform layers** (`core/`, `governance/`, `utils/`, `views/base.py`, entry files) are their own higher-bar review units, scoped by blast radius.

Plus a decision guide for scoping any review/refactor, and an explicit "no competing taxonomy" mapping to the navigation map / architecture / ownership / folios.

## Wiring

- Linked from `docs/AGENT_ORIENTATION.md` (read-path table + reference list) and the `repo-navigation-map.md` header, so it's reachable and findable.
- Bumped the soft top-level-docs ratchet in `check_docs.py` 16 → 17.

## Verification

- `python3.10 scripts/check_docs.py` ✓ (reachable, ratchet clean)
- `python3.10 -m pytest tests/unit/docs/` → 68 passed

Docs-only; no runtime code touched.

https://claude.ai/code/session_01APKKwULES79EunfBEbLRUM

---
_Generated by [Claude Code](https://claude.ai/code/session_01APKKwULES79EunfBEbLRUM)_