### PR TITLE
Hermes: self-healing repo sync (recover from a diverged mirror clone)

### DIFF
--- a/.sessions/2026-06-15-hermes-sync-hardening.md
+++ b/.sessions/2026-06-15-hermes-sync-hardening.md
@@ -1,0 +1,16 @@
+# Session — Hermes sync hardening (self-healing mirror sync + divergence recovery)
+
+> **Status:** `in-progress` — born-red per Q-0133. Live follow-up: the owner's VPS clone had
+> DIVERGED from origin/main, so `git pull --ff-only` aborted and the new script wasn't even
+> downloaded. Recovery (backup branch + `reset --hard origin/main`) unblocked it and the
+> apply-script then landed all three `hermes config set` calls. This hardens the sync so a
+> diverged clone can never get stuck again.
+
+## What I'm about to do
+- `docs/operations/hermes-operating-prompt.md` — replace the fragile `git pull --ff-only origin
+  main` sync line with the self-healing form `git fetch origin main && git checkout -B main
+  origin/main` (always lands on fresh main, can't abort on divergence — the pattern the dispatch
+  routine already uses). State the clone is a read-only MIRROR; never commit to it. Keep it
+  concise — SOUL.md is at ~81% of its byte budget.
+- `docs/operations/hermes-terminal-cheatsheet.md` — make the deploy-section pull robust + add a
+  "clone diverged → recovery" snippet (backup branch + reset --hard).

--- a/.sessions/2026-06-15-hermes-sync-hardening.md
+++ b/.sessions/2026-06-15-hermes-sync-hardening.md
@@ -1,16 +1,62 @@
 # Session — Hermes sync hardening (self-healing mirror sync + divergence recovery)
 
-> **Status:** `in-progress` — born-red per Q-0133. Live follow-up: the owner's VPS clone had
-> DIVERGED from origin/main, so `git pull --ff-only` aborted and the new script wasn't even
-> downloaded. Recovery (backup branch + `reset --hard origin/main`) unblocked it and the
-> apply-script then landed all three `hermes config set` calls. This hardens the sync so a
-> diverged clone can never get stuck again.
+> **Status:** `complete`
 
