### PR TITLE
B4: extend consistency linter (select-option truncation) to disbot/cogs/

### DIFF
--- a/.sessions/2026-06-19-consistency-linter-cogs.md
+++ b/.sessions/2026-06-19-consistency-linter-cogs.md
@@ -1,0 +1,11 @@
+# Session — extend consistency linter (select-option truncation) to `disbot/cogs/`
+
+> **Status:** `in-progress`
+
+**Lane B4 (ultracode fleet).** Extending `scripts/check_consistency.py` rule 4
+(`select_option_truncation`) to also scan `disbot/cogs/` — the cog-layer blind spot
+BUG-0017 (Cog Manager dropdown silently dropped 22/46 cogs via `options[:25]`) lived in.
+The SelectOption module-gate stays so leaderboard `[:10]` slices in non-select cogs stay
+out; the new cog coverage is **warn-only** (no graduation this PR — the graduated `views/`
+coverage stays error). Evaluating `panel_base_class` for cogs (likely N/A — cogs are
+`commands.Cog`, not `discord.ui.View`). Code + tests + allowlist + plan + PR, born-red → green.

--- a/.sessions/2026-06-19-consistency-linter-cogs.md
+++ b/.sessions/2026-06-19-consistency-linter-cogs.md
@@ -1,11 +1,81 @@
 # Session — extend consistency linter (select-option truncation) to `disbot/cogs/`
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-**Lane B4 (ultracode fleet).** Extending `scripts/check_consistency.py` rule 4
-(`select_option_truncation`) to also scan `disbot/cogs/` — the cog-layer blind spot
-BUG-0017 (Cog Manager dropdown silently dropped 22/46 cogs via `options[:25]`) lived in.
-The SelectOption module-gate stays so leaderboard `[:10]` slices in non-select cogs stay
-out; the new cog coverage is **warn-only** (no graduation this PR — the graduated `views/`
-coverage stays error). Evaluating `panel_base_class` for cogs (likely N/A — cogs are
-`commands.Cog`, not `discord.ui.View`). Code + tests + allowlist + plan + PR, born-red → green.
+**Lane B4 (ultracode fleet).** PR #1133.
+
+## What & why
+`scripts/check_consistency.py` rule 4 (`select_option_truncation`) was `views/`-scoped, a
+real cog-layer blind spot — **BUG-0017** (the Cog Manager dropdown silently dropped 22/46
+cogs via `options[:25]`) lived in exactly that gap. This is the plan's anticipated follow-up:
+the rule-4 row ended *"extend rule 4 to `disbot/cogs/` … if a cog-level select truncation
+ever surfaces"* — BUG-0017 was that surfaced case.
+
+## Change
+- **Rule 4 now scans both `views/` and `cogs/`.** The `SelectOption` module-gate is kept for
+  both, so a leaderboard `[:10]` in a non-select cog stays OUT (only a file that actually
+  constructs a `discord.SelectOption` is scanned).
+- **Cog coverage is WARN-ONLY** via a new `Finding.force_warning` flag. `run_checks` keeps a
+  `force_warning` finding at `warning` even though the rule is graduated to `error` for
+  `views/` — so the not-yet-soaked cog scope can't fail CI before it graduates separately
+  (the step-3 graduation discipline). The `views/` scope stays error-enforced, unchanged.
+- `_all_files()` widened to include `disbot/cogs/`; the views-only rules
+  (`edit_in_place`/`back_button`/`panel_base_class`) self-restrict via their own
+  `rel.startswith("views/")` guard, so they still skip cogs.
+- **`panel_base_class` for cogs: evaluated, NOT extended.** Cogs are `commands.Cog`
+  subclasses, so the rule doesn't apply to the cogs themselves. A few cog *modules* define
+  helper `discord.ui.View` subclasses (`cogs/logging/select_view.py`,
+  `cogs/logging/provision_view.py`, `cogs/deathmatch_cog.py`, `cogs/settings_cog.py`) — a
+  separate, larger triage surface, out of scope for this warn-only extension. Deliberately
+  not extended (forced filler ≠ work); noted in the plan.
+
+## First-run cog-scope finding count: **2** (net new genuine truncations: **0**)
+Both are `top_xp[:3]` / `top_coins[:3]` in `cogs/community_spotlight_cog.py::_build_main_embed`
+— top-3 leaderboard **embed** fields, not selects (the file's real `_GameSelect` builds from
+the fixed `_GAMES` list, no slice). Allowlisted by `::qualname` so the file's select stays
+checked. BUG-0017's Cog Manager dropdown is already windowed (#1120, `attach_windowed_select`)
+so it produces zero findings — the rule is now its regression guard.
+
+## Tests
+Flipped the old cogs-scope **negative** (`test_trunc_only_scans_views`) into positives:
+`test_trunc_flags_front_slice_in_cog_select` (a cog select front-truncation IS flagged),
+`test_trunc_cog_finding_is_warn_only` (force_warning → stays `warning` through `run_checks`),
+`test_trunc_cog_without_select_is_out_of_scope` (module-gate keeps a bare `[:10]` cog out),
+`test_trunc_cog_allowlist_suppresses_by_qualname`, plus `test_all_files_includes_both_views_and_cogs`
+and `test_views_only_rules_skip_cogs`. 42 tests pass.
+
+## Verification
+- `python3.10 scripts/check_consistency.py --mode strict` — exit 0 (cog coverage warn-only).
+- `python3.10 scripts/check_architecture.py --mode strict` — 0 errors.
+- `python3.10 scripts/check_quality.py --full` — green.
+
+## ⚑ Self-initiated
+None beyond the routed B4 lane — this is the plan's named follow-up for BUG-0017.
+
+## 💡 Session idea
+The linter graduates a *rule* as a whole, but this PR shows a rule can have **multiple scopes
+at different maturities** (views graduated, cogs warm-up). Extend the `--graduation` tracker to
+report **per-scope** soak state (e.g. `select_option_truncation [views: GRADUATED] [cogs:
+NOT READY — 0 findings, soaking]`), driven by a small per-scope severity map on the `Rule`
+instead of the single `force_warning` finding flag. That makes "is the cog scope ready to flip
+to error?" a one-hop answer the same way `--graduation` already does for whole rules, and
+generalizes cleanly to any future scope extension (e.g. adding `services/` to a rule).
+
+## ⟲ Previous-session review
+The `2026-06-18-cog-routing-pagination` session fixed the *views*-side #1040 truncation
+(setup cog-routing select) and, tellingly, proposed exactly this idea as its session idea —
+*"a lightweight invariant test that asserts every operator-facing select built from a registry
+either paginates or stays ≤25, so the next subsystem that crosses a Discord limit fails loudly
+at the source."* This PR is the cog-layer realization of that idea via the linter (a static
+regression guard rather than a runtime test). What that session could have done better: it
+flagged the *cumulative cross-PR drift* class but left the cog layer (where BUG-0017 then
+surfaced) uncovered — closing the symmetric blind spot in the same pass would have pre-empted
+BUG-0017. Workflow improvement surfaced: when a fix closes a limit-drift gap in one layer,
+check the mirror layer (cogs ↔ views) in the same session — the linter's per-scope coverage is
+now the durable mechanism for that.
+
+## 📄 Doc audit
+Plan doc (`docs/planning/repo-consistency-linter-plan-2026-06-17.md`) updated with the cog-scope
+extension (shipped + count + panel_base_class N/A decision). No new owner decision (routed lane,
+no CLAUDE.md/router change). Living-ledger / `active-work.md` are orchestrator-owned (not touched
+this lane, per B4 hard rule).

