### PR TITLE
feat(manifest): manifest spine slice 1 — typed CommandManifest over the command ledger

### DIFF
--- a/.sessions/2026-06-17-command-manifest-spine-slice1.md
+++ b/.sessions/2026-06-17-command-manifest-spine-slice1.md
@@ -1,6 +1,6 @@
 # Session — manifest spine, slice 1 (typed CommandManifest over the ledger)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Context
 
@@ -30,6 +30,67 @@ bot-owned manifest built at startup**, with AST demoted to drift-detection.
 
 Full plan: `docs/planning/manifest-spine-execution-plan-2026-06-17.md`.
 
-## What shipped
+## What shipped (PR #1018)
 
-(filled in as the work lands)
+- **`core/runtime/command_manifest.py`** — typed `CommandManifest` / `CommandManifestEntry` (the
+  #998 schema), built as a **pure projection** of the cached `CommandSurfaceLedger` (reuses it — no
+  second surface walk). Carries every ledger-known field (`qualified_name`, `kind`, `cog`,
+  `subsystem`, `classification` + `classification_declared`, `visibility_tier`, `aliases`,
+  `discord_hidden`, `runtime_verified`) + a `to_dict()` export; deferred fields
+  (`source`/`panels`/`actions`/`related_settings`/`capability_required`) are shape-pinned but empty.
+  Startup-cached + a `command_manifest` diagnostics provider (immediate operator consumer).
+- **Startup wiring (`bot1.py`)** right after the ledger build, non-fatal, `startup_outcome`-tracked.
+- **CI invariant** `test_command_manifest.py` (8 tests) — manifest-faithfully-projects-ledger (count
+  parity, `qualified_name`, field mapping, `to_dict()` schema, cache round-trip, diagnostics).
+- **Pinned-surface cascade:** `KNOWN_PHASES` + smoke checklist (new `command_manifest` phase),
+  `tests/_isolation.py` reset-hook classification, the execution plan linked from the vision doc.
+- **`docs/planning/manifest-spine-execution-plan-2026-06-17.md`** — the Q-0162 spine sequenced into
+  PR1 (this) → PR2 panel registry → PR3 control-API read + dashboard export + AST drift guard → PR4
+  panel-layout editor.
+
+`check_quality --full` green (10397 passed) · `check_architecture --mode strict` 0 errors.
+**Merge gate:** self-merge on green (Q-0113) — additive, behavior-neutral, owner-approved lane.
+
+## 💡 Session idea (Q-0089) — promote the AST scanner into a CI drift guard against the manifest
+
+This slice makes the runtime manifest the source of truth and the vision doc demotes
+`scripts/scan_commands.py` (AST) to "drift detection only" — but that demotion is currently *aspirational*:
+there's no test yet that fails when the AST scan and the runtime manifest disagree. The idea (slated as
+PR3, but worth flagging as genuinely high-value): a CI test that runs the AST scanner and asserts its
+command set reconciles with a committed manifest snapshot, so a command renamed/moved in code without a
+matching manifest refresh *fails CI* — turning "two sources that might silently diverge" into "one of
+them is authoritative and the other is a guard." It's the structural payoff that makes the whole spine
+trustworthy, and it's the cheapest way to keep the AST honest as the manifest grows.
+
+## ⟲ Previous-slice review (Q-0102)
+
+The immediately-previous slice this session (#1017, the global settings tier) went well — it shipped a
+complete read+write feature with 18 tests and correctly reasoned about *not* forcing a 2nd slice when
+the remaining lanes looked gated. **The miss it had, in hindsight:** it concluded "the dashboard's next
+ungated slice is gated (phase ③ owner-paced)" and handed off toward a *different* lane — but it didn't
+notice that the **manifest spine** (a *different* dashboard sub-lane, owner-approved Q-0162, Phase-E
+predecessor shipped) was both ungated AND buildable. So its handoff slightly undersold the available
+work. **System improvement (initiated):** when a session decides "the active lane's next slice is
+gated," it should scan the lane's *sibling* sub-lanes (the vision doc's decision table / phase rows)
+before concluding the whole lane is blocked — a gated headline phase doesn't mean every sub-lane is
+gated. I acted on exactly that this run: re-reading the vision doc's Q-0162 decision row surfaced the
+manifest spine as the genuine next buildable slice. Worth wiring into `/session-close` as a "did you
+check sibling sub-lanes?" prompt when a handoff declares a lane blocked.
+
+## 📋 Documentation audit (Q-0104)
+
+- The new lane is in its durable homes: the execution plan (linked from the vision doc, no orphan), the
+  vision doc's reviewer/decision references, and the current-state ledger entry for #1018.
+- No new owner *decision* this run (Q-0162 already approved the spine); no new router Q-block needed.
+- The SessionStart banner flagged the ledger ~5 PRs behind; that cross-cutting reconcile is the
+  auto-firing docs-reconciliation routine's job (Q-0124) — I added only my own #1018 entry.
+- Nothing from this session lives only in chat.
+
+## Handoff (▶ next)
+
+The manifest spine's **PR2 (panel registry + `PanelManifest`)** is the next slice — ungated, bot-owned,
+and the prerequisite for the L3 panel-layout editor. It composes the view classes into declarative
+panel descriptors (`panel_id` / `view_class` / `buttons[]` with `action_id`/`custom_id`/`label`/`row`/
+`command`) and back-populates `CommandManifestEntry.panels` / `.actions` (shape already reserved). Then
+PR3 (control-API `GET /control/manifest` read + `dashboard.json` export + the AST drift guard above).
+Full sequence + turn-key detail: `docs/planning/manifest-spine-execution-plan-2026-06-17.md`.

--- a/.sessions/2026-06-17-command-manifest-spine-slice1.md
+++ b/.sessions/2026-06-17-command-manifest-spine-slice1.md
@@ -1,0 +1,35 @@
+# Session — manifest spine, slice 1 (typed CommandManifest over the ledger)
+
+> **Status:** `in-progress`
+
+## Context
+
+Continuation of the same dispatch fire that shipped the global settings tier (#1017, merged). The
+next ungated, owner-approved lane is the **manifest spine** — the dashboard vision doc's "key
+structural investment" (`dashboard-vision-finalized-state.md` § "The manifest spine"). It is
+**owner-decided BUILD IT** (Q-0162), its predecessor Phase E shipped (#1013), and its schema is
+finalized (#998) — so this is a decided, approved architectural lane, not an ambiguous one.
+
+Today command metadata comes from an AST scan (`scripts/scan_commands.py`) — fine for read-only docs,
+fragile for management. The runtime already has a richer truth: `core/runtime/command_surface_ledger.py`
+(classifications, visibility tier, aliases, declared-ness). The finalized answer is a **typed,
+bot-owned manifest built at startup**, with AST demoted to drift-detection.
+
+## Plan (this slice + the sequenced rest)
+
+- **PR1 (this) — `CommandManifest` over the ledger.** A new `core/runtime/command_manifest.py` that
+  projects the cached `CommandSurfaceLedger` into the typed #998 command schema, cached at startup +
+  surfaced as a `command_manifest` diagnostics provider, with a manifest-faithfully-projects-ledger
+  CI invariant (the first "reconciliation test that makes the metadata trustworthy"). Additive,
+  offline-testable, changes no existing behavior.
+- **PR2 — panel registry + `PanelManifest`** (declarative panel descriptors beside the view classes;
+  the prerequisite for the L3 panel-layout editor).
+- **PR3 — control-API `GET /control/manifest` read + `dashboard.json` export + scanner-vs-ledger
+  reconciliation drift guard** (AST becomes drift-detection).
+- **PR4 — the panel-layout editor (H / L3 "move buttons")** the spine unblocks.
+
+Full plan: `docs/planning/manifest-spine-execution-plan-2026-06-17.md`.
+
+## What shipped
+
+(filled in as the work lands)

--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -1147,6 +1147,22 @@ async def main() -> None:
 
                 startup_outcome.record_failure("command_surface_ledger", exc)
 
+            # Manifest spine slice 1 — project the just-built ledger into the
+            # typed, bot-owned CommandManifest (the reliable read artifact for
+            # command management; AST stays drift-detection only). Reuses the
+            # cached ledger, so no second surface walk. Non-fatal: a failure
+            # only means `!platform` reports the manifest as not-built.
+            try:
+                from core.runtime import command_manifest, startup_outcome
+
+                command_manifest.build_and_cache_from_bot(bot)
+                startup_outcome.record_success("command_manifest")
+            except Exception as exc:
+                logger.warning("Command manifest build skipped: %s", exc)
+                from core.runtime import startup_outcome
+
+                startup_outcome.record_failure("command_manifest", exc)
+
             # Command description catalog — enriches the ledger with
             # description / signature / display_name so the AI cog can
             # answer meta-questions accurately. Per-command exception

--- a/disbot/core/runtime/command_manifest.py
+++ b/disbot/core/runtime/command_manifest.py
@@ -1,0 +1,272 @@
+"""Command manifest — slice 1 of the dashboard manifest spine (Q-0162).
+
+A typed, bot-owned projection of the live command surface, built **at
+startup from the cached** :class:`core.runtime.command_surface_ledger.CommandSurfaceLedger`
+— not from an AST scan. The vision doc (``docs/planning/dashboard-vision-finalized-state.md``
+§ "The manifest spine") makes the manifest the reliable read artifact for
+command management and demotes the AST scanner to a drift-detection layer.
+
+This slice ships the **commands half** only. It composes the ledger (no
+duplicate surface walk) into the finalized #998 command schema and exports
+it via :meth:`CommandManifest.to_dict`. Fields that need later slices —
+``source`` (file/line, needs the AST join), ``panels`` / ``actions`` (need
+the panel registry, PR2), ``related_settings`` / ``capability_required``
+(need the ``SettingSpec`` / capability bindings) — are present in the schema
+but deferred (empty / ``None``) with documented TODOs so the shape is stable
+as the spine grows.
+
+Public surface (mirrors the ledger's builder-driven + cached pattern):
+
+    CommandManifestEntry      — frozen dataclass per command
+    CommandManifest           — frozen aggregate (envelope + entries)
+    MANIFEST_VERSION          — schema version int
+    build_command_manifest(ledger) — pure projection over a ledger
+    build_and_cache(ledger)        — project + cache, returns the manifest
+    build_and_cache_from_bot(bot)  — build/reuse the ledger, then cache
+    get_cached_manifest()          — last-built manifest, or None
+
+Diagnostics provider name: ``"command_manifest"``.
+
+Cycle discipline: top-level imports are stdlib + the same-package ledger
+module only; ``services`` is imported function-locally (mirrors the
+ledger's ``_register_diagnostics``).
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from core.runtime.command_surface_ledger import (
+    CommandSurfaceEntry,
+    CommandSurfaceLedger,
+)
+
+logger = logging.getLogger("bot.runtime.command_manifest")
+
+# Schema version — bump when the exported shape changes (consumers gate
+# on this). Matches the ``"version": 1`` envelope in the #998 schema.
+MANIFEST_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CommandManifestEntry:
+    """One command entrypoint, projected from a ``CommandSurfaceEntry``.
+
+    Carries every field the ledger already knows; the deferred fields
+    (``source`` / ``panels`` / ``actions`` / ``related_settings`` /
+    ``capability_required``) are reserved for later spine slices and stay
+    at their empty defaults until then.
+    """
+
+    qualified_name: str
+    kind: str  # "prefix" | "slash"
+    cog: str
+    subsystem: str | None
+    classification: str
+    classification_declared: bool
+    visibility_tier: str | None
+    aliases: tuple[str, ...]
+    discord_hidden: bool
+    # Came from the live runtime ledger walk (vs an AST guess).
+    runtime_verified: bool = True
+    # --- Deferred to later slices (shape pinned now, populated later) ---
+    # PR3 — joined from the AST scanner (file/line provenance).
+    source: dict[str, Any] | None = None
+    # PR2 — populated from the panel registry.
+    panels: tuple[str, ...] = ()
+    actions: tuple[str, ...] = ()
+    # Later — joined from SettingSpec / capability bindings.
+    related_settings: tuple[str, ...] = ()
+    capability_required: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "qualified_name": self.qualified_name,
+            "kind": self.kind,
+            "cog": self.cog,
+            "subsystem": self.subsystem,
+            "classification": self.classification,
+            "classification_declared": self.classification_declared,
+            "visibility_tier": self.visibility_tier,
+            "aliases": list(self.aliases),
+            "discord_hidden": self.discord_hidden,
+            "runtime_verified": self.runtime_verified,
+            "source": self.source,
+            "panels": list(self.panels),
+            "actions": list(self.actions),
+            "related_settings": list(self.related_settings),
+            "capability_required": self.capability_required,
+        }
+
+
+@dataclass(frozen=True)
+class CommandManifest:
+    """Typed snapshot of every command entrypoint at a point in time."""
+
+    version: int
+    generated_at: str  # ISO-8601 (tz-aware)
+    bot_build: str
+    commands: tuple[CommandManifestEntry, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "generated_at": self.generated_at,
+            "bot_build": self.bot_build,
+            "commands": [c.to_dict() for c in self.commands],
+            # Reserved (PR3) — drift findings vs the AST scanner.
+            "findings": [],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Projection
+# ---------------------------------------------------------------------------
+
+
+def _qualified_name(entry: CommandSurfaceEntry) -> str:
+    """``"group sub"`` for a child of a group, else the bare command name."""
+    if entry.parent_group:
+        return f"{entry.parent_group} {entry.name}"
+    return entry.name
+
+
+def _entry_from_ledger(entry: CommandSurfaceEntry) -> CommandManifestEntry:
+    return CommandManifestEntry(
+        qualified_name=_qualified_name(entry),
+        kind=entry.kind,
+        cog=entry.cog_name,
+        subsystem=entry.subsystem,
+        classification=entry.classification,
+        classification_declared=entry.classification_declared,
+        visibility_tier=entry.visibility_tier,
+        aliases=entry.aliases,
+        discord_hidden=entry.discord_hidden,
+        runtime_verified=True,
+    )
+
+
+def build_command_manifest(
+    ledger: CommandSurfaceLedger,
+    *,
+    bot_build: str = "",
+    now: datetime.datetime | None = None,
+) -> CommandManifest:
+    """Project a ``CommandSurfaceLedger`` into a typed ``CommandManifest``.
+
+    Pure and side-effect-free (does not touch the cache). Both prefix
+    (``ledger.entries``) and slash (``ledger.slash_entries``) routes are
+    projected, in that order. ``bot_build`` defaults to empty — a later
+    slice will source it from the deploy SHA.
+    """
+    generated_at = (now or datetime.datetime.now(datetime.timezone.utc)).isoformat()
+    commands = tuple(
+        _entry_from_ledger(e) for e in (*ledger.entries, *ledger.slash_entries)
+    )
+    return CommandManifest(
+        version=MANIFEST_VERSION,
+        generated_at=generated_at,
+        bot_build=bot_build,
+        commands=commands,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module state — cached last-built manifest
+# ---------------------------------------------------------------------------
+
+
+_CACHED: CommandManifest | None = None
+
+
+def build_and_cache(
+    ledger: CommandSurfaceLedger,
+    *,
+    bot_build: str = "",
+) -> CommandManifest:
+    """Project ``ledger`` and cache the result for diagnostics access."""
+    global _CACHED
+    manifest = build_command_manifest(ledger, bot_build=bot_build)
+    _CACHED = manifest
+    return manifest
+
+
+def build_and_cache_from_bot(bot: object, *, bot_build: str = "") -> CommandManifest:
+    """Build (or reuse) the command ledger, then project + cache the manifest.
+
+    Prefers the already-cached ledger (the startup path builds it just
+    before this) and falls back to building it, so the manifest never
+    forces a second surface walk.
+    """
+    from core.runtime import command_surface_ledger
+
+    ledger = command_surface_ledger.get_cached_ledger()
+    if ledger is None:
+        ledger = command_surface_ledger.build_ledger(bot)
+    return build_and_cache(ledger, bot_build=bot_build)
+
+
+def get_cached_manifest() -> CommandManifest | None:
+    """The last-built manifest, or ``None`` if not built yet."""
+    return _CACHED
+
+
+def _reset_for_tests() -> None:
+    """Test helper — clear the cache."""
+    global _CACHED
+    _CACHED = None
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics provider — registers at import time
+# ---------------------------------------------------------------------------
+
+
+def _snapshot() -> dict[str, Any]:
+    """Stable diagnostics snapshot for ``!platform`` / consistency."""
+    manifest = _CACHED
+    if manifest is None:
+        return {
+            "built": False,
+            "hint": "call command_manifest.build_and_cache_from_bot(bot) after "
+            "the ledger build.",
+        }
+    by_kind: dict[str, int] = {}
+    for c in manifest.commands:
+        by_kind[c.kind] = by_kind.get(c.kind, 0) + 1
+    return {
+        "built": True,
+        "version": manifest.version,
+        "generated_at": manifest.generated_at,
+        "bot_build": manifest.bot_build,
+        "command_count": len(manifest.commands),
+        "by_kind": by_kind,
+    }
+
+
+def _register_diagnostics() -> None:
+    from services import diagnostics_service
+
+    diagnostics_service.register("command_manifest", _snapshot)
+
+
+_register_diagnostics()
+
+
+__all__ = [
+    "MANIFEST_VERSION",
+    "CommandManifest",
+    "CommandManifestEntry",
+    "build_and_cache",
+    "build_and_cache_from_bot",
+    "build_command_manifest",
+    "get_cached_manifest",
+]

--- a/disbot/core/runtime/startup_outcome.py
+++ b/disbot/core/runtime/startup_outcome.py
@@ -49,6 +49,7 @@ from typing import Any
 # orchestrator never reached the recorder.
 KNOWN_PHASES: tuple[str, ...] = (
     "command_surface_ledger",
+    "command_manifest",
     "settings_registry",
     "customization_catalogue",
     "resource_provisioning_catalogue",

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -207,6 +207,16 @@ Source code and merged PRs win over anything written here.
 > auto-opens a `reconcile` issue at the boundary that fires the docs-reconciliation routine). Reset
 > this marker to the latest PR after a pass.
 
+- **#1018 (2026-06-17, manifest spine slice 1 — typed CommandManifest over the ledger)** — same
+  dispatch fire as #1017 (continuation). Started the **manifest spine** — the dashboard vision doc's
+  "key structural investment," owner-approved (Q-0162), Phase-E predecessor shipped (#1013), schema
+  finalized (#998). `core/runtime/command_manifest.py` projects the cached `CommandSurfaceLedger`
+  into the typed #998 command schema (no second surface walk), built+cached at startup, surfaced as a
+  `command_manifest` diagnostics provider, with the manifest-faithfully-projects-ledger CI invariant
+  (the first reconciliation test that makes the metadata trustworthy). AST stays drift-detection only.
+  Deferred fields (source/panels/actions/related_settings/capability_required) are shape-pinned but
+  empty. **Next: PR2** panel registry + `PanelManifest` (the L3 panel-editor prerequisite) — sequenced
+  in [`manifest-spine-execution-plan-2026-06-17.md`](planning/manifest-spine-execution-plan-2026-06-17.md).
 - **#1017 (2026-06-17, settings global tier — per-guild → global → default)** — scheduled dispatch,
   empty work order → advanced the active dashboard thread's next *ungated runtime* slice (the
   live-editor plan's settings-editor phase ②, the owner's "change things globally" ask).

--- a/docs/planning/dashboard-vision-finalized-state.md
+++ b/docs/planning/dashboard-vision-finalized-state.md
@@ -418,7 +418,9 @@ decided at their build phase, per the two execution plans' own open-questions se
 
 - Execution plans (authoritative for *what to build next*):
   [`developer-dashboard-plan.md`](developer-dashboard-plan.md) ·
-  [`dashboard-live-editor-plan.md`](dashboard-live-editor-plan.md)
+  [`dashboard-live-editor-plan.md`](dashboard-live-editor-plan.md) ·
+  [`manifest-spine-execution-plan-2026-06-17.md`](manifest-spine-execution-plan-2026-06-17.md)
+  (the Q-0162 manifest spine, sequenced — PR1 `CommandManifest` shipped #1018)
 - Owner decisions: router **Q-0155–Q-0160** (`docs/owner/maintainer-question-router.md`) and the new
   **Q-0162** + **Q-0163** (the question-panel decisions — see § "Decisions (owner question-panel,
   2026-06-16)").

--- a/docs/planning/manifest-spine-execution-plan-2026-06-17.md
+++ b/docs/planning/manifest-spine-execution-plan-2026-06-17.md
@@ -1,0 +1,67 @@
+# Manifest spine — execution plan (2026-06-17)
+
+> **Status:** `plan` — sequences the **owner-approved** (Q-0162: *"Build it"*) manifest spine into
+> modular, buildable PRs. The destination + schema are finalized in
+> [`dashboard-vision-finalized-state.md`](dashboard-vision-finalized-state.md) § "The manifest spine"
+> (synthesizing the owner's deep-research report + Codex #998); this doc is the *how/when*, not the
+> *what*. Where they differ on shape, the vision doc wins.
+
+## Why a spine (the decided rationale)
+
+Command/panel metadata today comes from an AST scan (`scripts/scan_commands.py`) — fine for read-only
+docs, fragile for *management*: it answers "does this *look* like a panel command?" not "*which*
+button, in *which* panel, backing *which* command, with *what* authority?". The runtime already holds a
+richer truth in `core/runtime/command_surface_ledger.py` (classification, visibility tier, aliases,
+declared-ness). The finalized answer: a **typed, bot-owned manifest built at startup** from runtime
+registrations + classifications + (later) panel registry + schema bindings, with the AST demoted to a
+**drift-detection layer**. The manifest gates *command-management trustworthiness* and the panel editor
+(H) — not the settings/help/routing editors, which ride already-typed seams (reviewer note R2, Q-0162).
+
+## Sequenced PRs (modular, not over-segmented)
+
+### PR1 — `CommandManifest` over the ledger ✅ SHIPPED (#1018)
+
+`core/runtime/command_manifest.py` projects the cached `CommandSurfaceLedger` into the typed #998
+command schema (`qualified_name`, `kind`, `cog`, `subsystem`, `classification` +
+`classification_declared`, `visibility_tier`, `aliases`, `discord_hidden`, `runtime_verified`), with a
+`to_dict()` export, startup caching (mirrors the ledger), a `command_manifest` diagnostics provider,
+and the **manifest-faithfully-projects-ledger** CI invariant (the first of the vision doc's
+reconciliation tests). Deferred fields (`source`, `panels`, `actions`, `related_settings`,
+`capability_required`) are present-but-empty so the shape is stable as the spine grows.
+
+### PR2 — panel registry + `PanelManifest`
+
+Declarative panel descriptors **beside the view classes** (`panel_id`, `view_class`, `buttons[]` with
+`action_id`/`custom_id`/`label`/`row`/`command`), built into a typed `PanelManifest`. This is "the
+first half of the L3 move-buttons work" and the prerequisite for *any* reliable panel-layout editor.
+Back-populates `CommandManifestEntry.panels` / `.actions`. Add the panel-registry-vs-view-classes
+reconciliation test (custom IDs match real components).
+
+### PR3 — control-API `manifest` read + `dashboard.json` export + AST drift guard
+
+- `GET /control/manifest` on the dormant control API (admin-gated, mirrors the Phase E read endpoints
+  shipped in #1013) serving `CommandManifest.to_dict()` (+ `PanelManifest`).
+- Generate the manifest into the committed `dashboard/data/dashboard.json` export (via a scanner/export
+  script), so the decoupled site reads the bot's truth.
+- The **scanner-vs-ledger / committed-export-vs-fresh-export** reconciliation drift guards (CI) that
+  make AST a drift-detection layer rather than a source of truth.
+- Join `source` (file/line) from the AST scanner; join `related_settings` / `capability_required` from
+  `SettingSpec` / capability bindings.
+
+### PR4 — the panel-layout editor (H / L3 "move buttons")
+
+The DB-backed panel-layout overlay + the website editor the spine unblocks (the second half of L3).
+Owner-paced like the other control-API *write* surfaces (needs the `CONTROL_API_TOKEN`); plan
+separately once PR2–PR3 land.
+
+## Verification (every slice)
+
+`python3.10 scripts/check_quality.py --full` green · `check_architecture --mode strict` 0 errors ·
+the new reconciliation test for that slice fails against pre-change behavior.
+
+## Notes / open follow-ups
+
+- `bot_build` in the manifest envelope is empty in PR1 — PR3 should source it from the deploy SHA
+  (`RAILWAY_GIT_COMMIT_SHA`) so the export is cache-bustable / freshness-badged.
+- The manifest reuses the **cached** ledger (no second surface walk); PR2's panel registry should
+  likewise compose, not re-walk.

--- a/docs/smoke-test-checklist.md
+++ b/docs/smoke-test-checklist.md
@@ -61,6 +61,7 @@ Inspect `!platform consistency` and the readiness snapshot's
 Inspect the readiness snapshot's `startup_outcomes`:
 
 - [ ] **`command_surface_ledger`** outcome.success == True
+- [ ] **`command_manifest`** outcome.success == True
 - [ ] **`settings_registry`** outcome.success == True
 - [ ] **`customization_catalogue`** outcome.success == True
 - [ ] **`resource_provisioning_catalogue`** outcome.success == True

--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -56,6 +56,7 @@ GLOBAL_RESET_HOOKS: tuple[tuple[str, str], ...] = (
     ("core.runtime.command_descriptions", "_reset_for_tests"),
     ("core.runtime.settings_registry", "_reset_for_tests"),
     ("core.runtime.command_surface_ledger", "_reset_for_tests"),
+    ("core.runtime.command_manifest", "_reset_for_tests"),
     ("core.runtime.guild_config", "_reset_for_tests"),
     ("core.runtime.user_config", "_reset_for_tests"),
     ("core.runtime.scope_locks", "_reset_for_tests"),

--- a/tests/unit/runtime/test_command_manifest.py
+++ b/tests/unit/runtime/test_command_manifest.py
@@ -1,0 +1,204 @@
+"""Unit tests for core.runtime.command_manifest — manifest spine slice 1.
+
+The manifest is a pure projection of the CommandSurfaceLedger, so these
+tests construct a ledger fixture directly (the ledger is a frozen
+aggregate) and pin: faithful projection (count parity, qualified_name
+composition, field mapping), the to_dict() export shape, the cache
+round-trip, and the diagnostics provider — the first "reconciliation
+test that makes the metadata trustworthy."
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from core.runtime import command_manifest as cm
+from core.runtime.command_surface_ledger import (
+    CommandSurfaceEntry,
+    CommandSurfaceLedger,
+    LedgerFindings,
+)
+
+
+def _e(name: str, cog: str, subsystem: str | None, **kw) -> CommandSurfaceEntry:
+    """CommandSurfaceEntry with visibility_tier defaulted (it's positional)."""
+    kw.setdefault("visibility_tier", None)
+    return CommandSurfaceEntry(name=name, cog_name=cog, subsystem=subsystem, **kw)
+
+
+def _ledger(
+    entries: tuple[CommandSurfaceEntry, ...],
+    slash: tuple[CommandSurfaceEntry, ...] = (),
+) -> CommandSurfaceLedger:
+    return CommandSurfaceLedger(
+        version=1,
+        built_at=datetime.datetime(2026, 6, 17, tzinfo=datetime.timezone.utc),
+        entries=entries,
+        router_prefixes=(),
+        findings=LedgerFindings(),
+        slash_entries=slash,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    cm._reset_for_tests()
+    yield
+    cm._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Faithful projection of the ledger
+# ---------------------------------------------------------------------------
+
+
+def test_projects_every_ledger_entry_exactly_once():
+    ledger = _ledger(
+        entries=(
+            _e("warn", "ModCog", "moderation"),
+            _e("xp", "XPCog", "xp"),
+        ),
+        slash=(
+            _e("ping", "CoreCog", None, kind="slash"),
+        ),
+    )
+    manifest = cm.build_command_manifest(ledger)
+    # Count parity: prefix entries + slash entries, no more, no fewer.
+    assert len(manifest.commands) == 3
+    names = [c.qualified_name for c in manifest.commands]
+    assert names == ["warn", "xp", "ping"]  # prefix first, then slash
+
+
+def test_qualified_name_composes_parent_group():
+    ledger = _ledger(
+        entries=(
+            _e("set", "SettingsCog", "settings", parent_group="settings"),
+            _e("standalone", "XPCog", "xp"),
+        ),
+    )
+    manifest = cm.build_command_manifest(ledger)
+    quals = {c.qualified_name for c in manifest.commands}
+    assert quals == {"settings set", "standalone"}
+
+
+def test_field_mapping_from_ledger_entry():
+    entry = CommandSurfaceEntry(
+        name="warn",
+        cog_name="ModCog",
+        subsystem="moderation",
+        visibility_tier="moderator",
+        aliases=("w", "warning"),
+        kind="prefix",
+        classification="primary_entrypoint",
+        classification_declared=True,
+        discord_hidden=False,
+    )
+    manifest = cm.build_command_manifest(_ledger((entry,)))
+    c = manifest.commands[0]
+    assert c.qualified_name == "warn"
+    assert c.kind == "prefix"
+    assert c.cog == "ModCog"
+    assert c.subsystem == "moderation"
+    assert c.visibility_tier == "moderator"
+    assert c.aliases == ("w", "warning")
+    assert c.classification == "primary_entrypoint"
+    assert c.classification_declared is True
+    assert c.discord_hidden is False
+    assert c.runtime_verified is True
+    # Deferred fields stay at their empty defaults until later slices.
+    assert c.source is None
+    assert c.panels == ()
+    assert c.actions == ()
+    assert c.related_settings == ()
+    assert c.capability_required is None
+
+
+# ---------------------------------------------------------------------------
+# Envelope + to_dict export shape
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_fields():
+    fixed = datetime.datetime(2026, 6, 17, 12, 0, tzinfo=datetime.timezone.utc)
+    manifest = cm.build_command_manifest(
+        _ledger((_e("x", "C", None),)),
+        bot_build="abc123",
+        now=fixed,
+    )
+    assert manifest.version == cm.MANIFEST_VERSION
+    assert manifest.bot_build == "abc123"
+    assert manifest.generated_at == fixed.isoformat()
+
+
+def test_to_dict_schema_shape():
+    manifest = cm.build_command_manifest(
+        _ledger(
+            (_e("warn", "ModCog", "moderation"),)
+        )
+    )
+    d = manifest.to_dict()
+    assert set(d) == {"version", "generated_at", "bot_build", "commands", "findings"}
+    assert d["findings"] == []
+    assert isinstance(d["commands"], list) and len(d["commands"]) == 1
+    cmd = d["commands"][0]
+    assert set(cmd) == {
+        "qualified_name",
+        "kind",
+        "cog",
+        "subsystem",
+        "classification",
+        "classification_declared",
+        "visibility_tier",
+        "aliases",
+        "discord_hidden",
+        "runtime_verified",
+        "source",
+        "panels",
+        "actions",
+        "related_settings",
+        "capability_required",
+    }
+    assert cmd["aliases"] == []  # tuple → list for JSON
+
+
+# ---------------------------------------------------------------------------
+# Cache round-trip + diagnostics
+# ---------------------------------------------------------------------------
+
+
+def test_build_and_cache_round_trip():
+    assert cm.get_cached_manifest() is None
+    ledger = _ledger((_e("x", "C", None),))
+    built = cm.build_and_cache(ledger)
+    assert cm.get_cached_manifest() is built
+    assert len(built.commands) == 1
+
+
+def test_diagnostics_snapshot_not_built():
+    from services import diagnostics_service
+
+    assert "command_manifest" in diagnostics_service.registered_names()
+    snap = diagnostics_service.snapshot("command_manifest")
+    assert snap["built"] is False
+
+
+def test_diagnostics_snapshot_built():
+    from services import diagnostics_service
+
+    cm.build_and_cache(
+        _ledger(
+            entries=(
+                _e("warn", "ModCog", "mod"),
+            ),
+            slash=(
+                _e("ping", "C", None, kind="slash"),
+            ),
+        )
+    )
+    snap = diagnostics_service.snapshot("command_manifest")
+    assert snap["built"] is True
+    assert snap["command_count"] == 2
+    assert snap["by_kind"] == {"prefix": 1, "slash": 1}
+    assert snap["version"] == cm.MANIFEST_VERSION


### PR DESCRIPTION
## Why

Continuation of the dispatch fire that shipped the global settings tier (#1017, merged). The next
ungated, **owner-approved** lane is the **manifest spine** — the dashboard vision doc's "key
structural investment" ([`dashboard-vision-finalized-state.md`](docs/planning/dashboard-vision-finalized-state.md)
§ "The manifest spine"). It is **owner-decided BUILD IT** (Q-0162), its predecessor Phase E shipped
(#1013), and its schema is finalized (#998) — a decided architectural lane, not an ambiguous one.

Command metadata today comes from an AST scan (`scripts/scan_commands.py`) — fine for read-only docs,
fragile for management ("does this *look* like a panel command?"). The runtime already carries the
richer truth in `core/runtime/command_surface_ledger.py` (classification, visibility tier, aliases,
declared-ness). The finalized answer is a **typed, bot-owned manifest built at startup**, with the AST
demoted to drift-detection.

## What (slice 1 — the commands half, projecting the existing ledger)

- **`core/runtime/command_manifest.py`** (new) — a typed `CommandManifest` / `CommandManifestEntry`
  per the #998 schema, built as a **pure projection** of the cached `CommandSurfaceLedger` (no
  duplicate surface walk, no AST). Carries every field the ledger already knows — `qualified_name`,
  `kind`, `cog`, `subsystem`, `classification` (+ `classification_declared` as the manageability
  signal), `visibility_tier`, `aliases`, `discord_hidden`, `runtime_verified=True` — plus a
  `to_dict()` export matching the schema envelope (`version` / `generated_at` / `bot_build` /
  `commands`). Fields needing later slices (`source` file/line, `panels`/`actions`, `related_settings`,
  `capability_required`) are present-but-deferred with documented TODOs.
- **Startup wiring (`bot1.py`)** — right after the ledger build, the manifest is built + cached from
  the cached ledger (non-fatal, `startup_outcome`-tracked, mirrors the ledger exactly).
- **Diagnostics** — a `command_manifest` provider (`!platform`), mirroring the ledger's, so an
  operator can inspect the manifest immediately (real consumer, not inert scaffolding).
- **CI invariant** — `test_command_manifest.py` pins **manifest-faithfully-projects-ledger** (count
  parity, `qualified_name` composition, field mapping, `to_dict()` schema shape, cache round-trip,
  diagnostics snapshot). This is the first of the vision doc's "reconciliation tests that make the
  metadata trustworthy."

Additive (new module + tests), offline-testable (the ledger is a frozen aggregate constructed
directly in fixtures), and changes **no** existing behavior.

## The sequenced rest (modular, in the plan)

[`docs/planning/manifest-spine-execution-plan-2026-06-17.md`](docs/planning/manifest-spine-execution-plan-2026-06-17.md):
**PR2** panel registry + `PanelManifest` (the L3 panel-editor prerequisite) · **PR3** control-API
`GET /control/manifest` read + `dashboard.json` export + scanner-vs-ledger drift guard (AST →
drift-detection) · **PR4** the panel-layout editor (H) the spine unblocks.

## Review

Self-merge on green (Q-0113) — additive, reversible, behavior-neutral, owner-approved lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016KtqmXE9GA5GkJR5L3ZYTc)_