### PR TITLE
fix(hermes): robust routine_fire.py dispatch helper + code-write scope (Q-0141) + bounded-work prompt

### DIFF
--- a/.sessions/2026-06-14-routine-fire-helper.md
+++ b/.sessions/2026-06-14-routine-fire-helper.md
@@ -1,16 +1,51 @@
 # Session: routine_fire.py — robust Claude Code dispatch helper
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-**Branch:** `claude/hermes-routine-fire` · **PR:** TBD · **Date:** 2026-06-14 · **Type:** ops/dispatch bugfix (manual)
+**Branch:** `claude/hermes-routine-fire` · **PR:** #864 (DRAFT — held for comparison) · **Date:** 2026-06-14 · **Type:** ops/dispatch bugfix (manual)
 
-## What I'm about to do
-Live-testing Hermes' new operating prompt, Hermes diagnosed a REAL bug: the dispatch skill's inline
-`curl -d "$(python3 -c ... "$WORK_ORDER")"` is shell-quoting-fragile for multi-line work orders, and
-tried to fix it by writing `scripts/hermes/routine_fire.py` itself — which crosses its docs-only
-write boundary (Q-0140: code → dispatch to Claude Code). Correct resolution, wrong hands. Build the
-helper properly here (the canonical version): `scripts/hermes/routine_fire.py`, stdlib-only, reads the
-work order from **stdin** (zero shell quoting), loads `CLAUDE_ROUTINE_*` from env or
-`~/.hermes/routine.env`, POSTs `{"text": …}`, prints the session URL, never prints the token,
-`--dry-run` to preview. Point `dispatch.md` STEP 4 at it + regen SKILL.md + test. Route the
-"may Hermes author its own small tooling scripts?" boundary question to a DISCUSS Q-block.
+## What this session did
+Live-testing Hermes' new operating prompt, Hermes diagnosed a **real bug** — the dispatch skill's
+inline `curl -d "$(python3 -c … "$WORK_ORDER")"` is shell-quoting-fragile for multi-line work orders
+— and started fixing it by writing `routine_fire.py` itself. The owner then **decided Hermes may
+write its own code** (Q-0141), turning this into a "nice test": both Hermes and I build the helper.
+
+### Shipped (my reference version)
+- **`scripts/hermes/routine_fire.py`** — stdlib-only. Work order on **stdin** (zero shell quoting),
+  loads `CLAUDE_ROUTINE_*` from env or `~/.hermes/routine.env`, POSTs `{"text": …}`, prints
+  `Fired. Watch: <session_url>`, **never prints the token**, `--dry-run` to preview the request
+  (token redacted). 7 unit tests; dry-run smoke proved a multi-line/quoted/`$var` order passes clean.
+- **`dispatch.md` STEP 4** now fires via the helper (+ regenerated SKILL.md).
+- **Q-0141** — Hermes' write scope expands from docs-only (Q-0140) to **code, via PRs (CI-gated)**;
+  prefer dispatch for big/risky changes, write small self-tooling directly; never push to main /
+  mutate prod outside gates. Operating prompt (WHO YOU ARE / WHAT YOU MAY WRITE / SAFETY) + skill-pack
+  README updated to match.
+
+### Opened as a DRAFT on purpose
+The owner is running a comparison — Hermes is authoring its own `routine_fire.py` in parallel. This PR
+is held (draft → won't auto-merge) so the owner can compare both and merge the better one (or a blend).
+
+### Verified
+`pytest test_routine_fire` 7 ✓ · `build_skills --check` 11 ✓ · `check_docs --strict` ✓ · `check_quality --check-only` ✓.
+
+## 💡 Session idea (Q-0089)
+**`routine_fire.py --log`**: append each fire (work-order summary + returned `session_url` + timestamp)
+to `~/.hermes/cron-output/dispatches.jsonl` — a lightweight audit trail of what Hermes dispatched and
+where it went. Directly feeds the `routine-activity-visibility` gap (no at-a-glance "what did Hermes
+fire?" today). Small, opt-in flag. Dedup-checked: no existing dispatch-log idea.
+
+## ⟲ Previous-session review (Q-0102)
+Reviewing **#863 (skill-author + Q-0140):** clean build of the self-extension layer. **What it
+missed:** it set Hermes' boundary as a *hard* "code → always dispatch, never edit" — which the owner
+**reversed within the hour** (Q-0141) once he weighed Hermes' capability (StepFun Step 3.7 Flash,
+~74.4% SWE-bench). **System improvement:** when defining an agent's capability boundary before trust
+is calibrated, pair it with an explicit **"revisit when calibrated"** switch (like review-merge's
+ADVISORY→TRUSTED) rather than a hard rule — so widening it is a one-line flip, not a multi-doc rewrite
+(this session). Set boundaries conservative-but-revisable, not carved.
+
+## Doc audit (Q-0104)
+`check_docs --strict` ✓ · `build_skills --check` ✓ · Q-0141 recorded with provenance ·
+operating-prompt / README / dispatch.md mutually consistent on the new write scope · quality green.
+**Grooming (Q-0015):** unblocked the dispatch seam of the autonomous loop — `routine_fire.py` makes
+`/fire` robust, which is what the dispatch-bridge / autonomous-loop-vision needed to actually fire
+reliably.

--- a/.sessions/2026-06-14-routine-fire-helper.md
+++ b/.sessions/2026-06-14-routine-fire-helper.md
@@ -2,7 +2,7 @@
 
 > **Status:** `complete`
 
-**Branch:** `claude/hermes-routine-fire` · **PR:** #864 (DRAFT — held for comparison) · **Date:** 2026-06-14 · **Type:** ops/dispatch bugfix (manual)
+**Branch:** `claude/hermes-routine-fire` · **PR:** #865 (DRAFT — held for comparison) · **Date:** 2026-06-14 · **Type:** ops/dispatch bugfix (manual)
 
 ## What this session did
 Live-testing Hermes' new operating prompt, Hermes diagnosed a **real bug** — the dispatch skill's

--- a/.sessions/2026-06-14-routine-fire-helper.md
+++ b/.sessions/2026-06-14-routine-fire-helper.md
@@ -1,0 +1,16 @@
+# Session: routine_fire.py — robust Claude Code dispatch helper
+
+> **Status:** `in-progress`
+
+**Branch:** `claude/hermes-routine-fire` · **PR:** TBD · **Date:** 2026-06-14 · **Type:** ops/dispatch bugfix (manual)
+
+## What I'm about to do
+Live-testing Hermes' new operating prompt, Hermes diagnosed a REAL bug: the dispatch skill's inline
+`curl -d "$(python3 -c ... "$WORK_ORDER")"` is shell-quoting-fragile for multi-line work orders, and
+tried to fix it by writing `scripts/hermes/routine_fire.py` itself — which crosses its docs-only
+write boundary (Q-0140: code → dispatch to Claude Code). Correct resolution, wrong hands. Build the
+helper properly here (the canonical version): `scripts/hermes/routine_fire.py`, stdlib-only, reads the
+work order from **stdin** (zero shell quoting), loads `CLAUDE_ROUTINE_*` from env or
+`~/.hermes/routine.env`, POSTs `{"text": …}`, prints the session URL, never prints the token,
+`--dry-run` to preview. Point `dispatch.md` STEP 4 at it + regen SKILL.md + test. Route the
+"may Hermes author its own small tooling scripts?" boundary question to a DISCUSS Q-block.

--- a/docs/operations/hermes-operating-prompt.md
+++ b/docs/operations/hermes-operating-prompt.md
@@ -43,6 +43,19 @@ THE REPO
 - /home/hermes/repos/superbot · default branch main · GitHub menno420/superbot.
 - Before any task: git -C /home/hermes/repos/superbot fetch origin main (read-only), then read.
 
+WORK IN BOUNDED STEPS — you lose the thread on long sessions, so design around it
+- ONE finite objective per session, with a clear done-condition. If a task balloons past ~15-20
+  tool calls or sprawls across many subsystems, STOP: dispatch the big part to Claude Code, or
+  hand me a crisp checkpoint with a single recommended next step. Never spin in place.
+- Watch your context window (~256K). A long-running session re-sends a huge history and you START
+  FORGETTING — when /status shows cumulative tokens approaching the window, finish up and tell me
+  to /new. Prefer a fresh short session per task over one sprawling one.
+- DON'T REINVENT. Before building anything: fetch main, then grep scripts/ + the skill pack +
+  current-state to see if it already exists. Reuse the existing helper (e.g.
+  scripts/hermes/routine_fire.py) — never write your own copy of something already there.
+- NO LOOSE ARTIFACTS. Anything you create goes on a branch + commit + PR (Q-0141). Never leave
+  untracked files sitting in the working tree "for now" — stage and PR it, or don't write it.
+
 EVERYTHING IS DOCUMENTED AND LINKED — that is not true of other repos, so use it
 - docs/AGENT_ORIENTATION.md is your MAP: it tells you which doc holds which kind of information.
   Learn it so you can jump straight to the right doc instead of searching.

--- a/docs/operations/hermes-operating-prompt.md
+++ b/docs/operations/hermes-operating-prompt.md
@@ -26,15 +26,18 @@ are safe even without this loaded — but loading it makes every ad-hoc prompt s
 You are Hermes, the mobile control plane for the SuperBot project.
 
 WHO YOU ARE
-- A READ-ONLY repo / planning / diagnostic / dispatch / review assistant. The BUILDER is
-  Claude Code, not you. You orient, verify, diagnose, plan, dispatch, and review.
+- A repo / planning / diagnostic / dispatch / review / contributor agent. Claude Code is the
+  PRIMARY builder; you orient, verify, diagnose, plan, dispatch, review — and may contribute
+  changes yourself through PRs (see WHAT YOU MAY WRITE).
 
-WHAT YOU MAY WRITE (everything else is read-only)
-- A DOCS-ONLY PR, and only that — for (a) a summary of work you verified, (b) a bug/problem
-  report from me or from Discord, or (c) a new skill source (via superbot-skill-author).
-  Docs-only PRs go through CI like any other.  (Q-0140)
+WHAT YOU MAY WRITE (Q-0140, Q-0141)
+- You may author changes through PRs (CI-gated): docs, bug reports, work summaries, new skill
+  sources, and CODE — including your own small self-tooling (e.g. dispatch helpers like
+  scripts/hermes/routine_fire.py).
+- For BIG or risky code changes, prefer to DISPATCH to Claude Code: it is the primary builder,
+  runs under the full CI mirror, and you yourself are weaker on long 20+-tool-call loops. Write
+  code directly when it is small, self-contained, and you can verify it; otherwise hand it off.
 - Merge a PR you have independently reviewed (the review-merge gate, Q-0117) — once calibrated.
-- ANYTHING that touches code -> dispatch a Claude Code work order. You never edit code or push.
 
 THE REPO
 - /home/hermes/repos/superbot · default branch main · GitHub menno420/superbot.
@@ -79,7 +82,8 @@ YOUR MEMORY (lean on the repo, not your head)
   your cron-output files. Read on demand.
 
 SAFETY
-- Never edit code, push, or merge (except review-merge once TRUSTED). Never print secrets/tokens.
+- Never push straight to main — everything you write goes through a PR + CI. Never merge except
+  the review-merge gate once TRUSTED. Never print secrets/tokens.
 - Railway/Neon: READ for verification is fine (Q-0130); do not mutate production unless I
   explicitly direct it. If unsure whether an action is a mutation, assume it is and ask.
 

--- a/docs/operations/hermes-skills/README.md
+++ b/docs/operations/hermes-skills/README.md
@@ -73,14 +73,15 @@ cron wiring needed.
 
 ## Shared operating rule (every skill)
 
-Skills default to **read-only**, and Hermes never edits runtime code, pushes runtime
-changes, or accesses production secrets. There are exactly **two sanctioned writes**:
+Most skills are **read-only**. Hermes contributes through **PRs (CI-gated)** and may author
+**code** as well as docs (Q-0141), under two standing rules:
 
-1. **The `review-merge` gate** (Q-0117) — merging a PR Hermes has independently reviewed.
-2. **Docs-only PRs** (Q-0140) — Hermes may author a docs-only PR directly: a work summary,
-   a bug/problem report, or a new skill source (`skill-author`). Anything touching code is
-   **dispatched** to Claude Code, never edited by Hermes.
+1. **Prefer dispatch for big/risky code** — Claude Code is the primary builder and runs the
+   full CI mirror; write code directly only when it's small, self-contained, and verifiable
+   (e.g. your own dispatch tooling like `routine_fire.py`).
+2. **The `review-merge` gate** (Q-0117) is Hermes' merge action — once calibrated.
 
-If a skill produces an implementation prompt, the prompt is an artifact for Claude Code —
-Hermes does not execute it. Reading Railway env vars / logs for verification is sanctioned
-(Q-0130); mutating production config is not, unless the owner explicitly directs it.
+Hermes never pushes straight to `main` and never mutates production config (Railway/Neon)
+outside the gates unless the owner directs it. Reading Railway env vars / logs for
+verification is sanctioned (Q-0130). If a skill produces an implementation prompt, that
+prompt is an artifact for Claude Code — Hermes does not execute it.

--- a/docs/operations/hermes-skills/dispatch.md
+++ b/docs/operations/hermes-skills/dispatch.md
@@ -54,19 +54,16 @@ STEP 3 — ASSEMBLE THE WORK ORDER (the `text` payload). Keep it tight and self-
 STEP 4 — GATE + DISPATCH:
   - SHOW me the assembled work order and the exact curl first. Wait for my "go" unless I
     already said "dispatch it" in this conversation.
-  - Load the routine secrets, then fire (never print the token). The verified call shape
-    (Claude Code Routines, research preview) needs the anthropic-version header too:
-      set -a; . "$HOME/.hermes/routine.env" 2>/dev/null; set +a
-      curl -sS -X POST "$CLAUDE_ROUTINE_FIRE_URL" \
-        -H "Authorization: Bearer $CLAUDE_ROUTINE_TOKEN" \
-        -H "anthropic-beta: $CLAUDE_ROUTINE_BETA" \
-        -H "anthropic-version: $CLAUDE_ROUTINE_VERSION" \
-        -H "Content-Type: application/json" \
-        -d "$(python3 -c 'import json,sys; print(json.dumps({"text": sys.argv[1]}))' "$WORK_ORDER")"
-  - A success returns JSON with claude_code_session_url — report that link so I can watch
-    the run. If CLAUDE_ROUTINE_TOKEN is unset (no ~/.hermes/routine.env), DO NOT fire — print
-    the work order + curl and tell me to set up the bridge (hermes-dispatch-bridge.md) or
-    paste the order into a session myself.
+  - Fire it with the helper — the work order goes in on STDIN, so the shell never parses it
+    (no quoting failures on multi-line orders with quotes/newlines). It loads the
+    CLAUDE_ROUTINE_* config from the env or ~/.hermes/routine.env and never prints the token:
+      printf '%s' "$WORK_ORDER" | python3 scripts/hermes/routine_fire.py
+      # preview the exact request first (token redacted), without firing:
+      printf '%s' "$WORK_ORDER" | python3 scripts/hermes/routine_fire.py --dry-run
+  - On success it prints `Fired. Watch: <claude_code_session_url>` — report that link so I can
+    watch the run. If the CLAUDE_ROUTINE_* config is missing, it exits non-zero and says so;
+    then DO NOT fire — show the work order + the --dry-run output and tell me to set up the
+    bridge (hermes-dispatch-bridge.md) or paste the order into a session myself.
 
 STEP 5 — REPORT: confirm the fire response (run id / status). Tell me the routine will open a
   claude/ PR; offer to watch it with `superbot-repo-health` / `log-triage` and to review it

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -5281,3 +5281,32 @@ five-sector mental model.
 
 **Home:** `docs/operations/hermes-operating-prompt.md`, `docs/operations/hermes-skills/README.md`
 (Shared operating rule), `docs/operations/hermes-skills/skill-author.md`.
+
+---
+
+### Q-0141 — Hermes may write code (not docs-only); + routine_fire.py dispatch helper (2026-06-14)
+
+> **DECISION 2026-06-14 (owner-directed in-session).** While live-testing Hermes' new operating
+> prompt, Hermes diagnosed a real bug (the dispatch curl is shell-quoting-fragile for multi-line
+> work orders) and started writing `scripts/hermes/routine_fire.py` itself — crossing the Q-0140
+> docs-only boundary. Asked the owner whether to hold that line; owner answered: *"yes it may write
+> its own code, I also think it can be pretty capable"* (Hermes runs StepFun Step 3.7 Flash,
+> ~74.4% SWE-bench).
+
+**Decision.** Hermes' write scope **expands beyond docs-only to code**, via **PRs (CI-gated)**:
+- It may author code — including its own small self-tooling — through PRs; it never pushes to `main`
+  and never mutates production config outside the gates.
+- It should still **prefer to DISPATCH big/risky code to Claude Code** (the primary builder, full CI
+  mirror; Hermes is self-admittedly weaker on long 20+-tool-call loops). Write directly when small,
+  self-contained, verifiable.
+- `review-merge` (Q-0117) remains its merge action (calibrating). Q-0140's docs-only framing is
+  superseded by this broader scope; the *content* (Hermes may PR work summaries / bug reports / skill
+  sources) still holds.
+
+**Also shipped:** `scripts/hermes/routine_fire.py` — the canonical robust dispatch helper (work order
+on stdin → no shell quoting; loads CLAUDE_ROUTINE_* from env/`~/.hermes/routine.env`; never prints the
+token; `--dry-run`). The `superbot-dispatch` skill now fires via it. **Opened as a DRAFT PR on purpose:
+the owner is running a "nice test" — Hermes is authoring its own version in parallel, to be compared.**
+
+**Home:** `docs/operations/hermes-operating-prompt.md`, `docs/operations/hermes-skills/README.md`,
+`scripts/hermes/routine_fire.py`, `docs/operations/hermes-skills/dispatch.md`.

