### PR TITLE
fix(security): counting staff check gates on permissions, not role names (BUG-0012)

### DIFF
--- a/disbot/cogs/counting_cog.py
+++ b/disbot/cogs/counting_cog.py
@@ -29,6 +29,7 @@ from cogs.counting._stage import COUNTING_STAGE_NAME, CountingStage
 from core.runtime import resources, scope_locks, tasks
 from core.runtime.interaction_helpers import help_ctx_shim
 from utils import db
+from utils.visibility_rules import get_member_visibility_tier, is_tier_sufficient
 from views.base import send_panel
 
 # _CountingHubView is instantiated below by the !countingmenu command
@@ -105,11 +106,26 @@ class CountingCog(commands.Cog):
     # --------------------------------------------
 
     async def is_staff_or_owner(self, ctx):
-        """Check if the user is staff or the bot owner."""
+        """Check if the user is staff or the bot owner.
+
+        Security (BUG-0012): gate on **real Discord permissions** via the
+        canonical governance visibility tier — never on role *names*.  The
+        previous implementation granted access to anyone holding a role merely
+        *named* ``"Admin"`` or ``"Moderator"``, regardless of whether that role
+        carried any actual permissions, so a powerless cosmetic role with a
+        matching name bypassed the permission system entirely.  Now a member
+        qualifies only if Discord reports them at moderator tier or above
+        (``moderate_members`` / ``administrator`` / guild owner) — a name match
+        confers nothing.
+        """
         if await self.bot.is_owner(ctx.author):
             return True
-        staff_roles = ["Admin", "Moderator"]
-        return any(role.name in staff_roles for role in ctx.author.roles)
+        member = ctx.author
+        guild = getattr(ctx, "guild", None)
+        if guild is None or getattr(member, "guild_permissions", None) is None:
+            return False
+        tier = get_member_visibility_tier(member, guild.owner_id)
+        return is_tier_sufficient(tier, "moderator")
 
     def staff_or_owner():  # type: ignore[misc]
         """Decorator to check if the user is staff or owner."""

--- a/docs/health/bug-book.md
+++ b/docs/health/bug-book.md
@@ -10,6 +10,47 @@
 > he hasn't formalized yet (see current-state 2026-06-10 standing invite) land
 > here as they surface.
 
