### PR TITLE
docs(dashboard): free multi-user control panel — identity & authority design

### DIFF
--- a/.sessions/2026-06-16-multiuser-control-panel-design.md
+++ b/.sessions/2026-06-16-multiuser-control-panel-design.md
@@ -1,0 +1,49 @@
+# Session — Free multi-user control panel: identity & authority design
+
+> **Status:** `complete`
+
+## Origin
+
+Owner set a major direction: the website is becoming a **free-to-use control panel** (anyone with
+Discord login), where **everyone configures the bot personally** — so the site needs **per-user**
+config as well as per-guild. Explicit: *"don't rush it — first the bot needs to be ready."* Docs-only
+design capture (router **Q-0159**); no runtime built, per the owner's "don't rush."
+
+## Finding (the bot is closer to ready than feared)
+
+Confirmed the bot **already has both config layers**, audited:
+
+- **Per-user:** `user_participation` (migrations 027/028) + `services.participation_mutation` +
+  `core/runtime/user_config.py` + the in-Discord profile editor (`views/profile/`).
+- **Per-guild:** `SettingsMutationPipeline` · `help_overlay` · `command_routing`.
+
+So "everyone changes it personally" is **not new bot work** — it's the existing per-user seam. The
+real **bot-ready** gap is just (1) the control API and (2) an **identity→authority bridge**: the
+control API resolves `(user_id, guild_id)` → member → runs the **existing** capability checks
+(`governance.capability`), so the site shows only allowed controls and every write is bot-verified.
+The site stores only a session; no second source of truth.
+
+## What shipped (this PR — docs only)
+
+- `docs/planning/dashboard-live-editor-plan.md` § "Free multi-user control panel — identity &
+  authority": the multi-user model, the per-user/per-guild seam table, the real readiness gap, and the
+  **bot-ready-first** sequencing.
+- Router **Q-0159** records the decision + provenance.
+
+## Verification
+
+- `python3.10 scripts/check_quality.py --check-only` → green (docs-only; no `.py` changed).
+
+## 💡 Session idea (Q-0089)
+
+**A read-only "your authority" preview on the website (pre-auth).** Even before login lands, the site
+could explain — per subsystem — *which tier/capability* governs each control (already derivable from
+`SettingSpec.capability_required` + the access map). It sets correct expectations for the future
+control panel ("you'll be able to edit X in servers where you're admin; Y is yours personally") and is
+pure read-model — no auth, no bot change. A gentle on-ramp to the multi-user model.
+
+## Documentation audit (Q-0104)
+
+- Owner decision recorded (Q-0159); design has a durable home. `check_docs` green.
+- No runtime touched (owner said don't rush). Pending build questions (cog-vs-command enable/disable;
+  `/commands` management surface go-ahead) remain open and noted for the next turn.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -5977,3 +5977,30 @@ usage-map + Railway management; multi-AI control board) remain in the plan.
 **Home:** [`docs/planning/dashboard-live-editor-plan.md`](../planning/dashboard-live-editor-plan.md)
 § "Command management surface" + "Strategic framing" · `services/command_routing.py` ·
 `services/settings_mutation.py` · this Q-block.
