### PR TITLE
docs(ideas): lock in owner brainstorm design + reconcile ledger (#1124–#1126)

### DIFF
--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -207,6 +207,19 @@ Source code and merged PRs win over anything written here.
 > auto-opens a `reconcile` issue at the boundary that fires the docs-reconciliation routine). Reset
 > this marker to the latest PR after a pass.
 
+- **#1126 (2026-06-19, ideas — owner brainstorm capture)** — captured two owner-directed idea docs from a
+  live brainstorm (the **federated Explore hub**: one world / each subsystem its own game; and the **AI
+  correction-report → audience-routed ticket service**), indexed in `ideas/README` with subsystem tags.
+  Later extended in-place with the owner's approved design (the three-track XP + hybrid-gear model; the
+  unified tagged feedback board + dual-gate submission moderation; the opt-in/declared memory policy on
+  `honcho-memory-evaluation`). Docs-only; recorded on sight.
+- **#1125 (2026-06-19, tooling — ledger-drift checker hardening)** — reworked
+  `scripts/check_current_state_ledger.py` (detection window now **scales to the reconciliation marker**;
+  sharper benign-lag-vs-drift split) + its tests, and refreshed the `ledger-guard-benign-lag` /
+  `ledger-window-scale-to-marker` idea docs (tooling + docs; recorded on sight).
+- **#1124 (2026-06-19, docs — planning/audit/idea map cleanup)** — a durable plan index, rebadged stale
+  plans/audits, idea subsystem tags, and de-staled routing pointers across `docs/planning/`,
+  `docs/subsystems/`, and `roadmap.md` (80 files, docs-only; recorded on sight).
 - **#1115 (2026-06-19, ideas — per-command feedback threads + idea→command mapping)** — captured two
   workflow/product ideas (per-command feedback threads · an idea→cog-command mapping) with their idea docs
   + README index entries (docs-only; merged to `main` just after this pass's marker — recorded on sight).

--- a/docs/ideas/ai-correction-report-and-ticket-service-2026-06-19.md
+++ b/docs/ideas/ai-correction-report-and-ticket-service-2026-06-19.md
@@ -34,6 +34,36 @@ When the classifier is unsure, the safe default is **owner-private, never public
 audience/redaction discipline the website split already enforces by construction (the `site.json`
 fail-closed whitelist) — the ticket router needs an equivalent, applied to *outbound* reports.
 
+## The unified feedback board + submission moderation (owner direction — 2026-06-19)
+
+**One destination, richly tagged.** Every item routes to **one board** (a web page) but carries visible
+facets — **type** (bug · idea · suggestion · comment · correction · moderation-flag) and **source/location**
+(which server · who · which front door) — so it filters cleanly by type and origin. This is the **owner
+review inbox (`/reviews`, shipped #1091) generalized** — add `type` + `location` facets to its schema and
+it *is* the unified board. **Owner board = the full firehose (all servers, filterable); the public bot-site
+shows only items explicitly promoted** (the website-split redaction model: owner sees all, public sees a
+whitelist).
+
+**Convergence worth keeping:** the provenance you want for *filtering* is the **same metadata the
+fail-closed audience guard needs to never leak a server-private item to public.** Building the filter
+builds the guard's input — the UX feature and the safety feature are one feature.
+
+**Submission moderation — a second AI gate, with the *opposite* fail-safe direction.** The website
+AI-monitors user submissions (aliases, comments, …) for foul language / pranks, but:
+
+- **This gate fails OPEN.** No foul language detected → **allow**, even if it *might* be a prank. The harm
+  to avoid is **silencing a legitimate user on suspicion** — never block a clean proposal just because it
+  *could* be a joke.
+- Contrast the report/ticket **audience guard, which fails CLOSED** (unsure who it's for → keep private).
+  **Two gates, opposite safe defaults, both correct** — they protect different harms (over-censoring users
+  vs. over-exposing data). A future session must **not** flatten them into one uniform "when unsure, block."
+- **Three-way outcome, not binary:** confident foul language → **block**; uncertain / maybe-prank →
+  **allow + soft-flag** to the board (`type: moderation-flag`) for optional human review; clean → allow
+  silently. The flag is just one more tagged item on the same board.
+- **Cost:** a free lexical pre-filter (wordlist/regex) handles the obvious slurs; the paid AI only
+  adjudicates the ambiguous remainder — the same metered pattern as the existing image moderation (Q-0082),
+  so it stays under the spend ceiling.
+
 ## Existing rails (don't rebuild these)
 
 - **Owner review inbox** — the `/reviews` board (Phase 1 shipped #1091);

--- a/docs/ideas/explore-hub-federated-world-2026-06-19.md
+++ b/docs/ideas/explore-hub-federated-world-2026-06-19.md
@@ -31,6 +31,39 @@ This already matches the in-flight direction: the fishing plan (Q-0175) reuses `
 character, and swappable gear-type loadouts — i.e. it was *already* drifting toward "one character across
 games." This idea codifies that into an explicit world model instead of letting each lane re-decide it.
 
+## Progression & gear model (owner direction — 2026-06-19, raw but decided)
+
+The owner's answer to "what's shared vs. siloed" is **both, separated by which pool** — three XP tracks,
+each with a distinct job:
+
+| Track | Earned by | Spent on | Purpose |
+|---|---|---|---|
+| **Message XP** | chatting (the existing social/level track) | — | drives **negotiation leverage vs. the AI Dungeon Master** (chat more → bargain better) — fuses the chat-AI and the game world. |
+| **Global game XP** | playing *any* game (slow trickle) | **global** game skills | a leg-up that applies everywhere — *including games you haven't started yet*. |
+| **Per-game XP** | playing *that* game (fast) | *that game's* skill tree only | keeps each game its own mastery climb. |
+
+- **Keep the existing `game_xp` vs message-XP split.** Message-XP stays as-is; the new hook is its
+  DM-negotiation use. `game_xp` becomes the **global** pool; the **per-game** track is the new layer.
+  Mining already has a skill tree — it is the working prototype.
+- **The leg-up comes from the global pool + shared resources/gear, never from per-game competence.** A
+  master miner picking up a rod starts the *fishing tree at zero* (still a real game to learn) but isn't
+  helpless (global skills + good materials + a generalist loadout). That knife-edge is what keeps it *one
+  world* and *each its own game*.
+- **Earning split:** every game feeds its own tree (fast) **and** the global pool (slow trickle).
+- **Skill division of labor** (so neither tree feels pointless): global = broad utilities (stamina, carry,
+  luck, xp-gain); per-game = signature mechanics (mining: vein-sense/fortune; fishing: line-tension/rare-bait).
+
+**Gear — hybrid (some shared, some game-bound):**
+- A **generalist loadout** that works across games is possible and encouraged.
+- An **auto-equip-strongest-for-this-game** option exists but **defaults OFF** and **prompts on first
+  equip** (never silently re-optimize someone's gear). This per-user toggle lives in **per-user config** —
+  the same surface as the memory controls (see `honcho-memory-evaluation`).
+
+**Interdependence without dependency (the world philosophy):** no game is required to play another, but
+they *feed* each other through resource loops — fish → food enabling deeper mining; mine/chop → materials
+for a better rod/boat. **Loops are accelerators, never gates** — the line never to cross is *"can't mine
+past depth N without food."*
+
 ## Open design questions (for the dedicated planning session — do not decide unprompted)
 
 1. **What the hub *is*** — a Discord HubView that routes into each game (Mine · Fish · Explore · …), or a

--- a/docs/ideas/honcho-memory-evaluation-2026-06-16.md
+++ b/docs/ideas/honcho-memory-evaluation-2026-06-16.md
@@ -14,6 +14,28 @@ user across conversations* — their preferences, past questions, running contex
 instead of starting from scratch every time. This is the V-04 "per-user preferences" vision item made
 real for the AI surface.
 
+## Owner-specified memory policy (2026-06-19) — opt-in, user-controlled
+
+The owner specified *how* this memory must behave (the policy; Honcho below is one possible *how-built*):
+
+- **Always opt-in.** Memory is never silently on. A per-user **enable/disable** toggle lives in the
+  **per-user configuration** surface (the same home as the auto-gear-swap toggle in
+  `explore-hub-federated-world`).
+- **User-chosen scope.** Each user picks **global** (across servers) or **per-guild** (this server only) —
+  scope is the *user's* choice, not a system-wide default.
+- **Declared memory.** Users can author facts directly: **`remember this: …`**. Declared memory is the
+  natural v1 — **cheaper** (no inference pass), **more accurate** (no hallucinated "facts"), and **more
+  trustworthy** (they see exactly what is stored). It is *literally* the "keep API costs low" answer.
+  *Inferred* memory (the Honcho-style conclusion extraction below) is an optional, budgeted later layer.
+- **See + forget controls.** If users can add, they must review and delete:
+  `what do you remember about me?` / `forget …` (or `forget everything`). For a public bot this is
+  table-stakes (right-to-be-forgotten), not polish.
+- **Server-level override.** A server admin can disable bot memory server-wide; **most-restrictive-wins**
+  (server-off beats user-on). Cheap to design in now, painful to retrofit.
+
+*(Source: owner brainstorm 2026-06-19. The Honcho evaluation below is the tooling / how-built companion to
+this policy.)*
+
 ## What Honcho is (the tool that fits)
 
 Honcho (Plastic Labs, open-source) is an agent **memory / social-cognition layer**: it models each


### PR DESCRIPTION
## Why

Locks the owner-approved design from the 2026-06-19 brainstorm into its durable homes (so it doesn't live only in chat), and reconciles the living ledger. Docs/ledger only.

## What

**Design captures (extending existing idea docs):**
- `explore-hub-federated-world` — the three-track XP model (message-XP → AI-DM negotiation / global game-XP → cross-game skills / per-game XP → own tree), hybrid gear with an opt-in auto-best toggle (default **off**, prompt on first equip), and resource loops as **accelerators, never gates**.
- `ai-correction-report-and-ticket-service` — the unified **tagged feedback board** (type + source/location; owner-firehose vs. public-promote) and **dual-gate submission moderation**: the moderation gate **fails OPEN** (never silence a user on prank-suspicion) while the audience guard **fails CLOSED** — two opposite-but-correct safe defaults. Free lexical pre-filter before the paid AI call.
- `honcho-memory-evaluation` — the owner **memory policy**: opt-in, user-chosen global/per-guild scope, declared `remember this:`, see/forget controls, server-level override (most-restrictive-wins).

**Ledger reconcile:** add **#1124, #1125, #1126** to `current-state.md` § Recently shipped. #1125's hardened checker (window scales to the reconciliation marker) now reports `last 15 merged PRs all present ✓`.

## Safety

Docs/ledger only — no runtime changes. `check_docs --strict` and `check_current_state_ledger.py --strict` both green; subsystem tags verified to parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS

---
_Generated by [Claude Code](https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS)_