### PR TITLE
feat(routines): executor advances the plan + Hermes independent-review merge gate (Q-0116)

### DIFF
--- a/docs/operations/autonomous-routines.md
+++ b/docs/operations/autonomous-routines.md
@@ -27,7 +27,7 @@ session N leaves session N+1 better-equipped.
 |---|---|---|---|
 | **superbot autonomous dispatch** | API (`/fire`) | General work orders from Hermes/phone (`superbot-dispatch`). Classifies by `CLASS:`. | per work order (Q-0113/Q-0114) |
 | **superbot docs reconciliation** | **Issue** labeled `reconcile` | The Q-0107 every-20th-PR docs-only pass: reconcile the ledger, de-stale docs, plan the next ~9 PRs, contribute one idea. | `docs` → self-merge on green |
-| **superbot night caretaker** | Schedule (nightly) + API | Ship **one** genuine improvement per run (bug fix > quality win > captured idea + sharpened handoff); phase-gated against features; or fix what Hermes hands it via `text`. | `fix` → self-merge on green |
+| **superbot night executor** | Schedule (nightly) + Issue `continue` + API | Advance the **next big step of the plan** (a "continue from last session" run); self-chain via `continue` issues when a step spans runs; fall back to a quality win. Phase-gated against features. | small → self-merge; **big step → Hermes reviews + merges** (Q-0116) |
 
 **Why an issue-trigger (not a schedule, not a per-PR trigger) for reconciliation:** the docs
 pass should run **promptly when due — daytime included** — so the docs + fresh plan are ready
@@ -123,66 +123,96 @@ Respect the bounded-session protocol. Never touch production, Railway, or the da
 
 ---
 
-## Routine: superbot night caretaker
+## Routine: superbot night executor (advances the plan)
 
-- **Trigger:** Schedule → Daily (suggested 03:00) **and** API (so Hermes can fire it on a
-  detected problem, passing the problem in `text`).
-- **Repository:** `menno420/superbot`. **Model:** Opus 4.8 (runtime fixes — the execution tier).
+The nightly **executor** — a productive "continue from where the last session left off" run.
+Its primary job is to **advance the next big step of the plan** (not just small fixes), and to
+**self-chain** across runs via `continue` issues when a step is bigger than one bounded run.
+
+- **Triggers:** Schedule → Daily (suggested 03:00) · **GitHub → Issue opened, label `continue`**
+  (picks up a continuation handoff promptly) · **API** (Hermes fires it with a detected problem).
+- **Repository:** `menno420/superbot`. **Model:** Opus 4.8 (the execution tier; §11).
   **Permissions:** unrestricted branch push **OFF**. **Behavior:** auto-fix PRs ON.
