### PR TITLE
feat(dashboard): surface typed SettingSpec metadata on /settings

### DIFF
--- a/.sessions/2026-06-16-settings-readmodel-and-vision.md
+++ b/.sessions/2026-06-16-settings-readmodel-and-vision.md
@@ -1,0 +1,55 @@
+# Session — `/settings` typed read-model (SettingSpec) + main-website vision
+
+> **Status:** `complete`
+
+## Origin
+
+Owner (foundations-first, delegated): build toward editing settings from the website. Mid-session the
+owner set the scope — *this is the bot's **main website**; the bot stays the source of truth; the site
+front-ends it* — and added asks: per-command alias boxes, enable/disable commands, a Manage button on
+every command and cog (router **Q-0158**).
+
+## The decisive discovery (don't rebuild — front-end)
+
+Researched the settings stack and found the bot **already has** a typed, audited settings system:
+`SettingSpec` (`cogs/*/schemas.py`: type/default/hint/choices/capability) → audited
+`services.settings_mutation.SettingsMutationPipeline.set_value` → in-Discord editor (`views/settings/`).
+And **`services.command_routing`** (migration 036) already does audited per-cog enable/disable. So the
+"settings-metadata registry" I had planned **already exists as `SettingSpec`**, and enable/disable
+already exists as `command_routing` — the website is a **front-end over these seams**, never a parallel
+system. (Corrected the live-editor plan, which had said "build a metadata registry first.")
+
+## What shipped (this PR)
+
+The **settings read-model** — `/settings` now shows real typed metadata, not just key names:
+
+- **`scripts/scan_setting_specs.py`** (stdlib AST) reads the `SettingSpec` declarations in
+  `cogs/*/schemas.py` → **64 typed specs** with `value_type`, `default`, `hint`, `allowed_values`. It
+  resolves `settings_key=XP_MIN` → `"xp_min"` and **follows imports** to resolve
+  `default=DEFAULT_ENABLED` to its literal (only 2/64 defaults stay unresolved → flagged
+  `default_known=False`, never a misleading `None`).
+- `export_dashboard_data.py` joins each spec onto its settings key by key string; `/settings` renders
+  a **type badge + default + hint + enum choices** per typed setting (`typed_settings` count added).
+- Plan + router updated with the **main-website vision**, the **command management surface** design
+  (Manage button per command/cog; enable/disable front-ending `command_routing`; per-command alias
+  boxes alongside the global `/aliases` search), and the settings-editor-already-exists correction.
+
+## Verification
+
+- `scan_setting_specs.py` → 64 typed specs; scanner + export tests green (9 passed).
+- Dashboard smoke **with deps**: `pytest tests/unit/dashboard/test_app.py` → **17 passed**.
+- `python3.10 scripts/check_quality.py --check-only` → green. No `disbot/` runtime touched.
+
+## 💡 Session idea (Q-0089)
+
+**A "bot capability ↔ website surface" map** — a small doc/table pairing each editable bot seam
+(`settings_mutation`, `help_overlay_mutation`, `command_routing`, synonym layer) with its website
+surface + status (read-only / suggest / live). It makes the "front-end the bot, don't duplicate"
+principle (Q-0158) *checkable* — any website write feature must name the existing seam it fronts, or
+it's flagged as a candidate parallel system. The dashboard analogue of `do_not_create`.
+
+## Documentation audit (Q-0104)
+
+- Owner decision recorded (Q-0158); design lives in the live-editor plan. `check_docs` green.
+- SessionStart "merged PRs not in current-state" = the reconciliation backlog (the routine's job,
+  Q-0124), not this manual session's.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -14,7 +14,7 @@ and the secrets model live in
 | `/functions` | Bot-function catalogue (from the subsystem registry) |
 | `/commands` | **Cog & command explorer** — every cog's commands, each badged prefix/slash and whether it's button-backed (a panel action or opens a view); live search + filters (`scripts/scan_commands.py`). |
 | `/aliases` | **Suggest a command alias** — pick a command, propose an alias, get a live collision check against every command/alias/synonym, a prefilled GitHub issue, and a paste-ready `synonyms.py` snippet (`scripts/scan_synonyms.py`). Client-side; no backend yet. |
-| `/settings` | **Settings catalogue** — every per-guild setting key the bot exposes, grouped by owning subsystem, with live filter. Key names only, never stored values (`scripts/scan_settings.py`). |
+| `/settings` | **Settings catalogue** — every per-guild setting key, grouped by owning subsystem, with live filter. Typed settings also show their **type, default, hint, and enum choices** from the bot's `SettingSpec`s (`scripts/scan_settings.py` + `scripts/scan_setting_specs.py`). Names + metadata only, never a stored value. |
 | `/access` | **Permissions & access map** — the visibility-tier ladder + which subsystems each tier can see. A faithful static mirror of `disbot/utils/visibility_rules.py` (`scripts/scan_access.py`). Visibility, **not** execution. |
 | `/ideas` | Idea backlog (from `docs/ideas/`) |
 | `/bugs` | Bug board (from `docs/health/bug-book.md`) + a "report a bug" CTA |

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,9 +1,9 @@
 {
   "meta": {
-    "generated_at": "2026-06-16T19:00:19Z",
+    "generated_at": "2026-06-16T20:03:01Z",
     "counts": {
       "functions": 33,
-      "ideas": 72,
+      "ideas": 73,
       "bugs": 15,
       "updates": 60,
       "env_vars": 34,
@@ -11,6 +11,7 @@
       "commands": 301,
       "setting_keys": 83,
       "setting_domains": 13,
+      "typed_settings": 64,
       "visible_subsystems": 33,
       "synonyms": 87
     }
@@ -887,6 +888,13 @@
       "summary": "PR #948 fixed the ~85s deploy downtime by releasing the runtime lock **early** (the moment"
     },
     {
+      "file": "deterministic-floor-catalogue-2026-06-16.md",
+      "title": "Idea — a generated \"deterministic floor catalogue\" index",
+      "status": "ideas",
+      "date": "2026-06-16",
+      "summary": "`btd6_context_service._BTD6_LIST_BUILDERS` now grows roughly **one member per dispatch run**"
+    },
+    {
       "file": "developer-dashboard-2026-06-16.md",
       "title": "Developer dashboard (personal website) for SuperBot",
       "status": "ideas",
@@ -1504,6 +1512,12 @@
       "status": "complete"
     },
     {
+      "file": "2026-06-16-model-tpm-confirmed-result.md",
+      "date": "2026-06-16",
+      "title": "2026-06-16 — TPM result confirmed (5-mini 500K) + reconcile the compaction guidance",
+      "status": "complete"
+    },
+    {
       "file": "2026-06-16-model-comparison-gpt5mini.md",
       "date": "2026-06-16",
       "title": "2026-06-16 — gpt-5-mini vs gpt-5.4-mini comparison + apply_context_fixes --set-model fix",
@@ -1519,6 +1533,12 @@
       "file": "2026-06-16-journal-session-lessons.md",
       "date": "2026-06-16",
       "title": "Session — journal: durable lessons from the security-tiers session",
+      "status": "complete"
+    },
+    {
+      "file": "2026-06-16-install-skills-staleness-guard.md",
+      "date": "2026-06-16",
+      "title": "2026-06-16 — install-skills.sh staleness guard (stale-skill root cause)",
       "status": "complete"
     },
     {
@@ -1618,6 +1638,12 @@
       "status": "complete"
     },
     {
+      "file": "2026-06-16-dashboard-games-settings-design.md",
+      "date": "2026-06-16",
+      "title": "Session — Dashboard: `/games` showcase + settings-editor design (global + per-server)",
+      "status": "complete"
+    },
+    {
       "file": "2026-06-16-dashboard-env-usage-map.md",
       "date": "2026-06-16",
       "title": "Session — Dashboard Phase 3 (read-only env-var usage map)",
@@ -1639,6 +1665,12 @@
       "file": "2026-06-16-dashboard-commands-explorer.md",
       "date": "2026-06-16",
       "title": "Session — Dashboard cog & command explorer (`/commands`)",
+      "status": "complete"
+    },
+    {
+      "file": "2026-06-16-dashboard-aliases.md",
+      "date": "2026-06-16",
+      "title": "Session — Dashboard: `/aliases` command-alias suggestion page",
       "status": "complete"
     },
     {
@@ -1705,6 +1737,12 @@
       "file": "2026-06-16-btd6-cost-comparison-floor.md",
       "date": "2026-06-16",
       "title": "Session — AI §7.5 deterministic BTD6 cost-comparison floor",
+      "status": "complete"
+    },
+    {
+      "file": "2026-06-16-btd6-capability-roster-floor.md",
+      "date": "2026-06-16",
+      "title": "Session — BTD6 property/capability roster floors (AI §7.6 new family)",
       "status": "complete"
     },
     {
@@ -1777,36 +1815,6 @@
       "file": "2026-06-15-mining-vault-v2-cap.md",
       "date": "2026-06-15",
       "title": "Session — Mining Vault v2: inventory soft-cap + vault-cap upgrade path",
-      "status": "complete"
-    },
-    {
-      "file": "2026-06-15-mining-skill-tree-slice-d.md",
-      "date": "2026-06-15",
-      "title": "2026-06-15 — mining Slice D: capped skill tree (§7.4)",
-      "status": "complete"
-    },
-    {
-      "file": "2026-06-15-mining-respec-titles-ef.md",
-      "date": "2026-06-15",
-      "title": "Session — 2026-06-15 · mining Slices E + F — respec polish + skill/milestone titles",
-      "status": "complete"
-    },
-    {
-      "file": "2026-06-15-mining-phase2-feature-gated.md",
-      "date": "2026-06-15",
-      "title": "2026-06-15 — mining Phase-2 feature dispatch: gated (fix-phase) + loop cleanup",
-      "status": "complete"
-    },
-    {
-      "file": "2026-06-15-mining-inplace-image-cards.md",
-      "date": "2026-06-15",
-      "title": "Session: Mining hub UX overhaul (in-place cards · sub-hubs · 3-layer menu doctrine)",
-      "status": "complete"
-    },
-    {
-      "file": "2026-06-15-mining-home-slice-c.md",
-      "date": "2026-06-15",
-      "title": "Session — 2026-06-15 · mining Slice C — the Home structure (character-card backdrop)",
       "status": "complete"
     }
   ],
