### PR TITLE
tooling: thin repo-wide architecture atlas + role in context_map (PR 2, Q-0151a)

### DIFF
--- a/.sessions/2026-06-16-thin-architecture-atlas.md
+++ b/.sessions/2026-06-16-thin-architecture-atlas.md
@@ -1,0 +1,60 @@
+# Session — thin architecture atlas (PR 2) + role in context_map
+
+> **Status:** `in-progress` — born-red per Q-0133; flips to `complete` as the final step.
+> **Date:** 2026-06-16 · **Branch:** `claude/hopeful-meitner-772pv8` · **PR:** #959
+
+## What I did
+
+PR 2 of the architecture-atlas plan
+([plan](../docs/planning/extension-taxonomy-crosswalk-plan-2026-06-16.md), owner-approved Q-0151a:
+*"I agree with your recommendations, and the readme is not required but not off limits"*). PR 1 (the
+extension-taxonomy crosswalk) shipped in #958.
+
+1. **`scripts/atlas.py`** — a *thin composer* (do-not-duplicate): imports `context_map`,
+   `_review_units`, and `extension_crosswalk` as libraries and emits a repo-wide, provenance-stamped
+   index (file → layer · review-unit · role · backs · registered · importers · tests). `--check` is a
+   composite coherence guard (delegates classification to `extension_crosswalk.check()`, adds the
+   extension-file-exists + buildability/orphan smoke check). Body **not committed** (on-demand + CI
+   `--check`, per Q-0151a). Reuse gate: never re-implements a fact a sibling tool already produces.
+2. **`scripts/context_map.py`** — surface each cog file's `role`/backing-subsystem (the down-payment;
+   agents run context_map before editing).
+3. **`docs/architecture/repo-atlas.md`** — a short *curated* companion pointer (what it answers, how to
+   run, relation to the context-pack system) — not generated, so no drift surface.
+4. Tests: `tests/unit/scripts/test_atlas.py`.
+
+## Verification
+`check_quality --full` green (**10039 passed**, 37 skipped) · `atlas.py --check` coherent (634 files) ·
+`atlas.py` summary/full render verified · `context_map.py` role line verified on a maintenance cog.
+Composer reuses the sibling tools as libraries (do-not-duplicate); body not committed; not CI-wired.
+
+## Session enders
+
+**Grooming (Q-0015).** Executed PR 2 of the atlas plan — moved idea #2 (thin unified atlas) from
+*routed/discuss* → *shipped* in the capture doc, and the plan's PR 2 from *sequenced* → *shipped*. The
+backlog now has the atlas off it; remaining routed items (count-cite guard, boundary-debt burndown,
+root README) are untouched and correctly parked.
+
+**💡 Session idea (Q-0089).** The atlas already computes **mirror-test coverage** (this run: files with
+a `test_<stem>.py`) and a **review-unit** per file — but nothing tracks coverage *by area*. Idea:
+surface **mirror-test coverage per review-unit** (slice/service/platform) from the atlas's existing
+`has_tests` + `review_unit` data — report-first (informational, since many files are tested
+transitively / are `__init__`), and *if* it proves stable, a soft per-area ratchet so a slice's
+coverage can't silently regress. Distinct from the eval-coverage ratchet (AI tools) and
+`command_surface_dump --diff-checklist` (commands) — this is *source-file* coverage by *area*.
+Dedup-checked: no per-area mirror-test signal exists today. Small; build atop `atlas.build_index()`.
+
+**⟲ Previous-session review (Q-0102).** #958 (the crosswalk) was clean — curated overlay over a
+registry-schema bump with a recorded rationale, a self-correcting count, and a CI-enforcing test. One
+genuine observation: its freshness enforcement lives in a **pytest test** (`test_extension_crosswalk`
+runs `--check`), so it's only caught by the **full** suite — not the fast `check_quality --check-only`
+/ `check_docs` gate that agents run between edits. Same is now true of the atlas. System improvement:
+either surface crosswalk/atlas freshness in `check_docs` (the fast gate), or document explicitly that
+"generated-artifact freshness is a full-suite-only gate" so an agent isn't surprised when `--check-only`
+is green but CI reds on a stale generated doc. (Lean toward documenting — adding it to `check_docs`
+risks slowing the fast gate.)
+
+**Doc audit (Q-0104).** Outputs are in durable homes: `scripts/atlas.py` + `docs/architecture/repo-atlas.md`
+(reachable via `AGENT_ORIENTATION` reference list — `check_docs --strict` ✓), plan + idea doc updated
+to *shipped*, no new owner decisions (Q-0151a/c already recorded). Pre-existing, **out of scope**: the
+`check_current_state_ledger` lag (other sessions' + my merged #957/#958) — owned by the #960
+reconciliation routine (Q-0124), which fires imminently at the #960 boundary.

--- a/.sessions/2026-06-16-thin-architecture-atlas.md
+++ b/.sessions/2026-06-16-thin-architecture-atlas.md
@@ -1,7 +1,7 @@
 # Session — thin architecture atlas (PR 2) + role in context_map
 
-> **Status:** `in-progress` — born-red per Q-0133; flips to `complete` as the final step.
-> **Date:** 2026-06-16 · **Branch:** `claude/hopeful-meitner-772pv8` · **PR:** #959
+> **Status:** `complete` — work done, PR #960, auto-merge on green.
+> **Date:** 2026-06-16 · **Branch:** `claude/hopeful-meitner-772pv8` · **PR:** #960
 
 ## What I did
 

--- a/docs/AGENT_ORIENTATION.md
+++ b/docs/AGENT_ORIENTATION.md
@@ -323,6 +323,10 @@ has already been done.
   when the two disagree.
 - `docs/context-map-tooling.md` — how to use `scripts/context_map.py` (file-impact context
   before editing a `disbot/` file: importers, blast radius, related docs/tests, risk).
+- [`docs/architecture/repo-atlas.md`](architecture/repo-atlas.md) — how to use `scripts/atlas.py`,
+  the repo-wide companion to this file: a generated, provenance-stamped index composing
+  `context_map` / `_review_units` / `extension_crosswalk` (layer · review-unit · role · tests across
+  the whole repo). Generated on demand, body not committed (Q-0151a).
 - `docs/repo-review-map.md` — the review/refactor partition of the repo: the coarse
   top-level domains (Axis A) and, inside the bot, the unit of independent review
   (Axis B = the vertical subsystem slice vs. the shared platform layers). Read when

--- a/docs/architecture/repo-atlas.md
+++ b/docs/architecture/repo-atlas.md
@@ -1,0 +1,62 @@
+# Repo architecture atlas — how to use it
+
+> **Status:** `reference` — a how-to for `scripts/atlas.py`. **This page is curated and stable;
+> the atlas *body* is generated on demand and intentionally not committed** (owner decision Q-0151a:
+> the atlas is a **companion** to `AGENT_ORIENTATION.md`, not a replacement). Born from the
+> architecture-atlas review ([capture](../ideas/architecture-atlas-and-structure-review-2026-06-16.md),
+> PR #957) and [the plan](../planning/extension-taxonomy-crosswalk-plan-2026-06-16.md) (PR 2).
+
+## What it is
+
+A **thin, repo-wide composer** over the maps this repo already has. `scripts/context_map.py` answers
+the orientation questions *for one file* (layer · owner · imports · blast radius · tests · docs · role);
+the atlas answers them **across the whole repo** in one provenance-stamped index, by importing the
+existing tools as libraries and joining their output:
+
+| Fact | Source tool (composed, never re-implemented) |
+|---|---|
+| layer · importers · ownership | `scripts/context_map.py` |
+| review unit (repo-review-map partition) | `scripts/_review_units.py` |
+| role · backing-subsystem · registered | `scripts/extension_crosswalk.py` (PR #958) |
+
+**Do-not-duplicate rule:** if you need a fact the atlas doesn't have, add it to the relevant *source*
+tool, not to `atlas.py`. The atlas only joins and rolls up.
+
+## How to run it
+
+```bash
+python3.10 scripts/atlas.py            # compact summary: rollups by layer / role / review-unit + provenance
+python3.10 scripts/atlas.py --full     # the full per-file index to stdout
+python3.10 scripts/atlas.py --check     # composite coherence guard (exit 1 on drift)
+```
+
+The body is **not committed** — regenerate it on demand. The provenance header carries the commit SHA
++ timestamp + generator version, so a generated copy is always self-dating.
+
+## What `--check` guards (kept honest — no false-positive gates)
+
+- **Delegates** classification + crosswalk-doc freshness to `extension_crosswalk.check()`, so
+  `atlas.py --check` is one entrypoint that also covers the crosswalk guard.
+- **Hard-fails** when a loaded extension has no source file on disk, or the index can't be built.
+- **Reports (does not fail)** "orphan" files that classify into no layer and aren't a known top-level
+  module — surfaced for a human, never a hard gate (a new top-level package is usually intentional).
+
+It is **not wired into CI** by default (matching `check_sector_map.py` / `dispatch_menu.py` — ask the
+owner before adding a `code-quality.yml` step; the crosswalk half is already CI-enforced via its test).
+
+## Relation to the other navigation surfaces
+
+- **`AGENT_ORIENTATION.md`** — the *curated reading-order router* (what to read, in what order). The
+  atlas is its generated **companion**: orientation tells you where to start; the atlas gives you the
+  repo-wide fact table. Orientation stays authoritative for *intent*.
+- **`docs/agent/` context packs** — *curated per-area* reading context (folio + binding docs + source
+  roots). The atlas is *generated + repo-wide + file-indexed*. They are complementary: packs answer
+  "I'm working in area X, what do I read?"; the atlas answers "across the whole repo, where does
+  everything sit?".
+- **`context_map.py`** — the per-file version of the same questions; run it before editing a file.
+
+## Provenance / disposability (Q-0105)
+
+Added 2026-06-16. Read-only, stdlib + the sibling scripts, no bot-runtime dependency. If it proves
+more nuisance than help across a few sessions, delete `scripts/atlas.py`, `tests/unit/scripts/test_atlas.py`,
+and this page together.

--- a/docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md
+++ b/docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md
@@ -82,7 +82,14 @@ the one place the review found a true blind spot. **Built (Q-0151c, owner-approv
 *(Count-correction: the live registry has **33** identities, not the 32 first written here — fixed
 2026-06-16; the crosswalk is now the self-correcting source.)*
 
-### 2. A *thin* unified atlas — compose, don't duplicate
+### 2. A *thin* unified atlas — compose, don't duplicate — ✅ APPROVED + SHIPPED (PR #959)
+Built per the owner's Q-0151a choice (companion to `AGENT_ORIENTATION`, body not committed,
+CI-`--check` + on-demand): **`scripts/atlas.py`** composes `context_map` / `_review_units` /
+`extension_crosswalk` into a repo-wide provenance-stamped index; the down-payment surfaces `role` in
+`scripts/context_map.py`; the curated companion is
+[`docs/architecture/repo-atlas.md`](../architecture/repo-atlas.md). See
+[the plan](../planning/extension-taxonomy-crosswalk-plan-2026-06-16.md) § "PR 2".
+
 The review's real surviving insight: the facts are all generable but **scattered** across
 `context_map` / `wiring_map` / `review_scope` / `command_surface_dump` / `settings_lane_matrix` /
 the agent context packs, with **no single provenance-stamped front page and no repo-wide `--check`
@@ -109,7 +116,7 @@ idea rather than opening a new one.
 |---|---|---|
 | Fix the 3 confirmed drift counts in binding docs | tiny / reversible | **Executed in this PR** (bugs-first; source wins). De-numbered to point at source so they can't re-rot. |
 | **Extension-type taxonomy crosswalk + CI guard** (#1) | medium — touches `subsystem_registry` (a `REGISTRY_SCHEMA_VERSION` bump + validation) and adds a generated artifact + guard | **Structure into a plan** — needs its own `docs/planning/` plan (ownership: registry; reuse: existing metadata seam; mechanics: schema-version bump, validation, generated crosswalk, guard). Not a drive-by. |
-| **Thin unified atlas** `scripts/atlas.py` (#2) | medium — composes existing tools; new generated artifact | **DISCUSS → Q-0151** (overlaps context-pack system; owner-policy decisions attached). |
+| **Thin unified atlas** `scripts/atlas.py` (#2) | medium — composes existing tools; new generated artifact | ✅ **SHIPPED (PR #959)** — Q-0151a answered (companion, body not committed); composer + `context_map` role line + companion doc + tests. |
 | **Count-citation guard** (#3) | small — `check_docs` rule | **Fold into** `readiness-maps-cite-regen-command-2026-06-13.md` (generalize it). Quick-win lane when capacity allows; needs a low-false-positive design (don't flag legit numbers). |
 | Selective boundary-debt burndown (Option B) — start with `arch-fix-13` `views→cogs` (≈18 entries) | medium, scoped, test-covered | **Roadmap candidate** (S1 / shared-platform). Already ticketed; this is execution, not discovery. Each cluster (blackjack, economy, xp, diagnostic) is its own small PR moving `_helpers`/`_state` to `utils/` or a shared module. |
 | Root README pointer | tiny but overrides a stated decision | **DISCUSS → Q-0151** (owner-only — contradicts `repo-navigation-map.md:51`). |

--- a/docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md
+++ b/docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md
@@ -82,7 +82,7 @@ the one place the review found a true blind spot. **Built (Q-0151c, owner-approv
 *(Count-correction: the live registry has **33** identities, not the 32 first written here — fixed
 2026-06-16; the crosswalk is now the self-correcting source.)*
 
-### 2. A *thin* unified atlas — compose, don't duplicate — ✅ APPROVED + SHIPPED (PR #959)
+### 2. A *thin* unified atlas — compose, don't duplicate — ✅ APPROVED + SHIPPED (PR #960)
 Built per the owner's Q-0151a choice (companion to `AGENT_ORIENTATION`, body not committed,
 CI-`--check` + on-demand): **`scripts/atlas.py`** composes `context_map` / `_review_units` /
 `extension_crosswalk` into a repo-wide provenance-stamped index; the down-payment surfaces `role` in
@@ -116,7 +116,7 @@ idea rather than opening a new one.
 |---|---|---|
 | Fix the 3 confirmed drift counts in binding docs | tiny / reversible | **Executed in this PR** (bugs-first; source wins). De-numbered to point at source so they can't re-rot. |
 | **Extension-type taxonomy crosswalk + CI guard** (#1) | medium — touches `subsystem_registry` (a `REGISTRY_SCHEMA_VERSION` bump + validation) and adds a generated artifact + guard | **Structure into a plan** — needs its own `docs/planning/` plan (ownership: registry; reuse: existing metadata seam; mechanics: schema-version bump, validation, generated crosswalk, guard). Not a drive-by. |
-| **Thin unified atlas** `scripts/atlas.py` (#2) | medium — composes existing tools; new generated artifact | ✅ **SHIPPED (PR #959)** — Q-0151a answered (companion, body not committed); composer + `context_map` role line + companion doc + tests. |
+| **Thin unified atlas** `scripts/atlas.py` (#2) | medium — composes existing tools; new generated artifact | ✅ **SHIPPED (PR #960)** — Q-0151a answered (companion, body not committed); composer + `context_map` role line + companion doc + tests. |
 | **Count-citation guard** (#3) | small — `check_docs` rule | **Fold into** `readiness-maps-cite-regen-command-2026-06-13.md` (generalize it). Quick-win lane when capacity allows; needs a low-false-positive design (don't flag legit numbers). |
 | Selective boundary-debt burndown (Option B) — start with `arch-fix-13` `views→cogs` (≈18 entries) | medium, scoped, test-covered | **Roadmap candidate** (S1 / shared-platform). Already ticketed; this is execution, not discovery. Each cluster (blackjack, economy, xp, diagnostic) is its own small PR moving `_helpers`/`_state` to `utils/` or a shared module. |
 | Root README pointer | tiny but overrides a stated decision | **DISCUSS → Q-0151** (owner-only — contradicts `repo-navigation-map.md:51`). |

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -38,7 +38,8 @@ living ledger (`docs/current-state.md`).
 > Trimmed 2026-06-16 (Q-0152): stale claims whose PRs merged are dropped — the durable record is the
 > PR + the `current-state.md` ledger. Keep this to the most recent handful, newest-first.
 
-- `claude/hopeful-meitner-772pv8` · extension-taxonomy crosswalk (Q-0151c) — overlay + generator + CI guard + plan · 2026-06-16 · **PR #958 (auto-merge on green)**
+- `claude/hopeful-meitner-772pv8` · thin architecture atlas (PR 2, Q-0151a) — `scripts/atlas.py` composer + `role` in `context_map.py` + companion doc + tests · 2026-06-16 · **PR #959 (auto-merge on green)**
+- `claude/hopeful-meitner-772pv8` · extension-taxonomy crosswalk (Q-0151c) — overlay + generator + CI guard + plan · 2026-06-16 · **PR #958 (merged)**
 - `claude/hopeful-meitner-772pv8` · architecture-atlas / structure-review idea intake (owner-uploaded review) · router Q-0151 · 2026-06-16 · **PR #957 (merged)**
 
 - `claude/coglist-command` · `!coglist` real command → admin "📋 Cog List" view · 2026-06-16 · **PR #951 (merged)**

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -38,7 +38,7 @@ living ledger (`docs/current-state.md`).
 > Trimmed 2026-06-16 (Q-0152): stale claims whose PRs merged are dropped — the durable record is the
 > PR + the `current-state.md` ledger. Keep this to the most recent handful, newest-first.
 
-- `claude/hopeful-meitner-772pv8` · thin architecture atlas (PR 2, Q-0151a) — `scripts/atlas.py` composer + `role` in `context_map.py` + companion doc + tests · 2026-06-16 · **PR #959 (auto-merge on green)**
+- `claude/hopeful-meitner-772pv8` · thin architecture atlas (PR 2, Q-0151a) — `scripts/atlas.py` composer + `role` in `context_map.py` + companion doc + tests · 2026-06-16 · **PR #960 (auto-merge on green)**
 - `claude/hopeful-meitner-772pv8` · extension-taxonomy crosswalk (Q-0151c) — overlay + generator + CI guard + plan · 2026-06-16 · **PR #958 (merged)**
 - `claude/hopeful-meitner-772pv8` · architecture-atlas / structure-review idea intake (owner-uploaded review) · router Q-0151 · 2026-06-16 · **PR #957 (merged)**
 

--- a/docs/planning/extension-taxonomy-crosswalk-plan-2026-06-16.md
+++ b/docs/planning/extension-taxonomy-crosswalk-plan-2026-06-16.md
@@ -44,7 +44,7 @@ My original Q-0151c phrasing suggested a `role` field on the subsystem registry 
 The CI **enforcement** the owner asked for is delivered by the test running `--check` (every extension
 must be classified), so "CI-enforced" is satisfied without touching runtime.
 
-## PR 2 — thin unified atlas · SHIPPED (PR #959)
+## PR 2 — thin unified atlas · SHIPPED (PR #960)
 
 Built as planned: **`scripts/atlas.py`** (composer) + the down-payment **role line in
 `scripts/context_map.py`** + the curated companion **[`docs/architecture/repo-atlas.md`](../architecture/repo-atlas.md)**

--- a/docs/planning/extension-taxonomy-crosswalk-plan-2026-06-16.md
+++ b/docs/planning/extension-taxonomy-crosswalk-plan-2026-06-16.md
@@ -44,7 +44,15 @@ My original Q-0151c phrasing suggested a `role` field on the subsystem registry 
 The CI **enforcement** the owner asked for is delivered by the test running `--check` (every extension
 must be classified), so "CI-enforced" is satisfied without touching runtime.
 
-## PR 2 — thin unified atlas · SEQUENCED (next session)
+## PR 2 — thin unified atlas · SHIPPED (PR #959)
+
+Built as planned: **`scripts/atlas.py`** (composer) + the down-payment **role line in
+`scripts/context_map.py`** + the curated companion **[`docs/architecture/repo-atlas.md`](../architecture/repo-atlas.md)**
++ **`tests/unit/scripts/test_atlas.py`** (the coherence-guard enforcement seam). Body not committed
+(Q-0151a); `--check` delegates classification to `extension_crosswalk.check()` and adds the
+extension-file-exists + orphan smoke checks. Not CI-wired (ask-first, like `dispatch_menu`).
+
+### Original PR 2 design (for reference)
 
 The review's surviving second idea, as a **companion** to `AGENT_ORIENTATION.md` (owner's Q-0151a
 choice — not a replacement; orientation stays the curated reading-order router). A thin

--- a/scripts/atlas.py
+++ b/scripts/atlas.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""SuperBot architecture atlas — a thin, repo-wide *composer* over the existing maps.
+
+The owner-uploaded architecture review asked for one provenance-stamped "front page"
+that answers, across the whole repo, the questions the per-file ``context_map.py``
+answers one file at a time: *where does each file belong · what review unit is it ·
+what role/subsystem does it back · who imports it · does it have tests*. This is that
+repo-wide index — generated on demand, **body not committed** (owner decision Q-0151a:
+companion to ``AGENT_ORIENTATION.md``, CI ``--check`` + on-demand generate).
+
+DO-NOT-DUPLICATE (the review's own warning, and this repo's helper policy): this is a
+**composer**, never a re-implementation. Every fact comes from a sibling tool imported
+as a library — if a fact isn't produced yet, add it *there*, not here:
+    - ``context_map``        — layer, reverse-import graph (importers), ownership facts
+    - ``_review_units``      — the repo-review-map partition (review unit)
+    - ``extension_crosswalk``— role / backing-subsystem / registered (PR #958)
+
+Modes
+-----
+    python3.10 scripts/atlas.py            # compact summary (rollups + provenance)
+    python3.10 scripts/atlas.py --full     # the full per-file index to stdout
+    python3.10 scripts/atlas.py --check    # composite coherence guard (exit 1 on drift)
+
+What ``--check`` adds vs. delegates (kept honest — no false-positive gates):
+    - DELEGATES classification + crosswalk-doc freshness to ``extension_crosswalk.check()``
+      so ``atlas.py --check`` is one entrypoint that also covers the crosswalk.
+    - ADDS (hard): every loaded extension resolves to a source file on disk; the index
+      builds for every file without error.
+    - ADDS (soft, reported not failed): source files that classify into no layer and are
+      not a known top-level module ("orphans") — surfaced so a human notices, never a
+      hard fail (a new top-level package is usually intentional).
+
+RELIABILITY / PROVENANCE (Q-0105): added 2026-06-16. Read-only, stdlib + the sibling
+scripts, disposable. If it proves more nuisance than help across a few sessions, delete
+this script + ``tests/unit/scripts/test_atlas.py`` + ``docs/architecture/repo-atlas.md``
+together — nothing in the bot runtime depends on it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import _review_units  # noqa: E402
+import context_map as cmap  # noqa: E402
+import extension_crosswalk as xwalk  # noqa: E402
+
+REPO_ROOT: Path = cmap.REPO_ROOT
+DISBOT_ROOT: Path = cmap.DISBOT_ROOT
+TESTS_ROOT: Path = cmap.TESTS_ROOT
+
+# Bump when the rendered layout changes.
+GENERATOR_VERSION = "v1"
+
+
+@dataclass(frozen=True)
+class FileRecord:
+    rel: str
+    module: str
+    layer: str | None
+    review_unit: str
+    role: str
+    backs: str | None
+    registered: bool
+    importers: int
+    has_tests: bool
+
+
+# ---------------------------------------------------------------------------
+# Composition helpers
+# ---------------------------------------------------------------------------
+
+
+def _cog_extension_short(rel: str) -> str | None:
+    """Map a ``disbot/cogs/...`` path to its extension short name (else None).
+
+    ``cogs/mining_cog.py`` and ``cogs/mining/exploration.py`` both -> ``mining``.
+    """
+    parts = Path(rel).parts
+    if len(parts) < 3 or parts[1] != "cogs":
+        return None
+    name = parts[2]
+    if name.endswith(".py"):
+        name = name[:-3]
+    return name.removesuffix("_cog")
+
+
+def _test_stems() -> set[str]:
+    """Source stems that have a mirror ``test_<stem>.py`` anywhere under tests/ (one walk)."""
+    return {p.stem[len("test_") :] for p in TESTS_ROOT.rglob("test_*.py")}
+
+
+def build_index() -> list[FileRecord]:
+    """The repo-wide roster, composed from the sibling tools (one reverse-graph build)."""
+    reverse = cmap.build_reverse()
+    test_stems = _test_stems()
+    role_by_ext = {row.extension: row for row in xwalk.build_rows()[0]}
+
+    records: list[FileRecord] = []
+    for py in sorted(DISBOT_ROOT.rglob("*.py")):
+        if py.name == "__init__.py":
+            continue  # package marker — its module is the package itself
+        mod = cmap.module_name(py)
+        if mod is None:
+            continue
+        rel = str(py.resolve().relative_to(REPO_ROOT))
+        layer = cmap._arch._file_layer(py)
+        review_unit = _review_units.classify_path(rel).label()
+        short = _cog_extension_short(rel)
+        row = role_by_ext.get(short) if short else None
+        records.append(
+            FileRecord(
+                rel=rel,
+                module=mod,
+                layer=layer,
+                review_unit=review_unit,
+                role=row.role if row else "",
+                backs=row.backs if row else None,
+                registered=bool(row and row.registered),
+                importers=len(reverse.importers(mod)),
+                has_tests=py.stem in test_stems,
+            ),
+        )
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Coherence guard
+# ---------------------------------------------------------------------------
+
+
+def _missing_extension_files() -> list[str]:
+    errors: list[str] = []
+    for short in xwalk.initial_extensions():
+        cog_file = DISBOT_ROOT / "cogs" / f"{short}_cog.py"
+        cog_pkg = DISBOT_ROOT / "cogs" / f"{short}_cog" / "__init__.py"
+        if not cog_file.exists() and not cog_pkg.exists():
+            errors.append(f"extension 'cogs.{short}_cog' has no source file on disk")
+    return errors
+
+
+def orphans(records: list[FileRecord]) -> list[str]:
+    """Files that classify into no layer and are not a known top-level module (soft)."""
+    out: list[str] = []
+    for r in records:
+        if r.layer is None and r.module.split(".")[0] not in cmap.TOP_LEVEL_MODULES:
+            out.append(r.rel)
+    return out
+
+
+def coherence_errors(records: list[FileRecord]) -> list[str]:
+    """Hard failures only. Classification/freshness is delegated to the crosswalk."""
+    return list(xwalk.check()) + _missing_extension_files()
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def _git_sha() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=REPO_ROOT,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+
+def _provenance(records: list[FileRecord]) -> list[str]:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return [
+        "# SuperBot architecture atlas (generated)",
+        "",
+        "> **GENERATED — NOT SOURCE OF TRUTH.** Composed from `context_map` · `_review_units` ·",
+        "> `extension_crosswalk`. Regenerate with `python3.10 scripts/atlas.py --full`. Body is",
+        "> intentionally not committed (Q-0151a); the curated companion is "
+        "`docs/architecture/repo-atlas.md`.",
+        "",
+        f"_commit:_ `{_git_sha()}`  ·  _generated:_ {now}  ·  "
+        f"_generator:_ `atlas {GENERATOR_VERSION}`  ·  **{len(records)}** source files.",
+        "",
+    ]
+
+
+def _counts(records: list[FileRecord], attr: str) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for r in records:
+        key = getattr(r, attr) or "(none)"
+        out[key] = out.get(key, 0) + 1
+    return out
+
+
+def _rollup_table(title: str, counts: dict[str, int]) -> list[str]:
+    out = [f"## By {title}", "", f"| {title} | files |", "|---|---:|"]
+    for key, n in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
+        out.append(f"| `{key}` | {n} |")
+    out.append("")
+    return out
+
+
+def render_summary(records: list[FileRecord]) -> str:
+    out = _provenance(records)
+    out += _rollup_table("layer", _counts(records, "layer"))
+    role_counts = {k: v for k, v in _counts(records, "role").items() if k != "(none)"}
+    out += _rollup_table("role", role_counts)
+    out += _rollup_table("review unit", _counts(records, "review_unit"))
+    tested = sum(1 for r in records if r.has_tests)
+    out.append(
+        f"_Mirror-test coverage:_ **{tested}/{len(records)}** files have a `test_<stem>.py`.",
+    )
+    orphan_list = orphans(records)
+    out.append(
+        f"_Orphans (no layer, not a known top-level module):_ **{len(orphan_list)}**.",
+    )
+    if orphan_list:
+        out.append("")
+        out += [f"- {o}" for o in orphan_list]
+    out.append("")
+    out.append(
+        "_Run `--full` for the per-file index, `--check` for the coherence guard._",
+    )
+    out.append("")
+    return "\n".join(out)
+
+
+def render_full(records: list[FileRecord]) -> str:
+    out = _provenance(records)
+    out += _rollup_table("layer", _counts(records, "layer"))
+    out.append("## Per-file index")
+    out.append("")
+    out.append("| File | Layer | Review unit | Role | Backs | Reg | Imp | Tests |")
+    out.append("|---|---|---|---|---|:--:|---:|:--:|")
+    for r in records:
+        backs = f"`{r.backs}`" if r.backs else ""
+        role = f"`{r.role}`" if r.role else ""
+        reg = "✓" if r.registered else ""
+        tests = "✓" if r.has_tests else ""
+        out.append(
+            f"| `{r.rel}` | `{r.layer or '—'}` | {r.review_unit} | {role} | {backs} | "
+            f"{reg} | {r.importers} | {tests} |",
+        )
+    out.append("")
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="SuperBot architecture atlas (composer).",
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--full",
+        action="store_true",
+        help="full per-file index to stdout.",
+    )
+    group.add_argument(
+        "--check",
+        action="store_true",
+        help="coherence guard: exit 1 on drift.",
+    )
+    args = parser.parse_args(argv)
+
+    records = build_index()
+
+    if args.check:
+        errors = coherence_errors(records)
+        soft = orphans(records)
+        if errors:
+            print("atlas: FAIL")
+            for e in errors:
+                print(f"  - {e}")
+            return 1
+        print(f"atlas: coherent ✓ ({len(records)} files)")
+        if soft:
+            print(f"  note: {len(soft)} orphan file(s) with no layer (informational):")
+            for o in soft:
+                print(f"    - {o}")
+        return 0
+
+    print(render_full(records) if args.full else render_summary(records), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/context_map.py
+++ b/scripts/context_map.py
@@ -185,6 +185,33 @@ def ownership_facts(mod: str) -> list[str]:
     return facts
 
 
+def extension_role_facts(rel: str) -> list[str]:
+    """Role / backing-subsystem for a ``disbot/cogs/...`` file, from the extension crosswalk.
+
+    Degrades to ``[]`` for non-cog files or if the overlay/crosswalk is unavailable —
+    this is disposable convenience tooling and must never break the map. (PR #958 data.)
+    """
+    parts = Path(rel).parts
+    if len(parts) < 3 or parts[1] != "cogs":
+        return []
+    short = parts[2]
+    if short.endswith(".py"):
+        short = short[:-3]
+    short = short.removesuffix("_cog")
+    try:
+        import extension_crosswalk as _xwalk
+
+        rows, _ = _xwalk.build_rows()
+    except Exception:  # noqa: BLE001 — never let optional tooling break context_map
+        return []
+    for row in rows:
+        if row.extension == short:
+            backs = f" → backs `{row.backs}`" if row.backs else ""
+            reg = " (registered subsystem)" if row.registered else ""
+            return [f"Extension role: `{row.role}`{backs}{reg} — `{short}` surface."]
+    return []
+
+
 def load_overrides() -> dict:
     if not OVERRIDES_PATH.exists():
         return {}
@@ -348,8 +375,13 @@ def render(path: Path, reverse: _Reverse, overrides: dict, max_importers: int) -
             "## File role / authority",
             "",
             _bullet_list(
-                owner_facts
-                or [f"`{layer or 'n/a'}`-layer module (no canonical mutation domain)."],
+                (
+                    owner_facts
+                    or [
+                        f"`{layer or 'n/a'}`-layer module (no canonical mutation domain).",
+                    ]
+                )
+                + extension_role_facts(rel),
             ),
             f"- Layer may import: {may_import}",
             "",

--- a/tests/unit/scripts/test_atlas.py
+++ b/tests/unit/scripts/test_atlas.py
@@ -1,0 +1,84 @@
+"""Tests for ``scripts/atlas.py`` — the thin repo-wide architecture-atlas composer.
+
+``test_coherent`` is the CI enforcement seam (Q-0151a): it fails the suite if the
+composite index can't be built, a loaded extension lacks a source file, or the
+delegated crosswalk guard drifts — no workflow edit needed. The rest pin the
+composition (role enrichment, review-unit coverage, do-not-duplicate reuse).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "atlas.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("atlas_ut", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def index(mod):
+    return mod.build_index()
+
+
+def test_coherent(mod, index):
+    """The live repo composes cleanly: no hard coherence errors."""
+    errors = mod.coherence_errors(index)
+    assert errors == [], "\n".join(errors)
+
+
+def test_no_orphans(mod, index):
+    """Every source file classifies into a layer or is a known top-level module."""
+    assert mod.orphans(index) == []
+
+
+def test_index_is_substantial_and_classified(index):
+    """Sanity: the roster covers the repo and every record carries a review unit."""
+    assert len(index) > 400
+    assert all(r.review_unit for r in index)
+    # The four known top-level modules are the only layer-less files.
+    layerless = {r.module for r in index if r.layer is None}
+    assert layerless <= {"bot1", "config", "guild_lifecycle", "healthserver"}
+
+
+def test_role_enrichment_from_crosswalk(index):
+    """Role/backs/registered are joined from the extension crosswalk (PR #958)."""
+    by_rel = {r.rel: r for r in index}
+    maint = by_rel["disbot/cogs/health_maintenance_cog.py"]
+    assert maint.role == "maintenance" and maint.backs == "diagnostic"
+    mining = by_rel["disbot/cogs/mining_cog.py"]
+    assert mining.role == "product_subsystem" and mining.registered is True
+    paragon = by_rel["disbot/cogs/paragon_cog.py"]
+    assert paragon.role == "specialized_surface" and paragon.backs == "btd6"
+
+
+def test_missing_extension_file_is_flagged(mod, monkeypatch):
+    """The guard catches an extension declared in the manifest with no source file."""
+    real = mod.xwalk.initial_extensions()
+    monkeypatch.setattr(mod.xwalk, "initial_extensions", lambda: [*real, "ghost_thing"])
+    errors = mod._missing_extension_files()
+    assert any("ghost_thing" in e for e in errors), errors
+
+
+def test_full_render_carries_provenance(mod, index):
+    rendered = mod.render_full(index)
+    assert "GENERATED — NOT SOURCE OF TRUTH" in rendered
+    assert "disbot/cogs/mining_cog.py" in rendered
+    assert "_commit:_" in rendered
+
+
+def test_is_a_composer_not_a_reimplementation(mod):
+    """Do-not-duplicate: the atlas must source its facts from the sibling tools."""
+    assert hasattr(mod, "cmap") and hasattr(mod, "xwalk") and hasattr(mod, "_review_units")


### PR DESCRIPTION
## What

**PR 2 of the architecture-atlas plan** — the thin, repo-wide atlas composer the owner approved in
Q-0151a (*"I agree with your recommendations"*; companion to `AGENT_ORIENTATION`, body not committed).
Follows PR 1 (the extension-taxonomy crosswalk, #958). **Born red** per Q-0133 — flips to `complete`
as the last step.

## Deliverables

1. **`scripts/atlas.py`** — a *thin composer* (do-not-duplicate): imports `context_map`,
   `_review_units`, and `extension_crosswalk` **as libraries** and emits a repo-wide,
   provenance-stamped index (file → layer · review-unit · role · backs · registered · importers ·
   tests). `--full` for the per-file table, default = rollup summary. `--check` is a composite
   coherence guard: **delegates** classification + crosswalk-doc freshness to
   `extension_crosswalk.check()`, **adds** the extension-file-exists hard check + an orphan smoke
   report. Body intentionally **not committed** (Q-0151a) — generated on demand, self-dating
   provenance header. **Not CI-wired** (ask-first, like `dispatch_menu`/`check_sector_map`).
2. **`scripts/context_map.py`** — the down-payment: each cog file's per-file map now shows its
   `Extension role: … → backs … (registered subsystem)` line, joined from the crosswalk. Degrades to
   nothing for non-cog files / if the overlay is unavailable.
3. **`docs/architecture/repo-atlas.md`** — a *curated* companion (how to run, what `--check` guards,
   how it relates to context-packs + `AGENT_ORIENTATION`). Not generated → no drift surface.
4. **`tests/unit/scripts/test_atlas.py`** — the coherence-guard enforcement seam (7 tests).

## Verification
- `python3.10 scripts/check_quality.py --full` → **10039 passed**, 37 skipped; black/isort/ruff/mypy/check_docs green.
- `python3.10 scripts/atlas.py --check` → coherent (634 files); spot-checked role enrichment + provenance.

Tooling + docs only; no `disbot/` runtime code.

https://claude.ai/code/session_017kiQvtYDdewQNK8ibqwQSf

---
_Generated by [Claude Code](https://claude.ai/code/session_017kiQvtYDdewQNK8ibqwQSf)_