### PR TITLE
Hermes: retune base for gpt-5.4-mini + record verified specs (cleanup pass)

### DIFF
--- a/.sessions/2026-06-15-hermes-gpt54mini-retune.md
+++ b/.sessions/2026-06-15-hermes-gpt54mini-retune.md
@@ -29,10 +29,17 @@ capabilities.
 
 ## Findings surfaced
 
-- **Python pin drift (verified, real):** `.python-version` = **3.13.13** (Railway/prod) vs CI
-  `code-quality.yml` = **3.10**. Prod and CI run different interpreters — a genuine parity gap.
-  Hermes' memory flagged it correctly. Investigation + recommendation: see below (no change this
-  session — touches CI/prod parity).
+- **Python pin drift — investigated, ALREADY TRACKED (no action needed this session).**
+  `.python-version` = **3.13.13** (Railway/prod) vs CI `code-quality.yml` = **3.10**. Hermes'
+  memory flagged it correctly, but it is **not a hidden bug** — it is documented in
+  `operations/production-deployment.md` § "Python version" and tracked as **router Q-0085**
+  (Open, awaiting owner). History: prod has *always* run 3.13 (unpinned railpack default); the
+  `3.13.13` pin (PR #863, 2026-06-14) was a *fix* for a railpack build-race outage, not the cause
+  of the drift. CI/tooling stayed on 3.10 (pyproject `target-version = py310`, mypy
+  `python_version = 3.10`, the repo-wide `python3.10 -m` rule). **Recommendation (already on
+  record in Q-0085): option 1 — align CI/local UP to 3.13 as its own dedicated toolchain-migration
+  session, not a rider on anything.** Until then the documented drift is accepted. → This means it
+  can safely **drop from Hermes' memory** (point it at Q-0085 / production-deployment.md instead).
 
 ## Status
 

--- a/.sessions/2026-06-15-hermes-gpt54mini-retune.md
+++ b/.sessions/2026-06-15-hermes-gpt54mini-retune.md
@@ -133,6 +133,5 @@ model are re-tuned. (This is the same drift the 💡 idea above would automate.)
 ## Status
 
 All Hermes-base files reviewed (SOUL.md · control-plane · investigation · cheatsheet ·
-`apply_context_fixes.sh` · skills · memories · `hermes_cog.py`). PR #923 held **born-red** (Q-0133)
-per owner's "keep open" — flips to `complete` (→ auto-merge on green) on the owner's word; enders +
-docs audit are done, so it is merge-ready.
+`apply_context_fixes.sh` · skills · memories · `hermes_cog.py`). Enders + docs audit done. Card
+flipped to `complete` at close-out → Code Quality goes green → PR #923 auto-merges (Q-0133).

--- a/.sessions/2026-06-15-hermes-gpt54mini-retune.md
+++ b/.sessions/2026-06-15-hermes-gpt54mini-retune.md
@@ -41,6 +41,32 @@ capabilities.
   session, not a rider on anything.** Until then the documented drift is accepted. → This means it
   can safely **drop from Hermes' memory** (point it at Q-0085 / production-deployment.md instead).
 
+## Hermes memory — recommended lean set (owner applies on the VPS)
+
+The owner shared Hermes' 4 live memory entries. Per SOUL.md's own rule — *"direct memory is a tiny
+sticky note; the real memory is the repo"* — 3 of 4 duplicate SOUL.md / the `dispatch` skill /
+current-state.md and should be **deleted** (they burn context and risk drifting from the docs).
+
+**KEEP (rewritten lean — the genuinely non-repo stickies):**
+
+```
+[infra] SuperBot deploys on merge → Railway project reliable-grace / service "superbot".
+        Hermes model = gpt-5.4-mini on the owner's own OpenAI key (custom OpenAI provider,
+        base https://api.openai.com/v1). Dispatch cron job id = 8c02f8431f37.
+[rule]  Bug reports / notes go to docs/health/bug-book.md or docs/current-state.md —
+        NEVER docs/ideas/* (ideas are for genuine new features). Hermes tripped on this (#888).
+[prefs] <owner working style / nicknames only — keep here and nowhere else>
+```
+
+**DELETE (redundant with durable docs that load every session):**
+- *Dispatch bridge* → fully in the `dispatch` skill + `hermes-dispatch-bridge.md`.
+- *SuperBot memory summary* (orientation / read-path / next-action source) → all in SOUL.md.
+  Its Python-drift fact → now Q-0085 / `production-deployment.md` (see Findings above), so drop it.
+- *Overseer model* (role, born-red-PR-per-session) → SOUL.md "WHO YOU ARE" + Q-0133; only the cron
+  id was worth keeping (folded into `[infra]` above).
+- *Dispatch bridge pattern* (the four-section TASK/CONTEXT/ACCEPTANCE/NOTES + `routine_fire.py`
+  format) → verbatim in `dispatch.md` lines 65–79.
+
 ## Status
 
 Checkpoint PR opened born-red (Q-0133); flips to `complete` as the final step after the cleanup

--- a/.sessions/2026-06-15-hermes-gpt54mini-retune.md
+++ b/.sessions/2026-06-15-hermes-gpt54mini-retune.md
@@ -107,7 +107,32 @@ oversight/dispatch/review control plane uses:
 
 Cheatsheet now documents the principle + `hermes skills uninstall` (the repo only had install).
 
