### PR TITLE
Plan: convert procedural prose into on-demand skills (slim CLAUDE.md ~25%)

### DIFF
--- a/.sessions/2026-06-17-procedures-to-skills-plan.md
+++ b/.sessions/2026-06-17-procedures-to-skills-plan.md
@@ -1,0 +1,52 @@
+# 2026-06-17 — Procedures→skills conversion plan
+
+> **Status:** `complete`
+> Manual, owner-live continuation of the 2026-06-17 routine-review session. Docs-only.
+
+**PR:** (this PR) — capture the procedures→skills conversion as an executable plan.
+**Branch:** `claude/procedures-to-skills-plan`
+
+## What was done
+
+- Captured the chat-only skills inventory (33 procedures, A/B/C buckets) into an **executable plan**:
+  `docs/planning/procedures-to-skills-conversion-plan-2026-06-17.md`.
+- Recorded the **owner-confirmed approach** (2026-06-17): relocate procedures to on-demand skills,
+  keeping a thin pointer + the binding rules in CLAUDE.md ("only get loaded when necessary").
+- Defined the **must-NOT-move safety list** (C-bucket) + the **thin-pointer convention** + the
+  **enforcement caveat** (mandatory enders stay hook-triggered) + a **batched build order**, with a
+  concrete before→after sample (the Q-0107 reconciliation bullet, ~28 → ~6 lines).
+- Linked the plan from the agent-tooling shortlist idea (Q-0170).
+
+## Decisions recorded
+
+- Owner approved the procedures→skills **direction** + the **relocate-not-delete / thin-pointer**
+  approach (extends Q-0170). **CLAUDE.md-editing batches are held born-red for owner review** (his core
+  instructions); add-only skill batches may merge on green.
+
+## Left open / next session
+
+- Execute **batch 1** (slim the Q-0107 reconciliation bullet → pointer) on the owner's go — held born-red
+  because it edits CLAUDE.md. Then batch 2 (enders → `/session-close`), batch 3 (new standalone skills).
+
+## 💡 Session idea
+
+**Idea:** a `check_pointer_integrity` lint — when CLAUDE.md keeps a "full procedure: `<doc/skill>`"
+thin pointer, assert the target exists and still contains the procedure.
+**Why:** the thin-pointer pattern's one failure mode is a dangling pointer after a later edit; a cheap
+stdlib guard makes the whole conversion safe to repeat across batches. (recorded here; small/disposable.)
+
+## ⟲ Previous-session review
+
+The previous session (#1026, this same conversation) correctly **held the governance edits born-red for
+owner review** instead of auto-merging — the right call for CLAUDE.md-touching work, and it paid off
+(the owner engaged and approved the direction). The improvement it surfaces, now captured in this plan:
+that "hold CLAUDE.md edits for review" instinct is written into the plan as an explicit per-batch rule,
+so it's a stated convention rather than a remembered one.
+
+## 📤 Run report
+
+- **Did:** captured the procedures→skills inventory as an executable plan + linked it · **Outcome:** shipped
+- **Run type:** manual (owner-live)
+- **⚑ Owner decisions needed:** greenlight to execute batch 1 (reconciliation bullet → pointer); choose all batches vs. a subset
+- **⚑ Owner manual steps:** none
+- **↪ Next:** execute batch 1 on the owner's go (held born-red — edits CLAUDE.md)

--- a/docs/ideas/agent-tooling-automation-shortlist-2026-06-17.md
+++ b/docs/ideas/agent-tooling-automation-shortlist-2026-06-17.md
@@ -15,6 +15,12 @@ strategy, and several recurring multi-step chores have no skill or script. This 
 to pick from; each item is small and the owner chooses which to build. (Distinct items get their own
 idea/plan — the two biggest already do: the consistency linter and the review inbox.)
 
+> **▶ Executable plan (2026-06-17, owner-confirmed approach):** the §A skill conversion is now planned
+> in detail — [`procedures-to-skills-conversion-plan-2026-06-17.md`](../planning/procedures-to-skills-conversion-plan-2026-06-17.md)
+> (the 33-procedure inventory, the thin-pointer convention, the must-NOT-move safety list, and the
+> batched build order). Owner's framing: relocate procedures to on-demand skills (load when needed),
+> keeping a thin pointer + the binding rules in CLAUDE.md.
+
 ## A. Dedicated Claude Code skills (slash commands for recurring flows)
 
 | Skill | Wraps the recurring flow | Why |

--- a/docs/planning/procedures-to-skills-conversion-plan-2026-06-17.md
+++ b/docs/planning/procedures-to-skills-conversion-plan-2026-06-17.md
@@ -1,0 +1,126 @@
+# Plan — Convert procedural prose into on-demand skills (slim the always-loaded context)
+
+> **Status:** `plan` — executable. Owner-directed + approved in-session 2026-06-17 (extends **Q-0170**;
+> the [agent-tooling shortlist](../ideas/agent-tooling-automation-shortlist-2026-06-17.md) is the idea).
+> Owner's framing: *"they won't be completely gone, but they will not waste so much space anymore and
+> only get loaded when necessary."* Source code + the binding contracts win over this file.
+
+## Goal
+
+Move the **procedural runbooks** ("do these steps to accomplish X") out of always-loaded context
+(`.claude/CLAUDE.md`, `docs/AGENT_ORIENTATION.md`) into **on-demand skills** (`.claude/skills/*`) and
+the routine prompts, so every session loads a leaner core. **Relocate, don't delete:** the knowledge
+still lives in the repo — it's just pulled when needed instead of read top-to-bottom every session.
+
+## The one rule that makes this safe — thin pointer + fat skill
+
+For each converted procedure, CLAUDE.md **keeps**:
+- the **owner directive + its Q-number** (so cross-references and provenance still resolve),
+- a **one-line WHAT** (so the agent knows the procedure exists and when to run it),
+- any **binding bar** that is a *rule*, not a step (e.g. "never forced filler", Q-0089),
+- a **pointer** to the skill/doc that holds the HOW.
+
+CLAUDE.md **loses**: the step-by-step detail (it moves to the skill/doc).
+
+> Net: the *rule* stays ambient; the *runbook* loads on demand. A converted bullet shrinks from
+> ~15–25 lines to ~2–4.
+
+**Enforcement caveat (important).** A skill only runs if it's *invoked*. For **mandatory-at-a-moment**
+procedures (the session enders), the trigger is already the **hook** (`scripts/claude_stop_check.py`)
++ the thin pointer — not the agent's memory. Do **not** convert a mandatory step into a skill *without*
+leaving the pointer + keeping the hook reminder. Pure "always behave this way" rules are **not**
+convertible at all (see the safety list).
+
+## Inventory (from the 2026-06-17 audit — 33 procedures)
+
+| Bucket | Count | Meaning |
+|---|---|---|
+| **A — already a skill** | 3 | `/pre-pr` · `/session-close` · `/architecture-review` |
+| **A — already a routine** | 2 | docs-reconciliation · dispatch (the autonomous form of a skill) |
+| **B — strong skill candidates** | ~13 | the procedural runbooks below |
+| **C — must stay always-loaded** | ~9 | the safety list below |
+
+**Realistic context win:** converting the B-bucket slims `.claude/CLAUDE.md` by **~100–120 lines
+(~25%)**, leaving the binding rules + architecture table + CodeGraph false-positive guide + orientation
+index in always-loaded context.
+
+## ⛔ Must NOT move (the C-bucket safety list)
+
+These shape behavior *continuously* or are *glob-triggered* — a skill (invoked at one moment) can't
+replace them. **A future session must not strip these from CLAUDE.md to "save space."**
+
+- The **architecture layer table** + the DB/Views/Mutations/Helpers invariants (binding rules).
+- The **Working agreement** principles (act-vs-ask, bugs-first, drift-on-sight Q-0166, "a new idea is
+  not a new priority").
+- The **CodeGraph false-positive rules** (`dead-unresolved`, name-collision, decorator entry points,
+  empty-callees, invisible edges) — safety-critical tool-use guardrails.
+- The **reading-order router** (`Read first` + AGENT_ORIENTATION's per-task routes) — orientation that
+  must be in-context before any task.
+- **ownership.md / runtime_contracts.md** references and the **question-router format** (governs owner
+  communication).
+- The **`.claude/rules/*.md`** files (mutation-and-db, discord-views, context-compiler) — already the
+  right mechanism: **glob-triggered**, so they load exactly when you edit the matching files.
+
+## Destinations + build order (each batch a real PR)
+
+| Batch | Convert | Destination | Risk | CLAUDE.md win |
+|---|---|---|---|---|
+| **1** | Q-0107 **reconciliation pass** bullet | the docs-reconciliation **routine prompt** (already owns the full procedure; manual sessions don't run it, Q-0124) → thin pointer | **low** (redundant with the routine doc) | ~20 lines |
+| **2** | session **enders** (Q-0015 groom · Q-0089 idea · Q-0102 review · Q-0104 audit) + born-red/PR-lifecycle (Q-0133/Q-0103) + claim-work (Q-0126) | **`/session-close`** (already holds most) + thin pointers; keep the Stop-hook reminder | med (mandatory, cross-referenced) | ~40 lines |
+| **3** | **new standalone skills** (no current home): `/pre-edit-check <file>` (context_map + arch), `/verify-bot` (boot + smoke), `/groom-ideas` | new `.claude/skills/*` + thin pointers from CLAUDE.md / journal | low (additive) | ~15 lines + journal |
+| **4** | the rest of the §A shortlist: `/route-idea` · `/cog-review` · `/plan-band` · `/fix-drift` · `/new-subsystem` | new skills (mostly *new capability*, little CLAUDE.md slimming) | low | small |
+
+**CLAUDE.md is the owner's core instruction file → every batch that edits it is held born-red for
+owner review** (the same posture #1026 used for the governance edits). Batches 3–4 that only *add*
+skills can merge on green.
+
+## Skill template (matches the existing `.claude/skills/*/SKILL.md` shape)
+
+```markdown
+# /skill-name
+<one-line purpose>
+
+## What this does
+<the procedure summary — points back to the CLAUDE.md directive + Q-number it implements>
+
+## Invocation
+/skill-name [args]
+
+## Instructions for Claude
+### Step 1 … (the runbook that USED to live in CLAUDE.md, verbatim + commands)
+```
+
+## Concrete before→after (Batch 1 sample — the reconciliation bullet)
+
+**BEFORE** (`.claude/CLAUDE.md`, ~28 lines): the full Q-0107 bullet — cadence history, the two-part
+reconcile+plan procedure, open-PR disposition, the band-depth + `PLAN BACKLOG THIN` flag, the
+auto-trigger workflow, the manual-session carve-out, the marker reset.
+
+**AFTER** (~6 lines):
+
+```markdown
+- **Reconciliation + planning pass — every 30th PR (Q-0107; cadence 30 per Q-0134).** A docs-only
+  review + next-band planning pass. **Run automatically by the docs-reconciliation routine — a
+  manually-started session does NOT run it unless the owner asks (Q-0124).** Full procedure (reconcile
+  ledger/docs/open-PRs · plan the full band, depth ≥ cadence + the ⚠️ PLAN BACKLOG THIN flag, Q-0164 ·
+  reset the marker): `docs/operations/autonomous-routines.md` (the routine's saved prompt), fired by
+  `.github/workflows/reconciliation-trigger.yml`. `scripts/check_reconciliation_due.py` flags when due.
+```
+
+The binding bits (cadence = 30, routine-owns-it, manual-doesn't, every Q-number) stay; the 20 lines of
+*how* move to the routine doc that already executes them.
+
+## Verification (per batch)
+
+- The moved procedure exists **verbatim** in its destination (no detail lost).
+- CLAUDE.md keeps the directive + Q-number + pointer; `grep` the moved Q-numbers across `docs/` to
+  confirm no cross-reference is orphaned.
+- `python3.10 scripts/check_docs.py --strict` + `check_session_log` + `check_quality.py --check-only`
+  green; the CLAUDE.md line-count drop is recorded in the PR.
+- (Idea: a `check_pointer_integrity` lint asserting each "full procedure: <target>" pointer resolves
+  to a target that still contains the procedure — captured in this session's log.)
+
+## Rollback
+
+Fully reversible (docs/skills only). If a converted procedure proves to be needed in always-loaded
+context after all, restore the prose from git history and drop the pointer.


### PR DESCRIPTION
Owner-live continuation of the routine-review session. The owner asked how many of the repo's already-described procedures could become Claude Code **skills** to slim always-loaded context, and confirmed the approach: *"they won't be completely gone, but they will not waste so much space anymore and only get loaded when necessary."*

This captures that (currently chat-only) analysis as an **executable plan** so it's not lost and becomes a buildable lane.

### What's in the plan
- The **33-procedure inventory** (A: already skills/routines · B: ~13 skill candidates · C: ~9 must-stay).
- The **thin-pointer + fat-skill convention** (relocate, don't delete) + the **enforcement caveat** (mandatory enders stay hook-triggered).
- The **⛔ must-NOT-move safety list** (architecture table, Working agreement, CodeGraph rules, orientation router, the glob-triggered `.claude/rules/`) so a future session can't strip binding rules to "save space."
- A **batched build order** (each a real PR; CLAUDE.md-editing batches held born-red for owner review) and a concrete **before→after sample** (the reconciliation bullet, ~28 → ~6 lines).

Realistic win: **~25% of CLAUDE.md** moves to on-demand skills, binding rules stay loaded.

Docs-only; auto-merges on green. **Execution (batch 1) is teed up for the owner's go.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EfHAjNAzYJCfsfCkj4tZgQ)_