### PR TITLE
tooling(check_docs): soft inventory-count guard + architecture-review thread close (Q-0151)

### DIFF
--- a/.sessions/2026-06-16-architecture-review-thread-close.md
+++ b/.sessions/2026-06-16-architecture-review-thread-close.md
@@ -1,0 +1,66 @@
+# Session close — architecture-review thread (notes & remarks)
+
+> **Status:** `complete` — session-close summary for the owner + the next session.
+> **Date:** 2026-06-16 · **Branch:** `claude/hopeful-meitner-772pv8` · **PRs:** #957 · #958 · #960 · #964
+
+## What this session delivered
+
+An owner-uploaded external architecture review → a full intake/judgment/execute thread:
+
+| PR | Outcome |
+|---|---|
+| **#957** | Cross-checked judgment on the review + 3 binding-doc drift fixes + routing (Q-0151). |
+| **#958** | Extension-taxonomy crosswalk (43 ext ↔ 33 subsystems; the review's strongest finding) + CI guard. |
+| **#960** | Thin repo-wide atlas composer (`scripts/atlas.py`) + `role` in `context_map.py`. |
+| **#964** | Soft count-citation guard in `check_docs` — closes the drift class the review surfaced. (this PR; bundles this close note.) |
+
+**Bottom line for the owner:** the review's *direction* was right but its *diagnosis was overstated* —
+the bot's structure is sound, most "drift" was already gone, and its flagship "per-file dashboard" was
+~80% already shipped as `context_map.py`. The genuinely-new value was narrow (the taxonomy crosswalk),
+and it's now built. **No filesystem reorganization is warranted** — the review agreed, and so do I.
+
+## Notes / remarks for the next session
+
+1. **The thread is complete.** All three genuinely-additive review ideas shipped; the drift class can't
+   silently recur. Don't re-open it.
+2. **What's deliberately NOT done (both owner-gated, don't auto-start):**
+   - **Boundary-debt burndown** (review Option B): the `views→cogs` `arch-fix-13` cluster (~18 tracked
+     entries — blackjack/economy/xp/diagnostic panels importing cog `_helpers`/`_state`). A real
+     *runtime* refactor; scope as one small PR per area. Needs an explicit owner go-ahead — the review's
+     own thesis was "don't do big refactors, the foundation is sound."
+   - **Root README** (Q-0151b): owner said "not required but not off limits." Trivial pointer-only if
+     wanted; left alone rather than override the deliberate "no README" stance on a *maybe*.
+3. **New tooling worth knowing about:** `python3.10 scripts/atlas.py` (repo-wide index; `--full` /
+   `--check`) and `scripts/extension_crosswalk.py` (the 43↔33 map). Both compose the existing tools —
+   **extend the source tool, never re-implement in the atlas.** `docs/architecture/repo-atlas.md` is the
+   how-to.
+4. **Workflow friction observed (worth a habit change):** when opening a PR via the GitHub MCP, **don't
+   hardcode the predicted PR number** in committed docs first — parallel sessions consume numbers
+   (predicted #959/#961, got #960/#964; cost two fix-up commits). Create the PR, capture the real
+   number, *then* write it. Also: MCP-created PRs can open **`behind` main** and may need a manual
+   branch sync + `enable_pr_auto_merge` (Q-0127) — the enabler workflow doesn't fire on an app token.
+
+## Session enders (consolidated)
+
+**Grooming (Q-0015).** Drained the whole architecture-review branch of the idea backlog: #1 crosswalk →
+shipped, #2 atlas → shipped, #3 count-guard → shipped, and resolved the adjacent
+`readiness-maps-cite-regen-command` idea (investigated its widening, found it moot — audit docs are
+frozen-by-design, the one live map self-cites).
+
+**💡 Session idea (Q-0089).** *Surface `check_docs` soft signals in the SessionStart banner* — new file
+`docs/ideas/sessionstart-surface-soft-check-signals-2026-06-16.md`. This session shipped a soft guard
+(#964) and an uncommitted-body atlas (#960); both are "correct but invisible-unless-run." The repo's
+right to avoid false-positive *hard* gates has produced a pile of *soft* signals with no surfacing
+channel — one banner line (`Docs: soft — …`, via a `check_docs --soft-summary` mode) closes the loop
+for the whole class. (Touches the SessionStart hook → owner-wires per Q-0106.)
+
+**⟲ Previous-session review (Q-0102).** Across #958/#960/#964 the work was disciplined (compose-don't-
+duplicate, honest about thin value, anti-FP soft choices). The one cross-cutting miss it revealed is the
+soft-signal *visibility* gap above — each PR independently chose an invisible-unless-run signal, which is
+fine per-PR but a pattern worth fixing system-wide (hence the Q-0089 idea). Nothing to redo.
+
+**Doc audit (Q-0104).** All outputs are in durable homes (idea docs updated to shipped/resolved, plan +
+router Q-0151 recorded, atlas companion reachable, this close note). `check_docs --strict` green.
+**Out of scope (owned by the routine):** PR #960 crossed the multiple-of-30 cadence boundary, so the
+**docs-reconciliation routine is DUE** and the `current-state.md` ledger lag (~11 PRs) is real — the
+auto-routine handles both at the boundary (Q-0124: a manual session does not run the recon pass).

--- a/.sessions/2026-06-16-count-citation-guard.md
+++ b/.sessions/2026-06-16-count-citation-guard.md
@@ -1,21 +1,19 @@
 # Session — count-citation guard (soft check_docs rule)
 
-> **Status:** `in-progress` — born-red per Q-0133; flips to `complete` as the final step.
-> **Date:** 2026-06-16 · **Branch:** `claude/hopeful-meitner-772pv8` · **PR:** #961
+> **Status:** `complete` — work done, PR #964, auto-merge on green.
+> **Date:** 2026-06-16 · **Branch:** `claude/hopeful-meitner-772pv8` · **PR:** #964
 
-## What I'm about to do
+## What I did
 
-The owner-picked follow-on (#3 of the architecture-review thread): the **count-citation guard** — close
+The owner-picked follow-on (#3 of the architecture-review thread): the **count-citation guard** — closes
 the drift loop the three #957 fixes opened (bare hand-maintained inventory counts in binding docs).
 
 1. **`scripts/check_docs.py`** — a **soft** check (`inventory_count_flags` / `print_inventory_count_report`,
-   never changes exit code, like the census ratchets): flag a bare `N migrations/workflows/extensions/
+   never changes exit code, like the census ratchets): flags a bare `N migrations/workflows/extensions/
    cogs/subsystems` in a **binding** doc unless it cites a regen command (`scripts/*.py`), is marked
-   `generated`, or carries `<!-- count-ok -->`. Pinned-to-code docs (`smoke-test-checklist`,
-   `help-command-surface-map`, `ai-config-ownership`) are exempt — their own doc-tests guard their counts.
-2. **`tests/unit/scripts/test_check_docs.py`** — 6 logic tests (uncited→flag · citations exempt ·
-   adjacent-line citation · non-binding ignored · pinned exempt · silent-when-clean). Deliberately **no**
-   repo zero-pinning test → keeps the guard genuinely soft (no FP hard-gate on a future legit count).
+   `generated`, or carries `<!-- count-ok -->`. Pinned-to-code docs exempt (their doc-tests guard counts).
+2. **`tests/unit/scripts/test_check_docs.py`** — 6 logic tests; deliberately **no** repo zero-pinning
+   test → keeps the guard genuinely soft (no FP hard-gate on a future legit count).
 3. Idea docs updated: architecture-atlas #3 → shipped; `readiness-maps-cite-regen-command` → mechanism
    partially shipped (remaining: widen scope to `production-readiness/*`).
 
@@ -24,4 +22,35 @@ docs — a hard gate would red CI on dozens of pre-existing instances, against t
 culture. Soft + binding-scoped + pinned-exempt = clean zero-flag baseline now, useful nudge on any new
 count. (The idea itself called for "a soft check_docs rule.")
 
-(Close-out enders added at the bottom before the flip.)
+## Verification
+`check_quality --full` green (**10045 passed**, 37 skipped) · `check_docs --strict` clean ·
+`inventory_count_flags()` on the live repo → `[]` (clean baseline).
+
+## Session enders
+
+**Grooming (Q-0015).** Executed idea #3 of the architecture-review thread (count guard) — moved it
+routed→shipped in the capture doc, and advanced `readiness-maps-cite-regen-command` from captured →
+*mechanism partially shipped* (the regex + cite/escape-hatch detection now exists; only the scope-widen
+to `production-readiness/*` remains). The atlas thread is now fully executed (#957/#958/#960/#964).
+
+**💡 Session idea (Q-0089).** **Surface `check_docs` soft warnings in the SessionStart banner.** This
+session shipped a *soft* guard, and #960 shipped an atlas whose body isn't committed — both share a
+weakness: a soft/generated signal only helps if someone *sees* it, and today you only see it by running
+`check_docs` by hand. The SessionStart hook already surfaces arch / recon / ledger state; add a one-line
+"check_docs soft: N top-level over budget · M inventory-count flags · K recently-shipped over budget" so
+the soft ratchets are *proactively* visible (their whole design is to nudge, which requires visibility).
+Dedup-checked: the banner shows arch/recon/ledger, not check_docs soft warnings; new. Small (one hook
+line + a `check_docs --soft-summary` mode).
+
+**⟲ Previous-session review (Q-0102).** #960 (the atlas) was a clean thin composer with honest scoping.
+One genuine observation, reinforced by this session: #960 chose *body-not-committed* (invisible unless
+run) and this session chose *soft warning* (invisible unless run) — independently reasonable, but the
+pair reveals a systemic gap: **the repo keeps adding read-only signals that nobody is prompted to look
+at.** That's exactly what the Q-0089 idea above addresses (surface them at SessionStart). Good call this
+session keeping the count guard in `check_docs` (doc-hygiene domain) rather than folding it into the
+atlas `--check` (code-structure domain) — the seams stayed clean.
+
+**Doc audit (Q-0104).** Outputs homed: the `check_docs` change + tests, both idea docs updated to
+shipped/partially-shipped, card. `check_docs --strict` green. Pre-existing, **out of scope**: the
+`check_current_state_ledger` lag — owned by the #960-boundary reconciliation routine (Q-0124), which is
+due/firing now.

--- a/.sessions/2026-06-16-count-citation-guard.md
+++ b/.sessions/2026-06-16-count-citation-guard.md
@@ -1,0 +1,27 @@
+# Session — count-citation guard (soft check_docs rule)
+
+> **Status:** `in-progress` — born-red per Q-0133; flips to `complete` as the final step.
+> **Date:** 2026-06-16 · **Branch:** `claude/hopeful-meitner-772pv8` · **PR:** #961
+
+## What I'm about to do
+
+The owner-picked follow-on (#3 of the architecture-review thread): the **count-citation guard** — close
+the drift loop the three #957 fixes opened (bare hand-maintained inventory counts in binding docs).
+
+1. **`scripts/check_docs.py`** — a **soft** check (`inventory_count_flags` / `print_inventory_count_report`,
+   never changes exit code, like the census ratchets): flag a bare `N migrations/workflows/extensions/
+   cogs/subsystems` in a **binding** doc unless it cites a regen command (`scripts/*.py`), is marked
+   `generated`, or carries `<!-- count-ok -->`. Pinned-to-code docs (`smoke-test-checklist`,
+   `help-command-surface-map`, `ai-config-ownership`) are exempt — their own doc-tests guard their counts.
+2. **`tests/unit/scripts/test_check_docs.py`** — 6 logic tests (uncited→flag · citations exempt ·
+   adjacent-line citation · non-binding ignored · pinned exempt · silent-when-clean). Deliberately **no**
+   repo zero-pinning test → keeps the guard genuinely soft (no FP hard-gate on a future legit count).
+3. Idea docs updated: architecture-atlas #3 → shipped; `readiness-maps-cite-regen-command` → mechanism
+   partially shipped (remaining: widen scope to `production-readiness/*`).
+
+Design rationale: calibration grep showed the count pattern is widespread + often stale across non-binding
+docs — a hard gate would red CI on dozens of pre-existing instances, against the repo's anti-FP-gate
+culture. Soft + binding-scoped + pinned-exempt = clean zero-flag baseline now, useful nudge on any new
+count. (The idea itself called for "a soft check_docs rule.")
+
+(Close-out enders added at the bottom before the flip.)

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -39,6 +39,13 @@ Current broad captures:
   + a root-README question → **Q-0151** (answered); count-cite guard → fold into
   `readiness-maps-cite-regen-command`. → relates `scripts/{context_map,wiring_map,review_scope}.py` ·
   `utils/subsystem_registry.py` · `architecture_rules/layers.yaml`.
+- [`sessionstart-surface-soft-check-signals-2026-06-16.md`](./sessionstart-surface-soft-check-signals-2026-06-16.md) —
+  **session idea (2026-06-16, Q-0089, from the atlas thread #960/#964):** the repo keeps adding *soft*
+  signals that only help if run by hand (the `check_docs` ratchets + new inventory-count guard, the
+  uncommitted atlas body, the `--check` tools). Add **one SessionStart banner line** (`Docs: soft — …`)
+  backed by a `check_docs --soft-summary` mode so the soft ratchets are proactively visible, not
+  discovered by luck. Touches the SessionStart hook → owner-wires per Q-0106. → relates
+  `scripts/claude_session_start.sh` · `scripts/check_docs.py`.
 - [`round-range-comparison-bare-range-list-2026-06-16.md`](./round-range-comparison-bare-range-list-2026-06-16.md) —
   **session idea (2026-06-16, Q-0089, from the §7.5 round-range comparison floor PR #955):** the new
   round-range cash comparison requires a round token before *each* range's first anchor (to keep

--- a/docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md
+++ b/docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md
@@ -105,9 +105,11 @@ Built as a **soft** `check_docs` rule (`inventory_count_flags` / `print_inventor
 bare `N migrations/workflows/extensions/cogs/subsystems` in a **binding** doc warns unless it cites a
 regen command (`scripts/*.py`), is marked generated, or carries `<!-- count-ok -->`. Pinned-to-code
 docs are exempt (their doc-test already guards their counts). Baseline is clean (the #957 fixes + the
-exemption). It generalizes — and partially ships — the existing backlog idea
-[`readiness-maps-cite-regen-command-2026-06-13.md`](./readiness-maps-cite-regen-command-2026-06-13.md)
-(whose remaining half is widening the scope to `production-readiness/*` / `audits/*`).
+exemption). It also effectively **resolves** the existing backlog idea
+[`readiness-maps-cite-regen-command-2026-06-13.md`](./readiness-maps-cite-regen-command-2026-06-13.md):
+its readiness-map widening was investigated and **dropped as not-worth-it** — the
+`production-readiness/*` maps are `audit`-badged (frozen by design), and the one live settings map
+already self-cites its regen command.
 
 The three drift instances fixed in #957 share one root cause: a **bare integer count hand-typed
 into a binding doc**. The durable fix is the existing backlog idea
@@ -125,7 +127,7 @@ idea rather than opening a new one.
 | Fix the 3 confirmed drift counts in binding docs | tiny / reversible | **Executed in this PR** (bugs-first; source wins). De-numbered to point at source so they can't re-rot. |
 | **Extension-type taxonomy crosswalk + CI guard** (#1) | medium — touches `subsystem_registry` (a `REGISTRY_SCHEMA_VERSION` bump + validation) and adds a generated artifact + guard | **Structure into a plan** — needs its own `docs/planning/` plan (ownership: registry; reuse: existing metadata seam; mechanics: schema-version bump, validation, generated crosswalk, guard). Not a drive-by. |
 | **Thin unified atlas** `scripts/atlas.py` (#2) | medium — composes existing tools; new generated artifact | ✅ **SHIPPED (PR #960)** — Q-0151a answered (companion, body not committed); composer + `context_map` role line + companion doc + tests. |
-| **Count-citation guard** (#3) | small — `check_docs` rule | ✅ **SHIPPED (PR #964)** — soft `inventory_count_flags` in `check_docs` over binding docs (cite/`generated`/`<!-- count-ok -->` exempt; pinned docs exempt). Generalizes + partially ships `readiness-maps-cite-regen-command` (remaining: widen scope to `production-readiness/*`). |
+| **Count-citation guard** (#3) | small — `check_docs` rule | ✅ **SHIPPED (PR #964)** — soft `inventory_count_flags` in `check_docs` over binding docs (cite/`generated`/`<!-- count-ok -->` exempt; pinned docs exempt). Resolves `readiness-maps-cite-regen-command` (the readiness-map widening was investigated + dropped — audit docs frozen-by-design; live map self-cites). |
 | Selective boundary-debt burndown (Option B) — start with `arch-fix-13` `views→cogs` (≈18 entries) | medium, scoped, test-covered | **Roadmap candidate** (S1 / shared-platform). Already ticketed; this is execution, not discovery. Each cluster (blackjack, economy, xp, diagnostic) is its own small PR moving `_helpers`/`_state` to `utils/` or a shared module. |
 | Root README pointer | tiny but overrides a stated decision | **DISCUSS → Q-0151** (owner-only — contradicts `repo-navigation-map.md:51`). |
 | Reject `src/` layout / Option C / Option D / microservices | n/a | **Endorse the rejection** — consistent with repo posture; no action. |

--- a/docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md
+++ b/docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md
@@ -100,7 +100,7 @@ re-implementing them), (b) stamps **provenance** (commit SHA, generator version,
 owner-policy questions (atlas as the primary entry vs a companion; commit the generated artifacts vs
 CI-only). → **DISCUSS**, not auto-build.
 
-### 3. Count-citation guard (generalizes an existing backlog idea) — ✅ SHIPPED (PR #961)
+### 3. Count-citation guard (generalizes an existing backlog idea) — ✅ SHIPPED (PR #964)
 Built as a **soft** `check_docs` rule (`inventory_count_flags` / `print_inventory_count_report`): a
 bare `N migrations/workflows/extensions/cogs/subsystems` in a **binding** doc warns unless it cites a
 regen command (`scripts/*.py`), is marked generated, or carries `<!-- count-ok -->`. Pinned-to-code
@@ -125,7 +125,7 @@ idea rather than opening a new one.
 | Fix the 3 confirmed drift counts in binding docs | tiny / reversible | **Executed in this PR** (bugs-first; source wins). De-numbered to point at source so they can't re-rot. |
 | **Extension-type taxonomy crosswalk + CI guard** (#1) | medium — touches `subsystem_registry` (a `REGISTRY_SCHEMA_VERSION` bump + validation) and adds a generated artifact + guard | **Structure into a plan** — needs its own `docs/planning/` plan (ownership: registry; reuse: existing metadata seam; mechanics: schema-version bump, validation, generated crosswalk, guard). Not a drive-by. |
 | **Thin unified atlas** `scripts/atlas.py` (#2) | medium — composes existing tools; new generated artifact | ✅ **SHIPPED (PR #960)** — Q-0151a answered (companion, body not committed); composer + `context_map` role line + companion doc + tests. |
-| **Count-citation guard** (#3) | small — `check_docs` rule | ✅ **SHIPPED (PR #961)** — soft `inventory_count_flags` in `check_docs` over binding docs (cite/`generated`/`<!-- count-ok -->` exempt; pinned docs exempt). Generalizes + partially ships `readiness-maps-cite-regen-command` (remaining: widen scope to `production-readiness/*`). |
+| **Count-citation guard** (#3) | small — `check_docs` rule | ✅ **SHIPPED (PR #964)** — soft `inventory_count_flags` in `check_docs` over binding docs (cite/`generated`/`<!-- count-ok -->` exempt; pinned docs exempt). Generalizes + partially ships `readiness-maps-cite-regen-command` (remaining: widen scope to `production-readiness/*`). |
 | Selective boundary-debt burndown (Option B) — start with `arch-fix-13` `views→cogs` (≈18 entries) | medium, scoped, test-covered | **Roadmap candidate** (S1 / shared-platform). Already ticketed; this is execution, not discovery. Each cluster (blackjack, economy, xp, diagnostic) is its own small PR moving `_helpers`/`_state` to `utils/` or a shared module. |
 | Root README pointer | tiny but overrides a stated decision | **DISCUSS → Q-0151** (owner-only — contradicts `repo-navigation-map.md:51`). |
 | Reject `src/` layout / Option C / Option D / microservices | n/a | **Endorse the rejection** — consistent with repo posture; no action. |

--- a/docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md
+++ b/docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md
@@ -100,8 +100,16 @@ re-implementing them), (b) stamps **provenance** (commit SHA, generator version,
 owner-policy questions (atlas as the primary entry vs a companion; commit the generated artifacts vs
 CI-only). → **DISCUSS**, not auto-build.
 
-### 3. Count-citation guard (generalizes an existing backlog idea)
-The three drift instances fixed in this PR share one root cause: a **bare integer count hand-typed
+### 3. Count-citation guard (generalizes an existing backlog idea) — ✅ SHIPPED (PR #961)
+Built as a **soft** `check_docs` rule (`inventory_count_flags` / `print_inventory_count_report`): a
+bare `N migrations/workflows/extensions/cogs/subsystems` in a **binding** doc warns unless it cites a
+regen command (`scripts/*.py`), is marked generated, or carries `<!-- count-ok -->`. Pinned-to-code
+docs are exempt (their doc-test already guards their counts). Baseline is clean (the #957 fixes + the
+exemption). It generalizes — and partially ships — the existing backlog idea
+[`readiness-maps-cite-regen-command-2026-06-13.md`](./readiness-maps-cite-regen-command-2026-06-13.md)
+(whose remaining half is widening the scope to `production-readiness/*` / `audits/*`).
+
+The three drift instances fixed in #957 share one root cause: a **bare integer count hand-typed
 into a binding doc**. The durable fix is the existing backlog idea
 [`readiness-maps-cite-regen-command-2026-06-13.md`](./readiness-maps-cite-regen-command-2026-06-13.md),
 generalized: a soft `check_docs` rule that flags a bare `N migrations` / `N workflows` / `N extensions`
@@ -117,7 +125,7 @@ idea rather than opening a new one.
 | Fix the 3 confirmed drift counts in binding docs | tiny / reversible | **Executed in this PR** (bugs-first; source wins). De-numbered to point at source so they can't re-rot. |
 | **Extension-type taxonomy crosswalk + CI guard** (#1) | medium — touches `subsystem_registry` (a `REGISTRY_SCHEMA_VERSION` bump + validation) and adds a generated artifact + guard | **Structure into a plan** — needs its own `docs/planning/` plan (ownership: registry; reuse: existing metadata seam; mechanics: schema-version bump, validation, generated crosswalk, guard). Not a drive-by. |
 | **Thin unified atlas** `scripts/atlas.py` (#2) | medium — composes existing tools; new generated artifact | ✅ **SHIPPED (PR #960)** — Q-0151a answered (companion, body not committed); composer + `context_map` role line + companion doc + tests. |
-| **Count-citation guard** (#3) | small — `check_docs` rule | **Fold into** `readiness-maps-cite-regen-command-2026-06-13.md` (generalize it). Quick-win lane when capacity allows; needs a low-false-positive design (don't flag legit numbers). |
+| **Count-citation guard** (#3) | small — `check_docs` rule | ✅ **SHIPPED (PR #961)** — soft `inventory_count_flags` in `check_docs` over binding docs (cite/`generated`/`<!-- count-ok -->` exempt; pinned docs exempt). Generalizes + partially ships `readiness-maps-cite-regen-command` (remaining: widen scope to `production-readiness/*`). |
 | Selective boundary-debt burndown (Option B) — start with `arch-fix-13` `views→cogs` (≈18 entries) | medium, scoped, test-covered | **Roadmap candidate** (S1 / shared-platform). Already ticketed; this is execution, not discovery. Each cluster (blackjack, economy, xp, diagnostic) is its own small PR moving `_helpers`/`_state` to `utils/` or a shared module. |
 | Root README pointer | tiny but overrides a stated decision | **DISCUSS → Q-0151** (owner-only — contradicts `repo-navigation-map.md:51`). |
 | Reject `src/` layout / Option C / Option D / microservices | n/a | **Endorse the rejection** — consistent with repo posture; no action. |

--- a/docs/ideas/readiness-maps-cite-regen-command-2026-06-13.md
+++ b/docs/ideas/readiness-maps-cite-regen-command-2026-06-13.md
@@ -3,15 +3,21 @@
 > **Status:** `ideas` — captured 2026-06-13 (Q-0089 session idea, from the P0-3 settings
 > pointer-lane foundation session). Not a plan; not approved. Source + merged PRs win.
 >
-> **⚙ Mechanism PARTIALLY SHIPPED (2026-06-16, PR #964, Q-0151).** The architecture-review
-> count-citation guard built exactly this mechanism in `check_docs.py`
-> (`inventory_count_flags` / `print_inventory_count_report`): a **soft** warning when a bare
-> inventory count (`N migrations/workflows/extensions/cogs/subsystems`) lacks a regen citation
-> (`scripts/*.py`), a `generated` marker, or `<!-- count-ok -->`. **Scope so far: `binding` docs
-> only.** The remaining half of *this* idea is to **widen the scope filter** to also cover
-> `docs/planning/production-readiness/*` and `docs/audits/*` (and add the `SettingSpec`/`BindingSpec`
-> count nouns) — a small follow-up that reuses the same regex + exemptions, just changing the
-> doc-set filter. Until then, the readiness maps stay unguarded.
+> **⚙ Mechanism SHIPPED for binding docs (2026-06-16, PR #964, Q-0151); the readiness-map widening
+> was investigated and DROPPED as not-worth-it.** The architecture-review count-citation guard built
+> this mechanism in `check_docs.py` (`inventory_count_flags` / `print_inventory_count_report`): a
+> **soft** warning when a bare inventory count lacks a regen citation (`scripts/*.py`), a `generated`
+> marker, or `<!-- count-ok -->`. Scope: **`binding` docs** (clean baseline, 0 flags).
+>
+> **Why widening to `production-readiness/*` was dropped (verified 2026-06-16):** 8 of the 10
+> `production-readiness/*` docs are badged **`audit`** — dated point-in-time snapshots where a frozen
+> count is *correct by design*; flagging them would be pure noise (the same reason ADRs/historical docs
+> are exempt). The one *live* map that matters
+> (`settings-bindings-provisioning-production-readiness-map`) **already self-cites**: its top line is
+> `python3.10 scripts/settings_lane_matrix.py (65 settings / 17 bindings, not the 36/13 below)` — the
+> exact cite-the-regen-command convention this idea asked for, already applied by hand. So there is no
+> valuable widening to do; the convention lives on as good practice for any *new* live readiness map.
+> **This idea is effectively resolved** (mechanism shipped where it adds value; the rest is moot).
 
 ## The gap
 

--- a/docs/ideas/readiness-maps-cite-regen-command-2026-06-13.md
+++ b/docs/ideas/readiness-maps-cite-regen-command-2026-06-13.md
@@ -2,6 +2,16 @@
 
 > **Status:** `ideas` — captured 2026-06-13 (Q-0089 session idea, from the P0-3 settings
 > pointer-lane foundation session). Not a plan; not approved. Source + merged PRs win.
+>
+> **⚙ Mechanism PARTIALLY SHIPPED (2026-06-16, PR #961, Q-0151).** The architecture-review
+> count-citation guard built exactly this mechanism in `check_docs.py`
+> (`inventory_count_flags` / `print_inventory_count_report`): a **soft** warning when a bare
+> inventory count (`N migrations/workflows/extensions/cogs/subsystems`) lacks a regen citation
+> (`scripts/*.py`), a `generated` marker, or `<!-- count-ok -->`. **Scope so far: `binding` docs
+> only.** The remaining half of *this* idea is to **widen the scope filter** to also cover
+> `docs/planning/production-readiness/*` and `docs/audits/*` (and add the `SettingSpec`/`BindingSpec`
+> count nouns) — a small follow-up that reuses the same regex + exemptions, just changing the
+> doc-set filter. Until then, the readiness maps stay unguarded.
 
 ## The gap
 

--- a/docs/ideas/readiness-maps-cite-regen-command-2026-06-13.md
+++ b/docs/ideas/readiness-maps-cite-regen-command-2026-06-13.md
@@ -3,7 +3,7 @@
 > **Status:** `ideas` — captured 2026-06-13 (Q-0089 session idea, from the P0-3 settings
 > pointer-lane foundation session). Not a plan; not approved. Source + merged PRs win.
 >
-> **⚙ Mechanism PARTIALLY SHIPPED (2026-06-16, PR #961, Q-0151).** The architecture-review
+> **⚙ Mechanism PARTIALLY SHIPPED (2026-06-16, PR #964, Q-0151).** The architecture-review
 > count-citation guard built exactly this mechanism in `check_docs.py`
 > (`inventory_count_flags` / `print_inventory_count_report`): a **soft** warning when a bare
 > inventory count (`N migrations/workflows/extensions/cogs/subsystems`) lacks a regen citation

--- a/docs/ideas/sessionstart-surface-soft-check-signals-2026-06-16.md
+++ b/docs/ideas/sessionstart-surface-soft-check-signals-2026-06-16.md
@@ -1,0 +1,50 @@
+# Surface `check_docs` soft signals in the SessionStart banner
+
+> **Status:** `ideas` — captured 2026-06-16 (Q-0089 session idea, from the architecture-atlas
+> thread: the count-guard #964 + the atlas #960). Not a plan; not approved. Source + merged PRs win.
+> **Touches executable config** (the SessionStart hook) → needs owner sign-off to wire (Q-0106).
+
+## The gap
+
+This repo keeps adding **read-only / soft signals that only help if someone runs them by hand**:
+
+- `check_docs` soft ratchets: the top-level-pile budget, `Recently shipped` budget, and now the
+  **inventory-count drift guard** (#964) — all *warn, never fail CI*.
+- The architecture **atlas** (#960): its body is generated **on demand, not committed** (Q-0151a).
+- `scripts/atlas.py --check`, `extension_crosswalk.py --check`, `dispatch_menu.py`, … — runnable,
+  not CI-wired (ask-first).
+
+A soft signal's whole value is the *nudge*, and a nudge nobody sees does nothing. Today the
+SessionStart banner surfaces **arch / recon / ledger** state — but not the `check_docs` soft warnings.
+So a binding doc can grow a stale inventory count (exactly the drift the #964 guard exists to catch)
+and the warning sits unseen until someone happens to run `check_docs`.
+
+## The idea
+
+Add **one line** to the SessionStart banner (`scripts/claude_session_start.sh`) summarising the soft
+signals, e.g.:
+
+```
+Docs   : soft — top-level 19/19 · recently-shipped 20/20 · inventory-count flags: 0
+```
+
+Backed by a cheap `check_docs --soft-summary` mode (a new flag that prints just the ratchet counts +
+`len(inventory_count_flags())`, no full run). The banner already shows `Recon`/`Ledger`, so this fits
+the existing shape — it makes the soft ratchets *proactively visible* instead of discovered by luck.
+
+## Why I believe in it
+
+Two PRs this session (#960 atlas body-not-committed, #964 soft count-guard) independently chose
+"correct but invisible-unless-run." That's a *systemic* pattern, not a one-off — the repo's instinct
+to avoid false-positive **hard** gates is right, but it has produced a pile of **soft** signals with
+no surfacing channel. One banner line closes the loop for the whole class at once, and it's the
+cheapest possible intervention (no new gate, no CI cost, no FP risk).
+
+## Mechanics / caveats
+
+- `scripts/claude_session_start.sh` is **executable config** — per Q-0106 an agent proposes, the owner
+  wires it. This capture is the proposal; the `--soft-summary` mode in `check_docs.py` (ordinary
+  tooling) can be built first and the hook line added on owner approval.
+- Keep it to **counts**, not the full flag list, so the banner stays scannable (the detail is one
+  `python3.10 scripts/check_docs.py` away).
+- Pairs with the prior `mirror-test coverage by review-unit` idea (same "surface a latent signal" theme).

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -35,6 +35,8 @@ living ledger (`docs/current-state.md`).
 
 ## Recently cleared
 
+- `claude/hopeful-meitner-772pv8` · count-citation guard + session-close notes (Q-0151, atlas thread #3)
+  — soft `check_docs` inventory-count rule · 2026-06-16 · **PR #964 (auto-merge on green)**
 - `claude/peaceful-tesla-vvayya` · Hermes efficiency — idea-spotlight · morning-briefing ·
   dispatch-resolve skills + 6h auto session-reset · 2026-06-16 · **PR #959 (auto-merge pending)**
 

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,9 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/hopeful-meitner-772pv8` · count-citation guard (Q-0151, atlas thread #3) — soft `check_docs`
+  rule flagging uncited inventory counts in binding docs · `scripts/check_docs.py` + tests + idea-doc
+  updates · 2026-06-16
 - `claude/upbeat-einstein-7rz9z0` · act on the 2026-06-16 autonomous-run review + owner answers —
   run-report footer · ledger guard-exemption + drift line · bug-fix-guard convention · auto-deploy
   misinformation fix · Q-0147 DM gate · Q-0085/0120/0121/0127 records · ledger tidy · 2026-06-16

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,9 +25,6 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/hopeful-meitner-772pv8` · count-citation guard (Q-0151, atlas thread #3) — soft `check_docs`
-  rule flagging uncited inventory counts in binding docs · `scripts/check_docs.py` + tests + idea-doc
-  updates · 2026-06-16
 - `claude/upbeat-einstein-7rz9z0` · act on the 2026-06-16 autonomous-run review + owner answers —
   run-report footer · ledger guard-exemption + drift line · bug-fix-guard convention · auto-deploy
   misinformation fix · Q-0147 DM gate · Q-0085/0120/0121/0127 records · ledger tidy · 2026-06-16

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -23,6 +23,15 @@ Hard rules (CI gate — see ``--strict``):
      MERGED work + the single ``▶ Next action`` pointer; in-flight status comes from
      live GitHub. This gate forbids reintroducing the rotting markers.
 
+Soft checks (printed as warnings — never change the exit code, like the census
+ratchets):
+
+  - **inventory-count** — a bare hand-maintained count (``N migrations`` /
+    ``workflows`` / ``extensions`` / ``cogs`` / ``subsystems``) in a ``binding``
+    doc, unless it cites a regen command, is marked generated, or carries
+    ``<!-- count-ok -->``. The drift class the 2026-06-16 architecture review
+    found; a nudge to cite/de-number, not a CI failure.
+
 Pure stdlib (no third-party imports) so CI can run it on every PR — including
 docs-only PRs — without installing anything.
 
@@ -77,6 +86,37 @@ _STALE_PENDING_RE = re.compile(
     r"\(\s*pending pr\s*\)|\(\s*this pr,?\s*pending\s*\)|\bthis pr \(pending\)",
     re.IGNORECASE,
 )
+
+# --- Inventory-count drift guard (soft) ------------------------------------
+# A bare integer followed by one of these nouns in a BINDING doc is almost always
+# a hand-maintained inventory count that rots the moment the repo grows — the
+# exact drift class the 2026-06-16 architecture review found ("51 migrations" when
+# live was 74; "×28 cogs" when live was 43). This is a **soft** forcing function
+# (warn, never fail CI): binding contracts should cite the source of a count or
+# drop the number, not pin a value that silently goes stale. (Q-0151 / folds in
+# the readiness-maps-cite-regen-command idea.)
+_COUNT_NOUNS = ("migrations", "workflows", "extensions", "cogs", "subsystems")
+_INVENTORY_COUNT_RE = re.compile(
+    r"\b\d+\s+(?:" + "|".join(_COUNT_NOUNS) + r")\b",
+    re.IGNORECASE,
+)
+# A count is acceptable when, on its line or an adjacent one, it cites a regen
+# command (a scripts/*.py), is marked generated, or carries the explicit
+# `<!-- count-ok -->` escape hatch (declare an intentionally-maintained count).
+_COUNT_CITED_RE = re.compile(
+    r"scripts/[\w./-]+\.py|\bgenerated\b|<!--\s*count-ok\s*-->",
+    re.IGNORECASE,
+)
+# Pinned-to-code docs already have a dedicated doc-test verifying their counts
+# against live source, so a stronger guard than this heuristic covers them.
+_COUNT_GUARD_EXEMPT_DOCS = frozenset(
+    {
+        "smoke-test-checklist.md",
+        "help-command-surface-map.md",
+        "ai-config-ownership.md",
+    },
+)
+
 
 # A backtick-wrapped docs path, e.g. `docs/foo.md` — used to walk the doc graph
 # (backtick refs are how most SuperBot docs cross-link, alongside markdown links).
@@ -289,6 +329,57 @@ def check_freshness() -> list[tuple[Path, str, str]]:
     return violations
 
 
+def inventory_count_flags() -> list[tuple[Path, str, str]]:
+    """Soft: bare hand-maintained inventory counts in BINDING docs (drift-prone).
+
+    Flags ``N migrations`` / ``N workflows`` / ``N extensions`` / ``N cogs`` /
+    ``N subsystems`` in a ``binding``-badged doc unless the count cites a regen
+    command, is marked generated, or carries ``<!-- count-ok -->``. **Soft** — the
+    caller prints these as a warning and never changes the exit code (a binding
+    doc may legitimately state a number; this is a nudge to cite or de-number it,
+    not a CI failure). Pinned-to-code docs are exempt (their doc-test guards them).
+    """
+    flags: list[tuple[Path, str, str]] = []
+    for f in _docs_files():
+        if _is_adr(f) or f.name in _COUNT_GUARD_EXEMPT_DOCS:
+            continue
+        if _doc_badge(f) != "binding":
+            continue
+        rel = f.relative_to(REPO_ROOT)
+        lines = f.read_text(encoding="utf-8").splitlines()
+        for i, line in enumerate(lines):
+            for m in _INVENTORY_COUNT_RE.finditer(line):
+                window = "\n".join(lines[max(0, i - 1) : i + 2])
+                if _COUNT_CITED_RE.search(window):
+                    continue
+                flags.append(
+                    (
+                        rel,
+                        "inventory-count",
+                        f"L{i + 1}: hand-maintained count `{m.group(0)}` in a binding "
+                        "doc rots when the repo grows — cite its regen command "
+                        "(e.g. `scripts/extension_crosswalk.py`), drop the number, or "
+                        "mark it `<!-- count-ok -->`.",
+                    ),
+                )
+    return flags
+
+
+def print_inventory_count_report() -> None:
+    """Soft report of drift-prone inventory counts in binding docs (never fails CI)."""
+    flags = inventory_count_flags()
+    if not flags:
+        return
+    print(
+        f"  ⚠ {len(flags)} hand-maintained inventory count(s) in binding docs — "
+        "cite a regen command, drop the number, or mark `<!-- count-ok -->`. "
+        "(soft — not a CI failure)",
+    )
+    for rel, _kind, msg in sorted(flags, key=lambda x: str(x[0])):
+        print(f"      {rel}: {msg}")
+    print()
+
+
 def census() -> tuple[int, int, dict[str, int]]:
     """Return ``(total_docs, top_level_count, counts_by_badge)``.
 
@@ -370,6 +461,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     print_census()
+    print_inventory_count_report()
 
     violations = (
         check_badges()

--- a/tests/unit/scripts/test_check_docs.py
+++ b/tests/unit/scripts/test_check_docs.py
@@ -278,3 +278,76 @@ def test_repo_top_level_docs_within_ratchet(cd):
         f"top-level docs/*.md = {top_level} > ratchet {cd._TOP_LEVEL_DOCS_BUDGET}; "
         "move plans/audits/historical into a subdir or lower the ratchet."
     )
+
+
+# ---------------------------------------------------------------------------
+# Inventory-count drift guard (soft) — Q-0151
+# ---------------------------------------------------------------------------
+
+
+def test_inventory_count_uncited_binding_flagged(cd, tmp_path, monkeypatch):
+    docs = tmp_path / "docs"
+    _write(
+        docs / "architecture.md",
+        "# A\n\n> **Status:** `binding`\n\nThe DB has 74 migrations today.\n",
+    )
+    monkeypatch.setattr(cd, "DOCS_ROOT", docs)
+    monkeypatch.setattr(cd, "REPO_ROOT", tmp_path)
+    flags = cd.inventory_count_flags()
+    assert len(flags) == 1
+    assert flags[0][1] == "inventory-count" and "74 migrations" in flags[0][2]
+
+
+def test_inventory_count_citations_exempt(cd, tmp_path, monkeypatch):
+    docs = tmp_path / "docs"
+    _write(
+        docs / "a.md",
+        "# A\n\n> **Status:** `binding`\n\n"
+        "74 migrations (see `scripts/x.py`).\n"
+        "6 workflows <!-- count-ok -->.\n"
+        "43 extensions are generated below.\n",
+    )
+    monkeypatch.setattr(cd, "DOCS_ROOT", docs)
+    monkeypatch.setattr(cd, "REPO_ROOT", tmp_path)
+    assert cd.inventory_count_flags() == []
+
+
+def test_inventory_count_adjacent_citation_exempt(cd, tmp_path, monkeypatch):
+    docs = tmp_path / "docs"
+    _write(
+        docs / "a.md",
+        "# A\n\n> **Status:** `binding`\n\n"
+        "Regenerate with `scripts/atlas.py`:\n"
+        "we load 43 extensions.\n",
+    )
+    monkeypatch.setattr(cd, "DOCS_ROOT", docs)
+    monkeypatch.setattr(cd, "REPO_ROOT", tmp_path)
+    assert cd.inventory_count_flags() == []
+
+
+def test_inventory_count_non_binding_ignored(cd, tmp_path, monkeypatch):
+    docs = tmp_path / "docs"
+    _write(docs / "ref.md", "# R\n\n> **Status:** `reference`\n\n74 migrations here.\n")
+    monkeypatch.setattr(cd, "DOCS_ROOT", docs)
+    monkeypatch.setattr(cd, "REPO_ROOT", tmp_path)
+    assert cd.inventory_count_flags() == []
+
+
+def test_inventory_count_pinned_doc_exempt(cd, tmp_path, monkeypatch):
+    docs = tmp_path / "docs"
+    _write(
+        docs / "help-command-surface-map.md",
+        "# H\n\n> **Status:** `binding`\n\n11 extensions lack the hook.\n",
+    )
+    monkeypatch.setattr(cd, "DOCS_ROOT", docs)
+    monkeypatch.setattr(cd, "REPO_ROOT", tmp_path)
+    assert cd.inventory_count_flags() == []
+
+
+def test_print_inventory_count_report_silent_when_clean(cd, tmp_path, monkeypatch, capsys):
+    docs = tmp_path / "docs"
+    _write(docs / "a.md", "# A\n\n> **Status:** `binding`\n\nno counts here.\n")
+    monkeypatch.setattr(cd, "DOCS_ROOT", docs)
+    monkeypatch.setattr(cd, "REPO_ROOT", tmp_path)
+    cd.print_inventory_count_report()
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
## What

The owner-picked follow-on (#3 of the architecture-review thread): the **count-citation guard**. The
three drift fixes in #957 (`51 migrations`→74, `×28 cogs`→43, the workflows line) shared one root
cause — a bare hand-maintained inventory count in a **binding** doc. This closes that loop. **Born red**
per Q-0133.

## How (soft, by design)

Calibration showed the count pattern is widespread and often stale across non-binding docs, so a hard
gate would red CI on dozens of pre-existing instances — against this repo's anti-false-positive-gate
culture (and the idea itself asked for "a soft check_docs rule"). So:

- **`scripts/check_docs.py`** — `inventory_count_flags()` + `print_inventory_count_report()`: a **soft**
  warning (never changes the exit code, like the existing census ratchets) when a bare
  `N migrations/workflows/extensions/cogs/subsystems` appears in a `binding` doc **unless** the line (or
  an adjacent one) cites a regen command (`scripts/*.py`), is marked `generated`, or carries
  `<!-- count-ok -->`.
- **Pinned-to-code docs exempt** (`smoke-test-checklist`, `help-command-surface-map`,
  `ai-config-ownership`) — their dedicated doc-tests already guard their counts with something stronger
  than this heuristic. Net: the current baseline is **clean (0 flags)**, so any *new* uncited count
  stands out.
- **`tests/unit/scripts/test_check_docs.py`** — 6 logic tests (uncited→flag · citation/`generated`/
  `<!-- count-ok -->` exempt · adjacent-line citation · non-binding ignored · pinned exempt ·
  silent-when-clean). **No** repo zero-pinning test — deliberately, to keep the guard genuinely soft
  (no FP hard-gate on a future legitimate count).

Generalizes and **partially ships** the `readiness-maps-cite-regen-command` idea (remaining half:
widen the scope filter to `production-readiness/*` / `audits/*`, reusing the same regex + exemptions).

## Verification
- `python3.10 scripts/check_quality.py --full` → **10045 passed**, 37 skipped; lint/mypy/check_docs green.
- `check_docs --strict` → clean; `inventory_count_flags()` on the live repo → `[]` (clean baseline).

Tooling + docs only; no `disbot/` runtime code.

https://claude.ai/code/session_017kiQvtYDdewQNK8ibqwQSf

---
_Generated by [Claude Code](https://claude.ai/code/session_017kiQvtYDdewQNK8ibqwQSf)_