### PR TITLE
docs(ideas): architecture-atlas / structure review — capture, judgment, drift fixes

### DIFF
--- a/.sessions/2026-06-16-architecture-atlas-structure-review.md
+++ b/.sessions/2026-06-16-architecture-atlas-structure-review.md
@@ -1,0 +1,20 @@
+# Session — architecture-atlas / structure-review idea intake
+
+> **Status:** `in-progress` — born-red per Q-0133; flips to `complete` as the final step.
+> **Date:** 2026-06-16 · **Branch:** `claude/hopeful-meitner-772pv8`
+
+## What I'm about to do
+
+The owner uploaded an external repo-architecture review ("SuperBot repository-architectuuratlas")
+and asked for **ideas we can use + my cross-checked final judgment** on the document's own ideas.
+
+Plan:
+1. Verify the document's central claims against live source (the doc is pinned to an older commit and
+   admits it could not re-verify live). — DONE in research below.
+2. Capture the review + my judgment as a routed idea doc:
+   `docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md` + README index entry.
+3. Bugs-first: fix the confirmed count-drift in **binding** docs (source wins).
+4. Route the genuinely-new items (extension-taxonomy crosswalk; unified atlas; count-cite guard) to
+   their correct homes; open one router Q-block for the genuine owner decisions.
+
+(Close-out enders — Q-0089 idea / Q-0102 review / Q-0104 audit — added at the bottom before the flip.)

--- a/.sessions/2026-06-16-architecture-atlas-structure-review.md
+++ b/.sessions/2026-06-16-architecture-atlas-structure-review.md
@@ -1,20 +1,67 @@
 # Session — architecture-atlas / structure-review idea intake
 
-> **Status:** `in-progress` — born-red per Q-0133; flips to `complete` as the final step.
-> **Date:** 2026-06-16 · **Branch:** `claude/hopeful-meitner-772pv8`
+> **Status:** `complete` — work done, PR #957 ready, auto-merge on green.
+> **Date:** 2026-06-16 · **Branch:** `claude/hopeful-meitner-772pv8` · **PR:** #957
 
-## What I'm about to do
+## Task
 
 The owner uploaded an external repo-architecture review ("SuperBot repository-architectuuratlas")
-and asked for **ideas we can use + my cross-checked final judgment** on the document's own ideas.
+and asked for **ideas we can use + a cross-checked final judgment** on the document's own ideas.
 
-Plan:
-1. Verify the document's central claims against live source (the doc is pinned to an older commit and
-   admits it could not re-verify live). — DONE in research below.
-2. Capture the review + my judgment as a routed idea doc:
-   `docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md` + README index entry.
-3. Bugs-first: fix the confirmed count-drift in **binding** docs (source wins).
-4. Route the genuinely-new items (extension-taxonomy crosswalk; unified atlas; count-cite guard) to
-   their correct homes; open one router Q-block for the genuine owner decisions.
+## What I did
 
