### PR TITLE
fix(deathmatch): stop the 1v1 challenge timer on accept/decline (BUG-0013)

### DIFF
--- a/.sessions/2026-06-16-fix-deathmatch-challenge-timer.md
+++ b/.sessions/2026-06-16-fix-deathmatch-challenge-timer.md
@@ -1,0 +1,60 @@
+# Session — fix BUG-0013: deathmatch 1v1 challenge timer overwrites the live duel
+
+> **Status:** `complete`
+
+## Origin — the intake pipeline working end to end
+
+The owner reported a bug to **Hermes** (gpt-5.4-mini) on Discord: the 1v1 deathmatch challenge
+accept-timer kept running while a match was active and clobbered the result with "player didn't
+respond in time". Hermes' new **`intake` skill** (shipped #928 earlier this session) routed it as a
+bug, did genuine root-cause analysis against the real source, pinpointed `_ChallengeView` in
+`deathmatch_cog.py`, and offered to bug-book it. This session is Claude Code **verifying that
+diagnosis and fixing it** — the full reported-bug → Hermes-triage → Claude-fix loop, live.
+
+## The bug (verified against source — Hermes was right)
+
+`_ChallengeView` (the accept/decline pre-match prompt) is created with `timeout=30.0`, but:
+- `btn_accept()` starts the real `_DuelView` yet **never called `self.stop()`**,
+- `btn_decline()` also never stopped the view,
+- `on_timeout()` had **no guard** for an already-answered challenge.
+
+So the challenge view lived on; when its 30s timeout fired it edited its message — the *same* message
+now showing the duel — to "⚔️ Challenge Expired". `_DuelView` was never the problem (it guards on
+`duel.is_over`).
+
+## Fix
+
+`disbot/cogs/deathmatch_cog.py`:
+- `__init__`: add a `_resolved` flag.
+- `btn_accept` / `btn_decline`: set `_resolved = True` + call `self.stop()` (cancels the pending
+  timeout — the duel owns the message lifecycle now).
+- `on_timeout`: return early when `_resolved` (belt-and-suspenders for the race where the timeout was
+  already firing). Behaviour-preserving for the genuine no-answer case.
+
+Contained to `_ChallengeView` — no signature changes, blast radius 2 modules (per the context map),
+neither affected.
+
+## Verification
+
+- `tests/unit/cogs/test_deathmatch_challenge_timeout.py` (NEW, 3 tests) — accept/decline stop the
+  view + guard a late `on_timeout`; an un-answered challenge still expires. All fail against the old
+  code, pass against the fix.
+- `python3.10 scripts/check_quality.py --full` → green (9893 passed).
+- `python3.10 scripts/check_architecture.py --mode strict` → 0 new (only pre-existing `xp` warnings).
+- Bug-book entry **BUG-0013** added (FIXED, regression test named).
+
+## 💡 Session idea (Q-0089)
+
+A lightweight AST invariant for Discord views: **any `discord.ui.View` with a finite `timeout=` whose
+button handlers transition to another view must call `self.stop()` (or set a resolved-guard).** This
+exact class — a stale timed view overwriting its successor — is easy to reintroduce and invisible to
+existing tests. A `test_timed_views_stop_on_resolution.py` guard would catch the next one. (Captured;
+not built — would need careful AST scoping to avoid false positives.)
+
+## ⟲ Previous-session review (Q-0102)
+
+The whole session built the Hermes base + the `intake` skill; this is the **first time it paid off in
+a real fix** — the owner reported a bug, the intake skill triaged it correctly, and it became a clean
+fixed bug here. What it proves: the front-door router + bug-book + Claude-fix chain composes exactly
+as designed. The one gap it surfaced (the idea above) is that the *bot's own view code* lacked an
+invariant for this timer-lifecycle class — worth a guard so the fix stays fixed.

--- a/disbot/cogs/deathmatch_cog.py
+++ b/disbot/cogs/deathmatch_cog.py
@@ -265,6 +265,12 @@ class _ChallengeView(discord.ui.View):
         self.duel_key = duel_key
         self.ctx = ctx
         self.message: discord.Message | None = None
+        # Set once the challenge is accepted or declined. accept/decline also
+        # call self.stop() (which cancels the timeout), but this flag guards the
+        # race where on_timeout() was already firing — so a stale 30s challenge
+        # timer can never overwrite the live (or finished) duel message with an
+        # "expired" notice.
+        self._resolved = False
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         if interaction.user != self.opponent:
@@ -276,6 +282,10 @@ class _ChallengeView(discord.ui.View):
         return True
 
     async def on_timeout(self) -> None:
