### PR TITLE
Add auto-merge-enabler workflow (native auto-merge for claude/* PRs)

### DIFF
--- a/.github/workflows/auto-merge-enabler.yml
+++ b/.github/workflows/auto-merge-enabler.yml
@@ -1,0 +1,66 @@
+name: auto-merge-enabler
+
+# Turn ON GitHub-native auto-merge for session PRs so they merge themselves the moment the
+# required `Code Quality` check passes — removing merge mechanics from the Claude session
+# entirely (the session just opens the PR; GitHub does the gated merge). This is the
+# "Native auto-merge + enabler" path (owner decision 2026-06-13), replacing Claude's manual
+# self-merge envelope.
+#
+# HARD REQUIREMENTS (one-time, maintainer-side — the workflow is inert until these exist):
+#   1. Repo Settings → General → Pull Requests → "Allow auto-merge" = ON.
+#   2. A branch rule on `main` that REQUIRES the "Code Quality" status check. Without a
+#      required check a PR is immediately mergeable and auto-merge has nothing to wait on
+#      (it cannot be enabled).
+#   3. ROUTINE_PAT must include Pull requests: Read/Write AND Contents: Read/Write (not just
+#      Issues). The PAT is used on purpose: the eventual merge is attributed to whoever
+#      enabled auto-merge, and a merge attributed to github-actions[bot] would NOT trigger
+#      `reconciliation-trigger.yml` (on: push to main) — silently killing the reconcile
+#      cadence. (Same GITHUB_TOKEN-author gotcha this repo hit with the routine issue triggers.)
+#
+# CARVE-OUTS (never auto-merge) — opt-out by label:
+#   * `needs-hermes-review` (Q-0117) — a substantial executor step; Hermes reviews + merges.
+#   * `do-not-automerge` — generic hold (agent-originated features Q-0114, or any PR a human
+#     wants to gate). Set this label AT PR-OPEN. v1 limitation: a label added AFTER open does
+#     not retroactively disable an already-enabled auto-merge.
+#
+# Provenance + reliability (Q-0105): added 2026-06-13. UNVERIFIED — watch the first few PRs to
+# confirm it enables auto-merge only on the right PRs and that merges attribute to the PAT
+# user (so the reconcile cadence keeps firing). Delete this workflow if it misfires; native
+# auto-merge can always be toggled by hand.
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: auto-merge-enabler-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  enable-auto-merge:
+    if: >-
+      github.repository == 'menno420/superbot' &&
+      github.event.pull_request.draft == false &&
+      startsWith(github.head_ref, 'claude/') &&
+      !contains(github.event.pull_request.labels.*.name, 'needs-hermes-review') &&
+      !contains(github.event.pull_request.labels.*.name, 'do-not-automerge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable native auto-merge (merge commit)
+        env:
+          # PAT (not GITHUB_TOKEN) so the eventual merge attributes to a real user and keeps
+          # reconciliation-trigger.yml (on: push to main) firing. Needs Pull requests + Contents
+          # write. The GITHUB_TOKEN fallback only avoids a hard failure (and would break the
+          # cadence-trigger attribution) — set ROUTINE_PAT with the wider scope.
+          GH_TOKEN: ${{ secrets.ROUTINE_PAT || secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          if gh pr merge --auto --merge "$PR" --repo "$GITHUB_REPOSITORY"; then
+            echo "Auto-merge enabled for PR #$PR — it will merge when 'Code Quality' is green."
+          else
+            echo "::warning::Could not enable auto-merge for PR #$PR. Confirm: (1) 'Allow auto-merge' is ON, (2) main requires the 'Code Quality' check, (3) ROUTINE_PAT has Pull requests + Contents write."
+          fi


### PR DESCRIPTION
## What

Adds `.github/workflows/auto-merge-enabler.yml` — turns on **GitHub-native auto-merge** for each `claude/*` PR so it merges itself the instant the required **Code Quality** check passes. This moves merge mechanics **off the Claude session** (owner decision 2026-06-13: "Native auto-merge + enabler"), and structurally removes the failure we hit on #778 (deferring a merge on stale CI status — auto-merge is server-side and can't "forget").

This is **PR 1 of 2**. PR 2 strips the now-redundant self-merge envelope from `.claude/CLAUDE.md` (+ trims the "self-merge on green" lines in the routine prompts) — but **only after** this is proven on a live PR.

## How it stays safe

- **Opt-out by label:** never auto-merges a PR labeled `needs-hermes-review` (Q-0117) or `do-not-automerge` (generic hold — incl. agent-originated features, Q-0114). Set the label **at PR-open**.
- **`claude/*` branches only**, non-draft only.
- It only **enables** auto-merge; GitHub still enforces the green gate. It never merges red or held code.

## ⚠️ Two conscious decisions for you (this PR is inert until both are done)

1. **Branch protection on `main`** (policy change): native auto-merge needs a required check to wait on. Add a rule on `main` requiring the **Code Quality** check. Effect: *every* merge to main (including yours) then needs CI green — generally good, but it's a real change.
2. **Widen `ROUTINE_PAT`** (security): the enabler uses your PAT (not `GITHUB_TOKEN`) so the auto-merge commit attributes to a real user — otherwise it's authored by `github-actions[bot]` and would **silently kill `reconciliation-trigger.yml`** (on: push to main), the same gotcha #778 fixed. So `ROUTINE_PAT` needs **Pull requests: Read/Write + Contents: Read/Write** added (currently Issues only). That makes it merge-capable — a deliberate privilege bump.

Plus the easy one: Settings → General → Pull Requests → **Allow auto-merge** = ON.

## Rollout / proof

1. You do the three setup items above.
2. I enable auto-merge on **this** PR by hand → GitHub merges it on green = proof the native feature + your setup work (this PR's own workflow can't act on itself — it isn't on `main` yet).
3. PR 2 (envelope strip) is then opened and **auto-merged hands-off** by this workflow = final proof of the full loop.

If you'd rather not widen the PAT or protect `main`, say so — we can switch to the repo-side direct-merge workflow instead (no branch protection, separate token).

https://claude.ai/code/session_01HjVDiF6UbzBHpJRHF1itQz

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjVDiF6UbzBHpJRHF1itQz)_