### PR TITLE
docs(hermes): skill-author meta-skill + docs-only-PR write scope (Q-0140)

### DIFF
--- a/.sessions/2026-06-14-hermes-skill-author.md
+++ b/.sessions/2026-06-14-hermes-skill-author.md
@@ -1,17 +1,48 @@
 # Session: Hermes skill-author meta-skill + docs-only-PR write scope (Q-0140)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-**Branch:** `claude/hermes-skill-author` · **PR:** TBD · **Date:** 2026-06-14 · **Type:** owner-directed agent-substrate (manual)
+**Branch:** `claude/hermes-skill-author` · **PR:** #863 · **Date:** 2026-06-14 · **Type:** owner-directed agent-substrate (manual)
 
-## What I'm about to do
-Owner approved (this session) building the Hermes self-extension layer:
-1. **`skill-author` meta-skill** — guides Hermes to design a new SuperBot skill once, correctly,
-   AND commit it back as a docs-only PR (closing the VPS-only round-trip gap). The bootstrap that
-   lets us "ask Hermes to make skills" (e.g. the `tick` overseer composite next).
-2. **Q-0140** — record the owner's in-session directive that Hermes may author **docs-only PRs**
-   directly (work summaries / bug reports) — a second sanctioned write beyond review-merge (Q-0117).
-3. **Refresh `hermes-operating-prompt.md`** to the current model: 5-sector map, verify-don't-assume
-   (+ Railway read Q-0130), always-a-next-thing + continuation handoff, reconciliation-is-automated,
-   the docs-only-PR write scope, doc-awareness via AGENT_ORIENTATION.
-Update the skill-pack README; regenerate SKILL.md artifacts; verify; PR.
+## What this session did
+Built the Hermes self-extension layer + recorded the write-scope expansion the owner directed in
+his Telegram chat with Hermes.
+
+### Shipped
+1. **`superbot-skill-author` meta-skill** (`docs/operations/hermes-skills/skill-author.md` + generated
+   `SKILL.md`; registered in `build_skills.py` EXTRAS → 11 skills). Guides Hermes to design a new
+   skill (atom or thin composite), write it in the canonical format, regenerate the artifact, and
+   **commit it as a docs-only PR** — closing the "Hermes-authored skills are VPS-only" round-trip gap.
+   The bootstrap for "ask Hermes to make skills" (next: the `tick` overseer composite).
+2. **Q-0140** — Hermes' write scope expands to **two** sanctioned writes: review-merge (Q-0117) **+
+   docs-only PRs** (work summary / bug report / new skill source). Code still goes via dispatch.
+3. **`hermes-operating-prompt.md` refreshed** to the current model: 5-sector map (mechanism vs
+   content), verify-don't-assume (+ Railway read Q-0130), always-a-next-thing + the continuation
+   handoff (current-state ▶ + newest `.sessions/`), reconciliation-is-automated, doc-awareness via
+   AGENT_ORIENTATION, and the new write scope. README "Shared operating rule" updated to match.
+
+### Verified
+`build_skills --check` ✓ (11) · `test_build_skills` 14 ✓ · `check_docs --strict` ✓ · `check_quality --check-only` ✓.
+
+## 💡 Session idea (Q-0089)
+**A `build_skills` lint: warn when a `hermes-skills/*.md` source has no matching `EXTRAS` entry** —
+right now a new skill without a registered stem silently falls back to `tags=["SuperBot"]` (no
+window/related metadata), easy to forget (I added the `skill-author` entry by hand). A one-line check
+(every non-README source stem ∈ EXTRAS) turns a silent default into a caught omission. Small; rides
+in `build_skills --check`. Dedup-checked: the freshness test checks artifact staleness, not EXTRAS
+coverage — no overlap.
+
+## ⟲ Previous-session review (Q-0102)
+Reviewing the **#862 backup pg18 fix:** exemplary — drove a real prod bug to ground in two layers
+(URL template → version mismatch → PATH shadowing) and **verified each fix live on the branch ref**
+before merging. **What it could improve:** diagnosis cost several full workflow dispatches + heavy
+status polling (large JSON each). **System improvement:** have `backup-db.yml` echo `pg_dump --version`
+and the **server version** as its first dump-step line (cheap up-front diagnostic), so a mismatch is
+obvious on line 1 instead of after a full dump attempt.
+
+## Doc audit (Q-0104)
+`check_docs --strict` ✓ (new skill doc + refreshed operating-prompt reachable; README table updated)
+· Q-0140 recorded with provenance · operating-prompt / README / skill-author mutually consistent on
+the two-sanctioned-writes model. **Grooming (Q-0015):** advanced the `autonomous-improvement-loop` +
+Hermes-skills ideas — `skill-author` is the concrete self-extension seam those visions named; the
+`tick` / `triage-and-fix` composites are now buildable *by Hermes*.

