### PR TITLE
Fix: routine triggers never fired — author trigger issues with ROUTINE_PAT, not GITHUB_TOKEN

### DIFF
--- a/.github/workflows/executor-nightly.yml
+++ b/.github/workflows/executor-nightly.yml
@@ -36,8 +36,22 @@ jobs:
     steps:
       - name: Open a scheduled `continue` issue (deduped)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Author the issue with a NON-default token. An issue created by the default
+          # secrets.GITHUB_TOKEN is authored by github-actions[bot], and a bot-authored issue
+          # does NOT start the Claude "night executor" routine. Verified 2026-06-13: a real-
+          # user-authored `continue` issue (#776) fired the routine in <1 min, while the
+          # github-actions[bot]-authored #768 sat open for hours and never fired. ROUTINE_PAT is
+          # a fine-grained PAT (this repo, Issues: read/write). The GITHUB_TOKEN fallback only
+          # prevents a hard failure when ROUTINE_PAT is unset — while unset, the routine will
+          # NOT fire, so set the secret.
+          GH_TOKEN: ${{ secrets.ROUTINE_PAT || secrets.GITHUB_TOKEN }}
+          ROUTINE_PAT_SET: ${{ secrets.ROUTINE_PAT != '' }}
         run: |
+          # Loud, non-fatal warning if the PAT is missing — otherwise the issue is bot-authored
+          # and the routine silently never fires (the exact failure this token change fixes).
+          if [ "$ROUTINE_PAT_SET" != "true" ]; then
+            echo "::warning::ROUTINE_PAT is not set — the issue will be authored by github-actions[bot], which does NOT start the Claude routine. Add ROUTINE_PAT (fine-grained PAT, this repo, Issues: read/write) to enable autonomous firing."
+          fi
           # Dedupe: if a scheduled executor-run issue is still open (executor hasn't picked up
           # the last one — it closes them when done), don't pile another on top.
           open_scheduled="$(gh issue list --repo "$GITHUB_REPOSITORY" --label continue --state open \

--- a/.github/workflows/reconciliation-trigger.yml
+++ b/.github/workflows/reconciliation-trigger.yml
@@ -45,8 +45,19 @@ jobs:
       - name: Open a reconcile issue (deduped)
         if: steps.due.outputs.due == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Author the issue with a NON-default token — see executor-nightly.yml for the full
+          # rationale. A github-actions[bot]-authored issue does NOT start the Claude docs-
+          # reconciliation routine (verified 2026-06-13 via issue #776 vs #768). ROUTINE_PAT is a
+          # fine-grained PAT (this repo, Issues: read/write); the GITHUB_TOKEN fallback only
+          # avoids a hard failure when the secret is unset (the routine will not fire while unset).
+          GH_TOKEN: ${{ secrets.ROUTINE_PAT || secrets.GITHUB_TOKEN }}
+          ROUTINE_PAT_SET: ${{ secrets.ROUTINE_PAT != '' }}
         run: |
+          # Loud, non-fatal warning if the PAT is missing — otherwise the issue is bot-authored
+          # and the routine silently never fires (the exact failure this token change fixes).
+          if [ "$ROUTINE_PAT_SET" != "true" ]; then
+            echo "::warning::ROUTINE_PAT is not set — the issue will be authored by github-actions[bot], which does NOT start the Claude routine. Add ROUTINE_PAT (fine-grained PAT, this repo, Issues: read/write) to enable autonomous firing."
+          fi
           # Dedupe: if an open `reconcile` issue already exists, do nothing (avoids a new
           # issue on every push between the boundary crossing and the routine running).
           open_count="$(gh issue list --label reconcile --state open --json number --jq 'length' 2>/dev/null || echo 0)"

--- a/docs/operations/autonomous-routines.md
+++ b/docs/operations/autonomous-routines.md
@@ -46,6 +46,19 @@ two ways —
 So the cadence runs in the GitHub Action (cheap, deterministic), and the routine just listens
 for the labeled issue.
 
