### PR TITLE
docs(research): external-systems watchlist — what to learn from & re-check

### DIFF
--- a/.sessions/2026-06-14-external-systems-watchlist.md
+++ b/.sessions/2026-06-14-external-systems-watchlist.md
@@ -1,0 +1,14 @@
+# Session: external-systems watchlist — what to learn from & re-check
+
+> **Status:** `in-progress`
+
+**Branch:** `claude/modest-ptolemy-2xipoh` · **PR:** TBD · **Date:** 2026-06-14 · **Type:** owner-directed docs (manual)
+
+## What I'm about to do
+Owner asked me to document the external AI systems / workflows worth learning from (the shortlist I
+gave in chat — Voyager, Reflexion, Generative Agents, MemGPT/Letta, SWE-agent, production
+autonomous-SWE loops, human eng-org practice) as a **living watchlist** a future session can
+occasionally re-check for new ideas. Decide the home myself (future-self must find it). Plan:
+`docs/research/external-systems-watchlist.md` + a `docs/research/README.md` root; cross-link from
+the orientation reference list and the `autonomous-improvement-loop-vision` idea; tie the re-check
+to an existing cadence (grooming sweep), not a new routine.

--- a/.sessions/2026-06-14-external-systems-watchlist.md
+++ b/.sessions/2026-06-14-external-systems-watchlist.md
@@ -1,14 +1,56 @@
 # Session: external-systems watchlist — what to learn from & re-check
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-**Branch:** `claude/modest-ptolemy-2xipoh` · **PR:** TBD · **Date:** 2026-06-14 · **Type:** owner-directed docs (manual)
+**Branch:** `claude/modest-ptolemy-2xipoh` · **PR:** #854 · **Date:** 2026-06-14 · **Type:** owner-directed docs (manual)
 
-## What I'm about to do
+## What this session did
 Owner asked me to document the external AI systems / workflows worth learning from (the shortlist I
-gave in chat — Voyager, Reflexion, Generative Agents, MemGPT/Letta, SWE-agent, production
-autonomous-SWE loops, human eng-org practice) as a **living watchlist** a future session can
-occasionally re-check for new ideas. Decide the home myself (future-self must find it). Plan:
-`docs/research/external-systems-watchlist.md` + a `docs/research/README.md` root; cross-link from
-the orientation reference list and the `autonomous-improvement-loop-vision` idea; tie the re-check
-to an existing cadence (grooming sweep), not a new routine.
+gave in chat) as a **living watchlist** a future session can occasionally re-check for new ideas,
+and to decide the home myself since future-self must find it.
+
+### Shipped
+- **New `docs/research/` folder** — the durable home for *external* intelligence (vs. `docs/ideas/`
+  for our own). `README.md` doubles as the reachability root.
+- **`docs/research/external-systems-watchlist.md`** (`reference`) — 7 lesson-first entries (Voyager
+  · Reflexion · Generative Agents · MemGPT/Letta · SWE-agent/SWE-bench · OpenHands/Devin/Factory ·
+  human eng-org practice) + 2 lighter watches (LLM-as-judge for the Hermes seam · multi-agent
+  frameworks). Each entry = one transferable lesson + **our adoption status (have/partial/gap)** +
+  where to check for new output. Honest framing up top: we're ahead on memory/governance, not the
+  execution loop — weight ideas that strengthen the former.
+- **Re-check loop** = grooming-driven (no new routine, which would be executable-config): a
+  `Last reviewed:` header + a "pick one entry per grooming sweep" convention. Wiring it into the
+  reconciliation pass is flagged as a **proposed** Q-block, not self-applied.
+- **Discoverability wiring:** cross-linked from `AGENT_ORIENTATION.md` (reference list) and the
+  `autonomous-improvement-loop-vision` idea (bidirectional). Verified reachable by `check_docs --strict`.
+
+### Home decision (mine to make)
+`docs/research/` over `docs/owner/`: this is agent-facing learning material, not owner intent/routing.
+A future session lands on it three ways — the orientation reference list, the loop-vision idea, and
+the grooming sweep that re-checks it. README-as-root guarantees it never orphans.
+
+## 💡 Session idea (Q-0089)
+**Register the watchlist with `scripts/check_doc_freshness.py` so its `Last reviewed:` date emits a
+soft staleness nudge** once it passes a threshold (e.g. 30 days) — turning the "re-check on grooming"
+convention into a visible signal an agent actually sees, instead of a rule it must remember. Composes
+existing tooling (the freshness checker already exists); small/safe grooming-lane candidate. Dedup-grep
+of `docs/ideas/` confirms no existing freshness-nudge idea for this doc class.
+
+## ⟲ Previous-session review (Q-0102)
+Reviewing **#853 (workflow-routine audit, this same branch):** strong — it corrected real
+control-plane drift with *live GitHub evidence* (not assumption) and shipped `check_loop_health.py`
+so that table can't silently drift again. **What it missed:** it pushed with only
+`check_quality --check-only` (formatters), and CI then caught two real breakages — stale cadence
+tests (a test that *encodes* the changed constant) and an unrebuilt generated skill artifact. Both
+are the same class: **editing a source whose downstream is verified elsewhere.** **System
+improvement:** a pre-push / Stop-hook guard that detects "you edited a *generator source* (a
+`*.md` skill, `index.yml`, a constant with a paired `test_*` that hard-codes it) but did not run the
+*full* suite / rebuild" — i.e. make the `--check-only`-is-insufficient case a *detected* condition,
+not a remembered one. That closes the exact gap that reddened #853's first push.
+
+## Doc audit (Q-0104)
+`check_docs --strict` ✓ (249 docs; new `docs/research/` reachable via README root + orientation link)
+· `check_current_state_ledger --strict` ✓ · `check_architecture --mode strict` 0 errors (pre-existing
+`[known]` xp warnings only). No new owner decision this session (home choice was delegated to me).
+**Grooming (Q-0015):** the watchlist itself seeds the grooming sweep with a recurring structured
+target — one entry re-checked per spare-capacity pass — so the backlog gains a renewable item.

