### PR TITLE
docs: ground the collaboration model in the Claude Code expertise research

### DIFF
--- a/.sessions/2026-06-16-code-expertise-research-readout.md
+++ b/.sessions/2026-06-16-code-expertise-research-readout.md
@@ -1,15 +1,58 @@
 # Session — Claude Code expertise research: workflow grounding
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-## About to do
+## Origin
 
 Owner asked me to read Anthropic's "Agentic coding and persistent returns to expertise"
 research (anthropic.com/research/claude-code-expertise) and report whether anything in it
-is usable in our workflow. Readout delivered in chat; owner approved the two contained
-follow-ups. This PR:
+is usable in our workflow. Readout delivered in chat; the report **confirms** our model
+rather than exposing a gap, so the owner approved two contained doc follow-ups.
 
-1. Cite the report in `docs/collaboration-model.md` § "Why this system exists" as external
-   grounding for the 70/30 plan-vs-execute split and the domain-expertise-beats-coding
-   finding.
-2. Capture the success-metric alignment observation as a `docs/ideas/` file + README entry.
+## What shipped (this PR — docs only)
+
+1. **`docs/collaboration-model.md`** § "Why this system exists" — added an *External
+   grounding* paragraph citing the ~400K-session study for the two premises it confirms:
+   the **70/30 plan-vs-execute split** ("people decide *what*, agents decide *how*" ≈ our
+   Q-0014) and **domain expertise beats coding background** (non-tech pros within ~4 pts of
+   engineers) — the empirical case for the docs/orientation system that turns the
+   maintainer's domain knowledge into precise specification.
+2. **`docs/ideas/success-metric-alignment-with-verified-success-2026-06-16.md`** (+ README
+   index) — the report's *verified success* metric (hard signals: tests/commits/confirm)
+   matches our CI-green + auto-merge + born-red gate; small audit idea on naming the
+   CI-only vs. human-confirm session lanes.
+
+## Verification
+
+- `python3.10 scripts/check_docs.py --strict` → green (312 docs, all reachable).
+- Docs-only; no `.py` touched, so no mypy/pytest delta.
+
+## 💡 Session idea (Q-0089)
+
+Captured as the idea file above — align our session success proxy with the research's
+"verified success" definition; name which session classes need explicit owner confirmation
+before auto-merge vs. CI-only.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous session (`2026-06-16-multiuser-control-panel-design.md`) was a clean docs-only
+design capture — strong on *auditing the existing seam before proposing new work* (it
+confirmed per-user + per-guild config already exist rather than assuming a build was
+needed). What it could improve: it left two build questions ("cog-vs-command enable/disable";
+`/commands` management go-ahead) explicitly open with no router Q-block to track them, so
+they live only in that log's prose — exactly the drift class our router exists to prevent.
+**System improvement it surfaces:** when a session defers a *decision* (not just an idea),
+the close-out should route it to a DISCUSS-lane Q-block, not a session-log sentence — a
+deferred decision in prose is invisible to the next session's orientation. Worth a one-line
+addition to the Q-0104 audit checklist: "any decision deferred this session → is it a
+router Q-block, not just log prose?"
+
+## Documentation audit (Q-0104)
+
+- New owner-approved doc changes have durable homes (collaboration-model.md + ideas/ +
+  README index). `check_docs --strict` green.
+- No new owner *decision* to record in the router (this was a "go ahead if useful"
+  approval of contained docs work, not a policy decision).
+- Ledger: SessionStart flagged 4 merged PRs not yet in current-state — that is the
+  routines' automated reconciliation scope (Q-0124), not this manual session's task; left
+  for the reconcile trigger.

--- a/.sessions/2026-06-16-code-expertise-research-readout.md
+++ b/.sessions/2026-06-16-code-expertise-research-readout.md
@@ -1,0 +1,15 @@
+# Session — Claude Code expertise research: workflow grounding
+
+> **Status:** `in-progress`
+
+## About to do
+
+Owner asked me to read Anthropic's "Agentic coding and persistent returns to expertise"
+research (anthropic.com/research/claude-code-expertise) and report whether anything in it
+is usable in our workflow. Readout delivered in chat; owner approved the two contained
+follow-ups. This PR:
+
+1. Cite the report in `docs/collaboration-model.md` § "Why this system exists" as external
+   grounding for the 70/30 plan-vs-execute split and the domain-expertise-beats-coding
+   finding.
+2. Capture the success-metric alignment observation as a `docs/ideas/` file + README entry.

--- a/docs/collaboration-model.md
+++ b/docs/collaboration-model.md
@@ -36,6 +36,21 @@ session. The docs are not bureaucracy and they are not done — they are a livin
 system that every session is expected to leave **a little better than it found
 it**.
 
