### PR TITLE
ideas: fold owner's donut refinements (multi-level · link existing derived marker · hover/tap)

### DIFF
--- a/docs/ideas/dev-site-project-status-donut-2026-06-19.md
+++ b/docs/ideas/dev-site-project-status-donut-2026-06-19.md
@@ -18,6 +18,28 @@ public bot-site ships the marketing/bot surface, the two sites overlap — so th
 and let the public site own "here's the bot." The status donut is the first concrete beat of that
 refocus.
 
+## Owner refinements (follow-up, 2026-06-19)
+1. **Three levels — project + subsystem _now_, per-cog later.** The graphs should exist for the
+   **whole project**, **per subsystem**, and eventually **per cog**; project + subsystem is v1. **All
+   three are already derivable** — `export_dashboard_data.py` already computes per-subsystem open work
+   (`_subsystem_open_work`) and a per-command maturity `status` — so this is *one data source at three
+   roll-up levels*, not three systems.
+2. **Link the EXISTING completion marker — confirmed it exists (don't reinvent).** The repo already
+   carries an honest maturity signal: a command/subsystem is `in-progress` **iff it has a linked OPEN
+   idea or OPEN bug**, else `finished` (`export_dashboard_data.py` § "maturity badge",
+   `_OPEN_IDEA_STATUSES` + open-bug statuses). The donut **links this** — exactly the owner's "this is
+   just linking an existing feature."
+3. **…and it dodges the staleness the owner flagged.** Owner's point: *"completion markers are exactly
+   what sessions forget to update."* The win — this marker is **derived at export time** from linked
+   open ideas/bugs, so **nothing is hand-maintained** and it can't rot like a manual "% done" stamp.
+   **Design rule for this feature:** use the **derived** signals (badge counts + subsystem open-work);
+   **never** the hand-typed roadmap "Now/Next" stamps (which *do* go stale — `current-state.md` even
+   warns about its own stale stamps).
+4. **Interaction — tap/hover enlarges + animates the selected segment.** Inline-SVG donut with pure-CSS
+   `:hover` segment-grow (desktop) + a small **inlined** progressive-enhancement `<script>` for tap
+   (touch) and the enlarge animation — consistent with the no-`static/`-dir rule (JS lives inline in
+   the template, exactly like the bot site).
+
 ## Why it's a strong fit — the data already exists, and the *badge is the status field*
 The donut's segments map directly onto the **doc-badge lifecycle** the grooming discipline already
 maintains (`docs/ideas/README.md` §5): an item is badged `ideas` → re-badged `plan` when structured →
@@ -61,8 +83,8 @@ badge counts). Owner confirms (b) vs (a) vs (c).
 
 ## Open questions for the owner
 1. The completion definition above — **(a) / (b) / (c)**.
-2. **Whole-project rollup, or per-sector small-multiples?** (S1–S5 — the sector map already exists; a
-   row of small donuts per sector is richer.)
+2. ~~Whole-project vs per-sector?~~ **Resolved (owner 2026-06-19): project + per-subsystem now,
+   per-cog later** — all three roll up from the same derived source (see Owner refinements §1).
 3. **Dev-site refocus scope** — full re-theme of `dashboard/` (nav + landing → "projects"), or add the
    status section first and evolve? (Refines the website-two-site-split plan §2 / §7.4.)
 


### PR DESCRIPTION
## What

Folds the owner's follow-up refinements into the captured dev-site status-donut idea (`docs/ideas/dev-site-project-status-donut-2026-06-19.md`). The refinements arrived via a screenshot — the owner's message had **queued client-side and not actually sent**, so this also makes sure the content isn't lost.

Refinements captured:
1. **Three roll-up levels** — whole-project + per-subsystem **now**, per-cog later. All three derive from *one* source (`export_dashboard_data.py` already computes per-subsystem open-work + per-command status).
2. **Link the EXISTING completion marker (verified — don't reinvent):** a command/subsystem is `in-progress` **iff** it has a linked OPEN idea or OPEN bug, else `finished`. The owner correctly recalled this already exists.
3. **It dodges the staleness the owner flagged** ("completion markers are exactly what sessions forget to update") — because it's **derived at export time**, nothing is hand-maintained. Design rule recorded: use derived signals, never the hand-typed roadmap stamps.
4. **Interaction:** tap/hover enlarges + animates the selected segment (inline SVG + inlined progressive-enhancement JS — no `static/` dir).

Resolves the doc's open-question 2.

## Safety

Docs-only — capture refinement, no build, no decisions locked, no runtime/config. `check_docs --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS

---
_Generated by [Claude Code](https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS)_