@@ -6210,43 +6218,87 @@
       "keys": [
         {
           "constant": "AI_ENABLED",
-          "key": "ai_enabled"
+          "key": "ai_enabled",
+          "type": "bool",
+          "hint": "Master switch for the AI Platform. When false, no AI feature runs for this guild — including BTD6 AI augmentation and the central natural-language stage.",
+          "allowed_values": [],
+          "default": false
         },
         {
           "constant": "AI_NATURAL_LANGUAGE_ENABLED",
-          "key": "ai_natural_language_enabled"
+          "key": "ai_natural_language_enabled",
+          "type": "bool",
+          "hint": "Whether the bot may reply to natural-language messages (channel- and role-policy still apply). Independent of ai.enabled so admins can keep AI features available without enabling passive replies.",
+          "allowed_values": [],
+          "default": false
         },
         {
           "constant": "AI_DEFAULT_PROVIDER",
-          "key": "ai_default_provider"
+          "key": "ai_default_provider",
+          "type": "str",
+          "hint": "Default provider used by AI tasks that don't specify their own. 'deterministic' keeps responses local; 'openai' / 'anthropic' route through the configured OpenAI / Anthropic account. Leave the model empty so each task auto-picks the right model for the provider. This per-guild setting wins over the AI_DEFAULT_PROVIDER environment default for this server (see docs/ai-config-ownership.md § provider precedence).",
+          "allowed_values": [
+            "deterministic",
+            "openai",
+            "anthropic"
+          ],
+          "default": "deterministic"
         },
         {
           "constant": "AI_DEFAULT_MODEL",
-          "key": "ai_default_model"
+          "key": "ai_default_model",
+          "type": "str",
+          "hint": "Default model identifier for the chosen provider. Leave empty to use the provider's own default.",
+          "allowed_values": [],
+          "default": ""
         },
         {
           "constant": "AI_MINIMUM_LEVEL_DEFAULT",
-          "key": "ai_minimum_level_default"
+          "key": "ai_minimum_level_default",
+          "type": "int",
+          "hint": "Default minimum XP level required to talk to the bot naturally. Channels, categories, and roles may override this in M2.",
+          "allowed_values": [],
+          "default": 2
         },
         {
           "constant": "AI_COOLDOWN_SECONDS",
-          "key": "ai_cooldown_seconds"
+          "key": "ai_cooldown_seconds",
+          "type": "int",
+          "hint": "Seconds between natural-language replies per user. Zero disables the cooldown.",
+          "allowed_values": [],
+          "default": 30
         },
         {
           "constant": "AI_FRESH_USER_MENTION_ALLOWANCE",
-          "key": "ai_fresh_user_mention_allowance"
+          "key": "ai_fresh_user_mention_allowance",
+          "type": "int",
+          "hint": "How many @-mention replies a fresh user (below the minimum level) is allowed before the level gate kicks in.",
+          "allowed_values": [],
+          "default": 1
         },
         {
           "constant": "AI_GUILD_INSTRUCTION_PROFILE",
-          "key": "ai_guild_instruction_profile"
+          "key": "ai_guild_instruction_profile",
+          "type": "str",
+          "hint": "Free-text guild-wide instruction body that prefixes every AI prompt for this guild. Transitional scalar seed: M2 backfills this into a typed ai_instruction_profile row named 'default' and the typed table becomes the runtime source of truth.",
+          "allowed_values": [],
+          "default": ""
         },
         {
           "constant": "AI_MEMORY_WINDOW_MINUTES",
-          "key": "ai_memory_window_minutes"
+          "key": "ai_memory_window_minutes",
+          "type": "int",
+          "hint": "How many minutes of recent channel messages the bot should keep in its in-process memory and include as context on each AI reply. ``0`` keeps only the last 3 messages per channel (the always-on minimum so basic conversational handles still work). Hard cap 120 minutes; the cache is in-process only and dropped on restart.",
+          "allowed_values": [],
+          "default": 0
         },
         {
           "constant": "AI_MEMORY_CHANNEL_SCAN_ENABLED",
-          "key": "ai_memory_channel_scan_enabled"
+          "key": "ai_memory_channel_scan_enabled",
+          "type": "bool",
+          "hint": "When ON, the bot may scan recent channel history via Discord's API to backfill its memory cache when the in-process buffer holds fewer messages than the configured window requires. OFF means memory is limited to messages the bot observed since process start.",
+          "allowed_values": [],
+          "default": false
         }
       ]
     },