-## What I'm about to do
-- `docs/operations/hermes-operating-prompt.md` — replace the fragile `git pull --ff-only origin
-  main` sync line with the self-healing form `git fetch origin main && git checkout -B main
-  origin/main` (always lands on fresh main, can't abort on divergence — the pattern the dispatch
-  routine already uses). State the clone is a read-only MIRROR; never commit to it. Keep it
-  concise — SOUL.md is at ~81% of its byte budget.
-- `docs/operations/hermes-terminal-cheatsheet.md` — make the deploy-section pull robust + add a
+## What I did
+
+Live follow-up to #913/#914. Applying the fixes on the VPS surfaced a real bug: the clone had
+**diverged** from `origin/main`, so `git pull --ff-only` aborted (`Not possible to fast-forward`)
+— which also meant the new `apply_context_fixes.sh` was never downloaded ("No such file"). I gave
+the owner a recovery (backup branch + `git reset --hard origin/main`); the apply-script then ran
+and landed **all three** `hermes config set` calls cleanly (threshold 0.75, protect_last_n 30,
+cache_ttl 1h — incl. the one I was unsure the version would accept). This PR hardens the sync so a
+diverged clone can't get stuck again.
+
+## What shipped (PR #915)
+
+- `docs/operations/hermes-operating-prompt.md` — replaced the fragile `git pull --ff-only origin
+  main` with the self-healing `git fetch origin main && git checkout -B main origin/main` (always
+  lands on fresh main, never aborts on divergence — the dispatch routine's proven pattern). States
+  the clone is a read-only mirror; never commit to it. SOUL.md grew only 6478→6560 bytes (still
+  <8000 budget; the size guard still infos at >80%).
+- `docs/operations/hermes-terminal-cheatsheet.md` — made the deploy-section sync robust + added a
   "clone diverged → recovery" snippet (backup branch + reset --hard).
+- **Verified:** `check_docs --strict` ✓; SOUL size re-measured (6560 bytes, under budget).
+
+## Handoff / next
+
+- The fixes are LIVE on the VPS (config applied, SOUL installed). The owner picks up the
+  self-healing sync next time they run `install-soul.sh` / `apply_context_fixes.sh` — no urgent
+  re-run (the current `--ff-only` SOUL works now that the clone is a clean mirror).
+- **Biggest remaining lever:** Hermes' model context window (256K → a 1M-context variant would
+  4× the headroom before the 50% compaction line). The owner should check `hermes config` for the
+  model; switching is `apply_context_fixes.sh --set-model=<provider/model>` (cost is their call).
+- The real test now: a previously-failing ~5-message doc-reading session should hold the thread.
+
+## 💡 Session idea (Q-0089)
+
+**Trim the Hermes operating prompt to leave real headroom.** It's now at 6560/8000 bytes (82%) and
+I've bumped it twice this chain — every future rule fights the truncation ceiling. The fix isn't a
+bigger budget, it's a leaner SOUL: move *procedural* detail (the skills list, verify-don't-assume
+command menu) into the **skills** (which load separately, not in slot #1) and keep SOUL.md to
+identity + the 5-6 load-bearing rules. Pairs with the #914 size guard (detect) — this is the
+reduce. Dedup-grepped `docs/ideas/` — the only hit is the dispatch-bridge idea (unrelated).
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous: `2026-06-15-hermes-soul-guard.md` (#914). Its "ship a script, not steps" lesson was
+**immediately validated** — the owner ran the script and it worked, landing all three config sets
+including the uncertain `cache_ttl`. Strong call. **What it missed:** it assumed the clone would
+`git pull --ff-only` cleanly to even *get* the script — it didn't (diverged), so delivery failed on
+the first attempt. **System improvement (this session):** a VPS operator script's FIRST dependency
+is "can the clone update at all?" — so the sync instruction must be self-healing, not abort-prone
+(now fixed). Lesson for control-plane work: harden the *delivery path* (git sync) before relying on
+the *payload* (the script).
+
+## 📋 Doc audit (Q-0104)
+
+`check_docs --strict` green; both edited docs reachable. SOUL.md re-measured at 6560 bytes (still
+under the 8000 budget — the operating-prompt change didn't push it over). No new owner decision to
+route (a robustness fix to instructions, not a decision). active-work claim updated; it moves to
+Recently-cleared when #915 merges. No chat-only content left undocumented — the recovery is now in
+the cheatsheet, the self-healing sync in the operating prompt.

--- a/docs/operations/hermes-operating-prompt.md
+++ b/docs/operations/hermes-operating-prompt.md
@@ -53,12 +53,13 @@ WHAT YOU MAY WRITE (Q-0140, Q-0141)
 - Merge a PR you have independently reviewed (the review-merge gate, Q-0117) — once calibrated.
 
 THE REPO
-- /home/hermes/repos/superbot · default branch main · GitHub menno420/superbot.
-- Before any task SYNC the working tree, do not just fetch: a bare `git fetch` updates the
-  remote-tracking ref but leaves the checked-out files STALE, so you would read old code and act
-  on a stale current-state.md. Run: git -C /home/hermes/repos/superbot pull --ff-only origin main
-  (fast-forward only — safe and read-only-ish; it never creates a merge commit and fails loudly if
-  the tree diverged). THEN read.
+- /home/hermes/repos/superbot · default branch main · GitHub menno420/superbot. The clone is a
+  read-only MIRROR of main — never commit to it; do your own writing on a `claude/` branch you push.
+- SYNC before any task (a bare `git fetch` leaves the files STALE → you read old code + a stale
+  current-state.md). Use the self-healing form — it always lands on fresh main and, unlike
+  `pull --ff-only`, never aborts if the clone diverged:
+    git -C /home/hermes/repos/superbot fetch origin main && git -C /home/hermes/repos/superbot checkout -B main origin/main
+  THEN read.
 
 WORK IN BOUNDED STEPS — you lose the thread on long sessions, so design around it
 - ONE finite objective per session, with a clear done-condition. If a task balloons past ~15-20

--- a/docs/operations/hermes-terminal-cheatsheet.md
+++ b/docs/operations/hermes-terminal-cheatsheet.md
@@ -25,11 +25,28 @@ sudo journalctl -u hermes-gateway -f           # Live-tail the logs (Ctrl+C to s
 
 ```bash
 cd /home/hermes/repos/superbot                 # Go to the repo (lines below assume you're here).
-git pull origin main                           # Pull the latest changes. Always do this before re-installing.
+git fetch origin main && git reset --hard origin/main   # Sync the mirror to GitHub before re-installing. Discards local repo edits (it's a read-only mirror); never aborts on divergence.
 bash scripts/hermes/install-soul.sh            # Write the operating prompt → ~/.hermes/SOUL.md (backs up first). No restart needed.
 bash scripts/hermes/install-skills.sh          # Copy skill files → ~/.hermes/skills/. Restart the gateway after this one.
 bash scripts/hermes/install-soul.sh --dry-run  # Preview the prompt without writing it.
 ```
+
+## Clone diverged from main → `git pull` won't fast-forward (recovery)
+
+`git pull` aborting with *"Not possible to fast-forward"* / *"diverging branches"* means the VPS
+clone has local commits that aren't on GitHub. The clone is a read-only **mirror** — reset it to
+match (the deploy command above already does this; this is the same fix with a safety snapshot):
+
+```bash
+cd /home/hermes/repos/superbot
+git branch backup-vps-$(date +%Y%m%d)   # Snapshot the local-only commits first (recoverable via: git log backup-vps-…).
+git fetch origin main
+git reset --hard origin/main             # Make the clone exactly match GitHub.
+git log --oneline -1                     # Confirm you're on the latest commit.
+```
+
+Never commit directly to the clone's `main` — Hermes writes on `claude/*` branches it pushes, so
+the mirror stays clean and this won't recur.
 
 ## Hermes config & identity
 

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -30,9 +30,9 @@ living ledger (`docs/current-state.md`).
 - `claude/hopeful-allen-home-slice-c` · mining Slice C — Home structure (character-card backdrop) ·
   `disbot/{utils/mining/structures,services/mining_workflow,utils/character_render,views/mining,
   cogs/mining_cog,utils/mining/market}` + plan/numbers · 2026-06-15
-- `claude/brave-sagan-s9th8h` · Hermes context work — #913 (research + SOUL sync fix) MERGED;
-  follow-up in progress: SOUL size guard + sharpen context diagnosis (owner 5-msg data point) ·
-  `scripts/hermes/install-soul.sh` + investigation doc · 2026-06-15
+- `claude/brave-sagan-s9th8h` · Hermes context work — #913/#914 MERGED + applied live on VPS;
+  follow-up in progress: self-healing sync (diverged clone can't `pull --ff-only`) ·
+  `hermes-operating-prompt` + `hermes-terminal-cheatsheet` · 2026-06-15
 
 ## Recently cleared
 


### PR DESCRIPTION
Follow-up to #913/#914. Applying the fixes live on the VPS surfaced a real bug: the clone had **diverged** from `origin/main`, so `git pull --ff-only` aborted (`Not possible to fast-forward`) — which also meant the new `apply_context_fixes.sh` was never downloaded. Recovery (backup branch + `git reset --hard origin/main`) unblocked it, and the apply-script then landed all three `hermes config set` calls cleanly (incl. `prompt_caching.cache_ttl 1h`). This hardens the sync so a diverged clone can't get stuck again.

- **`hermes-operating-prompt.md`** — replace the fragile `git pull --ff-only origin main` sync line with the self-healing `git fetch origin main && git checkout -B main origin/main` (always lands on fresh main, never aborts on divergence — the pattern the dispatch routine already uses). States the clone is a read-only **mirror**: never commit to it; write on a `claude/` branch you push. Kept concise — SOUL.md is at ~81% of its byte budget.
- **`hermes-terminal-cheatsheet.md`** — make the deploy-section sync robust + add a "clone diverged → recovery" snippet (backup branch + `reset --hard`).

**Maintainer note:** purely a robustness improvement to the *instructions*. Your current SOUL.md (the `--ff-only` version) works fine now that the clone is a clean mirror; you'll pick up the self-healing version next time you run `install-soul.sh` / `apply_context_fixes.sh` — no urgent action.

https://claude.ai/code/session_01FwmaNQr47seoRng82Mj39E

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwmaNQr47seoRng82Mj39E)_