### PR TITLE
P0-4 PR 2: converge channel creation + category lifecycle under ChannelLifecycleService

### DIFF
--- a/disbot/cogs/channel_cog.py
+++ b/disbot/cogs/channel_cog.py
@@ -26,7 +26,6 @@ from services.channel_lifecycle_service import (
     ChannelLifecycleService,
 )
 from services.lifecycle import SUCCESS
-from utils.channels import get_or_create_category, safe_channel_name
 from utils.ui_constants import INFO_COLOR, WARNING_COLOR
 from views.base import send_panel
 
@@ -236,10 +235,22 @@ class ChannelCog(commands.Cog):
     @is_admin_or_owner()
     async def manage_event(self, ctx, evt: str, action: str):
         if action.lower() == "create":
-            category = await get_or_create_category(ctx.guild, "Events")
-            name = await safe_channel_name(ctx.guild, evt)
-            await ctx.guild.create_text_channel(name, category=category)
-            await ctx.send(f'Event channel "{name}" created!')
+            result = await ChannelLifecycleService().create_channels(
+                ctx.guild,
+                [evt],
+                ctx.author,
+                category_name="Events",
+                actor_type="admin",
+            )
+            if result.outcome == SUCCESS:
+                created = ctx.guild.get_channel(result.applied[0].target_id)
+                name = created.name if created else evt
+                await ctx.send(f'Event channel "{name}" created!')
+            else:
+                await ctx.send(
+                    f"❌ Could not create event channel: "
+                    f"{self._channel_result_error(result)}",
+                )
         elif action.lower() == "delete":
             channel = self._resolve_channel(ctx.guild, evt)
             if not channel:
@@ -275,7 +286,6 @@ class ChannelCog(commands.Cog):
         permission: bool,
         category_name: str = None,
     ):
-        safe_name = await safe_channel_name(ctx.guild, channel_name)
         category = None
         if category_name:
             category = self._resolve_category(ctx.guild, category_name)
@@ -283,11 +293,23 @@ class ChannelCog(commands.Cog):
                 await ctx.send(f'Category "{category_name}" not found!')
                 return
 
-        # NOTE: channel *creation* converges under ResourceProvisioningPipeline
-        # in the P0-4 follow-up (Q-0100); for now creation stays direct here, but
-        # the permission overwrite on the new channel routes through the audited
-        # lifecycle seam.
-        new_channel = await ctx.guild.create_text_channel(safe_name, category=category)
+        # Channel creation routes through the audited lifecycle seam (P0-4 PR 2,
+        # Q-0100); the follow-up permission overwrite routes through it too.
+        result = await ChannelLifecycleService().create_channels(
+            ctx.guild,
+            [channel_name],
+            ctx.author,
+            category_id=category.id if category else None,
+            actor_type="admin",
+        )
+        if result.outcome != SUCCESS:
+            await ctx.send(
+                f'❌ Could not create channel "{channel_name}": '
+                f"{self._channel_result_error(result)}",
+            )
+            return
+        new_channel = ctx.guild.get_channel(result.applied[0].target_id)
+        safe_name = new_channel.name if new_channel else channel_name
         state = "granted" if permission else "restricted"
         suffix = f' (renamed to "{safe_name}")' if safe_name != channel_name else ""
         await self._apply_overwrite(
@@ -618,16 +640,26 @@ class ChannelCog(commands.Cog):
         if isinstance(potential, discord.CategoryChannel):
             category = potential
             channel_names = list(args[:-1])
+        if not channel_names:
+            await ctx.send("Please provide at least one channel name.")
+            return
 
+        result = await ChannelLifecycleService().create_channels(
+            ctx.guild,
+            channel_names,
+            ctx.author,
+            category_id=category.id if category else None,
+            actor_type="admin",
+        )
         created, failed = [], []
-        for ch in channel_names:
-            safe = await safe_channel_name(ctx.guild, ch)
-            try:
-                await ctx.guild.create_text_channel(safe, category=category)
-                suffix = f" (as {safe})" if safe != ch else ""
-                created.append(f"{ch}{suffix}")
-            except Exception:
-                failed.append(ch)
+        for step in result.steps:
+            if step.ok:
+                made = ctx.guild.get_channel(step.target_id)
+                actual = made.name if made else step.target_name
+                suffix = f" (as {actual})" if actual != step.target_name else ""
+                created.append(f"{step.target_name}{suffix}")
+            else:
+                failed.append(step.target_name)
 
         response = ""
         if created:

--- a/disbot/services/channel_lifecycle_service.py
+++ b/disbot/services/channel_lifecycle_service.py
@@ -12,12 +12,21 @@ mutation flows through here, returning a typed
 
 Boundaries (P0-4 convergence, Q-0100):
 
-* Channel *creation* / category creation stays with the provisioning pipeline
-  (the no-silent-auto-create invariant owns that path); this service does not
-  create channels.  ``set_permissions``/overwrite changes and ``clone`` were
-  the deliberate follow-up and are now **owned here** (Q-0100: clone/overwrite
-  → ChannelLifecycleService with audit+events), so the convergence invariant
-  pins ``.delete`` / ``.edit`` / ``.set_permissions`` / ``.clone``.
+* **Subsystem-bound** channel/category creation (a channel that becomes a
+  declared ``(subsystem, binding_name)`` binding) stays with
+  :class:`services.resource_provisioning.ResourceProvisioningPipeline` — it is
+  catalogue-driven and writes the binding row.
+* **Ad-hoc operator** channel creation (``!create`` / ``!evt`` / ``!bulkcreate``
+  / the create panel) has *no* declared binding, so it does not fit that
+  pipeline; it is now owned **here** via :meth:`create_channels` (P0-4 PR 2),
+  the channel-domain sibling of
+  :class:`services.role_lifecycle_service.RoleLifecycleService` (the audited
+  manual-role creator).  ``set_permissions``/overwrite and ``clone`` were the
+  earlier follow-up and are also **owned here** (P0-4 PR 1).  The convergence
+  invariant pins ``.delete`` / ``.edit`` / ``.set_permissions`` / ``.clone`` and
+  the operator ``create_*`` calls in the cog + channel views; this service is
+  the one sanctioned manual ``guild.create_*`` caller (no-silent-auto-create
+  allowlist).
 
 Authorisation: the bot's Discord permission (``manage_channels``) is checked
 here; the *actor's* authority stays at the cog/view layer (the channel
@@ -34,6 +43,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 import discord
@@ -226,6 +236,121 @@ class ChannelLifecycleService:
             event_emitted=event_emitted,
         )
 
