### PR TITLE
UX Lab PR A: core gallery — registry, 4 wings (42 patterns), probe bench, zero-write fence

### DIFF
--- a/disbot/cogs/ux_lab_cog.py
+++ b/disbot/cogs/ux_lab_cog.py
@@ -1,0 +1,71 @@
+"""UX Lab cog — the interface-gallery workbench entry point.
+
+Thin by design: this cog only routes ``!uxlab`` / ``/uxlab`` to the gallery
+home view. All exhibit content lives in ``views/ux_lab/``; pattern metadata
+lives in ``utils/ux_patterns/``. The lab performs **zero writes** — no DB,
+no guild mutations, no audit events (enforced by
+``tests/unit/invariants/test_ux_lab_zero_write.py``).
+
+Design: ``docs/planning/ux-lab-interface-gallery-plan-2026-06-12.md``.
+Audience: administrators (panel callbacks re-check via BaseView author lock;
+the entry commands carry the admin permission gate). Q-0116 may widen this.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from views.base import send_panel
+from views.ux_lab import UxLabHomeView, build_home_embed
+
+logger = logging.getLogger("bot.uxlab")
+
+
+class UxLabCog(commands.Cog, name="UX Lab"):  # type: ignore[call-arg]
+    """Browse every Discord UX pattern SuperBot could use — safely fake."""
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help/hub direct-navigation hook (returns the gallery home)."""
+        if interaction.guild is None:
+            return (
+                discord.Embed(description="The UX Lab only opens inside a server."),
+                discord.ui.View(),
+            )
+        return build_home_embed(), UxLabHomeView(interaction.user)
+
+    @commands.guild_only()
+    @commands.has_permissions(administrator=True)
+    @commands.command(name="uxlab", aliases=["interfacelab"])
+    async def uxlab(self, ctx: commands.Context) -> None:
+        """Open the UX Lab — the interface gallery + limit probe bench."""
+        await send_panel(ctx, embed=build_home_embed(), view=UxLabHomeView(ctx.author))
+
+    @app_commands.command(
+        name="uxlab",
+        description="Open the UX Lab — browse interface patterns (admin).",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.guild_only()
+    async def uxlab_slash(self, interaction: discord.Interaction) -> None:
+        """Slash front door to the same panel (one door, not one per action)."""
+        view = UxLabHomeView(interaction.user)
+        await interaction.response.send_message(
+            embed=build_home_embed(),
+            view=view,
+        )
+        view.message = await interaction.original_response()
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(UxLabCog(bot))

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -87,6 +87,7 @@ INITIAL_EXTENSIONS = [
     "cogs.community_spotlight_cog",
     "cogs.setup_cog",
     "cogs.server_management_cog",
+    "cogs.ux_lab_cog",
 ]
 
 # ==========================

--- a/disbot/services/customization_catalogue.py
+++ b/disbot/services/customization_catalogue.py
@@ -100,6 +100,7 @@ KNOWN_PANEL_COMMANDS: tuple[tuple[str, str], ...] = (
     ("role", "rolemenu"),
     ("server_management", "servermanagement"),
     ("utility", "utilitymenu"),
+    ("ux_lab", "uxlab"),
     ("xp", "xpmenu"),
 )
 

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -702,6 +702,29 @@ SUBSYSTEMS: dict[str, dict] = {
             "diagnostic.latency.check",
         ],
     },
