### PR TITLE
fix(btd6): current-event-first Live Events + fix dead event drill-down

### DIFF
--- a/.sessions/2026-06-16-btd6-live-events-current-first.md
+++ b/.sessions/2026-06-16-btd6-live-events-current-first.md
@@ -1,6 +1,6 @@
 # Session — BTD6 Live Events: fix the dead drill-down + current-event-first redesign
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## What I'm about to do
 
@@ -43,12 +43,51 @@ Plan:
 
 ## What was done
 
-(to be filled in as the deliberate final step)
+PR **#953** (born-red → flipped complete). Diagnosed from the recording by extracting frames with
+`imageio[ffmpeg]` (no ffmpeg in the env; installed for `python3.10`), then root-caused in source.
+
+- **Fixed the crash (the "does nothing").** `build_event_detail_view_model` called
+  `btd6_db.search_facts(entity_kind=…, entity_key=…, limit=2)` — but `search_facts` takes no
+  `entity_key` kwarg → `TypeError` on **every** drill-down (proved via `inspect.signature`). The
+  select had already deferred the ephemeral, so `HubView.on_error` swallowed it → silent no-op.
+  Rewrote the builder to use `get_latest_fact` for the index fact + the correct per-kind metadata
+  fact. The path had **zero coverage**; the one existing test mocked `search_facts` with a bare
+  `AsyncMock` (accepts any kwarg) which masked the bug.
+- **Current-event-first redesign.** New `build_live_overview_view_model()` (live events only, strict
+  future-end filter matching the hub panel) + `LiveOverviewView`: a landing that shows what's live
+  per kind with countdowns (or "_nothing live_"), a select of **only** live events → rich detail,
+  and history moved behind a de-emphasized **📜 Past events** button with **↩ Live now** back-nav.
+  Detail is colour-coded (green=live / grey=ended) and now renders full rules + banned/limited
+  towers + disabled flags + scores + coverage.
+- **Fixed a latent bug:** `_event_helpers.build_event_payload` looked up boss metadata as
+  `{id}_normal`; ingestion stores `{id}_standard`, so `!btd6events event boss <id>` never found
+  restrictions. Now `_standard`.
+- **Tests:** crash regression (detail must not call `search_facts` with `entity_key`, must not
+  raise), boss-metadata-suffix assertion, live-overview VM (live-only / strict filter), and the
+  overview view/select/embed + history back-nav. `check_quality --full` green (**9990 passed, 37
+  skipped**); mypy clean; arch 0 new violations.
+
+Grooming (Q-0015): sharpened `docs/ideas/button-command-surface-parity-2026-06-16.md` — added the
+**sibling failure mode** (a button whose callback silently crashes vs. a button with no command
+front door) and scoped that idea away from it, routing the crash class to the new mock-fidelity idea.
 
 ## 💡 Session idea
 
-(pending)
+`docs/ideas/autospec-mock-fidelity-guard-2026-06-16.md` — make project mocks signature-faithful
+(`create_autospec` / `AsyncMock(spec=real_fn)`) via a lint/AST guard or a tiny `autospec_setattr`
+helper, so a call-site kwarg typo the real function would reject also fails the test. Born directly
+from this session: the drill-down crash shipped green **because** a bare `AsyncMock` was more
+permissive than the real `search_facts`. Dedup-checked against `docs/ideas/` (no existing mock/spec
+idea); README-indexed.
 
 ## ⟲ Previous-session review
 
