### PR TITLE
Mining §7.4: the capped skill tree (4 branches, points from game-XP, respec sink)

### DIFF
--- a/.sessions/2026-06-15-mining-skill-tree.md
+++ b/.sessions/2026-06-15-mining-skill-tree.md
@@ -1,0 +1,24 @@
+# Session: mining §7.4 — the capped skill tree (Slice D)
+
+> **Status:** `in-progress` — born-red session card (Q-0133). Flipped to `complete` as the final step.
+
+**Branch:** `claude/mining-skill-tree-2026-06-15` · **Date:** 2026-06-15 · **Type:** product (S1 games / mining)
+
+## What I'm about to do
+
+Execute **Slice D** (the marquee) of `docs/planning/mining-structures-skill-tree-plan-2026-06-14.md`:
+the **§7.4 capped skill tree** — the real Phase-2 build (the continuation Hermes opened #888 for but
+didn't actually build; #888 closed as churn, the `continue` night-executor routine didn't fire).
+
+Four branches (mining · combat · fortune · crafting), **capped so you can't max all** (forced
+specialization), spending shared **game-XP**-derived points, folding into the shared `EffectiveStats`,
+with a **coin-sink respec**. **Additive** — empty allocations → byte-identical (the safety invariant);
+combat (deathmatch) is left untouched this slice (a documented follow-up). The mining branch is **wired
+into mine loot** (the concrete gameplay effect); all four branches' bonuses show on the character/gear
+panels.
+
+Files: migration 071 · `utils/db/games/player_skills.py` · `utils/mining/skills.py` (pure) ·
+`services/skill_service.py` · the `EffectiveStats` merge at the mining read sites ·
+`!skills`/`!skill`/`!respec` · the RS02 ratchet for the new write primitive · tests + a real-Postgres boot.
+
+(Close-out + enders + badge flip at the bottom as the final step.)

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -27,6 +27,9 @@ living ledger (`docs/current-state.md`).
 
 - `claude/modest-ptolemy-2xipoh` · design capture — routine dispatch / staged deep-clean /
   planning sectors (owner discussion) · `docs/ideas/` + router Q-0137 · 2026-06-14
+- `claude/mining-skill-tree-2026-06-15` · mining §7.4 **capped skill tree** (Slice D — the real
+  Phase-2 build) · `disbot/{migrations/071,utils/db/games/player_skills,utils/mining/skills,
+  services/skill_service,...}` + `mining_cog` · 2026-06-15
 
 ## Recently cleared
 


### PR DESCRIPTION
## What

The **real Phase-2 mining build** — **Slice D** (the marquee) of
`docs/planning/mining-structures-skill-tree-plan-2026-06-14.md`: the **§7.4 capped skill tree**.

(Context: the `continue` issue #887 was meant to dispatch this; the night-executor routine didn't
fire, and Hermes opened a docs-only re-declaration #888 instead — closed as churn. This PR is the
actual build, done the way we work here: full stack + tests + a real-Postgres boot.)

### The feature
Four branches — **mining · combat · fortune · crafting** — each capped at 10 points; you spend points
derived from the shared **game-XP** level, with a **total cap of 20** so you *can't max all four*
(forced specialization → the build-identity engine the brainstorm §7.3 wants). Allocations fold into
the shared `EffectiveStats` read model; **respec** is a coin sink through the audited
`economy_service`.

- **Additive / safe:** with no points spent, every stat is **byte-identical** to today (pinned by a
  test). Combat (deathmatch) is intentionally **left untouched** this slice — the combat branch shows
  on the character sheet and is a documented near-term wire-in.
- **Concrete gameplay effect now:** the **mining branch raises the mine-loot multiplier** (more ore
  per swing); all four branches' bonuses display on the Character / Gear panels and `!skills`.

### Shape
- migration `071_player_skills.sql` + `utils/db/games/player_skills.py` (conn-aware)
- `utils/mining/skills.py` (pure model: branches, caps, `skill_stats`) + `services/skill_service.py`
  (points economy, allocate, respec, the gear+skill merge)
- `!skills` (view + stat preview) · `!skill <branch> [n]` (allocate) · `!respec`
- RS02 write-boundary ratchet extended to the new write primitive
- tests (pure mapping · points-cap math · allocate guards · respec · the byte-identical-when-empty
  invariant) + a real-Postgres round-trip

🔴 Born-red per Q-0133; flips to `complete` last → auto-merge on green.

https://claude.ai/code/session_01NGhPU2c12CD2qr96XqDSWR

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGhPU2c12CD2qr96XqDSWR)_