### PR TITLE
P0-1: audited game_wager_workflow + escrow-at-accept money safety

### DIFF
--- a/.sessions/2026-06-12-p0-1-wager-money-safety.md
+++ b/.sessions/2026-06-12-p0-1-wager-money-safety.md
@@ -1,0 +1,100 @@
+# 2026-06-12 — P0-1 games wager money-safety (game_wager_workflow)
+
+> **Status:** `audit`
+
+**PR:** #748 (ready, open)
+**Branch:** `claude/jolly-keller-plunlc`
+
+## Context
+
+Owner-approved (PR #745) implementation session: execute
+[`games-wager-money-safety-plan-2026-06-12.md`](../docs/planning/games-wager-money-safety-plan-2026-06-12.md)
+— hardening track **P0-1**. D1 escrow-at-accept the approved default. One risky-runtime PR.
+
+## What shipped (PR #748)
+
+- **`services/game_wager_workflow.py`** — the audited money boundary for every two-party /
+  paid-entry game coin move, composing `economy_service.*_in_txn` inside one
+  `db.transaction()` (the `mining_workflow` precedent). Ops: `open_pvp_wager`
+  (D1 escrow-at-accept), `settle_pvp`, `refund_pvp`, `enter_tournament`,
+  `payout_tournament`, `recover_escrow`. PvP settle/refund + tournament payout are
+  **idempotent** by `FOR UPDATE` row-consumption (replay = no-op, never double-pays).
+- **D1 escrow-at-accept** deletes the credit-then-`allow_overdraft`-debit **mint window**:
+  stakes leave both wallets atomically with per-player `*_escrow` `game_state` rows at
+  challenge accept; the loser can't be short at settle. If either player can't afford the
+  stake the match aborts before dealing (the one product-visible change).
+- **All four call sites migrated** (RPS + blackjack PvP escrow/settle; RPS + blackjack
+  tournament entry/payout). Removed the dead un-escrowed `deduct_fees` batch debit.
+- **`game_state_service`**: `save`/`clear` gain `conn=`; new `fetch_rows_for_update`
+  locks escrow rows for an atomic settle. Escrow rows carry the `bet` key, so the 24h GC +
+  `recover_escrow` (cog_load / on_guild_remove) refund stranded stakes. **No schema migration.**
+- **AST fence** `test_game_wager_write_boundary`: no `economy_service.credit/.debit` in the
+  wager files; `allow_overdraft=True` solo-only.
+- **Tests**: real-Postgres integration (failure injection at every boundary, terminal-state
+  matrix, idempotency — 12 tests) + mock-based CI coverage (10 tests).
+
+## Verification
+
+- `check_quality.py --full` ✓ (black/isort/ruff/mypy + **9144 passed, 3 skipped**)
+- `check_architecture.py --mode strict` ✓ (0 errors)
+- 12 real-Postgres integration tests ✓ · live boot ✓ (both modified cogs load; escrow
+  recovery cog_load tasks run clean)
+- `check_docs --strict` ✓ · `check_current_state_ledger --strict` ✓
+
+## Context delta (reflection interview)
+
+- **Needed but not pointed to:** the four call sites span **6 files across 3 layers**
+  (challenge-accept *and* resolve for each PvP game live in different view files), and the
+  tournament fee debit hides in `utils/tournaments.deduct_fees` — none of these adjacencies
+  are in the games folio. The folio now lists the `game_wager_workflow` seam; a "wager money
+  flow map" (accept→escrow→settle, per game) would have saved the manual trace.
+- **Pointed to but didn't need:** CodeGraph — a known set of files + grep + the plan's
+  turn-key op table carried the whole session (the documented "contained change" path).
+- **Discovered by hand:** that the generic 24h GC refunds by a single `row["user_id"]`, so
+  a two-party escrow must be **per-player rows** (not one canonical-id row) for recovery to
+  pay both — this drove the whole escrow row shape and isn't written anywhere.
+- **Decisions made alone:** per-player escrow rows in new `*_escrow` subsystems (vs.
+  stuffing escrow into the gameplay checkpoint, which the gameplay saves would clobber);
+  free-tournament reward left non-row-guarded (zero money-at-risk, single-call); fence
+  scoped to explicit wager files + a repo-wide `allow_overdraft` ban.
+- **Weak point of what shipped:** prompt escrow recovery (`recover_escrow`) reuses the
+  un-transactional refund-then-clear loop; correctness rests on the GC backstop, not a
+  second transaction. Acceptable (money is provably safe), but not as tight as the settle path.
+- **One change that would have helped:** a lint/hook catch for the
+  "bare `black`/`isort`/`ruff` over `tests/`" trap — I hit it (reformatted 269 unrelated
+  files; CLAUDE.md warns about exactly this) and had to selectively `git checkout` the
+  spurious churn. `check_quality.py` is the only correct path; nothing *stops* the bare run.
+
+## ⟲ Previous-session review (Q-0102)
+
+Reviewing `2026-06-12-reconciliation-cadence-rule.md` (the Q-0107 cadence session): **did
+well** — shipped the rule *with* its enforcement (`check_reconciliation_due.py` + 9 tests +
+`/session-close` wiring + the marker), so the cadence can't silently rot; the kill-switch
+header is exactly the Q-0105 discipline. **Could improve:** it set `Last reconciliation pass:
+PR #737` and said "next due at #740", but #741 (the actual first pass) then re-set it — a
+one-session window where two markers disagreed. **System improvement it surfaces:** the
+reconciliation marker and the "next implementation session" pointer both live as prose in
+`current-state.md` and are edited by hand every session — the same drift class the per-lane
+bullets fixed. A tiny `scripts/` helper that *reads* the marker + open-PR state and prints
+the single authoritative "what's next / is a pass due" line (instead of each session
+re-asserting it in prose) would remove the last hand-maintained status sentence.
+
+## 💡 Session idea (Q-0089)
+
+**A `wager-money-flow` doc (or `scripts/wager_flow_map.py`)** that traces every game's
+money path accept→escrow→settle/refund and entry→payout across its view/cog files. This
+session's single biggest cost was hand-tracing that PvP money touches *four* files per game
+(challenge-accept, play-resolve, plus the tournament entry/payout split) with the fee debit
+hidden in `utils/tournaments`. A generated map (grep the `game_wager_workflow` call sites +
+the `*_escrow`/entry subsystems) would make the next "touch a wager path" session a lookup,
+not an archaeology dig — and would double as the fence's human-readable companion. Dedup-checked
+`docs/ideas/`: the mining brainstorm and games folio cover *features*, not a money-flow map.
+
+## Notes for next session
+
+- Next hardening track: **P0-2** (Media/YouTube data-minimization, Q-0099 answered) —
+  see the [decade queue](../docs/planning/reconciliation-pass-2026-06-12.md).
+- Next reconciliation pass is due at **PR #750** (Q-0107).
+- `deduct_fees` is gone; `_save_tournament_entry` / `_clear_tournament_entry` remain as
+  row primitives (still unit-tested) but are no longer on the production path — the money
+  atomicity is in `enter_tournament`. Candidates to retire in a later cleanup.

--- a/disbot/cogs/blackjack/_state.py
+++ b/disbot/cogs/blackjack/_state.py
@@ -40,6 +40,13 @@ BLACKJACK_SOLO_VERSION = 1
 BLACKJACK_PVP_SUBSYSTEM = "blackjack_pvp"
 BLACKJACK_PVP_VERSION = 1
 
+# P0-1 — escrow subsystem for D1 escrow-at-accept.  One ``{"bet": stake,
+# "peer": other_id}`` row per player so the existing ``bet``-keyed
+# recovery refunds each player their own stake.  Wagered money moves only
+# through ``services.game_wager_workflow``.
+BLACKJACK_PVP_ESCROW_SUBSYSTEM = "blackjack_pvp_escrow"
+BLACKJACK_PVP_ESCROW_VERSION = 1
+
 BLACKJACK_TOURNAMENT_SUBSYSTEM = "blackjack_tournament"
 BLACKJACK_TOURNAMENT_VERSION = 1
 

--- a/disbot/cogs/blackjack_cog.py
+++ b/disbot/cogs/blackjack_cog.py
@@ -47,6 +47,7 @@ from cogs.blackjack._persistence import (  # noqa: F401 — re-exported
 # imports are flagged by ruff so we collect them via __all__ below
 # instead of relying on F401 noqa pragmas.
 from cogs.blackjack._state import (  # noqa: F401 — re-exported
+    BLACKJACK_PVP_ESCROW_SUBSYSTEM,
     BLACKJACK_PVP_SUBSYSTEM,
     BLACKJACK_PVP_VERSION,
     BLACKJACK_SOLO_SUBSYSTEM,
@@ -65,7 +66,12 @@ from cogs.blackjack._state import (  # noqa: F401 — re-exported
     _TournPlayerState,
 )
 from core.runtime import resources, tasks
-from services import economy_service, game_state_service, tournament_state_service
+from services import (
+    economy_service,
+    game_state_service,
+    game_wager_workflow,
+    tournament_state_service,
+)
 from services.blackjack_engine import is_blackjack as _is_blackjack
 from utils import db
 from utils.channels import cleanup_category, create_private_channel
@@ -125,6 +131,15 @@ class BlackjackCog(commands.Cog):
         # balance and starts a new game.
         tasks.spawn("blackjack:recover_solo", self._recover_blackjack_solo())
         tasks.spawn("blackjack:recover_pvp", self._recover_blackjack_pvp())
+        # P0-1 — refund any stranded PvP escrow (stakes debited at accept
+        # but the match never settled because the bot bounced).
+        tasks.spawn(
+            "blackjack:recover_pvp_escrow",
+            game_wager_workflow.recover_escrow(
+                BLACKJACK_PVP_ESCROW_SUBSYSTEM,
+                reason="blackjack:pvp_escrow_refund",
+            ),
+        )
         # PR G5 — tournament recovery DOES refund.  Entry fees were
         # debited at launch; if the bot crashed before _check_tourn_done
         # paid out the pot, those coins are still in limbo.  Refund
@@ -351,6 +366,13 @@ class BlackjackCog(commands.Cog):
                     guild.id,
                     exc,
                 )
+
+        # P0-1 — refund stranded PvP escrow for the departing guild.
+        await game_wager_workflow.recover_escrow(
+            BLACKJACK_PVP_ESCROW_SUBSYSTEM,
+            reason="blackjack:pvp_escrow_refund",
+            guild_id=guild.id,
+        )
 
     async def _cleanup_orphaned_tournaments(self):
         """On startup, find leftover BJ Tournament categories and notify players."""
@@ -590,9 +612,30 @@ async def _launch_tournament(
         await tournament_state_service.clear_active(tourn.guild_id)
         return
 
-    # Deduct entry fees (uses shared TournamentRegistration helper)
+    # P0-1 — debit each entry fee and write its recovery row in ONE
+    # transaction per player (the old flow batch-debited via
+    # ``deduct_fees`` then saved each row separately at channel-creation
+    # time: a crash in the window lost the fee with no row to refund).
+    # channel_id=0 keeps the guild-wide natural key; the per-round
+    # private channel is bookkeeping, not money.
     if tourn.entry_fee:
-        await tourn.deduct_fees()
+        paid: set[int] = set()
+        for uid in list(tourn.players):
+            try:
+                await game_wager_workflow.enter_tournament(
+                    guild_id=tourn.guild_id,
+                    user_id=uid,
+                    channel_id=0,
+                    subsystem=BLACKJACK_TOURNAMENT_SUBSYSTEM,
+                    version=BLACKJACK_TOURNAMENT_VERSION,
+                    fee=tourn.entry_fee,
+                    reason="tournament:entry_fee",
+                    extra_state={"rounds": tourn.rounds},
+                )
+                paid.add(uid)
+            except economy_service.InsufficientFundsError:
+                continue
+        tourn.players = paid
 
     if not tourn.players:
         if announce:
@@ -630,17 +673,9 @@ async def _launch_tournament(
                 tourn.rounds,
                 channel_id=ch.id,
             )
-            # PR G5 — persist the paid-entry state so a crash before
-            # the tournament resolves can refund this player on
-            # cog_load.  ``bet`` matches the G0 GC convention so the
-            # 24 h sweep is a secondary safety net.
-            await _save_tournament_entry(
-                guild_id=tourn.guild_id,
-                user_id=uid,
-                channel_id=ch.id,
-                entry_fee=tourn.entry_fee,
-                rounds=tourn.rounds,
-            )
+            # The paid-entry recovery row was written atomically with the
+            # fee debit in ``enter_tournament`` above (P0-1), keyed at
+            # channel_id=0 — no separate save here.
             await ch.send(
                 f"Welcome, {member.mention}! You have **{tourn.rounds}** rounds "
                 f"and start with **{TOURN_START_CHIPS}** chips. Good luck! 🃏",

--- a/disbot/cogs/rps_tournament_cog.py
+++ b/disbot/cogs/rps_tournament_cog.py
@@ -67,10 +67,12 @@ from core.runtime import tasks
 from services import (  # noqa: F401 — game_state_service kept for back-compat patch sites
     economy_service,
     game_state_service,
+    game_wager_workflow,
     tournament_state_service,
 )
 from utils.ui_constants import INFO_COLOR
 from views.rps import _RpsRegistrationView
+from views.rps._helpers import RPS_PVP_ESCROW_SUBSYSTEM
 
 logger = logging.getLogger("bot")
 
@@ -143,6 +145,15 @@ class RockPaperScissorsCog(commands.Cog, name="Rock Paper Scissors"):  # type: i
         # PR G1 — drop any rps_pvp_pending game_state rows left over
         # from a previous process.
         tasks.spawn("rps:recover_pvp_pending", self._recover_rps_pvp_pending())
+        # P0-1 — refund any stranded PvP escrow (stakes debited at accept
+        # but the match never settled because the bot bounced).
+        tasks.spawn(
+            "rps:recover_pvp_escrow",
+            game_wager_workflow.recover_escrow(
+                RPS_PVP_ESCROW_SUBSYSTEM,
+                reason="rps:pvp_escrow_refund",
+            ),
+        )
         # PR G6 — refund stranded tournament entries.  Same shape as
         # blackjack tournament: entry fees were debited at registration
         # and never paid back if the bot crashed before the final
@@ -172,6 +183,12 @@ class RockPaperScissorsCog(commands.Cog, name="Rock Paper Scissors"):  # type: i
     async def on_guild_remove(self, guild) -> None:
         """Wipe rps subsystem rows for a departed guild (delegator)."""
         await on_guild_remove_rps(guild.id)
+        # P0-1 — refund stranded PvP escrow for the departing guild.
+        await game_wager_workflow.recover_escrow(
+            RPS_PVP_ESCROW_SUBSYSTEM,
+            reason="rps:pvp_escrow_refund",
+            guild_id=guild.id,
+        )
 
     # ------------------------------------------------------------------
     # Tournament registration
@@ -319,13 +336,20 @@ class RockPaperScissorsCog(commands.Cog, name="Rock Paper Scissors"):  # type: i
         if user.id in self.paid_players or user in self.players:
             return False  # already registered
         if self.entry_fee > 0:
+            # P0-1 — debit the fee and write the recovery row in ONE
+            # transaction (the old flow debited, then saved the row in a
+            # separate call: a crash between lost the fee with no row to
+            # refund from).  channel_id=0 keeps the guild-wide natural
+            # key; state={"bet": fee} matches the recovery convention.
             try:
-                await economy_service.debit(
-                    guild_id,
-                    user.id,
-                    self.entry_fee,
+                await game_wager_workflow.enter_tournament(
+                    guild_id=guild_id,
+                    user_id=user.id,
+                    channel_id=0,
+                    subsystem=RPS_TOURNAMENT_SUBSYSTEM,
+                    version=RPS_TOURNAMENT_VERSION,
+                    fee=self.entry_fee,
                     reason="rps:entry_fee",
-                    actor_id=user.id,
                 )
             except economy_service.InsufficientFundsError:
                 return False
@@ -333,14 +357,6 @@ class RockPaperScissorsCog(commands.Cog, name="Rock Paper Scissors"):  # type: i
         self.players.append(user)
         self.scores[user] = 0
         await add_player_to_db(user, guild_id)
-        # PR G6 — persist the paid-entry state so a crash before the
-        # final payout in ``check_tournament_progress`` can refund this
-        # player on cog_load.
-        await save_tournament_entry(
-            guild_id=guild_id,
-            user_id=user.id,
-            entry_fee=self.entry_fee,
-        )
         return True
 
     # ------------------------------------------------------------------
@@ -648,25 +664,28 @@ class RockPaperScissorsCog(commands.Cog, name="Rock Paper Scissors"):  # type: i
         """Checks if the tournament is over or starts a new round."""
         if len(self.current_round) == 1:
             winner = self.current_round[0]
-            pot = self.entry_fee * len(self.paid_players)
+            # P0-1 — pay the winner the escrowed pot (the sum of the
+            # actual entry rows, not a recomputed fee×players) and delete
+            # those rows in ONE idempotent transaction.  This replaces
+            # the credit-then-separate-clear pair, so a re-run can never
+            # double-pay and recovery can never refund an already-settled
+            # tournament.
+            result = await game_wager_workflow.payout_tournament(
+                guild_id=guild.id,
+                subsystem=RPS_TOURNAMENT_SUBSYSTEM,
+                winner_id=winner.id,
+                reason="rps:tournament_win",
+                free_reward=100,
+                free_reason="rps:tournament_free_reward",
+            )
             msg_lines = [f"🏆 **{winner.display_name}** has won the RPS Tournament! 🏆"]
-            if pot:
-                new_bal = await economy_service.credit(
-                    guild.id,
-                    winner.id,
-                    pot,
-                    reason="rps:tournament_win",
+            if result.paid and self.entry_fee > 0:
+                msg_lines.append(
+                    f"💰 Payout: **{result.amount}** 🪙 "
+                    f"(Balance: {result.new_winner_balance} 🪙)",
                 )
-                msg_lines.append(f"💰 Payout: **{pot}** 🪙 (Balance: {new_bal} 🪙)")
-            elif self.entry_fee == 0:
-                reward = 100
-                new_bal = await economy_service.credit(
-                    guild.id,
-                    winner.id,
-                    reward,
-                    reason="rps:tournament_free_reward",
-                )
-                msg_lines.append(f"🎁 Free tournament reward: **{reward}** 🪙")
+            elif result.paid:
+                msg_lines.append(f"🎁 Free tournament reward: **{result.amount}** 🪙")
             announce = guild.system_channel or last_channel
             await announce.send("\n".join(msg_lines))
             self.tournament_active = False
@@ -676,30 +695,6 @@ class RockPaperScissorsCog(commands.Cog, name="Rock Paper Scissors"):  # type: i
             self.matches.clear()
             self.current_round.clear()
             self.match_channels.clear()
-            # PR G6 — natural completion: drop the persisted entry-fee
-            # rows WITHOUT refunding (the pot above already settled).
-            try:
-                rows = await game_state_service.list_active_for_subsystem(
-                    RPS_TOURNAMENT_SUBSYSTEM,
-                    guild_id=guild.id,
-                )
-                for row in rows:
-                    try:
-                        await game_state_service.clear_by_id(row["id"])
-                    except Exception as exc:
-                        logger.warning(
-                            "rps_tournament natural-completion clear "
-                            "failed for id=%s: %s",
-                            row.get("id"),
-                            exc,
-                        )
-            except Exception as exc:
-                logger.warning(
-                    "rps_tournament natural-completion sweep failed for "
-                    "guild=%d: %s — entries will be cleared by the 24h GC",
-                    guild.id,
-                    exc,
-                )
             # Clean up any remaining match channels
             await delete_all_match_channels(guild)
         else:

--- a/disbot/services/game_state_service.py
+++ b/disbot/services/game_state_service.py
@@ -52,6 +52,7 @@ async def save(
     state: dict[str, Any],
     *,
     version: int = 1,
+    conn: Any | None = None,
 ) -> None:
     """Upsert a game-state checkpoint.
 
@@ -62,6 +63,13 @@ async def save(
     drift across deploys.  On load, an adopting cog should compare
     the stored version to its current schema version and decide
     whether to resume the game or refund + clear.
+
+    P0-1: pass *conn* to compose this write inside a caller-owned
+    ``db.transaction()`` — ``services.game_wager_workflow`` escrows a
+    wager (coin debit + checkpoint write) in ONE transaction so a
+    crash can never leave money moved without a recovery row, or a row
+    without the money.  When *conn* is None the write runs on the pool
+    (the existing best-effort checkpoint behaviour).
     """
     payload = json.dumps(state)
     await pool.execute(
@@ -74,6 +82,7 @@ async def save(
                version    = EXCLUDED.version,
                updated_at = NOW()""",
         (guild_id, user_id, channel_id, subsystem, payload, version),
+        conn=conn,
     )
 
 
@@ -103,14 +112,74 @@ async def clear(
     user_id: int,
     channel_id: int,
     subsystem: str,
+    *,
+    conn: Any | None = None,
 ) -> None:
-    """Delete the checkpoint for a completed game."""
+    """Delete the checkpoint for a completed game.
+
+    P0-1: pass *conn* to delete inside a caller-owned transaction —
+    ``game_wager_workflow`` releases a wager's escrow row in the same
+    transaction that pays out the pot, so a settle is all-or-nothing.
+    """
     await pool.execute(
         """DELETE FROM game_state
            WHERE guild_id=$1 AND user_id=$2
              AND channel_id=$3 AND subsystem=$4""",
         (guild_id, user_id, channel_id, subsystem),
+        conn=conn,
     )
+
+
+async def fetch_rows_for_update(
+    guild_id: int,
+    subsystem: str,
+    *,
+    conn: Any,
+    channel_id: int | None = None,
+    user_ids: list[int] | None = None,
+) -> list[dict[str, Any]]:
+    """Lock and return checkpoint rows for an escrow/payout settlement.
+
+    The P0-1 wager workflow calls this **inside** a ``db.transaction()``
+    to take a row-level ``FOR UPDATE`` lock on the escrow rows it is
+    about to settle.  The lock serialises concurrent settle/refund
+    attempts (a crash-retry or a double-click): the first call holds
+    the rows and deletes them; the second blocks, then finds them gone
+    and treats the settle as already done (idempotency without a
+    dedicated key column).
+
+    *channel_id* scopes a PvP match; *user_ids* narrows to the two
+    players.  Omit both to lock every row for the subsystem in the
+    guild (a tournament payout).  Each returned dict carries the
+    decoded ``state`` plus ``user_id`` / ``channel_id``.
+    """
+    clauses = ["guild_id=$1", "subsystem=$2"]
+    params: list[Any] = [guild_id, subsystem]
+    if channel_id is not None:
+        params.append(channel_id)
+        clauses.append(f"channel_id=${len(params)}")
+    if user_ids is not None:
+        params.append(list(user_ids))
+        clauses.append(f"user_id = ANY(${len(params)}::bigint[])")
+    sql = (
+        "SELECT user_id, channel_id, state, version FROM game_state WHERE "
+        + " AND ".join(clauses)
+        + " FOR UPDATE"
+    )
+    rows = await pool.fetchall(sql, tuple(params), conn=conn)
+    result: list[dict[str, Any]] = []
+    for r in rows:
+        raw = r["state"]
+        state = json.loads(raw) if isinstance(raw, str) else raw
+        result.append(
+            {
+                "user_id": r["user_id"],
+                "channel_id": r["channel_id"],
+                "state": state,
+                "version": r["version"],
+            },
+        )
+    return result
 
 
 async def list_active_for_subsystem(

--- a/disbot/services/game_wager_workflow.py
+++ b/disbot/services/game_wager_workflow.py
@@ -1,0 +1,479 @@
+"""Game wager workflow — the audited money boundary for wagered games (P0-1).
+
+Every two-party (PvP) or paid-entry (tournament) coin movement in the
+games stack composes the atomic ``economy_service`` primitives
+(``debit_in_txn`` / ``credit_in_txn``) **inside one** ``db.transaction()``
+here, exactly like ``services.mining_workflow`` does for mining.  Before
+this service the wager flows debited and credited in two separate
+top-level calls, so a crash between them could:
+
+* **mint coins** — the winner was credited the pot, then a failure
+  skipped the loser's debit (RPS / blackjack PvP settle); or
+* **lose an entry fee** — the fee was debited at registration, then a
+  crash skipped the checkpoint row that recovery refunds from
+  (RPS / blackjack tournament entry).
+
+The cure is D1 **escrow-at-accept** for PvP plus **debit-with-the-row**
+for tournament entry:
+
+* ``open_pvp_wager`` debits *both* players' stakes the moment a
+  challenge is accepted and writes one ``*_escrow`` checkpoint row per
+  player in the same transaction.  The pot now physically lives outside
+  both wallets — the loser *cannot* be short at settle, so the
+  overdraft-debit (and its mint window) is gone.
+* ``settle_pvp`` / ``refund_pvp`` pay the escrowed pot out (to the
+  winner, or back to each player on a tie/abort) and delete the escrow
+  rows in one transaction.  Both are **idempotent**: they ``FOR UPDATE``
+  the escrow rows, and a replay that finds them already gone is a no-op
+  — a crash-retry or a double settle can never double-pay.
+* ``enter_tournament`` debits the fee and writes the recovery row in one
+  transaction (closing the lost-fee window).
+* ``payout_tournament`` pays the winner and deletes the entry rows
+  together, idempotent by the same row-consumption guard.
+
+Escrow / entry rows carry the ``bet`` key, so the existing
+``services.game_state_cleanup`` GC sweep and the per-cog cog_load
+recovery loops already refund any row a crash strands — this service
+adds atomicity, not a new recovery surface.
+
+EventBus emission happens **after** the transaction commits, never
+inside it (the ``economy_service.transfer`` precedent).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from core.events import bus
+from services import economy_service, game_state_service
+from utils import db
+
+logger = logging.getLogger("bot.game_wager_workflow")
+
+# Payload key under which each escrow / entry row records the staked
+# amount.  Shared with services.game_state_cleanup (the GC refund
+# convention) and the per-cog recovery loops — keep it ``bet``.
+STAKE_KEY = "bet"
+
+
+@dataclass(frozen=True)
+class EscrowResult:
+    """The outcome of opening a PvP wager."""
+
+    #: True when both stakes were escrowed this call (False = free game,
+    #: stake <= 0, so nothing moved).
+    escrowed: bool
+    #: The per-player stake that left each wallet (0 when not escrowed).
+    stake: int
+
+
+@dataclass(frozen=True)
+class SettleResult:
+    """The outcome of a settle / refund / payout."""
+
+    #: True when money moved this call.  False means the wager was
+    #: already settled (idempotent replay) or there was nothing staked.
+    paid: bool
+    #: Total coins paid out this call.
+    amount: int
+    #: New balance of the credited winner, when a single winner was paid.
+    new_winner_balance: int | None = None
+
+
+# ---------------------------------------------------------------------------
+# PvP — escrow at accept, settle / refund at resolve
+# ---------------------------------------------------------------------------
+
+
+async def open_pvp_wager(
+    *,
+    guild_id: int,
+    channel_id: int,
+    subsystem: str,
+    version: int,
+    p1_id: int,
+    p2_id: int,
+    stake: int,
+    reason: str,
+) -> EscrowResult:
+    """Escrow both players' stakes when a PvP challenge is accepted.
+
+    Debits *stake* from each player and writes one escrow checkpoint row
+    per player — all in ONE transaction.  Raises
+    :class:`economy_service.InsufficientFundsError` (rolling back both
+    legs) if either player cannot afford the stake, so the caller can
+    abort the match before any hand is dealt.
+
+    A *stake* of 0 (free PvP) escrows nothing and returns
+    ``escrowed=False``.
+    """
+    if stake <= 0:
+        return EscrowResult(escrowed=False, stake=0)
+    async with db.transaction() as conn:
+        bal1 = await economy_service.debit_in_txn(
+            conn,
+            guild_id,
+            p1_id,
+            stake,
+            reason=reason,
+            actor_id=p1_id,
+        )
+        bal2 = await economy_service.debit_in_txn(
+            conn,
+            guild_id,
+            p2_id,
+            stake,
+            reason=reason,
+            actor_id=p2_id,
+        )
+        await game_state_service.save(
+            guild_id,
+            p1_id,
+            channel_id,
+            subsystem,
+            {STAKE_KEY: stake, "peer": p2_id},
+            version=version,
+            conn=conn,
+        )
+        await game_state_service.save(
+            guild_id,
+            p2_id,
+            channel_id,
+            subsystem,
+            {STAKE_KEY: stake, "peer": p1_id},
+            version=version,
+            conn=conn,
+        )
+    await _emit_balance(guild_id, p1_id, -stake, bal1, reason)
+    await _emit_balance(guild_id, p2_id, -stake, bal2, reason)
+    return EscrowResult(escrowed=True, stake=stake)
+
+
+async def settle_pvp(
+    *,
+    guild_id: int,
+    channel_id: int,
+    subsystem: str,
+    p1_id: int,
+    p2_id: int,
+    winner_id: int,
+    reason: str,
+) -> SettleResult:
+    """Pay the escrowed pot to *winner_id* and release the escrow rows.
+
+    Idempotent: locks both escrow rows ``FOR UPDATE`` and pays out the
+    summed stakes only if they are still present.  A second call (crash
+    retry / double resolve) finds the rows gone and returns
+    ``paid=False`` without moving money.
+    """
+    async with db.transaction() as conn:
+        rows = await game_state_service.fetch_rows_for_update(
+            guild_id,
+            subsystem,
+            conn=conn,
+            channel_id=channel_id,
+            user_ids=[p1_id, p2_id],
+        )
+        pot = _sum_stakes(rows)
+        if pot <= 0:
+            return SettleResult(paid=False, amount=0)
+        new_balance = await economy_service.credit_in_txn(
+            conn,
+            guild_id,
+            winner_id,
+            pot,
+            reason=reason,
+            actor_id=winner_id,
+        )
+        await _delete_escrow_rows(conn, guild_id, channel_id, subsystem, rows)
+    await _emit_balance(guild_id, winner_id, pot, new_balance, reason)
+    return SettleResult(paid=True, amount=pot, new_winner_balance=new_balance)
+
+
+async def refund_pvp(
+    *,
+    guild_id: int,
+    channel_id: int,
+    subsystem: str,
+    p1_id: int,
+    p2_id: int,
+    reason: str,
+) -> SettleResult:
+    """Return each player's own stake and release the escrow rows.
+
+    Used on a tie / both-forfeit / post-accept abort.  Idempotent by the
+    same ``FOR UPDATE`` row-consumption guard as :func:`settle_pvp`.
+    """
+    emits: list[tuple[int, int, int]] = []
+    async with db.transaction() as conn:
+        rows = await game_state_service.fetch_rows_for_update(
+            guild_id,
+            subsystem,
+            conn=conn,
+            channel_id=channel_id,
+            user_ids=[p1_id, p2_id],
+        )
+        if _sum_stakes(rows) <= 0:
+            return SettleResult(paid=False, amount=0)
+        total = 0
+        for row in rows:
+            stake = _row_stake(row)
+            if stake <= 0:
+                continue
+            uid = row["user_id"]
+            new_balance = await economy_service.credit_in_txn(
+                conn,
+                guild_id,
+                uid,
+                stake,
+                reason=reason,
+                actor_id=uid,
+            )
+            total += stake
+            emits.append((uid, stake, new_balance))
+        await _delete_escrow_rows(conn, guild_id, channel_id, subsystem, rows)
+    for uid, stake, new_balance in emits:
+        await _emit_balance(guild_id, uid, stake, new_balance, reason)
+    return SettleResult(paid=total > 0, amount=total)
+
+
+# ---------------------------------------------------------------------------
+# Tournament — debit-with-the-row at entry, settle the pot at payout
+# ---------------------------------------------------------------------------
+
+
+async def enter_tournament(
+    *,
+    guild_id: int,
+    user_id: int,
+    channel_id: int,
+    subsystem: str,
+    version: int,
+    fee: int,
+    reason: str,
+    extra_state: dict | None = None,
+) -> int:
+    """Debit the entry *fee* and write the recovery row in one transaction.
+
+    Returns the player's new balance.  Raises
+    :class:`economy_service.InsufficientFundsError` (rolling back the
+    row) when the player cannot afford the fee — the caller drops them
+    from the tournament.  A *fee* of 0 is a free entry: no debit, no row,
+    returns the current balance.
+    """
+    if fee <= 0:
+        return await db.get_coins(user_id, guild_id)
+    state = {STAKE_KEY: fee}
+    if extra_state:
+        state.update(extra_state)
+    async with db.transaction() as conn:
+        new_balance = await economy_service.debit_in_txn(
+            conn,
+            guild_id,
+            user_id,
+            fee,
+            reason=reason,
+            actor_id=user_id,
+        )
+        await game_state_service.save(
+            guild_id,
+            user_id,
+            channel_id,
+            subsystem,
+            state,
+            version=version,
+            conn=conn,
+        )
+    await _emit_balance(guild_id, user_id, -fee, new_balance, reason)
+    return new_balance
+
+
+async def payout_tournament(
+    *,
+    guild_id: int,
+    subsystem: str,
+    winner_id: int | None,
+    reason: str,
+    free_reward: int = 0,
+    free_reason: str | None = None,
+) -> SettleResult:
+    """Pay the tournament winner and release every entry row, atomically.
+
+    The pot is the sum of the escrowed entry fees (the *truth*, not a
+    recomputed ``fee × players``), so a player who dropped out after
+    paying is never short-changed.  Crediting the winner and deleting
+    the entry rows happen in one transaction; a replay finds no rows and
+    is a no-op, so recovery can never double-pay an already-settled
+    tournament.
+
+    *free_reward* covers the no-entry-fee case (a fixed consolation
+    reward).  Free tournaments stake nothing and leave no rows, so this
+    leg is not row-guarded — it is single-call by construction (no
+    recovery path pays rewards) and carries no money-at-risk.
+    """
+    async with db.transaction() as conn:
+        rows = await game_state_service.fetch_rows_for_update(
+            guild_id,
+            subsystem,
+            conn=conn,
+        )
+        pot = _sum_stakes(rows)
+        if rows:
+            # Paid tournament: release the escrowed entry rows and pay
+            # the winner the summed pot (row deletion is the idempotency
+            # guard — a replay finds no rows).
+            await _delete_escrow_rows(conn, guild_id, None, subsystem, rows)
+            if winner_id is None or pot <= 0:
+                return SettleResult(paid=False, amount=0)
+            paid_reason, amount = reason, pot
+        elif winner_id is not None and free_reward > 0:
+            # Free tournament: fixed consolation reward, no escrow to
+            # consume (single-call by construction — see docstring).
+            paid_reason, amount = free_reason or reason, free_reward
+        else:
+            return SettleResult(paid=False, amount=0)
+        new_balance = await economy_service.credit_in_txn(
+            conn,
+            guild_id,
+            winner_id,
+            amount,
+            reason=paid_reason,
+            actor_id=winner_id,
+        )
+    await _emit_balance(guild_id, winner_id, amount, new_balance, paid_reason)
+    return SettleResult(paid=True, amount=amount, new_winner_balance=new_balance)
+
+
+# ---------------------------------------------------------------------------
+# Recovery — refund stranded escrow / entry rows promptly (cog_load,
+# on_guild_remove).  The 24 h game_state GC already refunds these via the
+# ``bet`` convention; this just does it sooner so a crash mid-wager does
+# not leave coins escrowed for up to a day.
+# ---------------------------------------------------------------------------
+
+
+async def recover_escrow(
+    subsystem: str,
+    *,
+    reason: str,
+    guild_id: int | None = None,
+) -> int:
+    """Refund every stranded ``bet`` row for *subsystem*, then clear it.
+
+    Each escrow/entry row carries a single-player ``bet``, so the refund
+    is single-sided and the clear-after makes a re-run a no-op.  Refund
+    failures are logged but the row is still cleared (the GC convention —
+    never loop forever on a permanently-failing refund).  Returns the
+    number of rows refunded.  *guild_id* scopes ``on_guild_remove``;
+    omit it for a cog_load sweep.
+    """
+    try:
+        rows = await game_state_service.list_active_for_subsystem(
+            subsystem,
+            guild_id=guild_id,
+        )
+    except Exception as exc:
+        logger.warning("%s escrow recovery skipped: %s", subsystem, exc)
+        return 0
+    refunded = 0
+    for row in rows:
+        state = row.get("state") or {}
+        bet = state.get(STAKE_KEY)
+        if isinstance(bet, int) and bet > 0:
+            try:
+                await economy_service.refund(
+                    guild_id=row["guild_id"],
+                    user_id=row["user_id"],
+                    amount=bet,
+                    reason=reason,
+                )
+                refunded += 1
+            except Exception as exc:
+                logger.warning(
+                    "%s escrow refund failed for user=%s: %s",
+                    subsystem,
+                    row.get("user_id"),
+                    exc,
+                )
+        try:
+            await game_state_service.clear_by_id(row["id"])
+        except Exception as exc:
+            logger.warning(
+                "%s escrow clear failed for id=%s: %s",
+                subsystem,
+                row.get("id"),
+                exc,
+            )
+    if refunded:
+        logger.info(
+            "%s escrow recovery: refunded %d stranded stake(s)",
+            subsystem,
+            refunded,
+        )
+    return refunded
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _row_stake(row: dict) -> int:
+    state = row.get("state") or {}
+    stake = state.get(STAKE_KEY)
+    return stake if isinstance(stake, int) and stake > 0 else 0
+
+
+def _sum_stakes(rows: list[dict]) -> int:
+    return sum(_row_stake(r) for r in rows)
+
+
+async def _delete_escrow_rows(
+    conn,
+    guild_id: int,
+    channel_id: int | None,
+    subsystem: str,
+    rows: list[dict],
+) -> None:
+    """Delete every locked escrow/entry row inside the settle transaction."""
+    for row in rows:
+        await game_state_service.clear(
+            guild_id,
+            row["user_id"],
+            channel_id if channel_id is not None else row["channel_id"],
+            subsystem,
+            conn=conn,
+        )
+
+
+async def _emit_balance(
+    guild_id: int,
+    user_id: int | None,
+    delta: int,
+    new_balance: int | None,
+    reason: str,
+) -> None:
+    """EVT_BALANCE_CHANGED, after the owning transaction committed."""
+    if user_id is None or new_balance is None:
+        return
+    await bus.emit(
+        economy_service.EVT_BALANCE_CHANGED,
+        guild_id=guild_id,
+        user_id=user_id,
+        delta=delta,
+        new_balance=new_balance,
+        reason=reason,
+    )
+
+
+__all__ = [
+    "EscrowResult",
+    "SettleResult",
+    "open_pvp_wager",
+    "settle_pvp",
+    "refund_pvp",
+    "enter_tournament",
+    "payout_tournament",
+    "recover_escrow",
+]

--- a/disbot/utils/tournaments.py
+++ b/disbot/utils/tournaments.py
@@ -51,35 +51,10 @@ class TournamentRegistration:
         self.players.add(user_id)
         return True, f"✅ Registered! ({len(self.players)} player(s) so far)"
 
-    async def deduct_fees(self) -> set[int]:
-        """Deduct entry fees from all registered players at tournament start.
-
-        Returns the set of player IDs who successfully paid.
-        Players who can no longer afford the fee are removed.
-
-        Routes through services.economy_service so the deductions are
-        audit-logged and emit ``economy.balance_changed`` like every
-        other balance mutation.
-        """
-        if not self.entry_fee:
-            return set(self.players)
-        # Local import — utils.tournaments must not import services at
-        # module load (services may import utils transitively).
-        from services import economy_service
-
-        paid: set[int] = set()
-        for uid in list(self.players):
-            try:
-                await economy_service.debit(
-                    self.guild_id,
-                    uid,
-                    self.entry_fee,
-                    reason="tournament:entry_fee",
-                    actor_id=uid,
-                )
-                paid.add(uid)
-            except economy_service.InsufficientFundsError:
-                # Player can no longer afford — silently drop from set.
-                continue
-        self.players = paid
-        return paid
+    # Note (P0-1): fee collection moved OUT of this shared helper into
+    # ``services.game_wager_workflow.enter_tournament``, which debits the
+    # fee and writes the recovery row in ONE transaction.  The old
+    # ``deduct_fees`` debited each player in a separate top-level call
+    # from the row that recovery refunds from — a crash in that window
+    # lost the fee.  Both tournament cogs now call ``enter_tournament``
+    # per player; do not re-add an un-escrowed batch debit here.

--- a/disbot/views/blackjack/pvp_view.py
+++ b/disbot/views/blackjack/pvp_view.py
@@ -11,9 +11,16 @@ from __future__ import annotations
 import discord
 
 from cogs.blackjack._persistence import _clear_pvp_match, _save_pvp_match
-from cogs.blackjack._state import FREE_WIN_COINS, _active, _Game, _pvp, _PvPState
+from cogs.blackjack._state import (
+    BLACKJACK_PVP_ESCROW_SUBSYSTEM,
+    BLACKJACK_PVP_ESCROW_VERSION,
+    _active,
+    _Game,
+    _pvp,
+    _PvPState,
+)
 from core.runtime.interaction_helpers import safe_edit
-from services import economy_service
+from services import economy_service, game_wager_workflow
 from services.blackjack_engine import is_blackjack as _is_blackjack
 from utils.ui_constants import ECONOMY_COLOR, GAME_COLOR
 from views.base import handle_view_error as _on_view_error
@@ -108,6 +115,26 @@ async def _start_pvp(
     bet: int,
 ):
     channel = interaction.channel
+    # P0-1 (D1) — escrow both stakes before dealing.  If either player
+    # can no longer afford the stake, abort the match without dealing
+    # (the old flow dealt both hands then minted/short-paid at resolve).
+    if bet > 0:
+        try:
+            await game_wager_workflow.open_pvp_wager(
+                guild_id=guild_id,
+                channel_id=channel.id,
+                subsystem=BLACKJACK_PVP_ESCROW_SUBSYSTEM,
+                version=BLACKJACK_PVP_ESCROW_VERSION,
+                p1_id=p1.id,
+                p2_id=p2.id,
+                stake=bet,
+                reason="blackjack:pvp_escrow",
+            )
+        except economy_service.InsufficientFundsError:
+            await channel.send(  # type: ignore[union-attr]
+                f"❌ Match cancelled — both players need **{bet}** 🪙 to stake.",
+            )
+            return
     state = _PvPState(p1.id, p2.id, guild_id, bet, channel.id)
     key = frozenset({p1.id, p2.id})
     _pvp[key] = state
@@ -166,10 +193,9 @@ async def _start_pvp(
 async def _resolve_pvp(state: _PvPState, channel: discord.TextChannel):
     key = frozenset({state.p1, state.p2})
     _pvp.pop(key, None)
-    # PR G3 — match is fully resolved; drop the persisted row.
-    # Settlement-side credit/debit runs below regardless of the clear
-    # result, so a clear failure is non-fatal (the 24h game_state GC
-    # will sweep eventually).
+    # PR G3 — match is fully resolved; drop the persisted gameplay row.
+    # The escrow settle below is a separate, atomic transaction, so a
+    # clear failure here is non-fatal (the 24h game_state GC sweeps it).
     await _clear_pvp_match(state)
 
     v1 = state.results.get(state.p1, -1)
@@ -177,48 +203,45 @@ async def _resolve_pvp(state: _PvPState, channel: discord.TextChannel):
 
     if v1 == -1 and v2 == -1:
         result = "🤝 Both busted — tie! No coins exchanged."
-        coin_change = 0
         winner_id = None
     elif v1 == -1:
         winner_id = state.p2
         result = f"<@{state.p2}> wins (opponent busted)!"
-        coin_change = state.bet
     elif v2 == -1:
         winner_id = state.p1
         result = f"<@{state.p1}> wins (opponent busted)!"
-        coin_change = state.bet
     elif v1 > v2:
         winner_id = state.p1
         result = f"<@{state.p1}> wins with **{v1}** vs **{v2}**!"
-        coin_change = state.bet
     elif v2 > v1:
         winner_id = state.p2
         result = f"<@{state.p2}> wins with **{v2}** vs **{v1}**!"
-        coin_change = state.bet
     else:
         result = f"🤝 Tie — both had **{v1}**. No coins exchanged."
-        coin_change = 0
         winner_id = None
 
-    if coin_change and winner_id:
-        loser_id = state.p2 if winner_id == state.p1 else state.p1
-        payout = coin_change if coin_change else FREE_WIN_COINS
-        # Two-side payout: preserve prior add_coins floor-at-zero
-        # semantics for the loser (overdraft permitted). See the
-        # matching RPS PvP comment for the bet-escrow follow-up.
-        await economy_service.credit(
-            state.guild_id,
-            winner_id,
-            payout,
-            reason="blackjack:pvp_win",
-        )
-        await economy_service.debit(
-            state.guild_id,
-            loser_id,
-            payout,
-            reason="blackjack:pvp_loss",
-            allow_overdraft=True,
-        )
+    # P0-1 (D1) — stakes were escrowed at accept.  Pay the pot to the
+    # winner, or return both stakes on a tie, atomically + idempotently
+    # through the wager workflow (no mint window, no short-pay).
+    if state.bet > 0:
+        kwargs = {
+            "guild_id": state.guild_id,
+            "channel_id": state.channel_id,
+            "subsystem": BLACKJACK_PVP_ESCROW_SUBSYSTEM,
+            "p1_id": state.p1,
+            "p2_id": state.p2,
+        }
+        if winner_id:
+            await game_wager_workflow.settle_pvp(
+                **kwargs,
+                winner_id=winner_id,
+                reason="blackjack:pvp_win",
+            )
+        else:
+            await game_wager_workflow.refund_pvp(
+                **kwargs,
+                reason="blackjack:pvp_refund",
+            )
 
     embed = discord.Embed(
         title="🃏 Blackjack PvP Result",

--- a/disbot/views/blackjack/tournament_views.py
+++ b/disbot/views/blackjack/tournament_views.py
@@ -28,7 +28,7 @@ from cogs.blackjack._state import (
     _TournPlayerState,
 )
 from core.runtime import resources
-from services import economy_service, game_state_service, tournament_state_service
+from services import game_wager_workflow, tournament_state_service
 from services.blackjack_engine import hand_value as _hand_value
 from services.blackjack_engine import is_blackjack as _is_blackjack
 from utils.channels import cleanup_category
@@ -236,36 +236,41 @@ async def _check_tourn_done(tourn: _BjTournament, bot: commands.Bot):
         lines.append(f"{icon} **{name}** — {chips} chips")
 
     winner_id = ranking[0][0] if ranking else None
-    pot = tourn.pot
 
     embed = discord.Embed(
         title="🏆 Blackjack Tournament Results",
         description="\n".join(lines),
         color=ECONOMY_COLOR,
     )
-    if winner_id and pot:
-        new_bal = await economy_service.credit(
-            tourn.guild_id,
-            winner_id,
-            pot,
-            reason="blackjack:tournament_win",
-        )
+    # P0-1 — pay the winner the escrowed pot (the sum of the actual entry
+    # rows) and release those rows in ONE idempotent transaction.  This
+    # replaces the credit-then-separate-clear pair: a re-run finds no
+    # rows and cannot double-pay, and recovery cannot refund an
+    # already-settled tournament.
+    result = await game_wager_workflow.payout_tournament(
+        guild_id=tourn.guild_id,
+        subsystem=BLACKJACK_TOURNAMENT_SUBSYSTEM,
+        winner_id=winner_id,
+        reason="blackjack:tournament_win",
+        free_reward=200,
+        free_reason="blackjack:tournament_free_reward",
+    )
+    if result.paid and tourn.entry_fee > 0:
         embed.add_field(
             name="Winner's payout",
-            value=f"<@{winner_id}> receives **{pot}** 🪙 (Balance: {new_bal} 🪙)",
+            value=(
+                f"<@{winner_id}> receives **{result.amount}** 🪙 "
+                f"(Balance: {result.new_winner_balance} 🪙)"
+            ),
             inline=False,
         )
-    elif winner_id and not pot:
-        reward = 200
-        new_bal = await economy_service.credit(
-            tourn.guild_id,
-            winner_id,
-            reward,
-            reason="blackjack:tournament_free_reward",
-        )
+    elif result.paid:
         embed.add_field(
             name="Winner's reward",
-            value=f"<@{winner_id}> receives **{reward}** 🪙 (Balance: {new_bal} 🪙)",
+            value=(
+                f"<@{winner_id}> receives **{result.amount}** 🪙 "
+                f"(Balance: {result.new_winner_balance} 🪙)"
+            ),
             inline=False,
         )
 
@@ -275,33 +280,6 @@ async def _check_tourn_done(tourn: _BjTournament, bot: commands.Bot):
     # Clean up private channels
     if tourn.category:
         await cleanup_category(tourn.category)
-
-    # PR G5 — natural completion: clear the persisted entry-fee rows
-    # WITHOUT refunding (payouts above already settled the pot).  The
-    # cog_load recovery path is the ONLY one that refunds; clearing
-    # here prevents it from double-paying on the next restart.
-    try:
-        rows = await game_state_service.list_active_for_subsystem(
-            BLACKJACK_TOURNAMENT_SUBSYSTEM,
-            guild_id=tourn.guild_id,
-        )
-        for row in rows:
-            try:
-                await game_state_service.clear_by_id(row["id"])
-            except Exception as exc:
-                logger.warning(
-                    "blackjack_tournament natural-completion clear "
-                    "failed for id=%s: %s",
-                    row.get("id"),
-                    exc,
-                )
-    except Exception as exc:
-        logger.warning(
-            "blackjack_tournament natural-completion sweep failed for "
-            "guild=%d: %s — entries will be cleared by the 24 h GC sweep",
-            tourn.guild_id,
-            exc,
-        )
 
     _tournaments.pop(tourn.guild_id, None)
     await tournament_state_service.clear_active(tourn.guild_id)

--- a/disbot/views/rps/_helpers.py
+++ b/disbot/views/rps/_helpers.py
@@ -37,6 +37,15 @@ _rps_pvp_pending: dict[frozenset, dict] = {}
 RPS_PVP_PENDING_SUBSYSTEM = "rps_pvp_pending"
 RPS_PVP_PENDING_VERSION = 1
 
+# P0-1 — escrow subsystem for D1 escrow-at-accept.  One row PER player
+# (keyed at each player's own id, not the canonical surrogate) holding
+# ``{"bet": stake, "peer": other_id}``: per-player rows let the existing
+# ``bet``-keyed recovery (cog_load sweep + the 24 h GC) refund each
+# player their own stake without a two-party special case.  Money moves
+# only through ``services.game_wager_workflow``.
+RPS_PVP_ESCROW_SUBSYSTEM = "rps_pvp_escrow"
+RPS_PVP_ESCROW_VERSION = 1
+
 
 def rps_pvp_canonical_user_id(p1_id: int, p2_id: int) -> int:
     """The user_id used as the natural key for an rps_pvp_pending row.

--- a/disbot/views/rps/pvp_challenge.py
+++ b/disbot/views/rps/pvp_challenge.py
@@ -12,8 +12,10 @@ import logging
 import discord
 
 from core.runtime.interaction_helpers import safe_edit
-from services import game_state_service
+from services import economy_service, game_state_service, game_wager_workflow
 from views.rps._helpers import (
+    RPS_PVP_ESCROW_SUBSYSTEM,
+    RPS_PVP_ESCROW_VERSION,
     RPS_PVP_PENDING_SUBSYSTEM,
     RPS_PVP_PENDING_VERSION,
     _rps_pvp_pending,
@@ -65,6 +67,34 @@ class _RpsPvpChallengeView(discord.ui.View):
             view=self,
         ):
             return
+        # P0-1 (D1) — escrow both stakes the moment the challenge is
+        # accepted.  The pot leaves both wallets atomically here, so the
+        # loser cannot be short at settle (the old credit-then-overdraft-
+        # debit mint window is gone).  If either player can no longer
+        # afford the stake, abort before any move is picked.
+        if self.bet > 0:
+            try:
+                await game_wager_workflow.open_pvp_wager(
+                    guild_id=self.guild_id,
+                    channel_id=interaction.channel_id,
+                    subsystem=RPS_PVP_ESCROW_SUBSYSTEM,
+                    version=RPS_PVP_ESCROW_VERSION,
+                    p1_id=self.challenger.id,
+                    p2_id=self.opponent.id,
+                    stake=self.bet,
+                    reason="rps:pvp_escrow",
+                )
+            except economy_service.InsufficientFundsError:
+                await safe_edit(
+                    interaction,
+                    content=(
+                        "❌ Challenge cancelled — both players need "
+                        f"**{self.bet}** 🪙 to stake."
+                    ),
+                    view=self,
+                )
+                self.stop()
+                return
         key = frozenset({self.challenger.id, self.opponent.id})
         _rps_pvp_pending[key] = {
             "choices": {},

--- a/disbot/views/rps/pvp_play.py
+++ b/disbot/views/rps/pvp_play.py
@@ -3,7 +3,9 @@
 Sent to the channel once both players accept.  Each player clicks
 "Pick your move" → gets an ephemeral :class:`_RpsMovePickerView` →
 their choice is recorded back here.  When both picks land, the result
-is computed and payouts flow through :mod:`services.economy_service`.
+is computed and the escrowed pot is settled through
+:mod:`services.game_wager_workflow` (P0-1 — stakes were escrowed at
+challenge-accept time, so settle is atomic + idempotent).
 """
 
 from __future__ import annotations
@@ -12,10 +14,10 @@ import logging
 
 import discord
 
-from services import economy_service, game_state_service
+from services import game_state_service, game_wager_workflow
 from utils.ui_constants import GAME_COLOR, SUCCESS_COLOR
 from views.rps._helpers import (
-    _FREE_WIN,
+    RPS_PVP_ESCROW_SUBSYSTEM,
     RPS_PVP_PENDING_SUBSYSTEM,
     RPS_PVP_PENDING_VERSION,
     rps_pvp_canonical_user_id,
@@ -122,56 +124,57 @@ class _RpsPvpPlayView(discord.ui.View):
         e = {"rock": "🪨", "paper": "📄", "scissors": "✂️", "forfeit": "❌"}
 
         if m1 == "forfeit" and m2 == "forfeit":
-            result, coin_delta, winner_id = "🤝 Both forfeited.", 0, None
+            result, _, winner_id = "🤝 Both forfeited.", 0, None
         elif m1 == "forfeit":
-            result, coin_delta, winner_id = (
+            result, _, winner_id = (
                 f"{self.p2.mention} wins (opponent forfeited)!",
                 self.bet,
                 self.p2.id,
             )
         elif m2 == "forfeit":
-            result, coin_delta, winner_id = (
+            result, _, winner_id = (
                 f"{self.p1.mention} wins (opponent forfeited)!",
                 self.bet,
                 self.p1.id,
             )
         elif m1 == m2:
-            result, coin_delta, winner_id = "🤝 Tie! No coins exchanged.", 0, None
+            result, _, winner_id = "🤝 Tie! No coins exchanged.", 0, None
         elif _wins(m1, m2):
-            result, coin_delta, winner_id = (
+            result, _, winner_id = (
                 f"🎉 {self.p1.mention} wins!",
                 self.bet,
                 self.p1.id,
             )
         else:
-            result, coin_delta, winner_id = (
+            result, _, winner_id = (
                 f"🎉 {self.p2.mention} wins!",
                 self.bet,
                 self.p2.id,
             )
 
-        if coin_delta and winner_id:
-            loser_id = self.p2.id if winner_id == self.p1.id else self.p1.id
-            payout = coin_delta if coin_delta else _FREE_WIN
-            # Preserves prior semantics: winner always credited the full
-            # payout; loser debited down to floor-zero if short (overdraft
-            # allowed). Using economy_service.transfer would atomically
-            # reject the move on insufficient loser balance — that is the
-            # safer pattern but a behaviour change; revisit when game
-            # rules formalise bet escrow.
-            await economy_service.credit(
-                self.guild_id,
-                winner_id,
-                payout,
-                reason="rps:pvp_win",
-            )
-            await economy_service.debit(
-                self.guild_id,
-                loser_id,
-                payout,
-                reason="rps:pvp_loss",
-                allow_overdraft=True,
-            )
+        # P0-1 (D1) — the stakes were escrowed at accept.  Pay the pot to
+        # the winner, or return both stakes on a tie / double-forfeit.
+        # Both legs are atomic + idempotent inside the wager workflow, so
+        # no crash here can mint coins or leave the pot stranded.
+        if self.bet > 0:
+            kwargs = {
+                "guild_id": self.guild_id,
+                "channel_id": self.channel.id,
+                "subsystem": RPS_PVP_ESCROW_SUBSYSTEM,
+                "p1_id": self.p1.id,
+                "p2_id": self.p2.id,
+            }
+            if winner_id:
+                await game_wager_workflow.settle_pvp(
+                    **kwargs,
+                    winner_id=winner_id,
+                    reason="rps:pvp_win",
+                )
+            else:
+                await game_wager_workflow.refund_pvp(
+                    **kwargs,
+                    reason="rps:pvp_refund",
+                )
 
         embed = discord.Embed(
             title="✂️ RPS PvP Result",

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -56,6 +56,22 @@ Source code and merged PRs win over anything written here.
 > multiple of 10 — Q-0107; `scripts/check_reconciliation_due.py` flags it). Reset this
 > marker to the latest PR after a pass.
 
+- **#748 (2026-06-12, hardening P0-1 — wager money safety)** — new
+  `services/game_wager_workflow.py`: the audited money boundary for every two-party /
+  paid-entry game move, composing `economy_service.*_in_txn` inside one
+  `db.transaction()` (the mining_workflow precedent). **D1 escrow-at-accept** —
+  `open_pvp_wager` debits both stakes + writes per-player `*_escrow` rows when a PvP
+  challenge is accepted, deleting the old credit-then-overdraft-debit **mint window**;
+  `settle_pvp`/`refund_pvp`/`payout_tournament` are idempotent by `FOR UPDATE`
+  row-consumption (no double-pay); `enter_tournament` debits the fee + writes the
+  recovery row in one txn (closes the lost-fee window). All four call sites migrated
+  (RPS + blackjack PvP and tournament); dead un-escrowed `deduct_fees` removed; AST fence
+  (`test_game_wager_write_boundary`) bans `economy_service.credit/.debit` in the wager
+  files + `allow_overdraft=True` outside solo views. Failure-injection / terminal-matrix /
+  idempotency tests (real-Postgres integration + mock CI). No schema migration (escrow
+  rides existing `game_state`). Executes
+  [games-wager-money-safety-plan](planning/games-wager-money-safety-plan-2026-06-12.md);
+  **closes hardening P0-1** → next P0 track = P0-2.
 - **#745 (2026-06-12, the direction-lock round)** — owner question-panel round: **next
   implementation session = P0-1 wager money-safety** (design pinned:
   [games-wager-money-safety-plan](planning/games-wager-money-safety-plan-2026-06-12.md)) ·

--- a/docs/planning/games-wager-money-safety-plan-2026-06-12.md
+++ b/docs/planning/games-wager-money-safety-plan-2026-06-12.md
@@ -1,12 +1,16 @@
 # Games wager money-safety plan — P0-1 (2026-06-12)
 
-> **Status:** `plan` — the design for hardening track **P0-1** ([hardening
-> roadmap](production-readiness/hardening-roadmap-2026-06-12.md)). **Owner-picked as the
-> next implementation session** (2026-06-12, question panel — the same round that answered
-> Q-0097/Q-0082-interim/Q-0115). Evidence: the [games readiness
-> map](production-readiness/games-production-readiness-map-2026-06-12.md); claims below
-> re-verified against source 2026-06-12. One risky-runtime PR; ADR-002 (game state not
-> restart-safe) stays accepted — this plan fixes **money**, not game-state restartability.
+> **Status:** `historical` — **EXECUTED in PR #748 (2026-06-12).** Shipped the
+> `services/game_wager_workflow.py` service, D1 escrow-at-accept, all four call-site
+> migrations (RPS + blackjack PvP and tournament), the AST fence
+> (`test_game_wager_write_boundary`), and the failure-injection / idempotency /
+> terminal-matrix tests (real-Postgres integration + mock-based CI). The design below is
+> the as-built record. ADR-002 (game state not restart-safe) stays accepted — this fixed
+> **money**, not game-state restartability.
+>
+> _Original status:_ `plan` — the design for hardening track **P0-1** ([hardening
+> roadmap](production-readiness/hardening-roadmap-2026-06-12.md)), owner-picked 2026-06-12
+> (the question panel that answered Q-0097/Q-0082-interim/Q-0115).
 
 ## The defect class (source-verified)
 

--- a/docs/planning/production-readiness/hardening-roadmap-2026-06-12.md
+++ b/docs/planning/production-readiness/hardening-roadmap-2026-06-12.md
@@ -36,8 +36,13 @@ session". Tracks needing an owner decision name the routed Q-block.
 
 ## P0 — integrity (do before any public posture)
 
-### P0-1 · Games wager money-safety
-**Evidence:** [games map](games-production-readiness-map-2026-06-12.md) — RPS/blackjack PvP
+### P0-1 · Games wager money-safety  ·  ✅ **SHIPPED (PR #748, 2026-06-12)**
+**Done:** `services/game_wager_workflow.py` (D1 escrow-at-accept; atomic + idempotent settle/
+refund/payout; `enter_tournament` debit+row in one txn), all four call sites migrated, AST
+fence `test_game_wager_write_boundary`, failure-injection / terminal-matrix / idempotency
+tests. Record: [games-wager-money-safety-plan](../games-wager-money-safety-plan-2026-06-12.md).
+
+**Evidence (original):** [games map](games-production-readiness-map-2026-06-12.md) — RPS/blackjack PvP
 settle with sequential winner-credit + overdraft loser-debit (a crash between calls **mints
 coins**); paid tournament registration **debits before** writing a recovery checkpoint (a
 crash loses the fee with no row to refund — contra ADR-002); multi-call payouts/refunds have

--- a/docs/subsystems/games.md
+++ b/docs/subsystems/games.md
@@ -50,6 +50,19 @@ Start in `disbot/cogs/games_cog.py`, `disbot/views/games/`,
   **`utils/mining/`** — shared by the service, the cog, and the views. Economy is a
   dependency for bets/rewards, not a place for game cogs/views to duplicate balance
   writes.
+- **Wagered PvP + tournament money routes through `services/game_wager_workflow.py`**
+  (P0-1, PR #748): the same one-transaction-per-op seam as mining, for every two-party /
+  paid-entry coin move. **D1 escrow-at-accept** — PvP stakes leave both wallets atomically
+  with a per-player `*_escrow` `game_state` row when a challenge is accepted (`open_pvp_wager`),
+  so the loser can never be short at settle (the old credit-then-`allow_overdraft`-debit
+  **mint window** is gone). `settle_pvp` / `refund_pvp` / `payout_tournament` are idempotent
+  by `FOR UPDATE` row-consumption (replay = no-op, never double-pays); `enter_tournament`
+  debits the fee + writes the recovery row in one txn. Escrow/entry rows carry the `bet`
+  key, so the 24h `game_state` GC + `recover_escrow` (cog_load / on_guild_remove) refund any
+  stranded stake. AST-fenced by `tests/unit/invariants/test_game_wager_write_boundary.py`
+  (no `economy_service.credit/.debit` in the wager files; `allow_overdraft=True` solo-only).
+  **Solo** flows (single player vs the house) stay on `economy_service` directly — no
+  counterparty, no mint risk.
 - **Shared game-XP track: `services/game_xp_service.py`** (Wave 2 seed, 2026-06-10) —
   the second XP track (chat XP keeps driving auto-roles untouched): guild-scoped
   `game_xp` rows per game, central award policy (XP ≈ effort/risk; money moves award 0),

--- a/tests/unit/cogs/test_blackjack_tournament_persistence.py
+++ b/tests/unit/cogs/test_blackjack_tournament_persistence.py
@@ -1,19 +1,22 @@
-"""PR G5 — blackjack tournament persists per-player entry fees.
+"""PR G5 / P0-1 — blackjack tournament persists per-player entry fees.
 
-Tournaments are the highest-stakes path in the cog because
-``deduct_fees`` debits each player's entry_fee BEFORE any rounds run.
-A crash between fee deduction and the natural payout in
-``_check_tourn_done`` would otherwise leave the money in limbo
-forever.
+Tournaments are the highest-stakes path in the cog: each player's
+entry_fee is debited BEFORE any rounds run.  Since P0-1 the debit and
+the recovery row are written together by
+``services.game_wager_workflow.enter_tournament`` (one transaction), so
+a crash can no longer leave the money in limbo.
 
 The persistence design is per-player rows (one row per registered
 participant) — avoids the "sentinel user_id for guild-wide state"
 problem entirely.  Recovery refunds each row's ``bet`` (which equals
 the entry_fee) via ``economy_service.refund`` with a filterable
-reason, then deletes the row.
+reason, then deletes the row.  Natural completion is handled by
+``payout_tournament``: it credits the winner and deletes the rows in
+one idempotent transaction, so a replay cannot double-pay.
 
-Natural completion clears WITHOUT refund because the pot payout has
-already been credited; double-clearing would result in a double-pay.
+The ``_save_tournament_entry`` / ``_clear_tournament_entry`` helpers
+exercised below remain the row read/write primitives; P0-1 moved the
+*money* atomicity into ``enter_tournament`` / ``payout_tournament``.
 """
 
 from __future__ import annotations
@@ -136,8 +139,7 @@ async def test_recover_blackjack_tournament_refunds_each_row():
     # Every row was refunded with its bet amount.
     assert mock_refund.await_count == 3
     refunds = {
-        (c.kwargs["user_id"], c.kwargs["amount"])
-        for c in mock_refund.await_args_list
+        (c.kwargs["user_id"], c.kwargs["amount"]) for c in mock_refund.await_args_list
     }
     assert refunds == {(222, 100), (333, 50), (444, 200)}
     # Reason string is filterable in economy_audit_log.
@@ -275,8 +277,7 @@ async def test_on_guild_remove_refunds_tournament_entries_for_guild():
         await cog.on_guild_remove(guild)
     # Both tournament rows refunded with their bets.
     refunds = {
-        (c.kwargs["user_id"], c.kwargs["amount"])
-        for c in mock_refund.await_args_list
+        (c.kwargs["user_id"], c.kwargs["amount"]) for c in mock_refund.await_args_list
     }
     assert refunds == {(222, 100), (333, 50)}
     for c in mock_refund.await_args_list:

--- a/tests/unit/cogs/test_rps_pvp_pending_persistence.py
+++ b/tests/unit/cogs/test_rps_pvp_pending_persistence.py
@@ -36,7 +36,11 @@ def _row(id_, version=1, **kwargs):
         "updated_at": "2025-01-01",
     }
     base.update(
-        {k: v for k, v in kwargs.items() if k not in {"state", "guild_id", "user_id", "channel_id"}},
+        {
+            k: v
+            for k, v in kwargs.items()
+            if k not in {"state", "guild_id", "user_id", "channel_id"}
+        },
     )
     return base
 
@@ -89,11 +93,11 @@ async def test_record_choice_updates_persisted_state():
             new_callable=AsyncMock,
         ),
         patch(
-            "views.rps.pvp_play.economy_service.credit",
+            "views.rps.pvp_play.game_wager_workflow.settle_pvp",
             new_callable=AsyncMock,
         ),
         patch(
-            "views.rps.pvp_play.economy_service.debit",
+            "views.rps.pvp_play.game_wager_workflow.refund_pvp",
             new_callable=AsyncMock,
         ),
     ):
@@ -138,11 +142,11 @@ async def test_resolve_clears_persisted_state():
             new_callable=AsyncMock,
         ) as mock_clear,
         patch(
-            "views.rps.pvp_play.economy_service.credit",
+            "views.rps.pvp_play.game_wager_workflow.settle_pvp",
             new_callable=AsyncMock,
         ),
         patch(
-            "views.rps.pvp_play.economy_service.debit",
+            "views.rps.pvp_play.game_wager_workflow.refund_pvp",
             new_callable=AsyncMock,
         ),
     ):

--- a/tests/unit/invariants/test_game_wager_write_boundary.py
+++ b/tests/unit/invariants/test_game_wager_write_boundary.py
@@ -1,0 +1,117 @@
+"""P0-1 ratchet — wagered game money flows through game_wager_workflow.
+
+Two-party (PvP) and paid-entry (tournament) coin movement in the games
+stack must compose the atomic ``economy_service`` primitives **inside**
+``services.game_wager_workflow`` — never as a bare
+``economy_service.credit`` / ``.debit`` pair from a view or cog, which is
+the crash-window that minted coins (credit the winner, then a failure
+skips the loser's debit) or short-paid the loser via overdraft.
+
+Two checks, modelled on ``test_mining_write_boundary`` /
+``test_inv_f_economy_service``:
+
+1. The migrated PvP + tournament files may not call
+   ``economy_service.credit`` / ``.debit`` directly — wagered money moves
+   only through the workflow.  Recovery ``economy_service.refund`` (single
+   -sided, no mint risk) and the **solo** files (single player vs the
+   house — no second party to mint against) stay free; solo is explicitly
+   out of P0-1 scope.
+2. ``allow_overdraft=True`` — the exact mint/short-pay signature — is
+   forbidden anywhere under ``views/`` / ``cogs/`` except the two solo
+   game views, which floor a solo loss at zero with no counterparty.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DISBOT = _REPO_ROOT / "disbot"
+
+# The PvP + tournament money paths migrated in P0-1.  After migration
+# none of these may call economy_service.credit / .debit directly.
+_WAGER_FILES = (
+    _DISBOT / "views" / "rps" / "pvp_play.py",
+    _DISBOT / "views" / "rps" / "pvp_challenge.py",
+    _DISBOT / "views" / "blackjack" / "pvp_view.py",
+    _DISBOT / "views" / "blackjack" / "tournament_views.py",
+    _DISBOT / "cogs" / "rps_tournament_cog.py",
+    _DISBOT / "cogs" / "rps_tournament" / "_persistence.py",
+    _DISBOT / "cogs" / "blackjack" / "_persistence.py",
+)
+
+_FORBIDDEN_ATTRS = {"credit", "debit"}
+_ECONOMY_RECEIVERS = {"economy_service"}
+
+# Solo game views legitimately floor a single-player loss at zero — no
+# counterparty, so no mint risk.  Only these may pass allow_overdraft.
+_OVERDRAFT_ALLOWED = {
+    _DISBOT / "views" / "rps" / "solo_play.py",
+    _DISBOT / "views" / "blackjack" / "solo_view.py",
+}
+
+
+def _economy_credit_debit_calls(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    found: list[str] = []
+    for n in ast.walk(tree):
+        if not (isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)):
+            continue
+        if n.func.attr not in _FORBIDDEN_ATTRS:
+            continue
+        rcv = n.func.value
+        if isinstance(rcv, ast.Name) and rcv.id in _ECONOMY_RECEIVERS:
+            found.append(f"economy_service.{n.func.attr} (line {n.lineno})")
+    return found
+
+
+def _overdraft_calls(path: Path) -> list[int]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    lines: list[int] = []
+    for n in ast.walk(tree):
+        if not isinstance(n, ast.Call):
+            continue
+        for kw in n.keywords:
+            if (
+                kw.arg == "allow_overdraft"
+                and isinstance(kw.value, ast.Constant)
+                and kw.value.value is True
+            ):
+                lines.append(n.lineno)
+    return lines
+
+
+def test_no_direct_economy_credit_debit_in_wager_files():
+    """The PvP/tournament money paths route every wager through the workflow."""
+    violations: list[tuple[str, list[str]]] = []
+    for path in _WAGER_FILES:
+        assert path.exists(), f"wager-fence file list is stale: {path} is gone"
+        calls = _economy_credit_debit_calls(path)
+        if calls:
+            violations.append((str(path.relative_to(_REPO_ROOT)), calls))
+    assert not violations, (
+        "P0-1 violation: direct economy_service.credit/.debit in a wagered "
+        "game path — route the two-party/paid-entry money through "
+        "services.game_wager_workflow:\n"
+        + "\n".join(f"  {p}: {calls}" for p, calls in violations)
+    )
+
+
+def test_no_overdraft_outside_solo_game_views():
+    """``allow_overdraft=True`` is the mint signature — solo views only."""
+    violations: list[str] = []
+    for base in (_DISBOT / "views", _DISBOT / "cogs"):
+        for path in sorted(base.rglob("*.py")):
+            if "__pycache__" in path.parts or path in _OVERDRAFT_ALLOWED:
+                continue
+            for lineno in _overdraft_calls(path):
+                violations.append(
+                    f"{path.relative_to(_REPO_ROOT)}:{lineno}",
+                )
+    assert not violations, (
+        "P0-1 violation: allow_overdraft=True outside the solo game views "
+        "(the credit-then-overdraft-debit mint pattern). Two-party wagers "
+        "escrow at accept through services.game_wager_workflow:\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )

--- a/tests/unit/services/test_game_wager_workflow.py
+++ b/tests/unit/services/test_game_wager_workflow.py
@@ -1,0 +1,251 @@
+"""Unit (mock-the-pool) coverage for services.game_wager_workflow.
+
+The faithful transactional guarantees live in
+``test_game_wager_workflow_integration`` (real Postgres, skipped in CI).
+This suite mocks the DB seam so CI — which runs no Postgres — still
+exercises the orchestration: which primitives each op composes, the
+idempotent no-op when the escrow rows are gone, and the pot-vs-free
+payout branch.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services import economy_service
+from services import game_wager_workflow as wf
+
+
+@pytest.fixture
+def fake_db(monkeypatch):
+    """Patch the workflow's DB seam: transaction, economy + game_state legs."""
+    conn = object()
+
+    @asynccontextmanager
+    async def fake_txn():
+        yield conn
+
+    monkeypatch.setattr(wf.db, "transaction", fake_txn)
+    monkeypatch.setattr(wf.db, "get_coins", AsyncMock(return_value=0))
+    debit = AsyncMock(return_value=60)
+    credit = AsyncMock(return_value=140)
+    save = AsyncMock()
+    clear = AsyncMock()
+    monkeypatch.setattr(economy_service, "debit_in_txn", debit)
+    monkeypatch.setattr(economy_service, "credit_in_txn", credit)
+    monkeypatch.setattr(wf.game_state_service, "save", save)
+    monkeypatch.setattr(wf.game_state_service, "clear", clear)
+    monkeypatch.setattr(wf.bus, "emit", AsyncMock())
+    return {
+        "conn": conn,
+        "debit": debit,
+        "credit": credit,
+        "save": save,
+        "clear": clear,
+    }
+
+
+@pytest.mark.asyncio
+async def test_open_pvp_wager_debits_both_and_writes_two_rows(fake_db):
+    res = await wf.open_pvp_wager(
+        guild_id=1,
+        channel_id=2,
+        subsystem="s",
+        version=1,
+        p1_id=10,
+        p2_id=20,
+        stake=40,
+        reason="r",
+    )
+    assert res.escrowed and res.stake == 40
+    assert fake_db["debit"].await_count == 2
+    assert fake_db["save"].await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_open_pvp_wager_free_is_noop(fake_db):
+    res = await wf.open_pvp_wager(
+        guild_id=1,
+        channel_id=2,
+        subsystem="s",
+        version=1,
+        p1_id=10,
+        p2_id=20,
+        stake=0,
+        reason="r",
+    )
+    assert not res.escrowed
+    fake_db["debit"].assert_not_called()
+    fake_db["save"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_settle_pvp_credits_pot(fake_db, monkeypatch):
+    monkeypatch.setattr(
+        wf.game_state_service,
+        "fetch_rows_for_update",
+        AsyncMock(
+            return_value=[
+                {"user_id": 10, "channel_id": 2, "state": {"bet": 40}},
+                {"user_id": 20, "channel_id": 2, "state": {"bet": 40}},
+            ]
+        ),
+    )
+    res = await wf.settle_pvp(
+        guild_id=1,
+        channel_id=2,
+        subsystem="s",
+        p1_id=10,
+        p2_id=20,
+        winner_id=10,
+        reason="r",
+    )
+    assert res.paid and res.amount == 80
+    fake_db["credit"].assert_awaited_once()
+    assert fake_db["credit"].await_args.args[3] == 80  # pot
+    assert fake_db["clear"].await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_settle_pvp_idempotent_when_rows_gone(fake_db, monkeypatch):
+    monkeypatch.setattr(
+        wf.game_state_service,
+        "fetch_rows_for_update",
+        AsyncMock(return_value=[]),
+    )
+    res = await wf.settle_pvp(
+        guild_id=1,
+        channel_id=2,
+        subsystem="s",
+        p1_id=10,
+        p2_id=20,
+        winner_id=10,
+        reason="r",
+    )
+    assert not res.paid and res.amount == 0
+    fake_db["credit"].assert_not_called()
+    fake_db["clear"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refund_pvp_credits_each_own_stake(fake_db, monkeypatch):
+    monkeypatch.setattr(
+        wf.game_state_service,
+        "fetch_rows_for_update",
+        AsyncMock(
+            return_value=[
+                {"user_id": 10, "channel_id": 2, "state": {"bet": 40}},
+                {"user_id": 20, "channel_id": 2, "state": {"bet": 25}},
+            ]
+        ),
+    )
+    res = await wf.refund_pvp(
+        guild_id=1,
+        channel_id=2,
+        subsystem="s",
+        p1_id=10,
+        p2_id=20,
+        reason="r",
+    )
+    assert res.paid and res.amount == 65
+    assert fake_db["credit"].await_count == 2
+    assert fake_db["clear"].await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_enter_tournament_debits_and_saves(fake_db):
+    bal = await wf.enter_tournament(
+        guild_id=1,
+        user_id=10,
+        channel_id=0,
+        subsystem="t",
+        version=1,
+        fee=30,
+        reason="r",
+        extra_state={"rounds": 5},
+    )
+    assert bal == 60
+    fake_db["debit"].assert_awaited_once()
+    saved_state = fake_db["save"].await_args.args[4]
+    assert saved_state == {"bet": 30, "rounds": 5}
+
+
+@pytest.mark.asyncio
+async def test_enter_tournament_free_skips_debit(fake_db):
+    bal = await wf.enter_tournament(
+        guild_id=1,
+        user_id=10,
+        channel_id=0,
+        subsystem="t",
+        version=1,
+        fee=0,
+        reason="r",
+    )
+    assert bal == 0  # db.get_coins stub
+    fake_db["debit"].assert_not_called()
+    fake_db["save"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_payout_tournament_pot_path(fake_db, monkeypatch):
+    monkeypatch.setattr(
+        wf.game_state_service,
+        "fetch_rows_for_update",
+        AsyncMock(
+            return_value=[
+                {"user_id": 10, "channel_id": 0, "state": {"bet": 30}},
+                {"user_id": 20, "channel_id": 0, "state": {"bet": 30}},
+            ]
+        ),
+    )
+    res = await wf.payout_tournament(
+        guild_id=1,
+        subsystem="t",
+        winner_id=10,
+        reason="win",
+        free_reward=200,
+        free_reason="free",
+    )
+    assert res.paid and res.amount == 60
+    assert fake_db["credit"].await_args.args[3] == 60
+    assert fake_db["clear"].await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_payout_tournament_free_path(fake_db, monkeypatch):
+    monkeypatch.setattr(
+        wf.game_state_service,
+        "fetch_rows_for_update",
+        AsyncMock(return_value=[]),
+    )
+    res = await wf.payout_tournament(
+        guild_id=1,
+        subsystem="t",
+        winner_id=10,
+        reason="win",
+        free_reward=200,
+        free_reason="free",
+    )
+    assert res.paid and res.amount == 200
+    assert fake_db["credit"].await_args.args[3] == 200
+    fake_db["clear"].assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_payout_tournament_idempotent_no_rows_no_reward(fake_db, monkeypatch):
+    monkeypatch.setattr(
+        wf.game_state_service,
+        "fetch_rows_for_update",
+        AsyncMock(return_value=[]),
+    )
+    res = await wf.payout_tournament(
+        guild_id=1,
+        subsystem="t",
+        winner_id=10,
+        reason="win",
+    )
+    assert not res.paid
+    fake_db["credit"].assert_not_called()

--- a/tests/unit/services/test_game_wager_workflow_integration.py
+++ b/tests/unit/services/test_game_wager_workflow_integration.py
@@ -1,0 +1,472 @@
+"""Real-Postgres integration for services.game_wager_workflow (P0-1).
+
+The whole point of the wager workflow is *transactional* money movement:
+escrow both PvP stakes (or a tournament fee) atomically with the recovery
+row, settle/refund/payout atomically with the row deletion, and stay
+idempotent under replay.  A mock-the-pool test cannot prove that — a
+rollback only means something against a real transaction.  So this suite
+drives the workflow against a live database (schema + migrations applied
+by ``pool.init()``) and asserts the three guarantees the plan names:
+
+1. **Failure injection** — a fault between compose steps leaves *no*
+   partial money movement (balances and escrow rows both untouched).
+2. **Terminal-state matrix** — win / tie / refund / tournament payout
+   move exactly the right coins and leave no escrow rows.
+3. **Idempotency** — a second settle / payout is a no-op (never
+   double-pays), even after a crash-retry.
+
+CI safety / isolation mirrors ``test_health_findings_integration``: the
+module-local ``wager_db`` fixture skips when ``DATABASE_URL`` is unset
+(CI) or Postgres is unreachable, and every row this suite writes lives in
+a private guild-id band that it sweeps on entry + exit, so a booted bot's
+own rows are never disturbed.  Count/balance assertions are absolute only
+within that private band.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from services import economy_service, game_wager_workflow
+from utils import db
+from utils.db import pool
+
+# Private guild-id band — far from any real Discord snowflake the booted
+# bot would use, so this suite never collides with live rows.
+_GUILD_BASE = 990_000_000_000_000_000
+_SUB = "test_wager_escrow"
+_TSUB = "test_wager_tournament"
+
+
+async def _sweep() -> None:
+    await pool.execute(
+        "DELETE FROM game_state WHERE guild_id >= $1",
+        (_GUILD_BASE,),
+    )
+    await pool.execute(
+        "DELETE FROM xp WHERE guild_id >= $1",
+        (_GUILD_BASE,),
+    )
+    await pool.execute(
+        "DELETE FROM economy_audit_log WHERE guild_id >= $1",
+        (_GUILD_BASE,),
+    )
+
+
+@pytest_asyncio.fixture
+async def wager_db():
+    if not os.environ.get("DATABASE_URL"):
+        pytest.skip("DATABASE_URL unset — real-Postgres integration test skipped (CI)")
+    try:
+        await pool.init()
+    except (OSError, asyncpg.PostgresError) as exc:
+        pytest.skip(
+            f"Postgres unreachable ({type(exc).__name__}) — integration test skipped",
+        )
+    await _sweep()
+    try:
+        yield pool
+    finally:
+        await _sweep()
+        await pool.close()
+
+
+# Unique guild id per test so parallel rows never clash within the band.
+_counter = 0
+
+
+def _next_guild() -> int:
+    global _counter
+    _counter += 1
+    return _GUILD_BASE + _counter
+
+
+async def _set_balance(guild_id: int, user_id: int, coins: int) -> None:
+    await db.add_coins(user_id, guild_id, coins)
+
+
+async def _balance(guild_id: int, user_id: int) -> int:
+    return await db.get_coins(user_id, guild_id)
+
+
+async def _escrow_rows(guild_id: int, subsystem: str) -> list[dict]:
+    rows = await pool.fetchall(
+        "SELECT user_id, state FROM game_state WHERE guild_id=$1 AND subsystem=$2",
+        (guild_id, subsystem),
+    )
+    for r in rows:
+        if isinstance(r["state"], str):
+            r["state"] = json.loads(r["state"])
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# PvP — escrow at accept
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_pvp_wager_escrows_both_stakes_atomically(wager_db):
+    g, p1, p2 = _next_guild(), 1, 2
+    await _set_balance(g, p1, 100)
+    await _set_balance(g, p2, 100)
+
+    res = await game_wager_workflow.open_pvp_wager(
+        guild_id=g,
+        channel_id=5,
+        subsystem=_SUB,
+        version=1,
+        p1_id=p1,
+        p2_id=p2,
+        stake=40,
+        reason="t:escrow",
+    )
+    assert res.escrowed and res.stake == 40
+    assert await _balance(g, p1) == 60
+    assert await _balance(g, p2) == 60
+    rows = await _escrow_rows(g, _SUB)
+    assert {r["user_id"] for r in rows} == {p1, p2}
+
+
+@pytest.mark.asyncio
+async def test_open_pvp_wager_insufficient_funds_rolls_back(wager_db):
+    """If the second player cannot afford the stake, the first player's
+    debit AND both escrow rows roll back — no partial escrow.
+    """
+    g, p1, p2 = _next_guild(), 1, 2
+    await _set_balance(g, p1, 100)
+    await _set_balance(g, p2, 10)  # cannot afford 40
+
+    with pytest.raises(economy_service.InsufficientFundsError):
+        await game_wager_workflow.open_pvp_wager(
+            guild_id=g,
+            channel_id=5,
+            subsystem=_SUB,
+            version=1,
+            p1_id=p1,
+            p2_id=p2,
+            stake=40,
+            reason="t:escrow",
+        )
+    # No money moved, no rows written.
+    assert await _balance(g, p1) == 100
+    assert await _balance(g, p2) == 10
+    assert await _escrow_rows(g, _SUB) == []
+
+
+@pytest.mark.asyncio
+async def test_open_pvp_wager_fault_between_legs_leaves_nothing(wager_db, monkeypatch):
+    """A fault injected after the first debit rolls the whole escrow back."""
+    g, p1, p2 = _next_guild(), 1, 2
+    await _set_balance(g, p1, 100)
+    await _set_balance(g, p2, 100)
+
+    real_save = game_wager_workflow.game_state_service.save
+    calls = {"n": 0}
+
+    async def boom_on_second_save(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise RuntimeError("injected fault mid-escrow")
+        return await real_save(*args, **kwargs)
+
+    monkeypatch.setattr(
+        game_wager_workflow.game_state_service,
+        "save",
+        boom_on_second_save,
+    )
+    with pytest.raises(RuntimeError, match="injected fault"):
+        await game_wager_workflow.open_pvp_wager(
+            guild_id=g,
+            channel_id=5,
+            subsystem=_SUB,
+            version=1,
+            p1_id=p1,
+            p2_id=p2,
+            stake=40,
+            reason="t:escrow",
+        )
+    # Both debits rolled back with the failed row write.
+    assert await _balance(g, p1) == 100
+    assert await _balance(g, p2) == 100
+    assert await _escrow_rows(g, _SUB) == []
+
+
+# ---------------------------------------------------------------------------
+# PvP — settle / refund (terminal matrix + idempotency)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_settle_pvp_pays_pot_to_winner_and_is_idempotent(wager_db):
+    g, p1, p2 = _next_guild(), 1, 2
+    await _set_balance(g, p1, 100)
+    await _set_balance(g, p2, 100)
+    await game_wager_workflow.open_pvp_wager(
+        guild_id=g,
+        channel_id=5,
+        subsystem=_SUB,
+        version=1,
+        p1_id=p1,
+        p2_id=p2,
+        stake=40,
+        reason="t:escrow",
+    )
+    res = await game_wager_workflow.settle_pvp(
+        guild_id=g,
+        channel_id=5,
+        subsystem=_SUB,
+        p1_id=p1,
+        p2_id=p2,
+        winner_id=p1,
+        reason="t:win",
+    )
+    assert res.paid and res.amount == 80
+    assert await _balance(g, p1) == 140  # 60 + 80 pot
+    assert await _balance(g, p2) == 60  # stayed escrowed-out
+    assert await _escrow_rows(g, _SUB) == []
+
+    # Idempotent replay: no rows left → no-op, no double pay.
+    again = await game_wager_workflow.settle_pvp(
+        guild_id=g,
+        channel_id=5,
+        subsystem=_SUB,
+        p1_id=p1,
+        p2_id=p2,
+        winner_id=p1,
+        reason="t:win",
+    )
+    assert not again.paid and again.amount == 0
+    assert await _balance(g, p1) == 140
+
+
+@pytest.mark.asyncio
+async def test_refund_pvp_returns_each_own_stake_and_is_idempotent(wager_db):
+    g, p1, p2 = _next_guild(), 1, 2
+    await _set_balance(g, p1, 100)
+    await _set_balance(g, p2, 100)
+    await game_wager_workflow.open_pvp_wager(
+        guild_id=g,
+        channel_id=5,
+        subsystem=_SUB,
+        version=1,
+        p1_id=p1,
+        p2_id=p2,
+        stake=40,
+        reason="t:escrow",
+    )
+    res = await game_wager_workflow.refund_pvp(
+        guild_id=g,
+        channel_id=5,
+        subsystem=_SUB,
+        p1_id=p1,
+        p2_id=p2,
+        reason="t:refund",
+    )
+    assert res.paid and res.amount == 80
+    assert await _balance(g, p1) == 100  # made whole
+    assert await _balance(g, p2) == 100
+    assert await _escrow_rows(g, _SUB) == []
+
+    again = await game_wager_workflow.refund_pvp(
+        guild_id=g,
+        channel_id=5,
+        subsystem=_SUB,
+        p1_id=p1,
+        p2_id=p2,
+        reason="t:refund",
+    )
+    assert not again.paid
+    assert await _balance(g, p1) == 100
+
+
+@pytest.mark.asyncio
+async def test_settle_pvp_fault_does_not_mint_or_strand(wager_db, monkeypatch):
+    """A fault during settle leaves the pot escrowed (rows intact, winner
+    not credited) — the opposite of the pre-P0-1 mint window.
+    """
+    g, p1, p2 = _next_guild(), 1, 2
+    await _set_balance(g, p1, 100)
+    await _set_balance(g, p2, 100)
+    await game_wager_workflow.open_pvp_wager(
+        guild_id=g,
+        channel_id=5,
+        subsystem=_SUB,
+        version=1,
+        p1_id=p1,
+        p2_id=p2,
+        stake=40,
+        reason="t:escrow",
+    )
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("injected fault during clear")
+
+    monkeypatch.setattr(game_wager_workflow.game_state_service, "clear", boom)
+    with pytest.raises(RuntimeError, match="injected fault"):
+        await game_wager_workflow.settle_pvp(
+            guild_id=g,
+            channel_id=5,
+            subsystem=_SUB,
+            p1_id=p1,
+            p2_id=p2,
+            winner_id=p1,
+            reason="t:win",
+        )
+    # Winner credit rolled back with the failed row delete; pot still escrowed.
+    assert await _balance(g, p1) == 60
+    rows = await _escrow_rows(g, _SUB)
+    assert {r["user_id"] for r in rows} == {p1, p2}
+
+
+# ---------------------------------------------------------------------------
+# Tournament — entry + payout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enter_tournament_debits_and_writes_row_atomically(wager_db):
+    g, u = _next_guild(), 1
+    await _set_balance(g, u, 100)
+    bal = await game_wager_workflow.enter_tournament(
+        guild_id=g,
+        user_id=u,
+        channel_id=0,
+        subsystem=_TSUB,
+        version=1,
+        fee=30,
+        reason="t:entry",
+        extra_state={"rounds": 5},
+    )
+    assert bal == 70
+    rows = await _escrow_rows(g, _TSUB)
+    assert len(rows) == 1
+    assert rows[0]["state"]["bet"] == 30
+    assert rows[0]["state"]["rounds"] == 5
+
+
+@pytest.mark.asyncio
+async def test_enter_tournament_insufficient_rolls_back(wager_db):
+    g, u = _next_guild(), 1
+    await _set_balance(g, u, 10)
+    with pytest.raises(economy_service.InsufficientFundsError):
+        await game_wager_workflow.enter_tournament(
+            guild_id=g,
+            user_id=u,
+            channel_id=0,
+            subsystem=_TSUB,
+            version=1,
+            fee=30,
+            reason="t:entry",
+        )
+    assert await _balance(g, u) == 10
+    assert await _escrow_rows(g, _TSUB) == []
+
+
+@pytest.mark.asyncio
+async def test_payout_tournament_pays_pot_and_is_idempotent(wager_db):
+    g, w, loser = _next_guild(), 1, 2
+    await _set_balance(g, w, 100)
+    await _set_balance(g, loser, 100)
+    await game_wager_workflow.enter_tournament(
+        guild_id=g,
+        user_id=w,
+        channel_id=0,
+        subsystem=_TSUB,
+        version=1,
+        fee=30,
+        reason="t:entry",
+    )
+    await game_wager_workflow.enter_tournament(
+        guild_id=g,
+        user_id=loser,
+        channel_id=0,
+        subsystem=_TSUB,
+        version=1,
+        fee=30,
+        reason="t:entry",
+    )
+    res = await game_wager_workflow.payout_tournament(
+        guild_id=g,
+        subsystem=_TSUB,
+        winner_id=w,
+        reason="t:win",
+    )
+    assert res.paid and res.amount == 60  # pot = sum of the two entries
+    assert await _balance(g, w) == 130  # 70 + 60
+    assert await _escrow_rows(g, _TSUB) == []
+
+    # Replay: rows consumed → no-op, no double pay.
+    again = await game_wager_workflow.payout_tournament(
+        guild_id=g,
+        subsystem=_TSUB,
+        winner_id=w,
+        reason="t:win",
+    )
+    assert not again.paid
+    assert await _balance(g, w) == 130
+
+
+@pytest.mark.asyncio
+async def test_payout_tournament_free_reward_when_no_entries(wager_db):
+    g, w = _next_guild(), 1
+    await _set_balance(g, w, 100)
+    res = await game_wager_workflow.payout_tournament(
+        guild_id=g,
+        subsystem=_TSUB,
+        winner_id=w,
+        reason="t:win",
+        free_reward=200,
+        free_reason="t:free",
+    )
+    assert res.paid and res.amount == 200
+    assert await _balance(g, w) == 300
+
+
+@pytest.mark.asyncio
+async def test_payout_tournament_no_winner_is_noop(wager_db):
+    g = _next_guild()
+    res = await game_wager_workflow.payout_tournament(
+        guild_id=g,
+        subsystem=_TSUB,
+        winner_id=None,
+        reason="t:win",
+        free_reward=200,
+        free_reason="t:free",
+    )
+    assert not res.paid
+
+
+@pytest.mark.asyncio
+async def test_free_pvp_wager_moves_no_money(wager_db):
+    g, p1, p2 = _next_guild(), 1, 2
+    await _set_balance(g, p1, 100)
+    await _set_balance(g, p2, 100)
+    res = await game_wager_workflow.open_pvp_wager(
+        guild_id=g,
+        channel_id=5,
+        subsystem=_SUB,
+        version=1,
+        p1_id=p1,
+        p2_id=p2,
+        stake=0,
+        reason="t:escrow",
+    )
+    assert not res.escrowed
+    assert await _escrow_rows(g, _SUB) == []
+    settle = await game_wager_workflow.settle_pvp(
+        guild_id=g,
+        channel_id=5,
+        subsystem=_SUB,
+        p1_id=p1,
+        p2_id=p2,
+        winner_id=p1,
+        reason="t:win",
+    )
+    assert not settle.paid
+    assert await _balance(g, p1) == 100


### PR DESCRIPTION
Executes [`docs/planning/games-wager-money-safety-plan-2026-06-12.md`](docs/planning/games-wager-money-safety-plan-2026-06-12.md) (hardening track P0-1, owner-approved 2026-06-12 via PR #745). **D1 escrow-at-accept** is the approved default.

## The defect (source-verified)
Wagered-game money moved through **two separate top-level economy calls**, so a crash between them could:
- **mint coins** — RPS / blackjack PvP settle did `credit(winner)` then `debit(loser, allow_overdraft=True)`; a failure between them credits the winner with no matching debit, and overdraft let the loser short-pay (floor-zero).
- **lose an entry fee** — RPS / blackjack tournament entry debited the fee, then wrote the checkpoint row recovery refunds from in a *separate* call; a crash in the window lost the fee with nothing to refund.

## The fix
New `services/game_wager_workflow.py` — the audited money boundary for every two-party / paid-entry game move, composing the existing atomic `economy_service.*_in_txn` primitives inside one `db.transaction()` (the `services/mining_workflow` precedent).

| Op | Transactionally |
|---|---|
| `open_pvp_wager` | escrow-debit **both** players + write one `*_escrow` recovery row per player — at challenge **accept** (D1) |
| `settle_pvp` | pay the escrowed pot to the winner + release the rows — idempotent by `FOR UPDATE` row-consumption |
| `refund_pvp` | return each player's own stake + release — idempotent (tie / forfeit / abort) |
| `enter_tournament` | fee debit **+** entry row in one txn (closes the lost-fee window) |
| `payout_tournament` | pay the winner the escrowed pot **+** delete the entry rows — idempotent, never double-pays |
| `recover_escrow` | refund stranded stakes promptly at cog_load / on_guild_remove |

**D1 escrow-at-accept** deletes the overdraft semantics outright: stakes leave both wallets atomically when the challenge is accepted, so the loser *cannot* be short at settle. If either player can't afford the stake, the match aborts before any hand is dealt (the one product-visible change).

Escrow / entry rows ride the existing `game_state` table (new `*_escrow` subsystems — **no schema migration**) and carry the per-player `bet` key, so the existing 24h `game_state` GC sweep already refunds any stranded row; `recover_escrow` just does it sooner.

## Migrations (4 call sites + the 2 accept paths)
- RPS PvP — escrow at accept (`pvp_challenge`), settle/refund at resolve (`pvp_play`)
- Blackjack PvP — escrow at accept (`pvp_view._start_pvp`), settle/refund at resolve (`_resolve_pvp`)
- RPS tournament — `enter_tournament` at registration, `payout_tournament` at completion
- Blackjack tournament — `enter_tournament` at launch, `payout_tournament` at completion
- Removed the now-dead un-escrowed `deduct_fees` batch debit.

## The "stays fixed" layer
- **AST fence** (`tests/unit/invariants/test_game_wager_write_boundary.py`): no `economy_service.credit/.debit` in the migrated wager files, and no `allow_overdraft=True` outside the two solo game views (the mint signature). Solo (single player vs the house) stays out of P0-1 scope.
- **Failure-injection + terminal-matrix + idempotency** tests against **real Postgres** (`test_game_wager_workflow_integration`, skips cleanly in CI) — a fault between compose steps leaves *no* partial money movement; a replayed settle/payout is a no-op. Plus mock-based unit coverage for CI.

## Verification
- `check_quality.py --full`: black / isort / ruff / mypy + **9144 passed, 3 skipped** ✓
- `check_architecture.py --mode strict`: **0 errors** ✓
- 12 real-Postgres integration tests pass (failure injection / idempotency / terminal matrix) ✓
- Live boot: both modified cogs load clean, escrow-recovery cog_load tasks run without error ✓

ADR-002 (game state not restart-safe) stays accepted — this fixes **money**, not game-state restartability.

https://claude.ai/code/session_01WaMFMf4Upt7UaAv2JE8M1S

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaMFMf4Upt7UaAv2JE8M1S)_