### PR TITLE
Codex: agents read its edits in the comment, not a phantom PR/branch (Q-0174 resolved)

### DIFF
--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -6381,9 +6381,13 @@ can run "make changes" tasks, so the loop needs a bar + a budget-aware consumer.
    dispatcher. **Why:** only ~15 routine fires/day (~12 dispatch, ~1–2 reconciliation) — too scarce to
    spend on false positives. Auto-dispatch is a later, separate owner decision.
 
-**Open for the owner:** does Codex stay **comment-only**, or is its "open a fix PR" mode wanted? (Its
-auto-PRs can collide with in-flight PRs + consume review.) Complementary fix — `@codex review` on the
-**final head** (codex idea doc) — lands its *code* reviews on the complete diff, not the born-red opener.
+**RESOLVED (owner, 2026-06-17/18):** the comment-only-vs-auto-PR question is **moot — Codex is
+structurally comment-only.** It cannot push a branch or open a PR autonomously (a human must press
+"create PR" in the Codex UI); its "make changes" output is a *comment* describing a sandbox diff, never
+a repo change. **Decision: trial it as-is** (auto-review on). The only safeguard needed: **agents read
+Codex's proposed edits in its *comment*, not in a phantom branch/PR** (plan Part A § "Where Codex's edits
+live"). Still open — the `@codex review`-on-**final-head** tweak (codex idea doc) to land its *code*
+reviews on the complete diff, not the born-red opener.
 
 **Home:** [`planning/codex-review-integration-plan-2026-06-17.md`](../planning/codex-review-integration-plan-2026-06-17.md)
 · [`codex-automated-pr-review-2026-06-17.md`](../ideas/codex-automated-pr-review-2026-06-17.md) · this

--- a/docs/planning/codex-review-integration-plan-2026-06-17.md
+++ b/docs/planning/codex-review-integration-plan-2026-06-17.md
@@ -42,6 +42,19 @@ comments; apply the bar above; **fix the verified-real ones first** (they jump t
 Bounded read (the recent PRs, not the whole history) to respect the token budget. A born-red
 false-positive is acknowledged-and-skipped, not "fixed."
 
+### Where Codex's edits live — read its COMMENT, don't hunt for a PR/branch (owner-confirmed 2026-06-17)
+
+**Codex cannot push a branch or open a PR autonomously** — a human must press "create PR" in the Codex
+UI for anything to land. So when its auto-review runs a "task / make changes," the result is a
+**comment**: a summary + a *proposed* diff + a `[View task →]` chatgpt.com link, describing changes in
+**Codex's own sandbox copy** — even when it says "Committed `<sha>`" / "Created PR." **Nothing reaches
+our repo.** Therefore an agent acting on a Codex flag:
+- reads the **proposed change from Codex's comment** (the diff / the `file·Lnn` references it cites),
+- **verifies each against current `main`** (the bar above),
+- **applies the real ones itself** (one writer per file — the agent's own PR),
+- does **NOT** hunt for a Codex-pushed branch or a Codex PR (there is none — that hunt was the only
+  real friction Codex caused, a verification detour on #1032).
+
 ## Part B — Hermes 6H PR-check skill (to build; spec only for now)
 
 A new hermes-skill `superbot-pr-check`, self-scheduled **every 6H** (`blueprint.schedule "0 */6 * * *"`),


### PR DESCRIPTION
Owner-confirmed: **Codex can't land changes on its own** — it has no write access, so a human must press "create PR" in the Codex UI. Its "make changes" output is a **comment** describing a diff in its *own sandbox copy* (even when it says "Committed `<sha>` / Created PR"). Nothing reaches our repo.

So the fix is to make agents look in the **right place**:
- `codex-review-integration-plan` Part A → new "Where Codex's edits live" note: read the proposed change from Codex's **comment**, verify against `main`, apply it yourself; never hunt for a Codex branch/PR (the only friction it caused — a #1032 verification detour).
- **Q-0174 → RESOLVED:** comment-only-vs-auto-PR is moot (structurally comment-only) → **trial it as-is.**

Docs-only, single commit → auto-merges on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EfHAjNAzYJCfsfCkj4tZgQ)_