### PR TITLE
Clarify Railway token setup: accept RAILWAY_TOKEN + "which token?" guide

### DIFF
--- a/docs/operations/hermes-skills/log-triage.md
+++ b/docs/operations/hermes-skills/log-triage.md
@@ -31,8 +31,9 @@ Do the following in order. Skip any step whose tool is unavailable and say so.
 1. PRODUCTION LOGS (Railway)
    Preferred — the read-only API reader (no CLI or login needed):
      python3.10 scripts/hermes/railway_logs.py -n 400 2>&1
-   It reads a read-only token + ids from the environment (RAILWAY_PROJECT_TOKEN
-   or RAILWAY_API_TOKEN, plus RAILWAY_PROJECT_ID and RAILWAY_SERVICE_ID) and
+   It reads a read-only token + ids from the environment (RAILWAY_TOKEN — a
+   project token — or RAILWAY_API_TOKEN, plus RAILWAY_PROJECT_ID and
+   RAILWAY_SERVICE_ID) and
    prints the bot's latest-deployment logs. If it prints "No Railway token found"
    or another setup error, fall back to the `railway` CLI if present
    (`railway logs --service worker 2>&1 | tail -n 400`). If neither works, say
@@ -101,8 +102,8 @@ Format the output as:
 - **Setup (one-time, maintainer):** create a **read-only** Railway token
   ([railway.com/account/tokens](https://railway.com/account/tokens) — a *project*
   token scoped to the production project is least-privilege) and put it on the VPS
-  as `RAILWAY_PROJECT_TOKEN` (or `RAILWAY_API_TOKEN`), plus `RAILWAY_PROJECT_ID`
-  and `RAILWAY_SERVICE_ID` (from the dashboard URL
+  as `RAILWAY_TOKEN` (project token; or `RAILWAY_API_TOKEN` for an account token),
+  plus `RAILWAY_PROJECT_ID` and `RAILWAY_SERVICE_ID` (from the dashboard URL
   `railway.com/project/<id>/service/<id>`). Verify with
   `python3.10 scripts/hermes/railway_logs.py --whoami`. Until configured the skill
   still works — it triages the local `hermes-gateway` logs and reports production

--- a/docs/operations/production-deployment.md
+++ b/docs/operations/production-deployment.md
@@ -84,6 +84,25 @@ default.
 lifecycle: a Discord gateway bot has no inbound HTTP to health-check and must not
 sleep, so either would break it.
 
+## Which Railway token? (account vs project)
+
+Railway has **two** kinds of API token, on two different pages — this is the part that
+trips people up. Both work with the tools here; pick by how much scope you want.
+
+| | **Project token** (preferred) | **Account / workspace token** |
+|---|---|---|
+| Where | **Project → Settings → Tokens** (set environment `production`) | Account **Settings → Tokens** |
+| Scope | just this one project + environment (least-privilege) | your whole account / workspace |
+| Env var to set | **`RAILWAY_TOKEN`** (the var Railway's own hint names) | `RAILWAY_API_TOKEN` |
+| GraphQL header | `Project-Access-Token` (the tools set this for you) | `Authorization: Bearer` |
+| Verify with | `railway_vars.py list` (a project token has no `--whoami` identity) | `railway_logs.py --whoami` |
+
+**Recommendation:** create a **project token** (e.g. named `claude`, environment
+`production`) and set it as **`RAILWAY_TOKEN`** in the agent's environment. Only reach for
+an account token if a project token returns "Not Authorized". (`RAILWAY_PROJECT_TOKEN` is
+accepted as an alias for `RAILWAY_TOKEN`.) The **ids** are still required either way — the
+token says *who you are*, the ids say *which resource*.
+
 ## Hermes read-only log access (Railway API)
 
 **Posture (Q-0130, 2026-06-14):** the "no Railway access" rule now has one
@@ -111,9 +130,11 @@ python3.10 scripts/hermes/railway_logs.py --json     # raw JSON for tooling
    `railway.com/project/<PROJECT_ID>/service/<SERVICE_ID>` (the `worker` service).
    The production environment id is optional.
 3. Put them in **Hermes's environment** (the VPS — never the repo):
-   - `RAILWAY_PROJECT_TOKEN` (project token) **or** `RAILWAY_API_TOKEN` (account token)
+   - **`RAILWAY_TOKEN`** (project token) **or** `RAILWAY_API_TOKEN` (account token) —
+     see *Which Railway token?* above
    - `RAILWAY_PROJECT_ID`, `RAILWAY_SERVICE_ID`, optional `RAILWAY_ENVIRONMENT_ID`
-4. Verify: `python3.10 scripts/hermes/railway_logs.py --whoami`, then `... -n 50`.
+4. Verify: `railway_vars.py list` (project token) or `railway_logs.py --whoami` (account
+   token), then `python3.10 scripts/hermes/railway_logs.py -n 50`.
 
 **Auth detail:** account/workspace tokens use `Authorization: Bearer <token>`;
 project tokens use `Project-Access-Token: <token>` — the script picks the header from
@@ -154,12 +175,13 @@ python3.10 scripts/hermes/railway_vars.py unset OLD_NAME    # delete
 > edit *is* effectively a deploy unless you stage it; keep that in mind, since deploys
 > otherwise stay the maintainer's.
 
-**Setup (one-time, maintainer):** needs a **write-capable** token (a project token
-scoped to `reliable-grace`, or an account token) **and all three ids** — variables are
-per-environment, so `RAILWAY_ENVIRONMENT_ID` (production) is required alongside
-`RAILWAY_PROJECT_ID` and `RAILWAY_SERVICE_ID`. Put them in the agent's environment (the
-Claude Code cloud environment's variables and/or Hermes's VPS), and allow
-`backboard.railway.com` in that environment's network policy.
+**Setup (one-time, maintainer):** needs a **write-capable** token (a project token set as
+**`RAILWAY_TOKEN`** — see *Which Railway token?* above — or an account token as
+`RAILWAY_API_TOKEN`) **and all three ids** — variables are per-environment, so
+`RAILWAY_ENVIRONMENT_ID` (production) is required alongside `RAILWAY_PROJECT_ID` and
+`RAILWAY_SERVICE_ID`. Put them in the agent's environment (the Claude Code cloud
+environment's variables and/or Hermes's VPS), and allow `backboard.railway.com` in that
+environment's network policy.
 
 ## Backups
 

--- a/scripts/hermes/railway_logs.py
+++ b/scripts/hermes/railway_logs.py
@@ -12,17 +12,18 @@ separate, owner-gated decision — see router Q-0130.)
 
 Auth + config come from the environment (never the repo):
 
