### PR TITLE
fix(railway): unblock agent Railway access — RAILWAY_API_KEY alias + Cloudflare UA

### DIFF
--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -243,10 +243,14 @@ Source code and merged PRs win over anything written here.
   **env-var read/write** (`scripts/hermes/railway_vars.py` — list/get/set/unset, masked list,
   audit lines, stdin secrets, `--no-deploy`), both Q-0130; **#836** aligned token config to
   `RAILWAY_TOKEN` + a "which token?" guide; **#837** recorded the manual-step risk-labelling rule
-  (Q-0131). **Owner set the Railway token + project/service/env IDs in the agent env after the
-  session — the next *fresh* session must verify live:** `python3.10
-  scripts/hermes/railway_logs.py --whoami` then `railway_vars.py list`. *(Ledger: #824/#830/#833
-  from concurrent routines still pending the due Q-0107 reconciliation pass.)*
+  (Q-0131). **Owner set the Railway credential + project/service/env IDs in the agent env after
+  the session. VERIFIED LIVE 2026-06-14 by an auth-probe routine — and it surfaced two blockers
+  that made the access inert, both fixed (see the Railway-auth-fix PR below):** (1) the credential
+  is an **account token provisioned under `RAILWAY_API_KEY`**, a var name the scripts didn't read
+  (they read `RAILWAY_API_TOKEN`/`RAILWAY_TOKEN`); (2) Cloudflare fronts `backboard.railway.com`
+  and 1010-bans urllib's default User-Agent, so every call 403'd. After the fixes, `railway_logs.py
+  --whoami` returns the owner identity and `railway_vars.py list` reads live prod vars. *(Ledger:
+  #824/#830/#833 from concurrent routines still pending the due Q-0107 reconciliation pass.)*
 - **#788 + #789 + #790 + #791 + #792 + #793 + #795 + #796 + #798 (2026-06-13, the portable
   substrate-kit extraction — PR 1a + 1b)** — the owner's strategic refocus (the
   [portable agent-memory package](ideas/portable-agent-memory-package-2026-06-12.md) idea)

--- a/scripts/hermes/railway_logs.py
+++ b/scripts/hermes/railway_logs.py
@@ -16,6 +16,8 @@ Auth + config come from the environment (never the repo):
                             least-privilege; this is the var Railway's own Tokens
                             page tells you to set). RAILWAY_PROJECT_TOKEN is an alias.
     RAILWAY_API_TOKEN       account / workspace token -> ``Authorization: Bearer``
+                            (RAILWAY_API_KEY is an alias — the var the owner
+                            provisioned in the agent env, 2026-06-14)
     RAILWAY_PROJECT_ID      the project's id
     RAILWAY_SERVICE_ID      the bot service's id ("worker")
     RAILWAY_ENVIRONMENT_ID  optional; scopes the lookup to one environment
@@ -46,6 +48,9 @@ from collections.abc import Callable
 from typing import Any
 
 API_URL = "https://backboard.railway.com/graphql/v2"
+#: Non-default User-Agent: Cloudflare bans urllib's ``Python-urllib/X.Y`` default
+#: with error 1010, so every Railway API call must present a plain client UA.
+USER_AGENT = "superbot-railway-tool/1.0"
 
 #: A GraphQL transport: ``post(query, variables) -> data``. Injected so the
 #: query/parse logic is unit-testable without touching the network.
@@ -93,6 +98,11 @@ def build_poster(
         payload = json.dumps({"query": query, "variables": variables}).encode("utf-8")
         req = urllib.request.Request(API_URL, data=payload, method="POST")
         req.add_header("Content-Type", "application/json")
+        # Cloudflare fronts backboard.railway.com and bans urllib's default
+        # ``Python-urllib/X.Y`` User-Agent with error 1010 (TLS/client-signature
+        # block) — every call 403s without this, regardless of token. A plain
+        # client UA passes. (Discovered by an auth-probe routine, 2026-06-14.)
+        req.add_header("User-Agent", USER_AGENT)
         req.add_header(header_name, header_value)
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
@@ -169,7 +179,13 @@ def _resolve_token() -> tuple[str, bool]:
         os.environ.get("RAILWAY_TOKEN", "").strip()
         or os.environ.get("RAILWAY_PROJECT_TOKEN", "").strip()
     )
-    account = os.environ.get("RAILWAY_API_TOKEN", "").strip()
+    # ``RAILWAY_API_KEY`` is the var name the owner provisioned in the agent env
+    # (2026-06-14); it holds an account/workspace token, so it aliases
+    # RAILWAY_API_TOKEN, not the project-token slot.
+    account = (
+        os.environ.get("RAILWAY_API_TOKEN", "").strip()
+        or os.environ.get("RAILWAY_API_KEY", "").strip()
+    )
     if project:
         return project, True
     if account:
