### PR TITLE
docs: record owner decisions Q-0098–Q-0101

### DIFF
--- a/docs/ideas/repo-manageability-2026-06-12.md
+++ b/docs/ideas/repo-manageability-2026-06-12.md
@@ -7,9 +7,10 @@
 > **Update 2026-06-12 (owner-approved):** ideas **#1, #2, #3, #5 are EXECUTED** as
 > `scripts/{review_scope,_review_units,readiness_scoreboard,check_doc_freshness}.py` +
 > the `current-state.md` trim/archive + the `check_docs` Recently-shipped ratchet
-> (see [`context-map-tooling.md`](../context-map-tooling.md)). **#4 (folio coverage) is
-> routed to [Q-0101](../owner/maintainer-question-router.md) (discuss — maintenance vs.
-> uniformity).**
+> (see [`context-map-tooling.md`](../context-map-tooling.md)). **#4 (folio coverage)
+> RESOLVED 2026-06-12 via [Q-0101](../owner/maintainer-question-router.md) = (a) cheat-sheet
+> is enough; the gap is now documented as intentional in
+> [`docs/subsystems/README.md`](../subsystems/README.md). No stub folios.**
 
 The review-map (#715) + the seven readiness maps (#717–#723) made the repo *navigable* and
 *reviewable per slice*. These ideas target what's still friction. Each is dedup-checked

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -3905,6 +3905,10 @@ retention roll-up as **Not Done** for production readiness.
 
 ### Q-0098 — Do delegated Setup admins have apply authority for settings/bindings/provisioning?
 
+> **ANSWERED 2026-06-12 — (a) Delegates may apply.** Add a non-escalating delegated-setup
+> capability route so the mutation pipelines authorize the same actor the Setup gate did
+> (preserve execution-time re-checks). Unblocks roadmap **P0-3**.
+
 **Area:** Settings / Bindings / Provisioning · Setup delegation
 **Type:** Owner/product + authority decision exposed by production-readiness review
 **Priority:** High before Settings / Bindings / Provisioning is declared production-ready
@@ -3932,6 +3936,10 @@ either path changes an authority surface. Implementing either silently picks the
 
 ### Q-0099 — What is the retention & data-minimization policy for cached YouTube data?
 
+> **ANSWERED 2026-06-12 — (a) Bounded projection + scheduled purge.** Store only the bounded
+> fields the runtime uses, wire purge through a managed task, verify deletion against Postgres.
+> Unblocks roadmap **P0-2**.
+
 **Area:** Media / YouTube (shared platform)
 **Type:** Owner/product + privacy decision exposed by production-readiness review
 **Priority:** High before Media / YouTube is declared production-ready (privacy-sensitive)
@@ -3957,6 +3965,11 @@ storage or surfaces; wiring the existing purge on the current schema is a safe i
 [`docs/planning/production-readiness/media-youtube-production-readiness-map-2026-06-12.md`](../planning/production-readiness/media-youtube-production-readiness-map-2026-06-12.md)
 
 ### Q-0100 — Who is the canonical owner for direct channel mutations (create/clone/overwrite/category)?
+
+> **ANSWERED 2026-06-12 — (a) Converge under the existing seams.** Creation/category through
+> `ResourceProvisioningPipeline` (keep its confirmation rule), clone/overwrite through
+> `ChannelLifecycleService` with audit+events; then extend the channel invariant. Unblocks
+> roadmap **P0-4**.
 
 **Area:** Server management · channel lifecycle / resource provisioning
 **Type:** Architecture/ownership decision exposed by production-readiness review
@@ -3986,6 +3999,10 @@ unilaterally.
 [`docs/planning/production-readiness/server-management-production-readiness-map-2026-06-12.md`](../planning/production-readiness/server-management-production-readiness-map-2026-06-12.md)
 
 ### Q-0101 — Do the ~24 smaller subsystems need their own folio/context-pack, or is the cheat-sheet enough?
+
+> **ANSWERED 2026-06-12 — (a) Cheat-sheet is enough.** Folios stay for the high-traffic /
+> complex areas only; the gap is **intentional** and now documented in
+> [`docs/subsystems/README.md`](../subsystems/README.md). No stub folios. Idea #4 resolved.
 
 **Area:** Docs & agent system · orientation
 **Type:** Workflow/orientation decision (doc-maintenance burden vs. uniformity)

--- a/docs/planning/production-readiness/hardening-roadmap-2026-06-12.md
+++ b/docs/planning/production-readiness/hardening-roadmap-2026-06-12.md
@@ -144,9 +144,12 @@ operator/agent misrouting:
 |---|---|---|---|
 | Q-0077 | BTD6 auto-seed-on-boot | BTD6 data-lane proof | pre-existing |
 | Q-0097 | Health finding lifecycle (open/resolved/ignored) | P1-2 | Open (asked 2026-06-12) |
-| Q-0098 | Delegated-Setup apply authority contract | P0-3 | **routed 2026-06-12** |
-| Q-0099 | Media/YouTube retention & data-minimization policy | P0-2 | **routed 2026-06-12** |
-| Q-0100 | Canonical owner for direct channel mutations | P0-4 | **routed 2026-06-12** |
+| Q-0098 | Delegated-Setup apply authority contract | P0-3 | ✅ **ANSWERED 2026-06-12 — (a) delegates may apply** → P0-3 unblocked |
+| Q-0099 | Media/YouTube retention & data-minimization policy | P0-2 | ✅ **ANSWERED 2026-06-12 — (a) bounded projection + scheduled purge** → P0-2 unblocked |
+| Q-0100 | Canonical owner for direct channel mutations | P0-4 | ✅ **ANSWERED 2026-06-12 — (a) converge under existing seams** → P0-4 unblocked |
+
+**Net effect:** P0-2, P0-3, P0-4 are now **unblocked** (each has its decided design above).
+Only P1-2 still waits on an owner answer (Q-0097, health finding lifecycle).
 
 ## Recommended first three sessions
 
@@ -154,8 +157,9 @@ operator/agent misrouting:
    wrong commands and stale ownership. One session.
 2. **P0-1 games wager money-safety** — highest concrete harm (mints/loses currency),
    self-contained, no owner gate, test-injectable.
-3. **P0-3 or P0-4** — once **Q-0098 / Q-0100** are answered, the settings pointer-lane or
-   server-mgmt channel-ownership convergence (whichever the owner answers first).
+3. **P0-3 / P0-4** — now unblocked (Q-0098 / Q-0100 answered): settings pointer-lane +
+   delegated-apply route, or server-mgmt channel-ownership convergence under the existing
+   seams. Both are now design-decided; sequence by the owner's pick.
 
 > As a track lands, update the relevant map's rows from Partial/Not Done → Done with the PR
 > as evidence, and tick the verdict table above.

--- a/docs/subsystems/README.md
+++ b/docs/subsystems/README.md
@@ -40,3 +40,13 @@ one home — vertically too.
 > These folios intentionally link to existing contracts, ledgers, plans, and history.
 > Move an underlying doc only when doing so reduces drift without obscuring authority or
 > creating risky reference/doc-test churn.
+
+## Folio coverage is intentional, not exhaustive (owner decision Q-0101, 2026-06-12)
+
+Folios exist for the **high-traffic / structurally complex** areas above — not for every
+cog. The other ~24 subsystems (economy, moderation, xp, role, inventory, counting, …) are
+entered through the [`repo-navigation-map.md`](../repo-navigation-map.md) **subsystem
+cheat-sheet** (cog · view package · service · DB module) + [`ownership.md`](../ownership.md).
+That gap is a **decision** (maintenance burden vs. uniformity), not an omission: 24 stub
+folios that then rot would be worse than the cheat-sheet. Add a folio for a smaller cog only
+if it grows genuinely complex (its own view package + service + DB module + active plans).


### PR DESCRIPTION
## What & why

Records the four owner decisions just made (all chose the recommended option) in their durable homes, and does the one concrete thing Q-0101 implies. Docs-only.

| Q | Decision | Effect |
|---|---|---|
| **Q-0098** | (a) Delegates may apply — add a non-escalating delegated-setup capability route | unblocks **P0-3** |
| **Q-0099** | (a) Bounded projection + scheduled purge for the YouTube cache | unblocks **P0-2** |
| **Q-0100** | (a) Converge channel mutations under the existing seams (ResourceProvisioning / ChannelLifecycle) | unblocks **P0-4** |
| **Q-0101** | (a) Cheat-sheet is enough — folio gap is intentional | idea #4 resolved |

Changes:
- **Router** — each Q marked `ANSWERED 2026-06-12` with the chosen option.
- **`subsystems/README.md`** — new section documenting that folio coverage is intentional, not exhaustive (the Q-0101(a) "document the gap as a decision" action).
- **Hardening roadmap** — gate table shows P0-2/P0-3/P0-4 unblocked; recommended-sequence updated. Only P1-2 still waits on Q-0097.
- **`repo-manageability` idea doc** — #4 marked resolved.

## Verification
- `python3.10 scripts/check_docs.py --strict` ✓

https://claude.ai/code/session_01APKKwULES79EunfBEbLRUM

---
_Generated by [Claude Code](https://claude.ai/code/session_01APKKwULES79EunfBEbLRUM)_