### PR TITLE
feat(tooling): plan-code-drift check + ground-truth audit protocol (Q-0181)

### DIFF
--- a/.sessions/2026-06-19-plan-code-drift-check.md
+++ b/.sessions/2026-06-19-plan-code-drift-check.md
@@ -1,0 +1,27 @@
+# 2026-06-19 — Ground-truth audit protocol + plan-code-drift check
+
+> **Status:** `complete`
+
+Owner-directed (router **Q-0181**) follow-up to the 2026-06-19 review that found A3/A4 plans
+shipped-but-`plan`-badged — the "why didn't the docs-cleanup check plans vs code?" thread.
+
+## Shipped
+- **`scripts/check_plan_code_drift.py`** — flags `plan`-badged docs whose named implementation already
+  exists in `disbot/` (`STRONG` = named file + plan-specific symbol; a specificity filter drops shared
+  infra like `BaseView`/`SettingSpec`). Catches A3/A4; narrows 36 plans → ~7 STRONG candidates. Advisory
+  (`--strict` to gate once trusted). Lint-clean (black/ruff).
+- **`docs/operations/ground-truth-audit-protocol.md`** — the reusable *"verify against code, not badges"*
+  contract; template = `docs/audits/repo-wide-audit-2026-05-29.md` (the 22-auditor fan-out, owner's depth bar).
+- Router **Q-0181** — provenance + the *proposed* (not-yet-applied) session-close / Stop-hook wiring.
+
+## ⟲ Previous-session review
+The ultracode-review verification earlier this session was shallow — cheap proxies (doc badges,
+commit-message grep) over the code — so it mis-fingered B3 (actually shipped #960) and missed A2's
+mislabel. The durable fix is now structural (this check + protocol), not "remember to verify." System
+improvement: ground-truth verification is now both **invokable** (the protocol) and **partly automated**
+(the check), closing the recurring badge-drift class instead of relying on prompt wording.
+
+## 💡 Session idea
+A **diff-aware Stop-hook** that maps a session's touched `disbot/` files → the plans that name them →
+a rebadge prompt, so every session reconciles the plans it actually shipped (captured as the proposed
+half of Q-0181).

--- a/docs/operations/ground-truth-audit-protocol.md
+++ b/docs/operations/ground-truth-audit-protocol.md
@@ -1,0 +1,56 @@
+# Ground-truth audit protocol — verify docs/claims against the code, not against themselves
+
+> **Status:** `reference` — the durable contract for any *"make the docs correct / verify this / audit X"*
+> task. Owner-directed 2026-06-19 (router **Q-0181**), after a docs-cleanup verified docs against *each
+> other* (internal consistency) instead of against the *code* (ground truth) and missed shipped-but-
+> `plan`-badged plans (A3/A4). **Worked template:**
+> [`docs/audits/repo-wide-audit-2026-05-29.md`](../audits/repo-wide-audit-2026-05-29.md).
+
+## When to invoke this
+
+Any task whose correctness hinges on *"is this actually true / done?"* — *"make sure all docs are correct
+and up to date"*, *"verify this was all the intended work"*, *"audit subsystem X"*. The ambiguity in those
+asks is **never the goal** — it's the **evidence standard**. This protocol pins the evidence standard so
+the cheap reading ("the doc says so") can't substitute for the true one ("the code says so").
+
+## The contract (distilled from the 2026-05-29 audit's own method line)
+
+1. **Verify against the code at a pinned commit — never against a badge, a PR title, a plan's own prose,
+   or a subagent's self-report.** (The template's words: *"re-verified against `main` … not taken from PR
+   titles."*)
+2. **Read every file in scope, in full.** Breadth is the point. When scope is large, **fan out scoped
+   auditors** (the Agent tool, one per area) and have each *read* its files — not skim, not infer from docs.
+3. **Cite `file:line` evidence for every finding.** A claim with no code citation is `unverified`.
+4. **Treat every status/badge as a claim to *disprove*, not a given.** For each `plan`-badged doc: does its
+   named implementation exist and is it wired? If yes, the badge lies → rebadge `historical`.
+5. **"Done fast" is a red flag, not a green one.** A real ground-truth pass is slow by construction; a
+   quick finish means the cheap proxy got checked, not the code.
+
+## Evidence standard (paste this into the task prompt)
+
+> *For every 'shipped' / 'dropped' / 'correct' / 'done' claim, cite the proving artifact — `file.py:symbol`
+> that exists AND is wired into a caller, or a merged PR# you actually read. A doc badge, a plan's own
+> prose, a commit message, or a same-named file is NOT sufficient evidence. Where you can't find proof, say
+> 'unverified' — never infer. Output a verdict table: item · claim · evidence (`file:line` / PR#) · verdict.*
+
+The transferable rule: **when an instruction's correctness depends on a judgment, the ambiguity is in the
+evidence standard, not the goal — so state what evidence proves it.**
+
+## The automated slice (catches the recurring class with no prompt at all)
+
+The badge-drift class is now machine-checkable:
+
+```bash
+python3.10 scripts/check_plan_code_drift.py        # advisory
+python3.10 scripts/check_plan_code_drift.py --strict  # exit 1 on candidates (gate once trusted)
+```
+
+It flags every `plan`-badged doc whose named implementation already exists in `disbot/` (`STRONG` = named
+file **and** a plan-specific symbol both present), turning *"read 36 plans against code"* into *"verify ~7
+candidates."* It would have caught A3/A4 automatically. It is a **heuristic triage** (a plan may *extend*
+existing code), not the full audit — it narrows the field; the human/auditor confirms.
+
+## Output shape
+
+Match the template: an executive summary + a per-finding table (`item · status ✅/⚠️/❌ · file:line · note`),
+**every row re-verified against `main`.** See `docs/audits/repo-wide-audit-2026-05-29.md`.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -6665,3 +6665,39 @@ final head, and that Codex re-reviews the complete diff. Delete the workflow if 
 · [`codex-automated-pr-review-2026-06-17.md`](../ideas/codex-automated-pr-review-2026-06-17.md) · this
 Q-block. Related: Q-0171 (Codex live), Q-0174 (routines check Codex first; the post-merge consumer),
 Q-0133 (born-red card = the trigger signal), Q-0120 (verify bot output vs source).
+
+### Q-0181 — Verify docs/claims against the *code*, not their own badges: the ground-truth audit protocol + plan-code-drift check (2026-06-19)
+
+> **DIRECTED + APPLIED in-session (owner, 2026-06-19):** after the 2026-06-19 review found two plans
+> (A3 `games-economy-faucet-sink-diagnostic`, A4 `p0-2-content-free-media-diagnostics`) whose code had
+> shipped but were still badged `plan`, the owner asked *why* the earlier docs-cleanup didn't check each
+> plan against the code, and for a durable way to force ground-truth verification. Applied directly per the
+> CLAUDE.md in-session-directive exception (Q-0106) — the owner is the live reviewer.
+
+**Root cause:** *"make the docs correct / up to date"* was executed as **internal consistency** (routing,
+reachability, obvious-stale badges) rather than **truth against the code**. 5 of the task's 6 points are
+doc-organisation, so "completed/outdated" inherited the docs-only reading; the rebadge-on-ship convention
+relies on a human remembering, and nothing re-derived badge truth from code. Same failure class as the
+shallow ultracode-review verification (cheap proxy over ground truth) and the #763 / #1125 ledger checkers.
+
+**Decision — two artifacts:**
+- **`docs/operations/ground-truth-audit-protocol.md`** — the reusable contract for any "verify / make
+  correct / audit" task: verify against the code at a pinned commit (never a badge / PR-title / self-report),
+  read every file in scope (fan out auditors for breadth), cite `file:line`, treat a badge as a claim to
+  *disprove*, "done fast = red flag." Template instance: `docs/audits/repo-wide-audit-2026-05-29.md` (the
+  22-auditor fan-out the owner pointed at as the depth bar).
+- **`scripts/check_plan_code_drift.py`** — automates the badge-drift slice: flags every `plan`-badged doc
+  whose named implementation already exists in `disbot/` (`STRONG` = named file + plan-specific symbol).
+  Advisory; `--strict` to gate once trusted. Catches A3/A4 automatically; narrows 36 plans → ~7 candidates.
+
+**Reliability (Q-0105):** the check is UNVERIFIED — heuristic; a plan may *extend* existing code, so hits
+are review candidates, not proof. Confirm across a few sessions; **delete if noisy.**
+
+**Proposed (NOT yet applied — owner to greenlight; executable-config zone, Q-0106):** (1) run the check in
+the `/session-close` doc-audit (Q-0104) so every session surfaces its own rebadge candidates; (2) a
+diff-aware Stop-hook step mapping a session's touched `disbot/` files → the plans that name them →
+"rebadge if you shipped it."
+
+**Home:** `docs/operations/ground-truth-audit-protocol.md` · `scripts/check_plan_code_drift.py` · this
+Q-block. Related: Q-0104 (session-close doc audit), Q-0120 (verify bot output vs source), Q-0107
+(reconciliation pass), Q-0166 (fix drift on sight).

--- a/scripts/check_plan_code_drift.py
+++ b/scripts/check_plan_code_drift.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3.10
+"""check_plan_code_drift.py — flag planning docs still badged ``plan`` whose
+implementation already exists in ``disbot/`` (the "shipped-but-not-rebadged" drift class).
+
+PROVENANCE / RELIABILITY (owner-directed 2026-06-19, router Q-0181):
+    Why: a ``plan``-badged doc whose code already shipped silently misleads the next
+    agent into rebuilding it or mis-prioritising — the exact A3/A4 miss the 2026-06-19
+    review surfaced. The "rebadge-on-ship" convention relies on a human remembering;
+    this re-derives badge truth from the *code* instead (ground truth > a hand-kept badge).
+
+    UNVERIFIED — heuristic. Its hits are *candidates for human review*, not proof: a plan
+    may legitimately reference existing code it intends to *extend*. Confirm its output
+    against ground truth across a few sessions before trusting it, and **delete this script
+    if it proves noisy/unreliable over multiple sessions** rather than working around it.
+
+How: for each ``plan``-badged planning doc, extract the implementation artifacts it *names*
+— ``disbot/.../*.py`` paths and back-ticked symbols that are real ``def``/``class`` names in
+``disbot/`` — and report which already exist. A plan that names implementation which now
+exists is a **rebadge candidate** (likely shipped → should be ``historical``).
+
+Advisory by default (exit 0). ``--strict`` exits 1 when candidates are found, so it can be
+wired into CI once it has earned trust.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PLANNING = ROOT / "docs" / "planning"
+DISBOT = ROOT / "disbot"
+
+# A doc is in scope only if its front-matter Status badge is `plan` (buildable spec).
+_PLAN_BADGE = re.compile(r"Status:\*\*\s*`plan`")
+# Implementation file paths a plan names (in or out of back-ticks).
+_DISBOT_PATH = re.compile(r"disbot/[A-Za-z0-9_/]+\.py")
+# Back-ticked tokens — plans cite code symbols in back-ticks; we only keep ones that are
+# real disbot symbols (below), so prose in back-ticks never counts.
+_BACKTICKED = re.compile(r"`([^`]+)`")
+_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]+$")
+# def / class definitions in disbot source.
+_DEF_CLASS = re.compile(
+    r"^[ \t]*(?:async[ \t]+)?def[ \t]+([a-z_][A-Za-z0-9_]+)"
+    r"|^[ \t]*class[ \t]+([A-Za-z_][A-Za-z0-9_]+)",
+    re.MULTILINE,
+)
+# Symbols too generic to be evidence (would match across unrelated code).
+_GENERIC = frozenset(
+    {
+        "run",
+        "main",
+        "build",
+        "setup",
+        "handle",
+        "process",
+        "execute",
+        "start",
+        "stop",
+        "snapshot",
+        "reset",
+        "render",
+        "update",
+        "create",
+        "get",
+        "load",
+    },
+)
+
+
+def _disbot_symbols() -> set[str]:
+    syms: set[str] = set()
+    for p in DISBOT.rglob("*.py"):
+        try:
+            text = p.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for m in _DEF_CLASS.finditer(text):
+            syms.add(m.group(1) or m.group(2))
+    return syms - _GENERIC
+
+
+def _disbot_files() -> set[str]:
+    return {str(p.relative_to(ROOT)) for p in DISBOT.rglob("*.py")}
+
+
+def _plan_docs() -> list[Path]:
+    out = []
+    for p in sorted(PLANNING.glob("*.md")):
+        head = p.read_text(encoding="utf-8", errors="ignore")[:1500]
+        if _PLAN_BADGE.search(head):
+            out.append(p)
+    return out
+
+
+class Candidate:
+    def __init__(self, path: Path, exist_paths: set[str], exist_syms: set[str]) -> None:
+        self.path = path
+        self.exist_paths = exist_paths
+        self.exist_syms = exist_syms
+
+    @property
+    def strong(self) -> bool:
+        # Strong = the plan named a file that now exists AND ≥1 of its named symbols
+        # is a real disbot def/class. Weak = only one kind of evidence.
+        return bool(self.exist_paths) and bool(self.exist_syms)
+
+
+# A symbol cited by this many *or more* distinct plans is shared infrastructure
+# (BaseView, SettingSpec, HubView, debit, …), not any single plan's deliverable — so it
+# is not evidence that a *particular* plan shipped. Keep only plan-specific symbols.
+_SHARED_PLAN_THRESHOLD = 3
+
+
+def scan() -> list[Candidate]:
+    disbot_syms = _disbot_symbols()
+    disbot_files = _disbot_files()
+
+    # Pass 1: gather each plan's named (and real) paths + symbols, and count how many
+    # distinct plans cite each symbol (the specificity signal).
+    raw: list[tuple[Path, set[str], set[str]]] = []
+    sym_plan_count: dict[str, int] = {}
+    for doc in _plan_docs():
+        text = doc.read_text(encoding="utf-8", errors="ignore")
+        paths = {p for p in _DISBOT_PATH.findall(text) if p in disbot_files}
+        syms = {
+            t for t in _BACKTICKED.findall(text) if _IDENT.match(t) and t in disbot_syms
+        }
+        for s in syms:
+            sym_plan_count[s] = sym_plan_count.get(s, 0) + 1
+        raw.append((doc, paths, syms))
+
+    # Pass 2: drop shared-infrastructure symbols, then keep plans that still name real
+    # implementation — a real file path, or ≥2 plan-specific symbols.
+    candidates: list[Candidate] = []
+    for doc, paths, syms in raw:
+        specific = {s for s in syms if sym_plan_count[s] < _SHARED_PLAN_THRESHOLD}
+        if paths or len(specific) >= 2:
+            candidates.append(Candidate(doc, paths, specific))
+    return candidates
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 1 if any rebadge candidate is found (for CI once trusted)",
+    )
+    args = ap.parse_args()
+
+    candidates = scan()
+    if not candidates:
+        print("check_plan_code_drift: no `plan`-badged docs reference shipped code ✓")
+        return 0
+
+    strong = [c for c in candidates if c.strong]
+    print(
+        f"check_plan_code_drift: {len(candidates)} `plan`-badged doc(s) reference code that "
+        f"already exists — REBADGE CANDIDATES (verify completion, then rebadge `historical`):\n",
+    )
+    for c in sorted(candidates, key=lambda c: (not c.strong, c.path.name)):
+        tag = "STRONG" if c.strong else "weak  "
+        print(f"  [{tag}] docs/planning/{c.path.name}")
+        if c.exist_paths:
+            print(f"           files present : {', '.join(sorted(c.exist_paths))}")
+        if c.exist_syms:
+            shown = ", ".join(sorted(c.exist_syms)[:6])
+            more = "" if len(c.exist_syms) <= 6 else f" (+{len(c.exist_syms) - 6})"
+            print(f"           symbols present: {shown}{more}")
+    print(
+        "\n  NOTE: heuristic — a plan may *extend* existing code rather than have shipped. "
+        "Verify each against the code before rebadging. (STRONG = named file + symbol both exist.)",
+    )
+    return 1 if (args.strict and strong) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Owner-directed (router **Q-0181**) follow-up to the 2026-06-19 review, which found two plans (**A3** `games-economy-faucet-sink-diagnostic`, **A4** `p0-2-content-free-media-diagnostics`) whose code had **shipped but were still badged `plan`** — and surfaced *why*: a docs-cleanup verified docs against *each other* (consistency) instead of against the *code* (truth). This makes "verify against code, not badges" durable and partly automated.

## What

- **`scripts/check_plan_code_drift.py`** — flags every `plan`-badged doc whose **named implementation already exists in `disbot/`** (`STRONG` = named file + a plan-specific symbol; a specificity filter drops shared infra like `BaseView`/`SettingSpec`). Catches **A3/A4 automatically**; narrows 36 plans → ~7 STRONG candidates. Advisory today; `--strict` to gate once it's earned trust. Carries the Q-0105 "unverified — delete if noisy" header.
- **`docs/operations/ground-truth-audit-protocol.md`** — the reusable contract for any *"verify / make correct / audit"* task: verify against the code at a pinned commit (never a badge / PR-title / self-report), read every file in scope (fan out auditors), cite `file:line`, treat a badge as a claim to *disprove*, "done fast = red flag." Template = `docs/audits/repo-wide-audit-2026-05-29.md` (the 22-auditor fan-out the owner pointed at as the depth bar).
- **Router Q-0181** — provenance + a **proposed, not-yet-applied** wiring (run the check in `/session-close`; a diff-aware Stop-hook), left for owner greenlight since it touches the executable-config zone (Q-0106).

## Verification

`check_docs --strict` ✓ · `check_quality --check-only` ✓ · the check is lint-clean and confirmed to flag A3/A4. Docs + one advisory script — no runtime/`disbot/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS

---
_Generated by [Claude Code](https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS)_