### PR TITLE
feat(p0-3): !platform backfill command — complete the legacy-pointer migration

### DIFF
--- a/disbot/cogs/diagnostic/_backfill.py
+++ b/disbot/cogs/diagnostic/_backfill.py
@@ -1,0 +1,55 @@
+"""Orchestration for ``!platform backfill`` (legacy-pointer → binding migration).
+
+Kept out of ``diagnostic_cog.py`` (which is at the 800-LOC cog ceiling) and out of
+``_platform_embeds.py`` (pure renderers): this helper does channel I/O + the
+audited service mutation, so it lives in its own module. The cog command is a thin
+wrapper that delegates here.
+
+It completes the P0-3 pointer-lane convergence (plan §8): the retired
+``xp.announce_channel`` / ``economy.log_channel`` pointers fall back to legacy KV
+until their binding rows exist; ``apply`` writes those rows via the audited
+``services.binding_backfill.apply_backfill`` seam, clearing the Config-arbitration
+fallback consistency warning.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cogs.diagnostic._platform_embeds import (
+    build_backfill_apply_embed,
+    build_backfill_dryrun_embed,
+)
+
+
+async def handle_platform_backfill(ctx: Any, action: str) -> None:
+    """Dry-run (default) or ``apply`` the binding backfill for ``ctx.guild``.
+
+    ``action == "apply"`` writes the ``candidate_valid`` rows (idempotent,
+    advisory-lock guarded, audited as ``actor_type='backfill'``); anything else
+    is a read-only dry-run preview.
+    """
+    from services import binding_backfill
+
+    if ctx.guild is None:
+        await ctx.send("⚠️ This command must be run in a guild.", delete_after=15)
+        return
+
+    if action.lower() == "apply":
+        try:
+            result = await binding_backfill.apply_backfill(
+                ctx.guild,
+                actor_id=ctx.author.id,
+            )
+        except binding_backfill.BackfillLockHeldError:
+            await ctx.send(
+                "⏳ A backfill is already running for this guild — "
+                "try again in a moment.",
+                delete_after=15,
+            )
+            return
+        await ctx.send(embed=build_backfill_apply_embed(result))
+        return
+
+    summary = await binding_backfill.dry_run(ctx.guild)
+    await ctx.send(embed=build_backfill_dryrun_embed(summary))

--- a/disbot/cogs/diagnostic/_platform_embeds.py
+++ b/disbot/cogs/diagnostic/_platform_embeds.py
@@ -28,6 +28,7 @@ from services.platform_consistency import (
 
 if TYPE_CHECKING:
     from governance.models import CleanupPolicy, GovernanceSnapshot
+    from services.binding_backfill import ApplyResult, DryRunSummary
 
 
 # ---------------------------------------------------------------------------
@@ -1944,8 +1945,87 @@ async def build_command_access_diagnostic_embed(
     return embed
 
 
+def build_backfill_dryrun_embed(summary: DryRunSummary) -> discord.Embed:
+    """Render ``!platform backfill`` (dry run) — what *would* be written.
+
+    Pure renderer over a :class:`services.binding_backfill.DryRunSummary`
+    (fields are already stringified / scrubbed). The operator reviews this,
+    then runs ``!platform backfill apply`` to write the ``candidate_valid`` rows.
+    """
+    writable = summary.counts.get("candidate_valid", 0)
+    embed = discord.Embed(
+        title="🧩 Binding backfill — dry run",
+        description=(
+            f"**{writable}** legacy pointer(s) ready to migrate into binding rows."
+            if writable
+            else "Nothing to migrate — no `candidate_valid` legacy pointers."
+        ),
+        color=discord.Color.gold() if writable else discord.Color.green(),
+    )
+    counts_line = (
+        ", ".join(f"{k}={v}" for k, v in sorted(summary.counts.items()) if v)
+        or "*(no candidates)*"
+    )
+    embed.add_field(name="Classification counts", value=counts_line, inline=False)
+    lines = [
+        f"`{c.legacy_key}` → **{c.subsystem}.{c.binding_name}** — {c.classification}"
+        + (f" (target {c.legacy_target_id})" if c.legacy_target_id else "")
+        for c in summary.candidates[:12]
+    ]
+    embed.add_field(
+        name="Candidates",
+        value=_capped(lines, empty="*(none)*"),
+        inline=False,
+    )
+    embed.set_footer(
+        text="Run `!platform backfill apply` to write the candidate_valid rows "
+        "(idempotent + audited).",
+    )
+    return embed
+
+
+def build_backfill_apply_embed(result: ApplyResult) -> discord.Embed:
+    """Render ``!platform backfill apply`` — the write-phase outcome.
+
+    Pure renderer over a :class:`services.binding_backfill.ApplyResult`.
+    """
+    failed = result.is_failure
+    written = result.write_status_counts.get("written", 0)
+    embed = discord.Embed(
+        title="🧩 Binding backfill — " + ("failed" if failed else "applied"),
+        description=(
+            f"⚠️ Backfill completed with failures — {written} written; see below."
+            if failed
+            else f"✅ Backfill complete — {written} binding row(s) written."
+        ),
+        color=discord.Color.red() if failed else discord.Color.green(),
+    )
+    status_line = (
+        ", ".join(
+            f"{k}={v}" for k, v in sorted(result.write_status_counts.items()) if v
+        )
+        or "*(no writes)*"
+    )
+    embed.add_field(name="Write status", value=status_line, inline=False)
+    write_lines = [
+        f"`{w.legacy_key}` — {w.write_status}" + (f" ⚠️ {w.error}" if w.error else "")
+        for w in result.writes[:12]
+    ]
+    embed.add_field(
+        name="Writes",
+        value=_capped(write_lines, empty="*(none)*"),
+        inline=False,
+    )
+    if result.error:
+        embed.add_field(name="Error", value=str(result.error)[:1000], inline=False)
+    embed.set_footer(text="Re-running is idempotent — already-bound rows are skipped.")
+    return embed
+
+
 __all__ = [
     "build_anchors_embed",
+    "build_backfill_apply_embed",
+    "build_backfill_dryrun_embed",
     "build_bindings_embed",
     "build_caches_embed",
     "build_command_access_diagnostic_embed",

--- a/disbot/cogs/diagnostic_cog.py
+++ b/disbot/cogs/diagnostic_cog.py
@@ -637,6 +637,14 @@ class DiagnosticCog(commands.Cog):
         report = await collect_report(bot=self.bot, guild=ctx.guild)
         await ctx.send(embed=build_consistency_embed(report))
 
+    @platform_grp.command(name="backfill")  # type: ignore[arg-type]
+    @commands.has_permissions(administrator=True)
+    async def platform_backfill(self, ctx, action: str = "") -> None:
+        """Dry-run (default) or `apply` the legacy-pointer → binding backfill."""
+        from cogs.diagnostic._backfill import handle_platform_backfill
+
+        await handle_platform_backfill(ctx, action)
+
     @platform_grp.command(  # type: ignore[arg-type]
         name="command-access",
         aliases=["commandaccess"],

--- a/docs/planning/settings-pointer-lane-convergence-plan-2026-06-13.md
+++ b/docs/planning/settings-pointer-lane-convergence-plan-2026-06-13.md
@@ -290,16 +290,20 @@ forever, and Config arbitration warns on every boot.
 consistency WARNING that masks any *other* config-arbitration regression, and a
 migration that can never reach "done".
 
-**Remediation options (needs an owner decision before building — it is a
-cross-guild production data mutation):**
-1. An **admin-gated `!platform backfill` command** (dry-run → apply, audited via
-   the existing `BindingMutationPipeline`/`setup_delegate` seam) — the operator
-   runs it per guild; cleanest fit with the existing audited mutation lane.
-2. A **one-shot startup backfill** behind a flag — runs `apply_backfill` once per
-   guild at boot until checkpoints exist; lower-touch but mutates on boot.
-3. Accept the warning as expected-until-families-3–5 and **suppress
-   Config-arbitration `fallback` from the *startup* snapshot** while the migration
-   is in flight (documents intent, keeps the signal for `!platform consistency`).
+**Remediation options (considered):**
+1. **✅ SHIPPED — an admin-gated `!platform backfill` command** (owner-approved
+   2026-06-14): `!platform backfill` dry-runs (read-only preview); `!platform
+   backfill apply` writes the `candidate_valid` rows through the audited
+   `apply_backfill` seam (`actor_type='backfill'`, per-guild, idempotent —
+   already-bound rows are skipped, advisory-lock guarded). This wires the
+   already-built+tested `services.binding_backfill` to an operator surface so the
+   migration can finally be completed in production.
+2. A **one-shot startup backfill** behind a flag — not chosen (mutating on boot is
+   riskier than an explicit operator action).
+3. Suppress Config-arbitration `fallback` from the *startup* snapshot — not
+   needed once the operator runs the command per guild.
 
-Option 1 is recommended (explicit, audited, per-guild). Until one ships, the
-startup `degraded — attention: consistency` is expected and benign.
+**Operator action (clears the warning for good):** run `!platform backfill` then
+`!platform backfill apply` in each guild that still shows the Config-arbitration
+fallback. Until apply runs, the startup `degraded — attention: consistency` is
+expected and benign (legacy KV is the correct fallback).

--- a/tests/unit/runtime/test_platform_backfill_command.py
+++ b/tests/unit/runtime/test_platform_backfill_command.py
@@ -1,0 +1,167 @@
+"""Tests for ``!platform backfill`` — the legacy-pointer → binding migration command.
+
+Wires the already-built, tested ``services.binding_backfill`` (dry_run /
+apply_backfill) to an admin-gated command so the migration can be completed in
+production (P0-3 convergence plan §8). These tests cover the dry-run default, the
+explicit ``apply`` path (including the advisory-lock-held case), and the two
+embed builders.
+"""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cogs.diagnostic._platform_embeds import (
+    build_backfill_apply_embed,
+    build_backfill_dryrun_embed,
+)
+from services import binding_backfill
+from services.binding_backfill import (
+    ApplyResult,
+    CandidateResult,
+    DryRunSummary,
+    WriteResult,
+)
+
+_NOW = datetime.datetime(2026, 6, 14, tzinfo=datetime.timezone.utc)
+
+
+def _make_ctx() -> MagicMock:
+    ctx = MagicMock()
+    ctx.send = AsyncMock()
+    ctx.guild = MagicMock()
+    ctx.author.id = 4242
+    return ctx
+
+
+def _make_cog():
+    from cogs.diagnostic_cog import DiagnosticCog
+
+    return DiagnosticCog(bot=MagicMock())
+
+
+def _candidate(classification: str) -> CandidateResult:
+    return CandidateResult(
+        legacy_key="xp_announce_channel",
+        subsystem="xp",
+        binding_name="announce_channel",
+        kind="channel",
+        legacy_target_id=111,
+        legacy_raw="111",
+        binding_target_id=None,
+        binding_status=None,
+        classification=classification,
+        reason="legacy present, no binding",
+    )
+
+
+def _dryrun(*, writable: int = 1) -> DryRunSummary:
+    return DryRunSummary(
+        guild_id=1,
+        started_at=_NOW,
+        completed_at=_NOW,
+        summary_version=1,
+        candidates=(_candidate("candidate_valid"),) if writable else (),
+        counts={"candidate_valid": writable} if writable else {"both_absent": 1},
+    )
+
+
+def _apply(*, failed: bool = False) -> ApplyResult:
+    writes = (
+        WriteResult(
+            legacy_key="xp_announce_channel",
+            subsystem="xp",
+            binding_name="announce_channel",
+            target_id=111,
+            write_status="failed" if failed else "written",
+            classification="candidate_valid",
+            mutation_id="" if failed else "mut-1",
+            error="boom" if failed else None,
+        ),
+    )
+    return ApplyResult(
+        guild_id=1,
+        started_at=_NOW,
+        completed_at=_NOW,
+        actor_id=4242,
+        summary_version=1,
+        pre_counts={"candidate_valid": 1},
+        post_counts={"match": 1},
+        writes=writes,
+        write_status_counts={"failed": 1} if failed else {"written": 1},
+        error="boom" if failed else None,
+    )
+
+
+# --- command: dry-run default ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backfill_default_is_dry_run():
+    cog, ctx = _make_cog(), _make_ctx()
+    with (
+        patch.object(
+            binding_backfill, "dry_run", AsyncMock(return_value=_dryrun()),
+        ) as dr,
+        patch.object(binding_backfill, "apply_backfill", AsyncMock()) as ap,
+    ):
+        await cog.platform_backfill.callback(cog, ctx, "")
+    dr.assert_awaited_once()
+    ap.assert_not_awaited()  # default must never mutate
+    embed = ctx.send.call_args.kwargs["embed"]
+    assert "dry run" in (embed.title or "").lower()
+
+
+# --- command: apply --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backfill_apply_writes_with_actor_id():
+    cog, ctx = _make_cog(), _make_ctx()
+    with patch.object(
+        binding_backfill, "apply_backfill", AsyncMock(return_value=_apply()),
+    ) as ap:
+        await cog.platform_backfill.callback(cog, ctx, "apply")
+    ap.assert_awaited_once()
+    assert ap.call_args.kwargs["actor_id"] == 4242
+    embed = ctx.send.call_args.kwargs["embed"]
+    assert "applied" in (embed.title or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_backfill_apply_reports_lock_held():
+    cog, ctx = _make_cog(), _make_ctx()
+    with patch.object(
+        binding_backfill,
+        "apply_backfill",
+        AsyncMock(side_effect=binding_backfill.BackfillLockHeldError("held")),
+    ):
+        await cog.platform_backfill.callback(cog, ctx, "apply")
+    sent = ctx.send.call_args.args[0] if ctx.send.call_args.args else ""
+    assert "already running" in sent.lower()
+
+
+# --- embed builders --------------------------------------------------------
+
+
+def test_dryrun_embed_flags_writable_candidates():
+    embed = build_backfill_dryrun_embed(_dryrun(writable=2))
+    assert "2" in (embed.description or "")
+    assert "apply" in (embed.footer.text or "").lower()
+
+
+def test_dryrun_embed_nothing_to_do():
+    embed = build_backfill_dryrun_embed(_dryrun(writable=0))
+    assert "nothing to migrate" in (embed.description or "").lower()
+
+
+def test_apply_embed_success_vs_failure():
+    ok = build_backfill_apply_embed(_apply(failed=False))
+    assert "applied" in (ok.title or "").lower()
+    bad = build_backfill_apply_embed(_apply(failed=True))
+    assert "failed" in (bad.title or "").lower()
+    # the per-write error is surfaced
+    assert any("boom" in (f.value or "") for f in bad.fields)


### PR DESCRIPTION
## Completes the P0-3 pointer-lane migration (owner-approved)

This wires the already-built, fully-tested `services.binding_backfill` to an operator command so the migration can finally be **completed in production** — the root cause of the live `Startup health: degraded — attention: consistency` (Config arbitration falling back to legacy reads), per the convergence plan §8 finding.

### The command (admin-gated)
- **`!platform backfill`** — read-only **dry-run**: previews what would be written (classification counts + per-candidate lines).
- **`!platform backfill apply`** — writes the `candidate_valid` rows through the **audited** `apply_backfill` seam (`actor_type='backfill'`, per-guild, **idempotent** — already-bound rows are skipped, advisory-lock guarded; a lock-held run is reported, not crashed).

Running `apply` in each guild populates the `xp.announce_channel` / `economy.log_channel` binding rows, so the arbiter stops falling back and the consistency warning clears for good.

### Structure
- Orchestration (I/O + the service mutation) lives in a new `cogs/diagnostic/_backfill.py` — kept out of `diagnostic_cog.py` (at the 800-LOC ceiling) and out of `_platform_embeds.py` (pure renderers). The cog command is a thin wrapper; cog stays at 797 LOC.
- Two pure embed builders (`build_backfill_dryrun_embed` / `build_backfill_apply_embed`) added to `_platform_embeds.py`.

### Why this is in-scope during FIX phase
Owner-directed, and correctness-class: it completes an already-deployed-but-stuck migration and makes a built-and-tested-but-unreachable capability usable. It's the natural completion of arc PRs 2/3 (both DONE) and does **not** depend on the later families 3–5.

### What to test
In a guild showing the warning: `!platform backfill` (review the preview), then `!platform backfill apply`. Re-running is a no-op. Afterward `!platform consistency` should no longer flag Config arbitration fallback.

### The one risk
`apply` is a real (audited, idempotent, per-guild) write. The dry-run-by-default + explicit `apply` keyword is the safety gate; the existing `apply_backfill` advisory lock prevents concurrent runs.

### Tests
`tests/unit/runtime/test_platform_backfill_command.py` (+6): dry-run-default-never-mutates, apply-uses-actor-id, lock-held reporting, and both embed builders. `check_quality.py --full` green (9548); `check_architecture --mode strict` 0 errors. Plan §8 updated to mark option 1 shipped.

https://claude.ai/code/session_01MPHcterWHuDfT98cdYLHyj

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPHcterWHuDfT98cdYLHyj)_