### PR TITLE
feat(dashboard): /aliases — suggest a command alias

### DIFF
--- a/.sessions/2026-06-16-dashboard-aliases.md
+++ b/.sessions/2026-06-16-dashboard-aliases.md
@@ -1,0 +1,59 @@
+# Session — Dashboard: `/aliases` command-alias suggestion page
+
+> **Status:** `complete`
+
+## Origin
+
+Owner: *"a function that lets me suggest aliases for the commands, possibly editing them straight into
+the bot as well."*
+
+## Finding (what the bot does today)
+
+True `aliases=[...]` are hardcoded per command, **but** there's a clean soft-alias layer:
+`COMMAND_SYNONYMS` in `disbot/utils/synonyms.py` — one dict (canonical command → synonyms) resolved
+by one function (`find_command`) on the command-not-found path. That single dict + resolver is the
+**cleanest seam in the bot** for editing aliases live (cleaner than help overlays or panels — it's a
+soft layer, so no command re-registration and no per-guild state are required).
+
+## What shipped (this PR)
+
+The **suggest** half — the primary ask — as a decoupled, client-side page:
+
+- **`/aliases`** (`dashboard/templates/aliases.html`): pick a command (datalist of all 301) → propose
+  an alias → a **live collision check** against every command name, alias, and synonym (the route
+  builds a `taken` token→owner map so it says *why* a collision fails) → a **prefilled GitHub issue**
+  + a **paste-ready `synonyms.py` snippet** (with the command's existing synonyms pre-merged). No
+  backend, no auth — pure client-side, so it ships now.
+- **`scripts/scan_synonyms.py`** (stdlib AST) reads `COMMAND_SYNONYMS` (87 synonyms over 30 commands);
+  wired into `export_dashboard_data.py` (+ `synonyms` count) and the page's collision data.
+- Route + nav + tests (`test_scan_synonyms.py`, smoke `/aliases`).
+
+The page states the two tiers honestly: this **suggests** (snippet → `synonyms.py` edit → next deploy
+= "into the bot"); **instant live editing** is the next step and reuses the live-editor control API.
+
+## Scanner bug found + fixed
+
+`scan_synonyms` first returned 0 — `COMMAND_SYNONYMS` uses the **annotated** form
+(`COMMAND_SYNONYMS: dict[...] = {...}` → `ast.AnnAssign`), and the scanner only matched `ast.Assign`.
+Fixed to handle both (the `subsystem_registry` scanner already does this — a reusable lesson:
+**top-level dicts that carry a type annotation are `AnnAssign`, not `Assign`**).
+
+## Verification
+
+- `python3.10 -m pytest tests/unit/scripts/test_scan_synonyms.py tests/unit/scripts/test_export_dashboard_data.py`
+  → **green**; `scan_synonyms.py` → 87 synonyms / 30 commands.
+- Dashboard smoke **with deps installed** (the #979 lesson, now applied):
+  `python3.10 -m pytest tests/unit/dashboard/test_app.py` → **15 passed** (`/aliases` renders + form data present).
+- `python3.10 scripts/check_quality.py --check-only` → green.
+
+**Merge ≠ deploy:** the dashboard auto-redeploys on merge; `/aliases` goes live after the redeploy.
+
+## 💡 Session idea (Q-0089)
+
+**Build the live-edit foundation on the synonym map first, before help or panels.** The live-editor
+plan (Q-0156) sequences help-text first, but `COMMAND_SYNONYMS` is a *lower-risk* first target for the
+bot control API: it's a single global dict + resolver (no per-guild overlay table, no command
+re-registration, collisions checkable against the command-surface ledger). Shipping a `synonym_overlay`
+(static defaults + DB rows the resolver consults) + the audited mutation seam would make this very page
+**apply instantly into the bot** and prove the whole live-edit pattern on the cheapest seam. Worth
+slotting as live-editor **phase L1.5** (between the read API and the help-write path).

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -13,6 +13,7 @@ and the secrets model live in
 | `/` | Showcase landing — counts + recent updates |
 | `/functions` | Bot-function catalogue (from the subsystem registry) |
 | `/commands` | **Cog & command explorer** — every cog's commands, each badged prefix/slash and whether it's button-backed (a panel action or opens a view); live search + filters (`scripts/scan_commands.py`). |
+| `/aliases` | **Suggest a command alias** — pick a command, propose an alias, get a live collision check against every command/alias/synonym, a prefilled GitHub issue, and a paste-ready `synonyms.py` snippet (`scripts/scan_synonyms.py`). Client-side; no backend yet. |
 | `/settings` | **Settings catalogue** — every per-guild setting key the bot exposes, grouped by owning subsystem, with live filter. Key names only, never stored values (`scripts/scan_settings.py`). |
 | `/access` | **Permissions & access map** — the visibility-tier ladder + which subsystems each tier can see. A faithful static mirror of `disbot/utils/visibility_rules.py` (`scripts/scan_access.py`). Visibility, **not** execution. |
 | `/ideas` | Idea backlog (from `docs/ideas/`) |

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -34,6 +34,7 @@ _EMPTY: dict[str, Any] = {
     "env_usage": [],
     "settings": [],
     "access": {"tiers": [], "total_visible": 0, "internal_count": 0},
+    "synonyms": [],
 }
 
 app = FastAPI(title="SuperBot Dashboard", docs_url=None, redoc_url=None)
@@ -135,6 +136,41 @@ def access(request: Request):
         request,
         "access.html",
         {"data": load_data(), "page": "access"},
+    )
+
+
+@app.get("/aliases", response_class=HTMLResponse)
+def aliases(request: Request):
+    """Suggest a command alias — pick a command, propose an alias, get a live
+    collision check (against every command name, alias, and synonym) plus a
+    prefilled GitHub issue and a ready-to-paste ``synonyms.py`` snippet.
+    """
+    data = load_data()
+    commands_list = sorted(
+        {c["name"] for cog in data.get("cogs", []) for c in cog["commands"]},
+    )
+    # Map every token already in use -> what owns it, so the suggestion form can
+    # say *why* a proposed alias collides. Synonyms first, then aliases, then
+    # command names last so the strongest owner (a real command) wins a tie.
+    taken: dict[str, str] = {}
+    for syn in data.get("synonyms", []):
+        for token in syn["synonyms"]:
+            taken[token.lower()] = f"synonym of !{syn['canonical']}"
+    for cog in data.get("cogs", []):
+        for cmd in cog["commands"]:
+            for token in cmd.get("aliases") or []:
+                taken[token.lower()] = f"alias of !{cmd['name']}"
+    for name in commands_list:
+        taken[name.lower()] = "a command"
+    return templates.TemplateResponse(
+        request,
+        "aliases.html",
+        {
+            "data": data,
+            "page": "aliases",
+            "commands": commands_list,
+            "taken": taken,
+        },
     )
 
 

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "generated_at": "2026-06-16T18:32:42Z",
+    "generated_at": "2026-06-16T19:00:19Z",
     "counts": {
       "functions": 33,
       "ideas": 72,
@@ -11,7 +11,8 @@
       "commands": 301,
       "setting_keys": 83,
       "setting_domains": 13,
-      "visible_subsystems": 33
+      "visible_subsystems": 33,
+      "synonyms": 87
     }
   },
   "catalogue": [
@@ -1503,6 +1504,12 @@
       "status": "complete"
     },
     {
+      "file": "2026-06-16-model-comparison-gpt5mini.md",
+      "date": "2026-06-16",
+      "title": "2026-06-16 — gpt-5-mini vs gpt-5.4-mini comparison + apply_context_fixes --set-model fix",
+      "status": "complete"
+    },
+    {
       "file": "2026-06-16-ledger-reconcile-932-939.md",
       "date": "2026-06-16",
       "title": "Session — ledger reconcile (#932–#936, #939 into current-state)",
@@ -1596,6 +1603,18 @@
       "file": "2026-06-16-developer-dashboard-mvp.md",
       "date": "2026-06-16",
       "title": "Session — Developer dashboard (personal website) — design + read-only MVP",
+      "status": "complete"
+    },
+    {
+      "file": "2026-06-16-dashboard-settings-fix.md",
+      "date": "2026-06-16",
+      "title": "Session — hotfix: /settings 500 (Jinja `domain.keys` → dict-method collision)",
+      "status": "complete"
+    },
+    {
+      "file": "2026-06-16-dashboard-settings-access.md",
+      "date": "2026-06-16",
+      "title": "Session — Dashboard: settings + access pages, and the live help-editor plan",
       "status": "complete"
     },
     {
@@ -1788,24 +1807,6 @@
       "file": "2026-06-15-mining-home-slice-c.md",
       "date": "2026-06-15",
       "title": "Session — 2026-06-15 · mining Slice C — the Home structure (character-card backdrop)",
-      "status": "complete"
-    },
-    {
-      "file": "2026-06-15-mining-forge-slice-b.md",
-      "date": "2026-06-15",
-      "title": "Session: Mining Slice B — the Forge structure (gear-tier crafting gate)",
-      "status": "complete"
-    },
-    {
-      "file": "2026-06-15-merge-routine-prompts.md",
-      "date": "2026-06-15",
-      "title": "Session: Merge dispatch + night-executor into one routine prompt (2 total)",
-      "status": "complete"
-    },
-    {
-      "file": "2026-06-15-manual-test-bugfixes.md",
-      "date": "2026-06-15",
-      "title": "Session — manual-test bug fixes (counting channel UX · BTD6 overview clutter · round-63 data)",
       "status": "complete"
     }
   ],
