### PR TITLE
ai: introduce itself with its real capabilities + available games

### DIFF
--- a/.sessions/2026-06-20-ai-intro-capabilities.md
+++ b/.sessions/2026-06-20-ai-intro-capabilities.md
@@ -1,16 +1,116 @@
 # 2026-06-20 — AI self-introduction: advertise capabilities + available games
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-## What I'm about to do
-Owner asked (via Discord screenshot): when the bot is asked to *introduce itself*
-(or similar), it should briefly explain its capabilities **and** the general things
-the bot can do itself — e.g. which games are available. Today "@SuperBot introduce
-yourself" produces a generic blurb (server management + BTD6) because the message
-matches no command-catalog trigger, so only the static persona reaches the model and
-games/economy/progression are never mentioned.
+## Arc
+Owner asked (via Discord screenshot): when the bot is asked to *introduce itself* (or
+similar), it should briefly explain its capabilities **and** the general things the bot
+can do itself — e.g. which games are available. The screenshotted reply was a generic
+"server management + BTD6 support" blurb that never mentioned games, economy, or
+progression.
 
-Plan: give the model a curated, always-present capability overview + intro guidance in
-the AI instruction stack, and let intro-style phrasing inject the live command catalog.
+**Root cause:** `@SuperBot introduce yourself` routes to `general.nl_answer` and matches
+no command-catalog trigger in `bot_knowledge_service`, so the only thing reaching the
+model is the static persona (`_BOT_AI_POLICY` / `_TASK_CONTRACT`) — which frames scope as
+BTD6 + server management only. Nothing told the model the bot runs games, an economy, or
+progression, so it couldn't mention them.
 
