### PR TITLE
docs: mark dispatch-bridge routine creation step as DONE

### DIFF
--- a/docs/operations/hermes-dispatch-bridge.md
+++ b/docs/operations/hermes-dispatch-bridge.md
@@ -35,10 +35,11 @@ idea / nightly diagnosis
 
 ## Maintainer setup (one-time)
 
-- ⬜ **Create the routine** in the Claude Code console (https://code.claude.com/docs/en/routines):
-  prompt = the saved prompt below · repo = `menno420/superbot` · environment network policy
-  scoped tight · branch-push setting left at the default **`claude/`-only** · API trigger
-  enabled (you get a per-routine `/fire` URL + bearer token).
+- ✅ **Create the routine** — DONE 2026-06-12: the routine **superbot autonomous dispatch**
+  is live in the Claude Code console (https://code.claude.com/docs/en/routines) with the API
+  trigger enabled. prompt = the saved prompt below · repo = `menno420/superbot` · environment
+  network policy scoped tight · branch-push setting left at the default **`claude/`-only** ·
+  API trigger enabled (you get a per-routine `/fire` URL + bearer token).
 - ⬜ **Store the secrets on the VPS** for the `hermes` user (never commit them):
   ```bash
   # ~/.hermes/.env  (or the VPS secret store the gateway loads)


### PR DESCRIPTION
## What

First real calibration run of the Hermes → Claude Code dispatch bridge (Q-0113/Q-0114).

Single edit to `docs/operations/hermes-dispatch-bridge.md`: flip the maintainer-setup step **Create the routine** from ⬜ to ✅, noting the routine **superbot autonomous dispatch** is live in the Claude Code console with an API trigger enabled as of 2026-06-12.

## Why

The repo-side dispatch pieces shipped in #742; the routine + token were the remaining maintainer-side VPS/console actions. The routine now exists and fired this very work order, so the checkbox is factually DONE.

## Acceptance

- `python3.10 scripts/check_docs.py --strict` ✅ passes

## Note

Per the calibration work order, **this PR is intentionally left open for maintainer review — do not auto-merge.** This is the deliberate held-for-approval path of the calibration, confirming the routine opened a PR and held it rather than self-merging.

https://claude.ai/code/session_01WtJ158bsWCSVAXPk2WV9vv

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtJ158bsWCSVAXPk2WV9vv)_