### PR TITLE
P3: bot-site changelog + status pages (website two-site split)

### DIFF
--- a/.sessions/2026-06-19-website-changelog-status.md
+++ b/.sessions/2026-06-19-website-changelog-status.md
@@ -1,0 +1,23 @@
+# 2026-06-19 — Bot-site changelog + status pages (P3)
+
+> **Status:** `in-progress`
+
+Building unit **P3** of the website two-site split
+([plan](../docs/planning/website-two-site-split-plan-2026-06-19.md) §5) on the merged
+foundation (S1+S2+P1, #1109/#1110). Exclusive files only — two templates + their test;
+no `botsite/app.py`, no producer, no other template edits.
+
+## About to do
+
+- `botsite/templates/changelog.html` — a timeline grouped by date from
+  `site.json.bot_changelog`, kind tags (feature/fix/improvement), honest copy, **no raw
+  internal PR numbers** surfaced.
+- `botsite/templates/status.html` — a user trust band from `site.json.meta.build`
+  (online-as-of-last-deploy · build SHA/date) with a **"generated" freshness badge**
+  (no live claim, plan §3).
+- `tests/unit/botsite/test_changelog_status.py` — `importorskip`-guarded smoke tests.
+
+Verify: `python3.10 scripts/check_quality.py --full` + `check_architecture --mode
+strict`. Ship: ready PR to `main`, auto-merge armed.
+
+<!-- close-out (Q-0089 idea / Q-0102 review / Q-0104 audit / run report) is appended as the final step, then this status flips to complete. -->

--- a/.sessions/2026-06-19-website-changelog-status.md
+++ b/.sessions/2026-06-19-website-changelog-status.md
@@ -1,23 +1,123 @@
 # 2026-06-19 — Bot-site changelog + status pages (P3)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-Building unit **P3** of the website two-site split
-([plan](../docs/planning/website-two-site-split-plan-2026-06-19.md) §5) on the merged
-foundation (S1+S2+P1, #1109/#1110). Exclusive files only — two templates + their test;
-no `botsite/app.py`, no producer, no other template edits.
+Built unit **P3** of the website two-site split
+([plan](../docs/planning/website-two-site-split-plan-2026-06-19.md) §5 + the "Site
+identity & experience" brief + §3 freshness model) on the merged foundation
+(S1+S2+P1, #1109/#1110). Exclusive-file build run — two templates + their test, no
+`botsite/app.py` edit (the `/changelog` + `/status` routes were wired in P1).
 
-## About to do
+## Shipped (PR #1116)
 
-- `botsite/templates/changelog.html` — a timeline grouped by date from
-  `site.json.bot_changelog`, kind tags (feature/fix/improvement), honest copy, **no raw
-  internal PR numbers** surfaced.
-- `botsite/templates/status.html` — a user trust band from `site.json.meta.build`
-  (online-as-of-last-deploy · build SHA/date) with a **"generated" freshness badge**
-  (no live claim, plan §3).
-- `tests/unit/botsite/test_changelog_status.py` — `importorskip`-guarded smoke tests.
+- **`botsite/templates/changelog.html`** — a curated, user-facing **timeline grouped
+  by date** from `site.json.bot_changelog` (`{date, title, kind, summary}`). Kind
+  tags (`feature`→New / `improvement`→Improved / `fix`→Fixed; neutral "Update" for
+  untagged), an honest **"generated" freshness badge** (no live claim, §3), a friendly
+  empty state. Surfaces **no raw internal PR numbers** as user-facing ids (brief);
+  renders an optional outbound "Details →" link **only if** a future producer ever
+  supplies a `url` field (future-proof, no coupling — the curated source has none today).
+- **`botsite/templates/status.html`** — a slim **user trust band** from
+  `site.json.meta.build`: online-as-of-last-deploy + build SHA / date / latest-change
+  subject, with a prominent **"generated" badge** ("as of last deploy", **no real-time
+  claim** — the public site never reads the bot's private control API, §3). Honest
+  catalogue counts (commands/features/games), **never** server/user totals. Friendly
+  "Status unavailable" empty state + slate dot when build meta is absent.
+- **`tests/unit/botsite/test_changelog_status.py`** — 10 `importorskip`-guarded tests:
+  curated entries render (HTML-escaped via MarkupSafe), kind tags, the
+  generated-not-live posture, **no-PR-number leak**, the date-grouping (same-date
+  entries collapse under one heading, newest-first), no server/user totals, both
+  friendly empty states.
 
-Verify: `python3.10 scripts/check_quality.py --full` + `check_architecture --mode
-strict`. Ship: ready PR to `main`, auto-merge armed.
+## Verification
 
-<!-- close-out (Q-0089 idea / Q-0102 review / Q-0104 audit / run report) is appended as the final step, then this status flips to complete. -->
+- `python3.10 scripts/check_quality.py --full` → **10904 passed, 37 skipped** (CI
+  mirror, Python 3.10). `check_architecture --mode strict` → 0 errors.
+- All 32 `tests/unit/botsite/` tests green (23 P1 + 10 new — one extra over the brief's
+  ask to lock the date-grouping logic the committed data doesn't exercise).
+
+## Context delta
+
+- **Needed but not pointed to:** the **exact** `bot_changelog` record shape (no `url`
+  field) and `meta.build` keys live only in `scripts/export_dashboard_data.py`
+  (`parse_bot_changelog`) + the committed `site.json` — the plan describes the families
+  but not the field names. Reading the producer's parser was load-bearing: the brief
+  says "link out to GitHub release/PR", but the data has **no** link, so the honest
+  build was an optional-link-if-present, not a fabricated one. (Worth a one-line
+  "field shapes are in the producer's parser" pointer in the plan's P3 entry.)
+- **Discovered by hand:** two render-time facts the test had to respect — (1) Jinja2
+  autoescapes apostrophes to `&#39;` (decimal), so assert against `markupsafe.escape`,
+  **not** `html.escape` (which emits `&#x27;`); (2) `data_loader.load_site_data` binds
+  `DATA_FILE` as a *default argument*, so empty-state tests must wrap the loader to call
+  it with a missing path, not monkeypatch the module attribute.
+- **Pointed to but didn't need:** CodeGraph / the heavy arch-rule reading — this was a
+  pure-template + test unit in the (arch-unchecked) web tier; `context_map` wasn't
+  relevant either.
+- **Decisions made alone:** (1) no fabricated changelog→PR link (the data lacks one;
+  honesty over a guessed URL) — surfaced as an optional `url` hook; (2) the status
+  page's "online" signal mirrors P1's base.html posture (a known build ⇒ green dot ⇒
+  "online as of last deploy"), never a live ping; (3) added a 10th test beyond the
+  brief to lock the multi-entry-per-date grouping. All reversible, template-only.
+- **Weak point / flagged:** the pages are verified by unit render only — not by a real
+  browser / Tailwind-CDN paint. They reuse the proven P1 base.html chrome, so layout
+  risk is low, but a visual check at cutover is still worth it. Also: the "Details →"
+  link path is unexercised until S1 (or a later unit) adds a `url`/release field to the
+  changelog records — at which point a test asserting the link + the "no PR number"
+  rule together would be good.
+
+## 💡 Session idea
+
+**A `botsite` template-contract test that asserts every `site.json` family a template
+reads is one the whitelist/producer guarantees** — i.e. catch the inverse of the S1
+redaction whitelist: not "did a private family leak *out*", but "did a template start
+depending on a key the producer doesn't emit" (a silent empty-render regression). P3's
+templates lean on `bot_changelog[].kind` and `meta.build.commit`; if a future producer
+refactor renames a field, the page degrades to its empty state silently and CI stays
+green. A tiny test that renders each template against the committed `site.json` and
+asserts non-empty primary content (when the data is non-empty) would catch that drift —
+the read-side mirror of the existing write-side whitelist guard. (Dedup-checked:
+`docs/ideas/` has the redaction-whitelist and freshness-umbrella ideas, but none covers
+the *template-reads-a-real-key* direction.) Filed here; small enough to fold into a
+future botsite unit rather than a standalone idea file.
+
+## ⟲ Previous-session review
+
+The previous session (`2026-06-19-website-identity-and-fanout-enablers`, PR #1110) did
+the right *sequencing* thing: it folded the owner's binding identity/experience vision
+into the plan and added `botsite-ci.yml` **before** launching the fan-out, so units
+like this one build to a settled spec and actually run in CI. Genuine remark: it
+correctly resisted bundling the `web-ci.yml` centralization into the same PR (designed,
+not rushed) — good restraint. What it could have done better for *this* unit: its plan
+reshape detailed S1.1/P2 richly but left P3's data contract implicit — I had to read the
+producer to learn `bot_changelog` has no link field, which directly shaped the "no
+fabricated PR link" decision. **Concrete workflow improvement it surfaces:** when a plan
+unit's deliverable says "render X from `site.json.Y`", the plan (or the unit's brief)
+should name the **exact record fields** Y carries (or point at the producer function
+that defines them) — a fan-out builder shouldn't have to reverse-engineer the data
+contract from the generator to know whether a brief instruction ("link to the PR") is
+even backed by data. This is the same class as the Q-0132 "doc claims that mirror code
+must be CI-backed or stamped" rule, applied to plan↔data-contract drift.
+
+## 📤 Run report
+
+- **Did:** built website-split unit **P3** — the bot-site `/changelog` (curated
+  date-grouped timeline) + `/status` (honest generated-only trust band) templates +
+  tests, on the merged S1+S2+P1 foundation. · **Outcome:** shipped.
+- **Shipped:** #1116 — P3 changelog + status templates (2 templates + 1 test; CI green
+  10904 passed; auto-merge armed).
+- **Run type:** `manual` (ultracode build dispatch on a named unit).
+- **⚑ Owner decisions needed:** `none` (P3 had no open decisions; S1.1's three
+  open decisions — `status` derivation / idea-link method / notes source — remain the
+  previous session's surfaced items, not this unit's).
+- **⚑ Owner manual steps:** `none` for P3. (Standing, unchanged: the bot site's Railway
+  service + the cutover are owner steps per plan §6 — not triggered by this unit.)
+- **⚑ Self-initiated:** `none` — this was a dispatched build of an existing planned unit
+  (plan §5 P3); no idea was promoted to a plan/build unprompted. (The 10th test + the
+  optional-`url` link hook are in-scope correctness, not a new initiative.)
+- **↪ Next:** the rest of the back-half fan-out — **S1.1 → P2** (the interactive
+  command/feature browser) ∥ **P4** (submit intake) · **P5/P6** (dev-site moderation +
+  GitHub mirror) · **P7/P8** (redaction-audit + deploy docs). P3 is done.
+- **Note (out of scope here):** `check_current_state_ledger.py --strict` reports
+  pre-existing living-ledger drift (#1097–#1105 unrecorded) — older than this session
+  and **not** in P3's exclusive file set; flagged for the docs-reconciliation routine /
+  a manual docs session per the every-30-PR pass.

--- a/botsite/templates/changelog.html
+++ b/botsite/templates/changelog.html
@@ -1,0 +1,97 @@
+{% extends "base.html" %}
+{% block title %}Changelog — SuperBot{% endblock %}
+{% block description %}What's new in SuperBot — a curated, user-facing timeline of new features, fixes and improvements.{% endblock %}
+{% block content %}
+
+{# ── Page header ──────────────────────────────────────────────────────────────
+   The changelog is the curated, user-facing "what's new in the bot" feed
+   (plan §1 / §7.5) — it reads site.json.bot_changelog, NOT the dev-site session
+   feed. Each entry is {date, title, kind, summary}; the producer sorts newest
+   first. We group by date into a timeline (layout guidance) and re-sort
+   defensively so ordering never depends on the producer.
+   "generated" freshness badge (plan §3): this is a build-time snapshot, never a
+   live claim. ───────────────────────────────────────────────────────────────── #}
+<section class="border-b border-slate-800 pb-6 mb-8">
+  <div class="flex flex-wrap items-center gap-3">
+    <h1 class="text-3xl font-bold tracking-tight">What's new</h1>
+    <span
+      class="rounded bg-slate-800 px-2 py-0.5 text-xs text-slate-400"
+      title="Curated from the bot's changelog as of the last deploy — not a live feed."
+    >generated</span>
+  </div>
+  <p class="mt-3 text-slate-300 max-w-2xl">
+    New features, fixes and improvements you can feel — the changes that actually
+    reach your server. Hand-curated, newest first.
+  </p>
+</section>
+
+{# Kind → badge styling. An empty/unknown kind renders as a neutral "update". #}
+{% set kind_styles = {
+  'feature': ('New', 'bg-emerald-500/15 text-emerald-300 ring-emerald-500/30'),
+  'improvement': ('Improved', 'bg-sky-500/15 text-sky-300 ring-sky-500/30'),
+  'fix': ('Fixed', 'bg-amber-500/15 text-amber-300 ring-amber-500/30')
+} %}
+
+{% if entries %}
+  {# Group consecutive entries by date into timeline buckets, preserving the
+     producer's newest-first order. We build an ordered list of (date, [entries]). #}
+  {% set ns = namespace(groups=[], last=None) %}
+  {% for entry in entries %}
+    {% if entry.date != ns.last %}
+      {% set ns.groups = ns.groups + [(entry.date, [entry])] %}
+      {% set ns.last = entry.date %}
+    {% else %}
+      {% set _ = ns.groups[-1][1].append(entry) %}
+    {% endif %}
+  {% endfor %}
+
+  <div class="space-y-10">
+    {% for date, day_entries in ns.groups %}
+      <section class="relative">
+        {# Date heading — the timeline anchor. #}
+        <div class="flex items-center gap-3 mb-4">
+          <span class="h-2.5 w-2.5 rounded-full bg-indigo-500 ring-4 ring-indigo-500/15"></span>
+          <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-400">
+            <time datetime="{{ date }}">{{ date }}</time>
+          </h2>
+        </div>
+        {# The day's entries, indented to read as a timeline. #}
+        <div class="ml-[5px] border-l border-slate-800 pl-6 space-y-4">
+          {% for entry in day_entries %}
+            {% set label, badge = kind_styles.get(entry.kind, ('Update', 'bg-slate-700/40 text-slate-300 ring-slate-600/40')) %}
+            <article class="rounded-xl border border-slate-800 bg-slate-900/40 p-5">
+              <div class="flex flex-wrap items-center gap-3">
+                <span class="rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 {{ badge }}">{{ label }}</span>
+                <h3 class="font-semibold text-slate-100">{{ entry.title }}</h3>
+              </div>
+              {% if entry.summary %}
+                <p class="mt-2 text-sm text-slate-300">{{ entry.summary }}</p>
+              {% endif %}
+              {# Optional outbound link to a GitHub release/PR IF (and only if) the
+                 producer ever supplies one. We surface the friendly "Details"
+                 label — never a raw internal PR number as a user-facing ID
+                 (layout guidance / brief). #}
+              {% if entry.url %}
+                <a
+                  href="{{ entry.url }}"
+                  rel="noopener"
+                  class="mt-3 inline-flex items-center gap-1 text-sm text-sky-400 hover:text-sky-300"
+                >Details →</a>
+              {% endif %}
+            </article>
+          {% endfor %}
+        </div>
+      </section>
+    {% endfor %}
+  </div>
+{% else %}
+  {# Friendly empty state — no internal error text (cross-cutting guidance). #}
+  <div class="rounded-xl border border-slate-800 bg-slate-900/40 p-8 text-center">
+    <p class="text-slate-300">No changelog entries yet.</p>
+    <p class="mt-2 text-sm text-slate-500">
+      Check back soon — new features and fixes will show up here as they ship.
+    </p>
+  </div>
+{% endif %}
+
+{% endblock %}

--- a/botsite/templates/status.html
+++ b/botsite/templates/status.html
@@ -1,0 +1,96 @@
+{% extends "base.html" %}
+{% block title %}Status — SuperBot{% endblock %}
+{% block description %}SuperBot status — the deployed build and when it shipped, as of the last deploy.{% endblock %}
+{% block content %}
+
+{# ── Status / trust band ──────────────────────────────────────────────────────
+   A slim, user-facing trust band (plan §1 / §3): the bot's deployed build + when
+   it shipped, read from the generated site.json.meta.build. v1 source is the
+   GENERATED build-meta only — the public site never reads the bot's private
+   control API (plan §3 hard rule). So this is honestly labelled "as of last
+   deploy" with a "generated" freshness badge — NO live/real-time claim.
+   `build` = {commit, subject, committed_at, branch}, all optional; `site_counts`
+   = {commands, features, games} (from the shared context processor). ─────────── #}
+
+{% set has_build = build and build.commit %}
+
+<section class="border-b border-slate-800 pb-6 mb-8">
+  <div class="flex flex-wrap items-center gap-3">
+    <h1 class="text-3xl font-bold tracking-tight">Status</h1>
+    <span
+      class="rounded bg-slate-800 px-2 py-0.5 text-xs text-slate-400"
+      title="Reflects the last deploy, not a live health check."
+    >generated</span>
+  </div>
+  <p class="mt-3 text-slate-300 max-w-2xl">
+    What's running right now, as of the last deploy. This page is a build-time
+    snapshot — it doesn't poll the bot live.
+  </p>
+</section>
+
+{# ── Online-as-of-last-deploy card ───────────────────────────────────────────
+   The "online" signal is honest: a known build means the bot was deployed and
+   running as of that build. The dot mirrors base.html's posture (green = a build
+   is known; slate = none). We do NOT claim live uptime. #}
+<section class="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+  <div class="flex items-center gap-3">
+    <span class="inline-block h-3 w-3 rounded-full {{ 'bg-emerald-500' if has_build else 'bg-slate-500' }}"></span>
+    <span class="text-lg font-semibold">
+      {% if has_build %}Online as of the last deploy{% else %}Status unavailable{% endif %}
+    </span>
+  </div>
+  {% if has_build %}
+    <dl class="mt-5 grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+      <div class="rounded-lg border border-slate-800 bg-slate-950/40 p-4">
+        <dt class="text-slate-500">Build</dt>
+        <dd class="mt-1 font-mono text-slate-100">{{ build.commit }}</dd>
+      </div>
+      {% if build.committed_at %}
+        <div class="rounded-lg border border-slate-800 bg-slate-950/40 p-4">
+          <dt class="text-slate-500">Deployed build date</dt>
+          <dd class="mt-1 text-slate-100">
+            <time datetime="{{ build.committed_at }}">{{ build.committed_at }}</time>
+          </dd>
+        </div>
+      {% endif %}
+      {% if build.subject %}
+        <div class="rounded-lg border border-slate-800 bg-slate-950/40 p-4 sm:col-span-2">
+          <dt class="text-slate-500">Latest change</dt>
+          <dd class="mt-1 text-slate-200">{{ build.subject }}</dd>
+        </div>
+      {% endif %}
+    </dl>
+    <p class="mt-4 text-xs text-slate-500">
+      Build identifiers are public (they match the open-source repository). This is a
+      generated snapshot — for a live health check we'd label it "live".
+    </p>
+  {% else %}
+    {# Friendly empty state — no internal error text leaked (cross-cutting guidance). #}
+    <p class="mt-4 text-sm text-slate-400">
+      Build information isn't available right now. Please check back shortly.
+    </p>
+  {% endif %}
+</section>
+
+{# ── Honest catalogue counts — supporting trust signal (plan §3 / layout note).
+   NEVER server/user totals (those need the deferred live source). ────────────── #}
+{% if site_counts and (site_counts.commands or site_counts.features or site_counts.games) %}
+  <section class="mt-8">
+    <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-400 mb-3">What's in the box</h2>
+    <div class="grid grid-cols-3 gap-4 max-w-2xl">
+      {% set bands = [
+        (site_counts.commands, 'commands'),
+        (site_counts.features, 'feature areas'),
+        (site_counts.games, 'games')
+      ] %}
+      {% for value, label in bands %}
+        <div class="rounded-xl border border-slate-800 bg-slate-900/40 p-5 text-center">
+          <div class="text-3xl font-bold">{{ value or 0 }}</div>
+          <div class="text-sm text-slate-400">{{ label }}</div>
+        </div>
+      {% endfor %}
+    </div>
+  </section>
+{% endif %}
+
+{% endblock %}

--- a/tests/unit/botsite/test_changelog_status.py
+++ b/tests/unit/botsite/test_changelog_status.py
@@ -1,0 +1,200 @@
+"""Tests for the bot-site changelog + status templates (P3).
+
+Skipped automatically when the web dependencies are not installed (CI installs only
+the bot's ``requirements.txt``), so it never reddens CI; run it locally after
+``pip install -r botsite/requirements.txt``.
+
+Covers the two user-facing pages this unit ships — ``/changelog`` (a curated,
+date-grouped "what's new" timeline) and ``/status`` (an honest, generated-only trust
+band). The load-bearing guarantees: the curated data is rendered, the "generated"
+freshness posture is honest (no live claim), no raw internal PR number leaks onto the
+public changelog, the status band never fabricates server/user totals, and both pages
+have friendly empty states.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")  # Starlette's TestClient transport
+
+from fastapi.testclient import TestClient  # noqa: E402
+from markupsafe import escape as _md_escape  # noqa: E402  - Jinja2's autoescaper
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_APP = _REPO_ROOT / "botsite" / "app.py"
+
+
+@pytest.fixture(scope="module")
+def app_module():
+    spec = importlib.util.spec_from_file_location("botsite_app_changelog_ut", _APP)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def client(app_module):
+    return TestClient(app_module.app)
+
+
+# ---------------------------------------------------------------------------
+# /changelog — curated, date-grouped "what's new" timeline
+# ---------------------------------------------------------------------------
+
+
+def test_changelog_renders_curated_entries(client, app_module):
+    resp = client.get("/changelog")
+    assert resp.status_code == 200
+    entries = app_module.data_loader.load_site_data()["bot_changelog"]
+    assert entries, "fixture precondition: the committed site.json has changelog entries"
+    # The user-facing pieces of each entry are rendered: title, date, summary.
+    # Compare against MarkupSafe's escaped form — Jinja2 autoescapes (e.g. an
+    # apostrophe becomes &#39;), which is the correct safe behaviour, so the raw
+    # string need not appear verbatim. (Use the same escaper Jinja2 uses, not
+    # html.escape, which emits &#x27; instead of &#39;.)
+    for entry in entries:
+        assert str(_md_escape(entry["title"])) in resp.text
+        assert entry["date"] in resp.text
+        if entry["summary"]:
+            assert str(_md_escape(entry["summary"])) in resp.text
+
+
+def test_changelog_shows_kind_tags(client, app_module):
+    # Each entry is tagged feature/fix/improvement; the template maps those kinds to
+    # friendly labels. Assert the label for whatever kinds the data actually carries.
+    resp = client.get("/changelog")
+    assert resp.status_code == 200
+    kinds = {e["kind"] for e in app_module.data_loader.load_site_data()["bot_changelog"]}
+    label_for = {"feature": "New", "improvement": "Improved", "fix": "Fixed"}
+    for kind in kinds:
+        if kind in label_for:
+            assert label_for[kind] in resp.text
+
+
+def test_changelog_carries_generated_freshness_badge(client):
+    # The page declares its generated lineage honestly (plan §3) — not a live feed.
+    resp = client.get("/changelog")
+    assert resp.status_code == 200
+    assert "generated" in resp.text
+    # Honest framing: curated / newest-first, never a real-time claim.
+    assert "newest first" in resp.text.lower()
+
+
+def test_changelog_does_not_leak_raw_pr_numbers(client):
+    # Brief / layout guidance: never surface raw internal PR numbers as user-facing
+    # identifiers. The curated source has no PR ids; assert none leaked into the page
+    # body (e.g. "PR #1109" / "#1109"). We scan the rendered changelog content.
+    import re
+
+    resp = client.get("/changelog")
+    assert resp.status_code == 200
+    # No "PR #<n>" style identifiers anywhere on the user-facing page.
+    assert not re.search(r"PR\s*#\d+", resp.text)
+    # And no bare "#<4+ digit>" tokens (the internal PR-number shape) in the changelog body.
+    assert not re.search(r"#\d{3,}", resp.text)
+
+
+def _patch_empty_data(app_module, tmp_path, monkeypatch):
+    """Make the page routes load the safe empty shape (no committed artifact).
+
+    ``load_site_data`` binds ``DATA_FILE`` as a *default argument* at definition
+    time, so patching the module attribute alone has no effect. Instead wrap the
+    loader to call the real implementation against a missing path — that exercises
+    the genuine missing-artifact fallback rather than faking a return value.
+    """
+    dl = app_module.data_loader
+    real = dl.load_site_data
+    missing = tmp_path / "absent.json"
+    monkeypatch.setattr(dl, "load_site_data", lambda *a, **k: real(missing))
+
+
+def test_changelog_groups_same_date_entries_under_one_heading(app_module):
+    # The committed artifact happens to have one entry per date, so render the
+    # template directly with a synthetic multi-entry-per-date payload to lock in the
+    # timeline grouping: same-date entries collapse under a single date heading, and
+    # newest-first order is preserved.
+    import re
+
+    template = app_module.templates.get_template("changelog.html")
+    entries = [
+        {"date": "2026-06-19", "title": "Alpha", "kind": "feature", "summary": "a"},
+        {"date": "2026-06-19", "title": "Beta", "kind": "fix", "summary": "b"},
+        {"date": "2026-06-01", "title": "Gamma", "kind": "improvement", "summary": "c"},
+        {"date": "2026-05-01", "title": "Delta", "kind": "", "summary": "d"},
+    ]
+    rendered = template.render(
+        {"entries": entries, "page": "changelog", "build": {}, "site_counts": {}},
+    )
+    buckets = re.findall(r'<time datetime="([0-9-]+)">', rendered)
+    # 4 entries / 3 distinct dates → 3 timeline buckets, newest-first.
+    assert buckets == ["2026-06-19", "2026-06-01", "2026-05-01"]
+    assert buckets.count("2026-06-19") == 1  # the two same-date entries share a heading
+    assert "Alpha" in rendered and "Beta" in rendered
+    # An empty kind renders the neutral "Update" label (never blank/broken).
+    assert ">Update<" in rendered
+
+
+def test_changelog_empty_state_is_friendly(client, app_module, tmp_path, monkeypatch):
+    # With no curated entries, the page shows a friendly message — never an error or
+    # a blank page (cross-cutting guidance).
+    _patch_empty_data(app_module, tmp_path, monkeypatch)
+    resp = client.get("/changelog")
+    assert resp.status_code == 200
+    assert "No changelog entries yet" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# /status — honest, generated-only user trust band
+# ---------------------------------------------------------------------------
+
+
+def test_status_renders_build_trust_band(client, app_module):
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    build = app_module.data_loader.build_meta(app_module.data_loader.load_site_data())
+    assert build.get("commit"), "fixture precondition: committed site.json has a build sha"
+    # The deployed build sha is surfaced (it is public — matches the OSS repo).
+    assert build["commit"] in resp.text
+    # The build date, when present, is shown.
+    if build.get("committed_at"):
+        assert build["committed_at"] in resp.text
+
+
+def test_status_is_honest_generated_not_live(client):
+    # The trust band must label itself "as of last deploy" with a "generated" badge,
+    # and must make NO live/real-time claim (plan §3 hard rule — the public site never
+    # reads the bot's private control API).
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    assert "generated" in resp.text
+    assert "as of the last deploy" in resp.text.lower()
+    lowered = resp.text.lower()
+    for forbidden in ("real-time", "live status", "currently online", "uptime:"):
+        assert forbidden not in lowered
+
+
+def test_status_does_not_fabricate_server_or_user_totals(client):
+    # v1 must never render server/user numbers (those need the deferred live source).
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    lowered = resp.text.lower()
+    for forbidden in ("servers using", "active users", "members across", "users online"):
+        assert forbidden not in lowered
+
+
+def test_status_empty_state_is_friendly(client, app_module, tmp_path, monkeypatch):
+    # With no build meta, the band degrades to a friendly "unavailable" message and a
+    # slate (not green) dot — never an error.
+    _patch_empty_data(app_module, tmp_path, monkeypatch)
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    assert "Status unavailable" in resp.text
+    assert "isn't available right now" in resp.text


### PR DESCRIPTION
Builds unit **P3** of the [website two-site split](docs/planning/website-two-site-split-plan-2026-06-19.md) (§5 + the "Site identity & experience" brief + §3 freshness model) on the merged **S1+S2+P1** foundation (#1109/#1110). **Templates only** — the `/changelog` + `/status` routes were wired in P1, so `botsite/app.py` is untouched.

## What shipped (exclusive files)

- **`botsite/templates/changelog.html`** — a curated, user-facing **timeline grouped by date** from `site.json.bot_changelog`. Kind tags (`feature`→New / `improvement`→Improved / `fix`→Fixed; neutral "Update" for untagged), an honest **"generated" freshness badge** (no live claim, §3), and a friendly empty state. Surfaces **no raw internal PR numbers** as user-facing identifiers (brief / layout guidance); the curated source carries no link field today, so it renders an optional outbound "Details →" link **only if** a future producer ever supplies one (future-proof, no coupling).
- **`botsite/templates/status.html`** — a slim **user trust band** from `site.json.meta.build`: online-as-of-last-deploy + build SHA / date / latest-change subject, with a prominent **"generated" badge** ("as of last deploy", **no real-time claim** — the public site never reads the bot's private control API, §3). Plus honest catalogue counts (commands/features/games), **never** fabricated server/user totals. Friendly "unavailable" empty state + slate dot when build meta is absent.
- **`tests/unit/botsite/test_changelog_status.py`** — 10 `importorskip`-guarded tests: curated entries render (HTML-escaped), kind tags, the generated-not-live posture, **no-PR-number leak**, the date-grouping (same-date entries collapse under one heading, newest-first), no server/user totals, and both friendly empty states.

## Verification

- `python3.10 scripts/check_quality.py --full` → **10904 passed, 37 skipped** (CI mirror, Python 3.10).
- `python3.10 scripts/check_architecture.py --mode strict` → 0 errors (web tier never imports `disbot/`).
- All 32 `tests/unit/botsite/` tests green (23 existing P1 + 9 new... 10 with the grouping test).

## Scope / safety

Exclusive-file unit — **no** edits to `botsite/app.py`, the producer, other templates, the plan doc, or `disbot/`. No deploy. Born-red: the `in-progress` session card holds the merge gate until the close-out flips it `complete` as the final step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txth4MHhF5Li6fQJ4koA27

---
_Generated by [Claude Code](https://claude.ai/code/session_01Txth4MHhF5Li6fQJ4koA27)_