### PR TITLE
docs: ultracode fleet brief — parallel multi-agent build plan

### DIFF
--- a/.sessions/2026-06-19-ultracode-fleet-brief.md
+++ b/.sessions/2026-06-19-ultracode-fleet-brief.md
@@ -1,0 +1,15 @@
+# 2026-06-19 — Ultracode fleet brief
+
+> **Status:** `in-progress`
+
+## Arc (what I'm about to do)
+
+Follow-on to the governance/supply-chain session (PR #1064). The owner is about to run Claude's
+desktop **ultracode** (parallel multi-agent) mode and asked for the most valuable thing to do with it
++ a coordination brief. I fanned out three read-only scout agents (architecture boundary-debt · ungated
+hardening/bugs · buildable idea backlog) and synthesized a **file-disjoint fleet plan**: Lane A = 8
+architecture boundary-debt burndown units (verified live, 76 warns/0 errors), Lane B = 8 ungated
+tooling/ops/docs quick-wins. Shipping the brief as `docs/planning/ultracode-fleet-plan-2026-06-19.md`
+so each desktop agent reads it and claims one disjoint unit.
+
+_(Enders finalized in the closing commit when this flips to `complete`.)_

--- a/.sessions/2026-06-19-ultracode-fleet-brief.md
+++ b/.sessions/2026-06-19-ultracode-fleet-brief.md
@@ -1,15 +1,83 @@
 # 2026-06-19 — Ultracode fleet brief
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-## Arc (what I'm about to do)
+## Arc
 
-Follow-on to the governance/supply-chain session (PR #1064). The owner is about to run Claude's
-desktop **ultracode** (parallel multi-agent) mode and asked for the most valuable thing to do with it
-+ a coordination brief. I fanned out three read-only scout agents (architecture boundary-debt · ungated
-hardening/bugs · buildable idea backlog) and synthesized a **file-disjoint fleet plan**: Lane A = 8
-architecture boundary-debt burndown units (verified live, 76 warns/0 errors), Lane B = 8 ungated
-tooling/ops/docs quick-wins. Shipping the brief as `docs/planning/ultracode-fleet-plan-2026-06-19.md`
-so each desktop agent reads it and claims one disjoint unit.
+Follow-on to the governance/supply-chain session (PR #1064). The owner is about to run Claude's desktop
+**ultracode** (parallel multi-agent) mode and asked for the most valuable thing to do with it + a
+coordination brief. I fanned out three read-only scout agents (architecture boundary-debt · ungated
+hardening/bugs · buildable idea backlog) and synthesized a **file-disjoint fleet plan**.
 
-_(Enders finalized in the closing commit when this flips to `complete`.)_
+## Shipped (PR #1079)
+
+- `docs/planning/ultracode-fleet-plan-2026-06-19.md` — **Lane A** = 8 architecture boundary-debt
+  burndown units (verified live, 76 warns / 0 errors; clears ~48), **Lane B** = 8 ungated tooling/ops/docs
+  quick-wins (file-disjoint from Lane A, run concurrently), + rules of engagement, the held/do-not-fleet
+  list, and a paste-ready kickoff prompt.
+- Reachability pointer added in the repo-structure plan. `check_docs --strict` green.
+
+## Method note
+
+The recommendation itself was produced *via* multi-agent orchestration — 3 parallel `general-purpose`
+scouts (sonnet) scoping the three candidate lanes against live source — so the brief is grounded, not
+guessed. That doubled as a small live demo of the fan-out pattern the brief prescribes.
+
+## Context delta
+
+- **Discovered by hand:** the **shared-ledger collision** a parallel fleet hits — the repo's per-session
+  `.sessions/` files solve card collisions, but `docs/owner/active-work.md` and `docs/current-state.md`
+  are single shared files that 16 simultaneous agents *would* conflict on. The brief's "the brief IS the
+  claim ledger; agents don't each edit the shared ledgers" rule is the mitigation. → captured as the idea.
+- **Pointed to and needed:** scout A's `check_architecture --mode strict` verification — it corrected the
+  arch-debt counts to live (76/0) rather than trusting the 2-week-old architecture-atlas figures.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous session = #1064 (governance/supply-chain baseline, this conversation). **Did well:** caught a
+real latent bug (the `httpx 0.28` dashboard cookie-jar drift) *because* it actually ran a fresh install
+while wiring the new CI — verification surfaced the defect, not luck. **Could improve:** it modernized
+the test fixture but left the per-request-cookie deprecation warnings (a fuller test modernization was
+deferred). **System improvement:** that the drift was invisible until a fresh install argues the routed
+dependency-lockfile (Q-0177 P1.1) is the highest-value follow-up — the dashboard-CI job now catches the
+*class*, but a lockfile prevents it.
+
+## 💡 Session idea (Q-0089)
+
+**A collision-safe claim mechanism for parallel fleets.** `.sessions/` per-file design solved card
+collisions, but `active-work.md` / `current-state.md` remain single shared files — a real bottleneck the
+moment >2 agents run. Idea: per-agent claim *files* (`docs/owner/claims/<branch>.md`, append-free) that a
+small script aggregates into a rendered view, so a fleet claims without conflicting. Distinct from the
+existing ledger-dedup-linter idea (that *detects* dup claims; this *prevents* the merge conflict). Worth
+a capture file if the fleet pattern recurs; noted here for now.
+
+## 📊 Doc audit (Q-0104)
+
+- Fleet brief in `docs/planning/` ✓ (badge `plan`, reachable via the repo-structure plan pointer),
+  session card ✓, claim updated in `active-work.md` ✓. `check_docs --strict` green.
+- No new owner decisions, no router entry (the brief is execution guidance, not a decision).
+- Ledger lag (newest-merge, marker #1050) unchanged — deferred to the #1080 reconciliation pass per the
+  standing decision; not this session's drift.
+
+## 📤 Run report
+
+- **Did:** shipped a file-disjoint fleet coordination brief for the owner's ultracode run, produced via 3
+  parallel scout agents. · **Outcome:** shipped
+- **Shipped:** #1079 — `docs/planning/ultracode-fleet-plan-2026-06-19.md` + repo-structure pointer.
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** `none` (lane selection is the owner's at run time).
+- **⚑ Owner manual steps:** run the fleet on **desktop ultracode** by pasting the brief's kickoff prompt
+  (off-repo owner action).
+- **⚑ Self-initiated:** `none` (owner-requested brief; the 3 scout agents were the method, not unprompted builds).
+- **↪ Next:** owner runs the fleet; the held `core/runtime → services` serial PR follows after Lane A lands.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (#1079, auto-merge on green) |
+| Scout agents orchestrated | 3 (parallel, read-only) |
+| CI-red rounds | 1 (born-red gate by design) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (collision-safe fleet claim mechanism) |
+| Ideas groomed | ~16 ungated ideas/plans operationalized into buildable fleet units |

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,11 +25,10 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/focused-goldberg-mviel4` · **repo structure: governance + supply-chain + CI baseline**
-  (owner-directed from 3 uploaded reports; LICENSE=MIT + full scope, Q-0177) — comprehensive plan +
-  LICENSE/SECURITY.md/CONTRIBUTING.md/CITATION.cff + `.github/dependabot.yml` + CodeQL + dashboard-CI
-  job + issue/PR templates + dashboard test-isolation fix · `docs/planning/` · `.github/` ·
-  `dashboard` tests · 2026-06-19
+- `claude/focused-goldberg-mviel4` · **ultracode fleet brief** (owner-directed) — coordination doc for a
+  parallel multi-agent run: 8 architecture boundary-debt units + 8 ungated tooling/ops quick-wins, all
+  file-disjoint · `docs/planning/ultracode-fleet-plan-2026-06-19.md` · 2026-06-19
+  · _(prior #1064 governance/supply-chain baseline merged)_
 - `claude/magical-rubin-jnpnuw` · **dashboard.json structural-drift reporter** + freshness catch-up
   (executes the #1020 💡 idea + finding) · `scripts/check_dashboard_data.py` ·
   `dashboard/data/dashboard.json` · tests · 2026-06-17 · **auto-merge on green**

--- a/docs/planning/repo-structure-improvement-plan-2026-06-19.md
+++ b/docs/planning/repo-structure-improvement-plan-2026-06-19.md
@@ -76,6 +76,10 @@ clean. This is exactly the class the dashboard CI job now guards against.
 
 ## Prioritized backlog (the work beyond this session)
 
+> **Operationalized for parallel execution:** the file-disjoint, fleet-ready partition of this backlog
+> (plus the architecture boundary-debt burndown) is `docs/planning/ultracode-fleet-plan-2026-06-19.md`
+> — a coordination brief for a multi-agent ("ultracode") run.
+
 Batched into the repo's 2–3-PR plan convention. Impact/effort are relative; "route" names the gate.
 
 ### P0 — governance & legal (highest leverage, lowest risk) — ✅ done this session

--- a/docs/planning/ultracode-fleet-plan-2026-06-19.md
+++ b/docs/planning/ultracode-fleet-plan-2026-06-19.md
@@ -1,0 +1,97 @@
+# Ultracode fleet brief — parallel build run (2026-06-19)
+
+> **Status:** `plan` — coordination brief for a multi-agent ("ultracode") **parallel** build run.
+> Not new product scope: it operationalizes already-scoped, **ungated** work into **file-disjoint**
+> units a fleet of agents can build at once. Source code + merged PRs win over this doc. Companion to
+> [`repo-structure-improvement-plan-2026-06-19.md`](repo-structure-improvement-plan-2026-06-19.md);
+> the architecture units are verified live via `scripts/check_architecture.py --mode strict`
+> (76 warnings, 0 errors at write time).
+
+## Why this exists
+
+Ultracode's edge is **breadth** — many agents on independent units at once. That only pays off if the
+units don't collide. This brief pre-partitions ~16 ungated units into **disjoint file sets** so a fleet
+runs with near-zero coordination, and every unit is correctness-gated by CI before it can land. Pick a
+subset or run the whole thing.
+
+**The collision rule that matters most:** two agents must never edit the same file. The roster below is
+built so they don't. **Agents must NOT each edit the shared ledgers** (`docs/current-state.md`,
+`docs/owner/active-work.md`) — 16 simultaneous appends would conflict. This brief *is* the claim ledger;
+the reconciliation pass folds the merged PRs into `current-state.md` afterward.
+
+## Lane A — architecture boundary-debt burndown (8 disjoint units)
+
+Burns down the layer-boundary debt the structure review flagged. All `disbot/` runtime refactors —
+each PR must pass `scripts/check_architecture.py --mode strict` **and** the full test suite. Clears ~48
+of 76 warnings.
+
+| Unit | Files (the agent's exclusive set) | What | Risk |
+|---|---|---|---|
+| A1 | `cogs/economy/_helpers.py`, `cogs/xp/_helpers.py`, `cogs/economy_cog.py`, `cogs/xp_cog.py`, `views/economy/`, `views/xp/` + new `services/economy_helpers.py`, `services/xp_helpers.py` | Move the two `_helpers` out of cogs into `services/`; fix view imports | Low |
+| A2 | `cogs/moderation/_helpers.py`, `cogs/moderation_cog.py`, `views/moderation/modals.py` + new `services/moderation_helpers.py` | Move moderation `_helpers` → `services/` | Low |
+| A3 | `cogs/blackjack/_state.py`, `_persistence.py`, `actions.py`, `views/blackjack/`, `views/games/blackjack_panel.py` + new `services/blackjack_state.py`, `services/blackjack_persistence.py` | Move blackjack state/persistence → `services/` (resolve the intra-cog `actions`↔`_state` cycle) | Med |
+| A4 ⚠ | `cogs/diagnostic/_platform_embeds.py` (2,280 lines), `cogs/diagnostic/_helpers.py`, `views/diagnostic/` + new `services/diagnostic_embeds.py`, `services/diagnostic_helpers.py` | Move the big embed module → `services/`. **Grep ALL callers incl. lazy/function-body imports first** | Med (large) |
+| A5 ⚠ | `cogs/deathmatch/actions.py`, `cogs/deathmatch_cog.py`, `views/games/deathmatch_panel.py` | Untangle the `actions`↔`deathmatch_cog` **circular import**, then lift the shared UI types out of the cog | Med (cycle) |
+| A6 | `governance/__init__.py`, `cache.py`, `cleanup.py`, `execution.py`, `resolver.py`, `writes.py` + new `utils/governance_exceptions.py` | Move governance exception types → `utils/` so the layer stops importing `services` | Med |
+| A7 | `services/game_state_service.py`, `services/platform_consistency.py` + `utils/db/` (extend) | Wrap the raw `pool.execute()`/`conn.execute()` calls (13 of 18 raw-SQL warns) in `utils/db/` functions | Low |
+| A8 | `views/btd6/admin_panel.py`, `views/btd6/strategy_review.py`, `views/channels/list_panel.py`, `views/settings/edit_channel.py`, `edit_number_presets.py`, `edit_role.py`, `views/setup/launcher.py`, `views/xp/rank_view.py` | Each: extend `BaseView`/`HubView` if lifecycle fits, else add a one-line justification comment | Low |
+
+> **A4 and A5 are the only ones needing care** (huge file / circular import). Run them last, or give
+> those agents an explicit "map every caller — including lazy imports — before moving anything" step.
+
+## Lane B — ungated tooling / ops / docs quick-wins (8 disjoint units)
+
+File-disjoint from Lane A (these live in `scripts/`, `.github/`, `dashboard/`, `.claude/skills/`), so
+Lane B can run **concurrently with Lane A**. Each is a small, low-risk, no-owner-decision unit.
+
+| Unit | Files | What |
+|---|---|---|
+| B1 | `scripts/check_governance_files.py` + test | Presence + path-freshness guard for the new root files ([idea](../ideas/governance-files-presence-guard-2026-06-19.md)) |
+| B2 | `scripts/check_ledger_hygiene.py` + test | Duplicate claim / idea-link detector ([idea](../ideas/ledger-dedup-linter-2026-06-16.md)) |
+| B3 | `scripts/check_routine_permission_surface.py` + test | Fail if a routine command resolves to `ask` ([idea](../ideas/routine-permission-surface-lint-2026-06-16.md)) |
+| B4 | `scripts/check_plan_backlog.py` + test | Automate the PLAN-BACKLOG-THIN flag (Q-0164) |
+| B5 | `scripts/check_autospec_fidelity.py` + test | New AST guard flagging un-`spec`'d mock setattr ([idea](../ideas/autospec-mock-fidelity-guard-2026-06-16.md)) — **new script only, do not refactor existing tests** |
+| B6 | `.github/workflows/*.yml` | SHA-pin the third-party Actions (pairs with the now-active Dependabot, which bumps the SHAs) |
+| B7 | `dashboard/app.py`, `dashboard/templates/reviews.html` (new), `scripts/export_dashboard_data.py`, `docs/owner/review-inbox.md` (new) | Owner-review-inbox **Phase 1** — read-only `/reviews` page ([plan](owner-review-inbox-plan-2026-06-17.md)) |
+| B8 | `.claude/skills/` (new files only) | Procedures→skills **batches 3–4** — additive skill files only ([plan](procedures-to-skills-conversion-plan-2026-06-17.md)). **Do NOT edit `.claude/CLAUDE.md`** (Q-0106) |
+
+## Rules of engagement (every agent)
+
+1. **Own only your unit's file set.** Never touch a file listed under another unit. Never edit
+   `docs/current-state.md` or `docs/owner/active-work.md` (shared — they collide).
+2. **Born-red session card.** First commit creates `.sessions/<date>-<slug>.md` with
+   `> **Status:** \`in-progress\``; flip to `complete` as the last commit (per-file, so no collision).
+3. **Green before merge.** `python3.10 scripts/check_quality.py --full` **and**
+   `python3.10 scripts/check_architecture.py --mode strict` must pass. CI's `code-quality` is the
+   required check; the PR auto-merges on green.
+4. **Small, single-unit PR.** One unit = one PR. Don't widen scope.
+5. **Flag self-initiated.** On the run-report `⚑ Self-initiated:` line, name the unit (Q-0172).
+6. **A4/A5:** map every caller (including lazy/function-body imports) before moving code.
+
+## Held — do NOT fleet these
+
+- **`core/runtime → services` (arch-fix-11, ~13 runtime files)** — serial; one careful PR, done *after*
+  Lane A lands. Breaking these breaks the whole bot. Same for `utils/db/pool.py` (arch-fix-6).
+- **Consistency-linter graduation** (flipping rules to `error`) — PR #1063 is on the rails; let it settle.
+- **`.claude/CLAUDE.md` / `.claude/settings.json` edits** — owner-live only (Q-0106).
+- **Gated product lanes** — BTD6 floors (exhausted), fishing follow-ons, dashboard *writes* / control-API,
+  anything `needs-hermes-review` or creds-gated.
+
+## Kickoff prompt (paste into ultracode)
+
+> Read `docs/planning/ultracode-fleet-plan-2026-06-19.md`. Launch one agent per unit in the Lane A and
+> Lane B rosters, in parallel. Each agent owns ONLY its unit's listed files and follows the "Rules of
+> engagement" exactly: born-red session card → implement the unit → `python3.10
+> scripts/check_quality.py --full` and `python3.10 scripts/check_architecture.py --mode strict` both
+> green → open one small PR that auto-merges on green → flag it self-initiated. Do NOT touch any file
+> outside your unit, the shared ledgers (`current-state.md`, `active-work.md`), or anything in the
+> "Held" list. Start Lane B and Lane A units A1–A3, A6–A8 immediately; run A4 (diagnostic, huge file)
+> and A5 (deathmatch, circular import) last and tell those agents to map every caller — including lazy
+> imports — before moving code. Report each PR number as it opens.
+
+## Per-agent task template (if assigning manually)
+
+> You are one agent in a parallel fleet. Your unit is **<Unit ID>** from
+> `docs/planning/ultracode-fleet-plan-2026-06-19.md`. Touch ONLY these files: `<file set>`. Do `<what>`.
+> Follow the brief's Rules of engagement (born-red card, both checks green, one small PR, auto-merge on
+> green, flag self-initiated). Do not touch any other file or the shared ledgers.


### PR DESCRIPTION
## What

A coordination brief for a parallel multi-agent ("ultracode") build run — `docs/planning/ultracode-fleet-plan-2026-06-19.md`. Follow-on to #1064; owner-requested.

I fanned out three read-only scout agents (architecture boundary-debt · ungated hardening/bugs · buildable idea backlog) and synthesized their findings into a **file-disjoint fleet plan**:

- **Lane A — architecture boundary-debt burndown:** 8 independent units (verified live via `check_architecture --mode strict`: 76 warnings / 0 errors), clearing ~48 of them. `views→cogs` helper moves, `raw-SQL` wrapping, governance exceptions → `utils/`, BaseView inheritance.
- **Lane B — ungated tooling/ops/docs quick-wins:** 8 independent units (stdlib guards, SHA-pin Actions, owner-review-inbox Phase 1, additive skills) — file-disjoint from Lane A so both lanes run concurrently.

Plus the rules of engagement (the collision-avoidance contract: disjoint files, born-red cards, no shared-ledger edits, CI-green-before-merge), the **held / do-not-fleet** list (core→services, consistency graduation, CLAUDE.md edits, gated product lanes), and a ready-to-paste **kickoff prompt**.

Docs-only.

## Test

`check_docs.py --strict` green. The architecture unit inventory is verified against live `check_architecture.py --mode strict` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnTrJgVEeUgEpLXhZMvWus

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnTrJgVEeUgEpLXhZMvWus)_