### PR TITLE
docs: fix codegraph-usage version pin (3.10.0 → 3.11.2) + CodeGraph health check

### DIFF
--- a/.sessions/2026-06-12-codegraph-doc-version-fix.md
+++ b/.sessions/2026-06-12-codegraph-doc-version-fix.md
@@ -1,0 +1,62 @@
+# 2026-06-12 — CodeGraph health check + doc version-pin fix
+
+> **Status:** `audit`
+
+**PR:** opened this batch (codegraph-usage version fix)
+**Branch:** `claude/codegraph-doc-version-fix`
+
+## Context
+
+Owner: "see if you can find out what's wrong with CodeGraph — maybe nothing, but I thought
+agents had problems after we updated it" (the 3.10.0 → 3.11.2 bump on 2026-06-08).
+
+## Findings — CodeGraph itself is healthy
+
+- Live-tested at 3.11.2 this session: graph builds (35,912 nodes / 64,181 edges at SessionStart),
+  `list_functions validate_registry` resolves correctly, `check` returns accurate
+  complexity/boundary analysis (boundaries pass, no cycles). **No functional regression found.**
+- The "problems" agents hit are the two **documented, version-independent** issues, not a 3.11.2
+  regression:
+  1. **Availability gotcha** — on a cold container the first `npx -y` download blips and the hook
+     reports "CLI unavailable", silently disabling CodeGraph for the session (CLAUDE.md documents
+     this; two session logs confirm it: 2026-06-09/06-10). Environmental, clears on retry.
+  2. **Inherent false positives** — `dead-unresolved` (~100% FP; `validate_registry` confirmed),
+     name-collision caller merges, empty `callees`, invisible decorator/event edges. These are the
+     5 critical CLAUDE.md rules and existed identically at 3.10.0.
+
+## Findings — a real bug, now fixed
+
+`docs/codegraph-usage.md` was **stale at 3.10.0**: every rebuild/troubleshoot command said
+`npx -y @optave/codegraph@3.10.0 …` while the live pin (`.mcp.json` + SessionStart `CG_PKG`) is
+**3.11.2**. An agent following the doc would build/probe with the *wrong, old* version → a graph
+that can differ from the live MCP server. Bumped all command refs to 3.11.2; kept the historical
+"evaluated at 3.10.0" note but added the current-pin callout. (Drift since the 2026-06-08 bump —
+4 days unnoticed.)
+
+## Verification
+
+- `check_docs --strict` ✓. Live CodeGraph MCP tools verified working. Docs-only.
+
+## Grooming move
+
+None — directed investigation + bug fix, not backlog grooming.
+
+## ⟲ Previous-session review (Q-0102 — reviewing the #735 governance batch)
+
+- **What it did well:** cleanly encoded Q-0106 (propose-don't-self-edit) and tied it to the
+  permission-prompt rationale; folded #734 into the ledger.
+- **What it missed:** nothing in that batch — but this investigation shows a *class* of drift the
+  system doesn't yet guard: a version pin in a doc silently diverging from the canonical pin
+  (`.mcp.json`). The 3.10.0→3.11.2 doc lag sat unnoticed for 4 days.
+- **System improvement surfaced:** a version-pin drift check (docs vs. the canonical pin). →
+  this batch's 💡 idea.
+
+## 💡 Session idea
+
+**Idea:** A `check_pin_drift.py` (Q-0105 disposable guard) that greps docs for pinned-package refs
+(e.g. `@optave/codegraph@X.Y.Z`, `youtube-transcript-api<1.0`) and flags any that disagree with the
+canonical source (`.mcp.json`, `requirements*.txt`, the SessionStart `CG_PKG`).
+**Why:** the stale CodeGraph version commands sat in the canonical doc for 4 days because nothing
+cross-checks doc-stated pins against real pins. This closes that gap the way the ledger/log checks
+closed theirs — pin drift becomes a checkable signal, not a thing someone happens to notice.
+Advisory, git/stdlib, carries its own delete-if-unreliable header. _Small — recorded here._

--- a/docs/codegraph-usage.md
+++ b/docs/codegraph-usage.md
@@ -7,7 +7,10 @@
 > safety rules (dead-unresolved, name-collision, Discord decorators, empty callees,
 > blind-spot wiring). Everything else lives here.**
 >
-> Last evaluated: 2026-05-24, codegraph 3.10.0, against the live repo.
+> Last evaluated: 2026-05-24 at codegraph 3.10.0, against the live repo. **Pinned
+> `@optave/codegraph@3.11.2` since 2026-06-08** (bumped from 3.10.0, verified
+> graph-identical — all commands below run the pinned 3.11.2). If you ever run a bare
+> `@optave/codegraph` command, use the pinned version to match the live MCP server.
 > Evaluation method: every claim below was verified by running the tool, then
 > grep-searching or source-reading to confirm or refute the result.
 
@@ -66,10 +69,10 @@ functions called through any of these patterns.
 No global install is required. The MCP server starts via pinned `npx` on every
 Claude Code launch.
 
-1. Verify the package resolves: `npx -y @optave/codegraph@3.10.0 --version`
+1. Verify the package resolves: `npx -y @optave/codegraph@3.11.2 --version`
 2. Build the index (first time or fresh clone):
-   `npx -y @optave/codegraph@3.10.0 build .`
-3. Confirm the index: `npx -y @optave/codegraph@3.10.0 stats` — look for
+   `npx -y @optave/codegraph@3.11.2 build .`
+3. Confirm the index: `npx -y @optave/codegraph@3.11.2 stats` — look for
    `Active engine: native`
 4. Inside Claude Code, confirm MCP tools load by calling
    `mcp__codegraph__where` on any known symbol.
@@ -319,8 +322,8 @@ Caller lists are lower bounds. Callee lists are empty when lazy imports are used
 | Symptom | Fix |
 |---|---|
 | MCP tools unavailable and index present | Restart Claude Code — the `npx` MCP server is loaded once at session init |
-| MCP tools available but empty results | Index is missing. Run `npx -y @optave/codegraph@3.10.0 build .` — no restart needed |
-| Stale index after editing files | `npx -y @optave/codegraph@3.10.0 build .` to rebuild |
+| MCP tools available but empty results | Index is missing. Run `npx -y @optave/codegraph@3.11.2 build .` — no restart needed |
+| Stale index after editing files | `npx -y @optave/codegraph@3.11.2 build .` to rebuild |
 | `Active engine: wasm` in stats | Performance degraded. Rebuild the native binding (`npm rebuild better-sqlite3` inside the codegraph package). |
 | `execution_flow` returns 0 entries | Known broken — do not use. Use grep for forward tracing. |
 | `find_cycles` / `communities` return 0 | Known broken — file-level edges are broken in this index. Do not use. |
@@ -328,7 +331,7 @@ Caller lists are lower bounds. Callee lists are empty when lazy imports are used
 | `module_map` returns all zeros | Known broken. Use `fn_impact` or `context` for function-level connectivity. |
 | `file_deps` shows 0 imports | Known broken. Use grep to trace cross-file references. |
 | `impact_analysis` returns 0 dependents | Known broken. Use `fn_impact` for blast-radius. |
-| `semantic_search` returns "No embeddings" | Run `npx -y @optave/codegraph@3.10.0 embed` first. |
+| `semantic_search` returns "No embeddings" | Run `npx -y @optave/codegraph@3.11.2 embed` first. |
 | `brief` caller count seems too high | Count is transitive total, not direct callers. Use `fn_impact` Level 1. |
 | Caller list misses known callers | Callers use lazy imports or module-alias calls — grep-verify always. |
 | Unexpected callers in unrelated files | Name-collision: check whether those files have a same-named function/method. |

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -50,7 +50,7 @@ Source code and merged PRs win over anything written here.
 > get it from live GitHub. The newest merge a session sees may not be added yet; that
 > lag is expected (the next session reconciles). A merged PR tagged "pending" is the bug.
 
-- **#733–#734 (2026-06-12, the agent-workflow/memory hardening arc)** — **#733**: **Q-0102**
+- **#733–#735 (2026-06-12, the agent-workflow/memory hardening arc)** — **#733**: **Q-0102**
   (mandatory `⟲ Previous-session review` session-ender) + **Q-0103** (open session PRs **ready not
   draft**; every PR reaches a terminal state). `scripts/check_session_log.py` + post-edit/Stop-hook
   wiring enforce the Q-0089/Q-0102 enders. New
@@ -60,7 +60,9 @@ Source code and merged PRs win over anything written here.
   **#734**: reconciled this ledger's drift (added #730/#733, relabeled #731, added #724–#728) and
   built `scripts/check_current_state_ledger.py` (the living-ledger self-check) + **Q-0104** (closing
   documentation audit) + **Q-0105** (adopt-tooling-with-a-delete-if-unreliable kill-switch) +
-  permissions-posture doc. Captured ideas: autonomous self-improvement loop · Hermes→Claude Routines
+  permissions-posture doc. **#735**: **Q-0106** — agents propose `CLAUDE.md` rule changes via a
+  router Q-block, never self-edit (binding for a session but not pinned; read-only to a fully
+  autonomous agent). Captured ideas: autonomous self-improvement loop · Hermes→Claude Routines
   dispatch bridge · portable OSS memory/workflow package · ledger session-arc aggregation.
 - **#730 (2026-06-12, Hermes skills installable)** — `scripts/hermes/build_skills.py` generates
   installable `SKILL.md` files (Hermes frontmatter) from the skill docs + `install-skills.sh`


### PR DESCRIPTION
## What & why

Owner asked me to check whether something's wrong with CodeGraph after the 3.10.0 → 3.11.2 bump.

**CodeGraph itself is healthy.** Live-tested at 3.11.2 this session: the graph builds (35,912 nodes / 64,181 edges at SessionStart), `list_functions` resolves symbols correctly, `check` returns accurate complexity/boundary analysis. No functional regression from the bump.

**The "problems" agents hit are two documented, version-independent issues**, not a 3.11.2 regression:
1. **Availability gotcha** — on a cold container the first `npx -y` download blips and the hook reports "CLI unavailable", silently disabling CodeGraph for the session (clears on retry).
2. **Inherent false positives** — `dead-unresolved` (~100% FP; `validate_registry` confirmed), name-collision caller merges, empty `callees`, invisible decorator/event edges. These are the 5 critical CLAUDE.md rules and behaved identically at 3.10.0.

**Real bug found + fixed:** `docs/codegraph-usage.md` told agents to run `@optave/codegraph@3.10.0` while the live pin (`.mcp.json` + SessionStart `CG_PKG`) is **3.11.2** — so following the doc would build/probe with the *wrong, old* version. Bumped all command refs to 3.11.2; kept the historical "evaluated at 3.10.0" note with a current-pin callout. (Drift had sat unnoticed since the 2026-06-08 bump.)

## Verification
- `check_docs --strict` ✓ · live CodeGraph MCP tools verified working · ledger reconciled (#735). Docs-only.

https://claude.ai/code/session_016RkBwxihX7dcwdU7AoN7kD

---
_Generated by [Claude Code](https://claude.ai/code/session_016RkBwxihX7dcwdU7AoN7kD)_