### PR TITLE
fix(runtime): release the singleton lock early on shutdown — kill ~85s deploy downtime

### DIFF
--- a/.sessions/2026-06-16-runtime-lock-early-release.md
+++ b/.sessions/2026-06-16-runtime-lock-early-release.md
@@ -1,14 +1,122 @@
 # Session — runtime lock: release early on shutdown (fix ~85s deploy downtime)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-## What I'm about to do
+## Origin — a production Railway log dump
 
-A production Railway log dump showed an intermittent **~85s of bot downtime on deploy**: when the
-platform force-kills the old container ~10s after SIGTERM (before the bot's graceful `bot.close()`
-budget of 20s has elapsed), the singleton runtime-lock is never released, so the new replica waits
-the full ~90s stale-TTL before it can start. Owner decision (this session): **release the lock early**
-— drop it the moment shutdown begins, before the slow `bot.close()` — so a mid-drain SIGKILL can't
-leave the lock wedged. Robust to any kill timing; downtime ~85s → ~6s.
+The owner dropped a ~3.5h Railway log (3 container boots). Triaged it as "here's prod state, find +
+fix what's wrong." The bot itself is healthy (43 cogs load, gateway connects, BTD6 ingestion runs on
+schedule), but one signal was a real, user-visible bug.
 
