### PR TITLE
fix(ci): dashboard-data-refresh — auto-merging PR-flow (unfreezes deploys)

### DIFF
--- a/.github/workflows/dashboard-data-refresh.yml
+++ b/.github/workflows/dashboard-data-refresh.yml
@@ -1,39 +1,51 @@
 name: dashboard-data-refresh
 
 # Keep the committed dashboard data (dashboard/data/dashboard.json) fresh so the website's
-# Updates / Ideas / Bugs feeds reflect work as it merges, instead of lagging ~30 PRs behind the
+# Updates / Ideas / Bugs feeds reflect work as it merges, instead of lagging until the
 # every-30-PR reconciliation regen — the owner's "the updates are stuck on one from a few days
 # ago" report (Q-0167, 2026-06-17).
 #
 # Why a workflow (not the app): the dashboard is a decoupled Railway service deployed from
 # dashboard/ ONLY — it cannot see docs/, .sessions/, or disbot/ at runtime, so it serves the
-# committed JSON. This regenerates that JSON whenever a source that feeds it changes on main, and
-# commits it back if it changed.
+# committed JSON. This regenerates that JSON and lands it on main when a source that feeds it has
+# changed.
 #
-# Loop-safe: the push trigger is gated to the SOURCE paths (which do NOT include the JSON), so the
-# bot's own JSON-only commit never retriggers this workflow; [skip ci] keeps it from spinning any
-# other workflow. Uses ROUTINE_PAT (Contents: write) for push rights, the same token
-# pr-auto-update.yml uses.
+# === Why a PR, not a direct push (the 2026-06-18 fix) ===
+# The original version pushed the regenerated JSON straight to `main`. That can NEVER succeed: the
+# `main` branch ruleset requires the `code-quality` status check on any pushed commit, and a direct
+# push from a workflow carries no such check, so GitHub rejects it (GH013). The workflow therefore
+# failed on every merge — harmless on its own, but it turned each commit's CI check-suite red, and
+# Railway's "wait for CI before deploy" setting waits for the WHOLE suite, so one red check silently
+# SKIPPED every production deploy (the bot froze ~9h on a stale build). Root-caused 2026-06-18.
 #
-# Provenance + reliability (Q-0105): added 2026-06-17, owner-directed. UNVERIFIED — watch the first
-# few merges to confirm it commits a fresh JSON only on real source changes and never loops. Kill
+# The fix: land the refresh through a normal PR that AUTO-MERGES once `code-quality` is green — the
+# only path that satisfies the ruleset without a privileged push. It reuses ONE branch
+# (`bot/dashboard-refresh`), so at most one refresh PR is ever open; a later run force-updates that
+# branch rather than spawning a second PR.
+#
+# It is SCHEDULED (not per-merge): a 2-hourly cadence keeps the site fresh within the interval
+# while (a) bounding noise to at most one auto-PR per run and (b) removing the per-merge failures
+# entirely — this workflow no longer runs in any commit's check-suite, so it can never re-freeze
+# deploys even if "wait for CI" is re-enabled. `workflow_dispatch` gives an on-demand refresh.
+#
+# === Optional zero-PR upgrade (owner, GitHub setting) ===
+# If you'd rather the refresh land invisibly with NO auto-PRs, add the push identity
+# (`ROUTINE_PAT` / `superbot-dashboard-bot`) to the `main` ruleset's bypass list
+# (Settings -> Rules -> the main ruleset -> Bypass list). Then this workflow could direct-push
+# again; until then the PR-flow below is fully self-contained and needs no settings.
+#
+# Provenance + reliability (Q-0105): added 2026-06-17; rewritten to the PR-flow 2026-06-18. Kill
 # switch: delete this workflow; the reconciliation routine still regenerates on its cadence, and
 # `python3.10 scripts/export_dashboard_data.py` is always runnable by hand.
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'docs/ideas/**'
-      - 'docs/health/bug-book.md'
-      - '.sessions/**'
-      - 'disbot/**'
-      - 'scripts/export_dashboard_data.py'
-      - 'scripts/scan_*.py'
+  schedule:
+    - cron: '17 */2 * * *'   # every 2 hours (offset off the hour to dodge load spikes)
   workflow_dispatch:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: dashboard-data-refresh