-(Close-out enders — Q-0089 idea / Q-0102 review / Q-0104 audit — added at the bottom before the flip.)
+1. **Verified the review's claims against live source** (it was pinned to an older commit and admitted
+   it could not re-verify live). The cross-check changed the picture materially.
+2. **Capture + judgment doc** — `docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md`
+   (+ README index). Verdict: direction right, drift diagnosis **overstated**, flagship "per-file
+   dashboard" **~80% already shipped** as `context_map.py`; one recommendation (root README)
+   contradicts an explicit repo decision.
+3. **Bugs-first drift fixes** (source wins) — 3 confirmed stale counts in **binding** docs, de-numbered
+   to point at source so they can't re-rot: `architecture.md` `cogs/ (×28)`→43, `(51 migrations)`→74;
+   `repo-navigation-map.md` workflow line→6.
+4. **Routed** the genuinely-new ideas: extension-taxonomy crosswalk → own plan; thin unified atlas +
+   root-README → **router Q-0151** (DISCUSS); count-cite guard → fold into
+   `readiness-maps-cite-regen-command`.
+
+Verification: `check_docs --strict` ✓ · `check_quality --check-only` ✓. Docs only; no `disbot/` code.
+
+## Context delta (what the next session should know)
+
+- Live counts (verified 2026-06-16): **43** extensions · **32** registered subsystems · **39** EventBus
+  events · **74** migrations · **6** workflows. The 43↔32 gap is *unclassified*, not broken (Q-0151c).
+- `context_map.py` already answers the "per-file maintainer dashboard" question — **do not build a new
+  one**; compose it if an atlas is ever approved (Q-0151a).
+
+## Session enders
+
+**Grooming (Q-0015).** This session *was* a grooming/intake pass: moved the owner's architecture-review
+bundle from raw-upload → captured + routed (one DISCUSS Q-block, one plan-candidate, one fold-in into
+an existing idea, one executed bugs-first slice). Explicitly folded the count-cite guard into the
+existing `readiness-maps-cite-regen-command` idea rather than duplicating it.
+
+**💡 Session idea (Q-0089).** A generated **repo tooling/guard index** (`docs/tooling-index.md` from a
+`scripts --list`-style docstring scan): every `scripts/*.py` checker/analyzer with its one-line purpose
++ a "covers X — don't rebuild" note. This session's core finding was that a thoughtful external review
+recommended building `context_map.py`, *which already exists* — there is no single machine-readable
+manifest of what tooling/guards the repo already ships, so dedup happens by memory. This is the
+`do_not_create` list, but for **tooling** instead of subsystems. Cheap (parse module docstrings),
+reachable, and directly prevents the "let's build a dashboard/atlas/guard that already exists" failure
+mode. Dedup-checked: `claude-code-plugins-evaluation` filters *plugins* by hand; `docs/agent/index.yml`
+`do_not_create` is *per-subsystem*; no repo-wide tooling inventory exists. (Small; record-only here.)
+
+**⟲ Previous-session review (Q-0102).** The §7.5 BTD6 comparison-floor series (#946 tower / #950
+difficulty / #955 round-range) was disciplined work: each member shipped as a small, non-overlapping
+deterministic floor with an explicit "mutually exclusive on candidate count" guard and a clean
+self-recorded ledger entry. *What it could do better + a concrete system improvement:* each member
+spawned a follow-up idea because the floor's **trigger** is narrower than the mis-assembly **class** it
+claims to own (e.g. #955's round-token-per-range rule silently defers the natural comma-list phrasing →
+`round-range-comparison-bare-range-list` idea). System improvement: when a deterministic floor is added
+for a mis-assembly class, also add **`xfail` deferral tests** for the phrasings that *should* eventually
+trigger — so the trigger-vs-class coverage gap is visible in CI instead of living only as a follow-up
+idea doc. (Same "completeness vs trigger" theme as the grounding-completeness-claim idea.)
+
+**Doc audit (Q-0104).** This session's outputs are all in durable homes (judgment → idea doc; fixes →
+binding docs; decisions → Q-0151; capture → README-indexed; `check_docs --strict` ✓). One pre-existing
+item flagged, **not in scope**: `check_current_state_ledger --strict` shows a 9-PR lag (#944–#954) from
+*other* sessions — owned by the next reconciliation routine at #960 (Q-0124: a manual session does not
+run the recon pass), not this session.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,7 @@ platform concerns the cog simply *uses*.
          ┌──────────────────────────────┴────────────────────────────┐
          │                                                           │
    ┌─────▼─────────────┐    ┌──────────────────────┐    ┌────────────▼────────┐
-   │   cogs/  (×28)    │    │  core/runtime/       │    │   governance/      │
+   │   cogs/           │    │  core/runtime/       │    │   governance/      │
    │  thin dispatchers │◀──▶│  platform primitives │◀──▶│   policy engine    │
    └─────┬─────────────┘    └──────────┬───────────┘    └──────────┬─────────┘
          │                             │                            │
@@ -57,7 +57,7 @@ platform concerns the cog simply *uses*.
                                                     ▼
                                           ┌────────────────────┐
                                           │ PostgreSQL         │
