### PR TITLE
test: parallel-safe suite — re-enable pytest -n auto (~3× CI speedup)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install black==26.5.1 isort==8.0.1 ruff==0.15.14 mypy==2.1.0
-          pip install pytest==9.0.3 pytest-asyncio==1.4.0
+          pip install pytest==9.0.3 pytest-asyncio==1.4.0 pytest-xdist==3.6.1
           pip install -r requirements.txt
 
       - name: Run Black (check only)
@@ -119,15 +119,17 @@ jobs:
 
       - name: Run pytest
         if: steps.changes.outputs.code == 'true'
-        # pytest is the dominant per-run cost (~109s for the 9.4k-test suite), so
-        # parallelizing it (`pytest -n auto`) is the obvious speed win — but it was
-        # tried under Q-0126 (2026-06-14) and reverted: the suite has non-deterministic
-        # cross-test state pollution that only surfaces under parallel scheduling
-        # (different tests fail each run; green locally != green in CI; `--dist
-        # loadscope` made it worse, not better). Parallelization is deferred until the
-        # suite is made isolation-safe — see the follow-up in
-        # docs/ideas/ci-cost-and-duplicate-work-prevention-2026-06-14.md.
-        run: pytest tests/ -v --tb=short
+        # pytest is the dominant per-run cost (was ~109s serial for the 9.4k-test
+        # suite). `-n auto` (pytest-xdist) spreads it across the runner's cores for a
+        # ~3x speedup (~35s on the 4-core runner). This was tried + reverted once under
+        # Q-0126 (2026-06-14) because the suite had non-deterministic cross-test
+        # global-state pollution that only surfaced in parallel (a different subset
+        # failed each run). That was root-fixed in the Q-0126 follow-up: autouse reset
+        # of the lifecycle / startup-outcome / feature-flag singletons in
+        # tests/conftest.py + the server_logging bus-subscription teardown. Proven
+        # green across 8 parallel runs (5x --dist loadscope + 3x -n auto). Keep `-n
+        # auto` in lockstep with scripts/check_quality.py's run_pytest().
+        run: pytest tests/ -v -n auto --tb=short
 
       - name: Docs-only change — heavy checks skipped
         if: steps.changes.outputs.code != 'true'

--- a/disbot/services/server_logging.py
+++ b/disbot/services/server_logging.py
@@ -103,9 +103,18 @@ def _reset_for_tests() -> None:
     for k in list(_COUNTERS):
         _COUNTERS[k] = 0
     _BOT = None
-    # Note: bus subscription is intentionally NOT cleared — tests that
-    # need to exercise the subscriber call it directly and assert on
-    # counters; the bus binding is registered once per process.
+    # Tear the bus subscription down too, so a test that called setup()
+    # cannot leak _on_audit_action / _on_moderation_action onto the
+    # process-global bus for every later test (the leak surfaced under
+    # parallel xdist scheduling: the orphaned subscriber fired on another
+    # test's audit.action_recorded emit and skewed its delivery stats).
+    # setup() re-registers cleanly because we also drop the _SUBSCRIBED
+    # latch; tests that call the subscriber directly are unaffected.
+    if _SUBSCRIBED:
+        bus.off(EVT_MOD_ACTION, _on_moderation_action)
+        bus.off(EVT_MOD_ACTION, _on_moderation_action_public)
+        bus.off(EVT_AUDIT_ACTION_RECORDED, _on_audit_action)
+    _SUBSCRIBED = False
 
 
 # ---------------------------------------------------------------------------

--- a/docs/ideas/ci-cost-and-duplicate-work-prevention-2026-06-14.md
+++ b/docs/ideas/ci-cost-and-duplicate-work-prevention-2026-06-14.md
@@ -86,35 +86,55 @@ mechanics needed adjusting:
 3. **WIP issue.** Manifest as a `wip-claim` issue (no CI, no merge risk). Adds a surface agents
    must also check.
 
-## Follow-up: make the test suite parallel-safe, then re-enable xdist (the ~3× unlock)
+## Follow-up: make the test suite parallel-safe, then re-enable xdist — DONE (2026-06-14)
 