@@ -47,19 +59,45 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.ROUTINE_PAT || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-      - name: Regenerate dashboard data and commit if changed
+      - name: Regenerate dashboard data; open an auto-merging PR if it changed
+        env:
+          GH_TOKEN: ${{ secrets.ROUTINE_PAT || secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
+          # export_dashboard_data.py is stdlib-only by design — no pip install needed.
           python3.10 scripts/export_dashboard_data.py
           if git diff --quiet -- dashboard/data/dashboard.json; then
-            echo "dashboard.json already fresh — nothing to commit."
+            echo "dashboard.json already fresh — nothing to do."
             exit 0
           fi
+          echo "dashboard.json drifted — landing a refresh via an auto-merging PR."
+
+          BRANCH=bot/dashboard-refresh
           git config user.name "superbot-dashboard-bot"
           git config user.email "noreply@github.com"
+          # Build the branch as current main + ONLY the regenerated JSON.
+          git checkout -B "$BRANCH"
           git add dashboard/data/dashboard.json
-          git commit -m "chore(dashboard): refresh generated data [skip ci]"
-          git push
+          git commit -m "chore(dashboard): refresh generated data"
+          # Bot-owned branch: force is safe (concurrency group serialises runs).
+          git push --force origin "$BRANCH"
+
+          # Open the PR once; later runs reuse it (the force-push above updates its head).
+          existing="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' || true)"
+          if [ -z "$existing" ]; then
+            gh pr create --base main --head "$BRANCH" \
+              --title "chore(dashboard): refresh generated data" \
+              --body "Automated refresh of \`dashboard/data/dashboard.json\` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml." \
+              || echo "::warning::gh pr create failed — confirm ROUTINE_PAT has Pull requests: write."
+          else
+            echo "Reusing open refresh PR #$existing (head force-updated)."
+          fi
+
+          # Arm native auto-merge so it lands the moment Code Quality is green (the same
+          # mechanism auto-merge-enabler.yml uses for claude/* PRs).
+          gh pr merge "$BRANCH" --auto --merge --repo "$GITHUB_REPOSITORY" \
+            || echo "::warning::Could not arm auto-merge. Confirm: (1) 'Allow auto-merge' is ON, (2) main requires the 'Code Quality' check, (3) ROUTINE_PAT has Pull requests + Contents write."

--- a/.sessions/2026-06-18-dashboard-refresh-deploy-unblock.md
+++ b/.sessions/2026-06-18-dashboard-refresh-deploy-unblock.md
@@ -1,0 +1,83 @@
+# Session — fix the deploy-freezing dashboard-data-refresh workflow
+
+> **Status:** `complete`
+
+## What happened (the diagnosis)
+
+The owner reported the fishing commands didn't work / no fishing cog in the live bot.
+Using the read-only Railway API (`scripts/hermes/railway_logs.py`), I found production
+was **frozen on deployment #1036** (00:37 UTC) — every deploy since (incl. #1033, which
+adds the fishing cog) was Railway-status **`SKIPPED`**. The running deployment's boot log
+confirmed no `FishingCog` loaded; a full **local boot** confirmed the code is correct
+(FishingCog + migrations 075/076 load cleanly, commands register).
+
+**Root cause:** the `dashboard-data-refresh` workflow (added yesterday, #1026/Q-0167)
+`git push`es the regenerated `dashboard.json` straight to `main`. The `main` branch
+ruleset requires the `code-quality` status check on any pushed commit, so GitHub rejects
+the bot's direct push (`GH013`). The workflow therefore **failed on every merge**, turning
+each commit's CI check-suite red — and Railway's "wait for CI before deploy" setting waits
+for the **whole** suite, so one red check **silently SKIPPED every deploy**. This explains
+the owner's "why only now": "wait for CI" was fine for 2 days until #1026 added a workflow
+that can't satisfy its own ruleset.
+
+The owner unblocked deploys immediately by disabling Railway's "wait for CI" (fishing is
+now live — verified `FishingCog LIVE in prod` on deployment #1044). This PR fixes the
+**workflow** so it stops failing and actually works.
+
+## What shipped
+
+Rewrote `.github/workflows/dashboard-data-refresh.yml`:
+
+- **PR-flow instead of direct push.** It now lands the refresh through a normal PR that
+  **auto-merges** once `code-quality` is green (`gh pr merge --auto --merge` with
+  `ROUTINE_PAT`, the same mechanism `auto-merge-enabler.yml` uses). This is the only path
+  that satisfies the `main` ruleset without a privileged push — **no GitHub-settings change
+  required**. It reuses one branch (`bot/dashboard-refresh`), so at most one refresh PR is
+  ever open.
+- **Scheduled (every 2h) + `workflow_dispatch`, not per-merge.** This keeps the site fresh
+  within the interval, bounds noise to ≤1 auto-PR per run, and — critically — **removes the
+  per-merge failures and the deploy landmine entirely**: the workflow no longer runs in any
+  commit's check-suite, so it can never re-freeze deploys, even if "wait for CI" is
+  re-enabled (which becomes safe again).
+- **Documented the optional zero-PR upgrade**: if the owner adds the bot identity to the
+  `main` ruleset's bypass list, it could direct-push invisibly (no auto-PRs). Self-contained
+  PR-flow until then.
+
+`export_dashboard_data.py` is stdlib-only (verified) so the CI job needs no `pip install`.
+YAML validated; export runs clean.
+
+## 💡 Session idea
+
+**A read-only "deploy health" line in the routine SessionStart banner.** This whole outage
+was invisible for ~9h because nothing surfaced "production is N deploys behind / last deploy
+SKIPPED." `scripts/hermes/railway_logs.py` already exposes deployment status read-only; a
+tiny `scripts/hermes/deploy_status.py` that prints "prod = deployment #X (SUCCESS, 3h ago);
+HEAD is #Y — N commits ahead, last deploy SKIPPED" in the SessionStart hook would catch a
+frozen/failed deploy on the next routine run instead of waiting for the owner to notice.
+
+## ⟲ Previous-session review
+
+The previous step (the fishing arc) did everything right *in the repo* — code correct,
+tested, merged — yet the feature never reached users because of an **infra failure two
+layers away** (a sibling workflow + a Railway setting). The lesson: "merged + CI-green" is
+not "live." A routine that ships user-facing features should **verify the deploy landed**,
+not just the merge — exactly the deploy-health idea above. Also: the `dashboard-data-refresh`
+workflow was merged (#1026) flagged "UNVERIFIED — watch the first few merges"; nobody did,
+and it silently broke deploys. The Q-0105 "watch unverified tooling" instruction needs a
+teeth — the deploy-health line would have been that teeth.
+
+## 📤 Run report
+
+- **Did:** root-caused a ~9h production deploy freeze to the `dashboard-data-refresh`
+  workflow's un-pushable direct-push-to-main, and rewrote it to a self-contained
+  auto-merging PR-flow (scheduled, loop-safe, never reddens CI) · **Outcome:** shipped
+- **Shipped:** the workflow rewrite (this PR). Owner separately unblocked deploys by
+  disabling Railway "wait for CI"; fishing verified live on prod (#1044).
+- **⚑ Self-initiated:** owner-directed ("make it actually work properly, also improve it").
+- **⚑ Owner decisions needed:** optional — add the bot to the `main` ruleset bypass list for
+  a zero-PR (invisible direct-push) refresh; otherwise the PR-flow is fully self-contained.
+  Re-enabling Railway "wait for CI" is now safe (this workflow no longer fails per-merge).
+- **⚑ Owner manual steps:** `none` required (the fix is self-contained). Optional bypass above.
+- **↪ Next:** consider the deploy-health SessionStart line (idea above); the ledger has
+  drift (#1038–#1044) for the next reconciliation pass (due at #1050).
+- **Run type:** `routine · dispatch`


### PR DESCRIPTION
## Why

Root-caused a ~9h production deploy freeze (the bot was running stale code with no fishing cog). The `dashboard-data-refresh` workflow (added yesterday, #1026) `git push`es the regenerated `dashboard.json` **straight to `main`**, but the `main` branch ruleset requires the `code-quality` status check on any pushed commit → GitHub rejects the bot's direct push (`GH013`) on every merge. That turned each commit's CI check-suite red, and Railway's **"wait for CI before deploy"** waits for the *whole* suite → it silently **`SKIPPED` every deploy**. (Verified via the read-only Railway API: prod was frozen on #1036; #1033 onward all `SKIPPED`; the running boot log had no `FishingCog`.) This is also the answer to "why only now" — wait-for-CI was fine for 2 days until #1026 added a workflow that can't satisfy its own ruleset.

## What changed (`.github/workflows/dashboard-data-refresh.yml`)

- **PR-flow instead of direct push** — lands the refresh through a normal PR that **auto-merges** once `code-quality` is green (`gh pr merge --auto --merge` w/ `ROUTINE_PAT`, the same mechanism `auto-merge-enabler.yml` uses). The only path that satisfies the ruleset **without a GitHub-settings change**. Reuses one branch (`bot/dashboard-refresh`) → at most one refresh PR open at a time.
- **Scheduled (every 2h) + `workflow_dispatch`, not per-merge** — keeps the site fresh within the interval, bounds noise, and **removes the per-merge failures + the deploy landmine entirely**: the workflow no longer runs in any commit's check-suite, so it can never re-freeze deploys (re-enabling Railway "wait for CI" is safe again).
- **Documented the optional zero-PR upgrade** — add the bot identity to the `main` ruleset bypass list and it could direct-push invisibly; self-contained PR-flow until then.

`export_dashboard_data.py` is stdlib-only (no CI `pip install` needed). YAML validated; `check_docs` + session gate green.

## Merge

Owner-authorized self-merge ("make it actually work properly … you can merge this yourself / automerge"). Not `needs-hermes-review` — a contained CI-config fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcvJdSvjpjMBfwVnQiukYc)_