-                                          │ (51 migrations)    │
+                                          │ (migrations)       │
                                           └────────────────────┘
 ```
 

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -20,6 +20,16 @@ during grooming** (it stays listed here, annotated ✅) so the active backlog re
 
 Current broad captures:
 
+- [`architecture-atlas-and-structure-review-2026-06-16.md`](./architecture-atlas-and-structure-review-2026-06-16.md) —
+  **owner-uploaded external review + agent judgment (2026-06-16):** an outside-in repo-architecture
+  review ("repository-architectuuratlas") recommending a generated **architecture atlas** over any
+  filesystem reorg. Cross-checked against live source: the *direction is right* but the drift diagnosis
+  is **overstated** (only 3 real stale counts remained — fixed in PR #957) and the flagship "per-file
+  dashboard" is **~80% already shipped** as `context_map.py`. Genuinely-new signal: an **extension-type
+  taxonomy crosswalk** (43 ext ↔ 32 subsystems; the strongest, missing) → structure into a plan; a
+  *thin* unified atlas + a root-README question → **Q-0151** (discuss); count-cite guard → fold into
+  `readiness-maps-cite-regen-command`. → relates `scripts/{context_map,wiring_map,review_scope}.py` ·
+  `utils/subsystem_registry.py` · `architecture_rules/layers.yaml`.
 - [`round-range-comparison-bare-range-list-2026-06-16.md`](./round-range-comparison-bare-range-list-2026-06-16.md) —
   **session idea (2026-06-16, Q-0089, from the §7.5 round-range comparison floor PR #955):** the new
   round-range cash comparison requires a round token before *each* range's first anchor (to keep

--- a/docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md
+++ b/docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md
@@ -1,0 +1,117 @@
+# Architecture atlas & structure review — capture + agent judgment
+
+> **Status:** `ideas` — capture + evaluation. **Not a plan, not approval.** Source code, the binding
+> contracts, and `docs/current-state.md` win over anything here. Owner-uploaded review (2026-06-16) +
+> the agent's cross-checked verdict. Routing for each derived idea is in § "Routed proposals".
+
+## What this is
+
+The owner uploaded an external repo-architecture review (the *"SuperBot repository-architectuuratlas
+en evidence-based structuurreview"*, Dutch) and asked for **ideas we can use plus a cross-checked
+final judgment** on the document's own recommendations — *"these seem quite good but I'd like your
+final judgement as well."*
+
+The review was produced from a **pinned older commit** (`1ad7ca4…`) and **states openly that it could
+not re-verify the repo live** in its session — it treats its own facts as "confirmed-at-pinned-research
+level," not "re-counted from source." So the right thing to do here is exactly what `.claude/CLAUDE.md`
+demands: **verify its claims against live source before acting.** That verification is below, and it
+changes the picture in a few places.
+
+**Headline verdict.** The review's *direction* is correct and well-argued: SuperBot is a healthy
+modular monolith; the answer is a better **lens** (generated facts, drift checks), **not** a filesystem
+reorganization. But its *current-state diagnosis is overstated*, and its flagship recommendation is
+**~80% already shipped** in this repo. The genuinely additive ideas are narrower than the review frames
+them — and one of its recommendations contradicts an explicit repo decision it didn't know about.
+
+---
+
+## The review in one paragraph
+
+SuperBot = a hybrid modular monolith (vertical feature slices on a shared layered platform). The
+foundation is sound (runtime contracts, subsystem registry, mutation ownership, CI gates, multiple
+navigation maps). The real problem is **visualization/documentation drift** between source, the map
+layers, subsystem folios, and hand-maintained inventories — *not* the physical tree. Recommendation:
+**Option A** (keep the structure; replace hand-copied inventories with one **generated architecture
+atlas** — a provenance-stamped front page that, per file, answers *where it belongs · who owns the
+writes · what it may import · who depends on it · which tests/docs apply · blast radius* — with a
+`--check` CI drift mode), plus a **selective Option B** (fix the few real boundary violations). Reject
+**Option C** (feature-package migration) and **Option D** (big reorg) and a `src/` layout as
+unjustified by the evidence. External backing: C4 (multiple views), arc42, hexagonal (adapters
+outside the core), Fowler monolith-first, Nygard ADRs, Home-Assistant-style integration
+classification.
+
+---
+
+## Cross-check against live source (2026-06-16, commit `5d03b3d`)
+
+| Review claim | Live finding | Verdict |
+|---|---|---|
+| "High drift" in **extension counts** (43 live vs historical 28/36) | **No current doc pins an extension count.** The `28`/`36` figures live only in `docs/audits/repo-wide-audit-2026-05-29.md` — a correctly-badged *dated audit snapshot*, not a live map. | **Overstated** — drift already retired by the anti-drift machinery. |
+| "High drift" in **migration counts** | **Real.** `docs/architecture.md:60` says `(51 migrations)`; live = **74**. | **Confirmed** → fixed in this PR. |
+| "Medium drift" in **workflow inventory** | **Real.** `docs/repo-navigation-map.md:45` implies 1–2 workflow files; live = **6**. `architecture.md:41` also says `cogs/ (×28)`; live = **43**. | **Confirmed** → fixed in this PR. |
+| Build a generated **per-file "maintainer dashboard"** (layer · owner · imports · dependents · tests · docs · blast radius) | **~80% already exists** as `scripts/context_map.py` — it emits exactly: module, layer, review-unit, file role/authority (mutation-owner facts), layer-may-import, module-level **and** lazy imports, imported-by, blast radius, related docs, relevant tests, risk flags, recommended read-set, post-edit checks. EventBus wiring is `scripts/wiring_map.py`; review partition is `scripts/review_scope.py`; per-area packs are `tools/agent_context/`. | **Already shipped** (per file, on demand). The *delta* is real but narrow — see below. |
+| **No extension-type taxonomy / crosswalk** exists | **Confirmed.** 43 extensions vs 32 registered subsystems; the registry (`utils/subsystem_registry.py`) has rich metadata (`visibility_tier`, `category`, `parent_hub`, `hub_group`, `tags`) but **no lifecycle-role field** (bootstrap / maintenance / hub / adapter / lab / specialized-surface). Nothing maps the ~11 non-registry extensions. | **Confirmed + genuinely missing** — strongest idea. |
+| **Boundary debt**: `views→cogs`, `core/runtime→services`, `utils→core/services` | **Accurate**, and already **tracked**: `architecture_rules/layers.yaml` `known_violations` — `arch-fix-13` (≈18 `views/<game\|economy\|xp\|diagnostic>/ → cogs.<x>._helpers/_state`), `arch-fix-11` (≈17 `core/runtime → services`), `arch-fix-6/7/8`. | **Confirmed but not new** — these are ticketed; value = *burn down*, not discover. |
+| Add a minimal **root README** as a pointer | The repo made an **explicit, deliberate decision against one**: *"There is intentionally **no top-level README** — `docs/` is the documentation surface"* (`repo-navigation-map.md:51`). The review didn't know this. | **Contradicts a stated decision** — legitimate to revisit (public-era GitHub landing UX), but **owner-only** → Q-0151. |
+| Reject `src/` layout, Option C, Option D, microservices | Matches this repo's own posture (modular monolith, executable import contracts already in place). | **Endorsed.** |
+
+**Net:** the review is a high-quality outside-in read whose *recommended direction is right*, but it
+(a) over-weights drift that the repo's checkers have already largely eliminated, (b) proposes a
+flagship artifact that mostly exists, and (c) makes one recommendation against an explicit repo
+decision. Its honesty about its own provenance limits is a point in its favor and is why the
+cross-check mattered.
+
+---
+
+## What's genuinely additive (the real signal)
+
+Stripping out what already exists, three ideas survive — in priority order:
+
+### 1. Extension-type taxonomy crosswalk (strongest; genuinely missing)
+Make the **43 extensions ↔ 32 subsystems** mapping legible so the ~11 non-1:1 extensions
+(`bootstrap_access`, `health_maintenance`, `media_maintenance`, `hermes`, `ux_lab`, the multiple
+`btd6_*` surfaces, …) read as *classified*, not as a gap. Concretely: a `role`/`kind` classification
+(product-subsystem · hub/router · shared-platform · maintenance · operational-adapter · bootstrap ·
+specialized-surface · lab), surfaced as a **generated crosswalk table**, plus a **CI guard** that every
+entry in `config.INITIAL_EXTENSIONS` is either a registered subsystem **or** carries an explicit
+declared role — so a new unclassified extension fails CI instead of silently widening the gap. This is
+the one place the review found a true blind spot.
+
+### 2. A *thin* unified atlas — compose, don't duplicate
+The review's real surviving insight: the facts are all generable but **scattered** across
+`context_map` / `wiring_map` / `review_scope` / `command_surface_dump` / `settings_lane_matrix` /
+the agent context packs, with **no single provenance-stamped front page and no repo-wide `--check`
+drift mode**. A thin `scripts/atlas.py` that (a) emits a **repo-wide** file→{layer, review-unit,
+subsystem/role, owner, tests, docs} index by *importing the existing modules as libraries* (never
+re-implementing them), (b) stamps **provenance** (commit SHA, generator version, timestamp), and
+(c) offers `--check` for CI. **Risk:** this overlaps the agent context-pack system and raises real
+owner-policy questions (atlas as the primary entry vs a companion; commit the generated artifacts vs
+CI-only). → **DISCUSS**, not auto-build.
+
+### 3. Count-citation guard (generalizes an existing backlog idea)
+The three drift instances fixed in this PR share one root cause: a **bare integer count hand-typed
+into a binding doc**. The durable fix is the existing backlog idea
+[`readiness-maps-cite-regen-command-2026-06-13.md`](./readiness-maps-cite-regen-command-2026-06-13.md),
+generalized: a soft `check_docs` rule that flags a bare `N migrations` / `N workflows` / `N extensions`
+claim in a binding/living doc unless it cites its regen source or is marked generated. Fold into that
+idea rather than opening a new one.
+
+---
+
+## Routed proposals (idea-lifecycle § ROUTE)
+
+| Proposal | Size / risk | Route |
+|---|---|---|
+| Fix the 3 confirmed drift counts in binding docs | tiny / reversible | **Executed in this PR** (bugs-first; source wins). De-numbered to point at source so they can't re-rot. |
+| **Extension-type taxonomy crosswalk + CI guard** (#1) | medium — touches `subsystem_registry` (a `REGISTRY_SCHEMA_VERSION` bump + validation) and adds a generated artifact + guard | **Structure into a plan** — needs its own `docs/planning/` plan (ownership: registry; reuse: existing metadata seam; mechanics: schema-version bump, validation, generated crosswalk, guard). Not a drive-by. |
+| **Thin unified atlas** `scripts/atlas.py` (#2) | medium — composes existing tools; new generated artifact | **DISCUSS → Q-0151** (overlaps context-pack system; owner-policy decisions attached). |
+| **Count-citation guard** (#3) | small — `check_docs` rule | **Fold into** `readiness-maps-cite-regen-command-2026-06-13.md` (generalize it). Quick-win lane when capacity allows; needs a low-false-positive design (don't flag legit numbers). |
+| Selective boundary-debt burndown (Option B) — start with `arch-fix-13` `views→cogs` (≈18 entries) | medium, scoped, test-covered | **Roadmap candidate** (S1 / shared-platform). Already ticketed; this is execution, not discovery. Each cluster (blackjack, economy, xp, diagnostic) is its own small PR moving `_helpers`/`_state` to `utils/` or a shared module. |
+| Root README pointer | tiny but overrides a stated decision | **DISCUSS → Q-0151** (owner-only — contradicts `repo-navigation-map.md:51`). |
+| Reject `src/` layout / Option C / Option D / microservices | n/a | **Endorse the rejection** — consistent with repo posture; no action. |
+
+## Promotion gates not yet met (per `docs/ideas/README.md`)
+None of #1/#2 are promoted to active work here. #1 needs a plan (ownership ✓ registry; reuse ✓
+metadata seam; risk — low; mechanics — schema bump + guard) before it graduates. #2 needs the Q-0151
+owner answer first. The drift fixes are the only thing executed, and they qualify as bugs-first
+(contained, reversible, source-wins).

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,9 +25,6 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/hopeful-meitner-772pv8` · architecture-atlas / structure-review idea intake (owner-uploaded
-  review) — capture + judgment + route + fix confirmed count-drift in binding docs ·
-  `docs/ideas/` + `docs/architecture.md` + `docs/repo-navigation-map.md` + router Q-0151 · 2026-06-16
 - `claude/epic-noether-qgis28` · BTD6 Live Events — fix the dead event drill-down
   (`build_event_detail_view_model` `TypeError`) + current-event-first overview redesign (show only
   the live event + all its info; history behind 📜 Past events) · `services/btd6_view_model_service.py`
