### PR TITLE
fix: counting channel selector/whitelist UI · BTD6 overview de-clutter · round-63 camo-lead data

### DIFF
--- a/.sessions/2026-06-15-manual-test-bugfixes.md
+++ b/.sessions/2026-06-15-manual-test-bugfixes.md
@@ -1,0 +1,51 @@
+# Session — manual-test bug fixes (counting channel UX · BTD6 overview clutter · round-63 data)
+
+> **Status:** `complete`
+
+## What I'm about to do
+
+Owner-reported bugs from a live manual-testing screen recording (deathmatch cog excluded — it's
+being fixed separately):
+
+1. **Counting cog — no way to select/whitelist a channel.** The Counting Manager only operates on
+   the *current* channel; a tester asked "where to change whitelisted channels". Add a channel
+   selector + enable/disable-here flow so an admin can manage any counting channel and turn
+   counting on/off for an existing channel without `!start_match` creating a fresh timestamped one.
+2. **BTD6 tower/hero overview embeds dump a huge "Live data" event-restriction list.** The
+   `!btd6 tower`/`!btd6 hero` overviews (and the hero browser detail) inject every active
+   race/odyssey/challenge ban — irrelevant clutter. The tower *browser* already decided
+   restrictions belong only in the ⚠️ Event-status drill-down ("keep it uncluttered"); bring the
+   stragglers in line.
+3. **BTD6 round 63 wrongly lists "Camo Lead".** `rounds.json` round 63 has 75 plain Lead + 122
+   plain Ceramic (no camo modifier anywhere), but its curated `common_threats`/`summary` claim
+   "Camo Lead". Fix the data + add a CI guard so a curated threat can't claim a modifier no group
+   actually has.
+
+## What was done
+
+All three fixes applied:
+
+**Fix A — Counting channel selector/whitelist UI:**
+- Added `enable_channel`, `disable_channel`, `toggle_channel_flag`, `reset_channel_count` methods
+  to `CountingCog` in `disbot/cogs/counting_cog.py`, along with `_NO_ARG_MODES` frozenset and
+  `_default_channel_config` helper.
+- Replaced `disbot/views/counting/hub_panel.py` with a full channel-selector panel: `_ChannelPick`
+  (ChannelSelect component), `_ModePick` (mode enabler), action buttons (Toggle Turns, Toggle Reset,
+  Reset Count, Disable Here, Refresh). Panel supports managing any channel, not just current.
+- Added `tests/unit/cogs/test_counting_channel_select.py` with enable/disable/idempotency/arg-modes
+  rejection/toggle/reset tests.
+
+**Fix B — BTD6 overview de-clutter:**
+- `disbot/cogs/btd6/_builders.py`: `build_hero_embed` no longer calls
+  `get_active_event_restrictions_for_hero`; `build_tower_embed` no longer calls
+  `get_active_event_restrictions_for_tower`. Both pass no restrictions.
+- `disbot/views/btd6/hero_browser_view.py`: `build_hero_detail_embed` passes `restrictions=()`.
+- Added `tests/unit/cogs/test_btd6_overview_no_live_restrictions.py` asserting neither builder
+  calls the live-restriction service and no "Live data" field appears.
+
+**Fix C — BTD6 round 63 camo-lead data:**
+- `disbot/data/btd6/rounds.json`: corrected round-63 `summary` and `common_threats` (Lead +
+  Ceramic, no camo).
+- Added `tests/unit/services/test_btd6_round_threat_consistency.py`: parametrized over
+  `rounds.json` + `abr_rounds.json`, checks no `common_threats` entry claims a modifier
+  (camo/fortified/regrow) that no group actually carries.

