### PR TITLE
ci(conflict-guard): evaluate only the triggering PR on pull_request (cut noise)

### DIFF
--- a/.github/workflows/pr-conflict-guard.yml
+++ b/.github/workflows/pr-conflict-guard.yml
@@ -46,41 +46,28 @@ jobs:
     if: github.repository == 'menno420/superbot'
     runs-on: ubuntu-latest
     steps:
-      - name: Reflect each open PR's merge state as the conflict-guard status
-        # GITHUB_TOKEN (not ROUTINE_PAT): posting a commit status needs `statuses: write`, which the
-        # permissions block above grants the GITHUB_TOKEN. ROUTINE_PAT is scoped for Issues/PRs/
-        # Contents (auto-merge-enabler) and may lack commit-status write — which 403'd and failed
-        # this job on its first run. This guard posts no main commits, so it needs no PAT attribution.
+      - name: Reflect merge state as the conflict-guard status
+        # GITHUB_TOKEN (not ROUTINE_PAT): posting a commit status needs `statuses: write`, granted by
+        # the permissions block above. ROUTINE_PAT is scoped Issues/PRs/Contents and lacks commit-
+        # status write (that 403 failed this job's first run, #965 -> hotfix #966). No main commits → no PAT.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -uo pipefail
-          # This is a NON-REQUIRED visibility status, so the job must never red-flag a PR on its own
-          # hiccup: capture first, guard each post, and exit 0 regardless of per-PR post outcomes.
-          prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
-                  --json number,mergeStateStatus,headRefOid \
-                  --jq '.[] | "\(.number) \(.mergeStateStatus) \(.headRefOid)"' || true)
-          if [ -z "${prs:-}" ]; then
-            echo "no open PRs to evaluate"
-            exit 0
-          fi
-          # For every open PR: DIRTY -> red status; CLEAN/BEHIND/etc -> green (clears a prior red);
-          # UNKNOWN (GitHub still computing mergeability) -> skip, don't flap.
-          printf '%s\n' "$prs" | while read -r num state sha; do
-            [ -n "${sha:-}" ] || continue
+          # NON-REQUIRED visibility status: never red-flag a PR on a single hiccup (guard + exit 0).
+          # On a PR's own push, evaluate ONLY that PR — the all-PR sweep on every pull_request was
+          # needless noise that confused parallel sessions. On push:main / schedule, sweep all open
+          # PRs, because a PR can newly become DIRTY when main moves (not an event on the stale PR).
+
+          post() {  # $1=num  $2=mergeStateStatus  $3=headSha
+            local num="$1" state="$2" sha="$3" st desc
+            [ -n "$sha" ] || return 0
             case "$state" in
-              DIRTY)
-                st=failure
-                desc="Merge conflict with main — merge main in / rebase to resolve."
-                ;;
-              UNKNOWN|"")
-                echo "#$num mergeability not computed yet -> skip"
-                continue
-                ;;
-              *)
-                st=success
-                desc="No merge conflict with main."
-                ;;
+              DIRTY)      st=failure; desc="Merge conflict with main — merge main in / rebase to resolve." ;;
+              UNKNOWN|"") echo "#$num mergeability not computed yet -> skip"; return 0 ;;
+              *)          st=success; desc="No merge conflict with main." ;;
             esac
             if gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$sha" \
                  -f state="$st" -f context=conflict-guard -f description="$desc" >/dev/null 2>&1; then
@@ -88,5 +75,18 @@ jobs:
             else
               echo "::warning::could not post conflict-guard status for #$num (needs statuses: write)"
             fi
-          done
+          }
+
+          if [ "${EVENT:-}" = "pull_request" ]; then
+            line=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+                     --json mergeStateStatus,headRefOid \
+                     --jq '"\(.mergeStateStatus) \(.headRefOid)"' || true)
+            post "$PR_NUMBER" "$(printf '%s' "$line" | awk '{print $1}')" "$(printf '%s' "$line" | awk '{print $2}')"
+          else
+            prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+                    --json number,mergeStateStatus,headRefOid \
+                    --jq '.[] | "\(.number) \(.mergeStateStatus) \(.headRefOid)"' || true)
+            if [ -z "${prs:-}" ]; then echo "no open PRs to evaluate"; exit 0; fi
+            printf '%s\n' "$prs" | while read -r num state sha; do post "$num" "$state" "$sha"; done
+          fi
           exit 0

