### PR TITLE
fix(ci): pr-conflict-guard token (GITHUB_TOKEN) + bash-errexit safety

### DIFF
--- a/.github/workflows/pr-conflict-guard.yml
+++ b/.github/workflows/pr-conflict-guard.yml
@@ -47,32 +47,46 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Reflect each open PR's merge state as the conflict-guard status
+        # GITHUB_TOKEN (not ROUTINE_PAT): posting a commit status needs `statuses: write`, which the
+        # permissions block above grants the GITHUB_TOKEN. ROUTINE_PAT is scoped for Issues/PRs/
+        # Contents (auto-merge-enabler) and may lack commit-status write — which 403'd and failed
+        # this job on its first run. This guard posts no main commits, so it needs no PAT attribution.
         env:
-          GH_TOKEN: ${{ secrets.ROUTINE_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
-          # For every open PR: DIRTY -> red status; CLEAN/BEHIND/etc -> green (clears a prior
-          # red); UNKNOWN (GitHub still computing mergeability) -> skip, don't flap.
-          gh pr list --repo "$GITHUB_REPOSITORY" --state open \
-            --json number,mergeStateStatus,headRefOid \
-            --jq '.[] | "\(.number) \(.mergeStateStatus) \(.headRefOid)"' \
-          | while read -r num state sha; do
-              [ -z "${sha:-}" ] && continue
-              case "$state" in
-                DIRTY)
-                  gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$sha" \
-                    -f state=failure -f context=conflict-guard \
-                    -f description="Merge conflict with main — merge main in / rebase to resolve." \
-                    >/dev/null 2>&1 && echo "🔴 #$num DIRTY -> red"
-                  ;;
-                UNKNOWN|"")
-                  echo "#$num mergeability not computed yet -> skip"
-                  ;;
-                *)
-                  gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$sha" \
-                    -f state=success -f context=conflict-guard \
-                    -f description="No merge conflict with main." \
-                    >/dev/null 2>&1 && echo "🟢 #$num $state -> clear"
-                  ;;
-              esac
-            done
+          # This is a NON-REQUIRED visibility status, so the job must never red-flag a PR on its own
+          # hiccup: capture first, guard each post, and exit 0 regardless of per-PR post outcomes.
+          prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+                  --json number,mergeStateStatus,headRefOid \
+                  --jq '.[] | "\(.number) \(.mergeStateStatus) \(.headRefOid)"' || true)
+          if [ -z "${prs:-}" ]; then
+            echo "no open PRs to evaluate"
+            exit 0
+          fi
+          # For every open PR: DIRTY -> red status; CLEAN/BEHIND/etc -> green (clears a prior red);
+          # UNKNOWN (GitHub still computing mergeability) -> skip, don't flap.
+          printf '%s\n' "$prs" | while read -r num state sha; do
+            [ -n "${sha:-}" ] || continue
+            case "$state" in
+              DIRTY)
+                st=failure
+                desc="Merge conflict with main — merge main in / rebase to resolve."
+                ;;
+              UNKNOWN|"")
+                echo "#$num mergeability not computed yet -> skip"
+                continue
+                ;;
+              *)
+                st=success
+                desc="No merge conflict with main."
+                ;;
+            esac
+            if gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$sha" \
+                 -f state="$st" -f context=conflict-guard -f description="$desc" >/dev/null 2>&1; then
+              echo "#$num $state -> $st"
+            else
+              echo "::warning::could not post conflict-guard status for #$num (needs statuses: write)"
+            fi
+          done
+          exit 0

