### PR TITLE
feat(botsite): wire the "Add to Discord" buttons to the real install link

### DIFF
--- a/botsite/app.py
+++ b/botsite/app.py
@@ -58,6 +58,15 @@ from submit import router as submit_router  # noqa: E402  - after the shim
 
 app = FastAPI(title="SuperBot", docs_url=None, redoc_url=None)
 
+# The bot's public install link — the Discord "Add App" / OAuth2 authorize URL. The
+# bare ``client_id`` link uses the app's *default install settings* (scopes +
+# permissions) configured in the Discord developer portal, so it is the canonical
+# one-click invite. Injected into every template via ``site_context`` so all the
+# "Add to Discord" CTAs share one source (no duplicated magic strings in templates).
+ADD_TO_DISCORD_URL = (
+    "https://discord.com/oauth2/authorize?client_id=1403818430758654132"
+)
+
 
 def site_context(request: Request) -> dict[str, Any]:
     """Context merged into every template — the build/freshness band the nav shows.
@@ -70,6 +79,7 @@ def site_context(request: Request) -> dict[str, Any]:
     return {
         "build": data_loader.build_meta(data),
         "site_counts": data.get("counts", {}),
+        "add_url": ADD_TO_DISCORD_URL,
     }
 
 

--- a/botsite/templates/base.html
+++ b/botsite/templates/base.html
@@ -38,7 +38,9 @@
           </a>
           {# Persistent, distinctively-styled "Add to Discord" CTA (layout guidance). #}
           <a
-            href="/"
+            href="{{ add_url }}"
+            target="_blank"
+            rel="noopener"
             class="text-sm rounded-lg bg-indigo-600 hover:bg-indigo-500 px-4 py-1.5 font-semibold shadow"
           >Add to Discord</a>
         </div>

--- a/botsite/templates/index.html
+++ b/botsite/templates/index.html
@@ -11,7 +11,7 @@
     self-improving, AI-assisted development workflow.
   </p>
   <div class="mt-7 flex items-center justify-center gap-3">
-    <a href="/" class="rounded-lg bg-indigo-600 hover:bg-indigo-500 px-6 py-2.5 font-semibold shadow">
+    <a href="{{ add_url }}" target="_blank" rel="noopener" class="rounded-lg bg-indigo-600 hover:bg-indigo-500 px-6 py-2.5 font-semibold shadow">
       Add to Discord
     </a>
     <a href="/features" class="rounded-lg border border-slate-700 hover:border-slate-500 px-6 py-2.5 font-medium">
@@ -80,7 +80,7 @@
 
 {# ── Repeat CTA ────────────────────────────────────────────────────────────── #}
 <section class="mt-14 text-center">
-  <a href="/" class="rounded-lg bg-indigo-600 hover:bg-indigo-500 px-7 py-3 font-semibold shadow">
+  <a href="{{ add_url }}" target="_blank" rel="noopener" class="rounded-lg bg-indigo-600 hover:bg-indigo-500 px-7 py-3 font-semibold shadow">
     Add SuperBot to your server
   </a>
 </section>

--- a/tests/unit/botsite/test_app.py
+++ b/tests/unit/botsite/test_app.py
@@ -56,6 +56,18 @@ def test_index_renders(client):
     assert "How it works" in resp.text
 
 
+def test_add_to_discord_ctas_link_to_install_url(client, app_module):
+    # All the "Add to Discord" CTAs (nav + hero + repeat) point at the real Discord
+    # install link — wired from one source (app.ADD_TO_DISCORD_URL), not the "/"
+    # placeholder. Guards against a silent regression back to a dead button.
+    install = app_module.ADD_TO_DISCORD_URL
+    assert install.startswith("https://discord.com/oauth2/authorize?client_id=")
+    resp = client.get("/")
+    assert resp.status_code == 200
+    # The hero + repeat CTAs live on the landing; the nav CTA comes from base.html.
+    assert resp.text.count(install) >= 2
+
+
 def test_index_shows_honest_catalogue_counts_not_server_totals(client, app_module):
     # The capability band renders catalogue counts (commands/features/games) — never
     # server/user totals (plan layout note: those need the deferred live source).


### PR DESCRIPTION
## What

The owner provided the bot's Discord install link (OAuth2 authorize / "Add App"), to wire into the public site's "Add to Discord" buttons.

All three CTAs pointed at the `/` placeholder:
- nav (`base.html`) · hero (`index.html`) · repeat CTA (`index.html`)

Now they share **one source** — `ADD_TO_DISCORD_URL` in `app.py`, injected into every template via `site_context` as `add_url` (no duplicated magic strings) — and open in a new tab (`target="_blank" rel="noopener"`). The bare `client_id` link uses the app's *default install settings* (scopes + permissions) configured in the Discord developer portal, so it's the canonical one-click invite.

## Verification

- New regression test `test_add_to_discord_ctas_link_to_install_url` (the CTAs link to the real install URL, ≥2 occurrences in the rendered HTML — guards against silent revert to a dead button).
- **62 bot-site tests pass** (ran locally after `pip install -r botsite/requirements.txt`); `check_quality --check-only` + `mypy botsite/` clean.

## Effect

On merge, `botsite` auto-redeploys and the **Add to Discord** buttons on https://superbot-app.up.railway.app become live install links.

## Safety

Bot-site template/href change + one constant — no secrets, no `disbot/`, no decoupling impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS

---
_Generated by [Claude Code](https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS)_