### PR TITLE
docs(dashboard): reconcile vision roadmap (Phase E #1013 + R3 #1014 shipped)

### DIFF
--- a/.sessions/2026-06-17-dashboard-vision-reconcile.md
+++ b/.sessions/2026-06-17-dashboard-vision-reconcile.md
@@ -1,0 +1,58 @@
+# Session — dashboard vision-roadmap reconcile (+ Phase C parallel-collision close-out)
+
+> **Status:** `complete`
+
+## Context
+
+This was the **third PR (#1016) of the overnight dashboard run** (Phase E #1013 merged · R3 #1014 merged).
+It started as **Phase C — the read workspace** (a per-server overview + authority preview). While it sat in
+CI, a **parallel session #1015 (`claude/magical-rubin-n18ez2`) shipped the *same* Phase C read workspace**
+— and merged first. #1015's version is **more complete and better-factored** (dedicated
+`/admin/{guild}/overview` + `/me` pages with `_setup_health` + `_authority_preview` helpers), so it is
+**authoritative**; my inline-card variant was **redundant duplication**. Per the dedup discipline (Q-0126,
+first-to-merge wins), I **dropped my Phase C code** and reset to main with #1015's workspace.
+
+## What shipped (PR #1016 — repurposed: docs reconciliation)
+
+The one genuinely-additive remainder: **#1015 didn't reconcile the vision-doc status for Phase E (#1013)
+or R3 (#1014)** — main's roadmap still said *"Phase E SKIPPED — top next priority"* and *"rate-limiting
+not yet done,"* both now materially wrong. Fixed in `docs/planning/dashboard-vision-finalized-state.md`:
+
+- **Roadmap Phase E row** → ✅ SHIPPED (#1013) — the see-then-change read endpoints.
+- **§ Security R3 line** → ✅ SHIPPED (#1014) — CSRF token + rate-limiting (login · edits · control-API writes/429).
+- **The "Status reconciled" note** → rewritten for the #1013/#1014/#1015 reality; records the parallel
+  collision + the lesson; reviewer-note R1/R3 marked done (R2/R4 stand).
+- **`active-work.md`** — cleared my (now-stale) claim; Phase C credited to #1015.
+
+Docs-only; `check_docs --strict` green. No runtime change.
+
+## ⟲ Previous-slice review (Q-0102) — and the collision lesson
+
+The earlier slices this session (Phase E #1013, R3 #1014) went well — focused, dormant-by-default,
+`--full`-green, each merged clean. **The miss is the Phase C collision:** I scanned open PRs at session
+*start* (only #941/#929 then) and claimed Phase C in `active-work`, but #1015 opened + merged its own Phase
+C *during* my R3 work — and I started Phase C (hours later) **without re-scanning open PRs**. The claim
+ledger can't prevent a dup when the other session doesn't read it and merges first; the defense that *would*
+have caught it is **re-running `list_pull_requests` before each slice of a long multi-PR session**, not just
+at its start. **System improvement (initiated):** the `/session-close` (or a pre-slice habit) should prompt
+a fresh open-PR scan when a session opens its **Nth** PR — cheap, and it turns a silent hours-long overlap
+into a one-call catch. Recorded as the durable takeaway; the in-doc note is in the vision plan's reconciled
+status block.
+
+## 💡 Session idea (Q-0089) — a shared control-API contract test
+
+(Carried from the earlier Phase E work.) I built **both sides** of four `/control/*` endpoints
+(`disbot/control_api.py` + `dashboard/control_client.py`/route), keeping their JSON shapes in sync **by
+hand** — a bot-side field rename would silently break the dashboard (separate deployables, no shared type).
+Idea: a committed **contract fixture** (a JSON sample of each `/control/*` response) that *both* a bot-side
+test (handler emits these keys) and a dashboard-side test (client/route consumes these keys) assert against
+— the control-API-sized sibling of the manifest spine's reconciliation tests. Small, stdlib, decided-lane;
+promote to `docs/ideas/` if the control API grows a third consumer or sees its first drift bug.
+
+## 📋 Documentation audit (Q-0104)
+
+The vision-doc roadmap drift (E/R3 status) is the durable-home gap this run created — fixed here. The
+parallel-collision is documented in the plan's reconciled note. `check_docs --strict` green. **Did not**
+touch the `current-state.md` ledger — that cross-cutting reconcile (now ~14 merged PRs behind, incl.
+#1013/#1014/#1015) is the auto-firing recon routine's job (Q-0124); the SessionStart banner flags it.
+Nothing else from this session lives only in chat.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,10 +25,6 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/inspiring-wozniak-i92q58` · **dashboard R3 — live-surface hardening** (owner directive,
-  overnight; follows Phase E #1013 merged) — CSRF token on the editor forms + rate-limit the public login
-  & edit POSTs + rate-limit the control-API writes (429). Additive/dormant-safe · `dashboard/` ·
-  `disbot/control_api.py` · 2026-06-17 · *(next: Phase C read workspace)*
 - `claude/tender-noether-h5lpp1` · **night work queue** (owner directive) — seed a grounded queue of
   read-only deterministic BTD6 floor builders (AI §7.5/§7.6 lane) for the scheduled dispatch fires +
   repoint `current-state.md` ▶ Next action · `docs/planning/night-queue-2026-06-16.md` ·
@@ -53,6 +49,13 @@ living ledger (`docs/current-state.md`).
 
 ## Recently cleared
 
+- `claude/inspiring-wozniak-i92q58` · dashboard **Phase E** — control-API read endpoints + see-then-change
+  editor · 2026-06-17 · **PR #1013 (merged)**
+- `claude/inspiring-wozniak-i92q58` · dashboard **R3** — live-surface hardening (CSRF + rate-limiting) ·
+  2026-06-17 · **PR #1014 (merged)**
+- `claude/inspiring-wozniak-i92q58` · dashboard **vision-roadmap reconcile** (Phase C read workspace was
+  built in parallel by **#1015** and merged first — authoritative; this run's duplicate was dropped) ·
+  2026-06-17 · **PR #1016**
 - `claude/health-server-ipv6-bind` · health server IPv6 dual-stack bind (Railway private networking) · 2026-06-16 · **PR #1001 (merged)**
 - `claude/inspiring-wozniak-i92q58` · dashboard finalized-state vision plan · 2026-06-16 · **PR #1002 (merged)**
 - `claude/control-panel-web` · control panel — Discord OAuth login + editors (write side step 2) · 2026-06-16 · **PR #996 (merged)**

--- a/docs/planning/dashboard-vision-finalized-state.md
+++ b/docs/planning/dashboard-vision-finalized-state.md
@@ -342,10 +342,11 @@ reliable panel-layout editor — and is the first half of the L3 "move buttons" 
   website state or client code. **Operative gotcha (cost the #1001 fix):** Railway private networking is
   **IPv6-only** — the bot's health/control server must bind `::` (dual-stack via `HEALTH_HOST`), *not*
   `0.0.0.0`, or `worker.railway.internal` is unreachable. Phase-E implementers need this.
-- **Live-surface hardening (reviewer note R3, not yet done):** the panel is public + live but still lacks
-  **rate-limiting** (control API + the public login) and an **explicit CSRF token** (today only
-  `SameSite=Lax` on the session cookie). Neither is a write-authorization hole — the bot still gates every
-  write via the live member + seam — but both are near-term hardening items now that the surface is live.
+- **Live-surface hardening (reviewer note R3 — ✅ SHIPPED #1014):** the public+live panel now has an
+  **explicit CSRF token** on every editor form (per-session, constant-time-checked, beyond the cookie's
+  `SameSite=Lax`) and **rate-limiting** — the public login (per IP), the edit POSTs (per user), and the
+  control-API **writes** (per guild+user → HTTP 429). Stdlib sliding-window limiters, defense-in-depth;
+  the bot still gates every write via the live member + seam.
 - **Every mutation carries** actor id · guild id · idempotency/mutation id · CSRF token, is **rate-limited**
   (per IP/user/guild/action, and on public forms), and lands in the **bot's audit system** via the seam's
   `audit.action_recorded` emit. Structured logging (request id, actor, guild, action, result, latency) —
@@ -377,17 +378,21 @@ spine). This roadmap is the *connective tissue*, not a re-plan — each phase po
 | **B — freshness & provenance** | Lineage badges + per-widget states; automate export regen; ETag/conditional GETs | `developer-dashboard-plan.md` | none |
 | **C — OAuth + personal/server workspaces** | Login, sessions, `/admin` server picker, per-guild editor pages, the read workspace | `dashboard-live-editor-plan.md` L0 | ✅ **shipped + live**: OAuth login + server picker + editor pages (#996); the read workspace — `/me`, a per-server **overview** with setup-health, the authority preview — shipped read-only in #1015 |
 | **D — manifest spine** | Typed command/panel/settings manifest export + panel registry + reconciliation tests; AST demoted to drift detection | **NEW track** (this doc) | ✅ **approved (Q-0162).** Gates **command-management trustworthiness + the panel editor (H)** — *not* the already-shipped settings/help/routing editors (they ride already-typed seams). Build after the Phase-E reads, before H. |
-| **E — control API read endpoints** | Private, secret-protected reads: **current settings values**, help overlay, server context, capabilities, diagnostics, manifest | `dashboard-live-editor-plan.md` L1 | ⚠️ **SKIPPED — now the top next priority.** The token is set, but the current-value **GET** endpoints (`/control/settings/current`, `/control/help/overlay`) were never built, so the live editors **write blind** (see reviewer note R1). Highest-value, lowest-risk next slice. |
+| **E — control API read endpoints** | Private, secret-protected reads: **current settings values**, help overlay, server context, capabilities, diagnostics, manifest | `dashboard-live-editor-plan.md` L1 | ✅ **SHIPPED (#1013).** `GET /control/settings/current` · `help/overlay` · `help/catalogue` · `routing` — admin-gated, dormant-by-default; the editors now **see-then-change** instead of writing blind. *(Diagnostics/manifest reads still to come with Phase D.)* |
 | **F — first live writes (audited seams)** | Help / settings / cog-routing editors over the audited seams | `dashboard-live-editor-plan.md` L2 + Q-0157 | ✅ **SHIPPED + LIVE** (#993 endpoints + #996 editors) — confirmed end-to-end. Order help → settings → aliases/routing (Q-0163); **aliases live-overlay + global-settings tier still to come.** |
 | **G — owner zone: env values + control board** | Masked Railway value mgmt; idea/bug triage; multi-AI control board over the `/fire` routines | `developer-dashboard-plan.md` Phases 3b/4 | owner: Railway API creds; **owner-only, scope-shaped** (Q-0162) |
 | **H — panel-layout engine + editor** | DB-backed `panel_layout` overlay + render-time reader + audited seam, **then** the drag-and-drop editor | `dashboard-live-editor-plan.md` L3 | manifest spine (D) + panel registry; **scheduled last** (Q-0163) |
 
-> **Status reconciled (2026-06-17, with the reviewer note above):** the write side **shipped and went
-> live** right after this plan was written — the build jumped **C-auth → F-writes and skipped Phase E**
-> (the current-value read endpoints). So the setup gate is cleared *and then some*: live editing works,
-> but **the live editors write blind until Phase E lands** — which is why E is now the **top next
-> priority**, not a future phase. Near-term hardening the live surface still needs: **rate-limiting** +
-> an **explicit CSRF token** (reviewer note R3).
+> **Status reconciled (2026-06-17 — overnight run #1013/#1014/#1015):** the write-side gap is **closed**.
+> **Phase E shipped** (#1013) — the current-value read endpoints, so the editors **see-then-change** (no
+> longer blind). **R3 hardening shipped** (#1014) — CSRF tokens on every editor form + rate-limiting on the
+> public login, the edit POSTs, and the control-API writes (HTTP 429). **Phase C's read workspace shipped**
+> (#1015) — `/me`, the per-server overview, the authority preview. Reviewer-note R1 (Phase E now) and R3
+> (rate-limit + CSRF) are therefore **done**; R2 (manifest gate framing) and R4 (Railway IPv6) stand.
+> Remaining near-term: the aliases live-overlay + the global-settings tier (F tail) and the manifest spine
+> (D). *(Process note: a parallel session (#1015) and this run both built Phase C's read workspace — #1015
+> merged first and is authoritative; the duplicate inline-card variant from #1016 was dropped. Lesson:
+> re-scan open PRs before each slice of a long multi-PR session, not just at its start.)*
 
 ## Decisions (owner question-panel, 2026-06-16 — all forks resolved)
 


### PR DESCRIPTION
## Why (repurposed)

This PR began as **Phase C — the read workspace** (per-server overview + authority preview) in the overnight
dashboard run. While it sat in CI, a **parallel session #1015 (`claude/magical-rubin-n18ez2`) shipped the
same Phase C read workspace** — dedicated `/admin/{guild}/overview` + `/me` pages — and **merged first**, so
it's authoritative (Q-0126, first-to-merge). This run's inline-card variant was **redundant duplication**, so
I dropped it and reset to main with #1015's workspace.

The one genuinely-additive remainder: **#1015 didn't reconcile the vision-doc status for Phase E (#1013) or
R3 (#1014)** — main's roadmap still said *"Phase E SKIPPED — top next priority"* and *"rate-limiting not yet
done,"* both now materially wrong. This PR fixes that.

## What (docs only)

- **Roadmap Phase E row** → ✅ SHIPPED (#1013) — the see-then-change read endpoints.
- **§ Security R3 line** → ✅ SHIPPED (#1014) — CSRF token + rate-limiting (login · edits · control-API writes/429).
- **"Status reconciled" note** → rewritten for the #1013/#1014/#1015 reality + the parallel-collision lesson
  (re-scan open PRs before each slice of a long multi-PR session); reviewer-note R1/R3 marked done.
- **`active-work.md`** → cleared this session's claims (#1013/#1014/#1016).

`check_docs --strict` green; no runtime change. Session card is `complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7Y1wggMweKQnEsrLVnZ2Y