+    RAILWAY_TOKEN           project token  -> ``Project-Access-Token`` (preferred,
+                            least-privilege; this is the var Railway's own Tokens
+                            page tells you to set). RAILWAY_PROJECT_TOKEN is an alias.
     RAILWAY_API_TOKEN       account / workspace token -> ``Authorization: Bearer``
-    RAILWAY_PROJECT_TOKEN   project token             -> ``Project-Access-Token``
-                            Set exactly one. A project token scoped to the
-                            production project is the least-privilege choice.
     RAILWAY_PROJECT_ID      the project's id
     RAILWAY_SERVICE_ID      the bot service's id ("worker")
     RAILWAY_ENVIRONMENT_ID  optional; scopes the lookup to one environment
 
 Get a token at https://railway.com/account/tokens. The project/service ids are in
 the dashboard URL: ``railway.com/project/<PROJECT_ID>/service/<SERVICE_ID>``.
-Run ``--whoami`` first to confirm the token authenticates.
+Confirm setup: an account token with ``--whoami``; a project token by reading data
+(``-n 20`` here, or ``railway_vars.py list``) — project tokens have no ``me`` identity.
 
 Usage:
     python3.10 scripts/hermes/railway_logs.py [-n LINES] [--json]
@@ -156,16 +157,27 @@ def format_logs(logs: list[dict[str, Any]]) -> str:
 
 
 def _resolve_token() -> tuple[str, bool]:
-    """Return ``(token, is_project_token)`` from the environment."""
+    """Return ``(token, is_project_token)`` from the environment.
+
+    Mirrors Railway's own convention: ``RAILWAY_TOKEN`` is a project token
+    (sent as ``Project-Access-Token``); ``RAILWAY_API_TOKEN`` is an account /
+    workspace token (sent as ``Authorization: Bearer``). ``RAILWAY_PROJECT_TOKEN``
+    is accepted as an alias for ``RAILWAY_TOKEN``. A project token is
+    least-privilege and preferred when both are set.
+    """
+    project = (
+        os.environ.get("RAILWAY_TOKEN", "").strip()
+        or os.environ.get("RAILWAY_PROJECT_TOKEN", "").strip()
+    )
     account = os.environ.get("RAILWAY_API_TOKEN", "").strip()
-    project = os.environ.get("RAILWAY_PROJECT_TOKEN", "").strip()
     if project:
