### PR TITLE
Codex integration (Q-0174) + seed-grid decision (Q-0173) + fix 3 Codex-flagged drift items

### DIFF
--- a/.claude/skills/session-close/SKILL.md
+++ b/.claude/skills/session-close/SKILL.md
@@ -101,13 +101,14 @@ Run these in order and fix any failures before proceeding:
 python3.10 scripts/check_docs.py --strict
 python3.10 scripts/check_session_log.py --strict      # Q-0089 idea + Q-0102 review present
 python3.10 scripts/check_current_state_ledger.py --strict  # merged PRs are in the ledger
-python3.10 scripts/check_reconciliation_due.py        # Q-0107: is a 10th-PR docs/planning pass due?
+python3.10 scripts/check_reconciliation_due.py        # Q-0107: is a 30th-PR docs/planning pass due? (cadence 30, Q-0134)
 python3.10 scripts/check_quality.py --check-only
 ```
 
 If `check_reconciliation_due` reports **DUE**, the next session should be a docs-only review +
-planning-reconciliation pass (Q-0107: reconcile repo state + plan the next ~9 PRs, modular but
-not over-segmented); after that pass, reset the `Last reconciliation pass:** PR #N` marker in
+planning-reconciliation pass (Q-0107: reconcile repo state + plan the next **full band** — depth ≥ the
+30-PR cadence, Q-0164; raise ⚠️ PLAN BACKLOG THIN if the idea backlog can't fill it); after that pass,
+reset the `Last reconciliation pass:** PR #N` marker in
 `current-state.md` to the latest PR.
 
 If `check_session_log` fails, add the missing `💡 Session idea` / `⟲ Previous-session

--- a/.sessions/2026-06-17-command-manifest-spine-slice1.md
+++ b/.sessions/2026-06-17-command-manifest-spine-slice1.md
@@ -62,7 +62,7 @@ matching manifest refresh *fails CI* — turning "two sources that might silentl
 them is authoritative and the other is a guard." It's the structural payoff that makes the whole spine
 trustworthy, and it's the cheapest way to keep the AST honest as the manifest grows.
 
-## ⟲ Previous-slice review (Q-0102)
+## ⟲ Previous-session review (Q-0102)
 
 The immediately-previous slice this session (#1017, the global settings tier) went well — it shipped a
 complete read+write feature with 18 tests and correctly reasoned about *not* forcing a 2nd slice when

--- a/.sessions/2026-06-17-settle-decisions-codex.md
+++ b/.sessions/2026-06-17-settle-decisions-codex.md
@@ -1,9 +1,9 @@
 # 2026-06-17 — Settle mining/seed decisions + surface Codex's reviews
 
-> **Status:** `in-progress`
-> Manual session (owner-live), context-conscious: the owner asked to **settle decisions/ideas and let
-> the routines finish the build** after the weekly reset. Docs-only. Born-red per Q-0133; flip to
-> `complete` when CI is green. (Edits `.claude/skills/session-close/SKILL.md` — a skill, not CLAUDE.md.)
+> **Status:** `complete`
+> Manual session (owner-live), context-conscious: settle decisions/ideas, let the routines finish the
+> build after the weekly reset. Docs-only. Born-red per Q-0133; flipped to `complete` after CI green +
+> the Codex-integration follow-up (Q-0174) + 3 verified Codex-flagged drift fixes landed.
 
 **Branch:** `claude/settle-decisions-codex`
 
@@ -65,10 +65,10 @@ own + recent PRs before closing**, not wait to be asked — fold a "check bot re
 
 ## 📤 Run report
 
-- **Did:** settled the seed decision (Q-0173), surfaced + verified Codex's reviews, fixed the drift Codex caught, made the buildable lanes routine-discoverable · **Outcome:** shipped
+- **Did:** settled the seed decision (Q-0173) + the **Codex-integration directive (Q-0174** — the "real bug" bar + the issue-only Hermes-PR-check spec); surfaced/verified Codex's reviews + **fixed 3 real drift items it flagged** (`/session-close` cadence · roadmap "~9 PRs" · the manifest card's `Previous-slice`→`Previous-session` heading); made the buildable lanes routine-discoverable · **Outcome:** shipped
 - **Shipped:** (this PR) — docs-only settle (Q-0173 · Codex feedback folded · session-close drift fix · roadmap homing)
 - **Run type:** `manual`
-- **⚑ Owner decisions needed:** grid-Mine design Qs + fishing design Qs still pending your answers (Q-0173/Q-0172 tails); whether to switch Codex to review-on-final-head
+- **⚑ Owner decisions needed:** grid-Mine + fishing design Qs (Q-0173/Q-0172 tails); **Codex mode** — keep it comment-only or allow its "open a fix PR" mode? (Q-0174); whether to switch Codex to review-on-final-head
 - **⚑ Owner manual steps:** (optional) set the Codex connector to review on the final head (or we add the `@codex review`-on-complete Action)
 - **⚑ Self-initiated:** `none` (both tasks were owner-asked: document decisions + surface Codex) (Q-0172)
 - **↪ Next:** routines build the queue after the weekly reset; you answer the grid-Mine / fishing design Qs when ready

--- a/.sessions/2026-06-17-settle-decisions-codex.md
+++ b/.sessions/2026-06-17-settle-decisions-codex.md
@@ -1,0 +1,84 @@
+# 2026-06-17 — Settle mining/seed decisions + surface Codex's reviews
+
+> **Status:** `in-progress`
+> Manual session (owner-live), context-conscious: the owner asked to **settle decisions/ideas and let
+> the routines finish the build** after the weekly reset. Docs-only. Born-red per Q-0133; flip to
+> `complete` when CI is green. (Edits `.claude/skills/session-close/SKILL.md` — a skill, not CLAUDE.md.)
+
+**Branch:** `claude/settle-decisions-codex`
+
+## Goal
+
+Two owner asks: (1) document the current decisions/ideas so the routines can build them after the
+weekly limit reset; (2) surface what Codex replied on a PR (the owner flagged it; I'd claimed I could
+read Codex's reviews directly — time to prove it).
+
+## What was done
+
+**Codex reviews — found them + verified I read them directly.** Codex left real inline review comments
+(P1/P2 severity badges) on #1023 / #1024 / #1027 / #1028. Two classes:
+- **Genuine catches on docs/plan PRs (#1028):** 2 of its 4 points **verified correct and fixed this
+  session** — `/session-close` still said "10th-PR / ~9 PRs" (stale vs. the 30-PR / full-band cadence,
+  Q-0134/Q-0164), and the procedures-to-skills plan wasn't on `roadmap.md` (routines wouldn't discover
+  it). All 4 catches folded into the plan.
+- **Born-red false-positives (#1023/#1024/#1027):** Codex reviews on PR *open* = our card-first commit,
+  *before* the code lands — so it flagged "implementation missing / flip the card / script doesn't
+  exist," all `is_outdated` noise. Captured the fix (trigger `@codex review` on the final head) in the
+  Codex idea doc as an owner call.
+
+**Decisions settled:**
+- **Q-0173 — mining grid world = seed-deterministic procedural** (owner picked option #1 over literal
+  Minecraft-terrain replication). Recorded in the router + the mining-hub-redesign plan (resolves the
+  "fixed vs procedural" question; other grid-Mine design Qs stay owner-pending).
+- Vault cap = soft / warning-only (recorded #1031).
+
+**Routine-discoverability (so the routines can finish the job after the reset):**
+- Added the **procedures→skills conversion plan** to `roadmap.md` S4 (Codex catch #4).
+- Folded Codex's 4 review notes into the procedures-to-skills plan for the batch executors.
+- Fixed the `/session-close` cadence drift (Codex catch #1).
+
+## Left open / owner-pending (for after the reset)
+
+- **Grid-Mine design Qs** (Q-0173 tail): shared vs per-level grid · do moves cost a turn? · cell-yield
+  ↔ depth bands. **Fishing design Qs** (Q-0172): own loot ladder vs reskinned · water-gated? · rod on
+  the character doll? **Mining lane order:** hub declutter (PR2) recommended first.
+- **Buildable queue for the routines:** mining hub-declutter (PR2) · grid Mine (PR3, seed) · skills
+  batches 2–4 · Hermes house-style remaining skills · fishing plan. All on the roadmap + planning docs.
+
+## 💡 Session idea
+
+**Idea:** a tiny GitHub Action (or a line in `auto-merge-enabler`) that posts **`@codex review` when a
+`claude/*` PR's session card flips to `complete`** (the final head), so Codex reviews the *complete*
+diff instead of the born-red opening commit. **Why:** today Codex's auto-review fires at PR-open, which
+in our born-red flow is the card-only commit — wasting most of its code reviews on incomplete state
+(the #1023/#1024/#1027 false positives). Re-triggering on the final head turns Codex into a real
+second-reviewer on the actual diff. Pairs with Q-0171.
+
+## ⟲ Previous-session review
+
+The previous run (#1031, the preview tool) was a strong self-initiated call — pure tooling that solved
+the owner's stated pain. **What it (and I) missed:** it never checked whether Codex had reviewed the
+recent PRs, so the owner had to prompt me about Codex's reply. **System improvement:** when a session
+touches subscribed-PR activity, it should proactively sweep for **bot reviews (Codex/Copilot) on its
+own + recent PRs before closing**, not wait to be asked — fold a "check bot reviews" line into the
+`/session-close` audit.
+
+## 📤 Run report
+
+- **Did:** settled the seed decision (Q-0173), surfaced + verified Codex's reviews, fixed the drift Codex caught, made the buildable lanes routine-discoverable · **Outcome:** shipped
+- **Shipped:** (this PR) — docs-only settle (Q-0173 · Codex feedback folded · session-close drift fix · roadmap homing)
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** grid-Mine design Qs + fishing design Qs still pending your answers (Q-0173/Q-0172 tails); whether to switch Codex to review-on-final-head
+- **⚑ Owner manual steps:** (optional) set the Codex connector to review on the final head (or we add the `@codex review`-on-complete Action)
+- **⚑ Self-initiated:** `none` (both tasks were owner-asked: document decisions + surface Codex) (Q-0172)
+- **↪ Next:** routines build the queue after the weekly reset; you answer the grid-Mine / fishing design Qs when ready
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 3 (#1029/#1030/#1031); this docs PR is the 4th |
+| CI-red rounds | 0 (born-red gate only) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (`@codex review` on card-complete) |
+| Ideas groomed | 1 (seed decision Q-0173 settled; vault-cap closed) |

--- a/docs/ideas/codex-automated-pr-review-2026-06-17.md
+++ b/docs/ideas/codex-automated-pr-review-2026-06-17.md
@@ -22,6 +22,25 @@ Codex is **enabled and working** on `menno420/superbot`. What we observed + what
   summary comment every time** (not just a reaction). If it only reacts when it has no objection, its
   reasoning is invisible; a per-PR review comment makes every verdict readable by the loop.
 
+### What Codex actually caught (2026-06-17, verified) + the born-red friction
+
+Codex moved past reactions and **left real inline review comments** (P1/P2 severity badges + a "React
+👍/👎" footer); an agent reads them directly via `get_review_comments` / `get_reviews`. Two findings:
+
+- **It catches genuine issues on docs/plan PRs.** On #1028 (the procedures-to-skills plan) it raised 4
+  still-open P2 points — two **verified correct** and fixed this session: the `/session-close` skill
+  still said "10th-PR / ~9 PRs" (stale vs. the 30-PR/full-band cadence, Q-0134/Q-0164) and the plan
+  wasn't homed on `docs/roadmap.md` (so routines wouldn't discover it). Good signal — Codex is earning
+  its keep on documentation/plan review.
+- **⚠️ The born-red flow defeats most of its *code* reviews.** Codex reviews **on PR open**, which in our
+  born-red workflow (Q-0133) is the **card-first commit — *before* the implementation lands.** So on
+  #1023/#1024/#1027 it flagged "the implementation isn't here / flip the card / the script doesn't
+  exist" — all `is_outdated` false-positives from reviewing the incomplete opening commit. **The fix to
+  decide with the owner** (it touches the Codex settings he configured): to get a useful Codex pass,
+  trigger it on the **final head** — comment `@codex review` after the code + card-flip, before merge —
+  rather than relying on the open-time auto-review. Until then, weight Codex's docs/plan catches highly
+  and treat its "missing implementation" comments on born-red code PRs as timing artifacts.
+
 ## The idea
 
 Wire **Codex (OpenAI) to automatically review pull requests** as they open/update, posting review

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -6354,3 +6354,37 @@ moves cost a turn / trigger encounters · how cell yields map to the existing de
 
 **Home:** [`planning/mining-hub-redesign-2026-06-15.md`](../planning/mining-hub-redesign-2026-06-15.md)
 § "Mine — 3D grid navigator" · this Q-block. Related: Q-0172 (fishing/open-world is the sibling Explore lane).
+
+### Q-0174 — Codex review integration: routines fix flagged-real issues first; Hermes scans PRs (issue-only) (2026-06-17)
+
+> **DIRECTED — owner-in-session, 2026-06-17:** *"make sure the routines all check the previous PRs for
+> any of codex's comments, the first priority of any routine should be to fix anything codex flagged,
+> but not blindly… hermes on a 6H timer to check PRs and open an issue if necessary… before we do this
+> we should define what a real bug is… for now until hermes has been proven… it just opens an issue and
+> only dispatches on command."*
+
+**Context:** Codex (Q-0171) is live and **catching real drift** — verified this session it flagged the
+stale `/session-close` cadence, a roadmap "~9 PRs" line, and a mis-named session-card heading
+(`Previous-slice` vs the checker-required `Previous-session`) — all real, all fixed. (The owner is
+amazed a *code* reviewer spotted *docs* drift — evidence the repo is genuinely navigable.) But Codex
+also produces **born-red false positives** (it reviews the card-first commit before the code lands) and
+can run "make changes" tasks, so the loop needs a bar + a budget-aware consumer.
+
+**Decision (plan: `planning/codex-review-integration-plan-2026-06-17.md`):**
+1. **Routines check Codex first** — every routine's first priority: scan recent PRs for unresolved
+   Codex/bot flags, **verify against source**, fix the real ones first; never blindly (Q-0120).
+2. **The "real bug" bar** — verified-against-current-source · a genuine defect/contradiction (correctness
+   · arch/ownership · docs-vs-code drift · security) · not a nitpick. Explicitly rejects the born-red
+   timing class.
+3. **Hermes 6H PR-check (spec; issue-only)** — a new `superbot-pr-check` skill (6H) opens a GitHub issue
+   per real bug; **does NOT auto-dispatch** — dispatch only on command until Hermes is a proven
+   dispatcher. **Why:** only ~15 routine fires/day (~12 dispatch, ~1–2 reconciliation) — too scarce to
+   spend on false positives. Auto-dispatch is a later, separate owner decision.
+
+**Open for the owner:** does Codex stay **comment-only**, or is its "open a fix PR" mode wanted? (Its
+auto-PRs can collide with in-flight PRs + consume review.) Complementary fix — `@codex review` on the
+**final head** (codex idea doc) — lands its *code* reviews on the complete diff, not the born-red opener.
+
+**Home:** [`planning/codex-review-integration-plan-2026-06-17.md`](../planning/codex-review-integration-plan-2026-06-17.md)
+· [`codex-automated-pr-review-2026-06-17.md`](../ideas/codex-automated-pr-review-2026-06-17.md) · this
+Q-block. Related: Q-0171 (Codex live), Q-0120 (verify bot output vs source), Q-0117 (Hermes review-merge gate).

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -6331,3 +6331,26 @@ banner) · the dispatch routine prompt + skills (`hermes-dispatch-bridge.md`, `h
 **Home:** this Q-block · `.claude/CLAUDE.md` Working agreement. Related: Q-0114 (the retired phase gate),
 Q-0164 (PLAN BACKLOG THIN flag), Q-0165 (Run type line — the ⚑ Self-initiated line is its sibling),
 Q-0106 (in-session-directive exception).
+
+### Q-0173 — Mining grid world: seed-deterministic (option #1), not literal Minecraft terrain (2026-06-17)
+
+> **DIRECTED — owner-in-session, 2026-06-17:** asked *"is it possible to fetch a seed directly from
+> Minecraft and use that as our actual grid?"* After a feasibility breakdown (no API fetches terrain; a
+> seed is just a number; the spectrum = seed-as-RNG / Cubiomes biome-replication / full-block-gen), the
+> owner picked **#1: "probably the best option."**
+
+**Decision:** The grid Mine (mining-hub-redesign PR3) world model is a **seed-deterministic procedural
+grid we generate ourselves** — any number ("seed") feeds our own generator, so `seed 12345` produces
+the same world for everyone (deterministic · **shareable** · effectively infinite). This resolves the
+plan's open "fixed vs procedural/infinite" question → **procedural, seed-deterministic.** It is *not*
+literal Minecraft terrain: that would need either a reverse-engineered gen library (Cubiomes — biomes
++ structures only, a real C dependency; the *later* upgrade path if true Minecraft-shaped worlds are
+wanted) or running an actual Minecraft generator (Java server + region files — too heavy for Railway,
+rejected). Licensing stays clean — a seed is just a number; we ship no Minecraft code or assets.
+
+**Still open (owner deciding — do NOT resolve unprompted):** one shared grid vs. per-depth-level · do
+moves cost a turn / trigger encounters · how cell yields map to the existing depth bands
+(`utils/mining/world.py`, currently 1-D). These are the remaining grid-Mine design questions.
+
+**Home:** [`planning/mining-hub-redesign-2026-06-15.md`](../planning/mining-hub-redesign-2026-06-15.md)
+§ "Mine — 3D grid navigator" · this Q-block. Related: Q-0172 (fishing/open-world is the sibling Explore lane).

--- a/docs/planning/codex-review-integration-plan-2026-06-17.md
+++ b/docs/planning/codex-review-integration-plan-2026-06-17.md
@@ -1,0 +1,71 @@
+# Plan — Codex review integration: routines fix flagged issues first; Hermes scans PRs (issue-only)
+
+> **Status:** `plan` — owner-directed 2026-06-17 (**Q-0174**). Builds on Q-0171 (Codex live) + the
+> born-red-timing finding ([`codex-automated-pr-review-2026-06-17.md`](../ideas/codex-automated-pr-review-2026-06-17.md)).
+> Source + binding contracts win over this plan.
+
+## Owner directive (2026-06-17)
+
+- **Every routine's first priority: check recent PRs for Codex's comments and fix anything Codex
+  flagged — verified, never blindly** (Claude verifies by default; stated explicitly here so it's a
+  rule, not a habit).
+- **Hermes on a 6H timer checks PRs and OPENS AN ISSUE** for real problems. **NOT auto-dispatch** — it
+  "dispatches only on command" until it is proven a valuable dispatcher.
+- **Budget rationale (why issue-only):** only **~15 routine fires/day** (~12 scheduled dispatch, ~1–2
+  reconciliation). Routine fires are scarce, so Hermes must never burn one on a false positive. Hence
+  the issue-only default + the "real bug" bar below.
+
+## What counts as a "real bug" / actionable flag (the bar)
+
+A Codex/bot review comment (or CI signal) is **ACTIONABLE only if ALL** hold:
+
+1. **Verified against current `main` source — real *now*, not an artifact.** Reject the common non-bugs:
+   - **the born-red timing class** — Codex reviews the *card-first* commit *before* the code lands, so
+     it flags "implementation missing / flip the card / script doesn't exist" (the #1023/#1024/#1027
+     false positives); an `is_outdated` thread; a since-fixed line.
+2. **A genuine defect or contradiction** — one of: a **correctness bug** (wrong behaviour / crash /
+   broken contract or invariant) · a real **architecture/ownership violation** (services→views, raw SQL
+   outside `utils/db/`, an unaudited mutation) · a **docs-vs-code contradiction or stale-fact drift**
+   that would mislead an agent (e.g. the `/session-close` cadence Codex caught) · a **security / safety /
+   privacy** gap.
+3. **Not a nitpick / preference / false positive** — "could be cleaner", speculative "might want to", or
+   anything the repo's own checkers already pass is **not** a real bug.
+
+**Unsure → open an issue describing what you found; do not dispatch.** Never act blindly — the bot is
+one input, verified against shipped source (Q-0120).
+
+## Part A — routines check Codex first (prompt change, ships now)
+
+Add to the **dispatch** + **reconciliation** routine prompts a first-priority step: *before* taking new
+work, scan the **few most-recent merged PRs (and any open ones)** for **unresolved** Codex/bot review
+comments; apply the bar above; **fix the verified-real ones first** (they jump the queue like a bug).
+Bounded read (the recent PRs, not the whole history) to respect the token budget. A born-red
+false-positive is acknowledged-and-skipped, not "fixed."
+
+## Part B — Hermes 6H PR-check skill (to build; spec only for now)
+
+A new hermes-skill `superbot-pr-check`, self-scheduled **every 6H** (`blueprint.schedule "0 */6 * * *"`),
+that:
+
+1. Lists open + recently-merged PRs; for each reads Codex review comments, CI status, unresolved review
+   threads.
+2. Applies the **"real bug" bar** above.
+3. For each real bug → **opens a GitHub issue** (clear title · the PR/file/line · what's wrong · which
+   bar clause it meets), labelled so the dispatch routine can pick it up as a bug-book-class item.
+4. **Does NOT auto-dispatch a fixer.** Dispatch happens only on the owner's command (or a routine
+   picking the issue up on its normal fire).
+5. Output in the plain-language **house style** (`_house-style.md`).
+
+**Build steps (when a routine executes this):** `docs/operations/hermes-skills/pr-check.md` (doc =
+source of truth) + an `EXTRAS` entry with the 6H `schedule` in `scripts/hermes/build_skills.py` +
+a README row + rebuild. **Owner manual step:** redeploy on the VPS (`install-skills.sh`).
+
+**Graduation:** once Hermes's issues prove consistently real (a few cycles), revisit **auto-dispatch on
+a real bug** — a later owner decision, not part of this build.
+
+## Verification / rollback
+
+Docs + prompt edits are fully reversible. The skill is additive and **issue-only** (no merge or
+dispatch authority), so it is low-risk; it never gains dispatch authority without an explicit owner
+decision. The routine `@codex review`-on-final-head idea (codex idea doc) is the complementary fix that
+makes Codex's *code* reviews land on the complete diff instead of the born-red opening commit.

