### PR TITLE
fix(hooks): make settings.json hooks cwd-robust — kill the cwd-deadlock trap (Q-0150)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -142,7 +142,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3.10 scripts/claude_pre_edit.py",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}\" && python3.10 scripts/claude_pre_edit.py",
             "timeout": 20
           }
         ]
@@ -152,7 +152,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3.10 scripts/check_branch_freshness.py --event pretooluse",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}\" && python3.10 scripts/check_branch_freshness.py --event pretooluse",
             "timeout": 20
           }
         ]
@@ -164,7 +164,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3.10 scripts/claude_post_edit.py",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}\" && python3.10 scripts/claude_post_edit.py",
             "timeout": 30
           }
         ]
@@ -174,7 +174,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3.10 scripts/claude_pr_subscribe_reminder.py",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}\" && python3.10 scripts/claude_pr_subscribe_reminder.py",
             "timeout": 10
           }
         ]
@@ -185,12 +185,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3.10 scripts/claude_stop_check.py",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}\" && python3.10 scripts/claude_stop_check.py",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "python3.10 scripts/check_branch_freshness.py --event stop",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}\" && python3.10 scripts/check_branch_freshness.py --event stop",
             "timeout": 20
           }
         ]
@@ -201,7 +201,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/claude_session_start.sh",
+            "command": "cd \"${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}\" && bash scripts/claude_session_start.sh",
             "timeout": 180
           }
         ]

--- a/.session-journal.md
+++ b/.session-journal.md
@@ -365,9 +365,15 @@ PR #676; drift surfaced at boot + `!btd6 status`). Full note:
   **Recovery if you're already stuck:** your uncommitted work is on disk but Bash/Write are
   blocked — spawn a **`worktree`-isolated Agent**, have it `cd /home/user/superbot` (its
   hooks resolve correctly from the main root) and commit+push your branch so the work is
-  durable, then finish once the cwd resets. (Proposed durable fix: make the hooks use
-  `$CLAUDE_PROJECT_DIR/scripts/…` — router Q-block, since hooks aren't self-edited per
-  Q-0106.)
+  durable, then finish once the cwd resets. **Durable fix APPLIED (Q-0150, 2026-06-16):** every
+  hook command in `.claude/settings.json` is now prefixed with
+  `cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}" &&`, so a hook resolves the repo
+  root regardless of a stuck cwd (the `git rev-parse` fallback is load-bearing — `$CLAUDE_PROJECT_DIR`
+  was observed empty in-shell). Takes effect next session; keep the "never `cd` into a subdir" habit
+  until a fresh session confirms it live. *(Worktree-agent rescue this session also used a
+  `disbot/scripts -> ../scripts` symlink, but that makes `mypy disbot/` traverse `scripts/` and
+  report unrelated type errors — remove the symlink before `check_quality --full`. The Q-0150 fix
+  removes the need for either workaround.)*
 
 
 ### CI & quality gates

--- a/.sessions/2026-06-16-hook-cwd-robust.md
+++ b/.sessions/2026-06-16-hook-cwd-robust.md
@@ -1,0 +1,31 @@
+# Session — make the settings.json hooks cwd-robust (Q-0150)
+
+> **Status:** `in-progress`
+
+## What this is
+
+Owner-directed in-session (the maintainer asked for an explanation of the cwd-deadlock, then said
+"yes go ahead"). Third PR of this dispatch run (after #945 permission allow-list, #946 §7.5
+cost-comparison floor). Applies the durable fix the journal's cwd-deadlock entry had been pointing
+at, under the Q-0106 in-session exception. Provenance: **Q-0150**.
+
+## The trap (why)
+
+Hook commands in `.claude/settings.json` used **relative** `scripts/<hook>.py` paths. The Bash tool's
+cwd persists across calls, so a stray `cd <subdir> &&` leaves cwd in the subdir; the PreToolUse hooks
+(Bash + Edit|Write) then resolve `<subdir>/scripts/<hook>.py`, FileNotFound, exit non-zero → the
+harness blocks the tool. All three mutating tools share the hooks → full session deadlock (hit live
+this run; the worktree-agent symlink rescue got me out).
+
+## Fix (applied)
+
+Prefix every hook command with `cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}" &&` —
+prefers the documented hook env var, falls back to `git rev-parse --show-toplevel` (load-bearing:
+`$CLAUDE_PROJECT_DIR` was observed **empty** in-shell here). Resolves the repo root even from a stuck
+subdir; runs in the hook's own subshell so it never affects the tool cwd. All 7 hook commands updated.
+
+## Plan
+
+- `.claude/settings.json` — 7 hook commands wrapped (done).
+- Router **Q-0150** provenance + `.session-journal.md` entry marked "durable fix applied" (done).
+- Verify: JSON valid · each wrapped script exits 0 from a stuck `disbot/` cwd · `check_docs --strict`.

