### PR TITLE
Born-red session merge-gate: hold the merge until the card is ready (Q-0133)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -163,6 +163,23 @@ is **per-file**. Full convention: `docs/owner/ai-project-workflow.md` §9.
   restart/prod-checks stay the maintainer's. *If you ever merge by hand* (a carve-out, or
   auto-merge is down): re-verify **CI green on the final head** and **never defer the merge to
   the maintainer's next message** — that deferral was the #778 root cause.
+- **Open your session card born-red as the FIRST commit; flip it green as the LAST (owner
+  directive Q-0133, 2026-06-14).** Auto-merge fires the instant **Code Quality** is green, so a
+  session that pushes code first and its close-out docs (ledger entry, `.sessions/` log) second
+  can merge a *partial* PR before those docs land — the #843 race. The fix is one per-session
+  file that is **both** the start-declaration (*what is about to happen* — visible to parallel /
+  next sessions on the open PR) **and** the end-record (*what has happened*): your
+  **`.sessions/<date>-<slug>.md` log**. Create it in your **first** commit with a HOLD status
+  (`> **Status:** \`in-progress\``) and a one-line "what I'm about to do" — that opens the PR
+  **born red** (the `check_session_gate` step in `code-quality` holds the merge), so auto-merge
+  arms but **cannot fire on an incomplete PR**. Do the work; write the close-out docs + the
+  Q-0089/Q-0102 enders into that same log; then, as the **deliberate final step**, flip the badge
+  to `\`complete\`` and push → Code Quality goes green → it merges. The gate engages **only** when
+  a PR *adds* a session card (workflow-authored / non-adopting routine PRs are never deadlocked),
+  so creating the card is mandatory *by this rule* + the Stop-hook reminder, not by hard CI. This
+  supersedes the "open the PR ready" phrasing above for `claude/*` sessions: **open it born-red,
+  flip it ready last.** (`scripts/check_session_gate.py`; ready tokens:
+  `complete/done/ready/final/merged/shipped`.)
 - **End every session with a backlog-grooming pass — the standing secondary task (owner
   decision Q-0015).** Once the main task + PR are done and capacity remains, you are *not*
   finished: browse `docs/ideas/` (plus any ideas the maintainer dropped this session) and

--- a/.claude/skills/session-close/SKILL.md
+++ b/.claude/skills/session-close/SKILL.md
@@ -1,6 +1,12 @@
 # /session-close
 
