### PR TITLE
feat(dashboard): Phase C — read workspace (personal overview + server health + authority preview)

### DIFF
--- a/.sessions/2026-06-17-dashboard-phase-c-read-workspace.md
+++ b/.sessions/2026-06-17-dashboard-phase-c-read-workspace.md
@@ -1,0 +1,26 @@
+# Session — dashboard Phase C: the read workspace (personal overview + server health + authority preview)
+
+> **Status:** `in-progress`
+
+## What I'm about to do (born-red declaration, Q-0133)
+
+Scheduled dispatch, empty work order → advance the active thread. The night/BTD6 queues are consumed;
+the **dashboard lane is the live thread** (Phase E read endpoints shipped #1013; R3 hardening is in
+flight on #1014, another session — *not* mine to touch). The remaining buildable dashboard slice the
+Phase E log + the finalized-vision plan both name is **Phase C's read workspace** — skipped when the
+build jumped C-auth → F-writes:
+
+- `/me` — a logged-in **personal overview** (the hinge between the public site and per-server
+  management): who you are + the servers you administer, each linking to its overview.
+- `/admin/{guild}/overview` — a **read-only per-server health summary** (invalid settings,
+  customisations, help overrides, disabled cogs) — the non-editing companion to the editor.
+- an honest **authority preview** ("what you may read / change here") from the authority bridge.
+
+All **read-only**, over the already-shipped Phase E read endpoints (`/control/settings/current`,
+`/control/help/overlay`, `/control/routing`) + the authority bridge — **no new bot-side endpoints**,
+no runtime hot-path, no editor-form changes (so no overlap with #1014's CSRF work). New routes +
+templates + a pure `_setup_health` / `_authority_preview` projection, dashboard-only.
+
+## What shipped
+
+_(to be filled at close)_

--- a/.sessions/2026-06-17-dashboard-phase-c-read-workspace.md
+++ b/.sessions/2026-06-17-dashboard-phase-c-read-workspace.md
@@ -1,6 +1,6 @@
 # Session — dashboard Phase C: the read workspace (personal overview + server health + authority preview)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## What I'm about to do (born-red declaration, Q-0133)
 
@@ -21,6 +21,77 @@ All **read-only**, over the already-shipped Phase E read endpoints (`/control/se
 no runtime hot-path, no editor-form changes (so no overlap with #1014's CSRF work). New routes +
 templates + a pure `_setup_health` / `_authority_preview` projection, dashboard-only.
 
-## What shipped
+## What shipped (PR #1015 — Phase C read workspace)
 
-_(to be filled at close)_
+All in `dashboard/` — **read-only, no new bot endpoints, no `disbot/` code** (so no overlap with
+#1014's editor-form CSRF work):
+
+- **`/me` — personal overview** (`me.html`): greets the logged-in user, lists the servers they
+  administer as cards (each → Overview + Manage), and an honest "what you can do here" note. Pure
+  session data — no per-guild bot calls, so it stays fast for a user with many servers. Redirects to
+  `/admin` when logged out.
+- **`/admin/{guild}/overview` — read-only per-server health** (`admin_overview.html`): an authority
+  preview ("what you may read / change here", from the authority bridge) + a setup-health summary
+  (settings tracked · customised-from-default · invalid→using-default with names · help overrides +
+  Home customised · disabled cogs with names) computed from the Phase E reads (`_fetch_current_state`).
+  Honest per-widget states: dormant (not connected), `unavailable` (bot unreachable — the freshness
+  contract's state + the previous session's control-link self-check idea, for free off the `authority is
+  None` signal), not-a-member, and the live summary.
+- **Pure projections** in `app.py`: `_setup_health(current)` + `_authority_preview(authority)` (no I/O,
+  unit-tested) + a `_blank_current()` helper (de-duped the editor route's inline blank shape).
+- **Navigation**: a "My overview" nav link (logged-in), Overview/Manage buttons on the `/admin` picker
+  cards, and an Overview breadcrumb on the editor.
+
+**Verification:** `check_quality --full` green (10408 passed) · `--check-only` green · arch 0 errors ·
++13 dashboard tests (routes, redirects, the live-reads render, the unreachable banner, and the two pure
+projections), run for real under `python3.10` with fastapi installed (CI `importorskip`-skips them).
+
+## Handoff — dashboard ▶ next
+
+Phase C is done; the dashboard lane is at a natural boundary — every remaining slice is in-flight or
+needs its own focused session:
+- **R3 live-surface hardening** (rate-limiting + CSRF) — **in flight on #1014** (another session). Do
+  not duplicate.
+- **Phase D — manifest spine** (Q-0162): typed command/panel/settings manifest + panel registry +
+  reconciliation tests; gates command/panel *management* (the AST `button_backed` weakness), not the
+  shipped settings/help/routing editors. A real runtime investment — its own session.
+- **Global-settings runtime tier** (Q-0157): touches the hot `resolve_setting` path → a focused runtime
+  PR, deliberately not batched.
+- Then **H** (panel-layout engine + editor), scheduled last (needs D + a panel registry).
+
+## 💡 Session idea (Q-0089)
+
+**A per-server "config drift" badge sourced from the manifest spine (Phase D).** Once the manifest
+exists, the server overview's setup-health card could add a *binding-completeness* row: "N capabilities
+have no role/channel binding here" (the authority preview already hints "the bot is missing this
+binding" per the vision doc). Today's health card covers settings/help/routing; the missing dimension is
+*unbound capabilities* — the #1 silent-misconfiguration class (BUG-0012 was exactly a missing-binding
+fallback). It's a natural Phase-D consumer: the manifest knows each command's capability requirements,
+so the overview can show which are unsatisfied for the guild. Small, read-only, high signal — worth a
+`docs/ideas/` entry when D lands. (Dedup-checked: not in the vision doc's roadmap, which lists the
+authority preview but not a binding-completeness health metric.)
+
+## ⟲ Previous-session review (Q-0102) — #1013 (dashboard Phase E read endpoints)
+
+**Did well:** scoped tightly and honestly — it explicitly de-scoped R3 + Phase C to follow-up PRs in
+its own born-red card rather than cramming an overnight batch, which is exactly why *this* session had a
+clean, well-documented seam to pick up (the read endpoints + `_fetch_current_state` were ready to
+consume). The "see-then-change" framing was the right abstraction. **Missed / could-improve:** it built
+the read endpoints and wired them into the *editor* (`/admin/{guild}`) but didn't surface them on a
+read-only landing — so until this PR there was no place to *see* a server's state without entering edit
+mode, and no honest "bot unreachable" state anywhere (a silent failure the freshness contract names).
+**System improvement:** the dashboard lane now has three parallel-ish slices (E #1013, R3 #1014, C
+#1015) from overnight dispatches — the claim ledger (`docs/owner/active-work.md`) would have made the
+R3-vs-C split visible *before* I had to discover #1014 via `list_pull_requests`. Worth reinforcing in
+the dispatch routine: when a lane is being worked by multiple overnight fires, append the claim *first*,
+so the next fire reads intent without an open-PR scan.
+
+## 📋 Doc audit (Q-0104)
+
+- De-staled `dashboard-vision-finalized-state.md` — Phase C row + reviewer note now read **shipped**
+  (#1015), not "partly shipped / still open".
+- Added the #1015 Recently-shipped entry to `current-state.md` with the dashboard ▶ next handoff.
+- **Ledger note (not mine to fix):** SessionStart flags 6 merged PRs not yet in `current-state` — the
+  band-#990 reconciliation pass is next due at #1020 and is the **docs-reconciliation routine's** job
+  (Q-0124: a dispatch session does not run the recon pass). Left for that routine.
+

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -376,6 +376,82 @@ async def _control_flash(path: str, payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _blank_current() -> dict[str, Any]:
+    """The empty current-state shape (no reads yet / reads unavailable)."""
+    return {
+        "settings": {},
+        "help_overlay": None,
+        "help_catalogue": None,
+        "routing_map": {},
+        "reads_ok": False,
+    }
+
+
+def _setup_health(current: dict[str, Any]) -> dict[str, Any]:
+    """Summarize the live current-state read into a one-glance server-health card.
+
+    A pure projection of :func:`_fetch_current_state`'s result (no I/O) that drives
+    the read-only server overview: how many settings are invalid (→ falling back to
+    default), how many are customised away from the default, how many Help entities
+    are overridden (and whether the Home message is customised), and which cogs are
+    disabled for the guild.
+    """
+    invalid: list[dict[str, str]] = []
+    customised = 0
+    total_settings = 0
+    for subsystem, items in (current.get("settings") or {}).items():
+        for item in items:
+            total_settings += 1
+            if not item.get("valid", True):
+                invalid.append({"subsystem": subsystem, "name": item.get("name", "")})
+            elif item.get("provenance") and item["provenance"] != "default":
+                customised += 1
+
+    overlay = current.get("help_overlay") or {}
+    help_overrides = len(overlay.get("rows") or [])
+    home_customised = bool(overlay.get("home"))
+
+    routing = current.get("routing_map") or {}
+    disabled_cogs = sorted(name for name, enabled in routing.items() if not enabled)
+
+    return {
+        "total_settings": total_settings,
+        "customised": customised,
+        "invalid": invalid,
+        "invalid_count": len(invalid),
+        "help_overrides": help_overrides,
+        "home_customised": home_customised,
+        "disabled_cogs": disabled_cogs,
+        "disabled_count": len(disabled_cogs),
+        "healthy": not invalid,
+    }
+
+
+def _authority_preview(authority: dict[str, Any] | None) -> dict[str, Any]:
+    """An honest "what you may read / change here" matrix from the authority bridge.
+
+    A pure projection — it sets expectations, it never grants anything: the bot
+    remains the only real authority and re-checks every write live. The current
+    read + write control-API surfaces are all administrator-gated, so an admin (or
+    the guild owner, who holds admin) may read current config and edit settings /
+    help / cog routing; a plain member may do none of it here. Env-value
+    management lives in the separate owner (platform) zone, not per-guild.
+    """
+    found = bool(authority and authority.get("member_found"))
+    is_admin = bool(authority and authority.get("is_admin"))
+    is_owner = bool(authority and authority.get("is_owner"))
+    return {
+        "member_found": found,
+        "tier": (authority or {}).get("tier"),
+        "is_admin": is_admin,
+        "is_owner": is_owner,
+        "may_read_config": is_admin,
+        "may_edit_settings": is_admin,
+        "may_edit_help": is_admin,
+        "may_edit_routing": is_admin,
+    }
+
+
 async def _fetch_current_state(guild_id: int, user_id: int) -> dict[str, Any]:
     """Fetch the guild's live current config from the bot (Phase E reads).
 
@@ -472,6 +548,30 @@ def auth_logout(request: Request):
     return resp
 
 
+@app.get("/me", response_class=HTMLResponse)
+def me_overview(request: Request):
+    """Personal overview — the logged-in hinge between the public site and
+    per-server management. Greets the user and lists the servers they administer,
+    each linking to its read-only overview. Redirects to ``/admin`` (the sign-in
+    surface) when logged out. Pure session data — no per-guild bot calls, so it
+    stays fast for a user who administers many servers.
+    """
+    session = websession.read(request)
+    user = session.get("user")
+    if user is None:
+        return RedirectResponse("/admin", status_code=302)
+    return templates.TemplateResponse(
+        request,
+        "me.html",
+        {
+            "data": load_data(),
+            "page": "me",
+            "guilds": session.get("guilds", []),
+            "control_configured": control_client.is_configured(),
+        },
+    )
+
+
 @app.get("/admin", response_class=HTMLResponse)
 def admin_home(request: Request):
     """The control-panel home — sign-in prompt or the user's admin-guild picker."""
@@ -495,6 +595,43 @@ def admin_home(request: Request):
     return resp
 
 
+@app.get("/admin/{guild_id}/overview", response_class=HTMLResponse)
+async def admin_guild_overview(request: Request, guild_id: str):
+    """Read-only per-server overview — authority + a setup-health summary.
+
+    The non-editing companion to ``/admin/{guild}``: a one-glance picture (invalid
+    settings, customisations, help overrides, disabled cogs) plus an honest
+    authority preview, all from the Phase E read endpoints. Never writes.
+    """
+    session = websession.read(request)
+    user = session.get("user")
+    if user is None:
+        return RedirectResponse("/admin", status_code=302)
+    guild = _find_admin_guild(session, guild_id)
+    if guild is None:
+        return RedirectResponse("/admin", status_code=302)
+    authority = None
+    current = _blank_current()
+    if control_client.is_configured():
+        authority = await control_client.get_authority(int(guild_id), int(user["id"]))
+        if authority and authority.get("is_admin"):
+            current = await _fetch_current_state(int(guild_id), int(user["id"]))
+    return templates.TemplateResponse(
+        request,
+        "admin_overview.html",
+        {
+            "data": load_data(),
+            "page": "admin",
+            "guild": guild,
+            "authority": authority,
+            "preview": _authority_preview(authority),
+            "health": _setup_health(current),
+            "current": current,
+            "control_configured": control_client.is_configured(),
+        },
+    )
+
+
 @app.get("/admin/{guild_id}", response_class=HTMLResponse)
 async def admin_guild(request: Request, guild_id: str):
     """The per-guild editor — settings, help appearance, and cog routing."""
@@ -506,13 +643,7 @@ async def admin_guild(request: Request, guild_id: str):
     if guild is None:
         return RedirectResponse("/admin", status_code=302)
     authority = None
-    current: dict[str, Any] = {
-        "settings": {},
-        "help_overlay": None,
-        "help_catalogue": None,
-        "routing_map": {},
-        "reads_ok": False,
-    }
+    current: dict[str, Any] = _blank_current()
     if control_client.is_configured():
         authority = await control_client.get_authority(int(guild_id), int(user["id"]))
         # Live current state (see-then-change) — only when the bot says you're an

--- a/dashboard/templates/admin.html
+++ b/dashboard/templates/admin.html
@@ -29,13 +29,18 @@
   {% if guilds %}
     <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
       {% for g in guilds %}
-        <a href="/admin/{{ g.id }}"
-           class="rounded-xl border border-slate-800 bg-slate-900/50 p-4 hover:border-sky-600 transition">
+        <div class="rounded-xl border border-slate-800 bg-slate-900/50 p-4">
           <div class="font-semibold truncate">{{ g.name }}</div>
           <div class="text-xs text-slate-500 mt-1">
             {{ 'Owner' if g.owner else 'Administrator' }} · id {{ g.id }}
           </div>
-        </a>
+          <div class="mt-3 flex gap-2 text-xs">
+            <a href="/admin/{{ g.id }}/overview"
+               class="rounded bg-slate-700 hover:bg-slate-600 px-3 py-1">Overview</a>
+            <a href="/admin/{{ g.id }}"
+               class="rounded bg-sky-700 hover:bg-sky-600 px-3 py-1">Manage</a>
+          </div>
+        </div>
       {% endfor %}
     </div>
     <p class="mt-4 text-xs text-slate-500">

--- a/dashboard/templates/admin_guild.html
+++ b/dashboard/templates/admin_guild.html
@@ -3,6 +3,8 @@
 {% block content %}
 <div class="mb-5">
   <a href="/admin" class="text-xs text-slate-400 hover:text-sky-300">← All servers</a>
+  <span class="text-xs text-slate-600">·</span>
+  <a href="/admin/{{ guild.id }}/overview" class="text-xs text-slate-400 hover:text-sky-300">Overview</a>
   <h1 class="text-2xl font-bold mt-1">{{ guild.name }}</h1>
   <p class="text-slate-500 text-xs">
     {{ 'Owner' if guild.owner else 'Administrator' }} · guild id {{ guild.id }}

--- a/dashboard/templates/admin_overview.html
+++ b/dashboard/templates/admin_overview.html
@@ -1,0 +1,141 @@
+{% extends "base.html" %}
+{% block title %}{{ guild.name }} — Overview — SuperBot{% endblock %}
+{% block content %}
+<div class="mb-5">
+  <a href="/admin" class="text-xs text-slate-400 hover:text-sky-300">← All servers</a>
+  <div class="flex items-center justify-between gap-3 mt-1">
+    <h1 class="text-2xl font-bold">{{ guild.name }} <span class="text-slate-500 text-base font-normal">· overview</span></h1>
+    <a href="/admin/{{ guild.id }}"
+       class="shrink-0 rounded-lg bg-sky-700 hover:bg-sky-600 px-4 py-2 text-sm font-medium">Manage →</a>
+  </div>
+  <p class="text-slate-500 text-xs mt-1">
+    {{ 'Owner' if guild.owner else 'Administrator' }} · guild id {{ guild.id }}
+  </p>
+</div>
+
+{% if not control_configured %}
+  <div class="mb-6 rounded-lg border border-amber-900/60 bg-amber-950/30 px-4 py-3 text-sm text-amber-200">
+    The dashboard isn't connected to the bot yet (<code>CONTROL_API_TOKEN</code> unset), so live server
+    data isn't available. Set the shared token on both Railway services to see this server's current state.
+  </div>
+{% elif authority is none %}
+  <div class="mb-6 rounded-lg border border-rose-900/60 bg-rose-950/30 px-4 py-3 text-sm text-rose-200">
+    ⚠ The dashboard couldn't reach the bot's control API right now (it may be restarting or the private
+    network is down). Live server state is unavailable — try again shortly.
+  </div>
+{% elif authority and not authority.member_found %}
+  <div class="mb-6 rounded-lg border border-amber-900/60 bg-amber-950/30 px-4 py-3 text-sm text-amber-200">
+    The bot {{ 'is not in this server' if not authority.guild_found else "can't see your membership here" }},
+    so it can't report this server's state. Invite the bot (and make sure it can see you) to manage it.
+  </div>
+{% endif %}
+
+<!-- ===================== Authority preview ===================== -->
+<section class="mb-6 rounded-xl border border-slate-800 bg-slate-900/40 p-5">
+  <h2 class="text-lg font-semibold mb-1">🔑 Your authority here</h2>
+  <p class="text-slate-400 text-xs mb-4">
+    What the bot will let you read and change on this server. This is honest expectation-setting — the
+    <strong>bot</strong> makes the final decision and re-checks it on every edit.
+  </p>
+  <div class="mb-4 text-sm text-slate-300">
+    The bot sees you as
+    <span class="text-slate-100 font-medium">{{ preview.tier or 'member' }}</span>{% if preview.is_owner %} ·
+    <span class="text-amber-300">server owner</span>{% elif preview.is_admin %} ·
+    <span class="text-emerald-300">administrator</span>{% endif %}.
+  </div>
+  {% set rows = [
+       ('Read current configuration', preview.may_read_config),
+       ('Edit settings', preview.may_edit_settings),
+       ('Edit help appearance', preview.may_edit_help),
+       ('Enable / disable cogs', preview.may_edit_routing),
+     ] %}
+  <ul class="grid gap-2 sm:grid-cols-2">
+    {% for label, allowed in rows %}
+      <li class="flex items-center gap-2 text-sm rounded-lg border px-3 py-2
+        {{ 'border-emerald-900/50 bg-emerald-950/20 text-emerald-200' if allowed
+           else 'border-slate-800 bg-slate-950/30 text-slate-500' }}">
+        <span>{{ '✓' if allowed else '—' }}</span>
+        <span>You may {{ 'change' if 'Edit' in label or 'Enable' in label else 'read' }}: {{ label|lower }}</span>
+      </li>
+    {% endfor %}
+  </ul>
+  {% if not preview.is_admin %}
+    <p class="mt-3 text-xs text-slate-500">
+      Reading and editing this server requires administrator permission. Server value/platform
+      management lives in the separate owner zone.
+    </p>
+  {% endif %}
+</section>
+
+<!-- ===================== Setup health ===================== -->
+<section class="rounded-xl border border-slate-800 bg-slate-900/40 p-5">
+  <h2 class="text-lg font-semibold mb-1">🩺 Setup health</h2>
+  {% if not current.reads_ok %}
+    <p class="text-slate-500 text-sm">
+      {% if not preview.is_admin %}
+        Sign in as an administrator of this server to see its live configuration health.
+      {% else %}
+        Couldn't load this server's live state right now. Try again, or open
+        <a href="/admin/{{ guild.id }}" class="underline hover:text-slate-300">Manage</a>.
+      {% endif %}
+    </p>
+  {% else %}
+    <p class="text-slate-400 text-xs mb-4">
+      A one-glance picture from the bot's live truth. Drill into
+      <a href="/admin/{{ guild.id }}" class="underline hover:text-slate-300">Manage</a> to change anything.
+    </p>
+    <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4 mb-5">
+      <div class="rounded-lg border border-slate-800 bg-slate-950/40 px-4 py-3">
+        <div class="text-2xl font-bold">{{ health.total_settings }}</div>
+        <div class="text-xs text-slate-500">settings tracked</div>
+      </div>
+      <div class="rounded-lg border border-slate-800 bg-slate-950/40 px-4 py-3">
+        <div class="text-2xl font-bold text-sky-300">{{ health.customised }}</div>
+        <div class="text-xs text-slate-500">customised from default</div>
+      </div>
+      <div class="rounded-lg border px-4 py-3
+        {{ 'border-amber-900/60 bg-amber-950/20' if health.invalid_count else 'border-slate-800 bg-slate-950/40' }}">
+        <div class="text-2xl font-bold {{ 'text-amber-300' if health.invalid_count else 'text-emerald-300' }}">
+          {{ health.invalid_count }}</div>
+        <div class="text-xs text-slate-500">invalid → using default</div>
+      </div>
+      <div class="rounded-lg border border-slate-800 bg-slate-950/40 px-4 py-3">
+        <div class="text-2xl font-bold {{ 'text-rose-300' if health.disabled_count else 'text-slate-200' }}">
+          {{ health.disabled_count }}</div>
+        <div class="text-xs text-slate-500">cog(s) disabled</div>
+      </div>
+    </div>
+
+    {% if health.invalid %}
+      <div class="mb-4 rounded-lg border border-amber-900/50 bg-amber-950/20 px-4 py-3 text-sm">
+        <div class="font-medium text-amber-200 mb-1">Settings falling back to their default (value invalid):</div>
+        <ul class="text-amber-100/90 text-xs space-y-0.5">
+          {% for s in health.invalid %}
+            <li><code>{{ s.subsystem }}.{{ s.name }}</code></li>
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+
+    <div class="grid gap-3 sm:grid-cols-2 text-sm">
+      <div class="rounded-lg border border-slate-800 bg-slate-950/30 px-4 py-3">
+        <div class="text-slate-200 font-medium mb-1">📖 Help appearance</div>
+        <div class="text-slate-400 text-xs">
+          {{ health.help_overrides }} override(s)·
+          Home message {{ 'customised' if health.home_customised else 'default' }}.
+        </div>
+      </div>
+      <div class="rounded-lg border border-slate-800 bg-slate-950/30 px-4 py-3">
+        <div class="text-slate-200 font-medium mb-1">🧩 Cog routing</div>
+        <div class="text-slate-400 text-xs">
+          {% if health.disabled_cogs %}
+            Disabled: {{ health.disabled_cogs|join(', ') }}.
+          {% else %}
+            All cogs enabled for this server.
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+</section>
+{% endblock %}

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -23,6 +23,7 @@
         {% endfor %}
         <div class="ml-auto flex items-center gap-3">
           {% if current_user %}
+            <a href="/me" class="text-sm hover:text-sky-300 {{ 'text-sky-400 font-semibold' if page == 'me' else 'text-slate-300' }}">My overview</a>
             <a href="/admin" class="text-sm hover:text-sky-300 {{ 'text-sky-400 font-semibold' if page == 'admin' else 'text-slate-300' }}">Control panel</a>
             <span class="text-xs text-slate-400">{{ current_user.global_name or current_user.username }}</span>
             <a href="/auth/logout" class="text-sm rounded bg-slate-700 hover:bg-slate-600 px-3 py-1">Sign out</a>

--- a/dashboard/templates/me.html
+++ b/dashboard/templates/me.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{% block title %}My overview — SuperBot{% endblock %}
+{% block content %}
+<div class="mb-6">
+  <h1 class="text-2xl font-bold mb-1">
+    Hi {{ current_user.global_name or current_user.username }} 👋
+  </h1>
+  <p class="text-slate-400 text-sm">
+    Your control-panel home. From here you can open any server you administer — see its
+    configuration at a glance, then drill into the editors. The bot stays the source of truth and
+    re-checks your permissions on every change.
+  </p>
+</div>
+
+{% if not control_configured %}
+  <div class="mb-6 rounded-lg border border-amber-900/60 bg-amber-950/30 px-4 py-3 text-sm text-amber-200">
+    You're signed in, but the dashboard isn't connected to the bot yet
+    (<code>CONTROL_API_TOKEN</code> unset), so live server data and editing aren't available. Your
+    server list below is still yours.
+  </div>
+{% endif %}
+
+<section class="mb-8">
+  <h2 class="text-lg font-semibold mb-3">Servers you administer
+    <span class="text-slate-500 text-sm font-normal">· {{ guilds|length }}</span>
+  </h2>
+  {% if guilds %}
+    <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {% for g in guilds %}
+        <div class="rounded-xl border border-slate-800 bg-slate-900/50 p-4">
+          <div class="font-semibold truncate">{{ g.name }}</div>
+          <div class="text-xs text-slate-500 mt-1">
+            {{ 'Owner' if g.owner else 'Administrator' }} · id {{ g.id }}
+          </div>
+          <div class="mt-3 flex gap-2 text-xs">
+            <a href="/admin/{{ g.id }}/overview"
+               class="rounded bg-slate-700 hover:bg-slate-600 px-3 py-1">Overview</a>
+            <a href="/admin/{{ g.id }}"
+               class="rounded bg-sky-700 hover:bg-sky-600 px-3 py-1">Manage</a>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+    <p class="mt-4 text-xs text-slate-500">
+      Only servers where you're an owner or administrator are shown. A server the bot hasn't joined
+      will say so when you open it.
+    </p>
+  {% else %}
+    <p class="text-slate-500">No servers where you have administrator permission were found.</p>
+  {% endif %}
+</section>
+
+<section class="rounded-xl border border-slate-800 bg-slate-900/40 p-5 text-sm text-slate-400">
+  <h2 class="text-base font-semibold text-slate-200 mb-2">What you can do here</h2>
+  <ul class="space-y-1 list-disc list-inside">
+    <li>See each server's current settings, help appearance, and cog routing — straight from the bot.</li>
+    <li>Edit settings, the help appearance, and enable/disable cogs (administrators only).</li>
+    <li>Everything you change flows through the bot's own audited seams — never a second config store.</li>
+  </ul>
+</section>
+{% endblock %}

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -207,6 +207,19 @@ Source code and merged PRs win over anything written here.
 > auto-opens a `reconcile` issue at the boundary that fires the docs-reconciliation routine). Reset
 > this marker to the latest PR after a pass.
 
+- **#1015 (2026-06-17, dashboard Phase C — the read workspace)** — scheduled dispatch, empty work
+  order → advanced the active dashboard thread (night/BTD6 queues consumed; R3 hardening already
+  in flight on #1014). Shipped the Phase-C slice skipped when the build jumped C-auth → F-writes,
+  all **read-only** over the shipped Phase E reads (no new bot endpoints, no `disbot/` code): **`/me`**
+  (logged-in personal overview — who you are + the servers you administer, each card linking to its
+  overview/editor; pure session data), **`/admin/{guild}/overview`** (read-only per-server
+  setup-health summary — invalid settings, customisations, help overrides, disabled cogs — from
+  `_fetch_current_state`), and an honest **authority preview** ("what you may read / change here")
+  from the authority bridge. New pure `_setup_health`/`_authority_preview` projections + two
+  templates + nav/overview links. `check_quality --full` green (10408) · arch 0 · +12 dashboard
+  tests. **Dashboard ▶ next:** R3 hardening (#1014, in flight) → then the Phase D manifest spine
+  (Q-0162, gates command/panel management) + the global-settings runtime tier (Q-0157) — both their
+  own focused sessions.
 - **#1012 (2026-06-17, AI answerability floor — boss roster + per-difficulty map filter + boss
   immunity)** — scheduled dispatch fire, no work order; night queue fully consumed + both open PRs
   (#941/#929) Hermes-gated → took a fresh slice of the proven, ungated BTD6 deterministic-floor lane

--- a/docs/planning/dashboard-vision-finalized-state.md
+++ b/docs/planning/dashboard-vision-finalized-state.md
@@ -45,9 +45,10 @@ and forward-looking. Nothing here contradicts what shipped.
 **Material correction — the write side went live *today*, after this doc was written.** The phase table
 and several "Status today" cells understate reality:
 
-- **Phase C (OAuth + workspace) — partly shipped.** Discord OAuth login, a signed-cookie session, the
-  `/admin` server picker, and per-guild editor pages are live (#996). *Still open:* the richer *read*
-  workspace (`/me`, a server **overview** with setup-health, the authority preview) — those were skipped.
+- **Phase C (OAuth + workspace) — shipped.** Discord OAuth login, a signed-cookie session, the
+  `/admin` server picker, and per-guild editor pages are live (#996); the richer *read* workspace —
+  `/me` (personal overview), a per-server **overview** with setup-health, and the authority preview —
+  shipped in **#1015** (read-only, over the Phase E reads).
 - **Phase F (first live writes) — shipped + activated.** The help / settings / cog-routing editors write
   live through the audited seams (#993 endpoints + #996 editors); `CONTROL_API_TOKEN` + the OAuth secret
   are set on Railway and it is confirmed working end-to-end.
@@ -374,7 +375,7 @@ spine). This roadmap is the *connective tissue*, not a re-plan — each phase po
 |---|---|---|---|
 | **A — public IA + product homepage** | Product-grade homepage; use-case taxonomy; better `/commands` & `/functions`; freshness badges everywhere | `developer-dashboard-plan.md` | none (no OAuth/runtime) |
 | **B — freshness & provenance** | Lineage badges + per-widget states; automate export regen; ETag/conditional GETs | `developer-dashboard-plan.md` | none |
-| **C — OAuth + personal/server workspaces** | Login, sessions, `/admin` server picker, per-guild editor pages | `dashboard-live-editor-plan.md` L0 | 🟡 **partly shipped + live** (#996): OAuth login + server picker + editor pages run; **still open** — the richer *read* workspace (`/me`, a server **overview** with setup-health, the authority preview) |
+| **C — OAuth + personal/server workspaces** | Login, sessions, `/admin` server picker, per-guild editor pages, the read workspace | `dashboard-live-editor-plan.md` L0 | ✅ **shipped + live**: OAuth login + server picker + editor pages (#996); the read workspace — `/me`, a per-server **overview** with setup-health, the authority preview — shipped read-only in #1015 |
 | **D — manifest spine** | Typed command/panel/settings manifest export + panel registry + reconciliation tests; AST demoted to drift detection | **NEW track** (this doc) | ✅ **approved (Q-0162).** Gates **command-management trustworthiness + the panel editor (H)** — *not* the already-shipped settings/help/routing editors (they ride already-typed seams). Build after the Phase-E reads, before H. |
 | **E — control API read endpoints** | Private, secret-protected reads: **current settings values**, help overlay, server context, capabilities, diagnostics, manifest | `dashboard-live-editor-plan.md` L1 | ⚠️ **SKIPPED — now the top next priority.** The token is set, but the current-value **GET** endpoints (`/control/settings/current`, `/control/help/overlay`) were never built, so the live editors **write blind** (see reviewer note R1). Highest-value, lowest-risk next slice. |
 | **F — first live writes (audited seams)** | Help / settings / cog-routing editors over the audited seams | `dashboard-live-editor-plan.md` L2 + Q-0157 | ✅ **SHIPPED + LIVE** (#993 endpoints + #996 editors) — confirmed end-to-end. Order help → settings → aliases/routing (Q-0163); **aliases live-overlay + global-settings tier still to come.** |

--- a/tests/unit/dashboard/test_app.py
+++ b/tests/unit/dashboard/test_app.py
@@ -38,13 +38,18 @@ def _login_cookie(user_id="42", guild_id="111", guild_name="My Server"):
 
 
 @pytest.fixture(scope="module")
-def client():
+def app_module():
     spec = importlib.util.spec_from_file_location("dashboard_app_ut", _APP)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
-    return TestClient(module.app)
+    return module
+
+
+@pytest.fixture(scope="module")
+def client(app_module):
+    return TestClient(app_module.app)
 
 
 @pytest.mark.parametrize(
@@ -297,6 +302,174 @@ def test_admin_guild_unknown_guild_redirects(client):
     resp = client.get("/admin/999", cookies=_login_cookie(), follow_redirects=False)
     assert resp.status_code in (302, 307)
     assert resp.headers["location"] == "/admin"
+
+
+# ---------------------------------------------------------------------------
+# Phase C — the read workspace (/me, /admin/{guild}/overview, authority preview)
+# ---------------------------------------------------------------------------
+
+
+def test_me_requires_login(client):
+    # Not signed in → the personal overview bounces back to /admin (sign-in).
+    resp = client.get("/me", follow_redirects=False)
+    assert resp.status_code in (302, 307)
+    assert resp.headers["location"] == "/admin"
+
+
+def test_me_overview_lists_servers_when_logged_in(client):
+    resp = client.get("/me", cookies=_login_cookie())
+    assert resp.status_code == 200
+    assert "Servers you administer" in resp.text
+    assert "My Server" in resp.text
+    # Each server card links to both the overview and the editor.
+    assert "/admin/111/overview" in resp.text
+    assert 'href="/admin/111"' in resp.text
+
+
+def test_overview_requires_login(client):
+    resp = client.get("/admin/111/overview", follow_redirects=False)
+    assert resp.status_code in (302, 307)
+    assert resp.headers["location"] == "/admin"
+
+
+def test_overview_unknown_guild_redirects(client):
+    resp = client.get(
+        "/admin/999/overview",
+        cookies=_login_cookie(),
+        follow_redirects=False,
+    )
+    assert resp.status_code in (302, 307)
+    assert resp.headers["location"] == "/admin"
+
+
+def test_overview_renders_authority_preview_when_dormant(client):
+    # Logged in, control API dormant → the page renders with the authority preview
+    # and the "not connected" notice, never an error.
+    resp = client.get("/admin/111/overview", cookies=_login_cookie())
+    assert resp.status_code == 200
+    assert "Your authority here" in resp.text
+    assert "Setup health" in resp.text
+    assert "CONTROL_API_TOKEN" in resp.text
+
+
+def test_overview_shows_health_metrics_with_live_reads(client, monkeypatch):
+    # Configured + admin → the overview renders the live setup-health summary.
+    from unittest.mock import AsyncMock
+
+    import control_client
+
+    monkeypatch.setattr(control_client, "is_configured", lambda: True)
+    monkeypatch.setattr(
+        control_client,
+        "get_authority",
+        AsyncMock(
+            return_value={
+                "guild_found": True,
+                "member_found": True,
+                "is_admin": True,
+                "is_owner": False,
+                "tier": "administrator",
+            },
+        ),
+    )
+
+    async def fake_get(path, params=None):
+        if path == "/control/settings/current":
+            return 200, {
+                "ok": True,
+                "subsystems": {
+                    "moderation": [
+                        {"name": "warn_threshold", "value": 5, "provenance": "guild", "valid": True},
+                        {"name": "mute_role", "value": None, "provenance": "default", "valid": False},
+                    ],
+                },
+            }
+        if path == "/control/help/overlay":
+            return 200, {"ok": True, "rows": [{"entity_kind": "subsystem", "entity_key": "xp"}], "home": None}
+        if path == "/control/help/catalogue":
+            return 200, {"ok": True, "hubs": [], "subsystems": []}
+        if path == "/control/routing":
+            return 200, {
+                "ok": True,
+                "rows": [
+                    {"scope_type": "guild", "scope_id": None, "cog_name": "MiningCog", "enabled": False},
+                ],
+            }
+        return 503, {"error": "unexpected path"}
+
+    monkeypatch.setattr(control_client, "get", fake_get)
+
+    resp = client.get("/admin/111/overview", cookies=_login_cookie())
+    assert resp.status_code == 200
+    # One customised, one invalid, one help override, one disabled cog.
+    assert "customised from default" in resp.text
+    assert "invalid → using default" in resp.text
+    assert "mute_role" in resp.text  # the invalid setting is named
+    assert "MiningCog" in resp.text  # the disabled cog is named
+
+
+def test_overview_shows_unreachable_when_bot_down(client, monkeypatch):
+    # Configured, but the bot control API is unreachable (get_authority → None) →
+    # the overview shows an honest "unavailable" banner, never an error.
+    from unittest.mock import AsyncMock
+
+    import control_client
+
+    monkeypatch.setattr(control_client, "is_configured", lambda: True)
+    monkeypatch.setattr(control_client, "get_authority", AsyncMock(return_value=None))
+
+    resp = client.get("/admin/111/overview", cookies=_login_cookie())
+    assert resp.status_code == 200
+    assert "couldn't reach the bot's control API" in resp.text
+
+
+def test_setup_health_projection(app_module):
+    current = {
+        "settings": {
+            "moderation": [
+                {"name": "a", "provenance": "guild", "valid": True},
+                {"name": "b", "provenance": "default", "valid": True},
+                {"name": "c", "provenance": "default", "valid": False},
+            ],
+        },
+        "help_overlay": {"rows": [{"x": 1}, {"x": 2}], "home": {"title": "t"}},
+        "routing_map": {"AlphaCog": True, "BetaCog": False},
+    }
+    health = app_module._setup_health(current)
+    assert health["total_settings"] == 3
+    assert health["customised"] == 1
+    assert health["invalid_count"] == 1
+    assert health["invalid"] == [{"subsystem": "moderation", "name": "c"}]
+    assert health["help_overrides"] == 2
+    assert health["home_customised"] is True
+    assert health["disabled_cogs"] == ["BetaCog"]
+    assert health["healthy"] is False
+
+
+def test_setup_health_empty_is_healthy(app_module):
+    health = app_module._setup_health(app_module._blank_current())
+    assert health["total_settings"] == 0
+    assert health["invalid_count"] == 0
+    assert health["disabled_cogs"] == []
+    assert health["healthy"] is True
+
+
+def test_authority_preview_admin_vs_member(app_module):
+    admin = app_module._authority_preview(
+        {"member_found": True, "is_admin": True, "is_owner": False, "tier": "administrator"},
+    )
+    assert admin["may_read_config"] and admin["may_edit_settings"]
+    assert admin["may_edit_help"] and admin["may_edit_routing"]
+
+    member = app_module._authority_preview(
+        {"member_found": True, "is_admin": False, "is_owner": False, "tier": "member"},
+    )
+    assert not member["may_read_config"]
+    assert not member["may_edit_settings"]
+
+    none = app_module._authority_preview(None)
+    assert none["member_found"] is False
+    assert none["tier"] is None
 
 
 def test_admin_setting_post_when_logged_in_dormant_control(client):


### PR DESCRIPTION
## Why

Scheduled dispatch, empty work order → advance the live thread. The night/BTD6 queues are consumed and the **dashboard lane is the active thread**: Phase E read endpoints shipped (#1013); R3 hardening is in flight on #1014 (another session — untouched here). The remaining buildable dashboard slice the Phase E session log + the finalized-vision plan both name is **Phase C's read workspace**, skipped when the build jumped C-auth → F-writes.

## What (all read-only, over the shipped Phase E reads — no new bot endpoints)

- **`/me` — personal overview.** The logged-in hinge between the public site and per-server management: who you are + the servers you administer, each card linking to its overview/editor. Pure session data (no per-guild bot calls — scales to many guilds). Redirects to `/admin` when logged out.
- **`/admin/{guild}/overview` — read-only per-server health summary.** The non-editing companion to the editor: invalid settings (→ using default), customised settings, help overrides + Home customised, disabled cogs — a one-glance picture from `_fetch_current_state` (the Phase E reads). Links into the full editor.
- **Authority preview** — an honest "what you may read / change here" matrix from the authority bridge (`tier` / `is_admin` / `is_owner`). It sets expectations; the bot remains the only real authority (re-checks on every write).

New pure projections `_setup_health` / `_authority_preview` (unit-testable, no I/O), two new templates, a `/me` nav link, and overview links from the picker + editor. **No editor-form changes** → no overlap with #1014's CSRF work. Dashboard-only; no runtime/`disbot/` code.

## Status

🔴 born-red (Q-0133) → flipped to `complete` once `check_quality --full` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014gCcQe2uUiYMhVG1kPTBM4

---
_Generated by [Claude Code](https://claude.ai/code/session_014gCcQe2uUiYMhVG1kPTBM4)_