### PR TITLE
docs(hermes): add terminal cheatsheet reference

### DIFF
--- a/.sessions/2026-06-14-hermes-terminal-cheatsheet.md
+++ b/.sessions/2026-06-14-hermes-terminal-cheatsheet.md
@@ -1,6 +1,6 @@
 # Session: Hermes terminal cheatsheet doc + Acode/GitHub setup guidance
 
-> **Status:** `in-progress` — adding the versioned command cheatsheet; flip to complete last.
+> **Status:** `complete` — PR #874; born-red card flipped as the deliberate final step (Q-0133).
 
 **Branch:** `claude/sharp-ptolemy-5mzbvb` · **Date:** 2026-06-14 · **Type:** docs (owner-requested ops reference)
 

--- a/.sessions/2026-06-14-hermes-terminal-cheatsheet.md
+++ b/.sessions/2026-06-14-hermes-terminal-cheatsheet.md
@@ -1,0 +1,37 @@
+# Session: Hermes terminal cheatsheet doc + Acode/GitHub setup guidance
+
+> **Status:** `in-progress` — adding the versioned command cheatsheet; flip to complete last.
+
+**Branch:** `claude/sharp-ptolemy-5mzbvb` · **Date:** 2026-06-14 · **Type:** docs (owner-requested ops reference)
+
+## What this session did
+
+The owner wanted a copy-paste command reference for operating Hermes/SuperBot from his phone, stored
+durably (he'll open it in Acode) rather than as a drifting Notes paste. Created
+**`docs/operations/hermes-terminal-cheatsheet.md`** (`reference`) — service control, repo→Hermes
+deploy (`install-soul.sh`/`install-skills.sh`), Hermes config/identity, read-only repo health,
+prod diagnostics (`railway_*`), and general Linux — each command with a one-line what/why. Wired it
+into `hermes-control-plane.md` § Useful commands (reachability) so `check_docs` passes and Hermes can
+reference it too. One versioned source, openable from Acode/GitHub.
+
+Also gave the owner verified Acode↔GitHub setup guidance (the Acode **GitHub plugin** for
+browse-without-clone + a fine-grained PAT, vs the Clone Repository + GitPro plugins for full edit/commit)
+in chat — researched against the current Acode plugin ecosystem.
+
+Verification: `check_docs --strict` ✓. Docs only.
+
+## 💡 Session idea (Q-0089)
+
+The cheatsheet is hand-maintained, so it can drift from the actual scripts (a renamed flag, a new
+installer). Idea: a tiny CI check that greps the fenced commands referencing `scripts/hermes/*.sh|.py`
+and asserts each referenced script path exists — cheap protection against the cheatsheet citing a
+script that was moved/removed. Captured pending a dedup-grep.
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous run (#873, install-soul.sh) correctly made the operating-prompt install repeatable but
+stopped at "here are the commands in chat" for everything else — the owner then (reasonably) wanted
+those commands somewhere durable. Lesson reinforced: when a chat answer is a list of commands the
+owner will reuse, the durable move is to version it in the repo from the start (one source, Hermes-
+readable, Acode-openable), not leave it as a transient message. This session closes that by shipping
+the cheatsheet doc.

--- a/docs/operations/hermes-control-plane.md
+++ b/docs/operations/hermes-control-plane.md
@@ -239,6 +239,10 @@ Before inspecting SuperBot, use /home/hermes/repos/superbot. Do not modify files
 
 ## Useful commands
 
+> **Full reference:** [`hermes-terminal-cheatsheet.md`](hermes-terminal-cheatsheet.md) — the
+> copy-paste command list (service control, repo sync, health checks, prod diagnostics). The
+> essentials are repeated here.
+
 Check service status:
 
 ```bash

--- a/docs/operations/hermes-terminal-cheatsheet.md
+++ b/docs/operations/hermes-terminal-cheatsheet.md
@@ -1,0 +1,78 @@
+# Hermes / SuperBot — Terminal Cheatsheet
+
+> **Status:** `reference` — copy-paste command reference for operating Hermes on the VPS and
+> the SuperBot repo from a phone/terminal. Pairs with
+> [`hermes-control-plane.md`](hermes-control-plane.md) (the setup record) and
+> [`hermes-operating-prompt.md`](hermes-operating-prompt.md) (Hermes' identity). Keep it
+> current when a script/command changes — it is meant to be opened directly (e.g. in Acode).
+
+**Context:** VPS user `hermes` · repo `/home/hermes/repos/superbot` · Hermes home `~/.hermes`.
+Most repo commands assume you ran `cd /home/hermes/repos/superbot` first. Everything under
+*read-only* is safe to run anytime — it never mutates the repo, Hermes, or production.
+
+## Hermes service (systemd; restart/stop need `sudo`)
+
+```bash
+sudo systemctl restart hermes-gateway          # Restart Hermes. Run after install-skills.sh to load new/updated skills.
+systemctl status hermes-gateway --no-pager     # Is Hermes alive? active/failed + recent log lines.
+sudo systemctl stop hermes-gateway             # Stop Hermes (e.g. before maintenance).
+sudo systemctl start hermes-gateway            # Start it again.
+sudo journalctl -u hermes-gateway -n 50 --no-pager   # Last 50 log lines — first stop when Hermes misbehaves.
+sudo journalctl -u hermes-gateway -f           # Live-tail the logs (Ctrl+C to stop).
+```
+
+## Deploy repo config → Hermes (after a session changes prompts/skills)
+
+```bash
+cd /home/hermes/repos/superbot                 # Go to the repo (lines below assume you're here).
+git pull origin main                           # Pull the latest changes. Always do this before re-installing.
+bash scripts/hermes/install-soul.sh            # Write the operating prompt → ~/.hermes/SOUL.md (backs up first). No restart needed.
+bash scripts/hermes/install-skills.sh          # Copy skill files → ~/.hermes/skills/. Restart the gateway after this one.
+bash scripts/hermes/install-soul.sh --dry-run  # Preview the prompt without writing it.
+```
+
+## Hermes config & identity
+
+```bash
+hermes config                                  # Show Hermes' current configuration.
+hermes config edit                             # Safely edit config.yaml (e.g. trim joke personalities).
+hermes config check                            # Validate the config after editing.
+hermes --help                                  # Explore the rest of the Hermes CLI.
+cat ~/.hermes/SOUL.md                          # View Hermes' current base identity / operating prompt.
+ls ~/.hermes/skills/                           # List the skills Hermes has installed.
+```
+
+## Repo state & health (read-only)
+
+```bash
+git -C /home/hermes/repos/superbot log --oneline -10   # Last 10 commits — what landed recently.
+git -C /home/hermes/repos/superbot status              # Any uncommitted local changes on the VPS clone?
+python3 scripts/check_current_state_ledger.py --strict # Is the docs ledger in sync with merged PRs? (clean = nothing to reconcile)
+python3 scripts/check_phase_gate.py --phase            # fix-phase or invent-phase? (gates new feature work)
+python3 scripts/hermes/build_skills.py --check         # Are the installed skills up to date with the docs?
+```
+
+## Production (bot) diagnostics — read-only
+
+```bash
+python3 scripts/hermes/railway_logs.py -n 200          # Last 200 lines of the bot's live production logs.
+python3 scripts/hermes/railway_logs.py --whoami        # Test that the Railway token works.
+python3 scripts/hermes/railway_vars.py list            # List production env vars (values masked).
+```
+
+## General Linux (handy on any box)
+
+```bash
+df -h                                          # Free disk space (watch this on a small VPS).
+free -h                                        # RAM usage.
+du -sh ~/.hermes/*                             # What's eating space in Hermes' home (caches, state.db).
+top                                            # Live CPU/mem/process viewer (q to quit; 'htop' is nicer if installed).
+```
+
+## Notes
+
+- The `hermes …` commands are the Hermes Agent CLI (Nous Research). `hermes config set KEY VAL`
+  changes one setting and routes it to the right file automatically.
+- Hermes-run helper scripts (`build_skills.py`, `check_*`, `routine_fire.py`, `railway_*`) are
+  stdlib-only, so `python3` works (the VPS also has `python3.10` installed for doc-command parity).
+- SOUL.md reloads on every message (no restart); skills load on gateway start (restart needed).


### PR DESCRIPTION
## What

A versioned, copy-paste command reference for operating Hermes/SuperBot from a phone/terminal —
`docs/operations/hermes-terminal-cheatsheet.md` (`reference`). The owner wanted this stored durably
(opened from Acode) rather than as a drifting Notes paste; in the repo it's one source that stays
current, Hermes can read it, and Acode can open it directly.

Sections: Hermes service control · repo→Hermes deploy (`install-soul.sh`/`install-skills.sh`) · Hermes
config & identity · read-only repo health (`check_*`) · prod diagnostics (`railway_*`) · general Linux.
Each command has a one-line what/why. Wired into `hermes-control-plane.md` § Useful commands for
reachability.

## Verify

- `python3 scripts/check_docs.py --strict` → all checks passed ✓ (badge + reachability)

Docs only.

https://claude.ai/code/session_01LnvWKkK3vMHETjNZ8mtj5A

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnvWKkK3vMHETjNZ8mtj5A)_