### PR TITLE
feat(routines): issue-triggered docs reconciliation + cadence 10→20 (Q-0107)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -180,17 +180,20 @@ is **per-file**. Full convention: `docs/owner/ai-project-workflow.md` §9.
   This is the automated-plus-judgment complement to the Q-0102 review; it exists because this
   exact question, asked once (2026-06-12), surfaced multiple drifted ledger entries. The
   `/session-close` skill runs the automated half.
-- **Reconciliation + planning pass at every 10th PR — required (owner directive Q-0107,
-  2026-06-12).** PR numbers crossing a **multiple of 10** (#10, #20, #30, …) are reserved for a
+- **Reconciliation + planning pass at every 20th PR — required (owner directive Q-0107,
+  2026-06-12; cadence raised 10 → 20 same day — small PRs inflate the count, so every 10 fired
+  too often).** PR numbers crossing a **multiple of 20** (#20, #40, #60, …) are reserved for a
   **docs-only review + planning** pass — no runtime / `disbot/` code in it. It does two things:
   **(1) reconcile** — review the living ledger, active lanes, open Q-blocks, idea backlog, and
   roadmap; prune/archive stale docs; restate the current priorities; and **(2) plan the next ~9
-  PRs** — what is realistically achievable in the upcoming decade of PRs, **modular but not
+  PRs** — what is realistically achievable in the upcoming band of PRs, **modular but not
   over-segmented**: each planned PR should ship a *reasonable, meaningful change* (a real slice),
   **not** a trivial fragment — a small PR is fine only when the change genuinely is small or a
   required one-off. `scripts/check_reconciliation_due.py` flags when a pass is due (against the
-  `Last reconciliation pass:** PR #N` marker in `current-state.md`; surfaced by `/session-close`);
-  reset the marker to the latest PR after the pass.
+  `Last reconciliation pass:** PR #N` marker in `current-state.md`; surfaced by `/session-close`).
+  The pass is now **fired automatically** by `.github/workflows/reconciliation-trigger.yml` (opens
+  a `reconcile`-labeled issue at the boundary → the **superbot docs reconciliation** routine runs
+  it — see `docs/operations/autonomous-routines.md`); reset the marker to the latest PR after the pass.
 - Plans span **2–3 PRs max**: the first PR covers root causes / foundation; subsequent PRs implement on top.
 - **Plan approval = full execution** — once a plan is approved (via **ExitPlanMode**),
   complete it in one session without stopping for confirmation or waiting for merges

--- a/.github/workflows/reconciliation-trigger.yml
+++ b/.github/workflows/reconciliation-trigger.yml
@@ -1,0 +1,62 @@
+name: reconciliation-trigger
+
+# Owner directive Q-0107 (cadence raised to 20, 2026-06-12): when merged PRs cross a
+# multiple-of-20 band, open a `reconcile` issue that fires the "superbot docs reconciliation"
+# routine. This runs the docs/planning pass PROMPTLY (daytime included) so the docs are fresh
+# for the nightly executor — not deferred to a nightly poll.
+#
+# Provenance + reliability (Q-0105): added 2026-06-12. UNVERIFIED — confirm over a few cycles
+# that it opens the issue only at the boundary and dedupes. Delete this workflow if it
+# misfires repeatedly; it is a convenience trigger, not load-bearing runtime.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: reconciliation-trigger
+  cancel-in-progress: false
+
+jobs:
+  maybe-open-reconcile-issue:
+    # Never run on forks — this opens issues against the canonical repo only.
+    if: github.repository == 'menno420/superbot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so the cadence guard can scan merge subjects
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Is a reconciliation pass due?
+        id: due
+        run: |
+          # --strict exits 1 when a pass is due. (An if-condition is exempt from set -e.)
+          if python3.10 scripts/check_reconciliation_due.py --strict; then
+            echo "due=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "due=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Open a reconcile issue (deduped)
+        if: steps.due.outputs.due == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Dedupe: if an open `reconcile` issue already exists, do nothing (avoids a new
+          # issue on every push between the boundary crossing and the routine running).
+          open_count="$(gh issue list --label reconcile --state open --json number --jq 'length' 2>/dev/null || echo 0)"
+          if [ "${open_count:-0}" != "0" ]; then
+            echo "An open 'reconcile' issue already exists — nothing to do."
+            exit 0
+          fi
+          gh label create reconcile --color FBCA04 \
+            --description "Fires the docs-reconciliation routine (Q-0107)" --force 2>/dev/null || true
+          gh issue create \
+            --title "Docs reconciliation due (Q-0107)" \
+            --label reconcile \
+            --body $'A multiple-of-20 PR band was crossed — a docs-only reconciliation + planning pass is due (Q-0107).\n\nThis issue triggers the **superbot docs reconciliation** routine, which reconciles the ledger, de-stales docs, plans the next ~9 PRs, adds one idea, resets the `Last reconciliation pass` marker, and closes this issue.\n\nAuto-opened by `.github/workflows/reconciliation-trigger.yml`. You can also open a `reconcile`-labeled issue by hand whenever you spot docs drift.'

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -52,9 +52,11 @@ Source code and merged PRs win over anything written here.
 >
 > **Last reconciliation pass:** PR #741 (2026-06-12 —
 > [the pass record + decade queue](planning/reconciliation-pass-2026-06-12.md)). The next
-> **docs-only review + planning reconciliation** is due once merged PRs cross #750 (every
-> multiple of 10 — Q-0107; `scripts/check_reconciliation_due.py` flags it). Reset this
-> marker to the latest PR after a pass.
+> **docs-only review + planning reconciliation** is due once merged PRs cross #760 (every
+> multiple of **20** — Q-0107 cadence raised 10→20 on 2026-06-12; `check_reconciliation_due.py`
+> flags it, and `.github/workflows/reconciliation-trigger.yml` auto-opens a `reconcile` issue
+> at the boundary that fires the docs-reconciliation routine). Reset this marker to the latest
+> PR after a pass.
 
 - **#748 (2026-06-12, hardening P0-1 — wager money safety)** — new
   `services/game_wager_workflow.py`: the audited money boundary for every two-party /