+    async def create_channels(
+        self,
+        guild: discord.Guild,
+        names: Sequence[str],
+        actor: object | None,
+        *,
+        category_id: int | None = None,
+        category_name: str | None = None,
+        kind: str = "text",
+        reason: str | None = None,
+        actor_type: str = "user",
+    ) -> lc.LifecycleResult:
+        """Create one or more channels through the audited lifecycle seam.
+
+        This is the audited *manual* channel creator — the channel-domain sibling
+        of :class:`services.role_lifecycle_service.RoleLifecycleService` (Q-0100,
+        P0-4).  Ad-hoc operator channels (``!create`` / ``!evt`` / ``!bulkcreate``
+        / the create panel) have **no declared subsystem binding**, so they do not
+        fit the catalogue-driven
+        :class:`services.resource_provisioning.ResourceProvisioningPipeline`
+        (which resolves a ``(subsystem, binding_name)`` option and always writes a
+        binding row); routing them here gives them the same audit companion +
+        ``channel.lifecycle_changed`` event as every other operator channel
+        mutation, without minting a fake binding.
+
+        Channels are created with safe (auto-incremented) names.  An optional
+        category is resolved by id (``category_id``) or get-or-created by name
+        (``category_name``); a category failure aborts the whole batch (every
+        channel would otherwise land in the wrong place).  ``StepResult.target_id``
+        carries each new channel's id (``0`` on failure) so callers can re-resolve
+        the created channel (e.g. to apply a follow-up overwrite).
+        """
+        operation = "create"
+        reversibility = lc.COMPENSATABLE
+        mutation_id = str(uuid.uuid4())
+        actor_id = getattr(actor, "id", None) if actor is not None else None
+
+        if not self._bot_can_manage(guild):
+            return self._terminal(
+                mutation_id,
+                guild.id,
+                operation,
+                reversibility,
+                lc.BLOCKED,
+                "bot lacks the Manage Channels permission",
+            )
+
+        category, cat_error = await self._resolve_create_category(
+            guild,
+            category_id,
+            category_name,
+        )
+        if cat_error is not None:
+            return self._terminal(
+                mutation_id,
+                guild.id,
+                operation,
+                reversibility,
+                lc.BLOCKED,
+                cat_error,
+            )
+
+        steps: list[lc.StepResult] = []
+        for requested in names:
+            try:
+                channel = await self._create_one(
+                    guild,
+                    kind,
+                    requested,
+                    category,
+                    reason,
+                )
+            except discord.Forbidden:
+                steps.append(lc.StepResult(0, requested, False, "missing permission"))
+            except discord.HTTPException as exc:
+                steps.append(lc.StepResult(0, requested, False, f"Discord: {exc}"))
+            else:
+                steps.append(lc.StepResult(int(channel.id), requested, True))
+
+        steps_t = tuple(steps)
+        outcome = lc.classify_outcome(steps_t)
+        committed_at = lc.now_utc()
+        summary = self._create_summary(names, category, kind, steps_t)
+        audit_emitted = await lc.emit_lifecycle_audit(
+            mutation_id=mutation_id,
+            domain=DOMAIN,
+            operation=operation,
+            guild_id=guild.id,
+            target=f"channels:{len(names)}",
+            summary=summary,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            occurred_at=committed_at,
+        )
+        event_emitted = await self._emit_event(
+            mutation_id=mutation_id,
+            guild_id=guild.id,
+            operation=operation,
+            outcome=outcome,
+            steps=steps_t,
+            committed_at=committed_at,
+        )
+        return lc.LifecycleResult(
+            mutation_id=mutation_id,
+            guild_id=guild.id,
+            domain=DOMAIN,
+            operation=operation,
+            outcome=outcome,
+            reversibility=reversibility,
+            steps=steps_t,
+            committed_at=committed_at,
+            audit_emitted=audit_emitted,
+            event_emitted=event_emitted,
+        )
+
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
@@ -281,6 +406,78 @@ class ChannelLifecycleService:
             )
         elif operation == "clone":
             await channel.clone(name=request.clone_name, reason=reason)  # type: ignore[attr-defined]
