### PR TITLE
hardening(P0-3): retire XP-announce + economy-log scalar pointers (arc PR 2)

### DIFF
--- a/disbot/cogs/economy/schemas.py
+++ b/disbot/cogs/economy/schemas.py
@@ -22,18 +22,6 @@ from core.runtime.subsystem_schema import (
     SettingSpec,
     SubsystemSchema,
 )
-from utils.settings_keys import ECONOMY_LOG_CHANNEL
-
-
-def _validate_channel_id_or_empty(value: object) -> None:
-    """Empty string clears the log channel; otherwise a numeric ID."""
-    if not isinstance(value, str):
-        raise ValueError(f"expected str, got {type(value).__name__}")
-    if value and not value.isdigit():
-        raise ValueError(
-            "must be empty (to clear) or a numeric Discord channel ID",
-        )
-
 
 # ---------------------------------------------------------------------------
 # Phase 1a — Guild config schema
@@ -52,28 +40,16 @@ ECONOMY_BINDINGS: tuple[BindingSpec, ...] = (
     ),
 )
 
-ECONOMY_SETTINGS: tuple[SettingSpec, ...] = (
-    SettingSpec(
-        name="economy_log_channel",
-        value_type=str,
-        default="",
-        settings_key=ECONOMY_LOG_CHANNEL,
-        capability_required="economy.settings.configure",
-        hint=(
-            "Numeric Discord channel ID for the economy mutations log.  "
-            "Leave empty to suppress logging.  Mirrors the "
-            "``log_channel`` BindingSpec — reads go through the "
-            "binding/legacy arbitration ladder; PR #6 routes writes "
-            "through SettingsMutationPipeline so they land in the "
-            "settings_mutation_audit trail."
-        ),
-        validator=_validate_channel_id_or_empty,
-        # PR #7 — opt in to the native channel select.  Operators
-        # pick the channel from Discord's UI instead of pasting a
-        # numeric ID into a text modal.
-        input_hint="channel",
-    ),
-)
+# NOTE: the ``economy_log_channel`` scalar SettingSpec was retired in the
+# P0-3 pointer-lane convergence (arc PR 2).  The log channel is a
+# Discord-resource pointer and lives solely in the binding lane
+# (``log_channel`` above); reads go through
+# ``config_arbitration.get_economy_log_channel`` (binding-first), and
+# writes go through ``BindingMutationPipeline`` (the ``!setlogchannel``
+# command, the on-join auto-provision, and the setup wizard).  The legacy
+# ``economy_log_channel`` KV remains readable as the arbitration rollback
+# fallback.  See docs/planning/settings-pointer-lane-convergence-plan-2026-06-13.md.
+ECONOMY_SETTINGS: tuple[SettingSpec, ...] = ()
 
 ECONOMY_RESOURCE_REQUIREMENTS: tuple[ResourceRequirement, ...] = (
     ResourceRequirement(

--- a/disbot/cogs/economy_cog.py
+++ b/disbot/cogs/economy_cog.py
@@ -38,7 +38,6 @@ from services import economy_service
 from utils import db
 from utils.cooldowns import check_cooldown, format_remaining
 from utils.helpers import post_log_embed
-from utils.settings_keys import ECONOMY_LOG_CHANNEL
 from utils.ui_constants import ECONOMY_COLOR, INFO_COLOR
 
 # Views — importing this module triggers the @register decorator on
@@ -116,29 +115,45 @@ class EconomyCog(commands.Cog):
         actor: discord.Member | discord.User | None,
         actor_type: str = "user",
     ) -> None:
-        """Persist the economy log channel via :class:`SettingsMutationPipeline`.
+        """Persist the economy log channel via :class:`BindingMutationPipeline`.
 
+        P0-3 arc PR 2 retired the ``economy_log_channel`` scalar
+        ``SettingSpec``; the log channel now lives in the binding lane
+        (``economy.log_channel``) so there is one canonical pointer owner.
         Used by both the system-triggered ``_ensure_log_channel`` path
         (``on_ready`` / ``on_guild_join``, ``actor_type='system'``,
         ``actor=None``) and the admin ``!setlogchannel`` command
-        (``actor_type='user'``, ``actor`` is the invoking member).
-        Either way the pipeline records the change in
-        ``settings_mutation_audit`` and invalidates the per-key cache.
+        (``actor_type='user'``, ``actor`` is the invoking member).  The
+        pipeline records the change in ``binding_audit_log`` (a system
+        write records the bot's own id as actor_id, since that column is
+        NOT NULL — ``actor_type`` is the real discriminator).
         """
-        from services.settings_mutation import SettingsMutationPipeline
+        from core.runtime.subsystem_schema import BindingKind
+        from services.binding_mutation import BindingMutationPipeline
 
-        await SettingsMutationPipeline().set_value(
+        await BindingMutationPipeline().set_binding(
             guild,
             "economy",
-            "economy_log_channel",
-            channel_id,
+            "log_channel",
+            BindingKind.CHANNEL,
+            int(channel_id),
             actor,
             actor_type=actor_type,
         )
 
     async def _ensure_log_channel(self, guild: discord.Guild) -> None:
         """Create #economy-log for *guild* if it doesn't already exist."""
-        if await resources.resolve_settings_channel(guild, ECONOMY_LOG_CHANNEL):
+        from core.runtime.config_arbitration import get_economy_log_channel
+
+        # Binding-first read (the economy_log_channel scalar was retired
+        # in P0-3): a guild that already has the channel bound — or a
+        # pre-migration legacy value — is left alone; only a truly
+        # unconfigured guild gets one auto-created.
+        configured = await get_economy_log_channel(guild.id)
+        if (
+            configured.value is not None
+            and guild.get_channel(configured.value) is not None
+        ):
             return
 
         existing = resources.resolve_channel(guild, name="economy-log")

--- a/disbot/cogs/xp/schemas.py
+++ b/disbot/cogs/xp/schemas.py
@@ -34,7 +34,6 @@ from core.runtime.subsystem_schema import (
     SubsystemSchema,
 )
 from utils.settings_keys import (
-    XP_ANNOUNCE_CHANNEL,
     XP_COOLDOWN,
     XP_MAX,
     XP_MIN,
@@ -49,16 +48,6 @@ def _validate_positive_int(value: object) -> None:
 def _validate_cooldown(value: object) -> None:
     if not isinstance(value, int) or value < 0:
         raise ValueError(f"expected non-negative int cooldown, got {value!r}")
-
-
-def _validate_channel_id_or_empty(value: object) -> None:
-    """Empty string clears the announce channel; otherwise a numeric ID."""
-    if not isinstance(value, str):
-        raise ValueError(f"expected str, got {type(value).__name__}")
-    if value and not value.isdigit():
-        raise ValueError(
-            "must be empty (to clear) or a numeric Discord channel ID",
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -115,25 +104,15 @@ XP_SETTINGS: tuple[SettingSpec, ...] = (
         input_hint="numeric_presets",
         presets=(0, 15, 30, 60, 120, 300),
     ),
-    SettingSpec(
-        name="xp_announce_channel",
-        value_type=str,
-        default="",
-        settings_key=XP_ANNOUNCE_CHANNEL,
-        capability_required="xp.settings.configure",
-        hint=(
-            "Numeric Discord channel ID for level-up announcements.  "
-            "Leave empty to announce in the channel where the level-up "
-            "happened."
-        ),
-        validator=_validate_channel_id_or_empty,
-        # PR #7 — opt in to the native channel select.  The Settings
-        # edit dispatcher renders a discord.ui.ChannelSelect; the
-        # legacy text-modal fallback is still reachable when the spec
-        # is mutated programmatically (the SettingSpec.value_type is
-        # still str so the pipeline accepts either shape).
-        input_hint="channel",
-    ),
+    # NOTE: the ``xp_announce_channel`` scalar SettingSpec was retired in
+    # the P0-3 pointer-lane convergence (arc PR 2).  The announce channel
+    # is a Discord-resource pointer and now lives solely in the binding
+    # lane (``announce_channel`` below); reads go through
+    # ``config_arbitration.get_xp_announce_channel`` (binding-first), and
+    # writes go through ``BindingMutationPipeline`` (the XP config modal +
+    # the setup wizard).  The legacy ``xp_announce_channel`` KV remains
+    # readable as the arbitration rollback fallback.  See
+    # docs/planning/settings-pointer-lane-convergence-plan-2026-06-13.md.
 )
 
 XP_RESOURCE_REQUIREMENTS: tuple[ResourceRequirement, ...] = (

--- a/disbot/core/runtime/config_arbitration.py
+++ b/disbot/core/runtime/config_arbitration.py
@@ -301,15 +301,25 @@ async def read_config(
     legacy_key: str,
     *,
     binding_kind: str | None = None,
+    pointer_retired: bool = False,
 ) -> ConfigReadResult:
     """Resolve a config value via the bindings → legacy ladder.
 
     Resolution:
 
-    1. Consult ``is_enabled("bindings.primary", guild_id)``:
-       - If **OFF** → read legacy.  Return ``source='legacy'`` if a
-         value is present; ``source='missing'`` if not.
-       - If **ON**  → fall through to step 2.
+    1. Decide whether the binding is primary for this read:
+       - ``pointer_retired=True`` → binding is **always** primary,
+         regardless of the global ``bindings.primary`` canary flag.  A
+         retired pointer (its editable scalar ``SettingSpec`` is gone —
+         P0-3 convergence) has *completed* its transition: the binding
+         is its only write surface, so the read must consult the
+         binding even before the global flag is flipped.  This is what
+         lets the retirement deploy safely without a coordinated
+         production flag flip; the global flag still governs in-transition
+         keys (e.g. the governance role pointers).
+       - Otherwise consult ``is_enabled("bindings.primary", guild_id)``:
+         **OFF** → read legacy (``source='legacy'`` / ``'missing'``);
+         **ON** → fall through to step 2.
     2. Read the binding via :func:`core.runtime.bindings.get_binding`.
        - If ``status == BOUND`` and a target is present AND (when
          ``binding_kind`` was supplied) the binding's declared kind
@@ -318,7 +328,9 @@ async def read_config(
          and fall through to fallback.
        - Else → fall through to step 3.
     3. Read legacy as a fallback.  ``source='fallback'`` if legacy
-       supplies a value, ``source='missing'`` if not.
+       supplies a value, ``source='missing'`` if not.  For a retired
+       pointer this fallback is the rollback path: a guild whose value
+       was never migrated to a binding still reads its legacy KV.
 
     Failure handling:
 
@@ -335,21 +347,27 @@ async def read_config(
 
     diagnostics: list[str] = []
 
-    # Step 1: feature flag gate.
-    try:
-        primary_on = await feature_flags.is_enabled(
-            "bindings.primary",
-            guild_id,
-        )
-    except Exception as exc:  # noqa: BLE001 — arbitration must not raise
-        logger.warning(
-            "config_arbitration: is_enabled raised for guild=%d (%r); "
-            "treating bindings.primary as OFF",
-            guild_id,
-            exc,
-        )
-        primary_on = False
-        diagnostics.append(f"is_enabled raised: {type(exc).__name__}")
+    # Step 1: decide whether the binding is primary.  A retired pointer
+    # forces binding-primary (the flag governs only in-transition keys);
+    # everything else consults the global canary flag.
+    if pointer_retired:
+        primary_on = True
+        diagnostics.append("binding primary forced (retired pointer)")
+    else:
+        try:
+            primary_on = await feature_flags.is_enabled(
+                "bindings.primary",
+                guild_id,
+            )
+        except Exception as exc:  # noqa: BLE001 — arbitration must not raise
+            logger.warning(
+                "config_arbitration: is_enabled raised for guild=%d (%r); "
+                "treating bindings.primary as OFF",
+                guild_id,
+                exc,
+            )
+            primary_on = False
+            diagnostics.append(f"is_enabled raised: {type(exc).__name__}")
 
     if not primary_on:
         legacy_value = await _read_legacy(settings_db, guild_id, legacy_key)
@@ -540,6 +558,12 @@ async def get_xp_announce_channel(guild_id: int) -> ConfigReadResult:
     the existing ``XpConfig.announce_channel`` shape).  A binding-side
     snowflake int is stringified; an unparseable legacy value is
     returned as the raw string.
+
+    **Retired pointer (P0-3 arc PR 2):** the editable ``xp_announce_channel``
+    scalar ``SettingSpec`` was retired; the ``xp.announce_channel`` binding
+    is the only write surface, so this read is binding-first regardless of
+    the global ``bindings.primary`` flag (legacy KV remains the rollback
+    fallback).
     """
     result = await read_config(
         guild_id=guild_id,
@@ -547,6 +571,7 @@ async def get_xp_announce_channel(guild_id: int) -> ConfigReadResult:
         binding_name="announce_channel",
         legacy_key="xp_announce_channel",
         binding_kind="channel",
+        pointer_retired=True,
     )
     return _coerce_to_str(result)
 
@@ -557,6 +582,12 @@ async def get_economy_log_channel(guild_id: int) -> ConfigReadResult:
     Consumers (``utils.helpers.post_log_embed``) then do
     ``guild.get_channel(value)``.  An unparseable legacy value becomes
     ``None`` with a diagnostic explaining the parse failure.
+
+    **Retired pointer (P0-3 arc PR 2):** the editable ``economy_log_channel``
+    scalar ``SettingSpec`` was retired; the ``economy.log_channel`` binding
+    is the only write surface, so this read is binding-first regardless of
+    the global ``bindings.primary`` flag (legacy KV remains the rollback
+    fallback).
     """
     result = await read_config(
         guild_id=guild_id,
@@ -564,6 +595,7 @@ async def get_economy_log_channel(guild_id: int) -> ConfigReadResult:
         binding_name="log_channel",
         legacy_key="economy_log_channel",
         binding_kind="channel",
+        pointer_retired=True,
     )
     return _coerce_to_int(result)
 

--- a/disbot/services/binding_mutation.py
+++ b/disbot/services/binding_mutation.py
@@ -44,6 +44,24 @@ Boundary notes (source-verified):
   * Authority is capability-native (ADR-005 A1): resolved via
     :func:`governance.capability.actor_holds_capability` against
     ``BindingSpec.capability_required`` (empty resolves to the admin floor).
+
+Actor model (parity with :class:`services.settings_mutation.SettingsMutationPipeline`):
+
+  * ``actor_type='user'`` / ``'moderator'`` / ``'admin'`` — a Discord
+    member initiated the write; ``actor`` is that member and the
+    capability check applies.
+  * ``actor_type='system'`` / ``'backfill'`` — a scripted / lifecycle
+    write (e.g. the economy-log auto-provision on guild join).  ``actor``
+    may be ``None`` and the capability check is bypassed inside
+    :func:`governance.capability.actor_holds_capability` (it short-circuits
+    on the actor_type).  Because ``binding_audit_log.actor_id`` is
+    ``NOT NULL`` (unlike ``settings_mutation_audit``, which permits NULL),
+    a system write records the bot's own id (``guild.me.id``) as the
+    audit ``actor_id`` — ``actor_type`` is the real discriminator.  This
+    is what lets a Discord-resource pointer be set by an automatic path
+    *and* still live in the binding lane (the P0-3 pointer-lane
+    convergence: a pointer has one canonical binding owner, no parallel
+    scalar).
 """
 
 from __future__ import annotations
@@ -75,9 +93,22 @@ logger = logging.getLogger("bot.services.binding_mutation")
 
 EVT_BINDING_CHANGED = "bindings.changed"
 
+# Recognized actor types.  ``binding_audit_log`` (migration 022) carries
+# no CHECK on ``actor_type`` and its docstring anticipates
+# ``'user'`` / ``'system'`` / ``'backfill'``; we mirror the
+# ``settings_mutation`` set so the pipeline rejects a typo'd actor type
+# rather than writing an unrecognised discriminator.
+_ALLOWED_ACTOR_TYPES: frozenset[str] = frozenset(
+    {"user", "moderator", "admin", "system", "backfill"},
+)
+
 
 class BindingMutationError(Exception):
     """Base class for failures from :class:`BindingMutationPipeline`."""
+
+
+class InvalidBindingActorTypeError(BindingMutationError):
+    """Raised when ``actor_type`` is not in :data:`_ALLOWED_ACTOR_TYPES`."""
 
 
 class UnknownSubsystemError(BindingMutationError):
@@ -148,18 +179,28 @@ class BindingMutationPipeline:
         binding_name: str,
         kind: BindingKind,
         target_id: int,
-        actor: discord.Member,
+        actor: discord.Member | discord.User | None,
+        *,
+        actor_type: str = "user",
     ) -> BindingMutationResult:
         """Bind ``target_id`` to ``(subsystem, binding_name)``.
+
+        ``actor_type`` defaults to ``'user'`` (member-initiated; the
+        capability check applies).  ``'system'`` / ``'backfill'`` writes
+        pass ``actor=None`` and bypass the capability check (see the
+        module "Actor model" note) — used by lifecycle paths such as the
+        economy-log auto-provision on guild join.
 
         Raises:
             UnknownSubsystemError: ``subsystem`` not in SUBSYSTEMS.
             UndeclaredBindingError: schema does not declare ``binding_name``.
             BindingKindMismatchError: declared kind disagrees with ``kind``.
+            InvalidBindingActorTypeError: ``actor_type`` not recognised.
             UnauthorizedBindingMutationError: actor below the authority floor.
         """
+        self._validate_actor_type(actor_type)
         spec = self._resolve_spec(subsystem, binding_name, kind)
-        await self._validate_authority(spec, guild, actor)
+        await self._validate_authority(spec, guild, actor, actor_type)
 
         new_status = await validate_binding_target(guild, kind, target_id)
         old = await get_binding(guild.id, subsystem, binding_name)
@@ -172,6 +213,7 @@ class BindingMutationPipeline:
             new_status=new_status,
             old=old,
             actor=actor,
+            actor_type=actor_type,
             action_label="set",
         )
 
@@ -181,17 +223,22 @@ class BindingMutationPipeline:
         subsystem: str,
         binding_name: str,
         kind: BindingKind,
-        actor: discord.Member,
+        actor: discord.Member | discord.User | None,
+        *,
+        actor_type: str = "user",
     ) -> BindingMutationResult:
         """Clear the binding at ``(subsystem, binding_name)``.
 
         The slot row remains so the schema-declared binding stays
         discoverable; ``target_id`` is set to NULL and ``status`` to
-        ``unresolved``.
+        ``unresolved``.  ``actor_type`` follows the same model as
+        :meth:`set_binding`.
         """
