### PR TITLE
feat(health): log startup-health finding detail when not healthy (follow-up to #845)

### DIFF
--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -224,6 +224,20 @@ async def _report_startup_health() -> None:
             snapshot.status.value,
             snapshot.summary,
         )
+        # When not healthy, name the actual findings in the log so the
+        # degradation is diagnosable from logs alone — without the DB or the
+        # `!platform consistency` Discord command. The aggregate summary only
+        # names which *subsystems* need attention; this prints the per-finding
+        # severity + subsystem + message (already bounded + secret-scrubbed at
+        # adapter time), so a log-only operator can see exactly what fired.
+        if snapshot.status.value != "healthy" and snapshot.findings:
+            for finding in snapshot.findings:
+                logger.info(
+                    "Startup health finding: [%s] %s — %s",
+                    finding.severity.value,
+                    finding.related_subsystem or "?",
+                    finding.message,
+                )
         # Bot-awareness PR6: persist this snapshot's findings (best-effort, off
         # the readiness path) so recurrence survives restarts, then run the
         # 30-day retention sweep. Both calls are internally best-effort; the

--- a/tests/unit/runtime/test_startup_health_pr3.py
+++ b/tests/unit/runtime/test_startup_health_pr3.py
@@ -175,6 +175,58 @@ async def test_report_startup_health_requests_fresh_consistency(monkeypatch) -> 
     assert captured[0].include_fresh_consistency is True
 
 
+async def test_report_startup_health_logs_finding_detail_when_degraded(
+    monkeypatch, caplog
+) -> None:
+    """When the snapshot is not healthy, each finding is logged so the
+    degradation is diagnosable from logs alone (no DB / Discord command)."""
+    import datetime
+
+    from services.health_contracts import (
+        FindingSeverity,
+        HealthSnapshot,
+        OperationalHealthFinding,
+    )
+
+    finding = OperationalHealthFinding(
+        fingerprint="consistency.blocking:feature_flags",
+        severity=FindingSeverity.WARNING,
+        category="consistency.blocking_section",
+        message="Consistency check needs attention: Feature flags",
+        related_subsystem="consistency",
+    )
+    snap = HealthSnapshot(
+        snapshot_id="degradedx",
+        generated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+        purpose="startup",
+        status=SnapshotStatus.DEGRADED,
+        summary="Overall status: degraded — attention: consistency.",
+        subsystems=(),
+        findings=(finding,),
+        redaction_audience=HealthAudience.PLATFORM_OWNER,
+    )
+    monkeypatch.setattr(hss, "collect_snapshot", AsyncMock(return_value=snap))
+
+    with caplog.at_level("INFO"):
+        await bot1._report_startup_health()
+
+    detail_lines = [r for r in caplog.records if "Startup health finding:" in r.message]
+    assert detail_lines, "expected a per-finding log line when degraded"
+    rendered = detail_lines[0].getMessage()
+    assert "consistency" in rendered
+    assert "Feature flags" in rendered
+
+
+async def test_report_startup_health_no_finding_lines_when_healthy(
+    monkeypatch, caplog
+) -> None:
+    """A healthy snapshot logs no per-finding detail lines."""
+    monkeypatch.setattr(hss, "collect_snapshot", AsyncMock(return_value=_make_snapshot()))
+    with caplog.at_level("INFO"):
+        await bot1._report_startup_health()
+    assert not [r for r in caplog.records if "Startup health finding:" in r.message]
+
+
 async def test_report_startup_health_swallows_errors(monkeypatch) -> None:
     monkeypatch.setattr(
         hss, "collect_snapshot", AsyncMock(side_effect=RuntimeError("down"))


### PR DESCRIPTION
## Follow-up to #845 — make a degraded startup health diagnosable from logs

#845 fixed the false `degraded` and, in doing so, surfaced **one real consistency finding** in production (`recorded=1`, `attention: consistency`). But the startup-health log only prints the **aggregate** summary — it names which *subsystems* need attention, not *what* fired. So the actual finding is only visible via the DB or the `!platform consistency` Discord command. For a routine that has log access but neither of those, a genuine degradation is undiagnosable — exactly the wall hit while investigating the production finding.

### Change
When the settled-startup snapshot is **not healthy**, each finding is now logged at INFO:

```
Startup health finding: [warning] consistency — Consistency check needs attention: Feature flags
```

Findings are already bounded (`MAX_TOTAL_FINDINGS`) and secret-scrubbed at adapter time, so emitting them is safe. A healthy snapshot logs no extra lines.

### Why
This closes the loop on #845: the next deploy's logs will name the exact section/finding behind the production `degraded — attention: consistency`, so it can be diagnosed and fixed without DB access or a Discord command.

### Tests
`tests/unit/runtime/test_startup_health_pr3.py` (+2): finding detail is logged when degraded; none logged when healthy. `check_quality.py --full` green (9531); `check_architecture --mode strict` 0 errors.

https://claude.ai/code/session_01MPHcterWHuDfT98cdYLHyj

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPHcterWHuDfT98cdYLHyj)_