### PR TITLE
Dispatch-test fixes: executor dimension + startability tags + S1 freshness

### DIFF
--- a/.sessions/2026-06-14-sector-dispatch-test-fixes.md
+++ b/.sessions/2026-06-14-sector-dispatch-test-fixes.md
@@ -1,0 +1,28 @@
+# Session: dispatch-test fixes — executor dimension + startability tags + S1 freshness
+
+> **Status:** `in-progress`
+
+**Branch:** `claude/ecstatic-euler-bslyvd` · **PR:** (opening) · **Date:** 2026-06-14 · **Type:** owner-directed workflow substrate (docs-only)
+
+## Why (HOLD — born-red card, Q-0133)
+A live **dogfooding test** of the 5-sector dispatch structure (owner-requested this session) traced
+3 sectors (S1/S2/S5) from "dispatched → ready-to-work." The structure passed on speed (2–3 hops, all
+links resolve, the index ranks, a stale `Now` self-corrected at the linked authority in one hop), and
+surfaced **3 findings**. The owner chose to **build all 3 into one docs PR** (executor dimension
+decided-by-derivation).
+
+### Planned (docs-only — no `disbot/`)
+1. **Finding 1 (freshness):** de-drift **S1's `Now`** for #878 (offline eval/smoke matrix SHIPPED →
+   next = live half (creds-gated) + Layer B) and **link P1-1's plan** (the hardening roadmap) directly
+   from the S1 block.
+2. **Finding 2 (non-empty ≠ startable):** add a **startability legend** to the dispatch contract
+   (`▶ startable` / `⛔ gated` / `👤 maintainer`) and tag every sector's `Now` items — so a
+   dispatcher can see whether to fire an autonomous worker at all (S2's `Now` was non-empty but
+   demand-driven/maintainer-only; the startable item was in `Next`).
+3. **Finding 3 (executor dimension):** add **who runs it** to the dispatch contract —
+   **Claude-in-repo / Hermes-on-VPS / maintainer**. Most sectors default to Claude-in-repo; **S5 is
+   the outlier** (Hermes/maintainer). A complete dispatch is **sector + action + executor**.
+4. Record the derived decision as **router Q-0143** (refines Q-0137 Thread 1); stamp `current-state.md`.
+
+Homes: `repo-sector-map.md` § dispatch targets (the contract) · `roadmap.md` per-sector `Now` (the
+live tags) · router Q-0143 (provenance).

--- a/.sessions/2026-06-14-sector-dispatch-test-fixes.md
+++ b/.sessions/2026-06-14-sector-dispatch-test-fixes.md
@@ -1,28 +1,82 @@
 # Session: dispatch-test fixes — executor dimension + startability tags + S1 freshness
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-**Branch:** `claude/ecstatic-euler-bslyvd` · **PR:** (opening) · **Date:** 2026-06-14 · **Type:** owner-directed workflow substrate (docs-only)
+**Branch:** `claude/ecstatic-euler-bslyvd` · **PR:** #880 · **Date:** 2026-06-14 · **Type:** owner-directed workflow substrate (docs-only)
 
-## Why (HOLD — born-red card, Q-0133)
-A live **dogfooding test** of the 5-sector dispatch structure (owner-requested this session) traced
-3 sectors (S1/S2/S5) from "dispatched → ready-to-work." The structure passed on speed (2–3 hops, all
-links resolve, the index ranks, a stale `Now` self-corrected at the linked authority in one hop), and
-surfaced **3 findings**. The owner chose to **build all 3 into one docs PR** (executor dimension
-decided-by-derivation).
+## What this session did
+A continuation of the sector work. Earlier this session I restructured the roadmap by sector (PR #877,
+merged); the owner then asked me to **dogfood-test** the structure — pick 3 sectors and measure how
+fast a fresh session gets "ready to work." The test passed on speed and surfaced 3 findings; the owner
+chose to **build all 3 into one docs PR** (executor dimension decided-by-derivation → **Q-0143**).
 
