### PR TITLE
design-system: full landing-page composition + hybrid Claude Design edit loop

### DIFF
--- a/.github/workflows/design-system-ci.yml
+++ b/.github/workflows/design-system-ci.yml
@@ -1,0 +1,56 @@
+name: Design System CI
+
+# Builds + type-checks the React/Tailwind design-system (the source of truth
+# /design-sync uploads to Claude Design). Sibling of botsite-ci.yml / dashboard-ci.yml
+# for the JS tier: the main code-quality.yml installs only Python tooling and never
+# touches design-system/, so without this leg a broken component or type error would
+# land silently. Provenance: 2026-06-20 (Path 1 — full landing-page composition); closes
+# the "new JS toolchain with no CI" gap flagged by the #1168 session.
+#
+# Uses the runner's preinstalled Node (ubuntu-latest ships an LTS Node), so the only
+# third-party action is the SHA-pinned actions/checkout — no unpinned setup-node. If a
+# Node-version pin is ever needed, add actions/setup-node (pinned by SHA) then.
+#
+# `paths`-filtered so it only runs when design-system code changes (cheap). It is NOT a
+# required merge check (making it one is an owner repo-Settings step).
+#
+# UNVERIFIED (Q-0105, 2026-06-20): confirm it goes green a few times before trusting it;
+# delete this workflow if it proves flaky/unreliable over multiple sessions.
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "design-system/**"
+      - ".github/workflows/design-system-ci.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "design-system/**"
+      - ".github/workflows/design-system-ci.yml"
+
+concurrency:
+  group: design-system-ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  design-system:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: design-system
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Node version
+        run: node --version
+
+      - name: Install dependencies (npm ci)
+        run: npm ci
+
+      - name: Type-check (tsc --noEmit)
+        run: npm run typecheck
+
+      - name: Build (tsup + tailwind)
+        run: npm run build

--- a/.sessions/2026-06-20-design-system-landing-page.md
+++ b/.sessions/2026-06-20-design-system-landing-page.md
@@ -1,34 +1,145 @@
 # 2026-06-20 — Design-system: full landing-page composition + hybrid edit loop
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-## Arc (what this session is about)
+## Arc
 
 Owner is trying out **Claude Design** and kept hitting *"Can't save this edit — element
-isn't from project source"* when editing the hero. Root cause: only the 6 atomic components
-from `design-system/` (#1168) are source-backed; the hero / nav / section layout are
+isn't from project source"* when editing the hero. Root cause: after #1168 only the 6 atomic
+components from `design-system/` are source-backed; the hero / nav / section layout are
 generated canvas content with **nowhere in source to save to**. Owner chose **Path 1** —
 expand the design-system so the **whole landing page** is real, source-backed components, and
-tighten the **hybrid Claude Code + Claude Design workflow** (me as porter/reviewer; preview
-without merge+redeploy each iteration).
+tighten the **hybrid Claude Code + Claude Design workflow** (Claude Code as porter/reviewer;
+preview without merge+redeploy each iteration).
 
 Owner directive this session: *"anything documented in the repo is based on the situation when
 we documented it — good guidelines, not 100% strict rules. Do what's best for the vision:
-correctness over temporary fixes, stability first."* So I'm free to extend `design-system/`
-beyond the literal ask where it makes the loop genuinely usable.
+correctness over temporary fixes, stability first."*
 
-## Plan (this PR)
+## What shipped (this PR — #1175)
 
-- New layout/page components mirroring `botsite/` (`base.html` + `index.html`), faithful
-  palette (slate/indigo/sky/emerald/amber): `PageShell`, `SiteHeader`, `SiteFooter`, `Hero`,
-  `Section`, `StepCard`, `CapabilityBand`, `ButtonLink`, and a full `LandingPage` composition.
-- A Storybook story per new component + the full-page `LandingPage` story (the `/design-sync`
-  preview source) — so Claude Design composes/edit the *whole page* as real components.
-- Expand `design-system/README.md`: components table + the **hybrid / preview-without-redeploy**
-  loop (Claude Design canvas ⇄ Claude Code porter ⇄ local preview).
-- Add `design-system-ci.yml` (the JS CI leg the predecessor flagged) — checkout + `npm ci` +
-  `typecheck` + `build`, path-scoped to `design-system/**`, runner-preinstalled Node (only the
-  already-pinned `actions/checkout` SHA, no unverified `setup-node` pin).
-- Verify: `npm ci` / `npm run typecheck` / `npm run build` green in-container.
+New `design-system/src/` components, all faithful to `botsite/` (same Tailwind palette):
 
-_Shipped / verification / enders filled in as the deliberate final step, then Status → complete._
+- **Layout / chrome (mirror `base.html`):** `PageShell` (dark canvas + centered `<main>`),
+  `SiteHeader` (sticky nav · logo · links · status dot · Add-to-Discord), `SiteFooter`
+  (generated/as-of-last-deploy badge + source link).
+- **Sections (mirror `index.html`):** `Hero`, `CapabilityBand` (3 × `StatTile`), `Section`
+  (title + action link, or centered), `StepCard` (how-it-works).
+- **`ButtonLink`** — an anchor styled as a button (how the live site actually renders CTAs);
+  `Button` refactored to share its style via an exported `buttonClasses` (output identical).
+- **`LandingPage`** — the whole `index.html` composed from the parts, with sample-data
+  defaults so it renders standalone. **The canonical surface Claude Design edits**, mapping
+  1:1 onto the live page → every region now has somewhere in source to save to.
+- A **Storybook story per new component** + a full-page `Pages/LandingPage` story (the
+  `/design-sync` preview source).
+- **`design-system/README.md`**: regrouped components table + a new "hybrid loop" section
+  (Claude Design canvas ⇄ Claude Code porter/reviewer) and **preview-without-redeploy**
+  guidance (Storybook for the design layer; `uvicorn` for the real Jinja site).
+- **`.github/workflows/design-system-ci.yml`** — the JS CI leg the #1168 session flagged:
+  `npm ci` + `typecheck` + `build`, path-scoped to `design-system/**`, twin of
+  `botsite-ci` / `dashboard-ci`. Uses the runner's preinstalled Node (only the SHA-pinned
+  `actions/checkout`, no unpinned `setup-node`). Non-required check.
+
+**Production stays Jinja.** This library feeds Claude Design; canvas output is ported back
+into `botsite/` by Claude Code. Additive + isolated — nothing imports `design-system/`,
+Python CI untouched.
+
+## Verification (in-container)
+
+- `npm run typecheck` (`tsc --noEmit`) → **clean**.
+- `npm run build` (tsup + tailwind) → **exit 0**; `dist/index.js` 3.5 KB → **13.5 KB**
+  (new components), `dist/index.d.ts` 10 KB, `styles.css` rebuilt.
+- `check_docs --strict` → pass (377 docs reachable); `check_current_state_ledger --strict`
+  → pass (last 15 merged PRs present). Arch checker not applicable (no `disbot/` change).
+- `design-system-ci.yml` runs on this PR (path match) — **UNVERIFIED first run**; mirrors the
+  local typecheck+build, which are green.
+
+## Decisions made alone (ratify if wrong)
+
+- **`ButtonLink` + `buttonClasses`** — added an anchor-button rather than make `Button`
+  polymorphic; the live site renders CTAs as `<a>`, so this is the faithful element. `Button`
+  output is byte-identical (pure refactor to share the class string).
+- **`design-system-ci.yml` uses the runner's preinstalled Node** (no `setup-node`) — chosen
+  because the GitHub API was rate-limited (couldn't fetch a pin-able `setup-node` SHA) and the
+  repo's hygiene is SHA-pinned actions only. Keeps the only action (`checkout`) pinned.
+- **`LandingPage` defaults** mirror the *current* indigo `botsite/` (not the owner's green
+  canvas exploration) and use sample counts (308/36/8) — the live site overrides via props.
+
+## Context delta (reflection interview)
+
+- **Needed but not pointed to:** `design-system/README.md` is the canonical contract for the
+  Claude Design loop, but it's package-local — not in `docs/`, the AGENT_ORIENTATION route, or
+  `current-state`'s "where to read next". Found it by glob. Also reverse-engineered that
+  `code-quality.yml` has **no `paths` filter** (always runs + reports green for non-Python
+  PRs) and runs the session gate — so a design-system-only PR *can* reach green.
+- **Pointed to but didn't need:** the three binding docs (architecture/ownership/runtime) +
+  CodeGraph stats — all Python-layer, inert for a `design-system/` (JS) change.
+- **Discovered by hand:** `pull_request` workflows **do** fire on the MCP-created PR here
+  (Code Quality/CodeQL ran on commit 1) — the "app-token PR doesn't trigger workflows" worry
+  did not apply to required checks; only the auto-merge *enabler* needs the manual
+  `enable_pr_auto_merge` (Q-0127), which I did.
+- **Weak point / known limits:** `design-system-ci.yml` is UNVERIFIED (confirm green a few
+  times). LandingPage defaults are sample data, not live counts. Components mirror today's
+  indigo site by design; the owner's new look gets ported when finalized.
+- **Most-helpful change:** route web/site/Claude-Design tasks to `design-system/README.md`
+  from orientation (below).
+
+## ⟲ Previous-session review (Q-0102)
+
+Reviewing #1168 (the session that built the 6-component library). **Did well:** diagnosed
+*why* `/design-sync` no-op'd (no JS library) before building, and left a precise follow-up
+list — "port canvas output back into Jinja" + "add a JS CI leg" — which made *this* session a
+straight execution. **Missed:** it shipped only atoms, so the page chrome the owner actually
+clicks (hero/nav) wasn't editable — the exact "can't save" wall the owner hit. The atoms were
+necessary but not sufficient for the stated goal (edit the page). **Concrete system
+improvement (done-adjacent):** add a one-line pointer from `docs/AGENT_ORIENTATION.md` (web /
+site task route) to `design-system/README.md` so the next agent is *routed* to the Claude
+Design contract instead of discovering it by glob — captured as a groom item; small enough to
+land next session.
+
+## 💡 Session idea (Q-0089)
+
+**A `botsite/` ⇄ `design-system/` parity guard.** The README's rule "keep the components in
+sync with the templates so designs stay shippable" is enforced by nothing — drift between a
+component's Tailwind classes and the Jinja it mirrors silently makes a ported design wrong. A
+small test/script (e.g. assert each documented component↔template mapping exists, or compare
+the canonical class strings) would turn that rule into a guard, protecting the hybrid loop.
+Dedup-checked: no existing `docs/ideas/` entry mentions design-system / Claude Design / parity.
+(File under `docs/ideas/` next grooming pass if not built sooner.)
+
+## 📊 Doc audit (Q-0104)
+
+- Hybrid workflow + components durable in `design-system/README.md`; owner Path-1 decision in
+  this log + the active-work claim. `check_docs --strict` + `check_current_state_ledger
+  --strict` green. The merged-PR ledger entry for #1175 lands via the next reconciliation/
+  grooming pass (the PR isn't merged at log-write time — strict ledger check correctly doesn't
+  require an unmerged entry).
+
+## 📤 Run report
+
+- **Did:** expanded `design-system/` so the whole bot-site landing page is source-backed
+  components Claude Design can edit (`LandingPage` + chrome + sections), documented the hybrid
+  Claude Design ⇄ Claude Code loop + preview-without-redeploy, and added the design-system CI
+  leg. · **Outcome:** built + verified (typecheck/build green); PR #1175 open, auto-merge armed
+  on green.
+- **Shipped:** #1175 — design-system full landing-page composition + hybrid edit loop + JS CI.
+- **Run type:** `manual` (owner-directed, interactive — Path 1).
+- **⚑ Owner decisions needed:** `none`.
+- **⚑ Owner manual steps:** optional — run `/design-sync` to upload the expanded components to
+  Claude Design, then design against the full `LandingPage`; tell Claude Code to port the
+  result into `botsite/`.
+- **⚑ Self-initiated:** `design-system-ci.yml` — promoted the #1168 session's flagged JS-CI-leg
+  idea to implementation without a separate dispatch (within the owner's "stability first / do
+  what's best" latitude). No `docs/ideas/` file; provenance is the #1168 log + this one.
+- **↪ Next:** confirm `design-system-ci` green in CI; route AGENT_ORIENTATION → design-system
+  README; build the botsite⇄design-system parity guard.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 0 at log-write (auto-merge fires on green; #1175) |
+| CI-red rounds | 0 real (the only `code-quality` reds were the intended born-red session gate) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (botsite⇄design-system parity guard) |
+| Ideas groomed | 1 (executed #1168's flagged JS CI leg → shipped) |

--- a/.sessions/2026-06-20-design-system-landing-page.md
+++ b/.sessions/2026-06-20-design-system-landing-page.md
@@ -1,0 +1,34 @@
+# 2026-06-20 — Design-system: full landing-page composition + hybrid edit loop
+
+> **Status:** `in-progress`
+
+## Arc (what this session is about)
+
+Owner is trying out **Claude Design** and kept hitting *"Can't save this edit — element
+isn't from project source"* when editing the hero. Root cause: only the 6 atomic components
+from `design-system/` (#1168) are source-backed; the hero / nav / section layout are
+generated canvas content with **nowhere in source to save to**. Owner chose **Path 1** —
+expand the design-system so the **whole landing page** is real, source-backed components, and
+tighten the **hybrid Claude Code + Claude Design workflow** (me as porter/reviewer; preview
+without merge+redeploy each iteration).
+
+Owner directive this session: *"anything documented in the repo is based on the situation when
+we documented it — good guidelines, not 100% strict rules. Do what's best for the vision:
+correctness over temporary fixes, stability first."* So I'm free to extend `design-system/`
+beyond the literal ask where it makes the loop genuinely usable.
+
+## Plan (this PR)
+
+- New layout/page components mirroring `botsite/` (`base.html` + `index.html`), faithful
+  palette (slate/indigo/sky/emerald/amber): `PageShell`, `SiteHeader`, `SiteFooter`, `Hero`,
+  `Section`, `StepCard`, `CapabilityBand`, `ButtonLink`, and a full `LandingPage` composition.
+- A Storybook story per new component + the full-page `LandingPage` story (the `/design-sync`
+  preview source) — so Claude Design composes/edit the *whole page* as real components.
+- Expand `design-system/README.md`: components table + the **hybrid / preview-without-redeploy**
+  loop (Claude Design canvas ⇄ Claude Code porter ⇄ local preview).
+- Add `design-system-ci.yml` (the JS CI leg the predecessor flagged) — checkout + `npm ci` +
+  `typecheck` + `build`, path-scoped to `design-system/**`, runner-preinstalled Node (only the
+  already-pinned `actions/checkout` SHA, no unverified `setup-node` pin).
+- Verify: `npm ci` / `npm run typecheck` / `npm run build` green in-container.
+
+_Shipped / verification / enders filled in as the deliberate final step, then Status → complete._

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -30,14 +30,68 @@ not assumed here.
 
 ## Components
 
+**Atoms**
+
 | Component | Mirrors (in `botsite/`) |
 |---|---|
-| `Button` | the "Add to Discord" CTA + secondary buttons |
+| `Button` / `ButtonLink` | the "Add to Discord" CTA + secondary buttons — `<button>` and the anchor-as-button the live site actually renders (shared style via `buttonClasses`) |
 | `Badge` | command status (`finished`/`in-progress`), `game`, changelog kinds |
 | `Card` | the standard bordered surface |
-| `StatTile` | the homepage capability band counts |
+| `StatTile` | a single homepage capability-band count |
 | `FeatureCard` | the "what it does" / `/features` category cards |
 | `CommandCard` | the `/commands` reference row |
+
+**Layout / chrome** (mirror `base.html`)
+
+| Component | Mirrors (in `botsite/`) |
+|---|---|
+| `PageShell` | `<body>` dark canvas + centered `<main>` column + header/footer slots |
+| `SiteHeader` | the sticky nav — logo · links · "as of last deploy" status dot · Add-to-Discord |
+| `SiteFooter` | the "generated / as of last deploy" freshness footer + source link |
+
+**Sections & page** (mirror `index.html`)
+
+| Component | Mirrors (in `botsite/`) |
+|---|---|
+| `Hero` | the hero — wordmark · tagline · primary/secondary CTAs |
+| `CapabilityBand` | the capability band (3 × `StatTile`, honest catalogue counts) |
+| `Section` | the section-header pattern (title + "All features →", or centered) |
+| `StepCard` | the "how it works" numbered steps |
+| **`LandingPage`** | **the whole `index.html` page composed from the parts above** — the canonical surface Claude Design edits, so every region maps to source |
+
+## Editing the site — the hybrid loop (Claude Design ⇄ Claude Code)
+
+The whole landing page is now real components (`LandingPage` composes them), so on the
+Claude Design canvas you can select and edit **any** region — hero, nav, sections — and it
+maps to source. The error *"Can't save this edit — element isn't from project source"*
+appears when you edit something that *isn't* a synced component; composing pages from these
+parts is what avoids it. Roles:
+
+- **Claude Design** = the visual canvas. Drive it by *prompting the agent* ("make the hero
+  two-column", "warmer palette") as much as by hand-editing — property-panel edits only
+  persist for source-backed components, which is now the whole page.
+- **Claude Code** (the porter + reviewer) = takes canvas output and ports it into the
+  `botsite/` Jinja templates (Tailwind classes transfer 1:1), keeping it correct and
+  consistent — Claude Design is weak at searching this repo and mapping a design to the
+  right files, so this step stays with Claude Code. Just say "port what I just designed."
+
+### Preview without merging / redeploying
+
+You don't have to merge to `main` (which redeploys the Railway site) to see a change — two
+local previews cover the two layers:
+
+```bash
+# 1. The design layer (these components, incl. the full-page LandingPage story):
+npm run storybook                  # http://localhost:6006 → Pages/LandingPage
+
+# 2. The real site (Jinja — exactly what ships):
+pip install -r botsite/requirements.txt
+uvicorn botsite.app:app --reload   # http://127.0.0.1:8000
+```
+
+On Claude Code on the web, ask Claude Code to run either and screenshot the result — so the
+loop is **design → port → preview → approve → merge**, with the merge (and redeploy) only at
+the end.
 
 ## Build
 

--- a/design-system/src/Button.tsx
+++ b/design-system/src/Button.tsx
@@ -14,6 +14,15 @@ const VARIANTS: Record<ButtonVariant, string> = {
 };
 
 /**
+ * Shared class string for the brand button style. Used by both {@link Button}
+ * (a real `<button>`) and `ButtonLink` (an `<a>` styled as a button — which is
+ * how the live site renders its CTAs), so the look is defined in one place.
+ */
+export function buttonClasses(variant: ButtonVariant = "primary"): string {
+  return `rounded-lg px-6 py-2.5 font-semibold transition-colors ${VARIANTS[variant]}`;
+}
+
+/**
  * The primary action button used across the site — most visibly the persistent
  * "Add to Discord" call-to-action.
  */