--- a/disbot/cogs/btd6/_builders.py
+++ b/disbot/cogs/btd6/_builders.py
@@ -116,8 +116,10 @@ async def build_why_no_response_payload(
 
 
 async def build_hero_embed(name: str) -> discord.Embed:
+    # Live event restrictions live in their own drill-down, not on the
+    # overview — keep it uncluttered (mirrors the tower-browser decision).
     from cogs.btd6._embeds import response_to_embed as _response_to_embed
-    from services import btd6_ai_service, btd6_live_query_service
+    from services import btd6_ai_service
     from services.btd6_resolver_service import resolve
     from services.btd6_response_builder import for_hero
     from utils.btd6.context_footer import append_context_footer
@@ -126,10 +128,7 @@ async def build_hero_embed(name: str) -> discord.Embed:
     if not intent.heroes:
         return _response_to_embed(btd6_ai_service.deterministic_answer(intent))
     hero = intent.heroes[0]
-    restrictions = await btd6_live_query_service.get_active_event_restrictions_for_hero(
-        str(hero.id),
-    )
-    embed = _response_to_embed(for_hero(hero, restrictions=restrictions))
+    embed = _response_to_embed(for_hero(hero))
     embed.add_field(
         name="Coverage",
         value=get_coverage(AREA_HERO_STATS).user_label,
@@ -152,9 +151,14 @@ async def build_round_embed(number: int) -> discord.Embed:
 
 
 async def build_tower_embed(name: str) -> discord.Embed:
-    """Render the tower lookup embed with active-event restriction context."""
+    """Render the tower lookup embed.
+
+    Live event restrictions are intentionally *not* shown here — they live in
+    their own ⚠️ Event-status drill-down (mirrors the tower-browser detail),
+    so the overview stays uncluttered.
+    """
     from cogs.btd6._embeds import response_to_embed as _response_to_embed
-    from services import btd6_ai_service, btd6_live_query_service
+    from services import btd6_ai_service
     from services.btd6_knowledge_service import tower_fact
     from services.btd6_resolver_service import resolve
     from services.btd6_response_builder import for_tower
@@ -167,12 +171,7 @@ async def build_tower_embed(name: str) -> discord.Embed:
     fact = tower_fact(tower.id)
     if fact is None:
         return _response_to_embed(btd6_ai_service.deterministic_answer(intent))
-    restrictions = (
-        await btd6_live_query_service.get_active_event_restrictions_for_tower(
-            str(tower.id),
-        )
-    )
-    embed = _response_to_embed(for_tower(fact, restrictions=restrictions))
+    embed = _response_to_embed(for_tower(fact))
     return append_context_footer(embed, f"btd6_tower:{tower.id}")
 
 

--- a/disbot/cogs/counting/_channel_manager.py
+++ b/disbot/cogs/counting/_channel_manager.py
@@ -1,0 +1,127 @@
+"""Channel enable / disable / mutate helpers for CountingCog (panel-driven).
+
+The counting cog grew to the S4.6 warn-tier when these methods were added
+directly to counting_cog.py, so they live here following the established
+``cogs/<sub>/_helpers.py`` decomposition pattern.
+
+All functions receive the cog instance so they share its lock, count_data,
+game_logic dependency, and tasks.spawn path — none of the concurrency
+contracts change.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from cogs.counting import game_logic
+from core.runtime import scope_locks, tasks
+
+# No-argument modes panel can enable directly. ``multiples`` (factor)
+# and ``custom`` (sequence) need extra input, so they stay on !start_match.
+NO_ARG_MODES: frozenset[str] = frozenset(
+    {
+        "normal",
+        "reverse",
+        "skip",
+        "random",
+        "prime",
+        "fibonacci",
+        "squares",
+        "cubes",
+        "factorials",
+    },
+)
+
+
+def _scope_id(channel_id: str) -> str:
+    return f"counting:channel:{channel_id}"
+
+
+def default_channel_config(mode: str, *, skip_step: int = 5) -> dict:
+    """Build a fresh per-channel counting config for a no-arg mode."""
+    starting_count = 1000 if mode == "reverse" else 0
+    rand_target = rand_lo = rand_hi = None
+    if mode == "random":
+        rand_target, rand_lo, rand_hi = game_logic.start_random_round(starting_count)
+    config: dict = {
+        "current_count": starting_count,
+        "last_user": None,
+        "taking_turns": False,
+        "leaderboard": {},
+        "mode": mode,
+        "step": skip_step if mode == "skip" else 1,
+        "multiple": None,
+        "custom_sequence": None,
+        "sequence_index": 0,
+        "last_count_time": datetime.now(tz=timezone.utc).timestamp(),
+        "reset_on_wrong_count": False,
+        "next_expected": rand_target,
+        "range_lo": rand_lo,
+        "range_hi": rand_hi,
+    }
+    if mode == "prime":
+        config["prime_numbers"] = []
+    return config
+
+
+async def enable_channel(cog, guild_id: str, channel_id: str, mode: str) -> bool:
+    """Register an EXISTING channel as an active counting channel.
+
+    No Discord channel is created (unlike ``!start_match``). Returns
+    ``False`` if the channel is already active or ``mode`` needs arguments.
+    """
+    if mode not in NO_ARG_MODES:
+        return False
+    async with cog.lock:
+        cog.count_data.setdefault(guild_id, {}).setdefault("channels", {})
+        if channel_id in cog.count_data[guild_id]["channels"]:
+            return False
+        cog.count_data[guild_id]["channels"][channel_id] = default_channel_config(mode)
+        tasks.spawn(f"counting:save:{guild_id}", cog._save_guild(guild_id))
+    return True
+
+
+async def disable_channel(cog, guild_id: str, channel_id: str) -> bool:
+    """Remove a channel from the active counting set WITHOUT deleting the
+    Discord channel (distinct from ``!end_match``). Returns ``False`` if it
+    wasn't active.
+    """
+    async with cog.lock:
+        channels = cog.count_data.get(guild_id, {}).get("channels", {})
+        if channel_id not in channels:
+            return False
+        del channels[channel_id]
+        scope_locks.forget(_scope_id(channel_id))
+        tasks.spawn(f"counting:save:{guild_id}", cog._save_guild(guild_id))
+    return True
+
+
+async def toggle_channel_flag(cog, guild_id: str, channel_id: str, flag: str) -> bool:
+    """Flip a per-channel boolean (``taking_turns`` / ``reset_on_wrong_count``)."""
+    async with cog.lock:
+        ch_data = cog.count_data.get(guild_id, {}).get("channels", {}).get(channel_id)
+        if ch_data is None:
+            return False
+        ch_data[flag] = not ch_data.get(flag, False)
+        tasks.spawn(f"counting:save:{guild_id}", cog._save_guild(guild_id))
+    return True
+
+
+async def reset_channel_count(cog, guild_id: str, channel_id: str) -> bool:
+    """Reset a counting channel to its starting state."""
+    async with cog.lock:
+        ch_data = cog.count_data.get(guild_id, {}).get("channels", {}).get(channel_id)
+        if ch_data is None:
+            return False
+        mode = ch_data.get("mode", "normal")
+        ch_data["current_count"] = 1000 if mode == "reverse" else 0
+        ch_data["sequence_index"] = 0
+        ch_data["last_user"] = None
+        ch_data["leaderboard"] = {}
+        ch_data["last_count_time"] = datetime.now(tz=timezone.utc).timestamp()
+        if mode == "random":
+            ch_data["next_expected"] = None
+            ch_data["range_lo"] = None
+            ch_data["range_hi"] = None
+        tasks.spawn(f"counting:save:{guild_id}", cog._save_guild(guild_id))
+    return True

--- a/disbot/cogs/counting_cog.py
+++ b/disbot/cogs/counting_cog.py
@@ -102,6 +102,41 @@ class CountingCog(commands.Cog):
         await db.set_counting_state(guild_id, self.count_data.get(guild_id_str, {}))
 
     # --------------------------------------------
+    # Channel enable / disable / mutate (panel-driven)
+    # Implementations live in cogs/counting/_channel_manager.py to keep
+    # this file under the S4.6 LOC threshold.
+    # --------------------------------------------
+
+    async def enable_channel(self, guild_id: str, channel_id: str, mode: str) -> bool:
+        """Register an EXISTING channel as an active counting channel."""
+        from cogs.counting._channel_manager import enable_channel as _enable
+
+        return await _enable(self, guild_id, channel_id, mode)
+
+    async def disable_channel(self, guild_id: str, channel_id: str) -> bool:
+        """Remove a channel from the active counting set WITHOUT deleting it."""
+        from cogs.counting._channel_manager import disable_channel as _disable
+
+        return await _disable(self, guild_id, channel_id)
+
+    async def toggle_channel_flag(
+        self,
+        guild_id: str,
+        channel_id: str,
+        flag: str,
+    ) -> bool:
+        """Flip a per-channel boolean flag."""
+        from cogs.counting._channel_manager import toggle_channel_flag as _toggle
+
+        return await _toggle(self, guild_id, channel_id, flag)
+
+    async def reset_channel_count(self, guild_id: str, channel_id: str) -> bool:
+        """Reset a counting channel to its starting state."""
+        from cogs.counting._channel_manager import reset_channel_count as _reset
+
+        return await _reset(self, guild_id, channel_id)
+
+    # --------------------------------------------
     # Permission Helpers
     # --------------------------------------------
 

--- a/disbot/data/btd6/rounds.json
+++ b/disbot/data/btd6/rounds.json
@@ -2317,11 +2317,11 @@
     },
     {
       "round": 63,
-      "summary": "Long Ceramic-Lead wave with Camo Lead mixed in. Pierce-heavy ceramic answers AND camo detection both required.",
+      "summary": "Long lead stream backed by dense ceramic bursts (75 Lead, 122 Ceramic). Needs lead-popping plus pierce-heavy ceramic answers — no camo this round.",
       "danger": "high",
       "common_threats": [
-        "Ceramic",
-        "Camo Lead"
+        "Lead",
+        "Ceramic"
       ],
       "rbe": 14413,
       "cash": 2826,

--- a/disbot/views/btd6/hero_browser_view.py
+++ b/disbot/views/btd6/hero_browser_view.py
@@ -59,7 +59,9 @@ def build_hero_detail_embed(vm: HeroDetailViewModel) -> discord.Embed:
         embed = response_to_embed(btd6_ai_service.deterministic_answer(intent))
     else:
         hero = intent.heroes[0]
-        embed = response_to_embed(for_hero(hero, restrictions=tuple(vm.restrictions)))
+        # Live event restrictions live in their own drill-down, not on the
+        # overview — keep it uncluttered (mirrors the tower-browser detail).
+        embed = response_to_embed(for_hero(hero, restrictions=()))
 
     # Heroes with a bloonswiki module get a glanceable Level-1 stats field
     # (the rest are prose-only — cost + abilities, no combat stats).

--- a/disbot/views/counting/hub_panel.py
+++ b/disbot/views/counting/hub_panel.py
@@ -1,174 +1,269 @@
 """Counting-game admin hub panel.
 
-Top-level view shown by ``!countingmenu``.  Operates on the current
-channel — toggles taking-turns, toggles reset-on-wrong, and resets
-the count.  All mutations route through the cog's per-guild lock to
-preserve the existing concurrency contract.
+Shown by ``!countingmenu`` / ``!cm``.  Pick any text channel with the
+selector, then manage *that* channel: toggle taking-turns, toggle
+reset-on-wrong, reset the count, enable counting on an existing channel
+(the "whitelist" flow a tester asked for), or disable it again without
+deleting the channel.  All mutations route through the cog, which owns
+the per-guild lock + persistence, preserving the concurrency contract.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-
 import discord
 from discord.ext import commands
 
-from core.runtime import resources, tasks
+from core.runtime import resources
 from views.base import HubView
+
+# No-argument modes enable-able straight from the panel.  ``multiples``
+# (needs a factor) and ``custom`` (needs a sequence) keep the
+# argument-taking ``!start_match`` path.
+_ENABLE_MODES = (
+    "normal",
+    "reverse",
+    "skip",
+    "random",
+    "prime",
+    "fibonacci",
+    "squares",
+    "cubes",
+    "factorials",
+)
+
+
+class _ChannelPick(discord.ui.ChannelSelect):
+    """Pick which channel the panel manages (any text channel)."""
+
+    def __init__(self, hub: _CountingHubView) -> None:
+        super().__init__(
+            placeholder="Select a channel to manage…",
+            channel_types=[discord.ChannelType.text],
+            min_values=1,
+            max_values=1,
+            row=0,
+        )
+        self._hub = hub
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        self._hub.selected_cid = str(self.values[0].id)
+        await self._hub.rerender(interaction)
+
+
+class _ModePick(discord.ui.Select):
+    """Enable counting on the selected (currently inactive) channel."""
+
+    def __init__(self, hub: _CountingHubView) -> None:
+        super().__init__(
+            placeholder="Enable counting here — pick a mode…",
+            min_values=1,
+            max_values=1,
+            options=[
+                discord.SelectOption(label=mode.capitalize(), value=mode)
+                for mode in _ENABLE_MODES
+            ],
+            row=1,
+        )
+        self._hub = hub
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await self._hub.cog.enable_channel(
+            self._hub.gid,
+            self._hub.selected_cid,
+            self.values[0],
+        )
+        await self._hub.rerender(interaction)
+
+
+class _ToggleTurnsButton(discord.ui.Button):
+    def __init__(self, hub: _CountingHubView) -> None:
+        super().__init__(
+            label="🔄 Toggle Turns",
+            style=discord.ButtonStyle.blurple,
+            row=2,
+        )
+        self._hub = hub
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await self._hub.cog.toggle_channel_flag(
+            self._hub.gid,
+            self._hub.selected_cid,
+            "taking_turns",
+        )
+        await self._hub.rerender(interaction)
+
+
+class _ToggleResetButton(discord.ui.Button):
+    def __init__(self, hub: _CountingHubView) -> None:
+        super().__init__(
+            label="♻️ Toggle Reset",
+            style=discord.ButtonStyle.blurple,
+            row=2,
+        )
+        self._hub = hub
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await self._hub.cog.toggle_channel_flag(
+            self._hub.gid,
+            self._hub.selected_cid,
+            "reset_on_wrong_count",
+        )
+        await self._hub.rerender(interaction)
+
+
+class _ResetCountButton(discord.ui.Button):
+    def __init__(self, hub: _CountingHubView) -> None:
+        super().__init__(
+            label="🔁 Reset Count",
+            style=discord.ButtonStyle.danger,
+            row=2,
+        )
+        self._hub = hub
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await self._hub.cog.reset_channel_count(
+            self._hub.gid,
+            self._hub.selected_cid,
+        )
+        await self._hub.rerender(interaction)
+
+
+class _DisableButton(discord.ui.Button):
+    def __init__(self, hub: _CountingHubView) -> None:
+        super().__init__(
+            label="🛑 Disable Here",
+            style=discord.ButtonStyle.danger,
+            row=3,
+        )
+        self._hub = hub
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        disabled = await self._hub.cog.disable_channel(
+            self._hub.gid,
+            self._hub.selected_cid,
+        )
+        # Send a confirmation message — counting is off in that channel now.
+        # The panel user can select another channel or use !start_match.
+        msg = (
+            "Counting disabled in that channel."
+            if disabled
+            else "That channel wasn't an active counting channel."
+        )
+        await interaction.response.send_message(msg, ephemeral=True)
+
+
+class _RefreshButton(discord.ui.Button):
+    def __init__(self, hub: _CountingHubView) -> None:
+        super().__init__(
+            label="🔄 Refresh",
+            style=discord.ButtonStyle.secondary,
+            row=3,
+        )
+        self._hub = hub
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await self._hub.rerender(interaction)
 
 
 class _CountingHubView(HubView):
-    """Admin hub for managing the counting game in the current channel."""
+    """Admin hub for selecting + managing counting channels."""
 
-    def __init__(self, ctx: commands.Context, cog):
+    def __init__(self, ctx: commands.Context, cog) -> None:
         super().__init__(ctx.author)
         self.ctx = ctx
         self.cog = cog
+        self.gid = str(ctx.guild.id)
+        self.selected_cid = str(ctx.channel.id)
+        self._rebuild()
 
+    # -- state ---------------------------------------------------------
     def _channel_data(self) -> dict | None:
-        gid = str(self.ctx.guild.id)
-        cid = str(self.ctx.channel.id)
-        return self.cog.count_data.get(gid, {}).get("channels", {}).get(cid)
+        return (
+            self.cog.count_data.get(self.gid, {})
+            .get("channels", {})
+            .get(self.selected_cid)
+        )
 
+    def _selected_mention(self) -> str:
+        ch = resources.resolve_channel(
+            self.ctx.guild,
+            channel_id=self.selected_cid,
+        )
+        return ch.mention if ch else f"`{self.selected_cid}`"
+
+    def _active_mentions(self) -> list[str]:
+        mentions: list[str] = []
+        channels = self.cog.count_data.get(self.gid, {}).get("channels", {})
+        for cid in channels:
+            ch = resources.resolve_channel(self.ctx.guild, channel_id=cid)
+            if ch:
+                mentions.append(ch.mention)
+        return mentions
+
+    # -- component assembly --------------------------------------------
+    def _rebuild(self) -> None:
+        for child in list(self.children):
+            self.remove_item(child)
+        self.add_item(_ChannelPick(self))
+        if self._channel_data() is None:
+            self.add_item(_ModePick(self))
+        else:
+            self.add_item(_ToggleTurnsButton(self))
+            self.add_item(_ToggleResetButton(self))
+            self.add_item(_ResetCountButton(self))
+            self.add_item(_DisableButton(self))
+        self.add_item(_RefreshButton(self))
+
+    async def rerender(self, interaction: discord.Interaction) -> None:
+        self._rebuild()
+        await interaction.response.edit_message(
+            embed=await self.build_embed(),
+            view=self,
+        )
+
+    # -- embed ---------------------------------------------------------
     async def build_embed(self) -> discord.Embed:
-        embed = discord.Embed(title="🔢 Counting Manager", color=discord.Color.blue())
+        embed = discord.Embed(
+            title="🔢 Counting Manager",
+            color=discord.Color.blue(),
+        )
         ch_data = self._channel_data()
         if ch_data:
-            mode = ch_data.get("mode", "normal").capitalize()
-            current = ch_data.get("current_count", 0)
-            turns = ch_data.get("taking_turns", False)
-            reset_wrong = ch_data.get("reset_on_wrong_count", False)
-            embed.description = f"Managing {self.ctx.channel.mention}"  # type: ignore[union-attr]
-            embed.add_field(name="Mode", value=mode, inline=True)
-            embed.add_field(name="Current Count", value=str(current), inline=True)
+            embed.description = f"Managing {self._selected_mention()}"
+            embed.add_field(
+                name="Mode",
+                value=ch_data.get("mode", "normal").capitalize(),
+                inline=True,
+            )
+            embed.add_field(
+                name="Current Count",
+                value=str(ch_data.get("current_count", 0)),
+                inline=True,
+            )
             embed.add_field(
                 name="Taking Turns",
-                value="✅" if turns else "❌",
+                value="✅" if ch_data.get("taking_turns", False) else "❌",
                 inline=True,
             )
             embed.add_field(
                 name="Reset on Wrong",
-                value="✅" if reset_wrong else "❌",
+                value="✅" if ch_data.get("reset_on_wrong_count", False) else "❌",
                 inline=True,
             )
+            embed.set_footer(text="Buttons operate on the selected channel.")
         else:
-            gid = str(self.ctx.guild.id)
-            active_ids = list(
-                self.cog.count_data.get(gid, {}).get("channels", {}).keys(),
-            )
-            active_mentions = []
-            for cid in active_ids:
-                ch = resources.resolve_channel(self.ctx.guild, channel_id=cid)
-                if ch:
-                    active_mentions.append(ch.mention)
             embed.description = (
-                f"{self.ctx.channel.mention} is not an active counting channel.\n\n"  # type: ignore[union-attr]
-                "Start a new match with `!start_match <mode>`."
+                f"{self._selected_mention()} is not an active counting "
+                "channel.\n\nPick a mode below to **enable counting here**, or "
+                "select another channel above. `!start_match <mode>` still "
+                "creates a fresh channel."
             )
-            if active_mentions:
+            active = self._active_mentions()
+            if active:
                 embed.add_field(
                     name="Active Counting Channels",
-                    value="\n".join(active_mentions),
+                    value="\n".join(active),
                     inline=False,
                 )
-        embed.set_footer(text="Buttons below operate on the current channel.")
+            embed.set_footer(text="Select a channel above to manage it.")
         return embed
-
-    @discord.ui.button(
-        label="🔄 Toggle Turns",
-        style=discord.ButtonStyle.blurple,
-        row=0,
-    )
-    async def btn_toggle_turns(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ):
-        gid = str(self.ctx.guild.id)
-        cid = str(self.ctx.channel.id)
-        async with self.cog.lock:
-            ch_data = self.cog.count_data.get(gid, {}).get("channels", {}).get(cid)
-            if not ch_data:
-                await interaction.response.send_message(
-                    "This channel is not an active counting channel.",
-                    ephemeral=True,
-                )
-                return
-            ch_data["taking_turns"] = not ch_data.get("taking_turns", False)
-            tasks.spawn(f"counting:save:{gid}", self.cog._save_guild(gid))
-        await interaction.response.edit_message(
-            embed=await self.build_embed(),
-            view=self,
-        )
-
-    @discord.ui.button(
-        label="♻️ Toggle Reset",
-        style=discord.ButtonStyle.blurple,
-        row=0,
-    )
-    async def btn_toggle_reset(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ):
-        gid = str(self.ctx.guild.id)
-        cid = str(self.ctx.channel.id)
-        async with self.cog.lock:
-            ch_data = self.cog.count_data.get(gid, {}).get("channels", {}).get(cid)
-            if not ch_data:
-                await interaction.response.send_message(
-                    "This channel is not an active counting channel.",
-                    ephemeral=True,
-                )
-                return
-            ch_data["reset_on_wrong_count"] = not ch_data.get(
-                "reset_on_wrong_count",
-                False,
-            )
-            tasks.spawn(f"counting:save:{gid}", self.cog._save_guild(gid))
-        await interaction.response.edit_message(
-            embed=await self.build_embed(),
-            view=self,
-        )
-
-    @discord.ui.button(label="🔁 Reset Count", style=discord.ButtonStyle.danger, row=0)
-    async def btn_reset_count(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ):
-        gid = str(self.ctx.guild.id)
-        cid = str(self.ctx.channel.id)
-        async with self.cog.lock:
-            ch_data = self.cog.count_data.get(gid, {}).get("channels", {}).get(cid)
-            if not ch_data:
-                await interaction.response.send_message(
-                    "This channel is not an active counting channel.",
-                    ephemeral=True,
-                )
-                return
-            mode = ch_data.get("mode", "normal")
-            start = 1000 if mode == "reverse" else 0
-            ch_data["current_count"] = start
-            ch_data["sequence_index"] = 0
-            ch_data["last_user"] = None
-            ch_data["leaderboard"] = {}
-            ch_data["last_count_time"] = datetime.now(tz=timezone.utc).timestamp()
-            if mode == "random":
-                # Clear the round; the next guess rolls a fresh target +
-                # window via the handler (avoids a views->cogs import here).
-                ch_data["next_expected"] = None
-                ch_data["range_lo"] = None
-                ch_data["range_hi"] = None
-            tasks.spawn(f"counting:save:{gid}", self.cog._save_guild(gid))
-        await interaction.response.edit_message(
-            embed=await self.build_embed(),
-            view=self,
-        )
-
-    @discord.ui.button(label="🔄 Refresh", style=discord.ButtonStyle.secondary, row=1)
-    async def btn_refresh(self, interaction: discord.Interaction, _: discord.ui.Button):
-        await interaction.response.edit_message(
-            embed=await self.build_embed(),
-            view=self,
-        )

--- a/tests/unit/cogs/test_btd6_overview_no_live_restrictions.py
+++ b/tests/unit/cogs/test_btd6_overview_no_live_restrictions.py
@@ -1,0 +1,45 @@
+"""Tower / hero *overview* embeds must not dump live event restrictions.
+
+Live-tested bug: ``!btd6 tower <name>`` and ``!btd6 hero <name>`` rendered a
+"Live data" field stuffed with every active race / odyssey / challenge ban for
+that tower (dozens of lines). That belongs in the dedicated ⚠️ Event-status
+drill-down, not the overview — the tower *browser* detail already documents
+this ("keep it uncluttered"); the prefix/slash builders and the hero browser
+detail were the stragglers. These guards pin the decision: the overview
+builders never consult the event-restriction service, so no "Live data" field
+appears regardless of what events are live.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cogs.btd6._builders import build_hero_embed, build_tower_embed
+
+
+def _field_names(embed) -> list[str]:
+    return [f.name for f in embed.fields]
+
+
+@pytest.mark.asyncio
+async def test_tower_overview_has_no_live_data_field() -> None:
+    with patch(
+        "services.btd6_live_query_service.get_active_event_restrictions_for_tower",
+        new=AsyncMock(return_value=()),
+    ) as scan:
+        embed = await build_tower_embed("dart monkey")
+    assert "Live data" not in _field_names(embed)
+    scan.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_hero_overview_has_no_live_data_field() -> None:
+    with patch(
+        "services.btd6_live_query_service.get_active_event_restrictions_for_hero",
+        new=AsyncMock(return_value=()),
+    ) as scan:
+        embed = await build_hero_embed("quincy")
+    assert "Live data" not in _field_names(embed)
+    scan.assert_not_awaited()

--- a/tests/unit/cogs/test_counting_channel_select.py
+++ b/tests/unit/cogs/test_counting_channel_select.py
@@ -1,0 +1,54 @@
+"""Counting panel: enable/disable an EXISTING channel + per-channel mutate.
+
+Guards the live-tested "where to change whitelisted channels" gap — the panel
+can now register an existing channel as a counting channel (no new channel
+created) and disable it again without deleting it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import cogs.counting_cog as counting_cog
+from cogs.counting_cog import CountingCog
+
+
+def _cog() -> CountingCog:
+    return CountingCog(bot=MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_enable_then_disable_existing_channel(monkeypatch) -> None:
+    monkeypatch.setattr(counting_cog.db, "set_counting_state", AsyncMock(return_value=None))
+    cog = _cog()
+    assert await cog.enable_channel("1", "100", "normal") is True
+    assert cog.count_data["1"]["channels"]["100"]["mode"] == "normal"
+    # idempotent: already active
+    assert await cog.enable_channel("1", "100", "normal") is False
+    # disable removes membership without touching any Discord channel
+    assert await cog.disable_channel("1", "100") is True
+    assert "100" not in cog.count_data["1"]["channels"]
+    assert await cog.disable_channel("1", "100") is False
+
+
+@pytest.mark.asyncio
+async def test_enable_rejects_arg_modes() -> None:
+    cog = _cog()
+    assert await cog.enable_channel("1", "100", "multiples") is False
+    assert await cog.enable_channel("1", "100", "custom") is False
+
+
+@pytest.mark.asyncio
+async def test_toggle_and_reset_channel(monkeypatch) -> None:
+    monkeypatch.setattr(counting_cog.db, "set_counting_state", AsyncMock(return_value=None))
+    cog = _cog()
+    await cog.enable_channel("1", "100", "normal")
+    assert await cog.toggle_channel_flag("1", "100", "taking_turns") is True
+    assert cog.count_data["1"]["channels"]["100"]["taking_turns"] is True
+    cog.count_data["1"]["channels"]["100"]["current_count"] = 42
+    assert await cog.reset_channel_count("1", "100") is True
+    assert cog.count_data["1"]["channels"]["100"]["current_count"] == 0
+    # missing channel → False, no crash
+    assert await cog.toggle_channel_flag("1", "999", "taking_turns") is False

--- a/tests/unit/help/test_help_actionability_contract.py
+++ b/tests/unit/help/test_help_actionability_contract.py
@@ -328,6 +328,25 @@ async def _build_panel_for(
         from cogs.counting_cog import CountingCog
 
         cog = CountingCog(MagicMock())
+        # Pre-seed a channel so the panel shows the active-channel
+        # action buttons (Toggle, Reset, Disable) rather than only
+        # the channel-select + refresh buttons.
+        cog.count_data = {
+            str(interaction.guild.id): {
+                "channels": {
+                    str(interaction.channel.id): {
+                        "mode": "normal",
+                        "current_count": 0,
+                        "last_user": None,
+                        "taking_turns": False,
+                        "leaderboard": {},
+                        "reset_on_wrong_count": False,
+                        "step": 1,
+                        "sequence_index": 0,
+                    }
+                }
+            }
+        }
     elif subsystem == "chain":
         from cogs.chain_cog import ChainCog
 

--- a/tests/unit/services/test_btd6_round_threat_consistency.py
+++ b/tests/unit/services/test_btd6_round_threat_consistency.py
@@ -1,0 +1,69 @@
+"""Round ``common_threats`` must not claim a modifier no group actually has.
+
+The ``summary`` / ``danger`` / ``common_threats`` fields of ``rounds.json`` (and
+its ABR sidecar) are *curated* prose — ``fetch_bloonswiki.py`` preserves them
+across regeneration while re-deriving ``groups``/``rbe`` from the dump. That
+split is convenient but means a curator can type a threat the composition does
+not support, and nothing catches it: round 63 shipped ``common_threats =
+["Ceramic", "Camo Lead"]`` even though its groups are 75 plain Lead + 122 plain
+Ceramic with no camo modifier anywhere (the live-tested bug this guards).
+
+A bloon's *modifiers* (camo / fortified / regrow) are ground truth in the group
+data. So a structured threat token that names one of those modifier words must
+be backed by at least one group on that round actually carrying it. We check the
+structured ``common_threats`` only — the free-form ``summary`` may legitimately
+*negate* ("no camo this round"), so a bare word-match there would false-positive.
+
+Provenance: added 2026-06-15 alongside the round-63 data fix. Verifiable (it
+recomputes from the same JSON the bot loads). Delete it if it ever proves
+unreliable across multiple sessions — but a green here means no round's
+common_threats over-claims a bloon modifier.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DATA = _REPO_ROOT / "disbot" / "data" / "btd6"
+
+# The three bloon modifiers the group data records. A threat token naming one of
+# these (e.g. "Camo Lead", "Fortified MOAB") asserts the round contains a bloon
+# carrying that modifier — so a matching group must exist.
+_MODIFIERS = ("camo", "fortified", "regrow")
+
+
+def _round_files() -> list[Path]:
+    return [p for p in (_DATA / "rounds.json", _DATA / "abr_rounds.json") if p.exists()]
+
+
+def _present_modifiers(groups: list[dict]) -> set[str]:
+    present: set[str] = set()
+    for group in groups:
+        for mod in group.get("modifiers", ()) or ():
+            present.add(str(mod).lower())
+    return present
+
+
+@pytest.mark.parametrize("path", _round_files(), ids=lambda p: p.name)
+def test_common_threats_do_not_overclaim_modifiers(path: Path) -> None:
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    offenders: list[str] = []
+    for entry in doc.get("rounds", []):
+        round_no = entry.get("round")
+        present = _present_modifiers(entry.get("groups", []) or [])
+        for threat in entry.get("common_threats", []) or []:
+            tokens = str(threat).lower().split()
+            for mod in _MODIFIERS:
+                if mod in tokens and mod not in present:
+                    offenders.append(
+                        f"{path.name} round {round_no}: threat {threat!r} claims "
+                        f"'{mod}' but no group carries it (present: "
+                        f"{sorted(present) or 'none'})",
+                    )
+    assert not offenders, "Round threats over-claim bloon modifiers:\n" + "\n".join(
+        offenders,
+    )


### PR DESCRIPTION
Three owner-reported bugs from a live manual-testing screen recording (the deathmatch "Challenge Expired" embed is excluded — it's being fixed separately).

## 1. Counting cog — "where to change whitelisted channels"
The Counting Manager (`!countingmenu` / `!cm`) only ever operated on the **current** channel, and counting channels were only created fresh by `!start_match` (timestamped names) — there was no way to *select* a channel or to enable/disable counting on an **existing** one. A tester hit exactly this ("where to change whitelisted channels").

- The panel now has a **channel picker** (`discord.ui.ChannelSelect`); the toggles / reset operate on the **selected** channel.
- Selecting a non-counting channel offers a **mode picker** to *enable counting there* — registering an existing channel without creating a new one (the "whitelist" flow). `!start_match` still creates a fresh channel.
- A **🛑 Disable Here** button removes a channel from the active set **without deleting** it (distinct from `!end_match`).
- Mutations route through new audited-pattern cog methods (`enable_channel` / `disable_channel` / `toggle_channel_flag` / `reset_channel_count`) holding the existing per-guild lock; counting "active" status is membership-based, so this is clean. (Cog logic lives in `cogs/counting/_channel_manager.py` to stay under the 800-LOC gate, mirroring the existing `handler.py` decomposition.)

## 2. BTD6 tower/hero overview embeds — "filled with data that doesn't belong"
`!btd6 tower`/`hero` overviews (and the hero browser detail) dumped a huge **"Live data"** section listing every active race/odyssey/challenge ban (`… (26 more)`). The tower *browser* detail already documents the intended design — *event restrictions belong in their own ⚠️ Event-status drill-down, "keep it uncluttered"* — and these three call-sites were simply missed. They now match: the overview no longer pulls or renders event restrictions (the restriction info stays available in its dedicated drill-down + the interactive panel field). Bonus: drops an event-scan DB call per overview lookup.

## 3. BTD6 Round 63 wrongly lists "Camo Lead"
`rounds.json` round 63 is **75 plain Lead + 122 plain Ceramic** with no camo modifier on any bloon, but its curated `common_threats`/`summary` claimed "Camo Lead" (the only such inconsistency across all 140 rounds). Corrected to `["Lead", "Ceramic"]` with an accurate summary, plus a CI guard (`test_btd6_round_threat_consistency.py`) so a curated threat can never again claim a bloon modifier no group actually carries.

## Verification
- `python3.10 scripts/check_quality.py --full` — green (**9897 passed / 37 skipped**).
- `python3.10 scripts/check_architecture.py --mode strict` — exit 0 (the new view imports no cog; the `services → views` / `views → cogs` boundaries hold).
- New tests: round-threat consistency guard, tower/hero overview "no Live data" guards, counting enable/disable/toggle/reset.

https://claude.ai/code/session_01KZHVFaN2Br3eEqXVPU52yz

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZHVFaN2Br3eEqXVPU52yz)_