### PR TITLE
docs(ideas): capture BTD6 shorthand-corpus eval — the recurring router-class guard (BUG-0015 tail)

### DIFF
--- a/.sessions/2026-06-16-btd6-shorthand-corpus-idea.md
+++ b/.sessions/2026-06-16-btd6-shorthand-corpus-idea.md
@@ -1,0 +1,64 @@
+# 2026-06-16 — capture: BTD6 shorthand-corpus eval idea (post-BUG-0015 grooming)
+
+> **Status:** `in-progress`
+
+**Branch:** `claude/gifted-noether-37tiwr` · **Date:** 2026-06-16 · continuation after BUG-0015
+(#963 merged) — the standing secondary task (Q-0015 grooming / Q-0088 capture-to-queue).
+
+## What I'm about to do
+
+BUG-0015 ("d67 dart paragon") is **merged (#963)** and verified on main. With capacity remaining,
+and per Q-0088 (*late discoveries go into the queue, not unguided PRs past scope*), I'm **capturing**
+— not implementing — the one genuinely-valuable system-hardening idea this session surfaced: a
+**BTD6 community-shorthand corpus regression test** that guards the recurring "shorthand → unguarded
+general path → model freelances" bug class (BUG-0001/0003/0004/0008/0015). Today each fix has only
+its own isolated test; there is no single guard for the class.
+
+Also recording the verified **hero-per-level** investigation result so a future session doesn't
+re-derive it: heroes route fine + grounding already surfaces all-level descriptions + stats at
+1/3/10/20 — only non-headline-level *exact stats* are the (minor, low-priority) gap.
+
+Docs-only: a new `docs/ideas/` capture + README index entry. No `disbot/` runtime.
+
+## ✅ Done
+
+- `docs/ideas/btd6-shorthand-corpus-eval-2026-06-16.md` — the captured idea (class table, the
+  corpus-test sketch, why-captured-not-built, the hero sibling finding, lifecycle).
+- `docs/ideas/README.md` — index entry at the top (newest-first).
+
+## Context delta
+
+- **The conflict-guard flap I flagged at the end of the BUG-0015 session is already fixed** — hotfix
+  **#966** rewrote `pr-conflict-guard.yml`'s step with a guarded `post()` helper (no more `&& echo`
+  tripping `bash -e`; exit 0 on a single hiccup). No action needed; closed.
+- **The recurring router-class** (shorthand → unguarded path) is the highest-leverage durable
+  follow-up from BUG-0015 — captured as the corpus eval above.
+
+## Session enders
+
+**💡 Session idea (Q-0089).** *Is* the deliverable — the shorthand-corpus eval (a genuine, verified
+class guard; dedup-checked against `docs/ideas/`, no existing corpus/router-class entry).
+
+**⟲ Previous-session review (Q-0102).** The BUG-0015 session (#963) did the fix well (root-caused
+the two-layer routing+grounding gap, tested each layer, verified the merge in-turn through a busy
+merge-queue treadmill). What it could have done better: it flagged the conflict-guard flap to the
+owner but didn't note that flap was a brand-new workflow likely to be hotfixed imminently — and
+indeed #966 had already fixed it, so the flag was slightly stale by the time it was raised. **System
+improvement:** before flagging a CI/workflow defect, `git fetch` + check if a hotfix already landed
+(the same "sync-first" reflex the journal already prescribes for task overlap) — extended here to
+*infra observations*, not just task claims.
+
+**Doc audit (Q-0104).** Docs-only; `check_docs --strict` to run before push. No new owner decision.
+The `#963` ledger entry + the ~13 unrecorded merges remain the reconciliation routine's lane
+(Q-0124), not this session's.
+
+## 📤 Run report
+
+- **Did:** captured the BTD6 shorthand-corpus eval idea (the recurring router-class guard) + recorded
+  the hero-per-level finding; confirmed the conflict-guard flap is already fixed (#966) ·
+  **Outcome:** shipped (docs)
+- **Shipped:** the idea capture + README index entry (docs-only).
+- **⚑ Owner decisions needed:** `none`.
+- **⚑ Owner manual steps:** `none`.
+- **↪ Next:** the corpus eval is a small/decided grooming-pass execute-now candidate for a later
+  session or the next AI-router touch; BUG-0015 itself is fully shipped.

--- a/.sessions/2026-06-16-btd6-shorthand-corpus-idea.md
+++ b/.sessions/2026-06-16-btd6-shorthand-corpus-idea.md
@@ -1,6 +1,6 @@
 # 2026-06-16 — capture: BTD6 shorthand-corpus eval idea (post-BUG-0015 grooming)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Branch:** `claude/gifted-noether-37tiwr` · **Date:** 2026-06-16 · continuation after BUG-0015
 (#963 merged) — the standing secondary task (Q-0015 grooming / Q-0088 capture-to-queue).

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -20,6 +20,16 @@ during grooming** (it stays listed here, annotated ✅) so the active backlog re
 
 Current broad captures:
 
+- [`btd6-shorthand-corpus-eval-2026-06-16.md`](./btd6-shorthand-corpus-eval-2026-06-16.md) —
+  **late discovery from the BUG-0015 session (2026-06-16, PR #963):** a single **corpus regression
+  test** holding the canonical community-shorthand vocabulary (`despo`/`impop`/`r53`/`420 farm`/
+  `d67`/…) and asserting each routes to `AITask.BTD6_ANSWER` — the **class guard** for the recurring
+  "shorthand falls to the unguarded general path → model freelances" bug (BUG-0001/0003/0004/0008/
+  0015), which today has only scattered per-bug tests. Small/safe/decided-lane → a strong
+  grooming-pass execute-now candidate. Also records a verified *minor* hero-per-level-stats sibling
+  finding (heroes route fine + descriptions already ground; only non-headline-level exact stats are
+  the gap, low priority). → relates `services/ai_task_router.py` · `utils/btd6/keywords.py`.
+
 - [`developer-dashboard-2026-06-16.md`](./developer-dashboard-2026-06-16.md) —
   **owner-requested + approved (2026-06-16, Q-0155):** a personal website / developer dashboard
   deployed as a second Railway service — checklist, update tracker, bot-function catalogue,

--- a/docs/ideas/btd6-shorthand-corpus-eval-2026-06-16.md
+++ b/docs/ideas/btd6-shorthand-corpus-eval-2026-06-16.md
@@ -1,0 +1,65 @@
+# BTD6 community-shorthand corpus eval (router-class regression guard)
+
+> **Status:** `ideas`. **Not approved for implementation, not a plan.** A captured late
+> discovery from the BUG-0015 session (2026-06-16, PR #963). Source + the binding contracts +
+> `docs/current-state.md` win over this file.
+
+## The recurring class this would guard
+
+Five live-reported BTD6 bugs share **one root cause**: a community-shorthand question is **not
+recognised by `ai_task_router.classify`**, so it falls through to `GENERAL_NL_ANSWER` — the
+**unguarded** path (no grounding, no number guard) — where the model freelances from memory:
+
+| Bug | Shorthand that didn't route | Symptom |
+|---|---|---|
+| BUG-0001 | "cash by round 68" round-cash phrasing | refused / wrong total |
+| BUG-0003 | `despo`, `impop` | "despos" → wrong tower (Plasma Monkey Fan Club) |
+| BUG-0004 | `r53`/`r70` round shorthand | wrong cumulative total |
+| BUG-0008 | `420 farm` / short farm alias + money cue | invented farm income |
+| BUG-0015 | `d67` (degree) | "0-6-7 dart paragon doesn't exist" |
+
+Each was fixed with a *new `_looks_like_*` leg* in the router + a grounding leg — but each fix
+shipped its **own** isolated regression test. There is **no single guard** asserting "the whole
+known shorthand vocabulary routes to BTD6 grounding." A future router refactor (or a re-ordering
+of the `_looks_like_*` ladder) could silently regress one shorthand back onto the unguarded path,
+and only a *new* live user report would catch it — the exact failure loop this class keeps
+repeating.
+
+## The idea
+
+A single **corpus regression test** — `tests/unit/services/test_btd6_shorthand_corpus.py` — that
+holds the canonical list of community shorthands the bot must recognise and asserts each routes to
+`AITask.BTD6_ANSWER` (the class guard: "never silently drop a known shorthand to the unguarded
+path"), plus the matching conservatism negatives (the look-alikes that must *stay* general:
+`r2d2`, "67 degrees outside", "a degree in CS", "how do I farm coins"). It complements — does not
+replace — the per-bug tests: those pin *why* each leg exists; the corpus pins *the class as a
+whole* so adding a new shorthand is one obvious place and a refactor can't regress the set unseen.
+
+Cheap to start (routing-only, no DB), high leverage (it is the seam every one of these bugs went
+through). Optionally a second tier could assert the deterministic-grounding shorthands also produce
+their grounding facts, but that is heavier (dataset-backed) and a follow-on.
+
+## Why captured, not built
+
+Per the session-sizing rule (Q-0088: *no unguided PRs past declared scope — late discoveries go
+into the queue*), this was discovered while fixing BUG-0015 and belongs in the backlog, not bolted
+onto that PR. It is small/safe/decided-lane (a test in an existing area), so it is a strong
+**grooming-pass execute-now** candidate for a later session, or a quick win whenever the AI/BTD6
+router is next touched.
+
+## Related finding — hero per-level stats (a *minor*, lower-priority sibling)
+
+While checking whether BUG-0015 had a hero analogue, I verified: hero per-level questions ("Quincy
+at level 7") **route fine** (hero names *are* in the entity matcher, unlike the single-word towers
+that tripped BUG-0015), and `btd6_context_service` already grounds **per-level descriptions for all
+20 levels** + **headline stats at levels 1/3/10/20** (`_render_hero_descriptions` /
+`_render_hero_stats`, `_HERO_GROUNDING_LEVELS`). The only gap is **exact stats at a non-headline
+level** (e.g. level 7/15), which would mirror `_paragon_degree_facts`. This is **low priority**:
+heroes mostly gain *described abilities* (already grounded), not stat scaling, and the BTD6-path
+number guard makes the worst case a *refusal*, not a wrong answer (unlike the paragon case). Noted
+here so a future session doesn't re-investigate from scratch or over-invest in it.
+
+## Lifecycle
+
+`captured` → execute the corpus test in a grooming pass / next AI-router touch. The hero-stat
+sub-item stays `captured` at low priority unless a live report raises it.


### PR DESCRIPTION
## Why

Docs-only tail of the **BUG-0015** session (PR #963, merged). With capacity remaining after the
fix shipped, this **captures** — per Q-0088 (capture-to-queue, not unguided PRs past scope) and the
Q-0089 session-idea ender — the one genuinely-valuable system-hardening idea that session surfaced.

## What

The same root cause underlies **BUG-0001/0003/0004/0008/0015**: a community shorthand that
`ai_task_router.classify` doesn't recognise falls to the **unguarded `GENERAL_NL_ANSWER` path**,
where the model freelances. Today each fix carries only its own isolated regression test — there is
**no single guard for the class**. This captures the idea of a **BTD6 community-shorthand corpus
regression test** that asserts the whole shorthand vocabulary routes to `btd6.answer` (the class
guard), plus the verified (minor, low-priority) **hero-per-level exact-stats** sibling finding so a
future session doesn't re-derive it.

Captured, **not implemented** — it's a small/decided grooming-pass execute-now candidate for a later
AI-router touch.

## Files (docs-only, no `disbot/` runtime)

- `docs/ideas/btd6-shorthand-corpus-eval-2026-06-16.md` — the captured idea (class table, corpus-test
  sketch, why-captured-not-built, hero sibling finding, lifecycle).
- `docs/ideas/README.md` — index entry (newest-first).
- `.sessions/2026-06-16-btd6-shorthand-corpus-idea.md` — session log (Q-0089 idea · Q-0102 review ·
  Q-0104 audit).

`check_docs --strict` passes. Rebased onto current `main` (#989).

## Status

Born-red (Q-0133): the `.sessions/` card is `in-progress` until complete; flipped to `complete` as
the final step so auto-merge fires only on a finished PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGpPrMR9CArmxEuhQbD6qX

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGpPrMR9CArmxEuhQbD6qX)_