@@ -23,9 +32,6 @@ export function Button({
   ...props
 }: ButtonProps) {
   return (
-    <button
-      className={`rounded-lg px-6 py-2.5 font-semibold transition-colors ${VARIANTS[variant]} ${className}`}
-      {...props}
-    />
+    <button className={`${buttonClasses(variant)} ${className}`} {...props} />
   );
 }

--- a/design-system/src/ButtonLink.stories.tsx
+++ b/design-system/src/ButtonLink.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ButtonLink } from "./ButtonLink";
+
+const meta: Meta<typeof ButtonLink> = {
+  title: "Components/ButtonLink",
+  component: ButtonLink,
+  args: { children: "Add to Discord", href: "#" },
+};
+export default meta;
+
+type Story = StoryObj<typeof ButtonLink>;
+
+export const Primary: Story = { args: { variant: "primary" } };
+export const Secondary: Story = {
+  args: { variant: "secondary", children: "Explore features" },
+};

--- a/design-system/src/ButtonLink.tsx
+++ b/design-system/src/ButtonLink.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+
+import { buttonClasses, type ButtonVariant } from "./Button";
+
+export interface ButtonLinkProps
+  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  /** Visual style — matches {@link Button}. */
+  variant?: ButtonVariant;
+}
+
+/**
+ * An anchor styled as a brand button. The live site renders its calls-to-action
+ * ("Add to Discord", "Explore features") as links, not `<button>`s, so this is
+ * the faithful element for navigation/action CTAs. Shares {@link Button}'s
+ * styling via `buttonClasses`.
+ */
+export function ButtonLink({
+  variant = "primary",
+  className = "",
+  ...props
+}: ButtonLinkProps) {
+  return (
+    <a className={`inline-block ${buttonClasses(variant)} ${className}`} {...props} />
+  );
+}