--- a/architecture_rules/consistency_exceptions.yml
+++ b/architecture_rules/consistency_exceptions.yml
@@ -91,11 +91,14 @@ back_button:
     - pattern: views/xp/main_panel.py::_XpHubView
       reason: "Root XP hub opened directly by the xp cog command; top of its stack."
 
-# select_option_truncation: a `views/...py` path prefix whose front-truncating
-# slice is a *genuine* top-N display (an error message intentionally listing only
-# the first few of many), NOT a select that should paginate. Fix real selects to
-# paginate (see `views/setup/sections/cog_routing.py` `_CogPickView`) — only
-# allowlist a deliberate display truncation.
+# select_option_truncation: a `views/...py` OR `cogs/...py` path prefix whose
+# front-truncating slice is a *genuine* top-N display (an error message or embed
+# field intentionally listing only the first few of many), NOT a select that
+# should paginate. The rule scans both `views/` (graduated — a finding fails CI)
+# and `cogs/` (warn-only; extended 2026-06-19 for the BUG-0017 cog-layer blind
+# spot). Fix real selects to paginate (see `views/setup/sections/cog_routing.py`
+# `_CogPickView`, or the windowed `disbot/cogs/admin/cog_manager.py`
+# `attach_windowed_select`) — only allowlist a deliberate display truncation.
 select_option_truncation:
   exceptions:
     # --- Embed / text displays, NOT selects (the slice feeds an embed field or