+## 💡 Session idea (Q-0089)
+
+**A repeatable "Hermes base hygiene" check.** This session audited Hermes' live state against the
+repo's intent **by hand** — found 79 installed skills (only ~30 relevant), 4 MEMORY.md entries that
+duplicate SOUL.md/the dispatch skill, and a stale "read-only default" USER.md entry that now
+contradicts SOUL.md. All three are *drift between Hermes' live config and the durable docs*. Idea: a
+small read-only helper/skill (`hermes-base-hygiene`) that flags this drift — e.g. "installed skills ≫
+the focused set," "a memory entry's text substring-matches SOUL.md (likely redundant)," "a USER.md
+line contradicts WHAT YOU MAY WRITE." Worth having because the base will re-drift every time bundled
+skills update or memory accretes; doing the audit by hand each time is the waste it removes.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous session = **#921** (Hermes model-swap RESOLVED). **Did well:** cleanly closed the long
+model arc and captured the genuinely-useful propagation-flap lesson (don't conclude "not propagation"
+at 15 min). **Missed / could've done better:** it confirmed the *capable* model worked but stopped
+there — it left the entire Hermes base (SOUL.md, control-plane doc, the token-efficiency
+investigation) still written defensively for the **old weak model**, so the docs actively
+contradicted the live reality until this session caught it. **System improvement:** the
+**model-switch playbook should end with a "sweep the base for old-model assumptions" step** — a model
+swap isn't done when the model answers; it's done when the prompt/docs written around the *prior*
+model are re-tuned. (This is the same drift the 💡 idea above would automate.)
+
 ## Status
 
-Checkpoint PR opened born-red (Q-0133); flips to `complete` as the final step after the cleanup
-sweep + close-out enders land.
+All Hermes-base files reviewed (SOUL.md · control-plane · investigation · cheatsheet ·
+`apply_context_fixes.sh` · skills · memories · `hermes_cog.py`). PR #923 held **born-red** (Q-0133)
+per owner's "keep open" — flips to `complete` (→ auto-merge on green) on the owner's word; enders +
+docs audit are done, so it is merge-ready.

--- a/.sessions/2026-06-15-hermes-gpt54mini-retune.md
+++ b/.sessions/2026-06-15-hermes-gpt54mini-retune.md
@@ -1,0 +1,40 @@
+# Session — Hermes retune for gpt-5.4-mini + memory/base cleanup
+
+> **Status:** `in-progress`
+
+## Goal
+
+Owner-directed, live session. Now that **gpt-5.4-mini is confirmed working** (the model arc
+#913→#921 closed), re-tune the Hermes control-plane base for the *capable* model and prune what was
+built defensively around the old weak free model (`stepfun/step-3.7-flash:free`, ~256K). Goal: a
+**cleaner base configured to the owner's wish** + a recorded understanding of gpt-5.4-mini's real
+capabilities.
+
+## What I'm doing
+
+1. **SOUL.md retune** (`hermes-operating-prompt.md`) — replace the weak-model framing
+   ("you forget after ~15 tool calls / ~256K window") with the capable-model reality (400K reasoning
+   model; bounded sessions are now a **cost + re-grounding** habit, not a weakness crutch). Fix the
+   dispatch bullet's stale "you're weaker on long loops" → the real reason (Claude Code runs the CI
+   mirror Hermes can't).
+2. **gpt-5.4-mini specs recorded** (`hermes-control-plane.md` § Model/provider) — verified
+   2026-06-15: **400K ctx / 128K out, $0.75/$4.50 per 1M, Aug-2025 cutoff, reasoning model**, +
+   `agent.reasoning_effort` tuning lever, + cost-not-window framing.
+3. **Hermes memory cleanup** (owner applies on the VPS) — the owner shared the 4 live memory
+   entries; 3 of 4 duplicate SOUL.md / the `dispatch` skill / current-state. Recommended lean
+   replacement set (infra stickies + one behavioral sticky only).
+4. **Deeper base cleanup** (in progress) — archive/demote the token-efficiency investigation doc
+   (its conclusion was "it's the model"), slim `apply_context_fixes.sh` (compaction tuning now
+   secondary to the capability fix), prune the long completed "Suggested next steps".
+
+## Findings surfaced
+
+- **Python pin drift (verified, real):** `.python-version` = **3.13.13** (Railway/prod) vs CI
+  `code-quality.yml` = **3.10**. Prod and CI run different interpreters — a genuine parity gap.
+  Hermes' memory flagged it correctly. Investigation + recommendation: see below (no change this
+  session — touches CI/prod parity).
+
+## Status
+
+Checkpoint PR opened born-red (Q-0133); flips to `complete` as the final step after the cleanup
+sweep + close-out enders land.

