### PR TITLE
A7: wrap raw pool/conn.execute in utils/db

### DIFF
--- a/.sessions/2026-06-19-fleet-a7-db-wrappers.md
+++ b/.sessions/2026-06-19-fleet-a7-db-wrappers.md
@@ -1,5 +1,57 @@
 # 2026-06-19 — Fleet A7: wrap raw SQL in utils/db helpers
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-About to: move the 13 raw `pool.execute()/fetch*()` calls in `game_state_service.py` + `platform_consistency.py` behind named `utils/db/` helpers, behavior-preserving.
+## Arc
+
+Lane A unit **A7** of the [ultracode fleet brief](../docs/planning/ultracode-fleet-plan-2026-06-19.md):
+move the raw `pool.execute()` / `conn.execute()` / `fetch*` calls in
+`services/game_state_service.py` and `services/platform_consistency.py` back behind the
+`utils.db.*` seam, so the two services stop reaching past `utils/db/` for raw SQL
+(13 of the 18 `raw_sql` architecture warnings).
+
+## Shipped
+
+- **New `utils/db` helpers** — `utils/db/games/game_state.py` and
+  `utils/db/platform_consistency.py` — each wrapping the previously-inline SQL in named,
+  typed functions. The two services now call those helpers instead of touching the pool
+  directly. Behaviour-preserving (same queries, same results).
+- **`raw_sql` architecture warnings 18 → 5** (the remaining 5 live in
+  `automation_scheduler.py` / `binding_backfill.py`, out of this unit's scope).
+- `check_architecture --mode strict` exit 0 · `check_quality --check-only` clean ·
+  `pytest --collect-only` 10748 tests import-clean · 81 targeted game_state /
+  platform_consistency tests pass.
+
+## ⟲ Previous-session review (Q-0102)
+
+This unit was completed by the fleet **orchestrator** after a mid-run container restart
+killed the per-unit agent before it could flip its card. The agent had done the
+implementation correctly but left it uncommitted and offloaded the full test suite to a
+background process, then came to rest. **System improvement surfaced:** a fleet agent
+should *commit its work before* kicking off a long background verification, so a restart
+never strands finished work in an uncommitted worktree — and the orchestrator should tell
+sub-agents to validate with `pytest --collect-only` + targeted tests rather than 14
+concurrent full suites (the likely cause of the resource-exhaustion restart).
+
+## 📤 Run report
+
+- **Did:** wrapped the 13 raw-SQL calls in `game_state_service` + `platform_consistency`
+  behind new `utils/db` helpers (fleet unit A7). · **Outcome:** shipped
+- **Shipped:** #1087 — 2 new `utils/db` helper modules; 2 services rewired; `raw_sql` 18 → 5.
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** `none`
+- **⚑ Self-initiated:** A7 — docs/planning/ultracode-fleet-plan-2026-06-19.md (architecture
+  boundary-debt burndown, ungated)
+- **↪ Next:** remaining fleet units; the 5 residual `raw_sql` warns in
+  `automation_scheduler` / `binding_backfill` are a future slice.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (#1087, on green) |
+| CI-red rounds | 1 (born-red session gate by design) |
+| `raw_sql` arch warns | 18 → 5 |
+| New ideas contributed | 0 (fleet completion run) |
+| Ideas groomed | 0 |

--- a/.sessions/2026-06-19-fleet-a7-db-wrappers.md
+++ b/.sessions/2026-06-19-fleet-a7-db-wrappers.md
@@ -1,0 +1,5 @@
+# 2026-06-19 — Fleet A7: wrap raw SQL in utils/db helpers
+
+> **Status:** `in-progress`
+
+About to: move the 13 raw `pool.execute()/fetch*()` calls in `game_state_service.py` + `platform_consistency.py` behind named `utils/db/` helpers, behavior-preserving.

--- a/disbot/services/game_state_service.py
+++ b/disbot/services/game_state_service.py
@@ -39,7 +39,13 @@ import json
 import logging
 from typing import Any
 
-from utils.db import pool
+# A7: ``pool`` is no longer called directly here — every query moved behind
+# ``utils.db.games.game_state``. The import is kept so the historical
+# test-patch seam ``services.game_state_service.pool.<primitive>`` (used by
+# tests/unit/services/test_game_state_service.py) still resolves; those
+# patches mutate the shared pool module the db helpers call through.
+from utils.db import pool  # noqa: F401
+from utils.db.games import game_state as game_state_db
 
 logger = logging.getLogger("bot.game_state")
 
@@ -72,16 +78,13 @@ async def save(
     (the existing best-effort checkpoint behaviour).
     """
     payload = json.dumps(state)
-    await pool.execute(
-        """INSERT INTO game_state
-             (guild_id, user_id, channel_id, subsystem, state, version)
-           VALUES ($1, $2, $3, $4, $5::jsonb, $6)
-           ON CONFLICT (guild_id, user_id, channel_id, subsystem)
-           DO UPDATE SET
-               state      = EXCLUDED.state,
-               version    = EXCLUDED.version,
-               updated_at = NOW()""",
-        (guild_id, user_id, channel_id, subsystem, payload, version),
+    await game_state_db.upsert_checkpoint(
+        guild_id,
+        user_id,
+        channel_id,
+        subsystem,
+        payload,
+        version,
         conn=conn,
     )
 
@@ -93,11 +96,11 @@ async def load(
     subsystem: str,
 ) -> dict[str, Any] | None:
     """Return the latest checkpoint for this (user, channel, subsystem) or None."""
-    row = await pool.fetchone(
-        """SELECT state FROM game_state
-           WHERE guild_id=$1 AND user_id=$2
-             AND channel_id=$3 AND subsystem=$4""",
-        (guild_id, user_id, channel_id, subsystem),
+    row = await game_state_db.fetch_checkpoint(
+        guild_id,
+        user_id,
+        channel_id,
+        subsystem,
     )
     if row is None:
         return None
@@ -121,11 +124,11 @@ async def clear(
     ``game_wager_workflow`` releases a wager's escrow row in the same
     transaction that pays out the pot, so a settle is all-or-nothing.
     """
-    await pool.execute(
-        """DELETE FROM game_state
-           WHERE guild_id=$1 AND user_id=$2
-             AND channel_id=$3 AND subsystem=$4""",
-        (guild_id, user_id, channel_id, subsystem),
+    await game_state_db.delete_checkpoint(
+        guild_id,
+        user_id,
+        channel_id,
+        subsystem,
         conn=conn,
     )
 
@@ -153,33 +156,13 @@ async def fetch_rows_for_update(
     guild (a tournament payout).  Each returned dict carries the
     decoded ``state`` plus ``user_id`` / ``channel_id``.
     """
-    clauses = ["guild_id=$1", "subsystem=$2"]
-    params: list[Any] = [guild_id, subsystem]
-    if channel_id is not None:
-        params.append(channel_id)
-        clauses.append(f"channel_id=${len(params)}")
-    if user_ids is not None:
-        params.append(list(user_ids))
-        clauses.append(f"user_id = ANY(${len(params)}::bigint[])")
-    sql = (
-        "SELECT user_id, channel_id, state, version FROM game_state WHERE "
-        + " AND ".join(clauses)
-        + " FOR UPDATE"
+    return await game_state_db.lock_rows_for_settlement(
+        guild_id,
+        subsystem,
+        conn=conn,
+        channel_id=channel_id,
+        user_ids=user_ids,
     )
-    rows = await pool.fetchall(sql, tuple(params), conn=conn)
-    result: list[dict[str, Any]] = []
-    for r in rows:
-        raw = r["state"]
-        state = json.loads(raw) if isinstance(raw, str) else raw
-        result.append(
-            {
-                "user_id": r["user_id"],
-                "channel_id": r["channel_id"],
-                "state": state,
-                "version": r["version"],
-            },
-        )
-    return result
 
 
 async def list_active_for_subsystem(
@@ -193,36 +176,7 @@ async def list_active_for_subsystem(
     row dict contains: guild_id, user_id, channel_id, state (decoded
     dict), version, updated_at.
     """
-    if guild_id is None:
-        rows = await pool.get().fetch(
-            """SELECT guild_id, user_id, channel_id, state, version, updated_at
-               FROM game_state
-               WHERE subsystem=$1""",
-            subsystem,
-        )
-    else:
-        rows = await pool.get().fetch(
-            """SELECT guild_id, user_id, channel_id, state, version, updated_at
-               FROM game_state
-               WHERE subsystem=$1 AND guild_id=$2""",
-            subsystem,
-            guild_id,
-        )
-    result: list[dict[str, Any]] = []
-    for r in rows:
-        raw = r["state"]
-        state = json.loads(raw) if isinstance(raw, str) else raw
-        result.append(
-            {
-                "guild_id": r["guild_id"],
-                "user_id": r["user_id"],
-                "channel_id": r["channel_id"],
-                "state": state,
-                "version": r["version"],
-                "updated_at": r["updated_at"],
-            },
-        )
-    return result
+    return await game_state_db.list_active(subsystem, guild_id=guild_id)
 
 
 # ---------------------------------------------------------------------------
@@ -242,30 +196,7 @@ async def list_stale(cutoff_hours: int = GAME_STATE_TTL_HOURS) -> list[dict[str,
     via :func:`clear_by_id` (the natural key may have been reused by
     a brand-new game with the same player/channel/subsystem).
     """
-    rows = await pool.get().fetch(
-        """SELECT id, guild_id, user_id, channel_id, subsystem,
-                  state, version, updated_at
-             FROM game_state
-            WHERE updated_at < NOW() - make_interval(hours => $1)""",
-        cutoff_hours,
-    )
-    result: list[dict[str, Any]] = []
-    for r in rows:
-        raw = r["state"]
-        state = json.loads(raw) if isinstance(raw, str) else raw
-        result.append(
-            {
-                "id": r["id"],
-                "guild_id": r["guild_id"],
-                "user_id": r["user_id"],
-                "channel_id": r["channel_id"],
-                "subsystem": r["subsystem"],
-                "state": state,
-                "version": r["version"],
-                "updated_at": r["updated_at"],
-            },
-        )
-    return result
+    return await game_state_db.list_stale(cutoff_hours)
 
 
 async def clear_by_id(row_id: int) -> None:
@@ -275,4 +206,4 @@ async def clear_by_id(row_id: int) -> None:
     listed without racing a freshly-restarted game that already
     upserted at the same natural key.
     """
-    await pool.execute("DELETE FROM game_state WHERE id=$1", (row_id,))
+    await game_state_db.delete_checkpoint_by_id(row_id)

--- a/disbot/services/platform_consistency.py
+++ b/disbot/services/platform_consistency.py
@@ -446,11 +446,9 @@ async def _collect_rollout_audit() -> SectionResult:
     """Section 3: feature_flag_audit table reachable if migration exists."""
     name = "Rollout / audit"
     try:
-        from utils.db import pool
+        from utils.db import platform_consistency as pc_db
 
-        oid = await pool.get().fetchval(
-            "SELECT to_regclass('feature_flag_audit')",
-        )
+        oid = await pc_db.table_oid("feature_flag_audit")
     except Exception as exc:  # noqa: BLE001 — collector is fail-safe
         return SectionResult(
             name=name,
@@ -467,11 +465,9 @@ async def _collect_rollout_audit() -> SectionResult:
         )
 
     try:
-        from utils.db import pool
+        from utils.db import platform_consistency as pc_db
 
-        count = await pool.get().fetchval(
-            "SELECT COUNT(*) FROM feature_flag_audit",
-        )
+        count = await pc_db.feature_flag_audit_count()
     except Exception as exc:  # noqa: BLE001 — collector is fail-safe
         return SectionResult(
             name=name,
@@ -705,14 +701,10 @@ async def _collect_participation() -> SectionResult:
     """Section 7: participation storage / cache / mutation / audit."""
     name = "Participation"
     try:
-        from utils.db import pool
+        from utils.db import platform_consistency as pc_db
 
-        part_oid = await pool.get().fetchval(
-            "SELECT to_regclass('user_participation')",
-        )
-        audit_oid = await pool.get().fetchval(
-            "SELECT to_regclass('user_participation_audit')",
-        )
+        part_oid = await pc_db.table_oid("user_participation")
+        audit_oid = await pc_db.table_oid("user_participation_audit")
     except Exception as exc:  # noqa: BLE001 — collector is fail-safe
         return SectionResult(
             name=name,
@@ -837,12 +829,9 @@ async def _collect_migrations() -> SectionResult:
     db_versions: set[int] | None = None
     db_error: str | None = None
     try:
-        from utils.db import pool
+        from utils.db import platform_consistency as pc_db
 
-        rows = await pool.get().fetch(
-            "SELECT version FROM schema_migrations ORDER BY version",
-        )
-        db_versions = {int(r["version"]) for r in rows}
+        db_versions = set(await pc_db.applied_migration_versions())
     except Exception as exc:  # noqa: BLE001 — collector is fail-safe
         db_error = f"{type(exc).__name__}: {exc}"
 

--- a/disbot/utils/db/games/game_state.py
+++ b/disbot/utils/db/games/game_state.py
@@ -1,0 +1,204 @@
+"""game_state checkpoint-table CRUD — the restart-safe per-game state store.
+
+Migration 015. One row per (guild_id, user_id, channel_id, subsystem),
+``state`` is a JSONB blob each subsystem owns. The policy layer
+(``services.game_state_service``) decides *when* to checkpoint and owns
+the payload schema/versioning; this module is plain table CRUD only.
+
+A7 (2026-06-19): these helpers were lifted out of
+``services.game_state_service`` so the service no longer issues raw
+``pool.*`` calls — the SQL now lives behind the ``utils.db`` seam like
+every other table. Queries/params are byte-for-byte the originals.
+
+Transaction-aware (the Q-0071 precedent): the write/lock primitives take
+an optional ``conn`` so ``services.game_wager_workflow`` can escrow a
+wager (coin debit + checkpoint write) inside ONE caller-owned
+``db.transaction()``. With ``conn`` given a primitive must never open its
+own transaction — the caller owns commit/rollback.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from utils.db import pool
+
+_SAVE_SQL = """INSERT INTO game_state
+             (guild_id, user_id, channel_id, subsystem, state, version)
+           VALUES ($1, $2, $3, $4, $5::jsonb, $6)
+           ON CONFLICT (guild_id, user_id, channel_id, subsystem)
+           DO UPDATE SET
+               state      = EXCLUDED.state,
+               version    = EXCLUDED.version,
+               updated_at = NOW()"""
+
+_LOAD_SQL = """SELECT state FROM game_state
+           WHERE guild_id=$1 AND user_id=$2
+             AND channel_id=$3 AND subsystem=$4"""
+
+_CLEAR_SQL = """DELETE FROM game_state
+           WHERE guild_id=$1 AND user_id=$2
+             AND channel_id=$3 AND subsystem=$4"""
+
+_CLEAR_BY_ID_SQL = "DELETE FROM game_state WHERE id=$1"
+
+_LIST_ACTIVE_SQL = """SELECT guild_id, user_id, channel_id, state, version, updated_at
+               FROM game_state
+               WHERE subsystem=$1"""
+
+_LIST_ACTIVE_GUILD_SQL = """SELECT guild_id, user_id, channel_id, state, version, updated_at
+               FROM game_state
+               WHERE subsystem=$1 AND guild_id=$2"""
+
+_LIST_STALE_SQL = """SELECT id, guild_id, user_id, channel_id, subsystem,
+                  state, version, updated_at
+             FROM game_state
+            WHERE updated_at < NOW() - make_interval(hours => $1)"""
+
+
+def _decode_state(raw: Any) -> Any:
+    """Decode a JSONB ``state`` value — asyncpg may hand back str or dict."""
+    return json.loads(raw) if isinstance(raw, str) else raw
+
+
+async def upsert_checkpoint(
+    guild_id: int,
+    user_id: int,
+    channel_id: int,
+    subsystem: str,
+    payload: str,
+    version: int,
+    *,
+    conn: Any | None = None,
+) -> None:
+    """Upsert one checkpoint row. ``payload`` is the JSON-encoded state."""
+    await pool.execute(
+        _SAVE_SQL,
+        (guild_id, user_id, channel_id, subsystem, payload, version),
+        conn=conn,
+    )
+
+
+async def fetch_checkpoint(
+    guild_id: int,
+    user_id: int,
+    channel_id: int,
+    subsystem: str,
+) -> dict[str, Any] | None:
+    """Return the raw ``{"state": ...}`` row for this key, or ``None``."""
+    return await pool.fetchone(
+        _LOAD_SQL,
+        (guild_id, user_id, channel_id, subsystem),
+    )
+
+
+async def delete_checkpoint(
+    guild_id: int,
+    user_id: int,
+    channel_id: int,
+    subsystem: str,
+    *,
+    conn: Any | None = None,
+) -> None:
+    """Delete the checkpoint for this natural key."""
+    await pool.execute(
+        _CLEAR_SQL,
+        (guild_id, user_id, channel_id, subsystem),
+        conn=conn,
+    )
+
+
+async def delete_checkpoint_by_id(row_id: int) -> None:
+    """Delete a checkpoint by its synthetic ``id`` (GC-precise)."""
+    await pool.execute(_CLEAR_BY_ID_SQL, (row_id,))
+
+
+async def lock_rows_for_settlement(
+    guild_id: int,
+    subsystem: str,
+    *,
+    conn: Any,
+    channel_id: int | None = None,
+    user_ids: list[int] | None = None,
+) -> list[dict[str, Any]]:
+    """Lock (``FOR UPDATE``) + return checkpoint rows for an escrow settle.
+
+    Called **inside** a caller-owned ``db.transaction()``; the dynamic
+    WHERE narrows by *channel_id* (a PvP match) and/or *user_ids* (the
+    two players), or omits both to lock every row for the subsystem.
+    Each returned dict carries the decoded ``state`` plus ``user_id`` /
+    ``channel_id`` / ``version``.
+    """
+    clauses = ["guild_id=$1", "subsystem=$2"]
+    params: list[Any] = [guild_id, subsystem]
+    if channel_id is not None:
+        params.append(channel_id)
+        clauses.append(f"channel_id=${len(params)}")
+    if user_ids is not None:
+        params.append(list(user_ids))
+        clauses.append(f"user_id = ANY(${len(params)}::bigint[])")
+    sql = (
+        "SELECT user_id, channel_id, state, version FROM game_state WHERE "
+        + " AND ".join(clauses)
+        + " FOR UPDATE"
+    )
+    rows = await pool.fetchall(sql, tuple(params), conn=conn)
+    return [
+        {
+            "user_id": r["user_id"],
+            "channel_id": r["channel_id"],
+            "state": _decode_state(r["state"]),
+            "version": r["version"],
+        }
+        for r in rows
+    ]
+
+
+async def list_active(
+    subsystem: str,
+    *,
+    guild_id: int | None = None,
+) -> list[dict[str, Any]]:
+    """Return every active checkpoint for *subsystem*, optionally guild-scoped.
+
+    Each row dict contains: guild_id, user_id, channel_id, state
+    (decoded), version, updated_at.
+    """
+    if guild_id is None:
+        rows = await pool.get().fetch(_LIST_ACTIVE_SQL, subsystem)
+    else:
+        rows = await pool.get().fetch(_LIST_ACTIVE_GUILD_SQL, subsystem, guild_id)
+    return [
+        {
+            "guild_id": r["guild_id"],
+            "user_id": r["user_id"],
+            "channel_id": r["channel_id"],
+            "state": _decode_state(r["state"]),
+            "version": r["version"],
+            "updated_at": r["updated_at"],
+        }
+        for r in rows
+    ]
+
+
+async def list_stale(cutoff_hours: int) -> list[dict[str, Any]]:
+    """Return every checkpoint older than *cutoff_hours*, with synthetic ``id``.
+
+    Each row dict includes ``id`` so the GC can issue precise per-row
+    deletes via :func:`delete_checkpoint_by_id`.
+    """
+    rows = await pool.get().fetch(_LIST_STALE_SQL, cutoff_hours)
+    return [
+        {
+            "id": r["id"],
+            "guild_id": r["guild_id"],
+            "user_id": r["user_id"],
+            "channel_id": r["channel_id"],
+            "subsystem": r["subsystem"],
+            "state": _decode_state(r["state"]),
+            "version": r["version"],
+            "updated_at": r["updated_at"],
+        }
+        for r in rows
+    ]

--- a/disbot/utils/db/platform_consistency.py
+++ b/disbot/utils/db/platform_consistency.py
@@ -1,0 +1,46 @@
+"""Read-only DB probes for the platform-consistency diagnostics service.
+
+A7 (2026-06-19): these probes were lifted out of
+``services.platform_consistency`` so its section collectors no longer issue
+raw ``pool.*`` calls — the SQL now lives behind the ``utils.db`` seam like
+every other table accessor. Queries are byte-for-byte the originals.
+
+Every function here is a pure read used by a *fail-safe* collector: the
+collector wraps the call in ``try/except`` and downgrades any raise to a
+WARNING/FATAL section, so these helpers deliberately do **not** swallow
+exceptions themselves — the caller owns the failure policy.
+
+The probes go through ``pool.get().fetchval`` / ``pool.get().fetch`` (rather
+than the ``pool.fetchone``/``pool.fetchall`` dict primitives) to preserve the
+exact asyncpg surface the collectors relied on, including the existing test
+seam that patches ``utils.db.pool.get`` with a minimal fake pool.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from utils.db import pool
+
+
+async def table_oid(table_name: str) -> Any:
+    """Return ``to_regclass(<table>)`` — the table's OID, or ``None`` if absent.
+
+    ``table_name`` is interpolated into the SQL because asyncpg cannot
+    parameterise a ``to_regclass`` argument; callers pass only trusted
+    hard-coded literals (never user input).
+    """
+    return await pool.get().fetchval(f"SELECT to_regclass('{table_name}')")
+
+
+async def feature_flag_audit_count() -> Any:
+    """Return ``COUNT(*)`` of the ``feature_flag_audit`` table."""
+    return await pool.get().fetchval("SELECT COUNT(*) FROM feature_flag_audit")
+
+
+async def applied_migration_versions() -> list[int]:
+    """Return the sorted set of applied ``schema_migrations`` versions."""
+    rows = await pool.get().fetch(
+        "SELECT version FROM schema_migrations ORDER BY version",
+    )
+    return [int(r["version"]) for r in rows]


### PR DESCRIPTION
Wraps the 13 raw `pool.execute()/fetch*()` calls in `services/game_state_service.py` (8) and `services/platform_consistency.py` (5) behind named `utils/db/` helper functions. Behavior-preserving — same queries, same params, same results, just moved behind the `utils.db` seam. Clears the targeted raw-SQL architecture warnings.

Fleet run — docs/planning/ultracode-fleet-plan-2026-06-19.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJsGDUHJ16So4DpCUPsLsm)_