### PR TITLE
docs: route the website-split control-panel-placement decision (Q-0179)

### DIFF
--- a/.sessions/2026-06-19-website-split-decision-routing.md
+++ b/.sessions/2026-06-19-website-split-decision-routing.md
@@ -1,0 +1,16 @@
+# 2026-06-19 — Website split: route the control-panel-placement decision (Q-0179)
+
+> **Status:** `in-progress`
+
+## Arc
+
+Continuation after the website two-site-split **plan** merged (#1100). The plan's §7.4 surfaced a
+genuine **owner-intent fork** — the dev-site "owner-gated for edits" wording (Q-0178) vs today's
+existing *multi-user, any-guild-admin* control panel — that the router's Q-0178 "still open" list does
+**not** include. That is stale-router drift + an unrouted owner decision the build run needs answered.
+
+## What I'm about to do
+
+- Append router **Q-0179** (DISCUSS lane) routing the control-panel-placement fork to the owner, with a
+  pointer to the plan §7 for the full open-decisions list. Append-only; references Q-0178 + the plan.
+- Docs-only, planning-scope (no runtime code). Standing enders + flip to complete as the final step.

--- a/.sessions/2026-06-19-website-split-decision-routing.md
+++ b/.sessions/2026-06-19-website-split-decision-routing.md
@@ -1,16 +1,85 @@
 # 2026-06-19 — Website split: route the control-panel-placement decision (Q-0179)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Arc
 
 Continuation after the website two-site-split **plan** merged (#1100). The plan's §7.4 surfaced a
 genuine **owner-intent fork** — the dev-site "owner-gated for edits" wording (Q-0178) vs today's
-existing *multi-user, any-guild-admin* control panel — that the router's Q-0178 "still open" list does
+existing *multi-user, any-guild-admin* control panel — that the router's Q-0178 "still open" list did
 **not** include. That is stale-router drift + an unrouted owner decision the build run needs answered.
 
-## What I'm about to do
+## Shipped (PR #1102)
 
-- Append router **Q-0179** (DISCUSS lane) routing the control-panel-placement fork to the owner, with a
-  pointer to the plan §7 for the full open-decisions list. Append-only; references Q-0178 + the plan.
-- Docs-only, planning-scope (no runtime code). Standing enders + flip to complete as the final step.
+- Router **Q-0179** (DISCUSS lane, OPEN): routes the per-server control-panel-placement fork to the
+  owner — (1) keep the existing multi-user panel on the dev site (recommended, zero-migration) vs (2)
+  move it to the public bot site as a bot-user feature. References Q-0178 + plan §7; lists the two
+  implementation-level siblings (changelog source · captcha) for completeness. Append-only.
+- Updated the active-work claim; flipped the born-red card to complete (Q-0133).
+
+## Context delta
+
+- The plan (#1100) surfaced this fork in two durable places (plan §7.4 + current-state ▶ Next action)
+  but **not** in the router — the owner's canonical decision queue. Routing it is the proper completion
+  of "surface, don't guess": a plan §7 buried in a 300-line doc is less likely to get an owner decision
+  than a DISCUSS-lane Q-block. No new code; purely the decision-routing half of the planning work.
+- The merge of #1100 was a **merge commit** (not squash, despite the squash request) — my branch
+  fast-forwarded cleanly to `origin/main` (0 ahead) before this continuation, so #1102's diff is only
+  the new work.
+
+## ⟲ Previous-session review (Q-0102)
+
+**#1100 (the plan) — thorough and well-grounded**, with all 7 deliverables and real source-reading
+behind each. **What it missed:** it *surfaced* the §7.4 owner-intent fork but did not **route** it to the
+maintainer-question-router — it left Q-0178's "still open" list stale relative to what the planning
+discovered. A planning session that says "surface, don't guess" should close the loop by routing genuine
+owner forks to the router (their decision home), not only noting them in plan prose. (This continuation
+is that fix.) **System improvement:** the planning-session close (the `/plan-band` / session-close
+discipline) should carry an explicit step — *"did this session surface an owner-intent fork not already
+in the router? → append it as an OPEN Q-block."* Cheap habit; turns "surfaced in a plan" into "queued for
+the owner."
+
+## 💡 Session idea (Q-0089)
+
+**A tiny `scripts/router_status.py` digest** — reports (a) the highest `Q-NNNN` (so a session instantly
+knows the next free number, append-only convention) and (b) the list of **OPEN / DISCUSS-lane** blocks
+still awaiting an owner decision ("what does the owner still need to decide?"). Motivated by friction I
+hit this session: I `grep`'d for the next Q number and hand-scanned for what's unrouted, against a
+6,500-line / ~179-block router. Pure stdlib, read-only, disposable (Q-0105); pairs naturally with the
+website owner-zone's "open decisions" surface (it could even feed `export_dashboard_data.py`). Distinct
+from prior ideas (those were about born-red completeness / deliverable outlines). Believe in it — the
+router is now big enough that "next number + what's open" deserves one command.
+
+## 📊 Doc audit (Q-0104)
+
+- Q-0179 appended to the router (reachable; references the plan + Q-0178) · `check_docs --strict` green.
+- Ledger: only benign newest-merge lag (#1095–#1101, all newer than the #1094 marker → the #1110
+  reconciliation pass's job, per Q-0124 a manual session does not run it). Not this session's drift.
+- No new owner *decision* recorded (Q-0179 is an OPEN question, by design — "unanswered questions are
+  not approval").
+
+## 📤 Run report
+
+- **Did:** routed the one genuine owner-intent fork the merged plan (#1100 §7.4) surfaced but left out of
+  the router — control-panel placement → router Q-0179 (DISCUSS). · **Outcome:** shipped.
+- **Shipped:** #1102 — router Q-0179 + active-work update.
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** **Q-0179** — confirm (1) keep the multi-user per-server control panel on
+  the dev site (recommended), or (2) move it to the public bot site. Needed before the ultracode build
+  run wires it. (Plus the plan §7 siblings, build-time defaults unless you say otherwise.)
+- **⚑ Owner manual steps:** `none`.
+- **⚑ Self-initiated:** the *continuation* (routing the fork) was agent-initiated after the assigned
+  planning task merged — a contained, in-scope docs action (no new feature). Flagged here for visibility.
+- **↪ Next:** unchanged — the **ultracode build run** on the plan's §5 units (once the owner answers
+  Q-0179, or the build defaults to recommendation (1)).
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (#1102, auto-merge on green) |
+| Router blocks added | 1 (Q-0179, OPEN/DISCUSS) |
+| Owner decisions surfaced | 1 (control-panel placement) |
+| CI-red rounds | 1 (born-red gate by design) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (`router_status.py` digest) |

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,11 +25,15 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/kind-einstein-jlywgm` · **route the website-split control-panel-placement decision**
+  (continuation after the plan merged #1100) — router **Q-0179** (DISCUSS): the one owner-intent fork
+  the plan §7.4 discovered that Q-0178's "still open" list omits · `docs/owner/maintainer-question-router.md`
+  · 2026-06-19 · **auto-merge on green**
 - `claude/kind-einstein-jlywgm` · **website two-site split — implementation plan** (owner-directed,
   executes the #1099 brief + Q-0178) — the full plan + file-disjoint ultracode decomposition for the
   follow-up build run; docs-only · `docs/planning/website-two-site-split-plan-2026-06-19.md` ·
-  forward-links the brief + `docs/current-state.md` ▶ Next action · 2026-06-19 · **PR #1100,
-  auto-merge on green** (next = the ultracode build run on the plan's §5 units)
+  forward-links the brief + `docs/current-state.md` ▶ Next action · 2026-06-19 · **merged #1100**
+  (next = the ultracode build run on the plan's §5 units)
 - `claude/focused-goldberg-mviel4` · **website two-site split — planning brief** (owner-directed) —
   spec for the next planning session + idea capture + router Q-0178 · `docs/planning/website-two-site-split-planning-brief-2026-06-19.md`
   · 2026-06-19 · **merged #1099**

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -6525,3 +6525,36 @@ live-widget data source (gated on a control-API public-exposure security review)
 **Home:** the [planning brief](../planning/website-two-site-split-planning-brief-2026-06-19.md) + this
 Q-block; idea capture [`website-two-site-split-2026-06-19.md`](../ideas/website-two-site-split-2026-06-19.md).
 Related: the developer-dashboard initiative + Q-0155/Q-0156 (dashboard auth/live-editor lane).
+
+---
+
+### Q-0179 — Website split: where does the per-server control panel live? (2026-06-19)
+
+> **OPEN — DISCUSS lane, owner decides.** Surfaced by the website two-site-split *plan* (#1100, §7.4),
+> which the planning session grounded against the live dashboard. Routes a genuine owner-intent fork that
+> Q-0178's "still open" list does **not** include. Not blocking the plan, but **needed before the
+> ultracode build run wires the control panel one way.** Agent recommends; owner decides.
+
+**The fork.** Q-0178 (decision 3) says the dev site is "owner-gated for edits (existing Discord-OAuth
+owner auth)." But the *existing*, already-shipped, already-audited `/admin` control panel is
+**multi-user**: *any* Discord user signs in and edits the servers **they** administer (the bot re-checks
+each editor's live authority per guild — the browser is never trusted). So "owner-gated" as written does
+not match what is built. Two readings, materially different products:
+
+1. **Keep the existing multi-user per-server control panel on the dev site (v1 — agent recommendation).**
+   Zero migration; already built + audited; "owner-gated" reads loosely as "edits require the OAuth gate
+   and the bot is the authority." The **new** owner-only surfaces are moderation + env-value mgmt + the
+   control board. Lowest-risk, no-downtime.
+2. **Treat the per-server control panel as a bot-USER feature → move/mirror it to the public bot site.**
+   Cleaner audience separation (a server owner managing their server is a bot user, not a developer), but
+   it is migration + re-auth work and re-opens the public-surface security review for the live editors.
+
+**Recommendation:** (1) for v1 — leave it on the dev site, build the split around it, and revisit moving
+it to the bot site as a later, separate slice once the bot site exists. **Owner: confirm (1), or pick (2).**
+
+**Still-open siblings (implementation-level, not router-gating — defaults live in plan §7):** the
+bot-changelog source (curated file vs auto-derived) and the public-form captcha (honeypot+rate-limit v1
+vs add a provider). Listed for completeness; the build run defaults them per the plan unless you say so.
+
+**Home:** the [plan §7](../planning/website-two-site-split-plan-2026-06-19.md) + this Q-block. Related:
+Q-0178 (the four decided choices + its own "still open" list), Q-0155/Q-0156 (dashboard auth/live-editor).


### PR DESCRIPTION
## What

Short continuation after the website two-site-split **plan** merged (#1100). That plan's **§7.4**
surfaced a genuine **owner-intent fork** the router's Q-0178 "still open" list does **not** include:

> The dev site is "owner-gated for edits (existing Discord-OAuth owner auth)" (Q-0178) — but today's
> `/admin` is a **multi-user, any-guild-admin** control panel (the bot re-checks each editor's authority
> per guild), *not* owner-only. So: does the per-server control panel stay on the dev site, or is it a
> bot-**user** feature that belongs on the public bot site?

This routes that fork to the owner as router **Q-0179** (DISCUSS lane) — closing the router gap and
giving the follow-up ultracode build run the one prerequisite decision it needs ("surface, don't
guess"). Append-only; references Q-0178 + the plan §7.

Docs-only, planning-scope — **no runtime change**. Born-red per Q-0133; flips to `complete` last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C27AavfY95e5bp82FTZFpY

---
_Generated by [Claude Code](https://claude.ai/code/session_01C27AavfY95e5bp82FTZFpY)_