+## BUG-0012 — counting staff check trusts role *names*, not permissions (privilege bypass) — FIXED
+
+- **Symptom (owner-reported, 2026-06-14):** "you could give yourself a role
+  called 'admin' while the admin role did not have any actual permissions — the
+  fact that it was named 'admin' overruled the bot's permission system and
+  allowed users to execute admin commands." A non-privileged member who holds
+  (or can self-assign) a **cosmetic role merely named** `Admin` or `Moderator`
+  — carrying zero Discord permissions — passed the counting staff gate.
+- **Affected surface:** `CountingCog.is_staff_or_owner` (`disbot/cogs/counting_cog.py`),
+  which gates the `@staff_or_owner()`-decorated counting management commands
+  (`!countingmenu`/`!cm` and siblings). Scope was limited to the counting cog;
+  every other cog already gates on real permissions
+  (`@commands.has_permissions(...)`) or the governance visibility tier.
+- **Root cause:** the check was `staff_roles = ["Admin", "Moderator"]; return
+  any(role.name in staff_roles for role in ctx.author.roles)` — a **role-name
+  string match**, never the role's actual permissions. Discord role names are
+  arbitrary and self-assignable, so the name `"Admin"` granted authority a
+  powerless role does not actually carry. This is the owner's "missing bindings"
+  class: with no permission/binding check, authority fell back to a name. The
+  gap was **noted as a code-quality observation since 2026-06-05**
+  (`docs/audits/general-feature-layer-analysis-2026-06-05.md` §"Counting uses
+  hardcoded role names") but never recognized as a security issue or fixed.
+- **Impact:** privilege escalation within the counting subsystem on any guild
+  where a non-privileged member can obtain a role named `Admin`/`Moderator`.
+  No data-loss path, but it defeats the permission model for that surface.
+- **Fix (PR — this entry):** `is_staff_or_owner` now resolves the member's
+  **real** tier via the canonical `utils.visibility_rules.get_member_visibility_tier`
+  (which reads `guild_permissions`: `administrator` / `moderate_members` /
+  guild-owner) and requires `is_tier_sufficient(tier, "moderator")`; the bot
+  owner still short-circuits true. A role *name* now confers nothing.
+- **Regression test:** `tests/unit/cogs/test_counting_permissions.py` — pins
+  that a powerless role named `Admin`/`Moderator` is denied, while real
+  administrator / moderator / bot-owner / guild-owner are allowed and a plain
+  member is denied.
+- **Process note:** this bug had been captured by a routine as a vague
+  *permissions-arrangement review* idea in `docs/ideas/` (PR #834) — the wrong
+  home for a concrete bug. It belongs here in the bug book; #834 should be
+  closed (or refocused into a router DISCUSS item if a broader permission-model
+  audit is still wanted).
+- **Status:** FIXED — root-caused + fixed + regression-tested 2026-06-14.
+
 ## BUG-0011 — Hermes gateway crash-loops on restart (Telegram 409) + periodic status=1 — OPEN
 
 - **Symptom:** the `hermes-gateway` systemd service exits `Main process exited, code=exited,

--- a/tests/unit/cogs/test_counting_permissions.py
+++ b/tests/unit/cogs/test_counting_permissions.py
@@ -1,0 +1,95 @@
+"""BUG-0012 — counting staff check must gate on real permissions, not role names.
+
+``CountingCog.is_staff_or_owner`` previously returned True for anyone holding a
+role merely *named* ``"Admin"`` or ``"Moderator"`` — regardless of whether that
+role carried any actual Discord permissions.  A powerless cosmetic role with a
+matching name therefore bypassed the permission system and unlocked the counting
+management commands.
+
+These tests pin that the check now depends on real Discord permissions (via the
+canonical ``utils.visibility_rules`` tier) and that a name match alone confers
+nothing.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from cogs.counting_cog import CountingCog
+
+
+def _cog(owner: bool = False) -> CountingCog:
+    cog = CountingCog(MagicMock())
+    cog.bot.is_owner = AsyncMock(return_value=owner)
+    return cog
+
+
+def _ctx(
+    *,
+    perms: discord.Permissions,
+    role_names: tuple[str, ...] = (),
+    member_id: int = 1,
+    guild_owner_id: int = 999,
+):
+    ctx = MagicMock()
+    member = MagicMock()
+    member.id = member_id
+    member.guild_permissions = perms
+    roles = []
+    for n in role_names:
+        role = MagicMock()
+        role.name = n  # `name` is reserved in the MagicMock constructor
+        roles.append(role)
+    member.roles = roles
+    ctx.author = member
+    ctx.guild = MagicMock()
+    ctx.guild.owner_id = guild_owner_id
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_role_named_admin_without_permissions_is_denied():
+    """The core regression: a role *named* Admin/Moderator with no real
+    permissions must NOT grant staff access."""
+    cog = _cog(owner=False)
+    ctx = _ctx(perms=discord.Permissions.none(), role_names=("Admin", "Moderator"))
+    assert await cog.is_staff_or_owner(ctx) is False
+
+
+@pytest.mark.asyncio
+async def test_real_administrator_is_allowed():
+    cog = _cog(owner=False)
+    ctx = _ctx(perms=discord.Permissions(administrator=True))
+    assert await cog.is_staff_or_owner(ctx) is True
+
+
+@pytest.mark.asyncio
+async def test_real_moderator_is_allowed():
+    cog = _cog(owner=False)
+    ctx = _ctx(perms=discord.Permissions(moderate_members=True))
+    assert await cog.is_staff_or_owner(ctx) is True
+
+
+@pytest.mark.asyncio
+async def test_plain_member_is_denied():
+    cog = _cog(owner=False)
+    ctx = _ctx(perms=discord.Permissions.none())
+    assert await cog.is_staff_or_owner(ctx) is False
+
+
+@pytest.mark.asyncio
+async def test_bot_owner_always_allowed():
+    cog = _cog(owner=True)
+    # Even with zero permissions, the bot owner passes.
+    ctx = _ctx(perms=discord.Permissions.none())
+    assert await cog.is_staff_or_owner(ctx) is True
+
+
+@pytest.mark.asyncio
+async def test_guild_owner_is_allowed():
+    cog = _cog(owner=False)
+    ctx = _ctx(perms=discord.Permissions.none(), member_id=42, guild_owner_id=42)
+    assert await cog.is_staff_or_owner(ctx) is True


### PR DESCRIPTION
## Security fix — privilege bypass via role name

**Owner-reported:** *"you could give yourself a role called 'admin' while the admin role did not have any actual permissions — the fact that it was named 'admin' overruled the bot's permission system and allowed users to execute admin commands."*

### Root cause
`CountingCog.is_staff_or_owner` (`disbot/cogs/counting_cog.py`) gated on role **names**, not permissions:

```python
staff_roles = ["Admin", "Moderator"]
return any(role.name in staff_roles for role in ctx.author.roles)
```

Discord role names are arbitrary and self-assignable, so any member holding a **powerless cosmetic role named `Admin`/`Moderator`** passed the gate and could run the `@staff_or_owner()`-decorated counting management commands (`!countingmenu`/`!cm`, `!start_match`, …). This is the "missing bindings → falls back to a name" class. It had been noted as a code-quality observation since 2026-06-05 (`docs/audits/general-feature-layer-analysis-2026-06-05.md`) but never recognized as a security issue or fixed. Scope was limited to the counting cog — every other cog already gates on real permissions (`@commands.has_permissions(...)`) or the governance tier.

### Fix
`is_staff_or_owner` now resolves the member's **real** tier via the canonical `utils.visibility_rules.get_member_visibility_tier` (reads `guild_permissions`: `administrator` / `moderate_members` / guild-owner) and requires `is_tier_sufficient(tier, "moderator")`; the bot owner still short-circuits. A role *name* now confers nothing. One helper gates all `@staff_or_owner()` commands, so the fix covers all of them.

### Filed in the right place
Recorded as **BUG-0012** in `docs/health/bug-book.md` — the correct home for a concrete bug. A routine had earlier dropped a vague *permissions-arrangement review* into `docs/ideas/` (**PR #834**); that's the wrong place for a bug. #834 should be **closed** (or refocused into a router DISCUSS item if a broader permission-model audit is still wanted) now that the concrete issue is fixed and tracked here.

### What to test
In a guild, give a non-privileged member a role named `Admin` with **no** permissions; `!cm` should now be denied. A real administrator/moderator (or the guild/bot owner) still gets in.

### The one risk
If a guild relied on the *name*-based behavior (a powerless "Admin" role as an intentional allowlist), those holders now need real permissions or a configured tier role. That's the intended hardening.

### Tests
`tests/unit/cogs/test_counting_permissions.py` (+6): powerless `Admin`/`Moderator` name → denied; real administrator / moderator / bot-owner / guild-owner → allowed; plain member → denied. `check_quality.py --full` green (9529); `check_architecture --mode strict` 0 errors.

https://claude.ai/code/session_01MPHcterWHuDfT98cdYLHyj

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPHcterWHuDfT98cdYLHyj)_