### PR TITLE
chore: router_status.py — a question-router digest (next free Q + open queue)

### DIFF
--- a/.sessions/2026-06-19-router-status-tool.md
+++ b/.sessions/2026-06-19-router-status-tool.md
@@ -1,0 +1,17 @@
+# 2026-06-19 — router_status.py: a question-router digest tool
+
+> **Status:** `in-progress`
+
+## Arc
+
+Continuation grooming-ender after the website-split planning chain merged (#1100 plan · #1102 Q-0179).
+Executes the idea I captured in #1102's card (Q-0089): a small stdlib tool that digests the
+6,500-line / 184-block maintainer question router — the recurring per-session friction of finding the
+next free `Q-NNNN` and scanning for what's still OPEN (hit by hand twice this session).
+
+## What I'm about to do
+
+- Add `scripts/router_status.py` (pure stdlib, read-only, Q-0105 disposable) + a unit test:
+  reports the next free Q-number (exact) + the OPEN owner-decision queue vs DECIDED, with an honest
+  UNCLASSIFIED bucket. Flags: `--next` · `--open` · `--unclassified` · `--json`.
+- Verify its output against the live router; standing enders; flip to complete last.

--- a/.sessions/2026-06-19-router-status-tool.md
+++ b/.sessions/2026-06-19-router-status-tool.md
@@ -1,6 +1,6 @@
 # 2026-06-19 — router_status.py: a question-router digest tool
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Arc
 
@@ -9,9 +9,90 @@ Executes the idea I captured in #1102's card (Q-0089): a small stdlib tool that 
 6,500-line / 184-block maintainer question router — the recurring per-session friction of finding the
 next free `Q-NNNN` and scanning for what's still OPEN (hit by hand twice this session).
 
-## What I'm about to do
+## Shipped (PR #1103)
 
-- Add `scripts/router_status.py` (pure stdlib, read-only, Q-0105 disposable) + a unit test:
-  reports the next free Q-number (exact) + the OPEN owner-decision queue vs DECIDED, with an honest
-  UNCLASSIFIED bucket. Flags: `--next` · `--open` · `--unclassified` · `--json`.
-- Verify its output against the live router; standing enders; flip to complete last.
+- `scripts/router_status.py` — pure stdlib, read-only (never writes the router), Q-0105 disposable:
+  - `--next` → the next free Q-number, **exact** (header parse): `Q-0180` today.
+  - default digest → counts + next number + the **OPEN owner-decision queue** (2 today: Q-0137 partial ·
+    Q-0179), classified by each block's leading `> **MARKER**` convention.
+  - `--open` / `--unclassified` / `--json` for the detail.
+- `tests/unit/scripts/test_router_status.py` — parse / classify / next-number + a real-router smoke test
+  (6 tests, green). Carries the Q-0105 provenance/reliability header.
+- Verified against the live router; `check_quality.py --check-only` green (CI mirror).
+
+## Context delta
+
+- **Honest classifier limit, surfaced by the tool itself:** 116 of 184 blocks are UNCLASSIFIED — almost
+  all the *older* blocks (≈Q-0001…Q-0130) predate the `> **MARKER**` leading-status convention the newer
+  blocks use. The tool buckets them as UNCLASSIFIED rather than guessing (it does **not** fight the
+  evidence — Q-0120), and the default digest *summarises* that bucket instead of dumping 116 lines. The
+  two outputs that matter — next number (exact) and the OPEN queue (both genuinely-open blocks found) —
+  are reliable. This gap is the seed of this session's idea below.
+- **Gotcha worth recording:** loading a script by path via `importlib` that defines a `@dataclass` needs
+  the module registered in `sys.modules` *before* `exec_module`, or the dataclass decorator raises
+  `'NoneType' has no attribute '__dict__'` (it looks its module up by name). The existing
+  `export_dashboard_data._load_sibling` pattern doesn't hit this only because its siblings define no
+  dataclasses. Test loader does `sys.modules[spec.name] = module` before exec.
+- **CI-scope reminder confirmed:** ruff flagged `S101`/`PT018` on the *test* file — but CI excludes
+  `tests/` from black/isort/ruff, so those are not real CI failures; I did not chase them (the documented
+  "don't reformat tests to chase a formatter-over-tests red" rule).
+
+## ⟲ Previous-session review (Q-0102)
+
+**#1102 (route Q-0179) — correct and tight:** it caught the one genuine owner-intent fork the plan left
+unrouted and put it in the router with a clear recommendation. More importantly, the **self-audit loop
+worked**: #1100's card flagged "the plan surfaced the fork but didn't route it," and #1102 *was* that
+correction — each session reviewing its predecessor and closing the gap is exactly the Q-0102 mechanism
+doing its job. **What it (and every prior session) did the slow way:** it found the next Q-number and
+scanned for open blocks by hand-grepping a 6,500-line file — the friction this session's tool removes.
+**System improvement:** the `/route-idea` and `/session-close` disciplines should *use* `router_status.py`
+now that it exists (dogfood it — `--next` for the append number, `--open` for the close-out "what does the
+owner still owe a decision?" check), turning a manual grep into one command.
+
+## 💡 Session idea (Q-0089)
+
+**One-time backfill of leading status markers on the ~116 older router blocks.** Building the digest
+revealed that the older blocks (≈Q-0001…Q-0130) lack the `> **<STATUS>**` leading-status line that newer
+blocks use, so no tool — `router_status.py`, a future website "open decisions" surface, or a reconciliation
+check — can classify them. Idea: a careful one-pass normalization that prepends each old block a leading
+`> **<STATUS>**` line inferred from its body (most are decided/historical; a human confirms the handful
+that are ambiguous), making the **whole** router machine-classifiable. Distinct from prior ideas (born-red
+outlines / the digest tool itself); motivated directly by this tool's own UNCLASSIFIED output. Sizeable
+(116 blocks) → an idea file / its own session, not a drive-by. Believe in it — the digest is only as good
+as the convention's coverage.
+
+## 📊 Doc audit (Q-0104)
+
+- New files are `scripts/` + `tests/` (code, not docs) — `check_docs --strict` unaffected/green; no new
+  doc needs a reachability link.
+- Tool is self-documenting (module docstring + `--help`); the README/AGENT_ORIENTATION need no entry for a
+  disposable Q-0105 convenience script (it advertises its own deletion criteria).
+- Ledger: only benign newest-merge lag (#1095–#1102, all newer than the #1094 marker → the #1110
+  reconciliation pass's job; a manual session does not run it, Q-0124). Not this session's drift.
+
+## 📤 Run report
+
+- **Did:** executed the captured Q-0089 idea — shipped `scripts/router_status.py`, a stdlib digest of the
+  question router (next free Q-number + the OPEN owner-decision queue). · **Outcome:** shipped.
+- **Shipped:** #1103 — `scripts/router_status.py` + test + active-work entry.
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** `none` (disposable Q-0105 tooling; no owner gate). The standing OPEN
+  owner decision remains **Q-0179** (control-panel placement) — now also discoverable via
+  `python3.10 scripts/router_status.py --open`.
+- **⚑ Owner manual steps:** `none`.
+- **⚑ Self-initiated:** yes — grooming-ender executing a captured idea, agent-initiated in an unattended
+  continuation (Q-0129 welcomes workflow-improving self-initiative). Contained read-only tooling.
+- **↪ Next:** the website-split **ultracode build run** is still the substantive next step (gated on
+  Q-0179 / its default). The router-marker backfill (above) is a fresh groomable idea.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (#1103, auto-merge on green) |
+| New tool | `scripts/router_status.py` (stdlib, read-only, Q-0105) |
+| Tests added | 6 (all green) |
+| Router blocks the tool parses | 184 (next free: Q-0180; OPEN: 2) |
+| CI-red rounds | 1 (born-red gate by design) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (backfill old router status markers) |

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,11 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/kind-einstein-jlywgm` · **`scripts/router_status.py`** (grooming-ender — executes the #1102
+  Q-0089 idea) — stdlib digest of the question router: next free Q-number + the OPEN owner-decision
+  queue · `scripts/router_status.py` + `tests/unit/scripts/test_router_status.py` · 2026-06-19 ·
+  **auto-merge on green**
+
 - `claude/kind-einstein-jlywgm` · **route the website-split control-panel-placement decision**
   (continuation after the plan merged #1100) — router **Q-0179** (DISCUSS): the one owner-intent fork
   the plan §7.4 discovered that Q-0178's "still open" list omits · `docs/owner/maintainer-question-router.md`

--- a/scripts/router_status.py
+++ b/scripts/router_status.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3.10
+"""Digest the maintainer question router — next free Q-number + the open queue.
+
+Reads ``docs/owner/maintainer-question-router.md`` (the append-only owner-decision
+log, ~180+ ``### Q-NNNN`` blocks) and reports:
+
+* the **highest** ``Q-NNNN`` and the **next free** number — so a session appending a
+  new block (the append-only convention) gets the right number without grepping a
+  6,500-line file by hand; and
+* the blocks still **OPEN** (awaiting an owner decision) vs **DECIDED**, plus an
+  honest **UNCLASSIFIED** bucket for blocks whose leading status marker does not
+  match a known token.
+
+Classification reads each block's first ``> **<MARKER>`` line (the house
+convention): ``DECISION`` / ``DECIDED`` / ``ANSWERED`` / ``DIRECTED`` / ``APPLIED``
+… = decided; ``OPEN`` / ``PROPOSED`` / ``PARTLY DECIDED`` / ``DISCUSS`` = open.
+
+Pure stdlib, read-only — never writes the router. Useful with the website
+owner-zone "open decisions" surface (it could feed ``export_dashboard_data.py``).
+
+Reliability (Q-0105): **UNVERIFIED.** The next-number output is exact (a header
+parse). The OPEN/DECIDED split is a **heuristic** over the leading-marker
+convention and is reported alongside an ``UNCLASSIFIED`` list precisely so a human
+can confirm what the tool was unsure about (the Q-0120 "verify the tool against
+the evidence" discipline). Confirm the classification against the file a few times
+across sessions before trusting it; **delete this script if it proves unreliable**
+— it is a convenience digest, not load-bearing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ROUTER_FILE = REPO_ROOT / "docs" / "owner" / "maintainer-question-router.md"
+
+# ``### Q-0179 — <title> (<date>)`` — number is the load-bearing capture; the title
+# and trailing (YYYY-MM-DD) are best-effort.
+_HEAD_RE = re.compile(r"^###\s+(Q-(\d{4}))\b\s*(?:[—–-]\s*(.*?))?\s*$")
+# A block's first ``> **<bold>**`` quote line carries its status marker.
+_MARKER_RE = re.compile(r"^>\s*\*\*(.+?)\*\*")
+_DATE_RE = re.compile(r"\((\d{4}-\d{2}-\d{2})\)\s*$")
+
+# Leading marker tokens (matched against the uppercased bold text via startswith).
+# OPEN is checked first so "PARTLY DECIDED" classifies as open, not decided.
+_OPEN_TOKENS = (
+    "OPEN",
+    "PROPOSED",
+    "PARTLY",
+    "DISCUSS",
+    "UNDECIDED",
+    "AWAITING",
+    "PENDING",
+)
+_DECIDED_TOKENS = (
+    "DECISION",
+    "DECIDED",
+    "ANSWERED",
+    "DIRECTED",
+    "APPLIED",
+    "RESOLVED",
+    "APPROVED",
+    "NOW LIVE",
+    "ROLLED OUT",
+    "CLOSED",
+    "CAPTURED",
+)
+
+
+@dataclass
+class QBlock:
+    """One ``### Q-NNNN`` router block."""
+
+    number: int
+    qid: str
+    title: str
+    date: str
+    marker: str
+    status: str  # "open" | "decided" | "unclassified"
+
+
+def classify(marker: str) -> str:
+    """Classify a block by its leading bold marker text."""
+    upper = marker.strip().upper()
+    if upper.startswith(_OPEN_TOKENS):
+        return "open"
+    if upper.startswith(_DECIDED_TOKENS):
+        return "decided"
+    return "unclassified"
+
+
+def parse_blocks(text: str) -> list[QBlock]:
+    """Parse the router markdown into a list of :class:`QBlock` (in file order)."""
+    lines = text.splitlines()
+    blocks: list[QBlock] = []
+    current: dict[str, str | int] | None = None
+    marker_found = False
+
+    def _flush() -> None:
+        if current is not None:
+            marker = str(current["marker"])
+            blocks.append(
+                QBlock(
+                    number=int(current["number"]),
+                    qid=str(current["qid"]),
+                    title=str(current["title"]),
+                    date=str(current["date"]),
+                    marker=marker,
+                    status=classify(marker),
+                ),
+            )
+
+    for line in lines:
+        head = _HEAD_RE.match(line)
+        if head:
+            _flush()
+            rest = (head.group(3) or "").strip()
+            date_match = _DATE_RE.search(rest)
+            date = date_match.group(1) if date_match else ""
+            title = _DATE_RE.sub("", rest).strip() if date else rest
+            current = {
+                "number": int(head.group(2)),
+                "qid": head.group(1),
+                "title": title,
+                "date": date,
+                "marker": "",
+            }
+            marker_found = False
+            continue
+        if current is not None and not marker_found:
+            marker = _MARKER_RE.match(line)
+            if marker:
+                current["marker"] = marker.group(1).strip()
+                marker_found = True
+    _flush()
+    return blocks
+
+
+def next_number(blocks: list[QBlock]) -> str:
+    """The next free ``Q-NNNN`` for an append (highest + 1; ``Q-0001`` if empty)."""
+    highest = max((b.number for b in blocks), default=0)
+    return f"Q-{highest + 1:04d}"
+
+
+def _print_block_lines(blocks: list[QBlock]) -> None:
+    for b in blocks:
+        print(f"  {b.qid} — {b.title or '(untitled)'}  [{b.marker or 'no marker'}]")
+
+
+def _print_digest(blocks: list[QBlock]) -> None:
+    open_blocks = [b for b in blocks if b.status == "open"]
+    decided = sum(1 for b in blocks if b.status == "decided")
+    unclassified = [b for b in blocks if b.status == "unclassified"]
+    print("question-router status")
+    print(
+        f"  blocks: {len(blocks)}  ·  decided: {decided}  ·  "
+        f"open: {len(open_blocks)}  ·  unclassified: {len(unclassified)}",
+    )
+    print(f"  next free number: {next_number(blocks)}")
+    print()
+    print(f"OPEN — awaiting an owner decision ({len(open_blocks)}):")
+    if open_blocks:
+        _print_block_lines(open_blocks)
+    else:
+        print("  (none)")
+    if unclassified:
+        # Mostly older blocks with no leading `> **MARKER**` line — summarise, don't
+        # dump; the actionable signal is the OPEN list above. `--unclassified` lists them.
+        print()
+        print(
+            f"unclassified: {len(unclassified)} block(s) with an unrecognised/absent "
+            "marker (mostly older formats) — run --unclassified to list, --json for all.",
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Digest the maintainer question router.",
+    )
+    parser.add_argument(
+        "--router",
+        default=str(ROUTER_FILE),
+        help="router markdown path",
+    )
+    parser.add_argument(
+        "--next",
+        action="store_true",
+        help="print only the next free Q-number",
+    )
+    parser.add_argument(
+        "--open",
+        action="store_true",
+        help="print only the OPEN blocks",
+    )
+    parser.add_argument(
+        "--unclassified",
+        action="store_true",
+        help="print the blocks with an unrecognised/absent marker",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit the parsed blocks as JSON",
+    )
+    args = parser.parse_args(argv)
+
+    path = Path(args.router)
+    if not path.exists():
+        parser.error(f"router file not found: {path}")
+    blocks = parse_blocks(path.read_text(encoding="utf-8"))
+
+    if args.next:
+        print(next_number(blocks))
+    elif args.json:
+        print(json.dumps([asdict(b) for b in blocks], indent=2, ensure_ascii=False))
+    elif args.open:
+        _print_block_lines([b for b in blocks if b.status == "open"])
+    elif args.unclassified:
+        _print_block_lines([b for b in blocks if b.status == "unclassified"])
+    else:
+        _print_digest(blocks)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_router_status.py
+++ b/tests/unit/scripts/test_router_status.py
@@ -1,0 +1,104 @@
+"""Tests for ``scripts/router_status.py`` — the question-router digest."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_module():
+    """Load ``scripts/router_status.py`` by path (scripts/ is not a package)."""
+    script = REPO_ROOT / "scripts" / "router_status.py"
+    spec = importlib.util.spec_from_file_location("_router_status", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so the @dataclass decorator can resolve the module
+    # (dataclasses looks the module up in sys.modules by name).
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_MOD = _load_module()
+
+_SAMPLE = """# Maintainer question router
+
+### Q-0001 — A decided thing (2026-06-01)
+
+> **DECISION 2026-06-01 (owner-directed).** Body.
+
+**Home:** somewhere.
+
+---
+
+### Q-0002 — An answered thing (2026-06-02)
+
+> **ANSWERED 2026-06-02.** Body.
+
+### Q-0010 — Still open (2026-06-19)
+
+> **OPEN — DISCUSS lane, owner decides.** Body.
+
+### Q-0011 — Partial (2026-06-19)
+
+> **PARTLY DECIDED 2026-06-19.** Body.
+
+### Q-0012 — An observation
+
+> **OBSERVED 2026-06-14.** Body, no decision.
+"""
+
+
+def test_parse_blocks_counts_and_numbers() -> None:
+    blocks = _MOD.parse_blocks(_SAMPLE)
+    assert [b.number for b in blocks] == [1, 2, 10, 11, 12]
+    assert [b.qid for b in blocks] == ["Q-0001", "Q-0002", "Q-0010", "Q-0011", "Q-0012"]
+
+
+def test_title_and_date_extracted() -> None:
+    blocks = _MOD.parse_blocks(_SAMPLE)
+    first = blocks[0]
+    assert first.title == "A decided thing"
+    assert first.date == "2026-06-01"
+    # A block without a trailing date still parses (no date, full title).
+    obs = blocks[-1]
+    assert obs.title == "An observation"
+    assert obs.date == ""
+
+
+def test_classification() -> None:
+    by_id = {b.qid: b.status for b in _MOD.parse_blocks(_SAMPLE)}
+    assert by_id["Q-0001"] == "decided"  # DECISION
+    assert by_id["Q-0002"] == "decided"  # ANSWERED
+    assert by_id["Q-0010"] == "open"  # OPEN
+    assert by_id["Q-0011"] == "open"  # PARTLY DECIDED -> open (checked before DECIDED)
+    assert by_id["Q-0012"] == "unclassified"  # OBSERVED is neither
+
+
+def test_next_number() -> None:
+    blocks = _MOD.parse_blocks(_SAMPLE)
+    assert _MOD.next_number(blocks) == "Q-0013"  # highest (12) + 1
+    assert _MOD.next_number([]) == "Q-0001"
+
+
+def test_classify_tokens() -> None:
+    assert _MOD.classify("DECIDED + APPLIED 2026-06-16") == "decided"
+    assert _MOD.classify("NOW LIVE") == "decided"
+    assert _MOD.classify("PROPOSED") == "open"
+    assert _MOD.classify("Status:") == "unclassified"
+
+
+def test_real_router_parses() -> None:
+    """Smoke test against the committed router: it parses and the next number is sane."""
+    router = REPO_ROOT / "docs" / "owner" / "maintainer-question-router.md"
+    if not router.exists():  # pragma: no cover - the file is committed
+        return
+    blocks = _MOD.parse_blocks(router.read_text(encoding="utf-8"))
+    assert len(blocks) > 100  # the router is large and append-only
+    numbers = [b.number for b in blocks]
+    assert max(numbers) >= 179  # Q-0179 was appended this initiative
+    # Every block classified into exactly one of the three buckets.
+    assert all(b.status in {"open", "decided", "unclassified"} for b in blocks)


### PR DESCRIPTION
## What

A small grooming-ender that executes the idea I captured in #1102's session card (Q-0089): a stdlib
**digest of the maintainer question router**.

The router is append-only and now **184 blocks / ~6,500 lines**. Two recurring per-session chores —
finding the next free `Q-NNNN` to append, and scanning for which decisions are still **OPEN** for the
owner — I did by hand (grep) twice in this very session (routing Q-0179). This tool removes that friction.

`scripts/router_status.py` (pure stdlib, read-only — never writes the router):
- **next free number** — exact (header parse): `--next` → `Q-0180`.
- **OPEN owner-decision queue** vs **DECIDED**, classified by each block's leading `> **MARKER**`
  convention, with an honest **UNCLASSIFIED** bucket for older/absent markers (the Q-0120 "report what
  the tool is unsure about" discipline). Flags: `--open`, `--unclassified`, `--json`.

Live output today: `next free number: Q-0180`; OPEN = **2** (Q-0137 partial · Q-0179) — both genuinely-open
blocks correctly surfaced.

Carries the **Q-0105** provenance/reliability header (unverified, disposable, "delete if it proves
unreliable"). Read-only stdlib + a unit test — no runtime/`disbot/` code. Pairs with the website
owner-zone "open decisions" surface (it could feed `export_dashboard_data.py`).

Born-red per Q-0133; flips to `complete` last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C27AavfY95e5bp82FTZFpY

---
_Generated by [Claude Code](https://claude.ai/code/session_01C27AavfY95e5bp82FTZFpY)_