### PR TITLE
feat(dashboard): /games showcase + settings-editor design (global + per-server)

### DIFF
--- a/.sessions/2026-06-16-dashboard-games-settings-design.md
+++ b/.sessions/2026-06-16-dashboard-games-settings-design.md
@@ -1,0 +1,59 @@
+# Session — Dashboard: `/games` showcase + settings-editor design (global + per-server)
+
+> **Status:** `complete`
+
+## Origin
+
+Continuing the website. Owner: *"yes go ahead [with the games & economy showcase], would it also be
+possible to edit the settings from the website? It's fine if that triggers a redeploy, and as bot
+owner let me change things globally as well as per-server."*
+
+## What shipped (this PR)
+
+**`/games` — games & economy showcase** (the last of the four read-only surfaces from Q-0156). A new
+route + template that groups the **games / economy / progression** subsystems from the existing
+`data.catalogue` (emoji, description, capabilities, play commands, tier) and lists their tunable
+setting keys — **no new scanner, no regen** (reuses data already in `dashboard.json`). Nav + smoke
+test (`/games`) added.
+
+## Settings-editor design (answers the owner's question — recorded, not yet built)
+
+Researched the settings model: `utils/db/settings.py` is a per-guild KV store
+(`get_setting(guild_id, key, default)`); **defaults are scattered at call sites, there is no global
+layer** — but `core/runtime/feature_flags.py` already resolves **per-guild → global → default**, the
+exact shape to mirror. Design recorded in `docs/planning/dashboard-live-editor-plan.md`
+§ "Settings editor" + router **Q-0157**:
+
+- **Global layer** (`guild_id = 0` or a `global_settings` table) + `get_setting` →
+  per-guild → global → default (one function, hot path → focused runtime PR).
+- **Audited `settings_mutation` seam**; website (owner auth) → control API → seam with a **scope
+  picker** (global = owner-gated, per-server = admin-gated, re-checked bot-side).
+- **"Redeploy is fine"** → with the DB global layer **neither scope needs a redeploy** (applies live);
+  the redeploy/code-default path is messier (scattered defaults) and only a fallback.
+- **Prerequisite:** a **settings-metadata registry** (key → type/default/label/scope) — safe,
+  additive, and it also enriches the read-only `/settings` page. Build first.
+
+## Verification
+
+- Dashboard smoke **with deps installed**: `python3.10 -m pytest tests/unit/dashboard/test_app.py`
+  → **17 passed** (`/games` renders).
+- `python3.10 scripts/check_quality.py --check-only` → green.
+- No `disbot/` runtime touched (the settings editor is design-only this PR).
+
+**Merge ≠ deploy:** the dashboard auto-redeploys on merge; `/games` is live after the redeploy.
+
+## 💡 Session idea (Q-0089)
+
+**Make every read-only catalogue page a writable surface via one shared "edit field" component.**
+`/aliases` (suggest), the coming settings editor, and the help editor all repeat the same shape:
+show current value → propose/edit → validate (collision/type) → route to a destination (issue / PR /
+control-API). A single dashboard component (`field`, `current`, `scope`, `validator`, `sink`) would
+let any future catalogue page (`/settings`, `/access`, `/commands`) grow an edit affordance without
+re-inventing the flow — the dashboard analogue of the bot's audited-mutation seam.
+
+## Documentation audit (Q-0104)
+
+- New owner decision recorded (Q-0157) + the design has a durable home in the live-editor plan.
+- The SessionStart "7 merged PRs not in current-state" notice is the reconciliation backlog
+  (Recon DUE) — the routine's job (Q-0124), not this manually-started session's.
+- `check_quality --check-only` (incl. `check_docs`) green.

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -139,6 +139,28 @@ def access(request: Request):
     )
 
 