@@ -6851,5 +6852,244 @@
     ],
     "total_visible": 33,
     "internal_count": 0
-  }
+  },
+  "synonyms": [
+    {
+      "canonical": "assignroles",
+      "synonyms": [
+        "updateroles",
+        "roleupdate"
+      ]
+    },
+    {
+      "canonical": "avatar",
+      "synonyms": [
+        "pfp",
+        "bild"
+      ]
+    },
+    {
+      "canonical": "ban",
+      "synonyms": [
+        "bannieren",
+        "banish",
+        "sperren"
+      ]
+    },
+    {
+      "canonical": "blackjack",
+      "synonyms": [
+        "bj",
+        "21",
+        "cards",
+        "cardgame"
+      ]
+    },
+    {
+      "canonical": "cleanuphistory",
+      "synonyms": [
+        "cleanhistory",
+        "bereinigen"
+      ]
+    },
+    {
+      "canonical": "clear",
+      "synonyms": [
+        "purge",
+        "clean",
+        "delete",
+        "löschen"
+      ]
+    },
+    {
+      "canonical": "createrole",
+      "synonyms": [
+        "newrole",
+        "addrole",
+        "makerole"
+      ]
+    },
+    {
+      "canonical": "deleterole",
+      "synonyms": [
+        "removerole",
+        "rmrole"
+      ]
+    },
+    {
+      "canonical": "givexp",
+      "synonyms": [
+        "addxp",
+        "grantxp"
+      ]
+    },
+    {
+      "canonical": "help",
+      "synonyms": [
+        "hilfe",
+        "commands",
+        "cmds",
+        "cmd",
+        "befehle"
+      ]
+    },
+    {
+      "canonical": "invite",
+      "synonyms": [
+        "einladen"
+      ]
+    },
+    {
+      "canonical": "kick",
+      "synonyms": [
+        "rauswerfen",
+        "boot",
+        "entfernen"
+      ]
+    },
+    {
+      "canonical": "leaderboard",
+      "synonyms": [
+        "top",
+        "rankings",
+        "scores",
+        "highscore",
+        "highscores",
+        "scoreboard"
+      ]
+    },
+    {
+      "canonical": "loglevel",
+      "synonyms": [
+        "loglvl",
+        "setloglevel"
+      ]
+    },
+    {
+      "canonical": "poll",
+      "synonyms": [
+        "vote",
+        "abstimmung",
+        "umfrage"
+      ]
+    },
+    {
+      "canonical": "rank",
+      "synonyms": [
+        "level",
+        "lvl",
+        "xp",
+        "stats",
+        "score",
+        "myscore",
+        "mrank",
+        "myrank",
+        "progres",
+        "progress"
+      ]
+    },
+    {
+      "canonical": "remind",
+      "synonyms": [
+        "reminder",
+        "remindme",
+        "erinnerung"
+      ]
+    },
+    {
+      "canonical": "resetxp",
+      "synonyms": [
+        "clearxp"
+      ]
+    },
+    {
+      "canonical": "restart",
+      "synonyms": [
+        "reboot",
+        "restar"
+      ]
+    },
+    {
+      "canonical": "roles",
+      "synonyms": [
+        "rolelist",
+        "listroles"
+      ]
+    },
+    {
+      "canonical": "rolesettings",
+      "synonyms": [
+        "roleconfig",
+        "rolethresholds"
+      ]
+    },
+    {
+      "canonical": "rps",
+      "synonyms": [
+        "rockpaperscissors",
+        "rock",
+        "schere",
+        "stein",
+        "papier"
+      ]
+    },
+    {
+      "canonical": "serverinfo",
+      "synonyms": [
+        "sinfo"
+      ]
+    },
+    {
+      "canonical": "serverstats",
+      "synonyms": [
+        "serverstat",
+        "serv"
+      ]
+    },
+    {
+      "canonical": "timeout",
+      "synonyms": [
+        "mute",
+        "stumm",
+        "stumschalten"
+      ]
+    },
+    {
+      "canonical": "unban",
+      "synonyms": [
+        "entbannen"
+      ]
+    },
+    {
+      "canonical": "userinfo",
+      "synonyms": [
+        "uinfo",
+        "whois",
+        "user"
+      ]
+    },
+    {
+      "canonical": "warn",
+      "synonyms": [
+        "warning",
+        "verwarnen"
+      ]
+    },
+    {
+      "canonical": "word",
+      "synonyms": [
+        "addword",
+        "removeword",
+        "prohibit",
+        "blockword",
+        "wordlist"
+      ]
+    },
+    {
+      "canonical": "xpconfig",
+      "synonyms": [
+        "xpsettings"
+      ]
+    }
+  ]
 }