+        self._validate_actor_type(actor_type)
         spec = self._resolve_spec(subsystem, binding_name, kind)
-        await self._validate_authority(spec, guild, actor)
+        await self._validate_authority(spec, guild, actor, actor_type)
 
+        actor_id = self._resolve_actor_id(actor, guild)
         old = await get_binding(guild.id, subsystem, binding_name)
         if old.target_id is None and old.last_updated_at is None:
             # Nothing to clear; treat as a no-op success rather than
@@ -215,8 +262,8 @@ class BindingMutationPipeline:
                 guild_id=guild.id,
                 subsystem=subsystem,
                 binding_name=binding_name,
-                actor_id=actor.id,
-                actor_type="user",
+                actor_id=actor_id,
+                actor_type=actor_type,
                 mutation_id=mutation_id,
                 old_target_id=old.target_id,
                 old_status=old.status.value,
@@ -245,8 +292,8 @@ class BindingMutationPipeline:
             guild_id=guild.id,
             prev_value=str(old.target_id) if old.target_id is not None else None,
             new_value=None,
-            actor_id=actor.id,
-            actor_type="user",
+            actor_id=actor_id,
+            actor_type=actor_type,
             occurred_at=committed_at,
         )
         event_emitted = await self._emit_event(
@@ -316,18 +363,44 @@ class BindingMutationPipeline:
         )
         raise UndeclaredBindingError(msg)
 
