### PR TITLE
tooling: bug-book deferred-root-fix backlog guard (self-initiated, Q-0172)

### DIFF
--- a/.sessions/2026-06-19-bug-book-rootfix-backlog-guard.md
+++ b/.sessions/2026-06-19-bug-book-rootfix-backlog-guard.md
@@ -1,0 +1,57 @@
+# 2026-06-19 — Self-initiated tooling: bug-book deferred-root-fix backlog guard
+
+> **Status:** `complete`
+
+## Arc
+
+Second slice of a dispatch run (no work order). The first slice (PR #1143) closed BUG-0018 — a bug
+that had sat logged `FIXED (immediate) / root-fix RECOMMENDED` and un-promoted until a later run
+noticed it *by hand*. That miss is itself a workflow gap: a symptom-fixed-but-root-owed bug-book
+entry has no signal making it a pickable backlog item. This slice builds the guard that surfaces it
+(promoted from the #1143 session idea — idea→plan→build is open, Q-0172).
+
+## What shipped (PR — self-initiated, Q-0172)
+
+- `scripts/check_bug_book_rootfix_backlog.py` — stdlib, warn-only (Q-0105 disposable header). Parses
+  `docs/health/bug-book.md` and flags entries whose `## BUG-NNNN` header / `- **Status:**` line shows
+  a deferred root fix: `PARTIALLY FIXED`, `root-fix RECOMMENDED`, or `FIXED (immediate)` without
+  `(root)`. Skips terminal (`FIXED` / `FIXED (root)`) and honestly-labelled `OPEN`. Scoped to the
+  header + status line (never body prose) so a "recommendation" mention in a root-cause paragraph
+  can't false-positive. `--strict` exits 1 on a non-empty backlog.
+- `tests/unit/scripts/test_check_bug_book_rootfix_backlog.py` — 9 tests over an inline fixture
+  (deterministic as real entries open/close): the three flagged classes, the terminal/OPEN
+  exclusions, the `FIXED (root)` short-circuit (the BUG-0018 self-fix shape), reason strings,
+  empty book, and the advisory-vs-`--strict` exit contract.
+- `docs/health/bug-book.md` — a discoverability pointer in the intro convention block so future
+  agents know the guard exists.
+- Live run (against `origin/main`'s bug book, pre-#1143) correctly flags **BUG-0018** (the entry
+  #1143 fixes) + **BUG-0009** (genuinely PARTIALLY FIXED, slice 3 open) — proving it would have
+  caught exactly the miss that prompted it. Once #1143 merges, BUG-0018 drops off (→ FIXED root).
+
+## Verification
+
+- `python3.10 scripts/check_quality.py --check-only` green (black/isort/ruff/check_docs/consistency).
+- Targeted pytest green (9 passed); full mirror run before push.
+
+## ⟲ Previous-session review (Q-0102)
+
+(See the sibling log `2026-06-19-site-json-drift-rootfix.md` — same run.) The system improvement that
+review surfaced is exactly this slice: a `FIXED (immediate) / root-fix RECOMMENDED` entry is a
+standing backlog signal, and the workflow had no tool to make it pickable. Now it does.
+
+## 💡 Session idea (Q-0089)
+
+Wire `check_bug_book_rootfix_backlog.py` (and the sibling `check_plan_backlog`) into the
+`/session-close` skill's advisory readout, so every session close prints the current deferred-root
+backlog + thin-plan signals — turning "what should the next empty-fire run pick up?" into a standing,
+zero-effort prompt rather than something an agent has to think to run. (Deferred to keep this PR
+tooling-only; captured here for a follow-up.)
+
+## 📤 Run report
+
+- **Run type:** routine · dispatch
+- **⚑ Owner-decisions:** none
+- **⚑ Owner-manual-steps:** none
+- **⚑ Self-initiated:** YES — promoted the #1143 session idea (deferred-root-fix backlog guard) to a
+  built, tested, warn-only tool with no dispatch/owner ask (Q-0172). Reversible (disposable Q-0105
+  tool, not CI-wired). Flagged for owner review.

--- a/docs/health/bug-book.md
+++ b/docs/health/bug-book.md
@@ -16,6 +16,12 @@
 > [`operations/production-deployment.md`](../operations/production-deployment.md)).
 > Owner-reported inconsistencies he hasn't formalized yet (see current-state
 > 2026-06-10 standing invite) land here as they surface.
+>
+> **Deferred-root-fix backlog:** when an entry lands a *symptom* fix but defers the durable
+> root fix (status `PARTIALLY FIXED` / `root-fix RECOMMENDED` / `FIXED (immediate)` without
+> `(root)`), `python3.10 scripts/check_bug_book_rootfix_backlog.py` lists those entries so a
+> later empty-fire dispatch run can pick them up instead of them sitting un-promoted (the
+> trap BUG-0018 hit). Advisory by default; `--strict` exits 1 on a non-empty backlog.
 
 ## BUG-0018 — committed `botsite/data/site.json` drifts red whenever idea docs change (hard equality test over a high-churn derived field) — FIXED (immediate) / root-fix RECOMMENDED
 

--- a/scripts/check_bug_book_rootfix_backlog.py
+++ b/scripts/check_bug_book_rootfix_backlog.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3.10
+"""Bug-book root-fix backlog guard — surface entries that are symptom-fixed but still owe a root fix.
+
+The bug book (``docs/health/bug-book.md``) follows the CLAUDE.md "bugs first,
+durably" rule: root cause over symptom-patch. But a dispatch run under time
+pressure can land an *immediate* fix (regenerate the artifact, patch the symptom)
+and defer the durable root fix to "the owner / a later session" — and that deferral
+then sits un-promoted with no signal that work is still owed. BUG-0018 was exactly
+this: logged ``FIXED (immediate) / root-fix RECOMMENDED`` and left, until a later
+run noticed it by hand. This guard turns that latent backlog into an explicit list
+the next empty-fire dispatch run can pick up (the same role ``check_plan_backlog``
+plays for thin plans).
+
+What it flags (the "looks done but isn't fully" class — scoped to the ``## BUG-NNNN``
+header line + the entry's ``- **Status:**`` line, never arbitrary body prose, to
+avoid false positives from words like "recommend" in a root-cause paragraph):
+
+* ``PARTIALLY FIXED``                — a fix landed for some sub-cases, others open.
+* ``root-fix RECOMMENDED`` / ``RECOMMENDED`` — symptom fixed, durable fix deferred.
+* ``FIXED (immediate)`` without ``(root)`` — an explicitly-interim fix.
+
+What it does NOT flag: ``FIXED`` / ``FIXED (root)`` (terminal) and ``OPEN``
+(an honestly-labelled active bug, already visible as such — not the deferred-root trap).
+
+Advisory by default (exit 0); ``--strict`` makes a non-empty backlog exit 1 (e.g. for
+a cadence/close-out gate). Pure stdlib, like ``check_reconciliation_due.py``.
+
+Reliability (Q-0105, added 2026-06-19): **unverified** — confirm its output against the
+bug book a few times across sessions before trusting it. If it misfires (a status phrasing
+it can't classify, a false positive) over multiple sessions, **delete it**; it is a
+convenience backlog nudge, not load-bearing.
+
+Usage:
+    python3.10 scripts/check_bug_book_rootfix_backlog.py            # advisory (exit 0)
+    python3.10 scripts/check_bug_book_rootfix_backlog.py --strict   # exit 1 if backlog non-empty
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BUG_BOOK = REPO_ROOT / "docs" / "health" / "bug-book.md"
+
+# A bug entry opens at a "## BUG-NNNN — <title ...>" header (em-dash separated).
+_ENTRY_HEADER_RE = re.compile(r"^##\s+(BUG-\d+)\b(.*)$")
+# The per-entry status line: "- **Status:** <text>".
+_STATUS_LINE_RE = re.compile(r"^\s*-\s*\*\*Status:\*\*\s*(.*)$")
+
+
+@dataclass(frozen=True)
+class RootFixOwed:
+    """One bug-book entry that is symptom-fixed but still owes a durable root fix."""
+
+    bug_id: str
+    reason: str  # which signal matched (partial / recommended / immediate-only)
+    status_text: str  # the header tail + status line, for the report
+
+
+def _classify(status_text: str) -> str | None:
+    """Return the backlog reason for a status string, or None if it owes no root fix.
+
+    Order matters only for the message: a terminal ``FIXED (root)`` short-circuits
+    so a body that *mentions* "recommendation" can't re-flag a closed entry.
+    """
+    upper = status_text.upper()
+    if "FIXED (ROOT)" in upper:
+        return None
+    if "PARTIALLY" in upper:
+        return "partially fixed — open sub-cases remain"
+    if "RECOMMENDED" in upper:
+        return "root-fix RECOMMENDED but not done"
+    if "IMMEDIATE" in upper and "ROOT" not in upper:
+        return "FIXED (immediate) only — no root fix"
+    return None
+
+
+def find_rootfix_backlog(text: str) -> list[RootFixOwed]:
+    """Parse the bug book and return entries that owe a durable root fix."""
+    backlog: list[RootFixOwed] = []
+    lines = text.splitlines()
+    i = 0
+    n = len(lines)
+    while i < n:
+        header = _ENTRY_HEADER_RE.match(lines[i])
+        if not header:
+            i += 1
+            continue
+        bug_id = header.group(1)
+        header_tail = header.group(2)
+        # Collect this entry's status line(s) until the next "## " header.
+        status_text = header_tail
+        j = i + 1
+        while j < n and not lines[j].startswith("## "):
+            status_match = _STATUS_LINE_RE.match(lines[j])
+            if status_match:
+                status_text += " " + status_match.group(1)
+            j += 1
+        reason = _classify(status_text)
+        if reason is not None:
+            backlog.append(
+                RootFixOwed(
+                    bug_id=bug_id,
+                    reason=reason,
+                    status_text=status_text.strip(),
+                ),
+            )
+        i = j
+    return backlog
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 1 if the root-fix backlog is non-empty (default: advisory, exit 0)",
+    )
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=BUG_BOOK,
+        help="path to the bug book (default: docs/health/bug-book.md)",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.path.exists():
+        print(f"check_bug_book_rootfix_backlog: {args.path} not found", file=sys.stderr)
+        return 0  # advisory tool: a missing file is not a failure
+
+    backlog = find_rootfix_backlog(args.path.read_text(encoding="utf-8"))
+    if not backlog:
+        print("check_bug_book_rootfix_backlog: OK ✓ (no deferred root fixes owed)")
+        return 0
+
+    print(
+        f"check_bug_book_rootfix_backlog: {len(backlog)} entr{'y' if len(backlog) == 1 else 'ies'} owe a root fix",
+    )
+    for item in backlog:
+        print(f"  • {item.bug_id} — {item.reason}")
+    print(
+        "\nThese are symptom-fixed but still owe a durable root fix — a standing "
+        "dispatch backlog an empty-fire run can pick up (CLAUDE.md 'bugs first, durably').",
+    )
+    return 1 if args.strict else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_check_bug_book_rootfix_backlog.py
+++ b/tests/unit/scripts/test_check_bug_book_rootfix_backlog.py
@@ -1,0 +1,129 @@
+"""Tests for ``scripts/check_bug_book_rootfix_backlog.py`` — the root-fix backlog guard.
+
+Loaded via ``importlib`` (the repo convention for ``scripts/`` modules, which are not a
+package). Pure stdlib, so it runs in CI with no extra dependencies. Classification is
+verified against an inline fixture, never the live bug book, so the test is deterministic
+as real entries open and close.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "check_bug_book_rootfix_backlog.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location(
+        "check_bug_book_rootfix_backlog_ut", _SCRIPT
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+SAMPLE = """# Bug book
+
+## BUG-0099 — symptom patched, root deferred — FIXED (immediate) / root-fix RECOMMENDED
+
+- **Symptom:** something reddened CI.
+- **Root-fix RECOMMENDED (not done):** do the durable thing later.
+- **Status:** FIXED 2026-06-19 — immediate regen landed; root cause documented for later.
+
+## BUG-0098 — half done — PARTIALLY FIXED
+
+- **Symptom:** a family of mislabels.
+- **Status:** PARTIALLY FIXED — slices 1+2 done, slice 3 OPEN.
+
+## BUG-0097 — interim only
+
+- **Symptom:** a thing.
+- **Status:** FIXED (immediate) — interim, no durable fix yet.
+
+## BUG-0096 — fully closed — FIXED (root)
+
+- **Symptom:** a thing.
+- **Root-fix DONE (recommendation (a)):** the durable fix landed.
+- **Status:** FIXED (root) 2026-06-19 — closed at the root.
+
+## BUG-0095 — ordinary closed — FIXED
+
+- **Symptom:** a thing.
+- **Status:** FIXED — this PR.
+
+## BUG-0094 — still open — OPEN
+
+- **Symptom:** infra crash-loop.
+- **Status:** OPEN — captured during a setup session.
+"""
+
+
+def test_flags_recommended_partial_and_immediate_only(mod):
+    backlog = mod.find_rootfix_backlog(SAMPLE)
+    flagged = {item.bug_id for item in backlog}
+    # The three "looks done but owes a root fix" classes are flagged.
+    assert flagged == {"BUG-0099", "BUG-0098", "BUG-0097"}
+
+
+def test_does_not_flag_terminal_or_open(mod):
+    backlog = mod.find_rootfix_backlog(SAMPLE)
+    flagged = {item.bug_id for item in backlog}
+    # FIXED (root) and plain FIXED are terminal; OPEN is honestly-labelled, not the trap.
+    assert "BUG-0096" not in flagged
+    assert "BUG-0095" not in flagged
+    assert "BUG-0094" not in flagged
+
+
+def test_fixed_root_short_circuits_a_recommendation_mention(mod):
+    # An entry closed at the root whose body still says "recommendation (a)" must
+    # NOT re-flag — the FIXED (root) terminal wins (the BUG-0018 self-fix shape).
+    text = (
+        "## BUG-0100 — closed but mentions recommendation — FIXED (root)\n\n"
+        "- **Root-fix DONE (recommendation (a)):** durable fix landed.\n"
+        "- **Status:** FIXED (root) — recommendation (a) implemented.\n"
+    )
+    assert mod.find_rootfix_backlog(text) == []
+
+
+def test_reason_strings_are_specific(mod):
+    by_id = {item.bug_id: item.reason for item in mod.find_rootfix_backlog(SAMPLE)}
+    assert "partially" in by_id["BUG-0098"].lower()
+    assert "recommended" in by_id["BUG-0099"].lower()
+    assert "immediate" in by_id["BUG-0097"].lower()
+
+
+def test_empty_book_is_clean(mod):
+    assert mod.find_rootfix_backlog("# Bug book\n\nNo entries yet.\n") == []
+
+
+def test_main_advisory_exit_zero_even_with_backlog(mod, tmp_path):
+    book = tmp_path / "bug-book.md"
+    book.write_text(SAMPLE, encoding="utf-8")
+    assert mod.main(["--path", str(book)]) == 0  # advisory default
+
+
+def test_main_strict_exits_one_on_backlog(mod, tmp_path):
+    book = tmp_path / "bug-book.md"
+    book.write_text(SAMPLE, encoding="utf-8")
+    assert mod.main(["--strict", "--path", str(book)]) == 1
+
+
+def test_main_strict_exits_zero_when_clean(mod, tmp_path):
+    book = tmp_path / "bug-book.md"
+    book.write_text(
+        "# Bug book\n\n## BUG-1 — done — FIXED\n\n- **Status:** FIXED\n",
+        encoding="utf-8",
+    )
+    assert mod.main(["--strict", "--path", str(book)]) == 0
+
+
+def test_main_missing_file_is_advisory(mod, tmp_path):
+    assert mod.main(["--path", str(tmp_path / "nope.md")]) == 0


### PR DESCRIPTION
## What

Self-initiated tooling slice (idea→build open, Q-0172), promoted from PR #1143's session idea.

`scripts/check_bug_book_rootfix_backlog.py` — a warn-only stdlib guard that surfaces bug-book entries
which landed a *symptom* fix but defer the durable root fix: status `PARTIALLY FIXED`,
`root-fix RECOMMENDED`, or `FIXED (immediate)` without `(root)`. They become a pickable dispatch
backlog instead of sitting un-promoted.

## Why

PR #1143 fixed **BUG-0018**, which had sat logged `FIXED (immediate) / root-fix RECOMMENDED` and
un-promoted until a later run noticed it *by hand*. That is a workflow gap: a symptom-fixed-but-root-owed
entry has no signal making it a backlog item. This guard plays the role `check_plan_backlog` plays for
thin plans. Run live against current `main` it flags exactly **BUG-0018** + **BUG-0009** (genuinely
PARTIALLY FIXED) — proving it catches the class that prompted it.

## Scope / safety

- Warn-only, **not** CI-wired; carries the Q-0105 disposable provenance/reliability header (unverified
  → delete if it misfires across sessions).
- Scoped to the `## BUG-NNNN` header + `- **Status:**` line (never body prose) to avoid false positives.
- `--strict` exits 1 on a non-empty backlog (for a future cadence/close-out gate).
- 9 fixture-based tests; `check_quality --check-only` green.

## Self-initiated (Q-0172)

No dispatch/owner ask — flagged for review on the session-log run report. Reversible (disposable tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6shCTzaQrKChD1nRWL2ux)_