### PR TITLE
ci(hermes): auto-update behind PRs + red-on-conflict guard (Q-0154)

### DIFF
--- a/.github/workflows/pr-auto-update.yml
+++ b/.github/workflows/pr-auto-update.yml
@@ -1,0 +1,70 @@
+name: pr-auto-update
+
+# Keep open claude/* PRs up to date with main so a BEHIND branch doesn't sit silently
+# green-but-unmergeable. This repo requires branches to be up to date before merging, and
+# GitHub native auto-merge does NOT auto-update a behind branch (no merge queue) — it just
+# waits. So when main moves, this brings the behind PRs forward; they re-test against current
+# main and auto-merge fires. A branch that CANNOT be cleanly updated (a real merge conflict)
+# fails update-branch and is left DIRTY for `pr-conflict-guard.yml` to flag RED.
+#
+# This is the "behind = handled silently; conflict = loud red" half of the owner's intent
+# (Q-0154, 2026-06-16): a behind/conflicted PR must never rot unnoticed (the #959 stall that
+# surfaced this — 12 PRs merged during the work and the branch sat behind+green).
+#
+# REQUIREMENTS: ROUTINE_PAT with Pull requests: Read/Write AND Contents: Read/Write (the same
+# token auto-merge-enabler.yml already needs). The PAT (not GITHUB_TOKEN) keeps the eventual
+# merge attributed to a real user so reconciliation-trigger.yml (on: push to main) keeps firing.
+#
+# Provenance + reliability (Q-0105): added 2026-06-16, owner-directed. UNVERIFIED — watch the
+# first few main-pushes to confirm it only updates BEHIND claude/* PRs and that a true conflict
+# is left for the conflict-guard. Delete this workflow if it misfires; updating a branch is
+# always doable by hand ("Update branch" button).
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-auto-update
+  cancel-in-progress: false
+
+jobs:
+  update-behind:
+    if: github.repository == 'menno420/superbot'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update BEHIND claude/* PRs against main
+        env:
+          GH_TOKEN: ${{ secrets.ROUTINE_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          # Open, non-draft claude/* PRs that are BEHIND main and not carved out
+          # (needs-hermes-review / do-not-automerge are left alone). A real conflict
+          # reports DIRTY (not BEHIND) and is skipped here — pr-conflict-guard flags it.
+          nums=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --base main \
+            --json number,headRefName,mergeStateStatus,isDraft,labels \
+            --jq '.[]
+                  | select(.headRefName | startswith("claude/"))
+                  | select(.isDraft | not)
+                  | select(.mergeStateStatus == "BEHIND")
+                  | select([.labels[].name]
+                           | (contains(["needs-hermes-review"]) or contains(["do-not-automerge"]))
+                           | not)
+                  | .number')
+          if [ -z "$nums" ]; then
+            echo "No behind claude/* PRs to update."
+            exit 0
+          fi
+          for n in $nums; do
+            if gh api -X PUT "repos/$GITHUB_REPOSITORY/pulls/$n/update-branch" \
+                 -H "Accept: application/vnd.github+json" >/dev/null 2>&1; then
+              echo "Updated #$n against main (it will re-test, then auto-merge on green)."
+            else
+              echo "::warning::Could not update #$n — likely a real conflict; pr-conflict-guard will flag it RED."
+            fi
+          done

--- a/.github/workflows/pr-conflict-guard.yml
+++ b/.github/workflows/pr-conflict-guard.yml
@@ -1,0 +1,78 @@
+name: pr-conflict-guard
+
+# Make a merge conflict LOUD instead of silent. A conflicted (DIRTY) PR otherwise sits with a
+# green CI check (CI tested the branch head; the conflict is a git property, not a test result)
+# and GitHub only shows a small "this branch has conflicts" banner + quietly disables auto-merge
+# — so a conflicted branch rots unnoticed. This posts a RED `conflict-guard` commit status on any
+# DIRTY PR (and clears it to green when resolved), so the PR visibly goes red for an agent / the
+# maintainer to act on — the signal the autonomous loop was supposed to have (Q-0154, 2026-06-16).
+#
+# It is a VISIBILITY signal, NOT a required merge gate: a non-required status. A DIRTY PR already
+# cannot merge, so nothing extra needs blocking — and keeping it non-required means NO branch-
+# protection change is needed for it to work. (Make it a required check only if you want it to
+# hard-block; not necessary.)
+#
+# Conflicts usually appear when MAIN moves (another PR merges), which is not an event on the stale
+# PR — so the timely trigger is `push: main` (fires reliably on every merge). `pull_request`
+# covers the PR's own pushes; `schedule` is a slow backstop (GitHub cron is best-effort/laggy).
+#
+# REQUIREMENTS: a token with statuses: write + pull-requests: read (ROUTINE_PAT or the default
+# GITHUB_TOKEN both work; PAT preferred for consistency).
+#
+# Provenance + reliability (Q-0105): added 2026-06-16, owner-directed. UNVERIFIED — confirm the
+# first DIRTY PR actually shows the red `conflict-guard` status and that it clears on resolution.
+# Delete this workflow if it flaps or misreports; conflicts are also visible in the PR UI banner.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: "23 */3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+concurrency:
+  group: pr-conflict-guard-${{ github.event_name }}-${{ github.event.pull_request.number || 'sweep' }}
+  cancel-in-progress: true
+
+jobs:
+  flag-conflicts:
+    if: github.repository == 'menno420/superbot'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reflect each open PR's merge state as the conflict-guard status
+        env:
+          GH_TOKEN: ${{ secrets.ROUTINE_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          # For every open PR: DIRTY -> red status; CLEAN/BEHIND/etc -> green (clears a prior
+          # red); UNKNOWN (GitHub still computing mergeability) -> skip, don't flap.
+          gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+            --json number,mergeStateStatus,headRefOid \
+            --jq '.[] | "\(.number) \(.mergeStateStatus) \(.headRefOid)"' \
+          | while read -r num state sha; do
+              [ -z "${sha:-}" ] && continue
+              case "$state" in
+                DIRTY)
+                  gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$sha" \
+                    -f state=failure -f context=conflict-guard \
+                    -f description="Merge conflict with main — merge main in / rebase to resolve." \
+                    >/dev/null 2>&1 && echo "🔴 #$num DIRTY -> red"
+                  ;;
+                UNKNOWN|"")
+                  echo "#$num mergeability not computed yet -> skip"
+                  ;;
+                *)
+                  gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$sha" \
+                    -f state=success -f context=conflict-guard \
+                    -f description="No merge conflict with main." \
+                    >/dev/null 2>&1 && echo "🟢 #$num $state -> clear"
+                  ;;
+              esac
+            done