@@ -6256,47 +6308,91 @@
       "keys": [
         {
           "constant": "AUTOMOD_ENABLED",
-          "key": "automod_enabled"
+          "key": "automod_enabled",
+          "type": "bool",
+          "hint": "Master switch for automod.  When off, no rule acts regardless of the per-rule toggles.  Off by default — a fresh server is unaffected.",
+          "allowed_values": [],
+          "default": false
         },
         {
           "constant": "AUTOMOD_SPAM_ENABLED",
-          "key": "automod_spam_enabled"
+          "key": "automod_spam_enabled",
+          "type": "bool",
+          "hint": "Delete + warn on a burst of messages from one member in a channel.",
+          "allowed_values": [],
+          "default": false
         },
         {
           "constant": "AUTOMOD_INVITES_ENABLED",
-          "key": "automod_invites_enabled"
+          "key": "automod_invites_enabled",
+          "type": "bool",
+          "hint": "Delete + warn on Discord invite links (discord.gg/…).",
+          "allowed_values": [],
+          "default": false
         },
         {
           "constant": "AUTOMOD_CAPS_ENABLED",
-          "key": "automod_caps_enabled"
+          "key": "automod_caps_enabled",
+          "type": "bool",
+          "hint": "Delete + warn on messages that are mostly uppercase (shouting).",
+          "allowed_values": [],
+          "default": false
         },
         {
           "constant": "AUTOMOD_MENTIONS_ENABLED",
-          "key": "automod_mentions_enabled"
+          "key": "automod_mentions_enabled",
+          "type": "bool",
+          "hint": "Delete + warn on messages with too many @mentions (mass-ping).",
+          "allowed_values": [],
+          "default": false
         },
         {
           "constant": "AUTOMOD_SPAM_COUNT",
-          "key": "automod_spam_count"
+          "key": "automod_spam_count",
+          "type": "int",
+          "hint": "Messages from one member in one channel within the spam window before the spam rule trips.",
+          "allowed_values": [],
+          "default": 5
         },
         {
           "constant": "AUTOMOD_SPAM_WINDOW_SECONDS",
-          "key": "automod_spam_window_seconds"
+          "key": "automod_spam_window_seconds",
+          "type": "int",
+          "hint": "Sliding-window length (seconds) the spam count is measured over.",
+          "allowed_values": [],
+          "default": 7
         },
         {
           "constant": "AUTOMOD_CAPS_PERCENT",
-          "key": "automod_caps_percent"
+          "key": "automod_caps_percent",
+          "type": "int",
+          "hint": "Percentage of letters that must be uppercase before the caps rule trips (only on messages with enough letters to judge).",
+          "allowed_values": [],
+          "default": 70
         },
         {
           "constant": "AUTOMOD_MENTIONS_COUNT",
-          "key": "automod_mentions_count"
+          "key": "automod_mentions_count",
+          "type": "int",
+          "hint": "Number of @mentions in one message before the mass-mention rule trips.",
+          "allowed_values": [],
+          "default": 4
         },
         {
           "constant": "AUTOMOD_EXEMPT_ROLES",
-          "key": "automod_exempt_roles"
+          "key": "automod_exempt_roles",
+          "type": "str",
+          "hint": "Comma-separated role ids whose members are never acted on (staff, bots-with-a-role, …).  Leave empty for none.",
+          "allowed_values": [],
+          "default": ""
         },
         {
           "constant": "AUTOMOD_EXEMPT_CHANNELS",
-          "key": "automod_exempt_channels"
+          "key": "automod_exempt_channels",
+          "type": "str",
+          "hint": "Comma-separated channel ids automod never touches (announcements, memes, …).  Leave empty for none.",
+          "allowed_values": [],
+          "default": ""
         }
       ]
     },
@@ -6342,31 +6438,59 @@
       "keys": [
         {
           "constant": "COUNTERS_ENABLED",
-          "key": "counters_enabled"
+          "key": "counters_enabled",
+          "type": "bool",
+          "hint": "Master switch for server counters.  When off, no channel is renamed regardless of the bindings.  Off by default — a fresh server is unaffected.",
+          "allowed_values": [],
+          "default": false
         },
         {
           "constant": "COUNTERS_TOTAL_CHANNEL",
-          "key": "counters_total_channel"
+          "key": "counters_total_channel",
+          "type": "str",
+          "hint": "Channel whose name shows the total member count (a locked voice channel works well).  Leave unset to disable this counter.",
+          "allowed_values": [],
+          "default": ""
         },
         {
           "constant": "COUNTERS_HUMANS_CHANNEL",
-          "key": "counters_humans_channel"
+          "key": "counters_humans_channel",
+          "type": "str",
+          "hint": "Channel whose name shows the non-bot member count.  Unset to disable.",
+          "allowed_values": [],
+          "default": ""
         },
         {
           "constant": "COUNTERS_BOTS_CHANNEL",
-          "key": "counters_bots_channel"
+          "key": "counters_bots_channel",
+          "type": "str",
+          "hint": "Channel whose name shows the bot count.  Unset to disable.",
+          "allowed_values": [],
+          "default": ""
         },
         {
           "constant": "COUNTERS_TOTAL_TEMPLATE",
-          "key": "counters_total_template"
+          "key": "counters_total_template",
+          "type": "str",
+          "hint": "Name template for the total counter.  Placeholder: {count}.",
+          "allowed_values": [],
+          "default": "👥 Members: {count}"
         },
         {
           "constant": "COUNTERS_HUMANS_TEMPLATE",
-          "key": "counters_humans_template"
+          "key": "counters_humans_template",
+          "type": "str",
+          "hint": "Name template for the humans counter.  Placeholder: {count}.",
+          "allowed_values": [],
+          "default": "🧑 Humans: {count}"
         },
         {
           "constant": "COUNTERS_BOTS_TEMPLATE",
-          "key": "counters_bots_template"
+          "key": "counters_bots_template",
+          "type": "str",
+          "hint": "Name template for the bots counter.  Placeholder: {count}.",
+          "allowed_values": [],
+          "default": "🤖 Bots: {count}"
         }
       ]
     },
@@ -6390,15 +6514,27 @@
         },
         {
           "constant": "RPS_DEFAULT_ENTRY_FEE",
-          "key": "rps_default_entry_fee"
+          "key": "rps_default_entry_fee",
+          "type": "int",
+          "hint": "Default entry fee (🪙 coins) applied when an admin runs `!rpsregister` without an explicit entry_fee argument.",
+          "allowed_values": [],
+          "default": 0
         },
         {
           "constant": "BLACKJACK_DEFAULT_ENTRY_FEE",
-          "key": "blackjack_default_entry_fee"
+          "key": "blackjack_default_entry_fee",
+          "type": "int",
+          "hint": "Default entry fee (🪙 coins) applied when an admin runs `!bjtournament` without an explicit entry_fee argument.",
+          "allowed_values": [],
+          "default": 0
         },
         {
           "constant": "DEATHMATCH_TURN_TIMEOUT",
-          "key": "deathmatch_turn_timeout"
+          "key": "deathmatch_turn_timeout",
+          "type": "int",
+          "hint": "Seconds each player has to respond on their turn before the duel times out and the opponent wins by default.",
+          "allowed_values": [],
+          "default": 60
         }
       ]
     },
