### PR TITLE
UX Lab PR B: Components-V2 + PIL wings (14 exhibits), probe bench 4→10

### DIFF
--- a/disbot/utils/ux_patterns/image_builders.py
+++ b/disbot/utils/ux_patterns/image_builders.py
@@ -1,0 +1,163 @@
+"""PIL prototype builders for the UX Lab image wing.
+
+Three *candidate* card renderers that don't exist as features yet — the
+welcome card (the Q-0110 phase-2 preview), a leaderboard image, and an
+event poster — rendered entirely from sample data with **no network**: the
+avatar is a generated initials disc (the fallback-silhouette path every
+real implementation needs anyway, per the platform-limits doc §4).
+
+Same contract as ``utils/mining_render.py``: lazy PIL import, ``bytes |
+None`` return (``None`` = Pillow unavailable → callers keep an embed
+fallback), pure inputs in / bytes out.
+"""
+
+from __future__ import annotations
+
+import io
+
+# Shared sample palette (dark-theme friendly).
+_BG = (24, 25, 31)
+_PANEL = (32, 34, 42)
+_ACCENT = (88, 101, 242)  # blurple
+_TEXT = (235, 236, 240)
+_SUBTLE = (148, 155, 164)
+_GOLD = (240, 178, 50)
+
+
+def _fonts(size_big: int, size_small: int):  # noqa: ANN202 — PIL lazy types
+    """Best-effort font pair; Pillow's default bitmap font as the fallback."""
+    from PIL import ImageFont  # lazy: optional at import time
+
+    big: ImageFont.FreeTypeFont | ImageFont.ImageFont
+    small: ImageFont.FreeTypeFont | ImageFont.ImageFont
+    try:
+        big = ImageFont.truetype(
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+            size_big,
+        )
+        small = ImageFont.truetype(
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+            size_small,
+        )
+    except Exception:  # noqa: BLE001 — font availability is environmental
+        big = ImageFont.load_default()
+        small = ImageFont.load_default()
+    return big, small
+
+
+def _initials_disc(
+    draw,
+    *,
+    cx: int,
+    cy: int,
+    r: int,
+    initials: str,
+    font,
+) -> None:  # noqa: ANN001
+    """The no-network avatar: accent ring + initials disc."""
+    draw.ellipse(
+        (cx - r - 6, cy - r - 6, cx + r + 6, cy + r + 6),
+        outline=_ACCENT,
+        width=6,
+    )
+    draw.ellipse((cx - r, cy - r, cx + r, cy + r), fill=_PANEL)
+    box = draw.textbbox((0, 0), initials, font=font)
+    tw, th = box[2] - box[0], box[3] - box[1]
+    draw.text((cx - tw / 2, cy - th / 2 - box[1]), initials, font=font, fill=_TEXT)
+
+
+def render_welcome_card(
+    member_name: str = "AstroFox",
+    server_name: str = "Demo Server",
+    member_number: int = 1235,
+) -> bytes | None:
+    """The Q-0110 phase-2 candidate: avatar disc + greeting + member count."""
+    try:
+        from PIL import Image, ImageDraw  # lazy: degrade gracefully
+    except Exception:  # noqa: BLE001
+        return None
+    img = Image.new("RGB", (960, 360), _BG)
+    draw = ImageDraw.Draw(img)
+    big, small = _fonts(56, 30)
+    _initials_disc(
+        draw,
+        cx=180,
+        cy=180,
+        r=96,
+        initials=member_name[:2].upper(),
+        font=big,
+    )
+    draw.text((340, 110), f"Welcome, {member_name}!", font=big, fill=_TEXT)
+    draw.text(
+        (342, 196),
+        f"You are member #{member_number} of {server_name}",
+        font=small,
+        fill=_SUBTLE,
+    )
+    draw.line((340, 260, 900, 260), fill=_ACCENT, width=3)
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=85)
+    return buf.getvalue()
+
+
+def render_leaderboard_image(
+    rows: tuple[tuple[str, int], ...] = (
+        ("AstroFox", 13_370),
+        ("BananaMage", 11_204),
+        ("CinderWolf", 9_876),
+        ("DuskRunner", 8_545),
+        ("EmberLynx", 7_002),
+    ),
+) -> bytes | None:
+    """Top-N horizontal bars — the image alternative to the embed board."""
+    try:
+        from PIL import Image, ImageDraw  # lazy: degrade gracefully
+    except Exception:  # noqa: BLE001
+        return None
+    img = Image.new("RGB", (720, 96 + 64 * len(rows)), _BG)
+    draw = ImageDraw.Draw(img)
+    big, small = _fonts(36, 24)
+    draw.text((32, 24), "🏆 Top members", font=big, fill=_GOLD)
+    top = rows[0][1] if rows else 1
+    for i, (name, score) in enumerate(rows):
+        y = 96 + i * 64
+        width = int(420 * score / top)
+        draw.rounded_rectangle(
+            (200, y, 200 + width, y + 40),
+            radius=8,
+            fill=_ACCENT if i else _GOLD,
+        )
+        draw.text((32, y + 6), f"{i + 1}. {name}", font=small, fill=_TEXT)
+        draw.text((210 + width, y + 6), f"{score:,}", font=small, fill=_SUBTLE)
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=85)
+    return buf.getvalue()
+
+
+def render_event_poster(
+    title: str = "Movie Night 🎬",
+    when: str = "Friday · 20:00 CET",
+    host: str = "AstroFox",
+) -> bytes | None:
+    """Event-poster candidate (the Q-0112 scheduler's visual upgrade)."""
+    try:
+        from PIL import Image, ImageDraw  # lazy: degrade gracefully
+    except Exception:  # noqa: BLE001
+        return None
+    img = Image.new("RGB", (800, 420), _PANEL)
+    draw = ImageDraw.Draw(img)
+    big, small = _fonts(52, 28)
+    draw.rectangle((0, 0, 800, 12), fill=_ACCENT)
+    draw.rectangle((0, 408, 800, 420), fill=_ACCENT)
+    draw.text((48, 96), title, font=big, fill=_TEXT)
+    draw.text((50, 190), when, font=small, fill=_GOLD)
+    draw.text((50, 240), f"Hosted by {host}", font=small, fill=_SUBTLE)
+    draw.text(
+        (50, 320),
+        "RSVP with the buttons below ✅ ❔ ❌",
+        font=small,
+        fill=_TEXT,
+    )
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=85)
+    return buf.getvalue()

--- a/disbot/views/ux_lab/__init__.py
+++ b/disbot/views/ux_lab/__init__.py
@@ -9,6 +9,8 @@ Design: ``docs/planning/ux-lab-interface-gallery-plan-2026-06-12.md``.
 from views.ux_lab.buttons import ButtonsWingView
 from views.ux_lab.embeds import EmbedsWingView
 from views.ux_lab.home import UxLabHomeView, build_home_embed, home_builder
