### PR TITLE
docs(routines): foolproof routine-prompt canon + idea→plan promotion (Q-0144)

### DIFF
--- a/.sessions/2026-06-15-routine-workflow-canon.md
+++ b/.sessions/2026-06-15-routine-workflow-canon.md
@@ -1,0 +1,36 @@
+# Session: Routine workflow canon — foolproof prompts + idea→plan promotion
+
+> **Status:** `in-progress` — born-red (Q-0133). Flip to `complete` as the last step.
+
+**Branch:** `claude/routine-workflow-canon-2026-06-15` · **Date:** 2026-06-15 · **Type:** workflow/docs (S3 mechanism) · **Trigger:** owner-directed in-session (live conversation)
+
+## What I'm about to do (intentions — born-red)
+
+Owner-directed overhaul of the autonomous-routine prompts so they run **completely without
+guidance** and are **foolproof against bad dispatch input** (the "write a story about chickens"
+test). Provenance: a long live session with the owner + an independent review from a
+Hermes-dispatched routine. Recorded as router **Q-0144**.
+
+1. **Unify + harden the routine prompts** (`hermes-dispatch-bridge.md` dispatch prompt +
+   `autonomous-routines.md` night-executor prompt) onto the owner's canonical 12-step session
+   lifecycle, weaving in the two-reviewer fixes:
+   - **sync-first** (stale clone was a named Hermes failure),
+   - **orient-gate** (don't act until oriented),
+   - **work-order-is-a-hint / never-stop** (a dispatched order = owner asking = build it; the
+     phase gate doesn't apply to dispatched work — it only blocks self-invented features; a
+     garbage order redirects to the plan, never derails),
+   - **born-red mock PR** (Q-0133) as the async review surface,
+   - **judgment over the plan** (a plan is a suggestion of the desired output),
+   - **bugs-first / root-cause**,
+   - **2–3 slices per session, bounded by ~700K tokens** (not 1M),
+   - the standing enders (Q-0089 idea · Q-0102 prev-run review · Q-0104 doc audit),
+   - **scope-brake vs safety-brake** (irreversible stays ask-first).
+2. **Reconciliation routine — add idea→plan promotion** (owner directive): when plans are running
+   low on executable work, review `docs/ideas/` and promote the best one into a **complete,
+   executable plan**. De-stale its instructions.
+3. **Update `ai-project-workflow.md` §10** bounded-session protocol: "~2 substantial tasks" →
+   "2–3 slices, budget-bounded at ~700K."
+4. Record router **Q-0144**; reconcile current-state.
+
+Docs-only; self-merge on green (`check_docs --strict`). The in-repo prompt mirrors are canonical;
+the owner re-pastes the final text into the routine console.

--- a/.sessions/2026-06-15-routine-workflow-canon.md
+++ b/.sessions/2026-06-15-routine-workflow-canon.md
@@ -1,36 +1,60 @@
 # Session: Routine workflow canon — foolproof prompts + idea→plan promotion
 
-> **Status:** `in-progress` — born-red (Q-0133). Flip to `complete` as the last step.
+> **Status:** `complete` — PR #899; born-red card flipped as the deliberate final step (Q-0133).
 
 **Branch:** `claude/routine-workflow-canon-2026-06-15` · **Date:** 2026-06-15 · **Type:** workflow/docs (S3 mechanism) · **Trigger:** owner-directed in-session (live conversation)
 
-## What I'm about to do (intentions — born-red)
+## What shipped
 
 Owner-directed overhaul of the autonomous-routine prompts so they run **completely without
 guidance** and are **foolproof against bad dispatch input** (the "write a story about chickens"
-test). Provenance: a long live session with the owner + an independent review from a
-Hermes-dispatched routine. Recorded as router **Q-0144**.
+test). Provenance: a long live owner session (his verbatim 12-step lifecycle) + an independent
+review from a Hermes-dispatched routine. Recorded as router **Q-0144**.
 