--- a/dashboard/templates/aliases.html
+++ b/dashboard/templates/aliases.html
@@ -1,0 +1,117 @@
+{% extends "base.html" %}
+{% block title %}Suggest an alias — SuperBot{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-1">Suggest a command alias</h1>
+<p class="text-slate-400 mb-4 text-sm">
+  Pick a command and propose an alias (a "synonym" that resolves to it). The form checks your
+  suggestion against every existing command, alias, and synonym
+  ({{ data.synonyms | length }} commands already have synonyms), then gives you a one-click GitHub
+  issue and a paste-ready snippet.
+</p>
+<p class="text-slate-500 mb-6 text-xs rounded border border-slate-800 bg-slate-900/50 px-3 py-2">
+  💡 Today this <strong>suggests</strong> — the snippet edits
+  <code>disbot/utils/synonyms.py</code> (<code>COMMAND_SYNONYMS</code>), which reaches the live bot on
+  the next deploy. <strong>Editing aliases into the bot instantly</strong> (no deploy) is the next
+  step — it reuses the live-editor control API, and the synonym map is its cleanest target
+  (<code>docs/planning/dashboard-live-editor-plan.md</code>).
+</p>
+
+<div class="rounded-xl border border-slate-800 bg-slate-900/50 p-4 sm:p-5">
+  <div class="grid gap-4 sm:grid-cols-2">
+    <label class="block">
+      <span class="text-xs text-slate-400">Command</span>
+      <input id="cmd" list="cmd-list" autocomplete="off" placeholder="e.g. leaderboard"
+        class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none" />
+      <datalist id="cmd-list">
+        {% for c in commands %}<option value="{{ c }}"></option>{% endfor %}
+      </datalist>
+    </label>
+    <label class="block">
+      <span class="text-xs text-slate-400">Proposed alias</span>
+      <input id="alias" autocomplete="off" placeholder="e.g. lb"
+        class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none" />
+    </label>
+  </div>
+  <div id="alias-out" class="mt-4">
+    <p class="text-slate-500 text-sm">Pick a command and type a proposed alias.</p>
+  </div>
+</div>
+
+<script id="taken-data" type="application/json">{{ taken | tojson }}</script>
+<script id="syn-data" type="application/json">{{ data.synonyms | tojson }}</script>
+<script>
+  (function () {
+    const taken = JSON.parse(document.getElementById("taken-data").textContent);
+    const synMap = {};
+    JSON.parse(document.getElementById("syn-data").textContent).forEach((s) => {
+      synMap[s.canonical] = s.synonyms;
+    });
+    const REPO = "menno420/superbot";
+    const cmdInput = document.getElementById("cmd");
+    const aliasInput = document.getElementById("alias");
+    const out = document.getElementById("alias-out");
+
+    function esc(s) {
+      return String(s).replace(/[&<>"']/g, (c) =>
+        ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]),
+      );
+    }
+    function note(kind, text) {
+      const cls =
+        kind === "error"
+          ? "border-rose-900/60 bg-rose-950/40 text-rose-300"
+          : "border-emerald-900/60 bg-emerald-950/40 text-emerald-300";
+      return '<p class="rounded border ' + cls + ' px-3 py-2 text-sm">' + esc(text) + "</p>";
+    }
+    function render() {
+      const cmd = (cmdInput.value || "").trim().replace(/^[!\/]/, "");
+      const alias = (aliasInput.value || "").trim().toLowerCase();
+      if (!cmd || !alias) {
+        out.innerHTML = '<p class="text-slate-500 text-sm">Pick a command and type a proposed alias.</p>';
+        return;
+      }
+      if (/\s/.test(alias)) {
+        out.innerHTML = note("error", "Aliases can't contain spaces.");
+        return;
+      }
+      const owner = taken[alias];
+      if (owner) {
+        out.innerHTML = note("error", "“" + alias + "” is already " + owner + ".");
+        return;
+      }
+      const existing = synMap[cmd] || [];
+      const updated = existing.concat([alias]);
+      const snippet = '"' + cmd + '": [' + updated.map((s) => '"' + s + '"').join(", ") + "],";
+      const title = "Alias suggestion: !" + cmd + " → " + alias;
+      const body = [
+        "**Command:** `!" + cmd + "`",
+        "**Proposed alias:** `" + alias + "`",
+        "",
+        "Add to `disbot/utils/synonyms.py` (`COMMAND_SYNONYMS`):",
+        "```python",
+        snippet,
+        "```",
+        "",
+        "_Suggested via the dashboard /aliases page._",
+      ].join("\n");
+      const url =
+        "https://github.com/" + REPO + "/issues/new?labels=alias-suggestion&title=" +
+        encodeURIComponent(title) + "&body=" + encodeURIComponent(body);
+      const current = existing.length
+        ? '<p class="mt-2 text-xs text-slate-500">Current synonyms for !' + esc(cmd) + ": " +
+          existing.map(esc).join(", ") + "</p>"
+        : "";
+      out.innerHTML =
+        note("ok", "“" + alias + "” is free — no command, alias, or synonym uses it.") +
+        current +
+        '<div class="mt-3"><a target="_blank" rel="noopener" class="inline-block rounded bg-sky-600 hover:bg-sky-500 px-3 py-1.5 text-sm font-medium" href="' +
+        url + '">Open a prefilled GitHub issue →</a></div>' +
+        '<p class="mt-3 text-xs text-slate-400">Or paste this into <code>disbot/utils/synonyms.py</code>:</p>' +
+        '<pre class="mt-1 overflow-x-auto rounded bg-slate-950 border border-slate-800 p-3 text-xs text-slate-200"><code>' +
+        esc(snippet) + "</code></pre>";
+    }
+    cmdInput.addEventListener("input", render);
+    aliasInput.addEventListener("input", render);
+  })();
+</script>
+{% endblock %}

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -14,7 +14,7 @@
     <header class="border-b border-slate-800 bg-slate-900/70 backdrop-blur sticky top-0 z-10">
       <nav class="mx-auto max-w-5xl px-4 py-3 flex flex-wrap items-center gap-x-5 gap-y-2">
         <a href="/" class="font-bold text-lg mr-2">🤖 SuperBot</a>
