### PR TITLE
feat(ai): §7.5 paragon base-cost comparison floor (last unbuilt comparison member)

### DIFF
--- a/.sessions/2026-06-16-btd6-paragon-cost-comparison.md
+++ b/.sessions/2026-06-16-btd6-paragon-cost-comparison.md
@@ -1,0 +1,36 @@
+# 2026-06-16 — BTD6 paragon base-cost comparison floor (AI §7.5)
+
+> **Status:** `in-progress`
+
+**Branch:** `claude/magical-rubin-u3arq6` · **Date:** 2026-06-16 · scheduled dispatch (empty work
+order → advance the next plan slice).
+
+## What I'm about to do
+
+The live ▶ NEXT buildable plan-first lane is **the AI §7 next workflow family**. §7.5 (multi-entity
+comparison) has now shipped three of its four listed members — tower-vs-tower cost (#946),
+by-difficulty cost (#950), round-range cash (#955). The one member still flagged *not yet built* in
+the plan (`docs/ai/ai-complex-request-tool-orchestration-plan.md` §7.5) is **paragon
+degree/resource scenarios**. I'm building the **paragon base-cost** comparison — the paragon entity's
+headline resource number (its tier-6 build price), fully grounded in `utils/btd6/paragon_math`'s
+committed `BASE_PRICES_MEDIUM` table and difficulty-aware via `base_price`, so it ships under Q-0048
+with no prod-check exactly like the sibling cost builders.
+
+Question shape: "is Glaive Dominus or Ascended Shadow cheaper?" / "which paragon costs the most?" —
+rank the base build price of **two or more** paragons. This is the §7.5 comparison member of the
+BUG-0009 "grounded values, wrong assembly" class: each paragon's base price is grounded, but a model
+can mis-state *which is cheaper / by how much*, which the value-only faithfulness guard cannot catch.
+
+Plan (mirrors #946/#950/#955 exactly, contained + test-covered):
+- `btd6_data_service.compare_paragon_costs(names, *, difficulty="medium")` — resolve each name via
+  `paragon_math.resolve_paragon`, price via `paragon_math.base_price`, dedup on paragon id, rank
+  **ascending** (cheapest first), fail closed (<2 distinct priceable paragons).
+- `btd6_context_service.deterministic_paragon_cost_comparison_reply` — high-precision floor: the
+  existing cost-compare cue **+ an explicit `paragon` token** + two-or-more resolved paragons.
+  Appended to `deterministic_btd6_list_reply` **before** the tower cost builders, and the two tower
+  cost builders gain a `paragon`-present defer so the exclusivity invariant stays exactly-one-fires
+  (a "dart/ninja paragon" question must not reach the base-tower cost builder).
+- Tests: a new per-builder test module + the §7.5 exclusivity corpus entry (the invariant test
+  iterates the live `_BTD6_LIST_BUILDERS` tuple, so the new builder needs a corpus phrase).
+
+If capacity remains: a second clean slice (next plan member, a bug-book sweep, or a docs de-stale).

--- a/.sessions/2026-06-16-btd6-paragon-cost-comparison.md
+++ b/.sessions/2026-06-16-btd6-paragon-cost-comparison.md
@@ -1,6 +1,6 @@
 # 2026-06-16 — BTD6 paragon base-cost comparison floor (AI §7.5)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Branch:** `claude/magical-rubin-u3arq6` · **Date:** 2026-06-16 · scheduled dispatch (empty work
 order → advance the next plan slice).
@@ -34,3 +34,73 @@ Plan (mirrors #946/#950/#955 exactly, contained + test-covered):
   iterates the live `_BTD6_LIST_BUILDERS` tuple, so the new builder needs a corpus phrase).
 
 If capacity remains: a second clean slice (next plan member, a bug-book sweep, or a docs de-stale).
+
+## ✅ Done — PR #962 (self-merge on green via born-red flip, Q-0113/Q-0133)
+
+**The §7.5 paragon comparison member — the last unbuilt member is now shipped.**
+
+- `btd6_data_service.compare_paragon_costs(names, *, difficulty="medium")` — resolves each name via
+  `paragon_math.resolve_paragon`, prices the **base tier-6 build cost** via `paragon_math.base_price`
+  (difficulty-adjusted with the shared BTD6 multipliers), dedups on paragon id, ranks ascending,
+  fails closed (<2 distinct). Two paragons share a $500k base, so `all_equal`/tie is a real outcome.
+- `paragon_math.paragon_surfaces()` — new public helper exposing every resolver surface (names /
+  towers / ids / aliases) so the floor can scan *all* paragon mentions in a sentence the same way
+  `resolve_paragon` matches one (the alias map was module-private; exported a scan view, not the map).
+- `btd6_context_service.deterministic_paragon_cost_comparison_reply` + `_extract_paragon_names` +
+  `_format_paragon_cost_comparison` — high-precision floor: explicit `paragon` token + cost-compare
+  cue + ≥2 resolved paragons. Registered in `_BTD6_LIST_BUILDERS` **before** the tower cost builders.
+- **Exclusivity:** both tower cost builders now defer the moment `_PARAGON_CUE_RE` matches, so a
+  "dart/ninja paragon" question (tower aliases present) is never priced as the base tower. Pinned by
+  the §7.5 exclusivity invariant (new corpus phrase) + a dedicated builder-tuple test.
+- Tests: `tests/unit/services/test_btd6_paragon_cost_comparison.py` (21 cases) + the exclusivity
+  corpus entry. Plan §7.5 de-staled (member marked SHIPPED).
+
+Verification: `check_architecture --mode strict` ✓ · `check_quality --full` ✓ (10051 passed) ·
+new+invariant+paragon-math suites 53 passed.
+
+## Context delta (what the next session should know)
+
+- **Needed but not pointed to:** the §7.5 comparison floor is a *family* with a hard exclusivity
+  invariant (`tests/unit/invariants/test_btd6_floor_builder_exclusivity.py`) that runs **every**
+  builder against a corpus and asserts exactly-one-fires. Any new floor builder MUST (a) be added to
+  `_BTD6_LIST_BUILDERS` and (b) get a `_SHOULD_FIRE` corpus phrase, or the coverage test fails. The
+  orientation route to `btd6_context_service` doesn't flag this — found it by reading the invariant.
+- **Discovered by hand:** the resolver's alias map (`paragon_math._ALIASES`) was private; scanning a
+  sentence for *all* paragons needs a public surface view — now `paragon_surfaces()`.
+- **Decisions made alone:** the paragon comparison axis is **base build price** (the headline,
+  unambiguous, fully-grounded paragon resource number), not a target-degree resource solve — the
+  least-cash solve collapses to all-equal for most sub-cap targets, so it is a poor comparison axis.
+  The plan said "degree/resource scenarios" loosely; base price is the clean, honest member. If the
+  owner wants a *degree-target* resource comparison ("cheapest to reach degree 100"), that is a
+  follow-on slice on top of `solve_requirements` — captured below as the session idea.
+- **Flagged for maintainer / known limit:** the reply compares **base price only** and says so
+  explicitly in its footer; it deliberately does not fold in the degree-grind sacrifices (those
+  depend on the player's build). No prod-check needed (Q-0048 read-only deterministic floor).
+
+## Session enders
+
+**💡 Session idea (Q-0089).** *Paragon degree-target resource comparison* — a `compare_paragon_to_degree`
+member: "is it cheaper to get Glaive Dominus or Ascended Shadow to degree 100?" ranks the
+least-cash `solve_requirements` cost-to-target across paragons. Distinct from this slice (base price
+vs. degree-grind resources); genuinely useful for the "which paragon should I commit to" question.
+Worth a small idea file if the owner wants the degree axis — dedup-checked against `docs/ideas/` and
+the §7.5 plan (only the base-price member existed as "paragon scenarios"; the degree-target framing
+is new). Captured here, not promoted (a new idea is not a new priority).
+
+**⟲ Previous-session review (Q-0102).** The previous §7.5 session (#955, round-range) did this lane
+*right*: it explicitly noted "if capacity remains, assess the paragon member as a second slice" — a
+clean, scoped handoff that made this session trivial to start. What it could have done better: it
+shipped two round-range slices and stopped, leaving the named paragon member for a *whole separate
+dispatch* when both are ~80-line mirror builders — finishing the §7.5 family in one session was
+within reach. **System improvement surfaced:** the exclusivity invariant is excellent, but the
+*family-completion* signal lives only in prose ("members still unbuilt") inside a 600-line plan; a
+tiny `_SHIPPED`/`_UNBUILT` ledger at the top of the §7.5 plan section (or a check that greps the
+builder tuple against a declared member list) would make "is the comparison family done?" answerable
+without reading the plan body. Folded as a note, not built (docs-shape, low value vs. the plan prose).
+
+**Doc audit (Q-0104).** Plan §7.5 de-staled (member SHIPPED). active-work claim added at open (to be
+cleared at close). No new owner decision (the base-price axis choice is an in-lane engineering call,
+recorded above; if the owner wants the degree axis it routes through the session idea). The ledger
+`⚠ N PRs not in current-state` drift is the **reconciliation routine's lane** (next pass at #960,
+Q-0124) — not this dispatch session's to reconcile.
+

--- a/.sessions/2026-06-16-btd6-paragon-cost-comparison.md
+++ b/.sessions/2026-06-16-btd6-paragon-cost-comparison.md
@@ -104,3 +104,18 @@ recorded above; if the owner wants the degree axis it routes through the session
 `⚠ N PRs not in current-state` drift is the **reconciliation routine's lane** (next pass at #960,
 Q-0124) — not this dispatch session's to reconcile.
 
+## 📤 Run report
+
+- **Did:** shipped the §7.5 paragon base-cost comparison floor — the last unbuilt multi-entity
+  comparison member, completing the family · **Outcome:** shipped
+- **Shipped:** #962 — `compare_paragon_costs` + `deterministic_paragon_cost_comparison_reply`
+  (deterministic paragon base-price ranking; BUG-0009 wrong-assembly floor; Q-0048 read-only, no
+  prod-check). CI mirror green (10058); arch 0; auto-merge armed on green.
+- **⚑ Owner decisions needed:** `none` (the base-price comparison axis is an in-lane engineering
+  call; the optional paragon *degree-target* axis is captured as a session idea, not a decision).
+- **⚑ Owner manual steps:** `none` (merge auto-deploys; no seed-data / env / Discord step).
+- **↪ Next:** the §7.5 comparison family is COMPLETE — next AI §7 work is a *new* workflow family
+  beyond §7.5 (plan-first / prod-check-gated for model-loop families); the buildable deterministic
+  floor members are exhausted. Other plan-first lanes: image moderation (Q-0108), Hermes bug-triage
+  `gh issue create` write (Q-0121). See current-state ▶ NEXT.
+

--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -2035,6 +2035,10 @@ _COST_DIFFICULTY_RE = re.compile(
     r"\b(easy|medium|hard|impoppable|impop|chimps)\b",
     re.I,
 )
+# An explicit paragon token — the disambiguator that routes a cost comparison to
+# the paragon builder (and away from the base-tower cost builders, which match a
+# tower alias like "dart"/"ninja" and would otherwise price the *base* tower).
+_PARAGON_CUE_RE = re.compile(r"\bparagons?\b", re.I)
 
 # --- §7.5 round-range cash comparison -----------------------------------------
 # An income/earning noun (distinct from the cost cue above) — required so a
@@ -2288,6 +2292,10 @@ def deterministic_cost_comparison_reply(message_text: str) -> str | None:
         return None
     if any(word in low for word in _COST_COMPARE_STRATEGY_EXCLUDE):
         return None
+    # A paragon cost comparison is the paragon builder's job — base-tower pricing
+    # of a paragon's tower is the wrong answer (keeps the floor exactly-one-fires).
+    if _PARAGON_CUE_RE.search(low):
+        return None
 
     from services import btd6_data_service
 
@@ -2373,6 +2381,9 @@ def deterministic_difficulty_cost_comparison_reply(message_text: str) -> str | N
         return None
     if any(word in low for word in _COST_COMPARE_STRATEGY_EXCLUDE):
         return None
+    # Paragon comparisons defer to the paragon builder (see the multi-tower one).
+    if _PARAGON_CUE_RE.search(low):
+        return None
 
     from services import btd6_data_service
 
@@ -2405,6 +2416,122 @@ def deterministic_difficulty_cost_comparison_reply(message_text: str) -> str | N
     return _format_difficulty_cost_comparison(result)
 
 
+# --- §7.5 paragon base-cost comparison ----------------------------------------
+def _extract_paragon_names(text_lower: str) -> list[str]:
+    """The paragon ids a comparison names, in order of appearance, deduped.
+
+    Scans every resolver surface (paragon names, tower names, ids, aliases) and
+    keeps the longest surface at each span (so "ascended shadow" wins over a bare
+    "ascended"), then dedups on the resolved id. Surfaces shorter than 3 chars are
+    skipped to keep stray two-letter tokens out — the ``paragon`` word + cost cue
+    already gate this builder hard. Returns ids (``resolve_paragon`` accepts them),
+    so the data primitive re-resolves from a canonical key.
+    """
+    from utils.btd6 import paragon_math
+
+    spans: list[tuple[int, int, int, str]] = []  # (start, end, surface_len, id)
+    for surface, pid in paragon_math.paragon_surfaces():
+        if len(surface) < 3:
+            continue
+        for match in re.finditer(r"\b" + re.escape(surface) + r"s?\b", text_lower):
+            spans.append((match.start(), match.end(), len(surface), pid))
+
+    spans.sort(key=lambda sp: (sp[0], -sp[2]))
+    accepted: list[tuple[int, int, str]] = []
+    for start, end, _slen, pid in spans:
+        if any(start < a_end and end > a_start for a_start, a_end, _p in accepted):
+            continue
+        accepted.append((start, end, pid))
+    accepted.sort(key=lambda a: a[0])
+
+    seen: set[str] = set()
+    names: list[str] = []
+    for _start, _end, pid in accepted:
+        if pid in seen:
+            continue
+        seen.add(pid)
+        names.append(pid)
+    return names
+
+
+def _format_paragon_cost_comparison(result: dict[str, Any]) -> str:
+    diff = str(result["difficulty"]).capitalize()
+    lines = [f"**Paragon cost comparison — {diff} base price:**"]
+    for entry in result["entries"]:
+        lines.append(
+            f"• **{entry['name']}** ({entry['tower']}) — **${entry['base_cost']:,}**",
+        )
+    cheapest = result["cheapest"]
+    if result["all_equal"]:
+        lines.append(
+            f"→ They cost the **same** to build (**${cheapest['base_cost']:,}** each).",
+        )
+    elif len(result["entries"]) == 2:
+        lines.append(
+            f"→ The **{cheapest['name']}** is cheaper by **${result['spread']:,}**.",
+        )
+    else:
+        dearest = result["most_expensive"]
+        lines.append(
+            f"→ Cheapest: **{cheapest['name']}** (${cheapest['base_cost']:,}). Most "
+            f"expensive: **{dearest['name']}** (${dearest['base_cost']:,}). "
+            f"Spread: **${result['spread']:,}**.",
+        )
+    lines.append(
+        "_(Base tier-6 build price at that difficulty — the degree-grind "
+        "sacrifices are extra and depend on your build.)_",
+    )
+    reply = "\n".join(lines)
+    return reply if len(reply) <= 1900 else reply[:1899] + "…"
+
+
+def deterministic_paragon_cost_comparison_reply(message_text: str) -> str | None:
+    """A code-built "is Glaive Dominus or Ascended Shadow cheaper" answer, or ``None``.
+
+    The AI §7.5 *paragon* member of the multi-entity cost-comparison floor — the
+    paragon-entity sibling of :func:`deterministic_cost_comparison_reply` (which
+    ranks tower upgrade states). Ranks the **base build price** of two-or-more
+    paragons so the model can never mis-state which is cheaper / by how much (the
+    BUG-0009 "grounded values, wrong assembly" class). Fires only on an explicit
+    ``paragon`` token **and** a high-precision cost-compare cue **and** two-or-more
+    resolved paragons. The ``paragon`` token is also what makes this mutually
+    exclusive with the tower cost builders — they defer the moment "paragon" is
+    present (a "dart/ninja paragon" question must not be priced as the base tower).
+    Returns ``None`` otherwise (single-paragon lookups, strategy questions, and
+    anything outside a clear two-or-more paragon cost comparison reach the model).
+    """
+    text = (message_text or "").strip()
+    if not text:
+        return None
+    low = text.lower()
+    if not _PARAGON_CUE_RE.search(low):
+        return None
+    if not (_COST_COMPARE_CUE_RE.search(low) or _COST_COMPARE_VERB_RE.search(low)):
+        return None
+    if any(word in low for word in _COST_COMPARE_STRATEGY_EXCLUDE):
+        return None
+
+    names = _extract_paragon_names(low)
+    if len(names) < 2:
+        return None
+
+    difficulty = "medium"
+    diff_match = _COST_DIFFICULTY_RE.search(low)
+    if diff_match:
+        token = diff_match.group(1).lower()
+        # CHIMPS is a mode, not a pricing difficulty — its prices are Hard's.
+        difficulty = "hard" if token == "chimps" else token
+        if difficulty == "impop":
+            difficulty = "impoppable"
+
+    from services import btd6_data_service
+
+    result = btd6_data_service.compare_paragon_costs(names, difficulty=difficulty)
+    if not result.get("found"):
+        return None
+    return _format_paragon_cost_comparison(result)
+
+
 # --- BUG-0009 deterministic list-answer dispatcher ----------------------------
 # The ordered floor builders the dispatcher fans out to. Each OWNS its labelled
 # answer and is narrow (returns ``None`` for anything but its exact list shape),
@@ -2418,6 +2545,7 @@ _BTD6_LIST_BUILDERS: tuple[Callable[[str], str | None], ...] = (
     deterministic_mk_reference_reply,
     deterministic_geraldo_per_level_reply,
     deterministic_modes_reply,
+    deterministic_paragon_cost_comparison_reply,
     deterministic_cost_comparison_reply,
     deterministic_difficulty_cost_comparison_reply,
     deterministic_round_range_comparison_reply,

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -2350,6 +2350,82 @@ def compare_round_ranges(
     }
 
 
+def compare_paragon_costs(
+    names: Sequence[str],
+    *,
+    difficulty: str = "medium",
+) -> dict[str, Any]:
+    """Deterministic base-price ranking of two-or-more paragons.
+
+    The §7.5 *paragon* member of the multi-entity comparison primitive (the
+    sibling of :func:`compare_crosspath_costs` / :func:`compare_difficulty_costs`
+    / :func:`compare_round_ranges`). Answers "is Glaive Dominus or Ascended
+    Shadow cheaper?" — price each named paragon's **base build price** (the
+    tier-6 cost) once via :func:`paragon_math.base_price` over the committed
+    ``BASE_PRICES_MEDIUM`` table (difficulty-adjusted with the shared BTD6
+    multipliers), then rank/diff **in code** so the model never assembles the
+    comparison itself (the BUG-0009 "wrong assembly" class — a mis-stated
+    "cheaper" / wrong difference, which the value-only faithfulness guard cannot
+    catch). Ranked **ascending** (cheapest first) with a stable tie-break on the
+    paragon name (two paragons share a $500,000 base, so an equal-cost tie is a
+    real outcome).
+
+    Each name is resolved with :func:`paragon_math.resolve_paragon` (tower name,
+    paragon name, id, or colloquial alias) and **deduped** on the resolved
+    paragon id. Returns ``{"found": False, ...}`` when fewer than two distinct
+    paragons resolve (an unknown name is skipped, never guessed), so a caller can
+    fall through to the model rather than answer a degenerate comparison.
+    """
+    from utils.btd6 import difficulty_costs, paragon_math
+
+    try:
+        diff = difficulty_costs.normalize_difficulty(difficulty)
+    except ValueError:
+        return {"found": False, "note": f"unknown difficulty: {difficulty!r}"}
+
+    entries: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for name in names:
+        paragon = paragon_math.resolve_paragon(name)
+        if paragon is None:
+            continue
+        if paragon.paragon_id in seen:
+            continue
+        seen.add(paragon.paragon_id)
+        entries.append(
+            {
+                "paragon_id": paragon.paragon_id,
+                "name": paragon.name,
+                "tower": paragon.tower,
+                "base_cost": paragon_math.base_price(paragon, diff),
+            },
+        )
+
+    if len(entries) < 2:
+        return {
+            "found": False,
+            "note": "need at least two distinct resolvable paragons",
+            "priced": len(entries),
+        }
+
+    ranked = sorted(entries, key=lambda e: (e["base_cost"], e["name"]))
+    cheapest = ranked[0]
+    most_expensive = ranked[-1]
+    return {
+        "found": True,
+        "difficulty": diff,
+        "entries": ranked,
+        "cheapest": cheapest,
+        "most_expensive": most_expensive,
+        "spread": most_expensive["base_cost"] - cheapest["base_cost"],
+        "all_equal": cheapest["base_cost"] == most_expensive["base_cost"],
+        "note": (
+            f"paragon base (tier-6) build price at {diff} pricing; ranked "
+            "ascending. Excludes the degree-grind sacrifices."
+        ),
+    }
+
+
 def list_ct_relics() -> tuple[RelicEntry, ...]:
     """Every Contested Territory relic in the catalog (possibly empty)."""
     return get_dataset().ct_relics

--- a/disbot/utils/btd6/paragon_math.py
+++ b/disbot/utils/btd6/paragon_math.py
@@ -167,6 +167,25 @@ _ALIASES: dict[str, str] = {
 }
 
 
+def paragon_surfaces() -> tuple[tuple[str, str], ...]:
+    """Every ``(surface, paragon_id)`` the resolver matches, for text scanning.
+
+    Paragon names, tower names, ids, and the colloquial aliases — so a
+    multi-paragon comparison can find *all* mentions in a sentence the same way
+    :func:`resolve_paragon` matches a single string. Surfaces are lower-cased;
+    duplicates (a surface that equals its id) are returned as-is — the caller
+    dedups on the resolved id, not the surface.
+    """
+    surfaces: list[tuple[str, str]] = []
+    for paragon in PARAGONS:
+        surfaces.append((paragon.name.lower(), paragon.paragon_id))
+        surfaces.append((paragon.tower.lower(), paragon.paragon_id))
+        surfaces.append((paragon.paragon_id, paragon.paragon_id))
+    for alias, pid in _ALIASES.items():
+        surfaces.append((alias, pid))
+    return tuple(surfaces)
+
+
 def resolve_paragon(text: str) -> Paragon | None:
     """Resolve a tower name, paragon name, paragon id, or shorthand alias.
 
@@ -632,6 +651,7 @@ __all__ = [
     "game_mode_for",
     "max_extra_t5_count",
     "next_degree",
+    "paragon_surfaces",
     "power_for_next_degree",
     "resolve_paragon",
     "solve_requirements",

--- a/docs/ai/ai-complex-request-tool-orchestration-plan.md
+++ b/docs/ai/ai-complex-request-tool-orchestration-plan.md
@@ -599,7 +599,12 @@ This pattern is valuable for:
   `deterministic_difficulty_cost_comparison_reply`: ranks one `(tower, crosspath)` across
   two-or-more difficulties — the sibling of the above; the two are mutually exclusive on
   candidate count, so both ride the `deterministic_btd6_list_reply` floor seam);
-- paragon degree/resource scenarios — *not yet built*;
+- paragon degree/resource scenarios — **SHIPPED** (`compare_paragon_costs` +
+  `deterministic_paragon_cost_comparison_reply`: ranks the **base build price** of two-or-more
+  paragons, difficulty-aware, grounded in `utils/btd6/paragon_math`'s committed `BASE_PRICES_MEDIUM`;
+  fires only on an explicit `paragon` token, which also makes it mutually exclusive with the tower
+  cost builders — they defer the moment "paragon" is present so a "dart/ninja paragon" question is
+  never priced as the base tower);
 - round-range comparisons — **SHIPPED #955** (`compare_round_ranges` +
   `deterministic_round_range_comparison_reply`: ranks the total cash of two-or-more inclusive
   round ranges via the existing `round_cash` primitive, ABR-aware; distinct from the single-range

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -205,6 +205,25 @@ Source code and merged PRs win over anything written here.
 > auto-opens a `reconcile` issue at the boundary that fires the docs-reconciliation routine). Reset
 > this marker to the latest PR after a pass.
 
+- **#962 (2026-06-16, AI §7.5 — deterministic BTD6 paragon base-cost comparison floor)** — scheduled
+  dispatch (empty work order → the live ▶ NEXT buildable plan-first lane, the AI §7 workflow family).
+  Adds the **paragon** member — the last unbuilt §7.5 multi-entity comparison member (the
+  paragon-entity sibling of the #946/#950 tower cost builders): "is Glaive Dominus or Ascended Shadow
+  cheaper?" ranks the **base tier-6 build price** of **two or more** paragons (BUG-0009 wrong-assembly
+  class). `btd6_data_service.compare_paragon_costs(names, *, difficulty="medium")` resolves +
+  difficulty-prices each paragon via `paragon_math.base_price` over the committed `BASE_PRICES_MEDIUM`,
+  dedups on id, ranks ascending, fails closed (<2 distinct); a new public
+  `paragon_math.paragon_surfaces()` exposes the resolver surfaces for sentence scanning.
+  `btd6_context_service.deterministic_paragon_cost_comparison_reply` fires on an explicit `paragon`
+  token + a cost-compare cue + ≥2 resolved paragons, registered in `_BTD6_LIST_BUILDERS` **before**
+  the tower cost builders, which now defer on the paragon cue so a "dart/ninja paragon" question is
+  never priced as the base tower (exactly-one-fires invariant extended). Ships under Q-0048 (read-only
+  deterministic floor, no prod-check). `check_quality --full` green (10051); arch 0; mypy clean.
+  Tests: `tests/unit/services/test_btd6_paragon_cost_comparison.py` + the §7.5 exclusivity corpus
+  entry. **§7.5 multi-entity comparison family is now COMPLETE — all four members shipped (tower-cost
+  #946 · difficulty-cost #950 · round-range cash #955 · paragon base-cost #962).** The next AI §7
+  step is a *new* workflow family beyond §7.5 (plan-first); a paragon *degree-target* resource
+  comparison is captured as a session idea (needs design — the solver's "cash" axis ≠ real spend).
 - **#955 (2026-06-16, AI §7.5 — deterministic BTD6 round-range cash comparison floor)** — scheduled
   dispatch (empty work order → the live ▶ NEXT buildable plan-first lane, the AI §7 workflow family).
   Adds the **round-range** member of the §7.5 multi-entity comparison floor (the income sibling of

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,9 +25,6 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/magical-rubin-u3arq6` · AI §7.5 paragon base-cost comparison floor (the last unbuilt
-  comparison member) · `services/btd6_data_service.py` · `services/btd6_context_service.py` ·
-  `tests/unit/.../btd6` · 2026-06-16
 - `claude/upbeat-einstein-7rz9z0` · act on the 2026-06-16 autonomous-run review + owner answers —
   run-report footer · ledger guard-exemption + drift line · bug-fix-guard convention · auto-deploy
   misinformation fix · Q-0147 DM gate · Q-0085/0120/0121/0127 records · ledger tidy · 2026-06-16
@@ -41,6 +38,7 @@ living ledger (`docs/current-state.md`).
 > Trimmed 2026-06-16 (Q-0152): stale claims whose PRs merged are dropped — the durable record is the
 > PR + the `current-state.md` ledger. Keep this to the most recent handful, newest-first.
 
+- `claude/magical-rubin-u3arq6` · AI §7.5 paragon base-cost comparison floor (last unbuilt comparison member) · 2026-06-16 · **PR #962 (auto-merge on green)**
 - `claude/hopeful-meitner-772pv8` · extension-taxonomy crosswalk (Q-0151c) — overlay + generator + CI guard + plan · 2026-06-16 · **PR #958 (auto-merge on green)**
 - `claude/hopeful-meitner-772pv8` · architecture-atlas / structure-review idea intake (owner-uploaded review) · router Q-0151 · 2026-06-16 · **PR #957 (merged)**
 

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,9 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/magical-rubin-u3arq6` · AI §7.5 paragon base-cost comparison floor (the last unbuilt
+  comparison member) · `services/btd6_data_service.py` · `services/btd6_context_service.py` ·
+  `tests/unit/.../btd6` · 2026-06-16
 - `claude/upbeat-einstein-7rz9z0` · act on the 2026-06-16 autonomous-run review + owner answers —
   run-report footer · ledger guard-exemption + drift line · bug-fix-guard convention · auto-deploy
   misinformation fix · Q-0147 DM gate · Q-0085/0120/0121/0127 records · ledger tidy · 2026-06-16

--- a/tests/unit/invariants/test_btd6_floor_builder_exclusivity.py
+++ b/tests/unit/invariants/test_btd6_floor_builder_exclusivity.py
@@ -60,6 +60,10 @@ _SHOULD_FIRE: tuple[tuple[str, str], ...] = (
         "which earns more cash, rounds 20-40 or rounds 40-60?",
         "deterministic_round_range_comparison_reply",
     ),
+    (
+        "is the glaive dominus or ascended shadow paragon cheaper",
+        "deterministic_paragon_cost_comparison_reply",
+    ),
 )
 
 # Ordinary BTD6 questions / strategy / single-entity lookups — zero builders fire.

--- a/tests/unit/services/test_btd6_paragon_cost_comparison.py
+++ b/tests/unit/services/test_btd6_paragon_cost_comparison.py
@@ -1,0 +1,211 @@
+"""AI §7.5 — deterministic BTD6 *paragon* base-cost comparison.
+
+The paragon member of the multi-entity comparison floor — the paragon-entity
+sibling of the tower cost builders (``test_btd6_cost_comparison.py`` ranks tower
+upgrade states, ``test_btd6_difficulty_cost_comparison.py`` ranks difficulties,
+``test_btd6_round_range_comparison.py`` ranks income). "is Glaive Dominus or
+Ascended Shadow cheaper" ranks the **base build price** of **two or more**
+paragons, so the model can never mis-state which is cheaper / by how much (the
+BUG-0009 "grounded values, wrong assembly" class the value-only faithfulness
+guard cannot catch). These pin the deterministic ``compare_paragon_costs``
+primitive + the floor reply / dispatcher wiring, and the exclusivity with the
+tower cost builders (a "paragon" question must not be priced as the base tower).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from services import btd6_context_service, btd6_data_service  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_dataset_cache():
+    btd6_data_service.reset_cache()
+    yield
+    btd6_data_service.reset_cache()
+
+
+# --- the primitive (btd6_data_service.compare_paragon_costs) -------------------
+
+
+def test_compare_ranks_ascending_with_spread():
+    result = btd6_data_service.compare_paragon_costs(
+        ["glaive dominus", "ascended shadow"],
+    )
+    assert result["found"] is True
+    # Ranked ascending — cheapest first.
+    costs = [e["base_cost"] for e in result["entries"]]
+    assert costs == sorted(costs)
+    assert result["cheapest"]["name"] == "Glaive Dominus"
+    assert result["most_expensive"]["name"] == "Ascended Shadow"
+    assert result["cheapest"]["base_cost"] == 375_000
+    assert result["most_expensive"]["base_cost"] == 500_000
+    assert result["spread"] == 125_000
+    assert result["all_equal"] is False
+    assert result["difficulty"] == "medium"
+
+
+def test_compare_resolves_aliases_and_tower_names():
+    # "dart" (alias) + "wizard monkey" (tower name) both resolve to paragons.
+    result = btd6_data_service.compare_paragon_costs(["dart", "wizard monkey"])
+    assert result["found"] is True
+    ids = {e["paragon_id"] for e in result["entries"]}
+    assert ids == {"apex_plasma_master", "magus_perfectus"}
+
+
+def test_compare_equal_base_prices_is_a_real_tie():
+    # Ascended Shadow and Navarch share a $500,000 base — a genuine all-equal.
+    result = btd6_data_service.compare_paragon_costs(
+        ["ascended shadow", "navarch of the seas"],
+    )
+    assert result["found"] is True
+    assert result["all_equal"] is True
+    assert result["spread"] == 0
+
+
+def test_compare_dedups_on_paragon_id():
+    # The same paragon under two surfaces (id + alias) collapses → defer.
+    result = btd6_data_service.compare_paragon_costs(["apex_plasma_master", "dart"])
+    assert result["found"] is False
+    assert result["priced"] == 1
+
+
+def test_compare_needs_two_distinct():
+    result = btd6_data_service.compare_paragon_costs(["glaive dominus"])
+    assert result["found"] is False
+    assert result["priced"] == 1
+
+
+def test_compare_skips_unknown_names_never_guesses():
+    result = btd6_data_service.compare_paragon_costs(["glaive dominus", "not a paragon"])
+    assert result["found"] is False
+    assert result["priced"] == 1
+
+
+def test_compare_difficulty_scales_the_base_price():
+    result = btd6_data_service.compare_paragon_costs(
+        ["glaive dominus", "ascended shadow"],
+        difficulty="impoppable",
+    )
+    assert result["found"] is True
+    assert result["difficulty"] == "impoppable"
+    # Impoppable is the Medium price × 1.20 (rounded to $5).
+    assert result["cheapest"]["base_cost"] == 450_000
+    assert result["most_expensive"]["base_cost"] == 600_000
+
+
+def test_compare_unknown_difficulty_fails_closed():
+    result = btd6_data_service.compare_paragon_costs(
+        ["glaive dominus", "ascended shadow"],
+        difficulty="nightmare",
+    )
+    assert result["found"] is False
+
+
+# --- the floor reply (deterministic_paragon_cost_comparison_reply) -------------
+
+
+def test_reply_fires_and_names_the_cheaper_paragon():
+    reply = btd6_context_service.deterministic_paragon_cost_comparison_reply(
+        "is the glaive dominus or ascended shadow paragon cheaper?",
+    )
+    assert reply is not None
+    assert "Paragon cost comparison" in reply
+    assert "Glaive Dominus" in reply and "Ascended Shadow" in reply
+    assert "The **Glaive Dominus** is cheaper by **$125,000**" in reply
+
+
+def test_reply_three_paragons_uses_spread_format():
+    reply = btd6_context_service.deterministic_paragon_cost_comparison_reply(
+        "compare the cost of the dart, glaive and goliath doomship paragons",
+    )
+    assert reply is not None
+    assert "Cheapest:" in reply
+    assert "Most expensive:" in reply
+    assert "Spread:" in reply
+
+
+def test_reply_difficulty_token_routes_pricing():
+    reply = btd6_context_service.deterministic_paragon_cost_comparison_reply(
+        "which paragon is cheaper on impoppable, glaive dominus or ascended shadow?",
+    )
+    assert reply is not None
+    assert "Impoppable base price" in reply
+    assert "$450,000" in reply
+
+
+def test_reply_tie_states_same_price():
+    reply = btd6_context_service.deterministic_paragon_cost_comparison_reply(
+        "do the ascended shadow and navarch paragons cost the same?",
+    )
+    assert reply is not None
+    assert "cost the **same**" in reply
+
+
+def test_single_paragon_defers():
+    assert (
+        btd6_context_service.deterministic_paragon_cost_comparison_reply(
+            "how much does the glaive dominus paragon cost?",
+        )
+        is None
+    )
+
+
+def test_no_paragon_token_defers():
+    # Two paragon-tower names but no "paragon" word → not routed here (it is a
+    # tower question, owned by the tower cost builder).
+    assert (
+        btd6_context_service.deterministic_paragon_cost_comparison_reply(
+            "is the dart monkey or ninja monkey cheaper?",
+        )
+        is None
+    )
+
+
+def test_no_cost_cue_defers():
+    assert (
+        btd6_context_service.deterministic_paragon_cost_comparison_reply(
+            "what do the glaive dominus and ascended shadow paragons do?",
+        )
+        is None
+    )
+
+
+def test_strategy_recommendation_defers():
+    assert (
+        btd6_context_service.deterministic_paragon_cost_comparison_reply(
+            "should i build the glaive dominus or ascended shadow paragon?",
+        )
+        is None
+    )
+
+
+# --- the dispatcher wiring + exclusivity ---------------------------------------
+
+
+def test_dispatcher_routes_paragon_cost_comparison():
+    reply = btd6_context_service.deterministic_btd6_list_reply(
+        "is the glaive dominus or ascended shadow paragon cheaper?",
+    )
+    assert reply is not None
+    assert "Paragon cost comparison" in reply
+
+
+def test_paragon_question_does_not_reach_the_tower_cost_builder():
+    # A "dart/ninja paragon" cost question (tower aliases present) must not be
+    # priced as the base tower — the tower cost builders defer on the paragon cue.
+    phrase = "is the dart or ninja paragon cheaper?"
+    firing = [
+        builder.__name__
+        for builder in btd6_context_service._BTD6_LIST_BUILDERS
+        if builder(phrase) is not None
+    ]
+    assert firing == ["deterministic_paragon_cost_comparison_reply"]


### PR DESCRIPTION
## What

The AI §7.5 multi-entity comparison floor (the BUG-0009 "grounded values, wrong assembly" class)
has shipped three of its four plan-listed members: tower-vs-tower cost (#946), by-difficulty cost
(#950), round-range cash (#955). This builds the **last** member flagged *not yet built* in
`docs/ai/ai-complex-request-tool-orchestration-plan.md` §7.5 — **paragon degree/resource**: a
deterministic comparison of paragons' **base build price** (the paragon entity's headline resource
number), grounded in `utils/btd6/paragon_math`'s committed `BASE_PRICES_MEDIUM` table.

Question shape: *"is Glaive Dominus or Ascended Shadow cheaper?"* — rank the base price of two-or-more
paragons so the model can never mis-state which is cheaper / by how much (the value-only faithfulness
guard cannot catch a mis-ranking). Ships under Q-0048 (read-only deterministic floor, no prod-check).

## Shape (mirrors #946/#950/#955)

- `btd6_data_service.compare_paragon_costs(names, *, difficulty="medium")` — the §7.5 paragon
  comparison primitive: resolve + price each named paragon, rank ascending, fail closed (<2 distinct).
- `btd6_context_service.deterministic_paragon_cost_comparison_reply` — high-precision floor: cost cue
  **+ a `paragon` token** + two-or-more resolved paragons. Registered in `_BTD6_LIST_BUILDERS`; the
  tower cost builders gain a `paragon`-present defer so the exclusivity invariant stays
  exactly-one-fires.
- Tests: a per-builder module + the §7.5 exclusivity corpus entry.

> Born-red session card (Q-0133) flips to `complete` as the final commit.

https://claude.ai/code/session_01HK4ViAziy4FBfFj2gQ4rUE

---
_Generated by [Claude Code](https://claude.ai/code/session_01HK4ViAziy4FBfFj2gQ4rUE)_