### PR TITLE
docs(ideas): capture per-command feedback threads + idea→command mapping

### DIFF
--- a/.sessions/2026-06-19-feedback-threads-and-idea-mapping-capture.md
+++ b/.sessions/2026-06-19-feedback-threads-and-idea-mapping-capture.md
@@ -1,0 +1,44 @@
+# 2026-06-19 — Capture: per-command feedback threads + idea→cog/command mapping
+
+> **Status:** `complete`
+
+## Arc
+
+While the website back-half fan-out builds, the owner expanded the vision twice (the command-detail
+"notes" + the status rule). Captured both as durable idea docs so nothing's lost — they're follow-on
+features, not part of the v1 fan-out currently building. Non-overlapping with the 5 fan-out agents (this
+touches only `docs/ideas/`).
+
+## Shipped (this PR)
+
+- `docs/ideas/per-command-feedback-threads-2026-06-19.md` — the owner's **AI-moderated per-command
+  feedback-thread** feature ("Codex for the bot's features"): anyone posts questions/bugs/improvements on a
+  command/cog → an **Anthropic-API pass** cleans wording + blocks/rewrites foul language → threaded display.
+  Goals: owner inline review · user dedup · honest feedback. Reuses the submissions store + moderation
+  pipeline; **supersedes the v1 static `notes` field**.
+- `docs/ideas/idea-to-cog-command-mapping-2026-06-19.md` — the **idea/bug → cog/command mapping** effort
+  (explicit tag + validator; heuristic interim) that is the truth source for the site's per-command
+  `status` + `linked_ideas`. "As fast as possible, not rushing."
+- Indexed both in `docs/ideas/README.md`.
+
+## Decisions confirmed / context delta
+
+- **Status rule** (owner): a command is `in-progress` if it has **any related ideas/bugs**, else
+  `finished` — this **matches what the running browser agent (S1.1) is already building**, so no change to
+  the fan-out; accuracy improves as the mapping effort fills in (the agent uses a subsystem heuristic now).
+- **Notes are dynamic, not static:** the owner's "notes" = the feedback-thread system above (DB + AI
+  moderation + threading), not the help-text placeholder. The v1 browser's static `notes` field is a
+  harmless interim (mostly `null`); the feedback system replaces it. Left the running agent undisturbed
+  (its command-detail view is the right home for the future threads).
+- These two are **follow-ons after the v1 site lands** — captured now, promotable to plans + build under
+  Q-0172 once the fan-out is in.
+
+## 📤 Run report
+
+- **Did:** captured the owner's two new visions (per-command AI-moderated feedback threads + idea→command
+  mapping) as durable, indexed idea docs; confirmed the status rule matches the in-flight build. · shipped.
+- **Run type:** `manual` (owner vision capture, mid-fan-out).
+- **⚑ Self-initiated:** `none` (owner-directed capture).
+- **↪ Next:** the fan-out (5 agents) is building v1; on completion, verify + (per Q-0172) these two ideas
+  are prime follow-on builds. Still pending from earlier: the control-panel router lock + rollout/security
+  ops checklists.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -20,6 +20,17 @@ during grooming** (it stays listed here, annotated ✅) so the active backlog re
 
 Current broad captures:
 
+- [`per-command-feedback-threads-2026-06-19.md`](./per-command-feedback-threads-2026-06-19.md) —
+  **owner-directed (2026-06-19):** every command/cog on the bot site carries an optional **feedback thread**
+  (anyone posts questions/bugs/improvements), gated by an **Anthropic-API moderation pass** (clean-up +
+  foul-language block/rewrite) — "Codex for the bot's features." Goals: owner leaves inline thoughts to
+  review later · users see if an issue was already raised · honest feedback for all. Supersedes the v1
+  static `notes` field; reuses the submissions store + moderation pipeline. → relates website plan P2/§2.3/§4.
+- [`idea-to-cog-command-mapping-2026-06-19.md`](./idea-to-cog-command-mapping-2026-06-19.md) —
+  **owner-directed (2026-06-19):** map every idea (and bug) to its **cog/command** (explicit tag + a
+  validator; heuristic as interim fallback) — the truth source for the site's per-command **status**
+  (`in-progress` if any related ideas/bugs) and **linked-ideas** discoverability. "As fast as possible,
+  not rushing." → relates `export_dashboard_data.py` · the subsystem registry · website plan S1.1.
 - [`website-two-site-split-2026-06-19.md`](./website-two-site-split-2026-06-19.md) —
   **owner-directed (2026-06-19, Q-0178):** split the single dashboard into a **public bot site** (users;
   command reference, changelog, public bug/suggestion form → DB → owner-approve → mirror to GitHub) and a

--- a/docs/ideas/idea-to-cog-command-mapping-2026-06-19.md
+++ b/docs/ideas/idea-to-cog-command-mapping-2026-06-19.md
@@ -1,6 +1,6 @@
 # Map every idea (and bug) to its cog / command
 
-> **Status:** `idea` — **owner-directed (2026-06-19)**, captured during the website two-site-split fan-out.
+> **Status:** `ideas` — **owner-directed (2026-06-19)**, captured during the website two-site-split fan-out.
 > Near-term effort: *"start correctly mapping each idea to a command or cog as fast as possible (not
 > rushing)."* Foundational to the bot site's discoverability + status features.
 

