### PR TITLE
tooling: extension-type taxonomy crosswalk + CI guard (Q-0151c)

### DIFF
--- a/.sessions/2026-06-16-extension-taxonomy-crosswalk.md
+++ b/.sessions/2026-06-16-extension-taxonomy-crosswalk.md
@@ -1,0 +1,30 @@
+# Session — extension-taxonomy crosswalk (Q-0151c, owner-approved)
+
+> **Status:** `in-progress` — born-red per Q-0133; flips to `complete` as the final step.
+> **Date:** 2026-06-16 · **Branch:** `claude/hopeful-meitner-772pv8`
+
+## What I'm about to do
+
+Follow-on to PR #957 (architecture-atlas review). The owner **approved my Q-0151 recommendations**:
+build the extension-taxonomy crosswalk CI-enforced; thin atlas as a companion (sequenced); README
+optional. Scope chosen with the owner: **crosswalk now, plan the atlas**; overlay in
+`architecture_rules/` + a CI guard (not a registry schema bump).
+
+Plan:
+1. `architecture_rules/extension_roles.yaml` — curated editorial overlay classifying **all 43**
+   extensions by role (product / hub / shared-platform / maintenance / adapter / bootstrap /
+   specialized-surface / lab) + the backing subsystem for the 10 non-1:1 ones.
+2. `scripts/extension_crosswalk.py` — read-only generator (AST-parses `config.INITIAL_EXTENSIONS` +
+   `subsystem_registry.SUBSYSTEMS`, joins the overlay), `--write` regenerates the doc, `--check`
+   enforces (every extension classified · overlay↔source consistency · doc not stale).
+3. `docs/extension-taxonomy-crosswalk.md` — generated, committed, NOT-SOURCE-OF-TRUTH + provenance.
+4. `tests/unit/scripts/test_extension_crosswalk.py` — pins the `--check` invariants (this is the CI
+   enforcement seam — rides the existing suite, no workflow edit).
+5. `docs/planning/extension-taxonomy-crosswalk-plan-2026-06-16.md` — the plan (crosswalk done + atlas
+   sequenced as PR 2, with the overlay-over-registry rationale + the now-answered Q-0151).
+6. Housekeeping: record the owner's Q-0151 answer; fix my own **32→33 / ~11→10** count error in the
+   #957 capture doc + README (the exact count-drift class this work exists to kill); roadmap horizon.
+
+Verified live: **43** extensions · **33** subsystem keys · **exactly 10** non-1:1.
+
+(Close-out enders added before the flip.)

--- a/.sessions/2026-06-16-extension-taxonomy-crosswalk.md
+++ b/.sessions/2026-06-16-extension-taxonomy-crosswalk.md
@@ -1,9 +1,37 @@
 # Session — extension-taxonomy crosswalk (Q-0151c, owner-approved)
 
-> **Status:** `in-progress` — born-red per Q-0133; flips to `complete` as the final step.
-> **Date:** 2026-06-16 · **Branch:** `claude/hopeful-meitner-772pv8`
+> **Status:** `complete` — shipped; PR #958 ready, auto-merge on green.
+> **Date:** 2026-06-16 · **Branch:** `claude/hopeful-meitner-772pv8` · **PR:** #958
 
-## What I'm about to do
+## What I did
+
+Built the extension-type taxonomy crosswalk (the strongest idea from the #957 architecture-atlas
+review), CI-enforced via a curated overlay + guard (owner-approved Q-0151c — overlay, **not** a
+registry schema bump). Live-verified counts: **43** extensions · **33** subsystems · **10** non-1:1.
+
+- `architecture_rules/extension_roles.yaml` — all 43 classified into 8 roles.
+- `scripts/extension_crosswalk.py` — AST generator (`--write`/`--check`/preview); no imports/env.
+- `docs/architecture/extension-taxonomy-crosswalk.md` — generated, committed (`NOT SOURCE OF TRUTH`).
+- `tests/unit/scripts/test_extension_crosswalk.py` — the CI enforcement seam (5 tests) + proves the
+  guard catches an unclassified extension / bad `backs`.
+- `docs/planning/extension-taxonomy-crosswalk-plan-2026-06-16.md` — plan; sequences the thin atlas (PR 2).
+- Recorded the owner's **Q-0151** answer; **fixed my own 32→33 / ~11→10 count error** in the #957
+  capture doc + README + Q-0151c; roadmap S4 entry.
+
+Verified: `check_quality --full` (10032 passed) · `extension_crosswalk --check` ✓ · `check_docs --strict` ✓.
+
+## Context delta (for the next session)
+- The crosswalk + its `role`/`backs` data is the **dependency for the thin atlas (PR 2, Q-0151a)** —
+  build that by *composing* `context_map`/`wiring_map`/`review_scope` + this overlay, CI-`--check`,
+  body not committed.
+- Generated docs go in a **subdir** (`docs/architecture/`), not top-level `docs/` — the top-level
+  ratchet (`check_docs`) reserves that pile for true nav docs (hit this live this session).
+
+## What I was about to do
+
+(superseded by "What I did" above — kept for the born-red audit trail)
+
+## Plan (executed)
 
 Follow-on to PR #957 (architecture-atlas review). The owner **approved my Q-0151 recommendations**:
 build the extension-taxonomy crosswalk CI-enforced; thin atlas as a companion (sequenced); README
@@ -27,4 +55,32 @@ Plan:
 
 Verified live: **43** extensions · **33** subsystem keys · **exactly 10** non-1:1.
 