-        {% set nav_items = [('functions', 'Functions'), ('commands', 'Commands'), ('settings', 'Settings'), ('access', 'Access'), ('ideas', 'Ideas'), ('bugs', 'Bugs'), ('updates', 'Updates'), ('env', 'Env map')] %}
+        {% set nav_items = [('functions', 'Functions'), ('commands', 'Commands'), ('aliases', 'Aliases'), ('settings', 'Settings'), ('access', 'Access'), ('ideas', 'Ideas'), ('bugs', 'Bugs'), ('updates', 'Updates'), ('env', 'Env map')] %}
         {% for key, label in nav_items %}
           <a
             href="/{{ key }}"

--- a/scripts/export_dashboard_data.py
+++ b/scripts/export_dashboard_data.py
@@ -323,6 +323,12 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
         if registry_path.exists()
         else {"tiers": [], "total_visible": 0, "internal_count": 0}
     )
+    synonyms_path = repo_root / "disbot" / "utils" / "synonyms.py"
+    synonyms = (
+        _load_sibling("scan_synonyms.py", "scan_synonyms")(path=synonyms_path)
+        if synonyms_path.exists()
+        else []
+    )
 
     return {
         "meta": {
@@ -340,6 +346,7 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
                 "setting_keys": sum(len(d["keys"]) for d in settings),
                 "setting_domains": len(settings),
                 "visible_subsystems": access.get("total_visible", 0),
+                "synonyms": sum(len(s["synonyms"]) for s in synonyms),
             },
         },
         "catalogue": catalogue,