+    def _validate_actor_type(self, actor_type: str) -> None:
+        """Reject an unrecognised ``actor_type`` before any write."""
+        if actor_type not in _ALLOWED_ACTOR_TYPES:
+            raise InvalidBindingActorTypeError(
+                f"actor_type={actor_type!r} not in {sorted(_ALLOWED_ACTOR_TYPES)}",
+            )
+
+    @staticmethod
+    def _resolve_actor_id(
+        actor: discord.Member | discord.User | None,
+        guild: discord.Guild,
+    ) -> int:
+        """Audit ``actor_id`` for the write.
+
+        ``binding_audit_log.actor_id`` is ``NOT NULL`` (migration 022), so a
+        system write (``actor=None``) records the bot's own id — the
+        automatic actor — and relies on ``actor_type`` as the discriminator.
+        """
+        if actor is not None:
+            return actor.id
+        me = guild.me
+        return me.id if me is not None else 0
+
     async def _validate_authority(
         self,
         spec: BindingSpec,
         guild: discord.Guild,
-        actor: discord.Member,
+        actor: discord.Member | discord.User | None,
+        actor_type: str,
     ) -> None:
         """Step 2: capability-native authority (ADR-005 A1).
 
         The actor must hold ``spec.capability_required``; an empty capability
-        resolves to the administrator floor.  Resolution (and any per-guild
-        revoke overlay) lives in
-        :func:`governance.capability.actor_holds_capability`.
+        resolves to the administrator floor.  ``actor_type='system'`` /
+        ``'backfill'`` bypass the check inside
+        :func:`governance.capability.actor_holds_capability` (it short-circuits
+        on the actor_type, as the settings pipeline relies on).  Resolution
+        (and any per-guild revoke overlay) lives in that module.
         """
         from governance.capability import actor_holds_capability
 
@@ -335,7 +408,7 @@ class BindingMutationPipeline:
             actor,
             guild,
             spec.capability_required,
-            actor_type="user",
+            actor_type=actor_type,
         )
         if not decision.allowed:
             raise UnauthorizedBindingMutationError(decision.reason)
@@ -350,7 +423,8 @@ class BindingMutationPipeline:
         new_target_id: int,
         new_status: ResourceStatus,
         old: BindingValue,
-        actor: discord.Member,
+        actor: discord.Member | discord.User | None,
+        actor_type: str,
         action_label: str,
     ) -> BindingMutationResult:
         """Steps 5-6: write+audit, then best-effort emission.
@@ -359,6 +433,7 @@ class BindingMutationPipeline:
         in via ``old``.
         """
         del action_label  # currently single shape; reserved for future actions
