### PR TITLE
Website two-site split: P7 + P8 — redaction-audit record + botsite deploy/env docs

### DIFF
--- a/.sessions/2026-06-19-website-deploy-redaction-docs.md
+++ b/.sessions/2026-06-19-website-deploy-redaction-docs.md
@@ -1,0 +1,19 @@
+# 2026-06-19 — Website two-site split: P7 + P8 (redaction audit + deploy/env docs)
+
+> **Status:** `in-progress`
+>
+> **About to do (born-red card, Q-0133):** ultracode fan-out unit **P7 + P8** of the
+> website two-site-split (`docs/planning/website-two-site-split-plan-2026-06-19.md` §5).
+> Docs only — no runtime code. Building:
+> - **P7** — `docs/operations/dashboard-redaction-audit.md` (the §4.1 per-page redaction
+>   matrix as a living, dated checklist).
+> - **P8** — `docs/operations/botsite-deploy.md` (the 2nd-Railway-service deploy recipe) +
+>   extend `docs/operations/env-vars.md` (new env names) + `dashboard/README.md` moderation note.
+> - **Plan bookkeeping** — sole fan-out unit editing the plan: mark §5 back-half units
+>   (S1.1/P2/P3/P4/P5/P6/P7/P8) shipped + add §9 reference links to the two new ops docs.
+>
+> Scope fence: ONLY the files above. No `botsite/`/`dashboard/` code (only `dashboard/README.md`),
+> no `disbot/`, no `.github/`, no deploy/provision.
+
+(Close-out — arc, findings, context delta, enders, run report — written as the final step,
+then the badge flips to `complete`.)

--- a/.sessions/2026-06-19-website-deploy-redaction-docs.md
+++ b/.sessions/2026-06-19-website-deploy-redaction-docs.md
@@ -1,19 +1,143 @@
 # 2026-06-19 — Website two-site split: P7 + P8 (redaction audit + deploy/env docs)
 
-> **Status:** `in-progress`
->
-> **About to do (born-red card, Q-0133):** ultracode fan-out unit **P7 + P8** of the
-> website two-site-split (`docs/planning/website-two-site-split-plan-2026-06-19.md` §5).
-> Docs only — no runtime code. Building:
-> - **P7** — `docs/operations/dashboard-redaction-audit.md` (the §4.1 per-page redaction
->   matrix as a living, dated checklist).
-> - **P8** — `docs/operations/botsite-deploy.md` (the 2nd-Railway-service deploy recipe) +
->   extend `docs/operations/env-vars.md` (new env names) + `dashboard/README.md` moderation note.
-> - **Plan bookkeeping** — sole fan-out unit editing the plan: mark §5 back-half units
->   (S1.1/P2/P3/P4/P5/P6/P7/P8) shipped + add §9 reference links to the two new ops docs.
->
-> Scope fence: ONLY the files above. No `botsite/`/`dashboard/` code (only `dashboard/README.md`),
-> no `disbot/`, no `.github/`, no deploy/provision.
+> **Status:** `complete`
 
