### PR TITLE
docs: mining Phase-2 feature dispatch gated (fix-phase) + dispatch phase-gate idea

### DIFF
--- a/.sessions/2026-06-15-mining-phase2-feature-gated.md
+++ b/.sessions/2026-06-15-mining-phase2-feature-gated.md
@@ -1,0 +1,71 @@
+# 2026-06-15 — mining Phase-2 feature dispatch: gated (fix-phase) + loop cleanup
+
+> **Status:** `in-progress`
+
+**Branch:** claude/sharp-ptolemy-5z8at5
+**Type:** routine run (dispatched work order) · **Class:** feature → **gated**
+
+## What this session did
+
+Received a `CLASS: feature` work order — *"Implement Mining Phase 2 — Forge/Vault/Home
+structures + skill-tree wiring."* Per the routine feature protocol, ran the phase gate
+**first**:
+
+```
+python3.10 scripts/check_phase_gate.py --require-invent  → exit 1 (FIX phase)
+  - 2 OPEN bug(s) in the bug book (BUG-0009 claim-assembly, BUG-0011 Hermes gateway)
+  - 28 'Not Done' row(s) in the readiness maps
+```
+
+Fix-phase ⇒ agent-originated features stay gated (Q-0114). So I did **not** build the
+feature. The work is already captured anyway in the turn-key
+`planning/mining-structures-skill-tree-plan-2026-06-14.md` (Forge/Vault/Home + skill-tree as
+source-verified PR-sized slices A–F) — no new capture was needed.
+
+Cleanup + loop-close instead:
+
+- **Closed PR #888** — a prior run's "slice opener" docs PR for this same dispatch. It had
+  **skipped the executor phase gate** and opened a thin duplicate plan in the wrong dir
+  (`docs/plans/` vs the repo's `docs/planning/`), stuck `in-progress` (born-red), on a
+  non-`claude/*` branch so it could never auto-merge. Redundant + un-mergeable → disposed
+  (Q-0125), with the existing turn-key plan cited as its proper home.
+- **Captured ONE idea (Q-0089):** `docs/ideas/dispatch-phase-gate-precheck-2026-06-15.md` —
+  run the phase gate at the **dispatcher** before firing a `CLASS: feature`, so an out-of-season
+  feature never burns a fire or spawns a #888-class orphan; executor-side gate stays the backstop.
+
+## Run report
+
+- **Trigger:** "Implement Mining Phase 2 — Forge/Vault/Home structures + skill-tree wiring"
+  · **Class:** feature · **Outcome:** **blocked (fix-phase gate)** — correctly not built.
+- **Shipped:** this docs-only PR (idea capture + #888 disposal + this log). No runtime change.
+- **⛏ Owner decisions needed:** none new. (Phase clears when the 2 OPEN bugs + 28 `Not Done`
+  rows are worked down; mining Phase-2 then becomes buildable from the turn-key plan.)
+- **🔧 Owner manual steps:** none.
+- **↪ Next:** unchanged — the P1 correctness tier (current-state ▶ Next action). The phase gate
+  is doing its job; the next *feature* can't ship until fix-phase clears.
+- **Trigger quality:** structured (full `CLASS:`/CONTEXT/ACCEPTANCE), but **mis-routed** — a
+  feature was dispatched during fix-phase (the gap the Q-0089 idea above closes).
+
+## ⟲ Previous-session review (Q-0102)
+
+The run that opened **PR #888** is the one to learn from. It received this exact feature
+dispatch and **skipped `check_phase_gate.py` entirely** — instead of refusing the gated
+feature, it opened a docs "slice opener" PR that *declared* build work it never did, leaving a
+stuck born-red PR on a branch that can't auto-merge. Two concrete misses: (1) the feature
+protocol's mandatory phase-gate-first step was not run; (2) it created `docs/plans/` — a
+**new, non-canonical** directory duplicating the real `docs/planning/` plan. The system
+improvement that closes this: the **dispatch-side phase-gate pre-check** (this session's idea)
+— if the gate is enforced before the fire, a fix-phase feature never reaches an executor that
+might mishandle it. Honest positive: #888's run *did* correctly verify PR #884 was merged and
+point at the right lane — its orientation was fine; only its phase discipline failed.
+
+## 💡 Session idea (Q-0089)
+
+`docs/ideas/dispatch-phase-gate-precheck-2026-06-15.md` — gate `CLASS: feature` at the
+dispatcher (Hermes), not only the executor. See the file + README index entry.
+
+## Verification
+
+Docs-only PR. `check_docs --strict` expected clean; no `disbot/` runtime touched, so the
+`check_quality --full` ACCEPTANCE from the work order is N/A (nothing was built). Migration
+count unchanged (no migration added).

--- a/.sessions/2026-06-15-mining-phase2-feature-gated.md
+++ b/.sessions/2026-06-15-mining-phase2-feature-gated.md
@@ -1,6 +1,6 @@
 # 2026-06-15 — mining Phase-2 feature dispatch: gated (fix-phase) + loop cleanup
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Branch:** claude/sharp-ptolemy-5z8at5
 **Type:** routine run (dispatched work order) · **Class:** feature → **gated**

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -20,6 +20,12 @@ during grooming** (it stays listed here, annotated ✅) so the active backlog re
 
 Current broad captures:
 
+- [`dispatch-phase-gate-precheck-2026-06-15.md`](./dispatch-phase-gate-precheck-2026-06-15.md) —
+  **session idea (2026-06-15, Q-0089, from the mining-Phase-2 feature dispatch):** run
+  `check_phase_gate.py --phase` at the **dispatcher** before firing a `CLASS: feature` work
+  order — if `fix`, re-route to the fix-phase queue or hold the feature until invent-phase,
+  instead of burning a fire on capture-and-stop (and risking a stuck "slice opener" PR like
+  #888). Executor-side gate stays the backstop. → relates Q-0137 Thread 1.
 - [`games-economy-faucet-sink-diagnostic-2026-06-14.md`](./games-economy-faucet-sink-diagnostic-2026-06-14.md) —
   **S1 games / observability (2026-06-14, the mining Vault session #884):** a read-only
   `diagnostics_service` provider that sums the economy audit reasons already emitted

--- a/docs/ideas/dispatch-phase-gate-precheck-2026-06-15.md
+++ b/docs/ideas/dispatch-phase-gate-precheck-2026-06-15.md
@@ -1,0 +1,68 @@
+# Dispatch-side phase-gate pre-check — don't fire agent-feature work orders in fix-phase
+
+> **Status:** `ideas` — proposal, **not** approval. Written by the Claude Code routine that
+> received a `CLASS: feature` work order ("Implement Mining Phase 2 — Forge/Vault/Home +
+> skill-tree") on 2026-06-15 while the repo was in **fix-phase**. Grounded in what actually
+> happened that run (the gate fired, the feature was refused) + the orphan PR #888 a prior
+> run left behind. Binding contracts + `docs/current-state.md` win.
+
+## The concrete event this captures
+
+A feature work order arrived via the dispatch fire endpoint. The executor side did the
+**right** thing per the routine prompt: ran `scripts/check_phase_gate.py --require-invent`,
+got **exit 1 (fix-phase)** — 2 OPEN bugs + 28 `Not Done` readiness rows — and refused to
+build, because agent-*originated* features are gated until correctness work clears (Q-0114).
+The work was already captured anyway: the turn-key
+[`planning/mining-structures-skill-tree-plan-2026-06-14.md`](../planning/mining-structures-skill-tree-plan-2026-06-14.md)
+covers Forge/Vault/Home + skill-tree as source-verified PR-sized slices.
+
+So the run shipped **nothing buildable** — by design, correctly. But two things were wasted:
+
+1. **A whole dispatch was burned** on work the dispatcher could have known was out of season.
+   The limited daily routine budget (routine-system-improvements Priority 5, "productive once
+   started") was spent capturing-and-stopping on an already-captured plan.
+2. **A prior run (#888) left an orphan.** That run received the *same* dispatch, **skipped the
+   executor phase gate**, and opened a "slice opener" docs PR pretending to tee up build
+   work — a thin duplicate plan in the wrong dir (`docs/plans/` vs the repo's `docs/planning/`),
+   stuck `in-progress` (born-red), on a non-`claude/*` branch so it could never auto-merge.
+   An un-gated feature dispatch is exactly what produces this kind of stuck artifact.
+
+## The proposal — gate at the dispatcher, not only the executor
+
+The phase gate today is an **executor-side self-guard**: each routine runs
+`check_phase_gate.py` *after* it has already spent a fire. Move a copy of that check
+**upstream into the dispatch step** (Hermes' `superbot-dispatch` skill):
+
+- Before firing a work order classified `CLASS: feature` (agent-originated), run
+  `scripts/check_phase_gate.py --phase`. If it returns `fix`, **do not fire that feature** —
+  instead either (a) re-route to the standing fix-phase queue (current-state ▶ Next action →
+  else an OPEN bug-book item → else backlog grooming, the same ladder the executor falls back
+  to), or (b) hold the feature in a "queued until invent-phase" list and fire it automatically
+  when the gate next flips to `invent`.
+- `CLASS: fix | ux | docs | correctness` always fire (they flow freely in fix-phase) — the
+  pre-check only gates `feature`.
+- Keep the executor-side gate as the **backstop** (defense-in-depth): the dispatcher can be
+  wrong or stale, so the executor still refuses if it somehow receives a gated feature. The
+  point is to stop *wasting the fire*, not to remove the safety net.
+
+This is the dispatch-edge complement to routine-system-improvements Priority 3 ("make Hermes
+use the dispatch contract it already has") and Priority 5's owner-vs-agent clarity: Hermes
+already *classifies* by `CLASS:`; it should also *check season* before firing the one class
+that can be out of season.
+
+## Why it's worth having
+
+- **No burned fires on out-of-season features** — the scarce daily budget goes to in-season
+  fix/UX/docs/correctness work that actually moves the phase gate toward invent-phase.
+- **No more #888-class orphans** — a feature that never fires in fix-phase can't produce a
+  stuck "slice opener" PR.
+- **Cheap and reuses an existing primitive** — `check_phase_gate.py --phase` already prints
+  `fix`/`invent`; the dispatcher just reads one line and branches. No new contract.
+
+## Routing
+
+- Mechanism (add the pre-check to the dispatch skill) is a small Hermes-side change once the
+  shape is endorsed; relates to **Q-0137** Thread 1 (Hermes dispatch wiring, owner-undecided)
+  and the `routine-dispatch-and-staged-reconciliation` capture. No owner decision is strictly
+  required to add a *guard* that only prevents wasted/incorrect fires — but flag it under
+  Q-0137 since it touches Hermes' dispatch behavior.


### PR DESCRIPTION
## What & why

A `CLASS: feature` work order arrived — *"Implement Mining Phase 2 — Forge/Vault/Home
structures + skill-tree wiring."* Per the routine feature protocol, the phase gate runs first:

```
python3.10 scripts/check_phase_gate.py --require-invent → exit 1 (FIX phase)
  - 2 OPEN bugs (BUG-0009 claim-assembly, BUG-0011 Hermes gateway)
  - 28 'Not Done' readiness rows
```

Fix-phase ⇒ agent-originated features are gated (Q-0114). So **the feature was not built.**
The work is already captured in the turn-key
`planning/mining-structures-skill-tree-plan-2026-06-14.md` (Forge/Vault/Home + skill-tree,
source-verified PR-sized slices A–F), so no new capture was needed.

This PR is docs-only loop cleanup:

- **Q-0089 idea** — `docs/ideas/dispatch-phase-gate-precheck-2026-06-15.md`: run the phase gate
  at the **dispatcher** before firing a `CLASS: feature`, so an out-of-season feature never
  burns a fire or spawns a stuck "slice opener" PR. Executor-side gate stays the backstop.
- **Disposed PR #888** — a prior run's slice-opener for this same dispatch that skipped the
  executor phase gate and left a thin duplicate plan (wrong dir `docs/plans/`), stuck
  `in-progress`, on a non-`claude/*` branch that can't auto-merge. Closed as redundant (Q-0125).
- Session log with the Priority-1 run-report block + Q-0102 review.

## Verification

Docs-only — no `disbot/` runtime touched, so the work order's `check_quality --full` ACCEPTANCE
is N/A (nothing built); migration count unchanged (no migration). `check_docs --strict` ✓.

https://claude.ai/code/session_01VCFFNsheYmyiroKiC8NBcs

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCFFNsheYmyiroKiC8NBcs)_