### PR TITLE
docs: auth-probe session close-loop — credential smoke-check idea + log

### DIFF
--- a/.sessions/2026-06-14-railway-auth-probe.md
+++ b/.sessions/2026-06-14-railway-auth-probe.md
@@ -1,0 +1,59 @@
+# 2026-06-14 — `auth probe` routine: Railway access unblocked (PR #840)
+
+**Branch:** `claude/sharp-ptolemy-yi8q5t` · **PR:** #840 (fix, auto-merge armed)
+
+## Work order
+Routine fired with the free-form payload `auth probe`. Treated as CLASS: fix —
+verify the routine can authenticate/operate, and surface/fix whatever's broken.
+
+## What happened
+Verified each access path:
+- git/repo ✓ · GitHub MCP ✓ (authenticated as `menno420`)
+- **Railway ✗ → root-caused two independent blockers, both fixed:**
+  1. **Var-name mismatch.** Owner provisioned the credential as `RAILWAY_API_KEY`
+     (an account token), but `railway_logs.py`/`railway_vars.py` only read
+     `RAILWAY_API_TOKEN`/`RAILWAY_TOKEN`/`RAILWAY_PROJECT_TOKEN` → `No Railway
+     token found`. Confirmed token type empirically: rejected as project token
+     (`Project Token not found`), valid as account Bearer (`me { email }` =
+     owner). Added `RAILWAY_API_KEY` as an account-token alias (explicit
+     `RAILWAY_API_TOKEN` still wins).
+  2. **Cloudflare WAF.** `backboard.railway.com` 1010-bans urllib's default
+     `Python-urllib/X.Y` User-Agent → every call 403'd regardless of token
+     (curl/browser UA returns 200, so egress was never the issue). The GraphQL
+     transport now sends an explicit non-default User-Agent.
+
+Verified live after the fix: `--whoami` returns the owner identity; `vars list`
+reads live prod vars (masked). +5 regression tests; `check_quality --full` green
+(9509); arch 0 errors.
+
+## Notes
+- **No `PushNotification` / `send_later` tool in this routine env** — consistent
+  with the #828/Q-0129 finding. The finding's durable home is PR #840 + the
+  current-state verification note (which I updated from "must verify live" to the
+  verified outcome). Could not phone-notify; the PR is the notification.
+- PR created via MCP; **the `enable-auto-merge` check fired green anyway** (the
+  Q-0127 "doesn't fire for MCP PRs" caveat did not bite here), and I also enabled
+  auto-merge manually. Subscribed to PR activity.
+- PR #840 is a multiple-of-20 boundary, but per **Q-0124** a routine pursuing its
+  own work does not run the reconciliation pass — the `reconciliation-trigger`
+  workflow will auto-open the `reconcile` issue for the docs-reconciliation routine.
+
+## 💡 Session idea (Q-0089)
+`agent-env-credential-smoke-check-2026-06-14.md` — a stdlib `check_agent_env.py`
+doing a minimal authenticated round-trip per provisioned external credential,
+PASS/SKIP/FAIL at SessionStart. Absence = SKIP, present-but-broken = FAIL. This
+exact breakage sat silent until a routine probed by hand; this would flag it on
+the first session after provisioning.
+
+## ⟲ Previous-session review (Q-0102)
+The #827–#837 Railway-access session built solid, well-guarded tooling
+(masking, audit lines, stdin secrets, token-type handling) — genuinely good
+work. **What it missed:** it never made a single real call against the live
+Railway API from the agent env, so it didn't catch the Cloudflare-UA 1010 block
+(a one-call discovery) and it baked in the assumption the owner would use
+`RAILWAY_TOKEN`/`RAILWAY_API_TOKEN` rather than confirming the actual var name.
+It couldn't fully verify (the owner set the token afterward) — but it *could*
+have made one unauthenticated POST to prove the transport survives Cloudflare.
+**System improvement it surfaces:** the credential smoke-check idea above —
+"tooling is built" and "tooling works against the live endpoint from here" are
+different claims, and only the second is what an autonomous agent can rely on.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -20,6 +20,13 @@ during grooming** (it stays listed here, annotated ✅) so the active backlog re
 
 Current broad captures:
 