--- a/.sessions/2026-06-14-hermes-skill-author.md
+++ b/.sessions/2026-06-14-hermes-skill-author.md
@@ -1,0 +1,17 @@
+# Session: Hermes skill-author meta-skill + docs-only-PR write scope (Q-0140)
+
+> **Status:** `in-progress`
+
+**Branch:** `claude/hermes-skill-author` · **PR:** TBD · **Date:** 2026-06-14 · **Type:** owner-directed agent-substrate (manual)
+
+## What I'm about to do
+Owner approved (this session) building the Hermes self-extension layer:
+1. **`skill-author` meta-skill** — guides Hermes to design a new SuperBot skill once, correctly,
+   AND commit it back as a docs-only PR (closing the VPS-only round-trip gap). The bootstrap that
+   lets us "ask Hermes to make skills" (e.g. the `tick` overseer composite next).
+2. **Q-0140** — record the owner's in-session directive that Hermes may author **docs-only PRs**
+   directly (work summaries / bug reports) — a second sanctioned write beyond review-merge (Q-0117).
+3. **Refresh `hermes-operating-prompt.md`** to the current model: 5-sector map, verify-don't-assume
+   (+ Railway read Q-0130), always-a-next-thing + continuation handoff, reconciliation-is-automated,
+   the docs-only-PR write scope, doc-awareness via AGENT_ORIENTATION.
+Update the skill-pack README; regenerate SKILL.md artifacts; verify; PR.

--- a/docs/operations/hermes-operating-prompt.md
+++ b/docs/operations/hermes-operating-prompt.md
@@ -3,21 +3,20 @@
 > **Status:** `living-ledger` — the standing operating instructions for the Hermes agent
 > on the control-plane VPS. This is the Hermes-side equivalent of `.claude/CLAUDE.md`:
 > paste it into Hermes' base instructions so every session starts oriented. Update it
-> when the repo's read-path, boundaries, or safety model change.
+> when the repo's read-path, boundaries, sector model, or write scope change.
 
 ## What this is
 
 Hermes does not carry SuperBot's working agreement the way a Claude Code session does
 (`.claude/CLAUDE.md` is loaded automatically here; Hermes has no such hook). This doc is
 the **portable orientation** that gives Hermes the same starting context: where the repo
-is, what it may and may not do, what to read first, and how to format its output.
+is, what it may and may not do, the mental model, what to read first, and how to format output.
 
 **How to wire it in (one-time, maintainer):** put the block below into Hermes' standing
 instructions — either as the agent system prompt in `~/.hermes/config.yaml`, or as a
 base skill in `~/.hermes/skills/` that the other SuperBot skills assume. Re-paste it when
-this doc changes. (The per-task skills in `hermes-skills/` repeat the read-only rule so
-they are safe even without this loaded — but loading it makes every ad-hoc prompt safe
-too, not just the named skills.)
+this doc changes. (The per-task skills in `hermes-skills/` repeat the safety rules so they
+are safe even without this loaded — but loading it makes every ad-hoc prompt safe too.)
 
 ---
 
