### PR TITLE
fix(ops): repair daily Postgres backup — PGDG pg18 client + explicit pg_dump path

### DIFF
--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -82,7 +82,12 @@ jobs:
         run: |
           TIMESTAMP=$(date -u '+%Y%m%dT%H%M%SZ')
           FILENAME="superbot-backup-${TIMESTAMP}.sql.gz"
-          pg_dump --no-owner --no-acl "$DATABASE_PUBLIC_URL" | gzip > "$FILENAME"
+          # The runner ships pg16 at /usr/bin/pg_dump, which shadows the PGDG client we
+          # installed — so call the highest-version pg_dump by explicit path (future-proof:
+          # picks 18 now, 19+ after a Railway major bump, as long as the client is installed).
+          PG_BIN="$(ls -d /usr/lib/postgresql/*/bin 2>/dev/null | sort -V | tail -1)"
+          echo "Using pg_dump: ${PG_BIN}/pg_dump"
+          "${PG_BIN}/pg_dump" --no-owner --no-acl "$DATABASE_PUBLIC_URL" | gzip > "$FILENAME"
           SIZE=$(du -sh "$FILENAME" | cut -f1)
           echo "file=$FILENAME" >> "$GITHUB_OUTPUT"
           echo "Backup created: $FILENAME ($SIZE)"

--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -63,9 +63,16 @@ jobs:
           fi
           echo "Secret configured."
 
-      - name: Install postgresql-client
+      - name: Install postgresql-client (PGDG — must be >= the Railway server major)
+        # Ubuntu's default postgresql-client is v16, but Railway's Postgres is v18,
+        # and pg_dump refuses to dump a NEWER server with an OLDER client
+        # ("aborting because of server version mismatch"). Add the official PGDG apt
+        # repo and install the latest client — a newer client dumps older servers
+        # fine, so a future Railway major bump won't re-break this.
         run: |
           sudo apt-get update -qq
+          sudo apt-get install -y postgresql-common
+          sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
           sudo apt-get install -y postgresql-client
 
       - name: Dump and compress
@@ -141,6 +148,8 @@ jobs:
                 '**Likely causes:**',
                 '- `DATABASE_PUBLIC_URL` secret not set, or expired/rotated',
                 '  (Railway updates it when the database is recreated)',
+                '- pg_dump server/client version mismatch (Railway upgraded its',
+                '  Postgres major — bump the postgresql-client install in this workflow)',
                 '- Transient network issue between GitHub Actions and Railway',
                 '',
                 'Check the workflow logs. If the secret is stale, update it:',

--- a/.sessions/2026-06-14-fix-backup-pg18.md
+++ b/.sessions/2026-06-14-fix-backup-pg18.md
@@ -1,13 +1,39 @@
 # Session: fix Postgres backup — pg_dump v18 client (server version mismatch)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Branch:** `claude/fix-backup-pg-version` · **PR:** TBD · **Date:** 2026-06-14 · **Type:** owner-directed ops bugfix (manual)
 
-## What I'm about to do
-Live-verifying the backup (owner set `DATABASE_PUBLIC_URL`) surfaced the real root cause: the URL is
-now correct (connection succeeds), but `pg_dump` aborts on a **server/client version mismatch** —
-Railway's Postgres is **v18.3**, the workflow installed the Ubuntu-default client **v16.14**, and
-pg_dump refuses to dump a newer server with an older client. Fix `backup-db.yml` to install the
-PGDG **v18+** client (newer client dumps older servers → future-proof). Verify by dispatching the
-fixed workflow on this branch ref before merge.
+## What this session did
+Live-verifying the backup (after the owner set `DATABASE_PUBLIC_URL`) drove a real production bug to
+ground in two layers:
+1. **URL was the template, not resolved** — diagnosed earlier; owner pasted the resolved URL (built
+   via `railway_vars.py`, Q-0130). Connection then succeeded.
+2. **pg_dump version mismatch** — Railway Postgres is **v18.3**; the workflow used the Ubuntu-default
+   client **v16**, and pg_dump refuses to dump a newer server with an older client. Fixed in two parts:
+   - install the **PGDG v18 client** (the default `apt postgresql-client` is v16 on Ubuntu 24.04);
+   - **invoke pg_dump by explicit highest-version path** (`/usr/lib/postgresql/*/bin`), because the
+     runner ships pg16 at `/usr/bin/pg_dump` which shadows the PGDG client on PATH.
+   Both are future-proof: a newer client dumps older servers, and the path picks the highest installed.
+
+Verified by dispatching the fixed workflow on this branch ref (not just trusting the change).
+Also documented the version-mismatch failure mode in the workflow's failure-issue body.
+
+## 💡 Session idea (Q-0089)
+**Pin the backup runner's pg_dump to a known-good major via a tiny matrix var** (or assert
+`pg_dump --version` major ≥ the server major before dumping, failing loud with a clear message) — so
+a future Railway major bump produces a precise "bump the client" error instead of a silent empty dump.
+Composes with the integrity guard already present. Ops lane; small.
+
+## ⟲ Previous-session review (Q-0102)
+Reviewing the **#859 sector-map/hook-policy session:** clean and well-scoped (settled Q-0137, built
+the nav top layer, recorded Q-0139). **What it could improve:** it deferred the Hermes `skill-author`
+meta-skill to "next session" without capturing a concrete *first step*; a deferred item with no next
+action risks stalling. **System improvement:** when a session defers work, it should leave a one-line
+"first concrete step" in the `.sessions` carry-forward so the next session starts mid-stride — which
+this backup session benefited from (the prior backup diagnosis left an exact "paste resolved URL" step).
+
+## Doc audit (Q-0104)
+No `disbot/`/docs-content change (workflow-only fix). The fix was **verified live** on the branch ref,
+not assumed — the strongest form of the Q-0104 "is it real?" check. `DATABASE_PUBLIC_URL` now set
+(owner); the backup is the last red routine from the 06-14 control-plane audit going green.

