### PR TITLE
fix(permissions): let autonomous executor push to main without prompting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,8 +60,6 @@
     "ask": [
       "Bash(git push --force*)",
       "Bash(git push -f*)",
-      "Bash(git push origin main*)",
-      "Bash(git push -u origin main*)",
       "Bash(git reset --hard*)",
       "Bash(git clean*)"
     ]

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -4460,3 +4460,28 @@ fixes/docs keep self-merging on green (Q-0113); only big steps carry the label.
 **Home:** `docs/operations/autonomous-routines.md` (the executor + the three labels) ·
 `docs/operations/hermes-skills/review-merge.md` (the skill) · `hermes-operating-prompt.md`
 (the read-only carve-out) · this entry is provenance.
+
+### Q-0118 — Autonomous executor stalled on a `git push -u origin main` permission prompt
+
+> **DIRECTED 2026-06-13 (owner, in-session).** A nightly-executor routine run (no human present)
+> stopped at an interactive "Allow Claude to run `git push -u origin main`?" prompt while pushing a
+> ledger update. Owner: "this should not ask for permissions, especially not on an autonomous run …
+> it should just work exactly like in a normal session."
+
+**Area:** Executable config (`.claude/settings.json` permissions) · autonomy boundary
+**Type:** Owner decision (in-session directed edit to executable config — provenance per Q-0106)
+
+**Root cause:** `permissions.ask` listed `Bash(git push origin main*)` and `Bash(git push -u origin
+main*)`. In Claude Code, `ask` outranks `allow`, so those direct-to-main pushes overrode the broad
+`Bash(git push*)` allow and forced a prompt. In an autonomous routine (no human to click *Allow*),
+that hangs the run. The `ask` guard was meant to catch *accidental* direct-to-main pushes in
+interactive sessions, but the executor's normal session-close flow **is** a direct ledger push to
+`main`, so the guard was pure friction there.
+
+**Decision:** removed the two plain direct-to-main entries from `ask`; they now fall through to the
+existing `Bash(git push*)` allow → no prompt. **Kept gated** the genuinely destructive ops a *normal*
+session also gates: `git push --force*`, `git push -f*`, `git reset --hard*`, `git clean*`. Net: a
+plain push to main "just works exactly like a normal session," force-pushes/history-rewrites still
+prompt.
+
+**Home:** `.claude/settings.json` (`permissions.ask`) is the change; this entry is provenance.


### PR DESCRIPTION
## Problem

A nightly-executor routine run (autonomous, no human present) **stalled on an interactive permission prompt** — `Allow Claude to run git push -u origin main?` — while pushing a ledger update during session-close. On an autonomous run there's nobody to click *Allow*, so the run just hangs.

## Root cause

`.claude/settings.json` `permissions.ask` listed:

```json
"Bash(git push origin main*)",
"Bash(git push -u origin main*)",
```

In Claude Code, **`ask` outranks `allow`**, so these direct-to-main patterns overrode the broad `Bash(git push*)` allow rule and forced a prompt. That guard was meant to catch *accidental* direct-to-main pushes in interactive sessions — but the executor's normal session-close flow **is** a direct ledger push to `main`, so for it the guard was pure friction.

## Fix

Remove the two plain direct-to-main entries from `ask`; they now fall through to the existing `Bash(git push*)` allow → no prompt. **Kept gated** the genuinely destructive ops a *normal* interactive session also gates:

```json
"ask": [
  "Bash(git push --force*)",
  "Bash(git push -f*)",
  "Bash(git reset --hard*)",
  "Bash(git clean*)"
]
```

Net: a plain push to main "just works exactly like a normal session" (owner's words), while force-pushes / history-rewrites still prompt.

Owner-directed in-session change to executable config; provenance recorded as router **Q-0118** (per Q-0106).

https://claude.ai/code/session_01HEpnGZKAFLuk9F87DRGhqA

---
_Generated by [Claude Code](https://claude.ai/code/session_01HEpnGZKAFLuk9F87DRGhqA)_