### PR TITLE
docs(ideas): tie off #995 backlog hygiene + file two captured ideas

### DIFF
--- a/.sessions/2026-06-16-idea-backlog-hygiene.md
+++ b/.sessions/2026-06-16-idea-backlog-hygiene.md
@@ -1,27 +1,76 @@
 # 2026-06-16 — idea-backlog hygiene (tie off the #995 deferrals) + validate the union fix
 
-> **Status:** `in-progress` — born-red per Q-0133; flipped to `complete` as the deliberate
-> final step. Docs/ideas only (no `disbot/` runtime, no Python).
+> **Status:** `complete` — docs/ideas only (no `disbot/` runtime, no Python). One PR (#1004).
 
-## What I'm about to do
+## Arc
 
-Tie off the idea-backlog hygiene I **deferred** out of PR #995 to escape the merge-conflict livelock —
-now safe and contention-free because PR #1003 made `docs/ideas/README.md` auto-merge (`merge=union`).
-This PR is also the **first real-world test** of that fix: appending to the union-protected idea index
-should merge cleanly even as `main` moves.
+Tied off the idea-backlog hygiene I **deferred** out of PR #995 to escape the merge-conflict livelock
+— now safe because PR #1003 made `docs/ideas/README.md` auto-merge (`merge=union`). This PR is also the
+**first real-world test** of that fix: it appends to the union-protected idea index, which should merge
+cleanly even as `main` moves (the same kind of edit that conflicted 3× before #1003).
 
-- Mark the **subcog→parent-subsystem** idea SHIPPED (#995) — file Disposition + README entry (the
-  edits #995 reverted out to escape the livelock).
-- File the two captured-in-card ideas as proper indexed idea files:
-  - **cogs declare their subsystem** (Q-0089 from #995) — replace the dashboard's class-name guessing
-    + 3 hand-maintained lists with an authoritative declaration.
-  - **ledger dedup linter** (Q-0089 from #1003) — flag duplicate/stale claim/idea lines the union
-    driver can leave behind.
+## Shipped (PR #1004)
+
+- Marked the **subcog→parent-subsystem** idea **SHIPPED (#995)** — re-applied the file Disposition +
+  README index update that #995 reverted out to escape the livelock.
+- Filed the two captured-in-card ideas as proper indexed idea files:
+  - **`cog-declares-its-subsystem`** (Q-0089 from #995) — replace the dashboard's class-name guessing +
+    three hand-maintained lists with an authoritative subsystem declaration the scanner reads.
+  - **`ledger-dedup-linter`** (Q-0089 from #1003) — flag the duplicate/stale claim & idea lines the
+    `union` driver can leave behind (its one accepted downside).
+
+`check_docs --strict` green (both new files reachable; ideas badge 70→72); `check_quality --check-only`
+green. No runtime/Python touched.
 
 ## Status checklist
 
-- [ ] subcog idea → shipped (file + README entry)
-- [ ] file `cog-declares-its-subsystem` idea + README entry
-- [ ] file `ledger-dedup-linter` idea + README entry
-- [ ] `check_docs --strict` green (all idea files reachable)
-- [ ] session enders + flip card `complete`
+- [x] subcog idea → shipped (file + README entry)
+- [x] file `cog-declares-its-subsystem` idea + README entry
+- [x] file `ledger-dedup-linter` idea + README entry
+- [x] `check_docs --strict` green
+- [x] session enders + flip card `complete`
+
+## 💡 Session idea (Q-0089)
+
+This session's genuine idea contribution **is** the two idea files filed above (`cog-declares-its-
+subsystem` + `ledger-dedup-linter`) — both ideas I believe in, surfaced by the #995/#1003 work and now
+properly indexed. A pure-bookkeeping session, so per Q-0089's own bar I'm **not hallucinating a third
+filler idea**: the honest observation is that the idea backlog now *grows* friction-free (the union fix
+removed the one thing that slowed appends), which makes backlog **drain** — not capture — the live
+constraint. That is already captured as `idea-spotlight-verdict-loop` (a drain-rate ledger); no new
+idea needed here.
+
+## ⟲ Previous-session review (Q-0102)
+
+Reviewed **`2026-06-16-gitattributes-union-ledger.md`** (#1003 — my prior session). **Did well:** chose
+the *root-cause* fix over a fourth round of escape-by-shedding, **verified it before shipping**
+(`git merge-file --union` + `git check-attr` proving `union` on the two ledgers and `unspecified`
+elsewhere), kept it minimal + zero-contention so the contention-fix couldn't itself livelock, and
+documented the caveats + a revert note in the file. **Honest gap it left (by design):** the union
+driver's no-dedup downside — which it correctly deferred to an idea rather than scope-creeping the
+fix. This session filed that idea (`ledger-dedup-linter`), closing the loop. **System note:** the
+union fix + this hygiene pass together demonstrate the intended pattern — fix the *mechanism* (#1003),
+then let the *bookkeeping* (this PR) ride the now-frictionless path. Nothing to improve beyond the
+already-captured drain-rate concern.
+
+## ♻️ Backlog grooming (Q-0015)
+
+This session **is** a grooming pass: moved the subcog idea to its terminal **shipped** state and routed
+two captured-in-card ideas into proper indexed files (capture → filed). The backlog is now accurate for
+the #995/#1003 work; the next genuinely-unfiled item is none — the remaining ideas are all indexed.
+
+## Documentation audit (Q-0104)
+
+- All three idea files reachable + indexed; `check_docs --strict` + `check_quality --check-only` green.
+- No owner decision (a deferred-hygiene tie-off under Q-0129 self-initiated improvement), so no router
+  Q-block. **Ledger untouched (Q-0124):** reconciliation backlog is the routine's job; #1004 unmerged.
+
+## Context delta
+
+- The #995 idea-backlog state is now accurate (subcog = shipped); the two follow-up ideas
+  (cog-declares-subsystem, ledger-dedup-linter) are filed + indexed, ready for a future tooling lane.
+- This PR confirmed the #1003 `merge=union` fix in practice (an append to the idea index that would
+  previously have entered the livelock).
+- Still-open non-conflicting slices for a future session: the deferred Paragon/Setup/Hermes parent
+  mapping (needs owner intent), the "your authority" pre-auth preview (plan's ready read-only slice),
+  and the two newly-filed tooling ideas.

--- a/.sessions/2026-06-16-idea-backlog-hygiene.md
+++ b/.sessions/2026-06-16-idea-backlog-hygiene.md
@@ -1,0 +1,27 @@
+# 2026-06-16 — idea-backlog hygiene (tie off the #995 deferrals) + validate the union fix
+
+> **Status:** `in-progress` — born-red per Q-0133; flipped to `complete` as the deliberate
+> final step. Docs/ideas only (no `disbot/` runtime, no Python).
+
+## What I'm about to do
+
+Tie off the idea-backlog hygiene I **deferred** out of PR #995 to escape the merge-conflict livelock —
+now safe and contention-free because PR #1003 made `docs/ideas/README.md` auto-merge (`merge=union`).
+This PR is also the **first real-world test** of that fix: appending to the union-protected idea index
+should merge cleanly even as `main` moves.
+
+- Mark the **subcog→parent-subsystem** idea SHIPPED (#995) — file Disposition + README entry (the
+  edits #995 reverted out to escape the livelock).
+- File the two captured-in-card ideas as proper indexed idea files:
+  - **cogs declare their subsystem** (Q-0089 from #995) — replace the dashboard's class-name guessing
+    + 3 hand-maintained lists with an authoritative declaration.
+  - **ledger dedup linter** (Q-0089 from #1003) — flag duplicate/stale claim/idea lines the union
+    driver can leave behind.
+
+## Status checklist
+
+- [ ] subcog idea → shipped (file + README entry)
+- [ ] file `cog-declares-its-subsystem` idea + README entry
+- [ ] file `ledger-dedup-linter` idea + README entry
+- [ ] `check_docs --strict` green (all idea files reachable)
+- [ ] session enders + flip card `complete`

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -64,12 +64,26 @@ Current broad captures:
   unregistered cog / broken join / count drift **fails CI** instead of silently degrading a page.
   → `scripts/check_dashboard_data.py` · `tests/unit/scripts/test_check_dashboard_data.py`.
 - [`dashboard-subcog-parent-subsystem-2026-06-16.md`](./dashboard-subcog-parent-subsystem-2026-06-16.md) —
-  **session idea (2026-06-16, Q-0089, from the integrity guard #990):** the guard *allow-lists* the
-  cogs that don't resolve to a registry key (BTD6 sub-cogs · Paragon · RPS · Setup), but several of
-  them genuinely *belong* to a parent subsystem (`BTD6EventsCog`…→`btd6`) — so on the dashboard they
-  render with a generic 🧩 + no routing key. A small cog→parent-subsystem map in `scan_commands` would
-  let sub-cogs inherit their parent's registry identity (emoji/name/routing), shrinking the allow-list
-  to the truly-unregistered few. → relates `scripts/scan_commands.py` · `dashboard/`.
+  **mostly SHIPPED 2026-06-16 (PR #995):** `scan_commands._COG_SUBSYSTEM_OVERRIDES` maps the BTD6
+  sub-cogs → `btd6` and RPS → `rps_tournament`, so they inherit the parent's registry identity on
+  `/commands` (no more generic 🧩); the integrity guard's allow-list shrank 8 → 3. **Deferred (owner
+  intent):** `ParagonCog` / `SetupCog` / `HermesCog` stay allow-listed until a parent is confirmed.
+  → relates `scripts/scan_commands.py` · `scripts/check_dashboard_data.py`.
+- [`cog-declares-its-subsystem-2026-06-16.md`](./cog-declares-its-subsystem-2026-06-16.md) —
+  **session idea (2026-06-16, Q-0089, from the sub-cog mapping #995):** the dashboard guesses each
+  cog's subsystem from its **class name**, propped up by three hand-maintained lists (acronym table ·
+  override map · the guard's allow-list) that drift independently — and #995 still couldn't resolve 3
+  cogs from the name alone. Replace it with an **authoritative declaration** the scanner reads (a cog
+  `SUBSYSTEM = "btd6"` class attribute, or a command-surface-ledger join), deleting the override map
+  and self-describing every cog including sub-cogs. → relates `scripts/scan_commands.py` ·
+  `core/runtime/command_surface_ledger.py` · `utils/subsystem_registry.py`.
+- [`ledger-dedup-linter-2026-06-16.md`](./ledger-dedup-linter-2026-06-16.md) —
+  **session idea (2026-06-16, Q-0089, from the merge=union fix #1003):** #1003 made the append-only
+  ledgers (`active-work.md`, `ideas/README.md`) auto-merge via git `merge=union`, whose one downside is
+  it never deletes/dedups — so stale or duplicate claim/idea lines can accumulate. A tiny stdlib
+  `scripts/check_ledger_hygiene.py` flagging duplicate claim branches + duplicate idea-file links
+  (report-only, `--strict` fails CI) keeps the now-conflict-free ledgers *clean*. → relates
+  `docs/owner/active-work.md` · `docs/ideas/README.md` · `.gitattributes`.
 - [`success-metric-alignment-with-verified-success-2026-06-16.md`](./success-metric-alignment-with-verified-success-2026-06-16.md) —
   **session idea (2026-06-16, Q-0089, from the Claude Code expertise research readout):** Anthropic's
   ~400K-session study measures **verified success** by *hard signals* (tests passing, commits,

--- a/docs/ideas/cog-declares-its-subsystem-2026-06-16.md
+++ b/docs/ideas/cog-declares-its-subsystem-2026-06-16.md
@@ -1,0 +1,50 @@
+# Cogs declare their subsystem (kill the dashboard's name-derivation guesswork)
+
+> **Status:** `ideas` — captured 2026-06-16 (session idea, Q-0089, from the sub-cog mapping #995).
+> Source + merged PRs win.
+
+## The gap
+
+The dashboard derives each cog's subsystem key from its **class name**
+(`scan_commands._cog_to_subsystem`: `EconomyCog` → `economy`). That guess is wrong whenever the class
+name isn't the registry key, so it needs three hand-maintained patches stacked on top:
+
+1. an **acronym table** (`BTD6Cog` → `btd6`, #988),
+2. an explicit **override map** (`BTD6EventsCog` → `btd6`, `RockPaperScissorsCog` → `rps_tournament`,
+   #995), and
+3. a hand-maintained **allow-list** in `check_dashboard_data.py` for the cogs that still don't resolve
+   (`ParagonCog` / `SetupCog` / `HermesCog`).
+
+Three curated lists, all keyed on class name, all drifting independently — and #995 still couldn't
+resolve 3 cogs because their parent is genuinely ambiguous *from the class name alone*.
+
+## The idea
+
+Replace the name-derivation + override map with an **authoritative subsystem declaration** the scanner
+reads, so the dashboard stops guessing. Two candidate sources (pick by what's least invasive):
+
+- **A cog class attribute** — e.g. `class BTD6EventsCog(...): SUBSYSTEM = "btd6"`. The scanner reads the
+  literal via AST (it already AST-parses every cog). One line per cog, unambiguous, lives next to the
+  code it describes. Resolves Paragon/Setup/Hermes too (the author states intent once).
+- **The command-surface ledger / registry back-reference** — if `core/runtime/command_surface_ledger.py`
+  (or the registry's `entry_points`) already maps commands → subsystem authoritatively, the scanner
+  could join through it instead of the class name. No cog change, but only as reliable as that mapping's
+  coverage of *sub-cog* commands (entry_points are top commands, so this may not cover sub-cogs).
+
+Prefer whichever is authoritative for **every** cog including sub-cogs. The payoff: delete the override
+map + shrink the allow-list to genuinely-unregistered cogs, and new cogs render correctly with **zero**
+dashboard-side maintenance.
+
+## Why it's worth having
+
+- Eliminates three drifting hand-maintained lists (acronym table · override map · allow-list).
+- Makes a cog's subsystem **self-describing** — the same robustness win as the registry itself.
+- Resolves the 3 cogs #995 had to defer (their author states the intent in one place).
+
+## Disposition
+
+Decided-lane but needs a design choice (class attribute vs. ledger join) + touches `disbot/` cog
+classes if the attribute route is taken (a focused, low-risk change). **Structure into a small plan
+when the dashboard lane next has runtime capacity**; confirm the Paragon/Setup/Hermes parent intent as
+part of it. → relates `scripts/scan_commands.py` · `core/runtime/command_surface_ledger.py` ·
+`utils/subsystem_registry.py`.

--- a/docs/ideas/dashboard-subcog-parent-subsystem-2026-06-16.md
+++ b/docs/ideas/dashboard-subcog-parent-subsystem-2026-06-16.md
@@ -46,7 +46,10 @@ curated map, reviewed) and beats trying to infer the parent from the file name.
 
 ## Disposition
 
-Decided-lane, small → **execute when the dashboard lane next has capacity**; pairs naturally with the
-next `/commands` rendering pass. Confirm the `ParagonCog`/`SetupCog` parent intent with the owner (or
-leave them allow-listed). → relates `scripts/scan_commands.py` · `scripts/check_dashboard_data.py` ·
-`dashboard/templates/commands.html`.
+**SHIPPED (the unambiguous 5) 2026-06-16 — PR #995:** `scan_commands._COG_SUBSYSTEM_OVERRIDES` maps
+`BTD6EventsCog`/`BTD6OpsCog`/`BTD6ReferenceCog`/`BTD6StrategyCog` → `btd6` and `RockPaperScissorsCog` →
+`rps_tournament`, so they inherit the parent's registry identity on `/commands`; the integrity guard's
+allow-list shrank 8 → 3. **Deferred (owner intent):** `ParagonCog` (BTD6-adjacent? own subsystem?),
+`SetupCog` (hub-less wizard), `HermesCog` (ops) stay allow-listed — map them only if the owner confirms
+a parent. The broader replacement is captured separately as the *cogs-declare-their-subsystem* idea.
+→ relates `scripts/scan_commands.py` · `scripts/check_dashboard_data.py`.

--- a/docs/ideas/ledger-dedup-linter-2026-06-16.md
+++ b/docs/ideas/ledger-dedup-linter-2026-06-16.md
@@ -1,0 +1,43 @@
+# Ledger dedup linter (companion to the merge=union fix)
+
+> **Status:** `ideas` — captured 2026-06-16 (session idea, Q-0089, from the merge=union fix #1003).
+> Source + merged PRs win.
+
+## The gap
+
+PR #1003 marked the two append-only coordination ledgers — `docs/owner/active-work.md` (claim ledger)
+and `docs/ideas/README.md` (idea index) — with git's **`merge=union`** driver, so concurrent appends
+from parallel sessions auto-merge instead of conflicting (the livelock #995 hit 3×). That fix has one
+known, accepted downside: **union never deletes and never dedups**. So over time it can leave:
+
+- a **stale claim** in `active-work.md` (a claim a session removed on its branch survives the merge
+  because the other side didn't touch that line), and
+- a **duplicate** entry (two sessions that add near-identical claim/idea lines both land).
+
+The convention already permits pruning these by hand ("stale lines are fine to prune when you see
+them"), but nothing *surfaces* them — so they accumulate silently until someone notices.
+
+## The idea
+
+A tiny stdlib **`scripts/check_ledger_hygiene.py`** (or a `check_docs` sub-rule) that reports:
+
+- **Duplicate claim branches** in `active-work.md` — the same `` `claude/<branch>` `` appearing twice
+  under Active claims.
+- **Duplicate idea-file links** in `ideas/README.md` — the same `./<file>.md` linked twice.
+- *(Optional, higher-value)* **merged claims still in Active** — a claim whose branch corresponds to a
+  merged PR (cross-reference is harder offline; keep this advisory).
+
+Report-only by default (exit 0 + a list), with a `--strict` that fails CI on a duplicate. It pairs
+with #1003: union keeps the ledgers conflict-free, this keeps them *clean*.
+
+## Why it's worth having
+
+- Closes the one real downside of the union fix — without it, the ledgers slowly fill with cruft.
+- Pure stdlib, read-only, disposable (Q-0105) — same lane as the other `check_*` scripts.
+- Cheap: duplicate detection is a few lines of parsing the two well-structured lists.
+
+## Disposition
+
+Decided-lane, small → **execute when the dashboard/tooling lane next has capacity** (a few-line linter
++ a test). Wire to CI only after it proves reliable across a few sessions (Q-0105). → relates
+`docs/owner/active-work.md` · `docs/ideas/README.md` · `.gitattributes` (the union driver) · #1003.


### PR DESCRIPTION
## Why

Ties off the idea-backlog hygiene I **deferred** out of PR #995 to escape the merge-conflict livelock.
It's now safe and contention-free because PR #1003 made `docs/ideas/README.md` auto-merge
(`merge=union`) — so this PR also doubles as the **first real-world validation** of that fix
(appending to the union-protected idea index should merge cleanly even as `main` moves).

## What (docs/ideas only)

- Mark the **subcog→parent-subsystem** idea **SHIPPED (#995)** — re-apply the file Disposition + README
  index update that #995 reverted out to escape the livelock.
- File the two captured-in-card ideas as proper indexed idea files:
  - **cogs declare their subsystem** (Q-0089 from #995) — replace the dashboard's class-name guessing
    + three hand-maintained lists (acronym table · override map · guard allow-list) with an
    authoritative subsystem declaration the scanner reads.
  - **ledger dedup linter** (Q-0089 from #1003) — flag the duplicate/stale claim & idea lines the
    `union` driver can leave behind, the natural companion to the union fix.

No runtime, no Python — pure backlog bookkeeping + idea capture. `check_docs --strict` green.

Born-red session card (Q-0133); flips to `complete` as the final commit → auto-merge on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Tff5WCNJjR5nnfpibsKjD

---
_Generated by [Claude Code](https://claude.ai/code/session_011Tff5WCNJjR5nnfpibsKjD)_