### PR TITLE
docs(website-split): make §5 decomposition truly file-disjoint pre-ultracode

### DIFF
--- a/.sessions/2026-06-19-website-plan-disjoint-tighten.md
+++ b/.sessions/2026-06-19-website-plan-disjoint-tighten.md
@@ -1,0 +1,51 @@
+# 2026-06-19 — Pre-ultracode: make the website-plan §5 decomposition truly file-disjoint
+
+> **Status:** `complete`
+
+## Arc
+
+The owner is about to dispatch the website two-site-split plan (`website-two-site-split-plan-2026-06-19.md`)
+to an **ultracode** parallel build fleet and asked what to clear up first. A parallel fleet can't
+coordinate at the file level — file-disjointness *is* the mechanism — so §5 was reviewed for collisions.
+
+## Findings (the plan promised "exclusive file sets" but violated it)
+
+- **`botsite/app.py` claimed by three "parallel" units** (P1 skeleton, P2 reference-page routes, P4
+  `/submit` route) — guaranteed write collision, hedged with "if P1 lands a thin shell / otherwise fold."
+- **`scripts/export_dashboard_data.py` claimed by two** (S1 subset emitter, P3 changelog parse) — hedged
+  "coordinate with S1 or fold."
+- **Unresolved either/ors a fleet can't pick:** S2's module shape (`dashboard_db/` *or* per-service
+  helpers), P4's rate-limiter ("copy *or* shared import").
+- **`site.json` whitelist not pinned to exact keys** → S1's redaction guard would be non-deterministic.
+- A latent `botsite/README.md` double-claim (P1 + P8).
+
+## Fix (shipped — §5 rewrite)
+
+- **Single-owner files:** S1 owns `export_dashboard_data.py` end-to-end (subset emitter **+ the
+  bot_changelog parse** + `site.json`); **P1 owns `botsite/app.py` and wires ALL routes up front**, so no
+  back-half unit edits it. Moved P1 into the **serial foundation** (S1 → {S2, P1} → parallel P2–P8).
+- **Back half now truly disjoint:** P2/P3 own only templates; P4 owns `botsite/submit.py` (fills P1's
+  stub router) + `ratelimit.py` (pinned: **copy**, no shared import) + `submit.html`; P5 dev-site
+  moderation; P6 `github_mirror.py`; P7 the redaction-audit doc only; P8 a new `botsite-deploy.md` +
+  env-vars (P8 no longer touches `botsite/README.md`).
+- **S2 pinned:** one DDL/migration + two independent helpers (`botsite/submissions_db.py` INSERT-only,
+  `dashboard/submissions_db.py` SELECT/UPDATE) sharing only the table contract, not code.
+- **`site.json` whitelist pinned** to exact top-level keys (meta/counts/catalogue/commands/bot_changelog).
+- **Build-without-live-infra** note added: every unit builds code+tests against a test DB + mocked GitHub;
+  owner provisions Railway/Postgres/token at rollout — so no unit blocks on infra.
+
+## Context delta
+
+- The plan is now genuinely dispatchable to a parallel fleet: serial `S1 → {S2, P1}`, then 7 file-disjoint
+  back-half units. The remaining owner-side items are **not build blockers** — provisioning at rollout, and
+  the (deferred, security-review-gated) control-panel→3rd-service decision, which is out of the first wave.
+
+## 📤 Run report
+
+- **Did:** pre-ultracode review of §5; folded the `app.py` (×3) and `export_dashboard_data.py` (×2)
+  collisions into single owners, pinned the S2 module shape / rate-limiter / `site.json` whitelist, added a
+  build-without-infra note. · **Outcome:** shipped — the decomposition is now truly file-disjoint.
+- **Run type:** `manual` (owner question → readiness fix).
+- **⚑ Self-initiated:** the §5 tightening — contained, reversible plan edit that makes the doc honor its own
+  "exclusive file set" contract; flagged here for review.
+- **↪ Next:** dispatch §5 to ultracode — serial `S1 → {S2, P1}`, then parallel `P2–P8`.

