### PR TITLE
docs(planning): rebadge A3/A4 historical (shipped #1044) + wire drift check into /session-close (Q-0181)

### DIFF
--- a/.claude/skills/session-close/SKILL.md
+++ b/.claude/skills/session-close/SKILL.md
@@ -101,6 +101,7 @@ Run these in order and fix any failures before proceeding:
 python3.10 scripts/check_docs.py --strict
 python3.10 scripts/check_session_log.py --strict      # Q-0089 idea + Q-0102 review present
 python3.10 scripts/check_current_state_ledger.py --strict  # merged PRs are in the ledger
+python3.10 scripts/check_plan_code_drift.py            # Q-0181: a plan-badged doc whose code already shipped? rebadge -> historical
 python3.10 scripts/check_reconciliation_due.py        # Q-0107: is a 30th-PR docs/planning pass due? (cadence 30, Q-0134)
 python3.10 scripts/check_quality.py --check-only
 ```
@@ -117,7 +118,11 @@ review` section it names. The session card carries a `> **Status:**` badge:
 close — `check_session_gate` holds the merge until it is a ready token
 (`complete`/`done`/`ready`/`final`/`merged`/`shipped`). If `check_current_state_ledger`
 flags a merged PR, **verify its #number against live GitHub** then add it to
-`docs/current-state.md` § Recently shipped (or an aggregated range entry).
+`docs/current-state.md` § Recently shipped (or an aggregated range entry). If
+`check_plan_code_drift` flags a **STRONG** candidate whose work your session shipped, **verify the
+deliverables exist (don't trust the heuristic blindly), then rebadge that plan `historical`** — badge
++ a SHIPPED banner + move its row in `planning/README.md` — per
+`docs/operations/ground-truth-audit-protocol.md`.
 
 **Documentation audit (Q-0104) — the judgment half.** The checks above are the automated
 half. Also ask yourself: *"is anything important from this session captured only in chat?"*

--- a/.sessions/2026-06-19-rebadge-a3a4-session-close-wiring.md
+++ b/.sessions/2026-06-19-rebadge-a3a4-session-close-wiring.md
@@ -1,0 +1,34 @@
+# 2026-06-19 — Rebadge A3/A4 `historical` + wire drift check into /session-close
+
+> **Status:** `complete`
+
+Owner-directed (router **Q-0181**) follow-up: apply the fix-on-sight the new drift check surfaced, and
+close the session-close loop so every future session does it automatically.
+
+## What was done
+- Rebadged **`games-economy-faucet-sink-diagnostic`** (A3) and **`p0-2-content-free-media-diagnostics`** (A4)
+  `plan` → `historical`. Both verified present + wired + **tested** and shipped in **#1044** — not trusting
+  the heuristic: confirmed each deliverable (DB fn, service, `!platform` subcommand, tests) in source first.
+  Added SHIPPED banners + moved their rows Active → Historical in `docs/planning/README.md`.
+- Wired **`scripts/check_plan_code_drift.py`** into **`/session-close` Step 4** (quality gate) + a rebadge
+  instruction in the doc-audit prose — every session now surfaces its own rebadge candidates (the
+  session-close half of Q-0181, applied).
+- Updated router **Q-0181**: session-close wiring applied; the diff-aware Stop-hook stays *proposed*
+  (it edits `settings.json`, so it awaits an explicit greenlight + a watched first fire).
+
+## Decisions recorded
+Q-0181 session-close wiring **applied** (owner-directed in-session 2026-06-19).
+
+## Left open / next session
+The **diff-aware Stop-hook** (Q-0181 part 2) — awaits owner greenlight + a watched first fire.
+
+## 💡 Session idea
+Extend the drift check with the **reverse direction**: flag a `historical`-badged plan whose
+implementation has since been **deleted** from `disbot/` (a shipped feature later removed) — the inverse
+drift class, equally misleading to the next agent.
+
+## ⟲ Previous-session review
+The #1135 session built the drift check well but deliberately left the rebadges + wiring as a follow-up
+(correct — separate, lower-risk PR). This session applied them. Improvement surfaced: once a few sessions
+confirm the check's STRONG tier is false-positive-free, graduate it to `--strict` in `/session-close` so a
+shipped-but-`plan` doc *blocks* close instead of merely warning.

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -6693,10 +6693,12 @@ shallow ultracode-review verification (cheap proxy over ground truth) and the #7
 **Reliability (Q-0105):** the check is UNVERIFIED — heuristic; a plan may *extend* existing code, so hits
 are review candidates, not proof. Confirm across a few sessions; **delete if noisy.**
 
-**Proposed (NOT yet applied — owner to greenlight; executable-config zone, Q-0106):** (1) run the check in
-the `/session-close` doc-audit (Q-0104) so every session surfaces its own rebadge candidates; (2) a
-diff-aware Stop-hook step mapping a session's touched `disbot/` files → the plans that name them →
-"rebadge if you shipped it."
+**Applied (owner-directed in-session 2026-06-19):** (1) the check now runs in `/session-close` Step 4 (the
+quality gate) so every session surfaces its own rebadge candidates — and **A3/A4 were rebadged `historical`
+on the spot** (both SHIPPED in #1044, verified present + wired + tested). **Still proposed (owner to
+greenlight; executable-config zone, Q-0106):** (2) a diff-aware Stop-hook step mapping a session's touched
+`disbot/` files → the plans that name them → "rebadge if you shipped it" (it edits the Stop hook in
+`settings.json`, so it waits for an explicit greenlight + a watched first fire).
 
 **Home:** `docs/operations/ground-truth-audit-protocol.md` · `scripts/check_plan_code_drift.py` · this
 Q-block. Related: Q-0104 (session-close doc audit), Q-0120 (verify bot output vs source), Q-0107

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -34,11 +34,9 @@ sectors ([`repo-sector-map.md`](../repo-sector-map.md)); the live `Now/Next/Late
 |---|---|---|
 | [fishing-open-world-expansion](fishing-open-world-expansion-plan-2026-06-18.md) | Phase 1 (fishing v1 + gear-switching) **▶ buildable**; the unified-loadout / value-cook-sell / minigame tail is **owner-design-gated (Q-0175)** | [games](../subsystems/games.md) · `mining_exploration_brainstorm` |
 | [mining-hub-redesign](mining-hub-redesign-2026-06-15.md) | owner-picked Option A; **not yet built** (no hub-redesign commits) — ▶ startable | [games](../subsystems/games.md) · `voice-mode-planning-capture` |
-| [games-economy-faucet-sink-diagnostic](games-economy-faucet-sink-diagnostic-plan-2026-06-15.md) | read-only economy-flow read model; gate cleared (#905/#910/#912) — **▶ turn-key** | [games](../subsystems/games.md) · `games-economy-faucet-sink-diagnostic` |
 | [myprofile-foundation](myprofile-foundation-plan-2026-06-10.md) | PR A/B shipped (#938/#940); only **PR C onboarding** remains, **owner-gated (Q-0147)** | [settings](../subsystems/settings-bindings-provisioning.md) |
 | [settings-pointer-lane-convergence](settings-pointer-lane-convergence-plan-2026-06-13.md) | P0-3; families 1+2 done, **pointer retirement gated** | [settings](../subsystems/settings-bindings-provisioning.md) |
 | [ai-panel-inplace-navigation](ai-panel-inplace-navigation-plan-2026-06-19.md) | 2–3 PRs; **`needs-hermes-review` + wants a live guild walk**; blocks graduating the consistency linter's `edit_in_place` rule | [ai](../subsystems/ai.md) · `ai-panel-inplace-navigation` |
-| [p0-2-content-free-media-diagnostics](p0-2-content-free-media-diagnostics-plan-2026-06-14.md) | one media-diagnostics gap; ▶ buildable | [media-youtube](../subsystems/media-youtube.md) · `media-quota-health-finding` |
 | [safety-community-family](safety-community-family-plan-2026-06-13.md) | lane entry doc; automod/logging/welcome **shipped** + image-mod #941 + security tiers 1+2 #929 **shipped 2026-06-18**; remainder = **NL event scheduler** (plan-first, Q-0112) | roadmap safety lane · `server-safety-and-automod`, `community-platform-features` |
 
 ### S2 — BTD6
@@ -129,7 +127,9 @@ Each carries a `historical` (or `reference`) badge and a banner pointing at its 
   [games-wager-money-safety](games-wager-money-safety-plan-2026-06-12.md) (#748) ·
   [moderation-dm-config](moderation-dm-config-plan-2026-06-17.md) (#1023) ·
   [ux-lab-interface-gallery](ux-lab-interface-gallery-plan-2026-06-12.md) (#758/#760/#762 → durable artifact `ux/pattern-library.md`) ·
-  [server-management-pr14-hub](server-management-pr14-hub-plan.md) (#584).
+  [server-management-pr14-hub](server-management-pr14-hub-plan.md) (#584) ·
+  [games-economy-faucet-sink-diagnostic](games-economy-faucet-sink-diagnostic-plan-2026-06-15.md) (#1044) ·
+  [p0-2-content-free-media-diagnostics](p0-2-content-free-media-diagnostics-plan-2026-06-14.md) (#1044).
 - **Server-management initiative** (structurally complete through PR14; only the gated PR13 AI tail
   remains): the authoritative record is [server-management-status](server-management-status-2026-06-05.md)
   (`historical`, *referenced by `agent/index.yml`*); the

--- a/docs/planning/games-economy-faucet-sink-diagnostic-plan-2026-06-15.md
+++ b/docs/planning/games-economy-faucet-sink-diagnostic-plan-2026-06-15.md
@@ -1,6 +1,11 @@
 # Plan — games-economy faucet/sink diagnostic (observe the loop's balance)
 
-> **Status:** `plan` — promoted from the
+> **Status:** `historical` — **▶ SHIPPED in #1044** (verified present + wired + tested 2026-06-19:
+> `economy_flow_by_reason` in `utils/db/economy.py` · the `economy_flow_service` read model
+> (`build_flow_report` / `EconomyFlowReport`) · the `!platform economy` subcommand in
+> `cogs/diagnostic/platform_group.py` · `tests/unit/services/test_economy_flow_service.py`). The §6
+> follow-ups (windowed/timeseries view, inflation health-finding) remain captured, not part of this slice.
+> Original plan retained below for provenance. Promoted from the
 > [idea capture](../ideas/games-economy-faucet-sink-diagnostic-2026-06-14.md) (now `historical`)
 > by the band-#930 reconciliation pass (2026-06-15). Routing: **S1 Bot / games + observability**.
 > Approved-to-build basis: the idea's gate ("promote once a sink-heavy slice lands") is **cleared**

--- a/docs/planning/p0-2-content-free-media-diagnostics-plan-2026-06-14.md
+++ b/docs/planning/p0-2-content-free-media-diagnostics-plan-2026-06-14.md
@@ -1,6 +1,12 @@
 # P0-2 follow-up — content-free media diagnostics plan (2026-06-14)
 
-> **Status:** `plan` — implementation plan for the P0-2 media/YouTube follow-up
+> **Status:** `historical` — **▶ SHIPPED in #1044** (verified present + wired + tested 2026-06-19:
+> `get_cache_stats` in `utils/db/youtube_video_cache.py` · `MediaCacheHealth` / `cache_health` in
+> `video_reference_cache_service` · the `youtube_diagnostics` provider counters · the `!platform media`
+> → `build_media_embed` surface · tests `test_youtube_diagnostics` / `test_video_reference_cache_service`
+> / `test_youtube_video_cache_stats` / `test_media_maintenance_cog`). Provider-execution hardening (the
+> "out of scope" item) stays queued. Original plan retained below for provenance.
+> Implementation plan for the P0-2 media/YouTube follow-up
 > slice "content-free media diagnostics". Source code + merged PRs win over this
 > doc once the slice lands.
 > **Class:** correctness. **Lane:** shared-platform media (ADR-007), not AI/BTD6.


### PR DESCRIPTION
## Why

Applies the **fix-on-sight** the new drift check (`#1135`) surfaced, and closes the session-close loop — the "(a) + rebadge A3/A4" the owner greenlit. Docs/planning + the session-close skill only.

## What

**Rebadged two shipped-but-`plan` plans → `historical`** (the A3/A4 drift the 2026-06-19 review found). Per the ground-truth protocol I **verified each deliverable in source first** (not trusting the heuristic), both shipped in **#1044**:
- **A3** `games-economy-faucet-sink-diagnostic` — `economy_flow_by_reason` (`utils/db/economy.py`) · `economy_flow_service` · `!platform economy` · `test_economy_flow_service.py`.
- **A4** `p0-2-content-free-media-diagnostics` — `get_cache_stats` · `MediaCacheHealth`/`cache_health` · `youtube_diagnostics` counters · `!platform media`→`build_media_embed` · 4 test files.

Each got a SHIPPED banner; both rows moved Active → Historical in `docs/planning/README.md`.

**Wired the check into `/session-close`** (Step 4 quality gate + a rebadge instruction) so **every future session surfaces its own rebadge candidates** automatically — the session-close half of Q-0181, now applied. The diff-aware Stop-hook (part 2) stays *proposed* in Q-0181, awaiting greenlight (it edits `settings.json`).

## Verification

The drift check now confirms **A3/A4 are no longer flagged** (badge → `historical`). `check_docs --strict` ✓ · `check_quality --check-only` ✓. No runtime/`disbot/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS

---
_Generated by [Claude Code](https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS)_