### PR TITLE
docs(hermes): make morning-briefing + idea-spotlight rate-limit-lean

### DIFF
--- a/.sessions/2026-06-16-skills-rate-limit-rework.md
+++ b/.sessions/2026-06-16-skills-rate-limit-rework.md
@@ -1,0 +1,64 @@
+# 2026-06-16 — rate-limit rework: lean morning-briefing + idea-spotlight
+
+> **Status:** `complete` — owner-directed skill tuning; shipped in one push, auto-merges on green.
+
+## Arc
+
+Owner ran the new scheduled skills on the live Hermes bot and reported (with screenshots): the
+**output is clear and useful**, but **both** `morning-briefing` and `idea-spotlight` hit the model
+provider's rate limit *mid-run* (~2 each). Root cause: both prompts had open-ended "read/scan more"
+steps the model expanded into many tool calls (each = a model request) — the briefing fanned out on
+the router scan (~5+ `search_files`) plus ran ~8 separate commands; the spotlight read the file +
+skimmed relates + glanced at roadmap + router. On a rate-limited provider, ~12 calls trips the limit
+before the skill finishes. Owner asked for both to be **slightly reworked**.
+
+## Shipped (this PR)
+
+- **`morning-briefing`** — pinned to **four single commands + compose** (sync+date · health pass/fail
+  · PRs+CI+overnight in one `gh` block · one exact `grep` for owner-decisions). No open-ended scans.
+- **`idea-spotlight`** — **two commands + compose** (sync+pick in one; one `cat` of the picked file).
+  Leans on what `idea_spotlight.py` already extracts (summary + relates); no skimming relates /
+  roadmap / router.
+- **`skill-author`** (the meta-skill) — added a durable standing rule: *minimize tool round-trips;
+  one combined command per step; never open-ended "scan/search for X"; lean on a backing script* — so
+  future skills are built lean by default. Each reworked skill's Notes records the why + date.
+- Regenerated the three `SKILL.md` artifacts.
+
+`build_skills --check` ✓ (15 skills), `check_docs --strict` ✓, 21 build tests ✓. Docs/skills only —
+no `disbot/`, no runtime, no `.py` logic changed.
+
+## Context delta
+
+- **Discovered (live, by the owner's dogfooding):** each Hermes tool call is a model request, so a
+  scheduled skill's *call count* — not just its output — is load-bearing on a rate-limited provider.
+  The fix is the same "deterministic layer owns the answer, model just formats" pattern, applied to
+  *round-trips*: fixed combined commands instead of open-ended exploration.
+- **Decision made alone:** kept it a prompt-only "slight rework" (fixed commands) rather than a new
+  gatherer script — honoring the owner's "slightly" and the fact the spotlight is already
+  script-backed. If the briefing still trips at four calls, the next step is a single
+  `morning_briefing.py` gatherer (noted for follow-up).
+- **Flagged for maintainer:** the underlying rate limit is also infra — if Hermes shares an API
+  key/tier with the several concurrent Claude Code sessions, concurrent load makes 429s likely;
+  worth confirming Hermes' model/tier and that its gateway backs off + retries on 429.
+
+## 📤 Run report
+
+- **Did:** reworked both scheduled skills to be lean (briefing 4 cmds, spotlight 2) so they finish
+  within the provider rate limit; added a round-trip rule to skill-author · **Outcome:** shipped
+- **Shipped:** this PR — lean `morning-briefing` + `idea-spotlight` + `skill-author` rule + regen
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** re-install the skills on the VPS to pick up the lean versions
+  (`bash scripts/hermes/install-skills.sh`; no gateway restart needed for skills). Then re-run
+  *"run the morning briefing"* / *"run the idea spotlight"* to confirm they now complete. *Optional:*
+  check Hermes' model tier / 429 backoff if limits persist.
+- **↪ Next:** if the briefing still trips at 4 calls, build a `morning_briefing.py` gatherer (1 call).
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 4 (#959, #965, #966, #968; this one auto-merges on green) |
+| CI-red rounds | 0 (docs/skills only; verified locally pre-push) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 0 this follow-up (1 already this session — verdict loop) |
+| Ideas groomed | 0 this follow-up |

--- a/docs/operations/hermes-skills/idea-spotlight.md
+++ b/docs/operations/hermes-skills/idea-spotlight.md
@@ -19,27 +19,22 @@ the owner's verdict when he reports back.
 
 ```
 You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
-Do not modify any files in this skill. Read-only. Keep the whole output under 500 words.
+Read-only. ONE idea card, under 450 words. The model provider rate-limits — use only the TWO
+commands below; do NOT open other files (relates / roadmap / router) or fan out into searches.
 
-GOAL: present ONE idea from the backlog with the thinking started, so the owner can decide on it
-by end of day.
+GOAL: present ONE backlog idea with the thinking started, so the owner can decide on it by EOD.
 
-1. SYNC (so the backlog is fresh): 
-   git -C /home/hermes/repos/superbot fetch origin main && \
-   git -C /home/hermes/repos/superbot checkout -B main origin/main
+1. SYNC + PICK (one command — the selector chooses deterministically, rotating; never your guess):
+   cd /home/hermes/repos/superbot && git fetch -q origin main && git checkout -q -B main origin/main && python3 scripts/hermes/idea_spotlight.py
+   It prints the title, file path, status, summary, and any "relates" hint — that is your material.
+   (Optional flags, not needed for the daily run: --json, --list, --date YYYY-MM-DD.)
 
-2. PICK today's idea — let the deterministic selector choose (one per day, rotates the backlog,
-   never your own guess):
-   cd /home/hermes/repos/superbot && python3 scripts/hermes/idea_spotlight.py
-   It prints the title, the file path, the status, and a summary. (Use --json if you want it
-   structured; --list to see the whole active backlog; --date YYYY-MM-DD to re-pick a past day.)
+2. READ the picked idea file ONCE for the full detail (the path the selector printed):
+   cat <that file>
+   That is enough to write the card. Do NOT open the relates files, roadmap, or router — ground the
+   pros/cons in what these two outputs say; never invent a capability the repo doesn't have.
 
-3. READ the picked idea file in full (the path the selector printed). If it names "→ relates"
-   files, skim them read-only to ground your pros/cons — VERIFY against source, never invent a
-   capability the repo doesn't have. Also glance at docs/roadmap.md + docs/owner/
-   maintainer-question-router.md to see if it already has a horizon or an open Q-block.
-
-4. DELIVER the spotlight card in this exact shape:
+3. DELIVER the spotlight card in this exact shape (no more commands):
 
 ---
 ## 💡 Idea spotlight — [today's date]
@@ -66,6 +61,7 @@ discuss · drop · or an expansion — I'll route it.
 ---
 
 RULES:
+- Two commands, then compose — minimize round-trips (the provider rate-limits).
 - One idea only. Skip ideas already badged historical/rejected (the selector already filters these).
 - Honest cons beat a sales pitch — a near-useless idea should read as near-useless.
 - You are NOT building anything here. This is a thinking aid + a decision prompt.
@@ -88,6 +84,10 @@ it and the one next step. Only the OWNER authorizes a build.
 - **The loop is the point.** The morning card starts the owner thinking; the EOD reply, routed
   through `intake`, gives the idea a lifecycle move. Over time this drains the backlog one
   considered decision at a time — the human mirror of the grooming pass.
+- **Lean by design (rate-limit, 2026-06-16).** Each tool call is a model request on a rate-limited
+  provider; the first version read the file **and** skimmed the relates files **and** glanced at
+  roadmap + router, fanning out enough to trip the limit. It now leans on the selector's already-
+  extracted summary/relates + **one** file read (two commands total). Don't re-add the fan-out.
 - **Self-schedules.** Its `blueprint.schedule` (`30 6 * * *`) is set in
   `scripts/hermes/build_skills.py`, so once installed Hermes posts it daily to the home channel —
   no VPS cron. Change the time there and rebuild.

--- a/docs/operations/hermes-skills/morning-briefing.md
+++ b/docs/operations/hermes-skills/morning-briefing.md
@@ -20,38 +20,30 @@ it does not replace them as on-demand tools.
 
 ```
 You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
-Read-only. Produce ONE morning briefing, under 450 words. Use ✅/⚠️/❌ for the health line.
+Read-only. Produce ONE morning briefing, under 400 words. Use ✅/⚠️/❌ on the health line.
 
-1. SYNC: git -C /home/hermes/repos/superbot fetch origin main && \
-         git -C /home/hermes/repos/superbot checkout -B main origin/main
+IMPORTANT — the model provider rate-limits, so keep this to FOUR commands. Run each block below as
+a SINGLE shell command exactly as written; do NOT fan out into extra searches or file reads. Then
+compose from their output — no further commands.
 
-2. HEALTH (the fast subset of superbot-repo-health — don't re-run all six):
-   cd /home/hermes/repos/superbot
-   python3 scripts/check_docs.py --strict            # docs reachable/fresh?
-   python3 scripts/check_architecture.py --mode strict   # arch errors (warnings are fine)
-   → one ✅/⚠️/❌ line. (For the full traffic-light, point at superbot-repo-health.)
+A) SYNC + DATE:
+   cd /home/hermes/repos/superbot && git fetch -q origin main && git checkout -q -B main origin/main && date '+%Y-%m-%d'
 
-3. PULL REQUESTS + CI:
-   gh pr list --repo menno420/superbot --state open --json number,title,labels,isDraft,headRefName,updatedAt
-   gh run list --repo menno420/superbot --limit 6 --json status,conclusion,headBranch,displayTitle
-   → flag: any `needs-hermes-review` PR (your review-merge queue), any PR older than ~2 days, any
-     recent CI failure (name the branch).
+B) HEALTH (pass/fail only — known arch warnings are fine):
+   (python3 scripts/check_docs.py --strict >/dev/null 2>&1 && echo "docs: ok" || echo "docs: FAIL"); (python3 scripts/check_architecture.py --mode strict >/dev/null 2>&1 && echo "arch: ok" || echo "arch: errors")
 
-4. OVERNIGHT ROUTINE ACTIVITY (the self-improvement loop — did it run?):
-   gh pr list --repo menno420/superbot --state merged --limit 8 --json number,title,mergedAt
-   → list the claude/* PRs merged since the last briefing (~24h). If none merged and none are open,
-     say so plainly ("loop quiet overnight") — that itself is signal (cron lag or nothing to do).
+C) PRS + CI + OVERNIGHT (one block):
+   echo "== open PRs =="; gh pr list --repo menno420/superbot --state open --json number,headRefName,labels --jq '.[]|"#\(.number) \(.headRefName) [\(.labels|map(.name)|join(","))]"'; echo "== recent CI =="; gh run list --repo menno420/superbot --limit 6 --json conclusion,headBranch --jq '.[]|"\(.conclusion // "running") \(.headBranch)"'; echo "== merged ~24h =="; gh pr list --repo menno420/superbot --state merged --limit 8 --json number,title --jq '.[]|"#\(.number) \(.title)"'
 
-5. DECISIONS WAITING ON THE OWNER (reuse the superbot-open-questions logic):
-   Scan docs/owner/maintainer-question-router.md for OPEN / DISCUSS Q-blocks awaiting a verdict,
-   and docs/current-state.md ▶ Next action for any "owner-gated" / "👤" item. List the few that
-   actually need HIM (not agent work) — these are the loop's real bottleneck.
+D) DECISIONS WAITING ON THE OWNER (one grep — do not scan further):
+   grep -niE "awaiting (maintainer|owner)|status:\s*open|owner-gated|needs (owner|maintainer)" docs/owner/maintainer-question-router.md | head -15
 
-6. DELIVER in this shape:
+DELIVER in this shape — flag any needs-hermes-review PR, any CI failure (by branch), list the merged
+claude/* PRs (or "loop quiet overnight"), and the few decisions that truly need HIM:
 
 ---
 ## ☀️ SuperBot morning briefing — [date]
-- **Health:** ✅/⚠️/❌ [one line]
+- **Health:** ✅/⚠️/❌ [docs + arch, a few words]
 - **Open PRs:** [count] — [needs-hermes-review / stale flags, or "none"]
 - **CI:** [recent pass/fail summary]
 - **Overnight:** [merged claude/* PRs, or "loop quiet"]
@@ -62,10 +54,9 @@ Read-only. Produce ONE morning briefing, under 450 words. Use ✅/⚠️/❌ for
 ---
 
 RULES:
-- Verify, don't assume — every line is from a check above; say "gh unavailable" and mark ⚠️ if it is.
-- Keep it to signal. This is the owner's at-a-glance inbox, not a full report.
-- You take no action here (no merges, no dispatch) — the briefing is a hint; the owner or a
-  dedicated skill (review-merge / dispatch) acts.
+- Four commands, then compose — minimize round-trips (the provider rate-limits).
+- Verify, don't assume — every line comes from the output above; say "gh unavailable" + ⚠️ if so.
+- No actions (no merges, no dispatch) — the briefing is a hint; a dedicated skill acts.
 ```
 
 ---
@@ -80,6 +71,10 @@ RULES:
 - **Thin composite (skill-author rule).** It encodes the *decision flow* and runs the cheap checks
   inline; it references `repo-health` (full health) and `open-questions` (decision scan) rather than
   duplicating their bodies. If it grows a heavy section, split that section back into its atom.
+- **Lean by design (rate-limit, 2026-06-16).** Hermes' model provider rate-limits and each tool call
+  is a request; the first version fanned out (~12 calls — many `search_files` for the router scan)
+  and tripped the limit mid-run. It's now pinned to **four single commands + compose**. Keep it that
+  way — don't re-add open-ended "scan/search" steps or split the combined commands back apart.
 - **Self-schedules.** `blueprint.schedule` (`0 6 * * *`) is set in
   `scripts/hermes/build_skills.py`; the idea spotlight follows 30 min later. Change the times there.
 - **Provenance + reliability (Q-0105).** Added 2026-06-16, owner-directed. UNVERIFIED until a few

--- a/docs/operations/hermes-skills/skill-author.md
+++ b/docs/operations/hermes-skills/skill-author.md
@@ -48,6 +48,12 @@ STEP 2 — DESIGN. Decide:
       * anything touching code is DISPATCHED to Claude Code, never edited here;
       * verify, don't assume (railway_vars.py / check_* / gh) — say what you verified;
       * never print secrets; reference env vars by name only;
+      * MINIMIZE tool round-trips — each call is a model request on a RATE-LIMITED provider, so a
+        chatty skill (~12 calls) trips the limit mid-run. Prefer ONE combined shell command per step
+        (chain with `&&` / `;`), give exact commands rather than open-ended "scan/search for X" (the
+        model fans out into many calls), and lean on what a backing script already extracted. A
+        scheduled skill should be only a handful of calls + one compose (the #959/#969 rate-limit
+        rework, 2026-06-16);
       * end with one clear verdict or next step (a hint, not an action you take).
 
 STEP 3 — WRITE THE SOURCE. Create docs/operations/hermes-skills/<name>.md in the canonical shape

--- a/scripts/hermes/skills/idea-spotlight/SKILL.md
+++ b/scripts/hermes/skills/idea-spotlight/SKILL.md
@@ -19,27 +19,22 @@ metadata:
 <!-- GENERATED — DO NOT EDIT. Source of truth: docs/operations/hermes-skills/idea-spotlight.md. Regenerate with scripts/hermes/build_skills.py. -->
 
 You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
-Do not modify any files in this skill. Read-only. Keep the whole output under 500 words.
+Read-only. ONE idea card, under 450 words. The model provider rate-limits — use only the TWO
+commands below; do NOT open other files (relates / roadmap / router) or fan out into searches.
 
-GOAL: present ONE idea from the backlog with the thinking started, so the owner can decide on it
-by end of day.
+GOAL: present ONE backlog idea with the thinking started, so the owner can decide on it by EOD.
 
-1. SYNC (so the backlog is fresh): 
-   git -C /home/hermes/repos/superbot fetch origin main && \
-   git -C /home/hermes/repos/superbot checkout -B main origin/main
+1. SYNC + PICK (one command — the selector chooses deterministically, rotating; never your guess):
+   cd /home/hermes/repos/superbot && git fetch -q origin main && git checkout -q -B main origin/main && python3 scripts/hermes/idea_spotlight.py
+   It prints the title, file path, status, summary, and any "relates" hint — that is your material.
+   (Optional flags, not needed for the daily run: --json, --list, --date YYYY-MM-DD.)
 
-2. PICK today's idea — let the deterministic selector choose (one per day, rotates the backlog,
-   never your own guess):
-   cd /home/hermes/repos/superbot && python3 scripts/hermes/idea_spotlight.py
-   It prints the title, the file path, the status, and a summary. (Use --json if you want it
-   structured; --list to see the whole active backlog; --date YYYY-MM-DD to re-pick a past day.)
+2. READ the picked idea file ONCE for the full detail (the path the selector printed):
+   cat <that file>
+   That is enough to write the card. Do NOT open the relates files, roadmap, or router — ground the
+   pros/cons in what these two outputs say; never invent a capability the repo doesn't have.
 
-3. READ the picked idea file in full (the path the selector printed). If it names "→ relates"
-   files, skim them read-only to ground your pros/cons — VERIFY against source, never invent a
-   capability the repo doesn't have. Also glance at docs/roadmap.md + docs/owner/
-   maintainer-question-router.md to see if it already has a horizon or an open Q-block.
-
-4. DELIVER the spotlight card in this exact shape:
+3. DELIVER the spotlight card in this exact shape (no more commands):
 
 ---
 ## 💡 Idea spotlight — [today's date]
@@ -66,6 +61,7 @@ discuss · drop · or an expansion — I'll route it.
 ---
 
 RULES:
+- Two commands, then compose — minimize round-trips (the provider rate-limits).
 - One idea only. Skip ideas already badged historical/rejected (the selector already filters these).
 - Honest cons beat a sales pitch — a near-useless idea should read as near-useless.
 - You are NOT building anything here. This is a thinking aid + a decision prompt.

--- a/scripts/hermes/skills/morning-briefing/SKILL.md
+++ b/scripts/hermes/skills/morning-briefing/SKILL.md
@@ -19,38 +19,30 @@ metadata:
 <!-- GENERATED — DO NOT EDIT. Source of truth: docs/operations/hermes-skills/morning-briefing.md. Regenerate with scripts/hermes/build_skills.py. -->
 
 You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
-Read-only. Produce ONE morning briefing, under 450 words. Use ✅/⚠️/❌ for the health line.
+Read-only. Produce ONE morning briefing, under 400 words. Use ✅/⚠️/❌ on the health line.
 
-1. SYNC: git -C /home/hermes/repos/superbot fetch origin main && \
-         git -C /home/hermes/repos/superbot checkout -B main origin/main
+IMPORTANT — the model provider rate-limits, so keep this to FOUR commands. Run each block below as
+a SINGLE shell command exactly as written; do NOT fan out into extra searches or file reads. Then
+compose from their output — no further commands.
 
-2. HEALTH (the fast subset of superbot-repo-health — don't re-run all six):
-   cd /home/hermes/repos/superbot
-   python3 scripts/check_docs.py --strict            # docs reachable/fresh?
-   python3 scripts/check_architecture.py --mode strict   # arch errors (warnings are fine)
-   → one ✅/⚠️/❌ line. (For the full traffic-light, point at superbot-repo-health.)
+A) SYNC + DATE:
+   cd /home/hermes/repos/superbot && git fetch -q origin main && git checkout -q -B main origin/main && date '+%Y-%m-%d'
 
-3. PULL REQUESTS + CI:
-   gh pr list --repo menno420/superbot --state open --json number,title,labels,isDraft,headRefName,updatedAt
-   gh run list --repo menno420/superbot --limit 6 --json status,conclusion,headBranch,displayTitle
-   → flag: any `needs-hermes-review` PR (your review-merge queue), any PR older than ~2 days, any
-     recent CI failure (name the branch).
+B) HEALTH (pass/fail only — known arch warnings are fine):
+   (python3 scripts/check_docs.py --strict >/dev/null 2>&1 && echo "docs: ok" || echo "docs: FAIL"); (python3 scripts/check_architecture.py --mode strict >/dev/null 2>&1 && echo "arch: ok" || echo "arch: errors")
 
-4. OVERNIGHT ROUTINE ACTIVITY (the self-improvement loop — did it run?):
-   gh pr list --repo menno420/superbot --state merged --limit 8 --json number,title,mergedAt
-   → list the claude/* PRs merged since the last briefing (~24h). If none merged and none are open,
-     say so plainly ("loop quiet overnight") — that itself is signal (cron lag or nothing to do).
+C) PRS + CI + OVERNIGHT (one block):
+   echo "== open PRs =="; gh pr list --repo menno420/superbot --state open --json number,headRefName,labels --jq '.[]|"#\(.number) \(.headRefName) [\(.labels|map(.name)|join(","))]"'; echo "== recent CI =="; gh run list --repo menno420/superbot --limit 6 --json conclusion,headBranch --jq '.[]|"\(.conclusion // "running") \(.headBranch)"'; echo "== merged ~24h =="; gh pr list --repo menno420/superbot --state merged --limit 8 --json number,title --jq '.[]|"#\(.number) \(.title)"'
 
-5. DECISIONS WAITING ON THE OWNER (reuse the superbot-open-questions logic):
-   Scan docs/owner/maintainer-question-router.md for OPEN / DISCUSS Q-blocks awaiting a verdict,
-   and docs/current-state.md ▶ Next action for any "owner-gated" / "👤" item. List the few that
-   actually need HIM (not agent work) — these are the loop's real bottleneck.
+D) DECISIONS WAITING ON THE OWNER (one grep — do not scan further):
+   grep -niE "awaiting (maintainer|owner)|status:\s*open|owner-gated|needs (owner|maintainer)" docs/owner/maintainer-question-router.md | head -15
 
-6. DELIVER in this shape:
+DELIVER in this shape — flag any needs-hermes-review PR, any CI failure (by branch), list the merged
+claude/* PRs (or "loop quiet overnight"), and the few decisions that truly need HIM:
 
 ---
 ## ☀️ SuperBot morning briefing — [date]
-- **Health:** ✅/⚠️/❌ [one line]
+- **Health:** ✅/⚠️/❌ [docs + arch, a few words]
 - **Open PRs:** [count] — [needs-hermes-review / stale flags, or "none"]
 - **CI:** [recent pass/fail summary]
 - **Overnight:** [merged claude/* PRs, or "loop quiet"]
@@ -61,7 +53,6 @@ Read-only. Produce ONE morning briefing, under 450 words. Use ✅/⚠️/❌ for
 ---
 
 RULES:
-- Verify, don't assume — every line is from a check above; say "gh unavailable" and mark ⚠️ if it is.
-- Keep it to signal. This is the owner's at-a-glance inbox, not a full report.
-- You take no action here (no merges, no dispatch) — the briefing is a hint; the owner or a
-  dedicated skill (review-merge / dispatch) acts.
+- Four commands, then compose — minimize round-trips (the provider rate-limits).
+- Verify, don't assume — every line comes from the output above; say "gh unavailable" + ⚠️ if so.
+- No actions (no merges, no dispatch) — the briefing is a hint; a dedicated skill acts.

--- a/scripts/hermes/skills/skill-author/SKILL.md
+++ b/scripts/hermes/skills/skill-author/SKILL.md
@@ -36,6 +36,12 @@ STEP 2 — DESIGN. Decide:
       * anything touching code is DISPATCHED to Claude Code, never edited here;
       * verify, don't assume (railway_vars.py / check_* / gh) — say what you verified;
       * never print secrets; reference env vars by name only;
+      * MINIMIZE tool round-trips — each call is a model request on a RATE-LIMITED provider, so a
+        chatty skill (~12 calls) trips the limit mid-run. Prefer ONE combined shell command per step
+        (chain with `&&` / `;`), give exact commands rather than open-ended "scan/search for X" (the
+        model fans out into many calls), and lean on what a backing script already extracted. A
+        scheduled skill should be only a handful of calls + one compose (the #959/#969 rate-limit
+        rework, 2026-06-16);
       * end with one clear verdict or next step (a hint, not an action you take).
 
 STEP 3 — WRITE THE SOURCE. Create docs/operations/hermes-skills/<name>.md in the canonical shape


### PR DESCRIPTION
## Why (owner dogfooding feedback)

The owner ran both scheduled skills on the live Hermes bot. **The output is clear and useful** — but
**both** `morning-briefing` and `idea-spotlight` hit the model provider's rate limit *mid-run* (~2
each). Cause: each Hermes tool call is a model request, and both prompts had open-ended "read/scan
more" steps the model expands into many calls (~12 total): the briefing fanned out on the router scan
(~5+ `search_files`) + ran ~8 separate commands; the spotlight read the file + skimmed relates +
glanced at roadmap + router.

## What (slight rework — fewer round-trips, same output)

- **`morning-briefing`** → **four single combined commands + compose** (sync+date · health
  pass/fail · PRs+CI+overnight in one `gh` block · one exact `grep` for owner-decisions). No
  open-ended scans.
- **`idea-spotlight`** → **two commands + compose** (sync+pick combined; one `cat` of the picked
  file). Leans on what `idea_spotlight.py` already extracts; no skimming relates/roadmap/router.
- **`skill-author`** (meta-skill) → added a durable standing rule: *minimize tool round-trips, one
  combined command per step, never open-ended "scan/search", lean on a backing script* — so future
  skills are built lean by default. Each reworked skill's Notes records the why + date.
- Regenerated the three `SKILL.md` artifacts.

## Scope / verification

Docs + Hermes skill files only — no `disbot/`, no runtime, no `.py` logic. `build_skills --check` ✓
(15 skills), `check_docs --strict` ✓, 21 build tests ✓.

**Owner manual step after merge:** re-run `bash scripts/hermes/install-skills.sh` on the VPS to pick
up the lean versions (no gateway restart needed for skills), then re-run the briefing/spotlight to
confirm they complete within the rate limit.

https://claude.ai/code/session_011Add2RPDWutS7643URURns

---
_Generated by [Claude Code](https://claude.ai/code/session_011Add2RPDWutS7643URURns)_