### PR TITLE
fix(ci): pr-conflict-guard polls through GitHub's UNKNOWN-mergeability window

### DIFF
--- a/.github/workflows/pr-conflict-guard.yml
+++ b/.github/workflows/pr-conflict-guard.yml
@@ -22,6 +22,12 @@ name: pr-conflict-guard
 # Provenance + reliability (Q-0105): added 2026-06-16, owner-directed. UNVERIFIED — confirm the
 # first DIRTY PR actually shows the red `conflict-guard` status and that it clears on resolution.
 # Delete this workflow if it flaps or misreports; conflicts are also visible in the PR UI banner.
+#
+# 2026-06-19 fix: the push:main sweep queried mergeability the instant main moved and saw UNKNOWN
+# (GitHub computes it ASYNCHRONOUSLY — the query is what triggers it), so it skipped the very PR
+# that had just become DIRTY (the #1104 miss — log: "#1104 mergeability not computed yet -> skip").
+# The sweep now polls through that UNKNOWN window (resolve_state) before deciding. Still confirm on
+# the next real DIRTY PR that the red status now appears within ~30s of the conflicting merge.
 
 on:
   push:
@@ -77,16 +83,39 @@ jobs:
             fi
           }
 
+          # Poll through the UNKNOWN window GitHub shows right after main moves: mergeability is
+          # computed ASYNCHRONOUSLY and a query is what triggers it, so the push:main sweep (which
+          # runs seconds after a merge) would otherwise see UNKNOWN and skip the very PR that just
+          # went DIRTY — the #1104 miss. Returns a settled state, or UNKNOWN only if it never settles.
+          resolve_state() {  # $1=num -> echoes mergeStateStatus
+            local num="$1" s tries=0
+            while :; do
+              s=$(gh pr view "$num" --repo "$GITHUB_REPOSITORY" --json mergeStateStatus \
+                    --jq '.mergeStateStatus' 2>/dev/null || echo "")
+              case "$s" in
+                UNKNOWN|"") : ;;                        # not computed yet — keep polling
+                *)          printf '%s' "$s"; return 0 ;;
+              esac
+              tries=$((tries + 1))
+              if [ "$tries" -ge 10 ]; then printf '%s' "UNKNOWN"; return 0; fi
+              sleep 3
+            done
+          }
+
           if [ "${EVENT:-}" = "pull_request" ]; then
-            line=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-                     --json mergeStateStatus,headRefOid \
-                     --jq '"\(.mergeStateStatus) \(.headRefOid)"' || true)
-            post "$PR_NUMBER" "$(printf '%s' "$line" | awk '{print $1}')" "$(printf '%s' "$line" | awk '{print $2}')"
+            sha=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+                    --json headRefOid --jq '.headRefOid' 2>/dev/null || true)
+            post "$PR_NUMBER" "$(resolve_state "$PR_NUMBER")" "$sha"
           else
             prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
                     --json number,mergeStateStatus,headRefOid \
                     --jq '.[] | "\(.number) \(.mergeStateStatus) \(.headRefOid)"' || true)
             if [ -z "${prs:-}" ]; then echo "no open PRs to evaluate"; exit 0; fi
-            printf '%s\n' "$prs" | while read -r num state sha; do post "$num" "$state" "$sha"; done
+            # Every open PR is briefly UNKNOWN right after main moves — re-resolve those by polling
+            # instead of skipping them (the bug this fixes).
+            printf '%s\n' "$prs" | while read -r num state sha; do
+              case "$state" in UNKNOWN|"") state="$(resolve_state "$num")" ;; esac
+              post "$num" "$state" "$sha"
+            done
           fi
           exit 0

