### PR TITLE
docs: capture owner research — safety/automod, community features, Discord limits

### DIFF
--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -18,6 +18,25 @@ Pure brainstorm backlogs — capture without commitment. Each file should carry 
 
 Current broad captures:
 
+- [`server-safety-and-automod-2026-06-12.md`](./server-safety-and-automod-2026-06-12.md) —
+  **owner-uploaded research (2026-06-12):** four moderation-safety modules SuperBot
+  lacks vs. competitors (Carl-bot, Dyno, YAGPDB, Koya, Double Counter):
+  **automod rules engine** (spam/link/caps/mention filtering with per-rule escalation) ·
+  **server logging service** (message edits/deletes, join/leave, role changes) ·
+  **image moderation** (OpenAI omni-moderation free endpoint vs. API4AI vs. Hive 50+
+  categories) · **security service** (raid detection, account-age filter, alt detection,
+  VPN blocking — tiered by privacy risk). Larger decisions pending Q-0108, Q-0109,
+  Q-0111.
+- [`community-platform-features-2026-06-12.md`](./community-platform-features-2026-06-12.md) —
+  **owner-uploaded research (2026-06-12):** five community-management features from
+  ProBot, Koya, YAGPDB, Sesh, and Statbot:
+  **welcome service** (PIL avatar-composited welcome cards, join DM, auto-role, goodbye) ·
+  **social feed notifications** (YouTube-first per Q-0041, then Twitch/RSS/Reddit, with
+  optional LLM video summarization) ·
+  **event scheduler** (simple RSVP tier first; NL parsing gated on AI cost) ·
+  **custom commands** (TagScript-safe, DB-stored, admin-only creation) ·
+  **dynamic server counters** (statdock channel-renaming, quick-win candidate).
+  Decisions pending Q-0110 (welcome images), Q-0112 (event scheduler scope).
 - [`repo-manageability-2026-06-12.md`](./repo-manageability-2026-06-12.md) —
   **owner-asked (2026-06-12):** "what else would make the repo more easily manageable?"
   after the review-map + readiness-map work. Five workflow-substrate ideas: operationalize

