### PR TITLE
Plan: fishing v1 + boat/open-world expansion (Q-0175) — captured for the planners

### DIFF
--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -6392,3 +6392,29 @@ reviews on the complete diff, not the born-red opener.
 **Home:** [`planning/codex-review-integration-plan-2026-06-17.md`](../planning/codex-review-integration-plan-2026-06-17.md)
 · [`codex-automated-pr-review-2026-06-17.md`](../ideas/codex-automated-pr-review-2026-06-17.md) · this
 Q-block. Related: Q-0171 (Codex live), Q-0120 (verify bot output vs source), Q-0117 (Hermes review-merge gate).
+
+### Q-0175 — Fishing v1 + the boat / open-world expansion (the unified-character world) (2026-06-18)
+
+> **DIRECTED (design brain-dump) — owner-in-session, 2026-06-18:** the fishing / open-world vision,
+> captured *"before I forget… this should give the planners something to do."* The owner is the designer;
+> the plan captures his intent faithfully — build against his answers to the open questions.
+
+**Decision (Phase 1 — buildable):**
+- **Fishing v1:** **21 fish ranked by size**, **7 levels, 3 fish/level** — the starting rod/character
+  catches the 3 smallest; each level unlocks +3 bigger fish (`3 × 7 = 21`). Scales later; leveling reuses
+  the existing tier / `game_xp` systems.
+- **Unified character + swappable gear types:** one character; **named loadout presets per activity type**
+  (mining/fishing/exploration/…), each a deterministic saved slot ("put on fishing gear" swaps to it).
+  **Gear is never required** — any activity works with any gear; matching gear only **increases bonuses**.
+
+**Captured for LATER (Phase 2+, not now):** the **boat** as a second home base (stores rods; also for
+exploration); **bounded boat travel** (short timer, locked-in — can fish, not land things, can't leave
+till arrival); **real destinations** updating **coordinates + biome** (ties the seed-grid world Q-0173),
+each with a **specialty** + bonuses, **some** location-locked eventually.
+
+**Open (owner deciding — do NOT resolve unprompted):** the catch mechanic · leveling shape (rod-tier vs
+fishing-skill) · loadout-preset UI · fish value/use (sell/cook) · boat "stuff" while traveling.
+
+**Home:** [`planning/fishing-open-world-expansion-plan-2026-06-18.md`](../planning/fishing-open-world-expansion-plan-2026-06-18.md)
+· this Q-block. Related: Q-0172 (fishing = the canonical self-build), Q-0173 (the seed-grid world the boat
+travels), the V-13/V-14 ecosystem vision.

