### PR TITLE
docs(hermes): record Python 3.10 VPS prerequisite (deadsnakes, verified)

### DIFF
--- a/.sessions/2026-06-14-vps-python310-prereq.md
+++ b/.sessions/2026-06-14-vps-python310-prereq.md
@@ -1,0 +1,16 @@
+# Session: record Python 3.10 VPS prerequisite (deadsnakes, verified)
+
+> **Status:** `in-progress` — recording the verified VPS python3.10 prereq; flip to complete last.
+
+**Branch:** `claude/sharp-ptolemy-5mzbvb` · **Date:** 2026-06-14 · **Type:** docs (ops record, owner-verified)
+
+## What this session did
+
+The owner installed Python 3.10 on the Hermes VPS (Ubuntu 24.04 noble) via the deadsnakes PPA —
+verified live: `python3.10 --version` → 3.10.20, `python3.10 scripts/hermes/build_skills.py --check`
+passes — keeping the system `python3` at 3.11. Recorded the now-verified setup step in
+`docs/operations/hermes-control-plane.md` § VPS → new **Python toolchain** subsection (the exact
+deadsnakes commands + the note that PR #869 de-pinned the helpers, so 3.10 is for doc-command parity,
+not a hard requirement). This survives a VPS rebuild instead of living only in a Telegram screenshot.
+
+`check_docs --strict` ✓. Docs only.

--- a/.sessions/2026-06-14-vps-python310-prereq.md
+++ b/.sessions/2026-06-14-vps-python310-prereq.md
@@ -1,6 +1,6 @@
 # Session: record Python 3.10 VPS prerequisite (deadsnakes, verified)
 
-> **Status:** `in-progress` — recording the verified VPS python3.10 prereq; flip to complete last.
+> **Status:** `complete` — PR #870; born-red card flipped as the deliberate final step (Q-0133).
 
 **Branch:** `claude/sharp-ptolemy-5mzbvb` · **Date:** 2026-06-14 · **Type:** docs (ops record, owner-verified)
 

--- a/docs/operations/hermes-control-plane.md
+++ b/docs/operations/hermes-control-plane.md
@@ -24,6 +24,24 @@ Hermes is currently treated as a **repo-aware assistant**, not as a production b
 - Backups: not enabled yet
 - Firewall: Ubuntu `ufw` was configured for SSH during setup
 
+### Python toolchain
+
+- System interpreter: **Python 3.11** (the Ubuntu 24.04 default `python3`).
+- **Python 3.10 installed alongside** (verified 2026-06-14) via the deadsnakes PPA — so the repo's
+  `python3.10`-pinned commands run verbatim while `python3` stays 3.11 (nothing else on the VPS is
+  repointed). Re-run after a VPS rebuild:
+  ```bash
+  sudo add-apt-repository -y ppa:deadsnakes/ppa
+  sudo apt-get update
+  sudo apt-get install -y python3.10 python3.10-venv python3.10-distutils
+  python3.10 --version            # Python 3.10.20
+  ```
+- The Hermes-run helpers (`build_skills.py`, `check_current_state_ledger.py`, `check_phase_gate.py`,
+  `routine_fire.py`, `railway_*`) are stdlib-only and run under **either** `python3` (3.11) or
+  `python3.10` — PR #869 de-pinned them, so 3.10 is installed for doc-command parity, not because
+  they require it. (The `python3.10` pin in `.claude/CLAUDE.md` is for the CI-parity tools —
+  `check_quality`/black/mypy/pytest — which Hermes does not run.)
+
 ### Linux users
 
 - Initial setup was performed through `root`


### PR DESCRIPTION
## What

Record the now-verified Python 3.10 VPS setup step in `docs/operations/hermes-control-plane.md` so it
survives a VPS rebuild (it currently lives only in a Telegram screenshot).

The owner installed Python 3.10 on the Hermes VPS (Ubuntu 24.04 noble) via the deadsnakes PPA —
verified live (`python3.10 --version` → 3.10.20; `build_skills.py --check` passes), keeping system
`python3` at 3.11. Added a **Python toolchain** subsection with the exact deadsnakes commands and the
note that PR #869 already de-pinned the Hermes helpers (so 3.10 is for doc-command parity, not a hard
requirement; the `python3.10` pin in CLAUDE.md is for the CI-parity tools Hermes doesn't run).

## Verify

- `python3 scripts/check_docs.py --strict` → all checks passed ✓

Docs only.

https://claude.ai/code/session_01LnvWKkK3vMHETjNZ8mtj5A

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnvWKkK3vMHETjNZ8mtj5A)_