### PR TITLE
fix(dashboard,bot): reconcile command counts (bot status embed vs website /commands)

### DIFF
--- a/.sessions/2026-06-16-command-count-reconcile.md
+++ b/.sessions/2026-06-16-command-count-reconcile.md
@@ -1,0 +1,65 @@
+# Session — Reconcile command counts (website breakdown + bot status embed)
+
+> **Status:** `in-progress`
+
+## Origin
+
+Owner (2026-06-16): a screenshot showed the live bot reporting **"Commands 183 / Loaded cogs 43"**
+while the website `/commands` showed **"300 commands / 41 cogs"** — *"any idea why the bot and the
+website both lost a different number of commands … Yes you can do both [fixes], it currently says 275
+prefix and 25 slash on the website."*
+
+## Diagnosis (root cause)
+
+Neither lost commands — they counted **different surfaces**:
+
+- Bot embed (`services/webhook_reporter.py`) used `len(bot.commands)` = **top-level prefix only**
+  (183 = 182 in cogs + 1 in `bot1.py`). It omits group **subcommands** and **slash** commands (those
+  live in `bot.tree`).
+- Website AST scan counted **all** command methods: 182 top-level prefix + 93 subcommands + 25 slash =
+  300.
+- Cogs: 43 (bot `len(bot.cogs)`, incl. listener/task cogs) vs 41 (website classes-with-commands, which
+  also wrongly listed the `PlatformCommandsMixin` mixin as a cog).
+
+## What shipped (both fixes, as asked)
+
+1. **Website** (`scripts/scan_commands.py` + `/commands`): the stats now break commands into
+   **top-level prefix (183) · subcommands (93) · slash (25)**, with a note that the bot's status counts
+   only the 183 top-level (`len(bot.commands)`). Added `is_cog` detection so mixins/modules no longer
+   inflate the cog count (now **40 real cogs**), and the scanner now also picks up `bot1.py`'s one
+   module-level command — so **top-level prefix = 183 exactly matches the bot.** Mixin/module rows are
+   tagged in the UI.
+2. **Bot** (`services/webhook_reporter.py`): the "Bot Online" embed's **Commands** field now reports the
+   true total via `bot.walk_commands()` + `bot.tree.walk_commands()` — e.g. `301 (276 prefix · 25
+   slash)` — instead of the misleading top-level-only `len(bot.commands)`. Best-effort / never-raises
+   (the `getattr` pattern already used in `command_descriptions.py`).
+
+## Verification
+
+- `check_quality.py --full` → **green (10153 passed, 37 skipped)**; ruff/black/isort/mypy clean.
+- `check_architecture --mode strict` → exit 0; `check_docs --strict` → green.
+- scanner summary: cogs 40 · commands 301 · top-level prefix **183** · subcommands 93 · slash 25.
+- `/commands` renders the reconciled breakdown (TestClient → 200).
+
+## 💡 Session idea (Q-0089)
+
+**One source for "commands by surface."** The bot embed and the website now both compute
+prefix/subcommands/slash, but independently. Exposing a single helper (or the existing
+`command_surface_ledger`) as the one "count the command surface" source would stop the bot and
+dashboard drifting apart again — the concrete next step of the earlier "reconcile AST scan vs runtime
+ledger" idea.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous: the **`/commands` explorer (#972)**. Did well: clean AST scanner, good page, full tests. What
+this session exposed: it surfaced a single "300 commands / 41 cogs" without explaining it counts a
+*different surface* than the bot's status — which immediately confused the owner. Lesson (now applied):
+when a dashboard number mirrors one the user already sees elsewhere, show the breakdown and **name the
+metric**, so the two reconcile at a glance instead of looking contradictory.
+
+## Documentation audit (Q-0104)
+
+- The `/commands` page now self-documents the count methodology in its intro. `check_docs --strict`
+  green. A status-embed under-report (not a user/runtime bug) → no bug-book entry; root cause + fix
+  live here. `current-state.md` In-flight names no open PRs (convention); the merge-time reconciliation
+  (Q-0124) folds this PR into the ledger.

