### PR TITLE
docs(session): close 2026-06-12 readiness/roadmap/tooling arc

### DIFF
--- a/.sessions/2026-06-12-readiness-maps-roadmap-tooling.md
+++ b/.sessions/2026-06-12-readiness-maps-roadmap-tooling.md
@@ -1,0 +1,56 @@
+# 2026-06-12 — Readiness maps, hardening roadmap & manageability tooling
+
+> **Status:** `audit` — per-session log (continuation of the 2026-06-12 review-map session;
+> see also `.sessions/2026-06-12-repo-review-map.md`).
+
+**PRs:** [#717–#724](https://github.com/menno420/superbot/pull/724) (readiness maps + reconcile) · [#725](https://github.com/menno420/superbot/pull/725) (hardening roadmap) · [#726](https://github.com/menno420/superbot/pull/726) (manageability tooling) — all merged.
+**Branch:** session work across `claude/sleepy-hawking-tgderi` + `claude/manageability-tooling`.
+
+## What was done
+
+- **Reviewed + merged the seven per-subsystem production-readiness maps** the owner
+  commissioned off the review-map divisions (#717 AI · #718 health + Q-0097 · #719
+  server-mgmt · #720 settings · #721 BTD6 · #722 games · #723 media). Verified not
+  rubber-stamped: zero hallucinated paths across all seven, settings map read in full
+  (grounded, surfaces real debt). Reconciled into `planning/production-readiness/` with a
+  README index, consistent `audit` badges, folio links (#724).
+- **Consolidated hardening roadmap** (#725): every map's findings ranked P0 integrity /
+  P1 correctness / P2 drift, one bounded session per track, recommended first-three
+  sequence. Routed the three owner decisions the maps surfaced — **Q-0098** (delegated-setup
+  apply authority), **Q-0099** (YouTube retention/data-minimization), **Q-0100** (canonical
+  channel-mutation owner).
+- **Built the four owner-approved manageability tools** (#726): `review_scope.py` +
+  `_review_units.py` + the `context_map.py` review-unit line (operationalizes the review
+  map) · `readiness_scoreboard.py` (generated into the readiness README; 58% Done overall) ·
+  `check_doc_freshness.py` (advisory staleness for dated audits/plans) · `current-state.md`
+  trimmed 219→150 lines with `current-state-archive.md` + a soft `check_docs` ratchet.
+  Tests added; CI-scope lint clean.
+- **Grooming move (this log):** routed idea #4 (folio coverage for the ~24 smaller
+  subsystems) to **Q-0101** — it was a "discuss" item with no destination; now on the
+  router so it's not orphaned.
+
+## Decisions recorded
+
+- Exercised standing grants Q-0052/Q-0084 (draft-early + self-merge) and Q-0089 (new idea).
+- Owner steer (AskUserQuestion): build all four manageability tools; **hold the hardening
+  tracks** for now. `current-state.md` cap = 15 newest (journal-archive pattern).
+- New owner questions routed this session: Q-0098, Q-0099, Q-0100 (from the maps), Q-0101
+  (folio coverage grooming).
+
+## Left open / next session
+
+- **Hardening tracks** queued in the roadmap, owner's pick: P2 doc-drift sweep (cheapest,
+  no gate — but note ADR-006 is immutable, the health smoke checklist is doc-test-pinned,
+  and the media-folio fix is gated on Q-0099, so it's per-item careful work, not trivial) ·
+  P0-1 games money-safety (no gate, real runtime change) · P0-3/P0-4 (need Q-0098/Q-0100).
+- **Q-0101** awaits the owner: stub folios for small cogs vs. cheat-sheet-is-enough.
+
+## 💡 Session idea
+
+**Idea:** Make `review_scope.py` ambient instead of opt-in — wire it into the `/pre-pr`
+skill output and (optionally) a non-blocking CI step that posts the change's review scope
+(single-slice / multi-slice / platform) as a PR annotation.
+**Why:** the 2026-06-07 workflow review found `context_map.py` "good but un-surfaced at edit
+time" — the same risk applies here. A tool that prints the review unit only when you
+remember to run it decays; surfaced on every PR it actually shapes review scope. Small (the
+classifier already exists), read-only. Recorded here; promote if the owner wants it.

--- a/docs/ideas/repo-manageability-2026-06-12.md
+++ b/docs/ideas/repo-manageability-2026-06-12.md
@@ -7,8 +7,9 @@
 > **Update 2026-06-12 (owner-approved):** ideas **#1, #2, #3, #5 are EXECUTED** as
 > `scripts/{review_scope,_review_units,readiness_scoreboard,check_doc_freshness}.py` +
 > the `current-state.md` trim/archive + the `check_docs` Recently-shipped ratchet
-> (see [`context-map-tooling.md`](../context-map-tooling.md)). **#4 (folio coverage)
-> remains a discuss item.**
+> (see [`context-map-tooling.md`](../context-map-tooling.md)). **#4 (folio coverage) is
+> routed to [Q-0101](../owner/maintainer-question-router.md) (discuss — maintenance vs.
+> uniformity).**
 
 The review-map (#715) + the seven readiness maps (#717–#723) made the repo *navigable* and
 *reviewable per slice*. These ideas target what's still friction. Each is dedup-checked

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -3984,3 +3984,30 @@ unilaterally.
 
 **Source review:**
 [`docs/planning/production-readiness/server-management-production-readiness-map-2026-06-12.md`](../planning/production-readiness/server-management-production-readiness-map-2026-06-12.md)
+
+### Q-0101 — Do the ~24 smaller subsystems need their own folio/context-pack, or is the cheat-sheet enough?
+
+**Area:** Docs & agent system · orientation
+**Type:** Workflow/orientation decision (doc-maintenance burden vs. uniformity)
+**Priority:** Low — quality-of-life for agents working in the smaller cogs
+
+**Question:** Seven areas have a [folio](../subsystems/README.md) (+ generated context pack);
+the other ~24 cog subsystems (economy, moderation, xp, role, inventory, counting, …) have
+only the `repo-navigation-map.md` cheat-sheet row + `ownership.md`. The review-map implies
+"every slice has one entry page", which is currently uniform for 7 and ad-hoc for the rest.
+
+- **(a) Accept the cheat-sheet as the entry for small cogs (recommended default):** keep
+  folios for the high-traffic/complex areas only, and document that the gap is *intentional*
+  (so it reads as a decision, not an omission). Lowest maintenance.
+- **(b) Generate lightweight stub folios/context-packs per remaining subsystem:** uniform
+  "one entry page per slice", at the cost of ~24 more docs to keep fresh.
+- **(c) Hybrid:** add a folio only for a small cog once it crosses a complexity threshold
+  (e.g. has a view package + a service + a DB module), cheat-sheet otherwise.
+
+**Why this needs owner intent:** it's a maintenance-burden vs. uniformity trade-off on the
+docs surface — generating 24 stubs that then rot would be worse than the current gap.
+
+**Safe default until answered:** leave as-is; the cheat-sheet + ownership are the entry
+point for non-folio cogs.
+
+**Source review:** [`docs/ideas/repo-manageability-2026-06-12.md`](../ideas/repo-manageability-2026-06-12.md) #4.


### PR DESCRIPTION
## What & why

Session close-out for the 2026-06-12 readiness/roadmap/tooling arc (the earlier review-map chunk was already logged separately). Docs-only.

- **Session log** — `.sessions/2026-06-12-readiness-maps-roadmap-tooling.md` covering the seven-map review/merge (#717–#724), the consolidated hardening roadmap + routed Q-0098–Q-0100 (#725), and the four manageability tools (#726).
- **Grooming move** — routed idea #4 (folio coverage for the ~24 smaller subsystems) to **Q-0101**; it was a "discuss" item with no destination, now on the router so it isn't orphaned.
- **New idea (Q-0089)** — make `review_scope.py` ambient (wire into `/pre-pr` + a non-blocking PR annotation) so the review scope surfaces on every PR rather than only when remembered. Recorded in the session log's 💡 block.

## Verification
- `python3.10 scripts/check_docs.py --strict` ✓

https://claude.ai/code/session_01APKKwULES79EunfBEbLRUM

---
_Generated by [Claude Code](https://claude.ai/code/session_01APKKwULES79EunfBEbLRUM)_