### PR TITLE
Hermes: model-switch playbook + accurate current-state (open item: gpt-5.4-mini flapping)

### DIFF
--- a/.sessions/2026-06-15-hermes-model-playbook.md
+++ b/.sessions/2026-06-15-hermes-model-playbook.md
@@ -1,16 +1,55 @@
-# Session — Hermes model-switch playbook (close out the saga)
+# Session — Hermes model-switch playbook + saga close-out
 
-> **Status:** `in-progress` — born-red per Q-0133. gpt-5.4-mini is **CONFIRMED WORKING** on the
-> owner's own OpenAI key (live reply: "Hi! How can I help?"). Closing out: correct the #916
-> "live-reply pending" line and capture the full provider-maze playbook so the next setup is 5
-> minutes, not the 2.5 hours this took.
+> **Status:** `complete`
 
-## What I'm about to do (docs-only)
-- `hermes-control-plane.md` Model/provider → mark **CONFIRMED WORKING** (custom OpenAI-compatible
-  provider via `hermes model`, gpt-5.4-mini, alias added to the project allowlist), correct the
-  now-wrong `config set model openai/...` command (prefix routes to nous), and add the **6-trap
-  model-switch playbook**: empty `providers:{}` → nous catalog default · prefix routing · stale
-  built-in openai-api listing (gpt-4o-mini only) · gpt-4o-mini encrypted-content/reasoning 400 · org
-  verification · exact-match allowlist alias-vs-dated-snapshot trap.
-- `hermes-terminal-cheatsheet.md` → fix the misleading `config set model openai/...` line; use the
-  `hermes model` wizard; point at the playbook.
+## What we did (the whole Hermes thread, this session)
+
+Owner reported Hermes (the Nous Research control-plane agent on the VPS) misbehaving — errors,
+forgotten tasks, misunderstood assignments, not syncing to main. Diagnosed + fixed across PRs
+**#913–#917 (all merged & live)**:
+- **#913** — root cause corrected: the "forgetting" is **context compaction** (tool-output pruning
+  at 50%, not unbounded overflow); + fixed the SOUL.md sync bug (`git fetch`→`git pull`).
+- **#914** — `scripts/hermes/apply_context_fixes.sh` (VPS operator script: compression knobs +
+  re-install SOUL) + a SOUL.md size guard.
+- **#915** — self-healing repo sync (recover a diverged mirror clone).
+- **#916/#917** — recorded the model/provider decision in `hermes-control-plane.md`.
+- **Applied live on the VPS:** `compression.threshold 0.75`, `protect_last_n 30`, `cache_ttl 1h`,
+  SOUL reinstalled. The model is the dominant behaviour lever (free Step-Flash was too weak).
+
+This PR (docs-only): rewrote `hermes-control-plane.md` § Model/provider into the accurate **current
+state + a 6-trap model-switch playbook**, and corrected the misleading `config set model openai/…`
+line in the cheatsheet (the prefix routes to Nous; use the `hermes model` wizard).
+
+## Current state (⬜ OPEN — needs checking in a fresh chat)
+
+Hermes is **switched to `gpt-5.4-mini` on the owner's own OpenAI key** via a custom OpenAI provider
+(`openai-api`, 400K detected) — quality is good when it runs — **but it is NOT yet stable:** it
+**intermittently** returns `Project proj_OJ… does not have access to model gpt-5.4-mini` (flapped
+>15 min, so not mere propagation). **Pick up here:** `hermes-control-plane.md` § "Model / provider"
+→ the **⬜ NOT YET STABLE** bullet. Next step = point Hermes at the **exact dated id
+`gpt-5.4-mini-2026-03-17`** (the project has it fully granted) instead of the alias; if it still
+flaps, pin `auxiliary.*` / `delegation` (both `provider: auto`) in `~/.hermes/config.yaml`.
+
+## 💡 Session idea (Q-0089)
+
+**A Hermes model-health canary.** Model-access flapping was only discovered through the owner's
+frustration — nothing surfaced it. A tiny hourly cron (or a `hermes-model-health` skill) that sends
+a one-token "ping" to the configured model and reports `ok / denied / flapping` would turn silent
+model-access failures into a visible signal — the operator-side analogue of `check_loop_health`.
+Dedup-checked `docs/ideas/` — none.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous: `2026-06-15-hermes-model-record.md` (#916). It captured the model decision well, but
+asserted "Provider: openai-api" / "switched" from a single transient `/model` screen and marked only
+"live-reply pending" — which this thread had to walk back twice (it was actually routing via Nous,
+then a custom provider, and it *flaps*). **Lesson, now enforced here:** for control-plane/external
+config, **`configured` ≠ `working` ≠ `stable`** — don't record a switch as done until a live reply is
+confirmed *and* holds across several turns. This card marks the model switch **in-progress, not done.**
+
+## 📋 Doc audit (Q-0104)
+
+`check_docs --strict` green. `hermes-control-plane.md` § Model/provider now reflects the real
+(flapping) state + the playbook; the cheatsheet's wrong `config set model openai/…` guidance is
+corrected. The one open item is a **runtime/ops check** (gpt-5.4-mini stability), explicitly flagged
+in the doc as ⬜ — not a docs gap. Ledger unaffected (docs-only).

--- a/.sessions/2026-06-15-hermes-model-playbook.md
+++ b/.sessions/2026-06-15-hermes-model-playbook.md
@@ -1,0 +1,16 @@
+# Session — Hermes model-switch playbook (close out the saga)
+
+> **Status:** `in-progress` — born-red per Q-0133. gpt-5.4-mini is **CONFIRMED WORKING** on the
+> owner's own OpenAI key (live reply: "Hi! How can I help?"). Closing out: correct the #916
+> "live-reply pending" line and capture the full provider-maze playbook so the next setup is 5
+> minutes, not the 2.5 hours this took.
+
+## What I'm about to do (docs-only)
+- `hermes-control-plane.md` Model/provider → mark **CONFIRMED WORKING** (custom OpenAI-compatible
+  provider via `hermes model`, gpt-5.4-mini, alias added to the project allowlist), correct the
+  now-wrong `config set model openai/...` command (prefix routes to nous), and add the **6-trap
+  model-switch playbook**: empty `providers:{}` → nous catalog default · prefix routing · stale
+  built-in openai-api listing (gpt-4o-mini only) · gpt-4o-mini encrypted-content/reasoning 400 · org
+  verification · exact-match allowlist alias-vs-dated-snapshot trap.
+- `hermes-terminal-cheatsheet.md` → fix the misleading `config set model openai/...` line; use the
+  `hermes model` wizard; point at the playbook.

--- a/docs/operations/hermes-control-plane.md
+++ b/docs/operations/hermes-control-plane.md
@@ -73,34 +73,59 @@ Hermes config/data paths shown during setup:
 > The model is the single biggest driver of Hermes' behaviour, so it belongs in this record.
 
 - **Free default (what Hermes ships with):** `stepfun/step-3.7-flash:free`, served by **Nous
-  Research's own free inference endpoint** — `hermes config` shows `provider: nous`,
-  `base_url: https://inference-api.nousresearch.com/v1`. Not OpenRouter. A free, quantized,
-  lightweight tier — fine for chat, but too weak for reliable agentic control-plane work over this
-  repo (it was the root cause of the "misunderstands assignments / errors" the owner reported; no
-  config knob fixes a capability ceiling).
-- **Switched 2026-06-15 →** `openai/gpt-5.4-mini` on the **owner's own OpenAI key**
-  (`OPENAI_API_KEY` in `~/.hermes/.env`). `/model` confirms `Provider: openai-api` (routing left the
-  Nous endpoint). 400K context, ~$0.75/$4.50 per 1M tokens. **Live-reply verification pending** — the
-  config is set and the provider switched, but a fresh `/status` still showed `Agent Running: No`, so
-  confirm Hermes actually answers a task on it.
-- **⚠️ The `/model` Telegram quick-picker is stale** — for `openai-api` it only lists the old
-  `gpt-4o-mini` (a 2024 model). That is NOT what runs; `hermes config set model …` is authoritative.
-  Don't tap `gpt-4o-mini` expecting an upgrade — it's a downgrade from gpt-5.4-mini (keep it only as a
-  known-good fallback if a newer id won't route).
-- **Switch the model / use your own key** (no OpenRouter credits needed — own provider keys work
-  directly):
-  ```bash
-  hermes config set OPENAI_API_KEY sk-...        # or ANTHROPIC_API_KEY sk-ant-...  (set on the VPS; never share)
-  hermes config set model openai/gpt-5.4-mini    # or anthropic/claude-sonnet-4-6 · openai/gpt-5.5 · …
-  sudo systemctl restart hermes-gateway
-  hermes config | grep -i model                  # verify
-  ```
+  Research's own free inference endpoint** (`provider: nous`,
+  `base_url: https://inference-api.nousresearch.com/v1` — not OpenRouter), with only ~**$0.10 trial
+  credit**. Free, quantized, lightweight — fine for chat, too weak *and* too small for reliable
+  agentic control-plane work over this repo. Root cause of the "misunderstands / errors" the owner
+  reported; no config knob fixes a capability ceiling.
+- **Current target (2026-06-15):** `gpt-5.4-mini` on the **owner's own OpenAI key**, via a **custom
+  OpenAI-compatible provider** added with the `hermes model` wizard (base url
+  `https://api.openai.com/v1`, key in `~/.hermes/.env`). `/new` shows `Provider: openai-api · 400K
+  (detected)`. Non-Claude → keeps the independent-reviewer property (Q-0117) while fixing capability;
+  output is good when it runs (a coherent repo-health review confirmed the quality).
+- **⬜ NOT YET STABLE — STILL NEEDS CHECKING (open item, 2026-06-15 ~19:40).** Hermes answers some
+  turns but **intermittently** returns `Project proj_OJ… does not have access to model gpt-5.4-mini`,
+  and it flapped for >15 min (so it is *not* just propagation lag). Likely cause: the project allowlist
+  was given the **alias** `gpt-5.4-mini`, which OpenAI resolves unevenly. **Next step to try:** point
+  Hermes at the **exact dated snapshot `gpt-5.4-mini-2026-03-17`** (the project has had that granted
+  from the start, fully) instead of the alias — re-run `hermes model`, set the custom provider's model
+  to `gpt-5.4-mini-2026-03-17` (typed; the menu won't list it), `/new`, run several tasks. **If it
+  still flaps on the exact id:** a secondary path is resolving the alias — inspect `auxiliary.*` and
+  `delegation` in `~/.hermes/config.yaml` (both `provider: auto`) and pin them. Until verified stable
+  across several tasks, treat the gpt-5.4-mini switch as **in-progress, not done.**
 - **Rationale (independence vs. reliability):** Hermes is deliberately a **non-Claude** mind so its
   review is independent of the Claude that builds (Q-0117). The reliability fix was *capability*, not
   *Claude* — a frontier **non-Claude** model (gpt-5.4-mini, or gpt-5.5) keeps the independence and
   fixes the weakness. A Claude key (`anthropic/claude-sonnet-4-6`) is the most-reliable fallback if
   independence is dropped. For the **review** role specifically, a stronger model than the cheap mini
   is worth considering.
+
+#### Model-switch playbook (the ~3-hour maze — so it's 5 minutes next time)
+
+Moving Hermes to a capable own-key model hit these traps, in order:
+
+1. **`providers: {}` empty by default** → the model resolves via the remote `model_catalog` and
+   defaults to **`nous`** (Nous Portal). `hermes config set model X` changes only the *name*, not the
+   *provider* — it stays on `nous`. (Symptom: "I set the model but it still says nous.")
+2. **Prefix routing:** `openai/gpt-5.4-mini` (with the `openai/` prefix) routes to the **Nous Portal
+   catalog**, not OpenAI. Don't trust the prefix to pick the provider.
+3. **Built-in `openai-api` provider has a stale model list** — only `gpt-4o-mini`; rejects gpt-5.x
+   ("Model … not found in this provider's model listing"). For a newer OpenAI model, add a **custom
+   OpenAI-compatible provider** via `hermes model` (base url `https://api.openai.com/v1`).
+4. **`gpt-4o-mini` then 400s: "Encrypted content is not supported with this model."** Hermes sends
+   reasoning/`include` params (driven by `agent.reasoning_effort`) that non-reasoning models reject.
+   Use a reasoning model (gpt-5.x), or set `agent.reasoning_effort none` for gpt-4o-mini.
+5. **OpenAI gates the gpt-5 family behind org verification** — Settings → Organization → Verify
+   (one-time; unlocks all gated models).
+6. **Exact-match project allowlist.** OpenAI "Allowed models" lists match the **exact id**. The project
+   had the dated `gpt-5.4-mini-2026-03-17` but Hermes requested the alias `gpt-5.4-mini` → "no access."
+   Add the alias, or — more reliably (the alias resolves unevenly) — use the **exact dated id**.
+   **Diagnostic shortcut:** reproduce in OpenAI's own Playground (same project + model) — if it fails
+   there too, it's 100 % OpenAI-side, not Hermes.
+
+**To change the model later** (now the custom provider exists): re-run `hermes model` (keeps the
+custom-provider routing) — *not* `hermes config set model …` (reverts to the nous catalog default).
+Verify with `/new` (model · provider · context) + a real task.
 
 ### Terminal backend
 

--- a/docs/operations/hermes-terminal-cheatsheet.md
+++ b/docs/operations/hermes-terminal-cheatsheet.md
@@ -54,8 +54,7 @@ the mirror stays clean and this won't recur.
 hermes config                                  # Show Hermes' current configuration.
 hermes config edit                             # Safely edit config.yaml (e.g. trim joke personalities).
 hermes config check                            # Validate the config after editing.
-hermes model                                   # Interactive model picker. NOTE: the built-in list is stale (offers gpt-4o-mini) — `config set model` is authoritative.
-hermes config set model openai/gpt-5.4-mini    # Set the model (provider/model). Set the matching key first (below). Restart after.
+hermes model                                   # Provider+model wizard — use THIS to switch provider/model (e.g. add a custom OpenAI endpoint, base url https://api.openai.com/v1). NOT `config set model` (reverts to the nous catalog). See hermes-control-plane.md → Model-switch playbook.
 hermes config set OPENAI_API_KEY sk-...        # Use your own key directly — no OpenRouter needed (also ANTHROPIC_API_KEY for anthropic/* models). Set on the VPS; never share.
 hermes --help                                  # Explore the rest of the Hermes CLI.
 cat ~/.hermes/SOUL.md                          # View Hermes' current base identity / operating prompt.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -30,9 +30,9 @@ living ledger (`docs/current-state.md`).
 - `claude/hopeful-allen-home-slice-c` · mining Slice C — Home structure (character-card backdrop) ·
   `disbot/{utils/mining/structures,services/mining_workflow,utils/character_render,views/mining,
   cogs/mining_cog,utils/mining/market}` + plan/numbers · 2026-06-15
-- `claude/brave-sagan-s9th8h` · Hermes context work — #913/#914/#915 MERGED + applied live;
-  follow-up: record the model/provider decision (free Nous default → own-key gpt-5.4-mini) ·
-  `hermes-control-plane` + `hermes-terminal-cheatsheet` + investigation · 2026-06-15
+- `claude/brave-sagan-s9th8h` · Hermes model saga close-out — gpt-5.4-mini CONFIRMED WORKING on
+  own OpenAI key; capture the 6-trap provider-switch playbook + correct the docs ·
+  `hermes-control-plane` + `hermes-terminal-cheatsheet` · 2026-06-15
 
 ## Recently cleared
 


### PR DESCRIPTION
Close-out of the long Hermes model-switch thread. **Docs-only.**

The owner got `gpt-5.4-mini` running on their own OpenAI key (custom OpenAI provider, `openai-api`, 400K, good output) — **but it's not yet stable:** it intermittently returns `Project … does not have access to model gpt-5.4-mini` (flapped >15 min, so not mere propagation; likely the **alias** `gpt-5.4-mini` resolving unevenly vs the **dated snapshot** `gpt-5.4-mini-2026-03-17` the project actually has granted).

- **`hermes-control-plane.md` § Model/provider** — rewritten to the accurate current state, with an explicit **⬜ NOT YET STABLE / still-needs-checking** bullet (next step: point Hermes at the exact dated id; if still flapping, pin `auxiliary.*`/`delegation`), plus a **6-trap model-switch playbook** so the next setup is 5 minutes, not 3 hours (empty `providers:{}`→nous default · prefix routing · stale built-in openai-api listing · gpt-4o-mini encrypted-content/reasoning 400 · org verification · exact-match allowlist alias-vs-dated trap).
- **`hermes-terminal-cheatsheet.md`** — corrected the misleading `config set model openai/…` line (the `openai/` prefix routes to Nous; use the `hermes model` wizard) + pointer to the playbook.

**Open item (runtime, owner-side):** verify gpt-5.4-mini stops flapping with the dated id. Tracked in the doc + session card. A fresh chat can pick up from `hermes-control-plane.md` § Model/provider.

https://claude.ai/code/session_01FwmaNQr47seoRng82Mj39E

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwmaNQr47seoRng82Mj39E)_