@@ -6412,11 +6548,19 @@
         },
         {
           "constant": "TRUSTED_TIER_ROLE_ID",
-          "key": "trusted_tier_role_id"
+          "key": "trusted_tier_role_id",
+          "type": "str",
+          "hint": "Role whose members are treated as the 'trusted' tier — reserved for trust-gated features and surfaces.  Leave empty to disable.  Like the moderator role, this only ever adds standing.",
+          "allowed_values": [],
+          "default": ""
         },
         {
           "constant": "MODERATOR_TIER_ROLE_ID",
-          "key": "moderator_tier_role_id"
+          "key": "moderator_tier_role_id",
+          "type": "str",
+          "hint": "Role whose members may use moderation actions (warn, timeout, kick, ban) without holding Discord moderation permissions.  Leave empty to require Discord permissions only.  This only adds access — no one who can moderate today loses it.",
+          "allowed_values": [],
+          "default": ""
         }
       ]
     },
@@ -6488,51 +6632,98 @@
       "keys": [
         {
           "constant": "WARN_THRESHOLD",
-          "key": "warn_threshold"
+          "key": "warn_threshold",
+          "type": "int",
+          "hint": "Number of warnings before the escalation action is applied.  Set high to effectively disable automatic escalation.",
+          "allowed_values": [],
+          "default": 3
         },
         {
           "constant": "WARN_TIMEOUT_MINS",
-          "key": "warn_timeout_minutes"
+          "key": "warn_timeout_minutes",
+          "type": "int",
+          "hint": "Duration in minutes of the automatic timeout triggered when warn_threshold is reached and warn_escalation_action is 'timeout'.",
+          "allowed_values": [],
+          "default": 10
         },
         {
           "constant": "MOD_DM_ON_ACTION",
-          "key": "moderation_dm_on_action"
+          "key": "moderation_dm_on_action",
+          "type": "bool",
+          "hint": "DM the affected member a notice when they are warned, timed out, kicked, or banned.  Best-effort — silently skipped when the member has DMs closed.",
+          "allowed_values": [],
+          "default": false
         },
         {
           "constant": "MOD_DM_TEMPLATE",
-          "key": "moderation_dm_template"
+          "key": "moderation_dm_template",
+          "type": "str",
+          "hint": "Custom body for the notify-the-member DM.  Leave empty for the built-in per-action notice.  Tokens: {guild} {action} {reason} {user}.",
+          "allowed_values": [],
+          "default": ""
         },
         {
           "constant": "MOD_REQUIRE_REASON",
-          "key": "moderation_require_reason"
+          "key": "moderation_require_reason",
+          "type": "bool",
+          "hint": "Require a non-empty reason for warn / kick / ban.  When on, the action is rejected (at the moderation_service seam) if no reason is given.  Timeout is exempt — its reason carries the duration.",
+          "allowed_values": [],
+          "default": false
         },
         {
           "constant": "MOD_BAN_DELETE_MESSAGE_DAYS",
-          "key": "moderation_ban_delete_message_days"
+          "key": "moderation_ban_delete_message_days",
+          "type": "int",
+          "hint": "Days of the banned member's recent messages to purge (0–7).  0 keeps all messages — today's default.",
+          "allowed_values": [],
+          "default": 0
         },
         {
           "constant": "MOD_MAX_TIMEOUT_MINUTES",
-          "key": "moderation_max_timeout_minutes"
+          "key": "moderation_max_timeout_minutes",
+          "type": "int",
+          "hint": "Upper bound (minutes) for any single timeout; longer requests are clamped down.  Default 40320 = 28 days, Discord's maximum, so an unconfigured guild is unaffected.",
+          "allowed_values": []
         },
         {
           "constant": "MOD_WARN_ESCALATION_ACTION",
-          "key": "moderation_warn_escalation_action"
+          "key": "moderation_warn_escalation_action",
+          "type": "str",
+          "hint": "What happens when a member reaches warn_threshold warnings: 'timeout' (the default — auto-timeout for warn_timeout_minutes, then reset), 'kick', 'ban', or 'none' to disable auto-escalation.",
+          "allowed_values": [],
+          "default": "timeout"
         },
         {
           "constant": "MOD_POST_ACTION_CLEANUP",
-          "key": "moderation_post_action_cleanup"
+          "key": "moderation_post_action_cleanup",
+          "type": "str",
+          "hint": "After a kick or ban, sweep the member's recent messages in the channel where the action was taken: 'none' (default), 'kick', 'ban', or 'both'.  The bot needs Manage Messages + Read Message History in that channel.",
+          "allowed_values": [],
+          "default": "none"
         },
         {
           "constant": "MOD_POST_ACTION_CLEANUP_LIMIT",
-          "key": "moderation_post_action_cleanup_limit"
+          "key": "moderation_post_action_cleanup_limit",
+          "type": "int",
+          "hint": "How many recent messages to scan for the post-action cleanup sweep (1–500).  Only the moderated member's messages within that scan window are removed.",
+          "allowed_values": [],
+          "default": 100
         },
         {
           "constant": "MOD_PUBLIC_LOG_CHANNEL",
-          "key": "moderation_public_log_channel"
+          "key": "moderation_public_log_channel",
+          "type": "str",
+          "hint": "Channel for the optional public moderation log.  Leave empty to disable.  Public entries show the action, the affected member, and the reason — but never which moderator acted.",
+          "allowed_values": [],
+          "default": ""
         },
         {
           "constant": "MOD_PUBLIC_LOG_ACTIONS",
-          "key": "moderation_public_log_actions"
+          "key": "moderation_public_log_actions",
+          "type": "str",
+          "hint": "Which actions are announced in the public moderation log: 'none' (default, off), 'bans', 'removals' (kick + ban), or 'all' (warn + timeout + kick + ban).  The acting moderator is never shown publicly.  Requires public_log_channel to be set.",
+          "allowed_values": [],
+          "default": "none"
         }
       ]
     },
@@ -6546,11 +6737,19 @@
         },
         {
           "constant": "TIME_ROLES_STACK",
-          "key": "time_roles_stack"
+          "key": "time_roles_stack",
+          "type": "bool",
+          "hint": "When ON, members keep every tenure (time-based) role they have earned. When OFF (default), reaching a new tenure tier removes the previous one, so a member holds a single tenure role.",
+          "allowed_values": [],
+          "default": false
         },
         {
           "constant": "XP_ROLES_STACK",
-          "key": "xp_roles_stack"
+          "key": "xp_roles_stack",
+          "type": "bool",
+          "hint": "When ON (default), members keep every XP/level role they earn — the roles stack. When OFF, reaching a higher level role removes the lower level roles, so a member holds a single level role.",
+          "allowed_values": [],
+          "default": true
         }
       ]
     },
