### PR TITLE
docs(hermes): pick next slice from live state, not plan PR-numbers (Q-0142)

### DIFF
--- a/.sessions/2026-06-14-hermes-next-slice-live-state.md
+++ b/.sessions/2026-06-14-hermes-next-slice-live-state.md
@@ -1,0 +1,57 @@
+# Session: fix Hermes "always a bit behind" — pick next slice from live state, not plan PR-numbers
+
+> **Status:** `in-progress` — fixing the Hermes dispatch "pick next slice" gap (Q-0142); flip to complete last.
+
+**Branch:** `claude/sharp-ptolemy-5mzbvb` · **Date:** 2026-06-14 · **Type:** owner-directed workflow fix (Q-0142, in-session)
+
+## What this session did
+
+The owner shared the Telegram trace of how this very routine was dispatched and asked why Hermes
+"always seems to be a bit behind." Root-caused and fixed it.
+
+**Root cause.** When the owner says *"dispatch a continuation worker"* (no specific task), Hermes must
+decide *what* to build. The `superbot-dispatch` skill had **no procedure for that no-explicit-task
+case**, so he fell back to a planning doc's forward PR-number range — the band-#840 reconciliation
+plan's *"the next ~9 PRs (band #841–#860)"* — and read those numbers as the schedule, producing a
+stale "reconcile #848–#856" work order. The killer detail: he'd already run the live ledger guard
+(it returned CLEAN = nothing to reconcile) but dispatched a reconciliation task anyway, because the
+plan's numbers overrode live state. PR numbers in plans are a dated snapshot — GitHub assigns them
+globally across all parallel/housekeeping PRs, so a forward range is wrong the moment any unplanned
+PR merges (plan written at HEAD #840; live `main` was at #866 by dispatch).
+
+**Fix (Q-0142, owner-directed in-session).**
+- **`hermes-skills/dispatch.md`** — new **STEP 1b**: for the continuation-worker case, derive the
+  task from LIVE state (read ▶ Next action → run the ledger guard; drift = the only reconciliation
+  task, clean = nothing to reconcile → pick the next slice by **description/lane**, not a PR number,
+  and confirm it isn't already shipped). New **PLAN-NUMBERS-ARE-DATED** rule + "live state wins".
+- **`hermes-operating-prompt.md`** — the always-loaded "PICK THE NEXT THING BY DESCRIPTION, NOT BY PR
+  NUMBER" rule + a reconciliation guard line (check, don't hand-build from a plan range).
+- **`reconciliation-pass-2026-06-14-band840.md` §4** — de-numbered the heading ("The next ~9 slices
+  (planned after #840)") and strengthened the caption so the misleading "#841–#860 schedule" artifact
+  is gone at the source.
+- **Router Q-0142** — the provenance entry.
+- Regenerated `scripts/hermes/skills/dispatch/SKILL.md` via `build_skills.py`.
+
+**Owner action:** re-paste the operating prompt + `superbot-dispatch` skill into Hermes' config on the
+VPS for this to take effect (the repo is the source of truth; Hermes runs from a pasted copy).
+
+Verification: `check_docs --strict` ✓; `build_skills.py` regenerated cleanly (only `dispatch` SKILL.md
+diffs); diff scoped to 5 intended files. Docs/tooling only — no runtime bot code.
+
+## 💡 Session idea (Q-0089)
+
+A tiny `scripts/next_slice.py` (or a `--next` flag on an existing checker) that prints the single
+current "what's next" — the ▶ Next action lane + live ledger-guard status + open-PR count — in one
+line, so *both* Hermes and a fresh routine have a deterministic, always-live answer to "what should I
+work on?" instead of each re-deriving it from prose (and occasionally from stale plan numbers, as
+happened here). Captured to `docs/ideas/` pending a dedup-grep.
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous run (this same routine's band #841–#860 ledger reconciliation, PR #867) did the
+mechanical job correctly — but in hindsight it treated the *symptom* (a stale work order) as the whole
+task and only flagged the deeper cause in its Q-0102 note. The better move, which this session takes,
+was to follow the "stale work order" thread up to its source: the dispatch path that generated it.
+System improvement surfaced + applied: the dispatch skill now has an explicit live-state procedure for
+the continuation-worker case, closing the gap where a generic "dispatch a worker" request had no
+defined way to choose work and silently fell back to dated plan numbers.

--- a/.sessions/2026-06-14-hermes-next-slice-live-state.md
+++ b/.sessions/2026-06-14-hermes-next-slice-live-state.md
@@ -1,6 +1,6 @@
 # Session: fix Hermes "always a bit behind" — pick next slice from live state, not plan PR-numbers
 
-> **Status:** `in-progress` — fixing the Hermes dispatch "pick next slice" gap (Q-0142); flip to complete last.
+> **Status:** `complete` — PR #868; born-red card flipped as the deliberate final step (Q-0133).
 
 **Branch:** `claude/sharp-ptolemy-5mzbvb` · **Date:** 2026-06-14 · **Type:** owner-directed workflow fix (Q-0142, in-session)
 

--- a/docs/operations/hermes-operating-prompt.md
+++ b/docs/operations/hermes-operating-prompt.md
@@ -72,10 +72,18 @@ THERE IS ALWAYS A NEXT THING — the bot is never "done"
 - Every session ends by writing its continuation handoff into docs/current-state.md (the
   "Next action" pointer) and the newest .sessions/ log. Those are the two places to look for
   "what's next" — track them.
+- PICK THE NEXT THING BY DESCRIPTION, NOT BY PR NUMBER (Q-0142). The ▶ Next action pointer +
+  newest .sessions/ log name what's next as a LANE/SLICE ("P1-1 eval-smoke matrix"). Planning
+  docs also list "the next ~9 PRs" with #numbers — those numbers are a DATED snapshot (GitHub
+  assigns them globally; a forward "#841-#860" range is stale the moment any other PR merges).
+  Use the description; verify against live ledger state before dispatching. When the plan and
+  live state disagree, live state wins.
 
 DON'T WORRY ABOUT RECONCILIATION
 - The reconciliation passes fire AUTOMATICALLY (the routines). Drop them from your watchlist —
-  don't plan, trigger, or think about them.
+  don't plan, trigger, or think about them. If you ever think the ledger drifted, CHECK it with
+  the guard (check_current_state_ledger.py --strict) — never hand-build a reconciliation work
+  order from a plan's PR-number range (Q-0142).
 
 VERIFY, DON'T ASSUME (core directive)
 - Never guess whether a var is set, a routine fired, or a value is correct — CHECK it:

--- a/docs/operations/hermes-skills/dispatch.md
+++ b/docs/operations/hermes-skills/dispatch.md
@@ -35,6 +35,23 @@ STEP 1 — ORIENT (read-only). Ground the work order so the routine starts orien
   - Establish: what exactly is being asked, which files/subsystem it touches, and the
     acceptance check (a test, a command, a behavior). If unclear, ASK ME — do not guess.
 
+STEP 1b — IF I GAVE NO SPECIFIC TASK ("dispatch a continuation worker" / "pick the next thing"):
+  derive it from LIVE state, never from a plan's PR numbers (Q-0142 — the trap that fired stale
+  #848-#856 work on 2026-06-14: a planning doc's forward "#841-#860" range was read as the schedule
+  while live main had already advanced past it).
+    1. Read docs/current-state.md ▶ Next action — the live standing handoff. That pointer + the
+       newest .sessions/ log are the authority for "what's next".
+    2. Run the ledger guard against fresh main:
+         git -C /home/hermes/repos/superbot fetch origin main
+         python3.10 scripts/check_current_state_ledger.py --strict
+       Drift reported -> THAT is the only reconciliation task. CLEAN -> there is nothing to
+       reconcile; do NOT build a reconciliation work order from a planning doc's band range.
+       (Reconciliation passes fire automatically — the routines. You don't hand-dispatch them.)
+    3. Pick the next slice by its DESCRIPTION / lane ("P1-1 eval-smoke matrix"), NOT by a
+       "#841-#860" range or "slot N = #NNN" mapping. Those numbers were written at a past HEAD.
+    4. Confirm it isn't already done: grep current-state Recently-shipped + scan open PRs for it.
+       If it shipped, move to the next slice. THEN assemble the work order (STEP 3).
+
 STEP 2 — CLASSIFY (this decides the merge gate the routine will use):
   - BUG FIX / UX / DOCS / CORRECTNESS  -> the routine builds, tests, and SELF-MERGES on green CI.
   - AGENT-ORIGINATED FEATURE           -> the routine builds and OPENS a PR but must NOT merge;
@@ -80,6 +97,12 @@ RULES:
 - Never print secrets (tokens, the `.env`) to me. Reference env vars by name only.
 - One work order per fire. If the idea is really several changes, say so and dispatch the
   first, or hand me a multi-task plan for a session instead.
+- PLAN NUMBERS ARE DATED (Q-0142). Any "#AAA-#BBB" range or "slot N = #NNN" mapping in a
+  planning / reconciliation doc is a snapshot from when it was written — GitHub assigns PR
+  numbers globally across all parallel + housekeeping work, so a forward range is wrong the
+  moment an unplanned PR merges. Pick work by DESCRIPTION + live ledger state. When the plan
+  and live state disagree, LIVE STATE WINS (the repo's standing precedence rule: merged PRs >
+  current-state > plans). A clean ledger guard means nothing to reconcile — full stop.
 ```
 
 ---

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -5310,3 +5310,33 @@ the owner is running a "nice test" — Hermes is authoring its own version in pa
 
 **Home:** `docs/operations/hermes-operating-prompt.md`, `docs/operations/hermes-skills/README.md`,
 `scripts/hermes/routine_fire.py`, `docs/operations/hermes-skills/dispatch.md`.
+
+### Q-0142 — Hermes picks the next slice from LIVE state, never a plan's PR numbers (2026-06-14)
+
+> **DECISION 2026-06-14 (owner-directed in-session).** The owner showed the Telegram trace of a
+> "dispatch a continuation worker" run: Hermes built a work order to *reconcile the ledger for
+> #848–#856* — work that no longer existed. He'd run the live ledger guard (it returned CLEAN) but
+> dispatched a reconciliation task anyway, because he read the band-#840 reconciliation plan's
+> forward range — *"the next ~9 PRs (band #841–#860)"* — as the schedule. The plan was written at
+> HEAD #840; by dispatch time live `main` was at #866, so those numbers were stale. Owner: *"he
+> always seems to be a bit behind which is weird"* → asked to fix how Hermes picks work.
+
+**Root cause.** PR numbers in planning docs are a **dated snapshot** — GitHub assigns them globally
+across all parallel + housekeeping PRs, so any forward "#AAA–#BBB" band range (or "slot N = #NNN"
+mapping) is wrong the moment an unplanned PR merges. The `superbot-dispatch` skill had **no procedure
+for the no-explicit-task ("continuation worker") case**, so Hermes fell back to those plan numbers
+instead of live state.
+
+**Decision / fix (this PR).** When no specific task is given, Hermes derives the next slice from
+**live state**: (1) read `current-state.md` ▶ Next action; (2) run `check_current_state_ledger.py
+--strict` — drift = the only reconciliation task, CLEAN = nothing to reconcile (reconciliation passes
+fire automatically — never hand-dispatch one); (3) pick the slice by **description/lane**, not a PR
+number; (4) confirm it isn't already shipped. Standing rule: **when a plan and live state disagree,
+live state wins** (merged PRs > current-state > plans). Plan-doc forward ranges are de-numbered to
+slot-sequence framing so the misleading artifact is gone at the source.
+
+**Home:** `docs/operations/hermes-skills/dispatch.md` (STEP 1b + the PLAN-NUMBERS-ARE-DATED rule;
+artifact regenerated via `build_skills.py`), `docs/operations/hermes-operating-prompt.md` ("pick by
+description, not PR number"), `docs/planning/reconciliation-pass-2026-06-14-band840.md` §4 heading.
+**Re-paste the operating prompt + `superbot-dispatch` skill into Hermes' config on the VPS for this
+to take effect.**

--- a/docs/planning/reconciliation-pass-2026-06-14-band840.md
+++ b/docs/planning/reconciliation-pass-2026-06-14-band840.md
@@ -97,11 +97,15 @@ the parallel owner threads**:
 6. **Owner-led in parallel:** add `ROUTINE_PAT` · the P1-4 live walks · `!uxlab` walk · #704 +
    #834 disposition.
 
-## 4. The next ~9 PRs (band #841–#860)
+## 4. The next ~9 slices (planned after #840)
 
-> Modular but not over-segmented (Q-0107): each slot is a real slice. Numbers are
-> **sequence, not reserved PR numbers**. Owner steers override freely; note swaps here.
-> Ordered highest-value-first now that the P0 spine is complete.
+> Modular but not over-segmented (Q-0107): each slot is a real slice. The `#` column is
+> **slot sequence, NOT reserved PR numbers** — GitHub assigns PR numbers globally across all
+> parallel + housekeeping work, so do NOT map a slot to a predicted PR number or read this as a
+> "#841–#860" schedule (Q-0142 — that misread fired a stale reconciliation dispatch on
+> 2026-06-14). Pick the next slice by its **description**, verified against the live ledger.
+> Owner steers override freely; note swaps here. Ordered highest-value-first now that the P0
+> spine is complete.
 
 | # | PR (one session each) | Scope anchor | Gate |
 |---|---|---|---|

--- a/scripts/hermes/skills/dispatch/SKILL.md
+++ b/scripts/hermes/skills/dispatch/SKILL.md
@@ -24,6 +24,23 @@ STEP 1 — ORIENT (read-only). Ground the work order so the routine starts orien
   - Establish: what exactly is being asked, which files/subsystem it touches, and the
     acceptance check (a test, a command, a behavior). If unclear, ASK ME — do not guess.
 
+STEP 1b — IF I GAVE NO SPECIFIC TASK ("dispatch a continuation worker" / "pick the next thing"):
+  derive it from LIVE state, never from a plan's PR numbers (Q-0142 — the trap that fired stale
+  #848-#856 work on 2026-06-14: a planning doc's forward "#841-#860" range was read as the schedule
+  while live main had already advanced past it).
+    1. Read docs/current-state.md ▶ Next action — the live standing handoff. That pointer + the
+       newest .sessions/ log are the authority for "what's next".
+    2. Run the ledger guard against fresh main:
+         git -C /home/hermes/repos/superbot fetch origin main
+         python3.10 scripts/check_current_state_ledger.py --strict
+       Drift reported -> THAT is the only reconciliation task. CLEAN -> there is nothing to
+       reconcile; do NOT build a reconciliation work order from a planning doc's band range.
+       (Reconciliation passes fire automatically — the routines. You don't hand-dispatch them.)
+    3. Pick the next slice by its DESCRIPTION / lane ("P1-1 eval-smoke matrix"), NOT by a
+       "#841-#860" range or "slot N = #NNN" mapping. Those numbers were written at a past HEAD.
+    4. Confirm it isn't already done: grep current-state Recently-shipped + scan open PRs for it.
+       If it shipped, move to the next slice. THEN assemble the work order (STEP 3).
+
 STEP 2 — CLASSIFY (this decides the merge gate the routine will use):
   - BUG FIX / UX / DOCS / CORRECTNESS  -> the routine builds, tests, and SELF-MERGES on green CI.
   - AGENT-ORIGINATED FEATURE           -> the routine builds and OPENS a PR but must NOT merge;
@@ -69,3 +86,9 @@ RULES:
 - Never print secrets (tokens, the `.env`) to me. Reference env vars by name only.
 - One work order per fire. If the idea is really several changes, say so and dispatch the
   first, or hand me a multi-task plan for a session instead.
+- PLAN NUMBERS ARE DATED (Q-0142). Any "#AAA-#BBB" range or "slot N = #NNN" mapping in a
+  planning / reconciliation doc is a snapshot from when it was written — GitHub assigns PR
+  numbers globally across all parallel + housekeeping work, so a forward range is wrong the
+  moment an unplanned PR merges. Pick work by DESCRIPTION + live ledger state. When the plan
+  and live state disagree, LIVE STATE WINS (the repo's standing precedence rule: merged PRs >
+  current-state > plans). A clean ledger guard means nothing to reconcile — full stop.


### PR DESCRIPTION
## Why

The owner shared the Telegram trace of how a *"dispatch a continuation worker"* run was assembled and
asked why Hermes "always seems to be a bit behind." Root-caused it.

**Root cause.** When no specific task is given, the `superbot-dispatch` skill had **no procedure for
picking the next slice**, so Hermes fell back to a planning doc's forward PR-number range — the
band-#840 plan's *"the next ~9 PRs (band #841–#860)"* — and read those numbers as the schedule,
producing a stale `#848–#856` reconciliation work order. He'd even run the live ledger guard (it
returned **clean** = nothing to reconcile) but dispatched anyway, because the plan's numbers overrode
live state. PR numbers in plans are a **dated snapshot** — GitHub assigns them globally across all
parallel/housekeeping PRs, so a forward range is wrong the moment any unplanned PR merges (plan
written at HEAD #840; live `main` was at #866 by dispatch).

## Fix (Q-0142)

- **`dispatch.md` STEP 1b** — for the continuation-worker case: derive from LIVE state (read ▶ Next
  action → run the ledger guard → pick the slice by **description/lane**, not a PR number → confirm
  it isn't already shipped). New **PLAN-NUMBERS-ARE-DATED** rule + "live state wins".
- **`hermes-operating-prompt.md`** — always-loaded "pick the next thing by description, not PR number"
  + a reconciliation-guard line.
- **`reconciliation-pass-2026-06-14-band840.md` §4** — de-numbered the heading + strengthened the
  caption so the misleading "#841–#860 schedule" artifact is gone at the source.
- **Router Q-0142** — provenance. Regenerated `dispatch/SKILL.md` via `build_skills.py`.

## Owner action

Re-paste the operating prompt + `superbot-dispatch` skill into Hermes' config on the VPS for this to
take effect (the repo is the source of truth; Hermes runs from a pasted copy).

## Verify

- `python3.10 scripts/check_docs.py --strict` → all checks passed ✓
- `build_skills.py` regenerated cleanly (only `dispatch` SKILL.md diffs)
- Diff scoped to 5 intended files; docs/tooling only — no runtime bot code.

https://claude.ai/code/session_01LnvWKkK3vMHETjNZ8mtj5A

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnvWKkK3vMHETjNZ8mtj5A)_