+        # The challenge was already accepted/declined — the duel now owns the
+        # message, so the expired-challenge notice must not clobber it.
+        if self._resolved:
+            return
         for item in self.children:
             item.disabled = True  # type: ignore[attr-defined]
         embed = discord.Embed(
@@ -291,6 +301,7 @@ class _ChallengeView(discord.ui.View):
 
     @discord.ui.button(label="✅ Accept", style=discord.ButtonStyle.green)
     async def btn_accept(self, interaction: discord.Interaction, _: discord.ui.Button):
+        self._resolved = True
         for item in self.children:
             item.disabled = True  # type: ignore[attr-defined]
         # Both fighters bring their equipped combat gear (guild-scoped) into the
@@ -333,9 +344,15 @@ class _ChallengeView(discord.ui.View):
             view=duel_view,
         )
         duel_view.message = await interaction.original_response()
+        # Cancel this challenge view's 30s timeout — the duel owns the message
+        # lifecycle now (and _DuelView has its own turn timeout). Without this
+        # the stale challenge timer fires mid/post-match and overwrites the duel
+        # with "Challenge Expired".
+        self.stop()
 
     @discord.ui.button(label="❌ Decline", style=discord.ButtonStyle.danger)
     async def btn_decline(self, interaction: discord.Interaction, _: discord.ui.Button):
+        self._resolved = True
         for item in self.children:
             item.disabled = True  # type: ignore[attr-defined]
         embed = discord.Embed(
@@ -344,6 +361,9 @@ class _ChallengeView(discord.ui.View):
             color=discord.Color.greyple(),
         )
         await interaction.response.edit_message(embed=embed, view=self)
+        # Challenge resolved — stop the view so its timeout can't later fire and
+        # replace this "Declined" notice with an "Expired" one.
+        self.stop()
 
 
 class Deathmatch(commands.Cog):

--- a/docs/health/bug-book.md
+++ b/docs/health/bug-book.md
@@ -10,6 +10,35 @@
 > he hasn't formalized yet (see current-state 2026-06-10 standing invite) land
 > here as they surface.
 
+## BUG-0013 — 1v1 challenge timer keeps running after accept, overwrites the live duel — FIXED
+
+- **Symptom (owner-reported via Hermes, 2026-06-16):** "there is a problem with
+  the deathmatch cog, the 1v1 vs player command accept timer seems to keep
+  running while a match is active, and even when a match is completed it will
+  default to 'player didn't respond in time etc'." The accept/decline challenge
+  prompt's 30-second timer kept firing after the challenge was answered, replacing
+  the live (or already-finished) duel message with "⚔️ Challenge Expired — did
+  not respond in time."
+- **Affected surface:** `_ChallengeView` in `disbot/cogs/deathmatch_cog.py` (the
+  accept/decline pre-match view). `_DuelView` was never the problem — it already
+  guards on `duel.is_over`.
+- **Root cause:** `_ChallengeView` is created with `timeout=30.0`, but
+  `btn_accept()` (which starts the real `_DuelView`) and `btn_decline()` **never
+  called `self.stop()`**, and `on_timeout()` had **no guard** for an
+  already-answered challenge. So the challenge view lived on in the background;
+  when its timeout fired, `on_timeout()` edited its message — the *same* message
+  that now showed the duel — to the expired notice.
+- **Fix (this PR):** `btn_accept`/`btn_decline` set a `_resolved` flag and call
+  `self.stop()` (which cancels the pending timeout); `on_timeout()` returns early
+  when `_resolved` (belt-and-suspenders for the race where the timeout was already
+  firing). **Diagnosis credit:** the Hermes `intake` skill (gpt-5.4-mini)
+  root-caused this correctly from the live report — its first real bug, end to
+  end.
+- **Regression test:** `tests/unit/cogs/test_deathmatch_challenge_timeout.py` —
+  accept and decline stop the view + guard a late `on_timeout`; an un-answered
+  challenge still expires (no regression).
+- **Status:** FIXED.
+
 ## BUG-0012 — counting staff check trusts role *names*, not permissions (privilege bypass) — FIXED
 
 - **Symptom (owner-reported, 2026-06-14):** "you could give yourself a role

