### PR TITLE
workflow: reconciliation + planning pass at every 10th PR (Q-0107)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -180,6 +180,17 @@ is **per-file**. Full convention: `docs/owner/ai-project-workflow.md` §9.
   This is the automated-plus-judgment complement to the Q-0102 review; it exists because this
   exact question, asked once (2026-06-12), surfaced multiple drifted ledger entries. The
   `/session-close` skill runs the automated half.
+- **Reconciliation + planning pass at every 10th PR — required (owner directive Q-0107,
+  2026-06-12).** PR numbers crossing a **multiple of 10** (#10, #20, #30, …) are reserved for a
+  **docs-only review + planning** pass — no runtime / `disbot/` code in it. It does two things:
+  **(1) reconcile** — review the living ledger, active lanes, open Q-blocks, idea backlog, and
+  roadmap; prune/archive stale docs; restate the current priorities; and **(2) plan the next ~9
+  PRs** — what is realistically achievable in the upcoming decade of PRs, **modular but not
+  over-segmented**: each planned PR should ship a *reasonable, meaningful change* (a real slice),
+  **not** a trivial fragment — a small PR is fine only when the change genuinely is small or a
+  required one-off. `scripts/check_reconciliation_due.py` flags when a pass is due (against the
+  `Last reconciliation pass:** PR #N` marker in `current-state.md`; surfaced by `/session-close`);
+  reset the marker to the latest PR after the pass.
 - Plans span **2–3 PRs max**: the first PR covers root causes / foundation; subsequent PRs implement on top.
 - **Plan approval = full execution** — once a plan is approved (via **ExitPlanMode**),
   complete it in one session without stopping for confirmation or waiting for merges

--- a/.claude/skills/session-close/SKILL.md
+++ b/.claude/skills/session-close/SKILL.md
@@ -91,8 +91,14 @@ Run these in order and fix any failures before proceeding:
 python3.10 scripts/check_docs.py --strict
 python3.10 scripts/check_session_log.py --strict      # Q-0089 idea + Q-0102 review present
 python3.10 scripts/check_current_state_ledger.py --strict  # merged PRs are in the ledger
+python3.10 scripts/check_reconciliation_due.py        # Q-0107: is a 10th-PR docs/planning pass due?
 python3.10 scripts/check_quality.py --check-only
 ```
+
+If `check_reconciliation_due` reports **DUE**, the next session should be a docs-only review +
+planning-reconciliation pass (Q-0107: reconcile repo state + plan the next ~9 PRs, modular but
+not over-segmented); after that pass, reset the `Last reconciliation pass:** PR #N` marker in
+`current-state.md` to the latest PR.
 
 If `check_docs` fails on the new session log file: add the required `> **Status:**` badge.
 Session logs use the `audit` badge token. If `check_session_log` fails, add the missing

--- a/.sessions/2026-06-12-reconciliation-cadence-rule.md
+++ b/.sessions/2026-06-12-reconciliation-cadence-rule.md
@@ -1,0 +1,53 @@
+# 2026-06-12 — Reconciliation + planning cadence at every 10th PR (Q-0107)
+
+> **Status:** `audit`
+
+**PR:** opened this batch (Q-0107 cadence rule)
+**Branch:** `claude/reconciliation-cadence-rule`
+
+## Context
+
+Owner directive (voice), final rule of the session: every 10th PR (#10, #20, #30, … — multiples
+of 10) should be a **docs-only review + planning** pass that reviews repo state and refocuses;
+and **every planning pass focuses on what the next ~9 PRs can realistically achieve — modular but
+not over-segmented; each PR ships a reasonable change unless it really is a small required one.**
+
+## What was done
+
+- **Q-0107 (binding cadence rule).** `.claude/CLAUDE.md` § Session & plan workflow: PRs crossing a
+  multiple of 10 are a docs-only pass that **(1) reconciles** (ledger, lanes, Q-blocks, ideas,
+  roadmap; prune stale; restate priorities) and **(2) plans the next ~9 PRs** (realistic, modular,
+  not over-segmented; reasonable change per PR). Router Q-0107.
+- **`scripts/check_reconciliation_due.py`** (+ 9 tests): cadence guard — flags when merged PRs have
+  crossed into a new multiple-of-10 band since the `Last reconciliation pass:** PR #N` marker in
+  `current-state.md`. Advisory; `--strict` for the gate. Carries the Q-0105 kill-switch header.
+  Wired into `/session-close`.
+- **Marker set** in `current-state.md` (`Last reconciliation pass: PR #737`; next due at #740).
+  Reconciled #737 into the ledger.
+
+## Verification
+
+- `check_docs --strict` ✓ · `check_session_log --strict` ✓ · `check_current_state_ledger --strict` ✓ ·
+  `check_reconciliation_due` = not due (#737/#740) ✓ · 9 cadence tests pass. Docs/config only.
+
+## ⟲ Previous-session review (Q-0102 — reviewing the #737 Context7 batch)
+
+- **What it did well:** verified the npm version before pinning, wired Context7 cleanly (keyless,
+  documented key setup), recorded the decision and provenance.
+- **What it could have done better:** zoom out — this *whole conversation* shipped ~8 PRs, most of
+  them small workflow tweaks landed one-at-a-time. That is precisely the over-segmentation Q-0107's
+  "modular but not too segmented" guards against; a single up-front planning pass would have batched
+  several (e.g. all the session-ender rules in one PR). The cadence rule is the system learning from
+  its own session.
+- **System improvement surfaced:** surface the cadence guard at **session start**, not just close —
+  so a session knows *before* doing feature work whether it should be the planning pass. → 💡 below.
+
+## 💡 Session idea
+
+**Idea:** Surface `check_reconciliation_due` in the **SessionStart banner** (not only
+`/session-close`), so a session learns at boot that it's the designated 10th-PR planning pass and
+*becomes* one, instead of discovering it at close after already doing feature work.
+**Why:** the cadence rule only helps if a session knows early. The boot hook already prints repo
+state; one extra advisory line ("⚠ reconciliation/planning pass due — make this a docs-only Q-0107
+pass") routes the session correctly from turn one. Cheap (the check is fast, advisory), and it
+closes the loop between the guard and the behavior it's meant to trigger. _Small — recorded here._

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -49,7 +49,15 @@ Source code and merged PRs win over anything written here.
 > Convention: **merged PRs only** (with #numbers). In-flight work is *not* listed here —
 > get it from live GitHub. The newest merge a session sees may not be added yet; that
 > lag is expected (the next session reconciles). A merged PR tagged "pending" is the bug.
+>
+> **Last reconciliation pass:** PR #737 (2026-06-12). The next **docs-only review + planning
+> reconciliation** is due once merged PRs cross #740 (every multiple of 10 — Q-0107;
+> `scripts/check_reconciliation_due.py` flags it). Reset this marker to the latest PR after a pass.
 
+- **#737 (2026-06-12, Context7 MCP adopted)** — wired `@upstash/context7-mcp@3.2.0` (live
+  library docs → kills the "API-from-memory" bug class) as a pinned `.mcp.json` server +
+  [`docs/operations/mcp-servers.md`](operations/mcp-servers.md) (when-to-use, key setup, Q-0105
+  provenance). Q-0096 answered (Context7 yes; Postgres-MCP/pyright-lsp still open).
 - **#736 (2026-06-12, CodeGraph health check + doc pin fix)** — verified CodeGraph 3.11.2 is
   healthy (no regression from the bump; the "problems" are the cold-start availability blip + the
   documented false positives). Fixed the real bug: `docs/codegraph-usage.md` told agents to run the

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -4166,3 +4166,31 @@ owner review keeps the agent's "constitution" under human control while still le
 system evolve. This is the governance counterpart to the Q-0102/Q-0104 self-audit loop.
 
 **Home:** `.claude/CLAUDE.md` Working agreement (binding) · this entry is provenance.
+
+### Q-0107 — Reconciliation + planning pass at every 10th PR (docs-only)
+
+> **DIRECTED 2026-06-12 (owner, voice).** "After every 10 PRs there should be a docs-only
+> cleanup and plan reconciliation that reviews the state of the repo and refocuses our
+> attention." Refined: "every 10, 20, 30 etc should be docs-only reviewing and planning," and
+> "every planning session should focus on what the next 9 PRs can realistically achieve —
+> modular but not too segmented; each PR should ship a reasonable change unless it really is
+> only a small required change."
+
+**Area:** Agent system · workflow / planning cadence
+**Type:** Standing workflow rule (process)
+**Priority:** Standing — every 10th PR
+
+**Directive:**
+- PR numbers crossing a **multiple of 10** (#10, #20, #30, …) are a **docs-only review +
+  planning** pass — no runtime / `disbot/` code.
+- **Reconcile:** review the ledger, active lanes, open Q-blocks, idea backlog, roadmap; prune
+  stale docs; restate current priorities.
+- **Plan the next ~9 PRs:** what is realistically achievable in the upcoming decade of PRs,
+  **modular but not over-segmented** — each planned PR ships a *reasonable, meaningful* change,
+  not a trivial fragment (small PRs only when the change genuinely is small/required).
+- **Cadence guard:** `scripts/check_reconciliation_due.py` tracks the `Last reconciliation
+  pass:** PR #N` marker in `current-state.md` and flags when a pass is due; reset the marker
+  after a pass. Surfaced by `/session-close`.
+
+**Home:** `.claude/CLAUDE.md` § "Session & plan workflow" (binding) · `current-state.md` holds
+the marker · this entry is provenance.

--- a/scripts/check_reconciliation_due.py
+++ b/scripts/check_reconciliation_due.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3.10
+"""Reconciliation-cadence guard — flag when a docs-only review/planning pass is due.
+
+Owner directive Q-0107: PR numbers crossing a **multiple of 10** (#10, #20, #30, …) are
+reserved for a **docs-only repo review + planning-reconciliation** pass — review the state
+of the repo (ledger, active lanes, open Q-blocks, idea backlog, roadmap), prune stale docs,
+and refocus the next priorities. This guard tracks the cadence against the
+``Last reconciliation pass:** PR #N`` marker in ``docs/current-state.md``: a pass is **due**
+once merged PRs have crossed into a new multiple-of-10 band since the last marked pass.
+
+Advisory by default (exit 0); ``--strict`` for an explicit gate (e.g. ``/session-close``).
+After completing a pass, reset the marker to the latest PR. Pure stdlib, like ``check_docs.py``.
+
+Reliability (Q-0105, added 2026-06-12): **unverified** — if the cadence misfires (PR-number
+gaps from other repos' activity, a wrong marker) over multiple sessions, **delete it**; it is
+a convenience nudge for the Q-0107 cadence, not load-bearing.
+
+Usage:
+    python3.10 scripts/check_reconciliation_due.py            # advisory (exit 0)
+    python3.10 scripts/check_reconciliation_due.py --strict   # exit 1 if a pass is due
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CURRENT_STATE = REPO_ROOT / "docs" / "current-state.md"
+
+STEP = 10  # the cadence: a pass per multiple-of-10 PR band
+
+_MARKER_RE = re.compile(r"Last reconciliation pass:\*\*\s*PR #(\d+)")
+_MERGE_SUBJECT_RE = re.compile(r"(?:pull request #|\(#)(\d+)")
+
+
+def _latest_merged_pr() -> int | None:
+    """Highest merged PR number from recent origin/main history."""
+    try:
+        result = subprocess.run(
+            ["git", "log", "origin/main", "--pretty=format:%s", "-n", "60"],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    numbers = [
+        int(m.group(1))
+        for line in result.stdout.splitlines()
+        if (m := _MERGE_SUBJECT_RE.search(line))
+    ]
+    return max(numbers) if numbers else None
+
+
+def _last_reconcile_pr() -> int | None:
+    """The PR number recorded in the current-state.md reconciliation marker."""
+    try:
+        text = CURRENT_STATE.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    match = _MARKER_RE.search(text)
+    return int(match.group(1)) if match else None
+
+
+def is_due(
+    latest: int | None = None,
+    marker: int | None = None,
+) -> tuple[bool, int | None, int | None]:
+    """Return (due, latest_pr, marker_pr). Due once we cross a new multiple-of-10 band."""
+    if latest is None:
+        latest = _latest_merged_pr()
+    if marker is None:
+        marker = _last_reconcile_pr()
+    if latest is None or marker is None:
+        return (False, latest, marker)
+    return (latest // STEP > marker // STEP, latest, marker)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="reconciliation-cadence guard (Q-0107).",
+    )
+    parser.add_argument("--strict", action="store_true", help="exit 1 if a pass is due")
+    args = parser.parse_args(argv)
+
+    due, latest, marker = is_due()
+    if marker is None:
+        print(
+            "check_reconciliation_due: no `Last reconciliation pass:** PR #N` marker in "
+            "current-state.md — add one to start the Q-0107 cadence.",
+        )
+        return 0
+    next_band = (marker // STEP + 1) * STEP
+    if due:
+        print(
+            f"check_reconciliation_due: DUE — merged PRs crossed #{next_band} "
+            f"(last pass #{marker}, latest #{latest}). The next session should be a "
+            "docs-only repo review + planning reconciliation; reset the marker after.",
+        )
+        return 1 if args.strict else 0
+    print(
+        f"check_reconciliation_due: not due (last pass #{marker}, latest #{latest}; "
+        f"next pass at #{next_band}).",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_reconciliation_due.py
+++ b/tests/unit/scripts/test_check_reconciliation_due.py
@@ -1,0 +1,70 @@
+"""Tests for ``scripts/check_reconciliation_due.py`` — the Q-0107 cadence guard."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_MOD = REPO_ROOT / "scripts" / "check_reconciliation_due.py"
+
+_spec = importlib.util.spec_from_file_location("check_reconciliation_due", _MOD)
+assert _spec and _spec.loader
+crd = importlib.util.module_from_spec(_spec)
+sys.modules["check_reconciliation_due"] = crd
+_spec.loader.exec_module(crd)
+
+
+def test_not_due_same_band() -> None:
+    # marker #737 (band 73), latest #739 (band 73) → not due
+    due, latest, marker = crd.is_due(latest=739, marker=737)
+    assert due is False
+    assert (latest, marker) == (739, 737)
+
+
+def test_due_when_crossing_multiple_of_ten() -> None:
+    # marker #737 (band 73), latest #740 (band 74) → due
+    due, _, _ = crd.is_due(latest=740, marker=737)
+    assert due is True
+
+
+def test_due_when_crossing_multiple_bands() -> None:
+    due, _, _ = crd.is_due(latest=752, marker=737)
+    assert due is True
+
+
+def test_exactly_on_band_boundary_marker() -> None:
+    # last pass landed on #740 (band 74); latest #749 still band 74 → not due
+    assert crd.is_due(latest=749, marker=740)[0] is False
+    # latest #750 → new band → due
+    assert crd.is_due(latest=750, marker=740)[0] is True
+
+
+def test_no_marker_is_not_due(monkeypatch) -> None:
+    # No marker found in current-state → never due (can't compute a cadence).
+    monkeypatch.setattr(crd, "_last_reconcile_pr", lambda: None)
+    monkeypatch.setattr(crd, "_latest_merged_pr", lambda: 740)
+    assert crd.is_due()[0] is False
+
+
+def test_no_latest_is_not_due(monkeypatch) -> None:
+    monkeypatch.setattr(crd, "_latest_merged_pr", lambda: None)
+    monkeypatch.setattr(crd, "_last_reconcile_pr", lambda: 737)
+    assert crd.is_due()[0] is False
+
+
+def test_strict_exit_when_due(monkeypatch) -> None:
+    monkeypatch.setattr(crd, "is_due", lambda: (True, 740, 737))
+    assert crd.main(["--strict"]) == 1
+    assert crd.main([]) == 0  # advisory default never fails
+
+
+def test_strict_exit_when_not_due(monkeypatch) -> None:
+    monkeypatch.setattr(crd, "is_due", lambda: (False, 739, 737))
+    assert crd.main(["--strict"]) == 0
+
+
+def test_no_marker_main_exits_zero(monkeypatch) -> None:
+    monkeypatch.setattr(crd, "is_due", lambda: (False, 740, None))
+    assert crd.main(["--strict"]) == 0


### PR DESCRIPTION
## What & why

Owner directive (the session's final rule): **every 10th PR** (PR numbers crossing a multiple of 10 — #10, #20, #30, …) is reserved for a **docs-only review + planning** pass that reviews repo state, refocuses priorities, **and plans the next ~9 PRs** — modular but not over-segmented, each PR shipping a reasonable change unless it's genuinely a small required one.

## Changes
- **`.claude/CLAUDE.md`** § Session & plan workflow — the Q-0107 rule (reconcile + plan-next-9 + the modular-not-over-segmented PR-sizing principle).
- **`docs/owner/maintainer-question-router.md`** — Q-0107 provenance entry.
- **`scripts/check_reconciliation_due.py`** (+ 9 tests) — the cadence guard: flags when merged PRs have crossed into a new multiple-of-10 band since the `Last reconciliation pass:** PR #N` marker in `current-state.md`. Advisory by default, `--strict` for the gate, carries the Q-0105 delete-if-unreliable header. Wired into `/session-close`.
- **`docs/current-state.md`** — set the marker (`#737`; next pass due at #740) and reconciled #737 into the ledger.

## Verification
- `check_docs --strict` ✓ · `check_session_log --strict` ✓ · `check_current_state_ledger --strict` ✓ · `check_reconciliation_due` = not due (#737 → #740) ✓ · 27 script tests pass. Docs/config only.

## Note
The session log's Q-0102 review is pointed: this whole conversation shipped ~8 small workflow PRs one-at-a-time — exactly the over-segmentation this rule guards against. The cadence is the system learning from its own session.

https://claude.ai/code/session_016RkBwxihX7dcwdU7AoN7kD

---
_Generated by [Claude Code](https://claude.ai/code/session_016RkBwxihX7dcwdU7AoN7kD)_