+
+### Q-0159 — Free multi-user control panel: Discord-login identity, per-user config, bot-ready-first (2026-06-16)
+
+> **DECISION 2026-06-16 (owner-directed in-session).** Owner: *"we are building a **free-to-use**
+> control panel of this bot, so we need verification set up — Discord-account login — then the website
+> can see what your permissions are and for which guild/user the changes are. Everyone should be able
+> to change it personally how they like, so we need not only per-guild memory of the configuration but
+> also **per-user**. This was already the plan, but we should **not rush it — first the bot needs to be
+> ready for this**."*
+
+**Decisions / findings:**
+
+- **Free multi-user:** the site is a public control panel (anyone with Discord login), not just the
+  owner. Discord OAuth → identity + guild list; **the bot decides authority** per request.
+- **Per-user config already exists** (don't rebuild): `user_participation` (migrations 027/028) +
+  `services.participation_mutation` + `core/runtime/user_config.py` + the in-Discord profile editor
+  (`views/profile/`). Per-guild exists too. The site front-ends both.
+- **The real "bot-ready" gap is the control API + an identity→authority bridge** — the control API
+  resolves `(user_id, guild_id)` to a member and runs the **existing** capability checks
+  (`governance.capability.actor_holds_capability`), so the site shows only allowed controls and every
+  write is bot-verified. The site stores only a session; no second source of truth.
+- **Sequencing (owner: don't rush):** bot-ready first (control API → identity/authority bridge) →
+  *then* the website Discord login + editors.
+
+**Home:** [`docs/planning/dashboard-live-editor-plan.md`](../planning/dashboard-live-editor-plan.md)
+§ "Free multi-user control panel" · `services/participation_mutation.py` ·
+`governance/capability.py` · this Q-block.

--- a/docs/planning/dashboard-live-editor-plan.md
+++ b/docs/planning/dashboard-live-editor-plan.md
@@ -197,6 +197,40 @@ button on every command and cog**, each opening an editor.
   Manage button on every command and cog — pure dashboard, no bot change. **Write side** (toggle,
   edit alias) lands with the control-API + auth foundation (L0–L2).
 
+## Free multi-user control panel — identity & authority (owner, 2026-06-16)
+
+The owner widened the scope again: the site is becoming a **free-to-use control panel** — *anyone*
+signs in with Discord, not just the owner — and **everyone configures it personally how they like**,
+so the site needs **per-user** config as well as per-guild. Explicit guidance: *"we should not rush
+it — first the bot needs to be ready for this."*
+
+**Good news — both config layers already exist (front-end them):**
+
+| Layer | Bot system (audited) |
+|---|---|
+| **Per-guild** | `guild_settings` + `SettingsMutationPipeline` · `help_overlay` · `command_routing` |
+| **Per-user** | `user_participation` (migrations 027/028) + `services.participation_mutation` + `core/runtime/user_config.py` + the in-Discord profile editor (`views/profile/`) |
+
+So "everyone changes it personally" is **not new bot work** — it is the existing per-user
+participation/preferences seam, surfaced on the web.
+
+**What "bot ready" actually means (the real gap — *not* the config layers):**
+
+1. **The control API** — the bot exposing these seams to the decoupled site (Q-0156).
+2. **An identity → authority bridge.** Discord OAuth tells the site *who* you are and *which guilds*
+   you're in; but **the bot must decide what you may edit**. Every seam already authority-checks with a
+   live `discord.Member` (`governance.capability.actor_holds_capability`, the settings/participation
+   pipelines' capability gate). The control API must, per request, resolve the member for `(user_id,
+   guild_id)` and run that **same** check — so the site renders only the controls you're allowed, and
+   every write is **bot-verified**, never trusted from the browser. Per-user edits gate on "is this
+   your own profile"; per-guild edits gate on your tier in that guild.
+3. **No new source of truth.** The site stores only a session (who you are); all config stays in the
+   bot's per-user / per-guild stores.
+
+**Sequencing (owner: don't rush):** bot-ready first — ① control API, ② the identity→authority bridge
+(reuse the existing capability checks) — *then* the website's Discord login + editors. The per-user +
+per-guild config and their audited seams are already there; the foundation is the API + the bridge.
+
 ## Alternatives considered (and why not)
 
 - **Website writes `help_overlay` rows directly (shared Postgres).** Rejected: bypasses the audited


### PR DESCRIPTION
## Why

The owner set a major direction: the website becomes a **free-to-use control panel** (anyone with
Discord login), where **everyone configures the bot personally** — so it needs **per-user** config as
well as per-guild. Explicit guidance: *"don't rush it — first the bot needs to be ready."* This is a
**docs-only** design capture (no runtime built, per that guidance).

## Finding (the bot is closer to ready than feared)

Both config layers **already exist and are audited**:

- **Per-user:** `user_participation` (migrations 027/028) + `services.participation_mutation` +
  `core/runtime/user_config.py` + the in-Discord profile editor (`views/profile/`).
- **Per-guild:** `SettingsMutationPipeline` · `help_overlay` · `command_routing`.

So "everyone changes it personally" is **not new bot work** — it's the existing per-user seam. The
real **bot-ready** gap is (1) the control API and (2) an **identity→authority bridge**: resolve
`(user_id, guild_id)` → member → run the **existing** `governance.capability` checks, so the site
shows only allowed controls and every write is bot-verified. The site stores only a session.

## What

- `docs/planning/dashboard-live-editor-plan.md` § "Free multi-user control panel — identity &
  authority" (the model, the seam table, the readiness gap, bot-ready-first sequencing).
- Router **Q-0159** records the decision.

## Verification

`python3.10 scripts/check_quality.py --check-only` → green (docs-only; no `.py` changed).

https://claude.ai/code/session_014f52sCSiw4UAmHxxCP7DWV

---
_Generated by [Claude Code](https://claude.ai/code/session_014f52sCSiw4UAmHxxCP7DWV)_