### PR TITLE
feat(hermes): install-soul.sh + fix operating-prompt home to SOUL.md

### DIFF
--- a/.sessions/2026-06-14-install-soul-script.md
+++ b/.sessions/2026-06-14-install-soul-script.md
@@ -1,6 +1,6 @@
 # Session: install-soul.sh — scripted operating-prompt install + SOUL.md doc fix
 
-> **Status:** `in-progress` — adding the SOUL.md installer + fixing the wiring doc; flip to complete last.
+> **Status:** `complete` — PR #873; born-red card flipped as the deliberate final step (Q-0133).
 
 **Branch:** `claude/sharp-ptolemy-5mzbvb` · **Date:** 2026-06-14 · **Type:** tooling + docs fix (owner-driven, in-session)
 

--- a/.sessions/2026-06-14-install-soul-script.md
+++ b/.sessions/2026-06-14-install-soul-script.md
@@ -1,0 +1,46 @@
+# Session: install-soul.sh — scripted operating-prompt install + SOUL.md doc fix
+
+> **Status:** `in-progress` — adding the SOUL.md installer + fixing the wiring doc; flip to complete last.
+
+**Branch:** `claude/sharp-ptolemy-5mzbvb` · **Date:** 2026-06-14 · **Type:** tooling + docs fix (owner-driven, in-session)
+
+## What this session did
+
+While wiring the operating prompt onto the Hermes VPS, two things surfaced and were fixed.
+
+1. **Doc was wrong about the home.** `hermes-operating-prompt.md` said to paste the prompt into the
+   agent system prompt in `~/.hermes/config.yaml` *or* a base skill. Confirmed against the official
+   Nous Hermes docs (`hermes-agent.nousresearch.com`): the durable identity lives in **`~/.hermes/SOUL.md`**
+   — slot #1 of the system prompt, plain-text, **loaded fresh each message (no restart)**; `config.yaml`
+   is the CLI-managed engine config (`hermes config edit`/`set`), and `agent.personalities` are only
+   `/personality` tone overlays, not the base prompt. Corrected the "How to wire it in" section.
+2. **No repeatable installer.** Skills had `install-skills.sh`; the operating prompt had to be hand-pasted
+   (120 lines — painful on mobile, and a drift risk). Added **`scripts/hermes/install-soul.sh`**
+   (mirror of `install-skills.sh`): extracts the operating-prompt block straight from the doc and writes
+   it to `~/.hermes/SOUL.md`, timestamp-backing-up any existing file; `--dry-run` previews;
+   `HERMES_SOUL` overrides the target. Tested end-to-end here (extract / write / backup / dry-run).
+   Cross-linked from `hermes-skills/README.md`.
+
+The owner's live `SOUL.md` was just the default template (heading + comment, no real identity), so
+Hermes is running on its built-in default — the installer cleanly replaces it with the SuperBot prompt.
+
+Verification: `bash -n` + functional test (writes 96-line/6.1 KB SOUL.md, creates `.bak` on re-run);
+`check_docs --strict` ✓. Tooling + docs only — no runtime bot code.
+
+## 💡 Session idea (Q-0089)
+
+The skill pack has a CI freshness gate (`build_skills.py --check`) but the operating prompt has no
+equivalent — nothing verifies the block in `hermes-operating-prompt.md` is still extractable by
+`install-soul.sh` (a future doc reformat could silently break the installer). Idea: a tiny CI check (or
+a `--check` mode on `install-soul.sh`) that asserts the extraction still yields a non-empty block
+starting with "You are Hermes" — so the installer can't rot. Captured pending a dedup-grep.
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous run (#869, python3 tooling) correctly de-pinned the *invocation* but left the bigger
+deployment story implicit — it didn't notice the operating-prompt doc pointed at the wrong file
+(`config.yaml`) entirely. This session caught it only because the owner went to actually do the wiring
+and hit the wall. System improvement: agent-facing "how to deploy X" docs should be verified against
+the *target tool's own docs* (here, the Nous Hermes docs), not assumed — the same "validate against the
+consumer's environment" lesson as #869, now applied to the install destination, and made durable by
+shipping a tested installer rather than prose steps.

--- a/docs/operations/hermes-operating-prompt.md
+++ b/docs/operations/hermes-operating-prompt.md
@@ -12,11 +12,24 @@ Hermes does not carry SuperBot's working agreement the way a Claude Code session
 the **portable orientation** that gives Hermes the same starting context: where the repo
 is, what it may and may not do, the mental model, what to read first, and how to format output.
 
-**How to wire it in (one-time, maintainer):** put the block below into Hermes' standing
-instructions — either as the agent system prompt in `~/.hermes/config.yaml`, or as a
-base skill in `~/.hermes/skills/` that the other SuperBot skills assume. Re-paste it when
-this doc changes. (The per-task skills in `hermes-skills/` repeat the safety rules so they
-are safe even without this loaded — but loading it makes every ad-hoc prompt safe too.)
+**How to wire it in (one-time, maintainer):** the operating prompt is Hermes' durable
+identity, so it belongs in **`~/.hermes/SOUL.md`** — the plain-text file Hermes loads as
+slot #1 of its system prompt, **fresh on every message (no restart)**; an empty SOUL.md
+falls back to Hermes' built-in default identity. The repeatable way (mirrors
+`install-skills.sh`):
+
+```bash
+cd /home/hermes/repos/superbot && git pull origin main
+bash scripts/hermes/install-soul.sh          # extracts the block below -> SOUL.md (backs up first)
+bash scripts/hermes/install-soul.sh --dry-run  # preview without writing
+```
+
+Or edit `~/.hermes/SOUL.md` by hand (`cp ~/.hermes/SOUL.md ~/.hermes/SOUL.md.bak` first).
+Re-run after this doc changes. **Not `config.yaml`** — that is the CLI-managed engine config
+(`hermes config edit` / `hermes config set`); its `agent.personalities` are only
+`/personality` tone overlays, not the base prompt. The per-task skills in `hermes-skills/`
+install **separately** into `~/.hermes/skills/` via `install-skills.sh` and repeat the safety
+rules so they are safe even without this loaded — but SOUL.md makes every ad-hoc prompt safe too.
 
 ---
 

