### PR TITLE
B5: codex-review integration (routine fix-first + Hermes 6H pr-check skill)

### DIFF
--- a/.sessions/2026-06-19-codex-review-integration.md
+++ b/.sessions/2026-06-19-codex-review-integration.md
@@ -1,0 +1,18 @@
+# 2026-06-19 — Codex review integration (routine fix-first + Hermes 6H pr-check skill)
+
+> **Status:** `in-progress`
+
+## Intent (born-red)
+
+Lane B5 of the ultracode fleet (owner-directed, **Q-0174**). Ship the two unbuilt parts of
+`docs/planning/codex-review-integration-plan-2026-06-17.md`:
+
+- **Part A** — add a first-priority "check Codex first, verified" step to the **dispatch** and
+  **reconciliation** routine prompts: before taking new work, scan the few most-recent merged/open
+  PRs for unresolved Codex/bot review comments, apply the plan's "real bug" bar, fix the
+  verified-real ones first.
+- **Part B** — a new Hermes skill `superbot-pr-check`, self-scheduled every 6H (`0 */6 * * *`),
+  that lists open+recent PRs, applies the bar, and **opens a GitHub issue** for each real bug
+  (issue-only — NO dispatch/merge authority).
+
+This card flips to `complete` as the deliberate last step (Q-0133).

--- a/.sessions/2026-06-19-codex-review-integration.md
+++ b/.sessions/2026-06-19-codex-review-integration.md
@@ -1,18 +1,115 @@
 # 2026-06-19 — Codex review integration (routine fix-first + Hermes 6H pr-check skill)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-## Intent (born-red)
+## Arc
 
-Lane B5 of the ultracode fleet (owner-directed, **Q-0174**). Ship the two unbuilt parts of
-`docs/planning/codex-review-integration-plan-2026-06-17.md`:
+Lane B5 of the ultracode fleet (owner-directed, **Q-0174**). Shipped the two unbuilt parts of
+`docs/planning/codex-review-integration-plan-2026-06-17.md` — the routine-side "check Codex first,
+verified" fix-first step and the additive, issue-only Hermes 6H PR-check skill.
 
-- **Part A** — add a first-priority "check Codex first, verified" step to the **dispatch** and
-  **reconciliation** routine prompts: before taking new work, scan the few most-recent merged/open
-  PRs for unresolved Codex/bot review comments, apply the plan's "real bug" bar, fix the
-  verified-real ones first.
-- **Part B** — a new Hermes skill `superbot-pr-check`, self-scheduled every 6H (`0 */6 * * *`),
-  that lists open+recent PRs, applies the bar, and **opens a GitHub issue** for each real bug
-  (issue-only — NO dispatch/merge authority).
+## Shipped (PR #1132)
 