@@ -172,6 +175,14 @@ select_option_truncation:
       reason: "repair/craft selects are bounded by the curated gear+recipe catalog; under 25."
     - pattern: views/mining/gear_panel.py::_ItemSelect.__init__
       reason: "owned items in one slot, bounded by the curated per-slot gear catalog; under 25 (24 + unequip sentinel)."
+    # --- disbot/cogs/ scope (extended for the BUG-0017 cog-layer blind spot,
+    #     2026-06-19). The cog scope is warn-only until it soaks clean. The Cog
+    #     Manager dropdown (BUG-0017) is already windowed (#1120) so it produces
+    #     zero findings — the rule is now its regression guard. The only first-run
+    #     cog hit is a top-N embed display (not a select), allowlisted by ::qualname
+    #     so the file's real `_GameSelect` select stays checked. ---
+    - pattern: cogs/community_spotlight_cog.py::_build_main_embed
+      reason: "top_xp[:3] / top_coins[:3] are the top-3 XP/coins leaderboard EMBED fields, not a select; the file's `_GameSelect` builds its options from the fixed `_GAMES` list (no slice)."
 
 # panel_base_class: a view extending `discord.ui.View` directly outside the
 # rps/blackjack/games/ai path lanes. These entries MIRROR the arch checker's

--- a/docs/planning/repo-consistency-linter-plan-2026-06-17.md
+++ b/docs/planning/repo-consistency-linter-plan-2026-06-17.md
@@ -184,6 +184,28 @@ of editing in place, views that should be `BaseView`/`HubView` but aren't.
    is still open. **Next on this lane:** execute the AI-nav plan PR 1 (runtime/Q-0086 session) to
    start clearing rule 1's 17, then graduate `edit_in_place` once it reaches 0; add rule 5+ only as a
    fresh mechanical-consistency shape surfaces (a candidate: extend rule 4 to `disbot/cogs/`).
