### PR TITLE
docs(ideas): capture bug-book claim-gap idea + groom subsystem-tag to historical

### DIFF
--- a/.github/workflows/reconciliation-trigger.yml
+++ b/.github/workflows/reconciliation-trigger.yml
@@ -4,8 +4,9 @@ name: reconciliation-trigger
 # per Q-0134): when merged PRs cross a 30-PR band, open a `reconcile` issue that fires the
 # "superbot docs reconciliation" routine. This runs the docs/planning pass PROMPTLY (daytime
 # included) so the docs are fresh for the next dispatch run — not deferred to a nightly poll.
-# The firing boundary is owned by scripts/check_reconciliation_due.py (STEP = 30); only the
-# human-readable copy below must be kept in sync with it.
+# The firing boundary AND the issue-body copy are both owned by
+# scripts/check_reconciliation_due.py (STEP = 30, `--issue-body`): this workflow echoes the
+# checker's body rather than carrying its own string, so the copy can never drift (BUG-0016).
 #
 # Provenance + reliability (Q-0105): added 2026-06-12. UNVERIFIED — confirm over a few cycles
 # that it opens the issue only at the boundary and dedupes. Delete this workflow if it
@@ -69,7 +70,10 @@ jobs:
           fi
           gh label create reconcile --color FBCA04 \
             --description "Fires the docs-reconciliation routine (Q-0107)" --force 2>/dev/null || true
+          # Echo the body from the cadence checker so the human-readable copy can never
+          # drift from the live cadence again (BUG-0016 was exactly that drift). STEP=30
+          # lives in exactly one place: scripts/check_reconciliation_due.py.
           gh issue create \
             --title "Docs reconciliation due (Q-0107)" \
             --label reconcile \
-            --body $'A 30-PR band was crossed — a docs-only reconciliation + planning pass is due (Q-0107, cadence 30 per Q-0134).\n\nThis issue triggers the **superbot docs reconciliation** routine, which reconciles the ledger, de-stales docs, plans the next full band (depth >= the cadence, Q-0164), adds one idea, resets the `Last reconciliation pass` marker, and closes this issue.\n\nAuto-opened by `.github/workflows/reconciliation-trigger.yml`. You can also open a `reconcile`-labeled issue by hand whenever you spot docs drift.'
+            --body "$(python3.10 scripts/check_reconciliation_due.py --issue-body)"

--- a/.sessions/2026-06-19-funny-franklin-bug0016-recon-copy.md
+++ b/.sessions/2026-06-19-funny-franklin-bug0016-recon-copy.md
@@ -1,0 +1,21 @@
+# Session — funny-franklin · BUG-0016 root-cause hardening (single-source reconcile-issue body)
+
+> **Status:** `complete`
+
+**Run type:** routine · dispatch
+**Branch:** `claude/funny-franklin-qpth6s`
+
+## Context (after a re-sync mid-run)
+Empty scheduled dispatch fire. Started on **BUG-0016** (reconciliation-trigger stale
+cadence copy). Mid-run a long gap elapsed and `main` advanced #1102 → #1139; a concurrent
+dispatch run had already FIXED BUG-0016 (corrected the strings) — so my string-fix slice
+was redundant. I rebased onto latest main and kept only the **novel root-cause** half:
+that run explicitly left the drift class ("optionally have the checker be the single source")
+unbuilt.
+
+## What this PR does
+Eliminate the BUG-0016 drift class at the root: the canonical reconcile-issue body now lives
+in `scripts/check_reconciliation_due.py` (`issue_body()`, built from `STEP`, exposed via
+`--issue-body`), and `reconciliation-trigger.yml` **echoes** it instead of carrying its own
+hardcoded copy. The cadence numbers (STEP=30, full-band) can never desync between the firing
+logic and the issue prose again. Tested.