--- a/.sessions/2026-06-16-conflict-guard-token-hotfix.md
+++ b/.sessions/2026-06-16-conflict-guard-token-hotfix.md
@@ -1,0 +1,53 @@
+# 2026-06-16 — hotfix: pr-conflict-guard token + bash-errexit safety
+
+> **Status:** `complete` — hotfix, shipped in one push; PR auto-merges on green.
+
+## Arc
+
+PR #965 merged the two PR-mergeability-keeper workflows, but the `flag-conflicts` job **failed on its
+own PR** (dogfooding caught it) — and because that check is non-required, #965 merged anyway, putting
+the **broken `pr-conflict-guard.yml` live on main**. Root cause from the job log: GitHub runs `run:`
+steps with `bash -e`, and `gh api POST /statuses/...` was failing — `ROUTINE_PAT` is scoped for
+Issues/PRs/Contents but **not `statuses: write`**, so the post 403'd and the errexit shell killed the
+step.
+
+## Fix (this PR)
+
+- **Token:** `pr-conflict-guard` now uses the default **`GITHUB_TOKEN`** (which the workflow's
+  `permissions: statuses: write` block grants), not `ROUTINE_PAT`. The guard posts no main commits, so
+  it needs no PAT attribution. (`pr-auto-update` keeps `ROUTINE_PAT` — it needs Contents+PR write for
+  `update-branch` and PAT attribution for the cadence; that scope it does have.)
+- **Errexit safety:** capture the PR list first (`|| true`), guard each status post with `if/else`
+  (warn, don't die), and `exit 0` — a non-required *visibility* job must never red-flag a PR on a
+  single post hiccup.
+- Doc: corrected the `autonomous-routines.md` token line (it wrongly said both use `ROUTINE_PAT`).
+
+## Context delta
+
+- **Discovered by hand:** (1) GitHub Actions `run:` defaults to `bash -e`, so `set -uo pipefail`
+  leaves errexit ON — an unguarded failing command kills the step. (2) `ROUTINE_PAT` ≠ all-scopes:
+  it lacks commit-status write. Both now documented at the call sites + the routines doc.
+- **Decision made alone:** ship as a fast hotfix PR (the broken workflow is live on main and
+  red-noises other PRs) rather than waiting — bugs-first, and I introduced it.
+- **Flagged:** still UNVERIFIED end-to-end until a real DIRTY PR shows the red status; but the
+  token+errexit fix addresses the exact observed 403/exit-1.
+
+## 📤 Run report
+
+- **Did:** fixed the `pr-conflict-guard` workflow (wrong token + errexit) that #965 shipped broken to
+  main · **Outcome:** shipped (auto-merges on green)
+- **Shipped:** this PR — `pr-conflict-guard.yml` token→GITHUB_TOKEN + hardened; doc correction
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** `none` (GITHUB_TOKEN has the needed scope via the workflow permissions
+  block; nothing to configure)
+- **↪ Next:** watch the first real behind/conflict case to confirm both keepers fire correctly.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 2 (#959, #965; this hotfix auto-merges on green) |
+| CI-red rounds | 1 real (the #965 `flag-conflicts` dogfood failure — root-caused from the job log + fixed here) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 0 this hotfix (1 already this session) |
+| Ideas groomed | 0 this hotfix |

--- a/docs/operations/autonomous-routines.md
+++ b/docs/operations/autonomous-routines.md
@@ -245,9 +245,12 @@ behind branch without a merge queue). They split the two cases:
 `push: main` is the load-bearing trigger for both: a conflict/behind state arises when *main moves*
 (another PR merges), which is not an event on the stale PR. `conflict-guard` is a **non-required**
 status (a signal, not an extra gate — a DIRTY PR already can't merge), so no branch-protection
-change is needed. Both use `ROUTINE_PAT` (already scoped Pull requests + Contents write for
-`auto-merge-enabler.yml`). Kill switch (Q-0105): delete either workflow; both are disposable
-convenience guards, and "Update branch" / the conflict banner remain available by hand.
+change is needed. **Token split (learned by dogfooding):** `auto-update` uses `ROUTINE_PAT` (it needs
+Pull requests + Contents write for `update-branch`, and PAT attribution keeps the cadence firing);
+`conflict-guard` uses the default **`GITHUB_TOKEN`** because posting a commit status needs
+`statuses: write`, which `ROUTINE_PAT` is not scoped for (that 403 failed the guard's first run).
+Kill switch (Q-0105): delete either workflow; both are disposable convenience guards, and "Update
+branch" / the conflict banner remain available by hand.
 
 ## Control-plane state (maintainer-verified) — the bits no in-repo checker can see
 


### PR DESCRIPTION
## Why (hotfix for a bug #965 shipped to main)

#965 added the two PR-mergeability-keeper workflows, but `flag-conflicts` (from `pr-conflict-guard.yml`)
**failed on its own PR** — and because that check is non-required, #965 merged anyway, leaving the
broken workflow live on `main` (it now red-noises other PRs' `pull_request` runs and fails on
`push: main`).

Root cause, from the failed job log: GitHub runs `run:` steps with `bash -e`, and `gh api POST
/statuses/...` failed because **`ROUTINE_PAT` lacks `statuses: write`** (it's scoped for
Issues/PRs/Contents) → 403 → the errexit shell exited 1.

## Fix

- **Token:** `pr-conflict-guard` uses the default **`GITHUB_TOKEN`** (the workflow's
  `permissions: statuses: write` grants it). The guard posts no `main` commits, so it needs no PAT
  attribution. `pr-auto-update` keeps `ROUTINE_PAT` (it needs Contents+PR write for `update-branch`).
- **Errexit safety:** capture the PR list first (`|| true`), guard each status post with `if/else`
  (warn, don't die), and `exit 0` — a non-required *visibility* job must never red-flag a PR on a
  single post hiccup.
- Corrected the `autonomous-routines.md` token line (it wrongly said both keepers use `ROUTINE_PAT`).

## Verification

YAML re-validated; the bash is now errexit-safe (capture-then-loop, `if/else`-guarded, explicit
`exit 0`). This PR's own `pull_request` run exercises the **fixed** workflow, so `flag-conflicts`
should now pass and post a green `conflict-guard` status (the dogfood that caught the bug now
confirms the fix). No `disbot/` runtime touched.

https://claude.ai/code/session_011Add2RPDWutS7643URURns

---
_Generated by [Claude Code](https://claude.ai/code/session_011Add2RPDWutS7643URURns)_