### PR TITLE
Hermes: script to apply context fixes on the VPS + SOUL size guard

### DIFF
--- a/.sessions/2026-06-15-hermes-soul-guard.md
+++ b/.sessions/2026-06-15-hermes-soul-guard.md
@@ -1,22 +1,64 @@
-# Session — Hermes follow-up: SOUL size guard + sharpen the context diagnosis
+# Session — Hermes follow-up: VPS context-fix script + SOUL size guard
 
-> **Status:** `in-progress` — born-red per Q-0133. Continuation after #913 merged. The owner
-> added a key data point: even ~5-message, clearly-directed sessions still fail. That sharpens
-> (not contradicts) the diagnosis — it points at per-turn **doc volume**, not message count.
+> **Status:** `complete`
 
-## What I'm about to do
-- **`scripts/hermes/apply_context_fixes.sh` (NEW — the owner asked for a script, not steps).** A
-  safe, idempotent, reversible VPS operator script: backs up `config.yaml`, raises
-  `compression.threshold` 0.50→0.75 and `compression.protect_last_n` 20→30 via the validated
-  `hermes config set` CLI, attempts `prompt_caching.cache_ttl 1h`, re-installs the sync-fixed
-  SOUL.md, runs `hermes config check`, reminds to restart the gateway. `--dry-run` works with no
-  Hermes installed (testable here). Provenance + kill-switch header (Q-0105). NOTE: the
-  `hermes config set` calls can't be exercised on this container (no Hermes) — only dry-run is.
-- `scripts/hermes/install-soul.sh` — add a SOUL.md size guard (the #913 Q-0089 idea). Operating
-  prompt is 6478 bytes — ~81% of Hermes' likely ~8KB ceiling. Warn >budget, info >80%, override
-  via `HERMES_SOUL_BUDGET`.
-- `docs/operations/hermes-token-efficiency-investigation-2026-06-15.md` — add the owner's
-  5-message data point: a single large whole-file doc read can cross the 50% compaction line in
-  ONE turn, so compaction then prunes the doc Hermes just read. New levers: raise
-  `compression.threshold`, use a larger-context model, read doc SECTIONS (grep) not whole files;
-  point at the new script.
+## What I did
+
+Continuation after #913 merged. The owner asked for **a script that applies the fixes** (not
+manual steps) and added a key data point: even ~5-message, clearly-directed sessions still fail.
+That sharpened the diagnosis — it's per-turn **doc volume**, not message count: one large
+whole-file read can cross the 50% compaction line in a single turn, and compaction then prunes the
+doc Hermes just read. Confirmed the `hermes config set` CLI (dot-notation, validated) via the
+upstream config docs so the script edits config safely instead of doing raw YAML surgery.
+
+## What shipped (PR #914)
+
+- **`scripts/hermes/apply_context_fixes.sh` (NEW)** — idempotent, reversible VPS operator script:
+  backs up `config.yaml`, sets `compression.threshold` 0.50→0.75 + `compression.protect_last_n`
+  20→30 + attempts `prompt_caching.cache_ttl 1h` via `hermes config set`, re-installs the
+  sync-fixed SOUL.md, runs `hermes config check`, reminds to restart the gateway. `--dry-run` and
+  `--set-model=` flags. Provenance + kill-switch header (Q-0105).
+- `scripts/hermes/install-soul.sh` — SOUL.md size guard: warns >budget, infos >80%, override via
+  `HERMES_SOUL_BUDGET` (default 8000). Confirmed it fires the >80% line for the current 6478-byte
+  prompt.
+- `docs/operations/hermes-token-efficiency-investigation-2026-06-15.md` — the owner's 5-message
+  data point + sharpened levers (raise `compression.threshold`, larger-window model, read doc
+  SECTIONS not whole files) + a pointer to the new script.
+- **Verified:** `apply_context_fixes.sh --dry-run` is side-effect-free and prints the plan; the
+  size guard fires; `check_docs --strict` ✓. **Caveat:** the `hermes config set` calls can't be
+  exercised here (no Hermes on this container) — only `--dry-run` was tested.
+
+## Handoff / next
+
+- **Maintainer action (VPS):** `bash scripts/hermes/apply_context_fixes.sh` (try `--dry-run`
+  first), then `sudo systemctl restart hermes-gateway`. Consider a larger-context-window model.
+- The deeper bounded-re-grounding gateway fix stays a documented plan (not approved to build).
+- BUG-0011 (gateway crash-loop) still OPEN.
+
+## 💡 Session idea (Q-0089)
+
+**A Hermes "context self-check" skill/command.** A read-only skill Hermes runs at session start
+that reports its own context health: current model + window, `compression.threshold`, SOUL.md
+bytes vs budget, and "≈N% headroom before compaction at this fill." Compaction is *invisible*
+today (the root cause of the owner's frustration — Hermes silently forgot and never said so);
+making the budget legible lets Hermes (and the owner) SEE when a turn is about to lose its
+grounding and proactively `/new`. Dedup-checked `docs/ideas/` + `hermes-skills/` — none cover
+Hermes introspecting its own context budget. Small: one skill reading `hermes config` + `wc -c`.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous: `2026-06-15-hermes-research-deepening.md` (#913). It nailed the root cause (compaction,
+not overflow), verified against Hermes source rather than the report, and fixed the sync bug —
+strong. **What it could have done better:** it stopped at *documenting* the VPS config knobs; the
+owner's very next message was "just give me a script." **System improvement:** when a session's
+deliverable is "VPS/external config the owner must change," default to also shipping the operator
+**script** that applies it — for a non-coding owner a steps-list is a half-deliverable, a script is
+the deliverable (the working agreement's "build the path to the goal, don't just describe it"). I
+applied that this session; worth making it a standing reflex for control-plane work.
+
+## 📋 Doc audit (Q-0104)
+
+`check_docs --strict` green. The new script is referenced from the investigation doc (discoverable);
+its own header is self-documenting. No new owner decision to route (the config values are reversible
+suggestions, not decisions). No chat-only content left undocumented — the script + the sharpened
+diagnosis are both in the repo. Ledger unaffected until #914 merges; active-work claim updated.

--- a/.sessions/2026-06-15-hermes-soul-guard.md
+++ b/.sessions/2026-06-15-hermes-soul-guard.md
@@ -1,0 +1,22 @@
+# Session — Hermes follow-up: SOUL size guard + sharpen the context diagnosis
+
+> **Status:** `in-progress` — born-red per Q-0133. Continuation after #913 merged. The owner
+> added a key data point: even ~5-message, clearly-directed sessions still fail. That sharpens
+> (not contradicts) the diagnosis — it points at per-turn **doc volume**, not message count.
+
+## What I'm about to do
+- **`scripts/hermes/apply_context_fixes.sh` (NEW — the owner asked for a script, not steps).** A
+  safe, idempotent, reversible VPS operator script: backs up `config.yaml`, raises
+  `compression.threshold` 0.50→0.75 and `compression.protect_last_n` 20→30 via the validated
+  `hermes config set` CLI, attempts `prompt_caching.cache_ttl 1h`, re-installs the sync-fixed
+  SOUL.md, runs `hermes config check`, reminds to restart the gateway. `--dry-run` works with no
+  Hermes installed (testable here). Provenance + kill-switch header (Q-0105). NOTE: the
+  `hermes config set` calls can't be exercised on this container (no Hermes) — only dry-run is.
+- `scripts/hermes/install-soul.sh` — add a SOUL.md size guard (the #913 Q-0089 idea). Operating
+  prompt is 6478 bytes — ~81% of Hermes' likely ~8KB ceiling. Warn >budget, info >80%, override
+  via `HERMES_SOUL_BUDGET`.
+- `docs/operations/hermes-token-efficiency-investigation-2026-06-15.md` — add the owner's
+  5-message data point: a single large whole-file doc read can cross the 50% compaction line in
+  ONE turn, so compaction then prunes the doc Hermes just read. New levers: raise
+  `compression.threshold`, use a larger-context model, read doc SECTIONS (grep) not whole files;
+  point at the new script.

--- a/docs/operations/hermes-token-efficiency-investigation-2026-06-15.md
+++ b/docs/operations/hermes-token-efficiency-investigation-2026-06-15.md
@@ -178,11 +178,33 @@ work orders* (wrong scope → bad dispatch). So the fix targets the gateway sess
 - **#9763** — cron's `skip_memory=True` also blocks external memory providers in cron context. Only
   relevant if SuperBot ever wires a memory provider into a cron path.
 
+### Owner data point (2026-06-15): even ~5-message sessions fail → it's per-turn doc VOLUME
+
+The owner confirmed the failures happen in sessions of **~5 messages at most, with clear directed
+orders that name the skill**. That *sharpens* the diagnosis rather than contradicting it: the
+400-message valve is irrelevant at that length, so the culprit is **how much a single turn reads**.
+SuperBot's docs are large; one whole-file read (CLAUDE.md ≈30 KB, current-state, a plan, a folio,
+the binding contracts) can cross the **50% compaction line in ONE or TWO tool calls** — and the
+compaction then prunes the very doc Hermes just read. So "it can't handle our docs" (owner's words)
+is exactly right: the read that should have grounded the turn is the read that gets pruned. The
+levers below target that, not message count.
+
 ### Recommended config to try on the VPS (maintainer, reversible)
 
-In `~/.hermes/config.yaml` (re-confirm key names against the installed version first):
+**Easiest: run `scripts/hermes/apply_context_fixes.sh`** on the VPS (`--dry-run` to preview) — it
+applies the items below via the validated `hermes config set` CLI, backs up `config.yaml` first,
+and re-installs the sync-fixed SOUL.md. Then `sudo systemctl restart hermes-gateway`. Manually, in
+`~/.hermes/config.yaml` (re-confirm key names against the installed version first):
+- **`compression.threshold` ↑ (0.50 → ~0.75)** — the highest-impact knob for the owner's pattern:
+  compaction fires LATER, so a big doc read survives the turns that use it.
 - `compression.protect_last_n` ↑ (e.g. 20 → 30) so more recent turns survive a compaction.
 - `prompt_caching.cache_ttl: "1h"` for long control-plane sessions.
-- Verify the SOUL.md byte size — if the operating prompt is being truncated, trim it (it is
-  truncation-sensitive; don't bloat it).
+- **Use a larger-context-window model** — 50% of a 1M window is far more room than 50% of 256K, so
+  the doc read falls out much later (`hermes config set model <provider/model>`; cost is the owner's
+  call — weigh against the €30/mo Q-0082 cap).
+- **Read doc SECTIONS, not whole files** — grep / targeted reads keep a single turn small; a skill
+  that says "read all of current-state.md" is more likely to trip compaction than one that greps the
+  ▶ Next action. (Prompt/skill discipline, not a config knob.)
+- Verify the SOUL.md byte size (now guarded in `install-soul.sh`) — at 6478 bytes it is ~81% of the
+  likely ~8 KB ceiling, so don't grow the operating prompt without trimming.
 - Adopt a **`/new`-per-task** habit (the SOUL.md already preaches it) — the cheapest fix of all.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -30,9 +30,9 @@ living ledger (`docs/current-state.md`).
 - `claude/hopeful-allen-home-slice-c` · mining Slice C — Home structure (character-card backdrop) ·
   `disbot/{utils/mining/structures,services/mining_workflow,utils/character_render,views/mining,
   cogs/mining_cog,utils/mining/market}` + plan/numbers · 2026-06-15
-- `claude/brave-sagan-s9th8h` · Hermes research deepening — verify ChatGPT report vs. Hermes
-  source, correct the context-management root cause + fix SOUL sync bug · docs-only
-  (`hermes-token-efficiency-investigation` · `hermes-operating-prompt`) · 2026-06-15
+- `claude/brave-sagan-s9th8h` · Hermes context work — #913 (research + SOUL sync fix) MERGED;
+  follow-up in progress: SOUL size guard + sharpen context diagnosis (owner 5-msg data point) ·
+  `scripts/hermes/install-soul.sh` + investigation doc · 2026-06-15
 
 ## Recently cleared
 

--- a/scripts/hermes/apply_context_fixes.sh
+++ b/scripts/hermes/apply_context_fixes.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Apply the recommended Hermes context-management fixes on the control-plane VPS.
+#
+# WHY: Hermes "forgets / misunderstands / loses the thread" because its gateway
+# COMPACTS context at 50% of the model window — it summarizes the middle of the
+# conversation and DELETES tool outputs larger than ~200 chars. SuperBot's docs are
+# large, so even a short, clearly-directed session can cross 50% on the FIRST doc
+# read — and Hermes then prunes the very doc it just read. Full diagnosis:
+#   docs/operations/hermes-token-efficiency-investigation-2026-06-15.md
+#
+# WHAT THIS DOES (all reversible, via Hermes' own validated `hermes config set` CLI):
+#   - backs up ~/.hermes/config.yaml (timestamped) before any change
+#   - compression.threshold      0.50 -> 0.75   (compact LATER, so a doc survives more turns)
+#   - compression.protect_last_n 20   -> 30     (keep more recent turns uncompressed)
+#   - prompt_caching.cache_ttl   -> 1h          (attempted; key name varies by version)
+#   - re-installs the sync-fixed SOUL.md (install-soul.sh) and reports its size vs budget
+#   - runs `hermes config check` and reminds you to restart the gateway
+#
+# USAGE (on the VPS, as the `hermes` user, from the repo root):
+#   bash scripts/hermes/apply_context_fixes.sh             # apply (backs up first)
+#   bash scripts/hermes/apply_context_fixes.sh --dry-run   # show what it would do; change nothing
+#   bash scripts/hermes/apply_context_fixes.sh --set-model=anthropic/claude-opus-4   # also switch model
+#
+# Provenance: added 2026-06-15 from the Hermes token-efficiency investigation.
+# UNVERIFIED: the `hermes config set` calls cannot be exercised in CI (no Hermes there) — only
+# --dry-run is. Re-confirm key names with `hermes config` / `hermes config check` on your version.
+# Kill-switch (Q-0105): disposable operator convenience — delete this if the knobs change upstream
+# or it proves unreliable across sessions.
+set -uo pipefail
+
+DRY_RUN=0
+SET_MODEL=""
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    --set-model=*) SET_MODEL="${arg#*=}" ;;
+    -h | --help)
+      sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HERMES_BIN="$(command -v hermes || echo "$HOME/.local/bin/hermes")"
+CONFIG="${HERMES_HOME:-$HOME/.hermes}/config.yaml"
+
+say() { printf '%s\n' "$*"; }
+rule() { printf -- '------------------------------------------------------------\n'; }
+
+# The reversible compression knobs (see the investigation doc's "Recommended config").
+KEYS=("compression.threshold" "compression.protect_last_n" "prompt_caching.cache_ttl")
+VALS=("0.75" "30" "1h")
+
+rule
+say "Hermes context-management fixes"
+rule
+say "hermes CLI : $HERMES_BIN"
+say "config     : $CONFIG"
+say "mode       : $([[ $DRY_RUN -eq 1 ]] && echo DRY-RUN || echo APPLY)"
+rule
+
+if [[ $DRY_RUN -eq 0 && ! -x "$HERMES_BIN" ]]; then
+  say "✗ hermes CLI not found/executable at: $HERMES_BIN"
+  say "  Run this on the VPS as the 'hermes' user (or --dry-run to preview anywhere)."
+  exit 1
+fi
+
+# 1) Back up config.yaml (apply mode only).
+if [[ $DRY_RUN -eq 0 && -f "$CONFIG" ]]; then
+  cp "$CONFIG" "$CONFIG.bak.$(date +%Y%m%d_%H%M%S)"
+  say "✓ backed up $CONFIG"
+  rule
+fi
+
+# 2) Apply the knobs through the validated CLI (each set is non-fatal on its own).
+set_key() {
+  local key="$1" val="$2"
+  if [[ $DRY_RUN -eq 1 ]]; then
+    say "would run: hermes config set $key $val"
+  elif "$HERMES_BIN" config set "$key" "$val"; then
+    say "✓ set $key = $val"
+  else
+    say "⚠ could not set $key — the key name may differ on your version; check 'hermes config'."
+  fi
+}
+for i in "${!KEYS[@]}"; do set_key "${KEYS[$i]}" "${VALS[$i]}"; done
+# Optional model switch — opt-in only; model choice is cost-sensitive, so left to you.
+[[ -n "$SET_MODEL" ]] && set_key "model" "$SET_MODEL"
+rule
+
+# 3) Re-install the sync-fixed SOUL.md (+ its size guard reports headroom).
+say "re-installing SOUL.md (carries the git-sync fix)…"
+if [[ $DRY_RUN -eq 1 ]]; then
+  say "would run: bash $SCRIPT_DIR/install-soul.sh"
+  bash "$SCRIPT_DIR/install-soul.sh" --dry-run >/dev/null 2>&1 &&
+    say "  (dry-run: install-soul.sh extraction OK)"
+else
+  bash "$SCRIPT_DIR/install-soul.sh"
+fi
+rule
+
+# 4) Verify + next steps.
+if [[ $DRY_RUN -eq 0 ]]; then
+  say "verifying (hermes config check):"
+  "$HERMES_BIN" config check 2>/dev/null | sed 's/^/    /' || say "    (check unavailable)"
+  rule
+  say "current settings — see 'hermes config' for the live model + values."
+fi
+say "tip: a LARGER context-window model pushes the 50% compaction line further out."
+say "     switch with:  $0 --set-model=<provider/model>   (cost is your call)"
+rule
+say "NEXT — restart the gateway to load the changes:"
+say "     sudo systemctl restart hermes-gateway"
+rule

--- a/scripts/hermes/install-soul.sh
+++ b/scripts/hermes/install-soul.sh
@@ -52,6 +52,21 @@ sys.stdout.write(block + "\n")
 PYEOF
 )"
 
+# SOUL.md size guard. Hermes loads SOUL.md as system-prompt slot #1 and SILENTLY TRUNCATES it
+# if it is too large — an invisible cause of "Hermes forgets its own rules". The exact ceiling is
+# not published upstream; HERMES_SOUL_BUDGET defaults to 8000 (aligned with Hermes' documented
+# 8000-char per-context-file cap) — confirm against your installed version. Provenance: the Hermes
+# token-efficiency investigation, 2026-06-15. DELETE this guard if it proves noisy/wrong over time.
+SOUL_BUDGET="${HERMES_SOUL_BUDGET:-8000}"
+PROMPT_BYTES="$(printf '%s\n' "$PROMPT" | wc -c | tr -d ' ')"
+if [[ "$PROMPT_BYTES" -gt "$SOUL_BUDGET" ]]; then
+  echo "⚠ operating prompt is $PROMPT_BYTES bytes — OVER the ~$SOUL_BUDGET-byte budget." >&2
+  echo "  Hermes truncates an oversized SOUL.md SILENTLY (it loses rules past the cut)." >&2
+  echo "  Trim docs/operations/hermes-operating-prompt.md, or raise HERMES_SOUL_BUDGET if your version allows." >&2
+elif [[ "$PROMPT_BYTES" -gt $((SOUL_BUDGET * 8 / 10)) ]]; then
+  echo "ℹ operating prompt is $PROMPT_BYTES of ~$SOUL_BUDGET bytes (>80%) — little headroom before truncation." >&2
+fi
+
 if [[ "$DRY_RUN" -eq 1 ]]; then
   echo "# would write to: $DEST"
   echo "---"


### PR DESCRIPTION
Follow-up to #913. The owner asked for **a script that applies the Hermes context fixes**, not manual steps — and added a key data point: even ~5-message, clearly-directed sessions still fail. That sharpens the diagnosis (it's per-turn **doc volume**, not message count) rather than contradicting it.

- **`scripts/hermes/apply_context_fixes.sh` (NEW)** — safe, idempotent, reversible VPS operator script. Backs up `config.yaml`, then via the validated `hermes config set` CLI raises `compression.threshold` 0.50→0.75 and `compression.protect_last_n` 20→30 (compact LATER so a doc read survives more turns), attempts `prompt_caching.cache_ttl 1h`, re-installs the sync-fixed SOUL.md, runs `hermes config check`, and reminds to restart the gateway. `--dry-run` works with no Hermes installed. Provenance + kill-switch header (Q-0105). ⚠️ The `hermes config set` calls can't be exercised from CI (no Hermes here) — only `--dry-run` is.
- **`scripts/hermes/install-soul.sh`** — SOUL.md size guard (the #913 Q-0089 idea): the operating prompt is 6478 bytes, ~81% of Hermes' likely ~8KB ceiling, so it warns before a silent truncation. Override via `HERMES_SOUL_BUDGET`.
- **`hermes-token-efficiency-investigation-2026-06-15.md`** — the owner's 5-message data point + the sharpened levers (raise `compression.threshold`, larger-context model, read doc SECTIONS not whole files), and a pointer to the new script.

**Maintainer action:** on the VPS, `bash scripts/hermes/apply_context_fixes.sh` then `sudo systemctl restart hermes-gateway`.

https://claude.ai/code/session_01FwmaNQr47seoRng82Mj39E

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwmaNQr47seoRng82Mj39E)_