+**External grounding (Anthropic, "Agentic coding and persistent returns to
+expertise", 2026 — analysis of ~400K Claude Code sessions Oct 2025–Apr 2026):**
+the study's two headline findings are independent confirmation of this model, not
+just our preference. (1) Across sessions, humans make ~70% of *planning* decisions
+while agents make ~80% of *execution* decisions — "people decide *what*, agents
+decide *how*" — a near-verbatim match to "the maintainer designs and visualizes;
+you build" (Q-0014: approving a goal approves the path to it). (2) **Domain
+expertise predicts success more than coding background**: non-tech professionals
+reached verified success within ~4 points of software engineers (≈26% vs ≈30%),
+and clear specification is the single biggest learnable success lever. That is the
+empirical case for *this* docs/orientation system — it exists to turn the
+maintainer's domain expertise into the precise specification the agent needs,
+compensating for his being a non-coder. The reading cost above is buying the exact
+thing the data says drives outcomes.
+
 **So, to every future agent: improving the docs / orientation / tooling / journal
 is first-class work, never wasted effort and never "extra."** When you make the
 next session faster or more correct — you tighten an orientation route, capture a

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -62,6 +62,13 @@ Current broad captures:
   render with a generic 🧩 + no routing key. A small cog→parent-subsystem map in `scan_commands` would
   let sub-cogs inherit their parent's registry identity (emoji/name/routing), shrinking the allow-list
   to the truly-unregistered few. → relates `scripts/scan_commands.py` · `dashboard/`.
+- [`success-metric-alignment-with-verified-success-2026-06-16.md`](./success-metric-alignment-with-verified-success-2026-06-16.md) —
+  **session idea (2026-06-16, Q-0089, from the Claude Code expertise research readout):** Anthropic's
+  ~400K-session study measures **verified success** by *hard signals* (tests passing, commits,
+  explicit confirmation) — our CI-green + auto-merge + born-red gate is the same philosophy. Mostly
+  confirmatory; the contained value is naming which session *classes* should require explicit owner
+  confirmation before auto-merge vs. CI-only (the `needs-hermes-review`/`do-not-automerge` seam may
+  already cover it). → relates `docs/collaboration-model.md` · CLAUDE.md § Session workflow.
 - [`docs-ledger-parsing-helper-2026-06-16.md`](./docs-ledger-parsing-helper-2026-06-16.md) —
   **promoted Q-0089 idea (2026-06-16, originally surfaced in #967's session log):** extract the
   repeatedly-copied markdown-ledger regexes (Status badge / `BUG-NNNN` / idea-file parsers) into one

--- a/docs/ideas/success-metric-alignment-with-verified-success-2026-06-16.md
+++ b/docs/ideas/success-metric-alignment-with-verified-success-2026-06-16.md
@@ -1,0 +1,38 @@
+# Idea: align our session success proxy with the research's "verified success"
+
+> **Status:** `ideas`
+
+**Captured:** 2026-06-16 · **Context:** readout of Anthropic's "Agentic coding and
+persistent returns to expertise" research (~400K Claude Code sessions), owner asked
+whether anything in it is usable here (Q-0089 session ender).
+
+## Observation
+
+The report's strongest outcome metric is **verified success** — sessions backed by
+*hard signals*: tests passing, commits landing, explicit user confirmation — as
+opposed to a model merely *judging* a session successful. It found verified success
+is what separates expert from novice outcomes (≈28–33% vs ≈15%).
+
+Our workflow already has an analogue: a session is "done" only when its PR reaches a
+terminal state, and the terminal state is driven by **CI-green + auto-merge** (Q-0103
+/ Q-0123) plus the born-red→flip-green session gate (Q-0133). That is the same
+philosophy — *don't trust a self-judged "looks done," require a hard signal.* The
+report is external validation that this is the right success definition to optimize.
+
+## Proposal (small / low-stakes)
+
+A one-line audit, not a new mechanism: confirm our hard signals actually cover the
+report's three. We have tests-passing (CI) and commits-landing (auto-merge) well;
+the third — **explicit owner confirmation** — is currently implicit (silence + green
+CI merges the PR). Worth a deliberate check of whether any *class* of session should
+require an explicit owner ack before auto-merge arms (e.g. anything touching binding
+rules already routes through `needs-hermes-review` / `do-not-automerge` — so the seam
+may already exist and just needs to be named as "this is our verified-success-with-
+human-confirm lane").
+
+## Value
+
+Mostly confirmatory — the report says our success definition is the empirically
+right one, which is reassuring rather than action-forcing. The contained value is
+making the "which sessions need human confirmation vs. CI-only" boundary explicit
+rather than emergent.


### PR DESCRIPTION
## What

Owner asked me to read Anthropic's research report **"Agentic coding and persistent returns to expertise"** (anthropic.com/research/claude-code-expertise) and report whether anything in it is usable in our workflow. The readout was delivered in chat; the report **confirms** our direction rather than revealing a gap, so this PR captures the two contained follow-ups the owner approved.

## Changes

1. **`docs/collaboration-model.md`** § "Why this system exists" — cite the report as external grounding for two load-bearing premises of our model:
   - the **70/30 plan-vs-execute split** (humans decide *what*, agents decide *how*) — a near-verbatim match to our Working Agreement, and
   - **domain expertise beats coding background** (non-tech professionals succeed within ~4 pts of engineers) — the empirical justification for the docs/orientation system that compensates for the maintainer being a non-coder.

2. **`docs/ideas/`** — new capture noting the report's success metric ("verified success" = tests passing / commits / explicit confirmation) lines up with our CI-green + auto-merge proxy, with a one-line check idea. README index entry added.

## Verification

- Docs-only; no `.py` touched. `check_quality --check-only` + `check_docs --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXZp1RXmc6QQLGxXJu9h6P)_