### PR TITLE
docs(ideas): preserve specs from issues #229 + #232 before closing the stale issues

### DIFF
--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -202,6 +202,17 @@ Current broad captures:
   execute next," and a superseding plan must repoint the old one in the same commit. **Overlaps
   [`live-decade-queue-pointer-invariant-2026-06-13.md`](./live-decade-queue-pointer-invariant-2026-06-13.md)**
   (the later, more specific form) — grooming to reconcile the two into one invariant.
+- [`setup-wizard-onboarding-planner-spec.md`](./setup-wizard-onboarding-planner-spec.md) —
+  **preserved target-scope spec (from closed issue #232, owner 2026-05-21):** the full
+  guided server-onboarding planner — scan → propose plan → presets → `SetupOperation` drafts →
+  Final Review, with confidence/conflict-detection/completeness-scoring/post-setup-summary. Much
+  is now the active setup-platform lane; this preserves the original vision + the open-tail
+  enhancements. Settings/setup lane.
+- [`rps-tournament-service-refactor.md`](./rps-tournament-service-refactor.md) —
+  **preserved refactor spec (from closed issue #229, owner 2026-05-20):** move RPS tournament
+  orchestration/state out of `rps_tournament_cog.py` into an `RpsTournamentService` (5-step
+  decomposition; the money seam already audited via `game_wager_workflow`). Games lane; medium-high
+  before new tournament features.
 - [`superbot-vision-2026-06-10.md`](./superbot-vision-2026-06-10.md) — the
   maintainer's written **product vision statement** (2-minute setup, panel
   navigation doctrine, 4-button help home, per-user preferences, RPG

--- a/docs/ideas/rps-tournament-service-refactor.md
+++ b/docs/ideas/rps-tournament-service-refactor.md
@@ -1,0 +1,72 @@
+# Idea — refactor RPS tournament orchestration out of the cog
+
+> **Status:** `ideas` — not approved for implementation; a preserved refactor spec. **Not a
+> plan, not approval.** Captured 2026-06-13 from GitHub issue **#229** (owner-authored
+> 2026-05-20) so the decomposition lives in the repo, then the issue was closed (GitHub issues
+> are not this repo's planning home — `docs/` is). Promote to a `docs/planning/` plan before building.
+
+## Problem
+
+`disbot/cogs/rps_tournament_cog.py` still owns too much runtime state + business flow, even
+though some helper/persistence/recovery/bot-match code already lives in `cogs/rps_tournament/`
+submodules. The cog directly owns: `tournament_active`, `registration_active`, `players`,
+`scores`, `matches`, `current_round`, `match_channels`, `entry_fee`, `paid_players`; the
+registration countdown/reminder task; bracket shuffling + round pairing; manual matchup
+mutation; move capture + match resolution; winner payout + completion cleanup. This makes it
+hard to test, hard to recover after restarts, and inconsistent with the platform direction
+(cogs own Discord entry points; **services** own deterministic orchestration).
+
+**Money note (2026-06-12):** the wagered PvP + tournament *money* path is already audited via
+`services/game_wager_workflow.py` (#748 — escrow-at-accept, idempotent settle/refund/payout).
+This refactor is about the **orchestration/state** decomposition, not the money seam; keep the
+wager-workflow boundary intact.
+
+## Target architecture
+
+`RockPaperScissorsCog` becomes the Discord boundary only (arg parsing · permission decorators ·
+user-facing embeds · interaction/view entry points · message-pipeline handoff), delegating to:
+
+```
+RPS commands/listeners/views
+  → RpsTournamentService → RpsTournamentRuntime / state model → RPS rules engine
+                         → channel/resource helpers → economy/game_wager_workflow
+                         → tournament_state_service → persistence/recovery helpers
+```
+
+## Proposed extraction steps (contained series, tests + smoke per step)
+
+1. **Pure state + decision model** — typed dataclasses (`RpsTournamentRuntime`,
+   `RpsPlayerState`, `RpsMatchState`, `RpsRoundPlan`, `RpsMatchResult`); move pure decisions
+   first (validate start, shuffle/pair, byes, apply move, resolve round, match-complete,
+   tournament-complete). No Discord calls.
+2. **Service orchestration boundary** — `RpsTournamentService` owns the runtime transitions
+   (start/cancel registration, register player, start tournament, manual matchup, next round,
+   submit move, complete match/tournament). The cog becomes a thin adapter.
+3. **Persistence + recovery alignment** — persist enough to recover (registration metadata,
+   registered/paid ids, current-round ids, active match-channel ids, match state/moves/wins);
+   recovery restores or cleanly refunds/cancels rather than relying on in-memory lists.
+   *(Respect ADR-002: game state is not restart-safe by design — scope recovery to clean
+   refund/cancel, not full mid-match restoration, unless ADR-002 is revisited.)*
+4. **Timeout cleanup** — deterministic cleanup of abandoned registration countdowns, stale
+   match channels, inactive players/matches, restart-during-tournament, via
+   `core.runtime.tasks` naming/cancellation conventions.
+5. **Shared tournament abstractions** — only after RPS is stable, extract *proven* overlap with
+   blackjack tournament flow (active-tournament guard, registration lifecycle, fees/refunds/
+   payouts, channel cleanup, recovery hooks, status reporting). Avoid a premature generic
+   framework.
+
+## Acceptance criteria
+
+Cog no longer owns bracket/match state; cog methods are mostly adapters; pure logic + state
+transitions are unit-tested without Discord objects; recovery/timeout explicit + tested;
+`!rpsregister` / `!rpsstart` / `!rpsmatchup` / `!rpsbot` / `!rps` still work; the Games/Help
+RPS panel still delegates to the same path; economy debit/credit unchanged + auditable; match
+channels cleaned up deterministically on completion/cancel/restart.
+
+## Routing
+
+Games lane — folio [`subsystems/games.md`](../subsystems/games.md). **Priority (owner, #229):**
+medium-high, *before* large new game/tournament features; a contained refactor series, not a
+text cleanup. Promote to a `docs/planning/` plan (2–3 PR slices) when scheduled. Adjacent
+prior art to reuse: `services/mining_workflow.py` (cog→service decomposition pattern) and
+`services/game_wager_workflow.py` (the money seam).

--- a/docs/ideas/setup-wizard-onboarding-planner-spec.md
+++ b/docs/ideas/setup-wizard-onboarding-planner-spec.md
@@ -1,0 +1,68 @@
+# Idea — full setup-wizard server-onboarding planner (target scope)
+
+> **Status:** `ideas` — preserved target-scope spec, **not approval**. Captured 2026-06-13 from
+> GitHub issue **#232** (owner-authored 2026-05-21) so the vision lives in the repo, then the
+> issue was closed. **Much of this is now the active setup-platform lane** — read those docs for
+> *current* state; this file preserves the original full vision + the enumerated requirements that
+> aren't yet shipped. Living homes:
+> [`setup-platform/setup_wizard_finalization_plan.md`](../setup-platform/setup_wizard_finalization_plan.md)
+> (current wizard; PR1–3 shipped #435, PR4–6 roadmap) ·
+> [`setup-platform/roadmap_setup_platform.md`](../setup-platform/roadmap_setup_platform.md) ·
+> [`setup-platform/operator-settings-presets.md`](../setup-platform/operator-settings-presets.md) ·
+> [`planning/adaptive-setup-access-routine-platform-2026-06-08.md`](../planning/adaptive-setup-access-routine-platform-2026-06-08.md).
+
+## Intent
+
+The complete Setup Wizard should be a **guided server-onboarding planner**, not just a settings
+form: scan the current server, then propose a concrete, reviewable setup plan.
+
+## Spec (owner's original target scope)
+
+- **Server scan (read-only, deterministic):** categories · text/voice channels · roles ·
+  member counts · current bot permissions · likely admin/mod/staff channels · likely existing
+  bot/log/mod/proof/counting/mining/game channels · role-hierarchy constraints · missing
+  permissions that would block setup.
+- **Channel/category planning:** after scan, offer (1) bind existing, (2) create only missing
+  bot channels, (3) load a preset structure, (4) manual customize → Final Review. Key outputs:
+  log · bot/command · admin/setup · mod-log · cleanup targets · optional game/economy/proof/
+  counting/mining channels per loaded cogs.
+- **Presets → `SetupOperation` drafts (never apply immediately):** Minimal · Community · Gaming ·
+  Moderation-heavy · Existing-server safe mode.
+- **Command/channel routing:** server-default cog enable/disable → category override → channel
+  override; command-channel allowlist / bot-channel binding; per-cog routing where supported.
+  Simple default (all loaded cogs on/off), optional overrides.
+- **Cleanup levels (per server/category/channel):** Off · Light · Standard · Strict · Custom →
+  produce reviewable setting/binding/policy operations.
+- **Role suggestions:** bot-admin/setup-admin · moderator · trusted · muted/quarantined ·
+  time/progression · event/game roles — respecting hierarchy/permissions; new roles previewed +
+  applied only via Final Review.
+- **Other questions (ask only what's needed):** prefix/help preference · warn threshold · log
+  routing · economy/game defaults · automation templates (created disabled) · public vs
+  admin-only panels.
+
+## Architecture constraints (these match the shipped platform)
+
+Scan is read-only/deterministic · suggestions become `SetupOperation` draft records · no setup
+section mutates DB/Discord directly · **Final Review is the only apply point** · mutations route
+through the canonical pipelines (`SettingsMutationPipeline` / `BindingMutationPipeline` /
+`ResourceProvisioningPipeline` / `AutomationMutationPipeline`) · Setup Wizard + Settings Manager
+share reusable controls.
+
+## The open tail (enumerated #232 enhancements not yet shipped — preserve as design targets)
+
+- **Confidence/explanation field** on every proposed binding/resource (*why* this channel/role
+  fits).
+- **Conflict detection** (proposed bot channel already exists · role hierarchy too low · missing
+  Manage Channels).
+- **No-surprises mode** (never create resources unless explicitly confirmed).
+- **Rollback/cleanup note** per resource-creation op.
+- **Setup completeness scoring** (required vs optional).
+- **Post-setup summary** (created / bound / skipped / still-needs-attention).
+
+## Routing
+
+Settings/setup lane — folio [`subsystems/settings-bindings-provisioning.md`](../subsystems/settings-bindings-provisioning.md).
+**Priority (owner, #232):** high *after* Settings Manager contract reconciliation + setup
+draft-operation storage (both now in place). Promote the open-tail enhancements into the
+finalization plan's future roadmap (or a dedicated planner plan) when the onboarding-planner is
+scheduled; the draft-operation/Final-Review substrate they need already exists.


### PR DESCRIPTION
## Why

Owner asked that the remaining open **issues** be dispositioned the same way as the stale PRs: keep any information worth preserving, then close (GitHub issues aren't this repo's planning home — `docs/` is). Three issues remained (#801/#768 auto-closed already):

| Issue | Info to keep? | Action |
|---|---|---|
| **#229** RPS tournament refactor | **Yes** — the cog→service decomposition spec was genuinely uncaptured | → `docs/ideas/rps-tournament-service-refactor.md`, then close |
| **#232** setup-wizard onboarding planner | **Partly** — much is now the active setup-platform lane, but the original full vision + several enumerated enhancements (confidence/conflict-detection/completeness-scoring/post-setup-summary) weren't fully captured | → `docs/ideas/setup-wizard-onboarding-planner-spec.md` (preserves the vision + links the living homes), then close |
| **#773** Postgres backup failed (auto-alert) | **Already kept** — the gate (`DATABASE_PUBLIC_URL` secret) is tracked in the control-plane state ledger + current-state Gates | close (no capture needed) |

## What

Two new `docs/ideas/` capture docs (badged `ideas`, README-indexed → `check_docs --strict` green) preserving the owner's specs faithfully and linking them to their live area docs. This is the issue-side of the **Q-0125** open-item disposition rule landed in #806.

## Verification
`check_docs --strict` green (234 docs, both new files reachable). Docs-only.

https://claude.ai/code/session_01Q53Avwa2gHUnwyHZa7eK5w

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q53Avwa2gHUnwyHZa7eK5w)_