@@ -177,7 +193,7 @@ def _resolve_token() -> tuple[str, bool]:
     raise RailwayError(
         "No Railway token found. Set RAILWAY_TOKEN (a project token — "
         "least-privilege, and the var Railway's Tokens page tells you to set) or "
-        "RAILWAY_API_TOKEN (account/workspace token). "
+        "RAILWAY_API_TOKEN / RAILWAY_API_KEY (account/workspace token). "
         "Get one at https://railway.com/account/tokens.",
     )
 

--- a/scripts/hermes/railway_vars.py
+++ b/scripts/hermes/railway_vars.py
@@ -16,7 +16,9 @@ Config comes from the environment (never the repo):
 
     RAILWAY_TOKEN           a **write-capable** project token (preferred; the var
                             Railway's Tokens page tells you to set). RAILWAY_API_TOKEN
-                            works too (account token). RAILWAY_PROJECT_TOKEN is an alias.
+                            works too (account token); RAILWAY_API_KEY is an alias for
+                            it (the var the owner provisioned, 2026-06-14).
+                            RAILWAY_PROJECT_TOKEN is an alias for RAILWAY_TOKEN.
     RAILWAY_PROJECT_ID      the project's id
     RAILWAY_ENVIRONMENT_ID  the environment's id (required — variables are per-environment)
     RAILWAY_SERVICE_ID      the bot service's id
@@ -72,15 +74,20 @@ def resolve_token() -> tuple[str, bool]:
         os.environ.get("RAILWAY_TOKEN", "").strip()
         or os.environ.get("RAILWAY_PROJECT_TOKEN", "").strip()
     )
-    account = os.environ.get("RAILWAY_API_TOKEN", "").strip()
+    # ``RAILWAY_API_KEY`` aliases RAILWAY_API_TOKEN (account/workspace token) —
+    # the var name the owner provisioned in the agent env (2026-06-14).
+    account = (
+        os.environ.get("RAILWAY_API_TOKEN", "").strip()
+        or os.environ.get("RAILWAY_API_KEY", "").strip()
+    )
     if project:
         return project, True
     if account:
         return account, False
     raise RailwayError(
         "No Railway token found. Editing variables needs a WRITE-capable token in "
-        "RAILWAY_TOKEN (project token) or RAILWAY_API_TOKEN (account token). "
-        "Get one at https://railway.com/account/tokens.",
+        "RAILWAY_TOKEN (project token) or RAILWAY_API_TOKEN / RAILWAY_API_KEY "
+        "(account token). Get one at https://railway.com/account/tokens.",
     )
 
 

--- a/tests/unit/scripts/test_railway_logs.py
+++ b/tests/unit/scripts/test_railway_logs.py
@@ -32,7 +32,12 @@ def mod():
 @pytest.fixture(autouse=True)
 def _clean_token_env(monkeypatch):
     # Deterministic token resolution regardless of the CI/host environment.
-    for var in ("RAILWAY_TOKEN", "RAILWAY_PROJECT_TOKEN", "RAILWAY_API_TOKEN"):
+    for var in (
+        "RAILWAY_TOKEN",
+        "RAILWAY_PROJECT_TOKEN",
+        "RAILWAY_API_TOKEN",
+        "RAILWAY_API_KEY",
+    ):
         monkeypatch.delenv(var, raising=False)
 
 
@@ -47,6 +52,19 @@ def test_railway_token_is_treated_as_project(mod, monkeypatch):
 
 def test_api_token_is_account_when_no_project(mod, monkeypatch):
     monkeypatch.setenv("RAILWAY_API_TOKEN", "at")
+    assert mod._resolve_token() == ("at", False)
+
+
+def test_api_key_aliases_account_token(mod, monkeypatch):
+    # The owner provisioned the credential under RAILWAY_API_KEY (an account
+    # token); it must resolve as a (Bearer) account token, not a project token.
+    monkeypatch.setenv("RAILWAY_API_KEY", "ak")
+    assert mod._resolve_token() == ("ak", False)
+
+
+def test_explicit_api_token_wins_over_api_key(mod, monkeypatch):
+    monkeypatch.setenv("RAILWAY_API_TOKEN", "at")
+    monkeypatch.setenv("RAILWAY_API_KEY", "ak")
     assert mod._resolve_token() == ("at", False)
 
 
