### PR TITLE
feat(dashboard): /commands cog & command explorer (prefix/slash + button-backed)

### DIFF
--- a/.sessions/2026-06-16-dashboard-commands-explorer.md
+++ b/.sessions/2026-06-16-dashboard-commands-explorer.md
@@ -1,0 +1,61 @@
+# Session — Dashboard cog & command explorer (`/commands`)
+
+> **Status:** `in-progress`
+
+## Origin
+
+Owner (2026-06-16, after the dashboard went live): *"add the second layer … browse all the different
+cogs and all the commands they have, with a clean separation of the commands that have a button and
+those that are only prefix or slash based, it should also be able to show if it's slash command or
+prefix … if you have any other ideas implement at the same time."*
+
+## What shipped
+
+- **`scripts/scan_commands.py`** (stdlib, AST) — scans `disbot/cogs/**` for every cog + command:
+  invocation **type** (prefix / slash / both, from the decorator), aliases, brief, group subcommands,
+  and **button-backed** — the project's own `extras={"classification": "panel_action"}` marker (see
+  `core/runtime/command_surface_ledger.py`) OR a body that opens a view
+  (`panel_manager`/`send_panel`/`*View(`/`view=`). Live numbers: 41 cogs · 300 commands · 275 prefix /
+  25 slash / 108 button-backed.
+- **`scripts/export_dashboard_data.py`** — new `cogs` section + `cogs`/`commands` counts, via the same
+  importlib seam as the env scanner (still pure stdlib; CI install unaffected).
+- **`/commands` page** (`dashboard/app.py` + `templates/commands.html` + nav + home card): cogs
+  grouped (with subsystem emoji/name cross-linked from the registry), each command badged
+  **prefix/slash** and **🔘 button**, plus classification + aliases + brief.
+- **Other ideas added at the same time:** a stats header (commands · prefix · slash · button · cogs),
+  a live **search** box, and **filter chips** (All / Prefix / Slash / 🔘 Button) — tiny inline JS, no
+  build step — plus the home-page Commands card.
+- **Tests:** `test_scan_commands.py` (types · aliases · panel_action · opens-view · subcommands · real
+  repo) + `/commands` added to the app smoke + a `cogs`-section exporter test.
+
+## Verification
+
+- `python3.10 scripts/check_quality.py --full` → **green (10151 passed, 37 skipped)**; ruff/black/isort
+  clean; `check_docs --strict` green.
+- `/commands` renders all 300 commands locally (TestClient → 200; badges, search, filters present).
+- Deploys via the dashboard service already tracking `main` (auto-redeploys on merge).
+
+## 💡 Session idea (Q-0089)
+
+**Reconcile the AST command scan against the runtime ledger.** `scan_commands.py` approximates
+`core/runtime/command_surface_ledger.py` (the runtime truth) from source. A tiny test that diffs the
+two — names + types + classifications — would catch drift (a command the AST misses, or a
+classification only resolved at runtime), turning `/commands` into a *verified* mirror rather than a
+best-effort one. Small/decided-lane.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous: the **dashboard deploy fix (#970)** (same conversation). Did well: traced the gitignored
+`static/` root cause from the Railway runtime logs and removed the dependency cleanly. The deeper
+lesson — proven twice now — is that #967 shipped a `static/` mount that was never deploy-tested. This
+session benefited directly: `/commands` adds **no** new static asset, and the service now
+auto-redeploys from `main`, so a real deploy validates it. The "git-tracked assets" guard idea from
+#970 remains the durable fix for that whole class.
+
+## Documentation audit (Q-0104)
+
+- `check_docs --strict` green. `/commands` documented in `dashboard/README.md`; the plan's
+  surface-don't-duplicate table gains a cog/command-explorer row. Executes the owner's direct
+  in-session request → no new router decision needed.
+- Not a bug → no bug-book entry. `current-state.md` In-flight names no open PRs (convention); the
+  merge-time reconciliation (Q-0124) folds #967/#969/#970 + this PR into the ledger.

--- a/.sessions/2026-06-16-dashboard-commands-explorer.md
+++ b/.sessions/2026-06-16-dashboard-commands-explorer.md
@@ -1,6 +1,6 @@
 # Session — Dashboard cog & command explorer (`/commands`)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Origin
 

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -12,6 +12,7 @@ and the secrets model live in
 |---|---|
 | `/` | Showcase landing — counts + recent updates |
 | `/functions` | Bot-function catalogue (from the subsystem registry) |
+| `/commands` | **Cog & command explorer** — every cog's commands, each badged prefix/slash and whether it's button-backed (a panel action or opens a view); live search + filters (`scripts/scan_commands.py`). |
 | `/ideas` | Idea backlog (from `docs/ideas/`) |
 | `/bugs` | Bug board (from `docs/health/bug-book.md`) + a "report a bug" CTA |
 | `/updates` | Updates feed (from `.sessions/` logs) |
@@ -22,8 +23,8 @@ and the secrets model live in
 
 This app **never imports `disbot/`.** It reads only `dashboard/data/dashboard.json`,
 produced by `scripts/export_dashboard_data.py` (pure stdlib — which calls the equally
-pure-stdlib `scripts/scan_env_usage.py` for the env map). The bot and its Railway service
-are completely independent of this one.
+pure-stdlib `scripts/scan_env_usage.py` for the env map and `scripts/scan_commands.py` for
+the command explorer). The bot and its Railway service are completely independent of this one.
 
 ## Secrets safety (the `/env` map)
 

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -114,3 +114,22 @@ def env(request: Request):
         "env.html",
         {"data": load_data(), "page": "env"},
     )
+
+
+@app.get("/commands", response_class=HTMLResponse)
+def commands(request: Request):
+    """Cog & command explorer — invocation type (prefix/slash) + button backing."""
+    data = load_data()
+    cmds = [c for cog in data.get("cogs", []) for c in cog["commands"]]
+    stats = {
+        "prefix": sum(1 for c in cmds if c["type"] == "prefix"),
+        "slash": sum(1 for c in cmds if c["type"] == "slash"),
+        "both": sum(1 for c in cmds if c["type"] == "both"),
+        "button": sum(1 for c in cmds if c["button_backed"]),
+    }
+    sysmap = {c["key"]: c for c in data.get("catalogue", [])}
+    return templates.TemplateResponse(
+        request,
+        "commands.html",
+        {"data": data, "page": "commands", "stats": stats, "sysmap": sysmap},
+    )

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,12 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-06-16T16:17:21Z",
+    "generated_at": "2026-06-16T17:17:14Z",
     "counts": {
       "functions": 33,
-      "ideas": 70,
+      "ideas": 72,
       "bugs": 15,
       "updates": 60,
-      "env_vars": 34
+      "env_vars": 34,
+      "cogs": 41,
+      "commands": 300
     }
   },
   "catalogue": [
@@ -895,6 +897,20 @@
       "summary": "`disbot/cogs/diagnostic_cog.py` is the Discord-facing home of the whole `!platform` admin surface"
     },
     {
+      "file": "docs-ledger-parsing-helper-2026-06-16.md",
+      "title": "Idea — a shared `docs_ledger` markdown-parsing helper (one source of truth for the ledger regexes)",
+      "status": "ideas",
+      "date": "2026-06-16",
+      "summary": "The repo's markdown ledgers (`.sessions/` Status badges, `docs/health/bug-book.md` `## BUG-NNNN`"
+    },
+    {
+      "file": "env-map-deploy-readiness-cross-check-2026-06-16.md",
+      "title": "Idea — turn the env-usage map into a deploy-readiness check (required-but-unset detection)",
+      "status": "ideas",
+      "date": "2026-06-16",
+      "summary": "`scripts/scan_env_usage.py` (#969) now knows, statically and authoritatively, **which env vars the"
+    },
+    {
       "file": "honcho-memory-evaluation-2026-06-16.md",
       "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord users across conversations",
       "status": "ideas",
@@ -1442,6 +1458,12 @@
       "status": "complete"
     },
     {
+      "file": "2026-06-16-skills-rate-limit-rework.md",
+      "date": "2026-06-16",
+      "title": "2026-06-16 — rate-limit rework: lean morning-briefing + idea-spotlight",
+      "status": "complete"
+    },
+    {
       "file": "2026-06-16-runtime-lock-early-release.md",
       "date": "2026-06-16",
       "title": "Session — runtime lock: release early on shutdown (fix ~85s deploy downtime)",
@@ -1571,6 +1593,18 @@
       "file": "2026-06-16-dashboard-env-usage-map.md",
       "date": "2026-06-16",
       "title": "Session — Dashboard Phase 3 (read-only env-var usage map)",
+      "status": "complete"
+    },
+    {
+      "file": "2026-06-16-dashboard-deploy-fix.md",
+      "date": "2026-06-16",
+      "title": "Session — Dashboard deploy fix (StaticFiles crash) + Railway deploy config",
+      "status": "complete"
+    },
+    {
+      "file": "2026-06-16-dashboard-commands-explorer.md",
+      "date": "2026-06-16",
+      "title": "Session — Dashboard cog & command explorer (`/commands`)",
       "status": "in-progress"
     },
     {
@@ -1769,24 +1803,6 @@
       "file": "2026-06-15-hermes-research-deepening.md",
       "date": "2026-06-15",
       "title": "Session — Hermes research deepening (context-management root cause, verified vs. source)",
-      "status": "complete"
-    },
-    {
-      "file": "2026-06-15-hermes-model-resolved.md",
-      "date": "2026-06-15",
-      "title": "Session — Hermes model swap RESOLVED (gpt-5.4-mini live; it was propagation lag)",
-      "status": "complete"
-    },
-    {
-      "file": "2026-06-15-hermes-model-record.md",
-      "date": "2026-06-15",
-      "title": "Session — Hermes model/provider record (capture the live findings)",
-      "status": "complete"
-    },
-    {
-      "file": "2026-06-15-hermes-model-playbook.md",
-      "date": "2026-06-15",
-      "title": "Session — Hermes model-switch playbook + saga close-out",
       "status": "complete"
     }
   ],
