### PR TITLE
AI hardening: eval-coverage drift guard — the matrix can't silently fall behind the tool/task surface

### DIFF
--- a/.sessions/2026-06-14-eval-coverage-drift-guard.md
+++ b/.sessions/2026-06-14-eval-coverage-drift-guard.md
@@ -1,0 +1,23 @@
+# Session: eval-coverage drift guard (Q-0089 idea → build)
+
+> **Status:** `in-progress`
+
+**Branch:** `claude/wizardly-edison-xw34kb` · **PR:** (opening) · **Date:** 2026-06-14 · **Type:** AI hardening / invariant (follow-up to #878)
+
+## What I'm about to do (born-red declaration)
+Implement the session idea the owner approved from #878: a **CI eval-coverage drift guard**. A tiny
+invariant that fails when a canonical AI tool (`services.ai_tools.all_tool_specs`) or an `AITask`
+enters the surface but **no** golden/smoke eval case references it — so the now-versioned eval
+matrix can't silently fall behind the surface it's meant to prove ("enforce, don't exhort", the same
+principle as the doc-freshness gates).
+
+**Design:** a self-cleaning **ratchet**, not an absolute mandate (only 8/34 tools, 2/16 tasks are
+covered today). Partition: `catalogue == referenced ∪ acknowledged`. The acknowledged set is the
+explicit, reviewable **pick-list of the current gap**; the guard fails on (a) a new
+unreferenced+unacknowledged tool/task, (b) a stale ack whose tool/task no longer exists, and (c) an
+ack entry that is now *also* referenced (forces the ledger to shrink as coverage grows).
+
+## Coordination
+Bot tests only (`tests/evals/`). No `disbot/` runtime change. Follow-up to the just-merged #878.
+
+_(filled in at session close: shipped / verified / idea / review / doc audit)_

--- a/.sessions/2026-06-14-eval-coverage-drift-guard.md
+++ b/.sessions/2026-06-14-eval-coverage-drift-guard.md
@@ -1,6 +1,6 @@
 # Session: eval-coverage drift guard (Q-0089 idea → build)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Branch:** `claude/wizardly-edison-xw34kb` · **PR:** (opening) · **Date:** 2026-06-14 · **Type:** AI hardening / invariant (follow-up to #878)
 
@@ -20,4 +20,44 @@ ack entry that is now *also* referenced (forces the ledger to shrink as coverage
 ## Coordination
 Bot tests only (`tests/evals/`). No `disbot/` runtime change. Follow-up to the just-merged #878.
 
-_(filled in at session close: shipped / verified / idea / review / doc audit)_
+## Shipped
+- **`tests/evals/test_eval_coverage.py`** — the drift guard. Partition ratchet over the canonical
+  tool surface (`services.ai_tools.all_tool_specs`, 34 tools) and `AITask` (16): `referenced ∪
+  acknowledged == surface`, disjoint, with a **coverage floor** (8 tools / 2 tasks) so coverage can
+  only ratchet up. Three actionable failure directions (new-unacked · stale-ack · ack-now-covered)
+  + **2 meta-tests** proving the guard actually *fires* on synthetic drift (a guard that can't fail
+  is worse than none — the journal's dead-safety-check lesson). The two acknowledged sets are the
+  explicit, grouped **pick-list of the current gap** (BTD6 data · server-introspection · AI
+  self-awareness · diagnostics — 26 tools; 14 tasks).
+
+## Verified
+`check_quality --full` green (**9645 passed** — +12 guard tests) · `check_architecture --mode strict`
+**0 errors** · the guard's firing is itself tested (`test_guard_fires_on_a_synthetic_new_tool`).
+PR **#879** (born-red → flipped complete last).
+
+## 💡 Session idea (Q-0089)
+**Surface the coverage gap as a scorecard line:** have `run_evals.py --smoke` (and the live record)
+print `tools: 8/34 covered · tasks: 2/16` sourced from the same guard logic — so the acknowledged
+pick-list becomes a *visible dashboard number* that nudges each session to pick one off, not just a
+silent allowlist. Small; turns the ratchet into a progress signal. Dedup-checked: no existing
+eval-dashboard idea.
+
+## ⟲ Previous-session review (Q-0102)
+Reviewing **#878 (the eval/smoke matrix, this conversation's prior session):** solid — it shipped a
+genuinely missing artifact (CI-gated deterministic AI contract) and left Layer B correctly gated.
+**What it missed:** it *added* a versioned matrix but nothing stopped that matrix from decaying — the
+idea that became this PR. It also surfaced (but didn't fix) that **P1-1 is really 3–4 sub-slices**
+under one roadmap line. **System improvement:** this two-session arc (build the matrix → immediately
+guard it from decay) is a good *pattern* — **"ship the enforcement with the artifact, not a session
+later."** A new CI artifact (matrix, ledger, registry) should land with its anti-drift guard in the
+same or the very next PR, while the gap is fresh; the doc-freshness gates already embody this, and
+the eval matrix now does too.
+
+## Doc audit (Q-0104)
+`check_docs --strict` ✓ · `check_quality --full` ✓ · no owner decision this session (the idea was
+owner-approved in chat; the design — ratchet vs. mandate — was derived from current 8/34 reality, no
+router entry needed). Ledger: folded #879 into the existing #878 Recently-shipped entry (one eval
+thread → ratchet stays at 20); added a one-line note to the AI readiness map. The #872–#876 drift
+noted in #878's log remains for the reconciliation routine (Q-0124).
+**Grooming (Q-0015):** hardened the #878 artifact against the most likely way it would have rotted —
+exactly the "enforce, don't exhort" maturation the agent-workflow prizes.

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -207,17 +207,20 @@ Source code and merged PRs win over anything written here.
 > auto-opens a `reconcile` issue at the boundary that fires the docs-reconciliation routine). Reset
 > this marker to the latest PR after a pass.
 
-- **#878 (2026-06-14, P1-1 — versioned AI eval/smoke matrix, offline half)** — the standing #1
-  priority's deterministic, CI-gated half. The live golden set (`tests/evals/cases.py`) is
-  creds-only (`scripts/run_evals.py`), and CI exercised only the harness *machinery* — there was
-  no CI proof of the AI path's **deterministic contract**. New **`tests/evals/smoke.py`** drives
-  the **real gateway** with scripted providers (no API) — 16 cases across **gates · fallback ·
-  tool-dispatch · audit-visibility · safety · redaction · config** — gated by
-  `tests/evals/test_smoke_matrix.py` on every PR, and rendered as one **versioned scorecard**
-  (`scripts/run_evals.py --smoke`, creds-free). Both halves are now version-stamped
-  (`GOLDEN_SET_VERSION` / `SMOKE_MATRIX_VERSION`); the **#855 Layer-A** MOAB-path probe was added
-  to the golden set. `check_quality --full` green (9633); arch 0. **Still owed (P1-1):** the
-  live-quality battery (needs prod creds) + absence-guard **Layer B** (design-for-review).
+- **#878 + #879 (2026-06-14, P1-1 — versioned AI eval/smoke matrix, offline half + its drift guard)**
+  — the standing #1 priority's deterministic, CI-gated half. The live golden set
+  (`tests/evals/cases.py`) is creds-only (`scripts/run_evals.py`), and CI exercised only the harness
+  *machinery* — there was no CI proof of the AI path's **deterministic contract**. **#878:** new
+  **`tests/evals/smoke.py`** drives the **real gateway** with scripted providers (no API) — 16 cases
+  across **gates · fallback · tool-dispatch · audit-visibility · safety · redaction · config** —
+  gated by `tests/evals/test_smoke_matrix.py` on every PR, and rendered as one **versioned scorecard**
+  (`scripts/run_evals.py --smoke`, creds-free); both halves version-stamped (`GOLDEN_SET_VERSION` /
+  `SMOKE_MATRIX_VERSION`); the **#855 Layer-A** MOAB-path probe added to the golden set. **#879:** an
+  **eval-coverage drift guard** (`tests/evals/test_eval_coverage.py`) — a self-cleaning ratchet so a
+  new canonical AI tool/`AITask` can't silently fall outside the matrix (referenced ∪ acknowledged ==
+  surface; coverage floor; meta-tested to actually fire). `check_quality --full` green (9645); arch 0.
+  **Still owed (P1-1):** the live-quality battery (needs prod creds) + absence-guard **Layer B**
+  (design-for-review).
 - **#870 + #869 + #868 (2026-06-14, Hermes operating-layer hardening arc)** — three docs-only PRs
   maturing the Hermes autonomous-loop control plane. **#868 (Q-0142):** fixed a real misread — a
   stale reconciliation dispatch fired because a decade-queue slot was read as a reserved PR number;

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -27,13 +27,13 @@ living ledger (`docs/current-state.md`).
 
 - `claude/modest-ptolemy-2xipoh` · design capture — routine dispatch / staged deep-clean /
   planning sectors (owner discussion) · `docs/ideas/` + router Q-0137 · 2026-06-14
-- `claude/wizardly-edison-xw34kb` · eval-coverage drift guard (Q-0089 idea, owner-approved) ·
-  `tests/evals/test_eval_coverage.py` · 2026-06-14
 ## Recently cleared
 
+- `claude/wizardly-edison-xw34kb` · eval-coverage drift guard (Q-0089 idea, owner-approved) ·
+  `tests/evals/test_eval_coverage.py` · 2026-06-14 · **PR #879 (open, auto-merge on green)**
 - `claude/wizardly-edison-xw34kb` · P1-1 — versioned AI eval/smoke matrix (offline half:
   gates/fallback/tool-dispatch/audit) · `tests/evals/` + `scripts/run_evals.py` · 2026-06-14 ·
-  **PR #878 (open, auto-merge on green)**
+  **PR #878 (merged)**
 - `claude/ecstatic-euler-bslyvd` · map roadmaps/plans onto the 5 sectors → dispatchable per-sector
   queues + dispatch contract + S↔A reconcile · docs-only (`roadmap.md` · `repo-sector-map.md` ·
   `repo-review-map.md` · `current-state.md`) · 2026-06-14 · **PR #877**

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -27,6 +27,8 @@ living ledger (`docs/current-state.md`).
 
 - `claude/modest-ptolemy-2xipoh` · design capture — routine dispatch / staged deep-clean /
   planning sectors (owner discussion) · `docs/ideas/` + router Q-0137 · 2026-06-14
+- `claude/wizardly-edison-xw34kb` · eval-coverage drift guard (Q-0089 idea, owner-approved) ·
+  `tests/evals/test_eval_coverage.py` · 2026-06-14
 ## Recently cleared
 
 - `claude/wizardly-edison-xw34kb` · P1-1 — versioned AI eval/smoke matrix (offline half:

--- a/docs/planning/production-readiness/ai-production-readiness-map-2026-06-12.md
+++ b/docs/planning/production-readiness/ai-production-readiness-map-2026-06-12.md
@@ -190,7 +190,7 @@ These are not blockers for the current opt-in read-only/advisory feature set, bu
 - The **deterministic** half of the eval/smoke matrix is now CI-gated (`tests/evals/smoke.py`, #878 — gates · fallback · tool-dispatch · audit · safety · redaction · config). The remaining gap is the **live-quality** artifact (the golden set), which still isn't auto-required by CI after router/grounding/tool changes (it needs paid provider creds — run `scripts/run_evals.py`).
 - External-provider Setup Advisor needs production-like validation for timeout/fallback/redaction and recommendation quality.
 - `diagnostics_health_snapshot` still needs an operator live-test record across audience/redaction and fresh/cached modes.
-- The broader natural-language phrase space and BTD6 vocabulary cannot be exhaustively unit-tested; regression prompts from each live miss should continue to enter the eval suite.
+- The broader natural-language phrase space and BTD6 vocabulary cannot be exhaustively unit-tested; regression prompts from each live miss should continue to enter the eval suite. A CI **eval-coverage drift guard** (`tests/evals/test_eval_coverage.py`, #879) now enforces that a new canonical AI tool / `AITask` cannot silently fall outside the matrix — `8/34` tools and `2/16` tasks are eval-covered today, ratcheting up.
 - The Setup Advisor’s OpenAI path is tested through mocks/contracts, while Anthropic is intentionally absent.
 - Docs checks can verify links/pins/structure but cannot prove live provider or Discord behavior.
 

--- a/tests/evals/test_eval_coverage.py
+++ b/tests/evals/test_eval_coverage.py
@@ -1,0 +1,256 @@
+"""Eval-coverage drift guard — the versioned eval matrix can't silently fall
+behind the AI surface it is meant to prove.
+
+**"Enforce, don't exhort"** (the doc-freshness-gate principle): when a new
+canonical AI tool (``services.ai_tools.all_tool_specs``) or ``AITask`` enters the
+surface, the eval matrix — the golden set (``tests/evals/cases.py``) plus the
+offline smoke matrix (``tests/evals/smoke.py``) — must gain a case that exercises
+it, **or** it must be listed in the acknowledged-uncovered set below, with a
+reason.
+
+The acknowledged sets are a **self-cleaning ratchet, not a permanent exemption**:
+they are the explicit, reviewable *pick-list of today's coverage gap* (8/34
+tools, 2/16 tasks at creation, 2026-06-14). This module fails on three drift
+directions, each with an actionable message:
+
+1. a **new** tool/task that is neither referenced nor acknowledged
+   → add an eval case, or acknowledge it here with a reason;
+2. a **stale** acknowledgement whose tool/task no longer exists → remove it;
+3. an acknowledged entry that is **now also referenced** by a case
+   → remove it from the acknowledged set (coverage grew → the ledger shrinks).
+
+Plus a **coverage floor** so coverage can only ratchet up: you cannot quiet a
+deleted case by moving its tool/task into the acknowledged set.
+
+(1) catches the forgotten-eval case; (2)+(3)+the floor stop the acknowledged
+list from rotting into a rubber stamp.
+"""
+
+from __future__ import annotations
+
+from tests.evals.cases import CASES
+from tests.evals.smoke import SMOKE_CASES
+
+from core.runtime.ai.contracts import AITask
+from services import ai_tools
+
+# --------------------------------------------------------------------------- #
+# Acknowledged-uncovered TOOLS — the current gap. Pick names off these sets as
+# you add live/smoke probes for them; the tests below fail if a name here is
+# also covered (so the list can only shrink) or no longer exists.
+# --------------------------------------------------------------------------- #
+
+# BTD6 data + answerability lookups. Their *retrieval* is deterministically
+# unit-pinned (tests/unit/services/ — btd6 context/grounding/tooling); a live
+# golden probe (model uses the tool result faithfully) is the incremental add.
+_ACK_BTD6_TOOLS = frozenset(
+    {
+        "btd6_answerability",
+        "btd6_bloon_filter",
+        "btd6_boss_lookup",
+        "btd6_ct_team_status",
+        "btd6_cumulative_cost",
+        "btd6_geraldo_lookup",
+        "btd6_list_roster",
+        "btd6_map_lookup",
+        "btd6_mode_lookup",
+        "btd6_monkey_knowledge_lookup",
+        "btd6_paragon_calculate",
+        "btd6_paragon_requirements",
+        "btd6_paragon_stats_at_degree",
+        "btd6_power_effect",
+        "btd6_power_lookup",
+        "btd6_relic_lookup",
+        "btd6_round_cash",
+        "btd6_round_composition",
+    }
+)
+
+# Read-only guild-introspection tools (the model's "look at this server" surface).
+_ACK_SERVER_TOOLS = frozenset(
+    {
+        "get_server_overview",
+        "list_all_members",
+        "list_server_channels",
+        "list_server_roles",
+        "lookup_member",
+    }
+)
+
+# AI self-awareness tools (audience-tiered, read-only).
+_ACK_AI_INTROSPECTION_TOOLS = frozenset(
+    {
+        "get_ai_policy_explanation",
+        "get_ai_tool_catalog",
+    }
+)
+
+# Operator diagnostics (platform-owner scope).
+_ACK_DIAGNOSTICS_TOOLS = frozenset({"diagnostics_health_snapshot"})
+
+_ACK_UNCOVERED_TOOLS = (
+    _ACK_BTD6_TOOLS
+    | _ACK_SERVER_TOOLS
+    | _ACK_AI_INTROSPECTION_TOOLS
+    | _ACK_DIAGNOSTICS_TOOLS
+)
+
+# --------------------------------------------------------------------------- #
+# Acknowledged-uncovered TASKS. Most are exercised by their own service/cog
+# tests rather than the live eval matrix; listed so a *new* task forces a
+# conscious "add a case or acknowledge it" decision.
+# --------------------------------------------------------------------------- #
+_ACK_UNCOVERED_TASKS = frozenset(
+    {
+        "BTD6_STRATEGY_REVIEW",
+        "CODE_CONTEXT_EXPLAIN",
+        "HELP_ANSWER",
+        "LOGS_TRIAGE",
+        "MODERATION_ASSIST",
+        "PLATFORM_EXPLAIN_CONSISTENCY",
+        "PLATFORM_EXPLAIN_STATUS",
+        "SETTINGS_EXPLAIN",
+        "SETTINGS_PROPOSE",
+        "SETUP_EXPLAIN",
+        "SETUP_SUGGEST",
+        "VIDEO_COMPARE",
+        "VIDEO_DESCRIBE",
+        "VIDEO_QA",
+    }
+)
+
+# Coverage floors — the ratchet's teeth. Coverage can only go up: raise these as
+# you add cases (and shrink the acknowledged sets), never lower them to quiet a
+# deleted case.
+_TOOL_COVERAGE_FLOOR = 8
+_TASK_COVERAGE_FLOOR = 2
+
+
+# --------------------------------------------------------------------------- #
+# Surface + coverage collectors.
+# --------------------------------------------------------------------------- #
+def _catalogue_tools() -> set[str]:
+    """Every canonical tool name — flag-independent (the model-offerable surface)."""
+    return set(ai_tools.all_tool_specs())
+
+
+def _referenced_tools() -> set[str]:
+    """Tool names offered by at least one golden or smoke case."""
+    return {spec.name for case in CASES for spec in case.tools} | {
+        spec.name for case in SMOKE_CASES for spec in case.tools
+    }
+
+
+def _all_tasks() -> set[str]:
+    return {task.name for task in AITask}
+
+
+def _referenced_tasks() -> set[str]:
+    return {case.task.name for case in CASES} | {case.task.name for case in SMOKE_CASES}
+
+
+# --------------------------------------------------------------------------- #
+# Tools.
+# --------------------------------------------------------------------------- #
+def test_new_tool_needs_coverage_or_acknowledgement():
+    new_uncovered = _catalogue_tools() - _referenced_tools() - _ACK_UNCOVERED_TOOLS
+    assert not new_uncovered, (
+        f"New AI tool(s) with no eval coverage: {sorted(new_uncovered)}. "
+        "Add a golden/smoke case that offers the tool (tests/evals/cases.py) so "
+        "the versioned matrix proves it, or add the name to _ACK_UNCOVERED_TOOLS "
+        "with a reason (tests/evals/test_eval_coverage.py)."
+    )
+
+
+def test_no_stale_acknowledged_tools():
+    stale = _ACK_UNCOVERED_TOOLS - _catalogue_tools()
+    assert not stale, (
+        f"_ACK_UNCOVERED_TOOLS names tool(s) no longer in the catalogue: "
+        f"{sorted(stale)}. Remove the stale acknowledgement(s)."
+    )
+
+
+def test_acknowledged_tools_are_not_already_covered():
+    now_covered = _ACK_UNCOVERED_TOOLS & _referenced_tools()
+    assert not now_covered, (
+        f"Tool(s) are both acknowledged-uncovered AND referenced by a case: "
+        f"{sorted(now_covered)}. Coverage grew — remove them from "
+        "_ACK_UNCOVERED_TOOLS so the ledger reflects reality."
+    )
+
+
+def test_tool_coverage_does_not_regress():
+    covered = len(_referenced_tools() & _catalogue_tools())
+    assert covered >= _TOOL_COVERAGE_FLOOR, (
+        f"Eval tool coverage dropped to {covered} (floor {_TOOL_COVERAGE_FLOOR}). "
+        "A case that referenced a tool was removed — restore it, or you are "
+        "regressing the matrix. Do not lower the floor to quiet this."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Tasks.
+# --------------------------------------------------------------------------- #
+def test_new_task_needs_coverage_or_acknowledgement():
+    new_uncovered = _all_tasks() - _referenced_tasks() - _ACK_UNCOVERED_TASKS
+    assert not new_uncovered, (
+        f"New AITask(s) with no eval coverage: {sorted(new_uncovered)}. "
+        "Add a case with task=AITask.<NAME>, or add the name to "
+        "_ACK_UNCOVERED_TASKS with a reason."
+    )
+
+
+def test_no_stale_acknowledged_tasks():
+    stale = _ACK_UNCOVERED_TASKS - _all_tasks()
+    assert not stale, (
+        f"_ACK_UNCOVERED_TASKS names task(s) that no longer exist: {sorted(stale)}. "
+        "Remove the stale acknowledgement(s)."
+    )
+
+
+def test_acknowledged_tasks_are_not_already_covered():
+    now_covered = _ACK_UNCOVERED_TASKS & _referenced_tasks()
+    assert not now_covered, (
+        f"Task(s) are both acknowledged-uncovered AND referenced by a case: "
+        f"{sorted(now_covered)}. Remove them from _ACK_UNCOVERED_TASKS."
+    )
+
+
+def test_task_coverage_does_not_regress():
+    covered = len(_referenced_tasks() & _all_tasks())
+    assert (
+        covered >= _TASK_COVERAGE_FLOOR
+    ), f"Eval task coverage dropped to {covered} (floor {_TASK_COVERAGE_FLOOR})."
+
+
+# --------------------------------------------------------------------------- #
+# Canonical statement of the ratchet (the partition the granular tests enforce).
+# --------------------------------------------------------------------------- #
+def test_tool_surface_is_exactly_partitioned():
+    referenced = _referenced_tools()
+    assert referenced.isdisjoint(_ACK_UNCOVERED_TOOLS)
+    assert referenced | _ACK_UNCOVERED_TOOLS == _catalogue_tools()
+
+
+def test_task_surface_is_exactly_partitioned():
+    referenced = _referenced_tasks()
+    assert referenced.isdisjoint(_ACK_UNCOVERED_TASKS)
+    assert referenced | _ACK_UNCOVERED_TASKS == _all_tasks()
+
+
+# --------------------------------------------------------------------------- #
+# Meta-tests: prove the guard actually fires (a guard that cannot fail is worse
+# than none — it reads as covered). Synthetic drift must trip the predicate.
+# --------------------------------------------------------------------------- #
+def test_guard_fires_on_a_synthetic_new_tool(monkeypatch):
+    real = ai_tools.all_tool_specs
+    fake = "synthetic_uncovered_tool_zzz"
+    monkeypatch.setattr(ai_tools, "all_tool_specs", lambda: {**real(), fake: object()})
+    new_uncovered = _catalogue_tools() - _referenced_tools() - _ACK_UNCOVERED_TOOLS
+    assert fake in new_uncovered, "guard did not detect an injected uncovered tool"
+
+
+def test_guard_recognises_real_coverage():
+    # A tool the golden set genuinely offers must read as covered, not flagged.
+    assert "get_user_standing" in _referenced_tools()
+    assert "get_user_standing" not in _ACK_UNCOVERED_TOOLS


### PR DESCRIPTION
## Goal

Implement the owner-approved session idea from #878: a **CI eval-coverage drift guard**.

The versioned eval matrix (#878) only protects the surface it *references*. When someone adds a new canonical AI tool (`services.ai_tools`) or an `AITask`, nothing stops the matrix from silently falling behind it. This guard closes that gap — **"enforce, don't exhort"**, the same principle as the repo's doc-freshness gates.

## Design — a self-cleaning ratchet (not an absolute mandate)

Today only **8/34 tools** and **2/16 tasks** are eval-covered, so the guard locks in the *current* coverage and forces *new* surface to make a conscious choice, rather than demanding 26 cases up front.

Partition invariant: `all_tool_specs() == referenced ∪ acknowledged`. The acknowledged set is the explicit, reviewable **pick-list of the current gap**. The guard fails on:
1. a **new** tool/task that's neither referenced by a golden/smoke case nor acknowledged → "add a case or acknowledge it";
2. a **stale** acknowledgement whose tool/task no longer exists → "remove it";
3. an acknowledged entry that is **now also referenced** → "coverage grew, shrink the ledger" (self-cleaning, so the acknowledged list can't rot).

## Scope (bot tests only — no `disbot/` runtime change)

- **`tests/evals/test_eval_coverage.py`** — the guard, with the two acknowledged pick-lists grouped by reason.

## Status
Born-red per Q-0133 (the `.sessions/` card is `in-progress`); flips to `complete` as the final step, at which point auto-merge fires on green Code Quality.

https://claude.ai/code/session_015cm2UaphzDzduMr2bEFex9

---
_Generated by [Claude Code](https://claude.ai/code/session_015cm2UaphzDzduMr2bEFex9)_