--- a/.sessions/2026-06-16-command-count-reconcile.md
+++ b/.sessions/2026-06-16-command-count-reconcile.md
@@ -1,6 +1,6 @@
 # Session — Reconcile command counts (website breakdown + bot status embed)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Origin
 

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -122,10 +122,14 @@ def commands(request: Request):
     data = load_data()
     cmds = [c for cog in data.get("cogs", []) for c in cog["commands"]]
     stats = {
-        "prefix": sum(1 for c in cmds if c["type"] == "prefix"),
-        "slash": sum(1 for c in cmds if c["type"] == "slash"),
-        "both": sum(1 for c in cmds if c["type"] == "both"),
+        "total": len(cmds),
+        "top_prefix": sum(
+            1 for c in cmds if c["type"] in ("prefix", "both") and not c["parent"]
+        ),
+        "subcommands": sum(1 for c in cmds if c["parent"]),
+        "slash": sum(1 for c in cmds if c["type"] == "slash" and not c["parent"]),
         "button": sum(1 for c in cmds if c["button_backed"]),
+        "cogs": sum(1 for cog in data.get("cogs", []) if cog.get("is_cog")),
     }
     sysmap = {c["key"]: c for c in data.get("catalogue", [])}
     return templates.TemplateResponse(

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-06-16T17:17:14Z",
+    "generated_at": "2026-06-16T17:47:38Z",
     "counts": {
       "functions": 33,
       "ideas": 72,
       "bugs": 15,
       "updates": 60,
       "env_vars": 34,
-      "cogs": 41,
-      "commands": 300
+      "cogs": 40,
+      "commands": 301
     }
   },
   "catalogue": [
@@ -1605,7 +1605,7 @@
       "file": "2026-06-16-dashboard-commands-explorer.md",
       "date": "2026-06-16",
       "title": "Session — Dashboard cog & command explorer (`/commands`)",
-      "status": "in-progress"
+      "status": "complete"
     },
     {
       "file": "2026-06-16-count-citation-guard.md",
@@ -2430,9 +2430,29 @@
   ],
   "cogs": [
     {
+      "cog": "(bot1.py)",
+      "file": "disbot/bot1.py",
+      "subsystem": "",
+      "is_cog": false,
+      "commands": [
+        {
+          "name": "force",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Overrides channel restrictions and runs a command (admins only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
       "cog": "AICog",
       "file": "disbot/cogs/ai_cog.py",
       "subsystem": "a_i",
+      "is_cog": true,
       "commands": [
         {
           "name": "ai",
@@ -2583,6 +2603,7 @@
       "cog": "AdminCog",
       "file": "disbot/cogs/admin_cog.py",
       "subsystem": "admin",
+      "is_cog": true,
       "commands": [
         {
           "name": "admin",
@@ -2719,6 +2740,7 @@
       "cog": "Automod",
       "file": "disbot/cogs/automod_cog.py",
       "subsystem": "automod",
+      "is_cog": true,
       "commands": [
         {
           "name": "automod",
@@ -2737,6 +2759,7 @@
       "cog": "BTD6Cog",
       "file": "disbot/cogs/btd6_cog.py",
       "subsystem": "b_t_d6",
+      "is_cog": true,
       "commands": [
         {
           "name": "btd6",
@@ -2832,6 +2855,7 @@
       "cog": "BTD6EventsCog",
       "file": "disbot/cogs/btd6_events_cog.py",
       "subsystem": "b_t_d6_events",
+      "is_cog": true,
       "commands": [
         {
           "name": "btd6events",
@@ -2938,6 +2962,7 @@
       "cog": "BTD6OpsCog",
       "file": "disbot/cogs/btd6_ops_cog.py",
       "subsystem": "b_t_d6_ops",
+      "is_cog": true,
       "commands": [
         {
           "name": "btd6ops",
@@ -3022,6 +3047,7 @@
       "cog": "BTD6ReferenceCog",
       "file": "disbot/cogs/btd6_reference_cog.py",
       "subsystem": "b_t_d6_reference",
+      "is_cog": true,
       "commands": [
         {
           "name": "btd6ref",
@@ -3095,6 +3121,7 @@
       "cog": "BTD6StrategyCog",
       "file": "disbot/cogs/btd6_strategy_cog.py",
       "subsystem": "b_t_d6_strategy",
+      "is_cog": true,
       "commands": [
         {
           "name": "btd6strat",
@@ -3201,6 +3228,7 @@
       "cog": "BlackjackCog",
       "file": "disbot/cogs/blackjack_cog.py",
       "subsystem": "blackjack",
+      "is_cog": true,
       "commands": [
         {
           "name": "bjstart",
@@ -3256,6 +3284,7 @@
       "cog": "ChainCog",
       "file": "disbot/cogs/chain_cog.py",
       "subsystem": "chain",
+      "is_cog": true,
       "commands": [
         {
           "name": "chain",
@@ -3340,6 +3369,7 @@
       "cog": "ChannelCog",
       "file": "disbot/cogs/channel_cog.py",
       "subsystem": "channel",
+      "is_cog": true,
       "commands": [
         {
           "name": "bulkcreate",
@@ -3512,6 +3542,7 @@
       "cog": "Cleanup",
       "file": "disbot/cogs/cleanup_cog.py",
       "subsystem": "cleanup",
+      "is_cog": true,
       "commands": [
         {
           "name": "cleanup",
@@ -3596,6 +3627,7 @@
       "cog": "CommunityCog",
       "file": "disbot/cogs/community_cog.py",
       "subsystem": "community",
+      "is_cog": true,
       "commands": [
         {
           "name": "community",
@@ -3625,6 +3657,7 @@
       "cog": "CommunitySpotlightCog",
       "file": "disbot/cogs/community_spotlight_cog.py",
       "subsystem": "community_spotlight",
+      "is_cog": true,
       "commands": [
         {
           "name": "spotlight",
@@ -3645,6 +3678,7 @@
       "cog": "CountersCog",
       "file": "disbot/cogs/counters_cog.py",
       "subsystem": "counters",
+      "is_cog": true,
       "commands": [
         {
           "name": "counters",
@@ -3663,6 +3697,7 @@
       "cog": "CountingCog",
       "file": "disbot/cogs/counting_cog.py",
       "subsystem": "counting",
+      "is_cog": true,
       "commands": [
         {
           "name": "count_info",
@@ -3787,6 +3822,7 @@
       "cog": "Deathmatch",
       "file": "disbot/cogs/deathmatch_cog.py",
       "subsystem": "deathmatch",
+      "is_cog": true,
       "commands": [
         {
           "name": "dm_challenge",
@@ -3822,6 +3858,7 @@
       "cog": "DiagnosticCog",
       "file": "disbot/cogs/diagnostic_cog.py",
       "subsystem": "diagnostic",
+      "is_cog": true,
       "commands": [
         {
           "name": "check_database",
@@ -3996,6 +4033,7 @@
       "cog": "EconomyCog",
       "file": "disbot/cogs/economy_cog.py",
       "subsystem": "economy",
+      "is_cog": true,
       "commands": [
         {
           "name": "balance",
@@ -4096,6 +4134,7 @@
       "cog": "FourTwentyCog",
       "file": "disbot/cogs/four_twenty_cog.py",
       "subsystem": "four_twenty",
+      "is_cog": true,
       "commands": [
         {
           "name": "420",
@@ -4117,6 +4156,7 @@
       "cog": "GamesCog",
       "file": "disbot/cogs/games_cog.py",
       "subsystem": "games",
+      "is_cog": true,
       "commands": [
         {
           "name": "games",
@@ -4146,6 +4186,7 @@
       "cog": "General",
       "file": "disbot/cogs/general_cog.py",
       "subsystem": "general",
+      "is_cog": true,
       "commands": [
         {
           "name": "eightball",
@@ -4245,6 +4286,7 @@
       "cog": "HelpCog",
       "file": "disbot/cogs/help_cog.py",
       "subsystem": "help",
+      "is_cog": true,
       "commands": [
         {
           "name": "help",
@@ -4276,6 +4318,7 @@
       "cog": "HermesCog",
       "file": "disbot/cogs/hermes_cog.py",
       "subsystem": "hermes",
+      "is_cog": true,
       "commands": [
         {
           "name": "bugreport",
@@ -4305,6 +4348,7 @@
       "cog": "InventoryCog",
       "file": "disbot/cogs/inventory_cog.py",
       "subsystem": "inventory",
+      "is_cog": true,
       "commands": [
         {
           "name": "inventory",
@@ -4325,6 +4369,7 @@
       "cog": "LeaderboardCog",
       "file": "disbot/cogs/leaderboard_cog.py",
       "subsystem": "leaderboard",
+      "is_cog": true,
       "commands": [
         {
           "name": "leaderboard",
@@ -4353,6 +4398,7 @@
       "cog": "LoggingCog",
       "file": "disbot/cogs/logging_cog.py",
       "subsystem": "logging",
+      "is_cog": true,
       "commands": [
         {
           "name": "logging",
@@ -4426,6 +4472,7 @@
       "cog": "MiningCog",
       "file": "disbot/cogs/mining_cog.py",
       "subsystem": "mining",
+      "is_cog": true,
       "commands": [
         {
           "name": "ascend",
@@ -4825,6 +4872,7 @@
       "cog": "ModerationCog",
       "file": "disbot/cogs/moderation_cog.py",
       "subsystem": "moderation",
+      "is_cog": true,
       "commands": [
         {
           "name": "ban",
@@ -4931,6 +4979,7 @@
       "cog": "ParagonCog",
       "file": "disbot/cogs/paragon_cog.py",
       "subsystem": "paragon",
+      "is_cog": true,
       "commands": [
         {
           "name": "paragon",
@@ -4949,6 +4998,7 @@
       "cog": "PlatformCommandsMixin",
       "file": "disbot/cogs/diagnostic/platform_group.py",
       "subsystem": "platform_commands_mixin",
+      "is_cog": false,
       "commands": [
         {
           "name": "platform",
@@ -5388,6 +5438,7 @@
       "cog": "ProofChannelCog",
       "file": "disbot/cogs/proof_channel_cog.py",
       "subsystem": "proof_channel",
+      "is_cog": true,
       "commands": [
         {
           "name": "+prize",
@@ -5450,6 +5501,7 @@
       "cog": "RockPaperScissorsCog",
       "file": "disbot/cogs/rps_tournament_cog.py",
       "subsystem": "rock_paper_scissors",
+      "is_cog": true,
       "commands": [
         {
           "name": "rps",
@@ -5538,6 +5590,7 @@
       "cog": "RoleCog",
       "file": "disbot/cogs/role_cog.py",
       "subsystem": "role",
+      "is_cog": true,
       "commands": [
         {
           "name": "assignroles",
@@ -5701,6 +5754,7 @@
       "cog": "ServerManagementCog",
       "file": "disbot/cogs/server_management_cog.py",
       "subsystem": "server_management",
+      "is_cog": true,
       "commands": [
         {
           "name": "server-management",
@@ -5733,6 +5787,7 @@
       "cog": "SettingsCog",
       "file": "disbot/cogs/settings_cog.py",
       "subsystem": "settings",
+      "is_cog": true,
       "commands": [
         {
           "name": "settings",
@@ -5773,6 +5828,7 @@
       "cog": "SetupCog",
       "file": "disbot/cogs/setup_cog.py",
       "subsystem": "setup",
+      "is_cog": true,
       "commands": [
         {
           "name": "setup",
@@ -5890,6 +5946,7 @@
       "cog": "UtilityCog",
       "file": "disbot/cogs/utility_cog.py",
       "subsystem": "utility",
+      "is_cog": true,
       "commands": [
         {
           "name": "avatar",
@@ -6031,6 +6088,7 @@
       "cog": "UxLabCog",
       "file": "disbot/cogs/ux_lab_cog.py",
       "subsystem": "ux_lab",
+      "is_cog": true,
       "commands": [
         {
           "name": "uxlab",
@@ -6062,6 +6120,7 @@
       "cog": "WelcomeCog",
       "file": "disbot/cogs/welcome_cog.py",
       "subsystem": "welcome",
+      "is_cog": true,
       "commands": [
         {
           "name": "welcome",
@@ -6080,6 +6139,7 @@
       "cog": "XpCog",
       "file": "disbot/cogs/xp_cog.py",
       "subsystem": "xp",
+      "is_cog": true,
       "commands": [
         {
           "name": "givexp",

--- a/dashboard/templates/commands.html
+++ b/dashboard/templates/commands.html
@@ -3,18 +3,23 @@
 {% block content %}
 <h1 class="text-2xl font-bold mb-1">Cogs &amp; commands</h1>
 <p class="text-slate-400 mb-5 text-sm">
-  {{ data.meta.counts.get("commands", 0) }} commands across {{ data.meta.counts.get("cogs", 0) }} cogs,
-  scanned straight from the cog source. A <span class="text-sky-300">🔘 button</span> tag means the
-  command is a panel button's action or opens a view; everything else is reachable only by typing it.
+  {{ stats.total }} commands across {{ stats.cogs }} cogs, scanned from the cog source. Of these,
+  <span class="text-slate-200">{{ stats.top_prefix }}</span> are top-level prefix commands — the number
+  the bot's status embed reports (<code>len(bot.commands)</code>); the other {{ stats.subcommands }}
+  subcommands and {{ stats.slash }} slash commands live in <code>bot.tree</code> and aren't in that
+  count. A <span class="text-sky-300">🔘 button</span> tag means the command is a panel button's action
+  or opens a view. (The bot's "Loaded cogs" count is higher — it also counts listener/task cogs that
+  declare no commands.)
 </p>
 
-<section class="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-6">
+<section class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-6">
   {% set cards = [
-      ('commands', 'Commands', data.meta.counts.get('commands', 0)),
-      ('prefix', 'Prefix !', stats.prefix),
+      ('total', 'Commands', stats.total),
+      ('top_prefix', 'Prefix (top-level)', stats.top_prefix),
+      ('subcommands', 'Subcommands', stats.subcommands),
       ('slash', 'Slash /', stats.slash),
       ('button', '🔘 Button', stats.button),
-      ('cogs', 'Cogs', data.meta.counts.get('cogs', 0)),
+      ('cogs', 'Cogs', stats.cogs),
   ] %}
   {% for key, label, value in cards %}
     <div class="rounded-xl border border-slate-800 bg-slate-900/50 p-4">
@@ -43,6 +48,7 @@
       <span class="text-xl">{{ sys.emoji if sys and sys.emoji else "🧩" }}</span>
       <span class="font-semibold">{{ sys.display_name if sys and sys.display_name else cog.cog }}</span>
       <span class="text-xs text-slate-500">{{ cog.cog }}</span>
+      {% if not cog.is_cog %}<span class="text-[10px] rounded px-1.5 py-0.5 bg-slate-800 text-slate-500">{{ 'module' if cog.cog.startswith('(') else 'mixin' }}</span>{% endif %}
       <span class="ml-auto text-[11px] text-slate-500">{{ cog.commands|length }} cmd{{ '' if cog.commands|length == 1 else 's' }}</span>
     </div>
     <ul class="divide-y divide-slate-800/70">

--- a/disbot/services/webhook_reporter.py
+++ b/disbot/services/webhook_reporter.py
@@ -27,6 +27,33 @@ if TYPE_CHECKING:
 logger = logging.getLogger("bot.webhook")
 
 
+def _command_counts(bot: object) -> tuple[int, int]:
+    """Return (prefix incl. subcommands, slash incl. subcommands), best-effort.
+
+    ``len(bot.commands)`` is only *top-level* prefix commands — it omits group
+    subcommands and every slash command (those live in ``bot.tree``). Walking both
+    surfaces makes the status embed report the true total. Never raises: a status
+    embed must not break startup reporting.
+    """
+    walk = getattr(bot, "walk_commands", None)
+    try:
+        prefix = (
+            len(list(walk()))
+            if callable(walk)
+            else len(getattr(bot, "commands", ()) or ())
+        )
+    except Exception:
+        prefix = 0
+    slash = 0
+    tree_walk = getattr(getattr(bot, "tree", None), "walk_commands", None)
+    if callable(tree_walk):
+        try:
+            slash = len(list(tree_walk()))
+        except Exception:
+            slash = 0
+    return prefix, slash
+
+
 def _redact_embed(embed: discord.Embed) -> dict[str, int]:
     """Scrub sensitive substrings from text fields of ``embed`` in place.
 
@@ -116,7 +143,12 @@ class WebhookReporter:
         )
         embed.add_field(name="Prefix", value=f"`{bot.command_prefix}`", inline=True)
         embed.add_field(name="Servers", value=str(len(bot.guilds)), inline=True)
-        embed.add_field(name="Commands", value=str(len(bot.commands)), inline=True)
+        prefix_n, slash_n = _command_counts(bot)
+        embed.add_field(
+            name="Commands",
+            value=f"{prefix_n + slash_n} ({prefix_n} prefix · {slash_n} slash)",
+            inline=True,
+        )
         embed.add_field(name="Loaded cogs", value=str(len(bot.cogs)), inline=True)
         embed.set_footer(text=f"Logged in as {bot.user}")
         await self._send(embed, username="Bot Status")

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,7 +25,7 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/jolly-cannon-gn9ddg` · dashboard cog & command explorer (`/commands`) — `scripts/scan_commands.py` AST scan: prefix/slash + button-backed · 2026-06-16
+- `claude/jolly-cannon-gn9ddg` · reconcile command counts — website prefix/sub/slash breakdown + `is_cog` + bot1.py scan; bot status embed full count (`webhook_reporter`) · 2026-06-16
 - `claude/upbeat-einstein-7rz9z0` · act on the 2026-06-16 autonomous-run review + owner answers —
   run-report footer · ledger guard-exemption + drift line · bug-fix-guard convention · auto-deploy
   misinformation fix · Q-0147 DM gate · Q-0085/0120/0121/0127 records · ledger tidy · 2026-06-16

--- a/scripts/export_dashboard_data.py
+++ b/scripts/export_dashboard_data.py
@@ -311,7 +311,7 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
                 "bugs": len(bugs),
                 "updates": len(updates),
                 "env_vars": len(env_usage),
-                "cogs": len(cogs),
+                "cogs": sum(1 for c in cogs if c.get("is_cog")),
                 "commands": sum(len(c["commands"]) for c in cogs),
             },
         },

--- a/scripts/scan_commands.py
+++ b/scripts/scan_commands.py
@@ -48,6 +48,11 @@ _COMMAND_DECORATORS: dict[str, tuple[str, bool]] = {
     "commands.hybrid_group": ("both", True),
     "hybrid_group": ("both", True),
     "app_commands.group": ("slash", True),
+    # module-level registrations (e.g. bot1.py's @bot.command / @bot.tree.command)
+    "bot.command": ("prefix", False),
+    "bot.group": ("prefix", True),
+    "bot.tree.command": ("slash", False),
+    "tree.command": ("slash", False),
 }
 _SUBCOMMAND_LEAVES = {"command", "group", "subcommand"}
 _PANEL_TOKENS = ("panel_manager", "send_panel", "View(", "view=")
@@ -63,6 +68,24 @@ def _cog_to_subsystem(class_name: str) -> str:
     """Normalise a cog class name to its snake_case subsystem key."""
     base = class_name[:-3] if class_name.endswith("Cog") else class_name
     return _CAMEL_RE.sub("_", base).lower()
+
+
+def _is_cog(class_node: ast.ClassDef) -> bool:
+    """True if the class subclasses ``commands.Cog`` (a real, loadable cog).
+
+    A command-bearing *mixin* (e.g. ``PlatformCommandsMixin``) returns False — its
+    commands are real (inherited by a cog) but it is not itself a loaded cog, so it
+    must not inflate the cog count.
+    """
+    for base in class_node.bases:
+        node: ast.expr = base
+        while isinstance(node, ast.Attribute):
+            if node.attr.endswith("Cog"):
+                return True
+            node = node.value
+        if isinstance(node, ast.Name) and node.id.endswith("Cog"):
+            return True
+    return False
 
 
 def _decorator_path(dec: ast.expr) -> str:
@@ -190,15 +213,39 @@ def _scan_class(class_node: ast.ClassDef, source: str, rel_path: str) -> dict | 
         "cog": class_node.name,
         "file": rel_path,
         "subsystem": _cog_to_subsystem(class_node.name),
+        "is_cog": _is_cog(class_node),
+        "commands": commands,
+    }
+
+
+def _scan_module(tree: ast.Module, source: str, rel_path: str) -> dict | None:
+    """Scan module-level functions (e.g. ``bot1.py``'s ``@bot.command``)."""
+    commands: list[dict] = []
+    for item in tree.body:
+        cmd = _scan_method(item, source, {})
+        if cmd is not None:
+            commands.append(cmd)
+    if not commands:
+        return None
+    commands.sort(key=lambda c: (c["parent"] or "", c["name"]))
+    return {
+        "cog": f"({Path(rel_path).name})",
+        "file": rel_path,
+        "subsystem": "",
+        "is_cog": False,
         "commands": commands,
     }
 
 
 def scan_commands(repo_root: Path = REPO_ROOT) -> list[dict]:
-    """Return one record per cog (with commands) found under ``disbot/cogs``."""
+    """Return one record per cog/module that declares commands."""
     cogs_dir = repo_root / "disbot" / "cogs"
+    files = sorted(cogs_dir.rglob("*.py"))
+    bot1 = repo_root / "disbot" / "bot1.py"
+    if bot1.exists():
+        files.append(bot1)
     out: list[dict] = []
-    for path in sorted(cogs_dir.rglob("*.py")):
+    for path in files:
         try:
             source = path.read_text(encoding="utf-8")
             tree = ast.parse(source)
@@ -210,6 +257,9 @@ def scan_commands(repo_root: Path = REPO_ROOT) -> list[dict]:
                 cog = _scan_class(node, source, rel)
                 if cog is not None:
                     out.append(cog)
+        module = _scan_module(tree, source, rel)
+        if module is not None:
+            out.append(module)
     out.sort(key=lambda c: c["cog"])
     return out
 
@@ -221,8 +271,14 @@ def summarise(cogs: list[dict]) -> dict:
     for c in cmds:
         by_type[c["type"]] = by_type.get(c["type"], 0) + 1
     return {
-        "cogs": len(cogs),
+        "cogs": sum(1 for cog in cogs if cog.get("is_cog")),
+        "command_classes": len(cogs),
         "commands": len(cmds),
+        "top_level_prefix": sum(
+            1 for c in cmds if c["type"] in ("prefix", "both") and not c["parent"]
+        ),
+        "subcommands": sum(1 for c in cmds if c["parent"]),
+        "slash": sum(1 for c in cmds if c["type"] == "slash" and not c["parent"]),
         "by_type": by_type,
         "button_backed": sum(1 for c in cmds if c["button_backed"]),
     }

--- a/tests/unit/scripts/test_export_dashboard_data.py
+++ b/tests/unit/scripts/test_export_dashboard_data.py
@@ -126,7 +126,7 @@ def test_build_data_includes_env_usage_section(mod):
 def test_build_data_includes_cogs_section(mod):
     data = mod.build_data()
     cogs = data["cogs"]
-    assert data["meta"]["counts"]["cogs"] == len(cogs)
+    assert data["meta"]["counts"]["cogs"] == sum(1 for c in cogs if c.get("is_cog"))
     assert data["meta"]["counts"]["commands"] == sum(len(c["commands"]) for c in cogs)
     assert len(cogs) >= 20
     assert "EconomyCog" in {c["cog"] for c in cogs}

--- a/tests/unit/scripts/test_scan_commands.py
+++ b/tests/unit/scripts/test_scan_commands.py
@@ -57,43 +57,76 @@ class SampleCog(commands.Cog):
     @grp.command(name="sub")
     async def grp_sub(self, ctx):
         """A subcommand."""
+
+
+class SampleMixin:
+    """A command-bearing mixin — not a real Cog."""
+
+    @commands.command(name="mixincmd")
+    async def mixincmd(self, ctx):
+        """A command defined on a mixin."""
+'''
+
+SAMPLE_BOT1 = '''
+from discord.ext import commands
+
+
+@bot.command(name="rootcmd")
+async def rootcmd(ctx):
+    """A top-level command defined outside any cog."""
 '''
 
 
-def _write_sample(tmp_path: Path) -> Path:
+def _write_repo(tmp_path: Path) -> Path:
     cogs_dir = tmp_path / "disbot" / "cogs"
     cogs_dir.mkdir(parents=True)
     (cogs_dir / "sample_cog.py").write_text(SAMPLE_COG, encoding="utf-8")
+    (tmp_path / "disbot" / "bot1.py").write_text(SAMPLE_BOT1, encoding="utf-8")
     return tmp_path
 
 
 def test_scan_commands_types_aliases_and_buttons(mod, tmp_path):
-    cogs = mod.scan_commands(_write_sample(tmp_path))
-    assert len(cogs) == 1
-    cog = cogs[0]
-    assert cog["cog"] == "SampleCog"
-    assert cog["subsystem"] == "sample"
-    by_name = {c["name"]: c for c in cog["commands"]}
+    cogs = mod.scan_commands(_write_repo(tmp_path))
+    by_cog = {c["cog"]: c for c in cogs}
 
+    assert "SampleCog" in by_cog
+    sample = by_cog["SampleCog"]
+    assert sample["is_cog"] is True
+    assert sample["subsystem"] == "sample"
+    by_name = {c["name"]: c for c in sample["commands"]}
     assert by_name["ping"]["type"] == "prefix"
     assert by_name["ping"]["aliases"] == ["p"]
+    assert by_name["ping"]["button_backed"] is False
     assert by_name["slashping"]["type"] == "slash"
-    # panel_action classification -> button-backed
     assert by_name["panelcmd"]["classification"] == "panel_action"
     assert by_name["panelcmd"]["button_backed"] is True
-    # opening a view is also button-backed (heuristic)
     assert by_name["opensview"]["button_backed"] is True
-    # a plain prefix command is not button-backed
-    assert by_name["ping"]["button_backed"] is False
-    # group subcommand is attributed to its parent
     assert by_name["sub"]["parent"] == "grp"
+
+
+def test_mixin_is_not_a_cog_but_keeps_its_commands(mod, tmp_path):
+    by_cog = {c["cog"]: c for c in mod.scan_commands(_write_repo(tmp_path))}
+    assert "SampleMixin" in by_cog
+    assert by_cog["SampleMixin"]["is_cog"] is False
+    # the command is still counted — it is real (inherited by a cog)
+    assert "mixincmd" in {c["name"] for c in by_cog["SampleMixin"]["commands"]}
+
+
+def test_module_level_command_from_bot1(mod, tmp_path):
+    cogs = mod.scan_commands(_write_repo(tmp_path))
+    module = next((c for c in cogs if c["cog"] == "(bot1.py)"), None)
+    assert module is not None
+    assert module["is_cog"] is False
+    cmd = module["commands"][0]
+    assert cmd["name"] == "rootcmd"
+    assert cmd["type"] == "prefix"
+    assert cmd["parent"] is None
 
 
 def test_scan_commands_real_repo(mod):
     cogs = mod.scan_commands()
     assert len(cogs) >= 20
-    names = {c["cog"] for c in cogs}
-    assert "EconomyCog" in names
+    assert "EconomyCog" in {c["cog"] for c in cogs}
     total = sum(len(c["commands"]) for c in cogs)
     assert total >= 100
     for cog in cogs:
@@ -102,9 +135,14 @@ def test_scan_commands_real_repo(mod):
             assert isinstance(cmd["button_backed"], bool)
 
 
-def test_summarise_shape(mod):
+def test_summarise_breakdown_adds_up(mod):
     summary = mod.summarise(mod.scan_commands())
-    assert summary["cogs"] >= 20
+    assert summary["cogs"] >= 20  # real cogs only (is_cog)
+    assert summary["cogs"] <= summary["command_classes"]
     assert summary["commands"] >= 100
+    # the breakdown must partition the total exactly
+    assert (
+        summary["top_level_prefix"] + summary["subcommands"] + summary["slash"]
+        == summary["commands"]
+    )
     assert set(summary["by_type"]) <= {"prefix", "slash", "both"}
-    assert summary["button_backed"] >= 0


### PR DESCRIPTION
## Why

The owner noticed the live bot reports **"Commands 183 / Loaded cogs 43"** while the website
`/commands` showed **"300 commands / 41 cogs"** and asked why they differ. Root cause: **neither lost
commands — they count different surfaces.**

- Bot embed used `len(bot.commands)` = **top-level prefix only** (183 = 182 in cogs + 1 in `bot1.py`).
  It omits group **subcommands** and **slash** commands (those live in `bot.tree`).
- Website counted **every** command method: 182 top-level prefix + 93 subcommands + 25 slash = 300.
- Cogs: 43 = `len(bot.cogs)` (incl. listener/task cogs) vs 41 (website classes-with-commands, which
  also wrongly counted the `PlatformCommandsMixin` mixin).

## What (both fixes)

**Website** (`scripts/scan_commands.py` + `/commands`):
- Stats now break commands into **top-level prefix (183) · subcommands (93) · slash (25)** with a note
  that the bot's status reports only the 183 top-level (`len(bot.commands)`).
- `is_cog` detection: mixins/modules no longer inflate the cog count (**40 real cogs**); they're tagged
  in the UI.
- The scanner now also picks up `bot1.py`'s one module-level command — so **top-level prefix = 183,
  exactly matching the bot.**

**Bot** (`services/webhook_reporter.py`):
- The "Bot Online" embed's **Commands** field now reports the true total via `bot.walk_commands()` +
  `bot.tree.walk_commands()` — e.g. `301 (276 prefix · 25 slash)` — instead of the misleading
  top-level-only `len(bot.commands)`. Best-effort / never-raises (the `getattr` pattern already used in
  `command_descriptions.py`).

## Verification

`check_quality.py --full` → **green (10153 passed, 37 skipped)**; `check_architecture --mode strict` →
0; `check_docs --strict` → green. New scanner tests cover `is_cog`, the mixin, the `bot1.py` module
command, and the breakdown adding up. Both surfaces auto-redeploy from `main` (dashboard service + bot
worker).

## Status

Born-red (Q-0133): the `.sessions/` card is `in-progress` until flipped to `complete` as the final step.

https://claude.ai/code/session_012maBH3m51U7uJKP4zGUMgc

---
_Generated by [Claude Code](https://claude.ai/code/session_012maBH3m51U7uJKP4zGUMgc)_