+    "ux_lab": {
+        "display_name": "UX Lab",
+        "description": "Interface gallery — browse UI patterns, all fake & safe",
+        "emoji": "🧪",
+        "color": ADMIN_COLOR.value,
+        "visibility_tier": "administrator",
+        "visibility_mode": "normal",
+        "category": "admin",
+        "tags": ["admin", "design", "gallery", "patterns"],
+        "entry_points": ["uxlab"],
+        "default_channels": ["staff", "bot-spam"],
+        "related_subsystems": [],
+        "dependencies": [],
+        "soft_dependencies": [],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "ui_priority": 20,
+        # Zero-write workbench: the lab mutates nothing (CI-fenced by
+        # tests/unit/invariants/test_ux_lab_zero_write.py), so it holds no
+        # capability of its own — authority is the administrator floor on
+        # the command plus the view's author lock.
+        "capabilities": [],
+    },
     "ai": {
         "display_name": "AI Platform",
         "description": (

--- a/disbot/utils/ux_patterns/__init__.py
+++ b/disbot/utils/ux_patterns/__init__.py
@@ -1,0 +1,30 @@
+"""UX pattern registry + pure builders for the UX Lab (zero-write workbench).
+
+See ``docs/planning/ux-lab-interface-gallery-plan-2026-06-12.md``.
+"""
+
+from utils.ux_patterns.registry import (
+    REGISTRY,
+    PatternCategory,
+    PatternSpec,
+    PatternStatus,
+    ProbeResult,
+    category_counts,
+    get_spec,
+    register,
+    specs_for,
+    validate_registry,
+)
+
+__all__ = [
+    "REGISTRY",
+    "PatternCategory",
+    "PatternSpec",
+    "PatternStatus",
+    "ProbeResult",
+    "category_counts",
+    "get_spec",
+    "register",
+    "specs_for",
+    "validate_registry",
+]

--- a/disbot/utils/ux_patterns/builders.py
+++ b/disbot/utils/ux_patterns/builders.py
@@ -1,0 +1,317 @@
+"""Pure embed/component builders shared by UX Lab exhibits.
+
+Everything here is deterministic and side-effect free: builders take plain
+arguments (or use the canned sample data below) and return ``discord.Embed``
+objects. The embed archetypes double as the candidate "standard library" of
+card shapes — when a pattern graduates (plan PR C), real cogs import the
+builder rather than re-implementing the layout.
+
+Layer rules: stdlib + discord only (``utils/`` contract). No DB, no services.
+"""
+
+from __future__ import annotations
+
+import discord
+
+from utils.ui_constants import (
+    ADMIN_COLOR,
+    CHANNEL_COLOR,
+    ECONOMY_COLOR,
+    GAME_COLOR,
+    GENERAL_COLOR,
+    MINING_COLOR,
+    MOD_COLOR,
+    ROLE_COLOR,
+    UTILITY_COLOR,
+)
+from utils.ux_patterns.registry import PatternSpec, PatternStatus
+
+# ---------------------------------------------------------------------------
+# Sample data (no real users, no real guild state)
+# ---------------------------------------------------------------------------
+
+SAMPLE_MEMBERS: tuple[str, ...] = (
+    "AstroFox",
+    "BananaMage",
+    "CinderWolf",
+    "DuskRunner",
+    "EmberLynx",
+    "FrostByte",
+    "GlowStick",
+    "HexHound",
+)
+
+SAMPLE_LEADERBOARD: tuple[tuple[str, int, int], ...] = (
+    ("AstroFox", 42, 13_370),
+    ("BananaMage", 39, 11_204),
+    ("CinderWolf", 35, 9_876),
+    ("DuskRunner", 31, 8_545),
+    ("EmberLynx", 28, 7_002),
+)
+
+_STATUS_COLORS: dict[PatternStatus, discord.Color] = {
+    PatternStatus.STABLE: discord.Color.green(),
+    PatternStatus.EXPERIMENTAL: discord.Color.orange(),
+    PatternStatus.DEPRECATED: discord.Color.dark_grey(),
+    PatternStatus.REJECTED: discord.Color.red(),
+}
+
+# The named palette every subsystem embed draws from (the colour-strip
+# exhibit renders one embed per entry; keep ≤9 so strip + spec card ≤10).
+PALETTE: tuple[tuple[str, discord.Color], ...] = (
+    ("ADMIN_COLOR", ADMIN_COLOR),
+    ("MOD_COLOR", MOD_COLOR),
+    ("ECONOMY_COLOR", ECONOMY_COLOR),
+    ("GAME_COLOR", GAME_COLOR),
+    ("MINING_COLOR", MINING_COLOR),
+    ("ROLE_COLOR", ROLE_COLOR),
+    ("CHANNEL_COLOR", CHANNEL_COLOR),
+    ("UTILITY_COLOR", UTILITY_COLOR),
+    ("GENERAL_COLOR", GENERAL_COLOR),
+)
+
+
+def _join(items: tuple[str, ...], *, bullet: str = "• ") -> str:
+    return "\n".join(f"{bullet}{i}" for i in items) if items else "—"
+
+
+def spec_card(spec: PatternSpec) -> discord.Embed:
+    """The metadata card shown under every exhibit."""
+    flags: list[str] = []
+    if spec.uses_components_v2:
+        flags.append("Components V2")
+    if spec.requires_modal:
+        flags.append("modal")
+    if spec.requires_pil:
+        flags.append("PIL")
+    embed = discord.Embed(
+        title=f"📐 {spec.title}",
+        description=spec.notes or None,
+        color=_STATUS_COLORS[spec.status],
+    )
+    embed.add_field(
+        name="Pattern",
+        value=f"`{spec.pattern_id}` · {spec.status.value}"
+        + (f" · {', '.join(flags)}" if flags else ""),
+        inline=False,
+    )
+    embed.add_field(name="Use for", value=_join(spec.recommended_for), inline=True)
+    embed.add_field(name="Avoid for", value=_join(spec.anti_patterns), inline=True)
+    embed.add_field(name="Platform limits", value=_join(spec.limits), inline=False)
+    embed.add_field(
+        name="Adopted by",
+        value=_join(spec.adopted_by) if spec.adopted_by else "— (not adopted yet)",
+        inline=False,
+    )
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Embed archetypes (the embeds wing + reusable card shapes)
+# ---------------------------------------------------------------------------
+
+
+def build_info_card() -> discord.Embed:
+    embed = discord.Embed(
+        title="ℹ️ Server time settings",
+        description=(
+            "Short, scannable information with one optional action hint.\n"
+            "Keep to ≤3 fields; link the panel for anything deeper."
+        ),
+        color=GENERAL_COLOR,
+    )
+    embed.add_field(name="Timezone", value="Europe/Amsterdam", inline=True)
+    embed.add_field(name="Quiet hours", value="23:00 – 08:00", inline=True)
+    embed.set_footer(text="Use !settings to change these")
+    return embed
+
+
+def build_success_card() -> discord.Embed:
+    embed = discord.Embed(
+        title="✅ Role created",
+        description="**@Night Crew** is live and assignable.",
+        color=discord.Color.green(),
+    )
+    embed.add_field(name="Members", value="0 (new)", inline=True)
+    embed.add_field(name="Hoisted", value="Yes", inline=True)
+    return embed
+
+
+def build_warning_card() -> discord.Embed:
+    embed = discord.Embed(
+        title="⚠️ Approaching channel cap",
+        description=(
+            "This server has **94 / 100** text channels.\n"
+            "Cleanup or archiving is recommended before bulk provisioning."
+        ),
+        color=discord.Color.orange(),
+    )
+    embed.set_footer(text="Warnings state the limit AND the next action")
+    return embed
+
+
+def build_error_card() -> discord.Embed:
+    embed = discord.Embed(
+        title="❌ Couldn't move the channel",
+        description=(
+            "**Missing permission:** `Manage Channels` in **#archive**.\n"
+            "Grant the bot role that permission, then retry."
+        ),
+        color=discord.Color.red(),
+    )
+    embed.set_footer(text="Errors name the cause and the fix — never just 'failed'")
+    return embed
+
+
+def build_audit_log_card() -> discord.Embed:
+    embed = discord.Embed(color=MOD_COLOR, timestamp=discord.utils.utcnow())
+    embed.set_author(name="Audit · settings.warn_threshold.update")
+    embed.description = (
+        "**AstroFox** changed **Warn threshold** `3` → `5`\n"
+        "Scope: guild · Panel: Moderation settings"
+    )
+    embed.set_footer(text="case 0231 · compact single-line audit shape")
+    return embed
+
+
+def build_moderation_case_card() -> discord.Embed:
+    embed = discord.Embed(
+        title="🔨 Case #418 — Timeout",
+        description="Repeated spam in #general after two warnings.",
+        color=MOD_COLOR,
+        timestamp=discord.utils.utcnow(),
+    )
+    embed.add_field(name="Member", value="BananaMage", inline=True)
+    embed.add_field(name="Moderator", value="AstroFox", inline=True)
+    embed.add_field(name="Duration", value="2 hours", inline=True)
+    embed.add_field(name="Prior cases", value="#377 warn · #392 warn", inline=False)
+    embed.set_footer(text="Everything a reviewing mod needs on one card")
+    return embed
+
+
+def build_user_profile_card() -> discord.Embed:
+    embed = discord.Embed(title="🪪 AstroFox", color=ROLE_COLOR)
+    embed.add_field(name="Level", value="42", inline=True)
+    embed.add_field(name="Coins", value="13,370", inline=True)
+    embed.add_field(name="Daily streak", value="17 🔥", inline=True)
+    embed.add_field(
+        name="Badges",
+        value="⛏️ Magma Miner · 🎯 Sharpshooter · 🃏 High Roller",
+        inline=False,
+    )
+    embed.set_footer(text="Profile cards: identity top, numbers middle, flair last")
+    return embed
+
+
+def build_leaderboard_field_card() -> discord.Embed:
+    embed = discord.Embed(title="🏆 Top members — field columns", color=ECONOMY_COLOR)
+    for rank, (name, level, coins) in enumerate(SAMPLE_LEADERBOARD, start=1):
+        embed.add_field(
+            name=f"#{rank} {name}",
+            value=f"Lv {level} · {coins:,} coins",
+            inline=False,
+        )
+    embed.set_footer(text="Field rows: readable, but ranks wrap on mobile")
+    return embed
+
+
+def build_leaderboard_table_card() -> discord.Embed:
+    lines = [f"{'#':<3}{'member':<12}{'lv':>4}{'coins':>9}"]
+    lines += [
+        f"{i:<3}{name:<12}{level:>4}{coins:>9,}"
+        for i, (name, level, coins) in enumerate(SAMPLE_LEADERBOARD, start=1)
+    ]
+    embed = discord.Embed(
+        title="🏆 Top members — code-block table",
+        description="```\n" + "\n".join(lines) + "\n```",
+        color=ECONOMY_COLOR,
+    )
+    embed.set_footer(text="Monospace aligns columns; ~40 chars fit on mobile")
+    return embed
+
+
+def build_setup_summary_card() -> discord.Embed:
+    embed = discord.Embed(
+        title="🧭 Setup review — 3 changes staged",
+        description="Nothing is applied until you press **Confirm**.",
+        color=ADMIN_COLOR,
+    )
+    embed.add_field(
+        name="1 · Create role",
+        value="@Events Crew (hoisted, mentionable)",
+        inline=False,
+    )
+    embed.add_field(
+        name="2 · Create channel",
+        value="#events under **Community**",
+        inline=False,
+    )
+    embed.add_field(
+        name="3 · Bind setting",
+        value="`events.announce_channel` → #events",
+        inline=False,
+    )
+    embed.set_footer(text="The draft-lane Final Review shape (numbered, reversible)")
+    return embed
+
+
+def build_ai_answer_card() -> discord.Embed:
+    embed = discord.Embed(
+        title="🤖 Round 53 cash (ABR)",
+        description=(
+            "End of round 53 you'll have **$56,318** cumulative.\n\n"
+            "**How this was computed**\n"
+            "Per-round income table (ABR set) summed r1–r53, no start shift."
+        ),
+        color=UTILITY_COLOR,
+    )
+    embed.add_field(
+        name="Sources",
+        value="• pinned game dump v55.1\n• round-cash workflow (deterministic)",
+        inline=False,
+    )
+    embed.set_footer(text="AI answers carry provenance — answer, method, sources")
+    return embed
+
+
+def build_before_after_cards() -> list[discord.Embed]:
+    before = discord.Embed(
+        title="Before — #general permissions",
+        description="@everyone: ✅ send · ✅ embed · ✅ attach",
+        color=discord.Color.dark_grey(),
+    )
+    after = discord.Embed(
+        title="After — #general permissions",
+        description="@everyone: ✅ send · ❌ embed · ❌ attach",
+        color=CHANNEL_COLOR,
+    )
+    after.set_footer(text="Two embeds, same fields, diff in bold — scan the delta")
+    return [before, after]
+
+
+def build_color_strip() -> list[discord.Embed]:
+    embeds: list[discord.Embed] = []
+    for name, color in PALETTE:
+        embed = discord.Embed(description=f"**{name}** — `#{color.value:06X}`")
+        embed.colour = color
+        embeds.append(embed)
+    return embeds
+
+
+def build_budget_edge_card() -> discord.Embed:
+    embed = discord.Embed(
+        title="🧱 Deliberately maximal embed (25 fields)",
+        description=(
+            "This is what the 25-field ceiling actually looks like. "
+            "If a real panel needs this, it wants pagination instead."
+        ),
+        color=discord.Color.dark_grey(),
+    )
+    for i in range(1, 26):
+        embed.add_field(
+            name=f"Field {i:02d}",
+            value="value text that fills the column",
+            inline=True,
+        )
+    embed.set_footer(text="Caps: 25 fields · 1024/field · 6000 chars total")
+    return embed

--- a/disbot/utils/ux_patterns/registry.py
+++ b/disbot/utils/ux_patterns/registry.py
@@ -1,0 +1,128 @@
+"""UX pattern registry — the durable metadata behind every UX Lab exhibit.
+
+Each exhibit in the UX Lab (``views/ux_lab/``) registers a :class:`PatternSpec`
+here. The registry is the source of the lab's spec cards, the Home panel's
+coverage counts, and (plan PR C) the generated ``docs/ux/pattern-library.md``
+export. Pattern ids are the shared design vocabulary future plans reference
+("use ``danger_confirm_then_result``").
+
+Layer rules: this package imports stdlib + discord only (``utils/`` contract).
+It owns no state besides the in-process registry dict and performs no I/O.
+
+Design reference: ``docs/planning/ux-lab-interface-gallery-plan-2026-06-12.md``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+_PATTERN_ID_RE = re.compile(r"^[a-z][a-z0-9_]{2,63}$")
+
+
+class PatternCategory(str, Enum):
+    """The UX Lab wing a pattern belongs to."""
+
+    BUTTONS = "buttons"
+    SELECTS = "selects"
+    MODALS = "modals"
+    EMBEDS = "embeds"
+    LAYOUT_V2 = "layout_v2"
+    IMAGE = "image"
+    MOCKUP = "mockup"
+    PROBE = "probe"
+
+
+class PatternStatus(str, Enum):
+    """Adoption status — drives the spec-card colour and the library export."""
+
+    STABLE = "stable"
+    EXPERIMENTAL = "experimental"
+    DEPRECATED = "deprecated"
+    REJECTED = "rejected"
+
+
+@dataclass(frozen=True)
+class PatternSpec:
+    """Metadata for one reusable UX pattern.
+
+    ``pattern_id`` is the durable vocabulary token. ``adopted_by`` grows as
+    real views adopt the pattern (updated by the session that adopts it).
+    """
+
+    pattern_id: str
+    title: str
+    category: PatternCategory
+    status: PatternStatus
+    recommended_for: tuple[str, ...]
+    limits: tuple[str, ...]
+    anti_patterns: tuple[str, ...] = ()
+    adopted_by: tuple[str, ...] = ()
+    uses_components_v2: bool = False
+    requires_pil: bool = False
+    requires_modal: bool = False
+    notes: str = ""
+
+
+REGISTRY: dict[str, PatternSpec] = {}
+
+
+def register(spec: PatternSpec) -> PatternSpec:
+    """Add *spec* to the registry; raise on duplicate or malformed ids."""
+    if not _PATTERN_ID_RE.match(spec.pattern_id):
+        raise ValueError(
+            f"pattern_id {spec.pattern_id!r} is not snake_case "
+            "(^[a-z][a-z0-9_]{2,63}$)",
+        )
+    if spec.pattern_id in REGISTRY:
+        raise ValueError(f"duplicate pattern_id {spec.pattern_id!r}")
+    REGISTRY[spec.pattern_id] = spec
+    return spec
+
+
+def get_spec(pattern_id: str) -> PatternSpec:
+    """Return the registered spec; raise ``KeyError`` with a helpful message."""
+    try:
+        return REGISTRY[pattern_id]
+    except KeyError:
+        raise KeyError(
+            f"unknown pattern_id {pattern_id!r} — register it in the wing module",
+        ) from None
+
+
+def specs_for(category: PatternCategory) -> tuple[PatternSpec, ...]:
+    """All specs in *category*, in registration order."""
+    return tuple(s for s in REGISTRY.values() if s.category is category)
+
+
+def category_counts() -> dict[PatternCategory, int]:
+    """Registered-pattern count per category (the Home coverage line)."""
+    counts: dict[PatternCategory, int] = {c: 0 for c in PatternCategory}
+    for spec in REGISTRY.values():
+        counts[spec.category] += 1
+    return counts
+
+
+def validate_registry() -> list[str]:
+    """Return completeness problems (empty = healthy). Pinned by unit test."""
+    problems: list[str] = []
+    for spec in REGISTRY.values():
+        if not spec.title.strip():
+            problems.append(f"{spec.pattern_id}: empty title")
+        if not spec.recommended_for:
+            problems.append(f"{spec.pattern_id}: recommended_for is empty")
+        if not spec.limits:
+            problems.append(f"{spec.pattern_id}: limits is empty")
+    return problems
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """Outcome of one platform-limit probe (rendered by the probe bench)."""
+
+    probe_id: str
+    title: str
+    ok: bool
+    detail: str
+    extras: tuple[str, ...] = ()

--- a/disbot/views/help/home_builder.py
+++ b/disbot/views/help/home_builder.py
@@ -217,7 +217,9 @@ class HomeMessageBuilderView(_EditorViewBase):
 class _EditTitleButton(discord.ui.Button):
     def __init__(self) -> None:
         super().__init__(
-            label="✏️ Edit title…", style=discord.ButtonStyle.primary, row=0,
+            label="✏️ Edit title…",
+            style=discord.ButtonStyle.primary,
+            row=0,
         )
 
     async def callback(self, interaction: discord.Interaction) -> None:
@@ -229,7 +231,9 @@ class _EditTitleButton(discord.ui.Button):
 class _EditBodyButton(discord.ui.Button):
     def __init__(self) -> None:
         super().__init__(
-            label="📝 Edit body…", style=discord.ButtonStyle.primary, row=0,
+            label="📝 Edit body…",
+            style=discord.ButtonStyle.primary,
+            row=0,
         )
 
     async def callback(self, interaction: discord.Interaction) -> None:

--- a/disbot/views/ux_lab/__init__.py
+++ b/disbot/views/ux_lab/__init__.py
@@ -1,0 +1,25 @@
+"""UX Lab views — the interface-gallery wings (zero-write workbench).
+
+Importing this package registers every exhibit's :class:`PatternSpec` in
+``utils.ux_patterns.REGISTRY`` (wing modules register at import time).
+
+Design: ``docs/planning/ux-lab-interface-gallery-plan-2026-06-12.md``.
+"""
+
+from views.ux_lab.buttons import ButtonsWingView
+from views.ux_lab.embeds import EmbedsWingView
+from views.ux_lab.home import UxLabHomeView, build_home_embed, home_builder
+from views.ux_lab.modals import ModalsWingView
+from views.ux_lab.probes import ProbesBenchView
+from views.ux_lab.selects import SelectsWingView
+
+__all__ = [
+    "ButtonsWingView",
+    "EmbedsWingView",
+    "ModalsWingView",
+    "ProbesBenchView",
+    "SelectsWingView",
+    "UxLabHomeView",
+    "build_home_embed",
+    "home_builder",
+]

--- a/disbot/views/ux_lab/buttons.py
+++ b/disbot/views/ux_lab/buttons.py
@@ -1,0 +1,674 @@
+"""UX Lab wing 1 — button styles, layouts, confirmation flows, wizards.
+
+Every exhibit is interactive and fake: callbacks mutate only the view's
+in-memory ``state`` and re-render in place, or answer with an ephemeral.
+Nothing touches the database or guild state (CI-fenced).
+"""
+
+from __future__ import annotations
+
+import discord
+
+from utils.ux_patterns import PatternCategory, PatternSpec, PatternStatus, register
+from views.base import BaseView
+from views.ux_lab.wing import ExhibitRender, ExhibitWingView
+
+_CAT = PatternCategory.BUTTONS
+_ROW_LIMITS = ("5 buttons per action row", "5 rows / 25 components per view")
+
+
+def _header(title: str, body: str) -> discord.Embed:
+    return discord.Embed(
+        title=title,
+        description=body,
+        color=discord.Color.blurple(),
+    )
+
+
+register(
+    PatternSpec(
+        pattern_id="button_style_strip",
+        title="Button style strip",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        recommended_for=(
+            "primary = the one main action",
+            "secondary = neutral/nav",
+            "success/danger = outcome-coloured verbs",
+            "link = external URLs (no callback fires)",
+        ),
+        anti_patterns=(
+            "more than one primary button per panel",
+            "danger style for non-destructive actions",
+        ),
+        limits=(
+            *_ROW_LIMITS,
+            "premium style needs a SKU id — bots without SKUs skip it",
+        ),
+        notes="Tap any button — the ephemeral names the style you pressed.",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="button_emoji_forms",
+        title="Emoji-only vs emoji+text vs text-only",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        recommended_for=(
+            "emoji+text for primary surfaces (clear at any width)",
+            "emoji-only for dense paginators (◀ ▶) with obvious meaning",
+        ),
+        anti_patterns=(
+            "emoji-only for non-universal verbs — screen readers announce "
+            "the raw emoji name",
+        ),
+        limits=("label ≤ 80 chars", *_ROW_LIMITS),
+        notes="Accessibility: emoji-only buttons need an obvious, universal glyph.",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="home_panel_4",
+        title="4-button home (the V-03 Help Home shape)",
+        category=_CAT,
+        status=PatternStatus.EXPERIMENTAL,
+        recommended_for=(
+            "top-level hubs with ≤4 clear categories",
+            "the planned Help Home (Play / Server & Info / My Stuff / Manage)",
+        ),
+        anti_patterns=("hubs whose categories exceed one row — regroup first",),
+        limits=_ROW_LIMITS,
+        notes=(
+            "Owner vision V-03/Q-0078. Click a category — the panel swaps in "
+            "place and the breadcrumb updates (V-02 doctrine)."
+        ),
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="dense_action_row",
+        title="Dense operator rows (5 actions + nav)",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        recommended_for=(
+            "operator/admin panels trading density for power "
+            "(hub-ui-standard preset 3)",
+        ),
+        anti_patterns=("member-facing hubs — keep those ≤8 visible choices",),
+        limits=_ROW_LIMITS,
+        notes="Counters update in place — watch the embed, not the buttons.",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="danger_confirm_then_result",
+        title="Danger action → confirm panel → result",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        recommended_for=(
+            "destructive admin actions (delete/purge/reset)",
+            "any action that is hard to reverse",
+        ),
+        anti_patterns=("read-only actions — confirmation there is pure friction",),
+        limits=_ROW_LIMITS,
+        adopted_by=("views/channels (delete flows)",),
+        notes="The doctrine pattern: the danger verb never executes on first click.",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="confirm_via_modal",
+        title="Type-to-confirm modal (highest friction)",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        requires_modal=True,
+        recommended_for=(
+            "truly destructive, bulk, or irreversible operations "
+            "(e.g. purge ALL settings)",
+        ),
+        anti_patterns=(
+            "routine confirmations — reserve typing for the genuinely scary",
+        ),
+        limits=(
+            "modal text input ≤ 4000 chars",
+            "modal opens only from an interaction",
+        ),
+        notes="Type the channel name exactly; a mismatch shows the validation path.",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="wizard_next_back",
+        title="Multi-step wizard (Next / Back / Cancel / Save)",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        recommended_for=(
+            "guided setup flows where each step is ONE decision "
+            "(hub-ui-standard preset 5)",
+        ),
+        anti_patterns=("flows with optional steps a user may want to jump between",),
+        limits=_ROW_LIMITS,
+        notes="Progress header + one decision per step; Save renders the summary.",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="paginator_classic",
+        title="Paginator (◀ ▶ + page indicator + jump select)",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        recommended_for=("any list longer than one screen", "leaderboards, logs"),
+        anti_patterns=("3-item lists — show them outright",),
+        limits=("jump select caps at 25 pages — chunk beyond that", *_ROW_LIMITS),
+        adopted_by=("views/ux_lab/wing.py (this browser)",),
+        notes="Wrap-around paging; the jump select teleports.",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="toggle_pills",
+        title="Toggle pills (per-item on/off buttons)",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        recommended_for=(
+            "small fixed rule/flag sets (the automod rule-card shape, Q-0108)",
+        ),
+        anti_patterns=("more than ~8 toggles — use a multi-select instead",),
+        limits=_ROW_LIMITS,
+        notes="Style flips success/secondary; the embed mirrors the state.",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="timeout_behavior",
+        title="Disable-on-timeout (BaseView lifecycle)",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        recommended_for=("every ephemeral panel — it is BaseView's default",),
+        limits=("Discord keeps components clickable forever unless disabled",),
+        adopted_by=("views/base.py BaseView.on_timeout (bot-wide)",),
+        notes=(
+            "Spawns a 15-second panel; watch the buttons grey out when the "
+            "view times out instead of silently dying."
+        ),
+    ),
+)
+
+
+class _ConfirmDeleteModal(discord.ui.Modal, title="Confirm: delete #demo-channel"):
+    """Type-to-confirm — the highest-friction confirmation shape."""
+
+    answer: discord.ui.TextInput[discord.ui.Modal] = discord.ui.TextInput(
+        label="Type the channel name to confirm",
+        placeholder="demo-channel",
+        max_length=100,
+    )
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        if str(self.answer.value).strip() == "demo-channel":
+            await interaction.response.send_message(
+                "✅ (fake) **#demo-channel deleted.** A real flow would call the "
+                "audited mutation service here.",
+                ephemeral=True,
+            )
+        else:
+            await interaction.response.send_message(
+                f"❌ Validation failed: `{self.answer.value}` ≠ `demo-channel`. "
+                "Nothing happened — exactly the point of type-to-confirm.",
+                ephemeral=True,
+            )
+
+
+class _TimeoutDemoView(BaseView):
+    """Short-lived panel demonstrating disable-on-timeout."""
+
+    def __init__(self, author: discord.Member | discord.User) -> None:
+        super().__init__(author, timeout=15)
+        for label in ("I do something", "Me too"):
+            self.add_item(
+                discord.ui.Button(label=label, style=discord.ButtonStyle.primary),
+            )
+
+
+class ButtonsWingView(ExhibitWingView):
+    """Wing 1 — buttons."""
+
+    WING_TITLE = "Buttons"
+    WING_EMOJI = "🔘"
+
+    def _exhibit_ids(self) -> tuple[str, ...]:
+        return (
+            "button_style_strip",
+            "button_emoji_forms",
+            "home_panel_4",
+            "dense_action_row",
+            "danger_confirm_then_result",
+            "confirm_via_modal",
+            "wizard_next_back",
+            "paginator_classic",
+            "toggle_pills",
+            "timeout_behavior",
+        )
+
+    def _render_exhibit(self, pattern_id: str) -> ExhibitRender:
+        render = {
+            "button_style_strip": self._ex_style_strip,
+            "button_emoji_forms": self._ex_emoji_forms,
+            "home_panel_4": self._ex_home_panel,
+            "dense_action_row": self._ex_dense_row,
+            "danger_confirm_then_result": self._ex_danger_confirm,
+            "confirm_via_modal": self._ex_confirm_modal,
+            "wizard_next_back": self._ex_wizard,
+            "paginator_classic": self._ex_paginator,
+            "toggle_pills": self._ex_toggle_pills,
+            "timeout_behavior": self._ex_timeout,
+        }[pattern_id]
+        return render()
+
+    # -- exhibits -------------------------------------------------------------
+
+    def _ex_style_strip(self) -> ExhibitRender:
+        items: list[discord.ui.Item[discord.ui.View]] = []
+        styles = (
+            ("Primary", discord.ButtonStyle.primary),
+            ("Secondary", discord.ButtonStyle.secondary),
+            ("Success", discord.ButtonStyle.success),
+            ("Danger", discord.ButtonStyle.danger),
+        )
+        for label, style in styles:
+            btn = self.demo_button(label, style=style, row=0)
+
+            async def _cb(
+                interaction: discord.Interaction,
+                pressed: str = label,
+            ) -> None:
+                await self.ack(interaction, f"You pressed the **{pressed}** style.")
+
+            btn.callback = _cb  # type: ignore[method-assign]
+            items.append(btn)
+        items.append(
+            discord.ui.Button(
+                label="Link → discord.dev",
+                style=discord.ButtonStyle.link,
+                url="https://discord.com/developers/docs/components/overview",
+                row=1,
+            ),
+        )
+        items.append(
+            self.demo_button("Disabled", row=1, disabled=True),
+        )
+        items.append(
+            self.demo_button("Premium (SKU-gated — N/A here)", row=1, disabled=True),
+        )
+        return (
+            [
+                _header(
+                    "🔘 Every button style",
+                    "Row 1: the four interactive styles — tap them.\n"
+                    "Row 2: a link button (opens a URL, **no callback fires**), "
+                    "a disabled button, and the premium style placeholder "
+                    "(needs a SKU; bots without one cannot send it).",
+                ),
+            ],
+            items,
+        )
+
+    def _ex_emoji_forms(self) -> ExhibitRender:
+        items: list[discord.ui.Item[discord.ui.View]] = []
+        forms = (
+            ("⛏️", "Mine", "emoji + text — clearest"),
+            ("⛏️", None, "emoji only — compact, weakest for a11y"),
+            (None, "Mine", "text only — always readable"),
+        )
+        for emoji, label, meaning in forms:
+            btn: discord.ui.Button[discord.ui.View] = discord.ui.Button(
+                label=label,
+                emoji=emoji,
+                style=discord.ButtonStyle.secondary,
+                row=0,
+            )
+
+            async def _cb(
+                interaction: discord.Interaction,
+                desc: str = meaning,
+            ) -> None:
+                await self.ack(interaction, f"That form is: **{desc}**.")
+
+            btn.callback = _cb  # type: ignore[method-assign]
+            items.append(btn)
+        return (
+            [
+                _header(
+                    "⛏️ The three label forms",
+                    "Same action, three labels. Tap each — the ephemeral states "
+                    "the trade-off. Default to emoji+text on primary surfaces.",
+                ),
+            ],
+            items,
+        )
+
+    def _ex_home_panel(self) -> ExhibitRender:
+        picked: str | None = self.state.get("picked")
+        items: list[discord.ui.Item[discord.ui.View]] = []
+        for emoji, label in (
+            ("🎮", "Play"),
+            ("🏠", "Server & Info"),
+            ("🎒", "My Stuff"),
+            ("🛠️", "Manage"),
+        ):
+            btn = self.demo_button(
+                label,
+                emoji=emoji,
+                style=(
+                    discord.ButtonStyle.primary
+                    if picked == label
+                    else discord.ButtonStyle.secondary
+                ),
+                row=0,
+            )
+
+            async def _cb(
+                interaction: discord.Interaction,
+                chosen: str = label,
+            ) -> None:
+                self.state["picked"] = chosen
+                await self.rerender(interaction)
+
+            btn.callback = _cb  # type: ignore[method-assign]
+            items.append(btn)
+        crumb = f"🧪 UX Lab › Home › **{picked}**" if picked else "🧪 UX Lab › Home"
+        body = f"{crumb}\n\n" + (
+            f"You are 'inside' **{picked}** — same message, new content, "
+            "breadcrumb updated. No new message was posted."
+            if picked
+            else "The owner-vision Help Home: four top-level doors. "
+            "Click one — the panel swaps **in place** (V-02)."
+        )
+        return ([_header("🏠 4-button home", body)], items)
+
+    def _ex_dense_row(self) -> ExhibitRender:
+        counts: dict[str, int] = self.state.setdefault("counts", {})
+        items: list[discord.ui.Item[discord.ui.View]] = []
+        for verb in ("Reload", "Sync", "Prune", "Export", "Audit"):
+            btn = self.demo_button(verb, row=0)
+
+            async def _cb(
+                interaction: discord.Interaction,
+                pressed: str = verb,
+            ) -> None:
+                counts[pressed] = counts.get(pressed, 0) + 1
+                await self.rerender(interaction)
+
+            btn.callback = _cb  # type: ignore[method-assign]
+            items.append(btn)
+        tally = (
+            " · ".join(f"{v} ×{n}" for v, n in counts.items())
+            if counts
+            else "none yet — press some verbs"
+        )
+        return (
+            [
+                _header(
+                    "🛠️ Dense operator row",
+                    "A full 5-button action row (the operator-hub density "
+                    f"ceiling).\n**Fake invocations:** {tally}",
+                ),
+            ],
+            items,
+        )
+
+    def _ex_danger_confirm(self) -> ExhibitRender:
+        stage: str = self.state.get("stage", "idle")
+        items: list[discord.ui.Item[discord.ui.View]] = []
+        if stage == "idle":
+            btn = self.demo_button(
+                "Delete 14 messages",
+                style=discord.ButtonStyle.danger,
+                emoji="🗑️",
+                row=0,
+            )
+
+            async def _arm(interaction: discord.Interaction) -> None:
+                self.state["stage"] = "confirming"
+                await self.rerender(interaction)
+
+            btn.callback = _arm  # type: ignore[method-assign]
+            items.append(btn)
+            body = "Press the danger verb. **Nothing executes on first click.**"
+        elif stage == "confirming":
+            confirm = self.demo_button(
+                "Yes, delete them",
+                style=discord.ButtonStyle.danger,
+                row=0,
+            )
+            cancel = self.demo_button("Cancel", row=0)
+
+            async def _confirm(interaction: discord.Interaction) -> None:
+                self.state["stage"] = "done"
+                await self.rerender(interaction)
+
+            async def _cancel(interaction: discord.Interaction) -> None:
+                self.state["stage"] = "idle"
+                await self.rerender(interaction)
+
+            confirm.callback = _confirm  # type: ignore[method-assign]
+            cancel.callback = _cancel  # type: ignore[method-assign]
+            items += [confirm, cancel]
+            body = (
+                "⚠️ **You are about to (fake-)delete 14 messages in #general.**\n"
+                "The confirm step restates scope + count — never just 'Are you sure?'."
+            )
+        else:
+            reset = self.demo_button("Reset demo", row=0)
+
+            async def _reset(interaction: discord.Interaction) -> None:
+                self.state.clear()
+                await self.rerender(interaction)
+
+            reset.callback = _reset  # type: ignore[method-assign]
+            items.append(reset)
+            body = (
+                "✅ (fake) Deleted 14 messages. A real flow now posts the result "
+                "card + an audit entry through the mutation service."
+            )
+        return ([_header("🗑️ Danger → confirm → result", body)], items)
+
+    def _ex_confirm_modal(self) -> ExhibitRender:
+        btn = self.demo_button(
+            "Delete #demo-channel…",
+            style=discord.ButtonStyle.danger,
+            emoji="⌨️",
+            row=0,
+        )
+
+        async def _open(interaction: discord.Interaction) -> None:
+            await interaction.response.send_modal(_ConfirmDeleteModal())
+
+        btn.callback = _open  # type: ignore[method-assign]
+        return (
+            [
+                _header(
+                    "⌨️ Type-to-confirm",
+                    "Opens a modal that requires typing `demo-channel` exactly. "
+                    "Try a typo first to see the validation path.",
+                ),
+            ],
+            [btn],
+        )
+
+    def _ex_wizard(self) -> ExhibitRender:
+        steps = (
+            ("Pick a name", "The (fake) role will be called **@Night Crew**."),
+            ("Pick a colour", "Going with **indigo** — tasteful."),
+            ("Hoist it?", "Yes — members show separately in the sidebar."),
+        )
+        step: int = self.state.get("step", 0)
+        saved: bool = self.state.get("saved", False)
+        items: list[discord.ui.Item[discord.ui.View]] = []
+        if saved:
+            body = "💾 **Saved (fake).** Summary:\n" + "\n".join(
+                f"{i + 1}. {t} — {d}" for i, (t, d) in enumerate(steps)
+            )
+            reset = self.demo_button("Restart wizard", row=0)
+
+            async def _restart(interaction: discord.Interaction) -> None:
+                self.state.clear()
+                await self.rerender(interaction)
+
+            reset.callback = _restart  # type: ignore[method-assign]
+            items.append(reset)
+        else:
+            title, detail = steps[step]
+            progress = " → ".join(
+                f"**{i + 1}**" if i == step else str(i + 1) for i in range(len(steps))
+            )
+            body = f"Step {progress}\n\n**{title}**\n{detail}"
+            back = self.demo_button("◀ Back", row=0, disabled=step == 0)
+            nxt = self.demo_button(
+                "Next ▶" if step < len(steps) - 1 else "Save 💾",
+                style=discord.ButtonStyle.primary,
+                row=0,
+            )
+            cancel = self.demo_button("Cancel", style=discord.ButtonStyle.danger, row=0)
+
+            async def _back(interaction: discord.Interaction) -> None:
+                self.state["step"] = max(0, step - 1)
+                await self.rerender(interaction)
+
+            async def _next(interaction: discord.Interaction) -> None:
+                if step < len(steps) - 1:
+                    self.state["step"] = step + 1
+                else:
+                    self.state["saved"] = True
+                await self.rerender(interaction)
+
+            async def _cancel(interaction: discord.Interaction) -> None:
+                self.state.clear()
+                await self.rerender(interaction)
+
+            back.callback = _back  # type: ignore[method-assign]
+            nxt.callback = _next  # type: ignore[method-assign]
+            cancel.callback = _cancel  # type: ignore[method-assign]
+            items += [back, nxt, cancel]
+        return ([_header("🧙 Wizard flow", body)], items)
+
+    def _ex_paginator(self) -> ExhibitRender:
+        pages = tuple(
+            f"Page **{n}** — imagine 10 leaderboard rows." for n in range(1, 7)
+        )
+        page: int = self.state.get("page", 0)
+        items: list[discord.ui.Item[discord.ui.View]] = []
+        prev = self.demo_button("◀", row=0)
+        indicator = self.demo_button(f"{page + 1}/{len(pages)}", row=0, disabled=True)
+        nxt = self.demo_button("▶", row=0)
+
+        async def _prev(interaction: discord.Interaction) -> None:
+            self.state["page"] = (page - 1) % len(pages)
+            await self.rerender(interaction)
+
+        async def _next(interaction: discord.Interaction) -> None:
+            self.state["page"] = (page + 1) % len(pages)
+            await self.rerender(interaction)
+
+        prev.callback = _prev  # type: ignore[method-assign]
+        nxt.callback = _next  # type: ignore[method-assign]
+        items += [prev, indicator, nxt]
+        jump: discord.ui.Select[discord.ui.View] = discord.ui.Select(
+            placeholder="Jump to page…",
+            options=[
+                discord.SelectOption(label=f"Page {n + 1}", value=str(n))
+                for n in range(len(pages))
+            ],
+            row=1,
+        )
+
+        async def _jump(interaction: discord.Interaction) -> None:
+            self.state["page"] = int(jump.values[0])
+            await self.rerender(interaction)
+
+        jump.callback = _jump  # type: ignore[method-assign]
+        items.append(jump)
+        return (
+            [_header("📖 Classic paginator", pages[page])],
+            items,
+        )
+
+    def _ex_toggle_pills(self) -> ExhibitRender:
+        rules = ("Spam", "Invites", "Caps", "Mentions")
+        flags: dict[str, bool] = self.state.setdefault(
+            "flags",
+            {r: r in ("Spam", "Invites") for r in rules},
+        )
+        items: list[discord.ui.Item[discord.ui.View]] = []
+        for rule in rules:
+            on = flags[rule]
+            btn = self.demo_button(
+                f"{rule}: {'ON' if on else 'off'}",
+                style=(
+                    discord.ButtonStyle.success if on else discord.ButtonStyle.secondary
+                ),
+                row=0,
+            )
+
+            async def _flip(
+                interaction: discord.Interaction,
+                name: str = rule,
+            ) -> None:
+                flags[name] = not flags[name]
+                await self.rerender(interaction)
+
+            btn.callback = _flip  # type: ignore[method-assign]
+            items.append(btn)
+        lines = "\n".join(f"{'🟢' if flags[r] else '⚫'} **{r}** filter" for r in rules)
+        return (
+            [
+                _header(
+                    "🚦 Toggle pills",
+                    f"The automod rule-card shape (Q-0108):\n{lines}\n\n"
+                    "Button style and embed mirror the same state.",
+                ),
+            ],
+            items,
+        )
+
+    def _ex_timeout(self) -> ExhibitRender:
+        btn = self.demo_button(
+            "Spawn a 15-second panel",
+            style=discord.ButtonStyle.primary,
+            emoji="⏱️",
+            row=0,
+        )
+
+        async def _spawn(interaction: discord.Interaction) -> None:
+            view = _TimeoutDemoView(self._author)
+            await interaction.response.send_message(
+                embed=_header(
+                    "⏱️ This panel times out in 15 s",
+                    "Don't touch it — watch the buttons disable themselves "
+                    "(BaseView.on_timeout). Stale-but-clickable panels are the "
+                    "failure this prevents.",
+                ),
+                view=view,
+                ephemeral=True,
+            )
+            view.message = await interaction.original_response()
+
+        btn.callback = _spawn  # type: ignore[method-assign]
+        return (
+            [
+                _header(
+                    "⏱️ Disable-on-timeout",
+                    "Spawns an ephemeral demo panel with `timeout=15`.",
+                ),
+            ],
+            [btn],
+        )

--- a/disbot/views/ux_lab/embeds.py
+++ b/disbot/views/ux_lab/embeds.py
@@ -1,0 +1,187 @@
+"""UX Lab wing 4 — embed card archetypes.
+
+Thirteen card shapes rendered with sample data. The builders live in
+``utils/ux_patterns/builders.py`` so a graduating pattern is imported, not
+re-implemented.
+"""
+
+from __future__ import annotations
+
+import discord
+
+from utils.ux_patterns import PatternCategory, PatternSpec, PatternStatus
+from utils.ux_patterns import builders as b
+from utils.ux_patterns import register
+from views.ux_lab.wing import ExhibitRender, ExhibitWingView
+
+_CAT = PatternCategory.EMBEDS
+_EMBED_LIMITS = (
+    "title 256 · description 4096 · 25 fields · field value 1024",
+    "10 embeds / 6000 chars total per message",
+)
+
+
+def _archetype(
+    pattern_id: str,
+    title: str,
+    *,
+    status: PatternStatus = PatternStatus.STABLE,
+    recommended_for: tuple[str, ...],
+    anti_patterns: tuple[str, ...] = (),
+    adopted_by: tuple[str, ...] = (),
+    notes: str = "",
+    extra_limits: tuple[str, ...] = (),
+) -> None:
+    register(
+        PatternSpec(
+            pattern_id=pattern_id,
+            title=title,
+            category=_CAT,
+            status=status,
+            recommended_for=recommended_for,
+            anti_patterns=anti_patterns,
+            adopted_by=adopted_by,
+            limits=(*extra_limits, *_EMBED_LIMITS),
+            notes=notes,
+        ),
+    )
+
+
+_archetype(
+    "info_card",
+    "Info card",
+    recommended_for=("read-only facts with one next-step hint",),
+    anti_patterns=("burying an action the user must take — use a panel",),
+    notes="≤3 fields, footer carries the next step.",
+)
+_archetype(
+    "success_card",
+    "Success card",
+    recommended_for=("mutation results — say WHAT changed, not just 'done'",),
+    notes="Green + the object's new state.",
+)
+_archetype(
+    "warning_card",
+    "Warning card",
+    recommended_for=("approaching limits, degraded modes",),
+    anti_patterns=("warnings without a recommended action",),
+    notes="States the limit AND the next action.",
+)
+_archetype(
+    "error_card",
+    "Error card",
+    recommended_for=("failures — name the cause and the fix",),
+    anti_patterns=("'Something went wrong' with no cause",),
+    notes="Cause + fix, never just 'failed'.",
+)
+_archetype(
+    "audit_log_compact",
+    "Compact audit line",
+    recommended_for=("server-logging feeds (Q-0109) — high volume, one-line scan",),
+    adopted_by=("services/server_logging (shape candidate)",),
+    notes="Author line = event type; description = who/what/old→new.",
+)
+_archetype(
+    "moderation_case",
+    "Moderation case card",
+    recommended_for=("mod actions with review context (prior cases inline)",),
+    notes="Everything a reviewing mod needs without clicking away.",
+)
+_archetype(
+    "user_profile",
+    "User profile card",
+    recommended_for=("the /myprofile read-only card (plan PR A there)",),
+    notes="Identity top, numbers middle, flair last.",
+)
+_archetype(
+    "leaderboard_fields",
+    "Leaderboard — field rows",
+    recommended_for=("short boards (≤10) where mentions/emoji matter",),
+    anti_patterns=("long boards — rows wrap badly on mobile",),
+    notes="Compare with the code-block variant (next exhibit).",
+)
+_archetype(
+    "leaderboard_table",
+    "Leaderboard — code-block table",
+    recommended_for=("aligned numeric boards; mobile-stable up to ~40 chars wide",),
+    anti_patterns=("rows needing mentions/emoji — code blocks render them raw",),
+    notes="Monospace wins for numbers; loses mentions.",
+)
+_archetype(
+    "setup_summary",
+    "Setup final-review summary",
+    recommended_for=("the draft-lane Final Review (numbered, nothing applied yet)",),
+    adopted_by=("setup wizard Final Review (shape)",),
+    notes="Numbered staged ops + explicit 'nothing applied' line.",
+)
+_archetype(
+    "ai_answer_with_sources",
+    "AI answer with provenance",
+    recommended_for=("every AI answer — answer, method, sources, in that order",),
+    anti_patterns=("AI prose with no provenance block",),
+    notes="The answer-with-evidence contract, as a card.",
+)
+_archetype(
+    "before_after_diff",
+    "Before/after comparison",
+    recommended_for=("permission/setting changes — scan the delta",),
+    notes="Two embeds, same field order, delta in bold.",
+)
+_archetype(
+    "embed_color_strip",
+    "Subsystem colour strip",
+    recommended_for=("checking palette readability on light + dark themes",),
+    extra_limits=("one embed per colour — strip + spec card = 10 (the cap)",),
+    notes="View this on both themes and on a phone before approving colours.",
+)
+_archetype(
+    "embed_budget_edge",
+    "Deliberately maximal embed",
+    recommended_for=("seeing what the 25-field ceiling feels like (then paginating)",),
+    anti_patterns=("shipping anything this dense to members",),
+    notes="If a panel needs this, it wants pagination.",
+)
+
+
+class EmbedsWingView(ExhibitWingView):
+    """Wing 4 — embed archetypes."""
+
+    WING_TITLE = "Embeds"
+    WING_EMOJI = "🪧"
+
+    def _exhibit_ids(self) -> tuple[str, ...]:
+        return (
+            "info_card",
+            "success_card",
+            "warning_card",
+            "error_card",
+            "audit_log_compact",
+            "moderation_case",
+            "user_profile",
+            "leaderboard_fields",
+            "leaderboard_table",
+            "setup_summary",
+            "ai_answer_with_sources",
+            "before_after_diff",
+            "embed_color_strip",
+            "embed_budget_edge",
+        )
+
+    def _render_exhibit(self, pattern_id: str) -> ExhibitRender:
+        builders: dict[str, list[discord.Embed]] = {
+            "info_card": [b.build_info_card()],
+            "success_card": [b.build_success_card()],
+            "warning_card": [b.build_warning_card()],
+            "error_card": [b.build_error_card()],
+            "audit_log_compact": [b.build_audit_log_card()],
+            "moderation_case": [b.build_moderation_case_card()],
+            "user_profile": [b.build_user_profile_card()],
+            "leaderboard_fields": [b.build_leaderboard_field_card()],
+            "leaderboard_table": [b.build_leaderboard_table_card()],
+            "setup_summary": [b.build_setup_summary_card()],
+            "ai_answer_with_sources": [b.build_ai_answer_card()],
+            "before_after_diff": b.build_before_after_cards(),
+            "embed_color_strip": b.build_color_strip(),
+            "embed_budget_edge": [b.build_budget_edge_card()],
+        }
+        return (builders[pattern_id], [])

--- a/disbot/views/ux_lab/home.py
+++ b/disbot/views/ux_lab/home.py
@@ -1,0 +1,114 @@
+"""UX Lab home — the gallery's front door.
+
+Four wing buttons + the probe bench, a coverage line driven by the pattern
+registry, and in-place transitions throughout (the lab demonstrates the
+V-02 navigation doctrine it exhibits).
+"""
+
+from __future__ import annotations
+
+import discord
+
+from utils.ux_patterns import PatternCategory, category_counts
+from views.base import HubView
+from views.ux_lab.buttons import ButtonsWingView
+from views.ux_lab.embeds import EmbedsWingView
+from views.ux_lab.modals import ModalsWingView
+from views.ux_lab.probes import ProbesBenchView
+from views.ux_lab.selects import SelectsWingView
+from views.ux_lab.wing import ExhibitWingView
+
+_WING_LABELS: dict[PatternCategory, str] = {
+    PatternCategory.BUTTONS: "Buttons",
+    PatternCategory.SELECTS: "Selects",
+    PatternCategory.MODALS: "Modals",
+    PatternCategory.EMBEDS: "Embeds",
+    PatternCategory.PROBE: "Probe bench",
+}
+
+
+def build_home_embed() -> discord.Embed:
+    """The Home card: what the lab is + live registry coverage."""
+    counts = category_counts()
+    coverage = " · ".join(
+        f"{label} **{counts[cat]}**"
+        for cat, label in _WING_LABELS.items()
+        if counts[cat]
+    )
+    embed = discord.Embed(
+        title="🧪 UX Lab — interface gallery",
+        description=(
+            "Browse every interaction pattern SuperBot could use. Every "
+            "exhibit **reacts** when you press it and carries a spec card "
+            "(use-for / avoid-for / platform limits).\n\n"
+            "**Nothing here is real**: the lab never writes to the database "
+            "or changes the server (CI-enforced)."
+        ),
+        color=discord.Color.blurple(),
+    )
+    embed.add_field(name="Exhibits", value=coverage or "—", inline=False)
+    embed.add_field(
+        name="How to browse",
+        value=(
+            "Open a wing → flip exhibits with ◀ ▶ → press things. "
+            "🏠 always returns here, in place."
+        ),
+        inline=False,
+    )
+    embed.set_footer(
+        text="Design: docs/planning/ux-lab-interface-gallery-plan-2026-06-12.md",
+    )
+    return embed
+
+
+async def home_builder(
+    interaction: discord.Interaction,
+) -> tuple[discord.Embed, discord.ui.View]:
+    """ParentBuilder for every wing's 🏠 button — rebuilds Home in place."""
+    return build_home_embed(), UxLabHomeView(interaction.user)
+
+
+class UxLabHomeView(HubView):
+    """The gallery's category hub (admin workbench — author-locked)."""
+
+    def __init__(self, author: discord.Member | discord.User) -> None:
+        super().__init__(author)
+        wings: tuple[tuple[str, str, type[ExhibitWingView]], ...] = (
+            ("🔘", "Buttons", ButtonsWingView),
+            ("📋", "Selects", SelectsWingView),
+            ("⌨️", "Modals", ModalsWingView),
+            ("🪧", "Embeds", EmbedsWingView),
+        )
+        for emoji, label, wing_cls in wings:
+            btn: discord.ui.Button[discord.ui.View] = discord.ui.Button(
+                label=label,
+                emoji=emoji,
+                style=discord.ButtonStyle.primary,
+                row=0,
+            )
+
+            async def _open(
+                interaction: discord.Interaction,
+                cls: type[ExhibitWingView] = wing_cls,
+            ) -> None:
+                wing = cls(interaction.user, home_builder=home_builder)
+                embeds, view = wing.build()
+                await interaction.response.edit_message(embeds=embeds, view=view)
+
+            btn.callback = _open  # type: ignore[method-assign]
+            self.add_item(btn)
+
+        bench_btn: discord.ui.Button[discord.ui.View] = discord.ui.Button(
+            label="Probe bench",
+            emoji="🔬",
+            style=discord.ButtonStyle.secondary,
+            row=1,
+        )
+
+        async def _open_bench(interaction: discord.Interaction) -> None:
+            bench = ProbesBenchView(interaction.user, home_builder=home_builder)
+            embeds, view = bench.build()
+            await interaction.response.edit_message(embeds=embeds, view=view)
+
+        bench_btn.callback = _open_bench  # type: ignore[method-assign]
+        self.add_item(bench_btn)

--- a/disbot/views/ux_lab/modals.py
+++ b/disbot/views/ux_lab/modals.py
@@ -1,0 +1,383 @@
+"""UX Lab wing 3 — modal patterns: inputs, validation, preview-save, Label.
+
+Includes the discord.py 2.6+ capability check: a ``Label``-wrapped select
+inside a modal (the journal's old "modals are text-input only" rule is stale
+on the 2.7 pin — this exhibit is the living proof either way).
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import discord
+
+from utils.ux_patterns import PatternCategory, PatternSpec, PatternStatus, register
+from views.ux_lab.wing import ExhibitRender, ExhibitWingView
+
+_CAT = PatternCategory.MODALS
+_MODAL_LIMITS = (
+    "text input ≤ 4000 chars (paragraph) / 256 (short label)",
+    "modals open only from an interaction (button/select/slash)",
+    "a modal cannot open another modal from its on_submit",
+)
+
+
+def _header(title: str, body: str) -> discord.Embed:
+    return discord.Embed(title=title, description=body, color=discord.Color.purple())
+
+
+register(
+    PatternSpec(
+        pattern_id="modal_short_long",
+        title="Short + paragraph inputs",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        requires_modal=True,
+        recommended_for=(
+            "rename / re-describe flows",
+            "any free-text capture ≤ 2 fields",
+        ),
+        anti_patterns=("forms over ~4 fields — split into a wizard",),
+        limits=_MODAL_LIMITS,
+        notes="Required short field + optional paragraph; submit echoes both.",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="modal_label_select",
+        title="Select inside a modal (Label, 2.6+)",
+        category=_CAT,
+        status=PatternStatus.EXPERIMENTAL,
+        requires_modal=True,
+        recommended_for=(
+            "pick + describe in ONE round-trip (reason select + details)",
+        ),
+        anti_patterns=("entity picks — User/Role selects belong on views, not modals",),
+        limits=(
+            "Label text ≤ 45 chars, description ≤ 100",
+            "probe P-07: verify which select types Discord accepts here",
+            *_MODAL_LIMITS,
+        ),
+        notes=(
+            "The capability the old 'modals are text-only' rule predates. "
+            "If this modal renders with a working dropdown, the pin supports it."
+        ),
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="modal_validation_fail",
+        title="Validation failure path",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        requires_modal=True,
+        recommended_for=("numeric/state inputs that can be wrong",),
+        anti_patterns=("silently clamping bad input — name the rule that failed",),
+        limits=(
+            "a failed modal cannot reopen itself — the error must carry "
+            "enough context to retry",
+            *_MODAL_LIMITS,
+        ),
+        notes="Enter anything non-numeric (or >100) to see the failure shape.",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="modal_preview_save",
+        title="Modal → preview card → Save/Edit loop",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        requires_modal=True,
+        recommended_for=(
+            "anything user-visible after saving (welcome text, home embeds)",
+        ),
+        anti_patterns=("saving free text without showing it rendered first",),
+        limits=_MODAL_LIMITS,
+        adopted_by=("Home-message embed builder (Q-0059 mandatory preview)",),
+        notes="Edit reopens the modal **prefilled** — drafts never retype.",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="modal_report_form",
+        title="Report / feedback form",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        requires_modal=True,
+        recommended_for=("member reports, suggestion boxes, contact-staff",),
+        anti_patterns=("collecting more than the handling flow actually reads",),
+        limits=_MODAL_LIMITS,
+        notes="Submit renders the mod-queue card a staff channel would receive.",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="modal_template_editor",
+        title="Template editor with variable preview",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        requires_modal=True,
+        recommended_for=(
+            "custom commands (trigger → template)",
+            "welcome-message templates with {user}-style variables",
+        ),
+        anti_patterns=("free-form code-like templates without a rendered preview",),
+        limits=_MODAL_LIMITS,
+        notes="Uses {user} and {server} variables; submit shows them substituted.",
+    ),
+)
+
+
+class _ShortLongModal(discord.ui.Modal, title="Rename the (fake) channel"):
+    name: discord.ui.TextInput[discord.ui.Modal] = discord.ui.TextInput(
+        label="New name",
+        placeholder="lounge",
+        max_length=100,
+    )
+    topic: discord.ui.TextInput[discord.ui.Modal] = discord.ui.TextInput(
+        label="Topic (optional)",
+        style=discord.TextStyle.paragraph,
+        required=False,
+        max_length=1024,
+    )
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        topic = str(self.topic.value).strip() or "(unchanged)"
+        await interaction.response.send_message(
+            f"✅ (fake) Renamed to **#{self.name.value}** · topic: {topic}",
+            ephemeral=True,
+        )
+
+
+class _LabelSelectModal(discord.ui.Modal, title="Report a message"):
+    reason: discord.ui.Label[discord.ui.Modal] = discord.ui.Label(
+        text="Reason",
+        description="Why are you reporting this?",
+        component=discord.ui.Select(
+            options=[
+                discord.SelectOption(label="Spam", emoji="📣"),
+                discord.SelectOption(label="Harassment", emoji="🚫"),
+                discord.SelectOption(label="Other", emoji="❓"),
+            ],
+        ),
+    )
+    details: discord.ui.Label[discord.ui.Modal] = discord.ui.Label(
+        text="Details",
+        component=discord.ui.TextInput(
+            style=discord.TextStyle.paragraph,
+            required=False,
+            max_length=500,
+        ),
+    )
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        select = cast("discord.ui.Select[discord.ui.Modal]", self.reason.component)
+        details = cast("discord.ui.TextInput[discord.ui.Modal]", self.details.component)
+        picked = select.values[0] if select.values else "(none)"
+        await interaction.response.send_message(
+            f"📨 Reason **{picked}** · details: "
+            f"{str(details.value).strip() or '—'}\n"
+            "A select rendered inside a modal — the 2.6+ Label capability, "
+            "live-verified by submitting this.",
+            ephemeral=True,
+        )
+
+
+class _ValidationModal(discord.ui.Modal, title="Set warn threshold"):
+    threshold: discord.ui.TextInput[discord.ui.Modal] = discord.ui.TextInput(
+        label="Warnings before timeout (1–100)",
+        placeholder="5",
+        max_length=4,
+    )
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        raw = str(self.threshold.value).strip()
+        if not raw.isdigit() or not 1 <= int(raw) <= 100:
+            await interaction.response.send_message(
+                f"❌ **`{raw}` is not a number between 1 and 100.**\n"
+                "Nothing was saved. Press the button to try again — the error "
+                "names the rule, so the retry needs no guesswork.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_message(
+            f"✅ (fake) Warn threshold set to **{raw}**.",
+            ephemeral=True,
+        )
+
+
+class _DraftModal(discord.ui.Modal, title="Welcome message draft"):
+    def __init__(self, wing: ModalsWingView, *, prefill: str) -> None:
+        super().__init__()
+        self.text: discord.ui.TextInput[discord.ui.Modal] = discord.ui.TextInput(
+            label="Welcome text",
+            style=discord.TextStyle.paragraph,
+            default=prefill or None,
+            placeholder="Welcome {user} to {server}!",
+            max_length=500,
+        )
+        self.add_item(self.text)
+        self._wing = wing
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        self._wing.state["draft"] = str(self.text.value)
+        await self._wing.rerender(interaction)
+
+
+class _ReportFormModal(discord.ui.Modal, title="Contact the staff"):
+    subject: discord.ui.TextInput[discord.ui.Modal] = discord.ui.TextInput(
+        label="Subject",
+        max_length=100,
+    )
+    body: discord.ui.TextInput[discord.ui.Modal] = discord.ui.TextInput(
+        label="What happened?",
+        style=discord.TextStyle.paragraph,
+        max_length=1000,
+    )
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        card = discord.Embed(
+            title=f"📨 Staff inbox — {self.subject.value}",
+            description=str(self.body.value),
+            color=discord.Color.purple(),
+            timestamp=discord.utils.utcnow(),
+        )
+        card.set_footer(text="The card a real staff channel would receive (fake)")
+        await interaction.response.send_message(embed=card, ephemeral=True)
+
+
+class _TemplateModal(discord.ui.Modal, title="Custom command editor"):
+    trigger: discord.ui.TextInput[discord.ui.Modal] = discord.ui.TextInput(
+        label="Trigger",
+        placeholder="!hello",
+        max_length=32,
+    )
+    template: discord.ui.TextInput[discord.ui.Modal] = discord.ui.TextInput(
+        label="Response template",
+        style=discord.TextStyle.paragraph,
+        default="Hey {user}, welcome to {server}! 🎉",
+        max_length=500,
+    )
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        rendered = (
+            str(self.template.value)
+            .replace("{user}", interaction.user.display_name)
+            .replace("{server}", interaction.guild.name if interaction.guild else "?")
+        )
+        await interaction.response.send_message(
+            f"**`{self.trigger.value}` would answer:**\n{rendered}",
+            ephemeral=True,
+        )
+
+
+class ModalsWingView(ExhibitWingView):
+    """Wing 3 — modals."""
+
+    WING_TITLE = "Modals"
+    WING_EMOJI = "⌨️"
+
+    def _exhibit_ids(self) -> tuple[str, ...]:
+        return (
+            "modal_short_long",
+            "modal_label_select",
+            "modal_validation_fail",
+            "modal_preview_save",
+            "modal_report_form",
+            "modal_template_editor",
+        )
+
+    def _render_exhibit(self, pattern_id: str) -> ExhibitRender:
+        if pattern_id == "modal_preview_save":
+            return self._ex_preview_save()
+        launchers: dict[str, tuple[str, str, type[discord.ui.Modal]]] = {
+            "modal_short_long": (
+                "📝 Two inputs",
+                "Required short field + optional paragraph.",
+                _ShortLongModal,
+            ),
+            "modal_label_select": (
+                "🧩 Select in a modal",
+                "A Label-wrapped dropdown — pick a reason **inside** the modal.",
+                _LabelSelectModal,
+            ),
+            "modal_validation_fail": (
+                "🚧 Validation path",
+                "Enter junk on purpose; the failure names the rule.",
+                _ValidationModal,
+            ),
+            "modal_report_form": (
+                "📨 Report form",
+                "Subject + paragraph; submit renders the staff-queue card.",
+                _ReportFormModal,
+            ),
+            "modal_template_editor": (
+                "🔤 Template editor",
+                "{user}/{server} variables, shown substituted on submit.",
+                _TemplateModal,
+            ),
+        }
+        title, body, modal_cls = launchers[pattern_id]
+        btn = self.demo_button(
+            "Open the modal",
+            style=discord.ButtonStyle.primary,
+            emoji="⌨️",
+            row=0,
+        )
+
+        async def _open(interaction: discord.Interaction) -> None:
+            await interaction.response.send_modal(modal_cls())
+
+        btn.callback = _open  # type: ignore[method-assign]
+        return ([_header(title, body)], [btn])
+
+    def _ex_preview_save(self) -> ExhibitRender:
+        draft: str = self.state.get("draft", "")
+        items: list[discord.ui.Item[discord.ui.View]] = []
+        edit = self.demo_button(
+            "Edit draft…" if draft else "Write the draft…",
+            style=discord.ButtonStyle.primary,
+            emoji="✏️",
+            row=0,
+        )
+
+        async def _edit(interaction: discord.Interaction) -> None:
+            await interaction.response.send_modal(_DraftModal(self, prefill=draft))
+
+        edit.callback = _edit  # type: ignore[method-assign]
+        items.append(edit)
+        embeds = [
+            _header(
+                "💾 Preview before save",
+                "Write a draft; it renders below **before** anything saves. "
+                "Edit reopens the modal prefilled.",
+            ),
+        ]
+        if draft:
+            preview = discord.Embed(
+                title="👋 Preview — as members would see it",
+                description=draft.replace("{user}", "**AstroFox**").replace(
+                    "{server}",
+                    "**Demo Server**",
+                ),
+                color=discord.Color.green(),
+            )
+            embeds.append(preview)
+            save = self.demo_button("Save", style=discord.ButtonStyle.success, row=0)
+
+            async def _save(interaction: discord.Interaction) -> None:
+                self.state.clear()
+                await self.ack(
+                    interaction,
+                    "✅ (fake) Saved. A real flow writes through the audited "
+                    "settings seam — preview was mandatory (Q-0059 precedent).",
+                )
+
+            save.callback = _save  # type: ignore[method-assign]
+            items.append(save)
+        return (embeds, items)

--- a/disbot/views/ux_lab/probes.py
+++ b/disbot/views/ux_lab/probes.py
@@ -1,0 +1,301 @@
+"""UX Lab wing 8 — the platform-limit probe bench (PR A subset).
+
+Each probe attempts a crafted send and reports ✅/❌ with the exact error,
+the installed library version, and today's date — the copy-paste artifact
+that keeps ``docs/operations/discord-platform-limits.md`` honest. Probe
+messages clean themselves up via ``delete_after``.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import discord
+
+from core.runtime.interaction_helpers import safe_defer
+from utils.ux_patterns import (
+    PatternCategory,
+    PatternSpec,
+    PatternStatus,
+    ProbeResult,
+    register,
+)
+from views.base import HubView
+from views.navigation import ParentBuilder, transition_to
+from views.ux_lab.modals import _LabelSelectModal
+
+_CAT = PatternCategory.PROBE
+_PROBE_MSG_TTL = 45  # seconds before a probe's demo message self-deletes
+
+
+def _probe_spec(pattern_id: str, title: str, expect: str, notes: str = "") -> None:
+    register(
+        PatternSpec(
+            pattern_id=pattern_id,
+            title=title,
+            category=_CAT,
+            status=PatternStatus.STABLE,
+            recommended_for=("re-verifying the platform-limits doc on demand",),
+            limits=(expect,),
+            notes=notes,
+        ),
+    )
+
+
+_probe_spec(
+    "probe_legacy_grid_25",
+    "P-01 · legacy 5×5 component grid",
+    "expect PASS — 25 items is the legacy View ceiling",
+)
+_probe_spec(
+    "probe_select_26_options",
+    "P-02 · select with 26 options",
+    "expect FAIL — 25 options is the per-select cap",
+    notes="Reports WHICH layer rejected it (library construction vs API).",
+)
+_probe_spec(
+    "probe_embed_budget",
+    "P-06 · 10 embeds near the 6000-char total",
+    "expect PASS at ≤6000 combined; the cap is the message total, not per-embed",
+)
+_probe_spec(
+    "probe_modal_label_select",
+    "P-07 · Label-wrapped select inside a modal",
+    "expect PASS on discord.py ≥2.6 — submit the modal to complete the probe",
+    notes="Manual probe: it must open AND accept a submission.",
+)
+
+
+def _stamp() -> str:
+    return f"discord.py {discord.__version__} · {dt.date.today().isoformat()}"
+
+
+class ProbesBenchView(HubView):
+    """The limit-verification bench: one button per probe + Run all."""
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        home_builder: ParentBuilder,
+    ) -> None:
+        super().__init__(author)
+        self._home_builder = home_builder
+        self._results: dict[str, ProbeResult] = {}
+        self._build_items()
+
+    # -- probes ---------------------------------------------------------------
+
+    async def _probe_legacy_grid(
+        self,
+        channel: discord.abc.Messageable,
+    ) -> ProbeResult:
+        try:
+            view = discord.ui.View(timeout=_PROBE_MSG_TTL)
+            for n in range(25):
+                view.add_item(
+                    discord.ui.Button(
+                        label=str(n + 1),
+                        style=discord.ButtonStyle.secondary,
+                        disabled=True,
+                        row=n // 5,
+                    ),
+                )
+            await channel.send(
+                "🧪 P-01: 25 components (5×5) — self-deletes.",
+                view=view,
+                delete_after=_PROBE_MSG_TTL,
+            )
+        except Exception as exc:  # noqa: BLE001 — the exception IS the result
+            return ProbeResult(
+                "probe_legacy_grid_25",
+                "P-01 legacy 5×5 grid",
+                False,
+                f"{type(exc).__name__}: {str(exc)[:180]}",
+            )
+        return ProbeResult(
+            "probe_legacy_grid_25",
+            "P-01 legacy 5×5 grid",
+            True,
+            "sent — 25 items accepted (the legacy ceiling)",
+        )
+
+    async def _probe_select_26(
+        self,
+        channel: discord.abc.Messageable,
+    ) -> ProbeResult:
+        pid, title = "probe_select_26_options", "P-02 select with 26 options"
+        try:
+            sel: discord.ui.Select[discord.ui.View] = discord.ui.Select(
+                options=[
+                    discord.SelectOption(label=f"option {n}") for n in range(1, 27)
+                ],
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ProbeResult(
+                pid,
+                title,
+                True,
+                f"rejected at library construction — {type(exc).__name__}: "
+                f"{str(exc)[:140]}",
+            )
+        try:
+            view = discord.ui.View(timeout=_PROBE_MSG_TTL)
+            view.add_item(sel)
+            await channel.send(
+                "🧪 P-02: 26-option select — should never send.",
+                view=view,
+                delete_after=_PROBE_MSG_TTL,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ProbeResult(
+                pid,
+                title,
+                True,
+                f"rejected at the API — {type(exc).__name__}: {str(exc)[:140]}",
+            )
+        return ProbeResult(
+            pid,
+            title,
+            False,
+            "UNEXPECTED: Discord accepted 26 options — update the limits doc!",
+        )
+
+    async def _probe_embed_budget(
+        self,
+        channel: discord.abc.Messageable,
+    ) -> ProbeResult:
+        pid, title = "probe_embed_budget", "P-06 embed budget (10 × ~590 chars)"
+        try:
+            filler = "x" * 560
+            embeds = [
+                discord.Embed(title=f"Embed {n + 1}/10", description=filler)
+                for n in range(10)
+            ]
+            total = sum(len(e.title or "") + len(e.description or "") for e in embeds)
+            await channel.send(embeds=embeds, delete_after=_PROBE_MSG_TTL)
+        except Exception as exc:  # noqa: BLE001
+            return ProbeResult(
+                pid,
+                title,
+                False,
+                f"{type(exc).__name__}: {str(exc)[:180]}",
+            )
+        return ProbeResult(
+            pid,
+            title,
+            True,
+            f"sent — 10 embeds, {total} combined chars (≤6000 budget)",
+        )
+
+    # -- rendering ------------------------------------------------------------
+
+    def build(self) -> tuple[list[discord.Embed], ProbesBenchView]:
+        embed = discord.Embed(
+            title="🔬 Limit probe bench",
+            description=(
+                "Each probe attempts a crafted send and reports the exact "
+                "outcome. Probe messages self-delete after "
+                f"{_PROBE_MSG_TTL}s.\n**{_stamp()}**"
+            ),
+            color=discord.Color.gold(),
+        )
+        if self._results:
+            for res in self._results.values():
+                embed.add_field(
+                    name=f"{'✅' if res.ok else '❌'} {res.title}",
+                    value=res.detail[:1000],
+                    inline=False,
+                )
+        else:
+            embed.add_field(
+                name="No results yet",
+                value="Run a probe — results land here, dated and versioned.",
+                inline=False,
+            )
+        return [embed], self
+
+    def _build_items(self) -> None:
+        self.clear_items()
+        probes = (
+            ("P-01 grid", self._probe_legacy_grid),
+            ("P-02 26-option", self._probe_select_26),
+            ("P-06 embed budget", self._probe_embed_budget),
+        )
+        for label, runner in probes:
+            btn: discord.ui.Button[discord.ui.View] = discord.ui.Button(
+                label=label,
+                style=discord.ButtonStyle.primary,
+                row=0,
+            )
+
+            async def _run(
+                interaction: discord.Interaction,
+                probe=runner,  # noqa: ANN001 — bound method capture
+            ) -> None:
+                if not await safe_defer(interaction):
+                    return
+                channel = interaction.channel
+                if channel is None or not isinstance(
+                    channel,
+                    discord.abc.Messageable,
+                ):
+                    return
+                result = await probe(channel)
+                self._results[result.probe_id] = result
+                embeds, _ = self.build()
+                await interaction.edit_original_response(embeds=embeds, view=self)
+
+            btn.callback = _run  # type: ignore[method-assign]
+            self.add_item(btn)
+
+        modal_btn: discord.ui.Button[discord.ui.View] = discord.ui.Button(
+            label="P-07 modal+select (manual)",
+            style=discord.ButtonStyle.primary,
+            row=1,
+        )
+
+        async def _modal_probe(interaction: discord.Interaction) -> None:
+            await interaction.response.send_modal(_LabelSelectModal())
+
+        modal_btn.callback = _modal_probe  # type: ignore[method-assign]
+        self.add_item(modal_btn)
+
+        run_all: discord.ui.Button[discord.ui.View] = discord.ui.Button(
+            label="Run all automated",
+            emoji="🔬",
+            style=discord.ButtonStyle.success,
+            row=1,
+        )
+
+        async def _run_all(interaction: discord.Interaction) -> None:
+            if not await safe_defer(interaction):
+                return
+            channel = interaction.channel
+            if channel is None or not isinstance(channel, discord.abc.Messageable):
+                return
+            for probe in (
+                self._probe_legacy_grid,
+                self._probe_select_26,
+                self._probe_embed_budget,
+            ):
+                result = await probe(channel)
+                self._results[result.probe_id] = result
+            embeds, _ = self.build()
+            await interaction.edit_original_response(embeds=embeds, view=self)
+
+        run_all.callback = _run_all  # type: ignore[method-assign]
+        self.add_item(run_all)
+
+        home_btn: discord.ui.Button[discord.ui.View] = discord.ui.Button(
+            label="UX Lab",
+            emoji="🏠",
+            style=discord.ButtonStyle.secondary,
+            row=4,
+        )
+
+        async def _home(interaction: discord.Interaction) -> None:
+            await transition_to(interaction, builder=self._home_builder)
+
+        home_btn.callback = _home  # type: ignore[method-assign]
+        self.add_item(home_btn)

--- a/disbot/views/ux_lab/selects.py
+++ b/disbot/views/ux_lab/selects.py
@@ -1,0 +1,533 @@
+"""UX Lab wing 2 — select menus: navigation, multi-select, pagination, entities.
+
+Includes the canonical answer to the 25-option ceiling (category select →
+paginated select → preview → confirm) that the server-management roadmap
+names as a selector gap.
+"""
+
+from __future__ import annotations
+
+import discord
+
+from utils.ux_patterns import PatternCategory, PatternSpec, PatternStatus, register
+from views.ux_lab.wing import ExhibitRender, ExhibitWingView
+
+_CAT = PatternCategory.SELECTS
+_SELECT_LIMITS = (
+    "2–25 options per string select",
+    "option label/value/description ≤ 100 chars",
+    "1 select per action row",
+)
+
+_FAKE_ITEMS = tuple(f"item-{n:02d}" for n in range(1, 61))
+
+
+def _header(title: str, body: str) -> discord.Embed:
+    return discord.Embed(title=title, description=body, color=discord.Color.teal())
+
+
+register(
+    PatternSpec(
+        pattern_id="category_select_single",
+        title="Category select (navigation)",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        recommended_for=(
+            "hubs with 9+ dynamic children (hub-ui-standard threshold)",
+            "the Games-hub child picker shape",
+        ),
+        anti_patterns=("≤8 static choices — visible buttons beat a closed menu",),
+        limits=_SELECT_LIMITS,
+        adopted_by=("views/games/hub.py GamesHubView",),
+        notes="Pick a category — the panel content swaps in place.",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="settings_multi_select_preview",
+        title="Multi-select → preview → apply",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        recommended_for=(
+            "bulk settings toggles",
+            "any multi-pick that mutates state — preview before apply",
+        ),
+        anti_patterns=("destructive bulk actions without the preview step",),
+        limits=("min_values/max_values bound the pick count", *_SELECT_LIMITS),
+        notes="Pick 1–3 modules, then Preview, then Apply (all fake).",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="select_paginated_over_25",
+        title="Paginated select (lists beyond 25)",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        recommended_for=(
+            "role/channel/item lists longer than 25 (the selector-gap fix)",
+        ),
+        anti_patterns=(
+            "silently slicing options[:25] — items become invisible "
+            "(a real latent bug class here)",
+        ),
+        limits=("25 options per page — ◀ ▶ refill the menu", *_SELECT_LIMITS),
+        notes="60 fake items, 3 pages. The page indicator lives on the placeholder.",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="entity_selects",
+        title="Auto-populated entity selects",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        recommended_for=(
+            "picking real users/roles/channels — Discord supplies the list, "
+            "search included",
+        ),
+        anti_patterns=("fake string lists of members — entity selects are free",),
+        limits=("Discord populates + searches; one select per row", *_SELECT_LIMITS),
+        notes="Four entity types stacked. Picking only echoes — nothing mutates.",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="select_with_descriptions",
+        title="Options with descriptions, emoji + default",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        recommended_for=(
+            "choices needing a one-line explanation each (presets, modes)",
+        ),
+        anti_patterns=("descriptions that just repeat the label",),
+        limits=_SELECT_LIMITS,
+        notes="One option ships pre-selected (default=True) — note the check mark.",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="filter_then_list",
+        title="Two-stage filter (hierarchy navigation)",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        recommended_for=(
+            "category → item hierarchies (channel categories, shop sections)",
+        ),
+        anti_patterns=("flat lists that fit one menu — don't add a stage",),
+        limits=_SELECT_LIMITS,
+        notes="The first select narrows what the second offers.",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="select_as_verb_picker",
+        title="Target select + verb buttons (platform-manager shape)",
+        category=_CAT,
+        status=PatternStatus.STABLE,
+        recommended_for=(
+            "platform-manager panels: pick target, then Enable/Disable/Refresh "
+            "(hub-ui-standard preset 4)",
+        ),
+        anti_patterns=("verbs the canonical pipeline doesn't expose",),
+        limits=_SELECT_LIMITS,
+        adopted_by=("views/diagnostic/flag_manager.py FlagManagerView",),
+        notes="Pick a fake flag, then a verb — the result card names both.",
+    ),
+)
+
+register(
+    PatternSpec(
+        pattern_id="search_via_modal",
+        title="Search box for a select (modal-fed filter)",
+        category=_CAT,
+        status=PatternStatus.EXPERIMENTAL,
+        requires_modal=True,
+        recommended_for=(
+            "long string lists where typing beats paging (item catalogues)",
+        ),
+        anti_patterns=("entity lists — UserSelect/RoleSelect already search",),
+        limits=("modal round-trip costs one click vs native search", *_SELECT_LIMITS),
+        notes="🔍 opens a modal; the select refills with matches.",
+    ),
+)
+
+
+class _SearchModal(discord.ui.Modal, title="Filter the list"):
+    query: discord.ui.TextInput[discord.ui.Modal] = discord.ui.TextInput(
+        label="Search",
+        placeholder="e.g. 4",
+        max_length=20,
+        required=False,
+    )
+
+    def __init__(self, wing: SelectsWingView) -> None:
+        super().__init__()
+        self._wing = wing
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        self._wing.state["query"] = str(self.query.value).strip()
+        await self._wing.rerender(interaction)
+
+
+class SelectsWingView(ExhibitWingView):
+    """Wing 2 — select menus."""
+
+    WING_TITLE = "Selects"
+    WING_EMOJI = "📋"
+
+    def _exhibit_ids(self) -> tuple[str, ...]:
+        return (
+            "category_select_single",
+            "settings_multi_select_preview",
+            "select_paginated_over_25",
+            "entity_selects",
+            "select_with_descriptions",
+            "filter_then_list",
+            "select_as_verb_picker",
+            "search_via_modal",
+        )
+
+    def _render_exhibit(self, pattern_id: str) -> ExhibitRender:
+        render = {
+            "category_select_single": self._ex_category,
+            "settings_multi_select_preview": self._ex_multi_preview,
+            "select_paginated_over_25": self._ex_paginated,
+            "entity_selects": self._ex_entities,
+            "select_with_descriptions": self._ex_descriptions,
+            "filter_then_list": self._ex_filter_then_list,
+            "select_as_verb_picker": self._ex_verb_picker,
+            "search_via_modal": self._ex_search_modal,
+        }[pattern_id]
+        return render()
+
+    # -- exhibits -------------------------------------------------------------
+
+    def _ex_category(self) -> ExhibitRender:
+        picked: str | None = self.state.get("picked")
+        sel: discord.ui.Select[discord.ui.View] = discord.ui.Select(
+            placeholder="Open a category…",
+            options=[
+                discord.SelectOption(label=c, emoji=e)
+                for c, e in (
+                    ("Competitive", "⚔️"),
+                    ("Activities", "🎲"),
+                    ("Progression", "📈"),
+                )
+            ],
+            row=0,
+        )
+
+        async def _pick(interaction: discord.Interaction) -> None:
+            self.state["picked"] = sel.values[0]
+            await self.rerender(interaction)
+
+        sel.callback = _pick  # type: ignore[method-assign]
+        body = (
+            f"You're 'inside' **{picked}** now — same message, swapped content."
+            if picked
+            else "Pick a category. The panel updates in place (no new message)."
+        )
+        return ([_header("📂 Category navigation", body)], [sel])
+
+    def _ex_multi_preview(self) -> ExhibitRender:
+        picked: list[str] = self.state.get("picked", [])
+        stage: str = self.state.get("stage", "picking")
+        items: list[discord.ui.Item[discord.ui.View]] = []
+        if stage == "picking":
+            sel: discord.ui.Select[discord.ui.View] = discord.ui.Select(
+                placeholder="Enable 1–3 modules…",
+                min_values=1,
+                max_values=3,
+                options=[
+                    discord.SelectOption(label=m, emoji="📦")
+                    for m in ("Welcome", "Logging", "Automod", "Counters", "Events")
+                ],
+                row=0,
+            )
+
+            async def _pick(interaction: discord.Interaction) -> None:
+                self.state["picked"] = list(sel.values)
+                await self.rerender(interaction)
+
+            sel.callback = _pick  # type: ignore[method-assign]
+            items.append(sel)
+            preview = self.demo_button(
+                "Preview →",
+                style=discord.ButtonStyle.primary,
+                row=1,
+                disabled=not picked,
+            )
+
+            async def _preview(interaction: discord.Interaction) -> None:
+                self.state["stage"] = "preview"
+                await self.rerender(interaction)
+
+            preview.callback = _preview  # type: ignore[method-assign]
+            items.append(preview)
+            body = (
+                "Pick modules (min 1, max 3), then **Preview**.\n"
+                f"Currently picked: {', '.join(picked) or '—'}"
+            )
+        else:
+            apply_btn = self.demo_button(
+                "Apply",
+                style=discord.ButtonStyle.success,
+                row=0,
+            )
+            back = self.demo_button("◀ Edit picks", row=0)
+
+            async def _apply(interaction: discord.Interaction) -> None:
+                self.state.clear()
+                await self.ack(
+                    interaction,
+                    f"✅ (fake) Enabled: **{', '.join(picked)}**. A real flow "
+                    "writes through the audited settings pipeline here.",
+                )
+
+            async def _back(interaction: discord.Interaction) -> None:
+                self.state["stage"] = "picking"
+                await self.rerender(interaction)
+
+            apply_btn.callback = _apply  # type: ignore[method-assign]
+            back.callback = _back  # type: ignore[method-assign]
+            items += [apply_btn, back]
+            body = "**Preview — about to enable:**\n" + "\n".join(
+                f"• 📦 {m}" for m in picked
+            )
+        return ([_header("☑️ Multi-select with preview", body)], items)
+
+    def _ex_paginated(self) -> ExhibitRender:
+        page: int = self.state.get("page", 0)
+        pages = [_FAKE_ITEMS[i : i + 25] for i in range(0, len(_FAKE_ITEMS), 25)]
+        page %= len(pages)
+        sel: discord.ui.Select[discord.ui.View] = discord.ui.Select(
+            placeholder=f"Pick an item… (page {page + 1}/{len(pages)})",
+            options=[discord.SelectOption(label=i) for i in pages[page]],
+            row=0,
+        )
+
+        async def _pick(interaction: discord.Interaction) -> None:
+            await self.ack(interaction, f"Picked **{sel.values[0]}** — no mutation.")
+
+        sel.callback = _pick  # type: ignore[method-assign]
+        prev = self.demo_button("◀ page", row=1)
+        nxt = self.demo_button("page ▶", row=1)
+
+        async def _prev(interaction: discord.Interaction) -> None:
+            self.state["page"] = (page - 1) % len(pages)
+            await self.rerender(interaction)
+
+        async def _next(interaction: discord.Interaction) -> None:
+            self.state["page"] = (page + 1) % len(pages)
+            await self.rerender(interaction)
+
+        prev.callback = _prev  # type: ignore[method-assign]
+        nxt.callback = _next  # type: ignore[method-assign]
+        return (
+            [
+                _header(
+                    "📜 60 items, one select",
+                    "A select holds 25 options; ◀ ▶ refill it per page. The page "
+                    "lives on the **placeholder** so it survives the closed state.",
+                ),
+            ],
+            [sel, prev, nxt],
+        )
+
+    def _ex_entities(self) -> ExhibitRender:
+        items: list[discord.ui.Item[discord.ui.View]] = []
+        makers: tuple[tuple[str, type], ...] = (
+            ("member", discord.ui.UserSelect),
+            ("role", discord.ui.RoleSelect),
+            ("channel", discord.ui.ChannelSelect),
+            ("user or role", discord.ui.MentionableSelect),
+        )
+        for row, (noun, cls) in enumerate(makers):
+            sel = cls(placeholder=f"Pick a {noun}…", row=row)
+
+            async def _pick(
+                interaction: discord.Interaction,
+                menu: discord.ui.Item[discord.ui.View] = sel,
+                kind: str = noun,
+            ) -> None:
+                values = getattr(menu, "values", [])
+                shown = ", ".join(str(v) for v in values) or "nothing"
+                await self.ack(
+                    interaction,
+                    f"Resolved {kind}: **{shown}** — echo only, no mutation.",
+                )
+
+            sel.callback = _pick  # type: ignore[method-assign]
+            items.append(sel)
+        return (
+            [
+                _header(
+                    "👥 Entity selects",
+                    "User / Role / Channel / Mentionable — Discord populates and "
+                    "searches these natively. Each occupies a full row.",
+                ),
+            ],
+            items,
+        )
+
+    def _ex_descriptions(self) -> ExhibitRender:
+        sel: discord.ui.Select[discord.ui.View] = discord.ui.Select(
+            placeholder="Pick a preset…",
+            options=[
+                discord.SelectOption(
+                    label="Cozy",
+                    emoji="🛋️",
+                    description="Slow XP, no pings, weekly digest",
+                ),
+                discord.SelectOption(
+                    label="Balanced",
+                    emoji="⚖️",
+                    description="The defaults most servers want",
+                    default=True,
+                ),
+                discord.SelectOption(
+                    label="Competitive",
+                    emoji="🏁",
+                    description="Fast XP, leaderboards everywhere",
+                ),
+            ],
+            row=0,
+        )
+
+        async def _pick(interaction: discord.Interaction) -> None:
+            await self.ack(interaction, f"Preset **{sel.values[0]}** (fake-)selected.")
+
+        sel.callback = _pick  # type: ignore[method-assign]
+        return (
+            [
+                _header(
+                    "💬 Descriptions, emoji, default",
+                    "Each option explains itself in ≤100 chars; **Balanced** ships "
+                    "pre-selected via `default=True`.",
+                ),
+            ],
+            [sel],
+        )
+
+    def _ex_filter_then_list(self) -> ExhibitRender:
+        catalogue = {
+            "Tools": ("Pickaxe", "Lantern", "Rope"),
+            "Potions": ("Haste", "Glow", "Luck"),
+            "Gear": ("Helmet", "Boots", "Gloves"),
+        }
+        category: str | None = self.state.get("category")
+        items: list[discord.ui.Item[discord.ui.View]] = []
+        cat_sel: discord.ui.Select[discord.ui.View] = discord.ui.Select(
+            placeholder="1 · Pick a category…",
+            options=[discord.SelectOption(label=c) for c in catalogue],
+            row=0,
+        )
+
+        async def _pick_cat(interaction: discord.Interaction) -> None:
+            self.state["category"] = cat_sel.values[0]
+            await self.rerender(interaction)
+
+        cat_sel.callback = _pick_cat  # type: ignore[method-assign]
+        items.append(cat_sel)
+        if category:
+            item_sel: discord.ui.Select[discord.ui.View] = discord.ui.Select(
+                placeholder=f"2 · Pick from {category}…",
+                options=[discord.SelectOption(label=i) for i in catalogue[category]],
+                row=1,
+            )
+
+            async def _pick_item(interaction: discord.Interaction) -> None:
+                await self.ack(
+                    interaction,
+                    f"Picked **{item_sel.values[0]}** from **{category}**.",
+                )
+
+            item_sel.callback = _pick_item  # type: ignore[method-assign]
+            items.append(item_sel)
+        body = (
+            f"Stage 2 unlocked for **{category}** — the second menu only offers "
+            "that category's items."
+            if category
+            else "Two-stage hierarchy: the second select appears once the first "
+            "narrows it."
+        )
+        return ([_header("🗂️ Filter → list", body)], items)
+
+    def _ex_verb_picker(self) -> ExhibitRender:
+        target: str | None = self.state.get("target")
+        sel: discord.ui.Select[discord.ui.View] = discord.ui.Select(
+            placeholder="Pick a (fake) feature flag…",
+            options=[
+                discord.SelectOption(label=f, emoji="🚩")
+                for f in ("spotlight_v2", "mining_events", "ai_summaries")
+            ],
+            row=0,
+        )
+
+        async def _pick(interaction: discord.Interaction) -> None:
+            self.state["target"] = sel.values[0]
+            await self.rerender(interaction)
+
+        sel.callback = _pick  # type: ignore[method-assign]
+        items: list[discord.ui.Item[discord.ui.View]] = [sel]
+        for verb, style in (
+            ("Enable", discord.ButtonStyle.success),
+            ("Disable", discord.ButtonStyle.danger),
+            ("Refresh", discord.ButtonStyle.secondary),
+        ):
+            btn = self.demo_button(verb, style=style, row=1, disabled=target is None)
+
+            async def _act(
+                interaction: discord.Interaction,
+                action: str = verb,
+            ) -> None:
+                await self.ack(
+                    interaction,
+                    f"🚩 (fake) **{action}** → `{target}`. A real panel routes "
+                    "this through the canonical flag pipeline (audited).",
+                )
+
+            btn.callback = _act  # type: ignore[method-assign]
+            items.append(btn)
+        body = (
+            f"Target locked: `{target}` — now pick a verb."
+            if target
+            else "Pick the target first; the verb bank stays disabled until then."
+        )
+        return ([_header("🚩 Target + verb bank", body)], items)
+
+    def _ex_search_modal(self) -> ExhibitRender:
+        query: str = self.state.get("query", "")
+        matches = tuple(i for i in _FAKE_ITEMS if query in i)[:25]
+        items: list[discord.ui.Item[discord.ui.View]] = []
+        search = self.demo_button("🔍 Search…", row=0)
+
+        async def _open(interaction: discord.Interaction) -> None:
+            await interaction.response.send_modal(_SearchModal(self))
+
+        search.callback = _open  # type: ignore[method-assign]
+        items.append(search)
+        if matches:
+            sel: discord.ui.Select[discord.ui.View] = discord.ui.Select(
+                placeholder=(
+                    f"{len(matches)} match(es)" + (f" for “{query}”" if query else "")
+                ),
+                options=[discord.SelectOption(label=m) for m in matches],
+                row=1,
+            )
+
+            async def _pick(interaction: discord.Interaction) -> None:
+                await self.ack(interaction, f"Picked **{sel.values[0]}**.")
+
+            sel.callback = _pick  # type: ignore[method-assign]
+            items.append(sel)
+        body = (
+            f"Filter: `{query or '(none)'}` → {len(matches)} of {len(_FAKE_ITEMS)} "
+            "items shown. Try `4`."
+        )
+        return ([_header("🔍 Modal-fed filter", body)], items)

--- a/disbot/views/ux_lab/wing.py
+++ b/disbot/views/ux_lab/wing.py
@@ -1,0 +1,172 @@
+"""Shared exhibit browser for UX Lab wings.
+
+One small base view: a wing holds an ordered list of registered pattern ids
+and renders one exhibit at a time — exhibit content on rows 0–3, a fixed
+navigation row (Prev / counter / Next / Home) on row 4, and the pattern's
+spec card appended as the last embed. Navigation edits the message in place
+(the V-02 doctrine the lab itself demonstrates).
+
+This is intentionally *not* a new view framework: it extends the canonical
+:class:`views.base.HubView`, holds only in-memory state, and is private to
+``views/ux_lab/``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, TypeAlias
+
+import discord
+
+from utils.ux_patterns import get_spec
+from utils.ux_patterns.builders import spec_card
+from views.base import HubView
+from views.navigation import ParentBuilder, transition_to
+
+logger = logging.getLogger("bot.views.ux_lab")
+
+# Row indices: exhibits may use rows 0–3; row 4 belongs to wing navigation.
+NAV_ROW = 4
+MAX_EXHIBIT_ROW = 3
+
+ExhibitRender: TypeAlias = tuple[
+    list[discord.Embed],
+    list["discord.ui.Item[discord.ui.View]"],
+]
+
+
+class ExhibitWingView(HubView):
+    """Browse a wing's exhibits one page at a time, editing in place.
+
+    Subclasses define :meth:`_exhibit_ids` (ordered pattern ids) and
+    :meth:`_render_exhibit` (embeds + interactive items for one exhibit).
+    Per-exhibit demo state lives in ``self.state`` and is cleared on
+    navigation so every exhibit starts fresh.
+    """
+
+    WING_TITLE = "Wing"
+    WING_EMOJI = "🧪"
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        home_builder: ParentBuilder,
+    ) -> None:
+        super().__init__(author)
+        self._home_builder = home_builder
+        self._index = 0
+        # Scratch space for the *current* exhibit's demo state (toggle
+        # values, wizard step, …). Cleared on Prev/Next.
+        self.state: dict[str, Any] = {}
+
+    # -- subclass contract --------------------------------------------------
+
+    def _exhibit_ids(self) -> tuple[str, ...]:
+        raise NotImplementedError
+
+    def _render_exhibit(self, pattern_id: str) -> ExhibitRender:
+        raise NotImplementedError
+
+    # -- rendering ----------------------------------------------------------
+
+    @property
+    def current_pattern_id(self) -> str:
+        ids = self._exhibit_ids()
+        return ids[self._index % len(ids)]
+
+    def build(self) -> tuple[list[discord.Embed], ExhibitWingView]:
+        """Return ``(embeds, self)`` for the current exhibit, items rebuilt."""
+        pattern_id = self.current_pattern_id
+        embeds, items = self._render_exhibit(pattern_id)
+        embeds = [*embeds, spec_card(get_spec(pattern_id))]
+        self.clear_items()
+        for item in items:
+            self.add_item(item)
+        self._add_nav_row()
+        return embeds, self
+
+    def _add_nav_row(self) -> None:
+        ids = self._exhibit_ids()
+        prev_btn: discord.ui.Button[discord.ui.View] = discord.ui.Button(
+            emoji="◀",
+            style=discord.ButtonStyle.secondary,
+            row=NAV_ROW,
+            custom_id="uxlab:wing:prev",
+        )
+        counter: discord.ui.Button[discord.ui.View] = discord.ui.Button(
+            label=f"{(self._index % len(ids)) + 1}/{len(ids)} · {self.WING_TITLE}",
+            style=discord.ButtonStyle.secondary,
+            disabled=True,
+            row=NAV_ROW,
+            custom_id="uxlab:wing:counter",
+        )
+        next_btn: discord.ui.Button[discord.ui.View] = discord.ui.Button(
+            emoji="▶",
+            style=discord.ButtonStyle.secondary,
+            row=NAV_ROW,
+            custom_id="uxlab:wing:next",
+        )
+        home_btn: discord.ui.Button[discord.ui.View] = discord.ui.Button(
+            label="UX Lab",
+            emoji="🏠",
+            style=discord.ButtonStyle.secondary,
+            row=NAV_ROW,
+            custom_id="uxlab:wing:home",
+        )
+
+        async def _prev(interaction: discord.Interaction) -> None:
+            self._index = (self._index - 1) % len(self._exhibit_ids())
+            self.state.clear()
+            await self.rerender(interaction)
+
+        async def _next(interaction: discord.Interaction) -> None:
+            self._index = (self._index + 1) % len(self._exhibit_ids())
+            self.state.clear()
+            await self.rerender(interaction)
+
+        async def _home(interaction: discord.Interaction) -> None:
+            await transition_to(interaction, builder=self._home_builder)
+
+        prev_btn.callback = _prev  # type: ignore[method-assign]
+        next_btn.callback = _next  # type: ignore[method-assign]
+        home_btn.callback = _home  # type: ignore[method-assign]
+        self.add_item(prev_btn)
+        self.add_item(counter)
+        self.add_item(next_btn)
+        self.add_item(home_btn)
+
+    async def rerender(self, interaction: discord.Interaction) -> None:
+        """Re-render the current exhibit into the same message."""
+        embeds, _ = self.build()
+        if interaction.response.is_done():
+            await interaction.edit_original_response(embeds=embeds, view=self)
+        else:
+            await interaction.response.edit_message(embeds=embeds, view=self)
+
+    # -- small helpers shared by wings ---------------------------------------
+
+    @staticmethod
+    async def ack(interaction: discord.Interaction, text: str) -> None:
+        """The minimum visible reaction: an ephemeral acknowledgement."""
+        await interaction.response.send_message(text, ephemeral=True)
+
+    @staticmethod
+    def demo_button(
+        label: str,
+        *,
+        style: discord.ButtonStyle = discord.ButtonStyle.secondary,
+        emoji: str | None = None,
+        row: int = 0,
+        disabled: bool = False,
+        custom_id: str | None = None,
+    ) -> discord.ui.Button[discord.ui.View]:
+        """A plain button; caller assigns ``.callback`` (closure style)."""
+        return discord.ui.Button(
+            label=label,
+            style=style,
+            emoji=emoji,
+            row=row,
+            disabled=disabled,
+            custom_id=custom_id,
+        )

--- a/docs/help-command-surface-map.md
+++ b/docs/help-command-surface-map.md
@@ -23,8 +23,8 @@ Post-PR-#142 routing summary (relevant to every row in §2):
   routes call the host cog's `build_help_menu_view` hook for hub +
   subsystem destinations and fall back to a command-list embed only
   when the hook is missing or raises.
-- 28 of the 36 loaded extensions (`config.INITIAL_EXTENSIONS`) define
-  `build_help_menu_view` — equivalently, 28 of the 29 subsystem-owning
+- 29 of the 37 loaded extensions (`config.INITIAL_EXTENSIONS`) define
+  `build_help_menu_view` — equivalently, 29 of the 30 subsystem-owning
   cogs expose it. The 8 extensions without the hook: the bootstrap
   access guard (not a Help surface), `help_cog` itself (it IS the Help
   surface), the five split BTD6 support cogs (`btd6_reference` /
@@ -69,8 +69,8 @@ Post-PR-#142 routing summary (relevant to every row in §2):
 
 ## 2. Subsystem inventory
 
-29 registered subsystems in `utils/subsystem_registry.py` (one row
-each below); 36 loaded extensions in `config.INITIAL_EXTENSIONS` (the
+30 registered subsystems in `utils/subsystem_registry.py` (one row
+each below); 37 loaded extensions in `config.INITIAL_EXTENSIONS` (the
 extension↔subsystem mapping is many-to-one — see the routing summary
 above for the 8 extensions without a hook). Every subsystem's host cog
 defines `build_help_menu_view` except `help` itself, so the Help route
@@ -107,6 +107,7 @@ falls back to the command-list embed when the hook is missing or raises.
 | `server_management` | `server_management_cog.py` | `servermanagement`, `servermenu`, `guildmenu`, `/server-management` | — | `ServerManagementHubView` | `!help` → Server Management (shared resolver) | dropdown Server Management → panel | hub top-level (operator) — composes moderation/channels/roles/cleanup/setup |
 | `settings` | `settings_cog.py` | (entry via `!settings`) | — | `SettingsHubView` | `!help settings` → opens Settings panel (shared resolver) | dropdown Settings → panel | hub top-level |
 | `utility` | `utility_cog.py` | `utilitymenu`, `clear`/`purge`, `info`, `serverinfo`, `userinfo`, `avatar`, `remind` | — | `_UtilityPanelView` | `!help utility` → opens Utility panel (shared resolver) | dropdown Utility → panel | hub top-level |
+| `ux_lab` | `ux_lab_cog.py` | `uxlab` (alias `interfacelab`), `/uxlab` | — | `UxLabHomeView` (wings in `views/ux_lab/`) | `!help` → UX Lab (shared resolver; administrator tier) | admin-tier top-level (design workbench, no parent hub) | zero-write interface gallery (UX Lab plan 2026-06-12) |
 | `xp` | `xp_cog.py` | `xpmenu`, `rank`, `givexp`, `resetxp`, `xpconfig` | — | `_XpHubView` | `!help xp` → opens XP panel (shared resolver) | reached via Community; `parent_hub="community"` since PR #3 | hub child (Community) — declared; admin controls live in panel |
 
 ## 3. Known inconsistencies (resolved by PR #142 / PR #143)

--- a/docs/repo-navigation-map.md
+++ b/docs/repo-navigation-map.md
@@ -215,6 +215,7 @@ A condensed version of `docs/help-command-surface-map.md` and
 | community | `cogs/community_cog.py` | `views/community/` | n/a (hub) | n/a |
 | community_spotlight | `cogs/community_spotlight_cog.py` | views in-cog (`SpotlightView`/`GamesView`) | read-only — `services/rank_providers` + EventBus `xp.level_up` feed | reads via `utils/db/xp.py` (`get_guild_xp_totals`); registered as a `community`-hub child via `scripts/new_subsystem.py` (Q-0025/Q-0044, 2026-06-09) |
 | counting | `cogs/counting_cog.py` (+ `cogs/counting/`) | `views/counting/` | direct CRUD | `utils/db/games/counting.py` |
+| ux_lab | `cogs/ux_lab_cog.py` | `views/ux_lab/` (wings) + `utils/ux_patterns/` (registry/builders) | **zero-write** — no service, no DB (CI-fenced by `test_ux_lab_zero_write.py`) | n/a — interface-gallery workbench (UX Lab plan 2026-06-12) |
 | deathmatch | `cogs/deathmatch_cog.py` (+ `cogs/deathmatch/`) | — | direct CRUD | `utils/db/games/deathmatch.py` |
 | diagnostic | `cogs/diagnostic_cog.py` (+ `cogs/diagnostic/`) | `views/diagnostic/` | `services/diagnostics_service.py` (read-only providers) | n/a |
 | economy | `cogs/economy_cog.py` (+ `cogs/economy/`) | `views/economy/` | `services/economy_service.py` | `utils/db/economy.py` |

--- a/docs/setup-platform/settings-customization-command-map.md
+++ b/docs/setup-platform/settings-customization-command-map.md
@@ -920,6 +920,44 @@ Subsystems (29): `admin`, `ai`, `blackjack`, `btd6`, `chain`, `channel`,
 23. **priority**: `P2`.
 24. **recommended_PR_phase**: post-S11.
 
+### ux_lab
+
+1. **cog_module**: `disbot/cogs/ux_lab_cog.py`.
+2. **subsystem**: `ux_lab` (admin-tier design workbench).
+3. **current_commands**: `!uxlab` (alias: `!interfacelab`), `/uxlab`.
+4. **current_command_groups**: none.
+5. **current_command_panel_or_menu**: opens `UxLabHomeView`
+   (`disbot/views/ux_lab/home.py`) — wing buttons into the exhibit browsers
+   + the limit probe bench.
+6. **help_menu_discoverable**: Yes — `subsystem_registry.py` entry,
+   `visibility_tier=administrator` (admins only).
+7. **dedicated_panel_command**: `!uxlab`.
+8. **help_menu_direct_navigation_hook**: `build_help_menu_view` on the cog.
+9. **existing_SettingSpec_declarations**: none — **by design, permanently**:
+   the lab is a zero-write workbench (no settings, no DB, no mutations;
+   CI-fenced by `tests/unit/invariants/test_ux_lab_zero_write.py`).
+10. **existing_settings_keys**: none (see 9).
+11. **existing_BindingSpec_entries**: none (see 9).
+12. **existing_ResourceRequirement_entries**: none (see 9).
+13. **current_access_policy_behavior**: `visibility_tier=administrator`;
+    `has_permissions(administrator=True)` on both entry commands; views are
+    author-locked (`BaseView` default).
+14. **hardcoded_or_env_only_behavior**: exhibit content is code-defined
+    sample data — intentionally static (it is the demo corpus).
+15. **missing_customization_commands**: none — the lab must not grow a
+    settings surface (zero-write fence).
+16. **missing_settings_pages**: none (see 15).
+17. **missing_menu_buttons_selects_modals**: plan PRs B/C add the
+    Components-V2, PIL, mockup, and compare wings
+    (`docs/planning/ux-lab-interface-gallery-plan-2026-06-12.md` §8).
+18. **setting_class_per_value**: n/a (no configurable state, see 9).
+19. **target_Settings_Manager_page**: none — exempt by design.
+20. **target_mutation_path**: none — zero-write fence.
+21. **target_help_or_menu_route**: DONE — Help direct-nav (admin tier).
+22. **provisionable_resources**: none.
+23. **priority**: `P3` — workbench, not a member feature.
+24. **recommended_PR_phase**: UX Lab plan PR A (this entry); B/C follow.
+
 ### general
 
 1. **cog_module**: `disbot/cogs/general_cog.py`

--- a/tests/unit/cogs/test_help_render_paths.py
+++ b/tests/unit/cogs/test_help_render_paths.py
@@ -228,6 +228,7 @@ def test_advanced_top_level_set_today():
         "server_management",
         "settings",
         "utility",
+        "ux_lab",
     ]
 
 

--- a/tests/unit/invariants/test_ux_lab_zero_write.py
+++ b/tests/unit/invariants/test_ux_lab_zero_write.py
@@ -1,0 +1,81 @@
+"""UX Lab zero-write fence — the lab must never gain a mutation path.
+
+The UX Lab is a gallery of *fake* interactions (design decision, UX Lab plan
+§0/§7): no DB access, no service calls, no governance reads, no audit
+emissions — its only side effects are Discord messages in the invoking
+channel. This AST fence makes the property structural: the moment any
+ux-lab module imports a write-capable layer, CI names the file and line.
+
+Inverse of the ``test_game_wager_write_boundary`` precedent: that fence
+forces writes *through* a seam; this one forbids the seam entirely.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DISBOT = _REPO_ROOT / "disbot"
+
+# Every module that makes up the lab. New wing files are picked up
+# automatically via the package globs.
+_UX_LAB_PATHS = (
+    _DISBOT / "cogs" / "ux_lab_cog.py",
+    *sorted((_DISBOT / "views" / "ux_lab").glob("*.py")),
+    *sorted((_DISBOT / "utils" / "ux_patterns").glob("*.py")),
+)
+
+# Top-level packages/modules the lab may never import (module-level OR
+# lazy/function-body — ast.walk sees both).
+_FORBIDDEN_IMPORT_ROOTS = ("services", "governance", "utils.db")
+
+# Attribute names whose mere call is a mutation signal regardless of receiver.
+_FORBIDDEN_CALLS = {"emit_audit_action", "execute", "executemany", "fetchrow"}
+
+
+def _violations(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    found: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith(_FORBIDDEN_IMPORT_ROOTS):
+                    found.append(f"import {alias.name} (line {node.lineno})")
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if mod.startswith(_FORBIDDEN_IMPORT_ROOTS) or (
+                mod == "utils" and any(a.name == "db" for a in node.names)
+            ):
+                found.append(f"from {mod} import … (line {node.lineno})")
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in _FORBIDDEN_CALLS
+        ):
+            found.append(f"call .{node.func.attr}(…) (line {node.lineno})")
+    return found
+
+
+def test_ux_lab_files_exist():
+    """The fence must actually cover the lab (guards against path drift)."""
+    assert (_DISBOT / "cogs" / "ux_lab_cog.py").exists()
+    assert (_DISBOT / "views" / "ux_lab" / "home.py").exists()
+    assert (_DISBOT / "utils" / "ux_patterns" / "registry.py").exists()
+    assert len(list(_UX_LAB_PATHS)) >= 8
+
+
+def test_ux_lab_never_writes():
+    violations: list[tuple[str, list[str]]] = []
+    for path in _UX_LAB_PATHS:
+        if path.name == "__pycache__":
+            continue
+        found = _violations(path)
+        if found:
+            violations.append((str(path.relative_to(_REPO_ROOT)), found))
+    assert not violations, (
+        "UX Lab zero-write fence violated — the lab must stay a fake-only "
+        "gallery (UX Lab plan §0). Remove the import/call or build the "
+        "feature outside the lab:\n"
+        + "\n".join(f"  {p}: {found}" for p, found in violations)
+    )

--- a/tests/unit/runtime/test_command_surface_ledger.py
+++ b/tests/unit/runtime/test_command_surface_ledger.py
@@ -1051,6 +1051,7 @@ EXPECTED_SLASH_SURFACE: dict[str, str | None] = {
     "setup-undelegate": None,
     "setup-unskip": None,
     "utility": None,
+    "uxlab": None,
     # app_commands.Group namespaces (their subcommands ride the
     # group's surface decision; extend the pin per-subcommand only if
     # a group ever needs one classified individually)

--- a/tests/unit/utils/test_ux_patterns_registry.py
+++ b/tests/unit/utils/test_ux_patterns_registry.py
@@ -1,0 +1,72 @@
+"""UX pattern registry integrity — ids, completeness, spec-card caps."""
+
+from __future__ import annotations
+
+import pytest
+
+# Importing the views package registers every exhibit's PatternSpec.
+import views.ux_lab  # noqa: F401  — registration side effect is the point
+from utils.ux_patterns import (
+    REGISTRY,
+    PatternCategory,
+    PatternSpec,
+    PatternStatus,
+    category_counts,
+    get_spec,
+    register,
+    specs_for,
+    validate_registry,
+)
+from utils.ux_patterns.builders import spec_card
+
+
+def test_registry_is_populated_per_wing():
+    counts = category_counts()
+    assert counts[PatternCategory.BUTTONS] == 10
+    assert counts[PatternCategory.SELECTS] == 8
+    assert counts[PatternCategory.MODALS] == 6
+    assert counts[PatternCategory.EMBEDS] == 14
+    assert counts[PatternCategory.PROBE] == 4
+
+
+def test_registry_completeness():
+    assert validate_registry() == []
+
+
+def test_duplicate_registration_rejected():
+    existing = next(iter(REGISTRY.values()))
+    with pytest.raises(ValueError, match="duplicate"):
+        register(existing)
+
+
+def test_malformed_pattern_id_rejected():
+    bad = PatternSpec(
+        pattern_id="Not Snake",
+        title="x",
+        category=PatternCategory.BUTTONS,
+        status=PatternStatus.STABLE,
+        recommended_for=("y",),
+        limits=("z",),
+    )
+    with pytest.raises(ValueError, match="snake_case"):
+        register(bad)
+
+
+def test_get_spec_unknown_id_names_the_problem():
+    with pytest.raises(KeyError, match="unknown pattern_id"):
+        get_spec("definitely_not_registered")
+
+
+def test_every_spec_card_stays_within_embed_caps():
+    for spec in REGISTRY.values():
+        card = spec_card(spec)
+        assert len(card) <= 6000, spec.pattern_id
+        assert len(card.fields) <= 25, spec.pattern_id
+        for f in card.fields:
+            assert len(str(f.value)) <= 1024, spec.pattern_id
+
+
+def test_specs_for_returns_only_that_category():
+    for spec in specs_for(PatternCategory.MODALS):
+        assert spec.category is PatternCategory.MODALS
+        assert spec.requires_modal

--- a/tests/unit/views/test_ux_lab_views.py
+++ b/tests/unit/views/test_ux_lab_views.py
@@ -1,0 +1,152 @@
+"""UX Lab view smoke tests — every exhibit builds inside platform caps.
+
+Construction-level verification (no Discord connection): each wing page must
+respect the legacy 25-component / 10-embed / 6000-char caps with the spec
+card included, and demo callbacks must drive without touching anything
+outside the view (the runtime half of the zero-write fence).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from views.ux_lab.buttons import ButtonsWingView
+from views.ux_lab.embeds import EmbedsWingView
+from views.ux_lab.home import UxLabHomeView, build_home_embed, home_builder
+from views.ux_lab.modals import ModalsWingView
+from views.ux_lab.probes import ProbesBenchView
+from views.ux_lab.selects import SelectsWingView
+from views.ux_lab.wing import NAV_ROW
+
+_WINGS = (ButtonsWingView, SelectsWingView, ModalsWingView, EmbedsWingView)
+
+
+def _author() -> MagicMock:
+    author = MagicMock(spec=discord.Member)
+    author.id = 1234
+    author.display_name = "Tester"
+    return author
+
+
+async def _noop_builder(
+    interaction: discord.Interaction,
+) -> tuple[discord.Embed, discord.ui.View]:
+    return discord.Embed(), discord.ui.View()
+
+
+def _interaction(*, done: bool = False) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = _author()
+    interaction.response = MagicMock()
+    interaction.response.is_done = MagicMock(return_value=done)
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.send_modal = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
+    return interaction
+
+
+@pytest.mark.parametrize("wing_cls", _WINGS)
+def test_every_exhibit_builds_within_caps(wing_cls):
+    wing = wing_cls(_author(), home_builder=_noop_builder)
+    ids = wing._exhibit_ids()
+    assert ids, wing_cls.__name__
+    for index, pattern_id in enumerate(ids):
+        wing._index = index
+        wing.state.clear()
+        embeds, view = wing.build()
+        assert view is wing
+        assert 1 <= len(embeds) <= 10, pattern_id
+        assert sum(len(e) for e in embeds) <= 6000, pattern_id
+        assert len(view.children) <= 25, pattern_id
+        # Exhibit items stay off the nav row; nav row carries exactly 4.
+        nav_items = [i for i in view.children if getattr(i, "row", None) == NAV_ROW]
+        assert len(nav_items) == 4, pattern_id
+
+
+@pytest.mark.parametrize("wing_cls", _WINGS)
+@pytest.mark.asyncio
+async def test_wing_navigation_advances_and_resets_state(wing_cls):
+    wing = wing_cls(_author(), home_builder=_noop_builder)
+    wing.build()
+    wing.state["leftover"] = True
+    next_btn = next(
+        item
+        for item in wing.children
+        if isinstance(item, discord.ui.Button) and item.emoji is not None
+        and str(item.emoji) == "▶"
+    )
+    interaction = _interaction()
+    await next_btn.callback(interaction)
+    assert wing._index == 1
+    assert wing.state == {}
+    interaction.response.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_toggle_pill_flips_and_rerenders_in_place():
+    wing = ButtonsWingView(_author(), home_builder=_noop_builder)
+    wing._index = wing._exhibit_ids().index("toggle_pills")
+    wing.build()
+    pill = next(
+        item
+        for item in wing.children
+        if isinstance(item, discord.ui.Button)
+        and item.label is not None
+        and item.label.startswith("Caps")
+    )
+    assert wing.state["flags"]["Caps"] is False
+    await pill.callback(_interaction())
+    assert wing.state["flags"]["Caps"] is True
+
+
+@pytest.mark.asyncio
+async def test_danger_confirm_never_executes_on_first_click():
+    wing = ButtonsWingView(_author(), home_builder=_noop_builder)
+    wing._index = wing._exhibit_ids().index("danger_confirm_then_result")
+    wing.build()
+    danger = next(
+        item for item in wing.children if isinstance(item, discord.ui.Button)
+        and item.style is discord.ButtonStyle.danger
+    )
+    await danger.callback(_interaction())
+    assert wing.state["stage"] == "confirming"
+
+
+def test_home_view_and_embed_build():
+    embed = build_home_embed()
+    assert len(embed) <= 6000
+    view = UxLabHomeView(_author())
+    assert 1 <= len(view.children) <= 25
+    # Author lock stays on (workbench default — not a public panel).
+    assert view._public is False
+
+
+@pytest.mark.asyncio
+async def test_home_builder_returns_fresh_home():
+    interaction = _interaction()
+    embed, view = await home_builder(interaction)
+    assert isinstance(view, UxLabHomeView)
+    assert "UX Lab" in (embed.title or "")
+
+
+def test_probe_bench_builds_within_caps():
+    bench = ProbesBenchView(_author(), home_builder=_noop_builder)
+    embeds, view = bench.build()
+    assert len(view.children) <= 25
+    assert sum(len(e) for e in embeds) <= 6000
+
+
+@pytest.mark.asyncio
+async def test_probe_select_26_reports_rejection_layer():
+    bench = ProbesBenchView(_author(), home_builder=_noop_builder)
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    result = await bench._probe_select_26(channel)
+    # Wherever the rejection lands (library or API mock-pass-through),
+    # the probe must report rather than raise.
+    assert result.probe_id == "probe_select_26_options"
+    assert result.detail


### PR DESCRIPTION
## What this is

**PR A of the UX Lab plan** ([design](docs/planning/ux-lab-interface-gallery-plan-2026-06-12.md), owner-approved "start building it" 2026-06-12): the core interface gallery. `!uxlab` (admin-gated, + `/uxlab`) opens a browsable, clickable catalogue of **42 registered UX patterns** — every exhibit reacts, carries a spec card (use-for / avoid-for / platform limits / adopted-by), and mutates **nothing**.

## What's inside

- **`utils/ux_patterns/`** — the `PatternSpec` registry (the durable design vocabulary: future plans say "use `danger_confirm_then_result`") + 13 pure embed-archetype builders that double as the candidate standard library.
- **`views/ux_lab/`** — the `ExhibitWingView` browser (in-place V-02 navigation: ◀ ▶ counter 🏠 on every page, spec card under every exhibit) and four wings:
  - **Buttons (10)** — style strip, emoji forms, the V-03 4-button home with live breadcrumb, dense operator row, **danger → confirm → result doctrine**, type-to-confirm modal, wizard, paginator + jump select, toggle pills (the Q-0108 automod shape), disable-on-timeout demo.
  - **Selects (8)** — category nav, multi-select → preview → apply, **the >25-item paginated select** (the selector-gap fix), all four entity selects, descriptions/default, two-stage filter, target+verb bank, modal-fed search.
  - **Modals (6)** — short/paragraph, **Label-wrapped select inside a modal** (the 2.6+ capability), validation-failure path, preview-before-save loop (Q-0059 shape), report form, template editor with `{user}` preview.
  - **Embeds (14)** — info/success/warning/error, compact audit line (Q-0109 shape), mod case, profile, both leaderboard variants, setup final-review, AI answer with provenance, before/after diff, the palette colour strip, and the deliberately maximal 25-field embed.
- **Probe bench** — P-01 (5×5 legacy grid), P-02 (26-option select — reports *which layer* rejects), P-06 (10-embed/6000-char budget), P-07 (modal+select, manual), Run-all; results are dated + library-versioned, self-deleting demo messages.
- **Zero-write fence** — `test_ux_lab_zero_write.py`: AST ban on `services`/`governance`/`utils.db` imports and mutation calls across all lab modules (auto-covers future wings). 23 new tests total.
- **Registration** — full `new_subsystem.py` touch-point set (9/9 OK): SUBSYSTEMS (administrator tier, `capabilities: []` by design), KNOWN_PANEL_COMMANDS, INITIAL_EXTENSIONS, surface/command/navigation map rows, plus the three pinned-surface updates adding a subsystem requires (advanced top-level set, slash pin, counts).

## Verification

- `check_quality.py --full` green — **9,139 passed** (mypy + black/isort/ruff + full pytest).
- `check_architecture.py --mode strict` — **0 errors**, no new warnings.
- **Live boot on Galaxy Bot**: `✅ Loaded cogs.ux_lab_cog`, registry validated + frozen, 0 ERROR/CRITICAL, clean shutdown.

PRs B (Components V2 + PIL wings) and C (mock studio + compare + pattern-library export) follow in this session per the plan.

**Owner note:** `/uxlab` (slash) appears after the next slash sync (`!sync` owner command); `!uxlab` works immediately on deploy.

https://claude.ai/code/session_01Bj1NppGr719EGfqS6zXrgx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bj1NppGr719EGfqS6zXrgx)_