### PR TITLE
docs(phase-gate): clarify dispatched vs. agent-self-originated features (Q-0114)

### DIFF
--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -4355,6 +4355,17 @@ under the Q-0113 merge gate. The ordering ("bugs first … only then features", 
 enforced by `scripts/check_phase_gate.py`: a feature may only be *originated* in **invent-phase**
 (zero OPEN bugs, zero `Not Done` readiness rows) — otherwise it is captured as an idea, not built.
 
+> **Clarification (2026-06-15, owner-stated in-session; recorded here for discoverability).**
+> The gate is scoped to **agent-self-originated** features — ones an agent invents mid-session.
+> A **dispatched** work order (one fired at a routine via the `/fire` endpoint, even when tagged
+> `CLASS: feature`) is **owner-directed** and therefore **flows freely like a bug fix** — the
+> phase gate does *not* gate it. *(Provenance: the owner corrected this exact scenario when a
+> dispatched mining feature hit a FIX phase; the routine then correctly built mining Slice D
+> (#891) and Slice A / Vault v2 (#897). Background + the still-open "gate at the dispatcher"
+> mechanism idea: `docs/ideas/dispatch-phase-gate-precheck-2026-06-15.md`.)* So an agent
+> resolving a `feature` work order splits on **origin**: dispatched ⇒ build (owner-directed);
+> self-invented ⇒ run `check_phase_gate.py --require-invent`, and in fix-phase capture-and-stop.
+
 **Home:** `docs/ideas/autonomous-improvement-loop-vision-2026-06-12.md` (the loop this gates) ·
 `scripts/check_phase_gate.py` (the phase mechanism) · `docs/operations/hermes-dispatch-bridge.md`
 · `docs/owner/ai-project-workflow.md` §12 · this entry is provenance.

--- a/scripts/check_phase_gate.py
+++ b/scripts/check_phase_gate.py
@@ -13,6 +13,15 @@ gate applies to agent-originated *features*; bug/UX/docs/correctness work flows
 freely) — the phase signal is what tells a routine whether feature-origination
 is even in-season.
 
+**Scope (Q-0114 clarification, owner-stated 2026-06-15):** this gate is for
+**agent-SELF-originated** features — ones an agent invents mid-session. A
+**dispatched** work order (fired at a routine via the ``/fire`` endpoint, even
+when tagged ``CLASS: feature``) is **owner-directed** and flows freely like a bug
+fix — do NOT gate it. So a routine resolving a ``feature`` work order splits on
+*origin*: dispatched ⇒ build; self-invented ⇒ guard with ``--require-invent`` and,
+in fix-phase, capture-and-stop. (Background: the router Q-0114 entry +
+``docs/ideas/dispatch-phase-gate-precheck-2026-06-15.md``.)
+
 ## The signal
 
 Two hard conditions must both hold to be in **invent-phase**:


### PR DESCRIPTION
## Clarify the phase gate's scope: dispatched vs. agent-self-originated features

Pure docs/help text — no gate-logic, runtime, or CLAUDE.md changes.

This session (a dispatched `CLASS: feature` work order for mining Vault v2, merged
as #897) hit the exact confusion the owner already corrected once: the phase gate
reads FIX, the routine prompt says "feature (agent-originated) → if fix-phase,
capture-and-stop," and a literal agent could wrongly **gate an owner-dispatched
feature**. The decision was only discoverable by grepping an ideas file.

This records the owner's already-stated clarification in its **canonical homes** so
the next agent finds it without grepping:
- **router Q-0114 entry** — a Clarification note: a dispatched work order (`/fire`
  endpoint, even `CLASS: feature`) is **owner-directed** and flows freely; the gate
  is only for features an agent invents itself. Resolve a `feature` order by **origin**.
- **`scripts/check_phase_gate.py` docstring** — a matching Scope note (this is what
  `--require-invent` callers read).
- strengthened `docs/ideas/dispatch-phase-gate-precheck-2026-06-15.md` with the
  recurrence + the canonical-homing next step (landed in #897).

No new rule is created — it documents an existing owner decision. CI: docs-only.

https://claude.ai/code/session_01XW57uZ6P8qMYVFjKhaggJw

---
_Generated by [Claude Code](https://claude.ai/code/session_01XW57uZ6P8qMYVFjKhaggJw)_