-### Planned (docs-only — no `disbot/`)
-1. **Finding 1 (freshness):** de-drift **S1's `Now`** for #878 (offline eval/smoke matrix SHIPPED →
-   next = live half (creds-gated) + Layer B) and **link P1-1's plan** (the hardening roadmap) directly
-   from the S1 block.
-2. **Finding 2 (non-empty ≠ startable):** add a **startability legend** to the dispatch contract
-   (`▶ startable` / `⛔ gated` / `👤 maintainer`) and tag every sector's `Now` items — so a
-   dispatcher can see whether to fire an autonomous worker at all (S2's `Now` was non-empty but
-   demand-driven/maintainer-only; the startable item was in `Next`).
-3. **Finding 3 (executor dimension):** add **who runs it** to the dispatch contract —
-   **Claude-in-repo / Hermes-on-VPS / maintainer**. Most sectors default to Claude-in-repo; **S5 is
-   the outlier** (Hermes/maintainer). A complete dispatch is **sector + action + executor**.
-4. Record the derived decision as **router Q-0143** (refines Q-0137 Thread 1); stamp `current-state.md`.
+### The test (the input to this PR)
+Traced **S1 / S2 / S5** from *dispatched → ready-to-work* using only sector → `Now` → plan/folio →
+code. **Result: 2–3 targeted reads per sector, all links resolved, the index ranked even 8-area S1 to
+one `Now`, and a 20-min-stale `Now` (S1 vs #878) self-corrected at the linked authority in one hop.**
+Three findings: (1) `Now` lags merges; (2) a non-empty `Now` can be un-startable (S2 was demand-driven
++ maintainer-only); (3) `sector + action` assumed a Claude-in-repo executor, but most of **S5** is
+Hermes-VPS / maintainer.
 
-Homes: `repo-sector-map.md` § dispatch targets (the contract) · `roadmap.md` per-sector `Now` (the
-live tags) · router Q-0143 (provenance).
+### Shipped (docs-only — zero `disbot/`)
+1. **Executor dimension (finding 3)** → `repo-sector-map.md` § dispatch targets: a complete dispatch is
+   **sector + action + executor** (**Claude-in-repo** default S1–S4 · **Hermes-on-VPS** · **maintainer**);
+   **S5 is the executor outlier** — don't fire a repo-editing agent at an S5 token/deploy task. Augmented
+   the sector table with a Default-executor column + per-sector executor on every roadmap Dispatch line.
+2. **Startability tag (finding 2)** → the legend (**▶ startable / ⛔ gated / 👤 maintainer**) in the
+   contract, and the tags applied to every sector's `Now` (21 marks). A `Now` entirely ⛔/👤 is **not
+   autonomously dispatchable** → fall through to the first ▶ (S2's case, now explicit).
+3. **S1 freshness (finding 1)** → de-drifted S1's `Now` for **#878** (offline eval/smoke matrix shipped
+   → next = live half ⛔ creds + ▶ Layer B) and **linked P1-1's plan** (hardening roadmap) from the S1
+   block — the one missing hop the test hit.
+4. **Q-0143** recorded (refines Q-0137 Thread 1) + `current-state.md` stamp.
+
+## 💡 Session idea (Q-0089)
+**`scripts/dispatch_menu.py`** (or a `superbot-dispatch-menu` Hermes skill) — a **read-only generator**
+that parses the roadmap's sector index + the new tags and prints, per sector, the **first ▶ startable
+item + its executor + the linked plan** — i.e., the machine version of the dispatch test I just did by
+hand. A dispatcher (or Hermes) then picks from a **generated, always-fresh menu** instead of reading
+prose, and the "falls through to Next" logic (Q-0143) is computed, not eyeballed. **Distinct from**
+`check_sector_map.py` (structural coverage) and `sector_health.py` (attention telemetry): this is
+*dispatch resolution* — the read-side bridge between the Q-0143 contract and the Q-0137 Thread-1 `/fire`
+wiring. Dedup-grepped `docs/ideas/` + roadmap: no overlap.
+
+## ⟲ Previous-session review (Q-0102)
+Reviewing **PR #877** (my own immediate predecessor — the sector restructure this PR refines).
+**Did well:** made the sectors genuinely dispatchable *fast* — the test empirically confirmed 2–3 hops
+to ready, which is the whole point. **Missed (and the test caught):** it operationalized "every sector
+has a non-empty `Now`" as the Q-0137 deep-clean terminal condition — but that's **necessary, not
+sufficient**: S2 had a non-empty Now that was entirely un-startable (finding 2), and the model had no
+executor dimension so S5's queue pointed a repo-agent at VPS work (finding 3). #877's terminal
+condition should be tightened to *"every sector has a non-empty Now containing at least one ▶ startable
+item with a named executor."* **System improvement:** the **build → dogfood-test → fix** loop this
+session ran (restructure #877 → trace 3 sectors → ship the 3 fixes #880) is worth making a **standing
+move**: when you ship a navigational/structural change, *traverse it as a fresh consumer would* before
+declaring it done. That's the internal mirror of the live-test-the-bot practice, applied to the docs
+substrate. (Parallel **#878** shipped the P1-1 offline eval matrix cleanly — its only cross-effect was
+making S1's `Now` stale, which finding 1 fixed.)
+
+## Doc audit (Q-0104)
+`check_docs --strict` ✓ (badges unchanged from #877's state; all links incl. the new
+hardening-roadmap §P1-1 link reachable). 21 startability marks + 5 per-sector executor labels verified
+present. `check_current_state_ledger` still shows the expected **between-pass lag** (#872–#878 not yet
+in Recently-shipped) — the reconciliation routine's job at #900 (Q-0124), **not** a CI gate for
+docs-only PRs. No `disbot/` touched → `check_quality` n/a.
+
+**Grooming (Q-0015):** this PR groomed the dispatch design itself — turning a felt gap (the test
+findings) into a recorded decision (Q-0143) + applied convention, and queuing three concrete tooling
+follow-ons (`check_sector_map.py` extended to enforce tags/executor · `sector_health.py` ·
+`dispatch_menu.py`).
+
+## Context delta
+- **Discovered by hand:** the test *was* the discovery — three real gaps in the dispatch model that
+  only surfaced by traversing the structure as a consumer, not by reading it as an author. Cheap, high
+  signal. **One change that would have helped:** had #877 shipped a `check_sector_map.py` that asserted
+  tag + executor coverage, findings 2–3 would have been caught at author-time; that checker is now the
+  named follow-on in Q-0143.
+- **Decided alone (within the delegated envelope):** the three executor *names* (Claude-in-repo /
+  Hermes-VPS / maintainer) and the three tag *symbols* (▶/⛔/👤) — derived from the existing safety
+  model (Q-0117/Q-0140 Hermes writes; the maintainer-only deploy/secret boundary) rather than invented.
+- **Weak point of what shipped:** the tags + executors are **prose-asserted, not machine-checked**, so
+  they can drift exactly like finding 1 — a new `Now` item could land untagged. The fix is the queued
+  `check_sector_map.py` extension; until then the convention relies on session discipline.

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -20,7 +20,15 @@
 >
 > Cross-cutting: **Community Spotlight** (side-lane **#613**/**#614** + hotfixes **#615**/**#617**) was hardened in the review session (canonical `utils/db/xp.py` read, `member_count` crash fix, first tests) and **Q-0044 is executed**: the Q-0025 `scripts/new_subsystem.py` scaffold was built and used to register Spotlight as a `community`-hub child (**#626**, 2026-06-09 — execution-plan Lane 1; merged, verified live), and the `!hub`/`!server` aliases were **dropped same day** (kept `!spotlight`/`!activity`). Also decided: BTD6 data-refresh automation = **manual-dispatch workflow** (Q-0049 — **built same day in #633**, execution-plan Lane 5: `workflow_dispatch`-only, opens a reviewable PR, never pushes to main); mining descent lights **permanent, owner-confirmed** (Q-0050); the five product-vision questions (Q-0038–Q-0042) got their **draft-answer session** (Q-0051) **and the maintainer marked all five up same day (Lane 6, PR #631, structured choices)**: Q-0038 server-scoped clans, Q-0039 cosmetic-only donations (no bot-side billing), Q-0041 YouTube-first/dual-opt-in/voice-deferred, Q-0042 staged-Someday website — all approved as drafted; **Q-0040 adjusted: the AI dungeon master picks quests/rewards/difficulty from bounded, hard-capped menus** (not pure narration, not free-form authority). Posture decisions only — every lane still needs its own plan/promotion + the AI per-exposure lift; conclusions routed to the four roadmap drafts + router §21. Full repo review: [`audits/repo-review-2026-06-09.md`](audits/repo-review-2026-06-09.md) · agent-memory system review (did the orientation/memory system work in practice?): [`audits/agent-memory-system-review-2026-06-09.md`](audits/agent-memory-system-review-2026-06-09.md).
 >
-> **Last updated:** 2026-06-14, **roadmap restructured by sector → dispatchable per-sector queues
+> **Last updated:** 2026-06-14, **dispatch contract sharpened — executor dimension + startability tags
+> (PR #880, Q-0143)** — a live dogfooding test of the sector dispatch structure (owner-requested) passed
+> on speed (2–3 hops/sector, links resolve, the index ranks, a stale `Now` self-corrected in one hop)
+> and surfaced 3 findings, all built into one docs PR: a complete dispatch is now **sector + action +
+> executor** (Claude-in-repo / Hermes-VPS / maintainer — **S5 is the executor outlier**), each `Now`
+> item carries a **startability tag** (▶/⛔/👤), and S1's `Now` was de-drifted for #878 (offline
+> eval/smoke matrix shipped). Homes: `repo-sector-map.md` § dispatch targets + `roadmap.md` per-sector
+> `Now`. ·
+> 2026-06-14, **roadmap restructured by sector → dispatchable per-sector queues
 > (PR #877)** — owner-directed; the next-session sector-mapping brief executed. `roadmap.md` is now
 > organised under the **5 planning sectors** (S1–S5, Q-0137): a **per-sector dispatch index**
 > (Now/Next/Later each) is the new top layer, and the former "Agent ecosystem" lane is split into its

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -27,10 +27,12 @@ living ledger (`docs/current-state.md`).
 
 - `claude/modest-ptolemy-2xipoh` · design capture — routine dispatch / staged deep-clean /
   planning sectors (owner discussion) · `docs/ideas/` + router Q-0137 · 2026-06-14
-- `claude/ecstatic-euler-bslyvd` · dispatch-test fixes — executor dimension + startability tags +
-  S1 freshness · docs-only (`repo-sector-map.md` · `roadmap.md` · router Q-0143) · 2026-06-14
+
 ## Recently cleared
 
+- `claude/ecstatic-euler-bslyvd` · dispatch-test fixes — executor dimension + startability tags +
+  S1 freshness (Q-0143) · docs-only (`repo-sector-map.md` · `roadmap.md` · router · `current-state.md`) ·
+  2026-06-14 · **PR #880**
 - `claude/wizardly-edison-xw34kb` · P1-1 — versioned AI eval/smoke matrix (offline half:
   gates/fallback/tool-dispatch/audit) · `tests/evals/` + `scripts/run_evals.py` · 2026-06-14 ·
   **PR #878 (open, auto-merge on green)**

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -27,6 +27,8 @@ living ledger (`docs/current-state.md`).
 
 - `claude/modest-ptolemy-2xipoh` · design capture — routine dispatch / staged deep-clean /
   planning sectors (owner discussion) · `docs/ideas/` + router Q-0137 · 2026-06-14
+- `claude/ecstatic-euler-bslyvd` · dispatch-test fixes — executor dimension + startability tags +
+  S1 freshness · docs-only (`repo-sector-map.md` · `roadmap.md` · router Q-0143) · 2026-06-14
 ## Recently cleared
 
 - `claude/wizardly-edison-xw34kb` · P1-1 — versioned AI eval/smoke matrix (offline half:

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -5340,3 +5340,41 @@ artifact regenerated via `build_skills.py`), `docs/operations/hermes-operating-p
 description, not PR number"), `docs/planning/reconciliation-pass-2026-06-14-band840.md` §4 heading.
 **Re-paste the operating prompt + `superbot-dispatch` skill into Hermes' config on the VPS for this
 to take effect.**
+
+---
+
+### Q-0143 — Dispatch contract: the executor dimension + the startability tag (2026-06-14)
+
+> **DECIDED 2026-06-14 (owner-delegated "decided-by-derivation").** Refines **Q-0137 Thread 1**
+> (dispatch). Provenance: a live **dogfooding test** of the 5-sector dispatch structure this session
+> (traced S1/S2/S5 from *dispatched → ready-to-work*). The owner reviewed the three findings and chose
+> to build all three into one docs PR, delegating the design call to the agent. Recorded here so the
+> derivation is durable.
+
+**Context — what the test found.** The structure passed on **speed** (dispatch-to-ready was 2–3
+targeted reads per sector; all links resolved; the index ranked even the 8-area S1 down to one `Now`;
+a 20-min-stale `Now` self-corrected at the linked authority in one hop). It surfaced three gaps in the
+*dispatch model* (not the structure): (1) per-sector `Now` lags merges until the next reconciliation;
+(2) a non-empty `Now` can be **un-startable** (S2's was demand-driven + maintainer-only — the startable
+item was in `Next`); (3) the model `sector + action` silently assumed a **Claude-in-repo** executor,
+but most of **S5** runs on the Hermes VPS or is a maintainer action.
+
+**Decision (derived).** A complete dispatch is **`sector + action + executor`**, and every roadmap
+`Now` item carries a **startability tag**:
+
+- **Executor dimension** — three runners: **Claude-in-repo** (default for S1–S4), **Hermes-on-VPS**
+  (read-only ops; sanctioned writes = Q-0117 review-merge + Q-0140 docs-only PRs), **maintainer**
+  (deploy · secrets · Railway token · live spot-checks). **S5 is the outlier** — route an S5
+  token/deploy task to Hermes or the maintainer, *not* a repo-editing agent. (This sharpens Q-0137
+  Thread 1's "every routine started by Hermes": *which* runner depends on the sector.)
+- **Startability tag** — **▶ startable** (no gate) · **⛔ gated** (decision/dependency/creds) ·
+  **👤 maintainer**. A sector whose `Now` is entirely ⛔/👤 is **not autonomously dispatchable** —
+  surface the first ▶ item (often in `Next`) as the de-facto target.
+
+Also fixed in the same PR (finding 1): S1's `Now` de-drifted for #878 (offline eval/smoke matrix
+shipped) + P1-1's plan linked directly from the S1 block.
+
+**Home:** `docs/repo-sector-map.md` § "The sectors as dispatch targets" (the stable contract — executor
+table + startability legend) · `docs/roadmap.md` per-sector `Now` (the live tags + per-sector executor
+on each Dispatch line). **Open follow-on (not built):** a `check_sector_map.py` could later assert every
+`Now` item carries a tag and every sector a default executor — graduates the convention to enforced.

--- a/docs/repo-sector-map.md
+++ b/docs/repo-sector-map.md
@@ -95,10 +95,11 @@ specific knowledge?"* → **S3 (mechanism)**. *"Is this SuperBot's specific know
 ## The sectors as dispatch targets
 
 The point of a small, memorable top layer is that a **sector is a dispatch unit**: an autonomous
-worker (or a Hermes-fired routine) is dispatched by naming a **sector + an action** — e.g. *"continue
-the S2 BTD6 plan execution"* or *"plan the S3 AI-Memory sector, then an hour later execute it."* The
-worker reads that sector's **live queue** and advances it. This makes the five sectors the **menu** a
-dispatcher picks from.
+worker (or a Hermes-fired routine) is dispatched by naming a **sector + an action + an executor** (the
+executor is usually implied by the sector — see "Who runs it" below) — e.g. *"continue the S2 BTD6 plan
+execution"* or *"plan the S3 AI-Memory sector, then an hour later execute it."* The worker reads that
+sector's **live queue**, checks the next item's **startability tag**, and advances it. This makes the
+five sectors the **menu** a dispatcher picks from.
 
 **Where the live queue lives:** each sector's `Now / Next / Later` is the
 [roadmap's per-sector dispatch index](roadmap.md#by-sector--the-live-dispatch-queues). This map
@@ -113,13 +114,43 @@ truth each, so they don't drift.
 | **execute · continue** | advance the sector's active `Now` slice (or resume a `continue` handoff) | the linked plan + `docs/current-state.md` ▶ | the night-executor / a dispatch work order |
 | *reconcile / deep-clean* | *(sector-spanning, not a per-sector dispatch)* — the Q-0107 docs pass over **all** sectors | the ledger + every sector's queue | **kept independent of Hermes** (the watchdog, Q-0137 Thread 1) |
 
-| Sector | A worker dispatched here… | Live queue |
-|---|---|---|
-| **S1 Bot** | builds/fixes a bot subsystem slice (incl. the in-bot AI) | roadmap → S1 |
-| **S2 BTD6** | runs the decode/answerability backlog or a data refresh | roadmap → S2 |
-| **S3 AI-Memory** | builds a mechanism (checker · hook · loop seam · substrate-kit slice) | roadmap → S3 |
-| **S4 Docs** | grooms ideas, de-stales a doc area, or runs the docs pass | roadmap → S4 |
-| **S5 Operations** | builds a read-only ops skill or verifies/hardens the control plane | roadmap → S5 |
+| Sector | Default executor | A worker dispatched here… | Live queue |
+|---|---|---|---|
+| **S1 Bot** | Claude-in-repo | builds/fixes a bot subsystem slice (incl. the in-bot AI) | roadmap → S1 |
+| **S2 BTD6** | Claude-in-repo | runs the decode/answerability backlog or a data refresh | roadmap → S2 |
+| **S3 AI-Memory** | Claude-in-repo | builds a mechanism (checker · hook · loop seam · substrate-kit slice) | roadmap → S3 |
+| **S4 Docs** | Claude-in-repo | grooms ideas, de-stales a doc area, or runs the docs pass | roadmap → S4 |
+| **S5 Operations** | **Hermes-VPS / maintainer** | builds a read-only ops skill or verifies/hardens the control plane | roadmap → S5 |
+
+### Who runs it — the executor dimension
+A complete dispatch is **sector + action + executor**. The executor is *usually implied by the
+sector*, but naming it is what makes a dispatch unambiguous — three runners:
+
+- **Claude-in-repo** — a Claude Code session/routine that edits the repo and opens a PR. The default
+  for **S1–S4** (subsystem code · BTD6 data/answerability · mechanism · docs).
+- **Hermes-on-VPS** — the always-on VPS agent: read-only ops, log-triage, dispatch. It edits *nothing*
+  in the repo by default (its sanctioned writes are Q-0117 review-merge + Q-0140 docs-only PRs).
+- **maintainer** — the human: deploy, secrets, the Railway token, live prod spot-checks.
+
+**S5 is the executor outlier.** Most of S5 is *not* Claude-in-repo — it runs on the **Hermes VPS** or
+is a **maintainer** action (every recent silent failure lived here precisely *because* it isn't a file
+an agent edits). Only S5's in-repo control-plane *tooling* (a `check_*` script, a workflow guard) is
+Claude-shaped. So **don't fire a repo-editing agent at an S5 token/deploy task** — route it to Hermes
+or the maintainer. *(Derived 2026-06-14 from the dispatch test — **Q-0143**; the refinement of Q-0137
+Thread 1's "every routine started by Hermes": **which** runner depends on the sector.)*
+
+### Is it dispatchable at all — the startability tag
+A non-empty `Now` is **necessary but not sufficient** for a dispatch — an item can be blocked. So each
+`Now` item in the [roadmap](roadmap.md#by-sector--the-live-dispatch-queues) carries one tag:
+
+- **▶ startable** — an autonomous executor can begin now (no gate).
+- **⛔ gated** — blocked on a decision, dependency, or credentials.
+- **👤 maintainer** — only the maintainer can do it (deploy · secrets · a live spot-check).
+
+A sector whose `Now` is entirely `⛔`/`👤` is **not autonomously dispatchable** — surface its first
+**▶ startable** item (often in `Next`) as the de-facto target. *(S2's `Now` was exactly this: item 3
+`⛔` demand-driven, item 4 `👤` maintainer-only — so a "dispatch S2 execute" falls to the `▶` BTD6
+grounding-eval cases in `Next`. Q-0143.)*
 
 **What this map does *not* do:** it does not wire Hermes. Turning a phone message into a `/fire`
 dispatch — and moving the night executor off GitHub cron onto the always-on Hermes VPS — is **Q-0137

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -68,10 +68,14 @@
 > the [area drill-down](#area-drill-down-each-area-homed-to-a-sector) further down, every area homed
 > to exactly one sector.
 >
-> **Why sectors — the dispatch model.** A worker is dispatched by **sector + action**: e.g.
+> **Why sectors — the dispatch model.** A worker is dispatched by **sector + action + executor**: e.g.
 > *"continue the S2 BTD6 plan execution"* or *"plan the S3 AI-Memory sector, then an hour later execute
 > it."* The worker reads its sector's **Now** here, opens the linked plan/folio, and advances it. Each
-> sector's **Dispatch** line says what *plan* vs *execute·continue* mean for it. This index makes the
+> `Now` item is tagged **▶ startable / ⛔ gated / 👤 maintainer**, and each sector carries a default
+> **executor** (Claude-in-repo · Hermes-VPS · maintainer) — both defined in the dispatch contract
+> ([`repo-sector-map.md`](repo-sector-map.md) § "dispatch targets"); a `Now` that is entirely ⛔/👤 is
+> **not** autonomously dispatchable (fall through to the first ▶). Each sector's **Dispatch** line says
+> what *plan* vs *execute·continue* mean for it. This index makes the
 > sectors **dispatch-ready**; the Hermes/routine **wiring** that turns a phone message into a `/fire`
 > is **Q-0137 Thread 1** (owner-undecided) and is *not* built here — the actions map onto the existing
 > routine fleet in [`operations/autonomous-routines.md`](operations/autonomous-routines.md).
@@ -82,39 +86,43 @@
 > scope a PR review → use **review unit**.
 
 ### S1 — Bot product  ·  *the Discord bot users interact with (in-bot AI is a slice within it)*
-- **Now:** the **P1-1 AI eval-smoke matrix** — in-bot AI correctness (gates · fallback ·
-  grounding-refusal), with the absence-guard **Layer B** (Layer A ✅ #855); offline half buildable
-  now, live half creds-gated; BUG-0009 open ([bug book](health/bug-book.md)). **The P0 integrity spine
-  AND P1-2 are COMPLETE.** Product lanes run as **owner-steered alternates**: mining V-16 phase 2
-  (gated on the owner PNG pack) · games **P0-1 wager money-safety** · AI §7 workflow families
-  (post-prod-check).
+- **Now:** the **P1-1 AI eval-smoke matrix**
+  ([plan §P1-1](planning/production-readiness/hardening-roadmap-2026-06-12.md)) — in-bot AI correctness
+  (gates · fallback · grounding-refusal). Layer A ✅ #855; the **offline eval/smoke matrix ✅ SHIPPED
+  #878** (`tests/evals/smoke.py`, CI-gated); **▶ Layer B** (the absence-guard negative-existential gate)
+  is startable; the **⛔ live half** is creds-gated (owner-led P1-4); BUG-0009 open
+  ([bug book](health/bug-book.md)). **The P0 integrity spine AND P1-2 are COMPLETE.** Product alternates
+  (owner-steered): **▶ games P0-1 wager money-safety** · **⛔ mining V-16 phase 2** (owner PNG pack) ·
+  **⛔ AI §7 workflow families** (post-prod-check).
 - **Next:** safety/community remainder (image moderation · security tiers 1+2 · NL event scheduler) ·
   `myprofile` PR A (turn-key) · help home/navigation plan · settings Phase 2 tail → Phase 3.
 - **Later:** server-mgmt **PR13 AI generation layer** + governance setup (gated Q-0008/Q-0011) · media
   channel-summary (gated Q-0099) · the 4-button Help Home navigation doctrine (Q-0078) · games deferred
   follow-ups · the product-growth drafts (most of the Later/Someday product-growth list below).
-- **Dispatch:** `S1` · *plan* = pick a verified slice from a folio / production-readiness map and write
-  or refine its plan · *execute·continue* = advance the active **Now** slice (next P1-1 step, or an
-  owner-steered product lane). **Live queue →** the eight S1 areas in the drill-down below; folios:
-  [`subsystems/`](subsystems/README.md).
+- **Dispatch:** `S1` (executor **Claude-in-repo**) · *plan* = pick a verified slice from a folio /
+  production-readiness map and write or refine its plan · *execute·continue* = advance the next **▶
+  startable** Now item (currently Layer B or games P0-1). **Live queue →** the eight S1 areas in the
+  drill-down below; folios: [`subsystems/`](subsystems/README.md).
 
 ### S2 — BTD6  ·  *the Bloons TD 6 vertical — runtime + offline data, one standing sector*
 - **Now:** **the cutover is DONE.** Post-cutover decode backlog: ⭐ **item 3** (buff/zone tail —
-  demand-driven) · **item 4** (the maintainer's live spot-check, owed). Triage tool:
-  `scripts/btd6_probe.py "<exact user text>"`.
-- **Next:** the **P1-1 BTD6 eval cases** (the #704 finding — the capability message must match the
+  **⛔ demand-driven**) · **item 4** (the maintainer's live spot-check — **👤 maintainer**, owed). Triage
+  tool: `scripts/btd6_probe.py "<exact user text>"`. *Both Now items are blocked, so a "dispatch S2
+  execute" falls through to the ▶ startable item in Next.*
+- **Next:** the **▶ P1-1 BTD6 eval cases** (the #704 finding — the capability message must match the
   actual grounding-refusal behaviour, and asserted numbers (Despo price, Elite Lych HP) must be
   grounded). *The in-bot AI eval **harness** is S1; the BTD6 **data/grounding** correctness it checks
   is S2.*
 - **Later:** BTD6 product-extension routing (rules/trivia · challenges · runs · leaderboards) — gated
   on ADR-006 provenance / source-health.
-- **Dispatch:** `S2` · *plan* = structure a decode item or an extension feature into a plan · *execute·
-  continue* = run the decode/answerability backlog or a data refresh. **Live queue →** the **S2 BTD6**
+- **Dispatch:** `S2` (executor **Claude-in-repo**) · *plan* = structure a decode item or an extension
+  feature into a plan · *execute·continue* = the next **▶ startable** item (the BTD6 grounding-eval
+  cases — both Now items are ⛔/👤). **Live queue →** the **S2 BTD6**
   area in the drill-down below; folio: [`subsystems/btd6.md`](subsystems/btd6.md) · provenance:
   [ADR-006](decisions/006-btd6-data-provenance-ownership.md).
 
 ### S3 — AI-Memory system  ·  *the mechanism — the self-improving-agent engine (shippable on its own)*
-- **Now:** the owner's **[portable substrate-kit](planning/portable-substrate-kit-extraction-2026-06-13.md)**
+- **Now:** **▶** the owner's **[portable substrate-kit](planning/portable-substrate-kit-extraction-2026-06-13.md)**
   OSS arc — resume at the **PR-2 remainder** (modes + contract-doc templates + trigger/drift detection
   → PR 3). The **autonomous-loop mechanism** is live (#742/#753–#761; operating layer hardened
   #863/#865/#868/#869/#870) — its *operation* is S5, its *design* is here.
@@ -124,37 +132,42 @@
 - **Later:** promote the journal's earned candidate rules into CLAUDE.md (Q-0120) · the Context7-adopted
   plugins remainder (Postgres-MCP · pyright-LSP, Q-0096) · substrate-as-product productization (the
   future S5-of-S3 outward face).
-- **Dispatch:** `S3` · *plan* = design a new mechanism (a checker, a hook, a loop seam, a substrate-kit
-  layer) · *execute·continue* = build the next substrate-kit / tooling slice. **Live queue →** the
+- **Dispatch:** `S3` (executor **Claude-in-repo**) · *plan* = design a new mechanism (a checker, a hook,
+  a loop seam, a substrate-kit layer) · *execute·continue* = build the next substrate-kit / tooling
+  slice. **Live queue →** the
   **S3** area in the drill-down below; refs:
   [`operations/autonomous-routines.md`](operations/autonomous-routines.md) ·
   [`operations/hook-policy.md`](operations/hook-policy.md) ·
   [the loop vision](ideas/autonomous-improvement-loop-vision-2026-06-12.md).
 
 ### S4 — Documentation system  ·  *the content the engine produces — memory, folios, contracts*
-- **Now:** **this sector-roadmap mapping** (executing) · the 3-tap nav **middle/bottom layers** (folio
-  completeness + cog/idea leaf-wiring — the "larger nav build" the sector-map session flagged).
+- **Now:** sector-roadmap mapping **✅ #877** (+ the dispatch-test follow-up #880) · **▶** the 3-tap nav
+  **middle/bottom layers** (folio completeness + cog/idea leaf-wiring — the "larger nav build" the
+  sector-map session flagged).
 - **Next:** idea-backlog **grooming** cadence (Q-0015 — every idea ends implemented or discussed) ·
   orientation-route upkeep mined from `.sessions/` **context-deltas** · doc-reachability maintenance.
 - **Later / recurring:** the **Q-0107 reconciliation** *content* pass (de-stale docs · refactor the
   roadmap · keep the ledger honest) — its trigger/checker **machinery** is S3, the docs it produces are
   S4. Cadence: every 30th PR (Q-0134).
-- **Dispatch:** `S4` · *plan* = identify a doc gap / drift and scope its fix · *execute·continue* =
-  groom the idea backlog, de-stale a doc area, or run the docs-reconciliation pass. **Live queue →** the
+- **Dispatch:** `S4` (executor **Claude-in-repo**) · *plan* = identify a doc gap / drift and scope its
+  fix · *execute·continue* = groom the idea backlog, de-stale a doc area, or run the docs-reconciliation
+  pass. **Live queue →** the
   **S4** area in the drill-down below; refs:
   [`AGENT_ORIENTATION.md`](AGENT_ORIENTATION.md) · [`repo-sector-map.md`](repo-sector-map.md).
 
 ### S5 — Operations / control-plane  ·  *the operational health that isn't a file — deploy · secrets · loop*
-- **Now:** the read-only **Railway log-triage skill** (Railway access verified live #840 — the reserved
-  decade-queue slot) · **verify the daily backup cron end-to-end** (next scheduled `backup-db.yml` run
-  after the #862 pg18-client fix).
+- **Now:** the read-only **Railway log-triage skill** (**👤 maintainer** one-time Railway token on the
+  VPS → then **Hermes-run**; access verified live #840) · **verify the daily backup cron end-to-end**
+  (**👤 maintainer / observe** the next scheduled `backup-db.yml` run after the #862 pg18-client fix).
+  *S5's Claude-in-repo work is thin — mostly the in-repo control-plane tooling (a `check_*`, a workflow guard).*
 - **Next:** **dispatch reliability** (Q-0137 Thread 1 — move the night executor off GitHub's flaky
   `schedule:` cron onto the always-on Hermes VPS **and keep cron as a degraded backstop**;
   owner-undecided) · `ROUTINE_PAT` expiry monitoring · a Neon read-only role for DB-level checks.
 - **Later:** Hermes Docker backend + SSH-key hardening · security/authority tracking as Hermes gains
   write scope (Q-0117/Q-0121) · `BUG-0011` Hermes gateway restart crash-loop ([bug book](health/bug-book.md)).
-- **Dispatch:** `S5` · *plan* = design an ops check / a control-plane improvement · *execute·continue* =
-  build a read-only ops skill, verify a live control-plane row, or harden the loop's reliability.
+- **Dispatch:** `S5` (executor **Hermes-VPS / maintainer** — the outlier; only in-repo `check_*` /
+  workflow tooling is Claude-in-repo) · *plan* = design an ops check / a control-plane improvement ·
+  *execute·continue* = build a read-only ops skill, verify a live control-plane row, or harden the loop's reliability.
   **Live queue →** the **S5** area in the drill-down below; refs:
   [`operations/production-deployment.md`](operations/production-deployment.md) ·
   [`operations/hermes-control-plane.md`](operations/hermes-control-plane.md) ·


### PR DESCRIPTION
## Why

A live **dogfooding test** of the new 5-sector dispatch structure (owner-requested) traced 3 sectors
(S1/S2/S5) from *dispatched → ready-to-work*. **The structure passed on speed** — 2–3 hops per sector,
all links resolved, the index ranked even the heavy S1 down to one `Now`, and a 20-min-stale `Now`
self-corrected at the linked authority in one hop. It surfaced **3 findings**; the owner chose to build
all 3 into one docs PR (the executor dimension decided-by-derivation → **Q-0143**).

## Changes (docs-only — no `disbot/`)

1. **Finding 1 — freshness.** De-drift **S1's `Now`** for #878 (offline eval/smoke matrix SHIPPED →
   next = live half (creds-gated) + Layer B) and **link P1-1's plan** (the hardening roadmap) directly
   from the S1 block.
2. **Finding 2 — non-empty ≠ startable.** Add a **startability legend** to the dispatch contract
   (`▶ startable` / `⛔ gated` / `👤 maintainer`) and tag every sector's `Now` items. (S2's `Now` was
   non-empty but demand-driven / maintainer-only — the startable item was in `Next`.)
3. **Finding 3 — executor dimension.** Add **who runs it** to the dispatch contract:
   **Claude-in-repo / Hermes-on-VPS / maintainer**. Most sectors default to Claude-in-repo; **S5 is the
   outlier**. A complete dispatch is **sector + action + executor**.
4. Record **Q-0143** (refines Q-0137 Thread 1); stamp `current-state.md`.

Homes: `repo-sector-map.md` § dispatch targets (the contract) · `roadmap.md` per-sector `Now` (live
tags) · router Q-0143 (provenance).

## Status
Born-red per Q-0133; flips to `complete` as the final step → auto-merge on green.

https://claude.ai/code/session_019zGt5tgXLSEHHz3G9zGeVC

---
_Generated by [Claude Code](https://claude.ai/code/session_019zGt5tgXLSEHHz3G9zGeVC)_