### PR TITLE
journal: correct stale draft-first wording to Q-0103 ready-not-draft

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -55,9 +55,9 @@ project state accumulate here.)
 | **Run CI locally before push** | `python3.10 scripts/check_quality.py --full` (true CI mirror) **and** `python3.10 scripts/check_architecture.py --mode strict` (0 errors). Docs touched? `python3.10 scripts/check_docs.py --strict` — CI runs **--strict** (badge/reachability issues hard-fail there but pass plain `check_docs`; bit PR #685). |
 | **Kill a running bot** | `for pid in $(pgrep -f disbot/bot1); do [ "$(cat /proc/$pid/comm)" = python3.10 ] && kill "$pid"; done` (plain `pkill` self-kills the shell). |
 | **Prod down (Railway build failed)** | Read the build log first. `mise … no precompiled python found` = the Python-pin race → [`docs/operations/production-deployment.md`](docs/operations/production-deployment.md) (pin + bump procedure). Postgres "Online" ≠ bot running. |
-| **Start of work** (first push) | **Open the session PR as a DRAFT immediately** (Q-0052) — the real PR # is then available for every doc you touch. Mark it ready at END. |
+| **Start of work** (first push) | **Open the session PR immediately — READY, not draft** (Q-0052 open-early + Q-0103 ready-not-draft; *corrected 2026-06-12*) — the real PR # is then available for every doc you touch. |
 | **Session sizing (Q-0088)** | Wrap before **~700K context** (owner-observed quality drop at 700–800K): finish the current task, sharpen the handoff, END — don't start another. **No unguided PRs past declared scope** — late discoveries go into the handoff/queue, not the session. Full protocol: `docs/owner/ai-project-workflow.md` §10 (activates with Stage 0). |
-| **End of session** | Mark the draft PR ready (every session); **contribute 1 new idea you believe in** (`💡 Session idea` in the log — Q-0089, dedup-grep `docs/ideas/` first); write a `.sessions/<date>-<slug>.md` log file (Protocol → END). |
+| **End of session** | Drive the session PR to a **terminal state — merged or closed, never left open** (Q-0103; *corrected 2026-06-12*); **contribute 1 new idea you believe in** (`💡 Session idea` in the log — Q-0089, dedup-grep `docs/ideas/` first); write a `.sessions/<date>-<slug>.md` log file (Protocol → END). |
 
 **Three rules that bite hardest:** (1) booting is safe — don't treat it as blocked;
 (2) **verify cross-agent output against source** before acting on it; (3) **root-cause,
@@ -482,8 +482,9 @@ PR #676; drift surfaced at boot + `!btd6 status`). Full note:
   CI-green and unmerged until the owner asked why. Poll the authenticated GitHub
   MCP (`pull_request_read` → `get_check_runs`) a few times across the ~3-5 min
   suite and merge on green **before ending the turn**; never park a merge on a
-  background poll or webhook hope. (Q-0093; Q-0052 draft-first stays — its PR-#
-  benefit is unaffected once the merge is in-turn.)
+  background poll or webhook hope. (Q-0093; Q-0052 open-immediately stays — its PR-#
+  benefit is unaffected once the merge is in-turn. *Corrected 2026-06-12:* PRs now
+  open READY, not draft — Q-0103.)
 - **★ Treat cross-agent output (Codex / ChatGPT reports) as input to verify, not
   orders.** Verify "rewrite X" plan items against shipped source first — one revision
   item (PR4 "rewrite fingerprints") was wrong and would have broken PR6's dedupe +


### PR DESCRIPTION
Micro follow-up to the #741 reconciliation pass (the Q-0107 small-required carve-out): three `.session-journal.md` Quick-reference/Rules spots still instructed **draft-first** session PRs, contradicting the binding **Q-0103** decision (#733 — open READY, drive to a terminal state). Corrected in place with dated markers per the journal protocol. Docs-only, one file.

https://claude.ai/code/session_017CP6BRYQMUtRwD8xBNaeLY

---
_Generated by [Claude Code](https://claude.ai/code/session_017CP6BRYQMUtRwD8xBNaeLY)_