### PR TITLE
docs(routines): drop the no-op continue-issue clause from the dispatch prompt

### DIFF
--- a/.sessions/2026-06-15-dispatch-prompt-continue-trim.md
+++ b/.sessions/2026-06-15-dispatch-prompt-continue-trim.md
@@ -1,0 +1,28 @@
+# Session: Trim the no-op `continue`-issue clause from the dispatch prompt
+
+> **Status:** `complete` — born-red card flipped (Q-0133); single-push docs fix.
+
+**Branch:** `claude/dispatch-prompt-continue-trim-2026-06-15` · **Date:** 2026-06-15 · **Type:** docs (S3) · **Trigger:** owner-directed in-session
+
+## What shipped
+
+Follow-up to Q-0145. The dispatch prompt's step 8 still told the routine to "open a `continue`
+issue *if a continuation trigger is wired*" — a no-op in the 2-routine world (dispatch is fired by
+Hermes' VPS cron, nothing consumes `continue` issues since the night-executor was retired), and a
+mild risk (a literal routine could open orphan issues nobody services). Owner asked to remove it for
+clarity. Replaced the silent conditional with a positive instruction: the handoff IS sharpening
+▶ Next action (the next Hermes-cron dispatch reads it from live state); **do NOT open a `continue`
+issue**. Docs only; `check_docs --strict` ✓.
+
+## 💡 Session idea (Q-0089)
+
+Covered by the standing Q-0089 idea from this session's earlier slices (the routine-prompt
+consistency guard `check_routine_prompts.py`) — a guard like that would have flagged this stale
+no-op clause automatically. No new idea forced (Q-0089 bar).
+
+## ⟲ Previous-run review (Q-0102)
+
+#900 (the Q-0145 merge) correctly consolidated to 2 routines but left this one residual clause from
+the old 3-routine self-chaining model — a small reminder that when you retire a mechanism (the
+`continue`-issue trigger), you must sweep the *instructions that assumed it*, not just the routine.
+This trim closes that residue.

--- a/docs/operations/hermes-dispatch-bridge.md
+++ b/docs/operations/hermes-dispatch-bridge.md
@@ -135,10 +135,14 @@ dispatched work, or the next plan slice.
 
 8. HAND OFF + CLOSE THE LOOP (every run — this is a turn of SuperBot's self-improvement loop). When
    you stop (you neared ~700K, or finished a clean sub-step whose remaining work is clearly scoped —
-   never mid-sub-step), SHARPEN current-state ▶ Next action so the next dispatch resumes from live
-   state (the next Hermes fire reads it); if a continuation trigger is wired, also open a `continue`
-   issue with explicit next steps (what's DONE, what REMAINS, where you stopped, the files/tests).
+   never mid-sub-step), SHARPEN current-state ▶ Next action with the explicit handoff (what's DONE,
+   what REMAINS, where you stopped, the files/tests) — that IS the continuation; the next Hermes-cron
+   dispatch reads it from live state. Do NOT open a `continue` issue (no routine consumes them now).
    End with a final handoff stating what you did + why, the next agent's continuation steps, and any
+   remarks worth a later review ("CodeGraph was down", "Grimp unavailable", an arch warning you
+   couldn't retire). Fold in: ONE genuine new idea (Q-0089, never forced filler); one honest line
+   reviewing the PREVIOUS run (Q-0102); the doc audit (Q-0104); mark fixed bug-book entries FIXED.
+   Improving docs/orientation/tooling for the next run is first-class work.
    remarks worth a later review ("CodeGraph was down", "Grimp unavailable", an arch warning you
    couldn't retire). Fold in: ONE genuine new idea (Q-0089, never forced filler); one honest line
    reviewing the PREVIOUS run (Q-0102); the doc audit (Q-0104); mark fixed bug-book entries FIXED.


### PR DESCRIPTION
## What

Q-0145 follow-up (owner-directed). The dispatch prompt's step 8 still carried the old 3-routine self-chaining instruction — *"if a continuation trigger is wired, also open a `continue` issue"* — which is a **no-op** now (dispatch is fired by Hermes' VPS cron; nothing consumes `continue` issues since the night-executor was retired) and a mild risk (a literal routine could open orphan issues nobody services).

Replaced the silent conditional with a positive instruction: the handoff **is** sharpening `current-state ▶ Next action` (the next Hermes-cron dispatch reads it from live state); **do NOT open a `continue` issue**.

Docs only; `check_docs --strict` ✓. Self-merge on green.

https://claude.ai/code/session_01Q6s3aNZwGZzwCMoJrVnvUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6s3aNZwGZzwCMoJrVnvUa)_