### PR TITLE
ideas: re-file Honcho as a bot / AI-lane idea (per-user AI memory)

### DIFF
--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -28,9 +28,11 @@ Current broad captures:
   fact has one home and can't contradict itself; optional `check_docs` lint that the pointer stays a
   pointer. → relates `docs/operations/autonomous-routines.md` · Q-0135.
 - [`honcho-memory-evaluation-2026-06-16.md`](./honcho-memory-evaluation-2026-06-16.md) —
-  **evaluated (2026-06-16):** Honcho external agent-memory — **not** for the Hermes control plane
-  (its memory is deliberately a sticky note; the repo is the real memory), but a possible **Someday**
-  option for the bot's per-user AI personalization (V-04), gated on the AI spend ceiling (Q-0082).
+  **bot / AI-lane idea (2026-06-16, owner wants to look into soon):** give SuperBot's AI **per-user
+  memory** — remember a Discord user across conversations (V-04) — via Honcho-style
+  conclusion-extraction memory (better + cheaper than dumping raw history; matters under the Q-0082
+  spend ceiling). Evaluated for Hermes first and rejected there (now a footnote) — it's a **bot**
+  idea, not a Hermes one. Next: promote to a `docs/planning/` plan when the AI lane has capacity.
 - [`executor-chain-trigger-via-workflow-2026-06-15.md`](./executor-chain-trigger-via-workflow-2026-06-15.md) —
   **session idea (2026-06-15, Q-0089, from the eval-coverage 34/34 run; owner live concern):** the
   executor's STEP 3 self-chaining is unreliable because a `continue` issue opened by a routine *session*

--- a/docs/ideas/honcho-memory-evaluation-2026-06-16.md
+++ b/docs/ideas/honcho-memory-evaluation-2026-06-16.md
@@ -1,44 +1,54 @@
-# Idea: Honcho external memory — evaluated; not for Hermes (maybe the bot's AI someday)
+# Idea: per-user AI memory for the bot (Honcho) — remember Discord users across conversations
 
