### PR TITLE
A1: mining hub declutter (Option A PR2 — Character + Explore sub-hubs)

### DIFF
--- a/.sessions/2026-06-19-mining-hub-declutter.md
+++ b/.sessions/2026-06-19-mining-hub-declutter.md
@@ -1,13 +1,88 @@
 # Session — mining hub declutter (Option A PR2)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Lane:** ultracode A1 — Mining hub redesign Option A, PR2 ("hub declutter").
-**About to do:** slim `MiningHubView` from 14 buttons to the 6 of Option A (Mine · Harvest ·
-Explore · Character · Gear · Workshop); add a new **Character** sub-hub
-(Overview/Inventory/Stats/Skills/Vault/Home) and an **Explore** open-world *stub* sub-hub
-(Fishing/Roam/Quests "coming soon"); fold Descend/Ascend + the old mining random-event explore
-into the Mine action (`MineView`). Tests + docs + PR. PR3 (grid Mine) is OUT OF SCOPE.
 
-(Close-out — session idea, previous-session review, doc audit — filled in at the end; the
-status flips to `complete` as the deliberate final step.)
+## Arc
+
+Slimmed the headline mining hub from 14 buttons (5 rows) to the 6 of owner-picked Option A,
+and grouped the rest into dedicated sub-hubs mirroring the existing `MiningWorkshopHubView`
+template. PR3 (grid Mine) is owner-sign-off-gated — explicitly out of scope.
+
+## Shipped (PR #1131)
+
+Main hub → **6 buttons**: ⛏️ Mine · 🌲 Harvest · 🗺️ Explore · 🧍 Character · 🧰 Gear · 🔨 Workshop.
+
+- **NEW `disbot/views/mining/character_hub.py`** — `MiningCharacterHubView`: Overview ·
+  Inventory · Stats · Skills · Vault · Home. The Inventory/Stats button bodies (inline DB
+  reads) and `_render_inventory_file` moved here from `main_panel.py`.
+- **NEW `disbot/views/mining/explore_hub.py`** — `MiningExploreHubView`: open-world explorer
+  **stub** (Fishing/Roam/Quests "coming soon"). Pure stub — no fishing-module wiring. Uses
+  the new `custom_id mining:explore_hub` (distinct from the old `mining:explore`).
+- **`main_panel.py`** — trimmed to the 6 Option A actions; `_ACTIONS_GUIDE` /
+  `build_overview_embed` / `build_embed` text updated to match.
+- **`mine_view.py`** — folded Descend/Ascend + the depth-tied mining random-event explore
+  into `MineView` (row 1), each swapping to the navigable `_MineResultsView`.
+- **Tests** — new `test_mining_character_hub.py` + `test_mining_explore_hub.py`; updated
+  `test_mining_no_root_overview` (6-button IA), `test_mining_descent` (movement now in
+  `MineView`), `test_mining_inplace_cards` (inventory in Character hub), `test_mining_cog_dm_guard`
+  (new button set + sub-hub guards).
+- **Docs** — plan PR2 marked shipped; games folio updated.
+
+**Verified:** `python3.10 scripts/check_quality.py --full` GREEN (10888 passed, 44 skipped;
+mypy clean; ruff clean on `disbot/` after fixing two D209 docstrings) ·
+`python3.10 scripts/check_architecture.py --mode strict` 0 errors (only pre-existing known
+WARNs) · mining test subset 49/49.
+
+**Deviations (flagged in PR #1131 for owner review):**
+1. **Home placement** — `🏠 Home` placed in the Character sub-hub (it personalizes the
+   Character card; the plan's Character list predated the Home feature #910).
+2. **Explore name-clash routing** — the main hub's new `🗺️ Explore` opens the *open-world*
+   stub; the depth-tied mining random-event "explore" is a *different concept* and folded
+   into the Mine action as an interim until PR3's grid Mine.
+
+## 📤 Run report
+
+- **Did:** mining hub declutter to Option A 6-button IA + Character/Explore sub-hubs (fleet A1).
+  · **Outcome:** shipped
+- **Shipped:** #1131
+- **Run type:** `dispatch · fleet-unit`
+- **⚑ Self-initiated:** none (executed the owner-approved plan PR2 verbatim, within lane).
+- **⚑ Owner decisions needed:** live-verify the new layout after deploy (UI reorg, fully
+  reversible); confirm the two documented deviations (Home placement, Explore routing).
+
+## 💡 Session idea
+
+**A persistent-view custom_id drift guard.** This declutter changed `MiningHubView`'s
+component set (removed buttons, renamed `mining:explore` → `mining:explore_hub`). Old posted
+panels are superseded — acceptable for a redesign — but there is no automated signal when a
+`@register`-ed PersistentView's `custom_id` set changes, which is exactly the kind of change
+that can silently break restore paths or orphan live messages. A small check that snapshots
+each registered PersistentView's `{custom_id}` set into a committed fixture and fails (warn-
+tier) on drift would make every such change *deliberate and reviewed* — the same "pin the
+contract so a refactor can't drop it silently" instinct the mining tests already use, lifted
+to the registry level. Cheap, verifiable, disposable if noisy.
+
+## ⟲ Previous-session review
+
+The previous fleet session (B2, #1086 — ledger-hygiene linter) did the right disposable-tool
+thing: a read-only, warn-only linter with a provenance header, shipped with 19 tests. Its
+notable miss was *coverage of its own kill-switch claim* — it documents "delete if unreliable"
+but ships no signal for **when** it has proven reliable enough to graduate, so the next agent
+has no objective bar. **Concrete system improvement:** adopted convenience checks should record
+a tiny "confirmed-correct N times across sessions" tally in their header (incremented when an
+agent verifies the tool against ground truth), turning the vague "verify a few times" rule into
+a visible, decrementing-toward-trust counter — the missing back-half of the Q-0105 adopt-with-
+kill-switch loop.
+
+## Doc audit (Q-0104)
+
+- `check_docs.py --strict` → exit 0, all reachable (one *soft* recently-shipped ratchet warning,
+  which belongs to the orchestrator-owned `current-state.md` ledger — not editable from this
+  lane by hard rule).
+- Plan doc (`mining-hub-redesign-2026-06-15.md`) PR2 marked shipped with PR #; games folio
+  updated with the new sub-hub structure. New source files are reachable via the plan's source
+  anchors + the folio note.
+- `current-state.md` is intentionally untouched (HARD RULE for this lane); the next
+  reconciliation pass folds PR #1131 into the living ledger.

--- a/.sessions/2026-06-19-mining-hub-declutter.md
+++ b/.sessions/2026-06-19-mining-hub-declutter.md
@@ -1,0 +1,13 @@
+# Session — mining hub declutter (Option A PR2)
+
+> **Status:** `in-progress`
+
+**Lane:** ultracode A1 — Mining hub redesign Option A, PR2 ("hub declutter").
+**About to do:** slim `MiningHubView` from 14 buttons to the 6 of Option A (Mine · Harvest ·
+Explore · Character · Gear · Workshop); add a new **Character** sub-hub
+(Overview/Inventory/Stats/Skills/Vault/Home) and an **Explore** open-world *stub* sub-hub
+(Fishing/Roam/Quests "coming soon"); fold Descend/Ascend + the old mining random-event explore
+into the Mine action (`MineView`). Tests + docs + PR. PR3 (grid Mine) is OUT OF SCOPE.
+
+(Close-out — session idea, previous-session review, doc audit — filled in at the end; the
+status flips to `complete` as the deliberate final step.)

--- a/disbot/views/mining/character_hub.py
+++ b/disbot/views/mining/character_hub.py
@@ -1,0 +1,292 @@
+"""Character sub-hub — the "everything about you" group of the mining hub.
+
+Part of the Option A hub declutter (owner-directed, 2026-06-15;
+``docs/planning/mining-hub-redesign-2026-06-15.md``): the main mining hub shrinks
+to 6 buttons, and this sub-hub absorbs the player-centric actions —
+**Overview** (the read-only character stat card), **Inventory**, **Stats**,
+**Skills**, **Vault**, and **Home**.
+
+Home placement (deviation flagged for owner review, 2026-06-19): the plan's
+Character list predates the Home feature (#910). Home personalizes the Character
+card, so it lives here in the Character sub-hub rather than on the main hub.
+
+Each button renders **in place** (the ``main_panel`` child-opener pattern); this
+view owns no game logic, it only groups. Writes still flow through
+``services.mining_workflow`` from inside the panels it opens. Authority is
+re-checked at callback time via ``HubView``'s invoker lock + the per-callback
+guild guard (mirrors the main hub).
+"""
+
+from __future__ import annotations
+
+import discord
+
+from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
+from utils import db
+from utils.mining import items
+from utils.ui_constants import MINING_COLOR
+from views.base import HubView
+
+# Display labels for the typed Inventory panel, keyed by ItemKind.value
+# (string keys keep this rendering table independent of the enum). Mirrors the
+# table the Inventory button used on the main hub before the declutter.
+_KIND_LABELS: dict[str, str] = {
+    "resource": "⛏️ Resources",
+    "tool": "🛠️ Tools",
+    "consumable": "🧨 Consumables",
+    "structure": "🏛️ Structures",
+    "treasure": "💎 Treasure",
+}
+
+_GUIDE = (
+    "**🧍 Overview** — your full character profile (location, gear, level, worth)\n"
+    "**📦 Inventory** — view your mining resources\n"
+    "**📊 Stats** — view your mining statistics\n"
+    "**🌳 Skills** — spend skill points to specialize your character\n"
+    "**🏦 Vault** — stash loot safely, separate from your pack\n"
+    "**🏠 Home** — build it to personalize your Character card"
+)
+
+_INVENTORY_FILENAME = "inventory.png"
+
+
+def build_character_hub_embed() -> discord.Embed:
+    """The Character sub-hub overview (static — the panels own live state)."""
+    embed = discord.Embed(
+        title="🧍 Character — everything about you",
+        description=_GUIDE,
+        color=MINING_COLOR,
+    )
+    embed.set_footer(text="Only you can interact with this panel.")
+    return embed
+
+
+def _render_inventory_file(
+    display_name: str,
+    inventory: dict[str, int],
+    embed: discord.Embed,
+) -> discord.File | None:
+    """Render the PIL inventory card and wire it into *embed* as the in-place
+    image. Returns the File to attach (or ``None`` without Pillow — additive,
+    the text embed already carries the full inventory). Mirrors the helper the
+    Inventory button used on the main hub before the declutter.
+    """
+    import io
+
+    from utils.mining_render import build_card_spec, render_inventory_card
+
+    spec = build_card_spec(
+        f"{display_name}'s Mining Inventory",
+        items.sort_inventory(inventory),
+        classify_kind=lambda n: items.classify(n).value,
+        footer=f"Net worth: {items.total_value(inventory)}",
+    )
+    png = render_inventory_card(spec)
+    if png is None:
+        return None
+    embed.set_image(url=f"attachment://{_INVENTORY_FILENAME}")
+    return discord.File(io.BytesIO(png), filename=_INVENTORY_FILENAME)
+
+
+class MiningCharacterHubView(HubView):
+    """Sub-hub grouping Overview / Inventory / Stats / Skills / Vault / Home.
+
+    A child of the mining hub.
+    """
+
+    SUBSYSTEM = "mining"
+
+    def __init__(self, author: discord.Member | discord.User, guild_id: int) -> None:
+        super().__init__(author)
+        self.guild_id = guild_id
+
+    async def _edit_in_place(
+        self,
+        interaction: discord.Interaction,
+        *,
+        embed: discord.Embed,
+        view: discord.ui.View,
+        image: discord.File | None = None,
+    ) -> None:
+        """Edit the sub-hub's anchor message in place, owning its optional image.
+
+        The inventory card renders *into* this one message instead of a separate
+        ephemeral follow-up; every other action passes no image, which clears a
+        prior card so it never lingers on the next screen.
+        """
+        await safe_edit(
+            interaction,
+            embed=embed,
+            view=view,
+            attachments=[image] if image is not None else [],
+        )
+
+    @discord.ui.button(label="🧍 Overview", style=discord.ButtonStyle.primary, row=0)
+    async def overview_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ):
+        if not await safe_defer(interaction):
+            return
+        if interaction.guild_id is None:
+            await safe_followup(
+                interaction,
+                "Mining is only available inside a guild.",
+                ephemeral=True,
+            )
+            return
+        # Read-only character overview, shown in place on the sub-hub.
+        from views.mining.character_panel import build_character_embed
+
+        embed = await build_character_embed(
+            interaction.user.id,
+            interaction.guild_id,
+            name=interaction.user.display_name,
+        )
+        embed.set_footer(text="Pick another action above to continue.")
+        await self._edit_in_place(interaction, embed=embed, view=self)
+
+    @discord.ui.button(label="📦 Inventory", style=discord.ButtonStyle.grey, row=0)
+    async def inventory_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ):
+        if not await safe_defer(interaction):
+            return
+        if interaction.guild_id is None:
+            await safe_followup(
+                interaction,
+                "Mining is only available inside a guild.",
+                ephemeral=True,
+            )
+            return
+        user_id = str(interaction.user.id)
+        inventory = await db.get_mining_inventory(user_id, interaction.guild_id)
+        embed = discord.Embed(
+            title=f"📦 {interaction.user.name}'s Mining Inventory",
+            color=MINING_COLOR,
+        )
+        if not inventory:
+            # Empty-state UX rule (mother-hub-map.md): explain what the
+            # feature does and what the next step is.
+            embed.description = (
+                "Your mining inventory is empty. Use `!mine` in the mining "
+                "channel to start collecting items."
+            )
+            embed.set_footer(text="Pick another action above to continue.")
+        else:
+            for kind, rows in items.summarize_inventory(inventory):
+                embed.add_field(
+                    name=_KIND_LABELS.get(kind.value, kind.value.title()),
+                    value="\n".join(f"**{name.title()}** ×{qty}" for name, qty in rows),
+                    inline=False,
+                )
+            embed.set_footer(
+                text=(
+                    f"Net worth: {items.total_value(inventory)}  •  "
+                    "Pick another action above to continue."
+                ),
+            )
+        image = (
+            _render_inventory_file(interaction.user.display_name, inventory, embed)
+            if inventory
+            else None
+        )
+        await self._edit_in_place(interaction, embed=embed, view=self, image=image)
+
+    @discord.ui.button(label="📊 Stats", style=discord.ButtonStyle.grey, row=0)
+    async def stats_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not await safe_defer(interaction):
+            return
+        if interaction.guild_id is None:
+            await safe_followup(
+                interaction,
+                "Mining is only available inside a guild.",
+                ephemeral=True,
+            )
+            return
+        user_id = str(interaction.user.id)
+        inventory = await db.get_mining_inventory(user_id, interaction.guild_id)
+        total_items = sum(inventory.values())
+        unique_items = len(inventory)
+        embed = discord.Embed(
+            title=f"📊 {interaction.user.name}'s Mining Stats",
+            color=MINING_COLOR,
+        )
+        embed.add_field(name="Total Items Collected", value=str(total_items))
+        embed.add_field(name="Unique Items", value=str(unique_items))
+        embed.add_field(name="Net Worth", value=str(items.total_value(inventory)))
+        embed.set_footer(text="Pick another action above to continue.")
+        await self._edit_in_place(interaction, embed=embed, view=self)
+
+    @discord.ui.button(label="🌳 Skills", style=discord.ButtonStyle.primary, row=1)
+    async def skills_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not await safe_defer(interaction):
+            return
+        if interaction.guild_id is None:
+            await safe_followup(
+                interaction,
+                "Mining is only available inside a guild.",
+                ephemeral=True,
+            )
+            return
+        from views.mining.skills_panel import MiningSkillsView, build_skills_embed
+
+        embed = await build_skills_embed(interaction.user.id, interaction.guild_id)
+        view = MiningSkillsView(interaction.user, interaction.guild_id)
+        await self._edit_in_place(interaction, embed=embed, view=view)
+
+    @discord.ui.button(label="🏦 Vault", style=discord.ButtonStyle.primary, row=1)
+    async def vault_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not await safe_defer(interaction):
+            return
+        if interaction.guild_id is None:
+            await safe_followup(
+                interaction,
+                "Mining is only available inside a guild.",
+                ephemeral=True,
+            )
+            return
+        from views.mining.vault_panel import MiningVaultView, build_vault_embed
+
+        embed = await build_vault_embed(interaction.user.id, interaction.guild_id)
+        view = MiningVaultView(interaction.user, interaction.guild_id)
+        await self._edit_in_place(interaction, embed=embed, view=view)
+
+    @discord.ui.button(label="🏠 Home", style=discord.ButtonStyle.primary, row=1)
+    async def home_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not await safe_defer(interaction):
+            return
+        if interaction.guild_id is None:
+            await safe_followup(
+                interaction,
+                "Mining is only available inside a guild.",
+                ephemeral=True,
+            )
+            return
+        from views.mining.home_panel import MiningHomeView, build_home_embed
+
+        embed = await build_home_embed(interaction.user.id, interaction.guild_id)
+        view = MiningHomeView(interaction.user, interaction.guild_id)
+        await self._edit_in_place(interaction, embed=embed, view=view)
+
+    @discord.ui.button(label="↩ Mining Hub", style=discord.ButtonStyle.secondary, row=2)
+    async def back_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        from views.mining.main_panel import MiningHubView, build_overview_embed
+
+        embed = await build_overview_embed(
+            self._author.id,
+            self.guild_id,
+            name=getattr(self._author, "display_name", None),
+        )
+        await interaction.response.edit_message(
+            embed=embed,
+            view=MiningHubView(),
+            attachments=[],
+        )
+        self.stop()
+
+
+__all__ = ["MiningCharacterHubView", "build_character_hub_embed"]