-End the current session correctly: write the session log (with a previous-session review), groom one idea, add one new idea, verify quality, commit, push, open the PR (ready, not draft), and drive it to a terminal state — merge when CI is green, or close.
+End the current session correctly: finish the session card (the `.sessions/` log — write the previous-session review + new idea), groom one idea, verify quality, commit, push, and **flip the card's Status badge to `complete`** as the deliberate final step so the born-red merge-gate goes green and native auto-merge fires (Q-0133). Drive the PR to a terminal state — merge when CI is green, or close.
+
+> **Born-red flow (Q-0133):** the session card should already exist — you create
+> `.sessions/<date>-<slug>.md` with `> **Status:** \`in-progress\`` in your **first**
+> commit (it opens the PR born red so auto-merge can't fire on a partial PR). This skill
+> finishes that same file and flips it to `\`complete\``. If you skipped the start step,
+> create the card here.
 
 ## What this does
 
@@ -37,6 +43,10 @@ When this skill is invoked:
 
 ```markdown
 # YYYY-MM-DD — <session title>
+
+> **Status:** `complete`
+<!-- born-red flow (Q-0133): `in-progress` while the session is open; flip to
+     `complete` as the final close step so the merge-gate goes green. -->
 
 **PR:** [#NNN](link) — brief description.
 **Branch:** `<branch-name>`
@@ -100,11 +110,13 @@ planning-reconciliation pass (Q-0107: reconcile repo state + plan the next ~9 PR
 not over-segmented); after that pass, reset the `Last reconciliation pass:** PR #N` marker in
 `current-state.md` to the latest PR.
 
-If `check_docs` fails on the new session log file: add the required `> **Status:**` badge.
-Session logs use the `audit` badge token. If `check_session_log` fails, add the missing
-`💡 Session idea` / `⟲ Previous-session review` section it names. If
-`check_current_state_ledger` flags a merged PR, **verify its #number against live GitHub**
-then add it to `docs/current-state.md` § Recently shipped (or an aggregated range entry).
+If `check_session_log` fails, add the missing `💡 Session idea` / `⟲ Previous-session
+review` section it names. The session card carries a `> **Status:**` badge:
+`in-progress` while the session is open (the born-red gate, Q-0133) and `complete` at
+close — `check_session_gate` holds the merge until it is a ready token
+(`complete`/`done`/`ready`/`final`/`merged`/`shipped`). If `check_current_state_ledger`
+flags a merged PR, **verify its #number against live GitHub** then add it to
+`docs/current-state.md` § Recently shipped (or an aggregated range entry).
 
 **Documentation audit (Q-0104) — the judgment half.** The checks above are the automated
 half. Also ask yourself: *"is anything important from this session captured only in chat?"*
@@ -140,8 +152,14 @@ before ending. An abandoned open PR is the failure this prevents.**
 2. If no PR: create one **ready** (`mcp__github__create_pull_request`, `draft: false`).
 3. Subscribe to it (`mcp__github__subscribe_pr_activity`).
 4. Reconcile with main first (fetch + merge `origin/main`, UNION-resolve conflicts).
-5. Wait for CI: `mcp__github__pull_request_read` method `get_check_runs` until `completed`.
-6. If CI green: **merge** with `mcp__github__merge_pull_request` (merge-commit method).
+5. **Flip the card to ready (the merge trigger, Q-0133):** set the session card's
+   `> **Status:**` badge to `complete` and commit/push it **in the same push** as the
+   close-out docs. This is the deliberate final step — it turns the born-red gate green,
+   so native auto-merge fires on a *complete* PR (never the #843 partial-merge race).
+6. Auto-merge (Q-0123) merges the PR the instant **Code Quality** is green — you do not
+   merge by hand. Confirm via `mcp__github__pull_request_read` (`get_check_runs`) and the
+   merge webhook. *(Manual `mcp__github__merge_pull_request` only for a carve-out or if
+   auto-merge is down — then re-verify CI green on the final head.)*
 7. If CI red: diagnose, fix, push, re-check.
 8. If the work should not merge: **close** the PR with a one-line reason. Do not leave it open.
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -68,6 +68,22 @@ jobs:
       - name: Run doc hygiene (check_docs)
         run: python3 scripts/check_docs.py --strict
 
+      # Born-red session merge-gate (owner directive Q-0133). On a PR, if this
+      # session ADDED a `.sessions/` card, the merge is HELD until that card's
+      # `> **Status:**` badge is a ready token (`complete`). The card is created
+      # in the first commit with `in-progress` (PR born red, so native auto-merge
+      # arms but cannot fire on a partial PR — the #843 race), then flipped to
+      # `complete` as the deliberate final step. A PR that adds no card is NOT
+      # gated (workflow-authored / non-adopting routine PRs are never deadlocked).
+      # Pure stdlib; see scripts/check_session_gate.py. UNVERIFIED (Q-0105) —
+      # delete this step + the script if it ever holds a PR it shouldn't.
+      - name: Session merge-gate (check_session_gate)
+        if: github.event_name == 'pull_request'
+        run: |
+          python3 scripts/check_session_gate.py \
+            --base '${{ github.event.pull_request.base.sha }}' \
+            --head '${{ github.event.pull_request.head.sha }}'
+
       - name: Set up Python
         if: steps.changes.outputs.code == 'true'
         uses: actions/setup-python@v6

--- a/.sessions/2026-06-14-session-gate-born-red.md
+++ b/.sessions/2026-06-14-session-gate-born-red.md
@@ -1,0 +1,75 @@
+# 2026-06-14 — born-red session merge-gate (Q-0133)
+
+> **Status:** `in-progress`
+<!-- born-red flow (Q-0133): in-progress while open → flip to `complete` as the final
+     close step so the merge-gate goes green and auto-merge fires. -->
+
+**PR:** (this PR) — enforce the owner's "hold the merge until the session flips its
+plan/outcome doc green" rule. **Branch:** `claude/session-gate-born-red`.
+
+This is the second piece of the 2026-06-14 session (the first — hardening **P1-2**,
+health findings lifecycle + retention — shipped as **#843** + **#846**). The owner asked
+to fix auto-merge firing too quickly, having hit exactly that on #843.
+
+## What's about to happen / what was done
+
+- **Root problem:** native auto-merge (Q-0123) merges a `claude/*` PR the instant **Code
+  Quality** is green. A session pushing code first and close-out docs second merges a
+  *partial* PR — the #843 race (merged without its ledger entry → stranded #846).
+- **Owner's mechanism (refined live):** one per-session file that is **both** the
+  start-declaration ("what's about to happen", visible to parallel/next sessions on the
+  open PR) **and** the end-record ("what happened"), whose status gates the merge. That
+  file = the existing `.sessions/<date>-<slug>.md` log.
+- **Shipped:**
+  - `scripts/check_session_gate.py` — fails when a PR *adds* a session card whose
+    `> **Status:**` badge isn't a ready token; born-red at `in-progress`, green at
+    `complete`. Engage-when-present (a PR adding no card is not gated → routines /
+    workflow-authored PRs never deadlock). Only newly-*added* cards are inspected, so
+    re-badging an old log to `historical` never holds a PR. +11 unit tests.
+  - `.github/workflows/code-quality.yml` — a PR-only `Session merge-gate` step (the
+    required `code-quality` check carries the gate; no branch-protection change needed).
+  - `.claude/CLAUDE.md` § Session & plan workflow — the binding rule (open born-red first,
+    flip ready last); supersedes "open the PR ready" for `claude/*` sessions.
+  - `docs/owner/maintainer-question-router.md` **Q-0133** — the decision + rationale +
+    the engage-when-present strictness choice (and the airtight-later follow-up).
+  - `.claude/skills/session-close/SKILL.md` — the flip-to-`complete` close step + fixed a
+    stale "audit badge token" instruction (real cards close at `complete`) + added the
+    missing Status line to the template.
+- **Dogfooded:** this PR is born red by this very card (`in-progress`) — proving the gate
+  on its own change — then flipped to `complete` as the final step.
+
+## Decisions recorded
+
+- **Q-0133** (owner-directed, applied in-session per the Q-0106 exception): born-red
+  session-card merge-gate; engage-when-present strictness (safe for the autonomous loop),
+  tightenable to airtight later.
+
+## Left open / next session
+
+- **Tighten to airtight** (absent card = red for `claude/*` PRs, with carve-outs for
+  workflow-authored PRs) once routine adoption of the born-red card is proven reliable.
+- A SessionStart-hook reminder to *create* the born-red card could make adoption automatic
+  (left out of v1 to keep the hook surface untouched).
+
+## 💡 Session idea
+
+**Idea:** have the SessionStart hook auto-scaffold the born-red session card (a stub
+`.sessions/<date>-<branch>.md` at `in-progress`) so step 1 of every session is done for
+free, and the gate becomes effectively airtight without anyone remembering to create it.
+**Why:** the engage-when-present gate's one gap is a session that never creates a card;
+auto-scaffolding closes it at the source while keeping the file the owner's
+start+end+coordination artifact. Small hook change; pairs with the airtight follow-up.
+[small — recorded here; promote to `docs/ideas/` if the airtight tightening is taken up]
+
+## ⟲ Previous-session review
+
+The previous session was this same session's P1-2 work (#843 → #846). It did the
+engineering well (real-Postgres-verified SQL, sole-writer discipline, pattern reuse) but
+**surfaced this very bug by living it**: it pushed code first and session-close docs
+second, and auto-merge merged #843 without its ledger entry — a stranded #846 follow-up.
+That is the strongest kind of system feedback: the workflow's own gap caught in practice.
+The concrete improvement is exactly what this PR ships — make "the ledger/close-out docs
+must be in the same push as the code" an *enforced* born-red gate rather than a discipline
+rule (the journal's own standing principle: a doc claim mirroring code state should be
+CI-backed, not refreshed by per-session human discipline — Q-0132). System now self-heals
+the class instead of relying on the next session to notice.

--- a/.sessions/2026-06-14-session-gate-born-red.md
+++ b/.sessions/2026-06-14-session-gate-born-red.md
@@ -1,11 +1,12 @@
 # 2026-06-14 — born-red session merge-gate (Q-0133)
 
-> **Status:** `in-progress`
-<!-- born-red flow (Q-0133): in-progress while open → flip to `complete` as the final
-     close step so the merge-gate goes green and auto-merge fires. -->
+> **Status:** `complete`
+<!-- born-red flow (Q-0133): was `in-progress` (PR born red); flipped to `complete` as the
+     deliberate final close step so the merge-gate goes green and auto-merge fires. -->
 
-**PR:** (this PR) — enforce the owner's "hold the merge until the session flips its
-plan/outcome doc green" rule. **Branch:** `claude/session-gate-born-red`.
+**PR:** [#849](https://github.com/menno420/superbot/pull/849) — enforce the owner's "hold the
+merge until the session flips its plan/outcome doc green" rule. **Branch:**
+`claude/session-gate-born-red`.
 
 This is the second piece of the 2026-06-14 session (the first — hardening **P1-2**,
 health findings lifecycle + retention — shipped as **#843** + **#846**). The owner asked

--- a/docs/current-state-archive.md
+++ b/docs/current-state-archive.md
@@ -21,6 +21,13 @@
   *(Recorded here at the P1-2 session close to keep the strict ledger green — it merged
   without its own ledger entry on the same auto-merge race as #843; its full fold is the
   next pass's, per Q-0124.)*
+- **#765 + #767 + #769 + #770 (2026-06-12/13, backup posture + autonomous-loop
+  follow-ups)** — **#769** Postgres backup posture (band slot 3 — daily `pg_dump` to a
+  GitHub Actions artifact; [production-deployment §Backups](operations/production-deployment.md))
+  · **#767** `executor-nightly.yml` cron moved off `:00` to dodge scheduler congestion ·
+  **#770** permissions: the autonomous executor may push to `main` without prompting ·
+  **#765** the autonomous-loop session close (loop live + Hermes dual-platform control
+  plane — [session log](../.sessions/2026-06-13-autonomous-loop-hermes-control-plane.md)).
 - **#764 (2026-06-12 night, the P2 doc-drift sweep — band slot 2)** — all five
   hardening-P2 fixes, source-verified then applied: smoke checklist's nonexistent
   `!platform diagnostics` → `runtime`/`consistency` + the platform-panel

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -20,7 +20,13 @@
 >
 > Cross-cutting: **Community Spotlight** (side-lane **#613**/**#614** + hotfixes **#615**/**#617**) was hardened in the review session (canonical `utils/db/xp.py` read, `member_count` crash fix, first tests) and **Q-0044 is executed**: the Q-0025 `scripts/new_subsystem.py` scaffold was built and used to register Spotlight as a `community`-hub child (**#626**, 2026-06-09 — execution-plan Lane 1; merged, verified live), and the `!hub`/`!server` aliases were **dropped same day** (kept `!spotlight`/`!activity`). Also decided: BTD6 data-refresh automation = **manual-dispatch workflow** (Q-0049 — **built same day in #633**, execution-plan Lane 5: `workflow_dispatch`-only, opens a reviewable PR, never pushes to main); mining descent lights **permanent, owner-confirmed** (Q-0050); the five product-vision questions (Q-0038–Q-0042) got their **draft-answer session** (Q-0051) **and the maintainer marked all five up same day (Lane 6, PR #631, structured choices)**: Q-0038 server-scoped clans, Q-0039 cosmetic-only donations (no bot-side billing), Q-0041 YouTube-first/dual-opt-in/voice-deferred, Q-0042 staged-Someday website — all approved as drafted; **Q-0040 adjusted: the AI dungeon master picks quests/rewards/difficulty from bounded, hard-capped menus** (not pure narration, not free-form authority). Posture decisions only — every lane still needs its own plan/promotion + the AI per-exposure lift; conclusions routed to the four roadmap drafts + router §21. Full repo review: [`audits/repo-review-2026-06-09.md`](audits/repo-review-2026-06-09.md) · agent-memory system review (did the orientation/memory system work in practice?): [`audits/agent-memory-system-review-2026-06-09.md`](audits/agent-memory-system-review-2026-06-09.md).
 >
-> **Last updated:** 2026-06-14, **hardening P1-2 — health findings lifecycle + operational
+> **Last updated:** 2026-06-14, **born-red session merge-gate (#849, Q-0133)**. Every
+> `claude/*` session now opens its PR **born red** via an `in-progress` `.sessions/` card and
+> flips it to `complete` as the deliberate final step — so native auto-merge fires on a
+> *complete* PR, never a partial one (the #843 race). Folded into the required `code-quality`
+> check (`scripts/check_session_gate.py`); engage-when-present so routines never deadlock;
+> dogfooded on its own PR. ·
+> 2026-06-14, **hardening P1-2 — health findings lifecycle + operational
 > retention (#843, Q-0097)**. The persistent operational-health findings store gained an
 > operator-managed transition path through the sole writer (`health_findings_service.set_status`
 > + DB primitive `set_finding_status`, audited via `audit.action_recorded`), surfaced as
@@ -169,6 +175,19 @@ Source code and merged PRs win over anything written here.
 > at the boundary that fires the docs-reconciliation routine). Reset this marker to the latest
 > PR after a pass.
 
+- **#849 (2026-06-14, born-red session merge-gate — Q-0133)** — closed the auto-merge race
+  that landed **#843** without its ledger entry (native auto-merge, Q-0123, fires the instant
+  Code Quality is green, so a session pushing code first and close-out docs second merges a
+  *partial* PR). The owner's fix, as refined live: one per-session file that is **both** the
+  start-declaration (*what's about to happen*, visible to parallel/next sessions on the open PR)
+  **and** the end-record (*what happened*) — the existing `.sessions/<date>-<slug>.md` log —
+  whose `> **Status:**` badge gates the merge. Created in the **first** commit as `in-progress`
+  (PR **born red**, race-free), flipped to `complete` as the deliberate **final** step → green →
+  merge. `scripts/check_session_gate.py` (folded into the required `code-quality` check — no
+  branch-protection change) fails when a PR *adds* a session card that isn't ready;
+  **engage-when-present** (a PR adding no card isn't gated, so routines / workflow-authored PRs
+  never deadlock); only newly-*added* cards inspected. +11 tests; the gate was **dogfooded on its
+  own PR** (born red, then flipped). Follow-up: tighten to airtight once routine adoption is proven.
 - **#843 (2026-06-14, hardening P1-2 — health findings lifecycle + operational retention,
   Q-0097)** — closed the two **code** gaps in the health/diagnostics readiness map (the
   remaining gap to production-ready is now the owner-led live walk only). Before: in normal
@@ -437,16 +456,7 @@ Source code and merged PRs win over anything written here.
   ladder). New advisory event `automod.rule_triggered`; config via the `!settings`
   widget. 31 tests; CI green; live-boot verified. **Next band slot: server event
   logging v1 (slot 5).**
-- **#765 + #767 + #769 + #770 (2026-06-12/13, backup posture + autonomous-loop
-  follow-ups)** — **#769** Postgres backup posture (band slot 3 — daily `pg_dump` to a
-  GitHub Actions artifact; [production-deployment §Backups](operations/production-deployment.md))
-  · **#767** `executor-nightly.yml` cron moved off `:00` to dodge scheduler congestion ·
-  **#770** permissions: the autonomous executor may push to `main` without prompting ·
-  **#765** the autonomous-loop session close (loop live + Hermes dual-platform control
-  plane — [session log](../.sessions/2026-06-13-autonomous-loop-hermes-control-plane.md)).
-  *(Reconciled here by the automod session; #771 is a parallel ledger-update PR for the
-  same band — UNION-merge if both land.)*
-- **Older merges (#764 … #535) → [`current-state-archive.md`](current-state-archive.md).** Recently-shipped keeps the ~20 newest; older entries are archived (`scripts/check_docs.py` soft-ratchets the count). *(The #764 P2 doc-drift-sweep entry was archived 2026-06-14 to offset the #843 entry added above; the band-#840 reconciliation pass archived three entries — the #763 second-reconciliation-pass record, the #758/#760/#762 UX-Lab BUILD, and the #753/#754/#756/#759/#761 autonomous-loop wiring; the #755 entry was archived earlier the same day to offset #829; the #746–#754 entry to offset #825; the #741/#742/#745/#748 entries by the band-#820 pass.)*
+- **Older merges (#765 … #535) → [`current-state-archive.md`](current-state-archive.md).** Recently-shipped keeps the ~20 newest; older entries are archived (`scripts/check_docs.py` soft-ratchets the count). *(The #765+#767+#769+#770 backup-posture entry was archived 2026-06-14 to offset the #849 entry added above; the #764 P2 doc-drift-sweep entry to offset #843; the band-#840 reconciliation pass archived three entries — the #763 second-reconciliation-pass record, the #758/#760/#762 UX-Lab BUILD, and the #753/#754/#756/#759/#761 autonomous-loop wiring; the #755 entry to offset #829; the #746–#754 entry to offset #825; the #741/#742/#745/#748 entries by the band-#820 pass.)*
 
 > Older than this: see `docs/planning/*` trackers and `docs/decisions/*` ADRs.
 

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -5045,3 +5045,45 @@ future-product-direction's "AI explanations only, no write tools") and the ChatG
 grounding contract (the repo already enforces grounding-first/cite-everything) — both already covered.
 
 **Home:** this block (provenance index); the four docs above hold the items.
+
+---
+
+### Q-0133 — Born-red session card: hold the merge until the session flips it ready (2026-06-14)
+
+> **DECISION 2026-06-14 (owner-directed, applied in-session per the Q-0106 in-session-exception —
+> the owner is the live reviewer for this CLAUDE.md + workflow change).**
+
+**Problem.** Native auto-merge (Q-0123) merges a `claude/*` PR the instant **Code Quality** is
+green. A session that pushes its code first and its close-out docs (ledger entry, `.sessions/`
+log) second merges a **partial** PR before those docs land — the **#843** case: it merged without
+its ledger entry, leaving a stranded follow-up (#846). Push-batching discipline (Q-0126) alone did
+not prevent it; the owner asked to **enforce** a hold.
+
+**Owner's mechanism (his words, refined live).** "Enforce a rule so that the first docs PR…has a
+document with failing CI, and only when you want to merge do you change the document and CI goes
+green" → refined to: "the **same file** is also the session-start and session-end file, so it shows
+the next/parallel session **what is about to happen and what has happened**."
+
+**Decision — adopted as designed.** That single file is the existing **`.sessions/<date>-<slug>.md`
+session log**, and its `> **Status:**` badge gates the merge:
+- Created in the **first** commit with `Status: in-progress` + a one-line "what's about to happen"
+  → the PR is **born red** (race-free: the gate is red from commit 1, not a label added later).
+- Flipped to `Status: complete` as the **deliberate final step**, after the close-out docs (and the
+  Q-0089/Q-0102 enders) are written → Code Quality green → auto-merge fires on a *complete* PR.
+- Per-session filename → no parallel-chat collision, no `main` conflict; it lands on `main` as the
+  durable "what happened" record (already the `.sessions/` convention). Coordination ("what's about
+  to happen") is visible on the open PR; complements the pre-PR `active-work.md` claim ledger.
+
+**Strictness chosen — engage-when-present (not airtight).** The `check_session_gate` step in
+`code-quality` fails **only** when the PR *adds* a session card whose status isn't a ready token;
+a PR that adds no card merges as before. This is deliberate: it **cannot deadlock the autonomous
+loop** (workflow-authored PRs like `btd6-data-refresh`, or a routine that hasn't created a card,
+are never blocked). Creating the card is mandatory **by the CLAUDE.md rule** + the Stop-hook /
+`/session-close` reminder, not by hard CI. *Can be tightened to airtight (absent = red, with
+carve-outs for workflow-authored PRs) later if routine adoption proves reliable — left as the
+follow-up.* Reliability (Q-0105): UNVERIFIED — `scripts/check_session_gate.py` + the workflow step
+are deletable if the gate ever holds a PR it shouldn't.
+
+**Home:** `.claude/CLAUDE.md` § Session & plan workflow (the rule); `scripts/check_session_gate.py`
++ `.github/workflows/code-quality.yml` (the gate); `.claude/skills/session-close/SKILL.md` (the
+flip-ready step). Shipped this session (born-red dogfooded on its own PR).

--- a/scripts/check_session_gate.py
+++ b/scripts/check_session_gate.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3.10
+"""Session merge-gate — hold a PR red until its session card says it's done.
+
+The merge race this closes (owner directive Q-0133, 2026-06-14)
+--------------------------------------------------------------
+Native auto-merge (Q-0123) merges a `claude/*` PR the instant the required
+`Code Quality` check goes green. A session that pushes its code first and its
+session-close docs (the ledger entry, the `.sessions/` log) second can therefore
+merge **before** those docs are pushed — the #843 case: the PR merged without its
+ledger entry, leaving a stranded follow-up.
+
+The fix is the owner's: every session declares itself up-front in a single
+per-session file that is *both* the start-declaration ("what is about to happen",
+visible to parallel/next sessions on the open PR) **and** the end-record ("what
+has happened"). That file is the existing `.sessions/<date>-<slug>.md` log, and
+its `> **Status:**` badge gates the merge:
+
+* Created in the **first** commit with a HOLD status (`in-progress`) → the PR is
+  **born red**, so auto-merge arms but cannot fire (no race window — the gate is
+  red from commit 1, not added later).
+* Flipped to a READY status (`complete`) as the deliberate **final** step →
+  `Code Quality` goes green → auto-merge fires.
+
+Engage-when-present (the safe default Q-0133 chose over airtight): the gate fails
+**only** when the PR *adds* a session card whose status is a hold/unknown token. A
+PR that adds **no** new session card behaves exactly as before (merges on green),
+so workflow-authored PRs (btd6-data-refresh) and any routine that hasn't created a
+card are never deadlocked. Creating the card is mandatory **by CLAUDE.md rule** +
+the Stop-hook / `/session-close` reminder, not by hard CI enforcement.
+
+Only **newly-added** cards (`git diff --diff-filter=A`) are inspected — a
+reconciliation PR that re-badges an *old* log to `historical` is never held.
+
+Pure stdlib (runs in CI's `code-quality` job before any setup) and unit-tested.
+
+Usage:
+    python3.10 scripts/check_session_gate.py                 # auto (vs origin/main)
+    python3.10 scripts/check_session_gate.py --base SHA --head SHA   # CI
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# READY = the PR may merge. Anything else on a newly-added card holds it red, so a
+# typo'd or still-in-progress status fails safe (held) rather than merging early.
+_READY_STATUSES = {"complete", "done", "ready", "final", "merged", "shipped"}
+
+# Terminator is an em/en-dash or pipe or end-of-line — NOT a plain hyphen, which is
+# part of word-tokens like `in-progress`.
+_STATUS_RE = re.compile(r"\*\*Status:\*\*\s*`?\s*([A-Za-z0-9 _-]+?)\s*`?\s*(?:[—–|]|$)")
+
+
+def parse_status(text: str) -> str | None:
+    """Return the lowercased `> **Status:** `<token>`` badge token, or None."""
+    for line in text.splitlines():
+        if "**Status:**" in line:
+            m = _STATUS_RE.search(line)
+            if m:
+                return m.group(1).strip().lower()
+    return None
+
+
+def added_session_cards(base: str | None, head: str | None) -> list[Path]:
+    """`.sessions/*.md` files ADDED between base and head (README excluded).
+
+    CI passes the PR base/head SHAs; locally we diff against ``origin/main`` (the
+    merge base of this branch). Returns [] on any git failure — a gate that cannot
+    read git must not block (fail-open here; the rule + reminder are the backstop).
+    """
+    if base and head:
+        # CI: the card is committed in the PR — the committed diff is authoritative.
+        cmds = [
+            [
+                "git",
+                "diff",
+                "--name-only",
+                "--diff-filter=A",
+                base,
+                head,
+                "--",
+                ".sessions/",
+            ],
+        ]
+    else:
+        # Local: include not-yet-committed cards (staged or untracked) so a pre-push
+        # run reflects what the PR will contain.
+        cmds = [
+            [
+                "git",
+                "diff",
+                "--name-only",
+                "--diff-filter=A",
+                "origin/main...HEAD",
+                "--",
+                ".sessions/",
+            ],
+            ["git", "ls-files", "--others", "--exclude-standard", "--", ".sessions/"],
+        ]
+    found: set[str] = set()
+    for cmd in cmds:
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO_ROOT)
+        except OSError:
+            continue
+        if result.returncode != 0:
+            continue
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if line.startswith(".sessions/") and line.endswith(".md"):
+                if Path(line).name != "README.md":
+                    found.add(line)
+    return [REPO_ROOT / p for p in sorted(found)]
+
+
+def held_cards(cards: list[Path]) -> list[tuple[Path, str]]:
+    """Return (card, status) for each card NOT in a READY status."""
+    held: list[tuple[Path, str]] = []
+    for card in cards:
+        try:
+            text = card.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        status = parse_status(text) or "(no Status badge)"
+        if status not in _READY_STATUSES:
+            held.append((card, status))
+    return held
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="SuperBot session merge-gate.")
+    parser.add_argument("--base", help="base commit SHA (CI: PR base)")
+    parser.add_argument("--head", help="head commit SHA (CI: PR head)")
+    args = parser.parse_args(argv)
+
+    cards = added_session_cards(args.base, args.head)
+    if not cards:
+        print("check_session_gate: no new session card in this PR — not gated. ✓")
+        return 0
+
+    held = held_cards(cards)
+    if not held:
+        names = ", ".join(c.name for c in cards)
+        print(
+            f"check_session_gate: session card(s) ready — merge unblocked ✓ ({names})",
+        )
+        return 0
+
+    print("check_session_gate: MERGE HELD — session card not marked ready.")
+    for card, status in held:
+        rel = card.relative_to(REPO_ROOT) if card.is_relative_to(REPO_ROOT) else card
+        print(f"  - {rel}: Status `{status}` (held)")
+    ready = ", ".join(sorted(_READY_STATUSES))
+    print(
+        "\nThis is the born-red session gate (Q-0133): flip the card's "
+        "`> **Status:**` badge to a ready token to merge.\n"
+        f"  Ready tokens: {ready}\n"
+        "  (Do this as the deliberate final step, after the session-close docs "
+        "are written — so auto-merge fires on a complete PR, not a partial one.)",
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_session_gate.py
+++ b/tests/unit/scripts/test_check_session_gate.py
@@ -1,0 +1,94 @@
+"""Tests for scripts/check_session_gate.py — the born-red session merge-gate (Q-0133)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SPEC = importlib.util.spec_from_file_location(
+    "check_session_gate",
+    _REPO_ROOT / "scripts" / "check_session_gate.py",
+)
+assert _SPEC and _SPEC.loader
+gate = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(gate)
+
+
+# --- parse_status -----------------------------------------------------------
+
+
+def test_parse_status_backticked():
+    assert (
+        gate.parse_status("> **Status:** `in-progress` — doing the thing")
+        == "in-progress"
+    )
+
+
+def test_parse_status_plain():
+    assert gate.parse_status("> **Status:** complete") == "complete"
+
+
+def test_parse_status_complete_with_trailing():
+    assert gate.parse_status("> **Status:** `complete` — PR #843 merged.") == "complete"
+
+
+def test_parse_status_missing():
+    assert gate.parse_status("# A log with no badge\n\nsome text") is None
+
+
+# --- held_cards -------------------------------------------------------------
+
+
+def test_held_card_in_progress(tmp_path):
+    card = tmp_path / "2026-06-14-x.md"
+    card.write_text("# x\n\n> **Status:** `in-progress`\n", encoding="utf-8")
+    held = gate.held_cards([card])
+    assert held == [(card, "in-progress")]
+
+
+def test_ready_card_complete_not_held(tmp_path):
+    card = tmp_path / "2026-06-14-x.md"
+    card.write_text("# x\n\n> **Status:** `complete`\n", encoding="utf-8")
+    assert gate.held_cards([card]) == []
+
+
+def test_unknown_status_is_held_fail_safe(tmp_path):
+    """An added card with an unrecognized status fails safe (held), not merged."""
+    card = tmp_path / "2026-06-14-x.md"
+    card.write_text("# x\n\n> **Status:** `frobnicating`\n", encoding="utf-8")
+    held = gate.held_cards([card])
+    assert held == [(card, "frobnicating")]
+
+
+def test_missing_badge_is_held(tmp_path):
+    card = tmp_path / "2026-06-14-x.md"
+    card.write_text("# x\n\njust prose, no badge\n", encoding="utf-8")
+    held = gate.held_cards([card])
+    assert held and held[0][1] == "(no Status badge)"
+
+
+# --- main / exit codes ------------------------------------------------------
+
+
+def test_main_no_cards_passes(monkeypatch, capsys):
+    monkeypatch.setattr(gate, "added_session_cards", lambda base, head: [])
+    assert gate.main(["--base", "a", "--head", "b"]) == 0
+    assert "not gated" in capsys.readouterr().out
+
+
+def test_main_held_card_fails(monkeypatch, capsys, tmp_path):
+    card = tmp_path / "2026-06-14-x.md"
+    card.write_text("# x\n\n> **Status:** `in-progress`\n", encoding="utf-8")
+    monkeypatch.setattr(gate, "added_session_cards", lambda base, head: [card])
+    assert gate.main([]) == 1
+    out = capsys.readouterr().out
+    assert "MERGE HELD" in out and "in-progress" in out
+
+
+def test_main_ready_card_passes(monkeypatch, capsys, tmp_path):
+    card = tmp_path / "2026-06-14-x.md"
+    card.write_text("# x\n\n> **Status:** `complete`\n", encoding="utf-8")
+    monkeypatch.setattr(gate, "added_session_cards", lambda base, head: [card])
+    assert gate.main([]) == 0
+    assert "merge unblocked" in capsys.readouterr().out


### PR DESCRIPTION
## What & why

Enforces your rule: a session can't merge a **partial** PR. Native auto-merge (Q-0123) merges a `claude/*` PR the instant **Code Quality** is green — so a session that pushes code first and its close-out docs (ledger entry, `.sessions/` log) second merges *before* those docs land. That's exactly what bit **#843** (it merged without its ledger entry, leaving a stranded follow-up #846).

**Your mechanism, implemented as you refined it:** one per-session file that is **both** the start-declaration (*what's about to happen* — visible to parallel/next sessions on the open PR) **and** the end-record (*what happened*). That file is the existing `.sessions/<date>-<slug>.md` log, and its `> **Status:**` badge gates the merge:

- Created in the **first** commit with `Status: in-progress` → the PR is **born red** (race-free — red from commit 1, not a label added later), so auto-merge arms but **cannot fire on an incomplete PR**.
- Flipped to `Status: complete` as the **deliberate final step**, after the close-out docs are written → Code Quality goes green → it merges.

## How it works
- **`scripts/check_session_gate.py`** — fails when a PR *adds* a session card whose status isn't a ready token (`complete`/`done`/`ready`/`final`/`merged`/`shipped`). Folded into the already-required `code-quality` check, so **no branch-protection change is needed**.
- **Engage-when-present** (the safe strictness — see Q-0133): a PR that adds **no** session card merges as before, so workflow-authored PRs (`btd6-data-refresh`) and any routine that hasn't created a card are **never deadlocked**. Creating the card is mandatory *by the CLAUDE.md rule* + the `/session-close` reminder, not by hard CI. Can be tightened to airtight later (left as the noted follow-up).
- Only **newly-added** cards are inspected — re-badging an old log to `historical` never holds a PR.

## Files
`scripts/check_session_gate.py` (+11 unit tests) · `.github/workflows/code-quality.yml` (PR-only gate step) · `.claude/CLAUDE.md` § Session & plan workflow (the rule) · `docs/owner/maintainer-question-router.md` (**Q-0133**) · `.claude/skills/session-close/SKILL.md` (flip-to-complete step + template fix).

## Dogfooded on its own PR
This PR is **born red** by its own `in-progress` session card — you should see **Code Quality fail with "MERGE HELD"** until I flip the card to `complete` as the final step. That both proves the gate and follows the new rule.

## Verification
`check_quality --full` green (9568 passed) · `check_docs --strict` ✓ · gate unit tests ✓ · gate confirmed to hold this PR locally.

https://claude.ai/code/session_01LNf6E8AyhW48SSHWGowh69

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNf6E8AyhW48SSHWGowh69)_