### PR TITLE
B7: owner-review-inbox Phase 1 (/reviews)

### DIFF
--- a/.sessions/2026-06-19-fleet-b7-review-inbox.md
+++ b/.sessions/2026-06-19-fleet-b7-review-inbox.md
@@ -1,0 +1,5 @@
+# 2026-06-19 — Fleet B7: owner-review-inbox Phase 1
+
+> **Status:** `in-progress`
+
+About to: ship the read-only `/reviews` dashboard page (Phase 1 of the owner-review-inbox plan) — route + template + export feed + `docs/owner/review-inbox.md`.

--- a/.sessions/2026-06-19-fleet-b7-review-inbox.md
+++ b/.sessions/2026-06-19-fleet-b7-review-inbox.md
@@ -1,5 +1,41 @@
-# 2026-06-19 — Fleet B7: owner-review-inbox Phase 1
+# 2026-06-19 — Fleet B7: owner-review-inbox Phase 1 (/reviews)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-About to: ship the read-only `/reviews` dashboard page (Phase 1 of the owner-review-inbox plan) — route + template + export feed + `docs/owner/review-inbox.md`.
+## Arc
+
+Lane B unit **B7** of the [ultracode fleet brief](../docs/planning/ultracode-fleet-plan-2026-06-19.md) —
+Phase 1 of the owner-review-inbox plan (Q-0169): a **read-only** `/reviews` dashboard page over
+a committed ledger. Scoped strictly to read-only (Phase 2 write side / control-API is Held).
+
+## Shipped (#1091)
+
+- `dashboard/app.py` — new read-only `/reviews` route (mirrors the `/bugs` · `/updates` patterns).
+- `dashboard/templates/reviews.html` (new) — page extending `base.html`, open vs. resolved grouped.
+- `scripts/export_dashboard_data.py` — new `reviews` export block parsed from the ledger, plus
+  `reviews` / `reviews_open` counts in `meta.counts`.
+- `docs/owner/review-inbox.md` (new) — the committed `## REV-NNNN` ledger + what Phase 1 ships.
+- New tests: `tests/unit/dashboard/test_reviews_page.py`, `tests/unit/scripts/test_export_review_inbox.py` (8 pass).
+- Verified: lint clean · `check_dashboard_data: OK` (45 cogs) · `pytest --collect-only` 10756 import-clean.
+
+> Completed by the fleet orchestrator after a mid-run container restart killed the per-unit
+> agent before it flipped its card; the agent's implementation was intact in the worktree.
+
+## 📤 Run report
+
+- **Did:** shipped owner-review-inbox Phase 1 read-only `/reviews` page (fleet B7). · **Outcome:** shipped
+- **Shipped:** #1091
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** `none`
+- **⚑ Self-initiated:** B7 — docs/planning/ultracode-fleet-plan-2026-06-19.md → owner-review-inbox-plan-2026-06-17.md (Phase 1, ungated read-only)
+- **↪ Next:** Phase 2 (write side / control-API) remains Held.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (#1091, on green) |
+| CI-red rounds | 1 (born-red gate by design) |
+| New ideas contributed | 0 (fleet completion run) |
+| Ideas groomed | 0 |

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -78,6 +78,7 @@ _EMPTY: dict[str, Any] = {
     "catalogue": [],
     "ideas": [],
     "bugs": [],
+    "reviews": [],
     "updates": [],
     "env_usage": [],
     "settings": [],
@@ -204,6 +205,35 @@ def bugs(request: Request):
         request,
         "bugs.html",
         {"data": load_data(), "page": "bugs"},
+    )
+
+
+@app.get("/reviews", response_class=HTMLResponse)
+def reviews(request: Request):
+    """Owner review inbox (read-only) — open vs. resolved reviews grouped by area.
+
+    Phase 1 of the owner↔agent review channel (Q-0169): a read view over the
+    committed ``docs/owner/review-inbox.md`` ledger. ``OPEN`` reviews are the
+    actionable list (a bugs-first cousin); the rest are the resolved history. The
+    write side (post-from-the-dashboard) is Phase 2 and stays Held.
+    """
+    data = load_data()
+    items = data.get("reviews", [])
+    open_reviews = [r for r in items if (r.get("status") or "").upper() == "OPEN"]
+    resolved_reviews = [r for r in items if (r.get("status") or "").upper() != "OPEN"]
+    by_area: dict[str, list[dict]] = {}
+    for review in open_reviews:
+        by_area.setdefault(review.get("area") or "general", []).append(review)
+    return templates.TemplateResponse(
+        request,
+        "reviews.html",
+        {
+            "data": data,
+            "page": "reviews",
+            "open_by_area": sorted(by_area.items()),
+            "open_reviews": open_reviews,
+            "resolved_reviews": resolved_reviews,
+        },
     )
 
 

--- a/dashboard/templates/reviews.html
+++ b/dashboard/templates/reviews.html
@@ -1,0 +1,75 @@
+{% extends "base.html" %}
+{% block title %}Reviews — SuperBot{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-1">Review inbox</h1>
+<p class="text-slate-400 mb-6 text-sm">
+  {{ data.meta.counts.get("reviews_open", 0) }} open of
+  {{ data.meta.counts.get("reviews", 0) }} owner reviews — read-only mirror of the
+  review inbox (<code>docs/owner/review-inbox.md</code>). The owner posts a "change
+  X about this cog" review here; sessions act on the open ones and mark them
+  <code>RESOLVED (#PR)</code>. Posting from the dashboard arrives in Phase 2.
+</p>
+
+<section>
+  <h2 class="text-lg font-semibold mb-3">Open
+    <span class="text-sm font-normal text-slate-500">({{ open_reviews|length }})</span>
+  </h2>
+  {% for area, items in open_by_area %}
+    <div class="mb-5">
+      <h3 class="text-xs uppercase tracking-wide text-slate-500 mb-2">{{ area }}</h3>
+      <ul class="space-y-3">
+        {% for r in items %}
+          <li class="rounded-xl border border-slate-800 bg-slate-900/50 p-4">
+            <div class="flex items-center gap-2 flex-wrap">
+              <code class="text-xs text-slate-500">{{ r.id }}</code>
+              <span class="font-semibold">{{ r.area }}</span>
+              <span class="ml-auto text-[10px] uppercase rounded px-2 py-0.5 shrink-0 bg-rose-900 text-rose-300">{{ r.status }}</span>
+            </div>
+            {% if r.summary %}
+              <p class="mt-2 text-sm text-slate-400">{{ r.summary }}</p>
+            {% endif %}
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% else %}
+    <p class="text-slate-500 text-sm">No open reviews.</p>
+  {% endfor %}
+</section>
+
+{% if resolved_reviews %}
+  <section class="mt-10">
+    <h2 class="text-lg font-semibold mb-3">Resolved
+      <span class="text-sm font-normal text-slate-500">({{ resolved_reviews|length }})</span>
+    </h2>
+    <ul class="space-y-3">
+      {% for r in resolved_reviews %}
+        <li class="rounded-xl border border-slate-800 bg-slate-900/50 p-4">
+          <div class="flex items-center gap-2 flex-wrap">
+            <code class="text-xs text-slate-500">{{ r.id }}</code>
+            <span class="font-semibold">{{ r.area }}</span>
+            <span class="ml-auto text-[10px] uppercase rounded px-2 py-0.5 shrink-0 bg-emerald-900 text-emerald-300">{{ r.status }}</span>
+          </div>
+          {% if r.summary %}
+            <p class="mt-2 text-sm text-slate-400">{{ r.summary }}</p>
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+{% endif %}
+
+<section class="mt-10 rounded-xl border border-dashed border-slate-700 p-6 text-center">
+  <h2 class="font-semibold">Want to post a review?</h2>
+  <p class="text-sm text-slate-400 mt-1 max-w-md mx-auto">
+    Posting a review from the dashboard — an owner-auth form that appends a
+    <code>REV-NNNN</code> entry — arrives in Phase 2. For now the owner edits
+    <code>docs/owner/review-inbox.md</code> directly (via the GitHub app), or opens
+    an issue on GitHub.
+  </p>
+  <a
+    href="https://github.com/menno420/superbot/blob/main/docs/owner/review-inbox.md"
+    class="inline-block mt-3 rounded bg-sky-600 hover:bg-sky-500 px-4 py-2 text-sm font-medium"
+  >Open the review inbox</a>
+</section>
+{% endblock %}

--- a/docs/owner/review-inbox.md
+++ b/docs/owner/review-inbox.md
@@ -1,0 +1,49 @@
+# Review inbox — owner reviews of cogs, commands, and ideas
+
+> **Status:** `living-ledger` — the durable intake for the owner's **reviews**:
+> "change X about this cog", "this command should do Y", or a fresh idea worth
+> acting on (decision **Q-0169**, 2026-06-17;
+> [plan](../planning/owner-review-inbox-plan-2026-06-17.md)). It is the owner↔agent
+> review channel: a remembered review lands here so it does not evaporate, and
+> "is it fixed?" is answerable at a glance via the **OPEN → RESOLVED** status.
+> **Convention:** one numbered entry per review, newest first. Mirrors the bug-book
+> shape so the same intake instincts apply — but a review is a *requested change /
+> improvement*, not a production bug.
+
+## What this is (and what Phase 1 ships)
+
+This file is the **single source of truth** for owner reviews. The dashboard's
+read-only `/reviews` page (Phase 1) is a **read view** over it: `scripts/export_dashboard_data.py`
+parses each `## REV-NNNN` section into the dashboard payload, and the page renders
+open vs. resolved items grouped by area. There is **no write side yet** — the owner
+edits this file directly (via the GitHub app), and a new review shows up on the
+dashboard within a merge (the `dashboard-data-refresh.yml` workflow regenerates the
+JSON on `docs/**` changes).
+
+Phase 1 is deliberately zero-infrastructure: no API token, no auth, no form. The
+post-from-the-dashboard form (Phase 2) and public submissions (Phase 3) are owner-paced
+and share the control-API write side the live editors use — see the plan.
+
+## Agent intake — how to act on a review
+
+Treat an **OPEN** review like a bug-book entry (a bugs-first cousin): a requested
+change waiting to be made. When you address one in a PR, flip its status line to
+`RESOLVED (#PR)` in the **same** PR that closes it, so the dashboard shows it
+resolved within a merge. Keep the entry — the resolved history is the point.
+
+## Convention — entry shape
+
+```
+## REV-NNNN — <area> — STATUS
+
+- **Review (owner):** <the requested change / improvement, verbatim where possible>
+- **Area:** <cog / command / subsystem / idea>
+- **Resolution:** <filled at resolve time — what changed, the fix PR>
+```
+
+`STATUS` is `OPEN` or `RESOLVED` (a trailing `(#PR)` is fine — the parser reads the
+first word). `<area>` is the cog/command/idea the review is about; it groups the
+dashboard view.
+
+<!-- No reviews recorded yet. The owner adds the first REV-NNNN entry here (via the
+GitHub app or a session); until then /reviews renders its empty state. -->

--- a/scripts/export_dashboard_data.py
+++ b/scripts/export_dashboard_data.py
@@ -12,6 +12,7 @@ Sources (all read-only, never imported):
 * Bot-function catalogue  <- ``disbot/utils/subsystem_registry.py`` (AST-parsed)
 * Ideas                   <- ``docs/ideas/*.md`` (title + Status badge + date)
 * Bugs                    <- ``docs/health/bug-book.md`` (``## BUG-NNNN ...``)
+* Reviews                 <- ``docs/owner/review-inbox.md`` (``## REV-NNNN — area — STATUS``)
 * Updates feed            <- ``.sessions/*.md`` (date + title + Status badge)
 * Env-var usage map       <- ``disbot/**/*.py`` via ``scripts/scan_env_usage.py``
                              (names + code locations only — never a value)
@@ -103,6 +104,11 @@ _STATUS_RE = re.compile(
 # Bug headings use em/en-dash separators: ``## BUG-0014 — title — STATUS``.
 _BUG_HEAD_RE = re.compile(r"^##\s+(BUG-\d+)\s*[—–]\s*(.+?)\s*$")
 _BUG_STATUS_RE = re.compile(r"[—–]\s*([A-Za-z][A-Za-z ]*)\s*$")
+# Review-inbox headings: ``## REV-0001 — <area> — STATUS`` (area in the middle,
+# status last). The bracketed body is split on the *last* dash for the status,
+# leaving everything before it as the area (so a hyphenated area survives).
+_REVIEW_HEAD_RE = re.compile(r"^##\s+(REV-\d+)\s*[—–]\s*(.+?)\s*$")
+_REVIEW_STATUS_RE = re.compile(r"[—–]\s*([A-Za-z][A-Za-z ]*?)(?:\s*\([^)]*\))?\s*$")
 
 
 def _truncate(text: str, limit: int) -> str:
@@ -319,6 +325,59 @@ def _bug_summary(lines: list[str], start: int) -> str:
     return _truncate(_strip_md(" ".join(collected)), 280)
 
 
+def parse_reviews(text: str) -> list[dict]:
+    """Parse the review-inbox markdown into id/area/status/summary records.
+
+    Mirrors :func:`parse_bugs` but for the owner-review-inbox shape
+    ``## REV-NNNN — <area> — STATUS`` (decision Q-0169): the bracketed body is
+    split on the *last* dash so a hyphenated area survives, the status is
+    normalised to ``OPEN`` / ``RESOLVED`` (everything else passes through
+    verbatim), and the summary is the ``- **Review (owner):**`` bullet beneath
+    the heading. The page groups by area and shows open vs. resolved.
+    """
+    reviews: list[dict] = []
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        head = _REVIEW_HEAD_RE.match(line)
+        if not head:
+            continue
+        review_id, rest = head.group(1), head.group(2)
+        status = "unknown"
+        status_match = _REVIEW_STATUS_RE.search(rest)
+        if status_match and len(status_match.group(1).strip()) <= 24:
+            status = status_match.group(1).strip()
+            rest = rest[: status_match.start()].rstrip()
+        reviews.append(
+            {
+                "id": review_id,
+                "area": _strip_md(rest) or "general",
+                "status": status,
+                "summary": _review_summary(lines, index),
+            },
+        )
+    return reviews
+
+
+def _review_summary(lines: list[str], start: int) -> str:
+    """Return the 'Review (owner)' bullet beneath a review heading, truncated."""
+    collected: list[str] = []
+    capturing = False
+    for line in lines[start + 1 : start + 60]:
+        if line.startswith("## "):
+            break
+        stripped = line.strip()
+        if not capturing:
+            if stripped.lower().startswith("- **review"):
+                cleaned = re.sub(r"^- \*\*review[^:]*:\*\*", "", stripped, flags=re.I)
+                collected.append(cleaned)
+                capturing = True
+            continue
+        if not stripped or stripped.startswith("- **"):
+            break
+        collected.append(stripped)
+    return _truncate(_strip_md(" ".join(collected)), 280)
+
+
 def parse_updates(sessions_dir: Path, limit: int = 60) -> list[dict]:
     """Parse ``.sessions/*.md`` logs into a newest-first updates feed."""
     updates: list[dict] = []
@@ -381,6 +440,7 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
     registry = repo_root / "disbot" / "utils" / "subsystem_registry.py"
     ideas_dir = repo_root / "docs" / "ideas"
     bug_book = repo_root / "docs" / "health" / "bug-book.md"
+    review_inbox = repo_root / "docs" / "owner" / "review-inbox.md"
     sessions_dir = repo_root / ".sessions"
 
     catalogue = (
@@ -390,6 +450,11 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
     )
     ideas = parse_ideas(ideas_dir) if ideas_dir.is_dir() else []
     bugs = parse_bugs(bug_book.read_text(encoding="utf-8")) if bug_book.exists() else []
+    reviews = (
+        parse_reviews(review_inbox.read_text(encoding="utf-8"))
+        if review_inbox.exists()
+        else []
+    )
     updates = parse_updates(sessions_dir) if sessions_dir.is_dir() else []
 
     scan_root = repo_root / "disbot"
@@ -454,6 +519,10 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
                 "functions": len(catalogue),
                 "ideas": len(ideas),
                 "bugs": len(bugs),
+                "reviews": len(reviews),
+                "reviews_open": sum(
+                    1 for r in reviews if r["status"].upper() == "OPEN"
+                ),
                 "updates": len(updates),
                 "env_vars": len(env_usage),
                 "cogs": sum(1 for c in cogs if c.get("is_cog")),
@@ -468,6 +537,7 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
         "catalogue": catalogue,
         "ideas": ideas,
         "bugs": bugs,
+        "reviews": reviews,
         "updates": updates,
         "env_usage": env_usage,
         "cogs": cogs,

--- a/tests/unit/dashboard/test_reviews_page.py
+++ b/tests/unit/dashboard/test_reviews_page.py
@@ -1,0 +1,75 @@
+"""Smoke test for the read-only ``/reviews`` dashboard page (B7, Phase 1).
+
+A new test file (the shared ``test_app.py`` page list is owned by another unit).
+Skipped automatically when the dashboard's web dependencies are not installed
+(CI installs only the bot's ``requirements.txt``), so this never reddens the main
+code-quality job; the dashboard-ci workflow installs fastapi/httpx and runs it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")  # Starlette's TestClient transport
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_APP = _REPO_ROOT / "dashboard" / "app.py"
+
+if str(_APP.parent) not in sys.path:
+    sys.path.insert(0, str(_APP.parent))
+
+
+@pytest.fixture(scope="module")
+def app_module():
+    spec = importlib.util.spec_from_file_location("dashboard_app_reviews_ut", _APP)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def client(app_module):
+    return TestClient(app_module.app)
+
+
+def test_reviews_page_renders(client):
+    resp = client.get("/reviews")
+    assert resp.status_code == 200
+    assert "Review inbox" in resp.text
+
+
+def test_reviews_page_renders_with_empty_data(client, app_module, monkeypatch):
+    # A missing/empty payload must degrade to the empty state, never 500.
+    monkeypatch.setattr(app_module, "load_data", lambda: dict(app_module._EMPTY))
+    resp = client.get("/reviews")
+    assert resp.status_code == 200
+    assert "No open reviews." in resp.text
+
+
+def test_reviews_page_groups_open_and_resolved(client, app_module, monkeypatch):
+    payload = dict(app_module._EMPTY)
+    payload["meta"] = {"generated_at": "", "counts": {"reviews": 2, "reviews_open": 1}}
+    payload["reviews"] = [
+        {"id": "REV-0002", "area": "economy", "status": "OPEN", "summary": "scale it"},
+        {
+            "id": "REV-0001",
+            "area": "help",
+            "status": "RESOLVED",
+            "summary": "fixed wrap",
+        },
+    ]
+    monkeypatch.setattr(app_module, "load_data", lambda: payload)
+    resp = client.get("/reviews")
+    assert resp.status_code == 200
+    assert "REV-0002" in resp.text  # open
+    assert "REV-0001" in resp.text  # resolved
+    assert "Resolved" in resp.text

--- a/tests/unit/scripts/test_export_review_inbox.py
+++ b/tests/unit/scripts/test_export_review_inbox.py
@@ -1,0 +1,86 @@
+"""Tests for the owner-review-inbox parser in ``export_dashboard_data.py`` (B7).
+
+Loaded via ``importlib`` (the repo convention for ``scripts/`` modules, which are
+not a package). The exporter is pure stdlib, so this runs in CI with no extra
+dependencies. Mirrors ``test_export_dashboard_data.py``'s bug-book parser test —
+the review parser is its Q-0169 cousin (``## REV-NNNN — area — STATUS``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "export_dashboard_data.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("export_review_inbox_ut", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+SAMPLE_REVIEWS = """# Review inbox
+
+## REV-0002 — economy-cog — OPEN
+
+- **Review (owner):** the daily payout should scale with streak length.
+- **Area:** economy cog
+
+## REV-0001 — help command — RESOLVED (#1234)
+
+- **Review (owner):** the help embed wraps badly on mobile.
+- **Resolution:** rewrapped the embed in PR #1234.
+"""
+
+
+def test_parse_reviews_extracts_id_area_status_summary(mod):
+    reviews = mod.parse_reviews(SAMPLE_REVIEWS)
+    assert [r["id"] for r in reviews] == ["REV-0002", "REV-0001"]
+    assert reviews[0]["status"] == "OPEN"
+    assert reviews[0]["area"] == "economy-cog"
+    assert "scale with streak length" in reviews[0]["summary"]
+
+
+def test_parse_reviews_strips_pr_tag_from_resolved_status(mod):
+    reviews = mod.parse_reviews(SAMPLE_REVIEWS)
+    resolved = reviews[1]
+    # The trailing "(#1234)" must not bleed into the status token.
+    assert resolved["status"] == "RESOLVED"
+    assert resolved["area"] == "help command"
+    assert "wraps badly on mobile" in resolved["summary"]
+
+
+def test_parse_reviews_handles_text_without_entries(mod):
+    assert mod.parse_reviews("# Review inbox\n\nNo reviews yet.\n") == []
+
+
+def test_parse_reviews_hyphenated_area_survives(mod):
+    # Only the *last* dash delimits the status, so a hyphenated area is preserved.
+    text = "## REV-0003 — blackjack-game-state — OPEN\n\n- **Review (owner):** x\n"
+    reviews = mod.parse_reviews(text)
+    assert len(reviews) == 1
+    assert reviews[0]["area"] == "blackjack-game-state"
+    assert reviews[0]["status"] == "OPEN"
+
+
+def test_build_data_includes_reviews_section_and_counts(mod):
+    data = mod.build_data()
+    assert "reviews" in data
+    reviews = data["reviews"]
+    assert isinstance(reviews, list)
+    assert data["meta"]["counts"]["reviews"] == len(reviews)
+    assert data["meta"]["counts"]["reviews_open"] == sum(
+        1 for r in reviews if r["status"].upper() == "OPEN"
+    )
+    for review in reviews:
+        assert set(review) >= {"id", "area", "status", "summary"}
+        assert review["id"].startswith("REV-")


### PR DESCRIPTION
Owner-review-inbox **Phase 1** — a read-only `/reviews` dashboard page.

Implements Phase 1 of `docs/planning/owner-review-inbox-plan-2026-06-17.md` (decision Q-0169): a read-only "Review board" page over a committed `docs/owner/review-inbox.md` ledger (one `## REV-NNNN — <area> — STATUS` section each, mirroring the bug-book parser). Zero infrastructure, no API token, no writes — the Phase 2 write side / control-API is Held.

What ships:
- `dashboard/app.py` — new `/reviews` route (read-only, mirrors the existing `/bugs` / `/updates` patterns).
- `dashboard/templates/reviews.html` (new) — read-only page extending `base.html`, open vs. resolved grouped, matching `updates.html` / `bugs.html` style.
- `scripts/export_dashboard_data.py` — new `reviews` block parsed from `docs/owner/review-inbox.md`, plus a `reviews` / `reviews_open` count in `meta.counts`.
- `docs/owner/review-inbox.md` (new) — the committed ledger + what Phase 1 ships.
- New test file `tests/unit/scripts/test_export_review_inbox.py` (parser unit tests; the existing shared test files are owned by other units).

Fleet run — `docs/planning/ultracode-fleet-plan-2026-06-19.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJsGDUHJ16So4DpCUPsLsm

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJsGDUHJ16So4DpCUPsLsm)_