### PR TITLE
harden: bug-book guard short-circuits on terminal FIXED (root) label (#1146 review)

### DIFF
--- a/.sessions/2026-06-19-bug-book-guard-prose-root.md
+++ b/.sessions/2026-06-19-bug-book-guard-prose-root.md
@@ -1,0 +1,35 @@
+# 2026-06-19 — Bug-book guard: terminal short-circuit on `FIXED (root)` label, not bare `(root)`
+
+> **Status:** `complete`
+
+## Arc
+
+Second-round Codex review on #1146 (which merged before this could be folded in). Valid edge case:
+`_classify`'s terminal short-circuit keyed on bare `(root)`, so a *still-deferred* status whose prose
+mentions `(root)` — e.g. `FIXED (immediate) — root-fix RECOMMENDED; add (root) after the durable fix`
+— returned `None` before the deferred-signal checks, wrongly clearing exactly the entry the guard
+exists to list.
+
+## Fix
+
+Tightened the short-circuit to the terminal **`FIXED (root)` label** (not any `(root)` occurrence) —
+the bug-book contract is that a deferred entry *lacks* that terminal label. Real entries all write
+`FIXED (root)` for the terminal case, so live output is unchanged (still reports only BUG-0009).
+
+- `scripts/check_bug_book_rootfix_backlog.py` — one-line condition + docstring.
+- `tests/unit/scripts/test_check_bug_book_rootfix_backlog.py` — `test_prose_root_marker_does_not_suppress_a_deferred_status` (14 tests total).
+- Verified: 14 pass, `check_quality --check-only` green, full mirror before push.
+
+## Note
+
+This closes the #1144/#1146 review loop. Further review nitpicks on this warn-only, disposable (Q-0105)
+tool would be diminishing returns against increasingly contrived wording — the contract-correct cases
+are now covered; a later session should not chase further low-stakes edge cases here.
+
+## 📤 Run report
+
+- **Run type:** routine · dispatch
+- **⚑ Owner-decisions:** none
+- **⚑ Owner-manual-steps:** none
+- **⚑ Self-initiated:** YES — review-driven hardening of the self-initiated #1144/#1146 guard. No
+  dispatch/owner ask. Reversible (warn-only disposable tool).

--- a/scripts/check_bug_book_rootfix_backlog.py
+++ b/scripts/check_bug_book_rootfix_backlog.py
@@ -80,18 +80,21 @@ def _classify(status_text: str) -> str | None:
     """Return the backlog reason for a status string, or None if it owes no root fix.
 
     Matches **precise phrases / parenthesized markers**, not loose substrings, and
-    classifies the terminal ``(root)`` marker first (#1144 review hardening):
+    classifies the terminal ``FIXED (root)`` label first (#1144 / #1146 review hardening):
 
-    * a terminal ``FIXED (root)`` / ``(root)`` marker short-circuits — a closed-at-root
-      entry whose text still *mentions* a recommendation can't re-flag;
+    * the terminal ``FIXED (root)`` *label* short-circuits — a closed-at-root entry whose
+      text still *mentions* a recommendation can't re-flag. Keyed on the full ``FIXED (root)``
+      phrase, **not** any ``(root)`` occurrence, so prose like "add (root) after the durable
+      fix" in a *still-deferred* status doesn't wrongly clear it (the bug-book contract is that
+      a deferred entry *lacks* the terminal label);
     * ``PARTIALLY FIXED`` (the status phrase, not any "partially …") → partial;
     * ``RECOMMENDED`` (the deferred-root word; "recommendation" does not match) → deferred;
-    * ``(immediate)`` present without ``(root)`` → an explicitly-interim fix. Keying on the
-      parenthesized ``(immediate)`` label (not bare "immediate") and on the ``(root)``
-      *marker* (not any "root", so "root cause deferred" prose no longer suppresses it).
+    * ``(immediate)`` (the parenthesized label, not bare "immediate") → an explicitly-interim
+      fix. The terminal ``FIXED (root)`` short-circuit above already excludes a since-rooted
+      entry, so "root cause deferred" prose no longer suppresses a genuine immediate-only one.
     """
     upper = status_text.upper()
-    if "(ROOT)" in upper:
+    if "FIXED (ROOT)" in upper:
         return None
     if "PARTIALLY FIXED" in upper:
         return "partially fixed — open sub-cases remain"

--- a/tests/unit/scripts/test_check_bug_book_rootfix_backlog.py
+++ b/tests/unit/scripts/test_check_bug_book_rootfix_backlog.py
@@ -141,6 +141,17 @@ def test_terminal_fixed_mentioning_recommendation_is_not_flagged(mod):
     assert mod.find_rootfix_backlog(text) == []
 
 
+def test_prose_root_marker_does_not_suppress_a_deferred_status(mod):
+    # A still-deferred status that mentions "(root)" as prose (not the terminal
+    # FIXED (root) label) must still flag — only the terminal label bypasses the checks.
+    text = (
+        "## BUG-0204 — interim — FIXED (immediate)\n\n"
+        "- **Status:** FIXED (immediate) — root-fix RECOMMENDED; add (root) after the durable fix.\n"
+    )
+    flagged = {item.bug_id for item in mod.find_rootfix_backlog(text)}
+    assert flagged == {"BUG-0204"}
+
+
 def test_title_with_root_word_and_partially_does_not_false_positive(mod):
     # Belt-and-braces: a title carrying both "root" and "partially" with a plain FIXED
     # status is terminal — the title is never scanned for status signals.


### PR DESCRIPTION
## What

Second-round Codex review follow-up to **#1146** (which merged before this could be folded in).

`_classify`'s terminal short-circuit keyed on bare `(root)`, so a *still-deferred* status whose prose
mentions `(root)` — e.g. `FIXED (immediate) — root-fix RECOMMENDED; add (root) after the durable fix` —
returned `None` before the deferred-signal checks, wrongly clearing the exact entry the guard exists to
list.

## Fix

Tighten the short-circuit to the terminal **`FIXED (root)` label** (not any `(root)` occurrence) — the
bug-book contract is that a deferred entry *lacks* that terminal label. Real entries all write
`FIXED (root)` for the terminal case, so live output is unchanged (still reports only BUG-0009). Adds a
regression test (14 total). `check_quality --check-only` green; full mirror green.

## Note

This closes the #1144/#1146 review loop on this warn-only, disposable (Q-0105) guard. Further nitpicks
on increasingly contrived wording would be diminishing returns — the contract-correct cases are covered.

## Self-initiated (Q-0172)

Review-driven hardening of the self-initiated guard. No dispatch/owner ask. Reversible (warn-only tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6shCTzaQrKChD1nRWL2ux)_