--- a/.sessions/2026-06-16-conflict-guard-noise-refine.md
+++ b/.sessions/2026-06-16-conflict-guard-noise-refine.md
@@ -1,0 +1,56 @@
+# 2026-06-16 — refine pr-conflict-guard to cut per-PR noise
+
+> **Status:** `complete` — owner-directed refinement; shipped in one push, auto-merges on green.
+
+## Arc
+
+After the conflict-guard hotfix (#966), the owner flagged that the guard — though now green — was
+**noisy**: it ran on every PR's push and swept *all* open PRs each time, so every PR got an
+unfamiliar `flag-conflicts` run + a `conflict-guard` status, and two parallel sessions (#963, #964)
+spent effort investigating a red check that wasn't theirs. Owner chose (via AskUserQuestion) to
+**refine to cut the noise**.
+
+## Shipped (this PR)
+
+- **`pr-conflict-guard.yml`** — a PR's **own** push (`pull_request`) now evaluates **only that PR**
+  (one `gh pr view` + one status post); the all-PR **sweep** runs only on `push: main` + `schedule`
+  (the moments a PR can *newly* become DIRTY because main moved). Same coverage, far less noise.
+- Bash refactored into a `post()` helper, branching on `$EVENT`; errexit-safe (guarded, `exit 0`).
+- Docs: corrected Q-0154 (real PR refs #965/#966 + this refinement; the conflict-guard token is
+  `GITHUB_TOKEN`, not "the same token"; added the dogfooding tail) and the `autonomous-routines.md`
+  conflict-guard row (scoped triggers).
+
+**Verified locally** with a `gh` stub (6 cases): pull_request DIRTY→one red / CLEAN→one green /
+UNKNOWN→skip-no-post; push sweep mixed states; empty list; and a failing post → warning, RC=0
+(non-fatal). Confirms only the triggering PR is touched on its own push.
+
+## Context delta
+
+- **Discovered by hand:** GitHub Actions exposes `$GITHUB_EVENT_NAME` (+ the event payload via
+  `${{ github.event.* }}`), so a workflow can cheaply branch "this PR vs sweep all" — the clean way
+  to keep a guard's footprint proportional to the trigger.
+- **Decision made alone:** kept the guard (refined) rather than removing it — the owner picked
+  refine; the red-on-conflict signal stays, just quieter.
+- **Flagged:** still UNVERIFIED against a real DIRTY PR end-to-end, but the stub test + the live
+  green runs post-#966 cover the mechanics. Cosmetic stale red checks on PRs opened during the
+  ~6-min #965 breakage clear on their next push.
+
+## 📤 Run report
+
+- **Did:** refined `pr-conflict-guard` so it only touches the triggering PR on its own push (sweep
+  reserved for main-moves/schedule) — kills the cross-session noise · **Outcome:** shipped (auto-merges)
+- **Shipped:** this PR — `pr-conflict-guard.yml` scope refinement + Q-0154/routines doc corrections
+- **⚑ Owner decisions needed:** `none` (chosen via AskUserQuestion)
+- **⚑ Owner manual steps:** `none`
+- **↪ Next:** the mergeability keepers are settled; watch the first real behind/conflict case to
+  confirm auto-update brings a behind PR forward and a DIRTY PR shows the red `conflict-guard`.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 3 (#959, #965, #966; this refinement auto-merges on green) |
+| CI-red rounds | 0 in this PR (the #965 dogfood failure was fixed in #966; logic stub-tested here pre-push) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 0 this follow-up (1 already this session) |
+| Ideas groomed | 0 this follow-up |

--- a/docs/operations/autonomous-routines.md
+++ b/docs/operations/autonomous-routines.md
@@ -240,7 +240,7 @@ behind branch without a merge queue). They split the two cases:
 | Workflow | Trigger | Does | Net effect |
 |---|---|---|---|
 | **`pr-auto-update.yml`** | `push: main` | brings open non-draft `claude/*` PRs that are **BEHIND** up to date (`update-branch`); carve-outs (`needs-hermes-review`/`do-not-automerge`) left alone; a real conflict fails the update and falls through to the guard | **behind = handled silently** → re-tests against current main → auto-merge fires |
-| **`pr-conflict-guard.yml`** | `push: main` + `pull_request` + schedule | posts a **red `conflict-guard` commit status** on any **DIRTY** PR, clears it on resolution (skips `UNKNOWN` to avoid flap) | **conflict = loud red** → an agent / the maintainer sees it and resolves it |
+| **`pr-conflict-guard.yml`** | `push: main` + schedule (sweep all PRs) · `pull_request` (that PR only) | posts a **red `conflict-guard` commit status** on any **DIRTY** PR, clears it on resolution (skips `UNKNOWN` to avoid flap). A PR's own push checks only itself; the all-PR sweep runs on `push: main`/schedule (when a PR can newly conflict) — keeps the noise off every PR | **conflict = loud red** → an agent / the maintainer sees it and resolves it |
 
 `push: main` is the load-bearing trigger for both: a conflict/behind state arises when *main moves*
 (another PR merges), which is not an event on the stale PR. `conflict-guard` is a **non-required**

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -5829,27 +5829,35 @@ reset per the runbook (confirm the `HERMES_RESET_CMD` for your Hermes build — 
 > **build both** halves (via `AskUserQuestion`). Touches `.github/workflows/` (executable config), so
 > recorded under the Q-0106 in-session exception (owner is the live reviewer).
 
-**What shipped (PR #961):**
+**What shipped (PR #965; token hotfix #966; noise-reduction refinement as a follow-up):**
 
 - **`.github/workflows/pr-auto-update.yml`** — on `push: main`, brings open non-draft `claude/*` PRs
-  that are `BEHIND` up to date (`update-branch`) so they re-test against current main and auto-merge
-  fires. Carve-outs (`needs-hermes-review` / `do-not-automerge`) are left alone. A branch that can't
-  be cleanly updated (a real conflict) fails update-branch and is left for the guard. *Behind =
-  handled silently.* (Would have prevented the #959 stall.)
-- **`.github/workflows/pr-conflict-guard.yml`** — on `push: main` + `pull_request` + a schedule
-  backstop, posts a **red `conflict-guard` commit status** on any `DIRTY` PR and clears it to green
-  when resolved (skips `UNKNOWN` to avoid flapping). *Conflict = loud red.* It is a **non-required**
-  status (visibility, not an extra merge gate — a DIRTY PR already can't merge), so **no
-  branch-protection change is needed** for it to work.
+  that are `BEHIND` up to date (`update-branch`, with `ROUTINE_PAT`) so they re-test against current
+  main and auto-merge fires. Carve-outs (`needs-hermes-review` / `do-not-automerge`) are left alone.
+  A branch that can't be cleanly updated (a real conflict) fails update-branch and is left for the
+  guard. *Behind = handled silently.* (Would have prevented the #959 stall.)
+- **`.github/workflows/pr-conflict-guard.yml`** — posts a **red `conflict-guard` commit status** on any
+  `DIRTY` PR and clears it to green when resolved (skips `UNKNOWN` to avoid flapping). *Conflict = loud
+  red.* Non-required status (visibility, not an extra merge gate — a DIRTY PR already can't merge), so
+  **no branch-protection change is needed**. Uses the default **`GITHUB_TOKEN`** (it needs
+  `statuses: write`, which `ROUTINE_PAT` is not scoped for — the #966 hotfix). Scope (the refinement):
+  a PR's **own** push evaluates **only that PR**; the all-PR **sweep** runs only on `push: main` +
+  schedule (when a PR can newly conflict) — the earlier sweep-on-every-PR was needless noise that made
+  parallel sessions investigate a red check that wasn't theirs.
 
 **Why `push: main` is the key trigger:** a conflict/behind state appears when *main moves* (another
 PR merges) — which is not an event on the stale PR — so both workflows hinge on `push: main`, which
 fires reliably on every merge. (GitHub `schedule:` cron is a laggy backstop only.)
 
-**Owner manual steps:** none beyond what already exists — `ROUTINE_PAT` already needs Pull requests +
-Contents write for `auto-merge-enabler.yml`, which is exactly what `pr-auto-update` uses; the guard
-posts statuses with the same token. Optionally make `conflict-guard` a *required* check if you want a
+**Owner manual steps:** none beyond what already exists — `ROUTINE_PAT` (auto-update) already has the
+Pull requests + Contents write it needs for `auto-merge-enabler.yml`; `conflict-guard` uses the
+`GITHUB_TOKEN` the workflow grants. Optionally make `conflict-guard` a *required* check if you want a
 conflict to hard-block (not necessary — it already can't merge).
+
+**Dogfooding tail (2026-06-16):** the guard's first run failed on its own PR (`bash -e` + a
+`gh api` 403 because `ROUTINE_PAT` lacks `statuses: write`) and, being non-required, #965 merged it
+broken to main → it red-flagged other sessions' PRs for ~6 min until hotfix #966 (token → GITHUB_TOKEN
++ errexit-safe). Then the owner flagged the sweep-on-every-PR noise → the scope refinement above.
 
 **Home:** `.github/workflows/{pr-auto-update,pr-conflict-guard}.yml` ·
 `docs/operations/autonomous-routines.md` § "PR mergeability keepers" · this Q-block.


### PR DESCRIPTION
## Why (owner-flagged)

The `conflict-guard` worked after #966, but it was **noisy**: it swept *all* open PRs on *every* PR's
push, so each PR got an unfamiliar `flag-conflicts` run + a `conflict-guard` status, and two parallel
sessions (#963, #964) spent effort investigating a red check that wasn't theirs. The owner chose to
refine it.

## What

- **`pr-conflict-guard.yml`** — on a PR's **own** push (`pull_request`), evaluate **only that PR** (one
  `gh pr view` + one status post). Keep the all-PR **sweep** only on `push: main` + `schedule` — the
  moments a PR can *newly* become `DIRTY` because main moved. Same coverage, far less noise.
- Bash refactored into a `post()` helper that branches on `$GITHUB_EVENT_NAME`; errexit-safe
  (guarded, `exit 0`).
- Docs: corrected the Q-0154 block (real PR refs #965/#966; `conflict-guard` uses `GITHUB_TOKEN`, not
  "the same token"; added the dogfooding tail) and the `autonomous-routines.md` conflict-guard row
  (scoped triggers).

## Verification

Stub-tested the embedded bash locally with a fake `gh` (6 cases): `pull_request` DIRTY→one red /
CLEAN→one green / UNKNOWN→skip-no-post; `push` sweep over mixed states; empty list; and a failing
status post → warning + RC 0 (non-fatal). Confirms a PR's own push touches **only** that PR. YAML
validated. No `disbot/` runtime.

https://claude.ai/code/session_011Add2RPDWutS7643URURns

---
_Generated by [Claude Code](https://claude.ai/code/session_011Add2RPDWutS7643URURns)_