### PR TITLE
fix(healthserver): IPv6 dual-stack bind for Railway private networking

### DIFF
--- a/.sessions/2026-06-16-health-server-ipv6-bind.md
+++ b/.sessions/2026-06-16-health-server-ipv6-bind.md
@@ -1,0 +1,34 @@
+# Session — health server IPv6 dual-stack bind (Railway private networking)
+
+> **Status:** `in-progress`
+
+## Origin
+
+Discovered while wiring up the control panel (#989/#993/#996 + the Railway env vars): the bot's health
+server — which now also hosts the **control API** (`/control/*`) — binds **`0.0.0.0` (IPv4 only)**.
+**Railway's private network is IPv6-only**, so the decoupled dashboard could never reach the bot at
+`worker.railway.internal:8080`; the cross-service call would fail with connection refused. This is the
+prerequisite that makes the live editors actually work end-to-end.
+
+## What shipped
+
+- **`disbot/healthserver.py`** — bind host is now `HEALTH_HOST` (default **`::`**), so the health
+  server listens IPv6 **dual-stack**: reachable over Railway private networking *and* (via IPv4-mapped
+  addresses on Linux) still answers IPv4/local health probes. `web.TCPSite(runner, _HEALTH_HOST, …)` +
+  the log line + the module docstring updated.
+- **Kill-switch (Q-0105 ethos):** if a runtime ever lacks IPv6, set `HEALTH_HOST=0.0.0.0` — no code
+  change, no redeploy-from-revert.
+- **`docs/operations/env-vars.md`** regenerated (`HEALTH_HOST` is the 36th variable).
+
+## Why this is safe
+
+`::` on Linux defaults to `IPV6_V6ONLY=0` → one socket serves both stacks, so existing IPv4 probes
+keep working. The startup path already surfaces a bind failure (main waits on `bind_ready`); the
+`HEALTH_HOST` override is the fallback if `::` is ever unavailable.
+
+## Verification
+
+- `python3.10 scripts/check_quality.py --full` → **green (10273 passed)** — the `test_healthserver.py`
+  suite mocks `web.TCPSite`, so the host change is covered without a real socket; env-doc sync test
+  passes after regeneration.
+- `python3.10 scripts/check_architecture.py --mode strict` → 0 errors.

--- a/.sessions/2026-06-16-health-server-ipv6-bind.md
+++ b/.sessions/2026-06-16-health-server-ipv6-bind.md
@@ -1,6 +1,6 @@
 # Session — health server IPv6 dual-stack bind (Railway private networking)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Origin
 

--- a/disbot/healthserver.py
+++ b/disbot/healthserver.py
@@ -1,6 +1,7 @@
 """Minimal HTTP health server for container orchestration probes.
 
-Exposes these endpoints on 0.0.0.0:8080 (configurable via HEALTH_PORT env var):
+Exposes these endpoints on ``[::]:8080`` — IPv6 dual-stack so Railway private
+networking can reach it (host/port via HEALTH_HOST / HEALTH_PORT):
 
   GET /health     — liveness probe; returns 200 while the event loop is running
   GET /ready      — readiness probe; returns 200 only when the bot is logged in
@@ -61,6 +62,12 @@ except ImportError:
 logger = logging.getLogger("bot.health")
 
 _HEALTH_PORT = int(os.environ.get("HEALTH_PORT", "8080"))
+# Bind IPv6 dual-stack (``::``) by default so the server is reachable over
+# Railway's **private network** (IPv6-only) — e.g. the dashboard control panel
+# reaching the control API at ``worker.railway.internal:8080``. On Linux ``::``
+# also accepts IPv4-mapped connections, so IPv4/local health checks keep working.
+# Kill-switch: set ``HEALTH_HOST=0.0.0.0`` if a runtime ever lacks IPv6.
+_HEALTH_HOST = os.environ.get("HEALTH_HOST", "::")
 
 
 async def _health_handler(request: web.Request) -> web.Response:
@@ -197,9 +204,9 @@ async def start_health_server(
     runner = web.AppRunner(app, access_log=None)
     try:
         await runner.setup()
-        site = web.TCPSite(runner, "0.0.0.0", _HEALTH_PORT)
+        site = web.TCPSite(runner, _HEALTH_HOST, _HEALTH_PORT)
         await site.start()
-        logger.info("Health server listening on 0.0.0.0:%d", _HEALTH_PORT)
+        logger.info("Health server listening on %s:%d", _HEALTH_HOST, _HEALTH_PORT)
         if ready_event is not None:
             ready_event.set()
         # Keep running until the task is cancelled (bot shutdown).

--- a/docs/operations/env-vars.md
+++ b/docs/operations/env-vars.md
@@ -13,7 +13,7 @@ it reads it, and whether it is **required** (read without a default anywhere) or
 only — never a value**; the values live in Railway service variables
 (see [`production-deployment.md`](production-deployment.md)).
 
-**35 variables** — 3 required · 32 optional.
+**36 variables** — 3 required · 33 optional.
 
 ## Required (read without a default — the deploy must set these)
 
@@ -50,7 +50,8 @@ only — never a value**; the values live in Railway service variables
 | `CONTROL_API_TOKEN` | control_api | `disbot/control_api.py:65` *(default)* |
 | `DISCORD_WEBHOOK_URL` | config | `disbot/config.py:102` *(default)* |
 | `HEALTH_GROUPED_FINDINGS` | services | `disbot/services/health_snapshot_service.py:267` *(default)* |
-| `HEALTH_PORT` | healthserver | `disbot/healthserver.py:63` *(default)* |
+| `HEALTH_HOST` | healthserver | `disbot/healthserver.py:70` *(default)* |
+| `HEALTH_PORT` | healthserver | `disbot/healthserver.py:64` *(default)* |
 | `IDENTITY_CONTRACT_STRICT` | bot1 | `disbot/bot1.py:175` *(default)* |
 | `LOG_LEVEL` | config | `disbot/config.py:103` *(default)* |
 | `OPENAI_API_KEY` | config, core, services | `disbot/config.py:159` *(default)*<br>`disbot/core/runtime/ai/providers/openai_provider.py:74` *(default)*<br>`disbot/services/setup_ai_advisor.py:175` *(default)*<br>`disbot/services/setup_ai_advisor.py:406` *(default)* |

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -29,10 +29,9 @@ living ledger (`docs/current-state.md`).
   read-only deterministic BTD6 floor builders (AI §7.5/§7.6 lane) for the scheduled dispatch fires +
   repoint `current-state.md` ▶ Next action · `docs/planning/night-queue-2026-06-16.md` ·
   `docs/current-state.md` · 2026-06-16
-- `claude/control-panel-web` · **control panel — Discord OAuth login + editors** (write side step 2,
-  owner directive) — stdlib signed-cookie session + control-API client + `/admin` guild picker +
-  per-guild settings/help/routing editors over the control API; dormant until secrets set ·
-  `dashboard/` · `tests/unit/dashboard/` · 2026-06-16
+- `claude/health-server-ipv6-bind` · health server **IPv6 dual-stack bind** (`HEALTH_HOST=::`) so the
+  dashboard control panel can reach the bot's control API over Railway's IPv6 private network ·
+  `disbot/healthserver.py` · 2026-06-16
 - `claude/dashboard-data-integrity-guard` · `scripts/check_dashboard_data.py` — stdlib integrity
   guard for the exported `dashboard.json` (cog→subsystem resolution · count integrity · required
   fields) + test · `scripts/` · `tests/unit/scripts/` · 2026-06-16
@@ -49,6 +48,8 @@ living ledger (`docs/current-state.md`).
 
 ## Recently cleared
 
+- `claude/control-panel-web` · control panel — Discord OAuth login + editors (write side step 2) · 2026-06-16 · **PR #996 (merged)**
+- `claude/control-api-write-side` · control API mutation endpoints (write side step 1) · 2026-06-16 · **PR #993 (merged)**
 - `claude/practical-turing-pnppjf` · dashboard `/commands` management surface (READ side) — Manage
   button on every command + cog, per-item panels + per-command alias box · 2026-06-16 · **PR #988 (merged)**
 - `claude/kind-carson-736rnk` · dashboard `/settings` + `/access` read-only pages + live help-editor


### PR DESCRIPTION
## Why

While wiring up the control panel (the Railway env vars are now set), I found the prerequisite that
makes the live editors actually work end-to-end: the bot's health server — which since #989 also hosts
the **control API** (`/control/*`) — binds **`0.0.0.0` (IPv4 only)**. **Railway's private network is
IPv6**, so the decoupled dashboard could never reach the bot at `worker.railway.internal:8080` (the
cross-service call would fail with connection refused).

## What

- **`disbot/healthserver.py`** — the bind host is now `HEALTH_HOST` (default **`::`**), so the server
  listens **IPv6 dual-stack**: reachable over Railway private networking *and* (via IPv4-mapped
  addresses on Linux, where `IPV6_V6ONLY=0` is the default) still answers existing IPv4/local health
  probes. Updated the `TCPSite` bind, the log line, and the module docstring.
- **Kill-switch:** if a runtime ever lacks IPv6, set `HEALTH_HOST=0.0.0.0` — no code change.
- **`docs/operations/env-vars.md`** regenerated (`HEALTH_HOST` is the 36th variable).

## Verification

- `python3.10 scripts/check_quality.py --full` → **green (10273 passed)** — `test_healthserver.py`
  mocks `web.TCPSite`, so the host change is covered without a real socket.
- `python3.10 scripts/check_architecture.py --mode strict` → 0 errors.

Part of activating the control panel: with this + the Railway env vars in place, the only remaining
step is the owner adding `DISCORD_OAUTH_CLIENT_SECRET` on the dashboard service.

https://claude.ai/code/session_014f52sCSiw4UAmHxxCP7DWV

---
_Generated by [Claude Code](https://claude.ai/code/session_014f52sCSiw4UAmHxxCP7DWV)_