### PR TITLE
Hermes: record the model/provider decision in the ops docs

### DIFF
--- a/.sessions/2026-06-15-hermes-model-record.md
+++ b/.sessions/2026-06-15-hermes-model-record.md
@@ -1,0 +1,57 @@
+# Session — Hermes model/provider record (capture the live findings)
+
+> **Status:** `complete`
+
+## What I did
+
+Continuation of the long Hermes investigation (#913/#914/#915 merged + applied live). The single
+biggest driver of Hermes' behaviour — its model/provider — was documented nowhere in the repo, and a
+pile of verified facts from this session lived only in chat. Captured them in the ops docs.
+
+## What shipped (docs-only)
+
+- `hermes-control-plane.md` — new **"Model / provider"** subsection: the free default is Nous
+  Research's own inference endpoint (`stepfun/step-3.7-flash:free` via `inference-api.nousresearch.com`,
+  verified from `hermes config`); 2026-06-15 switched to `openai/gpt-5.4-mini` on the owner's own
+  OpenAI key (`/model` confirms `Provider: openai-api`; **live-reply verification still pending**); the
+  own-key switch commands; the **stale `/model` picker** gotcha (offers only `gpt-4o-mini` — a
+  downgrade, not what runs); and the independence-vs-reliability rationale (Q-0117).
+- `hermes-terminal-cheatsheet.md` — added the switch-model / own-key commands + the stale-picker note.
+- `hermes-token-efficiency-investigation-2026-06-15.md` — "Live outcome" note: the lever was model
+  *capability*, not window.
+- **Verified:** `check_docs --strict` ✓. The model facts (free default, provider switch, picker
+  gotcha, own-key mechanism) are all verified from the owner's terminal/Telegram output; only
+  gpt-5.4-mini's end-to-end *reply* is pending (marked as such in the doc).
+
+## Handoff / next
+
+- **Owner:** send Hermes a real task to confirm gpt-5.4-mini actually answers (the `/status` showed
+  `Agent Running: No`). If it errors, fall back to `gpt-4o-mini` (picker), `gpt-5.5`, or a Claude key
+  — all one command (cheatsheet). Then this record's "pending" line can be ticked.
+- Don't tap `gpt-4o-mini` in the `/model` picker expecting an upgrade — it's stale.
+
+## 💡 Session idea (Q-0089)
+
+**Per-role model for Hermes.** Hermes plays several roles (orient / dispatch / **review**). The cheap
+`gpt-5.4-mini` is fine for orient/dispatch, but the **review-merge gate** (Q-0117) is the role that
+most needs to be sharp — it's the independent check on Claude's big steps. Hermes' cron supports
+per-job `model` overrides, so the review skill could pin a stronger model (gpt-5.5, or a different
+mind) while the default stays cheap. Best independence × reliability per €. Dedup-checked
+`docs/ideas/` — none.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous: `2026-06-15-hermes-sync-hardening.md` (#915). It responsively hardened the sync right after
+the diverged-clone bit the owner live — good reflexes. **System improvement this run surfaced:** the
+#1 driver of Hermes' behaviour (its *model*) was invisible to every repo-side doc and `check_*` until
+the owner happened to mention it mid-session — the Control-plane state table tracks secrets/deploys
+but never "what model is Hermes on." This PR homes it in the control-plane doc; a future pass could
+add a "model" row to that table so it can't silently drift.
+
+## 📋 Doc audit (Q-0104)
+
+`check_docs --strict` green; all three edited docs reachable. The model decision (chat-only until now
+— exactly the Q-0104 drift class) is now durably homed in `hermes-control-plane.md` + cheatsheet +
+investigation pointer. No new owner Q-block: the model choice is a reversible ops config in its proper
+home (the control-plane record), not a binding policy. The one open item is a **runtime** check
+(gpt-5.4-mini live reply), flagged in the doc — not a docs gap. Ledger unaffected (docs-only).

--- a/docs/operations/hermes-control-plane.md
+++ b/docs/operations/hermes-control-plane.md
@@ -66,6 +66,42 @@ Hermes config/data paths shown during setup:
 /home/hermes/.hermes/
 ```
 
+### Model / provider
+
+> Added 2026-06-15 (the Hermes context-management investigation —
+> [`hermes-token-efficiency-investigation-2026-06-15.md`](hermes-token-efficiency-investigation-2026-06-15.md)).
+> The model is the single biggest driver of Hermes' behaviour, so it belongs in this record.
+
+- **Free default (what Hermes ships with):** `stepfun/step-3.7-flash:free`, served by **Nous
+  Research's own free inference endpoint** — `hermes config` shows `provider: nous`,
+  `base_url: https://inference-api.nousresearch.com/v1`. Not OpenRouter. A free, quantized,
+  lightweight tier — fine for chat, but too weak for reliable agentic control-plane work over this
+  repo (it was the root cause of the "misunderstands assignments / errors" the owner reported; no
+  config knob fixes a capability ceiling).
+- **Switched 2026-06-15 →** `openai/gpt-5.4-mini` on the **owner's own OpenAI key**
+  (`OPENAI_API_KEY` in `~/.hermes/.env`). `/model` confirms `Provider: openai-api` (routing left the
+  Nous endpoint). 400K context, ~$0.75/$4.50 per 1M tokens. **Live-reply verification pending** — the
+  config is set and the provider switched, but a fresh `/status` still showed `Agent Running: No`, so
+  confirm Hermes actually answers a task on it.
+- **⚠️ The `/model` Telegram quick-picker is stale** — for `openai-api` it only lists the old
+  `gpt-4o-mini` (a 2024 model). That is NOT what runs; `hermes config set model …` is authoritative.
+  Don't tap `gpt-4o-mini` expecting an upgrade — it's a downgrade from gpt-5.4-mini (keep it only as a
+  known-good fallback if a newer id won't route).
+- **Switch the model / use your own key** (no OpenRouter credits needed — own provider keys work
+  directly):
+  ```bash
+  hermes config set OPENAI_API_KEY sk-...        # or ANTHROPIC_API_KEY sk-ant-...  (set on the VPS; never share)
+  hermes config set model openai/gpt-5.4-mini    # or anthropic/claude-sonnet-4-6 · openai/gpt-5.5 · …
+  sudo systemctl restart hermes-gateway
+  hermes config | grep -i model                  # verify
+  ```
+- **Rationale (independence vs. reliability):** Hermes is deliberately a **non-Claude** mind so its
+  review is independent of the Claude that builds (Q-0117). The reliability fix was *capability*, not
+  *Claude* — a frontier **non-Claude** model (gpt-5.4-mini, or gpt-5.5) keeps the independence and
+  fixes the weakness. A Claude key (`anthropic/claude-sonnet-4-6`) is the most-reliable fallback if
+  independence is dropped. For the **review** role specifically, a stronger model than the cheap mini
+  is worth considering.
+
 ### Terminal backend
 
 Hermes was initially configured with the Docker terminal backend, but Docker was not installed yet. This caused command execution failures.

--- a/docs/operations/hermes-terminal-cheatsheet.md
+++ b/docs/operations/hermes-terminal-cheatsheet.md
@@ -54,6 +54,9 @@ the mirror stays clean and this won't recur.
 hermes config                                  # Show Hermes' current configuration.
 hermes config edit                             # Safely edit config.yaml (e.g. trim joke personalities).
 hermes config check                            # Validate the config after editing.
+hermes model                                   # Interactive model picker. NOTE: the built-in list is stale (offers gpt-4o-mini) — `config set model` is authoritative.
+hermes config set model openai/gpt-5.4-mini    # Set the model (provider/model). Set the matching key first (below). Restart after.
+hermes config set OPENAI_API_KEY sk-...        # Use your own key directly — no OpenRouter needed (also ANTHROPIC_API_KEY for anthropic/* models). Set on the VPS; never share.
 hermes --help                                  # Explore the rest of the Hermes CLI.
 cat ~/.hermes/SOUL.md                          # View Hermes' current base identity / operating prompt.
 ls ~/.hermes/skills/                           # List the skills Hermes has installed.

--- a/docs/operations/hermes-token-efficiency-investigation-2026-06-15.md
+++ b/docs/operations/hermes-token-efficiency-investigation-2026-06-15.md
@@ -208,3 +208,12 @@ and re-installs the sync-fixed SOUL.md. Then `sudo systemctl restart hermes-gate
 - Verify the SOUL.md byte size (now guarded in `install-soul.sh`) — at 6478 bytes it is ~81% of the
   likely ~8 KB ceiling, so don't grow the operating prompt without trimming.
 - Adopt a **`/new`-per-task** habit (the SOUL.md already preaches it) — the cheapest fix of all.
+
+### Live outcome (2026-06-15)
+
+The dominant lever turned out to be model **capability**, not window: Hermes ran on a free, quantized
+Flash tier (`stepfun/step-3.7-flash:free` via Nous Research's own endpoint), and the 256K window was
+never the bottleneck. Resolved by switching to the owner's **own OpenAI key** → `openai/gpt-5.4-mini`
+(a non-Claude frontier-family model — keeps the Q-0117 independent-reviewer property *and* fixes
+reliability). Full record + switch commands: [`hermes-control-plane.md`](hermes-control-plane.md)
+§ Model / provider.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -30,9 +30,9 @@ living ledger (`docs/current-state.md`).
 - `claude/hopeful-allen-home-slice-c` · mining Slice C — Home structure (character-card backdrop) ·
   `disbot/{utils/mining/structures,services/mining_workflow,utils/character_render,views/mining,
   cogs/mining_cog,utils/mining/market}` + plan/numbers · 2026-06-15
-- `claude/brave-sagan-s9th8h` · Hermes context work — #913/#914 MERGED + applied live on VPS;
-  follow-up in progress: self-healing sync (diverged clone can't `pull --ff-only`) ·
-  `hermes-operating-prompt` + `hermes-terminal-cheatsheet` · 2026-06-15
+- `claude/brave-sagan-s9th8h` · Hermes context work — #913/#914/#915 MERGED + applied live;
+  follow-up: record the model/provider decision (free Nous default → own-key gpt-5.4-mini) ·
+  `hermes-control-plane` + `hermes-terminal-cheatsheet` + investigation · 2026-06-15
 
 ## Recently cleared
 


### PR DESCRIPTION
Captures the model/provider findings from the long Hermes investigation (#913/#914/#915) that were living only in chat. The model is the single biggest driver of Hermes' behaviour, yet the ops docs never recorded it.

- **`hermes-control-plane.md`** — new "Model / provider" subsection: the free default is **Nous Research's own free inference endpoint** (`stepfun/step-3.7-flash:free` via `inference-api.nousresearch.com`, verified from `hermes config` — not OpenRouter); switched 2026-06-15 to `openai/gpt-5.4-mini` on the owner's **own OpenAI key** (`/model` confirms `Provider: openai-api`; **live-reply verification still pending**); own-key switch commands; the **stale `/model` picker** gotcha (it offers only the old `gpt-4o-mini` — a downgrade, not what runs); independence-vs-reliability rationale (Q-0117).
- **`hermes-terminal-cheatsheet.md`** — switch-model / own-key commands + the stale-picker note.
- **investigation doc** — "Live outcome": the dominant lever was model *capability*, not window.

All model facts are verified from the owner's terminal/Telegram output; only gpt-5.4-mini's end-to-end *reply* is pending (clearly marked). Docs-only.

https://claude.ai/code/session_01FwmaNQr47seoRng82Mj39E

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwmaNQr47seoRng82Mj39E)_