### PR TITLE
chore(settings): persist substrate-kit allowlist to cut permission prompts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,6 +41,9 @@
       "Bash(python3.10 -m isort*)",
       "Bash(python3.10 -m ruff*)",
       "Bash(python3.10 -m mypy*)",
+      "Bash(python3.10 substrate-kit/src/build_bootstrap.py*)",
+      "Bash(python3.10 substrate-kit/dist/bootstrap.py*)",
+      "Bash(mktemp*)",
       "Bash(ls*)",
       "Bash(wc*)",
       "Bash(echo*)",
@@ -55,7 +58,9 @@
       "mcp__github__unsubscribe_pr_activity",
       "mcp__github__get_file_contents",
       "mcp__github__list_commits",
-      "mcp__github__get_commit"
+      "mcp__github__get_commit",
+      "mcp__github__get_job_logs",
+      "mcp__github__actions_list"
     ],
     "ask": [
       "Bash(git push --force*)",


### PR DESCRIPTION
**Fixes the recurring permission prompts for future chats.**

Root cause (diagnosed with the maintainer): tapping **"Always allow"** in the web/app writes to `.claude/settings.local.json`, which is **gitignored and per-container** — every new chat clones the repo into a fresh container *without* it, so the approvals never persisted and the same prompts returned each session.

Fix: add the missing entries to the **committed** `.claude/settings.json` (travels with the repo to every chat). The existing allowlist already covered `git` + `scripts/check_*` + `pytest`/`black`/`isort`/`ruff`/`mypy` + the GitHub/CodeGraph MCP reads; the gap was the **`substrate-kit/` paths** and two read tools. Adds:

- `Bash(python3.10 substrate-kit/src/build_bootstrap.py*)` — regenerate the bootstrap
- `Bash(python3.10 substrate-kit/dist/bootstrap.py*)` — run it (`init`/`render`/`--simulate`)
- `Bash(mktemp*)` — scratch dirs for smokes
- `mcp__github__get_job_logs`, `mcp__github__actions_list` — CI log/run reads

Per the maintainer's in-session `/fewer-permission-prompts` (2026-06-13). Deliberately **not** adding `rm`/`cp` (too broad to bless globally). JSON validated.

https://claude.ai/code/session_013k7YPSDzChSAAWKbaD6fdW

---
_Generated by [Claude Code](https://claude.ai/code/session_013k7YPSDzChSAAWKbaD6fdW)_