### PR TITLE
docs(hermes): note Telegram-driven dispatch path live-verified 2026-06-12

### DIFF
--- a/docs/operations/hermes-dispatch-bridge.md
+++ b/docs/operations/hermes-dispatch-bridge.md
@@ -59,6 +59,8 @@ idea / nightly diagnosis
   clone → read-only, no changes) and a first real run (PR #747: a minimal docs edit, held open
   for review per the work order, CI green) both passed; the routine respected the work-order
   instructions precisely. Self-merge-on-green and the daily schedule are the earned next steps.
+  The full Telegram-driven path (the Hermes `superbot-dispatch` skill sourcing the routine token from
+  the VPS → `/fire`) was live-verified end-to-end on 2026-06-12.
 
 ## The routine's saved prompt (paste into the routine config)
 


### PR DESCRIPTION
## What

Adds one concise factual line to `docs/operations/hermes-dispatch-bridge.md`
recording that the full Telegram-driven dispatch path — the Hermes
`superbot-dispatch` skill sourcing the routine token from the VPS → `/fire` —
was live-verified end-to-end on 2026-06-12.

This is also a **self-merge calibration** run for the routine dispatch bridge
(Q-0113): a minimal docs edit fired through the path it documents, then
self-merged on green CI.

## Acceptance

`python3.10 scripts/check_docs.py --strict` passes (exit 0).

Docs-only, single-line change.

https://claude.ai/code/session_015Kr87JcSZKPMobxdaA7gic

---
_Generated by [Claude Code](https://claude.ai/code/session_015Kr87JcSZKPMobxdaA7gic)_