### PR TITLE
Add read-only Railway logs API for Hermes (unblocks log-triage)

### DIFF
--- a/docs/operations/hermes-skills/log-triage.md
+++ b/docs/operations/hermes-skills/log-triage.md
@@ -1,9 +1,10 @@
 # Skill: `superbot-log-triage`
 
-> **Status:** `living-ledger` — ready-to-use Hermes skill prompt. **Gated:** needs a
-> read-only production log source on the VPS (see Setup below) before it can see live
-> bot logs; until then it triages only the VPS-local gateway logs. Update when the
-> deploy target or log source changes.
+> **Status:** `living-ledger` — ready-to-use Hermes skill prompt. **Gated:** the
+> read-only log reader (`scripts/hermes/railway_logs.py`) exists; it just needs a
+> read-only Railway **token** + ids on the VPS (see Setup below) before it can see
+> live bot logs. Until configured it triages only the VPS-local gateway logs.
+> Update when the deploy target or log source changes.
 
 **Window:** between sessions / after a deploy / when the bot misbehaves
 **Purpose:** Read SuperBot's production logs and turn them into a plain-language
@@ -28,9 +29,13 @@ Produce a LOG TRIAGE REPORT for SuperBot. Keep the output under 600 words.
 Do the following in order. Skip any step whose tool is unavailable and say so.
 
 1. PRODUCTION LOGS (Railway)
-   If the `railway` CLI is installed and logged in, run:
-     railway logs --service superbot 2>&1 | tail -n 400
-   (Adjust the service name if different.) If `railway` is not available, say
+   Preferred — the read-only API reader (no CLI or login needed):
+     python3.10 scripts/hermes/railway_logs.py -n 400 2>&1
+   It reads a read-only token + ids from the environment (RAILWAY_PROJECT_TOKEN
+   or RAILWAY_API_TOKEN, plus RAILWAY_PROJECT_ID and RAILWAY_SERVICE_ID) and
+   prints the bot's latest-deployment logs. If it prints "No Railway token found"
+   or another setup error, fall back to the `railway` CLI if present
+   (`railway logs --service worker 2>&1 | tail -n 400`). If neither works, say
    "production logs unavailable — read-only Railway token not configured" and
    continue to step 4 using the local gateway logs instead.
 
@@ -93,10 +98,17 @@ Format the output as:
 - **Read-only by design.** This skill diagnoses; it never restarts, redeploys, or
   scales the bot. Operating production stays a maintainer action (see
   `docs/operations/hermes-control-plane.md` § "Current safety model").