--- a/disbot/views/mining/explore_hub.py
+++ b/disbot/views/mining/explore_hub.py
@@ -1,0 +1,128 @@
+"""Explore sub-hub — the open-world explorer group of the mining hub (STUB).
+
+Part of the Option A hub declutter (owner-directed, 2026-06-15;
+``docs/planning/mining-hub-redesign-2026-06-15.md``): the main mining hub shrinks
+to 6 buttons, and the new ``🗺️ Explore`` button opens this **open-world** sub-hub.
+
+Name-clash note (deviation flagged for owner review, 2026-06-19): this open-world
+Explore is a *different concept* from the existing depth-tied mining random-event
+"explore" — the latter is a mining mechanic that folded into the Mine action
+(``MineView``) in this same PR. This sub-hub is the open-world explorer the owner
+asked for ("a separate open-world explorer, not tied to mine depth"); its exact
+commands are undefined, so it ships as a **pure stub / "early" hub**.
+
+The Fishing / Roam / Quests buttons show an in-place "coming soon" message and are
+deliberately **not** wired into any fishing module or any file outside this lane —
+fishing v1 lives in separate modules a future design pass / other lane owns.
+
+Authority is re-checked at callback time via ``HubView``'s invoker lock + the
+per-callback guild guard (mirrors the main hub).
+"""
+
+from __future__ import annotations
+
+import discord
+
+from core.runtime.interaction_helpers import safe_defer, safe_edit
+from utils.ui_constants import MINING_COLOR
+from views.base import HubView
+
+_GUIDE = (
+    "_Open-world exploration — **early / coming soon**. Unlike the mine (which is "
+    "tied to depth), this is a free-roam overworld. The activities below are being "
+    "designed; the buttons preview what's planned._\n\n"
+    "**🎣 Fishing** — cast a line in lakes and rivers _(coming soon)_\n"
+    "**🧭 Roam** — wander the overworld and stumble on places _(coming soon)_\n"
+    "**📜 Quests** — pick up and track objectives _(coming soon)_"
+)
+
+
+def build_explore_hub_embed() -> discord.Embed:
+    """The Explore sub-hub overview (static stub — no live state yet)."""
+    embed = discord.Embed(
+        title="🗺️ Explore — open world (early)",
+        description=_GUIDE,
+        color=MINING_COLOR,
+    )
+    embed.set_footer(text="Only you can interact with this panel.")
+    return embed
+
+
+def _coming_soon_embed(feature: str, blurb: str) -> discord.Embed:
+    """An in-place 'coming soon' card for a stubbed Explore activity."""
+    embed = discord.Embed(
+        title=f"{feature} — coming soon",
+        description=(
+            f"{blurb}\n\n"
+            "This is part of the open-world Explore hub, which is **early** and still "
+            "being designed. It isn't playable yet — pick another option above, or "
+            "head back to the mining hub."
+        ),
+        color=MINING_COLOR,
+    )
+    embed.set_footer(text="Pick another action above to continue.")
+    return embed
+
+
+class MiningExploreHubView(HubView):
+    """Sub-hub for the open-world explorer (Fishing / Roam / Quests).
+
+    A stub child of the mining hub — no game logic, every activity is a
+    placeholder.
+    """
+
+    SUBSYSTEM = "mining"
+
+    def __init__(self, author: discord.Member | discord.User, guild_id: int) -> None:
+        super().__init__(author)
+        self.guild_id = guild_id
+
+    @discord.ui.button(label="🎣 Fishing", style=discord.ButtonStyle.primary, row=0)
+    async def fishing_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not await safe_defer(interaction):
+            return
+        embed = _coming_soon_embed(
+            "🎣 Fishing",
+            "Cast a line in lakes and rivers for fish, junk, and the occasional "
+            "treasure.",
+        )
+        await safe_edit(interaction, embed=embed, view=self, attachments=[])
+
+    @discord.ui.button(label="🧭 Roam", style=discord.ButtonStyle.primary, row=0)
+    async def roam_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not await safe_defer(interaction):
+            return
+        embed = _coming_soon_embed(
+            "🧭 Roam",
+            "Wander the overworld and stumble on biomes, landmarks, and encounters.",
+        )
+        await safe_edit(interaction, embed=embed, view=self, attachments=[])
+
+    @discord.ui.button(label="📜 Quests", style=discord.ButtonStyle.primary, row=0)
+    async def quests_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        if not await safe_defer(interaction):
+            return
+        embed = _coming_soon_embed(
+            "📜 Quests",
+            "Pick up objectives, track progress, and earn rewards for completing them.",
+        )
+        await safe_edit(interaction, embed=embed, view=self, attachments=[])
+
+    @discord.ui.button(label="↩ Mining Hub", style=discord.ButtonStyle.secondary, row=1)
+    async def back_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+        from views.mining.main_panel import MiningHubView, build_overview_embed
+
+        embed = await build_overview_embed(
+            self._author.id,
+            self.guild_id,
+            name=getattr(self._author, "display_name", None),
+        )
+        await interaction.response.edit_message(
+            embed=embed,
+            view=MiningHubView(),
+            attachments=[],
+        )
+        self.stop()
+
+
+__all__ = ["MiningExploreHubView", "build_explore_hub_embed"]