--- a/tests/unit/cogs/test_deathmatch_challenge_timeout.py
+++ b/tests/unit/cogs/test_deathmatch_challenge_timeout.py
@@ -1,0 +1,126 @@
+"""Regression — the 1v1 ``_ChallengeView`` 30s timer must stop on accept/decline.
+
+Owner-reported via Hermes (2026-06-16): the deathmatch "challenge a player" view's
+30-second timeout kept running after the challenge was accepted, so when it fired
+it overwrote the live (or already-finished) duel message with
+``"⚔️ Challenge Expired — did not respond in time"``.
+
+Root cause: ``btn_accept``/``btn_decline`` never called ``self.stop()`` and
+``on_timeout`` had no guard, so the stale challenge view lived on in the
+background. Fix: accept/decline set ``_resolved`` + call ``self.stop()``, and
+``on_timeout`` returns early when ``_resolved``. ``_DuelView`` was never the
+problem (it guards on ``duel.is_over``).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+
+def _player(id_: int = 100, name: str = "Player") -> SimpleNamespace:
+    return SimpleNamespace(id=id_, display_name=name, mention=f"<@{id_}>", bot=False)
+
+
+def _challenge_view():
+    from cogs.deathmatch_cog import _ChallengeView
+
+    cog = MagicMock()
+    cog.active_duels = {}
+    challenger = _player(100, "Challenger")
+    opponent = _player(200, "Opponent")
+    ctx = MagicMock()
+    ctx.guild = SimpleNamespace(id=1)
+    view = _ChallengeView(cog, challenger, opponent, (1, 100, 200), ctx)
+    view.message = AsyncMock()  # the original challenge message
+    return view, cog, opponent
+
+
+def _button(view: discord.ui.View, prefix: str) -> discord.ui.Button:
+    return next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and (c.label or "").startswith(prefix)
+    )
+
+
+def _stub_interaction(user: SimpleNamespace) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = user
+    interaction.guild_id = 0
+    interaction.response = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.original_response = AsyncMock(return_value=AsyncMock())
+    return interaction
+
+
+@pytest.mark.asyncio
+async def test_decline_stops_view_and_guards_timeout():
+    view, _cog, opponent = _challenge_view()
+
+    await _button(view, "❌").callback(_stub_interaction(opponent))  # type: ignore[union-attr]
+
+    assert view._resolved is True
+    assert view.is_finished(), "decline must stop the view so the timeout is cancelled"
+
+    # A timeout that races through anyway must NOT overwrite the declined message.
+    view.message.reset_mock()
+    await view.on_timeout()
+    view.message.edit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_accept_stops_view_and_guards_timeout():
+    view, cog, opponent = _challenge_view()
+
+    from utils import equipment
+
+    with (
+        patch(
+            "cogs.deathmatch_cog.db.get_equipment",
+            new_callable=AsyncMock,
+            return_value={},
+        ),
+        patch(
+            "cogs.deathmatch_cog.equipment.compute_stats",
+            return_value=equipment.EffectiveStats(),
+        ),
+        patch(
+            "services.settings_resolution.resolve_value",
+            new_callable=AsyncMock,
+            return_value=60,
+        ),
+    ):
+        await _button(view, "✅").callback(_stub_interaction(opponent))  # type: ignore[union-attr]
+
+    assert view._resolved is True
+    assert view.is_finished(), "accept must stop the view so the timeout is cancelled"
+    assert view.duel_key in cog.active_duels, "accept registers the active duel"
+
+    # The exact reported bug: the stale challenge timer must NOT clobber the
+    # live duel message with an "expired" notice.
+    view.message.reset_mock()
+    await view.on_timeout()
+    view.message.edit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_timeout_still_expires_when_unresolved():
+    """No regression: an un-answered challenge still expires after 30s."""
+    view, _cog, _opponent = _challenge_view()
+
+    await view.on_timeout()
+
+    view.message.edit.assert_called_once()
+    embed = view.message.edit.call_args.kwargs["embed"]
+    assert embed.title == "⚔️ Challenge Expired"


### PR DESCRIPTION
## The first real bug caught by the Hermes `intake` pipeline 🎯

The owner reported a bug to **Hermes** (gpt-5.4-mini) on Discord; the new **`intake` skill** (#928) routed it as a bug, root-caused it against the real source, and pinpointed `_ChallengeView`. This PR is Claude Code **verifying that diagnosis and fixing it** — the full reported-bug → Hermes-triage → Claude-fix loop, live.

## The bug (BUG-0013, verified against source)
The 1v1 deathmatch challenge accept-timer kept running after the challenge was answered, so when its 30s timeout fired it overwrote the live (or finished) duel message with *"⚔️ Challenge Expired — did not respond in time."*

`_ChallengeView` (`disbot/cogs/deathmatch_cog.py`) is created with `timeout=30.0`, but:
- `btn_accept()` starts the real `_DuelView` yet **never called `self.stop()`**,
- `btn_decline()` also never stopped the view,
- `on_timeout()` had **no guard** for an already-answered challenge.

So the challenge view lived on; its timeout edited its message — the *same* one now showing the duel — to the expired notice. `_DuelView` was never the problem (it guards on `duel.is_over`).

## Fix
- `__init__`: add a `_resolved` flag.
- `btn_accept` / `btn_decline`: set `_resolved` + call `self.stop()` (cancels the pending timeout).
- `on_timeout`: return early when `_resolved` (belt-and-suspenders for the already-firing race).

Behaviour-preserving for the genuine no-answer case; contained to `_ChallengeView` (no signature changes).

## Verification
- `tests/unit/cogs/test_deathmatch_challenge_timeout.py` (NEW, 3 tests) — accept/decline stop the view + guard a late `on_timeout`; an un-answered challenge still expires. Fail against old code, pass against the fix.
- `python3.10 scripts/check_quality.py --full` → green (9893 passed).
- `python3.10 scripts/check_architecture.py --mode strict` → 0 new.
- Bug-book **BUG-0013** added (FIXED, regression test named).

**Merge ≠ deploy** — this needs a production deploy (auto-deploys on merge to `main` via Railway) before the live duel is fixed.

https://claude.ai/code/session_01VKtm6YmQxhqDGVGLHj8pmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtm6YmQxhqDGVGLHj8pmL)_