--- a/design-system/src/CapabilityBand.stories.tsx
+++ b/design-system/src/CapabilityBand.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { CapabilityBand } from "./CapabilityBand";
+
+const meta: Meta<typeof CapabilityBand> = {
+  title: "Sections/CapabilityBand",
+  component: CapabilityBand,
+};
+export default meta;
+
+type Story = StoryObj<typeof CapabilityBand>;
+
+export const Default: Story = {
+  args: {
+    stats: [
+      { value: 308, label: "commands", href: "/commands" },
+      { value: 36, label: "feature areas", href: "/features" },
+      { value: 8, label: "games", href: "/features" },
+    ],
+  },
+};

--- a/design-system/src/CapabilityBand.tsx
+++ b/design-system/src/CapabilityBand.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+
+import { StatTile } from "./StatTile";
+
+export interface CapabilityStat {
+  /** The headline number. */
+  value: React.ReactNode;
+  /** What the number counts. */
+  label: string;
+  /** Optional deep-link. */
+  href?: string;
+}
+
+export interface CapabilityBandProps {
+  /** The capability tiles (honest catalogue counts only). */
+  stats: CapabilityStat[];
+}
+
+/**
+ * The homepage capability band — a centered row of {@link StatTile}s showing
+ * honest catalogue counts (commands / feature areas / games). Mirrors the
+ * capability `<section>` in `botsite/index.html`.
+ */
+export function CapabilityBand({ stats }: CapabilityBandProps) {
+  return (
+    <section className="mx-auto grid max-w-2xl grid-cols-3 gap-4">
+      {stats.map((stat, i) => (
+        <StatTile
+          key={i}
+          value={stat.value}
+          label={stat.label}
+          href={stat.href}
+        />
+      ))}
+    </section>
+  );
+}