+from views.ux_lab.image_cards import ImageWingView
+from views.ux_lab.layout_v2 import LayoutWingView
 from views.ux_lab.modals import ModalsWingView
 from views.ux_lab.probes import ProbesBenchView
 from views.ux_lab.selects import SelectsWingView
@@ -16,6 +18,8 @@ from views.ux_lab.selects import SelectsWingView
 __all__ = [
     "ButtonsWingView",
     "EmbedsWingView",
+    "ImageWingView",
+    "LayoutWingView",
     "ModalsWingView",
     "ProbesBenchView",
     "SelectsWingView",

--- a/disbot/views/ux_lab/home.py
+++ b/disbot/views/ux_lab/home.py
@@ -13,6 +13,8 @@ from utils.ux_patterns import PatternCategory, category_counts
 from views.base import HubView
 from views.ux_lab.buttons import ButtonsWingView
 from views.ux_lab.embeds import EmbedsWingView
+from views.ux_lab.image_cards import ImageWingView
+from views.ux_lab.layout_v2 import LayoutWingView
 from views.ux_lab.modals import ModalsWingView
 from views.ux_lab.probes import ProbesBenchView
 from views.ux_lab.selects import SelectsWingView
@@ -23,6 +25,8 @@ _WING_LABELS: dict[PatternCategory, str] = {
     PatternCategory.SELECTS: "Selects",
     PatternCategory.MODALS: "Modals",
     PatternCategory.EMBEDS: "Embeds",
+    PatternCategory.LAYOUT_V2: "Components V2",
+    PatternCategory.IMAGE: "PIL cards",
     PatternCategory.PROBE: "Probe bench",
 }
 
@@ -73,18 +77,20 @@ class UxLabHomeView(HubView):
 
     def __init__(self, author: discord.Member | discord.User) -> None:
         super().__init__(author)
-        wings: tuple[tuple[str, str, type[ExhibitWingView]], ...] = (
-            ("🔘", "Buttons", ButtonsWingView),
-            ("📋", "Selects", SelectsWingView),
-            ("⌨️", "Modals", ModalsWingView),
-            ("🪧", "Embeds", EmbedsWingView),
+        wings: tuple[tuple[str, str, type[ExhibitWingView], int], ...] = (
+            ("🔘", "Buttons", ButtonsWingView, 0),
+            ("📋", "Selects", SelectsWingView, 0),
+            ("⌨️", "Modals", ModalsWingView, 0),
+            ("🪧", "Embeds", EmbedsWingView, 0),
+            ("🧱", "Components V2", LayoutWingView, 1),
+            ("🎨", "PIL cards", ImageWingView, 1),
         )
-        for emoji, label, wing_cls in wings:
+        for emoji, label, wing_cls, row in wings:
             btn: discord.ui.Button[discord.ui.View] = discord.ui.Button(
                 label=label,
                 emoji=emoji,
                 style=discord.ButtonStyle.primary,
-                row=0,
+                row=row,
             )
 
             async def _open(

--- a/disbot/views/ux_lab/image_cards.py
+++ b/disbot/views/ux_lab/image_cards.py
@@ -1,0 +1,247 @@
+"""UX Lab wing 6 — PIL-generated image cards.
+
+Reuse first: the mining inventory/stat renderers and the gear paper-doll
+compositor are exhibited with sample data, not re-implemented. The three
+*candidate* cards (welcome / leaderboard image / event poster) come from
+``utils/ux_patterns/image_builders.py``. Every render runs in
+``asyncio.to_thread`` (CPU-bound), reports duration + bytes against the
+8 MiB bot cap, and attaches alt text — the platform-limits doc §4 rules,
+demonstrated live.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import time
+from collections.abc import Callable
+
+import discord
+
+from core.runtime.interaction_helpers import safe_defer
+from utils.ux_patterns import PatternCategory, PatternSpec, PatternStatus, register
+from utils.ux_patterns.image_builders import (
+    render_event_poster,
+    render_leaderboard_image,
+    render_welcome_card,
+)
+from views.ux_lab.wing import ExhibitRender, ExhibitWingView
+
+_CAT = PatternCategory.IMAGE
+_IMG_LIMITS = (
+    "~8 MiB bot attachment cap (413 above)",
+    "JPEG/WebP for composites; PNG only for transparency/pixel art",
+    "PIL is CPU-bound — render inside asyncio.to_thread",
+    "alt text via the attachment description field (≤1024 chars)",
+)
+
+_SAMPLE_INVENTORY: list[tuple[str, int]] = [
+    ("stone", 240),
+    ("iron ore", 87),
+    ("gold ore", 31),
+    ("diamond", 6),
+    ("magma shard", 2),
+]
+_SAMPLE_LOADOUT: dict[str, str] = {
+    "tool": "iron pickaxe",
+    "light": "lantern",
+    "helmet": "iron helmet",
+    "chestplate": "iron chestplate",
+    "leggings": "iron leggings",
+    "boots": "iron boots",
+    "weapon": "iron sword",
+    "shield": "wooden shield",
+    "charm": "lucky charm",
+}
+
+
+def _img_spec(
+    pattern_id: str,
+    title: str,
+    *,
+    status: PatternStatus,
+    recommended_for: tuple[str, ...],
+    adopted_by: tuple[str, ...] = (),
+    notes: str = "",
+) -> None:
+    register(
+        PatternSpec(
+            pattern_id=pattern_id,
+            title=title,
+            category=_CAT,
+            status=status,
+            requires_pil=True,
+            recommended_for=recommended_for,
+            adopted_by=adopted_by,
+            limits=_IMG_LIMITS,
+            notes=notes or "🎨 Render draws the card with sample data.",
+        ),
+    )
+
+
+_img_spec(
+    "pil_inventory_card",
+    "Inventory card (shipped renderer)",
+    status=PatternStatus.STABLE,
+    recommended_for=("compact item-quantity grids beyond embed-field comfort",),
+    adopted_by=("views/mining/main_panel.py (live since #665)",),
+)
+_img_spec(
+    "pil_stat_card",
+    "Stat card (shipped renderer)",
+    status=PatternStatus.STABLE,
+    recommended_for=("profile-style number walls with a custom look",),
+    adopted_by=("views/mining/character_panel.py (live since #665)",),
+)
+_img_spec(
+    "pil_character_paperdoll",
+    "Gear paper-doll compositor (shipped renderer)",
+    status=PatternStatus.STABLE,
+    recommended_for=("equipment visualisation; sprite packs drop in by file",),
+    adopted_by=("mining gear panel (live since #702)",),
+    notes="Placeholder shapes render where no sprite PNG exists — the owner "
+    "pack upgrades it without code changes.",
+)
+_img_spec(
+    "pil_welcome_card",
+    "Welcome card (Q-0110 phase-2 candidate)",
+    status=PatternStatus.EXPERIMENTAL,
+    recommended_for=("the welcome service's phase-2 card (vs embed-only v1)",),
+    notes="Uses the no-network initials disc — the avatar-download fallback "
+    "path a real implementation needs anyway.",
+)
+_img_spec(
+    "pil_leaderboard_image",
+    "Leaderboard image (candidate)",
+    status=PatternStatus.EXPERIMENTAL,
+    recommended_for=("a flashier monthly-winners post; NOT the live board",),
+)
+_img_spec(
+    "pil_event_poster",
+    "Event poster (Q-0112 candidate)",
+    status=PatternStatus.EXPERIMENTAL,
+    recommended_for=("scheduled-event announcements above the RSVP buttons",),
+)
+
+
+def _render_inventory() -> bytes | None:
+    from utils.mining_render import build_card_spec, render_inventory_card
+
+    spec = build_card_spec(
+        "AstroFox's satchel",
+        _SAMPLE_INVENTORY,
+        footer="UX Lab sample data",
+    )
+    return render_inventory_card(spec)
+
+
+def _render_stat_card() -> bytes | None:
+    from utils.mining_render import build_stat_card_spec, render_stat_card
+
+    spec = build_stat_card_spec(
+        "AstroFox",
+        level=42,
+        xp_bar="█████████░ 90%",
+        location="Magma Chambers (-740m)",
+        deepest="Crystal Hollow (-810m)",
+        gear_lines=[("tool", "Iron Pickaxe (18/40)"), ("light", "Lantern")],
+        coins=13_370,
+        net_worth=21_205,
+    )
+    return render_stat_card(spec)
+
+
+def _render_paperdoll() -> bytes | None:
+    from utils.character_render import render_character_for
+
+    return render_character_for(dict(_SAMPLE_LOADOUT))
+
+
+_RENDERERS: dict[str, tuple[Callable[[], bytes | None], str, str]] = {
+    # pattern_id -> (renderer, filename, alt text)
+    "pil_inventory_card": (
+        _render_inventory,
+        "uxlab-inventory.png",
+        "Inventory card: 5 sample items with quantities in coloured rows",
+    ),
+    "pil_stat_card": (
+        _render_stat_card,
+        "uxlab-stats.png",
+        "Stat card for AstroFox: level 42, XP bar, location, gear, coins",
+    ),
+    "pil_character_paperdoll": (
+        _render_paperdoll,
+        "uxlab-paperdoll.png",
+        "Paper-doll figure wearing a full sample iron loadout",
+    ),
+    "pil_welcome_card": (
+        lambda: render_welcome_card(),
+        "uxlab-welcome.jpg",
+        "Welcome card greeting AstroFox as member #1235 of Demo Server",
+    ),
+    "pil_leaderboard_image": (
+        lambda: render_leaderboard_image(),
+        "uxlab-leaderboard.jpg",
+        "Leaderboard image: top five members as horizontal score bars",
+    ),
+    "pil_event_poster": (
+        lambda: render_event_poster(),
+        "uxlab-poster.jpg",
+        "Event poster for Movie Night, Friday 20:00 CET, hosted by AstroFox",
+    ),
+}
+
+
+class ImageWingView(ExhibitWingView):
+    """Wing 6 — PIL image cards."""
+
+    WING_TITLE = "PIL cards"
+    WING_EMOJI = "🎨"
+
+    def _exhibit_ids(self) -> tuple[str, ...]:
+        return tuple(_RENDERERS)
+
+    def _render_exhibit(self, pattern_id: str) -> ExhibitRender:
+        renderer, filename, alt = _RENDERERS[pattern_id]
+        header = discord.Embed(
+            title=f"🎨 {pattern_id}",
+            description=(
+                "**🎨 Render** draws the card from sample data in a worker "
+                "thread and posts it with alt text + size/time stats."
+            ),
+            color=discord.Color.dark_magenta(),
+        )
+        btn = self.demo_button(
+            "🎨 Render the card",
+            style=discord.ButtonStyle.primary,
+            row=0,
+        )
+
+        async def _render(interaction: discord.Interaction) -> None:
+            if not await safe_defer(interaction, ephemeral=True):
+                return
+            start = time.perf_counter()
+            png = await asyncio.to_thread(renderer)
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            if png is None:
+                await interaction.followup.send(
+                    "Pillow isn't available in this runtime — the renderer "
+                    "degraded to its embed fallback path (by design).",
+                    ephemeral=True,
+                )
+                return
+            file = discord.File(
+                io.BytesIO(png),
+                filename=filename,
+                description=alt,
+            )
+            await interaction.followup.send(
+                f"`{filename}` · **{len(png) / 1024:.0f} KB** "
+                f"(cap ~8 MiB) · rendered in **{elapsed_ms:.0f} ms** · "
+                f"alt text attached",
+                file=file,
+                ephemeral=True,
+            )
+
+        btn.callback = _render  # type: ignore[method-assign]
+        return ([header], [btn])

--- a/disbot/views/ux_lab/layout_v2.py
+++ b/disbot/views/ux_lab/layout_v2.py
@@ -1,0 +1,416 @@
+"""UX Lab wing 5 — Components V2 layouts (EXPERIMENTAL lane).
+
+A Components-V2 message replaces ``content``/``embeds`` entirely, so these
+exhibits cannot render inside the classic wing browser. Each browser page
+explains the layout and carries a **📤 Render** button that sends the real
+``LayoutView`` message into the channel (self-deleting). Send failures are
+reported verbatim — a failed render IS probe data.
+
+Intentional divergence (architecture note): ``_LabLayout`` extends
+``discord.ui.LayoutView`` directly — it cannot extend ``BaseView`` because
+LayoutView is a sibling of ``discord.ui.View``, not a subclass. This is the
+lab's sanctioned experimental lineage (UX Lab plan §2); adopting LayoutView
+for real panels stays a separate ADR decision. Author-lock and timeout
+semantics are mirrored from ``BaseView`` below.
+"""
+
+from __future__ import annotations
+
+import discord
+
+from utils.ux_patterns import PatternCategory, PatternSpec, PatternStatus, register
+from views.ux_lab.wing import ExhibitRender, ExhibitWingView
+
+_CAT = PatternCategory.LAYOUT_V2
+_CV2_LIMITS = (
+    "40 components total (nested count) per message",
+    "4000 display characters across all text items",
+    "replaces content/embeds; polls/stickers unavailable",
+)
+# Stable public placeholder images (Discord's default avatars).
+_AVATARS = tuple(f"https://cdn.discordapp.com/embed/avatars/{n}.png" for n in range(5))
+_RENDER_TTL = 120  # seconds before a rendered CV2 demo message self-deletes
+
+
+def _cv2_spec(
+    pattern_id: str,
+    title: str,
+    *,
+    recommended_for: tuple[str, ...],
+    anti_patterns: tuple[str, ...] = (),
+    notes: str = "",
+    extra_limits: tuple[str, ...] = (),
+) -> None:
+    register(
+        PatternSpec(
+            pattern_id=pattern_id,
+            title=title,
+            category=_CAT,
+            status=PatternStatus.EXPERIMENTAL,
+            uses_components_v2=True,
+            recommended_for=recommended_for,
+            anti_patterns=anti_patterns,
+            limits=(*extra_limits, *_CV2_LIMITS),
+            notes=notes or "Press 📤 Render — the layout posts below (self-deletes).",
+        ),
+    )
+
+
+_cv2_spec(
+    "cv2_text_only",
+    "Text-display message (no embed chrome)",
+    recommended_for=("long-form markdown without the embed frame",),
+    anti_patterns=("content that needs fields/columns — embeds still win there",),
+)
+_cv2_spec(
+    "cv2_section_accessory",
+    "Sections with thumbnail / button accessory",
+    recommended_for=("list rows with a per-row image or action",),
+    extra_limits=("≤3 text displays per section + exactly 1 accessory",),
+)
+_cv2_spec(
+    "cv2_container_dashboard",
+    "Container dashboard (accent colour card)",
+    recommended_for=("rich status cards without embeds; the 'future panel' look",),
+)
+_cv2_spec(
+    "cv2_media_gallery",
+    "Media gallery grid",
+    recommended_for=("image sets (welcome banners, screenshots) in one grid",),
+    extra_limits=("≤10 items per gallery",),
+)
+_cv2_spec(
+    "cv2_file_display",
+    "Inline file component",
+    recommended_for=("showing a generated text/log file inside the message body",),
+    extra_limits=("the attachment must be referenced by the component",),
+)
+_cv2_spec(
+    "cv2_settings_page",
+    "Settings page recreation (the SettingsHub comparison)",
+    recommended_for=("judging whether real settings panels should adopt CV2",),
+    anti_patterns=("adopting for real panels before the ADR decision",),
+)
+_cv2_spec(
+    "cv2_mobile_compact",
+    "Dense vs compact (the phone check)",
+    recommended_for=("checking a layout on desktop AND a phone before approving",),
+    notes="Render it, then open Discord on your phone — same message, "
+    "different feel.",
+)
+_cv2_spec(
+    "cv2_interactive_mix",
+    "Interactive components inside containers",
+    recommended_for=("verifying buttons/selects fire normally inside CV2",),
+)
+
+
+class _LabLayout(discord.ui.LayoutView):
+    """Author-locked, short-lived LayoutView for lab renders.
+
+    Mirrors the two BaseView behaviors that matter here: only the invoker
+    may interact, and the message is short-lived (``delete_after`` on send
+    handles cleanup, so no ``on_timeout`` edit is needed).
+    """
+
+    def __init__(self, author_id: int) -> None:
+        super().__init__(timeout=_RENDER_TTL)
+        self._author_id = author_id
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id != self._author_id:
+            await interaction.response.send_message(
+                "This demo isn't yours.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+
+def _ack_button(label: str, *, style: discord.ButtonStyle) -> discord.ui.Button:  # type: ignore[type-arg]
+    btn: discord.ui.Button = discord.ui.Button(label=label, style=style)  # type: ignore[type-arg]
+
+    async def _cb(interaction: discord.Interaction) -> None:
+        await interaction.response.send_message(
+            f"**{label}** fired from inside a Components-V2 container.",
+            ephemeral=True,
+        )
+
+    btn.callback = _cb  # type: ignore[method-assign]
+    return btn
+
+
+class LayoutWingView(ExhibitWingView):
+    """Wing 5 — Components V2 (browser pages + real CV2 renders)."""
+
+    WING_TITLE = "Components V2"
+    WING_EMOJI = "🧱"
+
+    def _exhibit_ids(self) -> tuple[str, ...]:
+        return (
+            "cv2_text_only",
+            "cv2_section_accessory",
+            "cv2_container_dashboard",
+            "cv2_media_gallery",
+            "cv2_file_display",
+            "cv2_settings_page",
+            "cv2_mobile_compact",
+            "cv2_interactive_mix",
+        )
+
+    # -- LayoutView builders (one per exhibit) --------------------------------
+
+    def _build_text_only(self, author_id: int) -> _LabLayout:
+        view = _LabLayout(author_id)
+        view.add_item(
+            discord.ui.TextDisplay(
+                "## Pure text display\n"
+                "This message has **no embed and no `content`** — everything "
+                "you read is a `TextDisplay` component.\n"
+                "- full markdown\n- no coloured sidebar\n- 4000-char budget",
+            ),
+        )
+        return view
+
+    def _build_sections(self, author_id: int) -> _LabLayout:
+        view = _LabLayout(author_id)
+        view.add_item(
+            discord.ui.Section(
+                "**AstroFox** · Lv 42",
+                "Top miner this week",
+                accessory=discord.ui.Thumbnail(_AVATARS[0]),
+            ),
+        )
+        view.add_item(discord.ui.Separator())
+        view.add_item(
+            discord.ui.Section(
+                "**BananaMage** · Lv 39",
+                "Closing in fast",
+                accessory=discord.ui.Thumbnail(_AVATARS[1]),
+            ),
+        )
+        view.add_item(discord.ui.Separator())
+        view.add_item(
+            discord.ui.Section(
+                "**Manage members**",
+                "A section can carry a button instead of an image →",
+                accessory=_ack_button("Open", style=discord.ButtonStyle.primary),
+            ),
+        )
+        return view
+
+    def _build_container(self, author_id: int) -> _LabLayout:
+        view = _LabLayout(author_id)
+        view.add_item(
+            discord.ui.Container(
+                discord.ui.TextDisplay("## 🩺 Server health"),
+                discord.ui.TextDisplay(
+                    "Gateway **online** · DB **12 ms** · 3 managed tasks",
+                ),
+                discord.ui.Separator(spacing=discord.SeparatorSpacing.large),
+                discord.ui.TextDisplay("-# accent-coloured container, no embed"),
+                discord.ui.ActionRow(
+                    _ack_button("Refresh", style=discord.ButtonStyle.secondary),
+                    _ack_button("Details", style=discord.ButtonStyle.primary),
+                ),
+                accent_colour=discord.Colour.green(),
+            ),
+        )
+        return view
+
+    def _build_gallery(self, author_id: int) -> _LabLayout:
+        view = _LabLayout(author_id)
+        view.add_item(discord.ui.TextDisplay("**Media gallery** — 4 items:"))
+        view.add_item(
+            discord.ui.MediaGallery(
+                *(
+                    discord.MediaGalleryItem(
+                        url,
+                        description=f"placeholder avatar {n}",
+                    )
+                    for n, url in enumerate(_AVATARS[:4])
+                ),
+            ),
+        )
+        return view
+
+    def _build_file(self, author_id: int) -> tuple[_LabLayout, list[discord.File]]:
+        view = _LabLayout(author_id)
+        view.add_item(
+            discord.ui.TextDisplay("**Inline file** — rendered in the body:"),
+        )
+        view.add_item(discord.ui.File("attachment://uxlab-demo.txt"))
+        payload = (
+            "UX Lab file-component demo\n"
+            "==========================\n"
+            "A CV2 message must reference every attachment via a component\n"
+            "(File / Thumbnail / MediaGallery) — unreferenced uploads are\n"
+            "rejected. This file proves the File component path works.\n"
+        )
+        import io  # noqa: PLC0415 — tiny, send-path only
+
+        file = discord.File(
+            io.BytesIO(payload.encode()),
+            filename="uxlab-demo.txt",
+            description="UX Lab file-component demo text file",
+        )
+        return view, [file]
+
+    def _build_settings_page(self, author_id: int) -> _LabLayout:
+        view = _LabLayout(author_id)
+        rows = (
+            ("Welcome messages", "ON", discord.ButtonStyle.success),
+            ("Server logging", "off", discord.ButtonStyle.secondary),
+            ("Automod", "ON", discord.ButtonStyle.success),
+        )
+        children: list[discord.ui.Item] = [  # type: ignore[type-arg]
+            discord.ui.TextDisplay("## ⚙️ Module settings (CV2 recreation)"),
+        ]
+        for name, state, style in rows:
+            children.append(discord.ui.Separator())
+            children.append(
+                discord.ui.Section(
+                    f"**{name}**",
+                    f"Currently **{state}** — fake toggle",
+                    accessory=_ack_button(state, style=style),
+                ),
+            )
+        view.add_item(
+            discord.ui.Container(
+                *children,
+                accent_colour=discord.Colour.blurple(),
+            ),
+        )
+        return view
+
+    def _build_mobile_compact(self, author_id: int) -> _LabLayout:
+        view = _LabLayout(author_id)
+        view.add_item(
+            discord.ui.Container(
+                discord.ui.TextDisplay("## Dense"),
+                discord.ui.TextDisplay(
+                    "Three stats on one line: **42** level · **13,370** coins "
+                    "· **17🔥** streak — reads fine on desktop, cramped on "
+                    "a phone.",
+                ),
+                accent_colour=discord.Colour.orange(),
+            ),
+        )
+        view.add_item(discord.ui.Separator(spacing=discord.SeparatorSpacing.large))
+        view.add_item(
+            discord.ui.Container(
+                discord.ui.TextDisplay("## Compact"),
+                discord.ui.TextDisplay("Level **42**"),
+                discord.ui.TextDisplay("Coins **13,370**"),
+                discord.ui.TextDisplay("Streak **17** 🔥"),
+                accent_colour=discord.Colour.green(),
+            ),
+        )
+        view.add_item(
+            discord.ui.TextDisplay(
+                "-# Open this on your phone — pick the one that survives.",
+            ),
+        )
+        return view
+
+    def _build_interactive(self, author_id: int) -> _LabLayout:
+        view = _LabLayout(author_id)
+        sel: discord.ui.Select = discord.ui.Select(  # type: ignore[type-arg]
+            placeholder="A select inside CV2…",
+            options=[discord.SelectOption(label=f"Choice {n}") for n in range(1, 4)],
+        )
+
+        async def _pick(interaction: discord.Interaction) -> None:
+            await interaction.response.send_message(
+                f"Select fired inside CV2: **{sel.values[0]}**",
+                ephemeral=True,
+            )
+
+        sel.callback = _pick  # type: ignore[method-assign]
+        view.add_item(
+            discord.ui.Container(
+                discord.ui.TextDisplay("**Interaction parity check**"),
+                discord.ui.ActionRow(
+                    _ack_button("Button A", style=discord.ButtonStyle.primary),
+                    _ack_button("Button B", style=discord.ButtonStyle.secondary),
+                ),
+                discord.ui.ActionRow(sel),
+                accent_colour=discord.Colour.purple(),
+            ),
+        )
+        return view
+
+    # -- browser pages ---------------------------------------------------------
+
+    def _render_exhibit(self, pattern_id: str) -> ExhibitRender:
+        explainers = {
+            "cv2_text_only": "A message that is *only* TextDisplay components.",
+            "cv2_section_accessory": "Rows of text with a thumbnail or button "
+            "hanging off each section.",
+            "cv2_container_dashboard": "An accent-coloured container card with "
+            "text, separator, and an action row — no embed anywhere.",
+            "cv2_media_gallery": "Four placeholder images in the native grid.",
+            "cv2_file_display": "A generated text file rendered inline via the "
+            "File component.",
+            "cv2_settings_page": "Today's SettingsHub re-imagined as CV2 "
+            "sections with toggle accessories — the direct comparison target.",
+            "cv2_mobile_compact": "The same stats twice — dense vs compact — "
+            "for a desktop-vs-phone judgement call.",
+            "cv2_interactive_mix": "Buttons and a select living inside a "
+            "container; every callback answers ephemerally.",
+        }
+        header = discord.Embed(
+            title=f"🧱 {pattern_id}",
+            description=(
+                f"{explainers[pattern_id]}\n\n"
+                "**📤 Render** posts the real Components-V2 message below "
+                f"(self-deletes after {_RENDER_TTL}s). A send failure is "
+                "reported verbatim — that's probe data, not a bug to hide."
+            ),
+            color=discord.Color.dark_teal(),
+        )
+        btn = self.demo_button(
+            "📤 Render this layout",
+            style=discord.ButtonStyle.primary,
+            row=0,
+        )
+
+        async def _render(interaction: discord.Interaction) -> None:
+            channel = interaction.channel
+            if channel is None or not isinstance(channel, discord.abc.Messageable):
+                await self.ack(interaction, "No sendable channel here.")
+                return
+            files: list[discord.File] = []
+            try:
+                if pattern_id == "cv2_file_display":
+                    layout, files = self._build_file(interaction.user.id)
+                else:
+                    builder = {
+                        "cv2_text_only": self._build_text_only,
+                        "cv2_section_accessory": self._build_sections,
+                        "cv2_container_dashboard": self._build_container,
+                        "cv2_media_gallery": self._build_gallery,
+                        "cv2_settings_page": self._build_settings_page,
+                        "cv2_mobile_compact": self._build_mobile_compact,
+                        "cv2_interactive_mix": self._build_interactive,
+                    }[pattern_id]
+                    layout = builder(interaction.user.id)
+                await channel.send(
+                    view=layout,
+                    files=files,
+                    delete_after=_RENDER_TTL,
+                )
+            except Exception as exc:  # noqa: BLE001 — the failure IS the data
+                await self.ack(
+                    interaction,
+                    f"❌ Render failed — `{type(exc).__name__}: "
+                    f"{str(exc)[:300]}`\n(discord.py {discord.__version__})",
+                )
+                return
+            await self.ack(
+                interaction,
+                f"✅ Rendered below — self-deletes in {_RENDER_TTL}s.",
+            )
+
+        btn.callback = _render  # type: ignore[method-assign]
+        return ([header], [btn])

--- a/disbot/views/ux_lab/probes.py
+++ b/disbot/views/ux_lab/probes.py
@@ -64,6 +64,37 @@ _probe_spec(
     "expect PASS on discord.py ≥2.6 — submit the modal to complete the probe",
     notes="Manual probe: it must open AND accept a submission.",
 )
+_probe_spec(
+    "probe_cv2_40_children",
+    "P-03 · LayoutView with exactly 40 children",
+    "expect PASS — 40 is the CV2 ceiling (verified in library source)",
+)
+_probe_spec(
+    "probe_cv2_41_children",
+    "P-04 · LayoutView with 41 children",
+    "expect FAIL at library construction — ValueError('… exceeded (40)')",
+)
+_probe_spec(
+    "probe_cv2_text_budget",
+    "P-05 · CV2 display-text budget (4000 chars)",
+    "expect PASS at 4000 combined; the probe reports which layer rejects 4001",
+)
+_probe_spec(
+    "probe_cv2_content_exclusive",
+    "P-09 · CV2 + content= mutual exclusion",
+    "expect FAIL — a CV2 message replaces content/embeds entirely",
+)
+_probe_spec(
+    "probe_modal_entity_select",
+    "P-08 · entity select (UserSelect) inside a modal",
+    "UNKNOWN — exactly what this probe exists to pin down",
+    notes="Manual probe: open it; rejection at construction/open is the answer.",
+)
+_probe_spec(
+    "probe_attachment_alt_text",
+    "P-10 · attachment alt-text round-trip",
+    "expect PASS — description field ≤1024 chars survives upload",
+)
 
 
 def _stamp() -> str:
@@ -188,6 +219,156 @@ class ProbesBenchView(HubView):
             f"sent — 10 embeds, {total} combined chars (≤6000 budget)",
         )
 
+    async def _probe_cv2_40(self, channel: discord.abc.Messageable) -> ProbeResult:
+        pid, title = "probe_cv2_40_children", "P-03 LayoutView · 40 children"
+        try:
+            view = discord.ui.LayoutView(timeout=_PROBE_MSG_TTL)
+            for n in range(40):
+                view.add_item(discord.ui.TextDisplay(f"-# item {n + 1}/40"))
+            await channel.send(view=view, delete_after=_PROBE_MSG_TTL)
+        except Exception as exc:  # noqa: BLE001
+            return ProbeResult(
+                pid,
+                title,
+                False,
+                f"{type(exc).__name__}: {str(exc)[:180]}",
+            )
+        return ProbeResult(pid, title, True, "sent — 40 children accepted")
+
+    async def _probe_cv2_41(self, channel: discord.abc.Messageable) -> ProbeResult:
+        pid, title = "probe_cv2_41_children", "P-04 LayoutView · 41 children"
+        try:
+            view = discord.ui.LayoutView(timeout=_PROBE_MSG_TTL)
+            for n in range(41):
+                view.add_item(discord.ui.TextDisplay(f"-# item {n + 1}/41"))
+        except ValueError as exc:
+            return ProbeResult(
+                pid,
+                title,
+                True,
+                f"rejected at library construction — ValueError: {str(exc)[:140]}",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ProbeResult(
+                pid,
+                title,
+                False,
+                f"{type(exc).__name__}: {str(exc)[:180]}",
+            )
+        try:
+            await channel.send(view=view, delete_after=_PROBE_MSG_TTL)
+        except Exception as exc:  # noqa: BLE001
+            return ProbeResult(
+                pid,
+                title,
+                True,
+                f"rejected at the API — {type(exc).__name__}: {str(exc)[:140]}",
+            )
+        return ProbeResult(
+            pid,
+            title,
+            False,
+            "UNEXPECTED: 41 children accepted — update the doc!",
+        )
+
+    async def _probe_cv2_text_budget(
+        self,
+        channel: discord.abc.Messageable,
+    ) -> ProbeResult:
+        pid, title = "probe_cv2_text_budget", "P-05 CV2 text budget (4000)"
+        try:
+            at_limit = discord.ui.LayoutView(timeout=_PROBE_MSG_TTL)
+            at_limit.add_item(discord.ui.TextDisplay("x" * 4000))
+            await channel.send(view=at_limit, delete_after=_PROBE_MSG_TTL)
+        except Exception as exc:  # noqa: BLE001
+            return ProbeResult(
+                pid,
+                title,
+                False,
+                f"4000 chars rejected — {type(exc).__name__}: {str(exc)[:140]}",
+            )
+        try:
+            over = discord.ui.LayoutView(timeout=_PROBE_MSG_TTL)
+            over.add_item(discord.ui.TextDisplay("x" * 4001))
+            await channel.send(view=over, delete_after=_PROBE_MSG_TTL)
+        except Exception as exc:  # noqa: BLE001
+            return ProbeResult(
+                pid,
+                title,
+                True,
+                "4000 sent OK; 4001 rejected — "
+                f"{type(exc).__name__}: {str(exc)[:120]}",
+            )
+        return ProbeResult(
+            pid,
+            title,
+            False,
+            "UNEXPECTED: 4001 chars accepted — update the doc!",
+        )
+
+    async def _probe_cv2_content_exclusive(
+        self,
+        channel: discord.abc.Messageable,
+    ) -> ProbeResult:
+        pid, title = "probe_cv2_content_exclusive", "P-09 CV2 + content="
+        try:
+            view = discord.ui.LayoutView(timeout=_PROBE_MSG_TTL)
+            view.add_item(discord.ui.TextDisplay("CV2 exclusivity probe"))
+            await channel.send(
+                "plain content alongside CV2",
+                view=view,
+                delete_after=_PROBE_MSG_TTL,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ProbeResult(
+                pid,
+                title,
+                True,
+                f"rejected as expected — {type(exc).__name__}: {str(exc)[:140]}",
+            )
+        return ProbeResult(
+            pid,
+            title,
+            False,
+            "UNEXPECTED: content + CV2 accepted together — update the doc!",
+        )
+
+    async def _probe_alt_text(
+        self,
+        channel: discord.abc.Messageable,
+    ) -> ProbeResult:
+        import io  # noqa: PLC0415 — tiny, probe-only
+
+        pid, title = "probe_attachment_alt_text", "P-10 alt-text round-trip"
+        alt = "UX Lab alt-text probe file"
+        try:
+            file = discord.File(
+                io.BytesIO(b"alt-text probe\n"),
+                filename="uxlab-alt-probe.txt",
+                description=alt,
+            )
+            msg = await channel.send(
+                "🧪 P-10: alt-text round-trip — self-deletes.",
+                file=file,
+                delete_after=_PROBE_MSG_TTL,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return ProbeResult(
+                pid,
+                title,
+                False,
+                f"{type(exc).__name__}: {str(exc)[:180]}",
+            )
+        got = msg.attachments[0].description if msg.attachments else None
+        if got == alt:
+            return ProbeResult(pid, title, True, "description survived upload verbatim")
+        return ProbeResult(
+            pid,
+            title,
+            False,
+            f"description came back as {got!r} (sent {alt!r})",
+        )
+
     # -- rendering ------------------------------------------------------------
 
     def build(self) -> tuple[list[discord.Embed], ProbesBenchView]:
@@ -215,18 +396,25 @@ class ProbesBenchView(HubView):
             )
         return [embed], self
 
+    def _automated_probes(self):  # noqa: ANN202 — (label, runner, row) triples
+        return (
+            ("P-01 grid", self._probe_legacy_grid, 0),
+            ("P-02 26-option", self._probe_select_26, 0),
+            ("P-06 embed budget", self._probe_embed_budget, 0),
+            ("P-03 CV2 ×40", self._probe_cv2_40, 1),
+            ("P-04 CV2 ×41", self._probe_cv2_41, 1),
+            ("P-05 CV2 4000ch", self._probe_cv2_text_budget, 1),
+            ("P-09 CV2+content", self._probe_cv2_content_exclusive, 2),
+            ("P-10 alt-text", self._probe_alt_text, 2),
+        )
+
     def _build_items(self) -> None:
         self.clear_items()
-        probes = (
-            ("P-01 grid", self._probe_legacy_grid),
-            ("P-02 26-option", self._probe_select_26),
-            ("P-06 embed budget", self._probe_embed_budget),
-        )
-        for label, runner in probes:
+        for label, runner, row in self._automated_probes():
             btn: discord.ui.Button[discord.ui.View] = discord.ui.Button(
                 label=label,
                 style=discord.ButtonStyle.primary,
-                row=0,
+                row=row,
             )
 
             async def _run(
@@ -251,8 +439,8 @@ class ProbesBenchView(HubView):
 
         modal_btn: discord.ui.Button[discord.ui.View] = discord.ui.Button(
             label="P-07 modal+select (manual)",
-            style=discord.ButtonStyle.primary,
-            row=1,
+            style=discord.ButtonStyle.secondary,
+            row=2,
         )
 
         async def _modal_probe(interaction: discord.Interaction) -> None:
@@ -261,11 +449,48 @@ class ProbesBenchView(HubView):
         modal_btn.callback = _modal_probe  # type: ignore[method-assign]
         self.add_item(modal_btn)
 
+        entity_btn: discord.ui.Button[discord.ui.View] = discord.ui.Button(
+            label="P-08 modal+UserSelect (manual)",
+            style=discord.ButtonStyle.secondary,
+            row=2,
+        )
+
+        async def _entity_modal_probe(interaction: discord.Interaction) -> None:
+            # Construction or open may be rejected at any layer — wherever it
+            # fails IS the probe's answer, so report instead of raising.
+            try:
+                modal = discord.ui.Modal(title="P-08: entity select", timeout=120)
+                modal.add_item(
+                    discord.ui.Label(
+                        text="Pick a member",
+                        component=discord.ui.UserSelect(),
+                    ),
+                )
+
+                async def _submitted(submit_interaction: discord.Interaction) -> None:
+                    await submit_interaction.response.send_message(
+                        "✅ P-08: Discord accepted a UserSelect inside a modal "
+                        "(submission received) — update the limits doc.",
+                        ephemeral=True,
+                    )
+
+                modal.on_submit = _submitted  # type: ignore[method-assign]
+                await interaction.response.send_modal(modal)
+            except Exception as exc:  # noqa: BLE001 — the failure IS the result
+                await interaction.response.send_message(
+                    f"❌ P-08 rejected — `{type(exc).__name__}: "
+                    f"{str(exc)[:200]}` (that rejection is the probe's answer)",
+                    ephemeral=True,
+                )
+
+        entity_btn.callback = _entity_modal_probe  # type: ignore[method-assign]
+        self.add_item(entity_btn)
+
         run_all: discord.ui.Button[discord.ui.View] = discord.ui.Button(
             label="Run all automated",
             emoji="🔬",
             style=discord.ButtonStyle.success,
-            row=1,
+            row=3,
         )
 
         async def _run_all(interaction: discord.Interaction) -> None:
@@ -274,11 +499,7 @@ class ProbesBenchView(HubView):
             channel = interaction.channel
             if channel is None or not isinstance(channel, discord.abc.Messageable):
                 return
-            for probe in (
-                self._probe_legacy_grid,
-                self._probe_select_26,
-                self._probe_embed_budget,
-            ):
+            for _label, probe, _row in self._automated_probes():
                 result = await probe(channel)
                 self._results[result.probe_id] = result
             embeds, _ = self.build()

--- a/tests/unit/utils/test_ux_patterns_registry.py
+++ b/tests/unit/utils/test_ux_patterns_registry.py
@@ -26,7 +26,9 @@ def test_registry_is_populated_per_wing():
     assert counts[PatternCategory.SELECTS] == 8
     assert counts[PatternCategory.MODALS] == 6
     assert counts[PatternCategory.EMBEDS] == 14
-    assert counts[PatternCategory.PROBE] == 4
+    assert counts[PatternCategory.LAYOUT_V2] == 8
+    assert counts[PatternCategory.IMAGE] == 6
+    assert counts[PatternCategory.PROBE] == 10
 
 
 def test_registry_completeness():

--- a/tests/unit/views/test_ux_lab_layout_image_wings.py
+++ b/tests/unit/views/test_ux_lab_layout_image_wings.py
@@ -1,0 +1,130 @@
+"""UX Lab PR-B wings — CV2 layout builders and PIL image exhibits.
+
+Construction-level verification: every LayoutView the CV2 wing can send must
+build inside the library-enforced 40-child / 4000-char budgets (discord.py
+raises at construction, so instantiation IS the test), and every image
+exhibit must render bytes under the 8 MiB bot cap with alt text attached.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import discord
+import pytest
+
+from utils.ux_patterns.image_builders import (
+    render_event_poster,
+    render_leaderboard_image,
+    render_welcome_card,
+)
+from views.ux_lab.image_cards import _RENDERERS, ImageWingView
+from views.ux_lab.layout_v2 import LayoutWingView, _LabLayout
+
+_BOT_ATTACH_CAP = 8 * 1024 * 1024
+
+
+def _author() -> MagicMock:
+    author = MagicMock(spec=discord.Member)
+    author.id = 1234
+    return author
+
+
+async def _noop_builder(
+    interaction: discord.Interaction,
+) -> tuple[discord.Embed, discord.ui.View]:
+    return discord.Embed(), discord.ui.View()
+
+
+def test_every_cv2_layout_builds_within_library_budgets():
+    """discord.py raises ValueError at >40 children / >4000 chars — so a
+    clean construction proves every exhibit fits the CV2 budget."""
+    wing = LayoutWingView(_author(), home_builder=_noop_builder)
+    builders = {
+        "cv2_text_only": wing._build_text_only,
+        "cv2_section_accessory": wing._build_sections,
+        "cv2_container_dashboard": wing._build_container,
+        "cv2_media_gallery": wing._build_gallery,
+        "cv2_settings_page": wing._build_settings_page,
+        "cv2_mobile_compact": wing._build_mobile_compact,
+        "cv2_interactive_mix": wing._build_interactive,
+    }
+    for pattern_id, builder in builders.items():
+        layout = builder(1234)
+        assert isinstance(layout, _LabLayout), pattern_id
+    layout, files = wing._build_file(1234)
+    assert isinstance(layout, _LabLayout)
+    assert files and files[0].description, "file exhibit must carry alt text"
+
+
+def test_cv2_wing_browser_pages_within_caps():
+    wing = LayoutWingView(_author(), home_builder=_noop_builder)
+    for index, pattern_id in enumerate(wing._exhibit_ids()):
+        wing._index = index
+        embeds, view = wing.build()
+        assert len(view.children) <= 25, pattern_id
+        assert sum(len(e) for e in embeds) <= 6000, pattern_id
+
+
+def test_layoutview_enforces_the_40_child_ceiling():
+    """The fact the limits doc + probes P-03/P-04 rest on."""
+    view = discord.ui.LayoutView()
+    for n in range(40):
+        view.add_item(discord.ui.TextDisplay(f"item {n}"))
+    with pytest.raises(ValueError, match="maximum number of children"):
+        view.add_item(discord.ui.TextDisplay("the 41st"))
+
+
+@pytest.mark.asyncio
+async def test_lab_layout_is_author_locked():
+    layout = _LabLayout(author_id=1)
+    stranger = MagicMock(spec=discord.Interaction)
+    stranger.user = MagicMock()
+    stranger.user.id = 2
+    stranger.response = MagicMock()
+    stranger.response.send_message = MagicMock()
+
+    from unittest.mock import AsyncMock
+
+    stranger.response.send_message = AsyncMock()
+    assert await layout.interaction_check(stranger) is False
+    stranger.response.send_message.assert_awaited_once()
+
+
+def test_image_wing_pages_within_caps():
+    wing = ImageWingView(_author(), home_builder=_noop_builder)
+    for index, pattern_id in enumerate(wing._exhibit_ids()):
+        wing._index = index
+        embeds, view = wing.build()
+        assert len(view.children) <= 25, pattern_id
+        assert sum(len(e) for e in embeds) <= 6000, pattern_id
+
+
+def test_every_image_exhibit_has_alt_text_and_filename():
+    for pattern_id, (_renderer, filename, alt) in _RENDERERS.items():
+        assert filename, pattern_id
+        assert alt and len(alt) <= 1024, pattern_id
+
+
+@pytest.mark.parametrize(
+    "renderer",
+    [render_welcome_card, render_leaderboard_image, render_event_poster],
+)
+def test_new_image_builders_render_under_the_bot_cap(renderer):
+    pytest.importorskip("PIL")
+    png = renderer()
+    assert png is not None
+    assert 0 < len(png) < _BOT_ATTACH_CAP
+
+
+def test_shipped_renderers_still_render_from_sample_data():
+    """The reuse contract: the lab exhibits the LIVE renderers."""
+    pytest.importorskip("PIL")
+    for pattern_id in (
+        "pil_inventory_card",
+        "pil_stat_card",
+        "pil_character_paperdoll",
+    ):
+        renderer, _f, _a = _RENDERERS[pattern_id]
+        data = renderer()
+        assert data is not None and len(data) < _BOT_ATTACH_CAP, pattern_id


### PR DESCRIPTION
## What this is

**PR B of the UX Lab plan** ([design §8](docs/planning/ux-lab-interface-gallery-plan-2026-06-12.md)): the experimental lane — Components V2 layouts and PIL image cards — plus six new limit probes. Builds on #758 (merged).

## Components V2 wing (8 exhibits, all `EXPERIMENTAL`)

A CV2 message replaces `content`/`embeds`, so it can't render inside the classic browser — each browser page explains the layout and a **📤 Render** button posts the *real* `LayoutView` message into the channel (self-deletes in 120 s; a send failure is reported verbatim, because that's probe data). Exhibits: pure text-display message · sections with thumbnail/button accessories · accent-colour container dashboard · media gallery grid · inline `File` component · **a CV2 recreation of today's SettingsHub** (the direct comparison the ADR decision needs) · dense-vs-compact phone check · interactive parity mix (buttons + select inside containers).

`_LabLayout` extends `discord.ui.LayoutView` directly with the documented intentional-divergence comment (LayoutView is a sibling of `View`, not a subclass — it cannot extend `BaseView`) and mirrors the author-lock. The architecture checker confirms no new warnings; CV2 adoption for real panels remains a future ADR, per the plan's pinned non-decision.

## PIL wing (6 exhibits)

Reuse first: the **shipped** mining inventory + stat-card renderers (#665) and the gear paper-doll compositor (#702) are exhibited from sample data — not re-implemented. Three new candidates in `utils/ux_patterns/image_builders.py`: the **welcome card** (the exact Q-0110 phase-2 preview, using a no-network initials disc = the avatar-fallback path a real implementation needs anyway), a leaderboard image, and an event poster (Q-0112 candidate). Every render runs in `asyncio.to_thread`, reports **ms + KB against the 8 MiB bot cap**, and attaches alt text — the platform-limits doc §4 rules, demonstrated live.

## Probe bench: 4 → 10 probes

P-03 (40-child LayoutView, expect pass) · P-04 (41 children — expect the library `ValueError`) · P-05 (4000-char display budget edge, reports which layer rejects 4001) · P-09 (CV2 + `content=` mutual exclusion) · P-08 (**UserSelect inside a modal** — manual; the genuine unknown this probe exists to answer) · P-10 (alt-text round-trip — reads the description back off the sent message). Run-all now covers all 8 automated probes.

## Tests + verification

10 new tests (33 lab tests total): every CV2 builder constructs inside the library-enforced 40/4000 budgets (discord.py raises at construction, so instantiation is the proof), the 41-child ceiling raises, `_LabLayout` author-lock, new image builders render under the bot cap, and the shipped-renderer reuse contract. Zero-write fence auto-covers the new files (path glob).

- `check_quality.py --full` green — **9,180 passed**.
- `check_architecture.py --mode strict` — 0 errors, no new warnings.
- Live boot: cog loads with both new wings, 0 ERROR/CRITICAL.

**One deliberate deferral from the plan's PR-B list:** the PersistentView exhibit — it needs boot-time registration machinery for honest restart-survival; assessed into PR C rather than faked here.

https://claude.ai/code/session_01Bj1NppGr719EGfqS6zXrgx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bj1NppGr719EGfqS6zXrgx)_