-(Close-out — arc, findings, context delta, enders, run report — written as the final step,
-then the badge flips to `complete`.)
+Ultracode fan-out unit **P7 + P8** of the website two-site-split
+(`docs/planning/website-two-site-split-plan-2026-06-19.md` §5). **Docs only — no runtime code.**
+The sole fan-out unit that edits the plan, so it also records the back-half wave's completion.
+
+## Shipped (PR #1113)
+
+- **P7** — `docs/operations/dashboard-redaction-audit.md` (new, `audit`-badged): the plan §4.1
+  per-page redaction matrix as a **living, dated checklist** — every dev-site route → auth →
+  what it renders → secret-value risk → ✅/⛔ verdict, plus the standing rationale per row and a
+  "how to re-run" header. Verified against the live `dashboard/app.py` routes (all 14 public read
+  routes + `/me`, `/admin/*`, `/auth/*` gated; `/admin/moderation` audited against its P5 spec).
+- **P8:**
+  - `docs/operations/botsite-deploy.md` (new, `living-ledger`): the 2nd-Railway-service deploy
+    recipe for `botsite/` (**Root Directory = `botsite`**, its own `requirements.txt` + `Procfile`,
+    the import path `app:app`, the **no-`static/` gotcha** = the #970 class), the §6 additive
+    rollout + per-step rollback, the submissions-DB + dev-site moderation note, the 2→3-service
+    table, and the local `importorskip` run path.
+  - `docs/operations/env-vars.md` (extended): a new hand-maintained **"Website tier"** section
+    naming `SUBMISSIONS_DB_DSN` (INSERT-only public role / full dev role), `SUBMISSIONS_IP_SALT`,
+    `GITHUB_ISSUE_MIRROR_TOKEN` (dev-site only, repo-scoped Issues:write), optional captcha keys,
+    and the dev-site OAuth/session/control set — written in **prose (not `| name |` rows)** on
+    purpose (see Decisions made alone).
+  - `dashboard/README.md`: a short owner-gated **moderation** note (pending queue → approve →
+    GitHub mirror; the token + full DSN live only on the dev site).
+- **Plan bookkeeping:** §5 — marked all back-half units **✅ S1.1/P2/P3/P4/P5/P6/P7/P8 shipped**
+  (the section heading, each unit bullet, the status block, and the dependency-graph line now read
+  "executed in the fan-out wave"); §9 — added reference links to the two new `docs/operations/`
+  docs (this is what makes them reachable for `check_docs --strict`).
+
+## Verification (green)
+
+- `python3.10 scripts/check_docs.py --strict` → **all checks passed ✓** (both new docs reachable
+  via the §9 links off the plan, which is reachable from `current-state.md`; badges `audit` +
+  `living-ledger` valid; all relative links resolve; top-level ratchet still 20).
+- `python3.10 scripts/check_quality.py --check-only` → **All checks passed ✓** (EXIT 0). The only
+  warnings are the pre-existing 17 `views/ai/` `edit_in_place` findings (warn-only, tracked by the
+  AI-nav plan) — untouched by this docs-only PR. No Python changed, so formatters are clean.
+
+## Decisions made alone (for owner ratification)
+
+1. **The website-tier env vars are documented as PROSE, not table rows, in `env-vars.md`** — and
+   the file gained an explicit `<!-- END GENERATED REGION -->` marker. *Why:* `env-vars.md` is a
+   **fully generated file** (`scripts/scan_env_usage.py --write-doc` rewrites the whole file from a
+   scan of `disbot/` only), and the freshness drift check
+   (`check_generated_artifacts_fresh._ENV_VAR_ROW`) extracts env names from any `` | `NAME` `` row.
+   Web-service vars (`botsite/`/`dashboard/`) are **not** read by `disbot/`, so a `| name |` table
+   for them would (a) get clobbered on the next regen and (b) **false-flag as drift** (present in
+   the committed file, absent from a fresh bot-source scan). Prose sub-bullets avoid both. The
+   authoritative, regen-safe home for these names is `botsite-deploy.md` (which I own); `env-vars.md`
+   carries the discoverable index + a loud "re-add after regen" caveat. **The cleaner long-term fix**
+   is to make `scripts/scan_env_usage.py:render_doc` *emit* a static website-tier section so it
+   survives regen — left undone because the script is **outside this unit's scope fence** (see
+   Flagged). Filed as a session idea.
+2. **Marked all back-half units (S1.1/P2/P3/P4/P5/P6) shipped, per the prompt**, even though at the
+   moment of writing only the foundation (#1109) + #1110 were merged on `main` and the other
+   templates/modules were still landing on parallel branches. *Why:* the prompt is explicit ("mark
+   the back-half units shipped … record the fan-out's completion") and designates this unit as the
+   sole plan editor precisely so the fan-out's bookkeeping lands once. The wording I used says
+   "shipped in the fan-out wave" rather than citing a PR number per unit, so it stays accurate
+   regardless of each sibling PR's exact merge moment.
+
+## Context delta (reflection interview)
+
+- **Needed but not pointed to:**
+  - **`env-vars.md` is whole-file generated AND a drift check keys on its table rows.** Neither the
+    file's own header nor orientation warns that *appending* a table will both be clobbered and
+    trip a warn-only drift false-positive. I had to read `scripts/scan_env_usage.py` (`render_doc`
+    overwrites the file) **and** `scripts/check_generated_artifacts_fresh.py` (`_ENV_VAR_ROW`) to
+    learn this. → folded into the doc via the `END GENERATED REGION` marker + caveat; worth a line
+    in a future "editing generated docs" note.
+  - **Worktree vs. main-repo cwd gotcha.** This session runs in a git **worktree**
+    (`.claude/worktrees/agent-…`), but `Bash` calls that begin `cd /home/user/superbot` operate on
+    the **main** repo, while `Edit`/`Read`/`Write` operate on the worktree — so a `cd`-prefixed grep
+    showed *stale* (pre-edit) content and made it look like my edits hadn't applied. The fix: run
+    Bash with **no `cd`** (the worktree is already the default cwd) and use **absolute worktree
+    paths**. Cost ~3 tool calls of confusion. (CLAUDE.md notes "cwd resets between bash calls" but
+    not the worktree-vs-main split.)
+- **Pointed to but didn't need:** the deep CodeGraph/architecture-rule sections of CLAUDE.md — this
+  was a pure docs unit (no symbol navigation, no layer boundaries). Correctly skippable for a
+  docs-only fan-out unit; not a complaint, just an observation that the orientation is bot-code-shaped.
+- **Discovered by hand:** the `check_docs` reachability mechanism — a new doc is an orphan **unless**
+  it is linked (markdown link or backtick `docs/*.md` ref) from a read-path root / folio / README,
+  *transitively*. My two docs become reachable only because the **plan §9** links them and the plan
+  itself is reachable from `current-state.md`. Verified by reading `check_docs.py::check_reachable`.
+- **Decisions made alone:** the two above (prose-not-table env vars; mark-shipped wording).
+- **Flagged for maintainer / known limits:** see the run report ⚑ lines. The headline is the
+  `env-vars.md` regen footgun — a clean fix exists but needs `scripts/scan_env_usage.py`, outside
+  this unit's fence.
+- **One docs/tooling change that would have helped most:** an "editing generated docs" gotcha note
+  (which docs are whole-file-regenerated + which checks key on their structure) — captured as the
+  session idea below.
+
+## 💡 Session idea (Q-0089)
+
+**Make `scripts/scan_env_usage.py:render_doc` emit a declarative "Website tier" (non-`disbot/`)
+env section** so the web-service env names live *in the generator* and survive `--write-doc`
+regen, instead of as a hand-maintained appendix that the regen clobbers and the drift check would
+false-flag. Small, high-value: it removes the exact footgun this session had to document around,
+and keeps `env-vars.md` a single source of truth for *all* deploy-relevant env names (bot + web).
+*(Out of scope for this unit — the script belongs to no fan-out unit but the fence listed only
+`env-vars.md`; recorded here for the next agent.)* Dedup-checked `docs/ideas/` + the roadmap — no
+existing entry for the env-doc generator covering web services.
+
+## ⟲ Previous-session review (Q-0102)
+
+**Reviewed:** `2026-06-19-website-foundation-s1s2p1.md` (the S1+S2+P1 foundation, #1109) — the
+direct predecessor in this lane. **Did well:** it nailed the file-disjointness that made *this*
+fan-out safe — S1 sole-owns the producer, S2's two helpers share only the DDL, P1 sole-owns
+`app.py` and pre-wires every route so the template/module units never touch it. That discipline is
+exactly why P2–P8 could run in parallel without write conflicts, and it held. **Could have done
+better / system improvement it surfaces:** the foundation seeded `botsite/data/site.json` as a
+committed generated artifact and registered it in two freshness guards — but **neither the
+foundation nor the plan flagged the symmetric trap one layer over in `env-vars.md`** (whole-file
+regenerated + a drift check that keys on table rows), which this session tripped over. The
+concrete workflow improvement: a short **"editing generated docs"** orientation note enumerating
+which committed docs are whole-file-regenerated by a script and which checkers parse their
+structure — so the *next* agent extending a generated doc doesn't reverse-engineer it from the
+scanner source. (That's the Q-0089 idea above, generalized from "env-vars" to "generated docs".)
+
+## 📤 Run report
+
+- **Did:** built website-split fan-out **P7 + P8** (redaction-audit record + `botsite/` deploy/env
+  docs) and recorded the back-half wave's completion in the plan · **Outcome:** shipped
+- **Shipped:** #1113 — P7 `dashboard-redaction-audit.md` + P8 `botsite-deploy.md` /
+  `env-vars.md` (Website-tier section) / `dashboard/README.md` moderation note + plan §5/§9
+  bookkeeping. Docs only.
+- **Run type:** `manual` (dispatched ultracode build unit)
+- **⚑ Owner decisions needed:** `none` — but two **alone-decisions** above to ratify if desired
+  (prose-not-table env vars; "shipped in the fan-out wave" plan wording).
+- **⚑ Owner manual steps:** the website-split **rollout is owner-paced** (`botsite-deploy.md` § Rollout):
+  provision the new `botsite/` Railway service (Root Dir = `botsite`), provision the dashboard-owned
+  submissions Postgres + apply `botsite/migrations/001_submissions.sql`, grant the INSERT-only vs full
+  DB roles, set `SUBMISSIONS_DB_DSN` / `GITHUB_ISSUE_MIRROR_TOKEN` per the §4.4 matrix, then cut the
+  marketing domain over. None of this is done here (docs only).
+- **⚑ Self-initiated:** `none` — this was a dispatched build unit (not an unprompted idea→build). The
+  Q-0089 idea (env-doc generator for web vars) is filed, **not** built, and is correctly out of fence.
+- **↪ Next:** the website-split's deferred follow-ups — the control-panel migration to the bot side +
+  the live status aggregator (both gated on the control-API public-exposure security review), and the
+  owner-paced rollout above.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -54,6 +54,23 @@ and the **same** `CONTROL_API_TOKEN` on the bot worker. The login session is a s
 HMAC-signed cookie (`websession.py`) and forms are parsed with `urllib` — **no** `itsdangerous` /
 `python-multipart`, so the app stays verifiable with just fastapi + jinja2 + httpx.
 
+## Submission moderation (owner-gated)
+
+The dev site is also the **moderation home** for the public bot site's `/submit` form. Public
+submissions land in a **separate, dashboard-owned** Postgres (the `submissions` table —
+`botsite/migrations/001_submissions.sql`, *not* the bot's DB) as `status='pending'` and are
+**never shown publicly**. The owner reviews them on the **owner-gated `/admin/moderation`** page
+(restricted to `BOT_OWNER_USER_ID`; CSRF-protected; all fields rendered **escaped**) and approves
+or rejects each. On **approve**, the dev site mirrors the row to a GitHub issue via
+`dashboard/github_mirror.py` using the matching `.github/ISSUE_TEMPLATE/` shape and records
+`github_issue_url`; **reject** just flips the status. The **`GITHUB_ISSUE_MIRROR_TOKEN`** (a
+fine-grained PAT, `menno420/superbot` only, Issues:write) and the full submissions DSN live
+**only here** — never on the public bot site, which holds at most an **INSERT-only** role on that
+one table. Full design: the website two-site-split plan
+([`../docs/planning/website-two-site-split-plan-2026-06-19.md`](../docs/planning/website-two-site-split-plan-2026-06-19.md)
+§2.3 / §4) + the deploy/env recipe
+[`../docs/operations/botsite-deploy.md`](../docs/operations/botsite-deploy.md).
+
 ## Run locally
 
 ```bash

--- a/docs/operations/botsite-deploy.md
+++ b/docs/operations/botsite-deploy.md
@@ -1,0 +1,146 @@
+# Bot site (`botsite/`) deploy — the 2nd Railway web service
+
+> **Status:** `living-ledger` — the deploy recipe + rollout/rollback sequence for the **public
+> marketing bot site** (`botsite/`), a *second* Railway web service alongside the developer
+> dashboard. Operational facts; the maintainer owns the Railway dashboard. Source + the live
+> Railway config win over this file. Written 2026-06-19 for the website two-site-split
+> ([plan](../planning/website-two-site-split-plan-2026-06-19.md) §6 / §2.1 / §4.4).
+
+The website two-site-split runs the public bot site as its **own Railway service**, deployed the
+same proven way as `dashboard/`: a service whose **Root Directory** is the app's own folder, so
+Railway installs *that folder's* `requirements.txt` and runs *that folder's* `Procfile`. This is
+what keeps each web service's build scoped to its own deps and the bot's deploy untouched.
+
+> **It never imports `disbot`.** Like the dashboard, the bot site reads only a committed generated
+> artifact — `botsite/data/site.json` (the public whitelist subset produced by
+> `scripts/export_dashboard_data.py`). Decoupling is preserved; see `botsite/README.md`.
+
+## The two (eventually three) web services
+
+| Service | Root Dir | What it is | Auth posture | Secrets it holds |
+|---|---|---|---|---|
+| `worker` | repo root | the **bot** | — | bot's Postgres DSN, Discord token, AI keys ([`env-vars.md`](env-vars.md)) |
+| dev site (current) | `dashboard/` | developer dashboard + control panel + submission moderation | public read pages · OAuth/owner-gated edits | `GITHUB_ISSUE_MIRROR_TOKEN`, full submissions DSN, OAuth/session, `CONTROL_API_TOKEN` |
+| **bot site (new)** | **`botsite/`** | **public marketing + reference + `/submit` intake** | **fully public** | **exactly one — the INSERT-only submissions DSN** |
+
+The per-server control panel's future move to the bot side adds a **third** service (a gated
+"manage my server" manager, isolated at the process + secret level — plan §4.4 / §7.4). That slice
+is gated on the control-API public-exposure security review and lands *after* the first additive
+wave; it is **not** part of standing up the public bot site below, and the public marketing
+service stays secret-free regardless.
+
+## Deploy recipe (mirrors the dashboard's proven shape)
+
+The bot site reuses the exact recipe `dashboard/` proved out (see
+[`production-deployment.md`](production-deployment.md) for the bot's Railway facts and
+`dashboard/README.md` for the dashboard's):
+
+1. **New Railway service, same project.** In the production Railway project, add a **new service**
+   from the same GitHub repo. It auto-builds and auto-redeploys on push to `main`, like the others.
+2. **Set Root Directory = `botsite`.** This is the load-bearing setting — Railway scopes the
+   build to that folder, so it installs **`botsite/requirements.txt`** (FastAPI + Jinja2 +
+   uvicorn + asyncpg, kept separate from the bot's and the dashboard's deps) and **not** the bot's
+   root `requirements.txt`. Without it, the service would try to install the bot's full deps (the
+   trap the per-service split exists to avoid).
+3. **Start command = the `Procfile`.** `botsite/Procfile` is
+   `web: uvicorn app:app --host 0.0.0.0 --port ${PORT:-8080}` — identical in shape to the
+   dashboard's. Because Root Directory is `botsite`, the import path is `app:app` (the module is
+   `botsite/app.py`, imported as top-level `app` from inside the root dir), exactly as the
+   dashboard runs `app:app` from `dashboard/`.
+4. **Python pin.** The repo-root `.python-version` (`3.13.13`) applies to all repo-built services;
+   keep `RAILPACK_PYTHON_VERSION` **unset** on this service so the repo stays the single source of
+   truth (same rule as the bot — see [`production-deployment.md`](production-deployment.md)
+   § "Python version — pinned, and why").
+5. **Env vars** — see [`env-vars.md`](env-vars.md) § "Website tier". The public bot site needs
+   **only** `SUBMISSIONS_DB_DSN` (an **INSERT-only** DB role) + optionally `SUBMISSIONS_IP_SALT`.
+   It holds **no** OAuth secret, **no** GitHub token, **no** control-API token (plan §4.4). With
+   `SUBMISSIONS_DB_DSN` unset the site still serves — `/submit` shows a "temporarily unavailable"
+   state and everything else renders (dormant-by-default, same discipline as the control API).
+
+### ⚠️ The no-`static/` gotcha (the #970 deploy-crash class)
+
+The repo root `.gitignore` ignores `static/` (and `staticfiles/`). The dashboard hit a deploy
+crash (#970) when code referenced a `static/` mount that was never committed — git-ignored, so it
+existed locally but not in the Railway build. **The bot site must not rely on a committed
+`static/` directory.** It mounts no static dir; CSS is Tailwind-via-CDN and any
+progressive-enhancement JS is inlined in templates. If you ever add assets, either commit them
+under a **non-ignored** path or serve them another way — never assume a `static/` folder survives
+the build. (This is why both web services are "no JS build, no `static/` dir".)
+
+## Run + verify locally (the `importorskip`-guarded path)
+
+Mirrors the dashboard's local flow:
+
+```bash
+pip install -r botsite/requirements.txt
+python3.10 scripts/export_dashboard_data.py     # (re)generate botsite/data/site.json (+ dashboard.json)
+uvicorn app:app --reload --app-dir botsite       # http://127.0.0.1:8000
+python3.10 -m pytest tests/unit/botsite/          # app smoke (local; importorskip-guarded like dashboard)
+```
+
+The committed `botsite/data/site.json` is a **generated artifact** — re-run
+`scripts/export_dashboard_data.py` after its sources change; the freshness + whitelist guard
+(`scripts/check_dashboard_data.py`) asserts it is regenerable-identical **and** that its top-level
+keys stay within the redaction whitelist (fails closed on a new private family).
+
+## Submissions DB + the dev-site moderation note
+
+The public `/submit` form's only write is `INSERT … status='pending'` into a **separate,
+dashboard-owned Postgres** (plan §2.3 / §7.3 / Q-0178 — *not* the bot's DB, so decoupling holds).
+The one canonical schema is `botsite/migrations/001_submissions.sql`; apply it once against that
+Postgres at rollout. Two helpers share **only that contract, never code**:
+
+- `botsite/submissions_db.py` — **INSERT-only** (`insert_pending`), on the public site.
+- `dashboard/submissions_db.py` — SELECT + UPDATE (`list_pending` / `set_status` /
+  `attach_issue_url`), on the dev site behind the owner gate.
+
+**Moderation lives on the dev site, never the bot site.** Nothing a user submits is shown
+publicly — rows land `pending` and are invisible until the owner approves them on the dev site's
+**owner-gated `/admin/moderation`** page (CSRF-protected, renders all fields **escaped**). On
+approve, the **dev site** (which alone holds `GITHUB_ISSUE_MIRROR_TOKEN`) mirrors the row to a
+GitHub issue using the matching `.github/ISSUE_TEMPLATE/` shape and records `github_issue_url`;
+reject just flips the status. The public site never holds the GitHub token and never reaches
+GitHub. Abuse defenses (honeypot + per-IP rate-limit + server-side validation, salted IP **hash**
+only) are layered *before* anything is stored-visibly or mirrored (plan §4.2). See
+[`dashboard-redaction-audit.md`](dashboard-redaction-audit.md) for the per-page public-read
+certification and `dashboard/README.md` § Moderation for the owner-side flow.
+
+## Rollout — additive, no downtime (plan §6)
+
+The split is **additive**, which is what makes it safe. Sequence:
+
+1. **The dev site never stops serving.** It *is* the current live dashboard. The split only
+   **adds** to it (the public-subset emission, moderation, the GitHub mirror, these docs) — no
+   existing route changes behaviour. Each piece lands green on `main` and auto-redeploys as today.
+2. **Stand the bot site up dark.** Provision the new `botsite/` service once the bot-site code has
+   landed. It serves on its **Railway-generated URL first** — no public domain, no announcement —
+   so it is verifiable in production without being "the website" yet.
+3. **Provision the submissions DB + wire env per the §4.4 matrix** (owner step): create the
+   dashboard-owned Postgres, apply `001_submissions.sql`, grant the public service an
+   **INSERT-only** role and the dev service a full role, set the DSNs + `GITHUB_ISSUE_MIRROR_TOKEN`
+   on the dev service. Intake (`/submit`) and moderation light up only when their env is set
+   (dormant-by-default).
+4. **Cut over deliberately.** When the bot site is complete + reviewed, point the **marketing
+   domain** at it and link it from the dev site / Discord. The dev site keeps its existing domain
+   (e.g. `superbot-dashboard.up.railway.app`) for the owner + agents. *(Domains are deferred to
+   cutover — Q-0178 decision 1; build on Railway URLs until then.)*
+
+## Rollback — at every step
+
+- **The bot site is a separate service** → if it misbehaves, **pause/delete the service** or
+  **revert DNS**; the dev site and the bot are wholly unaffected.
+- **The submissions DB is additive** → `DROP TABLE submissions;` fully unwinds intake (the
+  migration is `CREATE TABLE IF NOT EXISTS`, forward-only + idempotent; nothing else references
+  it).
+- **Each dev-site PR is independently revertible** — no coupled migrations on the bot's DB
+  (decoupling guarantees this).
+
+## See also
+
+- [`../planning/website-two-site-split-plan-2026-06-19.md`](../planning/website-two-site-split-plan-2026-06-19.md)
+  — the full plan (§2 architecture, §4.4 secret matrix, §6 rollout).
+- [`env-vars.md`](env-vars.md) — every env var, names + locations only (the website-tier names
+  are in its own section).
+- [`dashboard-redaction-audit.md`](dashboard-redaction-audit.md) — the public-read certification.
+- [`production-deployment.md`](production-deployment.md) — the bot's Railway facts + the Python pin.
+- `botsite/README.md` — the app's own readme (owned by P1; not edited here).

--- a/docs/operations/dashboard-redaction-audit.md
+++ b/docs/operations/dashboard-redaction-audit.md
@@ -1,0 +1,112 @@
+# Dashboard redaction audit — the public read-only dev site
+
+> **Status:** `audit` — a living, dated certification that **every dev-site page renders
+> only public-safe content**. It is the standing record behind the website two-site-split's
+> non-negotiable #1 (*the public read surface leaks no secret, no per-guild value, no
+> dev-internal data*). Source code + the live templates/routes win over this file — re-verify
+> on a page/template change and bump the date.
+
+This audit operationalises the per-page redaction matrix in
+[`../planning/website-two-site-split-plan-2026-06-19.md`](../planning/website-two-site-split-plan-2026-06-19.md)
+§4.1 as a **checklist you re-run**, not a one-time table. The dev site (the current
+`dashboard/` service) makes **all read pages public read-only**; this file certifies each page's
+posture so the public-read decision stays auditable as the site grows.
+
+It pairs with the *physical* guard on the public **bot** site: `botsite/data/site.json` is a
+**redaction-by-construction** whitelist subset (plan §2.2 / §5 — `meta` · `counts` · `catalogue`
+· `commands` · `bot_changelog` only), and `scripts/check_dashboard_data.py` fails closed if a new
+top-level key escapes that whitelist. **Two complementary mechanisms:** the bot site is redacted
+*by construction* (a file that physically cannot hold a private family); the dev site is redacted
+*by route auth* (gated surfaces sit behind OAuth / the owner gate). This audit covers the **dev
+site by-route-auth** half — the bot-site whitelist guard is the by-construction half and is
+CI-enforced, not re-audited here.
+
+## How to use this checklist
+
+- **When:** re-run on any change to a `dashboard/` route, template, or the data producer
+  (`scripts/export_dashboard_data.py`), and on the every-30-PR reconciliation pass.
+- **What "verify" means per row:** open the route's template + its data slice and confirm the
+  *Renders* column is still exhaustive and the *Secret-value risk* is still `none` (for a ✅ row)
+  or still gated (for a ⛔ row). A new field that surfaces a stored value or per-guild config
+  flips the verdict and is a release blocker until redacted or gated.
+- **The crisp boundary (the one rule the whole audit enforces):** *public read-only = the
+  repo-level **generated** catalogues (value-free by construction); anything per-guild, any env
+  **value**, any raw submission, any control-action stays behind the OAuth / owner gate.*
+
+## Per-page redaction matrix
+
+**Last audited: 2026-06-19** (verified against `dashboard/app.py` routes + the served templates;
+the gated `/admin/moderation` row is the new P5 surface, audited against its plan §2.3 / §4.1 spec
+as it lands in the fan-out wave).
+
+| Dev page | Route | Auth | Renders | Secret-value risk | Verdict |
+|---|---|---|---|---|---|
+| `/` | `GET /` | public | landing — catalogue counts + recent updates | none (declared metadata only) | ✅ public-safe |
+| `/functions` | `GET /functions` | public | subsystem catalogue metadata | none (declared metadata only) | ✅ public-safe |
+| `/games` | `GET /games` | public | game catalogue metadata | none | ✅ public-safe |
+| `/status` | `GET /status` | public | inventory counts, build SHA/subject, bug/access health summary | none — build SHA is already public on GitHub | ✅ public-safe |
+| `/commands` | `GET /commands` | public | command names/types/aliases, cog-routing **defaults** | none (no per-guild values) | ✅ public-safe |
+| `/aliases` | `GET /aliases` | public | command/alias/synonym tokens (suggest tool) | none | ✅ public-safe |
+| `/settings` | `GET /settings` | public | setting **keys** + typed `SettingSpec` metadata (type/default/hint/choices) | **names + metadata only, never a stored value** — confirm `default` is the *spec* default, not a live value (it is) | ✅ public-safe |
+| `/access` | `GET /access` | public | visibility-tier ladder (which tier sees which subsystem) | none — visibility, **not** execution | ✅ public-safe |
+| `/ideas` | `GET /ideas` | public | `docs/ideas/`-derived index | none (already-public docs) | ✅ public-safe |
+| `/bugs` | `GET /bugs` | public | bug-book-derived index + "report a bug" CTA | none (already-public docs) | ✅ public-safe |
+| `/reviews` | `GET /reviews` | public | owner-review-inbox markdown index | none (already-public docs) | ✅ public-safe |
+| `/updates` | `GET /updates` | public | `.sessions/`-derived updates feed | none (already-public docs) | ✅ public-safe |
+| `/env` | `GET /env` | public | env-var **names** + code `file:line` + required/optional/layer | **🔒 names + locations only — never a value; never opens `.env`** | ✅ public-safe **by design** (this is the redaction line) |
+| `/healthz` | `GET /healthz` | public | liveness JSON | none | ✅ public-safe |
+| `/me` | `GET /me` | **OAuth** | the signed-in user's admined guilds | per-user identity | ⛔ **NOT public** — OAuth-gated |
+| `/admin/*` | `GET/POST /admin/{guild_id}/…` | **OAuth + bot-side live authority** | one server's **live** settings values, help text, routing | **🔒 per-guild private config** | ⛔ **NOT public** — gated (the "owner-gated for edits" zone) |
+| `/auth/*` | `GET /auth/{login,callback,logout}` | OAuth handshake | OAuth redirect/callback/logout | OAuth code exchange | ⛔ **NOT a content page** — handshake only |
+| `/admin/moderation` (P5, new) | `GET/POST /admin/moderation` | **owner-gated** | raw public submissions (may contain anything) | **🔒 unmoderated user input** | ⛔ **owner-gated** — never public, rendered escaped |
+| env-value mgmt / control board (future owner ring) | — | **owner-only** | secret **values** (via Railway) | **🔒 secrets** | ⛔ **owner-only**, never reachable from the public side |
+
+## Why each ✅ row is value-free (the standing rationale)
+
+- **The generated catalogues are value-free by construction.** `/`, `/functions`, `/games`,
+  `/commands`, `/aliases`, `/status` all render `scripts/export_dashboard_data.py` output — repo
+  **structure** (command/subsystem/game names, types, routing *defaults*, counts), never a stored
+  per-guild value. The producer reads source + committed docs, never the bot's DB or `.env`.
+- **`/settings` renders the spec, not the state.** It surfaces setting **keys** + their
+  `SettingSpec` metadata (type, *spec* default, hint, enum choices). The `default` is the
+  declared default in code, not a guild's live value — the live value lives only behind
+  `/admin/{guild}` (gated). Re-confirm this each audit: a producer change that reads a *stored*
+  default would silently flip this row.
+- **`/access` is a visibility map, not an execution grant.** It mirrors
+  `disbot/utils/visibility_rules.py` — which tier *can see* which subsystem. No token, no
+  per-guild override, no execution authority.
+- **`/env` is the redaction line, drawn explicitly.** It is static analysis of the bot source:
+  variable **names** + the `file:line` that read them + required/optional/layer. It **never**
+  reads, stores, or renders a value, and **never** opens an `.env` file. Railway stays the single
+  source of truth for values. This is the page most likely to be mistaken for a secret surface —
+  it is safe precisely because it surfaces *names + locations only*. See
+  [`env-vars.md`](env-vars.md) (the in-repo form of the same map) and
+  [`production-deployment.md`](production-deployment.md) (where the values actually live).
+
+## Why each ⛔ row stays gated (the standing rationale)
+
+- **`/me` + `/admin/*`** render one server's **live** configuration — settings values, help text,
+  routing. That is per-guild private data, so the route requires Discord OAuth **and** a per-edit
+  bot-side authority re-check (the browser's identity claim is re-verified by the bot on every
+  write — see `dashboard/README.md` § Control panel). Opening a panel never authorises a later
+  callback.
+- **`/admin/moderation` (P5)** lists raw public `/submit` submissions, which may contain
+  arbitrary user text. It is **owner-gated** (restricted to `BOT_OWNER_USER_ID`, mirroring the
+  existing global-settings owner gate) and renders all stored fields **escaped** so a crafted
+  payload cannot inject HTML/markdown into the owner's view or a mirrored issue. Nothing a user
+  submits is ever shown publicly — submissions land `status='pending'` and the only exposure path
+  is explicit owner approval (plan §2.3 / §4.2).
+- **The future owner ring** (env-value management, control board) handles secret **values** via
+  the Railway API. It is owner-only and must never be reachable from any public-side route.
+
+## What this audit deliberately does NOT cover
+
+- **The public bot site's `site.json`** — redacted *by construction* (the whitelist subset) and
+  guarded by `scripts/check_dashboard_data.py` (CI, fail-closed on a new key). That guard is the
+  by-construction half; this file is the dev-site by-route-auth half.
+- **Secret-holding per service** — which service may hold which secret is the §4.4 matrix; the
+  env-name surface is [`env-vars.md`](env-vars.md) and the deploy/secret-scope recipe is
+  [`botsite-deploy.md`](botsite-deploy.md).
+- **The control-API public-exposure security review** — the prerequisite gating the per-server
+  panel's migration to the bot side (plan §3 / §7.4). That review is a separate, owner-paced
+  deliverable; until it lands, the panel stays on the dev site (gated, as audited above).

--- a/docs/operations/env-vars.md
+++ b/docs/operations/env-vars.md
@@ -61,3 +61,59 @@ only — never a value**; the values live in Railway service variables
 | `SETUP_ADVISOR_OPENAI_MODEL` | config, services | `disbot/config.py:161` *(default)*<br>`disbot/services/setup_ai_advisor.py:173` *(default)* |
 | `SETUP_ADVISOR_PROVIDER` | config, core, services | `disbot/config.py:160` *(default)*<br>`disbot/core/runtime/ai/feature_flags.py:129` *(default)*<br>`disbot/services/setup_ai_advisor.py:393` *(default)* |
 | `STRICT_DISABLED` | bot1 | `disbot/bot1.py:172` *(default)* |
+
+<!-- END GENERATED REGION — everything ABOVE this line is rewritten by
+     scripts/scan_env_usage.py --write-doc. The "Website tier" section BELOW is
+     hand-maintained (those vars are read by the web services, not by disbot/, so the
+     bot-source scanner never emits them). Keep it out of the `| `NAME` |` table form so
+     the freshness drift check (scripts/check_generated_artifacts_fresh.py `_ENV_VAR_ROW`)
+     doesn't see these names and false-flag them as "missing from a fresh scan." -->
+
+## Website tier (web services — not read by the bot source)
+
+> **Hand-maintained, not generated.** The variables below are read by the **web** services
+> (`botsite/` and `dashboard/`), not by `disbot/`, so the bot-source scanner above never lists
+> them. They are deliberately written as prose (not a `| name |` table row) so the env-vars
+> freshness check doesn't mistake them for missing bot vars. The authoritative deploy/secret-scope
+> home is [`botsite-deploy.md`](botsite-deploy.md) (§ env + § rollout) and the website
+> two-site-split plan's §4.4 secret matrix; this section is the discoverable name index.
+>
+> **If you regenerate the bot section above** (`scripts/scan_env_usage.py --write-doc` rewrites the
+> whole file), **re-add this section afterward** — the generator only emits bot-source vars.
+
+The crisp split: the **public** bot site (`botsite/`) holds **exactly one** secret — an
+**INSERT-only** DB role on one table. Everything else lives only on the owner-gated **dev** site
+(`dashboard/`). Per-service secret-holding is the plan's §4.4 matrix.
+
+**Submissions intake (the `/submit` flow → moderation → GitHub mirror):**
+
+- **`SUBMISSIONS_DB_DSN`** — Postgres DSN for the **dashboard-owned** submissions DB (a *separate*
+  store from the bot's Postgres, so decoupling holds). Read by `botsite/submissions_db.py`
+  (`_DSN_ENV`) and `dashboard/submissions_db.py`. **Least-privilege role differs per service:**
+  the **public bot site** gets an **INSERT-only** role (it can only `insert_pending`); the
+  **dev site** gets a **full** role (SELECT + UPDATE, to list/moderate). **Dormant by default** —
+  unset means `/submit` shows "temporarily unavailable" and nothing connects.
+- **`SUBMISSIONS_IP_SALT`** — *optional.* Salt for the **salted IP hash** stored for abuse
+  forensics (never the raw IP). Read by `botsite/submissions_db.py` (`_IP_SALT_ENV`); falls back to
+  a per-process salt when unset (a usable within-run dedup key, since the hash is for forensics,
+  not identity).
+- **`GITHUB_ISSUE_MIRROR_TOKEN`** — the GitHub-issue mirror token. **Dev site only — never on the
+  public bot site, never in the repo, never in `site.json`.** A **fine-grained PAT scoped to only
+  `menno420/superbot` with the single permission Issues: Read & write** (no code, no actions, no
+  metadata-write). The mirror call runs server-side on owner approval, so the token never reaches a
+  browser or the public service.
+- **(optional) captcha keys** — *fast-follow lever, not v1.* If honeypot + rate-limit prove
+  insufficient (plan §4.2 / §7.6), a Cloudflare Turnstile / hCaptcha pair (e.g. a public site key +
+  a secret verify key) can be added on the public site. Not set in v1 — recorded here so the name
+  surface is known when/if it lands.
+
+**Dev-site control panel + login (existing, dormant unless configured — see `dashboard/README.md`):**
+
+- **`DISCORD_OAUTH_CLIENT_ID`**, **`DISCORD_OAUTH_CLIENT_SECRET`**, **`DISCORD_OAUTH_REDIRECT_URI`**
+  — Discord OAuth for the `/admin` control panel + the owner-gated `/admin/moderation`. Dev site
+  only.
+- **`DASHBOARD_SESSION_SECRET`** — HMAC key for the stdlib signed session cookie
+  (`dashboard/websession.py`). Dev site only.
+- **`CONTROL_API_TOKEN`** (+ optional **`CONTROL_API_URL`**) — bearer for the bot's private control
+  API; set on **both** the dev site and the bot worker. **Never on the public bot site.** (Also
+  listed in the bot section above as read by `disbot/control_api.py`.)

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -77,6 +77,12 @@ living ledger (`docs/current-state.md`).
   `scripts/check_consistency.py` · `tests/unit/scripts/test_check_consistency.py` ·
   `docs/current-state.md` · 2026-06-18 · **auto-merge on green**
 
+- `claude/website-deploy-redaction-docs` · website two-site-split **fan-out P7 + P8** (docs only) —
+  the §4.1 redaction-audit record + the `botsite/` deploy/env docs; sole fan-out unit editing the
+  plan (mark §5 back-half shipped + §9 links) · `docs/operations/dashboard-redaction-audit.md` ·
+  `docs/operations/botsite-deploy.md` · `docs/operations/env-vars.md` · `dashboard/README.md` ·
+  `docs/planning/website-two-site-split-plan-2026-06-19.md` · 2026-06-19 · **auto-merge on green**
+
 ## Recently cleared
 
 - `claude/magical-rubin-bq71go` · manifest spine **PR3** — control-API `GET /control/manifest` read +

--- a/docs/planning/website-two-site-split-plan-2026-06-19.md
+++ b/docs/planning/website-two-site-split-plan-2026-06-19.md
@@ -421,10 +421,19 @@ against a **test DB** (S2's schema on a throwaway/test Postgres or SQLite) and a
 exactly the `importorskip`/mock pattern the existing `dashboard/` suite uses. No unit needs the real
 Railway service, the real Postgres, or any token; the owner provisions those at **rollout** (§6).
 
-> **▶ Status (2026-06-19): the serial foundation S1 + S2 + P1 is MERGED (#1109).** The remaining work is
-> the back half — now **reshaped by the Site identity & experience brief above**: a new unit **S1.1**
-> enriches the per-command data the interactive browser needs, and **P2** becomes that browser (not a
-> static table). The rest (P3–P8) is unchanged. New dependency: **S1.1 → P2**.
+> **▶ Status (2026-06-19): the serial foundation S1 + S2 + P1 is MERGED (#1109), and the back half then
+> SHIPPED in a parallel ultracode fan-out wave (2026-06-19).** All back-half units —
+> **S1.1** (enriched per-command data) · **P2** (interactive command/feature browser) · **P3**
+> (changelog + status templates) · **P4** (submission intake module) · **P5** (dev-site moderation UI)
+> · **P6** (GitHub-mirror mechanism) · **P7** (this redaction-audit record) · **P8** (deploy + env docs)
+> — were built file-disjoint as planned (no two concurrently-running units shared a file). The
+> back-half was **reshaped by the Site identity & experience brief above**: S1.1 enriches the
+> per-command data the interactive browser needs, and P2 is that browser (not a static table), on the
+> dependency **S1.1 → P2**. *The remaining product follow-ups are the deliberately-deferred slices:*
+> the per-server **control-panel migration** to the bot side (gated on the control-API
+> public-exposure security review, §4.4 / §7.4) and the **live status aggregator** (deferred behind
+> the same review, §3 / §7.2). What remains before the bot site is "the website" is the owner-paced
+> **rollout** (§6: provision the new Railway service + the submissions DB, then cut over the domain).
 
 ### Serial foundation (✅ MERGED #1109) — original spec retained for reference
 
@@ -456,9 +465,12 @@ Railway service, the real Postgres, or any token; the owner provisions those at 
   `app.include_router(submit_router)`). This single-owner `app.py` is what makes the back half disjoint —
   **no other unit edits `app.py`.** *(Honor the no-`static/` gotcha.)*
 
-### Parallel back half (truly file-disjoint — fan out once S1 + S2 + P1 land)
+### Parallel back half (✅ SHIPPED 2026-06-19 — file-disjoint fan-out wave)
 
-- **S1.1 — enrich the public command data (extends the merged S1 producer + whitelist; P2 depends on it).**
+> All eight units below shipped in the 2026-06-19 fan-out (foundation #1109 first). Their exclusive
+> file sets are retained for reference + auditability of the disjointness.
+
+- **✅ S1.1 — enrich the public command data (extends the merged S1 producer + whitelist; P2 depends on it).**
   Exclusive: `scripts/export_dashboard_data.py` (the `build_site_subset` command projection),
   `scripts/check_dashboard_data.py` (extend `check_site_subset`'s per-command whitelist — still
   **fail-closed**), `botsite/data/site.json` (regenerate), `tests/unit/scripts/` (extend). Adds, **per
@@ -474,39 +486,43 @@ Railway service, the real Postgres, or any token; the owner provisions those at 
     heuristic name-match as fallback.)*
   - `notes` — curated per-command notes (ours/community). *(Source = open decision — recommend v1 reuse the
     help-overlay re-describe text; a dedicated community-notes source is a fast-follow, not invented.)*
-- **P2 — interactive command + feature browser (the owner-vision core; depends on S1.1).** Exclusive:
+- **✅ P2 — interactive command + feature browser (the owner-vision core; depends on S1.1).** Exclusive:
   `botsite/templates/commands.html`, `botsite/templates/features.html`, `botsite/templates/_command_detail.html`
   (the detail partial). Renders the **enriched** `site.json` as **clickable command cards → a detail view**
   (use-cases · aliases · permissions · examples · **notes** · **status badge** · **linked ideas**), with
   fast client-side search/filter so nothing takes long to find; progressive-enhancement JS inline (honor
   the no-`static/` gotcha). `/features` groups the same data by category — the all-in-one showcase. Reads
   `site.json`; rendered by P1's already-wired routes; **no `app.py` edit.**
-- **P3 — changelog + status templates.** Exclusive: `botsite/templates/changelog.html`,
+- **✅ P3 — changelog + status templates.** Exclusive: `botsite/templates/changelog.html`,
   `botsite/templates/status.html` + the "generated vs live" freshness badges. Reads `site.json.bot_changelog`
   + `meta.build` (both produced by S1). Templates only — no `app.py`, no producer edit.
-- **P4 — submission intake module.** Exclusive: `botsite/submit.py` (the `/submit` `APIRouter` + honeypot +
+- **✅ P4 — submission intake module.** Exclusive: `botsite/submit.py` (the `/submit` `APIRouter` + honeypot +
   validation + INSERT via S2's `botsite/submissions_db.py` — fills in P1's stub), `botsite/ratelimit.py`
   (**copy** the proven stdlib limiter — no shared import, §2.2), `botsite/templates/submit.html`,
   `tests/unit/botsite/test_submit.py`.
-- **P5 — dev-site moderation UI.** Exclusive: `dashboard/templates/moderation.html`, the
+- **✅ P5 — dev-site moderation UI.** Exclusive: `dashboard/templates/moderation.html`, the
   `/admin/moderation` route + approve/reject handlers in `dashboard/app.py`, owner-gate helper,
   `tests/unit/dashboard/test_moderation.py`. Lists `pending`, approve/reject, CSRF-protected; uses S2's
   `dashboard/submissions_db.py` + P6's mirror.
-- **P6 — GitHub-mirror mechanism.** Exclusive: `dashboard/github_mirror.py` (least-privilege issue-create
+- **✅ P6 — GitHub-mirror mechanism.** Exclusive: `dashboard/github_mirror.py` (least-privilege issue-create
   client + template-shape mapping) + its test. Called by P5 on approve; built/tested against a stub first.
-- **P7 — redaction audit record.** Exclusive: `docs/operations/dashboard-redaction-audit.md` (the §4.1
-  matrix as a living checklist). Docs only — no `dashboard/app.py` or shared-template edits (those belong
+- **✅ P7 — redaction audit record.** Exclusive: `docs/operations/dashboard-redaction-audit.md` (the §4.1
+  matrix as a living checklist, §9). Docs only — no `dashboard/app.py` or shared-template edits (those belong
   to P5), so it can't collide.
-- **P8 — deploy + env docs.** Exclusive: `docs/operations/botsite-deploy.md` (new — the 2nd-service deploy
-  recipe + Railway setup), `docs/operations/env-vars.md` (+ the new env names: `GITHUB_ISSUE_MIRROR_TOKEN`,
-  the submissions DSN, optional captcha keys), `dashboard/README.md` (moderation note). *(P1 owns
-  `botsite/README.md`; P8 does not touch it.)*
+- **✅ P8 — deploy + env docs.** Exclusive: `docs/operations/botsite-deploy.md` (new — the 2nd-service deploy
+  recipe + Railway setup, §9), `docs/operations/env-vars.md` (+ the new env names: `GITHUB_ISSUE_MIRROR_TOKEN`,
+  `SUBMISSIONS_DB_DSN`, `SUBMISSIONS_IP_SALT`, optional captcha keys — added as a hand-maintained
+  *Website tier* section, since the generated bot-source scanner doesn't emit web-service vars),
+  `dashboard/README.md` (moderation note). *(P1 owns `botsite/README.md`; P8 does not touch it.)*
 
-**Dependency graph (updated 2026-06-19):** the foundation `S1 → {S2, P1}` is **merged (#1109)**. Remaining:
-`S1.1 → P2` (the browser needs the enriched data) runs as its own short serial pair; `{P3, P4, P6, P7, P8}`
-fan out fully in parallel alongside it; P4 fills P1's `submit.py` stub + uses S2's INSERT helper, P5 uses
-S2's read helper + P6 (P6 stub-buildable first). S1.1 is the only producer-touching unit, so it never
-collides with the template/module units. No two concurrently-running units share a file.
+**Dependency graph (executed 2026-06-19):** the foundation `S1 → {S2, P1}` **merged (#1109)**, then the
+back half **shipped in the fan-out wave**: `S1.1 → P2` (the browser needs the enriched data) ran as its
+own short serial pair; `{P3, P4, P6, P7, P8}` fanned out fully in parallel alongside it; P4 filled P1's
+`submit.py` stub + uses S2's INSERT helper, P5 uses S2's read helper + P6 (P6 stub-buildable first). S1.1
+was the only producer-touching unit, so it never collided with the template/module units. **No two
+concurrently-running units shared a file** — the disjointness held. *Deferred follow-ups (not part of the
+fan-out): the control-panel migration + the live status aggregator, both gated on the control-API
+security review; and the owner-paced rollout (§6).*
 
 ---
 
@@ -640,6 +656,14 @@ architecture sections deliberately left open; the build run may refine them.
   this split realises (Public → bot site; Personal/Server/Owner → dev site).
 - [`web-tier-centralization-proposal-2026-06-19.md`](web-tier-centralization-proposal-2026-06-19.md) — the
   `web-ci.yml` matrix (dashboard + botsite) + PR-machinery de-duplication (owner centralization mandate).
+- [`../operations/dashboard-redaction-audit.md`](../operations/dashboard-redaction-audit.md) — **P7**:
+  the §4.1 per-page redaction matrix as a living, dated audit certifying the dev site's public-read
+  posture (the by-route-auth half of non-negotiable #1; the bot-site whitelist guard is the
+  by-construction half).
+- [`../operations/botsite-deploy.md`](../operations/botsite-deploy.md) — **P8**: the 2nd-Railway-service
+  deploy recipe for `botsite/` (Root Directory = `botsite`, its own `requirements.txt` + `Procfile`, the
+  no-`static/` gotcha) + the §6 rollout/rollback sequence + the dev-site moderation note.
 - `dashboard/` (the decoupled service), `scripts/export_dashboard_data.py` (the single data producer),
   `disbot/control_api.py` (the private, owner-paced live source), `.github/ISSUE_TEMPLATE/` (the mirror
-  shapes, #1064), `docs/operations/env-vars.md` (the env-name surface).
+  shapes, #1064), [`../operations/env-vars.md`](../operations/env-vars.md) (the env-name surface, now with
+  a hand-maintained *Website tier* section — **P8**).


### PR DESCRIPTION
Ultracode fan-out units **P7 + P8** of the website two-site-split plan
(`docs/planning/website-two-site-split-plan-2026-06-19.md` §5). **Docs only — no runtime code.**

## What this ships

- **P7** — `docs/operations/dashboard-redaction-audit.md` (new): the plan §4.1 per-page redaction
  matrix as a living, dated checklist (every dev-site page → what renders / what's stripped /
  verdict), so the public-read posture is auditable. Verified against the live `dashboard/app.py`
  routes.
- **P8:**
  - `docs/operations/botsite-deploy.md` (new): the 2nd-Railway-service deploy recipe for `botsite/`
    (Root Directory = `botsite`, its own `requirements.txt` + `Procfile`, the **no-`static/`** gotcha)
    + the dev-site moderation note + Railway setup + the rollout/rollback sequence.
  - `docs/operations/env-vars.md` (extend): a new "Website tier" section naming the new env vars —
    `GITHUB_ISSUE_MIRROR_TOKEN` (dev-site only, repo-scoped Issues:write), `SUBMISSIONS_DB_DSN`
    (INSERT-only role on the public site / full on the dev site) + `SUBMISSIONS_IP_SALT`, optional
    captcha keys, and the dev-site OAuth/session/control set.
  - `dashboard/README.md`: a short moderation note.
- **Plan bookkeeping** (sole fan-out unit editing the plan): §5 back-half units
  (S1.1/P2/P3/P4/P5/P6/P7/P8) marked shipped in the fan-out wave; §9 reference links to the two
  new `docs/operations/` docs added (for `check_docs` reachability).

## Verification
- `python3.10 scripts/check_docs.py --strict` (reachability + ratchets) — green
- `python3.10 scripts/check_quality.py --check-only` — green

Born-red session card (`.sessions/2026-06-19-website-deploy-redaction-docs.md`) holds the merge
until close-out, then flips to `complete` (Q-0133).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txth4MHhF5Li6fQJ4koA27

---
_Generated by [Claude Code](https://claude.ai/code/session_01Txth4MHhF5Li6fQJ4koA27)_