--- a/.sessions/2026-06-14-fix-backup-pg18.md
+++ b/.sessions/2026-06-14-fix-backup-pg18.md
@@ -1,0 +1,13 @@
+# Session: fix Postgres backup — pg_dump v18 client (server version mismatch)
+
+> **Status:** `in-progress`
+
+**Branch:** `claude/fix-backup-pg-version` · **PR:** TBD · **Date:** 2026-06-14 · **Type:** owner-directed ops bugfix (manual)
+
+## What I'm about to do
+Live-verifying the backup (owner set `DATABASE_PUBLIC_URL`) surfaced the real root cause: the URL is
+now correct (connection succeeds), but `pg_dump` aborts on a **server/client version mismatch** —
+Railway's Postgres is **v18.3**, the workflow installed the Ubuntu-default client **v16.14**, and
+pg_dump refuses to dump a newer server with an older client. Fix `backup-db.yml` to install the
+PGDG **v18+** client (newer client dumps older servers → future-proof). Verify by dispatching the
+fixed workflow on this branch ref before merge.

--- a/.sessions/2026-06-14-fix-backup-pg18.md
+++ b/.sessions/2026-06-14-fix-backup-pg18.md
@@ -2,7 +2,7 @@
 
 > **Status:** `complete`
 
-**Branch:** `claude/fix-backup-pg-version` · **PR:** TBD · **Date:** 2026-06-14 · **Type:** owner-directed ops bugfix (manual)
+**Branch:** `claude/fix-backup-pg-version` · **PR:** #862 · **Date:** 2026-06-14 · **Type:** owner-directed ops bugfix (manual)
 
 ## What this session did
 Live-verifying the backup (after the owner set `DATABASE_PUBLIC_URL`) drove a real production bug to


### PR DESCRIPTION
## What

Fixes the daily Postgres backup, which has failed every day since it was added. Diagnosed by
**live verification** (dispatching the workflow on this branch and reading the logs), in two layers:

1. **`DATABASE_PUBLIC_URL` held Railway's unresolved `${{…}}` template** (owner fixed by pasting the
   resolved URL — built via `railway_vars.py`, Q-0130). Connection then succeeded.
2. **pg_dump version mismatch:** Railway's Postgres is **v18.3**; the workflow used the Ubuntu-default
   client **v16** and pg_dump refuses to dump a newer server with an older client. Fixed in two parts:
   - install the **PGDG v18 client** (Ubuntu's default `postgresql-client` is v16 on 24.04);
   - **invoke pg_dump by explicit highest-version path** (`/usr/lib/postgresql/*/bin`) — the runner
     ships pg16 at `/usr/bin/pg_dump`, which shadowed the PGDG client on PATH.

Both are future-proof (a newer client dumps older servers; the path picks the highest installed), so a
later Railway major bump won't re-break it. Also documented the version-mismatch failure mode in the
workflow's failure-issue body.

## Verification

**Dispatched the fixed workflow on this branch → run succeeded** (run #6, 2026-06-14T17:42): pg_dump
ran, integrity check passed (≥10 CREATE TABLE statements), artifact uploaded. The prior runs failed at
exactly the diagnosed points. Backups are now live.

https://claude.ai/code/session_01THYNzZHw2HvBT7bjBj3u9Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01THYNzZHw2HvBT7bjBj3u9Q)_