### PR TITLE
Record manual-step risk-labelling rule (owner trust dynamic, Q-0131)

### DIFF
--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -4974,3 +4974,30 @@ environment (see `production-deployment.md` § "Env variable read/write (Railway
 **Home:** `scripts/hermes/railway_logs.py` + `docs/operations/production-deployment.md` (access posture +
 setup) + the `log-triage` skill (doc + generated SKILL.md). This Q-block is provenance for T0 and the
 open decision for T1–T3.
+
+---
+
+### Q-0131 — Maintainer follows provided steps without vetting → label the risk class of every manual step
+
+> **OBSERVED 2026-06-14 (owner, in-session).** Verbatim: *"the only thing I do is follow the steps
+> you provide, so if you wanted to add something destructive you could have easily achieved that by
+> steering me, since I don't really know what I'm doing anyways."*
+
+**Area:** owner working profile · agent-behavior safeguard
+**Type:** owner-surfaced trust dynamic → guideline **ADOPTED** (in the working profile)
+
+**The dynamic.** The maintainer executes agent-provided manual steps literally, without the technical
+judgment to vet them himself (consistent with the §2 "harder for him to: read coding jargon; tell at a
+glance whether a decision is architectural/…"). That makes any manual step an agent hands him a real
+position of trust.
+
+**Guideline (adopted in `maintainer-working-profile.md` §2).** When handing the maintainer a manual step
+— especially anything touching secrets, production, money, deletion, or an external service — **label its
+risk class plainly** (`✅ safe/read-only` · `↩️ reversible` · `⚠️ irreversible/destructive`) so he can
+judge it without the internals, and never bury a destructive/irreversible action inside routine-looking
+steps. The structural safeguards that keep the trust sound — reviewable/revertible PRs, cross-agent
+review, and "ask what it does" always being answerable — must be preserved, not eroded.
+
+**Home:** `docs/owner/maintainer-working-profile.md` §2 (the observation + rule). If this should be
+elevated to a *binding* executor rule (`docs/collaboration-model.md` / CLAUDE.md), that's a one-line owner
+yes — flagged here, not self-applied (Q-0106).

--- a/docs/owner/maintainer-working-profile.md
+++ b/docs/owner/maintainer-working-profile.md
@@ -51,6 +51,19 @@ becomes implementation work. That routing is the job of
 [`maintainer-question-router.md`](./maintainer-question-router.md), so the maintainer does
 not have to carry it.
 
+**He executes agent-provided steps without independently vetting them (observed 2026-06-14).**
+In his words: *"the only thing I do is follow the steps you provide … if you wanted to add
+something destructive you could have easily achieved that by steering me, since I don't really
+know what I'm doing."* This is an explicit high-trust execution relationship, and a real
+responsibility. **Standing rule for agents (not just a nicety): when you hand the maintainer a
+manual step — anything touching secrets, production, money, deletion, or an external service —
+label its risk class plainly** so he can judge it without the technical context: `✅ safe /
+read-only`, `↩️ reversible`, or `⚠️ irreversible / destructive`. Never bury a destructive or
+irreversible action inside routine-looking steps. What keeps this trust *sound* — and must stay
+true — is the safety net under it: everything an agent does lands as a **reviewable, revertible
+PR**; cross-agent review checks any single agent; and he can always ask *"what does this actually
+do?"* and get a plain answer. (See router Q-0131.)
+
 **How he runs it day-to-day (observed 2026-06-08).** The maintainer runs **several chats in
 parallel by default** — typically a Claude Code *implementation* chat, plus ChatGPT *projects*
 per pipeline stage (`SuperBot Prompts` = Prompt Forge, `SuperBot Decisions`, `SuperBot


### PR DESCRIPTION
## What

Captures a trust dynamic the owner surfaced in-session and a standing safeguard it implies. Docs-only.

**Observed:** the maintainer follows agent-provided manual steps without independently vetting them (*"if you wanted to add something destructive you could have steered me, since I don't really know what I'm doing"*).

**Rule adopted** (`maintainer-working-profile.md` §2): when handing the maintainer a manual step — anything touching secrets, production, money, deletion, or an external service — **label its risk class plainly** (✅ safe/read-only · ↩️ reversible · ⚠️ irreversible/destructive), and never bury a destructive action inside routine-looking steps. The structural safeguards that keep this trust sound (reviewable/revertible PRs, cross-agent review, "ask what it does" always answerable) must be preserved.

Provenance: **Q-0131**. Elevation to a *binding* executor rule (collaboration-model / CLAUDE.md) is flagged for a one-line owner yes, not self-applied (Q-0106).

https://claude.ai/code/session_01Rent5bfB32i5zumoMSSGQa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rent5bfB32i5zumoMSSGQa)_