--- a/docs/planning/mining-hub-redesign-2026-06-15.md
+++ b/docs/planning/mining-hub-redesign-2026-06-15.md
@@ -49,6 +49,12 @@ this **replaces** the old linear Descend/Ascend.
 - **Open design questions:** one shared grid vs. per-level · fixed size vs. procedural/infinite ·
   do moves cost a turn / trigger encounters · how cell yields relate to the existing depth-band
   tables (`utils/mining/world.py`, currently 1-D depth).
+- **World model — DECIDED (owner, Q-0173, 2026-06-17):** a **seed-deterministic procedural grid we
+  generate ourselves** — any number ("seed") feeds our own generator, so `seed 12345` gives everyone
+  the same world (deterministic · **shareable** · effectively infinite). This resolves "fixed vs
+  procedural/infinite" above → **procedural.** NOT literal Minecraft terrain (no API fetches it;
+  replicating it needs Cubiomes for biomes — a *later* upgrade — or a Java generator, rejected as too
+  heavy for Railway). The other open questions above stay owner-pending.
 
 ## Build order
 

--- a/docs/planning/procedures-to-skills-conversion-plan-2026-06-17.md
+++ b/docs/planning/procedures-to-skills-conversion-plan-2026-06-17.md
@@ -110,6 +110,23 @@ auto-trigger workflow, the manual-session carve-out, the marker reset.
 The binding bits (cadence = 30, routine-owns-it, manual-doesn't, every Q-number) stay; the 20 lines of
 *how* move to the routine doc that already executes them.
 
+## Codex review feedback (PR #1028, 2026-06-17 — fold into the batches)
+
+Codex's automated review of this plan raised 4 points (still open on the PR); the first two were
+verified correct and actioned this session:
+
+1. **Batch 1 also de-stales `/session-close`.** Slimming the CLAUDE.md Q-0107 bullet to a pointer left
+   the `/session-close` skill's old "10th-PR / ~9 PRs" cadence contradicting Q-0134/Q-0164. *(Fixed
+   2026-06-17.)*
+2. **This plan needs a roadmap horizon row** (the "Adding a plan" contract), or dispatch/reconciliation
+   agents won't discover it. *(Added to the S4 lane in `roadmap.md`, 2026-06-17.)*
+3. **Batch 2 — keep pre-work rules loadable *before* work starts.** Q-0126 (claim work) + Q-0133/Q-0103
+   (born-red) are needed before a session / right after the first push, not at close; don't bury their
+   HOW only inside `/session-close`. Put them in a startup/pre-work skill (or keep them always-loaded).
+4. **Batch 3 — any CLAUDE.md pointer edit is born-red.** Batch 3 is "add-only / merge on green," but its
+   row also adds CLAUDE.md pointers; state explicitly that *any* CLAUDE.md edit (even a pointer) is
+   born-red for owner review, so it can't auto-merge.
+
 ## Verification (per batch)
 
 - The moved procedure exists **verbatim** in its destination (no detail lost).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,7 +5,7 @@
 > sector is a self-contained dispatch queue. **Last updated:** 2026-06-14 (restructured by
 > sector — the next-session brief acting on the [sector map](repo-sector-map.md)).
 >
