### PR TITLE
B4: automate PLAN-BACKLOG-THIN flag

### DIFF
--- a/.sessions/2026-06-19-fleet-b4-plan-backlog.md
+++ b/.sessions/2026-06-19-fleet-b4-plan-backlog.md
@@ -1,5 +1,37 @@
-# 2026-06-19 — Fleet B4: automate the PLAN-BACKLOG-THIN flag
+# 2026-06-19 — Fleet B4: automate the PLAN-BACKLOG-THIN flag (Q-0164)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-About to: build `scripts/check_plan_backlog.py` + test — a warn-only checker that computes whether the buildable band-plan backlog can fill the next reconciliation cadence band (Q-0164).
+## Arc
+
+Lane B unit **B4** of the [ultracode fleet brief](../docs/planning/ultracode-fleet-plan-2026-06-19.md) —
+ungated tooling quick-win. automate the PLAN-BACKLOG-THIN flag (Q-0164).
+
+## Shipped (#1090)
+
+New `scripts/check_plan_backlog.py` (+24 unit tests) — automates the `PLAN-BACKLOG-THIN` readout (Q-0164); informational/warn-only. Provenance header included.
+
+Verified: its unit test passes · `check_quality --check-only` clean · the script runs exit 0
+on the current repo · `pytest --collect-only` import-clean.
+
+> Completed by the fleet orchestrator after a mid-run container restart killed the per-unit
+> agent before it flipped its card; the agent's implementation was intact in the worktree.
+
+## 📤 Run report
+
+- **Did:** automate the PLAN-BACKLOG-THIN flag (Q-0164) (fleet B4). · **Outcome:** shipped
+- **Shipped:** #1090
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** `none`
+- **⚑ Self-initiated:** B4 — docs/planning/ultracode-fleet-plan-2026-06-19.md (ungated tooling)
+- **↪ Next:** remaining fleet units.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (#1090, on green) |
+| CI-red rounds | 1 (born-red gate by design) |
+| New ideas contributed | 0 (fleet completion run) |
+| Ideas groomed | 0 |

--- a/.sessions/2026-06-19-fleet-b4-plan-backlog.md
+++ b/.sessions/2026-06-19-fleet-b4-plan-backlog.md
@@ -1,0 +1,5 @@
+# 2026-06-19 — Fleet B4: automate the PLAN-BACKLOG-THIN flag
+
+> **Status:** `in-progress`
+
+About to: build `scripts/check_plan_backlog.py` + test — a warn-only checker that computes whether the buildable band-plan backlog can fill the next reconciliation cadence band (Q-0164).

--- a/scripts/check_plan_backlog.py
+++ b/scripts/check_plan_backlog.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3.10
+"""PLAN-BACKLOG-THIN reporter — is the band plan deep enough to reach the next pass? (stdlib, read-only).
+
+WHY (Q-0164, added 2026-06-19): the reconciliation pass plans **enough genuine buildable
+work to reach the next pass (depth ≥ the 30-PR cadence)**; when the idea backlog *genuinely
+can't* fill the band, that is the signal to raise a loud ``⚠️ PLAN BACKLOG THIN`` flag so the
+owner drops ideas or a dedicated planning session runs. Today that judgment is made by hand
+each pass ("are we running low on plans?" — a vibe). This guard turns it into a **number**:
+it parses the live ``reconciliation-pass-*-bandNNNN.md`` plan's §4 "next band" section,
+counts the **buildable** slices (gate-tagged ``ready`` or ``plan-first``), and prints the THIN
+condition when the buildable depth falls short of the target. It is the depth-axis
+verified-signal sibling of the hand-written Q-0164 paragraph; the balance-axis sibling
+(``⚑ Product lanes gated``) is a separate, later idea.
+
+How the buildable depth is computed (the parse, so it can be checked by hand):
+
+* The live band plan is the single non-``historical`` ``reconciliation-pass-*.md`` whose
+  Status badge is ``plan`` and whose filename carries the highest ``bandNNNN``.
+* Inside its ``## 4.`` … ``## 5.`` section, every queue-table **slice row** (first cell an
+  ``A1`` / ``B2`` / ``C5``-style lane-slice id) is classified by the gate tag in its own row,
+  or — when the row has none — the gate declared in its ``**Lane X — …**`` header. Buildable =
+  ``ready`` or ``plan-first``; gated = ``creds`` / ``owner`` / ``data`` (work that needs an
+  owner decision, prod creds, or sourced data first).
+* Plans bundle multi-PR initiatives into a single table row (e.g. "Batches 2–4") and list
+  some lanes as prose, not tables, so the **row count is a floor**. When the §4 section states
+  an explicit ``Depth check … ~N[-M] … slices`` estimate, that count's **lower bound** is read
+  too (the conservative reading) and the **effective buildable depth is the larger of the two**
+  — respecting the planner's own honest judgment rather than under-counting it.
+
+THIN fires when the effective buildable depth is below ``--min-buildable`` (default
+``MIN_BUILDABLE_DEFAULT`` — a margin below the full cadence, because the planner has treated a
+high-teens count as "enough to reach the next pass" in practice; pass ``--min-buildable 30`` to
+demand a full band).
+
+Run::
+
+    python3.10 scripts/check_plan_backlog.py                    # warn-only (always exit 0)
+    python3.10 scripts/check_plan_backlog.py --strict           # exit 1 when THIN
+    python3.10 scripts/check_plan_backlog.py --min-buildable 30 # demand a full-cadence band
+    python3.10 scripts/check_plan_backlog.py --json             # machine-readable summary
+
+**Warn-only by design.** A THIN backlog is a *planning* signal for the reconciliation routine
+/ a dedicated planning session, never a per-push merge blocker — so the default exit is 0 and
+``--strict`` is the opt-in cadence gate. The check reasons over the *plan* docs, so it never
+touches runtime code and never has to run a bot.
+
+Reliability (Q-0105): **unverified** — this is a convenience nudge for the Q-0164 cadence,
+not load-bearing runtime code. The "buildable depth" it reports is a *parse* of human-written
+plan tables, so confirm its count against the §4 queue by hand a few times across sessions
+before trusting its verdict, and **delete this script if it proves unreliable** over multiple
+sessions rather than working around it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLANNING_DIR = REPO_ROOT / "docs" / "planning"
+
+# The cadence: the next reconciliation pass fires every STEP-th merged PR (Q-0134, 30-PR band
+# — kept identical to check_reconciliation_due.STEP on purpose; if that retunes, retune here).
+STEP = 30
+
+# Default THIN threshold. The Q-0164 rule is "depth ≥ the cadence", but in practice the planner
+# has judged a high-teens buildable count as "enough to reach the next pass without inventing
+# filler" (band-#1050's §4 Depth check: "~18–22 … No PLAN BACKLOG THIN flag"). So the default
+# demands only *half* a cadence band — low enough to agree with that lived non-THIN judgment
+# (the conservative 18-lower-bound reading still clears it), high enough to fire on a genuine
+# drain. Pass --min-buildable 30 for a strict full-cadence demand.
+MIN_BUILDABLE_DEFAULT = STEP // 2  # 15 at STEP=30
+
+# Gate-state tags used in the §4 queue tables. Buildable = work an agent can pick up now;
+# gated = needs an owner decision / prod creds / sourced data first (Q-0164 §3).
+BUILDABLE_TAGS = ("ready", "plan-first")
+GATED_TAGS = ("creds", "owner", "data")
+_ALL_TAGS = BUILDABLE_TAGS + GATED_TAGS
+
+# A live band plan: `reconciliation-pass-YYYY-MM-DD-bandNNNN.md`. The trailing bandNNNN is the
+# cadence-band marker; the newest one with a `plan` Status badge is the live queue.
+_BAND_FILE_RE = re.compile(r"reconciliation-pass-.*-band(\d+)\.md$")
+_STATUS_RE = re.compile(r">\s*\*\*Status:\*\*\s*`([a-z]+)`")
+# A queue-table slice row: a markdown table row whose first cell is a lane-slice id like
+# `A1`, `B12`, `C5` (one uppercase letter + digits). Bold wrappers / whitespace tolerated.
+_SLICE_ROW_RE = re.compile(r"^\|\s*\**([A-Z]\d+)\**\s*\|")
+# A lane header: `**Lane A — consistency-linter (… all `ready`):**`
+_LANE_HEADER_RE = re.compile(r"^\*\*Lane\s+([A-Z])\b")
+# The §4 "next band" section header, and the next-section sentinel that ends it.
+_NEXT_BAND_HEADER_RE = re.compile(r"^##\s*4\.")
+_SECTION_HEADER_RE = re.compile(r"^##\s")
+# An explicit author depth-check estimate inside §4: a count *anchored to the word "slices"*,
+# e.g. "~18–22 genuine `ready`/`plan-first` slices" or "12 buildable slices". Anchoring on
+# "slices" avoids picking up unrelated digits on the same line (PR numbers, "Q-0164"). For a
+# range like "18–22" the **lower** bound is read — the conservative reading (the backlog must
+# clear the threshold even at the pessimistic end of the author's own estimate).
+_DEPTH_LINE_RE = re.compile(r"(?i)\bdepth check\b")
+_SLICES_COUNT_RE = re.compile(
+    r"~?\s*(\d+)\s*(?:[–\-]\s*\d+)?\s*(?:\S+\s+){0,4}?slices?\b",
+    re.IGNORECASE,
+)
+
+
+def _tags_in(text: str) -> set[str]:
+    """Gate tags appearing as backtick tokens (`` `ready` ``) in a line of plan text."""
+    return {t for t in _ALL_TAGS if f"`{t}`" in text}
+
+
+def _classify(row_tags: set[str], lane_tags: set[str]) -> str:
+    """Classify one slice → 'buildable' | 'gated'.
+
+    A slice is *gated* only when its own row (or, failing that, its lane header) carries a
+    gated tag and **no** buildable tag — so a "plan-first → then ready" lane reads buildable.
+    A slice with no tag at all inherits its lane's tags; if neither has any tag, the §4
+    contract ("every slot is a real, ungated slice unless tagged") makes it buildable.
+    """
+    tags = row_tags or lane_tags
+    if tags & set(BUILDABLE_TAGS):
+        return "buildable"
+    if tags & set(GATED_TAGS):
+        return "gated"
+    return "buildable"  # untagged → ungated by the §4 convention
+
+
+@dataclass(frozen=True)
+class Slice:
+    slice_id: str
+    classification: str  # 'buildable' | 'gated'
+    tags: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BacklogReport:
+    plan_path: Path | None
+    band: int | None
+    buildable_rows: int  # buildable slices counted from the queue tables (a floor)
+    gated_rows: int
+    total_rows: int
+    stated_depth: (
+        int | None
+    )  # the author's "Depth check" lower bound, if the plan states one
+    effective_depth: (
+        int  # max(buildable_rows, stated_depth or 0) — the depth THIN compares
+    )
+    threshold: int
+    thin: bool
+    slices: tuple[Slice, ...]
+
+
+def find_live_band_plan(planning_dir: Path = PLANNING_DIR) -> Path | None:
+    """The newest live (`Status: plan`) `reconciliation-pass-*-bandNNNN.md` by band number."""
+    best: tuple[int, Path] | None = None
+    for path in sorted(planning_dir.glob("reconciliation-pass-*.md")):
+        match = _BAND_FILE_RE.search(path.name)
+        if not match:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        status = _STATUS_RE.search(text)
+        if not status or status.group(1) != "plan":
+            continue
+        band = int(match.group(1))
+        if best is None or band > best[0]:
+            best = (band, path)
+    return best[1] if best else None
+
+
+def _next_band_lines(text: str) -> list[str]:
+    """The lines inside the `## 4.` (next band) section, up to the next `## ` header."""
+    lines = text.splitlines()
+    out: list[str] = []
+    in_section = False
+    for line in lines:
+        if _NEXT_BAND_HEADER_RE.match(line):
+            in_section = True
+            continue
+        if in_section and _SECTION_HEADER_RE.match(line):
+            break
+        if in_section:
+            out.append(line)
+    return out
+
+
+def parse_slices(lines: list[str]) -> list[Slice]:
+    """Parse the §4 queue-table slice rows into classified Slices.
+
+    Walks the next-band section top-to-bottom, tracking the current lane header's gate tags;
+    each slice row inherits them when its own row is untagged.
+    """
+    slices: list[Slice] = []
+    lane_tags: set[str] = set()
+    for line in lines:
+        header = _LANE_HEADER_RE.match(line)
+        if header:
+            lane_tags = _tags_in(line)
+            continue
+        row = _SLICE_ROW_RE.match(line)
+        if not row:
+            continue
+        row_tags = _tags_in(line)
+        classification = _classify(row_tags, lane_tags)
+        effective = sorted(row_tags or lane_tags)
+        slices.append(Slice(row.group(1), classification, tuple(effective)))
+    return slices
+
+
+def parse_stated_depth(lines: list[str]) -> int | None:
+    """The author's explicit 'Depth check … ~N[-M] … slices' lower bound, if §4 states one.
+
+    Anchored to a 'Depth check' line (the note often wraps onto the following line, so a
+    2-line window is searched), then to the first count that precedes the word 'slices' — so
+    PR numbers / 'Q-0164' on the same line are ignored. A range like '~18–22 … slices' yields
+    its **lower** bound (18), the conservative reading.
+    """
+    for idx, line in enumerate(lines):
+        if not _DEPTH_LINE_RE.search(line):
+            continue
+        window = " ".join(lines[idx : idx + 2])  # the depth note often wraps one line
+        match = _SLICES_COUNT_RE.search(window)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def build_report(
+    plan_path: Path | None = None,
+    threshold: int = MIN_BUILDABLE_DEFAULT,
+    planning_dir: Path = PLANNING_DIR,
+) -> BacklogReport:
+    """Compute the buildable-depth backlog report against ``threshold``."""
+    if plan_path is None:
+        plan_path = find_live_band_plan(planning_dir)
+    if plan_path is None:
+        return BacklogReport(
+            plan_path=None,
+            band=None,
+            buildable_rows=0,
+            gated_rows=0,
+            total_rows=0,
+            stated_depth=None,
+            effective_depth=0,
+            threshold=threshold,
+            thin=False,
+            slices=(),
+        )
+    band_match = _BAND_FILE_RE.search(plan_path.name)
+    band = int(band_match.group(1)) if band_match else None
+    lines = _next_band_lines(plan_path.read_text(encoding="utf-8"))
+    slices = parse_slices(lines)
+    buildable = sum(1 for s in slices if s.classification == "buildable")
+    gated = sum(1 for s in slices if s.classification == "gated")
+    stated = parse_stated_depth(lines)
+    effective = max(buildable, stated or 0)
+    return BacklogReport(
+        plan_path=plan_path,
+        band=band,
+        buildable_rows=buildable,
+        gated_rows=gated,
+        total_rows=len(slices),
+        stated_depth=stated,
+        effective_depth=effective,
+        threshold=threshold,
+        thin=effective < threshold,
+        slices=tuple(slices),
+    )
+
+
+def _report_dict(report: BacklogReport) -> dict[str, object]:
+    return {
+        "plan": (
+            str(report.plan_path.relative_to(REPO_ROOT)) if report.plan_path else None
+        ),
+        "band": report.band,
+        "buildable_rows": report.buildable_rows,
+        "gated_rows": report.gated_rows,
+        "total_rows": report.total_rows,
+        "stated_depth": report.stated_depth,
+        "effective_depth": report.effective_depth,
+        "cadence": STEP,
+        "threshold": report.threshold,
+        "thin": report.thin,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="PLAN-BACKLOG-THIN reporter (Q-0164): is the band plan deep enough?",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 1 when the buildable backlog is THIN (below --min-buildable)",
+    )
+    parser.add_argument(
+        "--min-buildable",
+        type=int,
+        default=MIN_BUILDABLE_DEFAULT,
+        metavar="N",
+        help=(
+            "minimum effective buildable depth before THIN fires "
+            f"(default {MIN_BUILDABLE_DEFAULT}; pass {STEP} to demand a full cadence band)"
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="print a machine-readable summary instead of prose",
+    )
+    args = parser.parse_args(argv)
+
+    report = build_report(threshold=args.min_buildable)
+
+    if args.json:
+        print(json.dumps(_report_dict(report), indent=2))
+        return 1 if (args.strict and report.thin) else 0
+
+    if report.plan_path is None:
+        print(
+            "check_plan_backlog: no live `reconciliation-pass-*-bandNNNN.md` plan "
+            "(Status: `plan`) found in docs/planning/ — can't compute buildable depth. "
+            "This is informational; the next reconciliation pass writes the band plan.",
+        )
+        return 0
+
+    rel = report.plan_path.relative_to(REPO_ROOT)
+    stated = (
+        f", author depth-check ~{report.stated_depth}"
+        if report.stated_depth is not None
+        else ""
+    )
+    detail = (
+        f"effective buildable depth {report.effective_depth} "
+        f"({report.buildable_rows} buildable queue rows{stated}; "
+        f"{report.gated_rows} gated, {report.total_rows} total rows) "
+        f"vs. threshold {report.threshold} (cadence {STEP})"
+    )
+    if report.thin:
+        print(
+            f"check_plan_backlog: ⚠️ PLAN BACKLOG THIN — band #{report.band} plan ({rel}): "
+            f"{detail}. Per Q-0164, raise the `⚠️ PLAN BACKLOG THIN` flag (current-state "
+            "▶ Next action + the run-report ⚑ Owner-decisions line): promote what's honest, "
+            "then ask the owner to drop ideas or run a dedicated planning session.",
+        )
+        return 1 if args.strict else 0
+
+    print(
+        f"check_plan_backlog: OK — band #{report.band} plan ({rel}): {detail}. "
+        "Backlog is deep enough to reach the next reconciliation pass.",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_plan_backlog.py
+++ b/tests/unit/scripts/test_check_plan_backlog.py
@@ -1,0 +1,370 @@
+"""Tests for ``scripts/check_plan_backlog.py`` — the Q-0164 PLAN-BACKLOG-THIN reporter.
+
+Fixtures are synthetic band-plan markdown written into a tmp planning dir, so the tests never
+depend on the live, mutable ``reconciliation-pass-*.md`` files.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_MOD = REPO_ROOT / "scripts" / "check_plan_backlog.py"
+
+_spec = importlib.util.spec_from_file_location("check_plan_backlog", _MOD)
+assert _spec and _spec.loader
+cpb = importlib.util.module_from_spec(_spec)
+sys.modules["check_plan_backlog"] = cpb
+_spec.loader.exec_module(cpb)
+
+
+# --- synthetic band-plan fixtures --------------------------------------------------------
+
+_PLAN_RICH = """# Reconciliation pass — band-#1200
+
+> **Status:** `plan`
+
+## 1. Verified state
+
+Prose with a stray `ready` mention that must NOT be counted (no slice row).
+
+## 4. The next band — buildable, highest-value first
+
+> Gate-state tags: `ready` · `creds` · `owner` · `plan-first` · `data`.
+
+**Lane A — flagship (all `ready`):**
+
+| # | Slice | Scope anchor |
+|---|---|---|
+| A1 | **Do the first thing** | anchor |
+| A2 | **Do the second thing** | anchor |
+
+**Lane B — gated work:**
+
+| # | Slice | Gate | Scope anchor |
+|---|---|---|---|
+| B1 | **A creds thing** | `creds` | anchor |
+| B2 | **An owner thing** | `owner` | anchor |
+| B3 | **A ready thing despite the lane** | `ready` | anchor |
+
+**Lane C — small guards (ungated, `plan-first` → then `ready`):**
+
+| # | Slice | Scope anchor |
+|---|---|---|
+| C1 | **A plan-first thing** | anchor |
+
+**Depth check (Q-0164):** Lanes A–C total **~18–22 genuine `ready`/`plan-first` slices** —
+enough buildable work to reach #1230. **No `⚠️ PLAN BACKLOG THIN` flag this pass.**
+
+## 5. Pruned / fixed
+
+done.
+"""
+
+_PLAN_THIN = """# Reconciliation pass — band-#900
+
+> **Status:** `plan`
+
+## 4. The next band
+
+**Lane A — what's left (mostly gated):**
+
+| # | Slice | Gate | Scope anchor |
+|---|---|---|---|
+| A1 | **The one ungated thing** | `ready` | anchor |
+| A2 | **A creds-blocked thing** | `creds` | anchor |
+| A3 | **An owner-blocked thing** | `owner` | anchor |
+| A4 | **A data-blocked thing** | `data` | anchor |
+
+**Depth check (Q-0164):** only **3 genuine `ready` slices** — short of the band.
+
+## 5. Done
+"""
+
+_PLAN_HISTORICAL = """# Old pass — band-#1500
+
+> **Status:** `historical`
+
+## 4. The next band
+
+**Lane A — stuff (`ready`):**
+
+| # | Slice | Scope anchor |
+|---|---|---|
+| A1 | **old** | anchor |
+"""
+
+
+def _write(planning_dir: Path, name: str, body: str) -> Path:
+    path = planning_dir / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# --- find_live_band_plan -----------------------------------------------------------------
+
+
+def test_find_live_band_plan_picks_highest_band_plan(tmp_path: Path) -> None:
+    _write(tmp_path, "reconciliation-pass-2026-01-01-band900.md", _PLAN_THIN)
+    newest = _write(tmp_path, "reconciliation-pass-2026-02-01-band1200.md", _PLAN_RICH)
+    assert cpb.find_live_band_plan(tmp_path) == newest
+
+
+def test_find_live_band_plan_skips_historical(tmp_path: Path) -> None:
+    # A higher band number, but `historical` — must be ignored in favour of the live one.
+    _write(tmp_path, "reconciliation-pass-2026-03-01-band1500.md", _PLAN_HISTORICAL)
+    live = _write(tmp_path, "reconciliation-pass-2026-02-01-band1200.md", _PLAN_RICH)
+    assert cpb.find_live_band_plan(tmp_path) == live
+
+
+def test_find_live_band_plan_none_when_empty(tmp_path: Path) -> None:
+    assert cpb.find_live_band_plan(tmp_path) is None
+
+
+def test_find_live_band_plan_ignores_non_band_files(tmp_path: Path) -> None:
+    _write(tmp_path, "reconciliation-pass-2026-02-01-q0107.md", _PLAN_RICH)
+    assert cpb.find_live_band_plan(tmp_path) is None
+
+
+# --- section + slice parsing -------------------------------------------------------------
+
+
+def test_next_band_lines_bounded_by_section_4(tmp_path: Path) -> None:
+    lines = cpb._next_band_lines(_PLAN_RICH)
+    joined = "\n".join(lines)
+    assert "Lane A — flagship" in joined
+    assert "Depth check" in joined
+    # Must stop at `## 5.` — the pruned section's content is excluded.
+    assert "Pruned / fixed" not in joined
+    # Must start after `## 4.` — the §1 prose `ready` mention is excluded.
+    assert "stray `ready` mention" not in joined
+
+
+def test_parse_slices_classifies_lane_and_row_tags() -> None:
+    slices = cpb.parse_slices(cpb._next_band_lines(_PLAN_RICH))
+    by_id = {s.slice_id: s for s in slices}
+    # All six lane-slice rows are found; the §1 prose `ready` is not a row.
+    assert set(by_id) == {"A1", "A2", "B1", "B2", "B3", "C1"}
+    # Lane A inherits `ready` from its header.
+    assert by_id["A1"].classification == "buildable"
+    assert by_id["A2"].classification == "buildable"
+    # Lane B rows carry their own gate column.
+    assert by_id["B1"].classification == "gated"  # creds
+    assert by_id["B2"].classification == "gated"  # owner
+    assert by_id["B3"].classification == "buildable"  # row `ready` overrides the gated lane
+    # Lane C header has both plan-first and ready → buildable.
+    assert by_id["C1"].classification == "buildable"
+
+
+def test_classify_untagged_defaults_buildable() -> None:
+    # The §4 convention: "every slot is a real, ungated slice unless tagged".
+    assert cpb._classify(set(), set()) == "buildable"
+
+
+def test_classify_row_tag_overrides_lane_tag() -> None:
+    assert cpb._classify({"ready"}, {"creds"}) == "buildable"
+    assert cpb._classify({"data"}, {"ready"}) == "gated"
+
+
+# --- stated-depth parsing (the anchored, lower-bound, noise-resistant read) ---------------
+
+
+def test_parse_stated_depth_reads_range_lower_bound() -> None:
+    depth = cpb.parse_stated_depth(cpb._next_band_lines(_PLAN_RICH))
+    assert depth == 18  # the lower bound of "~18–22", not 22 and not a stray number
+
+
+def test_parse_stated_depth_ignores_pr_and_q_numbers() -> None:
+    # "#1230" and "Q-0164" share the depth-check window; only the slices-anchored count counts.
+    depth = cpb.parse_stated_depth(cpb._next_band_lines(_PLAN_RICH))
+    assert depth not in (1230, 164, 1164, 22)
+
+
+def test_parse_stated_depth_single_count() -> None:
+    depth = cpb.parse_stated_depth(cpb._next_band_lines(_PLAN_THIN))
+    assert depth == 3
+
+
+def test_parse_stated_depth_none_when_absent() -> None:
+    body = "## 4. band\n\n| # | Slice |\n|---|---|\n| A1 | x |\n"
+    assert cpb.parse_stated_depth(cpb._next_band_lines(body)) is None
+
+
+# --- build_report end to end -------------------------------------------------------------
+
+
+def test_build_report_rich_is_not_thin(tmp_path: Path) -> None:
+    plan = _write(tmp_path, "reconciliation-pass-2026-02-01-band1200.md", _PLAN_RICH)
+    report = cpb.build_report(plan_path=plan)
+    assert report.band == 1200
+    assert report.buildable_rows == 4  # A1, A2, B3, C1
+    assert report.gated_rows == 2  # B1, B2
+    assert report.total_rows == 6
+    assert report.stated_depth == 18
+    assert report.effective_depth == 18  # max(4 rows, 18 stated)
+    assert report.thin is False  # 18 >= default threshold 15
+
+
+def test_build_report_thin_when_buildable_short(tmp_path: Path) -> None:
+    plan = _write(tmp_path, "reconciliation-pass-2026-01-01-band900.md", _PLAN_THIN)
+    report = cpb.build_report(plan_path=plan)
+    assert report.buildable_rows == 1  # only A1 is `ready`
+    assert report.gated_rows == 3  # creds, owner, data
+    assert report.stated_depth == 3
+    assert report.effective_depth == 3  # max(1, 3)
+    assert report.thin is True  # 3 < default threshold 15
+
+
+def test_build_report_effective_depth_prefers_row_floor(tmp_path: Path) -> None:
+    # When there is NO stated depth-check, the buildable row count carries the verdict.
+    body = (
+        "> **Status:** `plan`\n\n## 4. band\n\n"
+        "**Lane A — work (`ready`):**\n\n| # | Slice |\n|---|---|\n"
+        + "".join(f"| A{i} | thing {i} |\n" for i in range(1, 17))
+        + "\n## 5. done\n"
+    )
+    plan = _write(tmp_path, "reconciliation-pass-2026-02-01-band1230.md", body)
+    report = cpb.build_report(plan_path=plan)
+    assert report.buildable_rows == 16
+    assert report.stated_depth is None
+    assert report.effective_depth == 16
+    assert report.thin is False  # 16 >= 15
+
+
+def test_build_report_custom_threshold(tmp_path: Path) -> None:
+    plan = _write(tmp_path, "reconciliation-pass-2026-02-01-band1200.md", _PLAN_RICH)
+    # Demand a full-cadence band: 18 < 30 → THIN.
+    report = cpb.build_report(plan_path=plan, threshold=cpb.STEP)
+    assert report.threshold == 30
+    assert report.thin is True
+
+
+def test_build_report_no_plan(tmp_path: Path) -> None:
+    report = cpb.build_report(planning_dir=tmp_path)
+    assert report.plan_path is None
+    assert report.thin is False
+    assert report.effective_depth == 0
+
+
+# --- main / CLI --------------------------------------------------------------------------
+
+
+def test_main_advisory_exit_zero_even_when_thin(monkeypatch) -> None:
+    monkeypatch.setattr(
+        cpb,
+        "build_report",
+        lambda threshold=cpb.MIN_BUILDABLE_DEFAULT: cpb.BacklogReport(
+            plan_path=_MOD,  # any path; only used for display
+            band=900,
+            buildable_rows=1,
+            gated_rows=3,
+            total_rows=4,
+            stated_depth=3,
+            effective_depth=3,
+            threshold=threshold,
+            thin=True,
+            slices=(),
+        ),
+    )
+    assert cpb.main([]) == 0  # warn-only default never fails
+    assert cpb.main(["--strict"]) == 1  # strict gates on THIN
+
+
+def test_main_not_thin_exits_zero(monkeypatch) -> None:
+    monkeypatch.setattr(
+        cpb,
+        "build_report",
+        lambda threshold=cpb.MIN_BUILDABLE_DEFAULT: cpb.BacklogReport(
+            plan_path=_MOD,
+            band=1200,
+            buildable_rows=4,
+            gated_rows=2,
+            total_rows=6,
+            stated_depth=18,
+            effective_depth=18,
+            threshold=threshold,
+            thin=False,
+            slices=(),
+        ),
+    )
+    assert cpb.main(["--strict"]) == 0
+
+
+def test_main_no_plan_exits_zero(monkeypatch) -> None:
+    monkeypatch.setattr(
+        cpb,
+        "build_report",
+        lambda threshold=cpb.MIN_BUILDABLE_DEFAULT: cpb.BacklogReport(
+            plan_path=None,
+            band=None,
+            buildable_rows=0,
+            gated_rows=0,
+            total_rows=0,
+            stated_depth=None,
+            effective_depth=0,
+            threshold=threshold,
+            thin=False,
+            slices=(),
+        ),
+    )
+    assert cpb.main(["--strict"]) == 0
+
+
+def test_main_json_mode(monkeypatch, capsys) -> None:
+    import json
+
+    monkeypatch.setattr(
+        cpb,
+        "build_report",
+        lambda threshold=cpb.MIN_BUILDABLE_DEFAULT: cpb.BacklogReport(
+            plan_path=_MOD,
+            band=1200,
+            buildable_rows=4,
+            gated_rows=2,
+            total_rows=6,
+            stated_depth=18,
+            effective_depth=18,
+            threshold=threshold,
+            thin=False,
+            slices=(),
+        ),
+    )
+    assert cpb.main(["--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["band"] == 1200
+    assert payload["effective_depth"] == 18
+    assert payload["thin"] is False
+    assert payload["cadence"] == cpb.STEP
+
+
+def test_min_buildable_default_below_cadence() -> None:
+    # The default threshold demands a margin, not a full band (so it agrees with the planner's
+    # own lived non-THIN judgment), and is still a positive depth.
+    assert 0 < cpb.MIN_BUILDABLE_DEFAULT < cpb.STEP
+
+
+def test_step_matches_reconciliation_cadence() -> None:
+    # The cadence must stay identical to the reconciliation-due guard's band size.
+    crd_mod = REPO_ROOT / "scripts" / "check_reconciliation_due.py"
+    spec = importlib.util.spec_from_file_location("check_reconciliation_due_for_cpb", crd_mod)
+    assert spec and spec.loader
+    crd = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(crd)
+    assert cpb.STEP == crd.STEP
+
+
+def test_live_repo_plan_runs_and_is_consistent() -> None:
+    """Smoke test against the live repo: the script must run, find a plan, and its default
+    verdict must NOT contradict that plan's own stated PLAN-BACKLOG-THIN judgment (Q-0120)."""
+    report = cpb.build_report()
+    if report.plan_path is None:
+        return  # no live band plan in this checkout — nothing to assert
+    text = report.plan_path.read_text(encoding="utf-8")
+    if "No `⚠️ PLAN BACKLOG THIN`" in text or "No ⚠️ PLAN BACKLOG THIN" in text:
+        # The live plan explicitly declared itself NOT thin — the tool must agree by default.
+        assert report.thin is False, (
+            "default verdict contradicts the live plan's own 'No PLAN BACKLOG THIN' "
+            "declaration (Q-0120: a tool that fights the evidence is the tool's bug)"
+        )


### PR DESCRIPTION
Fleet B4 — automates the Q-0164 `⚠️ PLAN BACKLOG THIN` flag.

New `scripts/check_plan_backlog.py` (pure stdlib, disposable Q-0105 tooling) computes whether the buildable band-plan backlog can fill the next reconciliation cadence band. It parses the §4 "next band" queue tables of the live `reconciliation-pass-*-bandNNNN.md` plan, counts buildable (`ready` + `plan-first`) slices vs. the 30-PR cadence, and reports the PLAN-BACKLOG-THIN condition. Warn-only by default (exit 0); `--strict` for a gate. Thorough unit test added.

Fleet run — docs/planning/ultracode-fleet-plan-2026-06-19.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJsGDUHJ16So4DpCUPsLsm)_