@@ -44,6 +41,10 @@ living ledger (`docs/current-state.md`).
 
 ## Recently cleared
 
+- `claude/hopeful-meitner-772pv8` · architecture-atlas / structure-review idea intake (owner-uploaded
+  review) — capture + judgment + route + fix confirmed count-drift in binding docs · `docs/ideas/` +
+  `docs/architecture.md` + `docs/repo-navigation-map.md` + router Q-0151 · 2026-06-16 ·
+  **PR #957 (open, auto-merge on green)**
 - `claude/coglist-command` · `!coglist` real command → opens the admin "📋 Cog List" `_CogManagerView`
   (owner request; aliases cogs/listcogs/cogslist) · `disbot/cogs/admin_cog.py` + test · 2026-06-16 ·
   **PR #951 (open, auto-merge on green)**

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,9 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/hopeful-meitner-772pv8` · architecture-atlas / structure-review idea intake (owner-uploaded
+  review) — capture + judgment + route + fix confirmed count-drift in binding docs ·
+  `docs/ideas/` + `docs/architecture.md` + `docs/repo-navigation-map.md` + router Q-0151 · 2026-06-16
 - `claude/epic-noether-qgis28` · BTD6 Live Events — fix the dead event drill-down
   (`build_event_detail_view_model` `TypeError`) + current-event-first overview redesign (show only
   the live event + all its info; history behind 📜 Past events) · `services/btd6_view_model_service.py`

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -5666,3 +5666,45 @@ a subdir" habit remains good hygiene regardless.
 
 **Home:** `.claude/settings.json` (`hooks`) + this Q-block; `.session-journal.md` cwd-deadlock entry
 updated to "durable fix applied (Q-0150)".
+
+---
+
+### Q-0151 — Architecture-atlas review: unified atlas? root README? taxonomy enforcement? (2026-06-16)
+
+> **DISCUSS lane — agent-surfaced, NOT applied.** Raised by the owner-uploaded repo-architecture
+> review (captured + cross-checked in
+> [`docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md`](../ideas/architecture-atlas-and-structure-review-2026-06-16.md),
+> PR #957). The review's direction is sound and its bugs-first drift fixes were taken directly; these
+> three are the genuine **owner-policy** calls left over.
+
+**Q-0151a — A thin unified atlas?** The review's flagship "per-file maintainer dashboard" is ~80%
+already shipped (`context_map.py` + `wiring_map.py` + `review_scope.py` + the agent context packs).
+The surviving delta is a **repo-wide, provenance-stamped index** with a single `--check` drift mode,
+built by *composing* the existing scripts (never re-implementing them). If we build it:
+**(i)** is the atlas the **primary** architecture entry point, or a **companion** to
+`AGENT_ORIENTATION.md` (which stays the human/agent reading-order router)? **(ii)** do we **commit**
+the generated Markdown/JSON to git, or keep it **CI-artifact-only**?
+*Agent recommendation:* build it thin, as a **companion** (not a replacement — orientation is curated
+intent, the atlas is generated facts), **CI-`--check` + on-demand generate**, do **not** commit the
+generated body (commit only the generator + a provenance header), to avoid a new drift surface. It
+overlaps the context-pack system, so confirm before building.
+
+**Q-0151b — Revisit the "no root README" decision?** The review recommends a minimal root README
+pointer. The repo made an **explicit decision against one** (`repo-navigation-map.md:51` — *"There is
+intentionally no top-level README — docs/ is the documentation surface"*). Now that the repo is
+public-era, a tiny GitHub-landing pointer (→ `AGENT_ORIENTATION.md` + `current-state.md`) may be worth
+it. *Agent recommendation:* add a **5-line pointer-only** README (no content duplication) **iff** the
+owner wants a public landing page; otherwise keep the deliberate no-README posture. Owner's call —
+it overrides a stated decision.
+
+**Q-0151c — How far to enforce extension classification?** The strongest finding: no taxonomy maps the
+43 extensions ↔ 32 subsystems (the ~11 non-1:1 are unclassified). Should classification cover **only
+the ~11 non-subsystem extensions**, or **all 43**? And should the `role` be **advisory metadata** or a
+**CI-enforced** guard (a new `INITIAL_EXTENSIONS` entry must declare a role or be a registered
+subsystem)? *Agent recommendation:* classify **all 43** (cheap, and partial taxonomies rot), role as a
+registry field, **CI-enforced** so the gap can't silently re-grow — but this is a
+`REGISTRY_SCHEMA_VERSION` bump, so it ships via its **own plan**, not a drive-by.
+
+**Home when answered:** a `docs/planning/` plan for the taxonomy (Q-0151c) + atlas (Q-0151a) if
+approved; the README decision (Q-0151b) records here + `repo-navigation-map.md`. The capture doc holds
+the full evidence and routing table.

--- a/docs/repo-navigation-map.md
+++ b/docs/repo-navigation-map.md
@@ -42,7 +42,7 @@ superbot/
 ├── .claude/                 # Claude Code config (CLAUDE.md, settings.json)
 │   └── rules/               # path-scoped Claude instruction files
 ├── .codegraph/              # CodeGraph index (built artifact; not in git)
-├── .github/workflows/       # CI (code-quality.yml + ai-evals.yml)
+├── .github/workflows/       # CI workflows (see .github/workflows/)
 ├── pyproject.toml           # black, isort, ruff, mypy, pytest config
 ├── requirements.txt         # runtime deps
 └── Procfile                 # process declaration (deployment)


### PR DESCRIPTION
## What

The owner uploaded an external repo-architecture review (the "SuperBot repository-architectuuratlas")
and asked for **ideas we can use + a cross-checked final judgment** on the document's own
recommendations. This PR is that response, handled through the repo's idea-intake lifecycle.

**Born red** per Q-0133 — flips to `complete` as the final step.

## Deliverables

1. **Capture + judgment doc** — `docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md`:
   the review's claims verified against live source (it was pinned to an older commit and could not
   re-verify live), with a confirmed / overstated / already-exists / genuinely-new verdict per claim,
   plus the routed proposals. README index updated.
2. **Bugs-first drift fixes** (source wins over docs) — three confirmed stale counts in **binding**
   docs, de-numbered to point at the source of truth so they cannot re-rot:
   - `docs/architecture.md` — `cogs/ (×28)` → live 43; `(51 migrations)` → live 74.
   - `docs/repo-navigation-map.md` — workflow line → live 6.
3. **Routing** — extension-taxonomy crosswalk + unified-atlas composer + a count-cite guard, each sent
   to one home; one router block (**Q-0151**) for the genuine owner decisions the review surfaced
   (atlas-as-primary vs companion; the "add a root README" idea, which contradicts an *explicit*
   repo decision; how far to enforce extension classification).

## Verification
- `python3.10 scripts/check_docs.py --strict` (reachability)
- `python3.10 scripts/check_quality.py --check-only`

Docs only; no `disbot/` runtime code.

https://claude.ai/code/session_017kiQvtYDdewQNK8ibqwQSf

---
_Generated by [Claude Code](https://claude.ai/code/session_017kiQvtYDdewQNK8ibqwQSf)_