-> **Status:** `ideas` — captured + evaluated 2026-06-16 (owner asked "is Honcho worth looking into?", seen in
-> the Hermes env as `HONCHO_API_KEY` → `honcho_context`). Verdict: **not a fit for the Hermes control
-> plane**; a possible future option for the **bot's** per-user AI memory. Routed here per the `intake`
-> skill (idea → capture + classify, don't promote).
+> **Status:** `ideas` — **bot / AI-lane idea** (owner-flagged "would be cool to have for our bot",
+> 2026-06-16; wants to look into it **soon**). It first surfaced while evaluating Honcho for the
+> *Hermes* control plane — not a fit there (footnote below) — but it **is** the right shape for the
+> **bot's** per-user AI memory. Vision anchor: **V-04** (per-user preferences); gated on the AI spend
+> ceiling (Q-0082).
 
-## What Honcho is
+## The idea — give SuperBot's AI real memory of individual users
+
+Today the bot's AI answers each request cold. **Per-user memory** would let it *remember a Discord
+user across conversations* — their preferences, past questions, running context — and personalize
+instead of starting from scratch every time. This is the V-04 "per-user preferences" vision item made
+real for the AI surface.
+
+## What Honcho is (the tool that fits)
 
 Honcho (Plastic Labs, open-source) is an agent **memory / social-cognition layer**: it models each
-participant as a "peer" and **extracts conclusions** from conversations/events (not just chunks to
-match later), exposing a `honcho_context` *representation document* with insights about a peer in a
-session — quick to inject into a prompt without an extra LLM round-trip. Strong long-memory benchmarks
-(LongMem-S ~90%, LoCoMo, BEAM) at a **median ~5% of the context budget**. Hermes ships it as one of
-its ~8 external memory providers.
+participant as a "peer" and **extracts conclusions** from conversations (not just stores raw chunks),
+exposing a `honcho_context` *representation document* — a compact summary of insights about a user —
+to inject into the prompt without re-reading history. Strong long-memory benchmarks (LongMem-S ~90%,
+LoCoMo, BEAM) at a **median ~5% of the context budget**.
 
-## Why it's NOT for Hermes (the control plane)
+**Why it beats the naive approach:** dumping full chat history into a big context window actually
+*degrades* accuracy (Plastic Labs' benchmark: full-haystack context drops Haiku 4.5 ~27 pts vs an
+oracle). Honcho gives the useful *conclusions* at a fraction of the size — better memory, less context,
+lower cost. The cost angle matters because the AI lane runs under a hard spend ceiling (Q-0082).
 
-- Hermes' memory need is deliberately **tiny** — owner prefs + infra stickies + one behavioural rule
-  (just cleaned to `MEMORY.md` / `USER.md`). SOUL.md's own rule: *"direct memory is a sticky note; the
-  real memory is the repo"* (`current-state.md`, `.sessions/`, the docs). A user-modelling layer is
-  overkill for an agent whose whole job is reading a thoroughly-documented repo.
-- It adds an external dependency + API key + latency/cost to model **one owner** (and a few allowed
-  users) — exactly the kind of unused integration the 2026-06-16 lean-base pass was *removing*.
-- Hermes cron runs `skip_memory=True`, and upstream issue #9763 blocks external memory providers in
-  the cron path anyway — so it would not help the routine/dispatch loop.
+## What to look into (when this is picked up)
 
-## Where it COULD fit (future — the BOT, not Hermes)
+- **Scope + privacy:** which AI surfaces get memory (general AI cog? BTD6 Q&A? all?), per-user vs
+  per-guild, opt-in, what's stored, retention/forget — ties to the bot's existing P0-2
+  data-minimization discipline.
+- **Cost:** Honcho's per-call/representation cost vs the Q-0082 ceiling; self-host vs hosted.
+- **Integration:** the AI cog's prompt-build seam is where a `honcho_context` doc would inject; needs
+  a `HONCHO_API_KEY` + provider wiring. (Caveat: Hermes cron blocks external memory providers, upstream
+  #9763 — but the *bot's* AI cog isn't cron, so that's a Hermes-only limit, not a bot one.)
+- **Alternatives:** Honcho is one of several (Mem0, Supermemory, …) — compare before committing.
 
-If SuperBot's **AI cog** ever wants genuine **per-user memory / personalization** (remembering a
-Discord user's preferences and history across conversations — the V-04 "per-user preferences" vision
-item), Honcho-style conclusion-extraction memory is the right *shape*: far better than dumping history
-into the prompt (Plastic Labs' own benchmark shows a full-haystack context drops Haiku 4.5 ~27 pts vs
-an oracle). That's an **AI-lane product decision**, gated on the AI spend ceiling (Q-0082), not a
-Hermes setup step.
+## Footnote — why NOT for Hermes (the control plane)
+
+First evaluated for Hermes and rejected: Hermes' memory is deliberately a sticky note (owner prefs +
+infra facts; the *repo* is its real memory), so a per-user modelling layer is overkill there. The
+conclusion stands — Honcho is a **bot** idea, not a Hermes one.
 
 ## Disposition
 
-- **Hermes:** no action — keep the built-in `MEMORY.md` / `USER.md`.
-- **Bot AI memory:** parked as a **Someday** option for the AI lane; revisit only if/when per-user
-  personalization is prioritized.
+- **Bot / AI lane:** owner wants to look into this **soon** → promote to a `docs/planning/` plan
+  (scope · privacy · cost vs Q-0082 · integration seam) when the AI lane has capacity. V-04 is the
+  anchor.
+- **Hermes:** no action (keep the built-in `MEMORY.md` / `USER.md`).
 
 Sources: [honcho.dev](https://honcho.dev/) · [plastic-labs/honcho](https://github.com/plastic-labs/honcho) ·
 the Hermes memory-providers doc.


### PR DESCRIPTION
Owner-requested: re-file the Honcho capture as a **bot / AI-lane idea** (per-user AI memory), not a Hermes one, so it's findable and ready to look into soon. Docs/ideas only.

- **Reframed the idea** to lead with the bot use case: give SuperBot's AI **per-user memory** — remember a Discord user across conversations (the V-04 "per-user preferences" vision item) — via Honcho's conclusion-extraction memory (better + cheaper than dumping raw history; relevant under the Q-0082 AI spend ceiling).
- Demoted the "not for Hermes" verdict to a **footnote** (the conclusion stands — it's a bot idea).
- Added a **"what to look into"** section (scope/privacy, cost vs Q-0082, AI-cog integration seam, alternatives) and a disposition to **promote to a `docs/planning/` plan** when the AI lane has capacity.
- README index entry reframed to match.

`check_docs --strict` green.

https://claude.ai/code/session_01VKtm6YmQxhqDGVGLHj8pmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKtm6YmQxhqDGVGLHj8pmL)_