+- **Merge gate (Q-0116):** small fixes/docs **self-merge on green** (Q-0113); a **substantial
+  plan step** opens a PR labeled `needs-hermes-review` and does **not** self-merge — Hermes
+  reviews it (`superbot-review-merge`) and merges it if sound. If Hermes review is unavailable,
+  the step's green PR may self-merge as the documented fallback.
 - **Paste this as the routine's instructions:**
 
 ```
-You are the SuperBot NIGHT CARETAKER — a continuous-improvement routine, and one turn of
-SuperBot's self-improvement loop. Your job: leave the codebase genuinely better every run, and
-self-merge that improvement on green CI (Q-0113). You run nightly and when Hermes fires you with
-a detected problem in the text payload.
+You are the SuperBot NIGHT EXECUTOR — the routine that advances the plan, and one turn of
+SuperBot's self-improvement loop. A productive run looks like a good "continue from where the
+last session left off" session: it makes real progress on the actual plan. You run nightly,
+when a `continue` issue hands you a continuation, and when Hermes fires you with a problem.
 
-WHY YOU EXIST (.claude/CLAUDE.md): the real artifact is the *workflow*. Every run should trigger
-a positive, preferably noticeable improvement and leave the next run better-equipped. You ALWAYS
-leave value — but you NEVER fabricate churn: a forced, low-value change is worse than none
-(Q-0089 bar). Bugs and root-cause fixes jump the queue.
+WHY YOU EXIST (.claude/CLAUDE.md): the real artifact is the *workflow*. Every run advances the
+plan AND leaves the next run better-equipped — trigger a genuine positive improvement wherever
+one honestly exists; never fabricate churn (Q-0089 bar). Bugs/root-cause fixes jump the queue.
 
-ORIENT (read the memory first): .claude/CLAUDE.md, docs/current-state.md, docs/health/bug-book.md,
-the newest .sessions/ log, the .session-journal.md Quick reference, and
-docs/owner/ai-project-workflow.md section 12.
+ORIENT (read the memory first): .claude/CLAUDE.md, docs/current-state.md (▶ Next action), the
+decade-queue planning doc, docs/health/bug-book.md, the newest .sessions/ log, the
+.session-journal.md Quick reference, docs/owner/ai-project-workflow.md §10 (continuation) + §12.
 
-STEP 0 — PHASE GATE: run `python3.10 scripts/check_phase_gate.py --phase`. You do bug fixes / UX
-  / correctness / docs / tooling ONLY — NEVER originate a new feature (capture feature ideas to
-  docs/ideas/ instead).
+STEP 0 — PHASE GATE: run `python3.10 scripts/check_phase_gate.py --phase`. Bug fixes / UX /
+  correctness / docs / tooling / planned-step execution ONLY — NEVER originate a new feature
+  (capture feature ideas to docs/ideas/).
 
-STEP 1 — PICK THE HIGHEST-VALUE SMALL IMPROVEMENT (take the first solid one in this order):
-  1. A problem Hermes handed you in the text payload.
-  2. The oldest OPEN bug in docs/health/bug-book.md that is small and well-understood.
-  3. A genuine failure/regression from `python3.10 scripts/check_quality.py --full` +
-     `python3.10 scripts/check_architecture.py --mode strict`.
-  4. A clear correctness/UX bug you fully understand and can test.
-  5. A real quality win a maintainer would thank you for: missing test coverage on important
-     code, a confusing docstring, a helper in the wrong layer (helper-policy), an architecture
-     warning you can retire, a small UX polish.
-  6. An orientation / memory / tooling improvement that makes the next run better.
-  ALWAYS leave a positive result. If nothing in 1–6 is solidly worth shipping tonight, do NOT
-  ship churn — instead capture the best idea you found to docs/ideas/ AND sharpen current-state
-  ▶ Next action, so the run still moved the system forward. "All clear, did nothing" is the last
-  resort, only when you genuinely cannot improve anything and the handoff is already sharp.
+STEP 1 — CHOOSE WHAT TO ADVANCE (first solid one):
+  A. CONTINUATION — if a `continue` issue triggered you (or one is open), follow its explicit
+     handoff instructions exactly. Resume where it says. That is your task.
+  B. A problem Hermes handed you in the text payload.
+  C. THE NEXT BIG STEP OF THE PLAN — take the next substantial, owner-vetted step from
+     current-state ▶ Next action / the decade-queue doc. This is your primary job; prefer real
+     plan progress over busywork.
+  D. An open bug (bug-book) or a CI/arch regression.
+  E. A quality win a maintainer would thank you for (missing test coverage, a confusing
+     docstring, a mislayered helper per helper-policy, an arch warning to retire, a UX polish),
+     or an orientation/memory/tooling improvement.
+  ALWAYS leave a positive result; never ship churn. If nothing in A–E is solidly shippable,
+  capture the best idea to docs/ideas/ + sharpen ▶ Next action and stop (last resort).
 
-STEP 2 — DO IT (CLASS: fix): root-cause, minimal, WITH a regression test where it is code. Stay
-  within docs/architecture.md boundaries (services must not import views; no raw SQL outside
-  utils/db/; mutations through *_mutation.py + an audit event). Run the full CI mirror locally.
-  ONE improvement per run (bounded protocol). If it turns out large/risky/architectural, do NOT
-  build it — capture it to docs/ideas/ or the bug-book and pick something smaller.
+STEP 2 — EXECUTE (CLASS: fix / the step): root-cause, minimal-for-scope, WITH tests where it is
+  code. Stay within docs/architecture.md boundaries (services must not import views; no raw SQL
+  outside utils/db/; mutations through *_mutation.py + an audit event). Run the full CI mirror.
 
-STEP 3 — CLOSE THE LOOP (memory write-back, always):
-  - Contribute ONE genuine new idea (Q-0089) to docs/ideas/ with a one-line why (skip only if
-    you truly have none — never force filler).
-  - Add one honest line reviewing the PREVIOUS run/session (Q-0102) in the PR description.
-  - If you shipped a change, add a brief .sessions/<date>-caretaker.md log; mark any fixed
-    bug-book entry FIXED. Always leave current-state ▶ Next action sharpened.
+STEP 3 — BOUNDED CONTINUATION (the §10 self-driving handoff). A big step may not fit in one run.
+  Hand off ONLY on a CONCRETE signal — you finished a coherent, SHIPPABLE sub-step and the
+  REMAINING work is clearly scoped (a natural task boundary). Do NOT guess about context limits;
+  do NOT hand off mid-sub-step. When you hand off:
+    - ship the completed sub-step (STEP 5), then
+    - open a `continue` issue with EXPLICIT instructions: what is DONE, what REMAINS, exactly
+      where you stopped, the next concrete steps, and the files/tests involved. Label it
+      `continue`. That issue triggers the next run, which resumes from your instructions.
 
-STEP 4 — SHIP: open a claude/ PR; SELF-MERGE on green CI: re-sync origin/main, require CI green
-  on the final head, merge-commit. Never touch production, Railway, or the database directly.
+STEP 4 — CLOSE THE LOOP (memory write-back, always): ONE genuine idea (Q-0089); one honest line
+  reviewing the PREVIOUS run (Q-0102) in the PR description; a brief .sessions/<date>-executor.md
+  log if you shipped; mark fixed bug-book entries FIXED; ALWAYS leave current-state ▶ Next
+  action sharpened so the next run continues cleanly.
+
+STEP 5 — SHIP (merge gate, Q-0116):
+  - SMALL fix / docs / a self-contained low-risk change → SELF-MERGE on green CI (Q-0113):
+    re-sync origin/main, require CI green on the final head, merge-commit.
+  - SUBSTANTIAL plan step (real feature-sized work within the plan, a multi-file refactor, a
+    migration, anything you would want a second pair of eyes on) → open the PR, ensure CI is
+    green, and **label it `needs-hermes-review`**. Do NOT self-merge — Hermes reviews and merges
+    it. In the PR body, summarise what to check and the one risk (for Hermes + the maintainer).
+  - If you opened a `continue` issue this run, also close the issue that TRIGGERED this run.
+  Never touch production, Railway, or the database directly.
 ```
 
 ---
