### PR TITLE
Website two-site split: serial foundation (S1 + S2 + P1)

### DIFF
--- a/.sessions/2026-06-19-website-foundation-s1s2p1.md
+++ b/.sessions/2026-06-19-website-foundation-s1s2p1.md
@@ -1,0 +1,22 @@
+# 2026-06-19 — Website two-site split: serial foundation (S1 + S2 + P1)
+
+> **Status:** `in-progress`
+
+Building the **serial foundation** of the website two-site-split per
+`docs/planning/website-two-site-split-plan-2026-06-19.md` §5: the three disjoint
+foundation units that everything downstream depends on.
+
+- **S1** — extend `scripts/export_dashboard_data.py` to also emit
+  `botsite/data/site.json` (a redaction-by-construction public subset), fold in the
+  `bot_changelog` parse, seed `docs/bot-changelog.md`, register `site.json` in the
+  freshness/whitelist guards.
+- **S2** — the `submissions` table DDL + two independent access helpers
+  (`botsite/submissions_db.py` INSERT-only; `dashboard/submissions_db.py` read/moderate).
+- **P1** — the bot-site FastAPI app (`botsite/`) with every route wired up front + an
+  empty `/submit` stub router.
+
+Scope fence: foundation only (no P2–P8, no control-manager, no `disbot/` edits, no deploy).
+
+<!-- This card is born-red (in-progress) per Q-0133: the check_session_gate step in
+code-quality holds the auto-merge until the Status flips to `complete`. The close-out
+docs (Context delta, idea, previous-session review, run report) land before that flip. -->

--- a/.sessions/2026-06-19-website-foundation-s1s2p1.md
+++ b/.sessions/2026-06-19-website-foundation-s1s2p1.md
@@ -1,6 +1,6 @@
 # 2026-06-19 — Website two-site split: serial foundation (S1 + S2 + P1)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 Building the **serial foundation** of the website two-site-split per
 `docs/planning/website-two-site-split-plan-2026-06-19.md` §5: the three disjoint
