### PR TITLE
feat(routines): executor-nightly cron — open a `continue` issue at 03:00/05:00

### DIFF
--- a/.github/workflows/executor-nightly.yml
+++ b/.github/workflows/executor-nightly.yml
@@ -1,0 +1,52 @@
+name: executor-nightly
+
+# Fires the "superbot night executor" routine on a real overnight schedule by opening a
+# `continue`-labeled issue (the routine's console Schedule trigger was unreliable in the
+# research-preview UI, so the cadence lives here instead — same pattern as
+# reconciliation-trigger.yml). Two runs a night = two FRESH-context starts (fights the
+# ~700K-context degradation). The executor reads the issue body, advances the next plan step,
+# and closes the issue.
+#
+# Times are UTC. 01:00 + 03:00 UTC == 03:00 + 05:00 CEST (the maintainer's summer local time).
+# Adjust the cron if your local offset changes (CET winter would be 02:00 + 04:00 UTC).
+#
+# Provenance + reliability (Q-0105): added 2026-06-12. UNVERIFIED — confirm it opens one issue
+# per scheduled slot and the executor picks it up. Delete this workflow if it misfires; it is a
+# convenience scheduler, not load-bearing runtime.
+
+on:
+  schedule:
+    - cron: "0 1,3 * * *"
+  workflow_dispatch: {} # lets you also kick a run by hand from the Actions tab
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: executor-nightly
+  cancel-in-progress: false
+
+jobs:
+  open-executor-run-issue:
+    if: github.repository == 'menno420/superbot'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open a scheduled `continue` issue (deduped)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Dedupe: if a scheduled executor-run issue is still open (executor hasn't picked up
+          # the last one — it closes them when done), don't pile another on top.
+          open_scheduled="$(gh issue list --repo "$GITHUB_REPOSITORY" --label continue --state open \
+            --search 'in:title "Scheduled executor run"' --json number --jq 'length' 2>/dev/null || echo 0)"
+          if [ "${open_scheduled:-0}" != "0" ]; then
+            echo "A scheduled executor-run issue is still open — skipping (the executor will get to it)."
+            exit 0
+          fi
+          gh label create continue --repo "$GITHUB_REPOSITORY" --color 1D76DB \
+            --description "Executor continuation / scheduled run" --force 2>/dev/null || true
+          gh issue create --repo "$GITHUB_REPOSITORY" \
+            --title "Scheduled executor run ($(date -u +%Y-%m-%d\ %H:%M) UTC)" \
+            --label continue \
+            --body $'Scheduled overnight run of the **superbot night executor** — no prior handoff.\n\nAdvance the **next big step of the plan** per `docs/current-state.md` ▶ Next action / the decade-queue doc (executor STEP 1.C). If a bigger step needs more than one run, hand off via a fresh `continue` issue per STEP 3. Close this issue when the run ships (executor STEP 5).\n\nAuto-opened by `.github/workflows/executor-nightly.yml`.'

--- a/docs/operations/autonomous-routines.md
+++ b/docs/operations/autonomous-routines.md
@@ -27,7 +27,7 @@ session N leaves session N+1 better-equipped.
 |---|---|---|---|
 | **superbot autonomous dispatch** | API (`/fire`) | General work orders from Hermes/phone (`superbot-dispatch`). Classifies by `CLASS:`. | per work order (Q-0113/Q-0114) |
 | **superbot docs reconciliation** | **Issue** labeled `reconcile` | The Q-0107 every-20th-PR docs-only pass: reconcile the ledger, de-stale docs, plan the next ~9 PRs, contribute one idea. | `docs` → self-merge on green |
-| **superbot night executor** | Schedule (nightly) + Issue `continue` + API | Advance the **next big step of the plan** (a "continue from last session" run); self-chain via `continue` issues when a step spans runs; fall back to a quality win. Phase-gated against features. | small → self-merge; **big step → Hermes reviews + merges** (Q-0117) |
+| **superbot night executor** | Issue `continue` (cron-driven 03:00/05:00 + handoffs) | Advance the **next big step of the plan** (a "continue from last session" run); self-chain via `continue` issues when a step spans runs; fall back to a quality win. Phase-gated against features. | small → self-merge; **big step → Hermes reviews + merges** (Q-0117) |
 
 **Why an issue-trigger (not a schedule, not a per-PR trigger) for reconciliation:** the docs
 pass should run **promptly when due — daytime included** — so the docs + fresh plan are ready
@@ -129,8 +129,11 @@ The nightly **executor** — a productive "continue from where the last session 
 Its primary job is to **advance the next big step of the plan** (not just small fixes), and to
 **self-chain** across runs via `continue` issues when a step is bigger than one bounded run.
 
-- **Triggers:** Schedule → Daily (suggested 03:00) · **GitHub → Issue opened, label `continue`**
-  (picks up a continuation handoff promptly) · **API** (Hermes fires it with a detected problem).
+- **Triggers:** **GitHub → Issue opened, label `continue`** — and that's all it needs. The
+  overnight cadence is driven by `.github/workflows/executor-nightly.yml` (a cron that opens a
+  scheduled `continue` issue at 03:00 and 05:00 local), because the console Schedule trigger was
+  unreliable in the research-preview UI. The same `continue` trigger also picks up real
+  continuation handoffs. (No API trigger / no token — on-demand work goes through dispatch.)
 - **Repository:** `menno420/superbot`. **Model:** Opus 4.8 (the execution tier; §11).
   **Permissions:** unrestricted branch push **OFF**. **Behavior:** auto-fix PRs ON.
 - **Merge gate (Q-0117):** small fixes/docs **self-merge on green** (Q-0113); a **substantial
@@ -248,6 +251,7 @@ The routine treats the issue as the go-signal, runs the docs-only pass, and clos
 - [`hermes-dispatch-bridge.md`](./hermes-dispatch-bridge.md) — the `/fire` mechanism + gates.
 - [`hermes-skills/dispatch.md`](./hermes-skills/dispatch.md) · [`hermes-skills/review.md`](./hermes-skills/review.md)
 - `scripts/check_reconciliation_due.py` · `scripts/check_phase_gate.py` · `scripts/check_current_state_ledger.py`
-- `.github/workflows/reconciliation-trigger.yml` — the Action that opens the `reconcile` issue on the 20-PR boundary.
+- `.github/workflows/reconciliation-trigger.yml` — opens the `reconcile` issue on the 20-PR boundary.
+- `.github/workflows/executor-nightly.yml` — cron that opens a scheduled `continue` issue at 03:00/05:00 local.
 - [`hermes-skills/review-merge.md`](./hermes-skills/review-merge.md) — Hermes' independent review + merge gate for `needs-hermes-review` PRs (Q-0117).
 - `docs/owner/ai-project-workflow.md` §10 (staging/continuation) · §12 (the loop).


### PR DESCRIPTION
## What

The console Schedule trigger was unreliable in the research-preview UI (stuck at 09:00), so this drives the executor's overnight cadence from a **cron Action** instead — the same pattern as `reconciliation-trigger.yml`.

- **`.github/workflows/executor-nightly.yml`** (new): at **01:00 + 03:00 UTC (= 03:00 + 05:00 CEST)** it opens a **`continue`-labeled issue** whose body tells the executor to advance the next plan step (no prior handoff). The executor's `Issue continue` trigger fires, it advances the plan, and closes the issue.
  - **Deduped** against an already-open scheduled issue (no pile-up if the executor is down).
  - `workflow_dispatch` so you can also kick a run by hand; canonical-repo guard; Q-0105 delete-if-unreliable header.
- **Two scheduled slots = two fresh-context starts**, which directly fights the ~700K-context degradation.
- The executor now needs **only the `continue` trigger** — no Schedule trigger (the buggy one), no API/token. That same trigger also picks up real continuation handoffs.

`autonomous-routines.md` updated (executor trigger row + config + See also).

## Verification

Workflow YAML valid · `check_docs --strict` ✅. CI-config/docs only; no `disbot/`.

## Note on times

Cron is UTC; `0 1,3 * * *` = 03:00/05:00 CEST (summer). If your offset changes (CET winter), shift to `0 2,4 * * *`. Easy one-line tweak.

https://claude.ai/code/session_01U7iVHpMhVaNwiw5HuEH7js

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7iVHpMhVaNwiw5HuEH7js)_