### PR TITLE
docs(hermes): confirm 5-mini 500K TPM result + reconcile compaction guidance

### DIFF
--- a/.sessions/2026-06-16-model-tpm-confirmed-result.md
+++ b/.sessions/2026-06-16-model-tpm-confirmed-result.md
@@ -1,0 +1,29 @@
+# 2026-06-16 — TPM result confirmed (5-mini 500K) + reconcile the compaction guidance
+
+> **Status:** `in-progress` — follow-up to the merged #978 (same session). Docs-only; one push.
+> Session enders (Q-0089 idea, Q-0102 review, Q-0104 audit) were satisfied in this session's first
+> card (`2026-06-16-model-comparison-gpt5mini.md`, merged in #978) — not repeated here.
+
+## What I'm about to do
+
+The owner pulled their OpenAI **Project → Rate limits** page and it confirmed the empirical answer +
+gave a config directive. Capturing both durably (I promised "I'll add the result to the doc"):
+
+- **Confirmed:** `gpt-5-mini` = **500K TPM** vs `gpt-5.4-mini` = **200K TPM** on the same account
+  (dated 5.4 snapshot also 200K; `gpt-4o-mini` 200K; org Default 250K; all 500 RPM). It's case (b) —
+  the 200K is a per-model throttle on the newer 5.4-mini, not an org ceiling. Switching to 5-mini =
+  2.5× headroom → the chosen fix.
+- **Owner directive:** **leave compaction at default** — do NOT lower `compression.threshold`. With
+  500K headroom it isn't needed, and lowering it interrupts tasks mid-flow (prunes context the turn
+  still needs). The bot "can just do its tasks normally without interruption."
+
+## Edits
+
+- `docs/operations/hermes-control-plane.md` — table row → confirmed per-account caps; replaced the
+  "either/or decisive test" with the ✅ confirmed result + the durable lesson (published per-tier
+  tables are uniform — only the project/org Limits page shows an account's real per-model cap) + the
+  decision (switch to 5-mini; compaction stays default, owner-declined).
+- `docs/operations/hermes-session-reset.md` — the #976 "compaction is the primary lever" framing is
+  superseded for this account: added a ✅ RESOLVED note (model-cap is the fix; compaction declined),
+  demoted the compaction bullet to "only when you can't switch to a higher-cap model," and reset the
+  order-of-preference (model swap → /new → compaction-if-no-alternative).

--- a/.sessions/2026-06-16-model-tpm-confirmed-result.md
+++ b/.sessions/2026-06-16-model-tpm-confirmed-result.md
@@ -1,6 +1,6 @@
 # 2026-06-16 — TPM result confirmed (5-mini 500K) + reconcile the compaction guidance
 
-> **Status:** `in-progress` — follow-up to the merged #978 (same session). Docs-only; one push.
+> **Status:** `complete` — follow-up to the merged #978 (same session), shipped as #980. Docs-only.
 > Session enders (Q-0089 idea, Q-0102 review, Q-0104 audit) were satisfied in this session's first
 > card (`2026-06-16-model-comparison-gpt5mini.md`, merged in #978) — not repeated here.
 

--- a/docs/operations/hermes-control-plane.md
+++ b/docs/operations/hermes-control-plane.md
@@ -122,21 +122,30 @@ Hermes config/data paths shown during setup:
   | Input · output /1M | **$0.25 · $2.00** | $0.75 · $4.50 *(2.25–3× more)* |
   | Knowledge cutoff | May 2024 | **Aug 2025** |
   | Capability / speed | baseline | **"significantly improves … coding, reasoning, tool use", ~2× faster** (OpenAI) |
-  | Rate limits (all tiers) | — | **identical to 5-mini** |
+  | Rate limits — **this account** (2026-06-16) | **500K TPM** | **200K TPM** *(published tiers identical; the account's per-model override differs — see below)* |
 
-  Net: 5-mini saves ~2–3× cost but re-introduces the weaker/slower model class the role left in
-  #913→#921 — and does **not** fix TPM. Switch only if the dashboard proves 5-mini's *actual* cap is
-  higher. **To switch, re-run `hermes model`** (keeps the custom OpenAI-provider routing) + allowlist
-  the exact id — **not** `hermes config set model` / `apply_context_fixes.sh --set-model`, which revert
-  routing to the Nous catalog (model-switch playbook below).
-  - **The decisive test (owner-confirmed 2026-06-16): the dashboard caps gpt-5.4-mini at 200K — below
-    its published 500K Tier 1.** That asymmetry means one of two things, and the dashboard's per-model
-    number for **gpt-5-mini** settles it *without switching the live bot* (limits are listed per model
-    regardless of which is active): **(a)** 5-mini also shows ~200K → it's an **org-wide tier throttle**,
-    the model is irrelevant, **raise the usage tier** (Tier 1→2 = 2M); **(b)** 5-mini shows higher
-    (≈500K) → the 200K is a **rollout/verification throttle on the *newer* 5.4-mini**, so switching to
-    5-mini (or requesting a 5.4-mini limit increase) genuinely lifts the cap. **Check that number first;
-    only switch if it's case (b).**
+  Net: 5-mini is ~2–3× cheaper but weaker/slower/staler — the model class the role left in #913→#921.
+  On OpenAI's *published* per-tier tables it does **not** change TPM (identical limits); the deciding
+  factor is the **account's actual per-model cap** (the project/org Limits page), which can differ from
+  the tables. **To switch, re-run `hermes model`** (keeps the custom OpenAI-provider routing) +
+  allowlist the exact id — **not** `hermes config set model` / `apply_context_fixes.sh --set-model`,
+  which revert routing to the Nous catalog (model-switch playbook below).
+  - **✅ CONFIRMED for this account (2026-06-16, owner's Project → Rate limits page): switching to
+    5-mini DOES lift the cap.** The page (limits inherited from the org unless overridden) showed
+    **`gpt-5-mini` 500,000 TPM** vs **`gpt-5.4-mini` 200,000 TPM** (the dated `gpt-5.4-mini-2026-03-17`
+    snapshot also 200K; `gpt-4o-mini` 200K; org **Default `*`** 250K / 3K RPM; all at 500 RPM). So the
+    200K is a **per-model throttle on the newer 5.4-mini, not an org-wide ceiling** — 5-mini gives
+    **2.5×** the per-minute budget on the same key. **Lesson (Q-0120 instinct): never reason TPM from
+    published per-tier tables — they're uniform within a model class; the project/org Limits page is the
+    only source of an account's real per-model cap.**
+  - **Decision (owner directive, 2026-06-16): switch Hermes to `gpt-5-mini` and leave compaction at its
+    default.** The 500K cap clears the wall on its own, so lowering `compression.threshold` is **not**
+    needed — and the owner explicitly declined it because aggressive compaction interrupts a task
+    mid-flow (it summarizes/prunes context the turn still needs, so the bot "can just do its tasks
+    normally without interruption"). Accept the small capability/speed drop and re-run the calibration
+    probes (above) to confirm the dispatch/review role still holds on 5-mini. To instead keep the
+    more-capable 5.4-mini, OpenAI must raise its **org** limit above 200K — the project page can't
+    override above the org-inherited cap.
 - **Recommended `config.yaml` for gpt-5.4-mini (verify key names against the installed version —
   Q-0105 unverified):** `agent.reasoning_effort: medium` (it **is** a reasoning model — never `none`,
   which was only the gpt-4o-mini workaround; the review-merge role can go `high`).

--- a/docs/operations/hermes-session-reset.md
+++ b/docs/operations/hermes-session-reset.md
@@ -23,9 +23,18 @@ systemd timer (every 6h)  →  scripts/hermes/session_reset.sh  →  $HERMES_RES
 `review-merge` already run as **fresh, stateless** sessions on their own cron (a scheduled skill
 never accumulates into your chat). This runbook is only about the **interactive** thread you type in.
 
-## ⚠️ Root cause clarification (2026-06-16 live incident) — it's TPM, and compaction is the primary lever
+## ⚠️ Root cause clarification (2026-06-16 live incident) — it's TPM (resolved by the per-model cap)
 
 A real incident clarified what actually goes wrong and the cleanest fix — read this before wiring a timer:
+
+> **✅ RESOLVED (2026-06-16): the fix was the per-model TPM cap, not compaction.** The owner's OpenAI
+> account caps `gpt-5.4-mini` at **200K TPM** but `gpt-5-mini` at **500K TPM** (2.5×, confirmed on the
+> project Rate-limits page) — so the chosen fix is **switching Hermes to `gpt-5-mini`**, which clears
+> the wall with headroom to spare. **Compaction was deliberately left at default — the owner declined
+> lowering it because it interrupts tasks mid-flow** (it prunes context the turn still needs). The
+> compaction guidance below is retained as *general background* for an account with no higher-cap model
+> to switch to; it is **not** the path taken here. Full detail + the decision:
+> [`hermes-control-plane.md`](./hermes-control-plane.md) § Model/provider ("gpt-5-mini vs gpt-5.4-mini").
 
 - **The failure is a per-minute rate limit, not a context-window overflow.** The gateway logged
   `Rate limit reached for gpt-5.4-mini … on tokens per min (TPM): Limit 200000, Used …, Requested ~100k`
@@ -38,8 +47,9 @@ A real incident clarified what actually goes wrong and the cleanest fix — read
   **restart does NOT clear context**) and `hermes sessions --help` (store mgmt: `list/delete/prune/
   stats/…` — and the bloated session is the *newest*, so `prune` (old) won't touch it). **The only
   clean live reset is `/new` in Telegram.**
-- **So compaction — not a 6h hard-reset — is the primary durable fix.** Lower the compaction
-  threshold so the gateway keeps each call small *continuously*, well under the TPM budget:
+- **Compaction is the durable fix *only when you can't switch to a higher-cap model* (not the path
+  taken here — see the RESOLVED note above).** Lower the compaction threshold so the gateway keeps each
+  call small *continuously*, well under the TPM budget:
   ```bash
   hermes config                                  # confirm current compression.threshold (≈ 0.50)
   hermes config set compression.threshold 0.25   # compact at ~100K of the 400K window, not ~200K
@@ -52,9 +62,11 @@ A real incident clarified what actually goes wrong and the cleanest fix — read
   *concurrently*, doubling per-minute pressure.
 - **Immediate unstick:** `/new` in Telegram (drops the bloated session), then restart for any new skills.
 
-The auto-reset below is still useful as a coarse "fresh start every 6h," but it is **secondary** to
-compaction and, given the CLI reality, a true hard reset means `hermes sessions delete <current-id>`
-**+** `gateway restart`, or simply relying on `/new`. Prefer compaction.
+The auto-reset below is still useful as a coarse "fresh start every 6h," but it is **secondary** and,
+given the CLI reality, a true hard reset means `hermes sessions delete <current-id>` **+** `gateway
+restart`, or simply relying on `/new`. Order of preference for TPM: **raise the per-model cap (model
+swap to 5-mini = 500K)** → then `/new`/auto-reset for hygiene → compaction only if no higher-cap model
+is available (and the owner declined it here, as it interrupts tasks).
 
 ## The one knob to confirm (UNVERIFIED — like `apply_context_fixes.sh`)
 


### PR DESCRIPTION
Follow-up to #978 (same session) — captures the **confirmed empirical result** the owner pulled from their OpenAI dashboard, plus a config directive.

## Confirmed (owner's Project → Rate limits page, 2026-06-16)

| model | TPM | RPM |
|---|---|---|
| **`gpt-5-mini`** | **500,000** | 500 |
| `gpt-5.4-mini` (current) | 200,000 | 500 |
| `gpt-5.4-mini-2026-03-17` | 200,000 | 500 |
| `gpt-4o-mini` | 200,000 | 500 |
| org **Default `*`** | 250,000 | 3,000 |

So it's **case (b)**: the 200K is a per-model throttle on the *newer* 5.4-mini, **not** an org-wide ceiling — `gpt-5-mini` gives **2.5×** the per-minute budget on the same key. **Switching Hermes to `gpt-5-mini` is the chosen fix.**

**Durable lesson:** never reason TPM from OpenAI's *published* per-tier tables (they're uniform within a model class) — only the project/org Limits page shows an account's real per-model cap.

## Owner directive: leave compaction at default

With 500K of headroom, lowering `compression.threshold` is unnecessary — and the owner explicitly declined it because aggressive compaction interrupts a task mid-flow (prunes context the turn still needs). The bot "can just do its tasks normally without interruption."

## Changes (docs only)

- **`hermes-control-plane.md`** — confirmed per-account caps in the comparison table; replaced the "either/or decisive test" with the ✅ confirmed result + the lesson + the decision (switch to 5-mini; compaction stays default).
- **`hermes-session-reset.md`** — the #976 "compaction is the primary lever" framing is superseded for this account: added a ✅ RESOLVED note, demoted compaction to a no-higher-cap-model fallback, reset the order of preference (model swap → `/new` → compaction-if-no-alternative).

## Verification

`python3.10 scripts/check_docs.py --strict` ✓ · no Python/scripts touched.

https://claude.ai/code/session_011Add2RPDWutS7643URURns

---
_Generated by [Claude Code](https://claude.ai/code/session_011Add2RPDWutS7643URURns)_