@@ -20,3 +20,136 @@ Scope fence: foundation only (no P2–P8, no control-manager, no `disbot/` edits
 <!-- This card is born-red (in-progress) per Q-0133: the check_session_gate step in
 code-quality holds the auto-merge until the Status flips to `complete`. The close-out
 docs (Context delta, idea, previous-session review, run report) land before that flip. -->
+
+## Shipped (PR #1109)
+
+All three foundation units, in order `S1 → {S2, P1}`:
+
+- **S1** — `scripts/export_dashboard_data.py` emits both `dashboard.json` + the new
+  `botsite/data/site.json` (`--targets`, both by default). `build_site_subset()` is
+  redaction-by-construction (top-level keys *exactly* `{meta, counts, catalogue,
+  commands, bot_changelog}`; catalogue-only counts; value-free commands). Folded in the
+  `bot_changelog` parse + seeded `docs/bot-changelog.md`. Registered `site.json` in
+  `check_dashboard_data.check_site_subset` (fail-closed whitelist + counts) and
+  `check_generated_artifacts_fresh` (freshness). Tests in
+  `tests/unit/scripts/test_export_dashboard_data.py` (+ the two guard test files).
+- **S2** — `botsite/migrations/001_submissions.sql` (one canonical DDL, separate
+  dashboard-owned Postgres) + `botsite/submissions_db.py` (INSERT-only) +
+  `dashboard/submissions_db.py` (SELECT+UPDATE). Share only the table contract, no
+  code. Tests run with no live Postgres (pure helpers + a fake asyncpg connection).
+- **P1** — `botsite/{__init__,app,data_loader,submit}.py` + `Procfile` +
+  `requirements.txt` + `templates/{base,index}.html` + `README.md` +
+  `tests/unit/botsite/test_app.py`. `app.py` wires every route up front; `/submit` is
+  a mounted empty-stub router; secret-free; no `static/`.
+
+**Verification:** `check_quality.py --full` green (formatters + `mypy disbot/` + full
+pytest **10,895 passed, 37 skipped**); `check_architecture.py --mode strict` exit 0;
+no web→`disbot/` import. Verified locally that the app boots and `/` renders without
+loading `disbot`, and that the whitelist guard fails closed on an injected `env_usage`
+key.
+
+## Decisions made alone (ratify)
+
+- **`commands` subset `cooldown` = `null`.** The AST command scanner
+  (`scan_commands.py`) does not statically resolve runtime cooldown decorators, so the
+  whitelisted `cooldown` field is emitted `None` rather than fabricated. `name` /
+  `aliases` / `category` / `permissions` (= subsystem `visibility_tier`) / `usage`
+  (= the scanner's `brief`) are populated honestly. A later unit can enrich `cooldown`
+  if the scanner learns to read `@commands.cooldown(...)`.
+- **Raised the `check_docs` top-level-docs ratchet 19→20.** The plan pins
+  `docs/bot-changelog.md` at the docs root; it is a genuine top-level *content* peer
+  (a durable user-facing ledger alongside `current-state.md` / `roadmap.md`), so this
+  is a sanctioned raise in the same class as the 2026-06-14 `repo-sector-map` raise —
+  documented inline. (The alternative, hiding it in a subdir, would fight the plan's
+  pinned path and the README/producer references.)
+- **`site.json` whitelist enforced in three places.** The producer (`build_site_subset`
+  raises on a stray key), `check_dashboard_data.check_site_subset` (error-severity,
+  fail-closed), and `check_generated_artifacts_fresh.drift_site_json`. Triple-guarding
+  the redaction boundary is deliberate — it is non-negotiable #1 of the plan.
+
+## 💡 Session idea — public-data-contract *field-level* snapshot test
+
+S1 guards the `site.json` **top-level** keys (fail-closed). The next leak class is
+*within* a whitelisted family: a producer change that adds a new **field** to
+`commands` or `catalogue` that turns out to be sensitive (e.g. a per-guild value, an
+internal id) would pass the top-level whitelist silently. **Idea:** a tiny snapshot
+test that pins the *exact set of leaf field names* per public family (a committed
+`site_contract.json` of `{family: sorted(field_names)}`), so any new field — safe or
+not — trips the test and forces a conscious "is this field public?" review before it
+ships. Cheap, stdlib, extends redaction-by-construction from keys to leaves. (Dedup:
+no existing idea covers field-level public-contract pinning — only the top-level
+whitelist this PR adds.) Worth having because the whole split rests on non-negotiable
+#1, and the *field* boundary is the one the current guard doesn't cover.
+
+## ⟲ Previous-session review (#1107 — the §5 disjoint-tighten)
+
+**Did well:** #1107 (the pre-ultracode plan tighten) is *why this build had zero write
+conflicts* — it folded the P1/P2/P4 `app.py` overlap and the S1/P3 producer overlap
+into single owners and pinned the whitelist keys, so I built §5 literally as written
+with no "decide at build" ambiguity. That is the planner-feeds-builder loop working
+exactly as intended. **Could have been sharper:** §5 named the `commands` whitelist as
+`name/aliases/category/cooldown/permissions/usage` without noting that the existing AST
+scanner produces none of `cooldown`/`permissions`/`usage`/`category` directly — I had
+to reverse-engineer the honest mapping (join to the subsystem catalogue; `cooldown`
+unscannable). **System improvement:** when a plan pins an *output field list*, it
+should cite the *source field* each maps from (or flag "needs a new scanner field"), so
+the builder doesn't discover a fabrication risk mid-build. I captured the honest mapping
+in `export_dashboard_data` comments + the session-idea field-contract test so the gap is
+now visible to the next agent rather than tribal.
+
+## 📨 Documentation audit (Q-0104)
+
+- `check_docs --strict` → green (the new `docs/bot-changelog.md` is badged + reachable;
+  README links resolve; ratchet at 20).
+- `check_current_state_ledger.py --strict` flags PRs #1096/#1097/#1100–#1103 missing
+  from `current-state.md § Recently shipped` — **pre-existing benign newest-merge lag**
+  (all *newer* than the `Last reconciliation pass: #1094` marker; the convention + the
+  Q-0166 carve-out say the next reconciliation pass records these, and Q-0124 says a
+  build session should not divert into a docs pass). Not this session's drift; flagged
+  in the run report for the next pass. This PR (#1109) is itself newest-merge lag the
+  next session/ledger entry will record.
+- New owner-relevant decisions: none requiring a router Q (the build executes the
+  already-decided plan §5; the ratchet raise + `cooldown=null` are recorded above and
+  in-code, not product-intent forks).
+
+## Context delta
+
+- **Needed but not pointed to:** the command-field provenance (which `site.json`
+  command fields map from which scanner fields) — reverse-engineered from
+  `scan_commands.py`; now in `export_dashboard_data` comments. Also: the `check_docs`
+  top-level-docs ratchet exists and a new top-level doc trips it — not surfaced by the
+  `new-doc` route until CI fails; worth a one-liner in the docs-authoring orientation.
+- **Pointed to but didn't need:** CodeGraph — this was a contained, plan-recipe build
+  (new files in a known shape), so `context_map` + grep + the plan §5 file list carried
+  it; the symbol graph would have been overhead (matches the CLAUDE.md "right tool by
+  task size" guidance).
+- **Discovered by hand:** `check_architecture.py` only scans `disbot/` (so `botsite/`
+  is never arch-checked — the web→`disbot/` ban must be enforced by the app's own test,
+  which I added); the dataclass-in-an-importlib-loaded-module needs `sys.modules`
+  registration *before* exec (else `__module__` resolves to `None`) — the repo's
+  `_load_module` already handles this, but a bare `importlib` loader doesn't.
+- **Most-helpful one change:** a plan convention that an output-field whitelist cites
+  each field's *source* (executed as the session-idea field-contract test + in-code
+  comments).
+
+## 📤 Run report
+
+- **Did:** built the website two-site-split serial foundation (S1 data producer +
+  public `site.json` subset, S2 submissions store, P1 bot-site app) end-to-end ·
+  **Outcome:** shipped
+- **Shipped:** #1109 — S1 + S2 + P1 (`botsite/` new service skeleton, `site.json`
+  producer + redaction guards, submissions DDL + two helpers). Auto-merge armed; merges
+  on green.
+- **Run type:** `manual` (owner-dispatched ultracode build run)
+- **⚑ Owner decisions needed:** `none` (executes the already-locked plan §5 / Q-0178/Q-0179)
+- **⚑ Owner manual steps:** at rollout — provision the **2nd Railway service** (Root
+  Directory = `botsite`), the **dashboard-owned submissions Postgres** + apply
+  `botsite/migrations/001_submissions.sql`, and set `SUBMISSIONS_DB_DSN` (INSERT-only
+  role on the public site, full role on the dev site). All dormant-by-default until
+  then — nothing deploys-live without it (plan §6).
+- **⚑ Self-initiated:** `none` (owner-dispatched build of the approved plan; the ratchet
+  raise + `cooldown=null` are in-scope build decisions, recorded above)
+- **↪ Next:** the parallel back-half units P2 (reference templates) · P3 (changelog +
+  status templates) · P4 (submission intake — fills `botsite/submit.py` + copies the
+  limiter) · P5/P6 (dev-site moderation + GitHub mirror) · P7/P8 (redaction-audit +
+  deploy docs) — all file-disjoint, fan out now that this foundation lands.

--- a/botsite/Procfile
+++ b/botsite/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn app:app --host 0.0.0.0 --port ${PORT:-8080}

--- a/botsite/README.md
+++ b/botsite/README.md
@@ -1,0 +1,106 @@
+# SuperBot — public bot site
+
+The **public marketing + reference website** for SuperBot, deployed as its own
+Railway service (separate from both the bot and the developer dashboard). It is the
+public half of the website two-site split — full design, topology, security model,
+and the build decomposition live in
+[`docs/planning/website-two-site-split-plan-2026-06-19.md`](../docs/planning/website-two-site-split-plan-2026-06-19.md).
+
+**This directory is the serial foundation (units S1 + S2 + P1).** The app wires every
+route up front; the reference/changelog/status page templates and the `/submit`
+intake form land in the parallel back-half units (P2–P4).
+
+## What it serves
+
+| Route | What | Template / source |
+|---|---|---|
+| `/` | Marketing landing — hero, feature bands, honest capability counts, "Add to Discord" | `index.html` (this unit) |
+| `/commands` | Read-only command reference (search + filters) | `commands.html` (P2) |
+| `/features` | Feature showcase (function + game catalogue, user-framed) | `features.html` (P2) |
+| `/changelog` | User-facing bot changelog | `changelog.html` (P3) ← `site.json.bot_changelog` |
+| `/status` | User trust band — online (as of last deploy) · build · counts | `status.html` (P3) |
+| `/submit` | Public bug/suggestion form → `pending` intake | `botsite/submit.py` + `submit.html` (P4) |
+| `/healthz` | Liveness probe (JSON) for Railway | app constant |
+
+The routes for the P2/P3 templates are **wired now** (in `app.py`) but reference
+template files that land in those later units — that is by design, so `app.py` stays
+the single owner of routing and the back half is file-disjoint.
+
+## Decoupling (the hard rule)
+
+This app **never imports `disbot/`.** It reads only the committed public subset
+`botsite/data/site.json`, produced by `scripts/export_dashboard_data.py`
+(`--targets site`). That subset is **redaction by construction** — an explicit
+top-level whitelist (`meta`, `counts`, `catalogue`, `commands`, `bot_changelog`) that
+*physically cannot* contain a dev-only family (env vars, settings, access, reviews,
+ideas, raw bugs) or any per-guild value. A CI guard asserts the file's keys stay a
+subset of that whitelist (fails closed on a new key).
+
+## Secret posture — and why it stays clean
+
+This is the **public, secret-free** surface. It holds **at most one** secret: the
+**INSERT-only** submissions DB DSN (`SUBMISSIONS_DB_DSN`) used by `/submit` to write
+one `pending` row. It never holds the GitHub mirror token, the control-API token, or
+any OAuth secret (plan §4.4 secret matrix). A full compromise of this service cannot
+read submissions, reach GitHub, reach the bot, or touch the bot's DB.
+
+**The future "manage my server" control panel is a *separate service*, not a router
+mounted here** (plan §4.4 / §7.4). Mounting a control-API-writing editor inside this
+process would make a marketing-surface compromise reach `CONTROL_API_TOKEN` — defeating
+the invariant. So the gated manager gets its own process + env scope and drops in under
+the bot-site domain **without any refactor of this app**: `app.py` keeps wiring only the
+public routes, and `botsite/submit.py` is the one write seam (INSERT-only).
+
+## Run locally
+
+```bash
+pip install -r botsite/requirements.txt
+python3.10 scripts/export_dashboard_data.py --targets site   # (re)generate site.json
+uvicorn botsite.app:app --reload                             # http://127.0.0.1:8000
+```
+
+## Regenerate the data
+
+The committed `botsite/data/site.json` is a generated artifact (same producer as the
+dashboard). Re-run after the sources change:
+
+```bash
+python3.10 scripts/export_dashboard_data.py                  # writes BOTH artifacts
+```
+
+## Tests
+
+```bash
+python3.10 -m pytest tests/unit/scripts/test_export_dashboard_data.py   # runs in CI (stdlib)
+pip install -r botsite/requirements.txt
+python3.10 -m pytest tests/unit/botsite/                                # app + db smoke (local)
+```
+
+The app smoke test is `importorskip`-guarded, so it skips automatically in CI (which
+installs only the bot's `requirements.txt`).
+
+## Deploy on Railway (a new service)
+
+Deploy as a **new service** in the existing Railway project — the bot's `worker` and
+the dashboard service are untouched.
+
+1. Railway → your project → **New → GitHub Repo** → `menno420/superbot`.
+2. New service → **Settings → Source**: set **Root Directory** to `botsite`. This is
+   essential — it makes Railway build *this* folder (installing `botsite/requirements.txt`,
+   **not** the bot's deps) and run `botsite/Procfile`.
+3. **Start command:** taken from `botsite/Procfile` (`uvicorn app:app --host 0.0.0.0
+   --port $PORT`).
+4. **Healthcheck path** (optional): `/healthz`.
+5. **Environment variables:** none required for the read-only pages. `/submit` lights
+   up only when `SUBMISSIONS_DB_DSN` (an INSERT-only role on the dashboard-owned
+   submissions DB) is set — dormant-by-default until then.
+6. **Networking → Generate Domain** for a public URL (domains are deferred to cutover —
+   plan §7.1; dark-launch on the Railway URL first).
+
+Redeploys automatically on push to `main`. Refresh the data by regenerating
+`botsite/data/site.json` and committing it.
+
+> **Note:** the bot site intentionally has **no `static/` directory** — the repo's root
+> `.gitignore` ignores `static/`, so a file there would never be committed or deployed
+> (the #970 deploy-crash gotcha). Styling is the Tailwind CDN + a small inline `<style>`
+> block in `base.html`.

--- a/botsite/__init__.py
+++ b/botsite/__init__.py
@@ -1,0 +1,21 @@
+"""SuperBot public marketing site — a decoupled web app that renders generated JSON.
+
+The **public** half of the website two-site split
+(``docs/planning/website-two-site-split-plan-2026-06-19.md``): a marketing +
+reference site (features, command reference, changelog, status) plus a public
+bug/suggestion intake form. It is a *separate Railway service* from both the bot and
+the developer dashboard.
+
+Two hard invariants this package must never break:
+
+1. **Never import ``disbot``.** It reads only the committed public subset
+   ``botsite/data/site.json`` (produced by ``scripts/export_dashboard_data.py``) —
+   the same decoupling the dashboard has, with a *redaction-by-construction* data
+   boundary (the subset physically cannot contain a private family).
+2. **Holds at most one secret** — the INSERT-only submissions DSN (plan §4.4). It
+   never holds the GitHub mirror token, the control-API token, or any OAuth secret.
+
+The future gated "manage my server" surface is a **separate service** (plan §4.4),
+NOT a router mounted here — so this marketing app stays secret-free and the gated
+manager drops in without re-coupling. See ``botsite/README.md``.
+"""

--- a/botsite/app.py
+++ b/botsite/app.py
@@ -1,0 +1,169 @@
+"""FastAPI app for the SuperBot public marketing site (the bot site).
+
+The **public** half of the website two-site split
+(``docs/planning/website-two-site-split-plan-2026-06-19.md``). It is decoupled from
+the bot: it reads only the committed public subset ``botsite/data/site.json``
+(produced by ``scripts/export_dashboard_data.py``) and **never imports ``disbot``**.
+
+This module is the **single owner of routing** (plan §5 — P1): it wires *every* route
+up front so the parallel back-half units (templates, the submit intake) can fill in
+their pieces without touching this file. The page routes render their template by
+filename; the template files for ``/commands`` / ``/features`` / ``/changelog`` /
+``/status`` land in later units (P2/P3), so those routes are wired now but their
+templates may not exist yet — that is expected. ``/`` and ``/healthz`` are the only
+surfaces this unit fully ships templates for.
+
+Secret posture (plan §4.4): this app holds **at most one** secret — the INSERT-only
+submissions DSN used by the ``/submit`` intake (mounted from ``botsite/submit.py``,
+an empty stub until unit P4). It never holds the GitHub mirror token, the control-API
+token, or any OAuth secret. The gated "manage my server" surface is a **separate
+service**, not a router mounted here — so this marketing app stays secret-free and the
+manager drops in without re-coupling.
+
+Local run::
+
+    pip install -r botsite/requirements.txt
+    python3.10 scripts/export_dashboard_data.py --targets site   # (re)generate site.json
+    uvicorn botsite.app:app --reload
+
+Deploy: a new Railway service (Root Directory = ``botsite``) — see ``botsite/README.md``.
+There is intentionally **no ``static/`` directory** — the repo's ``.gitignore`` ignores
+``static/`` (the #970 deploy-crash gotcha); styling is the Tailwind CDN + a small inline
+block in ``base.html``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+BASE_DIR = Path(__file__).resolve().parent
+
+# The app runs both as a package (`botsite.app`, local) and as a top-level module
+# (`app:app`, Railway Root Directory = botsite), and the test loads app.py by file
+# path. Putting this directory on sys.path lets the sibling modules import
+# identically in all three contexts (mirrors the dashboard's proven shim). The
+# sibling imports below intentionally follow the shim (E402), so they are isolated
+# from the third-party imports above.
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
+
+import data_loader  # noqa: E402  - after the sys.path shim above
+from submit import router as submit_router  # noqa: E402  - after the shim
+
+app = FastAPI(title="SuperBot", docs_url=None, redoc_url=None)
+
+
+def site_context(request: Request) -> dict[str, Any]:
+    """Context merged into every template — the build/freshness band the nav shows.
+
+    Carries the generated-build provenance so the chrome can render the honest
+    "generated · as of last deploy" freshness badge (plan §3) without each route
+    re-deriving it. The public site never claims live state here.
+    """
+    data = data_loader.load_site_data()
+    return {
+        "build": data_loader.build_meta(data),
+        "site_counts": data.get("counts", {}),
+    }
+
+
+templates = Jinja2Templates(
+    directory=str(BASE_DIR / "templates"),
+    context_processors=[site_context],
+)
+
+
+def _render(request: Request, template: str, page: str, **extra: Any) -> HTMLResponse:
+    """Render ``template`` with the shared data payload + page marker.
+
+    Centralises the ``load_site_data`` + ``page`` plumbing every page route shares,
+    so the wired routes stay one-liners and a later unit's template only needs the
+    context keys it consumes.
+    """
+    context: dict[str, Any] = {"data": data_loader.load_site_data(), "page": page}
+    context.update(extra)
+    return templates.TemplateResponse(request, template, context)
+
+
+# ===========================================================================
+# Routes — ALL wired up front (plan §5). Page templates for /commands,
+# /features, /changelog, /status land in later units; the routes reference them
+# by filename now. /submit is mounted from the (stub) submit router.
+# ===========================================================================
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    """Liveness probe (used by Railway)."""
+    return {"status": "ok"}
+
+
+@app.get("/", response_class=HTMLResponse)
+def index(request: Request) -> HTMLResponse:
+    """Marketing landing — hero, feature bands, capability counts, 'Add to Discord'."""
+    data = data_loader.load_site_data()
+    return _render(
+        request,
+        "index.html",
+        "home",
+        features=data_loader.features_by_category(data)[:5],
+    )
+
+
+@app.get("/commands", response_class=HTMLResponse)
+def commands(request: Request) -> HTMLResponse:
+    """Read-only command reference (search + filters). Template: P2 (commands.html)."""
+    data = data_loader.load_site_data()
+    return _render(
+        request,
+        "commands.html",
+        "commands",
+        groups=data_loader.commands_by_category(data),
+    )
+
+
+@app.get("/features", response_class=HTMLResponse)
+def features(request: Request) -> HTMLResponse:
+    """Feature showcase (function + game catalogue). Template: P2 (features.html)."""
+    data = data_loader.load_site_data()
+    return _render(
+        request,
+        "features.html",
+        "features",
+        groups=data_loader.features_by_category(data),
+    )
+
+
+@app.get("/changelog", response_class=HTMLResponse)
+def changelog(request: Request) -> HTMLResponse:
+    """User-facing bot changelog. Template: P3 (changelog.html)."""
+    data = data_loader.load_site_data()
+    return _render(
+        request,
+        "changelog.html",
+        "changelog",
+        entries=data.get("bot_changelog", []),
+    )
+
+
+@app.get("/status", response_class=HTMLResponse)
+def status(request: Request) -> HTMLResponse:
+    """User trust band — online (as of last deploy) · build · counts. Template: P3."""
+    data = data_loader.load_site_data()
+    return _render(
+        request,
+        "status.html",
+        "status",
+        build=data_loader.build_meta(data),
+    )
+
+
+# /submit — GET form + POST intake. Owned by botsite/submit.py (an empty stub here;
+# unit P4 fills it). Mounted up front so app.py stays the single routing owner.
+app.include_router(submit_router)

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,0 +1,3212 @@
+{
+  "meta": {
+    "generated_at": "2026-06-19T13:15:55Z",
+    "build": {
+      "commit": "2f6089a",
+      "subject": "Website split foundation: born-red session card (S1+S2+P1)",
+      "committed_at": "2026-06-19T13:13:03Z",
+      "branch": "worktree-agent-a2c7cd0ecd504a3e0"
+    }
+  },
+  "counts": {
+    "commands": 306,
+    "features": 36,
+    "games": 8
+  },
+  "catalogue": [
+    {
+      "key": "ai",
+      "display_name": "AI Platform",
+      "description": "Read-only AI gateway diagnostics: provider state, feature flags, task routing, and request/failure counters. Does not own AI provider logic — that lives in core/runtime/ai/.",
+      "emoji": "🤖",
+      "category": "admin",
+      "tags": [
+        "ai",
+        "platform",
+        "diagnostics",
+        "providers"
+      ],
+      "badges": [
+        "admin"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "admin",
+      "display_name": "Administration",
+      "description": "Cog management, server stats, diagnostics",
+      "emoji": "⚙️",
+      "category": "admin",
+      "tags": [
+        "admin",
+        "cogs",
+        "management",
+        "diagnostics"
+      ],
+      "badges": [
+        "admin"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "diagnostic",
+      "display_name": "Diagnostics",
+      "description": "Bot health, latency, and system diagnostics",
+      "emoji": "🩺",
+      "category": "admin",
+      "tags": [
+        "diagnostics",
+        "health",
+        "latency",
+        "debug"
+      ],
+      "badges": [
+        "admin"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "logging",
+      "display_name": "Server Logging",
+      "description": "Per-guild moderation/cleanup event logging — channel selection, auto-create, and audit (S7)",
+      "emoji": "📝",
+      "category": "admin",
+      "tags": [
+        "logging",
+        "audit",
+        "moderation",
+        "cleanup"
+      ],
+      "badges": [
+        "admin"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "server_management",
+      "display_name": "Server Management",
+      "description": "Unified hub for moderation, channels, roles, cleanup, setup",
+      "emoji": "🧭",
+      "category": "admin",
+      "tags": [
+        "admin",
+        "hub",
+        "navigation",
+        "operations"
+      ],
+      "badges": [
+        "admin"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "settings",
+      "display_name": "Settings Manager",
+      "description": "Read-only browsing of platform settings, bindings, and audit history (S5)",
+      "emoji": "⚙️",
+      "category": "admin",
+      "tags": [
+        "settings",
+        "configuration",
+        "audit",
+        "platform"
+      ],
+      "badges": [
+        "admin"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "ux_lab",
+      "display_name": "UX Lab",
+      "description": "Interface gallery — browse UI patterns, all fake & safe",
+      "emoji": "🧪",
+      "category": "admin",
+      "tags": [
+        "admin",
+        "design",
+        "gallery",
+        "patterns"
+      ],
+      "badges": [
+        "admin"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "community",
+      "display_name": "Community",
+      "description": "Progression, roles, and community activities",
+      "emoji": "🌱",
+      "category": "community",
+      "tags": [
+        "community",
+        "hub",
+        "progression"
+      ],
+      "badges": [
+        "community"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "community_spotlight",
+      "display_name": "Community Spotlight",
+      "description": "Live server activity dashboard — leaders, level-ups, game stats",
+      "emoji": "🌟",
+      "category": "community",
+      "tags": [
+        "spotlight",
+        "activity",
+        "leaderboard",
+        "community"
+      ],
+      "badges": [
+        "community"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "counters",
+      "display_name": "Server Counters",
+      "description": "Live member-count channels (total · humans · bots)",
+      "emoji": "📊",
+      "category": "community",
+      "tags": [
+        "counters",
+        "stats",
+        "members",
+        "community"
+      ],
+      "badges": [
+        "community"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "welcome",
+      "display_name": "Welcome",
+      "description": "Member greetings, farewells, and an optional entry role",
+      "emoji": "👋",
+      "category": "community",
+      "tags": [
+        "welcome",
+        "greeting",
+        "onboarding",
+        "community"
+      ],
+      "badges": [
+        "community"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "economy",
+      "display_name": "Economy",
+      "description": "Daily coins, work, shop, balance",
+      "emoji": "💰",
+      "category": "economy",
+      "tags": [
+        "economy",
+        "currency",
+        "coins",
+        "progression"
+      ],
+      "badges": [
+        "economy"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "inventory",
+      "display_name": "Inventory",
+      "description": "Item management and crafting",
+      "emoji": "🎒",
+      "category": "economy",
+      "tags": [
+        "inventory",
+        "items",
+        "crafting"
+      ],
+      "badges": [
+        "economy"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "mining",
+      "display_name": "Mining",
+      "description": "Mining minigame and resource collection",
+      "emoji": "⛏️",
+      "category": "economy",
+      "tags": [
+        "mining",
+        "resources",
+        "minigame"
+      ],
+      "badges": [
+        "economy"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "btd6",
+      "display_name": "BTD6 Assistant",
+      "description": "Deterministic Bloons Tower Defense 6 assistant — tower/hero/map lookups, round threat summaries, and CHIMPS-mode guidance. Built on validated fixtures; consumes the AI gateway only when explicitly enabled (Module 5).",
+      "emoji": "🐵",
+      "category": "games",
+      "tags": [
+        "games",
+        "btd6",
+        "bloons",
+        "tower defense"
+      ],
+      "badges": [
+        "games"
+      ],
+      "is_game": true
+    },
+    {
+      "key": "blackjack",
+      "display_name": "Blackjack",
+      "description": "Blackjack card game",
+      "emoji": "🃏",
+      "category": "games",
+      "tags": [
+        "games",
+        "blackjack",
+        "cards"
+      ],
+      "badges": [
+        "games"
+      ],
+      "is_game": true
+    },
+    {
+      "key": "counting",
+      "display_name": "Counting",
+      "description": "Collaborative counting game",
+      "emoji": "🔢",
+      "category": "games",
+      "tags": [
+        "games",
+        "counting",
+        "community"
+      ],
+      "badges": [
+        "games"
+      ],
+      "is_game": true
+    },
+    {
+      "key": "deathmatch",
+      "display_name": "Deathmatch",
+      "description": "1v1 duel battles",
+      "emoji": "⚔️",
+      "category": "games",
+      "tags": [
+        "games",
+        "duel",
+        "pvp",
+        "deathmatch"
+      ],
+      "badges": [
+        "games"
+      ],
+      "is_game": true
+    },
+    {
+      "key": "fishing",
+      "display_name": "Fishing",
+      "description": "Fishing minigame — cast a line, build your collection",
+      "emoji": "🎣",
+      "category": "games",
+      "tags": [
+        "fishing",
+        "minigame",
+        "activities"
+      ],
+      "badges": [
+        "games"
+      ],
+      "is_game": true
+    },
+    {
+      "key": "games",
+      "display_name": "Games",
+      "description": "Competitive games and channel activities",
+      "emoji": "🎮",
+      "category": "games",
+      "tags": [
+        "games",
+        "hub",
+        "activities"
+      ],
+      "badges": [
+        "games"
+      ],
+      "is_game": true
+    },
+    {
+      "key": "rps_tournament",
+      "display_name": "Rock Paper Scissors",
+      "description": "Rock Paper Scissors: quick play, PvP, bot matches, tournaments",
+      "emoji": "✂️",
+      "category": "games",
+      "tags": [
+        "games",
+        "rps",
+        "tournament"
+      ],
+      "badges": [
+        "games"
+      ],
+      "is_game": true
+    },
+    {
+      "key": "chain",
+      "display_name": "Word Chain",
+      "description": "Word-chaining game",
+      "emoji": "🔗",
+      "category": "games",
+      "tags": [
+        "games",
+        "words",
+        "chain"
+      ],
+      "badges": [
+        "games"
+      ],
+      "is_game": true
+    },
+    {
+      "key": "channel",
+      "display_name": "Channels",
+      "description": "Channel and category creation, deletion, and restrictions",
+      "emoji": "📐",
+      "category": "management",
+      "tags": [
+        "channels",
+        "management",
+        "permissions"
+      ],
+      "badges": [
+        "management"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "role",
+      "display_name": "Roles",
+      "description": "Time-based and XP-based automatic role assignment",
+      "emoji": "🎭",
+      "category": "management",
+      "tags": [
+        "roles",
+        "assignment",
+        "automation"
+      ],
+      "badges": [
+        "management"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "automod",
+      "display_name": "Automod",
+      "description": "Spam, invite links, excessive caps, and mass-mention filtering",
+      "emoji": "🛡️",
+      "category": "moderation",
+      "tags": [
+        "automod",
+        "moderation",
+        "safety",
+        "spam",
+        "filter"
+      ],
+      "badges": [
+        "moderation"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "cleanup",
+      "display_name": "Cleanup",
+      "description": "Prohibited words, command deletion, channel hygiene",
+      "emoji": "🧹",
+      "category": "moderation",
+      "tags": [
+        "cleanup",
+        "words",
+        "moderation",
+        "hygiene"
+      ],
+      "badges": [
+        "moderation"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "image_moderation",
+      "display_name": "Image moderation",
+      "description": "Scan uploaded images for sexual, violent, harassment, or hate content",
+      "emoji": "🖼️",
+      "category": "moderation",
+      "tags": [
+        "image",
+        "moderation",
+        "safety",
+        "nsfw",
+        "filter"
+      ],
+      "badges": [
+        "moderation"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "moderation",
+      "display_name": "Moderation",
+      "description": "Warnings, timeouts, bans, mod logs",
+      "emoji": "🔨",
+      "category": "moderation",
+      "tags": [
+        "moderation",
+        "safety",
+        "logs",
+        "warn",
+        "ban"
+      ],
+      "badges": [
+        "moderation"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "proof_channel",
+      "display_name": "Proof Channel",
+      "description": "Proof submission and exclusive access sessions",
+      "emoji": "📋",
+      "category": "moderation",
+      "tags": [
+        "proof",
+        "events",
+        "access"
+      ],
+      "badges": [
+        "moderation"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "security",
+      "display_name": "Server Security",
+      "description": "Raid detection + account-age screening on member join",
+      "emoji": "🛡️",
+      "category": "moderation",
+      "tags": [
+        "security",
+        "raid",
+        "moderation",
+        "safety"
+      ],
+      "badges": [
+        "moderation"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "leaderboard",
+      "display_name": "Leaderboard",
+      "description": "Server leaderboards for XP, coins, and games",
+      "emoji": "🏆",
+      "category": "progression",
+      "tags": [
+        "leaderboard",
+        "rankings",
+        "stats"
+      ],
+      "badges": [
+        "progression"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "xp",
+      "display_name": "XP & Levels",
+      "description": "Experience points, levels, and leaderboards",
+      "emoji": "⭐",
+      "category": "progression",
+      "tags": [
+        "xp",
+        "levels",
+        "progression",
+        "leaderboard"
+      ],
+      "badges": [
+        "progression"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "four_twenty",
+      "display_name": "420",
+      "description": "A leafy little easter-egg panel — wisdom and number trivia",
+      "emoji": "🍃",
+      "category": "utility",
+      "tags": [
+        "fun",
+        "easter-egg",
+        "420"
+      ],
+      "badges": [
+        "utility"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "general",
+      "display_name": "General",
+      "description": "General bot commands and information",
+      "emoji": "💬",
+      "category": "utility",
+      "tags": [
+        "general",
+        "info",
+        "community"
+      ],
+      "badges": [
+        "utility"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "help",
+      "display_name": "Help",
+      "description": "Interactive help menu and command discovery",
+      "emoji": "📚",
+      "category": "utility",
+      "tags": [
+        "help",
+        "commands",
+        "discovery"
+      ],
+      "badges": [
+        "utility"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "utility",
+      "display_name": "Utility",
+      "description": "General utility commands",
+      "emoji": "🔧",
+      "category": "utility",
+      "tags": [
+        "utility",
+        "tools",
+        "general"
+      ],
+      "badges": [
+        "utility"
+      ],
+      "is_game": false
+    }
+  ],
+  "commands": [
+    {
+      "name": "access",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the read-only access-policy explorer."
+    },
+    {
+      "name": "admin",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the Admin control panel (administrator only)."
+    },
+    {
+      "name": "adminmenu",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the interactive admin control panel."
+    },
+    {
+      "name": "ai",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the AI Platform panel."
+    },
+    {
+      "name": "aimenu",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the AI Platform panel (alias for ``!ai``)."
+    },
+    {
+      "name": "aimenu",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the AI Platform panel (administrator only)."
+    },
+    {
+      "name": "check_database",
+      "aliases": [
+        "checkdb"
+      ],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Verify that all expected PostgreSQL tables exist."
+    },
+    {
+      "name": "cog",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Load, unload, or reload a cog by name (underscores and _cog suffix optional)."
+    },
+    {
+      "name": "coglist",
+      "aliases": [
+        "cogs",
+        "listcogs",
+        "cogslist"
+      ],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the interactive cog manager — the panel's 📋 Cog List button."
+    },
+    {
+      "name": "create",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Preview + create a new log channel for any registered route."
+    },
+    {
+      "name": "diagnostic_bot_status",
+      "aliases": [
+        "diag_status"
+      ],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Display bot health and performance metrics."
+    },
+    {
+      "name": "diagnostics",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": ""
+    },
+    {
+      "name": "diagnostics",
+      "aliases": [
+        "diag"
+      ],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the interactive diagnostics hub panel."
+    },
+    {
+      "name": "find_command",
+      "aliases": [
+        "findcmd"
+      ],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Search for commands by keyword in their name or description."
+    },
+    {
+      "name": "forget",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Flush the chat-memory cache for THIS channel."
+    },
+    {
+      "name": "latency",
+      "aliases": [
+        "ping"
+      ],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Report the bot's WebSocket latency."
+    },
+    {
+      "name": "lifecycle",
+      "aliases": [
+        "lc"
+      ],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Lifecycle state (phase, pending request, recent events)."
+    },
+    {
+      "name": "list_commands_detailed",
+      "aliases": [
+        "listcmds"
+      ],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "List all registered commands with details, paginated by cog."
+    },
+    {
+      "name": "loadall",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Load all unloaded cogs, skipping already-loaded ones."
+    },
+    {
+      "name": "logging",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the logging admin panel (S7d)."
+    },
+    {
+      "name": "loglevel",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Change the bot log level (DEBUG/INFO/WARNING/ERROR/CRITICAL)."
+    },
+    {
+      "name": "platform",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the Platform / Diagnostics hub (administrator only)."
+    },
+    {
+      "name": "policy",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Show the effective AI policy for a channel (dry-run resolver)."
+    },
+    {
+      "name": "providers",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": ""
+    },
+    {
+      "name": "query_logs",
+      "aliases": [
+        "querylogs"
+      ],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Query recent logs from the logs table. !query_logs [INFO|ERROR|...] [limit]"
+    },
+    {
+      "name": "readiness",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Run the full AI readiness chain check."
+    },
+    {
+      "name": "recent_errors",
+      "aliases": [
+        "errors"
+      ],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Retrieve the most recent ERROR-level log entries."
+    },
+    {
+      "name": "restart",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Request a graceful restart through the lifecycle service."
+    },
+    {
+      "name": "routes",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the Phase 9b Routes subpage directly."
+    },
+    {
+      "name": "routing",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": ""
+    },
+    {
+      "name": "server-management",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the Server Management hub (moderation, channels, roles, cleanup, setup)."
+    },
+    {
+      "name": "servermanagement",
+      "aliases": [
+        "servermenu",
+        "guildmenu"
+      ],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the unified Server Management hub."
+    },
+    {
+      "name": "serverstats",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Display server statistics."
+    },
+    {
+      "name": "set",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the channel-select view for ``mod`` or ``cleanup`` binding."
+    },
+    {
+      "name": "settings",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the AI Platform settings panel directly."
+    },
+    {
+      "name": "settings",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the Settings Manager hub (browse + edit/reset scalars)."
+    },
+    {
+      "name": "settings",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the Settings Manager hub (administrator only)."
+    },
+    {
+      "name": "slashes",
+      "aliases": [
+        "slashlist"
+      ],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "List currently-registered slash commands (admin only)."
+    },
+    {
+      "name": "status",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": ""
+    },
+    {
+      "name": "status",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Show this guild's server-logging configuration + counters."
+    },
+    {
+      "name": "support-report",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Render a copy-pasteable support report from recent audit (PR-H)."
+    },
+    {
+      "name": "syncslash",
+      "aliases": [
+        "syncs"
+      ],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Sync the app-command tree for slash commands (owner only)."
+    },
+    {
+      "name": "system_info",
+      "aliases": [
+        "sysinfo"
+      ],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Display system-level stats."
+    },
+    {
+      "name": "test",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Send a synthetic warn embed to the configured log channel."
+    },
+    {
+      "name": "test_notification",
+      "aliases": [
+        "testnotify"
+      ],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Send a test notification via the webhook reporter."
+    },
+    {
+      "name": "unloadall",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Unload all loaded cogs except this one."
+    },
+    {
+      "name": "uxlab",
+      "aliases": [
+        "interfacelab"
+      ],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the UX Lab — the interface gallery + limit probe bench."
+    },
+    {
+      "name": "uxlab",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the UX Lab — browse interface patterns (admin)."
+    },
+    {
+      "name": "validate_json_files",
+      "aliases": [
+        "validatejson"
+      ],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Validate the structure of all JSON files in the data directory."
+    },
+    {
+      "name": "why-no-response",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Show the most recent denials / skips for this guild."
+    },
+    {
+      "name": "community",
+      "aliases": [],
+      "category": "community",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the Community hub — XP, Roles, and community activities."
+    },
+    {
+      "name": "community",
+      "aliases": [],
+      "category": "community",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the Community hub (XP, Roles, and community games)."
+    },
+    {
+      "name": "counters",
+      "aliases": [],
+      "category": "community",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Show the current server-counter channels for this server."
+    },
+    {
+      "name": "spotlight",
+      "aliases": [
+        "activity"
+      ],
+      "category": "community",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show the Community Spotlight — live XP, coins, games, and level-ups."
+    },
+    {
+      "name": "welcome",
+      "aliases": [],
+      "category": "community",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Show the current welcome (greeting) policy for this server."
+    },
+    {
+      "name": "ascend",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Climb one mining band back toward the surface."
+    },
+    {
+      "name": "balance",
+      "aliases": [
+        "bal",
+        "wallet"
+      ],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show your (or another user's) current coin balance."
+    },
+    {
+      "name": "build",
+      "aliases": [
+        "craft"
+      ],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Build / craft an item from recipes (one shared, atomic implementation)."
+    },
+    {
+      "name": "buildable",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Lists only what the user can currently build based on their inventory."
+    },
+    {
+      "name": "buildlist",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Shows all craftable structures from recipes.json."
+    },
+    {
+      "name": "buy",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Buy gear with coins (e.g. `!buy iron sword`)."
+    },
+    {
+      "name": "character",
+      "aliases": [
+        "profile",
+        "char"
+      ],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show your full mining character — location, gear, stats, wealth."
+    },
+    {
+      "name": "chop",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Chop wood. If you have an 'axe', you'll collect double."
+    },
+    {
+      "name": "daily",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Claim your daily reward. Higher streaks unlock better odds!"
+    },
+    {
+      "name": "descend",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Descend one mining band deeper (gated by your equipped light)."
+    },
+    {
+      "name": "economy",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the Economy hub (daily, work, shop, balance)."
+    },
+    {
+      "name": "economymenu",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the interactive economy control panel."
+    },
+    {
+      "name": "equip",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Equip a tool, light, or charm so its stats apply to your character."
+    },
+    {
+      "name": "explore",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Discover random events or items (driven by your gear and depth)."
+    },
+    {
+      "name": "fastmine",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "One quick mining swing — no buttons (the old !fastmine, reborn)."
+    },
+    {
+      "name": "forge",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the Forge — build it to unlock higher-tier gear crafting."
+    },
+    {
+      "name": "gear",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show your equipped gear, its condition, and the stats it grants."
+    },
+    {
+      "name": "give",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Admin-only: give resources to a user."
+    },
+    {
+      "name": "home",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the Home — build it to personalize your Character card."
+    },
+    {
+      "name": "inventory",
+      "aliases": [
+        "inv"
+      ],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show your (or another user's) unified inventory hub."
+    },
+    {
+      "name": "joblist",
+      "aliases": [
+        "jobs"
+      ],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show all jobs, requirements, and your mastery for each."
+    },
+    {
+      "name": "market",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show the mining market — sellable resources + the gear shop."
+    },
+    {
+      "name": "mine",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Start mining with interactive buttons."
+    },
+    {
+      "name": "mineinv",
+      "aliases": [
+        "mineinventory"
+      ],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show your unified inventory (compatibility alias for !inventory)."
+    },
+    {
+      "name": "minemenu",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the mining hub panel."
+    },
+    {
+      "name": "minestats",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Shows your total mining items and number of unique items."
+    },
+    {
+      "name": "quickcraft",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Re-craft the last gear item that broke and equip it."
+    },
+    {
+      "name": "repair",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Repair a worn gear item for coins (e.g. `!repair pickaxe`)."
+    },
+    {
+      "name": "reset_inventory",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Admin-only: reset a user's inventory in THIS guild (PR M3 — guild-scoped)."
+    },
+    {
+      "name": "sell",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Sell raw resources for coins (e.g. `!sell diamond 5`)."
+    },
+    {
+      "name": "sellall",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Sell every raw resource in your inventory for coins."
+    },
+    {
+      "name": "setlogchannel",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Set the economy log channel. Usage: !setlogchannel #channel"
+    },
+    {
+      "name": "shop",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Browse and buy items from the shop."
+    },
+    {
+      "name": "skill",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Spend a skill point into a branch (e.g. `!skill mining`)."
+    },
+    {
+      "name": "skills",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open your skill tree — spend points to specialize your character."
+    },
+    {
+      "name": "stash",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Deposit an item into your vault (e.g. `!stash diamond 5`)."
+    },
+    {
+      "name": "titles",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open your titles — equip an earned title on your Character card."
+    },
+    {
+      "name": "unequip",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Clear an equipment slot (tool, light, charm, or a combat piece)."
+    },
+    {
+      "name": "unstash",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Withdraw an item from your vault (e.g. `!unstash diamond 5`)."
+    },
+    {
+      "name": "use",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Use a special item from your inventory (e.g., torch, dynamite)."
+    },
+    {
+      "name": "vault",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open your vault — a safe stash separate from your mining pack."
+    },
+    {
+      "name": "vaultupgrade",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Buy one vault-capacity tier with coins (e.g. more room to stash)."
+    },
+    {
+      "name": "work",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the job selector and earn coins + XP (1 h cooldown)."
+    },
+    {
+      "name": "workshop",
+      "aliases": [],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the workshop — repair worn gear, craft replacements."
+    },
+    {
+      "name": "announcechannel",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Set/clear the BTD6 new-version announcement channel (administrator)."
+    },
+    {
+      "name": "ask",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Deterministic Q&A. Module 5 adds optional AI augmentation."
+    },
+    {
+      "name": "bjstart",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Manually start a pending Blackjack tournament early."
+    },
+    {
+      "name": "bjstatus",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show the current tournament status."
+    },
+    {
+      "name": "bjtournament",
+      "aliases": [
+        "bjtourn"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Start a Blackjack tournament. !bjtournament [entry_fee] [rounds] [mins]"
+    },
+    {
+      "name": "blackjack",
+      "aliases": [
+        "bj"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Play blackjack. !bj [bet] or !bj @player [bet]"
+    },
+    {
+      "name": "browse",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Browse published BTD6 strategies (PR-F)."
+    },
+    {
+      "name": "btd6",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the BTD6 panel."
+    },
+    {
+      "name": "btd6events",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "BTD6 live events, leaderboards, and data-source diagnostics."
+    },
+    {
+      "name": "btd6menu",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the BTD6 panel (alias for ``!btd6``)."
+    },
+    {
+      "name": "btd6menu",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the BTD6 panel."
+    },
+    {
+      "name": "btd6ops",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "BTD6 ingestion operations (staff readable; toggles are admin)."
+    },
+    {
+      "name": "btd6ref",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "BTD6 reference lookups (towers / heroes / rounds / relics / CT)."
+    },
+    {
+      "name": "btd6strat",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "BTD6 strategy memory (browse / submit / review)."
+    },
+    {
+      "name": "chain",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Manage message chains and word limits in your server."
+    },
+    {
+      "name": "chainmenu",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the interactive chain management panel."
+    },
+    {
+      "name": "count_info",
+      "aliases": [
+        "ci"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Displays the current count and configuration."
+    },
+    {
+      "name": "count_rules",
+      "aliases": [
+        "cr"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Displays the counting game rules."
+    },
+    {
+      "name": "countingmenu",
+      "aliases": [
+        "cm"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the interactive counting game management panel."
+    },
+    {
+      "name": "create",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Create a chain in a specified channel or the current channel if none is provided."
+    },
+    {
+      "name": "ct",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Browse active Contested Territory events and their relic tiles."
+    },
+    {
+      "name": "ctteam",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "View or set this server's CT team (paste the bracket group id / URL)."
+    },
+    {
+      "name": "delete",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Delete a chain from a specified channel or the current channel if none is provided."
+    },
+    {
+      "name": "diagnostics",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": ""
+    },
+    {
+      "name": "dm_challenge",
+      "aliases": [
+        "deathmatch",
+        "challenge",
+        "dm"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Challenge another user to a deathmatch duel."
+    },
+    {
+      "name": "dm_help",
+      "aliases": [
+        "deathmatch_help"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Display help information for Deathmatch commands."
+    },
+    {
+      "name": "end_match",
+      "aliases": [
+        "em"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Ends the counting match in the specified channel and deletes the channel."
+    },
+    {
+      "name": "event",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show one specific BTD6 event with its tower restrictions."
+    },
+    {
+      "name": "fish",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Cast a line and catch a fish — level up to unlock bigger fish."
+    },
+    {
+      "name": "fishlog",
+      "aliases": [
+        "fishdex"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show your fishing collection — every species you've caught."
+    },
+    {
+      "name": "fishtop",
+      "aliases": [
+        "topfishers"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show this server's top anglers by total fish caught."
+    },
+    {
+      "name": "games",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the Games hub — competitive games and channel activities."
+    },
+    {
+      "name": "games",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the Games hub (competitive + activities)."
+    },
+    {
+      "name": "grounding",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show the grounding facts that fed an AI response (PR-D)."
+    },
+    {
+      "name": "hero",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": ""
+    },
+    {
+      "name": "latest-data",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show newest fact envelope per entity_kind (PR-D)."
+    },
+    {
+      "name": "leaderboard",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Top-N race or boss leaderboard. No event_id = newest active."
+    },
+    {
+      "name": "list",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "List all active chains and word limits in the server."
+    },
+    {
+      "name": "live",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show recent live events for ``kind`` (race / boss / ct / odyssey / event)."
+    },
+    {
+      "name": "mine",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "List my own strategy submissions in this guild (PR-F)."
+    },
+    {
+      "name": "pending",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "List pending strategy submissions with review buttons."
+    },
+    {
+      "name": "readiness",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": ""
+    },
+    {
+      "name": "refresh-source",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Manually refresh one Ninja Kiwi source (staff-only)."
+    },
+    {
+      "name": "relic",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "CT relic effect + current tile (by name / abbrev e.g. SMS / alias)."
+    },
+    {
+      "name": "removelimit",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Remove the word limit from a specified channel or the current channel if none is provided."
+    },
+    {
+      "name": "reset_count",
+      "aliases": [
+        "rc"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Resets the count to the starting value."
+    },
+    {
+      "name": "round",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": ""
+    },
+    {
+      "name": "rps",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Quick RPS. !rps [bet] or !rps @player [bet]"
+    },
+    {
+      "name": "rpsbot",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Starts matches against the bot. Delegator — see _bot_matches."
+    },
+    {
+      "name": "rpshelp",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Displays help information for RPS tournament commands."
+    },
+    {
+      "name": "rpsmatchup",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Manually creates a match between two specific members."
+    },
+    {
+      "name": "rpsregister",
+      "aliases": [
+        "rpsreg"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Starts the registration period with a reaction role message. !rpsregister [@role] [entry_fee]"
+    },
+    {
+      "name": "rpssettings",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Updates bot settings."
+    },
+    {
+      "name": "rpsstart",
+      "aliases": [
+        "rpsbegin"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Starts the RPS tournament. Usage: !rps_start [mode] [best_of]"
+    },
+    {
+      "name": "runs",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": ""
+    },
+    {
+      "name": "seed-data",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Seed the Postgres data store from the bundled files (administrator)."
+    },
+    {
+      "name": "set_skip_numbers",
+      "aliases": [
+        "ssn"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Set the skip step N for a 'skip' match (count climbs 1, 1+N, 1+2N, …)."
+    },
+    {
+      "name": "setlimit",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Set a word limit in a specified channel or the current channel if none is provided."
+    },
+    {
+      "name": "source-health",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show source registry freshness (PR-D)."
+    },
+    {
+      "name": "source_disable",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": ""
+    },
+    {
+      "name": "source_enable",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": ""
+    },
+    {
+      "name": "sources",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "List BTD6 source registry rows."
+    },
+    {
+      "name": "start_match",
+      "aliases": [
+        "sm"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Starts a new counting match with the specified mode."
+    },
+    {
+      "name": "status",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": ""
+    },
+    {
+      "name": "strategies",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "List strategy memory entries available in this guild."
+    },
+    {
+      "name": "strategy",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show one strategy in detail (PR-F)."
+    },
+    {
+      "name": "strategy-audit",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show the per-strategy audit log (PR-F)."
+    },
+    {
+      "name": "submit",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open a strategy submission modal (slash-only on Discord)."
+    },
+    {
+      "name": "test-intent",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": ""
+    },
+    {
+      "name": "toggle_reset_on_wrong_count",
+      "aliases": [
+        "trwc"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Toggles the 'reset on wrong count' feature."
+    },
+    {
+      "name": "toggle_turns",
+      "aliases": [
+        "tt"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Toggles the 'taking turns' mode."
+    },
+    {
+      "name": "tower",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": ""
+    },
+    {
+      "name": "why-no-response",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show the most recent BTD6 denials / skips for this guild."
+    },
+    {
+      "name": "assignroles",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Manually run time-based role assignment for all members."
+    },
+    {
+      "name": "bulkcreate",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Create multiple channels. Usage: !bulkcreate <ch1> [ch2...] [category]"
+    },
+    {
+      "name": "bulkdelete",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Delete multiple channels. Usage: !bulkdelete <name|id> [name|id...] or <keyword>"
+    },
+    {
+      "name": "channelinfo",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Channel details. Usage: !channelinfo <name|id>"
+    },
+    {
+      "name": "channelmenu",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the interactive channel management panel."
+    },
+    {
+      "name": "clone",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Clone a channel. Usage: !clone <name|id> <new_name>"
+    },
+    {
+      "name": "create",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Create a channel with role access. Usage: !create <name> <@role> <True/False> [category]"
+    },
+    {
+      "name": "createrole",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Create a role (use !roles → Create instead)."
+    },
+    {
+      "name": "debugroles",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Print all role names for verification."
+    },
+    {
+      "name": "del",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Delete a specific channel. Usage: !del <name|id>"
+    },
+    {
+      "name": "deleterole",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Delete a role by name or mention."
+    },
+    {
+      "name": "evt",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Create or delete an event channel. Usage: !evt <name|id> <create/delete>"
+    },
+    {
+      "name": "list",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "List all categories and channels, including uncategorized."
+    },
+    {
+      "name": "listreactroles",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "List all active reaction roles in this server."
+    },
+    {
+      "name": "lock",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Lock a channel. Usage: !lock <name|id>"
+    },
+    {
+      "name": "move",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Move a channel to a category. Usage: !move <channel name|id> <category name|id>"
+    },
+    {
+      "name": "permissions",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Modify channel permissions. Usage: !permissions <name|id> <@role> <allow/deny>"
+    },
+    {
+      "name": "reactroles",
+      "aliases": [
+        "reaktionsrollen"
+      ],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Attach a reaction role to a message. Usage: !reactroles <message_id> <emoji> <@role>"
+    },
+    {
+      "name": "refreshmembers",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Force-fetch all members from Discord."
+    },
+    {
+      "name": "removereactrole",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Remove a reaction role binding. Usage: !removereactrole <message_id> <emoji>"
+    },
+    {
+      "name": "rename",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Rename a channel. Usage: !rename <old name|id> <new_name>"
+    },
+    {
+      "name": "rolecreator",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the role hub (use !roles instead)."
+    },
+    {
+      "name": "rolemenu",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the role hub (use !roles instead)."
+    },
+    {
+      "name": "roles",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the role management hub."
+    },
+    {
+      "name": "rolesettings",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the role management hub (alias for !roles)."
+    },
+    {
+      "name": "set",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Set access for a channel/category. Usage: !set <name|id> <@role> <True/False>"
+    },
+    {
+      "name": "setrole",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Add or update a time-based role threshold."
+    },
+    {
+      "name": "unlock",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Unlock a channel. Usage: !unlock <name|id>"
+    },
+    {
+      "name": "unsetrole",
+      "aliases": [],
+      "category": "management",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Remove a role from time-based assignment."
+    },
+    {
+      "name": "+prize",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "staff",
+      "usage": "Grant a winner exclusive access to #proof. Usage: +prize @winner"
+    },
+    {
+      "name": "-prize",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "staff",
+      "usage": "End the prize session and make #proof read-only again. Usage: -prize"
+    },
+    {
+      "name": "add",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Adds a word to the prohibited words list."
+    },
+    {
+      "name": "automod",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Show the current automod policy for this server."
+    },
+    {
+      "name": "ban",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "moderator",
+      "usage": "Ban a member from the server."
+    },
+    {
+      "name": "cleanup",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the Cleanup hub panel — overview + routing to subviews."
+    },
+    {
+      "name": "cleanuphistory",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Clean matching channel history by keyword, commands, or prohibited words."
+    },
+    {
+      "name": "clearwarnings",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "moderator",
+      "usage": "Clear all warnings for a member."
+    },
+    {
+      "name": "imagemod",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Show the current image-moderation policy for this server."
+    },
+    {
+      "name": "kick",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "moderator",
+      "usage": "Kick a member from the server."
+    },
+    {
+      "name": "list",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Shows all prohibited words."
+    },
+    {
+      "name": "moderation",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "moderator",
+      "usage": "Open the Moderation hub (moderator only)."
+    },
+    {
+      "name": "modlogs",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "moderator",
+      "usage": "Show moderation log history for a member."
+    },
+    {
+      "name": "modmenu",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "moderator",
+      "usage": "Show the interactive moderation action panel."
+    },
+    {
+      "name": "prizemenu",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "staff",
+      "usage": "Open the interactive prize channel management panel."
+    },
+    {
+      "name": "prizestatus",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "staff",
+      "usage": "Show current #proof channel permissions."
+    },
+    {
+      "name": "remove",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Removes a word from the prohibited words list."
+    },
+    {
+      "name": "security",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Show the current server-security policy (raid + account-age)."
+    },
+    {
+      "name": "timedprize",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "staff",
+      "usage": "Grant timed access to #proof; auto-unlocks after duration minutes. Usage: timedprize @winner <minutes>"
+    },
+    {
+      "name": "timeout",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "moderator",
+      "usage": "Timeout a member for a given number of minutes."
+    },
+    {
+      "name": "unban",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "moderator",
+      "usage": "Unban a user by their Discord user ID."
+    },
+    {
+      "name": "warn",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "moderator",
+      "usage": "Warn a user. Escalates at the configured threshold (default: timeout)."
+    },
+    {
+      "name": "word",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Manage prohibited words. Subcommands: add, remove, list."
+    },
+    {
+      "name": "wordmenu",
+      "aliases": [],
+      "category": "moderation",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Open the interactive prohibited words management panel."
+    },
+    {
+      "name": "access",
+      "aliases": [
+        "whyhere"
+      ],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Explain which subsystems you can use in a channel/thread (IL-1)."
+    },
+    {
+      "name": "anchors",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Show last restoration outcome and active anchor counts per subsystem."
+    },
+    {
+      "name": "automation",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Open the automation management + diagnostics panel."
+    },
+    {
+      "name": "backfill",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Dry-run (default) or `apply` the legacy-pointer → binding backfill."
+    },
+    {
+      "name": "bindings",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Subsystem bindings (Phase 2b) — taxonomy + per-guild histograms."
+    },
+    {
+      "name": "bugreport",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Report a bug — Hermes dispatches a Claude Code session to fix it automatically."
+    },
+    {
+      "name": "caches",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Cache state: F-1 guild_config + governance.cache."
+    },
+    {
+      "name": "cleanup-preview",
+      "aliases": [
+        "cleanuppreview",
+        "cleanup-policy"
+      ],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Dry-run preview of the cleanup policy resolved for a location (IL-2)."
+    },
+    {
+      "name": "command-access",
+      "aliases": [
+        "commandaccess"
+      ],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Show the live command-access decision for a channel."
+    },
+    {
+      "name": "consistency",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Unified platform readiness diagnostic — read-only (Phase 2 PR-10)."
+    },
+    {
+      "name": "counting-health",
+      "aliases": [
+        "countinghealth"
+      ],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Surface counting persistence health from task_outcome_total (IL-3)."
+    },
+    {
+      "name": "customization",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Customization catalogue across subsystems (S2)."
+    },
+    {
+      "name": "dispatch",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Send a raw Hermes work order to the Claude Code Routine (owner only)."
+    },
+    {
+      "name": "economy",
+      "aliases": [
+        "coinflow"
+      ],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Faucet/sink coin-economy view (`!platform economy [days]`): minted"
+    },
+    {
+      "name": "finding",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Transition a persistent finding: `resolve` / `ignore` / `reopen` <fingerprint>."
+    },
+    {
+      "name": "findings",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Persistent operational-health findings (open / resolved / ignored / all)."
+    },
+    {
+      "name": "flag",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Open the editable per-guild flag manager (Phase 6.5a)."
+    },
+    {
+      "name": "flags",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Feature flags: declarations + Phase 2d evaluator state per flag."
+    },
+    {
+      "name": "force",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Overrides channel restrictions and runs a command (admins only)."
+    },
+    {
+      "name": "health",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Deterministic operational health snapshot (admin-gated, redacted)."
+    },
+    {
+      "name": "identity",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Run the identity-contract validator and show findings."
+    },
+    {
+      "name": "lifecycle",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Lifecycle state: phase, pending request, recent events."
+    },
+    {
+      "name": "locks",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "scope_locks snapshot; pass a prefix to filter (e.g. `counting`)."
+    },
+    {
+      "name": "media",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Content-free media (YouTube) diagnostics."
+    },
+    {
+      "name": "migrations",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Platform migration checkpoints (Phase 2 PR-5) — status + summary."
+    },
+    {
+      "name": "paragon",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Open the BTD6 Paragon degree calculator."
+    },
+    {
+      "name": "participation-schemas",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Registered ParticipationSchema instances (Phase 1b)."
+    },
+    {
+      "name": "platform",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Runtime introspection group."
+    },
+    {
+      "name": "provisioning",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Cross-linked ResourceRequirement × BindingSpec catalogue (S2.5)."
+    },
+    {
+      "name": "resource-requirements",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Declared ResourceRequirement entries across subsystems (Phase 1c)."
+    },
+    {
+      "name": "resources",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Resource runtime (Phase 2a) — taxonomy + cached status histogram."
+    },
+    {
+      "name": "runtime",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "High-level runtime snapshot: every registered diagnostic provider."
+    },
+    {
+      "name": "schemas",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Registered SubsystemSchema instances (Phase 1a)."
+    },
+    {
+      "name": "sessions",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Active session counts (DB-backed); optionally filtered by subsystem."
+    },
+    {
+      "name": "setting",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Explain one scalar setting for this guild."
+    },
+    {
+      "name": "settings-registry",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Declared SettingSpec catalogue + this guild's current values (S1)."
+    },
+    {
+      "name": "setup",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Open or resume the linear setup wizard."
+    },
+    {
+      "name": "setup",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Open the setup wizard (owner, delegated admin, or admin)."
+    },
+    {
+      "name": "setup-delegate",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Grant a member delegated setup-admin authority (owner only)."
+    },
+    {
+      "name": "setup-depth",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Pick the wizard depth (owner/delegated admin only)."
+    },
+    {
+      "name": "setup-hub",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Open the legacy section-list hub (compat)."
+    },
+    {
+      "name": "setup-readiness",
+      "aliases": [
+        "readiness",
+        "ready"
+      ],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Per-guild setup-readiness inventory (PR H)."
+    },
+    {
+      "name": "setup-reset",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Clear all staged setup operations (owner/delegated admin only)."
+    },
+    {
+      "name": "setup-skip",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Mark a setup section as skipped (owner/delegated admin only)."
+    },
+    {
+      "name": "setup-status",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Quick at-a-glance setup state (read-only)."
+    },
+    {
+      "name": "setup-undelegate",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Revoke delegated setup-admin authority (owner only)."
+    },
+    {
+      "name": "setup-unskip",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Remove a section from the skipped set (owner/delegated admin only)."
+    },
+    {
+      "name": "slow",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Show the most recent slow-path entries (S3.2 ring buffer)."
+    },
+    {
+      "name": "startup",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Settled-startup health report (extension load, gateway, DB, …)."
+    },
+    {
+      "name": "status",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "High-level platform status: uptime, cogs, governance, scheduler."
+    },
+    {
+      "name": "tasks",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Managed background-task snapshot (core.runtime.tasks)."
+    },
+    {
+      "name": "views",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Registered PersistentView classes (by subsystem)."
+    },
+    {
+      "name": "givexp",
+      "aliases": [],
+      "category": "progression",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Give XP to a user (admin only)."
+    },
+    {
+      "name": "leaderboard",
+      "aliases": [
+        "lb",
+        "rankings",
+        "minelb",
+        "miningleaderboard",
+        "dm_leaderboard",
+        "dm_lb",
+        "rpslb",
+        "countlb",
+        "counting_leaderboard"
+      ],
+      "category": "progression",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show a leaderboard. !leaderboard [xp|coins|mining|deathmatch|rps|counting]"
+    },
+    {
+      "name": "rank",
+      "aliases": [],
+      "category": "progression",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show rank in a category."
+    },
+    {
+      "name": "resetxp",
+      "aliases": [],
+      "category": "progression",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Reset a user's XP to zero (admin only)."
+    },
+    {
+      "name": "xpconfig",
+      "aliases": [],
+      "category": "progression",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the XP configuration panel (admin only)."
+    },
+    {
+      "name": "xpmenu",
+      "aliases": [],
+      "category": "progression",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the XP panel showing your rank and quick admin actions."
+    },
+    {
+      "name": "420",
+      "aliases": [
+        "fourtwenty",
+        "fourtwenty420"
+      ],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the 🍃 420 panel — rotating wisdom and number trivia."
+    },
+    {
+      "name": "avatar",
+      "aliases": [],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Display a user's avatar."
+    },
+    {
+      "name": "clear",
+      "aliases": [
+        "purge"
+      ],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Purge messages. Max 100."
+    },
+    {
+      "name": "eightball",
+      "aliases": [
+        "8ball"
+      ],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Ask the Magic 8-Ball a yes/no question."
+    },
+    {
+      "name": "fact",
+      "aliases": [],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Sends a random interesting fact."
+    },
+    {
+      "name": "generalmenu",
+      "aliases": [
+        "gmenu"
+      ],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the interactive General panel."
+    },
+    {
+      "name": "greet",
+      "aliases": [],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Greets you with a random greeting."
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "hilfe"
+      ],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Shows available commands. Pass a category name for details."
+    },
+    {
+      "name": "help",
+      "aliases": [],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show available commands (optionally narrow to one category)."
+    },
+    {
+      "name": "info",
+      "aliases": [],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show server or user info. !info [server|user] [@mention]"
+    },
+    {
+      "name": "invite",
+      "aliases": [],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Generate a one-use server invite."
+    },
+    {
+      "name": "joke",
+      "aliases": [],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Sends a random joke."
+    },
+    {
+      "name": "motivate",
+      "aliases": [],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Sends a motivational message."
+    },
+    {
+      "name": "myprofile",
+      "aliases": [],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "View your per-server profile card."
+    },
+    {
+      "name": "myprofile",
+      "aliases": [],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "View your profile: participation, subscriptions, preferences, visibility."
+    },
+    {
+      "name": "poll",
+      "aliases": [],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Create a simple reaction poll."
+    },
+    {
+      "name": "quote",
+      "aliases": [],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Sends a random famous quote."
+    },
+    {
+      "name": "remind",
+      "aliases": [],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Set a reminder. !remind <minutes> <message>"
+    },
+    {
+      "name": "serverinfo",
+      "aliases": [],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Alias for !info server."
+    },
+    {
+      "name": "trivia",
+      "aliases": [],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Asks a trivia question with a reveal button."
+    },
+    {
+      "name": "userinfo",
+      "aliases": [],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Alias for !info user [@member]."
+    },
+    {
+      "name": "utility",
+      "aliases": [],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the Utility hub (server info, polls, reminders)."
+    },
+    {
+      "name": "utilitymenu",
+      "aliases": [],
+      "category": "utility",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the interactive utility panel."
+    }
+  ],
+  "bot_changelog": [
+    {
+      "date": "2026-06-19",
+      "title": "New public bot website",
+      "kind": "improvement",
+      "summary": "A brand-new public website for the bot is taking shape — a marketing + reference site"
+    },
+    {
+      "date": "2026-06-12",
+      "title": "Owner review inbox on the dashboard",
+      "kind": "improvement",
+      "summary": "The developer dashboard now surfaces an owner review inbox, so feedback and review"
+    },
+    {
+      "date": "2026-06-08",
+      "title": "Command-alias suggestions",
+      "kind": "feature",
+      "summary": "You can now suggest a friendly alias for any command from the dashboard's Aliases page,"
+    }
+  ]
+}

--- a/botsite/data_loader.py
+++ b/botsite/data_loader.py
@@ -1,0 +1,95 @@
+"""Load + validate the public ``site.json`` subset (stdlib only).
+
+The bot site renders the committed ``botsite/data/site.json`` — the public subset
+produced by ``scripts/export_dashboard_data.py`` (plan §2.2). This module is the one
+read seam: it loads the file, falls back to a safe empty shape if it is missing or
+corrupt (so the app never crashes on a bad/absent artifact — the same robustness the
+dashboard's ``load_data`` has), and exposes the known top-level families with safe
+defaults.
+
+It is intentionally tiny and dependency-free (no ``disbot`` import, no third-party
+import) so it can be unit-tested without the web stack installed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+BASE_DIR = Path(__file__).resolve().parent
+DATA_FILE = BASE_DIR / "data" / "site.json"
+
+# The empty shape mirrors the producer's whitelist (see export_dashboard_data
+# SITE_TOPLEVEL_KEYS) so every template can rely on the keys existing even when the
+# artifact is absent at runtime — friendly empty states, never a KeyError.
+_EMPTY: dict[str, Any] = {
+    "meta": {"generated_at": "", "build": {}},
+    "counts": {"commands": 0, "features": 0, "games": 0},
+    "catalogue": [],
+    "commands": [],
+    "bot_changelog": [],
+}
+
+
+def load_site_data(path: Path = DATA_FILE) -> dict[str, Any]:
+    """Load ``site.json``, returning a safe empty shape on any read/parse failure.
+
+    The returned dict always carries the whitelisted top-level keys (missing ones
+    are backfilled from :data:`_EMPTY`), so callers never guard for absent families.
+    """
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return _empty()
+    if not isinstance(raw, dict):
+        return _empty()
+    data = _empty()
+    for key in _EMPTY:
+        if key in raw:
+            data[key] = raw[key]
+    return data
+
+
+def _empty() -> dict[str, Any]:
+    """A fresh copy of the empty data shape (never share the module-level dict)."""
+    return json.loads(json.dumps(_EMPTY))
+
+
+def build_meta(data: dict[str, Any]) -> dict[str, Any]:
+    """Return the build provenance block for the "generated" freshness badge.
+
+    The status/trust band renders this, honestly labelled "as of last deploy" (plan
+    §3 — generated build-meta is the v1 source; the public site never reads the
+    bot's live control API). Always a dict (possibly empty).
+    """
+    meta = data.get("meta", {})
+    build = meta.get("build", {})
+    return build if isinstance(build, dict) else {}
+
+
+def commands_by_category(data: dict[str, Any]) -> list[tuple[str, list[dict]]]:
+    """Group the public command reference by category, sorted (for the reference page).
+
+    A read-only projection used by the wired ``/commands`` route; the template (a
+    later unit) renders the groups. Pure, so it is unit-testable here.
+    """
+    grouped: dict[str, list[dict]] = {}
+    for cmd in data.get("commands", []):
+        grouped.setdefault(cmd.get("category") or "other", []).append(cmd)
+    for cmds in grouped.values():
+        cmds.sort(key=lambda c: c.get("name") or "")
+    return sorted(grouped.items())
+
+
+def features_by_category(data: dict[str, Any]) -> list[tuple[str, list[dict]]]:
+    """Group the catalogue (features showcase) by category, sorted.
+
+    Backs the wired ``/features`` route; the template lands in a later unit.
+    """
+    grouped: dict[str, list[dict]] = {}
+    for entry in data.get("catalogue", []):
+        grouped.setdefault(entry.get("category") or "other", []).append(entry)
+    for entries in grouped.values():
+        entries.sort(key=lambda e: e.get("display_name") or e.get("key") or "")
+    return sorted(grouped.items())

--- a/botsite/migrations/001_submissions.sql
+++ b/botsite/migrations/001_submissions.sql
@@ -1,0 +1,58 @@
+-- Submissions store — migration 001 (the public bug/suggestion intake table).
+--
+-- This is the ONE canonical schema for the `submissions` table, owned by the
+-- website tier (NOT the bot). It lives in a **separate, dashboard-owned Postgres**
+-- (plan §2.3 / §7.3 / Q-0178 decision 3) — deliberately not the bot's DB, so the
+-- bot-decoupling rule holds and the public bot site can hold an INSERT-only role on
+-- exactly this one table (plan §4.4 secret matrix).
+--
+-- Two independent helpers share ONLY this contract — never code (plan §2.2 / §5):
+--   * botsite/submissions_db.py   — INSERT-only  (insert_pending)
+--   * dashboard/submissions_db.py — SELECT+UPDATE (list_pending / set_status /
+--                                   attach_issue_url)
+--
+-- Flow (plan §2.3): the public bot-site /submit form INSERTs a row with
+-- status='pending'; it is NEVER shown publicly. The owner-gated dev-site
+-- /admin/moderation lists pending rows and approves/rejects; on approve the dev
+-- site mirrors the row to a GitHub issue and records github_issue_url.
+--
+-- Schema (plan §2.3):
+--   id              bigserial PK
+--   kind            'bug' | 'suggestion'  (maps to .github/ISSUE_TEMPLATE shapes)
+--   title           length-capped, server-trimmed
+--   body            length-capped; stored as plain text, rendered ESCAPED
+--   surface         from the bug template dropdown (bot / dashboard / CI / other);
+--                   nullable (suggestions need no surface)
+--   contact         optional, never required, never published
+--   status          'pending' (default) -> 'approved' | 'rejected'
+--   submitted_at    timestamptz default now()
+--   source_ip_hash  SALTED hash for rate-limit/abuse forensics — NEVER the raw IP
+--   moderated_by    owner Discord id at decision time (nullable until moderated)
+--   github_issue_url set when mirrored to a GitHub issue (nullable)
+--
+-- Deploy / rollback (plan §6): additive. Apply this file once against the
+-- dashboard-owned Postgres at rollout (owner step). `DROP TABLE submissions;`
+-- fully unwinds intake — nothing else references it. Forward-only and idempotent
+-- (CREATE TABLE IF NOT EXISTS), so re-applying is a no-op.
+
+CREATE TABLE IF NOT EXISTS submissions (
+    id               BIGINT       GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    kind             TEXT         NOT NULL,
+    title            TEXT         NOT NULL,
+    body             TEXT         NOT NULL,
+    surface          TEXT,
+    contact          TEXT,
+    status           TEXT         NOT NULL DEFAULT 'pending',
+    submitted_at     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    source_ip_hash   TEXT,
+    moderated_by     TEXT,
+    github_issue_url TEXT,
+    CHECK (kind IN ('bug', 'suggestion')),
+    CHECK (status IN ('pending', 'approved', 'rejected'))
+);
+
+-- The moderation queue reads `WHERE status='pending' ORDER BY submitted_at` — a
+-- partial index keeps that hot read cheap as the approved/rejected history grows.
+CREATE INDEX IF NOT EXISTS submissions_pending_idx
+    ON submissions (submitted_at)
+    WHERE status = 'pending';

--- a/botsite/requirements.txt
+++ b/botsite/requirements.txt
@@ -1,0 +1,15 @@
+# Web dependencies for the PUBLIC bot site service ONLY.
+# Kept separate from the bot's root requirements.txt (and from the dashboard's) so
+# CI's bot install and the bot's Railway build are unaffected — this is its own
+# Railway service (Root Directory = botsite). Mirrors the dashboard's proven recipe.
+fastapi>=0.137.2,<1.0
+uvicorn[standard]>=0.49.0,<1.0
+jinja2>=3.1.6,<4.0
+# asyncpg: the /submit intake INSERTs one pending row into the dashboard-owned
+# submissions DB (botsite/submissions_db.py). Pinned floor matches the bot's so the
+# driver behaves identically. The form parses with stdlib urllib (no python-multipart)
+# and the app holds NO other secret than the INSERT-only submissions DSN (plan §4.4).
+asyncpg>=0.29.0,<1.0
+# NOTE: deliberately NO httpx / itsdangerous / OAuth deps here. This is the public,
+# secret-free marketing surface — the gated "manage my server" manager is a SEPARATE
+# service (plan §4.4) and carries those deps in its own requirements, never this one.

--- a/botsite/submissions_db.py
+++ b/botsite/submissions_db.py
@@ -1,0 +1,187 @@
+"""INSERT-only submissions store for the public bot site.
+
+The public marketing bot site's **only** write is the ``/submit`` intake: a
+validated form INSERTs one ``pending`` row into the **dashboard-owned** submissions
+Postgres (plan §2.3 / §4.4). This module is that single write path — it can
+``insert_pending`` and **nothing else**. It deliberately cannot read, list, update,
+or delete: a full compromise of the public site cannot exfiltrate submissions,
+reach GitHub, or touch the bot. Least privilege is enforced *twice* — by this
+module's surface (INSERT-only) and by the DB role the owner grants its DSN.
+
+The schema is the single contract in ``botsite/migrations/001_submissions.sql``;
+this module shares **only that contract** with ``dashboard/submissions_db.py`` (the
+read/moderate side) — never code (plan §2.2 / §5).
+
+**Dormant by default.** When ``SUBMISSIONS_DB_DSN`` is not set, :func:`is_configured`
+is ``False`` and :func:`insert_pending` raises :class:`SubmissionsNotConfigured`; the
+``/submit`` route shows a "submissions are temporarily unavailable" state rather than
+erroring. Nothing here connects to anything until the owner sets the DSN on the
+public Railway service at rollout (plan §6).
+
+Decoupling: this module is part of the web tier and never imports ``disbot``. It
+uses ``asyncpg`` directly against its own DSN — it is NOT the bot's ``utils.db``
+seam (that rule is scoped to the bot's Postgres + ``disbot/``). ``asyncpg`` is
+lazy-imported so the module (and the bot-site app that imports it) loads even where
+the driver is absent.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+from typing import Any
+
+# The two intake kinds (must match the DDL CHECK + the GitHub issue-template shapes).
+KIND_BUG = "bug"
+KIND_SUGGESTION = "suggestion"
+VALID_KINDS: frozenset[str] = frozenset({KIND_BUG, KIND_SUGGESTION})
+
+# Server-side length caps (plan §4.2 — validation + sanitation). Mirrored by the
+# form, but enforced here so a hand-crafted POST can never store an oversized blob.
+MAX_TITLE_LEN = 200
+MAX_BODY_LEN = 8_000
+MAX_SURFACE_LEN = 80
+MAX_CONTACT_LEN = 200
+
+_DSN_ENV = "SUBMISSIONS_DB_DSN"
+# Salt for the source-IP hash. A dedicated env keeps the salt out of the codebase;
+# a per-process fallback still yields a usable within-run dedup key when unset
+# (the hash is for abuse forensics, not identity — plan §2.3 / §4.2).
+_IP_SALT_ENV = "SUBMISSIONS_IP_SALT"
+_FALLBACK_SALT = os.urandom(16).hex()
+
+
+class SubmissionsNotConfigured(RuntimeError):
+    """Raised by :func:`insert_pending` when ``SUBMISSIONS_DB_DSN`` is unset."""
+
+
+class SubmissionValidationError(ValueError):
+    """Raised when a submission fails server-side validation (bad kind / empty)."""
+
+
+def dsn() -> str | None:
+    """Return the submissions DB DSN, or ``None`` when the store is dormant."""
+    value = os.environ.get(_DSN_ENV, "").strip()
+    return value or None
+
+
+def is_configured() -> bool:
+    """``True`` when the submissions DB DSN is set (the store is live)."""
+    return dsn() is not None
+
+
+def hash_ip(raw_ip: str | None) -> str | None:
+    """Return a **salted** hash of ``raw_ip`` for abuse forensics — never the raw IP.
+
+    Plan §2.3 / §4.2: we store ``source_ip_hash`` only, so the moderation view and
+    any forensic dedup work on a pseudonymous token, not a real address. Returns
+    ``None`` for an empty/unknown IP so the column stays NULL rather than hashing "".
+    """
+    if not raw_ip:
+        return None
+    salt = (os.environ.get(_IP_SALT_ENV, "").strip() or _FALLBACK_SALT).encode()
+    return hmac.new(salt, raw_ip.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def _clean(text: str | None, limit: int) -> str | None:
+    """Trim, drop control characters, and length-cap a free-text field.
+
+    Returns ``None`` for an empty/whitespace-only result so optional columns stay
+    NULL. Control characters (other than ``\\n`` / ``\\t``) are stripped so a crafted
+    payload can't smuggle terminal escapes into the owner's moderation view.
+    """
+    if text is None:
+        return None
+    # Keep newlines + tabs; drop other C0/C1 control chars.
+    cleaned = "".join(
+        ch for ch in text if ch in ("\n", "\t") or (ch >= " " and ch != "\x7f")
+    ).strip()
+    if not cleaned:
+        return None
+    return cleaned[:limit]
+
+
+def build_insert(
+    *,
+    kind: str,
+    title: str,
+    body: str,
+    surface: str | None = None,
+    contact: str | None = None,
+    source_ip: str | None = None,
+) -> tuple[str, tuple[Any, ...]]:
+    """Validate + sanitise a submission and build its parametrised INSERT.
+
+    Pure (no I/O), so the whole validation contract is unit-testable without a DB:
+    returns ``(sql, params)`` where ``params`` is positional for asyncpg's ``$1..``.
+    Raises :class:`SubmissionValidationError` on a bad ``kind`` or a missing
+    required field (``title`` / ``body``). ``surface`` / ``contact`` are optional
+    and stored NULL when blank. The row is always inserted ``status='pending'`` —
+    this module physically cannot insert any other status (plan §2.3).
+    """
+    if kind not in VALID_KINDS:
+        raise SubmissionValidationError(
+            f"kind must be one of {sorted(VALID_KINDS)}, got {kind!r}",
+        )
+    clean_title = _clean(title, MAX_TITLE_LEN)
+    clean_body = _clean(body, MAX_BODY_LEN)
+    if not clean_title:
+        raise SubmissionValidationError("title is required")
+    if not clean_body:
+        raise SubmissionValidationError("body is required")
+
+    sql = (
+        "INSERT INTO submissions "
+        "(kind, title, body, surface, contact, status, source_ip_hash) "
+        "VALUES ($1, $2, $3, $4, $5, 'pending', $6) "
+        "RETURNING id"
+    )
+    params = (
+        kind,
+        clean_title,
+        clean_body,
+        _clean(surface, MAX_SURFACE_LEN),
+        _clean(contact, MAX_CONTACT_LEN),
+        hash_ip(source_ip),
+    )
+    return sql, params
+
+
+async def insert_pending(
+    *,
+    kind: str,
+    title: str,
+    body: str,
+    surface: str | None = None,
+    contact: str | None = None,
+    source_ip: str | None = None,
+) -> int:
+    """INSERT one ``pending`` submission and return its new ``id``.
+
+    The single write path of the public site. Validates + sanitises via
+    :func:`build_insert`, then opens a short-lived asyncpg connection to the
+    submissions DSN and executes the INSERT. Raises :class:`SubmissionsNotConfigured`
+    when the store is dormant and :class:`SubmissionValidationError` on bad input.
+    """
+    target = dsn()
+    if target is None:
+        raise SubmissionsNotConfigured(
+            f"{_DSN_ENV} is not set — the submissions store is dormant",
+        )
+    sql, params = build_insert(
+        kind=kind,
+        title=title,
+        body=body,
+        surface=surface,
+        contact=contact,
+        source_ip=source_ip,
+    )
+    import asyncpg  # lazy — keeps module import-safe where the driver is absent
+
+    conn = await asyncpg.connect(target)
+    try:
+        new_id = await conn.fetchval(sql, *params)
+    finally:
+        await conn.close()
+    return int(new_id)

--- a/botsite/submissions_db.py
+++ b/botsite/submissions_db.py
@@ -13,7 +13,7 @@ this module shares **only that contract** with ``dashboard/submissions_db.py`` (
 read/moderate side) — never code (plan §2.2 / §5).
 
 **Dormant by default.** When ``SUBMISSIONS_DB_DSN`` is not set, :func:`is_configured`
-is ``False`` and :func:`insert_pending` raises :class:`SubmissionsNotConfigured`; the
+is ``False`` and :func:`insert_pending` raises :class:`SubmissionsNotConfiguredError`; the
 ``/submit`` route shows a "submissions are temporarily unavailable" state rather than
 erroring. Nothing here connects to anything until the owner sets the DSN on the
 public Railway service at rollout (plan §6).
@@ -52,7 +52,7 @@ _IP_SALT_ENV = "SUBMISSIONS_IP_SALT"
 _FALLBACK_SALT = os.urandom(16).hex()
 
 
-class SubmissionsNotConfigured(RuntimeError):
+class SubmissionsNotConfiguredError(RuntimeError):
     """Raised by :func:`insert_pending` when ``SUBMISSIONS_DB_DSN`` is unset."""
 
 
@@ -85,10 +85,10 @@ def hash_ip(raw_ip: str | None) -> str | None:
 
 
 def _clean(text: str | None, limit: int) -> str | None:
-    """Trim, drop control characters, and length-cap a free-text field.
+    r"""Trim, drop control characters, and length-cap a free-text field.
 
     Returns ``None`` for an empty/whitespace-only result so optional columns stay
-    NULL. Control characters (other than ``\\n`` / ``\\t``) are stripped so a crafted
+    NULL. Control characters (other than ``\n`` / ``\t``) are stripped so a crafted
     payload can't smuggle terminal escapes into the owner's moderation view.
     """
     if text is None:
@@ -161,12 +161,12 @@ async def insert_pending(
 
     The single write path of the public site. Validates + sanitises via
     :func:`build_insert`, then opens a short-lived asyncpg connection to the
-    submissions DSN and executes the INSERT. Raises :class:`SubmissionsNotConfigured`
+    submissions DSN and executes the INSERT. Raises :class:`SubmissionsNotConfiguredError`
     when the store is dormant and :class:`SubmissionValidationError` on bad input.
     """
     target = dsn()
     if target is None:
-        raise SubmissionsNotConfigured(
+        raise SubmissionsNotConfiguredError(
             f"{_DSN_ENV} is not set — the submissions store is dormant",
         )
     sql, params = build_insert(

--- a/botsite/submit.py
+++ b/botsite/submit.py
@@ -1,0 +1,30 @@
+"""Public ``/submit`` intake — APIRouter (STUB, filled by a later unit).
+
+This is the *seam* the bot-site app mounts up front (``app.include_router(router)``)
+so the app boots with every route wired (plan §5 — P1 owns ``app.py`` and wires all
+routes; the submit module owns its own router). **This unit ships an empty router on
+purpose** — the real intake (the ``GET``/``POST /submit`` form + honeypot + rate-limit
++ validation + the INSERT via ``botsite.submissions_db.insert_pending``) is unit P4
+(plan §5), which owns this file's real content. Keeping the router here, owned by this
+module, is what keeps P1's ``app.py`` the single owner of routing while P4 fills the
+behaviour without editing ``app.py``.
+
+Contract for P4 (do not change the export name):
+* keep ``router`` as the module-level :class:`fastapi.APIRouter` instance,
+* add ``GET /submit`` (render the form) + ``POST /submit`` (validate → honeypot →
+  rate-limit → ``insert_pending(status='pending')`` → thank-you redirect),
+* the form's fields must cover every non-defaulted ``submissions`` column
+  (``kind`` / ``title`` / ``body`` / ``surface`` / optional ``contact``) — see
+  ``botsite/migrations/001_submissions.sql`` and plan §2.3 / the layout note,
+* render the stored body **escaped**; never list submissions publicly.
+
+Until then the router carries no routes, so mounting it is a safe no-op and ``/submit``
+simply 404s (the nav/footer can hide the link until P4 lands).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+# The mounted router. Empty by design (P1 stub); P4 attaches the /submit routes.
+router = APIRouter()

--- a/botsite/templates/base.html
+++ b/botsite/templates/base.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}SuperBot — the Discord bot{% endblock %}</title>
+    <meta
+      name="description"
+      content="{% block description %}SuperBot — a feature-rich Discord bot: games, moderation, AI tools, and more.{% endblock %}"
+    />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+      html { scroll-behavior: smooth; }
+      code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    </style>
+  </head>
+  <body class="bg-slate-950 text-slate-100 min-h-screen flex flex-col">
+    <header class="border-b border-slate-800 bg-slate-900/70 backdrop-blur sticky top-0 z-10">
+      <nav class="mx-auto max-w-6xl px-4 py-3 flex flex-wrap items-center gap-x-5 gap-y-2">
+        <a href="/" class="font-bold text-lg mr-2">🤖 SuperBot</a>
+        {% set nav_items = [('features', 'Features'), ('commands', 'Commands'), ('changelog', 'Changelog'), ('status', 'Status')] %}
+        {% for key, label in nav_items %}
+          <a
+            href="/{{ key }}"
+            class="text-sm hover:text-sky-300 {{ 'text-sky-400 font-semibold' if page == key else 'text-slate-300' }}"
+          >{{ label }}</a>
+        {% endfor %}
+        <div class="ml-auto flex items-center gap-3">
+          {# Small status dot → /status. "Generated" posture: green = a build is known
+             (as of last deploy), slate = no build meta. No live claim here (plan §3). #}
+          <a
+            href="/status"
+            title="Status (as of last deploy)"
+            class="flex items-center gap-1 text-xs text-slate-400 hover:text-slate-200"
+          >
+            <span class="inline-block h-2.5 w-2.5 rounded-full {{ 'bg-emerald-500' if build and build.commit else 'bg-slate-500' }}"></span>
+            <span class="hidden sm:inline">Status</span>
+          </a>
+          {# Persistent, distinctively-styled "Add to Discord" CTA (layout guidance). #}
+          <a
+            href="/"
+            class="text-sm rounded-lg bg-indigo-600 hover:bg-indigo-500 px-4 py-1.5 font-semibold shadow"
+          >Add to Discord</a>
+        </div>
+      </nav>
+    </header>
+    <main class="mx-auto max-w-6xl w-full px-4 py-8 flex-1">
+      {% block content %}{% endblock %}
+    </main>
+    <footer class="border-t border-slate-800 mx-auto max-w-6xl w-full px-4 py-6 text-xs text-slate-500">
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
+        {# Freshness badge — honest "generated" lineage (plan §3): the data is a
+           build-time snapshot, never a real-time claim. #}
+        <span class="rounded bg-slate-800 px-2 py-0.5 text-slate-400">generated</span>
+        <span>
+          {% if build and build.commit %}
+            as of last deploy · build <code>{{ build.commit }}</code>{% if build.committed_at %} · {{ build.committed_at }}{% endif %}
+          {% else %}
+            build info unavailable
+          {% endif %}
+        </span>
+        <span class="ml-auto">
+          <a class="underline hover:text-slate-300" href="https://github.com/menno420/superbot">source</a>
+        </span>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/botsite/templates/index.html
+++ b/botsite/templates/index.html
@@ -1,0 +1,87 @@
+{% extends "base.html" %}
+{% block title %}SuperBot — the all-in-one Discord bot{% endblock %}
+{% block description %}Games, moderation, AI tools and more — SuperBot brings {{ data.counts.features }} feature areas and {{ data.counts.commands }} commands to your Discord server.{% endblock %}
+{% block content %}
+
+{# ── Hero ───────────────────────────────────────────────────────────────── #}
+<section class="text-center py-12 sm:py-16">
+  <h1 class="text-4xl sm:text-5xl font-bold tracking-tight">SuperBot</h1>
+  <p class="mt-4 text-lg text-slate-300 max-w-2xl mx-auto">
+    One Discord bot for games, moderation, AI tools and more — built by a
+    self-improving, AI-assisted development workflow.
+  </p>
+  <div class="mt-7 flex items-center justify-center gap-3">
+    <a href="/" class="rounded-lg bg-indigo-600 hover:bg-indigo-500 px-6 py-2.5 font-semibold shadow">
+      Add to Discord
+    </a>
+    <a href="/features" class="rounded-lg border border-slate-700 hover:border-slate-500 px-6 py-2.5 font-medium">
+      Explore features
+    </a>
+  </div>
+</section>
+
+{# ── Capability band — HONEST catalogue counts only (plan layout note). Never
+   server/user totals — those need the deferred live source (plan §3). ───────── #}
+<section class="grid grid-cols-3 gap-4 max-w-2xl mx-auto">
+  {% set bands = [
+    (data.counts.commands, 'commands', '/commands'),
+    (data.counts.features, 'feature areas', '/features'),
+    (data.counts.games, 'games', '/features')
+  ] %}
+  {% for value, label, href in bands %}
+    <a href="{{ href }}" class="rounded-xl border border-slate-800 bg-slate-900/50 p-5 text-center hover:border-sky-600 transition-colors">
+      <div class="text-3xl font-bold">{{ value }}</div>
+      <div class="text-sm text-slate-400">{{ label }}</div>
+    </a>
+  {% endfor %}
+</section>
+
+{# ── Feature cards (grouped by category; deep-link to the showcase) ────────── #}
+<section class="mt-14">
+  <div class="flex items-center justify-between mb-4">
+    <h2 class="text-xl font-semibold">What it does</h2>
+    <a href="/features" class="text-sm text-sky-400 hover:text-sky-300">All features →</a>
+  </div>
+  {% if features %}
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {% for category, entries in features %}
+        <div class="rounded-xl border border-slate-800 bg-slate-900/40 p-5">
+          <div class="text-xs uppercase tracking-wide text-slate-500 mb-2">{{ category }}</div>
+          <ul class="space-y-2">
+            {% for entry in entries[:4] %}
+              <li class="flex items-start gap-2">
+                <span class="shrink-0">{{ entry.emoji or '•' }}</span>
+                <span class="text-sm text-slate-200">{{ entry.display_name or entry.key }}</span>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endfor %}
+    </div>
+  {% else %}
+    <p class="text-sm text-slate-500">Feature catalogue coming soon.</p>
+  {% endif %}
+</section>
+
+{# ── How it works ─────────────────────────────────────────────────────────── #}
+<section class="mt-14">
+  <h2 class="text-xl font-semibold mb-4 text-center">How it works</h2>
+  <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 max-w-3xl mx-auto">
+    {% set steps = [('1', 'Invite', 'Add SuperBot to your server.'), ('2', 'Configure', 'Pick the features you want.'), ('3', 'Enjoy', 'Your members start playing and using it.')] %}
+    {% for num, title, body in steps %}
+      <div class="rounded-xl border border-slate-800 bg-slate-900/40 p-5 text-center">
+        <div class="mx-auto mb-2 h-8 w-8 rounded-full bg-indigo-600 flex items-center justify-center font-bold">{{ num }}</div>
+        <div class="font-semibold">{{ title }}</div>
+        <div class="text-sm text-slate-400 mt-1">{{ body }}</div>
+      </div>
+    {% endfor %}
+  </div>
+</section>
+
+{# ── Repeat CTA ────────────────────────────────────────────────────────────── #}
+<section class="mt-14 text-center">
+  <a href="/" class="rounded-lg bg-indigo-600 hover:bg-indigo-500 px-7 py-3 font-semibold shadow">
+    Add SuperBot to your server
+  </a>
+</section>
+{% endblock %}

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,11 +1,11 @@
 {
   "meta": {
-    "generated_at": "2026-06-19T10:56:29Z",
+    "generated_at": "2026-06-19T13:15:55Z",
     "build": {
-      "commit": "9c5ec88c",
-      "subject": "Merge pull request #1099 from menno420/claude/focused-goldberg-mviel4",
-      "committed_at": "2026-06-19T12:45:44Z",
-      "branch": "main"
+      "commit": "2f6089a",
+      "subject": "Website split foundation: born-red session card (S1+S2+P1)",
+      "committed_at": "2026-06-19T13:13:03Z",
+      "branch": "worktree-agent-a2c7cd0ecd504a3e0"
     },
     "counts": {
       "functions": 36,
@@ -21,7 +21,8 @@
       "setting_domains": 15,
       "typed_settings": 84,
       "visible_subsystems": 36,
-      "synonyms": 87
+      "synonyms": 87,
+      "bot_changelog": 3
     }
   },
   "catalogue": [
@@ -1709,11 +1710,51 @@
   "reviews": [],
   "updates": [
     {
+      "file": "2026-06-19-website-two-site-split-plan.md",
+      "date": "2026-06-19",
+      "title": "2026-06-19 — Website two-site split: the implementation plan (Q-0178)",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": false
+    },
+    {
       "file": "2026-06-19-website-split-planning-brief.md",
       "date": "2026-06-19",
       "title": "2026-06-19 — Website two-site split: planning brief",
       "status": "complete",
       "run_type": "manual",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-06-19-website-split-decisions-locked.md",
+      "date": "2026-06-19",
+      "title": "2026-06-19 — Website split: review the external research + lock the open decisions",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-06-19-website-split-decision-routing.md",
+      "date": "2026-06-19",
+      "title": "2026-06-19 — Website split: route the control-panel-placement decision (Q-0179)",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": true
+    },
+    {
+      "file": "2026-06-19-website-plan-disjoint-tighten.md",
+      "date": "2026-06-19",
+      "title": "2026-06-19 — Pre-ultracode: make the website-plan §5 decomposition truly file-disjoint",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": true
+    },
+    {
+      "file": "2026-06-19-website-foundation-s1s2p1.md",
+      "date": "2026-06-19",
+      "title": "2026-06-19 — Website two-site split: serial foundation (S1 + S2 + P1)",
+      "status": "in-progress",
+      "run_type": "",
       "self_initiated": false
     },
     {
@@ -1723,6 +1764,14 @@
       "status": "complete",
       "run_type": "manual",
       "self_initiated": false
+    },
+    {
+      "file": "2026-06-19-router-status-tool.md",
+      "date": "2026-06-19",
+      "title": "2026-06-19 — router_status.py: a question-router digest tool",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": true
     },
     {
       "file": "2026-06-19-repo-governance-supply-chain-baseline.md",
@@ -1915,6 +1964,22 @@
       "status": "complete",
       "run_type": "routine",
       "self_initiated": false
+    },
+    {
+      "file": "2026-06-19-conflict-guard-unknown-race-fix.md",
+      "date": "2026-06-19",
+      "title": "2026-06-19 — Fix the pr-conflict-guard UNKNOWN-mergeability race",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": true
+    },
+    {
+      "file": "2026-06-19-codex-final-head-review.md",
+      "date": "2026-06-19",
+      "title": "2026-06-19 — Codex reviews the final head, not the born-red opener",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": true
     },
     {
       "file": "2026-06-19-ai-panel-inplace-nav-plan.md",
@@ -2123,70 +2188,26 @@
       "status": "complete",
       "run_type": "",
       "self_initiated": false
+    }
+  ],
+  "bot_changelog": [
+    {
+      "date": "2026-06-19",
+      "title": "New public bot website",
+      "kind": "improvement",
+      "summary": "A brand-new public website for the bot is taking shape — a marketing + reference site"
     },
     {
-      "file": "2026-06-17-moderation-dm-per-action.md",
-      "date": "2026-06-17",
-      "title": "Session — per-action moderation DMs (Q-0147 standing DM policy)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
+      "date": "2026-06-12",
+      "title": "Owner review inbox on the dashboard",
+      "kind": "improvement",
+      "summary": "The developer dashboard now surfaces an owner review inbox, so feedback and review"
     },
     {
-      "file": "2026-06-17-manifest-spine-pr3-control-read-reconcile.md",
-      "date": "2026-06-17",
-      "title": "Manifest spine PR3 — control-API manifest read + cross-manifest reconciliation",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-17-manifest-spine-pr2-panel-registry.md",
-      "date": "2026-06-17",
-      "title": "2026-06-17 — Manifest spine PR2: panel registry + PanelManifest",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-17-idea-gate-open.md",
-      "date": "2026-06-17",
-      "title": "2026-06-17 — Open the idea→plan gate (Q-0172) + skills batch-1 slim",
-      "status": "complete",
-      "run_type": "manual",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-17-hermes-house-style.md",
-      "date": "2026-06-17",
-      "title": "2026-06-17 — Hermes plain-language house style — rollout (Q-0168)",
-      "status": "complete",
-      "run_type": "manual",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-17-global-settings-tier.md",
-      "date": "2026-06-17",
-      "title": "Session — global settings tier (per-guild → global → default)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-17-generated-artifact-freshness-umbrella.md",
-      "date": "2026-06-17",
-      "title": "Session — generated-artifact freshness umbrella (one drift reporter for every committed generated file)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-17-dashboard-vision-review.md",
-      "date": "2026-06-17",
-      "title": "Session — review the dashboard vision plan + control-panel session close",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
+      "date": "2026-06-08",
+      "title": "Command-alias suggestions",
+      "kind": "feature",
+      "summary": "You can now suggest a friendly alias for any command from the dashboard's Aliases page,"
     }
   ],
   "env_usage": [

--- a/dashboard/submissions_db.py
+++ b/dashboard/submissions_db.py
@@ -50,7 +50,7 @@ _ROW_COLUMNS = (
 _DSN_ENV = "SUBMISSIONS_DB_DSN"
 
 
-class SubmissionsNotConfigured(RuntimeError):
+class SubmissionsNotConfiguredError(RuntimeError):
     """Raised by the query helpers when ``SUBMISSIONS_DB_DSN`` is unset."""
 
 
@@ -68,7 +68,7 @@ def is_configured() -> bool:
 def _require_dsn() -> str:
     target = dsn()
     if target is None:
-        raise SubmissionsNotConfigured(
+        raise SubmissionsNotConfiguredError(
             f"{_DSN_ENV} is not set — the submissions store is dormant",
         )
     return target
@@ -87,7 +87,7 @@ async def list_pending(limit: int = 200) -> list[dict[str, Any]]:
     Oldest-first so the owner works through the backlog in arrival order. Each row
     is a plain dict of :data:`_ROW_COLUMNS`; the body is returned verbatim (plain
     text) — the moderation template renders it **escaped** (plan §4.2), this layer
-    never renders. Raises :class:`SubmissionsNotConfigured` when dormant.
+    never renders. Raises :class:`SubmissionsNotConfiguredError` when dormant.
     """
     sql = (
         f"SELECT {', '.join(_ROW_COLUMNS)} FROM submissions "
@@ -113,7 +113,7 @@ async def set_status(
     makes a double-click idempotent — a second decision on an already-moderated row
     is a no-op and returns ``False``). ``status`` must be ``approved`` or
     ``rejected``; ``moderated_by`` records the owner's Discord id at decision time.
-    Raises :class:`ValueError` on a bad status, :class:`SubmissionsNotConfigured`
+    Raises :class:`ValueError` on a bad status, :class:`SubmissionsNotConfiguredError`
     when dormant.
     """
     if status not in MODERATION_STATUSES:
@@ -137,7 +137,7 @@ async def attach_issue_url(submission_id: int, issue_url: str) -> bool:
 
     Called after the GitHub mirror creates the issue (plan §2.3). Idempotent: only
     sets the URL when it is still NULL, so a retried mirror cannot overwrite a prior
-    link (the double-file guard, plan §4.2). Raises :class:`SubmissionsNotConfigured`
+    link (the double-file guard, plan §4.2). Raises :class:`SubmissionsNotConfiguredError`
     when dormant.
     """
     sql = (

--- a/dashboard/submissions_db.py
+++ b/dashboard/submissions_db.py
@@ -1,0 +1,160 @@
+"""Read + moderate side of the submissions store (dev-site / dashboard).
+
+The owner-gated dev site reads the ``pending`` queue and moderates it (plan §2.3):
+``list_pending`` shows what the public submitted, ``set_status`` approves/rejects a
+row, and ``attach_issue_url`` records the GitHub issue created on approval. This
+module holds the **full** (read/write) role on the submissions DB — the counterpart
+to the public site's INSERT-only :mod:`botsite.submissions_db`.
+
+The two modules share **only** the table contract in
+``botsite/migrations/001_submissions.sql`` — never code (plan §2.2 / §5). Keeping
+them as independent, single-purpose modules is what lets the two services hold
+different DB roles (INSERT-only vs. full) without a shared package re-coupling them.
+
+**Dormant by default.** When ``SUBMISSIONS_DB_DSN`` is not set, :func:`is_configured`
+is ``False`` and the moderation page shows a "set this up" state instead of querying
+anything (same discipline as the control API). The owner sets the DSN on the dev-site
+Railway service at rollout (plan §6).
+
+Decoupling: part of the web tier, never imports ``disbot``; uses ``asyncpg`` directly
+against its own DSN (NOT the bot's ``utils.db`` seam). ``asyncpg`` is lazy-imported so
+the module loads where the driver is absent.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+# Terminal moderation statuses an owner decision can set (the DDL also allows the
+# default 'pending', which only the public INSERT path writes — never a moderator).
+STATUS_PENDING = "pending"
+STATUS_APPROVED = "approved"
+STATUS_REJECTED = "rejected"
+MODERATION_STATUSES: frozenset[str] = frozenset({STATUS_APPROVED, STATUS_REJECTED})
+
+# Columns the moderation view reads. Explicit (never SELECT *) so a future schema
+# addition can't silently surface an unexpected column in the owner's UI.
+_ROW_COLUMNS = (
+    "id",
+    "kind",
+    "title",
+    "body",
+    "surface",
+    "contact",
+    "status",
+    "submitted_at",
+    "github_issue_url",
+)
+
+_DSN_ENV = "SUBMISSIONS_DB_DSN"
+
+
+class SubmissionsNotConfigured(RuntimeError):
+    """Raised by the query helpers when ``SUBMISSIONS_DB_DSN`` is unset."""
+
+
+def dsn() -> str | None:
+    """Return the submissions DB DSN, or ``None`` when the store is dormant."""
+    value = os.environ.get(_DSN_ENV, "").strip()
+    return value or None
+
+
+def is_configured() -> bool:
+    """``True`` when the submissions DB DSN is set."""
+    return dsn() is not None
+
+
+def _require_dsn() -> str:
+    target = dsn()
+    if target is None:
+        raise SubmissionsNotConfigured(
+            f"{_DSN_ENV} is not set — the submissions store is dormant",
+        )
+    return target
+
+
+async def _connect() -> Any:
+    """Open a short-lived asyncpg connection to the submissions DSN."""
+    import asyncpg  # lazy — keeps module import-safe where the driver is absent
+
+    return await asyncpg.connect(_require_dsn())
+
+
+async def list_pending(limit: int = 200) -> list[dict[str, Any]]:
+    """Return the ``pending`` submissions, oldest first (the moderation queue).
+
+    Oldest-first so the owner works through the backlog in arrival order. Each row
+    is a plain dict of :data:`_ROW_COLUMNS`; the body is returned verbatim (plain
+    text) — the moderation template renders it **escaped** (plan §4.2), this layer
+    never renders. Raises :class:`SubmissionsNotConfigured` when dormant.
+    """
+    sql = (
+        f"SELECT {', '.join(_ROW_COLUMNS)} FROM submissions "
+        f"WHERE status = 'pending' ORDER BY submitted_at ASC LIMIT $1"
+    )
+    conn = await _connect()
+    try:
+        rows = await conn.fetch(sql, limit)
+    finally:
+        await conn.close()
+    return [dict(row) for row in rows]
+
+
+async def set_status(
+    submission_id: int,
+    status: str,
+    *,
+    moderated_by: str | None = None,
+) -> bool:
+    """Approve or reject a **pending** submission; return ``True`` if a row changed.
+
+    Only flips a row that is still ``pending`` (the ``WHERE status='pending'`` guard
+    makes a double-click idempotent — a second decision on an already-moderated row
+    is a no-op and returns ``False``). ``status`` must be ``approved`` or
+    ``rejected``; ``moderated_by`` records the owner's Discord id at decision time.
+    Raises :class:`ValueError` on a bad status, :class:`SubmissionsNotConfigured`
+    when dormant.
+    """
+    if status not in MODERATION_STATUSES:
+        raise ValueError(
+            f"status must be one of {sorted(MODERATION_STATUSES)}, got {status!r}",
+        )
+    sql = (
+        "UPDATE submissions SET status = $2, moderated_by = $3 "
+        "WHERE id = $1 AND status = 'pending'"
+    )
+    conn = await _connect()
+    try:
+        result = await conn.execute(sql, submission_id, status, moderated_by)
+    finally:
+        await conn.close()
+    return _rows_affected(result) > 0
+
+
+async def attach_issue_url(submission_id: int, issue_url: str) -> bool:
+    """Record the GitHub issue URL on an approved submission; return ``True`` on change.
+
+    Called after the GitHub mirror creates the issue (plan §2.3). Idempotent: only
+    sets the URL when it is still NULL, so a retried mirror cannot overwrite a prior
+    link (the double-file guard, plan §4.2). Raises :class:`SubmissionsNotConfigured`
+    when dormant.
+    """
+    sql = (
+        "UPDATE submissions SET github_issue_url = $2 "
+        "WHERE id = $1 AND github_issue_url IS NULL"
+    )
+    conn = await _connect()
+    try:
+        result = await conn.execute(sql, submission_id, issue_url)
+    finally:
+        await conn.close()
+    return _rows_affected(result) > 0
+
+
+def _rows_affected(command_tag: str) -> int:
+    """Parse asyncpg's command tag (e.g. ``"UPDATE 1"``) into a row count."""
+    try:
+        return int(str(command_tag).split()[-1])
+    except (ValueError, IndexError):
+        return 0

--- a/docs/bot-changelog.md
+++ b/docs/bot-changelog.md
@@ -1,0 +1,49 @@
+# SuperBot — bot changelog
+
+> **Status:** `living-ledger` — the **curated, user-facing** "what's new in the bot"
+> source. One entry per *user-visible* bot change (a new command, a new game, a fix a
+> user can feel). The public bot site renders this at `/changelog`
+> (`scripts/export_dashboard_data.py` parses it into `site.json.bot_changelog`).
+> Decided in router **Q-0179** / plan §7.5 (2026-06-19): a curated file, **not**
+> auto-derived from session logs — the run-type seam classifies *how a session ran*,
+> not whether a change is user-relevant, so auto-deriving would leak dev-internal noise
+> onto a user surface.
+
+## What belongs here (and what does not)
+
+- **Belongs:** a new command or game; a visible new feature; a behaviour or bugfix a
+  user would notice; a meaningful UX change. Write it in **user language** — "you can
+  now…", not "refactored the X service".
+- **Does not belong:** internal refactors, docs/tooling/workflow changes, CI work,
+  test-only changes, routine reconciliation passes. Those live in the dev site's
+  `/updates` feed (the `.sessions/` logs), never here.
+
+## Format (parsed — keep it stable)
+
+Each entry is a level-2 heading `## YYYY-MM-DD — <title>`, optionally tagged with a
+**kind** in parentheses — `(feature)`, `(fix)`, or `(improvement)` — followed by a
+short user-facing description. Newest first. The parser reads the date, the title, the
+kind, and the first description line; everything else is for humans.
+
+> **Seeding note (2026-06-19).** This file is **seeded** as part of the website
+> two-site split foundation (plan §5, unit S1). The entries below are an initial,
+> deliberately small set so `/changelog` renders something honest on day one; the
+> ongoing discipline is to add one entry here whenever a *user-visible* change ships.
+
+---
+
+## 2026-06-19 — New public bot website (improvement)
+
+A brand-new public website for the bot is taking shape — a marketing + reference site
+(features, command reference, changelog, status) separate from the developer dashboard,
+plus a public form to send in bugs and suggestions. More to come as it rolls out.
+
+## 2026-06-12 — Owner review inbox on the dashboard (improvement)
+
+The developer dashboard now surfaces an owner review inbox, so feedback and review
+notes have a durable home instead of getting lost in chat.
+
+## 2026-06-08 — Command-alias suggestions (feature)
+
+You can now suggest a friendly alias for any command from the dashboard's Aliases page,
+with a live check that the alias doesn't collide with an existing command or synonym.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -27,6 +27,14 @@ Current broad captures:
   services. Structured into the required-output brief
   [`planning/website-two-site-split-planning-brief-2026-06-19.md`](../planning/website-two-site-split-planning-brief-2026-06-19.md)
   for the next planning session. → relates `dashboard/` · `scripts/export_dashboard_data.py`.
+- [`public-data-contract-field-snapshot-2026-06-19.md`](./public-data-contract-field-snapshot-2026-06-19.md) —
+  **session idea (2026-06-19, Q-0089, from the website two-site-split foundation build #1109):** S1
+  guards the public `site.json` subset at the **top-level key** boundary (fail-closed whitelist); the
+  uncovered leak class is a new *field* inside an allowed family (`commands`/`catalogue`). A tiny stdlib
+  snapshot test pins the **exact leaf field set per public family** so any new field trips a conscious
+  "is this public?" review — extending redaction-by-construction from keys to leaves. Quick-win,
+  disposable (Q-0105). → relates `scripts/export_dashboard_data.py` (`build_site_subset`) ·
+  `scripts/check_dashboard_data.py` · the split plan §2.2/§4.1.
 - [`governance-files-presence-guard-2026-06-19.md`](./governance-files-presence-guard-2026-06-19.md) —
   **session idea (2026-06-19, Q-0089, from the repo governance/supply-chain baseline session):** a tiny
   stdlib `scripts/check_governance_files.py` that asserts the new root governance files (`LICENSE` ·

--- a/docs/ideas/public-data-contract-field-snapshot-2026-06-19.md
+++ b/docs/ideas/public-data-contract-field-snapshot-2026-06-19.md
@@ -1,0 +1,54 @@
+# Public-data-contract field-level snapshot test
+
+> **Status:** `ideas` — a brainstorm capture, **not** a plan and **not** approval.
+> Session idea (2026-06-19, Q-0089), from the website two-site-split foundation build
+> (PR #1109, units S1+S2+P1).
+
+## The gap
+
+The foundation build (S1) guards the public `botsite/data/site.json` subset at the
+**top-level key** boundary, three ways: the producer (`build_site_subset` raises on a
+stray key), `check_dashboard_data.check_site_subset` (error-severity, fail-closed
+whitelist), and `check_generated_artifacts_fresh.drift_site_json`. That is the strong
+guarantee for non-negotiable #1 (the public site physically cannot carry a dev-only
+*family*).
+
+But the guard stops at the family boundary. The next leak class is **within** an
+allowed family: a producer change that adds a new **field** to `commands` or
+`catalogue` (say a per-guild value, an internal id, or a future `owner_only_note`)
+would pass the top-level whitelist **silently** — the family is allowed, so nobody is
+forced to ask "is this *field* public?".
+
+## The idea
+
+A tiny, stdlib snapshot test that pins the **exact set of leaf field names per public
+family**. Commit a `botsite/data/site_contract.json` (or inline constant) of the shape
+`{ "commands": ["aliases", "category", "cooldown", "name", "permissions", "usage"],
+"catalogue": ["badges", "category", "description", "display_name", "emoji", "is_game",
+"key", "tags"], "meta": [...], "counts": [...] }`. The test asserts every public
+record's field set equals the pinned contract. Any new field — safe *or* not — trips
+the test and forces a conscious "should this be public?" review + a contract bump
+before it can ship.
+
+## Why it's worth having
+
+- The whole split rests on non-negotiable #1 (the public site never leaks). The
+  *field* boundary is precisely the one the current top-level guard does **not** cover.
+- It is cheap (stdlib, no new dep), disposable (Q-0105 — delete if it nags without
+  catching anything real), and extends "redaction by construction" from keys → leaves
+  with no runtime cost.
+- It composes with the existing fail-closed whitelist: keys *and* leaves both fail
+  closed, so the redaction contract is total.
+
+## Disposition
+
+Quick-win, decided-lane. Natural home: extend `tests/unit/scripts/test_export_dashboard_data.py`
+(or a sibling) with the contract + assertion, and surface the contract in
+`check_dashboard_data.check_site_subset` so the CLI guard covers it too. Relates:
+`scripts/export_dashboard_data.py` (`build_site_subset`, `SITE_TOPLEVEL_KEYS`,
+`SITE_COMMAND_FIELDS`) · `scripts/check_dashboard_data.py` · the website two-site-split
+plan §2.2/§4.1 (the redaction boundary).
+
+Dedup note: no existing idea covers field-level public-contract pinning — the closest,
+[`website-two-site-split-2026-06-19.md`](./website-two-site-split-2026-06-19.md), is the
+parent capture and only the top-level whitelist shipped in #1109.

--- a/scripts/check_dashboard_data.py
+++ b/scripts/check_dashboard_data.py
@@ -54,6 +54,7 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DATA_FILE = REPO_ROOT / "dashboard" / "data" / "dashboard.json"
+SITE_DATA_FILE = REPO_ROOT / "botsite" / "data" / "site.json"
 
 # Real (``is_cog``) cogs that legitimately have NO own SUBSYSTEMS registry entry
 # AND no parent to map to: ``HermesCog`` (ops bridge), ``SetupCog`` (the hub-less
@@ -273,15 +274,76 @@ def validate(data: dict[str, Any]) -> list[Issue]:
     return issues
 
 
-def _build_fresh() -> dict[str, Any]:
-    """Regenerate the payload from live sources (sibling import — scripts/ isn't a package)."""
+def _export_module() -> Any:
+    """Load the producer module (sibling import — scripts/ isn't a package)."""
     script = Path(__file__).resolve().parent / "export_dashboard_data.py"
     spec = importlib.util.spec_from_file_location("_export_dashboard_seam", script)
     if spec is None or spec.loader is None:  # pragma: no cover - import wiring
         raise ImportError("cannot load export_dashboard_data.py")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    return module.build_data()
+    return module
+
+
+def _build_fresh() -> dict[str, Any]:
+    """Regenerate the full payload from live sources."""
+    return _export_module().build_data()
+
+
+def check_site_subset(
+    committed: dict[str, Any] | None = None,
+    *,
+    site_path: Path = SITE_DATA_FILE,
+) -> list[Issue]:
+    """Validate the public ``botsite/data/site.json`` subset (plan §5 / §2.2).
+
+    Two assertions, both **fail-closed**:
+
+    * **whitelist** — the committed file's top-level keys must be a *subset* of the
+      producer's :data:`SITE_TOPLEVEL_KEYS`. A new (un-whitelisted) top-level key is
+      the leak class this guards: it would mean the producer started emitting a
+      family that was never vetted as public. This is an **error** — the redaction
+      guarantee for non-negotiable #1.
+    * **counts** — ``counts.commands`` / ``features`` / ``games`` must equal the
+      lengths in the committed file (the count-drift class, mirrored from
+      :func:`check_count_integrity`).
+
+    Returns ``[]`` when the file is absent (it is a generated artifact; the freshness
+    reporter handles "missing"); callers that require its presence check separately.
+    """
+    issues: list[Issue] = []
+    if committed is None:
+        if not site_path.exists():
+            return issues
+        committed = json.loads(site_path.read_text(encoding="utf-8"))
+
+    allowed: set[str] = set(_export_module().SITE_TOPLEVEL_KEYS)
+    extra = set(committed) - allowed
+    if extra:
+        issues.append(
+            _err(
+                "site_key_not_whitelisted",
+                f"site.json has top-level key(s) {sorted(extra)} not in the public "
+                f"whitelist {sorted(allowed)} — a non-public family must never reach "
+                f"the marketing site (plan §2.2); fix build_site_subset / the whitelist",
+            ),
+        )
+
+    counts = committed.get("counts", {})
+    expected = {
+        "commands": len(committed.get("commands", [])),
+        "features": len(committed.get("catalogue", [])),
+        "games": sum(1 for e in committed.get("catalogue", []) if e.get("is_game")),
+    }
+    for key, exp in expected.items():
+        if key in counts and counts[key] != exp:
+            issues.append(
+                _err(
+                    "site_count_mismatch",
+                    f"site.json counts.{key}={counts[key]} but the data has {exp}",
+                ),
+            )
+    return issues
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -298,6 +360,11 @@ def main(argv: list[str] | None = None) -> int:
         help="report (warn-only) structural drift between the committed JSON and a fresh export",
     )
     parser.add_argument("--data", default=str(DATA_FILE), help="path to dashboard.json")
+    parser.add_argument(
+        "--site",
+        action="store_true",
+        help="also validate the public botsite/data/site.json subset (whitelist + counts)",
+    )
     args = parser.parse_args(argv)
 
     if args.fresh:
@@ -306,6 +373,8 @@ def main(argv: list[str] | None = None) -> int:
         data = json.loads(Path(args.data).read_text(encoding="utf-8"))
 
     issues = validate(data)
+    if args.site:
+        issues.extend(check_site_subset())
     if args.drift:
         # Compare the committed artifact (never the fresh one, even under --fresh)
         # against a fresh build so the report names what the *committed* file is

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -140,7 +140,12 @@ _REACHABILITY_ALLOWLIST: frozenset[str] = frozenset()
 # 2026-06-14: 18 -> 19 — the one sanctioned *raise*: repo-sector-map.md is a genuine
 # top-level navigation peer to repo-navigation-map.md / repo-review-map.md (the 3-tap nav
 # top layer, owner-directed Q-0137). Keep raising reserved for true top-level nav docs only.
-_TOP_LEVEL_DOCS_BUDGET = 19
+# 2026-06-19: 19 -> 20 — sanctioned raise: bot-changelog.md is a genuine top-level content
+# peer (the curated user-facing changelog the public bot site renders), pinned to this path
+# by the website two-site-split plan (§1/§5, owner-directed Q-0178/Q-0179). Not a
+# plan/audit/historical snapshot (those still belong in subdirs) — a durable, frequently
+# updated ledger alongside current-state.md / roadmap.md.
+_TOP_LEVEL_DOCS_BUDGET = 20
 
 # Soft cap on `current-state.md` § Recently shipped (newest-first merged-PR bullets).
 # Keeps the 2nd-most-read doc lean — overflow is archived to current-state-archive.md.

--- a/scripts/check_generated_artifacts_fresh.py
+++ b/scripts/check_generated_artifacts_fresh.py
@@ -144,6 +144,63 @@ def drift_dashboard_json() -> list[Drift]:
     ]
 
 
+# Structural identifier sets for the public site.json subset — only identity is
+# compared (never order/volatile churn), mirroring the dashboard.json surfaces.
+_SITE_SURFACES: dict[str, Callable[[dict[str, Any]], set[Any]]] = {
+    "catalogue keys": lambda d: {e.get("key") for e in d.get("catalogue", [])},
+    "command names": lambda d: {c.get("name") for c in d.get("commands", [])},
+    "changelog dates": lambda d: {e.get("date") for e in d.get("bot_changelog", [])},
+}
+
+
+def drift_site_json() -> list[Drift]:
+    """``botsite/data/site.json`` — the public subset (plan §5 / §2.2).
+
+    Two kinds of finding (both surfaced here, so one report covers the artifact):
+
+    * **whitelist** — the committed file's top-level keys must be a subset of the
+      producer's ``SITE_TOPLEVEL_KEYS``; a stray key is the leak class (a non-public
+      family reaching the marketing site) and is reported even though this umbrella
+      is warn-only by default (``--strict`` turns it into an exit-1 cadence gate).
+    * **structural freshness** — catalogue keys / command names / changelog dates
+      present in a fresh subset but missing from the committed file (a source change
+      that shipped but was never re-exported), and vice-versa. The volatile churn
+      (build SHA, timestamps) is ignored, like the dashboard.json reporter.
+    """
+    mod = _load_module("dashboard", REPO_ROOT / "scripts" / "check_dashboard_data.py")
+    site_path = mod.SITE_DATA_FILE
+    if not site_path.exists():
+        return [
+            Drift(
+                "site.json",
+                "artifact",
+                f"{site_path.relative_to(REPO_ROOT)} does not exist — re-run "
+                f"scripts/export_dashboard_data.py",
+            ),
+        ]
+    committed = json.loads(site_path.read_text(encoding="utf-8"))
+    fresh = mod._export_module().build_site_subset(mod._build_fresh())
+
+    findings: list[Drift] = []
+    # whitelist (reuse the canonical assertion in check_dashboard_data)
+    findings.extend(
+        Drift("site.json", "whitelist", issue.message)
+        for issue in mod.check_site_subset(committed, site_path=site_path)
+    )
+    # structural freshness
+    for surface_name, surface in _SITE_SURFACES.items():
+        findings.extend(
+            _set_drift(
+                "site.json",
+                surface_name,
+                surface(committed),
+                surface(fresh),
+                "re-run scripts/export_dashboard_data.py",
+            ),
+        )
+    return findings
+
+
 _ENV_VAR_ROW = re.compile(r"^\|\s*`([A-Z][A-Z0-9_]*)`", re.MULTILINE)
 
 
@@ -244,6 +301,12 @@ REGISTRY: tuple[Artifact, ...] = (
         "dashboard/data/dashboard.json",
         "scripts/export_dashboard_data.py",
         drift_dashboard_json,
+    ),
+    Artifact(
+        "site.json",
+        "botsite/data/site.json",
+        "scripts/export_dashboard_data.py",
+        drift_site_json,
     ),
     Artifact(
         "env-vars.md",

--- a/scripts/export_dashboard_data.py
+++ b/scripts/export_dashboard_data.py
@@ -1,11 +1,20 @@
 #!/usr/bin/env python3.10
-"""Export the developer dashboard's read-only data to JSON (stdlib only).
+"""Export the read-only web data to JSON (stdlib only) — both sites' producer.
 
 The developer dashboard (``docs/planning/developer-dashboard-plan.md``) is a
 decoupled web app under ``dashboard/`` that must **not** import ``disbot/``. This
 script is the seam between the two: it reads the repo's existing structured
-sources and serialises them to ``dashboard/data/dashboard.json``, which the
-FastAPI app renders.
+sources and serialises them. It is the **single producer** for both web tiers
+(``docs/planning/website-two-site-split-plan-2026-06-19.md`` §2.2 — one producer,
+two artifacts, no shared package):
+
+* ``dashboard/data/dashboard.json`` — the **full** payload (developer dashboard).
+* ``botsite/data/site.json`` — a **minimized public subset** (the marketing bot
+  site). It is an explicit *whitelist* of user-safe families only (see
+  :data:`SITE_TOPLEVEL_KEYS` / :func:`build_site_subset`); it physically cannot
+  contain a dev-only family (``env_usage`` / ``settings`` / ``access`` / ``reviews``
+  / ``ideas`` / raw ``bugs``) or any per-guild value — *redaction by construction*,
+  the strongest guarantee for the split's non-negotiable #1.
 
 Sources (all read-only, never imported):
 
@@ -14,14 +23,17 @@ Sources (all read-only, never imported):
 * Bugs                    <- ``docs/health/bug-book.md`` (``## BUG-NNNN ...``)
 * Reviews                 <- ``docs/owner/review-inbox.md`` (``## REV-NNNN — area — STATUS``)
 * Updates feed            <- ``.sessions/*.md`` (date + title + Status badge)
+* Bot changelog           <- ``docs/bot-changelog.md`` (``## YYYY-MM-DD — title``,
+                             curated user-facing changes — plan §7.5)
 * Env-var usage map       <- ``disbot/**/*.py`` via ``scripts/scan_env_usage.py``
                              (names + code locations only — never a value)
 
-Pure stdlib so it runs in CI with no extra dependencies and the dashboard's web
-dependencies (fastapi, uvicorn, ...) never enter the bot's ``requirements.txt``.
-Re-run after the sources change::
+Pure stdlib so it runs in CI with no extra dependencies and the web tiers' deps
+(fastapi, uvicorn, ...) never enter the bot's ``requirements.txt``.
+Re-run after the sources change (writes BOTH artifacts by default)::
 
-    python3.10 scripts/export_dashboard_data.py
+    python3.10 scripts/export_dashboard_data.py                 # both artifacts
+    python3.10 scripts/export_dashboard_data.py --targets site  # only site.json
 
 Reliability (Q-0105): **unverified** — confirm the JSON against the live sources
 a few times across sessions before trusting it, and delete this seam if it proves
@@ -42,6 +54,34 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 OUTPUT_FILE = REPO_ROOT / "dashboard" / "data" / "dashboard.json"
+SITE_OUTPUT_FILE = REPO_ROOT / "botsite" / "data" / "site.json"
+
+# The ONLY top-level keys the public ``site.json`` subset is allowed to carry
+# (plan §5 / §2.2). This is the redaction guarantee for the marketing bot site:
+# :func:`build_site_subset` constructs exactly these and nothing else, and the
+# freshness/whitelist guard (``check_generated_artifacts_fresh`` /
+# ``check_dashboard_data``) asserts the committed file's keys are a SUBSET of this
+# set — so a new key in the producer fails closed instead of silently leaking a
+# private family onto the public site. Deliberately OMITS ``env_usage``,
+# ``settings``, ``access``, ``reviews``, ``ideas``, raw ``bugs``, and ``cogs``
+# (the dashboard-only families).
+SITE_TOPLEVEL_KEYS: frozenset[str] = frozenset(
+    {"meta", "counts", "catalogue", "commands", "bot_changelog"},
+)
+# Per-command fields the public ``commands`` reference exposes (no per-guild value
+# ever appears — these are repo-level command metadata). ``usage`` is the one-line
+# description (the AST scanner's ``brief``); ``category`` + ``permissions`` are
+# joined from the command's subsystem catalogue entry; ``cooldown`` is reserved
+# (the AST scanner does not statically resolve runtime cooldown decorators today,
+# so it is emitted as ``null`` rather than fabricated — see :func:`build_site_subset`).
+SITE_COMMAND_FIELDS: tuple[str, ...] = (
+    "name",
+    "aliases",
+    "category",
+    "cooldown",
+    "permissions",
+    "usage",
+)
 
 
 def _load_scan_env_usage() -> Callable[..., list[dict]]:
@@ -399,6 +439,64 @@ def parse_updates(sessions_dir: Path, limit: int = 60) -> list[dict]:
     return updates[:limit]
 
 
+# Bot-changelog headings: ``## YYYY-MM-DD — <title>``, with an optional trailing
+# ``(feature)`` / ``(fix)`` / ``(improvement)`` kind tag inside the title (plan §7.5).
+# The user-facing curated source — NOT the .sessions/ dev feed.
+_CHANGELOG_HEAD_RE = re.compile(r"^##\s+(\d{4}-\d{2}-\d{2})\s*[—–-]\s*(.+?)\s*$")
+_CHANGELOG_KIND_RE = re.compile(
+    r"\((feature|fix|improvement)\)\s*$",
+    re.IGNORECASE,
+)
+_VALID_CHANGELOG_KINDS = frozenset({"feature", "fix", "improvement"})
+
+
+def parse_bot_changelog(text: str) -> list[dict]:
+    """Parse ``docs/bot-changelog.md`` into date/title/kind/summary records.
+
+    The **curated, user-facing** changelog (plan §7.5 / Q-0179): one record per
+    ``## YYYY-MM-DD — <title>`` heading, newest-first. An optional trailing
+    ``(feature)`` / ``(fix)`` / ``(improvement)`` tag in the title sets ``kind``
+    (default ``""``); the summary is the first body paragraph beneath the heading.
+    Deliberately separate from :func:`parse_updates` — that feeds the dev site's
+    ``/updates`` from ``.sessions/`` logs (how a session ran), while this is the
+    hand-curated "what's new for users" source the public ``/changelog`` renders.
+    """
+    entries: list[dict] = []
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        head = _CHANGELOG_HEAD_RE.match(line)
+        if not head:
+            continue
+        date, title = head.group(1), head.group(2).strip()
+        kind = ""
+        kind_match = _CHANGELOG_KIND_RE.search(title)
+        if kind_match:
+            kind = kind_match.group(1).lower()
+            title = title[: kind_match.start()].rstrip()
+        entries.append(
+            {
+                "date": date,
+                "title": _strip_md(title),
+                "kind": kind if kind in _VALID_CHANGELOG_KINDS else "",
+                "summary": _truncate(_changelog_summary(lines, index), 280),
+            },
+        )
+    entries.sort(key=lambda e: e["date"], reverse=True)
+    return entries
+
+
+def _changelog_summary(lines: list[str], start: int) -> str:
+    """Return the first body paragraph beneath a changelog heading."""
+    for line in lines[start + 1 : start + 30]:
+        if line.startswith("## "):
+            break
+        stripped = line.strip()
+        if not stripped or stripped[0] in "#>-*":
+            continue
+        return _strip_md(stripped)
+    return ""
+
+
 def _git_meta(repo_root: Path) -> dict[str, str]:
     """Return the build commit context the data was generated from, or ``{}``.
 
@@ -442,6 +540,7 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
     bug_book = repo_root / "docs" / "health" / "bug-book.md"
     review_inbox = repo_root / "docs" / "owner" / "review-inbox.md"
     sessions_dir = repo_root / ".sessions"
+    bot_changelog_file = repo_root / "docs" / "bot-changelog.md"
 
     catalogue = (
         parse_catalogue(registry.read_text(encoding="utf-8"))
@@ -456,6 +555,11 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
         else []
     )
     updates = parse_updates(sessions_dir) if sessions_dir.is_dir() else []
+    bot_changelog = (
+        parse_bot_changelog(bot_changelog_file.read_text(encoding="utf-8"))
+        if bot_changelog_file.exists()
+        else []
+    )
 
     scan_root = repo_root / "disbot"
     env_usage = (
@@ -532,6 +636,7 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
                 "typed_settings": len(specs),
                 "visible_subsystems": access.get("total_visible", 0),
                 "synonyms": sum(len(s["synonyms"]) for s in synonyms),
+                "bot_changelog": len(bot_changelog),
             },
         },
         "catalogue": catalogue,
@@ -539,6 +644,7 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
         "bugs": bugs,
         "reviews": reviews,
         "updates": updates,
+        "bot_changelog": bot_changelog,
         "env_usage": env_usage,
         "cogs": cogs,
         "settings": settings,
@@ -547,14 +653,166 @@ def build_data(repo_root: Path = REPO_ROOT) -> dict:
     }
 
 
+# ---------------------------------------------------------------------------
+# Public subset (botsite/data/site.json) — plan §5 / §2.2
+# ---------------------------------------------------------------------------
+# Game categories the marketing "features showcase" treats as games (the
+# `/features` page merges the function catalogue + games; the public counts
+# expose only catalogue counts, never server/user totals — plan layout note).
+_GAME_CATEGORIES: frozenset[str] = frozenset({"games"})
+# Public catalogue fields — declared metadata only (name/description/category/
+# badges). Omits internal-only fields like ``capabilities`` and ``entry_points``
+# (operator wiring, not user marketing) and ``visibility_mode`` (an internal flag).
+_SITE_CATALOGUE_FIELDS: tuple[str, ...] = (
+    "key",
+    "display_name",
+    "description",
+    "emoji",
+    "category",
+    "tags",
+)
+
+
+def _site_catalogue(catalogue: list[dict]) -> list[dict]:
+    """Project the full catalogue to the public, user-safe metadata subset.
+
+    ``badges`` is a small derived, user-facing list (currently the category), kept
+    deliberately generic so the showcase can render a chip without leaking the
+    internal ``visibility_tier`` / ``capabilities``.
+    """
+    out: list[dict] = []
+    for entry in catalogue:
+        projected = {f: entry.get(f) for f in _SITE_CATALOGUE_FIELDS if f in entry}
+        category = entry.get("category")
+        projected["badges"] = [category] if category else []
+        projected["is_game"] = category in _GAME_CATEGORIES
+        out.append(projected)
+    return out
+
+
+def _site_commands(cogs: list[dict], catalogue: list[dict]) -> list[dict]:
+    """Build the public command reference (no per-guild value, ever).
+
+    Each command exposes exactly :data:`SITE_COMMAND_FIELDS`. ``category`` and
+    ``permissions`` are joined from the command's owning subsystem catalogue entry
+    (``category`` = the subsystem category; ``permissions`` = its declared
+    ``visibility_tier`` — the honest static "who can see this" signal, NOT a
+    per-guild grant). ``usage`` is the command's one-line description (the AST
+    scanner's ``brief``). ``cooldown`` is reserved/``None`` — runtime cooldown
+    decorators are not statically resolved by the scanner today, so it is left
+    unset rather than fabricated. Subcommands are skipped (the reference lists
+    top-level commands; a later page can expand groups).
+    """
+    sysmap = {c.get("key"): c for c in catalogue}
+    out: list[dict] = []
+    for cog in cogs:
+        subsystem = cog.get("subsystem") or ""
+        sys_entry = sysmap.get(subsystem, {})
+        for cmd in cog.get("commands", []):
+            out.append(
+                {
+                    "name": cmd.get("name"),
+                    "aliases": list(cmd.get("aliases") or []),
+                    "category": sys_entry.get("category") or "other",
+                    "cooldown": None,
+                    "permissions": sys_entry.get("visibility_tier") or "",
+                    "usage": cmd.get("brief") or "",
+                },
+            )
+    out.sort(key=lambda c: ((c.get("category") or ""), (c.get("name") or "")))
+    return out
+
+
+def build_site_subset(data: dict) -> dict:
+    """Derive the public ``site.json`` subset from the full dashboard payload.
+
+    Returns a dict whose top-level keys are **exactly** :data:`SITE_TOPLEVEL_KEYS`
+    — redaction by construction (plan §2.2). It carries only user-safe families:
+    a slim ``meta`` (build provenance only), public catalogue ``counts``
+    (commands/features/games — never server/user totals), a metadata-only
+    ``catalogue``, a value-free ``commands`` reference, and the curated
+    ``bot_changelog``. Everything dev-only (``env_usage`` / ``settings`` /
+    ``access`` / ``reviews`` / ``ideas`` / raw ``bugs`` / ``cogs``) is dropped.
+    """
+    meta = data.get("meta", {})
+    catalogue = data.get("catalogue", [])
+    cogs = data.get("cogs", [])
+
+    site_catalogue = _site_catalogue(catalogue)
+    site_commands = _site_commands(cogs, catalogue)
+    games = sum(1 for e in site_catalogue if e.get("is_game"))
+
+    subset = {
+        # meta: build provenance only (sha/subject/date) + generation stamp. NO
+        # private counts here — the public counts live in the separate ``counts``
+        # family below, scoped to catalogue totals only.
+        "meta": {
+            "generated_at": meta.get("generated_at", ""),
+            "build": meta.get("build", {}),
+        },
+        # counts: catalogue totals ONLY (plan §5). Never server/user totals — those
+        # would require the deferred live source (plan §3, post-security-review).
+        "counts": {
+            "commands": len(site_commands),
+            "features": len(site_catalogue),
+            "games": games,
+        },
+        "catalogue": site_catalogue,
+        "commands": site_commands,
+        "bot_changelog": data.get("bot_changelog", []),
+    }
+    # Defensive: guarantee the contract the CI whitelist asserts. If a future edit
+    # adds a key here, this raises in the producer/tests before it can ship.
+    extra = set(subset) - SITE_TOPLEVEL_KEYS
+    if extra:
+        raise ValueError(
+            f"site.json subset produced disallowed top-level keys: {sorted(extra)} "
+            f"(allowed: {sorted(SITE_TOPLEVEL_KEYS)})",
+        )
+    return subset
+
+
+def _write_json(out: Path, payload: dict) -> str:
+    """Write ``payload`` as pretty JSON to ``out`` and return its repo-relative path."""
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return str(out.relative_to(REPO_ROOT) if out.is_relative_to(REPO_ROOT) else out)
+
+
 def main(argv: list[str] | None = None) -> int:
-    """CLI entry point: write the JSON payload (or print its summary)."""
-    parser = argparse.ArgumentParser(description="Export dashboard data to JSON.")
-    parser.add_argument("--output", default=str(OUTPUT_FILE), help="output JSON path")
+    """CLI entry point: write the JSON artifact(s) (or print the summary).
+
+    By default writes **both** ``dashboard.json`` (full) and ``site.json`` (public
+    subset) from one in-memory build (plan §2.2 — single producer). ``--targets``
+    selects which to emit; ``--check`` prints the full payload's meta and writes
+    nothing.
+    """
+    parser = argparse.ArgumentParser(
+        description="Export the web data to JSON (dashboard full payload + bot-site public subset).",
+    )
+    parser.add_argument(
+        "--targets",
+        choices=("both", "dashboard", "site"),
+        default="both",
+        help="which artifact(s) to write (default: both)",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(OUTPUT_FILE),
+        help="dashboard.json output path",
+    )
+    parser.add_argument(
+        "--site-output",
+        default=str(SITE_OUTPUT_FILE),
+        help="site.json (public subset) output path",
+    )
     parser.add_argument(
         "--check",
         action="store_true",
-        help="print the meta summary without writing the file",
+        help="print the meta summary without writing any file",
     )
     args = parser.parse_args(argv)
 
@@ -563,14 +821,13 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(data["meta"], indent=2))
         return 0
 
-    out = Path(args.output)
-    out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(
-        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
-        encoding="utf-8",
-    )
-    rel = out.relative_to(REPO_ROOT) if out.is_relative_to(REPO_ROOT) else out
-    print(f"wrote {rel} — {data['meta']['counts']}")
+    if args.targets in ("both", "dashboard"):
+        rel = _write_json(Path(args.output), data)
+        print(f"wrote {rel} — {data['meta']['counts']}")
+    if args.targets in ("both", "site"):
+        subset = build_site_subset(data)
+        rel = _write_json(Path(args.site_output), subset)
+        print(f"wrote {rel} — {subset['counts']}")
     return 0
 
 

--- a/tests/unit/botsite/test_app.py
+++ b/tests/unit/botsite/test_app.py
@@ -1,0 +1,153 @@
+"""Smoke test for the public bot-site FastAPI app (P1).
+
+Skipped automatically when the web dependencies are not installed (CI installs only
+the bot's ``requirements.txt``), so it never reddens CI; run it locally after
+``pip install -r botsite/requirements.txt``.
+
+Covers the two surfaces this unit fully ships templates for — ``/`` and ``/healthz``
+— plus the structural guarantees P1 owns: every route is wired, the submit stub
+mounts cleanly, and the app never imports ``disbot``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")  # Starlette's TestClient transport
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_APP = _REPO_ROOT / "botsite" / "app.py"
+
+
+@pytest.fixture(scope="module")
+def app_module():
+    spec = importlib.util.spec_from_file_location("botsite_app_ut", _APP)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def client(app_module):
+    return TestClient(app_module.app)
+
+
+# ---------------------------------------------------------------------------
+# the surfaces this unit ships (/ + /healthz)
+# ---------------------------------------------------------------------------
+
+
+def test_healthz_ok(client):
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_index_renders(client):
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "SuperBot" in resp.text
+    # The marketing landing's load-bearing pieces.
+    assert "Add to Discord" in resp.text
+    assert "How it works" in resp.text
+
+
+def test_index_shows_honest_catalogue_counts_not_server_totals(client, app_module):
+    # The capability band renders catalogue counts (commands/features/games) — never
+    # server/user totals (plan layout note: those need the deferred live source).
+    resp = client.get("/")
+    assert resp.status_code == 200
+    counts = app_module.data_loader.load_site_data()["counts"]
+    assert str(counts["commands"]) in resp.text
+    assert "feature areas" in resp.text
+    # No server/user vocabulary leaked onto the public landing.
+    lowered = resp.text.lower()
+    for forbidden in ("servers using", "active users", "members across"):
+        assert forbidden not in lowered
+
+
+def test_footer_shows_generated_freshness_badge(client):
+    # The "generated" lineage badge (plan §3) — honest, never a live claim.
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "generated" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# structural guarantees P1 owns (routing, the submit stub, decoupling)
+# ---------------------------------------------------------------------------
+
+
+def _route_paths(app) -> set[str]:
+    """Registered route paths (some entries — e.g. an included empty router — have
+    no ``.path``, so read it defensively)."""
+    return {p for route in app.routes if (p := getattr(route, "path", None))}
+
+
+def test_every_route_is_wired(app_module):
+    # P1 wires every route up front; the back-half units only fill templates/behaviour.
+    paths = _route_paths(app_module.app)
+    for expected in ("/", "/commands", "/features", "/changelog", "/status", "/healthz"):
+        assert expected in paths, f"route {expected} not wired"
+
+
+def test_submit_router_is_mounted_but_stub(app_module):
+    # The submit router is mounted (so P4 can fill it without touching app.py) but
+    # carries no routes yet → /submit is not registered as a path in this unit.
+    import submit
+
+    assert submit.router.routes == []
+    assert "/submit" not in _route_paths(app_module.app)
+
+
+def test_app_does_not_import_disbot(app_module):
+    # The hard decoupling rule: the web tier must never import disbot.
+    src = _APP.read_text(encoding="utf-8")
+    assert "import disbot" not in src
+    assert "from disbot" not in src
+    # And it must not have been pulled in transitively at import time.
+    assert not any(name == "disbot" or name.startswith("disbot.") for name in sys.modules)
+
+
+def test_no_static_dir(app_module):
+    # The #970 gotcha: there must be NO static/ dir (it would never deploy — gitignored).
+    assert not (_APP.parent / "static").exists()
+
+
+# ---------------------------------------------------------------------------
+# data_loader — load/validate site.json (robust to a missing/corrupt artifact)
+# ---------------------------------------------------------------------------
+
+
+def test_data_loader_falls_back_to_empty_shape(app_module, tmp_path):
+    dl = app_module.data_loader
+    missing = tmp_path / "nope.json"
+    data = dl.load_site_data(missing)
+    # Always carries the whitelisted top-level keys → templates never KeyError.
+    assert set(data) == {"meta", "counts", "catalogue", "commands", "bot_changelog"}
+    assert data["counts"] == {"commands": 0, "features": 0, "games": 0}
+
+
+def test_data_loader_handles_corrupt_json(app_module, tmp_path):
+    dl = app_module.data_loader
+    bad = tmp_path / "bad.json"
+    bad.write_text("{ not json", encoding="utf-8")
+    data = dl.load_site_data(bad)
+    assert data["catalogue"] == []
+
+
+def test_data_loader_reads_committed_site_json(app_module):
+    # The real committed artifact loads and carries the expected families.
+    dl = app_module.data_loader
+    data = dl.load_site_data()
+    assert set(data) >= {"meta", "counts", "catalogue", "commands", "bot_changelog"}
+    assert data["counts"]["commands"] == len(data["commands"])

--- a/tests/unit/botsite/test_submissions_db.py
+++ b/tests/unit/botsite/test_submissions_db.py
@@ -139,7 +139,7 @@ def test_is_configured_reflects_dsn_env(sdb, monkeypatch):
 
 async def test_insert_pending_raises_when_dormant(sdb, monkeypatch):
     monkeypatch.delenv("SUBMISSIONS_DB_DSN", raising=False)
-    with pytest.raises(sdb.SubmissionsNotConfigured):
+    with pytest.raises(sdb.SubmissionsNotConfiguredError):
         await sdb.insert_pending(kind="bug", title="t", body="b")
 
 

--- a/tests/unit/botsite/test_submissions_db.py
+++ b/tests/unit/botsite/test_submissions_db.py
@@ -1,0 +1,191 @@
+"""Tests for ``botsite/submissions_db.py`` — the INSERT-only submissions writer.
+
+No live Postgres: the pure validation/sanitation contract (``build_insert`` /
+``hash_ip``) is tested directly, and the one I/O path (``insert_pending``) is
+exercised against a tiny fake ``asyncpg`` connection injected via ``sys.modules``.
+Loaded by file path (the module is a plain file under ``botsite/``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE = _REPO_ROOT / "botsite" / "submissions_db.py"
+
+
+@pytest.fixture(scope="module")
+def sdb():
+    spec = importlib.util.spec_from_file_location("botsite_submissions_db_ut", _MODULE)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# build_insert — validation + sanitation (pure, no DB)
+# ---------------------------------------------------------------------------
+
+
+def test_build_insert_always_inserts_pending(sdb):
+    sql, params = sdb.build_insert(kind="bug", title="t", body="b")
+    # The status literal is hard-coded 'pending' in the SQL — this module cannot
+    # insert any other status (plan §2.3).
+    assert "'pending'" in sql
+    assert "status" not in sql.split("VALUES")[1] or "'pending'" in sql
+    assert params[0] == "bug"
+    assert params[1] == "t"
+    assert params[2] == "b"
+
+
+def test_build_insert_rejects_unknown_kind(sdb):
+    with pytest.raises(sdb.SubmissionValidationError, match="kind"):
+        sdb.build_insert(kind="malware", title="t", body="b")
+
+
+def test_build_insert_requires_title_and_body(sdb):
+    with pytest.raises(sdb.SubmissionValidationError, match="title"):
+        sdb.build_insert(kind="bug", title="   ", body="b")
+    with pytest.raises(sdb.SubmissionValidationError, match="body"):
+        sdb.build_insert(kind="suggestion", title="t", body="")
+
+
+def test_build_insert_length_caps(sdb):
+    long_title = "x" * (sdb.MAX_TITLE_LEN + 50)
+    long_body = "y" * (sdb.MAX_BODY_LEN + 50)
+    _, params = sdb.build_insert(kind="bug", title=long_title, body=long_body)
+    assert len(params[1]) == sdb.MAX_TITLE_LEN
+    assert len(params[2]) == sdb.MAX_BODY_LEN
+
+
+def test_build_insert_strips_control_chars(sdb):
+    # A crafted payload with an escape sequence must be neutralised, newlines kept.
+    _, params = sdb.build_insert(
+        kind="bug",
+        title="ok\x1b[31mevil",
+        body="line1\nline2\x07",
+    )
+    assert "\x1b" not in params[1]
+    assert params[1] == "ok[31mevil"
+    assert "\n" in params[2]  # newline preserved
+    assert "\x07" not in params[2]  # bell stripped
+
+
+def test_build_insert_optional_fields_null_when_blank(sdb):
+    _, params = sdb.build_insert(
+        kind="suggestion",
+        title="t",
+        body="b",
+        surface="   ",
+        contact="",
+    )
+    # surface (params[3]) + contact (params[4]) → None when blank.
+    assert params[3] is None
+    assert params[4] is None
+
+
+def test_build_insert_keeps_surface_and_contact_when_present(sdb):
+    _, params = sdb.build_insert(
+        kind="bug",
+        title="t",
+        body="b",
+        surface="Discord bot",
+        contact="me@example.com",
+    )
+    assert params[3] == "Discord bot"
+    assert params[4] == "me@example.com"
+
+
+# ---------------------------------------------------------------------------
+# hash_ip — salted, never the raw IP
+# ---------------------------------------------------------------------------
+
+
+def test_hash_ip_is_salted_and_not_raw(sdb):
+    raw = "203.0.113.7"
+    hashed = sdb.hash_ip(raw)
+    assert hashed is not None
+    assert raw not in hashed  # never store the raw IP
+    assert len(hashed) == 64  # sha256 hexdigest
+    # Deterministic within a process (same salt) → forensic dedup works.
+    assert sdb.hash_ip(raw) == hashed
+    # Different IPs hash differently.
+    assert sdb.hash_ip("198.51.100.1") != hashed
+
+
+def test_hash_ip_none_for_empty(sdb):
+    assert sdb.hash_ip(None) is None
+    assert sdb.hash_ip("") is None
+
+
+# ---------------------------------------------------------------------------
+# dormant-by-default
+# ---------------------------------------------------------------------------
+
+
+def test_is_configured_reflects_dsn_env(sdb, monkeypatch):
+    monkeypatch.delenv("SUBMISSIONS_DB_DSN", raising=False)
+    assert sdb.is_configured() is False
+    assert sdb.dsn() is None
+    monkeypatch.setenv("SUBMISSIONS_DB_DSN", "postgres://x")
+    assert sdb.is_configured() is True
+
+
+async def test_insert_pending_raises_when_dormant(sdb, monkeypatch):
+    monkeypatch.delenv("SUBMISSIONS_DB_DSN", raising=False)
+    with pytest.raises(sdb.SubmissionsNotConfigured):
+        await sdb.insert_pending(kind="bug", title="t", body="b")
+
+
+# ---------------------------------------------------------------------------
+# insert_pending — the I/O path against a fake asyncpg connection
+# ---------------------------------------------------------------------------
+
+
+class _FakeConn:
+    def __init__(self, record):
+        self.record = record
+        self.closed = False
+
+    async def fetchval(self, sql, *params):
+        self.record["sql"] = sql
+        self.record["params"] = params
+        return 4242
+
+    async def close(self):
+        self.closed = True
+
+
+async def test_insert_pending_executes_and_returns_id(sdb, monkeypatch):
+    monkeypatch.setenv("SUBMISSIONS_DB_DSN", "postgres://test")
+    record: dict = {}
+    fake_conn = _FakeConn(record)
+
+    class _FakeAsyncpg:
+        async def connect(self, target):  # noqa: ARG002 - signature parity
+            record["dsn"] = target
+            return fake_conn
+
+    monkeypatch.setitem(sys.modules, "asyncpg", _FakeAsyncpg())
+
+    new_id = await sdb.insert_pending(
+        kind="bug",
+        title="It broke",
+        body="steps",
+        surface="Discord bot",
+        source_ip="203.0.113.9",
+    )
+    assert new_id == 4242
+    assert record["dsn"] == "postgres://test"
+    assert record["sql"].startswith("INSERT INTO submissions")
+    assert "'pending'" in record["sql"]
+    # Params carry the salted IP hash (last positional), never the raw IP.
+    assert record["params"][-1] != "203.0.113.9"
+    assert record["params"][-1] is not None
+    assert fake_conn.closed is True  # connection always closed

--- a/tests/unit/dashboard/test_submissions_db.py
+++ b/tests/unit/dashboard/test_submissions_db.py
@@ -62,13 +62,13 @@ async def test_set_status_rejects_bad_status(sdb, monkeypatch):
 
 async def test_list_pending_raises_when_dormant(sdb, monkeypatch):
     monkeypatch.delenv("SUBMISSIONS_DB_DSN", raising=False)
-    with pytest.raises(sdb.SubmissionsNotConfigured):
+    with pytest.raises(sdb.SubmissionsNotConfiguredError):
         await sdb.list_pending()
 
 
 async def test_set_status_raises_when_dormant(sdb, monkeypatch):
     monkeypatch.delenv("SUBMISSIONS_DB_DSN", raising=False)
-    with pytest.raises(sdb.SubmissionsNotConfigured):
+    with pytest.raises(sdb.SubmissionsNotConfiguredError):
         await sdb.set_status(1, "approved")
 
 

--- a/tests/unit/dashboard/test_submissions_db.py
+++ b/tests/unit/dashboard/test_submissions_db.py
@@ -1,0 +1,156 @@
+"""Tests for ``dashboard/submissions_db.py`` — the read/moderate submissions side.
+
+No live Postgres: status validation, the command-tag row-count parse, and the
+dormant guards are tested directly, and the SELECT/UPDATE I/O paths run against a
+tiny fake ``asyncpg`` connection injected via ``sys.modules``. Loaded by file path
+(the module is a plain file under ``dashboard/``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE = _REPO_ROOT / "dashboard" / "submissions_db.py"
+
+
+@pytest.fixture(scope="module")
+def sdb():
+    spec = importlib.util.spec_from_file_location("dashboard_submissions_db_ut", _MODULE)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_rows_affected_parses_command_tag(sdb):
+    assert sdb._rows_affected("UPDATE 1") == 1
+    assert sdb._rows_affected("UPDATE 0") == 0
+    assert sdb._rows_affected("INSERT 0 5") == 5
+    assert sdb._rows_affected("weird") == 0
+
+
+def test_is_configured_reflects_dsn_env(sdb, monkeypatch):
+    monkeypatch.delenv("SUBMISSIONS_DB_DSN", raising=False)
+    assert sdb.is_configured() is False
+    monkeypatch.setenv("SUBMISSIONS_DB_DSN", "postgres://x")
+    assert sdb.is_configured() is True
+
+
+async def test_set_status_rejects_bad_status(sdb, monkeypatch):
+    monkeypatch.setenv("SUBMISSIONS_DB_DSN", "postgres://x")
+    # 'pending' is NOT a moderation decision — only approved/rejected are allowed.
+    # The status check runs before any connection, so no DB/fake is needed.
+    with pytest.raises(ValueError, match="status"):
+        await sdb.set_status(1, "pending")
+
+
+# ---------------------------------------------------------------------------
+# dormant-by-default
+# ---------------------------------------------------------------------------
+
+
+async def test_list_pending_raises_when_dormant(sdb, monkeypatch):
+    monkeypatch.delenv("SUBMISSIONS_DB_DSN", raising=False)
+    with pytest.raises(sdb.SubmissionsNotConfigured):
+        await sdb.list_pending()
+
+
+async def test_set_status_raises_when_dormant(sdb, monkeypatch):
+    monkeypatch.delenv("SUBMISSIONS_DB_DSN", raising=False)
+    with pytest.raises(sdb.SubmissionsNotConfigured):
+        await sdb.set_status(1, "approved")
+
+
+# ---------------------------------------------------------------------------
+# I/O paths against a fake asyncpg connection
+# ---------------------------------------------------------------------------
+
+
+class _FakeConn:
+    def __init__(self, record, *, fetch_rows=None, execute_tag="UPDATE 1"):
+        self.record = record
+        self._fetch_rows = fetch_rows or []
+        self._execute_tag = execute_tag
+        self.closed = False
+
+    async def fetch(self, sql, *params):
+        self.record["sql"] = sql
+        self.record["params"] = params
+        return self._fetch_rows
+
+    async def execute(self, sql, *params):
+        self.record["sql"] = sql
+        self.record["params"] = params
+        return self._execute_tag
+
+    async def close(self):
+        self.closed = True
+
+
+def _install_fake(monkeypatch, conn):
+    class _FakeAsyncpg:
+        async def connect(self, target):
+            conn.record["dsn"] = target
+            return conn
+
+    monkeypatch.setenv("SUBMISSIONS_DB_DSN", "postgres://test")
+    monkeypatch.setitem(sys.modules, "asyncpg", _FakeAsyncpg())
+
+
+async def test_list_pending_queries_pending_oldest_first(sdb, monkeypatch):
+    record: dict = {}
+    rows = [{"id": 1, "kind": "bug", "title": "a", "status": "pending"}]
+    conn = _FakeConn(record, fetch_rows=rows)
+    _install_fake(monkeypatch, conn)
+
+    result = await sdb.list_pending(limit=50)
+    assert result == rows
+    assert "WHERE status = 'pending'" in record["sql"]
+    assert "ORDER BY submitted_at ASC" in record["sql"]
+    assert "SELECT *" not in record["sql"]  # explicit columns, never SELECT *
+    assert record["params"] == (50,)
+    assert conn.closed is True
+
+
+async def test_set_status_approves_pending_row(sdb, monkeypatch):
+    record: dict = {}
+    conn = _FakeConn(record, execute_tag="UPDATE 1")
+    _install_fake(monkeypatch, conn)
+
+    changed = await sdb.set_status(7, "approved", moderated_by="999")
+    assert changed is True
+    # The WHERE clause guards on status='pending' → idempotent double-click.
+    assert "WHERE id = $1 AND status = 'pending'" in record["sql"]
+    assert record["params"] == (7, "approved", "999")
+
+
+async def test_set_status_noop_on_already_moderated(sdb, monkeypatch):
+    record: dict = {}
+    conn = _FakeConn(record, execute_tag="UPDATE 0")  # no row matched
+    _install_fake(monkeypatch, conn)
+
+    changed = await sdb.set_status(7, "rejected")
+    assert changed is False
+
+
+async def test_attach_issue_url_only_when_null(sdb, monkeypatch):
+    record: dict = {}
+    conn = _FakeConn(record, execute_tag="UPDATE 1")
+    _install_fake(monkeypatch, conn)
+
+    changed = await sdb.attach_issue_url(7, "https://github.com/menno420/superbot/issues/1")
+    assert changed is True
+    # Idempotent mirror: only sets when github_issue_url IS NULL (double-file guard).
+    assert "WHERE id = $1 AND github_issue_url IS NULL" in record["sql"]
+    assert record["params"] == (7, "https://github.com/menno420/superbot/issues/1")

--- a/tests/unit/scripts/test_check_dashboard_data.py
+++ b/tests/unit/scripts/test_check_dashboard_data.py
@@ -201,3 +201,64 @@ def test_drift_findings_are_only_warnings_against_live(mod):
 def test_main_drift_exits_zero(mod):
     # --drift reports warnings but never fails the run.
     assert mod.main(["--drift"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# site.json subset guard (--site) — the redaction whitelist (plan §5 / §2.2)
+# ---------------------------------------------------------------------------
+
+
+def test_site_subset_clean_when_whitelisted(mod):
+    clean = {
+        "meta": {},
+        "counts": {"commands": 1, "features": 0, "games": 0},
+        "catalogue": [],
+        "commands": [{"name": "ping"}],
+        "bot_changelog": [],
+    }
+    assert mod.check_site_subset(clean) == []
+
+
+def test_site_subset_fails_closed_on_unwhitelisted_key(mod):
+    # The leak class: a non-public family appearing at the top level is an ERROR.
+    forged = {
+        "meta": {},
+        "counts": {},
+        "catalogue": [],
+        "commands": [],
+        "bot_changelog": [],
+        "env_usage": ["SECRET_TOKEN"],  # must never reach the public site
+    }
+    issues = mod.check_site_subset(forged)
+    assert [i.code for i in issues] == ["site_key_not_whitelisted"]
+    assert issues[0].severity == "error"
+    assert "env_usage" in issues[0].message
+
+
+def test_site_subset_flags_count_mismatch(mod):
+    forged = {
+        "meta": {},
+        "counts": {"commands": 99},  # wrong
+        "catalogue": [],
+        "commands": [{"name": "ping"}],
+        "bot_changelog": [],
+    }
+    issues = mod.check_site_subset(forged)
+    assert any(i.code == "site_count_mismatch" and i.severity == "error" for i in issues)
+
+
+def test_live_site_subset_is_clean(mod):
+    # The freshly-built subset must pass its own whitelist + count guard.
+    fresh = mod._export_module().build_site_subset(mod._build_fresh())
+    errors = [i for i in mod.check_site_subset(fresh) if i.severity == "error"]
+    assert errors == [], f"fresh site.json subset has errors: {errors}"
+
+
+def test_committed_site_json_passes_guard(mod):
+    # The committed botsite/data/site.json must pass the guard as shipped.
+    errors = [i for i in mod.check_site_subset() if i.severity == "error"]
+    assert errors == [], f"committed site.json has errors: {errors}"
+
+
+def test_main_site_exits_zero(mod):
+    assert mod.main(["--site"]) == 0

--- a/tests/unit/scripts/test_check_generated_artifacts_fresh.py
+++ b/tests/unit/scripts/test_check_generated_artifacts_fresh.py
@@ -132,5 +132,22 @@ def test_main_list_prints_registry(mod, capsys):
     assert mod.main(["--list"]) == 0
     out = capsys.readouterr().out
     assert "dashboard.json" in out
+    assert "site.json" in out
     assert "env-vars.md" in out
     assert "context-packs" in out
+
+
+# ---------------------------------------------------------------------------
+# site.json artifact (the public subset — plan §5 / §2.2)
+# ---------------------------------------------------------------------------
+def test_site_json_is_registered(mod):
+    labels = {a.label for a in mod.REGISTRY}
+    assert "site.json" in labels
+
+
+def test_site_json_committed_is_fresh(mod):
+    # The committed botsite/data/site.json must be in sync with the producer.
+    findings = mod.drift_site_json()
+    assert findings == [], "\n".join(
+        f"[{d.surface}] {d.message}" for d in findings
+    )

--- a/tests/unit/scripts/test_export_dashboard_data.py
+++ b/tests/unit/scripts/test_export_dashboard_data.py
@@ -147,3 +147,183 @@ def test_build_data_includes_cogs_section(mod):
         for cmd in cog["commands"]:
             assert set(cmd) >= {"name", "type", "button_backed", "aliases"}
             assert cmd["type"] in {"prefix", "slash", "both"}
+
+
+# ---------------------------------------------------------------------------
+# S1 — bot changelog parser (docs/bot-changelog.md → site.json.bot_changelog)
+# ---------------------------------------------------------------------------
+
+SAMPLE_CHANGELOG = """# Bot changelog
+
+## 2026-06-19 — New game: Blackjack (feature)
+
+You can now play Blackjack against the bot.
+
+## 2026-06-10 — Faster help menu (improvement)
+
+The help menu opens faster now.
+
+## 2026-05-01 — Untagged entry
+
+No kind tag here.
+"""
+
+
+def test_parse_bot_changelog_extracts_date_title_kind_summary(mod):
+    entries = mod.parse_bot_changelog(SAMPLE_CHANGELOG)
+    assert [e["date"] for e in entries] == ["2026-06-19", "2026-06-10", "2026-05-01"]
+    assert entries[0]["title"] == "New game: Blackjack"
+    assert entries[0]["kind"] == "feature"
+    assert "Blackjack against the bot" in entries[0]["summary"]
+    assert entries[1]["kind"] == "improvement"
+    # An entry with no kind tag → kind == "" (never fabricated), title intact.
+    assert entries[2]["kind"] == ""
+    assert entries[2]["title"] == "Untagged entry"
+
+
+def test_parse_bot_changelog_empty_source(mod):
+    assert mod.parse_bot_changelog("# Bot changelog\n\nNo entries yet.\n") == []
+
+
+def test_build_data_includes_bot_changelog(mod):
+    data = mod.build_data()
+    assert "bot_changelog" in data
+    assert data["meta"]["counts"]["bot_changelog"] == len(data["bot_changelog"])
+    for entry in data["bot_changelog"]:
+        assert set(entry) == {"date", "title", "kind", "summary"}
+        assert entry["kind"] in {"", "feature", "fix", "improvement"}
+
+
+# ---------------------------------------------------------------------------
+# S1 — the public site.json subset (redaction by construction, plan §2.2 / §5)
+# ---------------------------------------------------------------------------
+
+
+def test_site_subset_toplevel_keys_are_exactly_the_whitelist(mod):
+    subset = mod.build_site_subset(mod.build_data())
+    # The hard guarantee: nothing but the whitelisted families, ever.
+    assert set(subset) == set(mod.SITE_TOPLEVEL_KEYS)
+    assert set(subset) == {"meta", "counts", "catalogue", "commands", "bot_changelog"}
+
+
+def test_site_subset_omits_every_dev_only_family(mod):
+    subset = mod.build_site_subset(mod.build_data())
+    for forbidden in (
+        "env_usage",
+        "settings",
+        "access",
+        "reviews",
+        "ideas",
+        "bugs",
+        "cogs",
+        "synonyms",
+    ):
+        assert forbidden not in subset, f"{forbidden} leaked into site.json"
+
+
+def test_site_subset_meta_carries_build_only_no_private_counts(mod):
+    meta = mod.build_site_subset(mod.build_data())["meta"]
+    # Only build provenance + the generation stamp — never the dashboard's full
+    # meta.counts (which include server-revealing internals like env_vars).
+    assert set(meta) <= {"generated_at", "build"}
+    assert "counts" not in meta
+
+
+def test_site_subset_counts_are_catalogue_only(mod):
+    counts = mod.build_site_subset(mod.build_data())["counts"]
+    # Catalogue totals ONLY — never server/user totals (plan §5 / layout note).
+    assert set(counts) == {"commands", "features", "games"}
+    for forbidden in ("guilds", "servers", "users", "members", "env_vars"):
+        assert forbidden not in counts
+
+
+def test_site_subset_commands_carry_no_per_guild_value(mod):
+    subset = mod.build_site_subset(mod.build_data())
+    assert subset["commands"], "expected a non-empty command reference"
+    for cmd in subset["commands"]:
+        assert set(cmd) == set(mod.SITE_COMMAND_FIELDS)
+        assert set(cmd) == {
+            "name",
+            "aliases",
+            "category",
+            "cooldown",
+            "permissions",
+            "usage",
+        }
+        # cooldown is reserved (not statically resolvable) — None, never fabricated.
+        assert cmd["cooldown"] is None
+
+
+def test_site_subset_catalogue_is_metadata_only(mod):
+    subset = mod.build_site_subset(mod.build_data())
+    assert subset["catalogue"], "expected a non-empty catalogue"
+    for entry in subset["catalogue"]:
+        # Public metadata only — internal wiring fields must not be present.
+        for forbidden in ("capabilities", "entry_points", "visibility_mode"):
+            assert forbidden not in entry
+        assert "badges" in entry
+        assert isinstance(entry["is_game"], bool)
+
+
+def test_site_subset_counts_match_lengths(mod):
+    subset = mod.build_site_subset(mod.build_data())
+    assert subset["counts"]["commands"] == len(subset["commands"])
+    assert subset["counts"]["features"] == len(subset["catalogue"])
+    assert subset["counts"]["games"] == sum(
+        1 for e in subset["catalogue"] if e.get("is_game")
+    )
+
+
+def test_build_site_subset_raises_if_a_disallowed_key_is_added(mod):
+    # The producer's own defensive guard: a future edit that adds an un-whitelisted
+    # key must fail in the producer, not silently ship. We simulate by monkeypatching
+    # SITE_TOPLEVEL_KEYS to a stricter set so the real subset trips it.
+    original = mod.SITE_TOPLEVEL_KEYS
+    try:
+        mod.SITE_TOPLEVEL_KEYS = frozenset({"meta"})  # type: ignore[misc]
+        with pytest.raises(ValueError, match="disallowed top-level keys"):
+            mod.build_site_subset(mod.build_data())
+    finally:
+        mod.SITE_TOPLEVEL_KEYS = original  # type: ignore[misc]
+
+
+def test_committed_site_json_matches_a_fresh_build(mod):
+    # The committed botsite/data/site.json must be regenerable-identical (modulo
+    # the volatile meta) to a fresh subset — the freshness guarantee S1 registers.
+    import json
+
+    committed = json.loads(mod.SITE_OUTPUT_FILE.read_text(encoding="utf-8"))
+    fresh = mod.build_site_subset(mod.build_data())
+    # Compare the stable families; meta carries the volatile build SHA/timestamp.
+    for family in ("counts", "catalogue", "commands", "bot_changelog"):
+        assert committed[family] == fresh[family], f"{family} drifted — re-export"
+
+
+def test_cli_targets_site_writes_only_site_json(mod, tmp_path):
+    dash = tmp_path / "dashboard.json"
+    site = tmp_path / "site.json"
+    rc = mod.main(
+        [
+            "--targets",
+            "site",
+            "--output",
+            str(dash),
+            "--site-output",
+            str(site),
+        ],
+    )
+    assert rc == 0
+    assert site.exists()
+    assert not dash.exists()  # --targets site must not write the dashboard payload
+
+
+def test_cli_targets_both_writes_both(mod, tmp_path):
+    dash = tmp_path / "dashboard.json"
+    site = tmp_path / "site.json"
+    rc = mod.main(["--output", str(dash), "--site-output", str(site)])
+    assert rc == 0
+    assert dash.exists() and site.exists()
+    import json
+
+    site_data = json.loads(site.read_text(encoding="utf-8"))
+    assert set(site_data) == set(mod.SITE_TOPLEVEL_KEYS)


### PR DESCRIPTION
Builds the **serial foundation** of the website two-site split per [`docs/planning/website-two-site-split-plan-2026-06-19.md`](https://github.com/menno420/superbot/blob/main/docs/planning/website-two-site-split-plan-2026-06-19.md) §5 — the three file-disjoint foundation units everything downstream (P2–P8) depends on. Code + tests only; no live infra, no `disbot/` changes, no deploy.

## S1 — data producer + public subset (sole owner of `export_dashboard_data.py`)
- `scripts/export_dashboard_data.py` now emits **both** `dashboard/data/dashboard.json` (full) and `botsite/data/site.json` (public subset) from one in-memory build (`--targets` selector, both by default).
- `build_site_subset()` is **redaction by construction**: top-level keys are *exactly* `{meta, counts, catalogue, commands, bot_changelog}`. `counts` are catalogue-only (commands/features/games — never server/user totals); `commands` carry no per-guild value (`name/aliases/category/cooldown/permissions/usage`; `cooldown` reserved `None`, not fabricated); dev-only families (`env_usage`/`settings`/`access`/`reviews`/`ideas`/raw `bugs`/`cogs`) are dropped.
- Folds in the `bot_changelog` parse + seeds the curated `docs/bot-changelog.md` (plan §7.5).
- Registers `site.json` in `check_dashboard_data.py` (`check_site_subset`: **fail-closed** whitelist + count assertions) and `check_generated_artifacts_fresh.py` (freshness). Verified the whitelist fails closed on an injected `env_usage` key.

## S2 — submissions store (one schema, two independent helpers, no shared package)
- `botsite/migrations/001_submissions.sql` — the one canonical DDL (separate dashboard-owned Postgres; plan §2.3/§7.3).
- `botsite/submissions_db.py` — **INSERT-only** (`insert_pending`): validates/sanitises, always `status='pending'`, salted `source_ip_hash` (never raw IP).
- `dashboard/submissions_db.py` — **SELECT+UPDATE** (`list_pending` / `set_status` / `attach_issue_url`), idempotent moderation.
- They share **only** the table contract, never code. Tests run with no live Postgres (pure helpers + a fake asyncpg connection).

## P1 — bot-site app + ALL routes (sole owner of `botsite/app.py`)
- `botsite/{__init__,app,data_loader,submit}.py`, `Procfile`, `requirements.txt`, `templates/{base,index}.html`, `README.md`, `tests/unit/botsite/test_app.py`.
- `app.py` wires **every** route up front (`/`, `/commands`, `/features`, `/changelog`, `/status`, `/healthz`) + mounts the `/submit` stub router. P2/P3 templates land later (routes wired now, by design).
- **Secret-free** public surface (holds at most the INSERT-only submissions DSN); the future "manage my server" manager is a **separate service**, not a router here — drops in without refactoring `app.py` (the correctness mandate). Honors the no-`static/` #970 gotcha.

## Verification (green)
- `python3.10 scripts/check_quality.py --full` → **All checks passed** (black/isort/ruff/check_docs/check_consistency + `mypy disbot/` + full pytest **10,895 passed, 37 skipped**).
- `python3.10 scripts/check_architecture.py --mode strict` → **exit 0**; confirmed **no web→`disbot/` import**.

## Deviation from §5
- Raised the `check_docs` top-level-docs ratchet 19→20 (a one-line, documented, sanctioned raise) because the plan pins `docs/bot-changelog.md` at the docs root — it's a genuine top-level content peer, not a plan/audit snapshot.
- The `commands` subset's `cooldown` is emitted as `null` (the AST scanner does not statically resolve runtime cooldown decorators today) rather than fabricated — `name/aliases/category/permissions/usage` are populated honestly from the scanner + subsystem join.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txth4MHhF5Li6fQJ4koA27

---
_Generated by [Claude Code](https://claude.ai/code/session_01Txth4MHhF5Li6fQJ4koA27)_