### PR TITLE
fix(commands): stop the `!coglist` infinite "assumed from" loop (BUG-0014)

### DIFF
--- a/.sessions/2026-06-16-fix-coglist-resolution-loop.md
+++ b/.sessions/2026-06-16-fix-coglist-resolution-loop.md
@@ -1,0 +1,19 @@
+# Session — fix BUG-0014: `!coglist` infinite "assumed from" command-resolution loop
+
+> **Status:** `in-progress`
+
+## What I'm about to do
+
+Owner uploaded a Discord screen recording: typing `!coglist` (or `!cogs`) makes SuperBot spam
+"↩️ Ran `!coglist` — assumed from `!coglist`." **forever, until the bot is restarted.** Root cause
+(confirmed): `utils/synonyms.py` declares `"coglist": ["listcogs", "cogslist"]`, but **no `coglist`
+command is registered** (audited: it's the only orphaned canonical of 32). The typo-resolver
+auto-corrects the fuzzy token to the phantom `coglist`; `on_command_error` re-dispatches `!coglist`
+via `process_commands`; it `CommandNotFound`s again → re-resolves to itself → infinite loop.
+
+Fix (durable, root-cause): (1) **loop-breaker in `on_command_error`** — only re-dispatch an AUTO
+correction when it's a *registered* command *different* from the raw token (a phantom/identity
+correction can only re-loop); (2) **remove the orphaned `coglist` synonym**; (3) **CI invariant** —
+every `COMMAND_SYNONYMS` canonical must be a real command name/alias (so an orphan can't ship again).
+
+(Filled in as the deliberate final step — born-red per Q-0133.)

--- a/.sessions/2026-06-16-fix-coglist-resolution-loop.md
+++ b/.sessions/2026-06-16-fix-coglist-resolution-loop.md
@@ -1,19 +1,87 @@
 # Session — fix BUG-0014: `!coglist` infinite "assumed from" command-resolution loop
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-## What I'm about to do
+## Origin
 
-Owner uploaded a Discord screen recording: typing `!coglist` (or `!cogs`) makes SuperBot spam
-"↩️ Ran `!coglist` — assumed from `!coglist`." **forever, until the bot is restarted.** Root cause
-(confirmed): `utils/synonyms.py` declares `"coglist": ["listcogs", "cogslist"]`, but **no `coglist`
-command is registered** (audited: it's the only orphaned canonical of 32). The typo-resolver
-auto-corrects the fuzzy token to the phantom `coglist`; `on_command_error` re-dispatches `!coglist`
-via `process_commands`; it `CommandNotFound`s again → re-resolves to itself → infinite loop.
+Owner uploaded a Discord screen recording (extracted frames via a pip-installed static ffmpeg, since
+none was present): typing `!coglist` / `!cogs` made SuperBot spam **"↩️ Ran `!coglist` — assumed from
+`!coglist`." forever — it does not stop until the bot is restarted.** A runaway message loop (spam +
+rate-limit risk). Came in mid-session, right after the runtime-lock PR (#948) merged.
 
-Fix (durable, root-cause): (1) **loop-breaker in `on_command_error`** — only re-dispatch an AUTO
-correction when it's a *registered* command *different* from the raw token (a phantom/identity
-correction can only re-loop); (2) **remove the orphaned `coglist` synonym**; (3) **CI invariant** —
-every `COMMAND_SYNONYMS` canonical must be a real command name/alias (so an orphan can't ship again).
+## Root cause (audited)
 
-(Filled in as the deliberate final step — born-red per Q-0133.)
+`utils/synonyms.py` declared `"coglist": ["listcogs", "cogslist"]`, but **no `coglist` command is
+registered** — an AST audit of the whole table found it's the *only* orphaned canonical of 32. The
+loop:
+
+1. `!coglist` → `CommandNotFound`.
+2. `on_command_error` → `command_resolution.classify("coglist")` fuzzy-matches the synonym `cogslist`
+   → canonical `coglist` (lexically isolated, len≥4, not destructive) → `Outcome.AUTO`.
+3. The handler rewrites the message to `!coglist` (**the same token**) and re-dispatches via
+   `process_commands`.
+4. `!coglist` is still unregistered → `CommandNotFound` → back to step 2. **Infinite loop.**
+
+The structural amplifier: the handler re-dispatched an AUTO correction **without checking the target
+exists or differs from the input**, so any phantom/identity correction loops forever.
+
+## Fix (root-cause, three layers)
+
+1. **Loop-breaker — `bot1.on_command_error`:** an AUTO correction is only re-dispatched when it is a
+   *registered* command (`bot.get_command(...)`) **and** different from the raw token; otherwise it
+   falls through to the normal not-found reply. Makes the loop class impossible regardless of synonym
+   data (the durable, general fix at the dangerous seam).
+2. **Data — `utils/synonyms.py`:** removed the orphaned `coglist` entry.
+3. **CI invariant — `tests/unit/invariants/test_command_synonyms_resolve_to_real_commands.py`:**
+   AST-scans every `@commands.command/group` name + alias across `disbot/` (338 tokens) and asserts
+   every `COMMAND_SYNONYMS` canonical is a real command — so an orphan can't ship again. Verified it
+   flags a re-added `coglist` (not vacuous).
+
+## Verification
+
+- `tests/unit/test_bot1_command_resolution_loop.py` (new, 3 tests): phantom and identity AUTO
+  corrections do **not** re-dispatch (single terminal not-found reply, no "assumed from"); a valid
+  correction (registered + different) still auto-runs exactly once + rewrites the message.
+- The new synonym invariant + existing `test_command_resolution.py` pass.
+- `python3.10 scripts/check_quality.py --full` → **green (9958 passed, 37 skipped)**.
+- `python3.10 scripts/check_architecture.py --mode strict` → **exit 0**.
+- Bug book: **BUG-0014** recorded FIXED.
+
+**Merge ≠ deploy** — needs a Railway prod deploy to clear the loop in production.
+
+## 💡 Session idea (Q-0089)
+
+[`reference-integrity-invariants-2026-06-16.md`](../docs/ideas/reference-integrity-invariants-2026-06-16.md)
+— BUG-0014 was a *dangling reference* that failed silently. Extract the AST command-surface discovery
+from the new synonym guard into a shared test helper, and close the sibling gap that
+`test_entrypoints.py` documents as unchecked: `SUBSYSTEMS.entry_points` → a real command. One "what
+commands exist" source for every "this declaration must resolve" invariant. (Filed + indexed.)
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous session: **the runtime-lock early-release fix (PR #948**, `2026-06-16-runtime-lock-early-release.md`).
+- **Did well:** correctly treated the singleton-release-timing change as architectural and used
+  `AskUserQuestion` to let the owner pick the approach (downtime-vs-overlap) rather than guessing —
+  exactly the act-vs-ask line the collaboration model draws; and it shipped a *positive* AST invariant
+  pinning the new behavior, not just a fix.
+- **Through-line it reinforces:** both #948 and this BUG-0014 fix shipped a **CI guard that fails
+  against the old behavior** in the same PR as the fix (#948's "driver releases lock before close"
+  assertion; this session's synonym-orphan invariant). That norm is working and is the cheapest
+  insurance against regressions.
+- **Concrete workflow improvement:** make it an explicit bug-fix-checklist item — *"a live bug fix
+  ships a CI guard that fails against the pre-fix behavior."* Both recent sessions did it ad hoc; the
+  deathmatch session (two back) *deferred* its guard (still open). Worth codifying so it isn't
+  optional. (No code change here — surfaced for the workflow.)
+
+## Documentation audit (Q-0104)
+
+- `check_docs.py --strict` → **green** (new idea file reachable + indexed). `check_architecture
+  --mode strict` → exit 0.
+- Bug book (BUG-0014), session log, active-work claim, and the idea file/index are all updated — no
+  durable info left only in chat. The fix + rationale live in the handler comment + the bug book.
+- Living-ledger drift (#944/#945, and now #948) remains the **next reconciliation's** job (not due
+  till #960; Q-0124 — manual sessions don't run the reconciliation pass). This PR (#949) is
+  intentionally not added to the ledger (unmerged).
+- Backlog grooming (Q-0015): deliberately not bundled — focused, higher-risk runtime bug fix; mixing
+  unrelated idea-execution would violate the small-focused-runtime-PR norm. The standing grooming
+  pickup (the deathmatch timed-view invariant) remains named in #948's log.

--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -503,7 +503,21 @@ async def on_command_error(ctx: commands.Context, error: commands.CommandError) 
         resolution = command_resolution.classify(raw, token_map, auto_set)
         prefix = ctx.prefix or config.PREFIX
 
-        if resolution.outcome is command_resolution.Outcome.AUTO and resolution.command:
+        # Loop-breaker (BUG-0014): an AUTO correction is only safe to
+        # re-dispatch when it points at a *registered* command that *differs*
+        # from what the user typed. Re-dispatching a correction that is
+        # unregistered (e.g. a stale synonym whose canonical has no command)
+        # or identical to the raw token just re-enters CommandNotFound →
+        # re-resolves to the same phantom → an infinite "assumed from" spam
+        # loop that only stops on restart. An unsafe AUTO correction falls
+        # through to the generic not-found reply instead of re-dispatching.
+        auto_safe = (
+            resolution.outcome is command_resolution.Outcome.AUTO
+            and resolution.command is not None
+            and resolution.command.lower() != raw.lower()
+            and bot.get_command(resolution.command) is not None
+        )
+        if auto_safe:
             # Rewrite the mistyped token and re-dispatch through the full
             # command pipeline (process_commands), so permission checks and
             # cooldowns still run — never ctx.invoke, which would bypass them.

--- a/disbot/utils/synonyms.py
+++ b/disbot/utils/synonyms.py
@@ -44,7 +44,6 @@ COMMAND_SYNONYMS: dict[str, list[str]] = {
     "givexp": ["addxp", "grantxp"],
     "resetxp": ["clearxp"],
     "xpconfig": ["xpsettings"],
-    "coglist": ["listcogs", "cogslist"],
     "restart": ["reboot", "restar"],
     "loglevel": ["loglvl", "setloglevel"],
     "remind": ["reminder", "remindme", "erinnerung"],

--- a/docs/health/bug-book.md
+++ b/docs/health/bug-book.md
@@ -10,6 +10,36 @@
 > he hasn't formalized yet (see current-state 2026-06-10 standing invite) land
 > here as they surface.
 
+## BUG-0014 — `!coglist` infinite "assumed from" command-resolution loop — FIXED
+
+- **Symptom (owner-reported via screen recording, 2026-06-16):** typing `!coglist`
+  (or `!cogs`) made SuperBot spam "↩️ Ran `!coglist` — assumed from `!coglist`."
+  **endlessly — it did not stop until the bot was restarted.** A runaway message
+  loop (channel spam + rate-limit risk).
+- **Affected surface:** `bot1.on_command_error` (the `CommandNotFound` typo-resolver
+  re-dispatch) + the data in `disbot/utils/synonyms.py`.
+- **Root cause:** `COMMAND_SYNONYMS` declared `"coglist": ["listcogs", "cogslist"]`,
+  but **no `coglist` command is registered** (audited: the only orphaned canonical of
+  32). So `command_resolution.classify` fuzzy-matched the typed token to the phantom
+  canonical `coglist` and returned `Outcome.AUTO`; `on_command_error` rewrote the
+  message to `!coglist` (the *same* token) and re-dispatched via `process_commands`;
+  `!coglist` still wasn't a real command → `CommandNotFound` → re-resolved to the same
+  phantom → **infinite loop.** The amplifier was structural: the handler re-dispatched
+  an AUTO correction without checking the target actually exists or differs from input.
+- **Fix (this PR):** (1) **loop-breaker** — `on_command_error` only re-dispatches an
+  AUTO correction when it is a *registered* command (`bot.get_command`) *different* from
+  the raw token; an unsafe/identity/phantom correction falls through to the normal
+  not-found reply (makes the loop class impossible regardless of synonym data). (2)
+  removed the orphaned `coglist` synonym. (3) **CI invariant** —
+  `tests/unit/invariants/test_command_synonyms_resolve_to_real_commands.py` AST-asserts
+  every `COMMAND_SYNONYMS` canonical is a registered command name/alias, so an orphan
+  can't ship again.
+- **Regression test:** `tests/unit/test_bot1_command_resolution_loop.py` — phantom and
+  identity AUTO corrections do NOT re-dispatch (single terminal not-found reply); a
+  valid correction (registered + different) still auto-runs exactly once. Plus the
+  synonym-orphan invariant above (verified to flag the re-added `coglist`).
+- **Status:** FIXED. **Merge ≠ deploy** — needs a Railway prod deploy to clear it live.
+
 ## BUG-0013 — 1v1 challenge timer keeps running after accept, overwrites the live duel — FIXED
 
 - **Symptom (owner-reported via Hermes, 2026-06-16):** "there is a problem with

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -20,6 +20,13 @@ during grooming** (it stays listed here, annotated ✅) so the active backlog re
 
 Current broad captures:
 
+- [`reference-integrity-invariants-2026-06-16.md`](./reference-integrity-invariants-2026-06-16.md) —
+  **session idea (2026-06-16, Q-0089, from the BUG-0014 `!coglist`-loop fix PR #949):** BUG-0014 was a
+  dangling reference (a synonym → a command that didn't exist) that failed *silently*. Extract the
+  AST command-surface discovery from the new synonym guard into a shared test helper, and close the
+  known sibling gap — `SUBSYSTEMS.entry_points` → real command, which `test_entrypoints.py` documents
+  as unchecked. One "what commands exist" source for every "this declaration must resolve" invariant.
+  → relates `tests/unit/registry/test_entrypoints.py` · `utils/subsystem_registry.py` · `utils/synonyms.py`.
 - [`close-timeout-align-with-platform-grace-2026-06-16.md`](./close-timeout-align-with-platform-grace-2026-06-16.md) —
   **session idea (2026-06-16, Q-0089, from the runtime-lock deploy-downtime fix PR #948):** make
   `LIFECYCLE_CLOSE_TIMEOUT_SECONDS` env-configurable (mirror the `RUNTIME_LOCK_BOOT_*` knobs) so an

--- a/docs/ideas/reference-integrity-invariants-2026-06-16.md
+++ b/docs/ideas/reference-integrity-invariants-2026-06-16.md
@@ -1,0 +1,47 @@
+# Idea — a shared "declaration → real target" reference-integrity invariant
+
+> **Status:** `ideas`. Not a plan, not approval. Source + binding contracts win.
+> Captured 2026-06-16 (Q-0089 session ender) from the BUG-0014 fix (PR #949).
+
+## The observation
+
+BUG-0014 (the `!coglist` infinite loop) was, at its core, a **dangling reference**:
+`COMMAND_SYNONYMS` declared a canonical (`coglist`) that pointed at a command which
+**did not exist**. Nothing failed loudly — it silently mis-resolved and then looped.
+
+This is a *class*, not a one-off. The repo has several "declaration tables" whose
+entries name a target that must exist, and a dangling entry tends to fail silently:
+
+- `COMMAND_SYNONYMS` canonical → a registered command (now guarded by
+  `test_command_synonyms_resolve_to_real_commands.py`, PR #949).
+- `SUBSYSTEMS[...].entry_points` → a registered command. **Explicitly NOT checked
+  today** — `tests/unit/registry/test_entrypoints.py` says so in its own docstring:
+  "A separate runtime check … would compare entry_points against bot.commands after
+  cog load; that belongs in an integration test that requires a running bot."
+- settings keys → consumers (already guarded — `test_settings_declared_vs_consumed_parity.py`, #917/#918).
+- help-overlay / customization-catalogue entries → real surfaces.
+
+## The idea
+
+Extract the AST command-surface discovery written for the BUG-0014 guard (walk
+`@commands.command/group` `name=`/`aliases=` + function-name fallback across
+`disbot/`) into a **shared test helper** that exposes the authoritative
+registered-command token set *without a live bot*. Then close the known gaps with
+the same pattern — most concretely, the **`SUBSYSTEMS.entry_points` → real command**
+check that `test_entrypoints.py` documents as missing. One source of truth for "what
+commands exist," reused by every "this declaration must resolve" invariant.
+
+## What to look into / cautions
+
+- The AST discovery is a heuristic (it misses commands registered by exotic dynamic
+  paths). Acceptable for a guard, but the shared helper should be honest about that
+  and easy to broaden. (Q-0105 disposable-guard discipline.)
+- Don't over-unify: settings parity already has its own (good) home; this is about
+  the *command-target* references specifically.
+
+## Disposition
+
+Small/decided-lane follow-up. A future session can lift the helper out of
+`test_command_synonyms_resolve_to_real_commands.py` and add the `entry_points` check.
+Relates: `tests/unit/registry/test_entrypoints.py`, `disbot/utils/subsystem_registry.py`,
+`disbot/utils/synonyms.py`.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,9 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/fix-coglist-resolution-loop` · BUG-0014 — `!coglist` infinite "assumed from" resolution
+  loop (owner video) · `disbot/bot1.py` (on_command_error loop-breaker) + `disbot/utils/synonyms.py`
+  + invariant test + bug book · 2026-06-16
 - `claude/modest-ptolemy-2xipoh` · design capture — routine dispatch / staged deep-clean /
   planning sectors (owner discussion) · `docs/ideas/` + router Q-0137 · 2026-06-14
 - `claude/hopeful-allen-home-slice-c` · mining Slice C — Home structure (character-card backdrop) ·

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,9 +25,6 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/fix-coglist-resolution-loop` · BUG-0014 — `!coglist` infinite "assumed from" resolution
-  loop (owner video) · `disbot/bot1.py` (on_command_error loop-breaker) + `disbot/utils/synonyms.py`
-  + invariant test + bug book · 2026-06-16
 - `claude/modest-ptolemy-2xipoh` · design capture — routine dispatch / staged deep-clean /
   planning sectors (owner discussion) · `docs/ideas/` + router Q-0137 · 2026-06-14
 - `claude/hopeful-allen-home-slice-c` · mining Slice C — Home structure (character-card backdrop) ·
@@ -40,6 +37,9 @@ living ledger (`docs/current-state.md`).
 
 ## Recently cleared
 
+- `claude/fix-coglist-resolution-loop` · BUG-0014 — `!coglist` infinite "assumed from" resolution
+  loop (owner video) · `disbot/bot1.py` loop-breaker + `disbot/utils/synonyms.py` + synonym-orphan
+  invariant + bug book · 2026-06-16 · **PR #949 (open, auto-merge on green)**
 - `claude/keen-heisenberg-xqro71` · runtime lock — release early on shutdown (fix ~85s deploy
   downtime; prod log triage) · `disbot/{bot1.py,services/runtime.py,services/metrics.py}` +
   lifecycle invariant tests · 2026-06-16 · **PR #948 (open, auto-merge on green)**

--- a/tests/unit/invariants/test_command_synonyms_resolve_to_real_commands.py
+++ b/tests/unit/invariants/test_command_synonyms_resolve_to_real_commands.py
@@ -1,0 +1,77 @@
+"""Invariant: every ``COMMAND_SYNONYMS`` canonical is a real command.
+
+BUG-0014 — ``utils/synonyms.py`` declared ``"coglist": ["listcogs", "cogslist"]``
+but no ``coglist`` command was ever registered. The typo-resolver auto-corrected
+the fuzzy token to that phantom canonical and ``bot1.on_command_error``
+re-dispatched ``!coglist`` forever ("↩️ Ran ``!coglist`` — assumed from
+``!coglist``" spam until the bot was restarted). This invariant fails closed if a
+synonym's canonical is not a registered command name or alias, so an orphaned
+synonym can never ship again.
+
+AST-scoped to the prefix-command decorators across ``disbot/`` so it runs in well
+under a second and needs no live bot / DB.
+
+UNVERIFIED convenience guard (Q-0105, 2026-06-16): command discovery walks
+``@commands.command`` / ``@commands.group`` decorators (+ function-name fallback
+when no explicit ``name=``). If a future command is registered through some exotic
+dynamic path this scan misses, the fix is to broaden the discovery (or add the
+name) — not to weaken the synonym contract. Delete this guard if it proves
+unreliable across multiple sessions.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from utils.synonyms import COMMAND_SYNONYMS
+
+_DISBOT = Path(__file__).resolve().parents[3] / "disbot"
+
+
+def _registered_command_tokens() -> set[str]:
+    """Every prefix-command name + alias declared across ``disbot/`` (lowercased)."""
+    tokens: set[str] = set()
+    for path in _DISBOT.rglob("*.py"):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for dec in node.decorator_list:
+                if not isinstance(dec, ast.Call):
+                    continue
+                dotted = ast.unparse(dec.func)
+                if not (dotted.endswith("command") or dotted.endswith("group")):
+                    continue
+                name: str | None = None
+                for kw in dec.keywords:
+                    if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+                        name = str(kw.value.value)
+                    elif kw.arg == "aliases" and isinstance(
+                        kw.value, (ast.List, ast.Tuple)
+                    ):
+                        for el in kw.value.elts:
+                            if isinstance(el, ast.Constant):
+                                tokens.add(str(el.value).lower())
+                tokens.add((name or node.name).lower())
+    return tokens
+
+
+def test_every_synonym_canonical_is_a_registered_command() -> None:
+    tokens = _registered_command_tokens()
+    # Sanity: the scan must actually find the command surface, otherwise the
+    # invariant would vacuously pass while discovery is silently broken.
+    assert len(tokens) > 100, (
+        f"command-decorator scan found only {len(tokens)} tokens — the AST "
+        "discovery likely broke; fix it before trusting this guard."
+    )
+    orphans = sorted(c for c in COMMAND_SYNONYMS if c.lower() not in tokens)
+    assert not orphans, (
+        "COMMAND_SYNONYMS canonical(s) with no registered command (name or "
+        f"alias): {orphans}. A synonym pointing at a phantom command "
+        "auto-corrects to nothing and loops on re-dispatch (BUG-0014). Point "
+        "the synonym at a real command or remove the entry."
+    )

--- a/tests/unit/test_bot1_command_resolution_loop.py
+++ b/tests/unit/test_bot1_command_resolution_loop.py
@@ -1,0 +1,116 @@
+"""Regression tests for the BUG-0014 command-resolution loop.
+
+A user typing ``!coglist`` made ``bot1.on_command_error`` re-dispatch an AUTO
+typo-correction (``coglist``) that was not a registered command, which
+``CommandNotFound``-ed again and re-resolved to the same phantom — an infinite
+"↩️ Ran ``!coglist`` — assumed from ``!coglist``" spam loop that only stopped on
+restart.
+
+The fix is the loop-breaker in ``on_command_error``: an AUTO correction is only
+re-dispatched when it is a *registered* command *different* from the raw token.
+These tests drive the handler directly with a stubbed resolver and assert the
+re-dispatch (``bot.process_commands``) only fires on a safe correction.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from discord.ext import commands
+
+import bot1
+from utils.command_resolution import Outcome, Resolution
+
+
+def _make_ctx(raw: str, content: str) -> SimpleNamespace:
+    """Minimal Context stand-in exposing only what on_command_error reads."""
+    return SimpleNamespace(
+        command=None,
+        cog=None,
+        invoked_with=raw,
+        prefix="!",
+        message=SimpleNamespace(content=content),
+        send=AsyncMock(),
+        channel=SimpleNamespace(id=1),
+        author="tester",
+        guild=None,
+    )
+
+
+def _sent_texts(ctx: SimpleNamespace) -> list[str]:
+    return [c.args[0] for c in ctx.send.await_args_list if c.args]
+
+
+@pytest.mark.asyncio
+async def test_phantom_auto_correction_does_not_redispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An AUTO correction to an UNREGISTERED command (the BUG-0014 phantom) must
+    NOT be re-dispatched — that is the infinite loop. The user gets a single
+    terminal not-found reply instead."""
+    monkeypatch.setattr(bot1, "reporter", None)
+    monkeypatch.setattr(
+        bot1.command_resolution,
+        "classify",
+        lambda *a, **k: Resolution(Outcome.AUTO, "coglist"),
+    )
+    monkeypatch.setattr(bot1.bot, "get_command", lambda name: None)  # unregistered
+    proc = AsyncMock()
+    monkeypatch.setattr(bot1.bot, "process_commands", proc)
+
+    ctx = _make_ctx("coglist", "!coglist")
+    await bot1.on_command_error(ctx, commands.CommandNotFound())
+
+    proc.assert_not_called()
+    texts = _sent_texts(ctx)
+    assert len(texts) == 1 and "not found" in texts[0].lower(), texts
+    # The misleading "assumed from" note must NOT have been sent.
+    assert not any("assumed from" in t for t in texts), texts
+
+
+@pytest.mark.asyncio
+async def test_identity_auto_correction_does_not_redispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even if the correction were 'registered', a correction equal to the raw
+    token must not re-dispatch — it can only re-enter CommandNotFound."""
+    monkeypatch.setattr(bot1, "reporter", None)
+    monkeypatch.setattr(
+        bot1.command_resolution,
+        "classify",
+        lambda *a, **k: Resolution(Outcome.AUTO, "coglist"),
+    )
+    monkeypatch.setattr(bot1.bot, "get_command", lambda name: object())  # pretend real
+    proc = AsyncMock()
+    monkeypatch.setattr(bot1.bot, "process_commands", proc)
+
+    ctx = _make_ctx("coglist", "!coglist")  # corrected == raw
+    await bot1.on_command_error(ctx, commands.CommandNotFound())
+
+    proc.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_valid_auto_correction_still_redispatches_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A genuine typo correction (registered command, different token) must
+    still auto-run exactly once — the loop-breaker must not regress the feature."""
+    monkeypatch.setattr(bot1, "reporter", None)
+    monkeypatch.setattr(
+        bot1.command_resolution,
+        "classify",
+        lambda *a, **k: Resolution(Outcome.AUTO, "serverstats"),
+    )
+    monkeypatch.setattr(bot1.bot, "get_command", lambda name: object())  # registered
+    proc = AsyncMock()
+    monkeypatch.setattr(bot1.bot, "process_commands", proc)
+
+    ctx = _make_ctx("serverstas", "!serverstas")
+    await bot1.on_command_error(ctx, commands.CommandNotFound())
+
+    proc.assert_awaited_once()
+    assert ctx.message.content == "!serverstats"
+    assert any("assumed from" in t for t in _sent_texts(ctx))


### PR DESCRIPTION
## The bug (owner screen recording)

Typing `!coglist` (or `!cogs`) makes SuperBot spam **"↩️ Ran `!coglist` — assumed from `!coglist`."** indefinitely — it doesn't stop until the bot is restarted. A runaway message loop (spam + rate-limit risk).

## Root cause

`utils/synonyms.py` declared `"coglist": ["listcogs", "cogslist"]`, but **no `coglist` command is registered** (audited the whole table via AST: `coglist` is the *only* orphaned canonical of 32). The chain:

1. User types `!coglist` → `CommandNotFound`.
2. `on_command_error` → `command_resolution.classify("coglist")` fuzzy-matches the synonym `cogslist` → canonical `coglist`, which is lexically isolated → `Outcome.AUTO`.
3. The handler rewrites the message to `!coglist` (**the same token**) and re-dispatches via `process_commands`.
4. `!coglist` is still not a registered command → `CommandNotFound` → back to step 2. **Infinite loop.**

The amplifier is structural: the handler re-dispatches an AUTO correction **without checking the corrected command actually exists or differs from the input** — so any phantom/identity correction loops forever.

## Fix (root-cause, three layers)

1. **Loop-breaker — `bot1.on_command_error`:** only re-dispatch an AUTO correction when it is a *registered* command (`bot.get_command(...)`) **and** different from the raw token. A phantom or identity correction can only `CommandNotFound` again, so it now falls through to the normal not-found reply instead of re-dispatching. This makes the loop class impossible regardless of synonym-table mistakes.
2. **Data fix — `utils/synonyms.py`:** remove the orphaned `coglist` entry (there is no command to point it at).
3. **CI invariant — `tests/unit/invariants/test_command_synonyms_resolve_to_real_commands.py`:** AST-scan every `@commands.command/group` name + alias across `disbot/`, assert every `COMMAND_SYNONYMS` canonical is a real command name/alias. Zero orphans now; an orphaned synonym can't ship again.

## Tests
- `tests/unit/test_bot1_command_resolution_loop.py` (new) — drives `on_command_error` with a phantom AUTO correction and asserts `process_commands` is **not** re-invoked (no loop) + the not-found reply is sent; and that a *valid* correction (registered, different token) still re-dispatches once.
- `tests/unit/utils/test_command_resolution.py` — unchanged behavior verified.
- The new invariant fails against the pre-fix `synonyms.py` (proves it catches the orphan).

BUG-0014 recorded FIXED in the bug book. **Merge ≠ deploy** — needs a Railway prod deploy to clear it live.

🤖 https://claude.ai/code/session_01Q9Kb4db8VyTSfMRvv9oAn9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9Kb4db8VyTSfMRvv9oAn9)_