--- a/docs/operations/autonomous-routines.md
+++ b/docs/operations/autonomous-routines.md
@@ -17,39 +17,52 @@ kill switch is toggling the routine off in the console.
 | Routine | Trigger | Job | Class / merge |
 |---|---|---|---|
 | **superbot autonomous dispatch** | API (`/fire`) | General work orders from Hermes/phone (`superbot-dispatch`). Classifies by `CLASS:`. | per work order (Q-0113/Q-0114) |
-| **superbot docs reconciliation** | Schedule (nightly), self-gated | The Q-0107 every-10th-PR docs-only pass: reconcile the ledger, de-stale docs, plan the next ~9 PRs, contribute one idea. | `docs` → self-merge on green |
+| **superbot docs reconciliation** | **Issue** labeled `reconcile` | The Q-0107 every-20th-PR docs-only pass: reconcile the ledger, de-stale docs, plan the next ~9 PRs, contribute one idea. | `docs` → self-merge on green |
 | **superbot night caretaker** | Schedule (nightly) + API | Find & fix **one** small, well-understood runtime bug per run, with a test; or fix what Hermes hands it via `text`. | `fix` → self-merge on green |
 
-**Why nightly-schedule, not per-PR GitHub trigger, for reconciliation:** a GitHub
-`pull_request.closed` trigger fires a full cloud session on *every* merge (most just to check
-"not due" and exit), which burns the daily routine-run cap. A nightly run that consults
-`scripts/check_reconciliation_due.py` does the same job for ~1 run/night and catches the
-10th-PR boundary by morning. Switch to the GitHub trigger only if you want it instant and the
-run cap allows.
+**Why an issue-trigger (not a schedule, not a per-PR trigger) for reconciliation:** the docs
+pass should run **promptly when due — daytime included** — so the docs + fresh plan are ready
+for the nightly executor, not deferred to a night-time poll (owner point, 2026-06-12). A
+per-PR `pull_request.closed` trigger would spin a full cloud session on *every* merge (mostly
+to exit), burning the daily run cap. The clean middle: **the issue *is* the trigger**, opened
+two ways —
+1. **Automatically** by `.github/workflows/reconciliation-trigger.yml`: on every push to `main`
+   it runs `scripts/check_reconciliation_due.py --strict` and, when merged PRs cross a
+   **multiple-of-20** band (Q-0107, raised from 10 on 2026-06-12 — small PRs inflate the
+   count), opens a deduped issue labeled `reconcile`.
+2. **By judgment** — *any agent or the maintainer* opens a `reconcile`-labeled issue the moment
+   they spot docs needing reordering, even off-cycle. The routine treats the issue's existence
+   as the go-signal (it does not re-gate on the cadence), does the pass, and closes the issue.
+
+So the cadence runs in the GitHub Action (cheap, deterministic), and the routine just listens
+for the labeled issue.
 
 **The docs/runtime split (honors Q-0107):** the reconciliation routine is **docs-only** — if
 it *spots* a runtime bug it appends it to `docs/health/bug-book.md` (OPEN), and the **caretaker**
 routine fixes it. Neither routine invents features (the phase gate holds those until
 invent-phase, and these prompts never originate them).
 
