### PR TITLE
B2: ledger hygiene dedup linter

### DIFF
--- a/.sessions/2026-06-19-fleet-b2-ledger-hygiene.md
+++ b/.sessions/2026-06-19-fleet-b2-ledger-hygiene.md
@@ -1,5 +1,37 @@
-# 2026-06-19 — Fleet B2: ledger hygiene / dedup linter
+# 2026-06-19 — Fleet B2: ledger-hygiene duplicate-claim / idea-link linter
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-About to: build `scripts/check_ledger_hygiene.py` (+ test) — a stdlib duplicate claim-branch / idea-link detector over the two append-only ledgers (report-only by default, `--strict` for CI), per the B2 unit of the ultracode fleet brief.
+## Arc
+
+Lane B unit **B2** of the [ultracode fleet brief](../docs/planning/ultracode-fleet-plan-2026-06-19.md) —
+ungated tooling quick-win. ledger-hygiene duplicate-claim / idea-link linter.
+
+## Shipped (#1086)
+
+New `scripts/check_ledger_hygiene.py` (+19 unit tests) — read-only duplicate-claim / idea-link detector over the ledgers; warn-only default. Provenance header included.
+
+Verified: its unit test passes · `check_quality --check-only` clean · the script runs exit 0
+on the current repo · `pytest --collect-only` import-clean.
+
+> Completed by the fleet orchestrator after a mid-run container restart killed the per-unit
+> agent before it flipped its card; the agent's implementation was intact in the worktree.
+
+## 📤 Run report
+
+- **Did:** ledger-hygiene duplicate-claim / idea-link linter (fleet B2). · **Outcome:** shipped
+- **Shipped:** #1086
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** `none`
+- **⚑ Self-initiated:** B2 — docs/planning/ultracode-fleet-plan-2026-06-19.md (ungated tooling)
+- **↪ Next:** remaining fleet units.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (#1086, on green) |
+| CI-red rounds | 1 (born-red gate by design) |
+| New ideas contributed | 0 (fleet completion run) |
+| Ideas groomed | 0 |

--- a/.sessions/2026-06-19-fleet-b2-ledger-hygiene.md
+++ b/.sessions/2026-06-19-fleet-b2-ledger-hygiene.md
@@ -1,0 +1,5 @@
+# 2026-06-19 — Fleet B2: ledger hygiene / dedup linter
+
+> **Status:** `in-progress`
+
+About to: build `scripts/check_ledger_hygiene.py` (+ test) — a stdlib duplicate claim-branch / idea-link detector over the two append-only ledgers (report-only by default, `--strict` for CI), per the B2 unit of the ultracode fleet brief.

--- a/scripts/check_ledger_hygiene.py
+++ b/scripts/check_ledger_hygiene.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3.10
+r"""Ledger-hygiene linter — surface duplicate claim branches / idea-file links.
+
+Provenance / reliability header (per CLAUDE.md Q-0105 adopt-with-kill-switch)
+---------------------------------------------------------------------------
+- Why: PR #1003 put git's ``merge=union`` driver on the two append-only
+  coordination ledgers (``docs/owner/active-work.md`` claim ledger,
+  ``docs/ideas/README.md`` idea index) so concurrent appends from parallel
+  sessions auto-merge instead of conflicting (the #995 livelock, hit 3x). Union's
+  one accepted downside: it never deletes and never dedups, so over time a
+  duplicate claim line or a twice-linked idea file can land and accumulate
+  silently — the convention already *permits* pruning these by hand, but nothing
+  *surfaces* them. This linter is the surface. It pairs with #1003: union keeps
+  the ledgers conflict-free, this keeps them clean. Idea:
+  ``docs/ideas/ledger-dedup-linter-2026-06-16.md`` (fleet unit B2).
+- Added: 2026-06-19. **Unverified** — confirm its output against ground truth a
+  few times across sessions before trusting it (the duplicate counts it reports
+  should match a hand grep of the two ledgers). **Delete this script + its test if
+  it proves unreliable / noisy over multiple sessions** — it is a disposable
+  convenience guard (Q-0105), not load-bearing. It is read-only: it never modifies
+  the ledgers it inspects.
+
+Behavior
+--------
+Read-only over two well-structured lists:
+
+* **Active claims** (``active-work.md`` § "Active claims") — flags the same
+  ``\`claude/<branch>\``` appearing twice *within that section*. A branch may
+  legitimately appear once in Active claims and again under "Recently cleared",
+  so the scan is scoped to the Active-claims section only.
+* **Idea index** (``ideas/README.md`` § "What lives here") — flags the same
+  ``./<file>.md`` linked twice as a top-level **index entry** (a list item that
+  opens ``- [\`...\`](./<file>.md)``). Inline cross-references to an idea from
+  inside *another* idea's prose are reported separately as advisory only (they
+  are intentional and never fail ``--strict``).
+
+Exit codes: report-only by default (always 0 — it lists what it found and
+returns clean so it can run as an advisory without blocking). ``--strict`` exits
+1 when a hard duplicate (duplicate Active claim branch, or duplicate idea index
+entry) is found, for the reconciliation-cadence pass / opt-in CI.
+
+Pure stdlib, unit-tested.
+
+Usage:
+    python3.10 scripts/check_ledger_hygiene.py            # report-only (exit 0)
+    python3.10 scripts/check_ledger_hygiene.py --strict   # fail on hard dupes
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+ACTIVE_WORK = REPO_ROOT / "docs" / "owner" / "active-work.md"
+IDEAS_README = REPO_ROOT / "docs" / "ideas" / "README.md"
+
+# A `claude/<slug>` branch token inside backticks. Slug is lowercase alnum + dashes.
+_BRANCH_RE = re.compile(r"`(claude/[A-Za-z0-9][A-Za-z0-9-]*)`")
+
+# A top-level idea **index entry**: a list item that opens with a markdown link to
+# a sibling idea file, e.g. `- [`foo-2026-06-16.md`](./foo-2026-06-16.md) — ...`.
+_INDEX_ENTRY_RE = re.compile(r"^-\s+\[[^\]]*\]\((\./[A-Za-z0-9._-]+\.md)\)")
+
+# Any markdown link to a sibling idea file, wherever it appears (entry or inline ref).
+_ANY_IDEA_LINK_RE = re.compile(r"\]\((\./[A-Za-z0-9._-]+\.md)\)")
+
+
+def section_body(text: str, heading: str) -> str:
+    """Return the body of the ``## <heading>`` section (up to the next ``## ``).
+
+    Returns "" when the heading is absent. Matching is exact on the heading text
+    after the ``## `` marker (leading/trailing whitespace stripped), so
+    "Active claims" finds ``## Active claims`` but not ``## Recently cleared``.
+    """
+    lines = text.splitlines()
+    out: list[str] = []
+    capturing = False
+    for line in lines:
+        if line.startswith("## "):
+            if capturing:
+                break  # reached the next section — stop
+            capturing = line[3:].strip() == heading
+            continue
+        if capturing:
+            out.append(line)
+    return "\n".join(out)
+
+
+def duplicate_active_claims(text: str) -> list[tuple[str, int]]:
+    """``(branch, count)`` for each branch appearing >1x in the Active-claims section.
+
+    Sorted by branch for deterministic output. Scans only the Active-claims
+    section so a branch that also appears under "Recently cleared" is not a dupe.
+    """
+    body = section_body(text, "Active claims")
+    counts = Counter(_BRANCH_RE.findall(body))
+    return sorted((b, n) for b, n in counts.items() if n > 1)
+
+
+def duplicate_idea_entries(text: str) -> list[tuple[str, int]]:
+    """``(link, count)`` for each idea file linked >1x as a top-level INDEX entry.
+
+    Only list items that *open* with the idea link count — these are the canonical
+    index rows, where a true duplicate means the same idea was indexed twice.
+    Sorted by link for deterministic output.
+    """
+    counts: Counter[str] = Counter()
+    for line in text.splitlines():
+        m = _INDEX_ENTRY_RE.match(line)
+        if m:
+            counts[m.group(1)] += 1
+    return sorted((link, n) for link, n in counts.items() if n > 1)
+
+
+def duplicate_idea_links(text: str) -> list[tuple[str, int]]:
+    """``(link, count)`` for each idea file linked >1x ANYWHERE (entry or inline).
+
+    A superset of :func:`duplicate_idea_entries`: an idea indexed once but also
+    cross-referenced from another idea's prose shows here (advisory) but not in
+    the entries report (it is intentional, so it never fails ``--strict``).
+    """
+    counts = Counter(_ANY_IDEA_LINK_RE.findall(text))
+    return sorted((link, n) for link, n in counts.items() if n > 1)
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="SuperBot ledger-hygiene linter.")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 1 when a hard duplicate (claim branch / idea index entry) is found",
+    )
+    parser.add_argument(
+        "--active-work",
+        type=Path,
+        default=ACTIVE_WORK,
+        help="path to the claim ledger (default: docs/owner/active-work.md)",
+    )
+    parser.add_argument(
+        "--ideas-readme",
+        type=Path,
+        default=IDEAS_README,
+        help="path to the idea index (default: docs/ideas/README.md)",
+    )
+    args = parser.parse_args(argv)
+
+    active_text = _read(args.active_work)
+    ideas_text = _read(args.ideas_readme)
+
+    dup_claims = duplicate_active_claims(active_text)
+    dup_entries = duplicate_idea_entries(ideas_text)
+    # Advisory-only set: cross-reference dupes that are NOT duplicate index entries.
+    entry_links = {link for link, _ in dup_entries}
+    dup_refs = [
+        (link, n)
+        for link, n in duplicate_idea_links(ideas_text)
+        if link not in entry_links
+    ]
+
+    hard = bool(dup_claims or dup_entries)
+
+    if dup_claims:
+        print("Duplicate Active-claims branches (active-work.md § Active claims):")
+        for branch, n in dup_claims:
+            print(f"  - `{branch}` appears {n}x — prune the stale duplicate line.")
+    if dup_entries:
+        print("Duplicate idea index entries (ideas/README.md § What lives here):")
+        for link, n in dup_entries:
+            print(f"  - {link} indexed {n}x — keep one index entry, drop the rest.")
+    if dup_refs:
+        print("Advisory — idea files linked more than once (incl. cross-references):")
+        for link, n in dup_refs:
+            print(f"  - {link} linked {n}x (likely an intentional cross-ref; review).")
+
+    if not hard and not dup_refs:
+        print(
+            "check_ledger_hygiene: ledgers clean — no duplicate claims or idea links. ✓",
+        )
+        return 0
+
+    if hard and args.strict:
+        print(
+            "\ncheck_ledger_hygiene: FAIL (--strict) — prune the duplicate(s) above. "
+            "The append-only union driver (#1003) never dedups, so a duplicate must "
+            "be removed by hand.",
+        )
+        return 1
+
+    print(
+        "\ncheck_ledger_hygiene: report-only — exiting 0. Run with --strict to fail "
+        "on a hard duplicate (claim branch / idea index entry).",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_ledger_hygiene.py
+++ b/tests/unit/scripts/test_check_ledger_hygiene.py
@@ -1,0 +1,240 @@
+"""Tests for ``scripts/check_ledger_hygiene.py`` — the B2 ledger-hygiene linter.
+
+Covers section scoping, the three duplicate detectors (active-claim branches,
+idea index entries, any-link cross-refs), the entry-vs-advisory split, and
+``main`` exit codes in both report-only and ``--strict`` modes — including the
+real-repo invariant that the linter exits 0 against the live ledgers so its PR
+can land (it never modifies the ledgers it can only read).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MOD = _REPO_ROOT / "scripts" / "check_ledger_hygiene.py"
+
+_spec = importlib.util.spec_from_file_location("check_ledger_hygiene", _MOD)
+assert _spec and _spec.loader
+clh = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(clh)
+
+
+# --- section_body -----------------------------------------------------------
+
+
+def test_section_body_extracts_named_section() -> None:
+    text = (
+        "# Title\n\n"
+        "## Active claims\n"
+        "- `claude/a` · scope\n"
+        "- `claude/b` · scope\n\n"
+        "## Recently cleared\n"
+        "- `claude/a` · 2026 · PR #1\n"
+    )
+    body = clh.section_body(text, "Active claims")
+    assert "`claude/a`" in body and "`claude/b`" in body
+    # The Recently-cleared line must NOT bleed into the Active-claims body.
+    assert "PR #1" not in body
+
+
+def test_section_body_missing_returns_empty() -> None:
+    assert clh.section_body("## Other\n- x\n", "Active claims") == ""
+
+
+def test_section_body_exact_heading_match_not_prefix() -> None:
+    text = "## Active claims extended\n- `claude/x`\n"
+    # The heading "Active claims" must not match "Active claims extended".
+    assert clh.section_body(text, "Active claims") == ""
+
+
+# --- duplicate_active_claims ------------------------------------------------
+
+
+def test_duplicate_active_claims_flags_repeat_in_section() -> None:
+    text = (
+        "## Active claims\n"
+        "- `claude/dup` · scope one\n"
+        "- `claude/solo` · scope\n"
+        "- `claude/dup` · scope two (accidental re-add)\n"
+    )
+    assert clh.duplicate_active_claims(text) == [("claude/dup", 2)]
+
+
+def test_duplicate_active_claims_ignores_recently_cleared() -> None:
+    """A branch in BOTH Active claims and Recently cleared is NOT a duplicate."""
+    text = (
+        "## Active claims\n"
+        "- `claude/live` · current work\n"
+        "## Recently cleared\n"
+        "- `claude/live` · 2026 · PR #9 (different older run, same generated slug)\n"
+    )
+    assert clh.duplicate_active_claims(text) == []
+
+
+def test_duplicate_active_claims_clean_section() -> None:
+    text = "## Active claims\n- `claude/a`\n- `claude/b`\n"
+    assert clh.duplicate_active_claims(text) == []
+
+
+def test_duplicate_active_claims_sorted_and_counts() -> None:
+    text = (
+        "## Active claims\n"
+        "- `claude/zeta`\n- `claude/zeta`\n- `claude/zeta`\n"
+        "- `claude/alpha`\n- `claude/alpha`\n"
+    )
+    assert clh.duplicate_active_claims(text) == [
+        ("claude/alpha", 2),
+        ("claude/zeta", 3),
+    ]
+
+
+# --- duplicate_idea_entries -------------------------------------------------
+
+
+def test_duplicate_idea_entries_flags_double_index_row() -> None:
+    text = (
+        "- [`foo-2026-06-16.md`](./foo-2026-06-16.md) — first index entry\n"
+        "- [`bar-2026-06-16.md`](./bar-2026-06-16.md) — other\n"
+        "- [`foo-2026-06-16.md`](./foo-2026-06-16.md) — accidental second entry\n"
+    )
+    assert clh.duplicate_idea_entries(text) == [("./foo-2026-06-16.md", 2)]
+
+
+def test_duplicate_idea_entries_inline_crossref_not_an_entry() -> None:
+    """A cross-ref inside another idea's prose is NOT a duplicate index entry."""
+    text = (
+        "- [`foo-2026-06-16.md`](./foo-2026-06-16.md) — the one index entry\n"
+        "- [`bar-2026-06-16.md`](./bar-2026-06-16.md) — references\n"
+        "  [`foo-2026-06-16.md`](./foo-2026-06-16.md) for context\n"
+    )
+    # Only one *index entry* for foo (the indented prose ref does not open a list item).
+    assert clh.duplicate_idea_entries(text) == []
+
+
+def test_duplicate_idea_entries_clean() -> None:
+    text = "- [`a.md`](./a.md) — one\n- [`b.md`](./b.md) — two\n"
+    assert clh.duplicate_idea_entries(text) == []
+
+
+# --- duplicate_idea_links (any link, advisory superset) ---------------------
+
+
+def test_duplicate_idea_links_includes_crossrefs() -> None:
+    text = (
+        "- [`foo.md`](./foo.md) — entry\n"
+        "- [`bar.md`](./bar.md) — see [`foo.md`](./foo.md)\n"
+    )
+    assert clh.duplicate_idea_links(text) == [("./foo.md", 2)]
+
+
+# --- main: report-only (always exit 0) --------------------------------------
+
+
+def test_main_clean_exits_zero(tmp_path, capsys) -> None:
+    aw = tmp_path / "active-work.md"
+    aw.write_text("## Active claims\n- `claude/a`\n", encoding="utf-8")
+    rm = tmp_path / "README.md"
+    rm.write_text("- [`a.md`](./a.md) — one\n", encoding="utf-8")
+    rc = clh.main(["--active-work", str(aw), "--ideas-readme", str(rm)])
+    assert rc == 0
+    assert "clean" in capsys.readouterr().out
+
+
+def test_main_hard_dupe_report_only_exits_zero(tmp_path, capsys) -> None:
+    aw = tmp_path / "active-work.md"
+    aw.write_text(
+        "## Active claims\n- `claude/dup`\n- `claude/dup`\n", encoding="utf-8"
+    )
+    rm = tmp_path / "README.md"
+    rm.write_text("- [`a.md`](./a.md)\n", encoding="utf-8")
+    # Report-only default: surfaces the dupe but exits 0 (non-blocking advisory).
+    rc = clh.main(["--active-work", str(aw), "--ideas-readme", str(rm)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "claude/dup" in out and "report-only" in out
+
+
+def test_main_advisory_crossref_never_fails_strict(tmp_path, capsys) -> None:
+    """A cross-reference-only duplicate is advisory: exits 0 even under --strict.
+
+    This is the live-repo case (`live-decade-queue-pointer-invariant` linked
+    twice) — the linter must NOT redden a PR for an intentional cross-ref.
+    """
+    aw = tmp_path / "active-work.md"
+    aw.write_text("## Active claims\n- `claude/a`\n", encoding="utf-8")
+    rm = tmp_path / "README.md"
+    rm.write_text(
+        "- [`foo.md`](./foo.md) — entry\n"
+        "- [`bar.md`](./bar.md) — see [`foo.md`](./foo.md)\n",
+        encoding="utf-8",
+    )
+    rc = clh.main(["--strict", "--active-work", str(aw), "--ideas-readme", str(rm)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Advisory" in out
+
+
+# --- main: --strict (exit 1 on a hard dupe) ---------------------------------
+
+
+def test_main_strict_fails_on_duplicate_claim(tmp_path, capsys) -> None:
+    aw = tmp_path / "active-work.md"
+    aw.write_text(
+        "## Active claims\n- `claude/dup`\n- `claude/dup`\n", encoding="utf-8"
+    )
+    rm = tmp_path / "README.md"
+    rm.write_text("- [`a.md`](./a.md)\n", encoding="utf-8")
+    rc = clh.main(["--strict", "--active-work", str(aw), "--ideas-readme", str(rm)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "FAIL" in out and "claude/dup" in out
+
+
+def test_main_strict_fails_on_duplicate_idea_entry(tmp_path, capsys) -> None:
+    aw = tmp_path / "active-work.md"
+    aw.write_text("## Active claims\n- `claude/a`\n", encoding="utf-8")
+    rm = tmp_path / "README.md"
+    rm.write_text(
+        "- [`foo.md`](./foo.md) — entry one\n- [`foo.md`](./foo.md) — entry two\n",
+        encoding="utf-8",
+    )
+    rc = clh.main(["--strict", "--active-work", str(aw), "--ideas-readme", str(rm)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "FAIL" in out and "./foo.md" in out
+
+
+def test_main_missing_files_exit_zero(tmp_path, capsys) -> None:
+    """Absent ledger files read as empty → clean, never crash."""
+    rc = clh.main(
+        [
+            "--active-work",
+            str(tmp_path / "nope.md"),
+            "--ideas-readme",
+            str(tmp_path / "nope2.md"),
+        ]
+    )
+    assert rc == 0
+    assert "clean" in capsys.readouterr().out
+
+
+# --- live-repo invariant ----------------------------------------------------
+
+
+def test_live_ledgers_exit_zero_report_only() -> None:
+    """Against the real ledgers, the default report-only run must exit 0.
+
+    Guards the brief's landing requirement: even if the live README has a real
+    cross-ref duplicate, the linter exits cleanly so its own PR can merge.
+    """
+    assert clh.main([]) == 0
+
+
+def test_module_carries_kill_switch_header() -> None:
+    """Q-0105 disposability: the docstring must say to delete it if unreliable."""
+    assert clh.__doc__ is not None
+    doc = clh.__doc__.lower()
+    assert "unverified" in doc
+    assert "delete this script" in doc


### PR DESCRIPTION
Fleet unit **B2** — a tiny stdlib `scripts/check_ledger_hygiene.py` (+ unit test) that detects **duplicate claim branches** in `docs/owner/active-work.md` (Active claims section) and **duplicate idea-file links** in `docs/ideas/README.md`. Report-only (exit 0) by default; `--strict` fails on a duplicate. Read-only over the ledgers — never modifies them.

Implements [`docs/ideas/ledger-dedup-linter-2026-06-16.md`](../blob/main/docs/ideas/ledger-dedup-linter-2026-06-16.md). Pairs with the `merge=union` ledger driver (#1003): union keeps the ledgers conflict-free; this keeps them clean. Carries the Q-0105 provenance/reliability header (unverified, disposable).

Fleet run — docs/planning/ultracode-fleet-plan-2026-06-19.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJsGDUHJ16So4DpCUPsLsm)_