--- a/.sessions/2026-06-19-conflict-guard-unknown-race-fix.md
+++ b/.sessions/2026-06-19-conflict-guard-unknown-race-fix.md
@@ -1,0 +1,62 @@
+# 2026-06-19 — Fix the pr-conflict-guard UNKNOWN-mergeability race
+
+> **Status:** `complete`
+
+## Arc
+
+Follow-on bug fix from the website-split session (#1104). The owner asked why the conflict guard
+(`pr-conflict-guard.yml`, Q-0154) didn't turn #1104 red when it became conflicted. Root-caused it from
+the guard's own job log and fixed the race.
+
+## Root cause (proven, not theorized)
+
+When #1105 merged to `main` (12:34), the guard's `push: main` sweep ran **4 seconds later** and logged:
+
+```
+#1104 mergeability not computed yet -> skip
+#1074 CLEAN -> success
+```
+
+GitHub computes a PR's mergeability **asynchronously** — the instant `main` moves, every open PR's merge
+state is invalidated to `UNKNOWN` until GitHub recomputes it (a *query* is what triggers the compute). The
+guard's only real-time "main moved" trigger is `push: main`, which fires seconds after the merge — so it
+queried #1104, saw `UNKNOWN`, hit its `UNKNOWN|"") -> skip` branch, and **never posted the red status**.
+`#1074` was correct only because its mergeability was already cached (it hadn't just changed).
+
+Backstops couldn't save it: the `pull_request` trigger can't run on a conflicted PR (no merge ref — same
+reason Code Quality didn't run), and the `schedule` is every 3h while the conflict was resolved in ~5 min.
+So it's a **latent timing race**, not a regression — it "worked" before only when a dirty PR sat long
+enough for a later sweep/schedule to re-check it after mergeability settled.
+
+## Fix (`pr-conflict-guard.yml`)
+
+Added a `resolve_state()` poller: when a PR reports `UNKNOWN`, re-query `gh pr view ... mergeStateStatus`
+up to 10× at 3s intervals (≤30s) until it settles, instead of skipping. Applied in both the `push`/
+`schedule` sweep (per-PR) and the `pull_request` path. `post()` is unchanged — a still-`UNKNOWN` PR after
+30s still skips (fail-safe; never false-flags). Non-required visibility status, so the change can't break
+merges. Header provenance updated; YAML validated.
+
+## Context delta
+
+- The compounding insight for the agent network: a **conflicted PR runs *no* `pull_request` workflows**
+  (GitHub needs a merge ref), so any conflict check must live on `push: main` / `schedule` — and on
+  `push: main` it MUST poll through the async-mergeability `UNKNOWN` window or it misses the common case.
+- This pairs with the website-split session's lesson: when CI doesn't start on a PR, check
+  `mergeable_state` **first** (a `dirty` PR silently blocks `pull_request` CI) before theorizing about
+  token/trigger issues.
+
+## Verification
+
+- `python3.10 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-conflict-guard.yml'))"` → OK.
+- Full runtime verification needs the next real DIRTY PR to confirm the red `conflict-guard` status now
+  appears within ~30s of the conflicting merge (noted in the workflow header; the guard stays Q-0105
+  "unverified / disposable" until then).
+
+## 📤 Run report
+
+- **Did:** root-caused (from the guard's job log) why `pr-conflict-guard` didn't flag #1104 red, and fixed
+  the async-mergeability `UNKNOWN`-skip race with a bounded poll. · **Outcome:** shipped.
+- **Run type:** `manual` (owner question → discovered bug → fix).
+- **⚑ Self-initiated:** the fix — a contained, reversible bug fix to a non-required visibility workflow,
+  acted on per "bugs first / act on contained reversible fixes." Flagged here for review.
+- **↪ Next:** confirm on the next real conflicted PR that the red status appears; otherwise none.


### PR DESCRIPTION
## What

Fixes why `pr-conflict-guard.yml` (Q-0154) **didn't turn #1104 red** when it became conflicted — the exact failure the owner flagged.

## Root cause (from the guard's own job log)

When #1105 merged to `main`, the guard's `push: main` sweep ran **4 seconds later** and logged:

```
#1104 mergeability not computed yet -> skip
#1074 CLEAN -> success
```

GitHub computes PR mergeability **asynchronously** — the instant `main` moves, every open PR's merge state is invalidated to `UNKNOWN` until GitHub recomputes it (a *query* is what triggers the compute). The guard's only real-time "main moved" trigger is `push: main`, which fires seconds after the merge, so it queried #1104, saw `UNKNOWN`, hit its `UNKNOWN -> skip` branch, and **never posted the red status**. `#1074` was correct only because its state was already cached.

The backstops can't cover it: the `pull_request` trigger can't run on a conflicted PR (no merge ref — same reason Code Quality didn't run), and the `schedule` is every 3h while the conflict was resolved in ~5 min. So it's a **latent timing race**, not a regression.

## Fix

Add `resolve_state()`: when a PR reports `UNKNOWN`, re-query up to 10× at 3s intervals (≤30s) until it settles, instead of skipping. Applied to both the `push`/`schedule` sweep and the `pull_request` path. `post()` is unchanged — a PR still `UNKNOWN` after 30s still skips (fail-safe; never false-flags). It's a **non-required visibility status**, so this cannot affect the merge pipeline.

## Verification

YAML validated; all four triggers intact. Full runtime confirmation needs the next real DIRTY PR (the guard stays Q-0105 "unverified/disposable" until then — noted in the workflow header). Session card `complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txth4MHhF5Li6fQJ4koA27

---
_Generated by [Claude Code](https://claude.ai/code/session_01Txth4MHhF5Li6fQJ4koA27)_