### PR TITLE
Settings reverse-parity invariant — close the declared ⇔ consumed bijection

### DIFF
--- a/.sessions/2026-06-15-settings-reverse-parity.md
+++ b/.sessions/2026-06-15-settings-reverse-parity.md
@@ -1,0 +1,17 @@
+# Session — settings reverse-parity invariant (complete the declared ⇔ consumed bijection)
+
+> **Status:** `in-progress`
+
+## What I'm about to do
+
+Second slice of the same dispatch run that shipped P1-3 (#917, merged). #917 added settings
+**forward** parity — every declared `SettingSpec` has a runtime consumer. This adds the **reverse**
+direction: every literal `resolve_value`/`resolve_setting(g, subsystem, name)` read must target a
+*declared* setting, so the settings lane becomes a true **bijection** (declared ⇔ consumed).
+
+The gap it closes is a real silent-bug class: a typo'd or stale read —
+`resolve_value(g, "welcom", "enabld", default)` — never matches a written key, so it resolves to the
+**fallback forever**, an invisible always-default bug no test catches today. This was the Q-0089
+session idea from the #917 close-out; building it now rather than orphaning it (it reuses the same
+AST walk in `test_settings_declared_vs_consumed_parity.py`). Holds today: 0 violations across 48
+literal reads.

--- a/.sessions/2026-06-15-settings-reverse-parity.md
+++ b/.sessions/2026-06-15-settings-reverse-parity.md
@@ -1,17 +1,55 @@
 # Session — settings reverse-parity invariant (complete the declared ⇔ consumed bijection)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-## What I'm about to do
+## What I did
 
 Second slice of the same dispatch run that shipped P1-3 (#917, merged). #917 added settings
 **forward** parity — every declared `SettingSpec` has a runtime consumer. This adds the **reverse**
-direction: every literal `resolve_value`/`resolve_setting(g, subsystem, name)` read must target a
-*declared* setting, so the settings lane becomes a true **bijection** (declared ⇔ consumed).
+direction, so the settings lane is now a true **bijection** (declared ⇔ consumed). This was the
+Q-0089 session idea from #917's close-out — built immediately rather than orphaned (it reuses the
+same AST walk, so it was cheap and in-domain).
 
