### PR TITLE
docs(hermes): wire superbot-dispatch to the verified Routines /fire API

### DIFF
--- a/docs/operations/hermes-dispatch-bridge.md
+++ b/docs/operations/hermes-dispatch-bridge.md
@@ -40,20 +40,25 @@ idea / nightly diagnosis
   trigger enabled. prompt = the saved prompt below · repo = `menno420/superbot` · environment
   network policy scoped tight · branch-push setting left at the default **`claude/`-only** ·
   API trigger enabled (you get a per-routine `/fire` URL + bearer token).
-- ⬜ **Store the secrets on the VPS** for the `hermes` user (never commit them):
+- ✅ **Store the secrets on the VPS** for the `hermes` user (never commit them). The
+  `superbot-dispatch` skill sources `~/.hermes/routine.env`, so put them there (chmod 600):
   ```bash
-  # ~/.hermes/.env  (or the VPS secret store the gateway loads)
-  CLAUDE_ROUTINE_FIRE_URL="https://…/routines/<id>/fire"
-  CLAUDE_ROUTINE_TOKEN="<bearer token>"
-  CLAUDE_ROUTINE_BETA="<the dated routines beta header value from the docs>"
+  # ~/.hermes/routine.env  (verified Routines /fire shape, 2026-06-12)
+  CLAUDE_ROUTINE_FIRE_URL="https://api.anthropic.com/v1/claude_code/routines/<trig_id>/fire"
+  CLAUDE_ROUTINE_TOKEN="sk-ant-oat01-…"          # the per-routine bearer token (shown once)
+  CLAUDE_ROUTINE_BETA="experimental-cc-routine-2026-04-01"
+  CLAUDE_ROUTINE_VERSION="2023-06-01"
   ```