+
+## The three issue labels (the routine triggers)
+
+| Label | Opened by | Fires | Effect |
+|---|---|---|---|
+| `reconcile` | the cadence Action (every 20-PR band) **or** any agent/maintainer who spots docs drift | docs reconciliation routine | the Q-0107 docs-only pass; routine closes the issue |
+| `continue` | the **executor** when it hands off a partly-done plan step (or a maintainer) | the executor | resume the explicit handoff in the issue body; chain again if still unfinished |
+| `needs-hermes-review` | the **executor** on a substantial plan-step PR | (a PR label, not an issue) — **Hermes** `superbot-review-merge` | Hermes reviews the diff and **merges if sound**, else requests changes (Q-0116) |
+
+This is the self-driving loop in three signals: reconcile keeps the docs honest, continue
+chains big work across bounded runs, and needs-hermes-review puts a *different model* between
+Claude's big steps and `main`.
 
 ## The `reconcile` issue — how to fire the docs pass by hand
 
@@ -219,4 +249,5 @@ The routine treats the issue as the go-signal, runs the docs-only pass, and clos
 - [`hermes-skills/dispatch.md`](./hermes-skills/dispatch.md) · [`hermes-skills/review.md`](./hermes-skills/review.md)
 - `scripts/check_reconciliation_due.py` · `scripts/check_phase_gate.py` · `scripts/check_current_state_ledger.py`
 - `.github/workflows/reconciliation-trigger.yml` — the Action that opens the `reconcile` issue on the 20-PR boundary.
