### PR TITLE
feat(admin): add !coglist command wired to the "📋 Cog List" panel button

### DIFF
--- a/.sessions/2026-06-16-coglist-command.md
+++ b/.sessions/2026-06-16-coglist-command.md
@@ -1,15 +1,85 @@
 # Session — `!coglist` text command → the "📋 Cog List" button (owner request)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-## What I'm about to do
+## Origin
 
-Owner: "the command coglist should be a real command — there is a button that does exactly that, so
-link the text command to the button as well." The admin panel's **📋 Cog List** button
-(`_AdminPanelView.coglist_btn`) opens the interactive `_CogManagerView` (loaded/unloaded/syntax
-status for every cog; mutations owner-gated). After BUG-0014 (#949) I removed the orphaned `coglist`
-synonym; now I make `coglist` a **real command** that opens that same view, with `cogs`/`listcogs`/
-`cogslist` as exact aliases (no fuzzy synonym needed → #949's synonym-orphan invariant stays green).
-Admin-gated like `!adminmenu` (the panel that hosts the button); the view keeps mutation owner-gating.
+Owner, after the BUG-0014 loop fix (#949): *"the command `coglist` should be a real command — there
+is a button that does exactly that, so link the text command to the button as well."* #949 removed
+the orphaned `coglist` *synonym* (the loop cause); this makes `coglist` a **real command** wired to
+the existing button's view.
 
-(Filled in as the deliberate final step — born-red per Q-0133.)
+## Change
+
+`disbot/cogs/admin_cog.py` — new prefix command `coglist_command` (method renamed off the
+discord.py-reserved `cog_` prefix; command name is `coglist`):
+
+```python
+@commands.command(name="coglist", aliases=["cogs", "listcogs", "cogslist"],
+                  extras={"alias_classification": "power_user_shortcut"})
+@commands.has_permissions(administrator=True)
+async def coglist_command(self, ctx):
+    view = _CogManagerView(self, ctx.author)
+    await send_panel(ctx, embed=view.build_embed(), view=view)
+```
+
+- Opens the **same `_CogManagerView`** the admin panel's 📋 Cog List button opens — one surface, no
+  duplicated rendering.
+- **Exact aliases** `cogs`/`listcogs`/`cogslist` (the tokens users actually type — the BUG-0014 video
+  showed both `!cogs` and `!coglist`), so they resolve directly with no fuzzy synonym → #949's
+  synonym-orphan invariant stays green (no `coglist` synonym canonical reintroduced).
+- **Admin-gated** like `!adminmenu` (which hosts the button); the view keeps its own **owner-gating on
+  mutations**. All four names verified collision-free.
+- Two discord.py contracts hit + satisfied: method can't start with `cog_` (renamed to
+  `coglist_command`); a ≥3-alias command must declare `extras["alias_classification"]` (the
+  surface-ledger invariant) — declared `power_user_shortcut` (visible fluency spellings).
+
+## Verification
+
+- `tests/unit/cogs/test_admin_cog_manager.py` — new: command registered with name + aliases + admin
+  check; invoking it sends a `_CogManagerView` (mirrors the existing button test). 20/20 pass.
+- `python3.10 scripts/check_quality.py --full` → **green (9974 passed, 37 skipped)**.
+- `python3.10 scripts/check_architecture.py --mode strict` → **exit 0**.
+
+**Merge ≠ deploy-only:** Railway auto-deploys on merge to `main` (per `production-deployment.md`), so
+this reaches prod on merge — `!coglist` / `!cogs` will open the cog manager after the deploy completes.
+
+## 💡 Session idea (Q-0089)
+
+[`button-command-surface-parity-2026-06-16.md`](../docs/ideas/button-command-surface-parity-2026-06-16.md)
+— this gap (a button with no command front door) was found only because a user hit it. A review-lane
+audit pairing distinct action-buttons with command equivalents (not a brittle CI guard — most buttons
+are navigation) would surface the rest; a lighter automatable slice mines "command not found" misses
+for high-frequency expected names. (Filed + indexed.)
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous session: **BUG-0014 `!coglist` loop fix (#949)**.
+- **Did well:** correct root-cause loop-breaker + a CI invariant that fails against the orphan; tight
+  and well-tested.
+- **What it could have done better (the owner's follow-up proves it):** #949 treated the orphaned
+  `coglist` synonym as *purely* bad data and **removed** it — but the owner actually *wanted* `coglist`
+  to work (a button already did it). The fuller fix was "make the target exist," not "delete the
+  dangling pointer." Genuine lesson: **a dangling reference can signal a *missing feature*, not just
+  stale data** — when removing an orphan, ask whether the right fix is to make its target real
+  (and flag to the owner if unsure) rather than silently deleting. #949's loop fix was still correct
+  and necessary; this PR is the complementary "make it real" half.
+- **Workflow improvement:** worth a line in the bug-fix habit — when a fix is "remove a dead
+  reference," pause on whether users expected that reference to resolve (the BUG-0014 video literally
+  showed the user typing `!coglist` *wanting* an answer).
+
+## Documentation audit (Q-0104)
+
+- `check_docs.py --strict` → green (new idea file reachable + indexed). `check_architecture --mode
+  strict` → exit 0.
+- Not a bug → no bug-book entry. Session log + active-work claim + idea file/index updated; the fix +
+  rationale live in the command docstring + this log. No chat-only durable info outstanding.
+- **Operational finding (out of band, reported to owner, not a repo change here):** the Railway
+  `RAILWAY_API_KEY` in the agent env is truncated (29 chars, Railway's API rejects it; owner confirmed
+  it doesn't match the dashboard token ending `-4c20`). The token *kind* (Account scope) is correct
+  for `railway_logs.py`. Live-log verification is blocked until the env value is re-pasted in full —
+  a `docs/operations/production-deployment.md` "verify the env value isn't truncated" gotcha is a
+  candidate follow-up (not bundled into this feature PR).
+- Living-ledger drift (#948/#949 + this) stays the **next reconciliation's** job (not due till #960;
+  Q-0124). Backlog grooming (Q-0015): this PR *is* a groomed follow-up to BUG-0014; standing pickups
+  (deathmatch timed-view invariant; the two prior idea files) remain named in their logs.

--- a/.sessions/2026-06-16-coglist-command.md
+++ b/.sessions/2026-06-16-coglist-command.md
@@ -1,0 +1,15 @@
+# Session — `!coglist` text command → the "📋 Cog List" button (owner request)
+
+> **Status:** `in-progress`
+
+## What I'm about to do
+
+Owner: "the command coglist should be a real command — there is a button that does exactly that, so
+link the text command to the button as well." The admin panel's **📋 Cog List** button
+(`_AdminPanelView.coglist_btn`) opens the interactive `_CogManagerView` (loaded/unloaded/syntax
+status for every cog; mutations owner-gated). After BUG-0014 (#949) I removed the orphaned `coglist`
+synonym; now I make `coglist` a **real command** that opens that same view, with `cogs`/`listcogs`/
+`cogslist` as exact aliases (no fuzzy synonym needed → #949's synonym-orphan invariant stays green).
+Admin-gated like `!adminmenu` (the panel that hosts the button); the view keeps mutation owner-gating.
+
+(Filled in as the deliberate final step — born-red per Q-0133.)

--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -168,6 +168,28 @@ class AdminCog(commands.Cog):
             parts.append("❌ Failed:\n" + "\n".join(failed))
         await ctx.send("\n".join(parts) or "✅ Nothing to unload.")
 
+    @commands.cooldown(rate=2, per=10, type=commands.BucketType.user)
+    @commands.command(
+        name="coglist",
+        aliases=["cogs", "listcogs", "cogslist"],
+        # Fluency spellings users actually type (the BUG-0014 report showed
+        # both !cogs and !coglist) — visible by contract, not compat shims.
+        extras={"alias_classification": "power_user_shortcut"},
+    )
+    @commands.has_permissions(administrator=True)
+    async def coglist_command(self, ctx):
+        """Open the interactive cog manager — the panel's 📋 Cog List button.
+
+        Mirrors ``_AdminPanelView`` → "📋 Cog List": posts the same
+        ``_CogManagerView`` (loaded / unloaded / syntax status for every
+        cog) so the text command and the button share one surface. Admins
+        can view the list; mutations stay owner-gated by the view itself
+        (non-owners' Load/Unload/Reload buttons deny). The prefix ``!cog``
+        command remains the unprotected escape hatch for mutations.
+        """
+        view = _CogManagerView(self, ctx.author)
+        await send_panel(ctx, embed=view.build_embed(), view=view)
+
     # ------------------------------------------------------------------
     # Slash-command tree sync + diagnostics (PR E')
     # ------------------------------------------------------------------

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -20,6 +20,13 @@ during grooming** (it stays listed here, annotated ✅) so the active backlog re
 
 Current broad captures:
 
+- [`button-command-surface-parity-2026-06-16.md`](./button-command-surface-parity-2026-06-16.md) —
+  **session idea (2026-06-16, Q-0089, from the `!coglist` command request PR #951):** the admin panel
+  had a 📋 Cog List button but no text command — users expect a button's action to also be reachable
+  by a command. A review-lane audit (not a brittle CI guard — many buttons are navigation, not
+  actions) pairing distinct action-buttons with command front doors would surface the rest; a lighter
+  automatable slice is mining "command not found" misses for high-frequency expected names (BUG-0014
+  was one). → relates `cogs/admin_cog.py` · `core/runtime/command_surface_ledger.py`.
 - [`reference-integrity-invariants-2026-06-16.md`](./reference-integrity-invariants-2026-06-16.md) —
   **session idea (2026-06-16, Q-0089, from the BUG-0014 `!coglist`-loop fix PR #949):** BUG-0014 was a
   dangling reference (a synonym → a command that didn't exist) that failed *silently*. Extract the

--- a/docs/ideas/button-command-surface-parity-2026-06-16.md
+++ b/docs/ideas/button-command-surface-parity-2026-06-16.md
@@ -1,0 +1,36 @@
+# Idea — button ↔ text-command surface parity audit
+
+> **Status:** `ideas`. Not a plan, not approval. Source + binding contracts win.
+> Captured 2026-06-16 (Q-0089 session ender) from the `!coglist` command request (PR #951).
+
+## The observation
+
+The admin panel had a **📋 Cog List** button (opening `_CogManagerView`) but **no text command**
+for it — so a user typing `!coglist` / `!cogs` got nothing (and, pre-#949, an infinite loop). The
+owner's fix request was telling: *"there is a button that does exactly that, so link the text command
+to the button as well."* Users expect an action reachable by a button to also be reachable by a
+command (and often a slash). The reverse is the already-tracked direction (commands → surfaces).
+
+## The idea
+
+A review-lane audit (maybe a soft, advisory check) that pairs **interactive panel buttons that
+perform a distinct action** with an equivalent **text/slash command**, and flags buttons whose action
+has no command front door. The cog-list gap was found only because a user hit it; a periodic parity
+pass would surface the rest (e.g. other `_*PanelView` action buttons).
+
+## What to look into / cautions
+
+- **Not 1:1 and hard to fully automate.** Many buttons are *navigation* (open a sub-panel), not
+  distinct actions — those don't need a command. An AST/heuristic guard would over-flag; this is
+  better as a **guided manual review** (or a checklist in the UX docs) than a hard CI invariant.
+- A lighter, automatable slice: ensure the *names users actually type* exist — e.g. mine the
+  `on_command_error` "command not found" telemetry (or known synonyms) for high-frequency misses and
+  confirm each maps to a real command/alias. (BUG-0014 was exactly such a miss.)
+- discord.py gotchas this class hits: method names can't start with `cog_`/`bot_`; a command with
+  ≥3 aliases must declare `extras={"alias_classification": ...}` (the surface-ledger invariant).
+
+## Disposition
+
+Review-lane idea (UX/discoverability). Candidate to fold into `docs/ux/` review guidance or the
+production eval checklist rather than ship as a brittle CI guard. Relates: `cogs/admin_cog.py`
+(panel buttons), `core/runtime/command_surface_ledger.py`, `utils/synonyms.py`.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,8 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/coglist-command` · `!coglist` real command → opens the admin "📋 Cog List" `_CogManagerView`
+  (owner request) · `disbot/cogs/admin_cog.py` + test · 2026-06-16
 - `claude/modest-ptolemy-2xipoh` · design capture — routine dispatch / staged deep-clean /
   planning sectors (owner discussion) · `docs/ideas/` + router Q-0137 · 2026-06-14
 - `claude/hopeful-allen-home-slice-c` · mining Slice C — Home structure (character-card backdrop) ·

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,8 +25,6 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/coglist-command` · `!coglist` real command → opens the admin "📋 Cog List" `_CogManagerView`
-  (owner request) · `disbot/cogs/admin_cog.py` + test · 2026-06-16
 - `claude/modest-ptolemy-2xipoh` · design capture — routine dispatch / staged deep-clean /
   planning sectors (owner discussion) · `docs/ideas/` + router Q-0137 · 2026-06-14
 - `claude/hopeful-allen-home-slice-c` · mining Slice C — Home structure (character-card backdrop) ·
@@ -39,6 +37,9 @@ living ledger (`docs/current-state.md`).
 
 ## Recently cleared
 
+- `claude/coglist-command` · `!coglist` real command → opens the admin "📋 Cog List" `_CogManagerView`
+  (owner request; aliases cogs/listcogs/cogslist) · `disbot/cogs/admin_cog.py` + test · 2026-06-16 ·
+  **PR #951 (open, auto-merge on green)**
 - `claude/fix-coglist-resolution-loop` · BUG-0014 — `!coglist` infinite "assumed from" resolution
   loop (owner video) · `disbot/bot1.py` loop-breaker + `disbot/utils/synonyms.py` + synonym-orphan
   invariant + bug book · 2026-06-16 · **PR #949 (open, auto-merge on green)**

--- a/tests/unit/cogs/test_admin_cog_manager.py
+++ b/tests/unit/cogs/test_admin_cog_manager.py
@@ -86,6 +86,32 @@ async def test_coglist_button_opens_cog_manager_view():
 
 
 # ---------------------------------------------------------------------------
+# !coglist prefix command opens the SAME manager as the button (owner request)
+# ---------------------------------------------------------------------------
+
+
+def test_coglist_command_registered_with_name_and_aliases():
+    cog = _admin_cog()
+    cmd = cog.coglist_command
+    assert cmd.name == "coglist"
+    assert set(cmd.aliases) == {"cogs", "listcogs", "cogslist"}
+    # Admin-gated like !adminmenu (has_permissions attaches a check).
+    assert cmd.checks, "!coglist must carry a permission check (admin-gated)"
+
+
+@pytest.mark.asyncio
+async def test_coglist_command_opens_cog_manager_view():
+    cog = _admin_cog()
+    ctx = MagicMock()
+    ctx.author = _author()
+    with patch("cogs.admin_cog.send_panel", new=AsyncMock()) as send_panel:
+        await cog.coglist_command.callback(cog, ctx)
+    send_panel.assert_awaited_once()
+    _args, kwargs = send_panel.call_args
+    assert isinstance(kwargs["view"], _CogManagerView)
+
+
+# ---------------------------------------------------------------------------
 # View shape — Select + 4 action buttons
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Why

Owner request: "the command `coglist` should be a real command — there is a button that does exactly that, so link the text command to the button as well."

The admin panel's **📋 Cog List** button (`_AdminPanelView.coglist_btn`) opens the interactive `_CogManagerView` (loaded/unloaded/syntax status for every cog; load/unload/reload). After BUG-0014 (#949) the orphaned `coglist` *synonym* was removed — this makes `coglist` a **real command** wired to that same view, so `!coglist` works as users expect.

## Change

`disbot/cogs/admin_cog.py` — a new prefix command in the Cog Management section:

```python
@commands.cooldown(rate=2, per=10, type=commands.BucketType.user)
@commands.command(name="coglist", aliases=["cogs", "listcogs", "cogslist"])
@commands.has_permissions(administrator=True)
async def cog_list(self, ctx):
    view = _CogManagerView(self, ctx.author)
    await send_panel(ctx, embed=view.build_embed(), view=view)
```

- Opens the **same `_CogManagerView`** the button opens (one source of truth — no duplicated rendering).
- **Exact aliases** `cogs` / `listcogs` / `cogslist` (the tokens users actually typed, incl. the BUG-0014 video) — so they resolve directly, no fuzzy synonym needed. #949's synonym-orphan invariant stays green (no `coglist` synonym canonical re-introduced).
- **Admin-gated** (`has_permissions(administrator=True)`), mirroring `!adminmenu`, which hosts the button; the view keeps its own **owner-gating on mutations** (non-owners view, mutations deny). All four names verified collision-free against the existing command surface.

## Tests
`tests/unit/cogs/test_admin_cog_manager.py` — new cases: the command is registered with the right name + aliases + admin check, and invoking it sends a `_CogManagerView` (mirrors the existing `coglist_btn` test).

`check_quality --full` + `check_architecture --mode strict` green.

🤖 https://claude.ai/code/session_01Q9Kb4db8VyTSfMRvv9oAn9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9Kb4db8VyTSfMRvv9oAn9)_