-The gap it closes is a real silent-bug class: a typo'd or stale read —
-`resolve_value(g, "welcom", "enabld", default)` — never matches a written key, so it resolves to the
-**fallback forever**, an invisible always-default bug no test catches today. This was the Q-0089
-session idea from the #917 close-out; building it now rather than orphaning it (it reuses the same
-AST walk in `test_settings_declared_vs_consumed_parity.py`). Holds today: 0 violations across 48
-literal reads.
+## What shipped (PR #918)
+
+- `tests/unit/invariants/test_settings_declared_vs_consumed_parity.py` — a second test,
+  `test_every_literal_setting_read_targets_a_declared_setting`, + a `_scan_literal_reads()` helper.
+  It asserts every `resolve_value`/`resolve_setting` call with a string-literal `(subsystem, name)`
+  pair targets a setting that exists in the schema registry. Closes the silent-bug class where a
+  typo'd/stale read (`resolve_value(g, "welcom", "enabld", default)`) never matches a written key
+  and resolves to the **fallback forever** — invisible, uncaught today. Holds: **0 violations**
+  across 48 literal reads. Verified to fire on an injected stray read.
+- **Verified:** `check_quality --full` green (9811); arch 0; the guard fires on a violation.
+
+## Handoff / next
+
+- Settings parity is now a complete bijection (no dead declarations · no stray reads). The
+  remaining next ▶ startable plan work is unchanged from #917's handoff: the **safety quick-win**
+  (welcome phase 2 PIL cards — but note that needs *visual design* input, the owner's domain, so
+  it's design-first not turn-key) · **plan-first BUG-0009** (AI §7 list-builders) · the
+  creds/review-blocked P1-1 remainder (Layer B · live battery).
+- **Still-open pre-existing ledger drift** (from #917's handoff, NOT addressed here): 9 PRs
+  #902–#916 absent from the living ledger; the #930 reconciliation pass's job.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous run = #917 (P1-3 invariants), this run's own first slice. It did the P1-3 disposition
+honestly — it resisted shipping a *brittle* BTD6 provenance guard (an AST docstring-marker scan) and
+instead recorded it as a design-for-review residual, which is the right call under the repo's
+"verifiable, not a temporary patch" bar. What it could have done better: it *contributed* the
+reverse-parity idea (Q-0089) but stopped at the idea — this slice closes that gap by building it
+same-run, which is the better pattern (an idea you can cheaply build now beats an idea filed for
+later). **System note:** this validates the dispatch routine's "2–3 slices, never just after one PR"
+bias — the second slice here cost little and turned a one-directional check into a full invariant,
+exactly the compounding the multi-slice rule is for.
+
+## 💡 Session idea (Q-0089)
+
+Covered by the build itself — this slice *is* the Q-0089 idea from #917 promoted to shipped code, so
+contributing a fresh forced idea here would be ceremony (the standing bar: genuine generation, not
+filler). The honest forward note instead: the **same bijection pattern is worth auditing across the
+other registry-backed lanes** — the AI tool catalogue already has it (declared == consumed, praised
+in the P1-3 disposition); the *bindings* and *resource-provisioning* registries may have the same
+one-directional gap settings just had (a declared binding nothing reads, or a binding read that
+isn't declared). A future P1-3-style pass could run the same forward/reverse parity over those two
+registries. Recorded for the next reconcile; not built here (out of this slice's scope).

--- a/docs/current-state-archive.md
+++ b/docs/current-state-archive.md
@@ -13,6 +13,21 @@
 
 ## Recently shipped — archived (newest first)
 
+- **#843 (2026-06-14, hardening P1-2 — health findings lifecycle + operational retention,
+  Q-0097)** — closed the two **code** gaps in the health/diagnostics readiness map (the
+  remaining gap to production-ready is now the owner-led live walk only). Before: in normal
+  operation every persisted finding stayed `open` forever (no transition path → the retention
+  roll-up was unreachable) and retention ran **only at startup** (a long-lived replica never
+  re-swept). Now, **operator-managed (Q-0097)** through the **sole writer**: (1)
+  `utils/db/health_findings.set_finding_status` (CTE `UPDATE … RETURNING` the prior status; added
+  to the sole-writer AST guard) + `health_findings_service.set_status` (the one transition path,
+  `open`↔`resolved`/`ignored`, validates status, emits `audit.action_recorded` on a real operator
+  change — system recording stays audit-free) + `!platform finding resolve/ignore/reopen
+  <fingerprint>` (admin command, kept **out** of the read-only platform hub). (2) A new
+  `HealthMaintenanceCog` reruns `run_retention()` on a daily `tasks.loop` (mirrors
+  `MediaMaintenanceCog`); the startup sweep stays. Pinned the platform-hub typed-only exclusion of
+  `startup`/`findings`/`finding`. +15 tests; `check_quality --full` green (9551); arch 0; the new
+  `set_finding_status` SQL verified on real Postgres.
 - **#856 + #853 (2026-06-14, external-systems watchlist + workflow-health review)** — **#856:** a
   new **`docs/research/`** home for *external* intelligence (vs. `docs/ideas/` for our own);
   `external-systems-watchlist.md` — 7 lesson-first entries (Voyager · Reflexion · Generative Agents

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -262,6 +262,16 @@ Source code and merged PRs win over anything written here.
 > auto-opens a `reconcile` issue at the boundary that fires the docs-reconciliation routine). Reset
 > this marker to the latest PR after a pass.
 
+- **#918 (2026-06-15, settings reverse-parity invariant — complete the declared ⇔ consumed
+  bijection)** — second slice of the #917 dispatch run, promoting that PR's Q-0089 idea straight to
+  shipped code. #917 added settings *forward* parity (every declared `SettingSpec` has a reader);
+  this adds the *reverse* direction —
+  `test_settings_declared_vs_consumed_parity.py::test_every_literal_setting_read_targets_a_declared_setting`
+  asserts every literal `resolve_value`/`resolve_setting(g, subsystem, name)` read targets a
+  *declared* setting. Closes the silent-bug class where a typo'd/stale read
+  (`resolve_value(g, "welcom", "enabld", default)`) never matches a written key and resolves to the
+  fallback forever (invisible, uncaught). 0 violations across 48 literal reads; reuses the same AST
+  walk; verified to fire. `check_quality --full` green (9811); arch 0; test-only.
 - **#917 (2026-06-15, P1-3 contract invariants — close the cross-cutting "stays fixed" layer)** —
   the next ▶ startable plan slice (band-#900 decade queue slot 3 · hardening roadmap §P1-3). Reviewed
   all four named tracks and closed the **two** genuine buildable-now gaps with CI-runnable AST
@@ -499,25 +509,7 @@ Source code and merged PRs win over anything written here.
   **engage-when-present** (a PR adding no card isn't gated, so routines / workflow-authored PRs
   never deadlock); only newly-*added* cards inspected. +11 tests; the gate was **dogfooded on its
   own PR** (born red, then flipped). Follow-up: tighten to airtight once routine adoption is proven.
-- **#843 (2026-06-14, hardening P1-2 — health findings lifecycle + operational retention,
-  Q-0097)** — closed the two **code** gaps in the health/diagnostics readiness map (the
-  remaining gap to production-ready is now the owner-led live walk only). Before: in normal
-  operation every persisted finding stayed `open` forever (no transition path → the retention
-  roll-up was unreachable) and retention ran **only at startup** (a long-lived replica never
-  re-swept). Now, **operator-managed (Q-0097)** through the **sole writer**: (1)
-  `utils/db/health_findings.set_finding_status` (CTE `UPDATE … RETURNING` the prior status; added
-  to the sole-writer AST guard) + `health_findings_service.set_status` (the one transition path,
-  `open`↔`resolved`/`ignored`, validates status, emits `audit.action_recorded` on a real operator
-  change — system recording stays audit-free) + `!platform finding resolve/ignore/reopen
-  <fingerprint>` (admin command, kept **out** of the read-only platform hub). (2) A new
-  `HealthMaintenanceCog` reruns `run_retention()` on a daily `tasks.loop` (mirrors
-  `MediaMaintenanceCog`); the startup sweep stays. Pinned the platform-hub typed-only exclusion of
-  `startup`/`findings`/`finding`. +15 tests; `check_quality --full` green (9551); arch 0; the new
-  `set_finding_status` SQL verified on real Postgres. *(The code + Slice-A/B/C doc updates merged in
-  #843; this ledger entry + the session-close docs land as a small follow-up — the auto-merge fired
-  on the first green before the session-close push, see the session log.)* **Next P1 = P1-1
-  eval-matrix** (needs prod-like creds for the live half).
-- **Older merges (#856 … #535) → [`current-state-archive.md`](current-state-archive.md).** Recently-shipped keeps the ~20 newest; older entries are archived (`scripts/check_docs.py` soft-ratchets the count). *(The #917 P1-3 contract-invariants session (2026-06-15) added its entry and archived the four oldest live entries — #856+#853, #851+#850+#848+#852, #840, #839+housekeeping — to bring the ledger back to 20. The #912 mining-Slices-E+F session (2026-06-15) added its entry and archived the oldest live one — #829 P0-2 PR 1 — to hold the ratchet. The #897 mining-Vault-v2 session (2026-06-15) added its entry and archived the oldest live one — #825 P0-4 PR 2 — to hold the ratchet at 20. The #895 non-BTD6 eval-coverage session (2026-06-15) added its entry — folded into the #878 eval bullet, plus the #892+#889 docs-hygiene entry — and archived the oldest live one, #820 P0-4 PR 1, to hold the ratchet. The #884 mining-Vault session (2026-06-14) added its entry and archived the oldest live one — the #814+#815 CI-efficiency arc — to hold the ratchet at 20. The #878 P1-1 eval/smoke session (2026-06-14) added its own entry and archived the oldest live one — the #802…#813 portable-substrate-kit group — to hold the ratchet at 20. The band-#870 reconciliation pass (2026-06-14) added two live entries — the #870+#869+#868 Hermes operating-layer arc and #867 ledger window catch-up — and archived the two oldest to hold the ratchet at 20: the #803… reconciliation+workflow-rules group and the #827… Railway agent-access session. Earlier: the band #841–#860 ledger-reconciliation added eight live entries — #866, #865, #864, #863, #862, #859, the #856+#853 group, and the #851/#850/#848/#852 group — and archived the eight oldest: the #788…#798 substrate-kit arc, #817, #794, the #786+#787 group, #778, #777, #775, #774. Earlier still: the #772 automod-v1 entry was archived to offset #855; the #765+#767+#769+#770 backup-posture entry to offset #849; the #764 P2 doc-drift-sweep entry to offset #843; the band-#840 reconciliation pass archived the #763 second-reconciliation-pass record, the #758/#760/#762 UX-Lab BUILD, and the #753/#754/#756/#759/#761 autonomous-loop wiring; the #755 entry to offset #829; the #746–#754 entry to offset #825; the #741/#742/#745/#748 entries by the band-#820 pass.)*
+- **Older merges (#856 … #535) → [`current-state-archive.md`](current-state-archive.md).** Recently-shipped keeps the ~20 newest; older entries are archived (`scripts/check_docs.py` soft-ratchets the count). *(The #918 settings-reverse-parity session (2026-06-15) added its entry and archived the oldest live one — #843 P1-2 health-findings — to hold the ratchet at 20. The #917 P1-3 contract-invariants session (2026-06-15) added its entry and archived the four oldest live entries — #856+#853, #851+#850+#848+#852, #840, #839+housekeeping — to bring the ledger back to 20. The #912 mining-Slices-E+F session (2026-06-15) added its entry and archived the oldest live one — #829 P0-2 PR 1 — to hold the ratchet. The #897 mining-Vault-v2 session (2026-06-15) added its entry and archived the oldest live one — #825 P0-4 PR 2 — to hold the ratchet at 20. The #895 non-BTD6 eval-coverage session (2026-06-15) added its entry — folded into the #878 eval bullet, plus the #892+#889 docs-hygiene entry — and archived the oldest live one, #820 P0-4 PR 1, to hold the ratchet. The #884 mining-Vault session (2026-06-14) added its entry and archived the oldest live one — the #814+#815 CI-efficiency arc — to hold the ratchet at 20. The #878 P1-1 eval/smoke session (2026-06-14) added its own entry and archived the oldest live one — the #802…#813 portable-substrate-kit group — to hold the ratchet at 20. The band-#870 reconciliation pass (2026-06-14) added two live entries — the #870+#869+#868 Hermes operating-layer arc and #867 ledger window catch-up — and archived the two oldest to hold the ratchet at 20: the #803… reconciliation+workflow-rules group and the #827… Railway agent-access session. Earlier: the band #841–#860 ledger-reconciliation added eight live entries — #866, #865, #864, #863, #862, #859, the #856+#853 group, and the #851/#850/#848/#852 group — and archived the eight oldest: the #788…#798 substrate-kit arc, #817, #794, the #786+#787 group, #778, #777, #775, #774. Earlier still: the #772 automod-v1 entry was archived to offset #855; the #765+#767+#769+#770 backup-posture entry to offset #849; the #764 P2 doc-drift-sweep entry to offset #843; the band-#840 reconciliation pass archived the #763 second-reconciliation-pass record, the #758/#760/#762 UX-Lab BUILD, and the #753/#754/#756/#759/#761 autonomous-loop wiring; the #755 entry to offset #829; the #746–#754 entry to offset #825; the #741/#742/#745/#748 entries by the band-#820 pass.)*
 
 > Older than this: see `docs/planning/*` trackers and `docs/decisions/*` ADRs.
 

--- a/tests/unit/invariants/test_settings_declared_vs_consumed_parity.py
+++ b/tests/unit/invariants/test_settings_declared_vs_consumed_parity.py
@@ -197,6 +197,42 @@ def _scan_consumption(
     return named_pairs, whole_subsystems, key_values
 
 
+def _scan_literal_reads() -> list[tuple[str, str, str]]:
+    """``(subsystem, name, "file:line")`` for every ``resolve_value`` /
+    ``resolve_setting`` call with a string-literal ``(subsystem, name)`` pair.
+
+    The subsystem may be a literal or a module-level ``SUBSYSTEM`` alias;
+    the name must be a literal (dynamic-name reads carry nothing to check).
+    """
+    reads: list[tuple[str, str, str]] = []
+    for path in sorted(_DISBOT.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        try:
+            tree = ast.parse(path.read_text())
+        except SyntaxError:  # pragma: no cover — defensive
+            continue
+        subsystem_const = _module_subsystem_const(tree)
+        rel = path.relative_to(_REPO_ROOT)
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and _call_name(node) in _RESOLVE_NAMED):
+                continue
+            if len(node.args) < 3:
+                continue
+            sub_arg, name_arg = node.args[1], node.args[2]
+            subsystem = _string_const(sub_arg)
+            if (
+                subsystem is None
+                and isinstance(sub_arg, ast.Name)
+                and sub_arg.id in _SUBSYSTEM_VARS
+            ):
+                subsystem = subsystem_const
+            name = _string_const(name_arg)
+            if subsystem and name:
+                reads.append((subsystem, name, f"{rel}:{node.lineno}"))
+    return reads
+
+
 def _module_subsystem_const(tree: ast.Module) -> str | None:
     for node in tree.body:
         if not (
@@ -244,4 +280,37 @@ def test_every_declared_setting_has_a_runtime_consumer():
         "declaration is intentionally ahead of its consumer — add it to "
         "_DECLARED_NO_OP_OK with a tracking reference:\n"
         + "\n".join(f"  {d}" for d in dead)
+    )
+
+
+def test_every_literal_setting_read_targets_a_declared_setting():
+    """The reverse direction — no read of an *undeclared* setting.
+
+    The forward parity above proves every declaration has a reader. The
+    mirror gap is just as silent: a typo'd or stale literal read —
+    ``resolve_value(g, "welcom", "enabld", default)`` — resolves to the
+    *fallback* forever (the misspelled key is never written, so it always
+    misses), an invisible always-default bug no other test catches. This
+    asserts every ``resolve_value``/``resolve_setting`` call with a literal
+    ``(subsystem, name)`` pair targets a setting that actually exists in the
+    schema registry, turning the settings lane's parity into a true
+    bijection (declared ⇔ consumed). Dynamic-name and ``resolve_batch``
+    reads carry no literal name to check and are out of scope.
+    """
+    declared_pairs = set(_declared_settings())
+    literal_reads = _scan_literal_reads()
+
+    stray = sorted(
+        {
+            f"({sub!r}, {name!r}) at {loc}"
+            for sub, name, loc in literal_reads
+            if (sub, name) not in declared_pairs
+        }
+    )
+    assert not stray, (
+        "P1-3 reverse-parity violation: a resolve_value/resolve_setting "
+        "call reads a (subsystem, name) that is NOT a declared SettingSpec "
+        "— it silently resolves to the fallback every time (a typo'd or "
+        "stale key). Fix the literal, or declare the setting:\n"
+        + "\n".join(f"  {s}" for s in stray)
     )


### PR DESCRIPTION
**Born-red** (Q-0133 — the `in-progress` session card holds the merge gate until the work + close-out land).

Second slice of the same dispatch run as #917 (P1-3 contract invariants, merged). #917 added settings **forward** parity — every declared `SettingSpec` has a runtime consumer. This adds the **reverse** direction, turning the settings lane into a true **bijection** (declared ⇔ consumed).

## The gap it closes

A typo'd or stale literal read — `resolve_value(g, "welcom", "enabld", default)` — never matches a written key, so it resolves to the **fallback forever**: an invisible always-default bug no test catches today. The new check (`test_every_literal_setting_read_targets_a_declared_setting`) asserts every `resolve_value`/`resolve_setting` call with a string-literal `(subsystem, name)` pair targets a setting that actually exists in the schema registry. Holds today: **0 violations** across 48 literal reads. Reuses the same AST walk as the forward-parity test.

This was the Q-0089 session idea from #917's close-out — built now rather than orphaned.

_Generated by [Claude Code](https://claude.ai/code/session_011KW5nRbU3U9Q1xesKMugvm)_

---
_Generated by [Claude Code](https://claude.ai/code/session_011KW5nRbU3U9Q1xesKMugvm)_