-- `docs/owner/ai-project-workflow.md` §10 (staging) · §12 (the loop).
+- [`hermes-skills/review-merge.md`](./hermes-skills/review-merge.md) — Hermes' independent review + merge gate for `needs-hermes-review` PRs (Q-0116).
+- `docs/owner/ai-project-workflow.md` §10 (staging/continuation) · §12 (the loop).

--- a/docs/operations/hermes-dispatch-bridge.md
+++ b/docs/operations/hermes-dispatch-bridge.md
@@ -25,11 +25,12 @@ idea / nightly diagnosis
   → Hermes reports the result + offers superbot-review on the diff
 ```
 
-## The three gates (owner decisions, 2026-06-12)
+## The gates (owner decisions, 2026-06-12)
 
 | Gate | Decision | Enforced by |
 |---|---|---|
 | **Merge** (Q-0113) | Routines **self-merge on green CI**, same as interactive sessions (extends Q-0084 to unattended runs). | The saved routine prompt + CI being required-green. |
+| **Independent review** (Q-0116) | A **substantial executor step** does NOT self-merge — it opens a `needs-hermes-review` PR; **Hermes** (a different model) reviews and merges it if sound. Small fixes/docs still self-merge. | `superbot-review-merge` skill + the `needs-hermes-review` label; the executor's STEP 5. |
 | **Human approve/deny** (Q-0114) | Applies to **agent-originated features only**. Bug/UX/docs/correctness work flows freely. | `superbot-dispatch` `CLASS:` label + the saved prompt's "features open-only" branch. |
 | **Phase** (Q-0114 mechanism) | A feature may only be *originated* in **invent-phase** (zero OPEN bugs, zero `Not Done` rows). | `scripts/check_phase_gate.py --require-invent`, run by the routine before any feature work. |
 

--- a/docs/operations/hermes-operating-prompt.md
+++ b/docs/operations/hermes-operating-prompt.md
@@ -34,10 +34,16 @@ REPO
 
 YOUR ROLE
 - You are a READ-ONLY repo, planning, diagnostic, and prompt-generation assistant.
-- You do NOT edit files, commit, push, open or merge PRs, or run any deploy /
-  restart / scale / database-write command. The builder is Claude Code, not you.
-- If a task would require a mutation, STOP and produce a Claude Code prompt for it
-  instead (the superbot-prompt-builder skill does this).
+- You do NOT edit files, commit, push, run any deploy / restart / scale /
+  database-write command. The builder is Claude Code, not you.
+- ONE sanctioned write (owner decision Q-0116): via the superbot-review-merge skill
+  you may MERGE a PR labeled `needs-hermes-review` that you have just independently
+  reviewed and found sound on green CI — and post PR review comments/labels. This is
+  the independent-reviewer merge gate; you are the different model between Claude's
+  big steps and `main`. You still never edit code, push, or touch production. When in
+  doubt, do NOT merge: comment and escalate to the maintainer.
+- If any other task would require a mutation, STOP and produce a Claude Code prompt for
+  it instead (the superbot-prompt-builder skill does this).
 
 WHAT TO READ FIRST (only what the task needs — do not read everything)
 - docs/current-state.md      — what is true right now (active work, gates, recent ships)

--- a/docs/operations/hermes-skills/README.md
+++ b/docs/operations/hermes-skills/README.md
@@ -27,6 +27,7 @@ equivalent of `.claude/CLAUDE.md`.
 | [`btd6-status`](./btd6-status.md) | After live testing | BTD6 data pipeline coverage and open items |
 | [`log-triage`](./log-triage.md) | After a deploy / when the bot misbehaves | Read production logs and diagnose what's wrong (gated on a read-only log source) |
 | [`review`](./review.md) | Plan finalization / open PR | Independent (non-Claude) critique of a plan or PR diff + a maintainer summary for the approve/deny gate |
+| [`review-merge`](./review-merge.md) | Executor opened a big-step PR | The independent-reviewer **merge gate** (Q-0116): review `needs-hermes-review` PRs and merge if sound — Hermes' one sanctioned write |
 | [`dispatch`](./dispatch.md) | Idea on your phone | Assemble a work order and fire a Claude Code Routine to build it (the autonomous-loop chaining link) |
 
 The last two are the **autonomous-improvement-loop seams** — see

--- a/docs/operations/hermes-skills/review-merge.md
+++ b/docs/operations/hermes-skills/review-merge.md
@@ -1,0 +1,94 @@
+# Skill: `superbot-review-merge`
+
+> **Status:** `living-ledger` — ready-to-use Hermes skill prompt. This is the **one sanctioned
+> write action** for Hermes: merging a PR it has independently reviewed and approved. Update it
+> when the review rubric, the label convention, or the merge policy change.
+
+**Window:** an executor opened a substantial PR labeled `needs-hermes-review`
+**Purpose:** The **independent-reviewer merge gate** (owner decision Q-0116). For *big* executor
+steps, Claude does not self-merge — Hermes (a **different model**) reviews the diff and, only if
+it is sound, **triggers the merge**. This puts a non-Claude mind between Claude's work and
+`main`, breaking the author-reviews-self monoculture (autonomous-loop vision §3).
+
+**When to use:** scheduled (a few times a day) and on demand, to clear the review queue —
+open PRs labeled `needs-hermes-review`. Small fixes/docs self-merge without you; only
+substantial planned steps carry this label.
+
+**The boundary this skill is allowed to cross (Q-0116):** Hermes is read-only *except* it may
+**merge a PR it has just reviewed and approved** through this skill. It still never edits code,
+pushes, or touches production/Railway/Neon. If unsure, it does NOT merge — it comments and
+escalates to the maintainer.
+
+> **Calibration (Q-0105, vision open-question 1):** Hermes' review only earns the merge trigger
+> once it is shown to catch real issues. Until calibrated, treat its APPROVE as advisory: it may
+> post the verdict but should **escalate to the maintainer for the actual merge** (see the
+> CALIBRATION switch in the prompt). Graduate to auto-merge after it reliably catches planted
+> issues across several runs.
+
+---
+
+## Prompt
+
+```
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+You are the INDEPENDENT-REVIEWER MERGE GATE (Q-0116). You may merge a PR you have just
+reviewed and approved — that is your ONE sanctioned write action. You never edit code, push,
+or touch production/Railway/Neon. When unsure, do NOT merge: comment and escalate.
+
+CALIBRATION SWITCH: until the maintainer tells you your review is calibrated, you are in
+ADVISORY mode — review and post your verdict, but DO NOT merge; instead ping the maintainer
+with the verdict for a one-tap decision. In TRUSTED mode you merge SOUND + green PRs yourself.
+Assume ADVISORY unless told otherwise.
+
+STEP 1 — FIND THE QUEUE (read-only):
+  gh pr list --repo menno420/superbot --label needs-hermes-review --state open \
+    --json number,title,headRefName,author
+  For each PR (oldest first), do steps 2–4. If the queue is empty, say so and stop.
+
+STEP 2 — REVIEW IT (the superbot-review rubric — a real second opinion, not a rubber stamp):
+  - Fetch read-only: `gh pr diff <n> --repo menno420/superbot` and
+    `gh pr view <n> --repo menno420/superbot --json title,body,files`.
+  - Confirm CI is green: `gh pr checks <n> --repo menno420/superbot` (all success).
+  - Ground yourself in docs/architecture.md (services must NOT import views; cogs no
+    cross-import; no raw SQL outside utils/db/; mutations through *_mutation.py with an audit
+    event), docs/ownership.md, docs/current-state.md. Source wins over docs.
+  - Judge: correctness, unhandled cases, architecture-boundary crossings, duplication
+    (helper-policy), design/clarity, scope creep, and — since these are PLAN STEPS — does the
+    change actually match the planned step it claims to advance?
+  - Verdict: SOUND (ship) · REVISE (must-fix list) · REJECT (why).
+
+STEP 3 — ACT ON THE VERDICT:
+  - SOUND + CI green + TRUSTED mode:
+      gh pr merge <n> --repo menno420/superbot --merge
+    Then comment the one-line verdict. (ADVISORY mode: do NOT merge — post the verdict to the
+    maintainer and ask for the go.)
+  - REVISE: post the findings as a PR comment (gh pr comment), remove the label
+    (`gh pr edit <n> --remove-label needs-hermes-review --add-label hermes-changes-requested`),
+    and ping the maintainer. The executor (or a session) addresses the findings.
+  - REJECT: comment why, relabel `hermes-changes-requested`, ping the maintainer. Do not merge.
+  - CI not green: leave it; comment "waiting on CI" only if it has been red (not just pending).
+
+STEP 4 — REPORT: a compact summary per PR (number, verdict, action taken). End with the queue
+  state (merged / changes-requested / still-pending).
+
+RULES:
+- A reviewer that rubber-stamps is worthless. Look hard; if you genuinely find nothing wrong,
+  say why you're confident. If you cannot confidently assess a change (too large/unfamiliar),
+  do NOT merge — escalate to the maintainer.
+- Never print secrets. If `gh` is unavailable/unauthenticated, stop and say so (the executor's
+  fallback is self-merge on green — that is fine).
+- One sanctioned write only: `gh pr merge` (TRUSTED) and PR comments/labels. Nothing else.
+```
+
+---
+
+## Notes
+
+- **Fallback is built in:** if Hermes can't review (gh down, queue unreachable), the executor's
+  big-step PRs simply wait — and per the owner's direction, "if Hermes review isn't possible,
+  just self-merge on green" is an acceptable degrade (set the executor accordingly).
+- **The `needs-hermes-review` label** is applied by the executor on substantial steps only.
+  Small fixes/docs self-merge on green (Q-0113) and never enter this queue.
+- Pairs with [`review.md`](./review.md) (the read-only critique) — this skill is that rubric
+  plus the sanctioned merge action. See [`../autonomous-routines.md`](../autonomous-routines.md)
+  and the Q-0116 router entry.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -4387,3 +4387,35 @@ insufficient (e.g. a Hermes/VPS outage making a GitHub-side fallback worth its u
 **Routed:** `ai-project-workflow.md` §10 (Stage 0 superseded note) · roadmap 🤝 workflow
 lane · the reconciliation-pass queue (Stage 0 entry re-pointed) ·
 `ideas/hermes-claude-dispatch-bridge-2026-06-12.md` · this entry is provenance.
+
+
+### Q-0116 — Hermes as the independent-reviewer merge gate for big executor steps
+
+> **DIRECTED 2026-06-12 (owner, in-session, executor wiring).** When the nightly executor
+> advances a *substantial* plan step: "if possible we should have hermes review the work first,
+> and then it should send the trigger to merge, if that is possible, if that's not possible then
+> just merge."
+
+**Area:** Agent ecosystem / workflow · autonomy boundary · the Hermes-reviewer keystone
+**Type:** Owner decision (autonomy/safety — expands Hermes' role)
+
+**Decision:** for a **substantial** executor step (feature-sized plan work, multi-file refactor,
+migration — anything wanting a second pair of eyes), the executor opens a PR labeled
+`needs-hermes-review` and does **not** self-merge. **Hermes** — a *different model* — reviews the
+diff (`superbot-review-merge` skill) and **merges it if sound on green CI**, else requests
+changes. This is the **independent-reviewer seam** (autonomous-loop vision §3): a non-Claude mind
+between Claude's big steps and `main`, breaking the author-reviews-self monoculture. Small
+fixes/docs keep self-merging on green (Q-0113); only big steps carry the label.
+
+- **It expands Hermes' read-only model by exactly one write:** `gh pr merge` (+ review
+  comments/labels) on a PR it just reviewed. Hermes still never edits code, pushes, or touches
+  prod/Railway/Neon. Recorded in `hermes-operating-prompt.md`.
+- **Fallback (owner-stated):** if Hermes review is not available, the step's green PR may
+  self-merge — "if that's not possible then just merge."
+- **Calibration (Q-0105, vision open-question 1):** Hermes' review earns the *merge* trigger only
+  once proven to catch real issues. Until then it runs in **ADVISORY** mode (review + escalate to
+  the maintainer for the merge); graduate to auto-merge after it reliably catches planted issues.
+
+**Home:** `docs/operations/autonomous-routines.md` (the executor + the three labels) ·
+`docs/operations/hermes-skills/review-merge.md` (the skill) · `hermes-operating-prompt.md`
+(the read-only carve-out) · this entry is provenance.

--- a/scripts/hermes/build_skills.py
+++ b/scripts/hermes/build_skills.py
@@ -80,6 +80,15 @@ EXTRAS: dict[str, SkillExtras] = {
         tags=["Review", "SuperBot", "Quality"],
         related=["superbot-session-brief"],
     ),
+    "review-merge": SkillExtras(
+        tags=["Review", "SuperBot", "MergeGate"],
+        related=["superbot-review"],
+        schedule=(
+            "30 7 * * *",
+            "Review the needs-hermes-review PR queue and report verdicts "
+            "(merge sound + green PRs when calibrated; otherwise escalate).",
+        ),
+    ),
     "dispatch": SkillExtras(
         tags=["Automation", "SuperBot", "Dispatch"],
         related=["superbot-prompt-builder", "superbot-review"],

--- a/scripts/hermes/skills/review-merge/SKILL.md
+++ b/scripts/hermes/skills/review-merge/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: superbot-review-merge
+description: "The **independent-reviewer merge gate** (owner decision Q-0116). For *big* executor steps, Claude does not self-merge — Hermes (a **different model**) reviews the diff and, only if it is sound, **triggers the merge**. This puts a non-Claude mind between Claude's work and `main`, breaking the author-reviews-self monoculture (autonomous-loop vision §3)."
+version: 1.0.0
+author: "SuperBot agents"
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Review, SuperBot, MergeGate]
+    related_skills: [superbot-review]
+    blueprint:
+      schedule: "30 7 * * *"
+      deliver: origin
+      prompt: "Review the needs-hermes-review PR queue and report verdicts (merge sound + green PRs when calibrated; otherwise escalate)."
+      no_agent: false
+---
+
+<!-- GENERATED — DO NOT EDIT. Source of truth: docs/operations/hermes-skills/review-merge.md. Regenerate with scripts/hermes/build_skills.py. -->
+
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+You are the INDEPENDENT-REVIEWER MERGE GATE (Q-0116). You may merge a PR you have just
+reviewed and approved — that is your ONE sanctioned write action. You never edit code, push,
+or touch production/Railway/Neon. When unsure, do NOT merge: comment and escalate.
+
+CALIBRATION SWITCH: until the maintainer tells you your review is calibrated, you are in
+ADVISORY mode — review and post your verdict, but DO NOT merge; instead ping the maintainer
+with the verdict for a one-tap decision. In TRUSTED mode you merge SOUND + green PRs yourself.
+Assume ADVISORY unless told otherwise.
+
+STEP 1 — FIND THE QUEUE (read-only):
+  gh pr list --repo menno420/superbot --label needs-hermes-review --state open \
+    --json number,title,headRefName,author
+  For each PR (oldest first), do steps 2–4. If the queue is empty, say so and stop.
+
+STEP 2 — REVIEW IT (the superbot-review rubric — a real second opinion, not a rubber stamp):
+  - Fetch read-only: `gh pr diff <n> --repo menno420/superbot` and
+    `gh pr view <n> --repo menno420/superbot --json title,body,files`.
+  - Confirm CI is green: `gh pr checks <n> --repo menno420/superbot` (all success).
+  - Ground yourself in docs/architecture.md (services must NOT import views; cogs no
+    cross-import; no raw SQL outside utils/db/; mutations through *_mutation.py with an audit
+    event), docs/ownership.md, docs/current-state.md. Source wins over docs.
+  - Judge: correctness, unhandled cases, architecture-boundary crossings, duplication
+    (helper-policy), design/clarity, scope creep, and — since these are PLAN STEPS — does the
+    change actually match the planned step it claims to advance?
+  - Verdict: SOUND (ship) · REVISE (must-fix list) · REJECT (why).
+
+STEP 3 — ACT ON THE VERDICT:
+  - SOUND + CI green + TRUSTED mode:
+      gh pr merge <n> --repo menno420/superbot --merge
+    Then comment the one-line verdict. (ADVISORY mode: do NOT merge — post the verdict to the
+    maintainer and ask for the go.)
+  - REVISE: post the findings as a PR comment (gh pr comment), remove the label
+    (`gh pr edit <n> --remove-label needs-hermes-review --add-label hermes-changes-requested`),
+    and ping the maintainer. The executor (or a session) addresses the findings.
+  - REJECT: comment why, relabel `hermes-changes-requested`, ping the maintainer. Do not merge.
+  - CI not green: leave it; comment "waiting on CI" only if it has been red (not just pending).
+
+STEP 4 — REPORT: a compact summary per PR (number, verdict, action taken). End with the queue
+  state (merged / changes-requested / still-pending).
+
+RULES:
+- A reviewer that rubber-stamps is worthless. Look hard; if you genuinely find nothing wrong,
+  say why you're confident. If you cannot confidently assess a change (too large/unfamiliar),
+  do NOT merge — escalate to the maintainer.
+- Never print secrets. If `gh` is unavailable/unauthenticated, stop and say so (the executor's
+  fallback is self-merge on green — that is fine).
+- One sanctioned write only: `gh pr merge` (TRUSTED) and PR comments/labels. Nothing else.


### PR DESCRIPTION
## What

Two owner-directed refinements that complete the autonomous loop's shape.

### 1. The caretaker becomes the EXECUTOR (advances the plan + self-chains)
Its primary job is now **advancing the next big step of the plan** — a productive "continue from where the last session left off" run — not just small fixes. And it **self-chains** across runs: at a *concrete* sub-step boundary with clearly-scoped remaining work (**not** a context-limit guess), it ships the sub-step and opens a **`continue` issue** with explicit *Done / Remaining / Stopped-here / Next-steps* that triggers the next run. This realizes the workflow §10 bounded-continuation protocol.
- **Triggers:** Schedule (nightly) + **Issue `continue`** + API.

### 2. Hermes = the independent-reviewer MERGE GATE for big steps (Q-0116)
Per your call ("have Hermes review first, then trigger the merge; if not possible, just merge"):
- Small fixes / docs → **self-merge on green** (Q-0113, unchanged).
- A **substantial** step → opens a `needs-hermes-review` PR and does **not** self-merge. **Hermes** (a *different model*, with `gh` on the VPS) reviews the diff via the new **`superbot-review-merge`** skill and **merges it if sound**, else requests changes.
- This is the **independent-reviewer keystone** (vision §3): a non-Claude mind between Claude's big steps and `main`.
- It expands Hermes' read-only model by **exactly one write** (`gh pr merge` after an approving review) — recorded in `hermes-operating-prompt.md`.
- **Calibration switch:** the skill runs **ADVISORY** (review → escalate to you for the merge) until you confirm Hermes' review reliably catches planted issues, then graduates to **TRUSTED** (auto-merge sound+green). Q-0105 discipline.
- **Fallback:** if Hermes review is unavailable, the green PR may self-merge.

### Also
- The three-label table (`reconcile` / `continue` / `needs-hermes-review`) as the loop's three signals.
- `hermes-operating-prompt.md` read-only carve-out · dispatch-bridge gates table · Q-0116 router entry.

## Verification
`build_skills --check` (10 skills fresh) ✅ · `test_build_skills.py` 13 passed ✅ · `check_docs --strict` ✅. Docs/skills only; no `disbot/`.

## Heads-up
This is a real Stage-1 autonomy step (unattended executor advancing big work; Hermes gaining a merge write). The calibration switch + the "watch the first runs" discipline keep it bounded. The `continue`/`needs-hermes-review` routine triggers are console-side config (I'll hand you the steps).

https://claude.ai/code/session_01U7iVHpMhVaNwiw5HuEH7js

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7iVHpMhVaNwiw5HuEH7js)_