### PR TITLE
docs: bot site URL → superbot-app.up.railway.app

### DIFF
--- a/docs/operations/botsite-deploy.md
+++ b/docs/operations/botsite-deploy.md
@@ -17,7 +17,7 @@ project (`reliable-grace`) via the public GraphQL API, mirroring the `dashboard`
 | Railway service | `botsite` (`e5bbedfc-8438-49c2-b543-5ed95617e2ef`), same project, `production` env |
 | Source / branch | `menno420/superbot` @ **`main`** — auto-redeploys on push (like `dashboard` / `worker`) |
 | Build scope | **Root Directory = `botsite`** · start = `botsite/Procfile` (`uvicorn app:app …`) · `RAILPACK_PYTHON_VERSION` unset (repo `.python-version` `3.13.13` is the single source) |
-| **Public URL** | **https://botsite-production-1ea7.up.railway.app** |
+| **Public URL** | **https://superbot-app.up.railway.app** |
 | Secrets | **none** — only Railway's auto-injected `RAILWAY_*`. No `SUBMISSIONS_DB_DSN`, no OAuth, no tokens (the §4.4 public posture, by construction) |
 | Verified live | `/` · `/commands` · `/features` · `/changelog` · `/status` · `/submit` · `/healthz` all return **HTTP 200**; `/submit` shows the **dormant** "temporarily unavailable" state (no DSN) — dormant-by-default confirmed in prod |
 

--- a/docs/operations/website-split-next-steps-2026-06-19.md
+++ b/docs/operations/website-split-next-steps-2026-06-19.md
@@ -19,7 +19,7 @@ The plan ([`../planning/website-two-site-split-plan-2026-06-19.md`](../planning/
 
 **State:** both web apps are **dormant-by-default** — safe no-ops until their env is set.
 **Update 2026-06-19 — the bot site is now STOOD UP DARK:** live on its Railway URL
-(**https://botsite-production-1ea7.up.railway.app**), secret-free, all routes HTTP 200, `/submit`
+(**https://superbot-app.up.railway.app**), secret-free, all routes HTTP 200, `/submit`
 dormant (no DSN). See [`botsite-deploy.md`](botsite-deploy.md) ▶ Live status. The submissions DB + the
 dev-site env are still unprovisioned (owner steps below), so end-to-end intake is not live yet.
 
@@ -45,7 +45,7 @@ dev-site env are still unprovisioned (owner steps below), so end-to-end intake i
 - [x] Provision the **new Railway service**, Root Directory = `botsite/` (own `requirements.txt` + `Procfile`;
   honor the no-`static/` gotcha). Dark-launch on the Railway URL first — verifiable in prod, not "the website" yet.
   **DONE 2026-06-19** — service `botsite` @ `main`, Root Dir = `botsite`, secret-free; live at
-  `botsite-production-1ea7.up.railway.app` (all routes 200, `/submit` dormant). See `botsite-deploy.md` ▶ Live status.
+  `superbot-app.up.railway.app` (all routes 200, `/submit` dormant). See `botsite-deploy.md` ▶ Live status.
 - [ ] Provision the **dashboard-owned submissions Postgres**; apply `botsite/migrations/001_submissions.sql`
   (idempotent `CREATE TABLE IF NOT EXISTS`).
 - [ ] Set env vars per the **Website tier** section of [`env-vars.md`](env-vars.md): `SUBMISSIONS_DB_DSN`


### PR DESCRIPTION
## What

The owner asked to move the public bot site onto a clean URL. I renamed its Railway service domain:

- **Public bot site → https://superbot-app.up.railway.app** (verified HTTP 200, serving the real site). The old `botsite-production-1ea7.up.railway.app` is replaced.
- **Dashboard untouched** — still `superbot-dashboard.up.railway.app` (HTTP 200, Discord OAuth login intact). No other service changed.

This PR updates the deploy ledger (`botsite-deploy.md` ▶ Live status) and rollout tracker (`website-split-next-steps.md`) to the new URL so they aren't stale. ("No marketing domain yet" still holds — `superbot-app` is a Railway subdomain, not a custom domain; the custom-domain cutover remains the deferred owner step.)

## Note

`superbot.up.railway.app` (the cleanest name) is held by an unrelated Railway account, so it wasn't available; `superbot-app` was the owner's chosen clean alternative.

## Safety

Docs-only — records an infra change already made + verified. No runtime/config. `check_docs --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS

---
_Generated by [Claude Code](https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS)_