+   **Rule 4 extended to `disbot/cogs/` — SHIPPED (#1133, 2026-06-19):** the candidate above became
+   real — **BUG-0017** (the Cog Manager dropdown silently dropped 22/46 cogs via `options[:25]`) was
+   exactly the surfaced cog-level select truncation the rule-4 row's follow-up note anticipated.
+   `select_option_truncation` now scans **both** `views/` (the graduated scope — a finding fails CI)
+   **and** `cogs/`; the `SelectOption` module-gate is kept for both, so leaderboard `[:10]` slices in
+   non-select cogs stay OUT. The cog scope is emitted **warn-only** via a new `Finding.force_warning`
+   flag (`run_checks` keeps a `force_warning` finding at `warning` even though the rule's severity is
+   `error` for views) — graduating the cog scope is a separate later flip once it soaks clean, per the
+   step-3 discipline. **First-run cog-scope count: 2** — both `top_xp[:3]`/`top_coins[:3]` in
+   `cogs/community_spotlight_cog.py::_build_main_embed`, which are top-3 leaderboard **embed** fields
+   (not selects), allowlisted by `::qualname` so the file's real `_GameSelect` stays checked. BUG-0017's
+   Cog Manager dropdown was already windowed (#1120, `attach_windowed_select`) so it produces **zero**
+   findings — the rule is now its regression guard. *Net new genuine cog truncations: 0.*
+   **`panel_base_class` for cogs — evaluated, NOT extended.** Cogs are `commands.Cog` subclasses, so
+   the rule does not apply to the cogs themselves. A handful of cog *modules* do define helper view
+   classes that subclass `discord.ui.View` directly (`cogs/logging/select_view.py`,
+   `cogs/logging/provision_view.py`, `cogs/deathmatch_cog.py` `_DuelView`/`_ChallengeView`,
+   `cogs/settings_cog.py` `_DisabledHelpHookView`). Those are a *separate, larger* triage surface
+   (each needs its own allowlist/migration call against the arch ground truth) and are out of scope for
+   this warn-only select-truncation extension — so `panel_base_class` was **deliberately not** extended
+   to cogs here (forced filler ≠ work). A future focused PR could take the in-cog-view triage if the
+   owner wants it.
 
 ## Verification (each PR)
 

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -12,10 +12,14 @@ rules that no import graph can catch (owner directive Q-0170, 2026-06-17):
   3. **panel base-class** — a view extending ``discord.ui.View`` directly outside
      the ``views/rps``/``views/blackjack`` game-state allowlist and the framework
      home (``views/base.py``), instead of ``BaseView``/``HubView``/``PersistentView``.
-  4. **select-option truncation** — a select-building view that *front-truncates* a
-     collection (``options[:25]``, ``roles[:25]``) instead of paginating.  A Discord
-     select caps at 25 options, so the slice silently drops every entry past the cap
-     (the #1040 class).  Windowed pagination (``x[start:start+N]``) is not flagged.
+  4. **select-option truncation** — a select-building view *or cog* that
+     *front-truncates* a collection (``options[:25]``, ``roles[:25]``) instead of
+     paginating.  A Discord select caps at 25 options, so the slice silently drops
+     every entry past the cap (the #1040 / BUG-0017 class).  Windowed pagination
+     (``x[start:start+N]``) is not flagged.  The ``views/`` scope is graduated (a
+     finding fails CI); the ``cogs/`` scope is newer and stays warn-only until it
+     soaks clean (the BUG-0017 cog-layer blind spot — the Cog Manager dropdown
+     dropping 22/46 cogs).
 
 It is **warn-first and disposable** (Q-0105): every finding is a warning, nothing
 fails CI yet.  A rule graduates to an error + a ``code-quality`` wire-in only once
@@ -73,6 +77,12 @@ class Finding:
     message: str
     qualname: str = ""
     severity: str = "warning"  # every rule is warn-only until it graduates
+    # When True, ``run_checks`` keeps this finding at ``warning`` even if its rule
+    # has graduated to ``error``.  This lets a single graduated rule cover a NEW,
+    # not-yet-soaked scope (e.g. ``select_option_truncation`` extended to
+    # ``disbot/cogs/``) warn-only while its proven scope (``views/``) keeps failing
+    # CI — graduating the new scope is a separate, later flip once it stays clean.
+    force_warning: bool = False
 
     def display(self, root: Path) -> str:
         try:
@@ -626,15 +636,32 @@ def _front_truncations_with_scope(
     return results
 
 
+# The scopes rule 4 scans.  ``views/`` is the proven, GRADUATED scope (a finding
+# fails CI).  ``cogs/`` is the NEW scope (extended for the BUG-0017 cog-layer
+# blind spot — the Cog Manager dropdown that silently dropped 22/46 cogs via
+# ``options[:25]``); its findings are emitted ``force_warning`` (warn-only) until
+# the cog scope has soaked clean for a few sessions and is graduated separately.
+_SELECT_TRUNCATION_SCOPES = ("views/", "cogs/")
+
+
 def rule_select_option_truncation(files: list[Path], exceptions: dict) -> list[Finding]:
-    """Flag a front-truncating slice in a select-building view (the #1040 class).
+    """Flag a front-truncating slice in a select-building view OR cog (the #1040 class).
 
     A Discord select caps at 25 options, so ``options[:25]`` (or any ``[:N<=25]``)
     silently drops every entry past the cap instead of paginating — the bug that
-    hid routable cogs in the setup cog-routing picker (#1040).  The fix is a
-    windowed page (``x[start:start+N]``), which this rule does not flag.
+    hid routable cogs in the setup cog-routing picker (#1040) and, in the cog
+    layer, the Cog Manager dropdown (**BUG-0017**: 22/46 cogs dropped).  The fix
+    is a windowed page (``x[start:start+N]``), which this rule does not flag.
 
-    Warn-only.  Allowlist a genuine top-N display (e.g. an error message that
+    The rule scans both ``views/`` (the GRADUATED scope — a finding fails CI) and
+    ``cogs/`` (the NEW scope extended for BUG-0017).  Cog findings are emitted
+    **warn-only** (``force_warning``) regardless of the rule's graduated severity,
+    so the not-yet-soaked cog coverage cannot fail CI before it graduates on its
+    own.  The ``SelectOption`` module-gate is kept for both: a file is scanned only
+    if it actually constructs a ``discord.SelectOption``, so a leaderboard
+    ``rows[:10]`` in a cog that never builds a select is NOT flagged.
+
+    Allowlist a genuine top-N display (e.g. an error message or an embed field that
     intentionally lists only the first few of many) in ``consistency_exceptions.yml``.
     """
     cfg = exceptions.get("select_option_truncation", {})
@@ -645,8 +672,12 @@ def rule_select_option_truncation(files: list[Path], exceptions: dict) -> list[F
             rel = str(filepath.relative_to(DISBOT_ROOT))
         except ValueError:
             continue
-        if not rel.startswith("views/") or "test" in rel.lower():
+        if not rel.startswith(_SELECT_TRUNCATION_SCOPES) or "test" in rel.lower():
             continue
+        # Cog-scope coverage is NEW and not yet soaked: emit warn-only so it never
+        # fails CI before the cog scope graduates separately (the views/ scope,
+        # already graduated, keeps the rule's error severity).
+        force_warning = rel.startswith("cogs/")
         try:
             tree = ast.parse(filepath.read_text(encoding="utf-8", errors="replace"))
         except (SyntaxError, OSError):
@@ -664,6 +695,7 @@ def rule_select_option_truncation(files: list[Path], exceptions: dict) -> list[F
                     line=sub.lineno,
                     rule="select_option_truncation",
                     qualname=qualname,
+                    force_warning=force_warning,
                     message=(
                         "front-truncating slice `[:N]` (N≤25) in a select-building "
                         "view silently drops options past Discord's 25-option cap "
@@ -744,7 +776,17 @@ RULES: list[Rule] = [
 
 
 def _all_files() -> list[Path]:
-    return sorted((DISBOT_ROOT / "views").rglob("*.py"))
+    # ``views/`` is the original scope (rules 1–3 + the graduated select rule);
+    # ``cogs/`` is scanned only by ``select_option_truncation`` (extended for the
+    # BUG-0017 cog-layer blind spot).  The other rules self-restrict to ``views/``
+    # by their own ``rel.startswith("views/")`` guard, so including cog files here
+    # widens only the select-truncation rule, as intended.
+    return sorted(
+        [
+            *(DISBOT_ROOT / "views").rglob("*.py"),
+            *(DISBOT_ROOT / "cogs").rglob("*.py"),
+        ],
+    )
 
 
 def _counts_by_rule(findings: list[Finding]) -> dict[str, int]:
@@ -760,9 +802,11 @@ def run_checks(files: list[Path], exceptions: dict) -> list[Finding]:
         rule_findings: list[Finding] = rule.fn(files, exceptions)  # type: ignore[operator]
         # Stamp each finding with its rule's current severity, so graduating a
         # rule to ``error`` (flip ``Rule.severity``) actually makes ``--mode
-        # strict`` fail on it — no per-rule wiring needed.
+        # strict`` fail on it — no per-rule wiring needed.  A finding that opted
+        # into ``force_warning`` (a not-yet-soaked NEW scope of a graduated rule)
+        # stays ``warning`` so it never fails CI before that scope graduates.
         for f in rule_findings:
-            f.severity = rule.severity
+            f.severity = "warning" if f.force_warning else rule.severity
         findings += rule_findings
     return findings
 

--- a/tests/unit/scripts/test_check_consistency.py
+++ b/tests/unit/scripts/test_check_consistency.py
@@ -437,6 +437,32 @@ def build_embed(rows):
     return embed
 """
 
+# A cog module that builds a select AND front-truncates its option source — the
+# BUG-0017 cog-layer class (the Cog Manager dropdown that dropped 22/46 cogs via
+# `options[:25]`). The rule scans `cogs/` too now, so this IS flagged — warn-only.
+_COG_TRUNCATES = """\
+import discord
+
+
+class _CogSelect(discord.ui.Select):
+    def __init__(self, cogs):
+        options = [discord.SelectOption(label=c, value=c) for c in cogs]
+        super().__init__(options=options[:25])
+"""
+
+# A cog module with a bare top-N slice but NO SelectOption — the module-gate keeps
+# leaderboard `[:10]` slices in non-select cogs OUT (no false positive).
+_COG_NO_SELECT = """\
+import discord
+
+
+def build_leaderboard_embed(rows):
+    embed = discord.Embed(title="Top")
+    for row in rows[:10]:
+        embed.add_field(name=row.name, value=str(row.score))
+    return embed
+"""
+
 
 def _trunc_findings(mod, tmp_path, monkeypatch, src, *, rel="views/role_picker.py"):
     _write(mod, tmp_path, monkeypatch, rel, src)
@@ -462,10 +488,74 @@ def test_trunc_non_select_view_is_out_of_scope(mod, tmp_path, monkeypatch):
     assert _trunc_findings(mod, tmp_path, monkeypatch, _NON_SELECT) == []
 
 
-def test_trunc_only_scans_views(mod, tmp_path, monkeypatch):
-    assert (
-        _trunc_findings(mod, tmp_path, monkeypatch, _TRUNCATES, rel="cogs/x.py") == []
+def test_trunc_flags_front_slice_in_cog_select(mod, tmp_path, monkeypatch):
+    # The cog scope was extended for the BUG-0017 cog-layer blind spot: a cog that
+    # builds a select AND front-truncates its options IS flagged now (it used to be
+    # explicitly out of scope). The module-gate still applies.
+    findings = _trunc_findings(
+        mod, tmp_path, monkeypatch, _COG_TRUNCATES, rel="cogs/x.py"
     )
+    assert len(findings) == 1
+    assert findings[0].rule == "select_option_truncation"
+    assert findings[0].qualname == "_CogSelect.__init__"
+
+
+def test_trunc_cog_finding_is_warn_only(mod, tmp_path, monkeypatch):
+    # The cog scope is NEW and not yet soaked, so its findings are emitted
+    # `force_warning` and `run_checks` keeps them at `warning` even though the rule
+    # has graduated to `error` for `views/`. This is what stops the cog coverage
+    # from failing CI before it graduates separately.
+    _write(mod, tmp_path, monkeypatch, "cogs/x.py", _COG_TRUNCATES)
+    raw = mod.rule_select_option_truncation([tmp_path / "cogs/x.py"], {})
+    assert raw and all(f.force_warning for f in raw)
+    stamped = mod.run_checks([tmp_path / "cogs/x.py"], {})
+    cog_findings = [f for f in stamped if f.rule == "select_option_truncation"]
+    assert cog_findings and all(f.severity == "warning" for f in cog_findings)
+
+
+def test_trunc_cog_without_select_is_out_of_scope(mod, tmp_path, monkeypatch):
+    # The SelectOption module-gate keeps a leaderboard `[:10]` in a non-select cog
+    # OUT — exactly the false positive the gate exists to prevent.
+    assert (
+        _trunc_findings(mod, tmp_path, monkeypatch, _COG_NO_SELECT, rel="cogs/lb.py")
+        == []
+    )
+
+
+def test_trunc_cog_allowlist_suppresses_by_qualname(mod, tmp_path, monkeypatch):
+    # A genuine top-N display in a cog (an embed slice in a file that also builds a
+    # select) is allowlisted by `cogs/...::qualname`, the live `community_spotlight`
+    # pattern.
+    _write(mod, tmp_path, monkeypatch, "cogs/x.py", _COG_TRUNCATES)
+    cfg = {
+        "select_option_truncation": {
+            "exceptions": [
+                {
+                    "pattern": "cogs/x.py::_CogSelect.__init__",
+                    "reason": "intentional top-N display in a cog",
+                },
+            ],
+        },
+    }
+    assert mod.rule_select_option_truncation([tmp_path / "cogs/x.py"], cfg) == []
+
+
+def test_all_files_includes_both_views_and_cogs(mod):
+    # `_all_files()` widened to include `disbot/cogs/` (for the select-truncation
+    # cog scope); the views-only rules self-restrict by their own `views/` guard.
+    rels = {str(p.relative_to(mod.DISBOT_ROOT)) for p in mod._all_files()}
+    assert any(r.startswith("views/") for r in rels)
+    assert any(r.startswith("cogs/") for r in rels)
+
+
+def test_views_only_rules_skip_cogs(mod, tmp_path, monkeypatch):
+    # Even though `_all_files()` now yields cog files, the non-select rules must
+    # not flag a cog — they guard on `rel.startswith("views/")`. A cog shaped like
+    # an edit_in_place / direct-View violation stays clean for those rules.
+    _write(mod, tmp_path, monkeypatch, "cogs/score_cog.py", _BAD)
+    assert mod.rule_edit_in_place([tmp_path / "cogs/score_cog.py"], {}) == []
+    _write(mod, tmp_path, monkeypatch, "cogs/picker_cog.py", _DIRECT_VIEW)
+    assert mod.rule_panel_base_class([tmp_path / "cogs/picker_cog.py"], {}) == []
 
 
 def test_trunc_allowlist_suppresses_by_file_prefix(mod, tmp_path, monkeypatch):


### PR DESCRIPTION
## What

Extends `scripts/check_consistency.py` rule 4 (`select_option_truncation`) to also scan
`disbot/cogs/`, closing the cog-layer blind spot that **BUG-0017** lived in (the Cog Manager
dropdown silently dropped 22/46 cogs via `options[:25]`). This is the routed follow-up the plan
flagged: *"extend rule 4 to `disbot/cogs/` … if a cog-level select truncation ever surfaces"* —
BUG-0017 was that surfaced case.

- **Module-gate preserved.** A cog file is scanned only if it actually constructs a
  `discord.SelectOption`, so leaderboard-style `[:10]` slices in non-select cogs stay OUT.
- **New cog coverage is WARN-ONLY.** The rule is graduated to `error` for `views/`; cog-scope
  findings are tagged `warning` (a per-finding override) so they cannot fail `--mode strict`.
  Graduation of the cog scope waits for a few clean sessions, per the plan's discipline.
- **First-run cog-scope finding count: 2** — both in
  `community_spotlight_cog.py::_build_main_embed` (the top-3 XP / coins leaderboard *embed*
  slices `top_xp[:3]` / `top_coins[:3]`). These are genuine top-N **display** truncations, not
  select drops, so they are allowlisted by `::qualname` (the same standard as the
  `views/btd6` leaderboard embeds). BUG-0017's Cog Manager dropdown was already windowed
  (#1120) so it produces zero findings — the rule now acts as the regression guard there.

## panel_base_class decision: evaluated, NOT extended (out of scope here)

`panel_base_class` flags classes extending `discord.ui.View` directly. Cogs are
`commands.Cog` subclasses, so the rule does not apply to the cogs *themselves*. A few cog
*modules* do define helper view classes that subclass `discord.ui.View`
(`logging/select_view.py`, `logging/provision_view.py`, `deathmatch_cog.py`,
`settings_cog.py`). Those are a separate, larger triage surface (each needs its own
allowlist/migration call against the arch ground truth) and are not part of this warn-only
select-truncation extension — so this PR does **not** extend `panel_base_class` to cogs. Noted
in the plan as evaluated-and-deferred.

## Tests

- Flipped the cogs-scope **negative** for the extended rule into a **positive**: a cog fixture
  that front-truncates select options IS flagged (warn-only).
- Kept the SelectOption module-gate negative: a cog with a bare `[:10]` and no `SelectOption`
  is NOT flagged.
- Added a cog-scope warn-only severity assertion + an allowlist negative.

## Verification

- `python3.10 scripts/check_consistency.py --mode strict` — clean (cog coverage is warn-only).
- `python3.10 scripts/check_quality.py --full` — green.
- `python3.10 scripts/check_architecture.py --mode strict` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJANFhJehGkv15K6hHDWoz)_