### PR TITLE
Make unattended-action stance explicit; note send_later is unprovisioned

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -50,7 +50,11 @@ The short version that governs how you work:
   expected, not scope creep). *Ask* only when it's irreversible (data loss /
   external publish), large/cross-cutting (architectural), or the goal itself is
   genuinely ambiguous. If you're about to offer options you expect rejected,
-  you've answered your own question — act.
+  you've answered your own question — act. **Unattended ≠ off-limits (owner directive
+  Q-0129, 2026-06-14):** the maintainer *welcomes* self-initiated action taken in sessions he
+  isn't watching **when it improves the workflow** — the project's whole premise is AI running
+  its own project with only light guidance. Within the rails above, default to **acting and
+  improving**; never hold back a contained, reversible improvement just because no one is watching.
 - **Unclear owner intent.** Consult or add to
   `docs/owner/maintainer-question-router.md` when product/owner intent is genuinely
   unclear; unanswered questions are not approval. Preserve maintainer answers and

--- a/.session-journal.md
+++ b/.session-journal.md
@@ -452,6 +452,16 @@ PR #676; drift surfaced at boot + `!btd6 status`). Full note:
   source" rule applies to your own prior session's notes too, not just Codex/ChatGPT.
 
 ### Cross-agent & git workflow
+- **`send_later` is NOT provisioned in this environment — don't chase it (2026-06-14, Q-0129).**
+  The remote/web harness system prompt now tells PR-watching sessions to "arm a `send_later`
+  self check-in (claude-code-remote MCP) before ending your turn, *if available*." It is **not
+  available here** — a direct ToolSearch returns only `Monitor`/`WebFetch`. So **skip it
+  silently**: don't spend a tool lookup on it and don't narrate the attempt. The working fallback
+  is the documented one — **subscribe to PR activity + report**, plus (optionally) a git-ancestor
+  `Monitor` (`git merge-base --is-ancestor <head> origin/main`) to catch the merge webhooks may
+  not push; native auto-merge lands the PR server-side regardless. The human-set-up equivalent of
+  a self check-in is a one-off Routine (`/schedule in 1h, check PR #N`). **Delete this note** if a
+  future session finds `send_later` *does* resolve here.
 - **★-candidate — Derive the clean/durable answer; don't surface it as an owner
   question when the documented principles already settle it (2026-06-13, Q-0119).**
   When a decision reduces to "the clean / durable / root-cause / one-source-of-truth

--- a/docs/collaboration-model.md
+++ b/docs/collaboration-model.md
@@ -45,6 +45,16 @@ ships a feature **and** leaves the workflow sharper is the ideal session, not an
 over-reaching one. Over many slightly-different sessions, all feeding the same
 shared memory, the system converges on *exactly the right context per task*.
 
+**Owner's standing endorsement — unattended initiative is wanted, not merely tolerated
+(Q-0129, 2026-06-14):** the maintainer has stated plainly that he **does not oppose unattended
+action** — work done on the agent's own initiative in a session he is not watching — **as long
+as it improves the workflow.** In his words, "this whole project's main idea is that AI gets more
+freedom to run its own project with only a little guidance," and a self-initiated docs/tooling
+improvement is "exactly the kind of self-initiated action I like." So the default posture is
+**act and improve**, not wait to be watched or asked. The autonomy boundary below still holds
+(irreversible / external publish / a new *enforced* rule or hook still merit a pause) — but inside
+it, unattended initiative is the goal, not a risk to minimize.
+
 **North star (Q-0083, 2026-06-10):** the owner's declared end-state for this
 workflow is **full self-driving** — the bot detecting its own issues, spawning
 its own fix sessions, merging green work, deploying with canary + rollback,

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -4877,3 +4877,46 @@ specific dangerous class only, prefer `defaultMode: "auto"` + an `ask` list over
 **Home:** `.claude/settings.json` (the change); this Q-block (provenance per Q-0106). The
 `docs/current-state.md` Recently-shipped entry lands when the PR merges (merged-PRs-only convention).
 CLAUDE.md is unchanged — this configures the harness, it does not alter a written rule.
