### PR TITLE
docs(journal): durable lessons from the security-tiers session

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -54,6 +54,7 @@ project state accumulate here.)
 | **Postgres down** (fresh container / after resume) | Re-run the **Runbook** bring-up recipe — idempotent (`PG_VERSION` check skips re-initdb). |
 | **Run CI locally before push** | `python3.10 scripts/check_quality.py --full` (true CI mirror) **and** `python3.10 scripts/check_architecture.py --mode strict` (0 errors). Docs touched? `python3.10 scripts/check_docs.py --strict` — CI runs **--strict** (badge/reachability issues hard-fail there but pass plain `check_docs`; bit PR #685). |
 | **Kill a running bot** | `for pid in $(pgrep -f disbot/bot1); do [ "$(cat /proc/$pid/comm)" = python3.10 ] && kill "$pid"; done` (plain `pkill` self-kills the shell). |
+| **Run a script in `disbot/`** | Do it from the repo root with absolute paths or `python3.10 -c "import sys; sys.path.insert(0,'disbot'); …"`. **NEVER `cd disbot`** — the persisted cwd breaks the root-relative PreToolUse hooks and dead-locks all Bash+Write for the turn (Boot & environment §, 2026-06-15). |
 | **Prod down (Railway build failed)** | Read the build log first. `mise … no precompiled python found` = the Python-pin race → [`docs/operations/production-deployment.md`](docs/operations/production-deployment.md) (pin + bump procedure). Postgres "Online" ≠ bot running. |
 | **Orient** (start of session) | **`git fetch origin main` + skim `git log HEAD..origin/main --oneline` FIRST** — the container clone can lag live `main`; a concurrent agent may have merged your exact task (cost a full duplicate recon pass 2026-06-13, #804). **Check open PRs' _health_** (`list_pull_requests` + each one's CI/mergeable state), not just titles — a red/stuck/redundant PR is a bugs-first item to fix or close (Q-0125; #766 sat red + #771 redundant for ~21h, missed by sessions *and* reconciliation). And **a manual session does NOT run the Q-0107 reconciliation pass** — routines do it automatically; the `Recon: DUE` banner is for them (Q-0124). Do the work you were started for. |
 | **Start of work** (first push) | **Open the session PR immediately — READY, not draft** (Q-0052 open-early + Q-0103 ready-not-draft; *corrected 2026-06-12*) — the real PR # is then available for every doc you touch. |
@@ -351,6 +352,23 @@ PR #676; drift surfaced at boot + `!btd6 status`). Full note:
   "maintainer tests on prod" once hid the local boot path entirely.
 - **`services.runtime.BOOT_ID`** = the process/session id; filter live logs by it to
   separate real bot errors from test-fixture pollution in `bot.log`.
+- **★ NEVER `cd` into a subdirectory in the Bash tool — it can hard-deadlock the whole
+  session (2026-06-15).** The PreToolUse hooks (`.claude/settings.json`) invoke their
+  scripts with a **repo-root-relative** path (`python3.10 scripts/claude_pre_edit.py`,
+  `python3.10 scripts/check_branch_freshness.py`). The Bash tool's cwd **persists across
+  calls**, so a single `cd disbot && …` (e.g. to run an import smoke-test) leaves cwd in
+  `disbot/`; from there the hooks resolve `disbot/scripts/…`, which doesn't exist →
+  FileNotFound → the hook *blocks* — and now **every Bash AND Write/Edit is dead** for the
+  rest of the turn (Write has the same relative-path hook). It cleared only on the next
+  turn (the harness reset cwd). **Avoidance:** never `cd` into a subdir — run from the repo
+  root with absolute paths or `python3.10 -c "import sys; sys.path.insert(0,'disbot'); …"`.
+  **Recovery if you're already stuck:** your uncommitted work is on disk but Bash/Write are
+  blocked — spawn a **`worktree`-isolated Agent**, have it `cd /home/user/superbot` (its
+  hooks resolve correctly from the main root) and commit+push your branch so the work is
+  durable, then finish once the cwd resets. (Proposed durable fix: make the hooks use
+  `$CLAUDE_PROJECT_DIR/scripts/…` — router Q-block, since hooks aren't self-edited per
+  Q-0106.)
+
 
 ### CI & quality gates
 - **When hand-running the auto-fixers, run `black` LAST (2026-06-14).** `ruff check --fix` adds
@@ -359,6 +377,14 @@ PR #676; drift surfaced at boot + `!btd6 status`). Full note:
   `python3.10 scripts/check_quality.py` (it sequences them). New `scripts/*.py` are exempt from T201
   (`print()` is allowed there per `pyproject.toml` per-file-ignores) but still must pass black/isort/
   ruff — `tests/` are fully excluded from the formatters in CI.
+- **Check the PR's file count before declaring done — a surprising number means stray noise (2026-06-15).**
+  `git diff --name-only main...HEAD | wc -l` should match your mental model of the change. A recovery
+  step once ran `black disbot/ tests/`, which reformatted ~300 unrelated `tests/` files (CI **excludes
+  `tests/` from black**, so they were never black-clean) and committed them into a feature PR — a
+  321-file diff for a 22-file change. Caught + reverted via `git checkout main -- <spurious files>`.
+  Two habits: **never run `black`/`isort` over `tests/`** (only `disbot/` is in CI's formatter scope),
+  and **eyeball the changed-file list before the final push** — a clean, reviewable diff is part of the
+  deliverable, not an afterthought.
 - **A doc claim that mirrors code state must be CI-backed, or stamped as a snapshot — never refreshed
   by per-session human discipline (owner-derived 2026-06-02, Q-0132).** At 10–40 PRs/day a "update the
   docs every session" rule is *structurally guaranteed to lose*, and it manufactures the dangerous

--- a/.sessions/2026-06-16-journal-session-lessons.md
+++ b/.sessions/2026-06-16-journal-session-lessons.md
@@ -1,0 +1,29 @@
+# Session — journal: durable lessons from the security-tiers session
+
+> **Status:** `complete`
+
+**Owner-directed (in-session):** after the security-tiers-1-2 session (PR #929),
+the owner asked me to document the lessons I judged valuable so a future session
+can follow them. Docs-only — `.session-journal.md` (the cross-session memory).
+
+## What changed
+Added three lean, high-value entries to `.session-journal.md`:
+1. **Boot & environment — the cwd-deadlock trap** (★): never `cd` into a subdir
+   in the Bash tool; the persisted cwd breaks the repo-root-relative PreToolUse
+   hooks and dead-locks all Bash+Write for the turn. Includes the avoidance
+   (absolute paths / `python3.10 -c` from root) and the recovery (worktree-agent
+   commit to preserve work). The durable fix (hooks → `$CLAUDE_PROJECT_DIR`) is a
+   proposed router Q-block, since hooks aren't self-edited (Q-0106).
+2. **Quick-reference row** pointing at the above.
+3. **CI & quality gates — check the PR file count before declaring done**: never
+   run `black`/`isort` over `tests/` (CI excludes it), and eyeball
+   `git diff --name-only main...HEAD | wc -l` so a clean diff is part of the
+   deliverable.
+
+These are the genuine, non-duplicative takeaways; the softer "house habits"
+(mirror the nearest shipped analog, reconcile the order against live state, defer
+to a fresh reconciliation / the review gate) are already covered by CLAUDE.md +
+the collaboration model, so I did not re-state them.
+
+**Verification:** `check_docs.py --strict` green; journal is `.md` (excluded from
+formatters/mypy).


### PR DESCRIPTION
## Why

Owner-directed in-session: after the security-tiers-1-2 session (PR #929), record the lessons worth keeping so a future session can follow them. Docs-only → `.session-journal.md` (the cross-session working memory).

## What

Three lean, non-duplicative entries:
1. **Boot & environment — the cwd-deadlock trap** (★): never `cd` into a subdir in the Bash tool — the persisted cwd breaks the repo-root-relative PreToolUse hooks and dead-locks all Bash + Write/Edit for the turn. Includes the avoidance (absolute paths / `python3.10 -c` from root) and the recovery (a `worktree`-isolated Agent commit to preserve uncommitted work). Durable fix (hooks → `$CLAUDE_PROJECT_DIR`) noted as a proposed router Q-block (Q-0106: hooks aren't self-edited).
2. A **Quick-reference row** pointing at it.
3. **CI & quality gates — check the PR file count before declaring done**: never run `black`/`isort` over `tests/` (CI excludes it from the formatters), and eyeball `git diff --name-only main...HEAD | wc -l` so a clean, reviewable diff is part of the deliverable.

The softer "house habits" already live in CLAUDE.md + the collaboration model, so they're not re-stated here.

`check_docs.py --strict` green; docs-only (no `disbot/`). Session card born `complete` (one-shot change).

https://claude.ai/code/session_01FSzvBVXJR7quqt9rVAFjHj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSzvBVXJR7quqt9rVAFjHj)_