### PR TITLE
docs(journal): capture two earned calibration rules (act-vs-ask · auto-merge race)

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -451,6 +451,28 @@ PR #676; drift surfaced at boot + `!btd6 status`). Full note:
   source" rule applies to your own prior session's notes too, not just Codex/ChatGPT.
 
 ### Cross-agent & git workflow
+- **★-candidate — Derive the clean/durable answer; don't surface it as an owner
+  question when the documented principles already settle it (2026-06-13, Q-0119).**
+  When a decision reduces to "the clean / durable / root-cause / one-source-of-truth
+  fix vs. cheaper-but-inconsistent alternatives," the working agreement *already
+  determines* it — **decide the clean option and record it as a _derived_ decision**
+  (with the rationale + which principle drove it), rather than handing the owner a
+  multiple-choice. **"Architectural" is not itself an ask-trigger**; ask only when the
+  principles genuinely don't disambiguate (a real product / taste / cost fork, or
+  something irreversible). This also covers an *inherited* OPEN router Q a prior
+  session over-deferred — close it by derivation. (Miss: surfaced Q-0119's (a)/(b)/(c)
+  where (a) was both the documented clean home *and* my own recommendation; owner
+  flagged it should have been derived. CLAUDE.md is already explicit — "if you're about
+  to offer options you expect rejected, you've answered your own question — act.")
+- **★-candidate — With native auto-merge armed, land ALL commits (code AND docs)
+  before CI goes green (2026-06-13, #794→#797).** `auto-merge-enabler` arms native
+  auto-merge at PR-open and GitHub merges the instant `code-quality` passes —
+  server-side, ~15s. Docs / session-log commits pushed *after* the first green strand
+  on the branch post-merge and need a recovery follow-up PR (#794 merged at its first
+  head before the docs landed → had to open #797). So either **bundle docs into the
+  same push as code**, or run the doc-freshness + session-log step *before* the first
+  push. (Successor to the Q-0093 "merge in-turn" lesson, which predates native
+  auto-merge.)
 - **Never stamp a PR number you haven't created (3 mis-stamps on 2026-06-10:**
   **#673→ok, #677→#678, #680→#682).** Parallel sessions consume numbers, so a
   guessed "next" number is wrong whenever anyone else ships. Order: push →


### PR DESCRIPTION
## What

Two ★-candidate rules added to `.session-journal.md` (the documented earned-rule → CLAUDE.md promotion pipeline, tracked by Q-0120 — *not* self-edits to a binding rule):

1. **Derive the clean/durable answer; don't ask when the principles already settle it.** When a decision reduces to "clean/root-cause/one-source-of-truth fix vs. cheaper-but-inconsistent," the working agreement already determines it — decide and record it as a *derived* decision. "Architectural" is not itself an ask-trigger. **Provenance:** the owner's feedback on Q-0119 this session — I surfaced (a)/(b)/(c) where (a) was both the documented clean home and my own recommendation, which is exactly the "options you expect rejected" case CLAUDE.md says to just act on.

2. **With native auto-merge armed, land all commits (code + docs) before CI goes green.** `auto-merge-enabler` merges server-side ~15s after `code-quality` passes, so late docs/session-log commits strand and need a recovery PR. **Provenance:** #794 merged at its first head before the docs landed → had to open #797 to recover.

Docs-only; `check_docs --strict` passes locally.

https://claude.ai/code/session_018KXPV2uPJj1MK7JTAf54nx

---
_Generated by [Claude Code](https://claude.ai/code/session_018KXPV2uPJj1MK7JTAf54nx)_