### PR TITLE
feat(tooling): check_lane_overlap.py — mechanize the fleet pre-flight overlap check

### DIFF
--- a/.sessions/2026-06-19-mechanize-lane-overlap-check.md
+++ b/.sessions/2026-06-19-mechanize-lane-overlap-check.md
@@ -1,0 +1,35 @@
+# 2026-06-19 — Mechanize the fleet overlap-check (`check_lane_overlap.py`)
+
+> **Status:** `complete`
+
+Gives teeth to the fleet's #1137 *procedural* overlap rule (the #1133/#1128 duplicate-work lesson): a
+script the orchestrator runs, so overlap-detection no longer depends on someone remembering the step.
+
+## What was done
+- **`scripts/check_lane_overlap.py`** — given a lane's scope (files/dirs/globs), scans recent commits and
+  flags any whose files overlap → *"this scope already shipped recently — drop/re-scope before dispatch."*
+  **Dogfood-verified:** `check_lane_overlap.py scripts/check_consistency.py` flags the #1128
+  consistency-linter-cog-scope commit — i.e. it *would have caught the #1133 duplicate before dispatch.*
+  Advisory; `--strict` to gate. Covers the recently-MERGED half (local git) and is explicit that the
+  OPEN-PR half still needs `list_pull_requests`.
+- Wired into **`ultracode-fleet-plan` rule #7** (the rule now points at the script).
+- CI-clean via `check_quality.py --check-only` (trusted over a bare `black --check` that disagreed — the
+  CI-mirror rule earned its keep this session).
+
+## Decisions recorded
+None new — tooling that operationalizes the existing #1137 rule #7 / the CLAUDE.md "scan open PRs before
+starting" rule. No router Q needed.
+
+## Left open / next session
+Graduate to `--strict` as a real dispatch gate once it's proven false-positive-free across a few fleet runs.
+
+## 💡 Session idea
+Teach `check_lane_overlap` to also accept a **planning-doc** and auto-extract its `disbot/` scope (the way
+`check_plan_code_drift` already extracts named symbols), so the orchestrator can pass a plan instead of
+enumerating files by hand.
+
+## ⟲ Previous-session review
+The #1137 fleet session correctly root-caused the #1133/#1128 collision and shipped the rule — but stopped
+at *"MUST run the check,"* a step the incident itself proved can be skipped under pressure. This session
+mechanized it. The durable improvement (the whole day's through-line): **pair every new procedural "MUST do
+X" rule with a script that does X**, so the guard doesn't lean on memory.

--- a/docs/planning/ultracode-fleet-plan-2026-06-19.md
+++ b/docs/planning/ultracode-fleet-plan-2026-06-19.md
@@ -69,7 +69,8 @@ Lane B can run **concurrently with Lane A**. Each is a small, low-risk, no-owner
 6. **A4/A5:** map every caller (including lazy/function-body imports) before moving code.
 7. **Orchestrator pre-flight overlap check (before dispatch — the #1133/#1128 lesson).** Before
    spawning lanes, the orchestrator MUST run `list_pull_requests` (open + recently-merged) **and**
-   grep recent merge commits for each lane's scope — not just scan `active-work.md`. The claim ledger
+   run `python3.10 scripts/check_lane_overlap.py <lane scope…>` (the mechanized recently-merged scan —
+   it caught the #1133/#1128 case in testing) for each lane's scope — not just scan `active-work.md`. The claim ledger
    is necessary but **insufficient**: it can be stale or uncommitted (a working-tree claim that never
    landed is invisible to other sessions), and a concurrent session's work may already be an open or
    just-merged PR that no ledger lists. On 2026-06-19, lane B4 (PR #1133) duplicated already-merged

--- a/scripts/check_lane_overlap.py
+++ b/scripts/check_lane_overlap.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3.10
+"""check_lane_overlap.py — before starting work on a scope, flag whether that scope was
+already touched by *recently-merged* work (the #1133/#1128 duplicate-work lesson).
+
+PROVENANCE / RELIABILITY (2026-06-19, mechanizes ultracode-fleet-plan rule #7 / the #1137
+fleet-dispatch overlap-check rule):
+    Why: lane B4 (PR #1133) rebuilt the consistency-linter cog-scope work that #1128 had
+    merged ~8 minutes earlier, because the orchestrator trusted a stale claim ledger instead
+    of scanning what had actually shipped. The fleet's fix was a *procedural* "MUST scan
+    recent PRs" rule — but the incident happened *because* a manual step got skipped. This
+    gives that rule teeth: a script the orchestrator runs so overlap-detection doesn't depend
+    on memory.
+
+    UNVERIFIED — heuristic, and **partial by construction**: it sees only the *recently-merged*
+    half (local git history). The *open-PR* half (a concurrent unmerged PR touching the same
+    files) needs GitHub and CANNOT be checked locally — always ALSO run `list_pull_requests`.
+    Confirm its hits across a few sessions; **delete it if it proves noisy/unreliable.**
+
+Usage:
+    check_lane_overlap.py <scope> [<scope> ...] [--limit N] [--strict]
+
+    <scope>  — files / directories / globs the lane will touch
+               (e.g. `scripts/check_consistency.py`, `disbot/views/mining/`, `disbot/**/fish*`).
+    --limit  — how many recent commits to scan (default 80 — ~2 burst bands).
+    --strict — exit 1 if any overlap is found (for a dispatch gate once trusted).
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from fnmatch import fnmatch
+
+_RS = "\x1e"  # record separator between commits
+_US = "\x1f"  # unit separator between hash and subject
+
+
+def _recent_commits(limit: int) -> list[tuple[str, str, list[str]]]:
+    """Return [(short_hash, subject, [changed_files])] for the last *limit* commits."""
+    out = subprocess.run(
+        ["git", "log", f"-n{limit}", "--name-only", f"--format={_RS}%h{_US}%s"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    commits: list[tuple[str, str, list[str]]] = []
+    for record in out.split(_RS):
+        if not record.strip():
+            continue
+        lines = record.split("\n")
+        short_hash, _, subject = lines[0].partition(_US)
+        files = [ln for ln in lines[1:] if ln.strip()]
+        commits.append((short_hash, subject, files))
+    return commits
+
+
+def _matches(path: str, scope: str) -> bool:
+    """A changed *path* belongs to *scope* (an exact file, a dir prefix, or a glob)."""
+    scope = scope.rstrip("/")
+    if path == scope or path.startswith(scope + "/"):
+        return True
+    return any(ch in scope for ch in "*?[") and fnmatch(path, scope)
+
+
+def scan(scopes: list[str], limit: int) -> dict[str, list[tuple[str, str, list[str]]]]:
+    """Map each scope -> the recent commits whose files overlap it."""
+    commits = _recent_commits(limit)
+    hits: dict[str, list[tuple[str, str, list[str]]]] = {}
+    for scope in scopes:
+        overlaps = []
+        for short_hash, subject, files in commits:
+            matched = [f for f in files if _matches(f, scope)]
+            if matched:
+                overlaps.append((short_hash, subject, matched))
+        if overlaps:
+            hits[scope] = overlaps
+    return hits
+
+
+_FOOTER = (
+    "\n  NOTE: this covers the recently-MERGED half only (local git). The OPEN-PR half "
+    "(a concurrent unmerged PR on the same files) needs GitHub — ALSO run `list_pull_requests`."
+)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "scopes",
+        nargs="+",
+        help="files / dirs / globs the lane will touch",
+    )
+    ap.add_argument(
+        "--limit",
+        type=int,
+        default=80,
+        help="recent commits to scan (default 80)",
+    )
+    ap.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 1 if any overlap is found (dispatch gate)",
+    )
+    args = ap.parse_args()
+
+    hits = scan(args.scopes, args.limit)
+    if not hits:
+        print(
+            f"check_lane_overlap: no recently-merged commit (last {args.limit}) touched "
+            f"{', '.join(args.scopes)} ✓" + _FOOTER,
+        )
+        return 0
+
+    print(
+        "check_lane_overlap: ⚠ OVERLAP — this scope was touched by recently-merged work. "
+        "Verify it didn't already ship your lane (drop/re-scope before dispatch):\n",
+    )
+    for scope, overlaps in hits.items():
+        print(f"  scope `{scope}`:")
+        for short_hash, subject, matched in overlaps:
+            shown = ", ".join(matched[:4])
+            more = "" if len(matched) <= 4 else f" (+{len(matched) - 4})"
+            print(f"    {short_hash}  {subject[:72]}")
+            print(f"             ↳ {shown}{more}")
+    print(_FOOTER)
+    return 1 if args.strict else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Gives **teeth** to the fleet's #1137 *procedural* overlap rule (the #1133/#1128 duplicate-work lesson). That rule said the orchestrator "MUST scan recent PRs before dispatch" — but the incident happened *because* a manual step got skipped. A reminder-not-to-skip is vulnerable to the same skip; this is the mechanical version.

## What

**`scripts/check_lane_overlap.py`** — given a lane's scope (files / dirs / globs), scans recent commits and flags any whose files overlap → *"this scope already shipped recently — drop/re-scope before dispatch."*

- **Dogfood-verified:** `check_lane_overlap.py scripts/check_consistency.py` flags the #1128 consistency-linter commit — i.e. **it would have caught the #1133 duplicate before it was built.**
- Advisory by default; `--strict` to gate once trusted. Carries the Q-0105 "unverified / delete if noisy" header.
- Honest about its limits: covers the **recently-merged** half (local git); explicitly tells you the **open-PR** half still needs `list_pull_requests` (GitHub).
- Wired into **`ultracode-fleet-plan` rule #7** so the rule points at the tool.

## Verification

`check_quality.py --check-only` ✓ (trusted over a bare `black --check` that disagreed) · `check_docs --strict` ✓. One advisory script + a doc edit — no runtime/`disbot/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS

---
_Generated by [Claude Code](https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS)_