### PR TITLE
docs: website two-site split — planning brief for the next session (Q-0178)

### DIFF
--- a/.sessions/2026-06-19-website-split-planning-brief.md
+++ b/.sessions/2026-06-19-website-split-planning-brief.md
@@ -1,0 +1,19 @@
+# 2026-06-19 — Website two-site split: planning brief
+
+> **Status:** `in-progress`
+
+## Arc (what I'm about to do)
+
+Owner-directed: after the ultracode run completed, the owner wants to split the single developer
+dashboard into **two audience-targeted sites** — a **public bot site** (users; submit bugs/suggestions)
+and a **dev/repo site** (the current dashboard; owner-gated edits, public read-only). The owner asked me
+to **document the required planning output for the next session** (a planning session) + capture the idea.
+
+Owner decisions captured this session (via question panel → router Q-0178): bot site public + hybrid-live
+with public submissions (DB → owner-approve → mirror to GitHub); dev site = repurposed dashboard, **all
+pages public read-only**, owner-gated edits; **2 Railway services**.
+
+Shipping: the planning brief (`docs/planning/website-two-site-split-planning-brief-2026-06-19.md`) that
+specifies what the next planning session must deliver + the idea capture + router Q-0178.
+
+_(Enders finalized in the closing commit when this flips to `complete`.)_

--- a/.sessions/2026-06-19-website-split-planning-brief.md
+++ b/.sessions/2026-06-19-website-split-planning-brief.md
@@ -1,19 +1,80 @@
 # 2026-06-19 — Website two-site split: planning brief
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-## Arc (what I'm about to do)
+## Arc
 
-Owner-directed: after the ultracode run completed, the owner wants to split the single developer
-dashboard into **two audience-targeted sites** — a **public bot site** (users; submit bugs/suggestions)
-and a **dev/repo site** (the current dashboard; owner-gated edits, public read-only). The owner asked me
-to **document the required planning output for the next session** (a planning session) + capture the idea.
+Owner-directed after the ultracode run: split the single dashboard into a **public bot site** (users;
+submit bugs/suggestions) and a **dev/repo site** (current dashboard; owner-gated edits, public read-only).
+The owner asked me to **document the required planning output for the next session** + capture the idea,
+and to ask remaining questions via the question panel first.
 
-Owner decisions captured this session (via question panel → router Q-0178): bot site public + hybrid-live
-with public submissions (DB → owner-approve → mirror to GitHub); dev site = repurposed dashboard, **all
-pages public read-only**, owner-gated edits; **2 Railway services**.
+## Shipped (PR #1099)
 
-Shipping: the planning brief (`docs/planning/website-two-site-split-planning-brief-2026-06-19.md`) that
-specifies what the next planning session must deliver + the idea capture + router Q-0178.
+- Asked the 4 shaping questions via `AskUserQuestion`; recorded the answers as **router Q-0178**.
+- `docs/planning/website-two-site-split-planning-brief-2026-06-19.md` — the **required-output spec** for
+  the next (planning) session: owner-decided constraints, hard non-negotiables (no secret values in the
+  public read-only view; preserve dashboard decoupling; moderation-before-public), and the 7 deliverables
+  the plan must produce (page/audience matrix · architecture · hybrid-data design · security review ·
+  **file-disjoint decomposition for a follow-up ultracode run** · migration/rollout · open decisions).
+- Idea capture + `docs/ideas/README.md` index entry. `check_docs --strict` green.
 
