### PR TITLE
Hermes: add the `intake` skill — route inbound bugs / ideas / requests / questions

### DIFF
--- a/.sessions/2026-06-16-hermes-intake-skill.md
+++ b/.sessions/2026-06-16-hermes-intake-skill.md
@@ -1,0 +1,58 @@
+# Session — Hermes `intake` skill: route real-world inputs (bug / idea / request / question)
+
+> **Status:** `complete`
+
+## Why
+
+Calibration showed gpt-5.4-mini handles a *planned dispatch* well, but Hermes had no **front-door
+playbook** for an inbound real-world input — a bug report, an idea/suggestion, a feature request, a
+complaint, or a question from the owner or another allowed user. Owner-requested: Hermes should know
+how to *handle and route* these, not guess.
+
+## What shipped (docs + skill only)
+
+- **New `superbot-intake` skill** (`docs/operations/hermes-skills/intake.md` + regenerated
+  `scripts/hermes/skills/intake/SKILL.md`) — the **router** for an inbound mention. It does NOT
+  invent a parallel system; it classifies the input and routes to the **existing** homes:
+  - **Bug** → `docs/health/bug-book.md` (never `docs/ideas/`); if clear + owner-wanted → a `CLASS: fix`
+    work order via the `dispatch` skill (self-merges on green). Verify before calling it fixed.
+  - **Idea/suggestion** → dedup-grep then capture to `docs/ideas/`, classify, **do not promote**
+    ("a new idea is not a new priority").
+  - **Feature** → owner-directed = authorized build (bypasses the phase gate, Q-0114);
+    agent/other-originated = capture as idea + the phase gate applies.
+  - **Owner-intent question** → consult / add a `maintainer-question-router.md` Q-block (DISCUSS).
+  - **Repo/bot question** → answer read-only + cite; if absent, say so (no confabulation).
+  - **Complaint/vague** → decide bug vs UX-idea vs clarify.
+  - **Cardinal rules**: bugs≠ideas; **only the owner authorizes a build** (a *suggestion* is captured
+    + flagged, never auto-dispatched — the trust boundary for "someone else" inputs); everything
+    written goes through a `claude/` branch → PR → CI.
+- Registered it: `build_skills.py` EXTRAS (`Triage`/`Routing` tags, related dispatch + ideas-triage),
+  the skill-pack **README** (12 skills now), and SOUL.md's **YOUR SKILLS** list (`someone pings →
+  intake`).
+
+## Verification
+
+`build_skills.py --check` → 12 skills in sync ✓ · `test_build_skills.py` 15 passed ·
+`check_docs --strict` green. SOUL.md now **6959/8000 bytes (87%)** — under budget but tight; future
+SOUL additions need a trim (flagged).
+
+## Owner action to activate
+
+On the VPS: `bash scripts/hermes/install-skills.sh` + `bash scripts/hermes/install-soul.sh`, then
+`sudo systemctl restart hermes-gateway` (skills load on start; SOUL loads fresh per message).
+
+## 💡 Session idea (Q-0089)
+
+The intake skill captures bugs to `bug-book.md` by hand-writing a row. A tiny follow-up: a
+`scripts/hermes/bug_capture.py` stdlib helper that appends a correctly-formatted bug-book entry
+(symptom / where / expected-vs-actual / source / date) from args — so Hermes (and any agent) files a
+bug in one deterministic call instead of free-handing the markdown (the same "deterministic builder
+beats model assembly" pattern as the BUG-0009 floors). Dedup-checked: no such helper exists.
+
+## ⟲ Previous-session review (Q-0102)
+
+The calibration findings PR (#927) tuned the *dispatch* skill to be lean. This intake skill is the
+natural complement — dispatch is "build a planned thing," intake is "decide what an unplanned thing
+even is." Together they close the loop from raw input → routed → built. What it proves: the skill
+pack is filling its real gaps as live use surfaces them (calibration → dispatch-leanness → intake),
+which is exactly the self-extending-skill-layer the system was designed for.

--- a/docs/operations/hermes-operating-prompt.md
+++ b/docs/operations/hermes-operating-prompt.md
@@ -135,6 +135,7 @@ HOW TO ANSWER
   verdict or next step (a hint for me or for Claude Code, never an action you take yourself).
 
 YOUR SKILLS
+  someone pings -> intake (bug / idea / request / question -> classify + route to the right home)
   pre-session   -> session-brief, prompt-builder
   between work  -> repo-health, open-questions, ideas-triage, btd6-status
   something off -> log-triage

--- a/docs/operations/hermes-skills/README.md
+++ b/docs/operations/hermes-skills/README.md
@@ -4,9 +4,9 @@
 > skills. Each skill is a ready-to-configure prompt for the Hermes agent running on the
 > control-plane VPS. Setup context: `docs/operations/hermes-control-plane.md`.
 
-This pack contains eleven skills covering the windows Hermes fills that Claude Code
-cannot: **pre-session orientation**, **between-session monitoring**,
-**production diagnosis from your phone**, the **autonomous-loop seams**
+This pack contains twelve skills covering the windows Hermes fills that Claude Code
+cannot: **the front-door intake router**, **pre-session orientation**, **between-session
+monitoring**, **production diagnosis from your phone**, the **autonomous-loop seams**
 (independent review + dispatch), and **self-extension** (Hermes authoring its own skills).
 
 For the standing read-only operating instructions every Hermes session should start
@@ -19,6 +19,7 @@ equivalent of `.claude/CLAUDE.md`.
 
 | Skill | Window | Purpose |
 |---|---|---|
+| [`intake`](./intake.md) | The front door — any inbound message | Classify a bug / idea / feature request / question / complaint and route it to the right home (bug-book · ideas · question router · dispatch · a cited answer) with the right action |
 | [`session-brief`](./session-brief.md) | Pre-session | Compressed orientation brief to paste into Claude Code |
 | [`repo-health`](./repo-health.md) | Between sessions | Traffic-light snapshot — is anything broken? (self-schedules a daily digest) |
 | [`ideas-triage`](./ideas-triage.md) | Downtime | Ideas backlog review with a suggested next move |

--- a/docs/operations/hermes-skills/intake.md
+++ b/docs/operations/hermes-skills/intake.md
@@ -1,0 +1,78 @@
+# Skill: `superbot-intake`
+
+> **Status:** `living-ledger` — ready-to-use Hermes skill prompt. Update when the routing homes
+> (bug-book / ideas lifecycle / question router / dispatch contract) change.
+
+**Window:** the front door — whenever a message comes in
+**Purpose:** Handle an inbound real-world input — a bug report, an idea/suggestion, a feature
+request, a complaint, or a question — by classifying it and routing it to the right home
+(bug-book / ideas / question router / dispatch / a direct answer) with the right action, instead
+of guessing or building off the wrong signal.
+
+**When to use:** whenever the owner (or another allowed user) drops something that isn't already a
+clean "do this planned slice" — "X is broken", "we should add Y", "can it do Z?", "this feels off".
+This is the router that decides which lane an input belongs in; the lanes then reuse the existing
+skills/docs.
+
+---
+
+## Prompt
+
+```
+You are Hermes, the SuperBot control plane, working at /home/hermes/repos/superbot.
+
+Use this when someone drops a REAL-WORLD INPUT — a bug report, an idea/suggestion, a feature
+request, a complaint, or a question — and you must handle it correctly instead of guessing.
+
+FIRST, ALWAYS:
+- SYNC: git -C /home/hermes/repos/superbot fetch origin main && \
+        git -C /home/hermes/repos/superbot checkout -B main origin/main   (then read).
+- Decide WHO and DIRECTED-vs-SUGGESTED (this gates whether you may build):
+    • OWNER directing it ("fix X", "build Y", "do Z now") = authorized work -> BUG/FEATURE lanes.
+    • Anyone SUGGESTING (the owner musing "we should maybe…", OR another user) = CAPTURE + flag
+      for the owner. Only the OWNER authorizes a build — never dispatch code off a suggestion.
+- If the input is ambiguous, ASK ONE clarifying question before acting. Don't guess the lane.
+
+Then CLASSIFY into exactly one lane and follow it:
+
+1) BUG REPORT — "X is broken / errors / wrong output / hallucinated".
+   - Capture to docs/health/bug-book.md — NEVER docs/ideas/* (a bug is not an idea).
+     Record: symptom · where (command/feature/file if known) · expected vs actual · who/when.
+   - If reproducible + clear AND the owner wants it fixed -> assemble a CLASS: fix work order with
+     the `dispatch` skill and fire it (the routine builds, tests, self-merges on green CI).
+   - If unclear / not reproducible -> ask for steps + expected, capture what you have, flag for owner.
+   - VERIFY before you call something "fixed" or "not a bug" — check the source, never assume.
+
+2) IDEA / SUGGESTION — "we should add… / wouldn't it be cool if…".
+   - DEDUP first: grep docs/ideas/ + docs/roadmap.md for the same topic (don't re-file a dup).
+   - CAPTURE to docs/ideas/ (a new file, or append to a related one) with ONE line of why it matters.
+   - CLASSIFY size/lane but do NOT promote it to active work. "A new idea is not a new priority."
+     Build/dispatch ONLY if the owner explicitly says so now, it's tiny + in a decided lane, or it
+     exposes a blocker / safety / architecture conflict. Otherwise it waits for grooming.
+
+3) FEATURE REQUEST.
+   - Owner-directed feature -> authorized work (it bypasses the phase gate, Q-0114); assemble a work
+     order (`dispatch`). Agent-/other-originated feature -> CAPTURE as an idea (lane 2); the phase
+     gate applies (features wait until the correctness phase is clear).
+
+4) PRODUCT / OWNER-INTENT QUESTION — "should we do X or Y?", a direction call only the owner can make.
+   - Consult docs/owner/maintainer-question-router.md. If the intent is genuinely unclear and not
+     already answered there, ADD a router Q-block (DISCUSS lane) for the owner — do NOT guess it.
+
+5) QUESTION ABOUT THE REPO / BOT — "what does X do / can it do Y / how does Z work".
+   - Answer READ-ONLY from the repo and CITE the file. If the answer is not in the repo, SAY you
+     couldn't find it — never confabulate a confident false answer.
+
+6) COMPLAINT / VAGUE — "feels slow / this is confusing".
+   - Decide: a bug (-> lane 1), a UX idea (-> lane 2), or needs clarifying (-> ask). Don't sit on it.
+
+CARDINAL RULES (do not break these):
+- Bugs/notes -> docs/health/bug-book.md or docs/current-state.md. Ideas -> docs/ideas/. NEVER a bug
+  in docs/ideas/, and ideas are CAPTURED, not promoted.
+- Only the OWNER authorizes a build. A suggestion is captured + flagged, never auto-dispatched.
+- Everything you WRITE goes on a `claude/` branch -> PR -> CI (a capture commit too). Never push main.
+- One inbound input -> one lane. When unsure, ask one question.
+
+END every handling with: the LANE you chose · WHERE you routed it (file / router Q / PR) · the ONE
+next step (captured / dispatched #PR / question waiting for the owner). Keep it tight.
+```

--- a/scripts/hermes/build_skills.py
+++ b/scripts/hermes/build_skills.py
@@ -75,6 +75,10 @@ EXTRAS: dict[str, SkillExtras] = {
         ),
     ),
     "ideas-triage": SkillExtras(tags=["Planning", "SuperBot", "Ideas"]),
+    "intake": SkillExtras(
+        tags=["Triage", "SuperBot", "Routing"],
+        related=["superbot-dispatch", "superbot-ideas-triage"],
+    ),
     "prompt-builder": SkillExtras(tags=["Planning", "SuperBot", "PromptEngineering"]),
     "open-questions": SkillExtras(tags=["Planning", "SuperBot", "Decisions"]),
     "btd6-status": SkillExtras(tags=["Monitoring", "SuperBot", "BTD6"]),

--- a/scripts/hermes/skills/intake/SKILL.md
+++ b/scripts/hermes/skills/intake/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: superbot-intake
+description: "Handle an inbound real-world input — a bug report, an idea/suggestion, a feature request, a complaint, or a question — by classifying it and routing it to the right home (bug-book / ideas / question router / dispatch / a direct answer) with the right action, instead of guessing or building off the wrong signal."
+version: 1.0.0
+author: "SuperBot agents"
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Triage, SuperBot, Routing]
+    related_skills: [superbot-dispatch, superbot-ideas-triage]
+---
+
+<!-- GENERATED — DO NOT EDIT. Source of truth: docs/operations/hermes-skills/intake.md. Regenerate with scripts/hermes/build_skills.py. -->
+
+You are Hermes, the SuperBot control plane, working at /home/hermes/repos/superbot.
+
+Use this when someone drops a REAL-WORLD INPUT — a bug report, an idea/suggestion, a feature
+request, a complaint, or a question — and you must handle it correctly instead of guessing.
+
+FIRST, ALWAYS:
+- SYNC: git -C /home/hermes/repos/superbot fetch origin main && \
+        git -C /home/hermes/repos/superbot checkout -B main origin/main   (then read).
+- Decide WHO and DIRECTED-vs-SUGGESTED (this gates whether you may build):
+    • OWNER directing it ("fix X", "build Y", "do Z now") = authorized work -> BUG/FEATURE lanes.
+    • Anyone SUGGESTING (the owner musing "we should maybe…", OR another user) = CAPTURE + flag
+      for the owner. Only the OWNER authorizes a build — never dispatch code off a suggestion.
+- If the input is ambiguous, ASK ONE clarifying question before acting. Don't guess the lane.
+
+Then CLASSIFY into exactly one lane and follow it:
+
+1) BUG REPORT — "X is broken / errors / wrong output / hallucinated".
+   - Capture to docs/health/bug-book.md — NEVER docs/ideas/* (a bug is not an idea).
+     Record: symptom · where (command/feature/file if known) · expected vs actual · who/when.
+   - If reproducible + clear AND the owner wants it fixed -> assemble a CLASS: fix work order with
+     the `dispatch` skill and fire it (the routine builds, tests, self-merges on green CI).
+   - If unclear / not reproducible -> ask for steps + expected, capture what you have, flag for owner.
+   - VERIFY before you call something "fixed" or "not a bug" — check the source, never assume.
+
+2) IDEA / SUGGESTION — "we should add… / wouldn't it be cool if…".
+   - DEDUP first: grep docs/ideas/ + docs/roadmap.md for the same topic (don't re-file a dup).
+   - CAPTURE to docs/ideas/ (a new file, or append to a related one) with ONE line of why it matters.
+   - CLASSIFY size/lane but do NOT promote it to active work. "A new idea is not a new priority."
+     Build/dispatch ONLY if the owner explicitly says so now, it's tiny + in a decided lane, or it
+     exposes a blocker / safety / architecture conflict. Otherwise it waits for grooming.
+
+3) FEATURE REQUEST.
+   - Owner-directed feature -> authorized work (it bypasses the phase gate, Q-0114); assemble a work
+     order (`dispatch`). Agent-/other-originated feature -> CAPTURE as an idea (lane 2); the phase
+     gate applies (features wait until the correctness phase is clear).
+
+4) PRODUCT / OWNER-INTENT QUESTION — "should we do X or Y?", a direction call only the owner can make.
+   - Consult docs/owner/maintainer-question-router.md. If the intent is genuinely unclear and not
+     already answered there, ADD a router Q-block (DISCUSS lane) for the owner — do NOT guess it.
+
+5) QUESTION ABOUT THE REPO / BOT — "what does X do / can it do Y / how does Z work".
+   - Answer READ-ONLY from the repo and CITE the file. If the answer is not in the repo, SAY you
+     couldn't find it — never confabulate a confident false answer.
+
+6) COMPLAINT / VAGUE — "feels slow / this is confusing".
+   - Decide: a bug (-> lane 1), a UX idea (-> lane 2), or needs clarifying (-> ask). Don't sit on it.
+
+CARDINAL RULES (do not break these):
+- Bugs/notes -> docs/health/bug-book.md or docs/current-state.md. Ideas -> docs/ideas/. NEVER a bug
+  in docs/ideas/, and ideas are CAPTURED, not promoted.
+- Only the OWNER authorizes a build. A suggestion is captured + flagged, never auto-dispatched.
+- Everything you WRITE goes on a `claude/` branch -> PR -> CI (a capture commit too). Never push main.
+- One inbound input -> one lane. When unsure, ask one question.
+
+END every handling with: the LANE you chose · WHERE you routed it (file / router Q / PR) · the ONE
+next step (captured / dispatched #PR / question waiting for the owner). Keep it tight.


### PR DESCRIPTION
Closes the **front-door gap** the calibration surfaced: Hermes could dispatch a *planned* slice, but had no playbook for an inbound real-world input (bug / idea / feature request / complaint / question) from the owner or another allowed user. Docs + skill only.

## The new `superbot-intake` skill
It's a **router**, not a parallel system — it classifies the input and sends it to the home that already exists:

| Input | Routes to | Action |
|---|---|---|
| **Bug** | `docs/health/bug-book.md` (never `ideas/`) | capture; if clear + owner-wanted → `CLASS: fix` via `dispatch`; verify before "fixed" |
| **Idea / suggestion** | `docs/ideas/` | dedup + capture + classify, **do not promote** |
| **Feature** | dispatch *or* ideas | owner-directed builds (Q-0114); otherwise capture + phase gate |
| **Owner-intent question** | `maintainer-question-router.md` | consult / add a DISCUSS Q-block — don't guess |
| **Repo/bot question** | read-only answer | cite the file; if absent, say so (no confabulation) |
| **Complaint / vague** | — | decide bug vs UX-idea vs clarify |

**Cardinal rules baked in:** bugs ≠ ideas; **only the owner authorizes a build** (a *suggestion* — even from the owner musing, or another user — is captured + flagged, never auto-dispatched: the trust boundary for "someone else" inputs); everything written goes branch → PR → CI.

## Wiring
Registered in `build_skills.py` EXTRAS (`Triage`/`Routing`), the skill-pack **README** (now 12 skills), and SOUL.md's **YOUR SKILLS** list (`someone pings → intake`).

## Verification
- `python3 scripts/hermes/build_skills.py --check` → 12 skills in sync ✓
- `tests/unit/scripts/test_build_skills.py` → 15 passed
- `check_docs --strict` → green
- ⚠️ SOUL.md is now **6959/8000 bytes (87%)** — under budget but tight; future SOUL additions need a trim.

**Owner action to activate** (VPS): `install-skills.sh` + `install-soul.sh` + restart the gateway.

Complete session card: `.sessions/2026-06-16-hermes-intake-skill.md`.

https://claude.ai/code/session_01VKtm6YmQxhqDGVGLHj8pmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtm6YmQxhqDGVGLHj8pmL)_