+        actor_id = self._resolve_actor_id(actor, guild)
         mutation_id = str(uuid.uuid4())
         try:
             await bindings_db.upsert_with_audit(
@@ -368,8 +443,8 @@ class BindingMutationPipeline:
                 kind=kind.value,
                 target_id=new_target_id,
                 status=new_status.value,
-                actor_id=actor.id,
-                actor_type="user",
+                actor_id=actor_id,
+                actor_type=actor_type,
                 mutation_id=mutation_id,
                 old_target_id=old.target_id,
                 old_status=old.status.value,
@@ -398,8 +473,8 @@ class BindingMutationPipeline:
             guild_id=guild.id,
             prev_value=str(old.target_id) if old.target_id is not None else None,
             new_value=str(new_target_id),
-            actor_id=actor.id,
-            actor_type="user",
+            actor_id=actor_id,
+            actor_type=actor_type,
             occurred_at=committed_at,
         )
         event_emitted = await self._emit_event(
@@ -483,6 +558,7 @@ __all__ = [
     "BindingMutationError",
     "BindingMutationPipeline",
     "BindingMutationResult",
+    "InvalidBindingActorTypeError",
     "UnauthorizedBindingMutationError",
     "UndeclaredBindingError",
     "UnknownSubsystemError",

--- a/disbot/views/setup/sections/channels.py
+++ b/disbot/views/setup/sections/channels.py
@@ -63,10 +63,12 @@ _BINDING_TO_TAG: dict[str, str] = {
     "warning_channel": "likely_log",
     "error_channel": "likely_log",
     "audit_channel": "likely_log",
-    # economy
-    "economy_log_channel": "likely_log",
-    # xp
-    "xp_announce_channel": "likely_general",
+    # economy (binding name is ``log_channel`` — was wrongly keyed by the
+    # legacy settings key ``economy_log_channel`` before the P0-3 retirement,
+    # so this hint never fired).
+    "log_channel": "likely_log",
+    # xp (binding name is ``announce_channel`` — same legacy-key mismatch).
+    "announce_channel": "likely_general",
 }
 
 
@@ -83,8 +85,8 @@ _BINDING_TO_INTENT: dict[str, str] = {
     "warning_channel": "logs",
     "error_channel": "logs",
     "audit_channel": "logs",
-    "economy_log_channel": "logs",
-    "xp_announce_channel": "general",
+    "log_channel": "logs",
+    "announce_channel": "general",
     "welcome_channel": "welcome",
 }
 

--- a/disbot/views/setup/sections/logging_presets.py
+++ b/disbot/views/setup/sections/logging_presets.py
@@ -128,7 +128,7 @@ _LOGGING_BINDINGS: tuple[LoggingBinding, ...] = (
     ),
     LoggingBinding(
         subsystem="economy",
-        binding_name="economy_log_channel",
+        binding_name="log_channel",
         intent="general_logs",
         detailed_channel_name="economy-logs",
     ),

--- a/disbot/views/xp/config_panel.py
+++ b/disbot/views/xp/config_panel.py
@@ -12,9 +12,8 @@ import discord
 from discord.ext import commands
 
 from cogs.xp._helpers import _guild_xp_settings
+from core.runtime.config_arbitration import get_xp_announce_channel
 from core.runtime.interaction_helpers import safe_edit
-from utils import db
-from utils.settings_keys import XP_ANNOUNCE_CHANNEL
 from utils.ui_constants import UTILITY_COLOR
 from views.base import BaseView
 from views.navigation import attach_back_button
@@ -50,7 +49,11 @@ class XpConfigView(BaseView):
     async def build_embed(self) -> discord.Embed:
         gid = self.ctx.guild.id
         xp_min, xp_max, cooldown = await _guild_xp_settings(gid)
-        cid = await db.get_setting(gid, XP_ANNOUNCE_CHANNEL, "")
+        # Binding-first read (the xp_announce_channel scalar was retired
+        # in P0-3; arbitration resolves xp.announce_channel, legacy KV
+        # remains the rollback fallback).
+        ann = await get_xp_announce_channel(gid)
+        cid = ann.value or ""
         channel_str = f"<#{cid}>" if cid else "Same channel as message"
 
         embed = discord.Embed(title="⚙️ XP Configuration", color=UTILITY_COLOR)

--- a/disbot/views/xp/modals.py
+++ b/disbot/views/xp/modals.py
@@ -8,13 +8,21 @@ Five modals extracted from ``cogs/xp_cog.py``:
   _XpCooldownModal   — XP gain cooldown seconds (XpConfigView)
   _XpChannelModal    — level-up announcement channel id (XpConfigView)
 
-The three config modals (range / cooldown / channel) write through
+The range / cooldown modals write through
 :class:`services.settings_mutation.SettingsMutationPipeline` since
 PR #5.  The pipeline handles audit, the per-key SettingSpec-lane
 cache invalidation, and event emission — each scalar value lands
 with a row in ``settings_mutation_audit``.
 
-After every successful pipeline write, the helper also calls
+The **channel** modal writes through
+:class:`services.binding_mutation.BindingMutationPipeline` since the
+P0-3 pointer-lane convergence retired the ``xp_announce_channel``
+scalar ``SettingSpec``: the announce channel lives in the binding lane
+(``xp.announce_channel``) with one canonical pointer owner.  An empty
+input clears the binding; a numeric ID sets it.  The audit row lands
+in ``binding_audit_log``.
+
+After every successful scalar pipeline write, the helper also calls
 :func:`utils.guild_config_accessors.invalidate_xp_config` to drop the
 legacy composite ``XpConfig`` cache that the XP ``on_message`` hot
 path consumes.  The pipeline's own invalidation covers the per-key
@@ -111,6 +119,88 @@ async def _set_xp_setting_via_pipeline(
     # ``XpConfig`` accessor used by the XP on_message hot path is a
     # separate cache; drop it explicitly so the next message read
     # sees the new value without waiting for the TTL.
+    invalidate_xp_config(guild.id)
+    return True
+
+
+async def _set_xp_announce_channel_via_binding(
+    interaction: discord.Interaction,
+    raw_value: str,
+) -> bool:
+    """Set / clear the ``xp.announce_channel`` binding from modal input.
+
+    P0-3 arc PR 2 retired the ``xp_announce_channel`` scalar
+    ``SettingSpec``; the announce channel now lives in the binding lane
+    (one canonical pointer owner, no parallel scalar).  Empty input
+    *clears* the binding (announce in-place); a numeric channel ID
+    *sets* it.  Authority is the same ``xp.settings.configure``
+    capability the retired scalar required (it is the binding's
+    ``capability_required``).
+
+    Returns True on success (caller defers + re-renders); on failure
+    sends an ephemeral and returns False so the caller short-circuits.
+    Still pokes :func:`invalidate_xp_config` so the XP ``on_message``
+    hot-path composite cache re-reads the (binding-first) channel.
+    """
+    from core.runtime.subsystem_schema import BindingKind
+    from services.binding_mutation import (
+        BindingMutationError,
+        BindingMutationPipeline,
+        UnauthorizedBindingMutationError,
+    )
+
+    guild = interaction.guild
+    if guild is None:
+        await interaction.response.send_message(
+            "❌ XP config requires a guild context.",
+            ephemeral=True,
+        )
+        return False
+
+    raw = raw_value.strip()
+    if raw and not raw.isdigit():
+        await interaction.response.send_message(
+            "❌ Channel must be empty (to clear) or a numeric Discord channel ID.",
+            ephemeral=True,
+        )
+        return False
+
+    pipeline = BindingMutationPipeline()
+    try:
+        if not raw:
+            await pipeline.clear_binding(
+                guild,
+                "xp",
+                "announce_channel",
+                BindingKind.CHANNEL,
+                interaction.user,
+            )
+        else:
+            await pipeline.set_binding(
+                guild,
+                "xp",
+                "announce_channel",
+                BindingKind.CHANNEL,
+                int(raw),
+                interaction.user,
+            )
+    except UnauthorizedBindingMutationError as exc:
+        await interaction.response.send_message(f"❌ {exc}", ephemeral=True)
+        return False
+    except BindingMutationError as exc:
+        await interaction.response.send_message(
+            f"❌ {type(exc).__name__}: {exc}",
+            ephemeral=True,
+        )
+        return False
+    except Exception as exc:  # noqa: BLE001 — defensive
+        logger.exception("XP modal announce-channel binding write failed")
+        await interaction.response.send_message(
+            f"❌ Unexpected error: {type(exc).__name__}: {exc}",
+            ephemeral=True,
+        )
+        return False
+
     invalidate_xp_config(guild.id)
     return True
 
@@ -279,14 +369,13 @@ class _XpChannelModal(discord.ui.Modal, title="Level-up Announcement Channel"): 
         self.view = view
 
     async def on_submit(self, interaction: discord.Interaction):
-        # The xp_announce_channel SettingSpec's validator enforces
-        # "empty or numeric"; surface any failure as an ephemeral and
-        # bail before touching the parent view.
-        val = self.channel_id.value.strip()
-        if not await _set_xp_setting_via_pipeline(
+        # P0-3: the announce channel is a binding now (the scalar
+        # xp_announce_channel SettingSpec was retired).  The helper
+        # validates "empty or numeric", clears or sets the binding, and
+        # surfaces any failure as an ephemeral before touching the view.
+        if not await _set_xp_announce_channel_via_binding(
             interaction,
-            "xp_announce_channel",
-            val,
+            self.channel_id.value,
         ):
             return
         if not await safe_defer(interaction):

--- a/tests/unit/cogs/test_economy_log_channel_pipeline.py
+++ b/tests/unit/cogs/test_economy_log_channel_pipeline.py
@@ -1,24 +1,29 @@
-"""Regression tests for PR #6 — economy_cog log-channel writes use the pipeline.
+"""Regression tests — economy_cog log-channel writes use the binding lane.
 
-Pre-PR-#6 ``cogs/economy_cog.py`` wrote ``ECONOMY_LOG_CHANNEL`` via
-``db.set_setting`` from three sites:
+The economy log channel is a Discord-resource pointer.  PR #6 first
+routed its writes through ``SettingsMutationPipeline`` (the scalar
+``economy_log_channel``); the P0-3 pointer-lane convergence (arc PR 2)
+then **retired that scalar** and moved the channel into the binding lane
+(``economy.log_channel``).  ``cogs/economy_cog.py`` now writes it via
+``services.binding_mutation.BindingMutationPipeline`` from three sites:
 
 * ``on_ready`` listener (``_ensure_log_channel`` → existing channel found)
 * ``on_guild_join`` listener (``_ensure_log_channel`` → newly created)
 * ``!setlogchannel`` admin command
 
-PR #6 routes all three through ``services.settings_mutation.
-SettingsMutationPipeline`` via the new ``_record_log_channel`` helper.
-System-triggered paths pass ``actor=None`` + ``actor_type='system'``;
-the admin command passes the invoking member.
+System-triggered paths pass ``actor=None`` + ``actor_type='system'``; the
+admin command passes the invoking member.  ``_ensure_log_channel``'s
+"already configured?" check reads binding-first via
+``config_arbitration.get_economy_log_channel``.
 
-These tests pin the new contract by:
+These tests pin the contract by:
 
-* Asserting the cog module no longer references ``db.set_setting``.
-* Patching the pipeline class and verifying each call site invokes
-  it with the expected ``(subsystem, name, value, actor_type)`` shape.
-* Asserting the ``economy_log_channel`` SettingSpec is declared with
-  the empty-or-numeric validator.
+* Asserting the cog module does not reference ``db.set_setting``.
+* Patching the binding pipeline and verifying each call site invokes
+  ``set_binding`` with the expected ``(subsystem, binding_name, kind,
+  target_id, actor, actor_type)`` shape.
+* Asserting the ``economy_log_channel`` scalar SettingSpec is retired
+  and the ``economy.log_channel`` binding is its replacement home.
 """
 
 from __future__ import annotations
@@ -26,10 +31,13 @@ from __future__ import annotations
 import ast
 import importlib
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
+
+from core.runtime.subsystem_schema import BindingKind
 
 _COG_PATH = (
     Path(__file__).resolve().parents[3] / "disbot" / "cogs" / "economy_cog.py"
@@ -42,8 +50,8 @@ _COG_PATH = (
 
 
 def test_economy_cog_does_not_reference_db_set_setting():
-    """``cogs/economy_cog.py`` is removed from the no-direct-writes
-    allowlist in PR #6; the AST scan now enforces it.
+    """``cogs/economy_cog.py`` must not write settings directly — the log
+    channel is a binding now, and there is no other scalar write.
     """
     source = _COG_PATH.read_text()
     tree = ast.parse(source)
@@ -62,12 +70,13 @@ def test_economy_cog_exports_record_helper():
 
 
 # ---------------------------------------------------------------------------
-# Helper-level: _record_log_channel hits the pipeline with the right shape
+# Helper-level: _record_log_channel hits the binding pipeline with the
+# right shape
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_record_log_channel_uses_pipeline_for_admin_writes():
+async def test_record_log_channel_binds_for_admin_writes():
     from cogs.economy_cog import EconomyCog
 
     cog = EconomyCog(MagicMock())
@@ -76,20 +85,21 @@ async def test_record_log_channel_uses_pipeline_for_admin_writes():
     actor = MagicMock(spec=discord.Member)
     actor.id = 7
 
-    pipeline_instance = MagicMock()
-    pipeline_instance.set_value = AsyncMock(return_value=MagicMock())
+    pipeline = MagicMock()
+    pipeline.set_binding = AsyncMock(return_value=MagicMock())
 
     with patch(
-        "services.settings_mutation.SettingsMutationPipeline",
-        return_value=pipeline_instance,
+        "services.binding_mutation.BindingMutationPipeline",
+        return_value=pipeline,
     ):
         await cog._record_log_channel(guild, "1234567890", actor=actor)
 
-    pipeline_instance.set_value.assert_awaited_once_with(
+    pipeline.set_binding.assert_awaited_once_with(
         guild,
         "economy",
-        "economy_log_channel",
-        "1234567890",
+        "log_channel",
+        BindingKind.CHANNEL,
+        1234567890,
         actor,
         actor_type="user",
     )
@@ -97,10 +107,10 @@ async def test_record_log_channel_uses_pipeline_for_admin_writes():
 
 @pytest.mark.asyncio
 async def test_record_log_channel_uses_system_actor_type_for_listeners():
-    """The two listener-triggered paths (on_ready / on_guild_join via
+    """The listener-triggered paths (on_ready / on_guild_join via
     ``_ensure_log_channel``) call ``_record_log_channel`` with
-    ``actor=None`` + ``actor_type='system'`` so the pipeline's
-    administrator-tier check is bypassed via the system bucket.
+    ``actor=None`` + ``actor_type='system'`` so the binding pipeline's
+    capability check is bypassed via the system bucket.
     """
     from cogs.economy_cog import EconomyCog
 
@@ -108,12 +118,12 @@ async def test_record_log_channel_uses_system_actor_type_for_listeners():
     guild = MagicMock(spec=discord.Guild)
     guild.id = 99
 
-    pipeline_instance = MagicMock()
-    pipeline_instance.set_value = AsyncMock(return_value=MagicMock())
+    pipeline = MagicMock()
+    pipeline.set_binding = AsyncMock(return_value=MagicMock())
 
     with patch(
-        "services.settings_mutation.SettingsMutationPipeline",
-        return_value=pipeline_instance,
+        "services.binding_mutation.BindingMutationPipeline",
+        return_value=pipeline,
     ):
         await cog._record_log_channel(
             guild,
@@ -122,27 +132,28 @@ async def test_record_log_channel_uses_system_actor_type_for_listeners():
             actor_type="system",
         )
 
-    pipeline_instance.set_value.assert_awaited_once_with(
+    pipeline.set_binding.assert_awaited_once_with(
         guild,
         "economy",
-        "economy_log_channel",
-        "555",
+        "log_channel",
+        BindingKind.CHANNEL,
+        555,
         None,
         actor_type="system",
     )
 
 
 # ---------------------------------------------------------------------------
-# Listener path: _ensure_log_channel routes existing-channel pickup through
-# the pipeline
+# Listener path: _ensure_log_channel reads binding-first, then routes an
+# existing-channel pickup through the binding pipeline
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_ensure_log_channel_existing_routes_through_pipeline():
-    """When ``resources.resolve_channel`` finds an existing
-    #economy-log, ``_ensure_log_channel`` records its id via the
-    pipeline (not ``db.set_setting``).
+async def test_ensure_log_channel_existing_routes_through_binding():
+    """When the guild has no configured log channel (binding-first read
+    returns nothing) but a #economy-log already exists,
+    ``_ensure_log_channel`` binds its id via the pipeline (system actor).
     """
     from cogs import economy_cog
 
@@ -153,54 +164,73 @@ async def test_ensure_log_channel_existing_routes_through_pipeline():
     existing = MagicMock()
     existing.id = 12345
 
-    pipeline_instance = MagicMock()
-    pipeline_instance.set_value = AsyncMock(return_value=MagicMock())
+    pipeline = MagicMock()
+    pipeline.set_binding = AsyncMock(return_value=MagicMock())
 
-    with patch.object(
-        economy_cog.resources,
-        "resolve_settings_channel",
-        new=AsyncMock(return_value=None),
+    with patch(
+        "core.runtime.config_arbitration.get_economy_log_channel",
+        new=AsyncMock(return_value=SimpleNamespace(value=None)),
     ), patch.object(
         economy_cog.resources,
         "resolve_channel",
         return_value=existing,
     ), patch(
-        "services.settings_mutation.SettingsMutationPipeline",
-        return_value=pipeline_instance,
+        "services.binding_mutation.BindingMutationPipeline",
+        return_value=pipeline,
     ):
         await cog._ensure_log_channel(guild)
 
-    pipeline_instance.set_value.assert_awaited_once()
-    call = pipeline_instance.set_value.await_args
-    assert call.args[1:4] == ("economy", "economy_log_channel", "12345")
+    pipeline.set_binding.assert_awaited_once()
+    call = pipeline.set_binding.await_args
+    assert call.args[1:5] == ("economy", "log_channel", BindingKind.CHANNEL, 12345)
     assert call.kwargs.get("actor_type") == "system"
 
 
-# ---------------------------------------------------------------------------
-# SettingSpec presence (PR #6 schema addition)
-# ---------------------------------------------------------------------------
-
-
-def test_economy_log_channel_settingspec_declared():
-    """PR #6 added ``economy_log_channel`` to ``ECONOMY_SETTINGS`` so the
-    pipeline accepts writes for it.  Pin the spec shape and validator.
+@pytest.mark.asyncio
+async def test_ensure_log_channel_skips_when_already_bound():
+    """A guild that already has the channel bound (and present) is left
+    alone — no re-create, no re-bind.
     """
-    from cogs.economy.schemas import ECONOMY_SETTINGS
+    from cogs import economy_cog
 
-    by_name = {spec.name: spec for spec in ECONOMY_SETTINGS}
-    assert "economy_log_channel" in by_name, (
-        "economy_log_channel must be declared as a SettingSpec — "
-        "PR #6 promoted it from a direct-write to a pipeline-managed "
-        "scalar."
+    cog = economy_cog.EconomyCog(MagicMock())
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 42
+    guild.get_channel = MagicMock(return_value=MagicMock())  # channel present
+
+    pipeline = MagicMock()
+    pipeline.set_binding = AsyncMock()
+
+    with patch(
+        "core.runtime.config_arbitration.get_economy_log_channel",
+        new=AsyncMock(return_value=SimpleNamespace(value=98765)),
+    ), patch.object(
+        economy_cog.resources,
+        "resolve_channel",
+    ) as resolve_channel, patch(
+        "services.binding_mutation.BindingMutationPipeline",
+        return_value=pipeline,
+    ):
+        await cog._ensure_log_channel(guild)
+
+    guild.get_channel.assert_called_once_with(98765)
+    resolve_channel.assert_not_called()
+    pipeline.set_binding.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# SettingSpec retirement (P0-3 arc PR 2)
+# ---------------------------------------------------------------------------
+
+
+def test_economy_log_channel_settingspec_retired():
+    """P0-3 arc PR 2 retired the ``economy_log_channel`` scalar SettingSpec;
+    the log channel lives in the binding lane now (``economy.log_channel``).
+    """
+    from cogs.economy.schemas import ECONOMY_BINDINGS, ECONOMY_SETTINGS
+
+    assert "economy_log_channel" not in {spec.name for spec in ECONOMY_SETTINGS}, (
+        "economy_log_channel scalar SettingSpec must be retired — the log "
+        "channel lives in the binding lane now (P0-3)."
     )
-    spec = by_name["economy_log_channel"]
-    assert spec.value_type is str
-    assert spec.default == ""
-    assert spec.validator is not None
-    # Empty is allowed (clears the channel).
-    spec.validator("")
-    # Numeric IDs are allowed.
-    spec.validator("1234567890")
-    # Non-numeric non-empty is rejected.
-    with pytest.raises(ValueError):
-        spec.validator("not-a-channel")
+    assert "log_channel" in {b.name for b in ECONOMY_BINDINGS}

--- a/tests/unit/config_arbitration/test_subsystem_accessors.py
+++ b/tests/unit/config_arbitration/test_subsystem_accessors.py
@@ -58,37 +58,14 @@ def _bv(*, kind, target_id, status):
 
 
 @pytest.mark.asyncio
-async def test_xp_announce_channel_flag_off_returns_legacy_string():
-    with (
-        patch(
-            "core.runtime.feature_flags.is_enabled",
-            new_callable=AsyncMock,
-            return_value=False,
-        ),
-        patch(
-            "utils.db.settings.get_setting",
-            new_callable=AsyncMock,
-            return_value="123456",
-        ),
-    ):
-        result = await get_xp_announce_channel(guild_id=1)
-    assert result.value == "123456"
-    assert isinstance(result.value, str)
-    assert result.source == "legacy"
-
-
-@pytest.mark.asyncio
-async def test_xp_announce_channel_flag_on_binding_stringifies_int():
-    """When the binding returns an int, the accessor stringifies it.
-
-    XP callers expect a string (``XpConfig.announce_channel: str``).
+async def test_xp_announce_channel_reads_binding_first_even_when_flag_off():
+    """Retired pointer (P0-3): the accessor forces binding-first and the
+    binding int is stringified — regardless of the global ``bindings.primary``
+    flag, which is *not even consulted*.
     """
+    is_enabled = AsyncMock(return_value=False)  # global flag OFF
     with (
-        patch(
-            "core.runtime.feature_flags.is_enabled",
-            new_callable=AsyncMock,
-            return_value=True,
-        ),
+        patch("core.runtime.feature_flags.is_enabled", new=is_enabled),
         patch(
             "core.runtime.bindings.get_binding",
             new_callable=AsyncMock,
@@ -103,15 +80,45 @@ async def test_xp_announce_channel_flag_on_binding_stringifies_int():
     assert result.value == "999999"
     assert isinstance(result.value, str)
     assert result.source == "binding"
+    is_enabled.assert_not_awaited()  # retired pointer bypasses the flag
+
+
+@pytest.mark.asyncio
+async def test_xp_announce_channel_falls_back_to_legacy_when_unbound():
+    """Binding unbound → legacy KV is the rollback fallback (string)."""
+    with (
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(
+                kind=BindingKind.CHANNEL,
+                target_id=None,
+                status=ResourceStatus.UNRESOLVED,
+            ),
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="123456",
+        ),
+    ):
+        result = await get_xp_announce_channel(guild_id=1)
+    assert result.value == "123456"
+    assert isinstance(result.value, str)
+    assert result.source == "fallback"
 
 
 @pytest.mark.asyncio
 async def test_xp_announce_channel_missing_returns_none():
     with (
         patch(
-            "core.runtime.feature_flags.is_enabled",
+            "core.runtime.bindings.get_binding",
             new_callable=AsyncMock,
-            return_value=False,
+            return_value=_bv(
+                kind=BindingKind.CHANNEL,
+                target_id=None,
+                status=ResourceStatus.UNRESOLVED,
+            ),
         ),
         patch(
             "utils.db.settings.get_setting",
@@ -130,33 +137,11 @@ async def test_xp_announce_channel_missing_returns_none():
 
 
 @pytest.mark.asyncio
-async def test_economy_log_channel_flag_off_parses_legacy_to_int():
+async def test_economy_log_channel_reads_binding_first_even_when_flag_off():
+    """Retired pointer (P0-3): binding-first int, flag bypassed."""
+    is_enabled = AsyncMock(return_value=False)
     with (
-        patch(
-            "core.runtime.feature_flags.is_enabled",
-            new_callable=AsyncMock,
-            return_value=False,
-        ),
-        patch(
-            "utils.db.settings.get_setting",
-            new_callable=AsyncMock,
-            return_value="777777",
-        ),
-    ):
-        result = await get_economy_log_channel(guild_id=1)
-    assert result.value == 777777
-    assert isinstance(result.value, int)
-    assert result.source == "legacy"
-
-
-@pytest.mark.asyncio
-async def test_economy_log_channel_flag_on_returns_binding_int():
-    with (
-        patch(
-            "core.runtime.feature_flags.is_enabled",
-            new_callable=AsyncMock,
-            return_value=True,
-        ),
+        patch("core.runtime.feature_flags.is_enabled", new=is_enabled),
         patch(
             "core.runtime.bindings.get_binding",
             new_callable=AsyncMock,
@@ -169,7 +154,34 @@ async def test_economy_log_channel_flag_on_returns_binding_int():
     ):
         result = await get_economy_log_channel(guild_id=1)
     assert result.value == 999
+    assert isinstance(result.value, int)
     assert result.source == "binding"
+    is_enabled.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_economy_log_channel_falls_back_to_legacy_when_unbound():
+    """Binding unbound → legacy KV fallback, parsed to int."""
+    with (
+        patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(
+                kind=BindingKind.CHANNEL,
+                target_id=None,
+                status=ResourceStatus.UNRESOLVED,
+            ),
+        ),
+        patch(
+            "utils.db.settings.get_setting",
+            new_callable=AsyncMock,
+            return_value="777777",
+        ),
+    ):
+        result = await get_economy_log_channel(guild_id=1)
+    assert result.value == 777777
+    assert isinstance(result.value, int)
+    assert result.source == "fallback"
 
 
 @pytest.mark.asyncio
@@ -177,9 +189,13 @@ async def test_economy_log_channel_unparseable_legacy_becomes_missing():
     """A legacy KV holding junk that can't be int-parsed should not crash."""
     with (
         patch(
-            "core.runtime.feature_flags.is_enabled",
+            "core.runtime.bindings.get_binding",
             new_callable=AsyncMock,
-            return_value=False,
+            return_value=_bv(
+                kind=BindingKind.CHANNEL,
+                target_id=None,
+                status=ResourceStatus.UNRESOLVED,
+            ),
         ),
         patch(
             "utils.db.settings.get_setting",
@@ -257,14 +273,27 @@ async def test_counters_increment_across_accessors():
             return_value=False,
         ),
         patch(
+            "core.runtime.bindings.get_binding",
+            new_callable=AsyncMock,
+            return_value=_bv(
+                kind=BindingKind.CHANNEL,
+                target_id=None,
+                status=ResourceStatus.UNRESOLVED,
+            ),
+        ),
+        patch(
             "utils.db.settings.get_setting",
             new_callable=AsyncMock,
             return_value="123",
         ),
     ):
-        await get_xp_announce_channel(guild_id=1)
-        await get_economy_log_channel(guild_id=1)
-        await get_trusted_tier_role(guild_id=1)
+        await get_xp_announce_channel(guild_id=1)  # retired → forced binding-first
+        await get_economy_log_channel(guild_id=1)  # retired → forced binding-first
+        await get_trusted_tier_role(guild_id=1)  # flag-gated → honours OFF flag
     snap = config_arbitration.counters_snapshot()
     assert snap["calls_total"] == 3
-    assert snap["by_flag_state"]["off"] == 3
+    # The two retired pointers force binding-primary (flag_state on, falling
+    # back to legacy as the binding is unbound); the governance role pointer
+    # still honours the (off) global flag.
+    assert snap["by_flag_state"]["on"] == 2
+    assert snap["by_flag_state"]["off"] == 1

--- a/tests/unit/invariants/test_pointer_lane_ledger.py
+++ b/tests/unit/invariants/test_pointer_lane_ledger.py
@@ -49,12 +49,16 @@ _COGS_DIR = _REPO_ROOT / "disbot" / "cogs"
 # (or removing it) is a convergence step the P0-3 plan governs.
 # ---------------------------------------------------------------------------
 
-CONVERGEABLE_POINTERS: frozenset[str] = frozenset(
-    {
-        "economy.economy_log_channel",  # → economy.log_channel (declared)
-        "xp.xp_announce_channel",  # → xp.announce_channel (declared)
-    },
-)
+# Empty since P0-3 arc PR 2 (2026-06-13): the two convergeable pointers
+# (``economy.economy_log_channel`` → ``economy.log_channel`` and
+# ``xp.xp_announce_channel`` → ``xp.announce_channel``) were *retired* —
+# their editable scalar SettingSpecs were deleted, so they are no longer
+# registered pointer settings.  Their bindings are now the sole write
+# surface (read binding-first via ``config_arbitration`` with
+# ``pointer_retired=True``); the legacy KV stays as the rollback fallback.
+# A new convergeable pointer (a scalar whose binding home is declared and
+# in ``MIGRATED_KEYS``) would be listed here until its own retirement.
+CONVERGEABLE_POINTERS: frozenset[str] = frozenset()
 
 DEFERRED_POINTERS: frozenset[str] = frozenset(
     {
@@ -184,4 +188,38 @@ def test_convergeable_and_deferred_match_backfill_registries():
     assert not bad_deferred, (
         "DEFERRED_POINTERS whose key is not in DEFERRED_KEYS "
         f"(un-homed): {bad_deferred}"
+    )
+
+
+def test_no_dual_declared_pointer():
+    """A ``MIGRATED_KEYS`` pointer must not also be a registered scalar setting.
+
+    Once a pointer's binding home is declared (it graduated into
+    ``MIGRATED_KEYS``), its editable scalar ``SettingSpec`` is retired so the
+    binding is the single operator-visible truth — the P0-3 convergence.  A
+    scalar still registered for a migrated key is the "two operator-visible
+    truths" bug this ratchet prevents (a future agent who adds a binding home
+    but forgets to delete the scalar fails here).
+
+    ``DEFERRED_KEYS`` are intentionally excluded: their binding has no schema
+    home yet, so they *keep* their scalar by design (the moderation
+    trusted/moderator role pointers).  This invariant could only be added
+    *after* the live duals were gone — it ships with arc PR 2, which retired
+    the XP-announce + economy-log scalars.
+    """
+    from core.runtime.subsystem_schema import all_schemas
+    from services.binding_backfill import MIGRATED_KEYS
+
+    _pointer_settings()  # ensure every cog schema is registered
+    schemas = all_schemas()
+    registered_keys = {
+        s.settings_key for schema in schemas.values() for s in schema.settings
+    }
+    migrated_keys = {mk.legacy_key for mk in MIGRATED_KEYS}
+    duals = sorted(migrated_keys & registered_keys)
+    assert not duals, (
+        "These legacy keys are in MIGRATED_KEYS (their binding home is "
+        "declared) but STILL have a registered scalar SettingSpec — retire "
+        "the scalar so the binding is the single operator-visible truth "
+        "(P0-3 pointer-lane convergence):\n" + "\n".join(f"  {k}" for k in duals)
     )

--- a/tests/unit/scripts/test_settings_lane_matrix.py
+++ b/tests/unit/scripts/test_settings_lane_matrix.py
@@ -64,13 +64,13 @@ def test_known_pointers_are_classified_correctly(matrix_mod):
     m = matrix_mod.build_matrix()
     by_name = {f"{p.subsystem}.{p.setting_name}": p for p in m.pointers}
 
-    # Economy/XP log+announce are homed (binding declared).
-    assert by_name["economy.economy_log_channel"].disposition == (
-        "binding_backed_convergeable"
-    )
-    assert by_name["xp.xp_announce_channel"].disposition == (
-        "binding_backed_convergeable"
-    )
-    # Governance role pointers are deferred (reserved-namespace, no home).
+    # XP-announce + economy-log were RETIRED (P0-3 arc PR 2): their scalar
+    # SettingSpecs are deleted, so they are no longer pointer settings at
+    # all — the binding lane is their sole home now.
+    assert "economy.economy_log_channel" not in by_name
+    assert "xp.xp_announce_channel" not in by_name
+
+    # Governance role pointers are still deferred (reserved-namespace, no
+    # schema home yet — Q-0119); their scalars remain until a home is picked.
     assert by_name["moderation.trusted_role"].disposition == "binding_backed_deferred"
     assert by_name["moderation.trusted_role"].target_binding_declared is False

--- a/tests/unit/views/test_settings_input_hint_dispatch.py
+++ b/tests/unit/views/test_settings_input_hint_dispatch.py
@@ -192,7 +192,9 @@ async def test_unknown_input_hint_falls_through_to_default_routing():
 
 
 def test_channel_view_has_select_and_clear_button():
-    view = ChannelSettingSelectView("xp", "xp_announce_channel", None)
+    # (Uses a still-live channel setting; xp_announce_channel was retired
+    # to the binding lane in P0-3.)
+    view = ChannelSettingSelectView("moderation", "public_log_channel", None)
     types = {type(c).__name__ for c in view.children}
     assert "_ChannelPickSelect" in types
     assert "_ClearChannelButton" in types
@@ -263,15 +265,8 @@ def test_presets_view_truncates_when_too_many_presets():
 
 
 # ---------------------------------------------------------------------------
-# Existing channel SettingSpecs opted in (PR #7 wiring sanity)
+# Channel SettingSpec wiring (PR #7) + the P0-3 pointer-lane retirement
 # ---------------------------------------------------------------------------
-
-
-def test_xp_announce_channel_uses_channel_hint():
-    from cogs.xp.schemas import XP_SETTINGS
-
-    by_name = {spec.name: spec for spec in XP_SETTINGS}
-    assert by_name["xp_announce_channel"].input_hint == "channel"
 
 
 def test_xp_cooldown_uses_numeric_presets_hint():
@@ -282,8 +277,19 @@ def test_xp_cooldown_uses_numeric_presets_hint():
     assert len(by_name["xp_cooldown"].presets) > 0
 
 
-def test_economy_log_channel_uses_channel_hint():
-    from cogs.economy.schemas import ECONOMY_SETTINGS
+def test_retired_channel_pointers_are_not_scalar_settings():
+    """P0-3 arc PR 2 retired the ``xp_announce_channel`` +
+    ``economy_log_channel`` scalar SettingSpecs, so the channel
+    input-hint dispatch no longer surfaces them.  They live in the
+    binding lane now (``xp.announce_channel`` / ``economy.log_channel``);
+    the no-dual-declared-pointer invariant pins that they are not also
+    scalars.
+    """
+    from cogs.economy.schemas import ECONOMY_BINDINGS, ECONOMY_SETTINGS
+    from cogs.xp.schemas import XP_BINDINGS, XP_SETTINGS
 
-    by_name = {spec.name: spec for spec in ECONOMY_SETTINGS}
-    assert by_name["economy_log_channel"].input_hint == "channel"
+    assert "xp_announce_channel" not in {s.name for s in XP_SETTINGS}
+    assert "economy_log_channel" not in {s.name for s in ECONOMY_SETTINGS}
+    # The binding is the canonical pointer home.
+    assert "announce_channel" in {b.name for b in XP_BINDINGS}
+    assert "log_channel" in {b.name for b in ECONOMY_BINDINGS}

--- a/tests/unit/views/test_xp_config_modals_use_pipeline.py
+++ b/tests/unit/views/test_xp_config_modals_use_pipeline.py
@@ -1,23 +1,28 @@
-"""Regression tests for PR #5 — XP config modals use SettingsMutationPipeline.
+"""Regression tests for the XP config modal write paths.
 
-Pre-PR-#5 the three XP config modals (range / cooldown / channel)
-called ``db.set_setting`` directly and then manually invoked
-``invalidate_xp_config``. PR #5 routes each write through
-``services.settings_mutation.SettingsMutationPipeline`` so the
+The **range / cooldown** modals write through
+``services.settings_mutation.SettingsMutationPipeline`` (PR #5) so the
 mutation lands with audit + per-key cache invalidation + event
 emission; the modal still pokes ``invalidate_xp_config`` afterward
 because the legacy composite ``XpConfig`` accessor is a separate
 cache that the pipeline doesn't know about.
 
-These tests pin the new contract by:
+The **channel** modal moved to
+``services.binding_mutation.BindingMutationPipeline`` in the P0-3
+pointer-lane convergence (arc PR 2): the ``xp_announce_channel``
+scalar SettingSpec was retired and the announce channel now lives in
+the binding lane (``xp.announce_channel``).  An empty input clears the
+binding; a numeric ID sets it.  The modal still pokes
+``invalidate_xp_config`` so the on_message hot-path cache re-reads the
+(binding-first) channel.
+
+These tests pin the contract by:
 
 * Asserting the modals do not import ``db.set_setting``.
-* Patching ``SettingsMutationPipeline.set_value`` and verifying each
-  modal's ``on_submit`` calls it with the expected ``(subsystem,
-  name, value)`` triple for valid inputs.
+* Patching the pipeline / helper and verifying each modal's
+  ``on_submit`` drives it with the expected arguments for valid inputs.
 * Verifying ``invalidate_xp_config(guild.id)`` is called after a
-  successful pipeline write so the legacy hot-path cache stays
-  fresh.
+  successful write so the legacy hot-path cache stays fresh.
 * Verifying validation failures stay ephemeral (no pipeline call,
   no cache poke) for non-numeric / non-positive inputs.
 """
@@ -263,7 +268,10 @@ async def test_xp_cooldown_modal_writes_cooldown():
 
 
 @pytest.mark.asyncio
-async def test_xp_channel_modal_writes_channel_string():
+async def test_xp_channel_modal_drives_binding_helper():
+    """The channel modal passes its raw input to the binding helper
+    (which validates + sets/clears the xp.announce_channel binding).
+    """
     from views.xp import modals as xp_modals
 
     fake_view = MagicMock()
@@ -276,7 +284,7 @@ async def test_xp_channel_modal_writes_channel_string():
 
     with patch.object(
         xp_modals,
-        "_set_xp_setting_via_pipeline",
+        "_set_xp_announce_channel_via_binding",
         new=AsyncMock(return_value=True),
     ) as helper, patch.object(
         xp_modals,
@@ -286,67 +294,134 @@ async def test_xp_channel_modal_writes_channel_string():
         await modal.on_submit(interaction)
 
     helper.assert_awaited_once()
-    assert helper.await_args.args[1:] == ("xp_announce_channel", "1234567890")
+    assert helper.await_args.args[1] == "1234567890"
     fake_view._rerender.assert_awaited_once()
 
 
+# ---------------------------------------------------------------------------
+# Channel binding helper (_set_xp_announce_channel_via_binding) — P0-3
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
-async def test_xp_channel_modal_writes_empty_string_to_clear():
-    """Empty input clears the channel — passed through to the pipeline
-    as ``""`` (the SettingSpec validator accepts empty).
-    """
+async def test_announce_helper_sets_binding_for_numeric_input():
+    from core.runtime.subsystem_schema import BindingKind
     from views.xp import modals as xp_modals
 
-    fake_view = MagicMock()
-    fake_view._rerender = AsyncMock()
-    modal = xp_modals._XpChannelModal(fake_view)
-    modal.channel_id = MagicMock()
-    modal.channel_id.value = "  "
+    interaction = _modal_interaction()
+    pipeline = MagicMock()
+    pipeline.set_binding = AsyncMock(return_value=MagicMock())
+    pipeline.clear_binding = AsyncMock(return_value=MagicMock())
+
+    with patch(
+        "services.binding_mutation.BindingMutationPipeline",
+        return_value=pipeline,
+    ), patch.object(xp_modals, "invalidate_xp_config") as inv:
+        ok = await xp_modals._set_xp_announce_channel_via_binding(
+            interaction,
+            " 1234567890 ",
+        )
+
+    assert ok is True
+    pipeline.set_binding.assert_awaited_once_with(
+        interaction.guild,
+        "xp",
+        "announce_channel",
+        BindingKind.CHANNEL,
+        1234567890,
+        interaction.user,
+    )
+    pipeline.clear_binding.assert_not_called()
+    inv.assert_called_once_with(99)
+
+
+@pytest.mark.asyncio
+async def test_announce_helper_clears_binding_on_blank_input():
+    from core.runtime.subsystem_schema import BindingKind
+    from views.xp import modals as xp_modals
 
     interaction = _modal_interaction()
+    pipeline = MagicMock()
+    pipeline.set_binding = AsyncMock(return_value=MagicMock())
+    pipeline.clear_binding = AsyncMock(return_value=MagicMock())
 
-    with patch.object(
-        xp_modals,
-        "_set_xp_setting_via_pipeline",
-        new=AsyncMock(return_value=True),
-    ) as helper, patch.object(
-        xp_modals,
-        "safe_defer",
-        new=AsyncMock(return_value=True),
-    ):
-        await modal.on_submit(interaction)
+    with patch(
+        "services.binding_mutation.BindingMutationPipeline",
+        return_value=pipeline,
+    ), patch.object(xp_modals, "invalidate_xp_config") as inv:
+        ok = await xp_modals._set_xp_announce_channel_via_binding(interaction, "   ")
 
-    helper.assert_awaited_once()
-    assert helper.await_args.args[1:] == ("xp_announce_channel", "")
-
-
-# ---------------------------------------------------------------------------
-# SettingSpec presence (PR #5 schema addition)
-# ---------------------------------------------------------------------------
-
-
-def test_xp_announce_channel_settingspec_declared():
-    """PR #5 added ``xp_announce_channel`` to ``XP_SETTINGS`` so the
-    pipeline accepts writes for it. Pin the declaration and the
-    validator's empty-or-numeric contract via the schema, not the
-    modal.
-    """
-    from cogs.xp.schemas import XP_SETTINGS
-
-    by_name = {spec.name: spec for spec in XP_SETTINGS}
-    assert "xp_announce_channel" in by_name, (
-        "xp_announce_channel must be declared as a SettingSpec — "
-        "PR #5 promoted it from a direct-write to a pipeline-managed "
-        "scalar."
+    assert ok is True
+    pipeline.clear_binding.assert_awaited_once_with(
+        interaction.guild,
+        "xp",
+        "announce_channel",
+        BindingKind.CHANNEL,
+        interaction.user,
     )
-    spec = by_name["xp_announce_channel"]
-    assert spec.value_type is str
-    assert spec.default == ""
-    assert spec.validator is not None
-    # Empty is allowed.
-    spec.validator("")
-    # Numeric IDs are allowed.
-    spec.validator("1234567890")
-    # Non-numeric non-empty is rejected.
-    with pytest.raises(ValueError):
-        spec.validator("not-a-channel")
+    pipeline.set_binding.assert_not_called()
+    inv.assert_called_once_with(99)
+
+
+@pytest.mark.asyncio
+async def test_announce_helper_rejects_non_numeric_without_writing():
+    from views.xp import modals as xp_modals
+
+    interaction = _modal_interaction()
+    pipeline = MagicMock()
+    pipeline.set_binding = AsyncMock()
+    pipeline.clear_binding = AsyncMock()
+
+    with patch(
+        "services.binding_mutation.BindingMutationPipeline",
+        return_value=pipeline,
+    ), patch.object(xp_modals, "invalidate_xp_config") as inv:
+        ok = await xp_modals._set_xp_announce_channel_via_binding(
+            interaction,
+            "not-a-channel",
+        )
+
+    assert ok is False
+    pipeline.set_binding.assert_not_called()
+    pipeline.clear_binding.assert_not_called()
+    inv.assert_not_called()
+    sent = interaction.response.send_message.await_args
+    assert sent.kwargs.get("ephemeral") is True
+
+
+@pytest.mark.asyncio
+async def test_announce_helper_returns_false_on_dm():
+    from views.xp import modals as xp_modals
+
+    interaction = MagicMock()
+    interaction.guild = None
+    interaction.response.send_message = AsyncMock()
+
+    with patch(
+        "services.binding_mutation.BindingMutationPipeline",
+    ) as pipeline_cls, patch.object(xp_modals, "invalidate_xp_config") as inv:
+        ok = await xp_modals._set_xp_announce_channel_via_binding(interaction, "123")
+
+    assert ok is False
+    pipeline_cls.assert_not_called()
+    inv.assert_not_called()
+    interaction.response.send_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# SettingSpec retirement (P0-3 arc PR 2)
+# ---------------------------------------------------------------------------
+
+
+def test_xp_announce_channel_settingspec_retired():
+    """P0-3 arc PR 2 retired the ``xp_announce_channel`` scalar SettingSpec;
+    the announce channel is a binding now (``xp.announce_channel``).  Pin
+    that the scalar is gone and the binding is its replacement home.
+    """
+    from cogs.xp.schemas import XP_BINDINGS, XP_SETTINGS
+
+    assert "xp_announce_channel" not in {spec.name for spec in XP_SETTINGS}, (
+        "xp_announce_channel scalar SettingSpec must be retired — the "
+        "announce channel lives in the binding lane now (P0-3)."
+    )
+    assert "announce_channel" in {b.name for b in XP_BINDINGS}


### PR DESCRIPTION
## What

P0-3 **arc PR 2** of the [settings pointer-lane convergence plan](https://github.com/menno420/superbot/blob/main/docs/planning/settings-pointer-lane-convergence-plan-2026-06-13.md) §3 — retire the two `binding_backed_convergeable` pointer settings so each Discord-resource pointer has **one canonical binding owner** (no parallel editable scalar):

| Retired scalar | Now lives in |
|---|---|
| `xp.xp_announce_channel` | `xp.announce_channel` binding |
| `economy.economy_log_channel` | `economy.log_channel` binding |

## Why a design refinement was needed (read this)

The plan framed arc PR 2 as "delete the scalar SettingSpec, keep legacy KV readable". But the read path (`config_arbitration.read_config`) only consults the **binding** when the global `bindings.primary` flag is ON — and that flag is **`default=False` and not yet flipped in production** ("flipped after binding backfill verifies on production guilds"). So binding-only writes after retirement would be **invisible to reads** with the flag OFF — a latent production break gated on a manual maintainer flag flip.

**Fix (Design A):** a *retired* pointer reads **binding-first unconditionally** — it has completed its transition, so the binding is authoritative by definition. New `pointer_retired=True` arg on `read_config`; the two retired accessors pass it. The global flag still governs **in-transition** keys (the governance role pointers, which are DEFERRED). Legacy KV remains the rollback fallback (binding UNRESOLVED → legacy). This makes the retirement **safe to deploy with no coordinated flag flip** — the maintainer just merges + deploys.

> **Rollback-semantics refinement to the plan:** for a *retired* key, the rollback is **not** "flip `bindings.primary` OFF" (that flag no longer governs it) — it's the still-live **legacy-KV fallback** + PR revert (the legacy column is never deleted). The plan's §6 rollback line is updated accordingly.

## Changes

- **`config_arbitration`** — `pointer_retired=True` → binding-first regardless of the canary flag; `get_xp_announce_channel` / `get_economy_log_channel` opt in. Additive (`read_config` default `False` preserves all other callers).
- **`binding_mutation`** — `BindingMutationPipeline.set_binding`/`clear_binding` now accept `actor_type` (`'system'`/`'backfill'` bypass the capability check via `actor_holds_capability`, mirroring the settings pipeline). Needed for the economy log-channel auto-provision on join. System writes record the bot's id as the audit `actor_id` since `binding_audit_log.actor_id` is `NOT NULL`; `actor_type` is the discriminator. Backward-compatible (keyword-only, default `'user'`).
- **Writers → binding lane:** XP "Level-up Channel" modal (set / clear), economy `_record_log_channel` (×3: `on_ready` auto-detect, `on_guild_join` auto-create, `!setlogchannel`). **Stale legacy reads → arbitration:** XP config panel embed, economy `_ensure_log_channel` "already configured?" check. (`post_log_embed` + the XP hot-path accessor already read binding-first.)
- **Deleted both scalar `SettingSpec`s** (+ their validators / unused imports). `ECONOMY_SETTINGS` is now empty (`log_channel` binding remains).
- **Adjacent bugs fixed** (surfaced by the convergence): `logging_presets.py` and `channels.py` hint maps keyed the economy/xp channel bindings by their **legacy settings keys** (`economy_log_channel`/`xp_announce_channel`) instead of the real binding names (`log_channel`/`announce_channel`) — so the economy-logs wizard preset was silently filtered out and the channel hints never fired.
- **Ledger:** `CONVERGEABLE_POINTERS` emptied (the two retired keys are no longer pointer settings) + new `test_no_dual_declared_pointer` invariant (a `MIGRATED_KEYS` key must not also be a registered scalar — the "two operant truths" guard; could only be added once the duals were gone).
- Updated ~5 affected test files to pin the new contract.

## Authority parity (no regression)

Both bindings carry the **same `*.settings.configure` capability** the retired scalars required, so the operator authority surface is unchanged. `!setlogchannel` stays admin-gated.

## Verification

- `python3.10 scripts/check_quality.py --full` — **9328 passed, 34 skipped**, lint + mypy clean.
- `python3.10 scripts/check_architecture.py --mode strict` — **0 errors** (79 pre-existing warnings).
- Real-Postgres boot proof of the binding-first read + backfill dry-run — _in progress, will note in a follow-up comment._

No DB migration (binding tables exist since migration 022; legacy KV untouched). Sequenced next: arc PR 3 (delegated-apply authority, Q-0098).

https://claude.ai/code/session_018KXPV2uPJj1MK7JTAf54nx

---
_Generated by [Claude Code](https://claude.ai/code/session_018KXPV2uPJj1MK7JTAf54nx)_