### PR TITLE
docs(ideas): capture owner brainstorm — federated Explore hub + AI correction-report/ticket service

### DIFF
--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,20 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`ai-correction-report-and-ticket-service-2026-06-19.md`](./ai-correction-report-and-ticket-service-2026-06-19.md) —
+  **owner-directed (2026-06-19, brainstorm; needs its own extensive session):** when a user corrects the
+  AI, have it **report the correction to the owner** (a write into the owner review inbox, never the public
+  site) — the first step toward an **AI ticket service** (bug reports · server problems · moderation). The
+  hard part the owner named: **audience routing, fail-closed** — the AI must classify *who each report is
+  for* (owner / this server's mods / public) and never leak a server-private issue to the public website.
+  Rails already exist (owner-review-inbox · submissions DB · Hermes triage); it's the AI's first *write*
+  capability, so gated by Q-0048. → relates `planning/owner-review-inbox-plan` · `per-command-feedback-threads`.
+- [`explore-hub-federated-world-2026-06-19.md`](./explore-hub-federated-world-2026-06-19.md) —
+  **owner-directed (2026-06-19, brainstorm):** the **Explore hub** as the missing spine — a *federated*
+  open world where mining/fishing/pets/quests share one character, currency, and a light survival/adventure
+  overlay, **but each subsystem still feels like its own complete game**. Codifies the direction the fishing
+  plan is already drifting toward (shared `game_xp` · unified character · swappable loadouts); homes four
+  separate gated lanes under one world model. → relates `planning/{fishing-open-world-expansion,mining-hub-redesign,rpg-survival-difficulty-design}`.
 - [`plan-homing-guard-2026-06-19.md`](./plan-homing-guard-2026-06-19.md) —
   **session idea (2026-06-19, Q-0089, from the planning-map cleanup):** a stdlib
   `scripts/check_plan_homing.py` asserting every non-`historical` `docs/planning/` doc is linked from a

--- a/docs/ideas/ai-correction-report-and-ticket-service-2026-06-19.md
+++ b/docs/ideas/ai-correction-report-and-ticket-service-2026-06-19.md
@@ -1,0 +1,69 @@
+# AI reports corrections → an audience-routed AI ticket service
+
+> **Status:** `ideas` — **owner-directed (2026-06-19, brainstorm). NEEDS ITS OWN EXTENSIVE SESSION —
+> capture only, not a plan.** Source + the binding contracts win.
+> **Subsystem:** ai — the AI's first write/report capability.
+
+## The owner's framing (verbatim intent)
+
+> *"it should slightly remember stuff about users but not too much to prevent high API costs … it should
+> be able to post on the website as well, like if a user corrects it on something, all it does now is
+> either deny or acknowledge it, but the best thing would be if the AI could actually report this to us,
+> and this would also be a good first step towards the AI ticket service, that allows users to send in bug
+> reports, server problems, moderation things etc. This should be its own extensive session later because
+> it must account for many things, like for who is the report meant, what is the correct response etc, we
+> can't have the AI accidentally send a server bug to the bot website."*
+
+## The seed (near-term) and the vision (later)
+
+- **Seed:** today, when a user corrects the AI, it can only *deny or acknowledge*. Instead, let the AI
+  **file the correction for the owner to review** — a write into the **owner review inbox**, never the
+  public site.
+- **Vision:** an **AI ticket service** — users send **bug reports · server problems · moderation issues**
+  *through the AI*, which triages and routes each to the right audience.
+
+## The hard part (owner-named): audience routing, fail-closed
+
+The central problem is **not** "can the AI write a ticket" — the rails for that mostly exist (below). It is:
+
+> **Can the AI correctly classify *who each report is for* — owner-private · this server's mods · the
+> public bug tracker — with a guard that fails closed so a server-private issue can NEVER leak onto the
+> public website?**
+
+When the classifier is unsure, the safe default is **owner-private, never public**. This is the same
+audience/redaction discipline the website split already enforces by construction (the `site.json`
+fail-closed whitelist) — the ticket router needs an equivalent, applied to *outbound* reports.
+
+## Existing rails (don't rebuild these)
+
+- **Owner review inbox** — the `/reviews` board (Phase 1 shipped #1091);
+  [owner-review-inbox-plan](../planning/owner-review-inbox-plan-2026-06-17.md). *The near-term write target.*
+- **Website submissions DB + moderation pipeline + GitHub-issue mirror** (website split) — the public
+  intake path the ticket service would *route to* only after an explicit human approve step.
+- [per-command-feedback-threads](./per-command-feedback-threads-2026-06-19.md) — AI-moderated per-command
+  feedback; the same moderation/store the ticket service reuses.
+- [hermes-bug-triage-flow](./hermes-bug-triage-flow-2026-06-13.md) (Q-0121) — the triage→curated-issue
+  mechanism; the ticket service is its user-facing front door.
+
+## Why it is gated / design-first (correct, not over-caution)
+
+- This is the AI's **first real write / external capability.** Per the standing **Q-0048** posture,
+  read-only AI ships freely but **writes/external calls need a per-exposure design + lift** — so a careful,
+  dedicated session is the *rule*, not timidity.
+- **Memory stays light** (owner: keep it small to control API cost) — conclusion-style, opt-in, bounded
+  under the **Q-0082** spend ceiling. Memory is a *companion* feature; the reporting/ticket capability is
+  separate and the higher-stakes one.
+
+## What the dedicated session must define (checklist for later)
+
+- The **report schema** (kind: correction / bug / server-problem / moderation; subject; evidence).
+- The **audience classifier** + its **fail-closed default** (unsure → owner-private; never auto-public).
+- **Redaction** — a server's private detail must never cross into a public/GitHub artifact.
+- A mandatory **human approve step** before any report becomes public or a GitHub issue.
+- **Dedup** ("was this already reported?") and **abuse/cost controls** (stranger-grade, Q-0080/Q-0082).
+- The **"correct response"** back to the reporting user (acknowledge · "filed for review" · resolution).
+
+→ relates [owner-review-inbox-plan](../planning/owner-review-inbox-plan-2026-06-17.md) ·
+[per-command-feedback-threads](./per-command-feedback-threads-2026-06-19.md) ·
+[hermes-bug-triage-flow](./hermes-bug-triage-flow-2026-06-13.md) · the website-split redaction contract ·
+the [ai folio](../subsystems/ai.md) · Q-0048 (AI write gate) · Q-0121 (Hermes triage write scope).

--- a/docs/ideas/explore-hub-federated-world-2026-06-19.md
+++ b/docs/ideas/explore-hub-federated-world-2026-06-19.md
@@ -1,0 +1,48 @@
+# The Explore hub — a federated open world (one world, each subsystem its own game)
+
+> **Status:** `ideas` — **owner-directed (2026-06-19, brainstorm).** Not a plan, not approval; capture of
+> the owner's framing so a dedicated planning session starts from it. Source + the binding contracts win.
+> **Subsystem:** games, mining, fishing — the federated open-world spine.
+
+## The owner's framing (verbatim intent)
+
+> *"a bit of survival/RPG as well as adventure and quests, each subsystem like mining and fishing etc
+> should be part of one world but also should feel like their own game."*
+
+## Why this is the missing spine
+
+Mining, fishing, pets, and RPG-survival are each planned as **separate lanes** today
+([fishing](../planning/fishing-open-world-expansion-plan-2026-06-18.md) ·
+[mining-hub-redesign](../planning/mining-hub-redesign-2026-06-15.md) ·
+[rpg-survival](../planning/rpg-survival-difficulty-design-2026-06-10.md) ·
+[pets-companions](../planning/pets-companions-plan-2026-06-09.md)). They all *want* to plug into a shared
+world that **doesn't exist yet** — so defining that world is the single highest-leverage design move: one
+decision homes four gated lanes.
+
+## The principle: a **federated** world
+
+- **Shared (the "one world" half):** one character, one economy/currency, the shared `game_xp` track, a
+  light **survival/RPG + adventure/quest overlay**, and an **Explore hub** that acts as the "town square"
+  you walk out from into each game.
+- **Distinct (the "its own game" half):** each subsystem stays a **complete, satisfying game on its own** —
+  you can just fish, or just mine, and it feels whole without the rest.
+
+This already matches the in-flight direction: the fishing plan (Q-0175) reuses `game_xp`, a unified
+character, and swappable gear-type loadouts — i.e. it was *already* drifting toward "one character across
+games." This idea codifies that into an explicit world model instead of letting each lane re-decide it.
+
+## Open design questions (for the dedicated planning session — do not decide unprompted)
+
+1. **What the hub *is*** — a Discord HubView that routes into each game (Mine · Fish · Explore · …), or a
+   richer map/location model with destinations/biomes that gate which game is reachable where?
+2. **How the survival/adventure overlay attaches** without forcing it on cozy players — difficulty modes
+   (Easy ≡ today's game, byte-identical, per the rpg-survival plan), opt-in stakes, quests as optional goals.
+3. **Where each existing subsystem docks** into the hub (mining-hub-redesign Option A already splits into
+   sub-hubs — the Explore hub is the parent of those).
+4. **Cross-game identity** — a single profile that characterizes a player across games (the per-user
+   identity seed) is the natural front-end for this world.
+
+→ relates [fishing-open-world-expansion-plan](../planning/fishing-open-world-expansion-plan-2026-06-18.md) ·
+[mining-hub-redesign](../planning/mining-hub-redesign-2026-06-15.md) ·
+[rpg-survival-difficulty-design](../planning/rpg-survival-difficulty-design-2026-06-10.md) ·
+[pets-companions](../planning/pets-companions-plan-2026-06-09.md) · the [games folio](../subsystems/games.md).


### PR DESCRIPTION
## Why

Two owner-directed idea captures from a 2026-06-19 brainstorm, so they survive past the chat (this remote container is ephemeral). **Capture only — not plans, not approval.**

## What

- **`explore-hub-federated-world-2026-06-19.md`** — the **Explore hub** as the missing spine: a *federated* open world where mining/fishing/pets/quests share one character, currency, and a light survival/adventure overlay, **but each subsystem still feels like its own complete game**. Codifies the direction the fishing plan is already drifting toward; homes four separate gated game lanes under one world model. Subsystem tag: `games, mining, fishing`.
- **`ai-correction-report-and-ticket-service-2026-06-19.md`** — when a user corrects the AI, have it **report the correction to the owner** (a write into the owner review inbox, never the public site) — the first step toward an **AI ticket service**. The hard part the owner named is captured as the central problem: **fail-closed audience routing** (the AI must classify who each report is for and never leak a server-private issue to the public website). Flagged as needing its own extensive session; gated by Q-0048 (AI's first write capability). Subsystem tag: `ai`.

Both indexed in `docs/ideas/README.md`; subsystem tags verified to parse via `export_dashboard_data._subsystem_tags`.

## Safety

Docs-only (two new idea files + one index edit). No runtime/behavior changes. `check_docs --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS

---
_Generated by [Claude Code](https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS)_