### PR TITLE
feat(dashboard): /commands management surface (READ side) — Manage buttons + per-item panels

### DIFF
--- a/.sessions/2026-06-16-commands-management-surface.md
+++ b/.sessions/2026-06-16-commands-management-surface.md
@@ -1,31 +1,124 @@
 # 2026-06-16 — `/commands` management surface (READ side)
 
-> **Status:** `in-progress` — born-red per Q-0133; flipped to `complete` as the deliberate
-> final step once the work + close-out docs land. Dashboard-only (no `disbot/` runtime).
+> **Status:** `complete` — dashboard-only (no `disbot/` runtime). One PR (#988).
 
-## What I'm about to do
+## Arc
 
-Continue the bot's main website (`dashboard/`). Build the **`/commands` management surface —
-READ side** (Q-0158, owner ask): a **Manage** button on every command *and* every cog, each
-opening a panel that shows that command's current aliases + its cog's routing/enabled model
-(front-ending `services.command_routing`) + a **per-command alias suggest box** (suggest→PR mode,
-like `/aliases` but scoped to one command). The global `/aliases` page stays the broad search.
+Continued the bot's main website (`dashboard/`). Built the **`/commands` management surface —
+READ side** (Q-0158 owner ask): turned the read-only explorer into a management surface — a
+**Manage** button on every command *and* every cog, each opening a slide-over panel. Decoupled +
+read-only (no `disbot/` import, no auth, no bot change); the bot stays the source of truth and the
+site front-ends its existing audited seams (`command_routing` + the synonym layer).
 
-Decoupled + read-only: no `disbot/` import, no auth, no bot change. The write side (live toggle /
-live alias) is gated behind the control API + Discord OAuth (Phase 2), which the owner has **not**
-set up yet — so this session grows the read-only side, as the handoff directs.
+Confirmed the one open architectural fork with the owner first (the handoff + the predecessor
+session both flagged it), then built the whole read side — which ships identically either way.
 
-**Owner decision confirmed this session (AskUserQuestion → Q-0160):** enable/disable is
-**cog-level now, per-command later** — front-end the existing audited `command_routing` (per-cog,
-scope-aware); per-command stays a documented future bot layer.
+## Owner decision (AskUserQuestion → Q-0160)
+
+Q-0158 literally asked to "enable/disable **each command** from the website," but the bot routes
+only at **cog (subsystem)** level today. Per-command would be a new finer bot routing layer.
+**Owner chose: cog-level now, per-command later.** So the panels show **cog-level** routing state;
+the per-command write affordance this session is the **alias suggest box**. Recorded as router
+**Q-0160** (explicit sign-off on the Q-0158 interpretation, so it isn't reopened).
+
+## Shipped (PR #988)
+
+- **`dashboard/templates/commands.html`** — Manage button on every command + cog; a slide-over
+  drawer (vanilla JS, no framework, same style as the existing `/aliases` + `/commands` scripts)
+  populated from `data-*` attrs + three embedded JSON blobs (collision map, synonyms, routable set):
+  - **Command panel:** identity (type / parent / cog / brief / button-backed) · current aliases
+    (code aliases vs soft synonyms, distinguished) · cog-level routing state · a **per-command alias
+    suggest box** — the `/aliases` collision check + prefilled GitHub issue + paste-ready
+    `synonyms.py` snippet, scoped to that one command.
+  - **Cog panel:** identity (class / file / loaded-vs-mixin) · routing state · its command list.
+- **`dashboard/app.py`** — factored `_command_names` / `_build_taken_map` (shared by `/aliases` +
+  `/commands`, DRY) + `_routable_subsystems`; `/commands` now feeds `routable` / `taken` /
+  `synonyms_by_canonical`. `/aliases` refactored onto the shared helpers (unchanged behaviour).
+- **Drive-by fix** — acronym-aware `_cog_to_subsystem` (`scripts/scan_commands.py`): `BTD6Cog`→
+  `btd6`, `AICog`→`ai`, `XPCog`→`xp` (were `b_t_d6`/`a_i`/`x_p`, matching no registry key). Fixes the
+  cog→registry join for those cogs' header emoji/name *and* their routing-key display. Added
+  `visibility_mode` to the exported catalogue so routability is computed precisely (non-internal).
+- Regenerated `dashboard/data/dashboard.json`; updated the plan doc (read side marked shipped).
 
 ## Status checklist
 
-- [ ] acronym-aware `_cog_to_subsystem` (fixes BTD6/AI cog→subsystem join) + test
-- [ ] `/commands` Manage buttons (command + cog) + slide-over panel
-- [ ] per-command alias suggest box (collision check + prefilled issue + snippet)
-- [ ] cog routing-state display (cog-level model, audited seam)
-- [ ] export enrich + regenerate `dashboard.json`
-- [ ] smoke test (web deps) + `check_quality --check-only`
-- [ ] Q-0160 router record + plan-doc update
-- [ ] session enders (idea / review / grooming / docs audit) + flip card `complete`
+- [x] acronym-aware `_cog_to_subsystem` + test
+- [x] `/commands` Manage buttons (command + cog) + slide-over panel
+- [x] per-command alias suggest box (collision check + prefilled issue + snippet)
+- [x] cog routing-state display (cog-level model, audited seam)
+- [x] export enrich (`visibility_mode`) + regenerate `dashboard.json`
+- [x] smoke test (web deps) + `check_quality --check-only`
+- [x] Q-0160 router record + plan-doc update
+- [x] session enders + flip card `complete`
+
+## Verification
+
+- `pip install -r dashboard/requirements.txt httpx` (under `python3.10 -m pip` — bare `pip` hit a
+  different interpreter and silently skipped the suite) → `python3.10 -m pytest tests/unit/dashboard/`
+  → **20 passed** (incl. the new `test_commands_page_has_manage_surface`).
+- `python3.10 -m pytest tests/unit/scripts/test_scan_commands.py` → **8 passed** (incl. the new
+  acronym test); export/scanner script tests **54 passed**.
+- `python3.10 scripts/check_quality.py --check-only` → green; `check_docs --strict` → green.
+- End-to-end render: 301 command + 42 cog Manage buttons, drawer + embedded data present,
+  `data-subsystem="btd6"`×9 / `ai`×14 (acronym join works), `/aliases` still renders.
+
+## 💡 Session idea (Q-0089)
+
+**Dashboard cog↔registry coverage check** — `docs/ideas/dashboard-registry-coverage-check-2026-06-16.md`
+(+ README index). A stdlib self-check (a `--check` mode on the exporter or a unit test) that flags
+scanned cogs whose `subsystem` doesn't resolve to a registered subsystem (split *expected* allow-list
+vs *unexpected* drift) — so a cog rename / new acronym cog / registry-key change that breaks the
+dashboard's cog→registry join **fails a check** instead of silently degrading that cog's card. I hit
+exactly this class this session (the acronym cogs were silently degraded); fixing one class by hand
+proved the failure is invisible. Decided-lane, small.
+
+## ♻️ Backlog grooming (Q-0015)
+
+Advanced the predecessor session's "**your authority preview (pre-auth)**" idea — it was buried in
+the `2026-06-16-multiuser-control-panel-design` session log — into the plan's **Ready read-only
+slices** list (`dashboard-live-editor-plan.md`). It's now a tracked, no-auth, no-bot-change next slice
+and a natural extension of the `/commands` + `/access` read surfaces I just shipped (moved one step
+down its lifecycle: log-note → tracked plannable slice).
+
+## ⟲ Previous-session review (Q-0102)
+
+Reviewed **`2026-06-16-multiuser-control-panel-design.md`** (the design session that handed off to
+me; router Q-0159). **Did well:** it correctly resisted the urge to build — owner said "don't rush,
+bot first" — and instead nailed the *finding* that both config layers already exist, so the real gap
+is just the control API + identity→authority bridge. That framing made my session trivial to scope.
+It also explicitly listed its open questions ("cog-vs-command enable/disable; `/commands` go-ahead")
+at the bottom — and I resolved exactly those, which is the handoff loop working as designed.
+**Could've gone further:** its own 💡 idea (the authority preview) was a *read-only, no-auth* slice it
+could have started building in that same session instead of leaving the whole read side to me — the
+"don't rush" applied to the *runtime* (control API / OAuth), not to read-only website work, so there
+was idle read-only capacity. **System improvement it surfaces:** a session's 💡 idea, when it's
+itself a small same-lane read-only slice, tends to get stranded in the log (the predecessor's did;
+I had to go dig it out to groom it). The grooming ender *catches* this, but late. A lighter fix:
+when a session's own 💡 idea is small + decided-lane + same-lane, it should either be executed in
+that session or filed as a proper idea file then (not only in the log) — i.e. close the Q-0089→Q-0015
+gap at *creation* time, not one session later. (Captured here as the workflow note, not a rule change
+— CLAUDE.md is propose-only.)
+
+## Documentation audit (Q-0104)
+
+- Owner decision recorded (Q-0160, router + plan); new idea filed + README-indexed; plan doc updated
+  (read side shipped + the groomed slice). `check_docs --strict` green; `check_quality --check-only`
+  green.
+- **Ledger backlog deliberately untouched (Q-0124):** the SessionStart banner flagged 8 merged PRs
+  not yet in `current-state.md` (#979/#978/#976/#974/…). That's the **automated reconciliation**
+  routine's job, not a manual build session's — and the Recently-shipped ratchet is already at 20, so
+  adding them needs an archive pass (reconciliation). My own PR (#988) isn't merged yet, so it's
+  correctly absent. Nothing from *this* session is missing a durable home.
+
+## Context delta
+
+- The bot's **command routing is cog-level only** and keys on the **subsystem key** (snake_case,
+  e.g. `games`/`economy`), *not* the cog class name — verified in `services/access_projection.py`
+  (axis 3) + `views/setup/sections/cog_routing.py` (operator picker = non-internal SUBSYSTEMS keys).
+  Default is **enabled** (channel→category→guild→default-true); routing only *restricts*.
+- The dashboard cog→registry join was silently broken for **acronym cogs** (naive CamelCase split);
+  fixed here for the whole class. ~10/42 cog entries still don't resolve (module/mixins + genuinely
+  unregistered cogs) — captured as the Q-0089 coverage-check idea.
+- Per-guild routing state is **runtime DB** — the static dashboard shows the *model* (default +
+  scope + the audited seam), never a fabricated live value; live state + toggling needs the control
+  API (Phase 2, OAuth not yet set up by the owner → read-only side is the lane to grow).

--- a/.sessions/2026-06-16-commands-management-surface.md
+++ b/.sessions/2026-06-16-commands-management-surface.md
@@ -1,0 +1,31 @@
+# 2026-06-16 — `/commands` management surface (READ side)
+
+> **Status:** `in-progress` — born-red per Q-0133; flipped to `complete` as the deliberate
+> final step once the work + close-out docs land. Dashboard-only (no `disbot/` runtime).
+
+## What I'm about to do
+
+Continue the bot's main website (`dashboard/`). Build the **`/commands` management surface —
+READ side** (Q-0158, owner ask): a **Manage** button on every command *and* every cog, each
+opening a panel that shows that command's current aliases + its cog's routing/enabled model
+(front-ending `services.command_routing`) + a **per-command alias suggest box** (suggest→PR mode,
+like `/aliases` but scoped to one command). The global `/aliases` page stays the broad search.
+
+Decoupled + read-only: no `disbot/` import, no auth, no bot change. The write side (live toggle /
+live alias) is gated behind the control API + Discord OAuth (Phase 2), which the owner has **not**
+set up yet — so this session grows the read-only side, as the handoff directs.
+
+**Owner decision confirmed this session (AskUserQuestion → Q-0160):** enable/disable is
+**cog-level now, per-command later** — front-end the existing audited `command_routing` (per-cog,
+scope-aware); per-command stays a documented future bot layer.
+
+## Status checklist
+
+- [ ] acronym-aware `_cog_to_subsystem` (fixes BTD6/AI cog→subsystem join) + test
+- [ ] `/commands` Manage buttons (command + cog) + slide-over panel
+- [ ] per-command alias suggest box (collision check + prefilled issue + snippet)
+- [ ] cog routing-state display (cog-level model, audited seam)
+- [ ] export enrich + regenerate `dashboard.json`
+- [ ] smoke test (web deps) + `check_quality --check-only`
+- [ ] Q-0160 router record + plan-doc update
+- [ ] session enders (idea / review / grooming / docs audit) + flip card `complete`

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -49,6 +49,46 @@ def load_data() -> dict[str, Any]:
         return dict(_EMPTY)
 
 
+def _command_names(data: dict[str, Any]) -> list[str]:
+    """Sorted, de-duplicated set of every command name across all cogs."""
+    return sorted({c["name"] for cog in data.get("cogs", []) for c in cog["commands"]})
+
+
+def _build_taken_map(data: dict[str, Any]) -> dict[str, str]:
+    """Map every token already in use -> a human label of what owns it.
+
+    Synonyms first, then aliases, then command names last so the strongest owner
+    (a real command) wins a tie. Shared by ``/aliases`` and the per-command alias
+    box on ``/commands`` so both apply identical collision logic.
+    """
+    taken: dict[str, str] = {}
+    for syn in data.get("synonyms", []):
+        for token in syn["synonyms"]:
+            taken[token.lower()] = f"synonym of !{syn['canonical']}"
+    for cog in data.get("cogs", []):
+        for cmd in cog["commands"]:
+            for token in cmd.get("aliases") or []:
+                taken[token.lower()] = f"alias of !{cmd['name']}"
+    for name in _command_names(data):
+        taken[name.lower()] = "a command"
+    return taken
+
+
+def _routable_subsystems(data: dict[str, Any]) -> list[str]:
+    """Operator-routable subsystem keys — registered and not internal.
+
+    Mirrors ``views/setup/sections/cog_routing.py``: ``command_routing`` keys on
+    the subsystem key and only non-internal subsystems appear in the operator
+    routing picker, so this is the set a cog's per-server enable/disable state
+    applies to.
+    """
+    return sorted(
+        entry["key"]
+        for entry in data.get("catalogue", [])
+        if entry.get("visibility_mode", "normal") != "internal"
+    )
+
+
 @app.get("/healthz")
 def healthz() -> dict[str, str]:
     """Liveness probe (used by Railway)."""
@@ -168,30 +208,14 @@ def aliases(request: Request):
     prefilled GitHub issue and a ready-to-paste ``synonyms.py`` snippet.
     """
     data = load_data()
-    commands_list = sorted(
-        {c["name"] for cog in data.get("cogs", []) for c in cog["commands"]},
-    )
-    # Map every token already in use -> what owns it, so the suggestion form can
-    # say *why* a proposed alias collides. Synonyms first, then aliases, then
-    # command names last so the strongest owner (a real command) wins a tie.
-    taken: dict[str, str] = {}
-    for syn in data.get("synonyms", []):
-        for token in syn["synonyms"]:
-            taken[token.lower()] = f"synonym of !{syn['canonical']}"
-    for cog in data.get("cogs", []):
-        for cmd in cog["commands"]:
-            for token in cmd.get("aliases") or []:
-                taken[token.lower()] = f"alias of !{cmd['name']}"
-    for name in commands_list:
-        taken[name.lower()] = "a command"
     return templates.TemplateResponse(
         request,
         "aliases.html",
         {
             "data": data,
             "page": "aliases",
-            "commands": commands_list,
-            "taken": taken,
+            "commands": _command_names(data),
+            "taken": _build_taken_map(data),
         },
     )
 
@@ -243,7 +267,14 @@ def status(request: Request):
 
 @app.get("/commands", response_class=HTMLResponse)
 def commands(request: Request):
-    """Cog & command explorer — invocation type (prefix/slash) + button backing."""
+    """Cog & command management surface — explorer + a per-item Manage panel.
+
+    The read side of the Q-0158 ask: every command and cog gets a Manage button
+    opening a panel with its current aliases, its cog's (cog-level) routing
+    state, and a per-command alias suggest box. Front-ends the bot's seams
+    (``command_routing`` + the synonym layer); the live write side lands with the
+    control API (Phase 2). Owner direction Q-0160: routing is cog-level.
+    """
     data = load_data()
     cmds = [c for cog in data.get("cogs", []) for c in cog["commands"]]
     stats = {
@@ -260,5 +291,15 @@ def commands(request: Request):
     return templates.TemplateResponse(
         request,
         "commands.html",
-        {"data": data, "page": "commands", "stats": stats, "sysmap": sysmap},
+        {
+            "data": data,
+            "page": "commands",
+            "stats": stats,
+            "sysmap": sysmap,
+            "routable": _routable_subsystems(data),
+            "taken": _build_taken_map(data),
+            "synonyms_by_canonical": {
+                s["canonical"]: s["synonyms"] for s in data.get("synonyms", [])
+            },
+        },
     )

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,11 +1,11 @@
 {
   "meta": {
-    "generated_at": "2026-06-16T20:18:37Z",
+    "generated_at": "2026-06-16T20:40:29Z",
     "build": {
-      "commit": "ad042439",
-      "subject": "feat(dashboard): /status — live build & health surface (Q-0156)",
-      "committed_at": "2026-06-16T20:16:37Z",
-      "branch": "claude/magical-rubin-ci82qw"
+      "commit": "eb2141b",
+      "subject": "chore(session): open /commands management surface (READ side) — born-red card",
+      "committed_at": "2026-06-16T20:36:06Z",
+      "branch": "claude/practical-turing-pnppjf"
     },
     "counts": {
       "functions": 33,
@@ -29,6 +29,7 @@
       "description": "Read-only AI gateway diagnostics: provider state, feature flags, task routing, and request/failure counters. Does not own AI provider logic — that lives in core/runtime/ai/.",
       "emoji": "🤖",
       "visibility_tier": "administrator",
+      "visibility_mode": "normal",
       "category": "admin",
       "tags": [
         "ai",
@@ -59,6 +60,7 @@
       "description": "Cog management, server stats, diagnostics",
       "emoji": "⚙️",
       "visibility_tier": "administrator",
+      "visibility_mode": "normal",
       "category": "admin",
       "tags": [
         "admin",
@@ -85,6 +87,7 @@
       "description": "Bot health, latency, and system diagnostics",
       "emoji": "🩺",
       "visibility_tier": "administrator",
+      "visibility_mode": "normal",
       "category": "admin",
       "tags": [
         "diagnostics",
@@ -111,6 +114,7 @@
       "description": "Per-guild moderation/cleanup event logging — channel selection, auto-create, and audit (S7)",
       "emoji": "📝",
       "visibility_tier": "administrator",
+      "visibility_mode": "normal",
       "category": "admin",
       "tags": [
         "logging",
@@ -138,6 +142,7 @@
       "description": "Unified hub for moderation, channels, roles, cleanup, setup",
       "emoji": "🧭",
       "visibility_tier": "administrator",
+      "visibility_mode": "normal",
       "category": "admin",
       "tags": [
         "admin",
@@ -160,6 +165,7 @@
       "description": "Read-only browsing of platform settings, bindings, and audit history (S5)",
       "emoji": "⚙️",
       "visibility_tier": "administrator",
+      "visibility_mode": "normal",
       "category": "admin",
       "tags": [
         "settings",
@@ -184,6 +190,7 @@
       "description": "Interface gallery — browse UI patterns, all fake & safe",
       "emoji": "🧪",
       "visibility_tier": "administrator",
+      "visibility_mode": "normal",
       "category": "admin",
       "tags": [
         "admin",
@@ -203,6 +210,7 @@
       "description": "Progression, roles, and community activities",
       "emoji": "🌱",
       "visibility_tier": "user",
+      "visibility_mode": "normal",
       "category": "community",
       "tags": [
         "community",
@@ -229,6 +237,7 @@
       "description": "Live server activity dashboard — leaders, level-ups, game stats",
       "emoji": "🌟",
       "visibility_tier": "user",
+      "visibility_mode": "normal",
       "category": "community",
       "tags": [
         "spotlight",
@@ -254,6 +263,7 @@
       "description": "Live member-count channels (total · humans · bots)",
       "emoji": "📊",
       "visibility_tier": "administrator",
+      "visibility_mode": "normal",
       "category": "community",
       "tags": [
         "counters",
@@ -278,6 +288,7 @@
       "description": "Member greetings, farewells, and an optional entry role",
       "emoji": "👋",
       "visibility_tier": "administrator",
+      "visibility_mode": "normal",
       "category": "community",
       "tags": [
         "welcome",
@@ -302,6 +313,7 @@
       "description": "Daily coins, work, shop, balance",
       "emoji": "💰",
       "visibility_tier": "user",
+      "visibility_mode": "normal",
       "category": "economy",
       "tags": [
         "economy",
@@ -333,6 +345,7 @@
       "description": "Item management and crafting",
       "emoji": "🎒",
       "visibility_tier": "user",
+      "visibility_mode": "normal",
       "category": "economy",
       "tags": [
         "inventory",
@@ -358,6 +371,7 @@
       "description": "Mining minigame and resource collection",
       "emoji": "⛏️",
       "visibility_tier": "user",
+      "visibility_mode": "normal",
       "category": "economy",
       "tags": [
         "mining",
@@ -383,6 +397,7 @@
       "description": "Deterministic Bloons Tower Defense 6 assistant — tower/hero/map lookups, round threat summaries, and CHIMPS-mode guidance. Built on validated fixtures; consumes the AI gateway only when explicitly enabled (Module 5).",
       "emoji": "🐵",
       "visibility_tier": "user",
+      "visibility_mode": "normal",
       "category": "games",
       "tags": [
         "games",
@@ -410,6 +425,7 @@
       "description": "Blackjack card game",
       "emoji": "🃏",
       "visibility_tier": "user",
+      "visibility_mode": "normal",
       "category": "games",
       "tags": [
         "games",
@@ -435,6 +451,7 @@
       "description": "Collaborative counting game",
       "emoji": "🔢",
       "visibility_tier": "user",
+      "visibility_mode": "normal",
       "category": "games",
       "tags": [
         "games",
@@ -456,6 +473,7 @@
       "description": "1v1 duel battles",
       "emoji": "⚔️",
       "visibility_tier": "user",
+      "visibility_mode": "normal",
       "category": "games",
       "tags": [
         "games",
@@ -482,6 +500,7 @@
       "description": "Competitive games and channel activities",
       "emoji": "🎮",
       "visibility_tier": "user",
+      "visibility_mode": "normal",
       "category": "games",
       "tags": [
         "games",
@@ -509,6 +528,7 @@
       "description": "Rock Paper Scissors: quick play, PvP, bot matches, tournaments",
       "emoji": "✂️",
       "visibility_tier": "user",
+      "visibility_mode": "normal",
       "category": "games",
       "tags": [
         "games",
@@ -530,6 +550,7 @@
       "description": "Word-chaining game",
       "emoji": "🔗",
       "visibility_tier": "user",
+      "visibility_mode": "normal",
       "category": "games",
       "tags": [
         "games",
@@ -552,6 +573,7 @@
       "description": "Channel and category creation, deletion, and restrictions",
       "emoji": "📐",
       "visibility_tier": "administrator",
+      "visibility_mode": "normal",
       "category": "management",
       "tags": [
         "channels",
@@ -576,6 +598,7 @@
       "description": "Time-based and XP-based automatic role assignment",
       "emoji": "🎭",
       "visibility_tier": "administrator",
+      "visibility_mode": "normal",
       "category": "management",
       "tags": [
         "roles",
@@ -601,6 +624,7 @@
       "description": "Spam, invite links, excessive caps, and mass-mention filtering",
       "emoji": "🛡️",
       "visibility_tier": "administrator",
+      "visibility_mode": "normal",
       "category": "moderation",
       "tags": [
         "automod",
@@ -626,6 +650,7 @@
       "description": "Prohibited words, command deletion, channel hygiene",
       "emoji": "🧹",
       "visibility_tier": "administrator",
+      "visibility_mode": "normal",
       "category": "moderation",
       "tags": [
         "cleanup",
@@ -654,6 +679,7 @@
       "description": "Warnings, timeouts, bans, mod logs",
       "emoji": "🔨",
       "visibility_tier": "moderator",
+      "visibility_mode": "normal",
       "category": "moderation",
       "tags": [
         "moderation",
@@ -689,6 +715,7 @@
       "description": "Proof submission and exclusive access sessions",
       "emoji": "📋",
       "visibility_tier": "staff",
+      "visibility_mode": "normal",
       "category": "moderation",
       "tags": [
         "proof",
@@ -716,6 +743,7 @@
       "description": "Server leaderboards for XP, coins, and games",
       "emoji": "🏆",
       "visibility_tier": "user",
+      "visibility_mode": "normal",
       "category": "progression",
       "tags": [
         "leaderboard",
@@ -741,6 +769,7 @@
       "description": "Experience points, levels, and leaderboards",
       "emoji": "⭐",
       "visibility_tier": "user",
+      "visibility_mode": "normal",
       "category": "progression",
       "tags": [
         "xp",
@@ -768,6 +797,7 @@
       "description": "A leafy little easter-egg panel — wisdom and number trivia",
       "emoji": "🍃",
       "visibility_tier": "user",
+      "visibility_mode": "normal",
       "category": "utility",
       "tags": [
         "fun",
@@ -791,6 +821,7 @@
       "description": "General bot commands and information",
       "emoji": "💬",
       "visibility_tier": "user",
+      "visibility_mode": "normal",
       "category": "utility",
       "tags": [
         "general",
@@ -814,6 +845,7 @@
       "description": "Interactive help menu and command discovery",
       "emoji": "📚",
       "visibility_tier": "user",
+      "visibility_mode": "normal",
       "category": "utility",
       "tags": [
         "help",
@@ -835,6 +867,7 @@
       "description": "General utility commands",
       "emoji": "🔧",
       "visibility_tier": "user",
+      "visibility_mode": "normal",
       "category": "utility",
       "tags": [
         "utility",
@@ -1716,6 +1749,12 @@
       "status": "complete"
     },
     {
+      "file": "2026-06-16-commands-management-surface.md",
+      "date": "2026-06-16",
+      "title": "2026-06-16 — `/commands` management surface (READ side)",
+      "status": "in-progress"
+    },
+    {
       "file": "2026-06-16-command-count-reconcile.md",
       "date": "2026-06-16",
       "title": "Session — Reconcile command counts (website breakdown + bot status embed)",
@@ -1815,12 +1854,6 @@
       "file": "2026-06-15-reconcile.md",
       "date": "2026-06-15",
       "title": "Session — 2026-06-15 · band-#900 docs reconciliation (eighth Q-0107 pass)",
-      "status": "complete"
-    },
-    {
-      "file": "2026-06-15-reconcile-band930.md",
-      "date": "2026-06-15",
-      "title": "Session — 2026-06-15 · band-#930 docs reconciliation (ninth Q-0107 pass)",
       "status": "complete"
     }
   ],
@@ -2469,7 +2502,7 @@
     {
       "cog": "AICog",
       "file": "disbot/cogs/ai_cog.py",
-      "subsystem": "a_i",
+      "subsystem": "ai",
       "is_cog": true,
       "commands": [
         {
@@ -2776,7 +2809,7 @@
     {
       "cog": "BTD6Cog",
       "file": "disbot/cogs/btd6_cog.py",
-      "subsystem": "b_t_d6",
+      "subsystem": "btd6",
       "is_cog": true,
       "commands": [
         {
@@ -2872,7 +2905,7 @@
     {
       "cog": "BTD6EventsCog",
       "file": "disbot/cogs/btd6_events_cog.py",
-      "subsystem": "b_t_d6_events",
+      "subsystem": "btd6_events",
       "is_cog": true,
       "commands": [
         {
@@ -2979,7 +3012,7 @@
     {
       "cog": "BTD6OpsCog",
       "file": "disbot/cogs/btd6_ops_cog.py",
-      "subsystem": "b_t_d6_ops",
+      "subsystem": "btd6_ops",
       "is_cog": true,
       "commands": [
         {
@@ -3064,7 +3097,7 @@
     {
       "cog": "BTD6ReferenceCog",
       "file": "disbot/cogs/btd6_reference_cog.py",
-      "subsystem": "b_t_d6_reference",
+      "subsystem": "btd6_reference",
       "is_cog": true,
       "commands": [
         {
@@ -3138,7 +3171,7 @@
     {
       "cog": "BTD6StrategyCog",
       "file": "disbot/cogs/btd6_strategy_cog.py",
-      "subsystem": "b_t_d6_strategy",
+      "subsystem": "btd6_strategy",
       "is_cog": true,
       "commands": [
         {

--- a/dashboard/templates/commands.html
+++ b/dashboard/templates/commands.html
@@ -8,8 +8,8 @@
   the bot's status embed reports (<code>len(bot.commands)</code>); the other {{ stats.subcommands }}
   subcommands and {{ stats.slash }} slash commands live in <code>bot.tree</code> and aren't in that
   count. A <span class="text-sky-300">🔘 button</span> tag means the command is a panel button's action
-  or opens a view. (The bot's "Loaded cogs" count is higher — it also counts listener/task cogs that
-  declare no commands.)
+  or opens a view. Click <span class="text-sky-300">Manage</span> on any command or cog to see its
+  aliases, its cog's routing state, and suggest a per-command alias.
 </p>
 
 <section class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-6">
@@ -43,13 +43,24 @@
 
 {% for cog in data.cogs %}
   {% set sys = sysmap.get(cog.subsystem) %}
+  {% set cog_display = sys.display_name if sys and sys.display_name else cog.cog %}
+  {% set cog_emoji = sys.emoji if sys and sys.emoji else "🧩" %}
   <section class="cog mb-6 rounded-xl border border-slate-800 bg-slate-900/40">
     <div class="flex items-center gap-2 px-4 py-3 border-b border-slate-800">
-      <span class="text-xl">{{ sys.emoji if sys and sys.emoji else "🧩" }}</span>
-      <span class="font-semibold">{{ sys.display_name if sys and sys.display_name else cog.cog }}</span>
+      <span class="text-xl">{{ cog_emoji }}</span>
+      <span class="font-semibold">{{ cog_display }}</span>
       <span class="text-xs text-slate-500">{{ cog.cog }}</span>
       {% if not cog.is_cog %}<span class="text-[10px] rounded px-1.5 py-0.5 bg-slate-800 text-slate-500">{{ 'module' if cog.cog.startswith('(') else 'mixin' }}</span>{% endif %}
-      <span class="ml-auto text-[11px] text-slate-500">{{ cog.commands|length }} cmd{{ '' if cog.commands|length == 1 else 's' }}</span>
+      <span class="text-[11px] text-slate-500">{{ cog.commands|length }} cmd{{ '' if cog.commands|length == 1 else 's' }}</span>
+      <button type="button"
+        class="manage-btn ml-auto text-[11px] rounded border border-slate-700 px-2 py-1 hover:border-sky-500 hover:text-sky-300"
+        data-kind="cog"
+        data-cog="{{ cog.cog }}"
+        data-cog-display="{{ cog_display }}"
+        data-cog-emoji="{{ cog_emoji }}"
+        data-subsystem="{{ cog.subsystem }}"
+        data-file="{{ cog.file }}"
+        data-iscog="{{ '1' if cog.is_cog else '0' }}">⚙️ Manage</button>
     </div>
     <ul class="divide-y divide-slate-800/70">
       {% for cmd in cog.commands %}
@@ -73,6 +84,20 @@
             {% if cmd.aliases %}
               <span class="text-[10px] text-slate-500">aka {{ cmd.aliases | join(', ') }}</span>
             {% endif %}
+            <button type="button"
+              class="manage-btn ml-auto text-[11px] rounded border border-slate-700 px-2 py-1 hover:border-sky-500 hover:text-sky-300"
+              data-kind="command"
+              data-name="{{ cmd.name }}"
+              data-invoke="{{ '/' if cmd.type == 'slash' else '!' }}"
+              data-type="{{ cmd.type }}"
+              data-parent="{{ cmd.parent or '' }}"
+              data-cog="{{ cog.cog }}"
+              data-cog-display="{{ cog_display }}"
+              data-cog-emoji="{{ cog_emoji }}"
+              data-subsystem="{{ cog.subsystem }}"
+              data-brief="{{ cmd.brief }}"
+              data-aliases="{{ cmd.aliases | join(',') }}"
+              data-button="{{ '1' if cmd.button_backed else '0' }}">⚙️ Manage</button>
           </div>
           {% if cmd.brief %}<p class="mt-1 text-xs text-slate-400">{{ cmd.brief }}</p>{% endif %}
         </li>
@@ -83,8 +108,24 @@
   <p class="text-slate-500">No commands found.</p>
 {% endfor %}
 
+<!-- Slide-over Manage panel (populated client-side) -->
+<div id="drawer-overlay" class="hidden fixed inset-0 bg-black/60 z-20"></div>
+<aside id="drawer"
+  class="hidden fixed top-0 right-0 z-30 h-full w-full max-w-md overflow-y-auto border-l border-slate-800 bg-slate-900 p-5 shadow-2xl">
+  <div class="mb-4 flex items-start justify-between gap-3">
+    <h2 id="drawer-title" class="text-lg font-bold leading-tight"></h2>
+    <button id="drawer-close" type="button"
+      class="shrink-0 rounded px-2 text-xl text-slate-400 hover:text-white">✕</button>
+  </div>
+  <div id="drawer-body" class="space-y-4 text-sm"></div>
+</aside>
+
+<script id="taken-data" type="application/json">{{ taken | tojson }}</script>
+<script id="syn-data" type="application/json">{{ synonyms_by_canonical | tojson }}</script>
+<script id="routable-data" type="application/json">{{ routable | tojson }}</script>
 <script>
   (function () {
+    // ---- search + filter (unchanged behaviour) -----------------------------
     const search = document.getElementById("cmd-search");
     const chips = document.querySelectorAll(".cmd-chip");
     let typeFilter = "all";
@@ -114,6 +155,205 @@
         apply();
       }),
     );
+
+    // ---- shared data -------------------------------------------------------
+    const taken = JSON.parse(document.getElementById("taken-data").textContent);
+    const synMap = JSON.parse(document.getElementById("syn-data").textContent);
+    const routable = new Set(JSON.parse(document.getElementById("routable-data").textContent));
+    const REPO = "menno420/superbot";
+
+    function esc(s) {
+      return String(s).replace(/[&<>"']/g, (c) =>
+        ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]),
+      );
+    }
+    function note(kind, text) {
+      const cls =
+        kind === "error"
+          ? "border-rose-900/60 bg-rose-950/40 text-rose-300"
+          : "border-emerald-900/60 bg-emerald-950/40 text-emerald-300";
+      return '<p class="rounded border ' + cls + ' px-3 py-2 text-sm">' + esc(text) + "</p>";
+    }
+    function section(title) {
+      return '<h3 class="text-xs font-semibold uppercase tracking-wide text-slate-500">' + esc(title) + "</h3>";
+    }
+    function chip(text, cls) {
+      return '<span class="inline-block rounded px-1.5 py-0.5 text-[11px] ' + (cls || "bg-slate-800 text-slate-300") + '">' + esc(text) + "</span>";
+    }
+
+    // ---- routing-state block (cog-level — Q-0160) --------------------------
+    function routingBlock(subsystem, cogDisplay) {
+      const isRoutable = routable.has(subsystem);
+      let body;
+      if (isRoutable) {
+        body =
+          '<p class="text-slate-300"><span class="font-medium text-emerald-300">Enabled by default.</span> ' +
+          "An admin can enable / disable the " + chip(subsystem, "bg-slate-800 text-sky-300") +
+          " cog per <strong>server</strong>, <strong>category</strong>, or <strong>channel</strong> " +
+          "via <strong>Cog routing</strong> (<code>!settings</code> → Cog routing, or the Setup wizard). " +
+          "Writes go through the audited <code>command_routing.set_policy</code> seam " +
+          "(channel → category → guild → default-on).</p>";
+      } else {
+        body =
+          '<p class="text-slate-400">This cog isn’t gated by operator <strong>cog routing</strong> ' +
+          "(it isn’t a registered routable subsystem). Its commands follow the bot’s standard " +
+          "command access — tiers &amp; visibility (see <a class='underline hover:text-sky-300' href='/access'>Access</a>).</p>";
+      }
+      return (
+        '<div class="space-y-2">' +
+        section("Cog routing — " + cogDisplay) +
+        body +
+        '<p class="text-xs text-slate-500">Routing is <strong>cog-level</strong> today ' +
+        "(owner direction Q-0160). Live per-server state &amp; toggling from this site arrive with the " +
+        "bot control API (Phase 2); per-command enable/disable is a documented future bot layer.</p>" +
+        "</div>"
+      );
+    }
+
+    // ---- per-command alias suggest box (scoped /aliases) -------------------
+    function aliasBox(cmd) {
+      const existing = synMap[cmd] || [];
+      const id = "alias-in-" + Math.random().toString(36).slice(2);
+      const current = existing.length
+        ? '<p class="text-xs text-slate-500">Current synonyms: ' +
+          existing.map((s) => chip(s, "bg-slate-800 text-slate-300")).join(" ") + "</p>"
+        : '<p class="text-xs text-slate-500">No synonyms yet for <code>!' + esc(cmd) + "</code>.</p>";
+      const html =
+        '<div class="space-y-2">' +
+        section("Add an alias for !" + cmd) +
+        current +
+        '<input id="' + id + '" autocomplete="off" placeholder="propose an alias, e.g. lb" ' +
+        'class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none" />' +
+        '<div class="alias-out"></div>' +
+        '<p class="text-[11px] text-slate-500">💡 Suggests a synonym (edits ' +
+        "<code>disbot/utils/synonyms.py</code>) → reaches the live bot on the next deploy. " +
+        "Live alias editing (no deploy) lands with the control API.</p>" +
+        "</div>";
+      return { html, id, existing };
+    }
+    function wireAliasBox(cmd, mount) {
+      const box = aliasBox(cmd);
+      mount.innerHTML = box.html;
+      const input = mount.querySelector("#" + box.id);
+      const out = mount.querySelector(".alias-out");
+      function render() {
+        const alias = (input.value || "").trim().toLowerCase();
+        if (!alias) { out.innerHTML = ""; return; }
+        if (/\s/.test(alias)) { out.innerHTML = note("error", "Aliases can’t contain spaces."); return; }
+        const owner = taken[alias];
+        if (owner) { out.innerHTML = note("error", "“" + alias + "” is already " + owner + "."); return; }
+        const updated = box.existing.concat([alias]);
+        const snippet = '"' + cmd + '": [' + updated.map((s) => '"' + s + '"').join(", ") + "],";
+        const title = "Alias suggestion: !" + cmd + " → " + alias;
+        const body = [
+          "**Command:** `!" + cmd + "`",
+          "**Proposed alias:** `" + alias + "`",
+          "",
+          "Add to `disbot/utils/synonyms.py` (`COMMAND_SYNONYMS`):",
+          "```python", snippet, "```",
+          "",
+          "_Suggested via the dashboard /commands Manage panel._",
+        ].join("\n");
+        const url =
+          "https://github.com/" + REPO + "/issues/new?labels=alias-suggestion&title=" +
+          encodeURIComponent(title) + "&body=" + encodeURIComponent(body);
+        out.innerHTML =
+          note("ok", "“" + alias + "” is free — no command, alias, or synonym uses it.") +
+          '<div class="mt-2"><a target="_blank" rel="noopener" class="inline-block rounded bg-sky-600 hover:bg-sky-500 px-3 py-1.5 text-sm font-medium" href="' +
+          url + '">Open a prefilled GitHub issue →</a></div>' +
+          '<pre class="mt-2 overflow-x-auto rounded bg-slate-950 border border-slate-800 p-3 text-xs text-slate-200"><code>' +
+          esc(snippet) + "</code></pre>";
+      }
+      input.addEventListener("input", render);
+    }
+
+    // ---- drawer ------------------------------------------------------------
+    const overlay = document.getElementById("drawer-overlay");
+    const drawer = document.getElementById("drawer");
+    const drawerTitle = document.getElementById("drawer-title");
+    const drawerBody = document.getElementById("drawer-body");
+
+    function openDrawer() {
+      overlay.classList.remove("hidden");
+      drawer.classList.remove("hidden");
+    }
+    function closeDrawer() {
+      overlay.classList.add("hidden");
+      drawer.classList.add("hidden");
+      drawerBody.innerHTML = "";
+    }
+    overlay.addEventListener("click", closeDrawer);
+    document.getElementById("drawer-close").addEventListener("click", closeDrawer);
+    document.addEventListener("keydown", (e) => { if (e.key === "Escape") closeDrawer(); });
+
+    function renderCommand(d) {
+      drawerTitle.innerHTML = esc(d.invoke + d.name) +
+        ' <span class="text-xs font-normal text-slate-500">' + esc(d.type) + "</span>";
+      const codeAliases = (d.aliases || "").split(",").filter(Boolean);
+      const softSyns = synMap[d.name] || [];
+      const meta =
+        '<div class="space-y-1">' + section("Command") +
+        '<p class="text-slate-300">' + esc(d.brief || "No description.") + "</p>" +
+        '<p class="text-xs text-slate-500">Cog: ' + esc(d.cogEmoji + " " + d.cogDisplay) +
+        " <span class='text-slate-600'>(" + esc(d.cog) + ")</span>" +
+        (d.parent ? " · subcommand of <code>" + esc(d.parent) + "</code>" : "") +
+        (d.button === "1" ? " · 🔘 button-backed" : "") + "</p></div>";
+      const aliasState =
+        '<div class="space-y-1">' + section("Current aliases") +
+        (codeAliases.length
+          ? '<p class="text-xs text-slate-500">Code aliases (in the command decorator): ' +
+            codeAliases.map((a) => chip(a, "bg-violet-950 text-violet-200")).join(" ") + "</p>"
+          : '<p class="text-xs text-slate-500">No code aliases.</p>') +
+        (softSyns.length
+          ? '<p class="text-xs text-slate-500">Soft synonyms (editable below): ' +
+            softSyns.map((a) => chip(a, "bg-slate-800 text-slate-300")).join(" ") + "</p>"
+          : '<p class="text-xs text-slate-500">No soft synonyms yet.</p>') +
+        "</div>";
+      const aliasMount = '<div data-alias-mount></div>';
+      drawerBody.innerHTML = meta + aliasState + routingBlock(d.subsystem, d.cogDisplay) + aliasMount;
+      wireAliasBox(d.name, drawerBody.querySelector("[data-alias-mount]"));
+    }
+
+    function renderCog(d, sectionEl) {
+      drawerTitle.innerHTML = esc(d.cogEmoji + " " + d.cogDisplay) +
+        ' <span class="text-xs font-normal text-slate-500">' + esc(d.cog) + "</span>";
+      const names = sectionEl
+        ? Array.from(sectionEl.querySelectorAll("li.cmd code")).map((c) => c.textContent.trim())
+        : [];
+      const meta =
+        '<div class="space-y-1">' + section("Cog") +
+        '<p class="text-xs text-slate-500"><code>' + esc(d.file) + "</code>" +
+        (d.iscog === "1" ? "" : " · not a loaded cog (mixin / module)") + "</p>" +
+        "</div>";
+      const cmdList =
+        '<div class="space-y-1">' + section(names.length + " command" + (names.length === 1 ? "" : "s")) +
+        (names.length
+          ? '<div class="flex flex-wrap gap-1">' +
+            names.map((n) => chip(n, "bg-slate-800 text-sky-300")).join("") + "</div>"
+          : '<p class="text-xs text-slate-500">No commands.</p>') +
+        "</div>";
+      drawerBody.innerHTML = meta + routingBlock(d.subsystem, d.cogDisplay) + cmdList;
+    }
+
+    document.querySelectorAll(".manage-btn").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const d = btn.dataset;
+        if (d.kind === "command") {
+          renderCommand({
+            name: d.name, invoke: d.invoke, type: d.type, parent: d.parent,
+            cog: d.cog, cogDisplay: d.cogDisplay, cogEmoji: d.cogEmoji,
+            subsystem: d.subsystem, brief: d.brief, aliases: d.aliases, button: d.button,
+          });
+        } else {
+          renderCog(
+            { cog: d.cog, cogDisplay: d.cogDisplay, cogEmoji: d.cogEmoji,
+              subsystem: d.subsystem, file: d.file, iscog: d.iscog },
+            btn.closest("section.cog"),
+          );
+        }
+        openDrawer();
+      });
+    });
   })();
 </script>
 {% endblock %}

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -39,6 +39,14 @@ Current broad captures:
   banner — turning the passive inventory into an active config check. Gated on the Phase 3 Railway-API
   integration. → relates `scripts/scan_env_usage.py` · `dashboard/`.
 
+- [`dashboard-registry-coverage-check-2026-06-16.md`](./dashboard-registry-coverage-check-2026-06-16.md) —
+  **session idea (2026-06-16, Q-0089, from the `/commands` management surface):** a stdlib coverage
+  self-check that flags scanned cogs whose `subsystem` key doesn't resolve to a registered subsystem
+  (split *expected* allow-list vs *unexpected* drift), as a `--check` mode on the exporter or a unit
+  test — so a cog rename / new acronym cog / registry-key change that breaks the dashboard's cog→
+  registry join **fails a check** instead of silently degrading that cog's card + routing state.
+  Decided-lane, small; execute when the dashboard lane next has capacity. → relates
+  `scripts/scan_commands.py` · `scripts/export_dashboard_data.py` · `dashboard/`.
 - [`docs-ledger-parsing-helper-2026-06-16.md`](./docs-ledger-parsing-helper-2026-06-16.md) —
   **promoted Q-0089 idea (2026-06-16, originally surfaced in #967's session log):** extract the
   repeatedly-copied markdown-ledger regexes (Status badge / `BUG-NNNN` / idea-file parsers) into one

--- a/docs/ideas/dashboard-registry-coverage-check-2026-06-16.md
+++ b/docs/ideas/dashboard-registry-coverage-check-2026-06-16.md
@@ -1,0 +1,44 @@
+# Dashboard cog↔registry coverage check
+
+> **Status:** `ideas` — captured 2026-06-16 (session idea, Q-0089). Small, safe, decided-lane
+> (dashboard tooling). Source + merged PRs win.
+
+## The gap (hit while building the `/commands` management surface)
+
+The dashboard joins each scanned cog to the SUBSYSTEMS registry by its `subsystem` key
+(`scripts/scan_commands.py` `_cog_to_subsystem`) to show the cog's emoji / display name and its
+**routing key**. When that key doesn't resolve to a registry entry, the join silently degrades —
+the cog renders with the generic 🧩 + its raw class name, and its routing-state panel can't say
+which subsystem it routes on. This session fixed one whole class of it (acronym cogs:
+`BTD6Cog`→`btd6`, `AICog`→`ai`, `XPCog`→`xp` — they were `b_t_d6`/`a_i`/`x_p` and matched nothing),
+but the failure was **invisible** until someone eyeballed the page. ~10 of 42 scanned cog entries
+still don't resolve (the `bot1.py` module, mixins, and `hermes`/`paragon`/`setup`/`rps`/the BTD6
+sub-cogs — some legitimately have no registry entry, some may be real drift).
+
+## The idea
+
+A tiny **coverage self-check** over the export: list every scanned cog whose `subsystem` does **not**
+resolve to a registered subsystem, split into *expected* (an allow-list: `(bot1.py)`, mixins, known
+hub-less cogs) vs *unexpected* (real drift the registry should cover). Surface it as either:
+
+- a `--check` mode on `scripts/export_dashboard_data.py` (prints the unresolved set, non-zero exit on
+  an *unexpected* miss), or
+- a stdlib unit test `tests/unit/scripts/test_scan_commands.py` that asserts the unexpected-miss set is
+  empty against a small curated allow-list.
+
+So a future cog rename / a new acronym cog / a registry key change that breaks the join **fails a
+check** instead of silently giving that cog a degraded dashboard card.
+
+## Why it's worth having
+
+- Pure stdlib, read-only, no bot change — same disposable-tooling lane as the other `scan_*` scripts
+  (Q-0105 provenance header applies).
+- Turns an invisible degradation into a caught one — the dashboard's correctness depends on this join
+  for two surfaces now (`/commands` header + routing state) and more as the management surface grows.
+- Cheap: the allow-list is short and the resolve logic already exists.
+
+## Disposition
+
+Decided-lane / small → **execute when the dashboard lane next has capacity** (a few-line `--check`
+mode + one test). Not urgent; capture so the next dashboard session can knock it out. → relates
+`scripts/scan_commands.py` · `scripts/export_dashboard_data.py` · `dashboard/`.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,10 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/practical-turing-pnppjf` · dashboard `/commands` management surface (READ side) — Manage
+  button on every command + cog, per-item panel (aliases + cog routing state + per-command alias
+  suggest box) · `dashboard/templates/commands.html` · `dashboard/app.py` ·
+  `scripts/export_dashboard_data.py` · 2026-06-16
 - `claude/upbeat-einstein-7rz9z0` · act on the 2026-06-16 autonomous-run review + owner answers —
   run-report footer · ledger guard-exemption + drift line · bug-fix-guard convention · auto-deploy
   misinformation fix · Q-0147 DM gate · Q-0085/0120/0121/0127 records · ledger tidy · 2026-06-16

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -6004,3 +6004,30 @@ usage-map + Railway management; multi-AI control board) remain in the plan.
 **Home:** [`docs/planning/dashboard-live-editor-plan.md`](../planning/dashboard-live-editor-plan.md)
 § "Free multi-user control panel" · `services/participation_mutation.py` ·
 `governance/capability.py` · this Q-block.
+
+### Q-0160 — Command enable/disable granularity: cog-level now, per-command later (2026-06-16)
+
+> **DECISION 2026-06-16 (owner-directed in-session, applied directly via `AskUserQuestion`).** While
+> building the `/commands` management surface (Q-0158), the open fork the handoff flagged was put to
+> the owner: Q-0158 literally asked to *"enable/disable each command from the website,"* but the bot
+> today routes only at **cog (subsystem)** level (`services.command_routing`, migration 036).
+> Per-individual-command disable would be a **new, finer routing layer in the bot** (a new DB table +
+> an enforcement hook in the dispatch path). Asked which direction the enable/disable affordance
+> should take.
+
+**Decision:**
+
+- **Cog-level now, per-command later.** The website's enable/disable **front-ends the existing
+  audited `command_routing`** (per-cog, scope-aware channel → category → guild → default-on, via
+  `set_policy`) — no new bot runtime. **Per-command** enable/disable stays a **documented future bot
+  layer**, not built now.
+- **Read-side impact (this session):** the `/commands` Manage panels show **cog-level** routing state
+  and front the synonym layer for the per-command **alias** suggest box; they do **not** imply a
+  per-command on/off toggle. The live write side (toggling, live aliases) still lands with the
+  control API + Discord OAuth (Phase 2), which the owner has not yet set up.
+- Confirms the interpretation already recorded in Q-0158; this Q-block is its explicit owner sign-off
+  so a later session doesn't reopen the fork.
+
+**Home:** [`docs/planning/dashboard-live-editor-plan.md`](../planning/dashboard-live-editor-plan.md)
+§ "Command management surface" · `services/command_routing.py` · `dashboard/templates/commands.html` ·
+this Q-block.

--- a/docs/planning/dashboard-live-editor-plan.md
+++ b/docs/planning/dashboard-live-editor-plan.md
@@ -25,16 +25,28 @@ edit capability** — front-end these seams, do not rebuild:
 
 **Build next, in order:**
 
-1. **`/commands` management surface — READ side (safe, no bot change, no auth).** A **Manage button on
-   every command and cog**; each opens a panel showing the command's current aliases + its cog's
-   routing state + a **per-command alias box** (suggest→PR mode for now). This is the owner's Q-0158
-   ask and needs nothing from the bot. *(Open decision: cog-level vs per-command enable/disable —
-   cog-level front-ends `command_routing` as-is; per-command is a finer new bot layer.)*
+1. ✅ **`/commands` management surface — READ side — SHIPPED 2026-06-16.** A **Manage button on every
+   command and cog** (`dashboard/templates/commands.html`); each opens a slide-over panel showing the
+   command's current aliases (code aliases + soft synonyms) + its cog's **cog-level** routing state
+   (front-ending `command_routing.set_policy`, default-on, scope-aware) + a **per-command alias box**
+   (suggest→PR mode — the `/aliases` collision check + prefilled issue + snippet, scoped to one
+   command). Decoupled, read-only, no bot change. **Open decision RESOLVED → Q-0160: cog-level now,
+   per-command later** (per-command would be a new bot routing layer). Drive-by: acronym-aware
+   `_cog_to_subsystem` so `BTD6Cog`/`AICog`/`XPCog` join the registry (`btd6`/`ai`/`xp`).
 2. **Bot-ready foundation (runtime — do NOT rush; owner setup required, see § "Free multi-user control
    panel").** ① a private **control API** on the bot exposing the seams above; ② the **identity →
    authority bridge** (resolve `(user_id, guild_id)` → member → run `governance.capability` checks).
 3. **Website auth + editors:** Discord OAuth login → per-user + per-guild editors over the control API
    (settings global+per-server per Q-0157; help; aliases live; cog routing).
+
+**Ready read-only slices (no auth, no bot change — grow these while phase 2/3 are gated):**
+
+- **"Your authority" preview (pre-auth).** Per subsystem, explain *which tier / capability* governs
+  each control (derivable from `SettingSpec.capability_required` + the access map) — sets correct
+  expectations for the future control panel ("you'll edit X in servers where you're admin; Y is
+  yours personally"). Pure read-model; a gentle on-ramp to the multi-user model. *(Groomed up from
+  the 2026-06-16 multi-user-design session log, Q-0015 — now a natural extension of the shipped
+  `/commands` + `/access` read surfaces.)*
 
 **Owner setup needed before phase 2/3 (nothing needed for phase 1):** a Discord OAuth app
 (client id/secret + redirect), a dashboard session secret, and a shared bot↔dashboard token —
@@ -234,9 +246,12 @@ button on every command and cog**, each opening an editor.
 - **Per-command alias box (owner correction).** The global `/aliases` form stays as the broad
   *search / quick-add*; additionally **each command gets its own alias box** inline in `/commands`.
   Backing: the synonym layer (suggest→PR today; live once the synonym overlay + control API land).
-- **Read side builds now (safe):** surface each command's current aliases + cog-routing state + a
-  Manage button on every command and cog — pure dashboard, no bot change. **Write side** (toggle,
-  edit alias) lands with the control-API + auth foundation (L0–L2).
+- **Read side — SHIPPED 2026-06-16** (`dashboard/templates/commands.html`): a Manage button on every
+  command and cog opening a slide-over panel — current aliases (code + soft synonyms), cog-level
+  routing state (front-ends `command_routing`), and a per-command alias suggest box (the `/aliases`
+  collision check + prefilled issue + snippet, scoped to one command). The global `/aliases` page
+  stays the broad search. **Write side** (live toggle, live alias) lands with the control-API + auth
+  foundation (L0–L2). **Granularity owner-decided → Q-0160: cog-level now, per-command later.**
 
 ## Free multi-user control panel — identity & authority (owner, 2026-06-16)
 

--- a/scripts/export_dashboard_data.py
+++ b/scripts/export_dashboard_data.py
@@ -84,6 +84,11 @@ _CATALOGUE_FIELDS = (
     "emoji",
     "category",
     "visibility_tier",
+    # ``visibility_mode`` ("normal" / "internal") drives cog-routing operator
+    # visibility: only non-internal subsystems are operator-routable (see
+    # views/setup/sections/cog_routing.py), so the dashboard reads it to mark a
+    # cog's routing state accurately.
+    "visibility_mode",
     "tags",
     "entry_points",
     "capabilities",

--- a/scripts/scan_commands.py
+++ b/scripts/scan_commands.py
@@ -56,7 +56,11 @@ _COMMAND_DECORATORS: dict[str, tuple[str, bool]] = {
 }
 _SUBCOMMAND_LEAVES = {"command", "group", "subcommand"}
 _PANEL_TOKENS = ("panel_manager", "send_panel", "View(", "view=")
-_CAMEL_RE = re.compile(r"(?<!^)(?=[A-Z])")
+# Acronym-aware CamelCase -> snake_case: split before a Capitalised word that
+# follows an acronym run (HTTPServer -> HTTP_Server) and between a lower/digit
+# and a capital (RockPaper -> Rock_Paper); an acronym (+digit) run stays whole.
+_ACRONYM_BOUNDARY_RE = re.compile(r"([A-Z]+)([A-Z][a-z])")
+_WORD_BOUNDARY_RE = re.compile(r"([a-z0-9])([A-Z])")
 
 
 def _truncate(text: str, limit: int) -> str:
@@ -65,9 +69,17 @@ def _truncate(text: str, limit: int) -> str:
 
 
 def _cog_to_subsystem(class_name: str) -> str:
-    """Normalise a cog class name to its snake_case subsystem key."""
+    """Normalise a cog class name to its snake_case subsystem key.
+
+    Acronym-aware so a run of capitals stays together: ``AICog`` -> ``ai``,
+    ``BTD6Cog`` -> ``btd6``, ``XPCog`` -> ``xp`` — the snake_case keys the
+    SUBSYSTEMS registry actually uses, not ``a_i`` / ``b_t_d6`` / ``x_p``. This
+    makes the dashboard's cog->subsystem join (header emoji/name + the routing
+    key) resolve for acronym-named cogs instead of silently falling back.
+    """
     base = class_name[:-3] if class_name.endswith("Cog") else class_name
-    return _CAMEL_RE.sub("_", base).lower()
+    step1 = _ACRONYM_BOUNDARY_RE.sub(r"\1_\2", base)
+    return _WORD_BOUNDARY_RE.sub(r"\1_\2", step1).lower()
 
 
 def _is_cog(class_node: ast.ClassDef) -> bool:

--- a/tests/unit/dashboard/test_app.py
+++ b/tests/unit/dashboard/test_app.py
@@ -70,6 +70,25 @@ def test_aliases_page_renders_suggestion_form(client):
     assert 'id="cmd-list"' in resp.text
 
 
+def test_commands_page_has_manage_surface(client):
+    resp = client.get("/commands")
+    assert resp.status_code == 200
+    # A Manage button (on every command and cog) + the slide-over panel.
+    assert "manage-btn" in resp.text
+    assert "Manage" in resp.text
+    assert 'id="drawer"' in resp.text
+    # The embedded data the drawer's JS needs: collision map, synonyms, routable.
+    assert 'id="taken-data"' in resp.text
+    assert 'id="syn-data"' in resp.text
+    assert 'id="routable-data"' in resp.text
+    # Cog-level routing framing (Q-0160) front-ending the audited seam.
+    assert "command_routing.set_policy" in resp.text
+    # Manage buttons carry per-command data attributes for the drawer.
+    assert 'data-kind="command"' in resp.text
+    # Acronym-aware cog->subsystem join: BTD6Cog now resolves to ``btd6``.
+    assert 'data-subsystem="btd6"' in resp.text
+
+
 def test_settings_page_lists_a_known_key(client):
     resp = client.get("/settings")
     assert resp.status_code == 200

--- a/tests/unit/scripts/test_scan_commands.py
+++ b/tests/unit/scripts/test_scan_commands.py
@@ -104,6 +104,18 @@ def test_scan_commands_types_aliases_and_buttons(mod, tmp_path):
     assert by_name["sub"]["parent"] == "grp"
 
 
+def test_cog_to_subsystem_is_acronym_aware(mod):
+    f = mod._cog_to_subsystem
+    # Plain CamelCase splits on word boundaries.
+    assert f("EconomyCog") == "economy"
+    assert f("CommunitySpotlightCog") == "community_spotlight"
+    assert f("RockPaperScissorsCog") == "rock_paper_scissors"
+    # Acronym (+digit) runs stay whole -> they match the registry's keys.
+    assert f("AICog") == "ai"
+    assert f("BTD6Cog") == "btd6"
+    assert f("XPCog") == "xp"
+
+
 def test_mixin_is_not_a_cog_but_keeps_its_commands(mod, tmp_path):
     by_cog = {c["cog"]: c for c in mod.scan_commands(_write_repo(tmp_path))}
     assert "SampleMixin" in by_cog


### PR DESCRIPTION
## Why

Continue the bot's main website (`dashboard/`, Q-0158). Build the **`/commands` management
surface — READ side**: the owner's ask to turn `/commands` from a read-only explorer into a
management surface — a **Manage** button on every command *and* every cog.

Binding principles honored: the **bot stays the source of truth**; the site **front-ends the
bot's existing audited seams** (`command_routing`, the synonym layer) — never a parallel system.
Decoupled + read-only: no `disbot/` import, no auth, no bot change.

## Owner decision this session (AskUserQuestion → Q-0160)

The owner asked to "enable/disable each command from the website," but the bot routes at **cog
(subsystem)** level today. Confirmed direction: **cog-level now, per-command later** — front-end
the existing audited `command_routing` (per-cog, scope-aware via `set_policy`); per-command stays
a documented future bot layer. So the panels show **cog-level** routing state; the per-command
write affordance this session is the **alias suggest box** (suggest→PR).

## What (read-only, decoupled)

- **Manage panel on every command and cog** — a slide-over drawer (vanilla JS, no framework, same
  style as the existing `/aliases` + `/commands` scripts), populated from JSON embedded in the page.
- **Command panel:** identity (type/parent/cog/brief) · **current aliases** (code aliases +
  soft synonyms, distinguished) · **cog routing state** (cog-level model: enabled-by-default,
  scope-aware, audited `command_routing.set_policy`) · a **per-command alias suggest box** — the
  `/aliases` collision check + prefilled GitHub issue + paste-ready `synonyms.py` snippet, scoped
  to that one command.
- **Cog panel:** identity (class/file/subsystem) · routing state · its command list.
- The global `/aliases` page stays the broad search/quick-add (unchanged).
- **Drive-by fix:** acronym-aware `_cog_to_subsystem` in `scan_commands` so `BTD6Cog`/`AICog` map
  to `btd6`/`ai` (was `b_t_d6`/`a_i`) — fixes the cog→registry join for those cogs' header
  emoji/name *and* their routing-key display. `visibility_mode` added to the exported catalogue so
  routability is computed precisely (non-internal subsystems).

## Verification

- `pip install -r dashboard/requirements.txt httpx && python3.10 -m pytest tests/unit/dashboard/`
  (the smoke test skips in CI — runs locally with web deps; catches template bugs like the #979
  `/settings` 500).
- `python3.10 scripts/check_quality.py --check-only`.
- `python3.10 -m pytest tests/unit/scripts/test_scan_commands.py`.

Born-red session card (Q-0133); flips to `complete` as the final commit → auto-merge on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Tff5WCNJjR5nnfpibsKjD

---
_Generated by [Claude Code](https://claude.ai/code/session_011Tff5WCNJjR5nnfpibsKjD)_