+
+---
+
+### Q-0129 — `send_later` noise + owner endorsement of unattended self-initiated work
+
+> **OBSERVED 2026-06-14 (owner, in-session, same conversation as Q-0128).** Two things. (1) On the
+> harness referencing a `send_later` tool: *"i noticed a lot of sessions mention that, but that only
+> started about a week ago … now all of the sudden every session is trying to use send later but it's
+> never there."* (2) Directive on autonomy: *"it should be clear in the repo that I do not oppose
+> unattended action, as long as it is something that improves the workflow, this whole project's main
+> idea is that AI gets more freedom to run its own project with only a little guidance"* — and earlier
+> in the thread, approving the self-initiated journal note: *"that is exactly the kind of self
+> initiated action I like."*
+
+**Area:** harness/system-prompt behavior · collaboration-model autonomy stance
+**Type:** (1) operational note — **APPLIED** (journal); (2) owner directive — **APPLIED** (ethos to docs)
+
+**(1) `send_later` — what it is and why the noise.** `send_later` is a tool from Anthropic's internal
+**`claude-code-remote`** MCP server that lets a session schedule a future self check-in (re-wake to
+re-check a PR's CI/merge state — the events webhooks don't push). ~A week ago the remote/web harness
+**system prompt** (platform-injected, *not* this repo) gained a PR-watching instruction: "arm a
+`send_later` self check-in before ending your turn, *if available*." The tool is **not provisioned in
+this environment** (a direct ToolSearch returns only `Monitor`/`WebFetch`), so every session checks,
+falls back to subscribe-and-report, and narrates the attempt — the noise the owner saw. Harmless
+(conditional instruction; PRs auto-merge server-side regardless). **Recorded the skip-it note in the
+journal** (§Cross-agent & git workflow): don't chase it; subscribe + report (+ optional git-ancestor
+`Monitor`) is the working fallback; delete the note if `send_later` ever resolves. The human-set-up
+equivalent is a one-off Routine (`/schedule in 1h, check PR #N`). Not in this repo's power to enable —
+it's platform/feature-flag gated.
+
+**(2) Unattended initiative is *wanted*, not merely tolerated.** The owner made his autonomy stance
+explicit: unattended, self-initiated action is welcome **whenever it improves the workflow** — the
+project's premise is AI running its own project with light guidance. This *strengthens* (does not
+replace) the existing "Autonomy boundary — docs free, config asks" rail: the irreversible / external /
+new-enforced-rule pauses still hold, but inside them the default posture is **act and improve**, not
+wait to be watched. Homed as **ethos** (not a new *enforced* rule — so "docs," free-rein per
+collaboration-model.md §"Autonomy boundary"; recorded here for provenance since owner-directed
+in-session): a clause on the CLAUDE.md "Act vs. ask" bullet + a paragraph in
+`docs/collaboration-model.md` §"Why this system exists."
+
+**Home:** `.claude/CLAUDE.md` §Working agreement (Act vs. ask clause); `docs/collaboration-model.md`
+§"Why this system exists" (the endorsement); `.session-journal.md` §Cross-agent & git workflow (the
+`send_later` skip note). This Q-block is provenance.


### PR DESCRIPTION
## What

Two owner-directed, in-session changes (provenance **Q-0129**), both docs/ethos — no runtime code.

### 1. Make the unattended-action stance explicit
The maintainer clarified his autonomy stance: he **welcomes unattended, self-initiated action whenever it improves the workflow** — the project's whole premise is AI running its own project with only light guidance. Recorded as **ethos, not a new enforced rule** (so it's "docs," free-rein per the collaboration model; the existing irreversible / external-publish / new-enforced-rule pauses still hold):

- `.claude/CLAUDE.md` "Act vs. ask" bullet → gains an **"Unattended ≠ off-limits"** clause.
- `docs/collaboration-model.md` §"Why this system exists" → gains the owner's standing endorsement.

### 2. Note that `send_later` is not provisioned here
The remote/web harness system prompt (platform-injected, ~a week ago) now tells PR-watching sessions to arm a `send_later` self check-in *"if available"* — but the tool isn't provisioned in this environment, so every session checks, falls back, and narrates the attempt (the noise the owner noticed). Journal note (`.session-journal.md` §Cross-agent & git workflow) tells future sessions to **skip it silently** and use the documented fallback (subscribe + report, + optional git-ancestor `Monitor`). Includes a "delete this note if it ever resolves" kill-switch.

## Provenance
Owner-directed in-session → applied directly; recorded as **Q-0129** in `docs/owner/maintainer-question-router.md`. Follows #827 (the `bypassPermissions` fix, Q-0128) from the same conversation.

https://claude.ai/code/session_01Rent5bfB32i5zumoMSSGQa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rent5bfB32i5zumoMSSGQa)_