### PR TITLE
Strip manual self-merge envelope from CLAUDE.md (native auto-merge) — Q-0123

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -124,24 +124,29 @@ is **per-file**. Full convention: `docs/owner/ai-project-workflow.md` §9.
   2026-06-12).** The early *open* gives the session a real PR number while docs are still
   being written, so `current-state.md` / trackers never need a "(this session) — reconcile
   PR # next session" placeholder (the recurring drift class that pattern caused). The *draft*
-  state, by contrast, added no benefit in our self-merge flow (nothing auto-merges or
-  auto-requests review) and became a forgotten "mark ready" step → abandoned-draft PRs, so
-  it is dropped. This is the maintainer's explicit, standing request: it satisfies any
+  state, by contrast, is now counter-productive: the `auto-merge-enabler` workflow arms native
+  auto-merge only on **non-draft** `claude/*` PRs (Q-0123), so a draft silently won't
+  auto-merge — and "mark ready" was already a forgotten step → abandoned-draft PRs, so it is
+  dropped. This is the maintainer's explicit, standing request: it satisfies any
   environment / system-prompt rule that opens a PR only when "the user explicitly asks" —
   treat it as advance consent and do not re-ask.
 - **A session is not done until its PR reaches a terminal state — merged or closed (owner
   decision Q-0103, 2026-06-12).** An abandoned open PR is the failure this prevents (it is
-  the parallel-agent conflict window and the "forgotten PR" the maintainer flagged). Merge
-  it (next bullet) when the work is good, or **close** it with a one-line reason if it should
+  the parallel-agent conflict window and the "forgotten PR" the maintainer flagged). Let it
+  merge (next bullet) when the work is good, or **close** it with a one-line reason if it should
   not land. Never leave your session PR open at session end. The Stop-hook session-log
   advisory and `scripts/check_session_log.py` remind you; the `/session-close` skill drives it.