-**Stage-1 note (workflow §10):** these two are *scheduled, unattended, self-merging* routines —
-real Stage-1 autonomy, earned by the Stage-0 calibration runs on 2026-06-12 (connectivity ·
-held-for-review PR #747 · self-merge PR #751). Watch the first scheduled run of each (or fire
-once via **Run now**) before trusting them overnight. Stagger their schedules so they don't race
-on `main`.
+**Stage-1 note (workflow §10):** these two are *unattended, self-merging* routines (the docs
+one issue-triggered, the caretaker nightly) — real Stage-1 autonomy, earned by the Stage-0
+calibration runs on 2026-06-12 (connectivity · held-for-review PR #747 · self-merge PR #751).
+Before trusting them, fire each once via **Run now** (the docs one: open a test `reconcile`
+issue) and watch. They can both touch `main`; the docs routine UNION-resolves as the reconciler.
 
 ---
 
 ## Routine: superbot docs reconciliation
 
-- **Trigger:** Schedule → Daily (suggested 03:30 in your zone; staggered after the caretaker).
+- **Trigger:** GitHub → **Issue opened**, filtered to **label is one of `reconcile`**.
+  (The `reconcile` issue is opened by the Action above on the 20-PR boundary, or by hand when
+  an agent spots drift.)
 - **Repository:** `menno420/superbot`. **Model:** Sonnet or Opus (docs work — the volume tier
   is fine; §11). **Permissions:** unrestricted branch push **OFF**. **Behavior:** auto-fix PRs ON.
 - **Paste this as the routine's instructions:**
 
 ```
-You are the SuperBot DOCS RECONCILIATION routine — the Q-0107 every-10th-PR docs-only
-review + planning pass. You run autonomously and self-merge on green CI (Q-0113).
+You are the SuperBot DOCS RECONCILIATION routine — the Q-0107 docs-only review + planning
+pass. You are triggered by a GitHub issue labeled `reconcile`. You run autonomously and
+self-merge on green CI (Q-0113).
 
 STRICTLY DOCS-ONLY. Never modify disbot/ runtime code, migrations, or tests in this routine
 (that is the Q-0107 rule). Runtime bugs you notice are CAPTURED, not fixed here (step 3).
@@ -57,9 +70,9 @@ STRICTLY DOCS-ONLY. Never modify disbot/ runtime code, migrations, or tests in t
 ORIENT: read .claude/CLAUDE.md, docs/current-state.md, the newest .sessions/ log, and
 docs/owner/ai-project-workflow.md section 12.
 
-STEP 1 — GATE: run `python3.10 scripts/check_reconciliation_due.py`.
-  - NOT due: stop now. Open no PR. End with "reconciliation not due — no action".
-  - DUE: continue.
+STEP 1 — GO-SIGNAL: the triggering `reconcile` issue IS your go-signal — do the pass. (Do not
+  re-gate on check_reconciliation_due: the issue was opened either because the cadence fired or
+  because an agent spotted drift; either way reconciliation is wanted.) Note the issue number.
 
 STEP 2 — RECONCILE (the Q-0107 pass):
   - Reconcile docs/current-state.md against live merged PRs: run
@@ -68,18 +81,20 @@ STEP 2 — RECONCILE (the Q-0107 pass):
   - Run `python3.10 scripts/check_docs.py --strict`; fix every reachability/badge/staleness
     issue, plus stale links, wrong PR numbers, and broken references you find.
   - Prune/relabel clearly stale docs; restate current priorities in current-state Next-action.
-  - Plan the next ~9 PRs (the upcoming decade) — modular, each a meaningful slice — into the
+  - Plan the next ~9 PRs (the upcoming band) — modular, each a meaningful slice — into the
     decade-queue planning doc.
   - Contribute ONE new genuine idea (Q-0089) to docs/ideas/ with a one-line why.
   - Reset the "Last reconciliation pass: PR #N" marker in current-state.md to the latest PR.
-    (This is what makes a re-fire exit at step 1 — do not skip it.)
+    (The trigger Action keys off this marker — resetting it is what stops it re-opening a
+    reconcile issue next push. Do not skip it.)
 
 STEP 3 — RUNTIME BUGS YOU NOTICED: do NOT fix them here. Append each to docs/health/bug-book.md
   as a new OPEN entry for the night-caretaker routine. Stay docs-only.
 
 STEP 4 — SHIP: open a docs-only claude/ PR; ensure check_docs, check_current_state_ledger, and
   check_session_log all pass; SELF-MERGE on green CI: re-sync origin/main first, UNION-resolve
-  conflicts (you are the reconciler), require CI green on the final head, merge-commit.
+  conflicts (you are the reconciler), require CI green on the final head, merge-commit. Then
+  CLOSE the triggering `reconcile` issue (reference the merged PR) so it doesn't linger.
 
 Respect the bounded-session protocol. Never touch production, Railway, or the database.
 ```
@@ -129,14 +144,32 @@ the database directly.
 
 ---
 
+## The `reconcile` issue — how to fire the docs pass by hand
+
+The docs-reconciliation routine triggers on a GitHub **issue labeled `reconcile`**. Beyond the
+automatic Action (every 20-PR band), **any agent or the maintainer should open one whenever the
+docs visibly need reordering** — the ledger drifted, a plan is stale, links rot, priorities
+moved — without waiting for the cadence:
+
+```bash
+gh issue create --repo menno420/superbot --label reconcile \
+  --title "Docs reconciliation: <one-line reason>" \
+  --body "What looks stale / needs reordering, and why now."
+```
+
+The routine treats the issue as the go-signal, runs the docs-only pass, and closes the issue.
+(If the `reconcile` label doesn't exist yet, the Action creates it on first use; or
+`gh label create reconcile --color FBCA04`.)
+
 ## Operating the fleet
 
 - **Pause/kill:** toggle a routine off (or delete it) in the console. The caretaker's API
-  trigger also lets Hermes fire it; revoke that token to cut the on-demand path.
+  trigger also lets Hermes fire it; revoke that token to cut the on-demand path. To stop the
+  automatic cadence, disable `.github/workflows/reconciliation-trigger.yml`.
 - **Watch runs:** each fire is a session in your list; a green run-status means it *started and
   exited cleanly*, not that the task succeeded — open the run to confirm.
-- **Cost:** routines draw subscription usage + a daily run cap. Nightly schedules + the
-  reconciliation self-gate keep volume low. The cap is also a natural runaway stop.
+- **Cost:** routines draw subscription usage + a daily run cap. The issue-trigger (cadence
+  gated in the Action) + nightly caretaker keep volume low. The cap is also a runaway stop.
 - **Improve the prompts here, not only in the console** — edit this doc, then re-paste into the
   routine. This keeps the fleet's behavior reviewable in git.
 
@@ -145,4 +178,5 @@ the database directly.
 - [`hermes-dispatch-bridge.md`](./hermes-dispatch-bridge.md) — the `/fire` mechanism + gates.
 - [`hermes-skills/dispatch.md`](./hermes-skills/dispatch.md) · [`hermes-skills/review.md`](./hermes-skills/review.md)
 - `scripts/check_reconciliation_due.py` · `scripts/check_phase_gate.py` · `scripts/check_current_state_ledger.py`
+- `.github/workflows/reconciliation-trigger.yml` — the Action that opens the `reconcile` issue on the 20-PR boundary.
 - `docs/owner/ai-project-workflow.md` §10 (staging) · §12 (the loop).

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -4189,24 +4189,32 @@ system evolve. This is the governance counterpart to the Q-0102/Q-0104 self-audi
 > modular but not too segmented; each PR should ship a reasonable change unless it really is
 > only a small required change."
 
+> **AMENDED 2026-06-12 (owner, in-session, autonomous-routines wiring):** cadence raised
+> **10 → 20**. Rationale: "some sessions create a lot of small PRs, so [the threshold]
+> shouldn't be too low" — every 10 fired too often. The pass is also now **fired automatically**
+> by a GitHub Action (`.github/workflows/reconciliation-trigger.yml`) that opens a
+> `reconcile`-labeled issue at the boundary, triggering the **superbot docs reconciliation**
+> routine (`docs/operations/autonomous-routines.md`). Agents/maintainer may also open a
+> `reconcile` issue by hand to fire the pass when they spot docs drift off-cycle.
+
 **Area:** Agent system · workflow / planning cadence
 **Type:** Standing workflow rule (process)
-**Priority:** Standing — every 10th PR
+**Priority:** Standing — every 20th PR
 
 **Directive:**
-- PR numbers crossing a **multiple of 10** (#10, #20, #30, …) are a **docs-only review +
+- PR numbers crossing a **multiple of 20** (#20, #40, #60, …) are a **docs-only review +
   planning** pass — no runtime / `disbot/` code.
 - **Reconcile:** review the ledger, active lanes, open Q-blocks, idea backlog, roadmap; prune
   stale docs; restate current priorities.
-- **Plan the next ~9 PRs:** what is realistically achievable in the upcoming decade of PRs,
+- **Plan the next ~9 PRs:** what is realistically achievable in the upcoming band of PRs,
   **modular but not over-segmented** — each planned PR ships a *reasonable, meaningful* change,
   not a trivial fragment (small PRs only when the change genuinely is small/required).
-- **Cadence guard:** `scripts/check_reconciliation_due.py` tracks the `Last reconciliation
-  pass:** PR #N` marker in `current-state.md` and flags when a pass is due; reset the marker
-  after a pass. Surfaced by `/session-close`.
+- **Cadence guard:** `scripts/check_reconciliation_due.py` (`STEP = 20`) tracks the
+  `Last reconciliation pass:** PR #N` marker in `current-state.md` and flags when a pass is due;
+  reset the marker after a pass. Surfaced by `/session-close` and the trigger Action.
 
 **Home:** `.claude/CLAUDE.md` § "Session & plan workflow" (binding) · `current-state.md` holds
-the marker · this entry is provenance.
+the marker · `docs/operations/autonomous-routines.md` (the routine + Action) · this entry is provenance.
 
 
 ### Q-0108 — Automod rules engine + image moderation: wanted? Which scope to start?

--- a/scripts/check_reconciliation_due.py
+++ b/scripts/check_reconciliation_due.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3.10
 """Reconciliation-cadence guard — flag when a docs-only review/planning pass is due.
 
-Owner directive Q-0107: PR numbers crossing a **multiple of 10** (#10, #20, #30, …) are
+Owner directive Q-0107: PR numbers crossing a **multiple of 20** (#20, #40, #60, …) are
 reserved for a **docs-only repo review + planning-reconciliation** pass — review the state
 of the repo (ledger, active lanes, open Q-blocks, idea backlog, roadmap), prune stale docs,
 and refocus the next priorities. This guard tracks the cadence against the
 ``Last reconciliation pass:** PR #N`` marker in ``docs/current-state.md``: a pass is **due**
-once merged PRs have crossed into a new multiple-of-10 band since the last marked pass.
+once merged PRs have crossed into a new multiple-of-20 band since the last marked pass.
+(Cadence raised 10 → 20 on 2026-06-12, owner-directed: small PRs inflate the count, so every
+10 fired too often; the band size is the ``STEP`` constant below — retune there.)
 
 Advisory by default (exit 0); ``--strict`` for an explicit gate (e.g. ``/session-close``).
 After completing a pass, reset the marker to the latest PR. Pure stdlib, like ``check_docs.py``.
@@ -31,7 +33,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CURRENT_STATE = REPO_ROOT / "docs" / "current-state.md"
 
-STEP = 10  # the cadence: a pass per multiple-of-10 PR band
+STEP = 20  # the cadence: a pass per multiple-of-20 PR band (raised from 10, 2026-06-12)
 
 _MARKER_RE = re.compile(r"Last reconciliation pass:\*\*\s*PR #(\d+)")
 _MERGE_SUBJECT_RE = re.compile(r"(?:pull request #|\(#)(\d+)")

--- a/tests/unit/scripts/test_check_reconciliation_due.py
+++ b/tests/unit/scripts/test_check_reconciliation_due.py
@@ -17,28 +17,29 @@ _spec.loader.exec_module(crd)
 
 
 def test_not_due_same_band() -> None:
-    # marker #737 (band 73), latest #739 (band 73) → not due
+    # STEP=20: marker #737 (band 36), latest #739 (band 36) → not due
     due, latest, marker = crd.is_due(latest=739, marker=737)
     assert due is False
     assert (latest, marker) == (739, 737)
 
 
-def test_due_when_crossing_multiple_of_ten() -> None:
-    # marker #737 (band 73), latest #740 (band 74) → due
+def test_due_when_crossing_band() -> None:
+    # STEP=20: marker #737 (band 36), latest #740 (band 37) → due
     due, _, _ = crd.is_due(latest=740, marker=737)
     assert due is True
 
 
 def test_due_when_crossing_multiple_bands() -> None:
-    due, _, _ = crd.is_due(latest=752, marker=737)
+    # STEP=20: marker #737 (band 36), latest #780 (band 39) → due
+    due, _, _ = crd.is_due(latest=780, marker=737)
     assert due is True
 
 
 def test_exactly_on_band_boundary_marker() -> None:
-    # last pass landed on #740 (band 74); latest #749 still band 74 → not due
-    assert crd.is_due(latest=749, marker=740)[0] is False
-    # latest #750 → new band → due
-    assert crd.is_due(latest=750, marker=740)[0] is True
+    # STEP=20: last pass landed on #740 (band 37); latest #759 still band 37 → not due
+    assert crd.is_due(latest=759, marker=740)[0] is False
+    # latest #760 → new band (38) → due
+    assert crd.is_due(latest=760, marker=740)[0] is True
 
 
 def test_no_marker_is_not_due(monkeypatch) -> None:


### PR DESCRIPTION
## What

Makes the docs-reconciliation routine fire **promptly when due** (the moment a PR-band boundary is crossed, daytime included) so the docs + fresh plan are ready for the nightly executor — not deferred to a nightly poll. And raises the Q-0107 cadence **10 → 20** per the owner's in-session directive (small PRs inflate the count, so every 10 fired too often).

**The mechanism — the issue *is* the trigger:**

- **`.github/workflows/reconciliation-trigger.yml`** (new): on every push to `main`, runs `check_reconciliation_due.py --strict`; at a multiple-of-20 boundary it opens a **deduped `reconcile`-labeled issue** (creates the label, skips if one's already open). Cheap, deterministic — the cadence gating lives in the Action, not a per-PR cloud session.
- The **superbot docs reconciliation** routine triggers on that `reconcile` issue, treats it as the go-signal (no self-gate, so off-cycle manual issues work too), runs the docs-only pass, resets the marker, and closes the issue.
- **Agent convention:** any agent or the maintainer can `gh issue create --label reconcile` the moment they spot docs drift, firing the pass off-cycle.

**Cadence change (Q-0107 amended):**
- `check_reconciliation_due.py`: `STEP 10 → 20` (+ tests updated for the new bands).
- Synced the prose in `.claude/CLAUDE.md`, the router Q-0107 (with provenance), and the `current-state` marker note (next pass at #760).

## Verification

- Workflow YAML valid · `test_check_reconciliation_due.py` 9 passed · `check_quality --check-only` ✅ · `check_docs --strict` ✅
- Live check now reads: `not due (last pass #741, latest #751; next pass at #760)` — so merging this won't surprise-fire.
- No `disbot/` changes.

https://claude.ai/code/session_01U7iVHpMhVaNwiw5HuEH7js

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7iVHpMhVaNwiw5HuEH7js)_