### PR TITLE
ci(executor-nightly): move cron off :00 to dodge scheduler congestion

### DIFF
--- a/.github/workflows/executor-nightly.yml
+++ b/.github/workflows/executor-nightly.yml
@@ -7,8 +7,10 @@ name: executor-nightly
 # ~700K-context degradation). The executor reads the issue body, advances the next plan step,
 # and closes the issue.
 #
-# Times are UTC. 01:00 + 03:00 UTC == 03:00 + 05:00 CEST (the maintainer's summer local time).
-# Adjust the cron if your local offset changes (CET winter would be 02:00 + 04:00 UTC).
+# Times are UTC. 01:17 + 03:17 UTC == 03:17 + 05:17 CEST (the maintainer's summer local time).
+# The :17 minute is deliberate — GitHub's cron scheduler is heavily congested at the top of the
+# hour (`:00`), so `schedule` runs there get delayed or dropped; an off-hour minute fires reliably.
+# Adjust the cron if your local offset changes (CET winter would be 02:17 + 04:17 UTC).
 #
 # Provenance + reliability (Q-0105): added 2026-06-12. UNVERIFIED — confirm it opens one issue
 # per scheduled slot and the executor picks it up. Delete this workflow if it misfires; it is a
@@ -16,7 +18,7 @@ name: executor-nightly
 
 on:
   schedule:
-    - cron: "0 1,3 * * *"
+    - cron: "17 1,3 * * *"
   workflow_dispatch: {} # lets you also kick a run by hand from the Actions tab
 
 permissions:


### PR DESCRIPTION
## Why

While investigating why the nightly executor didn't fire at 3am CEST (= 01:00 UTC), I confirmed the workflow is structurally healthy — it's on `main`, `state: active`, valid cron, repo guard satisfied. The 01:00 no-show was the **first-occurrence effect** (a freshly-registered cron, merged 22:39 UTC, routinely skips its very first tick) compounded by scheduling at the **most congested minute of the hour**.

GitHub's own docs warn that the `schedule` event is best-effort and *"can be delayed during periods of high loads... High load times include the start of every hour"* — `:00` is where most of the platform's cron jobs pile up, so runs there get delayed or dropped.

## What

Shift the two nightly ticks from `0 1,3 * * *` → `17 1,3 * * *` (01:17 / 03:17 UTC = 03:17 / 05:17 CEST). An off-hour minute sits in the scheduler's quiet trough and fires reliably.

- No change to frequency or job behaviour — same two runs a night.
- Header comments updated to the new times, with a note explaining *why* `:17` is deliberate.

This is a reliability improvement for every *future* night; it does not retroactively fix tonight's first-occurrence miss (the 03:17 UTC slot tonight is the likely first real fire).

https://claude.ai/code/session_01HEpnGZKAFLuk9F87DRGhqA

---
_Generated by [Claude Code](https://claude.ai/code/session_01HEpnGZKAFLuk9F87DRGhqA)_