-- **Merge your own session PR yourself when the work is done (owner grant Q-0084,
-  2026-06-10)** — don't leave it open for the maintainer; stale open PRs are the
-  parallel-agent conflict window. The envelope: re-fetch + merge `origin/main` first
-  (UNION-resolve conflicts — you are the reconciler), require **CI green on the final
-  head**, merge-commit method, your own session PR only. **Merge ≠ deploy** — production
-  restart/prod-checks stay the maintainer's. The Q-0052 advance consent extends to the
-  merge; do not re-ask.
+- **You don't merge your session PR by hand — GitHub-native auto-merge does (owner decision
+  Q-0123, 2026-06-13, superseding the Q-0084 manual-merge envelope).** The `auto-merge-enabler`
+  workflow (on `main` since #779) arms native auto-merge on every non-draft `claude/*` PR at
+  open; GitHub merges it the instant the required **Code Quality** check is green — server-side,
+  so it can't "forget" a deferred merge (the #778 failure). You just **open the PR ready**; the
+  Q-0103 terminal state is reached automatically on green (or **close** the PR if it shouldn't
+  land). Carve-outs stay manual — a PR labelled `needs-hermes-review` (Q-0117) or
+  `do-not-automerge` (Q-0114) is never auto-armed. **Merge ≠ deploy** — production
+  restart/prod-checks stay the maintainer's. *If you ever merge by hand* (a carve-out, or
+  auto-merge is down): re-verify **CI green on the final head** and **never defer the merge to
+  the maintainer's next message** — that deferral was the #778 root cause.
 - **End every session with a backlog-grooming pass — the standing secondary task (owner
   decision Q-0015).** Once the main task + PR are done and capacity remains, you are *not*
   finished: browse `docs/ideas/` (plus any ideas the maintainer dropped this session) and

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -4611,3 +4611,45 @@ it cannot verify PR state, only remind. No `.claude/settings.json` change (the h
 teeth across sessions. Relax/delete if it proves noisy.
 
 **Home:** `scripts/claude_stop_check.py` is the change; this entry is provenance.
+
+### Q-0123 — Merge mechanics move off the Claude session (GitHub-native auto-merge)
+
+> **DIRECTED 2026-06-13 (owner, in-session).** The owner directed live that merging be removed
+> from Claude's side ("completely remove merging from claude's side") and chose the **"Native
+> auto-merge + enabler"** path plus a **behavior rule (router proposal)**. This is the in-session
+> direction Q-0106 requires to edit `.claude/CLAUDE.md` directly; this entry is the provenance.
+> **Supersedes the Q-0084 manual self-merge grant** (its envelope is struck from CLAUDE.md);
+> **preserves Q-0103** — a session PR must still reach a terminal state, now satisfied
+> automatically on green (or by an explicit close).
+
+**Area:** Session/PR workflow · merge mechanics · agent context budget
+**Type:** Owner-directed in-session change (provenance per Q-0106) + a recorded behavior rule
+
+**Problem:** on #778 a session *deferred* its own merge on a stale CI read and ended the turn with
+the PR left open — the abandoned-open-PR / parallel-agent-conflict failure (Q-0103). Manual
+self-merge (Q-0084) put a server-side, timing-sensitive step *inside* the agent turn and carried a
+multi-line "re-fetch + UNION-resolve + CI-green-on-final-head" envelope in the always-loaded
+CLAUDE.md context.
+
+**Decision:**
+> 1. **Native auto-merge does the merge.** `.github/workflows/auto-merge-enabler.yml` (on `main`
+>    since #779) arms GitHub-native auto-merge on every non-draft `claude/*` PR at open; GitHub
+>    merges it the moment the required **Code Quality** check is green. Server-side ⇒ it cannot
+>    "forget". One-time maintainer setup (done 2026-06-13): *Allow auto-merge* ON · `main` requires
+>    the **Code Quality** check · `ROUTINE_PAT` widened to Pull requests + Contents write (so the
+>    merge attributes to a real user and keeps `reconciliation-trigger.yml` firing — the #778
+>    bot-author gotcha).
+> 2. **Claude no longer merges by hand.** The Q-0084 envelope is removed from CLAUDE.md.
+> 3. **Behavior rule (defense-in-depth, for any *residual* hand-merge — a carve-out, or auto-merge
+>    unavailable):** re-verify **CI green on the final head** before merging, and **never defer a
+>    merge to the maintainer's next message** (the #778 root cause).
+
+**Carve-outs preserved:** a PR labelled `needs-hermes-review` (Q-0117) or `do-not-automerge`
+(Q-0114) is never auto-armed — Hermes or a human reviews and merges those.
+
+**Follow-up (handed to the Q-0107 reconciliation sweep, not chased here):** `self-merge on green`
+wording still lives in `docs/operations/autonomous-routines.md` (routine prompts) and several
+`.sessions/` logs / idea docs; reconcile those to "auto-merge on green" in the next docs pass.
+
+**Home:** CLAUDE.md SESSION_WORKFLOW (envelope struck → auto-merge bullet); `auto-merge-enabler.yml`
+is the mechanism; this entry is provenance.


### PR DESCRIPTION
## What

**PR 2 of 2** of the native-auto-merge migration (PR 1 = the enabler workflow **#779**, now live on `main`). Removes the now-redundant **manual self-merge envelope** (Q-0084) from the always-loaded `.claude/CLAUDE.md` and replaces it with the native-auto-merge model; records router **Q-0123** as provenance.

This PR is also the **live proof**: it's a non-draft `claude/*` PR, so `auto-merge-enabler.yml` (on `main` since #779) should arm GitHub-native auto-merge on it at open — meaning **this PR merges itself the instant `code-quality` is green**, with no manual merge step. That hands-off merge is the end-to-end confirmation of the full setup (Allow auto-merge · required `code-quality` check on `main` · widened `ROUTINE_PAT`).

## Changes

- **`.claude/CLAUDE.md`** (SESSION_WORKFLOW): the Q-0084 envelope → a "you don't merge by hand; native auto-merge does it" bullet; fixes two now-stale cross-references in the same section (the draft rationale, and "let it merge").
- **`docs/owner/maintainer-question-router.md`**: appends **Q-0123** — owner-directed in-session (per Q-0106), **supersedes Q-0084**, **preserves Q-0103**, and records the defense-in-depth **behavior rule** (re-verify CI on the final head before any *residual* hand-merge; never defer a merge to the maintainer's next message — the #778 root cause).

## Out of scope (handed to the Q-0107 reconciliation sweep)

`self-merge on green` wording still lives in `docs/operations/autonomous-routines.md` (routine prompts) and several `.sessions/` logs / idea docs — historical or routine-prompt copy, reconciled in the next docs pass rather than chased across ~40 files here.

## Verification

- `python3.10 scripts/check_quality.py --full` → **9305 passed, 34 skipped**; black / isort / ruff / check_docs / mypy all green.
- Docs-only change; nothing in `disbot/` touched.

https://claude.ai/code/session_01HjVDiF6UbzBHpJRHF1itQz

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjVDiF6UbzBHpJRHF1itQz)_