### PR TITLE
A1: move economy/xp _helpers → services/

### DIFF
--- a/.sessions/2026-06-19-fleet-a1-economy-xp-helpers.md
+++ b/.sessions/2026-06-19-fleet-a1-economy-xp-helpers.md
@@ -1,0 +1,5 @@
+# 2026-06-19 — Fleet A1: move economy/xp _helpers into services/
+
+> **Status:** `in-progress`
+
+About to: move `cogs/economy/_helpers.py` and `cogs/xp/_helpers.py` into `services/` and rewrite the cog + view imports so `views/` stops importing helpers out of `cogs/`.

--- a/.sessions/2026-06-19-fleet-a1-economy-xp-helpers.md
+++ b/.sessions/2026-06-19-fleet-a1-economy-xp-helpers.md
@@ -1,5 +1,39 @@
-# 2026-06-19 — Fleet A1: move economy/xp _helpers into services/
+# 2026-06-19 — Fleet A1: move economy/xp _helpers from cogs into services/
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-About to: move `cogs/economy/_helpers.py` and `cogs/xp/_helpers.py` into `services/` and rewrite the cog + view imports so `views/` stops importing helpers out of `cogs/`.
+## Arc
+
+Lane A unit **A1** of the [ultracode fleet brief](../docs/planning/ultracode-fleet-plan-2026-06-19.md) —
+architecture boundary-debt burndown (ungated). move economy/xp _helpers from cogs into services/.
+
+## Shipped (#1080)
+
+- `cogs/economy/_helpers.py` → **`services/economy_helpers.py`**, `cogs/xp/_helpers.py` → **`services/xp_helpers.py`** (git renames; old cog modules deleted).
+- Repointed importers: economy_cog, xp_cog, views/economy/{main,shop,work}_panel, views/xp/{config,main}_panel, views/xp/rank_view.
+- **rank_view.py A8 collision resolved here:** kept A1's `services.xp_helpers` import fix and folded in A8's `_RankView` justification comment (A8 drops the file).
+
+Verified: `check_architecture --mode strict` exit 0 · `check_quality --check-only` clean ·
+`pytest --collect-only` 10748 tests import-clean · targeted-domain tests pass.
+
+> Completed by the fleet orchestrator after a mid-run container restart killed the per-unit
+> agent before it flipped its card; the agent's implementation was intact in the worktree.
+
+## 📤 Run report
+
+- **Did:** move economy/xp _helpers from cogs into services/ (fleet A1). · **Outcome:** shipped
+- **Shipped:** #1080
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** `none`
+- **⚑ Self-initiated:** A1 — docs/planning/ultracode-fleet-plan-2026-06-19.md (ungated arch boundary-debt)
+- **↪ Next:** remaining fleet units.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (#1080, on green) |
+| CI-red rounds | 1 (born-red gate by design) |
+| New ideas contributed | 0 (fleet completion run) |
+| Ideas groomed | 0 |

--- a/disbot/cogs/economy_cog.py
+++ b/disbot/cogs/economy_cog.py
@@ -20,7 +20,10 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from cogs.economy._helpers import (
+from core.runtime import panel_manager, resources
+from core.runtime.interaction_helpers import safe_defer, safe_followup
+from services import economy_service
+from services.economy_helpers import (
     _DAILY_COOLDOWN,
     _DAILY_TIERS,
     _WORK_COOLDOWN,
@@ -32,9 +35,6 @@ from cogs.economy._helpers import (
     _pick_daily,
     _shop_embed,
 )
-from core.runtime import panel_manager, resources
-from core.runtime.interaction_helpers import safe_defer, safe_followup
-from services import economy_service
 from utils import db
 from utils.cooldowns import check_cooldown, format_remaining
 from utils.helpers import post_log_embed

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -5,10 +5,10 @@ import logging
 import discord
 from discord.ext import commands
 
-from cogs.xp._helpers import _STAT_TYPES, _build_rank_embed
 from core.runtime.interaction_helpers import help_ctx_shim
 from services import xp_service
 from services.rank_providers import get_provider
+from services.xp_helpers import _STAT_TYPES, _build_rank_embed
 from utils import embeds as em
 from utils.ui_constants import ECONOMY_COLOR
 from views.base import send_panel

--- a/disbot/services/economy_helpers.py
+++ b/disbot/services/economy_helpers.py
@@ -1,9 +1,9 @@
 """Shared economy data + helpers.
 
 Pure-function helpers + lookup tables used by both ``cogs/economy_cog``
-and the views under ``views/economy/``.  Hosted here (rather than in
-the cog) so the views can import them without creating a circular
-dependency back through the cog module.
+and the views under ``views/economy/``.  Hosted in ``services/`` (the
+shared-logic layer) so the views can import them without reaching into
+``cogs/`` — the layer boundary that ``views → cogs`` must not cross.
 """
 
 from __future__ import annotations

--- a/disbot/services/xp_helpers.py
+++ b/disbot/services/xp_helpers.py
@@ -1,10 +1,9 @@
 """Shared XP helpers (S4.2-followup extraction).
 
 These were top-level helpers in ``cogs/xp_cog.py`` consumed by the rank
-command, the rank view, the hub panel, and the config panel.  Lifted
-here per the F-3 convention so they live alongside the listener body
-and are importable by both the cog and ``views/xp/*`` without
-creating a circular import through ``cogs.xp_cog``.
+command, the rank view, the hub panel, and the config panel.  Hosted in
+``services/`` (the shared-logic layer) so they live importable by both
+the cog and ``views/xp/*`` without ``views`` reaching back into ``cogs``.
 
 Public-ish names (no leading underscore in spirit, but kept consistent
 with the historical naming so the diff stays small):

--- a/disbot/views/economy/main_panel.py
+++ b/disbot/views/economy/main_panel.py
@@ -19,7 +19,10 @@ import time
 
 import discord
 
-from cogs.economy._helpers import (
+from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
+from core.runtime.persistent_views import PersistentView, register
+from services import economy_service
+from services.economy_helpers import (
     _DAILY_COOLDOWN,
     _WORK_COOLDOWN,
     JOBS,
@@ -29,9 +32,6 @@ from cogs.economy._helpers import (
     _pick_daily,
     _shop_embed,
 )
-from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
-from core.runtime.persistent_views import PersistentView, register
-from services import economy_service
 from utils import db
 from utils.cooldowns import check_cooldown, format_remaining
 from utils.helpers import post_log_embed

--- a/disbot/views/economy/shop_panel.py
+++ b/disbot/views/economy/shop_panel.py
@@ -15,9 +15,9 @@ from __future__ import annotations
 
 import discord
 
-from cogs.economy._helpers import SHOP_ITEMS, _build_economy_embed
 from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
 from services import shop_purchase_workflow
+from services.economy_helpers import SHOP_ITEMS, _build_economy_embed
 from utils import db
 from utils.helpers import post_log_embed
 from utils.ui_constants import SUCCESS_COLOR, WARNING_COLOR

--- a/disbot/views/economy/work_panel.py
+++ b/disbot/views/economy/work_panel.py
@@ -19,9 +19,14 @@ import time
 
 import discord
 
-from cogs.economy._helpers import _WORK_COOLDOWN, JOBS, _build_economy_embed, _job_pay
 from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
 from services import economy_service, xp_service
+from services.economy_helpers import (
+    _WORK_COOLDOWN,
+    JOBS,
+    _build_economy_embed,
+    _job_pay,
+)
 from utils import db
 from utils.cooldowns import check_cooldown, format_remaining
 from utils.helpers import post_log_embed

--- a/disbot/views/xp/config_panel.py
+++ b/disbot/views/xp/config_panel.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 import discord
 from discord.ext import commands
 
-from cogs.xp._helpers import _guild_xp_settings
 from core.runtime.config_arbitration import get_xp_announce_channel
 from core.runtime.interaction_helpers import safe_edit
+from services.xp_helpers import _guild_xp_settings
 from utils.ui_constants import UTILITY_COLOR
 from views.base import BaseView
 from views.navigation import attach_back_button

--- a/disbot/views/xp/main_panel.py
+++ b/disbot/views/xp/main_panel.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import discord
 from discord.ext import commands
 
-from cogs.xp._helpers import _build_rank_embed
+from services.xp_helpers import _build_rank_embed
 from views.base import HubView
 
 

--- a/disbot/views/xp/rank_view.py
+++ b/disbot/views/xp/rank_view.py
@@ -9,9 +9,13 @@ from __future__ import annotations
 
 import discord
 
-from cogs.xp._helpers import _build_rank_embed
+from services.xp_helpers import _build_rank_embed
 
 
+# Extends discord.ui.View directly (not BaseView): specialized lifecycle —
+# an ephemeral nav wrapper with a bespoke on_timeout that disables the
+# dropdown AND calls self.stop() to release the view, and no invoker lock
+# (the !rank card is shared/read-only), so BaseView's lifecycle is a mismatch.
 class _RankView(discord.ui.View):
     """Navigation dropdown for the rank card — lets users switch stat views."""
 


### PR DESCRIPTION
## Fleet unit A1 — move economy/xp `_helpers` into `services/`

Moves the two cog `_helpers` modules into the `services/` layer so `views/` stops reaching into `cogs/` for shared helpers (clears the `arch-fix-13` known violations for the economy/xp view panels):

- `cogs/economy/_helpers.py` → **`services/economy_helpers.py`**
- `cogs/xp/_helpers.py` → **`services/xp_helpers.py`**

Importing cogs (`economy_cog.py`, `xp_cog.py`) and view files under `views/economy/` and `views/xp/` now import from the new `services.` location. Behavior is identical — this is a move + import-rewrite, not a rewrite.

Both helper modules only depend on `utils.*` (and `services.rank_providers` lazily, in xp), so they are fully `services/`-layer compliant. The old empty `cogs/.../_helpers.py` packages' `_helpers.py` files are deleted. `mock.patch` targets in the test suite (`views.economy.work_panel._job_pay`, `cogs.economy_cog._build_economy_embed`, etc.) keep resolving because the names stay bound on the re-importing modules.

Verified `python3.10 scripts/check_architecture.py --mode strict` shows no NEW violations (net reduction — the economy/xp view→cog known-violation warnings disappear).

Fleet run — docs/planning/ultracode-fleet-plan-2026-06-19.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJsGDUHJ16So4DpCUPsLsm)_