### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-20T04:39:42Z",
+    "generated_at": "2026-06-20T09:37:07Z",
     "build": {
-      "commit": "9a388d52",
-      "subject": "Merge pull request #1160 from menno420/claude/funny-franklin-dapcss",
-      "committed_at": "2026-06-20T05:27:38Z",
+      "commit": "003bdf8e",
+      "subject": "Merge pull request #1163 from menno420/claude/funny-franklin-ea3xrw",
+      "committed_at": "2026-06-20T11:26:48Z",
       "branch": "main"
     },
     "counts": {
@@ -2019,6 +2019,22 @@
       "self_initiated": false
     },
     {
+      "file": "2026-06-20-claude-md-pointer-pinning.md",
+      "date": "2026-06-20",
+      "title": "2026-06-20 — Pin the always-loaded instruction core against pointer rot",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-06-20-arch-ratchet-cog-layer.md",
+      "date": "2026-06-20",
+      "title": "2026-06-20 — Extend the `baseview_inheritance` arch ratchet to the cog layer",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": false
+    },
+    {
       "file": "2026-06-19-website-two-site-split-plan.md",
       "date": "2026-06-19",
       "title": "2026-06-19 — Website two-site split: the implementation plan (Q-0178)",
@@ -2446,22 +2462,6 @@
       "file": "2026-06-19-consistency-linter-cog-scope.md",
       "date": "2026-06-19",
       "title": "2026-06-19 — Consistency linter: extend rules 3+4 to the cog layer",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-19-consistency-graduation-tracker.md",
-      "date": "2026-06-19",
-      "title": "2026-06-19 — Consistency-linter graduation tracker",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-06-19-consistency-edit-in-place-triage.md",
-      "date": "2026-06-19",
-      "title": "2026-06-19 — Consistency-linter: triage the `edit_in_place` backlog (rule 1)",
       "status": "complete",
       "run_type": "routine",
       "self_initiated": false


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.