### PR TITLE
fix(BUG-0016): single-source the reconcile-issue body to kill the drift class

### DIFF
--- a/.github/workflows/reconciliation-trigger.yml
+++ b/.github/workflows/reconciliation-trigger.yml
@@ -4,8 +4,9 @@ name: reconciliation-trigger
 # per Q-0134): when merged PRs cross a 30-PR band, open a `reconcile` issue that fires the
 # "superbot docs reconciliation" routine. This runs the docs/planning pass PROMPTLY (daytime
 # included) so the docs are fresh for the next dispatch run — not deferred to a nightly poll.
-# The firing boundary is owned by scripts/check_reconciliation_due.py (STEP = 30); only the
-# human-readable copy below must be kept in sync with it.
+# The firing boundary AND the issue-body copy are both owned by
+# scripts/check_reconciliation_due.py (STEP = 30, `--issue-body`): this workflow echoes the
+# checker's body rather than carrying its own string, so the copy can never drift (BUG-0016).
 #
 # Provenance + reliability (Q-0105): added 2026-06-12. UNVERIFIED — confirm over a few cycles
 # that it opens the issue only at the boundary and dedupes. Delete this workflow if it
@@ -69,7 +70,10 @@ jobs:
           fi
           gh label create reconcile --color FBCA04 \
             --description "Fires the docs-reconciliation routine (Q-0107)" --force 2>/dev/null || true
+          # Echo the body from the cadence checker so the human-readable copy can never
+          # drift from the live cadence again (BUG-0016 was exactly that drift). STEP=30
+          # lives in exactly one place: scripts/check_reconciliation_due.py.
           gh issue create \
             --title "Docs reconciliation due (Q-0107)" \
             --label reconcile \
-            --body $'A 30-PR band was crossed — a docs-only reconciliation + planning pass is due (Q-0107, cadence 30 per Q-0134).\n\nThis issue triggers the **superbot docs reconciliation** routine, which reconciles the ledger, de-stales docs, plans the next full band (depth >= the cadence, Q-0164), adds one idea, resets the `Last reconciliation pass` marker, and closes this issue.\n\nAuto-opened by `.github/workflows/reconciliation-trigger.yml`. You can also open a `reconcile`-labeled issue by hand whenever you spot docs drift.'
+            --body "$(python3.10 scripts/check_reconciliation_due.py --issue-body)"

--- a/.sessions/2026-06-19-funny-franklin-bug0016-recon-copy.md
+++ b/.sessions/2026-06-19-funny-franklin-bug0016-recon-copy.md
@@ -1,0 +1,21 @@
+# Session — funny-franklin · BUG-0016 root-cause hardening (single-source reconcile-issue body)
+
+> **Status:** `complete`
+
+**Run type:** routine · dispatch
+**Branch:** `claude/funny-franklin-qpth6s`
+
+## Context (after a re-sync mid-run)
+Empty scheduled dispatch fire. Started on **BUG-0016** (reconciliation-trigger stale
+cadence copy). Mid-run a long gap elapsed and `main` advanced #1102 → #1139; a concurrent
+dispatch run had already FIXED BUG-0016 (corrected the strings) — so my string-fix slice
+was redundant. I rebased onto latest main and kept only the **novel root-cause** half:
+that run explicitly left the drift class ("optionally have the checker be the single source")
+unbuilt.
+
+## What this PR does
+Eliminate the BUG-0016 drift class at the root: the canonical reconcile-issue body now lives
+in `scripts/check_reconciliation_due.py` (`issue_body()`, built from `STEP`, exposed via
+`--issue-body`), and `reconciliation-trigger.yml` **echoes** it instead of carrying its own
+hardcoded copy. The cadence numbers (STEP=30, full-band) can never desync between the firing
+logic and the issue prose again. Tested.

