### PR TITLE
BTD6: list class-wide MK in "affects <tower>" + fix sniper routing miss

### DIFF
--- a/.sessions/2026-06-18-btd6-mk-affects-tower.md
+++ b/.sessions/2026-06-18-btd6-mk-affects-tower.md
@@ -1,0 +1,73 @@
+# 2026-06-18 — BTD6 "which MK affects <tower>" — class-wide MK + routing
+
+> **Status:** `in-progress`
+> Owner-live follow-up to #1035/#1037. Two real misses from new #general screenshots.
+
+**PR:** (this PR) — list class-wide MK + fix the sniper routing miss.
+**Branch:** `claude/zen-wright-77q0ru` (reset onto main after #1037 merged).
+
+## What I'm about to do / did
+
+The owner posted new screenshots: the improved glue-gunner MK reply (from #1035) still
+"fails to correctly mention the MK that affects the glue gunner," and "Which MK affects the
+sniper" got **refused**. Both verified at source.
+
+### 1. Content — list the class-wide MK that affect the tower
+The #1035 reply only listed name-matching MK and pointed at the tab. The owner wants the
+tab-wide points that actually affect the tower (Come On Everybody!) *listed*. Added
+`btd6_data_service.monkey_knowledge_class_wide(category)` — MK in the tower's class tab whose
+description carries an explicit **class-scope phrase** ("all Primary towers", "Military
+Monkeys"). This is deliberately stricter than "names no tower": that looser test wrongly
+caught tower-specific points the name index missed (Icy Chill → Ice Monkey, Charged Chinooks →
+Heli) and power/economy points (Targeted Pineapples, More Cash). The reply now has two labelled
+sections — "Names the <tower>" + "Class-wide <Tab> — buffs every <Tab> tower" — and is framed
+"Monkey Knowledge that affects the <tower>".
+  - Glue Gunner → 6 named + Come On Everybody! (Primary class-wide).
+  - Sniper → 3 named + Advanced Logistics / Elite Military Training / Military Conscription.
+
+### 2. Routing — "which MK affects the sniper" was refused
+Root cause: the task router classified it `GENERAL_NL_ANSWER`, so the deterministic MK floor
+(which only runs on the `BTD6_ANSWER` route) was skipped → the model answered → the grounding
+guard blocked it → refusal. Single-word tower aliases (`sniper`, `boomerang`, `glue`) are
+deliberately dropped from the entity matcher as too collision-prone, so only multi-word names
+("glue gunner", "sniper monkey") routed BTD6. Added `_looks_like_mk_tower_question`: an MK cue
+(`monkey knowledge`/`mk`) + a tower alias (including the dropped single-word ones, ≥4 chars)
+routes BTD6. The MK cue gates it, so "is mk11 a good game" / "do you like the sniper rifle in
+cod" stay GENERAL.
+
+Also reconciled the living ledger (#1037).
+
+## Verification
+
+- `python3.10 scripts/check_quality.py --full` → green (10498 passed, 38 skipped).
+- `python3.10 scripts/check_architecture.py --mode strict` → 0 errors.
+- New tests: `test_btd6_mk_reference` (class-wide relation + reply sections + honest-empty),
+  `test_ai_task_router_btd6_natural` (MK-tower routing + conservatism).
+
+## 💡 Session idea
+
+**Idea:** a small router↔floor parity check — for each deterministic BTD6 floor builder, assert a
+representative trigger phrase also classifies `BTD6_ANSWER` (so the floor is actually reachable).
+**Why:** this exact bug was a *routing/floor mismatch* — the floor fired when called directly but
+the router never sent the message to it. A parity test catches "floor exists but is unreachable"
+as a class, which the existing floor-exclusivity test (which calls builders directly) can't see.
+
+## ⟲ Previous-session review
+
+The #1035 fix (tab-note disclosure) was a half-measure: it *explained* the omission rather than
+*fixing* it, and it never questioned whether the question even reached the floor — so the sniper
+routing miss sat undiscovered until the owner re-tested. The lesson (captured as the session
+idea): when a deterministic floor "isn't answering," check **reachability** (does the router send
+it there?) before assuming the builder is wrong — a builder that passes its own unit test can
+still be dead on the live path. Codex (#1037) and the owner (this PR) are jointly doing the
+independent-reviewer job the system intends.
+
+## 📤 Run report
+
+- **Did:** listed class-wide MK in the "affects <tower>" answer + fixed the single-word-alias MK
+  routing miss + ledger reconcile · **Outcome:** shipped, CI green
+- **Run type:** manual (owner-live)
+- **⚑ Self-initiated:** none (owner-reported misses; ledger reconcile is on-sight)
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none (no data reseed — pure code/grounding/routing)
+- **↪ Next:** optional router↔floor reachability parity test (session idea)

--- a/.sessions/2026-06-18-btd6-mk-affects-tower.md
+++ b/.sessions/2026-06-18-btd6-mk-affects-tower.md
@@ -1,9 +1,9 @@
 # 2026-06-18 — BTD6 "which MK affects <tower>" — class-wide MK + routing
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 > Owner-live follow-up to #1035/#1037. Two real misses from new #general screenshots.
 
-**PR:** (this PR) — list class-wide MK + fix the sniper routing miss.
+**PR:** #1038 — list class-wide MK + fix the sniper routing miss.
 **Branch:** `claude/zen-wright-77q0ru` (reset onto main after #1037 merged).
 
 ## What I'm about to do / did

--- a/disbot/services/ai_task_router.py
+++ b/disbot/services/ai_task_router.py
@@ -173,6 +173,62 @@ def _looks_like_btd6_entity(lowered: str) -> bool:
     return bool(tokens & single)
 
 
+# Tower single-word names/aliases (sniper, boomerang, glue, dart, …) — the tokens
+# _get_entity_aliases() deliberately drops as too collision-prone to be a BTD6
+# signal on their own. They become a safe signal ONLY behind an explicit
+# Monkey-Knowledge cue: "which MK affects the sniper" is unambiguously BTD6, but
+# unguarded it routed GENERAL and the deterministic MK floor never ran (the model
+# then grounding-refused; owner live-test 2026-06-18). 4-char floor keeps the
+# ultra-short collision-prone ones (sub/ice/ace) out even with the cue.
+_tower_alias_lock = threading.Lock()
+_tower_single_aliases: frozenset[str] | None = None
+
+
+def _get_tower_single_aliases() -> frozenset[str]:
+    global _tower_single_aliases
+    if _tower_single_aliases is not None:
+        return _tower_single_aliases
+    with _tower_alias_lock:
+        if _tower_single_aliases is not None:
+            return _tower_single_aliases
+        out: set[str] = set()
+        try:
+            from services import btd6_data_service
+
+            ds = btd6_data_service.get_dataset()
+        except Exception:
+            _tower_single_aliases = frozenset()
+            return _tower_single_aliases
+        for tower in ds.towers:
+            for surface in (tower.canonical, *tower.aliases):
+                s = surface.lower()
+                if " " not in s and len(s) >= 4:
+                    out.add(s)
+        _tower_single_aliases = frozenset(out)
+        return _tower_single_aliases
+
+
+_MK_CUE_RE = re.compile(r"\bmonkey\s+knowledges?\b|\bmk\b", re.I)
+
+
+def _looks_like_mk_tower_question(lowered: str) -> bool:
+    """A Monkey-Knowledge question naming a tower — even by a short single-word
+    alias the general entity matcher drops.
+
+    Gated on the MK cue so a bare common word ("sniper", "glue") only counts as
+    BTD6 when "monkey knowledge"/"mk" is also present. Multi-word tower names and
+    hero/boss tokens already route via :func:`_looks_like_btd6_entity`; this adds
+    the dropped single-word tower aliases under the cue.
+    """
+    if not _MK_CUE_RE.search(lowered):
+        return False
+    multi, _single = _get_entity_aliases()
+    if any(phrase in lowered for phrase in multi):
+        return True
+    tokens = frozenset(re.findall(r"[a-z0-9]+", lowered))
+    return bool(tokens & _get_tower_single_aliases())
+
+
 # "r53"-style round shorthand (live miss 2026-06-11: "How much do I have on
 # r70 if I had 26932 at the end of r53" routed general — the model assembled
 # tool numbers wrongly with no number guard). The trailing \b rejects
@@ -303,6 +359,8 @@ def classify(
         looks_btd6 = _looks_like_short_alias_money(lowered)
     if not looks_btd6:
         looks_btd6 = _looks_like_paragon_degree(lowered)
+    if not looks_btd6:
+        looks_btd6 = _looks_like_mk_tower_question(lowered)
     if not looks_btd6 and conversation_btd6_context:
         looks_btd6 = via_cue = _looks_like_conversation_followup(lowered)
     if channel_is_strategy_intake and looks_btd6:

--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -1905,38 +1905,49 @@ def deterministic_mk_reference_reply(message_text: str) -> str | None:
     if tower is None:
         return None
 
-    # The in-game Monkey Knowledge tab a tower's category sits under — Primary /
-    # Military / Magic / Support tab points that buff *every* tower in the class
-    # (e.g. "Come On Everybody", "Flanking Maneuvers") affect this tower too but
-    # never name it, so they are not in the reference list. Naming the tab lets
-    # the answer disclose that scope instead of reading as a missing entry — the
-    # "why isn't Come On Everybody in the Glue Gunner list" confusion.
+    # A complete "which MK affects <tower>" answer has two parts:
+    #   1. points that NAME the tower or one of its upgrades, and
+    #   2. CLASS-WIDE points that buff every tower in the tower's class without
+    #      naming it (e.g. "Come On Everybody!" → all Primary towers).
+    # The owner reported part 2 missing: "which MK affects the glue gunner" must
+    # include Come On Everybody (2026-06-18). Both halves are deterministic
+    # relations, so the floor owns the labelled answer.
     tab = tower.category.title()
-    tab_note = (
-        f"This lists only Monkey Knowledge that *names* the {tower.canonical}. "
-        f"Tab-wide points in the **{tab}** tab (which buff every {tab} tower, "
-        f"e.g. attack-speed or cost effects) also apply to it but aren't listed "
-        f"here — ask about {tab} Monkey Knowledge to see those."
+    named = sorted(
+        btd6_data_service.monkey_knowledge_referencing(tower),
+        key=lambda mk: mk.canonical.lower(),
+    )
+    class_wide = sorted(
+        btd6_data_service.monkey_knowledge_class_wide(tower.category),
+        key=lambda mk: mk.canonical.lower(),
     )
 
-    rows = btd6_data_service.monkey_knowledge_referencing(tower)
-    if not rows:
+    if not named and not class_wide:
         return (
-            f"**No Monkey Knowledge specifically references the "
-            f"{tower.canonical}.** Monkey Knowledge points name a tower or one "
-            "of its upgrades in their description; none currently name this one. "
-            + tab_note
+            f"**No Monkey Knowledge specifically affects the "
+            f"{tower.canonical}.** No point names it or one of its upgrades, and "
+            f"no {tab}-tab point buffs the whole {tab} class."
         )
 
-    ordered = sorted(rows, key=lambda mk: mk.canonical.lower())
+    total = len(named) + len(class_wide)
     lines = [
-        f"**Monkey Knowledge points that reference the {tower.canonical} "
-        f"({len(ordered)})** — these name the {tower.canonical} or one of its "
-        "upgrades:",
+        f"**Monkey Knowledge that affects the {tower.canonical} ({total})** — "
+        f"both points that name it and class-wide {tab} points that buff every "
+        f"{tab} tower:",
     ]
-    lines.extend(f"• **{mk.canonical}** — {mk.description}" for mk in ordered)
-    lines.append("")
-    lines.append(tab_note)
+    if named:
+        lines.append("")
+        lines.append(
+            f"__Names the {tower.canonical} or an upgrade ({len(named)}):__",
+        )
+        lines.extend(f"• **{mk.canonical}** — {mk.description}" for mk in named)
+    if class_wide:
+        lines.append("")
+        lines.append(
+            f"__Class-wide {tab} Monkey Knowledge — buffs every {tab} tower "
+            f"({len(class_wide)}):__",
+        )
+        lines.extend(f"• **{mk.canonical}** — {mk.description}" for mk in class_wide)
     reply = "\n".join(lines)
     return reply if len(reply) <= 1900 else reply[:1899] + "…"
 

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -1558,6 +1558,40 @@ def monkey_knowledge_referencing(
     return _mk_index().get(tower.canonical, ())
 
 
+# A class-wide Monkey Knowledge point buffs EVERY tower in a class (e.g. "Come
+# On Everybody!" → all Primary towers). It is detected by an explicit class-scope
+# phrase in the description — "all Primary towers", "Military Monkeys" — NOT by
+# "references no tower": that looser test wrongly catches tower-specific points
+# the name index missed (Icy Chill → Ice Monkey, Charged Chinooks → Heli) and
+# power/economy points (Targeted Pineapples, More Cash), none of which affect an
+# arbitrary tower in the class. Owner ask: "which MK affects the glue gunner"
+# must include Come On Everybody, which names no tower (2026-06-18).
+def _mk_class_scope_re(category: str) -> re.Pattern[str]:
+    cat = re.escape(category.strip().lower())
+    return re.compile(
+        rf"\b(?:all|every)\s+{cat}\b|\b{cat}\s+(?:towers?|monkeys?)\b",
+        re.I,
+    )
+
+
+def monkey_knowledge_class_wide(
+    category: str,
+) -> tuple[MonkeyKnowledgeEntry, ...]:
+    """Monkey Knowledge that buffs every tower in ``category`` (a tower category:
+    ``primary`` / ``military`` / ``magic`` / ``support``).
+
+    These sit in the matching MK tab and scope to the whole class via an explicit
+    phrase ("all Primary towers", "Military Monkeys"). They affect a given tower
+    in the class without naming it, so the "MK that affects <tower>" answer must
+    include them alongside :func:`monkey_knowledge_referencing`. Order follows the
+    category roster; empty when none scope to the class.
+    """
+    tab = category.strip().title()
+    pattern = _mk_class_scope_re(category)
+    rows = monkey_knowledge_by_category().get(tab, ())
+    return tuple(mk for mk in rows if pattern.search(mk.description))
+
+
 # Round-set selection. "default" = the standard 1-140 (rounds.json, wiki-
 # sourced); "alternate" = ABR (abr_rounds.json, game-sourced sidecar). Aliases
 # accept the names players actually type; anything else resolves to None and

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -207,6 +207,10 @@ Source code and merged PRs win over anything written here.
 > auto-opens a `reconcile` issue at the boundary that fires the docs-reconciliation routine). Reset
 > this marker to the latest PR after a pass.
 
+- **#1037 (2026-06-18, BTD6 round_cash identity ABR fix — Codex P2 on #1035)** — gated the inclusive
+  range `identity` sentence to emit only when the cumulative subtraction reconciles with `range_cash`;
+  it was contradicting `range_cash` for ABR ranges spanning the unplayed rounds 1-2 (the cumulative
+  totals start at round 3). Self-validating, so the existing `cumulative_note` covers the excluded case.
 - **#1036 (2026-06-18, fishing v1 + open-world expansion plan — Q-0175, docs-only)** — captured the
   owner's fishing/boat brain-dump as a buildable plan: Phase 1 (fishing v1 — 21 fish, 7 levels × 3 fish,
   reuses tier/`game_xp`; one character with named swappable gear-type loadouts, gear never required —

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -99,6 +99,9 @@ living ledger (`docs/current-state.md`).
   wording · how-many-bloons refusal · ABR/standard RBE labeling · income-range identity ·
   `btd6_context_service` / `btd6_data_service` / `ai_tools` · 2026-06-18 · **PR #1035 (merged)**
 - `claude/zen-wright-77q0ru` · BTD6 `round_cash` identity ABR fix (Codex P2 on #1035) — gate identity
-  to reconciling ranges · `btd6_data_service` · 2026-06-18 · **PR (this session)**
+  to reconciling ranges · `btd6_data_service` · 2026-06-18 · **PR #1037 (merged)**
+- `claude/zen-wright-77q0ru` · BTD6 "which MK affects <tower>" — list class-wide MK + fix sniper
+  routing miss · `btd6_data_service` / `btd6_context_service` / `ai_task_router` · 2026-06-18 ·
+  **PR (this session)**
 
 _(move claims here with their PR # as they close, then prune older entries)_

--- a/tests/unit/services/test_ai_task_router_btd6_natural.py
+++ b/tests/unit/services/test_ai_task_router_btd6_natural.py
@@ -374,3 +374,40 @@ def test_degree_without_paragon_or_paragon_without_degree_stays_general(text):
     assert (
         decision.task is AITask.GENERAL_NL_ANSWER
     ), f"{text!r} routed to {decision.task!r} instead of GENERAL_NL_ANSWER"
+
+
+@pytest.mark.parametrize(
+    "text",
+    # Live miss 2026-06-18: "which MK affects the sniper" routed GENERAL because
+    # single-word tower aliases (sniper, boomerang, glue) are dropped from the
+    # entity matcher, so the deterministic MK floor never ran and the model
+    # grounding-refused. The "mk"/"monkey knowledge" cue + a tower alias (even a
+    # short single word) must route BTD6 so the MK floor answers.
+    [
+        "which MK affects the sniper",
+        "Which MK affects the sniper",
+        "which monkey knowledge affects the boomerang",
+        "what mk apply to the glue gunner",  # multi-word tower, still BTD6
+        "which mk affects the dart monkey",
+    ],
+)
+def test_mk_tower_questions_route_to_btd6_answer(text):
+    decision = ai_task_router.classify(text)
+    assert (
+        decision.task is AITask.BTD6_ANSWER
+    ), f"{text!r} routed to {decision.task!r} instead of BTD6_ANSWER"
+
+
+@pytest.mark.parametrize(
+    "text",
+    # Conservatism: the MK cue gate keeps non-BTD6 "mk"/tower-word chatter out.
+    [
+        "is mk11 a good game",  # "mk11" — no \bmk\b boundary, not BTD6
+        "do you like the sniper rifle in cod",  # tower word, no MK cue
+    ],
+)
+def test_mk_tower_conservatism_stays_general(text):
+    decision = ai_task_router.classify(text)
+    assert (
+        decision.task is AITask.GENERAL_NL_ANSWER
+    ), f"{text!r} routed to {decision.task!r} instead of GENERAL_NL_ANSWER"

--- a/tests/unit/services/test_btd6_mk_reference.py
+++ b/tests/unit/services/test_btd6_mk_reference.py
@@ -33,7 +33,9 @@ def _reset_dataset_cache():
 def _names(tower_surface: str) -> set[str]:
     tower = btd6_data_service.find_tower(tower_surface)
     assert tower is not None
-    return {mk.canonical for mk in btd6_data_service.monkey_knowledge_referencing(tower)}
+    return {
+        mk.canonical for mk in btd6_data_service.monkey_knowledge_referencing(tower)
+    }
 
 
 def test_farm_relation_is_the_genuinely_related_mk_not_the_whole_category():
@@ -68,9 +70,30 @@ def test_spike_factory_excludes_road_spikes_power_mk():
 
 
 def test_strong_match_wins_over_a_different_towers_alias():
-    """"Arcane Spike does extra damage" (Arcane Impale) is a Wizard upgrade —
+    """ "Arcane Spike does extra damage" (Arcane Impale) is a Wizard upgrade —
     the weak "spike" alias must not pull it into the Spike Factory list."""
     assert "Arcane Impale" not in _names("spike factory")
+
+
+def test_class_wide_relation_is_scope_phrased_not_just_unnamed():
+    """Class-wide = an explicit class-scope phrase ("all Primary towers",
+    "Military Monkeys"), NOT merely "names no tower" — that looser test wrongly
+    catches tower-specific points the name index missed and power/economy points."""
+    primary = {
+        mk.canonical for mk in btd6_data_service.monkey_knowledge_class_wide("primary")
+    }
+    assert "Come On Everybody!" in primary
+    # Primary-tab but tower-specific (Ice Monkey freeze) / global economy — excluded:
+    assert "Icy Chill" not in primary
+    assert "More Cash" not in primary
+
+    military = {
+        mk.canonical for mk in btd6_data_service.monkey_knowledge_class_wide("military")
+    }
+    assert "Advanced Logistics" in military  # "All Military Monkeys base costs…"
+    # Military-tab but tower/power-specific — excluded:
+    assert "Charged Chinooks" not in military
+    assert "Targeted Pineapples" not in military
 
 
 def test_relation_is_memoized_stable():
@@ -106,36 +129,41 @@ def test_reply_handles_mk_abbreviation_and_relation_cue():
     assert "Just One More" not in reply
 
 
-def test_reply_header_is_grammatical_and_scopes_to_names():
+def test_reply_header_is_grammatical_and_affect_framed():
     reply = btd6_context_service.deterministic_mk_reference_reply(
-        "what monkey knowledge points apply to the glue gunner",
+        "which MK affects the glue gunner",
     )
     assert reply is not None
-    # "Monkey Knowledge points that reference" — not the ungrammatical
+    # "Monkey Knowledge that affects the Glue Gunner" — grammatical, and framed
+    # as "affects" (names + class-wide), not the old ungrammatical
     # "Monkey Knowledge that reference".
-    assert "Monkey Knowledge points that reference" in reply
+    assert "Monkey Knowledge that affects the Glue Gunner" in reply
+    assert "Monkey Knowledge that reference " not in reply
 
 
-def test_reply_discloses_tab_wide_mk_scope():
-    """The "why isn't Come On Everybody in the Glue Gunner list" confusion: the
-    list only names the tower, so the reply must point at the category tab whose
-    tab-wide points (e.g. Come On Everybody) also apply but aren't listed."""
-    # Glue Gunner is a Primary tower.
+def test_reply_includes_class_wide_tab_mk_that_affects_the_tower():
+    """The owner ask: "which MK affects the glue gunner" must INCLUDE the
+    class-wide Primary point (Come On Everybody!), not just name-matching ones —
+    and must not drop into the model-refusal path (2026-06-18)."""
+    # Glue Gunner is a Primary tower → Come On Everybody! applies class-wide.
     reply = btd6_context_service.deterministic_mk_reference_reply(
-        "what monkey knowledge points apply to the glue gunner",
+        "which MK affects the glue gunner",
     )
     assert reply is not None
-    assert "Primary" in reply
-    assert "only Monkey Knowledge that *names*" in reply
-    assert "ask about Primary Monkey Knowledge" in reply.lower() or (
-        "Primary Monkey Knowledge" in reply
-    )
-    # A Military tower points at the Military tab instead.
+    assert "Come On Everybody" in reply
+    assert "Names the Glue Gunner" in reply
+    assert "Class-wide Primary" in reply
+    # A Military tower lists the Military class-wide points instead.
     sniper = btd6_context_service.deterministic_mk_reference_reply(
-        "what monkey knowledge points apply to the sniper monkey",
+        "which MK affects the sniper",
     )
     assert sniper is not None
-    assert "Military" in sniper
+    assert "Ceramic Shock" in sniper  # names the Sniper
+    assert "Advanced Logistics" in sniper  # class-wide Military
+    assert "Class-wide Military" in sniper
+    # A class-wide point that DOESN'T scope to the whole class must not appear —
+    # Icy Chill (Ice Monkey freeze) is Primary-tab but tower-specific.
+    assert "Icy Chill" not in reply
 
 
 @pytest.mark.parametrize(
@@ -152,23 +180,24 @@ def test_reply_is_conservative_and_returns_none(text):
     assert btd6_context_service.deterministic_mk_reference_reply(text) is None
 
 
-def test_reply_for_tower_with_no_referenced_mk_is_honest():
-    """A tower no MK references gets an explicit deterministic "none", never a
-    model-assembled (and therefore mislabel-prone) list."""
-    # Find a tower with an empty relation, if any exists in the dataset.
+def test_reply_for_tower_with_no_affecting_mk_is_honest():
+    """A tower that no point names AND whose class has no class-wide point gets an
+    explicit deterministic "none", never a model-assembled (mislabel-prone) list."""
+    # Need a tower with empty named relation AND empty class-wide relation.
     empty_tower = next(
         (
             t
             for t in btd6_data_service.get_dataset().towers
             if not btd6_data_service.monkey_knowledge_referencing(t)
+            and not btd6_data_service.monkey_knowledge_class_wide(t.category)
         ),
         None,
     )
     if empty_tower is None:
-        pytest.skip("every tower currently has at least one referencing MK")
+        pytest.skip("every tower currently has at least one affecting MK")
     reply = btd6_context_service.deterministic_mk_reference_reply(
-        f"which monkey knowledges relate to the {empty_tower.canonical}",
+        f"which monkey knowledges affect the {empty_tower.canonical}",
     )
     assert reply is not None
-    assert "No Monkey Knowledge specifically references" in reply
+    assert "No Monkey Knowledge specifically affects" in reply
     assert empty_tower.canonical in reply


### PR DESCRIPTION
Owner live-test follow-up to #1035/#1037. Two real misses from new #general screenshots, both verified at source.

### 1. "which MK affects `<tower>`" must *list* the class-wide MK that affect it
After #1035 the glue-gunner reply listed only name-matching MK and pointed at the Primary tab — the owner's point is that the tab-wide points that actually affect it (Come On Everybody!) should be **listed**.

Added `btd6_data_service.monkey_knowledge_class_wide(category)`: MK in the tower's class tab whose description carries an **explicit class-scope phrase** ("all Primary towers", "Military Monkeys"). This is deliberately stricter than "names no tower", which wrongly caught:
- tower-specific points the name index missed (Icy Chill → Ice Monkey, Charged Chinooks → Heli), and
- power/economy points (Targeted Pineapples, More Cash).

The reply now has two labelled sections, framed "**Monkey Knowledge that affects the `<tower>`**":
- **Glue Gunner** → 6 named + **Come On Everybody!** (Primary class-wide)
- **Sniper** → 3 named + **Advanced Logistics / Elite Military Training / Military Conscription** (Military class-wide)

### 2. "Which MK affects the sniper" was *refused*
Root cause was **routing**, not the builder: the task router classified it `GENERAL_NL_ANSWER`, so the deterministic MK floor (which only runs on the `BTD6_ANSWER` route) was skipped → the model answered → the grounding guard blocked it → refusal. Single-word tower aliases (`sniper`, `boomerang`, `glue`) are deliberately dropped from the entity matcher as collision-prone, so only multi-word names ("glue gunner", "sniper monkey") routed BTD6.

Added `_looks_like_mk_tower_question`: an MK cue (`monkey knowledge`/`mk`) + a tower alias (including the dropped single-word ones, ≥4 chars) routes BTD6. The MK cue gates it, so "is mk11 a good game" / "do you like the sniper rifle in cod" stay GENERAL.

### Verification
- `python3.10 scripts/check_quality.py --full` → green (10498 passed, 38 skipped)
- `python3.10 scripts/check_architecture.py --mode strict` → 0 errors
- New tests in `test_btd6_mk_reference` (class-wide relation + reply sections + honest-empty) and `test_ai_task_router_btd6_natural` (MK-tower routing + conservatism)

No data reseed — pure code/grounding/routing. Also reconciles the ledger (#1037). Born-red (Q-0133) via the in-progress session card; flips to complete to merge on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrUKH1qyhjVFsFw4ucuHr6

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrUKH1qyhjVFsFw4ucuHr6)_