-> **▶ The live decade queue (next ~9 PRs):**
+> **▶ The live queue (next full band — ~30 PRs, the 30-PR cadence Q-0134):**
 > [`planning/reconciliation-pass-2026-06-17-band1020.md`](planning/reconciliation-pass-2026-06-17-band1020.md)
 > §4 — set by the eleventh Q-0107 pass (issue #1021). **▶ Next ungated startable = moderation-DM config**
 > ([moderation-dm-config-plan](planning/moderation-dm-config-plan-2026-06-17.md), turn-key, Q-0147 —

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -595,7 +595,11 @@ condition — every sector non-empty).*
   fix the ledger, refactor the roadmap) each time merged PRs cross a **multiple of 30** (Q-0134; the
   trigger/checker **machinery is S3**, the docs it writes are S4) · the session enders (Q-0089 idea ·
   Q-0102 prev-session review · Q-0104 closing audit).
-- **Next** — the **thin architecture atlas** (PR 2 of
+- **Next** — the **procedures→skills conversion**
+  ([`procedures-to-skills-conversion-plan-2026-06-17.md`](planning/procedures-to-skills-conversion-plan-2026-06-17.md);
+  Q-0170/Q-0172 — relocate ~25% of always-loaded `CLAUDE.md` into on-demand skills; **batch 1 shipped
+  #1029**, batches 2–4 next, incorporating the PR-#1028 Codex review notes) · the **thin architecture
+  atlas** (PR 2 of
   [`extension-taxonomy-crosswalk-plan-2026-06-16.md`](planning/extension-taxonomy-crosswalk-plan-2026-06-16.md);
   Q-0151a — a companion to orientation, composing `context_map`/`wiring_map`/`review_scope` + the role
   data into one repo-wide CI-`--check` index) · idea-backlog **grooming** (Q-0015 — every idea ends


### PR DESCRIPTION
Docs-only **settle + Codex-integration** pass (you asked to document the decisions, let the routines build after the weekly reset — and to wire Codex's flags into the routines).

### Decisions settled
- **Q-0173 — the mining grid world = a seed-deterministic procedural grid we generate ourselves** (you picked option #1 over literal Minecraft-terrain replication). Router + mining-hub-redesign plan; resolves the "fixed vs procedural" question. Other grid-Mine design Qs stay owner-pending.
- **Q-0174 — Codex review integration** ([plan](https://github.com/menno420/superbot/blob/main/docs/planning/codex-review-integration-plan-2026-06-17.md)): routines check Codex first (verified, never blindly) · the **"real bug" bar** · the **issue-only Hermes 6H PR-check** spec (dispatch only on command, given your ~15 routine-fires/day budget).

### Codex — verified I read it directly, and acted on it
Codex flagged real drift on the day's PRs; this session **fixed 3 verified-real items it caught**:
- `/session-close` skill's stale "10th-PR / ~9 PRs" cadence → 30-PR full-band (Q-0134/Q-0164).
- `roadmap.md` "decade queue (next ~9 PRs)" → full-band wording.
- the manifest-spine session card's `Previous-slice review` heading → `Previous-session review` (check_session_log now passes).

Its **born-red false positives** (it reviews the card-first commit before code lands) are documented in the Codex idea doc, with the fix (`@codex review` on the final head).

### Open for you
Keep Codex **comment-only**, or allow its "open a fix PR" mode? (It tried to open its own task/PR here — auto-PRs can collide with in-flight work.)

Born-red flipped to complete; CI-green merges it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)