-This is the **live idea** that remains. xdist would cut pytest from ~109s to ~35s, but CI proved
-the suite isn't parallel-safe. The evidence (all on a 4-core box, matching CI):
+xdist cuts pytest from ~109s serial to ~35s (~3×), but the first attempt (PR #814) had to be
+reverted: the suite had non-deterministic cross-test state pollution that only surfaced in
+parallel. The original evidence:
 
 | Run | Result |
 |---|---|
 | CI `-n auto` | **9 failed** (`test_slash_access_check` ×7, `test_platform_consistency`, `test_flag_manager`) |
 | local `-n auto` | 0 failed (green) |
-| local `-n 4` | 0 failed (green) |
 | local `-n 4 --dist loadscope` (run 1) | **7 failed** (slash cluster) |
-| local `-n 4 --dist loadscope` (run 2) | **1 failed** — `test_platform_flags_embed` (in neither CI nor run 1) |
+| local `-n 4 --dist loadscope` (run 2) | **1 failed** — `test_platform_flags_embed` |
 
-A *different* set fails each run → **non-deterministic cross-test state pollution** that only
-surfaces under parallel scheduling. **Green locally ≠ green in CI**, and no `--dist` flag fixes
-it (loadscope made it worse). The culprits are global singletons mutated by one test and read by
-another without reset — candidates from the failures: the readiness-snapshot registry, the slash
-access-control config, the flag registry, the platform-flags embed state.
+A *different* set failed each run → process-global singletons mutated by one test and read by
+another without reset; a polluter only collides with a reader under parallel scheduling. **`--dist
+loadscope` reproduced it reliably locally** (default `load` was green locally — that was the trap).
 
-**Plan when picked up:** (1) add autouse reset/isolation fixtures for those globals (start with
-the 4+ implicated modules, then audit for more); (2) re-run `pytest -n auto` several times until
-deterministically green; (3) re-enable `-n auto` in `code-quality.yml` + `scripts/check_quality.py`
-and re-pin `pytest-xdist` in `requirements-dev.txt`; (4) verify across **multiple CI runs**, not
-just locally (that's the trap this idea documents). Likely a `docs/planning/` plan, not a one-shot.
+### Root cause (three process-global singletons, all confirmed by repro)
+
+1. **`core.runtime.lifecycle`** phase → the access-check cluster (`test_bootstrap_access_cog`
+   `test_channel_guard_*` + `test_slash_access_check` `test_slash_check_*`). A test that left
+   lifecycle in shutdown made the access resolver short-circuit for the next reader.
+2. **`core.runtime.feature_flags._REGISTRY`** → `test_platform_flags_embed`. A test that wiped the
+   registry via `_reset_for_tests()` (which clears to *empty*) left the import-time default flag
+   declarations gone for the next reader.
+3. **`core.events.bus`** leaked subscription → `test_event_bus_delivery`. `server_logging.setup()`
+   registered `_on_audit_action` on the global bus, but `server_logging._reset_for_tests()`
+   **deliberately never unsubscribed** ("registered once per process") — so the orphaned subscriber
+   fired on another test's `audit.action_recorded` emit and skewed its delivery-stats assertion.
+
+### Fix (root-cause, test-only + one service reset)
+
+- `tests/conftest.py` — one autouse fixture resets `lifecycle` + `startup_outcome` + `feature_flags`
+  before/after every test. Each module already shipped a reset hook (`startup_outcome`'s docstring
+  literally asks for an autouse fixture); they were never wired suite-wide. `feature_flags` is
+  **snapshot/restored** to its import-time baseline, not wiped (wiping would drop the defaults).
+- `services/server_logging._reset_for_tests()` — now tears down its bus subscription + drops the
+  `_SUBSCRIBED` latch, so `setup()` re-registers cleanly and the leak dies at its source.
+
+### Verification
+
+8 parallel runs, all `9422 passed, 0 failed`: 5× `--dist loadscope` (the reliable-failure mode) +
+3× `-n auto`, ~34-38s each vs ~109s serial. Re-enabled `-n auto` in `code-quality.yml` +
+`scripts/check_quality.py`; re-pinned `pytest-xdist==3.6.1` in `requirements-dev.txt`. The real
+final proof is **CI itself across multiple runs** (the trap this idea documents) — watch the PR.
 
 ## Lifecycle
 
-- (a) concurrency + caching → **implemented** (PR #814); re-badge `historical` after merge.
-- (a) xdist → **reverted**; folded into the Follow-up above.
-- (b) claim ledger + push-batching → **decided & implemented** this session (CLAUDE.md +
-  `docs/owner/active-work.md`).
-- **Follow-up (parallel-safe suite)** → the remaining live idea; groom into a plan when prioritized.
+- (a) concurrency + caching → **implemented** (PR #814, merged); re-badge `historical`.
+- (a) xdist → reverted in #814, then **re-enabled parallel-safe** in the follow-up (this PR).
+- (b) claim ledger + push-batching → **decided & implemented** (CLAUDE.md + `docs/owner/active-work.md`).
+- **Follow-up (parallel-safe suite)** → **DONE** (this PR) — root-fixed + verified across 8 runs.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,10 +25,12 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/trusting-goldberg-po4p7s` · CI-cost reduction + duplicate-work convention (Q-0126) ·
-  `.github/workflows/code-quality.yml`, `scripts/check_quality.py`, `requirements-dev.txt`,
-  `.claude/CLAUDE.md`, this file, the question router, idea doc · 2026-06-14 · PR #814
+- `claude/trusting-goldberg-po4p7s` · parallel-safe test suite → re-enable xdist (the ~3×
+  pytest CI win; follow-up from the #814 idea doc) · test-only: autouse isolation fixtures in
+  `tests/conftest.py` + implicated test modules, then re-pin `pytest-xdist` & flip `-n auto`
+  in `.github/workflows/code-quality.yml` + `scripts/check_quality.py` · 2026-06-14
 
 ## Recently cleared
 
-_(move claims here with their PR # as they close, then prune older entries)_
+- `claude/trusting-goldberg-po4p7s` · CI-cost reduction + duplicate-work convention (Q-0126) ·
+  concurrency-cancel + pip/mypy caching + claim ledger + push-batching · 2026-06-14 · **#814 (merged)**

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,6 +15,9 @@ ruff==0.15.14
 mypy==2.1.0
 pytest==9.0.3
 pytest-asyncio==1.4.0
+# Parallel test runner (`pytest -n auto`) — the ~3x CI speedup re-enabled after the
+# Q-0126 test-isolation follow-up made the suite parallel-safe. Pinned to match CI.
+pytest-xdist==3.6.1
 
 # Import-graph engine for scripts/context_map.py (the file-context tool).
 # Developer/agent-only — NOT a bot-runtime dep and NOT installed in CI; the tool

--- a/scripts/check_quality.py
+++ b/scripts/check_quality.py
@@ -129,11 +129,12 @@ def run_mypy() -> int:
 
 
 def run_pytest() -> int:
-    # Serial on purpose: `pytest -n auto` (xdist) was tried under Q-0126 and reverted
-    # — the suite has non-deterministic cross-test state pollution under parallel
-    # scheduling. Re-enable only after the isolation follow-up lands (so CI and this
-    # mirror flip together). See code-quality.yml's pytest step + the Q-0126 idea doc.
-    return _run("pytest", _tool("pytest", "tests/", "-q", "--tb=short"))
+    # `-n auto` (pytest-xdist) parallelizes the ~9.4k-test suite across cores for a
+    # ~3x speedup, mirroring code-quality.yml exactly. Parallel-safe since the Q-0126
+    # test-isolation follow-up: autouse singleton resets in tests/conftest.py + the
+    # server_logging bus-subscription teardown. Keep this flag in lockstep with CI's
+    # pytest step (flip both together if the suite ever regresses to serial).
+    return _run("pytest", _tool("pytest", "tests/", "-q", "-n", "auto", "--tb=short"))
 
 
 def run_check_docs() -> int:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,3 +28,50 @@ def validated_registry():
     from utils.subsystem_registry import validate_registry
 
     validate_registry()
+
+
+@pytest.fixture(scope="session")
+def _feature_flag_registry_baseline():
+    """Snapshot the import-time feature-flag declarations once per session.
+
+    ``feature_flags._REGISTRY`` is populated at module import (the Phase-1d
+    default declarations), so the per-test reset must *restore* this
+    baseline rather than wipe the registry empty — wiping would drop the
+    defaults and break every test that reads a declared flag.
+    """
+    from core.runtime import feature_flags
+
+    return dict(feature_flags._REGISTRY)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_global_runtime_state(_feature_flag_registry_baseline):
+    """Reset process-global runtime singletons before/after every test.
+
+    The bot keeps several module-level singletons — the lifecycle phase,
+    the startup-outcome ledger, and the feature-flag registry/cache — that
+    one test can mutate and the next can read. Under serial collection the
+    deterministic ordering happens to hide the leakage; under ``pytest-xdist``
+    parallel scheduling a polluting test can land on the same worker *before*
+    a reader with no reset between them, so the suite was not parallel-safe
+    (a different subset failed each parallel run). Each of these modules
+    already ships a test-reset hook — ``startup_outcome.reset_for_tests``'s
+    docstring even asks for exactly this autouse fixture — they were just
+    never wired suite-wide. Resetting before *and* after each test makes the
+    starting state independent of execution order.
+    """
+    from core.runtime import feature_flags, lifecycle, startup_outcome
+
+    def _restore() -> None:
+        lifecycle.reset_for_tests()
+        startup_outcome.reset_for_tests()
+        # Restore the registry to its import-time baseline (not empty),
+        # then clear the per-evaluation cache + bootstrap-fallback counter.
+        feature_flags._REGISTRY.clear()
+        feature_flags._REGISTRY.update(_feature_flag_registry_baseline)
+        feature_flags._CACHE.clear()
+        feature_flags._reset_metrics_for_tests()
+
+    _restore()
+    yield
+    _restore()


### PR DESCRIPTION
## What

Re-enables `pytest -n auto` (pytest-xdist) for the ~9.4k-test suite — the **~3× CI speedup** (~109s serial → ~35s) that was reverted in #814 because the suite wasn't parallel-safe. This PR **root-fixes** the non-determinism and turns parallelism back on.

This is the live follow-up parked in the #814 idea doc (`docs/ideas/ci-cost-and-duplicate-work-prevention-2026-06-14.md`).

## Root cause

Three process-global singletons were mutated by one test and read by another with no reset between them. Under serial collection the deterministic ordering hid it; under parallel scheduling a polluter can land on the same worker before a reader, so **a different subset failed each run** (`--dist loadscope` reproduced it reliably; default `load` was green locally — that was the trap).

| Polluted global | Symptom test(s) |
|---|---|
| `core.runtime.lifecycle` phase | `test_bootstrap_access_cog::test_channel_guard_*` + `test_slash_access_check::test_slash_check_*` |
| `feature_flags._REGISTRY` defaults | `test_platform_flags_embed` |
| leaked `server_logging` bus subscription | `test_event_bus_delivery::test_diagnostics_snapshot...` |

The bus leak is the subtle one: `server_logging.setup()` subscribes `_on_audit_action` to the global bus, but `_reset_for_tests()` **deliberately never unsubscribed** ("registered once per process") — so the orphaned handler fired on another test's `audit.action_recorded` emit and skewed its delivery-stats assertion.

## Fix (root-cause; test-only + one service reset)

- **`tests/conftest.py`** — one autouse fixture resets `lifecycle` + `startup_outcome` + `feature_flags` before/after every test. Each module already shipped a reset hook (`startup_outcome`'s docstring literally asks for an autouse fixture); they were just never wired suite-wide. `feature_flags` is **snapshot/restored** to its import-time baseline, not wiped (wiping would drop the default flag declarations).
- **`services/server_logging._reset_for_tests()`** — now tears down its bus subscription + drops the `_SUBSCRIBED` latch, so `setup()` re-registers cleanly and the leak dies at its source.
- **Re-enable** — `-n auto` back in `code-quality.yml` + `scripts/check_quality.py` (kept in lockstep); `pytest-xdist==3.6.1` pinned in `requirements-dev.txt`.

## Verification

- **8 parallel runs, all `9422 passed, 0 failed`**: 5× `--dist loadscope` (the reliable-failure mode) + 3× `-n auto`, ~34–38s each vs ~109s serial.
- `check_quality.py --full` green (black / isort / ruff / check_docs / mypy / **pytest via the new `-n auto` mirror, 34.43s**); `check_architecture --mode strict` 0 errors.
- The honest caveat (the trap this work documents): **green locally ≠ proof** — the real confirmation is CI itself across multiple runs. Watch this PR's Code Quality.

https://claude.ai/code/session_01SuxJQKJBY9CwwM1YAcb8ds

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuxJQKJBY9CwwM1YAcb8ds)_