### PR TITLE
governance: agents propose CLAUDE.md changes, never self-edit (Q-0106)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,10 +14,19 @@ The short version that governs how you work:
   lets any agent work correctly with little steering. **Improving the docs /
   orientation / tooling for the next session is first-class work, never wasted
   effort or "extra"** — every session should leave the next better-equipped. You
-  have **free rein on docs / journal / orientation**; **ask before changing
-  executable config** (hooks, `.claude/settings.json`, or binding *rules* in this
-  file). The *why*, the autonomy boundary, and the context-delta loop are in
-  **`docs/collaboration-model.md` § "Why this system exists."**
+  have **free rein on docs / journal / orientation**. **This file (and executable
+  config — hooks, `.claude/settings.json`) you do NOT self-edit on your own initiative
+  (owner directive Q-0106, 2026-06-12).** These instructions are **binding *for* your
+  session but not pinned** — the whole system, this file included, is still in
+  development. The way you evolve a binding rule is to **propose it, not apply it**:
+  when you have an idea to change/add/remove a rule here, record it as a **router
+  Q-block (DISCUSS lane)** in `docs/owner/maintainer-question-router.md` for live owner
+  review — never edit the rule in yourself. **The one exception is a change the
+  maintainer directs in-session**: then the owner *is* the live reviewer, so you apply
+  it directly and record the Q-number (every rule change ships with its provenance Q).
+  In a fully autonomous session with no human live, this means CLAUDE.md is **read-only
+  to you** — you only ever write *proposals*. The *why*, the autonomy boundary, and the
+  context-delta loop are in **`docs/collaboration-model.md` § "Why this system exists."**
 - **Session prompts are guidance, not orders.** A prompt (usually drafted via
   ChatGPT) explains the focus and reminds you of things; weigh it against source,
   the roadmaps, and your own judgment. It is one input, never a command list.

--- a/.sessions/2026-06-12-claude-md-governance-rule.md
+++ b/.sessions/2026-06-12-claude-md-governance-rule.md
@@ -1,0 +1,57 @@
+# 2026-06-12 — CLAUDE.md governance: propose, don't self-edit (Q-0106)
+
+> **Status:** `audit`
+
+**PR:** opened this batch (CLAUDE.md self-edit governance)
+**Branch:** `claude/claude-md-governance-rule`
+
+## Context
+
+Owner directive (voice), closing the autonomy-safety thread: for full autonomous improvement,
+agents must **never edit `CLAUDE.md` on their own initiative** when they have an idea — they
+**document the proposal for live review**. But the instructions, while binding *for* a session,
+are **not locked/pinned** — they are still in development like the rest of the system.
+
+## What was done
+
+- **Q-0106 (binding governance rule).** `.claude/CLAUDE.md` Working agreement now states:
+  CLAUDE.md is **binding for a session but not pinned**; agents **propose** rule changes via a
+  **router Q-block (DISCUSS lane)**, never self-edit; the **one exception** is a maintainer-
+  directed in-session change (the owner *is* the live reviewer, so it applies directly with a
+  provenance Q). In a **fully autonomous session, CLAUDE.md is read-only** to the agent — it
+  only writes proposals. Recorded in the router (Q-0106).
+- This is the governance counterpart to the self-audit loop (Q-0102/Q-0104) and the reason the
+  `Edit(.claude/CLAUDE.md)` permission prompt is deliberately kept (it is the live-review gate
+  when a human is present — `claude-code-hooks-and-plugins.md` § Permissions posture).
+
+## Verification
+
+- `check_docs --strict` ✓ · `check_session_log --strict` ✓ · `check_current_state_ledger --strict` ✓.
+  Docs/config only.
+
+## Grooming move
+
+None — this batch *is* a directed governance change, not backlog grooming. Backlog was groomed
+across the #730/#733/#734 batches this session.
+
+## ⟲ Previous-session review (Q-0102 — reviewing the #734 batch)
+
+- **What it did well:** built the ledger guard, found + reconciled real pre-existing drift, and
+  landed Q-0104/Q-0105 — each rule change carrying a provenance Q.
+- **What it could have done better:** the #734 batch accreted scope mid-flight (drift fix → ledger
+  tool → Q-0104 → Q-0105) across several pushes → several CI runs. Acceptable when directives
+  arrive live, but the recurring "batch keeps growing" pattern is worth naming.
+- **System improvement surfaced:** every rule change this session shipped with a provenance Q —
+  but nothing *checks* that. → captured as this batch's 💡 idea (provenance self-check), which
+  directly enforces Q-0106's "rules ship with a provenance Q."
+
+## 💡 Session idea
+
+**Idea:** A `check_claude_md_provenance.py` (Q-0105 disposable guard) that verifies every binding
+rule in `CLAUDE.md` citing a `Q-NNNN` resolves to a real router entry, and flags rule bullets added
+with **no** provenance Q at all.
+**Why:** Q-0106 requires every rule change to ship with a provenance Q; this makes that
+self-checking — the *constitution's* provenance becomes verifiable the way the ledger and session
+log now are. It would catch a rule slipped in without owner provenance (the autonomous-self-edit
+failure mode Q-0106 guards against). Advisory, git/stdlib, carries its own delete-if-unreliable
+header. _Small — recorded here; promote to an idea file if it grows._

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -50,15 +50,18 @@ Source code and merged PRs win over anything written here.
 > get it from live GitHub. The newest merge a session sees may not be added yet; that
 > lag is expected (the next session reconciles). A merged PR tagged "pending" is the bug.
 
