### PR TITLE
docs(Q-0119): record owner decision — governance role pointers get a reserved schema home

### DIFF
--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -373,8 +373,10 @@ Source code and merged PRs win over anything written here.
   deterministic list-builders, plan-level) and **BUG-0011** (Hermes gateway restart crash-loop — needs
   a clean VPS foreground repro) stay OPEN — [`health/bug-book.md`](health/bug-book.md).
 - **Open decisions:** **Q-0096** remainder (Context7 adopted #737; **Postgres-MCP + `pyright-lsp`**
-  undecided) · **Q-0119** (governance role-pointer home, P0-3 family 3) · **Q-0120/Q-0121** (this
-  workflow pass's proposals — candidate-rule promotion · Hermes bug-triage `gh issue create` write).
+  undecided) · **Q-0120/Q-0121** (the workflow pass's proposals — candidate-rule promotion · Hermes
+  bug-triage `gh issue create` write). *(**Q-0119 answered 2026-06-13** → governance role pointers
+  get their own reserved-namespace `governance` schema home (option a); P0-3 family 3 is unblocked
+  for a future arc PR — router §Q-0119 + the [convergence plan §5](planning/settings-pointer-lane-convergence-plan-2026-06-13.md).)*
 - **AI / BTD6 feature expansion — re-postured 2026-06-09 (Q-0048):** AI tools that are
   **read-only AND deterministic** (no writes, no external calls, audience-tiered) carry a
   **standing lift** and may ship without a per-case ask. Anything that **writes, costs

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -4488,9 +4488,18 @@ prompt.
 
 ### Q-0119 — Where do the governance role-pointer bindings live? (P0-3 family 3)
 
-> **OPEN — awaiting owner decision (DISCUSS lane).** Raised 2026-06-13 during the P0-3
-> settings pointer-lane convergence session. No code until the owner picks; reads keep
-> working via the legacy scalar meanwhile (deferred, not broken).
+> **ANSWERED 2026-06-13 (owner, structured-choices round) → option (a), the reserved-schema
+> path.** Raised 2026-06-13 during the P0-3 convergence session (#794); decided same day in a
+> follow-up `AskUserQuestion` round. **Verbatim choice: "Give authority its own home."** Give
+> server-wide authority settings their own reserved-namespace `governance` schema home — *not*
+> re-home under `moderation` (b), *not* a permanent legacy exception (c).
+>
+> **Answer scope:** unblocks pointer-family 3 (the governance trusted/moderator role pointers)
+> for a future P0-3 arc PR. **No behavior change today** and no code shipped this round — reads
+> keep working via the legacy scalar + the binding ladder; recorded for the next session to
+> execute (teach the identity-contract validator to expect a reserved-namespace `governance`
+> schema, declare the two role bindings there, graduate the keys `DEFERRED_KEYS` → `MIGRATED_KEYS`,
+> and retire the scalars with `pointer_retired=True` like families 1+2).
 
 **Area:** Settings/bindings lane integrity · governance authority namespace
 **Type:** Architecture decision (blocks pointer-family 3 convergence)
@@ -4518,8 +4527,8 @@ finding). This session **reframed** the backfill (the two governance role keys m
   governance-tier scalars, exempt from the lane rule. Cheapest; abandons lane uniformity.
 
 **Home:** `docs/planning/settings-pointer-lane-convergence-plan-2026-06-13.md` §5 (full
-analysis + the family-3 gate); this entry is the router pointer. On decision, record it here
-and execute in the P0-3 arc.
+analysis + the family-3 gate); this entry is the router pointer. **Decided → option (a);**
+execute in a future P0-3 arc PR (family 3).
 
 ### Q-0120 — Promote the earned candidate rules from `.session-journal.md` into `.claude/CLAUDE.md`?
 

