### PR TITLE
docs(routines): de-stale trigger refs to the console Schedule (Q-0146)

### DIFF
--- a/.sessions/2026-06-15-docs-console-schedule-trigger.md
+++ b/.sessions/2026-06-15-docs-console-schedule-trigger.md
@@ -1,0 +1,47 @@
+# Session: De-stale the docs/prompts to the console-Schedule trigger
+
+> **Status:** `complete` — born-red card flipped (Q-0133).
+
+## Shipped
+
+De-staled every **active** trigger description to the console-Schedule reality (`0 */2 * * *`, every
+2h), recorded as **Q-0146**: the dispatch prompt intro + step 8 + Maintainer-setup (`hermes-dispatch-bridge.md`);
+the fleet table · Stage-1 note · merged-section trigger note · operating cost line · label table ·
+timing-caveat resolution (`autonomous-routines.md`); the current-state stamp-line; the Q-0145 trigger
+note (marked superseded) + new Q-0146. Left genuine historical records intact (the #865 `routine_fire.py`
+ledger entry, Q-0141, the A/B PAT test, and the "what it replaced" mentions). `check_docs --strict` ✓.
+
+## 💡 Session idea (Q-0089)
+
+The `check_routine_prompts.py` guard idea (logged earlier this session) would extend cleanly here:
+also assert the **trigger description** in the prompt/fleet-table matches a single declared source
+(the console cron), so a future trigger change can't leave a "Hermes cron"-style stale claim that an
+autonomous run reads about itself.
+
+## ⟲ Previous-run review (Q-0102)
+
+#900/#904 (the consolidation + trim) were right to flag the trigger as "owner-managed, not in this PR"
+rather than guess the final wiring — which is exactly why this clean-up was a quick, low-risk de-stale
+once the owner settled on the console Schedule. Lesson kept: when a control-plane decision is still in
+flux, document the *current* state and defer the wiring claim, rather than over-committing the doc to a
+mechanism that's about to change (Hermes-cron → console Schedule changed twice in one day).
+
+**Branch:** `claude/docs-console-schedule-trigger-2026-06-15` · **Date:** 2026-06-15 · **Type:** docs (S3) · **Trigger:** owner-directed in-session
+
+## What I'm about to do (intentions — born-red)
+
+Owner found a reliable way to set the console **Schedule** trigger and enabled it (`0 */2 * * *`,
+every 2h), retiring the Hermes-VPS-cron plan (Hermes proved unreliable for the cadence). Owner fixed
+the console prompts; my task = make the in-repo docs/prompt mirrors match. Record as **Q-0146**.
+
+Update the **active** trigger descriptions (the ones an autonomous run reads) from "Hermes VPS cron"
+→ "console Schedule (every 2h)":
+- `hermes-dispatch-bridge.md` dispatch prompt intro + step 8 + the maintainer-setup/runbook prose.
+- `autonomous-routines.md` fleet table · Stage-1 note · the merged-section trigger note · operating
+  section · the control-plane caveat (mark the GitHub-schedule-lag observation historical) · See-also
+  (mark `executor-nightly.yml` legacy).
+- `docs/current-state.md` Q-0145 stamp-line trigger note.
+- Router: update the Q-0145 trigger-consequence note + add **Q-0146**.
+
+Leave genuine historical records (the #865 routine_fire.py ledger entry, Q-0141, the A/B PAT test).
+Docs only; self-merge on green `check_docs`.

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -41,9 +41,9 @@
 > **dispatch** prompt (`hermes-dispatch-bridge.md`), which absorbed the executor's bug-book orient +
 > bounded-continuation handoff; the `autonomous-routines.md` night-executor section → a pointer; fleet
 > + label tables de-staled. **2 routine prompts now: dispatch (all execution) + docs reconciliation.**
-> Trigger consequence (owner-managed, not in this PR): dispatch is fired by **Hermes' VPS cron →
-> `routine_fire.py`** (reliable), replacing the GitHub `schedule:` cron (proven ~1 run/night, hours
-> late); the legacy `executor-nightly.yml` should be disabled/repointed. Docs only. ·
+> Trigger (Q-0146, 2026-06-15): dispatch's cadence is the Claude Code console **Schedule** trigger —
+> every **2h**, cron `0 */2 * * *`, owner-enabled — superseding the Hermes-VPS-cron / GitHub-`schedule:`
+> plan (both unreliable for cadence); the legacy `executor-nightly.yml` is superseded. Docs only. ·
 > 2026-06-15, **routine-prompt canon — foolproof, completion-biased, idea→plan
 > (PR #899, Q-0144)** — owner-directed in-session: rewrote the dispatch + night-executor routine
 > prompts onto the owner's 12-step lifecycle and made them foolproof against bad dispatch input (the

--- a/docs/operations/autonomous-routines.md
+++ b/docs/operations/autonomous-routines.md
@@ -25,7 +25,7 @@ session N leaves session N+1 better-equipped.
 
 | Routine | Trigger | Job | Class / merge |
 |---|---|---|---|
-| **superbot dispatch** — the single execution routine | API (`/fire`) — Hermes VPS cron · `/bugreport` · continuations | **ALL build work** (Q-0145): advance the next plan slice, fixes, dispatched features, bug reports. Work order is a *hint*; the plan is the authority. Classifies by `CLASS:`. (Merged the former **night executor** — they always did the same job; dispatch was just the more steerable one.) | small → self-merge (Q-0113); substantial step → Hermes reviews + merges (Q-0117); *self-invented* feature → phase gate (Q-0114) |
+| **superbot dispatch** — the single execution routine | **console Schedule** (every 2h, `0 */2 * * *`, Q-0146) + API (`/fire`) for on-demand (`/bugreport`, phone) | **ALL build work** (Q-0145): advance the next plan slice, fixes, dispatched features, bug reports. A scheduled fire has no work order → advance the next plan slice; a work order is a *hint*, the plan is the authority. Classifies by `CLASS:`. (Merged the former **night executor** — they always did the same job; dispatch was just the more steerable one.) | small → self-merge (Q-0113); substantial step → Hermes reviews + merges (Q-0117); *self-invented* feature → phase gate (Q-0114) |
 | **superbot docs reconciliation** | **Issue** labeled `reconcile` | The Q-0107 every-30th-PR docs-only pass: reconcile the ledger, de-stale docs, plan the next band, **promote an idea→plan when plans run low** (Q-0144), contribute one idea. | `docs` → self-merge on green |
 
 **Why an issue-trigger (not a schedule, not a per-PR trigger) for reconciliation:** the docs
@@ -65,7 +65,7 @@ routine fixes it. Neither routine invents features (the phase gate holds those u
 invent-phase, and these prompts never originate them).
 
 **Stage-1 note (workflow §10):** both routines are *unattended, self-merging* (reconciliation is
-issue-triggered; dispatch is fired by Hermes' VPS cron) — real Stage-1 autonomy, earned by the
+issue-triggered; dispatch is fired by the console Schedule every 2h) — real Stage-1 autonomy, earned by the
 Stage-0 calibration runs on 2026-06-12 (connectivity · held-for-review PR #747 · self-merge PR #751).
 Before trusting them, fire each once via **Run now** (the docs one: open a test `reconcile`
 issue) and watch. They can both touch `main`; the docs routine UNION-resolves as the reconciler.
@@ -169,13 +169,15 @@ is simply the more steerable one (it takes a work order); the fixed-prompt night
 it couldn't do. So there are now **2 routine prompts total**: **dispatch** (all execution work) +
 **docs reconciliation**.
 
-**Trigger note (owner-managed VPS/console wiring).** Dispatch is fired via the API (`/fire`); the
-reliable nightly cadence is driven by **Hermes' VPS cron** → `scripts/hermes/routine_fire.py`, which
-replaces the GitHub `schedule:` cron. (Proven: the GitHub `schedule:` trigger delivers only ~1
-run/night, hours late — see the timing caveat under Control-plane state.) The legacy
-`.github/workflows/executor-nightly.yml` opened `continue` issues to fire the now-retired
-night-executor; **it should be disabled or repointed to fire dispatch** — left for the owner, who
-manages the trigger wiring. A `continue`-labelled issue is still a valid human-filed handoff signal.
+**Trigger note (Q-0146).** Dispatch's cadence is the Claude Code console **Schedule** trigger —
+every **2 hours**, cron **`0 */2 * * *`** (UTC), owner-enabled 2026-06-15. A scheduled fire has no
+work order, so the routine advances the next plan slice from `current-state.md` ▶ Next action. The
+API (`/fire`) trigger stays for on-demand work-order fires. This replaced the earlier plan to drive
+the cadence from **Hermes' VPS cron** / the GitHub `schedule:` cron — both proved unreliable (the
+GitHub `schedule:` trigger delivered only ~1 run/night, hours late; see the timing caveat under
+Control-plane state). The legacy `.github/workflows/executor-nightly.yml` (it opened `continue`
+issues for the now-retired night-executor) is superseded and should be disabled. A `continue`-labelled
+issue is still a valid human-filed handoff signal a dispatch run reads on its next fire.
 
 ---
 
@@ -184,7 +186,7 @@ manages the trigger wiring. A `continue`-labelled issue is still a valid human-f
 | Label | Opened by | Fires | Effect |
 |---|---|---|---|
 | `reconcile` | the cadence Action (every 30-PR band) **or** any agent/maintainer who spots docs drift | docs reconciliation routine | the Q-0107 docs-only pass; routine closes the issue |
-| `continue` | the **dispatch** routine when it hands off a partly-done plan step (or a maintainer) | a human-filed handoff signal; dispatch (fired by Hermes' cron) resumes from live state + the issue body | resume the explicit handoff; chain again if still unfinished |
+| `continue` | a maintainer filing a handoff (the dispatch routine itself no longer opens them — it hands off via ▶ Next action) | dispatch (fired by the console Schedule) reads it on its next fire | resume the explicit handoff; chain again if still unfinished |
 | `needs-hermes-review` | the **dispatch** routine on a substantial plan-step PR | (a PR label, not an issue) — **Hermes** `superbot-review-merge` | Hermes reviews the diff and **merges if sound**, else requests changes (Q-0117) |
 
 This is the self-driving loop in three signals: reconcile keeps the docs honest, continue
@@ -215,8 +217,8 @@ The routine treats the issue as the go-signal, runs the docs-only pass, and clos
   automatic cadence, disable `.github/workflows/reconciliation-trigger.yml`.
 - **Watch runs:** each fire is a session in your list; a green run-status means it *started and
   exited cleanly*, not that the task succeeded — open the run to confirm.
-- **Cost:** routines draw subscription usage + a daily run cap. The issue-trigger (cadence
-  gated in the Action) + the Hermes-cron dispatch cadence keep volume low. The cap is also a runaway stop.
+- **Cost:** routines draw subscription usage + a daily run cap. The reconciliation issue-trigger
+  (cadence gated in the Action) + the every-2h dispatch Schedule keep volume bounded; the cap is also a runaway stop.
 - **Improve the prompts here, not only in the console** — edit this doc, then re-paste into the
   routine. This keeps the fleet's behavior reviewable in git.
 
@@ -250,9 +252,10 @@ The routine treats the issue as the go-signal, runs the docs-only pass, and clos
 > (`0 2 * * *` = 02:00 UTC) opened its failure issue at **06:15 UTC (06-13)** and **06:39 UTC
 > (06-14)** — both ~4 h late. The `:17`-minute offset reduces top-of-hour congestion but does **not**
 > eliminate the multi-hour variance. The timezone is correct (crons are always UTC, documented in
-> `executor-nightly.yml`); the lag is GitHub's scheduler. If on-time firing ever matters, drive the
-> cadence from an external scheduler that calls `workflow_dispatch` (or accept the loop is
-> "sometime overnight", not "at 03:17").
+> `executor-nightly.yml`); the lag is GitHub's scheduler. **Resolved 2026-06-15 (Q-0146):** the
+> dispatch cadence moved off GitHub cron entirely onto the Claude Code console **Schedule** trigger
+> (`0 */2 * * *`, every 2h), which fires reliably — this caveat now applies only to the remaining
+> GitHub-`schedule:` workflows (e.g. `backup-db.yml`) and the superseded `executor-nightly.yml`.
 
 ## See also
 

--- a/docs/operations/hermes-dispatch-bridge.md
+++ b/docs/operations/hermes-dispatch-bridge.md
@@ -36,11 +36,17 @@ idea / nightly diagnosis
 
 ## Maintainer setup (one-time)
 
-- ✅ **Create the routine** — DONE 2026-06-12: the routine **superbot autonomous dispatch**
-  is live in the Claude Code console (https://code.claude.com/docs/en/routines) with the API
-  trigger enabled. prompt = the saved prompt below · repo = `menno420/superbot` · environment
-  network policy scoped tight · branch-push setting left at the default **`claude/`-only** ·
-  API trigger enabled (you get a per-routine `/fire` URL + bearer token).
+- ✅ **Create the routine** — DONE 2026-06-12: the routine **superbot dispatch** is live in the
+  Claude Code console (https://code.claude.com/docs/en/routines). prompt = the saved prompt below ·
+  repo = `menno420/superbot` · environment network policy scoped tight · branch-push setting left at
+  the default **`claude/`-only**.
+  - **Schedule trigger (the cadence, Q-0146, 2026-06-15):** the console **Schedule** fires it every
+    **2 hours** — cron **`0 */2 * * *`** (UTC). A scheduled fire carries no work order, so the
+    routine advances the next plan slice from `current-state.md` ▶ Next action. This replaced the
+    earlier Hermes-VPS-cron / GitHub-`schedule:` plan (both proved unreliable for cadence); the
+    owner enabled it 2026-06-15 for the first autonomous day.
+  - **API trigger (on-demand):** also enabled — a per-routine `/fire` URL + bearer token for
+    work-order fires (a `/bugreport`, a phone request, a one-off).
 - ✅ **Store the secrets on the VPS** for the `hermes` user (never commit them). The
   `superbot-dispatch` skill sources `~/.hermes/routine.env`, so put them there (chmod 600):
   ```bash
@@ -70,8 +76,9 @@ Claude-Code side. The `text` payload Hermes sends (the work order) is appended t
 
 ```
 You are the SuperBot DISPATCH routine — the single execution routine that does ALL the project's
-build work (everything except the docs-reconciliation routine). You are fired with a work order
-(Hermes VPS cron / a Discord /bugreport / a continuation / a maintainer request), and you are one
+build work (everything except the docs-reconciliation routine). You are fired by the console
+Schedule (every ~2 hours, with no work order — your job is then to advance the next plan slice) OR
+with a work order (a Discord /bugreport · a continuation · a maintainer request), and you are one
 turn of SuperBot's self-improvement loop. Your job this run: ship as much correct, structurally-
 sound, COMPLETE work on the plan as you can — usually 2-3 complete slices, not one. Bias toward
 finishing real work, never toward stopping early. There is NO valid "stop / refuse" outcome except
@@ -136,7 +143,7 @@ dispatched work, or the next plan slice.
 8. HAND OFF + CLOSE THE LOOP (every run — this is a turn of SuperBot's self-improvement loop). When
    you stop (you neared ~700K, or finished a clean sub-step whose remaining work is clearly scoped —
    never mid-sub-step), SHARPEN current-state ▶ Next action with the explicit handoff (what's DONE,
-   what REMAINS, where you stopped, the files/tests) — that IS the continuation; the next Hermes-cron
+   what REMAINS, where you stopped, the files/tests) — that IS the continuation; the next scheduled
    dispatch reads it from live state. Do NOT open a `continue` issue (no routine consumes them now).
    End with a final handoff stating what you did + why, the next agent's continuation steps, and any
    remarks worth a later review ("CodeGraph was down", "Grimp unavailable", an arch warning you

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -5467,14 +5467,43 @@ and the bounded-continuation handoff. The routine fleet is now **2 prompts**: **
 execution) + **docs reconciliation**. The night-executor section in `autonomous-routines.md` is
 replaced with a pointer; the fleet/label tables and prose are de-staled (executor/caretaker → dispatch).
 
-**Trigger consequence (owner-managed, NOT changed in this PR).** Dispatch is fired via the API
-(`/fire`) — **Hermes' VPS cron → `scripts/hermes/routine_fire.py`** is now the reliable nightly
-cadence, replacing the GitHub `schedule:` cron (proven to deliver only ~1 run/night, hours late — run
-history 2026-06-13/14/15). The legacy `.github/workflows/executor-nightly.yml` opened `continue` issues
-to fire the now-retired night-executor; **it should be disabled or repointed to fire dispatch.** Left
-for the owner, who manages the VPS/console trigger wiring (this PR is docs-only).
+**Trigger consequence (superseded same day by Q-0146).** This PR assumed the cadence would be driven
+by **Hermes' VPS cron → `routine_fire.py`**, replacing the GitHub `schedule:` cron (proven to deliver
+only ~1 run/night, hours late — run history 2026-06-13/14/15). Hermes then proved unreliable for the
+cadence too, and the owner found a reliable way to set the **console Schedule** trigger — so the final
+trigger is the console Schedule (Q-0146), not Hermes. See Q-0146.
 
 **Home:** `docs/operations/hermes-dispatch-bridge.md` (the one execution prompt) ·
 `docs/operations/autonomous-routines.md` (fleet table → 2 routines; night-executor section → pointer).
 Owner re-pastes the merged dispatch prompt into the routine console; deletes the separate
 night-executor routine.
+
+---
+
+### Q-0146 — Dispatch cadence = the console Schedule trigger, every 2h (2026-06-15)
+
+> **DECISION 2026-06-15 (owner-directed in-session, applied directly).** Owner: *"hermes is proving
+> unreliable for this, and the reason we did the actions in the first place was because I couldn't
+> correctly set the schedule time, but now I found a way to make that work."* The original move to
+> Hermes-dispatch (Q-0136/Q-0145) existed only to work around the owner not being able to set the
+> Claude Code console **Schedule** trigger; once that was solved, the simpler path won.
+
+**Decision.** The **dispatch** routine's cadence is the Claude Code console **Schedule** trigger,
+firing every **2 hours** — cron **`0 */2 * * *`** (UTC), owner-enabled 2026-06-15 for the first
+autonomous day. A scheduled fire carries **no work order**, so the routine advances the next plan
+slice from `current-state.md` ▶ Next action (the dispatch prompt's "empty work order → take the next
+real plan slice" path handles this with no prompt change needed). The API (`/fire`) trigger stays for
+**on-demand** work-order fires (a `/bugreport`, a phone request). This **supersedes** the
+Hermes-VPS-cron / GitHub-`schedule:` cadence plan (both proved unreliable: GitHub `schedule:` delivered
+~1 run/night hours late; Hermes proved unreliable for cadence). The legacy
+`.github/workflows/executor-nightly.yml` is superseded and should be disabled.
+
+**Prompt review (owner asked, "I don't think it needs changes").** Correct — functionally none: the
+scheduled (no-work-order) fire routes through the existing empty-input path → advance the plan. Only
+two self-description references were stale ("Hermes cron" → console Schedule); de-staled in this Q's
+PR. Owner fixed the console-pasted prompts directly; this PR brings the in-repo mirrors + docs to match.
+
+**Home:** `docs/operations/hermes-dispatch-bridge.md` (prompt intro + step 8 + Maintainer setup) ·
+`docs/operations/autonomous-routines.md` (fleet table · Stage-1 note · trigger note · timing caveat) ·
+`docs/current-state.md` stamp-line. **Owner action:** disable `executor-nightly.yml` (the last legacy
+trigger).


### PR DESCRIPTION
## What

Owner-directed: the dispatch cadence moved to the Claude Code console **Schedule** trigger (`0 */2 * * *`, every 2h), superseding the Hermes-VPS-cron / GitHub-`schedule:` plan (both proved unreliable). The owner fixed the console-pasted prompts directly; this PR brings the **in-repo prompt mirrors + docs** to match. Recorded as **Q-0146**.

De-staled every **active** trigger description from "Hermes cron" → console Schedule:
- `hermes-dispatch-bridge.md` — dispatch prompt intro + step 8 + Maintainer-setup.
- `autonomous-routines.md` — fleet table · Stage-1 note · merged-section trigger note · cost line · `continue`-label row · the timing-caveat resolution.
- `docs/current-state.md` stamp-line; router **Q-0145** marked superseded + new **Q-0146**.

Left genuine **historical** records intact (the #865 `routine_fire.py` ledger entry, Q-0141, the A/B PAT test, and the "what it replaced" mentions).

Docs only; `check_docs --strict` ✓. Self-merge on green.

**Owner's last to-do:** disable `.github/workflows/executor-nightly.yml` (the last legacy trigger).

https://claude.ai/code/session_01Q6s3aNZwGZzwCMoJrVnvUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6s3aNZwGZzwCMoJrVnvUa)_