--- a/docs/health/bug-book.md
+++ b/docs/health/bug-book.md
@@ -114,6 +114,14 @@
   Q-0164)". Added a one-line note in the workflow header that `check_reconciliation_due.py`
   (`STEP = 30`) owns the firing boundary and the copy must track it. No regression guard (a
   string; the firing logic was already correct and is covered by the script's own tests).
+- **Root-cause hardening (follow-up dispatch run, 2026-06-19):** the first fix corrected the
+  copy but left it hardcoded in the workflow — the *drift class itself* (two places that must be
+  kept in sync) remained. Eliminated it: `check_reconciliation_due.py` now owns the canonical
+  body too (`issue_body()`, built from `STEP`, exposed via `--issue-body`), and the workflow
+  **echoes** it (`--body "$(python3.10 scripts/check_reconciliation_due.py --issue-body)"`)
+  instead of carrying a copy. The cadence numbers now live in exactly one place and can never
+  desync again. Guarded by `test_issue_body_tracks_the_live_cadence` /
+  `test_issue_body_flag_prints_body_and_exits_zero`.
 
 ## BUG-0015 — "d67 dart paragon" misread as upgrade path "0-6-7" (paragon degree ignored) — FIXED
 

--- a/scripts/check_reconciliation_due.py
+++ b/scripts/check_reconciliation_due.py
@@ -45,6 +45,26 @@ _MARKER_RE = re.compile(r"Last reconciliation pass:\*\*\s*PR #(\d+)")
 _MERGE_SUBJECT_RE = re.compile(r"(?:pull request #|PR #|\(#)(\d+)")
 
 
+def issue_body() -> str:
+    """The canonical `reconcile`-issue body — the single source the workflow echoes.
+
+    Built from ``STEP`` so the human-readable cadence copy can never drift away from the
+    live firing cadence again. BUG-0016 was exactly that drift: the workflow carried its own
+    hardcoded body string that still said "multiple-of-20" / "next ~9 PRs" long after the
+    cadence became 30 (Q-0134) and the planning horizon became the full band (Q-0164). The
+    workflow now calls ``check_reconciliation_due.py --issue-body`` instead of holding a copy.
+    """
+    return (
+        f"A {STEP}-PR band was crossed — a docs-only reconciliation + planning pass is due "
+        f"(Q-0107, cadence {STEP} per Q-0134).\n\n"
+        "This issue triggers the **superbot docs reconciliation** routine, which reconciles "
+        "the ledger, de-stales docs, plans the next full band (depth >= the cadence, Q-0164), "
+        "adds one idea, resets the `Last reconciliation pass` marker, and closes this issue.\n\n"
+        "Auto-opened by `.github/workflows/reconciliation-trigger.yml`. You can also open a "
+        "`reconcile`-labeled issue by hand whenever you spot docs drift."
+    )
+
+
 def _latest_merged_pr() -> int | None:
     """Highest merged PR number from recent origin/main history.
 
@@ -110,7 +130,16 @@ def main(argv: list[str] | None = None) -> int:
         description="reconciliation-cadence guard (Q-0107).",
     )
     parser.add_argument("--strict", action="store_true", help="exit 1 if a pass is due")
+    parser.add_argument(
+        "--issue-body",
+        action="store_true",
+        help="print the canonical `reconcile`-issue body and exit (the workflow echoes this)",
+    )
     args = parser.parse_args(argv)
+
+    if args.issue_body:
+        print(issue_body())
+        return 0
 
     due, latest, marker = is_due()
     if marker is None:

--- a/tests/unit/scripts/test_check_reconciliation_due.py
+++ b/tests/unit/scripts/test_check_reconciliation_due.py
@@ -71,6 +71,25 @@ def test_no_marker_main_exits_zero(monkeypatch) -> None:
     assert crd.main(["--strict"]) == 0
 
 
+def test_issue_body_tracks_the_live_cadence() -> None:
+    """The canonical issue body is built from STEP, so it can never drift from the
+    firing cadence (BUG-0016: the workflow's old hardcoded string said "multiple-of-20" /
+    "next ~9 PRs" long after the cadence became 30 + full-band)."""
+    body = crd.issue_body()
+    assert f"A {crd.STEP}-PR band was crossed" in body
+    assert f"cadence {crd.STEP} per Q-0134" in body
+    assert "next full band" in body
+    # The stale strings the bug was about must be gone.
+    assert "multiple-of-20" not in body
+    assert "~9 PRs" not in body
+
+
+def test_issue_body_flag_prints_body_and_exits_zero(capsys) -> None:
+    assert crd.main(["--issue-body"]) == 0
+    out = capsys.readouterr().out
+    assert out.strip() == crd.issue_body()
+
+
 def test_merge_subject_regex_covers_all_three_styles() -> None:
     """The 'PR #' alternative is load-bearing: MCP merges ("Merge PR #N: …")
     are the dominant style since 2026-06, and missing them froze the latest-PR


### PR DESCRIPTION
## What & why

BUG-0016 (the `reconcile` trigger issue's stale "multiple-of-20" / "next ~9 PRs" copy) was already **symptom-fixed** on main by a concurrent dispatch run — it corrected the strings. But that fix left the *drift class* itself intact: the workflow still carried its **own hardcoded** body string that had to be kept in sync with the `STEP=30` cadence by hand (its own bug-book note even flagged "optionally have the checker be the single source" as unbuilt). The strings desynced once already — that's how BUG-0016 happened — so this is the root fix.

## Change

- **`scripts/check_reconciliation_due.py`** — add `issue_body()` (built from `STEP`) and a `--issue-body` flag, so the canonical reconcile-issue body lives in exactly one place, right next to the firing cadence.
- **`.github/workflows/reconciliation-trigger.yml`** — `gh issue create` now echoes `--body "$(python3.10 scripts/check_reconciliation_due.py --issue-body)"` instead of a hardcoded `$'…'` copy. The cadence numbers can never desync from the firing logic again.
- **tests** — `test_issue_body_tracks_the_live_cadence` + `test_issue_body_flag_prints_body_and_exits_zero`.
- **bug-book** — record the root-cause hardening under BUG-0016.

## Provenance / relevance note

This run started on BUG-0016's *string* fix; a long gap elapsed and main advanced #1102 → #1155, during which a concurrent run shipped that same string fix. After re-syncing (rebased onto #1155) I kept **only** the still-novel root-cause half — verified absent on latest main. Pure stdlib, no runtime (`disbot/`) code; reversible.

## Verification

- `python3.10 -m pytest tests/unit/scripts/test_check_reconciliation_due.py` — 12 passed
- `python3.10 scripts/check_quality.py --check-only` — all checks passed
- `--issue-body` output and the workflow YAML both validated locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018K2pgLXa93NAxEjEg3EZ2F)_