--- a/docs/planning/fishing-open-world-expansion-plan-2026-06-18.md
+++ b/docs/planning/fishing-open-world-expansion-plan-2026-06-18.md
@@ -1,0 +1,96 @@
+# Plan — Fishing + the boat / open-world expansion (the unified-character world)
+
+> **Status:** `plan` — owner design brain-dump 2026-06-18 (**Q-0175**). Fishing is the canonical
+> **Q-0172** self-build candidate (the ratified ecosystem-#2 verdict, V-14). **The owner is the
+> designer — this captures his vision faithfully; verify against source + the owner before building.**
+> **Phase 1 is buildable now; Phase 2+ is explicitly "later, not now"** (captured so it isn't lost —
+> owner: *"this should be documented before I forget… this should give the planners something to do"*).
+
+## The vision (owner, 2026-06-18)
+
+One character does everything (mining · fishing · exploration · …); you swap **gear types** easily;
+fishing adds **real, size-ranked fish**; and a **boat** becomes a second home base that **travels** to
+**real destinations** (coordinates + biome), each with its own specialty. Everything ties to the one
+cross-game character — the V-13 paper-doll that "later holds the fishing rod."
+
+## Phase 1 — Fishing v1 (the buildable starting point)
+
+**Fish set — 21 fish, ranked by size.**
+- A curated **21-fish** dataset, each with a **size rank** (1 = smallest … 21 = largest) + name (value /
+  flavour can come later). Like the BTD6 / gear data: a committed JSON the game reads.
+- **7 levels, 3 fish per level (by size).** Your **starting rod / character catches the 3 smallest**
+  (level 1); each level up unlocks **+3** bigger fish in steps of 3 → **7 levels to catch all 21**
+  (`3 × 7 = 21`). (The owner started at "20" then rounded to **21** precisely so it divides into 7
+  clean levels.)
+- **Scales later:** more fish + levels append cleanly (21 / 7 is the *starting point*, not a cap).
+- Leveling = a **fishing level / rod-tier ladder** — reuse the existing tier ladder (`bronze…diamond`)
+  and/or the `game_xp` skill level; the planner picks the cleanest fit (don't invent a parallel system).
+
+**One character, swappable gear types (the unified-loadout model).**
+- **One character** holds everything (the existing `utils/equipment.py` slots + the `character_render`
+  doll). New concept: **named loadout presets per activity type** — mining · fishing · exploration · …
+  — each with its own **deterministic saved slot**. *"Put on fishing gear"* swaps your equipped items to
+  your saved fishing loadout.
+- **Gear is never required.** Any activity works with whatever you're wearing; the **matching** gear just
+  **increases the bonuses** (fishing gear → better fishing, etc.). Switching is an *optimization*, not a
+  gate.
+
+## Phase 2+ — the boat + open world (LATER — captured, not for now)
+
+**The boat = a second home base.**
+- Stores your **rods**; is **not** fishing-only — also the hub for **exploration** travel. A sibling of
+  the mining **Home** structure (likely on the `mining_structures` seam).
+
+**Boat travel — a bounded timer + locked-in.**
+- Pick a destination → a **timer** ("on your way to …"), **never hours/days** (short, bounded). While
+  traveling you are **locked in the boat**: you **can fish** + do "boat stuff" (TBD by the owner), but
+  **cannot** do land-locked things (mining, etc.), and **cannot leave until you arrive.**
+
+**Destinations = real coordinates + biome.**
+- A few destinations to choose from; arriving **updates your coordinates + your "biome."** Ties to the
+  **seed-deterministic grid world (Q-0173)** — destinations are real points in that world.
+- **Each place has a specialty** (e.g. one a great **farm** spot, another a great **mine**). Locations
+  grant **bonuses for certain things**; **some** features become **location-locked** *eventually* — not
+  all (the owner was explicit: bonuses first, hard location-locks only for a few, later).
+
+## Connections to existing systems (build on these, don't duplicate)
+
+- **The one character / paper-doll** — `utils/equipment.py` (slots/stats) + `utils/character_render.py`
+  (the doll; V-13: "the same doll later holds the fishing rod"). Loadout-presets extend equipment.
+- **The world / coordinates / biome** — the **seed-deterministic grid (Q-0173**, mining-hub-redesign PR3).
+- **The boat as a structure** — the mining structures seam (`mining_structures`, `build_structure`).
+- **Leveling** — the shared `game_xp` / skill-tree systems.
+- **Where it surfaces** — the mining-hub-redesign **Explore hub** (`🎣 Fishing · 🧭 Roam · …`, currently a
+  stub) is fishing's home panel.
+- **Lineage** — V-13 (multi-ecosystem open world) + the V-14 ecosystem-#2 = **FISHING** verdict, now concrete.
+
+## Open design questions (for the planner / owner — do NOT decide unprompted)
+
+- **Catch mechanic:** a deterministic roll (like `explore`)? a minigame? what picks *which* fish within
+  your unlocked size-band, and what determines success?
+- **Leveling:** a dedicated fishing rod-tier ladder, a fishing skill in the skill tree, or both?
+- **Loadout presets:** which activity types exist at v1 (mining/fishing/exploration)? the save/switch UI.
+- **Fish value / use:** sell? cook (ties the survival-plan P3 food loop)? collection goals / records?
+- **Boat "stuff":** what else you do while traveling (owner hasn't decided yet).
+- **Phase split:** confirm Phase 1 (fishing + gear-switching) ships before Phase 2 (boat / world).
+
+## Build order (suggested — Phase 1 first)
+
+1. **Fishing v1** — the 21-fish JSON + the level/size-band catch on the Explore hub's `🎣 Fishing`
+   (reuse the `cogs/mining/exploration.py` resolve seam). No boat yet (fish from shore / the hub).
+2. **Unified loadout presets** — saved gear-type slots + "put on X gear" swap (extends equipment).
+3. **The boat structure** + **travel timer + locked-in** behaviour (Phase 2).
+4. **Destinations + biome + location specialties / bonuses** (Phase 2+, ties Q-0173).
+
+## Source anchors
+
+- `disbot/utils/equipment.py` (slots/stats) · `disbot/utils/character_render.py` (doll) ·
+  `disbot/cogs/mining/exploration.py` (the explore resolve seam) · `disbot/views/mining/main_panel.py`
+  (the hub) · `disbot/utils/mining/structures.py` + `mining_structures` (boat-as-structure) ·
+  `disbot/utils/mining/world.py` (depth → the grid world, Q-0173) · `disbot/data/` (the fish JSON home).
+
+## Verification / rollback
+
+Docs-only capture; fully reversible. Each phase is an additive game feature (ADR-002: game state is
+not restart-safe — accepted). Phase 1 is data + a hub action + the loadout-preset extension; nothing
+here touches money/safety seams. Build against the owner's answers to the open questions above.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -496,7 +496,11 @@ accepted, not a target).
   into dedicated sub-hubs (Option A — main = Mine·Harvest·Explore·Character·Gear·Workshop), the
   inventory/gear image cards render in place (PR #911), and Mine becomes a 3D grid navigator;
   Explore becomes an open-world hub. Plan + IA:
-  [`planning/mining-hub-redesign-2026-06-15.md`](planning/mining-hub-redesign-2026-06-15.md).
+  [`planning/mining-hub-redesign-2026-06-15.md`](planning/mining-hub-redesign-2026-06-15.md). The
+  **fishing + open-world expansion** (21 fish / 7 levels · unified gear-type switching · the boat & real
+  destinations) is the next big games lane —
+  [`planning/fishing-open-world-expansion-plan-2026-06-18.md`](planning/fishing-open-world-expansion-plan-2026-06-18.md)
+  (Q-0175; **Phase 1 = fishing v1 + gear-switching is buildable**; the canonical Q-0172 self-build).
 - **Later** — bounded deferred actionability follow-ups (inventory architecture,
   leaderboards, bot-duel stats, shared back-button adoption) from the completed
   [actionability roadmap](archive/games-actionability-roadmap.md). Low priority; pick one bounded


### PR DESCRIPTION
Captures your fishing / open-world brain-dump **before it slips** — and gives the planners a buildable structure. Owner is the designer; this records your intent faithfully (Q-0175).

**Phase 1 — buildable now:**
- **Fishing v1** — **21 fish ranked by size**, **7 levels, 3 fish/level** (starting rod catches the 3 smallest; each level +3 → `3×7=21`). Scales later; leveling reuses the existing tier / `game_xp` systems.
- **One character, swappable gear types** — named loadout presets per activity (mining/fishing/exploration…), each a saved slot ("put on fishing gear"). **Gear is never required** — any activity works with any gear; matching gear only **increases bonuses**.

**Phase 2+ — captured for later (not now):** the **boat** as a 2nd home base (+ rod storage, also for exploration) · **bounded travel** (short timer, locked-in — can fish, not land things, can't leave till arrival) · **real destinations** updating **coordinates + biome** (ties the seed-grid world Q-0173) · per-location **specialties + bonuses**, some location-locked eventually.

Open design questions (catch mechanic · leveling shape · loadout UI · fish use · boat "stuff") are flagged for your call — I didn't decide them.

Indexed on the roadmap + Q-0175 so the routines can pick it up. Docs-only → auto-merges on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EfHAjNAzYJCfsfCkj4tZgQ)_