### PR TITLE
test(btd6): class-guard corpus for community-shorthand routing

### DIFF
--- a/.sessions/2026-06-16-btd6-shorthand-corpus-guard.md
+++ b/.sessions/2026-06-16-btd6-shorthand-corpus-guard.md
@@ -1,0 +1,17 @@
+# Session — BTD6 shorthand corpus regression guard
+
+> **Status:** `in-progress`
+
+## About to do
+
+Continuation of the code-expertise-research session (PR #994 merged). Picking up the
+standing secondary task — **Q-0015 backlog grooming**: execute the strongest small/safe/
+decided-lane idea, `docs/ideas/btd6-shorthand-corpus-eval-2026-06-16.md`.
+
+Ship a single **class-guard regression test** — `tests/unit/services/test_btd6_shorthand_corpus.py`
+— holding the canonical BTD6 community-shorthand vocabulary (`despo`/`impop`/round `r53`/
+`420 farm`/`d67`/…) and asserting each routes to `AITask.BTD6_ANSWER`, plus the conservatism
+negatives (`r2d2`, "67 degrees outside", "a degree in CS", "how do I farm coins") that must
+stay general. Guards the recurring "shorthand falls to the unguarded general path → model
+freelances" bug class (BUG-0001/0003/0004/0008/0015), which today has only scattered per-bug
+tests. Routing-only, no DB. Then re-badge the idea file `historical` ✅.

--- a/.sessions/2026-06-16-btd6-shorthand-corpus-guard.md
+++ b/.sessions/2026-06-16-btd6-shorthand-corpus-guard.md
@@ -1,17 +1,64 @@
 # Session — BTD6 shorthand corpus regression guard
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-## About to do
+## Origin
 
-Continuation of the code-expertise-research session (PR #994 merged). Picking up the
-standing secondary task — **Q-0015 backlog grooming**: execute the strongest small/safe/
-decided-lane idea, `docs/ideas/btd6-shorthand-corpus-eval-2026-06-16.md`.
+Continuation of the code-expertise-research session (PR #994 merged). Picked up the standing
+secondary task — **Q-0015 backlog grooming**: executed the strongest small/safe/decided-lane
+idea, `docs/ideas/btd6-shorthand-corpus-eval-2026-06-16.md`.
 
-Ship a single **class-guard regression test** — `tests/unit/services/test_btd6_shorthand_corpus.py`
-— holding the canonical BTD6 community-shorthand vocabulary (`despo`/`impop`/round `r53`/
-`420 farm`/`d67`/…) and asserting each routes to `AITask.BTD6_ANSWER`, plus the conservatism
-negatives (`r2d2`, "67 degrees outside", "a degree in CS", "how do I farm coins") that must
-stay general. Guards the recurring "shorthand falls to the unguarded general path → model
-freelances" bug class (BUG-0001/0003/0004/0008/0015), which today has only scattered per-bug
-tests. Routing-only, no DB. Then re-badge the idea file `historical` ✅.
+## What shipped (this PR — PR #1007)
+
+- **`tests/unit/services/test_btd6_shorthand_corpus.py`** (new, routing-only, no DB) — the
+  missing **class guard** for the BTD6 community-shorthand vocabulary:
+  - **9 positives** — `despo`/`despos`, `impop`, round `r53`/`r70`, `420 farm` + money cue,
+    `d67` paragon degree, round-cash phrasing — each must route to `AITask.BTD6_ANSWER`.
+  - **5 conservatism negatives** — `r2d2`, "67 degrees outside", "a degree in cs", "how do I
+    farm coins", "there r 5 of us" — must stay `GENERAL_NL_ANSWER`.
+  Complements the scattered per-bug tests (which pin *why* each leg exists) by pinning the
+  *class as a whole* so a router refactor / `_looks_like_*` re-ordering can't silently regress
+  one shorthand back onto the unguarded path (the loop behind BUG-0001/0003/0004/0008/0015).
+- Re-badged the idea file `historical` ✅ + README annotation (grooming lifecycle outcome).
+- Claim added/closed in `docs/owner/active-work.md`.
+
+## Verification
+
+- `python3.10 -m pytest tests/unit/services/test_btd6_shorthand_corpus.py -q` → 14 passed.
+- `python3.10 scripts/check_quality.py --check-only` → all checks passed (isort autofix applied).
+- `python3.10 scripts/check_docs.py --strict` → passed.
+
+## 💡 Session idea (Q-0089)
+
+**A corpus-coverage drift check.** The new test holds the shorthand vocabulary as a hand-curated
+list, and the idea file says "add a new shorthand here when a new `_looks_like_*` leg lands" — but
+nothing *enforces* that. A tiny check could count the `_looks_like_*` legs + curated keyword
+families in `ai_task_router` / `keywords.py` and assert the corpus test references at least one
+case per family, so adding a routing leg without a corpus case fails CI. Keeps the class guard from
+silently falling behind the router it guards. (Dedup-grep clean — distinct from the existing
+`btd6-shorthand-corpus-eval` idea, which was about the test itself, now shipped.) Captured here;
+not built (small but past this PR's declared scope, Q-0088).
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous session (the code-expertise-research readout, PR #994) did the *confirmatory* doc work
+well — it resisted the temptation to invent a workflow change from a report that only *validates*
+the existing model, and correctly downgraded to "cite + capture." What it could have done better:
+it surfaced a genuine process gap in its own Q-0102 note ("a deferred *decision* should become a
+router Q-block, not a session-log sentence") but left that as prose rather than acting on it —
+i.e. it diagnosed a drift class and then committed the same class. **System improvement it
+surfaces (acting on it now, not just noting):** the Q-0104 documentation-audit checklist should
+explicitly include *"any decision deferred this session → routed to a DISCUSS-lane Q-block, not
+just log prose?"* That is a one-line addition to the audit ritual — too small and rule-adjacent to
+self-apply (CLAUDE.md / skill text is config, Q-0106), so it goes to the router as a proposal
+rather than an edit. Logged as a candidate, not applied.
+
+## Documentation audit (Q-0104)
+
+- New test has its durable home; idea file + README re-badged to `historical` ✅ (lifecycle
+  outcome recorded). `check_docs --strict` green.
+- No new owner *decision* this session (grooming execution of an already-captured idea), so
+  nothing to record in the router. The Q-0102 checklist-addition above is a *proposal* for the
+  owner, noted here for routing — not a self-applied rule change.
+- Ledger: SessionStart flagged 13 merged PRs not yet in current-state — that is the routines'
+  automated reconciliation scope (Q-0124), not this manual grooming session's task.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -29,14 +29,14 @@ Current broad captures:
   change can't silently re-introduce an unattended stall. Cheap, read-only, disposable (Q-0105). →
   relates `.claude/settings.json` · Q-0149/Q-0161.
 - [`btd6-shorthand-corpus-eval-2026-06-16.md`](./btd6-shorthand-corpus-eval-2026-06-16.md) —
-  **late discovery from the BUG-0015 session (2026-06-16, PR #963):** a single **corpus regression
-  test** holding the canonical community-shorthand vocabulary (`despo`/`impop`/`r53`/`420 farm`/
-  `d67`/…) and asserting each routes to `AITask.BTD6_ANSWER` — the **class guard** for the recurring
-  "shorthand falls to the unguarded general path → model freelances" bug (BUG-0001/0003/0004/0008/
-  0015), which today has only scattered per-bug tests. Small/safe/decided-lane → a strong
-  grooming-pass execute-now candidate. Also records a verified *minor* hero-per-level-stats sibling
-  finding (heroes route fine + descriptions already ground; only non-headline-level exact stats are
-  the gap, low priority). → relates `services/ai_task_router.py` · `utils/btd6/keywords.py`.
+  **SHIPPED 2026-06-16 (PR #1007)** via a Q-0015 grooming pass: the **corpus class-guard test**
+  (`tests/unit/services/test_btd6_shorthand_corpus.py`) holds the canonical community-shorthand
+  vocabulary (`despo`/`impop`/`r53`/`420 farm`/`d67`/…) and asserts each routes to
+  `AITask.BTD6_ANSWER` (+ conservatism negatives), guarding the recurring "shorthand falls to the
+  unguarded general path → model freelances" bug class (BUG-0001/0003/0004/0008/0015) against a
+  silent router regression — previously covered only by scattered per-bug tests. The *minor*
+  hero-per-level-stats sibling finding (only non-headline-level exact stats are a gap) stays
+  `captured` at low priority. → relates `services/ai_task_router.py` · `utils/btd6/keywords.py`.
 
 - [`developer-dashboard-2026-06-16.md`](./developer-dashboard-2026-06-16.md) —
   **owner-requested + approved (2026-06-16, Q-0155):** a personal website / developer dashboard

--- a/docs/ideas/btd6-shorthand-corpus-eval-2026-06-16.md
+++ b/docs/ideas/btd6-shorthand-corpus-eval-2026-06-16.md
@@ -1,8 +1,10 @@
 # BTD6 community-shorthand corpus eval (router-class regression guard)
 
-> **Status:** `ideas`. **Not approved for implementation, not a plan.** A captured late
-> discovery from the BUG-0015 session (2026-06-16, PR #963). Source + the binding contracts +
-> `docs/current-state.md` win over this file.
+> **Status:** `historical` ✅ **SHIPPED 2026-06-16 (PR #1007)** — the corpus class-guard test
+> landed as `tests/unit/services/test_btd6_shorthand_corpus.py` (9 shorthand positives + 5
+> conservatism negatives). The hero-per-level-stats sub-item below stays `captured` at low
+> priority. A captured late discovery from the BUG-0015 session (2026-06-16, PR #963). Source +
+> the binding contracts + `docs/current-state.md` win over this file.
 
 ## The recurring class this would guard
 

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,10 +25,6 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/btd6-shorthand-corpus-guard` · **BTD6 shorthand corpus regression guard** (grooming-pass
-  execute-now, Q-0015) — single class-guard test asserting the canonical community-shorthand vocabulary
-  routes to `BTD6_ANSWER` + conservatism negatives · `tests/unit/services/test_btd6_shorthand_corpus.py`
-  · 2026-06-16
 - `claude/inspiring-wozniak-i92q58` · **dashboard finalized-vision — solidify with owner panel decisions**
   (owner directive) — apply the 8 question-panel answers to the vision doc + record provenance (Q-0162
   DECIDED + new Q-0163). Docs only · `docs/planning/dashboard-vision-finalized-state.md` ·

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,10 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/btd6-shorthand-corpus-guard` · **BTD6 shorthand corpus regression guard** (grooming-pass
+  execute-now, Q-0015) — single class-guard test asserting the canonical community-shorthand vocabulary
+  routes to `BTD6_ANSWER` + conservatism negatives · `tests/unit/services/test_btd6_shorthand_corpus.py`
+  · 2026-06-16
 - `claude/inspiring-wozniak-i92q58` · **dashboard finalized-vision — solidify with owner panel decisions**
   (owner directive) — apply the 8 question-panel answers to the vision doc + record provenance (Q-0162
   DECIDED + new Q-0163). Docs only · `docs/planning/dashboard-vision-finalized-state.md` ·

--- a/tests/unit/services/test_btd6_shorthand_corpus.py
+++ b/tests/unit/services/test_btd6_shorthand_corpus.py
@@ -1,0 +1,90 @@
+"""Class guard: the BTD6 community-shorthand vocabulary routes to BTD6_ANSWER.
+
+Five live-reported bugs share **one root cause** — a community-shorthand question
+is not recognised by ``ai_task_router.classify`` and falls through to the
+**unguarded** ``GENERAL_NL_ANSWER`` path (no grounding, no number guard), where
+the model freelances from memory:
+
+    BUG-0001  "cash by round 68" round-cash phrasing  → refused / wrong total
+    BUG-0003  ``despo`` / ``impop``                   → wrong tower
+    BUG-0004  ``r53`` / ``r70`` round shorthand        → wrong cumulative total
+    BUG-0008  ``420 farm`` + money cue                 → invented farm income
+    BUG-0015  ``d67`` (paragon degree)                 → "0-6-7 paragon doesn't exist"
+
+Each fix shipped its *own* per-bug regression test pinning *why* that leg exists.
+This file is the missing **class guard**: it pins the whole known shorthand
+vocabulary as a set, so a future router refactor (or a re-ordering of the
+``_looks_like_*`` ladder) can't silently regress one shorthand back onto the
+unguarded path — caught today only by a *new* live user report.
+
+Routing-only: ``classify`` is a deterministic keyword/leg scan, so these cases
+need no dataset or DB. The corpus deliberately avoids the entity-alias matcher
+(hero/tower *names*) — that is a separate mechanism with its own pins
+(``test_ai_task_router_btd6_natural.py``); this file guards the shorthand class.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from core.runtime.ai.contracts import AITask  # noqa: E402
+from services import ai_task_router  # noqa: E402
+
+# The canonical community-shorthand vocabulary. Each phrasing is self-contained
+# (carries its own BTD6 cue) so the route does not depend on the dataset-backed
+# entity matcher. Add a new shorthand here when a new ``_looks_like_*`` leg or
+# keyword lands — this is the one obvious place.
+SHORTHAND_CORPUS = [
+    # BUG-0001 — round-cash phrasing ("round " keyword)
+    "how much cash by round 68?",
+    # BUG-0003 — Desperado / Impoppable shorthand (keywords)
+    "cost on impop",
+    "despo on impoppable?",
+    "how many despos do i need",
+    # BUG-0004 — "rNN" round shorthand (two tokens, or one + money cue)
+    "how much do i have on r70 if i had 26932 at the end of r53",
+    "whats my cash at r53 and r70",
+    # BUG-0008 — short farm alias rescued behind a money cue
+    "how much money does a 420 farm make",
+    # BUG-0015 — "dNN" paragon degree shorthand
+    "does a d67 dart paragon exist",
+    "dart paragon at degree 67 stats",
+]
+
+
+# Deliberate look-alikes that must STAY on the general path — the conservatism
+# half of every leg above. A regression that over-routes one of these is just as
+# bad as one that under-routes a real shorthand.
+CONSERVATISM_NEGATIVES = [
+    "r2d2 is my favorite droid",  # digit→letter is no round boundary
+    "its 67 degrees outside",  # temperature "degree", no paragon
+    "i have a degree in cs",  # academic "degree", no paragon
+    "how do i farm coins",  # mining/harvest "farm", no money cue match
+    "there r 5 of us going",  # single "r N" token, no money cue
+]
+
+
+@pytest.mark.parametrize("text", SHORTHAND_CORPUS)
+def test_shorthand_routes_to_btd6_answer(text):
+    """Every known community shorthand must reach the guarded BTD6 path."""
+    decision = ai_task_router.classify(text)
+    assert decision.task is AITask.BTD6_ANSWER, (
+        f"{text!r} routed to {decision.task!r} instead of BTD6_ANSWER — a known "
+        "shorthand regressed onto the unguarded general path"
+    )
+
+
+@pytest.mark.parametrize("text", CONSERVATISM_NEGATIVES)
+def test_lookalikes_stay_general(text):
+    """The deliberate non-BTD6 look-alikes must not over-route."""
+    decision = ai_task_router.classify(text)
+    assert decision.task is AITask.GENERAL_NL_ANSWER, (
+        f"{text!r} over-routed to {decision.task!r} instead of GENERAL_NL_ANSWER"
+    )


### PR DESCRIPTION
## What

Backlog grooming pass (Q-0015) executing the strongest small/safe/decided-lane idea: [`btd6-shorthand-corpus-eval-2026-06-16.md`](https://github.com/menno420/superbot/blob/main/docs/ideas/btd6-shorthand-corpus-eval-2026-06-16.md).

Adds a single **class-guard regression test** for the BTD6 community-shorthand vocabulary. Five live-reported bugs (BUG-0001/0003/0004/0008/0015) shared one root cause: a shorthand question wasn't recognised by `ai_task_router.classify`, fell through to the **unguarded** `GENERAL_NL_ANSWER` path, and the model freelanced. Each was fixed with its own isolated per-bug test — but there was **no single guard** asserting "the whole known shorthand vocabulary routes to BTD6 grounding," so a router refactor or `_looks_like_*` re-ordering could silently regress one back onto the unguarded path, caught only by a *new* live report.

## Changes

- **`tests/unit/services/test_btd6_shorthand_corpus.py`** (new) — routing-only, no DB:
  - **Positives:** the canonical shorthand corpus (`despo`/`despos`, `impop`, round `r53`/`r70`, `420 farm` + money cue, `d67` paragon degree, round-cash phrasing) each must route to `AITask.BTD6_ANSWER`.
  - **Negatives (conservatism):** the deliberate look-alikes (`r2d2`, "67 degrees outside", "a degree in CS", "how do I farm coins", "there r 5 of us") must stay `GENERAL_NL_ANSWER`.
- Re-badged the idea file `historical` ✅ + README annotation (grooming lifecycle outcome).

It **complements** the per-bug tests (which pin *why* each leg exists); the corpus pins *the class as a whole*, so adding a new shorthand is one obvious place and a refactor can't regress the set unseen.

## Verification

- `python3.10 -m pytest tests/unit/services/test_btd6_shorthand_corpus.py -v` → green.
- `python3.10 scripts/check_quality.py --check-only` + `check_docs --strict` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXZp1RXmc6QQLGxXJu9h6P)_