--- a/docs/planning/website-two-site-split-plan-2026-06-19.md
+++ b/docs/planning/website-two-site-split-plan-2026-06-19.md
@@ -378,56 +378,78 @@ security-reviewed slice *after* the first additive build wave (which stays 2 ser
 
 ## 5. Decomposition into file-disjoint build units  *(deliverable 5)*
 
-Sequenced **serial foundation → parallel back half**. Each unit lists its **exclusive file set** so the
-parallel units are ultracode-able with no write conflicts. (The brief's reason for plan-first: the front
-half is serial; only after it can the back half fan out.)
+Sequenced **serial foundation → parallel back half**. Each unit lists its **exclusive file set**; the
+parallel units share **no** file, so a fleet builds them with no write conflicts. **Tightened
+2026-06-19 pre-ultracode** to make that literally true: the earlier draft let three "parallel" units edit
+`botsite/app.py` (P1/P2/P4) and two edit `export_dashboard_data.py` (S1/P3), with "decide at build / or
+fold" hedges a parallel fleet can't resolve. Those overlaps are folded into single owners below, and the
+remaining either/ors (S2's module shape, the rate-limiter, the whitelist keys) are pinned.
 
-### Serial foundation (must land first — everything downstream depends on it)
+**Build-without-live-infra (so no unit blocks on provisioning).** Every unit builds **code + tests only**,
+against a **test DB** (S2's schema on a throwaway/test Postgres or SQLite) and a **mocked GitHub** (P6) —
+exactly the `importorskip`/mock pattern the existing `dashboard/` suite uses. No unit needs the real
+Railway service, the real Postgres, or any token; the owner provisions those at **rollout** (§6).
 
-- **S1 — public data subset + freshness/whitelist guard.**
-  Files: `scripts/export_dashboard_data.py` (add the `site.json` subset emitter; add `--targets`),
-  `botsite/data/site.json` (generated, committed), `scripts/check_generated_artifacts_fresh.py` (+
-  `check_dashboard_data.py`) register `site.json` with a key-whitelist assertion, `tests/unit/scripts/…`.
-  *Why serial:* every bot-site page reads `site.json`; the whitelist is the redaction guarantee.
-- **S2 — submissions DB schema + access contract.**
-  Files: a new `dashboard_db/` (or `botsite/db.py` + `dashboard/db_submissions.py` sharing only the DDL)
-  with the `submissions` DDL/migration + a tiny stdlib-ish access layer (INSERT for the bot site, SELECT
-  /UPDATE for the dev site), tests. *Why serial:* both the intake (P3) and moderation (P5) units bind to
-  this schema. *(DB choice = §7.3; recommend a separate dashboard Postgres.)*
+### Serial foundation (must land first, in order — everything downstream depends on it)
 
-### Parallel back half (file-disjoint — ultracode-able together once S1+S2 land)
+- **S1 — the data producer, end to end (sole owner of `export_dashboard_data.py`).**
+  Files: `scripts/export_dashboard_data.py` (the `site.json` subset emitter + `--targets` **+ the
+  `bot_changelog` parse**, folded in here so no other unit touches the producer), `docs/bot-changelog.md`
+  (seed the curated source), `botsite/data/site.json` (generated + committed),
+  `scripts/check_generated_artifacts_fresh.py` (+ `check_dashboard_data.py`) registering `site.json` with
+  the **key-whitelist** assertion, `tests/unit/scripts/test_export_dashboard_data.py`.
+  **Whitelist — the exact allowed top-level `site.json` keys (the redaction guarantee, fails closed on a
+  new key):** `meta` (build sha/subject/date only), `counts` (catalogue counts only —
+  commands/features/games; **never** server/user totals), `catalogue` (subsystem + game
+  name/description/category/badges), `commands` (name/aliases/category/cooldown/permissions/usage — no
+  per-guild values), `bot_changelog`. **Omits** `env_usage`, `settings`, `access`, `reviews`, `ideas`, raw
+  `bugs`, and anything not listed.
+- **S2 — submissions store: one schema, two independent access helpers (no shared package — §2.2).**
+  Files: one committed **DDL/migration** for the `submissions` table (§2.3); `botsite/submissions_db.py`
+  (a single `insert_pending(...)`, **INSERT-only**); `dashboard/submissions_db.py`
+  (`list_pending()` / `set_status()` / `attach_issue_url()`, SELECT+UPDATE); tests for each. The two
+  helpers **share only the table contract (the DDL), not code** — that is what keeps the services
+  decoupled. *(Store = separate dashboard Postgres, §7.3.)*
+- **P1 — bot-site app + ALL routes (sole owner of `botsite/app.py`).**
+  Files: `botsite/__init__.py`, `botsite/app.py`, `botsite/Procfile`, `botsite/requirements.txt`,
+  `botsite/data_loader.py` (load/validate `site.json`), `botsite/templates/base.html`,
+  `botsite/templates/index.html`, `botsite/submit.py` (an **empty stub `APIRouter`** so the app boots —
+  P4 owns its real content), `botsite/README.md`, `tests/unit/botsite/test_app.py`. **`app.py` wires every
+  route up front** — `/`, `/commands`, `/features`, `/changelog`, `/status`, `/healthz` (each renders its
+  template *by filename*; the templates land in P2/P3) and `/submit` (via
+  `app.include_router(submit_router)`). This single-owner `app.py` is what makes the back half disjoint —
+  **no other unit edits `app.py`.** *(Honor the no-`static/` gotcha.)*
 
-- **P1 — bot-site skeleton.** Exclusive: `botsite/__init__.py`, `botsite/app.py`, `botsite/Procfile`,
-  `botsite/requirements.txt`, `botsite/templates/base.html`, `botsite/templates/index.html` (landing),
-  `botsite/README.md`, `tests/unit/botsite/`. The new service that boots, serves `/` + `/healthz`,
-  reads `site.json`. *(Honor the no-`static/` gotcha.)*
-- **P2 — bot-site reference pages.** Exclusive: `botsite/templates/commands.html`,
-  `botsite/templates/features.html`, the routes for them in `botsite/app.py` *(if P1 lands a thin app
-  shell first, P2 adds routes in a disjoint region; otherwise fold P1+P2)*. Read-only command reference +
-  feature showcase from `site.json`.
-- **P3 — bot-site changelog + status widget.** Exclusive: `botsite/templates/changelog.html`,
-  `botsite/templates/status.html`, `docs/bot-changelog.md` (the curated source), the changelog parse in
-  `export_dashboard_data.py`'s subset *(coordinate the one shared producer line with S1 — or fold the
-  changelog parse into S1)*. The "generated vs live" freshness badges.
-- **P4 — bot-site submission form (intake).** Exclusive: `botsite/templates/submit.html`, the `/submit`
-  route + intake logic in `botsite/app.py`, `botsite/ratelimit.py` (copy the proven stdlib limiter) or a
-  shared import, honeypot + validation, tests. Writes `pending` rows via S2's INSERT path.
+### Parallel back half (truly file-disjoint — fan out once S1 + S2 + P1 land)
+
+- **P2 — reference-page templates.** Exclusive: `botsite/templates/commands.html`,
+  `botsite/templates/features.html`. Read-only command reference + feature showcase from `site.json`,
+  rendered by P1's already-wired routes. Templates only — no `app.py`.
+- **P3 — changelog + status templates.** Exclusive: `botsite/templates/changelog.html`,
+  `botsite/templates/status.html` + the "generated vs live" freshness badges. Reads `site.json.bot_changelog`
+  + `meta.build` (both produced by S1). Templates only — no `app.py`, no producer edit.
+- **P4 — submission intake module.** Exclusive: `botsite/submit.py` (the `/submit` `APIRouter` + honeypot +
+  validation + INSERT via S2's `botsite/submissions_db.py` — fills in P1's stub), `botsite/ratelimit.py`
+  (**copy** the proven stdlib limiter — no shared import, §2.2), `botsite/templates/submit.html`,
+  `tests/unit/botsite/test_submit.py`.
 - **P5 — dev-site moderation UI.** Exclusive: `dashboard/templates/moderation.html`, the
   `/admin/moderation` route + approve/reject handlers in `dashboard/app.py`, owner-gate helper,
-  `tests/unit/dashboard/test_moderation.py`. Lists `pending`, approve/reject, CSRF-protected.
-- **P6 — GitHub-mirror mechanism.** Exclusive: `dashboard/github_mirror.py` (the least-privilege
-  issue-create client, template-shape mapping) + its test. Called by P5 on approve. *(Disjoint module so
-  it can be built/tested against a stub independently of P5's UI.)*
-- **P7 — dev-site public-read posture + redaction audit record.** Exclusive: a short
-  `docs/operations/dashboard-redaction-audit.md` (the §4.1 matrix as a living checklist) + any small
-  route/nav copy tweaks confirming the public-read framing + the freshness badges on the dev read pages.
-- **P8 — deploy + env docs.** Exclusive: `botsite/README.md` deploy recipe (2nd-service-style),
-  `dashboard/README.md` moderation note, `docs/operations/env-vars.md` (+ the new env names:
-  `GITHUB_ISSUE_MIRROR_TOKEN`, the submissions DSN, optional captcha keys), Railway setup notes.
+  `tests/unit/dashboard/test_moderation.py`. Lists `pending`, approve/reject, CSRF-protected; uses S2's
+  `dashboard/submissions_db.py` + P6's mirror.
+- **P6 — GitHub-mirror mechanism.** Exclusive: `dashboard/github_mirror.py` (least-privilege issue-create
+  client + template-shape mapping) + its test. Called by P5 on approve; built/tested against a stub first.
+- **P7 — redaction audit record.** Exclusive: `docs/operations/dashboard-redaction-audit.md` (the §4.1
+  matrix as a living checklist). Docs only — no `dashboard/app.py` or shared-template edits (those belong
+  to P5), so it can't collide.
+- **P8 — deploy + env docs.** Exclusive: `docs/operations/botsite-deploy.md` (new — the 2nd-service deploy
+  recipe + Railway setup), `docs/operations/env-vars.md` (+ the new env names: `GITHUB_ISSUE_MIRROR_TOKEN`,
+  the submissions DSN, optional captcha keys), `dashboard/README.md` (moderation note). *(P1 owns
+  `botsite/README.md`; P8 does not touch it.)*
 
-**Dependency graph:** `S1 → {P1, P2, P3}` · `S2 → {P4, P5}` · `P5 → P6` (P6 buildable in isolation
-against a stub first) · `{P1…P8}` otherwise parallel. The ultracode run takes S1+S2 serial, then fans
-out P1–P8 (P2/P3 sequence behind P1 only if P1 lands a shared app shell; otherwise mergeable as one).
+**Dependency graph:** serial `S1 → {S2, P1}` (S2 and P1 are file-disjoint, so they run together after S1);
+then the parallel back half `{P2, P3, P4, P5, P6, P7, P8}`. Edges within it: P4 fills P1's `submit.py` stub
+and uses S2's INSERT helper (so P4 lands after P1+S2); P5 uses S2's read helper + P6 (P6 is stub-buildable
+in isolation first). No two back-half units share a file.
 
 ---
 


### PR DESCRIPTION
## What

Pre-ultracode readiness pass on the website two-site-split plan, answering "anything to clear up before sending it to the fleet?" A **parallel** fleet can't coordinate at the file level — file-disjointness *is* the mechanism — and §5 promised "exclusive file sets" it didn't actually deliver.

## Collisions found (would cause merge conflicts / divergent builds)

- **`botsite/app.py` claimed by 3 "parallel" units** (P1 skeleton, P2 routes, P4 `/submit`), hedged "if P1 lands a thin shell / otherwise fold."
- **`scripts/export_dashboard_data.py` claimed by 2** (S1 + P3 changelog parse), hedged "coordinate or fold."
- **Unresolved either/ors** a fleet can't pick: S2's module shape (`dashboard_db/` *or* per-service helpers), P4's rate-limiter (copy *or* shared import).
- **`site.json` whitelist not pinned** to exact keys → non-deterministic redaction guard.
- Latent `botsite/README.md` double-claim (P1 + P8).

## Fix (§5 rewrite)

- **Single owners:** S1 owns `export_dashboard_data.py` end-to-end (+ the `bot_changelog` parse) + `site.json`; **P1 owns `botsite/app.py` and wires every route up front**, moved into the serial foundation (`S1 → {S2, P1}`) so **no back-half unit edits `app.py`**.
- **Back half now truly disjoint:** P2/P3 templates only; P4 owns `submit.py` (fills P1's stub router) + `ratelimit.py` (**copy**, pinned) + `submit.html`; P7 docs-only; P8 a new `botsite-deploy.md` (no `botsite/README.md` clash).
- **S2 pinned:** one DDL/migration + two independent helpers (`botsite/submissions_db.py` INSERT-only, `dashboard/submissions_db.py` SELECT/UPDATE) sharing only the table contract.
- **`site.json` whitelist pinned** to exact top-level keys.
- **Build-without-live-infra** note: units build code + tests against a test DB + mocked GitHub; owner provisions Railway/Postgres/token at rollout, so no unit blocks on infra.

Result: dispatchable as serial `S1 → {S2, P1}`, then 7 file-disjoint back-half units. Docs-only — no runtime change. Session card `complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txth4MHhF5Li6fQJ4koA27

---
_Generated by [Claude Code](https://claude.ai/code/session_01Txth4MHhF5Li6fQJ4koA27)_