--- a/disbot/views/mining/main_panel.py
+++ b/disbot/views/mining/main_panel.py
@@ -4,22 +4,26 @@ Pattern B placement per ``docs/architecture.md`` §"PersistentView
 placement": the view lives in views/ and the cog re-exports for the
 persistent-view registry side-effect.
 
+Option A declutter (owner-directed, 2026-06-15;
+``docs/planning/mining-hub-redesign-2026-06-15.md``): the main hub is six
+buttons — **⛏️ Mine · 🌲 Harvest · 🗺️ Explore · 🧍 Character · 🧰 Gear ·
+🔨 Workshop** — and everything else moved into a sub-hub or the Mine action:
+
+- **🧍 Character** sub-hub (``character_hub``): Overview · Inventory · Stats ·
+  Skills · Vault · Home.
+- **🗺️ Explore** sub-hub (``explore_hub``): the open-world explorer (Fishing /
+  Roam / Quests), a stub for now. *Distinct* from the old depth-tied mining
+  random-event "explore", which folded into the Mine action.
+- **🔨 Workshop** sub-hub (``workshop_hub``): Craft · Repair · Forge · Market.
+- **Mine** (``MineView``) absorbed Descend / Ascend + the old mining-explore
+  random-event as an interim until PR3's grid Mine.
+
 The Mine button opens a fresh ephemeral ``MineView`` from