--- a/.sessions/2026-06-16-hook-cwd-robust.md
+++ b/.sessions/2026-06-16-hook-cwd-robust.md
@@ -1,6 +1,6 @@
 # Session — make the settings.json hooks cwd-robust (Q-0150)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## What this is
 
@@ -29,3 +29,22 @@ subdir; runs in the hook's own subshell so it never affects the tool cwd. All 7 
 - `.claude/settings.json` — 7 hook commands wrapped (done).
 - Router **Q-0150** provenance + `.session-journal.md` entry marked "durable fix applied" (done).
 - Verify: JSON valid · each wrapped script exits 0 from a stuck `disbot/` cwd · `check_docs --strict`.
+
+## Done
+
+- `.claude/settings.json` — all 7 hook commands wrapped with
+  `cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}" &&`. JSON validated; programmatic
+  check confirmed 7/7 guarded.
+- Router **Q-0150** records the trap + applied fix + proof. `.session-journal.md` cwd-deadlock entry
+  updated to "durable fix APPLIED (Q-0150)" with the mypy-symlink-gotcha caveat.
+- Proof: each wrapped hook script pipe-tested from a stuck `disbot/` cwd → exit 0. `check_docs
+  --strict` green. PR **#947**, self-merge on green (config + docs only, owner-directed, reversible).
+
+## Handoff / note
+
+Takes effect **next** session. A fresh session should confirm the hooks fire correctly live, then the
+journal's "never `cd` into a subdir" avoidance can be downgraded from a hard rule to plain hygiene.
+
+> Session-level enders (Q-0089 idea · Q-0102 previous-session review · Q-0104 doc audit) for this
+> dispatch run are in the first card, `.sessions/2026-06-16-routine-permission-allowlist.md` (PR #945)
+> — not duplicated across this run's three PRs (#945 permissions, #946 §7.5, #947 this).

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -5624,3 +5624,45 @@ brakes (never touch prod / DB / external-publish / force-history directly from a
    environment's permission mode in the console.
 
 **Home:** `.claude/settings.json` (`permissions.allow` / `permissions.ask`) + this Q-block.
+
+### Q-0150 — Make the `.claude/settings.json` hooks cwd-robust (kill the cwd-deadlock trap) (2026-06-16)
+
+> **APPLIED — owner-directed in-session (the Q-0106 exception).** The maintainer asked for the hook
+> explanation, then directed "yes go ahead" to apply the fix. Applied directly to executable config;
+> this block is the provenance. Implements the durable fix the `.session-journal.md` cwd-deadlock
+> entry had been pointing at ("make the hooks use `$CLAUDE_PROJECT_DIR/scripts/…` — router Q-block,
+> since hooks aren't self-edited per Q-0106").
+
+**The trap.** Every hook command in `.claude/settings.json` invoked its script by a **relative path**
+(`python3.10 scripts/<hook>.py`). The Bash tool's cwd **persists across calls**, so a single compound
+`cd <subdir> && …` leaves cwd in that subdir; from there the PreToolUse hooks (which fire on **Bash,
+Edit, AND Write**) resolve `<subdir>/scripts/<hook>.py`, which doesn't exist → `FileNotFound` → the
+hook exits non-zero → the harness **blocks the tool call**. Because all three mutating tools share the
+relative-path hooks, the session **deadlocks**: the very tools needed to `cd` back or patch anything
+are themselves blocked, and an ordinary subagent inherits the same stuck cwd. (Hit live this session
+*and* previously — it is the journal's documented "cwd-deadlock trap".)
+
+**Fix (applied).** Prefix **every** hook command with a cwd guard that resolves the repo root
+regardless of the stuck cwd, with no dependency on an env var that may be unset:
+```
+cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}" && <original command>
+```
+- Prefers `$CLAUDE_PROJECT_DIR` (the documented Claude Code hook var) but **falls back to
+  `git rev-parse --show-toplevel`** when it is empty/unset — and it *was* observed empty in the
+  shell here, so the fallback is load-bearing, not decorative. `git rev-parse --show-toplevel` returns
+  the repo root even when run from a stuck subdir (git searches upward).
+- The `cd` runs in the **hook's own subshell**, so it never affects the tool's persistent cwd; it also
+  fixes any *internal* relative paths the scripts use. All 7 hook commands updated (PreToolUse
+  Bash + Edit|Write, PostToolUse Edit|Write + create_pull_request, Stop ×2, SessionStart).
+
+**Proof.** Each wrapped command was pipe-tested **from a deliberately-stuck `disbot/` cwd** and exited
+0 (`check_branch_freshness`, `claude_pre_edit`, `claude_post_edit`, `claude_pr_subscribe_reminder`,
+`claude_stop_check`), confirming the exact failure scenario is now handled. JSON validated.
+
+**Caveat.** Like all hook changes, it **takes effect next session** (hooks load at session start), so
+the avoidance note in `.session-journal.md` stays useful until this ships and one fresh session
+confirms it live; the journal entry is updated to mark the durable fix applied. The "never `cd` into
+a subdir" habit remains good hygiene regardless.
+
+**Home:** `.claude/settings.json` (`hooks`) + this Q-block; `.session-journal.md` cwd-deadlock entry
+updated to "durable fix applied (Q-0150)".


### PR DESCRIPTION
## Why

Owner-directed in-session (Q-0106 exception). Every hook command in `.claude/settings.json` invoked its script by a **relative path** (`python3.10 scripts/<hook>.py`). The Bash tool's cwd **persists across calls**, so a single compound `cd <subdir> && …` leaves cwd in that subdir; from there the PreToolUse hooks (which fire on **Bash, Edit, AND Write**) resolve `<subdir>/scripts/<hook>.py` → `FileNotFound` → the hook exits non-zero → the harness **blocks the tool call**. Because all three mutating tools share the relative-path hooks, the session **deadlocks** — the tools needed to recover are themselves blocked, and an ordinary subagent inherits the same stuck cwd. This was hit live this session (recovered via a worktree-isolated agent) and is the journal's long-documented "cwd-deadlock trap". Provenance: **Q-0150**.

## Fix

Prefix **every** hook command with a cwd guard:
```
cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}" && <original command>
```
- Prefers `$CLAUDE_PROJECT_DIR` (the documented Claude Code hook var) but **falls back to `git rev-parse --show-toplevel`** when it's empty/unset — and it *was* observed empty in-shell here, so the fallback is load-bearing. `git rev-parse --show-toplevel` returns the repo root even from a stuck subdir.
- The `cd` runs in the **hook's own subshell**, so it never affects the tool's persistent cwd, and it also fixes any internal relative paths the scripts use.
- All **7** hook commands updated: PreToolUse (Bash, Edit|Write), PostToolUse (Edit|Write, create_pull_request), Stop (×2), SessionStart.

## Proof

Each wrapped command was pipe-tested **from a deliberately-stuck `disbot/` cwd** and exited 0 (`check_branch_freshness`, `claude_pre_edit`, `claude_post_edit`, `claude_pr_subscribe_reminder`, `claude_stop_check`) — the exact failure scenario is now handled. JSON validated; `check_docs --strict` green.

## Notes

- **Takes effect next session** (hooks load at session start), so the journal's avoidance note stays useful until a fresh session confirms it live; the journal entry is updated to "durable fix applied (Q-0150)".
- Config + docs only; no `disbot/` runtime code. Self-merge on green (Q-0113) — contained, reversible, owner-directed.

https://claude.ai/code/session_01VKmqvXEk2KajWxWnjhGKKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKmqvXEk2KajWxWnjhGKKr)_