-(Filled in as the deliberate final step — born-red per Q-0133.)
+## The bug — intermittent ~85s of deploy downtime
+
+Two handoffs in the log:
+- **1st (clean):** old replica `33277b9d` shut down gracefully — logged `BTD6 ingestion supervisor
+  stopped` + `Runtime lock released`; new replica took over in ~10s.
+- **2nd (broken):** old replica `e8eade73` got SIGTERM at `08:45:53` (`closing bot (timeout 20.0s)`),
+  but Railway **force-killed the container ~10s later** at `08:46:03` (proven by `Connection reset by
+  peer` at `08:46:05` and the **absence of any `Runtime lock released` log**). New replica `05ed9fef`
+  then waited **95.6s (20 poll attempts)** for the stale lock to expire → **no live bot for ~89s**.
+
+**Root cause:** the singleton runtime-lock is released only in `main()`'s `finally` — *after*
+`bot.close()` (20s budget) + a 5s task drain. Railway's kill grace (~10s observed) is **shorter than
+the bot's own close timeout (20s)**, so on a slow close the `finally` never runs and the lock leaks for
+its full 90s TTL. Compounding it, the close-timeout force-exit (`os._exit(1)`) *also* bypasses the
+`finally`, leaving the lock "wedged until its 90s TTL" — the exact thing its own comment claims to
+avoid. It's intermittent because it only bites when `bot.close()` is slower than the platform grace.
+
+## Decision (owner, AskUserQuestion)
+
+Offered three approaches (early release / raise Railway grace / shorten close timeout). Owner chose
+**release the lock early** — robust to any kill timing (crash/OOM included), downtime ~85s → ~6s.
+
+## Fix
+
+- **`bot1._drive_close_on_lifecycle_request`** — the instant shutdown begins (right after the "closing
+  bot" log, before the close-beginning webhook and `bot.close()`): `_heartbeat_stop.set()` then
+  `await _runtime.release_lock_best_effort()`. So a mid-drain SIGKILL can no longer wedge the lock. The
+  release is idempotent + boot-scoped (`utils.db.runtime_lock.release` DELETEs only this boot's row), so
+  `main()`'s finally re-runs it as the canonical no-op net.
+- **`services.runtime.run_heartbeat_loop`** — a `not owned` result *while `stop_event` is set* is now an
+  expected shutdown release (new `outcome="released"`, clean loop exit), not a false "peer reclaimed →
+  split-brain → `os._exit(1)`". Ordering is guaranteed: the driver sets the stop-event *before* the row
+  is deleted, and the loop reads `is_set()` only after observing the row gone.
+- **`_heartbeat_stop` + `services.runtime`** promoted to module scope so the driver can reach them
+  (removed the `main()`-local copies).
+- **`services.metrics`** — documented the new `released` outcome on `runtime_lock_heartbeat_total`.
+
+### Architectural decision (recorded in the invariant docstrings)
+
+Two AST invariants (`test_lifecycle_observability_contract.py`, `test_bot_boot.py`) forbade the driver
+from calling `release_lock_best_effort` (cleanup belongs to `main()`'s finally). Updated **deliberately,
+with rationale**: the lock release is *not* local teardown like `db.close`/`reporter.close` — it is the
+**next-replica handoff signal**, and leaking it costs ~90s of downtime, so the driver drops it early on
+every shutdown path. `db.close` / `reporter.close` / `sys.exit` / `os.execv` stay finally-only, so
+shutdown-vs-restart cleanup remains unified. Both invariants now *assert the driver does release the
+lock, before `bot.close()`*.
+
+### Tradeoff (accepted)
+
+The lock frees while the old replica is still draining, so in rare unlucky timing the new replica could
+briefly overlap. In practice the new replica's 5s acquire-poll + ~connect time lands after the old's
+gateway has closed, so overlap is typically zero — strictly better than ~85s downtime.
+
+## Verification
+
+- `tests/unit/services/test_runtime.py` — new `test_heartbeat_released_when_lock_dropped_during_shutdown`
+  (released outcome, no `os._exit`); the peer-reclaim `lost`→`os._exit` path unchanged.
+- `tests/unit/test_bot1_lifecycle_close_driver.py` — new ordering test (release + heartbeat-stop happen
+  *before* `bot.close()`) + an autouse isolation fixture stubbing the early release.
+- Both invariant tests updated (forbidden-set minus the lock; positive assertions added).
+- `python3.10 scripts/check_quality.py --full` → **green (9939 passed, 37 skipped)**.
+- `python3.10 scripts/check_architecture.py --mode strict` → **exit 0** (only pre-existing `views`
+  warnings).
+
+**Merge ≠ deploy** — the downtime fix only takes effect after a Railway prod deploy.
+
+## Out of scope (noted, not fixed)
+
+- **"Config arbitration — degraded"** startup-health WARNING on every boot = the settings arbiter
+  falling back to legacy reads for some keys (`services/platform_consistency.py:_collect_config_arbitration`).
+  Designed-degradation; the known settings/bindings convergence lane — not a crash, separate concern.
+- **"setup_cog.on_ready: launcher message … is gone"** = the stored setup message was deleted in
+  Discord; logged + handled (`setup_cog.py:701`). Benign INFO.
+
+## 💡 Session idea (Q-0089)
+
+[`close-timeout-align-with-platform-grace-2026-06-16.md`](../docs/ideas/close-timeout-align-with-platform-grace-2026-06-16.md)
+— make `LIFECYCLE_CLOSE_TIMEOUT_SECONDS` env-configurable (mirror the `RUNTIME_LOCK_BOOT_*` knobs) so
+an operator can set it *below* the platform's real kill-grace. The force-exit fallback currently
+(hardcoded 20s) never fires under Railway's ~10s grace; the early lock-release makes that mostly moot
+for the lock, but aligning the timeout is real defense-in-depth for the rest of the finally cleanup.
+Small/decided-lane follow-up to this PR. (Indexed in `docs/ideas/README.md`.)
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous session: **BUG-0013 deathmatch challenge-timer fix** (`2026-06-16-fix-deathmatch-challenge-timer.md`).
+- **Did well:** first end-to-end proof of the reported-bug → Hermes-`intake`-triage → Claude-fix loop;
+  a tight, contained `_ChallengeView` fix with fail-against-old regression tests.
+- **What it surfaced (and the genuine through-line to today):** that bug was *"a timed view kept doing
+  work after it should have stopped, and clobbered its successor."* Today's bug is the **same class** at
+  the runtime layer — the heartbeat loop would have `os._exit(1)`'d on our *intentional* lock release if
+  I hadn't taught it that a stop-signalled release is benign. Both are "a loop/timer outlives its stop
+  signal."
+- **Concrete workflow improvement:** the deathmatch session *captured* its stays-fixed guard (an AST
+  invariant for timed views that transition without `self.stop()`) but **deferred building it** — it's
+  still open in that log. This session, by contrast, shipped its positive invariant alongside the fix.
+  The norm worth making explicit: **a lifecycle/timer/loop fix ships its "stays-fixed" invariant in the
+  same PR.** The deathmatch session's deferred guard is a ready grooming pick-up for a future session
+  (left un-bundled here on purpose — runtime PR, focused risk profile).
+
+## Documentation audit (Q-0104)
+
+- `check_docs.py --strict` → **green**. `check_architecture --mode strict` → exit 0.
+- `check_current_state_ledger.py --strict` flags **#944, #945** as not-yet-in-ledger — these are merges
+  from *before* this session (the branch started at #945's merge commit), i.e. the standing
+  living-ledger drift the **next reconciliation** handles (not due till #960; Q-0124: manual sessions
+  don't run the reconciliation pass). PR #948 is intentionally **not** added (unmerged — the next
+  session reconciles it). No chat-only durable info outstanding: the fix is in code + tests, the
+  decision + rationale in the invariant docstrings, the idea is filed + indexed, the claim is cleared.
+- Backlog grooming (Q-0015): deliberately *not* bundled — this is a focused, higher-risk runtime PR and
+  mixing unrelated idea-execution in would violate the small-focused-runtime-PR norm. Named the ready
+  grooming pick-up above (the deathmatch timed-view invariant).

--- a/.sessions/2026-06-16-runtime-lock-early-release.md
+++ b/.sessions/2026-06-16-runtime-lock-early-release.md
@@ -1,0 +1,14 @@
+# Session — runtime lock: release early on shutdown (fix ~85s deploy downtime)
+
+> **Status:** `in-progress`
+
+## What I'm about to do
+
+A production Railway log dump showed an intermittent **~85s of bot downtime on deploy**: when the
+platform force-kills the old container ~10s after SIGTERM (before the bot's graceful `bot.close()`
+budget of 20s has elapsed), the singleton runtime-lock is never released, so the new replica waits
+the full ~90s stale-TTL before it can start. Owner decision (this session): **release the lock early**
+— drop it the moment shutdown begins, before the slow `bot.close()` — so a mid-drain SIGKILL can't
+leave the lock wedged. Robust to any kill timing; downtime ~85s → ~6s.
+
+(Filled in as the deliberate final step — born-red per Q-0133.)

--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -14,6 +14,7 @@ from discord.ext import commands
 
 import config
 from core.runtime import lifecycle as _lifecycle
+from services import runtime as _runtime
 from services.runtime import BOOT_ID, install_boot_id_logging
 from services.webhook_reporter import WebhookReporter
 from utils import command_resolution, db
@@ -726,6 +727,14 @@ LIFECYCLE_CLOSE_TIMEOUT_SECONDS: float = 20.0
 _LIFECYCLE_CLOSE_POLL_INTERVAL: float = 0.5
 _LIFECYCLE_CLOSE_WEBHOOK_TIMEOUT_SECONDS: float = 2.0
 
+# Signals the runtime-lock heartbeat loop to stop. Module-level (not a
+# main() local) so the close-driver can set it the instant shutdown
+# begins — the heartbeat loop then treats a now-missing lock row as an
+# intentional shutdown release rather than a hostile peer-reclaim.
+# main() passes this same event to run_heartbeat_loop and re-sets it in
+# its finally block (idempotent).
+_heartbeat_stop: asyncio.Event = asyncio.Event()
+
 
 def _should_drive_lifecycle_close() -> bool:
     """Single eligibility predicate for the close-driver.
@@ -784,6 +793,21 @@ async def _drive_close_on_lifecycle_request() -> None:
             reason,
             LIFECYCLE_CLOSE_TIMEOUT_SECONDS,
         )
+        # LP-4 fast deploy handoff: drop the runtime lock NOW — before the
+        # slow bot.close() drain, the close-beginning webhook, and any
+        # force-exit branch below — so the next replica reclaims within its
+        # acquire-poll instead of waiting the ~90s stale TTL when the
+        # platform SIGKILLs us mid-drain (the ~85s production downtime this
+        # fixes). The release is idempotent + boot-scoped
+        # (utils.db.runtime_lock.release), so main()'s finally re-runs it as
+        # the canonical no-op net. Stop the heartbeat FIRST so its next tick
+        # treats the now-missing row as this intentional shutdown release,
+        # not a hostile peer-reclaim → os._exit. The lock is special among
+        # teardown steps — it is the next-replica handoff signal, not local
+        # cleanup like db/reporter close — so it (and only it) is dropped
+        # here; everything else stays owned by main()'s finally.
+        _heartbeat_stop.set()
+        await _runtime.release_lock_best_effort()
         if reporter is not None and pending is not None:
             try:
                 await asyncio.wait_for(
@@ -868,11 +892,10 @@ async def main() -> None:
     # Acquire the runtime instance lock now that migrations (including
     # 034_bot_runtime_lock) have run. If another replica holds the lock
     # this raises ``SystemExit(0)`` — Railway treats that as a graceful
-    # exit and does not crash-loop the loser.
-    from services import runtime as _runtime
-
+    # exit and does not crash-loop the loser. ``_runtime`` and
+    # ``_heartbeat_stop`` are module-level so the close-driver can release
+    # the lock + stop the heartbeat early (LP-4 fast handoff).
     await _runtime.acquire_lock_or_exit()
-    _heartbeat_stop = asyncio.Event()
 
     from core import runtime
     from core.runtime import message_pipeline

--- a/disbot/services/metrics.py
+++ b/disbot/services/metrics.py
@@ -166,13 +166,15 @@ runtime_lock_boot_wait_seconds = Histogram(
 # Runtime-lock heartbeat refresh attempts.  ``ok`` = lock still owned by
 # this boot; ``error`` = transient DB exception (retried up to
 # _HEARTBEAT_FAILURE_LIMIT before force-exit); ``lost`` = a peer reclaimed
-# the lock (single observation followed immediately by os._exit).
+# the lock (single observation followed immediately by os._exit);
+# ``released`` = the shutdown path dropped the lock on purpose for a fast
+# deploy handoff and the heartbeat loop exited cleanly (NOT a split-brain).
 # A sustained non-zero ``error`` rate indicates DB connectivity issues;
 # any ``lost`` observation indicates a split-brain that was just resolved.
 runtime_lock_heartbeat_total = Counter(
     "runtime_lock_heartbeat_total",
     "Runtime-lock heartbeat refresh attempts by outcome.",
-    ["outcome"],  # ok | error | lost
+    ["outcome"],  # ok | error | lost | released
 )
 
 # Current lifecycle phase, encoded as a multi-series gauge: exactly one

--- a/disbot/services/runtime.py
+++ b/disbot/services/runtime.py
@@ -256,8 +256,13 @@ async def run_heartbeat_loop(
       to keep running with a stale lock that another replica may have
       already reclaimed.
     * On a successful ``UPDATE 0`` (the row no longer matches our
-      ``boot_id``): treat as fatal; another replica won. Exit
-      immediately so we don't double-respond.
+      ``boot_id``) **while ``stop_event`` is set**: the shutdown path
+      (``bot1._drive_close_on_lifecycle_request``) released the lock on
+      purpose for a fast deploy handoff. Exit the loop cleanly
+      (``outcome="released"``) — this is expected, not a takeover.
+    * On a successful ``UPDATE 0`` with ``stop_event`` unset: treat as
+      fatal; another replica won. Exit immediately so we don't
+      double-respond.
     """
     from services import metrics as _metrics
 
@@ -293,6 +298,23 @@ async def run_heartbeat_loop(
                 time.monotonic() - heartbeat_started_at,
             )
             if not owned:
+                if stop_event.is_set():
+                    # Shutdown in progress: the close path released the
+                    # lock on purpose for a fast deploy handoff (see
+                    # bot1._drive_close_on_lifecycle_request, which sets
+                    # this event *before* deleting the row). A missing row
+                    # here is expected, not a hostile peer-reclaim — exit
+                    # the loop cleanly rather than os._exit(1).
+                    _metrics.runtime_lock_heartbeat_total.labels(
+                        outcome="released",
+                    ).inc()
+                    logger.info(
+                        "Runtime lock released for shutdown; heartbeat "
+                        "loop exiting (lock_name=%s boot_id=%s).",
+                        lock_name,
+                        boot_id,
+                    )
+                    return
                 _metrics.runtime_lock_heartbeat_total.labels(outcome="lost").inc()
                 logger.critical(
                     "Runtime lock no longer owned by this boot "

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -20,6 +20,13 @@ during grooming** (it stays listed here, annotated ✅) so the active backlog re
 
 Current broad captures:
 
+- [`close-timeout-align-with-platform-grace-2026-06-16.md`](./close-timeout-align-with-platform-grace-2026-06-16.md) —
+  **session idea (2026-06-16, Q-0089, from the runtime-lock deploy-downtime fix PR #948):** make
+  `LIFECYCLE_CLOSE_TIMEOUT_SECONDS` env-configurable (mirror the `RUNTIME_LOCK_BOOT_*` knobs) so an
+  operator can set it **below** the platform's real SIGTERM→SIGKILL grace (~10s observed on Railway vs
+  the hardcoded 20s) — defense-in-depth so the close-driver's force-exit fallback actually fires before
+  the platform kills the process. Small/decided-lane follow-up. → relates `disbot/bot1.py` ·
+  `disbot/services/runtime.py`.
 - [`control-plane-single-source-pointer-2026-06-15.md`](./control-plane-single-source-pointer-2026-06-15.md) —
   **session idea (2026-06-15, Q-0089) — ✅ EXECUTED (PR #943):** the autonomous-loop
   control-plane truth lives in two prose homes (the canonical table in `autonomous-routines.md` **and**

--- a/docs/ideas/close-timeout-align-with-platform-grace-2026-06-16.md
+++ b/docs/ideas/close-timeout-align-with-platform-grace-2026-06-16.md
@@ -1,0 +1,49 @@
+# Idea — align the lifecycle close-timeout with the platform's kill-grace (defense-in-depth)
+
+> **Status:** `ideas`. Not a plan, not approval. Source + binding contracts win.
+> Captured 2026-06-16 (Q-0089 session ender) from the runtime-lock deploy-downtime fix (PR #948).
+
+## The observation
+
+PR #948 fixed the ~85s deploy downtime by releasing the runtime lock **early** (the moment
+shutdown begins), so a platform SIGKILL mid-`bot.close()` can't wedge the lock. That's the
+primary fix and it stands on its own.
+
+But the investigation surfaced a second, latent mismatch worth closing as **defense-in-depth**:
+
+- `LIFECYCLE_CLOSE_TIMEOUT_SECONDS` is a hardcoded **20s** (`disbot/bot1.py`).
+- Railway's observed SIGTERM→SIGKILL grace in the prod log was **~10s** (SIGTERM `08:45:53` →
+  container stop `08:46:03`).
+- So the close-driver's `os._exit(1)` force-exit fallback (the path meant to fire on a *hung*
+  close) **never actually fires in this environment** — the platform kills the process first.
+
+The early lock-release makes this mostly moot for the lock specifically, but the timeout is
+still misaligned with reality: any *other* finally-block cleanup (DB close, reporter close)
+that the force-exit path was meant to bound is also at the platform's mercy.
+
+## The idea
+
+Make the close timeout **env-configurable** (mirror the existing `RUNTIME_LOCK_BOOT_WAIT_SECONDS`
+/ `RUNTIME_LOCK_BOOT_POLL_SECONDS` knobs in `services/runtime.py`), e.g.
+`RUNTIME_CLOSE_TIMEOUT_SECONDS`, so an operator can set it **below** their platform's real
+kill-grace. Then the in-process force-exit fires *before* the platform's SIGKILL, and the
+finally-block cleanup (the parts that aren't already early-released) gets a real chance to run.
+
+Optionally: log the platform grace as **observed** — on SIGTERM, the heartbeat-freeze-to-kill
+delta is derivable across boots from the lock row, so a startup line could report "previous
+holder's grace ≈ Xs" and flag when the configured close timeout exceeds it.
+
+## What to look into / cautions
+
+- Don't set it *too* low — a legitimately slow-but-valid close (many in-flight interactions)
+  shouldn't be cut short. Default should stay generous (the current 20s is fine as a default).
+- The real grace is platform-specific and not in the repo (no `railway.toml`); an env knob is
+  the right seam, with docs noting "set this under your platform's termination grace."
+- Verify against another prod log or two that ~10s is the steady grace (one data point only).
+
+## Disposition
+
+Small, contained, low-risk follow-up to PR #948. Decided-lane (mirrors an existing pattern).
+A future session can execute it directly, or fold it into the next runtime-hardening slice.
+Relates: `disbot/bot1.py` (`LIFECYCLE_CLOSE_TIMEOUT_SECONDS`), `disbot/services/runtime.py`
+(the env-knob pattern), `docs/runtime_contracts.md`.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,9 +25,6 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/keen-heisenberg-xqro71` · runtime lock — release early on shutdown (fix ~85s deploy
-  downtime; prod log triage) · `disbot/{bot1.py,services/runtime.py,services/metrics.py}` +
-  lifecycle invariant tests · 2026-06-16
 - `claude/modest-ptolemy-2xipoh` · design capture — routine dispatch / staged deep-clean /
   planning sectors (owner discussion) · `docs/ideas/` + router Q-0137 · 2026-06-14
 - `claude/hopeful-allen-home-slice-c` · mining Slice C — Home structure (character-card backdrop) ·
@@ -40,6 +37,9 @@ living ledger (`docs/current-state.md`).
 
 ## Recently cleared
 
+- `claude/keen-heisenberg-xqro71` · runtime lock — release early on shutdown (fix ~85s deploy
+  downtime; prod log triage) · `disbot/{bot1.py,services/runtime.py,services/metrics.py}` +
+  lifecycle invariant tests · 2026-06-16 · **PR #948 (open, auto-merge on green)**
 - `claude/hopeful-allen-qt5ax3` · games-economy faucet/sink diagnostic (`!platform economy`) ·
   `utils/db/economy` + `services/economy_flow_service` + `cogs/diagnostic` · 2026-06-16 ·
   **PR #937 (merged)**

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,9 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/keen-heisenberg-xqro71` · runtime lock — release early on shutdown (fix ~85s deploy
+  downtime; prod log triage) · `disbot/{bot1.py,services/runtime.py,services/metrics.py}` +
+  lifecycle invariant tests · 2026-06-16
 - `claude/modest-ptolemy-2xipoh` · design capture — routine dispatch / staged deep-clean /
   planning sectors (owner discussion) · `docs/ideas/` + router Q-0137 · 2026-06-14
 - `claude/hopeful-allen-home-slice-c` · mining Slice C — Home structure (character-card backdrop) ·

--- a/tests/unit/invariants/test_lifecycle_observability_contract.py
+++ b/tests/unit/invariants/test_lifecycle_observability_contract.py
@@ -14,8 +14,11 @@ future contributor cannot quietly:
   depends on (beginning / completed / timeout / startup summary),
 * remove a Prometheus metric the dashboards rely on
   (``lifecycle_*``, ``runtime_lock_*``, ``webhook_*``),
-* move cleanup ownership out of ``main()``'s finalizer into the
-  close-driver (which would couple shutdown vs restart cleanup).
+* move local-teardown ownership (DB close, reporter close, process
+  exit) out of ``main()``'s finalizer into the close-driver (which
+  would couple shutdown vs restart cleanup) — the runtime-lock release
+  is the deliberate exception, dropped *early* by the driver for a fast
+  deploy handoff (see ``test_close_driver_releases_runtime_lock_before_bot_close``).
 
 The contract is enforced via AST + attribute inspection so it runs in
 under a second and surfaces a meaningful failure message at CI time.
@@ -216,7 +219,6 @@ def test_close_driver_calls_close_timeout_webhook_before_os_exit() -> None:
 _DRIVER_FORBIDDEN_CALLS: tuple[str, ...] = (
     "db.close",
     "reporter.close",
-    "release_lock_best_effort",
     "sys.exit",
     "os.execv",
 )
@@ -224,7 +226,6 @@ _DRIVER_FORBIDDEN_CALLS: tuple[str, ...] = (
 
 def test_close_driver_does_not_own_finalizer_cleanup() -> None:
     """``main()``'s ``finally`` block is the canonical owner of:
-      - the runtime-lock release (``release_lock_best_effort``),
       - the DB pool close (``db.close``),
       - the reporter HTTP teardown (``reporter.close``),
       - any process-exit primitive other than the timeout-branch
@@ -233,6 +234,14 @@ def test_close_driver_does_not_own_finalizer_cleanup() -> None:
     A driver that owns any of these forks shutdown vs restart cleanup,
     which is what the close-path PRs generalised away.  This invariant
     catches any reversal.
+
+    **Exception — the runtime-lock release.** The lock release is *not*
+    local teardown; it is the next-replica handoff signal, and leaking
+    it costs ~90s of user-visible downtime on the next deploy. So the
+    driver deliberately drops it early (pinned by
+    ``test_close_driver_releases_runtime_lock_before_bot_close``);
+    main()'s finally re-runs it idempotently. It is intentionally NOT in
+    ``_DRIVER_FORBIDDEN_CALLS``.
     """
     fn = _close_driver_ast()
     offenders: list[str] = []
@@ -246,6 +255,32 @@ def test_close_driver_does_not_own_finalizer_cleanup() -> None:
         "contract reserves these for main()'s finally block: "
         f"{sorted(set(offenders))!r}"
     )
+
+
+def test_close_driver_releases_runtime_lock_before_bot_close() -> None:
+    """Fast deploy handoff (the ~85s-downtime fix): the close-driver must
+    drop the runtime lock EARLY — before the slow ``bot.close()`` — so a
+    platform SIGKILL mid-drain cannot leave the singleton lock wedged for
+    its ~90s stale TTL. The lock release is the one teardown step the
+    driver owns (it is the next-replica handoff signal, not local cleanup
+    like db/reporter close); ``main()``'s finally re-runs it idempotently.
+    """
+    fn = _close_driver_ast()
+    release_calls = [
+        c
+        for c in _calls_in(fn)
+        if _call_dotted_name(c).endswith("release_lock_best_effort")
+    ]
+    assert release_calls, (
+        "Close-driver must call release_lock_best_effort() early so the "
+        "runtime lock is freed before bot.close() — otherwise a SIGKILL "
+        "mid-close leaks the lock for ~90s (deploy downtime)."
+    )
+    close_calls = [c for c in _calls_in(fn) if _call_dotted_name(c) == "bot.close"]
+    assert close_calls, "Close-driver must still call bot.close()."
+    assert min(c.lineno for c in release_calls) < min(
+        c.lineno for c in close_calls
+    ), "release_lock_best_effort() must run BEFORE bot.close() in the driver."
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_runtime.py
+++ b/tests/unit/services/test_runtime.py
@@ -350,6 +350,34 @@ async def test_heartbeat_metric_increments_lost_when_peer_reclaims():
     exit_mock.assert_called_with(1)
 
 
+@pytest.mark.asyncio
+async def test_heartbeat_released_when_lock_dropped_during_shutdown():
+    """A ``UPDATE 0`` while ``stop_event`` is set is the shutdown path's
+    intentional early release (LP-4 fast deploy handoff), not a peer
+    reclaim: outcome=released, the loop exits cleanly, and os._exit is
+    NOT called. This is what lets bot1's close-driver drop the lock
+    before bot.close() without the heartbeat racing it into a false
+    split-brain exit."""
+    stop = asyncio.Event()
+    before_released = _heartbeat_counter_value("released")
+    before_lost = _heartbeat_counter_value("lost")
+
+    async def _hb(*_a, **_kw):
+        # Model the close-driver setting the stop-event *before* deleting
+        # the row, so the not-owned result is seen as a shutdown release.
+        stop.set()
+        return False
+
+    with patch.object(rl_db, "heartbeat", side_effect=_hb), patch(
+        "services.runtime.os._exit",
+    ) as exit_mock:
+        await runtime.run_heartbeat_loop(stop, interval_seconds=0)
+
+    assert _heartbeat_counter_value("released") == before_released + 1
+    assert _heartbeat_counter_value("lost") == before_lost
+    exit_mock.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # runtime_lock_heartbeat_seconds — duration of each heartbeat UPDATE call,
 # observed on every attempt (success AND exception) so DB latency trends

--- a/tests/unit/test_bot1_lifecycle_close_driver.py
+++ b/tests/unit/test_bot1_lifecycle_close_driver.py
@@ -32,6 +32,21 @@ def _reset_lifecycle_state() -> None:
     lifecycle.reset_for_tests()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_early_lock_release(monkeypatch: pytest.MonkeyPatch):
+    """The close-driver now releases the runtime lock + signals the
+    heartbeat to stop early (LP-4 fast deploy handoff). These tests run
+    without a DB pool, so stub the release to a no-op AsyncMock and reset
+    the module-level heartbeat-stop event between cases. The dedicated
+    ordering test installs its own spy over this stub."""
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(bot1._runtime, "release_lock_best_effort", AsyncMock())
+    bot1._heartbeat_stop.clear()
+    yield
+    bot1._heartbeat_stop.clear()
+
+
 class _FakeBot:
     """Minimal stand-in for ``commands.Bot`` exposing only ``close``."""
 
@@ -160,6 +175,41 @@ async def test_webhook_fires_before_bot_close(
     await asyncio.wait_for(bot1._drive_close_on_lifecycle_request(), timeout=2.0)
 
     assert order == ["webhook", "close"]
+
+
+@pytest.mark.asyncio
+async def test_close_driver_releases_lock_and_stops_heartbeat_before_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LP-4 fast deploy handoff (the ~85s-downtime fix): the driver must
+    drop the runtime lock and signal the heartbeat to stop BEFORE the slow
+    bot.close(), so a platform SIGKILL mid-drain cannot leave the singleton
+    lock wedged for its ~90s stale TTL."""
+    order: list[str] = []
+
+    class OrderedBot:
+        async def close(self) -> None:
+            order.append("close")
+
+    async def _spy_release(*_a: Any, **_kw: Any) -> None:
+        order.append("release")
+
+    monkeypatch.setattr(bot1, "bot", OrderedBot())
+    monkeypatch.setattr(bot1, "reporter", None)
+    monkeypatch.setattr(bot1._runtime, "release_lock_best_effort", _spy_release)
+    _install_fast_poll(monkeypatch)
+
+    assert not bot1._heartbeat_stop.is_set()
+    lifecycle.set_phase(lifecycle.Phase.RUNNING)
+    lifecycle.request_shutdown(reason="sigterm")
+
+    await asyncio.wait_for(bot1._drive_close_on_lifecycle_request(), timeout=2.0)
+
+    assert order == ["release", "close"], order
+    assert bot1._heartbeat_stop.is_set(), (
+        "driver must set the heartbeat stop-event so the heartbeat loop "
+        "treats the released lock as an intentional shutdown, not a reclaim"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_bot_boot.py
+++ b/tests/unit/test_bot_boot.py
@@ -230,10 +230,16 @@ def test_bot1_close_driver_gates_on_pending_and_draining() -> None:
 
 
 def test_bot1_close_driver_does_not_own_cleanup() -> None:
-    """Architectural boundary: cleanup belongs to ``main()``'s finally
-    block, not the close-driver.  The driver function body must not
-    call runtime-lock release, db.close, reporter.close, os.execv, or
-    sys.exit.  ``os._exit`` is permitted (close-timeout fail-safe).
+    """Architectural boundary: local teardown belongs to ``main()``'s
+    finally block, not the close-driver.  The driver function body must
+    not call db.close, reporter.close, os.execv, or sys.exit.
+    ``os._exit`` is permitted (close-timeout fail-safe).
+
+    The runtime-lock release is the deliberate exception: the driver
+    drops it *early* (before bot.close()) for a fast deploy handoff,
+    because a leaked lock costs ~90s of downtime on the next deploy — it
+    is the next-replica handoff signal, not local cleanup.  main()'s
+    finally re-runs it idempotently.
 
     AST-scoped to the driver function so that legitimate uses of those
     same calls elsewhere in bot1.py (the actual finalizer) are not
@@ -253,7 +259,6 @@ def test_bot1_close_driver_does_not_own_cleanup() -> None:
     ), "bot1.py must define async def _drive_close_on_lifecycle_request."
 
     forbidden_attr_calls = {
-        "release_lock_best_effort",
         "execv",
     }
     forbidden_attr_chains = {


### PR DESCRIPTION
## Why

A production Railway log dump showed an **intermittent ~85s of bot downtime on deploy**.

Timeline from the log (2nd of two handoffs):
- `08:45:53` old replica `e8eade73` gets SIGTERM → `closing bot (timeout 20.0s)`
- `08:46:03` Railway **force-kills the container** (~10s later) — proven by `Connection reset by peer` at `08:46:05` and the **absence of any `Runtime lock released` log**
- `08:45:52`→`08:47:28` new replica `05ed9fef` waits **95.6s (20 poll attempts)** for the stale lock to expire
- net: **no live bot for ~89s**

### Root cause
The runtime lock is released only in `main()`'s `finally` — *after* `bot.close()` (20s budget) + a 5s task drain. Railway's kill grace (~10s observed) is **shorter than the bot's own close timeout (20s)**, so on a slow close the `finally` never runs and the lock leaks for its full 90s TTL. The close-timeout force-exit (`os._exit(1)`) *also* bypasses the `finally`, leaving the lock "wedged until its 90s TTL" — the exact thing its own comment claims to avoid. The first handoff in the same log was clean (close finished in time), which is why this is intermittent.

## Fix (owner-chosen: "release the lock early")

Release the runtime lock **the moment shutdown begins** — as the first action of the close driver, before the slow `bot.close()` — so a mid-drain SIGKILL can no longer wedge it. Robust to *any* kill timing (crash/OOM included); downtime ~85s → ~6s.

- `bot1._drive_close_on_lifecycle_request`: stop the heartbeat + `release_lock_best_effort()` right after the "closing bot" log, before the close-beginning webhook / `bot.close()`. The release is idempotent + boot-scoped (`utils.db.runtime_lock.release`), so `main()`'s `finally` still re-runs it as the canonical net (no-op when already gone).
- `services.runtime.run_heartbeat_loop`: a `not owned` result while `stop_event` is set is now an **expected shutdown release** (new `outcome="released"`, clean loop exit) rather than a false "peer reclaimed → split-brain → `os._exit(1)`". Ordering is guaranteed: the driver sets the stop-event *before* deleting the row.
- `_heartbeat_stop` + `services.runtime` promoted to module scope so the driver can reach them.

### Architectural note
Two AST invariants (`test_lifecycle_observability_contract.py`, `test_bot_boot.py`) forbade the driver from calling `release_lock_best_effort` (cleanup belongs to `main()`'s finally). Updated **deliberately, with rationale**: the lock release is special — it is the *next-replica handoff signal*, not local teardown like `db.close`/`reporter.close`. It must be dropped on every shutdown path, as early as possible, because leaking it costs ~90s of user-visible downtime. `db.close` / `reporter.close` / `sys.exit` / `os.execv` stay finally-only, so shutdown-vs-restart cleanup remains unified.

### Tradeoff (accepted)
The lock frees while the old replica is still draining `bot.close()`, so in rare unlucky timing the new replica could briefly overlap the old. In practice the new replica's 5s acquire-poll + connect lands after the old's gateway has closed, so overlap is typically zero — and this is strictly better than ~85s of downtime.

## Tests
- `test_runtime.py`: new — `not owned` + `stop_event` set → `outcome="released"`, no `os._exit`; the existing peer-reclaim `lost`→`os._exit` path is unchanged.
- `test_bot1_lifecycle_close_driver.py`: new — driver releases the lock **before** `bot.close()` and sets the heartbeat stop-event.
- Both invariant tests updated to assert the driver *does* release the lock (and still must not own db/reporter/exit).

Out of scope (noted in the session log): the recurring "Config arbitration — degraded" startup-health warning (known settings/bindings convergence lane) and the benign "launcher message … is gone" info log.

🤖 https://claude.ai/code/session_01Q9Kb4db8VyTSfMRvv9oAn9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9Kb4db8VyTSfMRvv9oAn9)_