### PR TITLE
harden: scope bug-book root-fix guard to status label, precise matching (#1144 review)

### DIFF
--- a/.sessions/2026-06-19-bug-book-guard-precision.md
+++ b/.sessions/2026-06-19-bug-book-guard-precision.md
@@ -1,0 +1,43 @@
+# 2026-06-19 — Harden the bug-book root-fix guard (#1144 Codex-review follow-up)
+
+> **Status:** `complete`
+
+## Arc
+
+PR #1144 (the deferred-root-fix backlog guard) auto-merged on green before its Codex review
+landed. The review raised three valid precision points about the classifier — worth fixing now that
+the tool is on `main` (warn-only, so low-stakes, but the false-positive risk would bite `--strict`).
+
+## What the review found (and the fix)
+
+The classifier was fed the **whole header tail (title included)** and matched **loose substrings**:
+
+1. **Immediate + "root" prose** — `"IMMEDIATE" in upper and "ROOT" not in upper` suppressed a genuine
+   `FIXED (immediate)` entry whose deferral text said "root cause deferred" (the word "root" tripped it).
+2. **Bare `PARTIALLY`** — matched a *title* like "counting partially ignores …", false-positiving an
+   honestly-`FIXED`/`OPEN` entry (contradicting the documented OPEN exclusion; would redden `--strict`).
+3. **Terminal-first ordering** — hardening to classify the terminal `(root)` marker before treating a
+   `RECOMMENDED`/recommendation mention as deferred work.
+
+**Fix (one root cause — scope + precision):**
+- New `_header_status_label()` extracts only the **status label** (segment after the *last* em-dash) —
+  the title is never scanned for status signals.
+- `_classify` now matches **precise phrases / parenthesized markers**: `(root)` short-circuits first;
+  `PARTIALLY FIXED` (phrase); `RECOMMENDED` (word — "recommendation" no longer matches); `(immediate)`
+  (parenthesized label) keyed on the `(root)` *marker* absence, not any "root".
+
+## Verification
+
+- 4 new tests cover all three review cases (title-"partially" not flagged; immediate-with-"root cause"
+  prose still flagged; terminal-FIXED-with-"recommendation" not flagged; belt-and-braces title with
+  both "root" + "partially"). 13 tests pass.
+- Live run on current `main` correctly reports only **BUG-0009** (BUG-0018 now `FIXED (root)`).
+- `check_quality --check-only` green; full mirror run before push.
+
+## 📤 Run report
+
+- **Run type:** routine · dispatch
+- **⚑ Owner-decisions:** none
+- **⚑ Owner-manual-steps:** none
+- **⚑ Self-initiated:** YES — hardening follow-up to the self-initiated #1144 guard, prompted by its
+  Codex review (no dispatch/owner ask). Reversible (warn-only disposable tool).

--- a/scripts/check_bug_book_rootfix_backlog.py
+++ b/scripts/check_bug_book_rootfix_backlog.py
@@ -11,9 +11,10 @@ run noticed it by hand. This guard turns that latent backlog into an explicit li
 the next empty-fire dispatch run can pick up (the same role ``check_plan_backlog``
 plays for thin plans).
 
-What it flags (the "looks done but isn't fully" class — scoped to the ``## BUG-NNNN``
-header line + the entry's ``- **Status:**`` line, never arbitrary body prose, to
-avoid false positives from words like "recommend" in a root-cause paragraph):
+What it flags (the "looks done but isn't fully" class — matched on the header's
+**status label** (the segment after the last em-dash) + the entry's ``- **Status:**``
+line, never the title or body prose, so a title containing "partially"/"root" or a
+"recommendation" mention in a paragraph can't false-positive):
 
 * ``PARTIALLY FIXED``                — a fix landed for some sub-cases, others open.
 * ``root-fix RECOMMENDED`` / ``RECOMMENDED`` — symptom fixed, durable fix deferred.
@@ -58,23 +59,45 @@ class RootFixOwed:
 
     bug_id: str
     reason: str  # which signal matched (partial / recommended / immediate-only)
-    status_text: str  # the header tail + status line, for the report
+    status_text: str  # the header status label + status line, for the report
+
+
+def _header_status_label(header_tail: str) -> str:
+    """The status label from a ``## BUG-NNNN — <title> — <STATUS>`` header.
+
+    Returns the segment after the **last** em-dash — i.e. the status label, never the
+    title. Scoping to this (rather than the whole header tail) keeps a *title* that
+    merely contains words like "partially" or "root" from being misread as a status
+    (the false-positive class flagged in #1144 review). An entry that carries no header
+    status segment (status only on the ``- **Status:**`` line) yields its last segment,
+    which is harmless: the precise phrase/paren matching below won't fire on prose.
+    """
+    parts = header_tail.split("—")
+    return parts[-1].strip() if len(parts) > 1 else ""
 
 
 def _classify(status_text: str) -> str | None:
     """Return the backlog reason for a status string, or None if it owes no root fix.
 
-    Order matters only for the message: a terminal ``FIXED (root)`` short-circuits
-    so a body that *mentions* "recommendation" can't re-flag a closed entry.
+    Matches **precise phrases / parenthesized markers**, not loose substrings, and
+    classifies the terminal ``(root)`` marker first (#1144 review hardening):
+
+    * a terminal ``FIXED (root)`` / ``(root)`` marker short-circuits — a closed-at-root
+      entry whose text still *mentions* a recommendation can't re-flag;
+    * ``PARTIALLY FIXED`` (the status phrase, not any "partially …") → partial;
+    * ``RECOMMENDED`` (the deferred-root word; "recommendation" does not match) → deferred;
+    * ``(immediate)`` present without ``(root)`` → an explicitly-interim fix. Keying on the
+      parenthesized ``(immediate)`` label (not bare "immediate") and on the ``(root)``
+      *marker* (not any "root", so "root cause deferred" prose no longer suppresses it).
     """
     upper = status_text.upper()
-    if "FIXED (ROOT)" in upper:
+    if "(ROOT)" in upper:
         return None
-    if "PARTIALLY" in upper:
+    if "PARTIALLY FIXED" in upper:
         return "partially fixed — open sub-cases remain"
     if "RECOMMENDED" in upper:
         return "root-fix RECOMMENDED but not done"
-    if "IMMEDIATE" in upper and "ROOT" not in upper:
+    if "(IMMEDIATE)" in upper:
         return "FIXED (immediate) only — no root fix"
     return None
 
@@ -91,9 +114,9 @@ def find_rootfix_backlog(text: str) -> list[RootFixOwed]:
             i += 1
             continue
         bug_id = header.group(1)
-        header_tail = header.group(2)
-        # Collect this entry's status line(s) until the next "## " header.
-        status_text = header_tail
+        # The status signal lives in the header's status label + the Status: line —
+        # never the free-text title (which would cause false positives).
+        status_text = _header_status_label(header.group(2))
         j = i + 1
         while j < n and not lines[j].startswith("## "):
             status_match = _STATUS_LINE_RE.match(lines[j])

--- a/tests/unit/scripts/test_check_bug_book_rootfix_backlog.py
+++ b/tests/unit/scripts/test_check_bug_book_rootfix_backlog.py
@@ -104,6 +104,53 @@ def test_empty_book_is_clean(mod):
     assert mod.find_rootfix_backlog("# Bug book\n\nNo entries yet.\n") == []
 
 
+# ---------------------------------------------------------------------------
+# #1144 review hardening — precise matching, scoped to the status label not the title
+# ---------------------------------------------------------------------------
+
+
+def test_title_mentioning_partially_is_not_flagged(mod):
+    # A title like "partially ignores X" with a terminal FIXED status must NOT flag —
+    # the bare word "partially" in the title is not the "PARTIALLY FIXED" status phrase.
+    text = (
+        "## BUG-0200 — counting partially ignores role hierarchy — FIXED\n\n"
+        "- **Symptom:** a thing.\n"
+        "- **Status:** FIXED — this PR.\n"
+    )
+    assert mod.find_rootfix_backlog(text) == []
+
+
+def test_immediate_with_root_cause_prose_is_still_flagged(mod):
+    # "FIXED (immediate)" whose deferral text says "root cause deferred" must still
+    # flag — keying on the "(root)" marker, not any occurrence of the word "root".
+    text = (
+        "## BUG-0201 — interim patch — FIXED (immediate)\n\n"
+        "- **Status:** FIXED (immediate) — root cause deferred, no durable fix yet.\n"
+    )
+    flagged = {item.bug_id for item in mod.find_rootfix_backlog(text)}
+    assert flagged == {"BUG-0201"}
+
+
+def test_terminal_fixed_mentioning_recommendation_is_not_flagged(mod):
+    # A closed entry whose status says "recommendation (a) implemented" must NOT flag —
+    # "recommendation" is not the deferred-root word "RECOMMENDED".
+    text = (
+        "## BUG-0202 — closed — FIXED (root)\n\n"
+        "- **Status:** FIXED (root) — recommendation (a) implemented.\n"
+    )
+    assert mod.find_rootfix_backlog(text) == []
+
+
+def test_title_with_root_word_and_partially_does_not_false_positive(mod):
+    # Belt-and-braces: a title carrying both "root" and "partially" with a plain FIXED
+    # status is terminal — the title is never scanned for status signals.
+    text = (
+        "## BUG-0203 — root partially restored after partial outage — FIXED\n\n"
+        "- **Status:** FIXED — root-caused and fixed.\n"
+    )
+    assert mod.find_rootfix_backlog(text) == []
+
+
 def test_main_advisory_exit_zero_even_with_backlog(mod, tmp_path):
     book = tmp_path / "bug-book.md"
     book.write_text(SAMPLE, encoding="utf-8")


### PR DESCRIPTION
## What

Follow-up to **#1144** (the deferred-root-fix backlog guard, which auto-merged before its Codex review
landed). Addresses three valid precision points the review raised about `_classify`.

## Why

The classifier was fed the **whole header tail (title included)** and matched **loose substrings**:

1. `"IMMEDIATE" in upper and "ROOT" not in upper` suppressed a genuine `FIXED (immediate)` entry whose
   deferral text said *"root cause deferred"* — the word "root" tripped the guard.
2. Bare `"PARTIALLY"` matched a *title* like "counting partially ignores …", false-positiving an
   honestly-`FIXED`/`OPEN` entry (contradicts the documented OPEN exclusion; would redden `--strict`).
3. Hardening: classify the terminal `(root)` marker before treating a `RECOMMENDED`/recommendation
   mention as deferred work.

## Fix

- `_header_status_label()` extracts only the **status label** (segment after the last em-dash) — the
  free-text title is never scanned for status signals.
- `_classify` matches **precise phrases / parenthesized markers**: `(root)` short-circuits first;
  `PARTIALLY FIXED` (phrase); `RECOMMENDED` (word — "recommendation" no longer matches); `(immediate)`
  keyed on the `(root)` *marker* absence (not any "root").
- 4 new regression tests for the review cases (13 total). `check_quality --check-only` green; full mirror green.

## Self-initiated (Q-0172)

Hardening of the self-initiated #1144 guard, prompted by its review. No dispatch/owner ask. Reversible
(warn-only disposable tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6shCTzaQrKChD1nRWL2ux)_