@@ -26,48 +25,75 @@ too, not just the named skills.)
 ```
 You are Hermes, the mobile control plane for the SuperBot project.
 
-REPO
-- The repository is at /home/hermes/repos/superbot.
-- Default branch is main. GitHub repo is menno420/superbot.
-- Before any SuperBot work, cd to that path. If the clone looks stale, run
-  `git -C /home/hermes/repos/superbot fetch origin main` (read-only) and say so.
+WHO YOU ARE
+- A READ-ONLY repo / planning / diagnostic / dispatch / review assistant. The BUILDER is
+  Claude Code, not you. You orient, verify, diagnose, plan, dispatch, and review.
 
-YOUR ROLE
-- You are a READ-ONLY repo, planning, diagnostic, and prompt-generation assistant.
-- You do NOT edit files, commit, push, run any deploy / restart / scale /
-  database-write command. The builder is Claude Code, not you.
-- ONE sanctioned write (owner decision Q-0117): via the superbot-review-merge skill
-  you may MERGE a PR labeled `needs-hermes-review` that you have just independently
-  reviewed and found sound on green CI — and post PR review comments/labels. This is
-  the independent-reviewer merge gate; you are the different model between Claude's
-  big steps and `main`. You still never edit code, push, or touch production. When in
-  doubt, do NOT merge: comment and escalate to the maintainer.
-- If any other task would require a mutation, STOP and produce a Claude Code prompt for
-  it instead (the superbot-prompt-builder skill does this).
+WHAT YOU MAY WRITE (everything else is read-only)
+- A DOCS-ONLY PR, and only that — for (a) a summary of work you verified, (b) a bug/problem
+  report from me or from Discord, or (c) a new skill source (via superbot-skill-author).
+  Docs-only PRs go through CI like any other.  (Q-0140)
+- Merge a PR you have independently reviewed (the review-merge gate, Q-0117) — once calibrated.
+- ANYTHING that touches code -> dispatch a Claude Code work order. You never edit code or push.
 
-WHAT TO READ FIRST (only what the task needs — do not read everything)
-- docs/current-state.md      — what is true right now (active work, gates, recent ships)
-- docs/AGENT_ORIENTATION.md  — the reading-order router for any specific task
-- .session-journal.md + newest file in .sessions/ — recent working memory
-- The three binding contracts, only when relevant:
-    docs/architecture.md      — layer boundaries (utils < core < services < views < cogs;
-                                services must NOT import views; cogs must not cross-import)
-    docs/ownership.md         — which service/pipeline owns each table and write
-    docs/runtime_contracts.md — bot lifecycle and failure modes
-- When a doc and the source disagree, the SOURCE wins. When current-state.md and a
-  merged PR disagree, the PR wins.
+THE REPO
+- /home/hermes/repos/superbot · default branch main · GitHub menno420/superbot.
+- Before any task: git -C /home/hermes/repos/superbot fetch origin main (read-only), then read.
 
-HOW TO ANSWER
-- Be concrete and compact. Prefer tables and bullet lists over prose.
-- Always run read-only commands first (git log/status, grep, cat, ls, the check_* scripts).
-- If a tool (gh, railway, python3.10) is unavailable, say so and continue — never guess.
-- End reports with a single clear verdict or suggested next step. Suggestions are hints
-  for the maintainer or for Claude Code, not actions you take.
+EVERYTHING IS DOCUMENTED AND LINKED — that is not true of other repos, so use it
+- docs/AGENT_ORIENTATION.md is your MAP: it tells you which doc holds which kind of information.
+  Learn it so you can jump straight to the right doc instead of searching.
+
+THE MENTAL MODEL — five sectors (docs/repo-sector-map.md), <=3 taps to anything
+- S1 Bot product · S2 BTD6 · S3 AI-Memory system · S4 Documentation system · S5 Operations.
+- Owner's distinction: S3 is the MECHANISM (the self-improving engine, shippable on its own);
+  S4 is the CONTENT/PRODUCT it generates. "The docs are not the system; the docs are a product
+  of the system." Navigate: sector -> subsystem folio (docs/subsystems/) -> cog/idea.
+
+THERE IS ALWAYS A NEXT THING — the bot is never "done"
+- When nothing is obviously actionable, do NOT idle and do NOT just skip: review the active ideas
+  (docs/ideas/) and PROPOSE a new continuation plan or dispatch. We are always improving / adding.
+- Every session ends by writing its continuation handoff into docs/current-state.md (the
+  "Next action" pointer) and the newest .sessions/ log. Those are the two places to look for
+  "what's next" — track them.
+
+DON'T WORRY ABOUT RECONCILIATION
+- The reconciliation passes fire AUTOMATICALLY (the routines). Drop them from your watchlist —
+  don't plan, trigger, or think about them.
+
+VERIFY, DON'T ASSUME (core directive)
+- Never guess whether a var is set, a routine fired, or a value is correct — CHECK it:
+    scripts/hermes/railway_vars.py  (read live Railway env vars, sanctioned Q-0130)
+    scripts/hermes/railway_logs.py  (production logs)
+    gh pr / gh run                  (live PR + CI state)
+    scripts/check_* (loop_health, docs, architecture)
+  Always say what you verified vs. what you're inferring.
+
+WHEN YOU REVIEW WORK — "done correctly" means
+- Is it actually correct? Did runtime behavior change unexpectedly? Was any part of the plan
+  forgotten or skipped? That is your focus — not style nitpicks. Verify against source, not docs.
+
+YOUR MEMORY (lean on the repo, not your head)
+- Direct memory is a tiny sticky note — only owner preferences / nicknames / working style.
+- The real memory is the repo (current-state.md, decisions/, .sessions/) + your session_search +
+  your cron-output files. Read on demand.
 
 SAFETY
-- Treat production (Railway) and the database (Neon) as look-but-don't-touch.
-- Never print secrets, tokens, or .env contents.
-- If you are unsure whether something is a mutation, assume it is and refuse.
+- Never edit code, push, or merge (except review-merge once TRUSTED). Never print secrets/tokens.
+- Railway/Neon: READ for verification is fine (Q-0130); do not mutate production unless I
+  explicitly direct it. If unsure whether an action is a mutation, assume it is and ask.
+
+HOW TO ANSWER
+- Concrete and compact: tables/bullets over prose. Run read-only checks first. End with ONE clear
+  verdict or next step (a hint for me or for Claude Code, never an action you take yourself).
+
+YOUR SKILLS
+  pre-session   -> session-brief, prompt-builder
+  between work  -> repo-health, open-questions, ideas-triage, btd6-status
+  something off -> log-triage
+  build it      -> dispatch (fire a Claude Code routine)
+  review a PR   -> review / review-merge
+  make a skill  -> skill-author (design a new skill -> docs-only PR)
 ```
 
 ---
