### PR TITLE
Gate round_cash identity to reconciling ranges (Codex P2 on #1035)

### DIFF
--- a/.sessions/2026-06-18-btd6-round-cash-identity-fix.md
+++ b/.sessions/2026-06-18-btd6-round-cash-identity-fix.md
@@ -1,0 +1,60 @@
+# 2026-06-18 — BTD6 round_cash identity ABR fix (Codex P2 on #1035)
+
+> **Status:** `in-progress`
+> Owner-live follow-up to #1035. Fixing the one real Codex review finding on that PR.
+
+**PR:** (this PR) — gate the `round_cash` identity sentence to reconciling ranges.
+**Branch:** `claude/zen-wright-77q0ru` (reset onto main after #1035 merged).
+
+## What I'm about to do / did
+
+#1035 (BTD6 answer fixes) merged. Codex left one review comment (P2) — verified real:
+
+- **The bug:** the new `round_cash` `identity` sentence was gated only on `cumulative_at_end is not
+  None`. For an ABR range that spans the unplayed rounds 1-2 (e.g. `round_cash(1, 3, abr)`), the
+  cumulative totals start at round 3, so `cumulative_at_end - cumulative_before_start` omits rounds
+  1-2's cash and **contradicts** `range_cash` (range_cash=418 but the sentence said 790-650=140).
+  Because the tool spec tells the model to quote `identity` verbatim, that could surface contradictory
+  math.
+- **The fix:** emit `identity` only when the subtraction actually reconciles
+  (`round(cumulative_at_end - cumulative_before_start, 2) == range_cash`). Self-validating, so it's
+  honest for the ABR-unplayed case (the existing `cumulative_note` already explains that boundary) and
+  any future data edge — never publish a quote-verbatim sentence the numbers disprove. Verified:
+  ABR 3-10 (played range) keeps its identity; ABR 1-3 / 1-5 / 2-4 now omit it.
+
+Also reconciled the living ledger (#1034/#1035/#1036).
+
+## Verification
+
+- `python3.10 scripts/check_quality.py --full` → green (10490 passed, 38 skipped).
+- New tests in `test_btd6_abr_rounds`: no identity for ABR ranges spanning rounds 1-2; identity present
+  + reconciling for an entirely-played ABR range.
+- Codex review thread resolved.
+
+## 💡 Session idea
+
+**Idea:** a tiny invariant test that asserts *whenever* `round_cash` returns an `identity`, the
+arithmetic in it reconciles (`cumulative_at_end - cumulative_before_start == range_cash`) — parametrized
+over a spread of standard + ABR ranges. **Why:** the identity is a model-quoted string; this pins the
+"never emit a self-contradictory identity" property as a property, not just two example cases, so the
+next person who touches the gate can't silently reintroduce the #1035 P2.
+
+## ⟲ Previous-session review
+
+The previous session (#1035, this conversation) shipped the four fixes with full local CI + tests, but
+**missed the ABR-unplayed edge** on the new identity field — its test only covered a standard range
+(8-66) and the ABR tests predated the field, so the contradiction slipped through; Codex caught it.
+The improvement (captured as this session's idea): when a new field is *handed to the model to quote
+verbatim*, its tests must cover the round-set/edge axes the surrounding function already special-cases
+(the ABR `lo < 3` boundary was right there in the same function). Codex acting as the independent
+reviewer worked exactly as the Q-0174 integration intended.
+
+## 📤 Run report
+
+- **Did:** gated the `round_cash` identity to reconciling ranges (Codex P2 fix) + ledger reconcile ·
+  **Outcome:** shipped, CI green
+- **Run type:** manual (owner-live)
+- **⚑ Self-initiated:** none (owner asked me to review Codex's comments; ledger reconcile is on-sight)
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none
+- **↪ Next:** optional identity-reconciles invariant test (session idea)

--- a/.sessions/2026-06-18-btd6-round-cash-identity-fix.md
+++ b/.sessions/2026-06-18-btd6-round-cash-identity-fix.md
@@ -1,9 +1,9 @@
 # 2026-06-18 — BTD6 round_cash identity ABR fix (Codex P2 on #1035)
 
-> **Status:** `in-progress`
-> Owner-live follow-up to #1035. Fixing the one real Codex review finding on that PR.
+> **Status:** `complete`
+> Owner-live follow-up to #1035. Fixed the one real Codex review finding on that PR.
 
-**PR:** (this PR) — gate the `round_cash` identity sentence to reconciling ranges.
+**PR:** #1037 — gate the `round_cash` identity sentence to reconciling ranges.
 **Branch:** `claude/zen-wright-77q0ru` (reset onto main after #1035 merged).
 
 ## What I'm about to do / did

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -2008,7 +2008,18 @@ def round_cash(
     # figures that didn't match range_cash. The inclusive subtraction uses the
     # cumulative going INTO the start round (cumulative_before_start), so hand the
     # model the finished sentence rather than letting it re-derive the arithmetic.
-    if cumulative_at_end is not None:
+    #
+    # Emit it ONLY when the subtraction actually reconciles with range_cash. For
+    # an ABR range that includes the unplayed rounds 1-2 it does NOT: those rounds
+    # carry per-round cash but are not in the cumulative totals (which start at
+    # round 3), so cumulative_at_end - cumulative_before_start omits their cash
+    # and would contradict range_cash. Self-validating the identity here keeps it
+    # honest for that case (the cumulative_note below already explains it) and any
+    # future data edge — never publish a sentence the model is told to quote
+    # verbatim that the numbers disprove.
+    if cumulative_at_end is not None and (
+        round(cumulative_at_end - cumulative_before_start, 2) == range_cash
+    ):
         result["identity"] = (
             f"Earnings for rounds {lo}-{hi} (inclusive) = ${range_cash:,.2f}. "
             f"This equals the cumulative total through round {hi} "

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -207,6 +207,23 @@ Source code and merged PRs win over anything written here.
 > auto-opens a `reconcile` issue at the boundary that fires the docs-reconciliation routine). Reset
 > this marker to the latest PR after a pass.
 
+- **#1036 (2026-06-18, fishing v1 + open-world expansion plan — Q-0175, docs-only)** — captured the
+  owner's fishing/boat brain-dump as a buildable plan: Phase 1 (fishing v1 — 21 fish, 7 levels × 3 fish,
+  reuses tier/`game_xp`; one character with named swappable gear-type loadouts, gear never required —
+  only boosts bonuses) + Phase 2+ (boat as 2nd home base · bounded travel · seed-grid destinations with
+  coordinates/biome, ties Q-0173); indexed on the roadmap.
+- **#1035 (2026-06-18, BTD6 AI answer fixes — owner live-test screenshots)** — fixed 4 owner-spotted
+  BTD6 answer bugs at the deterministic data/grounding/tool layer: MK reference reply grammar +
+  tab-wide scope note (Come On Everybody / Flanking Maneuvers disclosure); grounded the total bloons
+  entering a round so "how many bloons spawn on rN" is answerable instead of refused (the derived sum
+  tripped the value-only faithfulness guard); `round_composition` `roundset_label` so ABR vs standard
+  figures don't read as self-contradiction; `round_cash` ready-to-quote inclusive-range `identity`
+  sentence (a same-day P2 follow-up gated it to ranges where the cumulative subtraction reconciles —
+  it was emitting a contradictory identity for ABR ranges that span the unplayed rounds 1-2).
+- **#1034 (2026-06-18, Codex edits-live note — Q-0174 resolved, docs-only)** — documented that Codex
+  has no write access: its "make changes" output is a comment describing a diff in its own sandbox, so
+  agents read the proposed change from the comment, verify against `main`, and apply it themselves
+  (never hunt for a phantom Codex branch/PR); Q-0174 resolved → trial comment-only as-is.
 - **#1032 (2026-06-17, settle decisions + Codex integration — docs-only)** — settled **Q-0173** (the
   mining grid world = a seed-deterministic procedural grid we generate, not literal Minecraft-terrain
   replication) and **Q-0174** (Codex review integration: routines check Codex first but verify, the

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -97,6 +97,8 @@ living ledger (`docs/current-state.md`).
 
 - `claude/zen-wright-77q0ru` · BTD6 AI answer fixes (owner live-test screenshots) — MK tab-wide scope
   wording · how-many-bloons refusal · ABR/standard RBE labeling · income-range identity ·
-  `btd6_context_service` / `btd6_data_service` / `ai_tools` · 2026-06-18 · **PR (this session)**
+  `btd6_context_service` / `btd6_data_service` / `ai_tools` · 2026-06-18 · **PR #1035 (merged)**
+- `claude/zen-wright-77q0ru` · BTD6 `round_cash` identity ABR fix (Codex P2 on #1035) — gate identity
+  to reconciling ranges · `btd6_data_service` · 2026-06-18 · **PR (this session)**
 
 _(move claims here with their PR # as they close, then prune older entries)_

--- a/tests/unit/services/test_btd6_abr_rounds.py
+++ b/tests/unit/services/test_btd6_abr_rounds.py
@@ -227,6 +227,24 @@ def test_round_cash_abr_unplayed_rounds_disclose_the_boundary():
     # range_cash still sums exactly the requested rounds' data.
     per = {p["round"]: p["cash"] for p in ranged["per_round"]}
     assert ranged["range_cash"] == round(sum(per.values()), 2)
+    # No identity sentence for an ABR range that spans the unplayed rounds 1-2:
+    # cumulative totals start at round 3, so the subtraction would omit rounds
+    # 1-2's cash and contradict range_cash (Codex P2 on PR #1035). The
+    # cumulative_note above carries the honest explanation instead.
+    assert "identity" not in ranged
+    assert "identity" not in round_cash(2, 4, roundset="abr")
+
+
+def test_round_cash_abr_played_range_keeps_a_reconciling_identity():
+    # An ABR range entirely at/after the entry round (3) has cumulative totals
+    # that bracket exactly its rounds, so the identity holds and is emitted.
+    res = round_cash(3, 10, roundset="abr")
+    assert res["found"] is True
+    assert "cumulative_note" not in res
+    assert "identity" in res
+    assert round(res["cumulative_at_end"] - res["cumulative_before_start"], 2) == (
+        res["range_cash"]
+    )
 
 
 def test_round_cash_default_behaviour_unchanged():


### PR DESCRIPTION
Follow-up to #1035 (BTD6 answer fixes) addressing the one real Codex review finding (P2) on that PR — verified against source before acting.

### The bug
The `round_cash` `identity` sentence added in #1035 was gated only on `cumulative_at_end is not None`. For an ABR range that spans the **unplayed rounds 1–2**, the cumulative totals start at round 3, so `cumulative_at_end − cumulative_before_start` omits rounds 1–2's cash and **contradicts** `range_cash`:

| call | range_cash | identity claimed | |
|---|---|---|---|
| `round_cash(1, 3, abr)` | 418 | 790 − 650 = 140 | ❌ |
| `round_cash(1, 5, abr)` | 755 | 1127 − 650 = 477 | ❌ |
| `round_cash(3, 10, abr)` | 1551 | 2201 − 650 = 1551 | ✅ (lo ≥ 3) |

Because the tool spec tells the model to quote `identity` verbatim, those ABR ranges could surface contradictory math.

### The fix
Emit `identity` only when the subtraction actually reconciles (`round(cumulative_at_end − cumulative_before_start, 2) == range_cash`). Self-validating, so it stays honest for the ABR-unplayed case (the existing `cumulative_note` already explains that boundary) and any future data edge — never publish a quote-verbatim sentence the numbers disprove.

### Verification
- `python3.10 scripts/check_quality.py --full` → green (10490 passed, 38 skipped)
- New `test_btd6_abr_rounds` cases: no identity for ABR ranges spanning rounds 1–2; identity present + reconciling for an entirely-played ABR range
- Codex review thread on #1035 resolved

Also reconciles the living ledger (#1034/#1035/#1036). Born-red (Q-0133) via the in-progress session card; flips to complete to merge on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrUKH1qyhjVFsFw4ucuHr6

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrUKH1qyhjVFsFw4ucuHr6)_