+
+    async def _resolve_create_category(
+        self,
+        guild: discord.Guild,
+        category_id: int | None,
+        category_name: str | None,
+    ) -> tuple[discord.CategoryChannel | None, str | None]:
+        """Resolve the target category for a create batch.
+
+        ``category_id`` resolves an existing category (error if it is gone);
+        ``category_name`` get-or-creates one by name (the long-standing
+        ``!evt`` / create-panel behaviour); neither given → no category.
+        Returns ``(category, error)`` — ``error`` is non-None on failure and the
+        caller aborts the whole batch.
+        """
+        if category_id is not None:
+            from core.runtime import guild_resources
+
+            cat = guild_resources.resolve_category(guild, category_id=category_id)
+            if cat is None:
+                return None, f"category {category_id} not found"
+            return cat, None
+        if category_name:
+            from utils.channels import get_or_create_category
+
+            try:
+                cat = await get_or_create_category(guild, category_name)
+            except discord.Forbidden:
+                return None, "missing permission to create the category"
+            except discord.HTTPException as exc:
+                return None, f"Discord: {exc}"
+            return cat, None
+        return None, None
+
+    async def _create_one(
+        self,
+        guild: discord.Guild,
+        kind: str,
+        requested_name: str,
+        category: discord.CategoryChannel | None,
+        reason: str | None,
+    ) -> discord.abc.GuildChannel:
+        """Create a single channel with a collision-safe name.
+
+        This is the one sanctioned ``guild.create_*`` call for *manual* operator
+        channels (allowlisted in ``test_no_silent_auto_create.py`` as the channel
+        sibling of ``role_lifecycle_service``).
+        """
+        from utils.channels import safe_channel_name
+
+        safe = await safe_channel_name(guild, requested_name)
+        if kind == "voice":
+            return await guild.create_voice_channel(
+                safe,
+                category=category,
+                reason=reason,
+            )
+        return await guild.create_text_channel(safe, category=category, reason=reason)
+
+    def _create_summary(
+        self,
+        names: Sequence[str],
+        category: discord.CategoryChannel | None,
+        kind: str,
+        steps: tuple[lc.StepResult, ...],
+    ) -> str:
+        applied = sum(1 for s in steps if s.ok)
+        where = f" in category {category.name!r}" if category is not None else ""
+        return (
+            f"create {len(names)} {kind} channel(s){where} "
+            f"({applied}/{len(steps)} applied)"
+        )
 
     def _resolve_overwrite_target(
         self,

--- a/disbot/views/channels/create_panel.py
+++ b/disbot/views/channels/create_panel.py
@@ -23,7 +23,8 @@ from discord.ext import commands
 
 from core.runtime.interaction_helpers import safe_defer
 from core.runtime.panel_recovery import restore_parent_or_send_fresh
-from utils.channels import get_or_create_category, safe_channel_name
+from services.channel_lifecycle_service import ChannelLifecycleService
+from services.lifecycle import BLOCKED
 from utils.ui_constants import ERROR_COLOR, SUCCESS_COLOR, WARNING_COLOR
 from views.base import BaseView
 from views.channels._helpers import _CATEGORY_PRESETS, _NAME_PRESETS
@@ -190,42 +191,40 @@ class _CreateSubView(BaseView):
 
         guild = interaction.guild
 
-        # Resolve the shared category once — a failure here aborts the whole
-        # batch (every channel would land in the same place).
-        category = None
-        if self.chosen_cat:
-            try:
-                category = await get_or_create_category(guild, self.chosen_cat)
-            except discord.Forbidden:
-                await interaction.followup.send(
-                    "❌ I don't have permission to create categories.",
-                    ephemeral=True,
-                )
-                return
-            except discord.HTTPException as exc:
-                await interaction.followup.send(
-                    f"❌ Failed to create category: {exc}",
-                    ephemeral=True,
-                )
-                return
+        # Channel + category creation route through the audited lifecycle seam
+        # (P0-4 PR 2, Q-0100). A category failure blocks the whole batch — every
+        # channel would otherwise land in the wrong place.
+        result = await ChannelLifecycleService().create_channels(
+            guild,
+            names,
+            interaction.user,
+            category_name=self.chosen_cat or None,
+            actor_type="admin",
+        )
+        if result.outcome == BLOCKED:
+            await interaction.followup.send(f"❌ {result.first_error}", ephemeral=True)
+            return
 
         created: list[str] = []
         renamed: list[str] = []
         forbidden: list[str] = []
         failed: list[str] = []
-        for requested in names:
-            safe = await safe_channel_name(guild, requested)
-            try:
-                ch = await guild.create_text_channel(safe, category=category)
-            except discord.Forbidden:
-                forbidden.append(requested)
-            except discord.HTTPException as exc:
-                logger.warning("Channel create failed | name=%r exc=%s", requested, exc)
-                failed.append(requested)
+        for step in result.steps:
+            if step.ok:
+                ch = guild.get_channel(step.target_id)
+                mention = ch.mention if ch is not None else step.target_name
+                created.append(mention)
+                if ch is not None and ch.name != step.target_name:
+                    renamed.append(f"`{step.target_name}` → {mention}")
+            elif step.error == "missing permission":
+                forbidden.append(step.target_name)
             else:
-                created.append(ch.mention)
-                if safe != requested:
-                    renamed.append(f"`{requested}` → {ch.mention}")
+                logger.warning(
+                    "Channel create failed | name=%r err=%s",
+                    step.target_name,
+                    step.error,
+                )
+                failed.append(step.target_name)
 
         result_embed = self._build_result_embed(
             created=created,

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,7 +25,10 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-_(no active claims)_
+- `claude/gracious-ramanujan-a8nnjf` · P0-4 PR 2 — converge channel creation + category
+  lifecycle under the audited `ChannelLifecycleService` (Q-0100, issue #821) ·
+  `services/channel_lifecycle_service.py` · `cogs/channel_cog.py` ·
+  `views/channels/create_panel.py` · the two channel invariants · 2026-06-14
 
 ## Recently cleared
 

--- a/docs/ownership.md
+++ b/docs/ownership.md
@@ -76,7 +76,7 @@ writes must come from the owning cog or a shared service.
 | `deathmatch`   | `deathmatch_stats`                             | direct via `utils/db/games/deathmatch.py` |
 | `rps_tournament` | `rps_players`, `rps_matches`                 | direct via `utils/db/games/rps.py`; balance mutations via economy_service |
 | `blackjack`    | (uses `xp.coins`; tournament state in `guild_settings`) | balance via economy_service |
-| `channel`      | (uses Discord API; visibility via governance)  | rename/move/delete/reorder via `services/channel_lifecycle_service.py`; visibility via governance pipeline; declared creation via `ResourceProvisioningPipeline` |
+| `channel`      | (uses Discord API; visibility via governance)  | rename/move/delete/reorder/overwrite/clone **and ad-hoc operator creation** via `services/channel_lifecycle_service.py` (P0-4, Q-0100); visibility via governance pipeline; subsystem-*bound* creation via `ResourceProvisioningPipeline` |
 | `proof_channel`| (uses Discord API; balance via economy)        | economy_service |
 | `utility`      | (no DB tables of its own)                      | n/a |
 | `leaderboard`  | (reads every owner's tables; no writes)        | n/a |
@@ -412,12 +412,16 @@ per-surface map in
   `role_automation.clear_{time,xp}_threshold` methods (old-value read → clear →
   XP-cache invalidate → audit emit), and the invariant now fences **every** threshold
   mutation primitive — setters, clears, and the full-row `remove_role_threshold`.
-- ⏳ **Channel create/edit lifecycle — still mixed.** Several channel create/edit
-  paths mix direct Discord calls with `ChannelLifecycleService`; this must converge on
-  a canonical audited writer **before** any profile/routine is allowed to drive channel
-  lifecycle (otherwise the draft lane has no single seam to compile into). Until then,
-  profiles/routines must not target that axis. This is the larger secondary gap noted
-  in the planning doc §16.5; assess before automating, do not rewrite wholesale.
+- ✅ **Channel create/edit lifecycle — converged (P0-4, Q-0100).** Every operator
+  channel mutation now routes through one canonical audited writer: change ops
+  (rename/move/delete/reorder), `set_overwrite`, and `clone` (P0-4 PR 1), plus **ad-hoc
+  operator creation** (`!create`/`!evt`/`!bulkcreate` + the create panel) via
+  `ChannelLifecycleService.create_channels` (P0-4 PR 2). Subsystem-*bound* creation stays
+  with `ResourceProvisioningPipeline`. Two invariants fence it:
+  `test_no_direct_channel_mutations.py` pins `.delete`/`.edit`/`.set_permissions`/`.clone`
+  + the `create_*` calls in the cog/views, and `test_no_silent_auto_create.py` keeps the
+  repo-wide create-call allowlist (the service is the one sanctioned manual `guild.create_*`
+  caller). The draft lane now has a single seam to compile channel-lifecycle into.
 
 ---
 

--- a/docs/planning/production-readiness/hardening-roadmap-2026-06-12.md
+++ b/docs/planning/production-readiness/hardening-roadmap-2026-06-12.md
@@ -27,7 +27,7 @@ session". Tracks needing an owner decision name the routed Q-block.
 | Games | Partial | Wager settlement not atomic — can mint coins / lose entry fees | [games](games-production-readiness-map-2026-06-12.md) |
 | Media / YouTube | **Not ready** | Cache never purged + raw metadata stored indefinitely (privacy) | [media](media-youtube-production-readiness-map-2026-06-12.md) |
 | Settings / bindings / provisioning | Partial | Dual-lane pointers bypass binding validation; delegated-setup authority mismatch | [settings](settings-bindings-provisioning-production-readiness-map-2026-06-12.md) |
-| Server management | Partial | Mixed channel-mutation ownership (some audited, some direct) | [server-mgmt](server-management-production-readiness-map-2026-06-12.md) |
+| Server management | Partial | ~~Mixed channel-mutation ownership~~ → **converged (P0-4 complete)**; remaining gap = live verification only | [server-mgmt](server-management-production-readiness-map-2026-06-12.md) |
 | AI / Setup Advisor | Partial | Live-eval defect rate; no versioned eval/smoke matrix | [ai](ai-production-readiness-map-2026-06-12.md) |
 | BTD6 | Partial (gated) | Model-faithfulness + absence-claim safety; manual blob seeding | [btd6](btd6-production-readiness-map-2026-06-12.md) |
 | Health / diagnostics | Partial | Findings have no lifecycle transition; smoke/hub drift | [health](health-diagnostics-production-readiness-map-2026-06-12.md) |
@@ -85,15 +85,25 @@ what actually writes.
 families) + decide the delegated-Setup apply contract (Q-0098) + add the parity invariants
 (P1-3). → settings map "Recommended next session".
 
-### P0-4 · Server-management channel-ownership convergence  ·  needs **Q-0100**
-**Evidence:** [server-mgmt map](server-management-production-readiness-map-2026-06-12.md) —
-channel creation, clone, permission-overwrite, and category lifecycle paths sit **outside**
-the one audited lifecycle/provisioning seam; the same operator action gets different audit,
-confirmation, and failure behavior depending on path. The channel invariant only pins
+### P0-4 · Server-management channel-ownership convergence  ·  ✅ **SHIPPED (PR 1 #820 + PR 2, 2026-06-14)** · Q-0100 answered
+**Done:** every operator channel mutation routes through the audited
+`ChannelLifecycleService`. **PR 1 (#820):** `set_overwrite` + `clone` ops, all
+`.set_permissions()`/`.clone()` call sites routed off, invariant pins both. **PR 2:** ad-hoc
+operator creation (`!create`/`!evt`/`!bulkcreate` + the create panel) + category lifecycle via
+`ChannelLifecycleService.create_channels` (audit + `channel.lifecycle_changed` event + typed
+per-name result); `test_no_direct_channel_mutations.py` now pins `create_text_channel`/
+`create_voice_channel`/category creation, and `test_no_silent_auto_create.py` lists the service
+as the one sanctioned manual `guild.create_*` caller.
+**Design decision (Q-0100):** ad-hoc creation has *no* declared binding, so it does NOT fit the
+catalogue-driven `ResourceProvisioningPipeline`; it is owned by `ChannelLifecycleService`
+(the channel sibling of the audited `RoleLifecycleService`). Subsystem-*bound* creation stays
+with the provisioning pipeline.
+
+**Evidence (original):** [server-mgmt map](server-management-production-readiness-map-2026-06-12.md) —
+channel creation, clone, permission-overwrite, and category lifecycle paths sat **outside**
+the one audited lifecycle/provisioning seam; the same operator action got different audit,
+confirmation, and failure behavior depending on path. The channel invariant only pinned
 `.edit()`/`.delete()`, giving a false sense of completeness.
-**Why P0:** audit-trail integrity; uneven confirmation on destructive guild mutations.
-**Bounded session:** decide the canonical owner per direct path (Q-0100), then converge under
-it + extend the invariant. → server-mgmt map "Recommended next session".
 
 ---
 
@@ -176,9 +186,10 @@ owner-picked as the next implementation session — design pinned:**
    wrong commands and stale ownership. One session.
 2. **P0-1 games wager money-safety** — highest concrete harm (mints/loses currency),
    self-contained, no owner gate, test-injectable.
-3. **P0-3 / P0-4** — now unblocked (Q-0098 / Q-0100 answered): settings pointer-lane +
-   delegated-apply route, or server-mgmt channel-ownership convergence under the existing
-   seams. Both are now design-decided; sequence by the owner's pick.
+3. **P0-3 / P0-4** — ✅ **both SHIPPED.** P0-3 (settings pointer-lane + delegated-apply,
+   #777/#794/#817) and P0-4 (channel-ownership convergence, #820 + PR 2, 2026-06-14) are
+   complete. **Next implementation track = P0-2 media retention (Q-0099), then P1-1 eval
+   matrix.**
 
 > As a track lands, update the relevant map's rows from Partial/Not Done → Done with the PR
 > as evidence, and tick the verdict table above.

--- a/docs/planning/production-readiness/server-management-production-readiness-map-2026-06-12.md
+++ b/docs/planning/production-readiness/server-management-production-readiness-map-2026-06-12.md
@@ -4,7 +4,7 @@
 >
 > **Scope:** setup, channel management, role management, moderation, cleanup, and the unified Server Management Hub. Source code and merged PRs win over this document.
 >
-> **Verdict:** **Partial / not yet production-ready as one end-to-end subsystem.** The unified composition, setup draft/apply lane, moderation convergence, role lifecycle service, cleanup policy controls, diagnostics composer, and most targeted unit/invariant coverage are Done. The main readiness blocker is the still-mixed channel mutation surface: direct channel creation, permission-overwrite, clone, and category paths remain outside one canonical audited lifecycle/provisioning seam. Production live verification and failure-path integration evidence are also incomplete.
+> **Verdict:** **Partial / not yet production-ready as one end-to-end subsystem.** The unified composition, setup draft/apply lane, moderation convergence, role lifecycle service, cleanup policy controls, diagnostics composer, and most targeted unit/invariant coverage are Done. **The channel-mutation surface is now converged (P0-4 complete, 2026-06-14): permission-overwrite + clone (PR 1) and ad-hoc creation + category lifecycle (PR 2) all route through the audited `ChannelLifecycleService`.** The remaining readiness gap is the cross-cutting one shared by every subsystem: production live verification and failure-path integration evidence.
 
 ## Current verified state
 
@@ -36,7 +36,7 @@
 | Server-management health/read model | `disbot/services/server_management_hub.py` | Read service | **Done** | Central read-only badge composer; keeps health reads out of the hub view. | `tests/unit/services/test_server_management_hub.py`. |
 | Access Map | `disbot/views/server_management/access_map.py` | Read-only panel | **Done** | Uses the access projection seam and is display-only. | Hub/access-map tests and display-only invariant coverage; merged #656. |
 | Help Preview | `disbot/views/server_management/access_map.py` | Read-only panel | **Done** | Uses `project_help_with_execution`, including governance/overlay behavior and orphan reporting after the #671 correction. | Merged #671; projection tests outside this subsystem map. |
-| Channel cog | `disbot/cogs/channel_cog.py` | Cog | **Partial** | Rich command surface and lifecycle routing for owned operations, but creation, clone, and overwrite mutations remain mixed/direct. | `tests/unit/invariants/test_no_direct_channel_mutations.py` explicitly excludes these remaining operations. |
+| Channel cog | `disbot/cogs/channel_cog.py` | Cog | **Done** | Full command surface routes every mutation through `ChannelLifecycleService` — change ops, overwrite, clone (P0-4 PR 1), and creation (`!create`/`!evt`/`!bulkcreate`, P0-4 PR 2). No direct `guild.create_*`. | `tests/unit/invariants/test_no_direct_channel_mutations.py` now pins `create_text_channel`/`create_voice_channel`/category creation; cog removed from `test_no_silent_auto_create.py` allowlist. |
 | Role cog | `disbot/cogs/role_cog.py`; `disbot/cogs/role/` | Cog / schema | **Done** | Canonical role hub, automation listeners, reaction-role commands, hidden panel-action routes, and schemas are wired; role-object lifecycle writes route through the lifecycle service. | Role routing/lifecycle/threshold invariant tests. |
 | Moderation cog | `disbot/cogs/moderation_cog.py`; `disbot/cogs/moderation/` | Cog / schema / helpers | **Done** | Prefix/slash/manual moderation surfaces converge on `moderation_service`; capability/permission OR-gate is pinned. | `test_no_direct_moderation_writes.py`; `test_moderation_role_authority.py`; merged #521. |
 | Cleanup cog | `disbot/cogs/cleanup_cog.py`; `disbot/cogs/cleanup/` | Cog / panel / schema | **Done** | Exposes cleanup configuration, history scan, word controls, staged policy application, and the reusable cleanup panel. | Cleanup cog/panel/stage/history tests; merged #549. |
@@ -76,11 +76,11 @@
 | Rename / move / reorder / delete service | `disbot/services/channel_lifecycle_service.py` | Lifecycle service | **Done** | Owns confirmed operator lifecycle operations, feasibility, audit companion, and lifecycle event emission. | `tests/unit/services/test_channel_lifecycle_service.py`; merged #523. |
 | Delete panel | `disbot/views/channels/delete_panel.py` | Panel | **Done** | Requires explicit confirmation and routes deletion through `ChannelLifecycleService`. | Channel mutation invariant. |
 | Move/reorder panel | `disbot/views/channels/move_panel.py` | Panel | **Done** | Selector-driven move/top/bottom operations route through the lifecycle service. | `tests/unit/views/test_channel_move_panel.py`; lifecycle tests. |
-| Channel creation panel | `disbot/views/channels/create_panel.py` | Panel / provisioning consumer | **Done** | Uses the resource-provisioning lane rather than silently creating from a detector/read model. | Resource-provisioning contract and channel service tests. |
-| Legacy/prefix channel creation | `ChannelCog.manage_event`; `create_channel_with_role`; `bulk_create_channels` | Management functions | **Partial** | These functions still call Discord channel/category creation directly, so channel creation does not have one canonical audited writer across all surfaces. | Source inspection; `docs/ownership.md` marks channel create/edit lifecycle mixed. |
+| Channel creation panel | `disbot/views/channels/create_panel.py` | Panel / lifecycle consumer | **Done** | P0-4 PR 2: the batch create flow routes through `ChannelLifecycleService.create_channels` (audit + `channel.lifecycle_changed` event + per-name typed result), not a direct `guild.create_text_channel`. *(Corrected 2026-06-14: the prior "uses the resource-provisioning lane" wording was aspirational — source still called Discord directly until PR 2.)* | `tests/unit/views/test_create_panel_multi.py`; panel removed from `test_no_silent_auto_create.py` allowlist. |
+| Legacy/prefix channel creation | `ChannelCog.manage_event`; `create_channel_with_role`; `bulk_create_channels` | Management functions | **Done** | P0-4 PR 2: all three route through `ChannelLifecycleService.create_channels` (one canonical audited creator across every surface); `manage_event`'s "Events" category and any named category are get-or-created inside that audited op. | `test_no_direct_channel_mutations.py` (pins `create_*` in the cog); `test_channel_lifecycle_service.py` create-batch tests. |
 | Channel permission overwrites | `ChannelCog.set_access`; `lock_channel`; `unlock_channel`; `modify_permissions`; `disbot/views/channels/restrict_panel.py` | Management functions / panels | **Done** | P0-4 (Q-0100): every overwrite routes through `ChannelLifecycleService.set_overwrite` (audit + `channel.lifecycle_changed` event + typed result); the invariant now pins `.set_permissions()`. `visibility_panel.py` was already audited via `governance_service`. | `test_no_direct_channel_mutations.py` (pins `.set_permissions`); `test_channel_lifecycle_service.py`; `test_restrict_panel_multi.py`. |
 | Channel clone | `ChannelCog.clone_channel` | Management function | **Done** | P0-4 (Q-0100): clone routes through `ChannelLifecycleService.clone` (compensatable, audited); the invariant pins `.clone()`. | `test_no_direct_channel_mutations.py`; `test_channel_lifecycle_service.py`. |
-| Category lifecycle / event category creation | `ChannelCog.manage_event`; channel create helpers | Management function | **Partial** | Category creation/lifecycle is not fully converged behind one audited service. | Source inspection; server-management folio current-state note. |
+| Category lifecycle / event category creation | `ChannelLifecycleService._resolve_create_category`; `utils.channels.get_or_create_category` | Management function | **Done** | P0-4 PR 2: category resolution/get-or-create happens inside the audited `create_channels` op (by id or by name); the raw `guild.create_category` stays in the allowlisted `utils.channels` infra helper, called only from the audited service. | `test_channel_lifecycle_service.py` (`get_or_creates_category_by_name`, `resolves_existing_category_by_id`). |
 | Bulk delete and single delete commands | `ChannelCog.bulk_delete_channels`; `delete_channel`; `manage_event(delete)` | Management functions | **Done** | Route through `ChannelLifecycleService` and return typed outcome errors. | Channel invariant and service tests. |
 | Channel list/info/pagination | `ChannelCog.list_channels`; `channel_info`; `_ChannelListPaginatorView` | Read-only management functions | **Done** | Read-only inventory and pagination are implemented. | `tests/unit/cogs/test_channel_list_paginate.py`. |
 
@@ -122,8 +122,19 @@
 
 ## Required before production-ready
 
-1. **Converge the remaining channel mutation paths.** **Clone + permission-overwrite are DONE** (P0-4 PR 1, Q-0100 — routed through `ChannelLifecycleService`). **Remaining: direct creation + category lifecycle** (`ChannelCog.manage_event` create, `create_channel_with_role`, `bulk_create_channels`, `views/channels/create_panel.py`) need to converge under `ResourceProvisioningPipeline` (preserve its confirmation rule), since ad-hoc operator creation has no declared binding — design that fit explicitly.
-2. **Expand the channel mutation invariant after each convergence.** `.set_permissions()` and `.clone()` are now pinned (P0-4 PR 1). Still to pin: the creation/category calls, once their canonical provisioning path exists.
+1. **Converge the remaining channel mutation paths.** ✅ **DONE (P0-4 complete, 2026-06-14).**
+   Clone + permission-overwrite (PR 1) and creation + category lifecycle (PR 2) all route
+   through `ChannelLifecycleService`. **Design note:** ad-hoc operator creation has *no*
+   declared binding, so it does NOT fit the catalogue-driven `ResourceProvisioningPipeline`
+   (which always resolves a `(subsystem, binding_name)` option and writes a binding row).
+   It is instead owned by `ChannelLifecycleService.create_channels` — the channel-domain
+   sibling of the allowlisted `RoleLifecycleService` (the audited manual-role creator).
+   Subsystem-*bound* creation stays with the provisioning pipeline.
+2. **Expand the channel mutation invariant after each convergence.** ✅ **DONE.**
+   `.set_permissions()` / `.clone()` (PR 1) and `create_text_channel` /
+   `create_voice_channel` / category creation (PR 2) are pinned in
+   `test_no_direct_channel_mutations.py` for the cog + channel views;
+   `test_no_silent_auto_create.py` lists the service as the one sanctioned manual creator.
 3. **Run a production-like live walk.** Exercise both prefix and slash entry points, hub navigation/back paths, setup stage → preview → apply → recovery, authority denials, Discord hierarchy failures, audit/log delivery, and cleanup scans on a real guild.
 4. **Verify persistence and partial-failure behavior on real PostgreSQL.** In particular: setup draft/op-kind parity against the deployed schema, lock contention, partial apply/recovery, cleanup policy writes, moderation history, and event/audit companion failure behavior.
 5. **Decide whether preflight adapters are required for every setup op before launch.** Today several known op kinds intentionally render `preflight unavailable`; this is safe but weakens operator confidence for compound changes.
@@ -131,8 +142,8 @@
 
 ## Bugs, inconsistencies, and risks
 
-- **Mixed channel ownership is the principal architectural risk.** Some channel paths are audited lifecycle operations while others call Discord directly. Similar operator actions therefore have different audit, confirmation, failure-reporting, and event behavior.
-- **The channel invariant can give a false sense of completeness.** It guarantees only `.edit()` / `.delete()` convergence and documents that overwrites/clone are outside its scope.
+- ~~**Mixed channel ownership is the principal architectural risk.**~~ ✅ **Resolved (P0-4 complete, 2026-06-14).** Every operator channel path — change ops, overwrite, clone, and creation/category — now routes through `ChannelLifecycleService` with uniform audit, confirmation, failure-reporting, and `channel.lifecycle_changed` event behavior.
+- ~~**The channel invariant can give a false sense of completeness.**~~ ✅ The invariant now pins `.edit`/`.delete`/`.set_permissions`/`.clone` **and** the `create_*` calls; nothing in the operator surface is out of its scope.
 - **Setup preflight coverage is incomplete.** Known operations without adapters are valid and apply correctly, but Final Review cannot always show a true current-versus-proposed diff.
 - **Best-effort companions are not durable history.** Channel/role lifecycle audit companions and domain events may fail after Discord mutation succeeds; this is by contract, but operators need live evidence that logging failures are visible enough operationally.
 - **Lifecycle services do not own every adjacent operation.** Role member assignment remains on automation/reaction-role paths by design; channel creation belongs to resource provisioning. Future work must preserve these boundaries rather than creating “one giant lifecycle service.”
@@ -145,7 +156,7 @@
 | Area | Readiness | Summary |
 |---|---|---|
 | **Setup** | **Partial** | Strong draft/apply/recovery architecture, canonical diagnostics, deterministic templates, and broad unit coverage. Needs live/Postgres/failure-path verification and a decision on incomplete preflight adapters. |
-| **Channels** | **Partial** | Rename/move/reorder/delete and their panels are converged. Direct creation, clone, overwrites, and category paths prevent full production readiness. |
+| **Channels** | **Partial** | All mutation paths are converged through `ChannelLifecycleService` (rename/move/reorder/delete, overwrite, clone, **and creation/category** — P0-4 complete). Remaining gap is live verification only. |
 | **Roles** | **Partial** | Core lifecycle and automation ownership are strong and invariant-pinned. Remaining gaps are primarily live verification and known UX follow-ups. |
 | **Moderation** | **Partial** | Service convergence, config, authority, history, and logging contracts are strong. Remaining gaps are live verification and member/unban UX. |
 | **Cleanup** | **Partial** | Policy hierarchy, presets, diagnostics, dry-run, versioning, and moderation integration are implemented. Production persistence/large-history/live behavior still needs verification. |
@@ -186,4 +197,12 @@
 
 ## Recommended next session
 
-**Run a channel-ownership convergence planning/review session, not an implementation-by-default session.** Produce a source-grounded decision for each remaining direct channel mutation (`create_*`, category creation, clone, and permission overwrites): canonical owner, confirmation requirement, audit/event contract, and migration/invariant implications. Cross-check the resource-provisioning contract before assigning creation ownership. End with a bounded implementation sequence and a live-verification matrix for the entire Server Management Hub. Do not add a setup op-kind, create a role-threshold writer, or permit direct cog/view DB writes as part of that work.
+**Channel-ownership convergence is COMPLETE (P0-4, 2026-06-14).** All channel mutation
+paths — change ops, overwrite, clone (PR 1) and creation/category (PR 2) — route through
+`ChannelLifecycleService` with audit + event + invariant coverage. The remaining
+server-management gap is the cross-cutting **production live-verification** one (a real-guild
+walk + real-Postgres failure-path run across all five managers — see § "Tests and
+live-verification gaps"), which pairs with P1-4 in the hardening roadmap and is owner-led.
+
+The next hardening **implementation** track is **P0-2 — Media/YouTube data-minimization &
+retention (Q-0099)**, then **P1-1 — the versioned AI eval/smoke matrix**.

--- a/tests/unit/invariants/test_no_direct_channel_mutations.py
+++ b/tests/unit/invariants/test_no_direct_channel_mutations.py
@@ -16,9 +16,15 @@ Scope notes:
   ``response.edit_message`` (attribute ``edit_message`` — never matched).
 * ``.delete`` / ``.edit`` / ``.set_permissions`` / ``.clone`` are pinned — the
   change operations the lifecycle service owns (Q-0100: clone/overwrite →
-  ChannelLifecycleService).  Channel *creation* (``.create_text_channel`` etc.)
-  is NOT pinned here: it converges under ``ResourceProvisioningPipeline`` in the
-  P0-4 creation follow-up, and is guarded by ``test_no_silent_auto_create.py``.
+  ChannelLifecycleService).
+* **P0-4 PR 2** also pins ad-hoc operator *creation*
+  (``.create_text_channel`` / ``.create_voice_channel`` / ``.create_category``):
+  the cog + channel views must route it through
+  ``ChannelLifecycleService.create_channels`` (the audited manual-channel
+  creator), not call Discord directly.  The complementary
+  ``test_no_silent_auto_create.py`` owns the repo-wide create-call allowlist
+  (the service itself is the one sanctioned manual ``guild.create_*`` caller);
+  subsystem-*bound* creation still goes through ``ResourceProvisioningPipeline``.
 """
 
 from __future__ import annotations
@@ -30,8 +36,18 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 _CHANNEL_COG = _REPO_ROOT / "disbot" / "cogs" / "channel_cog.py"
 _CHANNEL_VIEWS = _REPO_ROOT / "disbot" / "views" / "channels"
 
-# Channel mutations routed through ChannelLifecycleService.
-_FORBIDDEN = {"delete", "edit", "set_permissions", "clone"}
+# Channel mutations routed through ChannelLifecycleService — change operations
+# plus ad-hoc operator creation (P0-4 PR 2).
+_FORBIDDEN = {
+    "delete",
+    "edit",
+    "set_permissions",
+    "clone",
+    "create_text_channel",
+    "create_voice_channel",
+    "create_category",
+    "create_category_channel",
+}
 
 # Receiver expressions whose ``.delete()``/``.edit()`` are *message* operations
 # (panel re-renders), not channel mutations — excluded by the trailing name.

--- a/tests/unit/invariants/test_no_silent_auto_create.py
+++ b/tests/unit/invariants/test_no_silent_auto_create.py
@@ -73,13 +73,18 @@ _ALLOWED_PATHS = {
     # the one sanctioned guild.create_role caller for *manual* roles (subsystem
     # role provisioning still goes through ResourceProvisioningPipeline).
     _DISBOT / "services" / "role_lifecycle_service.py",
+    # Audited manual-channel creator (P0-4 PR 2, Q-0100).  The channel-domain
+    # sibling of role_lifecycle_service: it owns ad-hoc operator channel
+    # creation (the !create / !evt / !bulkcreate commands + the create panel,
+    # which have no declared subsystem binding) with a manage-channels check +
+    # audit companion + channel.lifecycle_changed event.  Subsystem-*bound*
+    # channel creation still goes through ResourceProvisioningPipeline.
+    _DISBOT / "services" / "channel_lifecycle_service.py",
     # Grandfathered legacy paths — UI CRUD and admin commands.
-    # Each migrates to ResourceProvisioningPipeline in a per-subsystem
-    # S10 sub-PR.  (role_cog / views/roles/creation_panel were removed from
-    # this list once their create_role calls routed through
-    # RoleLifecycleService in PR5.)
-    _DISBOT / "views" / "channels" / "create_panel.py",
-    _DISBOT / "cogs" / "channel_cog.py",
+    # Each migrates to a converged audited creator in a per-subsystem S10
+    # sub-PR.  (channel_cog / views/channels/create_panel were removed from
+    # this list once their create_text_channel calls routed through
+    # ChannelLifecycleService.create_channels in P0-4 PR 2.)
     _DISBOT / "cogs" / "counting_cog.py",  # auto-create counting channel
     _DISBOT / "cogs" / "economy_cog.py",  # auto-create economy log channel
 }

--- a/tests/unit/services/test_channel_lifecycle_service.py
+++ b/tests/unit/services/test_channel_lifecycle_service.py
@@ -309,6 +309,157 @@ async def test_clone_calls_clone_and_is_compensatable(svc):
     assert result.reversibility == COMPENSATABLE
 
 
+# ---------------------------------------------------------------------------
+# create_channels — the audited manual-channel creator (P0-4 PR 2, Q-0100)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_channels_success_no_category(svc):
+    guild = _guild([])
+    made = SimpleNamespace(id=500, name="announcements")
+    guild.create_text_channel = AsyncMock(return_value=made)
+    with patch(
+        "utils.channels.safe_channel_name",
+        new_callable=AsyncMock,
+        side_effect=lambda g, n: n,
+    ):
+        result = await svc.create_channels(
+            guild,
+            ["announcements"],
+            _actor(),
+            actor_type="admin",
+        )
+    guild.create_text_channel.assert_awaited_once_with(
+        "announcements",
+        category=None,
+        reason=None,
+    )
+    assert result.outcome == SUCCESS
+    assert result.operation == "create"
+    assert result.reversibility == COMPENSATABLE
+    assert [s.target_id for s in result.applied] == [500]
+
+
+@pytest.mark.asyncio
+async def test_create_channels_get_or_creates_category_by_name(svc):
+    guild = _guild([])
+    cat = SimpleNamespace(id=42, name="Events")
+    made = SimpleNamespace(id=501, name="party")
+    guild.create_text_channel = AsyncMock(return_value=made)
+    with (
+        patch(
+            "utils.channels.safe_channel_name",
+            new_callable=AsyncMock,
+            side_effect=lambda g, n: n,
+        ),
+        patch(
+            "utils.channels.get_or_create_category",
+            new_callable=AsyncMock,
+            return_value=cat,
+        ),
+    ):
+        result = await svc.create_channels(
+            guild,
+            ["party"],
+            _actor(),
+            category_name="Events",
+        )
+    guild.create_text_channel.assert_awaited_once_with(
+        "party",
+        category=cat,
+        reason=None,
+    )
+    assert result.outcome == SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_create_channels_resolves_existing_category_by_id_voice(svc):
+    guild = _guild([])
+    cat = SimpleNamespace(id=42, name="Voice")
+    made = SimpleNamespace(id=502, name="lounge")
+    guild.create_voice_channel = AsyncMock(return_value=made)
+    with (
+        patch(
+            "utils.channels.safe_channel_name",
+            new_callable=AsyncMock,
+            side_effect=lambda g, n: n,
+        ),
+        patch(
+            "core.runtime.guild_resources.resolve_category",
+            return_value=cat,
+        ),
+    ):
+        result = await svc.create_channels(
+            guild,
+            ["lounge"],
+            _actor(),
+            category_id=42,
+            kind="voice",
+        )
+    guild.create_voice_channel.assert_awaited_once_with(
+        "lounge",
+        category=cat,
+        reason=None,
+    )
+    assert result.outcome == SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_create_channels_blocked_when_category_id_missing(svc):
+    guild = _guild([])
+    guild.create_text_channel = AsyncMock()
+    with patch("core.runtime.guild_resources.resolve_category", return_value=None):
+        result = await svc.create_channels(guild, ["x"], _actor(), category_id=999)
+    assert result.outcome == BLOCKED
+    guild.create_text_channel.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_channels_blocked_without_manage_perm(svc):
+    guild = _guild([], manage_channels=False)
+    guild.create_text_channel = AsyncMock()
+    result = await svc.create_channels(guild, ["x"], _actor())
+    assert result.outcome == BLOCKED
+    guild.create_text_channel.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_channels_partial_failure_buckets_forbidden(svc):
+    guild = _guild([])
+    good = SimpleNamespace(id=600, name="ok")
+    guild.create_text_channel = AsyncMock(
+        side_effect=[good, discord.Forbidden(MagicMock(), "no perms")],
+    )
+    with patch(
+        "utils.channels.safe_channel_name",
+        new_callable=AsyncMock,
+        side_effect=lambda g, n: n,
+    ):
+        result = await svc.create_channels(guild, ["ok", "bad"], _actor())
+    assert result.outcome == PARTIAL
+    assert [s.target_id for s in result.applied] == [600]
+    assert result.failed[0].error == "missing permission"
+
+
+@pytest.mark.asyncio
+async def test_create_channels_emits_audit_and_event(svc, _no_side_effects):
+    guild = _guild([])
+    made = SimpleNamespace(id=700, name="general")
+    guild.create_text_channel = AsyncMock(return_value=made)
+    with patch(
+        "utils.channels.safe_channel_name",
+        new_callable=AsyncMock,
+        side_effect=lambda g, n: n,
+    ):
+        result = await svc.create_channels(guild, ["general"], _actor())
+    _no_side_effects.audit.assert_awaited_once()
+    _no_side_effects.event.assert_awaited_once()
+    assert _no_side_effects.audit.await_args.kwargs["operation"] == "create"
+    assert _no_side_effects.event.await_args.kwargs["mutation_id"] == result.mutation_id
+    assert _no_side_effects.event.await_args.args[0] == EVT_CHANNEL_LIFECYCLE
+
+
 @pytest.mark.asyncio
 async def test_preview_is_side_effect_free(svc):
     ch = _channel(10, "general")

--- a/tests/unit/views/test_create_panel_multi.py
+++ b/tests/unit/views/test_create_panel_multi.py
@@ -23,7 +23,28 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import discord
 import pytest
 
+from services.lifecycle import PARTIAL, SUCCESS
+from services.lifecycle.contracts import LifecycleResult, StepResult
 from views.selectors import MultiSelect
+
+
+def _lifecycle_result(steps, outcome):
+    return LifecycleResult(
+        mutation_id="m1",
+        guild_id=1,
+        domain="channel",
+        operation="create",
+        outcome=outcome,
+        reversibility="compensatable",
+        steps=tuple(steps),
+    )
+
+
+def _made_channel(name):
+    ch = MagicMock()
+    ch.mention = f"#{name}"
+    ch.name = name
+    return ch
 
 
 def _build_view():
@@ -83,18 +104,17 @@ async def test_create_makes_every_channel_under_one_category():
     view.chosen_cat = "Community"
 
     interaction = MagicMock()
+    chans = {1: _made_channel("alpha"), 2: _made_channel("beta")}
     interaction.guild = MagicMock()
+    interaction.guild.get_channel.side_effect = lambda cid: chans.get(cid)
     interaction.channel = MagicMock()
 
-    made: list[str] = []
-
-    async def _create(name, category=None):  # noqa: ARG001
-        made.append(name)
-        ch = MagicMock()
-        ch.mention = f"#{name}"
-        return ch
-
-    interaction.guild.create_text_channel = AsyncMock(side_effect=_create)
+    result = _lifecycle_result(
+        [StepResult(1, "alpha", True), StepResult(2, "beta", True)],
+        SUCCESS,
+    )
+    svc = MagicMock()
+    svc.create_channels = AsyncMock(return_value=result)
     embeds: list[discord.Embed] = []
 
     async def _restore(*, parent_message, channel, embed, view):  # noqa: ARG001
@@ -104,12 +124,8 @@ async def test_create_makes_every_channel_under_one_category():
     with (
         patch("views.channels.create_panel.safe_defer", AsyncMock(return_value=True)),
         patch(
-            "views.channels.create_panel.safe_channel_name",
-            AsyncMock(side_effect=lambda _g, n: n),
-        ),
-        patch(
-            "views.channels.create_panel.get_or_create_category",
-            AsyncMock(return_value=MagicMock()),
+            "views.channels.create_panel.ChannelLifecycleService",
+            return_value=svc,
         ),
         patch(
             "views.channels.create_panel.restore_parent_or_send_fresh",
@@ -119,7 +135,9 @@ async def test_create_makes_every_channel_under_one_category():
     ):
         await _click(view, "Create Channel", interaction)
 
-    assert made == ["alpha", "beta"]
+    # Creation routes through the audited lifecycle seam (P0-4 PR 2).
+    assert svc.create_channels.await_args.args[1] == ["alpha", "beta"]
+    assert svc.create_channels.await_args.kwargs["category_name"] == "Community"
     # First restore call carries the result embed (second is the manager panel).
     field_text = " ".join(f.value for f in embeds[0].fields)
     assert "#alpha" in field_text and "#beta" in field_text
@@ -131,19 +149,21 @@ async def test_create_partitions_partial_failures():
     view.selected_presets = ["ok", "denied", "boom"]
 
     interaction = MagicMock()
+    chans = {1: _made_channel("ok")}
     interaction.guild = MagicMock()
+    interaction.guild.get_channel.side_effect = lambda cid: chans.get(cid)
     interaction.channel = MagicMock()
 
-    async def _create(name, category=None):  # noqa: ARG001
-        if name == "denied":
-            raise discord.Forbidden(MagicMock(), "no")
-        if name == "boom":
-            raise discord.HTTPException(MagicMock(), "boom")
-        ch = MagicMock()
-        ch.mention = f"#{name}"
-        return ch
-
-    interaction.guild.create_text_channel = AsyncMock(side_effect=_create)
+    result = _lifecycle_result(
+        [
+            StepResult(1, "ok", True),
+            StepResult(0, "denied", False, "missing permission"),
+            StepResult(0, "boom", False, "Discord: boom"),
+        ],
+        PARTIAL,
+    )
+    svc = MagicMock()
+    svc.create_channels = AsyncMock(return_value=result)
     embeds: list[discord.Embed] = []
 
     async def _restore(*, parent_message, channel, embed, view):  # noqa: ARG001
@@ -153,8 +173,8 @@ async def test_create_partitions_partial_failures():
     with (
         patch("views.channels.create_panel.safe_defer", AsyncMock(return_value=True)),
         patch(
-            "views.channels.create_panel.safe_channel_name",
-            AsyncMock(side_effect=lambda _g, n: n),
+            "views.channels.create_panel.ChannelLifecycleService",
+            return_value=svc,
         ),
         patch(
             "views.channels.create_panel.restore_parent_or_send_fresh",


### PR DESCRIPTION
Closes the final P0 integrity track — **P0-4 channel-ownership convergence (Q-0100)**. Continuation of #820 (PR 1: clone + permission-overwrite). Resolves issue #821.

## What it does
Every operator channel mutation now routes through one audited seam. This PR converges the last two paths — **ad-hoc channel creation** and **category lifecycle**.

## The design decision (the wrinkle #821 flagged)
`ResourceProvisioningPipeline` is **catalogue-driven**: it resolves a `(subsystem, binding_name)` option, checks the option's capability, writes a binding row, and its audit table is keyed on `subsystem`/`binding_name`. **Ad-hoc operator channels (`!create` / `!evt` / `!bulkcreate` / the create panel) have no declared binding**, so they can't go through it without minting a fake binding + a schema migration + a step-bypass.

So they're owned instead by a new **`ChannelLifecycleService.create_channels`** — the channel-domain **sibling of `RoleLifecycleService`** (the already-allowlisted *audited manual-role creator*). Subsystem-**bound** creation still goes through the provisioning pipeline. This is the "design that fit explicitly" the readiness map asked for.

## Changes
- **`services/channel_lifecycle_service.py`** — `create_channels(guild, names, actor, *, category_id|category_name, kind, …)`: bot-perm check → category resolve/get-or-create → safe-named text/voice create → typed `LifecycleResult` (each `StepResult.target_id` = new channel id) + audit companion + `channel.lifecycle_changed` event. The one sanctioned manual `guild.create_*` caller.
- **`cogs/channel_cog.py`** — `manage_event` (create), `create_channel_with_role`, `bulk_create_channels` route through the service; dead `utils.channels` import dropped.
- **`views/channels/create_panel.py`** — batch create routes through the service.
- **Invariants** — `test_no_direct_channel_mutations.py` now pins `create_text_channel`/`create_voice_channel`/category creation in the cog + channel views; `test_no_silent_auto_create.py` adds the service to the allowlist and **removes** `channel_cog` + `create_panel` (they no longer create directly — a net tightening).
- **Docs** — server-mgmt readiness map (4 channel rows → Done; **corrected the `create_panel` "uses provisioning lane" drift** — it called Discord directly until this PR), hardening roadmap P0-4 → SHIPPED, `ownership.md` channel row converged.

## What to test (live)
`!create <name> @role true [category]`, `!evt <name> create`, `!bulkcreate a b c [category]`, and the create-panel multi-name flow — each should create the channel(s) **and** emit an audit entry + `channel.lifecycle_changed` (previously creation was unaudited).

## The one risk
Per-channel failures are now captured as failed `StepResult`s (not raised) and bucketed into the same created/renamed/permission-denied/failed summary the panel showed before — behavior preserved, but the error copy is now sourced from the typed result instead of the raw exception. No schema migration.

## Verification
`python3.10 scripts/check_quality.py --full` green (**9453 passed**); `check_architecture --mode strict` **0 errors**; 9 new `create_channels` unit tests + updated panel tests.

🤖 Autonomous executor — continuation of #821. Labeled `needs-hermes-review` (Q-0117) for independent review of this P0 integrity seam, matching PR 1 (#820).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQm3TjV8oyL5G1kUV3g7qj)_