+> **⚠️ The trigger Action must author the issue with a non-default token.** An issue created by
+> the default `secrets.GITHUB_TOKEN` is authored by `github-actions[bot]`, and a **bot-authored
+> issue does not start the routine**. Verified 2026-06-13: a real-user-authored `continue` issue
+> (#776) fired the executor in under a minute, while the `github-actions[bot]`-authored `continue`
+> issue (#768) sat open for hours and never fired — the trigger, GitHub App, model, and cap were
+> all healthy; the *author* was the whole problem. Both `reconciliation-trigger.yml` and
+> `executor-nightly.yml` therefore create the issue with **`secrets.ROUTINE_PAT`** (a fine-grained
+> PAT scoped to this repo with **Issues: read/write**), falling back to `GITHUB_TOKEN` only to
+> avoid a hard failure. **If the routines stop firing from the cron/cadence, check that
+> `ROUTINE_PAT` exists and is unexpired first** — a fine-grained PAT expires (≤1 year), and when
+> it lapses the issues silently revert to bot-authored. (A GitHub App installation token avoids
+> the expiry if this becomes a recurring chore.)
+
 **The docs/runtime split (honors Q-0107):** the reconciliation routine is **docs-only** — if
 it *spots* a runtime bug it appends it to `docs/health/bug-book.md` (OPEN), and the **caretaker**
 routine fixes it. Neither routine invents features (the phase gate holds those until


### PR DESCRIPTION
## Problem

The autonomous routines never started from the cron/cadence. The Action half worked (it created the labeled issue), but the routine half never fired — e.g. the nightly executor issue **#768** (`continue`) sat open for ~12h and was never picked up.

## Root cause (verified, not guessed)

`executor-nightly.yml` and `reconciliation-trigger.yml` create their trigger issue with the default `secrets.GITHUB_TOKEN`, so the issue is authored by **`github-actions[bot]`**. A **bot-authored issue does not start the Claude routine.**

Confirmed with a controlled A/B today:

| Issue | Author | Routine fired? |
|---|---|---|
| **#776** (hand-opened test) | `menno420` (real user) | ✅ **Yes — in <1 min** (commented + closed itself) |
| **#768** (nightly cron) | `github-actions[bot]` (`GITHUB_TOKEN`) | ❌ No — open ~12h, never fired |

Same repo, same `continue` label, same routine, same model/cap — the **only** difference was the issue author. The console side (routine, trigger, GitHub App install, model, cap) is healthy.

## Fix

Both workflows now author the issue with **`secrets.ROUTINE_PAT`** (a fine-grained PAT scoped to this repo with **Issues: read/write**), falling back to `GITHUB_TOKEN` only to avoid a hard failure. Added a loud, non-fatal `::warning::` when `ROUTINE_PAT` is unset, so the inert state is visible in the Actions log instead of failing silently. Documented the gotcha + a "check `ROUTINE_PAT` first" runbook line in `docs/operations/autonomous-routines.md`.

## ⚠️ Required maintainer action (the fix is inert until this is done)

Add a repo secret **`ROUTINE_PAT`**:
1. Account → Settings → Developer settings → Personal access tokens → **Fine-grained tokens** → Generate new token. Resource owner `menno420`, repository access **Only `menno420/superbot`**, Repository permissions → **Issues: Read and write**.
2. Repo → Settings → Secrets and variables → **Actions** → New repository secret named **`ROUTINE_PAT`**, paste the token.

Note: fine-grained PATs expire (≤1 year); when it lapses the issues silently revert to bot-authored. A GitHub App installation token avoids the expiry if this becomes a chore.

## Verification

- Both workflow YAMLs parse; `check_docs.py --strict` green.
- End-to-end: after `ROUTINE_PAT` is added, a `workflow_dispatch` run of `executor-nightly.yml` will create a real-user-authored `continue` issue → routine should fire (same as #776). That run is a **real** executor run (advances the plan / may self-merge), unlike the no-op #776 test.

https://claude.ai/code/session_01HjVDiF6UbzBHpJRHF1itQz

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjVDiF6UbzBHpJRHF1itQz)_