### PR TITLE
fix(botsite): /submit had a dead "Add to Discord" button (Codex catch on #1152)

### DIFF
--- a/botsite/app.py
+++ b/botsite/app.py
@@ -53,39 +53,19 @@ BASE_DIR = Path(__file__).resolve().parent
 if str(BASE_DIR) not in sys.path:
     sys.path.insert(0, str(BASE_DIR))
 
+import chrome  # noqa: E402  - sibling, after the sys.path shim above
 import data_loader  # noqa: E402  - after the sys.path shim above
 from submit import router as submit_router  # noqa: E402  - after the shim
 
 app = FastAPI(title="SuperBot", docs_url=None, redoc_url=None)
 
-# The bot's public install link — the Discord "Add App" / OAuth2 authorize URL. The
-# bare ``client_id`` link uses the app's *default install settings* (scopes +
-# permissions) configured in the Discord developer portal, so it is the canonical
-# one-click invite. Injected into every template via ``site_context`` so all the
-# "Add to Discord" CTAs share one source (no duplicated magic strings in templates).
-ADD_TO_DISCORD_URL = (
-    "https://discord.com/oauth2/authorize?client_id=1403818430758654132"
-)
-
-
-def site_context(request: Request) -> dict[str, Any]:
-    """Context merged into every template — the build/freshness band the nav shows.
-
-    Carries the generated-build provenance so the chrome can render the honest
-    "generated · as of last deploy" freshness badge (plan §3) without each route
-    re-deriving it. The public site never claims live state here.
-    """
-    data = data_loader.load_site_data()
-    return {
-        "build": data_loader.build_meta(data),
-        "site_counts": data.get("counts", {}),
-        "add_url": ADD_TO_DISCORD_URL,
-    }
-
-
+# The shared template chrome (the freshness band + the "Add to Discord" install URL)
+# lives in ``chrome.py`` so BOTH this app's Jinja env and the /submit router's own Jinja
+# env inject the same context — otherwise a page rendered by one env shows empty chrome
+# (the /submit dead-install-button regression). See ``chrome.site_context``.
 templates = Jinja2Templates(
     directory=str(BASE_DIR / "templates"),
-    context_processors=[site_context],
+    context_processors=[chrome.site_context],
 )
 
 

--- a/botsite/chrome.py
+++ b/botsite/chrome.py
@@ -1,0 +1,52 @@
+"""Shared template chrome for the bot site — injected into BOTH Jinja environments.
+
+The marketing app (``app.py``) and the ``/submit`` router (``submit.py``) each own a
+``Jinja2Templates`` instance but render the **same** ``base.html`` layout. Anything the
+layout needs — the freshness-badge build meta and the "Add to Discord" install URL —
+must be injected into *both* environments, or a page rendered by one env shows empty
+chrome. Defining the context processor here (imported by both) keeps it DRY.
+
+Regression this prevents: ``/submit`` is rendered by ``submit.py``'s own Jinja env, so
+when ``base.html``'s nav started using ``{{ add_url }}`` the submit page rendered a dead
+``href=""`` install button. Sharing this one processor fixes it at the root (and also
+gives ``/submit`` the same freshness badge as every other page).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+from fastapi import Request
+
+# Same sibling-import shim as app.py / submit.py — the module may be imported by file
+# path in tests, as a package, or as a top-level module on Railway (Root Dir = botsite).
+_BASE_DIR = Path(__file__).resolve().parent
+if str(_BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(_BASE_DIR))
+
+import data_loader  # noqa: E402  - sibling, after the sys.path shim above
+
+# The bot's public install link — the Discord "Add App" / OAuth2 authorize URL. The
+# bare ``client_id`` link uses the app's *default install settings* (scopes +
+# permissions) configured in the Discord developer portal, so it is the canonical
+# one-click invite.
+ADD_TO_DISCORD_URL = (
+    "https://discord.com/oauth2/authorize?client_id=1403818430758654132"
+)
+
+
+def site_context(request: Request) -> dict[str, Any]:
+    """Context merged into EVERY page across both Jinja envs (app + submit router).
+
+    Carries the generated-build freshness band + the install CTA URL so the shared
+    chrome (``base.html``) renders identically on every route. The public site never
+    claims live state here.
+    """
+    data = data_loader.load_site_data()
+    return {
+        "build": data_loader.build_meta(data),
+        "site_counts": data.get("counts", {}),
+        "add_url": ADD_TO_DISCORD_URL,
+    }

--- a/botsite/submit.py
+++ b/botsite/submit.py
@@ -42,12 +42,19 @@ _BASE_DIR = Path(__file__).resolve().parent
 if str(_BASE_DIR) not in sys.path:
     sys.path.insert(0, str(_BASE_DIR))
 
+import chrome  # noqa: E402  - sibling, after the sys.path shim above
 import ratelimit  # noqa: E402  - sibling, after the sys.path shim above
 import submissions_db  # noqa: E402  - sibling, after the sys.path shim above
 
-# The form's own templates dir (the app mounts its own Jinja env; this router renders
-# its single template directly, so it stays self-contained — no app.py coupling).
-_templates = Jinja2Templates(directory=str(_BASE_DIR / "templates"))
+# The form's own templates dir + the SHARED chrome context processor
+# (``chrome.site_context``) so base.html's nav/footer render identically here as on the
+# marketing app — notably the "Add to Discord" install button, which a separate Jinja
+# env would otherwise render as an empty href. Still self-contained: ``chrome`` is a
+# sibling module (no app.py coupling).
+_templates = Jinja2Templates(
+    directory=str(_BASE_DIR / "templates"),
+    context_processors=[chrome.site_context],
+)
 
 # Hidden field a human never sees/fills; any value means an automated submitter.
 _HONEYPOT_FIELD = "website"

--- a/tests/unit/botsite/test_app.py
+++ b/tests/unit/botsite/test_app.py
@@ -58,14 +58,24 @@ def test_index_renders(client):
 
 def test_add_to_discord_ctas_link_to_install_url(client, app_module):
     # All the "Add to Discord" CTAs (nav + hero + repeat) point at the real Discord
-    # install link — wired from one source (app.ADD_TO_DISCORD_URL), not the "/"
+    # install link — wired from one source (chrome.ADD_TO_DISCORD_URL), not the "/"
     # placeholder. Guards against a silent regression back to a dead button.
-    install = app_module.ADD_TO_DISCORD_URL
+    install = app_module.chrome.ADD_TO_DISCORD_URL
     assert install.startswith("https://discord.com/oauth2/authorize?client_id=")
     resp = client.get("/")
     assert resp.status_code == 200
     # The hero + repeat CTAs live on the landing; the nav CTA comes from base.html.
     assert resp.text.count(install) >= 2
+
+
+def test_submit_page_shares_chrome_with_working_install_cta(client, app_module):
+    # /submit is rendered by submit.py's SEPARATE Jinja env; it must share
+    # chrome.site_context so base.html's nav "Add to Discord" button isn't a dead
+    # href="" there. (Regression caught on PR #1152: the separate env had no context
+    # processor, so the public feedback page shipped a dead install button.)
+    resp = client.get("/submit")
+    assert resp.status_code == 200
+    assert app_module.chrome.ADD_TO_DISCORD_URL in resp.text
 
 
 def test_index_shows_honest_catalogue_counts_not_server_totals(client, app_module):


### PR DESCRIPTION
## What

Fixes a real regression **Codex caught on #1152**: the `/submit` page rendered a **dead "Add to Discord" button** (`href=""`).

**Root cause:** `/submit` is rendered by `submit.py`'s *own* `Jinja2Templates` instance, which never ran `app.py`'s `site_context` context processor. When `base.html`'s nav started using `{{ add_url }}` (#1152), that variable was undefined on `/submit` → empty href. My #1152 test only covered `/`, so it missed the second Jinja env.

## Root fix (DRY, not a patch)

Extract the shared chrome — `ADD_TO_DISCORD_URL` + `site_context` — into **`botsite/chrome.py`**, and register `chrome.site_context` on **both** Jinja environments (`app.py` *and* `submit.py`). Now every page, including `/submit`, gets the install CTA — and the freshness badge, which `/submit` was *also* silently missing.

## Verification

- New regression test `test_submit_page_shares_chrome_with_working_install_cta` (renders `/submit`, asserts the install URL is present).
- **63 bot-site tests pass** (was 62 + this one); `check_quality --check-only` + `mypy botsite/` clean.

On merge, `botsite` redeploys and the **Add to Discord** button works on `/submit` too (https://superbot-app.up.railway.app/submit).

## Safety

Bot-site only — no secrets, no `disbot/`, no decoupling change (`chrome.py` imports only `data_loader`, never `disbot`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS

---
_Generated by [Claude Code](https://claude.ai/code/session_018yz7Fhf4BRSMYp5YpNt4rS)_