### PR TITLE
design-system docs: document the GitHub-connector workflow (not /design-sync)

### DIFF
--- a/.github/workflows/design-system-ci.yml
+++ b/.github/workflows/design-system-ci.yml
@@ -1,7 +1,8 @@
 name: Design System CI
 
-# Builds + type-checks the React/Tailwind design-system (the source of truth
-# /design-sync uploads to Claude Design). Sibling of botsite-ci.yml / dashboard-ci.yml
+# Builds + type-checks the React/Tailwind design-system (the source of truth Claude
+# Design reads — via the GitHub connector, or the /design-sync upload). Sibling of
+# botsite-ci.yml / dashboard-ci.yml
 # for the JS tier: the main code-quality.yml installs only Python tooling and never
 # touches design-system/, so without this leg a broken component or type error would
 # land silently. Provenance: 2026-06-20 (Path 1 — full landing-page composition); closes

--- a/.sessions/2026-06-20-design-system-connector-docs.md
+++ b/.sessions/2026-06-20-design-system-connector-docs.md
@@ -1,6 +1,6 @@
 # 2026-06-20 — Design-system docs: connector-vs-`/design-sync` correction
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Arc
 

--- a/.sessions/2026-06-20-design-system-connector-docs.md
+++ b/.sessions/2026-06-20-design-system-connector-docs.md
@@ -1,0 +1,51 @@
+# 2026-06-20 — Design-system docs: connector-vs-`/design-sync` correction
+
+> **Status:** `in-progress`
+
+## Arc
+
+Follow-up to PR #1175 (same session). The owner clarified they enabled Claude Design via the
+**GitHub connector**, not the repo's `/design-sync` path — so the design-system README (which
+documented only `/design-sync`) misdescribed how they actually work, and my earlier "re-run
+`/design-sync`" advice was wrong. Owner approved a docs correction (AskUserQuestion 2026-06-20).
+
+## Plan / shipped
+
+- `design-system/README.md` — make the **GitHub connector** the primary documented path
+  (repo = source of truth; merging *is* the sync; refresh the project to pick up new commits);
+  keep `/design-sync` as a labelled alternative; fix the loop step + Build/Stack mentions.
+- `docs/AGENT_ORIENTATION.md` — add the missing **"Touching the public site / design-system /
+  Claude Design"** route (the orientation gap flagged in the #1175 log) pointing at the README.
+- `.github/workflows/design-system-ci.yml` — correct the one-line comment about how the
+  library reaches Claude Design.
+- `docs/owner/active-work.md` — clear the now-merged #1175 + #1168 claims; claim this PR.
+
+## Verification
+
+Docs-only (no code change). `design-system-ci` re-runs via the `design-system/**` path filter
+and stays green (typecheck/build untouched). README anchor link checked.
+
+## Session enders
+
+Continuation of the #1175 session — its full enders (idea Q-0089, grooming Q-0015,
+prev-session review Q-0102, doc audit Q-0104, telemetry) live in
+`.sessions/2026-06-20-design-system-landing-page.md` and are not duplicated here, to avoid
+hallucinated ceremony (the Q-0089/Q-0102 bar). One genuine note this follow-up surfaces:
+**doc accuracy degrades silently when a tool's UX differs from what we assumed** — the README
+asserted `/design-sync` as *the* path with no provenance date, so nothing flagged it when the
+owner's actual setup (connector) diverged. Cheap guard for next time: write integration docs
+around *what the repo guarantees* (the buildable library) and label *external-product UX*
+(how Claude Design ingests it) as "as of <date>, verify", since that half can drift without a
+repo change.
+
+## 📤 Run report
+
+- **Did:** corrected the design-system docs to document the GitHub-connector workflow the owner
+  actually uses (was `/design-sync`-only) + closed the AGENT_ORIENTATION website-route gap. ·
+  **Outcome:** docs-only PR, auto-merge on green.
+- **Run type:** `manual` (owner-directed follow-up).
+- **⚑ Owner decisions needed:** `none`.
+- **⚑ Self-initiated:** the `AGENT_ORIENTATION` route + `active-work` cleanup + workflow-comment
+  fix (bundled proactively as connected drift); the README fix itself was owner-requested.
+- **↪ Next:** owner refreshes/reopens Claude Design and confirms the new full-page components
+  appear (merging #1175 published them via the connector).

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -1,21 +1,24 @@
 # @superbot/design-system
 
 SuperBot's **React + Tailwind component library** — the design-system *source of
-truth* that Claude Design's [`/design-sync`](https://support.claude.com/en/articles/14604416-get-started-with-claude-design)
-uploads, so the Claude Design agent builds with SuperBot's **real components**
-instead of generic ones.
+truth* Claude Design builds with, so its agent composes pages from SuperBot's
+**real components** instead of generic ones. Claude Design reads this library
+straight from the repo via the **GitHub connector**; `/design-sync` is an
+alternative manual upload. See [Connecting to Claude Design](#connecting-to-claude-design).
 
 ## Why this exists (read before extending)
 
 The public site (`botsite/`) is **server-rendered Jinja2 + Tailwind (CDN)** — it
-has no JavaScript components. `/design-sync` can only sync a buildable
-JS/TS component library, so this package provides one.
+has no JavaScript components. Claude Design builds with a JS/TS component library,
+so this package provides one.
 
 **Production stays Jinja for now.** This library is *design tooling*, not the
 live site's runtime: it is the source of truth that feeds Claude Design. The
 intended loop is:
 
-1. Build & sync this library to Claude Design (`/design-sync`).
+1. Get this library into Claude Design — via the **GitHub connector** (it reads
+   the repo directly, so merging to the connected branch *is* the sync) or the
+   `/design-sync` upload. See [Connecting to Claude Design](#connecting-to-claude-design).
 2. Design pages on the Claude Design canvas — the agent now composes SuperBot's
    real components, so output maps 1:1 onto these parts.
 3. Port the resulting design back into the `botsite/` Jinja templates via Claude
@@ -99,27 +102,39 @@ the end.
 npm install
 npm run build        # tsup → dist/ (ESM + .d.ts) and the compiled dist/styles.css
 npm run typecheck    # tsc --noEmit
-npm run storybook    # local component gallery (also used by /design-sync for previews)
+npm run storybook    # local component gallery (also the /design-sync preview source)
 ```
 
-`dist/` is git-ignored (a build artifact). `/design-sync` runs the build itself
-during a sync, so only the source + config are committed.
+`dist/` is git-ignored (a build artifact) — Claude Design and `/design-sync` build
+from source, so only the source + config are committed.
 
-## Syncing to Claude Design
+## Connecting to Claude Design
 
-From the repo root, in Claude Code:
+Two ways to get these components into Claude Design — pick one:
 
-```
-/design-sync
-```
+### GitHub connector (primary — what this project uses)
 
-It detects this package, builds it, generates previews (from the Storybook
-stories), and uploads the components to a Claude Design **design-system project**
-(it will create one on the first sync). Requires a Pro/Max/Team/Enterprise plan
-and a claude.ai login (`/design-login` if prompted).
+Enable Claude Design's **GitHub connector** for this repo (in claude.ai → Settings →
+Connectors). Claude Design then reads the component library **straight from the repo**:
+
+- **The repo is the sync.** Whatever is on the connected branch (normally `main`) is what
+  Claude Design sees — **merging a PR is what publishes new/changed components.** There is no
+  separate upload step and no `/design-sync` to run.
+- After a merge, **refresh / reopen the Claude Design project** so it re-reads the latest
+  commit. If Claude Design lets you select a branch, you can preview a branch *before* it
+  merges.
+- Canvas edits save back to source as commits / PRs on the repo.
+
+### `/design-sync` (alternative — manual upload)
+
+If you are *not* using the connector, run [`/design-sync`](https://support.claude.com/en/articles/14604416-get-started-with-claude-design)
+from the repo root in Claude Code. It detects this package, builds it, generates previews
+(from the Storybook stories), and uploads the components to a Claude Design **design-system
+project** (created on first sync). Requires a Pro/Max/Team/Enterprise plan and a claude.ai
+login (`/design-login` if prompted).
 
 ## Stack
 
 React 18 · TypeScript · Tailwind CSS 3 · tsup (esbuild) · Storybook 8 (Vite).
-The package is intentionally framework-conventional so `/design-sync`'s
-heuristics recognise it without custom config.
+The package is intentionally framework-conventional so Claude Design (and
+`/design-sync`) recognise it without custom config.

--- a/docs/AGENT_ORIENTATION.md
+++ b/docs/AGENT_ORIENTATION.md
@@ -149,6 +149,16 @@ read **`docs/helper-policy.md`** first.
 2. `docs/decisions/007-media-youtube-ownership.md` — binding shared-media ownership decision.
 3. `docs/server-logging.md` — logging/audit routing and fail-safe expectations.
 
+### Touching the public site (`botsite/`) / design-system / Claude Design
+
+1. `design-system/README.md` — **the contract for the Claude Design workflow**: the
+   React/Tailwind component library that mirrors `botsite/`, how Claude Design reads it (the
+   **GitHub connector** — primary — or `/design-sync`), the hybrid design→port→preview loop,
+   and how to preview without redeploying.
+2. `botsite/` — the live server-rendered Jinja2 + Tailwind site (what actually ships). Canvas
+   designs are ported back into these templates; production stays Jinja.
+3. `.github/workflows/design-system-ci.yml` / `botsite-ci.yml` — the JS / site CI legs.
+
 ### Touching settings / bindings / resource provisioning
 
 1. `docs/subsystems/settings-bindings-provisioning.md` — canonical area entry point.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,20 +25,18 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/youthful-turing-odgvq6` · **design-system component library** (owner-chosen via
-  AskUserQuestion 2026-06-20 — "build a component library" so `/design-sync` has something to sync) ·
-  new top-level `design-system/` (React 18 + Tailwind 3 + tsup build → `dist/` + Storybook 8; 6
-  components mirroring `botsite/`) · `.gitignore` (+ `node_modules/`) · 2026-06-20 ·
-  **auto-merge on green** (additive · isolated · verified) · **PR #1168**
-- `claude/magical-cori-t36l2n` · **design-system full landing-page composition + hybrid edit
-  loop** (owner-chosen Path 1, 2026-06-20 — make the *whole* page source-backed so Claude Design
-  can edit it; me as porter/reviewer) · `design-system/src/` (`PageShell`/`SiteHeader`/
-  `SiteFooter`/`Hero`/`Section`/`StepCard`/`CapabilityBand`/`ButtonLink`/`LandingPage` + stories) ·
-  `design-system/README.md` · new `.github/workflows/design-system-ci.yml` · 2026-06-20 ·
-  **auto-merge on green** (additive · isolated · verified)
+- `claude/design-system-connector-docs` · **design-system docs: connector-vs-`/design-sync`
+  correction** (owner-directed 2026-06-20 — owner uses the GitHub connector, not `/design-sync`) ·
+  `design-system/README.md` (connector as primary path) · `docs/AGENT_ORIENTATION.md` (new
+  website/design-system route) · `.github/workflows/design-system-ci.yml` (comment) · 2026-06-20 ·
+  **auto-merge on green** (docs-only)
 
 ## Recently cleared
 
+- `claude/magical-cori-t36l2n` · design-system full landing-page composition + hybrid edit loop +
+  JS CI leg · 2026-06-20 · **PR #1175 (merged)**
+- `claude/youthful-turing-odgvq6` · design-system component library (6 components) · 2026-06-20 ·
+  **PR #1168 (merged)**
 - `claude/funny-franklin-bnvdxe` · federated Explore-hub spine **PR 1** — top-level world hub +
   `services/world_registry.py` seam + `!world` + mining Explore-button re-parent (retired the
   `views/mining/explore_hub.py` stub) · 2026-06-20 · **PR #1156 (needs-hermes-review, auto-merge disabled)**


### PR DESCRIPTION
## Why

Follow-up to #1175. The owner enabled Claude Design via the **GitHub connector**, not the repo's `/design-sync` path — so the design-system docs (which documented only `/design-sync`) misdescribed the actual workflow, and the advice "re-run `/design-sync`" was wrong for this setup.

## What

- **`design-system/README.md`** — make the **GitHub connector** the primary documented path (the repo *is* the source of truth Claude Design reads; merging a PR is what publishes components; refresh the project to pick up the latest commit). Keep `/design-sync` as a clearly-labelled **alternative** manual upload. Fix the intro, the loop step, and the Build/Stack mentions to match.
- **`docs/AGENT_ORIENTATION.md`** — add the missing **"Touching the public site (`botsite/`) / design-system / Claude Design"** reading route (there was none — confirmed gap flagged in the #1175 session log), pointing at the README as the workflow contract.
- **`.github/workflows/design-system-ci.yml`** — correct the one-line comment on how the library reaches Claude Design.
- **`docs/owner/active-work.md`** — clear the now-merged #1175 + #1168 claims; claim this PR.

Docs-only; no code change. `design-system-ci` re-runs (path filter) and stays green. `check_docs --strict` + the 70 docs pinning tests pass locally.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us471wswNwKLxVxdn4JLS4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Us471wswNwKLxVxdn4JLS4)_