-- **Setup (one-time, maintainer):** install the Railway CLI on the VPS and log in
-  with a **read-only** token scoped to the SuperBot service. Until then the skill
-  still works — it triages the local `hermes-gateway` logs and tells you production
-  logs are unavailable.
+- **Setup (one-time, maintainer):** create a **read-only** Railway token
+  ([railway.com/account/tokens](https://railway.com/account/tokens) — a *project*
+  token scoped to the production project is least-privilege) and put it on the VPS
+  as `RAILWAY_PROJECT_TOKEN` (or `RAILWAY_API_TOKEN`), plus `RAILWAY_PROJECT_ID`
+  and `RAILWAY_SERVICE_ID` (from the dashboard URL
+  `railway.com/project/<id>/service/<id>`). Verify with
+  `python3.10 scripts/hermes/railway_logs.py --whoami`. Until configured the skill
+  still works — it triages the local `hermes-gateway` logs and reports production
+  logs unavailable. (The `railway` CLI remains an optional fallback.) Full
+  reference: `docs/operations/production-deployment.md` § "Hermes read-only log
+  access (Railway API)".
 - A Neon (Postgres) read-only role can be added later the same way for DB-level
   triage (connection health, migration state) — keep it read-only.
 - The output is a diagnosis artifact. If it points at a real bug, paste it into a

--- a/docs/operations/production-deployment.md
+++ b/docs/operations/production-deployment.md
@@ -1,9 +1,11 @@
 # Production deployment — Railway
 
 > **Status:** `living-ledger` — operational facts about where production runs and how code
-> reaches it. Facts verified 2026-06-10 (the build-outage session, PR #685).
-> Maintainer owns the Railway dashboard; agents have **no** Railway access — changes
-> land repo-side (this doc, `.python-version`, `Procfile`) or via the maintainer.
+> reaches it. Facts verified 2026-06-10 (PR #685); deploy-config + log-access facts added
+> 2026-06-14 (Q-0130). Maintainer owns the Railway dashboard. Agents have **no write/deploy
+> access** — those changes land repo-side (this doc, `.python-version`, `Procfile`) or via the
+> maintainer. **New (Q-0130): Hermes has opt-in _read-only_ log access** via the Railway API —
+> see "Hermes read-only log access (Railway API)" below.
 
 ## Where production runs
 
@@ -58,6 +60,67 @@
   **3.13** and always has (the unpinned default predates this doc). Alignment
   direction is an owner decision —
   [`owner/maintainer-question-router.md`](../owner/maintainer-question-router.md) §36.
+
+## Deploy configuration (Railway service settings)
+
+Verified from the dashboard 2026-06-14 (the `worker` service, `production`
+environment). These are the settings worth knowing; everything else is Railway's
+default.
+
+| Setting | Value | Note |
+|---|---|---|
+| Custom Start Command | `python disbot/bot1.py` | Set in the service UI; matches the `Procfile`. |
+| Custom Build Command | (none) | railpack autodetects Python + pip. |
+| Watch Paths | (none) | Every push to `main` builds; no path filter. |
+| Healthcheck Path | (none) | No HTTP healthcheck — the bot is a gateway worker, not a web service. |
+| Cron Schedule | (none) | Long-running process, not a scheduled job. |
+| Teardown | off | The old deployment is not force-stopped the instant a new one starts. |
+| Serverless | off | The bot must stay resident (persistent Discord gateway); never scale-to-zero. |
+| Skipped Builds | off | Always rebuild (this flag is GitHub-only). |
+| Railway config file | (none) | Config lives in the dashboard + repo `Procfile` / `.python-version`. |
+
+**Do not enable Serverless or a Healthcheck Path** without rethinking the bot's
+lifecycle: a Discord gateway bot has no inbound HTTP to health-check and must not
+sleep, so either would break it.
+
+## Hermes read-only log access (Railway API)
+
+**Posture (Q-0130, 2026-06-14):** the "no Railway access" rule now has one
+**read-only** exception — Hermes (and any agent) can read the bot's production logs
+through the Railway public GraphQL API. This unblocks the `superbot-log-triage`
+skill. It is **read-only by construction**: the reader issues GraphQL *queries*
+only, never a mutation — no deploy / restart / scale / delete. Operate/write access
+stays the maintainer's (the broader-access ladder is the open half of Q-0130).
+
+**Reader:** [`scripts/hermes/railway_logs.py`](../../scripts/hermes/railway_logs.py)
+(stdlib-only). It resolves the bot service's latest deployment and prints its logs.
+
+```
+python3.10 scripts/hermes/railway_logs.py -n 400     # latest deployment's logs
+python3.10 scripts/hermes/railway_logs.py --whoami   # verify the token works
+python3.10 scripts/hermes/railway_logs.py --json     # raw JSON for tooling
+```
+
+**One-time maintainer setup:**
+
+1. Create a **read-only token** at <https://railway.com/account/tokens>. A **project
+   token** scoped to the `reliable-grace` production project is least-privilege and
+   preferred; an account/workspace token also works (broader scope).
+2. Find the ids in the dashboard URL
+   `railway.com/project/<PROJECT_ID>/service/<SERVICE_ID>` (the `worker` service).
+   The production environment id is optional.
+3. Put them in **Hermes's environment** (the VPS — never the repo):
+   - `RAILWAY_PROJECT_TOKEN` (project token) **or** `RAILWAY_API_TOKEN` (account token)
+   - `RAILWAY_PROJECT_ID`, `RAILWAY_SERVICE_ID`, optional `RAILWAY_ENVIRONMENT_ID`
+4. Verify: `python3.10 scripts/hermes/railway_logs.py --whoami`, then `... -n 50`.
+
+**Auth detail:** account/workspace tokens use `Authorization: Bearer <token>`;
+project tokens use `Project-Access-Token: <token>` — the script picks the header from
+whichever env var is set (project token preferred when both are present). Endpoint:
+`https://backboard.railway.com/graphql/v2`.
+
+**Network:** running it from a cloud routine/sandbox needs that environment's network
+policy to allow `backboard.railway.com`; on Hermes's VPS normal outbound is enough.
 
 ## Backups
 

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -4920,3 +4920,46 @@ in-session): a clause on the CLAUDE.md "Act vs. ask" bullet + a paragraph in
 **Home:** `.claude/CLAUDE.md` §Working agreement (Act vs. ask clause); `docs/collaboration-model.md`
 §"Why this system exists" (the endorsement); `.session-journal.md` §Cross-agent & git workflow (the
 `send_later` skip note). This Q-block is provenance.
+
+---
+
+### Q-0130 — Railway access for agents: read-only logs now; broader-access ladder to decide
+
+> **OBSERVED 2026-06-14 (owner, in-session, with two Railway dashboard screenshots).** Verbatim:
+> *"I also want to create a railway API for hermes so it can check the bots logs"* and *"if I can
+> grant claude more access to railway I'd love to do so."*
+
+**Area:** production access / security trust-tier · Hermes tooling · `production-deployment.md` posture
+**Type:** (1) read-only log access — **APPLIED** (owner-directed); (2) broader access — **DISCUSS** (owner picks the tier)
+
+**Context.** `docs/operations/production-deployment.md` had stated *"agents have no Railway access."*
+The `superbot-log-triage` skill was a stub — step 1 said "production logs unavailable — read-only
+Railway token not configured." The owner asked to close that gap and signalled openness to more.
+
+**(1) APPLIED — read-only log access (this PR).** New `scripts/hermes/railway_logs.py` (stdlib-only)
+reads the bot's latest-deployment logs via the Railway public GraphQL API
+(`backboard.railway.com/graphql/v2`; cookbook-verified queries `deployments` + `deploymentLogs`).
+**Read-only by construction** — queries only, no mutation. The `log-triage` skill is rewired to use it
+(doc source + regenerated `SKILL.md`). Owner setup (read-only token + ids as VPS env vars, least-priv
+project token) is documented in `production-deployment.md` § "Hermes read-only log access (Railway API)".
+Mocked unit test `tests/unit/scripts/test_railway_logs.py` (14 cases). The "no Railway access" posture
+is narrowed to "no *write/deploy* access; read-only logs allowed."
+
+**(2) DISCUSS — the broader-access ladder (owner picks how far to go).** Granting agents more Railway
+power is a deliberate trust-tier step (the collaboration-model "graduated trust tiers" / Q-0048 pattern),
+so it is *proposed*, not applied. Proposed ladder, least → most privileged:
+  - **T0 (done):** read-only **logs**.
+  - **T1:** read-only **status / metrics** — deployment status, restart count, resource usage, recent
+    deploy history (powers a richer health digest). Still query-only; same read-only token.
+  - **T2:** scoped **write — restart only** (`deploymentRestart` / `serviceInstanceRedeploy`). The first
+    *operate* power — recovers a crash-looped bot. Needs a mutating token (higher blast radius); gate
+    behind an explicit allow + an `emit_audit_action`-style log line, mirroring the Q-0084 merge grant.
+  - **T3:** broader **write** — env vars, scaling, rollbacks, new deploys. Highest risk; almost certainly
+    stays maintainer-only ("merge ≠ deploy; restarts / rollbacks / prod-checks stay the owner's",
+    Q-0084 + production-deployment.md).
+**Recommendation:** **T1** next (pure read, high value, no new risk class); keep **T2** behind an explicit
+owner grant + audit; hold **T3**. *Owner: which tier should I build next?*
+
+**Home:** `scripts/hermes/railway_logs.py` + `docs/operations/production-deployment.md` (access posture +
+setup) + the `log-triage` skill (doc + generated SKILL.md). This Q-block is provenance for T0 and the
+open decision for T1–T3.

--- a/scripts/hermes/railway_logs.py
+++ b/scripts/hermes/railway_logs.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Read SuperBot's production logs from the Railway public GraphQL API (read-only).
+
+This is the production-log source the ``superbot-log-triage`` Hermes skill was
+waiting on: it resolves the bot service's latest deployment and prints its recent
+logs, so Hermes (or any agent) can answer "why is the bot unhappy?" without the
+Railway CLI or the dashboard.
+
+**Read-only by design** — it issues GraphQL *queries* only, never a mutation. It
+cannot deploy, restart, scale, or delete anything. (Broader Railway access is a
+separate, owner-gated decision — see router Q-0130.)
+
+Auth + config come from the environment (never the repo):
+
+    RAILWAY_API_TOKEN       account / workspace token -> ``Authorization: Bearer``
+    RAILWAY_PROJECT_TOKEN   project token             -> ``Project-Access-Token``
+                            Set exactly one. A project token scoped to the
+                            production project is the least-privilege choice.
+    RAILWAY_PROJECT_ID      the project's id
+    RAILWAY_SERVICE_ID      the bot service's id ("worker")
+    RAILWAY_ENVIRONMENT_ID  optional; scopes the lookup to one environment
+
+Get a token at https://railway.com/account/tokens. The project/service ids are in
+the dashboard URL: ``railway.com/project/<PROJECT_ID>/service/<SERVICE_ID>``.
+Run ``--whoami`` first to confirm the token authenticates.
+
+Usage:
+    python3.10 scripts/hermes/railway_logs.py [-n LINES] [--json]
+    python3.10 scripts/hermes/railway_logs.py --whoami           # test the token
+    python3.10 scripts/hermes/railway_logs.py --deployment-id <id>
+
+Stdlib-only (urllib) so CI needs no extra dependency. Added 2026-06-14 under owner
+directive Q-0130.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from typing import Any
+
+API_URL = "https://backboard.railway.com/graphql/v2"
+
+#: A GraphQL transport: ``post(query, variables) -> data``. Injected so the
+#: query/parse logic is unit-testable without touching the network.
+PostFn = Callable[[str, dict[str, Any]], dict[str, Any]]
+
+DEPLOYMENTS_QUERY = """
+query deployments($input: DeploymentListInput!) {
+  deployments(input: $input, first: 5) {
+    edges { node { id status createdAt } }
+  }
+}
+""".strip()
+
+LOGS_QUERY = """
+query deploymentLogs($deploymentId: String!, $limit: Int) {
+  deploymentLogs(deploymentId: $deploymentId, limit: $limit) {
+    timestamp
+    message
+    severity
+  }
+}
+""".strip()
+
+WHOAMI_QUERY = "query { me { id email } }"
+
+#: Railway deployment statuses that mean "this is the live one worth reading".
+ACTIVE_STATUSES = {"SUCCESS", "DEPLOYED"}
+
+
+class RailwayError(RuntimeError):
+    """A config or API error worth printing plainly (no traceback)."""
+
+
+def build_poster(
+    token: str,
+    *,
+    is_project_token: bool,
+    timeout: float = 30.0,
+) -> PostFn:
+    """Return a ``PostFn`` bound to ``token`` and the right auth header."""
+    header_name = "Project-Access-Token" if is_project_token else "Authorization"
+    header_value = token if is_project_token else f"Bearer {token}"
+
+    def post(query: str, variables: dict[str, Any]) -> dict[str, Any]:
+        payload = json.dumps({"query": query, "variables": variables}).encode("utf-8")
+        req = urllib.request.Request(API_URL, data=payload, method="POST")
+        req.add_header("Content-Type", "application/json")
+        req.add_header(header_name, header_value)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                body = json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", "replace")
+            raise RailwayError(f"Railway API HTTP {exc.code}: {detail}") from exc
+        except urllib.error.URLError as exc:
+            raise RailwayError(
+                f"Could not reach Railway API ({API_URL}): {exc.reason}",
+            ) from exc
+        if body.get("errors"):
+            raise RailwayError(
+                "Railway API returned errors:\n" + json.dumps(body["errors"], indent=2),
+            )
+        return body.get("data") or {}
+
+    return post
+
+
+def latest_deployment(
+    post: PostFn,
+    *,
+    project_id: str,
+    service_id: str,
+    environment_id: str | None = None,
+) -> dict[str, Any]:
+    """Return the newest active deployment node (falls back to the newest one)."""
+    input_obj: dict[str, Any] = {"projectId": project_id, "serviceId": service_id}
+    if environment_id:
+        input_obj["environmentId"] = environment_id
+    data = post(DEPLOYMENTS_QUERY, {"input": input_obj})
+    edges = (data.get("deployments") or {}).get("edges") or []
+    nodes = [edge["node"] for edge in edges if edge.get("node")]
+    if not nodes:
+        raise RailwayError(
+            "No deployments found — check RAILWAY_PROJECT_ID / RAILWAY_SERVICE_ID.",
+        )
+    for node in nodes:
+        if node.get("status") in ACTIVE_STATUSES:
+            return node
+    return nodes[0]
+
+
+def fetch_logs(post: PostFn, *, deployment_id: str, limit: int) -> list[dict[str, Any]]:
+    """Return the raw log entries for one deployment, newest window last."""
+    data = post(LOGS_QUERY, {"deploymentId": deployment_id, "limit": limit})
+    return list(data.get("deploymentLogs") or [])
+
+
+def format_logs(logs: list[dict[str, Any]]) -> str:
+    """Render log entries as ``<timestamp> [SEVERITY] message`` lines."""
+    lines: list[str] = []
+    for entry in logs:
+        timestamp = entry.get("timestamp") or ""
+        severity = (entry.get("severity") or "").upper()
+        message = entry.get("message") or ""
+        prefix = f"{timestamp} " if timestamp else ""
+        sev_tag = f"[{severity}] " if severity else ""
+        lines.append(f"{prefix}{sev_tag}{message}")
+    return "\n".join(lines)
+
+
+def _resolve_token() -> tuple[str, bool]:
+    """Return ``(token, is_project_token)`` from the environment."""
+    account = os.environ.get("RAILWAY_API_TOKEN", "").strip()
+    project = os.environ.get("RAILWAY_PROJECT_TOKEN", "").strip()
+    if project:
+        return project, True  # least-privilege; preferred when both are set
+    if account:
+        return account, False
+    raise RailwayError(
+        "No Railway token found. Set RAILWAY_PROJECT_TOKEN (project token, "
+        "least-privilege) or RAILWAY_API_TOKEN (account/workspace token). "
+        "Get one at https://railway.com/account/tokens.",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-n",
+        "--lines",
+        type=int,
+        default=200,
+        help="how many log lines (default 200)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="print raw log JSON instead of text",
+    )
+    parser.add_argument(
+        "--whoami",
+        action="store_true",
+        help="verify the token, then exit",
+    )
+    parser.add_argument(
+        "--deployment-id",
+        help="read this deployment instead of resolving the latest",
+    )
+    parser.add_argument("--project-id", help="override RAILWAY_PROJECT_ID")
+    parser.add_argument("--service-id", help="override RAILWAY_SERVICE_ID")
+    parser.add_argument("--environment-id", help="override RAILWAY_ENVIRONMENT_ID")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        token, is_project_token = _resolve_token()
+        post = build_poster(token, is_project_token=is_project_token)
+
+        if args.whoami:
+            print(json.dumps(post(WHOAMI_QUERY, {}), indent=2))
+            return 0
+
+        deployment_id = args.deployment_id
+        if not deployment_id:
+            project_id = args.project_id or os.environ.get("RAILWAY_PROJECT_ID", "")
+            service_id = args.service_id or os.environ.get("RAILWAY_SERVICE_ID", "")
+            if not project_id or not service_id:
+                raise RailwayError(
+                    "Set RAILWAY_PROJECT_ID and RAILWAY_SERVICE_ID (from the "
+                    "dashboard URL railway.com/project/<id>/service/<id>), or pass "
+                    "--deployment-id. Use --whoami to confirm the token first.",
+                )
+            environment_id = args.environment_id or os.environ.get(
+                "RAILWAY_ENVIRONMENT_ID",
+            )
+            node = latest_deployment(
+                post,
+                project_id=project_id,
+                service_id=service_id,
+                environment_id=environment_id,
+            )
+            deployment_id = node["id"]
+            print(
+                f"# deployment {deployment_id} "
+                f"(status={node.get('status')}, created={node.get('createdAt')})",
+                file=sys.stderr,
+            )
+
+        logs = fetch_logs(post, deployment_id=deployment_id, limit=args.lines)
+        if args.json:
+            print(json.dumps(logs, indent=2))
+        else:
+            print(format_logs(logs))
+        return 0
+    except RailwayError as exc:
+        print(f"railway_logs: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hermes/skills/log-triage/SKILL.md
+++ b/scripts/hermes/skills/log-triage/SKILL.md
@@ -22,9 +22,13 @@ Produce a LOG TRIAGE REPORT for SuperBot. Keep the output under 600 words.
 Do the following in order. Skip any step whose tool is unavailable and say so.
 
 1. PRODUCTION LOGS (Railway)
-   If the `railway` CLI is installed and logged in, run:
-     railway logs --service superbot 2>&1 | tail -n 400
-   (Adjust the service name if different.) If `railway` is not available, say
+   Preferred — the read-only API reader (no CLI or login needed):
+     python3.10 scripts/hermes/railway_logs.py -n 400 2>&1
+   It reads a read-only token + ids from the environment (RAILWAY_PROJECT_TOKEN
+   or RAILWAY_API_TOKEN, plus RAILWAY_PROJECT_ID and RAILWAY_SERVICE_ID) and
+   prints the bot's latest-deployment logs. If it prints "No Railway token found"
+   or another setup error, fall back to the `railway` CLI if present
+   (`railway logs --service worker 2>&1 | tail -n 400`). If neither works, say
    "production logs unavailable — read-only Railway token not configured" and
    continue to step 4 using the local gateway logs instead.
 

--- a/tests/unit/scripts/test_railway_logs.py
+++ b/tests/unit/scripts/test_railway_logs.py
@@ -1,0 +1,217 @@
+"""Tests for ``scripts/hermes/railway_logs.py`` — the read-only Railway log reader.
+
+Hermetic: the GraphQL transport is either injected (``PostFn``) or the urllib
+layer is monkeypatched, so nothing touches the network. We exercise deployment
+selection, log formatting, the auth-header choice, GraphQL error surfacing, and
+the missing-token / missing-id guard paths.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "hermes" / "railway_logs.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("railway_logs_ut", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# --- deployment selection ---------------------------------------------------
+
+
+def _deploys(*nodes: dict) -> dict:
+    return {"deployments": {"edges": [{"node": n} for n in nodes]}}
+
+
+def test_latest_deployment_prefers_active(mod):
+    def post(query, variables):
+        return _deploys(
+            {"id": "d-building", "status": "BUILDING", "createdAt": "t2"},
+            {"id": "d-live", "status": "SUCCESS", "createdAt": "t1"},
+        )
+
+    node = mod.latest_deployment(post, project_id="p", service_id="s")
+    assert node["id"] == "d-live"
+
+
+def test_latest_deployment_falls_back_to_newest(mod):
+    def post(query, variables):
+        return _deploys(
+            {"id": "d-newest", "status": "FAILED", "createdAt": "t2"},
+            {"id": "d-older", "status": "CRASHED", "createdAt": "t1"},
+        )
+
+    node = mod.latest_deployment(post, project_id="p", service_id="s")
+    assert node["id"] == "d-newest"
+
+
+def test_latest_deployment_passes_environment_id(mod):
+    seen: dict = {}
+
+    def post(query, variables):
+        seen.update(variables)
+        return _deploys({"id": "d1", "status": "SUCCESS", "createdAt": "t"})
+
+    mod.latest_deployment(post, project_id="p", service_id="s", environment_id="e")
+    assert seen["input"] == {"projectId": "p", "serviceId": "s", "environmentId": "e"}
+
+
+def test_latest_deployment_omits_environment_when_absent(mod):
+    seen: dict = {}
+
+    def post(query, variables):
+        seen.update(variables)
+        return _deploys({"id": "d1", "status": "SUCCESS", "createdAt": "t"})
+
+    mod.latest_deployment(post, project_id="p", service_id="s")
+    assert "environmentId" not in seen["input"]
+
+
+def test_latest_deployment_raises_when_none(mod):
+    def post(query, variables):
+        return {"deployments": {"edges": []}}
+
+    with pytest.raises(mod.RailwayError):
+        mod.latest_deployment(post, project_id="p", service_id="s")
+
+
+# --- log fetch + formatting -------------------------------------------------
+
+
+def test_fetch_logs_returns_entries(mod):
+    def post(query, variables):
+        assert variables == {"deploymentId": "d1", "limit": 50}
+        return {"deploymentLogs": [{"message": "hi"}]}
+
+    assert mod.fetch_logs(post, deployment_id="d1", limit=50) == [{"message": "hi"}]
+
+
+def test_format_logs_renders_fields(mod):
+    logs = [
+        {"timestamp": "2026-06-14T10:00:00Z", "severity": "error", "message": "boom"},
+        {"message": "bare line"},
+    ]
+    out = mod.format_logs(logs).splitlines()
+    assert out[0] == "2026-06-14T10:00:00Z [ERROR] boom"
+    assert out[1] == "bare line"
+
+
+# --- transport: auth header + GraphQL error surfacing -----------------------
+
+
+class _FakeResp:
+    def __init__(self, payload: dict):
+        self._data = json.dumps(payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self):
+        return self._data
+
+
+def test_build_poster_account_uses_bearer(mod, monkeypatch):
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["auth"] = req.get_header("Authorization")
+        captured["proj"] = req.get_header("Project-access-token")
+        return _FakeResp({"data": {"me": {"id": "u1"}}})
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+    post = mod.build_poster("tok-abc", is_project_token=False)
+    data = post(mod.WHOAMI_QUERY, {})
+    assert data == {"me": {"id": "u1"}}
+    assert captured["auth"] == "Bearer tok-abc"
+    assert captured["proj"] is None
+
+
+def test_build_poster_project_uses_project_header(mod, monkeypatch):
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["auth"] = req.get_header("Authorization")
+        captured["proj"] = req.get_header("Project-access-token")
+        return _FakeResp({"data": {}})
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+    post = mod.build_poster("proj-tok", is_project_token=True)
+    post(mod.WHOAMI_QUERY, {})
+    assert captured["auth"] is None
+    assert captured["proj"] == "proj-tok"
+
+
+def test_post_raises_on_graphql_errors(mod, monkeypatch):
+    def fake_urlopen(req, timeout=None):
+        return _FakeResp({"errors": [{"message": "Not Authorized"}]})
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+    post = mod.build_poster("tok", is_project_token=False)
+    with pytest.raises(mod.RailwayError, match="Not Authorized"):
+        post(mod.WHOAMI_QUERY, {})
+
+
+# --- main() guard paths -----------------------------------------------------
+
+
+def test_main_no_token_exits_2(mod, monkeypatch, capsys):
+    monkeypatch.delenv("RAILWAY_API_TOKEN", raising=False)
+    monkeypatch.delenv("RAILWAY_PROJECT_TOKEN", raising=False)
+    assert mod.main([]) == 2
+    assert "No Railway token" in capsys.readouterr().err
+
+
+def test_main_token_but_no_ids_exits_2(mod, monkeypatch, capsys):
+    monkeypatch.setenv("RAILWAY_API_TOKEN", "tok")
+    monkeypatch.delenv("RAILWAY_PROJECT_TOKEN", raising=False)
+    monkeypatch.delenv("RAILWAY_PROJECT_ID", raising=False)
+    monkeypatch.delenv("RAILWAY_SERVICE_ID", raising=False)
+    assert mod.main([]) == 2
+    assert "RAILWAY_PROJECT_ID" in capsys.readouterr().err
+
+
+def test_main_whoami_happy_path(mod, monkeypatch, capsys):
+    monkeypatch.setenv("RAILWAY_API_TOKEN", "tok")
+    monkeypatch.delenv("RAILWAY_PROJECT_TOKEN", raising=False)
+
+    def fake_urlopen(req, timeout=None):
+        return _FakeResp({"data": {"me": {"id": "u1", "email": "a@b.c"}}})
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+    assert mod.main(["--whoami"]) == 0
+    assert "u1" in capsys.readouterr().out
+
+
+def test_main_fetches_and_formats(mod, monkeypatch, capsys):
+    monkeypatch.setenv("RAILWAY_PROJECT_TOKEN", "ptok")
+    monkeypatch.setenv("RAILWAY_PROJECT_ID", "p")
+    monkeypatch.setenv("RAILWAY_SERVICE_ID", "s")
+    monkeypatch.delenv("RAILWAY_API_TOKEN", raising=False)
+
+    def fake_urlopen(req, timeout=None):
+        body = json.loads(req.data.decode("utf-8"))
+        if "deployments" in body["query"]:
+            return _FakeResp(
+                {"data": _deploys({"id": "d1", "status": "SUCCESS", "createdAt": "t"})}
+            )
+        return _FakeResp({"data": {"deploymentLogs": [{"message": "running"}]}})
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+    assert mod.main(["-n", "10"]) == 0
+    assert "running" in capsys.readouterr().out


### PR DESCRIPTION
## What

Wires up the **read-only Railway log source** that Hermes's `superbot-log-triage` skill was waiting on — its step 1 was a stub: *"production logs unavailable — read-only Railway token not configured."* Also captures the Railway deploy-config facts from your screenshots and the access-posture change.

## The reader — `scripts/hermes/railway_logs.py` (stdlib-only)
- Reads the bot's latest-deployment logs via the Railway public GraphQL API (`backboard.railway.com/graphql/v2`, the `deployments` + `deploymentLogs` queries).
- **Read-only by construction** — issues GraphQL *queries* only, never a mutation. No deploy/restart/scale/delete.
- Token + ids from the environment (never the repo): `RAILWAY_PROJECT_TOKEN` (project token, least-privilege, preferred) or `RAILWAY_API_TOKEN`; `RAILWAY_PROJECT_ID` + `RAILWAY_SERVICE_ID`.
- `--whoami` (verify token), `--json`, `-n LINES`, `--deployment-id`.
- `tests/unit/scripts/test_railway_logs.py` — 14 mocked cases, no network.

## Wiring + docs
- **`log-triage` skill** rewired to call the reader (doc source + regenerated `SKILL.md`); the `railway` CLI stays an optional fallback.
- **`production-deployment.md`**: a "Deploy configuration" table from the dashboard (custom start command `python disbot/bot1.py`; teardown / serverless / healthcheck / cron / skipped-builds all off) + a "Hermes read-only log access (Railway API)" setup section. The "no Railway access" posture is narrowed to **"no write/deploy access; read-only logs allowed."**

## Owner setup (one-time, ~2 min)
1. Create a **read-only token** at railway.com/account/tokens (a project token scoped to `reliable-grace` production is least-privilege).
2. Grab `PROJECT_ID`/`SERVICE_ID` from the dashboard URL.
3. Put them in **Hermes's VPS env** (not the repo); verify with `--whoami`.

## Broader access (your "I'd love to grant more")
Captured as the **DISCUSS** half of **Q-0130** — a graduated ladder: **T0 logs (this PR)** → T1 read-only status/metrics → T2 scoped restart-only write → T3 full write. Recommendation: T1 next, T2 behind an explicit grant + audit, hold T3. **Tell me which tier to build next.**

Provenance: owner-directed in-session, **Q-0130**.

https://claude.ai/code/session_01Rent5bfB32i5zumoMSSGQa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rent5bfB32i5zumoMSSGQa)_