### PR TITLE
docs(ideas): capture diagnostic_cog !platform-group extraction

### DIFF
--- a/.sessions/2026-06-16-idea-platform-group-decompose.md
+++ b/.sessions/2026-06-16-idea-platform-group-decompose.md
@@ -1,0 +1,23 @@
+# Session — capture the diagnostic_cog platform-group decomposition idea
+
+> **Status:** `complete`
+
+## Why
+
+Third contribution of this dispatch run (after faucet/sink #937 merged + myprofile PR A #938
+pending) — the standing backlog-grooming ender (Q-0015). The faucet/sink slice pushed
+`diagnostic_cog.py` to **799/800 LOC**; the cause + fix were captured only in two `.sessions/`
+logs (which sessions don't read top-to-bottom), so the next `!platform` subcommand would hit the
+wall cold. This moves that surfaced idea into its durable home.
+
+## What shipped (docs only)
+
+- `docs/ideas/diagnostic-cog-platform-group-extraction-2026-06-16.md` — extract the `!platform`
+  group onto a `PlatformCommandsMixin` (`cogs/diagnostic/platform_group.py`) so the surface grows
+  past the 800-LOC cog ceiling; identity stays on `DiagnosticCog`, weight moves to a helper module
+  (the F-3 "surface = cog, weight = `cogs/<sub>/`" convention). Small/safe/decided-lane refactor.
+- `docs/ideas/README.md` — index entry.
+
+## Verification
+
+`check_docs --strict` green (ideas 53). Docs-only; no runtime code.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -153,6 +153,12 @@ Current broad captures:
   subclasses **defined under `cogs/`** — invisible to the baseview ratchet (which only scans
   `views/`). Surfaced when the `!list` paginator was found mislayered in `channel_cog.py`
   only by tripping the cog-size ceiling. Warn → ratchet. Small/safe grooming-lane candidate.
+- [`diagnostic-cog-platform-group-extraction-2026-06-16.md`](./diagnostic-cog-platform-group-extraction-2026-06-16.md) —
+  **refactor / near-term blocker (2026-06-16):** move the `!platform` command group off
+  `DiagnosticCog` onto a `PlatformCommandsMixin` (`cogs/diagnostic/platform_group.py`) so the
+  surface can grow past the 800-LOC cog ceiling — the cog hit **799/800** when the faucet/sink
+  `!platform economy` landed (#937), and the next subcommand has no room. Small/safe/decided-lane,
+  pure refactor; worth executing before it's urgent.
 - [`effective-check-constraint-test-helper-2026-06-14.md`](./effective-check-constraint-test-helper-2026-06-14.md) —
   **tooling (2026-06-14, PR #817):** a shared `effective_check_constraint(table, column)` test
   helper that derives the *current* SQL `CHECK (col IN …)` set by scanning all migrations in

--- a/docs/ideas/diagnostic-cog-platform-group-extraction-2026-06-16.md
+++ b/docs/ideas/diagnostic-cog-platform-group-extraction-2026-06-16.md
@@ -1,0 +1,52 @@
+# Idea — extract the `!platform` command group into a cog mixin
+
+> **Status:** `ideas` — captured 2026-06-16. Surfaced (twice) by the dispatch run that shipped
+> the faucet/sink diagnostic (#937) and myprofile PR A (#938). Routing: **S4 docs / S1 platform —
+> diagnostic slice**. Near-term, not speculative: `diagnostic_cog.py` is at **799/800 LOC**, so
+> the *next* `!platform` subcommand is blocked until this is done.
+
+## The friction (a real, dated blocker)
+
+`disbot/cogs/diagnostic_cog.py` is the Discord-facing home of the whole `!platform` admin surface
+— ~30 thin `@platform_grp.command` wrappers (`status`, `media`, `economy`, `health`, `findings`,
+`flags`, …), each delegating to a builder in `cogs/diagnostic/_platform_embeds.py`. The
+800-LOC cog ceiling (`tests/unit/invariants/test_cog_size.py`, hard fail at 800) is the F-3
+decompose signal.
+
+The *embed builders* already moved out (`_platform_embeds.py`) — that was the first decompose.
+But the **command registrations** stayed in the cog, and adding one more (the faucet/sink
+`!platform economy` in #937) pushed the file to **799/800**. #937 only landed by *shaving
+docstrings* to claw back lines — a symptom, not a fix. The next subcommand has no room at all.
+
+## The fix
+
+Move the `platform_*` command group off `DiagnosticCog` and onto a **mixin class** the cog
+inherits — e.g. `cogs/diagnostic/platform_group.py` defining `class PlatformCommandsMixin:` that
+holds `platform_grp` + every `@platform_grp.command`, with `DiagnosticCog(PlatformCommandsMixin,
+commands.Cog)`. discord.py resolves group commands across the MRO, so the surface is unchanged.
+
+Why a mixin (not a second cog): the `!platform` group must stay registered under **one** cog
+(`DiagnosticCog` → the `diagnostic` subsystem) so the command-surface ledger and help routing
+don't see it move subsystems. A mixin keeps the identity on `DiagnosticCog` while moving the LOC
+into a helper module (which is *not* subject to the 800-LOC cog ceiling — only top-level
+`*_cog.py` files are). This is the same "Discord surface = the cog; the weight lives in
+`cogs/<sub>/`" convention F-3 already established for the builders.
+
+## Scope / shape (one PR, low risk)
+
+- New `disbot/cogs/diagnostic/platform_group.py` with `PlatformCommandsMixin` holding the
+  `platform_grp` group + all `platform_*` subcommands (moved verbatim).
+- `DiagnosticCog` inherits the mixin; the slash front door + the non-`platform` commands stay put.
+- Verify: `test_cog_size` green (cog drops well under 800), `test_command_surface_ledger`
+  `EXPECTED_SLASH_SURFACE` unchanged (the `platform` group still resolves), `!platform <sub>` all
+  still register, `check_quality --full` + `check_architecture` green.
+- Pure refactor — no behavior change, fully reversible.
+
+## Why it's worth doing before it's urgent
+
+It's currently only recorded in two `.sessions/` logs, which sessions don't read top-to-bottom —
+so a future agent adding a `!platform` subcommand will hit the 799/800 wall *cold* and burn time
+re-discovering the cause + re-shaving docstrings. Doing the extraction proactively unblocks the
+whole `!platform` lane (more diagnostics are queued: the faucet/sink follow-ups in the plan, an
+inflation health-finding, etc.) and removes a recurring time-tax. Small, contained, decided-lane —
+a good "execute now" grooming pick for a session with capacity.


### PR DESCRIPTION
## Why

Backlog-grooming ender (Q-0015) for this dispatch run. The faucet/sink diagnostic (#937) pushed `diagnostic_cog.py` to **799/800 LOC** — the hard cog-size ceiling. The cause and the fix were captured only in `.sessions/` logs, which sessions don't read top-to-bottom, so the *next* `!platform` subcommand would hit the wall cold and burn time re-discovering it.

## What (docs only)

- `docs/ideas/diagnostic-cog-platform-group-extraction-2026-06-16.md` — extract the `!platform` command group off `DiagnosticCog` onto a `PlatformCommandsMixin` (`cogs/diagnostic/platform_group.py`), so the surface can grow past the 800-LOC cog ceiling while the command identity stays on `DiagnosticCog` (one subsystem, ledger/help unchanged) and the weight moves to a helper module that isn't subject to the ceiling — the same F-3 "surface = cog, weight = `cogs/<sub>/`" convention the embed-builder extraction already used. Small/safe/decided-lane pure refactor; worth executing before it's urgent.
- `docs/ideas/README.md` — index entry.

`check_docs --strict` green. Docs-only; no runtime code.

https://claude.ai/code/session_01WtFK6m8ayFbDMiiCsdTguu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtFK6m8ayFbDMiiCsdTguu)_