--- a/.sessions/2026-06-15-hermes-gpt54mini-retune.md
+++ b/.sessions/2026-06-15-hermes-gpt54mini-retune.md
@@ -67,6 +67,46 @@ current-state.md and should be **deleted** (they burn context and risk drifting 
 - *Dispatch bridge pattern* (the four-section TASK/CONTEXT/ACCEPTANCE/NOTES + `routine_fire.py`
   format) → verbatim in `dispatch.md` lines 65–79.
 
+### USER.md (the "about you / this workspace" file) — separate from MEMORY.md above
+
+The owner also shared the 8 `USER.md` entries. Mostly good (it already carries the `[infra]` +
+bug-location stickies), but:
+- **WRONG / stale — must fix:** *"default to read-only inspection unless you explicitly ask for
+  modifications."* This is the OLD safety model; SOUL.md's "WHAT YOU MAY WRITE" (Q-0140/0141/0117)
+  now lets Hermes author PRs + merge via the review gate. A wrong memory actively misleads — delete it.
+- **Conflicting:** *"capture ideas in docs/ideas/"* (alone) contradicts the bug-location entry —
+  merge into one rule: ideas → `docs/ideas/`; bugs/notes → bug-book / current-state, NEVER ideas.
+- **Redundant with SOUL.md (drop):** the oversight-rules block (sync-first, review, dispatch,
+  concise comms, reconciliation-is-automatic), the dispatch-workflow entry, and the work-order
+  grounding entry are all in SOUL.md + the `dispatch` skill.
+- **Keep:** the `[infra]` note (Railway reliable-grace/superbot · gpt-5.4-mini on owner's key · cron
+  `8c02f8431f37`) and the bug-location rule.
+
+Recommended lean USER.md: genuine owner **preferences** (concise/direct comms; owner can't code →
+relies on agents for correct end-to-end work) + the `[infra]` sticky + the merged ideas/bugs rule.
+On Hermes' offer to split into prefs / repo-conventions / runtime: yes for prefs + runtime, but
+**drop the repo-conventions** — they live in SOUL.md, which reloads every session, so memory copies
+only risk drift.
+
+## Hermes skills — prune the catalogue (79 → ~30; owner runs `hermes skills uninstall`)
+
+Skills load by progressive disclosure — the Level-0 list (all names+descriptions, ~3k+ tokens) is
+injected every turn, so 79 skills is real per-turn bloat + choice-noise. Keep only what the
+oversight/dispatch/review control plane uses:
+
+- **KEEP:** all `superbot/*` (13); `github/*` (6 — PR/issue/review/repo); `autonomous-ai-agents/`
+  claude-code · codex · hermes-agent · supervised-repo-oversight (it dispatches to these / is its
+  role); `software-development/` plan · requesting-code-review · simplify-code · systematic-debugging
+  · hermes-agent-skill-authoring.
+- **PRUNE (whole categories — nothing to do with SuperBot):** `creative/*`, `media/*`,
+  `productivity/*`, `smart-home/*`, `mlops/*`, `note-taking/*`, `social-media/*`, `data-science/*`,
+  `email/*`, `research/*`, `yuanbao`, plus `software-development/` node-inspect-debugger (SuperBot is
+  Python). ~46–50 skills.
+- **Your call:** `opencode`, `software-development/` spike · test-driven-development · python-debugpy
+  (Hermes dispatches code rather than debugging it live — lean prune).
+
+Cheatsheet now documents the principle + `hermes skills uninstall` (the repo only had install).
+
 ## Status
 
 Checkpoint PR opened born-red (Q-0133); flips to `complete` as the final step after the cleanup

--- a/.sessions/2026-06-15-hermes-gpt54mini-retune.md
+++ b/.sessions/2026-06-15-hermes-gpt54mini-retune.md
@@ -1,6 +1,6 @@
 # Session — Hermes retune for gpt-5.4-mini + memory/base cleanup
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Goal
 
@@ -133,5 +133,7 @@ model are re-tuned. (This is the same drift the 💡 idea above would automate.)
 ## Status
 
 All Hermes-base files reviewed (SOUL.md · control-plane · investigation · cheatsheet ·
-`apply_context_fixes.sh` · skills · memories · `hermes_cog.py`). Enders + docs audit done. Card
-flipped to `complete` at close-out → Code Quality goes green → PR #923 auto-merges (Q-0133).
+`apply_context_fixes.sh` · skills · memories · `hermes_cog.py`) + a gpt-5.4-mini calibration probe.
+Enders + docs audit done. Card flipped to `complete` at close-out → Code Quality green → PR #923
+auto-merges (Q-0133). Follow-up (owner, interactive): run the calibration probe + apply the
+recommended `config.yaml`.

