### PR TITLE
Capture: dispatch-resolution idea (--json + Hermes wiring) + checker-with-convention rule

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -315,6 +315,13 @@ PR #676; drift surfaced at boot + `!btd6 status`). Full note:
 > defaults; they become *binding* only once the maintainer approves promotion.
 
 ### Reading & docs
+- **Ship a doc *convention*'s checker in the SAME PR that introduces it (2026-06-14, #880→#882).**
+  When a PR adds a machine-readable convention — tags/markers/a parseable block (e.g. the sector
+  startability ▶/⛔/👤 tags + executor labels) — write its validator in that same PR, or the
+  convention is prose-only for ≥1 session and **drifts before the next session reads it**. Proof: #880
+  shipped the dispatch tags without a checker; within the gap it already drifted (a ▶ glyph used in
+  *prose*, not as an item tag), caught only when #882 built the tooling. A convention's dogfood **is**
+  its checker. (Candidate rule; the specific form of "dogfood what you build.")
 - **Grep a big planning doc's headers before reading it** (`grep -n "^## \|^### " <doc>`
   → `sed -n 'A,Bp'` the one section). Reading 1,000-line plans top-to-bottom is the
   single largest avoidable context cost (2026-06-09 review). Router merge-collision +

--- a/.sessions/2026-06-14-dispatch-idea-capture.md
+++ b/.sessions/2026-06-14-dispatch-idea-capture.md
@@ -1,0 +1,26 @@
+# Session: idea capture — dispatch resolution (--json + Hermes wiring)
+
+> **Status:** `complete`
+
+**Branch:** `claude/ecstatic-euler-bslyvd` · **PR:** (this) · **Date:** 2026-06-14 · **Type:** docs-only idea capture
+
+## What this is
+A small end-of-night capture addendum to the sector-tooling session (#882), owner-invited ("any good
+ideas you have like what you just said just document it"). Single-commit docs change — card opened
+`complete` (no partial-merge window to protect).
+
+### Captured
+1. **`docs/ideas/dispatch-resolution-json-hermes-2026-06-14.md`** — the genuinely-useful next step I
+   described in chat: give `dispatch_menu.py` a **`--json`** mode and wire it into the Hermes
+   `superbot-dispatch` skill so *"dispatch SX"* resolves to a concrete work order **and** routes by the
+   resolved executor (Claude-in-repo / Hermes-VPS / maintainer). The read-side of **Q-0137 Thread 1**;
+   `--json` half is a safe quick-win, the Hermes half is gated on the owner's Thread-1 decision.
+   Indexed in `docs/ideas/README.md`.
+2. **Journal candidate rule** (`.session-journal.md` § Reading & docs): *ship a doc convention's checker
+   in the same PR that introduces it* — earned this session (the #880 ▶-in-prose drift that #882
+   caught). The specific form of "dogfood what you build."
+
+## Context
+Owner is offline tonight and will check whether Hermes actually dispatched + the results in the morning.
+No code; no `disbot/`. The dispatch tooling shipped this session (#882) is what a Hermes dispatch would
+now resolve against. Q-0107 reconciliation stays the routine's job (next at #900).

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -26,6 +26,13 @@ Current broad captures:
   resumable **deep-clean** with a checkable terminal condition; (3) a **planning-sector** taxonomy
   (bot · BTD6 · agent substrate · **+ a forgotten Operations/control-plane sector**) distinct from the
   `repo-review-map.md` review taxonomy. Captured owner direction + agent opinion; not approved.
+- [`dispatch-resolution-json-hermes-2026-06-14.md`](./dispatch-resolution-json-hermes-2026-06-14.md) —
+  **session idea (2026-06-14, Q-0089, from the sector-tooling session #882; owner-invited):** give
+  `scripts/dispatch_menu.py` a **`--json`** mode and wire it into the Hermes `superbot-dispatch` skill, so
+  *"dispatch S2"* resolves to a concrete work order **and** routes by the resolved **executor**
+  (`Claude-in-repo` → `/fire`; `Hermes-VPS` → Hermes does it; `maintainer` → tell the owner). The
+  read-side of **Q-0137 Thread 1**: turns the Q-0143 contract + the dispatch menu from dispatch-*ready*
+  into dispatch-*resolved*. `--json` half = safe quick-win; Hermes-wiring half gated on Thread 1.
 - [`routine-system-improvements-2026-06-14.md`](./routine-system-improvements-2026-06-14.md) —
   **workflow / routine-system (2026-06-14, owner-requested):** first-hand field notes from a live
   routine run on making the unattended Hermes-dispatch loop smoother. Core orientation already

--- a/docs/ideas/dispatch-resolution-json-hermes-2026-06-14.md
+++ b/docs/ideas/dispatch-resolution-json-hermes-2026-06-14.md
@@ -1,0 +1,58 @@
+# Dispatch resolution — `dispatch_menu.py --json` wired into the Hermes dispatch skill
+
+> **Status:** `ideas` — **not approved, not a plan.** Capture so it isn't lost. The Hermes-wiring half
+> is gated on **Q-0137 Thread 1** (the owner's open dispatch decision); the `--json` half is a safe
+> read-only quick-win. Source, the binding contracts, and `docs/current-state.md` win over this.
+
+**Captured:** 2026-06-14 (from the sector-tooling session, PR #882 — the Q-0089 session idea, owner
+invited the capture). **Owning area:** S3 AI-Memory / S5 Operations (the dispatch mechanism).
+
+## The gap
+`scripts/dispatch_menu.py` (#882) already *computes* the answer to "what would a worker dispatched to
+sector SX pick up?" — per sector: the first **▶ startable** item, the **executor**, and whether the
+sector is blocked. But it emits **human-readable text only**. The owner's goal — *"ask Hermes to
+dispatch S2"* and have it resolve to a concrete work order — needs that resolution **machine-readable**
+so Hermes can consume it, not just a person reading a table.
+
+## Proposal (two halves)
+1. **`dispatch_menu.py --json [SECTOR]`** (safe quick-win, repo-side, read-only). Emit the same
+   resolution as JSON, one object per sector:
+   ```json
+   {"sector": "S2", "name": "BTD6", "executor": "Claude-in-repo",
+    "state": "now_blocked_fallthrough", "startable_item": "P1-1 BTD6 eval cases",
+    "source": "Next"}
+   ```
+   States: `startable` · `now_blocked_fallthrough` (→ Next) · `starving` (no ▶ anywhere) ·
+   `maintainer_or_hermes` (executor isn't Claude-in-repo). Small: extend the existing parse + a test.
+2. **Wire it into the Hermes `superbot-dispatch` skill** (gated on Q-0137 Thread 1). On *"dispatch
+   SX,"* Hermes runs `dispatch_menu.py --json SX` and **routes by the resolved executor**:
+   - `Claude-in-repo` → compose the `/fire` work order from `startable_item` (the existing dispatch
+     bridge);
+   - `Hermes-VPS` → Hermes does it itself (read-only ops, e.g. log-triage);
+   - `maintainer` → reply to the owner with the manual step, don't fire an agent.
+   This is the routing the #880 dispatch test showed is needed (don't fire a repo-editing agent at an
+   S5 token task).
+
+## Why it matters
+It closes the **read-side of Q-0137 Thread 1**: the Q-0143 contract (`sector + action + executor`) and
+`dispatch_menu` make the sectors dispatch-*ready*; this makes them dispatch-*resolved* — the owner names
+a sector, the system computes the concrete task **and** the right runner. It's the missing link between
+"the menu exists" and "Hermes fires the correct worker."
+
+## Connections
+- Builds on: `scripts/dispatch_menu.py` (#882), the dispatch contract **Q-0143**, the per-sector
+  startability/executor tags (`docs/repo-sector-map.md`).
+- Gated on / part of: **Q-0137 Thread 1** (Hermes-dispatch + cron backstop — owner-undecided).
+- Composes with: [`hermes-claude-dispatch-bridge-2026-06-12.md`](./hermes-claude-dispatch-bridge-2026-06-12.md)
+  (the `/fire` mechanism) and [`routine-dispatch-and-staged-reconciliation-2026-06-14.md`](./routine-dispatch-and-staged-reconciliation-2026-06-14.md).
+
+## Sizing / risk
+- `--json` half: **small**, read-only, repo-side — could ship in a grooming slice without the Thread-1
+  decision (it just exposes existing output in another format).
+- Hermes-skill half: a docs/skill change re-pasted onto the VPS; waits on Q-0137 Thread 1 because it
+  defines *how Hermes dispatches*. No repo mutation from Hermes (preserves the safety split).
+
+## Routing
+→ **DISCUSS lane under Q-0137 Thread 1** for the Hermes-wiring half (it's part of the dispatch-mechanism
+decision the owner owns). The `--json` half is a **quick-win** an executor can ship when it next touches
+the sector tooling — not auto-promoted.


### PR DESCRIPTION
## Why

End-of-night idea capture (owner-invited, after the #882 sector tooling). Docs-only, single commit.

## What

1. **`docs/ideas/dispatch-resolution-json-hermes-2026-06-14.md`** — the genuinely-useful next step:
   give `scripts/dispatch_menu.py` a **`--json`** mode and wire it into the Hermes `superbot-dispatch`
   skill, so *"dispatch S2"* resolves to a concrete work order **and routes by the resolved executor**
   (`Claude-in-repo` → `/fire`; `Hermes-VPS` → Hermes does it; `maintainer` → tell the owner). The
   read-side of **Q-0137 Thread 1** — turns the Q-0143 contract + `dispatch_menu` from dispatch-*ready*
   into dispatch-*resolved*. `--json` half = safe quick-win; Hermes half gated on the owner's Thread-1
   decision. Indexed in `docs/ideas/README.md`.
2. **Journal candidate rule** — *ship a doc convention's checker in the same PR that introduces it*
   (earned this session: the #880 ▶-in-prose drift that #882's tooling caught).

## Status
Card opened `complete` (single-commit docs change, no partial-merge window). Auto-merge on green.

https://claude.ai/code/session_019zGt5tgXLSEHHz3G9zGeVC

---
_Generated by [Claude Code](https://claude.ai/code/session_019zGt5tgXLSEHHz3G9zGeVC)_