### PR TITLE
feat(dashboard): dashboard.json integrity guard — catch export drift

### DIFF
--- a/.sessions/2026-06-16-dashboard-data-integrity-guard.md
+++ b/.sessions/2026-06-16-dashboard-data-integrity-guard.md
@@ -1,0 +1,35 @@
+# 2026-06-16 — dashboard.json integrity guard
+
+> **Status:** `in-progress` — born-red per Q-0133; flipped to `complete` as the deliberate
+> final step. Tooling + tests only (no `disbot/` runtime, no dashboard templates).
+
+## What I'm about to do
+
+The owner is shipping the control-panel **write path** (mutation endpoints) and the **website OAuth
++ editors** in parallel sessions, and asked me to continue with **something non-conflicting**. So I
+pivoted *off* the control-API read endpoints I'd started scoping (they'd collide with the
+mutation-endpoints session in `control_api.py`) onto a slice that touches neither `control_api.py`
+nor the website OAuth/editor pages.
+
+Build **`scripts/check_dashboard_data.py`** — a stdlib integrity guard for the dashboard's exported
+`dashboard.json`. The dashboard is now the bot's main website, extended by **many parallel sessions**;
+an export-integrity validator catches the drift classes that silently degrade pages (I hit one this
+very session — acronym cogs whose `subsystem` didn't resolve to the registry, so they rendered with
+a generic icon + no routing key). Checks:
+
+- **cog→subsystem resolution** — every real (`is_cog`) cog's `subsystem` resolves to a registry
+  subsystem, minus a curated allow-list of legitimately-unregistered cogs (BTD6 sub-cogs · Hermes ·
+  Paragon · Setup · RPS) and modules/mixins. A *new* unregistered cog or a broken join fails.
+- **count integrity** — `meta.counts.*` match the actual array lengths (the #973 count-drift class).
+- **required fields** — every command has a name + valid type; every cog has a file; etc.
+
+Touches only `scripts/` + `tests/` — guaranteed non-conflicting with both owner sessions and the
+other dashboard sessions touching templates.
+
+## Status checklist
+
+- [ ] `scripts/check_dashboard_data.py` (validate + CLI, Q-0105 header)
+- [ ] `tests/unit/scripts/test_check_dashboard_data.py` (synthetic drift + live-export guard)
+- [ ] my Q-0089 idea file → shipped; README updated
+- [ ] `check_quality --check-only` + the new tests green
+- [ ] session enders + flip card `complete`

--- a/.sessions/2026-06-16-dashboard-data-integrity-guard.md
+++ b/.sessions/2026-06-16-dashboard-data-integrity-guard.md
@@ -1,35 +1,105 @@
 # 2026-06-16 — dashboard.json integrity guard
 
-> **Status:** `in-progress` — born-red per Q-0133; flipped to `complete` as the deliberate
-> final step. Tooling + tests only (no `disbot/` runtime, no dashboard templates).
+> **Status:** `complete` — tooling + tests only (no `disbot/` runtime, no dashboard templates).
+> One PR (#990).
 
-## What I'm about to do
+## Arc
 
 The owner is shipping the control-panel **write path** (mutation endpoints) and the **website OAuth
-+ editors** in parallel sessions, and asked me to continue with **something non-conflicting**. So I
-pivoted *off* the control-API read endpoints I'd started scoping (they'd collide with the
-mutation-endpoints session in `control_api.py`) onto a slice that touches neither `control_api.py`
-nor the website OAuth/editor pages.
++ editors** in parallel sessions, and asked me to continue with **something non-conflicting**. I had
+just started scoping the control-API *read* endpoints — but those live in `disbot/control_api.py`,
+exactly where the mutation-endpoints session is working, so I **pivoted to avoid the collision**
+(syncing `main` first also revealed #989 had already landed the control-API foundation — I'd nearly
+duplicated it). Picked a slice touching neither `control_api.py` nor the website OAuth/editor pages.
 
-Build **`scripts/check_dashboard_data.py`** — a stdlib integrity guard for the dashboard's exported
-`dashboard.json`. The dashboard is now the bot's main website, extended by **many parallel sessions**;
-an export-integrity validator catches the drift classes that silently degrade pages (I hit one this
-very session — acronym cogs whose `subsystem` didn't resolve to the registry, so they rendered with
-a generic icon + no routing key). Checks:
+## Shipped (PR #990)
 
-- **cog→subsystem resolution** — every real (`is_cog`) cog's `subsystem` resolves to a registry
-  subsystem, minus a curated allow-list of legitimately-unregistered cogs (BTD6 sub-cogs · Hermes ·
-  Paragon · Setup · RPS) and modules/mixins. A *new* unregistered cog or a broken join fails.
-- **count integrity** — `meta.counts.*` match the actual array lengths (the #973 count-drift class).
-- **required fields** — every command has a name + valid type; every cog has a file; etc.
+- **`scripts/check_dashboard_data.py`** — a stdlib integrity guard for the exported `dashboard.json`
+  (the bot's main website's data, now extended by many parallel sessions):
+  - **cog→subsystem resolution** — every real (`is_cog`) cog's `subsystem` resolves to a registry
+    subsystem key, minus a curated allow-list of legitimately-unregistered cogs (BTD6 sub-cogs ·
+    Hermes · Paragon · Setup · RPS) and modules/mixins. A *new* unregistered cog / broken join errors.
+  - **count integrity** — `meta.counts.*` match the actual array lengths (the #973 count-drift class).
+  - **required fields** — every command has a name + valid `type`; every cog a `file`; every
+    catalogue entry a `key`.
+  - CLI: validates the committed JSON, or `--fresh` regenerates from live sources first (so a newly
+    added unregistered cog is caught even if the JSON is stale). Q-0105 provenance header.
+- **`tests/unit/scripts/test_check_dashboard_data.py`** — per-check synthetic drift cases + a live
+  guard validating the **freshly-built** export has no error-severity issues (the in-CI value).
 
-Touches only `scripts/` + `tests/` — guaranteed non-conflicting with both owner sessions and the
-other dashboard sessions touching templates.
+Directly motivated by #988: acronym cogs whose `subsystem` didn't resolve rendered with a generic
+icon + no routing key, invisibly — this turns that class into a failed check.
 
 ## Status checklist
 
-- [ ] `scripts/check_dashboard_data.py` (validate + CLI, Q-0105 header)
-- [ ] `tests/unit/scripts/test_check_dashboard_data.py` (synthetic drift + live-export guard)
-- [ ] my Q-0089 idea file → shipped; README updated
-- [ ] `check_quality --check-only` + the new tests green
-- [ ] session enders + flip card `complete`
+- [x] `scripts/check_dashboard_data.py` (validate + CLI, Q-0105 header)
+- [x] `tests/unit/scripts/test_check_dashboard_data.py` (synthetic drift + live-export guard)
+- [x] executed Q-0089 coverage-check idea → shipped; README updated
+- [x] `check_quality --check-only` + the new tests green
+- [x] session enders + flip card `complete`
+
+## Verification
+
+- `python3.10 -m pytest tests/unit/scripts/test_check_dashboard_data.py` → **7 passed**.
+- `python3.10 scripts/check_dashboard_data.py` → OK (42 cogs, 0 errors); `--fresh` → OK.
+- `python3.10 scripts/check_quality.py --check-only` → green (resolved one black↔ruff `COM812`
+  trailing-comma tension by running `ruff --fix` after black); `check_docs --strict` → green.
+- Sanity: the unit tests prove the guard *catches* a new unregistered cog / count mismatch / bad
+  field (not just passes on clean data).
+
+## 💡 Session idea (Q-0089)
+
+**Map sub-cogs to their parent subsystem** —
+`docs/ideas/dashboard-subcog-parent-subsystem-2026-06-16.md` (+ README). The guard *allow-lists* the
+~7 real cogs that don't resolve to a registry key, but several genuinely *belong* to a parent
+(`BTD6EventsCog`…→`btd6`; `RockPaperScissorsCog`→`rps_tournament`) — so on the dashboard they render
+with a generic 🧩 + no routing key. A small explicit cog→parent-subsystem override map in
+`scan_commands` would let them inherit the parent's identity and shrink the allow-list to the
+truly-unregistered few. Genuine — I saw it directly while curating the allow-list.
+
+## ♻️ Backlog grooming (Q-0015)
+
+Moved the **dashboard-registry-coverage-check** idea (filed last session, #988) all the way to its
+**terminal state — shipped** (this PR's main task literally executed it, broader than sketched: a
+full export integrity guard, not just the cog-resolution check). Updated its file Disposition +
+README entry to SHIPPED #990. Moving an idea `ideas → shipped` is the cleanest grooming move there is.
+
+## ⟲ Previous-session review (Q-0102)
+
+Reviewed **`2026-06-16-control-api-foundation.md`** (#989 — the bot-side control API that landed
+between my #988 and this session, and the work I almost duplicated). **Did very well:** it nailed the
+*safety shape* for adding a risky runtime surface to a production bot — **dormant by default**
+(routes register only when `CONTROL_API_TOKEN` is set, so merge ≠ activation), **fail-safe wiring**
+(a control-API error can never break health-server/bot startup), private-network + token auth, and a
+crisp "how to activate" runbook. It also complied with repo invariants *properly* (used
+`resolve_member`, registered in the atlas `TOP_LEVEL_MODULES`, regenerated `env-vars.md`) rather than
+suppressing the checks. **Could've gone further / what it missed:** it didn't update
+`docs/owner/active-work.md` with a claim — which is precisely why I started scoping the *same* control
+API a session later before catching it via `git log`. The claim ledger is the *pre-PR* duplicate-work
+signal (Q-0126); a runtime-foundation PR that other sessions will obviously build on most needs one.
+**System improvement it surfaces:** the near-duplication wasn't caught by the claim ledger (no claim)
+— it was caught by *me syncing main first*. The thinner, more reliable guard would be **"sync `main`
++ scan `git log` for the feature area before scoping any runtime work,"** because a merged PR is a
+harder signal than a claim that may never be written. The orientation already says scan open PRs;
+adding *recently-merged* `main` commits to that pre-flight scan would have caught #989 immediately.
+(Captured as the workflow note; CLAUDE.md is propose-only.)
+
+## Documentation audit (Q-0104)
+
+- Two idea files filed/updated + README-indexed (coverage-check → shipped; sub-cog parent map → new);
+  `check_docs --strict` green. The guard's provenance is in its own header (Q-0105) + this card.
+- No owner decision this session (a non-conflicting tooling pivot, owner-directed "continue with
+  something non conflicting"), so no router Q-block needed.
+- **Ledger untouched (Q-0124):** the merged-PR backlog is the automated reconciliation routine's job;
+  my own PR (#990) isn't merged yet. Nothing from this session lacks a durable home.
+
+## Context delta
+
+- **Sync `main` + scan `git log` before scoping runtime work** — #989 (control-API foundation) had
+  merged with no active-work claim; I nearly rebuilt it. A merged-commit scan of the feature area is
+  the reliable duplicate-work guard when a claim is missing.
+- The dashboard's cog→subsystem join has ~7 real cogs that don't resolve to a registry key (BTD6
+  sub-cogs · Paragon · RPS · Setup · Hermes) — now allow-listed by the guard and captured as the
+  parent-subsystem follow-up idea. New unregistered cogs beyond these will fail the guard's live test.
+- The control API is **dormant until `CONTROL_API_TOKEN` is set on both Railway services** (#989) —
+  the read/write endpoints + OAuth the owner is building in parallel are what switch the panel on.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -40,13 +40,18 @@ Current broad captures:
   integration. → relates `scripts/scan_env_usage.py` · `dashboard/`.
 
 - [`dashboard-registry-coverage-check-2026-06-16.md`](./dashboard-registry-coverage-check-2026-06-16.md) —
-  **session idea (2026-06-16, Q-0089, from the `/commands` management surface):** a stdlib coverage
-  self-check that flags scanned cogs whose `subsystem` key doesn't resolve to a registered subsystem
-  (split *expected* allow-list vs *unexpected* drift), as a `--check` mode on the exporter or a unit
-  test — so a cog rename / new acronym cog / registry-key change that breaks the dashboard's cog→
-  registry join **fails a check** instead of silently degrading that cog's card + routing state.
-  Decided-lane, small; execute when the dashboard lane next has capacity. → relates
-  `scripts/scan_commands.py` · `scripts/export_dashboard_data.py` · `dashboard/`.
+  **SHIPPED 2026-06-16 (PR #990)**, broader than sketched: `scripts/check_dashboard_data.py` validates
+  the exported `dashboard.json` — cog→subsystem resolution (with a curated allow-list) + count
+  integrity + required fields — and a unit test validates the freshly-built export, so a new
+  unregistered cog / broken join / count drift **fails CI** instead of silently degrading a page.
+  → `scripts/check_dashboard_data.py` · `tests/unit/scripts/test_check_dashboard_data.py`.
+- [`dashboard-subcog-parent-subsystem-2026-06-16.md`](./dashboard-subcog-parent-subsystem-2026-06-16.md) —
+  **session idea (2026-06-16, Q-0089, from the integrity guard #990):** the guard *allow-lists* the
+  cogs that don't resolve to a registry key (BTD6 sub-cogs · Paragon · RPS · Setup), but several of
+  them genuinely *belong* to a parent subsystem (`BTD6EventsCog`…→`btd6`) — so on the dashboard they
+  render with a generic 🧩 + no routing key. A small cog→parent-subsystem map in `scan_commands` would
+  let sub-cogs inherit their parent's registry identity (emoji/name/routing), shrinking the allow-list
+  to the truly-unregistered few. → relates `scripts/scan_commands.py` · `dashboard/`.
 - [`docs-ledger-parsing-helper-2026-06-16.md`](./docs-ledger-parsing-helper-2026-06-16.md) —
   **promoted Q-0089 idea (2026-06-16, originally surfaced in #967's session log):** extract the
   repeatedly-copied markdown-ledger regexes (Status badge / `BUG-NNNN` / idea-file parsers) into one

--- a/docs/ideas/dashboard-registry-coverage-check-2026-06-16.md
+++ b/docs/ideas/dashboard-registry-coverage-check-2026-06-16.md
@@ -39,6 +39,9 @@ check** instead of silently giving that cog a degraded dashboard card.
 
 ## Disposition
 
-Decided-lane / small → **execute when the dashboard lane next has capacity** (a few-line `--check`
-mode + one test). Not urgent; capture so the next dashboard session can knock it out. → relates
-`scripts/scan_commands.py` · `scripts/export_dashboard_data.py` · `dashboard/`.
+**SHIPPED 2026-06-16 — PR #990**, broader than the original sketch: `scripts/check_dashboard_data.py`
+validates the whole exported `dashboard.json` — **cog→subsystem resolution** (this idea, with the
+curated allow-list of legitimately-unregistered cogs) **plus** count integrity (`meta.counts.*` vs
+actual) and required-field presence. A unit test validates the freshly-built export so a new
+unregistered cog / broken join / count drift **fails CI**. → `scripts/check_dashboard_data.py` ·
+`tests/unit/scripts/test_check_dashboard_data.py`.

--- a/docs/ideas/dashboard-subcog-parent-subsystem-2026-06-16.md
+++ b/docs/ideas/dashboard-subcog-parent-subsystem-2026-06-16.md
@@ -1,0 +1,52 @@
+# Dashboard: map sub-cogs to their parent subsystem
+
+> **Status:** `ideas` — captured 2026-06-16 (session idea, Q-0089, from the integrity guard #990).
+> Small, decided-lane (dashboard tooling). Source + merged PRs win.
+
+## The gap (surfaced while building the integrity guard)
+
+`scripts/check_dashboard_data.py` (#990) allow-lists the real cogs whose `subsystem` doesn't resolve
+to a SUBSYSTEMS registry key: `BTD6EventsCog`/`BTD6OpsCog`/`BTD6ReferenceCog`/`BTD6StrategyCog`,
+`ParagonCog`, `RockPaperScissorsCog`, `SetupCog`, `HermesCog`. The allow-list keeps them from
+failing the guard — but it doesn't *fix* their dashboard rendering. Several of them genuinely **belong
+to a parent subsystem**:
+
+- the four `BTD6*Cog` sub-cogs are part of the **`btd6`** subsystem (the main `BTD6Cog` resolves);
+- `ParagonCog` is BTD6-adjacent (arguably `btd6`);
+- `RockPaperScissorsCog` lives in `rps_tournament_cog.py` → the registry key is **`rps_tournament`**
+  (a class-name vs key mismatch, not a missing subsystem).
+
+Because their `subsystem` string doesn't match a registry key, the `/commands` page renders them with
+the generic 🧩 icon + the raw class name + no routing key — a degraded card for ~7 of 42 cogs.
+
+## The idea
+
+Add a small, explicit **cog-class → parent-subsystem map** to `scripts/scan_commands.py` (or a thin
+override table the exporter applies), e.g.:
+
+```python
+_COG_SUBSYSTEM_OVERRIDES = {
+    "BTD6EventsCog": "btd6", "BTD6OpsCog": "btd6",
+    "BTD6ReferenceCog": "btd6", "BTD6StrategyCog": "btd6",
+    "RockPaperScissorsCog": "rps_tournament",
+    # ParagonCog / SetupCog / HermesCog: decide per owner intent (btd6? internal?)
+}
+```
+
+so those cogs inherit their parent's registry identity (emoji / display name / **routing key**) on the
+dashboard, and the `check_dashboard_data` allow-list shrinks to only the *truly* unregistered cogs
+(`HermesCog`, `SetupCog` — if those stay hub-less). An explicit override table is honest (it's a small
+curated map, reviewed) and beats trying to infer the parent from the file name.
+
+## Why it's worth having
+
+- Fixes a visible degradation on the bot's **main website** for the whole BTD6 + RPS surface.
+- Read-only, stdlib, dashboard-only — same disposable-tooling lane (Q-0105). No bot change.
+- Tightens the integrity guard: a smaller allow-list means more real coverage.
+
+## Disposition
+
+Decided-lane, small → **execute when the dashboard lane next has capacity**; pairs naturally with the
+next `/commands` rendering pass. Confirm the `ParagonCog`/`SetupCog` parent intent with the owner (or
+leave them allow-listed). → relates `scripts/scan_commands.py` · `scripts/check_dashboard_data.py` ·
+`dashboard/templates/commands.html`.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,10 +25,9 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/practical-turing-pnppjf` · dashboard `/commands` management surface (READ side) — Manage
-  button on every command + cog, per-item panel (aliases + cog routing state + per-command alias
-  suggest box) · `dashboard/templates/commands.html` · `dashboard/app.py` ·
-  `scripts/export_dashboard_data.py` · 2026-06-16
+- `claude/dashboard-data-integrity-guard` · `scripts/check_dashboard_data.py` — stdlib integrity
+  guard for the exported `dashboard.json` (cog→subsystem resolution · count integrity · required
+  fields) + test · `scripts/` · `tests/unit/scripts/` · 2026-06-16
 - `claude/upbeat-einstein-7rz9z0` · act on the 2026-06-16 autonomous-run review + owner answers —
   run-report footer · ledger guard-exemption + drift line · bug-fix-guard convention · auto-deploy
   misinformation fix · Q-0147 DM gate · Q-0085/0120/0121/0127 records · ledger tidy · 2026-06-16

--- a/scripts/check_dashboard_data.py
+++ b/scripts/check_dashboard_data.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3.10
+"""Validate the developer dashboard's exported ``dashboard.json`` (stdlib only).
+
+The dashboard (``dashboard/``) is the bot's main website; it renders
+``dashboard/data/dashboard.json``, produced by ``scripts/export_dashboard_data.py``
+from the repo's structured sources and extended by many parallel sessions. Nothing
+validated that payload, so a drift silently degraded a page until someone eyeballed
+it (PR #988 hit exactly this: acronym cogs whose ``subsystem`` didn't resolve to the
+registry rendered with a generic icon + no routing key). This guard turns the common
+drift classes into a failed check instead.
+
+Checks:
+
+* **cog->subsystem resolution** — every real (``is_cog``) cog's ``subsystem`` resolves
+  to a registry subsystem key (a catalogue entry), minus a curated allow-list of
+  cogs that legitimately have no own registry entry, and modules/mixins
+  (``is_cog == False``). A *new* unregistered cog or a broken join is an error.
+* **count integrity** — ``meta.counts.*`` match the actual array lengths (the #973
+  command-count-drift class).
+* **required fields** — every command has a name + valid ``type``; every cog has a
+  ``file``; every catalogue entry has a ``key``.
+
+Pure stdlib so it runs in CI with no extra dependencies (the dashboard's web deps
+never enter the bot's ``requirements.txt``). Run::
+
+    python3.10 scripts/check_dashboard_data.py            # validate committed JSON
+    python3.10 scripts/check_dashboard_data.py --fresh    # regenerate first, then validate
+
+Reliability (Q-0105): **unverified** — confirm its verdicts against the live sources
+a few times across sessions before trusting it, and delete this guard if it proves
+unreliable. It is a convenience guard, not load-bearing runtime code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DATA_FILE = REPO_ROOT / "dashboard" / "data" / "dashboard.json"
+
+# Real (``is_cog``) cogs that legitimately have NO own SUBSYSTEMS registry entry:
+# the BTD6 sub-cogs belong to the ``btd6`` subsystem; Hermes/Paragon/Setup are
+# ops/internal cogs; RPS's class name differs from its ``rps_tournament`` key.
+# Adding a cog here is a deliberate "this cog has no registry subsystem" call — the
+# point of the guard is that a *new* unresolved cog must be triaged, not silent.
+_UNREGISTERED_COG_ALLOWLIST = frozenset(
+    {
+        "BTD6EventsCog",
+        "BTD6OpsCog",
+        "BTD6ReferenceCog",
+        "BTD6StrategyCog",
+        "HermesCog",
+        "ParagonCog",
+        "RockPaperScissorsCog",
+        "SetupCog",
+    },
+)
+
+_VALID_COMMAND_TYPES = frozenset({"prefix", "slash", "both"})
+
+
+@dataclass(frozen=True)
+class Issue:
+    """One validation finding. ``severity`` is ``"error"`` or ``"warning"``."""
+
+    severity: str
+    code: str
+    message: str
+
+
+def _err(code: str, message: str) -> Issue:
+    return Issue("error", code, message)
+
+
+def _warn(code: str, message: str) -> Issue:
+    return Issue("warning", code, message)
+
+
+def check_cog_subsystem_resolution(data: dict[str, Any]) -> list[Issue]:
+    """Every real cog's ``subsystem`` must resolve to a registered subsystem."""
+    issues: list[Issue] = []
+    catalogue_keys = {e.get("key") for e in data.get("catalogue", [])}
+    for cog in data.get("cogs", []):
+        if not cog.get("is_cog"):
+            continue  # modules / mixins need no registry entry
+        name = cog.get("cog", "?")
+        subsystem = cog.get("subsystem", "")
+        if subsystem in catalogue_keys or name in _UNREGISTERED_COG_ALLOWLIST:
+            continue
+        issues.append(
+            _err(
+                "cog_subsystem_unresolved",
+                f"cog {name!r} (subsystem {subsystem!r}) does not resolve to a "
+                f"registered subsystem — register it, fix the cog->subsystem join "
+                f"in scan_commands._cog_to_subsystem, or add it to "
+                f"_UNREGISTERED_COG_ALLOWLIST in check_dashboard_data.py",
+            ),
+        )
+    return issues
+
+
+def check_count_integrity(data: dict[str, Any]) -> list[Issue]:
+    """``meta.counts.*`` must equal the actual lengths they summarise."""
+    issues: list[Issue] = []
+    counts = data.get("meta", {}).get("counts", {})
+    cogs = data.get("cogs", [])
+    settings = data.get("settings", [])
+    expected = {
+        "cogs": sum(1 for c in cogs if c.get("is_cog")),
+        "commands": sum(len(c.get("commands", [])) for c in cogs),
+        "synonyms": sum(len(s.get("synonyms", [])) for s in data.get("synonyms", [])),
+        "ideas": len(data.get("ideas", [])),
+        "bugs": len(data.get("bugs", [])),
+        "env_vars": len(data.get("env_usage", [])),
+        "setting_domains": len(settings),
+        "setting_keys": sum(len(d.get("keys", [])) for d in settings),
+        "visible_subsystems": data.get("access", {}).get("total_visible", 0),
+    }
+    for key, exp in expected.items():
+        if key not in counts:
+            issues.append(_warn("count_missing", f"meta.counts.{key} is missing"))
+        elif counts[key] != exp:
+            issues.append(
+                _err(
+                    "count_mismatch",
+                    f"meta.counts.{key}={counts[key]} but the data has {exp}",
+                ),
+            )
+    return issues
+
+
+def check_required_fields(data: dict[str, Any]) -> list[Issue]:
+    """Every command/cog/catalogue entry must carry its load-bearing fields."""
+    issues: list[Issue] = []
+    for cog in data.get("cogs", []):
+        cog_name = cog.get("cog")
+        if not cog_name:
+            issues.append(
+                _err(
+                    "cog_missing_name",
+                    f"a cog entry has no 'cog' ({cog.get('file')})",
+                ),
+            )
+        if not cog.get("file"):
+            issues.append(_err("cog_missing_file", f"cog {cog_name!r} has no 'file'"))
+        for cmd in cog.get("commands", []):
+            if not cmd.get("name"):
+                issues.append(
+                    _err(
+                        "command_missing_name",
+                        f"a command in {cog_name!r} has no name",
+                    ),
+                )
+            if cmd.get("type") not in _VALID_COMMAND_TYPES:
+                issues.append(
+                    _err(
+                        "command_bad_type",
+                        f"command {cmd.get('name')!r} in {cog_name!r} has invalid "
+                        f"type {cmd.get('type')!r}",
+                    ),
+                )
+    for entry in data.get("catalogue", []):
+        if not entry.get("key"):
+            issues.append(
+                _err("catalogue_missing_key", "a catalogue entry has no 'key'"),
+            )
+    return issues
+
+
+_CHECKS: tuple[Callable[[dict[str, Any]], list[Issue]], ...] = (
+    check_cog_subsystem_resolution,
+    check_count_integrity,
+    check_required_fields,
+)
+
+
+def validate(data: dict[str, Any]) -> list[Issue]:
+    """Run every check over ``data`` and return the combined findings."""
+    issues: list[Issue] = []
+    for check in _CHECKS:
+        issues.extend(check(data))
+    return issues
+
+
+def _build_fresh() -> dict[str, Any]:
+    """Regenerate the payload from live sources (sibling import — scripts/ isn't a package)."""
+    script = Path(__file__).resolve().parent / "export_dashboard_data.py"
+    spec = importlib.util.spec_from_file_location("_export_dashboard_seam", script)
+    if spec is None or spec.loader is None:  # pragma: no cover - import wiring
+        raise ImportError("cannot load export_dashboard_data.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.build_data()
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: validate the export, print findings, exit non-zero on error."""
+    parser = argparse.ArgumentParser(description="Validate the dashboard data export.")
+    parser.add_argument(
+        "--fresh",
+        action="store_true",
+        help="regenerate the payload from live sources before validating",
+    )
+    parser.add_argument("--data", default=str(DATA_FILE), help="path to dashboard.json")
+    args = parser.parse_args(argv)
+
+    if args.fresh:
+        data = _build_fresh()
+    else:
+        data = json.loads(Path(args.data).read_text(encoding="utf-8"))
+
+    issues = validate(data)
+    errors = [i for i in issues if i.severity == "error"]
+    warnings = [i for i in issues if i.severity == "warning"]
+
+    for issue in issues:
+        marker = "✗" if issue.severity == "error" else "⚠"
+        print(f"{marker} [{issue.code}] {issue.message}")
+
+    if errors:
+        print(
+            f"\ncheck_dashboard_data: {len(errors)} error(s), {len(warnings)} warning(s)",
+        )
+        return 1
+    print(
+        f"check_dashboard_data: OK ✓ "
+        f"({len(warnings)} warning(s); {len(data.get('cogs', []))} cogs validated)",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_check_dashboard_data.py
+++ b/tests/unit/scripts/test_check_dashboard_data.py
@@ -1,0 +1,147 @@
+"""Tests for ``scripts/check_dashboard_data.py`` — the dashboard export guard.
+
+Loaded via ``importlib`` (the repo convention for ``scripts/`` modules). Pure
+stdlib, so it runs in CI with no extra dependencies — including the live guard
+that validates the freshly-built export.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "check_dashboard_data.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("check_dashboard_data_ut", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# cog -> subsystem resolution
+# ---------------------------------------------------------------------------
+
+
+def test_cog_subsystem_resolution_flags_unregistered_real_cog(mod):
+    data = {
+        "catalogue": [{"key": "economy"}],
+        "cogs": [
+            {"cog": "EconomyCog", "is_cog": True, "subsystem": "economy", "file": "a"},
+            {"cog": "MysteryCog", "is_cog": True, "subsystem": "mystery", "file": "b"},
+        ],
+    }
+    issues = mod.check_cog_subsystem_resolution(data)
+    assert [i.code for i in issues] == ["cog_subsystem_unresolved"]
+    assert "MysteryCog" in issues[0].message
+    assert issues[0].severity == "error"
+
+
+def test_cog_subsystem_resolution_allows_allowlist_and_modules(mod):
+    data = {
+        "catalogue": [{"key": "economy"}],
+        # HermesCog is allow-listed (no own registry entry); the module is is_cog=False.
+        "cogs": [
+            {"cog": "HermesCog", "is_cog": True, "subsystem": "hermes", "file": "h"},
+            {"cog": "(bot1.py)", "is_cog": False, "subsystem": "", "file": "b"},
+        ],
+    }
+    assert mod.check_cog_subsystem_resolution(data) == []
+
+
+# ---------------------------------------------------------------------------
+# count integrity
+# ---------------------------------------------------------------------------
+
+
+def _count_consistent_data():
+    return {
+        "meta": {
+            "counts": {
+                "cogs": 1,
+                "commands": 2,
+                "synonyms": 1,
+                "ideas": 0,
+                "bugs": 0,
+                "env_vars": 0,
+                "setting_domains": 0,
+                "setting_keys": 0,
+                "visible_subsystems": 1,
+            },
+        },
+        "cogs": [{"is_cog": True, "commands": [{}, {}]}],
+        "synonyms": [{"synonyms": ["a"]}],
+        "ideas": [],
+        "bugs": [],
+        "env_usage": [],
+        "settings": [],
+        "access": {"total_visible": 1},
+    }
+
+
+def test_count_integrity_passes_when_consistent(mod):
+    assert mod.check_count_integrity(_count_consistent_data()) == []
+
+
+def test_count_integrity_flags_mismatch_and_missing(mod):
+    data = _count_consistent_data()
+    data["meta"]["counts"]["commands"] = 99  # wrong
+    del data["meta"]["counts"]["synonyms"]  # missing
+    issues = mod.check_count_integrity(data)
+    codes = {i.code for i in issues}
+    assert "count_mismatch" in codes
+    assert "count_missing" in codes
+    mismatch = next(i for i in issues if i.code == "count_mismatch")
+    assert mismatch.severity == "error"
+
+
+# ---------------------------------------------------------------------------
+# required fields
+# ---------------------------------------------------------------------------
+
+
+def test_required_fields_flags_each_class(mod):
+    data = {
+        "cogs": [
+            {
+                "cog": "X",
+                "file": "",  # missing file
+                "commands": [
+                    {"name": "ok", "type": "prefix"},
+                    {"name": "", "type": "weird"},  # missing name + bad type
+                ],
+            },
+        ],
+        "catalogue": [{"key": ""}],  # missing key
+    }
+    codes = {i.code for i in mod.check_required_fields(data)}
+    assert codes == {
+        "cog_missing_file",
+        "command_missing_name",
+        "command_bad_type",
+        "catalogue_missing_key",
+    }
+
+
+# ---------------------------------------------------------------------------
+# live guard — the in-CI value: a freshly-built export must be clean
+# ---------------------------------------------------------------------------
+
+
+def test_live_export_has_no_integrity_errors(mod):
+    data = mod._build_fresh()
+    errors = [i for i in mod.validate(data) if i.severity == "error"]
+    assert errors == [], f"dashboard export has integrity errors: {errors}"
+
+
+def test_main_fresh_exits_zero(mod):
+    assert mod.main(["--fresh"]) == 0


### PR DESCRIPTION
## Why

The dashboard (`dashboard/`) is now the bot's main website, extended by **many parallel sessions**
through the stdlib scanners → `dashboard/data/dashboard.json`. Nothing validates that export, so a
drift silently degrades a page until someone eyeballs it. I hit exactly this in #988 — acronym cogs
(`BTD6Cog`/`AICog`/`XPCog`) whose `subsystem` didn't resolve to the registry rendered with a generic
icon + no routing key, invisibly. This adds a guard so the **next** such drift fails a check instead.

**Non-conflicting by construction** (owner is doing the control-API mutation endpoints + the website
OAuth/editors in parallel sessions): touches only `scripts/` + `tests/` — never `control_api.py`,
never the dashboard templates/OAuth/editor pages.

## What

- **`scripts/check_dashboard_data.py`** — stdlib validator (`validate(data) -> list[Issue]`) over the
  exported payload:
  - **cog→subsystem resolution** — every real (`is_cog`) cog's `subsystem` resolves to a registry
    subsystem key, minus a curated allow-list of legitimately-unregistered cogs (BTD6 sub-cogs ·
    Hermes · Paragon · Setup · RPS) and modules/mixins (`is_cog == False`). A *new* unregistered cog
    or a broken join is an error.
  - **count integrity** — `meta.counts.*` match the actual array lengths (the #973 count-drift class).
  - **required fields** — every command has a name + valid `type`; every cog has a `file`; every
    catalogue entry has a `key`.
  - CLI: validates the committed `dashboard.json` by default, `--fresh` regenerates from live sources
    first (so a newly-added unregistered cog is caught even if the JSON is stale).
- **`tests/unit/scripts/test_check_dashboard_data.py`** — per-check synthetic drift cases + a live
  guard that validates the **freshly-built** export has no error-severity issues.

Reliability (Q-0105): unverified, disposable — provenance header included.

## Verification

- `python3.10 -m pytest tests/unit/scripts/test_check_dashboard_data.py`
- `python3.10 scripts/check_dashboard_data.py --fresh`
- `python3.10 scripts/check_quality.py --check-only`

Born-red session card (Q-0133); flips to `complete` as the final commit → auto-merge on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Tff5WCNJjR5nnfpibsKjD

---
_Generated by [Claude Code](https://claude.ai/code/session_011Tff5WCNJjR5nnfpibsKjD)_