### PR TITLE
docs(hermes): gpt-5-mini vs gpt-5.4-mini comparison + deprecate --set-model

### DIFF
--- a/.sessions/2026-06-16-model-comparison-gpt5mini.md
+++ b/.sessions/2026-06-16-model-comparison-gpt5mini.md
@@ -1,0 +1,18 @@
+# 2026-06-16 — gpt-5-mini vs gpt-5.4-mini comparison + apply_context_fixes --set-model fix
+
+> **Status:** `in-progress` — capturing a model-comparison finding (owner asked) + fixing one latent
+> script bug. Docs/scripts only; one push.
+
+## What I'm about to do
+
+Owner asked whether switching Hermes from `gpt-5.4-mini` to `gpt-5-mini` would raise the TPM ceiling
+("this one has a lot more tokens per minute") and to "get the diffs for those 2 models." Researched
+both from OpenAI's own model pages. Capturing the finding durably + fixing an adjacent bug it exposed.
+
+- **Finding:** the published per-tier rate-limit tables are **identical** for both models — switching
+  alone does not raise TPM. The 200K observed is *below* Tier 1's published 500K → the limiter is the
+  **org usage tier / gpt-5-family verification throttle**, not the model name. Trade-off if switched:
+  5-mini is ~2–3× cheaper but weaker/slower/staler (the class the repo left in #913→#921).
+- **Adjacent bug:** `apply_context_fixes.sh --set-model` runs `hermes config set model`, which the
+  model-switch playbook says reverts routing to the Nous catalog (the custom-provider setup is now the
+  norm). Fixing it to warn + point at `hermes model` instead of silently doing the wrong thing.

--- a/.sessions/2026-06-16-model-comparison-gpt5mini.md
+++ b/.sessions/2026-06-16-model-comparison-gpt5mini.md
@@ -1,18 +1,94 @@
 # 2026-06-16 — gpt-5-mini vs gpt-5.4-mini comparison + apply_context_fixes --set-model fix
 
-> **Status:** `in-progress` — capturing a model-comparison finding (owner asked) + fixing one latent
-> script bug. Docs/scripts only; one push.
+> **Status:** `complete` — docs/scripts only; one PR (#978).
 
-## What I'm about to do
+## Arc
 
-Owner asked whether switching Hermes from `gpt-5.4-mini` to `gpt-5-mini` would raise the TPM ceiling
-("this one has a lot more tokens per minute") and to "get the diffs for those 2 models." Researched
-both from OpenAI's own model pages. Capturing the finding durably + fixing an adjacent bug it exposed.
+Owner asked whether switching Hermes from `gpt-5.4-mini` to `gpt-5-mini` would raise the live bot's
+200K TPM ceiling ("this one has a lot more tokens per minute") and to "get the diffs for those 2
+models." Researched both from OpenAI's own model pages, captured the finding durably, fixed an
+adjacent script bug it exposed. Mid-session the owner confirmed the **dashboard caps 5.4-mini at
+200K** and is empirically testing 5-mini — which sharpened the doc into a decisive either/or test.
 
-- **Finding:** the published per-tier rate-limit tables are **identical** for both models — switching
-  alone does not raise TPM. The 200K observed is *below* Tier 1's published 500K → the limiter is the
-  **org usage tier / gpt-5-family verification throttle**, not the model name. Trade-off if switched:
-  5-mini is ~2–3× cheaper but weaker/slower/staler (the class the repo left in #913→#921).
-- **Adjacent bug:** `apply_context_fixes.sh --set-model` runs `hermes config set model`, which the
-  model-switch playbook says reverts routing to the Nous catalog (the custom-provider setup is now the
-  norm). Fixing it to warn + point at `hermes model` instead of silently doing the wrong thing.
+## The finding (verified 2026-06-16 from OpenAI's model pages)
+
+- **The published per-tier rate-limit tables are identical for both models** (Tier 1 500 RPM / 500K
+  TPM, Tier 2 5K / 2M, Tier 3 5K / 4M, Tier 4 10K / 10M, Tier 5 30K / 180M). So a model swap **does
+  not** lift TPM on paper.
+- The owner-observed/dashboard 200K is **below** Tier 1's published 500K → the limiter is the **org
+  usage tier or a gpt-5-family rollout/verification throttle, not the model name**.
+- **Decisive test (no live switch needed):** the dashboard lists limits **per model**, so compare
+  gpt-5-mini's number — **(a)** also ~200K → org-wide throttle, raise the tier (1→2 = 2M); **(b)**
+  higher (≈500K) → a throttle on the *newer* 5.4-mini, switching to 5-mini genuinely helps. Only case
+  (b) justifies the switch.
+- Trade-off if switched: 5-mini is ~2–3× cheaper ($0.25/$2.00 vs $0.75/$4.50) but weaker, ~2× slower,
+  and staler (May 2024 vs Aug 2025) — the model class the role deliberately left in #913→#921.
+
+## Shipped (PR #978 — docs/scripts only)
+
+- `docs/operations/hermes-control-plane.md` — added the side-by-side comparison + the
+  "lever is the tier, not the model" finding + the owner-confirmed decisive-test either/or in the
+  Model/provider section; pointed the existing 200K-TPM caveat at it.
+- `scripts/hermes/apply_context_fixes.sh` — fixed the adjacent bug: `--set-model` ran
+  `hermes config set model`, which the model-switch playbook shows reverts routing to the Nous catalog
+  (wrong for the own-key custom provider). The flag is now a no-op that prints the correct path
+  (re-run `hermes model`); usage + tip text updated to match.
+
+`bash -n` ✓ · dry-ran the deprecated `--set-model` path ✓ · `check_docs --strict` ✓ · no Python
+touched (no mypy/pytest/lint impact).
+
+## Context delta
+
+- **Load-bearing fact:** within a model *class*, OpenAI's per-tier rate limits are uniform — so "use a
+  different mini for more TPM" is usually a category error. The real TPM levers are **usage tier** and
+  **per-call size** (compaction), and the *only* source of an org's actual cap is the dashboard. A
+  model swap helps **only** when a newer model is rollout-throttled below its tier.
+- **Decision made alone:** landed the comparison + the `--set-model` fix without waiting on the live
+  test outcome — both are correct regardless of whether 5-mini's cap turns out higher. The pending
+  test result will be a one-line follow-up to the doc, not a change to this PR.
+- **Flagged for owner:** check gpt-5-mini's dashboard cap *before* switching — if it's also 200K the
+  switch is wasted effort and the tier is the real fix.
+
+## 💡 Session idea (Q-0089)
+
+**`docs/operations/openai-account-state.md` — an owner-pasted ground-truth snapshot.** Agents reason
+about TPM/cost from *published* tables, but the org's actual caps, usage tier, and verification status
+live on a dashboard no agent can see — so every such question (like today's) forces the owner to go
+look. A tiny dated doc the owner pastes their dashboard limits into (per-model TPM/RPM, tier, verified
+models) would give agents ground truth and let them answer definitively instead of "check your
+dashboard." Worth it the moment a second rate-limit/cost question comes up; not yet filed as an idea
+doc (small, and partly satisfied by the new control-plane note) — promote if it recurs.
+
+## ⟲ Previous-session review (Q-0102)
+
+Reviewing the #976 TPM-docs session (`2026-06-16-hermes-tpm-rate-limit-docs.md`). **Did well:** nailed
+the TPM-vs-context-window distinction and the verified no-clean-CLI-reset reality — genuinely
+load-bearing corrections that stopped a wrong-direction fix (`apply_context_fixes.sh`). **Missed:** it
+concluded on "compaction / raise the tier" but never evaluated the **model-choice** lever — so when
+the owner immediately asked "what about gpt-5-mini?", the answer wasn't pre-captured and needed a
+fresh research pass this session. **System improvement (acted on here):** a finding doc about a
+constraint (rate limit, cost) should also enumerate the *adjacent levers it considered and ruled out*
+(here: a model swap) so the obvious next question is already answered — which is exactly the
+comparison this session added. The chain self-corrected; the durable lesson is "capture the ruled-out
+alternatives, not just the chosen fix."
+
+## 📤 Run report
+
+- **Did:** researched gpt-5-mini vs gpt-5.4-mini, captured the comparison + the "TPM lever is the tier,
+  not the model" finding, fixed the `--set-model` routing bug · **Outcome:** shipped (PR #978).
+- **⚑ Owner decisions needed:** `none`.
+- **⚑ Owner manual steps (VPS):** check **gpt-5-mini's dashboard TPM cap first**; switch only if it's
+  higher than 5.4-mini's 200K — via `hermes model` (not `hermes config set model`) + allowlist the id +
+  `sudo systemctl restart hermes-gateway`. If 5-mini is also 200K, raise the OpenAI usage tier instead.
+- **↪ Next:** owner reports 5-mini's dashboard cap / live behavior → one-line doc follow-up with the
+  result (which lever won).
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs opened this session | 1 (#978) |
+| CI-red rounds | 0 (docs/scripts only; verified locally) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (openai-account-state snapshot) |
+| Ideas groomed | 0 |

--- a/docs/operations/hermes-control-plane.md
+++ b/docs/operations/hermes-control-plane.md
@@ -102,6 +102,33 @@ Hermes config/data paths shown during setup:
   note:** at $4.50/1M output a long accumulating gateway session is the real spend driver (not the
   window) — so the bounded-session / `/new`-per-task habit is now a **cost** lever, not a capability
   crutch.
+- **gpt-5-mini vs gpt-5.4-mini — does a model swap raise the TPM ceiling? No (verified 2026-06-16
+  from OpenAI's own model pages; Q-0105 — re-confirm against the dashboard before trusting).** The
+  owner asked whether dropping to `gpt-5-mini` would lift the 200K TPM wall. It would **not**: OpenAI's
+  **published per-tier rate-limit tables are identical** for both models — Tier 1 500 RPM / **500K
+  TPM**, Tier 2 5K / **2M**, Tier 3 5K / 4M, Tier 4 10K / 10M, Tier 5 30K / 180M. The 200K we hit is
+  *below* Tier 1's 500K → the limiter is the **org usage tier (or a gpt-5-family verification/rollout
+  throttle), not the model name**. Real ceiling levers, in order: **(1)** raise the usage tier — Tier
+  1→2 is 500K→**2M TPM (4×)** and dwarfs any model swap; **(2)** confirm the org isn't stuck below
+  Tier 1's 500K on the dashboard (`platform.openai.com/settings/organization/limits` — the only source
+  of the *actual* per-model cap); **(3)** lower `compression.threshold` so each call stays small (free,
+  continuous). The **one** case a swap to 5-mini helps is if OpenAI is rollout-throttling the *newer*
+  5.4-mini below its tier and 5-mini gives the full 500K — unverifiable except on that dashboard, and
+  you'd pay for it in capability:
+
+  | | **gpt-5-mini** | **gpt-5.4-mini** (current) |
+  |---|---|---|
+  | Context / max output | 400K / 128K | 400K / 128K — *same* |
+  | Input · output /1M | **$0.25 · $2.00** | $0.75 · $4.50 *(2.25–3× more)* |
+  | Knowledge cutoff | May 2024 | **Aug 2025** |
+  | Capability / speed | baseline | **"significantly improves … coding, reasoning, tool use", ~2× faster** (OpenAI) |
+  | Rate limits (all tiers) | — | **identical to 5-mini** |
+
+  Net: 5-mini saves ~2–3× cost but re-introduces the weaker/slower model class the role left in
+  #913→#921 — and does **not** fix TPM. Switch only if the dashboard proves 5-mini's *actual* cap is
+  higher. **To switch, re-run `hermes model`** (keeps the custom OpenAI-provider routing) + allowlist
+  the exact id — **not** `hermes config set model` / `apply_context_fixes.sh --set-model`, which revert
+  routing to the Nous catalog (model-switch playbook below).
 - **Recommended `config.yaml` for gpt-5.4-mini (verify key names against the installed version —
   Q-0105 unverified):** `agent.reasoning_effort: medium` (it **is** a reasoning model — never `none`,
   which was only the gpt-4o-mini workaround; the review-merge role can go `high`).
@@ -156,8 +183,9 @@ choice (mini vs. a stronger review model, Q-0117) gets decided on evidence rathe
 **Two minor caveats (operational, not capability):**
 - **200K TPM ceiling.** A single token-heavy task (loading 3 skills + ~15 searches/reads) hit the
   OpenAI per-minute token cap and the turn errored mid-way. Mitigations: **`/new` per task** (smaller
-  turns) and/or request a higher OpenAI usage-tier TPM. Not a model fault — it recovered fully on
-  "continue".
+  turns) and/or **raise the OpenAI usage tier** (Tier 1→2 is 500K→2M TPM). Switching to `gpt-5-mini`
+  does **not** help — identical TPM tiers (see § Model/provider, "gpt-5-mini vs gpt-5.4-mini"). Not a
+  model fault — it recovered fully on "continue".
 - **Over-loads skills.** It loaded 3 skills for a one-skill task (seen twice). A *"one skill per task;
   for an overlap check use `gh pr list` + grep `.sessions/`, don't deep-search"* steer (now in the
   `dispatch` skill) trims the heaviest part without dumbing it down. Consider

--- a/docs/operations/hermes-control-plane.md
+++ b/docs/operations/hermes-control-plane.md
@@ -129,6 +129,14 @@ Hermes config/data paths shown during setup:
   higher. **To switch, re-run `hermes model`** (keeps the custom OpenAI-provider routing) + allowlist
   the exact id — **not** `hermes config set model` / `apply_context_fixes.sh --set-model`, which revert
   routing to the Nous catalog (model-switch playbook below).
+  - **The decisive test (owner-confirmed 2026-06-16): the dashboard caps gpt-5.4-mini at 200K — below
+    its published 500K Tier 1.** That asymmetry means one of two things, and the dashboard's per-model
+    number for **gpt-5-mini** settles it *without switching the live bot* (limits are listed per model
+    regardless of which is active): **(a)** 5-mini also shows ~200K → it's an **org-wide tier throttle**,
+    the model is irrelevant, **raise the usage tier** (Tier 1→2 = 2M); **(b)** 5-mini shows higher
+    (≈500K) → the 200K is a **rollout/verification throttle on the *newer* 5.4-mini**, so switching to
+    5-mini (or requesting a 5.4-mini limit increase) genuinely lifts the cap. **Check that number first;
+    only switch if it's case (b).**
 - **Recommended `config.yaml` for gpt-5.4-mini (verify key names against the installed version —
   Q-0105 unverified):** `agent.reasoning_effort: medium` (it **is** a reasoning model — never `none`,
   which was only the gpt-4o-mini workaround; the review-merge role can go `high`).

--- a/scripts/hermes/apply_context_fixes.sh
+++ b/scripts/hermes/apply_context_fixes.sh
@@ -34,7 +34,14 @@
 # USAGE (on the VPS, as the `hermes` user, from the repo root):
 #   bash scripts/hermes/apply_context_fixes.sh             # apply (backs up first)
 #   bash scripts/hermes/apply_context_fixes.sh --dry-run   # show what it would do; change nothing
-#   bash scripts/hermes/apply_context_fixes.sh --set-model=anthropic/claude-opus-4   # also switch model
+#   bash scripts/hermes/apply_context_fixes.sh --set-model=...  # DEPRECATED — prints why + points at `hermes model`
+#
+# ⚠️ --set-model is INTENTIONALLY a no-op now (2026-06-16). It used `hermes config set model`, but the
+# model-switch playbook (docs/operations/hermes-control-plane.md § Model-switch playbook) proved that
+# command changes only the *name* and reverts routing to the Nous catalog — wrong for the current
+# own-key custom-provider setup. A bash script can't drive the interactive `hermes model` wizard, so
+# the flag now explains this and exits instead of silently doing the wrong thing. Switch models by
+# re-running `hermes model`.
 #
 # Provenance: added 2026-06-15 from the Hermes token-efficiency investigation.
 # UNVERIFIED: the `hermes config set` calls cannot be exercised in CI (no Hermes there) — only
@@ -104,8 +111,15 @@ set_key() {
   fi
 }
 for i in "${!KEYS[@]}"; do set_key "${KEYS[$i]}" "${VALS[$i]}"; done
-# Optional model switch — opt-in only; model choice is cost-sensitive, so left to you.
-[[ -n "$SET_MODEL" ]] && set_key "model" "$SET_MODEL"
+# Model switch is NOT done here. `hermes config set model` only changes the name and reverts routing to
+# the Nous catalog (model-switch playbook) — wrong for the own-key custom provider. Re-run `hermes
+# model` instead. The flag stays only to catch old muscle memory and explain the correct path.
+if [[ -n "$SET_MODEL" ]]; then
+  say "⚠ --set-model is a no-op: 'hermes config set model' reverts routing to the Nous catalog."
+  say "  To switch to '$SET_MODEL', re-run the wizard:  hermes model   (keeps the custom provider)"
+  say "  Then allowlist the exact model id in your OpenAI project. See"
+  say "  docs/operations/hermes-control-plane.md § Model-switch playbook."
+fi
 rule
 
 # 3) Re-install the sync-fixed SOUL.md (+ its size guard reports headroom).
@@ -127,7 +141,7 @@ if [[ $DRY_RUN -eq 0 ]]; then
   say "current settings — see 'hermes config' for the live model + values."
 fi
 say "tip: a LARGER context-window model pushes the 50% compaction line further out."
-say "     switch with:  $0 --set-model=<provider/model>   (cost is your call)"
+say "     to switch models, re-run:  hermes model   (NOT --set-model — see the playbook)"
 rule
 say "NEXT — restart the gateway to load the changes:"
 say "     sudo systemctl restart hermes-gateway"


### PR DESCRIPTION
## Why

The owner asked whether switching Hermes from `gpt-5.4-mini` to `gpt-5-mini` would raise the **200K TPM** wall the live bot keeps hitting ("this one has a lot more tokens per minute") and to "get the diffs for those 2 models."

## Finding (verified from OpenAI's own model pages, 2026-06-16)

**The published per-tier rate-limit tables are identical for both models** — Tier 1 500 RPM / 500K TPM, Tier 2 5K / 2M, … Tier 5 30K / 180M. So a model swap **does not lift TPM**. The 200K we hit is *below* Tier 1's 500K → the limiter is the **org usage tier (or a gpt-5-family verification/rollout throttle), not the model name**.

| | gpt-5-mini | gpt-5.4-mini (current) |
|---|---|---|
| Context / max output | 400K / 128K | 400K / 128K — same |
| Input · output /1M | **$0.25 · $2.00** | $0.75 · $4.50 |
| Knowledge cutoff | May 2024 | **Aug 2025** |
| Capability / speed | baseline | "significantly improves … coding, reasoning, tool use", ~2× faster (OpenAI) |
| Rate limits (all tiers) | — | identical to 5-mini |

Net: 5-mini is ~2–3× cheaper but weaker/slower/staler (the class the role left in #913→#921) **and does not fix TPM**. Real levers, in order: raise the usage tier (1→2 = 500K→2M, 4×); check the dashboard for the *actual* per-model cap; lower `compression.threshold`.

## Changes (docs/scripts only)

- **`docs/operations/hermes-control-plane.md`** — added the side-by-side comparison + the "lever is the tier, not the model" finding in the Model/provider section; pointed the existing 200K-TPM caveat at it.
- **`scripts/hermes/apply_context_fixes.sh`** — fixed an adjacent bug the question exposed: `--set-model` ran `hermes config set model`, which the model-switch playbook shows reverts routing to the Nous catalog (wrong for the own-key custom provider). The flag is now a no-op that explains the correct path (re-run `hermes model`).

## Verification

- `bash -n scripts/hermes/apply_context_fixes.sh` ✓ + dry-ran the deprecated flag path ✓
- `python3.10 scripts/check_docs.py --strict` ✓
- No Python touched (no mypy/pytest/lint impact).

https://claude.ai/code/session_011Add2RPDWutS7643URURns

---
_Generated by [Claude Code](https://claude.ai/code/session_011Add2RPDWutS7643URURns)_