--- a/.sessions/2026-06-14-external-systems-watchlist.md
+++ b/.sessions/2026-06-14-external-systems-watchlist.md
@@ -2,7 +2,7 @@
 
 > **Status:** `complete`
 
-**Branch:** `claude/modest-ptolemy-2xipoh` · **PR:** #854 · **Date:** 2026-06-14 · **Type:** owner-directed docs (manual)
+**Branch:** `claude/modest-ptolemy-2xipoh` · **PR:** #856 · **Date:** 2026-06-14 · **Type:** owner-directed docs (manual)
 
 ## What this session did
 Owner asked me to document the external AI systems / workflows worth learning from (the shortlist I

--- a/docs/AGENT_ORIENTATION.md
+++ b/docs/AGENT_ORIENTATION.md
@@ -327,6 +327,10 @@ has already been done.
   (Axis B = the vertical subsystem slice vs. the shared platform layers). Read when
   scoping what a given change's self-contained review unit is. Companion to the
   navigation map (paths), architecture (layers), and ownership (tables).
+- [`docs/research/external-systems-watchlist.md`](research/external-systems-watchlist.md) —
+  external AI-agent / memory / autonomous-SWE systems (and human-org practice) worth learning
+  from, each with the one transferable lesson + our adoption status. Re-checked on the grooming
+  cadence; the place to look when asking "what is the field doing that we should steal?"
 
 ### Plans / roadmaps (read for context only)
 

--- a/docs/ideas/autonomous-improvement-loop-vision-2026-06-12.md
+++ b/docs/ideas/autonomous-improvement-loop-vision-2026-06-12.md
@@ -142,3 +142,11 @@ decomposes into reviewable, independently-valuable steps:
 Each step is shippable and reviewable on its own; none requires committing to the whole
 loop up front. Build them in that order, review each in production, and the autonomous loop
 assembles itself from verified parts rather than as one leap.
+
+## See also — external systems we learn from
+
+The published work this north-star draws on (automatic curriculum, self-reflection as memory,
+the independent-reviewer / LLM-as-judge seam Hermes embodies) is tracked in
+[`../research/external-systems-watchlist.md`](../research/external-systems-watchlist.md) — the
+watchlist of external AI-agent / memory / autonomous-SWE systems worth periodically re-checking
+for ideas that strengthen this loop.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,7 +25,8 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-_(no active claims)_
+- `claude/modest-ptolemy-2xipoh` · external-systems watchlist (owner-directed docs) ·
+  `docs/research/` (new README + watchlist) + orientation/idea cross-links · 2026-06-14
 
 ## Recently cleared
 

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,25 @@
+# docs/research — external intelligence we learn from
+
+> **Status:** `reference`. Not a plan, not approval. These docs capture what exists
+> *outside* this repo that the agent ecosystem should learn from. Source code, the binding
+> contracts, and `docs/current-state.md` always win over anything here.
+
+## Why this folder exists
+
+The real artifact of this project is **the self-improving workflow itself** (`.claude/CLAUDE.md`
+Working agreement), not the bot. That makes "what is the rest of the field doing, and what should
+we steal from it?" a first-class question — but one that has had no durable home. Captures about
+*our own* ideas live in `docs/ideas/`; captures about *external* systems live here.
+
+## What lives here
+
+- [`external-systems-watchlist.md`](./external-systems-watchlist.md) — a **living watchlist** of
+  the AI-agent / memory / autonomous-SWE systems (and human-org practices) worth learning from,
+  each with the one transferable lesson, our adoption status, and where to check for new output.
+  Re-checked on the grooming cadence (see the doc's "How to keep this alive" section).
+
+## How to add to it
+
+Add an external system here when it teaches us something about the **workflow substrate** —
+memory, self-improvement, autonomy, agent–tool interfaces, multi-agent review. Keep each entry
+honest and lesson-first (what *we* do differently because of it), not a literature summary.

--- a/docs/research/external-systems-watchlist.md
+++ b/docs/research/external-systems-watchlist.md
@@ -1,0 +1,141 @@
+# External systems watchlist — what to learn from, and re-check
+
+> **Status:** `reference`. A living watchlist, not a plan or approval. Capture-and-learn only;
+> the binding contracts and source win. **Last reviewed:** 2026-06-14 (created).
+
+## Why this exists
+
+This project's real artifact is the **self-improving agent workflow** — the memory, journal,
+hooks, router, and tooling that let any agent work correctly with little steering
+(`.claude/CLAUDE.md` Working agreement). That dimension — *curated, version-controlled,
+self-governing memory plus a self-audit loop* — is the one most agent projects neglect, and the
+one that compounds. To keep compounding, we should periodically look at what the rest of the field
+is doing and steal the good parts.
+
+This page lists the systems worth learning from. Each entry is **lesson-first**: what it is in one
+line, the single transferable idea, **what we already do vs. the gap**, and where to check for new
+output. It is deliberately short — a watchlist, not a survey.
+
+> **Honest framing (so a future agent calibrates correctly):** we are *not* ahead on raw execution
+> — the plan→code→PR→CI→merge loop is shared with OpenHands, Devin, Factory, Sweep. We are ahead on
+> the **memory + governance discipline** that makes execution compound. So when reading these
+> systems, weight ideas that strengthen *that* (retrieval, self-reflection measurement, automatic
+> curriculum) over ideas that just re-implement the execution loop we already have.
+
+---
+
+## The watchlist
+
+### 1. Voyager (NVIDIA, 2023) — automatic curriculum + skill library
+- **What it is:** an LLM agent in Minecraft that proposes its own next task (automatic curriculum),
+  writes skills as reusable executable code, and self-verifies before adding a skill to its library.
+- **The lesson for us:** our curriculum is *manual* — the owner drops ideas, agents groom them
+  (`docs/ideas/`). Voyager's curriculum is *automatic*: the system proposes the next most-learnable
+  task itself. The open question it poses: **can next-task selection be more principled/automatic**
+  instead of owner-seeded + heuristic?
+- **Our status:** GAP. We have a skill *library* (`scripts/hermes/skills/`, `.claude/` skills) and a
+  backlog, but task selection is heuristic (active-work + roadmap + grooming), not a learned curriculum.
+- **Where to check:** the Voyager project repo & site (MineDojo / "Voyager" by Guo, Fan et al.);
+  follow-up "open-ended agent" work from the same group.
+
+### 2. Reflexion (Shinn, Cassano, Gopinath, Narasimhan, Yao, 2023) — self-reflection as memory
+- **What it is:** an agent that writes a *verbal* self-reflection after a failed attempt and stores
+  it as episodic memory, measurably improving the next attempt.
+- **The lesson for us:** this is **exactly our Q-0102** "review the previous session" ender — but
+  ours is *unmeasured*. Reflexion treats the reflection as an input whose value is observable. The
+  improvement: **close the loop — did last session's review demonstrably change what this session
+  did?** Make the self-audit measurable, not ceremonial.
+- **Our status:** PARTIAL. The reflection ritual exists (Q-0102); the *measurement* of whether it
+  helps does not. Pairs with the session "context delta" idea (`.sessions/README.md`).
+- **Where to check:** the Reflexion paper + citing work on verbal/episodic agent memory.
+
+### 3. Generative Agents (Park et al., Stanford, 2023) — scored memory retrieval
+- **What it is:** agents with a memory *stream* retrieved by a score combining **importance ×
+  recency × relevance**, plus periodic "reflection" that synthesizes higher-level memories.
+- **The lesson for us:** we retrieve memory by a **fixed hand-curated reading order**
+  (`AGENT_ORIENTATION.md`). That is great at small scale and is *why* orientation is reliable — but
+  as `current-state.md`, the journal, and `docs/` grow, **scored retrieval scales better than a
+  static list.** Worth prototyping a relevance/recency-ranked "what should I read for *this* task?"
+  layer on top of the fixed route, not replacing it.
+- **Our status:** GAP (by design, for now). Fixed reading-order is a deliberate strength; scored
+  retrieval is the scaling escape hatch when the read-path gets too big.
+- **Where to check:** "Generative Agents: Interactive Simulacra of Human Behavior" + memory-stream
+  follow-ups.
+
+### 4. MemGPT / Letta (2023→) — self-managed tiered memory / context paging
+- **What it is:** an agent that manages its *own* context window — paging information between
+  in-context "main memory" and external storage, deciding what to keep resident.
+- **The lesson for us:** we already do a crude version (archives: `.session-journal-archive.md`,
+  `docs/archive/`, per-file `.sessions/`). MemGPT formalizes it as the agent **actively paging its
+  own memory**. The lesson: as the living ledger grows, make context-paging an explicit discipline
+  (what graduates to archive, what stays resident) rather than ad-hoc.
+- **Our status:** PARTIAL. Archive discipline exists; agent-driven paging policy is informal.
+- **Where to check:** the Letta project (formerly MemGPT) repo + docs.
+
+### 5. SWE-agent / SWE-bench (Princeton, 2024) — the agent–computer interface matters
+- **What it is:** SWE-bench is the real-GitHub-issue benchmark; SWE-agent's key finding is that the
+  **interface** the agent acts *through* (its custom commands/tools) drives success as much as the
+  base model does.
+- **The lesson for us:** this **validates** our bespoke tooling — `context_map.py`, `wiring_map.py`,
+  `check_architecture.py`, the `check_*` guards, CodeGraph. Investing in agent-facing tooling is not
+  overhead; it is the lever. Keep building purpose-built tools; treat a recurring manual step as a
+  missing tool.
+- **Our status:** STRONG (this is a confirmation, not a gap). Our tooling layer *is* an
+  agent–computer interface.
+- **Where to check:** the SWE-bench leaderboard (track which interface/scaffold ideas win) +
+  SWE-agent releases.
+
+### 6. Production autonomous-SWE loops — OpenHands, Devin (Cognition), Factory
+- **What they are:** production systems running plan → code → test → PR → (often) merge-on-green,
+  with planning and verification-before-done as first-class stages.
+- **The lesson for us:** we **share this loop** — it is not where we are differentiated. Track them
+  for the *verification* and *long-horizon planning* patterns specifically (how they confirm a
+  change works before declaring done — our `/verify` & `/run` skills are the seam to mature), and
+  for merge-gating ideas. Do **not** copy their orchestration wholesale; our memory discipline is
+  the part they tend to lack.
+- **Our status:** PARITY on the loop; our edge is upstream of it (memory/governance).
+- **Where to check:** the OpenHands repo (most open), Cognition (Devin) and Factory engineering
+  blogs / changelogs.
+
+### 7. Human engineering-org practice — ADRs, RFCs, DORA, blameless postmortems
+- **What it is:** decades of well-run-team process: architecture decision records, RFCs, the DORA
+  delivery metrics, blameless postmortems, runbooks.
+- **The lesson for us:** our **closest kin is not an AI framework** — it is a disciplined eng org.
+  Our `docs/decisions/` (ADRs), the Q-router (decision provenance), `current-state.md` (runbook),
+  and the session self-audit are direct analogues. This literature is far deeper than the agent
+  field; keep mining it for the *next* governance primitive (e.g. DORA-style metrics on the
+  autonomous loop's own delivery — lead time, change-fail rate of routine PRs).
+- **Our status:** STRONG and ongoing; the richest vein for new governance ideas.
+- **Where to check:** the ADR community (adr.github.io), the DORA / "Accelerate" body of work,
+  Google SRE postmortem culture.
+
+---
+
+## Adjacent areas worth a lighter watch
+
+- **LLM-as-judge / evaluator-optimizer patterns** — directly relevant to the **Hermes
+  independent-reviewer** seam (`docs/ideas/autonomous-improvement-loop-vision-2026-06-12.md`). Track
+  how the field calibrates a "different mind" critic so Hermes's verdicts stay trustworthy.
+- **Multi-agent orchestration frameworks** (AutoGen, CrewAI, LangGraph) — mostly *re-implement*
+  coordination we already have bespoke; watch for *memory-sharing* and *handoff* primitives only,
+  not the orchestration.
+
+---
+
+## How to keep this alive (the re-check loop)
+
+This watchlist is only useful if it is revisited. The cadence is **grooming-driven, not a new
+routine** (a new routine would be executable-config the agent must not self-add):
+
+1. **Re-check trigger:** during the end-of-session **grooming sweep** (the standing secondary task,
+   `docs/ideas/README.md`), if no idea is more pressing, an agent may pick **one** entry here, check
+   its "where to check" source for genuinely new output, and either (a) capture a concrete new idea
+   into `docs/ideas/` with a back-link, or (b) note "checked, nothing new" by bumping the entry.
+2. **Update the header `Last reviewed:` date** whenever any entry is re-checked.
+3. **Keep it lesson-first.** If an entry stops teaching us anything actionable, cut it — a watchlist
+   that only grows becomes a survey nobody reads.
+
+> **Proposed (not self-applied):** wiring a periodic watchlist re-check into the **reconciliation
+> pass** would make the cadence reliable, but that changes a routine's scope (executable config) —
+> so it belongs in the question router as an owner decision, not a self-edit. Captured here as a
+> candidate; route it as a Q-block if an agent wants to formalize it.


### PR DESCRIPTION
## What

Adds a **living watchlist of external AI systems / workflows worth learning from**, at the
owner's request — and a new `docs/research/` home for external learning intelligence (distinct
from `docs/ideas/`, which captures *our own* ideas).

- **`docs/research/external-systems-watchlist.md`** (`reference`) — 7 lesson-first entries
  (Voyager · Reflexion · Generative Agents · MemGPT/Letta · SWE-agent/SWE-bench ·
  OpenHands/Devin/Factory · human eng-org practice) + 2 lighter watches (LLM-as-judge for the
  Hermes reviewer seam · multi-agent frameworks). Each entry carries the **one transferable
  lesson**, **our adoption status** (have / partial / gap), and **where to check** for new output.
- **`docs/research/README.md`** — folder intent + doubles as the reachability root.
- **Re-check loop** is grooming-driven (a `Last reviewed:` header + "pick one entry per grooming
  sweep"), *not* a new routine — wiring it into reconciliation is flagged as a proposed Q-block,
  not self-applied (routine scope = executable config).
- **Discoverability:** cross-linked from `AGENT_ORIENTATION.md` (reference list) and the
  `autonomous-improvement-loop-vision` idea (bidirectional).

## Why

The real artifact of this project is the self-improving workflow itself; "what is the field doing
that we should steal?" had no durable home. This gives it one, and ties its upkeep to an existing
cadence so a future session actually re-checks it.

## Verification

- `check_docs.py --strict` ✓ (new `docs/research/` reachable via README root + orientation link)
- `check_current_state_ledger.py --strict` ✓
- `check_architecture.py --mode strict` ✓ (0 errors; pre-existing `[known]` warnings only)

Docs-only change — no runtime / `disbot/` code touched.

https://claude.ai/code/session_01THYNzZHw2HvBT7bjBj3u9Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01THYNzZHw2HvBT7bjBj3u9Q)_