### PR TITLE
Hermes ops docs: lean-env filter how-to + Honcho evaluation + open-steps findability

### DIFF
--- a/.sessions/2026-06-16-hermes-ops-docs-honcho.md
+++ b/.sessions/2026-06-16-hermes-ops-docs-honcho.md
@@ -1,0 +1,38 @@
+# Session — Hermes ops docs: lean-filter how-to · Honcho eval · open-steps findability
+
+> **Status:** `complete`
+
+Owner-requested follow-ups from the live Hermes setup/calibration session. Docs/ideas only.
+
+## What shipped
+
+1. **Lean-filter technique documented** (`hermes-terminal-cheatsheet.md`, new "Lean a config of empty
+   placeholders" section). The owner asked to keep this reusable: the `grep -E '^[A-Z_0-9]+=.+'`
+   filter strips blank `NAME=` placeholders from a flat env file while preserving every set value
+   (incl. a custom `OPENAI_BASE_URL` the model depends on) — locally, secrets never leaving the box.
+   With the back-up + name-only review steps, and the "don't hand-trim CLI-managed `config.yaml`"
+   caveat. (Came out of leaning the owner's `~/.hermes/.env`, which had ~15 empty tool placeholders.)
+2. **Honcho evaluated → captured as an idea** (`docs/ideas/honcho-memory-evaluation-2026-06-16.md` +
+   README index). Verdict: **not for the Hermes control plane** (its memory is deliberately a sticky
+   note; the repo is the real memory), but a possible **Someday** option for the bot's per-user AI
+   personalization (V-04, gated on Q-0082). Routed via the new `intake` skill's idea lane (dogfood).
+3. **Open-steps findability** (`hermes-control-plane.md` § Still open): pulled the **read-only Railway
+   token** (log-triage gate) up into the open-steps list where it belongs (was buried in the
+   capability note), and corrected the now-stale "Discord integration (later)" item — the **gateway
+   is live** (owner chats with Hermes on Discord); only auto-*posting* summaries remains optional.
+
+`check_docs --strict` green.
+
+## 💡 Session idea (Q-0089)
+
+A `scripts/hermes/lean_env.py` (or a one-liner alias) that wraps the env lean-filter with a built-in
+**safety allow-list** — it refuses to write the new file if a required key (`OPENAI_API_KEY` /
+`OPENAI_BASE_URL` / the gateway tokens) didn't survive the filter, so a custom-provider var can never
+be silently dropped. Turns the "review before mv" manual step into a guard. Small, stdlib, disposable.
+
+## ⟲ Previous-session review (Q-0102)
+
+The intake skill (#928, prior PR this session) immediately earned its keep: the Honcho input was
+routed through its exact "idea → evaluate → capture, don't promote" lane here. What it proves: the
+front-door router and the idea/bug homes compose — a real inbound ("is Honcho worth it?") flowed
+cleanly to a captured, classified idea file instead of a chat message that evaporates.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -20,6 +20,10 @@ during grooming** (it stays listed here, annotated ✅) so the active backlog re
 
 Current broad captures:
 
+- [`honcho-memory-evaluation-2026-06-16.md`](./honcho-memory-evaluation-2026-06-16.md) —
+  **evaluated (2026-06-16):** Honcho external agent-memory — **not** for the Hermes control plane
+  (its memory is deliberately a sticky note; the repo is the real memory), but a possible **Someday**
+  option for the bot's per-user AI personalization (V-04), gated on the AI spend ceiling (Q-0082).
 - [`executor-chain-trigger-via-workflow-2026-06-15.md`](./executor-chain-trigger-via-workflow-2026-06-15.md) —
   **session idea (2026-06-15, Q-0089, from the eval-coverage 34/34 run; owner live concern):** the
   executor's STEP 3 self-chaining is unreliable because a `continue` issue opened by a routine *session*

--- a/docs/ideas/honcho-memory-evaluation-2026-06-16.md
+++ b/docs/ideas/honcho-memory-evaluation-2026-06-16.md
@@ -1,0 +1,44 @@
+# Idea: Honcho external memory — evaluated; not for Hermes (maybe the bot's AI someday)
+
+> **Status:** `ideas` — captured + evaluated 2026-06-16 (owner asked "is Honcho worth looking into?", seen in
+> the Hermes env as `HONCHO_API_KEY` → `honcho_context`). Verdict: **not a fit for the Hermes control
+> plane**; a possible future option for the **bot's** per-user AI memory. Routed here per the `intake`
+> skill (idea → capture + classify, don't promote).
+
+## What Honcho is
+
+Honcho (Plastic Labs, open-source) is an agent **memory / social-cognition layer**: it models each
+participant as a "peer" and **extracts conclusions** from conversations/events (not just chunks to
+match later), exposing a `honcho_context` *representation document* with insights about a peer in a
+session — quick to inject into a prompt without an extra LLM round-trip. Strong long-memory benchmarks
+(LongMem-S ~90%, LoCoMo, BEAM) at a **median ~5% of the context budget**. Hermes ships it as one of
+its ~8 external memory providers.
+
+## Why it's NOT for Hermes (the control plane)
+
+- Hermes' memory need is deliberately **tiny** — owner prefs + infra stickies + one behavioural rule
+  (just cleaned to `MEMORY.md` / `USER.md`). SOUL.md's own rule: *"direct memory is a sticky note; the
+  real memory is the repo"* (`current-state.md`, `.sessions/`, the docs). A user-modelling layer is
+  overkill for an agent whose whole job is reading a thoroughly-documented repo.
+- It adds an external dependency + API key + latency/cost to model **one owner** (and a few allowed
+  users) — exactly the kind of unused integration the 2026-06-16 lean-base pass was *removing*.
+- Hermes cron runs `skip_memory=True`, and upstream issue #9763 blocks external memory providers in
+  the cron path anyway — so it would not help the routine/dispatch loop.
+
+## Where it COULD fit (future — the BOT, not Hermes)
+
+If SuperBot's **AI cog** ever wants genuine **per-user memory / personalization** (remembering a
+Discord user's preferences and history across conversations — the V-04 "per-user preferences" vision
+item), Honcho-style conclusion-extraction memory is the right *shape*: far better than dumping history
+into the prompt (Plastic Labs' own benchmark shows a full-haystack context drops Haiku 4.5 ~27 pts vs
+an oracle). That's an **AI-lane product decision**, gated on the AI spend ceiling (Q-0082), not a
+Hermes setup step.
+
+## Disposition
+
+- **Hermes:** no action — keep the built-in `MEMORY.md` / `USER.md`.
+- **Bot AI memory:** parked as a **Someday** option for the AI lane; revisit only if/when per-user
+  personalization is prioritized.
+
+Sources: [honcho.dev](https://honcho.dev/) · [plastic-labs/honcho](https://github.com/plastic-labs/honcho) ·
+the Hermes memory-providers doc.

--- a/docs/operations/hermes-control-plane.md
+++ b/docs/operations/hermes-control-plane.md
@@ -438,16 +438,23 @@ hermes gateway
 
 ### Still open (infrastructure to-dos)
 
+- **Read-only Railway access (log triage) — the planned "next capability".** The
+  [`log-triage`](./hermes-skills/log-triage.md) skill + `scripts/hermes/railway_logs.py` can read
+  **production** logs once a **read-only Railway token** (+ the Railway CLI) is provisioned on the VPS.
+  This is the documented graduation from *repo* assistant to *ops* assistant — look-but-don't-touch,
+  no write/deploy power. (Also see "Read-only log triage" below for the full capability note.)
 - **SSH key login** — access still uses password login. Add key-based login (Termius), then disable
   root/password SSH. Do this before the VPS becomes important infrastructure.
 - **Docker terminal backend** — Hermes runs the `local` backend today; Docker would give safer
   command isolation (install Docker → add `hermes` to the docker group → set
-  `terminal.backend: docker` → retest from Telegram). Do it before Hermes runs heavier tooling.
+  `terminal.backend: docker` → retest). Do it before Hermes runs heavier tooling.
 - **Backups** — not urgent, but matters once memory/skills/schedules accumulate. Targets: `~/.hermes`
   (config + `state.db` memory) and the systemd unit; the skill/doc sources are already git-tracked.
   Methods: Hetzner snapshot · periodic `tar`.
-- **Discord integration (later)** — Telegram stays the private control surface; a private admin/dev
-  channel could later receive repo-health / CI / review summaries. Not a priority.
+- **Discord automated reports (optional)** — the Discord **gateway is live** (you chat with Hermes
+  there now); what's still optional is having it auto-*post* repo-health / CI / review summaries to a
+  private admin channel (the `repo-health` / `review-merge` skill blueprints can `deliver` there).
+  Low priority.
 
 ### Done — items that were on this list (kept as a record)
 

--- a/docs/operations/hermes-terminal-cheatsheet.md
+++ b/docs/operations/hermes-terminal-cheatsheet.md
@@ -61,6 +61,26 @@ cat ~/.hermes/SOUL.md                          # View Hermes' current base ident
 ls ~/.hermes/skills/                           # List the skills Hermes has installed.
 ```
 
+## Lean a config of empty placeholders (the `=.+` filter)
+
+Tools like Hermes write a `.env` listing **every** var they recognise, most left blank. To strip the
+empty placeholders and keep only what's actually set — values intact, secrets never leaving the box,
+never pasted into a chat:
+
+```bash
+cp ~/.hermes/.env ~/.hermes/.env.bak                              # ALWAYS back up first.
+grep -E '^[A-Z_0-9]+=.+' ~/.hermes/.env.bak > ~/.hermes/.env.new  # keep only KEY=VALUE lines that HAVE a value.
+grep -oE '^[A-Z_0-9]+=' ~/.hermes/.env.new                        # review kept KEY NAMES (no values) — confirm nothing essential dropped.
+mv ~/.hermes/.env.new ~/.hermes/.env                              # swap in once verified (cp the .bak back to undo).
+```
+
+`^[A-Z_0-9]+=.+` keeps any line with a non-empty value and drops blank `NAME=` placeholders, so it
+**cannot lose a set value** (e.g. a custom `OPENAI_BASE_URL` the model depends on). Works on any flat
+`KEY=VALUE` env file. Always run the `grep -oE '^…='` review step before `mv` to confirm the model
+key + gateway tokens survived. **Do NOT** hand-trim a CLI-managed `config.yaml` this way — that one is
+a full settings schema; change it with `hermes config set` and leave the rest (its size is defaults,
+not clutter).
+
 ## Hermes memory (built-in — plain-text markdown)
 
 Hermes' persistent memory is two files under `~/.hermes/memories/`, loaded into the system prompt as


### PR DESCRIPTION
Owner-requested follow-ups from the live Hermes setup/calibration session. Docs/ideas only.

- **Lean-filter how-to** (`hermes-terminal-cheatsheet.md`) — the reusable `grep '^[A-Z_0-9]+=.+'` technique to strip empty placeholders from any flat env file while keeping every set value (incl. a custom `OPENAI_BASE_URL`), locally, secrets never leaving the box. With backup + name-only review steps and the "don't hand-trim CLI-managed `config.yaml`" caveat.
- **Honcho evaluated → captured as an idea** (`docs/ideas/honcho-memory-evaluation-2026-06-16.md`) — verdict: not for the Hermes control plane (its memory is deliberately a sticky note; the repo is the real memory); a possible Someday option for the bot's per-user AI memory (V-04, gated on Q-0082). Routed via the new `intake` skill's idea lane.
- **Open-steps findability** (`hermes-control-plane.md` § Still open) — surfaced the read-only Railway token (log-triage gate) into the open-steps list (was buried), and corrected the stale "Discord integration (later)" item (the gateway is live; only auto-posting summaries remains optional).

`check_docs --strict` green.

https://claude.ai/code/session_01VKtm6YmQxhqDGVGLHj8pmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtm6YmQxhqDGVGLHj8pmL)_