-        return project, True  # least-privilege; preferred when both are set
+        return project, True
     if account:
         return account, False
     raise RailwayError(
-        "No Railway token found. Set RAILWAY_PROJECT_TOKEN (project token, "
-        "least-privilege) or RAILWAY_API_TOKEN (account/workspace token). "
+        "No Railway token found. Set RAILWAY_TOKEN (a project token — "
+        "least-privilege, and the var Railway's Tokens page tells you to set) or "
+        "RAILWAY_API_TOKEN (account/workspace token). "
         "Get one at https://railway.com/account/tokens.",
     )
 
@@ -206,6 +218,14 @@ def main(argv: list[str] | None = None) -> int:
         post = build_poster(token, is_project_token=is_project_token)
 
         if args.whoami:
+            if is_project_token:
+                print(
+                    "Project token detected (Project-Access-Token) — it has no "
+                    "'me' identity, so verify it by reading data instead:\n"
+                    "  python3.10 scripts/hermes/railway_logs.py -n 20\n"
+                    "  python3.10 scripts/hermes/railway_vars.py list",
+                )
+                return 0
             print(json.dumps(post(WHOAMI_QUERY, {}), indent=2))
             return 0
 

--- a/scripts/hermes/railway_vars.py
+++ b/scripts/hermes/railway_vars.py
@@ -14,11 +14,12 @@ Unlike the logs reader, this tool can **mutate** (set / unset), so it needs a
 
 Config comes from the environment (never the repo):
 
