### PR TITLE
feat(manifest): spine PR3 — control-API manifest read + cross-manifest reconciliation

### DIFF
--- a/.sessions/2026-06-17-manifest-spine-pr3-control-read-reconcile.md
+++ b/.sessions/2026-06-17-manifest-spine-pr3-control-read-reconcile.md
@@ -1,0 +1,32 @@
+# Manifest spine PR3 — control-API manifest read + cross-manifest reconciliation
+
+> **Status:** `in-progress`
+> **Branch:** `claude/magical-rubin-bq71go`
+> **Dispatch:** scheduled fire, empty work order → advanced the live ▶ Next slice (manifest spine
+> PR3, owner-approved Q-0162; PR1 #1018 + PR2 #1019 shipped).
+
+## What I'm about to do
+
+Ship the next manifest-spine slice — make the typed manifest **readable over the live control API**
+and **self-reconciling** (the spine's stated core purpose: turn AST-classified panel metadata into
+*verified* metadata):
+
+1. **`GET /control/manifest`** on the dormant control API — token-only (global data, mirrors
+   `/control/help/catalogue`), serving `CommandManifest.to_dict()` + `PanelManifest.to_dict()`; builds
+   on demand from the bot when the startup cache is empty. + a thin `control_client.get_manifest()`.
+2. **Cross-manifest reconciliation** — a pure `manifest_reconciliation` projection: a
+   `panel_action`-classified command whose subsystem owns **no** registered panel is a
+   `dangling_panel_action` finding. Surfaced in `CommandManifest.to_dict()["findings"]` (was reserved
+   `[]`) + the `command_manifest` diagnostics snapshot, so the live read carries its own trust signal.
+3. **CI drift guard** — the cheap, non-flaky "AST is drift-detection" test: the AST
+   `scan_commands` `panel_action` subsystems ⊆ the runtime `PanelManifest` subsystems (verified to
+   hold today: panel_action subs = {mining, moderation, role}, all have panels).
+
+**Deferred honestly to PR4** (no declared button→command binding yet — a name-level guard would be
+false-positive-prone, Q-0120): per-button `command` binding + the button-level
+`panel_action`↔button reconciliation. The dashboard.json manifest export stays the AST `cogs` view
+(the export can't import disbot); the live truth is `/control/manifest`.
+
+## Verification
+`python3.10 scripts/check_quality.py --full` green · `check_architecture --mode strict` 0 · new
+reconciliation + endpoint tests.

--- a/.sessions/2026-06-17-manifest-spine-pr3-control-read-reconcile.md
+++ b/.sessions/2026-06-17-manifest-spine-pr3-control-read-reconcile.md
@@ -1,32 +1,90 @@
 # Manifest spine PR3 — control-API manifest read + cross-manifest reconciliation
 
-> **Status:** `in-progress`
-> **Branch:** `claude/magical-rubin-bq71go`
+> **Status:** `complete`
+> **Branch:** `claude/magical-rubin-bq71go` · **PR #1020** (auto-merge armed on green)
 > **Dispatch:** scheduled fire, empty work order → advanced the live ▶ Next slice (manifest spine
 > PR3, owner-approved Q-0162; PR1 #1018 + PR2 #1019 shipped).
 
-## What I'm about to do
+## What shipped
 
-Ship the next manifest-spine slice — make the typed manifest **readable over the live control API**
-and **self-reconciling** (the spine's stated core purpose: turn AST-classified panel metadata into
-*verified* metadata):
+Made the typed manifest **readable over the live control API** and **self-reconciling** — the spine's
+stated core purpose: turn AST-classified panel metadata into *verified* metadata.
 
-1. **`GET /control/manifest`** on the dormant control API — token-only (global data, mirrors
-   `/control/help/catalogue`), serving `CommandManifest.to_dict()` + `PanelManifest.to_dict()`; builds
-   on demand from the bot when the startup cache is empty. + a thin `control_client.get_manifest()`.
-2. **Cross-manifest reconciliation** — a pure `manifest_reconciliation` projection: a
-   `panel_action`-classified command whose subsystem owns **no** registered panel is a
+1. **`GET /control/manifest`** (`disbot/control_api.py`) — token-only (global data, mirrors
+   `/control/help/catalogue`), serves `CommandManifest.to_dict()` + `PanelManifest.to_dict()`; uses the
+   startup cache, builds on demand from the bot when empty. + `dashboard/control_client.get_manifest()`.
+2. **`disbot/core/runtime/manifest_reconciliation.py`** — a pure projection over the command manifest:
+   a `panel_action`-classified command whose subsystem owns **no** registered panel is a
    `dangling_panel_action` finding. Surfaced in `CommandManifest.to_dict()["findings"]` (was reserved
-   `[]`) + the `command_manifest` diagnostics snapshot, so the live read carries its own trust signal.
-3. **CI drift guard** — the cheap, non-flaky "AST is drift-detection" test: the AST
-   `scan_commands` `panel_action` subsystems ⊆ the runtime `PanelManifest` subsystems (verified to
-   hold today: panel_action subs = {mining, moderation, role}, all have panels).
+   `[]`) + the `command_manifest` diagnostics snapshot (`finding_count`/`findings`).
+3. **CI drift guard** (`tests/unit/runtime/test_manifest_drift.py`) — the cheap, non-flaky
+   "AST-is-drift-detection" check: AST `scan_commands` `panel_action` subsystems ⊆ runtime
+   `PanelManifest` subsystems. Holds today ({mining, moderation, role} all have panels). Includes a
+   guard-the-guard test so it can't pass vacuously.
+4. **Deploy-SHA freshness badge** — `command_manifest.deploy_build_sha()` reads
+   `RAILWAY_GIT_COMMIT_SHA` (short 12); `build_and_cache_from_bot` defaults `bot_build` to it, so the
+   live read is cache-bustable / freshness-badged without every call site threading it.
 
-**Deferred honestly to PR4** (no declared button→command binding yet — a name-level guard would be
-false-positive-prone, Q-0120): per-button `command` binding + the button-level
-`panel_action`↔button reconciliation. The dashboard.json manifest export stays the AST `cogs` view
-(the export can't import disbot); the live truth is `/control/manifest`.
+`check_quality --full` green (10431, +16 tests) · `check_architecture --mode strict` 0 · env-vars doc
+regenerated (new `RAILWAY_GIT_COMMIT_SHA` ref).
 
-## Verification
-`python3.10 scripts/check_quality.py --full` green · `check_architecture --mode strict` 0 · new
-reconciliation + endpoint tests.
+## Decisions / what I deviated from the plan on
+
+- **Name-level `panel_action`↔button reconciliation deferred to PR4.** Verified against live data
+  (Q-0120 — never assert a guard that fights the evidence): `panel_action` command *names* do NOT map
+  to button `action_id` suffixes (`createrole` cmd vs `role:create` button). No declared button→command
+  binding exists yet, so a strict name-level guard would be ~false-positive. PR4 declares the binding
+  first, then the button-level check is real. The clean, holds-today reconciliation is **subsystem-level**.
+- **dashboard.json manifest export dropped from PR3.** The export script can't import disbot, so the
+  committed JSON stays the AST `cogs` view; the live truth is `/control/manifest`. Adding a runtime
+  manifest to the committed export would require the export to run the bot — wrong layer.
+- The reconciliation reads `entry.panels` (already back-populated by PR2's subsystem join), so findings
+  need no second walk and no panel-manifest argument — a clean consequence of PR2's design.
+
+## Handoff — next agent (▶ Next action is already sharpened in current-state)
+
+The manifest spine's **pure ungated read-code is exhausted.** Remaining = **PR4: the panel-layout
+editor** (H / L3 "move buttons") — a *declared* button→command binding across every persistent view +
+button-level reconciliation + a DB-backed layout overlay + the website editor. PR4 is **owner-paced**
+(control-API *write* surface, needs `CONTROL_API_TOKEN`) **and architecturally significant** (the
+binding can't be inferred — must be declared per view). A future empty fire should plan PR4 with the
+owner on write-side pacing, or take a different ungated lane (BTD6 floor candidates are thinning;
+image-mod #941 + security #929 are Hermes-gated).
+
+## 🐞 Finding (recorded, not fixed here)
+
+`dashboard/data/dashboard.json` is **~300 lines stale on main** — a fresh `export_dashboard_data.py`
+run differs (env line-numbers + accumulated ideas/sessions/bugs from parallel sessions). There is **no
+committed-vs-fresh freshness guard** (`check_dashboard_data.py` validates structure/counts only). I did
+NOT regenerate it in this PR — it pulls unrelated parallel-session churn into a focused PR and a strict
+byte-equality guard would constantly redden CI across the ~6 sessions that touch it. Better owned by
+the docs-reconciliation routine. See 💡 below.
+
+## 💡 Session idea (Q-0089)
+
+**dashboard.json freshness — make the docs-reconciliation routine regenerate it each pass, + a *soft*
+structural-drift reporter.** The committed `dashboard.json` is a generated artifact that silently
+drifts (hit this directly — 300 lines stale on main). Two-part: (a) the reconciliation routine runs
+`export_dashboard_data.py` as part of its docs pass (it already touches the source docs), keeping it
+fresh on cadence without burdening every session; (b) extend `check_dashboard_data.py` with a
+**non-blocking** structural-drift reporter — compare committed vs a fresh export on the *structural*
+keys only (cog/command set, env-var set, setting keys — NOT timestamps/build-SHA/ideas-churn) and emit
+a soft warning, so a *real* surface drift (a new cog/command/env-var never exported) is caught without
+the fragility of byte-equality. Genuinely believe in it — it's the missing half of the manifest spine's
+own "AST is drift-detection" philosophy applied to the committed export.
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous run (#1019, manifest spine PR2) did the spine a real favour: by **back-populating
+`CommandManifestEntry.panels` via the subsystem join in PR1's `build_and_cache_from_bot`**, it made
+*this* session's reconciliation trivial — the `dangling_panel_action` finding is a pure read of
+`entry.panels`, no second walk, no cross-module plumbing. Clean forward-compatible design.
+
+**What it (and the plan) could have done better → a workflow improvement:** the manifest-spine
+execution plan states PR3 should assert "every `panel_action` command maps to a real button" as if it
+were straightforward — but at name-level that's **false today** (I had to prototype against live data
+to discover it). **Improvement: an execution plan that schedules a *guard/assertion* should carry an
+explicit "verify this holds against ground truth before asserting it" caveat** — the Q-0120 principle
+("a check that fights the evidence is a bug in the check") applied at *plan-authoring* time, not just at
+guard-writing time. Saves the next agent from shipping a false-positive guard because the plan said so.
+(Captured here, not promoted — it's a refinement to plan-authoring convention, not a CLAUDE.md rule.)

--- a/dashboard/control_client.py
+++ b/dashboard/control_client.py
@@ -67,6 +67,20 @@ async def get_authority(guild_id: int, user_id: int) -> dict[str, Any] | None:
         return None
 
 
+async def get_manifest() -> dict[str, Any] | None:
+    """Fetch the bot's typed command + panel manifests (the live truth).
+
+    Returns the ``/control/manifest`` payload (``commands`` / ``panels`` /
+    reconciliation ``findings``), or ``None`` when the client is dormant or the
+    bot is unreachable — the decoupled site falls back to the committed
+    ``dashboard.json`` AST view. Token-only (global data, no guild/user).
+    """
+    status, body = await get("/control/manifest")
+    if status != 200:
+        return None
+    return body
+
+
 async def get(
     path: str,
     params: dict[str, Any] | None = None,

--- a/disbot/control_api.py
+++ b/disbot/control_api.py
@@ -28,6 +28,7 @@ Endpoints:
 
 * ``GET  /control/ping``                 — auth smoke.
 * ``GET  /control/authority``            — the identity→authority bridge (read).
+* ``GET  /control/manifest``             — the typed command + panel manifests (token-only).
 * ``POST /control/settings``             — front ``settings_mutation`` (capability-gated).
 * ``POST /control/help/overlay``         — front ``help_overlay_mutation.set_overlay_fields``.
 * ``POST /control/help/home``            — front ``help_overlay_mutation.set_home_message``.
@@ -740,6 +741,40 @@ async def _help_catalogue_handler(request: web.Request) -> web.Response:
     return _json_response({"ok": True, "hubs": hubs, "subsystems": subsystems})
 
 
+async def _manifest_handler(request: web.Request) -> web.Response:
+    """``GET /control/manifest`` → the typed command + panel manifests.
+
+    Token-only (global data, no guild/user — mirrors ``/control/help/catalogue``):
+    the command/panel surface is the bot's, not a guild's. Serves the cached
+    startup manifests and falls back to building them on demand (so the read works
+    even if a startup build was skipped). The command manifest's ``findings`` carry
+    the cross-manifest reconciliation drift (manifest spine PR3). Read-only.
+    """
+    if not is_authorized(request.headers.get("Authorization"), control_token()):
+        return _unauthorized()
+
+    from core.runtime import command_manifest, panel_manifest
+
+    bot = request.app["bot"]
+    try:
+        commands = command_manifest.get_cached_manifest()
+        if commands is None:
+            commands = command_manifest.build_and_cache_from_bot(bot)
+        panels = panel_manifest.get_cached_manifest()
+        if panels is None:
+            panels = panel_manifest.build_and_cache()
+    except Exception as exc:  # noqa: BLE001 - never 500 a read on a build hiccup
+        return _seam_error_or_500(exc, "manifest")
+
+    return _json_response(
+        {
+            "ok": True,
+            "commands": commands.to_dict(),
+            "panels": panels.to_dict(),
+        },
+    )
+
+
 async def _routing_get_handler(request: web.Request) -> web.Response:
     """``GET /control/routing?guild_id=&user_id=`` → current cog-routing rows.
 
@@ -801,13 +836,15 @@ def register_control_routes(app: web.Application, bot: Any) -> bool:
     app.router.add_get("/control/help/overlay", _help_overlay_get_handler)
     app.router.add_get("/control/help/catalogue", _help_catalogue_handler)
     app.router.add_get("/control/routing", _routing_get_handler)
+    # Manifest spine PR3 — the typed command/panel manifests (global, token-only).
+    app.router.add_get("/control/manifest", _manifest_handler)
     app.router.add_post("/control/settings", _settings_set_handler)
     app.router.add_post("/control/help/overlay", _help_overlay_handler)
     app.router.add_post("/control/help/home", _help_home_handler)
     app.router.add_post("/control/help/reset", _help_reset_handler)
     app.router.add_post("/control/routing", _routing_set_handler)
     logger.info(
-        "control_api: enabled — ping, authority + reads "
+        "control_api: enabled — ping, authority, manifest + reads "
         "(settings/current, help/overlay, help/catalogue, routing) + writes "
         "(settings, help/overlay, help/home, help/reset, routing; "
         "auth + per-request authority)",

--- a/disbot/core/runtime/command_manifest.py
+++ b/disbot/core/runtime/command_manifest.py
@@ -116,14 +116,27 @@ class CommandManifest:
     bot_build: str
     commands: tuple[CommandManifestEntry, ...]
 
+    def findings(self) -> list[dict[str, Any]]:
+        """Cross-manifest reconciliation findings (drift) for this manifest.
+
+        Computed lazily (no stored state) by the spine's reconciliation seam —
+        e.g. a ``panel_action`` command whose subsystem owns no registered panel.
+        Empty when the manifest is clean. Imported function-locally to keep this
+        module's top-level imports to its sibling ledger only (cycle discipline).
+        """
+        from core.runtime import manifest_reconciliation
+
+        return manifest_reconciliation.reconcile_to_dicts(self)
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "version": self.version,
             "generated_at": self.generated_at,
             "bot_build": self.bot_build,
             "commands": [c.to_dict() for c in self.commands],
-            # Reserved (PR3) — drift findings vs the AST scanner.
-            "findings": [],
+            # Cross-manifest reconciliation drift (manifest spine PR3) — the
+            # live read carries its own trust signal (empty == clean).
+            "findings": self.findings(),
         }
 
 
@@ -265,6 +278,7 @@ def _snapshot() -> dict[str, Any]:
     by_kind: dict[str, int] = {}
     for c in manifest.commands:
         by_kind[c.kind] = by_kind.get(c.kind, 0) + 1
+    findings = manifest.findings()
     return {
         "built": True,
         "version": manifest.version,
@@ -272,6 +286,9 @@ def _snapshot() -> dict[str, Any]:
         "bot_build": manifest.bot_build,
         "command_count": len(manifest.commands),
         "by_kind": by_kind,
+        # Cross-manifest reconciliation (PR3): 0 == clean.
+        "finding_count": len(findings),
+        "findings": findings,
     }
 
 

--- a/disbot/core/runtime/command_manifest.py
+++ b/disbot/core/runtime/command_manifest.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import datetime
 import logging
+import os
 from dataclasses import dataclass
 from typing import Any
 
@@ -231,7 +232,22 @@ def build_and_cache(
     return manifest
 
 
-def build_and_cache_from_bot(bot: object, *, bot_build: str = "") -> CommandManifest:
+def deploy_build_sha() -> str:
+    """The deploy's git SHA (short) for the manifest envelope, or ``""``.
+
+    Read from Railway's ``RAILWAY_GIT_COMMIT_SHA`` (set on every deploy). It
+    freshness-badges / cache-busts the exported manifest so a consumer can tell
+    which build the surface came from. Empty off-Railway (local / CI), which is
+    fine — the field is informational.
+    """
+    return os.environ.get("RAILWAY_GIT_COMMIT_SHA", "").strip()[:12]
+
+
+def build_and_cache_from_bot(
+    bot: object,
+    *,
+    bot_build: str | None = None,
+) -> CommandManifest:
     """Build (or reuse) the command ledger, then project + cache the manifest.
 
     Prefers the already-cached ledger (the startup path builds it just
@@ -239,9 +255,15 @@ def build_and_cache_from_bot(bot: object, *, bot_build: str = "") -> CommandMani
     forces a second surface walk. When the panel manifest has been built
     (startup builds it first), its ``subsystem -> panel_ids`` map is joined
     in so each command carries its subsystem's ``panels``.
+
+    ``bot_build`` defaults to the deploy SHA (:func:`deploy_build_sha`) so the
+    live read carries it without every call site threading it; pass an explicit
+    string (incl. ``""``) to override.
     """
     from core.runtime import command_surface_ledger, panel_manifest
 
+    if bot_build is None:
+        bot_build = deploy_build_sha()
     ledger = command_surface_ledger.get_cached_ledger()
     if ledger is None:
         ledger = command_surface_ledger.build_ledger(bot)
@@ -308,5 +330,6 @@ __all__ = [
     "build_and_cache",
     "build_and_cache_from_bot",
     "build_command_manifest",
+    "deploy_build_sha",
     "get_cached_manifest",
 ]

--- a/disbot/core/runtime/manifest_reconciliation.py
+++ b/disbot/core/runtime/manifest_reconciliation.py
@@ -1,0 +1,106 @@
+"""Manifest reconciliation — slice 3 of the dashboard manifest spine (Q-0162).
+
+The spine exists to turn *unverified* command/panel metadata into **verified**
+metadata: an AST scan can only answer "does this *look* like a panel command?",
+while the runtime manifests know which commands are classified ``panel_action``
+and which panels actually exist. This module is the reconciliation seam between
+them — it cross-checks the :class:`~core.runtime.command_manifest.CommandManifest`
+against the :class:`~core.runtime.panel_manifest.PanelManifest` and reports
+**findings** (drift) the live read (``GET /control/manifest``) and ``!platform``
+diagnostics surface.
+
+This slice ships the reconciliation that holds cleanly **today**:
+
+* ``dangling_panel_action`` — a command classified ``panel_action`` (declared to
+  be invoked from a panel button) whose **subsystem owns no registered panel** in
+  the PanelManifest. That command's panel action has nowhere to live, which is a
+  real structural drift. (The command manifest already back-populates each
+  command's ``panels`` from the panel manifest by subsystem, so the check is a
+  pure read of ``entry.panels``.)
+
+Deferred to a later slice (no declared button→command binding yet, so a stricter
+check would be false-positive-prone — the CLAUDE.md Q-0120 rule): the
+**button-level** reconciliation (every ``panel_action`` command maps to a *real
+button*, and every button's ``command`` points at a real command). ``panel_action``
+command *names* deliberately do not equal button ``action_id`` suffixes today
+(``createrole`` vs ``role:create``), so that check waits for the binding.
+
+Pure and side-effect-free: every function takes manifests and returns data. No
+module-level imports of ``services`` (mirrors the manifest modules' cycle
+discipline) — this module imports only its sibling manifest types.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from core.runtime.command_manifest import CommandManifest
+
+# Finding kinds (stable strings — consumers gate on them).
+DANGLING_PANEL_ACTION = "dangling_panel_action"
+
+
+@dataclass(frozen=True)
+class ReconciliationFinding:
+    """One cross-manifest drift finding.
+
+    ``kind`` is one of the module's finding-kind constants; ``command`` /
+    ``subsystem`` locate it; ``detail`` is a human-readable one-liner.
+    """
+
+    kind: str
+    command: str
+    subsystem: str | None
+    detail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "command": self.command,
+            "subsystem": self.subsystem,
+            "detail": self.detail,
+        }
+
+
+def reconcile(manifest: CommandManifest) -> tuple[ReconciliationFinding, ...]:
+    """Cross-check ``manifest`` against the panel join it already carries.
+
+    Returns the findings (empty when clean). A ``panel_action``-classified
+    command with no ``panels`` (its subsystem owns no registered panel) is a
+    :data:`DANGLING_PANEL_ACTION` finding — the command claims to be a panel
+    button's action but no panel backs it.
+
+    Pure: reads only the command entries' ``classification`` / ``panels`` (the
+    latter back-populated by ``command_manifest`` from the panel manifest by
+    subsystem), so it needs no second walk and no panel-manifest argument.
+    """
+    findings: list[ReconciliationFinding] = []
+    for entry in manifest.commands:
+        if entry.classification == "panel_action" and not entry.panels:
+            findings.append(
+                ReconciliationFinding(
+                    kind=DANGLING_PANEL_ACTION,
+                    command=entry.qualified_name,
+                    subsystem=entry.subsystem,
+                    detail=(
+                        f"command {entry.qualified_name!r} is classified "
+                        f"'panel_action' but its subsystem "
+                        f"({entry.subsystem!r}) owns no registered panel"
+                    ),
+                ),
+            )
+    return tuple(findings)
+
+
+def reconcile_to_dicts(manifest: CommandManifest) -> list[dict[str, Any]]:
+    """:func:`reconcile` as a list of plain dicts (the export / API shape)."""
+    return [f.to_dict() for f in reconcile(manifest)]
+
+
+__all__ = [
+    "DANGLING_PANEL_ACTION",
+    "ReconciliationFinding",
+    "reconcile",
+    "reconcile_to_dicts",
+]

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -207,6 +207,23 @@ Source code and merged PRs win over anything written here.
 > auto-opens a `reconcile` issue at the boundary that fires the docs-reconciliation routine). Reset
 > this marker to the latest PR after a pass.
 
+- **#1020 (2026-06-17, manifest spine PR3 — control-API manifest read + cross-manifest
+  reconciliation)** — scheduled dispatch, empty work order → advanced the manifest-spine thread (PR1
+  #1018 + PR2 #1019 shipped; the execution plan named PR3 next). Makes the typed manifest **readable
+  over the live control API** and **self-reconciling** (the spine's core purpose — verified, not
+  guessed, metadata): **(1)** `GET /control/manifest` on the dormant control API (token-only, global —
+  mirrors `/control/help/catalogue`) serves `CommandManifest` + `PanelManifest`, building on demand
+  when the startup cache is empty; + `control_client.get_manifest()`. **(2)** `core/runtime/manifest_reconciliation.py`
+  — a `panel_action`-classified command whose subsystem owns no registered panel is a
+  `dangling_panel_action` finding, surfaced in `CommandManifest.to_dict()["findings"]` (was reserved
+  `[]`) + the `command_manifest` diagnostics. **(3)** CI drift guard (`test_manifest_drift.py`): the
+  AST `scan_commands` `panel_action` subsystems ⊆ the runtime `PanelManifest` subsystems — the cheap
+  "AST is drift-detection" check (holds: {mining, moderation, role}). **(4)** the manifest envelope's
+  `bot_build` now defaults to the deploy SHA (`RAILWAY_GIT_COMMIT_SHA`, short) so the live read is
+  freshness-badged. `check_quality --full` green (10431, +16) · arch 0. **Deferred to PR4** (no
+  declared button→command binding yet — verified: `panel_action` cmd names ≠ button action-id
+  suffixes, so a name-level guard would be false-positive-prone, Q-0120): per-button `command` binding
+  + button-level reconciliation + the panel-layout editor (owner-paced control-API *writes*).
 - **#1018 (2026-06-17, manifest spine slice 1 — typed CommandManifest over the ledger)** — same
   dispatch fire as #1017 (continuation). Started the **manifest spine** — the dashboard vision doc's
   "key structural investment," owner-approved (Q-0162), Phase-E predecessor shipped (#1013), schema
@@ -254,10 +271,19 @@ Source code and merged PRs win over anything written here.
   from the authority bridge. New pure `_setup_health`/`_authority_preview` projections + two
   templates + nav/overview links. `check_quality --full` green (10408) · arch 0 · +12 dashboard
   tests. **Dashboard ▶ next:** R3 hardening shipped (#1014); the **Phase D manifest spine** (Q-0162,
-  gates command/panel management) is now the live ungated buildable thread — PR1 `CommandManifest`
-  (#1018) + PR2 panel registry/`PanelManifest` (#1019) shipped; **PR3** (control-API `manifest` read +
-  `dashboard.json` export + AST drift guard) is the next slice. The global-settings runtime tier
-  (Q-0157) stays its own owner-paced session.
+  gates command/panel management) — PR1 `CommandManifest` (#1018) + PR2 panel registry/`PanelManifest`
+  (#1019) + **PR3 control-API `/control/manifest` read + cross-manifest reconciliation + AST drift
+  guard + deploy-SHA badge (#1020)** all shipped. **The remaining manifest-spine work is PR4 — the
+  panel-layout editor (H / L3 "move buttons"): a declared button→command binding + button-level
+  reconciliation + the DB-backed layout overlay + the website editor.** PR4 is **owner-paced** (it is
+  a control-API *write* surface, needs `CONTROL_API_TOKEN`) **and architecturally significant** (the
+  binding must be declared across every persistent view — verified this session that `panel_action`
+  command names do NOT map to button action-ids, so it can't be inferred). So the manifest spine's
+  next pure ungated read-code is **exhausted** — a future empty fire should plan PR4 (with the owner
+  on the write-side pacing) or take a different ungated lane. The committed `dashboard.json` export of
+  the manifest was dropped from PR3: the export can't import disbot, so it stays the AST `cogs` view;
+  the live truth is `/control/manifest`. The global-settings runtime tier (Q-0157) stays its own
+  owner-paced session.
 - **#1012 (2026-06-17, AI answerability floor — boss roster + per-difficulty map filter + boss
   immunity)** — scheduled dispatch fire, no work order; night queue fully consumed + both open PRs
   (#941/#929) Hermes-gated → took a fresh slice of the proven, ungated BTD6 deterministic-floor lane
@@ -337,6 +363,10 @@ Source code and merged PRs win over anything written here.
   `check_quality --full` green (10292, +38); arch 0; mypy clean. Tests:
   `tests/unit/services/test_btd6_power_cost_comparison.py` + the §7.5 exclusivity corpus entry.
   Next night-queue `TODO` = slot 3 (relic category/effect roster).
+- **#1005 · #1006 · #1007 (2026-06-17, dashboard-vision docs + a routing-corpus test)** — the
+  dashboard finalized-vision plan review + owner panel decisions (#1005 review/close · #1006 solidify
+  with owner panel decisions) and the BTD6 community-shorthand class-guard corpus (#1007, test-only).
+  Docs/test band; no runtime change.
 - **#1000 (2026-06-16, AI §7.5 — deterministic BTD6 hero cost-comparison floor)** — scheduled
   dispatch (empty work order → the live ▶ NIGHT QUEUE, slot 1). Adds the **hero** member of the
   §7.5 multi-entity cost-comparison floor (the hero-entity sibling of the shipped paragon #962 /

--- a/docs/operations/env-vars.md
+++ b/docs/operations/env-vars.md
@@ -13,7 +13,7 @@ it reads it, and whether it is **required** (read without a default anywhere) or
 only — never a value**; the values live in Railway service variables
 (see [`production-deployment.md`](production-deployment.md)).
 
-**36 variables** — 3 required · 33 optional.
+**37 variables** — 3 required · 34 optional.
 
 ## Required (read without a default — the deploy must set these)
 
@@ -57,6 +57,7 @@ only — never a value**; the values live in Railway service variables
 | `OPENAI_API_KEY` | config, core, services | `disbot/config.py:159` *(default)*<br>`disbot/core/runtime/ai/providers/openai_provider.py:74` *(default)*<br>`disbot/services/setup_ai_advisor.py:175` *(default)*<br>`disbot/services/setup_ai_advisor.py:406` *(default)* |
 | `PARAGON_API_BASE_URL` | config, services | `disbot/config.py:186` *(default)*<br>`disbot/services/paragon_service.py:49` *(default)* |
 | `PARAGON_API_KEY` | config, services | `disbot/config.py:190` *(default)*<br>`disbot/services/paragon_service.py:50` *(default)* |
+| `RAILWAY_GIT_COMMIT_SHA` | core | `disbot/core/runtime/command_manifest.py:243` *(default)* |
 | `SETUP_ADVISOR_OPENAI_MODEL` | config, services | `disbot/config.py:158` *(default)*<br>`disbot/services/setup_ai_advisor.py:173` *(default)* |
 | `SETUP_ADVISOR_PROVIDER` | config, core, services | `disbot/config.py:157` *(default)*<br>`disbot/core/runtime/ai/feature_flags.py:129` *(default)*<br>`disbot/services/setup_ai_advisor.py:393` *(default)* |
 | `STRICT_DISABLED` | bot1 | `disbot/bot1.py:172` *(default)* |

--- a/docs/operations/env-vars.md
+++ b/docs/operations/env-vars.md
@@ -47,7 +47,7 @@ only — never a value**; the values live in Railway service variables
 | `CLAUDE_ROUTINE_FIRE_URL` | cogs | `disbot/cogs/hermes_cog.py:49` *(default)* |
 | `CLAUDE_ROUTINE_TOKEN` | cogs | `disbot/cogs/hermes_cog.py:50` *(default)* |
 | `CLAUDE_ROUTINE_VERSION` | cogs | `disbot/cogs/hermes_cog.py:52` *(default)* |
-| `CONTROL_API_TOKEN` | control_api | `disbot/control_api.py:110` *(default)* |
+| `CONTROL_API_TOKEN` | control_api | `disbot/control_api.py:111` *(default)* |
 | `DISCORD_WEBHOOK_URL` | config | `disbot/config.py:102` *(default)* |
 | `HEALTH_GROUPED_FINDINGS` | services | `disbot/services/health_snapshot_service.py:267` *(default)* |
 | `HEALTH_HOST` | healthserver | `disbot/healthserver.py:70` *(default)* |

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,10 +25,6 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/magical-rubin-bq71go` · manifest spine **PR3** — control-API `GET /control/manifest` read +
-  cross-manifest reconciliation (`dangling_panel_action` findings) + the AST-vs-panel-registry drift
-  guard · `disbot/control_api.py` · `disbot/core/runtime/{command_manifest,manifest_reconciliation}.py`
-  · `dashboard/control_client.py` · `tests/` · 2026-06-17
 - `claude/tender-noether-h5lpp1` · **night work queue** (owner directive) — seed a grounded queue of
   read-only deterministic BTD6 floor builders (AI §7.5/§7.6 lane) for the scheduled dispatch fires +
   repoint `current-state.md` ▶ Next action · `docs/planning/night-queue-2026-06-16.md` ·
@@ -53,6 +49,9 @@ living ledger (`docs/current-state.md`).
 
 ## Recently cleared
 
+- `claude/magical-rubin-bq71go` · manifest spine **PR3** — control-API `GET /control/manifest` read +
+  cross-manifest reconciliation (`dangling_panel_action`) + AST-vs-panel-registry drift guard +
+  deploy-SHA badge · 2026-06-17 · **PR #1020 (auto-merge on green)**
 - `claude/magical-rubin-p92toz` · manifest spine **PR2** — panel registry + `PanelManifest`
   (`core/runtime/panel_manifest.py` + `persistent_views` PANEL_ID/enumeration + command-panel join) ·
   2026-06-17 · **PR #1019 (auto-merge on green)**

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,10 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/magical-rubin-bq71go` · manifest spine **PR3** — control-API `GET /control/manifest` read +
+  cross-manifest reconciliation (`dangling_panel_action` findings) + the AST-vs-panel-registry drift
+  guard · `disbot/control_api.py` · `disbot/core/runtime/{command_manifest,manifest_reconciliation}.py`
+  · `dashboard/control_client.py` · `tests/` · 2026-06-17
 - `claude/tender-noether-h5lpp1` · **night work queue** (owner directive) — seed a grounded queue of
   read-only deterministic BTD6 floor builders (AI §7.5/§7.6 lane) for the scheduled dispatch fires +
   repoint `current-state.md` ▶ Next action · `docs/planning/night-queue-2026-06-16.md` ·

--- a/tests/unit/dashboard/test_control_client.py
+++ b/tests/unit/dashboard/test_control_client.py
@@ -61,3 +61,34 @@ async def test_get_dormant_returns_503(monkeypatch):
     status, body = await control_client.get("/control/settings/current", {"guild_id": 1})
     assert status == 503
     assert "not configured" in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_manifest_dormant_returns_none(monkeypatch):
+    monkeypatch.delenv("CONTROL_API_TOKEN", raising=False)
+    assert await control_client.get_manifest() is None
+
+
+@pytest.mark.asyncio
+async def test_get_manifest_returns_body_on_200(monkeypatch):
+    monkeypatch.setenv("CONTROL_API_TOKEN", "shared-secret")
+
+    async def _fake_get(path, params=None):
+        assert path == "/control/manifest"
+        return 200, {"ok": True, "commands": {"version": 1}, "panels": {"version": 1}}
+
+    monkeypatch.setattr(control_client, "get", _fake_get)
+    body = await control_client.get_manifest()
+    assert body is not None
+    assert body["commands"]["version"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_manifest_returns_none_on_error(monkeypatch):
+    monkeypatch.setenv("CONTROL_API_TOKEN", "shared-secret")
+
+    async def _fake_get(path, params=None):
+        return 502, {"error": "unreachable"}
+
+    monkeypatch.setattr(control_client, "get", _fake_get)
+    assert await control_client.get_manifest() is None

--- a/tests/unit/runtime/test_command_manifest.py
+++ b/tests/unit/runtime/test_command_manifest.py
@@ -188,6 +188,40 @@ def test_to_dict_schema_shape():
 
 
 # ---------------------------------------------------------------------------
+# Deploy-SHA freshness badge (manifest spine PR3)
+# ---------------------------------------------------------------------------
+
+
+def test_deploy_build_sha_reads_railway_env(monkeypatch):
+    monkeypatch.delenv("RAILWAY_GIT_COMMIT_SHA", raising=False)
+    assert cm.deploy_build_sha() == ""
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "abcdef0123456789deadbeef")
+    assert cm.deploy_build_sha() == "abcdef012345"  # short, 12 chars
+
+
+def test_build_and_cache_from_bot_defaults_bot_build_to_deploy_sha(monkeypatch):
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "feedface0000")
+    ledger = _ledger((_e("warn", "ModCog", "moderation"),))
+    monkeypatch.setattr(
+        "core.runtime.command_surface_ledger.get_cached_ledger",
+        lambda: ledger,
+    )
+    manifest = cm.build_and_cache_from_bot(object())
+    assert manifest.bot_build == "feedface0000"
+
+
+def test_build_and_cache_from_bot_explicit_bot_build_overrides(monkeypatch):
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "feedface0000")
+    ledger = _ledger((_e("warn", "ModCog", "moderation"),))
+    monkeypatch.setattr(
+        "core.runtime.command_surface_ledger.get_cached_ledger",
+        lambda: ledger,
+    )
+    manifest = cm.build_and_cache_from_bot(object(), bot_build="")
+    assert manifest.bot_build == ""
+
+
+# ---------------------------------------------------------------------------
 # Reconciliation findings in the envelope (manifest spine PR3)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/runtime/test_command_manifest.py
+++ b/tests/unit/runtime/test_command_manifest.py
@@ -188,6 +188,32 @@ def test_to_dict_schema_shape():
 
 
 # ---------------------------------------------------------------------------
+# Reconciliation findings in the envelope (manifest spine PR3)
+# ---------------------------------------------------------------------------
+
+
+def test_to_dict_findings_empty_when_clean():
+    # A panel_action command WITH its subsystem's panel joined is clean.
+    ledger = _ledger((_e("warn", "ModCog", "moderation", classification="panel_action"),))
+    manifest = cm.build_command_manifest(
+        ledger,
+        panels_by_subsystem={"moderation": ("moderation",)},
+    )
+    assert manifest.findings() == []
+    assert manifest.to_dict()["findings"] == []
+
+
+def test_to_dict_findings_report_dangling_panel_action():
+    # A panel_action command whose subsystem has no panel is flagged.
+    ledger = _ledger((_e("orphan", "MiscCog", "ghost", classification="panel_action"),))
+    manifest = cm.build_command_manifest(ledger)  # no panel join
+    findings = manifest.to_dict()["findings"]
+    assert len(findings) == 1
+    assert findings[0]["kind"] == "dangling_panel_action"
+    assert findings[0]["command"] == "orphan"
+
+
+# ---------------------------------------------------------------------------
 # Cache round-trip + diagnostics
 # ---------------------------------------------------------------------------
 
@@ -222,3 +248,6 @@ def test_diagnostics_snapshot_built():
     assert snap["command_count"] == 2
     assert snap["by_kind"] == {"prefix": 1, "slash": 1}
     assert snap["version"] == cm.MANIFEST_VERSION
+    # Reconciliation surfaced (PR3): no panel_action commands → clean.
+    assert snap["finding_count"] == 0
+    assert snap["findings"] == []

--- a/tests/unit/runtime/test_control_api.py
+++ b/tests/unit/runtime/test_control_api.py
@@ -151,6 +151,8 @@ def test_routes_registered_with_token(monkeypatch):
     # Phase E read endpoints register alongside the writes (still token-gated).
     assert "/control/settings/current" in paths
     assert "/control/help/catalogue" in paths
+    # Manifest spine PR3 — the typed command/panel manifests (token-only).
+    assert "/control/manifest" in paths
     # Mutation endpoints register alongside the reads (still token-gated).
     assert "/control/settings" in paths
     assert "/control/help/overlay" in paths
@@ -221,6 +223,58 @@ async def test_ping_requires_auth(monkeypatch):
     )
     assert resp.status == 200
     assert json.loads(resp.text)["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_manifest_handler_requires_auth(monkeypatch):
+    monkeypatch.setenv("CONTROL_API_TOKEN", TOKEN)
+    resp = await control_api._manifest_handler(_request(headers={}))
+    assert resp.status == 401
+
+
+@pytest.mark.asyncio
+async def test_manifest_handler_serves_command_and_panel_manifests(monkeypatch):
+    monkeypatch.setenv("CONTROL_API_TOKEN", TOKEN)
+    from core.runtime import command_manifest, panel_manifest
+
+    # Stub the cached manifests so the handler serves them without a live bot.
+    fake_cmd = MagicMock()
+    fake_cmd.to_dict.return_value = {"version": 1, "commands": [], "findings": []}
+    fake_panel = MagicMock()
+    fake_panel.to_dict.return_value = {"version": 1, "panels": []}
+    monkeypatch.setattr(command_manifest, "get_cached_manifest", lambda: fake_cmd)
+    monkeypatch.setattr(panel_manifest, "get_cached_manifest", lambda: fake_panel)
+
+    resp = await control_api._manifest_handler(_request(headers=_auth(), bot=_bot()))
+    assert resp.status == 200
+    body = json.loads(resp.text)
+    assert body["ok"] is True
+    assert body["commands"]["version"] == 1
+    assert body["panels"]["version"] == 1
+    assert body["commands"]["findings"] == []
+
+
+@pytest.mark.asyncio
+async def test_manifest_handler_builds_on_demand_when_uncached(monkeypatch):
+    monkeypatch.setenv("CONTROL_API_TOKEN", TOKEN)
+    from core.runtime import command_manifest, panel_manifest
+
+    built_cmd = MagicMock()
+    built_cmd.to_dict.return_value = {"version": 1, "commands": [], "findings": []}
+    built_panel = MagicMock()
+    built_panel.to_dict.return_value = {"version": 1, "panels": []}
+    monkeypatch.setattr(command_manifest, "get_cached_manifest", lambda: None)
+    monkeypatch.setattr(panel_manifest, "get_cached_manifest", lambda: None)
+    monkeypatch.setattr(
+        command_manifest,
+        "build_and_cache_from_bot",
+        lambda bot: built_cmd,
+    )
+    monkeypatch.setattr(panel_manifest, "build_and_cache", lambda: built_panel)
+
+    resp = await control_api._manifest_handler(_request(headers=_auth(), bot=_bot()))
+    assert resp.status == 200
+    assert json.loads(resp.text)["commands"]["version"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/runtime/test_manifest_drift.py
+++ b/tests/unit/runtime/test_manifest_drift.py
@@ -1,0 +1,87 @@
+"""AST-vs-runtime drift guard — manifest spine slice 3 (Q-0162).
+
+The manifest spine demotes the AST scanner (``scripts/scan_commands.py``) to a
+**drift-detection layer** and makes the runtime manifests the source of truth.
+This guard is the cheap, CI-runnable cross-check that keeps the two honest:
+
+    every subsystem the AST scanner sees a ``panel_action`` command in
+    must own at least one registered persistent panel (PanelManifest).
+
+It is the structural half of the ``dangling_panel_action`` reconciliation
+(``manifest_reconciliation``): a ``panel_action`` command whose subsystem owns no
+panel has nowhere to live. Both the AST scan and the panel manifest are cheap
+(arg-free view instantiation), so this runs in unit-test CI without a live bot —
+unlike the full command ledger, which needs a loaded bot.
+
+If this fails: either a new ``panel_action`` command landed in a subsystem with no
+panel (the drift the spine exists to catch), or the AST scanner / panel registry
+drifted — triage against the live registry before trusting the verdict (Q-0120).
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from pathlib import Path
+
+from core.runtime import panel_manifest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# The persistent-view modules whose import registers panels (mirrors
+# test_panel_manifest._real_manifest so collection order can't hide a panel).
+_PANEL_MODULES = (
+    "views.ai.panel",
+    "views.moderation.main_panel",
+    "views.economy.main_panel",
+    "views.btd6.panel",
+    "views.mining.main_panel",
+    "views.ux_lab.persistent_demo",
+    "views.server_management.hub",
+    "cogs.help.panels",
+    "cogs.role_cog",
+)
+
+
+def _load_scan_commands():
+    script = REPO_ROOT / "scripts" / "scan_commands.py"
+    spec = importlib.util.spec_from_file_location("_scan_commands_drift", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.scan_commands
+
+
+def _ast_panel_action_subsystems() -> dict[str, list[str]]:
+    """``subsystem -> [command names]`` for every AST ``panel_action`` command."""
+    scan_commands = _load_scan_commands()
+    out: dict[str, list[str]] = {}
+    for cog in scan_commands(repo_root=REPO_ROOT):
+        for cmd in cog["commands"]:
+            if cmd["classification"] == "panel_action":
+                out.setdefault(cog["subsystem"], []).append(cmd["name"])
+    return out
+
+
+def _panel_subsystems() -> set[str]:
+    for mod in _PANEL_MODULES:
+        importlib.import_module(mod)
+    return {p.subsystem for p in panel_manifest.build_panel_manifest().panels}
+
+
+def test_every_panel_action_subsystem_owns_a_panel():
+    pa = _ast_panel_action_subsystems()
+    panels = _panel_subsystems()
+    dangling = {sub: cmds for sub, cmds in pa.items() if sub not in panels}
+    assert not dangling, (
+        "panel_action commands in subsystem(s) with no registered panel "
+        f"(dangling): {dangling}. Register a panel, fix the cog->subsystem join, "
+        "or reclassify the command."
+    )
+
+
+def test_drift_guard_actually_sees_panel_actions():
+    # Guards the guard: if the scanner ever stops finding any panel_action
+    # command, the subset check above would pass vacuously — so assert it has
+    # real data to check (Q-0120: a green that contradicts evidence is a bug).
+    assert _ast_panel_action_subsystems(), "scan_commands found no panel_action commands"

--- a/tests/unit/runtime/test_manifest_reconciliation.py
+++ b/tests/unit/runtime/test_manifest_reconciliation.py
@@ -1,0 +1,81 @@
+"""Unit tests for core.runtime.manifest_reconciliation — manifest spine slice 3.
+
+The reconciliation is a pure projection over a CommandManifest (whose entries
+already carry the panel join), so these construct manifest fixtures directly and
+pin the ``dangling_panel_action`` finding, the clean case, and the to_dicts shape.
+"""
+
+from __future__ import annotations
+
+from core.runtime import manifest_reconciliation as mr
+from core.runtime.command_manifest import CommandManifest, CommandManifestEntry
+
+
+def _cmd(
+    name: str,
+    subsystem: str | None,
+    classification: str = "primary_entrypoint",
+    panels: tuple[str, ...] = (),
+) -> CommandManifestEntry:
+    return CommandManifestEntry(
+        qualified_name=name,
+        kind="prefix",
+        cog="C",
+        subsystem=subsystem,
+        classification=classification,
+        classification_declared=True,
+        visibility_tier=None,
+        aliases=(),
+        discord_hidden=False,
+        panels=panels,
+    )
+
+
+def _manifest(*commands: CommandManifestEntry) -> CommandManifest:
+    return CommandManifest(
+        version=1,
+        generated_at="2026-06-17T00:00:00+00:00",
+        bot_build="",
+        commands=tuple(commands),
+    )
+
+
+def test_clean_when_panel_action_has_a_panel():
+    manifest = _manifest(
+        _cmd("warn", "moderation", "panel_action", panels=("moderation",)),
+        _cmd("ping", None),  # not a panel action — ignored
+    )
+    assert mr.reconcile(manifest) == ()
+
+
+def test_dangling_panel_action_flagged():
+    manifest = _manifest(
+        _cmd("orphan", "ghost", "panel_action", panels=()),
+    )
+    findings = mr.reconcile(manifest)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.kind == mr.DANGLING_PANEL_ACTION
+    assert f.command == "orphan"
+    assert f.subsystem == "ghost"
+    assert "no registered panel" in f.detail
+
+
+def test_non_panel_action_with_no_panels_is_not_flagged():
+    # A normal command in a subsystem with no panel is fine — only panel_action
+    # commands need a backing panel.
+    manifest = _manifest(_cmd("xp", "xp", "primary_entrypoint", panels=()))
+    assert mr.reconcile(manifest) == ()
+
+
+def test_reconcile_to_dicts_shape():
+    manifest = _manifest(_cmd("orphan", "ghost", "panel_action", panels=()))
+    dicts = mr.reconcile_to_dicts(manifest)
+    assert dicts == [
+        {
+            "kind": mr.DANGLING_PANEL_ACTION,
+            "command": "orphan",
+            "subsystem": "ghost",
+            "detail": dicts[0]["detail"],
+        },
+    ]


### PR DESCRIPTION
## Why

Scheduled dispatch, empty work order → the live ▶ Next slice: **manifest spine PR3** (owner-approved
Q-0162; PR1 `CommandManifest` #1018 + PR2 `PanelManifest` #1019 shipped; sequenced in
[`manifest-spine-execution-plan-2026-06-17.md`](docs/planning/manifest-spine-execution-plan-2026-06-17.md)).

Makes the typed manifest **readable over the live control API** and **self-reconciling** — the spine's
stated core purpose: turn AST-classified panel metadata into *verified* metadata.

## What

1. **`GET /control/manifest`** on the dormant control API — token-only (global data, mirrors
   `/control/help/catalogue`), serving `CommandManifest.to_dict()` + `PanelManifest.to_dict()`; builds
   on demand from the bot when the startup cache is empty. + `control_client.get_manifest()`.
2. **Cross-manifest reconciliation** (`core/runtime/manifest_reconciliation.py`) — a pure projection: a
   `panel_action`-classified command whose subsystem owns **no** registered panel is a
   `dangling_panel_action` finding. Surfaced in `CommandManifest.to_dict()["findings"]` (was reserved
   `[]`) + the `command_manifest` diagnostics snapshot, so the live read carries its own trust signal.
3. **CI drift guard** — the cheap, non-flaky "AST is drift-detection" test: the AST `scan_commands`
   `panel_action` subsystems ⊆ the runtime `PanelManifest` subsystems (holds today: panel_action subs =
   {mining, moderation, role}, all have panels).

## Deferred honestly to PR4

No declared button→command binding exists yet, so a name-level `panel_action`↔button guard would be
false-positive-prone (Q-0120) — verified: `panel_action` command names do **not** map to button
action-id suffixes (`createrole` cmd vs `role:create` button). The per-button `command` binding + the
button-level reconciliation are PR4. The committed `dashboard.json` stays the AST `cogs` view (the
export can't import disbot); the live truth is `/control/manifest`.

## Verification
`check_quality --full` green · `check_architecture --mode strict` 0 · new reconciliation + endpoint tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5RAubLiGQhbZ4BSi1H6nu

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5RAubLiGQhbZ4BSi1H6nu)_