--- a/scripts/hermes/routine_fire.py
+++ b/scripts/hermes/routine_fire.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Fire a Claude Code routine work order — a robust replacement for the inline curl.
+
+Why this exists (owner-directed 2026-06-14): the ``superbot-dispatch`` skill built the
+``/fire`` request inline as ``curl ... -d "$(python3 -c '...json.dumps...' "$WORK_ORDER")"``,
+which is shell-quoting-fragile for multi-line work orders containing quotes/newlines
+(Hermes hit the failure live). This helper takes the work order on **stdin** — so the
+shell never parses it — loads the ``CLAUDE_ROUTINE_*`` config from the environment or
+``~/.hermes/routine.env``, POSTs ``{"text": <work order>}``, and prints the response (the
+``claude_code_session_url``). It never prints the token.
+
+Usage:
+    printf '%s' "$WORK_ORDER" | python3 scripts/hermes/routine_fire.py
+    python3 scripts/hermes/routine_fire.py --file work_order.txt
+    python3 scripts/hermes/routine_fire.py --dry-run < work_order.txt   # preview, don't fire
+
+Pure stdlib (urllib) so it runs on the Hermes VPS with no extra install.
+
+Provenance + reliability (Q-0105): added 2026-06-14, owner-directed; the dispatch bug was
+diagnosed live by Hermes. UNVERIFIED until a real fire succeeds end-to-end — confirm the
+first dispatch returns a session URL before trusting it. Delete/revise if it misfires.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+_REQUIRED = ("CLAUDE_ROUTINE_FIRE_URL", "CLAUDE_ROUTINE_TOKEN")
+_OPTIONAL = ("CLAUDE_ROUTINE_BETA", "CLAUDE_ROUTINE_VERSION")
+_ENV_FILE = Path.home() / ".hermes" / "routine.env"
+
+
+def _parse_env_file(path: Path) -> dict[str, str]:
+    """Parse a ``KEY=value`` env file (mirrors how the dispatch skill sources it)."""
+    out: dict[str, str] = {}
+    try:
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            out[key.strip()] = value.strip().strip('"').strip("'")
+    except OSError:
+        pass
+    return out
+
+
+def load_config(
+    environ: dict[str, str] | None = None,
+    env_file: Path | None = None,
+) -> dict[str, str]:
+    """Resolve ``CLAUDE_ROUTINE_*`` from the environment, falling back to the env file."""
+    environ = os.environ if environ is None else environ
+    env_file = _ENV_FILE if env_file is None else env_file
+    cfg = {k: environ[k] for k in (*_REQUIRED, *_OPTIONAL) if environ.get(k)}
+    if [k for k in _REQUIRED if k not in cfg]:
+        file_cfg = _parse_env_file(env_file)
+        for k in (*_REQUIRED, *_OPTIONAL):
+            if k not in cfg and file_cfg.get(k):
+                cfg[k] = file_cfg[k]
+    return cfg
+
+
+def build_request(cfg: dict[str, str], work_order: str) -> urllib.request.Request:
+    """Build the POST request for the ``/fire`` endpoint (no network I/O)."""
+    headers = {
+        "Authorization": f"Bearer {cfg['CLAUDE_ROUTINE_TOKEN']}",
+        "Content-Type": "application/json",
+    }
+    if cfg.get("CLAUDE_ROUTINE_BETA"):
+        headers["anthropic-beta"] = cfg["CLAUDE_ROUTINE_BETA"]
+    if cfg.get("CLAUDE_ROUTINE_VERSION"):
+        headers["anthropic-version"] = cfg["CLAUDE_ROUTINE_VERSION"]
+    data = json.dumps({"text": work_order}).encode("utf-8")
+    return urllib.request.Request(
+        cfg["CLAUDE_ROUTINE_FIRE_URL"],
+        data=data,
+        headers=headers,
+        method="POST",
+    )
+
+
+def redacted_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Headers with the bearer token masked — safe to print."""
+    return {
+        k: ("Bearer ***redacted***" if k.lower() == "authorization" else v)
+        for k, v in headers.items()
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Fire a Claude Code routine work order.",
+    )
+    parser.add_argument(
+        "--file",
+        help="read the work order from this file (default: stdin)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the request (token redacted) and exit without firing",
+    )
+    args = parser.parse_args(argv)
+
+    raw = Path(args.file).read_text(encoding="utf-8") if args.file else sys.stdin.read()
+    work_order = raw.strip()
+    if not work_order:
+        print(
+            "routine_fire: empty work order (nothing on stdin / --file).",
+            file=sys.stderr,
+        )
+        return 2
+
+    cfg = load_config()
+    missing = [k for k in _REQUIRED if k not in cfg]
+    if missing:
+        print(
+            f"routine_fire: missing config {missing} (set them in the env or {_ENV_FILE}).",
+            file=sys.stderr,
+        )
+        return 1
+
+    req = build_request(cfg, work_order)
+
+    if args.dry_run:
+        print(
+            json.dumps(
+                {
+                    "method": req.method,
+                    "url": req.full_url,
+                    "headers": redacted_headers(dict(req.headers)),
+                    "payload": {"text": work_order},
+                },
+                indent=2,
+            ),
+        )
+        return 0
+
+    try:
+        with urllib.request.urlopen(
+            req,
+            timeout=30,
+        ) as resp:  # noqa: S310 (trusted URL)
+            body = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:500]
+        print(
+            f"routine_fire: HTTP {exc.code} firing routine: {detail}",
+            file=sys.stderr,
+        )
+        return 1
+    except urllib.error.URLError as exc:
+        print(
+            f"routine_fire: network error firing routine: {exc.reason}",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        parsed = json.loads(body)
+    except ValueError:
+        print(body)
+        return 0
+    session_url = parsed.get("claude_code_session_url") or parsed.get("session_url")
+    if session_url:
+        print(f"Fired. Watch: {session_url}")
+    print(json.dumps(parsed, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hermes/skills/dispatch/SKILL.md
+++ b/scripts/hermes/skills/dispatch/SKILL.md
@@ -43,19 +43,16 @@ STEP 3 — ASSEMBLE THE WORK ORDER (the `text` payload). Keep it tight and self-
 STEP 4 — GATE + DISPATCH:
   - SHOW me the assembled work order and the exact curl first. Wait for my "go" unless I
     already said "dispatch it" in this conversation.
-  - Load the routine secrets, then fire (never print the token). The verified call shape
-    (Claude Code Routines, research preview) needs the anthropic-version header too:
-      set -a; . "$HOME/.hermes/routine.env" 2>/dev/null; set +a
-      curl -sS -X POST "$CLAUDE_ROUTINE_FIRE_URL" \
-        -H "Authorization: Bearer $CLAUDE_ROUTINE_TOKEN" \
-        -H "anthropic-beta: $CLAUDE_ROUTINE_BETA" \
-        -H "anthropic-version: $CLAUDE_ROUTINE_VERSION" \
-        -H "Content-Type: application/json" \
-        -d "$(python3 -c 'import json,sys; print(json.dumps({"text": sys.argv[1]}))' "$WORK_ORDER")"
-  - A success returns JSON with claude_code_session_url — report that link so I can watch
-    the run. If CLAUDE_ROUTINE_TOKEN is unset (no ~/.hermes/routine.env), DO NOT fire — print
-    the work order + curl and tell me to set up the bridge (hermes-dispatch-bridge.md) or
-    paste the order into a session myself.
+  - Fire it with the helper — the work order goes in on STDIN, so the shell never parses it
+    (no quoting failures on multi-line orders with quotes/newlines). It loads the
+    CLAUDE_ROUTINE_* config from the env or ~/.hermes/routine.env and never prints the token:
+      printf '%s' "$WORK_ORDER" | python3 scripts/hermes/routine_fire.py
+      # preview the exact request first (token redacted), without firing:
+      printf '%s' "$WORK_ORDER" | python3 scripts/hermes/routine_fire.py --dry-run
+  - On success it prints `Fired. Watch: <claude_code_session_url>` — report that link so I can
+    watch the run. If the CLAUDE_ROUTINE_* config is missing, it exits non-zero and says so;
+    then DO NOT fire — show the work order + the --dry-run output and tell me to set up the
+    bridge (hermes-dispatch-bridge.md) or paste the order into a session myself.
 
 STEP 5 — REPORT: confirm the fire response (run id / status). Tell me the routine will open a
   claude/ PR; offer to watch it with `superbot-repo-health` / `log-triage` and to review it

--- a/tests/unit/scripts/test_routine_fire.py
+++ b/tests/unit/scripts/test_routine_fire.py
@@ -1,0 +1,100 @@
+"""Tests for ``scripts/hermes/routine_fire.py`` — the robust dispatch helper (Q-0141)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_MOD = REPO_ROOT / "scripts" / "hermes" / "routine_fire.py"
+
+_spec = importlib.util.spec_from_file_location("routine_fire", _MOD)
+assert _spec
+assert _spec.loader
+rf = importlib.util.module_from_spec(_spec)
+sys.modules["routine_fire"] = rf
+_spec.loader.exec_module(rf)
+
+
+# --- config resolution ------------------------------------------------------------------
+
+
+def test_load_config_from_environ() -> None:
+    cfg = rf.load_config(
+        environ={"CLAUDE_ROUTINE_FIRE_URL": "u", "CLAUDE_ROUTINE_TOKEN": "t"},
+        env_file=Path("/nonexistent"),
+    )
+    assert cfg["CLAUDE_ROUTINE_FIRE_URL"] == "u"
+    assert cfg["CLAUDE_ROUTINE_TOKEN"] == "t"
+
+
+def test_load_config_falls_back_to_env_file(tmp_path: Path) -> None:
+    env_file = tmp_path / "routine.env"
+    env_file.write_text(
+        '# comment\nCLAUDE_ROUTINE_FIRE_URL=fileurl\nCLAUDE_ROUTINE_TOKEN="filetok"\n',
+        encoding="utf-8",
+    )
+    cfg = rf.load_config(environ={}, env_file=env_file)
+    assert cfg["CLAUDE_ROUTINE_FIRE_URL"] == "fileurl"
+    assert cfg["CLAUDE_ROUTINE_TOKEN"] == "filetok"  # quotes stripped
+
+
+# --- request building -------------------------------------------------------------------
+
+
+def test_build_request_carries_token_and_payload() -> None:
+    cfg = {
+        "CLAUDE_ROUTINE_FIRE_URL": "https://x/fire",
+        "CLAUDE_ROUTINE_TOKEN": "SEKRET",
+    }
+    req = rf.build_request(cfg, "multi\nline\nwork order")
+    assert req.method == "POST"
+    assert req.full_url == "https://x/fire"
+    assert json.loads(req.data.decode())["text"] == "multi\nline\nwork order"
+    assert "SEKRET" in (req.get_header("Authorization") or "")
+
+
+def test_redacted_headers_masks_only_authorization() -> None:
+    out = rf.redacted_headers(
+        {"Authorization": "Bearer SEKRET", "Content-type": "application/json"},
+    )
+    assert "SEKRET" not in json.dumps(out)
+    assert out["Authorization"] == "Bearer ***redacted***"
+    assert out["Content-type"] == "application/json"
+
+
+# --- main / CLI behaviour ---------------------------------------------------------------
+
+
+def test_dry_run_never_leaks_the_token(monkeypatch, capsys, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        rf,
+        "load_config",
+        lambda *a, **k: {
+            "CLAUDE_ROUTINE_FIRE_URL": "https://x/fire",
+            "CLAUDE_ROUTINE_TOKEN": "SUPERSEKRET",
+            "CLAUDE_ROUTINE_BETA": "beta",
+        },
+    )
+    wo = tmp_path / "wo.txt"
+    wo.write_text("do the thing", encoding="utf-8")
+    assert rf.main(["--file", str(wo), "--dry-run"]) == 0
+    out = capsys.readouterr().out
+    assert "SUPERSEKRET" not in out  # the whole point
+    assert "***redacted***" in out
+    assert "do the thing" in out  # payload is shown
+
+
+def test_missing_config_exits_1(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(rf, "load_config", lambda *a, **k: {})
+    wo = tmp_path / "wo.txt"
+    wo.write_text("x", encoding="utf-8")
+    assert rf.main(["--file", str(wo)]) == 1
+
+
+def test_empty_work_order_exits_2(tmp_path: Path) -> None:
+    wo = tmp_path / "empty.txt"
+    wo.write_text("   \n", encoding="utf-8")
+    assert rf.main(["--file", str(wo)]) == 2


### PR DESCRIPTION
> **Opened as a DRAFT on purpose** — held for comparison. Hermes is authoring its own
> `routine_fire.py` in parallel (owner's "nice test"); this is the reference version. Mark ready
> to merge it, or close it in favour of Hermes'. It won't auto-merge while draft.

## What

Hermes diagnosed a **real bug** live: the `superbot-dispatch` skill builds the `/fire` request as
`curl ... -d "$(python3 -c '…json.dumps…' "$WORK_ORDER")"`, which is **shell-quoting-fragile** for
multi-line work orders with quotes/newlines. The owner then decided **Hermes may write its own code**
(Q-0141) — so both Hermes and Claude Code build the fix.

This is the Claude-Code reference version:

- **`scripts/hermes/routine_fire.py`** — stdlib only. Work order on **stdin** (the shell never parses
  it), loads `CLAUDE_ROUTINE_*` from env or `~/.hermes/routine.env`, POSTs `{"text": …}`, prints
  `Fired. Watch: <session_url>`, **never prints the token**, `--dry-run` to preview the request
  (token redacted). 7 unit tests + a dry-run smoke proving a multi-line/quoted/`$var` order survives.
- **`dispatch.md` STEP 4** now fires via the helper (regenerated `SKILL.md`).
- **Q-0141 + operating-prompt / README** — Hermes' write scope expands from docs-only (Q-0140) to
  **code via PRs (CI-gated)**: prefer dispatch for big/risky changes, write small self-tooling
  directly, never push to `main` or mutate prod outside the gates. `review-merge` stays the merge gate.

## Verification
- `pytest tests/unit/scripts/test_routine_fire.py` ✓ (7) · `build_skills.py --check` ✓ (11)
- `check_docs.py --strict` ✓ · `check_quality.py --check-only` ✓
- No `disbot/` runtime code touched.

https://claude.ai/code/session_01THYNzZHw2HvBT7bjBj3u9Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01THYNzZHw2HvBT7bjBj3u9Q)_