--- a/design-system/src/Hero.stories.tsx
+++ b/design-system/src/Hero.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Hero } from "./Hero";
+
+const meta: Meta<typeof Hero> = {
+  title: "Sections/Hero",
+  component: Hero,
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+
+type Story = StoryObj<typeof Hero>;
+
+export const Default: Story = {
+  args: {
+    primary: { label: "Add to Discord", href: "#" },
+    secondary: { label: "Explore features", href: "/features" },
+  },
+};

--- a/design-system/src/Hero.tsx
+++ b/design-system/src/Hero.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+
+import { ButtonLink } from "./ButtonLink";
+
+export interface HeroCta {
+  /** Button label. */
+  label: string;
+  /** Destination href. */
+  href: string;
+}
+
+export interface HeroProps {
+  /** The big product wordmark/headline. */
+  title?: string;
+  /** Supporting tagline beneath the title. */
+  tagline?: React.ReactNode;
+  /** Primary CTA (the brand "Add to Discord" action). */
+  primary?: HeroCta;
+  /** Optional secondary CTA. */
+  secondary?: HeroCta;
+}
+
+/**
+ * The homepage hero — product wordmark, tagline, and the primary/secondary
+ * calls-to-action. Mirrors the hero `<section>` in `botsite/index.html`.
+ */
+export function Hero({
+  title = "SuperBot",
+  tagline = "One Discord bot for games, moderation, AI tools and more — built by a self-improving, AI-assisted development workflow.",
+  primary,
+  secondary,
+}: HeroProps) {
+  return (
+    <section className="py-12 text-center sm:py-16">
+      <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">{title}</h1>
+      <p className="mx-auto mt-4 max-w-2xl text-lg text-slate-300">{tagline}</p>
+      {(primary || secondary) && (
+        <div className="mt-7 flex items-center justify-center gap-3">
+          {primary && (
+            <ButtonLink
+              href={primary.href}
+              target="_blank"
+              rel="noopener"
+              variant="primary"
+            >
+              {primary.label}
+            </ButtonLink>
+          )}
+          {secondary && (
+            <ButtonLink href={secondary.href} variant="secondary">
+              {secondary.label}
+            </ButtonLink>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/design-system/src/LandingPage.stories.tsx
+++ b/design-system/src/LandingPage.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { LandingPage } from "./LandingPage";
+
+const meta: Meta<typeof LandingPage> = {
+  title: "Pages/LandingPage",
+  component: LandingPage,
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+
+type Story = StoryObj<typeof LandingPage>;
+
+// The whole marketing landing page composed from real components — the canonical
+// surface Claude Design edits (maps 1:1 onto botsite/index.html + base.html chrome).
+export const Default: Story = {
+  args: {
+    addUrl: "#",
+    build: { commit: "1f26d13", committedAt: "2026-06-20" },
+  },
+};

--- a/design-system/src/LandingPage.tsx
+++ b/design-system/src/LandingPage.tsx
@@ -1,0 +1,150 @@
+import * as React from "react";
+
+import { ButtonLink } from "./ButtonLink";
+import { CapabilityBand } from "./CapabilityBand";
+import { FeatureCard, type FeatureItem } from "./FeatureCard";
+import { Hero } from "./Hero";
+import { PageShell } from "./PageShell";
+import { Section } from "./Section";
+import { SiteFooter, type BuildMeta } from "./SiteFooter";
+import { SiteHeader } from "./SiteHeader";
+import { StepCard } from "./StepCard";
+
+export interface FeatureCategory {
+  /** Category heading (e.g. "games"). */
+  category: string;
+  /** Features listed under it. */
+  items: FeatureItem[];
+}
+
+export interface HowItWorksStep {
+  /** Step marker shown in the circle. */
+  number: React.ReactNode;
+  /** Step title. */
+  title: string;
+  /** Step description. */
+  body: string;
+}
+
+export interface LandingPageProps {
+  /** The "Add to Discord" install URL. */
+  addUrl?: string;
+  /** Honest catalogue counts for the capability band. */
+  counts?: { commands: number; features: number; games: number };
+  /** Feature categories for the "What it does" grid. */
+  features?: FeatureCategory[];
+  /** The "How it works" steps. */
+  steps?: HowItWorksStep[];
+  /** Deployed-build metadata for the footer freshness badge. */
+  build?: BuildMeta;
+}
+
+// Sample defaults so the page renders fully standalone in Storybook and on the
+// Claude Design canvas. The live site overrides these from botsite/data/site.json.
+const DEFAULT_COUNTS = { commands: 308, features: 36, games: 8 };
+
+const DEFAULT_FEATURES: FeatureCategory[] = [
+  {
+    category: "games",
+    items: [
+      { emoji: "🃏", name: "Blackjack" },
+      { emoji: "✊", name: "Rock Paper Scissors" },
+      { emoji: "🎲", name: "Dice" },
+    ],
+  },
+  {
+    category: "moderation",
+    items: [
+      { emoji: "🛡️", name: "Auto-moderation" },
+      { emoji: "⚠️", name: "Warnings" },
+      { emoji: "⏳", name: "Timeouts" },
+    ],
+  },
+  {
+    category: "ai tools",
+    items: [
+      { emoji: "🤖", name: "AI gateway" },
+      { emoji: "📝", name: "Summaries" },
+      { emoji: "🌐", name: "Translations" },
+    ],
+  },
+];
+
+const DEFAULT_STEPS: HowItWorksStep[] = [
+  { number: "1", title: "Invite", body: "Add SuperBot to your server." },
+  { number: "2", title: "Configure", body: "Pick the features you want." },
+  {
+    number: "3",
+    title: "Enjoy",
+    body: "Your members start playing and using it.",
+  },
+];
+
+/**
+ * The full marketing landing page composed from the design-system parts — the
+ * canonical "page" Claude Design edits, mapping 1:1 onto `botsite/index.html`
+ * (plus the `base.html` chrome). Every region is a real, source-backed
+ * component, so edits on the canvas always have somewhere in source to save to.
+ * Renders standalone with sample defaults; the live site passes real data.
+ */
+export function LandingPage({
+  addUrl = "#",
+  counts = DEFAULT_COUNTS,
+  features = DEFAULT_FEATURES,
+  steps = DEFAULT_STEPS,
+  build,
+}: LandingPageProps) {
+  return (
+    <PageShell
+      header={<SiteHeader addUrl={addUrl} hasBuild={Boolean(build?.commit)} />}
+      footer={<SiteFooter build={build} />}
+    >
+      <Hero
+        primary={{ label: "Add to Discord", href: addUrl }}
+        secondary={{ label: "Explore features", href: "/features" }}
+      />
+
+      <CapabilityBand
+        stats={[
+          { value: counts.commands, label: "commands", href: "/commands" },
+          { value: counts.features, label: "feature areas", href: "/features" },
+          { value: counts.games, label: "games", href: "/features" },
+        ]}
+      />
+
+      <Section
+        title="What it does"
+        action={{ label: "All features →", href: "/features" }}
+      >
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {features.map((f) => (
+            <FeatureCard
+              key={f.category}
+              category={f.category}
+              items={f.items}
+            />
+          ))}
+        </div>
+      </Section>
+
+      <Section title="How it works" centered>
+        <div className="mx-auto grid max-w-3xl grid-cols-1 gap-4 sm:grid-cols-3">
+          {steps.map((s, i) => (
+            <StepCard key={i} number={s.number} title={s.title} body={s.body} />
+          ))}
+        </div>
+      </Section>
+
+      <section className="mt-14 text-center">
+        <ButtonLink
+          href={addUrl}
+          target="_blank"
+          rel="noopener"
+          variant="primary"
+        >
+          Add SuperBot to your server
+        </ButtonLink>
+      </section>
+    </PageShell>
+  );
+}

--- a/design-system/src/PageShell.stories.tsx
+++ b/design-system/src/PageShell.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { PageShell } from "./PageShell";
+import { SiteFooter } from "./SiteFooter";
+import { SiteHeader } from "./SiteHeader";
+
+const meta: Meta<typeof PageShell> = {
+  title: "Layout/PageShell",
+  component: PageShell,
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+
+type Story = StoryObj<typeof PageShell>;
+
+export const WithChrome: Story = {
+  render: () => (
+    <PageShell
+      header={<SiteHeader active="features" />}
+      footer={
+        <SiteFooter build={{ commit: "1f26d13", committedAt: "2026-06-20" }} />
+      }
+    >
+      <p className="text-slate-300">Page content goes here.</p>
+    </PageShell>
+  ),
+};

--- a/design-system/src/PageShell.tsx
+++ b/design-system/src/PageShell.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+
+export interface PageShellProps {
+  /** The sticky site header (typically `<SiteHeader />`). */
+  header?: React.ReactNode;
+  /** The site footer (typically `<SiteFooter />`). */
+  footer?: React.ReactNode;
+  /** Page body, rendered inside the centered `<main>` column. */
+  children: React.ReactNode;
+}
+
+/**
+ * The page chrome that wraps every bot-site page — the dark canvas, the centered
+ * max-width column, and the header/footer slots. Mirrors `botsite/base.html`'s
+ * `<body>` + `<main>` layout so a page composed here ports straight to Jinja.
+ */
+export function PageShell({ header, footer, children }: PageShellProps) {
+  return (
+    <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
+      {header}
+      <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-8">
+        {children}
+      </main>
+      {footer}
+    </div>
+  );
+}

--- a/design-system/src/Section.stories.tsx
+++ b/design-system/src/Section.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Section } from "./Section";
+
+const meta: Meta<typeof Section> = {
+  title: "Sections/Section",
+  component: Section,
+};
+export default meta;
+
+type Story = StoryObj<typeof Section>;
+
+export const WithAction: Story = {
+  args: {
+    title: "What it does",
+    action: { label: "All features →", href: "/features" },
+    children: <p className="text-slate-300">Section content.</p>,
+  },
+};
+export const Centered: Story = {
+  args: {
+    title: "How it works",
+    centered: true,
+    children: <p className="text-center text-slate-300">Centered content.</p>,
+  },
+};

--- a/design-system/src/Section.tsx
+++ b/design-system/src/Section.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+
+export interface SectionAction {
+  /** Link label (e.g. "All features →"). */
+  label: string;
+  /** Link destination. */
+  href: string;
+}
+
+export interface SectionProps {
+  /** Section heading. */
+  title?: string;
+  /** Optional right-aligned action link (renders the title row as space-between). */
+  action?: SectionAction;
+  /** Center a plain title (used by "How it works"). */
+  centered?: boolean;
+  children: React.ReactNode;
+}
+
+/**
+ * A content section with the site's two heading styles: a left title with an
+ * optional right-aligned action link ("What it does" / "All features →"), or a
+ * centered title ("How it works"). Mirrors the section headers in
+ * `botsite/index.html`. Carries the `mt-14` rhythm between sections.
+ */
+export function Section({
+  title,
+  action,
+  centered = false,
+  children,
+}: SectionProps) {
+  return (
+    <section className="mt-14">
+      {title &&
+        (action ? (
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-xl font-semibold">{title}</h2>
+            <a
+              href={action.href}
+              className="text-sm text-sky-400 hover:text-sky-300"
+            >
+              {action.label}
+            </a>
+          </div>
+        ) : (
+          <h2
+            className={`mb-4 text-xl font-semibold ${centered ? "text-center" : ""}`}
+          >
+            {title}
+          </h2>
+        ))}
+      {children}
+    </section>
+  );
+}

--- a/design-system/src/SiteFooter.stories.tsx
+++ b/design-system/src/SiteFooter.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { SiteFooter } from "./SiteFooter";
+
+const meta: Meta<typeof SiteFooter> = {
+  title: "Layout/SiteFooter",
+  component: SiteFooter,
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+
+type Story = StoryObj<typeof SiteFooter>;
+
+export const WithBuild: Story = {
+  args: { build: { commit: "1f26d13", committedAt: "2026-06-20" } },
+};
+export const NoBuild: Story = {};

--- a/design-system/src/SiteFooter.tsx
+++ b/design-system/src/SiteFooter.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+
+export interface BuildMeta {
+  /** Short commit SHA of the deployed build. */
+  commit?: string;
+  /** Human-readable commit timestamp. */
+  committedAt?: string;
+}
+
+export interface SiteFooterProps {
+  /** Deployed-build metadata for the freshness badge. */
+  build?: BuildMeta;
+  /** Link to the public source repository. */
+  sourceUrl?: string;
+}
+
+/**
+ * The site footer — the honest "generated / as of last deploy" freshness badge,
+ * the build SHA, and a source link. Mirrors the `<footer>` in
+ * `botsite/base.html`. The public site never claims live state here.
+ */
+export function SiteFooter({
+  build,
+  sourceUrl = "https://github.com/menno420/superbot",
+}: SiteFooterProps) {
+  return (
+    <footer className="mx-auto w-full max-w-6xl border-t border-slate-800 px-4 py-6 text-xs text-slate-500">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+        <span className="rounded bg-slate-800 px-2 py-0.5 text-slate-400">
+          generated
+        </span>
+        <span>
+          {build?.commit ? (
+            <>
+              as of last deploy · build <code>{build.commit}</code>
+              {build.committedAt ? ` · ${build.committedAt}` : null}
+            </>
+          ) : (
+            "build info unavailable"
+          )}
+        </span>
+        <span className="ml-auto">
+          <a className="underline hover:text-slate-300" href={sourceUrl}>
+            source
+          </a>
+        </span>
+      </div>
+    </footer>
+  );
+}

--- a/design-system/src/SiteHeader.stories.tsx
+++ b/design-system/src/SiteHeader.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { SiteHeader } from "./SiteHeader";
+
+const meta: Meta<typeof SiteHeader> = {
+  title: "Layout/SiteHeader",
+  component: SiteHeader,
+  parameters: { layout: "fullscreen" },
+  args: { addUrl: "#" },
+};
+export default meta;
+
+type Story = StoryObj<typeof SiteHeader>;
+
+export const Default: Story = {};
+export const ActiveFeatures: Story = { args: { active: "features" } };
+export const NoBuild: Story = { args: { hasBuild: false } };

--- a/design-system/src/SiteHeader.tsx
+++ b/design-system/src/SiteHeader.tsx
@@ -1,0 +1,90 @@
+import * as React from "react";
+
+export interface NavItem {
+  /** Route key (e.g. "features") — also the active-state match key. */
+  key: string;
+  /** Visible label (e.g. "Features"). */
+  label: string;
+  /** Destination href. Defaults to `/{key}`. */
+  href?: string;
+}
+
+export interface SiteHeaderProps {
+  /** Primary nav links. Defaults to the live site's nav. */
+  navItems?: NavItem[];
+  /** The currently-active route key, highlighted in the nav. */
+  active?: string;
+  /** The "Add to Discord" install URL. */
+  addUrl?: string;
+  /**
+   * Whether a build is known — drives the status dot (emerald when a deploy is
+   * known, slate otherwise). Honest "as of last deploy" posture; never a live
+   * claim.
+   */
+  hasBuild?: boolean;
+}
+
+const DEFAULT_NAV: NavItem[] = [
+  { key: "features", label: "Features" },
+  { key: "commands", label: "Commands" },
+  { key: "changelog", label: "Changelog" },
+  { key: "status", label: "Status" },
+];
+
+/**
+ * The sticky top navigation — logo, primary links, the "as of last deploy"
+ * status dot, and the persistent "Add to Discord" CTA. Mirrors the `<header>`
+ * in `botsite/base.html`.
+ */
+export function SiteHeader({
+  navItems = DEFAULT_NAV,
+  active,
+  addUrl = "#",
+  hasBuild = true,
+}: SiteHeaderProps) {
+  return (
+    <header className="sticky top-0 z-10 border-b border-slate-800 bg-slate-900/70 backdrop-blur">
+      <nav className="mx-auto flex max-w-6xl flex-wrap items-center gap-x-5 gap-y-2 px-4 py-3">
+        <a href="/" className="mr-2 text-lg font-bold">
+          🤖 SuperBot
+        </a>
+        {navItems.map((item) => {
+          const isActive = item.key === active;
+          return (
+            <a
+              key={item.key}
+              href={item.href ?? `/${item.key}`}
+              className={`text-sm hover:text-sky-300 ${
+                isActive ? "font-semibold text-sky-400" : "text-slate-300"
+              }`}
+            >
+              {item.label}
+            </a>
+          );
+        })}
+        <div className="ml-auto flex items-center gap-3">
+          <a
+            href="/status"
+            title="Status (as of last deploy)"
+            className="flex items-center gap-1 text-xs text-slate-400 hover:text-slate-200"
+          >
+            <span
+              className={`inline-block h-2.5 w-2.5 rounded-full ${
+                hasBuild ? "bg-emerald-500" : "bg-slate-500"
+              }`}
+            />
+            <span className="hidden sm:inline">Status</span>
+          </a>
+          <a
+            href={addUrl}
+            target="_blank"
+            rel="noopener"
+            className="rounded-lg bg-indigo-600 px-4 py-1.5 text-sm font-semibold shadow hover:bg-indigo-500"
+          >
+            Add to Discord
+          </a>
+        </div>
+      </nav>
+    </header>
+  );
+}

--- a/design-system/src/StepCard.stories.tsx
+++ b/design-system/src/StepCard.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { StepCard } from "./StepCard";
+
+const meta: Meta<typeof StepCard> = {
+  title: "Sections/StepCard",
+  component: StepCard,
+  args: { number: "1", title: "Invite", body: "Add SuperBot to your server." },
+};
+export default meta;
+
+type Story = StoryObj<typeof StepCard>;
+
+export const Default: Story = {};

--- a/design-system/src/StepCard.tsx
+++ b/design-system/src/StepCard.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+
+export interface StepCardProps {
+  /** The step number/marker shown in the circle. */
+  number: React.ReactNode;
+  /** Step title. */
+  title: string;
+  /** Step description. */
+  body: string;
+}
+
+/**
+ * A single "how it works" step — a numbered circle, a title, and a short
+ * description. Mirrors the step cards in `botsite/index.html`.
+ */
+export function StepCard({ number, title, body }: StepCardProps) {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-5 text-center">
+      <div className="mx-auto mb-2 flex h-8 w-8 items-center justify-center rounded-full bg-indigo-600 font-bold">
+        {number}
+      </div>
+      <div className="font-semibold">{title}</div>
+      <div className="mt-1 text-sm text-slate-400">{body}</div>
+    </div>
+  );
+}

--- a/design-system/src/index.ts
+++ b/design-system/src/index.ts
@@ -17,3 +17,37 @@ export type { FeatureCardProps, FeatureItem } from "./FeatureCard";
 
 export { CommandCard } from "./CommandCard";
 export type { CommandCardProps } from "./CommandCard";
+
+// ── Layout / chrome ─────────────────────────────────────────────────────────
+export { ButtonLink } from "./ButtonLink";
+export type { ButtonLinkProps } from "./ButtonLink";
+
+export { PageShell } from "./PageShell";
+export type { PageShellProps } from "./PageShell";
+
+export { SiteHeader } from "./SiteHeader";
+export type { SiteHeaderProps, NavItem } from "./SiteHeader";
+
+export { SiteFooter } from "./SiteFooter";
+export type { SiteFooterProps, BuildMeta } from "./SiteFooter";
+
+// ── Sections ────────────────────────────────────────────────────────────────
+export { Hero } from "./Hero";
+export type { HeroProps, HeroCta } from "./Hero";
+
+export { Section } from "./Section";
+export type { SectionProps, SectionAction } from "./Section";
+
+export { StepCard } from "./StepCard";
+export type { StepCardProps } from "./StepCard";
+
+export { CapabilityBand } from "./CapabilityBand";
+export type { CapabilityBandProps, CapabilityStat } from "./CapabilityBand";
+
+// ── Page composition (the canonical surface Claude Design edits) ─────────────
+export { LandingPage } from "./LandingPage";
+export type {
+  LandingPageProps,
+  FeatureCategory,
+  HowItWorksStep,
+} from "./LandingPage";

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -30,6 +30,12 @@ living ledger (`docs/current-state.md`).
   new top-level `design-system/` (React 18 + Tailwind 3 + tsup build → `dist/` + Storybook 8; 6
   components mirroring `botsite/`) · `.gitignore` (+ `node_modules/`) · 2026-06-20 ·
   **auto-merge on green** (additive · isolated · verified) · **PR #1168**
+- `claude/magical-cori-t36l2n` · **design-system full landing-page composition + hybrid edit
+  loop** (owner-chosen Path 1, 2026-06-20 — make the *whole* page source-backed so Claude Design
+  can edit it; me as porter/reviewer) · `design-system/src/` (`PageShell`/`SiteHeader`/
+  `SiteFooter`/`Hero`/`Section`/`StepCard`/`CapabilityBand`/`ButtonLink`/`LandingPage` + stories) ·
+  `design-system/README.md` · new `.github/workflows/design-system-ci.yml` · 2026-06-20 ·
+  **auto-merge on green** (additive · isolated · verified)
 
 ## Recently cleared
 


### PR DESCRIPTION
## Why

The owner is trying out **Claude Design** and kept hitting *"Can't save this edit — element isn't from project source"* when editing the landing page hero. Root cause: after #1168 only the **6 atomic components** (`Button`, `Badge`, `Card`, `StatTile`, `FeatureCard`, `CommandCard`) are source-backed — the hero, nav, and section layout are generated canvas content with nowhere in source to save to.

Owner chose **Path 1**: expand `design-system/` so the **whole landing page** is real, source-backed components Claude Design can compose and edit, and tighten the **hybrid Claude Code ⇄ Claude Design workflow** (Claude Code as the porter/reviewer who maps canvas output to the right place in `botsite/`), with a preview loop that doesn't require merge+redeploy each iteration.

## What's in this PR

- **New layout/page components** mirroring `botsite/base.html` + `index.html` (faithful palette: slate/indigo/sky/emerald/amber): `PageShell`, `SiteHeader`, `SiteFooter`, `Hero`, `Section`, `StepCard`, `CapabilityBand`, `ButtonLink`, and a full **`LandingPage`** composition.
- **Storybook stories** per new component + a full-page `LandingPage` story — the `/design-sync` preview source, so Claude Design composes/edits the *whole page* as real components.
- **`design-system/README.md`** expanded: components table + the hybrid / preview-without-redeploy loop.
- **`.github/workflows/design-system-ci.yml`** — the JS CI leg the predecessor flagged (`npm ci` + `typecheck` + `build`), path-scoped to `design-system/**`. Non-required check (twin of `botsite-ci.yml` / `dashboard-ci.yml`).

Production stays Jinja (`botsite/`). This library is the design-system source of truth that feeds Claude Design; canvas output is ported back into the Jinja templates by Claude Code. Additive + isolated — nothing imports `design-system/`, Python CI is untouched.

## Verification

`npm ci` · `npm run typecheck` · `npm run build` green in-container (recorded in the session log on completion).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us471wswNwKLxVxdn4JLS4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Us471wswNwKLxVxdn4JLS4)_