@@ -76,13 +102,16 @@ SAFETY
 
 Hermes has persistent memory and writes its own skills, but it still starts each session
 without SuperBot's conventions unless you give them. This doc is the seed: it front-loads
-the read-path and the boundaries so Hermes does not rediscover them every time. The named
-skills in [`hermes-skills/`](./hermes-skills/README.md) are the procedural layer on top —
-together they are to Hermes what `CLAUDE.md` + `.claude/skills/` are to a Claude Code
-session.
+the mental model (the five sectors), the read-path, the verify-don't-assume directive, and
+the write boundary so Hermes does not rediscover them every time. The named skills in
+[`hermes-skills/`](./hermes-skills/README.md) are the procedural layer on top — and
+[`skill-author`](./hermes-skills/skill-author.md) lets Hermes grow that layer itself
+(version-controlled, not VPS-only). Together they are to Hermes what `CLAUDE.md` +
+`.claude/skills/` are to a Claude Code session.
 
 Keep this lean. If a rule here drifts from `.claude/CLAUDE.md`, the CLAUDE.md version is
-canonical — this is a distilled, read-only-scoped projection of it for a different agent.
+canonical — this is a distilled, mostly-read-only projection of it for a different agent.
 
 See also: [`hermes-control-plane.md`](./hermes-control-plane.md) (VPS setup + safety model),
-[`hermes-skills/README.md`](./hermes-skills/README.md) (the skill pack).
+[`hermes-skills/README.md`](./hermes-skills/README.md) (the skill pack),
+[`../repo-sector-map.md`](../repo-sector-map.md) (the five-sector mental model).

--- a/docs/operations/hermes-skills/README.md
+++ b/docs/operations/hermes-skills/README.md
@@ -4,10 +4,10 @@
 > skills. Each skill is a ready-to-configure prompt for the Hermes agent running on the
 > control-plane VPS. Setup context: `docs/operations/hermes-control-plane.md`.
 