--- a/.sessions/2026-06-16-pr-mergeability-keepers.md
+++ b/.sessions/2026-06-16-pr-mergeability-keepers.md
@@ -1,21 +1,61 @@
 # 2026-06-16 — PR mergeability keepers: auto-update behind + red-on-conflict
 
-> **Status:** `in-progress` — born-red session card (Q-0133). Flip to `complete` as the last step.
+> **Status:** `complete` — shipped; PR #965 auto-merges on green CI.
 
-## Intent (what this run is about to do)
+## Arc
 
-Follow-up to PR #959 (same session). The #959 stall surfaced a real gap the owner flagged: a
-behind/conflicted PR sits **green-and-stuck**, not red-and-actionable — the "forgotten PR" rot the
-loop was meant to kill. GitHub doesn't turn a conflict/behind state into a failed check, and native
-auto-merge won't auto-update a behind branch (no merge queue). Owner greenlit **both** halves
-(Q-0154):
+Follow-up to PR #959 (same session). The #959 stall (it sat `behind` main, green-but-unmergeable,
+while 12 PRs merged) made the owner ask: wasn't a problematic branch supposed to go **red so an
+agent acts**, not rot quietly? I verified the real behavior — a conflict/behind state is a git
+property, not a test result, so GitHub never reddens a check for it; native auto-merge won't
+auto-update a behind branch (no merge queue); born-red (Q-0133) only covers *incomplete* cards; the
+Q-0125 sweep is only every ~30 PRs. Owner chose **build both** (Q-0154).
 