--- a/docs/operations/hermes-skills/README.md
+++ b/docs/operations/hermes-skills/README.md
@@ -62,6 +62,11 @@ bash scripts/hermes/install-skills.sh --dry-run  # preview
 sudo systemctl restart hermes-gateway            # pick up the new skills
 ```
 
+The **operating prompt** (the always-on base identity) installs separately into `~/.hermes/SOUL.md`
+via its sibling installer — `bash scripts/hermes/install-soul.sh` (see
+[`../hermes-operating-prompt.md`](../hermes-operating-prompt.md)); SOUL.md loads fresh each message,
+so no restart is needed for that one.
+
 Hermes loads any `SKILL.md` under `~/.hermes/skills/` on next run — no registration step.
 Alternatively, each prompt is self-contained and works as a plain Telegram message too.
 

--- a/scripts/hermes/install-soul.sh
+++ b/scripts/hermes/install-soul.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Install the SuperBot operating prompt into Hermes' SOUL.md.
+#
+# SOUL.md (~/.hermes/SOUL.md) is slot #1 of Hermes' system prompt and is loaded
+# fresh on every message (no restart needed). This script extracts the operating
+# prompt from docs/operations/hermes-operating-prompt.md and writes it there,
+# timestamp-backing-up any existing SOUL.md first. It is the SOUL.md sibling of
+# install-skills.sh (which handles ~/.hermes/skills/).
+#
+# Usage (run on the VPS as the `hermes` user, from the repo root):
+#   bash scripts/hermes/install-soul.sh             # install (backs up first)
+#   bash scripts/hermes/install-soul.sh --dry-run   # print the prompt, write nothing
+#
+# Override the target with HERMES_SOUL (default: ~/.hermes/SOUL.md).
+set -euo pipefail
+
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h | --help)
+      sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DOC="$REPO_ROOT/docs/operations/hermes-operating-prompt.md"
+DEST="${HERMES_SOUL:-$HOME/.hermes/SOUL.md}"
+
+# Hermes-run helpers are stdlib-only and version-agnostic — python3 is fine.
+PY="$(command -v python3.10 || command -v python3 || true)"
+[[ -z "$PY" ]] && {
+  echo "error: need python3 on PATH" >&2
+  exit 1
+}
+
+# Extract the first fenced code block after the "## Operating prompt" heading.
+PROMPT="$("$PY" - "$DOC" <<'PYEOF'
+import pathlib, sys
+doc = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+block = doc.split("## Operating prompt", 1)[1].split("```", 2)[1].strip()
+if not block.startswith("You are Hermes"):
+    sys.exit("operating-prompt block not found / unexpected format")
+sys.stdout.write(block + "\n")
+PYEOF
+)"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "# would write to: $DEST"
+  echo "---"
+  printf '%s\n' "$PROMPT"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$DEST")"
+if [[ -f "$DEST" ]]; then
+  cp "$DEST" "$DEST.bak.$(date +%Y%m%d_%H%M%S)"
+fi
+printf '%s\n' "$PROMPT" >"$DEST"
+echo "Installed SuperBot operating prompt -> $DEST ($(wc -c <"$DEST") bytes)."
+echo "SOUL.md loads fresh each message — no restart needed."


### PR DESCRIPTION
## Why

While wiring the operating prompt onto the Hermes VPS, two issues surfaced:

1. **Our doc pointed at the wrong file.** `hermes-operating-prompt.md` said to paste the prompt into
   `~/.hermes/config.yaml`. Confirmed against the official Nous Hermes docs that the durable identity
   lives in **`~/.hermes/SOUL.md`** — slot #1 of the system prompt, plain-text, **loaded fresh each
   message (no restart)**. `config.yaml` is the CLI-managed engine config (`hermes config edit`/`set`);
   its `agent.personalities` are only `/personality` tone overlays, not the base prompt.
2. **No repeatable installer.** Skills had `install-skills.sh`; the operating prompt had to be
   hand-pasted (~120 lines — error-prone on mobile, and a drift risk).

## What

- **`scripts/hermes/install-soul.sh`** (mirror of `install-skills.sh`): extracts the operating-prompt
  block straight from `hermes-operating-prompt.md` and writes it to `~/.hermes/SOUL.md`, timestamp-
  backing-up any existing file. `--dry-run` previews; `HERMES_SOUL` overrides the target.
- **Fixed** the "How to wire it in" section of `hermes-operating-prompt.md` (SOUL.md, not config.yaml)
  and cross-linked the installer from `hermes-skills/README.md`.

## Usage (on the VPS)

```bash
cd /home/hermes/repos/superbot && git pull origin main
bash scripts/hermes/install-soul.sh            # writes the prompt to ~/.hermes/SOUL.md (backs up first)
bash scripts/hermes/install-soul.sh --dry-run  # preview
```

## Verify

- `bash -n scripts/hermes/install-soul.sh` ✓; functional test writes a 96-line/6.1 KB SOUL.md and
  creates a `.bak` on re-run
- `python3 scripts/check_docs.py --strict` ✓

Tooling + docs only — no runtime bot code.

https://claude.ai/code/session_01LnvWKkK3vMHETjNZ8mtj5A

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnvWKkK3vMHETjNZ8mtj5A)_