### PR TITLE
feat(hermes): idea-spotlight + morning-briefing + dispatch-resolve skills, 6h auto-reset

### DIFF
--- a/.sessions/2026-06-16-hermes-efficiency-skills.md
+++ b/.sessions/2026-06-16-hermes-efficiency-skills.md
@@ -1,27 +1,106 @@
 # 2026-06-16 — Hermes efficiency: idea-spotlight + briefing + dispatch-resolve + 6h auto-reset
 
-> **Status:** `in-progress` — born-red session card (Q-0133). Flip to `complete` as the last step.
+> **Status:** `complete` — shipped; PR #959 auto-merges on green CI.
 
-## Intent (what this run is about to do)
+## Arc
 
-Owner-requested (live, this session): make the Hermes control-plane agent more efficient with
-new specialised skills + an automatic session reset.
+Owner-requested live (this session): make the Hermes control-plane agent more efficient — new
+specialised skills + an automatic chat-session reset. Researched the whole Hermes setup, then asked
+two steering questions (`AskUserQuestion`); owner chose **morning-briefing + dispatch-resolve**
+(alongside the core idea-spotlight) and **reset every 6h** ("never a long session; the repo updates
+fast so old context isn't always valuable"). Recorded as **Q-0153**.
 
-- **`idea-spotlight`** (NEW scheduled skill, the headline) — picks **one** active idea from
-  `docs/ideas/` each day and posts a structured card (summary · pros · cons/risks · options &
-  expansions · suggested next step), so the owner can mull it during the day and **report back at
-  EOD**; the report-back routes through the existing `intake` skill. Backed by a deterministic
-  selector `scripts/hermes/idea_spotlight.py` (+ tests).
-- **`morning-briefing`** (NEW scheduled skill) — one consolidated morning digest (health · open
-  PRs · CI · overnight routine activity · decisions waiting on the owner · pointer to today's
-  spotlight) so there's one ping instead of several; absorbs `repo-health`'s daily schedule.
-- **`dispatch-resolve`** (NEW skill) + `scripts/dispatch_menu.py --json` — resolve a vague
-  "work on sector SX" into a concrete work order routed by executor (the read-side of the
-  captured `dispatch-resolution-json-hermes` idea; owner greenlit the Hermes-wiring half).
-- **Auto session-reset every 6h** — `scripts/hermes/session_reset.sh` + a systemd-timer runbook
-  (`docs/operations/hermes-session-reset.md`); owner installs on the VPS (the one unverified knob
-  is the reset invocation, documented).
+## Shipped (PR #959)
 
-Supporting: `build_skills.py` EXTRAS for the 3 new skills, regenerate `SKILL.md` artifacts,
-update the skill-pack README + operating prompt, mark the dispatch-resolution idea executed,
-record the owner's in-session decisions in the question router.
+- **`superbot-idea-spotlight`** (NEW scheduled skill, the headline) — `30 6 * * *`. Picks one active
+  `docs/ideas/` capture per day (deterministic, rotating) via the new
+  `scripts/hermes/idea_spotlight.py` (status-badge filtered, `--json`/`--list`/`--date`), and Hermes
+  posts a card with **pros · cons/risks · options & expansions**; the owner's EOD verdict routes back
+  through `superbot-intake`. 9 unit tests.
+- **`superbot-morning-briefing`** (NEW scheduled skill) — `0 6 * * *`. One consolidated digest
+  (health · open PRs · CI · overnight routine activity · decisions waiting on the owner). Absorbed
+  `repo-health`'s daily schedule (the "one ping not several" the owner picked); `repo-health` stays
+  on-demand.
+- **`superbot-dispatch-resolve`** (NEW skill) + **`scripts/dispatch_menu.py --json`** — resolves a
+  vague "work on SX" into a concrete work order routed by the resolved executor. The Hermes-wiring
+  half of `dispatch-resolution-json-hermes` (→ `historical`); 5 new tests.
+- **6h interactive session auto-reset** — `scripts/hermes/session_reset.sh` (safe wrapper:
+  logs, no-ops until configured) + the runbook `docs/operations/hermes-session-reset.md` (systemd
+  timer, `OnCalendar` every 6h). The one UNVERIFIED knob (`HERMES_RESET_CMD`) is documented.
+- Supporting: `build_skills.py` EXTRAS (15 skills now), regenerated `SKILL.md` artifacts, skill-pack
+  README + operating-prompt skill list, skill-author "how to schedule" line, Q-0153 router block.
+
+CI: `check_quality.py --full` green (10045 passed); `check_docs --strict`, `build_skills --check`,
+`check_architecture --mode strict` all clean; arch 0 new (no `disbot/` touched).
+
+## Context delta
+
+- **Needed but not pointed to:** the Hermes `blueprint.schedule` self-scheduling mechanism — the
+  single most relevant fact for this task — was only discoverable by reading `build_skills.py`'s
+  `EXTRAS`. Nothing in `skill-author.md` / the skill-pack README said "to schedule a skill, add
+  `schedule=`". *Fixed this session* (added the line to `skill-author.md` + the README schedule note).
+  Hermes hosting facts were spread across control-plane / cheatsheet / operating-prompt /
+  token-efficiency docs; had to assemble them.
+- **Pointed to but didn't need:** the giant `current-state.md` ▶ callout is bot-product-centric and
+  added little for a Hermes-tooling task (minor).
+- **Discovered by hand:** cron skills run **stateless** (`skip_memory=True`) — key to answering the
+  auto-reset question (scheduled skills don't need resetting; only the interactive chat does). Also:
+  an importlib-loaded script using `@dataclass` must be registered in `sys.modules` before
+  `exec_module` (only implicit in `test_build_skills.py`).
+- **Decisions made alone (all reversible; in Q-0153):** removed `repo-health`'s daily schedule
+  (consolidated into the briefing); date-`%`-len rotation for idea selection; briefing 06:00 /
+  spotlight 06:30 UTC; shipped auto-reset as a parameterized wrapper + runbook (owner confirms the
+  reset command on the VPS).
+- **Flagged for maintainer / known limits:** the auto-reset's `HERMES_RESET_CMD` is **unverified**
+  (can't be from the repo — confirm on the VPS). All 3 new skills are UNVERIFIED until they've run a
+  few times (Q-0105 headers). The idea-spotlight pick shifts when the active-idea count changes
+  (inherent to the simple rotation; acceptable).
+
+## 💡 Session idea (Q-0089)
+
+`docs/ideas/idea-spotlight-verdict-loop-2026-06-16.md` — the spotlight asks for a verdict but the
+selector has no memory of what's already decided, and nothing measures backlog drain. Give it a tiny
+**verdict ledger** (persist each `intake` route), bias selection toward un-decided ideas, and add a
+weekly drain-rate line to the briefing — a self-draining decision queue. Genuinely believe in it: it
+closes the loop this very PR opened.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous run (`2026-06-16-act-on-autonomous-run-review`, PR #956 / Q-0152): **did well** to batch the
+autonomous-run review's loop-closing changes and, notably, to *correct propagating misinformation*
+(the "merge needs a manual Railway deploy" myth) at the root rather than just patching one mention —
+good systemic hygiene. **System improvement it surfaces:** it made the `📤 Run report` footer
+*required* in session logs but there's no checker that a log actually contains it (the way
+`check_session_gate` checks the card status but not the footer). Extending `check_session_log.py` to
+assert the footer + its two `⚑` lines would make the convention self-enforcing — worth a future
+slice (not built here; out of scope).
+
+## 🔎 Doc audit (Q-0104)
+
+`check_docs --strict` green (all new docs reachable + badged). The SessionStart "12 merged PRs not in
+current-state" is **benign newest-merge lag**, not drift (the reconciliation routine owns the ledger;
+Q-0124 — a manual session doesn't reconcile). Owner decisions recorded in the router (Q-0153); the
+dispatch-resolution idea re-badged `historical` with its README entry updated.
+
+## 📤 Run report
+
+- **Did:** shipped 3 new Hermes skills (idea-spotlight · morning-briefing · dispatch-resolve) + a 6h
+  interactive-session auto-reset runbook · **Outcome:** shipped (PR #959, auto-merges on green)
+- **Shipped:** #959 — Hermes efficiency skills + `dispatch_menu --json` + session-reset wrapper/runbook
+- **⚑ Owner decisions needed:** `none` (the choices were made live via AskUserQuestion → Q-0153)
+- **⚑ Owner manual steps:** VPS, off-repo — (1) re-install: `install-skills.sh` → `install-soul.sh`
+  → `systemctl restart hermes-gateway` (picks up the 3 new skills + the updated operating prompt);
+  (2) wire the 6h reset per `docs/operations/hermes-session-reset.md` (set `HERMES_RESET_CMD` for
+  your Hermes build + enable the timer). Both detailed in Q-0153.
+- **↪ Next:** when the daily spotlight cards are confirmed landing, build the **idea-spotlight
+  verdict loop** (`docs/ideas/idea-spotlight-verdict-loop-2026-06-16.md`).
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 0 (this session's #959 auto-merges on green) |
+| CI-red rounds | 0 real (1 intentional born-red gate hold; 1 local ruff/black auto-fix before push) |
+| Repo-rule trips | 0 (no new arch violations; no `disbot/` touched) |
+| New ideas contributed | 1 (idea-spotlight verdict loop) |
+| Ideas groomed | 1 (dispatch-resolution-json-hermes → `historical`, executed) |

--- a/.sessions/2026-06-16-hermes-efficiency-skills.md
+++ b/.sessions/2026-06-16-hermes-efficiency-skills.md
@@ -1,0 +1,27 @@
+# 2026-06-16 — Hermes efficiency: idea-spotlight + briefing + dispatch-resolve + 6h auto-reset
+
+> **Status:** `in-progress` — born-red session card (Q-0133). Flip to `complete` as the last step.
+
+## Intent (what this run is about to do)
+
+Owner-requested (live, this session): make the Hermes control-plane agent more efficient with
+new specialised skills + an automatic session reset.
+
+- **`idea-spotlight`** (NEW scheduled skill, the headline) — picks **one** active idea from
+  `docs/ideas/` each day and posts a structured card (summary · pros · cons/risks · options &
+  expansions · suggested next step), so the owner can mull it during the day and **report back at
+  EOD**; the report-back routes through the existing `intake` skill. Backed by a deterministic
+  selector `scripts/hermes/idea_spotlight.py` (+ tests).
+- **`morning-briefing`** (NEW scheduled skill) — one consolidated morning digest (health · open
+  PRs · CI · overnight routine activity · decisions waiting on the owner · pointer to today's
+  spotlight) so there's one ping instead of several; absorbs `repo-health`'s daily schedule.
+- **`dispatch-resolve`** (NEW skill) + `scripts/dispatch_menu.py --json` — resolve a vague
+  "work on sector SX" into a concrete work order routed by executor (the read-side of the
+  captured `dispatch-resolution-json-hermes` idea; owner greenlit the Hermes-wiring half).
+- **Auto session-reset every 6h** — `scripts/hermes/session_reset.sh` + a systemd-timer runbook
+  (`docs/operations/hermes-session-reset.md`); owner installs on the VPS (the one unverified knob
+  is the reset invocation, documented).
+
+Supporting: `build_skills.py` EXTRAS for the 3 new skills, regenerate `SKILL.md` artifacts,
+update the skill-pack README + operating prompt, mark the dispatch-resolution idea executed,
+record the owner's in-session decisions in the question router.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -20,6 +20,13 @@ during grooming** (it stays listed here, annotated ✅) so the active backlog re
 
 Current broad captures:
 
+- [`idea-spotlight-verdict-loop-2026-06-16.md`](./idea-spotlight-verdict-loop-2026-06-16.md) —
+  **session idea (2026-06-16, Q-0089, from the idea-spotlight skill PR #959):** the new daily
+  `superbot-idea-spotlight` surfaces an idea + asks for a verdict, but the selector has no memory of
+  what the owner already decided, so a settled idea can resurface and nothing measures backlog drain.
+  Give it a tiny **verdict ledger** (persist each `intake` route), bias selection toward un-decided
+  ideas, and add a weekly drain-rate line to the briefing — turning the ritual into a self-draining
+  decision queue. Small/decided-lane. → relates `scripts/hermes/idea_spotlight.py`.
 - [`architecture-atlas-and-structure-review-2026-06-16.md`](./architecture-atlas-and-structure-review-2026-06-16.md) —
   **owner-uploaded external review + agent judgment (2026-06-16):** an outside-in repo-architecture
   review ("repository-architectuuratlas") recommending a generated **architecture atlas** over any
@@ -113,12 +120,12 @@ Current broad captures:
   (bot · BTD6 · agent substrate · **+ a forgotten Operations/control-plane sector**) distinct from the
   `repo-review-map.md` review taxonomy. Captured owner direction + agent opinion; not approved.
 - [`dispatch-resolution-json-hermes-2026-06-14.md`](./dispatch-resolution-json-hermes-2026-06-14.md) —
-  **session idea (2026-06-14, Q-0089, from the sector-tooling session #882; owner-invited):** give
-  `scripts/dispatch_menu.py` a **`--json`** mode and wire it into the Hermes `superbot-dispatch` skill, so
-  *"dispatch S2"* resolves to a concrete work order **and** routes by the resolved **executor**
-  (`Claude-in-repo` → `/fire`; `Hermes-VPS` → Hermes does it; `maintainer` → tell the owner). The
-  read-side of **Q-0137 Thread 1**: turns the Q-0143 contract + the dispatch menu from dispatch-*ready*
-  into dispatch-*resolved*. `--json` half = safe quick-win; Hermes-wiring half gated on Thread 1.
+  ✅ **EXECUTED → `historical` (2026-06-16, PR #959, owner-directed):** `scripts/dispatch_menu.py --json`
+  shipped **and** the Hermes-wiring half landed as the new **`superbot-dispatch-resolve`** skill, so
+  *"dispatch S2"* resolves to a concrete work order and routes by the resolved **executor**
+  (`Claude-in-repo` → `/fire`; `Hermes-VPS` → Hermes does it; `maintainer` → tell the owner). Originally
+  the 2026-06-14 Q-0089 session idea (the read-side of **Q-0137 Thread 1**; the broader cron-backstop
+  part of Thread 1 stays owner-undecided).
 - [`routine-system-improvements-2026-06-14.md`](./routine-system-improvements-2026-06-14.md) —
   **workflow / routine-system (2026-06-14, owner-requested):** first-hand field notes from a live
   routine run on making the unattended Hermes-dispatch loop smoother. Core orientation already

--- a/docs/ideas/dispatch-resolution-json-hermes-2026-06-14.md
+++ b/docs/ideas/dispatch-resolution-json-hermes-2026-06-14.md
@@ -1,8 +1,10 @@
 # Dispatch resolution — `dispatch_menu.py --json` wired into the Hermes dispatch skill
 
-> **Status:** `ideas` — **not approved, not a plan.** Capture so it isn't lost. The Hermes-wiring half
-> is gated on **Q-0137 Thread 1** (the owner's open dispatch decision); the `--json` half is a safe
-> read-only quick-win. Source, the binding contracts, and `docs/current-state.md` win over this.
+> **Status:** `historical` — **EXECUTED 2026-06-16 (PR #959, owner-directed).** Both halves shipped:
+> `scripts/dispatch_menu.py --json` (the read-only quick-win) **and** the Hermes-wiring half as the
+> new **`superbot-dispatch-resolve`** skill (`docs/operations/hermes-skills/dispatch-resolve.md`).
+> The owner greenlit the wiring half in-session (the Q-0137 Thread 1 *read-side*; the broader
+> cron-backstop part of Thread 1 stays with the owner). Original capture below.
 
 **Captured:** 2026-06-14 (from the sector-tooling session, PR #882 — the Q-0089 session idea, owner
 invited the capture). **Owning area:** S3 AI-Memory / S5 Operations (the dispatch mechanism).

--- a/docs/ideas/idea-spotlight-verdict-loop-2026-06-16.md
+++ b/docs/ideas/idea-spotlight-verdict-loop-2026-06-16.md
@@ -1,0 +1,35 @@
+# Idea: close the idea-spotlight loop — track the owner's verdicts
+
+> **Status:** `ideas` — **session idea (2026-06-16, Q-0089, from the idea-spotlight skill PR #959).**
+> Not approved, not a plan. Source + the binding contracts win.
+
+## The gap
+
+The new `superbot-idea-spotlight` skill surfaces one active idea per day and asks the owner to
+**report a verdict** (build / roadmap / discuss / drop / expand). But the **selection** side
+(`scripts/hermes/idea_spotlight.py`) only knows "active vs terminal" — it has **no memory of what
+the owner already decided**. So an idea the owner routed to *roadmap Later* (still `ideas`-badged,
+not `historical`) can resurface as the spotlight a few days later, and there's no measure of whether
+the daily ritual is actually **draining** the backlog.
+
+## The idea
+
+Give the spotlight a tiny **verdict ledger** so the loop closes and is measurable:
+
+1. **Record** each owner verdict (the `intake` route the EOD reply takes) to a small append-only
+   log — e.g. `docs/owner/idea-spotlight-log.md` (or a `.jsonl`): `date · idea-file · verdict ·
+   one-line note`. The reply already flows through `intake`; this just persists the outcome.
+2. **Bias selection** in `idea_spotlight.py`: deprioritise (or skip for N days) any idea with a
+   recent verdict, so the daily pick favours **un-decided** ideas — the backlog actually drains
+   instead of re-offering settled ones.
+3. **Measure** it: a weekly line in the morning briefing — "ideas decided this week: N · backlog:
+   M active" — the human mirror of the grooming drain-rate (gap-analysis §4 telemetry theme).
+
+## Why it matters / sizing
+
+It turns a one-way "here's an idea" notification into a **self-draining decision queue** with a
+visible trend — the same compounding the session-chain enders give the agent loop, for the owner's
+idea backlog. **Small/decided-lane:** one log file + a selection filter + a briefing line; read-only
+on the bot. Sequence it after a few real spotlight cards confirm the daily ritual lands.
+
+→ relates `scripts/hermes/idea_spotlight.py` · `docs/operations/hermes-skills/{idea-spotlight,intake,morning-briefing}.md`

--- a/docs/operations/hermes-operating-prompt.md
+++ b/docs/operations/hermes-operating-prompt.md
@@ -136,10 +136,12 @@ HOW TO ANSWER
 
 YOUR SKILLS
   someone pings -> intake (bug / idea / request / question -> classify + route to the right home)
+  each morning  -> morning-briefing (auto digest), idea-spotlight (auto idea-of-the-day; route the
+                   owner's end-of-day verdict back through intake)
   pre-session   -> session-brief, prompt-builder
   between work  -> repo-health, open-questions, ideas-triage, btd6-status
   something off -> log-triage
-  build it      -> dispatch (fire a Claude Code routine)
+  build it      -> dispatch (fire a Claude Code routine); vague "do sector SX" -> dispatch-resolve
   review a PR   -> review / review-merge
   make a skill  -> skill-author (design a new skill -> docs-only PR)
 ```

--- a/docs/operations/hermes-session-reset.md
+++ b/docs/operations/hermes-session-reset.md
@@ -1,0 +1,127 @@
+# Hermes session auto-reset (runbook)
+
+> **Status:** `living-ledger` — the VPS-side runbook for automatically clearing Hermes'
+> **interactive** chat session on a schedule, so the owner never has to type `/new`. The repo-side
+> piece (`scripts/hermes/session_reset.sh`) is shipped; the timer + the one reset command are
+> **maintainer-side VPS actions** (⬜ below). Provenance: owner-directed 2026-06-16 (reset every
+> **6 hours** — "so there's never a long session, and the repo updates fast so old context isn't
+> always valuable").
+
+## What this is
+
+Hermes' interactive Telegram session is **one long-lived, accumulating conversation**: the gateway
+re-sends the history every turn (so spend grows fast), and on a fast-moving repo the older context
+goes stale. The bounded-session habit (`hermes-operating-prompt.md` → "finish a task, then `/new`")
+fixes that by hand; this automates it — a small timer fires the reset **every 6 hours** so each
+sitting starts fresh and cheap.
+
+```text
+systemd timer (every 6h)  →  scripts/hermes/session_reset.sh  →  $HERMES_RESET_CMD  →  fresh session
+```
+
+**You do NOT need this for the scheduled skills.** `morning-briefing`, `idea-spotlight`, and
+`review-merge` already run as **fresh, stateless** sessions on their own cron (a scheduled skill
+never accumulates into your chat). This runbook is only about the **interactive** thread you type in.
+
+## The one knob to confirm (UNVERIFIED — like `apply_context_fixes.sh`)
+
+The exact way to clear the session depends on your Hermes build, and it can't be exercised from the
+repo (no Hermes in CI). `/new` is the **manual** equivalent you already use in Telegram; the script
+just needs the command-line form of it. Discover the candidates on the VPS:
+
+```bash
+hermes --help ; hermes session --help ; hermes chat --help   # look for a "new"/"reset"/"clear"
+```
+
+Common shapes (use whichever your version exposes):
+
+```bash
+HERMES_RESET_CMD="hermes session new"      # if the CLI has it
+# HERMES_RESET_CMD="hermes chat reset"     # alternative naming
+```
+
+> ⚠️ **Restarting the gateway is NOT a reset.** `systemctl restart hermes-gateway` reloads skills /
+> config but the session state persists in `~/.hermes/state.db`, so the conversation survives. Use
+> the real `/new` equivalent, not a restart. If your build genuinely has no CLI reset, ask in the
+> Hermes/Nous docs for the gateway's session-clear command before wiring the timer.
+
+## Setup (one-time, on the VPS as the `hermes` user)
+
+1. ✅ **The wrapper is in the repo:** `scripts/hermes/session_reset.sh` (logging + a safe no-op when
+   unconfigured, so the timer never red-flags before you set the command). Pull `main` to get it.
+
+2. ⬜ **Store the reset command** in `~/.hermes/reset.env` (chmod 600 — keep it out of git):
+   ```bash
+   echo 'HERMES_RESET_CMD="hermes session new"' > ~/.hermes/reset.env   # ← your confirmed command
+   chmod 600 ~/.hermes/reset.env
+   bash scripts/hermes/session_reset.sh --dry-run   # confirm it shows your command
+   bash scripts/hermes/session_reset.sh             # do one real reset; check ~/.hermes/reset.log
+   ```
+
+3. ⬜ **Install the every-6h timer.** A user-level systemd timer is simplest (the `hermes` user owns
+   it). Create the two units, then enable:
+   ```bash
+   mkdir -p ~/.config/systemd/user
+
+   cat > ~/.config/systemd/user/hermes-session-reset.service <<'EOF'
+   [Unit]
+   Description=Reset the Hermes interactive chat session (clear accumulated context)
+
+   [Service]
+   Type=oneshot
+   ExecStart=%h/repos/superbot/scripts/hermes/session_reset.sh
+   EOF
+
+   cat > ~/.config/systemd/user/hermes-session-reset.timer <<'EOF'
+   [Unit]
+   Description=Reset the Hermes chat session every 6 hours
+
+   [Timer]
+   OnCalendar=*-*-* 00/06:00:00
+   Persistent=true
+
+   [Install]
+   WantedBy=timers.target
+   EOF
+
+   systemctl --user daemon-reload
+   systemctl --user enable --now hermes-session-reset.timer
+   loginctl enable-linger hermes        # so the user timer runs even when not logged in
+   ```
+   `OnCalendar=*-*-* 00/06:00:00` fires at **00:00, 06:00, 12:00, 18:00 UTC** (every 6h). Adjust the
+   start hour if you'd rather the resets land at other times.
+
+4. ⬜ **Verify:**
+   ```bash
+   systemctl --user list-timers hermes-session-reset.timer   # next run time
+   journalctl --user -u hermes-session-reset.service -n 20    # last run output
+   cat ~/.hermes/reset.log                                    # the script's own log
+   ```
+
+### Cron alternative (if you prefer cron to systemd)
+
+```cron
+0 */6 * * * /home/hermes/repos/superbot/scripts/hermes/session_reset.sh >> /home/hermes/.hermes/reset.log 2>&1
+```
+
+## Kill switch (Q-0105)
+
+This is disposable convenience infrastructure, not load-bearing runtime. To stop it:
+
+```bash
+systemctl --user disable --now hermes-session-reset.timer   # (or remove the cron line)
+```
+
+Or just unset `HERMES_RESET_CMD` in `~/.hermes/reset.env` — the script then degrades to a logged
+no-op and resets nothing. If the reset mechanism changes upstream, delete the script + units rather
+than working around them.
+
+## See also
+
+- [`hermes-operating-prompt.md`](./hermes-operating-prompt.md) — the bounded-session habit this
+  automates (the manual `/new`).
+- [`hermes-skills/README.md`](./hermes-skills/README.md) — the scheduled skills (already stateless;
+  unaffected by this).
+- `scripts/hermes/apply_context_fixes.sh` — the complementary lever: tune the **compaction**
+  threshold so a single session holds context longer (reduces how often a reset matters).
+- [`hermes-control-plane.md`](./hermes-control-plane.md) — VPS setup + the gateway service.

--- a/docs/operations/hermes-skills/README.md
+++ b/docs/operations/hermes-skills/README.md
@@ -4,10 +4,11 @@
 > skills. Each skill is a ready-to-configure prompt for the Hermes agent running on the
 > control-plane VPS. Setup context: `docs/operations/hermes-control-plane.md`.
 
-This pack contains twelve skills covering the windows Hermes fills that Claude Code
+This pack contains fifteen skills covering the windows Hermes fills that Claude Code
 cannot: **the front-door intake router**, **pre-session orientation**, **between-session
-monitoring**, **production diagnosis from your phone**, the **autonomous-loop seams**
-(independent review + dispatch), and **self-extension** (Hermes authoring its own skills).
+monitoring**, a **daily idea ritual + morning digest**, **production diagnosis from your phone**,
+the **autonomous-loop seams** (independent review + dispatch + dispatch resolution), and
+**self-extension** (Hermes authoring its own skills).
 
 For the standing read-only operating instructions every Hermes session should start
 with, see [`hermes-operating-prompt.md`](../hermes-operating-prompt.md) — the Hermes-side
@@ -21,8 +22,10 @@ equivalent of `.claude/CLAUDE.md`.
 |---|---|---|
 | [`intake`](./intake.md) | The front door — any inbound message | Classify a bug / idea / feature request / question / complaint and route it to the right home (bug-book · ideas · question router · dispatch · a cited answer) with the right action |
 | [`session-brief`](./session-brief.md) | Pre-session | Compressed orientation brief to paste into Claude Code |
-| [`repo-health`](./repo-health.md) | Between sessions | Traffic-light snapshot — is anything broken? (self-schedules a daily digest) |
+| [`morning-briefing`](./morning-briefing.md) | Each morning | One consolidated digest — health · open PRs · CI · overnight routine activity · decisions waiting on you (self-schedules; one ping instead of several) |
+| [`repo-health`](./repo-health.md) | Between sessions (on-demand) | Full traffic-light snapshot — is anything broken? (the briefing now carries the daily health line) |
 | [`ideas-triage`](./ideas-triage.md) | Downtime | Ideas backlog review with a suggested next move |
+| [`idea-spotlight`](./idea-spotlight.md) | Daily | Surface **one** active idea with pros · cons · options/expansions to mull over — and route the owner's end-of-day verdict (self-schedules) |
 | [`prompt-builder`](./prompt-builder.md) | Pre-session | Turn a spoken idea into a structured Claude Code prompt |
 | [`open-questions`](./open-questions.md) | Between sessions | Surface unanswered Q- blocks from the router |
 | [`btd6-status`](./btd6-status.md) | After live testing | BTD6 data pipeline coverage and open items |
@@ -30,6 +33,7 @@ equivalent of `.claude/CLAUDE.md`.
 | [`review`](./review.md) | Plan finalization / open PR | Independent (non-Claude) critique of a plan or PR diff + a maintainer summary for the approve/deny gate |
 | [`review-merge`](./review-merge.md) | Executor opened a big-step PR | The independent-reviewer **merge gate** (Q-0117): review `needs-hermes-review` PRs and merge if sound — Hermes' one sanctioned write |
 | [`dispatch`](./dispatch.md) | Idea on your phone | Assemble a work order and fire a Claude Code Routine to build it (the autonomous-loop chaining link) |
+| [`dispatch-resolve`](./dispatch-resolve.md) | "work on sector SX" | Resolve a vague sector/lane directive into a concrete work order routed to the right executor (then delegates to `dispatch`) |
 | [`skill-author`](./skill-author.md) | A workflow you repeat / "make a skill for X" | The **meta-skill**: design a new skill and land its source in the repo via a docs-only PR (so Hermes-authored skills are version-controlled, not VPS-only) |
 
 The last two are the **autonomous-improvement-loop seams** — see
@@ -71,9 +75,14 @@ so no restart is needed for that one.
 Hermes loads any `SKILL.md` under `~/.hermes/skills/` on next run — no registration step.
 Alternatively, each prompt is self-contained and works as a plain Telegram message too.
 
-`repo-health` ships a `blueprint.schedule` (`0 8 * * *`) in its frontmatter, so once
-installed Hermes self-schedules the daily health digest to your home channel — no extra
-cron wiring needed.
+Some skills ship a `blueprint.schedule` in their frontmatter, so once installed Hermes
+self-schedules them to your home channel — **no extra VPS cron needed**, and each scheduled
+run is a fresh, stateless session (it never clogs your interactive chat). Currently scheduled:
+**`morning-briefing`** (`0 6 * * *` — the daily digest), **`idea-spotlight`** (`30 6 * * *` —
+the daily idea ritual), and **`review-merge`** (`30 7 * * *` — the needs-hermes-review queue).
+Change a time in `scripts/hermes/build_skills.py` and rebuild. *(For automatically clearing the
+**interactive** chat session, that's a separate VPS timer — see
+[`../hermes-session-reset.md`](../hermes-session-reset.md).)*
 
 ---
 

--- a/docs/operations/hermes-skills/dispatch-resolve.md
+++ b/docs/operations/hermes-skills/dispatch-resolve.md
@@ -1,0 +1,84 @@
+# Skill: `superbot-dispatch-resolve`
+
+> **Status:** `living-ledger` — ready-to-use Hermes skill prompt. The read-side resolver for the
+> dispatch contract. Update it when the sector map, the executor model, or `dispatch_menu.py`
+> change. Provenance: owner-directed 2026-06-16 (greenlit the Hermes-wiring half of the
+> `dispatch-resolution-json-hermes` idea, the read-side of Q-0137 Thread 1).
+
+**Window:** the owner says something vague-but-directive — "work on the bot", "do sector S2 next",
+"advance the AI lane"
+**Purpose:** Turn a loose "work on X" into a **concrete, correctly-scoped work order routed to the
+right runner** — by resolving the live roadmap into the first startable item + its executor, then
+either firing the dispatch routine (Claude work), doing it itself (a Hermes read-only op), or
+handing the owner a manual step. The missing link between "the dispatch menu exists" and "the
+correct worker fires".
+
+**When to use:** whenever the directive names a *sector or lane* rather than a specific task. For a
+specific, already-scoped task go straight to `superbot-dispatch`; for a spoken idea that needs
+shaping first, use `superbot-prompt-builder`.
+
+---
+
+## Prompt
+
+```
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot. Read-only here;
+the only action is firing the dispatch routine via the superbot-dispatch skill (or handing the owner
+a step). GOAL: resolve a vague "work on SX / the bot / lane Y" into a concrete task + the right runner.
+
+1. SYNC: git -C /home/hermes/repos/superbot fetch origin main && \
+         git -C /home/hermes/repos/superbot checkout -B main origin/main
+
+2. RESOLVE the sector(s). If the owner named a sector (S1..S5), pass it; else resolve all and pick:
+   cd /home/hermes/repos/superbot && python3 scripts/dispatch_menu.py --json [SX]
+   Each record is: {sector, name, executor, state, startable_item, source}. The states:
+     - startable                → a ▶ item in Now, run by Claude-in-repo
+     - now_blocked_fallthrough  → Now had no ▶; the item is from Next (still Claude-in-repo)
+     - maintainer_or_hermes     → there is a startable item but the executor is NOT Claude-in-repo
+     - starving                 → no ▶ item anywhere in that sector
+   (S1..S4 are normally Claude-in-repo; S5 Operations is the executor outlier — often Hermes/maintainer.)
+
+3. ROUTE by the resolved executor/state — do NOT fire a repo-editing agent at a non-Claude task:
+   - startable / now_blocked_fallthrough (executor Claude-in-repo):
+       Confirm the item against docs/current-state.md ▶ Next action + the sector's plan (the JSON is
+       a pointer; live state wins). Then hand off to the superbot-dispatch skill with a work order
+       built from `startable_item` (CLASS inferred: fix/ux/docs/correctness/feature). Dispatch fires
+       the routine; it builds/tests/PRs under the CI gates.
+   - maintainer_or_hermes, executor Hermes-VPS:
+       This is a read-only operations task (e.g. log-triage). DO IT YOURSELF with the matching skill;
+       do not fire a Claude routine.
+   - maintainer_or_hermes, executor maintainer (👤):
+       Reply to the owner with the concrete manual step. Do not fire any agent.
+   - starving:
+       No startable item — tell the owner the sector is blocked/empty and suggest a planning pass
+       (a `reconcile` issue or a plan-first slice), rather than inventing work. Never fabricate a task.
+
+4. REPORT: the sector, the resolved item, the executor, and what you DID (fired #PR via dispatch /
+   did it myself / handed the owner a step / flagged starving). One verdict line.
+
+RULES:
+- The roadmap JSON is a HINT; verify against live current-state before firing (Q-0142: pick by
+  description, not a stale PR number). When the menu and live state disagree, live state wins.
+- A dispatched work order is the owner asking → the routine builds it (the phase gate is only for
+  features the routine would INVENT itself). But only resolve+fire off an OWNER directive — never
+  off your own initiative.
+- Never push code yourself; dispatch does the mutation under CI. Keep the safety split intact.
+```
+
+---
+
+## Notes
+
+- **The read-side of Q-0137 Thread 1.** `dispatch_menu.py` (#882) + the Q-0143 contract made the
+  sectors dispatch-*ready* (a human can resolve them by reading a table); `--json` + this skill make
+  them dispatch-*resolved* (Hermes resolves them and routes to the right runner). The owner greenlit
+  the Hermes-wiring half in-session on 2026-06-16; the broader Thread-1 cron-backstop decision stays
+  with the owner.
+- **Thin resolver (skill-author rule).** It computes the task + runner and then *delegates* — to
+  `superbot-dispatch` (fire), an ops atom (do-it-itself), or the owner (manual step). It must not
+  re-implement the dispatch `/fire` body.
+- **Why route by executor.** The #880 dispatch test showed the real failure mode is firing a
+  repo-editing Claude routine at an S5 token/ops task. Routing on the resolved `executor` prevents
+  that — the whole reason `--json` carries the executor field.
+- **Provenance + reliability (Q-0105).** Added 2026-06-16, owner-directed. UNVERIFIED until it has
+  resolved + routed at least one real directive correctly. Delete or revise if it mis-routes.

--- a/docs/operations/hermes-skills/idea-spotlight.md
+++ b/docs/operations/hermes-skills/idea-spotlight.md
@@ -1,0 +1,96 @@
+# Skill: `superbot-idea-spotlight`
+
+> **Status:** `living-ledger` — ready-to-use Hermes skill prompt. Self-schedules a daily
+> "idea of the day". Update it when the idea backlog format or the routing homes change.
+> Provenance: owner-directed 2026-06-16 (the daily idea ritual + EOD report-back loop).
+
+**Window:** once a day (self-scheduled), or any time you want a fresh idea to think about
+**Purpose:** Surface **one** active idea from the backlog each day with the thinking already
+started — a short summary plus **pros, cons/risks, and options/expansions** — so the owner can
+mull it over during the day and report a decision back at the end of it.
+
+**When to use:** it self-fires daily via its `blueprint.schedule`. Invoke it by hand whenever the
+owner asks "what's a good idea to think about?" — and use the **end-of-day loop** below to route
+the owner's verdict when he reports back.
+
+---
+
+## Prompt
+
+```
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Do not modify any files in this skill. Read-only. Keep the whole output under 500 words.
+
+GOAL: present ONE idea from the backlog with the thinking started, so the owner can decide on it
+by end of day.
+
+1. SYNC (so the backlog is fresh): 
+   git -C /home/hermes/repos/superbot fetch origin main && \
+   git -C /home/hermes/repos/superbot checkout -B main origin/main
+
+2. PICK today's idea — let the deterministic selector choose (one per day, rotates the backlog,
+   never your own guess):
+   cd /home/hermes/repos/superbot && python3 scripts/hermes/idea_spotlight.py
+   It prints the title, the file path, the status, and a summary. (Use --json if you want it
+   structured; --list to see the whole active backlog; --date YYYY-MM-DD to re-pick a past day.)
+
+3. READ the picked idea file in full (the path the selector printed). If it names "→ relates"
+   files, skim them read-only to ground your pros/cons — VERIFY against source, never invent a
+   capability the repo doesn't have. Also glance at docs/roadmap.md + docs/owner/
+   maintainer-question-router.md to see if it already has a horizon or an open Q-block.
+
+4. DELIVER the spotlight card in this exact shape:
+
+---
+## 💡 Idea spotlight — [today's date]
+**[idea title]**  ([N] of [M] active · `docs/ideas/<file>`)
+
+**In a line:** [what it is, one sentence]
+**Why it matters:** [the problem it solves / value, one or two lines]
+
+**Pros**
+- [2–4 concrete upsides — be specific, grounded in the repo]
+
+**Cons / risks**
+- [2–4 honest downsides: cost, scope, privacy, maintenance, who-owns-it]
+
+**Options & expansions**
+- [2–4 ways to do it / smaller-first slices / bigger versions — "wherever possible"; if there is
+  only one sensible shape, say so rather than padding]
+
+**Suggested next step:** [the single most useful move — e.g. "ship the small slice", "needs a
+plan", "needs an owner decision (which …?)", "drop it"] · **lane:** [quick-win / plan / discuss / drop]
+
+**↩ Report back when you've thought about it:** reply with build it · roadmap (Now/Next/Later) ·
+discuss · drop · or an expansion — I'll route it.
+---
+
+RULES:
+- One idea only. Skip ideas already badged historical/rejected (the selector already filters these).
+- Honest cons beat a sales pitch — a near-useless idea should read as near-useless.
+- You are NOT building anything here. This is a thinking aid + a decision prompt.
+
+END-OF-DAY LOOP (when the owner replies with a verdict): hand the reply to the `superbot-intake`
+skill — it routes "build it" (owner-directed → dispatch), "roadmap" (horizon), "discuss" (a router
+Q-block), "drop" (rejection ledger), or "expand" (update the idea capture). Confirm where you routed
+it and the one next step. Only the OWNER authorizes a build.
+```
+
+---
+
+## Notes
+
+- **Why a script picks the idea.** Letting the model "choose an interesting idea" is the
+  assemble-the-answer class the BTD6/log-triage fixes closed — it drifts, repeats favourites, and
+  isn't reproducible. `scripts/hermes/idea_spotlight.py` makes the selection **deterministic per
+  day** (so a re-run agrees with itself) and **rotating** (every active idea comes up across one
+  cycle). Hermes does the *reasoning* (pros/cons/options); the script owns the *pick*.
+- **The loop is the point.** The morning card starts the owner thinking; the EOD reply, routed
+  through `intake`, gives the idea a lifecycle move. Over time this drains the backlog one
+  considered decision at a time — the human mirror of the grooming pass.
+- **Self-schedules.** Its `blueprint.schedule` (`30 6 * * *`) is set in
+  `scripts/hermes/build_skills.py`, so once installed Hermes posts it daily to the home channel —
+  no VPS cron. Change the time there and rebuild.
+- **Provenance + reliability (Q-0105).** Added 2026-06-16, owner-directed. UNVERIFIED until a few
+  daily cards have been seen to pick sensibly. Delete or revise if the selector or this prompt
+  proves unreliable.

--- a/docs/operations/hermes-skills/morning-briefing.md
+++ b/docs/operations/hermes-skills/morning-briefing.md
@@ -1,0 +1,86 @@
+# Skill: `superbot-morning-briefing`
+
+> **Status:** `living-ledger` — ready-to-use Hermes skill prompt. Self-schedules one daily digest.
+> Update it when the health checks, the routine fleet, or the decision homes change. Provenance:
+> owner-directed 2026-06-16 ("one message instead of several pings").
+
+**Window:** once each morning (self-scheduled)
+**Purpose:** One consolidated start-of-day digest — repo health, open PRs, recent CI, what the
+autonomous routines did overnight, and any decisions waiting on the owner — so the day starts from
+a single message instead of several separate pings.
+
+**When to use:** it self-fires each morning via its `blueprint.schedule`. Invoke by hand any time
+the owner asks "where are we?" / "what happened overnight?". This is a **thin composite**: it
+chains the cheap checks the atoms already define (`repo-health`, `open-questions`) into one rollup —
+it does not replace them as on-demand tools.
+
+---
+
+## Prompt
+
+```
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Read-only. Produce ONE morning briefing, under 450 words. Use ✅/⚠️/❌ for the health line.
+
+1. SYNC: git -C /home/hermes/repos/superbot fetch origin main && \
+         git -C /home/hermes/repos/superbot checkout -B main origin/main
+
+2. HEALTH (the fast subset of superbot-repo-health — don't re-run all six):
+   cd /home/hermes/repos/superbot
+   python3 scripts/check_docs.py --strict            # docs reachable/fresh?
+   python3 scripts/check_architecture.py --mode strict   # arch errors (warnings are fine)
+   → one ✅/⚠️/❌ line. (For the full traffic-light, point at superbot-repo-health.)
+
+3. PULL REQUESTS + CI:
+   gh pr list --repo menno420/superbot --state open --json number,title,labels,isDraft,headRefName,updatedAt
+   gh run list --repo menno420/superbot --limit 6 --json status,conclusion,headBranch,displayTitle
+   → flag: any `needs-hermes-review` PR (your review-merge queue), any PR older than ~2 days, any
+     recent CI failure (name the branch).
+
+4. OVERNIGHT ROUTINE ACTIVITY (the self-improvement loop — did it run?):
+   gh pr list --repo menno420/superbot --state merged --limit 8 --json number,title,mergedAt
+   → list the claude/* PRs merged since the last briefing (~24h). If none merged and none are open,
+     say so plainly ("loop quiet overnight") — that itself is signal (cron lag or nothing to do).
+
+5. DECISIONS WAITING ON THE OWNER (reuse the superbot-open-questions logic):
+   Scan docs/owner/maintainer-question-router.md for OPEN / DISCUSS Q-blocks awaiting a verdict,
+   and docs/current-state.md ▶ Next action for any "owner-gated" / "👤" item. List the few that
+   actually need HIM (not agent work) — these are the loop's real bottleneck.
+
+6. DELIVER in this shape:
+
+---
+## ☀️ SuperBot morning briefing — [date]
+- **Health:** ✅/⚠️/❌ [one line]
+- **Open PRs:** [count] — [needs-hermes-review / stale flags, or "none"]
+- **CI:** [recent pass/fail summary]
+- **Overnight:** [merged claude/* PRs, or "loop quiet"]
+- **⚑ Waiting on you:** [decisions only the owner can make, or "nothing"]
+- **💡 Idea of the day** is posted separately (superbot-idea-spotlight).
+### Verdict
+[one sentence — is today clear to work in, or does something need you first?]
+---
+
+RULES:
+- Verify, don't assume — every line is from a check above; say "gh unavailable" and mark ⚠️ if it is.
+- Keep it to signal. This is the owner's at-a-glance inbox, not a full report.
+- You take no action here (no merges, no dispatch) — the briefing is a hint; the owner or a
+  dedicated skill (review-merge / dispatch) acts.
+```
+
+---
+
+## Notes
+
+- **Replaces the separate health ping.** `repo-health` previously self-scheduled its own daily
+  digest; the briefing now carries the daily health line, so `repo-health`'s `blueprint.schedule`
+  was removed (it stays a full on-demand traffic-light). This is the "one message instead of
+  several" the owner asked for — re-add `repo-health`'s schedule in `build_skills.py` if you ever
+  want both.
+- **Thin composite (skill-author rule).** It encodes the *decision flow* and runs the cheap checks
+  inline; it references `repo-health` (full health) and `open-questions` (decision scan) rather than
+  duplicating their bodies. If it grows a heavy section, split that section back into its atom.
+- **Self-schedules.** `blueprint.schedule` (`0 6 * * *`) is set in
+  `scripts/hermes/build_skills.py`; the idea spotlight follows 30 min later. Change the times there.
+- **Provenance + reliability (Q-0105).** Added 2026-06-16, owner-directed. UNVERIFIED until a few
+  briefings have been seen to read accurately against live state. Delete or revise if it drifts.

--- a/docs/operations/hermes-skills/skill-author.md
+++ b/docs/operations/hermes-skills/skill-author.md
@@ -66,7 +66,11 @@ STEP 3 — WRITE THE SOURCE. Create docs/operations/hermes-skills/<name>.md in t
   must be a **Purpose:** line and a ## Prompt fenced block.
 
 STEP 4 — REGISTER + BUILD. Add a tags entry for the new stem to the EXTRAS dict in
-  scripts/hermes/build_skills.py (copy a sibling's line). Then regenerate the installable artifact:
+  scripts/hermes/build_skills.py (copy a sibling's line). To make the skill SELF-FIRE on a schedule
+  (like superbot-morning-briefing / superbot-idea-spotlight), add schedule=("<cron>", "<one-line
+  task>") to its EXTRAS entry — Hermes then runs it on that cron and delivers to the home channel,
+  no VPS cron needed, and each scheduled run is a fresh stateless session. Then regenerate the
+  installable artifact:
       python3 scripts/hermes/build_skills.py
       python3 scripts/hermes/build_skills.py --check     # must pass
       python3 scripts/check_docs.py --strict             # reachability/pins

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -32,11 +32,11 @@ living ledger (`docs/current-state.md`).
   (`build_event_detail_view_model` `TypeError`) + current-event-first overview redesign (show only
   the live event + all its info; history behind 📜 Past events) · `services/btd6_view_model_service.py`
   · `views/btd6/live_events_view.py` · `cogs/btd6/_event_helpers.py` · 2026-06-16
-- `claude/peaceful-tesla-vvayya` · Hermes efficiency — new skills (idea-spotlight · morning-briefing
-  · dispatch-resolve) + 6h auto session-reset · `docs/operations/hermes-skills/*` ·
-  `scripts/hermes/{idea_spotlight,session_reset}.*` · `scripts/dispatch_menu.py --json` · 2026-06-16
 
 ## Recently cleared
+
+- `claude/peaceful-tesla-vvayya` · Hermes efficiency — idea-spotlight · morning-briefing ·
+  dispatch-resolve skills + 6h auto session-reset · 2026-06-16 · **PR #959 (auto-merge pending)**
 
 > Trimmed 2026-06-16 (Q-0152): stale claims whose PRs merged are dropped — the durable record is the
 > PR + the `current-state.md` ledger. Keep this to the most recent handful, newest-first.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -32,6 +32,9 @@ living ledger (`docs/current-state.md`).
   (`build_event_detail_view_model` `TypeError`) + current-event-first overview redesign (show only
   the live event + all its info; history behind 📜 Past events) · `services/btd6_view_model_service.py`
   · `views/btd6/live_events_view.py` · `cogs/btd6/_event_helpers.py` · 2026-06-16
+- `claude/peaceful-tesla-vvayya` · Hermes efficiency — new skills (idea-spotlight · morning-briefing
+  · dispatch-resolve) + 6h auto session-reset · `docs/operations/hermes-skills/*` ·
+  `scripts/hermes/{idea_spotlight,session_reset}.*` · `scripts/dispatch_menu.py --json` · 2026-06-16
 
 ## Recently cleared
 

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -5767,3 +5767,40 @@ the full evidence and routing table.
 session — see its block.
 
 **Home:** the files above + this Q-block.
+
+### Q-0153 — Hermes efficiency: new skills (idea-spotlight · morning-briefing · dispatch-resolve) + a 6h interactive session auto-reset (2026-06-16)
+
+> **DECISION 2026-06-16 (owner-directed in-session, applied directly).** The owner asked to make the
+> Hermes control-plane agent more efficient with specialised skills and an automatic chat-session
+> reset, and (via `AskUserQuestion`) chose the specific set below. Recorded for provenance per the
+> CLAUDE.md working agreement (owner decisions get a home). All pieces are docs / Hermes-skill /
+> stdlib-tooling — **free rein**, no executable-config (`.claude/settings.json` / hooks) touched, so
+> no Q-0106 exception is needed; this block is the durable record, not an approval gate.
+
+**What shipped (PR #959):**
+
+- **`superbot-idea-spotlight`** (NEW scheduled skill, the headline ask) — picks **one** active
+  `docs/ideas/` capture per day (deterministic, rotating, via `scripts/hermes/idea_spotlight.py`)
+  and posts a card with **pros · cons/risks · options & expansions**, so the owner can mull it and
+  **report a verdict at end of day**; the EOD reply routes through `superbot-intake`.
+- **`superbot-morning-briefing`** (NEW scheduled skill) — one consolidated morning digest (health ·
+  open PRs · CI · overnight routine activity · decisions waiting on the owner). Absorbs
+  `repo-health`'s former daily schedule — the owner's explicit "**one message instead of several
+  pings**"; `repo-health` stays a full on-demand traffic-light.
+- **`superbot-dispatch-resolve`** (NEW skill) + **`scripts/dispatch_menu.py --json`** — resolves a
+  vague "work on sector SX" into a concrete work order routed by the resolved executor. This is the
+  **Hermes-wiring half** of `dispatch-resolution-json-hermes` (the **Q-0137 Thread 1 read-side**),
+  greenlit here; the broader Thread-1 cron-backstop decision stays owner-undecided.
+- **Interactive session auto-reset every 6h** — `scripts/hermes/session_reset.sh` + the runbook
+  [`hermes-session-reset.md`](../operations/hermes-session-reset.md) (systemd timer, `OnCalendar`
+  every 6h). Owner's rationale: "**never a long session, and the repo updates fast so old context
+  isn't always valuable.**" Scheduled *skills* already run stateless, so this targets only the
+  interactive chat thread.
+
+**Owner manual steps (VPS, off-repo):** re-install the skills + SOUL.md and restart the gateway
+(`install-skills.sh` → `install-soul.sh` → `systemctl restart hermes-gateway`); then wire the 6h
+reset per the runbook (confirm the `HERMES_RESET_CMD` for your Hermes build — the one UNVERIFIED knob).
+
+**Home:** `docs/operations/hermes-skills/{idea-spotlight,morning-briefing,dispatch-resolve}.md` ·
+`docs/operations/hermes-session-reset.md` · `scripts/hermes/{idea_spotlight.py,session_reset.sh}` ·
+`scripts/dispatch_menu.py` · `scripts/hermes/build_skills.py` (EXTRAS) · this Q-block.

--- a/scripts/dispatch_menu.py
+++ b/scripts/dispatch_menu.py
@@ -25,6 +25,7 @@ Usage::
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 from pathlib import Path
@@ -136,6 +137,61 @@ def menu_line(block: str) -> str:
     return "(no ▶ startable item found — check the roadmap)"
 
 
+def sector_record(sid: str, name: str, block: str) -> dict[str, str | None]:
+    """Return the machine-readable resolution for one sector block.
+
+    The JSON sibling of :func:`menu_line` — the read-side of the
+    ``dispatch-resolution-json-hermes`` idea, so the Hermes ``dispatch-resolve``
+    skill can route a vague "work on SX" by the resolved **executor** instead of a
+    human reading a table. ``state`` is one of: ``startable`` (▶ in Now, run by
+    Claude-in-repo) · ``now_blocked_fallthrough`` (Now had no ▶, the item is from
+    Next) · ``maintainer_or_hermes`` (a startable item but the executor isn't
+    Claude-in-repo → don't fire a repo-editing agent) · ``starving`` (no ▶ anywhere).
+    """
+    executor, _ = resolve(block)
+    now_item = first_startable(bullet_text(block, "Now"))
+    next_item = first_startable(bullet_text(block, "Next"))
+    if now_item:
+        item, source = now_item, "Now"
+    elif next_item:
+        item, source = next_item, "Next"
+    else:
+        item, source = None, None
+
+    is_claude = "claude-in-repo" in executor.lower()
+    if item is None:
+        state = "starving"
+    elif not is_claude:
+        state = "maintainer_or_hermes"
+    elif source == "Next":
+        state = "now_blocked_fallthrough"
+    else:
+        state = "startable"
+
+    return {
+        "sector": sid,
+        "name": name,
+        "executor": executor,
+        "state": state,
+        "startable_item": item,
+        "source": source,
+    }
+
+
+def build_records(
+    text: str,
+    only: str | None = None,
+) -> list[dict[str, str | None]]:
+    """Return the structured per-sector resolution (all sectors, or one)."""
+    blocks = sector_blocks(by_sector_section(text))
+    records: list[dict[str, str | None]] = []
+    for sid, name, block in blocks:
+        if only and sid != only:
+            continue
+        records.append(sector_record(sid, name, block))
+    return records
+
+
 def build_menu(text: str, only: str | None = None) -> list[str]:
     """Return the rendered menu lines for all sectors (or one, if ``only`` given)."""
     blocks = sector_blocks(by_sector_section(text))
@@ -161,6 +217,11 @@ def main() -> int:
         nargs="?",
         help="optional single sector id (e.g. S2) to show only that sector",
     )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit the per-sector resolution as JSON (for the dispatch-resolve skill)",
+    )
     args = parser.parse_args()
 
     text = _read(ROADMAP)
@@ -169,6 +230,11 @@ def main() -> int:
         return 1
 
     only = args.sector.upper() if args.sector else None
+
+    if args.json:
+        print(json.dumps(build_records(text, only), indent=2))
+        return 0
+
     print("SuperBot — sector dispatch menu  (live, from docs/roadmap.md § By sector)")
     print("=" * 72)
     for line in build_menu(text, only):

--- a/scripts/hermes/build_skills.py
+++ b/scripts/hermes/build_skills.py
@@ -163,7 +163,15 @@ def _extract_purpose(lines: list[str]) -> str:
 
 
 def _extract_prompt(lines: list[str]) -> str:
-    """Return the first fenced block following the ``## Prompt`` heading."""
+    """Return the first fenced block following the ``## Prompt`` heading.
+
+    The outer fence opens and closes at a **column-0** ```` ``` ````. A skill body
+    may itself contain *indented* nested fences (e.g. ``skill-author`` shows an
+    example skill complete with its own ``## Prompt`` fence) — those are body
+    content, not the boundary. Matching only column-0 fences keeps the whole prompt
+    instead of truncating at the first nested ```` ``` ```` (the bug that silently
+    dropped skill-author's STEP 4/STEP 5 from its generated artifact).
+    """
     in_prompt_section = False
     in_fence = False
     body: list[str] = []
@@ -173,12 +181,11 @@ def _extract_prompt(lines: list[str]) -> str:
             continue
         if not in_prompt_section:
             continue
-        stripped = line.strip()
         if not in_fence:
-            if stripped.startswith("```"):
+            if line.startswith("```"):  # column-0 opener
                 in_fence = True
             continue
-        if stripped == "```":
+        if line.startswith("```"):  # column-0 closer; indented nested fences pass through
             break
         body.append(line)
     return "\n".join(body).strip()

--- a/scripts/hermes/build_skills.py
+++ b/scripts/hermes/build_skills.py
@@ -67,14 +67,38 @@ class SkillExtras:
 # Stem -> extras. Add an entry here when a new skill doc is added.
 EXTRAS: dict[str, SkillExtras] = {
     "session-brief": SkillExtras(tags=["Orientation", "SuperBot", "Planning"]),
-    "repo-health": SkillExtras(
-        tags=["Monitoring", "SuperBot", "Health"],
+    # repo-health stays a full on-demand traffic-light; its daily schedule was
+    # removed 2026-06-16 because superbot-morning-briefing now carries the daily
+    # health line (owner's "one message instead of several pings"). Re-add the
+    # schedule here if both are ever wanted.
+    "repo-health": SkillExtras(tags=["Monitoring", "SuperBot", "Health"]),
+    "ideas-triage": SkillExtras(tags=["Planning", "SuperBot", "Ideas"]),
+    "idea-spotlight": SkillExtras(
+        tags=["Planning", "SuperBot", "Ideas"],
+        related=["superbot-ideas-triage", "superbot-intake"],
         schedule=(
-            "0 8 * * *",
-            "Run a SuperBot repo health check and deliver the traffic-light report.",
+            "30 6 * * *",
+            "Post today's SuperBot idea spotlight: pick one active idea and "
+            "deliver it with pros, cons, and options to think over.",
         ),
     ),
-    "ideas-triage": SkillExtras(tags=["Planning", "SuperBot", "Ideas"]),
+    "morning-briefing": SkillExtras(
+        tags=["Monitoring", "SuperBot", "Briefing"],
+        related=[
+            "superbot-repo-health",
+            "superbot-open-questions",
+            "superbot-idea-spotlight",
+        ],
+        schedule=(
+            "0 6 * * *",
+            "Post the SuperBot morning briefing: health, open PRs, CI, overnight "
+            "routine activity, and any decisions waiting on me.",
+        ),
+    ),
+    "dispatch-resolve": SkillExtras(
+        tags=["Automation", "SuperBot", "Dispatch"],
+        related=["superbot-dispatch", "superbot-prompt-builder"],
+    ),
     "intake": SkillExtras(
         tags=["Triage", "SuperBot", "Routing"],
         related=["superbot-dispatch", "superbot-ideas-triage"],

--- a/scripts/hermes/idea_spotlight.py
+++ b/scripts/hermes/idea_spotlight.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Pick today's SuperBot "idea spotlight" — one active idea, deterministically.
+
+This owns the *mechanical* half of the ``superbot-idea-spotlight`` Hermes skill:
+the **selection** of which idea to surface today, and the extraction of its title /
+status / one-line summary / "relates" hints. The skill prompt then does the
+*reasoning* half (pros, cons, options & expansions) over the idea this script
+picked. Same split as ``log_triage.py`` / ``dispatch_menu.py``: the deterministic
+layer owns the answer the model would otherwise assemble by eyeballing the backlog.
+
+Selection is **deterministic per calendar day** so a re-run on the same day surfaces
+the same idea (idempotent — a scheduled fire and a manual ``--date`` agree), and it
+**rotates** through the whole active backlog as the days advance (index =
+``date.toordinal() % len(active)`` over a name-sorted list, so every active idea is
+covered across one cycle).
+
+"Active" = an idea file whose ``> **Status:** `badge``` is *not* a terminal-lifecycle
+badge (``historical`` / ``rejected`` / ``shipped`` / ``superseded`` / ``done``).
+``ideas`` / ``raw`` / ``captured`` / no-badge all count as active. This mirrors the
+``docs/ideas/`` lifecycle: a capture is re-badged ``historical`` once it ships.
+
+Provenance / reliability header (per CLAUDE.md Q-0105 adopt-with-kill-switch):
+- Why: the owner wants one fresh idea per day to mull over and report back on (live
+  request, 2026-06-16). Picking it by hand is the "model assembles the answer" class;
+  this makes it deterministic, content-free, and testable.
+- Added: 2026-06-16. **Unverified** — confirm a few daily picks look sensible before
+  trusting it unattended. **Delete this script if the ``docs/ideas/`` badge convention
+  changes or it proves unreliable**; it is a disposable convenience reporter, read-only.
+
+Stdlib-only so the unit tests run in CI without installing anything. Invoke with
+**``python3``** (version-agnostic) like the rest of ``scripts/hermes/`` — the Hermes
+VPS has Python 3.11, not the repo's CI-pinned 3.10, and this is a stdlib text tool,
+NOT one of the CI-parity tools. Do not "correct" the usage lines to ``python3.10``.
+
+Usage::
+
+    python3 scripts/hermes/idea_spotlight.py                 # today's pick (markdown)
+    python3 scripts/hermes/idea_spotlight.py --json          # today's pick (JSON)
+    python3 scripts/hermes/idea_spotlight.py --date 2026-06-16
+    python3 scripts/hermes/idea_spotlight.py --list          # all active ideas + indices
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+IDEAS_DIR = REPO_ROOT / "docs" / "ideas"
+
+#: Status badges that mean the idea has reached a terminal lifecycle outcome and
+#: should NOT be spotlighted as live backlog. Everything else counts as active.
+_TERMINAL_BADGES = {"historical", "rejected", "shipped", "superseded", "done"}
+
+_STATUS_RE = re.compile(r">\s*\*\*Status:\*\*\s*`([^`]+)`")
+_TITLE_RE = re.compile(r"^#\s+(.+?)\s*$")
+_RELATES_RE = re.compile(r"(→\s*relates|^##\s+Connections)", re.IGNORECASE)
+
+_MAX_SUMMARY_LEN = 320
+
+
+@dataclass(frozen=True)
+class Idea:
+    """One parsed idea-capture file."""
+
+    path: Path
+    title: str
+    status: str
+    summary: str
+    relates: str
+
+    @property
+    def filename(self) -> str:
+        return self.path.name
+
+    @property
+    def is_active(self) -> bool:
+        return self.status.lower() not in _TERMINAL_BADGES
+
+
+def _first_title(lines: list[str]) -> str:
+    for line in lines:
+        m = _TITLE_RE.match(line)
+        if m:
+            return m.group(1).strip()
+    return "(untitled idea)"
+
+
+def _first_status(text: str) -> str:
+    m = _STATUS_RE.search(text)
+    return m.group(1).strip() if m else ""
+
+
+def _first_summary(lines: list[str]) -> str:
+    """Return the first real prose paragraph (skip title, blockquotes, headings)."""
+    para: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            if para:  # paragraph ended
+                break
+            continue
+        if stripped.startswith(("#", ">", "```", "|", "- ", "* ", "1.")):
+            if para:
+                break
+            continue
+        para.append(stripped)
+    summary = " ".join(para)
+    if len(summary) > _MAX_SUMMARY_LEN:
+        summary = summary[: _MAX_SUMMARY_LEN - 1].rstrip() + "…"
+    return summary
+
+
+def _first_relates(lines: list[str]) -> str:
+    """Return the first 'relates'/'Connections' hint line, if any (trimmed)."""
+    for line in lines:
+        if _RELATES_RE.search(line):
+            hint = line.strip().lstrip("#").strip()
+            return hint[:200]
+    return ""
+
+
+def parse_idea(path: Path) -> Idea:
+    """Parse one ``docs/ideas/<file>.md`` into an :class:`Idea`."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    lines = text.splitlines()
+    return Idea(
+        path=path,
+        title=_first_title(lines),
+        status=_first_status(text),
+        summary=_first_summary(lines),
+        relates=_first_relates(lines),
+    )
+
+
+def load_ideas(ideas_dir: Path) -> list[Idea]:
+    """Load every idea file (excluding README), name-sorted for stable ordering."""
+    files = sorted(p for p in ideas_dir.glob("*.md") if p.name.lower() != "readme.md")
+    return [parse_idea(p) for p in files]
+
+
+def active_ideas(ideas: list[Idea]) -> list[Idea]:
+    """Return only the live-backlog ideas (terminal badges filtered out)."""
+    return [i for i in ideas if i.is_active]
+
+
+def select(ideas: list[Idea], day: _dt.date) -> tuple[int, Idea | None]:
+    """Return ``(index, idea)`` for *day*'s deterministic pick over active ideas.
+
+    Index is ``day.toordinal() % len(active)`` against the name-sorted active list,
+    so the choice is stable per day and cycles through the whole backlog. Returns
+    ``(-1, None)`` when there is nothing active to surface.
+    """
+    active = active_ideas(ideas)
+    if not active:
+        return -1, None
+    index = day.toordinal() % len(active)
+    return index, active[index]
+
+
+def _rel_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def render_markdown(idea: Idea | None, index: int, total: int, day: _dt.date) -> str:
+    """Render the spotlight block the skill reasons over and delivers."""
+    head = f"## 💡 Idea spotlight — {day.isoformat()}"
+    if idea is None:
+        return f"{head}\n\nNo active ideas in the backlog right now. 🎉"
+    out = [
+        head,
+        f"**Idea {index + 1} of {total} active:** {idea.title}",
+        "",
+        f"- **File:** {_rel_path(idea.path)}",
+        f"- **Status:** `{idea.status or 'ideas'}`",
+    ]
+    if idea.relates:
+        out.append(f"- **Relates:** {idea.relates}")
+    if idea.summary:
+        out += ["", idea.summary]
+    return "\n".join(out)
+
+
+def to_dict(idea: Idea | None, index: int, total: int, day: _dt.date) -> dict:
+    """JSON-serialisable view of the pick (``--json``)."""
+    return {
+        "date": day.isoformat(),
+        "total_active": total,
+        "index": index,
+        "idea": (
+            None
+            if idea is None
+            else {
+                "title": idea.title,
+                "file": _rel_path(idea.path),
+                "status": idea.status,
+                "summary": idea.summary,
+                "relates": idea.relates,
+            }
+        ),
+    }
+
+
+def _parse_date(value: str | None) -> _dt.date:
+    if not value:
+        return _dt.datetime.now(_dt.timezone.utc).date()
+    return _dt.date.fromisoformat(value)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Pick today's SuperBot idea spotlight (deterministic per day).",
+    )
+    parser.add_argument(
+        "--date",
+        default=None,
+        help="ISO date (YYYY-MM-DD) to pick for; default: today (UTC)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit JSON instead of markdown",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="list every active idea with its rotation index instead of one pick",
+    )
+    args = parser.parse_args(argv)
+
+    if not IDEAS_DIR.is_dir():
+        print(f"idea_spotlight: cannot find ideas dir at {IDEAS_DIR}")
+        return 1
+
+    day = _parse_date(args.date)
+    ideas = load_ideas(IDEAS_DIR)
+    active = active_ideas(ideas)
+
+    if args.list:
+        if args.json:
+            print(
+                json.dumps(
+                    [
+                        {"index": i, "title": idea.title, "file": _rel_path(idea.path)}
+                        for i, idea in enumerate(active)
+                    ],
+                    indent=2,
+                ),
+            )
+        else:
+            print(f"Active ideas ({len(active)}):")
+            for i, idea in enumerate(active):
+                print(f"  [{i:>3}] {idea.title}  ({_rel_path(idea.path)})")
+        return 0
+
+    index, idea = select(ideas, day)
+    if args.json:
+        print(json.dumps(to_dict(idea, index, len(active), day), indent=2))
+    else:
+        print(render_markdown(idea, index, len(active), day))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/hermes/session_reset.sh
+++ b/scripts/hermes/session_reset.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Reset the Hermes INTERACTIVE chat session on a schedule (so the owner never has
+# to type /new). Run by an every-6h systemd timer (or cron) on the control-plane
+# VPS — full setup in docs/operations/hermes-session-reset.md.
+#
+# WHY: Hermes' interactive Telegram session is one long-lived, accumulating
+# conversation (the gateway re-sends history every turn → cost grows fast, and old
+# context goes stale as the repo moves quickly). A periodic reset keeps every
+# "sitting" fresh and cheap — the automated form of the bounded-session /new habit
+# in docs/operations/hermes-operating-prompt.md. (Scheduled SKILLS already run
+# stateless, so they don't need this — this is only the human chat thread.)
+#
+# WHAT THIS DOES: runs the command that clears the session (HERMES_RESET_CMD) and
+# logs the result. It is the SAFE WRAPPER (scheduling + logging + a no-op when
+# unconfigured) — you supply the one reset command for your Hermes version.
+#
+# THE ONE UNVERIFIED KNOB (confirm on the VPS, like apply_context_fixes.sh):
+# the exact way to clear the session depends on your Hermes build. Set it in
+# ~/.hermes/reset.env (chmod 600), e.g.:
+#     HERMES_RESET_CMD="hermes session new"      # if the CLI exposes it
+#     # or whatever your `hermes --help` / gateway docs show as the /new equivalent
+# Discover candidates with:  hermes --help ; hermes session --help ; hermes chat --help
+# If HERMES_RESET_CMD is unset, this script is a logged no-op (never an error), so
+# the timer won't spam failures before you've configured it.
+#
+# USAGE (on the VPS, as the `hermes` user):
+#   bash scripts/hermes/session_reset.sh            # do the reset (or no-op if unconfigured)
+#   bash scripts/hermes/session_reset.sh --dry-run  # show what it would run
+#
+# Invoke with bash (the VPS shell), not the CI-pinned python toolchain.
+# Provenance: added 2026-06-16, owner-directed (reset every 6h; "repo updates fast,
+# old session context is not always valuable"). Kill-switch (Q-0105): disposable
+# operator convenience — `systemctl --user disable --now hermes-session-reset.timer`
+# to stop it; delete this script if the reset mechanism changes upstream.
+set -uo pipefail
+
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h | --help)
+      sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+RESET_ENV="$HERMES_HOME/reset.env"
+RESET_LOG="${HERMES_RESET_LOG:-$HERMES_HOME/reset.log}"
+
+# Load the owner-confirmed reset command (and optional overrides) if present.
+# shellcheck disable=SC1090
+[[ -f "$RESET_ENV" ]] && source "$RESET_ENV"
+RESET_CMD="${HERMES_RESET_CMD:-}"
+
+now() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+log() { printf '%s %s\n' "$(now)" "$*" | tee -a "$RESET_LOG" >/dev/null 2>&1 || true; }
+
+mkdir -p "$HERMES_HOME" 2>/dev/null || true
+
+if [[ -z "$RESET_CMD" ]]; then
+  msg="session-reset SKIPPED — HERMES_RESET_CMD not set in $RESET_ENV (see docs/operations/hermes-session-reset.md)"
+  log "$msg"
+  echo "$msg"
+  exit 0  # a no-op, not a failure — don't make the timer report errors pre-config
+fi
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "would run: $RESET_CMD"
+  echo "would log to: $RESET_LOG"
+  exit 0
+fi
+
+log "session-reset RUNNING: $RESET_CMD"
+if out="$(bash -c "$RESET_CMD" 2>&1)"; then
+  log "session-reset OK"
+  [[ -n "$out" ]] && log "  output: ${out:0:200}"
+  echo "session reset OK ($(now))"
+else
+  rc=$?
+  log "session-reset FAILED (exit $rc): ${out:0:200}"
+  echo "session reset FAILED (exit $rc) — see $RESET_LOG" >&2
+  exit 0  # still exit 0: a transient reset failure should not red-flag the timer
+fi

--- a/scripts/hermes/skills/dispatch-resolve/SKILL.md
+++ b/scripts/hermes/skills/dispatch-resolve/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: superbot-dispatch-resolve
+description: "Turn a loose \"work on X\" into a **concrete, correctly-scoped work order routed to the right runner** — by resolving the live roadmap into the first startable item + its executor, then either firing the dispatch routine (Claude work), doing it itself (a Hermes read-only op), or handing the owner a manual step. The missing link between \"the dispatch menu exists\" and \"the correct worker fires\"."
+version: 1.0.0
+author: "SuperBot agents"
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Automation, SuperBot, Dispatch]
+    related_skills: [superbot-dispatch, superbot-prompt-builder]
+---
+
+<!-- GENERATED — DO NOT EDIT. Source of truth: docs/operations/hermes-skills/dispatch-resolve.md. Regenerate with scripts/hermes/build_skills.py. -->
+
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot. Read-only here;
+the only action is firing the dispatch routine via the superbot-dispatch skill (or handing the owner
+a step). GOAL: resolve a vague "work on SX / the bot / lane Y" into a concrete task + the right runner.
+
+1. SYNC: git -C /home/hermes/repos/superbot fetch origin main && \
+         git -C /home/hermes/repos/superbot checkout -B main origin/main
+
+2. RESOLVE the sector(s). If the owner named a sector (S1..S5), pass it; else resolve all and pick:
+   cd /home/hermes/repos/superbot && python3 scripts/dispatch_menu.py --json [SX]
+   Each record is: {sector, name, executor, state, startable_item, source}. The states:
+     - startable                → a ▶ item in Now, run by Claude-in-repo
+     - now_blocked_fallthrough  → Now had no ▶; the item is from Next (still Claude-in-repo)
+     - maintainer_or_hermes     → there is a startable item but the executor is NOT Claude-in-repo
+     - starving                 → no ▶ item anywhere in that sector
+   (S1..S4 are normally Claude-in-repo; S5 Operations is the executor outlier — often Hermes/maintainer.)
+
+3. ROUTE by the resolved executor/state — do NOT fire a repo-editing agent at a non-Claude task:
+   - startable / now_blocked_fallthrough (executor Claude-in-repo):
+       Confirm the item against docs/current-state.md ▶ Next action + the sector's plan (the JSON is
+       a pointer; live state wins). Then hand off to the superbot-dispatch skill with a work order
+       built from `startable_item` (CLASS inferred: fix/ux/docs/correctness/feature). Dispatch fires
+       the routine; it builds/tests/PRs under the CI gates.
+   - maintainer_or_hermes, executor Hermes-VPS:
+       This is a read-only operations task (e.g. log-triage). DO IT YOURSELF with the matching skill;
+       do not fire a Claude routine.
+   - maintainer_or_hermes, executor maintainer (👤):
+       Reply to the owner with the concrete manual step. Do not fire any agent.
+   - starving:
+       No startable item — tell the owner the sector is blocked/empty and suggest a planning pass
+       (a `reconcile` issue or a plan-first slice), rather than inventing work. Never fabricate a task.
+
+4. REPORT: the sector, the resolved item, the executor, and what you DID (fired #PR via dispatch /
+   did it myself / handed the owner a step / flagged starving). One verdict line.
+
+RULES:
+- The roadmap JSON is a HINT; verify against live current-state before firing (Q-0142: pick by
+  description, not a stale PR number). When the menu and live state disagree, live state wins.
+- A dispatched work order is the owner asking → the routine builds it (the phase gate is only for
+  features the routine would INVENT itself). But only resolve+fire off an OWNER directive — never
+  off your own initiative.
+- Never push code yourself; dispatch does the mutation under CI. Keep the safety split intact.

--- a/scripts/hermes/skills/idea-spotlight/SKILL.md
+++ b/scripts/hermes/skills/idea-spotlight/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: superbot-idea-spotlight
+description: "Surface **one** active idea from the backlog each day with the thinking already started — a short summary plus **pros, cons/risks, and options/expansions** — so the owner can mull it over during the day and report a decision back at the end of it."
+version: 1.0.0
+author: "SuperBot agents"
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Planning, SuperBot, Ideas]
+    related_skills: [superbot-ideas-triage, superbot-intake]
+    blueprint:
+      schedule: "30 6 * * *"
+      deliver: origin
+      prompt: "Post today's SuperBot idea spotlight: pick one active idea and deliver it with pros, cons, and options to think over."
+      no_agent: false
+---
+
+<!-- GENERATED — DO NOT EDIT. Source of truth: docs/operations/hermes-skills/idea-spotlight.md. Regenerate with scripts/hermes/build_skills.py. -->
+
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Do not modify any files in this skill. Read-only. Keep the whole output under 500 words.
+
+GOAL: present ONE idea from the backlog with the thinking started, so the owner can decide on it
+by end of day.
+
+1. SYNC (so the backlog is fresh): 
+   git -C /home/hermes/repos/superbot fetch origin main && \
+   git -C /home/hermes/repos/superbot checkout -B main origin/main
+
+2. PICK today's idea — let the deterministic selector choose (one per day, rotates the backlog,
+   never your own guess):
+   cd /home/hermes/repos/superbot && python3 scripts/hermes/idea_spotlight.py
+   It prints the title, the file path, the status, and a summary. (Use --json if you want it
+   structured; --list to see the whole active backlog; --date YYYY-MM-DD to re-pick a past day.)
+
+3. READ the picked idea file in full (the path the selector printed). If it names "→ relates"
+   files, skim them read-only to ground your pros/cons — VERIFY against source, never invent a
+   capability the repo doesn't have. Also glance at docs/roadmap.md + docs/owner/
+   maintainer-question-router.md to see if it already has a horizon or an open Q-block.
+
+4. DELIVER the spotlight card in this exact shape:
+
+---
+## 💡 Idea spotlight — [today's date]
+**[idea title]**  ([N] of [M] active · `docs/ideas/<file>`)
+
+**In a line:** [what it is, one sentence]
+**Why it matters:** [the problem it solves / value, one or two lines]
+
+**Pros**
+- [2–4 concrete upsides — be specific, grounded in the repo]
+
+**Cons / risks**
+- [2–4 honest downsides: cost, scope, privacy, maintenance, who-owns-it]
+
+**Options & expansions**
+- [2–4 ways to do it / smaller-first slices / bigger versions — "wherever possible"; if there is
+  only one sensible shape, say so rather than padding]
+
+**Suggested next step:** [the single most useful move — e.g. "ship the small slice", "needs a
+plan", "needs an owner decision (which …?)", "drop it"] · **lane:** [quick-win / plan / discuss / drop]
+
+**↩ Report back when you've thought about it:** reply with build it · roadmap (Now/Next/Later) ·
+discuss · drop · or an expansion — I'll route it.
+---
+
+RULES:
+- One idea only. Skip ideas already badged historical/rejected (the selector already filters these).
+- Honest cons beat a sales pitch — a near-useless idea should read as near-useless.
+- You are NOT building anything here. This is a thinking aid + a decision prompt.
+
+END-OF-DAY LOOP (when the owner replies with a verdict): hand the reply to the `superbot-intake`
+skill — it routes "build it" (owner-directed → dispatch), "roadmap" (horizon), "discuss" (a router
+Q-block), "drop" (rejection ledger), or "expand" (update the idea capture). Confirm where you routed
+it and the one next step. Only the OWNER authorizes a build.

--- a/scripts/hermes/skills/morning-briefing/SKILL.md
+++ b/scripts/hermes/skills/morning-briefing/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: superbot-morning-briefing
+description: "One consolidated start-of-day digest — repo health, open PRs, recent CI, what the autonomous routines did overnight, and any decisions waiting on the owner — so the day starts from a single message instead of several separate pings."
+version: 1.0.0
+author: "SuperBot agents"
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Monitoring, SuperBot, Briefing]
+    related_skills: [superbot-repo-health, superbot-open-questions, superbot-idea-spotlight]
+    blueprint:
+      schedule: "0 6 * * *"
+      deliver: origin
+      prompt: "Post the SuperBot morning briefing: health, open PRs, CI, overnight routine activity, and any decisions waiting on me."
+      no_agent: false
+---
+
+<!-- GENERATED — DO NOT EDIT. Source of truth: docs/operations/hermes-skills/morning-briefing.md. Regenerate with scripts/hermes/build_skills.py. -->
+
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Read-only. Produce ONE morning briefing, under 450 words. Use ✅/⚠️/❌ for the health line.
+
+1. SYNC: git -C /home/hermes/repos/superbot fetch origin main && \
+         git -C /home/hermes/repos/superbot checkout -B main origin/main
+
+2. HEALTH (the fast subset of superbot-repo-health — don't re-run all six):
+   cd /home/hermes/repos/superbot
+   python3 scripts/check_docs.py --strict            # docs reachable/fresh?
+   python3 scripts/check_architecture.py --mode strict   # arch errors (warnings are fine)
+   → one ✅/⚠️/❌ line. (For the full traffic-light, point at superbot-repo-health.)
+
+3. PULL REQUESTS + CI:
+   gh pr list --repo menno420/superbot --state open --json number,title,labels,isDraft,headRefName,updatedAt
+   gh run list --repo menno420/superbot --limit 6 --json status,conclusion,headBranch,displayTitle
+   → flag: any `needs-hermes-review` PR (your review-merge queue), any PR older than ~2 days, any
+     recent CI failure (name the branch).
+
+4. OVERNIGHT ROUTINE ACTIVITY (the self-improvement loop — did it run?):
+   gh pr list --repo menno420/superbot --state merged --limit 8 --json number,title,mergedAt
+   → list the claude/* PRs merged since the last briefing (~24h). If none merged and none are open,
+     say so plainly ("loop quiet overnight") — that itself is signal (cron lag or nothing to do).
+
+5. DECISIONS WAITING ON THE OWNER (reuse the superbot-open-questions logic):
+   Scan docs/owner/maintainer-question-router.md for OPEN / DISCUSS Q-blocks awaiting a verdict,
+   and docs/current-state.md ▶ Next action for any "owner-gated" / "👤" item. List the few that
+   actually need HIM (not agent work) — these are the loop's real bottleneck.
+
+6. DELIVER in this shape:
+
+---
+## ☀️ SuperBot morning briefing — [date]
+- **Health:** ✅/⚠️/❌ [one line]
+- **Open PRs:** [count] — [needs-hermes-review / stale flags, or "none"]
+- **CI:** [recent pass/fail summary]
+- **Overnight:** [merged claude/* PRs, or "loop quiet"]
+- **⚑ Waiting on you:** [decisions only the owner can make, or "nothing"]
+- **💡 Idea of the day** is posted separately (superbot-idea-spotlight).
+### Verdict
+[one sentence — is today clear to work in, or does something need you first?]
+---
+
+RULES:
+- Verify, don't assume — every line is from a check above; say "gh unavailable" and mark ⚠️ if it is.
+- Keep it to signal. This is the owner's at-a-glance inbox, not a full report.
+- You take no action here (no merges, no dispatch) — the briefing is a hint; the owner or a
+  dedicated skill (review-merge / dispatch) acts.

--- a/scripts/hermes/skills/repo-health/SKILL.md
+++ b/scripts/hermes/skills/repo-health/SKILL.md
@@ -8,11 +8,6 @@ platforms: [linux, macos]
 metadata:
   hermes:
     tags: [Monitoring, SuperBot, Health]
-    blueprint:
-      schedule: "0 8 * * *"
-      deliver: origin
-      prompt: "Run a SuperBot repo health check and deliver the traffic-light report."
-      no_agent: false
 ---
 
 <!-- GENERATED — DO NOT EDIT. Source of truth: docs/operations/hermes-skills/repo-health.md. Regenerate with scripts/hermes/build_skills.py. -->

--- a/scripts/hermes/skills/skill-author/SKILL.md
+++ b/scripts/hermes/skills/skill-author/SKILL.md
@@ -44,3 +44,38 @@ STEP 3 — WRITE THE SOURCE. Create docs/operations/hermes-skills/<name>.md in t
       > **Status:** `living-ledger` — <one line>.
       **Window:** ...   **Purpose:** <one sentence — the builder lifts this verbatim>
       **When to use:** ...
+      ```
+      <the skill's prompt body — the instructions you will follow when it runs>
+      ```
+      ## Notes
+      <why it exists, gotchas>
+  Requirements the builder enforces: the H1 must contain `superbot-<name>` in backticks; there
+  must be a **Purpose:** line and a ## Prompt fenced block.
+
+STEP 4 — REGISTER + BUILD. Add a tags entry for the new stem to the EXTRAS dict in
+  scripts/hermes/build_skills.py (copy a sibling's line). To make the skill SELF-FIRE on a schedule
+  (like superbot-morning-briefing / superbot-idea-spotlight), add schedule=("<cron>", "<one-line
+  task>") to its EXTRAS entry — Hermes then runs it on that cron and delivers to the home channel,
+  no VPS cron needed, and each scheduled run is a fresh stateless session. Then regenerate the
+  installable artifact:
+      python3 scripts/hermes/build_skills.py
+      python3 scripts/hermes/build_skills.py --check     # must pass
+      python3 scripts/check_docs.py --strict             # reachability/pins
+  (build_skills.py edits scripts/hermes/build_skills.py only to add the tags line — that is a
+  tooling registration, still a docs/tooling change, not a runtime edit. If you are unsure, ask.)
+
+STEP 5 — LAND IT (your docs-only PR). Branch, commit the new doc + its generated SKILL.md +
+  the EXTRAS line, push, and open a docs-only PR:
+      git checkout -b hermes/skill-<name>
+      git add docs/operations/hermes-skills/<name>.md scripts/hermes/skills/<name>/ scripts/hermes/build_skills.py
+      git commit -m "docs(hermes): add superbot-<name> skill"
+      git push -u origin hermes/skill-<name>
+      gh pr create --repo menno420/superbot --title "docs(hermes): add superbot-<name> skill" --body "<what it does + why>"
+  Report the PR link and ping me. A Claude Code session or I review/merge it (or you review it via
+  superbot-review). Once merged, install on the VPS with scripts/hermes/install-skills.sh.
+
+RULES:
+- Docs-only. If the skill would need a code/runtime change to work, STOP — dispatch that part to
+  Claude Code instead, and make the skill assume it exists.
+- One skill per PR. Don't bundle.
+- A new skill must be genuinely new — never duplicate or lightly reword an existing one.

--- a/tests/unit/scripts/test_build_skills.py
+++ b/tests/unit/scripts/test_build_skills.py
@@ -50,13 +50,20 @@ def test_required_frontmatter_present(path: Path, content: str) -> None:
     assert len(body) > 100, f"{path.name}: prompt body looks empty"
 
 
-def test_repo_health_self_schedules() -> None:
+def test_morning_briefing_self_schedules() -> None:
     rendered = build_skills.build_all()
-    health = next(p for p in rendered if p.parent.name == "repo-health")
-    content = rendered[health]
+    briefing = next(p for p in rendered if p.parent.name == "morning-briefing")
+    content = rendered[briefing]
     assert "blueprint:" in content
     assert "schedule:" in content
     assert "deliver: origin" in content
+
+
+def test_idea_spotlight_self_schedules() -> None:
+    rendered = build_skills.build_all()
+    spotlight = next(p for p in rendered if p.parent.name == "idea-spotlight")
+    content = rendered[spotlight]
+    assert "blueprint:" in content and "schedule:" in content
 
 
 def test_committed_artifacts_are_fresh() -> None:

--- a/tests/unit/scripts/test_build_skills.py
+++ b/tests/unit/scripts/test_build_skills.py
@@ -66,6 +66,39 @@ def test_idea_spotlight_self_schedules() -> None:
     assert "blueprint:" in content and "schedule:" in content
 
 
+def test_nested_fences_do_not_truncate_prompt() -> None:
+    """An indented nested fence in a prompt body must not close the outer fence.
+
+    Guards the skill-author truncation bug: its STEP 3 shows an example skill
+    (with its own ``## Prompt`` ``` fences), which used to cut extraction short.
+    """
+    sample = [
+        "# Skill: `superbot-x`",
+        "**Purpose:** test.",
+        "## Prompt",
+        "```",
+        "do a thing",
+        "      ```",  # indented nested example fence — must NOT close the outer one
+        "      nested example body",
+        "      ```",
+        "do another thing after the nested block",
+        "```",
+        "## Notes",
+    ]
+    body = build_skills._extract_prompt(sample)
+    assert "do a thing" in body
+    assert "nested example body" in body
+    assert "do another thing after the nested block" in body  # survived the nested fence
+
+
+def test_skill_author_keeps_all_steps() -> None:
+    """skill-author's generated prompt must include its later steps (regression)."""
+    rendered = build_skills.build_all()
+    author = next(p for p in rendered if p.parent.name == "skill-author")
+    content = rendered[author]
+    assert "STEP 4" in content and "STEP 5" in content
+
+
 def test_committed_artifacts_are_fresh() -> None:
     """Committed SKILL.md files must match a fresh build (run the builder)."""
     rc = build_skills.main(["--check"])

--- a/tests/unit/scripts/test_dispatch_menu.py
+++ b/tests/unit/scripts/test_dispatch_menu.py
@@ -71,3 +71,67 @@ def test_build_menu_single_sector_filter():
     joined = "\n".join(lines)
     assert "S2" in joined
     assert "S1  Bot product" not in joined
+
+
+def test_sector_record_startable_now_run_by_claude():
+    block = (
+        "### S2 — BTD6 · exec\n"
+        "- **Dispatch:** executor **Claude-in-repo**\n"
+        "- **Now:** **▶ go now** (foo)\n"
+        "- **Next:** y\n"
+    )
+    rec = dm.sector_record("S2", "BTD6", block)
+    assert rec["state"] == "startable"
+    assert rec["startable_item"] == "go now"
+    assert rec["source"] == "Now"
+    assert rec["executor"] == "Claude-in-repo"
+
+
+def test_sector_record_falls_through_to_next():
+    block = (
+        "### S1 — Bot · exec\n"
+        "- **Dispatch:** executor **Claude-in-repo**\n"
+        "- **Now:** **⛔ a** · **👤 b**\n"
+        "- **Next:** the **▶ real thing** (foo)\n"
+    )
+    rec = dm.sector_record("S1", "Bot", block)
+    assert rec["state"] == "now_blocked_fallthrough"
+    assert rec["source"] == "Next"
+    assert "real thing" in rec["startable_item"]
+
+
+def test_sector_record_non_claude_executor_is_routed_away():
+    block = (
+        "### S5 — Operations · exec\n"
+        "- **Dispatch:** executor **Hermes-VPS**\n"
+        "- **Now:** **▶ tail the logs** (foo)\n"
+    )
+    rec = dm.sector_record("S5", "Operations", block)
+    assert rec["state"] == "maintainer_or_hermes"
+    assert rec["executor"] == "Hermes-VPS"
+
+
+def test_sector_record_starving_when_no_startable():
+    block = (
+        "### S3 — AI · exec\n"
+        "- **Dispatch:** executor **Claude-in-repo**\n"
+        "- **Now:** **⛔ a**\n"
+        "- **Next:** also ⛔ blocked\n"
+    )
+    rec = dm.sector_record("S3", "AI", block)
+    assert rec["state"] == "starving"
+    assert rec["startable_item"] is None
+
+
+def test_build_records_covers_live_roadmap_sectors():
+    text = (_REPO / "docs" / "roadmap.md").read_text(encoding="utf-8")
+    records = dm.build_records(text)
+    sectors = {r["sector"] for r in records}
+    assert {"S1", "S2", "S3", "S4", "S5"} <= sectors
+    for r in records:
+        assert r["state"] in {
+            "startable",
+            "now_blocked_fallthrough",
+            "maintainer_or_hermes",
+            "starving",
+        }

--- a/tests/unit/scripts/test_idea_spotlight.py
+++ b/tests/unit/scripts/test_idea_spotlight.py
@@ -1,0 +1,138 @@
+"""Tests for ``scripts/hermes/idea_spotlight.py``.
+
+Guards the deterministic idea-of-the-day selector: active/terminal filtering, a
+stable per-day pick that rotates through the whole backlog, and the parse/render
+shapes the ``superbot-idea-spotlight`` skill reasons over.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = REPO_ROOT / "scripts" / "hermes" / "idea_spotlight.py"
+
+_spec = importlib.util.spec_from_file_location("idea_spotlight", _SCRIPT)
+assert _spec and _spec.loader
+spotlight = importlib.util.module_from_spec(_spec)
+# Register before exec so @dataclass can resolve the module via sys.modules
+# (mirrors tests/unit/scripts/test_build_skills.py).
+sys.modules["idea_spotlight"] = spotlight
+_spec.loader.exec_module(spotlight)
+
+
+def _write_backlog(tmp_path: Path) -> Path:
+    ideas = tmp_path / "ideas"
+    ideas.mkdir()
+    (ideas / "active1.md").write_text(
+        "# Idea: alpha\n\n"
+        "> **Status:** `ideas` — captured 2026-06-16.\n\n"
+        "## The idea\n\n"
+        "This is the alpha idea body explaining what it does.\n\n"
+        "→ relates `services/foo.py`\n",
+        encoding="utf-8",
+    )
+    (ideas / "active2.md").write_text(
+        "# Beta idea\n\n> **Status:** `raw`\n\nBeta body paragraph.\n",
+        encoding="utf-8",
+    )
+    (ideas / "active3.md").write_text(
+        "# Gamma idea\n\nNo status badge here — still an active capture.\n",
+        encoding="utf-8",
+    )
+    (ideas / "done1.md").write_text(
+        "# Old shipped idea\n\n> **Status:** `historical` — EXECUTED (#123).\n\nbody\n",
+        encoding="utf-8",
+    )
+    (ideas / "done2.md").write_text(
+        "# Bad idea\n\n> **Status:** `rejected`\n\nbody\n", encoding="utf-8"
+    )
+    # README must be excluded from the backlog.
+    (ideas / "README.md").write_text("# Index\n\n- [a](./active1.md)\n", encoding="utf-8")
+    return ideas
+
+
+def test_parse_extracts_title_status_summary_relates(tmp_path: Path) -> None:
+    ideas = _write_backlog(tmp_path)
+    idea = spotlight.parse_idea(ideas / "active1.md")
+    assert idea.title == "Idea: alpha"
+    assert idea.status == "ideas"
+    assert idea.summary == "This is the alpha idea body explaining what it does."
+    assert "relates" in idea.relates and "services/foo.py" in idea.relates
+    assert idea.is_active is True
+
+
+def test_active_filter_drops_terminal_badges(tmp_path: Path) -> None:
+    ideas = spotlight.load_ideas(_write_backlog(tmp_path))
+    active = spotlight.active_ideas(ideas)
+    titles = {i.title for i in active}
+    assert titles == {"Idea: alpha", "Beta idea", "Gamma idea"}
+    # README, historical and rejected are excluded.
+    assert "Old shipped idea" not in titles
+    assert "Bad idea" not in titles
+
+
+def test_no_status_badge_counts_as_active(tmp_path: Path) -> None:
+    ideas = spotlight.load_ideas(_write_backlog(tmp_path))
+    gamma = next(i for i in ideas if i.title == "Gamma idea")
+    assert gamma.status == ""
+    assert gamma.is_active is True
+
+
+def test_select_is_deterministic_per_day(tmp_path: Path) -> None:
+    ideas = spotlight.load_ideas(_write_backlog(tmp_path))
+    day = dt.date(2026, 6, 16)
+    first = spotlight.select(ideas, day)
+    second = spotlight.select(ideas, day)
+    assert first == second
+    idx, idea = first
+    assert idea is not None and 0 <= idx < 3
+
+
+def test_select_rotates_through_whole_backlog(tmp_path: Path) -> None:
+    ideas = spotlight.load_ideas(_write_backlog(tmp_path))
+    base = dt.date(2026, 6, 16)
+    picked = {
+        spotlight.select(ideas, base + dt.timedelta(days=d))[1].title  # type: ignore[union-attr]
+        for d in range(3)
+    }
+    # Three active ideas → three consecutive days cover all of them.
+    assert picked == {"Idea: alpha", "Beta idea", "Gamma idea"}
+
+
+def test_select_empty_backlog(tmp_path: Path) -> None:
+    empty = tmp_path / "ideas"
+    empty.mkdir()
+    idx, idea = spotlight.select(spotlight.load_ideas(empty), dt.date(2026, 6, 16))
+    assert idx == -1 and idea is None
+
+
+def test_to_dict_and_markdown_shapes(tmp_path: Path) -> None:
+    ideas = spotlight.load_ideas(_write_backlog(tmp_path))
+    day = dt.date(2026, 6, 16)
+    idx, idea = spotlight.select(ideas, day)
+    payload = spotlight.to_dict(idea, idx, len(spotlight.active_ideas(ideas)), day)
+    assert payload["date"] == "2026-06-16"
+    assert payload["total_active"] == 3
+    assert payload["idea"]["title"] == idea.title  # type: ignore[union-attr]
+
+    md = spotlight.render_markdown(idea, idx, 3, day)
+    assert "💡 Idea spotlight — 2026-06-16" in md
+    assert idea.title in md  # type: ignore[union-attr]
+
+
+def test_markdown_empty_backlog_is_friendly() -> None:
+    md = spotlight.render_markdown(None, -1, 0, dt.date(2026, 6, 16))
+    assert "No active ideas" in md
+
+
+def test_repo_backlog_builds_a_real_pick() -> None:
+    """Smoke test against the live docs/ideas backlog (not a fixture)."""
+    ideas = spotlight.load_ideas(spotlight.IDEAS_DIR)
+    assert ideas, "expected real idea files"
+    idx, idea = spotlight.select(ideas, dt.date(2026, 6, 16))
+    # The live backlog always has at least one active idea.
+    assert idea is not None and idea.is_active


### PR DESCRIPTION
## Why

Owner-requested (live, this session): make the Hermes control-plane agent more efficient — more
specialised skills, a **daily idea-of-the-day** ritual, and an **automatic session reset** so the
owner doesn't type `/new` each time.

## What

**Core**
- **`idea-spotlight`** (NEW scheduled skill) — picks **one** active idea from `docs/ideas/` each day
  and posts a structured card: summary · why it matters · **pros · cons/risks · options & expansions**
  · suggested next step · routing lane. The owner mulls it during the day and **reports back at EOD**;
  the reply routes through the existing `intake` skill. Backed by a deterministic, content-free
  selector `scripts/hermes/idea_spotlight.py` (+ unit tests).
- **End-of-day report-back loop** documented in the skill: owner's verdict → `intake` → roadmap /
  plan / router Q / reject.

**Owner-chosen extras**
- **`morning-briefing`** (NEW scheduled skill) — one consolidated morning digest (health · open PRs ·
  CI · overnight routine activity · decisions waiting on you · pointer to today's spotlight). Absorbs
  `repo-health`'s daily schedule (one ping instead of several); `repo-health` stays on-demand.
- **`dispatch-resolve`** (NEW skill) + **`scripts/dispatch_menu.py --json`** — resolve a vague "work on
  sector SX" into a concrete work order routed by the resolved executor. This is the read-side of the
  captured `dispatch-resolution-json-hermes` idea; owner greenlit the Hermes-wiring half this session.

**Auto session-reset every 6h**
- `scripts/hermes/session_reset.sh` + `docs/operations/hermes-session-reset.md` (systemd-timer
  runbook, `OnCalendar` every 6h). VPS-side; the owner installs it. The one unverified knob (the exact
  Hermes reset invocation) is documented — same posture as `apply_context_fixes.sh`.

**Supporting:** `build_skills.py` EXTRAS for the 3 new skills, regenerated `SKILL.md` artifacts,
updated skill-pack README + operating prompt, dispatch-resolution idea marked executed, owner
in-session decisions recorded in the question router.

## Safety / scope

Docs + Hermes skill files + two stdlib scripts + tests only — **no `disbot/` runtime, no migrations,
no DB, no production touch.** All Hermes-side changes are version-controlled here; the owner installs
them on the VPS via the existing `install-skills.sh` / `install-soul.sh` flow.

## Status

Born-red (Q-0133): the `.sessions/` card is `in-progress` until the work is complete; flipped to
`complete` as the final step so auto-merge fires only on a finished PR.

https://claude.ai/code/session_011Add2RPDWutS7643URURns

---
_Generated by [Claude Code](https://claude.ai/code/session_011Add2RPDWutS7643URURns)_