### PR TITLE
Capture idea: routine-activity visibility (see active sessions at a glance)

### DIFF
--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -20,6 +20,12 @@ during grooming** (it stays listed here, annotated ✅) so the active backlog re
 
 Current broad captures:
 
+- [`routine-activity-visibility-2026-06-14.md`](./routine-activity-visibility-2026-06-14.md) —
+  **workflow / UX (2026-06-14, owner-observed):** routine *run* sessions are hidden from the
+  Recents tab (intentional upstream behavior; open FR
+  [anthropics/claude-code#54517](https://github.com/anthropics/claude-code/issues/54517)), so there
+  is no at-a-glance "is a session active?" signal. Can't change the app UI — the DIY fit is a
+  **Discord webhook ping** from each routine on start/finish (ask-gated: needs a channel + webhook).
 - [`cogs-layer-view-residence-guard-2026-06-14.md`](./cogs-layer-view-residence-guard-2026-06-14.md) —
   **tooling / arch invariant (2026-06-14):** a guard flagging `discord.ui.View`/`Modal`
   subclasses **defined under `cogs/`** — invisible to the baseview ratchet (which only scans

--- a/docs/ideas/routine-activity-visibility-2026-06-14.md
+++ b/docs/ideas/routine-activity-visibility-2026-06-14.md
@@ -1,0 +1,44 @@
+# Routine-activity visibility — see active/running sessions at a glance
+
+> **Status:** `ideas` — capture only, owner-observed 2026-06-14. **Not a plan, not approval.**
+> Source code, the binding contracts, and `docs/current-state.md` win over anything here.
+
+**Observed (owner, 2026-06-14, in-session).** Routine *run* sessions do **not** appear among
+normal sessions in the **Recents** tab. To find a running routine the owner must open the
+**Routines** tab → tap a routine → scroll down → tap the active run. There is no at-a-glance
+"is any session active right now?" signal when he comes online.
+
+## Why it's like this (upstream, not ours)
+
+This is an intentional Claude Code **product** behavior: scheduled-routine runs are hidden from
+Recents so daily runs don't flood the list with hundreds of items. It is a known gap with an open
+Anthropic feature request —
+**[anthropics/claude-code#54517](https://github.com/anthropics/claude-code/issues/54517)**
+"Allow scheduled agent / Routine runs to appear in Recents or be pinnable in the sidebar" (related:
+[#33095](https://github.com/anthropics/claude-code/issues/33095), surface active CLI sessions in the
+mobile/web app). **We cannot change the app UI** — the real lever there is 👍 / commenting on #54517.
+
+## Existing workarounds (no build needed)
+
+- **Calendar tab** on the routines page → a visual timeline of all scheduled runs across routines,
+  faster than tapping each routine individually. ([routines docs](https://code.claude.com/docs/en/routines))
+- **Mobile app Code tab** shows sessions with a **green status dot** when active — but only for
+  sessions that *appear in the list*, so it does not help for Recents-hidden routine runs.
+
+## DIY angle that fits *our* ecosystem (the real opportunity)
+
+SuperBot is a Discord bot — so a routine can **announce itself**: have each routine's prompt (or a
+shared step) post a one-line **Discord webhook** ping to a private ops/`#routines` channel on
+**start** and **finish** ("🟢 routine X started 10:31" / "✅ finished — PR #N"). That turns "is
+anything running?" into a phone notification the owner already gets, independent of whether the app
+surfaces the session. Cheap, self-hosted, and independent of the upstream FR.
+
+- **Cost:** a webhook URL as a cloud-environment env var + ~10 lines in the routine prompt or a hook.
+- **Caveat (ask-gated):** posting to Discord is an *external publish* and needs a webhook/secret plus
+  the owner picking the channel — so it is an **ask before building**, not a free-rein change.
+
+## Classification
+
+- **Lane:** small/safe **once the owner okays the channel + webhook** (then it is a contained hook).
+- **Upstream half:** track-only — 👍 #54517; nothing for us to implement there.
+- **Next step:** owner decides whether to build the Discord-ping; if yes, it is roughly a 1-PR add.


### PR DESCRIPTION
## What

Captures an owner-observed idea (no runtime code — one new `docs/ideas/` file + README index entry).

**Observation (in-session):** routine *run* sessions don't appear in the **Recents** tab. Finding an active routine means Routines tab → tap routine → scroll → tap the run — there's no at-a-glance "is a session active right now?" signal.

## Findings captured
- **Upstream/intentional:** routine runs are hidden from Recents so daily runs don't flood it. Known gap with an open Anthropic FR — [anthropics/claude-code#54517](https://github.com/anthropics/claude-code/issues/54517) ("Allow scheduled agent / Routine runs to appear in Recents or be pinnable"). The app UI isn't ours to change; the lever there is 👍 on the issue.
- **Existing workarounds:** the routines **Calendar tab** (timeline of all runs) and the mobile **Code tab** green status dot (only for listed sessions).
- **DIY fit (the real opportunity):** SuperBot is a Discord bot, so a routine can post a **Discord webhook ping** on start/finish to a private ops channel → "is anything running?" becomes a phone notification, independent of the app surfacing it.

## Why capture (not build)
Per the workflow, a mid-stream idea is captured + classified, not promoted. The DIY build is **ask-gated** — posting to Discord is an external publish and needs a webhook/secret + the owner choosing a channel — so it's a capture + offer, not a free-rein change.

No provenance Q needed (pure idea capture, no rule/decision). Third follow-up from the same conversation as #827 (Q-0128) / #828 (Q-0129).

https://claude.ai/code/session_01Rent5bfB32i5zumoMSSGQa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rent5bfB32i5zumoMSSGQa)_