-- **#733 (2026-06-12, workflow/memory/permissions)** — **Q-0102** (mandatory `⟲ Previous-session
-  review` session-ender — review the predecessor + surface one system improvement) + **Q-0103**
-  (open session PRs **ready not draft**; every PR must reach a terminal state — merged or closed).
-  `scripts/check_session_log.py` + post-edit/Stop-hook wiring enforce the Q-0089/Q-0102 enders.
-  New [`docs/operations/claude-code-hooks-and-plugins.md`](operations/claude-code-hooks-and-plugins.md)
-  (the 6 wired hooks + candidate-hook brainstorm + plugins posture → Q-0096). `.claude/settings.json`
+- **#733–#734 (2026-06-12, the agent-workflow/memory hardening arc)** — **#733**: **Q-0102**
+  (mandatory `⟲ Previous-session review` session-ender) + **Q-0103** (open session PRs **ready not
+  draft**; every PR reaches a terminal state). `scripts/check_session_log.py` + post-edit/Stop-hook
+  wiring enforce the Q-0089/Q-0102 enders. New
+  [`docs/operations/claude-code-hooks-and-plugins.md`](operations/claude-code-hooks-and-plugins.md)
+  (the 6 wired hooks + brainstorm + plugins posture → Q-0096). `.claude/settings.json`
   permission-friction cut (`acceptEdits` + curated allowlist; force-push/destructive still prompt).
-  Captured ideas: autonomous self-improvement loop · Hermes→Claude Routines dispatch bridge ·
-  portable OSS memory/workflow package.
+  **#734**: reconciled this ledger's drift (added #730/#733, relabeled #731, added #724–#728) and
+  built `scripts/check_current_state_ledger.py` (the living-ledger self-check) + **Q-0104** (closing
+  documentation audit) + **Q-0105** (adopt-tooling-with-a-delete-if-unreliable kill-switch) +
+  permissions-posture doc. Captured ideas: autonomous self-improvement loop · Hermes→Claude Routines
+  dispatch bridge · portable OSS memory/workflow package · ledger session-arc aggregation.
 - **#730 (2026-06-12, Hermes skills installable)** — `scripts/hermes/build_skills.py` generates
   installable `SKILL.md` files (Hermes frontmatter) from the skill docs + `install-skills.sh`
   deploys them to the VPS; `repo-health` self-schedules a daily Telegram digest via a frontmatter

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -4125,3 +4125,36 @@ sessions.
 
 **Home:** `.claude/CLAUDE.md` § "Session & plan workflow" (the Q-0014 tooling bullet) · this
 entry is provenance.
+
+### Q-0106 — Agents never self-edit CLAUDE.md on their own initiative; propose for live review
+
+> **DIRECTED 2026-06-12 (owner, voice).** For full autonomous improvement, agents must not
+> edit `.claude/CLAUDE.md` (or binding rules) when *they* have an idea — they document the
+> proposal for live review. The owner's framing: the instructions "may be binding for their
+> session, but they are not locked/pinned — they are still in development just like the rest
+> of the system."
+
+**Area:** Agent system · governance / self-modification boundary
+**Type:** Standing workflow rule (process + safety)
+**Priority:** Standing — every session, load-bearing for autonomy
+
+**Decision:**
+- **`CLAUDE.md` is binding *for* a session but not *pinned*.** It is in development like the
+  rest of the system. Agents follow it this session and may *evolve* it — but only by
+  **proposing**, not self-applying.
+- **Agent-originated rule changes → a router Q-block (DISCUSS lane), never a direct edit.**
+  The change lands in `CLAUDE.md` only after the owner decides.
+- **Exception — maintainer-directed in-session changes apply directly.** When the owner
+  directs a rule change live (as with Q-0102–Q-0106), the owner *is* the live reviewer, so
+  the agent applies it and records the provenance Q-number.
+- **In a fully autonomous session (no human live), `CLAUDE.md` is read-only to the agent** —
+  it only ever writes proposals. This is *why* the `Edit(.claude/CLAUDE.md)` permission prompt
+  is kept (it is the live-review gate when a human is present); see
+  `docs/operations/claude-code-hooks-and-plugins.md` § Permissions posture.
+
+**Why:** self-modification of one's own binding instructions is the highest-risk autonomous
+action — the prime prompt-injection / value-drift target. Routing all rule changes through
+owner review keeps the agent's "constitution" under human control while still letting the
+system evolve. This is the governance counterpart to the Q-0102/Q-0104 self-audit loop.
+
+**Home:** `.claude/CLAUDE.md` Working agreement (binding) · this entry is provenance.


### PR DESCRIPTION
## What & why

Owner directive (voice): for full autonomous improvement, agents must **never edit `CLAUDE.md` on their own initiative** — they document the proposal for live review. And the framing the maintainer wants made explicit: the instructions are **binding *for* a session but not locked/pinned** — still in development like the rest of the system.

## The governance model (Q-0106)

- **`CLAUDE.md` is binding for a session but not pinned.** Agents follow it, and may *evolve* it — but only by **proposing**, not self-applying.
- **Agent-originated rule changes → a router Q-block (DISCUSS lane), never a direct edit.** The change lands only after the owner decides.
- **Exception — maintainer-directed in-session changes apply directly** (the owner *is* the live reviewer; record the provenance Q — as Q-0102…Q-0106 all did).
- **In a fully autonomous session, `CLAUDE.md` is read-only to the agent** — it only writes proposals. This is *why* the `Edit(.claude/CLAUDE.md)` permission prompt is deliberately kept: it's the live-review gate when a human is present.

This is the governance counterpart to the Q-0102/Q-0104 self-audit loop — self-modification of one's own binding instructions is the highest-risk autonomous action (the prime injection / value-drift target), so all rule changes route through owner review.

## Changes
- `.claude/CLAUDE.md` Working agreement — the propose-don't-self-edit rule + the binding-but-not-pinned framing.
- `docs/owner/maintainer-question-router.md` — Q-0106 provenance entry.
- `docs/current-state.md` — reconciled #734 into the ledger (folded into a `#733–#734` arc entry, dogfooding the session-arc aggregation idea).

## Verification
- `check_docs --strict` ✓ · `check_session_log --strict` ✓ · `check_current_state_ledger --strict` ✓. Docs/config only.

https://claude.ai/code/session_016RkBwxihX7dcwdU7AoN7kD

---
_Generated by [Claude Code](https://claude.ai/code/session_016RkBwxihX7dcwdU7AoN7kD)_