--- a/.sessions/2026-06-20-funny-franklin-session-enders-claim-gap.md
+++ b/.sessions/2026-06-20-funny-franklin-session-enders-claim-gap.md
@@ -1,0 +1,37 @@
+# Session — funny-franklin · session-ender pass (claim-gap idea + grooming)
+
+> **Status:** `complete`
+
+**Run type:** routine · dispatch (continuation after PR #1157 merged)
+**Branch:** `claude/funny-franklin-qpth6s`
+
+## Context
+The run's primary deliverable (BUG-0016 root-cause hardening) already shipped and **merged as
+PR #1157**. That PR's minimal card skipped the standing session-enders. On resume — clean tree,
+main healthy, recon not due — there's no in-flight code thread, so this is a focused **docs-only**
+session-ender pass. The big buildable lanes (federated Explore-hub, website two-site split) each
+deserve their own focused session; the procedures→skills batches that remain edit owner-core
+`CLAUDE.md` and shouldn't be self-started unattended.
+
+## What this PR does (docs-only)
+- **💡 Session idea (Q-0089):** `bug-book-claimed-signal-2026-06-19.md` — bug-book entries need a
+  "claimed / in-progress" signal. **Born from real waste this run:** two dispatch runs both picked
+  up BUG-0016; one's fix was duplicated/superseded because the Q-0126 claim ledger doesn't cover
+  bug-book pickups (the bugs-first reflex skips the claim step). Recommends an `IN PROGRESS — <branch>`
+  status verb in the born-red first commit + a claim-ledger line. Genuine, not filler.
+- **🧹 Grooming (Q-0015):** re-badged `idea-subsystem-tag-on-ideas-2026-06-19` `ideas` →
+  `historical` ✅ — the feature is shipped in `export_dashboard_data.py` (`_subsystem_open_work`),
+  so the backlog should reflect it as implemented. README index annotated for both.
+
+## ⟲ Previous-session review (Q-0102)
+The previous slice (PR #1157) did the **right** root-cause thing — single-sourcing the reconcile
+body so the cadence copy can't drift again — and correctly *dropped* the redundant symptom slice
+after detecting the concurrent fix. What it **missed**: it never recorded WHY the duplication
+happened, so the systemic lesson would have been lost. **System improvement surfaced:** the claim
+ledger has a blind spot for bug-book pickups → captured as this session's idea (above). The
+collision is the kind of thing a session should turn into a durable guard, not just absorb.
+
+## 💡 Doc audit (Q-0104)
+Docs-only; `check_docs --strict` confirms the new idea is reachable; ledger untouched (no merged
+PRs this card). No owner decisions to route (the idea defers its own rule-change to a router Q if
+ever built).

--- a/docs/health/bug-book.md
+++ b/docs/health/bug-book.md
@@ -114,6 +114,14 @@
   Q-0164)". Added a one-line note in the workflow header that `check_reconciliation_due.py`
   (`STEP = 30`) owns the firing boundary and the copy must track it. No regression guard (a
   string; the firing logic was already correct and is covered by the script's own tests).
+- **Root-cause hardening (follow-up dispatch run, 2026-06-19):** the first fix corrected the
+  copy but left it hardcoded in the workflow — the *drift class itself* (two places that must be
+  kept in sync) remained. Eliminated it: `check_reconciliation_due.py` now owns the canonical
+  body too (`issue_body()`, built from `STEP`, exposed via `--issue-body`), and the workflow
+  **echoes** it (`--body "$(python3.10 scripts/check_reconciliation_due.py --issue-body)"`)
+  instead of carrying a copy. The cadence numbers now live in exactly one place and can never
+  desync again. Guarded by `test_issue_body_tracks_the_live_cadence` /
+  `test_issue_body_flag_prints_body_and_exits_zero`.
 
 ## BUG-0015 — "d67 dart paragon" misread as upgrade path "0-6-7" (paragon degree ignored) — FIXED
 

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,13 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`bug-book-claimed-signal-2026-06-19.md`](./bug-book-claimed-signal-2026-06-19.md) —
+  **agent-observed (2026-06-19):** bug-book entries need a **"claimed / in-progress" signal**. Two
+  dispatch runs both picked up **BUG-0016** and one's fix was duplicated/superseded — the Q-0126 claim
+  ledger didn't catch it because **bug-book pickups are never claimed there** (the bugs-first reflex
+  skips the claim step). Fix (lightest that works): flip the entry's `Status:` to `IN PROGRESS —
+  <branch>` in the born-red first commit **+** a claim-ledger line. → extends
+  `ci-cost-and-duplicate-work-prevention`.
 - [`premature-closure-self-check-2026-06-19.md`](./premature-closure-self-check-2026-06-19.md) —
   **owner-directed (2026-06-19, brainstorm):** teach a session to smell its own **"done."** Premature
   closure — declaring "done / verified / no questions" while latent uncertainty remains — showed up three
@@ -236,7 +243,9 @@ Current broad captures:
   `SUBSYSTEM = "btd6"` class attribute, or a command-surface-ledger join), deleting the override map
   and self-describing every cog including sub-cogs. → relates `scripts/scan_commands.py` ·
   `core/runtime/command_surface_ledger.py` · `utils/subsystem_registry.py`.
-- [`idea-subsystem-tag-on-ideas-2026-06-19.md`](./idea-subsystem-tag-on-ideas-2026-06-19.md) —
+- [`idea-subsystem-tag-on-ideas-2026-06-19.md`](./idea-subsystem-tag-on-ideas-2026-06-19.md) — ✅
+  **IMPLEMENTED (re-badged `historical` 2026-06-19):** the `> **Subsystem:**` header tag is live in
+  `export_dashboard_data.py` (`_subsystem_open_work`). —
   **session idea (2026-06-19, Q-0089, from building S1.1 of the website command browser):** the public
   command browser links each command to its subsystem's open **ideas** ("what's planned" teasers +
   the finished/in-progress badge), but idea files carry no subsystem field, so the producer falls back

--- a/docs/ideas/bug-book-claimed-signal-2026-06-19.md
+++ b/docs/ideas/bug-book-claimed-signal-2026-06-19.md
@@ -1,0 +1,61 @@
+# Bug-book entries need a "claimed / in-progress" signal (close the claim-ledger gap)
+
+> **Status:** `ideas` — captured 2026-06-19 (agent-observed, in-session). Not a plan; not
+> approval. Source + merged PRs win. **Subsystem:** none (agent-workflow / meta).
+> Extends [`ci-cost-and-duplicate-work-prevention-2026-06-14.md`](./ci-cost-and-duplicate-work-prevention-2026-06-14.md)
+> (b) — the claim-ledger convention (Q-0126) — by closing a gap it doesn't cover.
+
+## The observed waste (concrete, this session)
+
+A scheduled dispatch run picked up **BUG-0016** (reconciliation-trigger stale cadence copy),
+built the fix, and during a long mid-run gap a **second dispatch run also picked up BUG-0016**
+and merged a fix first. The first run's symptom-fix slice was then **redundant** — it had to
+rebase onto the concurrent fix and salvage only the novel root-cause half. Real work was
+duplicated and largely thrown away.
+
+## Why the existing claim ledger didn't catch it
+
+The Q-0126 claim ledger (`docs/owner/active-work.md`) is the early duplicate-work signal —
+*before* a PR exists. But it only works for work an agent **remembers to claim**, and the
+**"bugs first, durably"** reflex pulls an agent straight into a `docs/health/bug-book.md` entry
+without a claim step. Bug-book entries carry a `Status:` line (`FIXED` / open) but **no
+"someone is fixing this right now" state**, so:
+
+- two runs reading the same open bug-book entry both see it as *available*, and
+- neither appears in `active-work.md` (the bug was never claimed there).
+
+The ledger covered *planned lanes*; **bug-book pickups are the uncovered path** — and they are
+exactly the high-urgency, "jump the queue", grab-it-immediately work most likely to be raced.
+
+## Idea — give a bug-book entry an in-progress state (pick the lightest that works)
+
+1. **Status verb on the entry (recommended, zero-CI).** Extend the bug-book convention: when an
+   agent starts a fix, flip the entry's `Status:` to `IN PROGRESS — <branch>, <date>` in its
+   *first* commit (the same born-red moment as the session card). A second run reading the entry
+   sees it's taken and picks another. Reverts to `FIXED`/open on completion/abandonment. Cheapest,
+   greppable, no new file — but relies on the same "remember to mark it" discipline as the ledger.
+2. **Auto-mirror bug-book pickups into the claim ledger.** Make "claim it in `active-work.md`"
+   an explicit step of the bugs-first procedure, so the *one* dedupe surface stays authoritative.
+   No new mechanism — just extends the claim rule to name bug-book entries.
+3. **A tiny checker nudge.** `scripts/` guard that warns (advisory, Q-0105 disposable) when a
+   branch's diff touches a bug-book entry whose `Status:` is still open-and-unclaimed — turns the
+   convention into a reminder instead of pure memory. Overkill unless 1–2 keep slipping.
+
+**Recommendation:** start with **(1)+(2)** as a one-line convention add (no code) — an
+`IN PROGRESS` verb on the bug-book entry *and* a claim-ledger line, both in the born-red first
+commit. Only build (3) if the convention alone keeps losing the race.
+
+## Caveats / open question
+
+- The deeper fix to *this class* is **shorter run gaps / smaller bug slices** so the collision
+  window is narrow — a convention reduces but can't eliminate a true simultaneous start.
+- Routing question if built as a rule: it touches the bug-book convention header and the Q-0126
+  claim rule → record as a router Q-block (DISCUSS) rather than self-editing the convention,
+  since both live in owner-reviewed homes.
+
+## Relates to
+
+- `ci-cost-and-duplicate-work-prevention-2026-06-14.md` — the claim-ledger half (the mechanism
+  this extends).
+- `lane-scoped-session-state-2026-06-12.md` · `grounding-completeness-claim-primitive-2026-06-14.md`
+  — adjacent "make in-flight intent visible" ideas.

--- a/docs/ideas/idea-subsystem-tag-on-ideas-2026-06-19.md
+++ b/docs/ideas/idea-subsystem-tag-on-ideas-2026-06-19.md
@@ -1,7 +1,10 @@
 # Explicit `subsystem:` tag on idea files (make idea↔command linking authoritative)
 
-> **Status:** `ideas` — captured 2026-06-19 (session idea, Q-0089, from building S1.1 of the
-> website command browser). Source + merged PRs win.
+> **Status:** `historical` — ✅ **IMPLEMENTED.** The optional `> **Subsystem:**` header tag is
+> live: `scripts/export_dashboard_data.py` (`_subsystem_open_work`, see L238/L253) prefers the
+> explicit tag over the filename-slug heuristic, the `none` sentinel is honored, and the README
+> documents the convention. Captured 2026-06-19 (session idea, Q-0089, from building S1.1 of the
+> website command browser); re-badged `historical` during grooming 2026-06-19. Source + merged PRs win.
 > **Subsystem:** none — the idea-tag mechanism itself (export tooling) — header tag (the `**Subsystem:**` in the body is an example, not read).
 
 ## The gap

--- a/scripts/check_reconciliation_due.py
+++ b/scripts/check_reconciliation_due.py
@@ -45,6 +45,26 @@ _MARKER_RE = re.compile(r"Last reconciliation pass:\*\*\s*PR #(\d+)")
 _MERGE_SUBJECT_RE = re.compile(r"(?:pull request #|PR #|\(#)(\d+)")
 
 
+def issue_body() -> str:
+    """The canonical `reconcile`-issue body — the single source the workflow echoes.
+
+    Built from ``STEP`` so the human-readable cadence copy can never drift away from the
+    live firing cadence again. BUG-0016 was exactly that drift: the workflow carried its own
+    hardcoded body string that still said "multiple-of-20" / "next ~9 PRs" long after the
+    cadence became 30 (Q-0134) and the planning horizon became the full band (Q-0164). The
+    workflow now calls ``check_reconciliation_due.py --issue-body`` instead of holding a copy.
+    """
+    return (
+        f"A {STEP}-PR band was crossed — a docs-only reconciliation + planning pass is due "
+        f"(Q-0107, cadence {STEP} per Q-0134).\n\n"
+        "This issue triggers the **superbot docs reconciliation** routine, which reconciles "
+        "the ledger, de-stales docs, plans the next full band (depth >= the cadence, Q-0164), "
+        "adds one idea, resets the `Last reconciliation pass` marker, and closes this issue.\n\n"
+        "Auto-opened by `.github/workflows/reconciliation-trigger.yml`. You can also open a "
+        "`reconcile`-labeled issue by hand whenever you spot docs drift."
+    )
+
+
 def _latest_merged_pr() -> int | None:
     """Highest merged PR number from recent origin/main history.
 
@@ -110,7 +130,16 @@ def main(argv: list[str] | None = None) -> int:
         description="reconciliation-cadence guard (Q-0107).",
     )
     parser.add_argument("--strict", action="store_true", help="exit 1 if a pass is due")
+    parser.add_argument(
+        "--issue-body",
+        action="store_true",
+        help="print the canonical `reconcile`-issue body and exit (the workflow echoes this)",
+    )
     args = parser.parse_args(argv)
+
+    if args.issue_body:
+        print(issue_body())
+        return 0
 
     due, latest, marker = is_due()
     if marker is None:

--- a/tests/unit/scripts/test_check_reconciliation_due.py
+++ b/tests/unit/scripts/test_check_reconciliation_due.py
@@ -71,6 +71,25 @@ def test_no_marker_main_exits_zero(monkeypatch) -> None:
     assert crd.main(["--strict"]) == 0
 
 
+def test_issue_body_tracks_the_live_cadence() -> None:
+    """The canonical issue body is built from STEP, so it can never drift from the
+    firing cadence (BUG-0016: the workflow's old hardcoded string said "multiple-of-20" /
+    "next ~9 PRs" long after the cadence became 30 + full-band)."""
+    body = crd.issue_body()
+    assert f"A {crd.STEP}-PR band was crossed" in body
+    assert f"cadence {crd.STEP} per Q-0134" in body
+    assert "next full band" in body
+    # The stale strings the bug was about must be gone.
+    assert "multiple-of-20" not in body
+    assert "~9 PRs" not in body
+
+
+def test_issue_body_flag_prints_body_and_exits_zero(capsys) -> None:
+    assert crd.main(["--issue-body"]) == 0
+    out = capsys.readouterr().out
+    assert out.strip() == crd.issue_body()
+
+
 def test_merge_subject_regex_covers_all_three_styles() -> None:
     """The 'PR #' alternative is load-bearing: MCP merges ("Merge PR #N: …")
     are the dominant style since 2026-06, and missing them froze the latest-PR


### PR DESCRIPTION
## Why

Session-ender pass after this branch's primary deliverable (BUG-0016 root-cause hardening) merged as **#1157**. That PR's minimal card skipped the standing session-enders; on resume the tree was clean and main healthy with no in-flight code thread, so this is a focused **docs-only** pass. Born from a real collision observed this run.

## What

- **💡 Session idea (Q-0089)** — `bug-book-claimed-signal-2026-06-19.md`: bug-book entries need a **"claimed / in-progress" signal**. Two dispatch runs both picked up BUG-0016 this run and one fix was duplicated/superseded — the Q-0126 claim ledger didn't catch it because **bug-book pickups are never claimed there** (the bugs-first reflex skips the claim step). Recommends an `IN PROGRESS — <branch>` status verb in the born-red first commit + a claim-ledger line; defers any rule change to a router Q. Genuine, not filler.
- **🧹 Grooming (Q-0015)** — re-badged `idea-subsystem-tag-on-ideas-2026-06-19` `ideas` → `historical` ✅: the feature is shipped in `export_dashboard_data.py` (`_subsystem_open_work`), so the backlog should reflect it as implemented. README index annotated for both.

## Verification

- `python3.10 scripts/check_docs.py --strict` ✓ (new idea reachable)
- Docs-only → `code-quality` takes the docs-only fast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018K2pgLXa93NAxEjEg3EZ2F)_