### PR TITLE
ops(website): stand the public bot site up dark on Railway + record live status

### DIFF
--- a/.sessions/2026-06-19-botsite-dark-launch.md
+++ b/.sessions/2026-06-19-botsite-dark-launch.md
@@ -1,6 +1,6 @@
 # 2026-06-19 — Stand up the public bot site DARK on Railway (owner-delegated)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 Owner-delegated unattended task ("wire the website … you have my Railway account token, full
 permissions … I'll see what happened when I wake up"). Executed the website-split **rollout step 2 —

--- a/.sessions/2026-06-19-botsite-dark-launch.md
+++ b/.sessions/2026-06-19-botsite-dark-launch.md
@@ -1,0 +1,72 @@
+# 2026-06-19 — Stand up the public bot site DARK on Railway (owner-delegated)
+
+> **Status:** `in-progress`
+
+Owner-delegated unattended task ("wire the website … you have my Railway account token, full
+permissions … I'll see what happened when I wake up"). Executed the website-split **rollout step 2 —
+stand the bot site up dark**: created its Railway service, deployed from `main`, verified it serves,
+and recorded the live facts in the canonical homes. Deliberately stopped at the documented owner gate
+(submissions DB + secrets + domain) rather than touch secrets/DB unattended.
+
+## What was done
+- **Verified the delegated token before acting** (the session's own ground-truth rule): the
+  `RAILWAY_API_KEY` is a real **account** token (`me` → `mennovanhattum@gmail.com`), Railway's API is
+  reachable, and `botsite/` is fully on `origin/main` (all build files) — so a `main`-tracking service
+  builds the current code.
+- **Created the `botsite` Railway service configured-first** (so the first build ran from the right
+  folder, not repo root): bare `serviceCreate` → `serviceInstanceUpdate` (Root Dir = `botsite`, start =
+  `uvicorn app:app …`) → `serviceConnect` (`menno420/superbot` @ `main`) → auto-build → **SUCCESS** →
+  `serviceDomainCreate` (port 8080, the `${PORT:-8080}` fallback the dashboard also uses).
+- **Secret-free / dormant** (the §4.4 public posture, by construction): the service carries only
+  Railway's auto-injected `RAILWAY_*` — no DSN, no OAuth, no tokens. (Confirmed the dashboard has no
+  submissions DSN either → the submissions DB is genuinely unprovisioned; nothing to "move.")
+- **Verified live in prod:** `/ /commands /features /changelog /status /submit /healthz` all **HTTP
+  200**; `/submit` shows the **dormant** "temporarily unavailable" state. Public URL:
+  **https://botsite-production-1ea7.up.railway.app**.
+- **Recorded durably** in the canonical homes (not the contended `current-state.md` mega-block — the
+  PR is benign-lag past the #1140 marker, so the next recon pass logs it): `botsite-deploy.md` ▶ Live
+  status block + the `website-split-next-steps.md` §2b rollout checklist ticks.
+
+## Decisions recorded
+None new (no router Q). This is an **ops execution of the already-decided** plan (Q-0178 / website
+two-site-split §6) — not a new decision. **No CLAUDE.md / hooks / settings edits** (Q-0106 respected).
+**Owner-delegated, not self-initiated** (Q-0172 n/a) — the maintainer explicitly asked for it.
+
+## Stopped at the owner gate — on purpose
+Did **not** provision the submissions Postgres / create the INSERT-only role / set `SUBMISSIONS_DB_DSN`
+/ cut over a domain. Those are rollout steps 3–4 (`botsite-deploy.md`), and they create a
+least-privilege DB role + put a secret on a service — security-sensitive + irreversible-ish work that
+the design explicitly defers to the owner. The site is fully functional **except** intake (which fails
+safe). Lighting up `/submit` is one clean owner/next-session step (provision DB → grant INSERT-only →
+set DSN). I can do it on request.
+
+## Left open / next session (all owner-paced)
+1. Submissions DB + `SUBMISSIONS_DB_DSN` (INSERT-only) → lights up `/submit`.
+2. Dev-site env (`GITHUB_ISSUE_MIRROR_TOKEN`, full DSN) → end-to-end submit→moderate→mirror.
+3. Marketing-domain cutover (Q-0178 defers to cutover).
+
+## 💡 Session idea (Q-0089)
+**`scripts/check_deploy_liveness.py`** — read the URL(s) recorded in `botsite-deploy.md` ▶ Live status
+(and the dashboard's) and curl `/healthz`, reporting up/down. This session exposed the gap it would
+close: the bot site was **code-complete + reviewed since ~#1119/#1122 but never deployed**, and nothing
+made "shipped to `main`" vs "live in prod" visibly diverge — so the ledger kept framing the *build* as
+the next step when the real remaining step was *rollout*. A mechanical liveness check turns "is the
+website actually live?" from tribal knowledge into one command. Disposable Q-0105 dev tool (stdlib +
+network-gated, skip when offline).
+
+## ⟲ Previous-session review (Q-0102)
+The predecessor (#1140 recon-trigger + voice pack) did its job well — the directive it planted **worked
+end-to-end**: the band-#1140 recon pass (#1142) ran tonight, routed Q-0182–Q-0185, and promoted two
+buildable plans. What it (and the whole chain) **missed**: no session noticed the website was sitting
+*code-complete-but-dark* — the un-deployed state was invisible because "merged to main" was treated as
+"done." **System improvement:** make deploy-liveness a first-class, checkable signal (the session idea
+above) so a finished-but-unshipped service can't hide behind a green ledger again. This is the same
+"pair every truth-claim with a check" through-line the recent tooling sessions have been building.
+
+## 📋 Doc audit (Q-0104)
+- Deploy facts recorded in their canonical home (`botsite-deploy.md`) + the rollout tracker
+  (`website-split-next-steps.md`) — both already reachable; no new orphan docs.
+- `current-state.md` intentionally **not** edited: the new PR is newer than the `#1140` reconciliation
+  marker → **benign lag** by the ledger checker's own rule; the next recon pass records it (avoids
+  racing the live routines on the contended mega-block).
+- `check_docs --strict` + `check_quality --check-only` green before the badge flip.

--- a/docs/operations/botsite-deploy.md
+++ b/docs/operations/botsite-deploy.md
@@ -6,6 +6,28 @@
 > Railway config win over this file. Written 2026-06-19 for the website two-site-split
 > ([plan](../planning/website-two-site-split-plan-2026-06-19.md) §6 / §2.1 / §4.4).
 
+## ▶ Live status — STOOD UP DARK (2026-06-19)
+
+The bot site is **deployed dark** (rollout step 2 below — Railway-generated URL only, no marketing
+domain, intake dormant). Provisioned in an owner-delegated session against the production Railway
+project (`reliable-grace`) via the public GraphQL API, mirroring the `dashboard` service's proven shape:
+
+| Fact | Value |
+|---|---|
+| Railway service | `botsite` (`e5bbedfc-8438-49c2-b543-5ed95617e2ef`), same project, `production` env |
+| Source / branch | `menno420/superbot` @ **`main`** — auto-redeploys on push (like `dashboard` / `worker`) |
+| Build scope | **Root Directory = `botsite`** · start = `botsite/Procfile` (`uvicorn app:app …`) · `RAILPACK_PYTHON_VERSION` unset (repo `.python-version` `3.13.13` is the single source) |
+| **Public URL** | **https://botsite-production-1ea7.up.railway.app** |
+| Secrets | **none** — only Railway's auto-injected `RAILWAY_*`. No `SUBMISSIONS_DB_DSN`, no OAuth, no tokens (the §4.4 public posture, by construction) |
+| Verified live | `/` · `/commands` · `/features` · `/changelog` · `/status` · `/submit` · `/healthz` all return **HTTP 200**; `/submit` shows the **dormant** "temporarily unavailable" state (no DSN) — dormant-by-default confirmed in prod |
+
+**Still the owner's to do (rollout steps 3–4 — deliberately NOT done unattended, since they create a
+least-privilege DB role + put a secret on a service):** provision the dashboard-owned submissions
+Postgres, apply `botsite/migrations/001_submissions.sql`, grant the **INSERT-only** role + set
+`SUBMISSIONS_DB_DSN` (this is what lights up `/submit`), then point a marketing domain at the service.
+Until then the site is fully functional **except** intake, which fails safe. **Rollback:** pause/delete
+the `botsite` service — the dev site and the bot are wholly untouched (additive split).
+
 The website two-site-split runs the public bot site as its **own Railway service**, deployed the
 same proven way as `dashboard/`: a service whose **Root Directory** is the app's own folder, so
 Railway installs *that folder's* `requirements.txt` and runs *that folder's* `Procfile`. This is

--- a/docs/operations/website-split-next-steps-2026-06-19.md
+++ b/docs/operations/website-split-next-steps-2026-06-19.md
@@ -17,7 +17,11 @@ The plan ([`../planning/website-two-site-split-plan-2026-06-19.md`](../planning/
   explicit `> **Subsystem:**` tag), and the `env-vars.md` web-tier marker drift. Full record:
   [`website-split-review-2026-06-19.md`](website-split-review-2026-06-19.md).
 
-**State:** both web apps are **dormant-by-default** — safe no-ops until their env is set. Nothing is live yet.
+**State:** both web apps are **dormant-by-default** — safe no-ops until their env is set.
+**Update 2026-06-19 — the bot site is now STOOD UP DARK:** live on its Railway URL
+(**https://botsite-production-1ea7.up.railway.app**), secret-free, all routes HTTP 200, `/submit`
+dormant (no DSN). See [`botsite-deploy.md`](botsite-deploy.md) ▶ Live status. The submissions DB + the
+dev-site env are still unprovisioned (owner steps below), so end-to-end intake is not live yet.
 
 ## 2. Left to do
 
@@ -38,16 +42,19 @@ The plan ([`../planning/website-two-site-split-plan-2026-06-19.md`](../planning/
   is the owner-paced batch — confirm it should be pursued.
 
 ### 2b. The rollout — turns the build into a live website (owner/infra; plan §6 + [`botsite-deploy.md`](botsite-deploy.md))
-- [ ] Provision the **new Railway service**, Root Directory = `botsite/` (own `requirements.txt` + `Procfile`;
+- [x] Provision the **new Railway service**, Root Directory = `botsite/` (own `requirements.txt` + `Procfile`;
   honor the no-`static/` gotcha). Dark-launch on the Railway URL first — verifiable in prod, not "the website" yet.
+  **DONE 2026-06-19** — service `botsite` @ `main`, Root Dir = `botsite`, secret-free; live at
+  `botsite-production-1ea7.up.railway.app` (all routes 200, `/submit` dormant). See `botsite-deploy.md` ▶ Live status.
 - [ ] Provision the **dashboard-owned submissions Postgres**; apply `botsite/migrations/001_submissions.sql`
   (idempotent `CREATE TABLE IF NOT EXISTS`).
 - [ ] Set env vars per the **Website tier** section of [`env-vars.md`](env-vars.md): `SUBMISSIONS_DB_DSN`
   (INSERT-only role on the public site, full role on the dev site), `SUBMISSIONS_IP_SALT`,
   `GITHUB_ISSUE_MIRROR_TOKEN` (dev-site only; fine-grained PAT, repo-scoped to `menno420/superbot`,
   **Issues: Read & write only**).
-- [ ] Verify the dark site, then **cut over the marketing domain**. **Rollback at every step:** delete/pause
-  the service · `DROP TABLE submissions` · revert DNS. The dev site is untouched throughout (additive).
+- [x] **Verify the dark site** — DONE 2026-06-19 (all 7 routes HTTP 200, `/submit` correctly dormant). —
+  [ ] then **cut over the marketing domain** (owner; deferred to cutover per Q-0178). **Rollback at every step:**
+  delete/pause the service · `DROP TABLE submissions` · revert DNS. The dev site is untouched throughout (additive).
 
 ### 2c. Deferred-by-design slices — gated on ONE prerequisite
 - [ ] **The control-API public-exposure security review** (plan §3 / §4.4 / §7.2 / §7.4) — unlocks both:

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,9 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/botsite-dark-launch` · **website-split rollout step 2** — stand the public bot site up DARK
+  on Railway (owner-delegated, Railway token) · ops (Railway `botsite` service) + docs
+  (`botsite-deploy.md` ▶ Live status · `website-split-next-steps.md` §2b ticks) · 2026-06-19
 - `claude/website-submit-form` · **website-split unit P4** — public `/submit` bug/suggestion
   form + intake (fills P1's `botsite/submit.py` stub) · exclusive: `botsite/submit.py` ·
   `botsite/ratelimit.py` · `botsite/templates/submit.html` · `tests/unit/botsite/test_submit.py`

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,9 +25,6 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/botsite-dark-launch` · **website-split rollout step 2** — stand the public bot site up DARK
-  on Railway (owner-delegated, Railway token) · ops (Railway `botsite` service) + docs
-  (`botsite-deploy.md` ▶ Live status · `website-split-next-steps.md` §2b ticks) · 2026-06-19
 - `claude/website-submit-form` · **website-split unit P4** — public `/submit` bug/suggestion
   form + intake (fills P1's `botsite/submit.py` stub) · exclusive: `botsite/submit.py` ·
   `botsite/ratelimit.py` · `botsite/templates/submit.html` · `tests/unit/botsite/test_submit.py`


### PR DESCRIPTION
## What

Owner-delegated unattended task ("wire the website … you have my Railway account token … I'll see what happened when I wake up"). Executed **rollout step 2 of the website two-site-split — stand the public bot site up DARK** (`docs/operations/botsite-deploy.md` / plan §6):

- Created the **`botsite` Railway service** in the production project (`reliable-grace`), mirroring the proven `dashboard` shape: **Root Directory = `botsite`**, source `menno420/superbot` **@ `main`** (auto-redeploys on push), start = `botsite/Procfile`, `RAILPACK_PYTHON_VERSION` unset.
- **Secret-free / dormant by construction** — the service holds **only** Railway's auto-injected `RAILWAY_*`. No DSN, no OAuth, no tokens (the §4.4 public posture).
- **Verified live in prod:** `/ /commands /features /changelog /status /submit /healthz` all **HTTP 200**; `/submit` shows the **dormant** "temporarily unavailable" state. Live (dark) at **https://botsite-production-1ea7.up.railway.app**.

This PR itself is **docs-only**: it records the live facts in `botsite-deploy.md` (▶ Live status) and ticks the `website-split-next-steps.md` §2b rollout checklist.

## Verified against ground truth (not assumed)

The delegated token was confirmed a real **account** token (`me` → the owner's email) and Railway's API reachable **before** any write; `botsite/` confirmed fully on `main`; the deploy reached `SUCCESS`; every route curled `200`. (The session's whole theme.)

## Stopped at the owner gate — on purpose

Did **not** provision the submissions Postgres / create the INSERT-only role / set `SUBMISSIONS_DB_DSN` / cut over a domain (rollout steps 3–4). Those create a least-privilege DB role + put a secret on a service — security-sensitive, deliberately deferred to the owner. The site is fully functional **except** intake, which fails safe. Rollback = pause/delete the `botsite` service (dev site + bot untouched).

## Safety

Docs-only repo change · no `disbot/` runtime · no secrets in the repo · no CLAUDE.md/hooks/config edits (Q-0106). Born-red session card flips to `complete` as the final commit; auto-merges on green Code Quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS

---
_Generated by [Claude Code](https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS)_