### PR TITLE
docs(hermes): capture branch-hygiene + prune command in the cheatsheet

### DIFF
--- a/.sessions/2026-06-14-branch-hygiene-cheatsheet.md
+++ b/.sessions/2026-06-14-branch-hygiene-cheatsheet.md
@@ -1,0 +1,33 @@
+# Session: branch-hygiene note in the cheatsheet (626→2 prune capture)
+
+> **Status:** `complete` — docs-only; born-red gate satisfied by this card.
+
+**Branch:** `claude/sharp-ptolemy-5mzbvb` · **Date:** 2026-06-14 · **Type:** docs (ops knowledge capture)
+
+## What this session did
+
+While helping the owner set up Acode↔GitHub, the repo's **626 leftover `claude/*` branches** broke
+Acode's branch picker (it paginates and never reaches `main`). The owner pruned them on the VPS
+(626→2: `main` + the live session branch). Captured the durable lesson in
+`hermes-terminal-cheatsheet.md` → new **Branch hygiene** section: enable "Automatically delete head
+branches", the one-time bulk-prune command (run from a clone with push rights — a Claude sandbox's
+git proxy 403s on deleting other branches), and the reassurance that deleting a branch never deletes
+its PR. `check_docs --strict` ✓.
+
+## 💡 Session idea (Q-0089)
+
+The autonomous loop creates a `claude/*` branch per PR but nothing in-repo enforces cleanup — the
+pileup is invisible until something (like Acode) chokes on it. Idea: have a routine (or the
+reconciliation pass) include a quick `git branch -r | wc -l` sanity check and flag when remote
+branch count crosses a threshold (say >50), so buildup is caught early instead of at 626. The real
+fix is the GitHub "auto-delete head branches" setting, but a checker catches the case where that's
+off. Captured pending a dedup-grep.
+
+## ⟲ Previous-session review (Q-0102)
+
+This whole Acode arc (a chain of small owner-driven fixes) went well as collaboration but exposed a
+gap: agent-facing setup docs assumed the repo was tidy. The branch pileup had been accumulating
+silently across hundreds of autonomous PRs because none enabled GitHub's auto-delete-on-merge — a
+one-time setting no session ever owned. Lesson: infrastructure defaults that prevent slow accretion
+(branch auto-delete, log rotation, cache caps) are worth setting *once, early*; this session both
+fixed the symptom and recorded the prevention so it's not rediscovered at the next 600-branch wall.

--- a/docs/operations/hermes-terminal-cheatsheet.md
+++ b/docs/operations/hermes-terminal-cheatsheet.md
@@ -69,6 +69,27 @@ du -sh ~/.hermes/*                             # What's eating space in Hermes' 
 top                                            # Live CPU/mem/process viewer (q to quit; 'htop' is nicer if installed).
 ```
 
+## Branch hygiene (keeping the repo prunable)
+
+Autonomous sessions create a `claude/*` branch per PR; they pile up fast (hit **626** once,
+which broke Acode's branch picker — it can't paginate that far to reach `main`).
+
+```bash
+# Prevent buildup (one-time, GitHub web): repo Settings → General → Pull Requests →
+#   check "Automatically delete head branches"  → every merged PR self-deletes its branch.
+
+# One-time bulk prune of leftover branches (run from a clone with push rights, e.g. the VPS —
+# NOT from a Claude sandbox, whose git proxy 403s on deleting other branches):
+cd /home/hermes/repos/superbot && git fetch --prune origin
+git branch -r | sed 's#^[[:space:]]*origin/##' | grep -v '^HEAD' \
+  | grep -vx main > /tmp/del.txt   # keep main (add more -vx lines to keep others)
+wc -l /tmp/del.txt                  # review the count first
+xargs -n 50 -a /tmp/del.txt git push origin --delete
+```
+
+**Deleting a branch never deletes its PR** — every PR (title, diff, commits, reviews) stays fully
+viewable at `…/pulls`, and merged code lives in `main`. Safe to prune freely.
+
 ## Notes
 
 - The `hermes …` commands are the Hermes Agent CLI (Nous Research). `hermes config set KEY VAL`


### PR DESCRIPTION
## What

Capture the branch-hygiene lesson from today in `hermes-terminal-cheatsheet.md` (new **Branch
hygiene** section): the autonomous loop's `claude/*` branches piled up to **626** and broke Acode's
branch picker; the owner pruned them (626→2). Records:
- Enable GitHub's **"Automatically delete head branches"** (prevents future buildup).
- The one-time bulk-prune command (run from a clone with push rights — a Claude sandbox's git proxy
  403s on deleting other branches).
- That **deleting a branch never deletes its PR** (history stays viewable; merged code is in `main`).

## Verify
- `python3 scripts/check_docs.py --strict` → all checks passed ✓

Docs only.

https://claude.ai/code/session_01LnvWKkK3vMHETjNZ8mtj5A

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnvWKkK3vMHETjNZ8mtj5A)_