### PR TITLE
Workflow enforcement hook — Stop-hook end-of-session advisory (Q-0122)

### DIFF
--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -4585,3 +4585,29 @@ dispatches **open a PR and hold** (not self-merge to prod) until reviewed — ru
 from this docs/tooling session, but available the moment `/bugreport` sees real use.
 
 **Home:** on decision, record here; build per the idea doc's build order in a control-plane session.
+
+### Q-0122 — Stop-hook end-of-session advisory (PR-lifecycle + grooming reminders)
+
+> **DIRECTED 2026-06-13 (owner, in-session).** The owner selected the "enforcement hooks" scope of the
+> 2026-06-13 workflow-hardening pass — the in-session direction Q-0106 requires for an executable-config
+> change (agents don't self-edit hooks on their own initiative). This entry is provenance; the change is
+> **non-blocking** (advisory only).
+
+**Area:** Executable config (`scripts/claude_stop_check.py`, the wired Stop hook) · session-ender enforcement
+**Type:** Owner-directed in-session edit to executable config (provenance per Q-0106)
+
+**Problem:** several mandatory session-enders relied purely on the agent remembering — **Q-0052** (open
+the PR early), **Q-0103/Q-0084** (the PR must reach a terminal state), **Q-0015** (grooming). Nothing
+flagged them. The existing Stop-hook session-log advisory only fired when the `.sessions/` log was
+*incomplete*, so a session that wrote a complete log but **forgot to merge its PR** got no nudge — the
+exact Q-0103 abandoned-open-PR failure.
+
+**Change:** broadened `_session_log_advisory` → `_end_of_session_advisory`, which — when HEAD is ahead
+of `origin/main` — **always** prints a terse, **non-blocking** reminder of the PR-lifecycle + grooming +
+session-log obligations. It stays advisory because the Stop hook runs locally with **no GitHub access**:
+it cannot verify PR state, only remind. No `.claude/settings.json` change (the hook is already wired).
+
+**Calibration (Q-0105):** advisory-first; consider a harder gate only if the reminder proves it needs
+teeth across sessions. Relax/delete if it proves noisy.
+
+**Home:** `scripts/claude_stop_check.py` is the change; this entry is provenance.

--- a/scripts/claude_stop_check.py
+++ b/scripts/claude_stop_check.py
@@ -92,38 +92,54 @@ def _commits_ahead_of_main() -> int:
         return 0
 
 
-def _session_log_advisory() -> None:
-    """Non-blocking reminder if a session has produced work but no complete log.
+def _end_of_session_advisory() -> None:
+    """Non-blocking end-of-session reminders, printed when HEAD is ahead of
+    origin/main (i.e. this session produced real work).
 
-    Runs on every Stop (even docs-only sessions, where the Python gate returns early)
-    but only speaks when there are commits ahead of origin/main and this session's log
-    is missing or incomplete (Q-0089 idea / Q-0102 previous-session review). Advisory
-    only — never changes the exit code. Fully defensive: any failure is swallowed.
+    Covers the session-ender obligations easy to forget because nothing else
+    checks them — but the Stop hook runs locally with **no GitHub access**, so the
+    PR-lifecycle line is a reminder to *confirm*, not true enforcement:
+
+      * Q-0052  — open the session PR early (right after the first push).
+      * Q-0103/Q-0084 — the PR must reach a terminal state (merge on green CI or
+        close); never leave it abandoned open (the parallel-agent conflict window).
+      * Q-0015  — grooming: move one ``docs/ideas/`` idea down its lifecycle.
+      * Q-0089/Q-0102 — the ``.sessions/`` log carries a new idea + a previous-
+        session review (delegated to ``check_session_log.py`` when present).
+
+    Advisory only — never changes the exit code. Fully defensive: any failure is
+    swallowed (provenance: owner-directed in-session, router Q-0122 / Q-0106).
     """
     try:
         if _commits_ahead_of_main() < 1:
             return
-        checker = SCRIPTS / "check_session_log.py"
-        if not checker.exists():
-            return
-        result = subprocess.run(
-            [PY, str(checker)],
-            capture_output=True,
-            text=True,
-            cwd=REPO_ROOT,
-        )
-        out = result.stdout.strip()
-        if "complete ✓" in out or not out:
-            return
         print(
-            "\n── session-log reminder (advisory) ─────────────────────────",
+            "\n── end-of-session reminders (advisory, non-blocking) ───────",
             file=sys.stderr,
         )
-        for line in out.splitlines():
-            print(f"  {line}", file=sys.stderr)
+        checker = SCRIPTS / "check_session_log.py"
+        if checker.exists():
+            result = subprocess.run(
+                [PY, str(checker)],
+                capture_output=True,
+                text=True,
+                cwd=REPO_ROOT,
+            )
+            out = result.stdout.strip()
+            if out and "complete ✓" not in out:
+                for line in out.splitlines():
+                    print(f"  {line}", file=sys.stderr)
+            else:
+                print("  · session log: complete ✓", file=sys.stderr)
         print(
-            "  Before ending: complete the `.sessions/` log (Q-0089 idea + "
-            "Q-0102 previous-session review), and merge or close this session's PR.",
+            "  · PR lifecycle (Q-0052/Q-0103/Q-0084): the session PR should be OPEN "
+            "and reach a terminal state — merge on green CI or close it. Don't leave "
+            "it abandoned open. (Hook has no GitHub access — confirm this yourself.)",
+            file=sys.stderr,
+        )
+        print(
+            "  · grooming (Q-0015): once the main task + PR are done, move one "
+            "docs/ideas/ idea one step down its lifecycle.",
             file=sys.stderr,
         )
     except Exception:  # noqa: BLE001 — advisory must never break the Stop hook
@@ -131,7 +147,7 @@ def _session_log_advisory() -> None:
 
 
 def main() -> int:
-    _session_log_advisory()
+    _end_of_session_advisory()
     changed = _changed_py_files()
     if not changed:
         return 0


### PR DESCRIPTION
## What

PR 3 of the 2026-06-13 workflow-reconciliation session (the enforcement-hook half). **Owner-directed-in-session executable-config change** — selecting this scope tier *is* the in-session direction Q-0106 requires; provenance recorded as router **Q-0122**. **Non-blocking / advisory.**

Broadens `claude_stop_check.py`'s session-log advisory into `_end_of_session_advisory`: when HEAD is ahead of `origin/main`, it **always** prints a terse, non-blocking reminder of the session-ender obligations that nothing else checks:
- **Q-0052** — open the PR early
- **Q-0103/Q-0084** — the PR must reach a terminal state (merge on green CI or close); don't abandon an open PR (the parallel-agent conflict window)
- **Q-0015** — grooming (move one `docs/ideas/` idea down its lifecycle)
- **Q-0089/Q-0102** — the `.sessions/` log (delegated to `check_session_log.py`)

### Why advisory, not enforcement
The Stop hook runs **locally with no GitHub access** — it can't verify PR state, only remind. The honest framing is a reminder. It closes the real gap: previously the advisory only fired when the `.sessions/` log was *incomplete*, so a session that wrote a complete log but **forgot to merge its PR** got no nudge (the exact Q-0103 abandoned-open-PR failure).

No `.claude/settings.json` change — the Stop hook is already wired; only its behavior changed. Q-0105 calibration: advisory-first; relax/delete if noisy.

## Verification

`python3.10 -m py_compile scripts/claude_stop_check.py` ✓ · `check_quality.py --check-only` (black/isort/ruff + check_docs) ✓ · smoke-ran the hook (silent + exit 0 when no commits ahead, as designed).

https://claude.ai/code/session_01VCxU1xp4mMY5p5i7qZsWZR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCxU1xp4mMY5p5i7qZsWZR)_