### PR TITLE
tooling: make Hermes skills installable + operating prompt + log-triage

### DIFF
--- a/.sessions/2026-06-12-hermes-installable-skills.md
+++ b/.sessions/2026-06-12-hermes-installable-skills.md
@@ -1,0 +1,71 @@
+# 2026-06-12 — Hermes: installable skills + operating prompt + log-triage
+
+> **Status:** `audit`
+
+**PR:** [#730](https://github.com/menno420/superbot/pull/730) — make Hermes skills installable + operating prompt + log-triage
+**Branch:** `claude/confident-cray-y4plo7`
+
+## Context
+
+Maintainer asked (mobile / exploratory): what's left to finish the Hermes agent he
+started setting up yesterday, what can it do that Claude/ChatGPT can't, can it read the
+bot's logs to diagnose problems, and can we give it journal-like instructions to orient
+faster. Researched the Hermes Agent (Nous Research) docs to ground the answer, then
+built the repo-side enablement he approved.
+
+## What was done
+
+- **`scripts/hermes/build_skills.py`** — generates installable `SKILL.md` files (Hermes
+  YAML frontmatter) from the `docs/operations/hermes-skills/*.md` docs. Follows the
+  `tools/agent_context` source → builder → generated-artifact pattern; pure stdlib so the
+  freshness test runs in CI. Docs stay source of truth; artifacts carry a `GENERATED` marker.
+- **`scripts/hermes/install-skills.sh`** — copies generated `SKILL.md` into `~/.hermes/skills/`
+  on the VPS (`--dry-run`, `--build`). Copies committed artifacts so the VPS needs no toolchain.
+- **`repo-health` self-schedules** — `blueprint.schedule: "0 8 * * *"` in its frontmatter →
+  Hermes auto-runs the daily health digest once installed. (This *implements* the prior
+  session's 💡 "daily health digest cron" idea — see grooming below.)
+- **`log-triage` skill** (`docs/operations/hermes-skills/log-triage.md`) — read-only
+  production/gateway log diagnosis. The maintainer's "can it read the bot's logs?" ask.
+  Triages local `hermes-gateway` logs today; Railway production logs once a **read-only**
+  token is set up on the VPS. Diagnoses only — never restarts/redeploys.
+- **`docs/operations/hermes-operating-prompt.md`** — the Hermes-side `CLAUDE.md`: standing
+  read-only orientation (repo path, read-path order, layer/ownership boundaries, safety
+  model). The maintainer's "journal-like instructions to learn faster" ask.
+- **`tests/unit/scripts/test_build_skills.py`** — freshness gate; fails CI if committed
+  artifacts drift from the docs.
+- Wired control-plane doc + skills README + `repo-navigation-map.md` for reachability.
+
+## Verification
+
+- `check_docs --strict` ✓ · `check_quality --check-only` ✓ (black/isort/ruff/check_docs)
+- `pytest tests/unit/scripts/test_build_skills.py test_check_docs.py tests/unit/docs/` → 96 passed
+- No `disbot/` changes (mypy scope untouched).
+
+## Grooming move
+
+Routed the **owner alerting / dead-man's switch** idea
+(`docs/ideas/gap-analysis-2026-06-11.md`) one step forward: this PR's scheduled
+`repo-health` digest + `log-triage` skill are the alerting substrate that idea called
+for. Annotated the idea with that link (captured → partially routed). Separately, the
+prior session's 💡 "Hermes daily health digest cron" reached **shipped** — the
+`blueprint.schedule` on `repo-health` is exactly that, no separate cron needed.
+
+## Left open / next session
+
+- **Maintainer VPS actions:** run `bash scripts/hermes/install-skills.sh` then
+  `sudo systemctl restart hermes-gateway`; for `log-triage` production logs install the
+  Railway CLI with a **read-only** token. SSH-key login still deferred.
+- The Hermes→Claude-Code dispatch bridge (this session's new idea) is the next big lever
+  for the autonomous loop — see idea file.
+
+## 💡 Session idea
+
+**Idea:** Hermes → Claude Code (web) dispatch bridge — captured as
+[`docs/ideas/hermes-claude-dispatch-bridge-2026-06-12.md`](../docs/ideas/hermes-claude-dispatch-bridge-2026-06-12.md).
+**Why:** Today Hermes can *prepare* a Claude Code prompt (`prompt-builder`) but the
+maintainer still has to open a session and paste it. If Hermes could *trigger* a Claude
+Code-on-the-web session from Telegram (via the web trigger/API), the loop closes: idea on
+your phone → Hermes orients + dispatches → Claude Code builds, tests, opens a PR, self-
+merges → Hermes reports back. That is the "nearly fully autonomous from anywhere" the
+maintainer is excited about, with the safety split intact (Hermes decides/dispatches
+read-only; Claude Code builds under CI gates). Needs API-surface research → discuss lane.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -44,6 +44,15 @@ Current broad captures:
   `review_scope.py` that classifies a changed-file set as single-slice / multi-slice /
   platform. Turns the review partition from a doc you must remember into a signal the
   toolchain emits. Read-only, quick-win lane, not auto-promoted.
+- [`autonomous-improvement-loop-vision-2026-06-12.md`](./autonomous-improvement-loop-vision-2026-06-12.md) —
+  **maintainer vision (2026-06-12, voice):** the north-star — agents continuously improve
+  the bot, chain session→session autonomously (idea → revised plan → implement), gate
+  agent-*generated* features behind correctness (bugs/UX first), and use **Hermes as the
+  independent reviewer** (a non-Claude "different mind" that critiques plans + implementations,
+  explains features to the maintainer, and routes his approve/deny verdict). Maps each claim
+  to existing scaffolding (`ai-project-workflow.md` §10/§11, the idea lifecycle); the loop is
+  ~3 seams short. Decomposes into reviewable steps (dispatch bridge → reviewer seam → phase
+  gate) → **discuss lane**.
 - [`hermes-claude-dispatch-bridge-2026-06-12.md`](./hermes-claude-dispatch-bridge-2026-06-12.md) —
   **session idea (2026-06-12, Q-0089):** let Hermes *trigger* a Claude Code-on-the-web
   session from Telegram (not just prepare the prompt), closing the autonomous loop —

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -44,6 +44,12 @@ Current broad captures:
   `review_scope.py` that classifies a changed-file set as single-slice / multi-slice /
   platform. Turns the review partition from a doc you must remember into a signal the
   toolchain emits. Read-only, quick-win lane, not auto-promoted.
+- [`hermes-claude-dispatch-bridge-2026-06-12.md`](./hermes-claude-dispatch-bridge-2026-06-12.md) —
+  **session idea (2026-06-12, Q-0089):** let Hermes *trigger* a Claude Code-on-the-web
+  session from Telegram (not just prepare the prompt), closing the autonomous loop —
+  phone idea → Hermes orients + dispatches → Claude Code builds/tests/PRs/self-merges →
+  Hermes reports back. Preserves the safety split (Hermes read-only; Claude Code mutates
+  under CI gates). Needs web-trigger API research → **discuss lane** (router Q-block).
 - [`claude-code-plugins-evaluation-2026-06-12.md`](./claude-code-plugins-evaluation-2026-06-12.md) —
   **owner-asked (2026-06-12):** "any good Claude (Code) plugins useful for us?" —
   ecosystem survey (official + community marketplaces, spot-verified), filtered

--- a/docs/ideas/autonomous-improvement-loop-vision-2026-06-12.md
+++ b/docs/ideas/autonomous-improvement-loop-vision-2026-06-12.md
@@ -1,0 +1,114 @@
+# Vision: the fully-autonomous self-improvement loop
+
+> **Status:** `ideas`. **Not approved for implementation** — this is the north-star the
+> existing workflow scaffolding is *already* building toward, captured so sessions can aim
+> at it. It decomposes into reviewable steps (see Routing); it is not a single build.
+> Binding contracts and owner decisions win over anything here.
+
+**Captured:** 2026-06-12 (maintainer vision, voice) · **Owning area:** agent ecosystem /
+workflow (the *real artifact*, per `.claude/CLAUDE.md` Working agreement & `docs/collaboration-model.md`).
+
+## The vision (maintainer's words, sharpened)
+
+> "Eventually all the agents together work so the bot is continuously improved. Once all
+> bugs are fixed, UX is perfect, everything works — *then* the agents come up with ideas of
+> their own, carefully reviewed. The best workflow recreates what I currently do, but fully
+> autonomous: one session creates an idea and stores it, the next revises it into a draft
+> plan, the session after finalizes the plan or starts implementing. And that's where Hermes
+> is the valuable link — it's the one mind that differs from Claude in this loop, so it can
+> independently review the plans and the way the functions are made, message me to explain
+> the new features, and I test and approve or deny."
+
+Three claims, each mapped to what already exists and what is missing.
+
+## 1. The multi-session idea → plan → implement pipeline
+
+This is **already the documented idea lifecycle** (`docs/ideas/README.md`:
+raw → captured → routed → plan → implement) and the **chaining protocol**
+(`docs/owner/ai-project-workflow.md` §10: handoff → fresh bounded session → green merge →
+auto-deploy → sharpened handoff). What the maintainer adds is removing the **human trigger
+between stages**: today *he* starts each session; the vision is sessions that **hand off to
+each other automatically**.
+
+- *Exists today:* the lifecycle, the per-session bounded-handoff protocol, forced
+  idea-generation every session (Q-0089), Railway auto-deploy on merge, agent self-merge of
+  green work (Q-0084).
+- *Missing:* the **automatic chaining** — session N's end state triggering session N+1.
+  This is exactly the [Hermes → Claude Code Routines dispatch bridge](./hermes-claude-dispatch-bridge-2026-06-12.md):
+  a scheduled/API/GitHub-event routine starts the next session with the prior session's
+  artifact as its work order. **That idea is step 1 of this vision.**
+
+## 2. The sequencing gate — correctness before invention
+
+The maintainer is explicit about **order**: bugs first, then UX, then "everything works,"
+and **only then** agent-originated features. This matches `.claude/CLAUDE.md` ("Bugs first,
+durably") and must be enforced, not assumed: an autonomous loop left ungated would invent
+features while bugs remain. The loop needs a **phase signal** — a machine-readable "are we
+in the fix/polish phase or the invent phase?" gate (candidate source: the readiness
+scoreboard + bug-book open count + the production-readiness maps). Agent-*generated* feature
+work stays gated behind that signal; bug/UX/correctness work is always in-season.
+
+## 3. Hermes as the independent reviewer — the keystone
+
+This is the genuinely **new architectural insight**, and the strongest reason the loop is
+trustworthy. In a Claude-only loop, every author *and* every reviewer is Claude — a
+**monoculture**: the same model's blind spots are invisible to itself, so self-review
+catches less than it appears to. Hermes is **a different model (Nous Research), a different
+mind**. Putting it in the loop as the independent reviewer breaks the monoculture:
+
+- **Independent plan review** — before a plan is finalized, Hermes (read-only, repo-aware)
+  critiques it: is the approach sound, does it fit the architecture, what did the Claude
+  author miss? A dissent from a different model is worth far more than another Claude pass.
+- **Independent implementation review** — Hermes reviews "the way the functions are made"
+  on the PR diff: not CI (that's mechanical) but design/clarity/missed-cases judgment from
+  outside the author's model family.
+- **Human liaison + approve/deny gate** — Hermes **messages the maintainer in plain
+  language** explaining each new feature, who **tests and approves or denies**. This keeps
+  the irreversible step (shipping an agent-originated feature) human, reached through a
+  *different* agent than the one that built it. The maintainer's verdict routes back into
+  the loop (merge / revise / reject-to-ledger).
+
+This also reframes Hermes' role across all three captures: not just dispatcher (idea 1) and
+monitor (`log-triage`/`repo-health`), but **the independent-review + human-gate seam**.
+
+## What exists vs. what's missing (honest)
+
+| Capability | State |
+|---|---|
+| Idea lifecycle + forced generation | ✅ exists (`ideas/README.md`, Q-0089) |
+| Bounded session handoff protocol | ✅ exists (`ai-project-workflow.md` §10) |
+| Plan→execute model split (premium plans, cheaper executes) | ✅ exists (§11) |
+| Auto-deploy on merge + agent self-merge | ✅ exists (Q-0084, production-deployment) |
+| Automatic session→session chaining | ❌ needs Routines bridge (idea 1) |
+| Correctness-vs-invention phase gate | ❌ needs a machine-readable signal |
+| Independent (non-Claude) plan/impl review | ❌ needs the Hermes-reviewer seam |
+| Human explain → approve/deny loop via Hermes | ❌ needs a Hermes review/notify skill + a verdict-routing convention |
+
+So the substrate is largely built; the loop is **~3 seams** short of closing.
+
+## Open questions (why this is discuss-lane)
+
+1. **Is Hermes capable enough to be the reviewer that matters?** Its review only adds value
+   if it catches real issues. Needs the "unverified — confirm against ground truth a few
+   times" discipline (CLAUDE.md tooling rule) before its dissent is trusted to gate work.
+2. **Where is the human gate, exactly?** Every agent-originated *feature* through the
+   approve/deny step? Or only above a risk threshold, with docs/bug-fixes flowing freely?
+3. **Self-merge under full autonomy** — the gating from idea 1 (routine opens PR; merge
+   behind green-CI + scope rules or a one-tap Telegram confirm) applies here too.
+4. **Loop stop-conditions** — what halts a runaway loop (cost cap, daily-run cap, a
+   red-readiness freeze)? §11 cost discipline is the budget side of this.
+
+## Routing
+
+**Discuss first (router Q-block).** This is the ecosystem north-star, not a single PR — it
+is the explicit *real artifact* of this repo, so the maintainer owns its shape. It
+decomposes into reviewable, independently-valuable steps:
+
+1. **[Dispatch bridge](./hermes-claude-dispatch-bridge-2026-06-12.md)** (Routines) — the chaining.
+2. **Hermes-reviewer seam** — a read-only `superbot-review` skill (plan + PR-diff critique)
+   + a notify/approve-deny convention. Independently useful even with manual chaining.
+3. **Phase gate** — a readiness/bug-count signal that says fix-phase vs. invent-phase.
+
+Each step is shippable and reviewable on its own; none requires committing to the whole
+loop up front. Build them in that order, review each in production, and the autonomous loop
+assembles itself from verified parts rather than as one leap.

--- a/docs/ideas/autonomous-improvement-loop-vision-2026-06-12.md
+++ b/docs/ideas/autonomous-improvement-loop-vision-2026-06-12.md
@@ -98,6 +98,31 @@ So the substrate is largely built; the loop is **~3 seams** short of closing.
 4. **Loop stop-conditions** — what halts a runaway loop (cost cap, daily-run cap, a
    red-readiness freeze)? §11 cost discipline is the budget side of this.
 
+## Model selection for the reviewer seam (maintainer direction, 2026-06-12)
+
+The reviewer's job is **independence + repo-comprehension + judgment — not raw coding
+skill**. Pick the backing model on those axes, and decide it **empirically** (the
+maintainer's stated method, and the repo's "unverified — confirm against ground truth a few
+times before trusting" rule): give the candidate a plan or PR diff where the issues are
+*already known*, and measure whether it finds them. Only then is its dissent trusted to gate.
+
+- **Hermes free tier first** — free, a different model family, zero-cost to test. If it
+  passes the known-answer calibration, no paid plan is needed.
+- **Claude-reviewing-Claude** — viable fallback but the **weakest independent check**: it
+  shares the author's blind spots (the monoculture this seam exists to break). Slightly more
+  efficient than one Claude, but not the goal.
+- **GPT / Gemini** — strongest *independent* options if Hermes-free underperforms. Gemini
+  is untested by the maintainer as of 2026-06-12.
+- **Grok — out of the gate role.** Maintainer-tested 2026-06-12: overclaims ability and
+  could not reliably pull repo context. A reviewer that can't accurately comprehend the repo
+  is disqualified *for review/gating* specifically. **Role-split:** unreliable-but-divergent
+  models may later feed *low-stakes idea generation* (where being wrong is cheap); reliable
+  models own review and gating (where wrong is costly).
+- **The seam is model-agnostic by design** — it is a read-only review skill + whatever
+  agent/connector backs it. The loop does not depend on which model sits behind it, so the
+  reviewer can be **tested cheaply and swapped freely** (Hermes-free → GPT/Gemini → Claude
+  fallback) without rebuilding anything. Start free; swap only if calibration says so.
+
 ## Routing
 
 **Discuss first (router Q-block).** This is the ecosystem north-star, not a single PR — it

--- a/docs/ideas/gap-analysis-2026-06-11.md
+++ b/docs/ideas/gap-analysis-2026-06-11.md
@@ -35,6 +35,12 @@
    on real downtime *or* on build-pipeline failure, and the Stage 1 caretaker
    will eventually want both as sensory inputs — pick it up when the owner
    says so, not before.
+   *(Grooming 2026-06-12, PR #730: the Hermes control plane now supplies the
+   alerting substrate this called for — a self-scheduled daily `repo-health`
+   digest and the read-only `log-triage` skill push repo/CI/log status to
+   Telegram. That covers the "is anything broken?" sensory input; real-downtime
+   alerting on the production bot still waits on the read-only Railway log
+   source. Moves this item captured → partially routed.)*
 
 ## AI-system / workflow gaps
 

--- a/docs/ideas/hermes-claude-dispatch-bridge-2026-06-12.md
+++ b/docs/ideas/hermes-claude-dispatch-bridge-2026-06-12.md
@@ -1,0 +1,49 @@
+# Idea: Hermes → Claude Code (web) dispatch bridge
+
+> **Status:** `ideas`. **Not approved for implementation.** Capture only — a Q-block
+> discussion is the gate (see Routing). Source code and the binding contracts win over
+> anything here.
+
+**Captured:** 2026-06-12 (session idea, Q-0089) · **Owning area:** agent workflow /
+control plane (not the bot runtime).
+
+## The idea
+
+Hermes can already *prepare* a structured Claude Code prompt from a spoken idea
+(`superbot-prompt-builder`). The missing link is **dispatch**: the maintainer still has
+to open a Claude Code session and paste the prompt by hand.
+
+If Hermes could **trigger a Claude Code-on-the-web session from Telegram** — via the web
+trigger / session API documented at https://code.claude.com/docs/en/claude-code-on-the-web
+— the full loop closes:
+
+```text
+idea on your phone
+  → Hermes orients (session-brief / prompt-builder, read-only)
+  → Hermes dispatches a Claude Code web session with that prompt
+  → Claude Code builds, tests, opens a draft PR, self-merges on green CI
+  → Hermes reports the result back to Telegram (repo-health / log-triage)
+```
+
+That is the "nearly fully autonomous from anywhere" the maintainer is after — and it
+**preserves the safety split**: Hermes stays read-only (it decides and dispatches; it does
+not edit code), and Claude Code does the mutation under the existing CI / draft-PR /
+self-merge gates. No new write power is granted to the always-on agent.
+
+## What it would need (research, not yet decided)
+
+- The Claude Code web trigger/session API surface: how a session is started
+  programmatically, what auth it needs, and whether a token can live safely on the VPS.
+- A thin Hermes skill (`superbot-dispatch`) or tool wrapper that posts the prompt + repo +
+  branch and returns the session/PR link.
+- A guardrail: Hermes dispatches but the resulting PR still goes through CI + self-merge
+  rules; the maintainer can cap what kinds of tasks may be auto-dispatched vs. require a
+  confirm.
+
+## Routing
+
+**Discuss first** — this grants the always-on agent the ability to *start work*, which is
+an autonomy/safety boundary and depends on an external API surface. Open a router Q-block
+before any implementation. Until then this is the headline next lever for the autonomous
+loop and pairs with the installed skill pack + operating prompt shipped 2026-06-12
+(PR #730).

--- a/docs/ideas/hermes-claude-dispatch-bridge-2026-06-12.md
+++ b/docs/ideas/hermes-claude-dispatch-bridge-2026-06-12.md
@@ -13,37 +13,66 @@ Hermes can already *prepare* a structured Claude Code prompt from a spoken idea
 (`superbot-prompt-builder`). The missing link is **dispatch**: the maintainer still has
 to open a Claude Code session and paste the prompt by hand.
 
-If Hermes could **trigger a Claude Code-on-the-web session from Telegram** — via the web
-trigger / session API documented at https://code.claude.com/docs/en/claude-code-on-the-web
-— the full loop closes:
+If Hermes could **trigger a Claude Code session from Telegram**, the full loop closes:
 
 ```text
-idea on your phone
-  → Hermes orients (session-brief / prompt-builder, read-only)
-  → Hermes dispatches a Claude Code web session with that prompt
-  → Claude Code builds, tests, opens a draft PR, self-merges on green CI
+idea on your phone (or a nightly Hermes diagnosis)
+  → Hermes orients (session-brief / prompt-builder / log-triage, read-only)
+  → Hermes dispatches a Claude Code session with that work order
+  → Claude Code builds, tests, opens a PR (merge gated — see below)
   → Hermes reports the result back to Telegram (repo-health / log-triage)
 ```
 
 That is the "nearly fully autonomous from anywhere" the maintainer is after — and it
 **preserves the safety split**: Hermes stays read-only (it decides and dispatches; it does
-not edit code), and Claude Code does the mutation under the existing CI / draft-PR /
-self-merge gates. No new write power is granted to the always-on agent.
+not edit code), and Claude Code does the mutation under CI gates.
 
-## What it would need (research, not yet decided)
+## The concrete mechanism: Claude Code **Routines** (verified 2026-06-12)
 
-- The Claude Code web trigger/session API surface: how a session is started
-  programmatically, what auth it needs, and whether a token can live safely on the VPS.
-- A thin Hermes skill (`superbot-dispatch`) or tool wrapper that posts the prompt + repo +
-  branch and returns the session/PR link.
-- A guardrail: Hermes dispatches but the resulting PR still goes through CI + self-merge
-  rules; the maintainer can cap what kinds of tasks may be auto-dispatched vs. require a
-  confirm.
+The dispatch surface this idea needed already exists — **Routines**
+(https://code.claude.com/docs/en/routines): a saved Claude Code config (prompt + repos +
+connectors + environment) that runs autonomously in the cloud, with three trigger types:
+
+- **API** — `POST` to a per-routine `/fire` endpoint with a bearer token and an optional
+  freeform `text` payload that is passed to the run alongside the saved prompt.
+- **Scheduled** — hourly/daily/weekly/cron (min interval 1h) or a one-off future time.
+- **GitHub** — `pull_request.*` and `release.*` events only (NOT issues/pushes/comments),
+  with filters on author/title/body/branch/labels/draft/merged.
+
+**Recommended wiring — API trigger.** Hermes (already an HTTP-capable agent on the VPS)
+`POST`s the diagnosed work order as `text` to the routine's `/fire` endpoint; the routine
+session implements it and opens a `claude/` PR. This is Anthropic's own documented "Alert
+triage" pattern (a monitoring tool POSTs an alert body → routine opens a draft PR with a
+fix), and it means **Hermes never needs repo write access** — it just sends text. Token
+lives in the VPS secret store.
+
+**Alternative — GitHub-PR trigger (the maintainer's original framing).** Hermes opens a
+docs-only / work-order PR (branch `hermes/orders-*` or label `claude-continue`); a routine
+with a filtered `pull_request.opened` trigger continues the work. Viable but costs more: it
+requires graduating Hermes from read-only to "can open a PR", and the hand-off must be a PR
+(GitHub triggers don't fire on issues/comments).
+
+**Note:** the "highest-value docs fix" / "new idea" half can also be a *pure scheduled
+routine* (no Hermes) — the documented "Docs drift" / "Backlog maintenance" patterns. Hermes
+adds the mobile, human-in-the-loop diagnosis + dispatch layer on top.
+
+## Open decisions (why this is discuss-lane, not build-now)
+
+1. **Routines run with no mid-run approval** and can use any included connector's write
+   tools. Guardrails = the prompt, the environment network policy, the included connectors,
+   and the branch-push setting (keep the default `claude/`-only). Each must be scoped tight.
+2. **Self-merge gating** — this repo lets an interactive Claude *session* self-merge on
+   green CI; a *routine* doing it fully unattended is a bigger step. Proposal: routine
+   **opens** the PR (CI runs), but merge stays behind green-CI + docs-only/test-covered
+   rules, or a one-tap Telegram confirm via Hermes — keeping the maintainer on the
+   irreversible step.
+3. Routines act as the maintainer's identity, draw down a daily run cap, and are research
+   preview (API behind a dated beta header).
 
 ## Routing
 
-**Discuss first** — this grants the always-on agent the ability to *start work*, which is
-an autonomy/safety boundary and depends on an external API surface. Open a router Q-block
-before any implementation. Until then this is the headline next lever for the autonomous
-loop and pairs with the installed skill pack + operating prompt shipped 2026-06-12
-(PR #730).
+**Discuss first (router Q-block)** — turning this on is an autonomy/safety-boundary
+decision for the maintainer (decisions 1–3 above), not an agent call. The mechanism is now
+verified and concrete, so the discussion can be a yes/no on scope rather than research.
+Headline next lever for the autonomous loop; pairs with the installed skill pack +
+operating prompt shipped 2026-06-12 (PR #730).

--- a/docs/operations/hermes-control-plane.md
+++ b/docs/operations/hermes-control-plane.md
@@ -452,4 +452,21 @@ Make Hermes consistently useful for SuperBot repo review, doc consistency checks
 
 This gives the highest value with the lowest risk because it improves behavior without giving Hermes broader write or production access.
 
-**The skill pack has been implemented** — see [`hermes-skills/`](./hermes-skills/README.md) for the six ready-to-use skill prompts.
+**The skill pack has been implemented** — see [`hermes-skills/`](./hermes-skills/README.md)
+for the ready-to-use skill prompts. They are now **scripted to install**: the docs are the
+source of truth, `scripts/hermes/build_skills.py` generates installable `SKILL.md` files,
+and `scripts/hermes/install-skills.sh` copies them onto the VPS. A standing read-only
+operating prompt (step 6 below) is implemented as
+[`hermes-operating-prompt.md`](./hermes-operating-prompt.md).
+
+### Next sanctioned capability: read-only log triage
+
+The highest-value graduation from "repo assistant" to "operations assistant" is letting
+Hermes **read production logs** and diagnose problems — without granting any write/deploy
+power. This stays inside the safety model: it is look-but-don't-touch.
+
+- The [`log-triage`](./hermes-skills/log-triage.md) skill is ready; it triages the
+  VPS-local `hermes-gateway` logs today and the production (Railway) logs once a
+  **read-only** Railway token + CLI is set up on the VPS.
+- A Neon read-only role can follow the same pattern for DB-level checks.
+- Operating production (restart / redeploy / scale) remains a maintainer action.

--- a/docs/operations/hermes-operating-prompt.md
+++ b/docs/operations/hermes-operating-prompt.md
@@ -1,0 +1,82 @@
+# Hermes Operating Prompt — SuperBot
+
+> **Status:** `living-ledger` — the standing operating instructions for the Hermes agent
+> on the control-plane VPS. This is the Hermes-side equivalent of `.claude/CLAUDE.md`:
+> paste it into Hermes' base instructions so every session starts oriented. Update it
+> when the repo's read-path, boundaries, or safety model change.
+
+## What this is
+
+Hermes does not carry SuperBot's working agreement the way a Claude Code session does
+(`.claude/CLAUDE.md` is loaded automatically here; Hermes has no such hook). This doc is
+the **portable orientation** that gives Hermes the same starting context: where the repo
+is, what it may and may not do, what to read first, and how to format its output.
+
+**How to wire it in (one-time, maintainer):** put the block below into Hermes' standing
+instructions — either as the agent system prompt in `~/.hermes/config.yaml`, or as a
+base skill in `~/.hermes/skills/` that the other SuperBot skills assume. Re-paste it when
+this doc changes. (The per-task skills in `hermes-skills/` repeat the read-only rule so
+they are safe even without this loaded — but loading it makes every ad-hoc prompt safe
+too, not just the named skills.)
+
+---
+
+## Operating prompt (paste into Hermes)
+
+```
+You are Hermes, the mobile control plane for the SuperBot project.
+
+REPO
+- The repository is at /home/hermes/repos/superbot.
+- Default branch is main. GitHub repo is menno420/superbot.
+- Before any SuperBot work, cd to that path. If the clone looks stale, run
+  `git -C /home/hermes/repos/superbot fetch origin main` (read-only) and say so.
+
+YOUR ROLE
+- You are a READ-ONLY repo, planning, diagnostic, and prompt-generation assistant.
+- You do NOT edit files, commit, push, open or merge PRs, or run any deploy /
+  restart / scale / database-write command. The builder is Claude Code, not you.
+- If a task would require a mutation, STOP and produce a Claude Code prompt for it
+  instead (the superbot-prompt-builder skill does this).
+
+WHAT TO READ FIRST (only what the task needs — do not read everything)
+- docs/current-state.md      — what is true right now (active work, gates, recent ships)
+- docs/AGENT_ORIENTATION.md  — the reading-order router for any specific task
+- .session-journal.md + newest file in .sessions/ — recent working memory
+- The three binding contracts, only when relevant:
+    docs/architecture.md      — layer boundaries (utils < core < services < views < cogs;
+                                services must NOT import views; cogs must not cross-import)
+    docs/ownership.md         — which service/pipeline owns each table and write
+    docs/runtime_contracts.md — bot lifecycle and failure modes
+- When a doc and the source disagree, the SOURCE wins. When current-state.md and a
+  merged PR disagree, the PR wins.
+
+HOW TO ANSWER
+- Be concrete and compact. Prefer tables and bullet lists over prose.
+- Always run read-only commands first (git log/status, grep, cat, ls, the check_* scripts).
+- If a tool (gh, railway, python3.10) is unavailable, say so and continue — never guess.
+- End reports with a single clear verdict or suggested next step. Suggestions are hints
+  for the maintainer or for Claude Code, not actions you take.
+
+SAFETY
+- Treat production (Railway) and the database (Neon) as look-but-don't-touch.
+- Never print secrets, tokens, or .env contents.
+- If you are unsure whether something is a mutation, assume it is and refuse.
+```
+
+---
+
+## Why this helps Hermes "learn faster"
+
+Hermes has persistent memory and writes its own skills, but it still starts each session
+without SuperBot's conventions unless you give them. This doc is the seed: it front-loads
+the read-path and the boundaries so Hermes does not rediscover them every time. The named
+skills in [`hermes-skills/`](./hermes-skills/README.md) are the procedural layer on top —
+together they are to Hermes what `CLAUDE.md` + `.claude/skills/` are to a Claude Code
+session.
+
+Keep this lean. If a rule here drifts from `.claude/CLAUDE.md`, the CLAUDE.md version is
+canonical — this is a distilled, read-only-scoped projection of it for a different agent.
+
+See also: [`hermes-control-plane.md`](./hermes-control-plane.md) (VPS setup + safety model),
+[`hermes-skills/README.md`](./hermes-skills/README.md) (the skill pack).

--- a/docs/operations/hermes-skills/README.md
+++ b/docs/operations/hermes-skills/README.md
@@ -4,8 +4,13 @@
 > skills. Each skill is a ready-to-configure prompt for the Hermes agent running on the
 > control-plane VPS. Setup context: `docs/operations/hermes-control-plane.md`.
 
-This pack contains six skills covering the two windows Hermes fills that Claude Code
-cannot: **pre-session orientation** and **between-session monitoring**.
+This pack contains seven skills covering the windows Hermes fills that Claude Code
+cannot: **pre-session orientation**, **between-session monitoring**, and
+**production diagnosis from your phone**.
+
+For the standing read-only operating instructions every Hermes session should start
+with, see [`hermes-operating-prompt.md`](../hermes-operating-prompt.md) — the Hermes-side
+equivalent of `.claude/CLAUDE.md`.
 
 ---
 
@@ -14,26 +19,46 @@ cannot: **pre-session orientation** and **between-session monitoring**.
 | Skill | Window | Purpose |
 |---|---|---|
 | [`session-brief`](./session-brief.md) | Pre-session | Compressed orientation brief to paste into Claude Code |
-| [`repo-health`](./repo-health.md) | Between sessions | Traffic-light snapshot — is anything broken? |
+| [`repo-health`](./repo-health.md) | Between sessions | Traffic-light snapshot — is anything broken? (self-schedules a daily digest) |
 | [`ideas-triage`](./ideas-triage.md) | Downtime | Ideas backlog review with a suggested next move |
 | [`prompt-builder`](./prompt-builder.md) | Pre-session | Turn a spoken idea into a structured Claude Code prompt |
 | [`open-questions`](./open-questions.md) | Between sessions | Surface unanswered Q- blocks from the router |
 | [`btd6-status`](./btd6-status.md) | After live testing | BTD6 data pipeline coverage and open items |
+| [`log-triage`](./log-triage.md) | After a deploy / when the bot misbehaves | Read production logs and diagnose what's wrong (gated on a read-only log source) |
 
 ---
 
-## How to install on the VPS
+## How it's built and installed
 
-Each skill file contains a ready-to-use prompt block. To add a skill to Hermes:
+These `.md` files are the **human-readable source of truth** for each prompt. Hermes
+loads skills as `SKILL.md` files with YAML frontmatter, so a small builder generates
+those from these docs (the same source → builder → generated-artifact pattern as
+`tools/agent_context/`):
 
-1. SSH into the VPS as `hermes`.
-2. Create a skill file in `~/.hermes/skills/` (or the path configured in `~/.hermes/config.yaml`).
-3. Paste the prompt block from the skill file into the Hermes skill config.
-4. Alternatively, send the full prompt text directly in Telegram — each skill prompt
-   is self-contained and works as a plain Telegram message too.
+```bash
+# Regenerate the installable SKILL.md artifacts after editing any skill doc:
+python3.10 scripts/hermes/build_skills.py
+```
 
-The repo-side skill files are the source of truth. If you update a skill prompt here,
-copy the new version to the VPS manually.
+This writes `scripts/hermes/skills/<name>/SKILL.md` (frontmatter + prompt body, marked
+`GENERATED — DO NOT EDIT`). **Edit the doc here, never the generated `SKILL.md`.** A test
+(`tests/unit/scripts/test_build_skills.py`) fails CI if the committed artifacts drift
+from the docs.
+
+To install on the VPS (run as the `hermes` user, from the repo root):
+
+```bash
+bash scripts/hermes/install-skills.sh            # copies SKILL.md files into ~/.hermes/skills/
+bash scripts/hermes/install-skills.sh --dry-run  # preview
+sudo systemctl restart hermes-gateway            # pick up the new skills
+```
+
+Hermes loads any `SKILL.md` under `~/.hermes/skills/` on next run — no registration step.
+Alternatively, each prompt is self-contained and works as a plain Telegram message too.
+
+`repo-health` ships a `blueprint.schedule` (`0 8 * * *`) in its frontmatter, so once
+installed Hermes self-schedules the daily health digest to your home channel — no extra
+cron wiring needed.
 
 ---
 

--- a/docs/operations/hermes-skills/log-triage.md
+++ b/docs/operations/hermes-skills/log-triage.md
@@ -1,0 +1,103 @@
+# Skill: `superbot-log-triage`
+
+> **Status:** `living-ledger` — ready-to-use Hermes skill prompt. **Gated:** needs a
+> read-only production log source on the VPS (see Setup below) before it can see live
+> bot logs; until then it triages only the VPS-local gateway logs. Update when the
+> deploy target or log source changes.
+
+**Window:** between sessions / after a deploy / when the bot misbehaves
+**Purpose:** Read SuperBot's production logs and turn them into a plain-language
+diagnosis — what's erroring, how often, and the likely cause — without opening a
+Claude Code session or SSHing in by hand. This is the "why is the bot unhappy?"
+skill.
+
+**When to use:** the bot went quiet on Discord, after shipping a change, or any time
+you want to know whether production is healthy before starting work.
+
+---
+
+## Prompt
+
+```
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Do not modify any files. Read-only only. Never run deploy, restart, scale, or any
+mutating command — you are diagnosing, not operating.
+
+Produce a LOG TRIAGE REPORT for SuperBot. Keep the output under 600 words.
+
+Do the following in order. Skip any step whose tool is unavailable and say so.
+
+1. PRODUCTION LOGS (Railway)
+   If the `railway` CLI is installed and logged in, run:
+     railway logs --service superbot 2>&1 | tail -n 400
+   (Adjust the service name if different.) If `railway` is not available, say
+   "production logs unavailable — read-only Railway token not configured" and
+   continue to step 4 using the local gateway logs instead.
+
+2. ERROR SCAN
+   From the log output, count and group by signature:
+   - Tracebacks (lines containing "Traceback (most recent call last)")
+   - Login / connection failures (e.g. "429", "Cannot connect", "WebSocket",
+     "Privileged ... intents", "Improper token")
+   - Database errors ("asyncpg", "connection", "pool", "timeout")
+   - Unhandled command/interaction errors ("Ignoring exception", "discord.ext")
+   For each group: how many times, the most recent timestamp, one example line.
+
+3. CRASH-LOOP CHECK
+   Look for repeated startup banners or repeated identical fatal lines close
+   together in time — that indicates a restart loop. Note the interval if so.
+   (The known crash-loop signature is a 429 on login; the bot is built to sleep
+   ~60s before exiting to break the loop — if you see that, it is degraded but
+   self-limiting, not hard-down.)
+
+4. LOCAL GATEWAY HEALTH (always available)
+   Run: systemctl is-active hermes-gateway 2>/dev/null || echo "not-systemd"
+   Run: journalctl -u hermes-gateway -n 50 --no-pager 2>/dev/null | tail -n 50
+   Report whether the Hermes gateway itself is healthy (this is you — confirms the
+   control plane is up).
+
+5. CORRELATE
+   If you found production errors, check the last 5 commits for a likely culprit:
+     git -C /home/hermes/repos/superbot log --oneline -5
+   Note any commit whose message plausibly relates to the error signature.
+
+Format the output as:
+
+---
+## SuperBot Log Triage — [today's date + time]
+
+### Production status
+[one line: healthy / degraded / crash-looping / unknown (logs unavailable)]
+
+### Error signatures
+| Signature | Count | Last seen | Example |
+|-----------|-------|-----------|---------|
+[rows — or "no errors in window"]
+
+### Crash-loop
+[yes/no + interval, or "none detected"]
+
+### Control-plane (Hermes gateway)
+[from step 4]
+
+### Likely cause / next step
+[1–3 sentences: the most probable cause and whether it warrants a Claude Code
+ session. Do NOT attempt a fix — surface it.]
+---
+```
+
+---
+
+## Notes
+
+- **Read-only by design.** This skill diagnoses; it never restarts, redeploys, or
+  scales the bot. Operating production stays a maintainer action (see
+  `docs/operations/hermes-control-plane.md` § "Current safety model").
+- **Setup (one-time, maintainer):** install the Railway CLI on the VPS and log in
+  with a **read-only** token scoped to the SuperBot service. Until then the skill
+  still works — it triages the local `hermes-gateway` logs and tells you production
+  logs are unavailable.
+- A Neon (Postgres) read-only role can be added later the same way for DB-level
+  triage (connection health, migration state) — keep it read-only.
+- The output is a diagnosis artifact. If it points at a real bug, paste it into a
+  Claude Code session (or use `superbot-prompt-builder`) to get a fix prompt.

--- a/docs/repo-navigation-map.md
+++ b/docs/repo-navigation-map.md
@@ -171,6 +171,7 @@ or read `docs/architecture.md` § "Ownership boundary" again).
 | A new helper (any kind) | Read `docs/helper-policy.md` **first**. The default answer is "inline it" or "put it in the cog's own package". | `docs/helper-policy.md` |
 | A production build/deploy config change | `.python-version` (interpreter pin — bump procedure in the doc) · `Procfile` (worker command) · Railway dashboard is maintainer-only (service vars, restarts) | `docs/operations/production-deployment.md` |
 | Hermes agent / Telegram gateway operations | Hetzner VPS (`hermes-control-plane-01`) · `hermes` user · `hermes-gateway.service` systemd unit · `gh` CLI · SuperBot clone at `/home/hermes/repos/superbot` | [`docs/operations/hermes-control-plane.md`](operations/hermes-control-plane.md) |
+| Hermes skills / operating prompt (mobile control plane) | Skill docs are source of truth; `scripts/hermes/build_skills.py` generates `SKILL.md`; `scripts/hermes/install-skills.sh` deploys to the VPS. Standing read-only instructions: [`hermes-operating-prompt.md`](operations/hermes-operating-prompt.md) | [`docs/operations/hermes-skills/README.md`](operations/hermes-skills/README.md) |
 | A live-reported bug (intake, root cause, fix record) | Add a numbered entry to the bug book; bugs jump the queue (root cause over symptom) | `docs/health/bug-book.md` |
 
 ---

--- a/scripts/hermes/build_skills.py
+++ b/scripts/hermes/build_skills.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Generate installable Hermes ``SKILL.md`` files from the repo's skill docs.
+
+The human-readable source of truth for each Hermes skill is its doc under
+``docs/operations/hermes-skills/<name>.md`` (prose + a ``## Prompt`` fenced
+block). Hermes itself, however, loads skills as ``SKILL.md`` files carrying a
+YAML frontmatter header (``name``/``description``/``version``/``author``/
+``license`` + ``metadata.hermes`` extras) — see
+https://hermes-agent.nousresearch.com/docs/developer-guide/creating-skills/.
+
+This builder bridges the two: it reads each skill doc, lifts the prompt body
+and purpose line, and emits a frontmatter-wrapped ``SKILL.md`` under
+``scripts/hermes/skills/<name>/`` ready to copy onto the VPS with
+``scripts/hermes/install-skills.sh``.
+
+It mirrors the ``tools/agent_context`` pattern: **edit the doc, never the
+generated file** — every emitted ``SKILL.md`` carries a ``GENERATED`` marker.
+
+Pure stdlib (no PyYAML) so the freshness test runs in CI without installing
+anything — same discipline as ``scripts/check_docs.py``.
+
+Usage:
+    python3.10 scripts/hermes/build_skills.py            # (re)generate artifacts
+    python3.10 scripts/hermes/build_skills.py --check    # exit 1 if stale (CI)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SKILL_DOCS_DIR = REPO_ROOT / "docs" / "operations" / "hermes-skills"
+SKILL_OUT_DIR = REPO_ROOT / "scripts" / "hermes" / "skills"
+
+GENERATED_MARKER = "GENERATED — DO NOT EDIT"
+
+# Name token in the doc H1: `# Skill: \`superbot-foo\``.
+_NAME_RE = re.compile(r"`(superbot-[a-z0-9-]+)`")
+
+
+@dataclass(frozen=True)
+class SkillExtras:
+    """Frontmatter fields the doc prose does not carry, keyed by file stem.
+
+    Kept here (not in the doc) so the doc stays clean prose; the substantive,
+    drift-prone content — the prompt — lives only in the doc.
+    """
+
+    tags: list[str]
+    # Optional self-scheduling blueprint: (cron, human task line). Hermes runs
+    # the skill on this schedule and delivers to the home channel. Closes the
+    # "daily health digest" loop with no extra cron wiring on the VPS.
+    schedule: tuple[str, str] | None = None
+    related: list[str] = field(default_factory=list)
+
+
+# Stem -> extras. Add an entry here when a new skill doc is added.
+EXTRAS: dict[str, SkillExtras] = {
+    "session-brief": SkillExtras(tags=["Orientation", "SuperBot", "Planning"]),
+    "repo-health": SkillExtras(
+        tags=["Monitoring", "SuperBot", "Health"],
+        schedule=(
+            "0 8 * * *",
+            "Run a SuperBot repo health check and deliver the traffic-light report.",
+        ),
+    ),
+    "ideas-triage": SkillExtras(tags=["Planning", "SuperBot", "Ideas"]),
+    "prompt-builder": SkillExtras(tags=["Planning", "SuperBot", "PromptEngineering"]),
+    "open-questions": SkillExtras(tags=["Planning", "SuperBot", "Decisions"]),
+    "btd6-status": SkillExtras(tags=["Monitoring", "SuperBot", "BTD6"]),
+    "log-triage": SkillExtras(
+        tags=["Monitoring", "SuperBot", "Diagnostics"],
+        related=["superbot-repo-health"],
+    ),
+}
+
+VERSION = "1.0.0"
+AUTHOR = "SuperBot agents"
+LICENSE = "MIT"
+
+
+@dataclass(frozen=True)
+class Skill:
+    stem: str
+    name: str
+    description: str
+    prompt: str
+
+
+def _extract_purpose(lines: list[str]) -> str:
+    """Lift the ``**Purpose:**`` blurb (may wrap across lines) into one line."""
+    collected: list[str] = []
+    capturing = False
+    for line in lines:
+        if "**Purpose:**" in line:
+            capturing = True
+            collected.append(line.split("**Purpose:**", 1)[1].strip())
+            continue
+        if capturing:
+            if not line.strip():
+                break
+            collected.append(line.strip())
+    return " ".join(collected).strip()
+
+
+def _extract_prompt(lines: list[str]) -> str:
+    """Return the first fenced block following the ``## Prompt`` heading."""
+    in_prompt_section = False
+    in_fence = False
+    body: list[str] = []
+    for line in lines:
+        if line.strip() == "## Prompt":
+            in_prompt_section = True
+            continue
+        if not in_prompt_section:
+            continue
+        stripped = line.strip()
+        if not in_fence:
+            if stripped.startswith("```"):
+                in_fence = True
+            continue
+        if stripped == "```":
+            break
+        body.append(line)
+    return "\n".join(body).strip()
+
+
+def parse_skill_doc(path: Path) -> Skill:
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    stem = path.stem
+
+    name_match = _NAME_RE.search(lines[0] if lines else "")
+    name = name_match.group(1) if name_match else f"superbot-{stem}"
+
+    description = _extract_purpose(lines)
+    if not description:
+        raise ValueError(f"{path.name}: no **Purpose:** line found")
+
+    prompt = _extract_prompt(lines)
+    if not prompt:
+        raise ValueError(f"{path.name}: no ## Prompt fenced block found")
+
+    return Skill(stem=stem, name=name, description=description, prompt=prompt)
+
+
+def _yaml_str(value: str) -> str:
+    """Double-quote a scalar for YAML, escaping quotes/backslashes."""
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def render_skill_md(skill: Skill) -> str:
+    extras = EXTRAS.get(skill.stem, SkillExtras(tags=["SuperBot"]))
+    tags = ", ".join(extras.tags)
+
+    fm: list[str] = [
+        "---",
+        f"name: {skill.name}",
+        f"description: {_yaml_str(skill.description)}",
+        f"version: {VERSION}",
+        f"author: {_yaml_str(AUTHOR)}",
+        f"license: {LICENSE}",
+        "platforms: [linux, macos]",
+        "metadata:",
+        "  hermes:",
+        f"    tags: [{tags}]",
+    ]
+    if extras.related:
+        related = ", ".join(extras.related)
+        fm.append(f"    related_skills: [{related}]")
+    if extras.schedule is not None:
+        cron, task = extras.schedule
+        fm += [
+            "    blueprint:",
+            f"      schedule: {_yaml_str(cron)}",
+            "      deliver: origin",
+            f"      prompt: {_yaml_str(task)}",
+            "      no_agent: false",
+        ]
+    fm.append("---")
+
+    header = (
+        f"<!-- {GENERATED_MARKER}. Source of truth: "
+        f"docs/operations/hermes-skills/{skill.stem}.md. "
+        "Regenerate with scripts/hermes/build_skills.py. -->"
+    )
+    return "\n".join(fm) + "\n\n" + header + "\n\n" + skill.prompt + "\n"
+
+
+def build_all() -> dict[Path, str]:
+    """Return ``{output_path: rendered_content}`` for every skill doc."""
+    out: dict[Path, str] = {}
+    for doc in sorted(SKILL_DOCS_DIR.glob("*.md")):
+        if doc.name == "README.md":
+            continue
+        skill = parse_skill_doc(doc)
+        out_path = SKILL_OUT_DIR / skill.stem / "SKILL.md"
+        out[out_path] = render_skill_md(skill)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit 1 if any generated SKILL.md is missing or stale (CI gate)",
+    )
+    args = parser.parse_args(argv)
+
+    rendered = build_all()
+
+    if args.check:
+        stale: list[Path] = []
+        for path, content in rendered.items():
+            if not path.exists() or path.read_text(encoding="utf-8") != content:
+                stale.append(path)
+        if stale:
+            print("build_skills --check: stale or missing generated skill(s):")
+            for p in sorted(stale):
+                print(f"  {p.relative_to(REPO_ROOT)}")
+            print("\nRun: python3.10 scripts/hermes/build_skills.py")
+            return 1
+        print(f"build_skills --check: {len(rendered)} skill(s) up to date ✓")
+        return 0
+
+    for path, content in rendered.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    print(f"build_skills: wrote {len(rendered)} skill(s) to {SKILL_OUT_DIR.relative_to(REPO_ROOT)}/")
+    for path in sorted(rendered):
+        print(f"  {path.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hermes/install-skills.sh
+++ b/scripts/hermes/install-skills.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Install the SuperBot Hermes skill pack onto the control-plane VPS.
+#
+# Copies the generated SKILL.md files (scripts/hermes/skills/<name>/SKILL.md)
+# into Hermes' skills directory. Hermes loads any SKILL.md dropped under
+# ~/.hermes/skills/ on next run — no registration step needed.
+#
+# The committed SKILL.md files are generated from the docs by
+# scripts/hermes/build_skills.py; this installer copies the committed
+# artifacts, so the VPS needs no Python toolchain. Pass --build to regenerate
+# from the docs first (requires python3 in the repo).
+#
+# Usage (run on the VPS as the `hermes` user, from the repo root):
+#   bash scripts/hermes/install-skills.sh             # install
+#   bash scripts/hermes/install-skills.sh --dry-run   # show what would happen
+#   bash scripts/hermes/install-skills.sh --build      # regenerate then install
+#
+# Override the target dir with HERMES_SKILLS_DIR (default: ~/.hermes/skills).
+set -euo pipefail
+
+DRY_RUN=0
+DO_BUILD=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    --build) DO_BUILD=1 ;;
+    -h | --help)
+      sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_DIR="$SCRIPT_DIR/skills"
+DEST_DIR="${HERMES_SKILLS_DIR:-$HOME/.hermes/skills}"
+
+if [[ "$DO_BUILD" -eq 1 ]]; then
+  PY="$(command -v python3.10 || command -v python3 || true)"
+  if [[ -z "$PY" ]]; then
+    echo "error: --build needs python3, none found on PATH" >&2
+    exit 1
+  fi
+  echo "Regenerating SKILL.md files from docs ($PY)..."
+  "$PY" "$SCRIPT_DIR/build_skills.py"
+fi
+
+if [[ ! -d "$SRC_DIR" ]]; then
+  echo "error: no skills directory at $SRC_DIR — run build_skills.py first" >&2
+  exit 1
+fi
+
+echo "Installing SuperBot Hermes skills"
+echo "  from: $SRC_DIR"
+echo "  to:   $DEST_DIR"
+[[ "$DRY_RUN" -eq 1 ]] && echo "  (dry run — no files will be written)"
+echo
+
+count=0
+for skill_md in "$SRC_DIR"/*/SKILL.md; do
+  [[ -e "$skill_md" ]] || continue
+  name="$(basename "$(dirname "$skill_md")")"
+  target="$DEST_DIR/$name"
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    echo "  would install: $name -> $target/SKILL.md"
+  else
+    mkdir -p "$target"
+    cp "$skill_md" "$target/SKILL.md"
+    echo "  installed: $name"
+  fi
+  count=$((count + 1))
+done
+
+echo
+echo "Done — $count skill(s)."
+if [[ "$DRY_RUN" -eq 0 ]]; then
+  echo "Restart the gateway to pick them up:  sudo systemctl restart hermes-gateway"
+  echo "Verify from Telegram:                 /skills   (or ask Hermes to list its skills)"
+fi

--- a/scripts/hermes/skills/btd6-status/SKILL.md
+++ b/scripts/hermes/skills/btd6-status/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: superbot-btd6-status
+description: "Snapshot of the BTD6 data pipeline — what the bot knows, what it doesn't, and what's broken. Useful after a live testing session where you hit wrong answers."
+version: 1.0.0
+author: "SuperBot agents"
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Monitoring, SuperBot, BTD6]
+---
+
+<!-- GENERATED — DO NOT EDIT. Source of truth: docs/operations/hermes-skills/btd6-status.md. Regenerate with scripts/hermes/build_skills.py. -->
+
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Do not modify any files. Read-only only.
+
+Produce a BTD6 STATUS REPORT. Keep the output under 500 words.
+
+Do the following in order:
+
+1. Read: /home/hermes/repos/superbot/docs/btd6/btd6-gamedata-decode-status.md
+   Extract:
+   - Overall decode progress (what percentage or count is grounded)
+   - Which data areas are complete (✅ or equivalent)
+   - Which data areas are partial or missing (⚠️ / ❌ or equivalent)
+   - Any open items or known gaps listed in the doc
+
+2. Read: /home/hermes/repos/superbot/docs/health/bug-book.md
+   Find any open bugs (not marked FIXED) that mention BTD6, round cash, grounding,
+   resolver, or BTD6-related commands. List each: BUG-NNNN — short description — status.
+
+3. Run: cd /home/hermes/repos/superbot && git log --oneline --all -- disbot/data/btd6/ | head -5
+   Show the 5 most recent commits that touched the BTD6 data files.
+   This tells you how recently the data was updated.
+
+4. Run: cd /home/hermes/repos/superbot && git log --oneline --all -- disbot/services/btd6_*.py | head -5
+   Show the 5 most recent commits that touched BTD6 service files.
+
+5. Check if the probe script exists:
+   ls /home/hermes/repos/superbot/scripts/btd6_probe.py
+   If it exists, run: cd /home/hermes/repos/superbot && python3 scripts/btd6_probe.py --help
+   (read-only — just check what options exist, do not run a full probe)
+
+Format the output as:
+
+---
+## BTD6 Status — [today's date]
+
+### Decode coverage
+[from step 1 — what's grounded vs. missing, compact table or list]
+
+### Open BTD6 bugs
+[from step 2 — or "none open"]
+
+### Recent data changes
+[from steps 3+4 — last 5 commits for data files, last 5 for services]
+
+### Probe tool
+[from step 5 — available options, or "probe script not found"]
+
+### Assessment
+[2–3 sentences: is the BTD6 pipeline in good shape, what's the biggest gap,
+ what would help most in the next session?]
+---

--- a/scripts/hermes/skills/ideas-triage/SKILL.md
+++ b/scripts/hermes/skills/ideas-triage/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: superbot-ideas-triage
+description: "Review the ideas backlog from mobile without a full Claude Code session. Shows what lifecycle state every idea is in and suggests one grooming move."
+version: 1.0.0
+author: "SuperBot agents"
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Planning, SuperBot, Ideas]
+---
+
+<!-- GENERATED — DO NOT EDIT. Source of truth: docs/operations/hermes-skills/ideas-triage.md. Regenerate with scripts/hermes/build_skills.py. -->
+
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Do not modify any files. Read-only only.
+
+Produce an IDEAS TRIAGE REPORT. Keep the output under 700 words.
+
+Do the following in order:
+
+1. Read: /home/hermes/repos/superbot/docs/ideas/README.md
+   Extract every linked idea file (they are in the bullet list under "Current broad captures").
+   For each idea, note its name and any lifecycle state mentioned (raw / captured / routed /
+   in-progress / or no state = assume captured).
+
+2. Read: /home/hermes/repos/superbot/docs/roadmap.md
+   Note which ideas have a horizon entry (Now / Next / Later / Someday).
+
+3. Read: /home/hermes/repos/superbot/docs/planning/ — list the files (ls only, do not read them).
+   Note which idea topics have a corresponding planning doc.
+
+4. Cross-reference steps 1–3 to assign each idea one of these states:
+   - RAW: in ideas/ but no badge, no roadmap entry, no planning doc
+   - CAPTURED: has ideas/ entry + badge, no further routing
+   - ROUTED: has a roadmap horizon OR a planning doc
+   - IN-PROGRESS: referenced as active in docs/current-state.md
+
+5. Read: /home/hermes/repos/superbot/docs/owner/maintainer-question-router.md
+   Check if any idea has an open Q- block blocking it.
+
+6. Identify:
+   - Ideas stuck at RAW (highest priority to route)
+   - The one idea closest to being executable (CAPTURED, clearly scoped, no blocker)
+   - Any idea with a planning doc but no roadmap entry (planning without a horizon = invisible)
+
+Format the output as:
+
+---
+## SuperBot Ideas Triage — [today's date]
+
+### Backlog by state
+| Idea | State | Roadmap horizon | Planning doc? |
+|------|-------|-----------------|---------------|
+[one row per idea]
+
+### Stuck at RAW
+[list ideas with no routing, one line each — these need a home]
+
+### Best candidate to execute next
+[one idea, one paragraph — why it's ready and what the first step would be]
+
+### Needs grooming attention
+[1–3 specific actions: "route X to roadmap", "link Y to planning doc", etc.]
+---

--- a/scripts/hermes/skills/log-triage/SKILL.md
+++ b/scripts/hermes/skills/log-triage/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: superbot-log-triage
+description: "Read SuperBot's production logs and turn them into a plain-language diagnosis — what's erroring, how often, and the likely cause — without opening a Claude Code session or SSHing in by hand. This is the \"why is the bot unhappy?\" skill."
+version: 1.0.0
+author: "SuperBot agents"
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Monitoring, SuperBot, Diagnostics]
+    related_skills: [superbot-repo-health]
+---
+
+<!-- GENERATED — DO NOT EDIT. Source of truth: docs/operations/hermes-skills/log-triage.md. Regenerate with scripts/hermes/build_skills.py. -->
+
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Do not modify any files. Read-only only. Never run deploy, restart, scale, or any
+mutating command — you are diagnosing, not operating.
+
+Produce a LOG TRIAGE REPORT for SuperBot. Keep the output under 600 words.
+
+Do the following in order. Skip any step whose tool is unavailable and say so.
+
+1. PRODUCTION LOGS (Railway)
+   If the `railway` CLI is installed and logged in, run:
+     railway logs --service superbot 2>&1 | tail -n 400
+   (Adjust the service name if different.) If `railway` is not available, say
+   "production logs unavailable — read-only Railway token not configured" and
+   continue to step 4 using the local gateway logs instead.
+
+2. ERROR SCAN
+   From the log output, count and group by signature:
+   - Tracebacks (lines containing "Traceback (most recent call last)")
+   - Login / connection failures (e.g. "429", "Cannot connect", "WebSocket",
+     "Privileged ... intents", "Improper token")
+   - Database errors ("asyncpg", "connection", "pool", "timeout")
+   - Unhandled command/interaction errors ("Ignoring exception", "discord.ext")
+   For each group: how many times, the most recent timestamp, one example line.
+
+3. CRASH-LOOP CHECK
+   Look for repeated startup banners or repeated identical fatal lines close
+   together in time — that indicates a restart loop. Note the interval if so.
+   (The known crash-loop signature is a 429 on login; the bot is built to sleep
+   ~60s before exiting to break the loop — if you see that, it is degraded but
+   self-limiting, not hard-down.)
+
+4. LOCAL GATEWAY HEALTH (always available)
+   Run: systemctl is-active hermes-gateway 2>/dev/null || echo "not-systemd"
+   Run: journalctl -u hermes-gateway -n 50 --no-pager 2>/dev/null | tail -n 50
+   Report whether the Hermes gateway itself is healthy (this is you — confirms the
+   control plane is up).
+
+5. CORRELATE
+   If you found production errors, check the last 5 commits for a likely culprit:
+     git -C /home/hermes/repos/superbot log --oneline -5
+   Note any commit whose message plausibly relates to the error signature.
+
+Format the output as:
+
+---
+## SuperBot Log Triage — [today's date + time]
+
+### Production status
+[one line: healthy / degraded / crash-looping / unknown (logs unavailable)]
+
+### Error signatures
+| Signature | Count | Last seen | Example |
+|-----------|-------|-----------|---------|
+[rows — or "no errors in window"]
+
+### Crash-loop
+[yes/no + interval, or "none detected"]
+
+### Control-plane (Hermes gateway)
+[from step 4]
+
+### Likely cause / next step
+[1–3 sentences: the most probable cause and whether it warrants a Claude Code
+ session. Do NOT attempt a fix — surface it.]
+---

--- a/scripts/hermes/skills/open-questions/SKILL.md
+++ b/scripts/hermes/skills/open-questions/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: superbot-open-questions
+description: "Surface all unanswered Q- blocks from the maintainer question router, grouped by area and urgency. Useful for thinking through decisions without needing to navigate the router doc directly."
+version: 1.0.0
+author: "SuperBot agents"
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Planning, SuperBot, Decisions]
+---
+
+<!-- GENERATED — DO NOT EDIT. Source of truth: docs/operations/hermes-skills/open-questions.md. Regenerate with scripts/hermes/build_skills.py. -->
+
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Do not modify any files. Read-only only.
+
+Produce an OPEN QUESTIONS REPORT from the SuperBot question router.
+Keep the output under 600 words.
+
+Do the following in order:
+
+1. Read: /home/hermes/repos/superbot/docs/owner/maintainer-question-router.md
+   Find every Q-NNNN entry. For each, note:
+   - The Q number
+   - The topic/area (one phrase)
+   - Whether it is marked as Answered / Open / Partially answered
+   - If it is blocking any active work (look for "gated on", "blocked until", "needs Q-")
+
+2. Read: /home/hermes/repos/superbot/docs/current-state.md
+   Check the active lanes for references to open Q- blocks (e.g., "Q-0085 open",
+   "pending Q-", "gate: Q-"). Add any you find that were not already in step 1.
+
+3. Separate the questions into:
+   - BLOCKING: directly gates an active lane or feature
+   - ARCHITECTURAL: affects layer design, ownership, or long-term structure
+   - PRODUCT: owner preference, UX, or business direction
+   - PROCESS: workflow, tooling, or agent-behavior decisions
+
+4. For each blocking question, note in one sentence what is blocked and what the
+   options are (if the router doc mentions them).
+
+Format the output as:
+
+---
+## SuperBot Open Questions — [today's date]
+
+### Blocking (answer these first)
+| Q# | Topic | Blocks |
+|----|-------|--------|
+[rows]
+
+### Architectural
+| Q# | Topic | Short description |
+|----|-------|------------------|
+[rows]
+
+### Product
+| Q# | Topic | Short description |
+|----|-------|------------------|
+[rows]
+
+### Process
+| Q# | Topic | Short description |
+|----|-------|------------------|
+[rows]
+
+### Summary
+[2–3 sentences: how many open total, which areas have the most open questions,
+ and which one question would unblock the most work if answered]
+---

--- a/scripts/hermes/skills/prompt-builder/SKILL.md
+++ b/scripts/hermes/skills/prompt-builder/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: superbot-prompt-builder
+description: "Turn a task description (including a spoken voice-mode idea) into a structured, oriented Claude Code prompt. Arrive at the session with a prompt ready to execute rather than spending context figuring out where to start."
+version: 1.0.0
+author: "SuperBot agents"
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Planning, SuperBot, PromptEngineering]
+---
+
+<!-- GENERATED — DO NOT EDIT. Source of truth: docs/operations/hermes-skills/prompt-builder.md. Regenerate with scripts/hermes/build_skills.py. -->
+
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Do not modify any files. Read-only only.
+
+I want you to build a CLAUDE CODE SESSION PROMPT for the following task:
+
+[TASK DESCRIPTION — replace this with what you want to build or fix]
+
+Do the following in order to build the prompt:
+
+1. IDENTIFY THE AREA
+   Which subsystem(s) does this task touch?
+   Options: ai / setup / settings / mining / games / help / economy / social / btd6 /
+            governance / runtime / views / utils / docs-only
+   Read the matching folio: /home/hermes/repos/superbot/docs/subsystems/<area>.md
+   Note the current state and any active work in that area.
+
+2. IDENTIFY BINDING CONTRACTS
+   Which of these apply to this task? (read only the ones that apply)
+   - /home/hermes/repos/superbot/docs/architecture.md (if touching layer boundaries)
+   - /home/hermes/repos/superbot/docs/ownership.md (if writing to DB or mutations)
+   - /home/hermes/repos/superbot/docs/runtime_contracts.md (if touching bot lifecycle)
+   - /home/hermes/repos/superbot/docs/helper-policy.md (if adding a utility function)
+   List which ones apply and the single most important rule from each.
+
+3. IDENTIFY SOURCE FILES
+   Run: find /home/hermes/repos/superbot/disbot -name "*.py" | xargs grep -l "<relevant keyword>" 2>/dev/null | head -10
+   (Use a keyword from the task — cog name, service name, command name, etc.)
+   List the 2–4 most relevant files. Do not read them — just list paths.
+
+4. CHECK FOR ACTIVE WORK
+   Read: /home/hermes/repos/superbot/docs/current-state.md
+   Does any active lane overlap with this task? Note it if so.
+
+5. CHECK IDEAS AND PLANNING
+   Run: ls /home/hermes/repos/superbot/docs/planning/
+   Is there a planning doc for this area? If yes, note its name.
+
+6. DRAFT THE PROMPT
+   Write a complete prompt using this structure:
+
+---
+## Task: [one-line task title]
+
+### Context
+[2–3 sentences: what this task is, why it matters, what subsystem it touches]
+
+### Read first
+[list of docs to read, in order — binding ones first]
+- docs/architecture.md (rule: ...)
+- docs/ownership.md (rule: ...)  [if applicable]
+- docs/subsystems/<area>.md
+
+### Relevant source files
+[2–4 file paths from step 3]
+
+### Active lane overlap
+[from step 4 — or "none detected"]
+
+### Implementation notes
+[1–3 specific constraints or gotchas from the binding docs — e.g.,
+ "always write through <service>.py", "use settings_keys constants not raw strings"]
+
+### Acceptance criteria
+[2–3 concrete things that should be true when the task is done]
+---
+
+Do not implement anything. Only produce the prompt.

--- a/scripts/hermes/skills/repo-health/SKILL.md
+++ b/scripts/hermes/skills/repo-health/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: superbot-repo-health
+description: "Traffic-light health snapshot. Answers \"is anything broken right now?\" without opening a full Claude Code session."
+version: 1.0.0
+author: "SuperBot agents"
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Monitoring, SuperBot, Health]
+    blueprint:
+      schedule: "0 8 * * *"
+      deliver: origin
+      prompt: "Run a SuperBot repo health check and deliver the traffic-light report."
+      no_agent: false
+---
+
+<!-- GENERATED — DO NOT EDIT. Source of truth: docs/operations/hermes-skills/repo-health.md. Regenerate with scripts/hermes/build_skills.py. -->
+
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Do not modify any files. Read-only only.
+
+Run a REPO HEALTH CHECK and produce a traffic-light report. Use ✅ (green), ⚠️ (warning),
+or ❌ (red) for each dimension. Keep the whole output under 500 words.
+
+Run these checks in order:
+
+1. DOCS CHECK
+   Run: cd /home/hermes/repos/superbot && python3 scripts/check_docs.py --strict
+   ✅ if "all checks passed"
+   ❌ if any issues — list them verbatim (they are short)
+
+2. ARCHITECTURE CHECK
+   Run: cd /home/hermes/repos/superbot && python3 scripts/check_architecture.py --mode strict
+   ✅ if exit 0 with 0 errors
+   ⚠️ if warnings only (list count)
+   ❌ if errors — list them
+
+3. OPEN PRS
+   Run: gh pr list --repo menno420/superbot --state open --json number,title,isDraft,headRefName
+   ✅ if 0 open PRs
+   ⚠️ if 1–2 open (list them)
+   ⚠️ if any are non-draft and older than 2 days (note which)
+   ❌ if 3+ open PRs
+
+4. RECENT CI
+   Run: gh run list --repo menno420/superbot --limit 5 --json status,conclusion,headBranch,displayTitle
+   ✅ if all 5 completed with success
+   ⚠️ if 1 failure (note branch)
+   ❌ if 2+ failures
+
+5. WORKING TREE
+   Run: git -C /home/hermes/repos/superbot status --short
+   ✅ if clean
+   ⚠️ if modified files present (list them — they may be from a previous Hermes run)
+
+6. MAIN SYNC
+   Run: git -C /home/hermes/repos/superbot fetch origin main --dry-run 2>&1
+   Run: git -C /home/hermes/repos/superbot log --oneline origin/main..HEAD
+   ✅ if HEAD is at origin/main (no local commits ahead)
+   ⚠️ if local commits ahead of origin/main (list them — repo clone may be stale)
+
+Format the output as:
+
+---
+## SuperBot Repo Health — [today's date + time]
+
+| Dimension       | Status | Notes |
+|-----------------|--------|-------|
+| Docs            | ✅/⚠️/❌ | ... |
+| Architecture    | ✅/⚠️/❌ | ... |
+| Open PRs        | ✅/⚠️/❌ | ... |
+| Recent CI       | ✅/⚠️/❌ | ... |
+| Working tree    | ✅/⚠️/❌ | ... |
+| Main sync       | ✅/⚠️/❌ | ... |
+
+### Details
+[any ⚠️ or ❌ items expanded here, one paragraph each]
+
+### Verdict
+[one sentence — is the repo ready to work in, or does something need attention first?]
+---

--- a/scripts/hermes/skills/session-brief/SKILL.md
+++ b/scripts/hermes/skills/session-brief/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: superbot-session-brief
+description: "Generate a compressed orientation brief that you paste into Claude Code at the start of a session. Skips the standard 15-minute orientation read."
+version: 1.0.0
+author: "SuperBot agents"
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Orientation, SuperBot, Planning]
+---
+
+<!-- GENERATED — DO NOT EDIT. Source of truth: docs/operations/hermes-skills/session-brief.md. Regenerate with scripts/hermes/build_skills.py. -->
+
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Do not modify any files. Read-only only.
+
+Produce a SESSION BRIEF for a Claude Code agent about to start work on this repo.
+Keep the entire output under 800 words. Be concrete — no filler.
+
+Do the following steps in order:
+
+1. Run: git -C /home/hermes/repos/superbot log --oneline -5
+   Report the last 5 commits (hash + message only).
+
+2. Run: git -C /home/hermes/repos/superbot status --short
+   If the tree is dirty, list the modified files. If clean, say "working tree clean".
+
+3. Run: gh pr list --repo menno420/superbot --state open --json number,title,isDraft,headRefName
+   List all open PRs as: #NNN [draft?] title (branch). If none, say "no open PRs".
+
+4. Read: /home/hermes/repos/superbot/docs/current-state.md
+   Extract and summarize:
+   - Active implementation lanes (what work is in progress)
+   - Recently shipped (last 3 entries only)
+   - Any gates or blockers mentioned
+
+5. Read: /home/hermes/repos/superbot/docs/owner/maintainer-question-router.md
+   List any Q- blocks marked as open (not answered). One line each: Q-NNNN — topic.
+   If more than 5 open, show the 5 most recent only.
+
+6. Read the most recent file in /home/hermes/repos/superbot/.sessions/ (sort by filename, newest first).
+   Summarize in 3 bullet points: what was done, what was left open, what is next.
+
+7. Based on steps 3–6, suggest ONE focus for the next session in one sentence.
+
+Format the output as:
+
+---
+## SuperBot Session Brief — [today's date]
+
+### Recent commits
+[step 1]
+
+### Repo state
+[step 2]
+
+### Open PRs
+[step 3]
+
+### Active lanes & gates
+[step 4 summary]
+
+### Open questions (Q- blocks)
+[step 5]
+
+### Last session summary
+[step 6]
+
+### Suggested focus
+[step 7]
+---

--- a/tests/unit/scripts/test_build_skills.py
+++ b/tests/unit/scripts/test_build_skills.py
@@ -1,0 +1,68 @@
+"""Tests for ``scripts/hermes/build_skills.py``.
+
+Guards the docs -> SKILL.md generator: every skill doc must produce a valid
+Hermes skill artifact, and the committed artifacts must stay in sync with the
+docs (the ``--check`` freshness gate, mirroring the agent-context pack test).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_BUILDER = REPO_ROOT / "scripts" / "hermes" / "build_skills.py"
+
+_spec = importlib.util.spec_from_file_location("hermes_build_skills", _BUILDER)
+assert _spec and _spec.loader
+build_skills = importlib.util.module_from_spec(_spec)
+sys.modules["hermes_build_skills"] = build_skills
+_spec.loader.exec_module(build_skills)
+
+
+def test_every_skill_doc_builds() -> None:
+    rendered = build_skills.build_all()
+    # One artifact per skill doc (README excluded).
+    docs = [
+        p
+        for p in build_skills.SKILL_DOCS_DIR.glob("*.md")
+        if p.name != "README.md"
+    ]
+    assert len(rendered) == len(docs)
+    assert rendered, "expected at least one skill doc to build"
+
+
+@pytest.mark.parametrize("path,content", list(build_skills.build_all().items()))
+def test_required_frontmatter_present(path: Path, content: str) -> None:
+    # Frontmatter block exists and carries every Hermes-required field.
+    assert content.startswith("---\n")
+    head = content.split("---", 2)[1]
+    for field in ("name:", "description:", "version:", "author:", "license:"):
+        assert field in head, f"{path.name}: missing {field}"
+    assert head.count("name: superbot-") == 1
+    # Generated marker so nobody hand-edits the artifact.
+    assert build_skills.GENERATED_MARKER in content
+    # Prompt body is non-empty and read-only by construction.
+    body = content.split("-->", 1)[1].strip()
+    assert len(body) > 100, f"{path.name}: prompt body looks empty"
+
+
+def test_repo_health_self_schedules() -> None:
+    rendered = build_skills.build_all()
+    health = next(p for p in rendered if p.parent.name == "repo-health")
+    content = rendered[health]
+    assert "blueprint:" in content
+    assert "schedule:" in content
+    assert "deliver: origin" in content
+
+
+def test_committed_artifacts_are_fresh() -> None:
+    """Committed SKILL.md files must match a fresh build (run the builder)."""
+    rc = build_skills.main(["--check"])
+    assert rc == 0, (
+        "Generated Hermes skills are stale. "
+        "Run: python3.10 scripts/hermes/build_skills.py"
+    )


### PR DESCRIPTION
## What & why

Yesterday's Hermes setup left the skill pack as **docs only** — not actually loadable by the agent on the VPS. This turns it into something Hermes can install and run, and adds the two capabilities asked about in this session: **reading the bot's logs to diagnose problems**, and **journal-like instructions so Hermes orients faster**.

## Changes

**Make the skills installable (the missing frontmatter step)**
- `scripts/hermes/build_skills.py` — generates installable `SKILL.md` files (Hermes YAML frontmatter: `name`/`description`/`version`/`author`/`license` + `metadata.hermes`) from the skill docs. Mirrors the repo's `tools/agent_context` source → builder → generated-artifact idiom; docs stay the source of truth, artifacts carry a `GENERATED — DO NOT EDIT` marker. Pure stdlib (no PyYAML) so the freshness test runs in CI.
- `scripts/hermes/install-skills.sh` — copies the generated `SKILL.md` files into `~/.hermes/skills/` on the VPS (`--dry-run`, `--build` flags).
- `repo-health` ships `blueprint.schedule: "0 8 * * *"` → Hermes **self-schedules the daily health digest** once installed (closes the prior session's "daily digest" idea with no extra cron wiring).
- `tests/unit/scripts/test_build_skills.py` — fails CI if committed artifacts drift from the docs.

**Read the bot's logs (new capability)**
- `docs/operations/hermes-skills/log-triage.md` — read-only production/gateway log diagnosis. Triages the local `hermes-gateway` logs today; triages Railway production logs once a **read-only** token is configured. Diagnoses only — never restarts/redeploys (stays inside the control-plane safety model).

**Orient faster (the journal-like instructions)**
- `docs/operations/hermes-operating-prompt.md` — the Hermes-side `CLAUDE.md`: standing read-only orientation (repo path, read-path order, layer/ownership boundaries, safety model) to paste into Hermes' base instructions.

**Wiring**
- Updated control-plane doc, skills README, and `repo-navigation-map.md` for discoverability/reachability.

## Verification
- `python3.10 scripts/check_docs.py --strict` ✓
- `python3.10 scripts/check_quality.py --check-only` ✓ (black/isort/ruff/check_docs)
- `python3.10 -m pytest tests/unit/scripts/test_build_skills.py tests/unit/scripts/test_check_docs.py tests/unit/docs/` ✓ (96 passed)
- No `disbot/` changes (mypy scope untouched).

## Maintainer follow-ups (VPS-side, can't be done from here)
- Run `bash scripts/hermes/install-skills.sh` on the VPS, then `sudo systemctl restart hermes-gateway`.
- For `log-triage` production logs: install the Railway CLI on the VPS with a **read-only** token.

https://claude.ai/code/session_016RkBwxihX7dcwdU7AoN7kD

---
_Generated by [Claude Code](https://claude.ai/code/session_016RkBwxihX7dcwdU7AoN7kD)_