+@app.get("/games", response_class=HTMLResponse)
+def games(request: Request):
+    """Player-facing showcase — games, economy, and progression subsystems."""
+    data = load_data()
+    wanted = ("games", "economy", "progression")
+    by_cat: dict[str, list[dict]] = {}
+    for entry in data.get("catalogue", []):
+        if entry.get("category") in wanted:
+            by_cat.setdefault(entry["category"], []).append(entry)
+    groups = [(cat, by_cat[cat]) for cat in wanted if cat in by_cat]
+    tunables = [
+        domain
+        for domain in data.get("settings", [])
+        if domain["domain"] in ("games", "economy", "xp")
+    ]
+    return templates.TemplateResponse(
+        request,
+        "games.html",
+        {"data": data, "page": "games", "groups": groups, "tunables": tunables},
+    )
+
+
 @app.get("/aliases", response_class=HTMLResponse)
 def aliases(request: Request):
     """Suggest a command alias — pick a command, propose an alias, get a live

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -14,7 +14,7 @@
     <header class="border-b border-slate-800 bg-slate-900/70 backdrop-blur sticky top-0 z-10">
       <nav class="mx-auto max-w-5xl px-4 py-3 flex flex-wrap items-center gap-x-5 gap-y-2">
         <a href="/" class="font-bold text-lg mr-2">🤖 SuperBot</a>
-        {% set nav_items = [('functions', 'Functions'), ('commands', 'Commands'), ('aliases', 'Aliases'), ('settings', 'Settings'), ('access', 'Access'), ('ideas', 'Ideas'), ('bugs', 'Bugs'), ('updates', 'Updates'), ('env', 'Env map')] %}
+        {% set nav_items = [('functions', 'Functions'), ('games', 'Games'), ('commands', 'Commands'), ('aliases', 'Aliases'), ('settings', 'Settings'), ('access', 'Access'), ('ideas', 'Ideas'), ('bugs', 'Bugs'), ('updates', 'Updates'), ('env', 'Env map')] %}
         {% for key, label in nav_items %}
           <a
             href="/{{ key }}"

--- a/dashboard/templates/games.html
+++ b/dashboard/templates/games.html
@@ -1,0 +1,65 @@
+{% extends "base.html" %}
+{% block title %}Games &amp; economy — SuperBot{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-1">Games &amp; economy</h1>
+<p class="text-slate-400 mb-6 text-sm">
+  The player-facing side of the bot — games, the coin economy, and XP progression, generated from the
+  live subsystem registry.
+</p>
+
+{% for category, entries in groups %}
+  <section class="mb-8">
+    <h2 class="text-xs uppercase tracking-wide text-sky-400 mb-3">{{ category }}</h2>
+    <div class="grid sm:grid-cols-2 gap-3">
+      {% for e in entries %}
+        <div class="rounded-xl border border-slate-800 bg-slate-900/50 p-4">
+          <div class="flex items-center gap-2">
+            <span class="text-2xl">{{ e.emoji or "🎮" }}</span>
+            <span class="font-semibold">{{ e.display_name or e.key }}</span>
+            {% if e.visibility_tier %}
+              <span class="ml-auto text-[10px] uppercase rounded bg-slate-800 px-2 py-0.5 text-slate-400">{{ e.visibility_tier }}</span>
+            {% endif %}
+          </div>
+          {% if e.description %}<p class="mt-2 text-sm text-slate-400">{{ e.description }}</p>{% endif %}
+          {% if e.entry_points %}
+            <p class="mt-2 text-xs text-slate-500">
+              play:
+              {% for c in e.entry_points %}<code class="text-sky-300">!{{ c }}</code>{% if not loop.last %} · {% endif %}{% endfor %}
+            </p>
+          {% endif %}
+          {% if e.capabilities %}
+            <div class="mt-2 flex flex-wrap gap-1">
+              {% for cap in e.capabilities %}
+                <span class="text-[10px] rounded bg-slate-800 text-slate-400 px-1.5 py-0.5">{{ cap }}</span>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </div>
+      {% endfor %}
+    </div>
+  </section>
+{% else %}
+  <p class="text-slate-500">No games or economy subsystems found.</p>
+{% endfor %}
+
+{% if tunables %}
+  <section class="mt-10">
+    <h2 class="text-xs uppercase tracking-wide text-sky-400 mb-3">Tunable settings</h2>
+    <p class="text-slate-500 text-xs mb-3">
+      Per-server knobs for these subsystems (key names only — see <a class="underline hover:text-slate-300" href="/settings">Settings</a>).
+    </p>
+    <div class="grid gap-2 sm:grid-cols-3">
+      {% for domain in tunables %}
+        <div class="rounded-lg border border-slate-800 bg-slate-900/50 p-3">
+          <div class="text-sm font-semibold text-sky-300">{{ domain.domain }}</div>
+          <ul class="mt-1 space-y-0.5">
+            {% for k in domain['keys'] %}
+              <li class="text-[11px] text-slate-400 font-mono">{{ k.key }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endfor %}
+    </div>
+  </section>
+{% endif %}
+{% endblock %}

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -5918,3 +5918,30 @@ usage-map + Railway management; multi-AI control board) remain in the plan.
 **Home:** [`docs/planning/dashboard-live-editor-plan.md`](../planning/dashboard-live-editor-plan.md)
 (architecture + phased build L0–L3) · `services/help_overlay_mutation.py` (the seam it fronts) ·
 `views/help/editor.py` (the in-Discord editor it mirrors) · this Q-block.
+
+### Q-0157 — Edit settings from the website: global (owner) + per-server scopes (2026-06-16)
+
+> **DECISION 2026-06-16 (owner-directed in-session).** Owner: *"would it be possible to edit the
+> settings from the website? It's fine if that has to trigger a redeploy. As bot owner give me the
+> option to change things globally instead of only for the server, as well as a per-server option if
+> available."* Recorded for provenance; the bot-side half touches the hot settings path, so it's
+> designed first and built as a focused runtime PR.
+
+**Decisions / findings:**
+
+- **Both scopes wanted:** a **global** (bot-owner, all-servers) default **and** a **per-server**
+  override. Per-server already exists (`guild_settings` KV); the **global layer is new**.
+- **Design (mirrors `feature_flags` per-guild → global → default):** add a global row space
+  (`guild_id = 0` or a `global_settings` table); change `get_setting` resolution to
+  per-guild → global → caller default (one function, hot path → focused runtime PR); an audited
+  `settings_mutation` seam; the website (owner auth) edits via the control API with a scope picker
+  (global = owner-gated, per-server = admin-gated, re-checked bot-side).
+- **"Redeploy is fine"** → with the DB global layer, **neither scope needs a redeploy** (it applies
+  live); the redeploy path is only relevant to the code-default fallback, which is messier.
+- **Prerequisite:** a **settings-metadata registry** (key → type/default/label/scope) — needed to
+  render an editor and to enrich the read-only `/settings` page. Safe, additive; build first.
+- Shares the **same auth + control-API foundation** as the help/alias editors (Q-0156).
+
+**Home:** [`docs/planning/dashboard-live-editor-plan.md`](../planning/dashboard-live-editor-plan.md)
+§ "Settings editor — global + per-server" · `utils/db/settings.py` · `core/runtime/feature_flags.py`
+(the resolution pattern) · this Q-block.

--- a/docs/planning/dashboard-live-editor-plan.md
+++ b/docs/planning/dashboard-live-editor-plan.md
@@ -108,6 +108,49 @@ usage-map page lists them by name once they exist.
   views consult, an audited mutation seam mirroring `help_overlay_mutation`, **then** a drag-and-drop
   website editor. Largest slice; planned separately once L0–L2 land.
 
+## Settings editor — global + per-server (owner ask, 2026-06-16)
+
+Owner: *"edit the settings from the website — it's fine if that triggers a redeploy — and as bot owner
+let me change things globally, as well as per-server if available."*
+
+**What the bot does today** (`utils/db/settings.py`): settings are a per-guild key/value store
+(`guild_settings(guild_id, key, value)`); `get_setting(guild_id, key, default)` returns the guild's
+row or a **default passed by the caller** — defaults are scattered at call sites, and there is **no
+global layer**. But `core/runtime/feature_flags.py` already resolves **per-guild → global → default**,
+so that resolution shape is a proven in-repo pattern to mirror.
+
+**Design (both scopes, mirrors feature_flags):**
+
+1. **Global layer.** Add a global settings row space — `guild_settings` at `guild_id = 0` (the repo
+   already uses `guild_id = 0` as the global/no-guild sentinel in several stores) *or* a sibling
+   `global_settings` table. A global value = the owner's default for every server.
+2. **Resolution change (one function, hot path — small but careful).** `get_setting` becomes
+   **per-guild row → global row → caller default**. This is a single, well-contained change to one
+   function, but it is read on every settings access, so it ships as its own focused, well-tested
+   `disbot/` PR (the risky-runtime rule).
+3. **Audited mutation seam** `services/settings_mutation.py` (mirrors `help_overlay_mutation`):
+   `set_setting(scope, key, value, actor)` where `scope` is `global` (owner-only) or a `guild_id`
+   (server admin) — value-validated per key, audited, cache-invalidated.
+4. **Website (owner auth) → control API → seam.** The editor shows each setting with a **scope
+   picker: "Global (all servers)" vs a specific server**; global is gated to the **bot owner**,
+   per-server to that server's admin (re-checked bot-side, like the help editor).
+
+**On "redeploy is fine":** with the global layer in the DB, **neither scope needs a redeploy** — both
+apply live (better than asked). The redeploy path is only needed if we instead edit *code* defaults;
+since defaults are scattered, the DB global layer is cleaner than centralising them into a committed
+file just to PR-and-redeploy. (If you'd rather avoid any hot-path change for now, the fallback is a
+committed `settings_defaults` file the website edits → PR → redeploy — but the DB layer is the better
+long-term answer and reuses the feature-flags pattern.)
+
+**Editor metadata gap:** a good settings editor needs each key's **type, default, label, and allowed
+range** (a checkbox vs a number vs a channel id). Those aren't centralised yet — a
+**settings-metadata registry** (key → {type, default, label, scope}) is the prerequisite that also
+enriches the read-only `/settings` page. Build it first (it's safe, additive data).
+
+**Phase placement:** this is another consumer of the **same** auth + control-API foundation (L0–L2)
+the help/alias editors need. Sequence: settings-metadata registry (safe) → global-layer resolution +
+mutation seam (focused runtime PR) → website settings editor over the control API.
+
 ## Alternatives considered (and why not)
 
 - **Website writes `help_overlay` rows directly (shared Postgres).** Rejected: bypasses the audited

--- a/tests/unit/dashboard/test_app.py
+++ b/tests/unit/dashboard/test_app.py
@@ -37,6 +37,7 @@ def client():
     [
         "/",
         "/functions",
+        "/games",
         "/commands",
         "/aliases",
         "/settings",
@@ -51,6 +52,12 @@ def test_pages_render(client, path):
     resp = client.get(path)
     assert resp.status_code == 200
     assert "SuperBot" in resp.text
+
+
+def test_games_page_shows_player_subsystems(client):
+    resp = client.get("/games")
+    assert resp.status_code == 200
+    assert "Games &amp; economy" in resp.text or "Games & economy" in resp.text
 
 
 def test_aliases_page_renders_suggestion_form(client):


### PR DESCRIPTION
## Why

Continuing the website. Ships the last of the four read-only surfaces the owner picked (Q-0156) and
records the design answering the owner's new ask: *edit settings from the website, global + per-server.*

## What

- **`/games` — games & economy showcase.** Groups the **games / economy / progression** subsystems
  from the existing `data.catalogue` (emoji, description, capabilities, play commands, tier) and lists
  their tunable setting keys. **No new scanner / no regen** — reuses data already in `dashboard.json`.
  Route, nav, and a smoke test added.
- **Settings-editor design (docs only, Q-0157).** Researched the model: `utils/db/settings.py` is a
  per-guild KV store with **scattered defaults and no global layer** — but `feature_flags.py` already
  resolves **per-guild → global → default**, the shape to mirror. Recorded in
  `docs/planning/dashboard-live-editor-plan.md` § "Settings editor": add a global layer + that
  resolution (focused runtime PR), an audited `settings_mutation` seam, and a website scope picker
  (global = owner-gated, per-server = admin-gated). With the DB global layer, **neither scope needs a
  redeploy**. A settings-metadata registry is the safe prerequisite.

## Verification

- Dashboard smoke **with deps installed**: `pytest tests/unit/dashboard/test_app.py` → **17 passed**
  (`/games` renders).
- `python3.10 scripts/check_quality.py --check-only` → green. No `disbot/` runtime touched.

https://claude.ai/code/session_014f52sCSiw4UAmHxxCP7DWV

---
_Generated by [Claude Code](https://claude.ai/code/session_014f52sCSiw4UAmHxxCP7DWV)_