+  Then `chmod 600 ~/.hermes/routine.env`. (The token is shown once at generation — regenerate
+  from the routine's API-trigger modal if lost.)
 - ⬜ **Install the skills** so Hermes can dispatch:
   ```bash
   bash scripts/hermes/install-skills.sh && sudo systemctl restart hermes-gateway
   ```
-- ⬜ **Calibrate before trusting (Q-0105):** dispatch a *known, tiny* fix first and confirm the
-  routine opened the PR, CI ran, and the merge gate behaved (self-merged a docs fix; held a
-  fake "feature" for approval). Only then let nightly diagnoses dispatch unattended.
+- ✅ **Calibrate before trusting (Q-0105):** DONE 2026-06-12 — a connectivity test (fire →
+  clone → read-only, no changes) and a first real run (PR #747: a minimal docs edit, held open
+  for review per the work order, CI green) both passed; the routine respected the work-order
+  instructions precisely. Self-merge-on-green and the daily schedule are the earned next steps.
 
 ## The routine's saved prompt (paste into the routine config)
 

--- a/docs/operations/hermes-skills/dispatch.md
+++ b/docs/operations/hermes-skills/dispatch.md
@@ -54,14 +54,19 @@ STEP 3 — ASSEMBLE THE WORK ORDER (the `text` payload). Keep it tight and self-
 STEP 4 — GATE + DISPATCH:
   - SHOW me the assembled work order and the exact curl first. Wait for my "go" unless I
     already said "dispatch it" in this conversation.
-  - Fire it (token from the VPS secret store; never print the token):
+  - Load the routine secrets, then fire (never print the token). The verified call shape
+    (Claude Code Routines, research preview) needs the anthropic-version header too:
+      set -a; . "$HOME/.hermes/routine.env" 2>/dev/null; set +a
       curl -sS -X POST "$CLAUDE_ROUTINE_FIRE_URL" \
         -H "Authorization: Bearer $CLAUDE_ROUTINE_TOKEN" \
         -H "anthropic-beta: $CLAUDE_ROUTINE_BETA" \
+        -H "anthropic-version: $CLAUDE_ROUTINE_VERSION" \
         -H "Content-Type: application/json" \
-        -d "$(jq -nc --arg t "$WORK_ORDER" '{text:$t}')"
-  - If $CLAUDE_ROUTINE_TOKEN is unset, DO NOT fire — print the work order + curl and tell me
-    to set up the bridge (hermes-dispatch-bridge.md) or paste the order into a session myself.
+        -d "$(python3 -c 'import json,sys; print(json.dumps({"text": sys.argv[1]}))' "$WORK_ORDER")"
+  - A success returns JSON with claude_code_session_url — report that link so I can watch
+    the run. If CLAUDE_ROUTINE_TOKEN is unset (no ~/.hermes/routine.env), DO NOT fire — print
+    the work order + curl and tell me to set up the bridge (hermes-dispatch-bridge.md) or
+    paste the order into a session myself.
 
 STEP 5 — REPORT: confirm the fire response (run id / status). Tell me the routine will open a
   claude/ PR; offer to watch it with `superbot-repo-health` / `log-triage` and to review it

--- a/scripts/hermes/skills/dispatch/SKILL.md
+++ b/scripts/hermes/skills/dispatch/SKILL.md
@@ -43,14 +43,19 @@ STEP 3 — ASSEMBLE THE WORK ORDER (the `text` payload). Keep it tight and self-
 STEP 4 — GATE + DISPATCH:
   - SHOW me the assembled work order and the exact curl first. Wait for my "go" unless I
     already said "dispatch it" in this conversation.
-  - Fire it (token from the VPS secret store; never print the token):
+  - Load the routine secrets, then fire (never print the token). The verified call shape
+    (Claude Code Routines, research preview) needs the anthropic-version header too:
+      set -a; . "$HOME/.hermes/routine.env" 2>/dev/null; set +a
       curl -sS -X POST "$CLAUDE_ROUTINE_FIRE_URL" \
         -H "Authorization: Bearer $CLAUDE_ROUTINE_TOKEN" \
         -H "anthropic-beta: $CLAUDE_ROUTINE_BETA" \
+        -H "anthropic-version: $CLAUDE_ROUTINE_VERSION" \
         -H "Content-Type: application/json" \
-        -d "$(jq -nc --arg t "$WORK_ORDER" '{text:$t}')"
-  - If $CLAUDE_ROUTINE_TOKEN is unset, DO NOT fire — print the work order + curl and tell me
-    to set up the bridge (hermes-dispatch-bridge.md) or paste the order into a session myself.
+        -d "$(python3 -c 'import json,sys; print(json.dumps({"text": sys.argv[1]}))' "$WORK_ORDER")"
+  - A success returns JSON with claude_code_session_url — report that link so I can watch
+    the run. If CLAUDE_ROUTINE_TOKEN is unset (no ~/.hermes/routine.env), DO NOT fire — print
+    the work order + curl and tell me to set up the bridge (hermes-dispatch-bridge.md) or
+    paste the order into a session myself.
 
 STEP 5 — REPORT: confirm the fire response (run id / status). Tell me the routine will open a
   claude/ PR; offer to watch it with `superbot-repo-health` / `log-triage` and to review it


### PR DESCRIPTION
## What

Wires the `superbot-dispatch` Hermes skill to the **verified** Claude Code Routines `/fire` API, after live-validating the dispatch bridge this session (connectivity test + calibration PR #747).

- **`superbot-dispatch` skill** — sources `~/.hermes/routine.env`, adds the required `anthropic-version` header, and builds the JSON body with `python3` (no `jq` dependency on the VPS). Reports the returned `claude_code_session_url`.
- **`hermes-dispatch-bridge.md`** — the secrets block now uses `~/.hermes/routine.env` with the verified URL host (`api.anthropic.com/v1/claude_code/routines/<id>/fire`), the `experimental-cc-routine-2026-04-01` beta header, and the `anthropic-version` pin. Marks the **Create-routine** and **Calibrate** setup steps DONE (routine live; PR #747 calibration passed).
- Regenerated the `dispatch/SKILL.md` artifact (freshness test green).

## Why

The pre-wired skill (PR #742) used a best-guess call shape. The real Routines API (pulled from the official docs and confirmed by two successful live fires) needs the `anthropic-version` header and a specific host/path, so the skill is updated to match what actually works.

## Verification

`build_skills.py --check` (9 fresh) ✅ · `test_build_skills.py` 12 passed ✅ · `check_docs --strict` ✅. Docs/tooling only; no `disbot/` changes.

https://claude.ai/code/session_01U7iVHpMhVaNwiw5HuEH7js

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7iVHpMhVaNwiw5HuEH7js)_