### PR TITLE
Hermes research: correct context-management root cause + fix SOUL sync bug

### DIFF
--- a/.sessions/2026-06-15-hermes-research-deepening.md
+++ b/.sessions/2026-06-15-hermes-research-deepening.md
@@ -1,16 +1,70 @@
 # Session — Hermes research deepening (context-management root cause, verified vs. source)
 
-> **Status:** `in-progress` — born-red per Q-0133. Owner asked for "more research" on why the
-> Hermes control-plane agent misbehaves (errors, forgotten tasks, misunderstood assignments,
-> not syncing to main); he supplied a ChatGPT deep-research report on the Nous Research Hermes
-> Agent. About to: verify that report against Hermes source/docs, map it onto SuperBot's actual
-> setup, correct the in-repo token-efficiency investigation, and fix one concrete SOUL.md bug.
+> **Status:** `complete`
 
-## What I'm about to do
-- Extend `docs/operations/hermes-token-efficiency-investigation-2026-06-15.md` with verified
-  findings: the real root cause is **compaction** (tool-output pruning at 50% + the 400-msg
-  gateway-hygiene valve, #12626), not unbounded growth; the exact `compression.*` config knobs;
-  cron's stateless+pre-run-`script` model as the bounded-dispatch implementation; SOUL.md
-  truncation risk; upstream issues to watch (#12626, #9763).
-- Fix the SOUL.md operating-prompt sync bug: `git fetch origin main` alone leaves a STALE working
-  tree, so Hermes reads old files even after "syncing" → the owner's "forgets to sync to main".
+## What I did
+
+Owner asked for "more research" on why the Hermes control-plane agent misbehaves (errors,
+forgotten tasks, misunderstood assignments, not syncing to main) and supplied a ChatGPT
+deep-research report on the Nous Research Hermes Agent. I confirmed Hermes IS that agent
+(`NousResearch/hermes-agent` — our SOUL.md/skills/gateway/cron match), then **verified the
+report's fix-critical claims against Hermes' own source/docs** (web) and mapped them onto
+SuperBot's actual setup.
+
+**Key correction:** both the report and our own `hermes-token-efficiency-investigation` doc
+mis-diagnosed the root cause as *unbounded history growth → overflow*. Hermes' source shows the
+gateway has **two-layer compaction** (agent compressor at 50%, gateway net at 85%, a 400-msg
+hard valve) that **summarizes middle turns and prunes tool outputs >200 chars to a stub**. The
+forgetting is that pruning of the early plan/folio read — not overflow. The 2.2M "cumulative
+tokens" is a *cost* metric, not the live window.
+
+## What shipped (PR #913, docs-only)
+
+- `docs/operations/hermes-token-efficiency-investigation-2026-06-15.md` — appended a verified
+  "## Findings" section: corrected compaction model + table of what KEEPS/SUMMARIZES/PRUNES; the
+  exact `compression.*` and `prompt_caching.cache_ttl` config knobs; answers to the doc's four
+  "investigate first" questions; cron (stateless `skip_memory=True` + `context_from` + pre-run
+  `script`) as the bounded-dispatch fix that already exists; a symptom→mechanism→fix table; the
+  SOUL.md truncation risk; upstream issues to watch (#12626, #9763); reversible VPS config to try.
+- `docs/operations/hermes-operating-prompt.md` — fixed the SOUL.md sync bug: `git fetch origin
+  main` alone leaves a STALE working tree (Hermes read old files even after "syncing" → the
+  owner's "forgets to sync to main"). Now `git pull --ff-only origin main`.
+- **Verified:** `python3.10 scripts/check_docs.py --strict` ✓ (orphan/staleness/links all pass).
+
+## Handoff / next
+
+- **Maintainer action (VPS):** re-run `bash scripts/hermes/install-soul.sh` to install the fixed
+  sync line; consider the reversible `~/.hermes/config.yaml` tweaks in the Findings section
+  (`compression.protect_last_n`↑, `prompt_caching.cache_ttl: "1h"`); verify the SOUL.md byte size
+  isn't being truncated.
+- **Not approved to build:** the deeper fix (bounded re-grounding for the gateway) stays a plan —
+  the investigation half is now done, the fix half awaits owner go-ahead.
+- BUG-0011 (gateway crash-loop) still OPEN — needs a clean foreground repro on the VPS.
+
+## 💡 Session idea (Q-0089)
+
+**A SOUL.md truncation guard in `install-soul.sh`.** Hermes silently truncates SOUL.md if it
+exceeds its budget (verified upstream) — an *invisible* cause of "Hermes forgets its rules/
+identity." The script already prints `$(wc -c)` bytes; add a warning when the rendered prompt
+exceeds a known/estimated truncation threshold, so a future operating-prompt edit can't silently
+get cut. Small, repo-side, kill-switchable. Dedup-checked `docs/ideas/` — none.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous: `2026-06-15-mining-home-slice-c.md` (PR #910). Strong run — shipped Slice C with
+byte-identical-when-unbuilt discipline, good test coverage, and documented the `cd`-wedge harness
+incident as a load-bearing system lesson. Little to fault.
+**System improvement surfaced this run:** repo-side fixes to *Hermes' own behavior* (the SOUL.md
+sync fix here, skill edits, operating-prompt changes) are **inert until manually re-installed on
+the VPS** (`install-soul.sh` / `install-skills.sh`), and nothing in-repo signals "the VPS Hermes
+is out of sync with the repo's Hermes docs." The control-plane state table tracks secrets/deploys
+but not install-freshness. Worth a row there (or a router DISCUSS): a tracked "SOUL/skills
+installed at repo SHA X" marker so an edit like this one doesn't quietly fail to take effect.
+
+## 📋 Doc audit (Q-0104)
+
+`check_docs --strict` green (both edited docs already reachable — investigation linked from
+`hermes-control-plane.md`, operating-prompt linked from several). No new owner decision to route
+(the config recommendations are reversible suggestions, not decisions). The active-work claim
+moves to Recently-cleared when #913 merges. No chat-only content left undocumented — the findings
+are in the investigation doc, the fix in the operating prompt. Ledger unaffected (docs-only).

--- a/.sessions/2026-06-15-hermes-research-deepening.md
+++ b/.sessions/2026-06-15-hermes-research-deepening.md
@@ -1,0 +1,16 @@
+# Session — Hermes research deepening (context-management root cause, verified vs. source)
+
+> **Status:** `in-progress` — born-red per Q-0133. Owner asked for "more research" on why the
+> Hermes control-plane agent misbehaves (errors, forgotten tasks, misunderstood assignments,
+> not syncing to main); he supplied a ChatGPT deep-research report on the Nous Research Hermes
+> Agent. About to: verify that report against Hermes source/docs, map it onto SuperBot's actual
+> setup, correct the in-repo token-efficiency investigation, and fix one concrete SOUL.md bug.
+
+## What I'm about to do
+- Extend `docs/operations/hermes-token-efficiency-investigation-2026-06-15.md` with verified
+  findings: the real root cause is **compaction** (tool-output pruning at 50% + the 400-msg
+  gateway-hygiene valve, #12626), not unbounded growth; the exact `compression.*` config knobs;
+  cron's stateless+pre-run-`script` model as the bounded-dispatch implementation; SOUL.md
+  truncation risk; upstream issues to watch (#12626, #9763).
+- Fix the SOUL.md operating-prompt sync bug: `git fetch origin main` alone leaves a STALE working
+  tree, so Hermes reads old files even after "syncing" → the owner's "forgets to sync to main".

--- a/docs/operations/hermes-operating-prompt.md
+++ b/docs/operations/hermes-operating-prompt.md
@@ -54,7 +54,11 @@ WHAT YOU MAY WRITE (Q-0140, Q-0141)
 
 THE REPO
 - /home/hermes/repos/superbot · default branch main · GitHub menno420/superbot.
-- Before any task: git -C /home/hermes/repos/superbot fetch origin main (read-only), then read.
+- Before any task SYNC the working tree, do not just fetch: a bare `git fetch` updates the
+  remote-tracking ref but leaves the checked-out files STALE, so you would read old code and act
+  on a stale current-state.md. Run: git -C /home/hermes/repos/superbot pull --ff-only origin main
+  (fast-forward only — safe and read-only-ish; it never creates a merge commit and fails loudly if
+  the tree diverged). THEN read.
 
 WORK IN BOUNDED STEPS — you lose the thread on long sessions, so design around it
 - ONE finite objective per session, with a clear done-condition. If a task balloons past ~15-20

--- a/docs/operations/hermes-token-efficiency-investigation-2026-06-15.md
+++ b/docs/operations/hermes-token-efficiency-investigation-2026-06-15.md
@@ -1,7 +1,9 @@
 # Hermes token-efficiency — investigation + fix plan (tomorrow's focus)
 
-> **Status:** `plan` — owner-prioritized for the next session (2026-06-15, captured fresh from the
-> live failure). Investigation-first: confirm the pipeline, then pick a fix. Not yet approved to build.
+> **Status:** `plan` — owner-prioritized (2026-06-15, captured fresh from the live failure).
+> **Investigation half is now DONE** — see "## Findings (verified against Hermes source/docs)" at the
+> bottom; the four "investigate first" questions are answered and the root cause is corrected
+> (it is **compaction**, not unbounded growth). The *fix* is still not approved to build.
 > Home: the Hermes control plane ([`hermes-control-plane.md`](hermes-control-plane.md)).
 
 ## The smoking gun (observed live 2026-06-14/15)
@@ -80,3 +82,107 @@ harness **summarizes/manages** the context window, and each session **re-orients
 resume (`git fetch` + read `current-state` / the plan / the folio). The fix for Hermes is to give it the
 *same* discipline: **bounded, re-grounding dispatches** instead of one ever-growing session. That is the
 deeper reason #1 above is the right primary lever.
+
+---
+
+## Findings (verified against Hermes source/docs, 2026-06-15)
+
+> Added after the owner asked for deeper research and supplied a ChatGPT deep-research report on the
+> Nous Research Hermes Agent. Hermes IS that agent (`github.com/NousResearch/hermes-agent` — confirmed
+> by our SOUL.md/skills/gateway/cron). Findings below are checked against Hermes' own source + dev docs,
+> **not** the report or marketing (the report itself warns Hermes docs drift from code).
+> **Trust note (Q-0105, unverified):** these are upstream-doc-derived — re-confirm a knob against the live
+> `~/.hermes/config.yaml` on the VPS before relying on it; delete this caveat once confirmed there.
+
+### The root cause was mis-diagnosed — it is COMPACTION, not unbounded growth
+
+The body above (and the report) assumed the gateway just re-sends an ever-growing history → O(N²) →
+overflow. Hermes' source says otherwise: the gateway has a **two-layer compaction system**, and the
+*forgetting* is what that compaction PRUNES — not window overflow.
+
+| Layer | Fires at | What it does |
+|---|---|---|
+| Agent `ContextCompressor` | **50%** of context (`compression.threshold: 0.50`) | summarizes the middle, prunes old tool outputs |
+| Gateway session hygiene | **85%** (fixed) + a **400-message** hard valve | safety net; the 400-msg valve fires on COUNT regardless of token pressure (bug #12626) |
+
+What compaction does (verified `compression` defaults):
+- **KEEPS:** the system prompt (SOUL.md); `protect_first_n: 3` (system + first exchange);
+  `protect_last_n: 20` (recent turns); `target_ratio: 0.20` tail budget.
+- **SUMMARIZES** the middle turns into Goal / Progress / Key Decisions / Relevant Files / Next Steps /
+  Critical Context.
+- **PRUNES** tool outputs >200 chars → `[Old tool output cleared to save context space]`.
+
+**So the mechanism behind "forgets / misunderstands":** Hermes reads the canonical plan or folio early
+(a large file = a >200-char tool output), makes a few more tool calls, crosses 50% — and that file read
+is **pruned to a stub**. It keeps a *summary* of "Relevant Files" but loses the actual contents, then
+falls back to pattern-matching the always-present SOUL.md. That is exactly the #888 failure (re-stated
+the plan from memory, wrong dir, owner-blocked slice).
+
+### Re-framing the 2.2M "cumulative tokens"
+
+It is **cumulative spend** (sum of input tokens across all turns), **not** the live working window (which
+IS bounded by the compaction above). So:
+- **Cost** (€30/mo Q-0082 cap): cumulative matters — a long gateway session is expensive.
+- **Correctness** (forgetting): cumulative is a red herring; the lever is *what survives compaction*,
+  not *how many tokens were billed*. Chasing "lower cumulative tokens" alone would not fix the forgetting.
+
+### Answers to the four "investigate first" questions
+
+1. **Where does per-turn context come from?** SOUL.md is slot #1, re-injected (and **truncated if too
+   large** — verify the operating prompt fits) every message, on top of the **compacted** history (not the
+   whole raw transcript).
+2. **Working cutoff vs. the counter.** Working window is bounded by the 50%/85%/400-msg compaction; the
+   2.2M is cumulative spend. The early repo-read falls out at the **first compaction crossing 50%**, not at
+   window overflow.
+3. **Session memory vs. working context.** Confirmed distinct: `.sessions/` logs + `state.db` + cron-output
+   files are durable disk memory; the working context is the compacted in-RAM transcript. Hermes does NOT
+   auto-reload disk memory mid-session — it must re-read on demand.
+4. **Can history be capped/summarized/flushed?** Yes, three ways: (a) the `compression.*` knobs above tune
+   summarize-vs-keep; (b) `prompt_caching.cache_ttl` (`5m` default → `1h` for long sessions); (c) the real
+   flush is **cron** — each cron run is a fresh stateless `AIAgent` (`skip_memory=True`, source comment
+   "Cron system prompts would corrupt user representations").
+
+### The bounded-dispatch fix already exists in Hermes — it's cron
+
+Candidate fix #1 above ("stateless, bounded dispatch") is not something to build — Hermes *ships* it as
+the cron subsystem:
+- **Fresh session per run**, no memory of prior runs → kills O(N²) growth AND forces re-grounding by
+  construction.
+- **`context_from=["job_a"]`** prepends a prior job's latest output — the state-passing seam between
+  bounded runs (the "collect → triage → ship" pipeline).
+- **Pre-run `script`** runs a shell command before the agent turn, stdout injected as context → the
+  **deterministic place to enforce `git fetch && git reset --hard origin/main`** so sync stops depending on
+  the LLM remembering (the "forgets to sync to main" fix). `no_agent=True` makes a script-only job.
+- Per-job **`model`/`provider`** override, **`skills=[]`**, **`deliver=`** routing.
+- **Caveat:** cron disables `clarify`/`messaging`/`cronjob` — a cron run CANNOT ask a follow-up, so its
+  prompt MUST be fully self-contained (the same discipline as a bounded Claude routine).
+
+Nuance for SuperBot: build *execution* already runs as bounded **Claude Code routines** (Q-0146 console
+Schedule) which re-orient from disk — those are fine. What still blows up is the **interactive Telegram
+gateway** Hermes (the control plane the owner talks to); its context collapse then propagates into *bad
+work orders* (wrong scope → bad dispatch). So the fix targets the gateway session, not the routines.
+
+### Symptom → mechanism → fix
+
+| Owner symptom | Mechanism (verified) | Fix | Side |
+|---|---|---|---|
+| "forgotten tasks" | compaction prunes early tool outputs at 50%; 400-msg silent valve (#12626) | re-ground at point of use; raise `protect_last_n`; short sessions; bounded cron / `/new` | VPS config + prompt |
+| "misunderstands assignments" | middle-turn summary loses work-order detail; SOUL.md truncated if oversized | verify SOUL.md size; self-contained work orders; bounded dispatch | VPS + prompt |
+| "forgets to sync to main" | SOUL.md did `git fetch` only → stale working tree; no deterministic sync | `git pull --ff-only` (this PR); pre-run `script` `reset --hard` for cron | prompt (done) + VPS |
+| "lots of errors" | BUG-0011 gateway crash-loop (Telegram 409); dispatch balks (Q-0136 sensitive-info; py3.10 #869) | BUG-0011 needs a clean foreground repro; the rest are fixed — re-install on VPS | VPS |
+
+### Upstream Hermes issues to watch (re-check during grooming)
+
+- **#12626** — gateway silently auto-compacts at 400 messages even when `/usage` shows low context
+  pressure. Directly explains some "forgotten tasks". Mitigate by short sessions; track for a fix.
+- **#9763** — cron's `skip_memory=True` also blocks external memory providers in cron context. Only
+  relevant if SuperBot ever wires a memory provider into a cron path.
+
+### Recommended config to try on the VPS (maintainer, reversible)
+
+In `~/.hermes/config.yaml` (re-confirm key names against the installed version first):
+- `compression.protect_last_n` ↑ (e.g. 20 → 30) so more recent turns survive a compaction.
+- `prompt_caching.cache_ttl: "1h"` for long control-plane sessions.
+- Verify the SOUL.md byte size — if the operating prompt is being truncated, trim it (it is
+  truncation-sensitive; don't bloat it).
+- Adopt a **`/new`-per-task** habit (the SOUL.md already preaches it) — the cheapest fix of all.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -30,6 +30,9 @@ living ledger (`docs/current-state.md`).
 - `claude/hopeful-allen-home-slice-c` · mining Slice C — Home structure (character-card backdrop) ·
   `disbot/{utils/mining/structures,services/mining_workflow,utils/character_render,views/mining,
   cogs/mining_cog,utils/mining/market}` + plan/numbers · 2026-06-15
+- `claude/brave-sagan-s9th8h` · Hermes research deepening — verify ChatGPT report vs. Hermes
+  source, correct the context-management root cause + fix SOUL sync bug · docs-only
+  (`hermes-token-efficiency-investigation` · `hermes-operating-prompt`) · 2026-06-15
 
 ## Recently cleared
 


### PR DESCRIPTION
Deepens the Hermes investigation the owner asked for (he supplied a ChatGPT deep-research report on the Nous Research Hermes Agent; verified against Hermes source/docs).

**Headline:** Hermes IS the Nous Research Hermes Agent (`NousResearch/hermes-agent`), so the report applies — but it (and SuperBot's own `hermes-token-efficiency-investigation` doc) **mis-diagnosed the root cause**. The gateway is NOT a naively-accumulating session. Hermes has real compaction (agent compressor at 50%, gateway net at 85%, a 400-message gateway-hygiene valve) that **summarizes middle turns and prunes tool outputs >200 chars to a stub**. That pruning of the early plan/folio read — not window overflow — is why Hermes "forgets" mid-task. The 2.2M "cumulative tokens" figure is a *cost* metric, not the live window.

Docs-only:
- **`docs/operations/hermes-token-efficiency-investigation-2026-06-15.md`** — verified findings: the corrected compaction model, the exact `compression.*` / `prompt_caching.cache_ttl` config knobs, cron's stateless + pre-run-`script` model as the bounded-dispatch implementation, the SOUL.md truncation risk, the symptom→mechanism→fix table, and upstream issues to watch (#12626 silent 400-msg compaction, #9763 cron memory).
- **`docs/operations/hermes-operating-prompt.md`** — fix the SOUL.md sync bug: `git fetch origin main` alone leaves a STALE working tree, so Hermes reads old files even after "syncing" (the owner's "forgets to sync to main"). Changed to `git pull --ff-only origin main`. **Maintainer action: re-run `install-soul.sh` on the VPS to pick this up.**

https://claude.ai/code/session_01FwmaNQr47seoRng82Mj39E

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwmaNQr47seoRng82Mj39E)_