### PR TITLE
Add Railway env-var read/write tool for agents (Q-0130 grant)

### DIFF
--- a/docs/operations/production-deployment.md
+++ b/docs/operations/production-deployment.md
@@ -1,11 +1,12 @@
 # Production deployment — Railway
 
 > **Status:** `living-ledger` — operational facts about where production runs and how code
-> reaches it. Facts verified 2026-06-10 (PR #685); deploy-config + log-access facts added
-> 2026-06-14 (Q-0130). Maintainer owns the Railway dashboard. Agents have **no write/deploy
-> access** — those changes land repo-side (this doc, `.python-version`, `Procfile`) or via the
-> maintainer. **New (Q-0130): Hermes has opt-in _read-only_ log access** via the Railway API —
-> see "Hermes read-only log access (Railway API)" below.
+> reaches it. Facts verified 2026-06-10 (PR #685); deploy-config + Railway-API access added
+> 2026-06-14 (Q-0130). Maintainer owns the Railway dashboard. **Q-0130 grants agents two API
+> capabilities:** read-only **logs** (Hermes) and owner-authorised **read/write of service env
+> variables** — see the two sections below. Everything else (deploy / restart / scale /
+> rollback) stays the maintainer's; non-API changes land repo-side (this doc,
+> `.python-version`, `Procfile`).
 
 ## Where production runs
 
@@ -121,6 +122,44 @@ whichever env var is set (project token preferred when both are present). Endpoi
 
 **Network:** running it from a cloud routine/sandbox needs that environment's network
 policy to allow `backboard.railway.com`; on Hermes's VPS normal outbound is enough.
+
+## Env variable read/write (Railway API)
+
+**Posture (Q-0130, 2026-06-14 — owner-authorised _write_).** Beyond read-only logs,
+the owner explicitly granted agents **read _and write_ access to the bot's service
+environment variables** (the Discord token, `DATABASE_URL`, AI keys, …) via the Railway
+API — to verify them at a glance and change them quickly, accepting the risk. This is a
+genuine write capability. It is **separate from** deploy / restart / scale / rollback,
+which remain the maintainer's.
+
+**Tool:** [`scripts/hermes/railway_vars.py`](../../scripts/hermes/railway_vars.py)
+(reuses the logs reader's transport).
+
+```
+python3.10 scripts/hermes/railway_vars.py list             # names, values masked
+python3.10 scripts/hermes/railway_vars.py list --reveal     # names + values (SECRETS!)
+python3.10 scripts/hermes/railway_vars.py get DATABASE_URL  # one value, to verify it
+python3.10 scripts/hermes/railway_vars.py set NAME VALUE     # create/update (redeploys)
+echo -n "secret" | python3.10 scripts/hermes/railway_vars.py set NAME   # value via stdin
+python3.10 scripts/hermes/railway_vars.py set NAME VALUE --no-deploy   # stage only
+python3.10 scripts/hermes/railway_vars.py unset OLD_NAME    # delete
+```
+
+**Guardrails baked in:** `list` / `get` never mutate; `list` masks values unless
+`--reveal`; `set` / `unset` print an audit line to stderr and never echo the token;
+`set` reads the value from stdin when omitted so secrets stay out of `argv`.
+
+> **A `set` / `unset` triggers a Railway redeploy by default** — that is how the change
+> takes effect. Pass `--no-deploy` to stage a value without redeploying. So an env-var
+> edit *is* effectively a deploy unless you stage it; keep that in mind, since deploys
+> otherwise stay the maintainer's.
+
+**Setup (one-time, maintainer):** needs a **write-capable** token (a project token
+scoped to `reliable-grace`, or an account token) **and all three ids** — variables are
+per-environment, so `RAILWAY_ENVIRONMENT_ID` (production) is required alongside
+`RAILWAY_PROJECT_ID` and `RAILWAY_SERVICE_ID`. Put them in the agent's environment (the
+Claude Code cloud environment's variables and/or Hermes's VPS), and allow
+`backboard.railway.com` in that environment's network policy.
 
 ## Backups
 

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -4958,7 +4958,18 @@ so it is *proposed*, not applied. Proposed ladder, least → most privileged:
     stays maintainer-only ("merge ≠ deploy; restarts / rollbacks / prod-checks stay the owner's",
     Q-0084 + production-deployment.md).
 **Recommendation:** **T1** next (pure read, high value, no new risk class); keep **T2** behind an explicit
-owner grant + audit; hold **T3**. *Owner: which tier should I build next?*
+owner grant + audit; hold **T3**.
+
+**DECIDED 2026-06-14 (owner, in-session) — env-var read+write GRANTED (a T3 subset), APPLIED.** Asked which
+tier, the owner chose to go straight to **service env-variable read _and write_**: *"would that mean that you
+could see and edit my env variables? honestly that would be kinda useful … I give you full access to
+implement this, I know there is some risk but honestly not a lot more than I already have, and I'm willing
+to take the gamble."* Shipped as `scripts/hermes/railway_vars.py` (`list` / `get` / `set` / `unset`) with
+guardrails: masked `list`, audit lines to stderr, secrets via stdin, and `--no-deploy` to stage without a
+redeploy (a `set` otherwise triggers a Railway redeploy). The **other** T3 powers — deploy / restart /
+scale / rollback — were **not** granted and stay maintainer-only. **T1 (read-only metrics)** remains open
+and available on request. Setup the owner must do: a **write-capable** token + all three ids in the agent
+environment (see `production-deployment.md` § "Env variable read/write (Railway API)").
 
 **Home:** `scripts/hermes/railway_logs.py` + `docs/operations/production-deployment.md` (access posture +
 setup) + the `log-triage` skill (doc + generated SKILL.md). This Q-block is provenance for T0 and the

--- a/scripts/hermes/railway_vars.py
+++ b/scripts/hermes/railway_vars.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Read and edit SuperBot's Railway service variables (env vars) — read + WRITE.
+
+Companion to ``railway_logs.py``. It lets an agent verify the bot's production
+environment variables and change them quickly, via the Railway public GraphQL API.
+Unlike the logs reader, this tool can **mutate** (set / unset), so it needs a
+**write-capable** token.
+
+    list                 list variable names (values masked)
+    list --reveal        list names + full values  (PRINTS SECRETS to stdout)
+    get NAME             print one variable's value (to verify it)
+    set NAME [VALUE]     create/update a variable (VALUE from arg, or stdin if omitted)
+    unset NAME           delete a variable
+
+Config comes from the environment (never the repo):
+
+    RAILWAY_API_TOKEN / RAILWAY_PROJECT_TOKEN   a **write-capable** token
+    RAILWAY_PROJECT_ID                          the project's id
+    RAILWAY_ENVIRONMENT_ID                       the environment's id (required —
+                                                 variables are per-environment)
+    RAILWAY_SERVICE_ID                          the bot service's id
+
+Guardrails: read subcommands (``list`` / ``get``) never mutate; ``list`` masks
+values unless ``--reveal``; writes print an audit line to stderr and never echo the
+token; ``set`` can take the value on stdin so secrets stay out of argv. Endpoint and
+transport are shared with the read-only logs reader.
+
+Provenance: owner directive Q-0130 (env-var read+write grant, 2026-06-14). The owner
+explicitly authorised write access to service variables, accepting the risk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+# Reuse the logs reader's GraphQL transport + error type (same dir on sys.path when
+# run as a script). resolve_token is re-implemented here with a write-aware message.
+from railway_logs import RailwayError, build_poster
+
+VARIABLES_QUERY = """
+query variables($projectId: String!, $environmentId: String!, $serviceId: String) {
+  variables(projectId: $projectId, environmentId: $environmentId, serviceId: $serviceId)
+}
+""".strip()
+
+UPSERT_MUTATION = """
+mutation variableUpsert($input: VariableUpsertInput!) {
+  variableUpsert(input: $input)
+}
+""".strip()
+
+DELETE_MUTATION = """
+mutation variableDelete($input: VariableDeleteInput!) {
+  variableDelete(input: $input)
+}
+""".strip()
+
+
+def resolve_token() -> tuple[str, bool]:
+    """Return ``(token, is_project_token)`` for a **write-capable** token."""
+    account = os.environ.get("RAILWAY_API_TOKEN", "").strip()
+    project = os.environ.get("RAILWAY_PROJECT_TOKEN", "").strip()
+    if project:
+        return project, True
+    if account:
+        return account, False
+    raise RailwayError(
+        "No Railway token found. Editing variables needs a WRITE-capable token in "
+        "RAILWAY_PROJECT_TOKEN or RAILWAY_API_TOKEN. Get one at "
+        "https://railway.com/account/tokens.",
+    )
+
+
+def resolve_ids(args: argparse.Namespace) -> tuple[str, str, str]:
+    """Return ``(project_id, environment_id, service_id)`` from args/env."""
+    project = args.project_id or os.environ.get("RAILWAY_PROJECT_ID", "")
+    environment = args.environment_id or os.environ.get("RAILWAY_ENVIRONMENT_ID", "")
+    service = args.service_id or os.environ.get("RAILWAY_SERVICE_ID", "")
+    missing = [
+        name
+        for name, value in (
+            ("RAILWAY_PROJECT_ID", project),
+            ("RAILWAY_ENVIRONMENT_ID", environment),
+            ("RAILWAY_SERVICE_ID", service),
+        )
+        if not value
+    ]
+    if missing:
+        raise RailwayError(
+            "Missing required id(s): "
+            + ", ".join(missing)
+            + ". Variables are scoped per environment, so all three are required. "
+            "Get them from the dashboard URL "
+            "railway.com/project/<PROJECT_ID>/service/<SERVICE_ID> and the "
+            "environment selector.",
+        )
+    return project, environment, service
+
+
+def get_variables(
+    post: Any,
+    *,
+    project_id: str,
+    environment_id: str,
+    service_id: str,
+) -> dict[str, str]:
+    """Return ``{name: value}`` for the service's variables."""
+    data = post(
+        VARIABLES_QUERY,
+        {
+            "projectId": project_id,
+            "environmentId": environment_id,
+            "serviceId": service_id,
+        },
+    )
+    return dict(data.get("variables") or {})
+
+
+def upsert_variable(
+    post: Any,
+    *,
+    project_id: str,
+    environment_id: str,
+    service_id: str,
+    name: str,
+    value: str,
+    skip_deploys: bool = False,
+) -> None:
+    """Create or update one variable.
+
+    By default Railway redeploys the service so the change takes effect; pass
+    ``skip_deploys=True`` to stage the value without triggering a deploy.
+    """
+    variable_input: dict[str, Any] = {
+        "projectId": project_id,
+        "environmentId": environment_id,
+        "serviceId": service_id,
+        "name": name,
+        "value": value,
+    }
+    if skip_deploys:
+        variable_input["skipDeploys"] = True
+    post(UPSERT_MUTATION, {"input": variable_input})
+
+
+def delete_variable(
+    post: Any,
+    *,
+    project_id: str,
+    environment_id: str,
+    service_id: str,
+    name: str,
+) -> None:
+    """Delete one variable."""
+    post(
+        DELETE_MUTATION,
+        {
+            "input": {
+                "projectId": project_id,
+                "environmentId": environment_id,
+                "serviceId": service_id,
+                "name": name,
+            },
+        },
+    )
+
+
+def mask(value: str) -> str:
+    """Mask a secret for display: keep a hint, hide the body."""
+    if len(value) <= 4:
+        return f"**** ({len(value)} chars)"
+    return f"{value[:2]}…{value[-2:]} ({len(value)} chars)"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project-id", help="override RAILWAY_PROJECT_ID")
+    parser.add_argument("--environment-id", help="override RAILWAY_ENVIRONMENT_ID")
+    parser.add_argument("--service-id", help="override RAILWAY_SERVICE_ID")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_list = sub.add_parser("list", help="list variable names (values masked)")
+    p_list.add_argument(
+        "--reveal",
+        action="store_true",
+        help="show full values (prints secrets)",
+    )
+    p_list.add_argument("--json", action="store_true", help="print raw JSON")
+
+    p_get = sub.add_parser("get", help="print one variable's value")
+    p_get.add_argument("name")
+
+    p_set = sub.add_parser("set", help="create/update a variable")
+    p_set.add_argument("name")
+    p_set.add_argument(
+        "value",
+        nargs="?",
+        help="value (omit to read from stdin — safer for secrets)",
+    )
+    p_set.add_argument(
+        "--no-deploy",
+        action="store_true",
+        help="stage the change without triggering a Railway redeploy",
+    )
+
+    p_unset = sub.add_parser("unset", help="delete a variable")
+    p_unset.add_argument("name")
+
+    return parser
+
+
+def _run(args: argparse.Namespace, post: Any) -> int:
+    project_id, environment_id, service_id = resolve_ids(args)
+    ids = {
+        "project_id": project_id,
+        "environment_id": environment_id,
+        "service_id": service_id,
+    }
+
+    if args.cmd == "list":
+        variables = get_variables(post, **ids)
+        if args.json:
+            print(json.dumps(variables, indent=2, sort_keys=True))
+        else:
+            for name in sorted(variables):
+                shown = variables[name] if args.reveal else mask(variables[name])
+                print(f"{name}={shown}")
+        return 0
+
+    if args.cmd == "get":
+        variables = get_variables(post, **ids)
+        if args.name not in variables:
+            raise RailwayError(f"No such variable: {args.name}")
+        print(variables[args.name])
+        return 0
+
+    if args.cmd == "set":
+        value = args.value
+        if value is None:
+            value = sys.stdin.read().rstrip("\n")
+        upsert_variable(
+            post,
+            name=args.name,
+            value=value,
+            skip_deploys=args.no_deploy,
+            **ids,
+        )
+        effect = "staged, no redeploy" if args.no_deploy else "Railway will redeploy"
+        print(
+            f"railway_vars: SET {args.name} on service {service_id} "
+            f"env {environment_id} (value: {len(value)} chars; {effect})",
+            file=sys.stderr,
+        )
+        return 0
+
+    if args.cmd == "unset":
+        delete_variable(post, name=args.name, **ids)
+        print(
+            f"railway_vars: UNSET {args.name} on service {service_id} "
+            f"env {environment_id}",
+            file=sys.stderr,
+        )
+        return 0
+
+    return 1  # unreachable: subparser is required
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        token, is_project_token = resolve_token()
+        post = build_poster(token, is_project_token=is_project_token)
+        return _run(args, post)
+    except RailwayError as exc:
+        print(f"railway_vars: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_railway_vars.py
+++ b/tests/unit/scripts/test_railway_vars.py
@@ -1,0 +1,209 @@
+"""Tests for ``scripts/hermes/railway_vars.py`` — the Railway env-var read/write tool.
+
+Hermetic: the GraphQL transport is replaced (``build_poster`` is monkeypatched to a
+recording fake), so nothing touches the network. We exercise id/token resolution,
+read (list/get) vs write (set/unset) routing, value masking, the stdin value path,
+and the guard exits.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "hermes" / "railway_vars.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    # railway_vars does `from railway_logs import ...`; ensure the sibling dir is
+    # importable the same way running it as a script would make it.
+    sys.path.insert(0, str(_SCRIPT.parent))
+    spec = importlib.util.spec_from_file_location("railway_vars_ut", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _recording_post(records: list, variables: dict | None = None):
+    def post(query: str, variables_in: dict):
+        records.append((query, variables_in))
+        if "query variables" in query:
+            return {"variables": variables or {}}
+        return {}
+
+    return post
+
+
+def _set_env(monkeypatch, **extra):
+    monkeypatch.setenv("RAILWAY_API_TOKEN", "tok")
+    monkeypatch.delenv("RAILWAY_PROJECT_TOKEN", raising=False)
+    monkeypatch.setenv("RAILWAY_PROJECT_ID", "p")
+    monkeypatch.setenv("RAILWAY_ENVIRONMENT_ID", "e")
+    monkeypatch.setenv("RAILWAY_SERVICE_ID", "s")
+    for key, value in extra.items():
+        monkeypatch.setenv(key, value)
+
+
+# --- pure helpers -----------------------------------------------------------
+
+
+def test_mask_hides_body(mod):
+    assert mod.mask("supersecretvalue").endswith("chars)")
+    assert "supersecret" not in mod.mask("supersecretvalue")
+    assert mod.mask("ab") == "**** (2 chars)"
+
+
+def test_get_variables_returns_map(mod):
+    records: list = []
+    post = _recording_post(records, {"A": "1", "B": "2"})
+    out = mod.get_variables(post, project_id="p", environment_id="e", service_id="s")
+    assert out == {"A": "1", "B": "2"}
+    assert records[0][1] == {"projectId": "p", "environmentId": "e", "serviceId": "s"}
+
+
+def test_upsert_sends_input(mod):
+    records: list = []
+    mod.upsert_variable(
+        _recording_post(records),
+        project_id="p",
+        environment_id="e",
+        service_id="s",
+        name="K",
+        value="V",
+    )
+    assert "variableUpsert" in records[0][0]
+    assert records[0][1]["input"] == {
+        "projectId": "p",
+        "environmentId": "e",
+        "serviceId": "s",
+        "name": "K",
+        "value": "V",
+    }
+
+
+def test_delete_sends_input(mod):
+    records: list = []
+    mod.delete_variable(
+        _recording_post(records),
+        project_id="p",
+        environment_id="e",
+        service_id="s",
+        name="K",
+    )
+    assert "variableDelete" in records[0][0]
+    assert records[0][1]["input"]["name"] == "K"
+
+
+# --- guard paths ------------------------------------------------------------
+
+
+def test_main_no_token_exits_2(mod, monkeypatch, capsys):
+    monkeypatch.delenv("RAILWAY_API_TOKEN", raising=False)
+    monkeypatch.delenv("RAILWAY_PROJECT_TOKEN", raising=False)
+    assert mod.main(["list"]) == 2
+    assert "WRITE-capable token" in capsys.readouterr().err
+
+
+def test_main_missing_ids_exits_2(mod, monkeypatch, capsys):
+    monkeypatch.setenv("RAILWAY_API_TOKEN", "tok")
+    monkeypatch.delenv("RAILWAY_PROJECT_TOKEN", raising=False)
+    for key in ("RAILWAY_PROJECT_ID", "RAILWAY_ENVIRONMENT_ID", "RAILWAY_SERVICE_ID"):
+        monkeypatch.delenv(key, raising=False)
+    assert mod.main(["list"]) == 2
+    assert "RAILWAY_ENVIRONMENT_ID" in capsys.readouterr().err
+
+
+# --- read commands ----------------------------------------------------------
+
+
+def test_list_masks_by_default(mod, monkeypatch, capsys):
+    _set_env(monkeypatch)
+    post = _recording_post([], {"TOKEN": "supersecretvalue"})
+    monkeypatch.setattr(mod, "build_poster", lambda token, **kw: post)
+    assert mod.main(["list"]) == 0
+    out = capsys.readouterr().out
+    assert "TOKEN=" in out
+    assert "supersecretvalue" not in out
+
+
+def test_list_reveal_shows_values(mod, monkeypatch, capsys):
+    _set_env(monkeypatch)
+    post = _recording_post([], {"TOKEN": "supersecretvalue"})
+    monkeypatch.setattr(mod, "build_poster", lambda token, **kw: post)
+    assert mod.main(["list", "--reveal"]) == 0
+    assert "supersecretvalue" in capsys.readouterr().out
+
+
+def test_get_prints_one_value(mod, monkeypatch, capsys):
+    _set_env(monkeypatch)
+    post = _recording_post([], {"DATABASE_URL": "postgres://x"})
+    monkeypatch.setattr(mod, "build_poster", lambda token, **kw: post)
+    assert mod.main(["get", "DATABASE_URL"]) == 0
+    assert capsys.readouterr().out.strip() == "postgres://x"
+
+
+def test_get_missing_var_exits_2(mod, monkeypatch, capsys):
+    _set_env(monkeypatch)
+    post = _recording_post([], {"A": "1"})
+    monkeypatch.setattr(mod, "build_poster", lambda token, **kw: post)
+    assert mod.main(["get", "NOPE"]) == 2
+    assert "No such variable" in capsys.readouterr().err
+
+
+# --- write commands ---------------------------------------------------------
+
+
+def test_set_calls_upsert_and_audits_without_leaking(mod, monkeypatch, capsys):
+    _set_env(monkeypatch)
+    records: list = []
+    monkeypatch.setattr(mod, "build_poster", lambda token, **kw: _recording_post(records))
+    assert mod.main(["set", "API_KEY", "topsecret"]) == 0
+    captured = capsys.readouterr()
+    assert any("variableUpsert" in q for q, _ in records)
+    assert records[0][1]["input"]["value"] == "topsecret"
+    assert "SET API_KEY" in captured.err  # audit line on stderr
+    assert "topsecret" not in captured.err  # never echo the secret
+    assert "topsecret" not in captured.out
+
+
+def test_set_reads_value_from_stdin(mod, monkeypatch):
+    _set_env(monkeypatch)
+    records: list = []
+    monkeypatch.setattr(mod, "build_poster", lambda token, **kw: _recording_post(records))
+    monkeypatch.setattr("sys.stdin", io.StringIO("from-stdin\n"))
+    assert mod.main(["set", "API_KEY"]) == 0
+    assert records[0][1]["input"]["value"] == "from-stdin"
+
+
+def test_unset_calls_delete(mod, monkeypatch, capsys):
+    _set_env(monkeypatch)
+    records: list = []
+    monkeypatch.setattr(mod, "build_poster", lambda token, **kw: _recording_post(records))
+    assert mod.main(["unset", "OLD_VAR"]) == 0
+    assert any("variableDelete" in q for q, _ in records)
+    assert "UNSET OLD_VAR" in capsys.readouterr().err
+
+
+def test_set_default_triggers_deploy(mod, monkeypatch, capsys):
+    _set_env(monkeypatch)
+    records: list = []
+    monkeypatch.setattr(mod, "build_poster", lambda token, **kw: _recording_post(records))
+    assert mod.main(["set", "K", "V"]) == 0
+    assert "skipDeploys" not in records[0][1]["input"]
+    assert "redeploy" in capsys.readouterr().err
+
+
+def test_set_no_deploy_stages_without_redeploy(mod, monkeypatch, capsys):
+    _set_env(monkeypatch)
+    records: list = []
+    monkeypatch.setattr(mod, "build_poster", lambda token, **kw: _recording_post(records))
+    assert mod.main(["set", "K", "V", "--no-deploy"]) == 0
+    assert records[0][1]["input"]["skipDeploys"] is True
+    assert "no redeploy" in capsys.readouterr().err


### PR DESCRIPTION
## What

You authorized agents to **read and edit** the bot's Railway env variables ("*would that mean you could see and edit my env variables? … I give you full access to implement this … I'm willing to take the gamble*"). This builds that write capability on top of the read-only logs reader (#832).

## The tool — `scripts/hermes/railway_vars.py`
Read **and write** service variables via the Railway GraphQL API (`variables` query + `variableUpsert` / `variableDelete`):

```
railway_vars.py list             # names, values masked
railway_vars.py list --reveal     # names + full values (secrets!)
railway_vars.py get DATABASE_URL  # one value, to verify it
railway_vars.py set NAME VALUE     # create/update (redeploys by default)
echo -n secret | railway_vars.py set NAME   # value via stdin (keeps secrets out of argv)
railway_vars.py set NAME VALUE --no-deploy   # stage without redeploying
railway_vars.py unset OLD_NAME
```

**Guardrails:** `list`/`get` never mutate; `list` masks values unless `--reveal`; `set`/`unset` print an audit line to stderr and never echo the token; `--no-deploy` stages a change without Railway's default redeploy (so an edit isn't a surprise deploy). 15 mocked tests, no network.

## Scope of the grant (recorded in Q-0130)
- ✅ **Granted + shipped:** env-var **read + write** (a T3 subset), per your explicit authorization.
- ⛔ **Not granted:** deploy / restart / scale / rollback — still maintainer-only.
- ⏸️ **Still open:** T1 read-only metrics, on request.

## What you need to do (one-time)
A **write-capable** token + **all three** ids (variables are per-environment, so `RAILWAY_ENVIRONMENT_ID` is required too):
1. Token at railway.com/account/tokens (project token scoped to `reliable-grace` = least-privilege, or an account token).
2. `RAILWAY_PROJECT_ID` / `RAILWAY_ENVIRONMENT_ID` / `RAILWAY_SERVICE_ID` from the dashboard.
3. Put them in the **agent environment** (Claude Code cloud env vars and/or Hermes's VPS) + allow `backboard.railway.com` in that env's network policy.

Full setup in `production-deployment.md` § "Env variable read/write (Railway API)". Provenance: **Q-0130**.

https://claude.ai/code/session_01Rent5bfB32i5zumoMSSGQa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rent5bfB32i5zumoMSSGQa)_