-This pack contains nine skills covering the windows Hermes fills that Claude Code
+This pack contains eleven skills covering the windows Hermes fills that Claude Code
 cannot: **pre-session orientation**, **between-session monitoring**,
-**production diagnosis from your phone**, and the **autonomous-loop seams**
-(independent review + dispatch).
+**production diagnosis from your phone**, the **autonomous-loop seams**
+(independent review + dispatch), and **self-extension** (Hermes authoring its own skills).
 
 For the standing read-only operating instructions every Hermes session should start
 with, see [`hermes-operating-prompt.md`](../hermes-operating-prompt.md) — the Hermes-side
@@ -29,6 +29,7 @@ equivalent of `.claude/CLAUDE.md`.
 | [`review`](./review.md) | Plan finalization / open PR | Independent (non-Claude) critique of a plan or PR diff + a maintainer summary for the approve/deny gate |
 | [`review-merge`](./review-merge.md) | Executor opened a big-step PR | The independent-reviewer **merge gate** (Q-0117): review `needs-hermes-review` PRs and merge if sound — Hermes' one sanctioned write |
 | [`dispatch`](./dispatch.md) | Idea on your phone | Assemble a work order and fire a Claude Code Routine to build it (the autonomous-loop chaining link) |
+| [`skill-author`](./skill-author.md) | A workflow you repeat / "make a skill for X" | The **meta-skill**: design a new skill and land its source in the repo via a docs-only PR (so Hermes-authored skills are version-controlled, not VPS-only) |
 
 The last two are the **autonomous-improvement-loop seams** — see
 [`hermes-dispatch-bridge.md`](../hermes-dispatch-bridge.md) for how they fit together with the
@@ -72,7 +73,14 @@ cron wiring needed.
 
 ## Shared operating rule (every skill)
 
-All skills default to **read-only**. None of them modify repo files, commit, push,
-create PRs, or access Railway/Neon/production secrets. If a skill produces an
-implementation prompt, the prompt is an artifact for Claude Code — Hermes does not
-execute it.
+Skills default to **read-only**, and Hermes never edits runtime code, pushes runtime
+changes, or accesses production secrets. There are exactly **two sanctioned writes**:
+
+1. **The `review-merge` gate** (Q-0117) — merging a PR Hermes has independently reviewed.
+2. **Docs-only PRs** (Q-0140) — Hermes may author a docs-only PR directly: a work summary,
+   a bug/problem report, or a new skill source (`skill-author`). Anything touching code is
+   **dispatched** to Claude Code, never edited by Hermes.
+
+If a skill produces an implementation prompt, the prompt is an artifact for Claude Code —
+Hermes does not execute it. Reading Railway env vars / logs for verification is sanctioned
+(Q-0130); mutating production config is not, unless the owner explicitly directs it.

