### PR TITLE
docs: promote AI-panel in-place-navigation idea to an executable plan (Q-0172)

### DIFF
--- a/.sessions/2026-06-19-ai-panel-inplace-nav-plan.md
+++ b/.sessions/2026-06-19-ai-panel-inplace-nav-plan.md
@@ -1,0 +1,97 @@
+# 2026-06-19 — Promote the AI-panel in-place-navigation idea to an executable plan
+
+> **Status:** `complete`
+
+## Arc (what I did)
+
+Fourth slice of this dispatch run (after #1058 edit_in_place + #1059 back_button). The mandatory
+backlog-grooming ender (Q-0015) + a Q-0172 self-initiated idea→plan promotion: structured
+[`ideas/ai-panel-inplace-navigation-2026-06-11.md`](../ideas/ai-panel-inplace-navigation-2026-06-11.md)
+into an executable plan. **Why this idea:** it is the *only* blocker for graduating the consistency
+linter's `edit_in_place` rule — that rule's 17 remaining warn-only findings (after #1058's triage) are
+*exactly* the `views/ai/` family. Building this plan both fixes the owner's headline 2026-06-11 UX
+complaint and unblocks rule 1's graduation.
+
+## Shipped (#1060)
+
+- New plan: [`planning/ai-panel-inplace-navigation-plan-2026-06-19.md`](../planning/ai-panel-inplace-navigation-plan-2026-06-19.md)
+  — re-verified the source scope (18 `views/ai/` classes, all raw `discord.ui.View` except the
+  `AIPanelView` `PersistentView`; the blanket `canonical_helpers.yaml` exemption makes the debt
+  ratchet-invisible), the target in-place HubView pattern, and a **2–3 PR build order**: PR 1 (AI anchor
+  + page model, clears panel.py's 3 findings) → PR 2 (chooser sub-trees in place, clears the 14 chooser
+  findings → rule 1 graduation candidate) → PR 3 (narrow the exemption + the second owner ask
+  "centralize settings by task" + graduate `edit_in_place` to error). Marked `needs-hermes-review` +
+  live-guild-walk per PR (substantial UI; not offline-testable).
+- Updated `docs/ideas/README.md` (idea → "PROMOTED to a plan") and `docs/roadmap.md` AI § Later (idea →
+  "Now an executable plan") so the promotion is reachable from both indices.
+
+## Continuation (the handoff)
+
+The plan is turn-key for a session with runtime context / a Q-0086 joint live session. PR 1 is the
+startable foundation. **This is the path to graduating consistency rule 1** — until PR 2 lands and the
+17 `views/ai/` findings clear, `edit_in_place` stays warn-only (rules 2/3/4 are already at 0 and are the
+nearer graduation candidates).
+
+## Context delta
+
+- **Pointed to and needed:** the idea file's source-confirmed diagnosis + scope sketch carried 80% of
+  the plan; the linter plan + #1058's triage made the "this idea blocks rule 1" link explicit.
+- **Discovered by hand:** re-counted the live `views/ai/` tree (18 classes) and confirmed only
+  `AIPanelView` is non-raw — the idea's per-file ephemeral counts were a 2026-06-11 snapshot; the
+  class-level shape is unchanged, so the plan stands.
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous slice (#1059, back_button) cleanly drove a rule to 0 by *verifying* the FP class rather
+than trusting the plan's prediction — good discipline. What the whole linter lane had **not** done until
+this run: connect the warn-only backlogs back to the *product* work that clears them. #1058 surfaced that
+rule 1's residue is the AI-nav idea; this slice closed the loop by promoting that idea to a buildable
+plan. **System improvement:** a warn-only linter finding that maps to an existing idea/plan should *say
+so* (the consistency_exceptions.yml now points `views/ai/` at the idea). Generalizing: the linter's
+graduation tracker could carry, per rule, the plan/idea that clears its residue — turning "why is this
+still warn-only?" into a one-hop answer. Captured below.
+
+## 💡 Session idea (Q-0089)
+
+**A per-rule "graduation blocker" line in the consistency-linter plan/tracker.** Each warn-only rule
+that can't yet flip to `error` is blocked by *something specific* (rule 1 ← the AI-nav redesign; a
+future rule ← an open triage). Recording that blocker (plan link) next to each rule's count makes the
+graduation queue self-explaining and stops a later agent re-deriving "what's left?" by hand. Distinct
+from #1058's `--diff` baseline idea (regression-guarding) and #1059's root-vs-child idea (a smarter rule
+input) — this is about the *graduation* metadata. Worth having; captured, not built.
+
+## 📊 Doc audit (Q-0104)
+
+- New plan reachable from `docs/ideas/README.md` + `docs/roadmap.md` (both updated). `check_docs --strict`
+  should stay green (run it at close).
+- No new owner decisions (the idea was already owner-requested; Q-0172 covers the self-initiated
+  promotion). Flagged on the run report's ⚑ Self-initiated line.
+- Ledger lag (#1053/#1055) unchanged — benign newest-merge lag for the #1080 pass (see #1058's card).
+
+## 📤 Run report
+
+- **Did:** promoted the owner-requested AI-panel in-place-navigation idea into an executable 2–3 PR plan
+  (the blocker for graduating consistency rule 1); updated the idea index + roadmap. · **Outcome:** shipped
+- **Shipped:** #1060 — `planning/ai-panel-inplace-navigation-plan-2026-06-19.md` + ideas-README + roadmap
+  promotion entries.
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** `none` (the redesign direction is already owner-approved; the plan's
+  settings-centralization shape is a design proposal for the executing session, not an owner gate).
+- **⚑ Owner manual steps:** `none`
+- **⚑ Self-initiated:** **YES** — promoted [`ideas/ai-panel-inplace-navigation-2026-06-11.md`](../ideas/ai-panel-inplace-navigation-2026-06-11.md)
+  → [`planning/ai-panel-inplace-navigation-plan-2026-06-19.md`](../planning/ai-panel-inplace-navigation-plan-2026-06-19.md)
+  under Q-0172 (no dispatched order named it; it was surfaced by #1058's triage as rule 1's blocker).
+  Docs-only; the build itself stays `needs-hermes-review` + live-walk.
+- **↪ Next:** graduation prep for rules 2/3/4 (all at 0); execute the AI-nav plan PR 1 in a runtime
+  session to start clearing rule 1's 17.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs this session (run total) | 3 (#1058 edit_in_place · #1059 back_button · #1060 AI-nav plan) |
+| Ideas groomed (Q-0015) | 1 (AI-nav idea → executable plan) |
+| Self-initiated promotions (Q-0172) | 1 |
+| CI-red rounds | 1 (born-red session gate by design) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (per-rule graduation-blocker tracker line) |

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -515,6 +515,10 @@ Current broad captures:
   `discord.ui.View` behind a blanket `views/ai/` yaml exemption (ratchet-invisible
   debt). Migrate it to the rest-of-bot in-place HubView pattern (V-02 navigation
   doctrine); source-confirmed diagnosis + scope sketch in the file.
+  **→ PROMOTED to an executable plan (2026-06-19, Q-0172):**
+  [`planning/ai-panel-inplace-navigation-plan-2026-06-19.md`](../planning/ai-panel-inplace-navigation-plan-2026-06-19.md)
+  (2–3 PRs; also the blocker for graduating the consistency linter's `edit_in_place` rule, whose 17
+  remaining findings are exactly this family).
 - [`gap-analysis-2026-06-11.md`](./gap-analysis-2026-06-11.md) — six
   dedup-verified blind spots from the owner's "what's still missing?" probe:
   cross-server character identity (**Q-0091**, the public-era architectural

--- a/docs/planning/ai-panel-inplace-navigation-plan-2026-06-19.md
+++ b/docs/planning/ai-panel-inplace-navigation-plan-2026-06-19.md
@@ -1,0 +1,115 @@
+# Plan — AI panels → in-place navigation (+ settings centralization)
+
+> **Status:** `plan` — executable plan promoted from
+> [`ideas/ai-panel-inplace-navigation-2026-06-11.md`](../ideas/ai-panel-inplace-navigation-2026-06-11.md)
+> (owner-requested live, 2026-06-11; roadmap AI § Later). Promoted 2026-06-19 under the open idea→plan
+> gate (Q-0172) — flagged self-initiated on that run's report. Source + the binding contracts win.
+>
+> **Why now:** this redesign is the *only* blocker for graduating the consistency linter's
+> **`edit_in_place` rule** — its 17 remaining warn-only findings are *exactly* the `views/ai/` family
+> (the rest of the tree is triaged to 0). Shipping this plan both fixes the owner's headline UX
+> complaint and lets rule 1 flip to `error` + wire into `code-quality.yml`.
+
+## The two owner asks (verbatim, 2026-06-11)
+
+1. *"the AI settings and panels create way too many ephemeral panels etc, this should be changed so it
+   matches the rest of the bot and updates in place"*
+2. *"these settings are a little confusing, and they should probably be more centralized as well,
+   because you have to go in different panels to edit certain AI settings"*
+
+## Source-confirmed scope (re-verified 2026-06-19)
+
+`disbot/views/ai/` is **18 view classes across 4 sub-trees**, all extending raw `discord.ui.View`
+**except** `AIPanelView` (a `PersistentView`):
+
+- **panel.py** — `AIPanelView` (the anchor; `policy_btn`/`behavior_btn`/`tools_btn` each `send_message`
+  a new ephemeral chooser → **3 `edit_in_place` findings**).
+- **behavior/** — `BehaviorChooserView` (**5 findings**: channel/category/preview/matrix/advanced) +
+  `scope_picker.py` (`BehaviorChannelSelectView`, `BehaviorCategorySelectView`) + `preset_picker.py`.
+- **policy/** — `PolicyChooserView` (**5 findings**: channel/category/role/preview/list) +
+  `channel_view`/`category_view`/`role_view`/`list_view`/`preview_view`.
+- **tools/** — `ToolsChooserView` (**4 findings**: guild/channel/category/preview) + `scope_view.py`
+  (`GuildToolsProfileView`, `ChannelToolsSelectView`, `CategoryToolsSelectView`) + `preview_view.py`.
+- **routing/** — `RoutingMatrixSelectView` (read-only dry-run, reached from the behavior chooser).
+- **support_report.py** — standalone.
+
+The blanket `views/ai/` exemption lives in `architecture_rules/canonical_helpers.yaml §
+base_view.exemptions` ("chained select menus require fine-grained interaction lifecycle control beyond
+what BaseView provides"); both `check_architecture` and the `panel_base_class` consistency rule honor it
+(reconciled in #1057), so this debt is **ratchet-invisible** until the exemption is narrowed.
+
+## The target pattern ("matches the rest of the bot")
+
+The post-RS10 doctrine (settings hub, server-management hub, mining hub) and V-02 navigation doctrine:
+**one anchor message; button/select callbacks `interaction.response.edit_message(...)` the same message
+to the next page; `BaseView`/`HubView` owns timeout/denial/error lifecycle; ephemeral messages reserved
+for confirmations/errors, not navigation.** The Settings hub's channel/enum/role edit flows already
+re-render the same message with the next select — the chained-select concern (the stated exemption
+reason) is solved there, so it is solvable here.
+
+## Build order (2–3 PRs)
+
+### PR 1 — foundation + the AI anchor (clears panel.py's 3 findings)
+
+- Establish the in-place page model on `AIPanelView`: a `HubView`-style anchor whose
+  `policy_btn`/`behavior_btn`/`tools_btn` **`edit_message`** the anchor to render the policy / behavior /
+  tools chooser as a *page* of the same message (with a back affordance to the AI home page), instead of
+  `send_message`-ing a new ephemeral.
+- Keep `AIPanelView` persistent (custom_ids) — the page swap is on the same persistent anchor.
+- Re-check `docs/ai-config-ownership.md` UI-surface pinning (doc-test-pinned) **before** moving panels;
+  update the pinned surface list in the same PR.
+- **Deliverable:** the 3 `panel.py` `edit_in_place` findings clear; the chooser entry points navigate
+  in place.
+
+### PR 2 — chooser sub-trees in place (clears the 14 chooser findings)
+
+- Migrate `BehaviorChooserView` / `PolicyChooserView` / `ToolsChooserView` and their scope pickers
+  (`scope_picker`, `policy/*_view`, `tools/scope_view`, the preview/list views, `routing/matrix`) onto
+  `BaseView`/`HubView` with in-place page swaps: the chooser → scope picker → confirmation are pages of
+  the one anchor, re-rendered via `edit_message`. Reserve ephemerals for confirmations/errors only.
+- Reuse the existing windowed-select helper (`views/paginated_select.attach_windowed_select`) for any
+  scope select that can exceed 25 options (channels/categories/roles) — do **not** reintroduce a
+  front-truncation (rule 4 guards this).
+- **Deliverable:** all 17 `edit_in_place` findings clear → **rule 1 becomes a graduation candidate.**
+
+### PR 3 — narrow the exemption + centralize (the second owner ask)
+
+- **Narrow/delete** the blanket `views/ai/` exemption in `canonical_helpers.yaml` per migrated class;
+  ratchet the conformance frozenset down as pages land (so the family is visible to the ratchet again,
+  matching every other direct-`View` entry). Drop the mirrored `views/ai/` path exemption from the
+  consistency `panel_base_class` rule (`_BASE_CLASS_ALLOWED_PATHS`) once the classes are `BaseView`.
+- **Centralize the settings surface (ask #2):** one AI hub page grouping settings by *task* ("make the
+  bot reply here" = `ai_enabled` ∧ `ai_natural_language_enabled` ∧ channel mode ∧ min level as ONE
+  guided flow) instead of seven sibling subpanels + a flat 10-key scalar editor. Make the required
+  couplings visible (the `ai_enabled` ON / `ai_natural_language_enabled` OFF silent-bot trap that opened
+  the 2026-06-11 session is the canonical symptom). Reconcile with the Settings-hub AI group so there is
+  one front door (`!aimenu` and `!settings` reach AI config by different routes today).
+- **Graduate `edit_in_place`:** flip to `error` + wire into `code-quality.yml` (rule 1's last blocker
+  cleared).
+
+## Risk / sequencing notes
+
+- **Substantial UI migration** (18 view classes, real Discord interaction lifecycle) — each PR is
+  `needs-hermes-review` (Q-0117), **not** a routine self-merge, and wants **live verification** in a
+  guild (the interaction behavior is not fully offline-testable). This plan is written for a session
+  with runtime context / the joint live-session cadence (Q-0086).
+- Keep default behavior byte-identical where the page content is unchanged; the change is *navigation
+  mechanism*, not policy/data.
+- PRs 1+2 are the `edit_in_place` clear; PR 3 (centralization + graduation) can trail as its own slice
+  if the band runs long (plans span 2–3 PRs).
+
+## Verification (each PR)
+
+- `python3.10 scripts/check_consistency.py --mode strict` — the migrated classes drop their
+  `edit_in_place` (and, in PR 3, `panel_base_class`) findings; no new `select_option_truncation`.
+- `python3.10 scripts/check_quality.py --full` green; `check_architecture --mode strict` exit 0.
+- `docs/ai-config-ownership.md` UI-surface doc-test stays green (update the pinned list in lockstep).
+- Live walk in a guild: `!aimenu` → policy → behavior → tools navigates **in place** (one anchor
+  message), confirmations/errors are the only ephemerals.
+
+## Routing
+
+- Lane: AI tooling UX / views conformance (RS10's natural follow-on; V-02 navigation doctrine).
+- Unblocks: consistency-linter rule 1 graduation
+  ([linter plan](repo-consistency-linter-plan-2026-06-17.md)).
+- Pairs with: the Help home / navigation plan (same doctrine).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -410,8 +410,10 @@ dedicated decision** for any action capability.
   migrate the `views/ai/` settings family off per-click ephemeral messages + the blanket
   raw-`discord.ui.View` yaml exemption onto the rest-of-bot in-place **HubView** pattern
   (V-02 navigation doctrine), and centralize the seven scattered subpanels. Clear
-  direction + a source-confirmed scope sketch in the idea file; wants its own planning
-  session before code.
+  direction + a source-confirmed scope sketch in the idea file. **Now an executable plan**
+  ([ai-panel-inplace-navigation-plan-2026-06-19](planning/ai-panel-inplace-navigation-plan-2026-06-19.md),
+  2–3 PRs) — also the blocker for graduating the consistency linter's `edit_in_place` rule (its 17
+  remaining findings are this family); each PR is `needs-hermes-review` + wants a live guild walk.
 
 ### 🎈 BTD6 data / tools · **S2 BTD6** — Now (THE CUTOVER IS DONE — post-cutover decode backlog)
 


### PR DESCRIPTION
Backlog-grooming ender (Q-0015) + a self-initiated idea→plan promotion (Q-0172). Structures the owner-requested [`ideas/ai-panel-inplace-navigation-2026-06-11.md`](docs/ideas/ai-panel-inplace-navigation-2026-06-11.md) into an executable plan.

**Why this idea:** it is the *only* blocker for graduating the consistency linter's `edit_in_place` rule — that rule's 17 remaining warn-only findings (after #1058's triage) are *exactly* the `views/ai/` family. The plan both fixes the owner's headline 2026-06-11 UX complaint ("AI panels stack ephemerals instead of updating in place") and unblocks rule 1's graduation.

- New plan: `planning/ai-panel-inplace-navigation-plan-2026-06-19.md` — re-verified scope (18 `views/ai/` classes, all raw `discord.ui.View` except the `AIPanelView` PersistentView), target in-place HubView pattern, and a 2–3 PR build order (anchor → chooser sub-trees → narrow the exemption + centralize settings + graduate the rule). Each PR is `needs-hermes-review` + wants a live guild walk (substantial UI, not offline-testable).
- Idea index + roadmap updated to reflect the promotion.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVc7nW5GnkMqyNj2vfSspu)_