### PR TITLE
docs(website-split): owner site-identity vision + fan-out enablers

### DIFF
--- a/.github/workflows/botsite-ci.yml
+++ b/.github/workflows/botsite-ci.yml
@@ -1,0 +1,72 @@
+name: Botsite CI
+
+# Runs the public bot-site test suite + type-check. Twin of dashboard-ci.yml, for the
+# second web service (`botsite/`, the website two-site split). Provenance: owner-directed
+# 2026-06-19 (website-split foundation follow-through).
+#
+# Why a separate workflow (same reason as the dashboard): the main `code-quality.yml`
+# installs only the BOT's requirements.txt, so the bot-site tests (`tests/unit/botsite/`)
+# `importorskip` fastapi/httpx and silently SKIP, and bot-site code is never type-checked
+# (CI runs `mypy disbot/` only). Black/isort/ruff already cover `botsite/` in the main job
+# (it is not in their exclude list), so this workflow adds exactly the two missing pieces:
+# real test execution + `mypy botsite/`.
+#
+# Centralization note (owner mandate, 2026-06-19): this is deliberately a near-twin of
+# dashboard-ci.yml rather than a merge of the two — keeping the working dashboard CI
+# untouched (correctness first). The better centralized form — one `web-ci.yml` with a
+# matrix over {dashboard, botsite} — is designed in
+# `docs/planning/web-tier-centralization-proposal-2026-06-19.md`; implement it as a focused
+# follow-up, then delete this file + dashboard-ci.yml.
+#
+# `paths`-filtered so it only runs when bot-site code/tests change (cheap). It is NOT a
+# required merge check (making it one is an owner repo-Settings step — see the plan).
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "botsite/**"
+      - "tests/unit/botsite/**"
+      - ".github/workflows/botsite-ci.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "botsite/**"
+      - "tests/unit/botsite/**"
+      - ".github/workflows/botsite-ci.yml"
+
+concurrency:
+  group: botsite-ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  botsite-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            botsite/requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Bot reqs: tests/conftest.py imports disbot (registry validation) before any
+          # bot-site test collects. Bot-site reqs: fastapi/jinja2 so the tests actually
+          # run instead of importorskip-skipping. mypy/pytest pinned to match CI.
+          pip install -r requirements.txt -r botsite/requirements.txt
+          pip install mypy==2.1.0 pytest==9.0.3 pytest-asyncio==1.4.0
+
+      - name: Type-check botsite (mypy)
+        run: mypy botsite/
+
+      - name: Run botsite tests
+        run: pytest tests/unit/botsite -v

--- a/.sessions/2026-06-19-website-identity-and-fanout-enablers.md
+++ b/.sessions/2026-06-19-website-identity-and-fanout-enablers.md
@@ -1,0 +1,55 @@
+# 2026-06-19 — Website split: owner identity vision + fan-out enablers
+
+> **Status:** `complete`
+
+## Arc
+
+Foundation S1+S2+P1 merged (#1109). Before launching the parallel back-half fan-out, the owner gave the
+binding **site identity + experience vision** and a standing **correctness/centralization mandate**. This
+PR folds the vision into the plan (so the fan-out builds to it), adds the missing bot-site CI, and captures
+the centralization design the mandate asks for. Non-overlapping with the (now-merged) foundation agent.
+
+## Shipped (this PR)
+
+- **Site identity & experience — binding brief** added to the plan (owner's words):
+  - Positioning: all-in-one — *"Add SuperBot and you can remove every other bot from your server."*
+  - Feel: fun-but-professional, simple, self-explanatory, browsable in seconds.
+  - **Interactive command reference:** every command is clickable → detail (use-cases · aliases ·
+    permissions · examples · **notes** · **status finished/in-progress** · **linked ideas**).
+  - **Discoverability:** project the repo's real commands ↔ aliases ↔ ideas ↔ status, linked by
+    cog/command, into a safe navigable shape (redaction lens still applies).
+- **Plan §5 reshaped for the vision:** new unit **S1.1** (enrich `site.json` per-command data — description/
+  use-cases, `status`, `linked_ideas`, `notes`; each from a real source, redaction-whitelisted fail-closed,
+  with the ambiguous derivations flagged as open decisions + recommendations). **P2** reshaped from a static
+  table → the **interactive command + feature browser**. Dep graph updated (`S1.1 → P2`; foundation merged).
+- **`.github/workflows/botsite-ci.yml`** (additive twin of `dashboard-ci.yml`): runs `tests/unit/botsite/`
+  + `mypy botsite/`, so the bot-site tests actually execute in CI instead of `importorskip`-skipping (the
+  gap from the fastapi-install discussion) — and the fan-out PRs get real CI.
+- **`docs/planning/web-tier-centralization-proposal-2026-06-19.md`** (the centralization mandate): designs
+  one `web-ci.yml` matrix (dashboard + botsite) to replace the two per-service files, and the PR-machinery
+  de-duplication (single source of truth for the "auto-managed PR" predicate, optional unified PR-sync
+  sweep preserving the #1106 race fix). Deliberately deferred to focused follow-up PRs — correctness-first,
+  don't churn working CI in a bundle.
+
+## Context delta
+
+- The owner's vision is **not just copy** — it extends the *data contract*: the interactive browser needs
+  enriched per-command data (status, linked ideas, notes), so S1.1 (a producer + whitelist extension) is a
+  new prerequisite for P2. Folding it in *before* the fan-out means the back-half builds the right thing.
+- Correctness/centralization mandate applied honestly: I added the **safe additive** `botsite-ci.yml` now
+  and **designed** (didn't rush) the `web-ci.yml` matrix + PR-machinery de-dup — because the things to
+  centralize are working CI/merge plumbing.
+
+## 📤 Run report
+
+- **Did:** folded the owner's binding site-identity/experience vision into the plan; reshaped §5 (added
+  S1.1 data-enrichment unit, made P2 the interactive browser); added `botsite-ci.yml`; wrote the web-tier +
+  PR-machinery centralization proposal. · **Outcome:** shipped.
+- **Run type:** `manual` (owner go-ahead + vision).
+- **⚑ Self-initiated:** `botsite-ci.yml` (closes a real CI gap the foundation missed) + the centralization
+  proposal (owner mandate) — both flagged for review.
+- **⚑ Owner decisions surfaced (S1.1):** `status` derivation source · idea→command linking method ·
+  per-command notes source — each with a recommended default; the build run defaults them unless owner says.
+- **↪ Next:** (1) a focused PR 2 — control-panel architecture lock (router Q-0179 + plan §7.4) + the rollout
+  & control-API-security-review ops checklists; (2) then **launch the fan-out** — S1.1 → P2 (interactive
+  browser) ∥ P3–P8 — once this enabler PR is merged.

--- a/docs/planning/web-tier-centralization-proposal-2026-06-19.md
+++ b/docs/planning/web-tier-centralization-proposal-2026-06-19.md
@@ -1,0 +1,83 @@
+# Web-tier + PR-machinery centralization — proposal (2026-06-19)
+
+> **Status:** `plan` — a proposal, owner-directed by the "if multiple things take care of two sides of one
+> problem, find a better centralized way — correctness first" mandate (2026-06-19). Nothing here is
+> implemented yet; each item says *why it's deferred to a focused PR* rather than rushed into a bundle,
+> because the things being centralized are **working CI/merge plumbing** and correctness comes first.
+
+## 1. Web CI: `dashboard-ci.yml` + `botsite-ci.yml` → one `web-ci.yml` matrix
+
+**The two sides.** Two near-identical workflows test the two web services: `dashboard-ci.yml` (installs
+`requirements.txt` + `dashboard/requirements.txt`, runs `mypy dashboard/` + `pytest tests/unit/dashboard`)
+and `botsite-ci.yml` (the same for `botsite/`). They exist because the main `code-quality.yml` installs only
+the bot's `requirements.txt`, so each web service's tests `importorskip` and skip, and neither is
+type-checked. They are genuine twins — the textbook "two sides of one problem (test the web tier)."
+
+**The centralized form.** One `web-ci.yml` with a **matrix over the services**:
+
+```yaml
+strategy:
+  matrix:
+    service:
+      - { name: dashboard, reqs: dashboard/requirements.txt, tests: tests/unit/dashboard }
+      - { name: botsite,   reqs: botsite/requirements.txt,   tests: tests/unit/botsite }
+# install: requirements.txt + ${{ matrix.service.reqs }}
+# mypy ${{ matrix.service.name }}/  ·  pytest ${{ matrix.service.tests }}
+```
+
+`paths:` becomes the union (`dashboard/**`, `botsite/**`, both test dirs, the workflow file). One file, one
+place to add the next web service (a third matrix row), no copy-paste drift.
+
+**Why deferred (not done in the foundation-follow-through PR).** Replacing `dashboard-ci.yml` — a *working*
+required-ish check — is higher blast-radius than *adding* `botsite-ci.yml`. Correctness-first says: ship the
+additive `botsite-ci.yml` now (gets the bot site tested immediately, unblocks the fan-out's CI), and do the
+matrix unification as its **own focused PR** where both matrix legs are verified green before the two
+per-service files are deleted. **Acceptance for that PR:** both `dashboard` and `botsite` matrix jobs run +
+pass on a PR touching each service; then delete `dashboard-ci.yml` + `botsite-ci.yml`.
+
+## 2. PR-sync machinery: `pr-auto-update.yml` + `pr-conflict-guard.yml`
+
+**The two sides.** Both react to *"`main` moved → an open PR is now out of sync"* (both trigger on
+`push: main` and enumerate open PRs): `pr-auto-update` updates **BEHIND** `claude/*` PRs; `pr-conflict-guard`
+posts a red status on **DIRTY** ones. The states are mutually exclusive per PR, so conceptually it's one
+sweep split in two.
+
+**Honest assessment.** They are *defensibly* separate: different actions (mutate the branch vs post a commit
+status), different tokens/permissions (`pr-auto-update` needs `contents:write` + `ROUTINE_PAT` to attribute
+the merge to a user so `reconciliation-trigger` keeps firing; `pr-conflict-guard` needs `statuses:write` +
+`GITHUB_TOKEN`, because `ROUTINE_PAT` lacks status-write — the #966 lesson). Merging them into one job is
+possible (a job can hold both permissions and pick the right token per step) but adds complexity. So the
+*biggest, lowest-risk* centralization is **not** merging the workflows — it's the duplication *inside* them:
+
+- **The eligibility/carve-out predicate is duplicated.** "Is this PR auto-managed?" = `claude/*` head **and
+  not** labelled `needs-hermes-review` / `do-not-automerge`. That rule is written out in **both**
+  `pr-auto-update.yml` and `auto-merge-enabler.yml` (and implied in the conflict guard). If a carve-out label
+  changes, three files must change in lockstep. **Recommendation (do first, low-risk):** extract it to one
+  source of truth — a tiny `scripts/pr_auto_managed.py` (or a documented shared `jq` filter snippet) that all
+  three workflows call. One place defines "auto-managed."
+- **Optional follow-up (medium-risk):** a single `push: main` **"PR-sync keeper"** that, per open PR, does
+  *update-if-BEHIND / red-if-DIRTY / clear-else* in one enumeration. If pursued, it **must preserve the
+  #1106 fix** (poll through GitHub's async-`UNKNOWN` mergeability window before deciding) — that bug is
+  exactly the kind a careless merge would reintroduce.
+
+## 3. The broader pattern (note, don't force)
+
+Several workflows touch "PR lifecycle / mergeability" — `auto-merge-enabler`, `pr-auto-update`,
+`pr-conflict-guard`, and the `code-quality` born-red session-gate. It's tempting to consolidate them, but
+each is currently single-purpose and working. **Centralize where there is genuine duplication (the
+eligibility predicate, the open-PR enumeration) — not for its own sake.** The correctness-first rule is:
+a unified workflow must be *demonstrably* equivalent (same triggers, tokens, carve-outs, and the #1106
+race fix) before it replaces working plumbing.
+
+## Recommended order
+
+1. **Now (shipped alongside this doc):** additive `botsite-ci.yml` — bot-site tests + `mypy botsite/` run.
+2. **Focused PR A:** extract the auto-managed-PR predicate to one source of truth (#2 first bullet).
+3. **Focused PR B:** `web-ci.yml` matrix replacing the two per-service CI files (#1), both legs verified.
+4. **Optional PR C:** the unified PR-sync keeper (#2 second bullet), preserving the #1106 race fix.
+
+## Builds on / references
+
+`.github/workflows/{dashboard-ci,botsite-ci,pr-auto-update,pr-conflict-guard,auto-merge-enabler}.yml` ·
+the #1106 conflict-guard `UNKNOWN`-race fix · `docs/planning/website-two-site-split-plan-2026-06-19.md` (the
+split this web-tier work serves).

--- a/docs/planning/website-two-site-split-plan-2026-06-19.md
+++ b/docs/planning/website-two-site-split-plan-2026-06-19.md
@@ -107,6 +107,37 @@ not *whether a change is user-relevant* — every `.sessions/` log is dev/repo c
 
 ---
 
+## Site identity & experience — the owner's vision (2026-06-19, binding brief)
+
+> Owner-directed; this is the **binding product brief** for the bot site's pages — the fan-out (S1.1, P2,
+> P3, …) builds to it. The tone/branding *wording* is the owner's to refine; the **positioning + behaviour
+> below are the build spec.**
+
+**Positioning — all-in-one, stated boldly.** SuperBot's pitch is that it *replaces the stack*: the goal is
+that **every function any Discord bot offers is present here, and better.** The hero one-liner is the
+owner's: **"Add SuperBot and you can remove every other bot from your server."**
+
+**Feel.** Fun **but** professional. Simple, self-explanatory, **easily browsable** — a visitor finds what
+they need in seconds, never hunts. Clear explanations over cleverness.
+
+**Interactive command reference (the core UX ask).** Every command on `/commands` (and surfaced through
+`/features`) is **clickable → a detail view**, not a static table row. The detail shows:
+- what it does + **use-cases**, its **aliases**, cooldown, required **permissions**, examples;
+- **notes/comments** left on it (ours or the community's);
+- a **status badge — `finished` vs `in-progress`** — so users instantly see how mature a feature is;
+- **linked ideas/plans** for that command/cog — so "what's coming" is discoverable right where the command
+  lives.
+
+**Discoverability through the repo's own data.** Same source-of-truth principle the whole split rests on:
+the site doesn't invent a parallel catalogue — it **projects the repo's real commands ↔ aliases ↔ ideas ↔
+status, linked by cog/command**, into a safe, user-facing, *navigable* shape. An idea that matches a
+subsystem surfaces on that subsystem's commands; an open idea/bug on a command flips its status to
+`in-progress`. Users browse the bot the way we see it — minus anything dev-internal or unsafe (the
+redaction lens still applies, §4; the data-contract extension that feeds this is unit **S1.1** in §5).
+
+**Proof, honestly.** Lead with real breadth — the honest catalogue counts (N commands · M features ·
+K games), never fabricated server/user totals (§3).
+
 ## 2. Architecture  *(deliverable 2)*
 
 ### 2.1 Topology — 2 Railway services (Q-0178)
@@ -390,7 +421,12 @@ against a **test DB** (S2's schema on a throwaway/test Postgres or SQLite) and a
 exactly the `importorskip`/mock pattern the existing `dashboard/` suite uses. No unit needs the real
 Railway service, the real Postgres, or any token; the owner provisions those at **rollout** (§6).
 
-### Serial foundation (must land first, in order — everything downstream depends on it)
+> **▶ Status (2026-06-19): the serial foundation S1 + S2 + P1 is MERGED (#1109).** The remaining work is
+> the back half — now **reshaped by the Site identity & experience brief above**: a new unit **S1.1**
+> enriches the per-command data the interactive browser needs, and **P2** becomes that browser (not a
+> static table). The rest (P3–P8) is unchanged. New dependency: **S1.1 → P2**.
+
+### Serial foundation (✅ MERGED #1109) — original spec retained for reference
 
 - **S1 — the data producer, end to end (sole owner of `export_dashboard_data.py`).**
   Files: `scripts/export_dashboard_data.py` (the `site.json` subset emitter + `--targets` **+ the
@@ -422,9 +458,29 @@ Railway service, the real Postgres, or any token; the owner provisions those at 
 
 ### Parallel back half (truly file-disjoint — fan out once S1 + S2 + P1 land)
 
-- **P2 — reference-page templates.** Exclusive: `botsite/templates/commands.html`,
-  `botsite/templates/features.html`. Read-only command reference + feature showcase from `site.json`,
-  rendered by P1's already-wired routes. Templates only — no `app.py`.
+- **S1.1 — enrich the public command data (extends the merged S1 producer + whitelist; P2 depends on it).**
+  Exclusive: `scripts/export_dashboard_data.py` (the `build_site_subset` command projection),
+  `scripts/check_dashboard_data.py` (extend `check_site_subset`'s per-command whitelist — still
+  **fail-closed**), `botsite/data/site.json` (regenerate), `tests/unit/scripts/` (extend). Adds, **per
+  command, only safe/curated fields** — never fabricated, redaction lens still applies:
+  - `description` / `use_cases` / `examples` — from the help catalogue + command docstrings (already
+    scanned); emit `null`, not invented prose, where absent.
+  - `status` — **`finished` | `in-progress`**, an honest maturity signal. *Recommended derivation:* a
+    command is `in-progress` if its cog/subsystem has a **linked open idea or open bug**, else `finished`;
+    a curated override can come later. *(Source = open decision — recommend this; flag for owner.)*
+  - `linked_ideas` — ideas mapped to the command's **cog/subsystem** (the subsystem registry already maps
+    cog→subsystem), surfaced as user-facing "what's planned" teasers — **title + status only, never raw
+    internal idea text** (redaction). *(Linking method = open decision — recommend explicit subsystem tag,
+    heuristic name-match as fallback.)*
+  - `notes` — curated per-command notes (ours/community). *(Source = open decision — recommend v1 reuse the
+    help-overlay re-describe text; a dedicated community-notes source is a fast-follow, not invented.)*
+- **P2 — interactive command + feature browser (the owner-vision core; depends on S1.1).** Exclusive:
+  `botsite/templates/commands.html`, `botsite/templates/features.html`, `botsite/templates/_command_detail.html`
+  (the detail partial). Renders the **enriched** `site.json` as **clickable command cards → a detail view**
+  (use-cases · aliases · permissions · examples · **notes** · **status badge** · **linked ideas**), with
+  fast client-side search/filter so nothing takes long to find; progressive-enhancement JS inline (honor
+  the no-`static/` gotcha). `/features` groups the same data by category — the all-in-one showcase. Reads
+  `site.json`; rendered by P1's already-wired routes; **no `app.py` edit.**
 - **P3 — changelog + status templates.** Exclusive: `botsite/templates/changelog.html`,
   `botsite/templates/status.html` + the "generated vs live" freshness badges. Reads `site.json.bot_changelog`
   + `meta.build` (both produced by S1). Templates only — no `app.py`, no producer edit.
@@ -446,10 +502,11 @@ Railway service, the real Postgres, or any token; the owner provisions those at 
   the submissions DSN, optional captcha keys), `dashboard/README.md` (moderation note). *(P1 owns
   `botsite/README.md`; P8 does not touch it.)*
 
-**Dependency graph:** serial `S1 → {S2, P1}` (S2 and P1 are file-disjoint, so they run together after S1);
-then the parallel back half `{P2, P3, P4, P5, P6, P7, P8}`. Edges within it: P4 fills P1's `submit.py` stub
-and uses S2's INSERT helper (so P4 lands after P1+S2); P5 uses S2's read helper + P6 (P6 is stub-buildable
-in isolation first). No two back-half units share a file.
+**Dependency graph (updated 2026-06-19):** the foundation `S1 → {S2, P1}` is **merged (#1109)**. Remaining:
+`S1.1 → P2` (the browser needs the enriched data) runs as its own short serial pair; `{P3, P4, P6, P7, P8}`
+fan out fully in parallel alongside it; P4 fills P1's `submit.py` stub + uses S2's INSERT helper, P5 uses
+S2's read helper + P6 (P6 stub-buildable first). S1.1 is the only producer-touching unit, so it never
+collides with the template/module units. No two concurrently-running units share a file.
 
 ---
 
@@ -581,6 +638,8 @@ architecture sections deliberately left open; the build run may refine them.
 - [`dashboard-live-editor-plan.md`](dashboard-live-editor-plan.md) — owner-auth + control-API write design.
 - [`dashboard-vision-finalized-state.md`](dashboard-vision-finalized-state.md) — the four-zone north star
   this split realises (Public → bot site; Personal/Server/Owner → dev site).
+- [`web-tier-centralization-proposal-2026-06-19.md`](web-tier-centralization-proposal-2026-06-19.md) — the
+  `web-ci.yml` matrix (dashboard + botsite) + PR-machinery de-duplication (owner centralization mandate).
 - `dashboard/` (the decoupled service), `scripts/export_dashboard_data.py` (the single data producer),
   `disbot/control_api.py` (the private, owner-paced live source), `.github/ISSUE_TEMPLATE/` (the mirror
   shapes, #1064), `docs/operations/env-vars.md` (the env-name surface).


### PR DESCRIPTION
## What

Foundation `S1+S2+P1` merged (#1109). Before launching the parallel back-half fan-out, this lands the things that *shape* it correctly + the missing bot-site CI.

### 1. Owner's site identity & experience — folded into the plan as a binding brief
- **Positioning:** all-in-one — *"Add SuperBot and you can remove every other bot from your server."*
- **Feel:** fun-but-professional, simple, self-explanatory, browsable in seconds.
- **Core UX ask:** every command is **clickable → a detail view** (use-cases · aliases · permissions · examples · **notes** · **status: finished/in-progress** · **linked ideas**).
- **Discoverability:** project the repo's real commands ↔ aliases ↔ ideas ↔ status, linked by cog/command, into a safe navigable shape (redaction lens intact).

### 2. Plan §5 reshaped for the vision
- New unit **S1.1** — enriches `site.json` per-command data (`description`/`use_cases`, `status`, `linked_ideas`, `notes`), each from a **real source**, whitelist still **fail-closed**, with the ambiguous derivations (status source · idea→command linking · notes source) flagged as open decisions + recommendations.
- **P2** reshaped: static table → the **interactive command + feature browser**. Dependency graph updated (`S1.1 → P2`; foundation merged).

### 3. `botsite-ci.yml` (additive)
Twin of `dashboard-ci.yml` — runs `tests/unit/botsite/` + `mypy botsite/`, so the bot-site tests actually execute in CI (instead of `importorskip`-skipping — the gap from the fastapi-install discussion) and the fan-out PRs get real CI.

### 4. Centralization proposal (owner mandate)
`docs/planning/web-tier-centralization-proposal-2026-06-19.md` — designs one `web-ci.yml` **matrix** (dashboard + botsite) to replace the two per-service files, and the PR-machinery de-duplication (one source of truth for the "auto-managed PR" predicate; optional unified PR-sync sweep preserving the #1106 race fix). **Deferred to focused PRs — correctness first**, don't churn working CI in a bundle.

Docs + one additive workflow; no runtime change. `check_docs --strict` green; `botsite-ci` validates on this PR. Session card `complete`.

**Next:** a focused PR 2 (control-panel architecture lock + rollout/security-review checklists), then **launch the fan-out** (S1.1 → P2 ∥ P3–P8) once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txth4MHhF5Li6fQJ4koA27

---
_Generated by [Claude Code](https://claude.ai/code/session_01Txth4MHhF5Li6fQJ4koA27)_