### PR TITLE
B6: SHA-pin third-party Actions

### DIFF
--- a/.github/workflows/ai-evals.yml
+++ b/.github/workflows/ai-evals.yml
@@ -32,9 +32,9 @@ jobs:
   evals:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.10"
 

--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -121,7 +121,7 @@ jobs:
           echo "- **Tables:** $TABLE_COUNT (CREATE TABLE statements)" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: postgres-backup-${{ github.run_id }}
           path: ${{ steps.dump.outputs.file }}
@@ -130,7 +130,7 @@ jobs:
 
       - name: Open issue on failure
         if: failure()
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const today = new Date().toISOString().slice(0, 10);

--- a/.github/workflows/btd6-data-refresh.yml
+++ b/.github/workflows/btd6-data-refresh.yml
@@ -54,10 +54,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.10"
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           # Full history so the docs-only detector can diff against the base.
           fetch-depth: 0
@@ -86,7 +86,7 @@ jobs:
 
       - name: Set up Python
         if: steps.changes.outputs.code == 'true'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.10"
           # Cache pip's download cache so the pinned tools + requirements.txt aren't
@@ -135,7 +135,7 @@ jobs:
 
       - name: Cache mypy incremental cache
         if: steps.changes.outputs.code == 'true'
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .mypy_cache
           # Exact key per disbot tree state; restore-keys falls back to the most recent

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,10 +30,10 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: python
           # 'security-extended' adds more security queries than the default set without
@@ -42,9 +42,9 @@ jobs:
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: "/language:python"

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.10"
           cache: "pip"

--- a/.github/workflows/dashboard-data-refresh.yml
+++ b/.github/workflows/dashboard-data-refresh.yml
@@ -56,11 +56,11 @@ jobs:
     if: github.repository == 'menno420/superbot'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           token: ${{ secrets.ROUTINE_PAT || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.10'
       - name: Regenerate dashboard data; open an auto-merging PR if it changed

--- a/.github/workflows/reconciliation-trigger.yml
+++ b/.github/workflows/reconciliation-trigger.yml
@@ -27,10 +27,10 @@ jobs:
     if: github.repository == 'menno420/superbot'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0 # full history so the cadence guard can scan merge subjects
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.10"
       - name: Is a reconciliation pass due?

--- a/.sessions/2026-06-19-fleet-b6-sha-pin-actions.md
+++ b/.sessions/2026-06-19-fleet-b6-sha-pin-actions.md
@@ -1,0 +1,51 @@
+# 2026-06-19 — Fleet B6: SHA-pin third-party GitHub Actions
+
+> **Status:** `complete`
+
+## Arc
+
+Lane B unit **B6** of the [ultracode fleet brief](../docs/planning/ultracode-fleet-plan-2026-06-19.md) —
+SHA-pin the third-party GitHub Actions across all workflows (supply-chain hardening that
+pairs with the now-active Dependabot, which bumps the SHAs going forward).
+
+## Shipped (#1088)
+
+Rebuilt on current `main` after the now-active Dependabot bumped several action majors
+mid-run (checkout→v7, cache→v5, github-script→v9, codeql→v4), which had made the original
+branch conflict. Pinned every third-party `uses:` tag to its resolved 40-char commit SHA
+with a trailing version comment (Dependabot reads the comment):
+
+- `actions/checkout@v7` → `9c091bb…`
+- `actions/cache@v5` → `27d5ce7…`
+- `actions/github-script@v9` → `3a2844b…`
+- `actions/setup-python@v6` → `a309ff8…`
+- `actions/upload-artifact@v4` → `ea165f8…`
+- `github/codeql-action/{analyze,autobuild,init}@v4` → `8aad20d…`
+- (`peter-evans/create-pull-request` was already SHA-pinned on main.)
+
+Local-action (`./…`) and reusable-workflow refs left untouched. No workflow logic changed —
+only the `@ref` of third-party `uses:` lines. All 8 workflow files YAML-parse; the pinned
+SHAs are the live tag commits (resolved via `git ls-remote`), and CI itself exercises them.
+
+> Rebuilt by the fleet orchestrator after a mid-run container restart + ongoing Dependabot
+> major bumps made the original agent's branch stale/conflicting.
+
+## 📤 Run report
+
+- **Did:** SHA-pinned all third-party Actions across 8 workflows (fleet B6). · **Outcome:** shipped
+- **Shipped:** #1088
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** `none`
+- **⚑ Self-initiated:** B6 — docs/planning/ultracode-fleet-plan-2026-06-19.md (ungated CI/supply-chain)
+- **↪ Next:** Dependabot now bumps these SHAs going forward.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (#1088, on green) |
+| CI-red rounds | 1 (born-red gate + 1 Dependabot-conflict rebuild) |
+| Actions SHA-pinned | 6 distinct actions across 8 workflows |
+| New ideas contributed | 0 (fleet completion run) |
+| Ideas groomed | 0 |


### PR DESCRIPTION
SHA-pin the third-party GitHub Actions in `.github/workflows/*.yml` — replace floating tags (`uses: owner/action@v4`) with the resolved full 40-char commit SHA plus a trailing version comment (`uses: owner/action@<sha> # v4`). Pairs with the now-active Dependabot, which bumps the SHAs (and reads the trailing version comment).

Scope: only third-party/marketplace `uses:` refs. Local actions, reusable workflows, and already-SHA-pinned refs (e.g. `peter-evans/create-pull-request`) are untouched. No workflow logic / triggers / steps changed — only `@ref` + trailing comment.

Fleet run — docs/planning/ultracode-fleet-plan-2026-06-19.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJsGDUHJ16So4DpCUPsLsm)_