@@ -350,6 +357,7 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
         "cogs": cogs,
         "settings": settings,
         "access": access,
+        "synonyms": synonyms,
     }
 
 

--- a/scripts/scan_synonyms.py
+++ b/scripts/scan_synonyms.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3.10
+"""Scan the bot's command-synonym map into a catalogue (stdlib only, read-only).
+
+The bot resolves "soft" command aliases through a single dict,
+``COMMAND_SYNONYMS`` in ``disbot/utils/synonyms.py`` (canonical command name →
+the synonyms that resolve to it on the command-not-found path, via
+``find_command``). The developer dashboard's **alias-suggestion** page
+(`/aliases`) needs this map so it can show what already resolves and reject a
+suggestion that collides with an existing synonym.
+
+This scanner ``literal_eval``s that dict (it is all string literals) and emits::
+
+    [{"canonical": "help", "synonyms": ["hilfe", "commands", "cmds", ...]}, ...]
+
+Pure stdlib so it runs in CI with no extra dependencies, mirroring the other
+``scripts/scan_*.py`` seams (which ``scripts/export_dashboard_data.py`` embeds in
+``dashboard/data/dashboard.json``).
+
+Run standalone::
+
+    python3.10 scripts/scan_synonyms.py            # human-readable summary
+    python3.10 scripts/scan_synonyms.py --json     # the raw JSON payload
+
+Reliability (Q-0105): **unverified** — confirm the map against
+``disbot/utils/synonyms.py`` a few times across sessions before trusting it, and
+delete this seam if it proves unreliable. Convenience generator, not runtime code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SYNONYMS = REPO_ROOT / "disbot" / "utils" / "synonyms.py"
+
+
+def scan_synonyms(path: Path = DEFAULT_SYNONYMS) -> list[dict]:
+    """Return the ``COMMAND_SYNONYMS`` map as canonical→synonyms records."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError):
+        return []
+    for node in ast.walk(tree):
+        # ``COMMAND_SYNONYMS = {...}`` (Assign) or the annotated
+        # ``COMMAND_SYNONYMS: dict[...] = {...}`` (AnnAssign) form.
+        value: ast.expr | None = None
+        if (
+            isinstance(node, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == "COMMAND_SYNONYMS"
+                for t in node.targets
+            )
+            or (
+                isinstance(node, ast.AnnAssign)
+                and isinstance(node.target, ast.Name)
+                and node.target.id == "COMMAND_SYNONYMS"
+            )
+        ):
+            value = node.value
+        if value is not None:
+            try:
+                mapping = ast.literal_eval(value)
+            except (ValueError, TypeError, SyntaxError):
+                return []
+            if not isinstance(mapping, dict):
+                return []
+            return [
+                {"canonical": str(canonical), "synonyms": [str(s) for s in syns]}
+                for canonical, syns in sorted(mapping.items())
+                if isinstance(syns, (list, tuple))
+            ]
+    return []
+
+
+def _format_summary(records: list[dict]) -> str:
+    """Render a short human-readable map for the CLI."""
+    total = sum(len(r["synonyms"]) for r in records)
+    lines = [f"{total} synonym(s) over {len(records)} command(s):\n"]
+    for record in records:
+        lines.append(f"  {record['canonical']:<16} ← {', '.join(record['synonyms'])}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: print the synonym map (summary / JSON)."""
+    parser = argparse.ArgumentParser(
+        description="Scan the bot's COMMAND_SYNONYMS map (read-only).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="print the raw JSON payload instead of the human summary",
+    )
+    args = parser.parse_args(argv)
+
+    records = scan_synonyms()
+    if args.json:
+        print(json.dumps(records, indent=2, ensure_ascii=False))
+    else:
+        print(_format_summary(records))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/dashboard/test_app.py
+++ b/tests/unit/dashboard/test_app.py
@@ -38,6 +38,7 @@ def client():
         "/",
         "/functions",
         "/commands",
+        "/aliases",
         "/settings",
         "/access",
         "/ideas",
@@ -50,6 +51,15 @@ def test_pages_render(client, path):
     resp = client.get(path)
     assert resp.status_code == 200
     assert "SuperBot" in resp.text
+
+
+def test_aliases_page_renders_suggestion_form(client):
+    resp = client.get("/aliases")
+    assert resp.status_code == 200
+    # The form + the embedded collision data the JS needs.
+    assert "Suggest a command alias" in resp.text
+    assert 'id="taken-data"' in resp.text
+    assert 'id="cmd-list"' in resp.text
 
 
 def test_settings_page_lists_a_known_key(client):

--- a/tests/unit/scripts/test_scan_synonyms.py
+++ b/tests/unit/scripts/test_scan_synonyms.py
@@ -1,0 +1,67 @@
+"""Tests for ``scripts/scan_synonyms.py`` — the command-synonym map scanner.
+
+Loaded via ``importlib`` (the repo convention for ``scripts/`` modules). Pure
+stdlib, so it runs in CI with no extra dependencies.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "scan_synonyms.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("scan_synonyms_ut", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# The real module uses the *annotated* form, so it must be covered.
+ANNOTATED = '''
+from __future__ import annotations
+
+COMMAND_SYNONYMS: dict[str, list[str]] = {
+    "help": ["hilfe", "commands"],
+    "rank": ["lvl", "xp"],
+}
+'''
+
+PLAIN = '''
+COMMAND_SYNONYMS = {"ban": ["sperren"]}
+'''
+
+
+def _write(tmp_path: Path, source: str) -> Path:
+    path = tmp_path / "synonyms.py"
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def test_scan_synonyms_handles_annotated_assignment(mod, tmp_path):
+    records = mod.scan_synonyms(_write(tmp_path, ANNOTATED))
+    by_canon = {r["canonical"]: r["synonyms"] for r in records}
+    assert by_canon == {"help": ["hilfe", "commands"], "rank": ["lvl", "xp"]}
+
+
+def test_scan_synonyms_handles_plain_assignment(mod, tmp_path):
+    records = mod.scan_synonyms(_write(tmp_path, PLAIN))
+    assert records == [{"canonical": "ban", "synonyms": ["sperren"]}]
+
+
+def test_scan_synonyms_real_repo(mod):
+    records = mod.scan_synonyms()
+    by_canon = {r["canonical"]: r["synonyms"] for r in records}
+    # The real COMMAND_SYNONYMS is populated and uses the annotated form.
+    assert len(records) >= 20
+    assert "lb" not in by_canon  # canonical keys are command names, not aliases
+    assert "bj" in by_canon.get("blackjack", [])


### PR DESCRIPTION
## Why

Owner: *"a function that lets me suggest aliases for the commands, possibly editing them straight into
the bot as well."* This ships the **suggest** half (the primary ask) now, and tees up live editing.

## Finding

True `aliases=[...]` are hardcoded per command, but there's a clean soft-alias layer:
**`COMMAND_SYNONYMS`** in `disbot/utils/synonyms.py` — one dict (canonical command → synonyms),
resolved by one function on the command-not-found path. That single dict + resolver is the **cleanest
seam in the bot** for editing aliases live (no per-guild state, no command re-registration).

## What

- **`/aliases`** page (client-side, decoupled): pick a command (datalist of all 301) → propose an
  alias → a **live collision check** against every command name, alias, and synonym (the route maps
  each taken token to its owner, so it says *why* a collision fails) → a **prefilled GitHub issue** +
  a **paste-ready `synonyms.py` snippet** (the command's existing synonyms pre-merged). No backend.
- **`scripts/scan_synonyms.py`** (stdlib AST) reads `COMMAND_SYNONYMS` (**87 synonyms / 30 commands**),
  handling both the plain and **annotated (`AnnAssign`)** assignment forms; wired into the export +
  the page's collision data.
- Route, nav, README row, and tests (`test_scan_synonyms.py` + smoke `/aliases`).

The page is honest about scope: it **suggests** (snippet → `synonyms.py` edit → next deploy = "into
the bot"). **Instant live editing** is the next step — it reuses the live-editor control API
(`docs/planning/dashboard-live-editor-plan.md`), with the synonym map as its cleanest first target
(filed as the session idea).

## Verification

- `scan_synonyms.py` → 87 synonyms / 30 commands; scanner + export tests green.
- Dashboard smoke **with deps installed** (the #979 lesson applied): `pytest tests/unit/dashboard/` →
  **15 passed** (`/aliases` renders + form data present).
- `python3.10 scripts/check_quality.py --check-only` → green.

https://claude.ai/code/session_014f52sCSiw4UAmHxxCP7DWV

---
_Generated by [Claude Code](https://claude.ai/code/session_014f52sCSiw4UAmHxxCP7DWV)_