### PR TITLE
workflow: reconciliation is the routines' job (Q-0124) + disposition stale open PRs (Q-0125)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -190,7 +190,11 @@ is **per-file**. Full convention: `docs/owner/ai-project-workflow.md` §9.
   too often).** PR numbers crossing a **multiple of 20** (#20, #40, #60, …) are reserved for a
   **docs-only review + planning** pass — no runtime / `disbot/` code in it. It does two things:
   **(1) reconcile** — review the living ledger, active lanes, open Q-blocks, idea backlog, and
-  roadmap; prune/archive stale docs; restate the current priorities; and **(2) plan the next ~9
+  roadmap; **disposition open PRs** (via the GitHub MCP — `list_pull_requests` + each one's
+  CI/mergeable state: close redundant/stale ones, fix or flag a red-CI one) — the gap that left
+  #766 (red CI) and #771 (redundant + conflicted) rotting unnoticed across sessions *and* prior
+  reconciliation passes (owner directive Q-0125, 2026-06-13); prune/archive stale docs; restate
+  the current priorities; and **(2) plan the next ~9
   PRs** — what is realistically achievable in the upcoming band of PRs, **modular but not
   over-segmented**: each planned PR should ship a *reasonable, meaningful change* (a real slice),
   **not** a trivial fragment — a small PR is fine only when the change genuinely is small or a
@@ -199,6 +203,11 @@ is **per-file**. Full convention: `docs/owner/ai-project-workflow.md` §9.
   The pass is now **fired automatically** by `.github/workflows/reconciliation-trigger.yml` (opens
   a `reconcile`-labeled issue at the boundary → the **superbot docs reconciliation** routine runs
   it — see `docs/operations/autonomous-routines.md`); reset the marker to the latest PR after the pass.
+  **A manually-started session does NOT run the reconciliation pass — the routines always do it
+  automatically; only run it in a manual session if the owner explicitly asks (owner directive
+  Q-0124, 2026-06-13).** The SessionStart `Recon: DUE` banner is a signal for the routine, not an
+  instruction to a human-started session — a manual session should pursue the work it was started
+  for (e.g. "continue where PR #N ended" = continue *that PR's* lane), not divert into a docs pass.
 - Plans span **2–3 PRs max**: the first PR covers root causes / foundation; subsequent PRs implement on top.
 - **Plan approval = full execution** — once a plan is approved (via **ExitPlanMode**),
   complete it in one session without stopping for confirmation or waiting for merges

--- a/.session-journal.md
+++ b/.session-journal.md
@@ -55,6 +55,7 @@ project state accumulate here.)
 | **Run CI locally before push** | `python3.10 scripts/check_quality.py --full` (true CI mirror) **and** `python3.10 scripts/check_architecture.py --mode strict` (0 errors). Docs touched? `python3.10 scripts/check_docs.py --strict` — CI runs **--strict** (badge/reachability issues hard-fail there but pass plain `check_docs`; bit PR #685). |
 | **Kill a running bot** | `for pid in $(pgrep -f disbot/bot1); do [ "$(cat /proc/$pid/comm)" = python3.10 ] && kill "$pid"; done` (plain `pkill` self-kills the shell). |
 | **Prod down (Railway build failed)** | Read the build log first. `mise … no precompiled python found` = the Python-pin race → [`docs/operations/production-deployment.md`](docs/operations/production-deployment.md) (pin + bump procedure). Postgres "Online" ≠ bot running. |
+| **Orient** (start of session) | **`git fetch origin main` + skim `git log HEAD..origin/main --oneline` FIRST** — the container clone can lag live `main`; a concurrent agent may have merged your exact task (cost a full duplicate recon pass 2026-06-13, #804). **Check open PRs' _health_** (`list_pull_requests` + each one's CI/mergeable state), not just titles — a red/stuck/redundant PR is a bugs-first item to fix or close (Q-0125; #766 sat red + #771 redundant for ~21h, missed by sessions *and* reconciliation). And **a manual session does NOT run the Q-0107 reconciliation pass** — routines do it automatically; the `Recon: DUE` banner is for them (Q-0124). Do the work you were started for. |
 | **Start of work** (first push) | **Open the session PR immediately — READY, not draft** (Q-0052 open-early + Q-0103 ready-not-draft; *corrected 2026-06-12*) — the real PR # is then available for every doc you touch. |
 | **Session sizing (Q-0088)** | Wrap before **~700K context** (owner-observed quality drop at 700–800K): finish the current task, sharpen the handoff, END — don't start another. **No unguided PRs past declared scope** — late discoveries go into the handoff/queue, not the session. Full protocol: `docs/owner/ai-project-workflow.md` §10 (activates with Stage 0). |
 | **End of session** | Drive the session PR to a **terminal state — merged or closed, never left open** (Q-0103; *corrected 2026-06-12*); **contribute 1 new idea you believe in** (`💡 Session idea` in the log — Q-0089, dedup-grep `docs/ideas/` first); write a `.sessions/<date>-<slug>.md` log file (Protocol → END). |
@@ -492,6 +493,14 @@ PR #676; drift surfaced at boot + `!btd6 status`). Full note:
   prepared assets *for* that session but appeared in no orientation doc; the
   session discovered it only at final-merge sync and had to reconcile a
   finished compositor against it. Cheap check, late surprise avoided.
+  **(Reinforced 2026-06-13 — the costliest recurrence yet, #804.)** A manual
+  session built an *entire* Q-0107 reconciliation pass without `git fetch`-ing
+  first; a concurrent routine had already merged the identical pass as **#804**
+  while it worked. The SessionStart banner showed the container's clone at #800
+  while live `main` was at #804. **Run `git fetch origin main` + `git log
+  HEAD..origin/main --oneline` as literally the first action of every session** —
+  before reading orientation docs, not at final sync. The banner's commit is a
+  snapshot, not live truth.
 - **★ Parallel same-plan execution agents are a sanctioned mode (proven 2026-06-09,
   N=4: Lanes 2/3/5/6 → #632/#634/#633/#631).** The binding how-to is
   `docs/owner/ai-project-workflow.md` §9 → "Parallel execution lanes" (subsystem

--- a/docs/operations/autonomous-routines.md
+++ b/docs/operations/autonomous-routines.md
@@ -107,6 +107,11 @@ STEP 2 — RECONCILE (the Q-0107 pass):
   - Docs: run `python3.10 scripts/check_docs.py --strict`; fix every reachability/badge/
     staleness issue + stale links, wrong PR numbers, broken references.
   - Prune/relabel clearly stale docs; restate current priorities in current-state ▶ Next action.
+  - DISPOSITION OPEN PRs (Q-0125): `list_pull_requests` (state=open) + each one's CI/mergeable
+    state. Close the redundant/stale (e.g. a superseded ledger PR), fix or flag a red-CI one
+    (a `check_docs` reachability orphan is usually one missing README link), leave the owner's.
+    "Noting" a PR is not disposition — act on it. (This sweep was missing: #766 sat red + #771
+    redundant for ~21h, unnoticed by sessions and two prior passes.)
   - Plan the next ~9 PRs (the upcoming band) — modular, each a meaningful slice — into the
     decade-queue planning doc, ordered so the highest-value improvements come first.
   - IMPROVE THE SYSTEM: if you see a way to make the orientation / memory / tooling better for

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -4662,3 +4662,68 @@ wording still lives in `docs/operations/autonomous-routines.md` (routine prompts
 
 **Home:** CLAUDE.md SESSION_WORKFLOW (envelope struck → auto-merge bullet); `auto-merge-enabler.yml`
 is the mechanism; this entry is provenance.
+
+### Q-0124 — The Q-0107 reconciliation pass is the routines' job, not a manual session's
+
+> **DIRECTED 2026-06-13 (owner, in-session).** Verbatim: *"please make a note that the
+> reconciliation is always done automatically by the routines so that should not be part of a
+> manually started session unless explicitly asked."* This is the in-session direction Q-0106
+> requires to edit `.claude/CLAUDE.md` directly; this entry is the provenance.
+
+**Area:** Session/PR workflow · the Q-0107 reconciliation cadence · manual-vs-routine task scope
+**Type:** Owner-directed in-session clarification (provenance per Q-0106)
+
+**Problem (the trigger):** a manually-started session ("continue where PR #800 ended") read the
+SessionStart `Recon: DUE` banner + the `current-state` "next pass is due" line and **diverted into
+running the reconciliation pass itself** — which (a) was not what the owner asked (PR #800's lane was
+the P0-3 hardening arc), and (b) duplicated a pass the routine was already running concurrently
+(merged as #804). The banner's wording ("the next session should be a docs-only reconciliation
+pass") read as an instruction to whatever session saw it.
+
+**Decision:**
+> The docs-only Q-0107 reconciliation pass is **always run automatically by the routines** (the
+> `reconcile`-issue trigger → the *superbot docs reconciliation* routine). A **manually-started
+> session does NOT run it unless the owner explicitly asks**; it pursues the work it was started for.
+> The `Recon: DUE` banner is a signal *for the routine*, not an instruction to a human-started
+> session.
+
+**Applied this session (provenance = this Q):** CLAUDE.md Q-0107 bullet gained the manual-session
+clause; `scripts/check_reconciliation_due.py`'s DUE banner reworded to say the routines run it and a
+manual session should not unless asked; journal Quick-reference + Rules note added.
+
+**Home:** CLAUDE.md § Session & plan workflow (Q-0107 bullet); `check_reconciliation_due.py` banner;
+`.session-journal.md` (Quick reference + Rules). This entry is provenance.
+
+### Q-0125 — Stale open PRs must be dispositioned (sessions + the reconciliation pass)
+
+> **OBSERVED 2026-06-13 (owner, in-session).** Verbatim: *"there are still a few PRs open … one of
+> them even has a failing CI that should be fixed"* and *"they are all quite old, I … was curious if
+> a session would see them, or if the reconciliation session would clean them up, but none of that
+> happened."* The owner deliberately left stale PRs to test whether the workflow self-heals; it did
+> not. Treated as an in-session directive to close the gap (provenance per Q-0106).
+
+**Area:** Session/PR workflow · open-PR hygiene · reconciliation-pass scope
+**Type:** Owner-observed workflow gap → recorded behavior rule
+
+**The gap:** four PRs sat open (#704 owner · #766 **red CI** · #771 redundant + conflicted · #805
+green/auto-merging). Neither ordinary sessions nor *two* reconciliation passes (#782 noted #771 as
+"recommend close" but never closed it; #804 didn't act either) dispositioned them. Sessions checked
+open PRs only for *title collisions* (the Q-0060 rule), never for *health* (red/stuck/redundant).
+
+**Decision (behavior rule):**
+> 1. **A session checks open-PR _health_, not just titles.** At orientation, `list_pull_requests`
+>    (state=open) + each one's CI/mergeable state; a red or stuck PR adjacent to your work is a
+>    bugs-first item.
+> 2. **The reconciliation pass _dispositions_ open PRs** (added to the Q-0107 reconcile scope):
+>    close redundant/stale, fix or flag a red-CI one, leave owner PRs. "Noting" a PR for close is
+>    not disposition — close it.
+> 3. **The autonomous docs-reconciliation routine** does the same (its prompt names the open-PR
+>    sweep), since a routine — not a manual session — runs the cadence pass (Q-0124).
+
+**Applied this session:** #766 CI fixed (3 idea files were `check_docs` reachability orphans → linked
+from the README index); #771 closed (redundant — its #765/#767/#769 entries are already in the ledger
+— and `dirty`/conflicted); CLAUDE.md Q-0107 reconcile bullet + the routine prompt gained the open-PR
+sweep; journal Quick-reference updated.
+
+**Home:** CLAUDE.md § Session & plan workflow (Q-0107 bullet); `docs/operations/autonomous-routines.md`
+(reconcile routine prompt); `.session-journal.md` (Quick reference + Rules). This entry is provenance.

--- a/scripts/check_reconciliation_due.py
+++ b/scripts/check_reconciliation_due.py
@@ -122,8 +122,10 @@ def main(argv: list[str] | None = None) -> int:
     if due:
         print(
             f"check_reconciliation_due: DUE — merged PRs crossed #{next_band} "
-            f"(last pass #{marker}, latest #{latest}). The next session should be a "
-            "docs-only repo review + planning reconciliation; reset the marker after.",
+            f"(last pass #{marker}, latest #{latest}). The docs-only reconciliation pass "
+            "is run automatically by the routines (the `reconcile`-issue trigger); a "
+            "manually-started session should NOT run it unless explicitly asked (Q-0124) "
+            "— pursue the work you were started for. Reset the marker after a pass.",
         )
         return 1 if args.strict else 0
     print(


### PR DESCRIPTION
## Why

Two owner directives from a live session, recorded so the workflow self-corrects (provenance per Q-0106 — both directed in-session).

This session was started with "continue where PR #800 ended" but mis-read the SessionStart `Recon: DUE` banner as the task and started a **duplicate** reconciliation pass — one a routine had already merged concurrently (#804). The owner then flagged that stale open PRs (one with red CI) had been ignored by sessions *and* two prior reconciliation passes. Both root causes are now closed.

## What

**Q-0124 — the reconciliation pass is the routines' job, not a manual session's.**
- A manually-started session does **not** run the Q-0107 docs-reconciliation pass unless explicitly asked; the routines (`reconcile`-issue trigger → docs-reconciliation routine) always do it automatically.
- The `Recon: DUE` banner is a signal *for the routine*, not an instruction to a human-started session.
- `.claude/CLAUDE.md` Q-0107 bullet gains the manual-session clause; `scripts/check_reconciliation_due.py`'s DUE banner reworded to say so; router `Q-0124`; journal.

**Q-0125 — stale open PRs must be dispositioned.**
- A session checks open-PR **CI/mergeable health** (not just title collisions) at orientation — a red/stuck/redundant PR is a bugs-first item.
- The reconciliation pass (and the autonomous docs-reconciliation routine) **dispositions** open PRs: close redundant/stale, fix or flag a red-CI one, leave owner PRs. "Noting" a PR is not disposition.
- `.claude/CLAUDE.md` reconcile scope + `docs/operations/autonomous-routines.md` reconcile prompt + router `Q-0125` + journal.

Also reinforced the **git-fetch-first** orientation rule in the journal (the #804 duplicate-pass miss — the container clone lagged live `main`).

## Companion actions this session (not in this diff)
- **#766** (3 idea captures, red CI): root cause = `check_docs` reachability orphans (the new idea files weren't linked from the README index) — fixed on its branch.
- **#771** (redundant ledger PR, `dirty`/conflicted): closed — its #765/#767/#769 entries are already in the ledger.

## Verification
`check_quality.py --check-only` green · `check_docs.py --strict` green · `check_reconciliation_due.py` parses + reports correctly. Docs/config only — no `disbot/` runtime code.

https://claude.ai/code/session_01Q53Avwa2gHUnwyHZa7eK5w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q53Avwa2gHUnwyHZa7eK5w)_