### PR TITLE
docs: consolidated hardening roadmap + manageability ideas

### DIFF
--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -18,6 +18,13 @@ Pure brainstorm backlogs — capture without commitment. Each file should carry 
 
 Current broad captures:
 
+- [`repo-manageability-2026-06-12.md`](./repo-manageability-2026-06-12.md) —
+  **owner-asked (2026-06-12):** "what else would make the repo more easily manageable?"
+  after the review-map + readiness-map work. Five workflow-substrate ideas: operationalize
+  the review-map in tooling (cross-ref #1) · trim/auto-archive the bloated `current-state.md`
+  · a freshness guard for dated snapshots · folio/context-pack coverage for the ~24 smaller
+  subsystems · a generated readiness scoreboard. Mostly quick-win lane; folio coverage =
+  discuss.
 - [`voice-mode-planning-capture-2026-06-11.md`](./voice-mode-planning-capture-2026-06-11.md) —
   **voice-mode brainstorm (2026-06-11):** UX and product ideas from a casual spoken planning
   session via ChatGPT. Covers setup wizard clarity, centralized settings navigation, help-menu

--- a/docs/ideas/repo-manageability-2026-06-12.md
+++ b/docs/ideas/repo-manageability-2026-06-12.md
@@ -1,0 +1,59 @@
+# Repo-manageability ideas — 2026-06-12
+
+> **Status:** `ideas` — **not approved.** Captured when the owner asked "what else would
+> make the repo more easily manageable?" after the review-map + readiness-map work. These
+> are about the *dev/review workflow* (the substrate), not the bot's features. Capture +
+> route only; promotion path is [`README.md`](README.md) → a `docs/planning/` slice.
+
+The review-map (#715) + the seven readiness maps (#717–#723) made the repo *navigable* and
+*reviewable per slice*. These ideas target what's still friction. Each is dedup-checked
+against existing docs/tooling.
+
+## 1. Operationalize the review-map in tooling *(already captured — cross-ref)*
+Make `context_map.py` print a file's review unit, add a PR-level `review_scope.py`. Fully
+specified in [`review-unit-tagging-2026-06-12.md`](review-unit-tagging-2026-06-12.md).
+**The single highest-leverage follow-up** — it turns the review partition from a doc you
+must remember into a signal the toolchain emits. Quick-win lane.
+
+## 2. Trim + auto-archive `docs/current-state.md`
+**Problem:** `current-state.md` is the **2nd doc every session reads**, but its header is a
+single enormous run-on "▶ Next action" paragraph (the repo already split some lanes after
+they "collided on every parallel merge"), and "Recently shipped" grows unbounded (now back
+to ~#660). Reading it is slow; editing it collides.
+**Idea:** (a) cap "Recently shipped" to the last ~15 entries and auto-archive older ones to a
+`docs/current-state-archive.md` (the journal already uses this archive pattern); (b) finish
+breaking the mega-header into the per-lane bullets the file itself recommends. A tiny
+`check_docs` soft-ratchet on the header/Recently-shipped length would keep it lean.
+**Why:** faster orientation + fewer parallel-merge collisions on the hottest doc. Quick-win
+lane; touches a high-traffic doc so confirm the cap number with the owner.
+
+## 3. Freshness guard for dated snapshots (audits / readiness maps)
+**Problem:** the seven readiness maps (and other `audit`/`plan` dated docs) are point-in-time
+— they silently rot as source moves. Nothing flags a stale map.
+**Idea:** a `check_docs`-adjacent check: for any doc whose name/header carries a date and an
+`audit`/`plan` badge, warn (never fail) if the source paths it cites have git-changed since
+that date — "this map may be stale; re-verify before trusting." Pairs with the gap-analysis
+"toolchain rot watch" item.
+**Why:** keeps the new review/readiness investment from decaying into misleading docs.
+Quick-win lane (read-only, git-log based).
+
+## 4. Folio / context-pack coverage for the smaller subsystems
+**Problem:** there are **7 folios** (+7 generated context packs) but ~31 cog subsystems. An
+agent on `economy`, `moderation`, `xp`, `role`, `inventory`, `counting`, etc. has the
+navigation cheat-sheet + ownership, but **no single-page area entry** like the 7 big areas.
+"Read only your subsystem" is uniform for 7, ad-hoc for the rest.
+**Idea:** either (a) generate a lightweight stub folio/context-pack per remaining subsystem
+from the cheat-sheet + registry + ownership rows, or (b) decide the cheat-sheet is
+sufficient for small cogs and document that explicitly so the gap is intentional, not
+accidental.
+**Why:** completes the "every slice has one entry page" promise the review-map implies.
+**Route: discuss** — could be over-engineering for tiny cogs; owner/lead call on a/b.
+
+## 5. Readiness scoreboard (generated, one glance)
+**Problem:** the readiness state now lives across seven maps; there's no single at-a-glance
+"how production-ready is the bot?" view that updates as maps refresh.
+**Idea:** a generated Done/Partial/Not-Done tally per subsystem (parsed from the maps' status
+tables) rendered into the production-readiness README or `current-state.md`. Refreshes when a
+track lands and a map's rows flip.
+**Why:** turns the hardening roadmap's progress into a visible metric. Quick-win lane, but
+depends on the maps keeping a parseable table shape (they do today).

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -3902,3 +3902,85 @@ retention roll-up as **Not Done** for production readiness.
 
 **Source review:**
 [`docs/planning/production-readiness/health-diagnostics-production-readiness-map-2026-06-12.md`](../planning/production-readiness/health-diagnostics-production-readiness-map-2026-06-12.md)
+
+### Q-0098 — Do delegated Setup admins have apply authority for settings/bindings/provisioning?
+
+**Area:** Settings / Bindings / Provisioning · Setup delegation
+**Type:** Owner/product + authority decision exposed by production-readiness review
+**Priority:** High before Settings / Bindings / Provisioning is declared production-ready
+
+**Question:** The Setup Final-Review gate authorizes the owner **or a delegated setup admin**
+to apply a staged draft, but the three mutation pipelines (settings/binding/provisioning)
+enforce an administrator floor in `governance.capability.actor_holds_capability()` that does
+**not** represent delegated-setup authority. A delegate can therefore stage and pass Final
+Review, then fail the canonical write per operation. Which is intended?
+
+- **(a) Delegates may apply (recommended if delegation is a real feature):** add a
+  non-escalating delegated-setup capability route so the pipelines authorize the same actor
+  the Setup gate did. Preserve execution-time re-checks.
+- **(b) Delegates may stage only:** keep the admin floor; change Setup copy/gates so they
+  stop promising apply authority a delegate doesn't have.
+
+**Why this needs owner intent:** it's a product call about what "delegated setup" means, and
+either path changes an authority surface. Implementing either silently picks the semantics.
+
+**Safe default until answered:** leave both gates as-is; treat the delegated-apply path as
+**Not Done** and surface the mismatch in operator UX rather than widening capability.
+
+**Source review:**
+[`docs/planning/production-readiness/settings-bindings-provisioning-production-readiness-map-2026-06-12.md`](../planning/production-readiness/settings-bindings-provisioning-production-readiness-map-2026-06-12.md)
+
+### Q-0099 — What is the retention & data-minimization policy for cached YouTube data?
+
+**Area:** Media / YouTube (shared platform)
+**Type:** Owner/product + privacy decision exposed by production-readiness review
+**Priority:** High before Media / YouTube is declared production-ready (privacy-sensitive)
+
+**Question:** The video cache stores `metadata_json` as the **full unsanitized** YouTube API
+item (including full descriptions), and `purge_expired_video_cache()` has **no caller** — so
+expired rows (transcripts + raw metadata) persist indefinitely. For a public bot, what is the
+allowed policy?
+
+- **(a) Bounded projection + scheduled purge (recommended):** store only the bounded fields
+  the runtime actually uses, define a deletion/purge owner, and schedule physical expiry
+  through a managed task; verify deletion against production Postgres.
+- **(b) Raw payload with a defined TTL:** keep full payloads but justify it, document the
+  retention window, and still wire the purge so expiry is physical, not just logical.
+
+**Why this needs owner intent:** data-minimization and retention are privacy/product calls,
+not implementation defaults — especially for stored third-party content.
+
+**Safe default until answered:** treat retention as **Not Done**; do not expand YouTube
+storage or surfaces; wiring the existing purge on the current schema is a safe interim fix.
+
+**Source review:**
+[`docs/planning/production-readiness/media-youtube-production-readiness-map-2026-06-12.md`](../planning/production-readiness/media-youtube-production-readiness-map-2026-06-12.md)
+
+### Q-0100 — Who is the canonical owner for direct channel mutations (create/clone/overwrite/category)?
+
+**Area:** Server management · channel lifecycle / resource provisioning
+**Type:** Architecture/ownership decision exposed by production-readiness review
+**Priority:** High before Server management is declared production-ready
+
+**Question:** Channel **creation, clone, permission-overwrite, and category-lifecycle** paths
+currently mutate Discord outside the one audited lifecycle/provisioning seam, so the same
+operator action gets different audit, confirmation, and failure behavior by path. What is the
+canonical owner for each?
+
+- **(a) Converge under the existing seams (recommended):** route creation/category through
+  `ResourceProvisioningPipeline` (preserving its confirmation rule) and clone/overwrite
+  through `ChannelLifecycleService` with audit + events; then extend the channel invariant to
+  pin `.set_permissions()`/`.clone()`/create.
+- **(b) A new dedicated channel-mutation owner:** if those paths don't fit the existing seams,
+  declare one canonical audited owner for them with the same confirmation/audit/event contract.
+
+**Why this needs owner intent:** it's an architecture decision about confirmation semantics on
+destructive guild mutations (e.g. should every clone/overwrite require confirmation like
+provisioning does?) before code converges.
+
+**Safe default until answered:** leave paths as-is; the channel invariant intentionally pins
+only `.edit()`/`.delete()` until the owner is chosen — do not widen `ChannelLifecycleService`
+unilaterally.
+
+**Source review:**
+[`docs/planning/production-readiness/server-management-production-readiness-map-2026-06-12.md`](../planning/production-readiness/server-management-production-readiness-map-2026-06-12.md)

--- a/docs/planning/production-readiness/README.md
+++ b/docs/planning/production-readiness/README.md
@@ -17,6 +17,12 @@ hardening that area reads its map + its [folio](../../subsystems/README.md) inst
 re-scanning source. They were produced **2026-06-12** by per-subsystem mapping agents
 (PRs #717–#723).
 
+> **▶ Consolidated, prioritized backlog:** the
+> [**hardening roadmap**](hardening-roadmap-2026-06-12.md) ranks every map's findings by
+> production risk (P0 integrity → P1 correctness → P2 drift), names the bounded session per
+> track, and lists the owner decisions (Q-0077/Q-0097/Q-0098/Q-0099/Q-0100) that gate them.
+> Start there to pick the next session; use the individual maps below for the evidence.
+
 ## Convention
 
 Each map carries an `audit` badge and a table of the shape:

--- a/docs/planning/production-readiness/hardening-roadmap-2026-06-12.md
+++ b/docs/planning/production-readiness/hardening-roadmap-2026-06-12.md
@@ -1,0 +1,161 @@
+# Production-readiness hardening roadmap — 2026-06-12
+
+> **Status:** `plan` — consolidated, prioritized hardening queue derived from the seven
+> per-subsystem [production-readiness maps](README.md). **Not implementation approval.**
+> Source code and merged PRs win; each item links to the map that is its evidence. Every
+> subsystem is currently rated **Partial / not-yet-production-ready** — this doc turns that
+> into a ranked, bounded backlog.
+
+## How this is prioritized
+
+By **production risk**, not effort:
+
+- **P0 — integrity** — could cause real harm if shipped: money loss/duplication, privacy
+  exposure, authority/audit inconsistency. Fix before a public posture.
+- **P1 — correctness & operations** — wrong answers, unobservable failures, no live proof,
+  no regression guards. Needed for confidence, not catastrophic.
+- **P2 — drift & quick wins** — stale docs / mislabels that misroute operators and agents.
+  Cheap, safe, do anytime (some are one-line fixes).
+
+Each track is a **bounded session** that maps back to a single map's "Recommended next
+session". Tracks needing an owner decision name the routed Q-block.
+
+## Verdict at a glance
+
+| Subsystem | Verdict | Principal blocker | Map |
+|---|---|---|---|
+| Games | Partial | Wager settlement not atomic — can mint coins / lose entry fees | [games](games-production-readiness-map-2026-06-12.md) |
+| Media / YouTube | **Not ready** | Cache never purged + raw metadata stored indefinitely (privacy) | [media](media-youtube-production-readiness-map-2026-06-12.md) |
+| Settings / bindings / provisioning | Partial | Dual-lane pointers bypass binding validation; delegated-setup authority mismatch | [settings](settings-bindings-provisioning-production-readiness-map-2026-06-12.md) |
+| Server management | Partial | Mixed channel-mutation ownership (some audited, some direct) | [server-mgmt](server-management-production-readiness-map-2026-06-12.md) |
+| AI / Setup Advisor | Partial | Live-eval defect rate; no versioned eval/smoke matrix | [ai](ai-production-readiness-map-2026-06-12.md) |
+| BTD6 | Partial (gated) | Model-faithfulness + absence-claim safety; manual blob seeding | [btd6](btd6-production-readiness-map-2026-06-12.md) |
+| Health / diagnostics | Partial | Findings have no lifecycle transition; smoke/hub drift | [health](health-diagnostics-production-readiness-map-2026-06-12.md) |
+
+---
+
+## P0 — integrity (do before any public posture)
+
+### P0-1 · Games wager money-safety
+**Evidence:** [games map](games-production-readiness-map-2026-06-12.md) — RPS/blackjack PvP
+settle with sequential winner-credit + overdraft loser-debit (a crash between calls **mints
+coins**); paid tournament registration **debits before** writing a recovery checkpoint (a
+crash loses the fee with no row to refund — contra ADR-002); multi-call payouts/refunds have
+no durable idempotency key.
+**Why P0:** real currency can be created or lost. No owner gate; fully test-injectable.
+**Bounded session:** design one economy-service-backed wager workflow (atomic-or-idempotent
+debit→checkpoint→settle), add failure-injection tests at each boundary, characterize
+terminal-state behavior. → games map "Recommended next session".
+
+### P0-2 · Media/YouTube data-minimization & retention  ·  needs **Q-0099**
+**Evidence:** [media map](media-youtube-production-readiness-map-2026-06-12.md) —
+`purge_expired_video_cache()` has **no caller** (expired transcripts/metadata kept forever);
+`metadata_json` stores the **full unsanitized** YouTube payload (descriptions etc.), contra
+the folio's "bounded cached metadata".
+**Why P0:** privacy/data-minimization exposure for a public bot; the feature is also
+mis-owned (`YOUTUBE_CONTEXT_ENABLED` labeled `ai` despite ADR-007 shared-platform ownership).
+**Bounded session:** ratify the retention/data-minimization contract (Q-0099), store only a
+bounded projection, wire purge through a managed-task owner, fix the flag ownership, add
+content-free media diagnostics.
+
+### P0-3 · Settings pointer-lane convergence + setup authority  ·  needs **Q-0098**
+**Evidence:** [settings map](settings-bindings-provisioning-production-readiness-map-2026-06-12.md)
+— legacy Discord pointers remain editable scalar settings while canonical bindings exist
+(two operator-visible truths; generic editors bypass binding validation); the delegated-Setup
+apply gate disagrees with the mutation-pipeline admin floor (a delegate passes Final Review
+then fails per-op writes); `binding_backfill.MIGRATED_KEYS` references an **undeclared**
+`governance.trusted_role`.
+**Why P0:** authority/lane integrity — silent divergence between what an operator is told and
+what actually writes.
+**Bounded session:** plan pointer-lane convergence (migration order for the four pointer
+families) + decide the delegated-Setup apply contract (Q-0098) + add the parity invariants
+(P1-3). → settings map "Recommended next session".
+
+### P0-4 · Server-management channel-ownership convergence  ·  needs **Q-0100**
+**Evidence:** [server-mgmt map](server-management-production-readiness-map-2026-06-12.md) —
+channel creation, clone, permission-overwrite, and category lifecycle paths sit **outside**
+the one audited lifecycle/provisioning seam; the same operator action gets different audit,
+confirmation, and failure behavior depending on path. The channel invariant only pins
+`.edit()`/`.delete()`, giving a false sense of completeness.
+**Why P0:** audit-trail integrity; uneven confirmation on destructive guild mutations.
+**Bounded session:** decide the canonical owner per direct path (Q-0100), then converge under
+it + extend the invariant. → server-mgmt map "Recommended next session".
+
+---
+
+## P1 — correctness & operations
+
+### P1-1 · AI answer correctness + a versioned eval/smoke harness
+**Evidence:** [ai map](ai-production-readiness-map-2026-06-12.md) (ongoing live-eval defect
+rate; PRs #703/#706/#707/#709 each fixed live-found routing/grounding/workflow bugs) +
+[btd6 map](btd6-production-readiness-map-2026-06-12.md) (PMFC/POD entity substitution,
+long-list omission/miscount, absence-claim guard **unimplemented**).
+**Bounded session:** build a short **versioned eval/smoke matrix** (gates · fallback · tool
+use · BTD6 prompts · grounding refusal · audit) run with production-like credentials, and
+implement the BTD6 absence-claim guard. *(BTD6 broad expansion stays gated regardless.)*
+
+### P1-2 · Health findings lifecycle + retention + diagnostics drift  ·  needs **Q-0097**
+**Evidence:** [health map](health-diagnostics-production-readiness-map-2026-06-12.md) —
+findings are filterable as `resolved`/`ignored` but **nothing transitions them** (open
+forever); retention is startup-only on a long-lived process; the smoke checklist points at a
+nonexistent `!platform diagnostics`; the Platform-hub "groups every subcommand" claim is false.
+**Bounded session:** answer Q-0097, implement the chosen lifecycle through the sole writer
+`health_findings_service`, schedule retention via the managed-task owner, fix the smoke/hub
+drift (P2-1 overlaps). → health map "Recommended next session".
+
+### P1-3 · Machine-checkable contract invariants (cross-cutting)
+**Evidence:** recurs in settings (declared-setting → runtime-consumer parity; no dual
+pointer+binding; backfill-target parity), games (cross-game terminal-state matrix), AI
+(declared-vs-consumed tools), BTD6 (derived-value provenance).
+**Why:** every map verified its contracts **manually** — without an invariant, the next
+regression ships silently.
+**Bounded session(s):** add AST/registry parity tests, ideally one per track as it lands
+(not a single mega-session). This is the durable "stays fixed" layer.
+
+### P1-4 · Production live-verification (the #1 cross-cutting blocker, owner-led)
+**Evidence:** **all seven** maps explicitly lack maintainer live-walk + real
+Postgres/Discord end-to-end proof despite strong unit coverage.
+**Bounded action:** extend the existing
+[production-eval checklist](../../audits/production-eval-checklist-2026-06-10.md) to cover the
+newer surfaces each map flagged (health findings/startup · media fetch/cache/purge · games
+terminal-states & refunds · settings three-lane smoke · server-mgmt channel paths), then run
+it. Owner-dependent — pairs with the commissioned untested-surface checklist.
+
+---
+
+## P2 — drift & quick wins (cheap, no owner gate)
+
+A single **doc-drift sweep** session clears all of these; each is small and removes active
+operator/agent misrouting:
+
+| Fix | Evidence |
+|---|---|
+| Health smoke checklist: replace nonexistent `!platform diagnostics` with real `!platform runtime`/`consistency`; correct the Platform-hub completeness claim | health map |
+| AI `core/runtime/ai/README.md`: drop stale "inert scaffold" wording for active code | ai map |
+| ADR-006: reconcile stale BTD6 pause wording + decode-status summary rows | btd6 map |
+| Media folio: "bounded cached metadata" vs. the raw-payload reality (fix doc or code per Q-0099) | media map |
+| `YOUTUBE_CONTEXT_ENABLED` ownership label `ai` → shared platform (ADR-007) | ai + media maps |
+
+---
+
+## Owner decisions gating the roadmap
+
+| Q | Decision | Gates | Status |
+|---|---|---|---|
+| Q-0077 | BTD6 auto-seed-on-boot | BTD6 data-lane proof | pre-existing |
+| Q-0097 | Health finding lifecycle (open/resolved/ignored) | P1-2 | Open (asked 2026-06-12) |
+| Q-0098 | Delegated-Setup apply authority contract | P0-3 | **routed 2026-06-12** |
+| Q-0099 | Media/YouTube retention & data-minimization policy | P0-2 | **routed 2026-06-12** |
+| Q-0100 | Canonical owner for direct channel mutations | P0-4 | **routed 2026-06-12** |
+
+## Recommended first three sessions
+
+1. **P2 doc-drift sweep** — cheapest, no gate; immediately stops operators/agents acting on
+   wrong commands and stale ownership. One session.
+2. **P0-1 games wager money-safety** — highest concrete harm (mints/loses currency),
+   self-contained, no owner gate, test-injectable.
+3. **P0-3 or P0-4** — once **Q-0098 / Q-0100** are answered, the settings pointer-lane or
+   server-mgmt channel-ownership convergence (whichever the owner answers first).
+
+> As a track lands, update the relevant map's rows from Partial/Not Done → Done with the PR
+> as evidence, and tick the verdict table above.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,6 +15,12 @@
 > **Initial cut — evolving, not locked.** New plans get slotted into their area below as
 > they land (see [Adding a plan](#adding-a-plan)); horizons will re-sequence as plans
 > arrive and gates clear. Treat the ordering as a current best-guess, not a commitment.
+>
+> **▶ Production-readiness:** the seven per-subsystem readiness maps + the consolidated
+> [**hardening roadmap**](planning/production-readiness/hardening-roadmap-2026-06-12.md)
+> (P0 integrity → P1 correctness → P2 drift, with the gating owner Qs) are the
+> risk-ranked "what's left to be production-ready" view across all subsystems. Index:
+> [`planning/production-readiness/`](planning/production-readiness/README.md).
 
 ## How to read
 


### PR DESCRIPTION
## What & why

Two follow-ups to your request: (1) consolidate the seven readiness maps' findings into one prioritized hardening roadmap, and (2) capture other repo-manageability ideas.

## 1. Consolidated hardening roadmap

`docs/planning/production-readiness/hardening-roadmap-2026-06-12.md` — ranks **every** map's findings by **production risk**:

- **P0 (integrity):** games wager money-safety (can mint/lose coins) · media retention+privacy (cache never purged, raw payloads stored) · settings pointer-lane + delegated-setup authority · server-mgmt channel-ownership convergence
- **P1 (correctness/ops):** AI eval/smoke harness + BTD6 faithfulness · health findings lifecycle · machine-checkable invariants · production live-verification (the #1 cross-cutting blocker)
- **P2 (drift/quick wins):** a doc-drift sweep (stale `!platform diagnostics`, AI README, ADR-006, media folio, flag-ownership label)

Each track = one bounded session mapped to a map's "Recommended next session", with a **verdict-at-a-glance** table and a **recommended first-three sequence** (doc-drift sweep → games money-safety → settings/server-mgmt once their owner Qs are answered).

## 2. Routed owner decisions

The maps surfaced three genuine owner decisions — added to the question-router (the no-orphan path):
- **Q-0098** — do delegated Setup admins have apply authority?
- **Q-0099** — YouTube cache retention & data-minimization policy?
- **Q-0100** — canonical owner for direct channel mutations (create/clone/overwrite/category)?

## 3. Manageability ideas (captured)

`docs/ideas/repo-manageability-2026-06-12.md` — five workflow-substrate ideas: operationalize the review-map in tooling (cross-ref the existing idea), trim/auto-archive the bloated `current-state.md`, a freshness guard for dated snapshots, folio/context-pack coverage for the ~24 smaller subsystems, and a generated readiness scoreboard.

## Verification

- `python3.10 scripts/check_docs.py --strict` ✓ (reachable, ratchet 17)

Docs-only.

https://claude.ai/code/session_01APKKwULES79EunfBEbLRUM

---
_Generated by [Claude Code](https://claude.ai/code/session_01APKKwULES79EunfBEbLRUM)_