### PR TITLE
fix(hermes): run stdlib tooling under python3, not python3.10

### DIFF
--- a/.sessions/2026-06-14-hermes-tooling-python3.md
+++ b/.sessions/2026-06-14-hermes-tooling-python3.md
@@ -1,0 +1,56 @@
+# Session: Hermes tooling runs under python3 (VPS has 3.11, not 3.10)
+
+> **Status:** `in-progress` — de-pinning Hermes stdlib tooling from python3.10; flip to complete last.
+
+**Branch:** `claude/sharp-ptolemy-5mzbvb` · **Date:** 2026-06-14 · **Type:** fix (tooling portability, Q-0142 follow-up)
+
+## What this session did
+
+Hermes (on the VPS) reported he couldn't rebuild the dispatch skill: the documented commands use
+`python3.10`, but the VPS only has `python3` (3.11). Root-caused and fixed.
+
+**Root cause.** Every Hermes-run script is **stdlib-only and version-agnostic** (`build_skills.py`,
+`check_current_state_ledger.py`, `check_phase_gate.py`, `routine_fire.py`, `railway_*` — all already
+shebang `#!/usr/bin/env python3` except the ledger guard, all run fine under 3.11). But the
+Hermes-facing docs/skills hard-coded `python3.10` in their invocation lines. The `python3.10` pin in
+`.claude/CLAUDE.md` is **only** for CI-parity tools (`check_quality` / black / mypy / pytest) — which
+Hermes never runs — so these stdlib utilities should just use `python3`. My own Q-0142 STEP 1b had
+introduced a `python3.10 check_current_state_ledger.py` command Hermes couldn't run; fixed here too.
+
+**Fix.** Changed `python3.10 ` → `python3 ` in the Hermes-facing invocation lines:
+- `hermes-skills/dispatch.md` (STEP 1b ledger guard + STEP 2 phase gate) → regenerated `dispatch/SKILL.md`
+- `hermes-skills/log-triage.md` (railway_logs) → regenerated `log-triage/SKILL.md`
+- `hermes-skills/skill-author.md` (build_skills + check_docs), `hermes-skills/README.md` (build_skills)
+- `scripts/hermes/build_skills.py` usage strings + a WHY-`python3` docstring note so nobody reverts it
+- `hermes-skills/repo-health.md` Notes — reframed to "use python3; the 3.10 pin is CI-parity-only"
+
+**Untouched (correctly):** `.claude/CLAUDE.md`, CI workflow, and all `check_quality`/formatter/test
+references stay `python3.10` — those are the real CI-parity tools. `install-skills.sh` already does
+`python3.10 || python3` fallback.
+
+**Owner action:** the install on the VPS now works with `python3 scripts/hermes/build_skills.py`. After
+pulling, re-run the install/rebuild; re-paste the regenerated `superbot-dispatch` skill into Hermes.
+(Optional alternative for full uniformity: install Python 3.10 on the VPS — but the version-agnostic
+fix means that's no longer required.)
+
+Verification: `build_skills.py --check` clean (idempotent under python3); no `python3.10` left in any
+`skills/*/SKILL.md`; `check_current_state_ledger.py` + `check_phase_gate.py` run under plain `python3`;
+`check_docs --strict` ✓. Docs/tooling only — no runtime bot code.
+
+## 💡 Session idea (Q-0089)
+
+A tiny `build_skills.py --check` is already CI-gated, but there's no guard that catches an *invocation*
+regression — i.e. a Hermes-facing doc re-introducing `python3.10` for a stdlib tool. Idea: a one-line
+check (extend `check_docs.py` or a `scripts/hermes` test) that fails if any file under
+`docs/operations/hermes-skills/` or `scripts/hermes/` contains `python3.10 ` (allowlisting
+`install-skills.sh`'s fallback) — so the "Hermes only has python3" constraint is enforced, not just
+documented. Captured pending a dedup-grep.
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous run (Q-0142, PR #868) correctly fixed *what Hermes picks* but shipped a command Hermes
+literally can't run (`python3.10 check_current_state_ledger.py`) — I added the instruction without
+checking it against Hermes's actual environment, the exact "green tests ≠ runs in the target env"
+gap. This session closes it. System improvement surfaced: agent-facing tooling docs should be
+validated against the *consumer's* environment (Hermes = python3-only VPS), not just the authoring
+repo (which has python3.10) — the proposed invocation-guard above makes that structural.

--- a/.sessions/2026-06-14-hermes-tooling-python3.md
+++ b/.sessions/2026-06-14-hermes-tooling-python3.md
@@ -1,6 +1,6 @@
 # Session: Hermes tooling runs under python3 (VPS has 3.11, not 3.10)
 
-> **Status:** `in-progress` — de-pinning Hermes stdlib tooling from python3.10; flip to complete last.
+> **Status:** `complete` — PR #869; born-red card flipped as the deliberate final step (Q-0133).
 
 **Branch:** `claude/sharp-ptolemy-5mzbvb` · **Date:** 2026-06-14 · **Type:** fix (tooling portability, Q-0142 follow-up)
 

--- a/docs/operations/hermes-skills/README.md
+++ b/docs/operations/hermes-skills/README.md
@@ -46,7 +46,7 @@ those from these docs (the same source → builder → generated-artifact patter
 
 ```bash
 # Regenerate the installable SKILL.md artifacts after editing any skill doc:
-python3.10 scripts/hermes/build_skills.py
+python3 scripts/hermes/build_skills.py
 ```
 
 This writes `scripts/hermes/skills/<name>/SKILL.md` (frontmatter + prompt body, marked

--- a/docs/operations/hermes-skills/dispatch.md
+++ b/docs/operations/hermes-skills/dispatch.md
@@ -43,7 +43,7 @@ STEP 1b — IF I GAVE NO SPECIFIC TASK ("dispatch a continuation worker" / "pick
        newest .sessions/ log are the authority for "what's next".
     2. Run the ledger guard against fresh main:
          git -C /home/hermes/repos/superbot fetch origin main
-         python3.10 scripts/check_current_state_ledger.py --strict
+         python3 scripts/check_current_state_ledger.py --strict
        Drift reported -> THAT is the only reconciliation task. CLEAN -> there is nothing to
        reconcile; do NOT build a reconciliation work order from a planning doc's band range.
        (Reconciliation passes fire automatically — the routines. You don't hand-dispatch them.)
@@ -57,7 +57,7 @@ STEP 2 — CLASSIFY (this decides the merge gate the routine will use):
   - AGENT-ORIGINATED FEATURE           -> the routine builds and OPENS a PR but must NOT merge;
                                           it pings me for approve/deny (Q-0114).
   Also run the phase gate to sanity-check feature work is even in-season:
-    python3.10 /home/hermes/repos/superbot/scripts/check_phase_gate.py --phase
+    python3 /home/hermes/repos/superbot/scripts/check_phase_gate.py --phase
   If it prints `fix` and this is an agent-originated feature, STOP and tell me we're in
   fix-phase — propose it as an idea capture instead of dispatching it.
 

--- a/docs/operations/hermes-skills/log-triage.md
+++ b/docs/operations/hermes-skills/log-triage.md
@@ -30,7 +30,7 @@ Do the following in order. Skip any step whose tool is unavailable and say so.
 
 1. PRODUCTION LOGS (Railway)
    Preferred — the read-only API reader (no CLI or login needed):
-     python3.10 scripts/hermes/railway_logs.py -n 400 2>&1
+     python3 scripts/hermes/railway_logs.py -n 400 2>&1
    It reads a read-only token + ids from the environment (RAILWAY_TOKEN — a
    project token — or RAILWAY_API_TOKEN, plus RAILWAY_PROJECT_ID and
    RAILWAY_SERVICE_ID) and
@@ -105,7 +105,7 @@ Format the output as:
   as `RAILWAY_TOKEN` (project token; or `RAILWAY_API_TOKEN` for an account token),
   plus `RAILWAY_PROJECT_ID` and `RAILWAY_SERVICE_ID` (from the dashboard URL
   `railway.com/project/<id>/service/<id>`). Verify with
-  `python3.10 scripts/hermes/railway_logs.py --whoami`. Until configured the skill
+  `python3 scripts/hermes/railway_logs.py --whoami`. Until configured the skill
   still works — it triages the local `hermes-gateway` logs and reports production
   logs unavailable. (The `railway` CLI remains an optional fallback.) Full
   reference: `docs/operations/production-deployment.md` § "Hermes read-only log

--- a/docs/operations/hermes-skills/repo-health.md
+++ b/docs/operations/hermes-skills/repo-health.md
@@ -83,7 +83,9 @@ Format the output as:
 
 ## Notes
 
-- If `python3` is not on the path, try `python3.10` (the repo uses Python 3.10 for CI).
+- Invoke the repo's stdlib checkers with **`python3`** (the VPS has 3.11, not 3.10) — they are
+  version-agnostic and run under any Python 3.9+. The `python3.10` pin in `.claude/CLAUDE.md` is
+  **only** for CI-parity tools (`check_quality` / black / mypy / pytest), which Hermes does not run.
 - The architecture check may produce warnings for known violations — these are tracked in
   `architecture_rules/` YAML files and are expected. Warnings alone are not a blocker.
 - If `gh` is not authenticated, skip steps 3 and 4 and mark them ⚠️ "gh not available".

--- a/docs/operations/hermes-skills/skill-author.md
+++ b/docs/operations/hermes-skills/skill-author.md
@@ -67,9 +67,9 @@ STEP 3 — WRITE THE SOURCE. Create docs/operations/hermes-skills/<name>.md in t
 
 STEP 4 — REGISTER + BUILD. Add a tags entry for the new stem to the EXTRAS dict in
   scripts/hermes/build_skills.py (copy a sibling's line). Then regenerate the installable artifact:
-      python3.10 scripts/hermes/build_skills.py
-      python3.10 scripts/hermes/build_skills.py --check     # must pass
-      python3.10 scripts/check_docs.py --strict             # reachability/pins
+      python3 scripts/hermes/build_skills.py
+      python3 scripts/hermes/build_skills.py --check     # must pass
+      python3 scripts/check_docs.py --strict             # reachability/pins
   (build_skills.py edits scripts/hermes/build_skills.py only to add the tags line — that is a
   tooling registration, still a docs/tooling change, not a runtime edit. If you are unsure, ask.)
 

--- a/scripts/hermes/build_skills.py
+++ b/scripts/hermes/build_skills.py
@@ -19,9 +19,15 @@ generated file** — every emitted ``SKILL.md`` carries a ``GENERATED`` marker.
 Pure stdlib (no PyYAML) so the freshness test runs in CI without installing
 anything — same discipline as ``scripts/check_docs.py``.
 
+Interpreter: invoke with **``python3``** (version-agnostic, runs under any 3.9+).
+The Hermes VPS has Python 3.11, not 3.10, and this is a stdlib markdown generator —
+NOT one of the CI-parity tools (black/mypy/pytest via ``check_quality``) that
+``.claude/CLAUDE.md`` pins to ``python3.10``. Do not "correct" these usage lines back
+to ``python3.10`` — that breaks Hermes, which only has ``python3`` (Q-0142 follow-up).
+
 Usage:
-    python3.10 scripts/hermes/build_skills.py            # (re)generate artifacts
-    python3.10 scripts/hermes/build_skills.py --check    # exit 1 if stale (CI)
+    python3 scripts/hermes/build_skills.py            # (re)generate artifacts
+    python3 scripts/hermes/build_skills.py --check    # exit 1 if stale (CI)
 """
 
 from __future__ import annotations
@@ -245,7 +251,7 @@ def main(argv: list[str] | None = None) -> int:
             print("build_skills --check: stale or missing generated skill(s):")
             for p in sorted(stale):
                 print(f"  {p.relative_to(REPO_ROOT)}")
-            print("\nRun: python3.10 scripts/hermes/build_skills.py")
+            print("\nRun: python3 scripts/hermes/build_skills.py")
             return 1
         print(f"build_skills --check: {len(rendered)} skill(s) up to date ✓")
         return 0

--- a/scripts/hermes/skills/dispatch/SKILL.md
+++ b/scripts/hermes/skills/dispatch/SKILL.md
@@ -32,7 +32,7 @@ STEP 1b — IF I GAVE NO SPECIFIC TASK ("dispatch a continuation worker" / "pick
        newest .sessions/ log are the authority for "what's next".
     2. Run the ledger guard against fresh main:
          git -C /home/hermes/repos/superbot fetch origin main
-         python3.10 scripts/check_current_state_ledger.py --strict
+         python3 scripts/check_current_state_ledger.py --strict
        Drift reported -> THAT is the only reconciliation task. CLEAN -> there is nothing to
        reconcile; do NOT build a reconciliation work order from a planning doc's band range.
        (Reconciliation passes fire automatically — the routines. You don't hand-dispatch them.)
@@ -46,7 +46,7 @@ STEP 2 — CLASSIFY (this decides the merge gate the routine will use):
   - AGENT-ORIGINATED FEATURE           -> the routine builds and OPENS a PR but must NOT merge;
                                           it pings me for approve/deny (Q-0114).
   Also run the phase gate to sanity-check feature work is even in-season:
-    python3.10 /home/hermes/repos/superbot/scripts/check_phase_gate.py --phase
+    python3 /home/hermes/repos/superbot/scripts/check_phase_gate.py --phase
   If it prints `fix` and this is an agent-originated feature, STOP and tell me we're in
   fix-phase — propose it as an idea capture instead of dispatching it.
 

--- a/scripts/hermes/skills/log-triage/SKILL.md
+++ b/scripts/hermes/skills/log-triage/SKILL.md
@@ -23,7 +23,7 @@ Do the following in order. Skip any step whose tool is unavailable and say so.
 
 1. PRODUCTION LOGS (Railway)
    Preferred — the read-only API reader (no CLI or login needed):
-     python3.10 scripts/hermes/railway_logs.py -n 400 2>&1
+     python3 scripts/hermes/railway_logs.py -n 400 2>&1
    It reads a read-only token + ids from the environment (RAILWAY_TOKEN — a
    project token — or RAILWAY_API_TOKEN, plus RAILWAY_PROJECT_ID and
    RAILWAY_SERVICE_ID) and


### PR DESCRIPTION
## Why

Hermes (on the VPS) couldn't rebuild the dispatch skill: the documented commands use `python3.10`,
but the VPS only has `python3` (3.11). Every Hermes-run script is **stdlib-only and version-agnostic**
(`build_skills.py`, `check_current_state_ledger.py`, `check_phase_gate.py`, `routine_fire.py`,
`railway_*`), so they should be invoked with `python3`. The `python3.10` pin in `.claude/CLAUDE.md` is
**only** for CI-parity tools (`check_quality` / black / mypy / pytest), which Hermes never runs.

This also fixes the `python3.10 check_current_state_ledger.py` command the previous PR (#868, Q-0142)
added in dispatch STEP 1b — a command Hermes can't run.

## Fix

`python3.10 ` → `python3 ` in the Hermes-facing invocation lines:
- `dispatch.md` (STEP 1b ledger guard + STEP 2 phase gate) → regenerated `dispatch/SKILL.md`
- `log-triage.md` (railway_logs) → regenerated `log-triage/SKILL.md`
- `skill-author.md`, `README.md` (build_skills/check_docs)
- `build_skills.py` usage strings + a WHY-`python3` docstring note (so it's not reverted)
- `repo-health.md` Notes — reframed: use `python3`; the 3.10 pin is CI-parity-only

**Untouched (correctly):** `.claude/CLAUDE.md`, CI workflow, all `check_quality`/formatter/test refs
stay `python3.10`. `install-skills.sh` already has a `python3.10 || python3` fallback.

## Owner action

Pull on the VPS, then `python3 scripts/hermes/build_skills.py` works; re-paste the regenerated
`superbot-dispatch` skill into Hermes. (Optional: installing Python 3.10 on the VPS would unify the
docs, but the version-agnostic fix makes it unnecessary.)

## Verify

- `python3 scripts/hermes/build_skills.py --check` → up to date ✓ (idempotent under python3)
- No `python3.10` left in any `skills/*/SKILL.md`
- `check_current_state_ledger.py` + `check_phase_gate.py` run under plain `python3`
- `check_docs.py --strict` ✓

Docs/tooling only — no runtime bot code.

https://claude.ai/code/session_01LnvWKkK3vMHETjNZ8mtj5A

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnvWKkK3vMHETjNZ8mtj5A)_