@@ -6560,35 +6759,67 @@
       "keys": [
         {
           "constant": "WELCOME_ENABLED",
-          "key": "welcome_enabled"
+          "key": "welcome_enabled",
+          "type": "bool",
+          "hint": "Master switch for welcome.  When off, no greeting posts and no entry role is granted regardless of the per-event toggles.  Off by default — a fresh server is unaffected.",
+          "allowed_values": [],
+          "default": false
         },
         {
           "constant": "WELCOME_JOIN_ENABLED",
-          "key": "welcome_join_enabled"
+          "key": "welcome_join_enabled",
+          "type": "bool",
+          "hint": "Post a greeting embed in the welcome channel when a member joins.",
+          "allowed_values": [],
+          "default": true
         },
         {
           "constant": "WELCOME_LEAVE_ENABLED",
-          "key": "welcome_leave_enabled"
+          "key": "welcome_leave_enabled",
+          "type": "bool",
+          "hint": "Post a farewell embed in the welcome channel when a member leaves.",
+          "allowed_values": [],
+          "default": false
         },
         {
           "constant": "WELCOME_CHANNEL",
-          "key": "welcome_channel"
+          "key": "welcome_channel",
+          "type": "str",
+          "hint": "Channel where greeting/farewell embeds are posted.  Leave unset to disable posting (the entry role still works).",
+          "allowed_values": [],
+          "default": ""
         },
         {
           "constant": "WELCOME_JOIN_MESSAGE",
-          "key": "welcome_join_message"
+          "key": "welcome_join_message",
+          "type": "str",
+          "hint": "Greeting template.  Placeholders: {user} (mention), {server} (name), {count} (member number).",
+          "allowed_values": [],
+          "default": "👋 Welcome {user} to **{server}**! You're member #{count}."
         },
         {
           "constant": "WELCOME_LEAVE_MESSAGE",
-          "key": "welcome_leave_message"
+          "key": "welcome_leave_message",
+          "type": "str",
+          "hint": "Farewell template.  Placeholders: {user} (name), {server} (name), {count} (remaining members).",
+          "allowed_values": [],
+          "default": "👋 **{user}** has left {server}. We're now {count} members."
         },
         {
           "constant": "WELCOME_ENTRY_ROLE",
-          "key": "welcome_entry_role"
+          "key": "welcome_entry_role",
+          "type": "str",
+          "hint": "Role granted the moment a member joins (e.g. a base Member role).  Leave unset for none.  Granted through moderation's audited role path.",
+          "allowed_values": [],
+          "default": ""
         },
         {
           "constant": "WELCOME_CARD_ENABLED",
-          "key": "welcome_card_enabled"
+          "key": "welcome_card_enabled",
+          "type": "bool",
+          "hint": "Attach a rendered welcome card image to the join greeting (phase 2).  Off by default; falls back to the embed-only greeting when image rendering is unavailable.",
+          "allowed_values": [],
+          "default": false
         }
       ]
     },
