### PR TITLE
chore(session): close 2026-06-12 repo-review-map session

### DIFF
--- a/.sessions/2026-06-12-repo-review-map.md
+++ b/.sessions/2026-06-12-repo-review-map.md
@@ -1,0 +1,56 @@
+# 2026-06-12 — Repo review map (the review/refactor partition)
+
+> **Status:** `audit` — per-session log. Newest-first sibling of the other `.sessions/` files.
+
+**PR:** [#715](https://github.com/menno420/superbot/pull/715) — `docs/repo-review-map.md` (merged, `9a18d1a`). Session-close artifacts ship in a follow-up PR on the same branch.
+**Branch:** `claude/sleepy-hawking-tgderi`
+
+## What was done
+
+- **Finalized the repo division the owner asked for** into `docs/repo-review-map.md`.
+  Verified the proposed 5-group split against the live tree (not the trimmed view it was
+  written from) and reconciled it with the existing subsystem-folio + layer model instead
+  of creating a competing taxonomy.
+  - **Axis A** (coarse, top-level): bot runtime · BTD6 data pipeline · dev/CI/agent tooling ·
+    docs & agent system · tests-as-mirror.
+  - **Axis B** (the actual foundation): inside the bot, the review unit is the **vertical
+    subsystem slice**; shared platform layers (`core/`, `governance/`, `utils/`,
+    `views/base.py`, entry files) are separate higher-bar units scoped by blast radius.
+  - Corrections applied where the proposal worked against the goal: BTD6 runtime (35
+    `btd6_*` services + 6 cogs + `views/btd6/` + `utils/db/btd6_*`) stays in the bot;
+    tests **mirror** their slice rather than forming a silo; `disbot/data` is runtime not
+    pipeline.
+- Wired the doc into the read-path: `AGENT_ORIENTATION.md` (reading table + reference list)
+  and the `repo-navigation-map.md` header. Bumped the soft top-level-docs ratchet 16→17 in
+  `check_docs.py`.
+- Merged PR #715 myself (Q-0084): branch current with `main`, CI `code-quality` green,
+  merge-commit method. Subscribed/auto-unsubscribed on merge.
+- **Grooming move:** routed [`ai-panel-inplace-navigation-2026-06-11.md`](../docs/ideas/ai-panel-inplace-navigation-2026-06-11.md)
+  one step — `captured → on the roadmap` (placed at `docs/roadmap.md` § AI **Later**, UX
+  debt; idea file stamped with the routing note).
+
+## Decisions recorded
+
+- None new. Exercised standing grants: Q-0052 (early-draft PR + advance consent),
+  Q-0084 (merge own session PR when green), Q-0089 (one new idea per session).
+- Judgment call (flagged to owner): the division is documented as a **review/refactor
+  lens** over the existing structure, **not** a physical folder reorg — the architecture
+  already enforces the slice boundaries that make independent review possible. Owner can
+  request a physical reorg (e.g. `scripts/btd6/` vs `scripts/dev/`) as a separate larger change.
+
+## Left open / next session
+
+- Optional **physical reorg** to make Axis A visible on disk (owner-gated, larger).
+- The new idea below (review-unit tagging) sits in the quick-win lane, not auto-promoted.
+
+## 💡 Session idea
+
+**Idea:** Operationalize `repo-review-map.md` in tooling — have `scripts/context_map.py`
+print a file's **review unit** (subsystem slice vs. shared-platform layer), and add a
+PR-level `scripts/review_scope.py` that classifies a changed-file set as single-slice /
+multi-slice / platform.
+**Why:** A partition that only lives in a doc decays; one the toolchain emits on every
+edit/PR gets used — and it catches the exact failure the map exists to prevent (a PR that
+quietly grew from one slice into a cross-slice or platform change). Read-only, cheap, fits
+the repo's "custom AST tooling" preference.
+Idea file created: [`docs/ideas/review-unit-tagging-2026-06-12.md`](../docs/ideas/review-unit-tagging-2026-06-12.md) (indexed in the ideas README).

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -30,6 +30,13 @@ Current broad captures:
 > beats occasional brilliance). Substantial ones land here as files; small ones
 > live in their session log's 💡 flag. The grooming pass then moves them.
 
