### PR TITLE
fix(hermes): staleness guard in install-skills.sh (stale-skill root cause)

### DIFF
--- a/.sessions/2026-06-16-install-skills-staleness-guard.md
+++ b/.sessions/2026-06-16-install-skills-staleness-guard.md
@@ -1,6 +1,6 @@
 # 2026-06-16 — install-skills.sh staleness guard (stale-skill root cause)
 
-> **Status:** `in-progress` — third small PR this session. Bash-only; one push.
+> **Status:** `complete` — third small PR this session (#981). Bash-only.
 > Session enders (Q-0089 idea, Q-0102 review, Q-0104 audit) were satisfied in this session's first
 > card (`2026-06-16-model-comparison-gpt5mini.md`, merged in #978) — not repeated here.
 

--- a/.sessions/2026-06-16-install-skills-staleness-guard.md
+++ b/.sessions/2026-06-16-install-skills-staleness-guard.md
@@ -1,0 +1,33 @@
+# 2026-06-16 — install-skills.sh staleness guard (stale-skill root cause)
+
+> **Status:** `in-progress` — third small PR this session. Bash-only; one push.
+> Session enders (Q-0089 idea, Q-0102 review, Q-0104 audit) were satisfied in this session's first
+> card (`2026-06-16-model-comparison-gpt5mini.md`, merged in #978) — not repeated here.
+
+## Why
+
+After the owner switched Hermes to `gpt-5-mini` (the 500K-TPM fix — confirmed working), the morning
+briefing + idea spotlight ran cleanly, **but** the idea-spotlight skill reported
+`scripts/hermes/idea_spotlight.py` "missing in this checkout" and fell back to manually picking an
+idea. Diagnosis: the script **is** in `main` (added #959, `07ed7de`) and the skill self-syncs the
+checkout in its step 1 — so the real cause is the **installed SKILL.md on the VPS is stale**
+(installed from a clone that predated #959/#971). Root cause one level up: `install-skills.sh` copies
+whatever is checked out with **no staleness check**, so installing from a behind clone silently ships
+old skills (and their helper scripts can be absent).
+
+## Fix (root cause, contained, bash-only)
+
+`scripts/hermes/install-skills.sh`:
+- **`--pull`** — syncs the checkout to `origin/main` (`git fetch + checkout -B main origin/main`, the
+  same sync the skills' own step 1 uses) **before** installing, so skills + helper scripts always match.
+- **Default best-effort warning** — does a quiet `git fetch` and warns loudly if the checkout is N
+  commits behind `origin/main` ("you may install STALE skills — re-run with --pull"). Non-destructive.
+- Header documents the staleness guard + cites the 2026-06-16 incident.
+
+`bash -n` ✓ · dry-run live-verified the warning fires (correctly caught my own 2-behind checkout) and
+that `idea-spotlight` is a committed skill artifact.
+
+## Owner's immediate unblock (no repo change needed)
+
+On the VPS as `hermes`: `cd ~/repos/superbot && bash scripts/hermes/install-skills.sh --pull && sudo
+systemctl restart hermes-gateway`, then re-run the spotlight — the selector will be present.

--- a/scripts/hermes/install-skills.sh
+++ b/scripts/hermes/install-skills.sh
@@ -11,19 +11,28 @@
 # from the docs first (requires python3 in the repo).
 #
 # Usage (run on the VPS as the `hermes` user, from the repo root):
-#   bash scripts/hermes/install-skills.sh             # install
+#   bash scripts/hermes/install-skills.sh             # install (warns if the checkout is stale)
+#   bash scripts/hermes/install-skills.sh --pull      # sync to origin/main FIRST, then install
 #   bash scripts/hermes/install-skills.sh --dry-run   # show what would happen
 #   bash scripts/hermes/install-skills.sh --build      # regenerate then install
+#
+# STALENESS GUARD: this installer copies whatever SKILL.md is checked out. If the clone is behind
+# origin/main, you silently install OLD skills (and their helper scripts under scripts/hermes/ may be
+# missing) — the 2026-06-16 "idea_spotlight.py missing in this checkout" incident. By default it now
+# does a best-effort `git fetch` and WARNS if you're behind; `--pull` resets the checkout to
+# origin/main before installing so skills + helper scripts always match.
 #
 # Override the target dir with HERMES_SKILLS_DIR (default: ~/.hermes/skills).
 set -euo pipefail
 
 DRY_RUN=0
 DO_BUILD=0
+DO_PULL=0
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=1 ;;
     --build) DO_BUILD=1 ;;
+    --pull) DO_PULL=1 ;;
     -h | --help)
       sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
@@ -38,6 +47,29 @@ done
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SRC_DIR="$SCRIPT_DIR/skills"
 DEST_DIR="${HERMES_SKILLS_DIR:-$HOME/.hermes/skills}"
+
+# Staleness guard — installing from a behind clone silently ships old skills (and helper scripts
+# under scripts/hermes/ may be absent). --pull syncs to origin/main first; otherwise just warn.
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+if git -C "$REPO_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+  if [[ "$DO_PULL" -eq 1 ]]; then
+    echo "Syncing checkout to origin/main first (--pull)…"
+    if git -C "$REPO_ROOT" fetch -q origin main && git -C "$REPO_ROOT" checkout -q -B main origin/main; then
+      echo "  synced to $(git -C "$REPO_ROOT" rev-parse --short HEAD)"
+    else
+      echo "  ⚠ sync failed (uncommitted changes / network?) — installing whatever is checked out." >&2
+    fi
+    echo
+  else
+    git -C "$REPO_ROOT" fetch -q origin main 2>/dev/null || true
+    behind="$(git -C "$REPO_ROOT" rev-list --count HEAD..origin/main 2>/dev/null || echo 0)"
+    if [[ "${behind:-0}" =~ ^[0-9]+$ ]] && [[ "${behind:-0}" -gt 0 ]]; then
+      echo "⚠ checkout is $behind commit(s) behind origin/main — you may install STALE skills." >&2
+      echo "  Re-run with --pull (or 'git pull' first) so skills + their helper scripts match." >&2
+      echo
+    fi
+  fi
+fi
 
 if [[ "$DO_BUILD" -eq 1 ]]; then
   PY="$(command -v python3.10 || command -v python3 || true)"


### PR DESCRIPTION
## Why

After switching Hermes to `gpt-5-mini` (the 500K-TPM fix — **confirmed working**, briefing + spotlight ran clean), the idea-spotlight skill reported `scripts/hermes/idea_spotlight.py` **"missing in this checkout"** and fell back to manually picking an idea.

Diagnosis: the script **is** in `main` (added in #959, `07ed7de`) and the skill self-syncs the checkout in its own step 1 — so the real cause is the **installed SKILL.md on the VPS is stale** (installed from a clone predating #959/#971). Root cause one level up: **`install-skills.sh` copies whatever is checked out with no staleness check**, so installing from a behind clone silently ships old skills (and their helper scripts can be absent).

## Fix (contained, bash-only)

`scripts/hermes/install-skills.sh`:
- **`--pull`** — syncs the checkout to `origin/main` (`git fetch && git checkout -B main origin/main`, the same sync the skills' step 1 uses) **before** installing, so skills + helper scripts always match.
- **Default best-effort warning** — quiet `git fetch`, then a loud warning if the checkout is N commits behind `origin/main` ("you may install STALE skills — re-run with --pull"). Non-destructive.
- Header documents the guard + cites the 2026-06-16 incident.

## Verification

- `bash -n` ✓
- Dry-run **live-verified**: the warning correctly fired on my own 2-behind checkout, and confirmed `idea-spotlight` is a committed skill artifact.
- No Python touched.

## Owner's immediate unblock (no repo change needed)

On the VPS as `hermes`:
```bash
cd ~/repos/superbot && bash scripts/hermes/install-skills.sh --pull && sudo systemctl restart hermes-gateway
```
then re-run the spotlight — the selector will be present.

https://claude.ai/code/session_011Add2RPDWutS7643URURns

---
_Generated by [Claude Code](https://claude.ai/code/session_011Add2RPDWutS7643URURns)_