-``views.mining.mine_view``.  Harvest / Explore / Inventory / Stats
-buttons call DB helpers directly — no cog round-trip needed.  The
-Build button opens ``_BuildModal`` which loads the current recipes
-list and validates the user's inventory.
+``views.mining.mine_view``.
 
 Navigation rule (PR #1 menu-lifecycle fix): the hub does not ship a
-root-level "↩ Overview" button. Such a button would be a no-op when
-the hub is already on its root state, violating the architecture
-rule that root panels must not show no-op Overview controls. Action
-buttons themselves are the navigation surface; after a Harvest /
-Explore / Inventory / Stats action, the embed shows the result and
-the user can click any action button to take the next step. The
-``_MineResultsView`` in ``views.mining.mine_view`` retains its own
-"↩ Mining Menu" button because it IS a child screen returning to
-this hub's root.
+root-level "↩ Overview" button. Action buttons themselves are the
+navigation surface; sub-hubs return via their own "↩ Mining Hub" button.
 """
 
 from __future__ import annotations
@@ -31,35 +35,19 @@ from core.runtime.persistent_views import PersistentView, register
 from services import mining_workflow
 from utils import db, equipment
 from utils.mining import capacity, items, workshop, world
-from utils.ui_constants import ERROR_COLOR, MINING_COLOR, SUCCESS_COLOR
+from utils.ui_constants import MINING_COLOR, SUCCESS_COLOR
 from views.mining.mine_view import MineView, _build_mine_prompt_embed
 
-# Display labels for the typed Inventory panel, keyed by ItemKind.value
-# (string keys keep this rendering table independent of the enum).
-_KIND_LABELS: dict[str, str] = {
-    "resource": "⛏️ Resources",
-    "tool": "🛠️ Tools",
-    "consumable": "🧨 Consumables",
-    "structure": "🏛️ Structures",
-    "treasure": "💎 Treasure",
-}
-
 # The hub's routing guide — shared by the stateless fallback embed and the
-# per-player live overview so the action list has one home.
+# per-player live overview so the action list has one home. Six top-level
+# actions; each detailed list lives on its sub-hub (Option A declutter).
 _ACTIONS_GUIDE = (
-    "**⛏️ Mine** — start a mining session\n"
+    "**⛏️ Mine** — dig for ore, move between depths, explore for events\n"
     "**🌲 Harvest** — chop wood\n"
-    "**🗺️ Explore** — discover random events\n"
-    "**📦 Inventory** — view your mining resources\n"
-    "**📊 Stats** — view your mining statistics\n"
-    "**🔨 Workshop** — craft & build · repair · 🔥 forge · 🛒 market (all here)\n"
-    "**⬇️ Descend / ⬆️ Ascend** — move between depth bands "
-    "(deeper = richer, gated by your light)\n"
-    "**🏦 Vault** — stash loot safely, separate from your pack\n"
+    "**🗺️ Explore** — the open-world explorer (fishing, roam, quests — early)\n"
+    "**🧍 Character** — you: overview · inventory · stats · skills · vault · home\n"
     "**🧰 Gear** — equip your best tools, lights, and combat gear\n"
-    "**🌳 Skills** — spend skill points to specialize your character\n"
-    "**🏠 Home** — build it to personalize your Character card\n"
-    "**🧍 Character** — your full character overview"
+    "**🔨 Workshop** — craft & build · repair · 🔥 forge · 🛒 market (all here)"
 )
 
 
@@ -129,9 +117,6 @@ async def build_overview_embed(
     return embed
 
 
-_INVENTORY_FILENAME = "inventory.png"
-
-
 async def _edit_in_place(
     interaction: discord.Interaction,
     *,
@@ -141,11 +126,10 @@ async def _edit_in_place(
 ) -> None:
     """Edit the hub's anchor message in place, owning its optional image.
 
-    The inventory card and the gear paper-doll render *into* this one message
-    (``image=...``) instead of a separate ephemeral follow-up that piles up on
-    every click (the owner's 2026-06-15 "too many ephemeral panels"). Every
-    other action passes no image, which clears a prior card so it never lingers
-    on the next screen.
+    The gear paper-doll renders *into* this one message (``image=...``) instead
+    of a separate ephemeral follow-up that piles up on every click (the owner's
+    2026-06-15 "too many ephemeral panels"). Every other action passes no image,
+    which clears a prior card so it never lingers on the next screen.
     """
     await safe_edit(
         interaction,
@@ -155,35 +139,9 @@ async def _edit_in_place(
     )
 
 
-def _render_inventory_file(
-    display_name: str,
-    inventory: dict[str, int],
-    embed: discord.Embed,
-) -> discord.File | None:
-    """Render the PIL inventory card and wire it into *embed* as the in-place
-    image.  Returns the File to attach (or ``None`` without Pillow — additive,
-    the text embed already carries the full inventory).
-    """
-    import io
-
-    from utils.mining_render import build_card_spec, render_inventory_card
-
-    spec = build_card_spec(
-        f"{display_name}'s Mining Inventory",
-        items.sort_inventory(inventory),
-        classify_kind=lambda n: items.classify(n).value,
-        footer=f"Net worth: {items.total_value(inventory)}",
-    )
-    png = render_inventory_card(spec)
-    if png is None:
-        return None
-    embed.set_image(url=f"attachment://{_INVENTORY_FILENAME}")
-    return discord.File(io.BytesIO(png), filename=_INVENTORY_FILENAME)
-
-
 @register
 class MiningHubView(PersistentView):
-    """Persistent, stateless mining hub panel."""
+    """Persistent, stateless mining hub panel — the six Option A top actions."""
 
     SUBSYSTEM = "mining"
 
@@ -257,7 +215,7 @@ class MiningHubView(PersistentView):
     @discord.ui.button(
         label="🗺️ Explore",
         style=discord.ButtonStyle.primary,
-        custom_id="mining:explore",
+        custom_id="mining:explore_hub",
         row=0,
     )
     async def explore_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
@@ -270,35 +228,26 @@ class MiningHubView(PersistentView):
                 ephemeral=True,
             )
             return
-        result = await mining_workflow.explore(
-            interaction.user.id,
-            interaction.guild_id,
+        # Option A: this opens the open-world explorer sub-hub (stub). It is a
+        # DIFFERENT concept from the old depth-tied mining random-event explore,
+        # which folded into the Mine action. New custom_id (mining:explore_hub)
+        # so the persistent panel doesn't reuse the old mining:explore id.
+        from views.mining.explore_hub import (
+            MiningExploreHubView,
+            build_explore_hub_embed,
         )
-        description = (
-            f"{interaction.user.mention} {result.text}\n"
-            f"_{world.describe_position(result.depth)}_"
-        )
-        if result.wear.notes:
-            description += "\n" + "\n".join(result.wear.notes)
-        if result.xp_note:
-            description += "\n" + result.xp_note
-        if result.pack_warning:
-            description += "\n" + result.pack_warning
-        embed = discord.Embed(
-            title="⛏️ Mining Hub",
-            description=description,
-            color=SUCCESS_COLOR if result.amount >= 0 else ERROR_COLOR,
-        )
-        embed.set_footer(text="Pick another action above to continue.")
-        await _edit_in_place(interaction, embed=embed, view=self)
+
+        embed = build_explore_hub_embed()
+        view = MiningExploreHubView(interaction.user, interaction.guild_id)
+        await _edit_in_place(interaction, embed=embed, view=view)
 
     @discord.ui.button(
-        label="📦 Inventory",
+        label="🧍 Character",
         style=discord.ButtonStyle.grey,
-        custom_id="mining:inventory",
+        custom_id="mining:character",
         row=1,
     )
-    async def inventory_btn(
+    async def character_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
@@ -312,47 +261,24 @@ class MiningHubView(PersistentView):
                 ephemeral=True,
             )
             return
-        user_id = str(interaction.user.id)
-        inventory = await db.get_mining_inventory(user_id, interaction.guild_id)
-        embed = discord.Embed(
-            title=f"📦 {interaction.user.name}'s Mining Inventory",
-            color=MINING_COLOR,
+        # Option A: the Character sub-hub groups Overview / Inventory / Stats /
+        # Skills / Vault / Home (Home placed here per the 2026-06-19 deviation).
+        from views.mining.character_hub import (
+            MiningCharacterHubView,
+            build_character_hub_embed,
         )
-        if not inventory:
-            # Empty-state UX rule (mother-hub-map.md): explain what the
-            # feature does and what the next step is.
-            embed.description = (
-                "Your mining inventory is empty. Use `!mine` in the mining "
-                "channel to start collecting items."
-            )
-            embed.set_footer(text="Pick another action above to continue.")
-        else:
-            for kind, rows in items.summarize_inventory(inventory):
-                embed.add_field(
-                    name=_KIND_LABELS.get(kind.value, kind.value.title()),
-                    value="\n".join(f"**{name.title()}** ×{qty}" for name, qty in rows),
-                    inline=False,
-                )
-            embed.set_footer(
-                text=(
-                    f"Net worth: {items.total_value(inventory)}  •  "
-                    "Pick another action above to continue."
-                ),
-            )
-        image = (
-            _render_inventory_file(interaction.user.display_name, inventory, embed)
-            if inventory
-            else None
-        )
-        await _edit_in_place(interaction, embed=embed, view=self, image=image)
+
+        embed = build_character_hub_embed()
+        view = MiningCharacterHubView(interaction.user, interaction.guild_id)
+        await _edit_in_place(interaction, embed=embed, view=view)
 
     @discord.ui.button(
-        label="📊 Stats",
-        style=discord.ButtonStyle.grey,
-        custom_id="mining:stats",
+        label="🧰 Gear",
+        style=discord.ButtonStyle.primary,
+        custom_id="mining:gear",
         row=1,
     )
-    async def stats_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
+    async def gear_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
         if not await safe_defer(interaction):
             return
         if interaction.guild_id is None:
@@ -362,19 +288,19 @@ class MiningHubView(PersistentView):
                 ephemeral=True,
             )
             return
-        user_id = str(interaction.user.id)
-        inventory = await db.get_mining_inventory(user_id, interaction.guild_id)
-        total_items = sum(inventory.values())
-        unique_items = len(inventory)
-        embed = discord.Embed(
-            title=f"📊 {interaction.user.name}'s Mining Stats",
-            color=MINING_COLOR,
+        # Lazy import: views→views child panel (mirrors the Workshop button).
+        from views.mining.gear_panel import (
+            MiningGearView,
+            build_gear_embed,
+            render_gear_doll,
         )
-        embed.add_field(name="Total Items Collected", value=str(total_items))
-        embed.add_field(name="Unique Items", value=str(unique_items))
-        embed.add_field(name="Net Worth", value=str(items.total_value(inventory)))
-        embed.set_footer(text="Pick another action above to continue.")
-        await _edit_in_place(interaction, embed=embed, view=self)
+
+        embed = await build_gear_embed(interaction.user.id, interaction.guild_id)
+        view = await MiningGearView.create(interaction.user, interaction.guild_id)
+        # V-16: the paper-doll renders *into* this message (one self-replacing
+        # panel) instead of a separate ephemeral follow-up that stacks per click.
+        doll = await render_gear_doll(embed, interaction.user.id, interaction.guild_id)
+        await _edit_in_place(interaction, embed=embed, view=view, image=doll)
 
     @discord.ui.button(
         label="🔨 Workshop",
@@ -406,215 +332,6 @@ class MiningHubView(PersistentView):
         embed = build_workshop_hub_embed()
         view = MiningWorkshopHubView(interaction.user, interaction.guild_id)
         await _edit_in_place(interaction, embed=embed, view=view)
-
-    @discord.ui.button(
-        label="⬇️ Descend",
-        style=discord.ButtonStyle.success,
-        custom_id="mining:descend",
-        row=2,
-    )
-    async def descend_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        if not await safe_defer(interaction):
-            return
-        if interaction.guild_id is None:
-            await safe_followup(
-                interaction,
-                "Mining is only available inside a guild.",
-                ephemeral=True,
-            )
-            return
-        result = await mining_workflow.descend(
-            interaction.user.id,
-            interaction.guild_id,
-        )
-        if not result.moved:
-            description = (
-                f"{interaction.user.mention} can't descend any deeper.\n"
-                f"_{result.hint}_"
-            )
-            color = ERROR_COLOR
-        else:
-            description = (
-                f"{interaction.user.mention} descended to "
-                f"**{world.describe_position(result.depth)}**."
-            )
-            if result.xp_note:
-                description += "\n" + result.xp_note
-            color = SUCCESS_COLOR
-        embed = discord.Embed(
-            title="⛏️ Mining Hub",
-            description=description,
-            color=color,
-        )
-        embed.set_footer(text="Pick another action above to continue.")
-        await _edit_in_place(interaction, embed=embed, view=self)
-
-    @discord.ui.button(
-        label="⬆️ Ascend",
-        style=discord.ButtonStyle.secondary,
-        custom_id="mining:ascend",
-        row=2,
-    )
-    async def ascend_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        if not await safe_defer(interaction):
-            return
-        if interaction.guild_id is None:
-            await safe_followup(
-                interaction,
-                "Mining is only available inside a guild.",
-                ephemeral=True,
-            )
-            return
-        result = await mining_workflow.ascend(
-            interaction.user.id,
-            interaction.guild_id,
-        )
-        if not result.moved:
-            description = f"{interaction.user.mention} is already at the **Surface**."
-            color = MINING_COLOR
-        else:
-            description = (
-                f"{interaction.user.mention} climbed up to "
-                f"**{world.describe_position(result.depth)}**."
-            )
-            color = SUCCESS_COLOR
-        embed = discord.Embed(
-            title="⛏️ Mining Hub",
-            description=description,
-            color=color,
-        )
-        embed.set_footer(text="Pick another action above to continue.")
-        await _edit_in_place(interaction, embed=embed, view=self)
-
-    @discord.ui.button(
-        label="🏦 Vault",
-        style=discord.ButtonStyle.primary,
-        custom_id="mining:vault",
-        row=2,
-    )
-    async def vault_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        if not await safe_defer(interaction):
-            return
-        if interaction.guild_id is None:
-            await safe_followup(
-                interaction,
-                "Mining is only available inside a guild.",
-                ephemeral=True,
-            )
-            return
-        # Lazy import: views→views child panel (mirrors the Market button).
-        from views.mining.vault_panel import MiningVaultView, build_vault_embed
-
-        embed = await build_vault_embed(interaction.user.id, interaction.guild_id)
-        view = MiningVaultView(interaction.user, interaction.guild_id)
-        await _edit_in_place(interaction, embed=embed, view=view)
-
-    @discord.ui.button(
-        label="🧰 Gear",
-        style=discord.ButtonStyle.primary,
-        custom_id="mining:gear",
-        row=3,
-    )
-    async def gear_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        if not await safe_defer(interaction):
-            return
-        if interaction.guild_id is None:
-            await safe_followup(
-                interaction,
-                "Mining is only available inside a guild.",
-                ephemeral=True,
-            )
-            return
-        # Lazy import: views→views child panel (mirrors the Market button).
-        from views.mining.gear_panel import (
-            MiningGearView,
-            build_gear_embed,
-            render_gear_doll,
-        )
-
-        embed = await build_gear_embed(interaction.user.id, interaction.guild_id)
-        view = await MiningGearView.create(interaction.user, interaction.guild_id)
-        # V-16: the paper-doll renders *into* this message (one self-replacing
-        # panel) instead of a separate ephemeral follow-up that stacks per click.
-        doll = await render_gear_doll(embed, interaction.user.id, interaction.guild_id)
-        await _edit_in_place(interaction, embed=embed, view=view, image=doll)
-
-    @discord.ui.button(
-        label="🧍 Character",
-        style=discord.ButtonStyle.grey,
-        custom_id="mining:character",
-        row=3,
-    )
-    async def character_btn(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ):
-        if not await safe_defer(interaction):
-            return
-        if interaction.guild_id is None:
-            await safe_followup(
-                interaction,
-                "Mining is only available inside a guild.",
-                ephemeral=True,
-            )
-            return
-        # Read-only character overview, shown in place on the hub.
-        from views.mining.character_panel import build_character_embed
-
-        embed = await build_character_embed(
-            interaction.user.id,
-            interaction.guild_id,
-            name=interaction.user.display_name,
-        )
-        embed.set_footer(text="Pick another action above to continue.")
-        await _edit_in_place(interaction, embed=embed, view=self)
-
-    @discord.ui.button(
-        label="🌳 Skills",
-        style=discord.ButtonStyle.primary,
-        custom_id="mining:skills",
-        row=3,
-    )
-    async def skills_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        if not await safe_defer(interaction):
-            return
-        if interaction.guild_id is None:
-            await safe_followup(
-                interaction,
-                "Mining is only available inside a guild.",
-                ephemeral=True,
-            )
-            return
-        # Lazy import: views→views child panel (mirrors the Market button).
-        from views.mining.skills_panel import MiningSkillsView, build_skills_embed
-
-        embed = await build_skills_embed(interaction.user.id, interaction.guild_id)
-        view = MiningSkillsView(interaction.user, interaction.guild_id)
-        await _edit_in_place(interaction, embed=embed, view=view)
-
-    @discord.ui.button(
-        label="🏠 Home",
-        style=discord.ButtonStyle.primary,
-        custom_id="mining:home",
-        row=4,
-    )
-    async def home_btn(self, interaction: discord.Interaction, _: discord.ui.Button):
-        if not await safe_defer(interaction):
-            return
-        if interaction.guild_id is None:
-            await safe_followup(
-                interaction,
-                "Mining is only available inside a guild.",
-                ephemeral=True,
-            )
-            return
-        # Lazy import: views→views child panel (mirrors the Forge button).
-        from views.mining.home_panel import MiningHomeView, build_home_embed
-
-        embed = await build_home_embed(interaction.user.id, interaction.guild_id)
-        view = MiningHomeView(interaction.user, interaction.guild_id)
-        await safe_edit(interaction, embed=embed, view=view)
 
 
 class _BuildModal(discord.ui.Modal, title="Build a Structure"):  # type: ignore[call-arg]

--- a/disbot/views/mining/mine_view.py
+++ b/disbot/views/mining/mine_view.py
@@ -26,7 +26,7 @@ import discord
 from core.runtime.interaction_helpers import safe_defer, safe_edit
 from services import mining_workflow
 from utils.mining import world
-from utils.ui_constants import MINING_COLOR
+from utils.ui_constants import ERROR_COLOR, MINING_COLOR, SUCCESS_COLOR
 from views.base import BaseView
 
 logger = logging.getLogger("bot.views.mining.mine_view")
@@ -38,14 +38,24 @@ def _build_mine_prompt_embed() -> discord.Embed:
         title="Mining",
         description=(
             "Choose a direction to mine.\n"
-            "If you own a pickaxe, you'll get extra loot!"
+            "If you own a pickaxe, you'll get extra loot!\n\n"
+            "**⬇️ Descend / ⬆️ Ascend** move between depth bands "
+            "(deeper = richer, gated by your light).\n"
+            "**🗺️ Explore** triggers a random depth event."
         ),
         color=MINING_COLOR,
     )
 
 
 class MineView(BaseView):
-    """Mine Left / Mine Right / Mine Down buttons (30-second timeout).
+    """Mine Left/Right/Down + movement (Descend/Ascend) + Explore (30s timeout).
+
+    Option A declutter (owner-directed, 2026-06-15;
+    ``docs/planning/mining-hub-redesign-2026-06-15.md``): Descend / Ascend and
+    the old depth-tied mining random-event "explore" folded off the main hub
+    into the Mine action here, as an interim until PR3's grid Mine. (The main
+    hub's new ``🗺️ Explore`` button is the *open-world* explorer — a different
+    concept; this Explore is the mining depth-event mechanic.)
 
     Ownership/timeout/error handling come from BaseView (RS10) — another
     user's click now gets the standard ephemeral denial instead of the
@@ -61,7 +71,7 @@ class MineView(BaseView):
         self.user_id = author.id
         self.guild_id = guild_id
 
-    @discord.ui.button(label="Mine Left", style=discord.ButtonStyle.primary)
+    @discord.ui.button(label="Mine Left", style=discord.ButtonStyle.primary, row=0)
     async def mine_left(
         self,
         interaction: discord.Interaction,
@@ -69,7 +79,7 @@ class MineView(BaseView):
     ) -> None:
         await self._handle_mine(interaction, "left")
 
-    @discord.ui.button(label="Mine Right", style=discord.ButtonStyle.primary)
+    @discord.ui.button(label="Mine Right", style=discord.ButtonStyle.primary, row=0)
     async def mine_right(
         self,
         interaction: discord.Interaction,
@@ -77,13 +87,109 @@ class MineView(BaseView):
     ) -> None:
         await self._handle_mine(interaction, "right")
 
-    @discord.ui.button(label="Mine Down", style=discord.ButtonStyle.primary)
+    @discord.ui.button(label="Mine Down", style=discord.ButtonStyle.primary, row=0)
     async def mine_down(
         self,
         interaction: discord.Interaction,
         button: discord.ui.Button,
     ) -> None:
         await self._handle_mine(interaction, "down")
+
+    @discord.ui.button(label="⬇️ Descend", style=discord.ButtonStyle.success, row=1)
+    async def descend_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not await safe_defer(interaction):
+            return
+        result = await mining_workflow.descend(self.user_id, self.guild_id)
+        if not result.moved:
+            description = (
+                f"{interaction.user.mention} can't descend any deeper.\n"
+                f"_{result.hint}_"
+            )
+            color = ERROR_COLOR
+        else:
+            description = (
+                f"{interaction.user.mention} descended to "
+                f"**{world.describe_position(result.depth)}**."
+            )
+            if result.xp_note:
+                description += "\n" + result.xp_note
+            color = SUCCESS_COLOR
+        await self._swap_to_results(interaction, "⛏️ Descend", description, color)
+
+    @discord.ui.button(label="⬆️ Ascend", style=discord.ButtonStyle.secondary, row=1)
+    async def ascend_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not await safe_defer(interaction):
+            return
+        result = await mining_workflow.ascend(self.user_id, self.guild_id)
+        if not result.moved:
+            description = f"{interaction.user.mention} is already at the **Surface**."
+            color = MINING_COLOR
+        else:
+            description = (
+                f"{interaction.user.mention} climbed up to "
+                f"**{world.describe_position(result.depth)}**."
+            )
+            color = SUCCESS_COLOR
+        await self._swap_to_results(interaction, "⛏️ Ascend", description, color)
+
+    @discord.ui.button(label="🗺️ Explore", style=discord.ButtonStyle.primary, row=1)
+    async def explore_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not await safe_defer(interaction):
+            return
+        result = await mining_workflow.explore(self.user_id, self.guild_id)
+        description = (
+            f"{interaction.user.mention} {result.text}\n"
+            f"_{world.describe_position(result.depth)}_"
+        )
+        if result.wear.notes:
+            description += "\n" + "\n".join(result.wear.notes)
+        if result.xp_note:
+            description += "\n" + result.xp_note
+        if result.pack_warning:
+            description += "\n" + result.pack_warning
+        color = SUCCESS_COLOR if result.amount >= 0 else ERROR_COLOR
+        await self._swap_to_results(interaction, "🗺️ Explored!", description, color)
+
+    async def _swap_to_results(
+        self,
+        interaction: discord.Interaction,
+        title: str,
+        description: str,
+        color: int,
+    ) -> None:
+        """Shared post-action swap to ``_MineResultsView`` (Mine Again / Menu / Help).
+
+        Used by Descend / Ascend / Explore so a movement action lands the user on
+        the same navigable results screen as a mine, never a dead end.
+        """
+        result_embed = discord.Embed(title=title, description=description, color=color)
+        result_embed.set_footer(
+            text=(
+                "Click ⛏️ Mine Again to keep mining, "
+                "or use the buttons below to navigate."
+            ),
+        )
+        results_view = _MineResultsView(interaction.user, self.guild_id)
+        await interaction.followup.edit_message(
+            message_id=interaction.message.id,
+            content=None,
+            embed=result_embed,
+            view=results_view,
+        )
+        results_view.message = interaction.message
+        self.stop()
 
     async def _handle_mine(
         self,

--- a/docs/planning/mining-hub-redesign-2026-06-15.md
+++ b/docs/planning/mining-hub-redesign-2026-06-15.md
@@ -60,10 +60,16 @@ this **replaces** the old linear Descend/Ascend.
 
 1. **PR 1 — in-place image cards** ✅ (PR #911) — inventory/gear cards stop stacking as
    ephemerals (independent; already green).
-2. **PR 2 — hub declutter** (confirmed, turn-key): main hub → the 6; new **Character** +
-   **Workshop** sub-hubs; **Craft** consolidation; **Explore** stub. Mine keeps current
-   behaviour as an interim (Descend/Ascend fold into the Mine action, off the main hub) until
-   PR 3. *Best done live with the owner once the test-bot token is restored.*
+2. **PR 2 — hub declutter** ✅ **SHIPPED (2026-06-19, PR #1131)**: main hub → the 6 (⛏️ Mine ·
+   🌲 Harvest · 🗺️ Explore · 🧍 Character · 🧰 Gear · 🔨 Workshop); new **Character** sub-hub
+   (`views/mining/character_hub.py` — Overview/Inventory/Stats/Skills/Vault/**Home**) + the
+   **Workshop** sub-hub (shipped earlier) + **Explore** open-world *stub* sub-hub
+   (`views/mining/explore_hub.py` — Fishing/Roam/Quests "coming soon"). Descend/Ascend AND the
+   old depth-tied mining random-event explore folded into the Mine action (`MineView`) as an
+   interim until PR 3. **Deviations (owner review):** (a) **Home** placed in the Character
+   sub-hub (it personalizes the Character card; the plan list predated #910); (b) the main hub's
+   new 🗺️ Explore (open-world stub, `custom_id mining:explore_hub`) is a *different concept*
+   from the depth-event explore that folded into Mine — routing documented in PR #1131.
 3. **PR 3 — grid Mine** (new mechanic): the (x,y,z) world model + 6-direction movement +
    discovery. Needs the v1 sign-off above first.
 4. **Later — open-world Explore**: fishing / quests / roam — own design pass.

--- a/docs/subsystems/games.md
+++ b/docs/subsystems/games.md
@@ -153,7 +153,13 @@ Start in `disbot/cogs/games_cog.py`, `disbot/views/games/`,
 **Active games plans** (live buildable set — full index: [`planning/README.md`](../planning/README.md)):
 - [fishing-open-world-expansion-plan](../planning/fishing-open-world-expansion-plan-2026-06-18.md) —
   Phase 1 (fishing v1 + gear-switching) buildable; the loadout/value/minigame tail is owner-design-gated (Q-0175).
-- [mining-hub-redesign](../planning/mining-hub-redesign-2026-06-15.md) — owner-picked Option A sub-hub split (not yet built).
+- [mining-hub-redesign](../planning/mining-hub-redesign-2026-06-15.md) — owner-picked Option A sub-hub split.
+  **PR2 (hub declutter) shipped:** the main hub is now six buttons (⛏️ Mine · 🌲 Harvest · 🗺️ Explore ·
+  🧍 Character · 🧰 Gear · 🔨 Workshop); a **Character** sub-hub (`views/mining/character_hub.py`)
+  groups Overview/Inventory/Stats/Skills/Vault/Home and an **Explore** stub sub-hub
+  (`views/mining/explore_hub.py`) previews the open-world explorer (Fishing/Roam/Quests — early).
+  Descend/Ascend + the depth-event explore folded into the Mine action (`MineView`). **PR3 (grid Mine)
+  is owner-sign-off-gated, not built.**
 - [games-economy-faucet-sink-diagnostic-plan](../planning/games-economy-faucet-sink-diagnostic-plan-2026-06-15.md) —
   read-only economy faucet/sink read model (turn-key).
 - *Shipped → `historical`:* [mining-structures-skill-tree-plan](../planning/mining-structures-skill-tree-plan-2026-06-14.md)

--- a/tests/unit/cogs/test_mining_cog_dm_guard.py
+++ b/tests/unit/cogs/test_mining_cog_dm_guard.py
@@ -51,32 +51,47 @@ async def test_cog_check_passes_in_guild():
 
 
 def test_persistent_view_button_handlers_check_guild_id():
-    """Every MiningHubView button that touches the DB must guard
-    against ``interaction.guild_id is None`` before reading.  This
-    asserts the presence of the guard in source so a future refactor
-    can't drop it silently.
+    """Every MiningHubView button that touches the DB (or opens a sub-hub that
+    will) must guard against ``interaction.guild_id is None`` before acting.
+    This asserts the guard's presence in source so a future refactor can't drop
+    it silently. Updated for the Option A 6-button hub (declutter PR2,
+    2026-06-19): Inventory / Stats moved into the Character sub-hub.
     """
     from cogs import mining_cog
 
     src = inspect.getsource(mining_cog.MiningHubView)
-    # The five DB-touching buttons share the same pattern.
+    # The six Option A top-level buttons; all guard before acting.
     for btn in (
         "mine_btn",
         "harvest_btn",
         "explore_btn",
-        "inventory_btn",
-        "stats_btn",
+        "character_btn",
+        "gear_btn",
+        "workshop_btn",
     ):
-        # Find the function block.
         assert f"async def {btn}(" in src, f"{btn} not found in source"
-    # The guard string appears for each button.  Count must match the
-    # five DB-touching buttons.
+    # The guard string appears for each button — six on the main hub.
     guard_occurrences = src.count("interaction.guild_id is None")
-    assert guard_occurrences >= 5, (
-        f"Expected at least 5 ``interaction.guild_id is None`` guards "
-        f"in MiningHubView; found {guard_occurrences}.  Each DB-touching "
+    assert guard_occurrences >= 6, (
+        f"Expected at least 6 ``interaction.guild_id is None`` guards "
+        f"in MiningHubView; found {guard_occurrences}.  Each top-level "
         "button must guard against DM invocations."
     )
+
+
+def test_character_and_explore_subhub_handlers_check_guild_id():
+    """The Character sub-hub's DB-touching buttons guard against DMs just like
+    the main hub (the moved Inventory / Stats / Overview etc.). The Explore
+    stub doesn't read the DB, so it needs no guild guard.
+    """
+    from views.mining import character_hub
+
+    src = inspect.getsource(character_hub.MiningCharacterHubView)
+    for btn in ("overview_btn", "inventory_btn", "stats_btn", "skills_btn",
+                "vault_btn", "home_btn"):
+        assert f"async def {btn}(" in src, f"{btn} not found in source"
+    # Six DB-touching sub-hub buttons each carry the guard.
+    assert src.count("interaction.guild_id is None") >= 6
 
 
 def test_build_modal_guards_dm():

--- a/tests/unit/views/test_mining_character_hub.py
+++ b/tests/unit/views/test_mining_character_hub.py
@@ -1,0 +1,166 @@
+"""Character sub-hub — structure, embed, and that it groups the moved actions.
+
+Option A declutter (owner-directed, 2026-06-15;
+``docs/planning/mining-hub-redesign-2026-06-15.md``): the Character sub-hub
+absorbs Overview / Inventory / Stats / Skills / Vault / Home off the main hub.
+Home placement here is the 2026-06-19 deviation (it personalizes the Character
+card). These tests pin the sub-hub shape and the in-place rendering contract.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from views.mining.character_hub import (
+    MiningCharacterHubView,
+    build_character_hub_embed,
+)
+
+_AUTHOR = SimpleNamespace(id=1, name="Digger", display_name="Digger")
+
+
+def _find_button(view: discord.ui.View, label_substr: str) -> discord.ui.Button:
+    for child in view.children:
+        if isinstance(child, discord.ui.Button) and label_substr in (child.label or ""):
+            return child
+    raise AssertionError(f"No button with label containing {label_substr!r}")
+
+
+def test_hub_embed_lists_the_character_actions():
+    embed = build_character_hub_embed()
+    assert "Character" in (embed.title or "")
+    blob = embed.description or ""
+    for token in ("Overview", "Inventory", "Stats", "Skills", "Vault", "Home"):
+        assert token in blob, f"missing {token!r} from the Character hub guide"
+
+
+def test_hub_has_all_six_actions_plus_back():
+    view = MiningCharacterHubView(_AUTHOR, 99)
+    labels = " | ".join(
+        b.label or "" for b in view.children if isinstance(b, discord.ui.Button)
+    )
+    for token in (
+        "Overview",
+        "Inventory",
+        "Stats",
+        "Skills",
+        "Vault",
+        "Home",
+        "Mining Hub",
+    ):
+        assert token in labels, f"missing {token!r} button"
+
+
+def test_hub_constructor_matches_workshop_template():
+    # Same (author, guild_id) shape as MiningWorkshopHubView (the template).
+    view = MiningCharacterHubView(_AUTHOR, 77)
+    assert view.guild_id == 77
+    assert view._author is _AUTHOR
+
+
+@pytest.mark.asyncio
+async def test_overview_button_shows_character_embed_in_place():
+    view = MiningCharacterHubView(_AUTHOR, 99)
+    btn = _find_button(view, "Overview")
+    interaction = MagicMock()
+    interaction.user = _AUTHOR
+    interaction.guild_id = 99
+    with (
+        patch(
+            "views.mining.character_hub.safe_defer",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "views.mining.character_panel.build_character_embed",
+            new_callable=AsyncMock,
+            return_value=discord.Embed(title="🧍 Digger"),
+        ),
+        patch(
+            "views.mining.character_hub.safe_edit", new_callable=AsyncMock,
+        ) as safe_edit,
+    ):
+        await btn.callback(interaction)
+    safe_edit.assert_awaited_once()
+    assert safe_edit.await_args.kwargs["view"] is view  # stays on the sub-hub
+
+
+@pytest.mark.asyncio
+async def test_stats_button_shows_stats_in_place():
+    view = MiningCharacterHubView(_AUTHOR, 99)
+    btn = _find_button(view, "Stats")
+    interaction = MagicMock()
+    interaction.user = _AUTHOR
+    interaction.guild_id = 99
+    with (
+        patch(
+            "views.mining.character_hub.safe_defer",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "views.mining.character_hub.db.get_mining_inventory",
+            new_callable=AsyncMock,
+            return_value={"gold": 3, "stone": 2},
+        ),
+        patch(
+            "views.mining.character_hub.safe_edit", new_callable=AsyncMock,
+        ) as safe_edit,
+    ):
+        await btn.callback(interaction)
+    embed = safe_edit.await_args.kwargs["embed"]
+    blob = " ".join(f"{f.name} {f.value}" for f in embed.fields)
+    assert "5" in blob  # total items collected (3 + 2)
+    assert "2" in blob  # unique items
+
+
+@pytest.mark.asyncio
+async def test_back_button_returns_to_main_hub():
+    view = MiningCharacterHubView(_AUTHOR, 99)
+    btn = _find_button(view, "Mining Hub")
+    interaction = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    with patch(
+        "views.mining.main_panel.build_overview_embed",
+        new_callable=AsyncMock,
+        return_value=discord.Embed(title="⛏️ Mining Hub"),
+    ):
+        await btn.callback(interaction)
+    interaction.response.edit_message.assert_awaited_once()
+    swapped = interaction.response.edit_message.await_args.kwargs["view"]
+    assert type(swapped).__name__ == "MiningHubView"
+
+
+@pytest.mark.asyncio
+async def test_skills_and_vault_open_their_panels_in_place():
+    view = MiningCharacterHubView(_AUTHOR, 99)
+    for label, mod, view_cls, embed_fn in (
+        ("Skills", "skills_panel", "MiningSkillsView", "build_skills_embed"),
+        ("Vault", "vault_panel", "MiningVaultView", "build_vault_embed"),
+    ):
+        btn = _find_button(view, label)
+        interaction = MagicMock()
+        interaction.user = _AUTHOR
+        interaction.guild_id = 99
+        with (
+            patch(
+                "views.mining.character_hub.safe_defer",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                f"views.mining.{mod}.{embed_fn}",
+                new_callable=AsyncMock,
+                return_value=discord.Embed(title=label),
+            ),
+            patch(f"views.mining.{mod}.{view_cls}", return_value=MagicMock()),
+            patch(
+                "views.mining.character_hub.safe_edit", new_callable=AsyncMock,
+            ) as safe_edit,
+        ):
+            await btn.callback(interaction)
+        safe_edit.assert_awaited_once()

--- a/tests/unit/views/test_mining_descent.py
+++ b/tests/unit/views/test_mining_descent.py
@@ -1,33 +1,115 @@
-"""The mining hub exposes Descend/Ascend depth navigation (persistent buttons)."""
+"""Descend / Ascend depth navigation folded into the Mine action (declutter PR2).
+
+Option A declutter (owner-directed, 2026-06-15;
+``docs/planning/mining-hub-redesign-2026-06-15.md``): Descend / Ascend moved off
+the main hub into the Mine action (``MineView``), alongside the folded
+depth-event Explore, as an interim until PR3's grid Mine. These tests pin:
+
+- the main hub no longer carries ``mining:descend`` / ``mining:ascend``;
+- ``MineView`` carries Descend / Ascend / Explore movement buttons (row 1);
+- the Descend / Ascend callbacks route through ``mining_workflow`` and swap to
+  the navigable results view.
+"""
 
 from __future__ import annotations
 
-import inspect
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
+import pytest
 
 from views.mining.main_panel import MiningHubView
+from views.mining.mine_view import MineView, _MineResultsView
 
 
 def _buttons(view: discord.ui.View) -> list[discord.ui.Button]:
     return [c for c in view.children if isinstance(c, discord.ui.Button)]
 
 
-def test_hub_has_descend_and_ascend_buttons_on_their_own_row():
+def _find_button(view: discord.ui.View, label_substr: str) -> discord.ui.Button:
+    for child in view.children:
+        if isinstance(child, discord.ui.Button) and label_substr in (child.label or ""):
+            return child
+    raise AssertionError(f"No button with label containing {label_substr!r}")
+
+
+def test_main_hub_no_longer_carries_descend_ascend():
     view = MiningHubView()
-    by_id = {b.custom_id: b for b in _buttons(view)}
-    assert "mining:descend" in by_id
-    assert "mining:ascend" in by_id
-    # Both live on their own row (row 2), below the six existing actions.
-    assert by_id["mining:descend"].row == 2
-    assert by_id["mining:ascend"].row == 2
+    ids = {b.custom_id for b in _buttons(view)}
+    assert "mining:descend" not in ids
+    assert "mining:ascend" not in ids
 
 
-def test_descent_buttons_guard_dm_invocations():
-    # Like every DB-touching hub button, descend/ascend must refuse DMs before
-    # reading state (mirrors test_mining_cog_dm_guard's contract).
-    src = inspect.getsource(MiningHubView)
-    for btn in ("descend_btn", "ascend_btn"):
-        assert f"async def {btn}(" in src, f"{btn} missing from the hub"
-    # Two new guards on top of the five pre-existing DB-touching buttons.
-    assert src.count("interaction.guild_id is None") >= 7
+def test_mine_view_carries_movement_and_explore_on_row_one():
+    view = MineView(MagicMock(id=1), guild_id=2)
+    labels = [b.label or "" for b in _buttons(view)]
+    descend = _find_button(view, "Descend")
+    ascend = _find_button(view, "Ascend")
+    explore = _find_button(view, "Explore")
+    assert descend.row == 1
+    assert ascend.row == 1
+    assert explore.row == 1
+    # The three Mine-direction buttons stay on row 0.
+    assert any("Mine Left" in lbl for lbl in labels)
+
+
+@pytest.mark.asyncio
+async def test_descend_button_routes_through_workflow_and_swaps_to_results():
+    view = MineView(MagicMock(id=1), guild_id=2)
+    btn = _find_button(view, "Descend")
+    interaction = MagicMock()
+    interaction.user.mention = "@user"
+    interaction.message.id = 99
+    interaction.followup.edit_message = AsyncMock()
+
+    from services.mining_workflow import DescentResult
+
+    with patch(
+        "views.mining.mine_view.safe_defer",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "views.mining.mine_view.mining_workflow.descend",
+        new_callable=AsyncMock,
+        return_value=DescentResult(moved=True, depth=1),
+    ):
+        await btn.callback(interaction)
+
+    interaction.followup.edit_message.assert_awaited_once()
+    swapped = interaction.followup.edit_message.await_args.kwargs["view"]
+    assert isinstance(swapped, _MineResultsView)
+
+
+@pytest.mark.asyncio
+async def test_explore_button_routes_through_workflow_and_swaps_to_results():
+    view = MineView(MagicMock(id=1), guild_id=2)
+    btn = _find_button(view, "Explore")
+    interaction = MagicMock()
+    interaction.user.mention = "@user"
+    interaction.message.id = 99
+    interaction.followup.edit_message = AsyncMock()
+
+    from services.mining_workflow import ExploreActionResult
+    from utils.mining.workshop import WearReport
+
+    with patch(
+        "views.mining.mine_view.safe_defer",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "views.mining.mine_view.mining_workflow.explore",
+        new_callable=AsyncMock,
+        return_value=ExploreActionResult(
+            text="found a gem",
+            item="diamond",
+            amount=1,
+            depth=0,
+            wear=WearReport(),
+        ),
+    ):
+        await btn.callback(interaction)
+
+    interaction.followup.edit_message.assert_awaited_once()
+    kwargs = interaction.followup.edit_message.await_args.kwargs
+    assert isinstance(kwargs["view"], _MineResultsView)
+    assert "found a gem" in (kwargs["embed"].description or "")

--- a/tests/unit/views/test_mining_explore_hub.py
+++ b/tests/unit/views/test_mining_explore_hub.py
@@ -1,0 +1,106 @@
+"""Explore sub-hub — the open-world explorer STUB.
+
+Option A declutter (owner-directed, 2026-06-15;
+``docs/planning/mining-hub-redesign-2026-06-15.md``): the main hub's new
+``🗺️ Explore`` button opens this open-world sub-hub. It is a *stub* — Fishing /
+Roam / Quests show a "coming soon" message and are deliberately NOT wired into
+any fishing module. (Distinct from the old depth-tied mining-explore event,
+which folded into the Mine action.) These tests pin the stub contract.
+"""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from views.mining.explore_hub import (
+    MiningExploreHubView,
+    build_explore_hub_embed,
+)
+
+_AUTHOR = SimpleNamespace(id=1, name="Digger", display_name="Digger")
+
+
+def _find_button(view: discord.ui.View, label_substr: str) -> discord.ui.Button:
+    for child in view.children:
+        if isinstance(child, discord.ui.Button) and label_substr in (child.label or ""):
+            return child
+    raise AssertionError(f"No button with label containing {label_substr!r}")
+
+
+def test_hub_embed_marks_it_as_early():
+    embed = build_explore_hub_embed()
+    assert "Explore" in (embed.title or "")
+    desc = (embed.description or "").lower()
+    assert "early" in desc or "coming soon" in desc
+
+
+def test_hub_has_the_three_stub_activities_plus_back():
+    view = MiningExploreHubView(_AUTHOR, 99)
+    labels = " | ".join(
+        b.label or "" for b in view.children if isinstance(b, discord.ui.Button)
+    )
+    for token in ("Fishing", "Roam", "Quests", "Mining Hub"):
+        assert token in labels, f"missing {token!r} button"
+
+
+def test_hub_constructor_matches_workshop_template():
+    view = MiningExploreHubView(_AUTHOR, 55)
+    assert view.guild_id == 55
+    assert view._author is _AUTHOR
+
+
+def test_stub_does_not_import_fishing_modules():
+    # Pure stub: no wiring into fishing v1 or any out-of-lane module. The only
+    # imports in the callbacks are the in-place helpers + the main-hub back nav.
+    src = inspect.getsource(MiningExploreHubView)
+    assert "from views.mining.fishing" not in src
+    assert "import fishing" not in src
+    assert "fishing_workflow" not in src
+
+
+@pytest.mark.asyncio
+async def test_each_activity_shows_coming_soon_in_place():
+    view = MiningExploreHubView(_AUTHOR, 99)
+    for label in ("Fishing", "Roam", "Quests"):
+        btn = _find_button(view, label)
+        interaction = MagicMock()
+        interaction.user = _AUTHOR
+        interaction.guild_id = 99
+        with (
+            patch(
+                "views.mining.explore_hub.safe_defer",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "views.mining.explore_hub.safe_edit", new_callable=AsyncMock,
+            ) as safe_edit,
+        ):
+            await btn.callback(interaction)
+        safe_edit.assert_awaited_once()
+        kwargs = safe_edit.await_args.kwargs
+        assert kwargs["view"] is view  # stays on the stub hub
+        embed = kwargs["embed"]
+        assert "coming soon" in (embed.title or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_back_button_returns_to_main_hub():
+    view = MiningExploreHubView(_AUTHOR, 99)
+    btn = _find_button(view, "Mining Hub")
+    interaction = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    with patch(
+        "views.mining.main_panel.build_overview_embed",
+        new_callable=AsyncMock,
+        return_value=discord.Embed(title="⛏️ Mining Hub"),
+    ):
+        await btn.callback(interaction)
+    interaction.response.edit_message.assert_awaited_once()
+    swapped = interaction.response.edit_message.await_args.kwargs["view"]
+    assert type(swapped).__name__ == "MiningHubView"

--- a/tests/unit/views/test_mining_inplace_cards.py
+++ b/tests/unit/views/test_mining_inplace_cards.py
@@ -15,7 +15,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import discord
 import pytest
 
-from views.mining import main_panel
+from views.mining import character_hub, main_panel
+from views.mining.character_hub import MiningCharacterHubView
 from views.mining.gear_panel import MiningGearView, render_gear_doll
 from views.mining.main_panel import MiningHubView
 
@@ -79,9 +80,11 @@ async def test_render_gear_doll_is_additive_without_pillow():
 
 
 def test_render_inventory_file_attaches_in_place():
+    # The inventory card helper moved with the Inventory button into the
+    # Character sub-hub (Option A declutter, 2026-06-15).
     embed = discord.Embed(title="Inventory")
     with patch("utils.mining_render.render_inventory_card", return_value=b"PNG"):
-        file = main_panel._render_inventory_file("Digger", {"gold": 4}, embed)
+        file = character_hub._render_inventory_file("Digger", {"gold": 4}, embed)
     assert isinstance(file, discord.File)
     assert file.filename == "inventory.png"
     assert embed.image.url == "attachment://inventory.png"
@@ -90,7 +93,7 @@ def test_render_inventory_file_attaches_in_place():
 def test_render_inventory_file_is_additive_without_pillow():
     embed = discord.Embed(title="Inventory")
     with patch("utils.mining_render.render_inventory_card", return_value=None):
-        file = main_panel._render_inventory_file("Digger", {"gold": 4}, embed)
+        file = character_hub._render_inventory_file("Digger", {"gold": 4}, embed)
     assert file is None
     assert embed.image.url is None
 
@@ -127,30 +130,31 @@ async def test_edit_in_place_clears_the_image_by_default():
 
 @pytest.mark.asyncio
 async def test_inventory_button_renders_card_in_place_no_ephemeral_followup():
-    view = MiningHubView()
+    # The Inventory button moved into the Character sub-hub (Option A declutter).
+    view = MiningCharacterHubView(_AUTHOR, 99)
     interaction = MagicMock()
     interaction.user = _AUTHOR
     interaction.guild_id = 99
     interaction.followup = MagicMock()
     interaction.followup.send = AsyncMock()
-    btn = _button(view, custom_id="mining:inventory")
+    btn = _button(view, label="📦 Inventory")
     with (
         patch(
-            "views.mining.main_panel.safe_defer",
+            "views.mining.character_hub.safe_defer",
             new_callable=AsyncMock,
             return_value=True,
         ),
         patch(
-            "views.mining.main_panel.db.get_mining_inventory",
+            "views.mining.character_hub.db.get_mining_inventory",
             new_callable=AsyncMock,
             return_value={"gold": 4},
         ),
         patch(
-            "views.mining.main_panel._render_inventory_file",
+            "views.mining.character_hub._render_inventory_file",
             return_value=MagicMock(spec=discord.File),
         ),
         patch(
-            "views.mining.main_panel.safe_edit", new_callable=AsyncMock,
+            "views.mining.character_hub.safe_edit", new_callable=AsyncMock,
         ) as safe_edit,
     ):
         await btn.callback(interaction)

--- a/tests/unit/views/test_mining_no_root_overview.py
+++ b/tests/unit/views/test_mining_no_root_overview.py
@@ -29,32 +29,52 @@ def test_mining_hub_view_has_no_root_overview_button():
 
 
 def test_mining_hub_view_action_buttons_still_present():
-    """The Mine / Harvest / Explore / Inventory / Stats action buttons remain —
-    the no-op Overview is removed, and (Option A declutter, 2026-06-15) Build /
-    Recipes / Forge / Market moved into the Workshop sub-hub.
+    """The six Option A top-level actions remain (declutter PR2, 2026-06-19):
+    Mine · Harvest · Explore (open-world sub-hub) · Character (sub-hub) · Gear ·
+    Workshop (sub-hub). Inventory / Stats / Skills / Vault / Home moved into the
+    Character sub-hub; Descend / Ascend + the old mining-explore folded into the
+    Mine action.
     """
     view = MiningHubView()
     ids = [getattr(c, "custom_id", None) for c in view.children]
     expected = {
         "mining:mine",
         "mining:harvest",
-        "mining:explore",
-        "mining:inventory",
-        "mining:stats",
+        "mining:explore_hub",
+        "mining:character",
+        "mining:gear",
         "mining:workshop",
     }
     for expected_id in expected:
         assert expected_id in ids, f"Missing action button {expected_id!r}; got {ids}"
 
 
-def test_mining_hub_view_button_count_after_declutter():
-    """After the Option A declutter (2026-06-15) merged with Slice C's Home:
-    the Workshop sub-hub absorbed Build/Craft/Recipes (consolidated) + Forge +
-    Market — four buttons off the main hub — while Home (Slice C) was added.
-    Pinned so the panel can't quietly re-bloat. (Character/Skills/Vault move next.)
+def test_mining_hub_view_is_exactly_the_six_option_a_actions():
+    """The Option A declutter (PR2, 2026-06-19): the main hub is exactly six
+    buttons. Everything else moved into the Character / Explore / Workshop
+    sub-hubs or the Mine action. Pinned so the panel can't quietly re-bloat.
     """
     view = MiningHubView()
     buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
-    ids = [getattr(c, "custom_id", None) for c in buttons]
-    assert "mining:home" in ids  # Slice C's Home button survived the merge
-    assert len(buttons) == 13
+    ids = {getattr(c, "custom_id", None) for c in buttons}
+    assert ids == {
+        "mining:mine",
+        "mining:harvest",
+        "mining:explore_hub",
+        "mining:character",
+        "mining:gear",
+        "mining:workshop",
+    }
+    assert len(buttons) == 6
+    # The moved/folded actions are gone from the persistent main panel.
+    for gone in (
+        "mining:inventory",
+        "mining:stats",
+        "mining:skills",
+        "mining:vault",
+        "mining:home",
+        "mining:descend",
+        "mining:ascend",
+        "mining:explore",  # old depth-event explore (now in the Mine action)
+    ):
+        assert gone not in ids, f"{gone!r} should have moved off the main hub"


### PR DESCRIPTION
## Option A PR2 — declutter the mining hub into sub-hubs

Implements the owner-picked **Option A** information architecture from
`docs/planning/mining-hub-redesign-2026-06-15.md` (PR2, "hub declutter"). The main
mining hub drops from **14 buttons across 5 rows → 6 buttons**, and the moved actions
land in dedicated sub-hubs mirroring the existing `MiningWorkshopHubView` template
exactly (constructor `(user, guild_id)`, opened in-place via `_edit_in_place`, not a
`@register`-ed PersistentView).

### Main hub → 6 buttons
`⛏️ Mine` · `🌲 Harvest` · `🗺️ Explore` · `🧍 Character` · `🧰 Gear` · `🔨 Workshop`

### NEW `🧍 Character` sub-hub ("everything about you")
`🧍 Overview` (stat card) · `📦 Inventory` · `📊 Stats` · `🌳 Skills` · `🏦 Vault` · `🏠 Home`.
The Inventory/Stats button *bodies* (inline DB reads) and the Skills/Vault/Character
panel-openers moved out of the main hub into this sub-hub.

### NEW `🗺️ Explore` sub-hub — STUB only (open-world, "early")
`🎣 Fishing` · `🧭 Roam` · `📜 Quests` show a clear "coming soon / early hub" in-place
message. **Pure stub** — not wired into any fishing module or any file outside this lane.

### Mine action absorbs movement + the old mining-explore
`⬇️ Descend` / `⬆️ Ascend` AND the old mining random-event explore folded into
`MineView` (off the main hub) as an interim until PR3's grid Mine.

---

### Deviations / decisions for owner review

1. **Home placement (small deviation):** the plan's Character list predates the Home
   feature (#910). `🏠 Home` is placed in the **Character** sub-hub because it
   personalizes the Character card. Flagged here for owner review.
2. **Explore name-clash routing:** the main hub's new `🗺️ Explore` opens the
   **open-world** sub-hub (stub) — a *different concept* from the existing depth-tied
   mining random-event "explore". The latter is a mining mechanic, so it folds into
   **Mine/movement** as an interim until PR3's grid Mine. The new hub Explore button
   uses a fresh `custom_id` (`mining:explore_hub`); the old `mining:explore` is gone
   from the persistent panel.

**Owner: this is a visual UX change to the headline mining hub — please live-verify the
new layout after deploy; fully reversible (UI reorg only).**

### Out of scope
**PR3 (grid Mine)** is owner-sign-off-gated and **not** built here.

### Verification
- `python3.10 scripts/check_quality.py --full` green
- `python3.10 scripts/check_architecture.py --mode strict` 0 errors
- New + updated unit tests for the 6-button main hub, both new sub-hub views, and the
  Mine-action fold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJANFhJehGkv15K6hHDWoz

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJANFhJehGkv15K6hHDWoz)_