### PR TITLE
docs(ops): correct DATABASE_PUBLIC_URL backup status to working

### DIFF
--- a/.sessions/2026-06-14-backup-status-correction.md
+++ b/.sessions/2026-06-14-backup-status-correction.md
@@ -1,0 +1,31 @@
+# Session: correct the DATABASE_PUBLIC_URL backup status (it's working)
+
+> **Status:** `complete` — docs-only; born-red gate satisfied by this card.
+
+**Branch:** `claude/sharp-ptolemy-5mzbvb` · **Date:** 2026-06-14 · **Type:** docs (ledger accuracy fix)
+
+## What this session did
+
+The owner pushed back on my "DB backup still failing" claim — correctly. I'd relied on the open
+"Postgres backup failed" issues, which **don't auto-close on success**. The actual run history shows
+the backup **succeeded at 17:41:49Z 2026-06-14** (workflow_dispatch) after the PR #862 pg18-client +
+`DATABASE_PUBLIC_URL` fix; the earlier failures were #862's test iterations + a pre-fix scheduled run.
+Closed the three stale failure-issues (#823/#860/#861) and corrected the control-plane state ledger
+(`autonomous-routines.md` row 2 ⬜→✅ + the summary note) — the stale "still unset" status was the
+source of my wrong advice, so fixing it prevents the next session repeating it. `check_docs --strict` ✓.
+
+## 💡 Session idea (Q-0089)
+
+`backup-db.yml` opens a failure-issue on each failed run but never **closes** it on a subsequent
+success — so resolved problems linger as open issues and mislead (exactly what happened here). Idea:
+add a tiny success-path step to the workflow that closes any open "Postgres backup failed" issues
+(`gh issue list --search ... | gh issue close`) when a run succeeds, so the issue tracker reflects
+live state. Captured pending a dedup-grep.
+
+## ⟲ Previous-session review (Q-0102)
+
+My own earlier turn this session asserted a failure from stale signal (open issues) instead of the
+authoritative source (workflow run conclusions) — a verify-don't-assume miss I'd just been preaching
+for Hermes (#869/#873). Lesson, now applied: for "is X working?" check the **run/outcome history**,
+not derived artifacts like auto-created issues that have no auto-close. The control-plane ledger fix
++ the proposed auto-close step turn that one-off correction into a durable guard.

--- a/docs/operations/autonomous-routines.md
+++ b/docs/operations/autonomous-routines.md
@@ -285,14 +285,15 @@ The routine treats the issue as the go-signal, runs the docs-only pass, and clos
 | # | Maintainer action | Why it matters | Source PR | Verified? |
 |---|---|---|---|---|
 | 1 | Add repo secret **`ROUTINE_PAT`** (fine-grained PAT, this repo, **Issues: read/write**) | **Hard blocker for the whole loop** — without it, cron/cadence trigger issues are authored by `github-actions[bot]`, which **does not start a Claude routine** (A/B-verified: real-user issue #776 fired in <1 min; bot's #768 never did) | #778 | ✅ **2026-06-14** (live-evidence verify: the scheduled executor issue #819 and the cadence reconcile issues #822/#841 were auto-opened by the workflows yet authored by **`menno420`** — the PAT owner — not `github-actions[bot]`. With `GITHUB_TOKEN` they would be bot-authored. So `ROUTINE_PAT` is set and active.) |
-| 2 | Add repo secret **`DATABASE_PUBLIC_URL`** (Railway Postgres public proxy URL) | the daily `backup-db.yml` `pg_dump` is inert without it (workflow fails + opens an issue) | #769 | ⬜ **still unset** — `backup-db.yml` opens a "Postgres backup failed" issue every day (latest #823, 2026-06-14); the cron *fires* but the dump fails for lack of this secret. |
+| 2 | Add repo secret **`DATABASE_PUBLIC_URL`** (Railway Postgres public proxy URL) | the daily `backup-db.yml` `pg_dump` is inert without it (workflow fails + opens an issue) | #769 | ✅ **2026-06-14 — set + working.** After the PR #862 pg18-client + resolved-URL fix, the backup **succeeded at 17:41:49Z** (run history: `success` workflow_dispatch). The earlier daily "Postgres backup failed" issues (#823/#860/#861) predated the fix and were stale (failure-issues don't auto-close on success); **closed 2026-06-14.** The next *scheduled* run confirms the cron path end-to-end. |
 | 3 | Railway → **Deploy** the staged `CLAUDE_ROUTINE_*` env vars | `/bugreport` + `/dispatch` (HermesCog #757) may be inactive until the worker redeploys with the vars live | #765 | ⬜ (not verifiable from the repo) |
 | 4 | Confirm the **dispatch routine prompt** is the free-form version | the owner finished routine setup *before* the #761 free-form prompt was handed over — it may carry the older prompt | #761/#765 | ⬜ (not verifiable from the repo) |
 | 5 | Confirm **routine models**: dispatch/executor = **Opus 4.8**, reconciliation = Sonnet/Opus (not **Fable 5**) | dispatch was last seen on Fable 5 (premium) → daily spend risk vs. the €30/mo Q-0082 cap | §11 / #765 | ⬜ (not verifiable from the repo) |
 | 6 | After #1: **`workflow_dispatch` `executor-nightly.yml`** once | the **first real unattended executor run** (the Q-0105 "watch the first run" moment) | #778 | ✅ **2026-06-14** — the loop **has now self-fired unattended**: scheduled executor issue #819 (auto-opened) ran on its own, opened the `continue` handoff #821, and that chain produced merged P0-4 work (#825). No manual `workflow_dispatch` was needed. |
 
-> Rows 1 + 6 are now verified live — the autonomous loop self-fires. Rows 2–5 remain maintainer-side
-> (row 2 is confirmed *still pending* by the daily backup-failure issues). The first autonomous
+> Rows 1, 2, and 6 are now verified live — the autonomous loop self-fires and the DB backup succeeds
+> (row 2 fixed 2026-06-14: the 17:41Z run is green; the daily failure-issues were stale and are closed).
+> Rows 3–5 remain maintainer-side (not verifiable from the repo). The first autonomous
 > **reconciliation** has also fired (the band-#820/#840 cadence passes ran via #822/#841).
 >
 > **⏱️ Timing caveat — GitHub Actions cron lag (not a config bug).** GitHub's `schedule:` trigger is


### PR DESCRIPTION
## What

Correct the control-plane ledger: the DB backup **is working**, not failing. I'd earlier relied on
the open "Postgres backup failed" issues, which don't auto-close on success. The run history shows the
backup **succeeded at 17:41:49Z 2026-06-14** (workflow_dispatch) after the PR #862 pg18-client +
`DATABASE_PUBLIC_URL` fix.

- `autonomous-routines.md` row 2: ⬜ "still unset" → ✅ "set + working" (+ corrected the summary note).
- Closed the three stale failure-issues (#823, #860, #861) — they predated the fix.

## Verify
- `python3 scripts/check_docs.py --strict` → all checks passed ✓
- Backup run history: `success @ 2026-06-14T17:41:49Z` (workflow_dispatch).

Docs only.

https://claude.ai/code/session_01LnvWKkK3vMHETjNZ8mtj5A

---
_Generated by [Claude Code](https://claude.ai/code/session_01LnvWKkK3vMHETjNZ8mtj5A)_