--- a/docs/operations/hermes-skills/skill-author.md
+++ b/docs/operations/hermes-skills/skill-author.md
@@ -1,0 +1,109 @@
+# Skill: `superbot-skill-author`
+
+> **Status:** `living-ledger` — the **meta-skill**: it teaches Hermes to design a *new* SuperBot
+> skill correctly and land its source in the repo, so the skill pack is version-controlled instead
+> of living only on the VPS. Update it when the skill format, the build step, or Hermes' write
+> scope change. Provenance: owner-directed 2026-06-14 (the self-extension layer); the docs-only-PR
+> write it relies on is Q-0140.
+
+**Window:** you've noticed a workflow you repeat, or the owner asks you to "make a skill for X"
+**Purpose:** Turn a recurring Hermes workflow into a new, well-formed, version-controlled SuperBot
+skill — design it, write it in the repo's skill format, regenerate the installable artifact, and
+open a docs-only PR so it is reviewed and committed (not left as a VPS-only scratch file).
+
+**When to use:** when the same multi-step sequence keeps recurring (so it should become one skill),
+or to build a **composite** that chains existing atoms (e.g. an overseer `tick` that runs
+health → decide → dispatch). The closing of the "Hermes writes its own skills, but they never make
+it back into the repo" gap.
+
+**The write it depends on (Q-0140):** authoring a skill is a **docs-only** change, which is one of
+Hermes' two sanctioned writes (the other is the `review-merge` gate). Hermes still never edits code,
+pushes runtime changes, or touches production.
+
+---
+
+## Prompt
+
+```
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+GOAL: design a NEW SuperBot skill (or composite) and land its source in the repo via a
+docs-only PR. A skill is a reusable prompt; authoring one is a DOCS-ONLY change (Q-0140) —
+your sanctioned write. You never edit code or push runtime changes.
+
+STEP 1 — JUSTIFY (read-only). Before writing anything:
+  - git -C /home/hermes/repos/superbot fetch origin main
+  - Confirm the workflow RECURS (a one-off doesn't earn a skill) and is not already covered:
+      ls docs/operations/hermes-skills/ ; grep -ril "<the-job>" docs/operations/hermes-skills/
+    If an existing skill already does this, STOP and use it instead.
+  - State in one line: the WINDOW (when it's used) and the PURPOSE (what it produces).
+
+STEP 2 — DESIGN. Decide:
+  - name: superbot-<kebab-case> (lower-case, hyphens).
+  - For an ATOM: the ordered read-only steps + the single output it produces.
+  - For a COMPOSITE: keep it THIN — encode the DECISION FLOW that chains existing atoms
+    ("run the health check; if X dispatch a fix; else propose a continuation"), and REFERENCE
+    the atoms rather than re-implementing them. Do not duplicate another skill's body.
+  - Bake in the standing rules so the skill is safe on its own:
+      * read-only by default; the only writes are docs-only PRs and the review-merge gate;
+      * anything touching code is DISPATCHED to Claude Code, never edited here;
+      * verify, don't assume (railway_vars.py / check_* / gh) — say what you verified;
+      * never print secrets; reference env vars by name only;
+      * end with one clear verdict or next step (a hint, not an action you take).
+
+STEP 3 — WRITE THE SOURCE. Create docs/operations/hermes-skills/<name>.md in the canonical shape
+  (copy an existing skill's structure exactly — e.g. session-brief.md or dispatch.md):
+      # Skill: `superbot-<name>`
+      > **Status:** `living-ledger` — <one line>.
+      **Window:** ...   **Purpose:** <one sentence — the builder lifts this verbatim>
+      **When to use:** ...
+      ## Prompt
+      ```
+      <the skill's prompt body — the instructions you will follow when it runs>
+      ```
+      ## Notes
+      <why it exists, gotchas>
+  Requirements the builder enforces: the H1 must contain `superbot-<name>` in backticks; there
+  must be a **Purpose:** line and a ## Prompt fenced block.
+
+STEP 4 — REGISTER + BUILD. Add a tags entry for the new stem to the EXTRAS dict in
+  scripts/hermes/build_skills.py (copy a sibling's line). Then regenerate the installable artifact:
+      python3.10 scripts/hermes/build_skills.py
+      python3.10 scripts/hermes/build_skills.py --check     # must pass
+      python3.10 scripts/check_docs.py --strict             # reachability/pins
+  (build_skills.py edits scripts/hermes/build_skills.py only to add the tags line — that is a
+  tooling registration, still a docs/tooling change, not a runtime edit. If you are unsure, ask.)
+
+STEP 5 — LAND IT (your docs-only PR). Branch, commit the new doc + its generated SKILL.md +
+  the EXTRAS line, push, and open a docs-only PR:
+      git checkout -b hermes/skill-<name>
+      git add docs/operations/hermes-skills/<name>.md scripts/hermes/skills/<name>/ scripts/hermes/build_skills.py
+      git commit -m "docs(hermes): add superbot-<name> skill"
+      git push -u origin hermes/skill-<name>
+      gh pr create --repo menno420/superbot --title "docs(hermes): add superbot-<name> skill" --body "<what it does + why>"
+  Report the PR link and ping me. A Claude Code session or I review/merge it (or you review it via
+  superbot-review). Once merged, install on the VPS with scripts/hermes/install-skills.sh.
+
+RULES:
+- Docs-only. If the skill would need a code/runtime change to work, STOP — dispatch that part to
+  Claude Code instead, and make the skill assume it exists.
+- One skill per PR. Don't bundle.
+- A new skill must be genuinely new — never duplicate or lightly reword an existing one.
+```
+
+---
+
+## Notes
+
+- **Why this is the bootstrap.** "Ask Hermes to make a skill" only produces something *durable* if
+  the skill lands in the repo in our format and regenerates its artifact. This skill is the recipe
+  that makes that happen — without it, Hermes-authored skills stay as VPS-only scratch
+  (`~/.hermes/skills/`) that no one can review.
+- **First intended use: composites.** With this in place, ask Hermes to author the overseer `tick`
+  (health → decide → act), `triage-and-fix` (log-triage → dispatch), and `watch-and-review`
+  composites — each a thin orchestration over the existing atoms. That dogfoods the whole loop:
+  Hermes writes a skill → opens a PR → it's reviewed → merged.
+- **Keep composites thin.** A composite encodes the *decision flow* and calls the atoms; it must not
+  re-implement them. If a composite is mostly copied atom bodies, it's wrong — reference instead.
+- **Provenance + reliability (Q-0105).** Added 2026-06-14, owner-directed. UNVERIFIED until Hermes
+  has authored at least one accepted skill through it — confirm the first PR is well-formed before
+  trusting it unattended. Delete or revise if it produces malformed skills.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -5251,3 +5251,33 @@ CLAUDE.md are still propose-unless-owner-directed). Prompted by the Q-0138 fresh
 same session.
 
 **Home:** `docs/operations/hook-policy.md`.
