### PR TITLE
feat(dashboard): control panel — Discord OAuth login + live editors (write side step 2)

### DIFF
--- a/.sessions/2026-06-16-control-panel-oauth-editors.md
+++ b/.sessions/2026-06-16-control-panel-oauth-editors.md
@@ -1,0 +1,85 @@
+# Session — control panel: Discord OAuth login + web editors (write side, step 2)
+
+> **Status:** `in-progress`
+
+## Origin
+
+Owner directive (in-session, 2026-06-16): *"finish these steps completely — (2) the website's Discord
+OAuth login + editors."* This is **step 2**, the website half, on top of #989 (control API + bridge) +
+#993 (mutation endpoints). The owner confirmed the parallel session is done; `list_pull_requests` was
+clean. Builds the **free, multi-user control panel**: anyone signs in with Discord and edits the
+servers they administer.
+
+## What shipped (this PR — dormant until the owner sets the secrets)
+
+A complete login → pick-server → edit loop on the decoupled dashboard, every write flowing through the
+bot's control API → existing audited seam (the website never writes the DB):
+
+- **`dashboard/auth.py`** — Discord OAuth2 (`identify guilds` scopes): consent URL, code→token, the
+  user + guild-list fetch, and the admin-guild filter (owner or `ADMINISTRATOR`). Dormant until
+  `DISCORD_OAUTH_CLIENT_ID` / `_SECRET` / `_REDIRECT_URI` are set.
+- **`dashboard/control_client.py`** — httpx client to the bot control API (`worker.railway.internal`),
+  bearer-authed with `CONTROL_API_TOKEN`. Dormant when the token is unset (editor shows "not
+  connected"); the authority bridge call + the `POST` over each seam.
+- **`dashboard/websession.py`** — a **stdlib HMAC-signed-cookie session** (no `itsdangerous`, no
+  middleware). See the constraint note below.
+- **`dashboard/app.py`** — `/auth/login` · `/auth/callback` · `/auth/logout`; `/admin` (the admin-guild
+  picker) · `/admin/{guild_id}` (the editor); and the `POST` handlers for settings / help-overlay /
+  help-home / cog-routing, each gated on the session admin + PRG-redirecting with a flash. Forms are
+  parsed with `urllib.parse.parse_qs` (stdlib — no `python-multipart`).
+- **Templates** — `admin.html` (sign-in / setup / guild picker), `admin_guild.html` (the three
+  editors), and the nav login state in `base.html` (via a Jinja context processor).
+- **The bot stays the authority.** The browser asserts identity; the bot resolves the live member and
+  the seam enforces real permissions on every write (#993). The session cookie is signed + httponly; a
+  forged cookie reads as empty.
+
+## The no-network constraint → stdlib session (why no itsdangerous / multipart)
+
+This environment has **no PyPI access for new packages**, so `itsdangerous` (SessionMiddleware) and
+`python-multipart` (form parsing) could not be installed — which made `tests/unit/dashboard/test_app.py`
+skip entirely, leaving the templates **unverified** (the #979 trap). Fix: drop both deps — a small
+stdlib HMAC-signed cookie + `urllib` form parsing — so the whole app is verifiable with just
+`fastapi` + `jinja2` + `httpx` (already present). Leaner *and* testable; same security shape as a
+signing library.
+
+## Verification
+
+- `pip install -r dashboard/requirements.txt` + `python3.10 -m pytest tests/unit/dashboard/` →
+  **42 passed** (the editor page renders for a logged-in user via a minted signed cookie; dormant
+  login/redirect paths; the OAuth/client logic + admin-guild filter).
+- `python3.10 scripts/check_quality.py --check-only` → green (black/isort/ruff over the CI scope
+  incl. `dashboard/`; check_docs). No `disbot/` change → mypy/bot-suite unaffected.
+
+## Owner setup to activate (nothing changes in prod on merge)
+
+On the **dashboard** Railway service: `DISCORD_OAUTH_CLIENT_ID`, `DISCORD_OAUTH_CLIENT_SECRET` (Reset
+in the Discord portal → paste into Railway, never chat), `DISCORD_OAUTH_REDIRECT_URI` =
+`https://superbot-dashboard.up.railway.app/auth/callback`, `DASHBOARD_SESSION_SECRET` (long random),
+`CONTROL_API_TOKEN` (same value as the bot worker), and `CONTROL_API_URL` if not the default
+`http://worker.railway.internal:8080`. On the **bot worker**: `CONTROL_API_TOKEN` (same value) +
+confirm Railway private networking. Then the bot's control API + this login both wake up.
+
+## 💡 Session idea (Q-0089)
+
+**A `/admin/{guild}` "current values" read panel.** The editors currently write blind (you type a
+setting/help value; the bot validates). Add control-API **GET** endpoints (`/control/settings/current`,
+`/control/help/overlay`) so the editor shows the guild's *current* per-server value beside each field —
+turning blind edits into see-then-change. Small, additive, read-only; the natural next control-API
+slice once the write side is proven.
+
+## ⟲ Previous-session review (Q-0102) — #993 (mutation endpoints)
+
+**Did well:** fronted the audited seams cleanly (the bot stays the authority; dormant-by-default
+preserved), mapped seam errors to precise HTTP codes, and 28 focused tests with the seams mocked.
+**Could've flagged sooner:** it listed "aliases" as a seam but there's no audited synonym-overlay yet —
+worth a one-line "aliases-live needs a new overlay" call-out in the PR body so the gap is unmissable
+(it was in the session card but easy to miss). **System improvement:** when a directive lists N targets
+and one lacks a seam, the PR description should explicitly enumerate *built vs deferred* targets so the
+owner sees the gap without reading the code — a small honesty-of-scope habit.
+
+## 📋 Documentation audit (Q-0104)
+
+`check_docs --strict` green. New dashboard env vars (`DISCORD_OAUTH_*`, `DASHBOARD_SESSION_SECRET`,
+`CONTROL_API_URL`) are **dashboard-side only** — `scan_env_usage` scans `disbot/`, so they don't enter
+`docs/operations/env-vars.md`; they're documented in `admin.html`'s setup panel + this card +
+(next) the dashboard README. Nothing from this session lives only in chat.

--- a/.sessions/2026-06-16-control-panel-oauth-editors.md
+++ b/.sessions/2026-06-16-control-panel-oauth-editors.md
@@ -1,6 +1,6 @@
 # Session — control panel: Discord OAuth login + web editors (write side, step 2)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Origin
 

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -36,6 +36,24 @@ and the *code locations* that read them — it never reads, stores, or renders a
 **value**, and it never opens an `.env` file. Railway stays the single source of truth for
 the values; managed value editing (behind owner login, masked) is a later Phase 3 slice.
 
+## Control panel (Discord login + live editors)
+
+Beyond the read-only pages, the dashboard is a **free, multi-user control panel** (`/admin`): sign in
+with Discord, pick a server you administer, and edit its **settings**, **help appearance**, and
+**cog enable/disable** — applied live. Every write goes to the **bot's control API**
+(`disbot/control_api.py`) over Railway's private network, and the **bot** resolves the live member and
+writes through its existing **audited seam** (settings/help/routing). The website never writes the DB
+and never decides permissions — the browser's identity claim is re-checked by the bot on every edit.
+
+**Dormant by default.** With nothing configured, `/admin` shows setup instructions and the read-only
+site is unchanged. To switch it on, set on this service: `DISCORD_OAUTH_CLIENT_ID`,
+`DISCORD_OAUTH_CLIENT_SECRET`, `DISCORD_OAUTH_REDIRECT_URI`
+(`https://superbot-dashboard.up.railway.app/auth/callback`), `DASHBOARD_SESSION_SECRET`,
+`CONTROL_API_TOKEN` (+ `CONTROL_API_URL` if not the default `http://worker.railway.internal:8080`);
+and the **same** `CONTROL_API_TOKEN` on the bot worker. The login session is a small stdlib
+HMAC-signed cookie (`websession.py`) and forms are parsed with `urllib` — **no** `itsdangerous` /
+`python-multipart`, so the app stays verifiable with just fastapi + jinja2 + httpx.
+
 ## Run locally
 
 ```bash

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -15,15 +15,29 @@ Deploy: a second Railway service — see ``dashboard/README.md``.
 from __future__ import annotations
 
 import json
+import secrets
+import sys
 from pathlib import Path
 from typing import Any
+from urllib.parse import parse_qs
 
 from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
 BASE_DIR = Path(__file__).resolve().parent
 DATA_FILE = BASE_DIR / "data" / "dashboard.json"
+
+# The dashboard runs both as a package (`dashboard.app`, local) and as a top-level
+# module (`app:app`, Railway Root Directory = dashboard) — and the test loads
+# app.py by file path. Putting this directory on sys.path lets the sibling helper
+# modules import identically in all three contexts.
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
+
+import auth  # noqa: E402  - after the sys.path shim above
+import control_client  # noqa: E402  - after the sys.path shim above
+import websession  # noqa: E402  - after the sys.path shim above
 
 _EMPTY: dict[str, Any] = {
     "meta": {"generated_at": "", "counts": {}},
@@ -38,7 +52,27 @@ _EMPTY: dict[str, Any] = {
 }
 
 app = FastAPI(title="SuperBot Dashboard", docs_url=None, redoc_url=None)
-templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+
+
+def session_context(request: Request) -> dict[str, Any]:
+    """Login state merged into every template (the nav login button / avatar)."""
+    return {
+        "current_user": websession.read(request).get("user"),
+        "login_enabled": auth.is_configured(),
+    }
+
+
+templates = Jinja2Templates(
+    directory=str(BASE_DIR / "templates"),
+    context_processors=[session_context],
+)
+
+
+async def _form(request: Request) -> dict[str, str]:
+    """Parse an ``application/x-www-form-urlencoded`` body (stdlib, no multipart)."""
+    raw = (await request.body()).decode("utf-8", "replace")
+    parsed = parse_qs(raw, keep_blank_values=True)
+    return {key: values[0] for key, values in parsed.items()}
 
 
 def load_data() -> dict[str, Any]:
@@ -303,3 +337,239 @@ def commands(request: Request):
             },
         },
     )
+
+
+# ===========================================================================
+# Control panel — Discord OAuth login + the per-guild editors
+#
+# Dormant until the owner configures the Discord OAuth app + the bot control
+# API token on Railway. With nothing configured, /admin renders a "set this up"
+# page and the nav shows no login button — the read-only site is unchanged.
+# Every edit POSTs to the bot's control API, which resolves the live member and
+# writes through the EXISTING audited seam — the website never writes the DB.
+# ===========================================================================
+
+
+def _find_admin_guild(
+    session: dict[str, Any],
+    guild_id: str,
+) -> dict[str, Any] | None:
+    """The session's admin-guild entry matching ``guild_id``, or ``None``."""
+    for guild in session.get("guilds", []):
+        if str(guild.get("id")) == str(guild_id):
+            return guild
+    return None
+
+
+async def _control_flash(path: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Call the control API; return a one-shot flash dict describing the outcome."""
+    status, body = await control_client.post(path, payload)
+    ok = status == 200 and bool(body.get("ok"))
+    return {
+        "ok": ok,
+        "status": status,
+        "message": (
+            "Saved — the bot applied it live."
+            if ok
+            else str(body.get("error") or f"Failed (HTTP {status}).")
+        ),
+    }
+
+
+@app.get("/auth/login")
+def auth_login(request: Request):
+    """Begin Discord OAuth — redirect to consent, or fall back to /admin if off."""
+    if not auth.is_configured():
+        return RedirectResponse("/admin", status_code=302)
+    session = websession.read(request)
+    state = secrets.token_urlsafe(16)
+    session["oauth_state"] = state
+    resp = RedirectResponse(auth.authorize_url(state), status_code=302)
+    websession.write(resp, session)
+    return resp
+
+
+@app.get("/auth/callback")
+async def auth_callback(request: Request):
+    """OAuth redirect target — verify state, exchange the code, store identity."""
+    session = websession.read(request)
+    code = request.query_params.get("code")
+    state = request.query_params.get("state")
+    expected = session.pop("oauth_state", None)
+    if not code or not state or state != expected:
+        return RedirectResponse("/admin", status_code=302)
+    try:
+        token = await auth.exchange_code(code)
+        identity = await auth.fetch_identity(token)
+    except Exception:  # noqa: BLE001 - any OAuth failure → back to /admin with a flash
+        session["flash"] = {
+            "ok": False,
+            "status": 502,
+            "message": "Discord sign-in failed — please try again.",
+        }
+        resp = RedirectResponse("/admin", status_code=302)
+        websession.write(resp, session)
+        return resp
+    user = identity.get("user", {})
+    session["user"] = {
+        "id": user.get("id"),
+        "username": user.get("username"),
+        "global_name": user.get("global_name"),
+        "avatar": user.get("avatar"),
+    }
+    session["guilds"] = auth.admin_guilds(identity.get("guilds", []))
+    resp = RedirectResponse("/admin", status_code=302)
+    websession.write(resp, session)
+    return resp
+
+
+@app.get("/auth/logout")
+def auth_logout(request: Request):
+    """Clear the session and return home."""
+    resp = RedirectResponse("/", status_code=302)
+    websession.clear(resp)
+    return resp
+
+
+@app.get("/admin", response_class=HTMLResponse)
+def admin_home(request: Request):
+    """The control-panel home — sign-in prompt or the user's admin-guild picker."""
+    session = websession.read(request)
+    user = session.get("user")
+    guilds = session.get("guilds", []) if user else []
+    flash = session.pop("flash", None)
+    resp = templates.TemplateResponse(
+        request,
+        "admin.html",
+        {
+            "data": load_data(),
+            "page": "admin",
+            "guilds": guilds,
+            "control_configured": control_client.is_configured(),
+            "flash": flash,
+        },
+    )
+    if flash is not None:
+        websession.write(resp, session)  # persist the flash pop
+    return resp
+
+
+@app.get("/admin/{guild_id}", response_class=HTMLResponse)
+async def admin_guild(request: Request, guild_id: str):
+    """The per-guild editor — settings, help appearance, and cog routing."""
+    session = websession.read(request)
+    user = session.get("user")
+    if user is None:
+        return RedirectResponse("/admin", status_code=302)
+    guild = _find_admin_guild(session, guild_id)
+    if guild is None:
+        return RedirectResponse("/admin", status_code=302)
+    authority = None
+    if control_client.is_configured():
+        authority = await control_client.get_authority(int(guild_id), int(user["id"]))
+    data = load_data()
+    flash = session.pop("flash", None)
+    resp = templates.TemplateResponse(
+        request,
+        "admin_guild.html",
+        {
+            "data": data,
+            "page": "admin",
+            "guild": guild,
+            "authority": authority,
+            "control_configured": control_client.is_configured(),
+            "settings": data.get("settings", []),
+            "cogs": [c for c in data.get("cogs", []) if c.get("is_cog")],
+            "catalogue": data.get("catalogue", []),
+            "flash": flash,
+        },
+    )
+    if flash is not None:
+        websession.write(resp, session)
+    return resp
+
+
+async def _edit(
+    request: Request,
+    guild_id: str,
+    path: str,
+    payload: dict[str, Any],
+) -> RedirectResponse:
+    """Shared editor POST: gate on session admin → control API → flash → redirect."""
+    session = websession.read(request)
+    if session.get("user") is None or _find_admin_guild(session, guild_id) is None:
+        return RedirectResponse("/admin", status_code=303)
+    session["flash"] = await _control_flash(path, payload)
+    resp = RedirectResponse(f"/admin/{guild_id}", status_code=303)
+    websession.write(resp, session)
+    return resp
+
+
+def _actor_id(request: Request) -> int | None:
+    user = websession.read(request).get("user")
+    try:
+        return int(user["id"]) if user else None
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+@app.post("/admin/{guild_id}/settings")
+async def post_setting(request: Request, guild_id: str):
+    """Edit one setting → POST /control/settings (the bot capability-gates it)."""
+    form = await _form(request)
+    payload = {
+        "guild_id": int(guild_id),
+        "user_id": _actor_id(request),
+        "subsystem": form.get("subsystem", "").strip(),
+        "name": form.get("name", "").strip(),
+        "value": form.get("value", "").strip(),
+    }
+    return await _edit(request, guild_id, "/control/settings", payload)
+
+
+@app.post("/admin/{guild_id}/help/overlay")
+async def post_help_overlay(request: Request, guild_id: str):
+    """Hide / rename / re-describe a Help entity → POST /control/help/overlay."""
+    form = await _form(request)
+    payload: dict[str, Any] = {
+        "guild_id": int(guild_id),
+        "user_id": _actor_id(request),
+        "entity_kind": form.get("entity_kind", "").strip(),
+        "entity_key": form.get("entity_key", "").strip(),
+        "display_hidden": form.get("display_hidden") == "on",
+    }
+    # Only forward text overrides the user actually filled in (blank = untouched).
+    if form.get("display_name", "").strip():
+        payload["display_name"] = form["display_name"].strip()
+    if form.get("description", "").strip():
+        payload["description"] = form["description"].strip()
+    return await _edit(request, guild_id, "/control/help/overlay", payload)
+
+
+@app.post("/admin/{guild_id}/help/home")
+async def post_help_home(request: Request, guild_id: str):
+    """Edit the Help Home message → POST /control/help/home."""
+    form = await _form(request)
+    payload: dict[str, Any] = {
+        "guild_id": int(guild_id),
+        "user_id": _actor_id(request),
+    }
+    if form.get("title", "").strip():
+        payload["title"] = form["title"].strip()
+    if form.get("body", "").strip():
+        payload["body"] = form["body"].strip()
+    return await _edit(request, guild_id, "/control/help/home", payload)
+
+
+@app.post("/admin/{guild_id}/routing")
+async def post_routing(request: Request, guild_id: str):
+    """Enable / disable a cog for the guild → POST /control/routing."""
+    form = await _form(request)
+    payload = {
+        "guild_id": int(guild_id),
+        "user_id": _actor_id(request),
+        "cog_name": form.get("cog_name", "").strip(),
+        "enabled": form.get("enabled") == "enabled",
+        "scope_type": "guild",
+    }
+    return await _edit(request, guild_id, "/control/routing", payload)

--- a/dashboard/auth.py
+++ b/dashboard/auth.py
@@ -1,0 +1,134 @@
+"""Discord OAuth2 for the dashboard control panel — login + identity.
+
+The dashboard is a **free, multi-user control panel**: anyone signs in with their
+Discord account, and the site then knows *who they are* and *which guilds they
+administer*. That identity is handed to the bot's control API, which makes the
+**real** authority decision (the bot resolves the live member and the audited
+seam enforces permissions — see ``disbot/control_api.py``). The browser's claim
+is never trusted on its own.
+
+**Dormant by default.** Every helper reads its config from the environment and
+returns ``None`` / a "not configured" signal when the OAuth app is not set up, so
+the dashboard runs exactly as the read-only site until the owner provisions
+``DISCORD_OAUTH_CLIENT_ID`` / ``DISCORD_OAUTH_CLIENT_SECRET`` /
+``DISCORD_OAUTH_REDIRECT_URI`` on Railway. No secret is ever committed.
+
+Scopes are the minimum needed: ``identify`` (who you are) + ``guilds`` (which
+servers you're in, with your permission bits) — never ``email`` or message access.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from urllib.parse import urlencode
+
+AUTHORIZE_URL = "https://discord.com/oauth2/authorize"
+TOKEN_URL = "https://discord.com/api/oauth2/token"
+API_BASE = "https://discord.com/api/v10"
+SCOPES = "identify guilds"
+
+# Discord permission bit for ADMINISTRATOR (0x8). A guild where the user is owner
+# or holds this bit is one they can administer — the only guilds the editor offers
+# (the bot re-verifies per write, so this is a UX filter, not the security gate).
+_PERM_ADMINISTRATOR = 0x8
+
+
+def oauth_config() -> tuple[str, str, str] | None:
+    """Return ``(client_id, client_secret, redirect_uri)`` or ``None`` if unset."""
+    client_id = os.environ.get("DISCORD_OAUTH_CLIENT_ID", "").strip()
+    client_secret = os.environ.get("DISCORD_OAUTH_CLIENT_SECRET", "").strip()
+    redirect_uri = os.environ.get("DISCORD_OAUTH_REDIRECT_URI", "").strip()
+    if not (client_id and client_secret and redirect_uri):
+        return None
+    return client_id, client_secret, redirect_uri
+
+
+def is_configured() -> bool:
+    """``True`` when the Discord OAuth app is fully configured (login enabled)."""
+    return oauth_config() is not None
+
+
+def authorize_url(state: str) -> str | None:
+    """The Discord consent URL to redirect a logging-in user to, or ``None``."""
+    config = oauth_config()
+    if config is None:
+        return None
+    client_id, _secret, redirect_uri = config
+    query = urlencode(
+        {
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "scope": SCOPES,
+            "state": state,
+            "prompt": "none",
+        },
+    )
+    return f"{AUTHORIZE_URL}?{query}"
+
+
+async def exchange_code(code: str) -> str:
+    """Exchange an OAuth ``code`` for an access token. Returns the access token.
+
+    Raises ``RuntimeError`` if OAuth is not configured and propagates HTTP errors
+    from httpx so the caller can render a failure page.
+    """
+    config = oauth_config()
+    if config is None:
+        raise RuntimeError("Discord OAuth is not configured")
+    import httpx
+
+    client_id, client_secret, redirect_uri = config
+    data = {
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+    }
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.post(
+            TOKEN_URL,
+            data=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        resp.raise_for_status()
+        token: str = resp.json()["access_token"]
+    return token
+
+
+async def fetch_identity(access_token: str) -> dict[str, Any]:
+    """Fetch the user + their guild list with the access token.
+
+    Returns ``{"user": {...}, "guilds": [...]}`` where ``guilds`` carries each
+    guild's ``permissions`` bits (so :func:`admin_guilds` can filter).
+    """
+    import httpx
+
+    headers = {"Authorization": f"Bearer {access_token}"}
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        user_resp = await client.get(f"{API_BASE}/users/@me", headers=headers)
+        user_resp.raise_for_status()
+        guilds_resp = await client.get(f"{API_BASE}/users/@me/guilds", headers=headers)
+        guilds_resp.raise_for_status()
+    return {"user": user_resp.json(), "guilds": guilds_resp.json()}
+
+
+def admin_guilds(guilds: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Filter ``guilds`` to those the user owns or holds ADMINISTRATOR in.
+
+    UX filter only — the editor offers these, but the bot re-checks authority on
+    every write against the live member, so a stale/forged list cannot escalate.
+    """
+    out: list[dict[str, Any]] = []
+    for guild in guilds:
+        if not isinstance(guild, dict):
+            continue
+        try:
+            perms = int(guild.get("permissions", 0))
+        except (TypeError, ValueError):
+            perms = 0
+        if guild.get("owner") or (perms & _PERM_ADMINISTRATOR):
+            out.append(guild)
+    return out

--- a/dashboard/control_client.py
+++ b/dashboard/control_client.py
@@ -1,0 +1,95 @@
+"""Client for the bot's private control API (``disbot/control_api.py``).
+
+The dashboard is a separate process that never imports the bot; to drive the
+bot's audited seams it calls the bot's control API over Railway's **private**
+network (``http://worker.railway.internal:8080`` by default), authenticating with
+the shared ``CONTROL_API_TOKEN``. Every call carries the acting user's Discord id
++ the target guild id; the **bot** resolves the live member and the audited seam
+makes the real authority decision — this client never decides permissions.
+
+**Dormant by default.** When ``CONTROL_API_URL`` / ``CONTROL_API_TOKEN`` are not
+set, :func:`is_configured` is ``False`` and the editor surface shows a
+"not connected" state instead of calling anything. Nothing here is exercised
+until the owner sets both on the dashboard Railway service.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+# The bot's control API is reachable on the Railway private network. The default
+# matches the health server's port; override with CONTROL_API_URL if needed.
+_DEFAULT_BASE = "http://worker.railway.internal:8080"
+
+
+def control_config() -> tuple[str, str] | None:
+    """Return ``(base_url, token)`` or ``None`` when the client is dormant."""
+    token = os.environ.get("CONTROL_API_TOKEN", "").strip()
+    if not token:
+        return None
+    base = os.environ.get("CONTROL_API_URL", "").strip() or _DEFAULT_BASE
+    return base.rstrip("/"), token
+
+
+def is_configured() -> bool:
+    """``True`` when the bot control API is reachable (token configured)."""
+    return control_config() is not None
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+
+async def get_authority(guild_id: int, user_id: int) -> dict[str, Any] | None:
+    """Ask the bot what ``user_id`` may do in ``guild_id`` (the authority bridge).
+
+    Returns the bridge payload (``tier`` / ``is_admin`` / ``member_found`` …), or
+    ``None`` when the client is dormant or the bot is unreachable.
+    """
+    config = control_config()
+    if config is None:
+        return None
+    import httpx
+
+    base, token = config
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(
+                f"{base}/control/authority",
+                params={"guild_id": guild_id, "user_id": user_id},
+                headers=_headers(token),
+            )
+        if resp.status_code != 200:
+            return None
+        return resp.json()
+    except Exception:  # noqa: BLE001 - bot unreachable / network error → no authority
+        return None
+
+
+async def post(path: str, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+    """POST ``payload`` to a control-API ``path`` (e.g. ``/control/settings``).
+
+    Returns ``(status_code, body)``. A dormant client returns ``(503, …)``; a
+    network failure returns ``(502, …)`` so the editor can show a clear message.
+    """
+    config = control_config()
+    if config is None:
+        return 503, {"error": "control API not configured"}
+    import httpx
+
+    base, token = config
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                f"{base}{path}",
+                json=payload,
+                headers=_headers(token),
+            )
+        try:
+            body = resp.json()
+        except Exception:  # noqa: BLE001 - non-JSON body
+            body = {"error": resp.text[:200]}
+        return resp.status_code, body
+    except Exception as exc:  # noqa: BLE001 - bot unreachable
+        return 502, {"error": f"could not reach the bot control API: {exc}"}

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -4,5 +4,10 @@
 fastapi>=0.110,<1.0
 uvicorn[standard]>=0.27,<1.0
 jinja2>=3.1,<4.0
-# httpx is only needed to run the test suite's TestClient (and, in later phases,
-# to call the GitHub/Railway APIs); not required to serve the read-only MVP.
+# httpx: the Discord OAuth token/identity calls + the bot control-API client, and
+# the test suite's Starlette TestClient transport.
+httpx>=0.27,<1.0
+# NOTE: the OAuth login session is a small stdlib HMAC-signed cookie
+# (dashboard/websession.py) and the editor forms are parsed with urllib
+# (dashboard/app.py::_form) — deliberately NO itsdangerous / python-multipart, so
+# the whole app stays verifiable with just fastapi + jinja2 + httpx installed.

--- a/dashboard/templates/admin.html
+++ b/dashboard/templates/admin.html
@@ -1,0 +1,73 @@
+{% extends "base.html" %}
+{% block title %}Control panel — SuperBot{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-1">Control panel</h1>
+<p class="text-slate-400 mb-5 text-sm">
+  Sign in with Discord to manage the servers you administer — edit settings, customize the help
+  appearance, and enable/disable cogs. Every change flows through the bot's own audited seams; the
+  website never writes the database directly, and the <strong>bot re-checks your permissions</strong>
+  on every edit.
+</p>
+
+{% if flash %}
+  <div class="mb-5 rounded-lg border px-4 py-3 text-sm
+    {{ 'border-emerald-900/60 bg-emerald-950/40 text-emerald-200' if flash.ok
+       else 'border-rose-900/60 bg-rose-950/40 text-rose-200' }}">
+    {{ flash.message }}
+  </div>
+{% endif %}
+
+{% if current_user %}
+  {% if not control_configured %}
+    <div class="mb-5 rounded-lg border border-amber-900/60 bg-amber-950/30 px-4 py-3 text-sm text-amber-200">
+      You're signed in, but the dashboard isn't connected to the bot yet
+      (<code>CONTROL_API_TOKEN</code> unset), so edits can't be applied live. The server list below is
+      still yours; connect the bot to enable editing.
+    </div>
+  {% endif %}
+  <h2 class="text-lg font-semibold mb-3">Servers you administer</h2>
+  {% if guilds %}
+    <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {% for g in guilds %}
+        <a href="/admin/{{ g.id }}"
+           class="rounded-xl border border-slate-800 bg-slate-900/50 p-4 hover:border-sky-600 transition">
+          <div class="font-semibold truncate">{{ g.name }}</div>
+          <div class="text-xs text-slate-500 mt-1">
+            {{ 'Owner' if g.owner else 'Administrator' }} · id {{ g.id }}
+          </div>
+        </a>
+      {% endfor %}
+    </div>
+    <p class="mt-4 text-xs text-slate-500">
+      Only servers where you're an owner or administrator are shown. A server the bot hasn't joined
+      will say so when you open it.
+    </p>
+  {% else %}
+    <p class="text-slate-500">No servers where you have administrator permission were found.</p>
+  {% endif %}
+{% elif login_enabled %}
+  <a href="/auth/login"
+     class="inline-block rounded-lg bg-indigo-600 hover:bg-indigo-500 px-4 py-2 text-sm font-medium">
+    Sign in with Discord →
+  </a>
+{% else %}
+  <div class="rounded-xl border border-slate-800 bg-slate-900/50 p-5">
+    <h2 class="text-lg font-semibold mb-2">Login isn't set up yet</h2>
+    <p class="text-slate-400 text-sm mb-3">
+      The free multi-user control panel is built and ready, but dormant. To switch it on, set these on
+      the dashboard's Railway service (the bot worker needs <code>CONTROL_API_TOKEN</code> too):
+    </p>
+    <ul class="text-sm text-slate-300 space-y-1">
+      <li><code>DISCORD_OAUTH_CLIENT_ID</code> — the Discord application's client id</li>
+      <li><code>DISCORD_OAUTH_CLIENT_SECRET</code> — the client secret (set in Railway, never in chat)</li>
+      <li><code>DISCORD_OAUTH_REDIRECT_URI</code> — <code>https://superbot-dashboard.up.railway.app/auth/callback</code></li>
+      <li><code>DASHBOARD_SESSION_SECRET</code> — a long random string for the login cookie</li>
+      <li><code>CONTROL_API_TOKEN</code> — shared secret, identical on the bot worker + this service</li>
+    </ul>
+    <p class="text-slate-500 text-xs mt-3">
+      Until then the read-only site works exactly as before. See
+      <code>docs/planning/dashboard-live-editor-plan.md</code>.
+    </p>
+  </div>
+{% endif %}
+{% endblock %}

--- a/dashboard/templates/admin_guild.html
+++ b/dashboard/templates/admin_guild.html
@@ -1,0 +1,165 @@
+{% extends "base.html" %}
+{% block title %}{{ guild.name }} — Control panel — SuperBot{% endblock %}
+{% block content %}
+<div class="mb-5">
+  <a href="/admin" class="text-xs text-slate-400 hover:text-sky-300">← All servers</a>
+  <h1 class="text-2xl font-bold mt-1">{{ guild.name }}</h1>
+  <p class="text-slate-500 text-xs">
+    {{ 'Owner' if guild.owner else 'Administrator' }} · guild id {{ guild.id }}
+  </p>
+</div>
+
+{% if flash %}
+  <div class="mb-5 rounded-lg border px-4 py-3 text-sm
+    {{ 'border-emerald-900/60 bg-emerald-950/40 text-emerald-200' if flash.ok
+       else 'border-rose-900/60 bg-rose-950/40 text-rose-200' }}">
+    {{ flash.message }}
+  </div>
+{% endif %}
+
+{% if not control_configured %}
+  <div class="mb-6 rounded-lg border border-amber-900/60 bg-amber-950/30 px-4 py-3 text-sm text-amber-200">
+    The dashboard isn't connected to the bot yet (<code>CONTROL_API_TOKEN</code> unset), so the editors
+    below are visible but edits can't be applied. Set the shared token on both Railway services to
+    enable live editing.
+  </div>
+{% elif authority and not authority.member_found %}
+  <div class="mb-6 rounded-lg border border-amber-900/60 bg-amber-950/30 px-4 py-3 text-sm text-amber-200">
+    The bot {{ 'is not in this server' if not authority.guild_found else "can't see your membership here" }},
+    so it can't apply edits. Invite the bot (and make sure it can see you) to manage this server.
+  </div>
+{% elif authority %}
+  <div class="mb-6 rounded-lg border border-slate-800 bg-slate-900/40 px-4 py-3 text-xs text-slate-400">
+    The bot sees you here as
+    <span class="text-slate-200">{{ authority.tier or 'member' }}</span>{% if authority.is_admin %} ·
+    <span class="text-emerald-300">administrator</span>{% endif %}. It re-checks this on every edit.
+  </div>
+{% endif %}
+
+<!-- ===================== Settings ===================== -->
+<section class="mb-8 rounded-xl border border-slate-800 bg-slate-900/40 p-5">
+  <h2 class="text-lg font-semibold mb-1">⚙️ Settings</h2>
+  <p class="text-slate-400 text-xs mb-4">
+    Change a per-server setting. Use the <code>subsystem</code> + setting <code>name</code> from the
+    <a href="/settings" class="underline hover:text-sky-300">Settings catalogue</a>; the bot coerces,
+    validates, and capability-gates the write.
+  </p>
+  <form method="post" action="/admin/{{ guild.id }}/settings" class="grid gap-3 sm:grid-cols-4">
+    <label class="block">
+      <span class="text-xs text-slate-400">Subsystem</span>
+      <input name="subsystem" list="subsystem-keys" required placeholder="moderation"
+        class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none" />
+    </label>
+    <label class="block">
+      <span class="text-xs text-slate-400">Setting name</span>
+      <input name="name" required placeholder="warn_threshold"
+        class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none" />
+    </label>
+    <label class="block">
+      <span class="text-xs text-slate-400">Value</span>
+      <input name="value" required placeholder="3"
+        class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none" />
+    </label>
+    <div class="flex items-end">
+      <button type="submit"
+        class="w-full rounded-lg bg-sky-600 hover:bg-sky-500 px-3 py-2 text-sm font-medium">Save</button>
+    </div>
+  </form>
+  <datalist id="subsystem-keys">
+    {% for c in catalogue %}<option value="{{ c.key }}"></option>{% endfor %}
+  </datalist>
+</section>
+
+<!-- ===================== Help appearance ===================== -->
+<section class="mb-8 rounded-xl border border-slate-800 bg-slate-900/40 p-5">
+  <h2 class="text-lg font-semibold mb-1">📖 Help appearance</h2>
+  <p class="text-slate-400 text-xs mb-4">
+    Hide, rename, or re-describe a hub/subsystem in <code>!help</code>, or customize the Help home
+    message. Leave a text field blank to leave it unchanged; the bot applies it live (cache invalidated).
+  </p>
+
+  <form method="post" action="/admin/{{ guild.id }}/help/overlay" class="grid gap-3 sm:grid-cols-2 mb-5">
+    <label class="block">
+      <span class="text-xs text-slate-400">Entity kind</span>
+      <select name="entity_kind"
+        class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none">
+        <option value="hub">hub</option>
+        <option value="subsystem">subsystem</option>
+      </select>
+    </label>
+    <label class="block">
+      <span class="text-xs text-slate-400">Entity key</span>
+      <input name="entity_key" list="subsystem-keys" required placeholder="games"
+        class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none" />
+    </label>
+    <label class="block">
+      <span class="text-xs text-slate-400">Rename (display name)</span>
+      <input name="display_name" placeholder="leave blank to keep"
+        class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none" />
+    </label>
+    <label class="block">
+      <span class="text-xs text-slate-400">Description</span>
+      <input name="description" placeholder="leave blank to keep"
+        class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none" />
+    </label>
+    <label class="flex items-center gap-2 text-sm text-slate-300">
+      <input type="checkbox" name="display_hidden" class="rounded border-slate-700 bg-slate-900" />
+      Hide this entity from Help
+    </label>
+    <div class="flex items-end">
+      <button type="submit"
+        class="rounded-lg bg-sky-600 hover:bg-sky-500 px-3 py-2 text-sm font-medium">Apply</button>
+    </div>
+  </form>
+
+  <div class="border-t border-slate-800 pt-4">
+    <h3 class="text-sm font-semibold mb-2">Help home message</h3>
+    <form method="post" action="/admin/{{ guild.id }}/help/home" class="grid gap-3">
+      <label class="block">
+        <span class="text-xs text-slate-400">Title</span>
+        <input name="title" placeholder="leave blank to keep"
+          class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none" />
+      </label>
+      <label class="block">
+        <span class="text-xs text-slate-400">Body</span>
+        <textarea name="body" rows="3" placeholder="leave blank to keep"
+          class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none"></textarea>
+      </label>
+      <div>
+        <button type="submit"
+          class="rounded-lg bg-sky-600 hover:bg-sky-500 px-3 py-2 text-sm font-medium">Save home</button>
+      </div>
+    </form>
+  </div>
+</section>
+
+<!-- ===================== Cog routing ===================== -->
+<section class="mb-8 rounded-xl border border-slate-800 bg-slate-900/40 p-5">
+  <h2 class="text-lg font-semibold mb-1">🧩 Cogs (enable / disable)</h2>
+  <p class="text-slate-400 text-xs mb-4">
+    Turn a cog on or off for this whole server (the bot's scope-aware
+    <code>command_routing</code>; default is enabled). Owner direction Q-0160: routing is cog-level.
+  </p>
+  <form method="post" action="/admin/{{ guild.id }}/routing" class="grid gap-3 sm:grid-cols-3">
+    <label class="block sm:col-span-2">
+      <span class="text-xs text-slate-400">Cog</span>
+      <select name="cog_name" required
+        class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none">
+        {% for cog in cogs %}<option value="{{ cog.cog }}">{{ cog.cog }}</option>{% endfor %}
+      </select>
+    </label>
+    <label class="block">
+      <span class="text-xs text-slate-400">State</span>
+      <select name="enabled"
+        class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none">
+        <option value="enabled">Enabled</option>
+        <option value="disabled">Disabled</option>
+      </select>
+    </label>
+    <div class="sm:col-span-3">
+      <button type="submit"
+        class="rounded-lg bg-sky-600 hover:bg-sky-500 px-3 py-2 text-sm font-medium">Apply routing</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -21,10 +21,18 @@
             class="text-sm hover:text-sky-300 {{ 'text-sky-400 font-semibold' if page == key else 'text-slate-300' }}"
           >{{ label }}</a>
         {% endfor %}
-        <a
-          href="/bugs#report"
-          class="ml-auto text-sm rounded bg-sky-600 hover:bg-sky-500 px-3 py-1 font-medium"
-        >Report a bug</a>
+        <div class="ml-auto flex items-center gap-3">
+          {% if current_user %}
+            <a href="/admin" class="text-sm hover:text-sky-300 {{ 'text-sky-400 font-semibold' if page == 'admin' else 'text-slate-300' }}">Control panel</a>
+            <span class="text-xs text-slate-400">{{ current_user.global_name or current_user.username }}</span>
+            <a href="/auth/logout" class="text-sm rounded bg-slate-700 hover:bg-slate-600 px-3 py-1">Sign out</a>
+          {% elif login_enabled %}
+            <a href="/auth/login" class="text-sm rounded bg-indigo-600 hover:bg-indigo-500 px-3 py-1 font-medium">Sign in with Discord</a>
+          {% else %}
+            <a href="/admin" class="text-sm hover:text-sky-300 {{ 'text-sky-400 font-semibold' if page == 'admin' else 'text-slate-300' }}">Control panel</a>
+          {% endif %}
+          <a href="/bugs#report" class="text-sm rounded bg-sky-600 hover:bg-sky-500 px-3 py-1 font-medium">Report a bug</a>
+        </div>
       </nav>
     </header>
     <main class="mx-auto max-w-5xl w-full px-4 py-8 flex-1">

--- a/dashboard/websession.py
+++ b/dashboard/websession.py
@@ -1,0 +1,78 @@
+"""Stdlib signed-cookie session for the dashboard — no third-party deps.
+
+Deliberately avoids ``itsdangerous`` / a session middleware so the whole app is
+verifiable with only ``fastapi`` + ``jinja2`` installed (the dashboard test suite
+must run locally to catch template bugs — the #979 lesson). It is the same idea a
+signing library uses: an HMAC-SHA256 signature over a base64url JSON payload. A
+tampered, unsigned, or malformed cookie reads back as an **empty** session, so a
+forged cookie can never inject identity — and the bot re-checks every write anyway.
+
+The signing key is ``DASHBOARD_SESSION_SECRET`` in production; a per-process random
+fallback keeps local/dormant runs working (sessions simply don't survive a restart
+without the real secret).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+from typing import Any
+
+COOKIE_NAME = "sb_session"
+_MAX_AGE = 60 * 60 * 24 * 7  # one week
+_FALLBACK_SECRET = secrets.token_hex(32)
+
+
+def _secret() -> bytes:
+    return (os.environ.get("DASHBOARD_SESSION_SECRET") or _FALLBACK_SECRET).encode()
+
+
+def _sign(payload: bytes) -> str:
+    return hmac.new(_secret(), payload, hashlib.sha256).hexdigest()
+
+
+def encode(data: dict[str, Any]) -> str:
+    """Serialise ``data`` to a signed cookie value."""
+    raw = base64.urlsafe_b64encode(json.dumps(data, separators=(",", ":")).encode())
+    return f"{raw.decode()}.{_sign(raw)}"
+
+
+def decode(cookie: str | None) -> dict[str, Any]:
+    """Read a signed cookie back to a dict; ``{}`` if absent/tampered/malformed."""
+    if not cookie or "." not in cookie:
+        return {}
+    raw_str, _, signature = cookie.rpartition(".")
+    raw = raw_str.encode()
+    if not hmac.compare_digest(signature, _sign(raw)):
+        return {}
+    try:
+        data = json.loads(base64.urlsafe_b64decode(raw))
+    except (ValueError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def read(request: Any) -> dict[str, Any]:
+    """The session dict carried by the request cookie (empty if none)."""
+    return decode(request.cookies.get(COOKIE_NAME))
+
+
+def write(response: Any, data: dict[str, Any]) -> None:
+    """Persist ``data`` onto ``response`` as the signed session cookie."""
+    response.set_cookie(
+        COOKIE_NAME,
+        encode(data),
+        max_age=_MAX_AGE,
+        httponly=True,
+        samesite="lax",
+        path="/",
+    )
+
+
+def clear(response: Any) -> None:
+    """Delete the session cookie (sign-out)."""
+    response.delete_cookie(COOKIE_NAME, path="/")

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,10 +25,10 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/control-api-write-side` · control API **mutation endpoints** (write side, owner directive) —
-  POST over the existing audited seams (`settings_mutation` · `help_overlay_mutation` ·
-  `command_routing`); dormant-by-default + per-request live-member authority · `disbot/control_api.py` ·
-  `tests/unit/runtime/test_control_api.py` · 2026-06-16
+- `claude/control-panel-web` · **control panel — Discord OAuth login + editors** (write side step 2,
+  owner directive) — stdlib signed-cookie session + control-API client + `/admin` guild picker +
+  per-guild settings/help/routing editors over the control API; dormant until secrets set ·
+  `dashboard/` · `tests/unit/dashboard/` · 2026-06-16
 - `claude/dashboard-data-integrity-guard` · `scripts/check_dashboard_data.py` — stdlib integrity
   guard for the exported `dashboard.json` (cog→subsystem resolution · count integrity · required
   fields) + test · `scripts/` · `tests/unit/scripts/` · 2026-06-16

--- a/tests/unit/dashboard/test_app.py
+++ b/tests/unit/dashboard/test_app.py
@@ -21,6 +21,21 @@ from fastapi.testclient import TestClient  # noqa: E402
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _APP = _REPO_ROOT / "dashboard" / "app.py"
 
+# Put the dashboard dir on sys.path so we can mint a valid signed session cookie
+# (the same websession module the app uses → the signature verifies).
+if str(_APP.parent) not in sys.path:
+    sys.path.insert(0, str(_APP.parent))
+import websession  # noqa: E402
+
+
+def _login_cookie(user_id="42", guild_id="111", guild_name="My Server"):
+    """A signed session cookie for a user who administers one guild."""
+    session = {
+        "user": {"id": user_id, "username": "owner", "global_name": "Owner"},
+        "guilds": [{"id": guild_id, "name": guild_name, "owner": True}],
+    }
+    return {websession.COOKIE_NAME: websession.encode(session)}
+
 
 @pytest.fixture(scope="module")
 def client():
@@ -126,3 +141,103 @@ def test_healthz_ok(client):
     resp = client.get("/healthz")
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# Control panel — dormant-by-default (no OAuth / control env in the test)
+# ---------------------------------------------------------------------------
+
+
+def test_admin_dormant_shows_setup_instructions(client):
+    resp = client.get("/admin")
+    assert resp.status_code == 200
+    # With OAuth unconfigured, /admin explains how to switch the panel on.
+    assert "Login isn't set up yet" in resp.text
+    assert "DISCORD_OAUTH_CLIENT_ID" in resp.text
+    assert "CONTROL_API_TOKEN" in resp.text
+
+
+def test_nav_has_no_signin_button_when_dormant(client):
+    # login_enabled is False → the nav offers "Control panel", never "Sign in".
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "Sign in with Discord" not in resp.text
+    assert "Control panel" in resp.text
+
+
+def test_auth_login_redirects_to_admin_when_dormant(client):
+    resp = client.get("/auth/login", follow_redirects=False)
+    assert resp.status_code in (302, 307)
+    assert resp.headers["location"] == "/admin"
+
+
+def test_auth_logout_clears_and_redirects_home(client):
+    resp = client.get("/auth/logout", follow_redirects=False)
+    assert resp.status_code in (302, 307)
+    assert resp.headers["location"] == "/"
+
+
+def test_admin_guild_requires_login(client):
+    # Not signed in → the per-guild editor bounces back to /admin.
+    resp = client.get("/admin/123456789", follow_redirects=False)
+    assert resp.status_code in (302, 307)
+    assert resp.headers["location"] == "/admin"
+
+
+def test_admin_guild_post_requires_login(client):
+    # A write attempt without a session is rejected (redirect, no control call).
+    resp = client.post(
+        "/admin/123456789/settings",
+        data={"subsystem": "moderation", "name": "warn_threshold", "value": "3"},
+        follow_redirects=False,
+    )
+    assert resp.status_code in (302, 303, 307)
+    assert resp.headers["location"] == "/admin"
+
+
+# ---------------------------------------------------------------------------
+# Control panel — logged-in (signed session cookie) — verifies the editor page
+# ---------------------------------------------------------------------------
+
+
+def test_admin_home_shows_guilds_when_logged_in(client):
+    resp = client.get("/admin", cookies=_login_cookie())
+    assert resp.status_code == 200
+    assert "Servers you administer" in resp.text
+    assert "My Server" in resp.text
+
+
+def test_admin_guild_editor_renders_all_sections(client):
+    # The big template: all three editors must render without a Jinja error.
+    resp = client.get("/admin/111", cookies=_login_cookie())
+    assert resp.status_code == 200
+    assert "My Server" in resp.text
+    assert "⚙️ Settings" in resp.text
+    assert "📖 Help appearance" in resp.text
+    assert "Cogs (enable / disable)" in resp.text
+    # Forms target the per-guild POST endpoints.
+    assert 'action="/admin/111/settings"' in resp.text
+    assert 'action="/admin/111/help/overlay"' in resp.text
+    assert 'action="/admin/111/routing"' in resp.text
+    # Dormant control API → the "not connected" banner is shown, not an error.
+    assert "CONTROL_API_TOKEN" in resp.text
+
+
+def test_admin_guild_unknown_guild_redirects(client):
+    # Logged in, but the guild isn't in the user's admin set → back to /admin.
+    resp = client.get("/admin/999", cookies=_login_cookie(), follow_redirects=False)
+    assert resp.status_code in (302, 307)
+    assert resp.headers["location"] == "/admin"
+
+
+def test_admin_setting_post_when_logged_in_dormant_control(client):
+    # Logged in + valid guild → the POST is accepted, calls the (dormant) control
+    # API, and PRG-redirects back to the editor with a flash.
+    resp = client.post(
+        "/admin/111/settings",
+        data={"subsystem": "moderation", "name": "warn_threshold", "value": "3"},
+        cookies=_login_cookie(),
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/admin/111"

--- a/tests/unit/dashboard/test_auth.py
+++ b/tests/unit/dashboard/test_auth.py
@@ -1,0 +1,101 @@
+"""Tests for the dashboard's Discord OAuth helpers (``dashboard/auth.py``).
+
+Pure-logic + dormant-by-default coverage (stdlib only, so these run in CI). The
+live Discord token/identity HTTP calls are integration-tested manually once the
+OAuth app is configured; here we pin the config gating, the consent URL, and the
+admin-guild filter.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_DASHBOARD = Path(__file__).resolve().parents[3] / "dashboard"
+if str(_DASHBOARD) not in sys.path:
+    sys.path.insert(0, str(_DASHBOARD))
+
+import auth  # noqa: E402
+
+_OAUTH_ENV = (
+    "DISCORD_OAUTH_CLIENT_ID",
+    "DISCORD_OAUTH_CLIENT_SECRET",
+    "DISCORD_OAUTH_REDIRECT_URI",
+)
+
+
+def _configure(monkeypatch):
+    monkeypatch.setenv("DISCORD_OAUTH_CLIENT_ID", "appid123")
+    monkeypatch.setenv("DISCORD_OAUTH_CLIENT_SECRET", "s3cret")
+    monkeypatch.setenv(
+        "DISCORD_OAUTH_REDIRECT_URI",
+        "https://superbot-dashboard.up.railway.app/auth/callback",
+    )
+
+
+def test_oauth_dormant_by_default(monkeypatch):
+    for var in _OAUTH_ENV:
+        monkeypatch.delenv(var, raising=False)
+    assert auth.oauth_config() is None
+    assert auth.is_configured() is False
+    assert auth.authorize_url("state") is None
+
+
+def test_oauth_requires_all_three_vars(monkeypatch):
+    for var in _OAUTH_ENV:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("DISCORD_OAUTH_CLIENT_ID", "appid123")
+    # client secret + redirect still missing → still dormant.
+    assert auth.is_configured() is False
+
+
+def test_oauth_configured(monkeypatch):
+    _configure(monkeypatch)
+    assert auth.is_configured() is True
+    cid, secret, redirect = auth.oauth_config()
+    assert cid == "appid123"
+    assert secret == "s3cret"
+    assert redirect.endswith("/auth/callback")
+
+
+def test_authorize_url_carries_state_scopes_and_redirect(monkeypatch):
+    _configure(monkeypatch)
+    url = auth.authorize_url("xyz-state")
+    assert url.startswith("https://discord.com/oauth2/authorize?")
+    assert "client_id=appid123" in url
+    assert "state=xyz-state" in url
+    assert "scope=identify+guilds" in url
+    assert "response_type=code" in url
+    assert "auth%2Fcallback" in url  # the redirect uri, url-encoded
+
+
+def test_admin_guilds_filters_to_owner_or_administrator():
+    guilds = [
+        {"id": "1", "name": "Owned", "owner": True, "permissions": "0"},
+        {"id": "2", "name": "Admin", "owner": False, "permissions": "8"},  # 0x8 = ADMIN
+        {"id": "3", "name": "Member", "owner": False, "permissions": "0"},
+        {"id": "4", "name": "Manager", "owner": False, "permissions": "32"},  # MANAGE_GUILD only
+        {"id": "5", "name": "AdminPlus", "owner": False, "permissions": "8589934592"},
+    ]
+    keep = {g["id"] for g in auth.admin_guilds(guilds)}
+    assert keep == {"1", "2"}  # owner OR administrator bit only
+
+
+def test_admin_guilds_tolerates_bad_shapes():
+    guilds = [
+        {"id": "1", "owner": True},  # no permissions key → owner still kept
+        "not-a-dict",
+        {"id": "2", "permissions": "not-an-int"},  # bad perms → coerced to 0, dropped
+    ]
+    keep = {g["id"] for g in auth.admin_guilds(guilds)}
+    assert keep == {"1"}
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_requires_configuration(monkeypatch):
+    for var in _OAUTH_ENV:
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(RuntimeError):
+        await auth.exchange_code("any-code")

--- a/tests/unit/dashboard/test_control_client.py
+++ b/tests/unit/dashboard/test_control_client.py
@@ -1,0 +1,55 @@
+"""Tests for the dashboard's bot control-API client (``dashboard/control_client.py``).
+
+Pure config gating + the dormant paths (stdlib only — no httpx import on these
+paths — so they run in CI). Live HTTP calls are exercised by the bot-side
+``test_control_api.py`` + manual integration once the token is configured.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_DASHBOARD = Path(__file__).resolve().parents[3] / "dashboard"
+if str(_DASHBOARD) not in sys.path:
+    sys.path.insert(0, str(_DASHBOARD))
+
+import control_client  # noqa: E402
+
+
+def test_dormant_without_token(monkeypatch):
+    monkeypatch.delenv("CONTROL_API_TOKEN", raising=False)
+    assert control_client.control_config() is None
+    assert control_client.is_configured() is False
+
+
+def test_configured_defaults_base_url(monkeypatch):
+    monkeypatch.setenv("CONTROL_API_TOKEN", "shared-secret")
+    monkeypatch.delenv("CONTROL_API_URL", raising=False)
+    base, token = control_client.control_config()
+    assert token == "shared-secret"
+    assert base == "http://worker.railway.internal:8080"  # default private host
+    assert control_client.is_configured() is True
+
+
+def test_configured_custom_base_url_is_trimmed(monkeypatch):
+    monkeypatch.setenv("CONTROL_API_TOKEN", "shared-secret")
+    monkeypatch.setenv("CONTROL_API_URL", "http://bot.internal:9000/")
+    base, _token = control_client.control_config()
+    assert base == "http://bot.internal:9000"  # trailing slash stripped
+
+
+@pytest.mark.asyncio
+async def test_post_dormant_returns_503(monkeypatch):
+    monkeypatch.delenv("CONTROL_API_TOKEN", raising=False)
+    status, body = await control_client.post("/control/settings", {"x": 1})
+    assert status == 503
+    assert "not configured" in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_authority_dormant_returns_none(monkeypatch):
+    monkeypatch.delenv("CONTROL_API_TOKEN", raising=False)
+    assert await control_client.get_authority(111, 222) is None


### PR DESCRIPTION
## Why

Owner directive (in-session): *"finish the write side completely — (2) the website's Discord OAuth login
+ editors."* This is **step 2** (the website half), on top of #989 (control API + identity→authority
bridge) and #993 (the mutation endpoints). It makes the dashboard the **free, multi-user control
panel**: anyone signs in with Discord and edits the servers they administer, applied live.

## What — a complete login → pick-server → edit loop (dormant until configured)

Every write flows through the bot's control API → the **existing audited seam**; the website never
writes the DB and never decides permissions.

- **`dashboard/auth.py`** — Discord OAuth2 (`identify guilds`): consent URL, code→token, user + guild
  fetch, admin-guild filter (owner or `ADMINISTRATOR`). Dormant until `DISCORD_OAUTH_*` are set.
- **`dashboard/control_client.py`** — httpx client to the bot control API
  (`worker.railway.internal`), bearer-authed with `CONTROL_API_TOKEN`; the authority-bridge read + the
  `POST` over each seam. Dormant when the token is unset.
- **`dashboard/websession.py`** — a **stdlib HMAC-signed-cookie** session (httponly; a forged cookie
  reads as empty).
- **`dashboard/app.py`** — `/auth/login` · `/auth/callback` · `/auth/logout`; `/admin` (admin-guild
  picker) · `/admin/{guild_id}` (the editor); `POST` handlers for settings / help-overlay / help-home /
  routing — session-admin gated, PRG-redirect with a flash. Forms parsed with `urllib` (no multipart).
- **Templates** — `admin.html`, `admin_guild.html`, nav login state in `base.html`.

**The bot stays the authority.** The browser asserts identity; the bot resolves the live member and the
seam enforces real permissions on every write (#993). **Dormant by default** — with nothing configured,
`/admin` shows setup instructions and the read-only site is unchanged, so **merging changes nothing in
production**.

## A deliberate dependency choice (no itsdangerous / python-multipart)

This build env has **no PyPI access for new packages**, which would have made `test_app.py` skip and
leave the templates **unverified** (the #979 trap). So the session is a small stdlib HMAC-signed cookie
and forms are parsed with `urllib` — no `itsdangerous`/`python-multipart`. The whole app is verifiable
with only fastapi + jinja2 + httpx; leaner *and* fully tested.

## Verification

- `pip install -r dashboard/requirements.txt` + `python3.10 -m pytest tests/unit/dashboard/` →
  **42 passed** — incl. the editor page rendered for a logged-in user (minted signed cookie), the
  dormant login/redirect paths, and the OAuth/client/admin-guild logic.
- `python3.10 scripts/check_quality.py --check-only` → green (black/isort/ruff over CI scope incl.
  `dashboard/`; check_docs). No `disbot/` change.

## Owner setup to activate (when you're ready)

On the **dashboard** service: `DISCORD_OAUTH_CLIENT_ID`, `DISCORD_OAUTH_CLIENT_SECRET` (set in Railway,
never chat), `DISCORD_OAUTH_REDIRECT_URI` = `https://superbot-dashboard.up.railway.app/auth/callback`,
`DASHBOARD_SESSION_SECRET`, `CONTROL_API_TOKEN` (+ `CONTROL_API_URL` if not the default). On the **bot
worker**: the same `CONTROL_API_TOKEN` + private networking. Then both the bot control API and this
login wake up.

https://claude.ai/code/session_014f52sCSiw4UAmHxxCP7DWV

---
_Generated by [Claude Code](https://claude.ai/code/session_014f52sCSiw4UAmHxxCP7DWV)_