### PR TITLE
fix(setup): paginate cog-routing picker instead of truncating at 25

### DIFF
--- a/.sessions/2026-06-18-cog-routing-pagination.md
+++ b/.sessions/2026-06-18-cog-routing-pagination.md
@@ -1,0 +1,53 @@
+# 2026-06-18 — Setup cog-routing select: paginate instead of truncating at 25
+
+> **Status:** `complete`
+
+## What & why
+While reviewing the `needs-hermes-review` queue (#929/#941/#1033) for merge, the
+full-suite CI mirror surfaced a real latent bug, not in any one PR: the setup
+**cog-routing** picker built a single Discord select from
+`_operator_visible_cogs()` which hard-capped at `visible[:25]`. The registry has
+now grown past 25 routable subsystems (35), so the cap **silently dropped** every
+cog past the 25th in sorted order — `moderation`, `role`, `rps_tournament`,
+`server_management`, `settings`, `utility`, `ux_lab`, `welcome`, `xp`,
+`proof_channel`. An operator literally could not route those cogs per
+scope. The bug already affected `main`; the only guard test
+(`test_operator_visible_cogs_returns_known_cog_names`, which checks `moderation`)
+was tipped red by the fishing merge (#1033) crossing the boundary.
+
+## Change
+- `_operator_visible_cogs()` now returns the **full** sorted visible list (no
+  truncation).
+- New `_CogPickView(BaseView)` pages the list into ≤25-option windows with
+  **◀ Prev / Next ▶** nav (buttons appear only when >1 page; edges disabled at
+  bounds). `_CogPickSelect` takes an explicit page of names + page/page_count for
+  its placeholder; `_cog_options(cog_names)` builds one page.
+- The three scope callbacks (guild / category / channel) construct a
+  `_CogPickView` instead of a bare single-select `BaseView`.
+- Tests: replaced the obsolete `caps_at_25` test (it pinned the buggy truncation)
+  with `test_cog_pick_view_paginates_without_dropping_any_cog` (every visible cog
+  is reachable across pages; each select ≤25) and a nav-presence test.
+
+Pure view-layer change; no service/DB/registry edits. `check_quality --full`
+green (10537 passed), `check_architecture --mode strict` 0 errors.
+
+## Context for the queue
+This unblocks #941 (image-mod) and #929 (security) once it lands on `main` — each
+adds another subsystem and would otherwise widen the same truncation. #1033
+(fishing) was merged earlier this session; #929's raid-lockdown bug was fixed on
+its branch; #929 itself needs a separate rebuild (orphan history). #941 has a
+concurrent session on it.
+
+## 💡 Session idea
+Add a lightweight invariant test that asserts **every operator-facing select that
+is built from a registry** (cog-routing, and any future ones) either paginates or
+provably stays ≤25 options — so the next subsystem that crosses a Discord limit
+fails loudly at the source instead of silently dropping entries.
+
+## ⟲ Previous-session review
+The session that added the `needs-hermes-review` PRs did the right thing gating
+substantial subsystems behind human review, but each added a routable subsystem
+without noticing the cumulative cog-routing select was approaching Discord's
+25-option ceiling — exactly the kind of cross-PR drift no single PR's tests catch.
+Workflow improvement: the session-idea test above turns that class of limit-drift
+into a hard CI signal.

--- a/disbot/views/setup/sections/cog_routing.py
+++ b/disbot/views/setup/sections/cog_routing.py
@@ -56,11 +56,19 @@ SCOPE_OPTIONS: list[discord.SelectOption] = [
 ]
 
 
-def _operator_visible_cogs() -> list[str]:
-    """Return SUBSYSTEMS keys whose visibility is not internal.
+# Discord caps a single select at 25 options, so the operator-visible cog list
+# is paged into windows of this size by ``_CogPickView`` rather than truncated.
+_COG_PAGE_SIZE = 25
 
-    Capped at Discord's 25-option select limit so the operator-facing
-    pick always fits a single select.
+
+def _operator_visible_cogs() -> list[str]:
+    """Return every SUBSYSTEMS key whose visibility is not internal.
+
+    The full sorted list — once this crossed Discord's 25-option select limit
+    the previous ``[:25]`` truncation silently dropped routable cogs
+    (``moderation``/``role``/``settings``/``xp``/…). ``_CogPickView`` paginates
+    the list into ≤25-option windows instead, so every visible cog stays
+    reachable.
     """
     visible = [
         name
@@ -68,13 +76,13 @@ def _operator_visible_cogs() -> list[str]:
         if meta.get("visibility_mode", "normal") != "internal"
     ]
     visible.sort()
-    return visible[:25]
+    return visible
 
 
-def _cog_options() -> list[discord.SelectOption]:
-    """Build Discord SelectOption entries for the visible cogs."""
+def _cog_options(cog_names: list[str]) -> list[discord.SelectOption]:
+    """Build Discord SelectOption entries for one page of visible cogs."""
     options: list[discord.SelectOption] = []
-    for name in _operator_visible_cogs():
+    for name in cog_names:
         meta = SUBSYSTEMS.get(name, {})
         label = meta.get("display_name", name)[:100]
         description = (meta.get("description") or "")[:100] or None
@@ -165,7 +173,11 @@ class _EnableDisableSelect(discord.ui.Select):
 
 
 class _CogPickSelect(discord.ui.Select):
-    """Cog picker — pre-scoped to the operator's earlier pick."""
+    """Cog picker — pre-scoped to the operator's earlier pick.
+
+    Shows one page of the operator-visible cogs; ``_CogPickView`` owns the
+    paging so the select never exceeds Discord's 25-option limit.
+    """
 
     def __init__(
         self,
@@ -173,12 +185,18 @@ class _CogPickSelect(discord.ui.Select):
         scope_kind: str,
         scope_id: int | None,
         scope_name: str,
+        cog_names: list[str],
+        page: int = 0,
+        page_count: int = 1,
     ) -> None:
+        placeholder = f"Pick a cog for {scope_kind} scope…"
+        if page_count > 1:
+            placeholder = f"Pick a cog ({scope_kind}) — page {page + 1}/{page_count}…"
         super().__init__(
-            placeholder=f"Pick a cog for {scope_kind} scope…",
+            placeholder=placeholder,
             min_values=1,
             max_values=1,
-            options=_cog_options(),
+            options=_cog_options(cog_names),
         )
         self._scope_kind = scope_kind
         self._scope_id = scope_id
@@ -208,6 +226,92 @@ class _CogPickSelect(discord.ui.Select):
         )
 
 
+class _CogPageButton(discord.ui.Button):
+    """Prev/Next nav for the paged cog picker."""
+
+    def __init__(self, *, delta: int, label: str, disabled: bool) -> None:
+        super().__init__(
+            style=discord.ButtonStyle.secondary,
+            label=label,
+            disabled=disabled,
+        )
+        self._delta = delta
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if isinstance(view, _CogPickView):
+            await view.change_page(interaction, self._delta)
+
+
+class _CogPickView(BaseView):
+    """Paged cog picker — renders one ≤25-option select plus Prev/Next nav.
+
+    Replaces the old single-select that truncated to 25 cogs and silently
+    dropped everything past it. The full operator-visible list is paged so
+    every routable cog stays reachable.
+    """
+
+    def __init__(
+        self,
+        user: object,
+        *,
+        scope_kind: str,
+        scope_id: int | None,
+        scope_name: str,
+    ) -> None:
+        super().__init__(user, public=False, timeout=120)
+        self._scope_kind = scope_kind
+        self._scope_id = scope_id
+        self._scope_name = scope_name
+        self._cogs = _operator_visible_cogs()
+        self._page = 0
+        self._render()
+
+    @property
+    def page_count(self) -> int:
+        if not self._cogs:
+            return 1
+        return -(-len(self._cogs) // _COG_PAGE_SIZE)  # ceil division
+
+    def _page_cogs(self) -> list[str]:
+        start = self._page * _COG_PAGE_SIZE
+        return self._cogs[start : start + _COG_PAGE_SIZE]
+
+    def _render(self) -> None:
+        self.clear_items()
+        page_count = self.page_count
+        self.add_item(
+            _CogPickSelect(
+                scope_kind=self._scope_kind,
+                scope_id=self._scope_id,
+                scope_name=self._scope_name,
+                cog_names=self._page_cogs(),
+                page=self._page,
+                page_count=page_count,
+            ),
+        )
+        if page_count > 1:
+            self.add_item(
+                _CogPageButton(
+                    delta=-1,
+                    label="◀ Prev",
+                    disabled=self._page == 0,
+                ),
+            )
+            self.add_item(
+                _CogPageButton(
+                    delta=1,
+                    label="Next ▶",
+                    disabled=self._page >= page_count - 1,
+                ),
+            )
+
+    async def change_page(self, interaction: discord.Interaction, delta: int) -> None:
+        self._page = max(0, min(self._page + delta, self.page_count - 1))
+        self._render()
+        await interaction.response.edit_message(view=self)
+
+
 # ---------------------------------------------------------------------------
 # Scope-picker view
 # ---------------------------------------------------------------------------
@@ -224,13 +328,11 @@ class _CategoryPickSelect(discord.ui.ChannelSelect):
 
     async def callback(self, interaction: discord.Interaction) -> None:
         picked = self.values[0]
-        view = BaseView(interaction.user, public=False, timeout=120)
-        view.add_item(
-            _CogPickSelect(
-                scope_kind="category",
-                scope_id=picked.id,
-                scope_name=picked.name,
-            ),
+        view = _CogPickView(
+            interaction.user,
+            scope_kind="category",
+            scope_id=picked.id,
+            scope_name=picked.name,
         )
         await interaction.response.send_message(
             f"Pick a cog to override in category **{picked.name}**:",
@@ -250,13 +352,11 @@ class _ChannelPickSelect(discord.ui.ChannelSelect):
 
     async def callback(self, interaction: discord.Interaction) -> None:
         picked = self.values[0]
-        view = BaseView(interaction.user, public=False, timeout=120)
-        view.add_item(
-            _CogPickSelect(
-                scope_kind="channel",
-                scope_id=picked.id,
-                scope_name=picked.name,
-            ),
+        view = _CogPickView(
+            interaction.user,
+            scope_kind="channel",
+            scope_id=picked.id,
+            scope_name=picked.name,
         )
         await interaction.response.send_message(
             f"Pick a cog to override in #{picked.name}:",
@@ -277,13 +377,11 @@ class _ScopeSelect(discord.ui.Select):
     async def callback(self, interaction: discord.Interaction) -> None:
         scope = self.values[0]
         if scope == "guild":
-            view = BaseView(interaction.user, public=False, timeout=120)
-            view.add_item(
-                _CogPickSelect(
-                    scope_kind="guild",
-                    scope_id=None,
-                    scope_name="guild",
-                ),
+            view = _CogPickView(
+                interaction.user,
+                scope_kind="guild",
+                scope_id=None,
+                scope_name="guild",
             )
             await interaction.response.send_message(
                 "Pick a cog to set the guild default for:",

--- a/tests/unit/views/setup/sections/test_cog_routing_section.py
+++ b/tests/unit/views/setup/sections/test_cog_routing_section.py
@@ -81,9 +81,53 @@ def test_operator_visible_cogs_returns_known_cog_names():
     assert "economy" in visible
 
 
-def test_operator_visible_cogs_caps_at_25():
-    visible = cog_routing._operator_visible_cogs()
-    assert len(visible) <= 25
+def test_cog_pick_view_paginates_without_dropping_any_cog():
+    """The picker pages the visible cogs into ≤25-option windows instead of
+    truncating. Regression: when the registry crossed 25 visible subsystems
+    the old ``[:25]`` cap silently dropped ``moderation``/``role``/``settings``/
+    ``xp``/… from the operator's select.
+    """
+    view = cog_routing._CogPickView(
+        SimpleNamespace(id=99),
+        scope_kind="guild",
+        scope_id=None,
+        scope_name="guild",
+    )
+    visible = set(cog_routing._operator_visible_cogs())
+
+    seen: set[str] = set()
+    for page in range(view.page_count):
+        view._page = page
+        view._render()
+        select = next(
+            c for c in view.children if isinstance(c, cog_routing._CogPickSelect)
+        )
+        # Discord rejects a select with more than 25 options.
+        assert len(select.options) <= 25
+        seen.update(o.value for o in select.options)
+
+    # Every operator-visible cog is reachable on some page — nothing truncated.
+    assert visible <= seen
+    assert {"moderation", "role", "settings", "xp"} <= seen
+
+
+def test_cog_pick_view_shows_nav_when_over_one_page():
+    """A multi-page picker exposes Prev/Next nav buttons; a single page does not."""
+    view = cog_routing._CogPickView(
+        SimpleNamespace(id=99),
+        scope_kind="guild",
+        scope_id=None,
+        scope_name="guild",
+    )
+    buttons = [c for c in view.children if isinstance(c, cog_routing._CogPageButton)]
+    if view.page_count > 1:
+        assert len(buttons) == 2
+        # First page: Prev disabled, Next enabled.
+        assert view._page == 0
+        prev_btn = next(b for b in buttons if "Prev" in (b.label or ""))
+        assert prev_btn.disabled is True
+    else:
+        assert buttons == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Found while reviewing the `needs-hermes-review` merge queue (#929/#941/#1033): the full-suite CI mirror surfaced a **real latent bug on `main`**, not in any one PR.

The setup **cog-routing** picker built a single Discord select from `_operator_visible_cogs()`, which hard-capped at `visible[:25]`. The registry has grown past 25 routable subsystems (**35** now), so the cap **silently dropped** every cog past the 25th in sorted order — `moderation`, `role`, `rps_tournament`, `server_management`, `settings`, `utility`, `ux_lab`, `welcome`, `xp`, `proof_channel`. Operators literally could not route those cogs per scope. The only guard test (which checks `moderation`) was tipped red once the fishing merge (#1033) crossed the boundary; adding image-mod (#941) or security (#929) widens the same gap.

## What

- `_operator_visible_cogs()` returns the **full** sorted visible list (no truncation).
- New `_CogPickView(BaseView)` pages the list into **≤25-option windows** with **◀ Prev / Next ▶** nav (buttons only when >1 page; disabled at bounds). `_CogPickSelect` takes an explicit page of names + page/page_count for its placeholder; `_cog_options(cog_names)` builds one page.
- The three scope callbacks (guild / category / channel) construct a `_CogPickView`.
- Tests: replaced the obsolete `caps_at_25` test (it pinned the buggy truncation) with `test_cog_pick_view_paginates_without_dropping_any_cog` (every visible cog reachable across pages; each select ≤25) + a nav-presence test.

Pure view-layer change — no service/DB/registry edits.

## Verification
- `python3.10 scripts/check_quality.py --full` → green (10537 passed, 38 skipped)
- `python3.10 scripts/check_architecture.py --mode strict` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTRdvMxYuWzwy1gztjCKUR)_