-    RAILWAY_API_TOKEN / RAILWAY_PROJECT_TOKEN   a **write-capable** token
-    RAILWAY_PROJECT_ID                          the project's id
-    RAILWAY_ENVIRONMENT_ID                       the environment's id (required —
-                                                 variables are per-environment)
-    RAILWAY_SERVICE_ID                          the bot service's id
+    RAILWAY_TOKEN           a **write-capable** project token (preferred; the var
+                            Railway's Tokens page tells you to set). RAILWAY_API_TOKEN
+                            works too (account token). RAILWAY_PROJECT_TOKEN is an alias.
+    RAILWAY_PROJECT_ID      the project's id
+    RAILWAY_ENVIRONMENT_ID  the environment's id (required — variables are per-environment)
+    RAILWAY_SERVICE_ID      the bot service's id
 
 Guardrails: read subcommands (``list`` / ``get``) never mutate; ``list`` masks
 values unless ``--reveal``; writes print an audit line to stderr and never echo the
@@ -61,17 +62,25 @@ mutation variableDelete($input: VariableDeleteInput!) {
 
 
 def resolve_token() -> tuple[str, bool]:
-    """Return ``(token, is_project_token)`` for a **write-capable** token."""
+    """Return ``(token, is_project_token)`` for a **write-capable** token.
+
+    ``RAILWAY_TOKEN`` = project token (Project-Access-Token); ``RAILWAY_API_TOKEN``
+    = account/workspace token (Bearer); ``RAILWAY_PROJECT_TOKEN`` is an alias for
+    ``RAILWAY_TOKEN``. The token must have write scope to set/unset variables.
+    """
+    project = (
+        os.environ.get("RAILWAY_TOKEN", "").strip()
+        or os.environ.get("RAILWAY_PROJECT_TOKEN", "").strip()
+    )
     account = os.environ.get("RAILWAY_API_TOKEN", "").strip()
-    project = os.environ.get("RAILWAY_PROJECT_TOKEN", "").strip()
     if project:
         return project, True
     if account:
         return account, False
     raise RailwayError(
         "No Railway token found. Editing variables needs a WRITE-capable token in "
-        "RAILWAY_PROJECT_TOKEN or RAILWAY_API_TOKEN. Get one at "
-        "https://railway.com/account/tokens.",
+        "RAILWAY_TOKEN (project token) or RAILWAY_API_TOKEN (account token). "
+        "Get one at https://railway.com/account/tokens.",
     )
 
 

--- a/scripts/hermes/skills/log-triage/SKILL.md
+++ b/scripts/hermes/skills/log-triage/SKILL.md
@@ -24,8 +24,9 @@ Do the following in order. Skip any step whose tool is unavailable and say so.
 1. PRODUCTION LOGS (Railway)
    Preferred — the read-only API reader (no CLI or login needed):
      python3.10 scripts/hermes/railway_logs.py -n 400 2>&1
-   It reads a read-only token + ids from the environment (RAILWAY_PROJECT_TOKEN
-   or RAILWAY_API_TOKEN, plus RAILWAY_PROJECT_ID and RAILWAY_SERVICE_ID) and
+   It reads a read-only token + ids from the environment (RAILWAY_TOKEN — a
+   project token — or RAILWAY_API_TOKEN, plus RAILWAY_PROJECT_ID and
+   RAILWAY_SERVICE_ID) and
    prints the bot's latest-deployment logs. If it prints "No Railway token found"
    or another setup error, fall back to the `railway` CLI if present
    (`railway logs --service worker 2>&1 | tail -n 400`). If neither works, say

--- a/tests/unit/scripts/test_railway_logs.py
+++ b/tests/unit/scripts/test_railway_logs.py
@@ -29,6 +29,27 @@ def mod():
     return module
 
 
+@pytest.fixture(autouse=True)
+def _clean_token_env(monkeypatch):
+    # Deterministic token resolution regardless of the CI/host environment.
+    for var in ("RAILWAY_TOKEN", "RAILWAY_PROJECT_TOKEN", "RAILWAY_API_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+
+
+# --- token resolution -------------------------------------------------------
+
+
+def test_railway_token_is_treated_as_project(mod, monkeypatch):
+    monkeypatch.setenv("RAILWAY_TOKEN", "pt")
+    monkeypatch.setenv("RAILWAY_API_TOKEN", "at")
+    assert mod._resolve_token() == ("pt", True)
+
+
+def test_api_token_is_account_when_no_project(mod, monkeypatch):
+    monkeypatch.setenv("RAILWAY_API_TOKEN", "at")
+    assert mod._resolve_token() == ("at", False)
+
+
 # --- deployment selection ---------------------------------------------------
 
 
@@ -196,6 +217,15 @@ def test_main_whoami_happy_path(mod, monkeypatch, capsys):
     monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
     assert mod.main(["--whoami"]) == 0
     assert "u1" in capsys.readouterr().out
+
+
+def test_main_whoami_project_token_guides(mod, monkeypatch, capsys):
+    # A project token has no `me` identity; --whoami should guide, not error.
+    monkeypatch.setenv("RAILWAY_TOKEN", "proj-tok")
+    assert mod.main(["--whoami"]) == 0
+    out = capsys.readouterr().out
+    assert "Project token detected" in out
+    assert "railway_vars.py list" in out
 
 
 def test_main_fetches_and_formats(mod, monkeypatch, capsys):

--- a/tests/unit/scripts/test_railway_vars.py
+++ b/tests/unit/scripts/test_railway_vars.py
@@ -31,6 +31,17 @@ def mod():
     return module
 
 
+@pytest.fixture(autouse=True)
+def _clean_token_env(monkeypatch):
+    for var in ("RAILWAY_TOKEN", "RAILWAY_PROJECT_TOKEN", "RAILWAY_API_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_railway_token_is_treated_as_project(mod, monkeypatch):
+    monkeypatch.setenv("RAILWAY_TOKEN", "pt")
+    assert mod.resolve_token() == ("pt", True)
+
+
 def _recording_post(records: list, variables: dict | None = None):
     def post(query: str, variables_in: dict):
         records.append((query, variables_in))


### PR DESCRIPTION
## Why

You hit real confusion picking a token — and there was a concrete cause: your dashboard's Tokens page literally says *"set the `RAILWAY_TOKEN` environment variable"*, but the tools only read `RAILWAY_PROJECT_TOKEN`. This aligns the tools with Railway's own naming and makes the account-vs-project choice explicit.

## Changes
- **`railway_logs.py` + `railway_vars.py`** now read **`RAILWAY_TOKEN`** (project token → `Project-Access-Token` header), keep `RAILWAY_PROJECT_TOKEN` as an alias, and `RAILWAY_API_TOKEN` (account token → `Bearer`). So you set exactly the var Railway tells you to.
- **`--whoami`** no longer misleads for project tokens — they have no `me` identity, so instead of a scary "Not Authorized" it detects the project token and points you to `-n 20` / `railway_vars.py list` to verify.
- **`production-deployment.md`** gains a **"Which Railway token? (account vs project)"** table + a clear recommendation (project token as `RAILWAY_TOKEN`).
- `log-triage` skill doc + regenerated `SKILL.md`: same naming.
- Tests: `RAILWAY_TOKEN` resolution + project-token `--whoami` guidance + deterministic token-env handling (**33 cases** across both tools).

No behavior change for anyone already using `RAILWAY_API_TOKEN` / `RAILWAY_PROJECT_TOKEN`. Follow-up to #832 / #835 (Q-0130).

https://claude.ai/code/session_01Rent5bfB32i5zumoMSSGQa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rent5bfB32i5zumoMSSGQa)_