@@ -6598,15 +6829,27 @@
       "keys": [
         {
           "constant": "XP_MIN",
-          "key": "xp_min"
+          "key": "xp_min",
+          "type": "int",
+          "hint": "Minimum XP awarded per qualifying message.",
+          "allowed_values": [],
+          "default": 15
         },
         {
           "constant": "XP_MAX",
-          "key": "xp_max"
+          "key": "xp_max",
+          "type": "int",
+          "hint": "Maximum XP awarded per qualifying message.",
+          "allowed_values": [],
+          "default": 25
         },
         {
           "constant": "XP_COOLDOWN",
-          "key": "xp_cooldown"
+          "key": "xp_cooldown",
+          "type": "int",
+          "hint": "Seconds between XP awards per user.  Zero disables the cooldown (not recommended in active guilds).",
+          "allowed_values": [],
+          "default": 60
         },
         {
           "constant": "XP_ANNOUNCE_CHANNEL",

--- a/dashboard/templates/settings.html
+++ b/dashboard/templates/settings.html
@@ -6,11 +6,15 @@
   {{ data.meta.counts.get("setting_keys", 0) }} per-server setting keys across
   {{ data.meta.counts.get("setting_domains", 0) }} subsystems — every knob the bot exposes,
   grouped by the subsystem that owns it.
+  {{ data.meta.counts.get("typed_settings", 0) }} carry a typed
+  <strong>SettingSpec</strong> (type · default · hint), the metadata the editable settings use.
 </p>
 <p class="text-slate-500 mb-6 text-xs rounded border border-slate-800 bg-slate-900/50 px-3 py-2">
-  🔧 Read-only static analysis (<code>scripts/scan_settings.py</code>, from
-  <code>disbot/utils/settings_keys/</code>). Shows the stable <strong>key names</strong> only —
-  not the value any server has set (those live in the bot's database). Editing values is a later phase.
+  🔧 Read-only static analysis (<code>scripts/scan_settings.py</code> +
+  <code>scripts/scan_setting_specs.py</code>). Shows the stable <strong>key names</strong>, their
+  type and default — not the value any server has set (those live in the bot's database). The bot
+  already has a typed, audited settings pipeline; the website editor (global + per-server) is a
+  front-end over it — see the live-editor plan.
 </p>
 
 <input
@@ -30,12 +34,20 @@
         <span class="text-xs text-slate-500">{{ domain['keys'] | length }} key{{ '' if domain['keys']|length == 1 else 's' }}</span>
       </div>
       {% if domain.purpose %}<p class="text-xs text-slate-400 mb-3">{{ domain.purpose }}</p>{% endif %}
-      <div class="grid gap-1 sm:grid-cols-2">
+      <div class="grid gap-1.5 sm:grid-cols-2">
         {% for k in domain['keys'] %}
-          <div class="setting-row flex items-center justify-between gap-2 rounded bg-slate-950/60 px-2.5 py-1.5"
-               data-haystack="{{ k.constant }} {{ k.key }}">
-            <code class="text-xs text-slate-200">{{ k.constant }}</code>
-            <code class="text-[11px] text-slate-500 shrink-0">{{ k.key }}</code>
+          <div class="setting-row rounded bg-slate-950/60 px-2.5 py-1.5"
+               data-haystack="{{ k.constant }} {{ k.key }} {{ k.hint or '' }}">
+            <div class="flex items-center gap-2 flex-wrap">
+              <code class="text-xs text-slate-200">{{ k.constant }}</code>
+              {% if k.type %}<span class="text-[9px] uppercase rounded bg-indigo-900/60 text-indigo-300 px-1 py-0.5">{{ k.type }}</span>{% endif %}
+              {% if k.default is defined %}<span class="text-[10px] text-slate-500">= {{ k.default | tojson }}</span>{% endif %}
+              <code class="text-[11px] text-slate-600 ml-auto shrink-0">{{ k.key }}</code>
+            </div>
+            {% if k.hint %}<p class="mt-0.5 text-[10px] text-slate-500 leading-snug">{{ k.hint }}</p>{% endif %}
+            {% if k.allowed_values %}
+              <p class="mt-0.5 text-[10px] text-slate-500">choices: {% for v in k.allowed_values %}<code class="text-slate-400">{{ v }}</code>{% if not loop.last %}, {% endif %}{% endfor %}</p>
+            {% endif %}
           </div>
         {% endfor %}
       </div>

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -5945,3 +5945,35 @@ usage-map + Railway management; multi-AI control board) remain in the plan.
 **Home:** [`docs/planning/dashboard-live-editor-plan.md`](../planning/dashboard-live-editor-plan.md)
 § "Settings editor — global + per-server" · `utils/db/settings.py` · `core/runtime/feature_flags.py`
 (the resolution pattern) · this Q-block.
+
+### Q-0158 — The dashboard is the bot's main website; `/commands` becomes a management surface (2026-06-16)
+
+> **DECISION 2026-06-16 (owner-directed in-session).** Owner set the scope and added asks:
+> *"this will be the main website for the bot — later a broader project-management site (review repo
+> sectors like the AI memory system). It should integrate well with the bot, but the bot itself stays
+> the top focus: everything must remain correctly manageable in the bot. The website is a shortcut to
+> manage everything faster with more oversight. Each command should get its own alias box; it should be
+> possible to enable/disable each command from the website; plus a search and a Manage button on every
+> command and cog."*
+
+**Decisions / findings:**
+
+- **Scope:** this `dashboard/` site is the **main bot website**; a separate broader project site comes
+  later. Standing principles: (1) the **bot stays the source of truth + top priority** (everything
+  manageable in the bot itself); (2) the website **front-ends existing audited bot seams** — never a
+  parallel system.
+- **Enable/disable commands** → front-end **`services.command_routing`** (migration 036): per-guild,
+  scope-aware **per-cog** enable/disable, already audited (`set_policy`). Per-*individual-command* is
+  finer than the bot does today → a later extension; start at cog level.
+- **Per-command alias box** (correction): the global `/aliases` form stays as broad search/quick-add;
+  *additionally* each command gets its own alias box in `/commands`. Backing = the synonym layer.
+- **`/commands` → management surface:** existing search + a **Manage button on every command and cog**.
+  Read side (current aliases + routing state + buttons) builds now; write side lands with the
+  control-API + auth foundation (Q-0156 L0–L2).
+- This session shipped the **settings read-model**: `/settings` now surfaces each setting's typed
+  `SettingSpec` (type/default/hint/choices) via `scripts/scan_setting_specs.py` — confirming the
+  settings editor + metadata already exist in the bot (front-end them, don't rebuild).
+
+**Home:** [`docs/planning/dashboard-live-editor-plan.md`](../planning/dashboard-live-editor-plan.md)
+§ "Command management surface" + "Strategic framing" · `services/command_routing.py` ·
+`services/settings_mutation.py` · this Q-block.

--- a/docs/planning/dashboard-live-editor-plan.md
+++ b/docs/planning/dashboard-live-editor-plan.md
@@ -142,14 +142,60 @@ file just to PR-and-redeploy. (If you'd rather avoid any hot-path change for now
 committed `settings_defaults` file the website edits → PR → redeploy — but the DB layer is the better
 long-term answer and reuses the feature-flags pattern.)
 
-**Editor metadata gap:** a good settings editor needs each key's **type, default, label, and allowed
-range** (a checkbox vs a number vs a channel id). Those aren't centralised yet — a
-**settings-metadata registry** (key → {type, default, label, scope}) is the prerequisite that also
-enriches the read-only `/settings` page. Build it first (it's safe, additive data).
+**The editor + metadata already exist (do NOT rebuild).** The bot has a typed, audited settings
+system: each editable setting is a `core.runtime.subsystem_schema.SettingSpec`
+(`value_type` / `default` / `hint` / `allowed_values`) declared in `cogs/<subsystem>/schemas.py`,
+**`services.settings_mutation.SettingsMutationPipeline.set_value(guild, subsystem, name, value,
+actor)`** is the audited write seam (coerce → validate → capability-gate → DB+audit txn → cache
+invalidate → emit), and `views/settings/edit_*` is a full in-Discord typed editor. **The metadata
+registry I planned to build already is `SettingSpec`** — surfaced read-only on `/settings` as of this
+session (`scripts/scan_setting_specs.py`: 64 typed specs with type/default/hint/choices). So the web
+settings editor is a **front-end over the existing pipeline**, exactly like help over
+`help_overlay_mutation` — *not* a from-scratch build.
 
-**Phase placement:** this is another consumer of the **same** auth + control-API foundation (L0–L2)
-the help/alias editors need. Sequence: settings-metadata registry (safe) → global-layer resolution +
-mutation seam (focused runtime PR) → website settings editor over the control API.
+**What's genuinely new = the global scope.** `set_value` and `resolve_setting` are **per-guild
+only** today. The owner's "change things globally" needs the global tier (steps 1–2 above:
+`guild_id = 0` rows + `resolve_setting` → per-guild → global → spec default), then `set_value` gaining
+a global-scope path (owner-gated). That is the one focused runtime PR; per-server editing is *just*
+the existing pipeline behind the control API.
+
+**Phase placement (revised):** ① surface `SettingSpec` on `/settings` ✅ (shipped — read-model done) →
+② global-scope tier in `resolve_setting` + `SettingsMutationPipeline` (focused runtime PR) →
+③ website settings editor over the control API (the **same** auth + control-API foundation L0–L2 the
+help/alias editors need; per-server reuses the existing pipeline as-is).
+
+## Strategic framing — the bot's main website (owner, 2026-06-16)
+
+The owner set the scope: **this is the bot's main website.** A separate, broader
+**project-management** site (review repo sectors — the AI memory system, etc.) comes later. Two
+standing principles for everything here:
+
+1. **The bot stays the source of truth and the top priority.** Everything must remain fully
+   manageable *in the bot itself*; the website is a **faster-oversight shortcut**, never the only way
+   to do something.
+2. **Front-end the bot's seams — never build a parallel system.** Every write the website performs
+   goes through an **existing audited bot seam** over the control API: settings →
+   `SettingsMutationPipeline`, help → `help_overlay_mutation`, **cog enable/disable →
+   `services.command_routing.set_policy`**, aliases → the synonym layer. The website renders current
+   state and drives those seams; it never owns a second copy of the truth.
+
+## Command management surface (`/commands` → manage, owner ask 2026-06-16)
+
+The owner wants `/commands` to become a **management surface**: the existing search **plus a Manage
+button on every command and cog**, each opening an editor.
+
+- **Per-cog enable/disable — front-ends `command_routing` (exists).** `services/command_routing.py`
+  (migration 036) already does per-guild, scope-aware (channel→category→guild) cog enable/disable with
+  an audited mutation owner (`set_policy` → `RoutingMutationResult`). The website's per-cog toggle
+  calls it via the control API — no new model. **Per-individual-command** disable is *finer* than the
+  bot does today (it routes at cog granularity); offering it would be a new per-command routing layer,
+  so start at cog level (what the bot supports) and treat command-level as a later extension.
+- **Per-command alias box (owner correction).** The global `/aliases` form stays as the broad
+  *search / quick-add*; additionally **each command gets its own alias box** inline in `/commands`.
+  Backing: the synonym layer (suggest→PR today; live once the synonym overlay + control API land).
+- **Read side builds now (safe):** surface each command's current aliases + cog-routing state + a
+  Manage button on every command and cog — pure dashboard, no bot change. **Write side** (toggle,
+  edit alias) lands with the control-API + auth foundation (L0–L2).
 
 ## Alternatives considered (and why not)
 

--- a/scripts/export_dashboard_data.py
+++ b/scripts/export_dashboard_data.py
@@ -317,6 +317,27 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
         if keys_dir.is_dir()
         else []
     )
+    cogs_dir = repo_root / "disbot" / "cogs"
+    specs = (
+        _load_sibling("scan_setting_specs.py", "scan_setting_specs")(
+            cogs_dir=cogs_dir,
+            keys_dir=keys_dir,
+        )
+        if cogs_dir.is_dir()
+        else []
+    )
+    # Enrich each settings key with its typed SettingSpec metadata (type,
+    # default, hint, enum choices) where the bot declares one.
+    spec_by_key = {s["settings_key"]: s for s in specs if s["settings_key"]}
+    for domain in settings:
+        for entry in domain["keys"]:
+            spec = spec_by_key.get(entry["key"])
+            if spec is not None:
+                entry["type"] = spec["value_type"]
+                entry["hint"] = spec["hint"]
+                entry["allowed_values"] = spec["allowed_values"]
+                if spec["default_known"]:
+                    entry["default"] = spec["default"]
     registry_path = repo_root / "disbot" / "utils" / "subsystem_registry.py"
     access = (
         _load_sibling("scan_access.py", "scan_access")(registry=registry_path)
@@ -345,6 +366,7 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
                 "commands": sum(len(c["commands"]) for c in cogs),
                 "setting_keys": sum(len(d["keys"]) for d in settings),
                 "setting_domains": len(settings),
+                "typed_settings": len(specs),
                 "visible_subsystems": access.get("total_visible", 0),
                 "synonyms": sum(len(s["synonyms"]) for s in synonyms),
             },

--- a/scripts/scan_setting_specs.py
+++ b/scripts/scan_setting_specs.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3.10
+"""Scan the bot's typed ``SettingSpec`` declarations (stdlib only, read-only).
+
+The bot already has a typed, validated, audited settings system: each editable
+scalar setting is a ``core.runtime.subsystem_schema.SettingSpec`` declared
+statically in a ``disbot/cogs/<subsystem>/schemas.py`` module
+(``value_type`` / ``default`` / ``settings_key`` / ``hint`` / ``allowed_values``
+/ …). That is the **metadata a settings editor needs** — type, default, the
+human hint, and any enum choices — and it is the source of truth the in-Discord
+editor (``views/settings/``) and the audited ``services.settings_mutation``
+pipeline both consume.
+
+This scanner AST-reads those ``SettingSpec(...)`` declarations so the developer
+dashboard can surface them (enriching ``/settings`` beyond bare key names, and
+serving as the read-model for the future web editor) **without importing
+``disbot``**. It resolves two kinds of references statically:
+
+* ``settings_key=XP_MIN`` -> ``"xp_min"`` via ``disbot/utils/settings_keys/``;
+* ``default=DEFAULT_ENABLED`` -> the constant's literal value, following a
+  ``from services.automod_config import DEFAULT_ENABLED`` import to read it.
+
+A default it cannot resolve statically is reported with ``default_known=False``
+(never a misleading ``None``).
+
+Emits one record per spec::
+
+    {"subsystem": "xp", "name": "xp_min", "settings_key": "xp_min",
+     "value_type": "int", "default": 15, "default_known": true,
+     "hint": "Minimum XP awarded …", "capability_required": "xp.settings.configure",
+     "allowed_values": []}
+
+Pure stdlib, mirroring the other ``scripts/scan_*.py`` seams (which
+``scripts/export_dashboard_data.py`` embeds in ``dashboard/data/dashboard.json``).
+
+Run standalone::
+
+    python3.10 scripts/scan_setting_specs.py            # human-readable summary
+    python3.10 scripts/scan_setting_specs.py --json     # the raw JSON payload
+
+Reliability (Q-0105): **unverified** — confirm against the ``cogs/*/schemas.py``
+declarations a few times across sessions before trusting it, and delete this seam
+if it proves unreliable. Convenience generator, not load-bearing runtime code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DISBOT_DIR = REPO_ROOT / "disbot"
+DEFAULT_COGS_DIR = DISBOT_DIR / "cogs"
+DEFAULT_KEYS_DIR = DISBOT_DIR / "utils" / "settings_keys"
+
+_STR_FIELDS = ("capability_required", "hint", "input_hint")
+
+# Sentinel distinguishing "unresolved default" from a literal ``None`` default.
+_UNRESOLVED = object()
+
+
+def _literal(node: ast.AST) -> object:
+    try:
+        return ast.literal_eval(node)
+    except (ValueError, TypeError, SyntaxError):
+        return _UNRESOLVED
+
+
+def _settings_key_map(keys_dir: Path) -> dict[str, str]:
+    """``XP_MIN = "xp_min"`` -> ``{"XP_MIN": "xp_min"}`` over settings_keys/."""
+    mapping: dict[str, str] = {}
+    if not keys_dir.is_dir():
+        return mapping
+    for path in keys_dir.glob("*.py"):
+        for name, value in _module_string_constants(path).items():
+            mapping[name] = value
+    return mapping
+
+
+def _module_string_constants(path: Path) -> dict[str, str]:
+    """Module-level ``NAME = "literal"`` string constants of one file."""
+    out: dict[str, str] = {}
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError):
+        return out
+    for node in tree.body:
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        ):
+            out[node.targets[0].id] = node.value.value
+    return out
+
+
+class _ConstResolver:
+    """Resolve a ``default=NAME`` reference to its literal value.
+
+    Looks in the schemas module's own constants first, then follows a
+    ``from <module> import NAME`` to read the constant from that module.
+    Parsed modules are cached; unknown names return :data:`_UNRESOLVED`.
+    """
+
+    def __init__(self, schema_tree: ast.Module) -> None:
+        self._local: dict[str, object] = _module_constants(schema_tree)
+        self._imports: dict[str, str] = {}
+        for node in schema_tree.body:
+            if isinstance(node, ast.ImportFrom) and node.module:
+                for alias in node.names:
+                    self._imports[alias.asname or alias.name] = node.module
+        self._module_cache: dict[str, dict[str, object]] = {}
+
+    def resolve(self, name: str) -> object:
+        if name in self._local:
+            return self._local[name]
+        module = self._imports.get(name)
+        if module is None:
+            return _UNRESOLVED
+        consts = self._module_cache.get(module)
+        if consts is None:
+            path = DISBOT_DIR / (module.replace(".", "/") + ".py")
+            try:
+                consts = _module_constants(ast.parse(path.read_text(encoding="utf-8")))
+            except (OSError, SyntaxError):
+                consts = {}
+            self._module_cache[module] = consts
+        return consts.get(name, _UNRESOLVED)
+
+
+def _module_constants(tree: ast.Module) -> dict[str, object]:
+    """Module-level ``NAME = <literal>`` constants (any literal type)."""
+    out: dict[str, object] = {}
+    for node in tree.body:
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        ):
+            value = _literal(node.value)
+            if value is not _UNRESOLVED:
+                out[node.targets[0].id] = value
+    return out
+
+
+def _resolve_settings_key(node: ast.AST, key_map: dict[str, str]) -> str:
+    if isinstance(node, ast.Name):
+        return key_map.get(node.id, node.id)
+    value = _literal(node)
+    return value if isinstance(value, str) else ""
+
+
+def _default(node: ast.AST, consts: _ConstResolver) -> tuple[object, bool]:
+    """``(value, known)`` for a ``default=`` argument."""
+    value = _literal(node)
+    if value is not _UNRESOLVED:
+        return value, True
+    if isinstance(node, ast.Name):
+        resolved = consts.resolve(node.id)
+        if resolved is not _UNRESOLVED:
+            return resolved, True
+    return None, False
+
+
+def _spec_from_call(
+    call: ast.Call,
+    subsystem: str,
+    key_map: dict[str, str],
+    consts: _ConstResolver,
+) -> dict:
+    """Build one record from a ``SettingSpec(...)`` call node (kwargs only)."""
+    record: dict = {
+        "subsystem": subsystem,
+        "name": "",
+        "settings_key": "",
+        "value_type": "",
+        "default": None,
+        "default_known": False,
+        "capability_required": "",
+        "hint": "",
+        "input_hint": "",
+        "allowed_values": [],
+    }
+    for kw in call.keywords:
+        if kw.arg is None:
+            continue
+        if kw.arg == "name":
+            value = _literal(kw.value)
+            record["name"] = value if isinstance(value, str) else ""
+        elif kw.arg == "value_type":
+            record["value_type"] = kw.value.id if isinstance(kw.value, ast.Name) else ""
+        elif kw.arg == "default":
+            record["default"], record["default_known"] = _default(kw.value, consts)
+        elif kw.arg == "settings_key":
+            record["settings_key"] = _resolve_settings_key(kw.value, key_map)
+        elif kw.arg == "allowed_values":
+            allowed = _literal(kw.value)
+            record["allowed_values"] = (
+                list(allowed) if isinstance(allowed, tuple) else []
+            )
+        elif kw.arg in _STR_FIELDS:
+            value = _literal(kw.value)
+            record[kw.arg] = value if isinstance(value, str) else ""
+    return record
+
+
+def scan_setting_specs(
+    cogs_dir: Path = DEFAULT_COGS_DIR,
+    keys_dir: Path = DEFAULT_KEYS_DIR,
+) -> list[dict]:
+    """Scan every ``cogs/*/schemas.py`` for ``SettingSpec(...)`` declarations."""
+    key_map = _settings_key_map(keys_dir)
+    records: list[dict] = []
+    for schema_path in sorted(cogs_dir.glob("*/schemas.py")):
+        subsystem = schema_path.parent.name
+        try:
+            tree = ast.parse(schema_path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError):
+            continue
+        consts = _ConstResolver(tree)
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "SettingSpec"
+            ):
+                records.append(_spec_from_call(node, subsystem, key_map, consts))
+    records.sort(key=lambda r: (r["subsystem"], r["name"]))
+    return records
+
+
+def _format_summary(records: list[dict]) -> str:
+    lines = [f"{len(records)} typed SettingSpec(s):\n"]
+    for r in records:
+        choices = f" choices={r['allowed_values']}" if r["allowed_values"] else ""
+        default = repr(r["default"]) if r["default_known"] else "?"
+        lines.append(
+            f"  {r['subsystem']}.{r['name']:<22} {r['value_type']:<5} "
+            f"default={default}{choices}",
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: print the SettingSpec catalogue (summary / JSON)."""
+    parser = argparse.ArgumentParser(
+        description="Scan the bot's typed SettingSpec declarations (read-only).",
+    )
+    parser.add_argument("--json", action="store_true", help="print raw JSON")
+    args = parser.parse_args(argv)
+
+    records = scan_setting_specs()
+    if args.json:
+        print(json.dumps(records, indent=2, ensure_ascii=False))
+    else:
+        print(_format_summary(records))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_scan_setting_specs.py
+++ b/tests/unit/scripts/test_scan_setting_specs.py
@@ -1,0 +1,96 @@
+"""Tests for ``scripts/scan_setting_specs.py`` — the SettingSpec scanner.
+
+Loaded via ``importlib`` (the repo convention for ``scripts/`` modules). Pure
+stdlib, so it runs in CI with no extra dependencies.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "scan_setting_specs.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("scan_setting_specs_ut", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+SAMPLE_SCHEMA = '''
+from core.runtime.subsystem_schema import SettingSpec
+from utils.settings_keys import MY_FLAG
+
+LOCAL_DEFAULT = True
+
+SAMPLE_SETTINGS = (
+    SettingSpec(
+        name="flag",
+        value_type=bool,
+        default=LOCAL_DEFAULT,
+        settings_key=MY_FLAG,
+        hint="A sample flag.",
+        capability_required="sample.configure",
+    ),
+    SettingSpec(
+        name="mode",
+        value_type=str,
+        default="normal",
+        settings_key="sample_mode",
+        allowed_values=("off", "normal", "strict"),
+    ),
+)
+'''
+
+
+def _write_repo(tmp_path: Path) -> tuple[Path, Path]:
+    cogs = tmp_path / "cogs" / "sample"
+    cogs.mkdir(parents=True)
+    (cogs / "schemas.py").write_text(SAMPLE_SCHEMA, encoding="utf-8")
+    keys = tmp_path / "settings_keys"
+    keys.mkdir()
+    (keys / "sample.py").write_text('MY_FLAG = "my_flag"\n', encoding="utf-8")
+    return tmp_path / "cogs", keys
+
+
+def test_scan_setting_specs_extracts_typed_metadata(mod, tmp_path):
+    cogs_dir, keys_dir = _write_repo(tmp_path)
+    records = mod.scan_setting_specs(cogs_dir=cogs_dir, keys_dir=keys_dir)
+    by_name = {r["name"]: r for r in records}
+
+    flag = by_name["flag"]
+    assert flag["subsystem"] == "sample"
+    assert flag["value_type"] == "bool"
+    assert flag["settings_key"] == "my_flag"  # resolved from the constant
+    assert flag["default"] is True and flag["default_known"] is True  # local const
+    assert flag["hint"] == "A sample flag."
+
+    mode = by_name["mode"]
+    assert mode["settings_key"] == "sample_mode"  # string-literal key
+    assert mode["allowed_values"] == ["off", "normal", "strict"]
+
+
+def test_scan_setting_specs_real_repo(mod):
+    records = mod.scan_setting_specs()
+    assert len(records) >= 50
+    by_key = {r["settings_key"]: r for r in records if r["settings_key"]}
+
+    # An enum-shaped setting surfaces its choices.
+    provider = by_key.get("ai_default_provider")
+    assert provider is not None
+    assert "openai" in provider["allowed_values"]
+
+    # An imported (cross-module) default resolves rather than showing None.
+    enabled = by_key.get("automod_enabled")
+    assert enabled is not None
+    assert enabled["default_known"] is True
+    assert enabled["value_type"] == "bool"


### PR DESCRIPTION
## Why

Foundations-first toward the settings editor. Researching the settings stack surfaced that the bot
**already has** the system — so the right step is to surface its metadata, not rebuild it.

## Discovery (front-end, don't duplicate)

- **`SettingSpec`** (`cogs/*/schemas.py`) already declares each setting's type / default / hint /
  choices; **`SettingsMutationPipeline`** is the audited write seam; `views/settings/` is a full
  in-Discord editor. The "metadata registry" I'd planned **already exists**.
- **`services.command_routing`** (migration 036) already does audited per-cog enable/disable.

So the website is a **front-end over existing audited seams** (the owner's "integrate, don't build a
parallel system; the bot stays the source of truth").

## What

- **`scripts/scan_setting_specs.py`** (stdlib AST) reads the `SettingSpec` declarations → **64 typed
  specs** with `value_type` / `default` / `hint` / `allowed_values`. Resolves `settings_key=XP_MIN` →
  `"xp_min"` and **follows imports** to resolve constant defaults like `default=DEFAULT_ENABLED`
  (only 2/64 stay unresolved → `default_known=False`, never a misleading `None`).
- `export_dashboard_data.py` joins each spec onto its key; **`/settings` now shows a type badge +
  default + hint + enum choices** per typed setting.
- **Plan + router (Q-0158)** record the main-website vision and the `/commands` **management surface**
  (Manage button per command/cog; enable/disable front-ending `command_routing`; per-command alias
  boxes alongside the global `/aliases` search).

## Verification

- `scan_setting_specs.py` → 64 specs; scanner + export tests green (9 passed).
- Dashboard smoke **with deps**: `pytest tests/unit/dashboard/test_app.py` → **17 passed**.
- `python3.10 scripts/check_quality.py --check-only` → green. No `disbot/` runtime touched.

https://claude.ai/code/session_014f52sCSiw4UAmHxxCP7DWV

---
_Generated by [Claude Code](https://claude.ai/code/session_014f52sCSiw4UAmHxxCP7DWV)_