### PR TITLE
feat(manifest-spine): PR2 — panel registry + PanelManifest (Q-0162)

### DIFF
--- a/.sessions/2026-06-17-manifest-spine-pr2-panel-registry.md
+++ b/.sessions/2026-06-17-manifest-spine-pr2-panel-registry.md
@@ -1,0 +1,28 @@
+# 2026-06-17 — Manifest spine PR2: panel registry + PanelManifest
+
+> **Status:** `in-progress`
+
+## What I'm about to do
+
+Scheduled dispatch fire, empty work order → advance the live active thread. The
+**manifest spine** (Q-0162, owner-approved) shipped PR1 (`CommandManifest`, #1018);
+`current-state.md` + the execution plan name **PR2 — panel registry + `PanelManifest`**
+as the next slice (the L3 panel-editor prerequisite). Both open PRs (#941, #929) are
+`needs-hermes-review`-gated; no claim on the manifest lane.
+
+Building (CLASS: feature, dispatched → no phase gate; ungated, read-only metadata):
+
+- `core/runtime/panel_manifest.py` — typed, bot-owned `PanelManifest` built **at
+  startup from the persistent-view registry** (the runtime-truth source, mirroring how
+  PR1 built `CommandManifest` from the ledger, not AST). One `PanelManifestEntry` per
+  registered `PersistentView`, `PanelButton[]` introspected from the real components
+  (`action_id`/`custom_id`/`label`/`row`/`command`).
+- `core/runtime/persistent_views.py` — additive: declarative `PANEL_ID` class var +
+  faithful ordered enumeration (`iter_registered_view_classes`) so the two `help`
+  panels (collapsed in the subsystem-keyed recovery dict) both appear.
+- Back-populate `CommandManifestEntry.panels` by subsystem join (actions stay deferred
+  — no declared button→command binding yet; honesty over fabrication).
+- Wire into `bot1.py` startup; `panel_manifest` diagnostics provider + startup_outcome.
+- Reconciliation test: panel registry vs view classes / custom IDs.
+
+`check_quality --full` + `check_architecture --mode strict` green before flip to ready.

--- a/.sessions/2026-06-17-manifest-spine-pr2-panel-registry.md
+++ b/.sessions/2026-06-17-manifest-spine-pr2-panel-registry.md
@@ -1,28 +1,116 @@
 # 2026-06-17 — Manifest spine PR2: panel registry + PanelManifest
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-## What I'm about to do
+## Arc
 
-Scheduled dispatch fire, empty work order → advance the live active thread. The
-**manifest spine** (Q-0162, owner-approved) shipped PR1 (`CommandManifest`, #1018);
-`current-state.md` + the execution plan name **PR2 — panel registry + `PanelManifest`**
-as the next slice (the L3 panel-editor prerequisite). Both open PRs (#941, #929) are
-`needs-hermes-review`-gated; no claim on the manifest lane.
+Scheduled dispatch fire, **empty work order**. The night queue + BTD6-floor lane
+are consumed/thinning and both open PRs (#941, #929) are `needs-hermes-review`-gated.
+The live active thread is the **manifest spine** (Q-0162, owner-approved): PR1
+(`CommandManifest`) shipped #1018, and `current-state.md` + the execution plan both
+named **PR2 — panel registry + `PanelManifest`** as the next slice (the L3
+panel-editor prerequisite). No claim on the lane → took it. Shipped as PR #1019.
 
-Building (CLASS: feature, dispatched → no phase gate; ungated, read-only metadata):
+## Shipped (PR #1019)
 
-- `core/runtime/panel_manifest.py` — typed, bot-owned `PanelManifest` built **at
-  startup from the persistent-view registry** (the runtime-truth source, mirroring how
-  PR1 built `CommandManifest` from the ledger, not AST). One `PanelManifestEntry` per
-  registered `PersistentView`, `PanelButton[]` introspected from the real components
-  (`action_id`/`custom_id`/`label`/`row`/`command`).
-- `core/runtime/persistent_views.py` — additive: declarative `PANEL_ID` class var +
-  faithful ordered enumeration (`iter_registered_view_classes`) so the two `help`
-  panels (collapsed in the subsystem-keyed recovery dict) both appear.
-- Back-populate `CommandManifestEntry.panels` by subsystem join (actions stay deferred
-  — no declared button→command binding yet; honesty over fabrication).
-- Wire into `bot1.py` startup; `panel_manifest` diagnostics provider + startup_outcome.
-- Reconciliation test: panel registry vs view classes / custom IDs.
+- **`core/runtime/panel_manifest.py`** (new) — typed `PanelManifest` /
+  `PanelManifestEntry` / `PanelButton`, built **at startup from the persistent-view
+  registry**. Design choice: the registry of `PersistentView` subclasses *is* the
+  panel registry — those are exactly the panels with stable static custom_ids that
+  survive restart (the manageable ones the L3 editor addresses). Each class is
+  instantiated arg-free and its real components introspected, so the manifest records
+  what the bot will actually render (mirrors PR1's "runtime truth, not AST"). 10
+  panels / 67 buttons live.
+- **`core/runtime/persistent_views.py`** — additive only: declarative `PANEL_ID`
+  class var (defaults to `SUBSYSTEM`) + a faithful ordered enumeration
+  (`iter_registered_view_classes`) so the **two `help` panels** — both registered
+  under subsystem `"help"`, so collapsed in the subsystem-keyed recovery dict — both
+  surface (`help:nav`, `help:categories`). Recovery behaviour unchanged.
+- **`CommandManifestEntry.panels` back-populated** by a subsystem join
+  (command.subsystem == panel.subsystem) via an optional `panels_by_subsystem` arg
+  threaded through `build_command_manifest` / `build_and_cache_from_bot`. `actions`
+  left deferred — there is no declared button→command binding yet, and the spine
+  exists to eliminate *unverified* metadata, so honesty over fabrication.
+- **Startup wiring** (`bot1.py`): panel manifest built before the command manifest
+  (so the join sees it) + `panel_manifest` `startup_outcome` phase + smoke-checklist
+  bullet. `panel_manifest` diagnostics provider.
+- **Reconciliation test** (`tests/unit/runtime/test_panel_manifest.py`, +18): the
+  vision doc's "panel registry vs view classes / custom IDs" check — every manifest
+  button round-trips against a fresh re-instantiation of its view class; panel_ids
+  unique; every registered class covered. +2 command-manifest join tests.
 
-`check_quality --full` + `check_architecture --mode strict` green before flip to ready.
+`check_quality --full` green (10414 passed) · `check_architecture --mode strict` 0
+errors · mypy clean.
+
+## Context delta
+
+- **Needed and had:** the execution plan's PR2 spec + PR1's shape made this turn-key —
+  I mirrored `command_manifest.py` almost structurally (frozen dataclasses, `to_dict`,
+  build/cache/diagnostics, `_reset_for_tests`, isolation-hook registration).
+- **Saved by probing first:** confirmed all registered `PersistentView`s instantiate
+  arg-free and expose static custom_ids via `view.children` *before* committing to the
+  introspection design — avoided a hand-maintained registry that would rot (the vision
+  doc explicitly warns against that).
+- **Found a latent issue:** the two `help` panels share subsystem `"help"`, so the
+  recovery dict (`get_view_class`) only returns the last-registered one
+  (`HelpCategoryView`). Not touched (anchor recovery is load-bearing + out of scope),
+  but the manifest now surfaces both, and a future slice could split the help
+  subsystem key. Flagged below.
+
+## Flagged for maintainer
+
+- **Latent (non-blocking):** `_REGISTRY` in `persistent_views.py` is keyed by
+  `SUBSYSTEM`, and the two `help` panels both use `"help"` — so `get_view_class("help")`
+  resolves to only one class (`HelpCategoryView`). Restart recovery for the other help
+  panel may rely on it being re-created fresh rather than via the registry. Worth a look
+  if help-panel restart ever misbehaves; the PanelManifest now makes the collision
+  visible. Not fixed this session (recovery seam, out of PR2 scope).
+
+## 💡 Session idea (Q-0089)
+
+The PanelManifest now knows every panel's `subsystem`; the recovery registry silently
+drops a panel when two share a subsystem (the `help` case above). A tiny invariant —
+`test_no_subsystem_owns_two_persistent_panels_without_distinct_panel_ids` *plus* a
+recovery-registry check that every registered class is reachable — would turn that
+silent collapse into a CI signal, and is the natural sibling of the reconciliation test
+shipped here. Filed under the manifest-spine reconciliation family; worth folding into
+PR3 (which already adds the AST/ledger/export drift guards).
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous run (#1018, manifest spine PR1) set this slice up almost perfectly: it
+shipped the deferred `panels`/`actions` fields *shape-pinned but empty* and wrote a
+clear "Next: PR2" pointer in both the ledger and the execution plan — so PR2 was a
+straight continuation with zero re-derivation. The one thing it left implicit was *how*
+the panel registry would be sourced (it said "panel registry" without naming the
+persistent-view registry as the source); I had to probe to confirm that was the right,
+non-rotting seam. **System improvement:** when a plan defers a field to a named future
+PR, the plan PR should also name the *source seam* it expects that PR to draw from
+(here: "PR2 sources panels from `core.runtime.persistent_views`"). I added that
+specificity to the execution plan's PR2/PR3 entries so the next slice (PR3) inherits the
+same turn-key clarity.
+
+## Doc audit (Q-0104)
+
+- Ledger: added the #1019 entry; updated the #1018 "Next: PR2" pointer to "shipped
+  #1019". Pre-existing 4-PR ledger drift (SessionStart banner) left for the
+  auto-reconciliation routine (Q-0124 — dispatch sessions don't run recon).
+- Execution plan: PR2 marked ✅ SHIPPED with the as-built note + source-seam clarity.
+- Smoke checklist: added the `panel_manifest` startup-phase bullet (CI-enforced 1:1 with
+  `KNOWN_PHASES`).
+- `check_docs` green; no new owner decisions.
+
+## 📤 Run report
+
+- **Did:** shipped manifest spine PR2 — the panel registry + typed `PanelManifest`
+  (the L3 panel-editor prerequisite) · **Outcome:** shipped
+- **Shipped:** #1019 (read-only metadata projection, no runtime behaviour change, no
+  migration — self-merge on green)
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none — auto-deploys on merge (no prod-check; read-only)
+- **↪ Next:** manifest spine **PR3** — `GET /control/manifest` read (admin-gated,
+  mirrors the Phase E reads #1013) + generate the manifest into the committed
+  `dashboard/data/dashboard.json` export + the scanner-vs-ledger / committed-vs-fresh
+  AST drift guards (makes AST a drift-detection layer). Fold in the recovery-registry
+  collision invariant (session idea above). Plan:
+  `planning/manifest-spine-execution-plan-2026-06-17.md` § PR3.

--- a/.sessions/2026-06-17-manifest-spine-pr2-panel-registry.md
+++ b/.sessions/2026-06-17-manifest-spine-pr2-panel-registry.md
@@ -51,30 +51,33 @@ errors · mypy clean.
   arg-free and expose static custom_ids via `view.children` *before* committing to the
   introspection design — avoided a hand-maintained registry that would rot (the vision
   doc explicitly warns against that).
-- **Found a latent issue:** the two `help` panels share subsystem `"help"`, so the
-  recovery dict (`get_view_class`) only returns the last-registered one
-  (`HelpCategoryView`). Not touched (anchor recovery is load-bearing + out of scope),
-  but the manifest now surfaces both, and a future slice could split the help
-  subsystem key. Flagged below.
+- **Checked a suspected collision — it's intentional:** the two `help` panels share
+  subsystem `"help"`, so the recovery dict (`get_view_class`) returns only the
+  last-registered class. I almost flagged it as a latent bug, then read the source:
+  `panels.py:352` documents it — help anchors are **skipped at restart**
+  (`message_anchor_manager.restore_anchors`), so the registration is unused for recovery
+  and the overwrite is harmless by design. The "verify against source before fixing"
+  discipline paid off; no change needed. The PanelManifest correctly surfaces *both* via
+  the new `PANEL_ID` (the manifest *describes* panels; it's not bound to the recovery
+  key).
 
 ## Flagged for maintainer
 
-- **Latent (non-blocking):** `_REGISTRY` in `persistent_views.py` is keyed by
-  `SUBSYSTEM`, and the two `help` panels both use `"help"` — so `get_view_class("help")`
-  resolves to only one class (`HelpCategoryView`). Restart recovery for the other help
-  panel may rely on it being re-created fresh rather than via the registry. Worth a look
-  if help-panel restart ever misbehaves; the PanelManifest now makes the collision
-  visible. Not fixed this session (recovery seam, out of PR2 scope).
+- None blocking. (The `help` subsystem-key overwrite looked like a bug but is
+  documented-intentional — see above.)
 
 ## 💡 Session idea (Q-0089)
 
-The PanelManifest now knows every panel's `subsystem`; the recovery registry silently
-drops a panel when two share a subsystem (the `help` case above). A tiny invariant —
-`test_no_subsystem_owns_two_persistent_panels_without_distinct_panel_ids` *plus* a
-recovery-registry check that every registered class is reachable — would turn that
-silent collapse into a CI signal, and is the natural sibling of the reconciliation test
-shipped here. Filed under the manifest-spine reconciliation family; worth folding into
-PR3 (which already adds the AST/ledger/export drift guards).
+The vision doc names the manifest's *whole reason for existing* as fixing the AST
+`button_backed` weakness — "which command does this button actually back?". PR2 ships
+both halves (commands + panels) but does not yet **cross-reconcile** them. A genuine
+next-slice invariant: reconcile the command ledger's `panel_action` *classification*
+against the PanelManifest's real button `action_id`s — every command the ledger calls a
+`panel_action` should have a matching button somewhere, and every button's eventual
+`command` binding should point at a real command. That is the test that finally makes
+"this looks like a panel command" → "this button, in this panel, backs this command"
+*verified*. Right-sized for PR3 alongside its AST/ledger/export drift guards; flagged
+there in the execution plan.
 
 ## ⟲ Previous-session review (Q-0102)
 

--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -1147,11 +1147,29 @@ async def main() -> None:
 
                 startup_outcome.record_failure("command_surface_ledger", exc)
 
+            # Manifest spine slice 2 — project the registered persistent panels
+            # into the typed PanelManifest (the L3 panel-editor's read artifact;
+            # built from the runtime registry, not an AST guess). Built BEFORE
+            # the command manifest so the latter can join each command to its
+            # subsystem's panels. Non-fatal: a failure only means `!platform`
+            # reports the panel manifest as not-built.
+            try:
+                from core.runtime import panel_manifest, startup_outcome
+
+                panel_manifest.build_and_cache()
+                startup_outcome.record_success("panel_manifest")
+            except Exception as exc:
+                logger.warning("Panel manifest build skipped: %s", exc)
+                from core.runtime import startup_outcome
+
+                startup_outcome.record_failure("panel_manifest", exc)
+
             # Manifest spine slice 1 — project the just-built ledger into the
             # typed, bot-owned CommandManifest (the reliable read artifact for
             # command management; AST stays drift-detection only). Reuses the
-            # cached ledger, so no second surface walk. Non-fatal: a failure
-            # only means `!platform` reports the manifest as not-built.
+            # cached ledger, so no second surface walk; joins the panel manifest
+            # (built just above) for each command's subsystem panels. Non-fatal:
+            # a failure only means `!platform` reports the manifest as not-built.
             try:
                 from core.runtime import command_manifest, startup_outcome
 

--- a/disbot/cogs/help/panels.py
+++ b/disbot/cogs/help/panels.py
@@ -128,6 +128,9 @@ class HelpPanelView(PersistentView):
     """
 
     SUBSYSTEM = "help"
+    # Two persistent panels share the "help" subsystem; declare distinct
+    # manifest ids (manifest spine PR2) so both surface in the PanelManifest.
+    PANEL_ID = "help:nav"
 
     def __init__(
         self,
@@ -367,6 +370,8 @@ class HelpCategoryView(PersistentView):
     """
 
     SUBSYSTEM = "help"
+    # Sibling of HelpPanelView under the "help" subsystem — distinct manifest id.
+    PANEL_ID = "help:categories"
 
     def __init__(
         self,

--- a/disbot/core/runtime/command_manifest.py
+++ b/disbot/core/runtime/command_manifest.py
@@ -139,7 +139,11 @@ def _qualified_name(entry: CommandSurfaceEntry) -> str:
     return entry.name
 
 
-def _entry_from_ledger(entry: CommandSurfaceEntry) -> CommandManifestEntry:
+def _entry_from_ledger(
+    entry: CommandSurfaceEntry,
+    *,
+    panels: tuple[str, ...] = (),
+) -> CommandManifestEntry:
     return CommandManifestEntry(
         qualified_name=_qualified_name(entry),
         kind=entry.kind,
@@ -151,6 +155,7 @@ def _entry_from_ledger(entry: CommandSurfaceEntry) -> CommandManifestEntry:
         aliases=entry.aliases,
         discord_hidden=entry.discord_hidden,
         runtime_verified=True,
+        panels=panels,
     )
 
 
@@ -159,6 +164,7 @@ def build_command_manifest(
     *,
     bot_build: str = "",
     now: datetime.datetime | None = None,
+    panels_by_subsystem: dict[str, tuple[str, ...]] | None = None,
 ) -> CommandManifest:
     """Project a ``CommandSurfaceLedger`` into a typed ``CommandManifest``.
 
@@ -166,10 +172,18 @@ def build_command_manifest(
     (``ledger.entries``) and slash (``ledger.slash_entries``) routes are
     projected, in that order. ``bot_build`` defaults to empty — a later
     slice will source it from the deploy SHA.
+
+    ``panels_by_subsystem`` (manifest spine PR2) is the
+    ``subsystem -> (panel_id, ...)`` map from the panel manifest: when given, a
+    command's ``panels`` is the panel ids registered under its subsystem (a
+    real, verifiable subsystem-level association). Per-button ``actions`` stay
+    deferred — there is no declared button→command binding yet.
     """
     generated_at = (now or datetime.datetime.now(datetime.timezone.utc)).isoformat()
+    pmap = panels_by_subsystem or {}
     commands = tuple(
-        _entry_from_ledger(e) for e in (*ledger.entries, *ledger.slash_entries)
+        _entry_from_ledger(e, panels=pmap.get(e.subsystem or "", ()))
+        for e in (*ledger.entries, *ledger.slash_entries)
     )
     return CommandManifest(
         version=MANIFEST_VERSION,
@@ -191,10 +205,15 @@ def build_and_cache(
     ledger: CommandSurfaceLedger,
     *,
     bot_build: str = "",
+    panels_by_subsystem: dict[str, tuple[str, ...]] | None = None,
 ) -> CommandManifest:
     """Project ``ledger`` and cache the result for diagnostics access."""
     global _CACHED
-    manifest = build_command_manifest(ledger, bot_build=bot_build)
+    manifest = build_command_manifest(
+        ledger,
+        bot_build=bot_build,
+        panels_by_subsystem=panels_by_subsystem,
+    )
     _CACHED = manifest
     return manifest
 
@@ -204,14 +223,18 @@ def build_and_cache_from_bot(bot: object, *, bot_build: str = "") -> CommandMani
 
     Prefers the already-cached ledger (the startup path builds it just
     before this) and falls back to building it, so the manifest never
-    forces a second surface walk.
+    forces a second surface walk. When the panel manifest has been built
+    (startup builds it first), its ``subsystem -> panel_ids`` map is joined
+    in so each command carries its subsystem's ``panels``.
     """
-    from core.runtime import command_surface_ledger
+    from core.runtime import command_surface_ledger, panel_manifest
 
     ledger = command_surface_ledger.get_cached_ledger()
     if ledger is None:
         ledger = command_surface_ledger.build_ledger(bot)
-    return build_and_cache(ledger, bot_build=bot_build)
+    pmf = panel_manifest.get_cached_manifest()
+    pmap = panel_manifest.panels_by_subsystem(pmf) if pmf is not None else None
+    return build_and_cache(ledger, bot_build=bot_build, panels_by_subsystem=pmap)
 
 
 def get_cached_manifest() -> CommandManifest | None:

--- a/disbot/core/runtime/panel_manifest.py
+++ b/disbot/core/runtime/panel_manifest.py
@@ -1,0 +1,298 @@
+"""Panel manifest — slice 2 of the dashboard manifest spine (Q-0162).
+
+A typed, bot-owned projection of the live **persistent panels** — the Discord
+UI views that survive restart (`core.runtime.persistent_views`) and therefore
+carry stable, static ``custom_id``s. These are exactly the manageable panels
+the panel-layout editor (track H / L3 "move buttons") needs to address.
+
+Like the command manifest (PR1), this is built **at startup from the runtime
+registry** — not from an AST guess. Each registered ``PersistentView`` class is
+instantiated arg-free and its real components are introspected, so the manifest
+records what the bot will actually render (the "custom IDs match real
+components" reconciliation property). The AST scanner stays a drift-detection
+layer (PR3), never the source of truth.
+
+This slice ships the panel half. The vision doc
+(``docs/planning/dashboard-vision-finalized-state.md`` § "The manifest spine")
+also has it back-populate ``CommandManifestEntry.panels`` by subsystem — done in
+``command_manifest`` via the cached panel manifest. Fields that need later
+slices — each button's ``command`` (no declared button→command binding yet) and
+the panel ``source`` (file/line, needs the AST join, PR3) — are present in the
+schema but deferred (``None``) so the shape is stable as the spine grows.
+
+Public surface (mirrors the command manifest):
+
+    PanelButton                — frozen dataclass per addressable component
+    PanelManifestEntry         — frozen dataclass per persistent panel
+    PanelManifest              — frozen aggregate (envelope + entries)
+    PANEL_MANIFEST_VERSION     — schema version int
+    build_panel_manifest(...)  — pure projection over view classes
+    build_and_cache(...)       — project + cache, returns the manifest
+    get_cached_manifest()      — last-built manifest, or None
+    panels_by_subsystem(...)   — subsystem → (panel_id, ...) join helper
+
+Diagnostics provider name: ``"panel_manifest"``.
+
+Cycle discipline: top-level imports are stdlib + the same-package
+``persistent_views`` module only; ``services`` is imported function-locally
+(mirrors the ledger / command-manifest pattern).
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from core.runtime.persistent_views import (
+    PersistentView,
+    iter_registered_view_classes,
+    panel_id_of,
+)
+
+logger = logging.getLogger("bot.runtime.panel_manifest")
+
+# Schema version — bump when the exported shape changes (consumers gate on it).
+PANEL_MANIFEST_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PanelButton:
+    """One addressable component (button / select) on a persistent panel.
+
+    ``action_id`` is the logical action id; ``custom_id`` is the Discord
+    component id. They are identical today (custom_ids are fully static) — the
+    field is kept distinct so a future dynamic-suffix custom_id can still expose
+    a stable logical action. ``command`` (which command this action invokes) is
+    deferred: there is no declared button→command binding yet, and the manifest
+    spine exists to eliminate *unverified* metadata, so it stays ``None`` rather
+    than be guessed.
+    """
+
+    action_id: str
+    custom_id: str
+    label: str | None
+    row: int | None
+    # Deferred — populated when a button→command binding is declared.
+    command: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action_id": self.action_id,
+            "custom_id": self.custom_id,
+            "label": self.label,
+            "row": self.row,
+            "command": self.command,
+        }
+
+
+@dataclass(frozen=True)
+class PanelManifestEntry:
+    """One persistent panel, projected from its registered view class."""
+
+    panel_id: str
+    view_class: str
+    subsystem: str
+    # "hardcoded" now; PR4's DB overlay introduces "db_overlay".
+    layout_source: str = "hardcoded"
+    # PR3 — joined from the AST scanner (file/line provenance).
+    source: dict[str, Any] | None = None
+    buttons: tuple[PanelButton, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "panel_id": self.panel_id,
+            "view_class": self.view_class,
+            "subsystem": self.subsystem,
+            "layout_source": self.layout_source,
+            "source": self.source,
+            "buttons": [b.to_dict() for b in self.buttons],
+        }
+
+
+@dataclass(frozen=True)
+class PanelManifest:
+    """Typed snapshot of every persistent panel at a point in time."""
+
+    version: int
+    generated_at: str  # ISO-8601 (tz-aware)
+    panels: tuple[PanelManifestEntry, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "generated_at": self.generated_at,
+            "panels": [p.to_dict() for p in self.panels],
+            # Reserved (PR3) — drift findings vs the AST scanner.
+            "findings": [],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Projection
+# ---------------------------------------------------------------------------
+
+
+def _button_from_component(item: Any) -> PanelButton | None:
+    """Project a discord.ui component into a ``PanelButton``, or ``None``.
+
+    Only components carrying a static ``custom_id`` are addressable panel
+    actions (buttons and registered selects); URL buttons and id-less items
+    are skipped.
+    """
+    custom_id = getattr(item, "custom_id", None)
+    if not custom_id:
+        return None
+    label = getattr(item, "label", None)
+    row = getattr(item, "row", None)
+    return PanelButton(
+        action_id=custom_id,
+        custom_id=custom_id,
+        label=label,
+        row=row,
+    )
+
+
+def _entry_from_view_class(cls: type[PersistentView]) -> PanelManifestEntry:
+    """Instantiate *cls* arg-free and introspect its real components.
+
+    Buttons are recorded in component order (the order discord.py renders /
+    the editor reorders); this is the faithful runtime view, not an AST guess.
+    """
+    view = cls()
+    buttons = tuple(
+        b for b in (_button_from_component(c) for c in view.children) if b is not None
+    )
+    return PanelManifestEntry(
+        panel_id=panel_id_of(cls),
+        view_class=cls.__name__,
+        subsystem=cls.SUBSYSTEM,
+        buttons=buttons,
+    )
+
+
+def build_panel_manifest(
+    view_classes: tuple[type[PersistentView], ...] | None = None,
+    *,
+    now: datetime.datetime | None = None,
+) -> PanelManifest:
+    """Project the registered persistent-view classes into a ``PanelManifest``.
+
+    Pure and side-effect-free (does not touch the cache). ``view_classes``
+    defaults to every registered class (faithful — includes both panels of a
+    subsystem that owns more than one). A class that cannot be instantiated /
+    introspected is skipped with a warning rather than failing the build, so a
+    single broken panel never blocks the manifest. Entries are sorted by
+    ``panel_id`` for stable output.
+    """
+    classes = (
+        view_classes if view_classes is not None else iter_registered_view_classes()
+    )
+    generated_at = (now or datetime.datetime.now(datetime.timezone.utc)).isoformat()
+    entries: list[PanelManifestEntry] = []
+    for cls in classes:
+        try:
+            entries.append(_entry_from_view_class(cls))
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(
+                "Panel manifest: skipped %s (instantiation/introspection failed): %s",
+                getattr(cls, "__name__", cls),
+                exc,
+            )
+    entries.sort(key=lambda e: e.panel_id)
+    return PanelManifest(
+        version=PANEL_MANIFEST_VERSION,
+        generated_at=generated_at,
+        panels=tuple(entries),
+    )
+
+
+def panels_by_subsystem(manifest: PanelManifest) -> dict[str, tuple[str, ...]]:
+    """``subsystem -> (panel_id, ...)`` — the join the command manifest uses
+    to back-populate ``CommandManifestEntry.panels``.
+    """
+    out: dict[str, list[str]] = {}
+    for p in manifest.panels:
+        out.setdefault(p.subsystem, []).append(p.panel_id)
+    return {sub: tuple(sorted(ids)) for sub, ids in out.items()}
+
+
+# ---------------------------------------------------------------------------
+# Module state — cached last-built manifest
+# ---------------------------------------------------------------------------
+
+
+_CACHED: PanelManifest | None = None
+
+
+def build_and_cache(
+    view_classes: tuple[type[PersistentView], ...] | None = None,
+) -> PanelManifest:
+    """Project the registry and cache the result for diagnostics / the join."""
+    global _CACHED
+    manifest = build_panel_manifest(view_classes)
+    _CACHED = manifest
+    return manifest
+
+
+def get_cached_manifest() -> PanelManifest | None:
+    """The last-built panel manifest, or ``None`` if not built yet."""
+    return _CACHED
+
+
+def _reset_for_tests() -> None:
+    """Test helper — clear the cache."""
+    global _CACHED
+    _CACHED = None
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics provider — registers at import time
+# ---------------------------------------------------------------------------
+
+
+def _snapshot() -> dict[str, Any]:
+    """Stable diagnostics snapshot for ``!platform`` / consistency."""
+    manifest = _CACHED
+    if manifest is None:
+        return {
+            "built": False,
+            "hint": "call panel_manifest.build_and_cache() after the persistent "
+            "views are registered (startup).",
+        }
+    by_subsystem = {p.panel_id: len(p.buttons) for p in manifest.panels}
+    return {
+        "built": True,
+        "version": manifest.version,
+        "generated_at": manifest.generated_at,
+        "panel_count": len(manifest.panels),
+        "button_count": sum(len(p.buttons) for p in manifest.panels),
+        "buttons_by_panel": by_subsystem,
+    }
+
+
+def _register_diagnostics() -> None:
+    from services import diagnostics_service
+
+    diagnostics_service.register("panel_manifest", _snapshot)
+
+
+_register_diagnostics()
+
+
+__all__ = [
+    "PANEL_MANIFEST_VERSION",
+    "PanelButton",
+    "PanelManifest",
+    "PanelManifestEntry",
+    "build_and_cache",
+    "build_panel_manifest",
+    "get_cached_manifest",
+    "panels_by_subsystem",
+]

--- a/disbot/core/runtime/persistent_views.py
+++ b/disbot/core/runtime/persistent_views.py
@@ -19,6 +19,9 @@ Subclass contract:
 Public surface:
     register(cls)              — decorator/call to register a view class
     get_view_class(subsystem)  — retrieve registered class by subsystem name
+    iter_registered_view_classes() — every registered class, in registration
+                                     order (faithful; not deduped by subsystem)
+    panel_id_of(cls)           — the manifest panel id for a class
     PersistentView             — base class to extend
 """
 
@@ -28,18 +31,42 @@ from typing import ClassVar
 
 import discord
 
+# Subsystem → class, used by restart recovery (one class per subsystem anchor).
 _REGISTRY: dict[str, type[PersistentView]] = {}
+# Registration-ordered list of *every* registered class — faithful even when two
+# panels share a subsystem (the recovery dict above collapses those). The panel
+# manifest (manifest spine PR2) enumerates this so both panels surface.
+_REGISTERED_CLASSES: list[type[PersistentView]] = []
 
 
 def register(cls: type[PersistentView]) -> type[PersistentView]:
     """Register a PersistentView subclass for restart recovery."""
     _REGISTRY[cls.SUBSYSTEM] = cls
+    if cls not in _REGISTERED_CLASSES:
+        _REGISTERED_CLASSES.append(cls)
     return cls
 
 
 def get_view_class(subsystem: str) -> type[PersistentView] | None:
     """Return the registered PersistentView class for *subsystem*, or None."""
     return _REGISTRY.get(subsystem)
+
+
+def iter_registered_view_classes() -> tuple[type[PersistentView], ...]:
+    """Every registered persistent-view class, in registration order.
+
+    Unlike :func:`get_view_class` this does **not** dedupe by subsystem, so a
+    subsystem that owns more than one persistent panel (e.g. ``help``) yields
+    all of them — the faithful enumeration the panel manifest needs.
+    """
+    return tuple(_REGISTERED_CLASSES)
+
+
+def panel_id_of(cls: type[PersistentView]) -> str:
+    """The manifest panel id for *cls* — its declared ``PANEL_ID`` or the
+    ``SUBSYSTEM`` fallback (unique when a subsystem owns one panel).
+    """
+    return cls.PANEL_ID or cls.SUBSYSTEM
 
 
 class PersistentView(discord.ui.View):
@@ -51,6 +78,13 @@ class PersistentView(discord.ui.View):
     """
 
     SUBSYSTEM: ClassVar[str] = ""
+
+    # Manifest spine (PR2): the stable id this panel is addressed by in the
+    # PanelManifest / panel-layout editor. Empty ⇒ falls back to SUBSYSTEM
+    # (unique when a subsystem owns exactly one persistent panel). Set it
+    # explicitly only when a subsystem registers more than one panel (e.g.
+    # the two ``help`` panels) so each gets a distinct manifest id.
+    PANEL_ID: ClassVar[str] = ""
 
     # RC-3 / ADR-004: when the panel's anchor row is missing we cannot verify
     # ownership.  Default False keeps today's behavior (allow).  Opt in to True

--- a/disbot/core/runtime/startup_outcome.py
+++ b/disbot/core/runtime/startup_outcome.py
@@ -49,6 +49,7 @@ from typing import Any
 # orchestrator never reached the recorder.
 KNOWN_PHASES: tuple[str, ...] = (
     "command_surface_ledger",
+    "panel_manifest",
     "command_manifest",
     "settings_registry",
     "customization_catalogue",

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -215,8 +215,22 @@ Source code and merged PRs win over anything written here.
   `command_manifest` diagnostics provider, with the manifest-faithfully-projects-ledger CI invariant
   (the first reconciliation test that makes the metadata trustworthy). AST stays drift-detection only.
   Deferred fields (source/panels/actions/related_settings/capability_required) are shape-pinned but
-  empty. **Next: PR2** panel registry + `PanelManifest` (the L3 panel-editor prerequisite) — sequenced
-  in [`manifest-spine-execution-plan-2026-06-17.md`](planning/manifest-spine-execution-plan-2026-06-17.md).
+  empty. PR2 (panel registry + `PanelManifest`) shipped #1019.
+- **#1019 (2026-06-17, manifest spine PR2 — panel registry + PanelManifest)** — scheduled dispatch,
+  empty work order → advanced the manifest-spine thread (PR1 `CommandManifest` shipped #1018; the
+  execution plan + `current-state` named PR2 next; both open PRs Hermes-gated). `core/runtime/panel_manifest.py`
+  projects the **persistent-view registry** (the panels with stable static custom_ids that survive
+  restart — the manageable ones) into a typed `PanelManifest`, built **at startup from the runtime
+  registry** (mirroring PR1's runtime-truth, not AST): each `PersistentView` is instantiated arg-free
+  and its real components introspected into `PanelButton`s (`action_id`/`custom_id`/`label`/`row`;
+  `command` deferred). `persistent_views.py` gained a declarative `PANEL_ID` + faithful
+  `iter_registered_view_classes` so the two `help` panels (collapsed in the subsystem-keyed recovery
+  dict) both surface (10 panels, 67 buttons live). `CommandManifestEntry.panels` back-populated by a
+  subsystem join (`actions` deferred — no declared button→command binding). `panel_manifest` diagnostics
+  provider + startup_outcome phase. Reconciliation test round-trips every manifest button against a fresh
+  view-class instantiation. `check_quality --full` green (10414) · arch 0 · +20 tests. **Next: PR3** —
+  control-API `manifest` read + `dashboard.json` export + the AST drift guard (sequenced in
+  [`manifest-spine-execution-plan-2026-06-17.md`](planning/manifest-spine-execution-plan-2026-06-17.md)).
 - **#1017 (2026-06-17, settings global tier — per-guild → global → default)** — scheduled dispatch,
   empty work order → advanced the active dashboard thread's next *ungated runtime* slice (the
   live-editor plan's settings-editor phase ②, the owner's "change things globally" ask).

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -253,9 +253,11 @@ Source code and merged PRs win over anything written here.
   `_fetch_current_state`), and an honest **authority preview** ("what you may read / change here")
   from the authority bridge. New pure `_setup_health`/`_authority_preview` projections + two
   templates + nav/overview links. `check_quality --full` green (10408) · arch 0 · +12 dashboard
-  tests. **Dashboard ▶ next:** R3 hardening (#1014, in flight) → then the Phase D manifest spine
-  (Q-0162, gates command/panel management) + the global-settings runtime tier (Q-0157) — both their
-  own focused sessions.
+  tests. **Dashboard ▶ next:** R3 hardening shipped (#1014); the **Phase D manifest spine** (Q-0162,
+  gates command/panel management) is now the live ungated buildable thread — PR1 `CommandManifest`
+  (#1018) + PR2 panel registry/`PanelManifest` (#1019) shipped; **PR3** (control-API `manifest` read +
+  `dashboard.json` export + AST drift guard) is the next slice. The global-settings runtime tier
+  (Q-0157) stays its own owner-paced session.
 - **#1012 (2026-06-17, AI answerability floor — boss roster + per-difficulty map filter + boss
   immunity)** — scheduled dispatch fire, no work order; night queue fully consumed + both open PRs
   (#941/#929) Hermes-gated → took a fresh slice of the proven, ungated BTD6 deterministic-floor lane

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -49,6 +49,9 @@ living ledger (`docs/current-state.md`).
 
 ## Recently cleared
 
+- `claude/magical-rubin-p92toz` · manifest spine **PR2** — panel registry + `PanelManifest`
+  (`core/runtime/panel_manifest.py` + `persistent_views` PANEL_ID/enumeration + command-panel join) ·
+  2026-06-17 · **PR #1019 (auto-merge on green)**
 - `claude/inspiring-wozniak-i92q58` · dashboard **Phase E** — control-API read endpoints + see-then-change
   editor · 2026-06-17 · **PR #1013 (merged)**
 - `claude/inspiring-wozniak-i92q58` · dashboard **R3** — live-surface hardening (CSRF + rate-limiting) ·

--- a/docs/planning/manifest-spine-execution-plan-2026-06-17.md
+++ b/docs/planning/manifest-spine-execution-plan-2026-06-17.md
@@ -29,13 +29,20 @@ and the **manifest-faithfully-projects-ledger** CI invariant (the first of the v
 reconciliation tests). Deferred fields (`source`, `panels`, `actions`, `related_settings`,
 `capability_required`) are present-but-empty so the shape is stable as the spine grows.
 
-### PR2 — panel registry + `PanelManifest`
+### PR2 — panel registry + `PanelManifest` ✅ SHIPPED (#1019)
 
-Declarative panel descriptors **beside the view classes** (`panel_id`, `view_class`, `buttons[]` with
-`action_id`/`custom_id`/`label`/`row`/`command`), built into a typed `PanelManifest`. This is "the
-first half of the L3 move-buttons work" and the prerequisite for *any* reliable panel-layout editor.
-Back-populates `CommandManifestEntry.panels` / `.actions`. Add the panel-registry-vs-view-classes
-reconciliation test (custom IDs match real components).
+`core/runtime/panel_manifest.py` projects the **persistent-view registry** (the panels with stable
+static custom_ids that survive restart — exactly the manageable ones) into a typed `PanelManifest`,
+built **at startup from the runtime registry** (mirroring PR1's "runtime truth, not AST"). Each
+registered `PersistentView` is instantiated arg-free and its real components are introspected into
+`PanelButton`s (`action_id`/`custom_id`/`label`/`row`; `command` deferred — no declared button→command
+binding yet). `persistent_views.py` gained a declarative `PANEL_ID` class var + a faithful ordered
+enumeration (`iter_registered_view_classes`) so the two `help` panels (collapsed in the subsystem-keyed
+recovery dict) both surface. `CommandManifestEntry.panels` is back-populated by a subsystem join
+(`actions` stays deferred). The **panel-registry-vs-view-classes** reconciliation test
+(`tests/unit/runtime/test_panel_manifest.py`) round-trips every manifest button against a fresh
+instantiation of its view class. Deferred: per-panel `source` (file/line, PR3 AST join), `layout_source`
+flips to `db_overlay` in PR4.
 
 ### PR3 — control-API `manifest` read + `dashboard.json` export + AST drift guard
 

--- a/docs/planning/manifest-spine-execution-plan-2026-06-17.md
+++ b/docs/planning/manifest-spine-execution-plan-2026-06-17.md
@@ -54,6 +54,13 @@ flips to `db_overlay` in PR4.
   make AST a drift-detection layer rather than a source of truth.
 - Join `source` (file/line) from the AST scanner; join `related_settings` / `capability_required` from
   `SettingSpec` / capability bindings.
+- **Cross-manifest reconciliation (the manifest's core purpose):** reconcile the command ledger's
+  `panel_action` classification against the PanelManifest's real button `action_id`s — every
+  `panel_action`-classified command should map to a real button, and (once the button→command binding
+  lands) every button's `command` should point at a real command. This is the test that turns "looks
+  like a panel command" into a *verified* "this button backs this command" — the AST `button_backed`
+  weakness the spine exists to close. Source seam for PR2's panel data: `core.runtime.persistent_views`
+  (the persistent-view registry — the panels with stable static custom_ids).
 
 ### PR4 — the panel-layout editor (H / L3 "move buttons")
 

--- a/docs/smoke-test-checklist.md
+++ b/docs/smoke-test-checklist.md
@@ -61,6 +61,7 @@ Inspect `!platform consistency` and the readiness snapshot's
 Inspect the readiness snapshot's `startup_outcomes`:
 
 - [ ] **`command_surface_ledger`** outcome.success == True
+- [ ] **`panel_manifest`** outcome.success == True
 - [ ] **`command_manifest`** outcome.success == True
 - [ ] **`settings_registry`** outcome.success == True
 - [ ] **`customization_catalogue`** outcome.success == True

--- a/tests/_isolation.py
+++ b/tests/_isolation.py
@@ -57,6 +57,7 @@ GLOBAL_RESET_HOOKS: tuple[tuple[str, str], ...] = (
     ("core.runtime.settings_registry", "_reset_for_tests"),
     ("core.runtime.command_surface_ledger", "_reset_for_tests"),
     ("core.runtime.command_manifest", "_reset_for_tests"),
+    ("core.runtime.panel_manifest", "_reset_for_tests"),
     ("core.runtime.guild_config", "_reset_for_tests"),
     ("core.runtime.user_config", "_reset_for_tests"),
     ("core.runtime.scope_locks", "_reset_for_tests"),

--- a/tests/unit/runtime/test_command_manifest.py
+++ b/tests/unit/runtime/test_command_manifest.py
@@ -60,9 +60,7 @@ def test_projects_every_ledger_entry_exactly_once():
             _e("warn", "ModCog", "moderation"),
             _e("xp", "XPCog", "xp"),
         ),
-        slash=(
-            _e("ping", "CoreCog", None, kind="slash"),
-        ),
+        slash=(_e("ping", "CoreCog", None, kind="slash"),),
     )
     manifest = cm.build_command_manifest(ledger)
     # Count parity: prefix entries + slash entries, no more, no fewer.
@@ -116,6 +114,36 @@ def test_field_mapping_from_ledger_entry():
 
 
 # ---------------------------------------------------------------------------
+# Panel join (manifest spine PR2)
+# ---------------------------------------------------------------------------
+
+
+def test_panels_joined_by_subsystem():
+    ledger = _ledger(
+        entries=(
+            _e("warn", "ModCog", "moderation"),
+            _e("ask", "AICog", "ai"),
+            _e("orphan", "MiscCog", "no_panels"),
+        ),
+    )
+    pmap = {"moderation": ("moderation",), "ai": ("ai",)}
+    manifest = cm.build_command_manifest(ledger, panels_by_subsystem=pmap)
+    by_name = {c.qualified_name: c for c in manifest.commands}
+    assert by_name["warn"].panels == ("moderation",)
+    assert by_name["ask"].panels == ("ai",)
+    # A subsystem with no panel — or no subsystem at all — joins to nothing.
+    assert by_name["orphan"].panels == ()
+    # actions stays deferred (no declared button→command binding yet).
+    assert by_name["warn"].actions == ()
+
+
+def test_panels_default_empty_without_join():
+    ledger = _ledger((_e("warn", "ModCog", "moderation"),))
+    manifest = cm.build_command_manifest(ledger)
+    assert manifest.commands[0].panels == ()
+
+
+# ---------------------------------------------------------------------------
 # Envelope + to_dict export shape
 # ---------------------------------------------------------------------------
 
@@ -133,11 +161,7 @@ def test_envelope_fields():
 
 
 def test_to_dict_schema_shape():
-    manifest = cm.build_command_manifest(
-        _ledger(
-            (_e("warn", "ModCog", "moderation"),)
-        )
-    )
+    manifest = cm.build_command_manifest(_ledger((_e("warn", "ModCog", "moderation"),)))
     d = manifest.to_dict()
     assert set(d) == {"version", "generated_at", "bot_build", "commands", "findings"}
     assert d["findings"] == []
@@ -189,12 +213,8 @@ def test_diagnostics_snapshot_built():
 
     cm.build_and_cache(
         _ledger(
-            entries=(
-                _e("warn", "ModCog", "mod"),
-            ),
-            slash=(
-                _e("ping", "C", None, kind="slash"),
-            ),
+            entries=(_e("warn", "ModCog", "mod"),),
+            slash=(_e("ping", "C", None, kind="slash"),),
         )
     )
     snap = diagnostics_service.snapshot("command_manifest")

--- a/tests/unit/runtime/test_panel_manifest.py
+++ b/tests/unit/runtime/test_panel_manifest.py
@@ -1,0 +1,256 @@
+"""Unit tests for core.runtime.panel_manifest — manifest spine slice 2.
+
+The panel manifest is a pure projection of the persistent-view registry, so
+most tests build from fake ``PersistentView`` fixtures (faithful projection,
+PANEL_ID resolution, button introspection, to_dict shape, cache + diagnostics,
+the subsystem join helper).
+
+The final block is the vision doc's **"panel registry vs view classes / custom
+IDs" reconciliation test** built against the *real* registered panels: every
+button's custom_id round-trips against a fresh instantiation of the view class,
+ids are unique per panel, panel_ids are unique across the manifest, and every
+registered persistent view appears — i.e. the metadata is trustworthy.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import discord
+import pytest
+
+from core.runtime import panel_manifest as pm
+from core.runtime import persistent_views
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    pm._reset_for_tests()
+    yield
+    pm._reset_for_tests()
+
+
+# --- Fake view classes (do not touch the live registry) --------------------
+
+
+class _FakePanel(persistent_views.PersistentView):
+    SUBSYSTEM = "fake"
+
+    @discord.ui.button(label="Alpha", custom_id="fake:alpha", row=0)
+    async def alpha(self, interaction, button):  # pragma: no cover - not invoked
+        ...
+
+    @discord.ui.button(label="Beta", custom_id="fake:beta", row=1)
+    async def beta(self, interaction, button):  # pragma: no cover - not invoked
+        ...
+
+
+class _ExplicitIdPanel(persistent_views.PersistentView):
+    SUBSYSTEM = "shared"
+    PANEL_ID = "shared:secondary"
+
+    @discord.ui.button(label="Gamma", custom_id="shared:gamma")
+    async def gamma(self, interaction, button):  # pragma: no cover - not invoked
+        ...
+
+
+class _UrlButtonPanel(persistent_views.PersistentView):
+    """A panel with a URL button (no custom_id) — must be skipped."""
+
+    SUBSYSTEM = "linky"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.add_item(discord.ui.Button(label="Docs", url="https://example.com"))
+
+    @discord.ui.button(label="Keep", custom_id="linky:keep")
+    async def keep(self, interaction, button):  # pragma: no cover - not invoked
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Faithful projection
+# ---------------------------------------------------------------------------
+
+
+def test_projects_each_view_class_to_one_entry():
+    mf = pm.build_panel_manifest((_FakePanel, _ExplicitIdPanel))
+    assert len(mf.panels) == 2
+    by_id = {p.panel_id: p for p in mf.panels}
+    assert set(by_id) == {"fake", "shared:secondary"}
+    assert by_id["fake"].view_class == "_FakePanel"
+    assert by_id["fake"].subsystem == "fake"
+    assert by_id["fake"].layout_source == "hardcoded"
+    assert by_id["fake"].source is None
+
+
+def test_panel_id_falls_back_to_subsystem_and_honours_explicit():
+    mf = pm.build_panel_manifest((_FakePanel, _ExplicitIdPanel))
+    ids = {p.view_class: p.panel_id for p in mf.panels}
+    assert ids["_FakePanel"] == "fake"  # PANEL_ID empty → SUBSYSTEM
+    assert ids["_ExplicitIdPanel"] == "shared:secondary"  # explicit PANEL_ID
+
+
+def test_buttons_introspected_in_component_order():
+    mf = pm.build_panel_manifest((_FakePanel,))
+    buttons = mf.panels[0].buttons
+    assert [b.custom_id for b in buttons] == ["fake:alpha", "fake:beta"]
+    alpha = buttons[0]
+    assert alpha.action_id == alpha.custom_id == "fake:alpha"
+    assert alpha.label == "Alpha"
+    assert alpha.row == 0
+    assert alpha.command is None  # deferred — no button→command binding yet
+
+
+def test_components_without_custom_id_are_skipped():
+    mf = pm.build_panel_manifest((_UrlButtonPanel,))
+    cids = [b.custom_id for b in mf.panels[0].buttons]
+    assert cids == ["linky:keep"]  # the url button has no custom_id → skipped
+
+
+def test_entries_sorted_by_panel_id():
+    mf = pm.build_panel_manifest((_ExplicitIdPanel, _FakePanel))
+    assert [p.panel_id for p in mf.panels] == ["fake", "shared:secondary"]
+
+
+# ---------------------------------------------------------------------------
+# Envelope + to_dict shape
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_fields():
+    fixed = datetime.datetime(2026, 6, 17, 12, 0, tzinfo=datetime.timezone.utc)
+    mf = pm.build_panel_manifest((_FakePanel,), now=fixed)
+    assert mf.version == pm.PANEL_MANIFEST_VERSION
+    assert mf.generated_at == fixed.isoformat()
+
+
+def test_to_dict_schema_shape():
+    mf = pm.build_panel_manifest((_FakePanel,))
+    d = mf.to_dict()
+    assert set(d) == {"version", "generated_at", "panels", "findings"}
+    assert d["findings"] == []
+    panel = d["panels"][0]
+    assert set(panel) == {
+        "panel_id",
+        "view_class",
+        "subsystem",
+        "layout_source",
+        "source",
+        "buttons",
+    }
+    button = panel["buttons"][0]
+    assert set(button) == {"action_id", "custom_id", "label", "row", "command"}
+
+
+# ---------------------------------------------------------------------------
+# Subsystem join helper
+# ---------------------------------------------------------------------------
+
+
+def test_panels_by_subsystem_groups_and_sorts():
+    mf = pm.build_panel_manifest((_FakePanel, _ExplicitIdPanel))
+    # Two panels under one subsystem must both appear, sorted.
+    join = pm.panels_by_subsystem(mf)
+    assert join["fake"] == ("fake",)
+    assert join["shared"] == ("shared:secondary",)
+
+
+def test_panels_by_subsystem_collects_multiple_per_subsystem():
+    mf = pm.build_panel_manifest((_FakePanel, _ExplicitIdPanel, _UrlButtonPanel))
+    # Add a second panel under "fake" by reusing the subsystem on a fresh class.
+    join = pm.panels_by_subsystem(mf)
+    assert set(join) == {"fake", "shared", "linky"}
+
+
+# ---------------------------------------------------------------------------
+# Cache round-trip + diagnostics
+# ---------------------------------------------------------------------------
+
+
+def test_build_and_cache_round_trip():
+    assert pm.get_cached_manifest() is None
+    built = pm.build_and_cache((_FakePanel,))
+    assert pm.get_cached_manifest() is built
+    assert len(built.panels) == 1
+
+
+def test_diagnostics_snapshot_not_built():
+    from services import diagnostics_service
+
+    assert "panel_manifest" in diagnostics_service.registered_names()
+    snap = diagnostics_service.snapshot("panel_manifest")
+    assert snap["built"] is False
+
+
+def test_diagnostics_snapshot_built():
+    from services import diagnostics_service
+
+    pm.build_and_cache((_FakePanel, _ExplicitIdPanel))
+    snap = diagnostics_service.snapshot("panel_manifest")
+    assert snap["built"] is True
+    assert snap["panel_count"] == 2
+    assert snap["button_count"] == 3  # 2 + 1
+    assert snap["version"] == pm.PANEL_MANIFEST_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation — panel registry vs view classes / custom IDs (real registry)
+# ---------------------------------------------------------------------------
+
+
+def _real_manifest() -> pm.PanelManifest:
+    """Build from the live registry, importing the panel modules so it's
+    populated regardless of test collection order.
+    """
+    import importlib
+
+    for mod in (
+        "views.ai.panel",
+        "views.moderation.main_panel",
+        "views.economy.main_panel",
+        "views.btd6.panel",
+        "views.mining.main_panel",
+        "views.ux_lab.persistent_demo",
+        "views.server_management.hub",
+        "cogs.help.panels",
+        "cogs.role_cog",
+    ):
+        importlib.import_module(mod)
+    return pm.build_panel_manifest()
+
+
+def test_real_manifest_covers_every_registered_class():
+    mf = _real_manifest()
+    registered = {c.__name__ for c in persistent_views.iter_registered_view_classes()}
+    projected = {p.view_class for p in mf.panels}
+    # Every registered persistent view is projected (no panel dropped, including
+    # the two that share the "help" subsystem).
+    assert registered <= projected
+
+
+def test_real_panel_ids_are_unique():
+    mf = _real_manifest()
+    ids = [p.panel_id for p in mf.panels]
+    assert len(ids) == len(set(ids)), f"duplicate panel_id(s): {ids}"
+
+
+def test_real_button_custom_ids_round_trip_against_view_classes():
+    """The core reconciliation: every button recorded in the manifest matches a
+    real component on a freshly instantiated view class (no fabricated id, none
+    dropped), and custom_ids are unique within a panel.
+    """
+    mf = _real_manifest()
+    by_class = {c.__name__: c for c in persistent_views.iter_registered_view_classes()}
+    for panel in mf.panels:
+        cls = by_class[panel.view_class]
+        live_ids = [
+            getattr(c, "custom_id", None)
+            for c in cls().children
+            if getattr(c, "custom_id", None)
+        ]
+        manifest_ids = [b.custom_id for b in panel.buttons]
+        assert manifest_ids == live_ids, f"{panel.panel_id} drifted from its view"
+        assert len(manifest_ids) == len(
+            set(manifest_ids),
+        ), f"{panel.panel_id} has duplicate custom_ids"


### PR DESCRIPTION
## Why

Scheduled dispatch fire, empty work order → advance the live active thread. The **manifest spine** (Q-0162, owner-approved) shipped PR1 (`CommandManifest`, #1018); `current-state.md` + [`manifest-spine-execution-plan-2026-06-17.md`](docs/planning/manifest-spine-execution-plan-2026-06-17.md) name **PR2 — panel registry + `PanelManifest`** as the next slice (the L3 panel-editor prerequisite). Both open PRs (#941, #929) are `needs-hermes-review`-gated; no claim on the manifest lane.

## What

A typed, bot-owned `PanelManifest` built **at startup from the persistent-view registry** — the runtime-truth source, mirroring how PR1 built `CommandManifest` from the runtime ledger rather than an AST guess.

- **`core/runtime/panel_manifest.py`** (new) — `PanelButton` / `PanelManifestEntry` / `PanelManifest` frozen dataclasses + `to_dict()`; one entry per registered `PersistentView`, buttons **introspected from the real instantiated components** (`action_id`/`custom_id`/`label`/`row`/`command`). Startup-cached, `panel_manifest` diagnostics provider.
- **`core/runtime/persistent_views.py`** — additive only: declarative `PANEL_ID` class var (defaults to `SUBSYSTEM`) + a faithful ordered enumeration (`iter_registered_view_classes`) so the **two `help` panels** (collapsed in the subsystem-keyed recovery dict) both surface as distinct panels. Recovery behaviour unchanged.
- **`CommandManifestEntry.panels` back-populated** by subsystem join (command.subsystem == panel.subsystem). `actions` stays deferred — there is no declared button→command binding yet, and the spine exists to *eliminate* unverified metadata, so honesty over fabrication.
- Wired into `bot1.py` startup (after the command-surface ledger, before the command manifest, so the join sees the cached panel manifest) + `startup_outcome`.

## Reconciliation test (makes the metadata trustworthy)

`tests/unit/runtime/test_panel_manifest.py` — the "panel registry vs view classes / custom IDs" check from the vision doc: every button's `custom_id` round-trips against the real re-instantiated component, ids are unique per panel, `panel_id`s are unique across the manifest, and every registered persistent view appears.

`check_quality --full` green · `check_architecture --mode strict` 0 errors.

## Review status

`CLASS: feature`, **dispatched** (no phase gate). Read-only metadata projection, no runtime behaviour change, no migration — contained + reversible, so **self-merge on green** (not a substantial new subsystem). Next: PR3 (control-API `manifest` read + `dashboard.json` export + AST drift guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQKwYNEPCByFssA2yPquSz

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQKwYNEPCByFssA2yPquSz)_