### PR TITLE
A3: blackjack state/persistence → services/

### DIFF
--- a/.sessions/2026-06-19-fleet-a3-blackjack-state.md
+++ b/.sessions/2026-06-19-fleet-a3-blackjack-state.md
@@ -1,5 +1,39 @@
-# 2026-06-19 — Fleet A3: move blackjack state/persistence into services/
+# 2026-06-19 — Fleet A3: move blackjack state/persistence into services/, break the actions↔_state cycle
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-About to: move blackjack `_state`/`_persistence` into `services/`, redirect view imports, resolve the intra-cog `actions`↔`_state` / cogs↔views import cycle, behavior-preserving.
+## Arc
+
+Lane A unit **A3** of the [ultracode fleet brief](../docs/planning/ultracode-fleet-plan-2026-06-19.md) —
+architecture boundary-debt burndown (ungated). move blackjack state/persistence into services/, break the actions↔_state cycle.
+
+## Shipped (#1092)
+
+- `cogs/blackjack/_state.py` → **`services/blackjack_state.py`**, `cogs/blackjack/_persistence.py` → **`services/blackjack_persistence.py`**.
+- Repointed `views/blackjack/*` imports to the new `services.` locations (clears `views→cogs.blackjack._state/_persistence`); cog keeps back-compat re-exports so patch sites stay valid.
+- Resolves the intra-package `cogs.blackjack ↔ views.blackjack` import cycle.
+
+Verified: `check_architecture --mode strict` exit 0 · `check_quality --check-only` clean ·
+`pytest --collect-only` 10748 tests import-clean · targeted-domain tests pass.
+
+> Completed by the fleet orchestrator after a mid-run container restart killed the per-unit
+> agent before it flipped its card; the agent's implementation was intact in the worktree.
+
+## 📤 Run report
+
+- **Did:** move blackjack state/persistence into services/, break the actions↔_state cycle (fleet A3). · **Outcome:** shipped
+- **Shipped:** #1092
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** `none`
+- **⚑ Self-initiated:** A3 — docs/planning/ultracode-fleet-plan-2026-06-19.md (ungated arch boundary-debt)
+- **↪ Next:** remaining fleet units.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (#1092, on green) |
+| CI-red rounds | 1 (born-red gate by design) |
+| New ideas contributed | 0 (fleet completion run) |
+| Ideas groomed | 0 |

--- a/.sessions/2026-06-19-fleet-a3-blackjack-state.md
+++ b/.sessions/2026-06-19-fleet-a3-blackjack-state.md
@@ -1,0 +1,5 @@
+# 2026-06-19 — Fleet A3: move blackjack state/persistence into services/
+
+> **Status:** `in-progress`
+
+About to: move blackjack `_state`/`_persistence` into `services/`, redirect view imports, resolve the intra-cog `actions`↔`_state` / cogs↔views import cycle, behavior-preserving.

--- a/disbot/cogs/blackjack/_persistence.py
+++ b/disbot/cogs/blackjack/_persistence.py
@@ -1,178 +1,48 @@
-"""Blackjack persistence helpers (S4.5).
+"""Blackjack persistence — back-compat re-export shim (fleet unit A3).
 
-Each helper here corresponds to one of the three blackjack subsystems
-(solo / pvp / tournament).  All writes go through
-``services.game_state_service``, which is the single mutation surface
-for game_state rows (per the layer rules in docs/ownership.md).
+The canonical home is now :mod:`services.blackjack_persistence`.  This
+module re-exports the leaf helpers and keeps a ``game_state_service``
+attribute so the existing test suite — which patches
+``cogs.blackjack._persistence.game_state_service.save`` /
+``…game_state_service.clear`` (a method on the shared ``game_state_service``
+module) and ``cogs.blackjack._persistence._save_solo_game`` /
+``…_save_pvp_match`` (the leaf functions the dispatcher below looks up) —
+keeps working without changes.
 
-The pre-extraction layout had these in ``cogs/blackjack_cog.py``; this
-module is a pure relocation.  Test patches that previously targeted
-``cogs.blackjack_cog.game_state_service.X`` should now target
-``cogs.blackjack._persistence.game_state_service.X`` — the function
-looks up ``game_state_service`` in its own module's namespace, so
-that's where the patch must apply.
+``_save_game_state`` is re-defined here (rather than re-exported) so it
+resolves ``_save_solo_game`` / ``_save_pvp_match`` / ``_is_solo_game`` in
+*this* module's namespace.  That keeps the routing test
+(``patch('cogs.blackjack._persistence._save_solo_game')``) effective for
+the cog's call path; the ``services.blackjack_persistence`` copy is the
+one the view layer uses.  Both dispatchers are behaviorally identical.
+
+New code should import directly from :mod:`services.blackjack_persistence`.
 """
 
 from __future__ import annotations
 
-import logging
-
-from cogs.blackjack._state import (
-    BLACKJACK_PVP_SUBSYSTEM,
-    BLACKJACK_PVP_VERSION,
-    BLACKJACK_SOLO_SUBSYSTEM,
-    BLACKJACK_SOLO_VERSION,
-    BLACKJACK_TOURNAMENT_SUBSYSTEM,
-    BLACKJACK_TOURNAMENT_VERSION,
-    _active,
-    _Game,
-    _PvPState,
+from services import game_state_service  # noqa: F401 — back-compat patch target
+from services.blackjack_persistence import (  # noqa: F401 — re-exported
+    _clear_pvp_match,
+    _clear_solo_game,
+    _clear_tournament_entry,
+    _is_solo_game,
+    _pvp_canonical_user_id,
+    _save_pvp_match,
+    _save_solo_game,
+    _save_tournament_entry,
+    _serialize_pvp_hand,
 )
-from services import game_state_service
-
-logger = logging.getLogger("bot")
-
-
-def _is_solo_game(game: _Game) -> bool:
-    return game.pvp_peer_id is None and game.tournament_chips is None
-
-
-# ---------------------------------------------------------------------------
-# Solo
-# ---------------------------------------------------------------------------
-
-
-async def _save_solo_game(game: _Game) -> None:
-    """Save the in-progress solo blackjack hand to game_state.
-
-    Skips non-solo games (PvP / tournament have their own subsystems).
-    Failures are logged WARN but never block gameplay — the in-memory
-    ``_active`` dict is authoritative while the bot is alive.
-    """
-    if not _is_solo_game(game):
-        return
-    if game.channel_id is None:
-        return
-    try:
-        await game_state_service.save(
-            guild_id=game.guild_id,
-            user_id=game.user_id,
-            channel_id=game.channel_id,
-            subsystem=BLACKJACK_SOLO_SUBSYSTEM,
-            state={
-                "bet": game.bet,
-                "doubled": game.doubled,
-                "deck": list(game.deck),
-                "player": list(game.player),
-                "dealer": list(game.dealer),
-            },
-            version=BLACKJACK_SOLO_VERSION,
-        )
-    except Exception as exc:
-        logger.warning("blackjack_solo save failed: %s", exc)
-
-
-async def _clear_solo_game(game: _Game) -> None:
-    """Drop the persisted solo row when the game ends or times out."""
-    if not _is_solo_game(game):
-        return
-    if game.channel_id is None:
-        return
-    try:
-        await game_state_service.clear(
-            guild_id=game.guild_id,
-            user_id=game.user_id,
-            channel_id=game.channel_id,
-            subsystem=BLACKJACK_SOLO_SUBSYSTEM,
-        )
-    except Exception as exc:
-        logger.warning("blackjack_solo clear failed: %s", exc)
-
-
-# ---------------------------------------------------------------------------
-# PvP
-# ---------------------------------------------------------------------------
-
-
-def _pvp_canonical_user_id(p1_id: int, p2_id: int) -> int:
-    """Single canonical user id used as the natural-key surrogate for
-    a PvP match.  Matches the convention from PR G1 (RPS PvP) so the
-    JSONB convention "smaller id wins the slot" is consistent across
-    paired-state subsystems.
-    """
-    return min(p1_id, p2_id)
-
-
-def _serialize_pvp_hand(game: _Game | None) -> dict | None:
-    """Compact JSON-safe snapshot of one player's hand, or None if the
-    player has already been popped from ``_active`` (i.e. they
-    finished and the other player is still playing).
-    """
-    if game is None:
-        return None
-    return {
-        "bet": game.bet,
-        "doubled": game.doubled,
-        "deck": list(game.deck),
-        "player": list(game.player),
-        "dealer": list(game.dealer),
-    }
-
-
-async def _save_pvp_match(state: _PvPState) -> None:
-    """Best-effort persist of a PvP match's full state."""
-    if state.channel_id is None:
-        return
-    p1_game = _active.get((state.p1, state.guild_id))
-    p2_game = _active.get((state.p2, state.guild_id))
-    try:
-        await game_state_service.save(
-            guild_id=state.guild_id,
-            user_id=_pvp_canonical_user_id(state.p1, state.p2),
-            channel_id=state.channel_id,
-            subsystem=BLACKJACK_PVP_SUBSYSTEM,
-            state={
-                "p1_id": state.p1,
-                "p2_id": state.p2,
-                "bet": state.bet,
-                # JSON-safe int keys.
-                "results": {str(uid): v for uid, v in state.results.items()},
-                "p1_game": _serialize_pvp_hand(p1_game),
-                "p2_game": _serialize_pvp_hand(p2_game),
-            },
-            version=BLACKJACK_PVP_VERSION,
-        )
-    except Exception as exc:
-        logger.warning("blackjack_pvp save failed: %s", exc)
-
-
-async def _clear_pvp_match(state: _PvPState) -> None:
-    """Best-effort game_state delete for a finished PvP match."""
-    if state.channel_id is None:
-        return
-    try:
-        await game_state_service.clear(
-            guild_id=state.guild_id,
-            user_id=_pvp_canonical_user_id(state.p1, state.p2),
-            channel_id=state.channel_id,
-            subsystem=BLACKJACK_PVP_SUBSYSTEM,
-        )
-    except Exception as exc:
-        logger.warning("blackjack_pvp clear failed: %s", exc)
-
-
-# ---------------------------------------------------------------------------
-# Mode-dispatching wrapper (called by views)
-# ---------------------------------------------------------------------------
+from services.blackjack_state import _Game
 
 
 async def _save_game_state(game: _Game) -> None:
     """Dispatch a save to the right subsystem helper based on game type.
 
-    Solo, PvP, and tournament games run through the same
-    ``BlackjackView`` so the call sites in ``hit_btn`` / ``double_btn``
-    don't know which subsystem to write.  This dispatcher keeps the
-    view code agnostic.
+    Re-defined here (vs. re-exported) so the ``_save_solo_game`` /
+    ``_save_pvp_match`` lookups hit *this* module's namespace — that
+    keeps ``patch('cogs.blackjack._persistence._save_solo_game')`` (the
+    routing test) effective for the cog's call path.
     """
     if game.pvp_state is not None:
         await _save_pvp_match(game.pvp_state)
@@ -185,59 +55,16 @@ async def _save_game_state(game: _Game) -> None:
     # but the entry fee does.
 
 
-# ---------------------------------------------------------------------------
-# Tournament
-# ---------------------------------------------------------------------------
-
-
-async def _save_tournament_entry(
-    *,
-    guild_id: int,
-    user_id: int,
-    channel_id: int,
-    entry_fee: int,
-    rounds: int,
-) -> None:
-    """Persist the post-deduct_fees state for one tournament player."""
-    try:
-        await game_state_service.save(
-            guild_id=guild_id,
-            user_id=user_id,
-            channel_id=channel_id,
-            subsystem=BLACKJACK_TOURNAMENT_SUBSYSTEM,
-            state={
-                "bet": entry_fee,  # GC sweep refund convention
-                "rounds": rounds,
-            },
-            version=BLACKJACK_TOURNAMENT_VERSION,
-        )
-    except Exception as exc:
-        logger.warning(
-            "blackjack_tournament save failed (user=%d guild=%d): %s",
-            user_id,
-            guild_id,
-            exc,
-        )
-
-
-async def _clear_tournament_entry(
-    *,
-    guild_id: int,
-    user_id: int,
-    channel_id: int,
-) -> None:
-    """Drop a tournament player's persisted entry after natural completion."""
-    try:
-        await game_state_service.clear(
-            guild_id=guild_id,
-            user_id=user_id,
-            channel_id=channel_id,
-            subsystem=BLACKJACK_TOURNAMENT_SUBSYSTEM,
-        )
-    except Exception as exc:
-        logger.warning(
-            "blackjack_tournament clear failed (user=%d guild=%d): %s",
-            user_id,
-            guild_id,
-            exc,
-        )
+__all__ = [
+    "_clear_pvp_match",
+    "_clear_solo_game",
+    "_clear_tournament_entry",
+    "_is_solo_game",
+    "_pvp_canonical_user_id",
+    "_save_game_state",
+    "_save_pvp_match",
+    "_save_solo_game",
+    "_save_tournament_entry",
+    "_serialize_pvp_hand",
+    "game_state_service",
+]

--- a/disbot/cogs/blackjack/_state.py
+++ b/disbot/cogs/blackjack/_state.py
@@ -1,147 +1,57 @@
-"""Blackjack state — data classes, module dicts, constants (S4.5).
+"""Blackjack state — back-compat re-export shim (fleet unit A3).
 
-Imports nothing from cogs.blackjack_cog (would create a cycle).  Imports
-from services.blackjack_engine (pure card primitives) and from
-utils.tournaments (TournamentRegistration base class).
+The canonical home is now :mod:`services.blackjack_state`.  This module
+re-exports every public name so that ``cogs.blackjack_cog`` and the test
+suite (``from cogs.blackjack._state import _active, _Game, …``) keep
+resolving to the *same objects* — re-import preserves identity, so the
+module-level state dicts (``_active`` / ``_pvp`` / ``_tournaments``) remain
+the single shared instances the cog mutates and the views read.
 
-The four data classes here are the natural-key carriers for blackjack
-state.  The three module dicts are the runtime owners:
-
-    _active        (user_id, guild_id) → _Game        (any mode)
-    _pvp           frozenset({p1,p2})  → _PvPState    (PvP match state)
-    _tournaments   guild_id            → _BjTournament (registration state)
-
-Importing this module multiple times preserves identity of the dicts —
-mutations from cog code and from views/blackjack/* both go through the
-same objects.
-
-Constants prefixed BLACKJACK_*_SUBSYSTEM / VERSION are persisted in
-game_state rows (migration 015).  Bumping them requires a migration.
+New code should import directly from :mod:`services.blackjack_state`; this
+shim exists only to avoid touching the (untouched) cog module and the
+existing tests.
 """
 
 from __future__ import annotations
 
-import discord
+from services.blackjack_state import (  # noqa: F401 — re-exported
+    BLACKJACK_PVP_ESCROW_SUBSYSTEM,
+    BLACKJACK_PVP_ESCROW_VERSION,
+    BLACKJACK_PVP_SUBSYSTEM,
+    BLACKJACK_PVP_VERSION,
+    BLACKJACK_SOLO_SUBSYSTEM,
+    BLACKJACK_SOLO_VERSION,
+    BLACKJACK_TOURNAMENT_SUBSYSTEM,
+    BLACKJACK_TOURNAMENT_VERSION,
+    FREE_WIN_COINS,
+    TOURN_BET_PER_ROUND,
+    TOURN_START_CHIPS,
+    _active,
+    _BjTournament,
+    _Game,
+    _pvp,
+    _PvPState,
+    _tournaments,
+    _TournPlayerState,
+)
 
-from services.blackjack_engine import new_deck as _new_deck
-from utils.tournaments import TournamentRegistration
-
-# ---------------------------------------------------------------------------
-# Public constants (referenced by cog, views, persistence, and tests)
-# ---------------------------------------------------------------------------
-
-FREE_WIN_COINS = 50
-TOURN_START_CHIPS = 1000
-TOURN_BET_PER_ROUND = 200
-
-BLACKJACK_SOLO_SUBSYSTEM = "blackjack_solo"
-BLACKJACK_SOLO_VERSION = 1
-
-BLACKJACK_PVP_SUBSYSTEM = "blackjack_pvp"
-BLACKJACK_PVP_VERSION = 1
-
-# P0-1 — escrow subsystem for D1 escrow-at-accept.  One ``{"bet": stake,
-# "peer": other_id}`` row per player so the existing ``bet``-keyed
-# recovery refunds each player their own stake.  Wagered money moves only
-# through ``services.game_wager_workflow``.
-BLACKJACK_PVP_ESCROW_SUBSYSTEM = "blackjack_pvp_escrow"
-BLACKJACK_PVP_ESCROW_VERSION = 1
-
-BLACKJACK_TOURNAMENT_SUBSYSTEM = "blackjack_tournament"
-BLACKJACK_TOURNAMENT_VERSION = 1
-
-
-# ---------------------------------------------------------------------------
-# Game state classes
-# ---------------------------------------------------------------------------
-
-
-class _Game:
-    def __init__(
-        self,
-        user_id: int,
-        guild_id: int,
-        bet: int,
-        tournament_chips: int | None = None,
-        *,
-        channel_id: int | None = None,
-    ):
-        self.user_id = user_id
-        self.guild_id = guild_id
-        self.bet = bet
-        self.doubled = False
-        self.tournament_chips = tournament_chips  # None = normal game
-        self.channel_id = channel_id  # PR G2 — needed for game_state persistence
-        self.deck = _new_deck()
-        self.player: list[str] = [self.deck.pop(), self.deck.pop()]
-        self.dealer: list[str] = [self.deck.pop(), self.deck.pop()]
-        # PvP linkage (set externally by _start_pvp)
-        self.pvp_peer_id: int | None = None
-        self.pvp_state: _PvPState | None = None
-
-    def hit(self) -> str:
-        card = self.deck.pop()
-        self.player.append(card)
-        return card
-
-    def dealer_play(self):
-        from services.blackjack_engine import hand_value as _hand_value
-
-        while _hand_value(self.dealer) < 17:
-            self.dealer.append(self.deck.pop())
-
-
-class _PvPState:
-    def __init__(self, p1: int, p2: int, guild_id: int, bet: int, channel_id: int):
-        self.p1 = p1
-        self.p2 = p2
-        self.guild_id = guild_id
-        self.bet = bet
-        self.channel_id = channel_id
-        self.results: dict[int, int] = {}  # user_id → final hand value (-1 = bust)
-        self.messages: dict[int, discord.Message] = {}
-
-
-class _BjTournament(TournamentRegistration):
-    def __init__(
-        self,
-        host_id: int,
-        guild_id: int,
-        announce_id: int,
-        entry_fee: int,
-        rounds: int,
-        duration_mins: int,
-    ):
-        super().__init__(host_id, guild_id, announce_id, entry_fee, duration_mins)
-        self.rounds = rounds
-        self.results: dict[int, int] = {}  # user_id → final chips
-        self.category: discord.CategoryChannel | None = None
-
-
-class _TournPlayerState:
-    def __init__(
-        self,
-        user_id: int,
-        guild_id: int,
-        rounds: int,
-        *,
-        channel_id: int | None = None,
-    ):
-        self.user_id = user_id
-        self.guild_id = guild_id
-        self.chips = TOURN_START_CHIPS
-        self.rounds_left = rounds
-        self.done = False
-        # PR G5 — recorded so ``_check_tourn_done`` can clear the
-        # persisted entry-fee row precisely without needing a list
-        # sweep at natural tournament completion.
-        self.channel_id = channel_id
-
-
-# ---------------------------------------------------------------------------
-# Runtime state dicts (mutated by both the cog and views/blackjack/*)
-# ---------------------------------------------------------------------------
-
-_active: dict[tuple[int, int], _Game] = {}  # (user_id, guild_id) → game
-_pvp: dict[frozenset, _PvPState] = {}  # frozenset({p1, p2}) → state
-_tournaments: dict[int, _BjTournament] = {}  # guild_id → tournament
+__all__ = [
+    "BLACKJACK_PVP_ESCROW_SUBSYSTEM",
+    "BLACKJACK_PVP_ESCROW_VERSION",
+    "BLACKJACK_PVP_SUBSYSTEM",
+    "BLACKJACK_PVP_VERSION",
+    "BLACKJACK_SOLO_SUBSYSTEM",
+    "BLACKJACK_SOLO_VERSION",
+    "BLACKJACK_TOURNAMENT_SUBSYSTEM",
+    "BLACKJACK_TOURNAMENT_VERSION",
+    "FREE_WIN_COINS",
+    "TOURN_BET_PER_ROUND",
+    "TOURN_START_CHIPS",
+    "_Game",
+    "_PvPState",
+    "_BjTournament",
+    "_TournPlayerState",
+    "_active",
+    "_pvp",
+    "_tournaments",
+]

--- a/disbot/cogs/blackjack/actions.py
+++ b/disbot/cogs/blackjack/actions.py
@@ -30,8 +30,11 @@ from dataclasses import dataclass
 import discord
 from discord.ext import commands
 
-from cogs.blackjack._persistence import _save_game_state
-from cogs.blackjack._state import (
+from core.runtime import tasks
+from services import economy_service, tournament_state_service
+from services.blackjack_engine import is_blackjack as _is_blackjack
+from services.blackjack_persistence import _save_game_state
+from services.blackjack_state import (
     FREE_WIN_COINS,
     _active,
     _BjTournament,
@@ -39,9 +42,6 @@ from cogs.blackjack._state import (
     _pvp,
     _tournaments,
 )
-from core.runtime import tasks
-from services import economy_service, tournament_state_service
-from services.blackjack_engine import is_blackjack as _is_blackjack
 from utils import db
 from utils.ui_constants import ECONOMY_COLOR, SUCCESS_COLOR
 from views.blackjack.embeds import _game_embed, _tourn_embed

--- a/disbot/services/blackjack_persistence.py
+++ b/disbot/services/blackjack_persistence.py
@@ -1,0 +1,248 @@
+"""Blackjack persistence helpers.
+
+Canonical home (fleet unit A3) for the blackjack game_state writers and
+clearers.  Moved out of ``cogs/blackjack/_persistence.py`` so the
+``views/blackjack/*`` layer imports persistence from ``services`` (a legal
+dependency) instead of reaching into the cog package.
+
+Each helper here corresponds to one of the three blackjack subsystems
+(solo / pvp / tournament).  All writes go through
+``services.game_state_service``, which is the single mutation surface for
+game_state rows (per the layer rules in docs/ownership.md).
+
+``cogs.blackjack._persistence`` remains a thin compatibility module that
+re-exports these helpers and keeps a ``game_state_service`` attribute, so
+existing test patches (``patch('cogs.blackjack._persistence.game_state_service.X')``
+— which replace a method on the shared ``game_state_service`` module —
+and ``patch('cogs.blackjack._persistence._save_solo_game')`` for the cog's
+own dispatcher) keep working unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from services import game_state_service
+from services.blackjack_state import (
+    BLACKJACK_PVP_SUBSYSTEM,
+    BLACKJACK_PVP_VERSION,
+    BLACKJACK_SOLO_SUBSYSTEM,
+    BLACKJACK_SOLO_VERSION,
+    BLACKJACK_TOURNAMENT_SUBSYSTEM,
+    BLACKJACK_TOURNAMENT_VERSION,
+    _active,
+    _Game,
+    _PvPState,
+)
+
+logger = logging.getLogger("bot")
+
+
+def _is_solo_game(game: _Game) -> bool:
+    return game.pvp_peer_id is None and game.tournament_chips is None
+
+
+# ---------------------------------------------------------------------------
+# Solo
+# ---------------------------------------------------------------------------
+
+
+async def _save_solo_game(game: _Game) -> None:
+    """Save the in-progress solo blackjack hand to game_state.
+
+    Skips non-solo games (PvP / tournament have their own subsystems).
+    Failures are logged WARN but never block gameplay — the in-memory
+    ``_active`` dict is authoritative while the bot is alive.
+    """
+    if not _is_solo_game(game):
+        return
+    if game.channel_id is None:
+        return
+    try:
+        await game_state_service.save(
+            guild_id=game.guild_id,
+            user_id=game.user_id,
+            channel_id=game.channel_id,
+            subsystem=BLACKJACK_SOLO_SUBSYSTEM,
+            state={
+                "bet": game.bet,
+                "doubled": game.doubled,
+                "deck": list(game.deck),
+                "player": list(game.player),
+                "dealer": list(game.dealer),
+            },
+            version=BLACKJACK_SOLO_VERSION,
+        )
+    except Exception as exc:
+        logger.warning("blackjack_solo save failed: %s", exc)
+
+
+async def _clear_solo_game(game: _Game) -> None:
+    """Drop the persisted solo row when the game ends or times out."""
+    if not _is_solo_game(game):
+        return
+    if game.channel_id is None:
+        return
+    try:
+        await game_state_service.clear(
+            guild_id=game.guild_id,
+            user_id=game.user_id,
+            channel_id=game.channel_id,
+            subsystem=BLACKJACK_SOLO_SUBSYSTEM,
+        )
+    except Exception as exc:
+        logger.warning("blackjack_solo clear failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# PvP
+# ---------------------------------------------------------------------------
+
+
+def _pvp_canonical_user_id(p1_id: int, p2_id: int) -> int:
+    """Single canonical user id used as the natural-key surrogate for
+    a PvP match.  Matches the convention from PR G1 (RPS PvP) so the
+    JSONB convention "smaller id wins the slot" is consistent across
+    paired-state subsystems.
+    """
+    return min(p1_id, p2_id)
+
+
+def _serialize_pvp_hand(game: _Game | None) -> dict | None:
+    """Compact JSON-safe snapshot of one player's hand, or None if the
+    player has already been popped from ``_active`` (i.e. they
+    finished and the other player is still playing).
+    """
+    if game is None:
+        return None
+    return {
+        "bet": game.bet,
+        "doubled": game.doubled,
+        "deck": list(game.deck),
+        "player": list(game.player),
+        "dealer": list(game.dealer),
+    }
+
+
+async def _save_pvp_match(state: _PvPState) -> None:
+    """Best-effort persist of a PvP match's full state."""
+    if state.channel_id is None:
+        return
+    p1_game = _active.get((state.p1, state.guild_id))
+    p2_game = _active.get((state.p2, state.guild_id))
+    try:
+        await game_state_service.save(
+            guild_id=state.guild_id,
+            user_id=_pvp_canonical_user_id(state.p1, state.p2),
+            channel_id=state.channel_id,
+            subsystem=BLACKJACK_PVP_SUBSYSTEM,
+            state={
+                "p1_id": state.p1,
+                "p2_id": state.p2,
+                "bet": state.bet,
+                # JSON-safe int keys.
+                "results": {str(uid): v for uid, v in state.results.items()},
+                "p1_game": _serialize_pvp_hand(p1_game),
+                "p2_game": _serialize_pvp_hand(p2_game),
+            },
+            version=BLACKJACK_PVP_VERSION,
+        )
+    except Exception as exc:
+        logger.warning("blackjack_pvp save failed: %s", exc)
+
+
+async def _clear_pvp_match(state: _PvPState) -> None:
+    """Best-effort game_state delete for a finished PvP match."""
+    if state.channel_id is None:
+        return
+    try:
+        await game_state_service.clear(
+            guild_id=state.guild_id,
+            user_id=_pvp_canonical_user_id(state.p1, state.p2),
+            channel_id=state.channel_id,
+            subsystem=BLACKJACK_PVP_SUBSYSTEM,
+        )
+    except Exception as exc:
+        logger.warning("blackjack_pvp clear failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Mode-dispatching wrapper (called by views)
+# ---------------------------------------------------------------------------
+
+
+async def _save_game_state(game: _Game) -> None:
+    """Dispatch a save to the right subsystem helper based on game type.
+
+    Solo, PvP, and tournament games run through the same
+    ``BlackjackView`` so the call sites in ``hit_btn`` / ``double_btn``
+    don't know which subsystem to write.  This dispatcher keeps the
+    view code agnostic.
+    """
+    if game.pvp_state is not None:
+        await _save_pvp_match(game.pvp_state)
+    elif _is_solo_game(game):
+        await _save_solo_game(game)
+    # Tournament games carry their own per-player rows persisted by
+    # ``_save_tournament_entry`` at launch time; per-hand state inside
+    # a tournament round is intentionally NOT persisted — recovery is
+    # cancel-and-refund (Option 2), so cards in flight don't matter
+    # but the entry fee does.
+
+
+# ---------------------------------------------------------------------------
+# Tournament
+# ---------------------------------------------------------------------------
+
+
+async def _save_tournament_entry(
+    *,
+    guild_id: int,
+    user_id: int,
+    channel_id: int,
+    entry_fee: int,
+    rounds: int,
+) -> None:
+    """Persist the post-deduct_fees state for one tournament player."""
+    try:
+        await game_state_service.save(
+            guild_id=guild_id,
+            user_id=user_id,
+            channel_id=channel_id,
+            subsystem=BLACKJACK_TOURNAMENT_SUBSYSTEM,
+            state={
+                "bet": entry_fee,  # GC sweep refund convention
+                "rounds": rounds,
+            },
+            version=BLACKJACK_TOURNAMENT_VERSION,
+        )
+    except Exception as exc:
+        logger.warning(
+            "blackjack_tournament save failed (user=%d guild=%d): %s",
+            user_id,
+            guild_id,
+            exc,
+        )
+
+
+async def _clear_tournament_entry(
+    *,
+    guild_id: int,
+    user_id: int,
+    channel_id: int,
+) -> None:
+    """Drop a tournament player's persisted entry after natural completion."""
+    try:
+        await game_state_service.clear(
+            guild_id=guild_id,
+            user_id=user_id,
+            channel_id=channel_id,
+            subsystem=BLACKJACK_TOURNAMENT_SUBSYSTEM,
+        )
+    except Exception as exc:
+        logger.warning(
+            "blackjack_tournament clear failed (user=%d guild=%d): %s",
+            user_id,
+            guild_id,
+            exc,
+        )

--- a/disbot/services/blackjack_state.py
+++ b/disbot/services/blackjack_state.py
@@ -1,0 +1,158 @@
+"""Blackjack state — data classes, module dicts, constants.
+
+Canonical home (fleet unit A3) for the blackjack runtime state that the
+cog uses, the views import, and the persistence helpers read.  Moved out
+of ``cogs/blackjack/_state.py`` so the ``views/blackjack/*`` layer imports
+its game state from ``services`` (a legal dependency) instead of reaching
+into the cog package — which broke the ``cogs.blackjack ↔ views.blackjack``
+import cycle.
+
+``cogs.blackjack._state`` is now a thin re-export shim of this module, so
+``cogs.blackjack_cog`` and tests that ``from cogs.blackjack._state import
+…`` keep resolving to the *same objects* (module dicts preserve identity
+under re-import).
+
+Imports only ``services.blackjack_engine`` (pure card primitives) and
+``utils.tournaments`` (TournamentRegistration base class) — no cog imports.
+
+The four data classes here are the natural-key carriers for blackjack
+state.  The three module dicts are the runtime owners:
+
+    _active        (user_id, guild_id) → _Game        (any mode)
+    _pvp           frozenset({p1,p2})  → _PvPState    (PvP match state)
+    _tournaments   guild_id            → _BjTournament (registration state)
+
+Importing this module multiple times preserves identity of the dicts —
+mutations from cog code and from views/blackjack/* both go through the
+same objects.
+
+Constants prefixed BLACKJACK_*_SUBSYSTEM / VERSION are persisted in
+game_state rows (migration 015).  Bumping them requires a migration.
+"""
+
+from __future__ import annotations
+
+import discord
+
+from services.blackjack_engine import new_deck as _new_deck
+from utils.tournaments import TournamentRegistration
+
+# ---------------------------------------------------------------------------
+# Public constants (referenced by cog, views, persistence, and tests)
+# ---------------------------------------------------------------------------
+
+FREE_WIN_COINS = 50
+TOURN_START_CHIPS = 1000
+TOURN_BET_PER_ROUND = 200
+
+BLACKJACK_SOLO_SUBSYSTEM = "blackjack_solo"
+BLACKJACK_SOLO_VERSION = 1
+
+BLACKJACK_PVP_SUBSYSTEM = "blackjack_pvp"
+BLACKJACK_PVP_VERSION = 1
+
+# P0-1 — escrow subsystem for D1 escrow-at-accept.  One ``{"bet": stake,
+# "peer": other_id}`` row per player so the existing ``bet``-keyed
+# recovery refunds each player their own stake.  Wagered money moves only
+# through ``services.game_wager_workflow``.
+BLACKJACK_PVP_ESCROW_SUBSYSTEM = "blackjack_pvp_escrow"
+BLACKJACK_PVP_ESCROW_VERSION = 1
+
+BLACKJACK_TOURNAMENT_SUBSYSTEM = "blackjack_tournament"
+BLACKJACK_TOURNAMENT_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Game state classes
+# ---------------------------------------------------------------------------
+
+
+class _Game:
+    def __init__(
+        self,
+        user_id: int,
+        guild_id: int,
+        bet: int,
+        tournament_chips: int | None = None,
+        *,
+        channel_id: int | None = None,
+    ):
+        self.user_id = user_id
+        self.guild_id = guild_id
+        self.bet = bet
+        self.doubled = False
+        self.tournament_chips = tournament_chips  # None = normal game
+        self.channel_id = channel_id  # PR G2 — needed for game_state persistence
+        self.deck = _new_deck()
+        self.player: list[str] = [self.deck.pop(), self.deck.pop()]
+        self.dealer: list[str] = [self.deck.pop(), self.deck.pop()]
+        # PvP linkage (set externally by _start_pvp)
+        self.pvp_peer_id: int | None = None
+        self.pvp_state: _PvPState | None = None
+
+    def hit(self) -> str:
+        card = self.deck.pop()
+        self.player.append(card)
+        return card
+
+    def dealer_play(self):
+        from services.blackjack_engine import hand_value as _hand_value
+
+        while _hand_value(self.dealer) < 17:
+            self.dealer.append(self.deck.pop())
+
+
+class _PvPState:
+    def __init__(self, p1: int, p2: int, guild_id: int, bet: int, channel_id: int):
+        self.p1 = p1
+        self.p2 = p2
+        self.guild_id = guild_id
+        self.bet = bet
+        self.channel_id = channel_id
+        self.results: dict[int, int] = {}  # user_id → final hand value (-1 = bust)
+        self.messages: dict[int, discord.Message] = {}
+
+
+class _BjTournament(TournamentRegistration):
+    def __init__(
+        self,
+        host_id: int,
+        guild_id: int,
+        announce_id: int,
+        entry_fee: int,
+        rounds: int,
+        duration_mins: int,
+    ):
+        super().__init__(host_id, guild_id, announce_id, entry_fee, duration_mins)
+        self.rounds = rounds
+        self.results: dict[int, int] = {}  # user_id → final chips
+        self.category: discord.CategoryChannel | None = None
+
+
+class _TournPlayerState:
+    def __init__(
+        self,
+        user_id: int,
+        guild_id: int,
+        rounds: int,
+        *,
+        channel_id: int | None = None,
+    ):
+        self.user_id = user_id
+        self.guild_id = guild_id
+        self.chips = TOURN_START_CHIPS
+        self.rounds_left = rounds
+        self.done = False
+        # PR G5 — recorded so ``_check_tourn_done`` can clear the
+        # persisted entry-fee row precisely without needing a list
+        # sweep at natural tournament completion.
+        self.channel_id = channel_id
+
+
+# ---------------------------------------------------------------------------
+# Runtime state dicts (mutated by both the cog and views/blackjack/*)
+# ---------------------------------------------------------------------------
+
+_active: dict[tuple[int, int], _Game] = {}  # (user_id, guild_id) → game
+_pvp: dict[frozenset, _PvPState] = {}  # frozenset({p1, p2}) → state
+_tournaments: dict[int, _BjTournament] = {}  # guild_id → tournament

--- a/disbot/views/blackjack/embeds.py
+++ b/disbot/views/blackjack/embeds.py
@@ -9,15 +9,15 @@ from __future__ import annotations
 
 import discord
 
-from cogs.blackjack._state import (
+from services.blackjack_engine import hand_str as _hand_str
+from services.blackjack_engine import hand_value as _hand_value
+from services.blackjack_engine import rank_value as _rank_value
+from services.blackjack_state import (
     FREE_WIN_COINS,
     TOURN_BET_PER_ROUND,
     _BjTournament,
     _Game,
 )
-from services.blackjack_engine import hand_str as _hand_str
-from services.blackjack_engine import hand_value as _hand_value
-from services.blackjack_engine import rank_value as _rank_value
 from utils.ui_constants import SUCCESS_COLOR
 
 

--- a/disbot/views/blackjack/pvp_view.py
+++ b/disbot/views/blackjack/pvp_view.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 
 import discord
 
-from cogs.blackjack._persistence import _clear_pvp_match, _save_pvp_match
-from cogs.blackjack._state import (
+from core.runtime.interaction_helpers import safe_edit
+from services import economy_service, game_wager_workflow
+from services.blackjack_engine import is_blackjack as _is_blackjack
+from services.blackjack_persistence import _clear_pvp_match, _save_pvp_match
+from services.blackjack_state import (
     BLACKJACK_PVP_ESCROW_SUBSYSTEM,
     BLACKJACK_PVP_ESCROW_VERSION,
     _active,
@@ -19,9 +22,6 @@ from cogs.blackjack._state import (
     _pvp,
     _PvPState,
 )
-from core.runtime.interaction_helpers import safe_edit
-from services import economy_service, game_wager_workflow
-from services.blackjack_engine import is_blackjack as _is_blackjack
 from utils.ui_constants import ECONOMY_COLOR, GAME_COLOR
 from views.base import handle_view_error as _on_view_error
 from views.blackjack.embeds import _game_embed

--- a/disbot/views/blackjack/solo_view.py
+++ b/disbot/views/blackjack/solo_view.py
@@ -23,12 +23,12 @@ from __future__ import annotations
 
 import discord
 
-from cogs.blackjack._persistence import _clear_solo_game, _save_game_state
-from cogs.blackjack._state import FREE_WIN_COINS, _active, _Game
 from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
 from services import economy_service
 from services.blackjack_engine import hand_value as _hand_value
 from services.blackjack_engine import is_blackjack as _is_blackjack
+from services.blackjack_persistence import _clear_solo_game, _save_game_state
+from services.blackjack_state import FREE_WIN_COINS, _active, _Game
 from utils import db
 from utils.ui_constants import ECONOMY_COLOR, ERROR_COLOR, GAME_COLOR, SUCCESS_COLOR
 from views.base import handle_view_error as _on_view_error

--- a/disbot/views/blackjack/tournament_views.py
+++ b/disbot/views/blackjack/tournament_views.py
@@ -18,7 +18,11 @@ import logging
 import discord
 from discord.ext import commands
 
-from cogs.blackjack._state import (
+from core.runtime import resources
+from services import game_wager_workflow, tournament_state_service
+from services.blackjack_engine import hand_value as _hand_value
+from services.blackjack_engine import is_blackjack as _is_blackjack
+from services.blackjack_state import (
     BLACKJACK_TOURNAMENT_SUBSYSTEM,
     TOURN_BET_PER_ROUND,
     _active,
@@ -27,10 +31,6 @@ from cogs.blackjack._state import (
     _tournaments,
     _TournPlayerState,
 )
-from core.runtime import resources
-from services import game_wager_workflow, tournament_state_service
-from services.blackjack_engine import hand_value as _hand_value
-from services.blackjack_engine import is_blackjack as _is_blackjack
 from utils.channels import cleanup_category
 from utils.ui_constants import ECONOMY_COLOR, ERROR_COLOR, GAME_COLOR, SUCCESS_COLOR
 from views.base import handle_view_error as _on_view_error


### PR DESCRIPTION
Move blackjack state (`cogs/blackjack/_state.py` → `services/blackjack_state.py`) and persistence (`cogs/blackjack/_persistence.py` → `services/blackjack_persistence.py`) into `services/`. Redirect the `views/blackjack/*` imports to the new `services.` locations, clearing the `views → cogs.blackjack._state/_persistence` known violations (arch-fix-13). Resolves the `cogs.blackjack ↔ views.blackjack` import cycle. Behavior-preserving; the cog keeps its back-compat re-exports and test patch sites stay valid.

Fleet run — docs/planning/ultracode-fleet-plan-2026-06-19.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJsGDUHJ16So4DpCUPsLsm)_