-_(Enders finalized in the closing commit when this flips to `complete`.)_
+Owner choices (Q-0178): bot site public + hybrid-live; submissions **DB → owner-approve → mirror to
+GitHub**; dev site **all pages public read-only**, owner edits; **2 Railway services** (repurpose
+dashboard + new bot site).
+
+## Context delta
+
+- **Discovered/decided:** the "all pages public read-only" choice makes a **secret-value redaction audit**
+  a hard requirement (the control-plane + env pages go public) — baked into the brief as non-negotiable #1.
+- The brief is deliberately a *spec for the next session*, not the plan — the planning is design-heavy with
+  serial dependencies (factor-shared → DB → parallelize), so it earns its own focused session.
+
+## ⟲ Previous-session review (Q-0102)
+
+The ultracode fleet run (the work between this card and #1079): **strong result** — 16/16 file-disjoint
+units, `main` stayed green, arch debt 76→45, zero Codex *code* findings. **What it missed:** the fleet
+agents skipped the mandatory session-card enders (`💡 Session idea` / `⟲ Previous-session review`) — Codex
+flagged it (B7 P2), and it's the one real process gap. **System improvement:** the kickoff prompt should
+require the enders before the card flips, and/or the born-red gate could check the *log completeness*, not
+just the status badge (captured as the idea below).
+
+## 💡 Session idea (Q-0089)
+
+**Extend the merge gate from card-*status* to card-*completeness*.** `check_session_gate.py` only checks
+the `Status:` badge; `check_session_log.py` (which knows the mandatory ender sections) is **not** a CI gate.
+The fleet proved agents will flip the badge but skip the `💡`/`⟲` enders. Idea: have the born-red gate (or
+a sibling soft check) also require the ender sections on a non-trivial session card, so an incomplete
+session log can't merge — closing the gap Codex caught across all 16 fleet cards. Distinct from existing
+captures (those are about *content* freshness, not session-log completeness). Cheap, stdlib, the script
+already exists.
+
+## 📊 Doc audit (Q-0104)
+
+- Brief in `docs/planning/` ✓ · idea in `docs/ideas/` + README ✓ · decision in router **Q-0178** ✓ ·
+  card ✓ — all reachable, `check_docs --strict` green.
+- Ledger: newest-merge lag only (the band-#1080 reconcile pass #1098 already reconciled through #1094;
+  #1095–#1099 are the next pass's job at #1110). Not this session's drift.
+
+## 📤 Run report
+
+- **Did:** captured the owner's website two-site-split decisions (Q-0178) and wrote the required-output
+  brief for the next planning session. · **Outcome:** shipped
+- **Shipped:** #1099 — planning brief + idea + router Q-0178.
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** still-open items in Q-0178 (domains/branding · live-widget data source ·
+  submissions DB store) — the planning session will surface these for you; not blocking the brief.
+- **⚑ Owner manual steps:** `none` (the next session is a planning session against this brief).
+- **⚑ Self-initiated:** `none` (owner-directed).
+- **↪ Next:** a **planning session** that reads the brief and produces the full implementation plan +
+  the file-disjoint decomposition; an ultracode build run follows that.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (#1099, auto-merge on green) |
+| Owner decisions captured | 4 (Q-0178, via question panel) |
+| CI-red rounds | 1 (born-red gate by design) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (card-completeness merge gate) |

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -20,6 +20,13 @@ during grooming** (it stays listed here, annotated ✅) so the active backlog re
 
 Current broad captures:
 
+- [`website-two-site-split-2026-06-19.md`](./website-two-site-split-2026-06-19.md) —
+  **owner-directed (2026-06-19, Q-0178):** split the single dashboard into a **public bot site** (users;
+  command reference, changelog, public bug/suggestion form → DB → owner-approve → mirror to GitHub) and a
+  **dev/repo site** (the current dashboard, all pages public read-only, owner-gated edits); 2 Railway
+  services. Structured into the required-output brief
+  [`planning/website-two-site-split-planning-brief-2026-06-19.md`](../planning/website-two-site-split-planning-brief-2026-06-19.md)
+  for the next planning session. → relates `dashboard/` · `scripts/export_dashboard_data.py`.
 - [`governance-files-presence-guard-2026-06-19.md`](./governance-files-presence-guard-2026-06-19.md) —
   **session idea (2026-06-19, Q-0089, from the repo governance/supply-chain baseline session):** a tiny
   stdlib `scripts/check_governance_files.py` that asserts the new root governance files (`LICENSE` ·

--- a/docs/ideas/website-two-site-split-2026-06-19.md
+++ b/docs/ideas/website-two-site-split-2026-06-19.md
@@ -1,0 +1,29 @@
+# Idea: split the dashboard into two audience-targeted sites
+
+> **Status:** `ideas` — capture. **Owner-directed (2026-06-19), decisions in router Q-0178; structured
+> into a planning brief.** Source code + binding contracts win. Not the plan — the plan is the next
+> session's job (see the brief).
+
+## The idea
+
+Split the single developer dashboard (`dashboard/`) into **two sites by audience**:
+
+- **Bot site (public, dynamic):** for Discord users — command reference, feature showcase, bot
+  changelog/updates, status, and a **public bug/suggestion form**.
+- **Dev/repo site:** the current dashboard, repurposed — ideas, bugs, repo/session updates, env map,
+  `/reviews`, control plane. **All pages public read-only**, owner-gated for edits.
+
+Submissions flow **DB → owner approves → mirror to GitHub issues**; deployed as **2 Railway services**
+(repurpose the dashboard + a new bot site). Rationale: bot-users and dev/ops content have different needs;
+separating them sharpens both.
+
+## Why it's worth having
+
+A clean public bot site is a real user-onboarding upgrade, and the dev dashboard stays the unpolluted
+"engine room." Feasible because `dashboard/` is already a decoupled Railway service reading generated JSON.
+
+## Route
+
+**Owner-directed → structured** into
+[`planning/website-two-site-split-planning-brief-2026-06-19.md`](../planning/website-two-site-split-planning-brief-2026-06-19.md)
+(the required output for the next planning session). Decisions: router Q-0178.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,10 +25,9 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/focused-goldberg-mviel4` · **ultracode fleet brief** (owner-directed) — coordination doc for a
-  parallel multi-agent run: 8 architecture boundary-debt units + 8 ungated tooling/ops quick-wins, all
-  file-disjoint · `docs/planning/ultracode-fleet-plan-2026-06-19.md` · 2026-06-19
-  · _(prior #1064 governance/supply-chain baseline merged)_
+- `claude/focused-goldberg-mviel4` · **website two-site split — planning brief** (owner-directed) —
+  spec for the next planning session + idea capture + router Q-0178 · `docs/planning/website-two-site-split-planning-brief-2026-06-19.md`
+  · 2026-06-19 · _(prior ultracode fleet #1080–#1097 + #1064/#1079 all merged)_
 - `claude/magical-rubin-jnpnuw` · **dashboard.json structural-drift reporter** + freshness catch-up
   (executes the #1020 💡 idea + finding) · `scripts/check_dashboard_data.py` ·
   `dashboard/data/dashboard.json` · tests · 2026-06-17 · **auto-merge on green**

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -6494,3 +6494,34 @@ rules), Q-0114 (`do-not-automerge` carve-out), Q-0133 (born-red gate).
 **Home:** the [plan](../planning/repo-structure-improvement-plan-2026-06-19.md) + this Q-block. Related:
 Q-0151 (architecture-atlas review — no reorg; root-README posture), Q-0106 (executable-config exception),
 Q-0105 (disposable-tooling discipline), gap-analysis §6 (toolchain-rot watch — closed by Dependabot).
+
+---
+
+### Q-0178 — Website two-site split: bot site vs dev/repo site (2026-06-19)
+
+> **DECISION 2026-06-19 (owner-directed in-session, via the question panel).** After the ultracode run,
+> the owner directed splitting the single developer dashboard into **two audience-targeted sites** and
+> asked for the required planning output for the next session. The product/privacy/topology choices below
+> were made by the owner via `AskUserQuestion`; they are the binding constraints the next planning session
+> must honor. Full brief: [`docs/planning/website-two-site-split-planning-brief-2026-06-19.md`](../planning/website-two-site-split-planning-brief-2026-06-19.md).
+
+**Decisions (the four choices):**
+
+1. **Bot site** — **public + dynamic (hybrid:** regenerated content + a few live status widgets). For
+   Discord users: command reference, feature showcase, bot changelog, status, and a public submission form.
+2. **Public submissions** — **DB intake → owner approves on the dev site → approved ones mirror to GitHub
+   issues** (reuse the `.github/ISSUE_TEMPLATE/` shapes). *Not* direct-to-GitHub and *not* a raw public
+   feed — moderation gate first.
+3. **Dev site** — the current dashboard, repurposed: **all pages public read-only**, owner-gated for
+   **edits** (existing Discord-OAuth owner auth). **Hard constraint:** public read-only must never expose
+   secret **values/tokens** — names + status only (env-var names are already public; values are the line).
+4. **Topology** — **2 Railway services**: repurpose `dashboard/` as the dev site + a **new** lightweight
+   public bot site. Preserve the dashboard's existing decoupling (no bot imports; reads generated JSON).
+
+**Still open (the planning session surfaces/recommends, owner decides):** domains/branding; the exact
+live-widget data source (gated on a control-API public-exposure security review); the submissions DB store
+(the bot's Postgres vs a separate one).
+
+**Home:** the [planning brief](../planning/website-two-site-split-planning-brief-2026-06-19.md) + this
+Q-block; idea capture [`website-two-site-split-2026-06-19.md`](../ideas/website-two-site-split-2026-06-19.md).
+Related: the developer-dashboard initiative + Q-0155/Q-0156 (dashboard auth/live-editor lane).

--- a/docs/planning/website-two-site-split-planning-brief-2026-06-19.md
+++ b/docs/planning/website-two-site-split-planning-brief-2026-06-19.md
@@ -1,0 +1,86 @@
+# Website two-site split — planning brief for the next session
+
+> **Status:** `plan` — a **brief**, not the plan itself: it specifies the **required output** the next
+> (planning) session must produce, plus the owner-decided constraints it must honor. Owner-directed
+> 2026-06-19; decisions recorded in router **Q-0178**. Source code + merged PRs win. The next session
+> reads this, then produces the full implementation plan + the ultracode decomposition.
+
+## Vision
+
+Split the single developer dashboard (`dashboard/`) into **two audience-targeted sites**:
+
+- **Bot site (public):** for Discord users / prospective server owners. What the bot does, command
+  reference, feature showcase, **bot changelog/updates**, status, and a **public form to submit
+  bugs/suggestions**. Marketing + reference + intake.
+- **Dev/repo site:** the *current* dashboard, repurposed. Ideas board, bug book, **repo/session
+  updates**, env map, `/reviews`, control plane. For the owner + agents + curious devs.
+
+The point is an **audience separation**: mixing bot-users and dev/ops content dilutes both. A clean
+public bot site improves user onboarding; the dev dashboard stays the "engine room."
+
+## Owner-decided constraints (Q-0178 — the next session must honor these)
+
+| Decision | Choice |
+|---|---|
+| Bot site visibility / data | **Public + dynamic (hybrid:** regenerated content + a few live status widgets) |
+| Public submissions | **DB intake → owner approves on the dev site → approved ones mirror to GitHub issues** (reuse the `.github/ISSUE_TEMPLATE/` shapes) |
+| Dev site exposure | **All pages public read-only**; owner-gated for **edits** (existing Discord-OAuth owner auth) |
+| Deployment topology | **2 Railway services** — repurpose the current `dashboard/` as the dev site; a **new** lightweight service is the bot site |
+
+## Hard constraints / non-negotiables
+
+1. **🔒 No secret values in the public read-only view.** "All pages public read-only" includes the env
+   map and control-plane pages — these may render env-var **names** + **status** only, **never values or
+   tokens**. The `CONTROL_API_TOKEN` and any credential must never reach a public response. A redaction
+   audit of every dev-site page is a required deliverable (below). (Env-var *names* are already public in
+   `docs/operations/env-vars.md`, so names are fine; values are the line.)
+2. **Preserve the dashboard's decoupling.** Today `dashboard/` imports **no** bot code and reads generated
+   JSON (`scripts/export_dashboard_data.py` → `dashboard/data/dashboard.json`). Both sites must keep this:
+   surface the repo's existing structured data, **don't duplicate or rebuild functionality**.
+3. **Public submission ⇒ abuse surface.** A public, no-login form is a spam/abuse vector. The plan must
+   specify rate-limiting, validation, and the owner-moderation gate **before** anything is publicly shown
+   or mirrored to GitHub.
+
+## REQUIRED PLANNING OUTPUT (what the next session must deliver)
+
+The next session produces a `docs/planning/` implementation plan containing **all** of:
+
+1. **Page/audience allocation matrix.** Every current dashboard page → `bot` / `dev` / `both`, with
+   rationale; plus the **new** bot-site pages (command reference, feature showcase, bot changelog, status,
+   submission form). Use the existing **Run-type seam** (`routine` vs manual/bot badges in the updates
+   feed) to split "bot updates" vs "repo updates".
+2. **Architecture.** The 2-service topology; how **shared templates/assets/data** are factored (a shared
+   package? a common static-data layer? duplication with a lint guard?) without re-coupling; the
+   **submission flow** end-to-end (DB schema, the owner-approval UI on the dev site, the GitHub-mirror
+   mechanism + token scope); the **auth boundaries** (bot site: public + submission intake; dev site:
+   public read-only + owner-edit via the existing OAuth).
+3. **Data / freshness design.** The hybrid model concretely: what is **regenerated** (source, cadence,
+   trigger) vs the **few live widgets** (their data source — if any touches `disbot/control_api.py`, the
+   security implications of a public service reading it, and the read-only/rate-limited contract).
+4. **Security review.** A per-page **redaction matrix** for the public read-only dev site (what renders,
+   what's stripped); the submission **abuse plan** (rate-limit, captcha/validation, moderation gate); the
+   **GitHub-mirror token** scope (least-privilege, repo-scoped issues:write).
+5. **Decomposition into file-disjoint build units.** The **ultracode-able** breakdown for the follow-up
+   build run — each unit's exclusive file set + what it does — **with sequencing**: the *serial*
+   prerequisites (e.g., factor shared data/templates first; stand up the submission DB) vs the units that
+   can then parallelize (bot-site pages, dev-site public-read toggles, the moderation UI).
+6. **Migration / rollout.** How to split with **no downtime** — keep the current dashboard serving the
+   dev audience throughout; stand the bot site up alongside; cut over deliberately. Include a rollback.
+7. **Owner decisions still open** (surface, don't guess): domains/branding for the two sites; the exact
+   live-widget data source (gated on the control-API security review); the submissions DB choice
+   (the bot's Postgres vs a separate store).
+
+## Why a planning session is next (not another ultracode run)
+
+The ungated **parallel** backlog is thin after the fleet, and this work is **design-heavy with sequential
+dependencies** (factor-shared → DB → then parallelize) — a fleet would stall on the serial front half.
+So the chain is: **this brief → a focused planning session (produces the plan + the ultracode
+decomposition above) → an ultracode build run** on the disjoint back-half units. Plan first, then
+parallelize.
+
+## Builds on (existing — don't duplicate)
+
+[`developer-dashboard-plan.md`](developer-dashboard-plan.md) (the current dashboard's design + the
+already-envisioned public bug form + GitHub-issue mirror) · [`dashboard-live-editor-plan.md`](dashboard-live-editor-plan.md)
+(owner-auth + control-API write design) · `dashboard/` (the decoupled service) · the `.github/ISSUE_TEMPLATE/`
+shapes from #1064 · `docs/operations/env-vars.md` (the env-name surface).


### PR DESCRIPTION
## What

Owner-directed planning brief: split the single developer dashboard into **two audience-targeted sites** — a public **bot site** and a repurposed **dev/repo site** — and document **the required output for the next (planning) session** so it can produce the full implementation plan + decomposition.

Captures the owner's decisions from this session (router **Q-0178**):
- **Bot site:** public + dynamic (hybrid data); anyone can submit bugs/suggestions → **DB intake → owner approves → mirror to GitHub issues**.
- **Dev site:** the current dashboard, **all pages public read-only**, owner-gated for edits.
- **Topology:** repurpose the dashboard as the dev site + a new bot site = **2 Railway services**.

Ships: the planning brief (`docs/planning/website-two-site-split-planning-brief-2026-06-19.md`), an idea capture, and router Q-0178. Docs-only — no runtime change. The next session is a **planning** session that executes against this brief; an ultracode build run follows once it's decomposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnTrJgVEeUgEpLXhZMvWus

---
_Generated by [Claude Code](https://claude.ai/code/session_01BnTrJgVEeUgEpLXhZMvWus)_