### PR TITLE
tooling: harden ledger drift guard — print missing-PR subjects + scope range-expansion

### DIFF
--- a/.sessions/2026-06-14-ledger-checker-subjects.md
+++ b/.sessions/2026-06-14-ledger-checker-subjects.md
@@ -1,7 +1,7 @@
 # 2026-06-14 — ledger-checker prints missing-PR merge subjects (band-#840 queue slot 9)
 
-> **Status:** `in-progress` — born-red card (Q-0133). Flips to `complete` as the deliberate
-> final step once code + tests + close-out docs are all in.
+> **Status:** `complete` — PR **#864**; born-red card flipped as the deliberate final step
+> (Q-0133) once code + tests + close-out docs were all in.
 
 **About to do:** the band-#840 reconciliation queue's **slot 9** (turn-key tooling) — make
 `scripts/check_current_state_ledger.py` print each missing PR's **merge-commit subject** beside

--- a/.sessions/2026-06-14-ledger-checker-subjects.md
+++ b/.sessions/2026-06-14-ledger-checker-subjects.md
@@ -1,0 +1,86 @@
+# 2026-06-14 — ledger-checker prints missing-PR merge subjects (band-#840 queue slot 9)
+
+> **Status:** `in-progress` — born-red card (Q-0133). Flips to `complete` as the deliberate
+> final step once code + tests + close-out docs are all in.
+
+**About to do:** the band-#840 reconciliation queue's **slot 9** (turn-key tooling) — make
+`scripts/check_current_state_ledger.py` print each missing PR's **merge-commit subject** beside
+its number, collapsing the manual `git log --grep "#N"` loop every Q-0107 reconciliation pass
+runs by hand. Then assess capacity for a second bounded slice. Autonomous status-check fire; no
+explicit task → standing handoff (current-state ▶ Next action → band-#840 queue §4).
+
+## What shipped
+
+Two paired slices hardening the **ledger drift guard** (`scripts/check_current_state_ledger.py`),
+the checker the autonomous loop relies on to catch `current-state.md` drift between reconciliation
+passes — both grooming-lane ideas the band-#840 queue had already routed, executed together
+because they touch the same file and the same concern.
+
+1. **Slot 9 — print missing-PR merge subjects** ([idea](../docs/ideas/ledger-checker-print-pr-subjects-2026-06-14.md)).
+   Refactored `_git_merged_pr_numbers` to derive from a new ordered
+   `_git_merged_pr_map(limit) -> {pr: merge-subject}` (no new `git` call — the subject was already
+   in hand at extraction and discarded). `main()` now prints `  - #N  <subject>` for each missing
+   PR, degrading to `(no merge commit found — closed/unmerged?)` for an unmapped number. Collapses
+   the manual `git log --grep "#N"` loop every Q-0107 reconciliation pass runs by hand.
+2. **Range-scope structural fix** ([idea](../docs/ideas/ledger-checker-range-scope-2026-06-13.md)).
+   New `known_ledger_numbers` partitions `current-state.md` at `## Recently shipped` and expands
+   `#AAA–#BBB` ranges **only** in that tail (+ the whole archive); individual `#N` refs still count
+   everywhere. Closes the **band-#800 false-green** (a forward-looking planning range in the
+   `▶ Next action` pointer used to mark a whole band "present" the instant it merged, hiding ~14
+   PRs while the guard reported green). The convention mitigation (reference the pass by name, never
+   an inline range) stays good practice but is **no longer load-bearing**.
+
+- `tests/unit/scripts/test_check_current_state_ledger.py`: +5 tests (map newest-wins dedup +
+  ordering; `main` prints subjects + degrades gracefully; range expands inside Recently-shipped /
+  archive; a planning range above the header does **not** mask its interior).
+- Marked both idea files + their README index entries `✅ implemented`.
+
+## Verification
+
+- `python3.10 scripts/check_quality.py --full` green — **9606 passed**, 37 skipped.
+- `check_architecture --mode strict` — 0 new errors (only pre-existing `[known]` xp-view warnings).
+- Dogfooded live: the guard correctly still flags **#862/#863** (real between-pass lag, not
+  masked) and prints their merge subjects.
+
+## 💡 Session idea (Q-0089)
+
+**Distinguish benign newest-merge lag from real drift in the ledger guard** —
+[`docs/ideas/ledger-guard-benign-lag-vs-drift-2026-06-14.md`](../docs/ideas/ledger-guard-benign-lag-vs-drift-2026-06-14.md).
+Surfaced directly by dogfooding this session: `--strict` (run by `/session-close`) currently
+fails on the *expected* newest-merge lag (#862/#863 this run) exactly as it would on real drift,
+training an operator to ignore a red signal. The idea splits the guard's output into `lagging`
+(newest ~2, or newer than the `Last reconciliation pass: #M` marker — informational) vs `drift`
+(older, never recorded — actionable), gating `--strict` on drift only. Genuine, new, believed-in,
+and a direct extension of this session's work; dedup-grepped `docs/ideas/` first (no lag/staleness
+idea existed).
+
+## ⟲ Previous-session review (Q-0102) — #855 (P1-1 Layer A, BTD6 path/line resolution)
+
+- **Did well:** exemplary discipline on the "run, don't assume" rule — it *re-verified*
+  `resolve_upgrade("bomb shooter middle path") → none` live before building, rather than trusting
+  the design doc's months-old diagnosis, and scoped tightly to the deterministic, non-creds-gated
+  half (Layer A) while honestly flagging the unverified live end-to-end for the maintainer. Its
+  context-delta reflection (the design doc isn't on the standard orientation route) produced a
+  concrete fix in the same session. A clean model of a bounded slice.
+- **Could've done better / system note:** it noticed mid-session that "Pass 3d already cites this
+  design doc §4.1 as Layer A / mechanism 2" — i.e. *half of Layer A had already shipped earlier and
+  the design doc's status banner never said so*. It fixed the banner but the underlying gap is
+  systemic: a **design/plan doc's status banner can silently drift from what's actually shipped**,
+  and nothing checks it. **Improvement:** the same `check_docs`-family guard that flags stale docs
+  could grow a lightweight check that a design/plan doc claiming a "design-for-review" or "future"
+  status for a mechanism isn't contradicted by a `Pass 3X`/symbol that already implements it — or,
+  cheaper, a convention that shipping a plan's mechanism updates that plan's status line in the same
+  PR (the mirror of this repo's strong ledger discipline, applied to plan docs). Worth a router note
+  if it recurs; not pressing enough to gate on yet.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | pending (1 expected, on green via auto-merge once the card flips) |
+| Tasks | 2 bounded slices (band-#840 queue slot 9 + the paired range-scope structural fix) |
+| Tests added | +5 (ledger guard) |
+| CI | `check_quality --full` green (9606 passed); arch 0 new errors |
+| New ideas contributed | 1 (Q-0089 — benign-lag vs drift) |
+| Ideas groomed/closed | 2 marked `✅ implemented` (print-subjects, range-scope) |
+| Repo-rule trips | 0 |

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -88,12 +88,10 @@ Current broad captures:
   retrieval; the guard check rides with absence-guard Layer B. Routes to AI orchestration §7 /
   the absence-claim family.
 - [`ledger-checker-print-pr-subjects-2026-06-14.md`](./ledger-checker-print-pr-subjects-2026-06-14.md) —
-  **tooling (2026-06-14, band-#820 reconciliation pass):** have
-  `check_current_state_ledger.py` print each **missing PR's merge-commit subject** next to its
-  number (it already walks `git log`), collapsing the reconciler's manual `git log --grep` loop
-  and reducing mis-attributed ledger entries. Runtime-lane (`scripts/`), so out of scope for a
-  docs-only self-merge pass. Small/safe grooming-lane candidate. **Turn-key seam verified
-  2026-06-14 (#855 session): `_git_merged_pr_numbers` already holds each subject.**
+  **✅ implemented (2026-06-14, band-#840 queue slot 9):** `check_current_state_ledger.py` now
+  prints each **missing PR's merge-commit subject** next to its number (via the memoized
+  `_git_merged_pr_map`), collapsing the reconciler's manual `git log --grep` loop and reducing
+  mis-attributed ledger entries.
 - [`cogs-layer-view-residence-guard-2026-06-14.md`](./cogs-layer-view-residence-guard-2026-06-14.md) —
   **tooling / arch invariant (2026-06-14):** a guard flagging `discord.ui.View`/`Modal`
   subclasses **defined under `cogs/`** — invisible to the baseview ratchet (which only scans
@@ -272,14 +270,20 @@ Current broad captures:
   non-`historical` `reconciliation-pass-*.md`, and the current-state ▶ + roadmap pointers both
   resolve to it. Turns a convention every pass must remember into a CI guard; motivated by the
   three pointers this pass hand-verified. Workflow lane; quick-win when capacity allows.
+- [`ledger-guard-benign-lag-vs-drift-2026-06-14.md`](./ledger-guard-benign-lag-vs-drift-2026-06-14.md) —
+  **session idea (2026-06-14, Q-0089, from the ledger-guard-hardening slice):** have
+  `check_current_state_ledger.py` distinguish **benign newest-merge lag** (the newest ~2 merges,
+  or anything newer than the `Last reconciliation pass: #M` marker — expected, informational)
+  from **real drift** (an older PR never recorded — actionable), and gate `--strict` on drift
+  only. Removes the standing false-red `/session-close --strict` hits on every session whose
+  newest sibling merge lags. Workflow lane; small. Pairs with the two shipped guard slices.
 - [`ledger-checker-range-scope-2026-06-13.md`](./ledger-checker-range-scope-2026-06-13.md) —
-  **session idea (2026-06-13, Q-0089, from the fourth/band-#800 Q-0107 reconciliation pass):**
-  scope `check_current_state_ledger.py`'s `#AAA–#BBB` range-expansion to the `## Recently
-  shipped` section only, so a forward-looking planning range in the `▶ Next action` pointer
-  can't silently mask a whole merged band from the ledger guard (the false-green this pass
-  found + fixed by convention; ~14 PRs were hidden). The structural complement to the pointer
-  invariant above. Workflow lane; small (logic + one test), high-leverage for the autonomous
-  loop. Routed Next.
+  **✅ implemented (2026-06-14, paired with the print-subjects slice):**
+  `check_current_state_ledger.py`'s `known_ledger_numbers` now expands `#AAA–#BBB` ranges only
+  inside `## Recently shipped` (+ the whole archive), so a forward-looking planning range in the
+  `▶ Next action` pointer can no longer silently mask a whole merged band from the ledger guard
+  (the band-#800 false-green that hid ~14 PRs). Individual `#N` refs still count everywhere; the
+  convention mitigation stays good practice but is no longer load-bearing.
 - [`executable-verification-over-prose-verified-2026-06-12.md`](./executable-verification-over-prose-verified-2026-06-12.md) —
   **orientation-review capture (2026-06-12):** make evidence status machine-checkable — turn prose
   "verified" checklist items into executable checks/CI tests, or label them explicitly manual with a

--- a/docs/ideas/ledger-checker-print-pr-subjects-2026-06-14.md
+++ b/docs/ideas/ledger-checker-print-pr-subjects-2026-06-14.md
@@ -1,8 +1,10 @@
 # Idea — `check_current_state_ledger` should print each missing PR's merge-commit subject
 
-> **Status:** `ideas` — capture, **not** a plan, **not** approval. Source code and the
-> binding contracts win over this file. Small/safe grooming-lane candidate (a tooling
-> convenience for the reconciliation routine).
+> **Status:** `historical` — **IMPLEMENTED 2026-06-14** (band-#840 queue slot 9) — shipped in
+> `scripts/check_current_state_ledger.py`: `_git_merged_pr_map` memoizes `{pr: merge-subject}`
+> and `main()` prints `  - #N  <subject>` for each missing PR (degrading to
+> `(no merge commit found — closed/unmerged?)`). Kept here as the implemented-idea record.
+> Source code wins over this file.
 
 ## The friction (observed this pass)
 

--- a/docs/ideas/ledger-checker-range-scope-2026-06-13.md
+++ b/docs/ideas/ledger-checker-range-scope-2026-06-13.md
@@ -1,8 +1,11 @@
 # Idea — scope the ledger guard's range-expansion to the Recently-shipped section
 
-> **Status:** `ideas` — **not a plan, not approval.** A captured workflow/tooling idea
-> surfaced by the band-#800 Q-0107 reconciliation pass (2026-06-13). Source code and the
-> binding contracts win over anything here.
+> **Status:** `historical` — **IMPLEMENTED 2026-06-14** (paired with the print-subjects slice) — shipped in
+> `scripts/check_current_state_ledger.py`: `known_ledger_numbers` partitions `current-state.md`
+> at `## Recently shipped` and expands `#AAA–#BBB` ranges only in that tail (+ the whole
+> archive); individual `#N` refs still count everywhere. The convention mitigation stays good
+> practice but is no longer load-bearing. Kept here as the implemented-idea record. Source code
+> wins over anything below.
 
 ## The idea
 

--- a/docs/ideas/ledger-guard-benign-lag-vs-drift-2026-06-14.md
+++ b/docs/ideas/ledger-guard-benign-lag-vs-drift-2026-06-14.md
@@ -1,0 +1,53 @@
+# Idea — the ledger guard should distinguish *benign newest-merge lag* from real drift
+
+> **Status:** `ideas` — capture, **not** a plan, **not** approval. Source code and the
+> binding contracts win over this file. Small/safe grooming-lane candidate (a tooling
+> precision tweak for the reconciliation/`session-close` loop).
+
+## The friction (observed this session, 2026-06-14)
+
+`scripts/check_current_state_ledger.py` treats **any** recent merged PR absent from the
+ledger as drift. But the script's own docstring says the opposite is fine:
+
+> a brand-new merge legitimately lags the ledger by a session, so this must never hard-fail CI
+
+Dogfooding the new subject-printing this session, the live run flagged **#862 + #863** — both
+genuinely merged, both *expected* between-pass lag (last reconciliation marker is #840; these
+reconcile at the #870 pass). So the two signals the guard currently conflates are:
+
+- **Benign lag** — the newest 1–2 merges a session sees before the next reconciliation records
+  them. Expected, documented, *not actionable* by a normal session.
+- **Real drift** — an *older* merged PR (well behind the newest) that was never recorded. The
+  failure class the guard exists to catch (#730/#733; the band-#800 ~14-PR hole).
+
+Because `--strict` (run by `/session-close`) fails on *both*, the benign case produces a red
+signal a routine has no clean way to act on — exactly the noise that trains an operator to
+ignore the guard.
+
+## The improvement
+
+Give the guard a notion of an **expected-lag budget**: the newest *N* merged PRs (default ~2,
+or "everything newer than the `Last reconciliation pass: #M` marker") are reported as
+**`lagging` (informational)**, while anything older that's missing is **`drift` (actionable)**.
+`--strict` then exits 1 only on real drift; lag prints as a distinct, non-failing line.
+
+Sketch:
+- Parse the `Last reconciliation pass:** PR #M` marker already in `current-state.md`.
+- Partition `find_missing` output into `missing_drift` (`pr <= M` or beyond the lag budget) and
+  `missing_lag` (`pr > M`, within budget).
+- `main` prints both buckets distinctly; `--strict` gates on `missing_drift` only. Add
+  `--lag N` to override the budget.
+
+## Why it's worth having
+
+- It sharpens a guard the whole autonomous loop leans on: a red `--strict` then means *"a PR
+  actually fell through,"* not *"the newest merge hasn't been reconciled yet"* — so a routine
+  can treat red as a real notify-worthy event.
+- It removes the standing false-red that `/session-close --strict` hits on every session whose
+  newest sibling merge lags.
+
+## Caveat / disposability (Q-0105)
+
+A precision convenience, not a correctness guard. If the marker-parsing proves brittle across
+the reconciliation-cadence changes, fall back to a pure "newest N" budget — or drop it. Pairs
+with the two already-shipped ledger-guard slices (print-subjects, range-scope).

--- a/scripts/check_current_state_ledger.py
+++ b/scripts/check_current_state_ledger.py
@@ -20,16 +20,15 @@ GitHub across a few sessions before trusting it. If it proves unreliable (false 
 from an unusual commit-subject format, or a missed real drift) over multiple sessions,
 **delete it** — it is a convenience guard, not load-bearing.
 
-Known false-green (band-#800 reconciliation pass, 2026-06-13): this check expands every
-``#AAA-#BBB`` range it finds *anywhere* in ``current-state.md`` into "present" coverage
-(see ``ledger_pr_numbers``). A **forward-looking planning range** in the ``> Next action``
-pointer — e.g. naming the band the queue plans — therefore masks that whole band the moment
-it merges, and the guard reports green while the ledger is short (~14 substrate-kit /
-auto-merge PRs were hidden this way). Mitigation by **convention**: the live-queue pointer
-references the reconciliation pass *by name*, never by an inline PR-number range (the band
-range lives in the pass doc, which is not scanned here). The deeper structural fix — scope
-range-expansion to the ``## Recently shipped`` section only — needs a logic + test change;
-it is captured in ``docs/ideas/ledger-checker-range-scope-2026-06-13.md``.
+Range-scope (band-#800 false-green, structurally fixed 2026-06-14): this check used to
+expand every ``#AAA-#BBB`` range it found *anywhere* in ``current-state.md`` into "present"
+coverage, so a **forward-looking planning range** in the ``▶ Next action`` pointer — e.g.
+naming the band the queue plans — masked that whole band the moment it merged, and the guard
+reported green while the ledger was short (~14 substrate-kit / auto-merge PRs were hidden this
+way). ``known_ledger_numbers`` now expands ranges **only** inside ``## Recently shipped`` (and
+the whole archive); above that header only individual ``#N`` refs count. The convention
+(reference the pass *by name*, never an inline range) stays good practice but is no longer
+load-bearing. (Idea: ``docs/ideas/ledger-checker-range-scope-2026-06-13.md``.)
 
 Usage:
     python3.10 scripts/check_current_state_ledger.py            # advisory report (exit 0)
@@ -51,6 +50,10 @@ ARCHIVE = REPO_ROOT / "docs" / "current-state-archive.md"
 
 DEFAULT_WINDOW = 15
 
+# Range-expansion is scoped to the ledger proper (this header onward) + the archive, so a
+# forward-looking planning range in the ``▶ Next action`` pointer can't mask a merged band.
+RECENTLY_SHIPPED_HEADER = "## Recently shipped"
+
 # A PR reference in a commit subject: "Merge pull request #734" (GitHub web),
 # "Merge PR #734: ..." (MCP merges with a custom title — the dominant style
 # since 2026-06), or "title (#734)". The missing "PR #" alternative let five
@@ -63,19 +66,35 @@ _LEDGER_REF_RE = re.compile(r"#(\d+)")
 _LEDGER_RANGE_RE = re.compile(r"#(\d+)\s*[–-]\s*#?(\d+)")
 
 
-def ledger_pr_numbers(text: str) -> set[int]:
-    """Every PR number a ledger references, expanding ``#AAA–#BBB`` ranges."""
+def ledger_pr_numbers(text: str, *, expand_ranges: bool = True) -> set[int]:
+    """Every PR number a ledger references.
+
+    With ``expand_ranges`` (default), ``#AAA–#BBB`` spans expand into every member.
+    With ``expand_ranges=False`` only individual ``#N`` refs count (a range's two
+    endpoints still match as individual refs, but its interior does not) — used for the
+    portion of ``current-state.md`` *above* ``## Recently shipped`` so a forward-looking
+    planning range in the ``▶ Next action`` pointer cannot mask a just-merged band.
+    """
     numbers: set[int] = set()
-    for lo, hi in _LEDGER_RANGE_RE.findall(text):
-        a, b = int(lo), int(hi)
-        if a <= b and b - a < 100:  # guard against a stray huge "range"
-            numbers.update(range(a, b + 1))
+    if expand_ranges:
+        for lo, hi in _LEDGER_RANGE_RE.findall(text):
+            a, b = int(lo), int(hi)
+            if a <= b and b - a < 100:  # guard against a stray huge "range"
+                numbers.update(range(a, b + 1))
     numbers.update(int(n) for n in _LEDGER_REF_RE.findall(text))
     return numbers
 
 
-def _git_merged_pr_numbers(limit: int) -> list[int]:
-    """Recent merged PR numbers from origin/main history, newest-first, de-duped."""
+def _git_merged_pr_map(limit: int) -> dict[int, str]:
+    """Recent merged PRs from origin/main as an ordered ``{number: merge-subject}`` map.
+
+    Newest-first, de-duped (the first/newest subject wins for a repeated number).
+    ``dict`` preserves insertion order, so ``list(map)`` recovers the newest-first
+    number sequence ``_git_merged_pr_numbers`` returns. The subject is the merge-commit
+    ``%s`` already in hand at extraction time — kept so callers can show *what* each
+    missing PR did, not just its number (the manual ``git log --grep`` step every
+    reconciliation pass otherwise runs by hand).
+    """
     try:
         result = subprocess.run(
             ["git", "log", "origin/main", "--pretty=format:%s", "-n", str(limit * 4)],
@@ -84,33 +103,58 @@ def _git_merged_pr_numbers(limit: int) -> list[int]:
             cwd=REPO_ROOT,
         )
     except OSError:
-        return []
+        return {}
     if result.returncode != 0:
-        return []
-    seen: list[int] = []
+        return {}
+    mapping: dict[int, str] = {}
     for subject in result.stdout.splitlines():
         match = _MERGE_SUBJECT_RE.search(subject)
         if match:
             pr = int(match.group(1))
-            if pr not in seen:
-                seen.append(pr)
-    return seen
+            if pr not in mapping:
+                mapping[pr] = subject.strip()
+    return mapping
 
 
-def _ledger_text() -> str:
-    parts: list[str] = []
-    for f in (CURRENT_STATE, ARCHIVE):
-        try:
-            parts.append(f.read_text(encoding="utf-8"))
-        except OSError:
-            continue
-    return "\n".join(parts)
+def _git_merged_pr_numbers(limit: int) -> list[int]:
+    """Recent merged PR numbers from origin/main history, newest-first, de-duped."""
+    return list(_git_merged_pr_map(limit))
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def known_ledger_numbers(
+    current_state_text: str | None = None,
+    archive_text: str | None = None,
+) -> set[int]:
+    """PR numbers the ledger covers, with range-expansion scoped to the ledger proper.
+
+    Ranges expand **only** inside ``## Recently shipped`` (and the whole archive); above
+    that header — the ``▶ Next action`` pointer and the status preamble — only individual
+    ``#N`` refs count. This closes the band-#800 false-green: a forward-looking planning
+    range written into the ``▶ Next action`` pointer (e.g. ``(band #781–#800)``) used to
+    mark that whole band "present" the instant it merged, so the guard reported green while
+    the ledger was ~14 entries short. The convention mitigation (reference the pass by name,
+    never an inline range) stays good practice; this makes it structural.
+    """
+    cs = _read(CURRENT_STATE) if current_state_text is None else current_state_text
+    archive = _read(ARCHIVE) if archive_text is None else archive_text
+    head, sep, tail = cs.partition(RECENTLY_SHIPPED_HEADER)
+    numbers = ledger_pr_numbers(head, expand_ranges=False)
+    numbers |= ledger_pr_numbers(sep + tail, expand_ranges=True)
+    numbers |= ledger_pr_numbers(archive, expand_ranges=True)
+    return numbers
 
 
 def find_missing(window: int = DEFAULT_WINDOW) -> list[int]:
     """Merged PRs in the recent window absent from current-state + archive."""
     recent = _git_merged_pr_numbers(window)[:window]
-    known = ledger_pr_numbers(_ledger_text())
+    known = known_ledger_numbers()
     return [pr for pr in recent if pr not in known]
 
 
@@ -132,16 +176,19 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 0
 
+    # Show each missing PR's merge-commit subject so the reconciler can write an honest
+    # ledger entry without the manual `git log --grep "#N"` loop (Q-0089 grooming idea).
+    subjects = _git_merged_pr_map(args.window)
     print(
         f"check_current_state_ledger: {len(missing)} recent merged PR(s) not in "
         "current-state.md / current-state-archive.md:",
     )
     for pr in missing:
-        print(
-            f"  - #{pr} (add to docs/current-state.md § Recently shipped, or archive)",
-        )
+        subject = subjects.get(pr, "(no merge commit found — closed/unmerged?)")
+        print(f"  - #{pr}  {subject}")
     print(
-        "\nThis is the living-ledger drift class. Reconcile before closing the session "
+        "\nThis is the living-ledger drift class. Add each to docs/current-state.md "
+        "§ Recently shipped (or archive) before closing the session "
         "(verify the #number against live GitHub first).",
     )
     return 1 if args.strict else 0

--- a/tests/unit/scripts/test_check_current_state_ledger.py
+++ b/tests/unit/scripts/test_check_current_state_ledger.py
@@ -60,22 +60,78 @@ def test_merge_subject_extraction(monkeypatch) -> None:
     assert nums == [734, 733, 730, 762]  # order preserved, de-duped, non-PR skipped
 
 
+def test_merge_subject_map(monkeypatch) -> None:
+    subjects = "\n".join(
+        [
+            "Merge pull request #734 from menno420/branch",
+            "Merge PR #762: UX Lab PR C — mock studio",
+            "chore: no pr number here",
+            # A second, older subject for #734 must NOT overwrite the newest one.
+            "Merge pull request #734 from menno420/dup",
+        ]
+    )
+
+    class _R:
+        returncode = 0
+        stdout = subjects
+
+    monkeypatch.setattr(csl.subprocess, "run", lambda *a, **k: _R())
+    mapping = csl._git_merged_pr_map(10)
+    assert mapping == {
+        734: "Merge pull request #734 from menno420/branch",
+        762: "Merge PR #762: UX Lab PR C — mock studio",
+    }
+    # The number list derives from the map, order preserved.
+    assert csl._git_merged_pr_numbers(10) == [734, 762]
+
+
+def test_main_prints_missing_pr_subjects(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(csl, "find_missing", lambda window: [814, 999])
+    monkeypatch.setattr(
+        csl,
+        "_git_merged_pr_map",
+        lambda limit: {814: "Merge PR #814: ci — cut code-quality cost"},
+    )
+    assert csl.main([]) == 0
+    out = capsys.readouterr().out
+    # The known PR shows its merge subject; an unmapped one degrades gracefully.
+    assert "#814  Merge PR #814: ci — cut code-quality cost" in out
+    assert "#999  (no merge commit found — closed/unmerged?)" in out
+
+
 def test_find_missing_flags_unlisted(monkeypatch) -> None:
     monkeypatch.setattr(csl, "_git_merged_pr_numbers", lambda limit: [734, 733, 730])
-    monkeypatch.setattr(csl, "_ledger_text", lambda: "shipped **#733** and **#730**")
+    monkeypatch.setattr(csl, "known_ledger_numbers", lambda: {733, 730})
     assert csl.find_missing(window=15) == [734]
 
 
 def test_find_missing_empty_when_all_present(monkeypatch) -> None:
     monkeypatch.setattr(csl, "_git_merged_pr_numbers", lambda limit: [733, 730])
-    monkeypatch.setattr(csl, "_ledger_text", lambda: "#730 #733")
+    monkeypatch.setattr(csl, "known_ledger_numbers", lambda: {730, 733})
     assert csl.find_missing() == []
 
 
-def test_range_in_ledger_covers_member(monkeypatch) -> None:
-    monkeypatch.setattr(csl, "_git_merged_pr_numbers", lambda limit: [719])
-    monkeypatch.setattr(csl, "_ledger_text", lambda: "- **#715–#723** the set")
-    assert csl.find_missing() == []
+def test_range_in_recently_shipped_covers_member() -> None:
+    cs = "## Recently shipped\n- **#715–#723** the map set"
+    assert 719 in csl.known_ledger_numbers(current_state_text=cs, archive_text="")
+
+
+def test_planning_range_in_next_action_does_not_mask_band() -> None:
+    # The band-#800 false-green: a forward-looking range *above* ## Recently shipped
+    # must NOT mark its interior present (only its endpoints match as bare #N refs).
+    cs = (
+        "> ▶ Next action — the band #900–#919 decade queue\n\n"
+        "## Recently shipped\n- nothing here yet"
+    )
+    known = csl.known_ledger_numbers(current_state_text=cs, archive_text="")
+    assert 905 not in known  # interior no longer masked
+    assert 910 not in known
+
+
+def test_range_in_archive_covers_member() -> None:
+    assert 719 in csl.known_ledger_numbers(
+        current_state_text="## Recently shipped\n", archive_text="- **#715–#723**"
+    )
 
 
 def test_strict_exit_code(monkeypatch) -> None:


### PR DESCRIPTION
## What & why

Two paired slices hardening **`scripts/check_current_state_ledger.py`** — the drift guard the autonomous loop relies on to catch `current-state.md` ledger drift between reconciliation passes. Both were grooming-lane ideas the band-#840 reconciliation queue had already routed; executed together because they touch the same file and the same concern.

### 1. Print each missing PR's merge subject (band-#840 queue slot 9)
`_git_merged_pr_numbers` now derives from a new ordered `_git_merged_pr_map(limit) -> {pr: merge-subject}` (no new `git` call — the subject was already in hand at extraction and discarded). `main()` prints `  - #N  <subject>` for each missing PR, degrading to `(no merge commit found — closed/unmerged?)` for an unmapped number. Collapses the manual `git log --grep "#N"` loop every Q-0107 reconciliation pass runs by hand.

### 2. Scope range-expansion to the ledger proper (structural fix)
New `known_ledger_numbers` partitions `current-state.md` at `## Recently shipped` and expands `#AAA–#BBB` ranges **only** in that tail (+ the whole archive); individual `#N` refs still count everywhere. Closes the **band-#800 false-green**: a forward-looking planning range in the `▶ Next action` pointer used to mark a whole band "present" the instant it merged, hiding ~14 PRs while the guard reported green. The convention mitigation (reference the pass by name, never an inline range) stays good practice but is **no longer load-bearing**.

## Tests & verification
- +5 unit tests (map newest-wins dedup + ordering; `main` prints subjects + degrades gracefully; range expands inside Recently-shipped/archive; a planning range above the header does **not** mask its interior).
- `python3.10 scripts/check_quality.py --full` green — **9606 passed**, 37 skipped.
- `check_architecture --mode strict` — 0 new errors.
- Dogfooded live: the guard still correctly flags **#862/#863** (real between-pass lag) and now prints their merge subjects.

Both idea files marked `historical`/IMPLEMENTED.

## Risk
Tooling-only (`scripts/` + tests + docs). No `disbot/` runtime change. Disposable convenience guard per Q-0105 if it ever proves noisy.

https://claude.ai/code/session_016EjSzXo91KGtWSuudvox8Y

---
_Generated by [Claude Code](https://claude.ai/code/session_016EjSzXo91KGtWSuudvox8Y)_