### PR TITLE
fix(dashboard): /settings 500 — Jinja domain.keys hit the dict method

### DIFF
--- a/.sessions/2026-06-16-dashboard-settings-fix.md
+++ b/.sessions/2026-06-16-dashboard-settings-fix.md
@@ -1,0 +1,50 @@
+# Session — hotfix: /settings 500 (Jinja `domain.keys` → dict-method collision)
+
+> **Status:** `complete`
+
+## Origin
+
+Owner, minutes after #977 merged: *"the settings tab gives an internal service error."* The live
+`/settings` page 500'd.
+
+## Root cause
+
+`dashboard/templates/settings.html` iterated `domain.keys` (the scanner field holding the list of
+`{constant, key}` entries). In Jinja, attribute access `domain.keys` on a **dict** resolves to the
+dict's built-in **`.keys` method**, not the `"keys"` item — so `{% for k in domain.keys %}` tried to
+iterate a `builtin_function_or_method` → `TypeError` → 500. Classic Jinja footgun: dict items named
+`keys` / `items` / `values` collide with dict methods.
+
+## Fix
+
+Subscript access — `domain['keys']` — in all four spots (the two `{% for %}` loops + the `| length`
+count). Subscript forces item lookup, bypassing the method. No data/scanner change; the JSON was fine.
+
+## Why CI didn't catch it (the real lesson)
+
+The dashboard app smoke test (`tests/unit/dashboard/test_app.py`) is **`importorskip`-guarded** and
+**skips in CI** by design — CI installs only the bot's `requirements.txt`, never the dashboard's web
+deps (the decoupling contract). So a **template-only** bug is invisible to CI, and my local run had
+*also* skipped because the web deps weren't installed. The smoke test *does* catch this (the
+`/settings` render → 200 assertion failed once deps were present) — it just never ran.
+
+**Process fix (applied):** install the dashboard deps and run the smoke test **locally** before
+pushing any `dashboard/` template change:
+`python3.10 -m pip install -r dashboard/requirements.txt httpx && python3.10 -m pytest tests/unit/dashboard/`.
+
+## Verification
+
+- `python3.10 -m pip install -r dashboard/requirements.txt httpx` then
+  `python3.10 -m pytest tests/unit/dashboard/test_app.py` → **13 passed** (`/settings` + `/access`
+  both render 200). Before the fix: `TypeError` on `/settings`.
+
+**Merge ≠ deploy:** the dashboard auto-redeploys on merge to `main`; `/settings` recovers after the
+redeploy.
+
+## 💡 Session idea (Q-0089)
+
+**A dashboard-only CI job** (`.github/workflows/dashboard-ci.yml`, triggered on `dashboard/**` +
+`scripts/scan_*` + `scripts/export_dashboard_data.py`) that installs the dashboard deps and runs
+`tests/unit/dashboard/` + the scanner tests. This is the structural fix for *"CI can't see dashboard
+template bugs"* — it would have caught this 500 on the original PR. Keeps the bot's CI untouched
+(separate job), honoring the decoupling. Worth doing as the immediate next dashboard PR.

--- a/dashboard/templates/settings.html
+++ b/dashboard/templates/settings.html
@@ -24,14 +24,14 @@
 <div class="space-y-5">
   {% for domain in data.settings %}
     <section class="setting-domain rounded-xl border border-slate-800 bg-slate-900/50 p-4"
-             data-haystack="{{ domain.domain }} {{ domain.purpose }} {% for k in domain.keys %}{{ k.constant }} {{ k.key }} {% endfor %}">
+             data-haystack="{{ domain.domain }} {{ domain.purpose }} {% for k in domain['keys'] %}{{ k.constant }} {{ k.key }} {% endfor %}">
       <div class="flex items-baseline gap-2 flex-wrap">
         <h2 class="text-lg font-semibold text-sky-300">{{ domain.domain }}</h2>
-        <span class="text-xs text-slate-500">{{ domain.keys | length }} key{{ '' if domain.keys|length == 1 else 's' }}</span>
+        <span class="text-xs text-slate-500">{{ domain['keys'] | length }} key{{ '' if domain['keys']|length == 1 else 's' }}</span>
       </div>
       {% if domain.purpose %}<p class="text-xs text-slate-400 mb-3">{{ domain.purpose }}</p>{% endif %}
       <div class="grid gap-1 sm:grid-cols-2">
-        {% for k in domain.keys %}
+        {% for k in domain['keys'] %}
           <div class="setting-row flex items-center justify-between gap-2 rounded bg-slate-950/60 px-2.5 py-1.5"
                data-haystack="{{ k.constant }} {{ k.key }}">
             <code class="text-xs text-slate-200">{{ k.constant }}</code>


### PR DESCRIPTION
## Why

`/settings` (shipped in #977) returns an **internal server error** on the live dashboard.

## Root cause

`dashboard/templates/settings.html` iterated `domain.keys`. In Jinja, `domain.keys` on a **dict**
resolves to the dict's built-in **`.keys` method**, not the `"keys"` item — so
`{% for k in domain.keys %}` iterates a `builtin_function_or_method` → `TypeError` → 500. (Classic
Jinja footgun for items named `keys`/`items`/`values`.)

## Fix

Subscript access `domain['keys']` in all four spots (two `{% for %}` loops + the `| length` count).
Forces item lookup, bypassing the method. **No data/scanner change** — the JSON was always correct.

## Why CI didn't catch it

The dashboard app smoke test (`tests/unit/dashboard/test_app.py`) is **`importorskip`-guarded and
skips in CI** — the bot's CI never installs the dashboard's web deps (the decoupling contract). A
template-only bug is therefore invisible to CI. The test *does* catch it once the deps are present.

**Verified locally** (`pip install -r dashboard/requirements.txt httpx` →
`pytest tests/unit/dashboard/test_app.py`): **13 passed**, `/settings` + `/access` both render 200.
Before: `TypeError` on `/settings`.

## Follow-up (filed in the session card)

A dashboard-only CI job (`dashboard/**` trigger) that installs the dashboard deps and runs these
tests — the structural fix so CI can see template bugs. Keeps the bot's CI untouched.

https://claude.ai/code/session_014f52sCSiw4UAmHxxCP7DWV

---
_Generated by [Claude Code](https://claude.ai/code/session_014f52sCSiw4UAmHxxCP7DWV)_