### PR TITLE
Local character-render preview — kill the sprite-positioning loop (Q-0172, self-initiated)

### DIFF
--- a/.sessions/2026-06-17-character-preview-tool.md
+++ b/.sessions/2026-06-17-character-preview-tool.md
@@ -1,0 +1,79 @@
+# 2026-06-17 — Character preview tool + vault-cap decision
+
+> **Status:** `in-progress`
+> Manual session (owner-live). **Born-red per Q-0133.** Flip to `complete` when CI is green.
+> The preview tool is **self-initiated** under the new Q-0172 gate (built to solve a pain the owner
+> described, not explicitly requested) — flagged in the run report for review.
+
+**Branch:** `claude/character-preview-tool`
+
+## Goal
+
+The owner described the sprite workflow as brutal: ~40 ChatGPT tries to get the art right, then
+**100+ more rounds** on positioning — each a manual upload-to-Discord-and-eyeball. Positioning is now
+data (`manifest.json`), but there was **no local preview**, so the loop stayed manual. This adds one.
+
+## What was done
+
+- **`scripts/preview_character.py`** (NEW — self-initiated, Q-0172) — renders the **live** V-16
+  compositor (`disbot/utils/character_render.py`) to a PNG locally: a single tier, a custom loadout,
+  or a **contact sheet of all five tiers**; `--asset-dir` previews an alternate candidate pack. It
+  reuses the real renderer, so the preview is the exact image the bot ships. This kills the manual
+  loop — render → look → tune `manifest.json` → re-render in seconds. Crucially, an agent can *see*
+  the rendered PNG, so positioning tuning no longer needs the owner to upload test files. Q-0105 dev
+  tool, disposable.
+- **Vault hard-cap follow-up → DECLINED (owner, 2026-06-17):** recorded in the mining-structures
+  plan. The owner chose to keep the soft / warning-only cap ("just keep a warning for now"). One
+  mining owner-gate closed.
+
+## Decisions recorded
+
+- Owner: keep the vault cap **soft / warning-only**, no hard enforcement (fits Q-0087
+  "never mandatory-feeling"). Mining-structures plan updated.
+
+## Left open / next session
+
+- The remaining mining sprite gate is purely the owner's **art** — drop the PNGs into
+  `disbot/assets/gear/` (same names); the preview tool + manifest handle the rest. Once art lands I
+  can tune any off positioning via the preview loop.
+- **Mining feature roadmap (awaiting owner steer):** hub declutter (PR 2 — confirmed/turn-key, 16
+  buttons → 6 + sub-hubs) · grid Mine (PR 3 — new mechanic, needs design sign-off) · open-world
+  Explore incl. **fishing** (future design pass; also the Q-0172 fishing-plan candidate).
+
+## 💡 Session idea
+
+**Idea:** generalize the preview into a `scripts/preview_cards.py` family — local PNG previews for
+**every** bot image card (welcome card, inventory card, stat card, character doll), each reusing its
+live renderer. **Why:** the character-preview win (fast art/layout loop without deploying) applies to
+all the PIL surfaces; one small dev tool would give every future card-art or layout change the same
+seconds-not-hours loop. Disposable (Q-0105).
+
+## ⟲ Previous-session review
+
+The previous run (the Hermes house-style rollout, #1030) made the right architectural call —
+centralizing the 5 rules into one `_house-style.md` that skills *cite*, rather than copying the rules
+into each skill (so the next skill author inherits the style for free). **Improvement it surfaces:**
+it converted 5 of ~9 owner-facing skills and parked the rest in the card's "left open" — but a
+card's left-open list is easy to lose. Partial rollouts should also leave a one-line breadcrumb in
+`current-state.md ▶ Next action` (or an idea file), so the remainder is visible to the *next* session,
+not just buried in a closed card.
+
+## 📤 Run report
+
+- **Did:** built a local character-render preview tool (kills the sprite-positioning loop) + recorded the vault-cap decision · **Outcome:** shipped
+- **Shipped:** (this PR) — `scripts/preview_character.py` + the vault-cap-declined record
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** `none` (vault cap decided this session)
+- **⚑ Owner manual steps:** provide the **sprite art** — paint/commission the ~37 PNGs (per `disbot/assets/gear/README.md`) and drop them into `disbot/assets/gear/`; ping me to tune positioning
+- **⚑ Self-initiated:** `scripts/preview_character.py` — local character-render preview, built to solve the owner's stated sprite-positioning pain (no explicit request) (Q-0172)
+- **↪ Next:** owner picks the mining feature lane (hub declutter / grid Mine / fishing); I tune sprite positioning once art lands
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 2 (#1029, #1030); this is the 3rd |
+| CI-red rounds | TBD (filled at flip-to-complete) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (`preview_cards.py` family) |
+| Ideas groomed | 1 (vault-cap gate resolved; sprite gate clarified to art-only) |

--- a/.sessions/2026-06-17-character-preview-tool.md
+++ b/.sessions/2026-06-17-character-preview-tool.md
@@ -1,7 +1,8 @@
 # 2026-06-17 — Character preview tool + vault-cap decision
 
-> **Status:** `in-progress`
-> Manual session (owner-live). **Born-red per Q-0133.** Flip to `complete` when CI is green.
+> **Status:** `complete`
+> Manual session (owner-live). Born-red per Q-0133; flipped to `complete` after the full
+> `check_quality --full` mirror passed green (the only "red" was the intended born-red gate).
 > The preview tool is **self-initiated** under the new Q-0172 gate (built to solve a pain the owner
 > described, not explicitly requested) — flagged in the run report for review.
 
@@ -72,8 +73,8 @@ not just buried in a closed card.
 
 | Metric | Value |
 |---|---|
-| PRs merged this session | 2 (#1029, #1030); this is the 3rd |
-| CI-red rounds | TBD (filled at flip-to-complete) |
+| PRs merged this session | 3 (#1029, #1030, this #1031) |
+| CI-red rounds | 0 (only red was the intended born-red gate; full suite green first try) |
 | Repo-rule trips | 0 |
 | New ideas contributed | 1 (`preview_cards.py` family) |
 | Ideas groomed | 1 (vault-cap gate resolved; sprite gate clarified to art-only) |

--- a/docs/planning/mining-structures-skill-tree-plan-2026-06-14.md
+++ b/docs/planning/mining-structures-skill-tree-plan-2026-06-14.md
@@ -117,8 +117,10 @@ Vault"; mining is **never** blocked). The vault gets an **upgradeable capacity**
 (`mining_workflow.vault_upgrade`, migration 072 `vault_level` on `mining_player_state`). All
 **additive** (level 0 = the v1 base; nothing blocks deposits/withdrawals). Owner directive honored:
 warn at cap, no hard cap. Tests: `tests/unit/utils/test_mining_capacity.py` + vault-upgrade
-contract pins in `tests/unit/cogs/test_mining_vault.py`. **Follow-up (future slice, owner-gated):**
-hard enforcement (block a mine/deposit at cap) if the owner ever approves it.
+contract pins in `tests/unit/cogs/test_mining_vault.py`. **Follow-up — DECLINED by the owner
+(2026-06-17):** hard enforcement (block a mine/deposit at cap) was offered and the owner chose to
+**keep the soft / warning-only cap** ("just keep a warning for now") — it fits the Q-0087
+"never mandatory-feeling" rule. No hard-cap slice will be built; reopen only if the owner asks.
 
 Turns the shipped Vault from a convenience into a **real sink** (the §7.5 intent: *"inventory cap +
 safe stash"*). The active pack gets a **soft cap**; the vault is uncapped-but-built.

--- a/scripts/preview_character.py
+++ b/scripts/preview_character.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Preview the mining paper-doll character render locally — no Discord needed.
+
+Renders the V-16 character compositor (``disbot/utils/character_render.py``) to a
+PNG you can open, so iterating on the **sprite pack + positioning** takes seconds
+instead of the upload-to-Discord-and-eyeball loop. Render one tier, a custom
+loadout, or a contact sheet of every tier; point it at the live assets dir or a
+candidate pack you are trying out.
+
+Examples:
+    # contact sheet of all five tiers -> /tmp/character_preview.png
+    python3 scripts/preview_character.py
+
+    # one full set
+    python3 scripts/preview_character.py --tier diamond
+
+    # a tier set plus the mining tools (pickaxe / lantern / charm)
+    python3 scripts/preview_character.py --tier gold --mining
+
+    # a hand-picked loadout (slot=item, comma-separated)
+    python3 scripts/preview_character.py --loadout "weapon=diamond sword,helmet=gold helmet"
+
+    # preview a candidate pack in another folder (its manifest.json + PNGs)
+    python3 scripts/preview_character.py --asset-dir /tmp/my_new_pack --out /tmp/new_pack.png
+
+Tuning positioning: edit ``disbot/assets/gear/manifest.json`` (a family's
+``anchor`` = its centre on the 200x300 doll; ``scale`` x 256 = its box) and
+re-run — the render reflects the change immediately, no code edit.
+
+Provenance (Q-0105 dev tooling): added 2026-06-17 to kill the manual
+sprite-positioning loop (owner reported ~100+ upload/retest rounds). Pure dev
+convenience — stdlib + Pillow (already the render dependency) + the live
+compositor, so the preview is the exact image the bot ships. Not CI-wired.
+Delete if it stops earning its keep.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+from pathlib import Path
+
+# The bot's source root is ``disbot/`` (its modules import as ``from utils import
+# ...``); put it on the path so we reuse the *live* compositor — the preview is
+# then the exact render the bot produces, not a reimplementation.
+_DISBOT = Path(__file__).resolve().parents[1] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from utils import character_render, equipment  # noqa: E402  (path-dependent import)
+
+# Default output lives in the OS temp dir (portable; avoids a hardcoded /tmp).
+_DEFAULT_OUT = str(Path(tempfile.gettempdir()) / "character_preview.png")
+
+
+def _full_set(tier: str, *, mining: bool) -> dict[str, str]:
+    """A complete same-tier combat set, optionally plus the mining tools."""
+    loadout = {
+        equipment.WEAPON: f"{tier} sword",
+        equipment.SHIELD: f"{tier} shield",
+        equipment.HELMET: f"{tier} helmet",
+        equipment.CHESTPLATE: f"{tier} chestplate",
+        equipment.LEGGINGS: f"{tier} leggings",
+        equipment.BOOTS: f"{tier} boots",
+    }
+    if mining:
+        loadout.update(
+            {
+                equipment.TOOL: "diamond pickaxe",
+                equipment.LIGHT: "diamond lantern",
+                equipment.CHARM: "lucky charm",
+            },
+        )
+    return loadout
+
+
+def _parse_loadout(spec: str) -> dict[str, str]:
+    """Parse ``slot=item,slot=item`` into an ``{slot: item}`` loadout."""
+    loadout: dict[str, str] = {}
+    for raw in spec.split(","):
+        pair = raw.strip()
+        if not pair:
+            continue
+        if "=" not in pair:
+            raise SystemExit(f"bad --loadout segment {pair!r} (want slot=item)")
+        slot, item = (p.strip() for p in pair.split("=", 1))
+        if slot not in equipment.SLOTS:
+            raise SystemExit(
+                f"unknown slot {slot!r}; valid: {', '.join(equipment.SLOTS)}",
+            )
+        loadout[slot] = item
+    return loadout
+
+
+def _render_one(loadout: dict[str, str], asset_dir: str | None) -> bytes:
+    png = character_render.render_character_for(loadout, asset_dir=asset_dir)
+    if png is None:
+        raise SystemExit(
+            "render returned None — Pillow is not installed (pip install Pillow) "
+            "or the assets are unreadable.",
+        )
+    return png
+
+
+def _contact_sheet(asset_dir: str | None, *, mining: bool) -> bytes:
+    """Render every tier side by side with a label — the whole pack at a glance."""
+    from io import BytesIO
+
+    from PIL import Image, ImageDraw
+
+    pad, label_h = 12, 22
+    tiles = [
+        (
+            tier,
+            Image.open(BytesIO(_render_one(_full_set(tier, mining=mining), asset_dir))),
+        )
+        for tier in equipment.TIER_ORDER
+    ]
+    tile_w = max(t.width for _, t in tiles)
+    tile_h = max(t.height for _, t in tiles)
+    sheet = Image.new(
+        "RGB",
+        (len(tiles) * tile_w + (len(tiles) + 1) * pad, tile_h + label_h + 2 * pad),
+        (18, 19, 23),
+    )
+    draw = ImageDraw.Draw(sheet)
+    for i, (tier, tile) in enumerate(tiles):
+        x = pad + i * (tile_w + pad)
+        sheet.paste(
+            tile.convert("RGB"),
+            (x + (tile_w - tile.width) // 2, label_h + pad),
+        )
+        draw.text((x + 4, pad // 2), tier.upper(), fill=(220, 220, 230))
+    out = BytesIO()
+    sheet.save(out, format="PNG")
+    return out.getvalue()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Preview the character render locally.",
+    )
+    parser.add_argument(
+        "--tier",
+        choices=equipment.TIER_ORDER,
+        help="render one full same-tier set",
+    )
+    parser.add_argument("--loadout", help="custom 'slot=item,slot=item' loadout")
+    parser.add_argument(
+        "--mining",
+        action="store_true",
+        help="also equip the mining tools (pickaxe / lantern / charm)",
+    )
+    parser.add_argument(
+        "--asset-dir",
+        help="render from this pack dir (manifest + PNGs) instead of the live one",
+    )
+    parser.add_argument(
+        "--out",
+        default=_DEFAULT_OUT,
+        help=f"output PNG path (default: {_DEFAULT_OUT})",
+    )
+    args = parser.parse_args(argv)
+
+    if args.loadout:
+        png, what = (
+            _render_one(_parse_loadout(args.loadout), args.asset_dir),
+            "custom loadout",
+        )
+    elif args.tier:
+        png = _render_one(_full_set(args.tier, mining=args.mining), args.asset_dir)
+        what = f"{args.tier} full set"
+    else:
+        png, what = (
+            _contact_sheet(args.asset_dir, mining=args.mining),
+            "contact sheet (all tiers)",
+        )
+
+    out = Path(args.out)
+    out.write_bytes(png)
+    print(f"wrote {what} -> {out}  ({len(png)} bytes)")
+    print(f"assets: {args.asset_dir or character_render.ASSET_DIR}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
**Self-initiated under the new Q-0172 gate** (flagged `⚑ Self-initiated` in the session card for review) — built to kill a pain the owner described, not explicitly requested.

### The pain
Getting the gear sprites right took ~40 ChatGPT tries; **positioning took 100+ more rounds**, each a manual upload-to-Discord-and-eyeball. Positioning is already data (`manifest.json`), but there was **no local preview** — so the loop stayed manual.

### What this adds
`scripts/preview_character.py` renders the **live** V-16 compositor (`disbot/utils/character_render.py`) to a PNG locally — so the preview is the *exact* image the bot ships, not a reimplementation:

```
python3 scripts/preview_character.py                 # contact sheet of all 5 tiers
python3 scripts/preview_character.py --tier diamond  # one full set
python3 scripts/preview_character.py --asset-dir /tmp/candidate_pack   # try a new pack
```

The loop is now **render → look → tune `manifest.json` → re-render in seconds**. And because an agent can *see* the rendered PNG, **I can do the positioning tuning for you** instead of you uploading test files — exactly the part that cost you 100 rounds.

Q-0105 dev tool (stdlib + Pillow, the existing render dep; not CI-wired; disposable).

### Also
Records your **vault-cap decision** — keep it soft / warning-only (no hard enforcement) — in the mining-structures plan. One mining owner-gate closed; the only remaining sprite gate is your **art**.

Born-red (Q-0133) until the card flips; CI-green merges it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EfHAjNAzYJCfsfCkj4tZgQ)_