### PR TITLE
fix(fishing): address Codex review on #1039 (migration hygiene · legacy count · stale dep)

### DIFF
--- a/.sessions/2026-06-18-fishing-codex-followups.md
+++ b/.sessions/2026-06-18-fishing-codex-followups.md
@@ -1,0 +1,89 @@
+# Session — fishing post-merge fixes (Codex review on #1039)
+
+> **Status:** `complete`
+
+## Context
+
+After the fishing reconciliation (#1039) merged, **Codex** flagged three valid P2
+issues in the now-deployed code. The owner confirmed in-session: *"I already merged
+it before codex commented, if necessary you can fix the issues and open another PR.
+you can merge this yourself / automerge."* So this is an explicitly-authorized
+follow-up that **self-merges on green** (no `needs-hermes-review`).
+
+## The three fixes
+
+1. **Migration hygiene (the schema-divergence bug).** `#1033` deployed migration
+   `075` with `best_weight` + `total_value` columns; `#1039` then *edited 075 in
+   place* to drop them. But the runner records applied migrations **by version
+   number** (`applied_migration_versions` → `SELECT version FROM schema_migrations`,
+   no checksum), so production — which already ran old-075 — **skips** the edited
+   075 and keeps the columns, while fresh DBs get the clean shape → divergence.
+   **Fix:** restored `075` to its as-deployed form and added **`076_fishing_catch_log_drop_value_cols.sql`**
+   (`ALTER TABLE … DROP COLUMN IF EXISTS …`) — idempotent, converges production
+   (drops the columns) and fresh DBs (no-op) to the same clean schema.
+2. **`!fishlog` legacy-species count.** A player who fished under the superseded
+   interim catalog can have `fishing_catch_log` rows for species no longer in the
+   21-fish `SPECIES` (e.g. `golden koi`/`ancient leviathan`). `len(log)` /
+   `sum(log.values())` counted them while the field rendered only the current
+   catalog → impossible `23/21`. **Fix:** count only `name in {s.name for s in
+   SPECIES}` in `!fishlog`, and `top_fishers` now takes the current-catalog
+   allow-list and filters with `species = ANY($2::text[])` so the leaderboard is
+   honest too.
+3. **Stale `economy` dependency.** Fishing v1 no longer writes coins, but
+   `SUBSYSTEMS['fishing']['dependencies']` still named `economy`, so the
+   governance dependency guard would block `!fish`/`!fishlog` in guilds that
+   disable the economy subsystem. **Fix:** `dependencies: []` (and dropped
+   `economy` from `related_subsystems`).
+
+**Tests:** `tests/unit/db/test_fishing_db.py` (+4 — `record_catch` touches no
+value column; `top_fishers` filters to the allow-list + short-circuits on empty;
+`get_fishing_log` shape). Existing fishing + migration-structure suites stay green.
+
+**Verification:** `check_quality --full` GREEN · `check_architecture --mode strict`
+0 · `check_docs` ✓ · `check_generated_artifacts_fresh` ✓.
+
+## 💡 Session idea
+
+**A "review-before-merge race" note for the routines.** Both fishing PRs merged
+*before* Codex's review landed (the enabler armed them, or the owner merged fast),
+so real P2 findings arrived post-merge as deployed bugs. A cheap mitigation: when a
+routine opens a PR it intends to self-merge, **wait for the Codex review pass (or a
+short grace window) before the merge fires** on anything touching runtime/migrations
+— Codex has now caught real issues on two consecutive fishing PRs, so the review is
+worth the few-minute delay. (Extends Q-0174/Q-0176 — routines consume Codex first.)
+
+## ⟲ Previous-session review
+
+The previous step (#1039, the reconciliation) correctly aligned the design but
+**shipped a migration bug while fixing a design bug**: editing the already-applied
+075 in place is the exact anti-pattern this fix now corrects. The lesson is general
+and worth pinning: **a migration, once merged, is immutable — schema changes are
+always a NEW migration**, never an edit, because the runner skips by version. The
+recovery was clean (the `DROP COLUMN IF EXISTS` follow-up is idempotent), and Codex
+caught it — which is itself the system working. The reconciliation also got the two
+*data*-hygiene bugs (legacy species, stale dependency) that only a careful reviewer
+would spot; good evidence that the Codex loop earns its keep on runtime PRs.
+
+## Documentation audit (Q-0104)
+
+- `check_current_state_ledger.py --strict` ✓; no current-state ▶ Next action change
+  needed (the fishing lane already points past v1 to the loadout-presets slice).
+- ownership.md / the surface maps already reflect the no-coin fishing model.
+- The migration set is honest again (075 = as-deployed; 076 = the transition).
+
+## 📤 Run report
+
+- **Did:** fixed the three Codex P2 findings on the merged fishing v1 — the
+  migration schema-divergence, the `!fishlog` legacy-species over-count, and the
+  stale `economy` dependency · **Outcome:** shipped (owner-authorized self-merge)
+- **Shipped:** migration 076 (drop unused cols) + 075 restored · `!fishlog`/`top_fishers`
+  filtered to the current catalog · fishing `dependencies: []` · +4 db tests.
+- **⚑ Self-initiated:** the fixes are review-driven (Codex) + **owner-authorized**
+  in-session ("fix the issues and open another PR … you can merge / automerge").
+- **⚑ Owner decisions needed:** `none` (clear bug fixes; the open Q-0175 mechanics
+  remain the owner's when ready).
+- **⚑ Owner manual steps:** `none` — a merge auto-deploys; migration 076 drops the
+  unused columns on the next boot.
+- **↪ Next:** fishing Phase 1 step 2 (unified loadout presets) → Phase 2 (boat/world),
+  per current-state ▶ Next action.
+- **Run type:** `routine · dispatch`

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-18T01:46:17Z",
+    "generated_at": "2026-06-18T02:03:14Z",
     "build": {
-      "commit": "feac60fd",
-      "subject": "fix(fishing): reconcile v1 to the owner's design (Q-0175 / plan #1036)",
-      "committed_at": "2026-06-18T01:42:01Z",
+      "commit": "e4de9036",
+      "subject": "Merge pull request #1039 from menno420/claude/funny-franklin-ttonj3",
+      "committed_at": "2026-06-18T03:57:46Z",
       "branch": "claude/funny-franklin-ttonj3"
     },
     "counts": {
@@ -512,7 +512,6 @@
         "fishlog"
       ],
       "related_subsystems": [
-        "economy",
         "mining"
       ],
       "capabilities": [
@@ -1630,6 +1629,14 @@
       "self_initiated": true
     },
     {
+      "file": "2026-06-18-fishing-codex-followups.md",
+      "date": "2026-06-18",
+      "title": "Session — fishing post-merge fixes (Codex review on #1039)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": true
+    },
+    {
       "file": "2026-06-18-btd6-round-cash-identity-fix.md",
       "date": "2026-06-18",
       "title": "2026-06-18 — BTD6 round_cash identity ABR fix (Codex P2 on #1035)",
@@ -2081,14 +2088,6 @@
       "file": "2026-06-16-fix-deathmatch-challenge-timer.md",
       "date": "2026-06-16",
       "title": "Session — fix BUG-0013: deathmatch 1v1 challenge timer overwrites the live duel",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-16-fix-coglist-resolution-loop.md",
-      "date": "2026-06-16",
-      "title": "Session — fix BUG-0014: `!coglist` infinite \"assumed from\" command-resolution loop",
       "status": "complete",
       "run_type": "",
       "self_initiated": false

--- a/disbot/cogs/fishing_cog.py
+++ b/disbot/cogs/fishing_cog.py
@@ -83,8 +83,12 @@ class FishingCog(commands.Cog):
         level = fishing_workflow.fishing_level_from_xp(fishing_xp)
         cap = max_size_rank_for_level(level)
 
-        caught = len(log)
-        total = sum(log.values())
+        # Count only current-catalog species — a player who fished under the
+        # superseded interim catalog (Q-0175 reconciliation) may have legacy rows
+        # (e.g. `golden koi`) that would otherwise show impossible progress (23/21).
+        known = {s.name for s in SPECIES}
+        caught = sum(1 for name in log if name in known)
+        total = sum(c for name, c in log.items() if name in known)
         embed = discord.Embed(
             title=f"🎣 {ctx.author.display_name}'s Fishing Log",
             color=_FISHING_COLOR,
@@ -120,7 +124,7 @@ class FishingCog(commands.Cog):
     )
     async def fishtop(self, ctx):
         """Show this server's top anglers by total fish caught."""
-        rows = await db.top_fishers(ctx.guild.id)
+        rows = await db.top_fishers(ctx.guild.id, [s.name for s in SPECIES])
         embed = discord.Embed(title="🎣 Top Anglers", color=_FISHING_COLOR)
         if not rows:
             embed.description = (

--- a/disbot/migrations/075_fishing_catch_log.sql
+++ b/disbot/migrations/075_fishing_catch_log.sql
@@ -1,11 +1,9 @@
--- Fishing collection log (ecosystem #2, owner design Q-0175 —
--- docs/planning/fishing-open-world-expansion-plan-2026-06-18.md). One row per
--- (user, guild, species) holding the player's running tally for that fish: how
--- many caught + first/last catch timestamps. An absent row = never caught, so
--- an EMPTY table is byte-identical to the pre-fishing bot (the additive safety
--- property). Fish value/use is an explicitly OPEN owner question, so there is no
--- coin/value column in v1 — the reward is progression (level up → unlock bigger
--- fish, fishing_workflow) + this collection record.
+-- Fishing collection log (ecosystem #2, the plan's PR 1 — the "collection-log
+-- hook" the survival plan's P3 ecosystem-ready-seams note requires).  One row
+-- per (user, guild, species) holding the player's running tally for that fish:
+-- how many caught, the heaviest one, total coins earned from it, and first/last
+-- catch timestamps.  An absent row = never caught (so an EMPTY table is
+-- byte-identical to the pre-fishing bot — the additive safety property).
 --
 -- user_id is BIGINT to match player_skills / game_xp / mining_structures
 -- (player-progression identity), NOT mining_inventory's legacy TEXT column.
@@ -14,6 +12,8 @@ CREATE TABLE IF NOT EXISTS fishing_catch_log (
     guild_id     BIGINT      NOT NULL DEFAULT 0,
     species      TEXT        NOT NULL,
     count        INTEGER     NOT NULL DEFAULT 0,
+    best_weight  REAL        NOT NULL DEFAULT 0,
+    total_value  BIGINT      NOT NULL DEFAULT 0,
     first_caught TIMESTAMPTZ NOT NULL DEFAULT now(),
     last_caught  TIMESTAMPTZ NOT NULL DEFAULT now(),
     PRIMARY KEY (user_id, guild_id, species)

--- a/disbot/migrations/076_fishing_catch_log_drop_value_cols.sql
+++ b/disbot/migrations/076_fishing_catch_log_drop_value_cols.sql
@@ -1,0 +1,14 @@
+-- Fishing v1 was reconciled to the owner's design (Q-0175 / #1036): fish are
+-- ranked by size and v1 pays NO coins (fish value/use is an explicitly OPEN
+-- owner question), so the catch log's `best_weight` + `total_value` columns
+-- (added in migration 075, deployed by #1033's interim coins design) are unused.
+--
+-- 075 was already applied in production (the version-numbered runner skips an
+-- already-recorded migration, so editing 075 in place would never reach existing
+-- databases and would diverge production from fresh schemas). Per migration
+-- hygiene, 075 stays as it was deployed and THIS migration performs the schema
+-- transition. `IF EXISTS` makes it idempotent + safe regardless of which form of
+-- 075 a given database applied: production (with the columns) drops them; a fresh
+-- database that already has the clean shape is a no-op.
+ALTER TABLE fishing_catch_log DROP COLUMN IF EXISTS best_weight;
+ALTER TABLE fishing_catch_log DROP COLUMN IF EXISTS total_value;

--- a/disbot/utils/db/games/fishing.py
+++ b/disbot/utils/db/games/fishing.py
@@ -56,12 +56,24 @@ async def get_fishing_log(
     return {r["species"]: r["count"] for r in rows}
 
 
-async def top_fishers(guild_id: int, *, limit: int = 10) -> list[tuple[int, int, int]]:
-    """``[(user_id, total_caught, unique_species)]`` for *guild_id*, top by catches."""
+async def top_fishers(
+    guild_id: int,
+    known_species: list[str],
+    *,
+    limit: int = 10,
+) -> list[tuple[int, int, int]]:
+    """``[(user_id, total_caught, unique_species)]`` for *guild_id*, top by catches.
+
+    Only counts rows whose species is in *known_species* (the current catalog) so
+    legacy rows from a superseded catalog never inflate the totals (Q-0175
+    reconciliation: the interim design's `golden koi`/`ancient leviathan` etc.).
+    """
+    if not known_species:
+        return []
     rows = await pool.fetchall(
         "SELECT user_id, SUM(count) AS caught, COUNT(*) AS species "
-        "FROM fishing_catch_log WHERE guild_id=$1 "
-        "GROUP BY user_id ORDER BY caught DESC LIMIT $2",
-        (guild_id, limit),
+        "FROM fishing_catch_log WHERE guild_id=$1 AND species = ANY($2::text[]) "
+        "GROUP BY user_id ORDER BY caught DESC LIMIT $3",
+        (guild_id, known_species, limit),
     )
     return [(r["user_id"], r["caught"], r["species"]) for r in rows]

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -232,8 +232,11 @@ SUBSYSTEMS: dict[str, dict] = {
         "tags": ["fishing", "minigame", "activities"],
         "entry_points": ["fish", "fishlog"],
         "default_channels": ["games", "bot-commands"],
-        "related_subsystems": ["economy", "mining"],
-        "dependencies": ["economy"],
+        "related_subsystems": ["mining"],
+        # No hard dependency: fishing v1 writes only the catch log + game_xp
+        # (no coins — fish value is a deferred owner question, Q-0175), so it must
+        # not be locked out when an admin disables the economy subsystem.
+        "dependencies": [],
         "soft_dependencies": [],
         "supports_dm": False,
         "has_cleanup_rules": False,

--- a/tests/unit/db/test_fishing_db.py
+++ b/tests/unit/db/test_fishing_db.py
@@ -1,0 +1,66 @@
+"""fishing_catch_log CRUD — SQL-shape pins (mock-pool idiom)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from utils.db.games import fishing
+
+
+@pytest.mark.asyncio
+async def test_record_catch_upserts_count_only():
+    with patch(
+        "utils.db.games.fishing.pool.execute",
+        new_callable=AsyncMock,
+    ) as mock_exec:
+        await fishing.record_catch(99, 1, "trout")
+    query, params = mock_exec.await_args.args
+    flat = " ".join(query.split())
+    assert "INSERT INTO fishing_catch_log (user_id, guild_id, species, count)" in flat
+    assert "ON CONFLICT (user_id, guild_id, species) DO UPDATE" in flat
+    assert "count = fishing_catch_log.count + 1" in flat
+    # No coin/value column is touched (v1 has no coins — Q-0175).
+    assert "total_value" not in flat
+    assert "best_weight" not in flat
+    assert params == (99, 1, "trout")
+
+
+@pytest.mark.asyncio
+async def test_top_fishers_filters_to_known_species():
+    known = ["minnow", "trout", "shark"]
+    with patch(
+        "utils.db.games.fishing.pool.fetchall",
+        new_callable=AsyncMock,
+        return_value=[{"user_id": 7, "caught": 12, "species": 3}],
+    ) as mock_fetch:
+        out = await fishing.top_fishers(1, known, limit=5)
+    query, params = mock_fetch.await_args.args
+    flat = " ".join(query.split())
+    # The current-catalog allow-list keeps legacy rows out of the leaderboard.
+    assert "species = ANY($2::text[])" in flat
+    assert params == (1, known, 5)
+    assert out == [(7, 12, 3)]
+
+
+@pytest.mark.asyncio
+async def test_top_fishers_empty_allow_list_short_circuits():
+    with patch(
+        "utils.db.games.fishing.pool.fetchall",
+        new_callable=AsyncMock,
+    ) as mock_fetch:
+        out = await fishing.top_fishers(1, [])
+    assert out == []
+    mock_fetch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_fishing_log_returns_species_to_count():
+    with patch(
+        "utils.db.games.fishing.pool.fetchall",
+        new_callable=AsyncMock,
+        return_value=[{"species": "trout", "count": 4}, {"species": "bass", "count": 1}],
+    ):
+        log = await fishing.get_fishing_log(99, 1)
+    assert log == {"trout": 4, "bass": 1}


### PR DESCRIPTION
## Why

Three valid **P2 Codex findings** on the merged fishing v1 (#1039), **owner-authorized** as a self-merging follow-up (*"fix the issues and open another PR … you can merge this yourself / automerge"*).

## Fixes

1. **Migration hygiene — the schema-divergence bug.** #1033 deployed migration `075` with `best_weight` + `total_value` columns; #1039 then *edited 075 in place* to drop them. But the runner records applied migrations **by version number** (no checksum), so production (already ran old-075) **skips** the edited 075 and keeps the columns, while fresh DBs get the clean shape → divergence. **Restored `075` to its as-deployed form + added `076_fishing_catch_log_drop_value_cols.sql`** (`ALTER TABLE … DROP COLUMN IF EXISTS …`) — idempotent; converges production (drops the columns) and fresh DBs (no-op) to one clean schema.
2. **`!fishlog` / `!fishtop` legacy-species count.** A player who fished under the superseded interim catalog can have rows for species no longer in the 21-fish `SPECIES` (e.g. `golden koi`) → impossible `23/21` progress. Both now count only the current catalog (`top_fishers` takes the allow-list, `species = ANY($2::text[])`).
3. **Stale `economy` dependency.** Fishing v1 writes no coins, but `SUBSYSTEMS['fishing']['dependencies']` still named `economy` → the governance guard would block `!fish` in guilds with economy disabled. Now `dependencies: []`.

**Tests:** `tests/unit/db/test_fishing_db.py` (+4). `check_quality --full` green (10537) · `check_architecture --mode strict` 0 · `check_docs` / `check_generated_artifacts_fresh` ✓.

## Merge

Owner-authorized **self-merge / auto-merge on green** — clear, contained bug fixes; no `needs-hermes-review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcvJdSvjpjMBfwVnQiukYc)_