### PR TITLE
fix(dashboard): drop StaticFiles mount (gitignored static/ broke deploy) + Railway deploy config

### DIFF
--- a/.sessions/2026-06-16-dashboard-deploy-fix.md
+++ b/.sessions/2026-06-16-dashboard-deploy-fix.md
@@ -1,0 +1,36 @@
+# Session — Dashboard deploy fix (StaticFiles crash) + Railway deploy config
+
+> **Status:** `in-progress`
+
+## Origin
+
+Owner (2026-06-16): *"can you guide me ... correctly put this website online"* → *"you should have
+full access to railway ... please do it."* I have Railway API access (`RAILWAY_API_KEY`), so I deployed
+the dashboard directly as a **new `dashboard` service** in the `reliable-grace` project (isolated from
+`worker`/`Postgres`). The first deploys **FAILED**: the build compiled, but the container crashed at
+startup —
+
+```
+RuntimeError: Directory '/app/static' does not exist
+  app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), ...)
+```
+
+**Root cause:** the repo's root `.gitignore` (line 85, `static/`) silently excluded
+`dashboard/static/`, so `style.css` was never committed → the dir is absent in the deployed image. It
+passed locally only because the file exists on disk. (Found via the Railway runtime logs.)
+
+## What this session is doing (HOLD — born-red per Q-0133)
+
+- `dashboard/app.py`: remove the `StaticFiles` import + `/static` mount (the crash). The app no longer
+  needs a `static/` dir at all — styling is the Tailwind CDN + a small inline `<style>` in `base.html`.
+- `dashboard/templates/base.html`: inline the two trivial CSS rules instead of `/static/style.css`.
+- `dashboard/Procfile`: `web: uvicorn app:app --host 0.0.0.0 --port ${PORT:-8080}` → the Railway
+  service is zero-config when its **root directory = `dashboard/`**.
+- `dashboard/README.md` + `docs/planning/developer-dashboard-plan.md`: correct the deploy steps to
+  **root directory = `dashboard/`** (repo-root was wrong — it installs the bot's deps, no FastAPI) and
+  record the `static/`-gitignore gotcha.
+
+Builds on top of #969 (env map, merged). No `disbot/` runtime touched; purely the dashboard + docs.
+
+_(Close-out — 💡 idea, ⟲ previous-session review, docs audit — added before the badge flips to
+`complete`.)_

--- a/.sessions/2026-06-16-dashboard-deploy-fix.md
+++ b/.sessions/2026-06-16-dashboard-deploy-fix.md
@@ -1,6 +1,6 @@
 # Session — Dashboard deploy fix (StaticFiles crash) + Railway deploy config
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Origin
 
@@ -32,5 +32,49 @@ passed locally only because the file exists on disk. (Found via the Railway runt
 
 Builds on top of #969 (env map, merged). No `disbot/` runtime touched; purely the dashboard + docs.
 
-_(Close-out — 💡 idea, ⟲ previous-session review, docs audit — added before the badge flips to
-`complete`.)_
+## Outcome — LIVE ✅
+
+Deployed via the Railway API (account token) as a new **`dashboard`** service in `reliable-grace`,
+isolated from `worker`/`Postgres`:
+
+- Config: root directory `dashboard/`, start `uvicorn app:app --host 0.0.0.0 --port ${PORT:-8080}`,
+  healthcheck `/healthz`, public domain **`dashboard-production-746b.up.railway.app`**. **No env vars**
+  (the read-only MVP serves committed JSON).
+- The first three deploys crashed on the `static/` mount (above). After this fix, deploy `1e7d8af4` is
+  **SUCCESS**: `GET /` → 200 (showcase) and `GET /healthz` → 200.
+- The service temporarily tracks this branch to bring the site up immediately; it is repointed at
+  `main` once this PR merges (the durable state).
+
+## Verification
+
+- `check_quality.py --check-only` → green; `check_docs.py --strict` → green.
+- `pytest tests/unit/dashboard/test_app.py` → 8 passed (all routes render without the static mount).
+- Live Railway deploy `1e7d8af4` SUCCESS; `/` and `/healthz` both 200.
+
+## 💡 Session idea (Q-0089)
+
+**A "deployed assets are git-tracked" guard.** This was a classic *works-locally / breaks-in-deploy*:
+the app referenced `dashboard/static/`, which the root `.gitignore` silently excluded, so it was absent
+from the deployed image. A tiny test asserting every directory the dashboard app reads/mounts
+(`templates/`, `data/`) is **git-tracked** (`git ls-files` non-empty) would have caught it pre-deploy —
+generalisable to "flag code that references a path matched by `.gitignore`." Small/decided-lane.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous session: **#969 env-usage map**.
+- **Did well:** clean stdlib AST scanner, a `/env` page, a generated `env-vars.md`, good tests — a solid
+  Phase-3a slice built neatly on the Phase-1 MVP.
+- **What it (and #967) missed:** both extended the dashboard without ever **deploying** it, so the
+  latent `static/` deploy bug rode along undetected — a web app that had never run in its target
+  environment. **Workflow improvement:** for a brand-new deployable surface, do a real deploy (or at
+  least the git-tracked-assets guard above) in the *first* slice, not several PRs later. Green local
+  tests created false confidence because they ran against the working tree, not the committed image.
+
+## Documentation audit (Q-0104)
+
+- `check_docs --strict` green. Deploy steps corrected in `dashboard/README.md` + the plan; the
+  `static/`-gitignore gotcha recorded in both + this log.
+- A **deploy-config defect found during deployment**, not a live bot/user bug → no `bug-book` entry
+  (that ledger is for bot runtime bugs); root cause + fix live here and in the README.
+- `current-state.md` In-flight names no open PRs (convention); #967/#969/#970 land in the merge-time
+  reconciliation (Q-0124) — the pre-existing ledger drift stays the routine's job.

--- a/dashboard/Procfile
+++ b/dashboard/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn app:app --host 0.0.0.0 --port ${PORT:-8080}

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -62,12 +62,25 @@ installs only the bot's `requirements.txt`).
 
 ## Deploy on Railway (second service)
 
-1. New service in the existing Railway project, from this repo.
-2. **Root directory:** repo root (so the start command can import `dashboard.app`).
-3. **Start command:** `uvicorn dashboard.app:app --host 0.0.0.0 --port $PORT`
-4. **Install:** `pip install -r dashboard/requirements.txt`
-5. **Watch paths:** `dashboard/**` (so bot-only changes don't rebuild this service).
+Deploy as a **second service** in the existing Railway project — the bot's `worker`
+service is untouched (it keeps using the root `Procfile` + `requirements.txt`).
 
-The bot's `worker` service is untouched — it keeps using the root `requirements.txt` and
-`Procfile`. Later phases attach this service to the existing Railway Postgres and the
-Railway API (for the secrets zone).
+1. Railway → your project → **New → GitHub Repo** → `menno420/superbot`.
+2. Open the new service → **Settings → Source**: set **Root Directory** to `dashboard`.
+   This is essential — it makes Railway build *this* folder (installing
+   `dashboard/requirements.txt`, **not** the bot's deps) and run `dashboard/Procfile`.
+   With the repo root as the directory, Railway installs the bot's requirements
+   (no FastAPI) and the service fails to start.
+3. **Start command:** taken from `dashboard/Procfile`
+   (`uvicorn app:app --host 0.0.0.0 --port $PORT`) — no need to set it by hand.
+4. **Healthcheck path** (optional): `/healthz`.
+5. **Environment variables:** none required — the read-only MVP serves the committed
+   `dashboard/data/dashboard.json` (no DB, no secrets, no API keys). Later phases add them.
+6. **Networking → Generate Domain** for a public URL.
+
+Redeploys automatically on push to `main`. To refresh the displayed data, regenerate
+`dashboard/data/dashboard.json` and commit it.
+
+> **Note:** the dashboard intentionally has **no `static/` directory** — the repo's root
+> `.gitignore` ignores `static/`, so a file there would never be committed or deployed.
+> Styling is the Tailwind CDN plus a small inline `<style>` block in `base.html`.

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -20,7 +20,6 @@ from typing import Any
 
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
-from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -36,7 +35,6 @@ _EMPTY: dict[str, Any] = {
 }
 
 app = FastAPI(title="SuperBot Dashboard", docs_url=None, redoc_url=None)
-app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
 

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -5,7 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{% block title %}SuperBot Dashboard{% endblock %}</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="/static/style.css" />
+    <style>
+      html { scroll-behavior: smooth; }
+      code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    </style>
   </head>
   <body class="bg-slate-950 text-slate-100 min-h-screen flex flex-col">
     <header class="border-b border-slate-800 bg-slate-900/70 backdrop-blur sticky top-0 z-10">

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,7 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/jolly-cannon-gn9ddg` · dashboard deploy fix — StaticFiles `/static` crash (`static/` is gitignored) + `dashboard/Procfile` + deploy-docs root=`dashboard/` · 2026-06-16
 - `claude/upbeat-einstein-7rz9z0` · act on the 2026-06-16 autonomous-run review + owner answers —
   run-report footer · ledger guard-exemption + drift line · bug-fix-guard convention · auto-deploy
   misinformation fix · Q-0147 DM gate · Q-0085/0120/0121/0127 records · ledger tidy · 2026-06-16

--- a/docs/planning/developer-dashboard-plan.md
+++ b/docs/planning/developer-dashboard-plan.md
@@ -66,7 +66,7 @@ APIs. The bot runtime is never in the dashboard's process.
 
 A **second service** in the existing Railway project:
 
-* Root directory: repo root · Start: `uvicorn dashboard.app:app --host 0.0.0.0 --port $PORT`
+* Root directory: `dashboard` · Start: `uvicorn app:app --host 0.0.0.0 --port $PORT` (from `dashboard/Procfile`). **Not** repo root — that installs the bot's deps (no FastAPI).
 * Dependencies: `dashboard/requirements.txt` (kept separate from the bot's root
   `requirements.txt`, so the bot's build and CI install are unaffected)
 * Watch paths: `dashboard/**` (bot-only changes don't rebuild the dashboard, and


### PR DESCRIPTION
## Why

The dashboard was deployed to Railway (a new `dashboard` service) and **crashed at startup**:

```
RuntimeError: Directory '/app/static' does not exist
  app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), ...)
```

**Root cause:** the repo's root `.gitignore` (line 85, `static/`) silently excluded
`dashboard/static/`, so `style.css` was never committed → the directory is absent in the deployed
image. It passed locally only because the file exists on disk (found via the Railway runtime logs).

## What

- **`dashboard/app.py`** — remove the `StaticFiles` import + `/static` mount (the crash). The app no
  longer needs a `static/` dir; styling is the Tailwind CDN + a small inline `<style>` in `base.html`.
- **`dashboard/templates/base.html`** — inline the two trivial CSS rules instead of `/static/style.css`.
- **`dashboard/Procfile`** — `web: uvicorn app:app --host 0.0.0.0 --port ${PORT:-8080}` so the service
  is zero-config when its **root directory = `dashboard/`**.
- **`dashboard/README.md` + `docs/planning/developer-dashboard-plan.md`** — correct the deploy steps to
  **root directory = `dashboard/`** (repo-root installs the bot's deps, no FastAPI) and record the
  `static/`-gitignore gotcha.

Builds on #969 (env map). No `disbot/` runtime touched — purely the dashboard + docs. Verified locally
(8/8 app routes render without the static mount; lint clean).

## Status

Born-red (Q-0133): the `.sessions/` card is `in-progress` until I've confirmed the live Railway deploy
works, then flipped to `complete` so auto-merge lands the same fix in `main`.

https://claude.ai/code/session_012maBH3m51U7uJKP4zGUMgc

---
_Generated by [Claude Code](https://claude.ai/code/session_012maBH3m51U7uJKP4zGUMgc)_