### PR TITLE
Repo structure: governance + supply-chain + CI baseline (plan + foundation, Q-0177)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: 🐞 Bug report
+description: Report a reproducible problem with the bot or dashboard.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. For a **security vulnerability**, stop here and follow
+        [`SECURITY.md`](https://github.com/menno420/superbot/blob/main/SECURITY.md) instead.
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: The deployed commit SHA if known, or roughly when you saw it.
+      placeholder: "e.g. 9849111 or 2026-06-19"
+    validations:
+      required: false
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where did it happen?
+      options:
+        - Discord bot (command / interaction)
+        - Developer dashboard
+        - CI / tooling
+        - Other / not sure
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Run `!command ...`
+        2. Click ...
+        3. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Logs / screenshots / extra context
+      description: Redact any tokens or secrets before pasting.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,15 @@
+# Issue-template chooser config. Provenance: Q-0177 (2026-06-19).
+# Planning lives in docs/ and the developer dashboard by design, so the contact links
+# point there first. Blank issues stay enabled so automation (the reconciliation /
+# Hermes routines) and quick notes are unaffected.
+blank_issues_enabled: true
+contact_links:
+  - name: 📋 Roadmap & active plans
+    url: https://github.com/menno420/superbot/blob/main/docs/roadmap.md
+    about: SuperBot's roadmap and plans live in docs/, not in issues. Browse here first.
+  - name: 🧭 Contributor orientation
+    url: https://github.com/menno420/superbot/blob/main/CONTRIBUTING.md
+    about: How the repo works, how to run the checks, and which areas accept contributions.
+  - name: 🔒 Report a security issue
+    url: https://github.com/menno420/superbot/blob/main/SECURITY.md
+    about: Do NOT open a public issue for a vulnerability — follow the security policy.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: 💡 Feature request
+description: Suggest an improvement or new capability.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Note: SuperBot's roadmap and most planning live in
+        [`docs/`](https://github.com/menno420/superbot/tree/main/docs) and the developer
+        dashboard. A feature request here is welcome; larger ideas may be routed into a
+        `docs/ideas/` capture or a `docs/planning/` plan.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The user-facing need, not the implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Bot product (commands / games / moderation)
+        - AI / BTD6
+        - Developer dashboard
+        - Tooling / workflow / docs
+        - Other / not sure
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--
+Provenance: Q-0177 (2026-06-19). Keep PRs focused. Agent sessions follow
+.claude/CLAUDE.md (born-red session card + enders); this template is mainly for
+human contributors. The body set by an agent via the API overrides this template.
+-->
+
+## Summary
+
+<!-- What does this change, and why? -->
+
+## Linked issue / plan
+
+<!-- "Closes #NN", or link the docs/planning or docs/ideas entry this implements. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Tooling / CI
+- [ ] Breaking change
+
+## Checks
+
+- [ ] `python3.10 scripts/check_quality.py --full` passes (black + isort + ruff + mypy + pytest)
+- [ ] `python3.10 scripts/check_architecture.py --mode strict` passes (exit 0)
+- [ ] Docs / ledger updated if behavior or project state changed
+- [ ] No secrets, tokens, or credentials added
+
+<!-- CI's "Code Quality" check must be green to merge. claude/* PRs auto-merge on green. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+# Dependabot version updates.
+#
+# Provenance: owner-greenlit in-session 2026-06-19 (Q-0177), part of the repo
+# governance/supply-chain baseline. This is the *version-update* half; the
+# *security-update + alert* half is a repo-Settings toggle the owner must enable
+# (Security → Code security → Dependabot alerts + security updates).
+#
+# Also closes the gap-analysis §6 "toolchain rot watch" concern by keeping GitHub
+# Actions versions fresh (the same class as the Python-3.13 / Node-20 deprecations
+# that bit unpinned infra). Grouped minor/patch updates keep PR noise low; tune the
+# cadence / open-PR limits here. Dependabot PRs land on `dependabot/*` branches, so
+# the `claude/*` auto-merge-enabler never auto-merges them — they wait for review.
+version: 2
+updates:
+  # Bot runtime + dev tooling (root requirements.txt + requirements-dev.txt).
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+    groups:
+      python-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # Developer dashboard — a separate Railway service with its own requirements.
+  - package-ecosystem: "pip"
+    directory: "/dashboard"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+    groups:
+      dashboard-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # GitHub Actions versions used by the workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+name: CodeQL
+
+# Static analysis (SAST) for the Python tree. Provenance: owner-greenlit in-session
+# 2026-06-19 (Q-0177), part of the repo governance/supply-chain baseline. Findings are
+# published to the repo's Security → Code scanning tab; this workflow is NOT a required
+# merge check (making it one is an owner repo-Settings step — see the plan). Action
+# versions are major-tag pinned to match the repo convention (checkout@v5); SHA-pinning
+# is a tracked hardening follow-up. Free for public repositories.
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "23 3 * * 1" # weekly, Monday 03:23 UTC
+
+# Mirror code-quality's cost discipline: cancel superseded PR runs; never cancel main.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          # 'security-extended' adds more security queries than the default set without
+          # the maintainability/quality noise. Dial to 'default' if it is too chatty, or
+          # to 'security-and-quality' for the full set.
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -1,0 +1,64 @@
+name: Dashboard CI
+
+# Runs the developer-dashboard test suite + type-check. Provenance: owner-greenlit
+# in-session 2026-06-19 (Q-0177), part of the repo governance/supply-chain baseline.
+#
+# Why a separate workflow: the main `code-quality.yml` installs only the BOT's
+# requirements.txt, so the dashboard tests (`tests/unit/dashboard/`) `importorskip`
+# fastapi/httpx and silently SKIP, and dashboard code is never type-checked (CI runs
+# `mypy disbot/` only). Black/isort/ruff already cover `dashboard/` in the main job
+# (it is not in their exclude list), so this workflow adds exactly the two missing
+# pieces: real test execution + `mypy dashboard/`.
+#
+# `paths`-filtered so it only runs when dashboard code/tests change (cheap). It is NOT a
+# required merge check (making it one is an owner repo-Settings step — see the plan).
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "dashboard/**"
+      - "tests/unit/dashboard/**"
+      - ".github/workflows/dashboard-ci.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "dashboard/**"
+      - "tests/unit/dashboard/**"
+      - ".github/workflows/dashboard-ci.yml"
+
+concurrency:
+  group: dashboard-ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  dashboard-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            dashboard/requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Bot reqs: tests/conftest.py imports disbot (registry validation) before any
+          # dashboard test collects. Dashboard reqs: fastapi/httpx so the tests actually
+          # run instead of importorskip-skipping. mypy/pytest pinned to match CI.
+          pip install -r requirements.txt -r dashboard/requirements.txt
+          pip install mypy==2.1.0 pytest==9.0.3 pytest-asyncio==1.4.0
+
+      - name: Type-check dashboard (mypy)
+        run: mypy dashboard/
+
+      - name: Run dashboard tests
+        run: pytest tests/unit/dashboard -v

--- a/.sessions/2026-06-19-repo-governance-supply-chain-baseline.md
+++ b/.sessions/2026-06-19-repo-governance-supply-chain-baseline.md
@@ -1,23 +1,135 @@
 # 2026-06-19 — Repo structure: governance + supply-chain + CI baseline
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-## Arc (what I'm about to do)
+## Arc
 
-Owner uploaded three external repo-review reports (two Dutch research passes + a Markdown
-review reconciling them) and asked for **a comprehensive plan to improve the repo structure**.
-Cross-checked every recommendation against live source + recorded owner decisions (the reports
-are *input to verify*, never orders — and a prior structure review already settled the
-code-layout question: **no filesystem reorg**, Q-0151). The genuine remaining gap is the
-**outward-facing governance / supply-chain / operational** layer.
+Owner uploaded three external repo-review reports (two Dutch research passes + a Markdown review
+reconciling them) and asked for **a comprehensive plan to improve the repo structure**. Cross-checked
+every recommendation against live source + recorded owner decisions (the reports are *input to verify*,
+never orders — and a prior structure review already settled the code-layout question: **no filesystem
+reorg**, Q-0151). The genuine remaining gap is the **outward-facing governance / supply-chain /
+operational** layer. Owner chose in-session (`AskUserQuestion`): **LICENSE = MIT**, scope = **plan +
+docs + CI config** (greenlighting the `.github/` executable-config changes — the CLAUDE.md Q-0106
+exception; provenance **Q-0177**).
 
-Owner chose, in-session: **LICENSE = MIT**, and scope = **plan + docs + CI config** (greenlighting
-the `.github/` executable-config changes in-session — the CLAUDE.md Q-0106 exception; provenance
-recorded as **Q-0177**).
+## Shipped (PR #1064)
 
-This session ships: the comprehensive plan doc + the executed foundation (LICENSE, SECURITY.md,
-CONTRIBUTING.md, CITATION.cff, Dependabot, CodeQL, a dashboard-CI job, issue/PR templates) +
-a root-fixed dashboard test bug surfaced while wiring the dashboard CI + the routed owner decisions.
+- **The plan:** [`planning/repo-structure-improvement-plan-2026-06-19.md`](../docs/planning/repo-structure-improvement-plan-2026-06-19.md)
+  — a verification table (each report claim → live finding → *already-shipped* / *deliberately-decided*
+  / *genuine-gap*), a prioritized P0–P3 backlog, routed decisions, S5 roadmap slot.
+- **Governance foundation:** `LICENSE` (MIT), `SECURITY.md`, `CONTRIBUTING.md`, `CITATION.cff`.
+- **Supply-chain / CI:** `.github/dependabot.yml` (pip root + dashboard + actions), `codeql.yml`
+  (Python SAST, non-blocking), `dashboard-ci.yml` (runs the previously-skipped `tests/unit/dashboard/`
+  + `mypy dashboard/`), `.github/ISSUE_TEMPLATE/` + `PULL_REQUEST_TEMPLATE.md`.
+- **Root-fixed bug** (surfaced wiring dashboard CI): fresh install pulled `httpx 0.28`, which persists
+  per-request `cookies=` into the shared module-scoped `TestClient` → a login cookie leaked into the
+  later "requires-login" tests (63 pass / 2 fail). Made the `client` fixture function-scoped
+  (`tests/unit/dashboard/test_app.py`) → **65 pass**, `mypy dashboard/` clean. A live demo of the
+  dependency-pin gap the plan flags.
+- **Routed (Q-0177):** dependency-lock strategy · control-API hardening · pointer-README (Q-0151b) ·
+  roadmap→labeled-issue mirror. **Owner manual steps:** enable Dependabot alerts/security-updates +
+  private vuln reporting; optionally make codeql/dashboard-ci required; confirm MIT copyright name.
 
-_(Enders — context delta, prev-session review, idea, doc audit, run report, telemetry — finalized
-in the closing commit when this badge flips to `complete`.)_
+Verification: `check_quality.py --full` ✓ (10704 passed) · `check_architecture --mode strict` exit 0 ·
+`check_docs --strict` ✓ · dashboard suite 65 pass.
+
+## Continuation (the handoff)
+
+The first buildable follow-up is the **P1 dependency-lock plan** (Q-0177 option a — `pip-tools`
+lockfile for the dashboard first, then the bot), which would make the `httpx 0.28`-class break
+impossible. After that: the backup *restore* drill (P2) and SHA-pinning Actions (pairs with Dependabot).
+Control-API hardening (P2) waits on the owner (write-surface "don't rush" zone).
+
+## Context delta
+
+- **Needed but not pointed to:** that `scripts/check_docs.py` scopes **`docs/**` only** — root
+  governance files (`LICENSE`/`SECURITY.md`/`CONTRIBUTING.md`/`CITATION.cff`) are entirely outside its
+  badge/link/reachability checks. Had to read the checker to confirm root files need no `Status:` badge.
+  Also the born-red ↔ auto-merge ↔ Q-0127 (MCP PR doesn't trigger the enabler) interplay is spread
+  across several CLAUDE.md bullets — a single "opening a PR from a session" checklist would help.
+- **Pointed to but didn't need:** the `current-state.md` ▶ Next action mega-paragraph — enormous and
+  almost entirely S1/S2 bot-product lane history; near-zero signal for a governance/ops task. The
+  roadmap S5 lane + the architecture-atlas capture carried the orientation.
+- **Discovered by hand:** the httpx ≥0.28 per-request-cookie-persistence behavior change (reverse-engineered
+  from the failure + deprecation warning); and that dashboard Python is *already* black/isort/ruff-checked
+  by the main job (it's not in their exclude list), so the real CI gap was only test-execution + `mypy`.
+
+## Decisions made alone (ratify or correct)
+
+- **LICENSE copyright holder = "Menno van Hattum"** (derived from the owner email). Flagged in Q-0177 +
+  as an owner manual step — trivial to correct.
+- **CodeQL query suite = `security-extended`** (security-focused, no quality noise; dial-able in the workflow).
+- **`dashboard-ci.yml` as a separate `paths`-filtered workflow** (not a second job in `code-quality.yml`)
+  — isolates dashboard concerns + only runs on dashboard changes. Non-required until the owner opts in.
+
+## Flagged for maintainer (known limits)
+
+- `codeql.yml` + `dashboard-ci.yml` are **not required checks** until added to branch protection — a
+  future dashboard test break would not block a merge yet (owner manual step in Q-0177).
+- CodeQL's **first run may surface findings** to triage (Security → Code scanning).
+- Dashboard deps are **still version ranges** — the lockfile decision is routed (Q-0177 P1.1), not done;
+  `dashboard-ci` is the early-warning net until then. The per-request-cookies **deprecation warnings**
+  remain (a larger test-modernization is a deferred follow-up).
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous session: [`2026-06-19-consistency-back-button-triage.md`](2026-06-19-consistency-back-button-triage.md)
+(#1059). **Did well:** exemplary Q-0120 discipline — it traced all 7 `back_button` findings to their
+construction sites rather than trusting the plan's prediction, and correctly concluded "allowlist, not a
+code change" without manufacturing a fix. **Could improve / system observation:** it's the 4th in a chain
+of single-rule micro-triage sessions (#1056/#1057/#1058/#1059) that each rewrite the same files —
+including the **enormous `current-state.md` ▶ Next action paragraph**, which self-warns about parallel-merge
+collisions. The unexecuted `repo-manageability-2026-06-12` idea #2 (cap + auto-archive Recently-shipped,
+break the mega-header into per-lane bullets) would directly cut that per-session friction. **System
+improvement:** that idea is overdue — every micro-session pays the mega-header tax; promoting it to a small
+plan would pay back across the whole session chain. (I felt the same tax this session — see Context delta.)
+
+## 💡 Session idea (Q-0089)
+
+**Contributor-doc / governance-files presence + freshness guard** —
+[`ideas/governance-files-presence-guard-2026-06-19.md`](../docs/ideas/governance-files-presence-guard-2026-06-19.md).
+A tiny stdlib `scripts/check_governance_files.py` asserting the new root files stay present **and** that
+the repo paths cited in `CONTRIBUTING.md`/`SECURITY.md` still resolve — `check_docs` scopes `docs/**`
+only, so these are unguarded, and the *first thing a new contributor runs* is the commands those docs
+cite. "Executable verification over prose" applied to the governance layer. Dedup-checked; worth having.
+
+## 📊 Doc audit (Q-0104)
+
+- Plan in `docs/planning/` ✓ · idea in `docs/ideas/` + README index ✓ · decision in router **Q-0177** ✓ ·
+  roadmap **S5** entry ✓ · session card ✓ — all homed + reachable (`check_docs --strict` green).
+- **Ledger:** the SessionStart banner + `check_current_state_ledger --strict` flag #1053/#1055/#1060/#1061
+  — all **newer than the recon marker #1050**, i.e. the "newest-merge lag → next pass records" exception
+  (Q-0166), and already deferred by #1058/#1059 to the **#1080 reconciliation pass**. Not this session's
+  drift; not added here (Q-0124 — a manual session pursues its task, not the docs pass).
+- My PR #1064 records into the ledger after it merges (the next recon pass / a follow-up), not pre-merge.
+
+## 📤 Run report
+
+- **Did:** shipped the outward-facing governance + supply-chain + CI baseline (license/security/contributing
+  + Dependabot/CodeQL/dashboard-CI + templates) + the comprehensive plan, and root-fixed a dashboard test
+  bug en route. · **Outcome:** shipped
+- **Shipped:** #1064 — LICENSE/SECURITY.md/CONTRIBUTING.md/CITATION.cff · `.github/dependabot.yml` ·
+  `codeql.yml` · `dashboard-ci.yml` · issue/PR templates · the plan + router Q-0177 + roadmap S5 · the
+  `httpx 0.28` test-isolation fix.
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** **Q-0177** — dependency-lock strategy · control-API hardening depth/timing
+  · pointer-README go/no-go (Q-0151b) · roadmap→labeled-issue mirror (agent rec: don't adopt GitHub
+  Projects wholesale).
+- **⚑ Owner manual steps:** enable **Dependabot alerts + security updates** + **private vulnerability
+  reporting** (Settings → Code security) · optionally add **codeql** + **dashboard-ci** to required checks ·
+  confirm the **MIT copyright holder** name in `LICENSE`.
+- **⚑ Self-initiated:** `none` (owner-directed task; the dashboard test fix was an in-scope bug surfaced by
+  the dashboard-CI work, not an unprompted feature build).
+- **↪ Next:** the Q-0177 routed decisions; first buildable = the **P1 dependency-lock plan** (`pip-tools`
+  lockfile, dashboard first).
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (#1064, auto-merge on green) |
+| CI-red rounds | 1 (born-red session gate by design) |
+| Repo-rule trips | 0 (arch strict exit 0; quality --full green first try) |
+| New ideas contributed | 1 (governance-files presence guard) |
+| Ideas groomed | 1 (gap-analysis §6 toolchain-rot-watch → closed by Dependabot; backup restore-drill routed) |

--- a/.sessions/2026-06-19-repo-governance-supply-chain-baseline.md
+++ b/.sessions/2026-06-19-repo-governance-supply-chain-baseline.md
@@ -1,0 +1,23 @@
+# 2026-06-19 — Repo structure: governance + supply-chain + CI baseline
+
+> **Status:** `in-progress`
+
+## Arc (what I'm about to do)
+
+Owner uploaded three external repo-review reports (two Dutch research passes + a Markdown
+review reconciling them) and asked for **a comprehensive plan to improve the repo structure**.
+Cross-checked every recommendation against live source + recorded owner decisions (the reports
+are *input to verify*, never orders — and a prior structure review already settled the
+code-layout question: **no filesystem reorg**, Q-0151). The genuine remaining gap is the
+**outward-facing governance / supply-chain / operational** layer.
+
+Owner chose, in-session: **LICENSE = MIT**, and scope = **plan + docs + CI config** (greenlighting
+the `.github/` executable-config changes in-session — the CLAUDE.md Q-0106 exception; provenance
+recorded as **Q-0177**).
+
+This session ships: the comprehensive plan doc + the executed foundation (LICENSE, SECURITY.md,
+CONTRIBUTING.md, CITATION.cff, Dependabot, CodeQL, a dashboard-CI job, issue/PR templates) +
+a root-fixed dashboard test bug surfaced while wiring the dashboard CI + the routed owner decisions.
+
+_(Enders — context delta, prev-session review, idea, doc audit, run report, telemetry — finalized
+in the closing commit when this badge flips to `complete`.)_

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: "If you use SuperBot or its agent-development workflow, please cite it as below."
+title: SuperBot
+abstract: >-
+  A Discord bot platform and the self-improving, agent-driven development
+  workflow (docs, journal, hooks, tooling, router) that builds and maintains it.
+type: software
+authors:
+  - given-names: Menno
+    family-names: van Hattum
+    alias: menno420
+repository-code: "https://github.com/menno420/superbot"
+url: "https://github.com/menno420/superbot"
+license: MIT
+keywords:
+  - discord-bot
+  - ai-agents
+  - autonomous-development
+  - claude-code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to SuperBot
+
+SuperBot is primarily built by **AI coding agents** working under a documented,
+self-improving workflow — but the repository is public and human contributions are
+welcome. This guide is the human-facing entry point; the agent workflow it bridges to is
+the real source of truth.
+
+## Start here (reading order)
+
+1. **`docs/AGENT_ORIENTATION.md`** — the primary reading-order router ("what do I read for
+   task X?").
+2. **`docs/collaboration-model.md`** — how we work (the binding working model).
+3. **`.claude/CLAUDE.md`** — the working agreement that governs every change.
+4. The three binding contracts before any non-trivial change:
+   - **`docs/architecture.md`** — layering and import boundaries.
+   - **`docs/ownership.md`** — which service/pipeline owns each table, event, and write.
+   - **`docs/runtime_contracts.md`** — lifecycle guarantees and failure modes.
+
+`docs/current-state.md` is the living "what's true right now" ledger. **Source code and
+merged PRs always win** over any document.
+
+## Repository layout
+
+| Path | What it is |
+|---|---|
+| `disbot/` | The Discord **bot runtime** (cogs, services, views, governance, control API). |
+| `dashboard/` | A **separate** FastAPI developer-dashboard service. It never imports bot code. |
+| `docs/` | The documentation surface — planning, ideas, contracts, subsystem folios. Planning lives here (and in the dashboard), **not** in GitHub issues, by design. |
+| `scripts/` | Repo tooling (quality/architecture/docs checkers, data exporters). |
+| `tests/` | The pytest suite (`tests/unit/...`). Dashboard tests live in `tests/unit/dashboard/`. |
+| `architecture_rules/` | Machine-checked layer/consistency rules. |
+
+## Local setup
+
+CI runs **Python 3.10** — match it exactly, or formatters/mypy silently disagree.
+
+```bash
+bash scripts/setup_dev_env.sh          # or: pip install -r requirements.txt -r requirements-dev.txt
+pip install -r dashboard/requirements.txt   # only if you touch dashboard/
+```
+
+## Before you open a PR
+
+Both must pass:
+
+```bash
+python3.10 scripts/check_quality.py --full        # black + isort + ruff + mypy + pytest (CI mirror)
+python3.10 scripts/check_architecture.py --mode strict
+```
+
+- Keep runtime (`disbot/`) PRs **small and focused**; larger end-to-end PRs are fine for
+  docs/tooling.
+- **Never** write directly to the database from a cog or view — go through the domain's
+  `*_mutation.py` service and emit an audit action. See `docs/architecture.md`.
+- Update the relevant docs/ledger when behavior or project state changes.
+- **No secrets, tokens, or credentials** in code, tests, or fixtures.
+
+CI (the **Code Quality** check) must be green before a PR can merge. `claude/*` PRs
+auto-merge on green; human PRs merge after review.
+
+## Open vs. owner-gated areas
+
+Some areas are **owner-gated**: the production deploy, control-API **write** surfaces,
+secret/credential management, and certain product/abuse decisions. Open questions and
+pending decisions are tracked in `docs/owner/maintainer-question-router.md`. Documentation,
+tests, tooling, and bug fixes are the easiest places to start.
+
+## Security
+
+Found a vulnerability? **Do not open a public issue** — follow `SECURITY.md`.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the project's
+**MIT License** (`LICENSE`).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Menno van Hattum
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,59 @@
+# Security Policy
+
+## Supported versions
+
+SuperBot is **continuously deployed** from `main` (a merge to `main` auto-deploys to
+the production Railway service). There are no release branches or version tags, so the
+**only supported version is the currently-deployed `main`**. Fixes land on `main` and
+deploy from there.
+
+| Version | Supported |
+|---|---|
+| `main` (deployed) | ✅ |
+| anything else | ❌ |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security vulnerability.**
+
+Report privately, one of:
+
+1. **GitHub private vulnerability reporting** — the repository's **Security → Report a
+   vulnerability** tab (preferred; keeps the report and fix coordinated in one place).
+2. **Email** — `mennovanhattum@gmail.com` with `[SuperBot security]` in the subject.
+
+Please include: a description, the affected component/path, reproduction steps or a PoC,
+and the impact you observed. We aim to acknowledge within **5 working days** and to
+coordinate disclosure once a fix is deployed. There is no paid bug-bounty program.
+
+## Scope
+
+In scope:
+
+- The **bot runtime** (`disbot/`) — commands, services, the audited mutation seams.
+- The **private control API** (`disbot/control_api.py`) and **health server**
+  (`disbot/healthserver.py`).
+- The **developer dashboard** (`dashboard/`) — auth, session cookie, control-API client.
+- **CI/CD workflows** (`.github/workflows/`) and how secrets are handled.
+
+Out of scope: vulnerabilities in third-party platforms (Discord, Railway, OpenAI/Anthropic
+APIs) themselves; findings that require a compromised maintainer machine or an already-leaked
+`CONTROL_API_TOKEN`; volumetric/DoS reports without a concrete amplification vector.
+
+## Current security posture (defense-in-depth)
+
+For context when assessing a report, the design already assumes a hostile network:
+
+- The **control API is dormant by default** — its `/control/*` surface registers **only**
+  when `CONTROL_API_TOKEN` is set, and is intended for a **private network** path.
+- Every control request must present a **bearer token**; writes pass through a
+  **sliding-window rate limiter**, and the **bot re-resolves the acting user via Discord**
+  before any mutation — the bot, not the API caller, remains the authority. Every mutation
+  flows through the existing **audited service seam** (`services/*_mutation.py` +
+  `services.audit_events.emit_audit_action()`).
+- **Secrets are environment variables** (Railway-managed) and are never committed; the
+  dashboard session is a stdlib **HMAC-signed cookie**.
+
+Hardening still on the roadmap (request signing / HMAC + timestamp, idempotency keys on
+writes, token rotation) is tracked in
+`docs/planning/repo-structure-improvement-plan-2026-06-19.md` and router **Q-0177**.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -20,6 +20,14 @@ during grooming** (it stays listed here, annotated ✅) so the active backlog re
 
 Current broad captures:
 
+- [`governance-files-presence-guard-2026-06-19.md`](./governance-files-presence-guard-2026-06-19.md) —
+  **session idea (2026-06-19, Q-0089, from the repo governance/supply-chain baseline session):** a tiny
+  stdlib `scripts/check_governance_files.py` that asserts the new root governance files (`LICENSE` ·
+  `SECURITY.md` · `CONTRIBUTING.md` · `CITATION.cff`) stay present **and** that the repo paths cited in
+  `CONTRIBUTING.md`/`SECURITY.md` still resolve — `check_docs.py` scopes `docs/**` only, so these root
+  files are unguarded. "Executable verification over prose" applied to the governance layer. Quick-win,
+  disposable (Q-0105). → relates `scripts/check_docs.py` · the P0 work in
+  [`planning/repo-structure-improvement-plan-2026-06-19.md`](../planning/repo-structure-improvement-plan-2026-06-19.md).
 - [`repo-consistency-linter-2026-06-17.md`](./repo-consistency-linter-2026-06-17.md) —
   **owner-directed (2026-06-17, Q-0170):** *"something like CI but specifically to find
   inconsistencies"* — panels missing a back button, cogs not following the arch rules, cogs sending

--- a/docs/ideas/governance-files-presence-guard-2026-06-19.md
+++ b/docs/ideas/governance-files-presence-guard-2026-06-19.md
@@ -1,0 +1,41 @@
+# Idea: contributor-doc / governance-files presence + freshness guard
+
+> **Status:** `ideas` — capture only. **Not a plan, not approval.** Source code, the binding
+> contracts, and `docs/current-state.md` win over anything here. Session idea (Q-0089, 2026-06-19,
+> from the repo governance/supply-chain baseline session).
+
+## The idea
+
+This session added the standard outward-facing governance files (`LICENSE`, `SECURITY.md`,
+`CONTRIBUTING.md`, `CITATION.cff`) and a contributor on-ramp. They're prose, so nothing stops a later
+refactor from silently deleting one, or letting `CONTRIBUTING.md`'s instructions rot (it cites
+`scripts/check_quality.py --full`, `scripts/setup_dev_env.sh`, the binding contract paths — if any
+move, the onboarding doc lies and the *first thing a new contributor runs* fails).
+
+A tiny stdlib guard — `scripts/check_governance_files.py`, in the `check_docs.py` house style:
+1. **Presence:** assert `LICENSE`, `SECURITY.md`, `CONTRIBUTING.md`, `CITATION.cff` exist.
+2. **Freshness:** parse the backtick repo-paths out of `CONTRIBUTING.md` + `SECURITY.md` and assert
+   each resolves on disk (the same link-resolution `check_docs` already does for `docs/**`, but these
+   root files are *outside* its scope — confirmed this session).
+3. Optionally: assert `CITATION.cff` parses as valid CFF and `LICENSE` is non-empty.
+
+This is the "executable verification over prose" ethos (the repo's own
+`executable-verification-over-prose-verified-2026-06-12` idea) applied to the governance layer the
+existing checkers don't cover.
+
+## Why it's worth having
+
+The whole point of adding a CONTRIBUTING on-ramp is that an outsider can run the commands and have
+them work. A guard makes that a CI invariant instead of a hope. Cheap, read-only, stdlib, disposable
+(Q-0105) — delete it if it proves more friction than value.
+
+## Dedup
+
+Checked against `docs/ideas/`: distinct from `check_docs.py` (scopes `docs/**` only — these are root
+files), from the generated-artifact-freshness umbrella (that guards *generated* artifacts; these are
+hand-written), and from the repo-consistency-linter (UX/interaction rules, not file presence).
+
+## Route
+
+Quick-win lane — a small guard, one session, no owner decision. Pairs with the P0 governance work in
+[`docs/planning/repo-structure-improvement-plan-2026-06-19.md`](../planning/repo-structure-improvement-plan-2026-06-19.md).

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,11 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/focused-goldberg-mviel4` · **repo structure: governance + supply-chain + CI baseline**
+  (owner-directed from 3 uploaded reports; LICENSE=MIT + full scope, Q-0177) — comprehensive plan +
+  LICENSE/SECURITY.md/CONTRIBUTING.md/CITATION.cff + `.github/dependabot.yml` + CodeQL + dashboard-CI
+  job + issue/PR templates + dashboard test-isolation fix · `docs/planning/` · `.github/` ·
+  `dashboard` tests · 2026-06-19
 - `claude/magical-rubin-jnpnuw` · **dashboard.json structural-drift reporter** + freshness catch-up
   (executes the #1020 💡 idea + finding) · `scripts/check_dashboard_data.py` ·
   `dashboard/data/dashboard.json` · tests · 2026-06-17 · **auto-merge on green**

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -6441,3 +6441,56 @@ born-red gate, not a replacement.
 
 **Home:** this Q-block. Related: Q-0117 (Hermes review-merge gate), Q-0123/Q-0127 (auto-merge-enabler arm
 rules), Q-0114 (`do-not-automerge` carve-out), Q-0133 (born-red gate).
+
+---
+
+### Q-0177 — Repo-structure improvement: governance + supply-chain + CI baseline (2026-06-19)
+
+> **DECISION 2026-06-19 (owner-directed in-session, applied directly).** The owner uploaded three
+> external repo reviews and asked for a comprehensive plan to improve the repo structure. The agent
+> cross-checked every recommendation against live source (the reviews are *input to verify*, not
+> orders) and the owner chose, via in-session `AskUserQuestion`: **LICENSE = MIT** and scope = **plan
+> + docs + CI config**. Recorded here per CLAUDE.md Q-0106 because part of it touches **executable
+> config** (`.github/` workflows + `dependabot.yml`) — applied under the in-session exception (the
+> owner is the live reviewer). The rest is docs (free rein), batched here for provenance. Full plan +
+> verification table: [`docs/planning/repo-structure-improvement-plan-2026-06-19.md`](../planning/repo-structure-improvement-plan-2026-06-19.md).
+
+**What shipped (this session's PR):**
+
+- **Governance foundation** (root): `LICENSE` (MIT, holder "Menno van Hattum"), `SECURITY.md`,
+  `CONTRIBUTING.md`, `CITATION.cff`.
+- **Supply-chain / CI** (executable config — the Q-0106 exception): `.github/dependabot.yml` (weekly
+  pip for root + `dashboard/` + github-actions), `.github/workflows/codeql.yml` (Python SAST,
+  non-blocking), `.github/workflows/dashboard-ci.yml` (runs the previously-`importorskip`-skipped
+  `tests/unit/dashboard/` + `mypy dashboard/`), `.github/ISSUE_TEMPLATE/` + `.github/PULL_REQUEST_TEMPLATE.md`.
+- **Bug root-fixed while wiring dashboard CI:** a fresh install resolved `httpx 0.28`, which persists
+  per-request cookies into the shared `TestClient` and broke 2 dashboard tests; made the fixture
+  function-scoped (`tests/unit/dashboard/test_app.py`) → 65 pass. A live demonstration of the
+  dependency-pin gap below.
+
+**Routed for the owner (decisions, no rush):**
+
+1. **Dependency-lock strategy** — runtime deps are version *ranges*; fresh installs drift (the
+   `httpx 0.28` break is the worked example). Options: (a) `pip-tools` compiled lockfiles for bot +
+   dashboard; (b) tighten ranges to known-good ceilings; (c) keep ranges + rely on Dependabot + the
+   new dashboard CI. *Agent rec:* (a) for the dashboard first. Ships as its own 2-PR plan once chosen.
+2. **Control-API hardening depth/timing** — request signing (HMAC + timestamp), idempotency keys,
+   token rotation. Owner-paced (control-API writes are the "don't rush" zone); sequence behind the
+   dashboard live-editor write lane.
+3. **Pointer README (Q-0151b reprise)** — owner already said "optional, not built now." Offer stands;
+   a ready 5-line pointer (→ `docs/AGENT_ORIENTATION.md` + `docs/current-state.md`) can ship the moment
+   the owner wants a public landing page.
+4. **Roadmap → labeled-issue mirror?** — the reviews push GitHub Issues/Projects for planning; the
+   repo deliberately keeps planning in `docs/` + the dashboard. *Agent rec:* do NOT adopt Projects
+   wholesale; an optional lightweight roadmap→labeled-issue mirror only if public visibility is wanted.
+
+**Owner manual steps (repo Settings / off-repo — cannot be done from a PR):**
+
+- Enable **Dependabot alerts + security updates** (Settings → Code security).
+- Enable **private vulnerability reporting** (Settings → Code security) so `SECURITY.md` route 1 works.
+- Optionally add **`codeql`** + **`dashboard-ci`** to **branch protection / required checks**.
+- Confirm the **MIT copyright holder** name in `LICENSE`.
+
+**Home:** the [plan](../planning/repo-structure-improvement-plan-2026-06-19.md) + this Q-block. Related:
+Q-0151 (architecture-atlas review — no reorg; root-README posture), Q-0106 (executable-config exception),
+Q-0105 (disposable-tooling discipline), gap-analysis §6 (toolchain-rot watch — closed by Dependabot).

--- a/docs/planning/repo-structure-improvement-plan-2026-06-19.md
+++ b/docs/planning/repo-structure-improvement-plan-2026-06-19.md
@@ -1,0 +1,140 @@
+# Repo-structure improvement plan — governance, supply-chain & operations baseline
+
+> **Status:** `plan` — prioritized improvement program derived from three owner-uploaded
+> external reviews, **cross-checked against live source** (2026-06-19). **Not blanket
+> implementation approval.** Source code and merged PRs win over this doc. Owner decisions
+> for this plan are recorded as **Q-0177** in
+> [`docs/owner/maintainer-question-router.md`](../owner/maintainer-question-router.md).
+
+## What this is
+
+The owner uploaded three external repo reviews — two Dutch research passes (one with no repo
+access, one with live access) and a Markdown review reconciling them — and asked for **a
+comprehensive plan to improve the repo structure**. Per `.claude/CLAUDE.md`, an external review
+is *input to verify against shipped source, never an order*. Every recommendation below was
+checked against live source before being kept, reframed, or dropped.
+
+### Headline verdict
+
+The reviews' **direction is correct on one axis and already-settled on another**:
+
+- **Code/directory structure** — the reviews (especially the earlier *architecture-atlas*
+  review) already drove a decision: **keep the modular monolith; do not reorganize the tree.**
+  `src/` layout, feature-package migration, and a big reorg were all evaluated and **rejected**
+  (the answer is "a better lens — generated facts/drift checks — not a reorg"). See
+  [`docs/ideas/architecture-atlas-and-structure-review-2026-06-16.md`](../ideas/architecture-atlas-and-structure-review-2026-06-16.md)
+  and Q-0151. **This plan does not touch the directory layout.**
+- **Outward-facing governance / supply-chain / operations** — this is the **genuine gap** and
+  the subject of this plan. The repo is exceptionally strong on *internal* docs/planning
+  machinery (roadmap, ideas backlog, current-state ledger, reconciliation passes, production
+  readiness maps) but thin on the *external* OSS-hygiene + supply-chain + CI-parity layer.
+
+The reviews also recommend a few things the repo **deliberately decided against** (a mandatory
+root README; moving planning into GitHub Issues/Projects). Those are reframed below, not adopted
+blindly — the repo's deliberate posture (docs-first; the developer dashboard as the planning
+surface) is the verified ground truth.
+
+## Verification table — every recommendation vs. live source
+
+| Review recommendation | Live finding (2026-06-19) | Verdict |
+|---|---|---|
+| Add a `LICENSE` | **Absent.** Repo is "all rights reserved" — no legal reuse. | **Genuine gap → SHIPPED this session** (MIT, owner Q-0177). |
+| Add `SECURITY.md` | **Absent.** Bot has a token-gated control API + secrets; no disclosure path. | **Genuine gap → SHIPPED.** |
+| Add `CONTRIBUTING.md` | **Absent.** Agent-first repo with no human on-ramp. | **Genuine gap → SHIPPED** (bridges humans into the agent workflow). |
+| Add `CITATION.cff` | **Absent.** | Minor gap → **SHIPPED** (trivial, owner picked full scope). |
+| Add a root `README` | **Intentionally absent** (`repo-navigation-map.md`: "docs/ is the documentation surface"); owner Q-0151b = *optional 5-line pointer, not built now*. | **Deliberately decided → routed, not forced** (ready 5-line pointer in Q-0177 for owner's call). |
+| Enable Dependabot | **No `.github/dependabot.yml`.** Runtime deps are version *ranges*; no freshness watch. | **Genuine gap → SHIPPED** (also closes gap-analysis §6 toolchain-rot-watch). |
+| Enable CodeQL / code scanning | **No SAST workflow.** | **Genuine gap → SHIPPED** (`codeql.yml`, non-blocking). |
+| Pin runtime deps / lockfile | **Confirmed:** `requirements.txt` + `dashboard/requirements.txt` use ranges; only `requirements-dev.txt` is pinned. **Live proof:** a fresh dashboard install resolved `httpx 0.28` and broke 2 tests this session (see below). | **Genuine gap → ROUTED** (strategy decision, Q-0177). |
+| Run dashboard tests in CI | **Confirmed:** `code-quality.yml` installs only the bot's `requirements.txt`, so `tests/unit/dashboard/` `importorskip` and **skip**; dashboard is never type-checked. | **Genuine gap → SHIPPED** (`dashboard-ci.yml`). |
+| Issue forms + PR template | **Absent** (`.github/` had only `workflows/`). | **Gap → SHIPPED** (config keeps planning in docs by design). |
+| Mirror planning into GitHub Issues/Projects | **Deliberate:** planning lives in `docs/` + the developer dashboard (the chosen surface; a public bug form + GitHub-issue mirror are already planned). | **Reframed → do NOT adopt GitHub Projects naively.** Optional lightweight roadmap→labeled-issue mirror only (P3). |
+| Harden the control API (HMAC, idempotency, token rotation) | Real defense-in-depth exists (dormant-by-default, bearer token, rate limiter, bot re-resolves authority); the named hardening is **not yet a dedicated plan**. | **Genuine gap → ROUTED** (owner-paced; control-API writes are the owner's "don't rush" zone). |
+| Test backup/restore | **Backup *integrity* check shipped** (`backup-db.yml` CREATE TABLE-count gate, idea `backup-integrity-check-2026-06-13`). A *restore drill* is **not** done. | **Partially shipped → restore-drill ROUTED** (P2). |
+| Declarative `INITIAL_EXTENSIONS` registry | The 43 extensions are **already classified** (extension-taxonomy crosswalk, PR #958, CI-guarded). A phase/dependency *load* registry is a further step. | **Mostly addressed → narrow follow-up** (P3, low priority). |
+| Reorganize the tree / `src/` layout / feature packages | **Already evaluated and rejected** (Q-0151; modular monolith kept). | **Endorse the rejection — no action.** |
+| Add `CHANGELOG.md` / SemVer releases | The living `current-state.md` ledger + reconciliation passes serve as the change record; the bot is **continuously deployed** (merge→Railway), so SemVer releases are low-value. | **Reframed → not adopted** (note in plan; revisit only if the substrate-kit is published as a package). |
+
+## Shipped this session (PR for branch `claude/focused-goldberg-mviel4`)
+
+**Governance foundation** (root, free-rein docs + owner-greenlit): `LICENSE` (MIT), `SECURITY.md`,
+`CONTRIBUTING.md`, `CITATION.cff`.
+
+**Supply-chain / CI** (`.github/`, owner-greenlit in-session under the Q-0106 exception, Q-0177):
+- `.github/dependabot.yml` — weekly pip (root + `dashboard/`) + github-actions version updates.
+- `.github/workflows/codeql.yml` — Python SAST, weekly + on PR, non-blocking.
+- `.github/workflows/dashboard-ci.yml` — installs both dep sets, runs `tests/unit/dashboard/`
+  (previously skipped) + `mypy dashboard/` (previously unchecked).
+- `.github/ISSUE_TEMPLATE/` (bug + feature forms + chooser config) + `.github/PULL_REQUEST_TEMPLATE.md`.
+
+**Root-fixed bug surfaced while wiring dashboard CI** (a live demonstration of the dependency-pin
+gap): on a fresh install the dashboard suite was **63 pass / 2 fail**. `httpx>=0.28` now *persists*
+per-request `cookies=` into the shared module-scoped `TestClient`, so an earlier login test's cookie
+leaked into the later "requires-login" assertions (→ 200 instead of a redirect). Fixed by making the
+`client` fixture function-scoped (`tests/unit/dashboard/test_app.py`) → **65 pass**, `mypy dashboard/`
+clean. This is exactly the class the dashboard CI job now guards against.
+
+## Prioritized backlog (the work beyond this session)
+
+Batched into the repo's 2–3-PR plan convention. Impact/effort are relative; "route" names the gate.
+
+### P0 — governance & legal (highest leverage, lowest risk) — ✅ done this session
+LICENSE / SECURITY / CONTRIBUTING / CITATION. *Owner manual follow-ups* (repo Settings, can't be done
+from a PR): enable **GitHub private vulnerability reporting**; confirm the MIT copyright holder name.
+
+### P1 — supply-chain & CI parity — mostly done this session; two follow-ups
+1. **Dependency reproducibility (ROUTED, Q-0177).** Adopt a constraints/lock strategy so fresh
+   installs don't drift (the `httpx 0.28` break is the worked example). Options in Q-0177:
+   (a) `pip-tools` compiled `requirements.lock` for bot + dashboard; (b) tighten the existing ranges
+   to known-good ceilings; (c) keep ranges + rely on Dependabot + the new dashboard CI as the
+   early-warning net. *Recommendation:* (a) for the dashboard first (it deploys separately and just
+   broke), then the bot. **2-PR plan** once the option is chosen.
+2. **Make the new checks *required* + enable Dependabot security updates (owner manual step).**
+   `codeql` and `dashboard-ci` are non-blocking until the owner adds them to branch protection;
+   Dependabot *alerts + security updates* are a repo-Settings toggle. Listed in Q-0177.
+
+### P2 — operational hardening (owner-paced)
+1. **Control-API hardening (ROUTED, Q-0177)** — request signing (HMAC + timestamp), idempotency keys
+   on writes, token rotation. Sequence behind the dashboard live-editor write lane (same owner "don't
+   rush" zone). **1–2 PR plan** when greenlit.
+2. **Backup *restore* drill** — extend `backup-db.yml` (integrity check already shipped) with a
+   scheduled restore-into-throwaway-Postgres verification + a recovery runbook. Builds on idea
+   `backup-integrity-check-2026-06-13`. **1 PR.**
+3. **SHA-pin third-party Actions** — current convention is major-tag pins; SHA-pinning is the
+   supply-chain hardening the reviews flag. Pairs naturally with Dependabot (which can bump SHAs).
+
+### P3 — polish / optional
+1. **Optional 5-line pointer README** (Q-0151b) — owner pre-blessed as optional; ready text in Q-0177.
+2. **Lightweight roadmap→labeled-issue mirror** — *only if* the owner wants public visibility; the
+   dashboard remains the primary planning surface (do not adopt GitHub Projects wholesale).
+3. **Declarative extension load registry** — phase/dependency metadata for `INITIAL_EXTENSIONS` on top
+   of the existing taxonomy crosswalk (low priority; ordering works today).
+4. **Contributor-doc freshness guard** — see the session idea
+   [`docs/ideas/governance-files-presence-guard-2026-06-19.md`](../ideas/governance-files-presence-guard-2026-06-19.md).
+
+## Routed owner decisions & manual steps (Q-0177)
+
+**Decisions** (in the router): dependency-lock strategy (P1.1); control-API hardening depth/timing
+(P2.1); pointer-README go/no-go (P3.1); whether to mirror the roadmap to labeled issues (P3.2).
+
+**Owner manual steps** (off-repo / repo-Settings — cannot be done from a PR):
+1. Enable **Dependabot alerts + security updates** (Settings → Code security).
+2. Enable **private vulnerability reporting** (Settings → Code security) so `SECURITY.md` route 1 works.
+3. Optionally add **`codeql`** and **`dashboard-ci`** to **branch protection / required checks**.
+4. Confirm the **MIT copyright holder** name in `LICENSE` (currently "Menno van Hattum").
+
+## Sector placement & metrics
+
+Homed under roadmap **S5 — Operations / control-plane** (with a governance facet) — see
+[`docs/roadmap.md`](../roadmap.md). Acceptance for the program: a fresh clone has an unambiguous
+license + disclosure path; dependency updates and SAST findings surface automatically; dashboard
+tests + types are enforced; and dependency installs are reproducible. This session clears the first
+three; reproducibility is the routed P1 follow-up.
+
+## Builds on (existing captures — not duplicated)
+
+[`architecture-atlas-and-structure-review-2026-06-16`](../ideas/architecture-atlas-and-structure-review-2026-06-16.md)
+(no-reorg decision) · [`hardening-roadmap-2026-06-12`](production-readiness/hardening-roadmap-2026-06-12.md)
+(production-risk backlog) · [`gap-analysis-2026-06-11`](../ideas/gap-analysis-2026-06-11.md) (toolchain-rot
+watch, data export/erasure) · [`repo-manageability-2026-06-12`](../ideas/repo-manageability-2026-06-12.md)
+· `backup-integrity-check-2026-06-13`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -626,6 +626,13 @@ secrets set? is Hermes up? **Every recent silent failure lived here.** Entry:
 [autonomous routines + control-plane state ledger](operations/autonomous-routines.md). *The "forgotten
 sector" (Q-0137); under-planned before — populated here.*
 
+- **Now (governance/supply-chain baseline, Q-0177)** — the
+  [repo-structure improvement plan](planning/repo-structure-improvement-plan-2026-06-19.md) shipped the
+  outward-facing layer the repo lacked: `LICENSE` (MIT) · `SECURITY.md` · `CONTRIBUTING.md` ·
+  `CITATION.cff` · `.github/dependabot.yml` · CodeQL · a **dashboard-CI** job (the dashboard tests were
+  silently `importorskip`-skipped) · issue/PR templates. **Routed next:** dependency-lock strategy ·
+  control-API hardening (HMAC/idempotency/rotation) · making CodeQL/dashboard-CI required + enabling
+  Dependabot alerts (owner repo-Settings steps).
 - **Now** — the read-only **Railway log-triage skill** (Railway access verified live #840 — the
   reserved decade-queue slot; look-but-don't-touch ops graduation) · **verify the daily backup cron
   end-to-end** (the next scheduled `backup-db.yml` run confirms the cron path after the #862

--- a/tests/unit/dashboard/test_app.py
+++ b/tests/unit/dashboard/test_app.py
@@ -54,8 +54,15 @@ def app_module():
     return module
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def client(app_module):
+    # Function-scoped so every test starts with a clean cookie jar. httpx >=0.28
+    # persists per-request ``cookies=`` into the client's jar (older httpx treated
+    # them as ephemeral); a module-scoped client therefore leaked an earlier test's
+    # login cookie into the later "requires login" assertions, which then saw a
+    # logged-in session and returned 200 instead of the expected /admin redirect.
+    # The expensive step (importing the app) stays module-scoped via ``app_module``;
+    # constructing a TestClient around it is cheap.
     return TestClient(app_module.app)
 
 


### PR DESCRIPTION
## What

Owner uploaded three external repo-review reports (two Dutch research passes + a Markdown review reconciling them) and asked for **a comprehensive plan to improve the repo structure**. Every recommendation was cross-checked against live source + recorded owner decisions — the reports are *input to verify*, never orders. A prior structure review already settled the code-layout question (**no filesystem reorg**, Q-0151), so the genuine remaining gap is the **outward-facing governance / supply-chain / operational** layer.

Owner chose in-session: **LICENSE = MIT** + scope = **plan + docs + CI config** (greenlighting the `.github/` executable-config changes — the CLAUDE.md Q-0106 in-session exception; provenance **Q-0177**).

## Ships

**The plan** — `docs/planning/repo-structure-improvement-plan-2026-06-19.md`: a verification table (each report claim → live finding → *already-shipped* / *deliberately-decided* / *genuine-gap*), a prioritized P0–P3 backlog batched into the repo's 2–3-PR convention, routed owner decisions, and the S5 roadmap slot.

**Executed governance foundation** (free-rein docs + owner-greenlit):
- `LICENSE` (MIT) · `SECURITY.md` (vuln disclosure, accurate to the dormant token-gated control API) · `CONTRIBUTING.md` (human bridge into the agent-first workflow) · `CITATION.cff`

**Executed supply-chain / CI config** (owner-greenlit in-session):
- `.github/dependabot.yml` — weekly pip (root + `dashboard/`) + github-actions updates (also closes the gap-analysis §6 *toolchain-rot-watch* concern)
- `.github/workflows/codeql.yml` — Python SAST (non-blocking, weekly + PR)
- `.github/workflows/dashboard-ci.yml` — runs the dashboard tests (currently `importorskip`-skipped in the bot CI) + `mypy dashboard/`
- `.github/ISSUE_TEMPLATE/` (bug + feature forms + config) + `PULL_REQUEST_TEMPLATE.md`

**Root-fixed bug surfaced while wiring dashboard CI:** the dashboard suite was 63 pass / **2 fail** on a fresh install — `httpx>=0.28` now persists per-request `cookies=` into the shared module-scoped `TestClient`, leaking a login cookie into later "requires-login" assertions. Made the `client` fixture function-scoped → **65 pass**, `mypy dashboard/` clean. (A live demonstration of the unpinned-dependency risk the plan flags.)

## Routed for the owner (Q-0177)
Dependency lockfile strategy · control-API hardening depth (HMAC/idempotency/rotation) · optional 5-line pointer README (Q-0151b) · making CodeQL/dashboard-CI *required* checks + enabling Dependabot alerts/security-updates + private vuln reporting (repo-settings steps only the owner can take).

## Test
`python3.10 scripts/check_quality.py --full` green · `check_architecture.py --mode strict` exit 0 · `check_docs.py --strict` green · dashboard suite 65 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnTrJgVEeUgEpLXhZMvWus

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnTrJgVEeUgEpLXhZMvWus)_