+- [`review-unit-tagging-2026-06-12.md`](./review-unit-tagging-2026-06-12.md) —
+  **session idea (2026-06-12, Q-0089):** operationalize the new
+  [`repo-review-map.md`](../repo-review-map.md) — have `context_map.py` print a file's
+  review unit (subsystem slice vs. shared-platform layer), and add a PR-level
+  `review_scope.py` that classifies a changed-file set as single-slice / multi-slice /
+  platform. Turns the review partition from a doc you must remember into a signal the
+  toolchain emits. Read-only, quick-win lane, not auto-promoted.
 - [`claude-code-plugins-evaluation-2026-06-12.md`](./claude-code-plugins-evaluation-2026-06-12.md) —
   **owner-asked (2026-06-12):** "any good Claude (Code) plugins useful for us?" —
   ecosystem survey (official + community marketplaces, spot-verified), filtered

--- a/docs/ideas/ai-panel-inplace-navigation-2026-06-11.md
+++ b/docs/ideas/ai-panel-inplace-navigation-2026-06-11.md
@@ -3,6 +3,10 @@
 > **Status:** `ideas` — **owner-requested direction, not yet planned/scheduled.**
 > Captured mid live-testing session (Q-0086 joint session, 2026-06-11). Not a plan;
 > promotion path is `docs/ideas/README.md` → a `docs/planning/` slice when picked up.
+>
+> **Routed (2026-06-12):** placed on `docs/roadmap.md` § AI at the **Later** horizon
+> (UX debt, owner-requested). State: `captured → on the roadmap`. Next step when picked
+> up = a `docs/planning/` slice (wants its own session with runtime context).
 
 ## What the owner said (live session, 2026-06-11)
 