-This card flips to `complete` as the deliberate last step (Q-0133).
+### Part A — routines check Codex first (in-repo canonical mirror)
+
+A first-priority "**check Codex first, verified**" step added to BOTH autonomous routine prompts:
+
+- **dispatch** routine — `docs/operations/hermes-dispatch-bridge.md` § "The routine's saved prompt",
+  new **step 1b** (between ORIENT and DECIDE): scan the few most-recent merged/open PRs for unresolved
+  Codex/bot review comments, apply the plan's "real bug" bar (verified against current `main`, genuine
+  defect, not a nitpick / born-red false positive), and fix the verified-real ones first. Reads Codex's
+  *comment* (it can't push a branch/PR), applies the change itself.
+- **reconciliation** routine — `docs/operations/autonomous-routines.md` § "superbot docs
+  reconciliation", new **STEP 1b**: same bar, but **routed by shape** to honor the docs-only Q-0107
+  rule — a verified-real *docs* defect is fixed in the pass; a verified-real *runtime* bug is captured
+  OPEN to the bug-book (step 3) for the dispatch routine.
+
+These are the canonical mirror; the **owner re-pastes** each into its routine's console config to take
+effect (the standing routine-prompt convention).
+
+### Part B — `superbot-pr-check` Hermes skill (additive, issue-only)
+
+- `docs/operations/hermes-skills/pr-check.md` — doc = source of truth, in the `_house-style.md`
+  output shape (bottom line first, fixed sections, plain words, one screen). Lists open + ~8
+  recently-merged PRs, reads Codex comments / CI / unresolved threads, applies the "real bug" bar,
+  and **opens a GitHub issue** for each real bug. Explicitly **NO merge and NO dispatch authority** —
+  graduation to auto-dispatch is a deliberate later owner decision.
+- `scripts/hermes/build_skills.py` — an `EXTRAS` entry registering it with the **6H schedule**
+  `"0 */6 * * *"`, tags `[Review, SuperBot, Quality]`, related `superbot-review` / `superbot-review-merge`.
+- `docs/operations/hermes-skills/README.md` — count 15 → 16, a new table row, and the scheduled-skills
+  list updated with `pr-check (0 */6 * * *)`.
+- **Regenerated artifact:** `scripts/hermes/skills/pr-check/SKILL.md` — committed, in sync. The build
+  wrote 16 skills (was 15) and the ONLY new/changed generated path is `skills/pr-check/` — the diff is
+  exactly the new skill, nothing else regenerated.
+
+## Verification
+
+- `python3.10 scripts/check_docs.py --strict` → **all checks passed ✓** (after fixing the plan's
+  badge: `shipped` is not an allowed token → `historical`, the convention for a fully-executed plan).
+- `python3.10 scripts/check_quality.py --full` → **All checks passed ✓** (exit 0; 10,884 passed,
+  44 skipped; black/isort/ruff/mypy all clean).
+- `python3.10 scripts/check_architecture.py --mode strict` → **exit 0, 0 errors** (only pre-existing
+  `baseview_inheritance` warnings on untouched `disbot/views/*`; no `disbot/` runtime touched).
+- `python3.10 -m pytest tests/unit/scripts/test_build_skills.py` → 22 passed; `build_skills --check`
+  → 16 skills up to date.
+
+## Context delta
+
+- **`shipped` is NOT a valid `check_docs` badge token.** Allowed: archive / audit / binding /
+  historical / ideas / living-ledger / owner-guidance / plan / reference. A fully-executed plan uses
+  **`historical`** (matches every other completed plan in `docs/planning/`). The PR-body / card may
+  say "shipped" freely — it's only the `> **Status:** \`...\`` doc-badge that is constrained.
+- **The reconciliation Codex-first step had to be shaped differently from dispatch's.** The dispatch
+  routine fixes whatever it finds; the reconciliation routine is docs-only (Q-0107), so its 1b routes a
+  runtime flag to the bug-book instead of fixing it. Copying dispatch's step verbatim would have created
+  a docs-only-rule contradiction — a small but real correctness point in a prompt that an agent obeys.
+- **`build_skills.py` invokes with `python3` on purpose** (the Hermes VPS has 3.11, not 3.10) — its
+  header explicitly warns against "correcting" it to `python3.10`. I left it; the freshness test runs
+  under 3.10 in CI fine because it's pure stdlib.
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous session (`2026-06-19-router-status.md`, PR #1103) shipped `scripts/router_status.py`,
+a question-router digest tool — a genuinely useful piece of self-improvement tooling, and it did the
+right thing surfacing its own honest limit (116/184 router blocks unclassified) rather than guessing,
+which is exactly the Q-0120 "don't fight the evidence" discipline. What it could have done better: it
+flagged the 116-block classifier gap as the seed of its *next* idea but left the gap itself open — the
+older `Q-0001…Q-0130` blocks predate the `> **MARKER**` convention, so `router_status.py` will keep
+reporting most of the router as UNCLASSIFIED until something backfills those markers.
+
+**System improvement it surfaces:** the router-status tool and this session's pr-check skill both
+*detect-and-report* (next number / open queue · PR flags → issues) but neither *closes the loop on its
+own backlog*. A small follow-up worth a routine fire: a one-time pass (or a `--backfill` dry-run mode)
+that proposes leading `> **MARKER**` lines for the legacy router blocks, so the digest tool graduates
+from "most blocks unclassified" to a trustworthy OPEN-queue readout. Captured as the session idea below
+in adjacent form.
+
+## 💡 Session idea (Q-0089)
+
+**A `codex-flag` issue-label lifecycle dashboard tile.** The new pr-check skill opens
+`bug` + `codex-flag` labelled issues; right now nothing measures whether those issues turn out *real*
+(the graduation question the plan defers — "once Hermes's issues prove consistently real, revisit
+auto-dispatch"). A tiny addition to `scripts/export_dashboard_data.py` that counts `codex-flag` issues
+by state (open / closed-fixed / closed-as-not-a-bug, read from the close reason or a `wontfix` label)
+gives the owner the *evidence* for the auto-dispatch graduation decision without him hand-auditing the
+issue tracker — it turns "a few cycles, see if they're real" into a number on `/updates`. Genuinely
+believe in it: it's the measurement that makes the deferred owner decision data-driven instead of
+gut-feel. (Dedup-checked `docs/ideas/` — the closest is the codex-automated-pr-review idea doc, which
+is about *catching* flags, not *scoring* them; this is the complementary metric.)
+
+## 📤 Run report
+
+- **Did:** shipped Q-0174 Part A (dispatch + reconciliation routine prompts get a verified
+  "check-Codex-first" fix-first step) + Part B (additive issue-only `superbot-pr-check` Hermes skill,
+  6H schedule, regenerated artifact). · **Outcome:** shipped
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** `none` (auto-dispatch graduation stays a deliberate future decision,
+  already noted in the plan — not needed now)
+- **⚑ Owner manual steps:** (1) re-paste the Part A routine prompts into the **dispatch** + **docs
+  reconciliation** routine console configs (routine-prompt mirror convention); (2) redeploy the new
+  skill on the VPS — `bash scripts/hermes/install-skills.sh` + restart `hermes-gateway` — to activate
+  the 6H schedule.
+- **⚑ Self-initiated:** `none` (this build was owner-directed, Q-0174 lane B5)
+- **↪ Next:** the codex-review integration is fully shipped; the natural follow-up is the
+  `codex-flag` issue-outcome dashboard tile (session idea above) once pr-check has run a few cycles and
+  produced real issues to score.

--- a/docs/operations/autonomous-routines.md
+++ b/docs/operations/autonomous-routines.md
@@ -115,6 +115,27 @@ STEP 1 — GO-SIGNAL: the triggering `reconcile` issue IS your go-signal — do 
   re-gate on check_reconciliation_due: the issue means reconciliation is wanted, whether the
   cadence fired or an agent spotted drift.) Note its number.
 
+STEP 1b — CHECK CODEX FIRST (first priority, before the reconcile pass — Q-0174). Scan the few
+  most-recent merged PRs (and any open ones) for UNRESOLVED Codex/bot review comments. Codex cannot
+  push a branch or open a PR — it leaves a COMMENT (a summary + a proposed diff + a `[View task →]`
+  link, describing changes in its own sandbox copy). READ ITS COMMENT, do NOT hunt for a Codex
+  branch/PR (there is none). For each flag, apply the "real bug" bar — ACTIONABLE only if ALL hold:
+    (a) VERIFIED against current `main` source — real *now*, not an artifact. Reject the born-red
+        timing class (Codex reviews the card-first commit *before* the code lands → "implementation
+        missing / flip the card / script doesn't exist"), an `is_outdated` thread, a since-fixed line.
+    (b) A genuine defect: a correctness bug · an architecture/ownership violation · a docs-vs-code
+        contradiction or stale-fact drift that would mislead an agent (the kind this routine owns —
+        e.g. the `/session-close` cadence Codex caught) · a security/safety/privacy gap.
+    (c) NOT a nitpick / preference / false positive / anything the repo's checkers already pass.
+  ROUTE BY SHAPE (you are docs-only, Q-0107): a verified-real DOCS defect → fix it now in this pass
+  (it jumps the queue). A verified-real RUNTIME bug → do NOT fix it here; append it OPEN to
+  docs/health/bug-book.md (step 3) for the dispatch routine, citing the PR/file/line + which bar
+  clause it meets. A born-red false-positive is acknowledged-and-skipped, not "fixed." Bounded read
+  (the recent PRs, not the whole history). Unsure → skip it (the Q-0174 Hermes pr-check skill opens
+  an issue for genuinely-unclear ones); never act blindly — the bot is one input, verified against
+  shipped source (Q-0120). The full bar lives in
+  docs/planning/codex-review-integration-plan-2026-06-17.md.
+
 STEP 2 — RECONCILE (the Q-0107 pass):
   - Ledger: run `python3.10 scripts/check_current_state_ledger.py --strict`; fix all drift (add
     missing merged-PR entries; trim Recently-shipped past the ratchet into the archive).

--- a/docs/operations/hermes-dispatch-bridge.md
+++ b/docs/operations/hermes-dispatch-bridge.md
@@ -93,6 +93,28 @@ dispatched work, or the next plan slice.
    log -> docs/health/bug-book.md -> docs/AGENT_ORIENTATION.md (your task's reading route). This
    repo has a real workflow — follow it; do not invent your own.
 
+1b. CHECK CODEX FIRST (first priority, before you take new work — Q-0174). Scan the few
+   most-recent merged PRs (and any open ones) for UNRESOLVED Codex/bot review comments. Codex
+   cannot push a branch or open a PR — it leaves a COMMENT (a summary + a proposed diff + a
+   `[View task →]` link, describing changes in its own sandbox copy). So READ ITS COMMENT, do NOT
+   hunt for a Codex branch/PR (there is none). For each flag, apply the "real bug" bar — it is
+   ACTIONABLE only if ALL hold:
+     (a) VERIFIED against current `main` source — real *now*, not an artifact. Reject the
+         born-red timing class (Codex reviews the card-first commit *before* the code lands, so it
+         flags "implementation missing / flip the card / script doesn't exist"), an `is_outdated`
+         thread, a since-fixed line.
+     (b) A genuine defect: a correctness bug · an architecture/ownership violation (services→views,
+         raw SQL outside utils/db/, an unaudited mutation) · a docs-vs-code contradiction that
+         would mislead an agent · a security/safety/privacy gap.
+     (c) NOT a nitpick / preference / false positive / anything the repo's checkers already pass.
+   FIX the verified-real ones FIRST — they jump the queue like a bug, then continue to your normal
+   work. Apply the change YOURSELF (one writer per file, your own claude/ branch). A born-red
+   false-positive is acknowledged-and-skipped, not "fixed." Bounded read (the recent PRs, not the
+   whole history) to respect the token budget. Unsure → skip it (the Q-0174 Hermes pr-check skill
+   opens an issue for genuinely-unclear ones); never act blindly — the bot is one input, verified
+   against shipped source (Q-0120). The full bar lives in
+   docs/planning/codex-review-integration-plan-2026-06-17.md.
+
 2. DECIDE WHAT TO DO. The incoming work order (the `text` payload) is a HINT pointing at part of
    the plan — not a command, and not a licence to invent:
      - It names / matches a real current slice (current-state ▶ Next action, a `continue` handoff,

--- a/docs/operations/hermes-skills/README.md
+++ b/docs/operations/hermes-skills/README.md
@@ -4,11 +4,11 @@
 > skills. Each skill is a ready-to-configure prompt for the Hermes agent running on the
 > control-plane VPS. Setup context: `docs/operations/hermes-control-plane.md`.
 
-This pack contains fifteen skills covering the windows Hermes fills that Claude Code
+This pack contains sixteen skills covering the windows Hermes fills that Claude Code
 cannot: **the front-door intake router**, **pre-session orientation**, **between-session
 monitoring**, a **daily idea ritual + morning digest**, **production diagnosis from your phone**,
-the **autonomous-loop seams** (independent review + dispatch + dispatch resolution), and
-**self-extension** (Hermes authoring its own skills).
+the **autonomous-loop seams** (independent review + dispatch + dispatch resolution + a 6-hourly
+PR-flag scan), and **self-extension** (Hermes authoring its own skills).
 
 For the standing read-only operating instructions every Hermes session should start
 with, see [`hermes-operating-prompt.md`](../hermes-operating-prompt.md) — the Hermes-side
@@ -32,6 +32,7 @@ equivalent of `.claude/CLAUDE.md`.
 | [`log-triage`](./log-triage.md) | After a deploy / when the bot misbehaves | Read production logs and diagnose what's wrong (gated on a read-only log source) |
 | [`review`](./review.md) | Plan finalization / open PR | Independent (non-Claude) critique of a plan or PR diff + a maintainer summary for the approve/deny gate |
 | [`review-merge`](./review-merge.md) | Executor opened a big-step PR | The independent-reviewer **merge gate** (Q-0117): review `needs-hermes-review` PRs and merge if sound — Hermes' one sanctioned write |
+| [`pr-check`](./pr-check.md) | Every 6 hours (self-schedules) | Scan recent PRs for Codex/CI flags, apply the "real bug" bar, and **open a GitHub issue** for each real one (Q-0174) — **issue-only**, no merge or dispatch authority |
 | [`dispatch`](./dispatch.md) | Idea on your phone | Assemble a work order and fire a Claude Code Routine to build it (the autonomous-loop chaining link) |
 | [`dispatch-resolve`](./dispatch-resolve.md) | "work on sector SX" | Resolve a vague sector/lane directive into a concrete work order routed to the right executor (then delegates to `dispatch`) |
 | [`skill-author`](./skill-author.md) | A workflow you repeat / "make a skill for X" | The **meta-skill**: design a new skill and land its source in the repo via a docs-only PR (so Hermes-authored skills are version-controlled, not VPS-only) |
@@ -81,8 +82,9 @@ Some skills ship a `blueprint.schedule` in their frontmatter, so once installed 
 self-schedules them to your home channel — **no extra VPS cron needed**, and each scheduled
 run is a fresh, stateless session (it never clogs your interactive chat). Currently scheduled:
 **`morning-briefing`** (`0 6 * * *` — the daily digest), **`idea-spotlight`** (`30 6 * * *` —
-the daily idea ritual), and **`review-merge`** (`30 7 * * *` — the needs-hermes-review queue).
-Change a time in `scripts/hermes/build_skills.py` and rebuild. *(For automatically clearing the
+the daily idea ritual), **`review-merge`** (`30 7 * * *` — the needs-hermes-review queue), and
+**`pr-check`** (`0 */6 * * *` — the 6-hourly Codex/CI PR-flag scan, issue-only). Change a time in
+`scripts/hermes/build_skills.py` and rebuild. *(For automatically clearing the
 **interactive** chat session, that's a separate VPS timer — see
 [`../hermes-session-reset.md`](../hermes-session-reset.md).)*
 

--- a/docs/operations/hermes-skills/pr-check.md
+++ b/docs/operations/hermes-skills/pr-check.md
@@ -1,0 +1,132 @@
+# Skill: `superbot-pr-check`
+
+> **Status:** `living-ledger` — ready-to-use Hermes skill prompt. Update when the "real bug" bar,
+> the PRs-to-scan window, or the issue-filing convention change. Built for Q-0174
+> ([codex-review-integration plan](../../planning/codex-review-integration-plan-2026-06-17.md)).
+
+**Window:** every 6 hours (self-scheduled, `0 */6 * * *`)
+**Purpose:** Scan recent PRs for Codex/bot review flags, apply the "real bug" bar, and **open a
+GitHub issue** for each verified-real defect — so a real bug Codex caught never sits unactioned,
+and a false positive never burns a routine fire. **Issue-only: no merge, no dispatch authority.**
+
+**When to use:** runs itself on the 6H schedule; also fire it by hand after a burst of merges, or
+when you want a second pass over the open-PR queue before the morning briefing.
+
+---
+
+## Prompt
+
+```
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Do not modify any files. Read-only on the repo. Your ONE write action is opening GitHub issues —
+you do NOT edit code, push, merge, comment-to-fix, dispatch a fixer, or touch production/Railway/Neon.
+
+This is the SuperBot PR CHECK (Q-0174). The job: find real bugs Codex/CI flagged on recent PRs and
+OPEN AN ISSUE for each — issue-only, never auto-dispatch. Dispatch happens only on the owner's
+command, or when a routine picks the issue up on its normal fire. Budget matters: routines fire only
+~15 times/day, so a false-positive issue is worse than none. Hold a high bar.
+
+STEP 1 — LIST THE PRs (bounded read, to respect the token budget):
+  Run: gh pr list --repo menno420/superbot --state open --json number,title,headRefName,isDraft
+  Run: gh pr list --repo menno420/superbot --state merged --limit 8 \
+         --json number,title,headRefName,mergedAt
+  These ~8 most-recent merged PRs + the open ones are your scan set — not the whole history.
+
+STEP 2 — READ EACH PR's SIGNALS (read-only):
+  For each PR number N:
+    - Codex/bot review COMMENTS and review threads:
+        gh pr view N --repo menno420/superbot --json reviews,comments,statusCheckRollup
+        gh api repos/menno420/superbot/pulls/N/comments        # inline review comments
+    - Note UNRESOLVED threads and any failing required check (statusCheckRollup).
+  Codex CANNOT push a branch or open a PR — it leaves a COMMENT (a summary + a proposed diff + a
+  `[View task →]` link describing changes in its own sandbox copy, even when it says "Committed
+  <sha>"). NOTHING of Codex's reaches the repo. So read the proposed change from its COMMENT — the
+  diff / the file·Lnn references it cites — and do NOT hunt for a Codex branch or PR (there is none).
+
+STEP 3 — APPLY THE "REAL BUG" BAR. A flag is ACTIONABLE only if ALL THREE hold:
+  (a) VERIFIED against current `main` source — real *now*, not an artifact. Reject the common
+      non-bugs:
+        - THE BORN-RED TIMING CLASS — Codex reviews the card-first commit *before* the code lands,
+          so it flags "implementation missing / flip the card / script doesn't exist" (the
+          #1023/#1024/#1027 false positives). Check the MERGED PR's final state, not the opening
+          commit Codex saw.
+        - an `is_outdated` review thread; a line already fixed in a later commit / a later PR.
+      To verify, read the cited file on `main`:
+        gh api repos/menno420/superbot/contents/<path>?ref=main  (or git show origin/main:<path>)
+  (b) A GENUINE DEFECT — one of:
+        - a CORRECTNESS bug (wrong behaviour / crash / a broken contract or invariant),
+        - a real ARCHITECTURE/OWNERSHIP violation (services→views, raw SQL outside utils/db/, an
+          unaudited mutation),
+        - a DOCS-vs-CODE contradiction or stale-fact drift that would mislead an agent (e.g. the
+          /session-close cadence Codex caught),
+        - a SECURITY / SAFETY / PRIVACY gap.
+  (c) NOT a nitpick / preference / false positive — "could be cleaner", a speculative "might want
+      to", or anything the repo's own checkers already pass is NOT a real bug.
+  UNSURE → open an issue DESCRIBING what you found (say it's unconfirmed); never dispatch, never act
+  blindly. The bot is one input, verified against shipped source (Q-0120).
+
+STEP 4 — OPEN AN ISSUE per real bug (your one write action):
+  Run, for each:
+    gh issue create --repo menno420/superbot --label bug --label codex-flag \
+      --title "PR #N: <one-line what's wrong>" \
+      --body "<the PR/file/line · what's wrong · which bar clause (a/b/c) it meets · the Codex
+               comment link if any · 'unconfirmed' if you weren't sure>"
+  One issue per distinct bug. Do NOT bundle unrelated bugs. Do NOT open an issue for a flag that
+  fails the bar — note it as skipped in your report instead. (If the `codex-flag` label doesn't
+  exist yet, create it: gh label create codex-flag --color FBCA04, or drop the second --label.)
+  You do NOT label anything for auto-dispatch — the dispatch routine picks bug-book/issue items up
+  on its own normal fire; that is the owner's standing design until pr-check is proven (graduation
+  to auto-dispatch is a later owner decision, not this skill's authority).
+
+STEP 5 — REPORT in the HOUSE STYLE (docs/operations/hermes-skills/_house-style.md): bottom line
+  first, plain words (translate jargon — "unresolved review thread" -> "a comment nobody's acted on
+  yet"; "born-red false positive" -> "a flag from before the code was finished, not a real bug"),
+  grouped, one screen. Keep PR #numbers and ✅/⚠️/❌. Shape:
+
+---
+🔎 PR check — [date + time]
+
+Bottom line: [All clear, nothing real to act on / opened N issue(s) for real bugs / N flags, all
+              were false positives].
+
+   Scanned          [N open + M recent merged PRs]
+   Real bugs found  ✅/⚠️/❌  [none / N — each opened as an issue #number]
+   Skipped flags    [N flags that didn't meet the bar — one plain phrase why, grouped]
+
+Issues opened (only if any):
+   • #<issue> — [PR #N · one plain line of what's wrong]
+
+Details (only if a real bug needs explaining):
+[each real bug in one plain paragraph — what it is + which PR/file + why it's real]
+---
+
+RULES:
+- Invoke the repo's `gh`/stdlib tooling with the VPS Python (`python3`, 3.11) if you script
+  anything — the `python3.10` pin in .claude/CLAUDE.md is only for CI-parity tools Hermes never runs.
+- ISSUE-ONLY. You never merge, never dispatch a fixer, never edit code. If gh is not authenticated,
+  say so and stop — never guess a PR's contents.
+- A pr-check that cries wolf is worse than silence (the routine-budget rationale). When in genuine
+  doubt whether something is real, the issue body must say so — but the high bar means most runs
+  open ZERO issues, and "all clear" is the expected, healthy result.
+```
+
+---
+
+## Notes
+
+- **Issue-only by design (Q-0174).** This skill is **additive** and has **no merge or dispatch
+  authority** — it opens issues and nothing else. Auto-dispatch on a real bug is a deliberate later
+  decision ("graduation") once Hermes's issues prove consistently real over a few cycles; until then
+  the owner (or a routine on its normal fire) decides what to act on.
+- **Why 6H / why bounded.** Routine fires are scarce (~15/day), so the scan is capped to the recent
+  PRs (~8 merged + the open ones), and the bar is high — most runs should open zero issues. The 6H
+  cadence catches a real bug within a quarter-day without spamming the issue tracker.
+- **Invoke the repo's stdlib checkers with `python3`** (the VPS has 3.11, not 3.10) — the
+  `python3.10` pin in `.claude/CLAUDE.md` is **only** for the CI-parity tools (`check_quality` /
+  black / mypy / pytest), which Hermes does not run.
+- **The complementary half** is the routine-side fix-first step (Part A of the same plan): the
+  dispatch + reconciliation routines check Codex first and *fix* verified-real bugs they find. This
+  skill is the **between-routine** safety net that turns a missed flag into a tracked issue.
+- After editing this doc, rebuild + redeploy:
+  `python3 scripts/hermes/build_skills.py` → `bash scripts/hermes/install-skills.sh` (owner's VPS
+  step).

--- a/docs/planning/codex-review-integration-plan-2026-06-17.md
+++ b/docs/planning/codex-review-integration-plan-2026-06-17.md
@@ -1,8 +1,23 @@
 # Plan — Codex review integration: routines fix flagged issues first; Hermes scans PRs (issue-only)
 
-> **Status:** `plan` — owner-directed 2026-06-17 (**Q-0174**). Builds on Q-0171 (Codex live) + the
+> **Status:** `historical` — **FULLY EXECUTED 2026-06-19 (PR #1132, lane B5).** Owner-directed
+> 2026-06-17 (**Q-0174**). Builds on Q-0171 (Codex live) + the
 > born-red-timing finding ([`codex-automated-pr-review-2026-06-17.md`](../ideas/codex-automated-pr-review-2026-06-17.md)).
 > Source + binding contracts win over this plan.
+>
+> **Both parts shipped 2026-06-19 (PR #1132, lane B5):**
+> - **Part A** — the "check Codex first, verified" first-priority step is in BOTH routine prompts:
+>   the **dispatch** routine ([`hermes-dispatch-bridge.md`](../operations/hermes-dispatch-bridge.md)
+>   § "The routine's saved prompt", step 1b) and the **reconciliation** routine
+>   ([`autonomous-routines.md`](../operations/autonomous-routines.md) § "superbot docs reconciliation",
+>   STEP 1b — docs defect fixed in pass, runtime bug captured to the bug-book). These are the in-repo
+>   canonical mirror; the **owner re-pastes** each into its routine's console config to take effect.
+> - **Part B** — the `superbot-pr-check` Hermes skill is built:
+>   [`hermes-skills/pr-check.md`](../operations/hermes-skills/pr-check.md) (doc = source of truth, house
+>   style) + an `EXTRAS` entry with the 6H `schedule "0 */6 * * *"` in `scripts/hermes/build_skills.py`
+>   + a README row + the regenerated `scripts/hermes/skills/pr-check/SKILL.md`. **Issue-only** (no merge
+>   or dispatch authority). **Owner manual step:** redeploy on the VPS
+>   (`bash scripts/hermes/install-skills.sh` + restart `hermes-gateway`) to activate the schedule.
 
 ## Owner directive (2026-06-17)
 
@@ -34,7 +49,7 @@ A Codex/bot review comment (or CI signal) is **ACTIONABLE only if ALL** hold:
 **Unsure → open an issue describing what you found; do not dispatch.** Never act blindly — the bot is
 one input, verified against shipped source (Q-0120).
 
-## Part A — routines check Codex first (prompt change, ships now)
+## Part A — routines check Codex first (prompt change) — ✅ SHIPPED (PR #1132)
 
 Add to the **dispatch** + **reconciliation** routine prompts a first-priority step: *before* taking new
 work, scan the **few most-recent merged PRs (and any open ones)** for **unresolved** Codex/bot review
@@ -55,7 +70,7 @@ our repo.** Therefore an agent acting on a Codex flag:
 - does **NOT** hunt for a Codex-pushed branch or a Codex PR (there is none — that hunt was the only
   real friction Codex caused, a verification detour on #1032).
 
-## Part B — Hermes 6H PR-check skill (to build; spec only for now)
+## Part B — Hermes 6H PR-check skill — ✅ SHIPPED (PR #1132)
 
 A new hermes-skill `superbot-pr-check`, self-scheduled **every 6H** (`blueprint.schedule "0 */6 * * *"`),
 that:

--- a/scripts/hermes/build_skills.py
+++ b/scripts/hermes/build_skills.py
@@ -131,6 +131,15 @@ EXTRAS: dict[str, SkillExtras] = {
         tags=["Meta", "SuperBot", "SelfExtension"],
         related=["superbot-prompt-builder"],
     ),
+    "pr-check": SkillExtras(
+        tags=["Review", "SuperBot", "Quality"],
+        related=["superbot-review", "superbot-review-merge"],
+        schedule=(
+            "0 */6 * * *",
+            "Scan recent PRs for Codex/CI flags, apply the 'real bug' bar, and "
+            "open a GitHub issue for each real bug (issue-only — no dispatch).",
+        ),
+    ),
 }
 
 VERSION = "1.0.0"

--- a/scripts/hermes/skills/pr-check/SKILL.md
+++ b/scripts/hermes/skills/pr-check/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: superbot-pr-check
+description: "Scan recent PRs for Codex/bot review flags, apply the \"real bug\" bar, and **open a GitHub issue** for each verified-real defect — so a real bug Codex caught never sits unactioned, and a false positive never burns a routine fire. **Issue-only: no merge, no dispatch authority.**"
+version: 1.0.0
+author: "SuperBot agents"
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Review, SuperBot, Quality]
+    related_skills: [superbot-review, superbot-review-merge]
+    blueprint:
+      schedule: "0 */6 * * *"
+      deliver: origin
+      prompt: "Scan recent PRs for Codex/CI flags, apply the 'real bug' bar, and open a GitHub issue for each real bug (issue-only — no dispatch)."
+      no_agent: false
+---
+
+<!-- GENERATED — DO NOT EDIT. Source of truth: docs/operations/hermes-skills/pr-check.md. Regenerate with scripts/hermes/build_skills.py. -->
+
+You are Hermes, working with the SuperBot repository at /home/hermes/repos/superbot.
+Do not modify any files. Read-only on the repo. Your ONE write action is opening GitHub issues —
+you do NOT edit code, push, merge, comment-to-fix, dispatch a fixer, or touch production/Railway/Neon.
+
+This is the SuperBot PR CHECK (Q-0174). The job: find real bugs Codex/CI flagged on recent PRs and
+OPEN AN ISSUE for each — issue-only, never auto-dispatch. Dispatch happens only on the owner's
+command, or when a routine picks the issue up on its normal fire. Budget matters: routines fire only
+~15 times/day, so a false-positive issue is worse than none. Hold a high bar.
+
+STEP 1 — LIST THE PRs (bounded read, to respect the token budget):
+  Run: gh pr list --repo menno420/superbot --state open --json number,title,headRefName,isDraft
+  Run: gh pr list --repo menno420/superbot --state merged --limit 8 \
+         --json number,title,headRefName,mergedAt
+  These ~8 most-recent merged PRs + the open ones are your scan set — not the whole history.
+
+STEP 2 — READ EACH PR's SIGNALS (read-only):
+  For each PR number N:
+    - Codex/bot review COMMENTS and review threads:
+        gh pr view N --repo menno420/superbot --json reviews,comments,statusCheckRollup
+        gh api repos/menno420/superbot/pulls/N/comments        # inline review comments
+    - Note UNRESOLVED threads and any failing required check (statusCheckRollup).
+  Codex CANNOT push a branch or open a PR — it leaves a COMMENT (a summary + a proposed diff + a
+  `[View task →]` link describing changes in its own sandbox copy, even when it says "Committed
+  <sha>"). NOTHING of Codex's reaches the repo. So read the proposed change from its COMMENT — the
+  diff / the file·Lnn references it cites — and do NOT hunt for a Codex branch or PR (there is none).
+
+STEP 3 — APPLY THE "REAL BUG" BAR. A flag is ACTIONABLE only if ALL THREE hold:
+  (a) VERIFIED against current `main` source — real *now*, not an artifact. Reject the common
+      non-bugs:
+        - THE BORN-RED TIMING CLASS — Codex reviews the card-first commit *before* the code lands,
+          so it flags "implementation missing / flip the card / script doesn't exist" (the
+          #1023/#1024/#1027 false positives). Check the MERGED PR's final state, not the opening
+          commit Codex saw.
+        - an `is_outdated` review thread; a line already fixed in a later commit / a later PR.
+      To verify, read the cited file on `main`:
+        gh api repos/menno420/superbot/contents/<path>?ref=main  (or git show origin/main:<path>)
+  (b) A GENUINE DEFECT — one of:
+        - a CORRECTNESS bug (wrong behaviour / crash / a broken contract or invariant),
+        - a real ARCHITECTURE/OWNERSHIP violation (services→views, raw SQL outside utils/db/, an
+          unaudited mutation),
+        - a DOCS-vs-CODE contradiction or stale-fact drift that would mislead an agent (e.g. the
+          /session-close cadence Codex caught),
+        - a SECURITY / SAFETY / PRIVACY gap.
+  (c) NOT a nitpick / preference / false positive — "could be cleaner", a speculative "might want
+      to", or anything the repo's own checkers already pass is NOT a real bug.
+  UNSURE → open an issue DESCRIBING what you found (say it's unconfirmed); never dispatch, never act
+  blindly. The bot is one input, verified against shipped source (Q-0120).
+
+STEP 4 — OPEN AN ISSUE per real bug (your one write action):
+  Run, for each:
+    gh issue create --repo menno420/superbot --label bug --label codex-flag \
+      --title "PR #N: <one-line what's wrong>" \
+      --body "<the PR/file/line · what's wrong · which bar clause (a/b/c) it meets · the Codex
+               comment link if any · 'unconfirmed' if you weren't sure>"
+  One issue per distinct bug. Do NOT bundle unrelated bugs. Do NOT open an issue for a flag that
+  fails the bar — note it as skipped in your report instead. (If the `codex-flag` label doesn't
+  exist yet, create it: gh label create codex-flag --color FBCA04, or drop the second --label.)
+  You do NOT label anything for auto-dispatch — the dispatch routine picks bug-book/issue items up
+  on its own normal fire; that is the owner's standing design until pr-check is proven (graduation
+  to auto-dispatch is a later owner decision, not this skill's authority).
+
+STEP 5 — REPORT in the HOUSE STYLE (docs/operations/hermes-skills/_house-style.md): bottom line
+  first, plain words (translate jargon — "unresolved review thread" -> "a comment nobody's acted on
+  yet"; "born-red false positive" -> "a flag from before the code was finished, not a real bug"),
+  grouped, one screen. Keep PR #numbers and ✅/⚠️/❌. Shape:
+
+---
+🔎 PR check — [date + time]
+
+Bottom line: [All clear, nothing real to act on / opened N issue(s) for real bugs / N flags, all
+              were false positives].
+
+   Scanned          [N open + M recent merged PRs]
+   Real bugs found  ✅/⚠️/❌  [none / N — each opened as an issue #number]
+   Skipped flags    [N flags that didn't meet the bar — one plain phrase why, grouped]
+
+Issues opened (only if any):
+   • #<issue> — [PR #N · one plain line of what's wrong]
+
+Details (only if a real bug needs explaining):
+[each real bug in one plain paragraph — what it is + which PR/file + why it's real]
+---
+
+RULES:
+- Invoke the repo's `gh`/stdlib tooling with the VPS Python (`python3`, 3.11) if you script
+  anything — the `python3.10` pin in .claude/CLAUDE.md is only for CI-parity tools Hermes never runs.
+- ISSUE-ONLY. You never merge, never dispatch a fixer, never edit code. If gh is not authenticated,
+  say so and stop — never guess a PR's contents.
+- A pr-check that cries wolf is worse than silence (the routine-budget rationale). When in genuine
+  doubt whether something is real, the issue body must say so — but the high bar means most runs
+  open ZERO issues, and "all clear" is the expected, healthy result.


### PR DESCRIPTION
Lane B5 of the ultracode fleet (owner-directed, **Q-0174**). Ships the two unbuilt parts of
[`docs/planning/codex-review-integration-plan-2026-06-17.md`](docs/planning/codex-review-integration-plan-2026-06-17.md).

## Part A — routines check Codex first (prompt change, ships now)

Adds a first-priority "**check Codex first, verified**" step to BOTH autonomous routine prompts:

- **dispatch** routine (`docs/operations/hermes-dispatch-bridge.md` § "The routine's saved prompt")
- **reconciliation** routine (`docs/operations/autonomous-routines.md` § "superbot docs reconciliation")

Before taking new work, each routine now scans the few most-recent merged/open PRs for **unresolved**
Codex/bot review comments, applies the plan's **"real bug" bar** (verified against current `main`,
genuine defect, not a nitpick / born-red false positive), and **fixes the verified-real ones first** —
they jump the queue. Codex can't push a branch or open a PR, so the agent reads its **comment** (the
proposed diff / `file·Lnn` refs), verifies against `main`, and applies the real changes itself; it does
**not** hunt for a Codex branch/PR.

These routine-prompt edits are the in-repo **canonical mirror** — per the routine-prompt convention,
the owner re-pastes each into its routine's console config to take effect.

## Part B — Hermes 6H PR-check skill (built)

New Hermes skill `superbot-pr-check`, self-scheduled **every 6H** (`schedule "0 */6 * * *"`):

- `docs/operations/hermes-skills/pr-check.md` — the doc = source of truth, in the `_house-style.md`
  output shape.
- `scripts/hermes/build_skills.py` — an `EXTRAS` entry registering it with the 6H schedule.
- `docs/operations/hermes-skills/README.md` — a new skill row + the scheduled-skills list updated.
- Regenerated artifact: `scripts/hermes/skills/pr-check/SKILL.md` (committed, in sync).

The skill lists open + recently-merged PRs, reads Codex comments / CI / unresolved threads, applies
the **"real bug" bar**, and **opens a GitHub issue** for each real bug. It is **additive + issue-only**
— it has **NO merge and NO dispatch authority** (dispatch happens only on the owner's command or a
routine picking the issue up on its normal fire). Low-risk and reversible.

## Owner follow-up (not done here)

- **VPS redeploy** of the new skill: `bash scripts/hermes/install-skills.sh` (+ restart
  `hermes-gateway`) on the control-plane VPS — the manual step that activates the 6H schedule.
- **Re-paste** the Part A routine prompts into the dispatch + reconciliation routine console configs.

## Checks

`check_docs.py --strict`, `check_quality.py --full`, `check_architecture.py --mode strict` all green
on the final head (no `disbot/` runtime touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJANFhJehGkv15K6hHDWoz)_