-1. **Unify + harden the routine prompts** (`hermes-dispatch-bridge.md` dispatch prompt +
-   `autonomous-routines.md` night-executor prompt) onto the owner's canonical 12-step session
-   lifecycle, weaving in the two-reviewer fixes:
-   - **sync-first** (stale clone was a named Hermes failure),
-   - **orient-gate** (don't act until oriented),
-   - **work-order-is-a-hint / never-stop** (a dispatched order = owner asking = build it; the
-     phase gate doesn't apply to dispatched work — it only blocks self-invented features; a
-     garbage order redirects to the plan, never derails),
-   - **born-red mock PR** (Q-0133) as the async review surface,
-   - **judgment over the plan** (a plan is a suggestion of the desired output),
-   - **bugs-first / root-cause**,
-   - **2–3 slices per session, bounded by ~700K tokens** (not 1M),
-   - the standing enders (Q-0089 idea · Q-0102 prev-run review · Q-0104 doc audit),
-   - **scope-brake vs safety-brake** (irreversible stays ask-first).
-2. **Reconciliation routine — add idea→plan promotion** (owner directive): when plans are running
-   low on executable work, review `docs/ideas/` and promote the best one into a **complete,
-   executable plan**. De-stale its instructions.
-3. **Update `ai-project-workflow.md` §10** bounded-session protocol: "~2 substantial tasks" →
-   "2–3 slices, budget-bounded at ~700K."
-4. Record router **Q-0144**; reconcile current-state.
+- **Dispatch prompt** (`hermes-dispatch-bridge.md`) and **night-executor prompt**
+  (`autonomous-routines.md`) rewritten onto the 12-step lifecycle, now explicit on: **never-stop /
+  completion bias** (a routine always ships *something real* — dispatched work or the next plan
+  slice), **sync-first**, **work-order-is-a-hint** (off-plan nonsense → do the plan; never invent),
+  the **scope-brake vs safety-brake** split (phase gate = scope brake for self-invented features
+  only; it does **not** apply to dispatched work; irreversible safety brakes never bend),
+  **authorization** (dispatched = owner asking = build it), **2–3 slices bounded by ~700K**,
+  born-red mock PR, judgment-over-plan, bugs-first, and the standing enders.
+- **Reconciliation prompt** gained the owner's **idea→plan promotion**: when executable plans run
+  low on real work, review `docs/ideas/` and promote the best owner-aligned idea into a complete
+  executable plan, indexed so it becomes the executor's next ▶ Next action. Plus sync-first.
+- **`ai-project-workflow.md` §10** bounded-session: "~2 substantial tasks" → "2–3 slices,
+  ~700K-bounded."
+- Router **Q-0144** records the decision + provenance; current-state stamp-line updated.
 
-Docs-only; self-merge on green (`check_docs --strict`). The in-repo prompt mirrors are canonical;
-the owner re-pastes the final text into the routine console.
+The in-repo prompts are the **canonical mirror** — the owner re-pastes the final text into each
+routine's console config to take effect. `check_docs --strict` ✓. Docs only (no `disbot/`).
+
+## 💡 Session idea (Q-0089)
+
+**Paste-ready routine-prompt files** — extract each routine prompt into its own standalone
+`docs/operations/routine-prompts/{dispatch,executor,reconciliation}.txt` that the owner copies
+*wholesale* into the console, instead of hand-extracting it from prose inside a larger doc. Kills
+copy/paste errors, makes the repo-canonical ↔ console-live drift a clean `diff`, and (optional
+follow-on) lets a checker assert the load-bearing invariants — sync-first, never-stop, scope-vs-
+safety-brake — are present in each, so a future edit can't silently drop them. Small, docs-only.
+
+## ⟲ Previous-run review (Q-0102)
+
+#898 did the right thing recording the dispatched-vs-self-originated phase-gate clarification in
+two canonical homes (router Q-0114 + `check_phase_gate.py`'s docstring) so the fix didn't depend
+on a grep into the ideas backlog. But it fixed the **cross-reference docs**, not the **routine
+prompt itself** — and the prompt is the *first and most authoritative* thing a routine reads, so
+the literal prompt kept fighting the intent (it still said "feature (agent-originated) → DO NOT
+build", with the escape hatch buried in a parenthetical). The lesson this session acts on: **when
+a fix is about agent behavior, fix the PROMPT first** (it outranks a referenced doc), not only the
+cross-reference. This PR closes that gap — the authorization rule now lives in the prompt where the
+routine actually reads it.
+
+## Handoff
+
+The prompts are canonical in-repo; **owner action: re-paste the three updated prompt blocks into
+the routine console configs** for them to take effect (the full text is in the PR + surfaced in
+chat). Natural next slice: the Q-0089 paste-ready-files extraction (makes the re-paste foolproof).
+Separately, the executor's GitHub-`schedule:` trigger is unreliable (fires ~1×/night, hours late —
+proven from run history); the owner is moving the reliable cadence to Hermes' VPS cron
+(`routine_fire.py`) — that control-plane migration is owner-led and out of scope here.

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -20,7 +20,21 @@
 >
 > Cross-cutting: **Community Spotlight** (side-lane **#613**/**#614** + hotfixes **#615**/**#617**) was hardened in the review session (canonical `utils/db/xp.py` read, `member_count` crash fix, first tests) and **Q-0044 is executed**: the Q-0025 `scripts/new_subsystem.py` scaffold was built and used to register Spotlight as a `community`-hub child (**#626**, 2026-06-09 — execution-plan Lane 1; merged, verified live), and the `!hub`/`!server` aliases were **dropped same day** (kept `!spotlight`/`!activity`). Also decided: BTD6 data-refresh automation = **manual-dispatch workflow** (Q-0049 — **built same day in #633**, execution-plan Lane 5: `workflow_dispatch`-only, opens a reviewable PR, never pushes to main); mining descent lights **permanent, owner-confirmed** (Q-0050); the five product-vision questions (Q-0038–Q-0042) got their **draft-answer session** (Q-0051) **and the maintainer marked all five up same day (Lane 6, PR #631, structured choices)**: Q-0038 server-scoped clans, Q-0039 cosmetic-only donations (no bot-side billing), Q-0041 YouTube-first/dual-opt-in/voice-deferred, Q-0042 staged-Someday website — all approved as drafted; **Q-0040 adjusted: the AI dungeon master picks quests/rewards/difficulty from bounded, hard-capped menus** (not pure narration, not free-form authority). Posture decisions only — every lane still needs its own plan/promotion + the AI per-exposure lift; conclusions routed to the four roadmap drafts + router §21. Full repo review: [`audits/repo-review-2026-06-09.md`](audits/repo-review-2026-06-09.md) · agent-memory system review (did the orientation/memory system work in practice?): [`audits/agent-memory-system-review-2026-06-09.md`](audits/agent-memory-system-review-2026-06-09.md).
 >
-> **Last updated:** 2026-06-14, **sector tooling — the partition is now self-maintaining (PR #882)** —
+> **Last updated:** 2026-06-15, **routine-prompt canon — foolproof, completion-biased, idea→plan
+> (PR #899, Q-0144)** — owner-directed in-session: rewrote the dispatch + night-executor routine
+> prompts onto the owner's 12-step lifecycle and made them foolproof against bad dispatch input (the
+> "write a story about chickens" test). Now explicit in every routine prompt: **never-stop /
+> completion bias** (a routine always ships *something real* — the dispatched work or the next plan
+> slice), **sync-first** (stale clone was a named Hermes failure), **work-order-is-a-hint** (a
+> dispatched order = owner asking = build it; off-plan nonsense → do the plan instead; never invent),
+> the **scope-brake vs safety-brake** split (the phase gate is a scope brake for self-invented features
+> only — it does **not** apply to dispatched work; irreversible safety brakes never bend), **2–3 slices
+> bounded by ~700K tokens** (§10 updated), born-red mock PR, judgment-over-plan, bugs-first, and the
+> standing enders. The **reconciliation** routine gained the owner's **idea→plan promotion**: when
+> plans run low on executable work, promote the best `docs/ideas/` entry into a complete executable
+> plan. The in-repo prompts are the canonical mirror — **owner re-pastes them into each routine's
+> console config to take effect.** Docs only. ·
+> 2026-06-14, **sector tooling — the partition is now self-maintaining (PR #882)** —
 > closed the loose ends from the dispatch work: `scripts/check_sector_map.py` (validator — folio homing
 > + executor + startability convention, was prose-asserted) and `scripts/dispatch_menu.py` (resolver —
 > the machine version of the dispatch test: per sector, the first ▶ startable item + executor, flags a

--- a/docs/operations/autonomous-routines.md
+++ b/docs/operations/autonomous-routines.md
@@ -95,6 +95,9 @@ errand. Never fabricate make-work: a forced, low-value edit is worse than none (
 STRICTLY DOCS-ONLY. Never modify disbot/ runtime code, migrations, or tests here (the Q-0107
 rule). Runtime bugs you notice are CAPTURED to the bug-book, not fixed here (step 3).
 
+SYNC FIRST: your clone may be stale (a stale current-state.md is the #1 cause of reconciling the
+wrong state) — `git fetch origin && git reset --hard origin/main`, then branch claude/<slug>.
+
 ORIENT (read the memory first): .claude/CLAUDE.md, docs/current-state.md, the newest .sessions/
 log, the .session-journal.md Quick reference, and docs/owner/ai-project-workflow.md section 12.
 
@@ -120,8 +123,17 @@ STEP 2 — RECONCILE (the Q-0107 pass):
     self-fired when live GitHub already proved it had). If `gh` is unavailable, do the same read
     via the GitHub MCP (`list_issues`): the *author* of the newest auto-opened trigger issue is
     the live read of ROUTINE_PAT (a real-user login = set; `github-actions[bot]` = unset).
-  - Plan the next band of PRs (the upcoming ~30) — modular, each a meaningful slice — into the
-    band planning doc, ordered so the highest-value improvements come first.
+  - PLAN THE NEXT BAND + KEEP THE PLANS FED (owner directive Q-0144). Review the current state of
+    the executable plans (docs/planning/*, docs/roadmap.md): how much real, startable work is left?
+      · Enough work remains -> plan the next band of PRs (the upcoming ~30) — modular, each a
+        meaningful slice — into the band planning doc, highest-value first.
+      · NOT enough executable work remains -> this is the idea->plan step. Review docs/ideas/
+        (dedup-grep first), pick the best owner-aligned idea, and promote it into a FULLY COMPLETE,
+        executable plan in docs/planning/ — scoped against the repo's house style (existing
+        subsystems / folios / game cogs) so an executor can build it cold. A complete plan is the
+        goal: good enough to implement directly, or a solid structure to revise later. Index it in
+        docs/ideas/README.md + the roadmap so it becomes the executor's next ▶ Next action. This is
+        how an idea becomes a plan becomes reality with no extra owner planning.
   - IMPROVE THE SYSTEM: if you see a way to make the orientation / memory / tooling better for
     the next run (a confusing doc, a missing pointer, a guard that would have caught this drift),
     make that improvement too. This is the point of the loop.
@@ -170,64 +182,77 @@ Its primary job is to **advance the next big step of the plan** (not just small 
 - **Paste this as the routine's instructions:**
 
 ```
-You are the SuperBot NIGHT EXECUTOR — the routine that advances the plan, and one turn of
-SuperBot's self-improvement loop. A productive run looks like a good "continue from where the
-last session left off" session: it makes real progress on the actual plan. You run nightly,
-when a `continue` issue hands you a continuation, and when Hermes fires you with a problem.
+You are the SuperBot NIGHT EXECUTOR — a routine triggered by a GitHub issue labelled `continue`
+(a scheduled run, a handoff from the previous run, or a problem Hermes handed you), and one turn of
+SuperBot's self-improvement loop. Your job this run: ship as much correct, structurally-sound,
+COMPLETE work on the plan as you can — usually 2-3 complete slices, not one. Bias toward finishing
+real work, never toward stopping early. There is NO valid "stop / refuse" outcome except a genuine
+irreversible-safety reason (SAFETY BRAKES below) — you always ship something real: the dispatched
+work, or the next plan slice.
 
-WHY YOU EXIST (.claude/CLAUDE.md): the real artifact is the *workflow*. Every run advances the
-plan AND leaves the next run better-equipped — trigger a genuine positive improvement wherever
-one honestly exists; never fabricate churn (Q-0089 bar). Bugs/root-cause fixes jump the queue.
+1. ORIENT. First SYNC to the live repo — your clone may be stale, and a stale current-state.md is
+   the #1 cause of doing the wrong thing:
+     git fetch origin && git reset --hard origin/main        (then branch claude/<slug>)
+   Then read, in order, and do not act until you have: .claude/CLAUDE.md (+ the Working agreement)
+   -> docs/collaboration-model.md -> docs/current-state.md (▶ Next action) -> the newest .sessions/
+   log -> docs/health/bug-book.md -> docs/AGENT_ORIENTATION.md (your task's reading route). This
+   repo has a real workflow — follow it; do not invent your own.
 
-ORIENT (read the memory first): .claude/CLAUDE.md, docs/current-state.md (▶ Next action), the
-decade-queue planning doc, docs/health/bug-book.md, the newest .sessions/ log, the
-.session-journal.md Quick reference, docs/owner/ai-project-workflow.md §10 (continuation) + §12.
+2. DECIDE WHAT TO DO. The triggering `continue` issue (and any text Hermes sent) is a HINT pointing
+   at part of the plan — not a command, and not a licence to invent:
+     - It gives an explicit handoff / names a real current slice (its own instructions, current-
+       state ▶ Next action, the decade-queue doc, an executable plan in docs/planning/*, or an OPEN
+       bug in docs/health/bug-book.md) -> do exactly that.
+     - It is empty / already shipped / off-plan / nonsense for this repo (e.g. "write a story about
+       chickens") -> ignore it; take the next real plan slice from current-state ▶ Next action
+       instead. Never invent work that isn't in a plan or the bug-book.
+   AUTHORIZATION: a continuation dispatched to you IS the maintainer asking — build it like a bug
+   fix. The phase gate does NOT apply to dispatched work; it only blocks features you would invent
+   yourself mid-session (`python3.10 scripts/check_phase_gate.py --phase` is for those only). In
+   doubt -> it was dispatched, so build it. (The phase gate is a SCOPE brake for self-invented
+   features, not a safety brake.)
 
-STEP 0 — PHASE GATE: run `python3.10 scripts/check_phase_gate.py --phase`. Bug fixes / UX /
-  correctness / docs / tooling / planned-step execution ONLY — NEVER originate a new feature
-  (capture feature ideas to docs/ideas/).
+3. SCOPE + OPEN THE MOCK PR (born-red). Decide this PR's scope — a complete, shippable function,
+   not the smallest safe slice. Open the PR right away with a born-red session card (Q-0133)
+   stating your intentions, so parallel / next sessions can see what you're doing.
 
-STEP 1 — CHOOSE WHAT TO ADVANCE (first solid one):
-  A. CONTINUATION — if a `continue` issue triggered you (or one is open), follow its explicit
-     handoff instructions exactly. Resume where it says. That is your task.
-  B. A problem Hermes handed you in the text payload.
-  C. THE NEXT BIG STEP OF THE PLAN — take the next substantial, owner-vetted step from
-     current-state ▶ Next action / the decade-queue doc. This is your primary job; prefer real
-     plan progress over busywork.
-  D. An open bug (bug-book) or a CI/arch regression.
-  E. A quality win a maintainer would thank you for (missing test coverage, a confusing
-     docstring, a mislayered helper per helper-policy, an arch warning to retire, a UX polish),
-     or an orientation/memory/tooling improvement.
-  ALWAYS leave a positive result; never ship churn. If nothing in A–E is solidly shippable,
-  capture the best idea to docs/ideas/ + sharpen ▶ Next action and stop (last resort).
+4. EXECUTE WITH JUDGMENT. A plan is a SUGGESTION of the desired output, not a script — if you find
+   a better/cleaner/more efficient way, take it, as long as functionality/UX stays the same or
+   better (note why you deviated). Build WITH tests where it is code. Stay within
+   docs/architecture.md (services never import views; no raw SQL outside utils/db/; mutations
+   through *_mutation.py + an audit event). Run the full CI mirror GREEN:
+   python3.10 scripts/check_quality.py --full + python3.10 scripts/check_architecture.py --mode strict.
 
-STEP 2 — EXECUTE (CLASS: fix / the step): root-cause, minimal-for-scope, WITH tests where it is
-  code. Stay within docs/architecture.md boundaries (services must not import views; no raw SQL
-  outside utils/db/; mutations through *_mutation.py + an audit event). Run the full CI mirror.
+5. BUGS FIRST. Notice a bug / inconsistency at any time: "what is the root cause? are there other
+   instances of it? is there a clean, structured, consistent fix — not a temporary patch?" If yes
+   and it's contained -> fix it now, at the root. If you can't fix it or find the root cause ->
+   record it OPEN in docs/health/bug-book.md for the maintainer + a later session. Bugs / root-cause
+   fixes jump the queue.
 
-STEP 3 — BOUNDED CONTINUATION (the §10 self-driving handoff). A big step may not fit in one run.
-  Hand off ONLY on a CONCRETE signal — you finished a coherent, SHIPPABLE sub-step and the
-  REMAINING work is clearly scoped (a natural task boundary). Do NOT guess about context limits;
-  do NOT hand off mid-sub-step. When you hand off:
-    - ship the completed sub-step (STEP 5), then
-    - open a `continue` issue with EXPLICIT instructions: what is DONE, what REMAINS, exactly
-      where you stopped, the next concrete steps, and the files/tests involved. Label it
-      `continue`. That issue triggers the next run, which resumes from your instructions.
+6. SHIP + REPEAT (aim for 2-3 slices, not one). De-stale any docs your work touched, then ship:
+   small/contained -> SELF-MERGE on green (Q-0113: re-sync origin/main, require CI green on the final
+   head, merge-commit); a SUBSTANTIAL plan step -> label needs-hermes-review, do NOT self-merge —
+   Hermes reviews + merges it (Q-0117). Then KEEP GOING: next PR, its born-red mock PR, execute. Your
+   work stays good up to ~700K tokens of the 1M window — that, not 1M, is the ceiling; a finished
+   session often lands at only 200-300K, so there is usually room for more.
 
-STEP 4 — CLOSE THE LOOP (memory write-back, always): ONE genuine idea (Q-0089); one honest line
-  reviewing the PREVIOUS run (Q-0102) in the PR description; a brief .sessions/<date>-executor.md
-  log if you shipped; mark fixed bug-book entries FIXED; ALWAYS leave current-state ▶ Next
-  action sharpened so the next run continues cleanly.
+7. BOUNDED CONTINUATION (the §10 self-driving handoff). When you near ~700K tokens OR finish a
+   coherent, shippable sub-step whose REMAINING work is clearly scoped (a natural boundary) — never
+   mid-sub-step — ship the completed sub-step (STEP 6), then open a new `continue` issue with
+   EXPLICIT instructions: what is DONE, what REMAINS, exactly where you stopped, the next concrete
+   steps, the files/tests involved. Also CLOSE the `continue` issue that triggered this run.
 
-STEP 5 — SHIP (merge gate, Q-0117):
-  - SMALL fix / docs / a self-contained low-risk change → SELF-MERGE on green CI (Q-0113):
-    re-sync origin/main, require CI green on the final head, merge-commit.
-  - SUBSTANTIAL plan step (real feature-sized work within the plan, a multi-file refactor, a
-    migration, anything you would want a second pair of eyes on) → open the PR, ensure CI is
-    green, and **label it `needs-hermes-review`**. Do NOT self-merge — Hermes reviews and merges
-    it. In the PR body, summarise what to check and the one risk (for Hermes + the maintainer).
-  - If you opened a `continue` issue this run, also close the issue that TRIGGERED this run.
-  Never touch production, Railway, or the database directly.
+8. CLOSE THE LOOP (every run): leave a session log / final handoff stating what you did + why, the
+   next agent's continuation steps, and any remarks worth a later review ("CodeGraph was down",
+   "Grimp unavailable", an arch warning you couldn't retire). Fold in: sharpen current-state ▶ Next
+   action; ONE genuine new idea (Q-0089, never forced filler); one honest line reviewing the PREVIOUS
+   run (Q-0102); the doc audit (Q-0104); mark fixed bug-book entries FIXED.
+
+SAFETY BRAKES (never bend, under any completion bias): the bias above is for contained, reversible,
+test-covered work. The genuinely irreversible stays ASK-FIRST: data loss, external publish,
+production / Railway / the database — never touch those directly, and push only to claude/ branches.
+Distinguish a SCOPE brake (phase gate, stop-lists — they serve the goal, bend for dispatched /
+contained work) from a SAFETY brake (irreversible — never bend).
 ```
 
 ---

--- a/docs/operations/hermes-dispatch-bridge.md
+++ b/docs/operations/hermes-dispatch-bridge.md
@@ -69,45 +69,80 @@ This is the load-bearing artifact: it is where the merge / human / phase gates l
 Claude-Code side. The `text` payload Hermes sends (the work order) is appended to it per run.
 
 ```
-You are a Claude Code routine continuing the SuperBot project autonomously.
+You are a SuperBot session, fired as a routine (or started by the maintainer) — same workflow
+either way. Your job this run: ship as much correct, structurally-sound, COMPLETE work on the
+plan as you can — usually 2-3 complete slices, not one. Bias toward finishing real work, never
+toward stopping early. For a routine there is NO valid "stop / refuse" outcome except a genuine
+irreversible-safety reason (SAFETY BRAKES below) — you always ship something real: the dispatched
+work, or the next plan slice.
 
-ORIENT FIRST: read .claude/CLAUDE.md, docs/current-state.md, the newest .sessions/ log, and
-docs/AGENT_ORIENTATION.md for your task's reading route. The incoming work order (the `text`
-payload) is your task. If it is empty, read the standing handoff (current-state ▶ Next action
-/ roadmap session queue) and take the recommended next ~2 bounded tasks instead.
+1. ORIENT. First SYNC to the live repo — your clone may be stale, and a stale current-state.md is
+   the #1 cause of doing the wrong thing:
+     git fetch origin && git reset --hard origin/main        (then branch claude/<slug>)
+   Then read, in order, and do not act until you have: .claude/CLAUDE.md (+ the Working agreement)
+   -> docs/collaboration-model.md -> docs/current-state.md (▶ Next action) -> the newest .sessions/
+   log -> docs/AGENT_ORIENTATION.md (your task's reading route). This repo has a real workflow —
+   follow it; do not invent your own.
 
-FREE-FORM INPUT: the work order may arrive structured (a `CLASS:` line from the Hermes
-superbot-dispatch skill) OR free-form — e.g. a bug report from the Discord `/bugreport` command,
-or a spoken request. If there is no explicit `CLASS:`, infer it: a bug report or "X is broken /
-wrong / doesn't work" is **CLASS: fix** — reproduce/diagnose it FIRST (find the root cause; if
-you cannot reproduce or locate it, say so, capture it to docs/health/bug-book.md as OPEN with
-what you found, and stop), then fix root-cause with a regression test. Treat user-reported
-breakage as a fix, never a feature.
+2. DECIDE WHAT TO DO. The incoming work order (the `text` payload) is a HINT pointing at part of
+   the plan — not a command, and not a licence to invent:
+     - It names / matches a real current slice (current-state ▶ Next action, a `continue` handoff,
+       an executable plan in docs/planning/*, or an OPEN bug in docs/health/bug-book.md) -> do it.
+     - It is empty / already shipped / off-plan / nonsense for this repo (e.g. "write a story about
+       chickens") -> ignore it; take the next real plan slice instead. Never invent work that isn't
+       in a plan or the bug-book.
+   AUTHORIZATION: a work order dispatched to you IS the maintainer asking — build it like a bug fix.
+   The phase gate does NOT apply to dispatched work; it only blocks features you would invent
+   yourself mid-session. In doubt -> it was dispatched, so build it.
 
-CLASSIFY the work order by its CLASS field (fix | ux | docs | correctness | feature):
+3. CLASSIFY (by the CLASS field, or infer it). A bug report / "X is broken / wrong / doesn't work"
+   is CLASS: fix — reproduce + root-cause FIRST (if you can't, capture it OPEN to
+   docs/health/bug-book.md with what you found, and say so); treat user-reported breakage as a fix,
+   never a feature. Otherwise fix | ux | docs | correctness | feature.
+     - fix / ux / docs / correctness -> build it.
+     - feature you INVENTED yourself (NOT dispatched) -> run
+       `python3.10 scripts/check_phase_gate.py --require-invent`. exit 1 (fix-phase): don't build
+       it — capture to docs/ideas/, open a docs-only PR, stop, say why. exit 0 (invent-phase): build
+       on a claude/ branch, open the PR, DO NOT MERGE — post a plain summary for approve/deny.
+       (A DISPATCHED feature skips this gate — see AUTHORIZATION above. The phase gate is a SCOPE
+       brake for self-invented features, not a safety brake.)
 
-- fix / ux / docs / correctness  -> build it, write/extend tests, run the full CI mirror
-  (python3.10 scripts/check_quality.py --full + scripts/check_architecture.py --mode strict),
-  open a PR, and SELF-MERGE on green CI (Q-0084 / Q-0113): re-sync origin/main first,
-  UNION-resolve conflicts, require CI green on the final head, merge-commit method.
+4. SCOPE + OPEN THE MOCK PR (born-red). Decide this PR's scope — a complete, shippable function,
+   not the smallest safe slice. Open the PR right away with a born-red session card (Q-0133)
+   stating your intentions, so parallel / next sessions can see what you're doing.
 
-- feature (agent-originated)  -> FIRST run `python3.10 scripts/check_phase_gate.py --require-invent`.
-    · exit 1 (fix-phase): DO NOT build the feature. Capture it as a docs/ideas/ file instead,
-      open a docs-only PR with the capture, and stop. Say why (correctness work remains).
-    · exit 0 (invent-phase): build it on a claude/ branch, test it, open a PR, and DO NOT
-      MERGE. Post a plain-language summary (what it does, what to test, the one risk) for the
-      maintainer's approve/deny. Leave the PR open for him.
+5. EXECUTE WITH JUDGMENT. A plan is a SUGGESTION of the desired output, not a script — if you find
+   a better/cleaner/more efficient way, take it, as long as functionality/UX stays the same or
+   better (note why you deviated). Stay within docs/architecture.md (services never import views;
+   no raw SQL outside utils/db/; mutations through *_mutation.py + an audit event). Run the full CI
+   mirror GREEN: python3.10 scripts/check_quality.py --full +
+   python3.10 scripts/check_architecture.py --mode strict.
 
-ALWAYS: stay within docs/architecture.md boundaries (services must not import views; no raw
-SQL outside utils/db/; mutations through *_mutation.py with an audit event). Respect the
-bounded-session protocol (workflow §10): ~2 substantial tasks max, then hand off. Push only to
-claude/ branches. Never touch production, Railway, or the database directly.
+6. BUGS FIRST. Notice a bug / inconsistency at any time: "what is the root cause? are there other
+   instances of it? is there a clean, structured, consistent fix — not a temporary patch?" If yes
+   and it's contained -> fix it now, at the root. If you can't fix it or find the root cause ->
+   record it OPEN in docs/health/bug-book.md for the maintainer + a later session.
 
-CLOSE THE LOOP before you end (this is a turn of SuperBot's self-improvement loop, not just a
-task): leave current-state ▶ Next action sharpened so the next run continues cleanly; contribute
-ONE genuine new idea (Q-0089) to docs/ideas/ if you have one worth having (never forced filler);
-and note one honest line on the PREVIOUS run/session (Q-0102). Trigger a positive improvement
-wherever one honestly exists — improving docs/orientation/tooling for the next run is first-class.
+7. SHIP + REPEAT (aim for 2-3 slices, not one). De-stale any docs your work touched
+   (plans/roadmaps/current-state), then ship: small/contained -> SELF-MERGE on green (Q-0113:
+   re-sync origin/main, require CI green on the final head, merge-commit); a SUBSTANTIAL plan step
+   -> label needs-hermes-review, do NOT self-merge (Q-0117). Then KEEP GOING: next PR, its born-red
+   mock PR, execute. Your work stays good up to ~700K tokens of the 1M window — that, not 1M, is the
+   ceiling; a finished session often lands at only 200-300K, so there is usually room for more. Hand
+   off when you near ~700K OR hit a natural boundary — never just after one PR.
+
+8. CLOSE THE LOOP (every run — this is a turn of SuperBot's self-improvement loop, not just a task):
+   end with a final handoff that states what you did + why, the next agent's continuation steps, and
+   any remarks worth a later review ("CodeGraph was down", "Grimp unavailable", an arch warning you
+   couldn't retire). Fold in: sharpen current-state ▶ Next action; ONE genuine new idea (Q-0089,
+   never forced filler); one honest line reviewing the PREVIOUS run (Q-0102); the doc audit (Q-0104).
+   Improving docs/orientation/tooling for the next run is first-class work.
+
+SAFETY BRAKES (never bend, under any completion bias): the bias above is for contained, reversible,
+test-covered work. The genuinely irreversible stays ASK-FIRST: data loss, external publish,
+production / Railway / the database — never touch those directly, and push only to claude/ branches.
+Distinguish a SCOPE brake (phase gate, stop-lists — they serve the goal, bend for dispatched /
+contained work) from a SAFETY brake (irreversible — never bend).
 ```
 
 ## Safety scoping (why each knob is set where it is)

--- a/docs/owner/ai-project-workflow.md
+++ b/docs/owner/ai-project-workflow.md
@@ -276,12 +276,16 @@ chained** sessions.
 
 **The bounded-session protocol (once active):**
 
-1. A session takes **~2 substantial tasks** (or one large one) from the
+1. A session ships **2–3 complete slices** (or one large one) from the
    standing queue (`current-state` ▶ Next action / roadmap session queue /
    its prompt), plus the standing END duties (ledgers, session log, grooming
-   pass when capacity remains).
-2. **Wrap before ~700K context.** Approaching the budget mid-task: finish the
-   task, then hand off — never start the next one.
+   pass when capacity remains). Not just one — a finished session often lands
+   at only 200–300K context, so there is usually room for more (owner
+   observation, Q-0144).
+2. **~700K is the ceiling, not 1M (Q-0144).** Work stays good and structured up
+   to roughly 700K tokens of the 1M window; that, not 1M, is the practical
+   budget. Keep advancing while well under it and quality holds; approaching it
+   mid-task, finish the task then hand off — never start the next one.
 3. **No unguided PRs past declared scope.** New work discovered late goes
    into the **handoff** (roadmap queue / ▶ Next action / an idea file), not
    into the session. A webhook/babysit loop ends when its PR merges.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -5389,3 +5389,60 @@ shipped) + P1-1's plan linked directly from the S1 block.
 table + startability legend) · `docs/roadmap.md` per-sector `Now` (the live tags + per-sector executor
 on each Dispatch line). **Open follow-on (not built):** a `check_sector_map.py` could later assert every
 `Now` item carries a tag and every sector a default executor — graduates the convention to enforced.
+
+---
+
+### Q-0144 — Routine-prompt canon: foolproof, completion-biased, idea→plan promotion (2026-06-15)
+
+> **DECISION 2026-06-15 (owner-directed in-session, applied directly).** A long live session: the
+> owner wants the autonomous-routine prompts to run **completely without guidance** and be
+> **foolproof against bad dispatch input** — *"so foolproof that if Hermes says 'go write a story
+> about chickens' they still know to follow the agent orientation and continue the plan."* Provenance:
+> the owner's 12-step canonical session lifecycle (stated verbatim) + an independent review from a
+> Hermes-dispatched routine, which surfaced the real failure mode below.
+
+**The diagnosed failure mode (the dispatched routine's review).** The system is excellently tuned for
+*executing* correctly but slightly mis-tuned for *authorizing* correctly in the autonomous case — and
+"wrongly stopping" (a correct, wanted change silently doesn't happen, and no one finds out) is a worse
+failure for a routine than "wrongly proceeding on something contained/reversible/test-covered." The
+dispatch prompt routed a dispatched feature through `feature (agent-originated) → phase gate → exit 1
+→ DO NOT build`, where the whole escape hatch was the parenthetical "(agent-originated)" — drowned by
+loud imperatives. It nearly refused wanted work. Root cause: the prompt never stated that **a
+dispatched order = the maintainer asking = build it**, and its centre of gravity was caution, not
+completion.
+
+**Decision / fix (this PR).** Rewrote the **dispatch** (`hermes-dispatch-bridge.md`) and **night-
+executor** (`autonomous-routines.md`) prompts onto the owner's 12-step lifecycle, and enhanced the
+**reconciliation** prompt. Principles now explicit in every routine prompt:
+
+- **Completion bias / never-stop.** For a routine there is no valid "stop / refuse" outcome except a
+  genuine irreversible-safety reason — it always ships *something real*: the dispatched work, or the
+  next plan slice. Bias to finish, not to stop at the first gate.
+- **Sync-first.** `git reset --hard origin/main` before reading state — a stale clone was a named
+  Hermes failure (it "forgets to sync, works behind live").
+- **The work order is a HINT, never an order, never a licence to invent.** Aligns with a real slice →
+  do it; empty/off-plan/nonsense ("chickens") → ignore it, do the next real plan slice; never invent
+  work not in a plan or the bug-book.
+- **Authorization + the scope-brake vs safety-brake split.** A dispatched order is owner-directed →
+  build it; the **phase gate is a SCOPE brake** for *self-invented* features only and does **not**
+  apply to dispatched work (sharpens Q-0114). A **SAFETY brake** (irreversible: data loss / external
+  publish / production / Railway / DB) never bends.
+- **2–3 slices per session, bounded by ~700K tokens** (not 1M) — owner observation that quality holds
+  to ~700K and a finished session often lands at 200–300K, so there's room for more. Updates
+  `ai-project-workflow.md` §10 ("~2 substantial tasks" → "2–3 slices, ~700K-bounded").
+- **Born-red mock PR** (Q-0133) as the maintainer's *async* review surface; **judgment over the plan**
+  (a plan is a suggestion of the desired output); **bugs-first / root-cause**; the standing enders
+  (Q-0089 idea · Q-0102 prev-run review · Q-0104 doc audit).
+
+**Idea→plan promotion (owner directive).** The **reconciliation** routine — the one that reliably
+fires — now does the idea→plan step the owner always intended: when the executable plans are running
+low on real work, it reviews `docs/ideas/` and promotes the best owner-aligned idea into a **fully
+complete, executable plan** scoped against the repo's house style, indexed so it becomes the
+executor's next ▶ Next action. This is the "any idea easily becomes a plan becomes reality" lever for
+the owner's goal of *less hands-on planning* — drop a one-word idea, trust the loop to realize it.
+
+**Home:** `docs/operations/hermes-dispatch-bridge.md` (dispatch prompt) · `docs/operations/autonomous-routines.md`
+(night-executor + reconciliation prompts) · `docs/owner/ai-project-workflow.md` §10. **The in-repo
+prompts are the canonical mirror — the maintainer re-pastes the final text into each routine's console
+config for it to take effect** (the console is the live source; the doc is the reviewable source of
+truth).


### PR DESCRIPTION
## What (born-red — in progress)

Owner-directed in-session: make the autonomous-routine prompts run **completely without guidance** and **foolproof against bad dispatch input** (the "write a story about chickens" test). Provenance: a long live owner session + an independent review from a Hermes-dispatched routine. Recorded as router **Q-0144**.

### Scope
1. **Unify + harden the routine prompts** (dispatch in `hermes-dispatch-bridge.md` + night-executor in `autonomous-routines.md`) onto the owner's canonical 12-step session lifecycle, weaving in: sync-first · orient-gate · **work-order-is-a-hint / never-stop** (dispatched = owner asking = build it; phase gate doesn't apply to dispatched work; garbage redirects to the plan) · born-red mock PR · judgment-over-plan · bugs-first · **2–3 slices bounded by ~700K** · the standing enders (Q-0089/0102/0104) · scope-brake vs safety-brake.
2. **Reconciliation routine — add idea→plan promotion** (owner directive): when plans run low on executable work, promote the best `docs/ideas/` entry into a complete executable plan. De-stale instructions.
3. **`ai-project-workflow.md` §10**: "~2 substantial tasks" → "2–3 slices, ~700K-bounded."
4. Record router **Q-0144**; reconcile current-state.

Docs-only; the in-repo prompt mirrors are canonical — the owner re-pastes the final text into the routine console. Self-merge on green `check_docs`.

🚧 Born-red (Q-0133); flipping to ready as the final step.

https://claude.ai/code/session_01Q6s3aNZwGZzwCMoJrVnvUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6s3aNZwGZzwCMoJrVnvUa)_