### PR TITLE
docs: #817 merge note + router Q-0127 (auto-merge-enabler doesn't fire for MCP PRs)

### DIFF
--- a/.sessions/2026-06-14-p0-3-delegated-setup-apply.md
+++ b/.sessions/2026-06-14-p0-3-delegated-setup-apply.md
@@ -82,9 +82,21 @@ in `governance.capability` and silently failed.
 
 ## Gates / handoff for the next session
 
-- **#817 will self-merge** on green `code-quality` (auto-merge armed; subscribed for CI). No
-  manual merge needed. **Next P0 = P0-4** (server-mgmt channel-ownership convergence, Q-0100),
-  then P0-2 (media/YouTube retention, Q-0099) — band-#800 decade queue §4 slots 3–4.
+- **#817 is MERGED** (merge commit `73002b4`, by hand). **Next P0 = P0-4** (server-mgmt
+  channel-ownership convergence, Q-0100), then P0-2 (media/YouTube retention, Q-0099) —
+  band-#800 decade queue §4 slots 3–4.
+- **⚠ Auto-merge did NOT arm — heads-up for tonight's sessions (router Q-0127).** The
+  `auto-merge-enabler` workflow had **0 runs for `claude/funny-bohr-skbaoz`** (and none for the
+  concurrent `claude/trusting-goldberg-po4p7s` band either). MCP-created PRs (`create_pull_request`)
+  don't fire the `pull_request:[opened]` trigger — the **same app-token-doesn't-trigger-workflows
+  class as #778's bot-authored-issue gotcha**. So the Q-0123 "open ready → it self-merges" path
+  silently doesn't work for MCP PRs; I merged #817 by hand (Q-0123 carve-out: CI green on the
+  final head `6e98721` + `mergeable_state: clean`, merged in-turn, not deferred). **Practical fix
+  a session can apply itself today:** call `mcp__github__enable_pr_auto_merge` right after
+  `create_pull_request` — it arms native auto-merge directly (no workflow trigger needed). Filed
+  as **router Q-0127** for the owner to decide the durable fix (enable-at-open vs. workflow
+  re-trigger). Until then: **after opening a PR, either call `enable_pr_auto_merge` or merge by
+  hand once `code-quality` is green on the final head.**
 - **Mid-session merge:** main advanced (#815 parallel-safe suite + `pytest -n auto`; #816
   session-close) **while I worked** — the PR went `dirty`. Merged `origin/main` in, resolved the
   one conflict (the `active-work.md` claim ledger, by UNION), re-ran the full mirror under the

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -4783,3 +4783,46 @@ per Q-0106 (owner-directed in-session).
 `.github/workflows/code-quality.yml` + `scripts/check_quality.py` (the CI wins). Follow-up (parallel-safe
 test suite → re-enable xdist) captured in
 [`docs/ideas/ci-cost-and-duplicate-work-prevention-2026-06-14.md`](../ideas/ci-cost-and-duplicate-work-prevention-2026-06-14.md).
+
+---
+
+### Q-0127 — Native auto-merge never arms for MCP-created PRs (the `auto-merge-enabler` doesn't fire)
+
+> **DISCUSS lane — agent-surfaced finding 2026-06-14 (PR #817 session). Proposing, not applying
+> (executable-config change, Q-0106 boundary).**
+
+**Area:** merge mechanics · the Q-0123 native-auto-merge workflow
+**Type:** automation gap — needs an owner call on the durable fix
+
+**The finding (measured).** `auto-merge-enabler.yml` triggers on `pull_request:[opened, reopened,
+ready_for_review]` and would have matched #817 (non-draft, `claude/` head, no carve-out label).
+But it had **0 workflow runs for `claude/funny-bohr-skbaoz`** — and **none for the concurrent
+`claude/trusting-goldberg-po4p7s` band (#815/#816) either** (checked `list_workflow_runs` for the
+enabler: newest run predates this band entirely). So native auto-merge was **never armed**; #817
+did not self-merge despite `code-quality` passing green and `mergeable_state: clean`. I merged it
+by hand in-turn per the Q-0123 carve-out (CI verified green on the final head, not deferred).
+
+**Likely root cause (same class as #778).** PRs opened via the GitHub MCP `create_pull_request`
+(an app/integration token) don't emit a `pull_request` event that triggers a workflow — GitHub's
+"events from `GITHUB_TOKEN` / a GitHub App don't start new workflow runs" recursion-guard, the
+**exact gotcha #778 documented for bot-authored issue triggers**. The Q-0123 design ("session just
+opens the PR; GitHub does the gated merge") therefore silently doesn't hold for the way agent
+sessions actually open PRs — they've apparently been merging by hand all along (the #786 "hands-off"
+claim predates this band and may have used a different path).
+
+**Proposed fix (two options — owner picks):**
+- **(a) Session arms it directly (smallest, works today).** After `create_pull_request`, the session
+  calls `mcp__github__enable_pr_auto_merge` (a PAT-authenticated MCP call, not a workflow trigger) →
+  native auto-merge arms regardless of the event gotcha. Add a CLAUDE.md bullet; the enabler workflow
+  becomes a backstop. *(Recommended — sidesteps the trigger entirely, keeps merge off the session's
+  critical path.)*
+- **(b) Re-trigger the enabler.** Have it also run on `workflow_dispatch` / a `push`-to-`claude/*`
+  branch event, or re-author PR creation so it fires `pull_request`. More moving parts; doesn't fix
+  the underlying app-token-doesn't-trigger rule.
+
+**Until decided:** after opening a PR, a session should call `enable_pr_auto_merge` **or** merge by
+hand once `code-quality` is green on the final head (Q-0123 carve-out). Recorded in the #817 session
+log handoff.
+
+**Home (once answered):** `.github/workflows/auto-merge-enabler.yml` + CLAUDE.md § Session & plan
+workflow (the merge-mechanics bullet).


### PR DESCRIPTION
Docs-only follow-up to **#817** (merged `73002b4`). Two handoff artifacts that surfaced *after* #817 merged:

- **Session log** — #817 was merged **by hand** because native auto-merge never armed; documents the workaround + a heads-up for the concurrent sessions.
- **Router Q-0127 (DISCUSS)** — the `auto-merge-enabler` workflow had **0 runs** for the session branch (and the concurrent band). MCP-created PRs (`create_pull_request`) don't fire its `pull_request:[opened]` trigger — the **same app-token-doesn't-trigger-workflows class as #778's bot-authored-issue gotcha** — so the Q-0123 "open ready → it self-merges" path silently doesn't hold for the way agent sessions open PRs. Proposes the **`enable_pr_auto_merge`-at-open** fix for owner review. Proposing, not applying (executable-config change, Q-0106).

**This PR also validates the proposed workaround:** I armed native auto-merge on it by calling `enable_pr_auto_merge` directly (instead of relying on the enabler workflow). If it self-merges on green, fix (a) works for tonight's sessions.

🤖 Generated in a Claude Code session.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1g65Fd4XGEnoSg4uA3cqf)_