-(pending)
+The previous session (#952, `railway_logs.py` retry/backoff) was a clean, well-tested transport
+hardening — injectable `sleep`/`max_retries`, fail-against-old tests, and it correctly *didn't* mask
+real 4xx/GraphQL errors. Good restraint. What the chain could do better, and this session is the
+proof: **a unit test that passes is not evidence the call works** — #952's tests were faithful
+because they drove the real `post()`, but the BTD6 bug here shows the opposite pattern (a mock more
+permissive than reality) shipping a 100%-broken user-facing feature green. **Concrete system
+improvement:** adopt signature-faithful mocks for the service/DB facades (the new
+`autospec-mock-fidelity-guard` idea) — the smallest durable change that would have turned this
+production crash into a red test. (No filler: this is a genuine, specific gap the session surfaced.)

--- a/.sessions/2026-06-16-btd6-live-events-current-first.md
+++ b/.sessions/2026-06-16-btd6-live-events-current-first.md
@@ -1,0 +1,54 @@
+# Session — BTD6 Live Events: fix the dead drill-down + current-event-first redesign
+
+> **Status:** `in-progress`
+
+## What I'm about to do
+
+Owner shared a Discord screen recording of the BTD6 **Live Events** browser. Two complaints:
+1. "it does not look nice, it's not easy to understand … this should be properly divided into clear
+   informational views that display **only the current event** and **all information available about
+   it**."
+2. "the race event button **still does nothing**."
+
+Diagnosis from the video + source:
+
+- **Root cause of "does nothing" (a real crash):** `services.btd6_view_model_service.
+  build_event_detail_view_model` calls `btd6_db.search_facts(entity_kind=…, entity_key=…, limit=2)`,
+  but `search_facts(*, fact_type=None, entity_kind=None, limit=50)` has **no `entity_key`
+  parameter** → `TypeError` on **every** event drill-down (race/boss/ct/odyssey/event). The select
+  callback already deferred the ephemeral, so the exception leaves it un-updated → "nothing happens."
+  The path had **zero test coverage**, so it shipped broken.
+- **UX problem:** the browser lists *all* stored facts (mostly `status: ended`) via
+  `build_event_list_view_model`, capped at 25, ordered by fetch time — a wall of dead events with
+  cryptic API ids, the same data duplicated in the embed *and* the dropdown, and no focus on what is
+  actually live. `get_active_events()` already filters to live/future events but the browser ignores
+  it.
+- **Latent secondary bug:** `cogs.btd6._event_helpers.build_event_payload` looks up boss metadata
+  with `{id}_normal`, but ingestion stores it as `{id}_standard` (`difficulty="standard"`), so boss
+  event detail never finds its rules/restrictions.
+
+Plan:
+1. **Fix the crash + enrich detail** — rewrite `build_event_detail_view_model` to use
+   `get_latest_fact` for the index fact and the correct per-kind metadata fact (race
+   `btd6.race_metadata`; boss `btd6.boss_metadata`/`btd6_boss_difficulty`/`{id}_standard`; odyssey
+   `btd6.odyssey_metadata`/`btd6_odyssey_difficulty`/`{id}_easy`), so detail renders full rules +
+   tower/hero restrictions for all kinds.
+2. **Current-event-first landing** — new `build_live_overview_view_model()` (live events only, strict
+   future-end filter matching the hub panel) + a `LiveOverviewView`: an embed showing the live event
+   per kind (or "nothing live"), a select containing **only** the currently-live events → rich
+   detail, and a de-emphasized **📜 Past events** button that opens the existing kind-picker/list
+   browser (history, also → the same rich detail). Nobody is stranded: history has a ↩ back to live.
+3. **Fix** the `_normal`→`_standard` boss-metadata suffix in `_event_helpers`.
+4. Tests for all three (the previously-uncovered detail path included).
+
+## What was done
+
+(to be filled in as the deliberate final step)
+
+## 💡 Session idea
+
+(pending)
+
+## ⟲ Previous-session review
+
+(pending)

--- a/disbot/cogs/btd6/_event_helpers.py
+++ b/disbot/cogs/btd6/_event_helpers.py
@@ -114,7 +114,13 @@ async def build_event_payload(kind: str, entity_key: str) -> discord.Embed:
         else:
             md_entity_key = entity_key
             if norm == "btd6_boss":
-                md_entity_key = f"{entity_key}_normal"  # difficulty hardcoded
+                # Difficulty is hardcoded to "standard" by the ingestion
+                # supervisor's boss fan-out (btd6_ingestion_service.
+                # _DEPENDENCY_CHAINS) — the metadata entity_key is
+                # "{bossID}_standard", NOT "_normal". Using "_normal" here
+                # silently found no metadata, so boss event detail never
+                # rendered its rules / restrictions.
+                md_entity_key = f"{entity_key}_standard"
             metadata_row = await btd6_db.get_latest_fact(
                 metadata_fact_type,
                 "btd6_boss_difficulty" if norm == "btd6_boss" else norm,

--- a/disbot/services/btd6_view_model_service.py
+++ b/disbot/services/btd6_view_model_service.py
@@ -420,6 +420,32 @@ _EVENT_KIND_TO_SOURCE_KEY: dict[str, str] = {
     "btd6_event": "nk_btd6_events",
 }
 
+# Index ("primary") fact-type per kind — carries name + window + scores. Mirrors
+# ``btd6_live_query_service._INDEX_FACT_TYPE`` (kept local to avoid reaching into
+# another service's private global; a drift here only degrades to a None lookup,
+# never a crash).
+_EVENT_INDEX_FACT_TYPE: dict[str, str] = {
+    "btd6_race": "btd6.races_index",
+    "btd6_boss": "btd6.bosses_index",
+    "btd6_ct": "btd6.ct_index",
+    "btd6_odyssey": "btd6.odyssey_index",
+    "btd6_event": "btd6.events_index",
+}
+
+# Metadata fact lookup per kind — carries rules + ``_towers`` restrictions.
+# ``(fact_type, metadata_entity_kind, entity_key_suffix)``. Race keeps its
+# metadata under the same entity_kind/key; boss + odyssey store it under a
+# separate *difficulty* entity_kind with a difficulty-suffixed key. The
+# suffixes MUST match the ingestion supervisor's hardcoded fan-out
+# (``btd6_ingestion_service._DEPENDENCY_CHAINS``: boss ``standard``,
+# odyssey ``easy``) or the lookup finds nothing. CT / event carry no
+# restriction metadata, so they are absent here (metadata stays ``None``).
+_EVENT_METADATA_LOOKUP: dict[str, tuple[str, str, str]] = {
+    "btd6_race": ("btd6.race_metadata", "btd6_race", ""),
+    "btd6_boss": ("btd6.boss_metadata", "btd6_boss_difficulty", "_standard"),
+    "btd6_odyssey": ("btd6.odyssey_metadata", "btd6_odyssey_difficulty", "_easy"),
+}
+
 
 @dataclass(frozen=True)
 class EventListItem:
@@ -527,6 +553,13 @@ async def build_event_detail_view_model(
 ) -> EventDetailViewModel | None:
     """Compose an event-detail view-model.
 
+    Fetches the index fact (name + window + scores) and the matching
+    metadata fact (rules + ``_towers`` restrictions) for one event so the
+    detail embed can render *all* the data available about it. Boss /
+    odyssey metadata lives under a separate difficulty entity_kind with a
+    difficulty-suffixed key (see :data:`_EVENT_METADATA_LOOKUP`); race keeps
+    it under the same key; CT / event carry no restriction metadata.
+
     Returns ``None`` when no fact exists for the requested key.
     """
     from utils.btd6.body_coerce import coerce_body
@@ -536,19 +569,25 @@ async def build_event_detail_view_model(
     context_type = _EVENT_KIND_TO_CONTEXT_TYPE.get(entity_kind, "event")
     source_key = _EVENT_KIND_TO_SOURCE_KEY.get(entity_kind, "")
 
-    rows = await btd6_db.search_facts(
-        entity_kind=entity_kind,
-        entity_key=entity_key,
-        limit=2,
+    # Index ("primary") fact — name / window / scores. Filter by the index
+    # fact_type so an entity that also has a same-key ``*_metadata`` fact
+    # (race) doesn't return the metadata as the primary row.
+    primary_row = await btd6_db.get_latest_fact(
+        _EVENT_INDEX_FACT_TYPE.get(entity_kind),
+        entity_kind,
+        entity_key,
     )
-    primary_row = next(
-        (r for r in rows if not str(r.get("fact_type", "")).endswith("_metadata")),
-        rows[0] if rows else None,
-    )
-    metadata_row = next(
-        (r for r in rows if str(r.get("fact_type", "")).endswith("_metadata")),
-        None,
-    )
+
+    # Metadata fact — rules + restrictions, keyed per kind.
+    metadata_row: dict[str, Any] | None = None
+    md_lookup = _EVENT_METADATA_LOOKUP.get(entity_kind)
+    if md_lookup is not None:
+        md_fact_type, md_entity_kind, key_suffix = md_lookup
+        metadata_row = await btd6_db.get_latest_fact(
+            md_fact_type,
+            md_entity_kind,
+            f"{entity_key}{key_suffix}",
+        )
 
     if primary_row is None and metadata_row is None:
         return None
@@ -577,6 +616,174 @@ async def build_event_detail_view_model(
         fetched_at=fetched_at,
         freshness=freshness,
         context=make_context_handle(context_type, entity_key),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Live overview view-model (current events across all kinds)
+# ---------------------------------------------------------------------------
+
+
+# (entity_kind, short_kind, emoji, label) — useful-first order, mirrors the
+# hub panel's "Currently active" block.
+_OVERVIEW_KINDS: tuple[tuple[str, str, str, str], ...] = (
+    ("btd6_race", "race", "🏁", "Race"),
+    ("btd6_boss", "boss", "👑", "Boss"),
+    ("btd6_ct", "ct", "🗺️", "CT"),
+    ("btd6_odyssey", "odyssey", "🌊", "Odyssey"),
+    ("btd6_event", "event", "🎪", "Event"),
+)
+
+
+@dataclass(frozen=True)
+class LiveOverviewItem:
+    """One currently-live event in the overview's drill-down select."""
+
+    entity_kind: str
+    short_kind: str
+    emoji: str
+    label: str  # human kind label, e.g. "Race"
+    entity_key: str
+    name: str
+    end_ms: int | None
+    window: WindowStatus
+    context: ContextHandle
+
+
+@dataclass(frozen=True)
+class LiveOverviewKind:
+    """One kind's live status in the overview embed (live events or none)."""
+
+    entity_kind: str
+    short_kind: str
+    emoji: str
+    label: str
+    live: tuple[LiveOverviewItem, ...]
+    freshness: DataFreshness
+
+
+@dataclass(frozen=True)
+class LiveOverviewViewModel:
+    """Landing view-model: what BTD6 events are live *right now*."""
+
+    kinds: tuple[LiveOverviewKind, ...]
+    context: ContextHandle
+
+    @property
+    def all_live(self) -> tuple[LiveOverviewItem, ...]:
+        """Every currently-live event, flattened in useful-first order."""
+        return tuple(item for kind in self.kinds for item in kind.live)
+
+    @property
+    def total_live(self) -> int:
+        return sum(len(kind.live) for kind in self.kinds)
+
+    @property
+    def worst_freshness(self) -> FreshnessBucket:
+        """Worst per-kind freshness bucket — drives the embed's stale warning."""
+        order: tuple[FreshnessBucket, ...] = (
+            "fresh",
+            "aging",
+            "stale",
+            "never",
+        )
+        worst = "fresh"
+        worst_idx = 0
+        for kind in self.kinds:
+            try:
+                idx = order.index(kind.freshness.state)
+            except ValueError:
+                idx = 0
+            if idx > worst_idx:
+                worst_idx, worst = idx, kind.freshness.state
+        return worst  # type: ignore[return-value]
+
+
+async def build_live_overview_view_model() -> LiveOverviewViewModel:
+    """Compose the live-events landing view-model.
+
+    Uses :func:`services.btd6_live_query_service.get_active_events` (the
+    canonical "what's live" query) and applies the same **strict** active
+    filter as the hub panel — only events whose ``end_ms`` is explicitly in
+    the future surface as live. This makes the overview agree with the
+    panel's "Currently active" block and keeps ended/ambiguous events out of
+    the user-facing "what's running now" claim (the wall-of-``ended`` UX
+    problem the old browser had). Per-kind freshness comes from the latest
+    stored fact for that kind, so a kind with nothing live still shows
+    whether ingestion ran recently.
+    """
+    from datetime import datetime, timezone
+
+    from services import btd6_live_query_service
+    from utils.db import btd6_sources as btd6_db
+
+    entity_kinds = tuple(ek for ek, _, _, _ in _OVERVIEW_KINDS)
+    headlines = await btd6_live_query_service.get_active_events(entity_kinds)
+    rows = await btd6_db.latest_fact_per_entity_kind(list(entity_kinds))
+    now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+
+    label_by_kind = {
+        ek: (short, emoji, label) for ek, short, emoji, label in _OVERVIEW_KINDS
+    }
+    live_by_kind: dict[str, list[LiveOverviewItem]] = {}
+    for headline in headlines:
+        # Strict filter: only an explicit future end_ms counts as live.
+        if headline.end_ms is None or headline.end_ms <= now_ms:
+            continue
+        meta = label_by_kind.get(headline.entity_kind)
+        if meta is None:
+            continue
+        short, emoji, label = meta
+        if not headline.entity_key:
+            continue
+        try:
+            ctx = make_context_handle(short, headline.entity_key)  # type: ignore[arg-type]
+        except ValueError:
+            continue
+        live_by_kind.setdefault(headline.entity_kind, []).append(
+            LiveOverviewItem(
+                entity_kind=headline.entity_kind,
+                short_kind=short,
+                emoji=emoji,
+                label=label,
+                entity_key=headline.entity_key,
+                name=headline.name or headline.entity_key,
+                end_ms=headline.end_ms,
+                window=format_window(headline.start_ms, headline.end_ms),
+                context=ctx,
+            ),
+        )
+
+    kinds: list[LiveOverviewKind] = []
+    for entity_kind, short, emoji, label in _OVERVIEW_KINDS:
+        source_key = _EVENT_KIND_TO_SOURCE_KEY.get(entity_kind, "")
+        row = rows.get(entity_kind)
+        if row is None:
+            freshness = DataFreshness(
+                state="never",
+                last_success_at=None,
+                last_attempt_at=None,
+                source_key=source_key,
+            )
+        else:
+            freshness = _freshness_from_fetched_at(
+                row.get("fetched_at"),
+                source_key=source_key,
+            )
+        kinds.append(
+            LiveOverviewKind(
+                entity_kind=entity_kind,
+                short_kind=short,
+                emoji=emoji,
+                label=label,
+                live=tuple(live_by_kind.get(entity_kind, ())),
+                freshness=freshness,
+            ),
+        )
+
+    return LiveOverviewViewModel(
+        kinds=tuple(kinds),
+        context=make_context_handle("hub", "live"),
     )
 
 

--- a/disbot/views/btd6/live_events_view.py
+++ b/disbot/views/btd6/live_events_view.py
@@ -1,12 +1,23 @@
-"""Live Events browser — race / boss / CT / odyssey / event drill-down.
+"""Live Events browser — current-event-first.
 
-Opened from the BTD6 hub. Two selects:
+Opened from the BTD6 hub's **Live Events** button. The landing is a
+*live overview* (:class:`LiveOverviewView`): it shows what race / boss /
+CT / odyssey / event is running **right now**, one line per kind, and a
+select containing **only the currently-live events**. Picking one opens a
+rich :class:`EventDetailView` with all the data stored about it (window,
+rules, tower/hero restrictions, scores, coverage).
 
-1. Event kind (race / boss / ct / odyssey / event) — drives the list.
-2. Event id — opens the detail view.
+History is a deliberate second step: the **📜 Past events** button opens
+:class:`LiveEventsBrowserView` — the by-kind list of recent (incl. ended)
+events — which drills into the same detail view. A ``↩ Live now`` button
+returns to the overview so nobody is stranded in history.
 
-Detail view's "Back" rebuilds the list with the kind preserved via
-the closure captured by :func:`views.navigation.attach_back_button`.
+This replaces the previous flow, which dumped *every* stored fact (mostly
+``ended``) into both the embed and a dropdown and never surfaced the
+current event. It also fixes the drill-down crashing on every click — the
+detail view-model used to call ``search_facts`` with an unsupported
+``entity_key`` kwarg, so the ephemeral silently never updated ("the race
+event button does nothing").
 """
 
 from __future__ import annotations
@@ -19,10 +30,13 @@ from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followu
 from services.btd6_view_model_service import (
     EventDetailViewModel,
     EventListViewModel,
+    LiveOverviewViewModel,
     build_event_detail_view_model,
     build_event_list_view_model,
+    build_live_overview_view_model,
 )
-from utils.btd6.freshness_render import render_freshness_warning
+from utils.btd6.context_footer import append_context_footer
+from utils.btd6.freshness_render import BUCKET_EMOJI, render_freshness_warning
 from views.base import HubView
 from views.navigation import attach_back_button
 
@@ -30,11 +44,11 @@ logger = logging.getLogger("bot.views.btd6.live_events")
 
 
 _KIND_LABELS: tuple[tuple[str, str, str], ...] = (
-    ("race", "🏁 Race", "Active + recent race events"),
-    ("boss", "👑 Boss", "Active + recent boss events"),
+    ("race", "🏁 Race", "Recent + active race events"),
+    ("boss", "👑 Boss", "Recent + active boss events"),
     ("ct", "🗺️ CT", "Contested Territory events"),
-    ("odyssey", "🌊 Odyssey", "Active + recent odysseys"),
-    ("event", "🎪 Event", "Other live events"),
+    ("odyssey", "🌊 Odyssey", "Recent + active odysseys"),
+    ("event", "🎪 Event", "Other recent events"),
 )
 
 
@@ -43,13 +57,63 @@ _KIND_LABELS: tuple[tuple[str, str, str], ...] = (
 # ---------------------------------------------------------------------------
 
 
+def build_live_overview_embed(vm: LiveOverviewViewModel) -> discord.Embed:
+    """Landing embed: what BTD6 events are live right now, one line per kind."""
+    total = vm.total_live
+    if total == 0:
+        embed = discord.Embed(
+            title="🐵 BTD6 — Live Events",
+            description=(
+                "**Nothing is running right now** — no race, boss, CT, odyssey, "
+                "or other event is currently live.\n\n"
+                "Tap **📜 Past events** to browse recent (ended) events, or check "
+                "back when one starts."
+            ),
+            color=discord.Color.greyple(),
+        )
+    else:
+        plural = "s" if total != 1 else ""
+        embed = discord.Embed(
+            title="🐵 BTD6 — Live Events",
+            description=(
+                f"**{total}** event{plural} live right now. Pick one below for full "
+                "details — rules, tower/hero restrictions, and timing. Tap "
+                "**📜 Past events** for recent history."
+            ),
+            color=discord.Color.green(),
+        )
+
+    for kind in vm.kinds:
+        badge = BUCKET_EMOJI.get(kind.freshness.state, "⚪")
+        if kind.live:
+            lines = []
+            for item in kind.live:
+                ends = item.window.relative.removeprefix("·").strip()
+                suffix = f" — {ends}" if ends else ""
+                lines.append(f"**{item.name}**{suffix}")
+            value = "\n".join(lines)
+        else:
+            value = "_nothing live_"
+        embed.add_field(
+            name=f"{kind.emoji} {kind.label} {badge}",
+            value=value[:1024],
+            inline=False,
+        )
+
+    warning = render_freshness_warning(vm.worst_freshness)
+    if warning:
+        embed.add_field(name="⚠️ Data freshness", value=warning, inline=False)
+    return append_context_footer(embed, vm.context.context_id)
+
+
 def build_kind_picker_embed() -> discord.Embed:
-    """First-step embed: pick an event kind."""
+    """Past-events step: pick an event kind to browse recent history."""
     return discord.Embed(
-        title="🐵 BTD6 — Live Events",
+        title="🐵 BTD6 — Past events",
         description=(
-            "Pick a category to browse the most-recent events. Use "
-            "**↩ Close** to dismiss the panel."
+            "Browse **recent events by category** — this list includes past "
+            "(ended) events, newest first. For what's live *right now*, use "
+            "**↩ Live now**."
         ),
         color=discord.Color.gold(),
     )
@@ -57,10 +121,10 @@ def build_kind_picker_embed() -> discord.Embed:
 
 def build_event_list_embed(vm: EventListViewModel) -> discord.Embed:
     embed = discord.Embed(
-        title=f"🐵 BTD6 — Live {vm.kind.title()} events",
+        title=f"🐵 BTD6 — Recent {vm.kind.title()} events",
         description=(
-            f"Showing {len(vm.items)} of {vm.total_count}. Pick an event "
-            "to view detail / restrictions."
+            f"Showing {len(vm.items)} of {vm.total_count} (newest first, "
+            "includes ended). Pick an event for full detail / restrictions."
         ),
         color=discord.Color.gold(),
     )
@@ -71,7 +135,7 @@ def build_event_list_embed(vm: EventListViewModel) -> discord.Embed:
         embed.add_field(
             name="No events",
             value=(
-                f"No active or recent `{vm.kind}` events stored yet. "
+                f"No `{vm.kind}` events stored yet. "
                 f"Try `!btd6 refresh-source {vm.freshness.source_key}`."
             ),
             inline=False,
@@ -79,18 +143,20 @@ def build_event_list_embed(vm: EventListViewModel) -> discord.Embed:
     for item in vm.items[:10]:
         embed.add_field(
             name=item.name[:256],
-            value=f"id=`{item.entity_key}` · {item.window.human}",
+            value=f"{item.window.human} · id=`{item.entity_key}`",
             inline=False,
         )
     return embed
 
 
 def build_event_detail_embed_from_vm(vm: EventDetailViewModel) -> discord.Embed:
-    """Render detail page for one event.
+    """Render the detail page for one event.
 
-    Reuses the existing ``build_event_detail_embed`` for byte-identical
-    layout. The VM holds the rows the legacy builder reads from, so we
-    construct row dicts and forward them.
+    Reuses the existing ``build_event_detail_embed`` for layout. The VM
+    holds the index + metadata bodies; we forward them as row dicts so the
+    builder renders window, rules, restrictions, scores, and coverage. The
+    embed colour reflects the live/ended/upcoming state so the current
+    event reads at a glance.
     """
     from cogs.btd6._builders import build_event_detail_embed
 
@@ -116,6 +182,13 @@ def build_event_detail_embed_from_vm(vm: EventDetailViewModel) -> discord.Embed:
         primary_row,
         metadata_row=metadata_row,
     )
+    # Colour-code by window state so "live" pops and "ended" reads as past.
+    _STATE_COLOR = {
+        "active": discord.Color.green(),
+        "upcoming": discord.Color.blurple(),
+        "ended": discord.Color.greyple(),
+    }
+    embed.color = _STATE_COLOR.get(vm.window.state, discord.Color.gold())
     warning = render_freshness_warning(vm.freshness.state)
     if warning:
         embed.add_field(name="⚠️ Data freshness", value=warning, inline=False)
@@ -123,12 +196,155 @@ def build_event_detail_embed_from_vm(vm: EventDetailViewModel) -> discord.Embed:
 
 
 # ---------------------------------------------------------------------------
-# Views
+# Detail drill-down (shared by the overview select and the history list)
+# ---------------------------------------------------------------------------
+
+
+async def _open_event_detail(
+    interaction: discord.Interaction,
+    kind: str,
+    entity_key: str,
+    *,
+    back_label: str,
+    back_custom_id: str,
+    parent_builder,
+) -> None:
+    """Build + render the event detail in place. Caller must have deferred."""
+    detail_vm = await build_event_detail_view_model(kind, entity_key)
+    if detail_vm is None:
+        await safe_edit(
+            interaction,
+            embed=discord.Embed(
+                title="🐵 BTD6 — Event",
+                description=(
+                    f"No data is stored for the `{kind}` event `{entity_key}`. "
+                    "It may have rotated out — try **📜 Past events**."
+                ),
+                color=discord.Color.red(),
+            ),
+            view=None,
+        )
+        return
+    detail_view = EventDetailView(interaction.user)
+    detail_view.set_vm(detail_vm)
+    attach_back_button(
+        detail_view,
+        label=back_label,
+        custom_id=back_custom_id,
+        parent_builder=parent_builder,
+    )
+    await safe_edit(
+        interaction,
+        embed=build_event_detail_embed_from_vm(detail_vm),
+        view=detail_view,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Live overview (landing)
+# ---------------------------------------------------------------------------
+
+
+class _LiveOverviewSelect(discord.ui.Select):
+    """Select of the currently-live events across all kinds."""
+
+    def __init__(self, vm: LiveOverviewViewModel) -> None:
+        live = vm.all_live
+        empty = not live
+        if empty:
+            options = [discord.SelectOption(label="(nothing live)", value="__none__")]
+        else:
+            options = [
+                discord.SelectOption(
+                    label=f"{item.emoji} {item.name}"[:100],
+                    value=f"{item.short_kind}:{item.entity_key}"[:100],
+                    description=(
+                        f"{item.label} · {item.window.relative.removeprefix('·').strip()}"
+                    )[:100],
+                )
+                for item in live[:25]
+            ]
+        super().__init__(
+            placeholder=(
+                "Nothing live right now"
+                if empty
+                else "Pick a live event for full details…"
+            ),
+            min_values=1,
+            max_values=1,
+            options=options,
+            row=0,
+            disabled=empty,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        choice = self.values[0]
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        if choice == "__none__":
+            return
+        kind, _, entity_key = choice.partition(":")
+        author = interaction.user
+
+        async def _rebuild_overview(
+            _i: discord.Interaction,
+        ) -> tuple[discord.Embed, discord.ui.View]:
+            vm = await build_live_overview_view_model()
+            return build_live_overview_embed(vm), LiveOverviewView(author, vm)
+
+        await _open_event_detail(
+            interaction,
+            kind,
+            entity_key,
+            back_label="↩ Back to live",
+            back_custom_id=f"btd6_live_overview:back:{kind}:{entity_key}"[:100],
+            parent_builder=_rebuild_overview,
+        )
+
+
+class _PastEventsButton(discord.ui.Button):
+    """Opens the by-kind history browser (recent + ended events)."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            label="📜 Past events",
+            style=discord.ButtonStyle.secondary,
+            row=1,
+            custom_id="btd6_live:past",
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        view = LiveEventsBrowserView(interaction.user)
+        await safe_edit(
+            interaction,
+            embed=build_kind_picker_embed(),
+            view=view,
+        )
+
+
+class LiveOverviewView(HubView):
+    """Landing view: the currently-live events + a route into history."""
+
+    def __init__(
+        self,
+        author: discord.User | discord.Member,
+        vm: LiveOverviewViewModel,
+    ) -> None:
+        super().__init__(author)
+        self._vm = vm
+        self.add_item(_LiveOverviewSelect(vm))
+        self.add_item(_PastEventsButton())
+
+
+# ---------------------------------------------------------------------------
+# Past-events history browser (by kind)
 # ---------------------------------------------------------------------------
 
 
 class _KindSelect(discord.ui.Select):
-    """Picks the event kind; opens the per-kind list view."""
+    """Picks the event kind; opens the per-kind history list."""
 
     def __init__(self) -> None:
         options = [
@@ -154,7 +370,7 @@ class _KindSelect(discord.ui.Select):
 
 
 class _EventSelect(discord.ui.Select):
-    """Picks one specific event; opens the detail view."""
+    """Picks one specific (recent/past) event; opens the detail view."""
 
     def __init__(self, vm: EventListViewModel) -> None:
         options = [
@@ -168,10 +384,8 @@ class _EventSelect(discord.ui.Select):
         empty = not options
         if empty:
             # Disable rather than offer a dead "(no events)" option that
-            # silently defers on click — that silent defer is what made the
-            # control look broken ("the race button does nothing"). The list
-            # embed already explains the empty state; a greyed-out select
-            # reinforces "nothing to pick" instead of "broken".
+            # silently defers on click. The list embed already explains the
+            # empty state; a greyed-out select reinforces "nothing to pick".
             options = [
                 discord.SelectOption(label="(no events)", value="__none__"),
             ]
@@ -192,80 +406,85 @@ class _EventSelect(discord.ui.Select):
     async def callback(self, interaction: discord.Interaction) -> None:
         choice = self.values[0]
         kind = self._kind
+        if not await safe_defer(interaction, ephemeral=True):
+            return
         if choice == "__none__":
-            # Defensive: the select is disabled when empty, but if a stale
-            # component fires, answer explicitly rather than silently defer.
-            if not await safe_defer(interaction, ephemeral=True):
-                return
+            # Defensive: the select is disabled when empty, but answer
+            # explicitly rather than silently defer if a stale component fires.
             await safe_edit(
                 interaction,
                 embed=discord.Embed(
-                    title=f"🐵 BTD6 — Live {kind.title()} events",
+                    title=f"🐵 BTD6 — Recent {kind.title()} events",
                     description=(
-                        f"No active or recent `{kind}` events are stored right "
-                        "now. Check back when one is live."
+                        f"No `{kind}` events are stored right now. Check back "
+                        "when one is live."
                     ),
                     color=discord.Color.gold(),
                 ),
                 view=None,
             )
             return
-        if not await safe_defer(interaction, ephemeral=True):
-            return
-        detail_vm = await build_event_detail_view_model(kind, choice)
-        if detail_vm is None:
-            embed = discord.Embed(
-                title="🐵 BTD6 — Event",
-                description=f"No fact stored for `{kind}` event `{choice}`.",
-                color=discord.Color.red(),
-            )
-            await safe_edit(interaction, embed=embed, view=None)
-            return
+
+        author = interaction.user
 
         async def _rebuild_list(
             _i: discord.Interaction,
         ) -> tuple[discord.Embed, discord.ui.View]:
             list_vm = await build_event_list_view_model(kind)
-            parent = LiveEventsBrowserView(interaction.user)
+            parent = LiveEventsBrowserView(author)
             parent.set_kind(kind, list_vm)
             return build_event_list_embed(list_vm), parent
 
-        detail_view = EventDetailView(interaction.user)
-        detail_view.set_vm(detail_vm)
-        attach_back_button(
-            detail_view,
-            label="↩ Back to list",
-            custom_id=f"btd6_event_detail:back:{kind}:{detail_vm.entity_key}",
-            parent_builder=_rebuild_list,
-        )
-        await safe_edit(
+        await _open_event_detail(
             interaction,
-            embed=build_event_detail_embed_from_vm(detail_vm),
-            view=detail_view,
+            kind,
+            choice,
+            back_label="↩ Back to list",
+            back_custom_id=f"btd6_event_detail:back:{kind}:{choice}"[:100],
+            parent_builder=_rebuild_list,
         )
 
 
 class LiveEventsBrowserView(HubView):
-    """List of events for a given kind. Top-level of the drill-down."""
+    """By-kind list of recent (incl. ended) events. The history path."""
 
     def __init__(self, author: discord.User | discord.Member) -> None:
         super().__init__(author)
         self._kind: str | None = None
         self._vm: EventListViewModel | None = None
+        self._render()
+
+    def _render(self) -> None:
+        """(Re)build children: kind picker + (event select) + back-to-live."""
+        self.clear_items()
         self.add_item(_KindSelect())
+        if self._vm is not None:
+            self.add_item(_EventSelect(self._vm))
+
+        author = self._author
+
+        async def _rebuild_overview(
+            _i: discord.Interaction,
+        ) -> tuple[discord.Embed, discord.ui.View]:
+            vm = await build_live_overview_view_model()
+            return build_live_overview_embed(vm), LiveOverviewView(author, vm)
+
+        attach_back_button(
+            self,
+            label="↩ Live now",
+            custom_id="btd6_live_browser:back",
+            parent_builder=_rebuild_overview,
+        )
 
     def set_kind(self, kind: str, vm: EventListViewModel) -> None:
         """Populate the event select for the given kind."""
-        for child in list(self.children):
-            self.remove_item(child)
-        self.add_item(_KindSelect())
         self._kind = kind
         self._vm = vm
-        self.add_item(_EventSelect(vm))
+        self._render()
 
 
 class EventDetailView(HubView):
-    """One specific event. Reached from :class:`LiveEventsBrowserView`."""
+    """One specific event. Reached from the overview or the history list."""
 
     def __init__(self, author: discord.User | discord.Member) -> None:
         super().__init__(author)
@@ -281,13 +500,14 @@ class EventDetailView(HubView):
 
 
 async def open_live_events_browser(interaction: discord.Interaction) -> None:
-    """Open the live-events browser as an ephemeral followup."""
+    """Open the live-events overview as an ephemeral followup."""
     if not await safe_defer(interaction, ephemeral=True):
         return
-    view = LiveEventsBrowserView(interaction.user)
+    vm = await build_live_overview_view_model()
+    view = LiveOverviewView(interaction.user, vm)
     await safe_followup(
         interaction,
-        embed=build_kind_picker_embed(),
+        embed=build_live_overview_embed(vm),
         view=view,
         ephemeral=True,
     )
@@ -296,8 +516,10 @@ async def open_live_events_browser(interaction: discord.Interaction) -> None:
 __all__ = [
     "EventDetailView",
     "LiveEventsBrowserView",
+    "LiveOverviewView",
     "build_event_detail_embed_from_vm",
     "build_event_list_embed",
     "build_kind_picker_embed",
+    "build_live_overview_embed",
     "open_live_events_browser",
 ]

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -185,6 +185,12 @@ Current broad captures:
   number, so it always omits itself and `check_current_state_ledger.py --strict` flags it next
   session (the #942 drift this run fixed). Teach the guard to **skip a docs-only ledger-bookkeeping
   PR** (title + diff-confined-to-`current-state*.md`), closing the recurrence at the guard level.
+- [`autospec-mock-fidelity-guard-2026-06-16.md`](./autospec-mock-fidelity-guard-2026-06-16.md) —
+  **tooling/testing (2026-06-16):** make project mocks signature-faithful (`create_autospec` /
+  `AsyncMock(spec=…)`) via a lint/AST guard or a tiny `autospec_setattr` helper, so a call-site
+  kwarg typo that the real function would reject also fails the test. Born from the BTD6 drill-down
+  crash that shipped green because a bare `AsyncMock` masked a `search_facts(entity_key=…)` signature
+  mismatch. Small/safe tooling-lane candidate.
 - [`effective-check-constraint-test-helper-2026-06-14.md`](./effective-check-constraint-test-helper-2026-06-14.md) —
   **tooling (2026-06-14, PR #817):** a shared `effective_check_constraint(table, column)` test
   helper that derives the *current* SQL `CHECK (col IN …)` set by scanning all migrations in

--- a/docs/ideas/autospec-mock-fidelity-guard-2026-06-16.md
+++ b/docs/ideas/autospec-mock-fidelity-guard-2026-06-16.md
@@ -1,0 +1,54 @@
+# Idea — signature-faithful mocks / autospec guard for service+DB facades
+
+> **Status:** `ideas` — brainstorm, not approved. Promotion path: `docs/ideas/README.md`.
+> **Captured:** 2026-06-16 (BTD6 live-events session, Q-0089 ender).
+
+## The problem this is born from
+
+The BTD6 event drill-down had been crashing on **every** click in production
+(`build_event_detail_view_model` called `btd6_db.search_facts(entity_key=…)`, but
+`search_facts` has no `entity_key` parameter → `TypeError`). It shipped green because
+its only test mocked the DB facade with a bare `AsyncMock`:
+
+```python
+monkeypatch.setattr(btd6_db, "search_facts", AsyncMock(return_value=[...]))
+```
+
+A bare `AsyncMock`/`MagicMock` **accepts any args and any kwargs**, so the call-site
+kwarg typo passed the test while raising at runtime. The mock was *more permissive
+than the real function*, which is exactly how a signature mismatch slips past CI.
+
+This is a recurring, high-cost failure class: a "tested" function that crashes on the
+first real call. The user-visible symptom here was "the race event button does
+nothing."
+
+## The idea
+
+Make project mocks **signature-faithful** so a call that the real function would
+reject also fails the test:
+
+1. **Lint/AST guard (cheap, catches the common case):** flag
+   `MagicMock(`/`AsyncMock(` used as a `monkeypatch.setattr(<real_module>, "<attr>", …)`
+   replacement for a project callable **without** `spec=`/`autospec=`. Steer toward
+   `create_autospec(real_fn)` (or `AsyncMock(spec=real_fn)`), which enforces the real
+   signature. Scope to `monkeypatch.setattr`/`patch.object` on `disbot.*` targets so
+   third-party mocks aren't touched. Disposable convenience guard (Q-0105 header:
+   delete if it proves noisy across a few sessions).
+2. **Or a tiny test helper:** `autospec_setattr(monkeypatch, obj, "name", side_effect/return_value=…)`
+   that wraps `create_autospec` — one call site, hard to misuse, and the DB-facade
+   tests (the densest mock users) adopt it first.
+
+## Why it's worth having
+
+- Directly prevents the class of bug that just cost a fully-broken user-facing feature
+  that "had a test."
+- Cheap and verifiable: `create_autospec` is stdlib; the guard is pure AST over `tests/`.
+- Complements the existing executable-verification push (`docs/ideas/
+  executable-verification-over-prose-verified-2026-06-12.md`) — same spirit, applied to
+  test doubles.
+
+## Disposition
+
+Promote to a small `docs/planning/` slice when a tooling lane has capacity; start by
+autospec-ing the BTD6 view-model + DB-facade tests (highest mock density) and measure how
+many latent signature mismatches it surfaces before deciding whether to CI-wire the guard.

--- a/docs/ideas/button-command-surface-parity-2026-06-16.md
+++ b/docs/ideas/button-command-surface-parity-2026-06-16.md
@@ -29,8 +29,21 @@ pass would surface the rest (e.g. other `_*PanelView` action buttons).
 - discord.py gotchas this class hits: method names can't start with `cog_`/`bot_`; a command with
   ≥3 aliases must declare `extras={"alias_classification": ...}` (the surface-ledger invariant).
 
+## Sibling failure mode (added 2026-06-16, BTD6 live-events session)
+
+There is a related-but-distinct "button does nothing" class this idea should **not** try to
+own: a button that *does* have a callback but the callback **silently crashes** after deferring
+(here, the BTD6 Live Events drill-down raised `TypeError` from a bad `search_facts(entity_key=…)`
+call; the deferred ephemeral never updated and the view's `on_error` swallowed it). That's not a
+missing-surface gap — it's a tested-but-broken callback — and the right guard is test-time
+signature fidelity, routed to
+[`autospec-mock-fidelity-guard-2026-06-16.md`](./autospec-mock-fidelity-guard-2026-06-16.md),
+not a surface-parity audit. Keeping the two scopes separate stops this idea from over-reaching.
+
 ## Disposition
 
-Review-lane idea (UX/discoverability). Candidate to fold into `docs/ux/` review guidance or the
-production eval checklist rather than ship as a brittle CI guard. Relates: `cogs/admin_cog.py`
-(panel buttons), `core/runtime/command_surface_ledger.py`, `utils/synonyms.py`.
+Review-lane idea (UX/discoverability), scoped to **missing command front doors for action
+buttons** (not silently-failing callbacks — see sibling note above). Candidate to fold into
+`docs/ux/` review guidance or the production eval checklist rather than ship as a brittle CI
+guard. Relates: `cogs/admin_cog.py` (panel buttons),
+`core/runtime/command_surface_ledger.py`, `utils/synonyms.py`.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,10 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/epic-noether-qgis28` · BTD6 Live Events — fix the dead event drill-down
+  (`build_event_detail_view_model` `TypeError`) + current-event-first overview redesign (show only
+  the live event + all its info; history behind 📜 Past events) · `services/btd6_view_model_service.py`
+  · `views/btd6/live_events_view.py` · `cogs/btd6/_event_helpers.py` · 2026-06-16
 - `claude/modest-ptolemy-2xipoh` · design capture — routine dispatch / staged deep-clean /
   planning sectors (owner discussion) · `docs/ideas/` + router Q-0137 · 2026-06-14
 - `claude/hopeful-allen-home-slice-c` · mining Slice C — Home structure (character-card backdrop) ·

--- a/tests/unit/services/test_btd6_view_model_service.py
+++ b/tests/unit/services/test_btd6_view_model_service.py
@@ -340,7 +340,7 @@ async def test_event_detail_returns_none_when_no_fact(monkeypatch) -> None:
     from services.btd6_view_model_service import build_event_detail_view_model
     from utils.db import btd6_sources as btd6_db
 
-    monkeypatch.setattr(btd6_db, "search_facts", AsyncMock(return_value=[]))
+    monkeypatch.setattr(btd6_db, "get_latest_fact", AsyncMock(return_value=None))
 
     vm = await build_event_detail_view_model("race", "missing")
     assert vm is None
@@ -352,25 +352,24 @@ async def test_event_detail_builds_full_vm(monkeypatch) -> None:
     from utils.db import btd6_sources as btd6_db
 
     now = datetime.now(tz=timezone.utc)
-    monkeypatch.setattr(
-        btd6_db,
-        "search_facts",
-        AsyncMock(
-            return_value=[
-                {
-                    "entity_kind": "btd6_race",
-                    "entity_key": "R42",
-                    "fact_type": "btd6.races_index",
-                    "body_json": {
-                        "name": "Reversed Loop",
-                        "start_ms": int(now.timestamp() * 1000) - 3_600_000,
-                        "end_ms": int(now.timestamp() * 1000) + 3_600_000,
-                    },
-                    "fetched_at": now,
-                },
-            ],
-        ),
-    )
+    index_row = {
+        "entity_kind": "btd6_race",
+        "entity_key": "R42",
+        "fact_type": "btd6.races_index",
+        "body_json": {
+            "name": "Reversed Loop",
+            "start_ms": int(now.timestamp() * 1000) - 3_600_000,
+            "end_ms": int(now.timestamp() * 1000) + 3_600_000,
+        },
+        "fetched_at": now,
+    }
+
+    async def _get_latest_fact(fact_type, entity_kind, entity_key):
+        if fact_type == "btd6.races_index":
+            return index_row
+        return None
+
+    monkeypatch.setattr(btd6_db, "get_latest_fact", _get_latest_fact)
 
     vm = await build_event_detail_view_model("race", "R42")
     assert vm is not None
@@ -378,6 +377,148 @@ async def test_event_detail_builds_full_vm(monkeypatch) -> None:
     assert vm.context.context_id == "btd6_race:R42"
     assert vm.window.state == "active"
     assert vm.freshness.state == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_event_detail_does_not_pass_entity_key_to_search_facts(
+    monkeypatch,
+) -> None:
+    """Regression: the drill-down used to call ``search_facts(entity_key=…)``,
+    which raises ``TypeError`` (no such kwarg) on EVERY event detail — the
+    "race event button does nothing" bug. The detail path must use
+    ``get_latest_fact`` (entity-keyed), never ``search_facts`` with an
+    ``entity_key`` kwarg.
+    """
+    import inspect
+
+    from services.btd6_view_model_service import build_event_detail_view_model
+    from utils.db import btd6_sources as btd6_db
+
+    # The real signature must not accept entity_key (proves the old call broke).
+    assert "entity_key" not in inspect.signature(btd6_db.search_facts).parameters
+
+    boom = AsyncMock(side_effect=AssertionError("detail must not call search_facts"))
+    monkeypatch.setattr(btd6_db, "search_facts", boom)
+    monkeypatch.setattr(btd6_db, "get_latest_fact", AsyncMock(return_value=None))
+
+    # Must not raise (old code raised TypeError here) and must not touch search_facts.
+    vm = await build_event_detail_view_model("race", "R42")
+    assert vm is None
+    boom.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_event_detail_fetches_boss_metadata_with_standard_suffix(
+    monkeypatch,
+) -> None:
+    """Boss metadata lives under ``btd6_boss_difficulty`` keyed
+    ``{id}_standard`` (the ingestion fan-out). The detail VM must look it up
+    with that suffix so boss rules/restrictions actually render.
+    """
+    from services.btd6_view_model_service import build_event_detail_view_model
+    from utils.db import btd6_sources as btd6_db
+
+    now = datetime.now(tz=timezone.utc)
+    calls: list[tuple] = []
+
+    async def _get_latest_fact(fact_type, entity_kind, entity_key):
+        calls.append((fact_type, entity_kind, entity_key))
+        if fact_type == "btd6.bosses_index":
+            return {
+                "entity_kind": "btd6_boss",
+                "entity_key": "Dreadbloon35",
+                "body_json": {"name": "Dreadbloon", "end_ms": 0},
+                "fetched_at": now,
+            }
+        if fact_type == "btd6.boss_metadata":
+            return {
+                "entity_kind": "btd6_boss_difficulty",
+                "entity_key": entity_key,
+                "body_json": {"_towers": [{"tower": "Druid", "max": 0}]},
+                "fetched_at": now,
+            }
+        return None
+
+    monkeypatch.setattr(btd6_db, "get_latest_fact", _get_latest_fact)
+
+    vm = await build_event_detail_view_model("boss", "Dreadbloon35")
+    assert vm is not None
+    # The metadata lookup used the _standard suffix, not _normal.
+    assert ("btd6.boss_metadata", "btd6_boss_difficulty", "Dreadbloon35_standard") in calls
+    assert vm.metadata_body.get("_towers")
+
+
+# ---------------------------------------------------------------------------
+# Live overview (current-event-first landing)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_live_overview_groups_only_live_events(monkeypatch) -> None:
+    from services import btd6_live_query_service
+    from services.btd6_live_query_service import ActiveEventHeadline
+    from services.btd6_view_model_service import build_live_overview_view_model
+    from utils.db import btd6_sources as btd6_db
+
+    now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+    headlines = (
+        ActiveEventHeadline(
+            "btd6_ct", "ct1", "Contested Territory", now_ms - 1000, now_ms + 36_000_000, None
+        ),
+        ActiveEventHeadline(
+            "btd6_event", "ev1", "Collab Event", None, now_ms + 72_000_000, None
+        ),
+        # ended → excluded by the strict future-end filter
+        ActiveEventHeadline("btd6_race", "r_old", "Old Race", None, now_ms - 1000, None),
+        # missing end_ms → excluded by the strict filter
+        ActiveEventHeadline("btd6_boss", "b1", "Boss", None, None, None),
+    )
+    monkeypatch.setattr(
+        btd6_live_query_service,
+        "get_active_events",
+        AsyncMock(return_value=headlines),
+    )
+    monkeypatch.setattr(
+        btd6_db, "latest_fact_per_entity_kind", AsyncMock(return_value={})
+    )
+
+    vm = await build_live_overview_view_model()
+    # All 5 kinds always present, in useful-first order.
+    assert tuple(k.short_kind for k in vm.kinds) == (
+        "race",
+        "boss",
+        "ct",
+        "odyssey",
+        "event",
+    )
+    # Only the two explicit-future events count as live.
+    assert vm.total_live == 2
+    assert {it.entity_key for it in vm.all_live} == {"ct1", "ev1"}
+    by_short = {k.short_kind: k for k in vm.kinds}
+    assert by_short["race"].live == ()  # ended excluded
+    assert by_short["boss"].live == ()  # missing-end excluded
+    assert by_short["ct"].live[0].name == "Contested Territory"
+    assert by_short["ct"].live[0].context.context_id == "btd6_ct:ct1"
+
+
+@pytest.mark.asyncio
+async def test_live_overview_empty_when_nothing_live(monkeypatch) -> None:
+    from services import btd6_live_query_service
+    from services.btd6_view_model_service import build_live_overview_view_model
+    from utils.db import btd6_sources as btd6_db
+
+    monkeypatch.setattr(
+        btd6_live_query_service, "get_active_events", AsyncMock(return_value=())
+    )
+    monkeypatch.setattr(
+        btd6_db, "latest_fact_per_entity_kind", AsyncMock(return_value={})
+    )
+
+    vm = await build_live_overview_view_model()
+    assert vm.total_live == 0
+    assert vm.all_live == ()
+    # No stored facts at all → worst per-kind freshness is "never".
+    assert vm.worst_freshness == "never"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/views/btd6/test_live_events_view.py
+++ b/tests/unit/views/btd6/test_live_events_view.py
@@ -12,13 +12,19 @@ from services.btd6_view_model_service import (
     DataFreshness,
     EventListItem,
     EventListViewModel,
+    LiveOverviewItem,
+    LiveOverviewKind,
+    LiveOverviewViewModel,
 )
 from utils.btd6.event_window import format_window
 from views.btd6.live_events_view import (
     EventDetailView,
     LiveEventsBrowserView,
+    LiveOverviewView,
+    _LiveOverviewSelect,
     build_event_list_embed,
     build_kind_picker_embed,
+    build_live_overview_embed,
 )
 
 
@@ -90,8 +96,119 @@ def test_event_select_caps_at_25() -> None:
 
 
 def test_kind_picker_embed_title() -> None:
+    # The kind picker is now the *history* (past-events) step; the live
+    # overview owns the "Live Events" title.
     embed = build_kind_picker_embed()
+    assert embed.title == "🐵 BTD6 — Past events"
+
+
+# ---------------------------------------------------------------------------
+# Live overview (current-event-first landing)
+# ---------------------------------------------------------------------------
+
+
+def _overview_item(short: str, key: str, name: str, end_ms: int) -> LiveOverviewItem:
+    emoji = {"race": "🏁", "boss": "👑", "ct": "🗺️", "odyssey": "🌊", "event": "🎪"}[short]
+    return LiveOverviewItem(
+        entity_kind=f"btd6_{short}",
+        short_kind=short,
+        emoji=emoji,
+        label=short.title(),
+        entity_key=key,
+        name=name,
+        end_ms=end_ms,
+        window=format_window(end_ms - 3_600_000, end_ms),
+        context=ContextHandle(context_id=f"btd6_{short}:{key}", context_type=short),
+    )
+
+
+def _overview_vm(live_items: list[LiveOverviewItem]) -> LiveOverviewViewModel:
+    by_kind: dict[str, list[LiveOverviewItem]] = {}
+    for it in live_items:
+        by_kind.setdefault(it.short_kind, []).append(it)
+    kinds = tuple(
+        LiveOverviewKind(
+            entity_kind=f"btd6_{short}",
+            short_kind=short,
+            emoji=emoji,
+            label=short.title(),
+            live=tuple(by_kind.get(short, [])),
+            freshness=DataFreshness(
+                state="fresh",
+                last_success_at=datetime.now(tz=timezone.utc),
+                last_attempt_at=datetime.now(tz=timezone.utc),
+                source_key=f"nk_btd6_{short}s",
+            ),
+        )
+        for short, emoji in (
+            ("race", "🏁"),
+            ("boss", "👑"),
+            ("ct", "🗺️"),
+            ("odyssey", "🌊"),
+            ("event", "🎪"),
+        )
+    )
+    return LiveOverviewViewModel(
+        kinds=kinds,
+        context=ContextHandle(context_id="btd6_hub:live", context_type="hub"),
+    )
+
+
+def test_overview_embed_lists_live_event_and_title() -> None:
+    now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+    vm = _overview_vm([_overview_item("ct", "ct1", "Contested Territory", now_ms + 36_000_000)])
+    embed = build_live_overview_embed(vm)
     assert embed.title == "🐵 BTD6 — Live Events"
+    # The live event's name appears in a field value.
+    joined = "\n".join(f.value or "" for f in embed.fields)
+    assert "Contested Territory" in joined
+    # And kinds with nothing live are clearly marked.
+    assert "nothing live" in joined
+
+
+def test_overview_embed_empty_state() -> None:
+    vm = _overview_vm([])
+    embed = build_live_overview_embed(vm)
+    assert "Nothing is running right now" in (embed.description or "")
+
+
+def test_overview_select_lists_only_live_events() -> None:
+    now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+    vm = _overview_vm(
+        [
+            _overview_item("ct", "ct1", "Contested Territory", now_ms + 36_000_000),
+            _overview_item("event", "ev1", "Collab Event", now_ms + 72_000_000),
+        ],
+    )
+    sel = _LiveOverviewSelect(vm)
+    assert sel.disabled is False
+    # value = "<short>:<entity_key>" so the callback can route to detail.
+    assert {o.value for o in sel.options} == {"ct:ct1", "event:ev1"}
+
+
+def test_overview_select_disabled_when_nothing_live() -> None:
+    sel = _LiveOverviewSelect(_overview_vm([]))
+    assert sel.disabled is True
+    assert [o.value for o in sel.options] == ["__none__"]
+
+
+def test_overview_view_has_select_and_past_events_button() -> None:
+    vm = _overview_vm([])
+    view = LiveOverviewView(_stub_user(), vm)
+    selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    assert len(selects) == 1
+    assert any("Past events" in (b.label or "") for b in buttons)
+
+
+def test_history_browser_has_back_to_live_button() -> None:
+    view = LiveEventsBrowserView(_stub_user())
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    assert any("Live now" in (b.label or "") for b in buttons)
+    # set_kind must preserve the back button (it re-renders all children).
+    view.set_kind("race", _vm("race", [_item("R1")]))
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    assert any("Live now" in (b.label or "") for b in buttons)
 
 
 def test_list_embed_renders_warning_when_stale() -> None:


### PR DESCRIPTION
## Why

Owner shared a Discord screen recording of the BTD6 **Live Events** browser with two complaints:

1. "it does not look nice, it's not easy to understand … this should be properly divided into clear informational views that display **only the current event** and **all information available about it**."
2. "the race event button **still does nothing**."

## What I found

- **Root cause of "does nothing" — a real crash on every drill-down.** `services.btd6_view_model_service.build_event_detail_view_model` called `btd6_db.search_facts(entity_kind=…, entity_key=…, limit=2)`, but `search_facts(*, fact_type=None, entity_kind=None, limit=50)` **has no `entity_key` parameter** → `TypeError` on **every** event detail (race/boss/ct/odyssey/event). The select callback had already deferred the ephemeral, so the exception was swallowed by the view's `on_error` and the message silently never updated. The path had **zero test coverage**, so it shipped broken (the existing test mocked `search_facts` with an `AsyncMock`, which accepts any kwarg and masked the bug).
- **UX problem.** The browser listed *all* stored facts (mostly `status: ended`) via `build_event_list_view_model`, capped at 25, ordered by fetch time — a wall of dead events with cryptic API ids, the **same data duplicated** in the embed *and* the dropdown, and no focus on what is actually live. `get_active_events()` already filters to live/future events but the browser ignored it.
- **Latent secondary bug.** `cogs.btd6._event_helpers.build_event_payload` looked up boss metadata with `{id}_normal`, but ingestion stores it as `{id}_standard` (`difficulty="standard"`), so `!btd6events event boss <id>` never found boss rules/restrictions.

## What changed

- **`services/btd6_view_model_service.py`**
  - Rewrote `build_event_detail_view_model` to use `get_latest_fact` for the index fact and the correct per-kind metadata fact (race `btd6.race_metadata`; boss `btd6.boss_metadata`/`btd6_boss_difficulty`/`{id}_standard`; odyssey `btd6.odyssey_metadata`/`btd6_odyssey_difficulty`/`{id}_easy`). Fixes the crash **and** renders full rules + tower/hero restrictions for all kinds.
  - Added `build_live_overview_view_model()` + `LiveOverviewViewModel` — the currently-live events only, with the **same strict future-end filter as the hub panel** (so the overview agrees with the panel's "Currently active" block).
- **`views/btd6/live_events_view.py`** — current-event-first redesign:
  - Landing is now a **live overview**: one line per kind showing the live event + countdown (or "_nothing live_"), and a select containing **only currently-live events** → rich detail (colour-coded green=live / grey=ended).
  - History moved behind a de-emphasized **📜 Past events** button (the old by-kind list, relabelled "recent/past"), with a **↩ Live now** button so nobody is stranded.
- **`cogs/btd6/_event_helpers.py`** — fixed the `_normal` → `_standard` boss-metadata suffix.

## Result

- Picking **Live Events** now immediately shows what's live (or a clear "Nothing is running right now") — no wall of ended events. Race/boss simply read "_nothing live_" instead of looking broken.
- Drilling into any event **works** and shows all available info — window/countdown, rules, banned/limited towers, disabled flags, scores, coverage.

## Tests / checks

- New tests: the previously-untested detail path — a **crash regression** (`search_facts` must never be called with `entity_key`; detail must not raise) and the **boss-metadata suffix** fix; plus the live-overview VM (live-only / strict filter) and the overview view/select/embed + history back-nav.
- `python3.10 scripts/check_quality.py --full` → **9990 passed, 37 skipped**; mypy clean; lint clean.
- `python3.10 scripts/check_architecture.py --mode strict` → no new violations.

https://claude.ai/code/session_01F9M5v2itsejDG26PvpnQy2

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9M5v2itsejDG26PvpnQy2)_