-(Close-out enders added before the flip.)
+## Session enders
+
+**Grooming (Q-0015).** This session *executed* the #1 routed idea from PR #957 (taxonomy crosswalk:
+captured/routed → shipped) and sequenced the thin atlas (PR 2) onto roadmap S4 Next. Backlog moved
+forward, not just browsed.
+
+**💡 Session idea (Q-0089).** Surface the new `role`/`backs` data **inside `context_map.py`'s per-file
+output** — when an agent maps a cog file before editing, show its extension role + backing subsystem
+from `architecture_rules/extension_roles.yaml`. That makes the taxonomy *load-bearing* (consumed by the
+tool agents actually run pre-edit) instead of a static doc, and is a concrete down-payment on the
+atlas (PR 2), since `context_map` is one of its composers. Dedup: the atlas plan mentions composing
+`context_map`, but surfacing `role` *in* its output is a smaller, independent enhancement worth doing
+even if the atlas slips. Small; record-only here.
+
+**⟲ Previous-session review (Q-0102).** Reviewing my own PR #957 (the architecture-atlas capture): the
+cross-checking discipline was the right call — it verified the review against source rather than
+echoing it and caught the root-README contradiction. **But it shipped a count error** ("32 subsystems
+/ ~11 non-1:1"; live is 33/10) — ironic in a PR *about* count-drift. Root cause: I trusted a
+sub-agent's numeric tally without re-deriving it from source before writing it into a doc. *System
+improvement (applied this session):* a sub-agent's count is unverified tool output (Q-0105 tier) —
+derive a number from source in-session before pinning it, **or** don't pin a raw number. This
+session's crosswalk is the durable fix: the count is now generated and self-correcting, and the stale
+"32" is corrected at every home.
+
+**Doc audit (Q-0104).** All this session's outputs are in durable homes and reachable
+(`check_docs --strict` ✓): crosswalk doc + overlay + script + test + plan; Q-0151 answer recorded;
+the count error fixed in the capture doc, README, and Q-0151c; roadmap S4 updated. Unchanged
+pre-existing item (not in scope, per Q-0124): the recently-merged-PR ledger lag is owned by the
+auto-reconciliation routine at #960, not a manual session.

--- a/architecture_rules/extension_roles.yaml
+++ b/architecture_rules/extension_roles.yaml
@@ -1,0 +1,193 @@
+# Extension role overlay — the curated editorial classification of every loaded
+# Discord extension (cog) in disbot/config.py::INITIAL_EXTENSIONS.
+#
+# WHY THIS FILE EXISTS (Q-0151c, owner-approved 2026-06-16; born from the
+# architecture-atlas review — docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md):
+# SuperBot loads 43 extensions but the subsystem registry has 33 identities. The
+# 10 extensions with no 1:1 registry key (bootstrap, maintenance loops, the BTD6
+# sub-surfaces, the Hermes adapter) are NOT a gap — they are a *classification*
+# that lived nowhere. This overlay is that classification, kept as editorial data
+# *outside* the runtime registry on purpose: a role like "bootstrap" / "adapter"
+# is a human review label, not runtime metadata, so it must not bloat the
+# deep-frozen registry. `scripts/extension_crosswalk.py` joins this with the live
+# manifest + registry to emit docs/extension-taxonomy-crosswalk.md and to enforce
+# (via --check / the test) that **every** extension is classified — so the gap can
+# never silently re-grow.
+#
+# RELIABILITY / PROVENANCE (Q-0105): added 2026-06-16. The *source* facts
+# (which extensions exist, which subsystems are registered) are derived live by
+# the generator and are self-correcting; only the `role` + `note` columns here are
+# editorial and may need an owner tweak. This overlay + its generator are
+# disposable convenience tooling — if it proves more nuisance than help across a
+# few sessions, delete the file, the script, and the test together; nothing in the
+# bot runtime depends on it.
+#
+# HOW TO EDIT: change a role/note/backs here, then run
+#   python3.10 scripts/extension_crosswalk.py --write
+# and commit both this file and the regenerated doc. A new extension added to
+# INITIAL_EXTENSIONS with no entry here fails `--check` (and the test) until
+# classified.
+
+# The role vocabulary. Each extension below must use exactly one of these keys.
+roles:
+  product_subsystem:
+    description: A feature vertical with its own owner, views, and tests.
+  hub:
+    description: A routing/composition layer that surfaces other subsystems; owns
+      little or no domain state of its own.
+  shared_platform:
+    description: A broad cross-cutting capability with high blast radius (admin,
+      settings, AI, diagnostics, help, utility).
+  maintenance:
+    description: A background-loop cog (scheduled work) with no subsystem identity;
+      runtime/ops, not a product surface.
+  operational_adapter:
+    description: A bridge to a control plane or external operation (not an in-guild
+      product feature).
+  bootstrap:
+    description: Load-order / lifecycle-critical admission or setup; sensitive to
+      INITIAL_EXTENSIONS ordering.
+  specialized_surface:
+    description: One of several surfaces within a single domain vertical (e.g. the
+      BTD6 sub-cogs) — backs a registered subsystem rather than being its own.
+  lab:
+    description: A development / UX laboratory surface; not a production product
+      surface.
+
+# Every extension in INITIAL_EXTENSIONS, keyed by its short name
+# (module "cogs.<name>_cog" -> "<name>"). `backs` names the registered subsystem
+# this surface belongs to when the extension is NOT itself a 1:1 registry key
+# (omit/empty otherwise). `note` is a one-line human label.
+extensions:
+  bootstrap_access:
+    role: bootstrap
+    note: Installs the prefix+slash command-access guard; MUST load first. Platform
+      admission, not a product subsystem.
+  admin:
+    role: shared_platform
+    note: Cog management, server stats, diagnostics entry; administrator floor.
+  help:
+    role: shared_platform
+    note: Help catalogue/projection surface; every subsystem's Help route composes it.
+  role:
+    role: product_subsystem
+  moderation:
+    role: product_subsystem
+  automod:
+    role: product_subsystem
+    note: Automod rules engine (Q-0108).
+  xp:
+    role: product_subsystem
+  blackjack:
+    role: product_subsystem
+    note: Game.
+  rps_tournament:
+    role: product_subsystem
+    note: Game (tournament orchestration).
+  utility:
+    role: shared_platform
+    note: General utility commands.
+  cleanup:
+    role: product_subsystem
+    note: Message-cleanup policy.
+  channel:
+    role: product_subsystem
+    note: Channel management (server-management area).
+  inventory:
+    role: product_subsystem
+  economy:
+    role: product_subsystem
+  counting:
+    role: product_subsystem
+    note: Counting game.
+  deathmatch:
+    role: product_subsystem
+    note: Game (1v1 duels).
+  proof_channel:
+    role: product_subsystem
+  mining:
+    role: product_subsystem
+    note: Mining character platform (large vertical).
+  diagnostic:
+    role: shared_platform
+    note: "`!platform` diagnostics; broad cross-subsystem read-model surface."
+  health_maintenance:
+    role: maintenance
+    backs: diagnostic
+    note: Scheduled health-findings retention loop; no subsystem identity.
+  ai:
+    role: shared_platform
+    note: AI orchestration / answerability; cross-cutting.
+  media_maintenance:
+    role: maintenance
+    note: Scheduled media/YouTube cache purge loop; no subsystem identity.
+  btd6:
+    role: product_subsystem
+    note: BTD6 core data / answerability vertical.
+  btd6_reference:
+    role: specialized_surface
+    backs: btd6
+    note: BTD6 reference lookups.
+  btd6_events:
+    role: specialized_surface
+    backs: btd6
+    note: BTD6 live-events surface.
+  btd6_strategy:
+    role: specialized_surface
+    backs: btd6
+  paragon:
+    role: specialized_surface
+    backs: btd6
+    note: BTD6 paragon grounding surface.
+  btd6_ops:
+    role: specialized_surface
+    backs: btd6
+    note: BTD6 data-ops (seed/refresh); operational flavor within the BTD6 vertical.
+  chain:
+    role: product_subsystem
+    note: Command-chain subsystem.
+  general:
+    role: product_subsystem
+    note: General-content commands.
+  four_twenty:
+    role: product_subsystem
+    note: Novelty / community feature.
+  leaderboard:
+    role: product_subsystem
+    note: Cross-subsystem leaderboards (reads XP/games).
+  settings:
+    role: shared_platform
+    note: Settings hub; cross-cutting config surface.
+  logging:
+    role: product_subsystem
+    note: Server-logging subsystem.
+  games:
+    role: hub
+    note: Games hub (routes blackjack/deathmatch/counting/rps).
+  community:
+    role: hub
+    note: Community hub.
+  community_spotlight:
+    role: product_subsystem
+    note: Community Spotlight (community-hub child; registered subsystem).
+  welcome:
+    role: product_subsystem
+    note: Welcome service (join embeds + optional PIL cards).
+  counters:
+    role: product_subsystem
+    note: Dynamic server counters.
+  setup:
+    role: bootstrap
+    backs: server_management
+    note: Guided setup wizard; lifecycle-critical, load-order sensitive.
+  server_management:
+    role: hub
+    note: Routing-only hub (moderation/channels/roles/cleanup/setup); holds no
+      capability of its own.
+  hermes:
+    role: operational_adapter
+    note: Bridge to the Hermes control plane / external operation.
+  ux_lab:
+    role: lab
+    note: Zero-write UX pattern gallery (admin-gated); design vocabulary, not a
+      product surface.

--- a/docs/architecture/extension-taxonomy-crosswalk.md
+++ b/docs/architecture/extension-taxonomy-crosswalk.md
@@ -1,0 +1,86 @@
+# Extension-type taxonomy crosswalk
+
+> **Status:** `living-ledger` — **GENERATED — NOT SOURCE OF TRUTH.** Do not edit by hand.
+> Regenerate with `python3.10 scripts/extension_crosswalk.py --write` after editing
+> `architecture_rules/extension_roles.yaml`. Sources: `disbot/config.py` (`INITIAL_EXTENSIONS`),
+> `disbot/utils/subsystem_registry.py` (`SUBSYSTEMS`), and that overlay. `--check` guards staleness.
+
+_Generator:_ `scripts/extension_crosswalk.py` `v1`  ·  **43** extensions  ·  **33** registered subsystems  ·  **10** non-1:1 extensions.
+
+Every loaded extension classified by **role** (editorial — in `architecture_rules/extension_roles.yaml`) and joined to the registry. A ✓ in *Registered* means the extension is a 1:1 subsystem identity; the non-1:1 rows are surfaces/maintenance/adapters that **back** a subsystem or the platform.
+
+## Roles
+
+| Role | Count | Meaning |
+|---|---:|---|
+| `bootstrap` | 2 | Load-order / lifecycle-critical admission or setup; sensitive to INITIAL_EXTENSIONS ordering. |
+| `hub` | 3 | A routing/composition layer that surfaces other subsystems; owns little or no domain state of its own. |
+| `lab` | 1 | A development / UX laboratory surface; not a production product surface. |
+| `maintenance` | 2 | A background-loop cog (scheduled work) with no subsystem identity; runtime/ops, not a product surface. |
+| `operational_adapter` | 1 | A bridge to a control plane or external operation (not an in-guild product feature). |
+| `product_subsystem` | 23 | A feature vertical with its own owner, views, and tests. |
+| `shared_platform` | 6 | A broad cross-cutting capability with high blast radius (admin, settings, AI, diagnostics, help, utility). |
+| `specialized_surface` | 5 | One of several surfaces within a single domain vertical (e.g. the BTD6 sub-cogs) — backs a registered subsystem rather than being its own. |
+
+## Crosswalk (load order)
+
+| # | Extension | Role | Registered | Backs | Note |
+|---:|---|---|:--:|---|---|
+| 1 | `bootstrap_access` | `bootstrap` | — |  | Installs the prefix+slash command-access guard; MUST load first. Platform admission, not a product subsystem. |
+| 2 | `admin` | `shared_platform` | ✓ |  | Cog management, server stats, diagnostics entry; administrator floor. |
+| 3 | `help` | `shared_platform` | ✓ |  | Help catalogue/projection surface; every subsystem's Help route composes it. |
+| 4 | `role` | `product_subsystem` | ✓ |  |  |
+| 5 | `moderation` | `product_subsystem` | ✓ |  |  |
+| 6 | `automod` | `product_subsystem` | ✓ |  | Automod rules engine (Q-0108). |
+| 7 | `xp` | `product_subsystem` | ✓ |  |  |
+| 8 | `blackjack` | `product_subsystem` | ✓ |  | Game. |
+| 9 | `rps_tournament` | `product_subsystem` | ✓ |  | Game (tournament orchestration). |
+| 10 | `utility` | `shared_platform` | ✓ |  | General utility commands. |
+| 11 | `cleanup` | `product_subsystem` | ✓ |  | Message-cleanup policy. |
+| 12 | `channel` | `product_subsystem` | ✓ |  | Channel management (server-management area). |
+| 13 | `inventory` | `product_subsystem` | ✓ |  |  |
+| 14 | `economy` | `product_subsystem` | ✓ |  |  |
+| 15 | `counting` | `product_subsystem` | ✓ |  | Counting game. |
+| 16 | `deathmatch` | `product_subsystem` | ✓ |  | Game (1v1 duels). |
+| 17 | `proof_channel` | `product_subsystem` | ✓ |  |  |
+| 18 | `mining` | `product_subsystem` | ✓ |  | Mining character platform (large vertical). |
+| 19 | `diagnostic` | `shared_platform` | ✓ |  | `!platform` diagnostics; broad cross-subsystem read-model surface. |
+| 20 | `health_maintenance` | `maintenance` | — | `diagnostic` | Scheduled health-findings retention loop; no subsystem identity. |
+| 21 | `ai` | `shared_platform` | ✓ |  | AI orchestration / answerability; cross-cutting. |
+| 22 | `media_maintenance` | `maintenance` | — |  | Scheduled media/YouTube cache purge loop; no subsystem identity. |
+| 23 | `btd6` | `product_subsystem` | ✓ |  | BTD6 core data / answerability vertical. |
+| 24 | `btd6_reference` | `specialized_surface` | — | `btd6` | BTD6 reference lookups. |
+| 25 | `btd6_events` | `specialized_surface` | — | `btd6` | BTD6 live-events surface. |
+| 26 | `btd6_strategy` | `specialized_surface` | — | `btd6` |  |
+| 27 | `paragon` | `specialized_surface` | — | `btd6` | BTD6 paragon grounding surface. |
+| 28 | `btd6_ops` | `specialized_surface` | — | `btd6` | BTD6 data-ops (seed/refresh); operational flavor within the BTD6 vertical. |
+| 29 | `chain` | `product_subsystem` | ✓ |  | Command-chain subsystem. |
+| 30 | `general` | `product_subsystem` | ✓ |  | General-content commands. |
+| 31 | `four_twenty` | `product_subsystem` | ✓ |  | Novelty / community feature. |
+| 32 | `leaderboard` | `product_subsystem` | ✓ |  | Cross-subsystem leaderboards (reads XP/games). |
+| 33 | `settings` | `shared_platform` | ✓ |  | Settings hub; cross-cutting config surface. |
+| 34 | `logging` | `product_subsystem` | ✓ |  | Server-logging subsystem. |
+| 35 | `games` | `hub` | ✓ |  | Games hub (routes blackjack/deathmatch/counting/rps). |
+| 36 | `community` | `hub` | ✓ |  | Community hub. |
+| 37 | `community_spotlight` | `product_subsystem` | ✓ |  | Community Spotlight (community-hub child; registered subsystem). |
+| 38 | `welcome` | `product_subsystem` | ✓ |  | Welcome service (join embeds + optional PIL cards). |
+| 39 | `counters` | `product_subsystem` | ✓ |  | Dynamic server counters. |
+| 40 | `setup` | `bootstrap` | — | `server_management` | Guided setup wizard; lifecycle-critical, load-order sensitive. |
+| 41 | `server_management` | `hub` | ✓ |  | Routing-only hub (moderation/channels/roles/cleanup/setup); holds no capability of its own. |
+| 42 | `hermes` | `operational_adapter` | — |  | Bridge to the Hermes control plane / external operation. |
+| 43 | `ux_lab` | `lab` | ✓ |  | Zero-write UX pattern gallery (admin-gated); design vocabulary, not a product surface. |
+
+## Non-1:1 extensions (no registry identity)
+
+These load as extensions but are **not** registered subsystems — they are classified by role instead of being product verticals:
+
+- `bootstrap_access` (`bootstrap`) — Installs the prefix+slash command-access guard; MUST load first. Platform admission, not a product subsystem.
+- `health_maintenance` (`maintenance` → backs `diagnostic`) — Scheduled health-findings retention loop; no subsystem identity.
+- `media_maintenance` (`maintenance`) — Scheduled media/YouTube cache purge loop; no subsystem identity.
+- `btd6_reference` (`specialized_surface` → backs `btd6`) — BTD6 reference lookups.
+- `btd6_events` (`specialized_surface` → backs `btd6`) — BTD6 live-events surface.
+- `btd6_strategy` (`specialized_surface` → backs `btd6`)
+- `paragon` (`specialized_surface` → backs `btd6`) — BTD6 paragon grounding surface.
+- `btd6_ops` (`specialized_surface` → backs `btd6`) — BTD6 data-ops (seed/refresh); operational flavor within the BTD6 vertical.
+- `setup` (`bootstrap` → backs `server_management`) — Guided setup wizard; lifecycle-critical, load-order sensitive.
+- `hermes` (`operational_adapter`) — Bridge to the Hermes control plane / external operation.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -26,8 +26,10 @@ Current broad captures:
   filesystem reorg. Cross-checked against live source: the *direction is right* but the drift diagnosis
   is **overstated** (only 3 real stale counts remained — fixed in PR #957) and the flagship "per-file
   dashboard" is **~80% already shipped** as `context_map.py`. Genuinely-new signal: an **extension-type
-  taxonomy crosswalk** (43 ext ↔ 32 subsystems; the strongest, missing) → structure into a plan; a
-  *thin* unified atlas + a root-README question → **Q-0151** (discuss); count-cite guard → fold into
+  taxonomy crosswalk** (43 ext ↔ 33 subsystems, 10 non-1:1) → **✅ SHIPPED PR #958** (overlay +
+  `scripts/extension_crosswalk.py` → `docs/architecture/extension-taxonomy-crosswalk.md`,
+  [plan](../planning/extension-taxonomy-crosswalk-plan-2026-06-16.md)); a *thin* unified atlas (→ PR 2)
+  + a root-README question → **Q-0151** (answered); count-cite guard → fold into
   `readiness-maps-cite-regen-command`. → relates `scripts/{context_map,wiring_map,review_scope}.py` ·
   `utils/subsystem_registry.py` · `architecture_rules/layers.yaml`.
 - [`round-range-comparison-bare-range-list-2026-06-16.md`](./round-range-comparison-bare-range-list-2026-06-16.md) —

--- a/docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md
+++ b/docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md
@@ -50,7 +50,7 @@ classification.
 | "High drift" in **migration counts** | **Real.** `docs/architecture.md:60` says `(51 migrations)`; live = **74**. | **Confirmed** → fixed in this PR. |
 | "Medium drift" in **workflow inventory** | **Real.** `docs/repo-navigation-map.md:45` implies 1–2 workflow files; live = **6**. `architecture.md:41` also says `cogs/ (×28)`; live = **43**. | **Confirmed** → fixed in this PR. |
 | Build a generated **per-file "maintainer dashboard"** (layer · owner · imports · dependents · tests · docs · blast radius) | **~80% already exists** as `scripts/context_map.py` — it emits exactly: module, layer, review-unit, file role/authority (mutation-owner facts), layer-may-import, module-level **and** lazy imports, imported-by, blast radius, related docs, relevant tests, risk flags, recommended read-set, post-edit checks. EventBus wiring is `scripts/wiring_map.py`; review partition is `scripts/review_scope.py`; per-area packs are `tools/agent_context/`. | **Already shipped** (per file, on demand). The *delta* is real but narrow — see below. |
-| **No extension-type taxonomy / crosswalk** exists | **Confirmed.** 43 extensions vs 32 registered subsystems; the registry (`utils/subsystem_registry.py`) has rich metadata (`visibility_tier`, `category`, `parent_hub`, `hub_group`, `tags`) but **no lifecycle-role field** (bootstrap / maintenance / hub / adapter / lab / specialized-surface). Nothing maps the ~11 non-registry extensions. | **Confirmed + genuinely missing** — strongest idea. |
+| **No extension-type taxonomy / crosswalk** exists | **Confirmed.** 43 extensions vs **33** registered subsystems; the registry (`utils/subsystem_registry.py`) has rich metadata (`visibility_tier`, `category`, `parent_hub`, `hub_group`, `tags`) but **no lifecycle-role field** (bootstrap / maintenance / hub / adapter / lab / specialized-surface). Nothing maps the **10** non-registry extensions. | **Confirmed + genuinely missing** — strongest idea (now shipped, PR #958). |
 | **Boundary debt**: `views→cogs`, `core/runtime→services`, `utils→core/services` | **Accurate**, and already **tracked**: `architecture_rules/layers.yaml` `known_violations` — `arch-fix-13` (≈18 `views/<game\|economy\|xp\|diagnostic>/ → cogs.<x>._helpers/_state`), `arch-fix-11` (≈17 `core/runtime → services`), `arch-fix-6/7/8`. | **Confirmed but not new** — these are ticketed; value = *burn down*, not discover. |
 | Add a minimal **root README** as a pointer | The repo made an **explicit, deliberate decision against one**: *"There is intentionally **no top-level README** — `docs/` is the documentation surface"* (`repo-navigation-map.md:51`). The review didn't know this. | **Contradicts a stated decision** — legitimate to revisit (public-era GitHub landing UX), but **owner-only** → Q-0151. |
 | Reject `src/` layout, Option C, Option D, microservices | Matches this repo's own posture (modular monolith, executable import contracts already in place). | **Endorsed.** |
@@ -67,15 +67,20 @@ cross-check mattered.
 
 Stripping out what already exists, three ideas survive — in priority order:
 
-### 1. Extension-type taxonomy crosswalk (strongest; genuinely missing)
-Make the **43 extensions ↔ 32 subsystems** mapping legible so the ~11 non-1:1 extensions
-(`bootstrap_access`, `health_maintenance`, `media_maintenance`, `hermes`, `ux_lab`, the multiple
-`btd6_*` surfaces, …) read as *classified*, not as a gap. Concretely: a `role`/`kind` classification
-(product-subsystem · hub/router · shared-platform · maintenance · operational-adapter · bootstrap ·
-specialized-surface · lab), surfaced as a **generated crosswalk table**, plus a **CI guard** that every
-entry in `config.INITIAL_EXTENSIONS` is either a registered subsystem **or** carries an explicit
-declared role — so a new unclassified extension fails CI instead of silently widening the gap. This is
-the one place the review found a true blind spot.
+### 1. Extension-type taxonomy crosswalk (strongest; genuinely missing) — ✅ APPROVED + SHIPPED (PR #958)
+Make the **43 extensions ↔ 33 subsystems** mapping legible so the **10** non-1:1 extensions
+(`bootstrap_access`, the two `*_maintenance` cogs, the five `btd6_*`/`paragon` surfaces, `setup`,
+`hermes`) read as *classified*, not as a gap. A `role` classification (product-subsystem · hub/router ·
+shared-platform · maintenance · operational-adapter · bootstrap · specialized-surface · lab), surfaced
+as a **generated crosswalk table**, plus a **CI guard** that every entry in `config.INITIAL_EXTENSIONS`
+is classified — so a new unclassified extension fails CI instead of silently widening the gap. This is
+the one place the review found a true blind spot. **Built (Q-0151c, owner-approved) as a curated overlay
+`architecture_rules/extension_roles.yaml` + `scripts/extension_crosswalk.py` →
+[`docs/architecture/extension-taxonomy-crosswalk.md`](../architecture/extension-taxonomy-crosswalk.md), enforced by
+`tests/unit/scripts/test_extension_crosswalk.py`** — see
+[the plan](../planning/extension-taxonomy-crosswalk-plan-2026-06-16.md).
+*(Count-correction: the live registry has **33** identities, not the 32 first written here — fixed
+2026-06-16; the crosswalk is now the self-correcting source.)*
 
 ### 2. A *thin* unified atlas — compose, don't duplicate
 The review's real surviving insight: the facts are all generable but **scattered** across

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,9 +25,6 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/hopeful-meitner-772pv8` · extension-taxonomy crosswalk (Q-0151c, owner-approved) — curated
-  role overlay + generator + generated doc + CI guard + tests + plan · `architecture_rules/` +
-  `scripts/` + `docs/` + `tests/unit/scripts/` · 2026-06-16
 - `claude/upbeat-einstein-7rz9z0` · act on the 2026-06-16 autonomous-run review + owner answers —
   run-report footer · ledger guard-exemption + drift line · bug-fix-guard convention · auto-deploy
   misinformation fix · Q-0147 DM gate · Q-0085/0120/0121/0127 records · ledger tidy · 2026-06-16
@@ -41,6 +38,7 @@ living ledger (`docs/current-state.md`).
 > Trimmed 2026-06-16 (Q-0152): stale claims whose PRs merged are dropped — the durable record is the
 > PR + the `current-state.md` ledger. Keep this to the most recent handful, newest-first.
 
+- `claude/hopeful-meitner-772pv8` · extension-taxonomy crosswalk (Q-0151c) — overlay + generator + CI guard + plan · 2026-06-16 · **PR #958 (auto-merge on green)**
 - `claude/hopeful-meitner-772pv8` · architecture-atlas / structure-review idea intake (owner-uploaded review) · router Q-0151 · 2026-06-16 · **PR #957 (merged)**
 
 - `claude/coglist-command` · `!coglist` real command → admin "📋 Cog List" view · 2026-06-16 · **PR #951 (merged)**

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,9 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/hopeful-meitner-772pv8` · extension-taxonomy crosswalk (Q-0151c, owner-approved) — curated
+  role overlay + generator + generated doc + CI guard + tests + plan · `architecture_rules/` +
+  `scripts/` + `docs/` + `tests/unit/scripts/` · 2026-06-16
 - `claude/upbeat-einstein-7rz9z0` · act on the 2026-06-16 autonomous-run review + owner answers —
   run-report footer · ledger guard-exemption + drift line · bug-fix-guard convention · auto-deploy
   misinformation fix · Q-0147 DM gate · Q-0085/0120/0121/0127 records · ledger tidy · 2026-06-16

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -5694,11 +5694,22 @@ updated to "durable fix applied (Q-0150)".
 
 ### Q-0151 — Architecture-atlas review: unified atlas? root README? taxonomy enforcement? (2026-06-16)
 
-> **DISCUSS lane — agent-surfaced, NOT applied.** Raised by the owner-uploaded repo-architecture
-> review (captured + cross-checked in
+> **ANSWERED 2026-06-16 — owner accepted the agent recommendations.** Owner: *"yes I agree with your
+> recommendations, and the readme is not required but not off limits."* Raised by the owner-uploaded
+> repo-architecture review (captured + cross-checked in
 > [`docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md`](../ideas/architecture-atlas-and-structure-review-2026-06-16.md),
-> PR #957). The review's direction is sound and its bugs-first drift fixes were taken directly; these
-> three are the genuine **owner-policy** calls left over.
+> PR #957). Resolution:
+> - **a (atlas):** build it thin, as a **companion** to `AGENT_ORIENTATION.md`, **CI-`--check` +
+>   on-demand generate, body not committed**. Sequenced as PR 2 of
+>   [`../planning/extension-taxonomy-crosswalk-plan-2026-06-16.md`](../planning/extension-taxonomy-crosswalk-plan-2026-06-16.md).
+> - **b (root README):** *not required but not off limits* — optional 5-line pointer-only README if a
+>   public landing page is later wanted; the deliberate no-README posture otherwise stands. Not built now.
+> - **c (taxonomy):** classify **all 43**, **CI-enforced** — but via a **curated overlay
+>   (`architecture_rules/extension_roles.yaml`) + a `--check` guard**, *not* a registry schema bump
+>   (lower risk; roles are editorial, not runtime; and the 10 most-interesting extensions have no
+>   registry entry to put a field on). **SHIPPED in PR #958.** (Rationale in the plan §"Design decision".)
+>
+> The original DISCUSS framing + per-question agent recommendations are preserved below for provenance.
 
 **Q-0151a — A thin unified atlas?** The review's flagship "per-file maintainer dashboard" is ~80%
 already shipped (`context_map.py` + `wiring_map.py` + `review_scope.py` + the agent context packs).
@@ -5721,8 +5732,8 @@ owner wants a public landing page; otherwise keep the deliberate no-README postu
 it overrides a stated decision.
 
 **Q-0151c — How far to enforce extension classification?** The strongest finding: no taxonomy maps the
-43 extensions ↔ 32 subsystems (the ~11 non-1:1 are unclassified). Should classification cover **only
-the ~11 non-subsystem extensions**, or **all 43**? And should the `role` be **advisory metadata** or a
+43 extensions ↔ 33 subsystems (the 10 non-1:1 are unclassified). Should classification cover **only
+the 10 non-subsystem extensions**, or **all 43**? And should the `role` be **advisory metadata** or a
 **CI-enforced** guard (a new `INITIAL_EXTENSIONS` entry must declare a role or be a registered
 subsystem)? *Agent recommendation:* classify **all 43** (cheap, and partial taxonomies rot), role as a
 registry field, **CI-enforced** so the gap can't silently re-grow — but this is a

--- a/docs/planning/extension-taxonomy-crosswalk-plan-2026-06-16.md
+++ b/docs/planning/extension-taxonomy-crosswalk-plan-2026-06-16.md
@@ -1,0 +1,71 @@
+# Extension-taxonomy crosswalk + thin architecture atlas — plan
+
+> **Status:** `plan` — cross-check source before extending. Born from the owner-uploaded
+> architecture-atlas review ([capture](../ideas/architecture-atlas-and-structure-review-2026-06-16.md),
+> PR #957) and the owner's **Q-0151** answer (2026-06-16: *"I agree with your recommendations, and the
+> readme is not required but not off limits"*). PR 1 (the crosswalk) is **shipped** in this plan's own
+> session; PR 2 (the atlas) is sequenced below.
+
+## Why
+
+The review's strongest genuinely-new finding: SuperBot loads **43** extensions but registers **33**
+subsystems, and the **10** non-1:1 extensions had no role classification anywhere. The review's
+flagship "per-file dashboard" was already ~80% shipped as `scripts/context_map.py`, so the additive
+work is narrow: (1) classify the extensions, (2) optionally compose the scattered generators into one
+provenance-stamped index.
+
+## PR 1 — extension-type taxonomy crosswalk · SHIPPED (this session)
+
+A read-only, CI-enforced crosswalk. **No runtime change.**
+
+- **`architecture_rules/extension_roles.yaml`** — the curated editorial overlay. Classifies all 43
+  extensions into one of 8 roles (`product_subsystem` · `hub` · `shared_platform` · `maintenance` ·
+  `operational_adapter` · `bootstrap` · `specialized_surface` · `lab`) + the backing subsystem for the
+  10 non-1:1 ones.
+- **`scripts/extension_crosswalk.py`** — AST-joins `config.INITIAL_EXTENSIONS` +
+  `subsystem_registry.SUBSYSTEMS` + the overlay. `--write` regenerates the doc; `--check` is the guard;
+  bare run previews. No imports/env (CI-safe).
+- **`docs/architecture/extension-taxonomy-crosswalk.md`** — generated, committed, `NOT SOURCE OF TRUTH` + provenance.
+- **`tests/unit/scripts/test_extension_crosswalk.py`** — runs `--check` (the CI enforcement seam) +
+  proves the guard catches an unclassified extension / a bad `backs`.
+
+### Design decision: overlay, not a registry field (owner-approved)
+
+My original Q-0151c phrasing suggested a `role` field on the subsystem registry (a
+`REGISTRY_SCHEMA_VERSION` bump). **We chose the curated overlay instead** because:
+1. A role like *bootstrap* / *operational_adapter* is a **human review label**, not runtime metadata —
+   it must not bloat the deep-frozen registry that governance resolves against.
+2. The 10 most-interesting extensions **have no registry entry at all** (that's the whole point), so a
+   registry field couldn't classify them anyway.
+3. Lower risk: the overlay + generator are disposable tooling (Q-0105); nothing in the bot runtime
+   depends on them. This matches the review's own "small curated overlay for what you can't safely
+   infer" recommendation.
+
+The CI **enforcement** the owner asked for is delivered by the test running `--check` (every extension
+must be classified), so "CI-enforced" is satisfied without touching runtime.
+
+## PR 2 — thin unified atlas · SEQUENCED (next session)
+
+The review's surviving second idea, as a **companion** to `AGENT_ORIENTATION.md` (owner's Q-0151a
+choice — not a replacement; orientation stays the curated reading-order router). A thin
+`scripts/atlas.py` that **composes the existing generators as libraries** (never re-implements them):
+`context_map` (per-file role/imports/blast-radius/tests/docs), `wiring_map` (EventBus), `review_scope`
+(review unit), and **this PR's role data** — into one repo-wide, provenance-stamped index.
+
+- **Provenance:** unlike the crosswalk (committed → deterministic, no timestamp), the atlas index
+  carries commit SHA + timestamp and is **CI-`--check` + on-demand generate, body NOT committed**
+  (owner's Q-0151a choice) — so a volatile provenance header is fine and it adds no committed
+  drift surface.
+- **Dependency:** consumes PR 1's `role`/`backs` data, which is why it sequences after.
+- **Reuse gate (do-not-duplicate):** must import `context_map` / `wiring_map` / `review_scope` as
+  modules. If a needed fact isn't already produced by one of them, add it *there*, not in the atlas.
+- **Overlap to resolve:** the agent context-pack system (`tools/agent_context/`) already produces
+  per-area packs; the atlas is repo-wide and file-indexed. Confirm the two stay complementary (packs =
+  curated per-area reading context; atlas = generated repo-wide fact index) before building.
+
+## Out of scope / explicitly deferred
+- **Root README** (Q-0151b) — owner: *not required but not off limits*. Optional 5-line pointer-only
+  README if a public GitHub landing page is wanted later; otherwise the deliberate "no root README"
+  posture (`repo-navigation-map.md`) stands. Not built here.
+- **Boundary-debt burndown** (review Option B) — already ticketed in `architecture_rules/layers.yaml`
+  (`arch-fix-11/13`); execution lane, tracked separately.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -590,9 +590,16 @@ condition — every sector non-empty).*
   fix the ledger, refactor the roadmap) each time merged PRs cross a **multiple of 30** (Q-0134; the
   trigger/checker **machinery is S3**, the docs it writes are S4) · the session enders (Q-0089 idea ·
   Q-0102 prev-session review · Q-0104 closing audit).
-- **Next** — idea-backlog **grooming** (Q-0015 — every idea ends implemented or discussed) ·
-  orientation-route upkeep mined from `.sessions/` **context-deltas** · doc-reachability maintenance
-  (`check_docs --strict`).
+- **Next** — the **thin architecture atlas** (PR 2 of
+  [`extension-taxonomy-crosswalk-plan-2026-06-16.md`](planning/extension-taxonomy-crosswalk-plan-2026-06-16.md);
+  Q-0151a — a companion to orientation, composing `context_map`/`wiring_map`/`review_scope` + the role
+  data into one repo-wide CI-`--check` index) · idea-backlog **grooming** (Q-0015 — every idea ends
+  implemented or discussed) · orientation-route upkeep mined from `.sessions/` **context-deltas** ·
+  doc-reachability maintenance (`check_docs --strict`).
+- **Shipped** — the **extension-type taxonomy crosswalk** (Q-0151c, PR #958): the curated role overlay
+  `architecture_rules/extension_roles.yaml` + `scripts/extension_crosswalk.py` →
+  [`extension-taxonomy-crosswalk.md`](architecture/extension-taxonomy-crosswalk.md), CI-enforced — the 43↔33
+  extension/subsystem map, 10 non-1:1 classified.
 
 ### 🛠️ Operations / control-plane · **S5** — standing lane
 

--- a/scripts/extension_crosswalk.py
+++ b/scripts/extension_crosswalk.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Extension-type taxonomy crosswalk for SuperBot.
+
+Joins three sources of truth into one browsable crosswalk that answers, for every
+loaded Discord extension: what *role* it plays, whether it is a registered
+subsystem, and (if not) which subsystem it backs.
+
+Sources
+-------
+1. ``disbot/config.py``                  — ``INITIAL_EXTENSIONS`` (the live manifest)
+2. ``disbot/utils/subsystem_registry.py``— ``SUBSYSTEMS`` (registered identities)
+3. ``architecture_rules/extension_roles.yaml`` — the curated editorial role overlay
+
+The first two are read by **AST** (no import, no env, no bot startup) so this runs
+identically in CI and locally. The overlay is the only hand-edited input.
+
+Why a crosswalk: SuperBot loads 43 extensions but registers 33 subsystems; the 10
+non-1:1 extensions (bootstrap / maintenance loops / BTD6 sub-surfaces / the Hermes
+adapter) are a *classification*, not a gap. See
+``docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md`` (Q-0151c).
+
+Modes
+-----
+    python3.10 scripts/extension_crosswalk.py            # print the crosswalk (preview)
+    python3.10 scripts/extension_crosswalk.py --write    # (re)generate the doc
+    python3.10 scripts/extension_crosswalk.py --check     # CI guard (exit 1 on drift)
+
+``--check`` fails when: an extension is unclassified, the overlay names a stranger,
+a role/backs value is invalid, a registered subsystem has no backing extension, or
+the committed doc is stale. ``tests/unit/scripts/test_extension_crosswalk.py`` runs
+``--check`` so the suite enforces it (no workflow edit needed).
+
+RELIABILITY / PROVENANCE (Q-0105): added 2026-06-16. Read-only, stdlib + yaml,
+disposable. If it proves more nuisance than help across a few sessions, delete this
+script, ``architecture_rules/extension_roles.yaml``, the generated doc, and the test
+together — nothing in the bot runtime depends on it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONFIG_PY = REPO_ROOT / "disbot" / "config.py"
+REGISTRY_PY = REPO_ROOT / "disbot" / "utils" / "subsystem_registry.py"
+OVERLAY_YAML = REPO_ROOT / "architecture_rules" / "extension_roles.yaml"
+GENERATED_DOC = REPO_ROOT / "docs" / "architecture" / "extension-taxonomy-crosswalk.md"
+
+# Bump when the rendered layout changes (so a stale committed doc is detected).
+GENERATOR_VERSION = "v1"
+
+_NOT_SOURCE_OF_TRUTH = (
+    "> **Status:** `living-ledger` — **GENERATED — NOT SOURCE OF TRUTH.** Do not edit "
+    "by hand.\n"
+    "> Regenerate with `python3.10 scripts/extension_crosswalk.py --write` after editing\n"
+    "> `architecture_rules/extension_roles.yaml`. Sources: `disbot/config.py` "
+    "(`INITIAL_EXTENSIONS`),\n"
+    "> `disbot/utils/subsystem_registry.py` (`SUBSYSTEMS`), and that overlay. "
+    "`--check` guards staleness."
+)
+
+
+# ---------------------------------------------------------------------------
+# AST extraction (no imports — safe in CI, no env / bot startup)
+# ---------------------------------------------------------------------------
+
+
+def _find_assignment(tree: ast.Module, name: str) -> ast.expr:
+    """Return the value node assigned to ``name`` at module level (Assign/AnnAssign)."""
+    for node in tree.body:
+        targets = (
+            node.targets
+            if isinstance(node, ast.Assign)
+            else [node.target] if isinstance(node, ast.AnnAssign) else []
+        )
+        for tgt in targets:
+            if isinstance(tgt, ast.Name) and tgt.id == name and node.value is not None:
+                return node.value
+    raise ValueError(f"could not find module-level assignment to {name!r}")
+
+
+def _str_constants(node: ast.expr) -> list[str]:
+    return [el.value for el in node.elts if isinstance(el, ast.Constant)]  # type: ignore[attr-defined]
+
+
+def initial_extensions() -> list[str]:
+    """Short names (``cogs.x_cog`` -> ``x``) in load order, from config.py."""
+    tree = ast.parse(CONFIG_PY.read_text(encoding="utf-8"))
+    raw = _str_constants(_find_assignment(tree, "INITIAL_EXTENSIONS"))
+    return [m.split(".")[-1].removesuffix("_cog") for m in raw]
+
+
+def subsystem_keys() -> set[str]:
+    """The registered subsystem identities, from subsystem_registry.py."""
+    tree = ast.parse(REGISTRY_PY.read_text(encoding="utf-8"))
+    node = _find_assignment(tree, "SUBSYSTEMS")
+    if not isinstance(node, ast.Dict):
+        raise ValueError("SUBSYSTEMS is not a dict literal")
+    return {k.value for k in node.keys if isinstance(k, ast.Constant)}
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Row:
+    extension: str
+    role: str
+    registered: bool
+    backs: str | None
+    note: str
+
+
+def _load_overlay() -> dict:
+    return yaml.safe_load(OVERLAY_YAML.read_text(encoding="utf-8"))
+
+
+def build_rows() -> tuple[list[Row], list[str]]:
+    """Return (rows in load order, validation errors)."""
+    overlay = _load_overlay()
+    roles = overlay.get("roles", {})
+    entries = overlay.get("extensions", {})
+    exts = initial_extensions()
+    keys = subsystem_keys()
+    errors: list[str] = []
+
+    ext_set = set(exts)
+    # 1. every extension classified · 2. no stranger overlay entries
+    for missing in sorted(ext_set - set(entries)):
+        errors.append(
+            f"extension {missing!r} is in INITIAL_EXTENSIONS but not classified in the overlay",
+        )
+    for stranger in sorted(set(entries) - ext_set):
+        errors.append(f"overlay entry {stranger!r} does not match any loaded extension")
+    # 4. every registered subsystem has a backing extension
+    for orphan in sorted(keys - ext_set):
+        errors.append(
+            f"registered subsystem {orphan!r} has no backing extension in INITIAL_EXTENSIONS",
+        )
+
+    rows: list[Row] = []
+    for ext in exts:
+        meta = entries.get(ext, {}) or {}
+        role = meta.get("role", "?")
+        backs = meta.get("backs") or None
+        note = (meta.get("note") or "").strip()
+        if ext in entries:
+            # 3. role + backs validity
+            if role not in roles:
+                errors.append(f"extension {ext!r} has unknown role {role!r}")
+            if backs is not None and backs not in keys:
+                errors.append(f"extension {ext!r} backs unknown subsystem {backs!r}")
+        rows.append(Row(ext, role, ext in keys, backs, note))
+    return rows, errors
+
+
+# ---------------------------------------------------------------------------
+# Rendering (deterministic — no timestamp/SHA so the committed doc is stable)
+# ---------------------------------------------------------------------------
+
+
+def _cell(text: str) -> str:
+    return text.replace("|", r"\|").replace("\n", " ").strip()
+
+
+def render(rows: list[Row], keys: set[str]) -> str:
+    by_role: dict[str, int] = {}
+    for r in rows:
+        by_role[r.role] = by_role.get(r.role, 0) + 1
+    non_1to1 = [r.extension for r in rows if not r.registered]
+    overlay = _load_overlay()
+    role_desc = overlay.get("roles", {})
+
+    out: list[str] = []
+    out.append("# Extension-type taxonomy crosswalk")
+    out.append("")
+    out.append(_NOT_SOURCE_OF_TRUTH)
+    out.append("")
+    out.append(
+        f"_Generator:_ `scripts/extension_crosswalk.py` `{GENERATOR_VERSION}`  ·  "
+        f"**{len(rows)}** extensions  ·  **{len(keys)}** registered subsystems  ·  "
+        f"**{len(non_1to1)}** non-1:1 extensions.",
+    )
+    out.append("")
+    out.append(
+        "Every loaded extension classified by **role** (editorial — in "
+        "`architecture_rules/extension_roles.yaml`) and joined to the registry. A "
+        "✓ in *Registered* means the extension is a 1:1 subsystem identity; the "
+        "non-1:1 rows are surfaces/maintenance/adapters that **back** a subsystem or "
+        "the platform.",
+    )
+    out.append("")
+
+    # Role legend + counts
+    out.append("## Roles")
+    out.append("")
+    out.append("| Role | Count | Meaning |")
+    out.append("|---|---:|---|")
+    for role in sorted(role_desc):
+        desc = _cell(str(role_desc[role].get("description", "")))
+        out.append(f"| `{role}` | {by_role.get(role, 0)} | {desc} |")
+    out.append("")
+
+    # The crosswalk, in load order
+    out.append("## Crosswalk (load order)")
+    out.append("")
+    out.append("| # | Extension | Role | Registered | Backs | Note |")
+    out.append("|---:|---|---|:--:|---|---|")
+    for i, r in enumerate(rows, 1):
+        reg = "✓" if r.registered else "—"
+        backs = f"`{r.backs}`" if r.backs else ""
+        out.append(
+            f"| {i} | `{r.extension}` | `{r.role}` | {reg} | {backs} | {_cell(r.note)} |",
+        )
+    out.append("")
+
+    # The non-1:1 callout (the review's "10 unclassified" — now classified)
+    out.append("## Non-1:1 extensions (no registry identity)")
+    out.append("")
+    out.append(
+        "These load as extensions but are **not** registered subsystems — they are "
+        "classified by role instead of being product verticals:",
+    )
+    out.append("")
+    for r in rows:
+        if not r.registered:
+            backs = f" → backs `{r.backs}`" if r.backs else ""
+            note = f" — {r.note}" if r.note else ""
+            out.append(f"- `{r.extension}` (`{r.role}`{backs}){note}")
+    out.append("")
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def check() -> list[str]:
+    """Return a list of drift/validation errors (empty == clean)."""
+    rows, errors = build_rows()
+    keys = subsystem_keys()
+    rendered = render(rows, keys).rstrip("\n") + "\n"
+    if not GENERATED_DOC.exists():
+        errors.append(
+            f"{GENERATED_DOC.relative_to(REPO_ROOT)} does not exist — run --write",
+        )
+    elif GENERATED_DOC.read_text(encoding="utf-8") != rendered:
+        errors.append(
+            f"{GENERATED_DOC.relative_to(REPO_ROOT)} is stale — run "
+            "`python3.10 scripts/extension_crosswalk.py --write`",
+        )
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Extension-type taxonomy crosswalk.")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--write", action="store_true", help="(re)generate the doc.")
+    group.add_argument(
+        "--check",
+        action="store_true",
+        help="CI guard: exit 1 on drift.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.check:
+        errors = check()
+        if errors:
+            print("extension_crosswalk: FAIL")
+            for e in errors:
+                print(f"  - {e}")
+            return 1
+        print("extension_crosswalk: all checks passed ✓")
+        return 0
+
+    rows, errors = build_rows()
+    keys = subsystem_keys()
+    rendered = render(rows, keys).rstrip("\n") + "\n"
+    if args.write:
+        GENERATED_DOC.write_text(rendered, encoding="utf-8")
+        print(f"wrote {GENERATED_DOC.relative_to(REPO_ROOT)} ({len(rows)} extensions)")
+        if errors:
+            print("WARNING — overlay validation errors (fix the overlay):")
+            for e in errors:
+                print(f"  - {e}")
+            return 1
+        return 0
+
+    # default: preview to stdout
+    print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_extension_crosswalk.py
+++ b/tests/unit/scripts/test_extension_crosswalk.py
@@ -1,0 +1,73 @@
+"""Tests for ``scripts/extension_crosswalk.py`` — the extension-taxonomy crosswalk.
+
+These tests *are* the CI enforcement of the taxonomy (Q-0151c): ``test_check_clean``
+fails the suite if any loaded extension is unclassified, the overlay drifts from the
+live manifest/registry, or the committed doc goes stale — no workflow edit needed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "extension_crosswalk.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("extension_crosswalk_ut", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_check_clean(mod):
+    """The live overlay classifies every extension and the doc is not stale."""
+    errors = mod.check()
+    assert errors == [], "\n".join(errors)
+
+
+def test_counts_match_live_sources(mod):
+    """Pin the headline numbers the architecture review hinged on (43 / 33 / 10)."""
+    rows, errors = mod.build_rows()
+    assert errors == []
+    assert len(rows) == len(mod.initial_extensions())
+    registered = [r for r in rows if r.registered]
+    non_1to1 = [r for r in rows if not r.registered]
+    assert len(registered) == len(mod.subsystem_keys())
+    # Every registered subsystem is backed by exactly one extension (no orphans).
+    assert {r.extension for r in registered} == mod.subsystem_keys()
+    # The non-1:1 set is the review's "unclassified" extensions — now classified.
+    assert len(non_1to1) >= 1
+    assert all(r.role != "?" for r in rows), "every row carries a real role"
+
+
+def test_render_is_deterministic(mod):
+    rows, _ = mod.build_rows()
+    keys = mod.subsystem_keys()
+    assert mod.render(rows, keys) == mod.render(rows, keys)
+
+
+def test_unclassified_extension_is_flagged(mod, monkeypatch):
+    """The guard must catch a new extension added without a role (the gap re-growing)."""
+    real = mod.initial_extensions()
+    monkeypatch.setattr(mod, "initial_extensions", lambda: [*real, "brand_new_thing"])
+    _rows, errors = mod.build_rows()
+    assert any("brand_new_thing" in e and "not classified" in e for e in errors), errors
+
+
+def test_invalid_backs_is_flagged(mod, monkeypatch):
+    """A `backs` pointing at a non-existent subsystem is rejected."""
+    overlay = mod._load_overlay()
+    # Corrupt one entry's `backs` to a stranger key.
+    victim = next(iter(overlay["extensions"]))
+    overlay["extensions"][victim] = {"role": "maintenance", "backs": "no_such_subsystem"}
+    monkeypatch.setattr(mod, "_load_overlay", lambda: overlay)
+    _rows, errors = mod.build_rows()
+    assert any("no_such_subsystem" in e for e in errors), errors


### PR DESCRIPTION
## What

Follow-on to #957 (architecture-atlas review). The owner **approved my Q-0151 recommendations**, so
this builds the **extension-type taxonomy crosswalk** — the strongest genuinely-new idea from that
review: nothing maps the **43 extensions ↔ 33 subsystems**, and the **10** non-1:1 extensions
(`bootstrap_access`, the two `*_maintenance` cogs, the five `btd6_*`/`paragon` surfaces, `setup`,
`hermes`) had no role classification.

**Born red** per Q-0133 — flips to `complete` as the final step.

## Approach (owner-confirmed)
- **Overlay, not a registry schema bump.** Editorial roles live in a curated
  `architecture_rules/extension_roles.yaml` (sibling to `layers.yaml`), enforced by a standalone
  `--check` guard. No runtime change — roles like *bootstrap*/*adapter* aren't runtime-relevant, and
  this matches the review's "small curated overlay" design at lower risk.
- **Generated, committed crosswalk** following the context-pack precedent (`docs/agent/generated/*`):
  `docs/extension-taxonomy-crosswalk.md` carries `NOT SOURCE OF TRUTH` + provenance, and a test fails
  if it goes stale.

## Files
- `architecture_rules/extension_roles.yaml` — all 43 classified.
- `scripts/extension_crosswalk.py` — AST-based generator (`--write` / `--check`); no imports/env.
- `docs/extension-taxonomy-crosswalk.md` — generated artifact.
- `tests/unit/scripts/test_extension_crosswalk.py` — the CI enforcement seam.
- `docs/planning/extension-taxonomy-crosswalk-plan-2026-06-16.md` — plan; sequences the **thin atlas**
  as PR 2 (it consumes the role data).
- Records the owner's **Q-0151** answer; fixes my own **32→33 / ~11→10** count error in the #957
  capture doc + README (the exact drift class this work kills).

## Verification
- `python3.10 scripts/check_quality.py --full`
- `python3.10 scripts/extension_crosswalk.py --check`

https://claude.ai/code/session_017kiQvtYDdewQNK8ibqwQSf

---
_Generated by [Claude Code](https://claude.ai/code/session_017kiQvtYDdewQNK8ibqwQSf)_