### PR TITLE
B1: governance-files presence guard

### DIFF
--- a/.sessions/2026-06-19-fleet-b1-governance-files-guard.md
+++ b/.sessions/2026-06-19-fleet-b1-governance-files-guard.md
@@ -1,0 +1,5 @@
+# 2026-06-19 — Fleet B1: governance-files presence guard
+
+> **Status:** `in-progress`
+
+About to: add `scripts/check_governance_files.py` + test — presence + path-freshness guard for the new root governance files (LICENSE, SECURITY.md, CONTRIBUTING.md, CITATION.cff).

--- a/.sessions/2026-06-19-fleet-b1-governance-files-guard.md
+++ b/.sessions/2026-06-19-fleet-b1-governance-files-guard.md
@@ -1,5 +1,37 @@
-# 2026-06-19 — Fleet B1: governance-files presence guard
+# 2026-06-19 — Fleet B1: governance-files presence + path-freshness guard
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-About to: add `scripts/check_governance_files.py` + test — presence + path-freshness guard for the new root governance files (LICENSE, SECURITY.md, CONTRIBUTING.md, CITATION.cff).
+## Arc
+
+Lane B unit **B1** of the [ultracode fleet brief](../docs/planning/ultracode-fleet-plan-2026-06-19.md) —
+ungated tooling quick-win. governance-files presence + path-freshness guard.
+
+## Shipped (#1082)
+
+New `scripts/check_governance_files.py` (+15 unit tests) — presence + path-freshness guard for the root governance files. Carries the required provenance/reliability header (unverified; delete-if-unreliable).
+
+Verified: its unit test passes · `check_quality --check-only` clean · the script runs exit 0
+on the current repo · `pytest --collect-only` import-clean.
+
+> Completed by the fleet orchestrator after a mid-run container restart killed the per-unit
+> agent before it flipped its card; the agent's implementation was intact in the worktree.
+
+## 📤 Run report
+
+- **Did:** governance-files presence + path-freshness guard (fleet B1). · **Outcome:** shipped
+- **Shipped:** #1082
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** `none`
+- **⚑ Self-initiated:** B1 — docs/planning/ultracode-fleet-plan-2026-06-19.md (ungated tooling)
+- **↪ Next:** remaining fleet units.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (#1082, on green) |
+| CI-red rounds | 1 (born-red gate by design) |
+| New ideas contributed | 0 (fleet completion run) |
+| Ideas groomed | 0 |

--- a/scripts/check_governance_files.py
+++ b/scripts/check_governance_files.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3.10
+"""Governance-files presence + path-freshness guard for SuperBot's root docs.
+
+Why this exists (provenance + reliability header — Q-0105)
+----------------------------------------------------------
+Added 2026-06-19 from the idea
+``docs/ideas/governance-files-presence-guard-2026-06-19.md`` (Fleet B1). The
+2026-06-19 governance/supply-chain baseline session added the standard
+outward-facing governance files (``LICENSE``, ``SECURITY.md``, ``CONTRIBUTING.md``,
+``CITATION.cff``) and a human contributor on-ramp. They are *prose*, so nothing
+stops a later refactor from silently deleting one, or letting ``CONTRIBUTING.md``'s
+instructions rot — it cites ``scripts/check_quality.py --full``,
+``scripts/setup_dev_env.sh``, and the binding-contract paths; if any of those move,
+the onboarding doc lies and the *first thing a new contributor runs* fails. These
+root files sit **outside** ``check_docs.py``'s ``docs/**`` scope, so its existing
+link/pinned-path resolution never covers them. This guard closes that gap with the
+repo's "executable verification over prose" ethos.
+
+What it checks
+--------------
+  1. **presence** — ``LICENSE``, ``SECURITY.md``, ``CONTRIBUTING.md``,
+     ``CITATION.cff`` all exist at the repo root and are non-empty.
+  2. **freshness** — every concrete repo path cited in backticks inside
+     ``CONTRIBUTING.md`` + ``SECURITY.md`` resolves on disk (the same link
+     resolution ``check_docs`` does for ``docs/**``, applied to these root files).
+  3. **citation** — ``CITATION.cff`` carries the minimal CFF keys
+     (``cff-version``, ``title``, ``authors``) so the citation metadata stays valid.
+
+Pure stdlib (no third-party imports) so CI can run it on every PR — including
+docs-only PRs — without installing anything. Advisory by default (exit 0);
+``--strict`` for an explicit gate (e.g. ``/session-close`` or CI).
+
+Reliability (Q-0105): **unverified** — confirm its output against ground truth a
+few times across sessions before trusting it. **Delete this script if it proves
+unreliable over multiple sessions** (false positives on legitimate path moves, CFF
+false negatives): it is a disposable convenience guard for the governance layer,
+not a load-bearing contract.
+
+Usage:
+    python3.10 scripts/check_governance_files.py            # report (always exit 0)
+    python3.10 scripts/check_governance_files.py --strict   # exit 1 on any violation
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The standard outward-facing governance files this guard protects. Each must
+# exist at the repo root and be non-empty.
+REQUIRED_FILES = ("LICENSE", "SECURITY.md", "CONTRIBUTING.md", "CITATION.cff")
+
+# The prose docs whose backtick path references must stay fresh (resolve on disk).
+# These are *outside* check_docs.py's docs/** scope, so this is the only guard.
+FRESHNESS_DOCS = ("CONTRIBUTING.md", "SECURITY.md")
+
+# Concrete repo path inside backticks, e.g. `docs/foo.md`, `scripts/x.py`,
+# `disbot/control_api.py`. Mirrors check_docs.py's `_PATH_REF_RE` but anchored on
+# the directories the root governance docs actually reference. A trailing-slash
+# directory reference (e.g. `disbot/`) is matched separately below.
+_PATH_REF_RE = re.compile(
+    r"`((?:docs|disbot|tests|scripts|architecture_rules|dashboard|\.claude|\.github)"
+    r"/[\w./-]+\.(?:py|md|sql|ya?ml|txt|sh|json|toml|cfg|ini))`",
+)
+# A directory reference in backticks, e.g. `disbot/`, `scripts/`, `docs/`. Must
+# end in a slash so we don't mistake a bare word for a path.
+_DIR_REF_RE = re.compile(
+    r"`((?:docs|disbot|tests|scripts|architecture_rules|dashboard|\.claude|\.github)"
+    r"/[\w./-]*?/?)`",
+)
+
+# Minimal CFF keys whose absence makes the citation metadata invalid/unusable.
+_REQUIRED_CFF_KEYS = ("cff-version", "title", "authors")
+
+
+def check_presence() -> list[tuple[str, str]]:
+    """Each required governance file must exist at the root and be non-empty."""
+    violations: list[tuple[str, str]] = []
+    for name in REQUIRED_FILES:
+        path = REPO_ROOT / name
+        if not path.exists():
+            violations.append(
+                (name, "missing — required governance file does not exist"),
+            )
+            continue
+        try:
+            if not path.read_text(encoding="utf-8").strip():
+                violations.append(
+                    (name, "empty — required governance file has no content"),
+                )
+        except OSError as exc:  # pragma: no cover - unreadable file is rare
+            violations.append((name, f"unreadable ({exc})"))
+    return violations
+
+
+def _referenced_paths(text: str) -> set[str]:
+    """All concrete file + directory repo-paths cited in backticks in ``text``."""
+    refs: set[str] = set()
+    for ref in _PATH_REF_RE.findall(text):
+        if not any(ch in ref for ch in "<>*"):  # skip placeholders / globs
+            refs.add(ref)
+    for ref in _DIR_REF_RE.findall(text):
+        # Only treat slash-terminated tokens as directory references; a path that
+        # the file regex already matched (ends in a known extension) is skipped.
+        if ref.endswith("/") and not any(ch in ref for ch in "<>*"):
+            refs.add(ref)
+    return refs
+
+
+def check_freshness() -> list[tuple[str, str]]:
+    """Every backtick repo-path in the freshness docs must resolve on disk."""
+    violations: list[tuple[str, str]] = []
+    for name in FRESHNESS_DOCS:
+        path = REPO_ROOT / name
+        if not path.exists():
+            continue  # presence check already reports a missing doc
+        text = path.read_text(encoding="utf-8")
+        for ref in sorted(_referenced_paths(text)):
+            if not (REPO_ROOT / ref).exists():
+                violations.append((name, f"references missing path `{ref}`"))
+    return violations
+
+
+def check_citation() -> list[tuple[str, str]]:
+    """``CITATION.cff`` must carry the minimal CFF keys (no YAML dep — stdlib only)."""
+    violations: list[tuple[str, str]] = []
+    path = REPO_ROOT / "CITATION.cff"
+    if not path.exists():
+        return violations  # presence check already reports it
+    text = path.read_text(encoding="utf-8")
+    # A top-level CFF key starts a line as `key:` (allowing no leading whitespace).
+    present = {
+        m.group(1)
+        for line in text.splitlines()
+        if (m := re.match(r"([A-Za-z][A-Za-z0-9_-]*):", line))
+    }
+    for key in _REQUIRED_CFF_KEYS:
+        if key not in present:
+            violations.append(("CITATION.cff", f"missing required CFF key `{key}`"))
+    return violations
+
+
+def collect_violations() -> list[tuple[str, str]]:
+    """All governance-file violations across presence, freshness, and citation."""
+    return check_presence() + check_freshness() + check_citation()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Governance-files presence + path-freshness guard.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 1 if any governance file is missing/empty or a cited path is stale",
+    )
+    args = parser.parse_args(argv)
+
+    violations = collect_violations()
+    if not violations:
+        files = ", ".join(REQUIRED_FILES)
+        print(
+            f"check_governance_files: all present, cited paths fresh, CFF valid ✓ "
+            f"({files})",
+        )
+        return 0
+
+    print("check_governance_files: governance-file issues found:")
+    for where, problem in violations:
+        print(f"  - {where}: {problem}")
+    print(
+        "\nFix: restore the missing/empty file, or update the stale backtick path so "
+        "the contributor on-ramp does not lie. (Q-0105 unverified guard — delete this "
+        "script if it proves unreliable over multiple sessions.)",
+    )
+    return 1 if args.strict else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_governance_files.py
+++ b/tests/unit/scripts/test_check_governance_files.py
@@ -1,0 +1,184 @@
+"""Tests for ``scripts/check_governance_files.py`` — the Fleet B1 governance guard.
+
+Covers presence (missing / empty file), path-freshness (a stale backtick repo-path
+in a root governance doc), CFF validity (missing required key), the ``--strict``
+exit contract, and that the live repo's governance files actually pass.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_MOD = REPO_ROOT / "scripts" / "check_governance_files.py"
+
+_spec = importlib.util.spec_from_file_location("check_governance_files", _MOD)
+assert _spec and _spec.loader
+cgf = importlib.util.module_from_spec(_spec)
+sys.modules["check_governance_files"] = cgf
+_spec.loader.exec_module(cgf)
+
+
+def _seed_clean_repo(root: Path) -> None:
+    """Write a minimal, fully-valid governance file set into ``root``."""
+    (root / "LICENSE").write_text("MIT License\n\nCopyright (c) 2026\n", encoding="utf-8")
+    (root / "SECURITY.md").write_text(
+        "# Security Policy\n\nReport via `disbot/control_api.py`.\n",
+        encoding="utf-8",
+    )
+    # A referenced path that exists on disk.
+    (root / "disbot").mkdir(exist_ok=True)
+    (root / "disbot" / "control_api.py").write_text("x = 1\n", encoding="utf-8")
+    (root / "CONTRIBUTING.md").write_text(
+        "# Contributing\n\nRun `scripts/check_quality.py`. See `docs/`.\n",
+        encoding="utf-8",
+    )
+    (root / "scripts").mkdir(exist_ok=True)
+    (root / "scripts" / "check_quality.py").write_text("y = 2\n", encoding="utf-8")
+    (root / "docs").mkdir(exist_ok=True)
+    (root / "CITATION.cff").write_text(
+        "cff-version: 1.2.0\ntitle: Test\nauthors:\n  - given-names: A\n",
+        encoding="utf-8",
+    )
+
+
+def _patch_root(monkeypatch, root: Path) -> None:
+    monkeypatch.setattr(cgf, "REPO_ROOT", root)
+
+
+# --- presence ---------------------------------------------------------------
+
+
+def test_clean_seeded_repo_passes(tmp_path, monkeypatch) -> None:
+    _seed_clean_repo(tmp_path)
+    _patch_root(monkeypatch, tmp_path)
+    assert cgf.collect_violations() == []
+    assert cgf.main([]) == 0
+    assert cgf.main(["--strict"]) == 0
+
+
+def test_missing_file_is_a_violation(tmp_path, monkeypatch) -> None:
+    _seed_clean_repo(tmp_path)
+    (tmp_path / "LICENSE").unlink()
+    _patch_root(monkeypatch, tmp_path)
+    violations = cgf.check_presence()
+    assert ("LICENSE", "missing — required governance file does not exist") in violations
+    assert cgf.main(["--strict"]) == 1
+
+
+def test_empty_file_is_a_violation(tmp_path, monkeypatch) -> None:
+    _seed_clean_repo(tmp_path)
+    (tmp_path / "SECURITY.md").write_text("   \n\n", encoding="utf-8")
+    _patch_root(monkeypatch, tmp_path)
+    problems = [p for where, p in cgf.check_presence() if where == "SECURITY.md"]
+    assert any("empty" in p for p in problems)
+    assert cgf.main(["--strict"]) == 1
+
+
+def test_all_required_files_checked(tmp_path, monkeypatch) -> None:
+    # Wipe everything: every required file should be reported missing.
+    _patch_root(monkeypatch, tmp_path)
+    reported = {where for where, _ in cgf.check_presence()}
+    assert reported == set(cgf.REQUIRED_FILES)
+
+
+# --- freshness --------------------------------------------------------------
+
+
+def test_stale_path_reference_is_a_violation(tmp_path, monkeypatch) -> None:
+    _seed_clean_repo(tmp_path)
+    # CONTRIBUTING cites a script that does not exist on disk.
+    (tmp_path / "CONTRIBUTING.md").write_text(
+        "# Contributing\n\nRun `scripts/totally_gone.py`.\n",
+        encoding="utf-8",
+    )
+    _patch_root(monkeypatch, tmp_path)
+    violations = cgf.check_freshness()
+    assert (
+        "CONTRIBUTING.md",
+        "references missing path `scripts/totally_gone.py`",
+    ) in violations
+    assert cgf.main(["--strict"]) == 1
+
+
+def test_stale_directory_reference_is_a_violation(tmp_path, monkeypatch) -> None:
+    _seed_clean_repo(tmp_path)
+    (tmp_path / "SECURITY.md").write_text(
+        "# Security\n\nSee `disbot/nonexistent_dir/`.\n",
+        encoding="utf-8",
+    )
+    _patch_root(monkeypatch, tmp_path)
+    violations = cgf.check_freshness()
+    assert any("disbot/nonexistent_dir/" in p for _, p in violations)
+
+
+def test_fresh_paths_pass(tmp_path, monkeypatch) -> None:
+    _seed_clean_repo(tmp_path)
+    _patch_root(monkeypatch, tmp_path)
+    assert cgf.check_freshness() == []
+
+
+def test_referenced_paths_skips_placeholders(tmp_path, monkeypatch) -> None:
+    # A glob/placeholder path is not treated as a concrete reference.
+    refs = cgf._referenced_paths("see `scripts/*.py` and `docs/<name>.md`")
+    assert refs == set()
+
+
+def test_referenced_paths_finds_files_and_dirs() -> None:
+    text = "Run `scripts/check_quality.py` in `disbot/`, read `docs/architecture.md`."
+    refs = cgf._referenced_paths(text)
+    assert "scripts/check_quality.py" in refs
+    assert "docs/architecture.md" in refs
+    assert "disbot/" in refs
+
+
+# --- citation ---------------------------------------------------------------
+
+
+def test_missing_cff_key_is_a_violation(tmp_path, monkeypatch) -> None:
+    _seed_clean_repo(tmp_path)
+    # Drop the `authors` key.
+    (tmp_path / "CITATION.cff").write_text(
+        "cff-version: 1.2.0\ntitle: Test\n",
+        encoding="utf-8",
+    )
+    _patch_root(monkeypatch, tmp_path)
+    violations = cgf.check_citation()
+    assert ("CITATION.cff", "missing required CFF key `authors`") in violations
+    assert cgf.main(["--strict"]) == 1
+
+
+def test_valid_cff_passes(tmp_path, monkeypatch) -> None:
+    _seed_clean_repo(tmp_path)
+    _patch_root(monkeypatch, tmp_path)
+    assert cgf.check_citation() == []
+
+
+def test_absent_cff_not_double_reported_by_citation(tmp_path, monkeypatch) -> None:
+    # check_citation must not crash / report when the file is absent (presence owns that).
+    _patch_root(monkeypatch, tmp_path)
+    assert cgf.check_citation() == []
+
+
+# --- strict / advisory exit contract ----------------------------------------
+
+
+def test_advisory_never_fails(tmp_path, monkeypatch) -> None:
+    # Even with everything missing, the advisory (non-strict) run exits 0.
+    _patch_root(monkeypatch, tmp_path)
+    assert cgf.main([]) == 0
+
+
+def test_strict_fails_when_violations(tmp_path, monkeypatch) -> None:
+    _patch_root(monkeypatch, tmp_path)
+    assert cgf.main(["--strict"]) == 1
+
+
+# --- live repo --------------------------------------------------------------
+
+
+def test_live_repo_governance_files_pass() -> None:
+    """The real repo's governance files must be present, fresh, and CFF-valid."""
+    assert cgf.collect_violations() == []


### PR DESCRIPTION
Adds `scripts/check_governance_files.py` + unit test — a presence + path-freshness guard for the new root governance files (LICENSE, SECURITY.md, CONTRIBUTING.md, CITATION.cff).

- **Presence:** asserts the four root governance files exist.
- **Freshness:** parses backtick repo-paths out of CONTRIBUTING.md + SECURITY.md and asserts each resolves on disk (these root files are outside `check_docs.py`'s `docs/**` scope).
- Pure stdlib, advisory by default with `--strict` gate, disposable per Q-0105.

Idea: `docs/ideas/governance-files-presence-guard-2026-06-19.md`

Fleet run — docs/planning/ultracode-fleet-plan-2026-06-19.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJsGDUHJ16So4DpCUPsLsm)_