-- **`.github/workflows/pr-auto-update.yml`** — on `push: main`, bring open `claude/*` PRs that are
-  `BEHIND` up to date (`update-branch`) so they re-test and auto-merge; a true conflict fails the
-  update and is left for the guard. (Would have prevented the #959 stall.)
-- **`.github/workflows/pr-conflict-guard.yml`** — on `push: main` + `pull_request` + schedule, post
-  a **red `conflict-guard` commit status** on any `DIRTY` PR (clear to green when resolved). A
-  conflict now goes visibly RED for an agent / the owner to act on. Non-required (visibility, not an
-  extra gate → no branch-protection change needed).
+## Shipped (PR #965)
 
-Supporting: Q-0154 in the router; a "PR mergeability keepers" section in `autonomous-routines.md`.
+- **`.github/workflows/pr-auto-update.yml`** — `push: main` → bring open non-draft `claude/*` PRs
+  that are `BEHIND` up to date so they re-test + auto-merge; carve-outs left alone; real conflicts
+  fall through to the guard. (behind = handled silently)
+- **`.github/workflows/pr-conflict-guard.yml`** — `push: main` + `pull_request` + schedule → red
+  `conflict-guard` status on any `DIRTY` PR, cleared on resolution (skips `UNKNOWN`). Non-required
+  (visibility, not a gate). (conflict = loud red)
+- Docs: router **Q-0154**; `autonomous-routines.md` § "PR mergeability keepers".
+
+YAML validated; jq/bash sweep + auto-update filter unit-checked against sample data locally.
+
+## Context delta
+
+- **Discovered by hand:** GitHub's mergeability model — `mergeStateStatus` (`BEHIND` vs `DIRTY` vs
+  `UNKNOWN`), that native auto-merge doesn't auto-update behind branches, and that conflicts surface
+  as a banner + auto-merge-disable, never a red check. Now captured in Q-0154 + the routines doc so
+  the next agent doesn't have to re-derive it from a live stall.
+- **Decisions made alone (in Q-0154):** `conflict-guard` is a **non-required** status (visibility,
+  no branch-protection change) rather than a hard gate; `push: main` as the primary trigger (cron is
+  a laggy backstop); applied to all open PRs (conflict-guard) but only `claude/*` (auto-update).
+- **Flagged for maintainer / known limits:** both workflows are UNVERIFIED until the first real
+  behind/conflict case exercises them (Q-0105 headers say so). `mergeStateStatus` is computed async,
+  so a freshly-pushed PR can read `UNKNOWN` briefly — handled by skipping (the `push:main`/schedule
+  re-runs settle it). This PR can still fall behind before it merges (the fix only helps *after* it's
+  on main) — I'll merge main in if so.
+
+## 📤 Run report
+
+- **Did:** shipped the two PR-mergeability-keeper workflows (auto-update behind + red-on-conflict) so
+  PRs stop sitting silently stuck · **Outcome:** shipped (PR #965, auto-merges on green)
+- **Shipped:** #965 — `pr-auto-update.yml` + `pr-conflict-guard.yml` + Q-0154 + routines doc
+- **⚑ Owner decisions needed:** `none` (chosen live via AskUserQuestion → Q-0154)
+- **⚑ Owner manual steps:** `none` required — `ROUTINE_PAT` already has the Pull-requests + Contents
+  write scope these need (same as `auto-merge-enabler.yml`). *Optional:* make `conflict-guard` a
+  required check if you want a conflict to hard-block (not necessary — a DIRTY PR can't merge anyway).
+- **↪ Next:** watch the first real behind/conflict case to confirm both fire (auto-update brings a
+  behind PR forward; a DIRTY PR shows the red `conflict-guard` status).
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (#959 earlier; this follow-up #965 auto-merges on green) |
+| CI-red rounds | 0 real (intentional born-red hold only) |
+| Repo-rule trips | 0 (no `disbot/` touched; YAML validated) |
+| New ideas contributed | 0 this follow-up (1 already this session — the verdict loop) |
+| Ideas groomed | 0 this follow-up (1 already this session) |

--- a/.sessions/2026-06-16-pr-mergeability-keepers.md
+++ b/.sessions/2026-06-16-pr-mergeability-keepers.md
@@ -1,0 +1,21 @@
+# 2026-06-16 — PR mergeability keepers: auto-update behind + red-on-conflict
+
+> **Status:** `in-progress` — born-red session card (Q-0133). Flip to `complete` as the last step.
+
+## Intent (what this run is about to do)
+
+Follow-up to PR #959 (same session). The #959 stall surfaced a real gap the owner flagged: a
+behind/conflicted PR sits **green-and-stuck**, not red-and-actionable — the "forgotten PR" rot the
+loop was meant to kill. GitHub doesn't turn a conflict/behind state into a failed check, and native
+auto-merge won't auto-update a behind branch (no merge queue). Owner greenlit **both** halves
+(Q-0154):
+
+- **`.github/workflows/pr-auto-update.yml`** — on `push: main`, bring open `claude/*` PRs that are
+  `BEHIND` up to date (`update-branch`) so they re-test and auto-merge; a true conflict fails the
+  update and is left for the guard. (Would have prevented the #959 stall.)
+- **`.github/workflows/pr-conflict-guard.yml`** — on `push: main` + `pull_request` + schedule, post
+  a **red `conflict-guard` commit status** on any `DIRTY` PR (clear to green when resolved). A
+  conflict now goes visibly RED for an agent / the owner to act on. Non-required (visibility, not an
+  extra gate → no branch-protection change needed).
+
+Supporting: Q-0154 in the router; a "PR mergeability keepers" section in `autonomous-routines.md`.

--- a/docs/operations/autonomous-routines.md
+++ b/docs/operations/autonomous-routines.md
@@ -230,6 +230,25 @@ The routine treats the issue as the go-signal, runs the docs-only pass, and clos
 - **Improve the prompts here, not only in the console** — edit this doc, then re-paste into the
   routine. This keeps the fleet's behavior reviewable in git.
 
+## PR mergeability keepers (auto-update + conflict-guard) — Q-0154
+
+Two small workflows keep open PRs from rotting silently — the gap the #959 stall exposed: a
+`behind`/conflicted PR sits **green-but-unmergeable** (a merge conflict is a git property, not a
+test result, so GitHub never reddens a check for it, and native auto-merge won't auto-update a
+behind branch without a merge queue). They split the two cases:
+
+| Workflow | Trigger | Does | Net effect |
+|---|---|---|---|
+| **`pr-auto-update.yml`** | `push: main` | brings open non-draft `claude/*` PRs that are **BEHIND** up to date (`update-branch`); carve-outs (`needs-hermes-review`/`do-not-automerge`) left alone; a real conflict fails the update and falls through to the guard | **behind = handled silently** → re-tests against current main → auto-merge fires |
+| **`pr-conflict-guard.yml`** | `push: main` + `pull_request` + schedule | posts a **red `conflict-guard` commit status** on any **DIRTY** PR, clears it on resolution (skips `UNKNOWN` to avoid flap) | **conflict = loud red** → an agent / the maintainer sees it and resolves it |
+
+`push: main` is the load-bearing trigger for both: a conflict/behind state arises when *main moves*
+(another PR merges), which is not an event on the stale PR. `conflict-guard` is a **non-required**
+status (a signal, not an extra gate — a DIRTY PR already can't merge), so no branch-protection
+change is needed. Both use `ROUTINE_PAT` (already scoped Pull requests + Contents write for
+`auto-merge-enabler.yml`). Kill switch (Q-0105): delete either workflow; both are disposable
+convenience guards, and "Update branch" / the conflict banner remain available by hand.
+
 ## Control-plane state (maintainer-verified) — the bits no in-repo checker can see
 
 > **Why this exists:** the autonomous loop spans the repo **and** a Railway/console/VPS control

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -33,6 +33,9 @@ living ledger (`docs/current-state.md`).
   the live event + all its info; history behind 📜 Past events) · `services/btd6_view_model_service.py`
   · `views/btd6/live_events_view.py` · `cogs/btd6/_event_helpers.py` · 2026-06-16
 
+- `claude/peaceful-tesla-vvayya` · PR mergeability keepers — auto-update behind + red-on-conflict
+  guard (Q-0154) · `.github/workflows/{pr-auto-update,pr-conflict-guard}.yml` · 2026-06-16
+
 ## Recently cleared
 
 - `claude/peaceful-tesla-vvayya` · Hermes efficiency — idea-spotlight · morning-briefing ·

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -5815,3 +5815,41 @@ reset per the runbook (confirm the `HERMES_RESET_CMD` for your Hermes build — 
 **Home:** `docs/operations/hermes-skills/{idea-spotlight,morning-briefing,dispatch-resolve}.md` ·
 `docs/operations/hermes-session-reset.md` · `scripts/hermes/{idea_spotlight.py,session_reset.sh}` ·
 `scripts/dispatch_menu.py` · `scripts/hermes/build_skills.py` (EXTRAS) · this Q-block.
+
+### Q-0154 — Behind/conflicted PRs must not sit silently: auto-update behind + red-on-conflict (2026-06-16)
+
+> **DECISION 2026-06-16 (owner-directed in-session, applied directly — ⚠ executable config, Q-0106
+> exception).** Surfaced live: PR #959 stalled because 12 PRs merged during the work, leaving the
+> branch `behind` main — and the owner pointed out this defeats the original intent, which was that a
+> problematic branch should go **red so an agent sees and acts**, not sit green-and-unmergeable. I
+> verified the actual behavior: a merge conflict/behind state is a *git property, not a test result*,
+> so GitHub does **not** redden a check for it, native auto-merge does **not** auto-update a behind
+> branch (no merge queue), and nothing in the repo turned conflicts red (born-red Q-0133 only covers
+> *incomplete* session cards; the Q-0125 reconciliation sweep is only every ~30 PRs). The owner chose
+> **build both** halves (via `AskUserQuestion`). Touches `.github/workflows/` (executable config), so
+> recorded under the Q-0106 in-session exception (owner is the live reviewer).
+
+**What shipped (PR #961):**
+
+- **`.github/workflows/pr-auto-update.yml`** — on `push: main`, brings open non-draft `claude/*` PRs
+  that are `BEHIND` up to date (`update-branch`) so they re-test against current main and auto-merge
+  fires. Carve-outs (`needs-hermes-review` / `do-not-automerge`) are left alone. A branch that can't
+  be cleanly updated (a real conflict) fails update-branch and is left for the guard. *Behind =
+  handled silently.* (Would have prevented the #959 stall.)
+- **`.github/workflows/pr-conflict-guard.yml`** — on `push: main` + `pull_request` + a schedule
+  backstop, posts a **red `conflict-guard` commit status** on any `DIRTY` PR and clears it to green
+  when resolved (skips `UNKNOWN` to avoid flapping). *Conflict = loud red.* It is a **non-required**
+  status (visibility, not an extra merge gate — a DIRTY PR already can't merge), so **no
+  branch-protection change is needed** for it to work.
+
+**Why `push: main` is the key trigger:** a conflict/behind state appears when *main moves* (another
+PR merges) — which is not an event on the stale PR — so both workflows hinge on `push: main`, which
+fires reliably on every merge. (GitHub `schedule:` cron is a laggy backstop only.)
+
+**Owner manual steps:** none beyond what already exists — `ROUTINE_PAT` already needs Pull requests +
+Contents write for `auto-merge-enabler.yml`, which is exactly what `pr-auto-update` uses; the guard
+posts statuses with the same token. Optionally make `conflict-guard` a *required* check if you want a
+conflict to hard-block (not necessary — it already can't merge).
+
+**Home:** `.github/workflows/{pr-auto-update,pr-conflict-guard}.yml` ·
+`docs/operations/autonomous-routines.md` § "PR mergeability keepers" · this Q-block.


### PR DESCRIPTION
## Why

Follow-up to #959, surfaced live: that PR stalled because 12 PRs merged during the work, leaving its
branch `behind` main — green CI, but silently unmergeable. The owner pointed out this defeats the
original intent: a problematic branch should go **red so an agent sees and acts**, not rot quietly.

I verified the actual behavior: a merge conflict / behind state is a **git property, not a test
result**, so GitHub never reddens a check for it; native auto-merge won't auto-update a behind branch
(no merge queue); and nothing in the repo turned conflicts red (born-red Q-0133 only covers
*incomplete* session cards; the Q-0125 reconciliation sweep is only every ~30 PRs). Owner chose
**build both** (Q-0154).

## What

- **`.github/workflows/pr-auto-update.yml`** — on `push: main`, bring open non-draft `claude/*` PRs
  that are `BEHIND` up to date (`update-branch`) → they re-test against current main and auto-merge
  fires. Carve-outs (`needs-hermes-review`/`do-not-automerge`) left alone; a real conflict fails the
  update and falls through to the guard. **(behind = handled silently — would have prevented #959.)**
- **`.github/workflows/pr-conflict-guard.yml`** — on `push: main` + `pull_request` + schedule, post a
  **red `conflict-guard` commit status** on any `DIRTY` PR, clear to green on resolution (skips
  `UNKNOWN` to avoid flap). **(conflict = loud red.)** Non-required status → visibility, not an extra
  merge gate, so **no branch-protection change needed**.

`push: main` is the load-bearing trigger for both (a conflict/behind state arises when main moves —
not an event on the stale PR). Both use `ROUTINE_PAT` (already scoped for `auto-merge-enabler.yml`).

## Scope / safety

Two workflow files + docs (router Q-0154, `autonomous-routines.md` § "PR mergeability keepers") + a
session card. No `disbot/` runtime, no DB. Both workflows are disposable/kill-switchable (Q-0105).
YAML validated; the jq/bash sweep + filter logic unit-checked against sample data locally.

https://claude.ai/code/session_011Add2RPDWutS7643URURns

---
_Generated by [Claude Code](https://claude.ai/code/session_011Add2RPDWutS7643URURns)_