--- a/docs/ideas/review-unit-tagging-2026-06-12.md
+++ b/docs/ideas/review-unit-tagging-2026-06-12.md
@@ -1,0 +1,53 @@
+# Review-unit tagging — make the repo-review-map a signal, not just a doc (2026-06-12)
+
+> **Status:** `ideas` — **not approved.** Session idea (Q-0089) from the session that
+> shipped [`docs/repo-review-map.md`](../repo-review-map.md) (PR #715). Capture only;
+> promotion path is `docs/ideas/README.md` → a `docs/planning/` slice when picked up.
+
+## The idea
+
+The new [`repo-review-map.md`](../repo-review-map.md) defines the unit of independent
+review (Axis B: a **subsystem slice** vs. a **shared platform layer**). Right now that's
+knowledge a reviewer has to *remember to apply*. Operationalize it: have the tooling
+**tell you the review unit automatically**.
+
+Two small, additive surfaces:
+
+1. **File-level tag in `scripts/context_map.py`.** The tool agents already run before
+   editing a `disbot/` file prints importers + blast radius. Add one line: the file's
+   **review unit** — the subsystem slice name (resolved from `utils/subsystem_registry.py`
+   + the `repo-navigation-map.md` cheat sheet) or, for `core/ · governance/ · utils/ ·
+   views/base.py · entry files`, the **shared-platform layer** label with its review bar.
+
+2. **PR-level classifier (new, e.g. `scripts/review_scope.py`).** Given a changed-file
+   set (`git diff --name-only origin/main...HEAD`), classify the change as one of:
+   - **single-slice** — all files in one subsystem slice (+ its mirrored tests) → low-bar, self-contained review;
+   - **multi-slice** — touches two+ slices → flag "should this go through the EventBus / a shared service instead?";
+   - **platform** — touches a B-platform layer → "blast-radius review, run `context_map.py` on the touched layer files."
+
+## Why I believe in it
+
+- **Closes the doc→practice gap.** A partition that only lives in a doc decays; one the
+  toolchain emits on every edit/PR gets *used* — the self-improving-workflow ethos
+  (`docs/collaboration-model.md`): each session leaves the next better-equipped.
+- **Cheap + verifiable.** Pure read-only AST/path classification over data that already
+  exists (registry + the cheat sheet); no runtime risk. Fits the "custom tooling on the
+  repo's own AST" preference (`.claude/CLAUDE.md` § Tooling).
+- **Catches the exact failure the review-map exists to prevent** — a PR that quietly grew
+  from one slice into a cross-slice or platform change, which is where review scope blows up.
+
+## Rough mechanics / open questions
+
+- Source of truth for "file → slice": prefer `subsystem_registry` + the navigation cheat
+  sheet; needs a small path→slice resolver (some slices span `cogs/ + views/ + services/ +
+  utils/db/`).
+- Could later become a soft CI annotation on PRs (print the scope classification), but
+  **start as a local dev tool only** — no gate, no CI redness.
+- Overlaps with `context_map.py` and `wiring_map.py`; reuse, don't duplicate.
+
+## Routing
+
+Captured. Small/safe/clear-direction → **quick-win lane** (could be one focused PR), but
+not auto-promoted (`docs/ideas/README.md` routing rule). Next step when picked up: confirm
+the path→slice resolver against the registry, then add the `context_map.py` line first
+(smallest slice of value) before the PR-level classifier.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -222,6 +222,12 @@ dedicated decision** for any action capability.
   backlog onto that foundation · [ai-readiness-plan](ai/ai-readiness-plan.md) M2 (typed policy
   tables + central NL stage) · [provider-switch + grounding fix](ai/ai-provider-and-grounding-fix-plan.md).
   Map: [ai-service-integration-map](ai/ai-service-integration-map.md).
+- **Later (UX debt — owner-requested)** — [AI panel in-place navigation](ideas/ai-panel-inplace-navigation-2026-06-11.md):
+  migrate the `views/ai/` settings family off per-click ephemeral messages + the blanket
+  raw-`discord.ui.View` yaml exemption onto the rest-of-bot in-place **HubView** pattern
+  (V-02 navigation doctrine), and centralize the seven scattered subpanels. Clear
+  direction + a source-confirmed scope sketch in the idea file; wants its own planning
+  session before code.
 
 ### 🎈 BTD6 data / tools — **Now** (THE CUTOVER IS DONE — post-cutover decode backlog)
 


### PR DESCRIPTION
## What & why

End-of-session artifacts for the repo-review-map session (the doc itself shipped in #715, already merged). This PR carries the mandated session-enders from `.claude/CLAUDE.md` § Session workflow:

- **Session log** — `.sessions/2026-06-12-repo-review-map.md`.
- **Backlog grooming (one step)** — routed the owner-requested **AI panel in-place navigation** idea from `captured → on the roadmap`: placed at `docs/roadmap.md` § AI **Later** (UX debt), and stamped the idea file with the routing note.
- **New idea (Q-0089)** — `docs/ideas/review-unit-tagging-2026-06-12.md`: operationalize the new `repo-review-map.md` in tooling (`context_map.py` prints a file's review unit; a PR-level `review_scope.py` classifies a changed-file set as single-slice / multi-slice / platform). Indexed in the ideas README.

## Verification

- `python3.10 scripts/check_docs.py --strict` ✓ (reachable, ratchet clean at 17)
- `python3.10 scripts/check_quality.py --check-only` → All checks passed ✓

Docs-only; no runtime code touched.

https://claude.ai/code/session_01APKKwULES79EunfBEbLRUM

---
_Generated by [Claude Code](https://claude.ai/code/session_01APKKwULES79EunfBEbLRUM)_