--- a/docs/operations/hermes-control-plane.md
+++ b/docs/operations/hermes-control-plane.md
@@ -92,6 +92,16 @@ Hermes config/data paths shown during setup:
   slowly and flap on the way. **If it ever flaps again,** pin the **exact dated snapshot
   `gpt-5.4-mini-2026-03-17`** (re-run `hermes model`, set the custom provider's model to it) — the
   exact id is granted deterministically and skips the alias-propagation wait.
+- **Verified specs (gpt-5.4-mini — fetched 2026-06-15; released 2026-03-17, after the Claude build
+  cutoff, so these are from current OpenAI / aggregator sources, not model memory):** **400K context
+  / 128K max output**, **$0.75 per 1M input · $4.50 per 1M output**, **Aug 2025 knowledge cutoff**, a
+  **reasoning** model with tool calling + structured output + text/image input. The `400K (detected)`
+  Hermes reports is correct. **Tuning lever:** it honours `agent.reasoning_effort` (the param that
+  400'd the non-reasoning gpt-4o-mini) — keep it on a reasoning setting; consider raising it for the
+  *review* role and lowering it (`minimal`/`low`) for cheap high-throughput dispatch triage. **Cost
+  note:** at $4.50/1M output a long accumulating gateway session is the real spend driver (not the
+  window) — so the bounded-session / `/new`-per-task habit is now a **cost** lever, not a capability
+  crutch.
 - **Rationale (independence vs. reliability):** Hermes is deliberately a **non-Claude** mind so its
   review is independent of the Claude that builds (Q-0117). The reliability fix was *capability*, not
   *Claude* — a frontier **non-Claude** model (gpt-5.4-mini, or gpt-5.5) keeps the independence and

--- a/docs/operations/hermes-control-plane.md
+++ b/docs/operations/hermes-control-plane.md
@@ -116,6 +116,24 @@ Hermes config/data paths shown during setup:
   independence is dropped. For the **review** role specifically, a stronger model than the cheap mini
   is worth considering.
 
+#### Calibrating gpt-5.4-mini in the role (a 10-minute probe)
+
+The model is the biggest behaviour lever, so **calibrate it, don't assume it.** Run these read-only
+tasks from Telegram (fresh `/new` each) — each targets a way the old weak model failed (e.g. #888's
+invented scope). Judge against "what good looks like"; if one fails, that's the real signal to raise
+`reasoning_effort`, shorten sessions, or reconsider the model for that role.
+
+| Probe (paste to Hermes) | What good looks like |
+|---|---|
+| "Sync, then read `current-state.md` and name the next ▶ startable slice **by description**." | Actually runs the sync, opens the file, names the real lane + cites it — not a slice invented from memory (#888). |
+| "Run repo-health: `check_loop_health`, open PRs, and the ledger guard, then give ONE verdict." | Runs all three read-only checks and synthesizes — doesn't collapse/forget after 2 tool calls. |
+| "Assemble (do **not** fire) a work order for <a real slice> in the four-section format." | Exact TASK/CONTEXT/ACCEPTANCE/NOTES, real file scope, an acceptance command, **no invented PR numbers** (Q-0142). |
+| Ask about something **not** in the repo. | Says it checked and found nothing (verify-don't-assume) — does **not** confabulate a confident false answer. |
+| Watch any multi-file read. | Greps / targeted-reads sections, not whole-file dumps — the cheap-and-grounded habit SOUL.md asks for. |
+
+Record outcomes in a `.sessions/` note or here if a pattern emerges; that's how the role's model
+choice (mini vs. a stronger review model, Q-0117) gets decided on evidence rather than vibes.
+
 #### Model-switch playbook (the ~3-hour maze — so it's 5 minutes next time)
 
 Moving Hermes to a capable own-key model hit these traps, in order:

--- a/docs/operations/hermes-control-plane.md
+++ b/docs/operations/hermes-control-plane.md
@@ -102,6 +102,13 @@ Hermes config/data paths shown during setup:
   note:** at $4.50/1M output a long accumulating gateway session is the real spend driver (not the
   window) — so the bounded-session / `/new`-per-task habit is now a **cost** lever, not a capability
   crutch.
+- **Recommended `config.yaml` for gpt-5.4-mini (verify key names against the installed version —
+  Q-0105 unverified):** `agent.reasoning_effort: medium` (it **is** a reasoning model — never `none`,
+  which was only the gpt-4o-mini workaround; the review-merge role can go `high`).
+  `compression.threshold: 0.50` (the default) is fine now — on a 400K window that already leaves
+  ~200K before compaction, so the old `apply_context_fixes.sh` 0.75 bump is **optional**, not
+  required. `prompt_caching.cache_ttl: 1h` trims cost on long sessions. Pin
+  `model: gpt-5.4-mini-2026-03-17` (the dated id) **only** if the alias ever flaps again (playbook).
 - **Rationale (independence vs. reliability):** Hermes is deliberately a **non-Claude** mind so its
   review is independent of the Claude that builds (Q-0117). The reliability fix was *capability*, not
   *Claude* — a frontier **non-Claude** model (gpt-5.4-mini, or gpt-5.5) keeps the independence and

--- a/docs/operations/hermes-control-plane.md
+++ b/docs/operations/hermes-control-plane.md
@@ -373,7 +373,7 @@ cd /home/hermes/repos/superbot
 hermes gateway
 ```
 
-## Suggested next steps
+## Roadmap — what's open vs. shipped
 
 > **✅ RESOLVED (2026-06-15): token efficiency / "forgetting."** Root-caused to the **weak free model**,
 > not the window — Hermes ran on `stepfun/step-3.7-flash:free` (quantized, ~256K). Fixed by the model
@@ -382,207 +382,55 @@ hermes gateway
 > [`hermes-token-efficiency-investigation-2026-06-15.md`](hermes-token-efficiency-investigation-2026-06-15.md)
 > (now `historical`); the `compression.*` knobs remain optional secondary levers.
 
-### 1. Add SSH key login
+### Still open (infrastructure to-dos)
 
-Current access still relies on password login. Long-term, add SSH key login through Termius or another SSH client.
+- **SSH key login** — access still uses password login. Add key-based login (Termius), then disable
+  root/password SSH. Do this before the VPS becomes important infrastructure.
+- **Docker terminal backend** — Hermes runs the `local` backend today; Docker would give safer
+  command isolation (install Docker → add `hermes` to the docker group → set
+  `terminal.backend: docker` → retest from Telegram). Do it before Hermes runs heavier tooling.
+- **Backups** — not urgent, but matters once memory/skills/schedules accumulate. Targets: `~/.hermes`
+  (config + `state.db` memory) and the systemd unit; the skill/doc sources are already git-tracked.
+  Methods: Hetzner snapshot · periodic `tar`.
+- **Discord integration (later)** — Telegram stays the private control surface; a private admin/dev
+  channel could later receive repo-health / CI / review summaries. Not a priority.
 
-Recommended later state:
+### Done — items that were on this list (kept as a record)
 
-```text
-SSH key login enabled
-Root password login disabled
-Password SSH disabled if comfortable
-Termius configured with key-based login
-```
+- **Skill pack** ✅ — the read-only skills in [`hermes-skills/`](./hermes-skills/README.md) are the
+  source of truth; `scripts/hermes/build_skills.py` generates installable `SKILL.md` files and
+  `install-skills.sh` deploys them to the VPS. (Superseded the aspirational `superbot-*` skill list.)
+- **Standing operating prompt** ✅ — [`hermes-operating-prompt.md`](./hermes-operating-prompt.md) is
+  installed to `~/.hermes/SOUL.md` via `install-soul.sh` (loads fresh each message).
+- **Scheduled work** ✅ — execution runs as bounded **Claude Code routines** on the console
+  **Schedule** trigger (every 2h, Q-0146); reconciliation auto-fires at the PR-band boundary. Hermes'
+  own cron can still post read-only Telegram reports if wanted. See
+  [`autonomous-routines.md`](./autonomous-routines.md).
+- **GitHub write access** ✅ (scoped) — Hermes may now author **PRs** (docs, bug reports, small
+  self-tooling — Q-0140/Q-0141) and **merge** a PR it independently reviewed (the review-merge gate,
+  Q-0117). It never pushes to `main` and never merges outside that gate; the exact boundary is the
+  operating prompt's "WHAT YOU MAY WRITE". (Supersedes the old "keep Hermes read-only only" note.)
 
-This should be done before the VPS becomes important infrastructure.
+### Autonomous-loop seams (built 2026-06-12; dispatch now wired)
 
-### 2. Install Docker and switch Hermes to Docker backend
-
-Hermes currently uses local terminal execution. This works, but Docker would give safer command isolation.
-
-Recommended future sequence:
-
-```text
-Install Docker
-Add hermes user to docker group
-Test docker run hello-world
-Switch Hermes terminal backend to docker
-Limit container resources if supported
-Retest repo inspection from Telegram
-```
-
-This should happen before allowing Hermes to run heavier commands or experimental tooling.
-
-### 3. Create SuperBot-specific Hermes skills
-
-Create reusable Hermes skills so prompts can be shorter and behavior is more consistent.
-
-Recommended skills:
-
-```text
-superbot-repo-health
-superbot-pr-review
-superbot-doc-consistency
-superbot-ci-triage
-superbot-btd6-audit
-superbot-ai-cog-audit
-superbot-release-summary
-superbot-agent-session-briefing
-```
-
-Each skill should include:
-
-- Repo path
-- Read-only default
-- Docs to inspect first
-- Architecture boundaries
-- Required output format
-- Verification commands
-- Stop conditions
-- No production mutation rule
-
-### 4. Add scheduled reports
-
-Use Hermes cron or system-level scheduling for regular Telegram reports.
-
-Useful schedules:
-
-```text
-Daily repo health summary
-Daily failed CI check
-Weekly stale docs scan
-Weekly open plan summary
-After-merge docs consistency check
-Before-agent-session repo briefing
-```
-
-Reports should be read-only and should not modify repo files.
-
-### 5. Improve GitHub access carefully
-
-GitHub CLI is authenticated. Keep Hermes read-only for now.
-
-Possible later permissions:
-
-```text
-Read PRs/issues/checks
-Draft issue comments
-Draft PR review summaries
-Create local markdown reports
-Open draft PRs only when explicitly requested
-```
-
-Avoid for now:
-
-```text
-Auto-merge
-Direct pushes
-Repo admin permissions
-Production secret access
-Railway deploy access
-Neon database access
-Broad personal access tokens
-```
-
-### 6. Add a stable SuperBot operating prompt
-
-Create a short operating guide for Hermes that defines how it should work in this repo.
-
-Suggested contents:
-
-```text
-Repo path
-Default branch
-No-edit default
-Architecture docs to read first
-Decision vs analysis boundaries
-Affected-system reporting format
-Migration/test/docs verification expectations
-How to classify risks and ownership
-```
-
-This can either be a Hermes skill, a repo doc, or both.
-
-### 7. Add Discord integration later
-
-Telegram is the best private control surface. Discord can be added later for SuperBot ecosystem visibility.
-
-Potential Discord use cases:
-
-```text
-Post repo health summaries
-Post CI failure alerts
-Post PR review summaries
-Post docs drift reports
-Support private admin/dev channel workflows
-```
-
-Keep Discord restricted to a private admin/dev channel.
-
-### 8. Add backup strategy
-
-Backups are not urgent yet, but they become important after adding custom Hermes skills, memory, or schedules.
-
-Recommended backup targets:
-
-```text
-/home/hermes/.hermes
-/home/hermes/repos/superbot/docs/operations/hermes-control-plane.md
-custom skills
-systemd service file
-```
-
-Possible backup methods:
-
-```text
-Hetzner backup
-manual snapshot
-git-tracked skill/docs files
-periodic tar archive
-```
-
-## Recommended next project phase
-
-The next best phase is not more infrastructure. The next best phase is a **SuperBot Hermes skill pack**.
-
-Goal:
-
-```text
-Make Hermes consistently useful for SuperBot repo review, doc consistency checks, PR summaries, CI triage, and agent-session preparation while preserving a read-only default.
-```
-
-This gives the highest value with the lowest risk because it improves behavior without giving Hermes broader write or production access.
-
-**The skill pack has been implemented** — see [`hermes-skills/`](./hermes-skills/README.md)
-for the ready-to-use skill prompts. They are now **scripted to install**: the docs are the
-source of truth, `scripts/hermes/build_skills.py` generates installable `SKILL.md` files,
-and `scripts/hermes/install-skills.sh` copies them onto the VPS. A standing read-only
-operating prompt (step 6 below) is implemented as
-[`hermes-operating-prompt.md`](./hermes-operating-prompt.md).
-
-### Autonomous-loop seams (built 2026-06-12)
-
-Three repo-side seams of the autonomous-improvement loop now exist (owner decisions
-Q-0113/Q-0114), keeping Hermes read-only while letting it review and dispatch:
+Three repo-side seams keep Hermes safe while letting it review and dispatch (Q-0113/Q-0114):
 
 - **`superbot-review`** — independent (non-Claude) critique of a plan or PR diff, with a
   plain-language maintainer summary for the approve/deny gate.
 - **`scripts/check_phase_gate.py`** — the fix-phase vs. invent-phase signal (agent-originated
   features stay gated until correctness is done).
-- **`superbot-dispatch`** + **[`hermes-dispatch-bridge.md`](./hermes-dispatch-bridge.md)** — turn
-  a work order into a Claude Code Routine `/fire` call. **Maintainer wiring required** (Routine +
-  token) before it can fire; see the runbook's ⬜ steps. The merge gate is full self-merge on
-  green CI (Q-0113); agent-originated features open a PR and wait for your approve/deny (Q-0114).
+- **`superbot-dispatch`** + [`hermes-dispatch-bridge.md`](./hermes-dispatch-bridge.md) — turns a
+  work order into a Claude Code Routine `/fire` call. **Now wired** via the console **Schedule**
+  trigger (every 2h, Q-0146) — no longer pending maintainer setup. Merge gate: self-merge on green
+  CI (Q-0113); agent-originated features open a PR and wait for your approve/deny (Q-0114).
 
-### Next sanctioned capability: read-only log triage
+### Read-only log triage — shipped
 
-The highest-value graduation from "repo assistant" to "operations assistant" is letting
-Hermes **read production logs** and diagnose problems — without granting any write/deploy
-power. This stays inside the safety model: it is look-but-don't-touch.
+Letting Hermes **read production logs** to diagnose problems (look-but-don't-touch) is live:
 
-- The [`log-triage`](./hermes-skills/log-triage.md) skill is ready; it triages the
-  VPS-local `hermes-gateway` logs today and the production (Railway) logs once a
-  **read-only** Railway token + CLI is set up on the VPS.
-- A Neon read-only role can follow the same pattern for DB-level checks.
-- Operating production (restart / redeploy / scale) remains a maintainer action.
+- The [`log-triage`](./hermes-skills/log-triage.md) skill + the `scripts/hermes/log_triage.py`
+  analyzer (content-free, redacted, deterministic — #906) triage the VPS-local `hermes-gateway`
+  logs today and Railway production logs via `scripts/hermes/railway_logs.py`. **Remaining gate:**
+  the read-only Railway token on the VPS (owner-provisioned).
+- A Neon read-only role can follow the same pattern for DB-level checks. Operating production
+  (restart / redeploy / scale) remains a maintainer action.

--- a/docs/operations/hermes-control-plane.md
+++ b/docs/operations/hermes-control-plane.md
@@ -375,11 +375,12 @@ hermes gateway
 
 ## Suggested next steps
 
-> **▶ Owner-prioritized next (2026-06-15): token efficiency.** Hermes `/status` showed **2.2M
-> cumulative tokens "re-sent each call"** after only a few messages (~8–9× the working window) →
-> context collapse by the 3rd–4th tool call. Root cause + investigation questions + candidate fixes
-> (stateless bounded dispatch · history cap · `soul.md` injection strategy) are captured in
-> [`hermes-token-efficiency-investigation-2026-06-15.md`](hermes-token-efficiency-investigation-2026-06-15.md).
+> **✅ RESOLVED (2026-06-15): token efficiency / "forgetting."** Root-caused to the **weak free model**,
+> not the window — Hermes ran on `stepfun/step-3.7-flash:free` (quantized, ~256K). Fixed by the model
+> swap to the capable 400K `gpt-5.4-mini` on the owner's own key (§ Model/provider; arc #913→#921). The
+> diagnosis (compaction at 50%, not unbounded growth) is kept in
+> [`hermes-token-efficiency-investigation-2026-06-15.md`](hermes-token-efficiency-investigation-2026-06-15.md)
+> (now `historical`); the `compression.*` knobs remain optional secondary levers.
 
 ### 1. Add SSH key login
 

--- a/docs/operations/hermes-operating-prompt.md
+++ b/docs/operations/hermes-operating-prompt.md
@@ -47,8 +47,8 @@ WHAT YOU MAY WRITE (Q-0140, Q-0141)
 - You may author changes through PRs (CI-gated): docs, bug reports, work summaries, new skill
   sources, and CODE — including your own small self-tooling (e.g. dispatch helpers like
   scripts/hermes/routine_fire.py).
-- For BIG or risky code changes, prefer to DISPATCH to Claude Code: it is the primary builder,
-  runs under the full CI mirror, and you yourself are weaker on long 20+-tool-call loops. Write
+- For BIG or risky code changes, prefer to DISPATCH to Claude Code: it is the primary builder and
+  runs under the full CI mirror (black/mypy/pytest on Python 3.10) that you cannot run here. Write
   code directly when it is small, self-contained, and you can verify it; otherwise hand it off.
 - Merge a PR you have independently reviewed (the review-merge gate, Q-0117) — once calibrated.
 
@@ -61,13 +61,17 @@ THE REPO
     git -C /home/hermes/repos/superbot fetch origin main && git -C /home/hermes/repos/superbot checkout -B main origin/main
   THEN read.
 
-WORK IN BOUNDED STEPS — you lose the thread on long sessions, so design around it
-- ONE finite objective per session, with a clear done-condition. If a task balloons past ~15-20
-  tool calls or sprawls across many subsystems, STOP: dispatch the big part to Claude Code, or
-  hand me a crisp checkpoint with a single recommended next step. Never spin in place.
-- Watch your context window (~256K). A long-running session re-sends a huge history and you START
-  FORGETTING — when /status shows cumulative tokens approaching the window, finish up and tell me
-  to /new. Prefer a fresh short session per task over one sprawling one.
+WORK IN BOUNDED SESSIONS — to stay cheap and well-grounded (not because you're weak)
+- You run on gpt-5.4-mini: a capable 400K-context reasoning model. You CAN carry a real
+  multi-step task without losing the thread — the old "you forget after ~15 tool calls" was the
+  weak free model and no longer applies.
+- Still keep ONE finite objective per session with a clear done-condition — for COST and GROUNDING,
+  not capability: the gateway re-sends history every turn (spend grows fast), and a fresh session
+  re-reads the repo instead of trusting stale memory. Finish a task, then /new; don't sprawl across
+  unrelated objectives or spin in place.
+- Compaction still fires at ~50% of the 400K window (prunes big tool outputs) — but that's ~200K of
+  headroom, ample for our docs. On a long session, re-read the plan/folio where you act on it, and
+  /new when /status shows cumulative tokens climbing toward the window.
 - DON'T REINVENT. Before building anything: fetch main, then grep scripts/ + the skill pack +
   current-state to see if it already exists. Reuse the existing helper (e.g.
   scripts/hermes/routine_fire.py) — never write your own copy of something already there.

--- a/docs/operations/hermes-terminal-cheatsheet.md
+++ b/docs/operations/hermes-terminal-cheatsheet.md
@@ -86,6 +86,21 @@ infra ids) — procedures belong in SOUL.md + the skills, which reload every ses
   memory entirely. There is **no** `hermes` CLI subcommand that deletes a memory by content — use the
   conversational `memory` tool or a hand-edit.
 
+## Hermes skills — keep the set focused
+
+Skills load by **progressive disclosure**: every turn the agent sees a Level-0 list of *all*
+installed skills' names + descriptions (~3k+ tokens), and only loads a skill's full body on demand.
+So a bloated catalog costs context **and** adds choice-noise on every message — keep Hermes to the
+skills its SuperBot control-plane role uses (the `superbot/*` pack + the github / repo / review /
+dispatch skills). The bundled non-SuperBot skills (creative / media / productivity / smart-home /
+mlops / note-taking / social-media / etc.) are safe to remove and re-installable later.
+
+```bash
+hermes skills list                       # What's installed.
+hermes skills uninstall <skill-name>     # Remove one (or `/skills uninstall <name>` in chat).
+bash scripts/hermes/install-skills.sh    # (Re)install the SuperBot skill pack from the repo.
+```
+
 ## Repo state & health (read-only)
 
 ```bash

--- a/docs/operations/hermes-terminal-cheatsheet.md
+++ b/docs/operations/hermes-terminal-cheatsheet.md
@@ -61,6 +61,31 @@ cat ~/.hermes/SOUL.md                          # View Hermes' current base ident
 ls ~/.hermes/skills/                           # List the skills Hermes has installed.
 ```
 
+## Hermes memory (built-in — plain-text markdown)
+
+Hermes' persistent memory is two files under `~/.hermes/memories/`, loaded into the system prompt as
+a **frozen snapshot at session start** — so an edit takes effect on the next `/new`, never mid-session:
+
+- `MEMORY.md` — the agent's own notes (~2,200 char / ~800 token cap).
+- `USER.md` — owner profile / preferences (~1,375 char / ~500 token cap).
+
+```bash
+cat ~/.hermes/memories/MEMORY.md            # View what Hermes remembers (its own notes).
+cat ~/.hermes/memories/USER.md              # View the owner-profile memory.
+cp ~/.hermes/memories/MEMORY.md ~/.hermes/memories/MEMORY.md.bak   # Back up before any hand-edit.
+nano ~/.hermes/memories/MEMORY.md           # Hand-edit (allowed, but not the intended path; mind the char cap).
+```
+
+**Intended way — let Hermes edit its own memory.** It has a `memory` tool (add / replace / remove by
+substring), so in Telegram just instruct it plainly (e.g. *"Remove your memory entry 'Dispatch bridge
+pattern'; keep only …"*), then `/new` so it reloads. Keep memory to **stickies only** (owner prefs,
+infra ids) — procedures belong in SOUL.md + the skills, which reload every session anyway.
+
+- `/memory pending` · `/memory approve <id>` · `/memory reject <id>` — staged-write approval, **only**
+  relevant if `write_approval: true` in `config.yaml` (off by default). `memory_enabled` toggles
+  memory entirely. There is **no** `hermes` CLI subcommand that deletes a memory by content — use the
+  conversational `memory` tool or a hand-edit.
+
 ## Repo state & health (read-only)
 
 ```bash

--- a/docs/operations/hermes-token-efficiency-investigation-2026-06-15.md
+++ b/docs/operations/hermes-token-efficiency-investigation-2026-06-15.md
@@ -1,10 +1,13 @@
 # Hermes token-efficiency — investigation + fix plan (tomorrow's focus)
 
-> **Status:** `plan` — owner-prioritized (2026-06-15, captured fresh from the live failure).
-> **Investigation half is now DONE** — see "## Findings (verified against Hermes source/docs)" at the
-> bottom; the four "investigate first" questions are answered and the root cause is corrected
-> (it is **compaction**, not unbounded growth). The *fix* is still not approved to build.
-> Home: the Hermes control plane ([`hermes-control-plane.md`](hermes-control-plane.md)).
+> **Status:** `historical` — RESOLVED 2026-06-15. The investigation is complete (findings at the
+> bottom: the root cause is **compaction**, not unbounded growth), and the *fix* turned out to be the
+> **model swap** — moving Hermes off the weak free `stepfun/step-3.7-flash:free` tier to the capable
+> 400K `gpt-5.4-mini` on the owner's own key (arc #913→#921). On a 400K window, 50% compaction leaves
+> ~200K of headroom, so the "doc-read-gets-pruned" failure is largely gone; the `compression.*` knobs
+> (and `apply_context_fixes.sh`) remain **optional secondary levers**, no longer the primary fix. Kept
+> as the record of the diagnosis. Home: the Hermes control plane
+> ([`hermes-control-plane.md`](hermes-control-plane.md) § Model/provider).
 
 ## The smoking gun (observed live 2026-06-14/15)
 

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -101,4 +101,9 @@ living ledger (`docs/current-state.md`).
 - `claude/trusting-goldberg-po4p7s` · CI-cost reduction + duplicate-work convention (Q-0126) ·
   concurrency-cancel + pip/mypy caching + claim ledger + push-batching · 2026-06-14 · **#814 (merged)**
 
+- `claude/laughing-curie-f45zyu` · Hermes retune for gpt-5.4-mini + base/memory cleanup
+  (SOUL.md capability re-tune · verified model specs · memory prune recs · investigation-doc
+  archive · `apply_context_fixes.sh` slim) · `docs/operations/hermes-*` + `scripts/hermes/` ·
+  2026-06-15 · **PR (open, born-red per Q-0133)**
+
 _(move claims here with their PR # as they close, then prune older entries)_

--- a/scripts/hermes/apply_context_fixes.sh
+++ b/scripts/hermes/apply_context_fixes.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 # Apply the recommended Hermes context-management fixes on the control-plane VPS.
 #
-# WHY: Hermes "forgets / misunderstands / loses the thread" because its gateway
+# STATUS (2026-06-15): OPTIONAL / secondary. The root cause of the "forgetting" was the weak free
+# model, fixed by switching Hermes to the capable 400K gpt-5.4-mini (arc #913->#921). On a 400K
+# window the 50% compaction leaves ~200K headroom, so these compaction knobs are no longer the
+# primary fix — keep them only as a marginal tuning lever, not a required step. See
+# docs/operations/hermes-control-plane.md § Model/provider.
+#
+# WHY (original diagnosis): Hermes "forgets / misunderstands / loses the thread" because its gateway
 # COMPACTS context at 50% of the model window — it summarizes the middle of the
 # conversation and DELETES tool outputs larger than ~200 chars. SuperBot's docs are
 # large, so even a short, clearly-directed session can cross 50% on the FIRST doc


### PR DESCRIPTION
**Born-red** (Q-0133 — the `in-progress` session card holds the merge gate until the cleanup sweep + close-out land). Owner-directed live session.

## Why

The model arc (#913→#921) confirmed **gpt-5.4-mini live and working** on the owner's own OpenAI key. But almost the entire Hermes doc/tooling base was written *defensively* around the **old weak free model** (`stepfun/step-3.7-flash:free`, quantized, ~256K). This pass re-tunes the base for the *capable* model and starts pruning the workarounds that no longer apply.

## This commit (checkpoint)

- **`hermes-operating-prompt.md` (SOUL.md source) — retuned for the capable model:**
  - `WORK IN BOUNDED STEPS — you lose the thread` → `WORK IN BOUNDED SESSIONS — to stay cheap and well-grounded (not because you're weak)`. The "you forget after ~15 tool calls / ~256K window" framing is replaced: gpt-5.4-mini is a 400K reasoning model that *can* carry a real multi-step task; bounded sessions are now justified by **cost + re-grounding**, not weakness.
  - The dispatch bullet's "you yourself are weaker on long 20+-tool-call loops" → the accurate reason: Claude Code runs the **full CI mirror Hermes can't run**.
- **`hermes-control-plane.md` § Model/provider — verified specs recorded:** 400K ctx / 128K out, $0.75/$4.50 per 1M, Aug-2025 cutoff, reasoning model; the `agent.reasoning_effort` tuning lever; cost-not-window framing.

## Still to land on this branch (born-red until done)

- Hermes **memory prune** recommendations (3 of 4 live entries duplicate SOUL.md / the `dispatch` skill — owner applies on the VPS).
- Archive/demote the **token-efficiency investigation** doc (its conclusion was "it's the model").
- Slim **`apply_context_fixes.sh`** (compaction tuning now secondary to the capability fix).
- Prune the long completed **"Suggested next steps"** in the control-plane doc.
- **Investigate + recommend** the verified Python pin drift (`.python-version` 3.13.13 vs CI 3.10) — no change this session.

https://claude.ai/code/session_01VKtm6YmQxhqDGVGLHj8pmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtm6YmQxhqDGVGLHj8pmL)_