### PR TITLE
UX Lab design: the interface-gallery cog plan (owner-commissioned brainstorm → design)

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -399,9 +399,13 @@ PR #676; drift surfaced at boot + `!btd6 status`). Full note:
   `position >=` check mis-flags perfectly manageable roles as "above the bot" (caught live
   2026-06-06). Route every "can the bot manage this role?" check through
   `utils.role_feasibility` (the single source of truth; `_at_or_above` does the tiebreak).
-- **A Discord Modal cannot contain a Select** (`UserSelect`/`StringSelect`) — modals are
-  text-input only. "Selector-ize a modal" therefore means a **modal→view restructure**
-  (pick the member in a view → follow-up modal/inputs), not a component swap.
+- **Modals CAN contain selects on the current pin** *(corrected 2026-06-12 — verified
+  against installed discord.py 2.7.1)*: since 2.6, `discord.ui.Label(text=…,
+  component=Select(...))` wraps a select inside a modal. The old "modals are text-input
+  only → restructure modal→view" advice predates the pin; which select *types* Discord
+  accepts in modals is probe-pending (UX Lab plan P-07/P-08,
+  `docs/planning/ux-lab-interface-gallery-plan-2026-06-12.md`). Existing modal→view
+  restructures remain fine — just don't cite the old rule to block a Label-based design.
 - **Discord caps bite on every catalogue growth** — re-check all four whenever content
   tables grow: **25 options/select** (a silent `options[:25]` slice = items invisible —
   the market panel had exactly this latent), **1024 chars/embed field** (clamp_embed

--- a/.sessions/2026-06-12-ux-lab-design.md
+++ b/.sessions/2026-06-12-ux-lab-design.md
@@ -1,0 +1,107 @@
+# 2026-06-12 — UX Lab design (interface-gallery cog, owner-commissioned)
+
+> **Status:** `audit`
+
+**PR:** #755 (ready, open at write time; merged in-session per Q-0084)
+**Branch:** `claude/wizardly-planck-c04laf`
+
+## Context
+
+Owner-commissioned brainstorm continuation + design: "design the most versatile and
+inclusive UX testing cog" — a gallery for browsing every Discord UX pattern and
+comparing against the bot's current panels. Input: the owner's original ask + a ChatGPT
+draft (treated per the verify-don't-trust rule — several of its claims needed source
+verification). Design session, not implementation (owner said "design"; idea lifecycle
+says structure, don't auto-promote).
+
+## What shipped (PR #755, docs-only)
+
+- [`docs/ideas/ux-lab-interface-gallery-2026-06-12.md`](../docs/ideas/ux-lab-interface-gallery-2026-06-12.md)
+  — capture: owner intent, durable-value case, scope fences.
+- [`docs/planning/ux-lab-interface-gallery-plan-2026-06-12.md`](../docs/planning/ux-lab-interface-gallery-plan-2026-06-12.md)
+  — the design: thin cog + 9 view wings + `utils/ux_patterns/` registry (no service
+  layer), `PatternSpec` schema, ~60-exhibit inventory, 10-probe limit bench,
+  compare/verdict mode, AST zero-write fence, 3-PR slicing (A core · B CV2+PIL ·
+  C mock studio + pattern-library export), acceptance criteria.
+- **Two stale-fact corrections** (both verified against installed discord.py 2.7.1 by
+  introspection): `discord-platform-limits.md` CV2 budget 25 → **40 children +
+  4 000-char text** (25 is the legacy `View` ceiling); journal rule "modals cannot
+  contain selects" corrected (`ui.Label`, 2.6+, wraps selects in modals).
+- Router **Q-0116** (scheduling + audience, OPEN) · roadmap 🖥️ lane horizon · ideas
+  README index entry.
+
+## Key verification notes (for the implementing session)
+
+- discord.py 2.7.1 exports the full CV2 set (`LayoutView`/`Container`/`Section`/
+  `TextDisplay`/`MediaGallery`/`File`/`Separator` + modal `Label`); `LayoutView`
+  raises at >40 children and documents the 4 000-char display budget.
+- ChatGPT's draft was right about the 40-component figure (repo doc was wrong) and
+  right that CV2 replaces content/embeds; its "gate on library support" caution is
+  resolved — support is present on the pin. Its suggested `ux_lab_service` was dropped
+  (no business logic, no writes → no service; ownership doc logic).
+- Rejection-ledger fences honored: no second panel/router framework (canonical view
+  lineage + one commented `LayoutView` exemption); no grab-bag helper module
+  (`utils/ux_patterns/` is single-purpose); slash = one front door.
+
+## Process notes
+
+- **The Q-0107 reconciliation pass is DUE** (`check_reconciliation_due`: crossed #750,
+  last pass #741). This session was owner-steered to the UX Lab design, so the pass is
+  deliberately left to the next session — or the #752 nightly docs-reconciliation
+  Routine if the owner has wired it (its gate + marker-reset design dedupes correctly).
+- Grooming (Q-0015): satisfied by the main task itself — a brand-new owner idea was
+  moved intake → captured → routed-to-plan (+ roadmap horizon + router Q) in one
+  session; no additional backlog pull made given the due reconciliation pass should be
+  the next session's focus.
+
+## 💡 Session idea (Q-0089)
+
+**`scripts/ui_component_census.py`** — offline AST census of every `discord.ui`
+component the codebase constructs: button styles, select types, per-view child counts,
+modals, and a "views within N of the 25-child ceiling" warning list. Why I believe in
+it: it is the **"current bot" half of the UX Lab's compare mode** (the lab shows what
+*could* be; the census shows what *is* — per-view, greppable, no boot needed), and it
+catches the cap-regression class that bit twice (the V-16 catalogue trips, PR #702)
+*before* a live panel silently truncates. Companion to `command_surface_dump.py`
+(commands) — same offline-AST family, different surface. Dedup-checked: nothing in
+`docs/ideas/` or the roadmap covers component-level census. Small, read-only,
+quick-win lane.
+
+## ⟲ Previous-session review (Q-0102) — PR #752 (autonomous-routines.md)
+
+**Did well:** exactly the right durable home — the Routine fleet's prompts now live in
+git (reviewable, improvable) instead of only in the console, and the nightly
+docs-reconciliation Routine reuses `check_reconciliation_due` as its self-gate with a
+marker-reset that makes re-fires exit cleanly; that mutual-exclusion design also covers
+the interactive-session-vs-routine duplicate-claimant case I went looking for (no fix
+needed — verified before claiming a gap).
+**Missed:** #752 wrote **no `.sessions/` log** (this review had to be reconstructed
+from the commit message + doc) and so also skipped the Q-0089 idea ender — the
+mandatory enders were dropped, likely because it ran as a quick continuation session.
+**Workflow improvement:** the session-log checker / Stop-hook advisory apparently
+doesn't bite on short continuation sessions that commit via a merge from another
+branch's flow. Worth one look at `scripts/check_session_log.py`'s trigger condition
+next time someone touches it: a session that *merges a PR* should be in scope even if
+it edited only docs. (Captured here, not built — docs-only session.)
+
+## Context delta (reflection interview)
+
+- **Route hit:** CLAUDE.md → collaboration-model → current-state → journal →
+  AGENT_ORIENTATION → ideas README + platform-limits + hub-ui-standard was exactly the
+  right chain for a design session; the ideas README's lifecycle section made the
+  "capture + plan + Q-block, don't implement" shape unambiguous.
+- **Route miss (small):** nothing pointed at `views/navigation.py` as the canonical
+  in-place-transition helper — found via grep from the vision doc's V-02 row. The
+  hub-ui-standard would be a natural home for one pointer line.
+- **Discovered by hand:** the discord.py 2.7.1 CV2 surface (the load-bearing facts) —
+  by deliberate introspection, which is the right method, but note for future agents:
+  **the installed library is the cheapest ground truth** for "does the pin support X?"
+  questions; prefer it over web docs for version-pinned claims.
+- **Decisions made alone:** no service layer for the lab; CV2 wing as commented
+  LayoutView exemption; verdicts as copy-paste lines instead of persistence (preserves
+  zero-write). All three are reversible design choices recorded in the plan.
+- **Weak point of what shipped:** the ~60-exhibit inventory is a design-time list —
+  implementation will likely merge/cut some exhibits once rendered side by side; the
+  plan says PR A may trim wings, but expect drift between inventory and v1.
+- **One change that would have helped:** none structural — the orientation route fit
+  this task well.

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -20,7 +20,7 @@
 >
 > Cross-cutting: **Community Spotlight** (side-lane **#613**/**#614** + hotfixes **#615**/**#617**) was hardened in the review session (canonical `utils/db/xp.py` read, `member_count` crash fix, first tests) and **Q-0044 is executed**: the Q-0025 `scripts/new_subsystem.py` scaffold was built and used to register Spotlight as a `community`-hub child (**#626**, 2026-06-09 — execution-plan Lane 1; merged, verified live), and the `!hub`/`!server` aliases were **dropped same day** (kept `!spotlight`/`!activity`). Also decided: BTD6 data-refresh automation = **manual-dispatch workflow** (Q-0049 — **built same day in #633**, execution-plan Lane 5: `workflow_dispatch`-only, opens a reviewable PR, never pushes to main); mining descent lights **permanent, owner-confirmed** (Q-0050); the five product-vision questions (Q-0038–Q-0042) got their **draft-answer session** (Q-0051) **and the maintainer marked all five up same day (Lane 6, PR #631, structured choices)**: Q-0038 server-scoped clans, Q-0039 cosmetic-only donations (no bot-side billing), Q-0041 YouTube-first/dual-opt-in/voice-deferred, Q-0042 staged-Someday website — all approved as drafted; **Q-0040 adjusted: the AI dungeon master picks quests/rewards/difficulty from bounded, hard-capped menus** (not pure narration, not free-form authority). Posture decisions only — every lane still needs its own plan/promotion + the AI per-exposure lift; conclusions routed to the four roadmap drafts + router §21. Full repo review: [`audits/repo-review-2026-06-09.md`](audits/repo-review-2026-06-09.md) · agent-memory system review (did the orientation/memory system work in practice?): [`audits/agent-memory-system-review-2026-06-09.md`](audits/agent-memory-system-review-2026-06-09.md).
 >
-> **Last updated:** 2026-06-12 (evening), **the first Q-0107 reconciliation pass (PR #741)** — every #715–#740 plan mapped, the decade queue set ([pass record](planning/reconciliation-pass-2026-06-12.md)), ledger + roadmap drift fixed; stamp-line history older than 2026-06-11 moved to [`current-state-archive.md`](current-state-archive.md) § Stamp-line history. · 2026-06-11 (afternoon), **first Q-0086 joint live-testing session (PR #707)** — model-loop gate lifted, BUG-0005…0008 fixed live, BUG-0009/0010 opened, Q-0094/Q-0095 recorded — see the AI lane bullet. · 2026-06-11, **AI-knowledge bug session (PRs #703 + #706 + process record #705): the morning's 3 live misses + the re-test round's BUG-0004 + the capabilities format fixed** — see the BTD6 lane bullet above. · Earlier same day: **gear-lane session (PR #702): V-16 phase 1 executed** — see the mining lane bullet above; this stamp line otherwise preserves the 2026-06-10 marathon record below.
+> **Last updated:** 2026-06-12 (night), **UX Lab design session (PR #755)** — owner-commissioned interface-gallery cog design (plan + Q-0116) + CV2 platform-limit corrections; **the next Q-0107 reconciliation pass is DUE** (merged PRs crossed #750 — next session, or the #752 nightly Routine if wired). · 2026-06-12 (evening), **the first Q-0107 reconciliation pass (PR #741)** — every #715–#740 plan mapped, the decade queue set ([pass record](planning/reconciliation-pass-2026-06-12.md)), ledger + roadmap drift fixed; stamp-line history older than 2026-06-11 moved to [`current-state-archive.md`](current-state-archive.md) § Stamp-line history. · 2026-06-11 (afternoon), **first Q-0086 joint live-testing session (PR #707)** — model-loop gate lifted, BUG-0005…0008 fixed live, BUG-0009/0010 opened, Q-0094/Q-0095 recorded — see the AI lane bullet. · 2026-06-11, **AI-knowledge bug session (PRs #703 + #706 + process record #705): the morning's 3 live misses + the re-test round's BUG-0004 + the capabilities format fixed** — see the BTD6 lane bullet above. · Earlier same day: **gear-lane session (PR #702): V-16 phase 1 executed** — see the mining lane bullet above; this stamp line otherwise preserves the 2026-06-10 marathon record below.
 
 > **Purpose:** the one file that answers "what is true right now?" so a new
 > session does not reconstruct it from the journal + planning docs. Read it
@@ -56,6 +56,28 @@ Source code and merged PRs win over anything written here.
 > multiple of 10 — Q-0107; `scripts/check_reconciliation_due.py` flags it). Reset this
 > marker to the latest PR after a pass.
 
+- **#755 (2026-06-12, UX Lab design — owner-commissioned)** — the **interface-gallery
+  cog design**: [capture](ideas/ux-lab-interface-gallery-2026-06-12.md) +
+  [full plan](planning/ux-lab-interface-gallery-plan-2026-06-12.md) for a zero-write,
+  admin-gated `!uxlab` gallery — 9 exhibit wings (~60 patterns: buttons / all 5 selects /
+  modals incl. Label-wrapped selects / embed archetypes / **Components V2** / PIL cards /
+  **mockups of the approved Q-0108–Q-0112 features**), a 10-probe platform-limit bench,
+  compare-with-verdict mode, a `PatternSpec` registry exporting to a pattern-library
+  doc in plan-PR C, AST zero-write fence, 3-PR slicing. **Found + fixed two
+  stale platform facts** (verified on installed discord.py 2.7.1): the limits doc's CV2
+  budget (25 → **40 children / 4 000-char text**) and the journal's "modals can't contain
+  selects" rule (Label, 2.6+). Scheduling + audience = router **Q-0116** (open). Docs-only.
+- **#746–#747 + #749–#752 (2026-06-12, the dispatch-bridge wiring + routine-fleet arc)** —
+  the Hermes→Claude Code dispatch bridge went **live-verified end-to-end**: **#746**
+  Context7 verify/tool-name fix · **#747** routine-creation step marked DONE (calibration
+  pass) · **#749** `superbot-dispatch` wired to the verified Routines `/fire` API ·
+  **#751** Telegram-driven dispatch path live-verified · **#752**
+  [`operations/autonomous-routines.md`](operations/autonomous-routines.md) — the Routine
+  fleet's prompts in git (autonomous dispatch · nightly docs-reconciliation, self-gated on
+  `check_reconciliation_due` · night caretaker, phase-gated, one-small-bug-per-run) ·
+  **#750** routed the wager-flow-map session idea into the backlog. *(Ledger entries added
+  retroactively by the #755 session's Q-0104 audit — these micro-PRs shipped without
+  ledger lines.)*
 - **#748 (2026-06-12, hardening P0-1 — wager money safety)** — new
   `services/game_wager_workflow.py`: the audited money boundary for every two-party /
   paid-entry game move, composing `economy_service.*_in_txn` inside one

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -18,6 +18,17 @@ Pure brainstorm backlogs — capture without commitment. Each file should carry 
 
 Current broad captures:
 
+- [`ux-lab-interface-gallery-2026-06-12.md`](./ux-lab-interface-gallery-2026-06-12.md) —
+  **owner-commissioned design (2026-06-12):** the **UX Lab** — a zero-write, admin-gated
+  gallery cog (`!uxlab`) exhibiting every Discord interaction/layout pattern the pinned
+  library supports (buttons · all 5 selects · modals incl. Label-wrapped selects · embed
+  card archetypes · **Components V2** layouts (verified: 40-child/4 000-char budget on
+  discord.py 2.7.1) · PIL cards), plus a **platform-limit probe bench** and clickable
+  **mockups of the approved Q-0108–Q-0112 features**. Each exhibit carries registry
+  metadata (`pattern_id`, status, limits) that graduates into `docs/ux/pattern-library.md`
+  — the bot's design vocabulary. **State: captured → routed** — full design in
+  [`../planning/ux-lab-interface-gallery-plan-2026-06-12.md`](../planning/ux-lab-interface-gallery-plan-2026-06-12.md)
+  (3 PRs); scheduling + audience open in router **Q-0116**.
 - [`server-safety-and-automod-2026-06-12.md`](./server-safety-and-automod-2026-06-12.md) —
   **owner-uploaded research (2026-06-12):** four moderation-safety modules SuperBot
   lacks vs. competitors (Carl-bot, Dyno, YAGPDB, Koya, Double Counter):

--- a/docs/ideas/ux-lab-interface-gallery-2026-06-12.md
+++ b/docs/ideas/ux-lab-interface-gallery-2026-06-12.md
@@ -1,0 +1,116 @@
+# UX Lab / Interface Gallery — a living Discord-UX sandbox cog
+
+> **Status:** `ideas` — owner-commissioned brainstorm capture (2026-06-12). **Not
+> approved for implementation as code yet** — the design is structured in
+> [`../planning/ux-lab-interface-gallery-plan-2026-06-12.md`](../planning/ux-lab-interface-gallery-plan-2026-06-12.md)
+> (owner-commissioned design session, 2026-06-12); scheduling + audience are open in
+> router **Q-0116**. Source code and binding contracts win over anything here.
+
+---
+
+## 1. Owner intent (the ask, 2026-06-12)
+
+> "I want this to eventually produce a testing cog, that just focuses on showing a lot
+> of different types of UX, different interfaces, button styles, menu layouts — the
+> purpose is that I can freely browse through the different styles and layouts so I can
+> then compare to what the bot already has and which parts I would change into something
+> new. It should include the most kinds of advanced button/interaction style messages and
+> embeds that are possible; they shouldn't necessarily have to link to any real functions
+> but they should have some kind of reaction or link to show how it would function. …
+> design the most versatile and inclusive UX testing cog."
+
+The maintainer is the **vision/taste layer** of this project (collaboration model): he
+decides *which* UI shapes are right by **looking at them**, not by reading component
+specs. Today there is no surface where he can look at a pattern that doesn't exist yet.
+Every UX decision (Q-0078 help home, Q-0110 welcome embed-vs-card, the V-02 navigation
+doctrine) is currently made from prose descriptions. The UX Lab closes that gap: a
+browsable, clickable, zero-risk gallery of every interaction pattern SuperBot could use.
+
+## 2. The idea in one paragraph
+
+One admin-gated command (`!uxlab`) opens a hub that exhibits **every Discord interaction
+and layout pattern available to the pinned library** — button styles and confirm flows,
+all five select types, modals (including the new Label-wrapped selects-in-modals),
+embed card archetypes, Components V2 layouts (containers / sections / media galleries),
+PIL-generated image cards, and **clickable mockups of approved-but-unbuilt features**
+(automod, logging, welcome, events — the Q-0108–Q-0112 lane). Every exhibit reacts
+visibly when clicked, states which real feature it could serve, and carries registry
+metadata (`pattern_id`, status, limits, anti-patterns) so the best patterns graduate
+into an official **pattern library** future cogs reuse instead of inventing one-off
+panels. A built-in **probe bench** re-verifies Discord's platform limits against the
+live library on demand. Nothing in the lab ever writes to the database or mutates guild
+state — enforced by an AST fence test, not by promise.
+
+## 3. Why this is durable value, not a toy
+
+1. **It converts UX decisions from prose to perception.** The owner's open decisions
+   (welcome embed vs PIL card — Q-0110 phase 2; logging channel routing — Q-0109;
+   the 4-button Help Home — V-03/Q-0078) become *clickable A/B choices* instead of
+   paragraph descriptions. The mock studio renders the approved safety/community lane
+   before a line of it is built, so the family plan (decade slot 8) gets reviewed by
+   clicking, not imagining.
+2. **It gives agents a shared design vocabulary.** "Use `danger_confirm_then_result`"
+   replaces re-describing a confirmation flow in every plan. The hub-ui-standard's five
+   presets get concrete, named, rendered instances. Future cogs stop inventing
+   inconsistent panels — the exact drift class the hub-ui-standard documents.
+3. **It keeps platform truth verifiable.** `docs/operations/discord-platform-limits.md`
+   warns its numbers change without notice — and indeed this design session found its
+   Components V2 budget wrong (25 → actually 40; corrected same PR). The probe bench
+   turns "re-verify before shipping" from a doc instruction into a button press whose
+   output is dated and library-versioned.
+4. **It is the Components V2 evidence generator.** discord.py 2.7.1 (pinned) fully
+   supports LayoutView/Container/Section/TextDisplay/MediaGallery/File/Separator —
+   verified by introspection this session. Whether SuperBot's *real* panels adopt CV2 is
+   an architectural decision (new view lineage beside BaseView) that should be made by
+   looking at rendered CV2 layouts and probe results — which the lab produces.
+
+## 4. What it is NOT (scope fences from the binding docs)
+
+- **Not a second panel/router framework** — the rejection ledger
+  (`docs/planning/superbot-ideas-lab-2026-06-05.md` §6) bans that. The lab is a normal
+  subsystem on the canonical `BaseView`/`HubView` lineage + `views/navigation.py`
+  transitions; its CV2 wing extends `discord.ui.LayoutView` as an explicitly-commented
+  experimental exemption, not a parallel base-class family.
+- **Not a settings surface, not a feature** — it mutates nothing, owns no tables, emits
+  no audit events. The zero-write property is the design's spine.
+- **Not auto-adoption of Components V2** — the lab demos CV2; adopting it for real
+  panels stays a separate ADR-shaped decision informed by the lab's evidence.
+- **Not member-facing** (initially) — it's a workbench for the owner/staff and for
+  design-review sessions; hidden from Help. Audience question open in Q-0116.
+
+## 5. Verified platform facts this capture rests on (2026-06-12)
+
+Verified by direct introspection of the **installed discord.py 2.7.1** (the pinned
+runtime dep), not from memory or external docs:
+
+- `discord.ui` exports the full CV2 set: `LayoutView`, `Container` (accent colour +
+  spoiler), `Section` (≤3 `TextDisplay`s + a `Thumbnail`/`Button` accessory),
+  `TextDisplay`, `MediaGallery` (≤10 items), `File`, `Separator`, `ActionRow`, plus
+  `Label` for modals.
+- `LayoutView` enforces **max 40 total children** and **4000 display characters**
+  across all items. (The repo's platform-limits doc said CV2 had a 25-component
+  budget — corrected in this session's PR; 25 is the *legacy* `View` ceiling.)
+- **Modals can now contain selects**: `Label` (added 2.6) wraps a component inside a
+  modal — the journal's "a Modal cannot contain a Select" rule predates the pin and was
+  corrected this session. Which select types modals accept in practice is exactly the
+  kind of fact the probe bench exists to pin down.
+- `ButtonStyle` includes `premium` (SKU-gated — exhibit shown disabled with a note).
+- Five select types: `Select` (string), `UserSelect`, `RoleSelect`, `ChannelSelect`,
+  `MentionableSelect`.
+
+## 6. Where the full design lives
+
+The complete design — architecture, pattern-registry schema, the exhibit inventory per
+wing, the probe bench, mock studio, compare mode, PR slicing (A/B/C), tests, and
+acceptance criteria — is
+[`../planning/ux-lab-interface-gallery-plan-2026-06-12.md`](../planning/ux-lab-interface-gallery-plan-2026-06-12.md).
+
+## 7. Lifecycle state
+
+- **Intake:** owner-commissioned brainstorm + design, 2026-06-12 (this file).
+- **Map:** new subsystem `ux_lab`; building/interface lane; low risk (additive,
+  zero-write, admin-gated); medium size (3 PRs).
+- **Route:** structured plan (above) + a `docs/roadmap.md` 🖥️ Building/interface
+  horizon + router **Q-0116** (scheduling + audience).
+- **Outcome target:** implemented (PR A → C), then `docs/ux/pattern-library.md`
+  becomes the durable export.

--- a/docs/operations/discord-platform-limits.md
+++ b/docs/operations/discord-platform-limits.md
@@ -14,10 +14,10 @@
 
 | Limit | Value | Notes |
 |---|---|---|
-| Action rows per message | **5** | Whether using legacy or Components V2 |
+| Action rows per message | **5** | Legacy (`discord.ui.View`) messages |
 | Buttons per action row | **5** | Buttons only; select menus use the full row |
 | Select menus per action row | **1** | Each menu occupies an entire row |
-| Total components per message | **25** | Across all action rows |
+| Total components per message | **25** | **Legacy `View` ceiling** (5 rows × 5); Components V2 has its own 40 budget — see below |
 | Button label length | **80 characters** | |
 | Button custom\_id length | **100 characters** | Used for persistent-view routing |
 | String-select options | **2 – 25** | Min 2, max 25 options per menu |
@@ -26,10 +26,31 @@
 | Select option description length | **100 characters** | |
 | Select placeholder text | **150 characters** | |
 
-**Components V2** (requires the `IS_COMPONENTS_V2` flag on the message) allows the full
-25-component budget across containers, sections, and interactive elements. SuperBot's
-`PersistentView` and `HubView` base classes handle registration automatically — keep the
-total component count under 25 per message.
+**Components V2** *(corrected 2026-06-12 — this section previously claimed a
+25-component budget; verified against the installed discord.py 2.7.1 source)*:
+requires the `IS_COMPONENTS_V2` flag on the message (discord.py sets it when sending a
+`discord.ui.LayoutView`) and is a different message shape with its own budgets:
+
+| CV2 limit | Value | Source |
+|---|---|---|
+| Total components (nested count) | **40** | `LayoutView` raises `ValueError('maximum number of children exceeded (40)')` |
+| Combined display text across all items | **4 000 characters** | `LayoutView` validation |
+| `Section` text displays | ≤3 + one accessory (`Thumbnail` or `Button`) | class docs |
+| `MediaGallery` items | ≤10 | class docs |
+
+A CV2 message **replaces** `content`/`embeds` (and disallows polls/stickers); files must
+be referenced by a component (`Thumbnail`, `MediaGallery`, `File`). discord.py ≥2.6
+exposes the full set: `LayoutView`, `Container` (accent colour, spoiler), `Section`,
+`TextDisplay`, `MediaGallery`, `File`, `Separator`. SuperBot's `BaseView`/`HubView`/
+`PersistentView` lineage is **legacy-View-based** — CV2 panels need `LayoutView`, a
+separate lineage; adopting it for real panels is an ADR-shaped decision (see the
+[UX Lab plan](../planning/ux-lab-interface-gallery-plan-2026-06-12.md), whose probe
+bench re-verifies this table on demand).
+
+**Modals** *(corrected 2026-06-12)*: since discord.py 2.6, a modal may contain
+`discord.ui.Label`-wrapped components — i.e. **selects inside modals are now possible**
+(`Label(text=…, component=Select(...))`; label text ≤45 chars, description ≤100).
+Older guidance that modals are text-input-only predates the 2.7 pin.
 
 **Pagination implication:** lists longer than 25 items (e.g., a full inventory, a large
 role list) require pagination or dynamic loading — a single select menu cannot show them

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -4379,3 +4379,35 @@ insufficient (e.g. a Hermes/VPS outage making a GitHub-side fallback worth its u
 **Routed:** `ai-project-workflow.md` §10 (Stage 0 superseded note) · roadmap 🤝 workflow
 lane · the reconciliation-pass queue (Stage 0 entry re-pointed) ·
 `ideas/hermes-claude-dispatch-bridge-2026-06-12.md` · this entry is provenance.
+
+### Q-0116 — UX Lab (interface gallery cog): scheduling + audience
+
+> **OPEN (2026-06-12).** Raised by the owner-commissioned UX Lab design session
+> (the brainstorm → design pass for the interface-gallery testing cog).
+
+**Area:** Building / interface · new subsystem `ux_lab`
+**Type:** Scheduling + product-audience decision (the design itself is pinned)
+
+**Context:** The owner commissioned "the most versatile and inclusive UX testing cog" —
+a zero-write, admin-gated gallery of every Discord interaction/layout pattern (buttons /
+selects / modals / embeds / Components V2 / PIL cards), a platform-limit probe bench,
+and clickable mockups of the approved Q-0108–Q-0112 safety/community features. Full
+design: [`../planning/ux-lab-interface-gallery-plan-2026-06-12.md`](../planning/ux-lab-interface-gallery-plan-2026-06-12.md)
+(3 PRs: A core wings · B Components-V2 + PIL · C mock studio + pattern-library export).
+
+**Question 1 — scheduling:** the decade queue (reconciliation pass §4) is full and
+allows owner-steered swaps. Where do UX Lab PRs A–C sit?
+*Recommended:* PR A as a near-term steered slice (it is additive/zero-risk and
+immediately useful), and PR C **before or with** the safety-lane family plan (decade
+slot 8) so the Q-0108–Q-0112 UX decisions are reviewed on rendered, clickable panels
+instead of prose. Alternative: after the current decade completes.
+
+**Question 2 — audience:** admin-gated (*recommended* — staff can browse styles too;
+every callback re-checks authority) vs owner-only. Hidden from Help either way
+(workbench, not a member feature).
+
+**Non-decision pinned in the plan:** the lab does NOT authorize migrating real panels
+to Components V2 — that stays a future ADR taken on the lab's evidence.
+
+**Routed (on answer):** roadmap 🖥️ Building/interface lane horizon · the plan's status
+banner · `ideas/ux-lab-interface-gallery-2026-06-12.md` lifecycle state.

--- a/docs/planning/ux-lab-interface-gallery-plan-2026-06-12.md
+++ b/docs/planning/ux-lab-interface-gallery-plan-2026-06-12.md
@@ -1,0 +1,355 @@
+# UX Lab — design + implementation plan (the interface gallery cog)
+
+> **Status:** `plan` — owner-commissioned design (2026-06-12). **Not yet scheduled**:
+> implementation slotting + audience are open in router **Q-0116**; the decade queue
+> ([reconciliation pass](reconciliation-pass-2026-06-12.md) §4) is unchanged until the
+> owner steers. Cross-check every library claim against source before implementing —
+> the verified-facts section below is dated and pinned to discord.py 2.7.1.
+> Capture/origin: [`../ideas/ux-lab-interface-gallery-2026-06-12.md`](../ideas/ux-lab-interface-gallery-2026-06-12.md).
+
+---
+
+## 0. Mission
+
+One admin-gated panel (`!uxlab`) that makes every Discord UX pattern SuperBot could use
+**visible, clickable, and comparable** — so the owner picks layouts by looking at them,
+agents reuse named patterns instead of inventing panels, and platform limits stay
+verifiable against the live library. Three product roles in one cog:
+
+| Role | What it does | Who it serves |
+|---|---|---|
+| **Gallery** | Browse every interaction/layout pattern, each with a visible fake reaction + a spec card | The owner's compare-and-choose loop; agents needing a shared vocabulary |
+| **Probe bench** | Press-a-button re-verification of platform limits against the installed library | The platform-limits doc; any session about to lean on a cap |
+| **Mock studio** | Clickable mockups of approved-but-unbuilt features (Q-0108–Q-0112 lane) | Design review of the safety/community family plan before it is built |
+
+**The spine property: the lab never mutates anything.** No DB reads/writes, no guild
+mutations, no audit events, no settings. All "state" is in-memory view state; all output
+is messages in the invoking channel. Enforced by an AST fence test (§7), not by promise.
+
+---
+
+## 1. Verified platform facts (pinned 2026-06-12, discord.py 2.7.1)
+
+Everything below was verified by **introspecting the installed library** this session.
+The probe bench (§6) exists to re-verify these on demand — when a probe disagrees with
+this table, trust the probe, fix the table (and `docs/operations/discord-platform-limits.md`).
+
+| Fact | Value | Source |
+|---|---|---|
+| Legacy `View` component ceiling | 25 items (5 action rows × 5) | platform-limits doc §1 |
+| **Components V2 (`LayoutView`) child ceiling** | **40 total (nested count)** | `LayoutView` raises `ValueError('maximum number of children exceeded (40)')` |
+| **CV2 text budget** | **4000 display characters across all items** | `LayoutView` docstring + validation |
+| CV2 top-level items | `ActionRow`, `Section`, `TextDisplay`, `MediaGallery`, `File`, `Separator`, `Container` | `discord.ui` exports, all `versionadded: 2.6` |
+| `Section` shape | ≤3 `TextDisplay`s + 1 accessory (`Thumbnail` or `Button`) | class docstring |
+| `MediaGallery` | ≤10 `MediaGalleryItem`s | class docstring |
+| `Container` | nestable, `accent_colour`, `spoiler` | `__init__` signature |
+| CV2 message shape | replaces `content`/`embeds`; polls/stickers unavailable; attachments must be referenced by a component | Discord docs — **probe-verify** (P-09) |
+| **Modals** | `Label` (2.6+) wraps a component inside a modal — **selects in modals are now possible**; which select types work is probe P-07/P-08 | `ui.Label.__init__(text, component, description)` |
+| Button styles | `primary`, `secondary`, `success`, `danger`, `link`, `premium` (SKU-gated) | `discord.ButtonStyle` |
+| Select types | `Select` (string, 2–25 options), `UserSelect`, `RoleSelect`, `ChannelSelect`, `MentionableSelect` | `discord.ui` exports |
+| Embeds | 10/message; 6000 chars combined; field/footer/title caps | platform-limits doc §2 |
+| Bot attachments | ~8 MiB cap; alt text via attachment `description` | platform-limits doc §3 |
+
+**Two stale-doc corrections shipped with this design** (found while verifying):
+`discord-platform-limits.md` §1 claimed CV2 has a 25-component budget (it is 40, with a
+4000-char text budget); the session journal claimed modals cannot contain selects
+(true pre-2.6, false on the 2.7 pin).
+
+---
+
+## 2. Architecture (binding-rule compliant)
+
+```text
+disbot/cogs/ux_lab_cog.py            # thin: !uxlab command + hub creation, nothing else
+disbot/views/ux_lab/
+  __init__.py
+  home.py        # UxLabHomeView(HubView) — category nav, edit-in-place transitions
+  buttons.py     # wing 1: button styles, layouts, confirm flows, wizards
+  selects.py     # wing 2: all 5 select types, multi-select, paginated >25 pattern
+  modals.py      # wing 3: text inputs, Label-wrapped selects, validation-fail flow
+  embeds.py      # wing 4: embed card archetypes
+  layout_v2.py   # wing 5: LayoutView/CV2 exhibits  ← experimental lineage, commented
+  image_cards.py # wing 6: PIL exhibits (reuses existing renderers)
+  mockups.py     # wing 7: approved-lane feature mockups (all marked MOCK)
+  probes.py      # wing 8: the limit-verification bench
+  compare.py     # wing 9: side-by-side A/B with verdict lines
+disbot/utils/ux_patterns/
+  __init__.py
+  registry.py    # PatternSpec dataclass + REGISTRY + validation helpers
+  builders.py    # pure embed/component builders shared by exhibits
+```
+
+Decisions and why:
+
+- **No service layer.** Services exist for business logic and owned writes
+  (`docs/ownership.md`); the lab has neither. A `ux_lab_service` would be ceremony.
+  The cog routes; views render; `utils/ux_patterns/` holds data + pure builders.
+- **`utils/ux_patterns/` is layer-legal**: utils may import stdlib + discord only
+  (architecture table), and the registry/builders import exactly that. Per
+  `docs/helper-policy.md`, pattern builders that future `views/` *and* potentially
+  `services/`-adjacent renderers will reuse belong in `utils/` — this is the promotion
+  home, not a grab-bag (each module has one owner and one purpose).
+- **Canonical view lineage, no second framework** (rejection ledger §6): every wing
+  view extends `HubView`/`BaseView`; navigation uses `views/navigation.py`
+  (`transition_to` edit-in-place, `attach_back_button`) so the lab itself *demonstrates*
+  the V-02 doctrine (breadcrumb header line, update-in-place, no dead ends).
+- **The CV2 wing is the one sanctioned exception**: `LayoutView` is a sibling of
+  `discord.ui.View`, so `layout_v2.py` classes cannot extend `BaseView`. They extend
+  `discord.ui.LayoutView` directly with the standard "intentional divergence" comment
+  (the same carve-out game-state views use) + an entry in the BaseView-conformance
+  ratchet's disposition notes. **Extracting a shared `BaseLayoutView` is explicitly
+  deferred** until/unless CV2 is adopted for real panels (that adoption is ADR-shaped,
+  decided on the lab's evidence — not by this plan).
+- **Gating:** command `@commands.has_permissions(administrator=True)`; every callback
+  re-checks via `views/base.interaction_is_admin` (capability-authority panel-callback
+  rule). Registered via `scripts/new_subsystem.py`, hidden from Help (workbench, not a
+  member feature) — audience widening is Q-0116's call.
+- **Lifecycle:** the hub is a normal `HubView` (180 s timeout — and the disable-on-
+  timeout behavior is itself exhibit B-10). One exhibit (PR B) demonstrates a
+  `PersistentView` through the canonical `core/runtime/persistent_views.py` registration
+  so restart-survival is visible; it is registered like any other persistent view, no
+  parallel mechanism.
+
+---
+
+## 3. The pattern registry (the durable artifact)
+
+```python
+class PatternCategory(Enum):
+    BUTTONS, SELECTS, MODALS, EMBEDS, LAYOUT_V2, IMAGE, MOCKUP, PROBE
+
+class PatternStatus(Enum):
+    STABLE, EXPERIMENTAL, DEPRECATED, REJECTED
+
+@dataclass(frozen=True)
+class PatternSpec:
+    pattern_id: str                  # "danger_confirm_then_result" — the shared vocabulary
+    title: str                       # "Danger action → confirm → result"
+    category: PatternCategory
+    status: PatternStatus
+    uses_components_v2: bool
+    requires_pil: bool
+    requires_modal: bool
+    recommended_for: tuple[str, ...] # "destructive admin actions", "settings apply"
+    anti_patterns: tuple[str, ...]   # "never for read-only actions (adds friction)"
+    limits: tuple[str, ...]          # the platform caps this pattern leans on
+    adopted_by: tuple[str, ...]      # real views using it — grows as patterns graduate
+    notes: str
+```
+
+- `REGISTRY: dict[str, PatternSpec]` + a renderer mapping `pattern_id → builder`.
+- Every exhibit panel shows its **spec card** (an embed of the metadata) next to the
+  rendered pattern — this satisfies "every demo states what real feature it could be
+  used for" and "states its limits" by construction.
+- The registry is the source for the eventual **`docs/ux/pattern-library.md`** export
+  (PR C): the doc is generated/pinned from the registry the same way other doc-pin
+  tests work, so doc and code cannot drift.
+- Future plans/PRs reference patterns by id ("the settings apply flow uses
+  `settings_multi_select_preview`") — and a pattern's `adopted_by` tuple records where
+  it landed, giving the periodic REVIEW pass a real adoption signal.
+
+---
+
+## 4. Gallery inventory (the inclusive list)
+
+Wing exhibits, each with a named `pattern_id`, a visible reaction, and a spec card.
+This inventory is the design's "most versatile and inclusive" core — drawn from the
+owner brainstorm, the ChatGPT draft, the hub-ui-standard audit table, the
+server-management roadmap's selector gaps, and the V-02/V-03 vision doctrine.
+
+### Wing 1 — Buttons (`buttons.py`)
+
+| id | Exhibit | Reaction |
+|---|---|---|
+| B-01 `button_style_strip` | All 6 styles incl. disabled + `premium` (shown disabled, SKU note) + link button | Click → ephemeral "you pressed X" |
+| B-02 `button_emoji_forms` | Emoji-only vs emoji+text vs text-only (a11y note: emoji-only needs a text fallback) | Click → swaps the form in place |
+| B-03 `home_panel_4` | The V-03 4-button home shape (Play / Server & Info / My Stuff / Manage) | Click → fake category page, breadcrumb updates |
+| B-04 `dense_action_row` | 5-button dense row + a second nav row (operator-hub density) | Counters update in place |
+| B-05 `danger_confirm_then_result` | Danger → confirm panel (the doctrine pattern) | Confirm → fake "done" result card; Cancel → back |
+| B-06 `confirm_via_modal` | Danger → type-to-confirm modal (for truly destructive ops) | Match → fake result; mismatch → validation error |
+| B-07 `wizard_next_back` | Multi-step wizard: Next/Back/Cancel/Save with progress header | Steps swap in place; Save → summary embed |
+| B-08 `paginator_classic` | ◀ ▶ page buttons + page indicator + jump-to select | Pages swap in place |
+| B-09 `toggle_pills` | A row of on/off toggle buttons re-rendering state (the automod-rule shape) | Style flips success/secondary |
+| B-10 `timeout_behavior` | Short-timeout view demonstrating disable-on-timeout | Wait 15 s → buttons grey out |
+
+### Wing 2 — Selects (`selects.py`)
+
+| id | Exhibit | Reaction |
+|---|---|---|
+| S-01 `category_select_single` | String select as navigation (GamesHub shape) | Pick → fake child page |
+| S-02 `settings_multi_select_preview` | Multi-select (min/max) → **Preview selected → Apply** confirmation | Preview embed lists picks; Apply → fake success |
+| S-03 `select_paginated_over_25` | **The >25 pattern**: category select → paginated select (◀ ▶ re-fills options) | Solves the server-mgmt 25-truncation gap |
+| S-04 `entity_selects` | `UserSelect` / `RoleSelect` / `ChannelSelect` / `MentionableSelect`, one per page | Pick → echoes the resolved entity, no mutation |
+| S-05 `select_with_descriptions` | Option descriptions + emojis + a default-selected option | Pick → spec card highlights caps (100-char) |
+| S-06 `filter_then_list` | Two-stage filter: select narrows, second select picks (hierarchy filtering) | Both swap in place |
+| S-07 `select_as_verb_picker` | Platform-manager shape: target select + verb button bank | Verb → fake pipeline-result card |
+| S-08 `search_via_modal` | Button → modal text input → select re-filled with "matches" | The search-inside-a-select emulation |
+
+### Wing 3 — Modals (`modals.py`)
+
+| id | Exhibit | Reaction |
+|---|---|---|
+| M-01 `modal_short_long` | Short + paragraph inputs, required/optional, placeholders, length caps | Submit → echo embed |
+| M-02 `modal_label_select` | **`Label`-wrapped string select inside a modal** (2.6+ capability) | Submit → echo; doubles as probe evidence |
+| M-03 `modal_validation_fail` | Server-side validation failure → ephemeral error → reopen hint | Shows the failure UX honestly |
+| M-04 `modal_preview_save` | Modal → preview card → Save/Edit loop (the Q-0059 home-embed shape) | Edit reopens prefilled |
+| M-05 `modal_report_form` | Report/feedback form (reason select + details paragraph) | Submit → fake mod-queue card |
+| M-06 `modal_template_editor` | Custom-command shape: trigger + template + preview rendering `{user}` vars | Submit → rendered preview |
+
+### Wing 4 — Embeds (`embeds.py`)
+
+Card archetypes, each one embed with realistic sample data + a "use for / don't use
+for" spec card: `info_card` · `success_card` · `warning_card` · `error_card` ·
+`audit_log_compact` (the server-logging shape, Q-0109) · `moderation_case` ·
+`user_profile` (the myprofile PR-A shape) · `leaderboard_table` (code-block alignment
+vs field columns, both shown) · `setup_summary` (wizard final-review shape) ·
+`ai_answer_with_sources` (provenance footer) · `before_after_diff` (the draft-lane
+Final Review shape) · `color_strip` (one embed per standard palette colour — the
+light/dark-theme readability check). Plus E-13 `embed_budget_edge`: a deliberately
+maximal embed (25 fields, 6000-char total) to *see* what dense actually looks like.
+
+### Wing 5 — Components V2 (`layout_v2.py`, all `EXPERIMENTAL`)
+
+| id | Exhibit |
+|---|---|
+| V2-01 `cv2_text_only` | Pure `TextDisplay` message (markdown, no embed chrome) |
+| V2-02 `cv2_section_accessory` | `Section` ×3 text + `Thumbnail`; sibling with a `Button` accessory |
+| V2-03 `cv2_container_dashboard` | `Container` with accent colour: header text, separator, action row — the "rich card without embeds" |
+| V2-04 `cv2_media_gallery` | `MediaGallery` with 1 / 4 / 10 items (grid behavior) |
+| V2-05 `cv2_file_display` | `File` component rendering an attached text file inline |
+| V2-06 `cv2_settings_page` | A settings-page recreation in CV2 (the direct comparison target for today's `SettingsHubView`) |
+| V2-07 `cv2_mobile_compact` | The same content twice: dense vs compact — for a phone-vs-desktop look |
+| V2-08 `cv2_interactive_mix` | Buttons + select *inside* containers/sections (interaction parity check) |
+
+Every V2 exhibit footer states: "CV2 message — no content/embeds/polls; 40-child /
+4000-char budget; adoption for real panels is a separate ADR decision."
+
+### Wing 6 — PIL image cards (`image_cards.py`)
+
+**Reuse first** (helper-policy): the mining inventory + stat-card renderers (#665) and
+the gear paper-doll compositor (#702) already exist — the wing exhibits them with
+sample data rather than re-implementing. New prototypes: `welcome_card` (avatar circle
+composite — the Q-0110 phase-2 preview, shown beside the embed-only variant),
+`leaderboard_image` (top-10 with avatars), `event_poster`. Every exhibit reports
+render time, output bytes vs the 8 MiB cap, format choice (JPEG/WebP per the limits
+doc §4), runs under `asyncio.to_thread`, and sets attachment alt text (a11y demo).
+
+### Wing 7 — Mock studio (`mockups.py`) — the approved-lane preview
+
+Clickable, clearly-bannered **MOCK** panels for the Q-0108–Q-0112 family, so the
+family plan (decade slot 8) is reviewed on rendered UI:
+
+- `mock_automod_rules` — 4 rule cards (spam/links/caps/mentions, the Q-0108 set) with
+  toggle pills + a threshold modal; state is view-local only.
+- `mock_logging_routing` — the Q-0109 open choice rendered: single-channel vs
+  per-category routing, switchable live to *feel* both.
+- `mock_welcome_ab` — Q-0110's exact decision: embed-only vs PIL-card welcome,
+  side-by-side with the same fake member.
+- `mock_event_rsvp` — Sesh-style event card with RSVP buttons + an NL-parse preview
+  ("friday 8pm" → parsed time card, Q-0112 shape).
+- `mock_feed_summary` — YouTube notification card with optional AI-summary block
+  (Q-0041 posture).
+- `mock_counters` — fake "📊 Members: 1,234" voice-channel preview card.
+- `mock_custom_command` — trigger → template → rendered-preview flow.
+- `mock_security_alerts` — raid alert + account-age warning cards (tiers 1+2 only,
+  per Q-0111; tiers 3+4 deliberately absent — they were declined).
+
+### Wing 8 — Probe bench (`probes.py`)
+
+Each probe = one button: attempt a crafted send → report ✅/❌ with the exact
+exception, the installed library version, and today's date (copy-paste-ready for the
+limits doc). Probes: P-01 legacy 5×5 grid · P-02 26-option select (expect failure) ·
+P-03 40-child LayoutView (expect pass) · P-04 41-child (expect `ValueError`) ·
+P-05 4000-char CV2 text budget edge · P-06 10-embed / 6000-char message ·
+P-07 modal + `Label`+string-select · P-08 modal + `Label`+entity-selects (which types
+does Discord accept?) · P-09 CV2 + `content=` mutual exclusion (expect API error) ·
+P-10 attachment alt-text round-trip. A `Run all` button posts a dated summary table —
+the artifact that keeps `discord-platform-limits.md` honest over time.
+
+### Wing 9 — Compare (`compare.py`)
+
+The owner's core loop, made first-class: pick two pattern ids (or "pattern vs a live
+panel archetype" — sample-data recreations of today's `SettingsHubView` /
+`GamesHubView` / Help home shapes from the hub-ui-standard audit table) → the panel
+renders A, a swap button flips to B in place (same data both sides) → a **Verdict**
+button emits a copy-paste markdown line
+(`uxlab-verdict: <pattern_id> — adopt|reject|tweak — <note>`) the owner pastes into
+chat/the router. Zero persistence by design; the durable ledger is the pattern
+library doc, updated by the session that receives the verdicts.
+
+---
+
+## 5. UX of the lab itself
+
+- `!uxlab` → Home: a `HubView` with one row of category buttons (wings grouped:
+  Core components · Layouts & media · Mockups · Bench), a wing select, and a
+  breadcrumb header (`🧪 UX Lab › Buttons › Danger confirm`). All transitions are
+  edit-in-place (`transition_to`); Home button everywhere; no dead ends — the lab
+  obeys (and exhibits) the V-02 doctrine and the hub-ui-standard thresholds.
+- Every exhibit page: rendered pattern (top) + spec card (bottom) + `Prev / Next /
+  Wing home` nav, so the owner can flip through a wing like a catalogue.
+- A `🔢 status` line on Home shows registry counts by category/status — the lab
+  self-reports its coverage.
+
+## 6. Slash front door
+
+`/uxlab` as a single slash front door to the same panel (command-integration
+standard: slash = front doors to panels, never one-per-sub-action). Typed `!uxlab`
+stays first-class.
+
+---
+
+## 7. Tests (CI-verifiable without Discord)
+
+1. **Zero-write AST fence** — `tests/unit/invariants/test_ux_lab_zero_write.py`:
+   across `cogs/ux_lab_cog.py`, `views/ux_lab/`, `utils/ux_patterns/` — no
+   `utils.db` / `services` / `governance` imports, no `emit_audit_action`, no
+   `pool.`/`conn.` tokens. (The `test_game_wager_write_boundary` precedent, inverted:
+   that fence forces writes *through* a seam; this one forbids writes entirely.)
+2. **Registry integrity** — unique `pattern_id`s; every spec has a renderer and every
+   renderer a spec; metadata completeness (non-empty `recommended_for`, `limits`).
+3. **Construction smoke** — every legacy exhibit view instantiates with ≤25 children;
+   every CV2 exhibit instantiates under the 40/4000 budget (the library raises at
+   construction, so plain instantiation is the test).
+4. **Spec-card render** — spec cards stay within embed caps via the existing
+   `clamp_embed` path.
+5. **(PR C) doc-pin** — `docs/ux/pattern-library.md` ↔ registry sync test, same
+   pattern as the other doc-pin tests.
+
+Cog-size ceiling (800 LOC) is respected by construction — the cog is thin; wings are
+view modules.
+
+---
+
+## 8. PR slicing (3 PRs, Q-0107 "real slice" bar)
+
+| PR | Scope | Why this cut |
+|---|---|---|
+| **A — foundation + core wings** | `utils/ux_patterns/` (registry + builders) · home hub · wings 1–4 (buttons/selects/modals/embeds) · probes P-01/02/06/07 · AST fence + registry/smoke tests · `scripts/new_subsystem.py` registration · slash front door | Immediately useful: the owner can browse the full legacy-component catalogue day one; the registry vocabulary exists from the first PR |
+| **B — CV2 + image wings** | wing 5 (`layout_v2.py` + ratchet disposition note) · CV2 probes P-03/04/05/08/09/10 · wing 6 (PIL, reusing #665/#702 renderers + welcome-card prototype) · PersistentView exhibit · platform-limits doc updated from probe output | The experimental lane, isolated so a CV2/library surprise can't block the stable gallery |
+| **C — mock studio + compare + export** | wing 7 (mockups) · wing 9 (compare + verdicts) · `docs/ux/pattern-library.md` seeded from the registry + doc-pin test · adoption guide section | The decision-making layer; ideally lands **before or with** the safety-lane family plan so Q-0108–Q-0112 UX is reviewed by clicking |
+
+All three are additive, admin-gated, zero-write — the low-risk lane where larger PRs
+are acceptable. Live verification each PR: boot the test bot (always safe), walk the
+new wings, screenshot for the PR body.
+
+## 9. Acceptance criteria
+
+- One command opens the gallery; every exhibit reacts visibly to interaction.
+- Every exhibit shows its spec card: intended real use, limits, anti-patterns, status.
+- Probes report pass/fail with exact errors against the installed library, dated.
+- Zero-mutation is CI-enforced (AST fence), not asserted in prose.
+- Pattern ids appear in at least one subsequent plan/PR as the design vocabulary
+  (the adoption signal that the lab is working).
+- `docs/ux/pattern-library.md` exists (PR C) and cannot drift from the registry.
+
+## 10. Open questions (router **Q-0116**) + explicit non-decisions
+
+- **Scheduling:** where do PRs A–C sit relative to the decade queue? Recommendation:
+  PR A as an owner-steered near-term slice; PR C before/with the family plan (slot 8)
+  so the safety-lane UX review happens on rendered panels. Owner's call — the queue
+  doc says steered swaps are by design.
+- **Audience:** admin-gated (recommended — staff can browse) vs owner-only.
+- **Non-decision (pinned):** the lab does **not** decide CV2 adoption for real
+  panels. That is a future ADR, taken on the lab's rendered evidence + probe results.
+  No session should cite this plan as authority to migrate live panels to LayoutView.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -187,6 +187,15 @@ Folio: [settings-bindings-provisioning](subsystems/settings-bindings-provisionin
   target; its sequencing gate — the Help overlay editor UI — **cleared 2026-06-10**
   (the editor shipped as **#677 + #679**), so it is ready to structure into its own
   plan on the same projection seam (capture-doc T-4) before building.
+- **Next (owner-steered, awaiting Q-0116 scheduling)** — the **UX Lab interface-gallery
+  cog**: owner-commissioned design pinned in
+  [ux-lab-interface-gallery-plan](planning/ux-lab-interface-gallery-plan-2026-06-12.md)
+  (3 PRs: core wings · Components-V2 + PIL · mock studio + pattern-library export). A
+  zero-write, admin-gated gallery of every interaction/layout pattern + a platform-limit
+  probe bench + clickable mockups of the Q-0108–Q-0112 lane — the design-review surface
+  for the safety/community family plan and the evidence generator for any future
+  Components-V2 adoption ADR. Capture:
+  [ideas/ux-lab-interface-gallery](ideas/ux-lab-interface-gallery-2026-06-12.md).
 - **Later** — [command-expansion-backlog](building-roadmap/command-expansion-backlog.md)
   and [admin-powers config-coverage](building-roadmap/admin-powers-config-coverage.md):
   backlogs — cross-check source before pulling one.


### PR DESCRIPTION
## What this is

The owner commissioned a brainstorm continuation + design for "the most versatile and inclusive UX testing cog" — a gallery where he can browse every Discord UX pattern, compare against the bot's current panels, and decide what to change. This PR is the **design** (docs-only); implementation is 3 planned PRs awaiting scheduling (router **Q-0116**).

## Deliverables

- **`docs/ideas/ux-lab-interface-gallery-2026-06-12.md`** — capture: owner intent, why it's durable (UX decisions move from prose to perception · shared `pattern_id` vocabulary for agents · platform truth stays verifiable · the Components-V2 evidence generator), scope fences from the rejection ledger (no second panel framework; zero-write; no auto-CV2-adoption).
- **`docs/planning/ux-lab-interface-gallery-plan-2026-06-12.md`** — the full design:
  - Architecture: thin `ux_lab_cog` + 9 view wings (`views/ux_lab/`) + a `utils/ux_patterns/` registry (no service layer — zero business logic, zero writes); canonical `BaseView`/`HubView` lineage + `views/navigation.py` in-place transitions; the CV2 wing as the one commented `LayoutView` exemption.
  - `PatternSpec` registry schema → every exhibit carries id/status/limits/anti-patterns metadata that later exports to `docs/ux/pattern-library.md` (doc-pinned).
  - **~60-exhibit inventory** across buttons / selects (incl. the >25 pagination pattern) / modals (incl. Label-wrapped selects) / embed archetypes / Components V2 / PIL cards (reusing the #665/#702 renderers) / **mock studio for the approved Q-0108–Q-0112 features** / a 10-probe **limit-verification bench** / side-by-side compare with verdict lines.
  - Zero-mutation enforced by an AST fence test (the `test_game_wager_write_boundary` precedent, inverted).
  - 3-PR slicing (A core wings · B CV2+PIL · C mock studio + pattern-library export), CI-verifiable tests, acceptance criteria.

## Verified-fact corrections (found while grounding the design)

- **`docs/operations/discord-platform-limits.md` was wrong about Components V2**: it claimed a 25-component budget. Verified against the installed discord.py **2.7.1** source: `LayoutView` enforces **40 children** and a **4 000-char display-text budget** (25 is the legacy `View` ceiling). Corrected with a dated note + CV2 constraint table.
- **`.session-journal.md`'s "a Modal cannot contain a Select" rule is stale on the 2.7 pin**: `discord.ui.Label` (2.6+) wraps selects inside modals. Corrected in place.

## Also in this PR

- Router **Q-0116** (OPEN): implementation scheduling (recommended: PR A near-term steered; PR C before/with the safety-lane family plan so Q-0108–Q-0112 UX is reviewed by clicking) + audience (recommended: admin-gated).
- Roadmap 🖥️ Building/interface lane horizon + ideas README index entry.

## Note for the next session

`check_reconciliation_due` reports the **Q-0107 reconciliation pass is DUE** (merged PRs crossed #750; last pass #741). This session was owner-steered to the UX Lab design, so the pass is left for the next session — or the #752 nightly docs-reconciliation Routine, if wired.

https://claude.ai/code/session_01Bj1NppGr719EGfqS6zXrgx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bj1NppGr719EGfqS6zXrgx)_