@@ -2408,6 +2424,3717 @@
           "line": 172,
           "layer": "bot1",
           "has_default": true
+        }
+      ]
+    }
+  ],
+  "cogs": [
+    {
+      "cog": "AICog",
+      "file": "disbot/cogs/ai_cog.py",
+      "subsystem": "a_i",
+      "commands": [
+        {
+          "name": "ai",
+          "type": "prefix",
+          "is_group": true,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the AI Platform panel.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "aimenu",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the AI Platform panel (alias for ``!ai``).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "aimenu",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the AI Platform panel (administrator only).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "diagnostics",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "forget",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "Flush the chat-memory cache for THIS channel.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "policy",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "Show the effective AI policy for a channel (dry-run resolver).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "providers",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "readiness",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "Run the full AI readiness chain check.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "routing",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "settings",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "Open the AI Platform settings panel directly.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "status",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "support-report",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "Render a copy-pasteable support report from recent audit (PR-H).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "why-no-response",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "Show the most recent denials / skips for this guild.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "AdminCog",
+      "file": "disbot/cogs/admin_cog.py",
+      "subsystem": "admin",
+      "commands": [
+        {
+          "name": "admin",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the Admin control panel (administrator only).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "adminmenu",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the interactive admin control panel.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "cog",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Load, unload, or reload a cog by name (underscores and _cog suffix optional).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "coglist",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "cogs",
+            "listcogs",
+            "cogslist"
+          ],
+          "brief": "Open the interactive cog manager — the panel's 📋 Cog List button.",
+          "classification": "power_user_shortcut",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "loadall",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Load all unloaded cogs, skipping already-loaded ones.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "loglevel",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Change the bot log level (DEBUG/INFO/WARNING/ERROR/CRITICAL).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "restart",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Request a graceful restart through the lifecycle service.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "serverstats",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Display server statistics.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "slashes",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "slashlist"
+          ],
+          "brief": "List currently-registered slash commands (admin only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "syncslash",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "syncs"
+          ],
+          "brief": "Sync the app-command tree for slash commands (owner only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "unloadall",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Unload all loaded cogs except this one.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "Automod",
+      "file": "disbot/cogs/automod_cog.py",
+      "subsystem": "automod",
+      "commands": [
+        {
+          "name": "automod",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Show the current automod policy for this server.",
+          "classification": "primary_entrypoint",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "BTD6Cog",
+      "file": "disbot/cogs/btd6_cog.py",
+      "subsystem": "b_t_d6",
+      "commands": [
+        {
+          "name": "btd6",
+          "type": "prefix",
+          "is_group": true,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the BTD6 panel.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "btd6menu",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the BTD6 panel (alias for ``!btd6``).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "btd6menu",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the BTD6 panel.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "ask",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6",
+          "aliases": [],
+          "brief": "Deterministic Q&A. Module 5 adds optional AI augmentation.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "ctteam",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6",
+          "aliases": [],
+          "brief": "View or set this server's CT team (paste the bracket group id / URL).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "diagnostics",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6",
+          "aliases": [],
+          "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "status",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6",
+          "aliases": [],
+          "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "test-intent",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6",
+          "aliases": [],
+          "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "BTD6EventsCog",
+      "file": "disbot/cogs/btd6_events_cog.py",
+      "subsystem": "b_t_d6_events",
+      "commands": [
+        {
+          "name": "btd6events",
+          "type": "prefix",
+          "is_group": true,
+          "parent": null,
+          "aliases": [],
+          "brief": "BTD6 live events, leaderboards, and data-source diagnostics.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "event",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6events",
+          "aliases": [],
+          "brief": "Show one specific BTD6 event with its tower restrictions.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "grounding",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6events",
+          "aliases": [],
+          "brief": "Show the grounding facts that fed an AI response (PR-D).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "latest-data",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6events",
+          "aliases": [],
+          "brief": "Show newest fact envelope per entity_kind (PR-D).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "leaderboard",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6events",
+          "aliases": [],
+          "brief": "Top-N race or boss leaderboard. No event_id = newest active.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "live",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6events",
+          "aliases": [],
+          "brief": "Show recent live events for ``kind`` (race / boss / ct / odyssey / event).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "refresh-source",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6events",
+          "aliases": [],
+          "brief": "Manually refresh one Ninja Kiwi source (staff-only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "source-health",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6events",
+          "aliases": [],
+          "brief": "Show source registry freshness (PR-D).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "sources",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6events",
+          "aliases": [],
+          "brief": "List BTD6 source registry rows.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "BTD6OpsCog",
+      "file": "disbot/cogs/btd6_ops_cog.py",
+      "subsystem": "b_t_d6_ops",
+      "commands": [
+        {
+          "name": "btd6ops",
+          "type": "prefix",
+          "is_group": true,
+          "parent": null,
+          "aliases": [],
+          "brief": "BTD6 ingestion operations (staff readable; toggles are admin).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "announcechannel",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6ops",
+          "aliases": [],
+          "brief": "Set/clear the BTD6 new-version announcement channel (administrator).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "readiness",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6ops",
+          "aliases": [],
+          "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "runs",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6ops",
+          "aliases": [],
+          "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "seed-data",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6ops",
+          "aliases": [],
+          "brief": "Seed the Postgres data store from the bundled files (administrator).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "source_disable",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6ops",
+          "aliases": [],
+          "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "source_enable",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6ops",
+          "aliases": [],
+          "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "BTD6ReferenceCog",
+      "file": "disbot/cogs/btd6_reference_cog.py",
+      "subsystem": "b_t_d6_reference",
+      "commands": [
+        {
+          "name": "btd6ref",
+          "type": "prefix",
+          "is_group": true,
+          "parent": null,
+          "aliases": [],
+          "brief": "BTD6 reference lookups (towers / heroes / rounds / relics / CT).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "ct",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6ref",
+          "aliases": [],
+          "brief": "Browse active Contested Territory events and their relic tiles.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "hero",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6ref",
+          "aliases": [],
+          "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "relic",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6ref",
+          "aliases": [],
+          "brief": "CT relic effect + current tile (by name / abbrev e.g. SMS / alias).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "round",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6ref",
+          "aliases": [],
+          "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "tower",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6ref",
+          "aliases": [],
+          "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "BTD6StrategyCog",
+      "file": "disbot/cogs/btd6_strategy_cog.py",
+      "subsystem": "b_t_d6_strategy",
+      "commands": [
+        {
+          "name": "btd6strat",
+          "type": "prefix",
+          "is_group": true,
+          "parent": null,
+          "aliases": [],
+          "brief": "BTD6 strategy memory (browse / submit / review).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "browse",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6strat",
+          "aliases": [],
+          "brief": "Browse published BTD6 strategies (PR-F).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "mine",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6strat",
+          "aliases": [],
+          "brief": "List my own strategy submissions in this guild (PR-F).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "pending",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6strat",
+          "aliases": [],
+          "brief": "List pending strategy submissions with review buttons.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "strategies",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6strat",
+          "aliases": [],
+          "brief": "List strategy memory entries available in this guild.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "strategy",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6strat",
+          "aliases": [],
+          "brief": "Show one strategy in detail (PR-F).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "strategy-audit",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6strat",
+          "aliases": [],
+          "brief": "Show the per-strategy audit log (PR-F).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "submit",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6strat",
+          "aliases": [],
+          "brief": "Open a strategy submission modal (slash-only on Discord).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "why-no-response",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6strat",
+          "aliases": [],
+          "brief": "Show the most recent BTD6 denials / skips for this guild.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "BlackjackCog",
+      "file": "disbot/cogs/blackjack_cog.py",
+      "subsystem": "blackjack",
+      "commands": [
+        {
+          "name": "bjstart",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Manually start a pending Blackjack tournament early.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "bjstatus",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Show the current tournament status.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "bjtournament",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "bjtourn"
+          ],
+          "brief": "Start a Blackjack tournament. !bjtournament [entry_fee] [rounds] [mins]",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "blackjack",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "bj"
+          ],
+          "brief": "Play blackjack. !bj [bet] or !bj @player [bet]",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        }
+      ]
+    },
+    {
+      "cog": "ChainCog",
+      "file": "disbot/cogs/chain_cog.py",
+      "subsystem": "chain",
+      "commands": [
+        {
+          "name": "chain",
+          "type": "prefix",
+          "is_group": true,
+          "parent": null,
+          "aliases": [],
+          "brief": "Manage message chains and word limits in your server.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "chainmenu",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the interactive chain management panel.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "create",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "chain",
+          "aliases": [],
+          "brief": "Create a chain in a specified channel or the current channel if none is provided.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "delete",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "chain",
+          "aliases": [],
+          "brief": "Delete a chain from a specified channel or the current channel if none is provided.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "list",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "chain",
+          "aliases": [],
+          "brief": "List all active chains and word limits in the server.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "removelimit",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "chain",
+          "aliases": [],
+          "brief": "Remove the word limit from a specified channel or the current channel if none is provided.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "setlimit",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "chain",
+          "aliases": [],
+          "brief": "Set a word limit in a specified channel or the current channel if none is provided.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "ChannelCog",
+      "file": "disbot/cogs/channel_cog.py",
+      "subsystem": "channel",
+      "commands": [
+        {
+          "name": "bulkcreate",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Create multiple channels. Usage: !bulkcreate <ch1> [ch2...] [category]",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "bulkdelete",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Delete multiple channels. Usage: !bulkdelete <name|id> [name|id...] or <keyword>",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "channelinfo",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Channel details. Usage: !channelinfo <name|id>",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "channelmenu",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the interactive channel management panel.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "clone",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Clone a channel. Usage: !clone <name|id> <new_name>",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "create",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Create a channel with role access. Usage: !create <name> <@role> <True/False> [category]",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "del",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Delete a specific channel. Usage: !del <name|id>",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "evt",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Create or delete an event channel. Usage: !evt <name|id> <create/delete>",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "list",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "List all categories and channels, including uncategorized.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "lock",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Lock a channel. Usage: !lock <name|id>",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "move",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Move a channel to a category. Usage: !move <channel name|id> <category name|id>",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "permissions",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Modify channel permissions. Usage: !permissions <name|id> <@role> <allow/deny>",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "rename",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Rename a channel. Usage: !rename <old name|id> <new_name>",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "set",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Set access for a channel/category. Usage: !set <name|id> <@role> <True/False>",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "unlock",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Unlock a channel. Usage: !unlock <name|id>",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "Cleanup",
+      "file": "disbot/cogs/cleanup_cog.py",
+      "subsystem": "cleanup",
+      "commands": [
+        {
+          "name": "cleanup",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the Cleanup hub panel — overview + routing to subviews.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "cleanuphistory",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Clean matching channel history by keyword, commands, or prohibited words.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "word",
+          "type": "prefix",
+          "is_group": true,
+          "parent": null,
+          "aliases": [],
+          "brief": "Manage prohibited words. Subcommands: add, remove, list.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "wordmenu",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the interactive prohibited words management panel.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "add",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "word",
+          "aliases": [],
+          "brief": "Adds a word to the prohibited words list.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "list",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "word",
+          "aliases": [],
+          "brief": "Shows all prohibited words.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "remove",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "word",
+          "aliases": [],
+          "brief": "Removes a word from the prohibited words list.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "CommunityCog",
+      "file": "disbot/cogs/community_cog.py",
+      "subsystem": "community",
+      "commands": [
+        {
+          "name": "community",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the Community hub — XP, Roles, and community activities.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "community",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the Community hub (XP, Roles, and community games).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        }
+      ]
+    },
+    {
+      "cog": "CommunitySpotlightCog",
+      "file": "disbot/cogs/community_spotlight_cog.py",
+      "subsystem": "community_spotlight",
+      "commands": [
+        {
+          "name": "spotlight",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "activity"
+          ],
+          "brief": "Show the Community Spotlight — live XP, coins, games, and level-ups.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        }
+      ]
+    },
+    {
+      "cog": "CountersCog",
+      "file": "disbot/cogs/counters_cog.py",
+      "subsystem": "counters",
+      "commands": [
+        {
+          "name": "counters",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Show the current server-counter channels for this server.",
+          "classification": "primary_entrypoint",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "CountingCog",
+      "file": "disbot/cogs/counting_cog.py",
+      "subsystem": "counting",
+      "commands": [
+        {
+          "name": "count_info",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "ci"
+          ],
+          "brief": "Displays the current count and configuration.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "count_rules",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "cr"
+          ],
+          "brief": "Displays the counting game rules.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "countingmenu",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "cm"
+          ],
+          "brief": "Open the interactive counting game management panel.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "end_match",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "em"
+          ],
+          "brief": "Ends the counting match in the specified channel and deletes the channel.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "reset_count",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "rc"
+          ],
+          "brief": "Resets the count to the starting value.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "set_skip_numbers",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "ssn"
+          ],
+          "brief": "Set the skip step N for a 'skip' match (count climbs 1, 1+N, 1+2N, …).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "start_match",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "sm"
+          ],
+          "brief": "Starts a new counting match with the specified mode.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "toggle_reset_on_wrong_count",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "trwc"
+          ],
+          "brief": "Toggles the 'reset on wrong count' feature.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "toggle_turns",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "tt"
+          ],
+          "brief": "Toggles the 'taking turns' mode.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "Deathmatch",
+      "file": "disbot/cogs/deathmatch_cog.py",
+      "subsystem": "deathmatch",
+      "commands": [
+        {
+          "name": "dm_challenge",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "deathmatch",
+            "challenge",
+            "dm"
+          ],
+          "brief": "Challenge another user to a deathmatch duel.",
+          "classification": "power_user_shortcut",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "dm_help",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "deathmatch_help"
+          ],
+          "brief": "Display help information for Deathmatch commands.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "DiagnosticCog",
+      "file": "disbot/cogs/diagnostic_cog.py",
+      "subsystem": "diagnostic",
+      "commands": [
+        {
+          "name": "check_database",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "checkdb"
+          ],
+          "brief": "Verify that all expected PostgreSQL tables exist.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "diagnostic_bot_status",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "diag_status"
+          ],
+          "brief": "Display bot health and performance metrics.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "diagnostics",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "diag"
+          ],
+          "brief": "Open the interactive diagnostics hub panel.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "find_command",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "findcmd"
+          ],
+          "brief": "Search for commands by keyword in their name or description.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "latency",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "ping"
+          ],
+          "brief": "Report the bot's WebSocket latency.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "lifecycle",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "lc"
+          ],
+          "brief": "Lifecycle state (phase, pending request, recent events).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "list_commands_detailed",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "listcmds"
+          ],
+          "brief": "List all registered commands with details, paginated by cog.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "platform",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the Platform / Diagnostics hub (administrator only).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "query_logs",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "querylogs"
+          ],
+          "brief": "Query recent logs from the logs table. !query_logs [INFO|ERROR|...] [limit]",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "recent_errors",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "errors"
+          ],
+          "brief": "Retrieve the most recent ERROR-level log entries.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "system_info",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "sysinfo"
+          ],
+          "brief": "Display system-level stats.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "test_notification",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "testnotify"
+          ],
+          "brief": "Send a test notification via the webhook reporter.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "validate_json_files",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "validatejson"
+          ],
+          "brief": "Validate the structure of all JSON files in the data directory.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "EconomyCog",
+      "file": "disbot/cogs/economy_cog.py",
+      "subsystem": "economy",
+      "commands": [
+        {
+          "name": "balance",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "bal",
+            "wallet"
+          ],
+          "brief": "Show your (or another user's) current coin balance.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "daily",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Claim your daily reward. Higher streaks unlock better odds!",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "economy",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the Economy hub (daily, work, shop, balance).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "economymenu",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the interactive economy control panel.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "joblist",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "jobs"
+          ],
+          "brief": "Show all jobs, requirements, and your mastery for each.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "setlogchannel",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Set the economy log channel. Usage: !setlogchannel #channel",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "shop",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Browse and buy items from the shop.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "work",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the job selector and earn coins + XP (1 h cooldown).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        }
+      ]
+    },
+    {
+      "cog": "FourTwentyCog",
+      "file": "disbot/cogs/four_twenty_cog.py",
+      "subsystem": "four_twenty",
+      "commands": [
+        {
+          "name": "420",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "fourtwenty",
+            "fourtwenty420"
+          ],
+          "brief": "Open the 🍃 420 panel — rotating wisdom and number trivia.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        }
+      ]
+    },
+    {
+      "cog": "GamesCog",
+      "file": "disbot/cogs/games_cog.py",
+      "subsystem": "games",
+      "commands": [
+        {
+          "name": "games",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the Games hub — competitive games and channel activities.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "games",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the Games hub (competitive + activities).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        }
+      ]
+    },
+    {
+      "cog": "General",
+      "file": "disbot/cogs/general_cog.py",
+      "subsystem": "general",
+      "commands": [
+        {
+          "name": "eightball",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "8ball"
+          ],
+          "brief": "Ask the Magic 8-Ball a yes/no question.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "fact",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Sends a random interesting fact.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "generalmenu",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "gmenu"
+          ],
+          "brief": "Open the interactive General panel.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "greet",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Greets you with a random greeting.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "joke",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Sends a random joke.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "motivate",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Sends a motivational message.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "quote",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Sends a random famous quote.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "trivia",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Asks a trivia question with a reveal button.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        }
+      ]
+    },
+    {
+      "cog": "HelpCog",
+      "file": "disbot/cogs/help_cog.py",
+      "subsystem": "help",
+      "commands": [
+        {
+          "name": "help",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "hilfe"
+          ],
+          "brief": "Shows available commands. Pass a category name for details.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "help",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Show available commands (optionally narrow to one category).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        }
+      ]
+    },
+    {
+      "cog": "HermesCog",
+      "file": "disbot/cogs/hermes_cog.py",
+      "subsystem": "hermes",
+      "commands": [
+        {
+          "name": "bugreport",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Report a bug — Hermes dispatches a Claude Code session to fix it automatically.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "dispatch",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Send a raw Hermes work order to the Claude Code Routine (owner only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "InventoryCog",
+      "file": "disbot/cogs/inventory_cog.py",
+      "subsystem": "inventory",
+      "commands": [
+        {
+          "name": "inventory",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "inv"
+          ],
+          "brief": "Show your (or another user's) unified inventory hub.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        }
+      ]
+    },
+    {
+      "cog": "LeaderboardCog",
+      "file": "disbot/cogs/leaderboard_cog.py",
+      "subsystem": "leaderboard",
+      "commands": [
+        {
+          "name": "leaderboard",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "lb",
+            "rankings",
+            "minelb",
+            "miningleaderboard",
+            "dm_leaderboard",
+            "dm_lb",
+            "rpslb",
+            "countlb",
+            "counting_leaderboard"
+          ],
+          "brief": "Show a leaderboard. !leaderboard [xp|coins|mining|deathmatch|rps|counting]",
+          "classification": "legacy_duplicate",
+          "has_panel": true,
+          "button_backed": true
+        }
+      ]
+    },
+    {
+      "cog": "LoggingCog",
+      "file": "disbot/cogs/logging_cog.py",
+      "subsystem": "logging",
+      "commands": [
+        {
+          "name": "logging",
+          "type": "prefix",
+          "is_group": true,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the logging admin panel (S7d).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "create",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "logging",
+          "aliases": [],
+          "brief": "Preview + create a new log channel for any registered route.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "routes",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "logging",
+          "aliases": [],
+          "brief": "Open the Phase 9b Routes subpage directly.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "set",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "logging",
+          "aliases": [],
+          "brief": "Open the channel-select view for ``mod`` or ``cleanup`` binding.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "status",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "logging",
+          "aliases": [],
+          "brief": "Show this guild's server-logging configuration + counters.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "test",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "logging",
+          "aliases": [],
+          "brief": "Send a synthetic warn embed to the configured log channel.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "MiningCog",
+      "file": "disbot/cogs/mining_cog.py",
+      "subsystem": "mining",
+      "commands": [
+        {
+          "name": "ascend",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Climb one mining band back toward the surface.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "build",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "craft"
+          ],
+          "brief": "Build / craft an item from recipes (one shared, atomic implementation).",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "buildable",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Lists only what the user can currently build based on their inventory.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "buildlist",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Shows all craftable structures from recipes.json.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "buy",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Buy gear with coins (e.g. `!buy iron sword`).",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "character",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "profile",
+            "char"
+          ],
+          "brief": "Show your full mining character — location, gear, stats, wealth.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "chop",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Chop wood. If you have an 'axe', you'll collect double.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "descend",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Descend one mining band deeper (gated by your equipped light).",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "equip",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Equip a tool, light, or charm so its stats apply to your character.",
+          "classification": "hidden",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "explore",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Discover random events or items (driven by your gear and depth).",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "fastmine",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "One quick mining swing — no buttons (the old !fastmine, reborn).",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "forge",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the Forge — build it to unlock higher-tier gear crafting.",
+          "classification": "panel_action",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "gear",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Show your equipped gear, its condition, and the stats it grants.",
+          "classification": "hidden",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "give",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Admin-only: give resources to a user.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "home",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the Home — build it to personalize your Character card.",
+          "classification": "panel_action",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "market",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Show the mining market — sellable resources + the gear shop.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "mine",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Start mining with interactive buttons.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "mineinv",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "mineinventory"
+          ],
+          "brief": "Show your unified inventory (compatibility alias for !inventory).",
+          "classification": "legacy_duplicate",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "minemenu",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the mining hub panel.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "minestats",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Shows your total mining items and number of unique items.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "quickcraft",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Re-craft the last gear item that broke and equip it.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "repair",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Repair a worn gear item for coins (e.g. `!repair pickaxe`).",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "reset_inventory",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Admin-only: reset a user's inventory in THIS guild (PR M3 — guild-scoped).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "sell",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Sell raw resources for coins (e.g. `!sell diamond 5`).",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "sellall",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Sell every raw resource in your inventory for coins.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "skill",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Spend a skill point into a branch (e.g. `!skill mining`).",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "skills",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open your skill tree — spend points to specialize your character.",
+          "classification": "panel_action",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "stash",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Deposit an item into your vault (e.g. `!stash diamond 5`).",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "titles",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open your titles — equip an earned title on your Character card.",
+          "classification": "panel_action",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "unequip",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Clear an equipment slot (tool, light, charm, or a combat piece).",
+          "classification": "hidden",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "unstash",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Withdraw an item from your vault (e.g. `!unstash diamond 5`).",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "use",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Use a special item from your inventory (e.g., torch, dynamite).",
+          "classification": "hidden",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "vault",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open your vault — a safe stash separate from your mining pack.",
+          "classification": "panel_action",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "vaultupgrade",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Buy one vault-capacity tier with coins (e.g. more room to stash).",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "workshop",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the workshop — repair worn gear, craft replacements.",
+          "classification": "panel_action",
+          "has_panel": true,
+          "button_backed": true
+        }
+      ]
+    },
+    {
+      "cog": "ModerationCog",
+      "file": "disbot/cogs/moderation_cog.py",
+      "subsystem": "moderation",
+      "commands": [
+        {
+          "name": "ban",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Ban a member from the server.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "clearwarnings",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Clear all warnings for a member.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "kick",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Kick a member from the server.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "moderation",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the Moderation hub (moderator only).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "modlogs",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Show moderation log history for a member.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "modmenu",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Show the interactive moderation action panel.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "timeout",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Timeout a member for a given number of minutes.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "unban",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Unban a user by their Discord user ID.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "warn",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Warn a user. Escalates at the configured threshold (default: timeout).",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        }
+      ]
+    },
+    {
+      "cog": "ParagonCog",
+      "file": "disbot/cogs/paragon_cog.py",
+      "subsystem": "paragon",
+      "commands": [
+        {
+          "name": "paragon",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the BTD6 Paragon degree calculator.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        }
+      ]
+    },
+    {
+      "cog": "PlatformCommandsMixin",
+      "file": "disbot/cogs/diagnostic/platform_group.py",
+      "subsystem": "platform_commands_mixin",
+      "commands": [
+        {
+          "name": "platform",
+          "type": "prefix",
+          "is_group": true,
+          "parent": null,
+          "aliases": [],
+          "brief": "Runtime introspection group.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "access",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [
+            "whyhere"
+          ],
+          "brief": "Explain which subsystems you can use in a channel/thread (IL-1).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "anchors",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Show last restoration outcome and active anchor counts per subsystem.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "automation",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Open the automation management + diagnostics panel.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "backfill",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Dry-run (default) or `apply` the legacy-pointer → binding backfill.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "bindings",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Subsystem bindings (Phase 2b) — taxonomy + per-guild histograms.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "caches",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Cache state: F-1 guild_config + governance.cache.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "cleanup-preview",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [
+            "cleanuppreview",
+            "cleanup-policy"
+          ],
+          "brief": "Dry-run preview of the cleanup policy resolved for a location (IL-2).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "command-access",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [
+            "commandaccess"
+          ],
+          "brief": "Show the live command-access decision for a channel.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "consistency",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Unified platform readiness diagnostic — read-only (Phase 2 PR-10).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "counting-health",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [
+            "countinghealth"
+          ],
+          "brief": "Surface counting persistence health from task_outcome_total (IL-3).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "customization",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Customization catalogue across subsystems (S2).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "economy",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [
+            "coinflow"
+          ],
+          "brief": "Faucet/sink coin-economy view (`!platform economy [days]`): minted",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "finding",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Transition a persistent finding: `resolve` / `ignore` / `reopen` <fingerprint>.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "findings",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Persistent operational-health findings (open / resolved / ignored / all).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "flag",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Open the editable per-guild flag manager (Phase 6.5a).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "flags",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Feature flags: declarations + Phase 2d evaluator state per flag.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "health",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Deterministic operational health snapshot (admin-gated, redacted).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "identity",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Run the identity-contract validator and show findings.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "lifecycle",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Lifecycle state: phase, pending request, recent events.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "locks",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "scope_locks snapshot; pass a prefix to filter (e.g. `counting`).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "media",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Content-free media (YouTube) diagnostics.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "migrations",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Platform migration checkpoints (Phase 2 PR-5) — status + summary.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "participation-schemas",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Registered ParticipationSchema instances (Phase 1b).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "provisioning",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Cross-linked ResourceRequirement × BindingSpec catalogue (S2.5).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "resource-requirements",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Declared ResourceRequirement entries across subsystems (Phase 1c).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "resources",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Resource runtime (Phase 2a) — taxonomy + cached status histogram.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "runtime",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "High-level runtime snapshot: every registered diagnostic provider.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "schemas",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Registered SubsystemSchema instances (Phase 1a).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "sessions",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Active session counts (DB-backed); optionally filtered by subsystem.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "setting",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Explain one scalar setting for this guild.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "settings-registry",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Declared SettingSpec catalogue + this guild's current values (S1).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "setup-readiness",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [
+            "readiness",
+            "ready"
+          ],
+          "brief": "Per-guild setup-readiness inventory (PR H).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "slow",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Show the most recent slow-path entries (S3.2 ring buffer).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "startup",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Settled-startup health report (extension load, gateway, DB, …).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "status",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "High-level platform status: uptime, cogs, governance, scheduler.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "tasks",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Managed background-task snapshot (core.runtime.tasks).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "views",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "platform",
+          "aliases": [],
+          "brief": "Registered PersistentView classes (by subsystem).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "ProofChannelCog",
+      "file": "disbot/cogs/proof_channel_cog.py",
+      "subsystem": "proof_channel",
+      "commands": [
+        {
+          "name": "+prize",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Grant a winner exclusive access to #proof. Usage: +prize @winner",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "-prize",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "End the prize session and make #proof read-only again. Usage: -prize",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "prizemenu",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the interactive prize channel management panel.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "prizestatus",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Show current #proof channel permissions.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "timedprize",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Grant timed access to #proof; auto-unlocks after duration minutes. Usage: timedprize @winner <minutes>",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "RockPaperScissorsCog",
+      "file": "disbot/cogs/rps_tournament_cog.py",
+      "subsystem": "rock_paper_scissors",
+      "commands": [
+        {
+          "name": "rps",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Quick RPS. !rps [bet] or !rps @player [bet]",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "rpsbot",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Starts matches against the bot. Delegator — see _bot_matches.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "rpshelp",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Displays help information for RPS tournament commands.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "rpsmatchup",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Manually creates a match between two specific members.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "rpsregister",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "rpsreg"
+          ],
+          "brief": "Starts the registration period with a reaction role message. !rpsregister [@role] [entry_fee]",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "rpssettings",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Updates bot settings.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "rpsstart",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "rpsbegin"
+          ],
+          "brief": "Starts the RPS tournament. Usage: !rps_start [mode] [best_of]",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "RoleCog",
+      "file": "disbot/cogs/role_cog.py",
+      "subsystem": "role",
+      "commands": [
+        {
+          "name": "assignroles",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Manually run time-based role assignment for all members.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "createrole",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Create a role (use !roles → Create instead).",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "debugroles",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Print all role names for verification.",
+          "classification": "internal_admin",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "deleterole",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Delete a role by name or mention.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "listreactroles",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "List all active reaction roles in this server.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "reactroles",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "reaktionsrollen"
+          ],
+          "brief": "Attach a reaction role to a message. Usage: !reactroles <message_id> <emoji> <@role>",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "refreshmembers",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Force-fetch all members from Discord.",
+          "classification": "internal_admin",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "removereactrole",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Remove a reaction role binding. Usage: !removereactrole <message_id> <emoji>",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "rolecreator",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the role hub (use !roles instead).",
+          "classification": "legacy_duplicate",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "rolemenu",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the role hub (use !roles instead).",
+          "classification": "legacy_duplicate",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "roles",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the role management hub.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "rolesettings",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the role management hub (alias for !roles).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "setrole",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Add or update a time-based role threshold.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        },
+        {
+          "name": "unsetrole",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Remove a role from time-based assignment.",
+          "classification": "panel_action",
+          "has_panel": false,
+          "button_backed": true
+        }
+      ]
+    },
+    {
+      "cog": "ServerManagementCog",
+      "file": "disbot/cogs/server_management_cog.py",
+      "subsystem": "server_management",
+      "commands": [
+        {
+          "name": "server-management",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the Server Management hub (moderation, channels, roles, cleanup, setup).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "servermanagement",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "servermenu",
+            "guildmenu"
+          ],
+          "brief": "Open the unified Server Management hub.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        }
+      ]
+    },
+    {
+      "cog": "SettingsCog",
+      "file": "disbot/cogs/settings_cog.py",
+      "subsystem": "settings",
+      "commands": [
+        {
+          "name": "settings",
+          "type": "prefix",
+          "is_group": true,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the Settings Manager hub (browse + edit/reset scalars).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "settings",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the Settings Manager hub (administrator only).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "access",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "settings",
+          "aliases": [],
+          "brief": "Open the read-only access-policy explorer.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        }
+      ]
+    },
+    {
+      "cog": "SetupCog",
+      "file": "disbot/cogs/setup_cog.py",
+      "subsystem": "setup",
+      "commands": [
+        {
+          "name": "setup",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open or resume the linear setup wizard.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "setup",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the setup wizard (owner, delegated admin, or admin).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "setup-delegate",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Grant a member delegated setup-admin authority (owner only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "setup-depth",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Pick the wizard depth (owner/delegated admin only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "setup-hub",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the legacy section-list hub (compat).",
+          "classification": "legacy_duplicate",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "setup-reset",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Clear all staged setup operations (owner/delegated admin only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "setup-skip",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Mark a setup section as skipped (owner/delegated admin only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "setup-status",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Quick at-a-glance setup state (read-only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "setup-undelegate",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Revoke delegated setup-admin authority (owner only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "setup-unskip",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Remove a section from the skipped set (owner/delegated admin only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "UtilityCog",
+      "file": "disbot/cogs/utility_cog.py",
+      "subsystem": "utility",
+      "commands": [
+        {
+          "name": "avatar",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Display a user's avatar.",
+          "classification": "hidden",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "clear",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "purge"
+          ],
+          "brief": "Purge messages. Max 100.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "info",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Show server or user info. !info [server|user] [@mention]",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "invite",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Generate a one-use server invite.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "myprofile",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "View your per-server profile card.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "myprofile",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "View your profile: participation, subscriptions, preferences, visibility.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "poll",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Create a simple reaction poll.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "remind",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Set a reminder. !remind <minutes> <message>",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "serverinfo",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Alias for !info server.",
+          "classification": "legacy_duplicate",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "userinfo",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Alias for !info user [@member].",
+          "classification": "legacy_duplicate",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "utility",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the Utility hub (server info, polls, reminders).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "utilitymenu",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the interactive utility panel.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        }
+      ]
+    },
+    {
+      "cog": "UxLabCog",
+      "file": "disbot/cogs/ux_lab_cog.py",
+      "subsystem": "ux_lab",
+      "commands": [
+        {
+          "name": "uxlab",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "interfacelab"
+          ],
+          "brief": "Open the UX Lab — the interface gallery + limit probe bench.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "uxlab",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the UX Lab — browse interface patterns (admin).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        }
+      ]
+    },
+    {
+      "cog": "WelcomeCog",
+      "file": "disbot/cogs/welcome_cog.py",
+      "subsystem": "welcome",
+      "commands": [
+        {
+          "name": "welcome",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Show the current welcome (greeting) policy for this server.",
+          "classification": "primary_entrypoint",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "XpCog",
+      "file": "disbot/cogs/xp_cog.py",
+      "subsystem": "xp",
+      "commands": [
+        {
+          "name": "givexp",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Give XP to a user (admin only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "rank",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Show rank in a category.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "resetxp",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Reset a user's XP to zero (admin only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "xpconfig",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the XP configuration panel (admin only).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "xpmenu",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Open the XP panel showing your rank and quick admin actions.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
         }
       ]
     }

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -14,7 +14,7 @@
     <header class="border-b border-slate-800 bg-slate-900/70 backdrop-blur sticky top-0 z-10">
       <nav class="mx-auto max-w-5xl px-4 py-3 flex flex-wrap items-center gap-x-5 gap-y-2">
         <a href="/" class="font-bold text-lg mr-2">🤖 SuperBot</a>
-        {% set nav_items = [('functions', 'Functions'), ('ideas', 'Ideas'), ('bugs', 'Bugs'), ('updates', 'Updates'), ('env', 'Env map')] %}
+        {% set nav_items = [('functions', 'Functions'), ('commands', 'Commands'), ('ideas', 'Ideas'), ('bugs', 'Bugs'), ('updates', 'Updates'), ('env', 'Env map')] %}
         {% for key, label in nav_items %}
           <a
             href="/{{ key }}"

--- a/dashboard/templates/commands.html
+++ b/dashboard/templates/commands.html
@@ -1,0 +1,113 @@
+{% extends "base.html" %}
+{% block title %}Commands — SuperBot{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-1">Cogs &amp; commands</h1>
+<p class="text-slate-400 mb-5 text-sm">
+  {{ data.meta.counts.get("commands", 0) }} commands across {{ data.meta.counts.get("cogs", 0) }} cogs,
+  scanned straight from the cog source. A <span class="text-sky-300">🔘 button</span> tag means the
+  command is a panel button's action or opens a view; everything else is reachable only by typing it.
+</p>
+
+<section class="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-6">
+  {% set cards = [
+      ('commands', 'Commands', data.meta.counts.get('commands', 0)),
+      ('prefix', 'Prefix !', stats.prefix),
+      ('slash', 'Slash /', stats.slash),
+      ('button', '🔘 Button', stats.button),
+      ('cogs', 'Cogs', data.meta.counts.get('cogs', 0)),
+  ] %}
+  {% for key, label, value in cards %}
+    <div class="rounded-xl border border-slate-800 bg-slate-900/50 p-4">
+      <div class="text-2xl font-bold">{{ value }}</div>
+      <div class="text-xs text-slate-400">{{ label }}</div>
+    </div>
+  {% endfor %}
+</section>
+
+<div class="flex flex-wrap items-center gap-2 mb-6">
+  <input id="cmd-search" type="search" placeholder="Search commands, cogs, aliases…"
+    class="flex-1 min-w-[12rem] rounded-lg bg-slate-900 border border-slate-700 px-3 py-2 text-sm
+           focus:outline-none focus:border-sky-500" />
+  {% set chips = [('all', 'All'), ('prefix', 'Prefix'), ('slash', 'Slash'), ('button', '🔘 Button')] %}
+  {% for key, label in chips %}
+    <button type="button" data-filter="{{ key }}"
+      class="cmd-chip text-xs rounded-full border border-slate-700 px-3 py-1.5 hover:border-sky-500
+             {{ 'ring-2 ring-sky-400' if key == 'all' else '' }}">{{ label }}</button>
+  {% endfor %}
+</div>
+
+{% for cog in data.cogs %}
+  {% set sys = sysmap.get(cog.subsystem) %}
+  <section class="cog mb-6 rounded-xl border border-slate-800 bg-slate-900/40">
+    <div class="flex items-center gap-2 px-4 py-3 border-b border-slate-800">
+      <span class="text-xl">{{ sys.emoji if sys and sys.emoji else "🧩" }}</span>
+      <span class="font-semibold">{{ sys.display_name if sys and sys.display_name else cog.cog }}</span>
+      <span class="text-xs text-slate-500">{{ cog.cog }}</span>
+      <span class="ml-auto text-[11px] text-slate-500">{{ cog.commands|length }} cmd{{ '' if cog.commands|length == 1 else 's' }}</span>
+    </div>
+    <ul class="divide-y divide-slate-800/70">
+      {% for cmd in cog.commands %}
+        <li class="cmd px-4 py-2.5"
+            data-type="{{ cmd.type }}"
+            data-button="{{ '1' if cmd.button_backed else '0' }}"
+            data-search="{{ (cmd.name ~ ' ' ~ cog.cog ~ ' ' ~ (cmd.aliases | join(' ')) ~ ' ' ~ cmd.brief) | lower }}">
+          <div class="flex items-center gap-2 flex-wrap">
+            <code class="text-sky-300">{{ '/' if cmd.type == 'slash' else '!' }}{{ cmd.name }}</code>
+            {% if cmd.parent %}<span class="text-[10px] text-slate-500">↳ under {{ cmd.parent }}</span>{% endif %}
+            <span class="text-[10px] uppercase rounded px-1.5 py-0.5
+              {{ 'bg-violet-900 text-violet-200' if cmd.type == 'slash'
+                 else ('bg-amber-900 text-amber-200' if cmd.type == 'both' else 'bg-slate-800 text-slate-300') }}">
+              {{ 'both' if cmd.type == 'both' else ('slash' if cmd.type == 'slash' else 'prefix') }}</span>
+            {% if cmd.button_backed %}
+              <span class="text-[10px] rounded px-1.5 py-0.5 bg-sky-900 text-sky-200">🔘 button</span>
+            {% endif %}
+            {% if cmd.classification and cmd.classification != 'panel_action' %}
+              <span class="text-[10px] rounded px-1.5 py-0.5 bg-slate-800 text-slate-400">{{ cmd.classification }}</span>
+            {% endif %}
+            {% if cmd.aliases %}
+              <span class="text-[10px] text-slate-500">aka {{ cmd.aliases | join(', ') }}</span>
+            {% endif %}
+          </div>
+          {% if cmd.brief %}<p class="mt-1 text-xs text-slate-400">{{ cmd.brief }}</p>{% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+{% else %}
+  <p class="text-slate-500">No commands found.</p>
+{% endfor %}
+
+<script>
+  (function () {
+    const search = document.getElementById("cmd-search");
+    const chips = document.querySelectorAll(".cmd-chip");
+    let typeFilter = "all";
+    function apply() {
+      const q = (search.value || "").toLowerCase().trim();
+      document.querySelectorAll("section.cog").forEach((sec) => {
+        let visible = 0;
+        sec.querySelectorAll("li.cmd").forEach((li) => {
+          const matchText = !q || li.dataset.search.includes(q);
+          let matchType = true;
+          if (typeFilter === "prefix") matchType = li.dataset.type !== "slash";
+          else if (typeFilter === "slash") matchType = li.dataset.type !== "prefix";
+          else if (typeFilter === "button") matchType = li.dataset.button === "1";
+          const show = matchText && matchType;
+          li.style.display = show ? "" : "none";
+          if (show) visible++;
+        });
+        sec.style.display = visible ? "" : "none";
+      });
+    }
+    search.addEventListener("input", apply);
+    chips.forEach((ch) =>
+      ch.addEventListener("click", () => {
+        typeFilter = ch.dataset.filter;
+        chips.forEach((c) => c.classList.remove("ring-2", "ring-sky-400"));
+        ch.classList.add("ring-2", "ring-sky-400");
+        apply();
+      }),
+    );
+  })();
+</script>
+{% endblock %}

--- a/dashboard/templates/index.html
+++ b/dashboard/templates/index.html
@@ -9,8 +9,8 @@
   </p>
 </section>
 
-<section class="grid grid-cols-2 sm:grid-cols-4 gap-4">
-  {% set cards = [('functions', 'Functions', '/functions'), ('ideas', 'Ideas', '/ideas'), ('bugs', 'Bugs', '/bugs'), ('updates', 'Updates', '/updates')] %}
+<section class="grid grid-cols-2 sm:grid-cols-3 gap-4">
+  {% set cards = [('functions', 'Functions', '/functions'), ('commands', 'Commands', '/commands'), ('ideas', 'Ideas', '/ideas'), ('bugs', 'Bugs', '/bugs'), ('updates', 'Updates', '/updates'), ('env_vars', 'Env map', '/env')] %}
   {% for key, label, href in cards %}
     <a href="{{ href }}" class="rounded-xl border border-slate-800 bg-slate-900/50 p-5 hover:border-sky-600 transition-colors">
       <div class="text-3xl font-bold">{{ data.meta.counts.get(key, 0) }}</div>

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,7 +25,7 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/jolly-cannon-gn9ddg` · dashboard deploy fix — StaticFiles `/static` crash (`static/` is gitignored) + `dashboard/Procfile` + deploy-docs root=`dashboard/` · 2026-06-16
+- `claude/jolly-cannon-gn9ddg` · dashboard cog & command explorer (`/commands`) — `scripts/scan_commands.py` AST scan: prefix/slash + button-backed · 2026-06-16
 - `claude/upbeat-einstein-7rz9z0` · act on the 2026-06-16 autonomous-run review + owner answers —
   run-report footer · ledger guard-exemption + drift line · bug-fix-guard convention · auto-deploy
   misinformation fix · Q-0147 DM gate · Q-0085/0120/0121/0127 records · ledger tidy · 2026-06-16

--- a/docs/planning/developer-dashboard-plan.md
+++ b/docs/planning/developer-dashboard-plan.md
@@ -31,6 +31,7 @@ not re-implement them:
 | Feature | How it's built | Existing data source |
 |---|---|---|
 | Bot-function catalogue | catalogue page | `disbot/utils/subsystem_registry.py` (AST-parsed; never imported) |
+| Cog & command explorer | `/commands` page ✅ | `disbot/cogs/**` (AST via `scripts/scan_commands.py`) — prefix/slash + button-backed |
 | Update tracking / changelog | updates feed | `.sessions/*.md` logs (+ later GitHub PRs, `current-state.md`) |
 | Ideas board | ideas page | `docs/ideas/*.md` |
 | Bug board | bugs page | `docs/health/bug-book.md` |

--- a/scripts/export_dashboard_data.py
+++ b/scripts/export_dashboard_data.py
@@ -53,6 +53,17 @@ def _load_scan_env_usage() -> Callable[..., list[dict]]:
     return module.scan_env_usage
 
 
+def _load_scan_commands() -> Callable[..., list[dict]]:
+    """Load ``scan_commands`` from its sibling script (scripts/ isn't a package)."""
+    script = Path(__file__).resolve().parent / "scan_commands.py"
+    spec = importlib.util.spec_from_file_location("_scan_commands_seam", script)
+    if spec is None or spec.loader is None:  # pragma: no cover - import wiring
+        raise ImportError("cannot load scan_commands.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.scan_commands
+
+
 # Catalogue fields surfaced from the registry (all str/list literals — the
 # non-literal ``color`` field is intentionally skipped).
 _CATALOGUE_FIELDS = (
@@ -283,6 +294,11 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
         if scan_root.is_dir()
         else []
     )
+    cogs = (
+        _load_scan_commands()(repo_root=repo_root)
+        if (repo_root / "disbot" / "cogs").is_dir()
+        else []
+    )
 
     return {
         "meta": {
@@ -295,6 +311,8 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
                 "bugs": len(bugs),
                 "updates": len(updates),
                 "env_vars": len(env_usage),
+                "cogs": len(cogs),
+                "commands": sum(len(c["commands"]) for c in cogs),
             },
         },
         "catalogue": catalogue,
@@ -302,6 +320,7 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
         "bugs": bugs,
         "updates": updates,
         "env_usage": env_usage,
+        "cogs": cogs,
     }
 
 

--- a/scripts/scan_commands.py
+++ b/scripts/scan_commands.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3.10
+"""Scan ``disbot/cogs/**`` for the command surface (stdlib, AST only).
+
+Produces the data behind the dashboard's `/commands` cog-and-command explorer:
+every cog, the commands it declares, each command's **invocation type**
+(prefix / slash / both), and whether it is **button-backed** (a panel action or a
+command that opens a Discord UI view). Never imports ``disbot`` — pure AST, so it
+runs in CI with no extra dependencies.
+
+Invocation type is read from the decorator:
+
+* ``@commands.command`` / ``@commands.group``            -> ``prefix``
+* ``@app_commands.command`` / ``@app_commands.group``    -> ``slash``
+* ``@commands.hybrid_command`` / ``@commands.hybrid_group`` -> ``both``
+* ``@<group>.command`` / ``@<group>.group``              -> subcommand (inherits
+  the parent group's type)
+
+Button-backed is the project's own model (see
+``core/runtime/command_surface_ledger.py``): a command declared
+``extras={"classification": "panel_action"}`` *is* a panel button's action, and a
+command whose body opens a view (``panel_manager`` / ``send_panel`` / ``*View(`` /
+``view=``) shows buttons. Either makes ``button_backed`` true.
+
+Reliability (Q-0105): **unverified** — confirm against the live ledger a few times
+before trusting it; delete this seam if it drifts. It is a convenience generator.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COGS_DIR = REPO_ROOT / "disbot" / "cogs"
+
+# decorator path -> (invocation type, is_group)
+_COMMAND_DECORATORS: dict[str, tuple[str, bool]] = {
+    "commands.command": ("prefix", False),
+    "command": ("prefix", False),
+    "commands.hybrid_command": ("both", False),
+    "hybrid_command": ("both", False),
+    "app_commands.command": ("slash", False),
+    "commands.group": ("prefix", True),
+    "group": ("prefix", True),
+    "commands.hybrid_group": ("both", True),
+    "hybrid_group": ("both", True),
+    "app_commands.group": ("slash", True),
+}
+_SUBCOMMAND_LEAVES = {"command", "group", "subcommand"}
+_PANEL_TOKENS = ("panel_manager", "send_panel", "View(", "view=")
+_CAMEL_RE = re.compile(r"(?<!^)(?=[A-Z])")
+
+
+def _truncate(text: str, limit: int) -> str:
+    text = " ".join(text.split())
+    return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
+
+
+def _cog_to_subsystem(class_name: str) -> str:
+    """Normalise a cog class name to its snake_case subsystem key."""
+    base = class_name[:-3] if class_name.endswith("Cog") else class_name
+    return _CAMEL_RE.sub("_", base).lower()
+
+
+def _decorator_path(dec: ast.expr) -> str:
+    """Dotted path of a decorator, e.g. ``commands.command`` or ``mygroup.command``."""
+    node = dec.func if isinstance(dec, ast.Call) else dec
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+    return ".".join(reversed(parts))
+
+
+def _kwarg(call: ast.Call | None, name: str) -> object:
+    if call is None:
+        return None
+    for kw in call.keywords:
+        if kw.arg == name:
+            try:
+                return ast.literal_eval(kw.value)
+            except (ValueError, TypeError, SyntaxError):
+                return None
+    return None
+
+
+def _classification(call: ast.Call | None) -> str:
+    extras = _kwarg(call, "extras")
+    if isinstance(extras, dict):
+        value = extras.get("classification") or extras.get("alias_classification")
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def _docstring_first_line(method: ast.AST) -> str:
+    doc = (
+        ast.get_docstring(method)
+        if isinstance(method, ast.FunctionDef | ast.AsyncFunctionDef)
+        else None
+    )
+    return doc.strip().splitlines()[0] if doc else ""
+
+
+def _find_groups(class_node: ast.ClassDef) -> dict[str, tuple[str, str]]:
+    """Map a group *method* name -> (command name, invocation type)."""
+    groups: dict[str, tuple[str, str]] = {}
+    for item in class_node.body:
+        if not isinstance(item, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        for dec in item.decorator_list:
+            path = _decorator_path(dec)
+            spec = _COMMAND_DECORATORS.get(path)
+            if spec and spec[1]:  # is a group
+                call = dec if isinstance(dec, ast.Call) else None
+                name = _kwarg(call, "name")
+                gname = name if isinstance(name, str) else item.name
+                groups[item.name] = (gname, spec[0])
+    return groups
+
+
+def _scan_method(
+    method: ast.AST,
+    source: str,
+    groups: dict[str, tuple[str, str]],
+) -> dict | None:
+    if not isinstance(method, ast.FunctionDef | ast.AsyncFunctionDef):
+        return None
+    kind: str | None = None
+    is_group = False
+    parent: str | None = None
+    call: ast.Call | None = None
+    for dec in method.decorator_list:
+        path = _decorator_path(dec)
+        spec = _COMMAND_DECORATORS.get(path)
+        if spec is not None:
+            kind, is_group = spec
+            call = dec if isinstance(dec, ast.Call) else None
+            break
+        parts = path.split(".")
+        if len(parts) == 2 and parts[0] in groups and parts[1] in _SUBCOMMAND_LEAVES:
+            parent, kind = groups[parts[0]]
+            is_group = parts[1] == "group"
+            call = dec if isinstance(dec, ast.Call) else None
+            break
+    if kind is None:
+        return None
+    name = _kwarg(call, "name")
+    cmd_name = name if isinstance(name, str) else method.name
+    aliases = _kwarg(call, "aliases")
+    brief = _kwarg(call, "brief") or _kwarg(call, "description") or _kwarg(call, "help")
+    if not isinstance(brief, str) or not brief:
+        brief = _docstring_first_line(method)
+    classification = _classification(call)
+    body = ast.get_source_segment(source, method) or ""
+    has_panel = any(tok in body for tok in _PANEL_TOKENS)
+    return {
+        "name": cmd_name,
+        "type": kind,
+        "is_group": is_group,
+        "parent": parent,
+        "aliases": (
+            [a for a in aliases if isinstance(a, str)]
+            if isinstance(aliases, list)
+            else []
+        ),
+        "brief": _truncate(brief, 160),
+        "classification": classification,
+        "has_panel": has_panel,
+        "button_backed": classification == "panel_action" or has_panel,
+    }
+
+
+def _scan_class(class_node: ast.ClassDef, source: str, rel_path: str) -> dict | None:
+    groups = _find_groups(class_node)
+    commands: list[dict] = []
+    for item in class_node.body:
+        cmd = _scan_method(item, source, groups)
+        if cmd is not None:
+            commands.append(cmd)
+    if not commands:
+        return None
+    commands.sort(key=lambda c: (c["parent"] or "", c["name"]))
+    return {
+        "cog": class_node.name,
+        "file": rel_path,
+        "subsystem": _cog_to_subsystem(class_node.name),
+        "commands": commands,
+    }
+
+
+def scan_commands(repo_root: Path = REPO_ROOT) -> list[dict]:
+    """Return one record per cog (with commands) found under ``disbot/cogs``."""
+    cogs_dir = repo_root / "disbot" / "cogs"
+    out: list[dict] = []
+    for path in sorted(cogs_dir.rglob("*.py")):
+        try:
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source)
+        except (OSError, SyntaxError):
+            continue
+        rel = str(path.relative_to(repo_root))
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef):
+                cog = _scan_class(node, source, rel)
+                if cog is not None:
+                    out.append(cog)
+    out.sort(key=lambda c: c["cog"])
+    return out
+
+
+def summarise(cogs: list[dict]) -> dict:
+    """Aggregate counts across all scanned cogs/commands."""
+    cmds = [c for cog in cogs for c in cog["commands"]]
+    by_type: dict[str, int] = {}
+    for c in cmds:
+        by_type[c["type"]] = by_type.get(c["type"], 0) + 1
+    return {
+        "cogs": len(cogs),
+        "commands": len(cmds),
+        "by_type": by_type,
+        "button_backed": sum(1 for c in cmds if c["button_backed"]),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Scan the cog command surface.")
+    parser.add_argument("--summary", action="store_true", help="print counts only")
+    args = parser.parse_args(argv)
+    cogs = scan_commands()
+    if args.summary:
+        print(json.dumps(summarise(cogs), indent=2))
+    else:
+        print(json.dumps({"summary": summarise(cogs), "cogs": cogs}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/dashboard/test_app.py
+++ b/tests/unit/dashboard/test_app.py
@@ -33,7 +33,7 @@ def client():
 
 
 @pytest.mark.parametrize(
-    "path", ["/", "/functions", "/ideas", "/bugs", "/updates", "/env"]
+    "path", ["/", "/functions", "/commands", "/ideas", "/bugs", "/updates", "/env"]
 )
 def test_pages_render(client, path):
     resp = client.get(path)

--- a/tests/unit/scripts/test_export_dashboard_data.py
+++ b/tests/unit/scripts/test_export_dashboard_data.py
@@ -121,3 +121,16 @@ def test_build_data_includes_env_usage_section(mod):
     # The section is the scanner's shape (names + locations only, no values).
     for record in env_usage:
         assert set(record) == {"name", "required", "usage_count", "layers", "usages"}
+
+
+def test_build_data_includes_cogs_section(mod):
+    data = mod.build_data()
+    cogs = data["cogs"]
+    assert data["meta"]["counts"]["cogs"] == len(cogs)
+    assert data["meta"]["counts"]["commands"] == sum(len(c["commands"]) for c in cogs)
+    assert len(cogs) >= 20
+    assert "EconomyCog" in {c["cog"] for c in cogs}
+    for cog in cogs:
+        for cmd in cog["commands"]:
+            assert set(cmd) >= {"name", "type", "button_backed", "aliases"}
+            assert cmd["type"] in {"prefix", "slash", "both"}

--- a/tests/unit/scripts/test_scan_commands.py
+++ b/tests/unit/scripts/test_scan_commands.py
@@ -1,0 +1,110 @@
+"""Tests for ``scripts/scan_commands.py`` — the cog command-surface scanner.
+
+Loaded via ``importlib`` (the repo convention for ``scripts/`` modules). Pure
+stdlib, so it runs in CI with no extra dependencies.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "scan_commands.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("scan_commands_ut", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+SAMPLE_COG = '''
+from discord import app_commands
+from discord.ext import commands
+
+
+class SampleCog(commands.Cog):
+    @commands.command(name="ping", aliases=["p"])
+    async def ping(self, ctx):
+        """Ping the bot."""
+        await ctx.send("pong")
+
+    @app_commands.command(name="slashping")
+    async def slashping(self, interaction):
+        """Slash ping."""
+
+    @commands.command(name="panelcmd", extras={"classification": "panel_action"})
+    async def panelcmd(self, ctx):
+        """Open via button."""
+
+    @commands.command(name="opensview")
+    async def opensview(self, ctx):
+        view = SomeView()
+        await ctx.send(view=view)
+
+    @commands.group(name="grp")
+    async def grp(self, ctx):
+        """A group."""
+
+    @grp.command(name="sub")
+    async def grp_sub(self, ctx):
+        """A subcommand."""
+'''
+
+
+def _write_sample(tmp_path: Path) -> Path:
+    cogs_dir = tmp_path / "disbot" / "cogs"
+    cogs_dir.mkdir(parents=True)
+    (cogs_dir / "sample_cog.py").write_text(SAMPLE_COG, encoding="utf-8")
+    return tmp_path
+
+
+def test_scan_commands_types_aliases_and_buttons(mod, tmp_path):
+    cogs = mod.scan_commands(_write_sample(tmp_path))
+    assert len(cogs) == 1
+    cog = cogs[0]
+    assert cog["cog"] == "SampleCog"
+    assert cog["subsystem"] == "sample"
+    by_name = {c["name"]: c for c in cog["commands"]}
+
+    assert by_name["ping"]["type"] == "prefix"
+    assert by_name["ping"]["aliases"] == ["p"]
+    assert by_name["slashping"]["type"] == "slash"
+    # panel_action classification -> button-backed
+    assert by_name["panelcmd"]["classification"] == "panel_action"
+    assert by_name["panelcmd"]["button_backed"] is True
+    # opening a view is also button-backed (heuristic)
+    assert by_name["opensview"]["button_backed"] is True
+    # a plain prefix command is not button-backed
+    assert by_name["ping"]["button_backed"] is False
+    # group subcommand is attributed to its parent
+    assert by_name["sub"]["parent"] == "grp"
+
+
+def test_scan_commands_real_repo(mod):
+    cogs = mod.scan_commands()
+    assert len(cogs) >= 20
+    names = {c["cog"] for c in cogs}
+    assert "EconomyCog" in names
+    total = sum(len(c["commands"]) for c in cogs)
+    assert total >= 100
+    for cog in cogs:
+        for cmd in cog["commands"]:
+            assert cmd["type"] in {"prefix", "slash", "both"}
+            assert isinstance(cmd["button_backed"], bool)
+
+
+def test_summarise_shape(mod):
+    summary = mod.summarise(mod.scan_commands())
+    assert summary["cogs"] >= 20
+    assert summary["commands"] >= 100
+    assert set(summary["by_type"]) <= {"prefix", "slash", "both"}
+    assert summary["button_backed"] >= 0


### PR DESCRIPTION
## Why

Owner request (2026-06-16, after the dashboard went live): a **second layer** to *"browse all the
different cogs and all the commands they have, with a clean separation of the commands that have a
button and those that are only prefix or slash based … show if it's slash command or prefix … if you
have any other ideas implement at the same time."*

## What

- **`scripts/scan_commands.py`** (stdlib, AST) — scans `disbot/cogs/**` for every cog + command:
  invocation **type** (prefix / slash / both, from the decorator), aliases, brief, group subcommands,
  and **button-backed** — the project's own `extras={"classification": "panel_action"}` marker (per
  `core/runtime/command_surface_ledger.py`) OR a body that opens a view
  (`panel_manager`/`send_panel`/`*View(`/`view=`). Live: **41 cogs · 300 commands · 275 prefix / 25
  slash / 108 button-backed**.
- **`/commands` page** (`dashboard/app.py` + `templates/commands.html` + nav + home card) — cogs
  grouped (subsystem emoji/name cross-linked from the registry), each command badged **prefix/slash**
  and **🔘 button**, plus classification + aliases + brief.
- **Other ideas added:** stats header, a live **search** box, and **filter chips**
  (All / Prefix / Slash / 🔘 Button) — tiny inline JS, no build step.
- **Exporter** gains a `cogs` section + counts (same pure-stdlib importlib seam as the env scanner).
- **Tests:** `test_scan_commands.py` (types · aliases · panel_action · opens-view · subcommands · real
  repo), `/commands` in the app smoke, and a `cogs`-section exporter test.

## Safety

`dashboard/` still never imports `disbot/`; the scanner is a `scripts/` AST seam (no bot runtime, no
new bot dependency). `check_quality.py --full` green (**10151 passed, 37 skipped**). Purely additive;
the dashboard service tracks `main` and auto-redeploys on merge.

## Status

Born-red (Q-0133): `.sessions/` card is `in-progress` until flipped to `complete` as the final step.

https://claude.ai/code/session_012maBH3m51U7uJKP4zGUMgc

---
_Generated by [Claude Code](https://claude.ai/code/session_012maBH3m51U7uJKP4zGUMgc)_