### PR TITLE
Explore world-registry parity invariant + games folio spine docs

### DIFF
--- a/.sessions/2026-06-20-world-registry-parity-invariant.md
+++ b/.sessions/2026-06-20-world-registry-parity-invariant.md
@@ -1,0 +1,50 @@
+# 2026-06-20 — Explore world-registry parity invariant + folio docs
+
+> **Status:** `complete` — small follow-up to the merged spine PR 1 (#1156). Docs + test only,
+> no runtime code → self-merge on green (Q-0113).
+
+> **Run type:** routine · dispatch
+
+## What I did
+
+Follow-up slice in the same dispatch run, after the federated Explore-hub **PR 1 merged (#1156)**.
+Hardened + documented the new world-registry seam — a safe, self-mergeable slice. I deliberately did
+**not** take the heavier next lanes this autonomous run:
+- **Plan PR 2** (global vs per-game XP split) needs a `player_skills` **`game` discriminator
+  migration** on a live progression table — a schema change I can't runtime-verify here; deferred to
+  a runtime-verified session.
+- **procedures→skills Batch 1** edits `.claude/CLAUDE.md`, which Q-0106 makes **read-only to me in
+  an autonomous session** (propose, don't self-edit) — out of scope here.
+
+## What shipped
+- **`tests/unit/invariants/test_world_registry_parity.py`** (NEW) — a CI invariant asserting every
+  registered Explore `WorldEntry.key` resolves to a real `SUBSYSTEMS` entry (no silent dead-end
+  buttons), each entry has non-empty label/emoji/description, the hub's button custom_ids are
+  unique, and the two built-ins (mining · fishing) register by default. A pytest invariant (not a
+  `check_*.py` script) because the registry is **code** (openers are callables), not a generated
+  JSON artifact — the same home as `test_command_synonyms_resolve_to_real_commands`.
+- **`docs/subsystems/games.md`** (EDIT) — new "Federated Explore world spine" section documenting
+  the seam (`world_registry` · `ExploreWorldHubView` · `!world` · the parity invariant) and **how to
+  add a world** (register a `WorldEntry` at the owning cog's setup), with the next spine slices
+  (PR 2/PR 3) + the Q-0182 gate noted, so the next agent finds the seam cold.
+
+## Verification
+- `python3.10 -m pytest tests/unit/invariants/test_world_registry_parity.py` → 4 passed.
+- `python3.10 scripts/check_docs.py --strict` → all checks passed (folio edit clean, ratchets held).
+- No `disbot/` runtime code changed → arch/lint trivially unaffected.
+
+## Handoff
+Federated Explore-hub **PR 2** (global vs per-game XP split — needs the `player_skills` `game`
+discriminator migration, **runtime-verify**) then **PR 3** (cross-game identity card). Plan §4–§5.
+The world-registry seam now has a parity invariant guarding it and a folio entry documenting it.
+
+## ⚑ Self-initiated
+None — this hardens/documents an already-merged, already-on-plan lane (PR 1). Not a new feature.
+
+## 📤 Run report
+- **Run type:** routine · dispatch
+- **What shipped:** world-registry parity invariant + games-folio spine documentation (follow-up to
+  merged PR #1156).
+- **⚑ Owner-decisions:** none
+- **⚑ Owner-manual-steps:** none
+- **⚑ Self-initiated:** none

--- a/docs/subsystems/games.md
+++ b/docs/subsystems/games.md
@@ -13,6 +13,36 @@ Start in `disbot/cogs/games_cog.py`, `disbot/views/games/`,
 `disbot/views/mining/`, `disbot/services/game_state_service.py`,
 `disbot/services/economy_service.py`, and `disbot/utils/db/games/`.
 
+## Federated Explore world spine (the open-world hub)
+
+The **open-world** games (mining · fishing · later pets/survival) are tied together by a
+top-level **Explore world hub** — the "town square" a player walks out into — separate from
+the competitive **Games hub** (`!games`, blackjack/RPS/deathmatch). Spine PR 1 (federated
+Explore-hub plan, merged #1156):
+
+- **`disbot/services/world_registry.py`** — the registry seam. Each world is a `WorldEntry`
+  (`key/label/emoji/description/opener/order`); `register_world_entry` is idempotent (de-dup by
+  key) and `get_world_entries` returns them sorted by `(order, label)`. **Pure**: it stores the
+  `opener` as an opaque callable and imports no view, so it never creates a `services → views`
+  edge. A new world docks in by registering an entry — no edit to the hub.
+- **`disbot/views/explore/world_hub.py`** — `ExploreWorldHubView(HubView)` +
+  `build_world_hub_embed()`, one button per registered world. Built-ins: **Mine** → the mining
+  hub, **Fish** → a fishing entry card (fishing is hub-less). An opener-less entry renders a
+  generic coming-soon card. Mirrors the registry-driven `views/games/hub.py` pattern.
+- **`!world`** (in `games_cog.py`) opens the hub directly; the mining `🗺️ Explore` button
+  (custom_id `mining:explore_hub`) forwards to it.
+- **Invariant:** `tests/unit/invariants/test_world_registry_parity.py` asserts every registered
+  world `key` resolves to a real `SUBSYSTEMS` entry (no silent dead-end buttons).
+
+**Adding a world:** register a `WorldEntry` (key = the subsystem key) at the owning cog's setup,
+with an `opener(interaction, view)` that enters that world in place. The built-in Mine/Fish
+defaults live in `world_hub.ensure_default_world_entries()` because their openers are view-layer
+code; a self-contained subsystem registers from its own module. **Next spine slices** (plan §4):
+PR 2 = make the global (`game_xp` SUM) vs per-game tree split explicit (per-game skill trees need a
+`player_skills` `game` discriminator — a schema slice, verify live first); PR 3 = a cross-game
+identity read-card. Gated open-world layers (gear auto-equip · survival overlay · biome map) wait
+on **Q-0182**.
+
 ## Rules & approved structures (binding — link, don't restate)
 
 - **ADR-002:** in-flight game state is intentionally not guaranteed restart-safe.

--- a/tests/unit/invariants/test_world_registry_parity.py
+++ b/tests/unit/invariants/test_world_registry_parity.py
@@ -1,0 +1,79 @@
+"""Invariant — every registered Explore world maps to a real subsystem.
+
+The federated Explore world hub (spine PR 1, `services/world_registry.py` +
+`views/explore/world_hub.py`) is **registry-driven**: each subsystem registers a
+`WorldEntry`, and the hub renders one button per entry. A world whose `key`
+doesn't correspond to a real `SUBSYSTEMS` entry would render a button that looks
+valid but is backed by nothing — a silent dead end. This invariant catches that
+at CI time, the same way `test_command_synonyms_resolve_to_real_commands` guards
+the synonym map.
+
+Why a test and not a `check_*.py` script: the registry is **code** (openers are
+callables), not a generated JSON artifact, so a pytest invariant — which already
+has `disbot` importable and runs in CI — is the right home (the `check_*.py`
+scripts validate generated artifacts).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import discord
+import pytest
+
+from services.world_registry import (
+    clear_world_entries,
+    get_world_entries,
+)
+from utils.subsystem_registry import SUBSYSTEMS
+from views.explore.world_hub import (
+    ExploreWorldHubView,
+    ensure_default_world_entries,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    clear_world_entries()
+    ensure_default_world_entries()
+    yield
+    clear_world_entries()
+
+
+def test_every_registered_world_key_is_a_real_subsystem():
+    """A registered world's key must resolve to a SUBSYSTEMS entry.
+
+    Otherwise the hub renders a button for a game that doesn't exist — the
+    silent dead-end this invariant exists to prevent.
+    """
+    orphans = [e.key for e in get_world_entries() if e.key not in SUBSYSTEMS]
+    assert not orphans, (
+        f"Explore world entries reference unknown subsystem key(s): {orphans}. "
+        f"Register the world under a real SUBSYSTEMS key, or add the subsystem."
+    )
+
+
+def test_every_world_entry_has_display_fields():
+    """Each entry needs a non-empty label/emoji/description for the button + embed."""
+    for entry in get_world_entries():
+        assert entry.label.strip(), f"world {entry.key!r} has a blank label"
+        assert entry.emoji.strip(), f"world {entry.key!r} has a blank emoji"
+        assert entry.description.strip(), f"world {entry.key!r} has a blank description"
+
+
+def test_hub_buttons_have_unique_custom_ids():
+    """No two world buttons may collide on custom_id (Discord rejects dupes)."""
+    author = SimpleNamespace(id=1, name="A", display_name="A")
+    view = ExploreWorldHubView(author, 123)
+    ids = [
+        c.custom_id
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and c.custom_id
+    ]
+    assert len(ids) == len(set(ids)), f"duplicate world button custom_ids: {ids}"
+
+
+def test_builtin_worlds_present():
+    """The two built-in worlds (mining · fishing) are registered by default."""
+    keys = {e.key for e in get_world_entries()}
+    assert {"mining", "fishing"} <= keys


### PR DESCRIPTION
Small follow-up to the merged federated Explore-hub spine **PR 1 (#1156)** — hardens + documents the
new world-registry seam. **Docs + a test only, no runtime code.**

## What this ships
- **`tests/unit/invariants/test_world_registry_parity.py`** (new) — a CI invariant: every registered
  Explore `WorldEntry.key` must resolve to a real `SUBSYSTEMS` entry (no silent dead-end buttons),
  each entry has non-empty label/emoji/description, the hub's button custom_ids are unique, and the
  two built-ins (mining · fishing) register by default. A pytest invariant (not a `check_*.py`
  script) because the registry is **code** — same home as `test_command_synonyms_resolve_to_real_commands`.
- **`docs/subsystems/games.md`** — a "Federated Explore world spine" section documenting the seam
  (`world_registry` · `ExploreWorldHubView` · `!world` · the invariant) and **how to add a world**,
  with the next spine slices (PR 2/PR 3) + the Q-0182 gate, so the next agent finds it cold.

## Why not the heavier lanes this run
- Plan **PR 2** (global vs per-game XP split) needs a `player_skills` `game`-discriminator **schema
  migration** on a live progression table — deferred to a runtime-verified session.
- **procedures→skills Batch 1** edits `.claude/CLAUDE.md`, which Q-0106 makes read-only in an
  autonomous session.

Self-merges on green (small/contained, Q-0113).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012duLvPVrBwsmbjRf5CNpwM

---
_Generated by [Claude Code](https://claude.ai/code/session_012duLvPVrBwsmbjRf5CNpwM)_