--- a/docs/ideas/idea-to-cog-command-mapping-2026-06-19.md
+++ b/docs/ideas/idea-to-cog-command-mapping-2026-06-19.md
@@ -1,0 +1,44 @@
+# Map every idea (and bug) to its cog / command
+
+> **Status:** `idea` — **owner-directed (2026-06-19)**, captured during the website two-site-split fan-out.
+> Near-term effort: *"start correctly mapping each idea to a command or cog as fast as possible (not
+> rushing)."* Foundational to the bot site's discoverability + status features.
+
+## Why
+
+The site's vision (website plan §"Site identity & experience") wants, per command:
+- **status** — `in-progress` if the command has **any related ideas or bugs**, else `finished`;
+- **linked ideas** — the ideas/plans for that command/cog, surfaced right where the command lives.
+
+Both require a **reliable mapping idea → cog/command** (and bug → cog/command). Today there is none — the
+v1 browser (unit S1.1) uses a **heuristic** (subsystem-level name-match) as an interim. The heuristic is
+approximate; the owner wants the **real, correct mapping**, built deliberately over time.
+
+## Mechanism (recommended)
+
+1. **Authoritative tag at the source.** Add an explicit `subsystem:` / `cog:` / `command:` field to each
+   `docs/ideas/*.md` (and each bug-book entry) — front-matter or a one-line header field. The producer
+   (`export_dashboard_data.py`) reads it; no guessing.
+2. **A validator** (`scripts/check_idea_mapping.py`, stdlib, Q-0105-disposable): every idea/bug maps to a
+   **real** cog/command/subsystem (resolved against the subsystem registry), and flags unmapped ones — so
+   the mapping is *checkable* and the backlog of "still unmapped" is visible and drains.
+3. **Heuristic as fallback only.** Where no explicit tag exists yet, the subsystem name-match heuristic
+   fills in (clearly marked lower-confidence), so the site degrades gracefully while the mapping is filled.
+
+## Effort shape ("fast as possible, not rushing")
+
+- ~80+ ideas + the bug book to map — do it in **batches**, correctly, not in one rushed pass.
+- A small **assist tool** can *propose* a mapping per idea (from its text + the subsystem registry) for a
+  human/agent to confirm — turning a manual slog into a review.
+- Each mapped batch immediately sharpens the site's `status` + `linked_ideas` accuracy (incremental payoff).
+
+## Connections
+
+- Feeds the v1 browser's `status` + `linked_ideas` (S1.1) — replacing the interim heuristic with truth.
+- Shares the key with **per-command feedback threads** (`per-command-feedback-threads-2026-06-19.md`):
+  notes/threads key on the same cog/command identity, so one mapping serves both.
+- Complements the existing subsystem registry (cog→subsystem) — this adds the idea/bug→cog/command edge
+  that registry doesn't carry.
+
+→ relates: `scripts/export_dashboard_data.py` (`build_site_subset`) · the subsystem registry ·
+`docs/ideas/` + the bug book · website plan unit S1.1.

--- a/docs/ideas/per-command-feedback-threads-2026-06-19.md
+++ b/docs/ideas/per-command-feedback-threads-2026-06-19.md
@@ -1,6 +1,6 @@
 # Per-command AI-moderated feedback threads ("Codex for the bot's features")
 
-> **Status:** `idea` — **owner-directed (2026-06-19)**, captured during the website two-site-split fan-out.
+> **Status:** `ideas` — **owner-directed (2026-06-19)**, captured during the website two-site-split fan-out.
 > A real new feature, distinct from the v1 static-notes placeholder. Ready to promote to a `docs/planning/`
 > plan + build after the v1 bot site lands (Q-0172: any agent may promote → build, flagged self-initiated).
 