--- a/docs/planning/settings-pointer-lane-convergence-plan-2026-06-13.md
+++ b/docs/planning/settings-pointer-lane-convergence-plan-2026-06-13.md
@@ -100,7 +100,7 @@ rollback (flip `bindings.primary` OFF). Ordered by risk (lowest first):
 |---|---|---|---|---|
 | 1 | **XP announce** | `xp.xp_announce_channel` → `xp.announce_channel` | ✅ **Retired (#794)** | Reference retirement; lowest blast radius. |
 | 2 | **Economy log** | `economy.economy_log_channel` → `economy.log_channel` | ✅ **Retired (#794)** | Retired with family 1 in arc PR 2. |
-| 3 | **Governance role pointers** | `moderation.{trusted,moderator}_role` → `governance.{trusted,moderator}_role` | **Blocked on Q-0119** (no schema home) | The hardest case; touches authority tiers. Do *not* retire until the home is decided. |
+| 3 | **Governance role pointers** | `moderation.{trusted,moderator}_role` → `governance.{trusted,moderator}_role` | **Q-0119 DECIDED → (a)**: reserved-namespace `governance` schema home. Ready to build. | The hardest case; touches authority tiers — declare the reserved schema + bindings, then retire with `pointer_retired=True`. |
 | 4 | **Welcome/counters orphans** | `welcome.channel`, `welcome.entry_role`, `counters.{total,humans,bots}_channel` | **Not started** — no binding declared | Each needs a `BindingSpec` + backfill mapping minted first. Lower priority (new, low-traffic). |
 | 5 | **Moderation public-log + logging fallbacks** | `moderation.public_log_channel`; `LOGGING_MOD_CHANNEL`/`LOGGING_CLEANUP_CHANNEL` fallbacks | **Not started** | `moderation.public_log_channel` has no binding; the logging fallbacks shadow 7 canonical bindings. |
 
@@ -204,7 +204,13 @@ family 3 is blocked on (routed to the owner as **Q-0119**, DISCUSS lane):
 
 Recommendation in the Q-block: **(a)** — it keeps governance authority in the
 governance namespace and generalizes (future reserved bindings get a home), at
-the cost of one validator allowlist. No code until the owner picks.
+the cost of one validator allowlist.
+
+> **DECIDED 2026-06-13 (owner) → option (a), "give authority its own home".** Family 3
+> is unblocked: a future P0-3 arc PR teaches the identity-contract validator to expect a
+> reserved-namespace `governance` schema, declares the `trusted_role`/`moderator_role`
+> bindings there, graduates the keys `DEFERRED_KEYS` → `MIGRATED_KEYS`, and retires the
+> scalars with `pointer_retired=True` (the families-1+2 pattern). Router Q-0119.
 
 ---
 
@@ -239,7 +245,7 @@ Run on a real guild + Postgres after arc PR 2 (extends the
 | **1 (this PR)** | Matrix tool · backfill reframe (Required #2) · 2 parity invariants · this plan · Q-0119 | shipped, behavior-preserving |
 | **2 (#794) ✅** | Retired XP-announce + economy-log scalars (families 1+2) · `test_no_dual_declared_pointer` invariant · `pointer_retired` binding-first decoupling · real-Postgres proof | DONE |
 | **3 (next)** | Delegated-apply contract (§4) — the `setup_delegate` actor_type + AST fence + audit | Q-0098 (answered); design pinned in §4 |
-| *(later)* | Families 3–5 (governance roles per Q-0119 · welcome/counters/mod-public-log bindings) | family 3 gated on Q-0119 |
+| *(later)* | Families 3–5 (governance roles · welcome/counters/mod-public-log bindings) | family 3 **ready** (Q-0119 → reserved `governance` schema); 4–5 need new `BindingSpec`s minted first |
 | *(later)* | **Sunset the global `bindings.primary` flag** — once every pointer family is retired (each binding-first via `pointer_retired=True`) and the non-pointer migrated keys are homed (Q-0119), the global canary governs nothing and can be removed. Arc PR 2 proved the per-key model is cleaner + safer to deploy than a guild-wide flip. | after families 3–5 + Q-0119 |
 
 P0-3's **P1-3 follow-up** (declared-setting → runtime-consumer disposition


### PR DESCRIPTION
## What

Records the owner's answer to **Q-0119** (decided in-session via a structured-choices round, following P0-3 arc PR 2 / #794).

**Decision — option (a), "give authority its own home":** the server-wide governance trusted/moderator role pointers get their own **reserved-namespace `governance` `SubsystemSchema` home** — *not* re-homed under `moderation` (b), *not* a permanent legacy exception (c).

This **unblocks P0-3 family 3** (the governance role pointers). A future arc PR will: teach the identity-contract validator to expect a reserved-namespace `governance` schema, declare the `trusted_role`/`moderator_role` bindings there, graduate the keys `DEFERRED_KEYS` → `MIGRATED_KEYS`, and retire the scalars with `pointer_retired=True` (the families-1+2 pattern from #794).

**No code or behavior change** this round — reads keep working via the legacy scalar + the binding ladder. This is the durable record so the next session can execute.

## Changes (docs only)

- **router Q-0119:** `OPEN` → `ANSWERED` (verbatim choice + answer-scope line).
- **convergence plan §3/§5/§7:** family 3 marked ready (Q-0119 → a).
- **current-state:** Q-0119 moved out of "Open decisions".

`check_docs --strict` ✓ · `check_current_state_ledger --strict` ✓.

https://claude.ai/code/session_018KXPV2uPJj1MK7JTAf54nx

---
_Generated by [Claude Code](https://claude.ai/code/session_018KXPV2uPJj1MK7JTAf54nx)_