@@ -176,6 +194,22 @@ def test_build_poster_project_uses_project_header(mod, monkeypatch):
     post(mod.WHOAMI_QUERY, {})
     assert captured["auth"] is None
     assert captured["proj"] == "proj-tok"
+
+
+def test_build_poster_sets_non_default_user_agent(mod, monkeypatch):
+    # Cloudflare fronts the API and 1010-bans urllib's default UA; the request
+    # must carry an explicit non-``Python-urllib`` User-Agent or every call 403s.
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["ua"] = req.get_header("User-agent")
+        return _FakeResp({"data": {}})
+
+    monkeypatch.setattr(mod.urllib.request, "urlopen", fake_urlopen)
+    post = mod.build_poster("tok", is_project_token=False)
+    post(mod.WHOAMI_QUERY, {})
+    assert captured["ua"] == mod.USER_AGENT
+    assert "urllib" not in captured["ua"].lower()
 
 
 def test_post_raises_on_graphql_errors(mod, monkeypatch):

--- a/tests/unit/scripts/test_railway_vars.py
+++ b/tests/unit/scripts/test_railway_vars.py
@@ -33,13 +33,24 @@ def mod():
 
 @pytest.fixture(autouse=True)
 def _clean_token_env(monkeypatch):
-    for var in ("RAILWAY_TOKEN", "RAILWAY_PROJECT_TOKEN", "RAILWAY_API_TOKEN"):
+    for var in (
+        "RAILWAY_TOKEN",
+        "RAILWAY_PROJECT_TOKEN",
+        "RAILWAY_API_TOKEN",
+        "RAILWAY_API_KEY",
+    ):
         monkeypatch.delenv(var, raising=False)
 
 
 def test_railway_token_is_treated_as_project(mod, monkeypatch):
     monkeypatch.setenv("RAILWAY_TOKEN", "pt")
     assert mod.resolve_token() == ("pt", True)
+
+
+def test_api_key_aliases_account_token(mod, monkeypatch):
+    # The owner provisioned the write token under RAILWAY_API_KEY (account token).
+    monkeypatch.setenv("RAILWAY_API_KEY", "ak")
+    assert mod.resolve_token() == ("ak", False)
 
 
 def _recording_post(records: list, variables: dict | None = None):


### PR DESCRIPTION
## What an "auth probe" routine found

This routine fired with the work order `auth probe`. Verifying the
owner-provisioned Railway credentials (the standing "next fresh session must
verify live" action from the #827–#837 session) surfaced that the Railway
access enabled last session was **entirely inert from the agent environment**
for two independent reasons — both now fixed.

### 1. Env-var name mismatch
The owner provisioned the credential under **`RAILWAY_API_KEY`**, but
`railway_logs.py` / `railway_vars.py` only read `RAILWAY_API_TOKEN`,
`RAILWAY_TOKEN`, or `RAILWAY_PROJECT_TOKEN` — so no token resolved
(`No Railway token found`). The credential is an **account token** (validated:
`Authorization: Bearer` → `me { email }` returns the owner). Added
`RAILWAY_API_KEY` as an alias for the account-token slot, with an explicit
`RAILWAY_API_TOKEN` still winning when both are set.

### 2. Cloudflare WAF block on urllib's User-Agent
Cloudflare fronts `backboard.railway.com` and **1010-bans urllib's default
`Python-urllib/X.Y` User-Agent** (a TLS/client-signature block), so every API
call 403'd regardless of token. Egress itself is fine — a curl/browser UA
returns 200. The GraphQL transport now sends an explicit non-default
`User-Agent`.

## Verified live after the fix
- `python3.10 scripts/hermes/railway_logs.py --whoami` → returns the owner identity
- `python3.10 scripts/hermes/railway_vars.py list` → reads live production vars (masked)

## What to test
The maintainer can confirm in any fresh agent session:
```
python3.10 scripts/hermes/railway_logs.py --whoami
python3.10 scripts/hermes/railway_vars.py list
```

## The one risk
The added `User-Agent` (`superbot-railway-tool/1.0`) is a plain identifier; if
Railway/Cloudflare ever tightens the WAF further it may need adjusting, but a
non-`urllib` UA is the documented fix for error 1010 and is verified working now.

## Tests
`+5` regression tests (`RAILWAY_API_KEY` aliasing in both tools, explicit
`RAILWAY_API_TOKEN` precedence, non-urllib User-Agent on the request).
`check_quality.py --full` green (9509 passed); `check_architecture --mode
strict` 0 errors.

https://claude.ai/code/session_01MPHcterWHuDfT98cdYLHyj

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPHcterWHuDfT98cdYLHyj)_