--- a/docs/ideas/per-command-feedback-threads-2026-06-19.md
+++ b/docs/ideas/per-command-feedback-threads-2026-06-19.md
@@ -1,0 +1,75 @@
+# Per-command AI-moderated feedback threads ("Codex for the bot's features")
+
+> **Status:** `idea` — **owner-directed (2026-06-19)**, captured during the website two-site-split fan-out.
+> A real new feature, distinct from the v1 static-notes placeholder. Ready to promote to a `docs/planning/`
+> plan + build after the v1 bot site lands (Q-0172: any agent may promote → build, flagged self-initiated).
+
+## The vision (owner's words, 2026-06-19)
+
+On the bot site, every command (and cog) carries an **optional feedback box**: **anyone** can leave a
+note — a question, a bug, an improvement — **right on that command**. It works like **Codex reviewing our
+PRs**: a **thread** of questions / bugs / improvements that accumulates per command.
+
+Three goals:
+1. **The owner** can browse the cogs/commands and **leave thoughts inline, right there, to review later.**
+2. **Every user** can **see whether a bug they found or an improvement they want has already been raised**
+   by someone else (dedup, transparency).
+3. **Everyone gets to give honest feedback** about the bot's actual functions.
+
+## The moderation gate (the key mechanic)
+
+Every submitted note passes through an **Anthropic-API review** *before* it posts (the bot already runs on
+Claude — an API key exists):
+- **suggests a cleaner phrasing** of the note where possible (so threads stay readable/useful);
+- **blocks or rewrites foul language / abuse** entirely;
+- (extension) can de-duplicate against existing notes on the same command ("this looks like the existing
+  thread X — add to it?") and classify the note (question / bug / improvement) to match the Codex-style
+  thread shape.
+
+This is the same spirit as Codex's PR review: an AI pass that turns raw input into a clean, useful,
+safe contribution.
+
+## Where it fits the architecture
+
+- **Home:** the **command detail view** (website plan §"Site identity & experience" → the interactive
+  browser, unit P2). The feedback thread lives under each command/cog; this **supersedes the v1 static
+  `notes` field** (which was a help-text placeholder — the real notes are these dynamic threads).
+- **Store:** a new table in the **dashboard-owned Postgres** (the same store as `submissions`, §2.3 of the
+  plan), keyed by cog/command, threaded. Reuses the submissions infrastructure pattern.
+- **Intake (public, no login — "anyone"):** post → **Anthropic-API moderation** → (clean/blocked) → store
+  → display. Inherits the public-submission **abuse plan** (honeypot + rate-limit + salted IP hash, plan
+  §4.2) *plus* the AI content gate. Render **escaped**.
+- **Display:** public, per-command thread (moderated entries only). Users browse existing feedback before
+  adding (goal 2).
+- **Owner side:** the dev site's moderation surface (the P5 moderation UI's sibling) lets the owner
+  review/hide/curate threads and **promote** a note to a GitHub issue via the existing least-privilege
+  mirror (§4.3) — so a good bug/idea flows into the real backlog. The owner's own inline notes (goal 1)
+  are first-class authored entries.
+
+## Relationship to the `/submit` form (P4)
+
+`/submit` is a **general** bug/suggestion form → moderation → GitHub issue. These feedback threads are
+**per-command, inline, threaded, AI-moderated discussion**. They converge at moderation: a thread entry the
+owner deems actionable can mirror to GitHub on the same pipeline. Design decision for the plan: whether
+`/submit` becomes "post to the relevant command's thread" or stays a separate general intake (recommend:
+keep both; `/submit` for "I don't know which command," threads for "I'm looking at this command").
+
+## Open design decisions (for the plan/build)
+
+- **Anthropic moderation contract:** model + prompt for the clean-up/block/classify pass; fail-safe
+  behaviour (if the API is down — queue for owner review rather than auto-post; never auto-post unmoderated).
+- **Identity:** fully anonymous vs optional contact vs Discord-OAuth attribution (affects spam + dedup).
+- **Cost/rate:** an Anthropic call per submitted note — rate-limit + cap to bound cost.
+- **Public display threshold:** auto-post after the AI gate, or owner-approve first (recommend: AI-gate
+  auto-post for clean notes, owner can hide; foul → blocked; borderline → held for owner).
+
+## Why it's worth having
+
+It turns the public site from a brochure into a **living, honest feedback loop on every function** — the
+internal mirror of how Codex/agents review our code, pointed at the bot's features and opened to users.
+It also gives the owner a frictionless inline "leave a thought on this command" surface (goal 1), which is
+exactly the kind of low-friction capture this whole agent-workflow project values.
+
+→ relates: website plan `planning/website-two-site-split-plan-2026-06-19.md` (P2 detail view · §2.3
+submissions store · §4.2 abuse plan · §4.3 mirror) · `idea-to-cog-command-mapping-2026-06-19.md` (threads
+key on the same cog/command mapping) · the bot's existing Anthropic/Claude integration.


### PR DESCRIPTION
## What

The owner expanded the website vision (2026-06-19) while the back-half fan-out is building. Captured both as durable, indexed idea docs — they're **follow-on features**, not part of the v1 fan-out currently in flight.

- **`per-command-feedback-threads-2026-06-19.md`** — the owner's **AI-moderated per-command feedback thread** ("Codex for the bot's features"): anyone posts a question/bug/improvement on a command/cog → an **Anthropic-API pass** cleans wording + blocks/rewrites foul language → threaded display. Goals: owner leaves inline thoughts to review later · users see if an issue was already raised · honest feedback for all. Reuses the submissions store + moderation pipeline; **supersedes the v1 static `notes` field**.
- **`idea-to-cog-command-mapping-2026-06-19.md`** — map every idea/bug to its **cog/command** (explicit tag + a validator; heuristic interim) — the truth source for the site's per-command **status** (`in-progress` if any related ideas/bugs) + **linked-ideas** discoverability. "As fast as possible, not rushing."

Indexed both in `docs/ideas/README.md`.

**Confirmed:** the status rule matches what the running browser agent (S1.1) already builds — no fan-out change needed; accuracy improves as the mapping fills in. Docs-only; `check_docs --strict` green. Session card `complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txth4MHhF5Li6fQJ4koA27

---
_Generated by [Claude Code](https://claude.ai/code/session_01Txth4MHhF5Li6fQJ4koA27)_