### PR TITLE
docs(hermes): capture TPM rate-limit finding + fix reset/compaction guidance

### DIFF
--- a/.sessions/2026-06-16-hermes-tpm-rate-limit-docs.md
+++ b/.sessions/2026-06-16-hermes-tpm-rate-limit-docs.md
@@ -1,0 +1,75 @@
+# 2026-06-16 — capture the Hermes TPM rate-limit finding (docs/script corrections)
+
+> **Status:** `complete` — docs/script-only corrections from a live debugging incident; one push.
+
+## Arc
+
+While helping the owner re-install the lean skills on the VPS, the real reason both scheduled skills
+"hit rate limits" surfaced in the gateway logs — and it's **not** what the existing docs assume.
+Captured the findings durably so the next agent/owner doesn't repeat the wrong-direction mistake.
+
+## The finding (from live `journalctl`)
+
+- Failure is **TPM — tokens *per minute*** (`Rate limit reached for gpt-5.4-mini … on tokens per min
+  (TPM): Limit 200000, Used …, Requested ~100k`), **not** the context window. The interactive session
+  had grown to **79 msgs / ~110K tokens**; the model window is 400K (fits fine), but the OpenAI org
+  TPM cap is **200K/min**, so every ~100K-token reply lets only ~2 calls/min through. A `bg-review`
+  background thread firing concurrent ~100K calls compounds it. The bot looked "down" but was
+  `active (running)` — it was starved, not crashed.
+- **No first-class CLI resets the live gateway conversation** — verified `hermes gateway --help`
+  (lifecycle only; restart KEEPS state) + `hermes sessions --help` (store mgmt; the bloated session
+  is the *newest* so `prune` won't touch it). The only clean live reset is **`/new`** in Telegram.
+- **Compaction is the primary durable fix, not a 6h hard-reset:** lower `compression.threshold`
+  (0.50 → 0.25) so the gateway keeps each call small *continuously*. This is the **opposite** of
+  `apply_context_fixes.sh` (which raises it for the doc-pruning problem) — running that for a TPM
+  limit makes it worse.
+
+## Shipped (this PR — docs/scripts only)
+
+- `docs/operations/hermes-session-reset.md` — added "⚠️ Root cause clarification (2026-06-16)": the
+  TPM-vs-window distinction, the verified no-clean-CLI-reset reality, compaction as the primary lever,
+  `/new` as the immediate unstick; corrected the "one knob" section's bogus `hermes session new`
+  candidates.
+- `scripts/hermes/apply_context_fixes.sh` — prominent "DO NOT run for a TPM rate-limit (it raises the
+  threshold = wrong direction)" warning.
+- `docs/operations/hermes-token-efficiency-investigation-2026-06-15.md` — a "2026-06-16 follow-up"
+  section separating this TPM failure from the 2026-06-15 context-window one (opposite fix direction).
+- `scripts/hermes/session_reset.sh` — header now states the no-clean-CLI-reset reality + points at
+  compaction as the preferred lever.
+
+`bash -n` on both scripts ✓, `session_reset.sh` dry-run ✓, `check_docs --strict` ✓.
+
+## Context delta
+
+- **Discovered by hand (the load-bearing lesson):** a 400K context **window** and a 200K-tokens-per
+  **minute** rate limit are different ceilings; a model that can *hold* a big conversation can still
+  be unable to *send* it under the per-minute budget. The repo's prior context docs only addressed the
+  window; this adds the TPM axis.
+- **Decision made alone:** landed the *certain* corrections now (CLI reality, wrong-direction warning,
+  TPM distinction) rather than waiting on the owner's live confirmation of the exact threshold value —
+  those facts hold regardless of how 0.25 tunes. The specific value is left as "tune + verify".
+- **Flagged for maintainer:** the exact best `compression.threshold` and whether the OpenAI TPM tier
+  needs raising are still pending the owner's live confirmation on the VPS; the bg-review concurrency
+  is an unquantified secondary load.
+
+## 📤 Run report
+
+- **Did:** captured the TPM rate-limit root cause + corrected the misleading reset/compaction docs ·
+  **Outcome:** shipped (docs/scripts only)
+- **Shipped:** this PR — session-reset runbook clarification + apply_context_fixes warning +
+  investigation-doc follow-up + session_reset header
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps (VPS, the actual fix):** `/new` in Telegram (immediate); `hermes config set
+  compression.threshold 0.25` + `sudo systemctl restart hermes-gateway` (durable); optionally raise
+  the OpenAI TPM tier / throttle `bg-review`. Do **not** run `apply_context_fixes.sh` for this.
+- **↪ Next:** owner confirms the compaction change holds; if so the skills + bot run clean.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 5 (#959, #965, #966, #968, #971; this one auto-merges on green) |
+| CI-red rounds | 0 (docs/scripts only; verified locally) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 0 this follow-up (1 already this session — verdict loop) |
+| Ideas groomed | 0 this follow-up |

--- a/docs/operations/hermes-session-reset.md
+++ b/docs/operations/hermes-session-reset.md
@@ -23,6 +23,39 @@ systemd timer (every 6h)  →  scripts/hermes/session_reset.sh  →  $HERMES_RES
 `review-merge` already run as **fresh, stateless** sessions on their own cron (a scheduled skill
 never accumulates into your chat). This runbook is only about the **interactive** thread you type in.
 
+## ⚠️ Root cause clarification (2026-06-16 live incident) — it's TPM, and compaction is the primary lever
+
+A real incident clarified what actually goes wrong and the cleanest fix — read this before wiring a timer:
+
+- **The failure is a per-minute rate limit, not a context-window overflow.** The gateway logged
+  `Rate limit reached for gpt-5.4-mini … on tokens per min (TPM): Limit 200000, Used …, Requested ~100k`
+  with `Context: 79 msgs, ~110,571 tokens`. The model's window is **400K**, so a 110K session fits
+  fine — but the OpenAI org's limit is **200,000 tokens *per minute***. Every reply re-sends the whole
+  conversation (~100K), so **2 replies/min saturate the budget** and the bot can't answer (it looks
+  "down" but is `active (running)`). The 3 automatic retries (each re-sending ~100K) guarantee it.
+- **There is no first-class CLI command to reset the live gateway conversation.** Verified against
+  `hermes gateway --help` (only `run/start/stop/restart/status/install/…` — service lifecycle, and
+  **restart does NOT clear context**) and `hermes sessions --help` (store mgmt: `list/delete/prune/
+  stats/…` — and the bloated session is the *newest*, so `prune` (old) won't touch it). **The only
+  clean live reset is `/new` in Telegram.**
+- **So compaction — not a 6h hard-reset — is the primary durable fix.** Lower the compaction
+  threshold so the gateway keeps each call small *continuously*, well under the TPM budget:
+  ```bash
+  hermes config                                  # confirm current compression.threshold (≈ 0.50)
+  hermes config set compression.threshold 0.25   # compact at ~100K of the 400K window, not ~200K
+  sudo systemctl restart hermes-gateway
+  ```
+  Tune **down** (0.20…) if it still throttles. This is the **opposite** of `apply_context_fixes.sh`
+  (which *raises* the threshold for a different, doc-pruning problem — do **not** run it for a TPM
+  rate-limit). The real ceiling fix is raising the OpenAI **TPM tier** (200K/min is low for a
+  400K-window model); also note a `bg-review` background thread fires its own ~100K calls
+  *concurrently*, doubling per-minute pressure.
+- **Immediate unstick:** `/new` in Telegram (drops the bloated session), then restart for any new skills.
+
+The auto-reset below is still useful as a coarse "fresh start every 6h," but it is **secondary** to
+compaction and, given the CLI reality, a true hard reset means `hermes sessions delete <current-id>`
+**+** `gateway restart`, or simply relying on `/new`. Prefer compaction.
+
 ## The one knob to confirm (UNVERIFIED — like `apply_context_fixes.sh`)
 
 The exact way to clear the session depends on your Hermes build, and it can't be exercised from the
@@ -30,14 +63,15 @@ repo (no Hermes in CI). `/new` is the **manual** equivalent you already use in T
 just needs the command-line form of it. Discover the candidates on the VPS:
 
 ```bash
-hermes --help ; hermes session --help ; hermes chat --help   # look for a "new"/"reset"/"clear"
+hermes gateway --help ; hermes sessions --help   # verified 2026-06-16: NO clean live-reset (see above)
 ```
 
-Common shapes (use whichever your version exposes):
+The reset shapes that actually exist on a `hermes_cli` build (none as clean as `/new`):
 
 ```bash
-HERMES_RESET_CMD="hermes session new"      # if the CLI has it
-# HERMES_RESET_CMD="hermes chat reset"     # alternative naming
+# Hard reset (fragile — needs the live session id): delete it, then restart so the gateway starts fresh.
+HERMES_RESET_CMD='id=$(hermes sessions list --json 2>/dev/null | <pick newest>); hermes sessions delete "$id" && sudo systemctl restart hermes-gateway'
+# PREFERRED instead of a hard reset: set compression.threshold low (above) so sessions stay small.
 ```
 
 > ⚠️ **Restarting the gateway is NOT a reset.** `systemctl restart hermes-gateway` reloads skills /

--- a/docs/operations/hermes-token-efficiency-investigation-2026-06-15.md
+++ b/docs/operations/hermes-token-efficiency-investigation-2026-06-15.md
@@ -9,6 +9,28 @@
 > as the record of the diagnosis. Home: the Hermes control plane
 > ([`hermes-control-plane.md`](hermes-control-plane.md) § Model/provider).
 
+## 2026-06-16 follow-up — a SECOND, DISTINCT failure: TPM rate-limit (not context-window)
+
+This doc's 2026-06-15 issue was the **context-window / compaction-pruning** problem (fixed by the
+400K model swap). A later live incident (2026-06-16) is a **different** failure that the model swap
+*enabled*, so keep the two separate:
+
+- **Symptom:** the gateway loops on `Rate limit reached for gpt-5.4-mini … on tokens per min (TPM):
+  Limit 200000, Used …, Requested ~100k` with `Context: 79 msgs, ~110,571 tokens`, retries 3×, errors,
+  and the bot goes unresponsive (still `active (running)`).
+- **Cause:** **TPM (tokens *per minute*), not the 400K window.** A 110K session fits the window fine,
+  but every reply re-sends ~100K tokens and the OpenAI org TPM cap is **200K/min** → ~2 replies
+  saturate the minute. The session bloated to 110K because nothing reset it (the 6h reset wasn't
+  wired and `/new` wasn't being used). A `bg-review` background thread firing concurrent ~100K calls
+  compounds it.
+- **Fix direction is the OPPOSITE of this doc's:** here the window is fine, so do **not** raise
+  `compression.threshold` (don't run `apply_context_fixes.sh`). **Lower** it (`hermes config set
+  compression.threshold 0.25`) so each call stays small under the TPM budget, and/or raise the OpenAI
+  TPM tier. Immediate unstick = `/new`. There is **no clean CLI to reset the live gateway session**
+  (`gateway` = lifecycle only, restart keeps state; `sessions` = store mgmt) — `/new` or compaction.
+- **Full runbook:** [`hermes-session-reset.md`](hermes-session-reset.md) § "Root cause clarification
+  (2026-06-16)".
+
 ## The smoking gun (observed live 2026-06-14/15)
 
 Hermes `/status` after only a handful of small messages:

--- a/scripts/hermes/apply_context_fixes.sh
+++ b/scripts/hermes/apply_context_fixes.sh
@@ -7,6 +7,15 @@
 # primary fix — keep them only as a marginal tuning lever, not a required step. See
 # docs/operations/hermes-control-plane.md § Model/provider.
 #
+# ⚠️ DO NOT RUN THIS FOR A "tokens per min (TPM)" RATE-LIMIT (2026-06-16 incident). This script
+# RAISES compression.threshold (0.50 -> 0.75) = compact LATER = sessions grow BIGGER. That is the
+# right direction for the doc-pruning problem this script was built for, but the WRONG direction for
+# a per-minute rate limit (`Rate limit reached … on tokens per min (TPM): Limit 200000 …`). A bigger
+# session re-sends MORE tokens per reply, so it hits the TPM ceiling sooner. For a TPM error, do the
+# opposite — LOWER the threshold (e.g. `hermes config set compression.threshold 0.25`) so each call
+# stays small, and/or raise the OpenAI TPM tier. Full incident + fix: docs/operations/hermes-session-reset.md
+# § "Root cause clarification (2026-06-16)".
+#
 # WHY (original diagnosis): Hermes "forgets / misunderstands / loses the thread" because its gateway
 # COMPACTS context at 50% of the model window — it summarizes the middle of the
 # conversation and DELETES tool outputs larger than ~200 chars. SuperBot's docs are

--- a/scripts/hermes/session_reset.sh
+++ b/scripts/hermes/session_reset.sh
@@ -14,12 +14,15 @@
 # logs the result. It is the SAFE WRAPPER (scheduling + logging + a no-op when
 # unconfigured) — you supply the one reset command for your Hermes version.
 #
-# THE ONE UNVERIFIED KNOB (confirm on the VPS, like apply_context_fixes.sh):
-# the exact way to clear the session depends on your Hermes build. Set it in
-# ~/.hermes/reset.env (chmod 600), e.g.:
-#     HERMES_RESET_CMD="hermes session new"      # if the CLI exposes it
-#     # or whatever your `hermes --help` / gateway docs show as the /new equivalent
-# Discover candidates with:  hermes --help ; hermes session --help ; hermes chat --help
+# THE RESET COMMAND (2026-06-16 incident finding — read first):
+# A `hermes_cli` gateway has NO clean CLI to reset the live conversation — verified via
+# `hermes gateway --help` (service lifecycle only; restart KEEPS state) and `hermes sessions --help`
+# (store mgmt: list/delete/prune). The only clean live reset is `/new` in Telegram. So PREFER the
+# continuous fix instead of this timer: lower compaction so sessions never get big
+# (`hermes config set compression.threshold 0.25`; see docs/operations/hermes-session-reset.md
+# § "Root cause clarification (2026-06-16)"). If you still want a hard periodic reset, set in
+# ~/.hermes/reset.env (chmod 600) a delete-current-session-then-restart command, e.g.:
+#     HERMES_RESET_CMD='id=$(hermes sessions list ... newest); hermes sessions delete "$id" && sudo systemctl restart hermes-gateway'
 # If HERMES_RESET_CMD is unset, this script is a logged no-op (never an error), so
 # the timer won't spam failures before you've configured it.
 #


### PR DESCRIPTION
## Why

A live VPS debugging incident (this session) surfaced the real reason Hermes' scheduled skills
"hit rate limits" — and it's **not** what the existing docs assume. Capturing it so the next
agent/owner doesn't go the wrong way.

**Finding (from the gateway's `journalctl`):** the failure is **TPM — tokens *per minute***
(`Rate limit reached for gpt-5.4-mini … on tokens per min (TPM): Limit 200000, Used …, Requested
~100k`), **not** a context-window overflow. The interactive session had grown to ~110K tokens; the
model window is 400K (fits), but the OpenAI org TPM cap is **200K/min**, so every ~100K-token reply
lets only ~2 calls through per minute. The session bloated because nothing reset it (a `bg-review`
background thread firing concurrent ~100K calls compounds it). The bot looked "down" but was
`active (running)` — starved, not crashed.

## What (docs/scripts only — no `disbot/`, no runtime)

- **`hermes-session-reset.md`** — new "⚠️ Root cause clarification (2026-06-16)": the TPM-vs-window
  distinction; the **verified** reality that there's **no clean CLI to reset the live gateway
  conversation** (`hermes gateway --help` = lifecycle only, restart keeps state; `hermes sessions
  --help` = store mgmt, and the bloated session is the *newest* so `prune` won't touch it) → `/new`
  is the only clean live reset; **compaction (lower `compression.threshold`) is the primary durable
  fix**, not a 6h hard-reset. Corrected the old section's bogus `hermes session new` candidate.
- **`apply_context_fixes.sh`** — prominent warning to **not** run it for a TPM limit (it *raises*
  the threshold → bigger sessions → wrong direction).
- **token-efficiency investigation doc** — a "2026-06-16 follow-up" separating this TPM failure from
  the 2026-06-15 context-window one (opposite fix direction).
- **`session_reset.sh`** — header now states the no-clean-CLI-reset reality + points at compaction.

## Verification

`bash -n` on both edited scripts ✓, `session_reset.sh --dry-run` ✓, `check_docs --strict` ✓.

The certain facts (CLI reality, wrong-direction warning, TPM distinction) are landed now; the exact
best `compression.threshold` and whether to raise the OpenAI TPM tier are left as tune-and-verify
guidance pending the owner's live confirmation on the VPS.

https://claude.ai/code/session_011Add2RPDWutS7643URURns

---
_Generated by [Claude Code](https://claude.ai/code/session_011Add2RPDWutS7643URURns)_