-(Born-red card per Q-0133 — flipped to `complete` as the final step.)
+## Shipped
+- **`disbot/services/ai_instruction_service.py`** — new always-assembled system layer
+  `_CAPABILITIES_OVERVIEW` (joins `_SYSTEM_SAFETY` / `_BOT_AI_POLICY` / `_TASK_CONTRACT`).
+  It tells the model how to introduce itself (brief, grouped, invite follow-up, ground
+  command names in the `bot_command_catalog` span when present, don't invent) and lists
+  the **real** feature areas: general assistant + BTD6 expertise; the available **games**
+  (Blackjack, Rock Paper Scissors incl. tournaments, Deathmatch, Counting, Chain, the
+  Mining adventure, Fishing); economy + progression (coins, daily/work, XP, levels,
+  leaderboards, profiles); server management. Explicitly steers the BTD6 mention to
+  *general terms* (no ungrounded tower/hero/paragon names or numbers) so the intro is not
+  floored by the faithfulness guard.
+- **`disbot/services/bot_knowledge_service.py`** — added introduction phrasings
+  (`introduce`, `who are you`, `what are you`, `what do you do`, `what do you offer`,
+  `tell me about yourself`) to `_CATALOG_SUBSTRING_TRIGGERS` so an introduction also
+  injects the live command catalog (an intro *is* a capability question).
+- **Tests:** `tests/unit/services/test_ai_instruction_capabilities.py` (pins the overview
+  content, games list, BTD6-grounding-safety wording, and its presence in every assembled
+  system prompt) + intro phrasings added to `test_bot_knowledge_service`'s trigger matches.
+- **Docs:** `docs/subsystems/ai.md` "Current state" note — where the bot's self-description
+  lives (the static overview layer, *not* a DB instruction profile).
+
+## Findings / verification
+- `python3.10 scripts/check_quality.py --full` → **10956 passed, 44 skipped**, lint + mypy
+  clean. `check_architecture.py --mode strict` → exit 0 (only pre-existing `[known]`
+  warns). `check_docs.py --strict` → green. Doc-pinning tests green.
+- Faithfulness-guard trace: an intro says "Bloons TD 6" → `general_path_should_verify`
+  fires → `validate_btd6_reply` runs over the reply. None of the game names (Blackjack,
+  Mining, Chain, …) are BTD6 *entity* proper names in the grounding name index, so a
+  general-terms intro has zero offending names → passes. The new "keep BTD6 general"
+  instruction is what keeps it that way if the model is tempted to name an entity.
+
+## Context delta
+- **Needed but not pointed to:** the *introduction* text is model-generated from the
+  instruction stack — there is no canned intro string. Tracing it meant reading
+  `ai_instruction_service.assemble` → `bot_knowledge_service.gather` (trigger gating) →
+  `natural_language_stage` (assembly order) → `btd6_grounding_service` (why a BTD6-themed
+  general reply can be floored). The AI folio now records where the self-description lives.
+- **Pointed to but didn't need:** `ai_introspection_service` / `ai_tool_catalogue` — they
+  model AI *lookup tools*, not the bot's games/commands, so they aren't the right home for
+  a capability overview (and `get_ai_tool_catalog` isn't offered when AI tools are off).
+- **Discovered by hand:** the interaction between a capability overview that mentions BTD6
+  and the general-path faithfulness floor — naming a specific BTD6 entity in an
+  ungrounded intro would floor the whole reply. The fix is prompt discipline, captured in
+  both the constant and a pinning test.
+- **Decisions made alone:** (1) curated overview in the *static* system layer rather than
+  a new DB-owned block or a generated feature manifest — the games list is low-drift and
+  this is the same pattern `_BOT_AI_POLICY` already uses for scope; (2) games named at the
+  category level (no exact command syntax) to avoid drift + the "don't invent commands"
+  trap, with `!help`/the catalog for specifics.
+- **Flagged for maintainer / known limits:** the games list in `_CAPABILITIES_OVERVIEW` is
+  hand-curated — if a *new* game ships, add a word to that constant (the pinning test lists
+  the current set). Not runtime-verified against a live provider this session (offline +
+  unit only); the prompt-discipline guard against name-dropping a BTD6 entity in an intro
+  is best-effort (retry-then-floor remains the backstop).
+
+## 💡 Session idea (Q-0089)
+A tiny **stdlib guard that pins `_CAPABILITIES_OVERVIEW`'s game list to the real game
+cogs** — e.g. assert each named game has a corresponding loaded cog / `parent_hub="games"`
+subsystem entry, so the curated intro can't silently claim a game that was removed (or
+omit one that's the whole point of the ask). Captured as a candidate; not built this run
+(the current list is correct and the test pins it), but it would make the overview
+self-auditing the way the catalogue/ledger guards already are.
+
+## ⟲ Previous-session review (Q-0102)
+Reviewed the website two-site-split **ultracode review-refactor** session
+(`2026-06-19-website-split-review-refactor.md`). **Did well:** it declared file-disjoint
+refactor units up front in the born-red card and found a genuine *cross-app* CI bug
+(bare-name `sys.modules` collision between `botsite/` and `dashboard/`) that only surfaces
+when both apps load in one test process — exactly the kind of latent defect a careful
+read-every-line pass should catch. **Could improve / system note:** that bare-sibling-
+import pattern (deploy with Root Directory = the app folder, import siblings by bare name
++ a `sys.path` shim) is a recurring footgun across the two web apps; it deserves a one-line
+entry in the journal's "recurring problems" so the *next* web-app author designs around it
+instead of rediscovering it via a flaky cross-suite failure. The improvement I initiated
+this session is the smaller analogue: documenting in the folio *where* a behaviour lives so
+the next agent doesn't have to re-trace the stack.
+
+## 📤 Run report
+- **Did:** make the bot's self-introduction advertise its real capabilities + available
+  games · **Outcome:** shipped
+- **Shipped:** PR (this session) — `_CAPABILITIES_OVERVIEW` instruction layer + intro
+  catalog triggers + tests + AI-folio note
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none (merge auto-deploys to Railway; the new behaviour is live
+  on the next mention after deploy)
+- **⚑ Self-initiated:** none (direct owner request)
+- **↪ Next:** unchanged — the current-state ▶ Next ungated startable (consistency-linter
+  AI-nav PR 1 / procedures→skills Batch 2 / a fresh `docs/ideas/` promotion)
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 0 (PR opened; auto-merge on green) |
+| CI-red rounds | 0 (green on first full local mirror) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (Q-0089 — game-list/cog parity guard) |
+| Ideas groomed | 0 |

--- a/.sessions/2026-06-20-ai-intro-capabilities.md
+++ b/.sessions/2026-06-20-ai-intro-capabilities.md
@@ -1,0 +1,16 @@
+# 2026-06-20 — AI self-introduction: advertise capabilities + available games
+
+> **Status:** `in-progress`
+
+## What I'm about to do
+Owner asked (via Discord screenshot): when the bot is asked to *introduce itself*
+(or similar), it should briefly explain its capabilities **and** the general things
+the bot can do itself — e.g. which games are available. Today "@SuperBot introduce
+yourself" produces a generic blurb (server management + BTD6) because the message
+matches no command-catalog trigger, so only the static persona reaches the model and
+games/economy/progression are never mentioned.
+
+Plan: give the model a curated, always-present capability overview + intro guidance in
+the AI instruction stack, and let intro-style phrasing inject the live command catalog.
+
+(Born-red card per Q-0133 — flipped to `complete` as the final step.)

--- a/disbot/services/ai_instruction_service.py
+++ b/disbot/services/ai_instruction_service.py
@@ -62,6 +62,42 @@ _BOT_AI_POLICY = (
     " large language model, but your name and identity are SuperBot."
 )
 
+_CAPABILITIES_OVERVIEW = (
+    "Introducing yourself / describing what you can do:\n"
+    "When a user asks you to introduce yourself, greets you, or asks who or"
+    " what you are, what you can do, what you offer, how to get started, or"
+    " what this bot does, give a brief, friendly overview of the main things"
+    " you offer — grouped into a few short lines covering the areas below — and"
+    " invite them to ask for more about any area. Keep it concise: highlight"
+    " representative features rather than dumping a full command list, and"
+    " point to '!help' (or offer to list a category's commands) for the exact"
+    " commands. When a 'bot_command_catalog' span is present, ground specific"
+    " command names in it, and never invent commands or features that are not"
+    " real.\n"
+    "The main things you can do on this server:\n"
+    "- Answer questions and chat: you are a general-purpose assistant (general"
+    " knowledge, explanations, writing and brainstorming, math, coding help,"
+    " everyday conversation) and you have deep Bloons TD 6 (BTD6) expertise"
+    " backed by verified game data (tower / hero / paragon / boss stats and"
+    " costs, per-round cash, strategy, and more).\n"
+    "- Games and fun: the server has several playable games — Blackjack, Rock"
+    " Paper Scissors (including tournaments), Deathmatch duels, the Counting"
+    " and Chain channel games, and an open-world Mining adventure (dig and"
+    " descend through biomes, craft and equip gear, a skill tree, and titles),"
+    " plus Fishing.\n"
+    "- Economy and progression: an in-server coin economy with daily and work"
+    " rewards, plus XP, levels, leaderboards, and player profiles.\n"
+    "- Server management and configuration: you help admins set up, configure,"
+    " and run the bot and the server (settings, roles, channels, moderation,"
+    " logging, and more).\n"
+    "When you mention your BTD6 knowledge in an overview, describe it in"
+    " general terms — do NOT name specific towers, heroes, or paragons, or"
+    " quote specific numbers, unless you have grounded data for them; offer to"
+    " look up specifics instead. Only mention a game or feature that genuinely"
+    " exists; if you are unsure whether a specific command exists, say how to"
+    " find it ('!help' or just ask) rather than guessing its name."
+)
+
 _TASK_CONTRACT = (
     "Task contract for THIS request:\n"
     "- The 'current_user_message' span at the END of the payload is the"
@@ -495,7 +531,12 @@ async def assemble(
     ``user_B`` / ... — opaque pseudonyms that keep raw Discord
     snowflakes out of the model-visible prompt.
     """
-    system: list[str] = [_SYSTEM_SAFETY, _BOT_AI_POLICY, _TASK_CONTRACT]
+    system: list[str] = [
+        _SYSTEM_SAFETY,
+        _BOT_AI_POLICY,
+        _CAPABILITIES_OVERVIEW,
+        _TASK_CONTRACT,
+    ]
 
     # Load each referenced profile body and wrap as data.
     seen: set[int] = set()

--- a/disbot/services/bot_knowledge_service.py
+++ b/disbot/services/bot_knowledge_service.py
@@ -63,6 +63,10 @@ _MAX_CATALOG_ENTRIES = 40
 _MAX_CATALOG_CHARS = 4000
 
 # Substring triggers — case-insensitive contains-match against lowercased text.
+# Includes introduction / "who are you" / "what do you do" phrasings: an
+# introduction IS a capability question, so the command catalog should reach
+# the model (alongside the always-present capability overview in
+# ai_instruction_service) when a user asks the bot to introduce itself.
 _CATALOG_SUBSTRING_TRIGGERS: tuple[str, ...] = (
     "what does",
     "what is the",
@@ -73,6 +77,12 @@ _CATALOG_SUBSTRING_TRIGGERS: tuple[str, ...] = (
     "how do i",
     "how to use",
     "can you do",
+    "introduce",
+    "who are you",
+    "what are you",
+    "what do you do",
+    "what do you offer",
+    "tell me about yourself",
 )
 
 # Prefix/slash triggers — must look command-shaped, NOT inside URLs/paths/dates/fractions.

--- a/docs/subsystems/ai.md
+++ b/docs/subsystems/ai.md
@@ -1,7 +1,7 @@
 # AI subsystem — folio
 
 > **Status:** `living-ledger` (area index). Source + `docs/current-state.md` win.
-> **Last updated:** 2026-06-19 (added the ai-panel-inplace-navigation plan pointer).
+> **Last updated:** 2026-06-20 (noted the self-introduction capability overview layer).
 
 ## What & where
 
@@ -52,6 +52,17 @@ scoped tools (including owner-gated diagnostics). Source:
   `docs/health/bug-book.md` (BUG-0005…0010, first Q-0086 session).
 - **Shipped:** owner-gated `diagnostics_health_snapshot` tool (#541). Setup-advisor
   integration shape: `docs/ai/ai-service-integration-map.md`.
+- **Self-introduction / capability overview (2026-06-20):** the static system layer
+  `ai_instruction_service._CAPABILITIES_OVERVIEW` (always assembled, alongside
+  `_SYSTEM_SAFETY` / `_BOT_AI_POLICY` / `_TASK_CONTRACT`) is what teaches the model to
+  introduce itself with its real feature areas — general assistant + BTD6 expertise,
+  the available **games** (Blackjack / RPS / Deathmatch / Counting / Chain / Mining /
+  Fishing), economy + progression, and server management. Introduction phrasings
+  ("introduce yourself", "who are you", "what do you do") also trip the
+  `bot_knowledge_service` command-catalog trigger so the live command list reaches the
+  model. The overview keeps BTD6 mentions general (no ungrounded entity names) so a
+  friendly intro is not floored by the faithfulness guard. This is the place to edit the
+  bot's self-description — *not* a DB instruction profile (those are guild overrides).
 - **Gate:** AI feature expansion is gated on *all* of bot-wide stability + provider/
   provenance + caching/source-health clarity + AI behavior/config correctness — see
   `docs/current-state.md` "Gates / blocked work".

--- a/tests/unit/services/test_ai_instruction_capabilities.py
+++ b/tests/unit/services/test_ai_instruction_capabilities.py
@@ -1,0 +1,80 @@
+"""SuperBot must advertise its own capabilities (and games) when introducing itself.
+
+Live behaviour (owner screenshot, 2026-06-20): asked "@SuperBot introduce
+yourself", the bot produced a generic "server management + BTD6 support" blurb
+and never mentioned the games it runs, the economy, or progression. The static
+persona only framed scope around BTD6 + server management, and an introduction
+matched no command-catalog trigger, so nothing taught the model the breadth of
+what the bot actually offers.
+
+The instruction stack now carries an always-present capability overview that
+tells the model how to introduce itself and lists the real feature areas —
+including the available games. These tests pin that overview (and its presence
+in every assembled system prompt) so the regression can't silently return.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services import ai_instruction_service as instr
+
+
+def test_capabilities_overview_describes_how_to_introduce_itself():
+    overview = instr._CAPABILITIES_OVERVIEW
+    lowered = overview.lower()
+    # The clause must fire on introduction / overview phrasings.
+    assert "introduce yourself" in lowered
+    assert "what you can do" in lowered
+    # And steer toward a brief, grouped overview rather than a command dump.
+    assert "concise" in lowered
+    assert "!help" in overview
+
+
+def test_capabilities_overview_lists_the_available_games():
+    """The owner asked specifically for "which games are available" — the
+    overview must name the real games the bot runs."""
+    overview = instr._CAPABILITIES_OVERVIEW
+    for game in ("Blackjack", "Rock Paper Scissors", "Deathmatch", "Mining", "Fishing"):
+        assert game in overview, game
+
+
+def test_capabilities_overview_covers_the_main_feature_areas():
+    overview = instr._CAPABILITIES_OVERVIEW
+    lowered = overview.lower()
+    # General assistant + BTD6 expertise.
+    assert "general-purpose assistant" in lowered
+    assert "bloons td 6" in lowered
+    # Economy / progression.
+    assert "coin economy" in lowered
+    assert "leaderboards" in lowered
+    # Server management.
+    assert "server management" in lowered
+
+
+def test_capabilities_overview_keeps_btd6_overview_grounding_safe():
+    """An introduction is a GENERAL_NL_ANSWER turn, and naming "Bloons TD 6"
+    makes the BTD6 faithfulness guard run over the reply. The overview must
+    tell the model to keep its BTD6 mention general (no ungrounded tower / hero
+    / paragon names or numbers) so a friendly intro is never floored to the
+    no-data refusal."""
+    overview = instr._CAPABILITIES_OVERVIEW
+    lowered = overview.lower()
+    assert "do not name specific towers, heroes, or paragons" in lowered
+    assert "never invent commands or features" in lowered
+
+
+@pytest.mark.asyncio
+async def test_assembled_system_prompt_carries_capabilities_overview():
+    """Every turn's system prompt (built by assemble) carries the overview —
+    assemble always includes it in the system layer, with no DB or guild
+    profile required."""
+    stack = await instr.assemble(
+        guild_id=1,
+        user_message="introduce yourself",
+        profile_ids=(),
+    )
+    sys_prompt = stack.render_system_prompt()
+    assert "The main things you can do on this server" in sys_prompt
+    assert "Blackjack" in sys_prompt
+    assert "general-purpose assistant" in sys_prompt

--- a/tests/unit/services/test_bot_knowledge_service.py
+++ b/tests/unit/services/test_bot_knowledge_service.py
@@ -105,6 +105,15 @@ def _install_catalog(monkeypatch, entries: tuple[CommandDescription, ...]) -> No
         "foo !btd6 ask",
         "/btd6 ask",
         "can I use /btd6 ask",
+        # Introduction / overview phrasings — an intro IS a capability question,
+        # so the command catalog should reach the model (owner ask 2026-06-20).
+        "introduce yourself",
+        "can you introduce yourself",
+        "who are you",
+        "what are you",
+        "what do you do",
+        "what do you offer",
+        "tell me about yourself",
     ],
 )
 def test_looks_like_command_question_matches(text: str) -> None:


### PR DESCRIPTION
## Why

Owner ask (Discord screenshot): when the bot is asked to *introduce itself* (or "who/what are you", "what do you do"), it should briefly explain its capabilities **and** the general things the bot can do itself — e.g. which games are available. The current reply is a generic "server management + BTD6 support" blurb that never mentions the games it runs, the economy, or progression.

**Root cause:** `@SuperBot introduce yourself` routes to `general.nl_answer` and matches no command-catalog trigger in `bot_knowledge_service`, so the only thing reaching the model is the static persona (`_BOT_AI_POLICY` / `_TASK_CONTRACT`), which frames the bot's scope as BTD6 + server management only. Nothing told the model the bot also runs games, an economy, and progression.

## What changed

- **`disbot/services/ai_instruction_service.py`** — new always-assembled system layer `_CAPABILITIES_OVERVIEW` (joins `_SYSTEM_SAFETY` / `_BOT_AI_POLICY` / `_TASK_CONTRACT`). It tells the model how to introduce itself — brief, grouped, invite a follow-up, ground command names in the `bot_command_catalog` span when present, never invent commands — and lists the **real** feature areas:
  - Answer questions & chat (general-purpose assistant + deep BTD6 expertise)
  - **Games & fun:** Blackjack, Rock Paper Scissors (incl. tournaments), Deathmatch, the Counting and Chain channel games, the open-world Mining adventure, and Fishing
  - Economy & progression (coins, daily/work, XP, levels, leaderboards, profiles)
  - Server management & configuration
  It explicitly steers the BTD6 mention to *general terms* (no ungrounded tower/hero/paragon names or numbers) so a friendly intro is never floored by the BTD6 faithfulness guard.
- **`disbot/services/bot_knowledge_service.py`** — introduction phrasings (`introduce`, `who are you`, `what are you`, `what do you do`, `what do you offer`, `tell me about yourself`) now trip the command-catalog trigger, so an introduction also injects the live command list (an intro *is* a capability question).
- **Tests** — `tests/unit/services/test_ai_instruction_capabilities.py` pins the overview content, the games list, the grounding-safety wording, and its presence in every assembled system prompt; the new triggers are added to `test_bot_knowledge_service`'s trigger matches.
- **Docs** — `docs/subsystems/ai.md` "Current state" note on where the bot's self-description lives (the static overview layer, *not* a DB instruction profile).

## Verification

- `python3.10 scripts/check_quality.py --full` → **10956 passed, 44 skipped**, lint + mypy clean
- `python3.10 scripts/check_architecture.py --mode strict` → exit 0 (only pre-existing `[known]` warns)
- `python3.10 scripts/check_docs.py --strict` → green; doc-pinning tests green

## Notes / limits

- The games list in `_CAPABILITIES_OVERVIEW` is hand-curated (low-drift, named at the category level to avoid the "don't invent commands" trap). If a new game ships, add a word to that constant — the pinning test lists the current set. Filed a follow-up idea (Q-0089) for a small guard that pins the list to the real game cogs.
- Offline + unit verification only this run (no live-provider walk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Scctb4vHnyrQwHP68cXyPx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Scctb4vHnyrQwHP68cXyPx)_