### PR TITLE
Workflow-health review: verify autonomous loop live + document cron lag

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -218,9 +218,10 @@ is **per-file**. Full convention: `docs/owner/ai-project-workflow.md` §9.
   This is the automated-plus-judgment complement to the Q-0102 review; it exists because this
   exact question, asked once (2026-06-12), surfaced multiple drifted ledger entries. The
   `/session-close` skill runs the automated half.
-- **Reconciliation + planning pass at every 20th PR — required (owner directive Q-0107,
-  2026-06-12; cadence raised 10 → 20 same day — small PRs inflate the count, so every 10 fired
-  too often).** PR numbers crossing a **multiple of 20** (#20, #40, #60, …) are reserved for a
+- **Reconciliation + planning pass at every 30th PR — required (owner directive Q-0107,
+  2026-06-12; cadence raised 10 → 20 same day, then 20 → 30 on 2026-06-14 per Q-0134 — at burst
+  velocity a 20-band crossed in under a day and fired the docs pass several times daily).** PR
+  numbers crossing a **multiple of 30** (#30, #60, #90, …) are reserved for a
   **docs-only review + planning** pass — no runtime / `disbot/` code in it. It does two things:
   **(1) reconcile** — review the living ledger, active lanes, open Q-blocks, idea backlog, and
   roadmap; **disposition open PRs** (via the GitHub MCP — `list_pull_requests` + each one's

--- a/.sessions/2026-06-14-workflow-routine-audit.md
+++ b/.sessions/2026-06-14-workflow-routine-audit.md
@@ -1,17 +1,72 @@
 # Session: workflow-routine audit — tools, Hermes, routines, loop health
 
-> **Status:** `in-progress` — born-red merge gate (Q-0133). Flip to `complete` as the final step.
+> **Status:** `complete`
 
-**Branch:** `claude/modest-ptolemy-2xipoh` · **Date:** 2026-06-14 · **Type:** owner-directed review (manual)
+**Branch:** `claude/modest-ptolemy-2xipoh` · **PR:** #853 · **Date:** 2026-06-14 · **Type:** owner-directed review (manual)
 
-## What I'm about to do
-Owner-requested workflow-health review session. Verifying:
-1. Repo-navigation tools (CodeGraph, Grimp, ≥3 active) work + are correctly documented.
-2. Hermes integration state — what's wired vs pending; the "sensitive information" dispatch problem.
-3. Autonomous routines — why they fire at the wrong times (timezone? lag? not firing?).
-4. My opinion on the loop (20-PR reconciliation cadence — widen or keep?) + any unclear workflow points.
+## What this session did
 
-Doc fixes expected: correct verified drift in `docs/operations/autonomous-routines.md` control-plane
-state table (evidence-backed live verification), plus a GitHub-Actions-cron-lag note.
+Owner-requested workflow-health review. Verified the four pillars of the autonomous system, then
+acted on three owner decisions taken live.
 
-(Findings + close-out written here as the final step.)
+### Findings (verified by direct test + live GitHub)
+1. **Navigation tools — all 4 active & working:** `context_map.py` (Grimp import graph),
+   `wiring_map.py` (EventBus), `check_architecture.py`, CodeGraph MCP `where`/`query`. CodeGraph
+   `semantic_search` is non-functional (embeddings never built) but **honestly documented** as
+   needing an `embed` pre-run — not drift. Trust tiers held (`dead-unresolved` false-positive on
+   `apply_operations` confirmed).
+2. **Routines DO fire — the docs were wrong.** The control-plane table claimed `ROUTINE_PAT` was
+   unverified and the loop had never self-fired; live GitHub proved both false (the 06-14
+   scheduled-executor #819 and reconcile #822/#841 were auto-opened yet authored by `menno420`,
+   the PAT owner → ROUTINE_PAT is set; #819→#821→merged #825 ran unattended). Corrected the table.
+3. **Timing complaint = GitHub Actions cron lag, not timezone/config.** Same cron fired 01:20 UTC
+   one day, 06:04 the next (~4¾ h late); backups ~4 h late both days. Documented the caveat.
+4. **One routine genuinely broken:** `backup-db.yml` runs but fails daily — `DATABASE_PUBLIC_URL`
+   unset (daily backup-failure issues #823/#773). No working DB backups. Maintainer-side.
+5. **Hermes:** wired (VPS, 10 skills, dispatch tested) but `review-merge` still advisory; the
+   "sensitive information" dispatch balk diagnosed (see Q-0136).
+
+### Changes shipped (PR #853)
+- **Q-0134:** reconciliation cadence widened 20→30 (`STEP=30`; CLAUDE.md + current-state + routines
+  doc; next pass now #870). Workflow reads the script, so it propagates with no workflow edit.
+- **Q-0135:** `scripts/check_loop_health.py` — live-GitHub probe of the control-plane table
+  (ROUTINE_PAT author / open backup-failure / loop-self-fired), folded into the reconciliation
+  routine STEP 2 so the table can't silently drift again. +9 unit tests on the pure `classify` core.
+- **Q-0136:** Hermes dispatch prompt gained an AUTHORIZED clause (using the named secret env var in
+  the `/fire` curl is sanctioned, not a leak) + a diagnosis note. **Owner: re-paste into Hermes.**
+- Control-plane table rows 1+6 ticked with evidence; cron-lag caveat; misleading "03:00/05:00
+  local" cron references corrected to UTC.
+
+## My opinion on the loop (the owner asked)
+The core continue→executor→reconcile chain genuinely works and self-fires. The 20-PR cadence was
+too tight at burst velocity (widened to 30). Biggest real gap is **observability of the control
+plane** — its state was only a hand-ticked table that drifted; `check_loop_health.py` + the
+reconciliation-pass re-verification closes that. The cron lag is GitHub's, not ours; accept
+"overnight" or move to an external `workflow_dispatch` trigger (captured idea).
+
+## Still-open / handed to owner
+- DATABASE_PUBLIC_URL secret (backups inert), Railway `CLAUDE_ROUTINE_*` deploy, routine
+  model/prompt confirmation (control-plane table rows 2–5).
+- Re-paste the updated `dispatch.md` into Hermes; deeper Hermes sensitive-info dig deferred.
+
+## 💡 Session idea (Q-0089)
+`docs/ideas/external-cron-trigger-for-routines-2026-06-14.md` — drive the overnight cadence from an
+external scheduler hitting `workflow_dispatch` (VPS cron) instead of GitHub's best-effort
+`schedule:`, which fired ~4¾ h late this session. Keep `schedule:` as a backstop. Genuinely
+surfaced by the timing investigation.
+
+## ⟲ Previous-session review (Q-0102)
+Reviewing **#849 (born-red session merge-gate, Q-0133):** strong work — it fixed a real race and
+dogfooded the gate on its own PR. **What it missed / could improve:** the gate is
+*engage-when-present* — it only fires when a PR **adds** a session card. The autonomous routines
+(executor/reconciliation) don't reliably add a `.sessions/` card, so a **routine-authored PR can
+still merge a partial PR** — the exact #843 race the gate was built to stop, just on the path most
+likely to run unattended. **System improvement:** require the routine prompts to create a born-red
+session card as their first commit too (or tighten the gate so routine-authored PRs without a card
+are held). Captured here as the concrete next hardening of Q-0133; worth a follow-up before
+trusting the loop to merge big steps on its own.
+
+## Doc audit (Q-0104)
+`check_docs --strict` ✓ · `check_current_state_ledger --strict` ✓ · `check_architecture` 0 errors ·
+`check_quality --check-only` ✓ · loop-health + context_map tests ✓. New owner decisions Q-0134/0135/
+0136 recorded in the router; new docs reachable (ideas README updated).

--- a/.sessions/2026-06-14-workflow-routine-audit.md
+++ b/.sessions/2026-06-14-workflow-routine-audit.md
@@ -1,0 +1,17 @@
+# Session: workflow-routine audit — tools, Hermes, routines, loop health
+
+> **Status:** `in-progress` — born-red merge gate (Q-0133). Flip to `complete` as the final step.
+
+**Branch:** `claude/modest-ptolemy-2xipoh` · **Date:** 2026-06-14 · **Type:** owner-directed review (manual)
+
+## What I'm about to do
+Owner-requested workflow-health review session. Verifying:
+1. Repo-navigation tools (CodeGraph, Grimp, ≥3 active) work + are correctly documented.
+2. Hermes integration state — what's wired vs pending; the "sensitive information" dispatch problem.
+3. Autonomous routines — why they fire at the wrong times (timezone? lag? not firing?).
+4. My opinion on the loop (20-PR reconciliation cadence — widen or keep?) + any unclear workflow points.
+
+Doc fixes expected: correct verified drift in `docs/operations/autonomous-routines.md` control-plane
+state table (evidence-backed live verification), plus a GitHub-Actions-cron-lag note.
+
+(Findings + close-out written here as the final step.)

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -169,11 +169,11 @@ Source code and merged PRs win over anything written here.
 >
 > **Last reconciliation pass:** PR #840 (2026-06-14, sixth Q-0107 cadence pass —
 > [the pass record + decade queue](planning/reconciliation-pass-2026-06-14-band840.md)). The next
-> **docs-only review + planning reconciliation** is due once merged PRs cross #860 (every
-> multiple of **20** — Q-0107 cadence raised 10→20 on 2026-06-12; `check_reconciliation_due.py`
-> flags it, and `.github/workflows/reconciliation-trigger.yml` auto-opens a `reconcile` issue
-> at the boundary that fires the docs-reconciliation routine). Reset this marker to the latest
-> PR after a pass.
+> **docs-only review + planning reconciliation** is due once merged PRs cross #870 (every
+> multiple of **30** — Q-0107 cadence raised 10→20 on 2026-06-12, then 20→30 on 2026-06-14 per
+> Q-0134; `check_reconciliation_due.py` flags it, and `.github/workflows/reconciliation-trigger.yml`
+> auto-opens a `reconcile` issue at the boundary that fires the docs-reconciliation routine). Reset
+> this marker to the latest PR after a pass.
 
 - **#849 (2026-06-14, born-red session merge-gate — Q-0133)** — closed the auto-merge race
   that landed **#843** without its ledger entry (native auto-merge, Q-0123, fires the instant

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -27,6 +27,12 @@ Current broad captures:
   present-but-broken = FAIL. Surfaced because the owner's Railway access sat **silently inert** (a
   var-name mismatch + a Cloudflare UA block) until a routine happened to probe it by hand — this
   would have flagged both on the first session after provisioning. Small; one script + a hook line.
+- [`external-cron-trigger-for-routines-2026-06-14.md`](./external-cron-trigger-for-routines-2026-06-14.md) —
+  **workflow / ops (2026-06-14, workflow-health review):** drive the overnight cadence from an
+  external scheduler hitting `workflow_dispatch` (a VPS cron, a Worker) instead of GitHub's
+  best-effort `schedule:` cron — observed firing ~4¾ h late / occasionally dropped this session.
+  Converts "sometime in a ~5 h window" into "at the time I chose". Small; one cron line on the
+  already-live Hermes VPS, GitHub `schedule:` kept as a backstop.
 - [`routine-activity-visibility-2026-06-14.md`](./routine-activity-visibility-2026-06-14.md) —
   **workflow / UX (2026-06-14, owner-observed):** routine *run* sessions are hidden from the
   Recents tab (intentional upstream behavior; open FR

--- a/docs/ideas/external-cron-trigger-for-routines-2026-06-14.md
+++ b/docs/ideas/external-cron-trigger-for-routines-2026-06-14.md
@@ -1,0 +1,45 @@
+# Idea: drive the autonomous cron from an external scheduler (not GitHub `schedule:`)
+
+> **Status:** `ideas` — capture only, **not** a plan and **not** approval for
+> implementation. Source code and the binding contracts win over this file.
+
+**Captured:** 2026-06-14 · **Source:** the workflow-health review session (Q-0134/0135/0136) ·
+**Lane:** small / decided — implementable when on-time firing matters
+
+## The problem it solves
+
+The autonomous loop's overnight cadence (`executor-nightly.yml`, `backup-db.yml`) relies on
+GitHub Actions `schedule:` crons. GitHub's scheduler is **best-effort on low-activity repos** —
+observed this session: the executor cron (`17 1,3 * * *` = 01:17/03:17 UTC) fired on time on
+2026-06-13 (01:20) but **~4¾ h late** on 2026-06-14 (06:04); the backup cron (02:00 UTC) opened
+its failure issues at 06:15 and 06:39 UTC both days (~4 h late). The `:17`-minute offset reduces
+top-of-hour congestion but does **not** eliminate the multi-hour variance, and GitHub
+occasionally **drops** a scheduled run entirely. So "runs overnight" is true; "runs at 03:17" is
+not. If the owner ever wants the loop to fire at a predictable time (e.g. so the docs are fresh
+before he wakes), GitHub `schedule:` can't deliver it.
+
+## The idea
+
+Drive the cadence from an **external scheduler that calls `workflow_dispatch`** (which fires
+immediately and reliably) instead of GitHub's internal `schedule:`:
+
+- A tiny cron on the **Hermes VPS** (already live, already has `gh`/a token) runs
+  `gh workflow run executor-nightly.yml` at the wanted local time — Hermes is the natural home
+  for the control-plane's "heartbeat".
+- Or a Cloudflare Worker / any uptime-cron service hitting the Actions REST
+  `POST /actions/workflows/{id}/dispatches`.
+- Keep the GitHub `schedule:` as a *backstop* (so the loop still runs if the external scheduler
+  is down), but treat `workflow_dispatch` as the primary, on-time path.
+
+## Why it's worth having
+
+It converts "sometime in a ~5 h window, occasionally skipped" into "at the time I chose, every
+day". It also makes the firing **observable** (the external scheduler logs success/failure),
+which pairs with the new `check_loop_health.py` control-plane probe (Q-0135). Low effort — one
+cron line on a box that already exists.
+
+## Size / route
+
+Small. One scheduled command on the VPS + a doc note. Groom into a control-plane session when
+on-time firing becomes a felt need (today the lag is documented and accepted). Until then this
+stays captured, not built — the loop *works*, it's just not punctual.

--- a/docs/operations/autonomous-routines.md
+++ b/docs/operations/autonomous-routines.md
@@ -275,15 +275,27 @@ The routine treats the issue as the go-signal, runs the docs-only pass, and clos
 
 | # | Maintainer action | Why it matters | Source PR | Verified? |
 |---|---|---|---|---|
-| 1 | Add repo secret **`ROUTINE_PAT`** (fine-grained PAT, this repo, **Issues: read/write**) | **Hard blocker for the whole loop** — without it, cron/cadence trigger issues are authored by `github-actions[bot]`, which **does not start a Claude routine** (A/B-verified: real-user issue #776 fired in <1 min; bot's #768 never did) | #778 | ⬜ |
-| 2 | Add repo secret **`DATABASE_PUBLIC_URL`** (Railway Postgres public proxy URL) | the daily `backup-db.yml` `pg_dump` is inert without it (workflow fails + opens an issue) | #769 | ⬜ |
-| 3 | Railway → **Deploy** the staged `CLAUDE_ROUTINE_*` env vars | `/bugreport` + `/dispatch` (HermesCog #757) may be inactive until the worker redeploys with the vars live | #765 | ⬜ |
-| 4 | Confirm the **dispatch routine prompt** is the free-form version | the owner finished routine setup *before* the #761 free-form prompt was handed over — it may carry the older prompt | #761/#765 | ⬜ |
-| 5 | Confirm **routine models**: dispatch/executor = **Opus 4.8**, reconciliation = Sonnet/Opus (not **Fable 5**) | dispatch was last seen on Fable 5 (premium) → daily spend risk vs. the €30/mo Q-0082 cap | §11 / #765 | ⬜ |
-| 6 | After #1: **`workflow_dispatch` `executor-nightly.yml`** once | the **first real unattended executor run** (the Q-0105 "watch the first run" moment — still pending; the loop has never self-fired) | #778 | ⬜ |
+| 1 | Add repo secret **`ROUTINE_PAT`** (fine-grained PAT, this repo, **Issues: read/write**) | **Hard blocker for the whole loop** — without it, cron/cadence trigger issues are authored by `github-actions[bot]`, which **does not start a Claude routine** (A/B-verified: real-user issue #776 fired in <1 min; bot's #768 never did) | #778 | ✅ **2026-06-14** (live-evidence verify: the scheduled executor issue #819 and the cadence reconcile issues #822/#841 were auto-opened by the workflows yet authored by **`menno420`** — the PAT owner — not `github-actions[bot]`. With `GITHUB_TOKEN` they would be bot-authored. So `ROUTINE_PAT` is set and active.) |
+| 2 | Add repo secret **`DATABASE_PUBLIC_URL`** (Railway Postgres public proxy URL) | the daily `backup-db.yml` `pg_dump` is inert without it (workflow fails + opens an issue) | #769 | ⬜ **still unset** — `backup-db.yml` opens a "Postgres backup failed" issue every day (latest #823, 2026-06-14); the cron *fires* but the dump fails for lack of this secret. |
+| 3 | Railway → **Deploy** the staged `CLAUDE_ROUTINE_*` env vars | `/bugreport` + `/dispatch` (HermesCog #757) may be inactive until the worker redeploys with the vars live | #765 | ⬜ (not verifiable from the repo) |
+| 4 | Confirm the **dispatch routine prompt** is the free-form version | the owner finished routine setup *before* the #761 free-form prompt was handed over — it may carry the older prompt | #761/#765 | ⬜ (not verifiable from the repo) |
+| 5 | Confirm **routine models**: dispatch/executor = **Opus 4.8**, reconciliation = Sonnet/Opus (not **Fable 5**) | dispatch was last seen on Fable 5 (premium) → daily spend risk vs. the €30/mo Q-0082 cap | §11 / #765 | ⬜ (not verifiable from the repo) |
+| 6 | After #1: **`workflow_dispatch` `executor-nightly.yml`** once | the **first real unattended executor run** (the Q-0105 "watch the first run" moment) | #778 | ✅ **2026-06-14** — the loop **has now self-fired unattended**: scheduled executor issue #819 (auto-opened) ran on its own, opened the `continue` handoff #821, and that chain produced merged P0-4 work (#825). No manual `workflow_dispatch` was needed. |
 
-> Once #1 is done, the cron path self-serves (#6 is just to watch the first one promptly). The first
-> autonomous **reconciliation** fires when merged PRs cross **#780**.
+> Rows 1 + 6 are now verified live — the autonomous loop self-fires. Rows 2–5 remain maintainer-side
+> (row 2 is confirmed *still pending* by the daily backup-failure issues). The first autonomous
+> **reconciliation** has also fired (the band-#820/#840 cadence passes ran via #822/#841).
+>
+> **⏱️ Timing caveat — GitHub Actions cron lag (not a config bug).** GitHub's `schedule:` trigger is
+> best-effort and, on a low-activity repo, runs are frequently **hours late or occasionally dropped**.
+> Observed here: the executor cron (`17 1,3 * * *` = 01:17/03:17 UTC) fired at **01:20 UTC on
+> 2026-06-13** (on time) but at **06:04 UTC on 2026-06-14** (~4¾ h late); the `backup-db.yml` cron
+> (`0 2 * * *` = 02:00 UTC) opened its failure issue at **06:15 UTC (06-13)** and **06:39 UTC
+> (06-14)** — both ~4 h late. The `:17`-minute offset reduces top-of-hour congestion but does **not**
+> eliminate the multi-hour variance. The timezone is correct (crons are always UTC, documented in
+> `executor-nightly.yml`); the lag is GitHub's scheduler. If on-time firing ever matters, drive the
+> cadence from an external scheduler that calls `workflow_dispatch` (or accept the loop is
+> "sometime overnight", not "at 03:17").
 
 ## See also
 

--- a/docs/operations/autonomous-routines.md
+++ b/docs/operations/autonomous-routines.md
@@ -26,8 +26,8 @@ session N leaves session N+1 better-equipped.
 | Routine | Trigger | Job | Class / merge |
 |---|---|---|---|
 | **superbot autonomous dispatch** | API (`/fire`) | General work orders from Hermes/phone (`superbot-dispatch`). Classifies by `CLASS:`. | per work order (Q-0113/Q-0114) |
-| **superbot docs reconciliation** | **Issue** labeled `reconcile` | The Q-0107 every-20th-PR docs-only pass: reconcile the ledger, de-stale docs, plan the next ~9 PRs, contribute one idea. | `docs` → self-merge on green |
-| **superbot night executor** | Issue `continue` (cron-driven 03:00/05:00 + handoffs) | Advance the **next big step of the plan** (a "continue from last session" run); self-chain via `continue` issues when a step spans runs; fall back to a quality win. Phase-gated against features. | small → self-merge; **big step → Hermes reviews + merges** (Q-0117) |
+| **superbot docs reconciliation** | **Issue** labeled `reconcile` | The Q-0107 every-30th-PR docs-only pass: reconcile the ledger, de-stale docs, plan the next band, contribute one idea. | `docs` → self-merge on green |
+| **superbot night executor** | Issue `continue` (cron-driven 01:17/03:17 UTC + handoffs) | Advance the **next big step of the plan** (a "continue from last session" run); self-chain via `continue` issues when a step spans runs; fall back to a quality win. Phase-gated against features. | small → self-merge; **big step → Hermes reviews + merges** (Q-0117) |
 
 **Why an issue-trigger (not a schedule, not a per-PR trigger) for reconciliation:** the docs
 pass should run **promptly when due — daytime included** — so the docs + fresh plan are ready
@@ -37,8 +37,9 @@ to exit), burning the daily run cap. The clean middle: **the issue *is* the trig
 two ways —
 1. **Automatically** by `.github/workflows/reconciliation-trigger.yml`: on every push to `main`
    it runs `scripts/check_reconciliation_due.py --strict` and, when merged PRs cross a
-   **multiple-of-20** band (Q-0107, raised from 10 on 2026-06-12 — small PRs inflate the
-   count), opens a deduped issue labeled `reconcile`.
+   **multiple-of-30** band (Q-0107, raised 10→20 on 2026-06-12, then 20→30 on 2026-06-14 per
+   Q-0134 — small PRs inflate the count and a 20-band crossed in under a day at burst
+   velocity), opens a deduped issue labeled `reconcile`.
 2. **By judgment** — *any agent or the maintainer* opens a `reconcile`-labeled issue the moment
    they spot docs needing reordering, even off-cycle. The routine treats the issue's existence
    as the go-signal (it does not re-gate on the cadence), does the pass, and closes the issue.
@@ -75,7 +76,7 @@ issue) and watch. They can both touch `main`; the docs routine UNION-resolves as
 ## Routine: superbot docs reconciliation
 
 - **Trigger:** GitHub → **Issue opened**, filtered to **label is one of `reconcile`**.
-  (The `reconcile` issue is opened by the Action above on the 20-PR boundary, or by hand when
+  (The `reconcile` issue is opened by the Action above on the 30-PR boundary, or by hand when
   an agent spots drift.)
 - **Repository:** `menno420/superbot`. **Model:** Sonnet or Opus (docs work — the volume tier
   is fine; §11). **Permissions:** unrestricted branch push **OFF**. **Behavior:** auto-fix PRs ON.
@@ -112,8 +113,15 @@ STEP 2 — RECONCILE (the Q-0107 pass):
     (a `check_docs` reachability orphan is usually one missing README link), leave the owner's.
     "Noting" a PR is not disposition — act on it. (This sweep was missing: #766 sat red + #771
     redundant for ~21h, unnoticed by sessions and two prior passes.)
-  - Plan the next ~9 PRs (the upcoming band) — modular, each a meaningful slice — into the
-    decade-queue planning doc, ordered so the highest-value improvements come first.
+  - CONTROL-PLANE (Q-0135): run `python3.10 scripts/check_loop_health.py` (reads live GitHub via
+    `gh`) and reconcile the § Control-plane state table against its PASS/FAIL/SKIP verdicts —
+    tick/untick the verifiable rows (ROUTINE_PAT, DATABASE_PUBLIC_URL, loop-self-fired) so the
+    table can't silently drift the way it did before 2026-06-14 (it claimed the loop had never
+    self-fired when live GitHub already proved it had). If `gh` is unavailable, do the same read
+    via the GitHub MCP (`list_issues`): the *author* of the newest auto-opened trigger issue is
+    the live read of ROUTINE_PAT (a real-user login = set; `github-actions[bot]` = unset).
+  - Plan the next band of PRs (the upcoming ~30) — modular, each a meaningful slice — into the
+    band planning doc, ordered so the highest-value improvements come first.
   - IMPROVE THE SYSTEM: if you see a way to make the orientation / memory / tooling better for
     the next run (a confusing doc, a missing pointer, a guard that would have caught this drift),
     make that improvement too. This is the point of the loop.
@@ -149,7 +157,8 @@ Its primary job is to **advance the next big step of the plan** (not just small 
 
 - **Triggers:** **GitHub → Issue opened, label `continue`** — and that's all it needs. The
   overnight cadence is driven by `.github/workflows/executor-nightly.yml` (a cron that opens a
-  scheduled `continue` issue at 03:00 and 05:00 local), because the console Schedule trigger was
+  scheduled `continue` issue at 01:17 and 03:17 UTC — though GitHub's scheduler often runs it
+  hours late; see the timing caveat under Control-plane state), because the console Schedule trigger was
   unreliable in the research-preview UI. The same `continue` trigger also picks up real
   continuation handoffs. (No API trigger / no token — on-demand work goes through dispatch.)
 - **Repository:** `menno420/superbot`. **Model:** Opus 4.8 (the execution tier; §11).
@@ -227,7 +236,7 @@ STEP 5 — SHIP (merge gate, Q-0117):
 
 | Label | Opened by | Fires | Effect |
 |---|---|---|---|
-| `reconcile` | the cadence Action (every 20-PR band) **or** any agent/maintainer who spots docs drift | docs reconciliation routine | the Q-0107 docs-only pass; routine closes the issue |
+| `reconcile` | the cadence Action (every 30-PR band) **or** any agent/maintainer who spots docs drift | docs reconciliation routine | the Q-0107 docs-only pass; routine closes the issue |
 | `continue` | the **executor** when it hands off a partly-done plan step (or a maintainer) | the executor | resume the explicit handoff in the issue body; chain again if still unfinished |
 | `needs-hermes-review` | the **executor** on a substantial plan-step PR | (a PR label, not an issue) — **Hermes** `superbot-review-merge` | Hermes reviews the diff and **merges if sound**, else requests changes (Q-0117) |
 
@@ -238,7 +247,7 @@ Claude's big steps and `main`.
 ## The `reconcile` issue — how to fire the docs pass by hand
 
 The docs-reconciliation routine triggers on a GitHub **issue labeled `reconcile`**. Beyond the
-automatic Action (every 20-PR band), **any agent or the maintainer should open one whenever the
+automatic Action (every 30-PR band), **any agent or the maintainer should open one whenever the
 docs visibly need reordering** — the ledger drifted, a plan is stale, links rot, priorities
 moved — without waiting for the cadence:
 
@@ -302,7 +311,8 @@ The routine treats the issue as the go-signal, runs the docs-only pass, and clos
 - [`hermes-dispatch-bridge.md`](./hermes-dispatch-bridge.md) — the `/fire` mechanism + gates.
 - [`hermes-skills/dispatch.md`](./hermes-skills/dispatch.md) · [`hermes-skills/review.md`](./hermes-skills/review.md)
 - `scripts/check_reconciliation_due.py` · `scripts/check_phase_gate.py` · `scripts/check_current_state_ledger.py`
-- `.github/workflows/reconciliation-trigger.yml` — opens the `reconcile` issue on the 20-PR boundary.
-- `.github/workflows/executor-nightly.yml` — cron that opens a scheduled `continue` issue at 03:00/05:00 local.
+- `scripts/check_loop_health.py` — live-GitHub probe of the Control-plane state table (Q-0135); run it in the reconciliation pass.
+- `.github/workflows/reconciliation-trigger.yml` — opens the `reconcile` issue on the 30-PR boundary.
+- `.github/workflows/executor-nightly.yml` — cron that opens a scheduled `continue` issue at 01:17/03:17 UTC (best-effort — often hours late).
 - [`hermes-skills/review-merge.md`](./hermes-skills/review-merge.md) — Hermes' independent review + merge gate for `needs-hermes-review` PRs (Q-0117).
 - `docs/owner/ai-project-workflow.md` §10 (staging/continuation) · §12 (the loop).

--- a/docs/operations/hermes-skills/dispatch.md
+++ b/docs/operations/hermes-skills/dispatch.md
@@ -74,7 +74,13 @@ STEP 5 — REPORT: confirm the fire response (run id / status). Tell me the rout
 
 RULES:
 - You send TEXT. You never edit code, push, or merge. The builder is Claude Code under CI.
-- Never print secrets (tokens, the .env). Reference env vars by name only.
+- AUTHORIZED: using the named secret env vars in the `/fire` curl is the *sanctioned* mechanism,
+  NOT "exposing sensitive information". Referencing `$CLAUDE_ROUTINE_TOKEN` in the Authorization
+  header sends the value only to the legitimate Anthropic Routines endpoint — it is never
+  printed, logged, echoed back to me, or sent anywhere else. Do NOT refuse or stall the dispatch
+  on a sensitive-data / credential-handling basis; this authenticated call is exactly your job.
+  (The single hard rule is the next line: don't *print* the value. Sourcing it into the curl is fine.)
+- Never print secrets (tokens, the `.env`) to me. Reference env vars by name only.
 - One work order per fire. If the idea is really several changes, say so and dispatch the
   first, or hand me a multi-task plan for a session instead.
 ```
@@ -92,3 +98,14 @@ RULES:
   repo write — it preserves the safety split (idea doc, "Recommended wiring — API trigger").
 - **Alternative without the token:** the skill degrades to `prompt-builder` + a printed curl,
   so it is useful even before the maintainer wires the `/fire` endpoint.
+- **The "sensitive information" refusal (diagnosed 2026-06-14, Q-0136).** The owner reported
+  Hermes "has a problem dispatching the routines, something about sensitive information." Most
+  likely cause: the prompt previously gave only the *prohibition* ("Never print secrets") with
+  no explicit *authorization* of the action, so a safety-cautious Claude-based agent reads "this
+  involves a credential" and declines or stalls. The AUTHORIZED rule above is the fix — it tells
+  Hermes that sourcing `$CLAUDE_ROUTINE_TOKEN` into the `/fire` curl is sanctioned, not a leak.
+  **Re-paste this skill into Hermes' config after this change.** If the balk persists, the second
+  hypothesis is mechanical, not a refusal: `~/.hermes/routine.env` isn't loading (missing, wrong
+  perms) or `CLAUDE_ROUTINE_TOKEN` is expired — Hermes then *correctly* won't fire (STEP 4). Check
+  on the VPS: `test -r ~/.hermes/routine.env && echo readable`, and that the four `CLAUDE_ROUTINE_*`
+  vars source non-empty (`set -a; . ~/.hermes/routine.env; set +a; : "${CLAUDE_ROUTINE_TOKEN:?unset}"`).

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -5087,3 +5087,75 @@ are deletable if the gate ever holds a PR it shouldn't.
 **Home:** `.claude/CLAUDE.md` § Session & plan workflow (the rule); `scripts/check_session_gate.py`
 + `.github/workflows/code-quality.yml` (the gate); `.claude/skills/session-close/SKILL.md` (the
 flip-ready step). Shipped this session (born-red dogfooded on its own PR).
+
+---
+
+### Q-0134 — Reconciliation cadence widened 20 → 30 PRs (2026-06-14)
+
+> **DECISION 2026-06-14 (owner-directed in-session — the live reviewer for this workflow change,
+> per the Q-0106 in-session exception).** Asked during the workflow-health review session.
+
+**Problem.** The Q-0107 docs-reconciliation cadence fired on every **multiple-of-20** PR band.
+At the project's burst velocity a 20-band crossed in **under a day** (#800→#820→#840 all on
+2026-06-13/14), so the docs-only pass fired **several times per day** — re-scoring a band that
+had barely moved and spending a cloud session each time. The owner had already raised it 10→20
+(2026-06-12) for the same reason; the symptom returned.
+
+**Decision.** Widen the band to **30** (`STEP = 30` in `scripts/check_reconciliation_due.py`).
+Considered a time-floor hybrid (≥N PRs AND ≥M hours) but the owner chose the simpler one-number
+change. Retune the constant if it drifts again. With the marker at #840 the next pass is due at
+**#870** (was #860).
+
+**Home:** `scripts/check_reconciliation_due.py` (`STEP`); `.claude/CLAUDE.md` § Session & plan
+workflow (the rule); `docs/current-state.md` marker note; `docs/operations/autonomous-routines.md`.
+The `reconciliation-trigger.yml` workflow reads the script, so the change propagates with no
+workflow edit.
+
+---
+
+### Q-0135 — Loop-health probe: re-verify the control-plane state from live GitHub (2026-06-14)
+
+> **DECISION 2026-06-14 (owner-directed in-session).** Asked in the same review session.
+
+**Problem.** The autonomous loop's wiring (ROUTINE_PAT, backups, whether it has self-fired) lived
+only in a hand-ticked table in `autonomous-routines.md` § Control-plane state, which no repo
+checker can see — and it **drifted**: it marked `ROUTINE_PAT` unverified and the loop "never
+self-fired" when live GitHub already proved both true (the trigger issues were authored by the
+PAT owner, and #819→#821→#825 had run unattended).
+
+**Decision.** Add `scripts/check_loop_health.py` — a stdlib, `gh`-backed, read-only probe that
+re-derives the verifiable rows from recent issues (trigger-issue author = ROUTINE_PAT state;
+open backup-failure issue = DATABASE_PUBLIC_URL unset; closed scheduled-executor issue = loop
+self-fired) and prints PASS/FAIL/SKIP. Degrades to SKIP where `gh` is absent (never reddens a
+session). Folded into the **reconciliation routine** STEP 2 (not a new fleet routine — no extra
+run-cap cost) so the table is re-checked every pass. Pure `classify` core unit-tested (+9 tests).
+Reliability (Q-0105): unverified — delete if its heuristics misclassify over multiple sessions.
+The repo-side sibling — an env-credential preflight at SessionStart — stays the captured idea
+`docs/ideas/agent-env-credential-smoke-check-2026-06-14.md`.
+
+**Home:** `scripts/check_loop_health.py`; `tests/unit/scripts/test_check_loop_health.py`;
+`docs/operations/autonomous-routines.md` (STEP 2 + See also).
+
+---
+
+### Q-0136 — Hermes dispatch: authorize secret-env use (the "sensitive information" balk) (2026-06-14)
+
+> **DECISION 2026-06-14 (owner-directed in-session).** The owner reported Hermes "has a problem
+> dispatching the routines, something about sensitive information"; asked me to diagnose.
+
+**Diagnosis.** The `superbot-dispatch` skill prompt gave Hermes only a *prohibition* — "Never
+print secrets … reference env vars by name only" — with no explicit *authorization* of the
+action it must take (sourcing `$CLAUDE_ROUTINE_TOKEN` into the `/fire` curl). A safety-cautious
+Claude-based agent reads "this involves a credential" and declines/stalls. Most likely the whole
+cause; the only other candidate is mechanical (`~/.hermes/routine.env` not loading / token
+expired → a *correct* refusal per STEP 4).
+
+**Decision.** Add an AUTHORIZED rule to the dispatch prompt: using the named secret env vars in
+the authenticated `/fire` call is sanctioned, not a leak (the value goes only to the Anthropic
+endpoint, never printed/logged/echoed) — do not refuse on a sensitive-data basis. Documented the
+diagnosis + both hypotheses + the VPS env-file check in the skill's Notes. **Owner action:**
+re-paste the updated skill into Hermes' config; if the balk persists, check the env file on the
+VPS. Deferred deeper investigation (owner: "we'll come back to that later") — this is the
+first-pass fix.
+
+**Home:** `docs/operations/hermes-skills/dispatch.md` (the AUTHORIZED rule + Notes diagnosis).

--- a/scripts/check_loop_health.py
+++ b/scripts/check_loop_health.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3.10
+"""Loop-health probe — verify the autonomous control-plane against live GitHub.
+
+The autonomous loop spans the repo **and** a GitHub/Railway/console control plane.
+The repo-side `check_*` scripts can't see the control-plane half, so its state lived
+only in a hand-maintained table in `docs/operations/autonomous-routines.md` § Control-plane
+state — and that table **drifted**: it claimed `ROUTINE_PAT` was unverified and the loop had
+never self-fired, when live GitHub already proved both true (2026-06-14 review). This probe
+closes that gap: it reads recent issues via the `gh` CLI and re-derives the verifiable rows,
+so a session (or the reconciliation routine) can spot regressions instead of trusting a stale
+tick-box.
+
+What it can verify from GitHub alone:
+- **ROUTINE_PAT live?** — the workflows auto-open the scheduled-executor / `reconcile` trigger
+  issues; if `ROUTINE_PAT` is set they are authored by the PAT owner (a real user login), and
+  if it is unset they fall back to `github-actions[bot]`, which does NOT start a Claude routine.
+  So the *author* of the newest auto-opened trigger issue is a live read of the secret's state.
+- **DATABASE_PUBLIC_URL set?** — `backup-db.yml` opens a "Postgres backup failed" issue when the
+  secret is missing; an OPEN one means backups are inert right now.
+- **Loop self-fired?** — a closed "Scheduled executor run" issue is evidence the unattended cron
+  path ran end-to-end.
+
+What it canNOT see (stays maintainer-verified in the table): Railway env-var deploys, routine
+model/prompt config in the console. Those rows are out of scope by design.
+
+Reliability (Q-0105): **unverified — added 2026-06-14 (Q-0135).** Confirm its verdicts against
+the real GitHub state a few times before trusting it; if its heuristics misclassify over
+multiple sessions, **delete it** — it is a convenience drift-guard, not load-bearing. Degrades
+to SKIP (exit 0) wherever `gh` is unavailable or unauthenticated, so it never reddens a session.
+
+Usage:
+    python3.10 scripts/check_loop_health.py            # advisory, human-readable
+    python3.10 scripts/check_loop_health.py --json      # machine-readable verdicts
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+REPO = "menno420/superbot"
+
+# Title prefixes the trigger workflows use (executor-nightly.yml / reconciliation-trigger.yml).
+_EXECUTOR_PREFIX = "Scheduled executor run"
+_RECONCILE_TITLE = "Docs reconciliation due"
+_BACKUP_PREFIX = "Postgres backup failed"
+
+# A bot login here means ROUTINE_PAT was NOT used (GITHUB_TOKEN fallback) → routine won't fire.
+_BOT_LOGINS = {"github-actions", "github-actions[bot]"}
+
+
+def classify(issues: list[dict]) -> list[tuple[str, str, str]]:
+    """Pure core: derive (check, status, detail) verdicts from a list of issues.
+
+    Each issue dict: {number, title, author_login, state, created_at}. ``issues`` is assumed
+    newest-first (the order ``gh issue list`` returns). status ∈ {PASS, WARN, FAIL, SKIP}.
+    """
+    verdicts: list[tuple[str, str, str]] = []
+
+    # --- ROUTINE_PAT (the hard blocker) -------------------------------------------------
+    trigger = next(
+        (
+            i
+            for i in issues
+            if i["title"].startswith(_EXECUTOR_PREFIX)
+            or i["title"].startswith(_RECONCILE_TITLE)
+        ),
+        None,
+    )
+    if trigger is None:
+        verdicts.append(
+            (
+                "ROUTINE_PAT",
+                "SKIP",
+                "no auto-opened trigger issue in recent history to read",
+            ),
+        )
+    elif trigger["author_login"] in _BOT_LOGINS:
+        verdicts.append(
+            (
+                "ROUTINE_PAT",
+                "FAIL",
+                f"trigger issue #{trigger['number']} is authored by "
+                f"`{trigger['author_login']}` — ROUTINE_PAT looks UNSET, so the routine will "
+                f"not fire. Add the fine-grained PAT (Issues: read/write).",
+            ),
+        )
+    else:
+        verdicts.append(
+            (
+                "ROUTINE_PAT",
+                "PASS",
+                f"trigger issue #{trigger['number']} authored by `{trigger['author_login']}` "
+                f"(not a bot) — ROUTINE_PAT is set and the loop can self-fire.",
+            ),
+        )
+
+    # --- DATABASE_PUBLIC_URL (backups) --------------------------------------------------
+    open_backup = next(
+        (
+            i
+            for i in issues
+            if i["title"].startswith(_BACKUP_PREFIX) and i["state"].upper() == "OPEN"
+        ),
+        None,
+    )
+    if open_backup is not None:
+        verdicts.append(
+            (
+                "DATABASE_PUBLIC_URL",
+                "FAIL",
+                f"open backup-failure issue #{open_backup['number']} — the daily pg_dump is "
+                f"inert; DATABASE_PUBLIC_URL is likely unset/stale. No working DB backups.",
+            ),
+        )
+    else:
+        verdicts.append(
+            (
+                "DATABASE_PUBLIC_URL",
+                "PASS",
+                "no open backup-failure issue — backups are not currently erroring.",
+            ),
+        )
+
+    # --- Loop self-fired (informational) ------------------------------------------------
+    fired = next((i for i in issues if i["title"].startswith(_EXECUTOR_PREFIX)), None)
+    if fired is not None:
+        verdicts.append(
+            (
+                "loop-self-fired",
+                "PASS",
+                f"scheduled executor issue #{fired['number']} exists — the unattended cron "
+                f"path has run.",
+            ),
+        )
+    else:
+        verdicts.append(
+            (
+                "loop-self-fired",
+                "SKIP",
+                "no scheduled-executor issue seen in recent history",
+            ),
+        )
+
+    return verdicts
+
+
+def _gh_issues(limit: int = 40) -> list[dict] | None:
+    """Fetch recent issues via `gh`. Returns None (→ SKIP) if gh is unavailable/unauth'd."""
+    try:
+        proc = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                REPO,
+                "--state",
+                "all",
+                "--limit",
+                str(limit),
+                "--json",
+                "number,title,author,state,createdAt",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    try:
+        raw = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+    return [
+        {
+            "number": i.get("number"),
+            "title": i.get("title", ""),
+            "author_login": (i.get("author") or {}).get("login", ""),
+            "state": i.get("state", ""),
+            "created_at": i.get("createdAt", ""),
+        }
+        for i in raw
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args()
+
+    issues = _gh_issues()
+    if issues is None:
+        msg = "check_loop_health: SKIP — `gh` unavailable or unauthenticated (control-plane not probed)."
+        if args.json:
+            print(
+                json.dumps(
+                    {"status": "SKIP", "reason": "gh unavailable", "verdicts": []},
+                ),
+            )
+        else:
+            print(msg)
+        return 0
+
+    verdicts = classify(issues)
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "verdicts": [
+                        {"check": c, "status": s, "detail": d} for c, s, d in verdicts
+                    ],
+                },
+            ),
+        )
+    else:
+        print("Loop-health probe (control-plane state, live from GitHub):")
+        for check, status, detail in verdicts:
+            print(f"  [{status:>4}] {check}: {detail}")
+        print(
+            "\n(Advisory only — exit 0. FAIL rows are real but maintainer-side; see "
+            "docs/operations/autonomous-routines.md § Control-plane state.)",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_reconciliation_due.py
+++ b/scripts/check_reconciliation_due.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3.10
 """Reconciliation-cadence guard — flag when a docs-only review/planning pass is due.
 
-Owner directive Q-0107: PR numbers crossing a **multiple of 20** (#20, #40, #60, …) are
+Owner directive Q-0107: PR numbers crossing a **multiple of 30** (#30, #60, #90, …) are
 reserved for a **docs-only repo review + planning-reconciliation** pass — review the state
 of the repo (ledger, active lanes, open Q-blocks, idea backlog, roadmap), prune stale docs,
 and refocus the next priorities. This guard tracks the cadence against the
 ``Last reconciliation pass:** PR #N`` marker in ``docs/current-state.md``: a pass is **due**
-once merged PRs have crossed into a new multiple-of-20 band since the last marked pass.
-(Cadence raised 10 → 20 on 2026-06-12, owner-directed: small PRs inflate the count, so every
-10 fired too often; the band size is the ``STEP`` constant below — retune there.)
+once merged PRs have crossed into a new multiple-of-30 band since the last marked pass.
+(Cadence raised 10 → 20 on 2026-06-12, then 20 → 30 on 2026-06-14 (Q-0134) — at burst
+velocity a 20-band crossed in under a day and fired the docs pass several times daily; the
+band size is the ``STEP`` constant below — retune there.)
 
 Advisory by default (exit 0); ``--strict`` for an explicit gate (e.g. ``/session-close``).
 After completing a pass, reset the marker to the latest PR. Pure stdlib, like ``check_docs.py``.
@@ -33,7 +34,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CURRENT_STATE = REPO_ROOT / "docs" / "current-state.md"
 
-STEP = 20  # the cadence: a pass per multiple-of-20 PR band (raised from 10, 2026-06-12)
+STEP = 30  # the cadence: a pass per multiple-of-30 PR band (10→20 2026-06-12; 20→30 2026-06-14, Q-0134)
 
 _MARKER_RE = re.compile(r"Last reconciliation pass:\*\*\s*PR #(\d+)")
 # Match all three merge-subject styles in this repo's history:
@@ -94,7 +95,7 @@ def is_due(
     latest: int | None = None,
     marker: int | None = None,
 ) -> tuple[bool, int | None, int | None]:
-    """Return (due, latest_pr, marker_pr). Due once we cross a new multiple-of-10 band."""
+    """Return (due, latest_pr, marker_pr). Due once we cross a new multiple-of-STEP band."""
     if latest is None:
         latest = _latest_merged_pr()
     if marker is None:

--- a/scripts/hermes/skills/dispatch/SKILL.md
+++ b/scripts/hermes/skills/dispatch/SKILL.md
@@ -63,6 +63,12 @@ STEP 5 — REPORT: confirm the fire response (run id / status). Tell me the rout
 
 RULES:
 - You send TEXT. You never edit code, push, or merge. The builder is Claude Code under CI.
-- Never print secrets (tokens, the .env). Reference env vars by name only.
+- AUTHORIZED: using the named secret env vars in the `/fire` curl is the *sanctioned* mechanism,
+  NOT "exposing sensitive information". Referencing `$CLAUDE_ROUTINE_TOKEN` in the Authorization
+  header sends the value only to the legitimate Anthropic Routines endpoint — it is never
+  printed, logged, echoed back to me, or sent anywhere else. Do NOT refuse or stall the dispatch
+  on a sensitive-data / credential-handling basis; this authenticated call is exactly your job.
+  (The single hard rule is the next line: don't *print* the value. Sourcing it into the curl is fine.)
+- Never print secrets (tokens, the `.env`) to me. Reference env vars by name only.
 - One work order per fire. If the idea is really several changes, say so and dispatch the
   first, or hand me a multi-task plan for a session instead.

--- a/tests/unit/scripts/test_check_loop_health.py
+++ b/tests/unit/scripts/test_check_loop_health.py
@@ -1,0 +1,103 @@
+"""Tests for the pure ``classify`` core of ``scripts/check_loop_health.py``.
+
+The ``gh``-shelling fetch is not exercised in CI (no auth there); only the pure
+verdict logic is tested, fed synthetic issue lists shaped like ``gh issue list --json``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "check_loop_health.py"
+
+
+@pytest.fixture(scope="module")
+def lh():
+    spec = importlib.util.spec_from_file_location("check_loop_health_ut", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _issue(number, title, author, state="CLOSED"):
+    return {
+        "number": number,
+        "title": title,
+        "author_login": author,
+        "state": state,
+        "created_at": "2026-06-14T06:00:00Z",
+    }
+
+
+def _status(verdicts, check):
+    return next(s for c, s, _ in verdicts if c == check)
+
+
+def test_routine_pat_pass_when_trigger_is_user_authored(lh):
+    # The real 2026-06-14 signal: an auto-opened scheduled run authored by the PAT owner.
+    issues = [_issue(819, "Scheduled executor run (2026-06-14 06:04 UTC)", "menno420")]
+    assert _status(lh.classify(issues), "ROUTINE_PAT") == "PASS"
+
+
+def test_routine_pat_fail_when_trigger_is_bot_authored(lh):
+    issues = [
+        _issue(
+            768, "Scheduled executor run (2026-06-13 01:20 UTC)", "github-actions[bot]",
+        ),
+    ]
+    assert _status(lh.classify(issues), "ROUTINE_PAT") == "FAIL"
+
+
+def test_routine_pat_bare_bot_login_also_fails(lh):
+    issues = [_issue(781, "Docs reconciliation due (Q-0107)", "github-actions")]
+    assert _status(lh.classify(issues), "ROUTINE_PAT") == "FAIL"
+
+
+def test_routine_pat_skip_when_no_trigger_issue(lh):
+    issues = [_issue(1, "Some unrelated issue", "menno420")]
+    assert _status(lh.classify(issues), "ROUTINE_PAT") == "SKIP"
+
+
+def test_routine_pat_reads_newest_trigger_first(lh):
+    # Newest-first: a recent user-authored trigger wins over an older bot one.
+    issues = [
+        _issue(841, "Docs reconciliation due (Q-0107)", "menno420"),
+        _issue(781, "Docs reconciliation due (Q-0107)", "github-actions"),
+    ]
+    assert _status(lh.classify(issues), "ROUTINE_PAT") == "PASS"
+
+
+def test_backup_fail_when_open_backup_issue_present(lh):
+    issues = [
+        _issue(
+            823, "Postgres backup failed (2026-06-14)", "github-actions", state="OPEN",
+        ),
+    ]
+    assert _status(lh.classify(issues), "DATABASE_PUBLIC_URL") == "FAIL"
+
+
+def test_backup_pass_when_backup_issue_closed(lh):
+    issues = [
+        _issue(
+            773, "Postgres backup failed (2026-06-13)", "github-actions", state="CLOSED",
+        ),
+    ]
+    assert _status(lh.classify(issues), "DATABASE_PUBLIC_URL") == "PASS"
+
+
+def test_loop_self_fired_pass_on_scheduled_issue(lh):
+    issues = [_issue(819, "Scheduled executor run (2026-06-14 06:04 UTC)", "menno420")]
+    assert _status(lh.classify(issues), "loop-self-fired") == "PASS"
+
+
+def test_all_three_checks_always_present(lh):
+    verdicts = lh.classify([])
+    checks = {c for c, _, _ in verdicts}
+    assert checks == {"ROUTINE_PAT", "DATABASE_PUBLIC_URL", "loop-self-fired"}

--- a/tests/unit/scripts/test_check_reconciliation_due.py
+++ b/tests/unit/scripts/test_check_reconciliation_due.py
@@ -17,29 +17,29 @@ _spec.loader.exec_module(crd)
 
 
 def test_not_due_same_band() -> None:
-    # STEP=20: marker #737 (band 36), latest #739 (band 36) → not due
+    # STEP=30: marker #737 (band 24: 720–749), latest #739 (band 24) → not due
     due, latest, marker = crd.is_due(latest=739, marker=737)
     assert due is False
     assert (latest, marker) == (739, 737)
 
 
 def test_due_when_crossing_band() -> None:
-    # STEP=20: marker #737 (band 36), latest #740 (band 37) → due
-    due, _, _ = crd.is_due(latest=740, marker=737)
+    # STEP=30: marker #737 (band 24: 720–749), latest #750 (band 25) → due
+    due, _, _ = crd.is_due(latest=750, marker=737)
     assert due is True
 
 
 def test_due_when_crossing_multiple_bands() -> None:
-    # STEP=20: marker #737 (band 36), latest #780 (band 39) → due
-    due, _, _ = crd.is_due(latest=780, marker=737)
+    # STEP=30: marker #737 (band 24), latest #810 (band 27) → due
+    due, _, _ = crd.is_due(latest=810, marker=737)
     assert due is True
 
 
 def test_exactly_on_band_boundary_marker() -> None:
-    # STEP=20: last pass landed on #740 (band 37); latest #759 still band 37 → not due
-    assert crd.is_due(latest=759, marker=740)[0] is False
-    # latest #760 → new band (38) → due
-    assert crd.is_due(latest=760, marker=740)[0] is True
+    # STEP=30: last pass landed on #750 (band boundary); latest #779 still band 25 → not due
+    assert crd.is_due(latest=779, marker=750)[0] is False
+    # latest #780 → new band (26) → due
+    assert crd.is_due(latest=780, marker=750)[0] is True
 
 
 def test_no_marker_is_not_due(monkeypatch) -> None:


### PR DESCRIPTION
Owner-directed workflow-health review session. Verified the four pillars of the autonomous system against live GitHub + by running the tools, then acted on three decisions taken live.

## Verified
- **Navigation tools** — all 4 active and working: `context_map.py` (Grimp), `wiring_map.py` (EventBus), `check_architecture.py`, CodeGraph `where`/`query`. CodeGraph `semantic_search` is non-functional (embeddings never built) but honestly documented — no drift.
- **Routines DO fire** — the control-plane doc was wrong: live GitHub proves `ROUTINE_PAT` is set and the loop self-fired unattended (06-14 scheduled executor #819 → continue #821 → merged #825, all authored by `menno420` not `github-actions[bot]`).
- **Timing complaint = GitHub Actions cron lag**, not timezone/config (same cron fired 01:20 UTC one day, 06:04 the next; backups ~4h late).
- **`backup-db.yml` genuinely broken** — `DATABASE_PUBLIC_URL` unset → daily failure issues. No working DB backups (maintainer-side).

## Changes
- **Q-0134** — reconciliation cadence widened **20 → 30** (`STEP=30`; CLAUDE.md + current-state marker `#870` + routines doc). Workflow reads the script, so it propagates with no workflow edit.
- **Q-0135** — `scripts/check_loop_health.py`: live-GitHub probe of the control-plane table (ROUTINE_PAT author / open backup-failure / loop-self-fired), folded into the reconciliation routine STEP 2 so the table can't silently drift again. +9 unit tests on the pure `classify` core.
- **Q-0136** — Hermes dispatch prompt gains an AUTHORIZED clause (sourcing the named secret env var into the `/fire` curl is sanctioned, not "exposing sensitive information") + a diagnosis note. **Owner action: re-paste `dispatch.md` into Hermes' config.**
- Control-plane table rows 1+6 ticked with evidence; row 2 marked still-pending; cron-lag caveat; misleading "03:00/05:00 local" cron refs corrected to UTC.

## Verification
`check_quality --check-only` ✓ · `check_docs --strict` ✓ · `check_current_state_ledger --strict` ✓ · `check_architecture` 0 errors · loop-health + context_map tests ✓ (24 passed).

## Handed to owner (control-plane, repo can't see)
`DATABASE_PUBLIC_URL` secret · Railway `CLAUDE_ROUTINE_*` deploy · routine model/prompt confirmation · re-paste the Hermes dispatch skill.

https://claude.ai/code/session_01THYNzZHw2HvBT7bjBj3u9Q