### PR TITLE
chore(gitignore): ignore transient background-agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,7 @@ superbot_btd6_data/
 
 # Local Claude Code settings (personal, not committed)
 .claude/settings.local.json
+
+# Transient git worktrees created by background agents (isolation: worktree).
+# Registered under .git/worktrees and auto-cleaned; never tracked in the parent repo.
+.claude/worktrees/


### PR DESCRIPTION
## What

Background agents launched with `isolation: worktree` get a git worktree under `.claude/worktrees/agent-<id>/` **inside the main checkout**, so it showed up as untracked in the parent repo (and tripped the Stop-hook untracked-files check during the website-foundation build run). These worktrees are registered under `.git/worktrees` and auto-cleaned; they must never be committed to the parent repo.

Adds `.claude/worktrees/` to `.gitignore` (next to the existing `.claude/settings.local.json` entry). Pure hygiene — helps every future agent-spawning session, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txth4MHhF5Li6fQJ4koA27

---
_Generated by [Claude Code](https://claude.ai/code/session_01Txth4MHhF5Li6fQJ4koA27)_