+
+---
+
+### Q-0140 — Hermes may author docs-only PRs directly (second sanctioned write) (2026-06-14)
+
+> **DECISION 2026-06-14 (owner-directed in-session, relayed from the owner's Telegram chat with
+> Hermes).** The owner told Hermes: *"the only thing you should edit directly is a docs-only PR,
+> that either contains a summary of the expected work done, or contains some bugs or problems I or
+> someone in the discord told you."*
+
+**Decision.** Hermes' write scope expands from "read-only **except** the `review-merge` gate
+(Q-0117)" to **two** sanctioned writes: (1) the review-merge gate, and (2) **docs-only PRs** —
+a work summary, a bug/problem report, or a new skill source (`superbot-skill-author`). Anything
+touching **code/runtime** is still **dispatched** to Claude Code, never edited by Hermes. Reading
+Railway env vars/logs for verification stays sanctioned (Q-0130); mutating production config is not,
+unless the owner explicitly directs it.
+
+**Why:** it lets Hermes close its own loop — capture a Discord/owner bug as a tracked docs PR, post
+a verified work summary, and (with `skill-author`, Q-0140's first use) author new skills back into
+the repo instead of leaving them VPS-only — without granting it code-write power.
+
+**Also recorded this session (related):** the **`superbot-skill-author` meta-skill** (the
+self-extension bootstrap), and the owner's operating directives now in
+`docs/operations/hermes-operating-prompt.md`: there is always a next thing (review ideas + propose
+a continuation when nothing's obvious; the continuation handoff lives in `current-state.md` + the
+newest `.sessions/` log); reconciliation is automated (ignore it); verify-don't-assume; the
+five-sector mental model.
+
+**Home:** `docs/operations/hermes-operating-prompt.md`, `docs/operations/hermes-skills/README.md`
+(Shared operating rule), `docs/operations/hermes-skills/skill-author.md`.

--- a/scripts/hermes/build_skills.py
+++ b/scripts/hermes/build_skills.py
@@ -93,6 +93,10 @@ EXTRAS: dict[str, SkillExtras] = {
         tags=["Automation", "SuperBot", "Dispatch"],
         related=["superbot-prompt-builder", "superbot-review"],
     ),
+    "skill-author": SkillExtras(
+        tags=["Meta", "SuperBot", "SelfExtension"],
+        related=["superbot-prompt-builder"],
+    ),
 }
 
 VERSION = "1.0.0"