--- a/docs/ideas/community-platform-features-2026-06-12.md
+++ b/docs/ideas/community-platform-features-2026-06-12.md
@@ -1,0 +1,261 @@
+# Community platform features — welcome, feeds, events, counters (2026-06-12)
+
+> **Status:** `ideas` — distilled from research uploaded by the owner
+> (2026-06-12: competitor analysis covering ProBot, YAGPDB, Koya, Statbot, Sesh,
+> and a broad Discord bot landscape survey). Dedup-checked against `superbot-vision-2026-06-10.md`,
+> `owner-vision-ideas-2026-06-08.md`, `competitive-teardown-2026-06-10.md`,
+> `fun-and-ease-brainstorm-2026-06-09.md`, and the roadmap.
+> **Not a plan, not approval.** Route through `ideas/README.md` before touching code.
+
+## Context
+
+The uploaded research identifies a cluster of "community server management" features
+that popular bots (Carl-bot, Dyno, Koya, ProBot, Sesh, Statbot) provide and SuperBot
+currently does not. These differ from the game/economy RPG lane — they are server *staff*
+and *community engagement* tools, not player progression. The research classifies them
+all as "Important improvement" priority.
+
+---
+
+## 1. Welcome service with customizable images
+
+### What competitors do
+
+ProBot and Koya generate customized welcome cards on member join: the user's avatar is
+composited onto a template background with their username, discriminator, and server
+member count. These are sent to a configurable `#welcome` channel. Koya also supports
+join DMs (private greeting to the new member), auto-roles on join (role assigned
+immediately, before the member takes any action), and goodbye messages on leave.
+
+### SuperBot gap
+
+SuperBot handles no join/leave events beyond guild_lifecycle.py. There is no welcome
+message, no welcome image, and no join auto-role distinct from the time/XP-based
+role-automation already in the role hub.
+
+### Proposed design
+
+A `services/welcome_service.py` that:
+
+- Listens for `on_member_join` and `on_member_remove`.
+- Sends a configurable welcome embed (or PIL-generated image card) to a designated
+  `#welcome` channel.
+- Optionally sends a join DM to the new member.
+- Assigns a configurable "entry role" on join (distinct from XP/time roles — instant).
+- Sends a goodbye message on member remove.
+- Config lives in the setup wizard (welcome section) and a settings panel.
+
+### PIL image card specifics
+
+The uploaded research confirms the PIL approach is feasible within Discord's bot constraints:
+- Bot upload limit is **~8 MiB per file** (see `docs/operations/discord-platform-limits.md`).
+- A 1920×1080 JPEG at medium compression is typically under 1 MB — well within limits.
+- Avatar + background + text = straightforward Pillow composite.
+- Export as JPEG or WebP, never raw PNG (too large for high-res cards).
+- Include an `alt_text` description for accessibility (Discord supports alt-text on attachments).
+
+### Sizing and risk
+
+Medium. The PIL template system is the most novel part; the event subscription and
+config UI are straightforward. Risk: avatar-fetch latency (download the avatar URL on
+join; handle network failures gracefully with a fallback text-only embed).
+
+### Route
+
+→ **Q-0110** (discuss: does the maintainer want image cards on day one, or start with
+embed-only welcome and add PIL cards later?). Then: plan.
+
+---
+
+## 2. Social feed notifications (YouTube, Twitch, RSS, Reddit)
+
+### What competitors do
+
+YAGPDB supports fast Reddit, YouTube, and RSS feeds. Koya extends this to YouTube,
+Twitch, Kick, RSS, Reddit, Spotify, and Bluesky — with custom messages, role pings,
+content filters, and per-source channels. Carl-bot also provides YouTube and Twitch
+notifications.
+
+### SuperBot overlap and gap
+
+The owner already confirmed (Q-0041) a **YouTube-first / dual-opt-in / voice-deferred**
+posture. A YouTube notification service (new-video alert in a configured channel) is
+approved in principle. The owner vision mentions Twitch and Spotify.
+
+What the research adds is the service design: a unified feed-subscription model where
+each guild can subscribe to N external sources (YouTube channel ID, Twitch username,
+RSS URL, subreddit) and map each source to a Discord channel and an optional role ping.
+
+### Proposed design
+
+A `services/feed_service.py` (or `notification_service.py`) with a polling scheduler:
+
+- Stores per-guild subscriptions: `(source_type, source_id, discord_channel_id, role_id)`.
+- Scheduler runs at configurable intervals per source type (YouTube: every 10 min via
+  YouTube Data API; Twitch: on-live webhook or polling; RSS: every 15 min).
+- On new content detected: posts an embed with title, thumbnail, URL, and optional role
+  mention to the configured channel.
+- Per-source filters: exclude certain keywords from titles (e.g., skip a channel's
+  "shorts" by keyword).
+- Config panel in the setup wizard and a feeds-management hub.
+
+### YouTube summarization extension
+
+The uploaded research also covers YouTube video summarization: fetch the transcript via
+the YouTube Data API, send it to an LLM (OpenAI/Claude/Gemini), and return a structured
+summary to Discord. This pairs naturally with the feed service — when a new video alert
+fires, optionally include an AI-generated summary. Constraints:
+- Not all videos have transcripts; auto-generated transcripts may be inaccurate.
+- Long transcripts may exceed LLM context windows → chunk + summarize iteratively.
+- Adds API cost per video (Q-0082's hard ceiling applies).
+- The owner confirmed YouTube-first; this is the enrichment layer on top.
+
+### Sizing and risk
+
+Large scope across all source types; manageable if shipped incrementally (YouTube first,
+then RSS, then Twitch). Risk: YouTube Data API quota exhaustion; Twitch webhook setup
+complexity. Cost: YouTube summarization adds LLM calls → meter under Q-0082 spend cap.
+
+### Route
+
+→ **Roadmap Later** (Q-0041 approves the direction; no new owner Q needed for YouTube
+start). Build plan needed before implementation.
+
+---
+
+## 3. Event scheduler
+
+### What Sesh does
+
+Sesh provides natural-language event creation ("next Friday 8pm" → parsed datetime),
+RSVP collection (yes/no/maybe), attendance limits with waitlists, automatic time-zone
+conversion per user, availability polls (multiple-time voting), role assignment for
+attendees, and Google Calendar export.
+
+### SuperBot gap
+
+No in-Discord event scheduling exists. The owner mentioned timers and polls as part of
+the "General commands" section of the ideal help menu.
+
+### Proposed design
+
+A `services/event_service.py` with:
+
+- **Simple tier (no NL):** slash command `/event create` with structured date/time
+  input (Discord's built-in datetime picker) + title + description + optional
+  attendee limit. Posts a formatted event embed with RSVP buttons (✅ Yes / ❓ Maybe / ❌ No).
+- **Reminder tier:** reminder message sent to RSVP'd members N minutes before the event.
+- **NL tier (later, gated):** natural-language time parsing via an LLM call → adds AI cost;
+  gate on Q-0082 spend ceiling and the maintainer's approval.
+- **Availability poll:** an embed listing multiple time slots; members vote; the bot
+  highlights the winning slot.
+- Time zones: store each user's preferred timezone (extends per-user preferences from
+  superbot-vision V-04); display event times in each user's local zone.
+
+### Sizing and risk
+
+Simple tier is small (embed + buttons + reminder scheduler). NL tier adds LLM cost.
+Risk: reminders require a persistent scheduler — the bot already has scheduler
+infrastructure (check `disbot/` for existing scheduler patterns before designing).
+
+### Route
+
+→ **Q-0112** (discuss: simple tier approved standalone vs. needs the NL tier to be
+worthwhile? Any existing scheduler to reuse?). Then: plan.
+
+---
+
+## 4. Custom commands (TagScript-safe)
+
+### What competitors do
+
+Carl-bot, Dyno, and YAGPDB let server operators create custom commands stored in the
+DB: a trigger (prefix, exact, contains, or regex match) maps to a templated response.
+YAGPDB uses a full TagScript interpreter; Carl-bot uses a simpler variable-substitution
+syntax. Both sandbox execution so operators can't run arbitrary code.
+
+### SuperBot gap
+
+All commands are hardcoded in Python cogs. Server operators can't create their own
+without a code deployment.
+
+### Proposed design
+
+A `services/custom_command_service.py` with:
+
+- DB table: `(guild_id, trigger, match_type, response_template, created_by, created_at)`.
+- Match types: prefix, exact, contains, regex (regex tier: admin-only, size-limited).
+- Template variables: `{user}`, `{server}`, `{channel}`, `{args}` — no code execution.
+- Management panel: add/edit/delete custom commands, with a live-preview before save.
+- Governance: operator or admin role required to create/modify; member-accessible to invoke.
+- Sandboxing: response templates are evaluated with a strict whitelist renderer —
+  no `exec()`, no imports, no external calls.
+- `on_message` handler checks custom commands after built-in command prefix handling
+  (lowest priority, so built-in commands always win).
+
+### Sizing and risk
+
+Medium. The DB schema and CRUD panel are straightforward; the sandboxed template
+evaluator needs careful implementation (no escape into Python runtime).
+Risk: abuse — require admin/operator role to create; log every command creation via
+the audit service.
+
+### Route
+
+→ **Roadmap Someday** (no new Q needed; direction is clear but scope is large and
+lower-priority than the other items in this file). Groom to Later once the core
+moderation/logging layer lands.
+
+---
+
+## 5. Dynamic server counters (Statbot / ServerStats style)
+
+### What competitors do
+
+ServerStats and Statbot provide "statdocks": voice channels whose names are
+continuously updated to show live server statistics — member count, online member
+count, bot count, server boost level, current date, custom goals.
+
+### SuperBot gap
+
+No such feature exists. The info is available via Discord's API; it just needs a
+scheduled task to rename the channels.
+
+### Proposed design
+
+A `services/counter_service.py`:
+
+- Per-guild config: list of `(voice_channel_id, counter_type, display_format)` rows.
+- Counter types: total members, online members, bot count, human count, boosts,
+  a custom number (set by admin).
+- Scheduled task: runs every 10 minutes (Discord rate-limits channel renames to 2/10 min
+  per channel, so multiple counters need multiple channels).
+- Setup: a counter wizard sub-panel where the admin creates a dedicated voice channel
+  (bot auto-names it on creation) per counter type.
+
+### Sizing and risk
+
+Small. Mostly a scheduler task + config panel. Risk: rate limiting (respect Discord's
+channel-rename rate limit; log throttle hits). The voice channel is "locked" (no
+join permission for members) — standard pattern for counter bots.
+
+### Route
+
+→ **Roadmap Next/Later** (quick-win candidate; small scope; no new Q needed).
+Groom into an executable slice once automod or logging is underway.
+
+---
+
+## Routing summary
+
+| Idea | Size | Risk | Router Q | Next destination |
+|---|---|---|---|---|
+| Welcome service (embed only) | Small | Low | — | Roadmap Next |
+| Welcome service (PIL image cards) | Medium | Low | Q-0110 | Discuss → plan |
+| Social feed notifications (YouTube) | Medium | Low–medium (API quota) | — | Roadmap Later (Q-0041 approved) |
+| Social feed notifications (other sources) | Large | Medium | — | Roadmap Someday |
+| YouTube video summarization | Medium | Medium (AI cost) | — | Roadmap Later |
+| Event scheduler (simple tier) | Small | Low | Q-0112 | Discuss → plan |
+| Event scheduler (NL tier) | Medium | Medium (AI cost) | Q-0112 | Discuss |
+| Custom commands | Medium | Medium (sandboxing) | — | Roadmap Someday |
+| Dynamic server counters | Small | Low | — | Roadmap Next (quick-win) |

--- a/docs/ideas/server-safety-and-automod-2026-06-12.md
+++ b/docs/ideas/server-safety-and-automod-2026-06-12.md
@@ -1,0 +1,225 @@
+# Server safety, automod, logging, and image moderation (2026-06-12)
+
+> **Status:** `ideas` — distilled from research uploaded by the owner
+> (2026-06-12: competitor analysis + Discord/AI integration reference docs).
+> Dedup-checked against `competitive-teardown-2026-06-10.md`, `gap-analysis-2026-06-11.md`,
+> `fun-and-ease-brainstorm-2026-06-09.md`, and the roadmap. **Not a plan, not approval.**
+> Route through `ideas/README.md` before touching any code.
+
+## Context
+
+Competitor bots (Carl-bot, Dyno, Arcane, YAGPDB, Koya, Double Counter) give server staff
+four safety layers SuperBot currently lacks:
+1. **Proactive automod** — automated message filtering before moderation is needed.
+2. **Comprehensive event logging** — full audit trail of server activity visible to staff.
+3. **AI-driven image moderation** — scanning uploaded images for NSFW/violent content.
+4. **Account security** — detecting alt accounts, raids, and anonymizing proxies on join.
+
+SuperBot's moderation service (warnings, timeouts, kicks, bans, escalation ladders) is
+the *manual* layer; these four are the *automated* layer below it. All four should route
+through the existing `moderation_service` for actions, emit audit events, and be
+configurable per guild.
+
+---
+
+## 1. Automod rules engine
+
+### What competitors do
+
+Carl-bot and Dyno filter spam, scam/invite links, mass mentions, attachment floods, and
+excessive emoji/caps, with per-rule actions (warn/timeout/kick) and escalation. YAGPDB
+lets admins write rule triggers (starts-with, contains, exact, regex) with configurable
+violator counts before an action fires. Koya's automod adds attachment and poll filters
+plus scam-URL detection.
+
+### SuperBot gap
+
+SuperBot has no `on_message` filter layer. Staff must notice and react manually; the
+moderation service only records after the fact.
+
+### Proposed design
+
+A `services/automod_service.py` that:
+
+- Listens for `on_message` via the event bus.
+- Evaluates a per-guild rule set stored in the DB (one row per rule: type, threshold,
+  action, channels/roles excluded).
+- Rule types (starting minimal): **spam** (N messages in T seconds) · **invite links**
+  (discord.gg/ pattern) · **mass mentions** (≥N @mentions in one message) · **excessive
+  caps** (>X% uppercase) · **blacklisted words** (configurable per guild).
+- Actions: delete message → call `moderation_service.warn()` with escalation intact.
+- Config UI: a dedicated automod panel in the moderation hub or setup wizard.
+
+### Sizing and risk
+
+Medium scope. The service itself is small; the config UI and the per-guild rule store
+are the bulk. Risk: false positives (overblocking legit messages) — needs an
+"exempt roles" and "exempt channels" safety valve from day one. Privacy: only message
+text is evaluated server-side, no external calls.
+
+### Current overlap
+
+The competitive teardown (open-source lane #15) lists "Trigger→response expressions
+(Nadeko/ReTrigger)" as a fit-4 candidate; that is the *response* half. This is the
+*filtering* half — different enough to warrant a separate concept. Automod is also
+mentioned in the uploaded competitor analysis as an "Important improvement."
+
+### Route
+
+→ **Q-0108** (discuss: which rule types to start with; actions policy) once the
+maintainer has seen this file. Then: structured plan in `docs/planning/`.
+
+---
+
+## 2. Server logging service
+
+### What competitors do
+
+Carl-bot logs deleted messages, edited messages, role changes, bans, kicks, and invite
+usage to a dedicated `#mod-log` channel. Arcane adds voice-channel joins/leaves and
+member join/leave events. All allow configuring which event types go to which channel.
+
+### SuperBot gap
+
+SuperBot logs moderation *actions* (via `emit_audit_action`) to the audit system, but
+there is no passive event log for:
+- Message edits and deletions (staff can't review what was said).
+- Member join/leave events (onboarding diagnostics, ban-evader detection).
+- Role grants and revocations not made by the bot itself.
+- Voice channel activity.
+
+### Proposed design
+
+A `services/server_logging_service.py` that:
+
+- Subscribes to Discord events: `on_message_delete`, `on_message_edit`,
+  `on_member_join`, `on_member_remove`, `on_member_update` (role changes),
+  `on_voice_state_update`.
+- Formats and posts to a configurable `#server-log` channel per event type.
+- Per-guild config: enable/disable per event category, separate channel per category.
+- Respects the existing audit service — does not duplicate moderation action logs.
+- Config exposed in the setup wizard and a settings panel.
+
+### Sizing and risk
+
+Small-medium. Mostly event handlers + embed formatting. Risk: high volume in large
+servers (paginate or rate-limit log posts). Sensitive: deleted-message logging can
+feel invasive — document clearly in setup that staff can see deleted messages.
+
+### Route
+
+→ **Q-0109** (discuss: scope of events, channel-per-type vs. single channel, privacy
+note in setup wizard). Then: plan.
+
+---
+
+## 3. Image moderation service
+
+### What the research established
+
+Three viable approaches, ordered by cost:
+
+| Provider | Cost | Coverage | Bot limit |
+|---|---|---|---|
+| **OpenAI omni-moderation-latest** | Free | Sexual, harassment, violence, hate, self-harm | 20 MB per image |
+| **API4AI NSFW Recognition** | Affordable paid tiers | SFW vs. NSFW + confidence score | REST API |
+| **Hive Moderation** | Higher cost, no free tier | 50+ categories (nudity, violence, drugs, weapons, hate symbols) | REST API |
+
+OpenAI's moderation endpoint accepts both text and images, returns category scores,
+and is free. This makes it a natural first-pass filter before any other service.
+Hive is enterprise-grade and the only one covering hate symbols + weapons — likely
+overkill for most community servers.
+
+### SuperBot gap
+
+No image-scanning layer exists. Users can post any image; the bot has no automated
+gate before it reaches the channel.
+
+### Proposed design
+
+A `services/image_moderation_service.py` that:
+
+- Intercepts `on_message` if the message has image attachments.
+- Downloads the image (up to the bot's 8 MiB per-attachment limit — see the
+  `docs/operations/discord-platform-limits.md` reference).
+- Sends to the chosen moderation provider asynchronously (OpenAI by default, since free).
+- If a category score exceeds a configurable threshold: delete the message, issue a
+  warn via `moderation_service`, emit an audit event, and optionally notify the user.
+- Per-guild config: enable/disable, which provider, per-category thresholds.
+- Requires: `message_content` intent (already enabled), manage-messages permission.
+
+### Privacy and data
+
+Images are sent to a third-party API. The setup wizard must inform server operators
+that uploads may be analyzed externally; users must be informed via server rules
+or a terms channel. Hive and API4AI both require a key; OpenAI keys are already used
+in the AI cog.
+
+### Sizing and risk
+
+Medium. The async pipeline + configurable thresholds + UI are the main work.
+Key risk: false positives (innocent image flagged). Mitigation: confidence threshold
+≥0.80 before action; audit event lets staff review and dismiss.
+
+### Route
+
+→ **Q-0108** (combine with automod discussion: does the maintainer want image scanning?
+Which tier — free OpenAI-only vs. paid NSFW specialist?). Then: plan.
+
+---
+
+## 4. Security service — alt detection, raid prevention, VPN blocking
+
+### What Double Counter does
+
+Double Counter fingerprints device, browser, network, and behaviour signals to flag
+alternate accounts on join. It provides raid detection (pattern-recognition on mass
+joins), invisible captcha challenges, VPN/proxy/Tor blocking via IP reputation
+databases, and a real-time dashboard showing confidence scores and recommended actions
+per flagged user.
+
+### SuperBot gap
+
+No account-join screening. Raid events, alt-account evaders, and VPN-masked bans are
+handled only after manual discovery.
+
+### Proposed design
+
+A `services/security_service.py` with opt-in modules:
+
+- **Raid detection** — monitor join rate; if >N joins in T seconds, trigger a lockdown
+  (slowmode up, new-account joins paused) and alert staff. Fully self-contained, no
+  external API required.
+- **New-account filter** — reject or quarantine accounts younger than N days on join
+  (configurable threshold). Simple, zero privacy cost.
+- **Alt detection** — flag accounts that join with unusual shared patterns (IP range
+  overlaps require an external service; shared device fingerprinting needs a captcha
+  gateway). **High privacy impact** — requires explicit owner approval and user disclosure.
+- **VPN/proxy blocking** — integrate a third-party IP reputation DB on join. Privacy
+  cost: every join sends an IP query externally. Legitimate VPN users (privacy-conscious
+  members) would be affected.
+
+### Privacy and risk assessment
+
+The simple tiers (raid detection, account-age filter) are low-risk and self-contained.
+The advanced tiers (alt-detection, VPN blocking) have real privacy and legal implications:
+GDPR applicability depends on where users are based; the owner is EU-based. These must
+be explicitly opt-in for the server, disclosed in server rules, and gated on the
+maintainer's explicit sign-off.
+
+### Route
+
+→ **Q-0111** (discuss: which security tiers are wanted; privacy/legal comfort level;
+raid detection and account-age filter can be approved independently of the advanced tiers).
+
+---
+
+## Routing summary
+
+| Idea | Size | Risk | Router Q | Next destination |
+|---|---|---|---|---|
+| Automod rules engine | Medium | Low (false positives) | Q-0108 | Discuss → plan |
+| Server logging service | Small–medium | Low (privacy note) | Q-0109 | Discuss → plan |
+| Image moderation | Medium | Medium (third-party, privacy) | Q-0108 | Discuss → plan |
+| Security service (simple tiers) | Small | Low | Q-0111 | Discuss → plan |
+| Security service (advanced tiers) | Medium | High (privacy/legal) | Q-0111 | Discuss → decision |

--- a/docs/operations/discord-platform-limits.md
+++ b/docs/operations/discord-platform-limits.md
@@ -1,0 +1,140 @@
+# Discord platform limits — technical reference
+
+> **Status:** `reference` — distilled from official Discord documentation and community
+> testing, as surfaced in the owner-uploaded research (2026-06-12).
+> Read this before designing any Discord UI component, image-generation feature,
+> or attachment-handling pipeline. Source: Discord developer docs, the
+> discord.py library, and verified community testing (cited per fact below).
+> **These limits change without notice** — re-verify against the official Discord
+> Developer Portal before shipping anything that depends on specific numbers.
+
+---
+
+## 1. Message components (Buttons, Select menus, Action rows)
+
+| Limit | Value | Notes |
+|---|---|---|
+| Action rows per message | **5** | Whether using legacy or Components V2 |
+| Buttons per action row | **5** | Buttons only; select menus use the full row |
+| Select menus per action row | **1** | Each menu occupies an entire row |
+| Total components per message | **25** | Across all action rows |
+| Button label length | **80 characters** | |
+| Button custom\_id length | **100 characters** | Used for persistent-view routing |
+| String-select options | **2 – 25** | Min 2, max 25 options per menu |
+| Select option label length | **100 characters** | |
+| Select option value length | **100 characters** | |
+| Select option description length | **100 characters** | |
+| Select placeholder text | **150 characters** | |
+
+**Components V2** (requires the `IS_COMPONENTS_V2` flag on the message) allows the full
+25-component budget across containers, sections, and interactive elements. SuperBot's
+`PersistentView` and `HubView` base classes handle registration automatically — keep the
+total component count under 25 per message.
+
+**Pagination implication:** lists longer than 25 items (e.g., a full inventory, a large
+role list) require pagination or dynamic loading — a single select menu cannot show them
+all.
+
+---
+
+## 2. Embeds and message content
+
+| Limit | Value |
+|---|---|
+| Embeds per message | **10** |
+| Embed title | **256 characters** |
+| Embed description | **4 096 characters** |
+| Embed fields per embed | **25** |
+| Embed field name | **256 characters** |
+| Embed field value | **1 024 characters** |
+| Embed footer text | **2 048 characters** |
+| Embed author name | **256 characters** |
+| Embed image/thumbnail URL | **2 048 characters** |
+| Total text across all embeds (per message) | **6 000 characters** |
+| Message content (outside embeds) | **2 000 characters** (4 000 with Nitro) |
+
+**6 000-character total** is the binding limit when multiple embeds are present —
+titles + descriptions + all field names + all field values + footers + author names
+combined must not exceed it.
+
+---
+
+## 3. File attachments and image sizes
+
+| Limit | Value | Notes |
+|---|---|---|
+| Attachments per message | **10** | |
+| Max file size — free users | 10 MB | |
+| Max file size — Nitro Basic | 50 MB | |
+| Max file size — Nitro | 500 MB | |
+| Max file size — **bots and webhooks** | **~8 MiB** | The 25 MB user limit does NOT apply; bots receive `413 Payload Too Large` above ~8 MiB |
+| Combined attachment size (user API) | 25 MB | Not relevant to bots — use 8 MiB cap |
+| Image inline-preview area limit | ~90 million pixels | Community-tested; larger images require download |
+| Image inline-preview max dimension | ~64 000 px (either side) | Community-tested |
+
+**The 8 MiB bot limit is the binding constraint** for all image-generation features
+(PIL-generated cards, PIL inventory displays, gear paper-doll compositors, etc.).
+Use JPEG or WebP export at medium compression — a 1920×1080 JPEG at medium quality
+is typically under 1 MB, leaving ample headroom. Avoid raw PNG for large canvases.
+
+**Alt text:** Discord supports alt-text on image attachments. When generating images
+programmatically (PIL), supply a concise description string as alt-text metadata to
+improve accessibility.
+
+---
+
+## 4. PIL image generation — bot design guide
+
+Derived from the 8 MiB constraint and the standard Pillow workflow.
+
+- **Export format:** JPEG or WebP for photographic/composite images; PNG only for
+  pixel-art or images requiring transparency at small sizes.
+- **Compression:** `image.save(buf, format='JPEG', quality=85)` typically yields
+  <500 KB at 1920×1080. Tune `quality` downward if the image consistently exceeds
+  2–3 MB.
+- **Canvas sizing:** stay within 3000×3000 px for inline previews. Higher is rarely
+  needed and risks hitting the 90 Mp area limit.
+- **Font rendering:** Pillow's `ImageDraw.text()` with a TTF font — keep font files
+  in `disbot/assets/fonts/`; load once at module import and cache.
+- **Avatar compositing (welcome cards):** download the user's avatar URL, open it
+  with `Image.open(BytesIO(data))`, resize/crop to a circle with an alpha mask, paste
+  onto the template. Handle network failures with a fallback silhouette.
+- **Concurrency:** PIL operations are CPU-bound; run inside `asyncio.to_thread()` to
+  avoid blocking the event loop.
+- **Caching:** leaderboard and profile images that don't change frequently can be
+  cached in-memory (keyed by a hash of the data) to avoid redundant re-renders.
+
+---
+
+## 5. YouTube transcript and summarization constraints
+
+When implementing YouTube video summarization (the feed-service extension):
+
+| Constraint | Detail |
+|---|---|
+| Transcript availability | Not all videos have transcripts; auto-generated ones may be inaccurate |
+| Transcript access | YouTube Data API (requires API key) or third-party transcript APIs |
+| LLM context window | Long transcripts exceed a single context window → chunk and summarize iteratively |
+| API quotas | YouTube Data API has daily quota units; transcript requests count against them |
+| AI cost | Each summarization call = tokens → count under the Q-0082 spend ceiling |
+| Language | Auto-generated transcripts are often in the video's primary language; verify before sending to an LLM |
+
+**Recommended pipeline:** fetch transcript → split into ≤N-token chunks → summarize each
+chunk → merge summaries with a final consolidation call → post to Discord as an embed.
+The owner confirmed YouTube-first posture (Q-0041); implement and meter before expanding.
+
+---
+
+## 6. Image moderation — provider comparison
+
+For the proposed image moderation service (`docs/ideas/server-safety-and-automod-2026-06-12.md` §3):
+
+| Provider | Cost | Image size limit | Categories | Notes |
+|---|---|---|---|---|
+| OpenAI omni-moderation-latest | **Free** | 20 MB | Sexual, harassment, violence, hate, self-harm | Accepts text + images in the same request; returns per-category confidence scores |
+| API4AI NSFW Recognition | Affordable paid | Not published | SFW / NSFW (binary + confidence) | Demo endpoint available; production requires a token |
+| Hive Moderation | Higher cost, no free tier | Not published | **50+ categories** (nudity, violence, drugs, weapons, hate symbols, …) | Enterprise-grade; per-category threshold tuning; no self-hosted option |
+
+**Recommendation for SuperBot:** start with OpenAI (free, already integrated in the AI cog,
+20 MB covers the 8 MiB bot attachment limit). Gate Hive behind a premium-server option
+if a richer category set is wanted later.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -4194,3 +4194,141 @@ system evolve. This is the governance counterpart to the Q-0102/Q-0104 self-audi
 
 **Home:** `.claude/CLAUDE.md` § "Session & plan workflow" (binding) · `current-state.md` holds
 the marker · this entry is provenance.
+
+
+### Q-0108 — Automod rules engine + image moderation: wanted? Which scope to start?
+
+> **DISCUSS (2026-06-12).** Source: owner-uploaded competitor research (Carl-bot, Dyno,
+> YAGPDB, Koya analysis) + AI-integration reference. Two related questions, grouped
+> because they share the same `on_message` interception point and moderation service.
+
+**Area:** Moderation platform · automod + image moderation
+**Type:** Product direction + provider choice
+**Priority:** Medium — next major moderation gap vs. competitors
+
+**Questions:**
+
+1. **Automod rules engine** — is this wanted as a near-term priority? If yes, which rule
+   types should be in v1? (Suggested minimal set: spam bursts · discord.gg/ invite links ·
+   mass @mentions. Caps-filtering and blacklisted-words are the next tier.)
+2. **Image moderation** — is automated image scanning wanted at all? If yes:
+   - Free tier: **OpenAI omni-moderation-latest** (already integrated, free, 20 MB limit,
+     covers sexual/violence/harassment/hate) — sufficient to start.
+   - Paid tier: **API4AI NSFW** (binary SFW/NSFW, affordable) or **Hive Moderation**
+     (50+ categories including weapons/drugs/hate symbols, enterprise cost, no free tier).
+   - Recommendation: start OpenAI-only (zero incremental cost); gate paid providers behind
+     a per-guild opt-in configuration.
+
+**Detail:** `docs/ideas/server-safety-and-automod-2026-06-12.md` §1 and §3.
+
+**Waiting on:** owner decision.
+
+---
+
+### Q-0109 — Server logging service: event scope and channel layout
+
+> **DISCUSS (2026-06-12).** Source: owner-uploaded competitor research (Carl-bot, Dyno,
+> Arcane logging capabilities). Companion to Q-0108 — independent enough to decide separately.
+
+**Area:** Moderation platform · server event logging
+**Type:** Product direction + UX design
+**Priority:** Medium — core staff utility; low implementation risk
+
+**Questions:**
+
+1. **Event scope** — which event categories to log in v1?
+   Suggested: message edits · message deletes · member join · member leave.
+   Optional adds: role grants/revocations (not by the bot) · voice channel joins/leaves.
+2. **Channel layout** — one combined `#server-log` channel, or separate channels per
+   category (e.g., `#message-log`, `#member-log`)? Separate channels give finer control
+   but add setup friction.
+3. **Privacy note** — deleted-message logging means staff can see what was said before
+   deletion. Does the maintainer want this disclosed clearly in the setup wizard?
+
+**Detail:** `docs/ideas/server-safety-and-automod-2026-06-12.md` §2.
+
+**Waiting on:** owner decision.
+
+---
+
+### Q-0110 — Welcome service: PIL image cards on day one, or start with embeds?
+
+> **DISCUSS (2026-06-12).** Source: owner-uploaded research (ProBot, Koya welcome
+> features + PIL-within-8-MiB bot constraints).
+
+**Area:** Community platform · welcome service
+**Type:** Product direction + implementation scope
+**Priority:** Medium — community onboarding; visible "first impression" feature
+
+**Questions:**
+
+1. Start with an embed-only welcome message (fast to ship, no PIL dependency) and add
+   PIL image cards in a follow-up slice? **OR** build the PIL avatar-composited welcome
+   card from the start?
+2. Is join DM (private welcome message to the new member) wanted alongside the channel
+   post?
+3. Is a "goodbye message on member leave" wanted, or just the welcome?
+
+**Detail:** `docs/ideas/community-platform-features-2026-06-12.md` §1 and
+`docs/operations/discord-platform-limits.md` §4.
+
+**Waiting on:** owner decision.
+
+---
+
+### Q-0111 — Security service: which tiers are wanted, given privacy tradeoffs?
+
+> **DISCUSS (2026-06-12).** Source: owner-uploaded research (Double Counter alt
+> detection + raid prevention capabilities). Privacy risk varies strongly by tier.
+
+**Area:** Server security · account screening
+**Type:** Product direction + privacy/legal boundary
+**Priority:** Lower until public scale; higher once the bot is public (Q-0080)
+
+**Tiers:**
+
+1. **Raid detection** (no external API, no privacy cost) — monitor join rate; if >N
+   joins in T seconds, apply slowmode and alert staff. Low risk. **Recommended yes.**
+2. **New-account age filter** (no external API) — reject or quarantine Discord accounts
+   younger than N days on join. Low risk. **Recommended yes.**
+3. **Alt detection** — requires external device/IP signals. Real privacy and GDPR
+   implications (owner is EU-based). Requires explicit member disclosure. **Needs
+   explicit owner approval.**
+4. **VPN/proxy blocking** — sends every join's IP to a third-party reputation DB.
+   Blocks legitimate privacy-conscious users. **Needs explicit owner approval.**
+
+**Questions:**
+
+1. Are tiers 1 + 2 approved for implementation (independently of tiers 3 + 4)?
+2. Are tiers 3 and 4 wanted at all, given the privacy and legal implications?
+
+**Detail:** `docs/ideas/server-safety-and-automod-2026-06-12.md` §4.
+
+**Waiting on:** owner decision.
+
+---
+
+### Q-0112 — Event scheduler: simple RSVP tier standalone, or needs NL parsing?
+
+> **DISCUSS (2026-06-12).** Source: owner-uploaded research (Sesh scheduling bot).
+> Also touches AI cost (Q-0082 ceiling).
+
+**Area:** Community platform · event scheduling
+**Type:** Product direction + AI cost boundary
+**Priority:** Medium — "General commands" section of the ideal help menu (owner vision)
+
+**Questions:**
+
+1. Is a **simple structured-input event scheduler** (slash command with date/time pickers,
+   RSVP buttons, reminder notifications) valuable on its own — even without natural-language
+   parsing?
+2. Is **natural-language time parsing** ("next Friday 8pm") wanted? It adds an LLM call per
+   event creation → counts against the Q-0082 spend ceiling.
+3. Is **availability polling** (members vote across multiple time options → bot highlights
+   winner) a day-one feature, or a follow-up?
+4. Is there an existing scheduler service in the codebase to reuse for reminders? (Agent
+   should check before designing new infra.)
+
+**Detail:** `docs/ideas/community-platform-features-2026-06-12.md` §3.
+
+**Waiting on:** owner decision.


### PR DESCRIPTION
## Summary

Extracts and structures the valuable content from five owner-uploaded research documents (2026-06-12). Two of the five were identical duplicates; the unique content is organised into focused, routable idea files following the repo's idea lifecycle.

**New files:**
- `docs/ideas/server-safety-and-automod-2026-06-12.md` — Four moderation-safety modules missing vs. competitors: automod rules engine (spam/link/caps/mention filtering), server logging service (message edits, joins, role changes), image moderation (OpenAI free vs. API4AI vs. Hive 50+ categories compared), and a tiered security service (raid detection → account-age filter → alt detection → VPN blocking, each tier sized by privacy risk)
- `docs/ideas/community-platform-features-2026-06-12.md` — Five community-management features: welcome service with PIL avatar-composited image cards, social feed notifications (YouTube-first per Q-0041, then Twitch/RSS/Reddit with optional LLM video summarization), event scheduler (simple RSVP tier now; NL parsing gated on AI cost), custom commands (TagScript-safe), and dynamic server counters (quick-win candidate)
- `docs/operations/discord-platform-limits.md` — Technical reference for agents: component limits (5 action rows, 25 total, 25 select options), the **8 MiB bot upload cap** (users get up to 500 MB, bots do not), PIL design guide (JPEG/WebP export, canvas sizing, avatar compositing, asyncio.to_thread), YouTube transcript constraints, and image moderation provider comparison

**Updated:**
- `docs/ideas/README.md` — Index entries for both new idea files
- `docs/owner/maintainer-question-router.md` — Q-0108…Q-0112 for the five decisions that need owner input before any planning starts

## Questions for the owner (via router)

| Q | Topic | Short question |
|---|---|---|
| Q-0108 | Automod + image moderation | Which automod rule types first? OpenAI-only for images, or add a paid NSFW provider? |
| Q-0109 | Server logging | Which events to log? One combined channel or separate channels per category? |
| Q-0110 | Welcome images | PIL avatar-composited cards from day one, or embed-only first? |
| Q-0111 | Security service | Are tiers 1+2 (raid detection, account-age filter) approved? Are tiers 3+4 (alt detection, VPN blocking) wanted given GDPR implications? |
| Q-0112 | Event scheduler | Simple RSVP tier standalone, or needs NL parsing? Is availability polling day-one? |

## Test plan

- [x] `check_docs --strict` passes (all new files reachable, badge counts correct)
- [x] No `disbot/` code changes — architecture check not applicable
- [x] All new files carry the `ideas` / `reference` badge and the standard "not a plan, not approval" disclaimer
- [x] Ideas README updated with index entries
- [x] Q-blocks appended in correct format (append-only, next free Q-numbers)

https://claude.ai/code/session_01XhL7WLQ8931gt1KoXUhmnD

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhL7WLQ8931gt1KoXUhmnD)_