+- [`agent-env-credential-smoke-check-2026-06-14.md`](./agent-env-credential-smoke-check-2026-06-14.md) —
+  **tooling (2026-06-14, the `auth probe` routine / PR #840):** a stdlib `check_agent_env.py` that
+  does a minimal authenticated round-trip for each external credential the env *claims* to provide
+  (Railway / Anthropic / OpenAI), printing PASS/SKIP/FAIL at SessionStart. Absence = SKIP, only
+  present-but-broken = FAIL. Surfaced because the owner's Railway access sat **silently inert** (a
+  var-name mismatch + a Cloudflare UA block) until a routine happened to probe it by hand — this
+  would have flagged both on the first session after provisioning. Small; one script + a hook line.
 - [`routine-activity-visibility-2026-06-14.md`](./routine-activity-visibility-2026-06-14.md) —
   **workflow / UX (2026-06-14, owner-observed):** routine *run* sessions are hidden from the
   Recents tab (intentional upstream behavior; open FR

--- a/docs/ideas/agent-env-credential-smoke-check-2026-06-14.md
+++ b/docs/ideas/agent-env-credential-smoke-check-2026-06-14.md
@@ -1,0 +1,55 @@
+# Idea: agent-env external-credential smoke check (preflight)
+
+> **Status:** `ideas` — capture only, **not** a plan and **not** approval for
+> implementation. Source code and the binding contracts win over this file.
+
+**Captured:** 2026-06-14 · **Source:** the `auth probe` routine that fixed the
+Railway access (PR #840) · **Lane:** small / decided — implementable
+
+## The problem it solves
+
+The owner provisioned Railway credentials in the agent environment, and the
+access was **completely inert for two independent reasons** — a var-name mismatch
+(`RAILWAY_API_KEY` vs the `RAILWAY_API_TOKEN`/`RAILWAY_TOKEN` the scripts read)
+and a Cloudflare UA block on urllib — yet **nothing surfaced it**. It only came
+to light because a routine happened to fire with an `auth probe` work order and
+ran the verification by hand. A different session would have hit
+`No Railway token found` mid-task and assumed access simply wasn't granted.
+
+The general failure class: **provisioned external-access credentials are never
+verified end-to-end against the live endpoint**, so a wrong var name, an expired
+token, a network/WAF block, or a transport bug stays silent until an agent needs
+it under time pressure.
+
+## The idea
+
+A single `scripts/check_agent_env.py` (stdlib-only, fast, read-only) that, for
+each optional external integration the env *claims* to provide, does the minimal
+authenticated round-trip and prints a one-line PASS/SKIP/FAIL:
+
+- **Railway** — if any `RAILWAY_*` token var is set, run the existing
+  `railway_logs.py --whoami` (account) or a `vars list` (project) and report.
+- **Anthropic / OpenAI** — if a key is set, a cheap models-list call.
+- **Discord** — token presence + shape (no live gateway needed).
+
+Key properties:
+- **SKIP, never FAIL, when a var is absent** — absence is a valid config, only a
+  *present-but-broken* credential is a failure.
+- Surfaced at **SessionStart** as a one-line banner (`env: railway ✓ · anthropic ✓
+  · openai SKIP`) so every session knows its real capabilities up front, and a
+  routine can notify on a FAIL.
+- Reuses the per-integration probes already written (the `--whoami` path here).
+
+## Why it's worth having
+
+It converts "silently broken until someone trips over it" into "flagged on the
+first session after provisioning." It's the env-level sibling of the
+control-plane state ledger in `operations/autonomous-routines.md`, and it would
+have caught both PR #840 bugs the moment the owner set the var.
+
+## Size / route
+
+Small. One stdlib script + a SessionStart hook line + a few probe adapters.
+Could grow into the `node_roles`-style "what can this session actually do?"
+self-report. Groom into a tooling PR when the external-integration surface grows
+past Railway.


### PR DESCRIPTION
Docs-only close-loop for the `auth probe` routine whose fix shipped in **#840**
(merged). Separate change from #840 — kept out of the fix PR; preserving it here
so the mandatory session-enders aren't lost when the ephemeral container is
reclaimed.

- **Q-0089 idea:** `docs/ideas/agent-env-credential-smoke-check-2026-06-14.md` — a
  stdlib `check_agent_env.py` that does a minimal authenticated round-trip per
  provisioned external credential (Railway / Anthropic / OpenAI), printing
  PASS/SKIP/FAIL at SessionStart. Absence = SKIP, present-but-broken = FAIL. This
  exact class of breakage (the #840 Railway access) sat silent until a routine
  probed it by hand. + README index entry.
- **Session log** with the Q-0102 previous-session review (the #827–#837 Railway
  session built good tooling but never made one live call from the agent env, so
  it missed the Cloudflare-UA block + the `RAILWAY_API_KEY` var-name reality).

No runtime code. `check_docs --strict` clean.

https://claude.ai/code/session_01MPHcterWHuDfT98cdYLHyj

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPHcterWHuDfT98cdYLHyj)_