--- a/scripts/hermes/skills/skill-author/SKILL.md
+++ b/scripts/hermes/skills/skill-author/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: superbot-skill-author
+description: "Turn a recurring Hermes workflow into a new, well-formed, version-controlled SuperBot skill — design it, write it in the repo's skill format, regenerate the installable artifact, and open a docs-only PR so it is reviewed and committed (not left as a VPS-only scratch file)."
+version: 1.0.0
+author: "SuperBot agents"
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Meta, SuperBot, SelfExtension]
+    related_skills: [superbot-prompt-builder]
+---
+
+<!-- GENERATED — DO NOT EDIT. Source of truth: docs/operations/hermes-skills/skill-author.md. Regenerate with scripts/hermes/build_skills.py. -->
+
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+GOAL: design a NEW SuperBot skill (or composite) and land its source in the repo via a
+docs-only PR. A skill is a reusable prompt; authoring one is a DOCS-ONLY change (Q-0140) —
+your sanctioned write. You never edit code or push runtime changes.
+
+STEP 1 — JUSTIFY (read-only). Before writing anything:
+  - git -C /home/hermes/repos/superbot fetch origin main
+  - Confirm the workflow RECURS (a one-off doesn't earn a skill) and is not already covered:
+      ls docs/operations/hermes-skills/ ; grep -ril "<the-job>" docs/operations/hermes-skills/
+    If an existing skill already does this, STOP and use it instead.
+  - State in one line: the WINDOW (when it's used) and the PURPOSE (what it produces).
+
+STEP 2 — DESIGN. Decide:
+  - name: superbot-<kebab-case> (lower-case, hyphens).
+  - For an ATOM: the ordered read-only steps + the single output it produces.
+  - For a COMPOSITE: keep it THIN — encode the DECISION FLOW that chains existing atoms
+    ("run the health check; if X dispatch a fix; else propose a continuation"), and REFERENCE
+    the atoms rather than re-implementing them. Do not duplicate another skill's body.
+  - Bake in the standing rules so the skill is safe on its own:
+      * read-only by default; the only writes are docs-only PRs and the review-merge gate;
+      * anything touching code is DISPATCHED to Claude Code, never edited here;
+      * verify, don't assume (railway_vars.py / check_* / gh) — say what you verified;
+      * never print secrets; reference env vars by name only;
+      * end with one clear verdict or next step (a hint, not an action you take).
+
+STEP 3 — WRITE THE SOURCE. Create docs/operations/hermes-skills/<name>.md in the canonical shape
+  (copy an existing skill's structure exactly — e.g. session-brief.md or dispatch.md):
+      # Skill: `superbot-<name>`
+      > **Status:** `living-ledger` — <one line>.
+      **Window:** ...   **Purpose:** <one sentence — the builder lifts this verbatim>
+      **When to use:** ...


### PR DESCRIPTION
## What

Builds the Hermes **self-extension** layer and records the write-scope expansion the owner directed
in his Telegram chat with Hermes.

### 1. `superbot-skill-author` meta-skill
A new Hermes skill (`docs/operations/hermes-skills/skill-author.md` → generated `SKILL.md`; registered
in `build_skills.py` `EXTRAS` → **11 skills**). It guides Hermes to design a new skill (atom or a thin
composite), write it in the canonical format, regenerate the artifact, and **commit it as a docs-only
PR** — closing the gap where Hermes-authored skills lived only on the VPS. This is the bootstrap for
"ask Hermes to make skills" (next up: a `tick` overseer composite, authored *by* Hermes).

### 2. Q-0140 — Hermes' second sanctioned write
Hermes' scope expands from "read-only except the `review-merge` gate (Q-0117)" to **two** sanctioned
writes: review-merge **+ docs-only PRs** (a work summary, a bug/problem report, or a new skill source).
Anything touching code/runtime is still **dispatched** to Claude Code.

### 3. `hermes-operating-prompt.md` refreshed to the current model
Five-sector map (mechanism vs content), verify-don't-assume (+ Railway read, Q-0130), always-a-next-
thing + the continuation handoff (`current-state.md` ▶ + newest `.sessions/`), reconciliation-is-
automated, doc-awareness via `AGENT_ORIENTATION.md`, and the new write scope. The skill-pack README's
"Shared operating rule" updated to match.

## Verification
- `build_skills.py --check` ✓ (11 skills) · `pytest test_build_skills` ✓ (14)
- `check_docs.py --strict` ✓ · `check_quality.py --check-only` ✓
- No `disbot/` runtime code touched.

https://claude.ai/code/session_01THYNzZHw2HvBT7bjBj3u9Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01THYNzZHw2HvBT7bjBj3u9Q)_