### PR TITLE
design-system: compose the rest of the site (Features / Commands / Changelog / Status)

### DIFF
--- a/.sessions/2026-06-20-design-system-site-pages.md
+++ b/.sessions/2026-06-20-design-system-site-pages.md
@@ -1,0 +1,83 @@
+# 2026-06-20 — Design-system: compose the rest of the site (Features/Commands/Changelog/Status)
+
+> **Status:** `in-progress`
+
+## Arc
+
+Third PR of this session (after #1175 landing page + #1176 connector docs). The owner — mid
+Claude Design exploration, re-syncing the repo into a fresh project — asked "anything we can do
+meantime?" and chose **compose the rest of the site** so Claude Design can edit *every* page, not
+just the landing page. Extends Path 1 (whole-page source-backed components) across all routes.
+
+First I ran a fidelity audit of the existing landing-page components against the real
+`botsite/templates/*.html` — they match class-for-class (only 3 cosmetic button drifts, deferred).
+Then built the remaining pages from the actual templates.
+
+## What shipped (this PR)
+
+New components mirroring the real templates (verified against `botsite/templates/`):
+- **Building blocks:** `PageHeader` (plain + bordered/"generated" variants), `SearchBar`, `Pill`
+  (active + link/button), `FeatureShowcaseCard`, `CommandDetail` + `CommandEntry` (native
+  `<details>`, JS-free), `ChangelogEntry`, `StatusCard`.
+- **Full page compositions** (each inside `PageShell` + header/footer, sample-data defaults):
+  `FeaturesPage`, `CommandsPage`, `ChangelogPage`, `StatusPage` — joining `LandingPage`.
+- A Storybook story per new component + page (the canvas / `/design-sync` preview surfaces).
+- `index.ts` exports + README components table (new Sections group + a Pages group) updated.
+
+Now all five public routes are real, source-backed components → Claude Design can edit the whole
+site. Additive + isolated; production stays Jinja (`botsite/`), ported back by Claude Code.
+
+## Verification (in-container)
+
+- `npm run typecheck` (`tsc --noEmit`) → clean.
+- `npm run build` → exit 0; `dist/index.d.ts` 10 KB → **19.4 KB** (all new components), CSS rebuilt.
+- `design-system-ci` re-runs on the PR (path filter) — mirrors the local typecheck + build.
+
+## Decisions made alone
+
+- Mirrored the templates **class-for-class** (faithful starting blocks port cleanly); kept the
+  interactive `<details>` for commands so it works JS-free like the template.
+- Built `FeatureShowcaseCard` as a NEW component (distinct from the homepage `FeatureCard`, which
+  is a category card) rather than overloading the latter.
+- Changelog kind badge uses the template's exact classes (`px-2.5`/`text-xs`/`font-medium`/`ring-1`)
+  rather than the uppercase `Badge` atom — Badge's `new/improved/fixed` tones differ in size, so
+  faithfulness won over reuse here.
+- Sample-data defaults on every page so they render standalone in Storybook / on the canvas; the
+  live site passes real data.
+
+## Fidelity audit (recorded, deferred)
+
+The landing-page components match `botsite/` exactly except three cosmetic button drifts: hero
+"Explore features" is `font-semibold` (site: `font-medium`); the bottom CTA uses the standard size
+(site: larger `px-7 py-3`); primary buttons add `text-white` + `transition-colors`. All inherited
+from the #1168 button atom; left for the owner (they're restyling on the canvas anyway).
+
+## Session enders
+
+Session-level enders (Q-0089 idea, Q-0102 prev-session review, Q-0015 grooming, Q-0104 doc audit,
+telemetry) were completed in `.sessions/2026-06-20-design-system-landing-page.md` — this is the
+same session's 3rd PR, so not duplicated (the Q-0089/Q-0102 no-filler bar). One genuine **new idea**
+this build surfaced: a **route manifest** mapping each `*Page` → its `botsite/` template + URL, so a
+coverage check can assert every route has a component (complements the parity-guard idea from #1175).
+
+## 📤 Run report
+
+- **Did:** composed the remaining four site pages (Features/Commands/Changelog/Status) + their
+  components as real, source-backed parts faithful to `botsite/`, so Claude Design can edit the
+  whole site. · **Outcome:** built + verified (typecheck/build green); PR auto-merges on green.
+- **Run type:** `manual` (owner-directed, interactive).
+- **⚑ Owner manual steps:** re-sync the Claude Design project; the new pages appear under `Pages/`
+  (FeaturesPage, CommandsPage, ChangelogPage, StatusPage).
+- **⚑ Self-initiated:** the fidelity audit + the route-manifest idea (proactive); the page-build
+  itself was owner-chosen.
+- **↪ Next:** owner designs pages on the canvas → tell Claude Code to port to `botsite/`. Optional:
+  the 3 button-drift fixes; the parity / route-manifest guards.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs this session | #1175 + #1176 merged; this is #3 (auto-merge on green) |
+| New components | 8 building blocks + 4 page compositions |
+| CI-red rounds | 0 real (born-red gate only) |
+| New ideas | +1 (route manifest) |

--- a/.sessions/2026-06-20-design-system-site-pages.md
+++ b/.sessions/2026-06-20-design-system-site-pages.md
@@ -1,6 +1,6 @@
 # 2026-06-20 — Design-system: compose the rest of the site (Features/Commands/Changelog/Status)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Arc
 

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -42,7 +42,9 @@ not assumed here.
 | `Card` | the standard bordered surface |
 | `StatTile` | a single homepage capability-band count |
 | `FeatureCard` | the "what it does" / `/features` category cards |
-| `CommandCard` | the `/commands` reference row |
+| `CommandCard` | the `/commands` reference row (compact) |
+| `SearchBar` | the `/features` + `/commands` search input |
+| `Pill` | the category jump / filter chips (active + link/button variants) |
 
 **Layout / chrome** (mirror `base.html`)
 
@@ -51,22 +53,38 @@ not assumed here.
 | `PageShell` | `<body>` dark canvas + centered `<main>` column + header/footer slots |
 | `SiteHeader` | the sticky nav — logo · links · "as of last deploy" status dot · Add-to-Discord |
 | `SiteFooter` | the "generated / as of last deploy" freshness footer + source link |
+| `PageHeader` | a page title + subtitle (plain, or bordered with a "generated" badge) |
 
-**Sections & page** (mirror `index.html`)
+**Sections** (page building blocks)
 
 | Component | Mirrors (in `botsite/`) |
 |---|---|
-| `Hero` | the hero — wordmark · tagline · primary/secondary CTAs |
+| `Hero` | the homepage hero — wordmark · tagline · primary/secondary CTAs |
 | `CapabilityBand` | the capability band (3 × `StatTile`, honest catalogue counts) |
 | `Section` | the section-header pattern (title + "All features →", or centered) |
 | `StepCard` | the "how it works" numbered steps |
-| **`LandingPage`** | **the whole `index.html` page composed from the parts above** — the canonical surface Claude Design edits, so every region maps to source |
+| `FeatureShowcaseCard` | a single `/features` card — emoji · name · `game` badge · tags · "See commands" |
+| `CommandEntry` / `CommandDetail` | a `/commands` expandable `<details>` card and its detail body (aliases · permissions · examples · "what's planned") |
+| `ChangelogEntry` | a `/changelog` timeline entry — kind label · title · summary · "Details" |
+| `StatusCard` | the `/status` "online as of last deploy" build card |
+
+**Pages** (full per-route compositions — the surfaces Claude Design edits)
+
+| Component | Mirrors (in `botsite/`) |
+|---|---|
+| `LandingPage` | the whole `index.html` homepage |
+| `FeaturesPage` | `/features` — searchable, category-jump pills, feature grid |
+| `CommandsPage` | `/commands` — searchable, filter pills, expandable command list |
+| `ChangelogPage` | `/changelog` — date-grouped "what's new" timeline |
+| `StatusPage` | `/status` — build trust card + "what's in the box" counts |
+
+Each page is composed inside `PageShell` (with `SiteHeader` + `SiteFooter`), so **the whole site** — not just one page — is editable in Claude Design, every region mapping back to source.
 
 ## Editing the site — the hybrid loop (Claude Design ⇄ Claude Code)
 
-The whole landing page is now real components (`LandingPage` composes them), so on the
-Claude Design canvas you can select and edit **any** region — hero, nav, sections — and it
-maps to source. The error *"Can't save this edit — element isn't from project source"*
+Every page is now real components (`LandingPage`, `FeaturesPage`, `CommandsPage`,
+`ChangelogPage`, `StatusPage`), so on the Claude Design canvas you can select and edit **any**
+region of **any** page — hero, nav, cards, sections — and it maps to source. The error *"Can't save this edit — element isn't from project source"*
 appears when you edit something that *isn't* a synced component; composing pages from these
 parts is what avoids it. Roles:
 

--- a/design-system/src/ChangelogEntry.stories.tsx
+++ b/design-system/src/ChangelogEntry.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ChangelogEntry } from "./ChangelogEntry";
+
+const meta: Meta<typeof ChangelogEntry> = {
+  title: "Sections/ChangelogEntry",
+  component: ChangelogEntry,
+};
+export default meta;
+
+type Story = StoryObj<typeof ChangelogEntry>;
+
+export const New: Story = {
+  args: {
+    kind: "feature",
+    title: "New games hub",
+    summary: "All the games in one place.",
+  },
+};
+export const Fixed: Story = {
+  args: { kind: "fix", title: "Fixed the submit button", url: "#" },
+};

--- a/design-system/src/ChangelogEntry.tsx
+++ b/design-system/src/ChangelogEntry.tsx
@@ -1,0 +1,71 @@
+import * as React from "react";
+
+export type ChangelogKind = "feature" | "improvement" | "fix" | "update";
+
+export interface ChangelogEntryProps {
+  /** Change kind — drives the colored label. Unknown/empty → "Update". */
+  kind?: ChangelogKind;
+  /** Entry title. */
+  title: string;
+  /** Optional one/two-line summary. */
+  summary?: string;
+  /** Optional outbound link (e.g. a release) — renders a "Details →" link. */
+  url?: string;
+}
+
+const KIND_STYLES: Record<ChangelogKind, { label: string; ring: string }> = {
+  feature: {
+    label: "New",
+    ring: "bg-emerald-500/15 text-emerald-300 ring-emerald-500/30",
+  },
+  improvement: {
+    label: "Improved",
+    ring: "bg-sky-500/15 text-sky-300 ring-sky-500/30",
+  },
+  fix: {
+    label: "Fixed",
+    ring: "bg-amber-500/15 text-amber-300 ring-amber-500/30",
+  },
+  update: {
+    label: "Update",
+    ring: "bg-slate-700/40 text-slate-300 ring-slate-600/40",
+  },
+};
+
+/**
+ * One entry in the `/changelog` timeline — a colored kind label ("New" /
+ * "Improved" / "Fixed" / "Update"), a title, an optional summary, and an
+ * optional "Details" link. Mirrors `botsite/templates/changelog.html`.
+ */
+export function ChangelogEntry({
+  kind = "update",
+  title,
+  summary,
+  url,
+}: ChangelogEntryProps) {
+  const style = KIND_STYLES[kind] ?? KIND_STYLES.update;
+  return (
+    <article className="rounded-xl border border-slate-800 bg-slate-900/40 p-5">
+      <div className="flex flex-wrap items-center gap-3">
+        <span
+          className={`rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ${style.ring}`}
+        >
+          {style.label}
+        </span>
+        <h3 className="font-semibold text-slate-100">{title}</h3>
+      </div>
+      {summary ? (
+        <p className="mt-2 text-sm text-slate-300">{summary}</p>
+      ) : null}
+      {url ? (
+        <a
+          href={url}
+          rel="noopener"
+          className="mt-3 inline-flex items-center gap-1 text-sm text-sky-400 hover:text-sky-300"
+        >
+          Details →
+        </a>
+      ) : null}
+    </article>
+  );
+}

--- a/design-system/src/ChangelogPage.stories.tsx
+++ b/design-system/src/ChangelogPage.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ChangelogPage } from "./ChangelogPage";
+
+const meta: Meta<typeof ChangelogPage> = {
+  title: "Pages/ChangelogPage",
+  component: ChangelogPage,
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+
+type Story = StoryObj<typeof ChangelogPage>;
+
+export const Default: Story = {
+  args: { build: { commit: "1f26d13", committedAt: "2026-06-20" } },
+};

--- a/design-system/src/ChangelogPage.tsx
+++ b/design-system/src/ChangelogPage.tsx
@@ -1,0 +1,121 @@
+import * as React from "react";
+
+import { ChangelogEntry, type ChangelogEntryProps } from "./ChangelogEntry";
+import { PageHeader } from "./PageHeader";
+import { PageShell } from "./PageShell";
+import { SiteFooter, type BuildMeta } from "./SiteFooter";
+import { SiteHeader } from "./SiteHeader";
+
+export interface ChangelogItem extends ChangelogEntryProps {
+  /** Date string — entries are grouped by date, newest first. */
+  date: string;
+}
+
+export interface ChangelogPageProps {
+  /** The "Add to Discord" install URL. */
+  addUrl?: string;
+  /** Changelog entries, newest first. */
+  entries?: ChangelogItem[];
+  /** Deployed-build metadata for the footer/header. */
+  build?: BuildMeta;
+}
+
+// Sample defaults so the page renders standalone in Storybook / on the canvas.
+const DEFAULT_ENTRIES: ChangelogItem[] = [
+  {
+    date: "2026-06-20",
+    kind: "feature",
+    title: "The whole site is now editable as real components",
+    summary: "Every page is a source-backed component you can redesign visually.",
+  },
+  {
+    date: "2026-06-20",
+    kind: "improvement",
+    title: "Faster command search",
+    summary: "Client-side filtering on the commands page is now instant.",
+  },
+  {
+    date: "2026-06-18",
+    kind: "fix",
+    title: "Fixed the broken feedback button",
+    summary: "The submit form works again.",
+  },
+];
+
+/**
+ * The full `/changelog` page — a curated, newest-first timeline grouped by date,
+ * each day listing {@link ChangelogEntry} items. Mirrors
+ * `botsite/templates/changelog.html`. Renders standalone with sample data.
+ */
+export function ChangelogPage({
+  addUrl = "#",
+  entries = DEFAULT_ENTRIES,
+  build,
+}: ChangelogPageProps) {
+  // Group consecutive entries by date, preserving order (newest first).
+  const groups: { date: string; items: ChangelogItem[] }[] = [];
+  for (const entry of entries) {
+    const last = groups[groups.length - 1];
+    if (last && last.date === entry.date) {
+      last.items.push(entry);
+    } else {
+      groups.push({ date: entry.date, items: [entry] });
+    }
+  }
+  return (
+    <PageShell
+      header={
+        <SiteHeader
+          active="changelog"
+          addUrl={addUrl}
+          hasBuild={Boolean(build?.commit)}
+        />
+      }
+      footer={<SiteFooter build={build} />}
+    >
+      <PageHeader
+        bordered
+        title="What's new"
+        badge={{
+          label: "generated",
+          title:
+            "Curated from the bot's changelog as of the last deploy — not a live feed.",
+        }}
+        subtitle="New features, fixes and improvements you can feel — the changes that actually reach your server. Hand-curated, newest first."
+      />
+      {groups.length > 0 ? (
+        <div className="space-y-10">
+          {groups.map((group) => (
+            <section key={group.date} className="relative">
+              <div className="mb-4 flex items-center gap-3">
+                <span className="h-2.5 w-2.5 rounded-full bg-indigo-500 ring-4 ring-indigo-500/15" />
+                <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-400">
+                  <time dateTime={group.date}>{group.date}</time>
+                </h2>
+              </div>
+              <div className="ml-[5px] space-y-4 border-l border-slate-800 pl-6">
+                {group.items.map((item, i) => (
+                  <ChangelogEntry
+                    key={i}
+                    kind={item.kind}
+                    title={item.title}
+                    summary={item.summary}
+                    url={item.url}
+                  />
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-xl border border-slate-800 bg-slate-900/40 p-8 text-center">
+          <p className="text-slate-300">No changelog entries yet.</p>
+          <p className="mt-2 text-sm text-slate-500">
+            Check back soon — new features and fixes will show up here as they
+            ship.
+          </p>
+        </div>
+      )}
+    </PageShell>
+  );
+}

--- a/design-system/src/CommandDetail.stories.tsx
+++ b/design-system/src/CommandDetail.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { CommandDetail } from "./CommandDetail";
+
+const meta: Meta<typeof CommandDetail> = {
+  title: "Sections/CommandDetail",
+  component: CommandDetail,
+};
+export default meta;
+
+type Story = StoryObj<typeof CommandDetail>;
+
+export const Default: Story = {
+  args: {
+    command: {
+      name: "blackjack",
+      description: "Start a game of blackjack against the bot.",
+      useCases: ["Have fun", "Wager points"],
+      aliases: ["bj"],
+      permissions: "anyone",
+      examples: ["!blackjack 100"],
+      plannedIdeas: [{ status: "planned", title: "Multiplayer tables" }],
+    },
+  },
+};

--- a/design-system/src/CommandDetail.tsx
+++ b/design-system/src/CommandDetail.tsx
@@ -1,0 +1,160 @@
+import * as React from "react";
+
+export interface PlannedIdea {
+  /** Short status label (e.g. "planned"). */
+  status: string;
+  /** The idea title. */
+  title: string;
+}
+
+export interface CommandRecord {
+  /** Command name, rendered as `!name`. */
+  name: string;
+  /** One-line usage/summary. */
+  usage?: string;
+  /** Maturity — drives the status badge. */
+  status?: "finished" | "in-progress";
+  /** Full description (first paragraph). */
+  description?: string;
+  /** What the command is good for. */
+  useCases?: string[];
+  /** Alternate invocations. */
+  aliases?: string[];
+  /** Who may run it (defaults to "anyone"). */
+  permissions?: string;
+  /** Cooldown text, or null/undefined when none. */
+  cooldown?: string | null;
+  /** Real `!command …` example invocations. */
+  examples?: string[];
+  /** Curated note. */
+  notes?: string;
+  /** "What's planned" teasers. */
+  plannedIdeas?: PlannedIdea[];
+}
+
+function DetailSection({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-1 text-xs uppercase tracking-wide text-slate-500">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * The expanded body of a command on `/commands` — description, use-cases, the
+ * aliases / permissions / cooldown grid, examples, notes, and "what's planned".
+ * Mirrors `botsite/templates/_command_detail.html`; every field degrades to a
+ * friendly omission. Pair with {@link CommandEntry} for the clickable card.
+ */
+export function CommandDetail({ command }: { command: CommandRecord }) {
+  const {
+    description,
+    usage,
+    useCases,
+    aliases,
+    permissions,
+    cooldown,
+    examples,
+    notes,
+    plannedIdeas,
+  } = command;
+  return (
+    <div className="mt-3 space-y-3 text-sm">
+      {description ? (
+        <p className="text-slate-300">{description}</p>
+      ) : usage ? (
+        <p className="text-slate-300">{usage}</p>
+      ) : null}
+
+      {useCases && useCases.length > 0 ? (
+        <DetailSection label="Use cases">
+          <ul className="list-inside list-disc space-y-0.5 text-slate-300">
+            {useCases.map((uc, i) => (
+              <li key={i}>{uc}</li>
+            ))}
+          </ul>
+        </DetailSection>
+      ) : null}
+
+      <dl className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-slate-500">
+            Aliases
+          </dt>
+          <dd className="mt-0.5">
+            {aliases && aliases.length > 0 ? (
+              <span className="flex flex-wrap gap-1">
+                {aliases.map((alias) => (
+                  <code
+                    key={alias}
+                    className="rounded bg-slate-800 px-1.5 py-0.5 text-xs text-sky-300"
+                  >
+                    !{alias}
+                  </code>
+                ))}
+              </span>
+            ) : (
+              <span className="text-slate-500">none</span>
+            )}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-slate-500">
+            Permissions
+          </dt>
+          <dd className="mt-0.5 text-slate-300">{permissions ?? "anyone"}</dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-slate-500">
+            Cooldown
+          </dt>
+          <dd className="mt-0.5 text-slate-300">{cooldown ?? "—"}</dd>
+        </div>
+      </dl>
+
+      {examples && examples.length > 0 ? (
+        <DetailSection label="Examples">
+          <ul className="space-y-1">
+            {examples.map((example, i) => (
+              <li key={i}>
+                <code className="rounded bg-slate-800 px-2 py-1 text-xs text-emerald-300">
+                  {example}
+                </code>
+              </li>
+            ))}
+          </ul>
+        </DetailSection>
+      ) : null}
+
+      {notes ? (
+        <DetailSection label="Notes">
+          <p className="text-slate-300">{notes}</p>
+        </DetailSection>
+      ) : null}
+
+      {plannedIdeas && plannedIdeas.length > 0 ? (
+        <DetailSection label="What's planned">
+          <ul className="space-y-1">
+            {plannedIdeas.map((idea, i) => (
+              <li key={i} className="flex items-start gap-2">
+                <span className="mt-0.5 shrink-0 rounded bg-violet-900/60 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-violet-300">
+                  {idea.status}
+                </span>
+                <span className="text-slate-300">{idea.title}</span>
+              </li>
+            ))}
+          </ul>
+        </DetailSection>
+      ) : null}
+    </div>
+  );
+}

--- a/design-system/src/CommandEntry.stories.tsx
+++ b/design-system/src/CommandEntry.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { CommandEntry } from "./CommandEntry";
+
+const meta: Meta<typeof CommandEntry> = {
+  title: "Sections/CommandEntry",
+  component: CommandEntry,
+};
+export default meta;
+
+type Story = StoryObj<typeof CommandEntry>;
+
+export const Collapsed: Story = {
+  args: {
+    command: {
+      name: "blackjack",
+      usage: "!blackjack <bet>",
+      status: "finished",
+      description: "Play blackjack against the bot.",
+      aliases: ["bj"],
+      examples: ["!blackjack 100"],
+    },
+  },
+};
+export const Expanded: Story = {
+  args: {
+    defaultOpen: true,
+    command: {
+      name: "automod",
+      usage: "!automod",
+      status: "in-progress",
+      description: "Configure automatic moderation rules.",
+      permissions: "admins",
+    },
+  },
+};

--- a/design-system/src/CommandEntry.tsx
+++ b/design-system/src/CommandEntry.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+
+import { Badge } from "./Badge";
+import { CommandDetail, type CommandRecord } from "./CommandDetail";
+
+export interface CommandEntryProps {
+  /** The command to render. */
+  command: CommandRecord;
+  /** Start expanded (defaults to collapsed). */
+  defaultOpen?: boolean;
+}
+
+/**
+ * A clickable command on `/commands`: a native `<details>` whose summary shows
+ * `!name`, a maturity badge and the one-line usage, expanding to the full
+ * {@link CommandDetail}. Uses `<details>` so it works without JavaScript, exactly
+ * like `botsite/templates/commands.html`.
+ */
+export function CommandEntry({
+  command,
+  defaultOpen = false,
+}: CommandEntryProps) {
+  const status = command.status ?? "finished";
+  return (
+    <details
+      open={defaultOpen}
+      className="group rounded-xl border border-slate-800 bg-slate-900/40 px-4 py-3 open:bg-slate-900/70"
+    >
+      <summary className="flex cursor-pointer list-none items-center gap-3">
+        <code className="font-semibold text-sky-300">!{command.name}</code>
+        <Badge tone={status}>{status}</Badge>
+        {command.usage ? (
+          <span className="hidden truncate text-sm text-slate-400 sm:inline">
+            {command.usage}
+          </span>
+        ) : null}
+        <span className="ml-auto text-xs text-slate-600 transition-transform group-open:rotate-90">
+          ▸
+        </span>
+      </summary>
+      <CommandDetail command={command} />
+    </details>
+  );
+}

--- a/design-system/src/CommandsPage.stories.tsx
+++ b/design-system/src/CommandsPage.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { CommandsPage } from "./CommandsPage";
+
+const meta: Meta<typeof CommandsPage> = {
+  title: "Pages/CommandsPage",
+  component: CommandsPage,
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+
+type Story = StoryObj<typeof CommandsPage>;
+
+export const Default: Story = {
+  args: { build: { commit: "1f26d13", committedAt: "2026-06-20" } },
+};

--- a/design-system/src/CommandsPage.tsx
+++ b/design-system/src/CommandsPage.tsx
@@ -1,0 +1,114 @@
+import * as React from "react";
+
+import type { CommandRecord } from "./CommandDetail";
+import { CommandEntry } from "./CommandEntry";
+import { PageHeader } from "./PageHeader";
+import { PageShell } from "./PageShell";
+import { Pill } from "./Pill";
+import { SearchBar } from "./SearchBar";
+import { SiteFooter, type BuildMeta } from "./SiteFooter";
+import { SiteHeader } from "./SiteHeader";
+
+export interface CommandCategoryGroup {
+  /** Category name (e.g. "games"). */
+  category: string;
+  /** Commands in this category. */
+  commands: CommandRecord[];
+}
+
+export interface CommandsPageProps {
+  /** The "Add to Discord" install URL. */
+  addUrl?: string;
+  /** Command categories to show. */
+  groups?: CommandCategoryGroup[];
+  /** Deployed-build metadata for the footer/header. */
+  build?: BuildMeta;
+}
+
+// Sample defaults so the page renders standalone in Storybook / on the canvas.
+const DEFAULT_GROUPS: CommandCategoryGroup[] = [
+  {
+    category: "games",
+    commands: [
+      {
+        name: "blackjack",
+        usage: "!blackjack <bet>",
+        status: "finished",
+        description: "Start a game of blackjack against the bot.",
+        aliases: ["bj"],
+        examples: ["!blackjack 100"],
+      },
+      {
+        name: "rps",
+        usage: "!rps @user",
+        status: "finished",
+        description: "Challenge a member to rock-paper-scissors.",
+        examples: ["!rps @friend"],
+      },
+    ],
+  },
+  {
+    category: "moderation",
+    commands: [
+      {
+        name: "warn",
+        usage: "!warn @user <reason>",
+        status: "finished",
+        description: "Issue a warning to a member.",
+        permissions: "moderators",
+        examples: ["!warn @user spamming"],
+      },
+      {
+        name: "automod",
+        usage: "!automod",
+        status: "in-progress",
+        description: "Configure automatic moderation rules.",
+        permissions: "admins",
+      },
+    ],
+  },
+];
+
+/**
+ * The full `/commands` reference page — searchable, category filter pills, and a
+ * list of expandable {@link CommandEntry} cards. Mirrors
+ * `botsite/templates/commands.html`. Renders standalone with sample data.
+ */
+export function CommandsPage({
+  addUrl = "#",
+  groups = DEFAULT_GROUPS,
+  build,
+}: CommandsPageProps) {
+  const all = groups.flatMap((g) => g.commands);
+  return (
+    <PageShell
+      header={
+        <SiteHeader
+          active="commands"
+          addUrl={addUrl}
+          hasBuild={Boolean(build?.commit)}
+        />
+      }
+      footer={<SiteFooter build={build} />}
+    >
+      <PageHeader
+        title="Commands"
+        subtitle={`${all.length} commands across ${groups.length} categories. Click any command for details — search or filter to find one fast.`}
+      />
+      <div className="mb-6 space-y-3">
+        <SearchBar placeholder="Search commands, aliases, descriptions…" />
+        <div className="flex flex-wrap gap-2">
+          <Pill active>All</Pill>
+          {groups.map((g) => (
+            <Pill key={g.category}>{g.category}</Pill>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-2">
+        {all.map((cmd) => (
+          <CommandEntry key={cmd.name} command={cmd} />
+        ))}
+      </div>
+    </PageShell>
+  );
+}

--- a/design-system/src/FeatureShowcaseCard.stories.tsx
+++ b/design-system/src/FeatureShowcaseCard.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { FeatureShowcaseCard } from "./FeatureShowcaseCard";
+
+const meta: Meta<typeof FeatureShowcaseCard> = {
+  title: "Sections/FeatureShowcaseCard",
+  component: FeatureShowcaseCard,
+};
+export default meta;
+
+type Story = StoryObj<typeof FeatureShowcaseCard>;
+
+export const Game: Story = {
+  args: {
+    emoji: "🃏",
+    name: "Blackjack",
+    description: "Play blackjack against the bot.",
+    tags: ["cards", "casino"],
+    isGame: true,
+  },
+};
+export const Plain: Story = {
+  args: {
+    emoji: "🛡️",
+    name: "Auto-moderation",
+    description: "Filter spam and unwanted content automatically.",
+    tags: ["safety"],
+  },
+};

--- a/design-system/src/FeatureShowcaseCard.tsx
+++ b/design-system/src/FeatureShowcaseCard.tsx
@@ -1,0 +1,68 @@
+import * as React from "react";
+
+import { Badge } from "./Badge";
+
+export interface FeatureShowcaseCardProps {
+  /** Leading emoji/icon. */
+  emoji?: string;
+  /** Feature display name. */
+  name: string;
+  /** One/two-line description. */
+  description?: string;
+  /** Short tag chips (first 4 shown). */
+  tags?: string[];
+  /** Show the fuchsia "game" badge. */
+  isGame?: boolean;
+  /** Deep-link to the related commands. */
+  commandsHref?: string;
+}
+
+/**
+ * A single feature card from the `/features` showcase — emoji, name, an optional
+ * "game" badge, description, tag chips, and a "See commands" link. Distinct from
+ * the homepage `FeatureCard`, which groups several features under one category.
+ * Mirrors the feature `<article>` in `botsite/templates/features.html`.
+ */
+export function FeatureShowcaseCard({
+  emoji = "•",
+  name,
+  description,
+  tags = [],
+  isGame = false,
+  commandsHref = "/commands#",
+}: FeatureShowcaseCardProps) {
+  return (
+    <article className="rounded-xl border border-slate-800 bg-slate-900/40 p-5 transition-colors hover:border-sky-700">
+      <div className="flex items-center gap-2">
+        <span className="text-2xl">{emoji}</span>
+        <h3 className="font-semibold">{name}</h3>
+        {isGame ? (
+          <span className="ml-auto">
+            <Badge tone="game">game</Badge>
+          </span>
+        ) : null}
+      </div>
+      {description ? (
+        <p className="mt-2 text-sm text-slate-400">{description}</p>
+      ) : null}
+      {tags.length > 0 ? (
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          {tags.slice(0, 4).map((tag) => (
+            <span
+              key={tag}
+              className="rounded bg-slate-800 px-1.5 py-0.5 text-[10px] text-slate-400"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      ) : null}
+      <a
+        href={commandsHref}
+        className="mt-3 inline-block text-xs text-sky-400 hover:text-sky-300"
+      >
+        See commands →
+      </a>
+    </article>
+  );
+}

--- a/design-system/src/FeaturesPage.stories.tsx
+++ b/design-system/src/FeaturesPage.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { FeaturesPage } from "./FeaturesPage";
+
+const meta: Meta<typeof FeaturesPage> = {
+  title: "Pages/FeaturesPage",
+  component: FeaturesPage,
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+
+type Story = StoryObj<typeof FeaturesPage>;
+
+export const Default: Story = {
+  args: { build: { commit: "1f26d13", committedAt: "2026-06-20" } },
+};

--- a/design-system/src/FeaturesPage.tsx
+++ b/design-system/src/FeaturesPage.tsx
@@ -1,0 +1,126 @@
+import * as React from "react";
+
+import {
+  FeatureShowcaseCard,
+  type FeatureShowcaseCardProps,
+} from "./FeatureShowcaseCard";
+import { PageHeader } from "./PageHeader";
+import { PageShell } from "./PageShell";
+import { Pill } from "./Pill";
+import { SearchBar } from "./SearchBar";
+import { SiteFooter, type BuildMeta } from "./SiteFooter";
+import { SiteHeader } from "./SiteHeader";
+
+export interface FeatureCategoryGroup {
+  /** Category name (e.g. "games"). */
+  category: string;
+  /** Features in this category. */
+  features: FeatureShowcaseCardProps[];
+}
+
+export interface FeaturesPageProps {
+  /** The "Add to Discord" install URL. */
+  addUrl?: string;
+  /** Feature categories to show. */
+  groups?: FeatureCategoryGroup[];
+  /** Deployed-build metadata for the footer/header. */
+  build?: BuildMeta;
+}
+
+// Sample defaults so the page renders standalone in Storybook / on the canvas.
+const DEFAULT_GROUPS: FeatureCategoryGroup[] = [
+  {
+    category: "games",
+    features: [
+      {
+        emoji: "🃏",
+        name: "Blackjack",
+        description: "Play blackjack against the bot.",
+        tags: ["cards", "casino"],
+        isGame: true,
+      },
+      {
+        emoji: "✊",
+        name: "Rock Paper Scissors",
+        description: "Challenge another member to a duel.",
+        tags: ["duel"],
+        isGame: true,
+      },
+    ],
+  },
+  {
+    category: "moderation",
+    features: [
+      {
+        emoji: "🛡️",
+        name: "Auto-moderation",
+        description: "Filter spam and unwanted content automatically.",
+        tags: ["safety"],
+      },
+      {
+        emoji: "⚠️",
+        name: "Warnings",
+        description: "Track and escalate member warnings.",
+        tags: ["audit"],
+      },
+    ],
+  },
+];
+
+/**
+ * The full `/features` showcase page — searchable, category-jump pills, and a
+ * grid of {@link FeatureShowcaseCard}s per category. Mirrors
+ * `botsite/templates/features.html`. Renders standalone with sample data.
+ */
+export function FeaturesPage({
+  addUrl = "#",
+  groups = DEFAULT_GROUPS,
+  build,
+}: FeaturesPageProps) {
+  const total = groups.reduce((n, g) => n + g.features.length, 0);
+  return (
+    <PageShell
+      header={
+        <SiteHeader
+          active="features"
+          addUrl={addUrl}
+          hasBuild={Boolean(build?.commit)}
+        />
+      }
+      footer={<SiteFooter build={build} />}
+    >
+      <PageHeader
+        title="Features"
+        subtitle={`${total} feature areas across ${groups.length} categories — games, moderation, AI, economy and more. Search or jump to a category.`}
+      />
+      <div className="mb-6 space-y-3">
+        <SearchBar placeholder="Search features…" />
+        <div className="flex flex-wrap gap-2">
+          {groups.map((g) => (
+            <Pill key={g.category} href={`#cat-${g.category}`}>
+              {g.category}
+            </Pill>
+          ))}
+        </div>
+      </div>
+      <div className="space-y-10">
+        {groups.map((g) => (
+          <section
+            key={g.category}
+            id={`cat-${g.category}`}
+            className="scroll-mt-24"
+          >
+            <h2 className="mb-4 text-lg font-semibold capitalize">
+              {g.category}
+            </h2>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {g.features.map((f) => (
+                <FeatureShowcaseCard key={f.name} {...f} />
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </PageShell>
+  );
+}

--- a/design-system/src/PageHeader.stories.tsx
+++ b/design-system/src/PageHeader.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { PageHeader } from "./PageHeader";
+
+const meta: Meta<typeof PageHeader> = {
+  title: "Layout/PageHeader",
+  component: PageHeader,
+};
+export default meta;
+
+type Story = StoryObj<typeof PageHeader>;
+
+export const Plain: Story = {
+  args: {
+    title: "Features",
+    subtitle: "36 feature areas across 8 categories — search or jump to one.",
+  },
+};
+export const Bordered: Story = {
+  args: {
+    bordered: true,
+    title: "What's new",
+    badge: { label: "generated", title: "As of the last deploy." },
+    subtitle: "New features, fixes and improvements. Hand-curated, newest first.",
+  },
+};

--- a/design-system/src/PageHeader.tsx
+++ b/design-system/src/PageHeader.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+
+export interface PageHeaderBadge {
+  /** Badge text (e.g. "generated"). */
+  label: string;
+  /** Tooltip explaining the badge. */
+  title?: string;
+}
+
+export interface PageHeaderProps {
+  /** The page title (h1). */
+  title: string;
+  /** Supporting copy beneath the title. */
+  subtitle?: React.ReactNode;
+  /**
+   * Bordered header style (Changelog / Status): a bottom rule + larger subtitle.
+   * Plain style (Features / Commands) when false.
+   */
+  bordered?: boolean;
+  /** Optional "generated"-style badge shown next to the title. */
+  badge?: PageHeaderBadge;
+}
+
+/**
+ * A page header mirroring the two `botsite/` styles: the plain title + muted
+ * subtitle used by `/features` and `/commands`, and the bordered variant (with
+ * an optional "generated" freshness badge) used by `/changelog` and `/status`.
+ */
+export function PageHeader({
+  title,
+  subtitle,
+  bordered = false,
+  badge,
+}: PageHeaderProps) {
+  if (bordered) {
+    return (
+      <section className="mb-8 border-b border-slate-800 pb-6">
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-3xl font-bold tracking-tight">{title}</h1>
+          {badge ? (
+            <span
+              className="rounded bg-slate-800 px-2 py-0.5 text-xs text-slate-400"
+              title={badge.title}
+            >
+              {badge.label}
+            </span>
+          ) : null}
+        </div>
+        {subtitle ? (
+          <p className="mt-3 max-w-2xl text-slate-300">{subtitle}</p>
+        ) : null}
+      </section>
+    );
+  }
+  return (
+    <section className="mb-8">
+      <h1 className="text-3xl font-bold">{title}</h1>
+      {subtitle ? <p className="mt-2 text-slate-400">{subtitle}</p> : null}
+    </section>
+  );
+}

--- a/design-system/src/Pill.stories.tsx
+++ b/design-system/src/Pill.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Pill } from "./Pill";
+
+const meta: Meta<typeof Pill> = {
+  title: "Components/Pill",
+  component: Pill,
+  args: { children: "games" },
+};
+export default meta;
+
+type Story = StoryObj<typeof Pill>;
+
+export const Inactive: Story = {};
+export const Active: Story = { args: { active: true, children: "All" } };
+export const AsLink: Story = { args: { href: "#cat-games", children: "games" } };

--- a/design-system/src/Pill.tsx
+++ b/design-system/src/Pill.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+
+export interface PillProps {
+  /** Active (selected) styling — the highlighted filter. */
+  active?: boolean;
+  /** Render as a link to this href (a jump/anchor pill) instead of a button. */
+  href?: string;
+  /** Click handler when rendered as a button. */
+  onClick?: () => void;
+  children: React.ReactNode;
+}
+
+const BASE = "rounded-full px-3 py-1 text-xs font-medium";
+const ACTIVE = "border border-sky-600 bg-sky-600/20 text-sky-300";
+const INACTIVE =
+  "border border-slate-700 text-slate-300 hover:border-slate-500";
+
+/**
+ * A rounded filter / jump chip. `/features` uses anchor pills (category jump
+ * links); `/commands` uses button pills with an active state. Mirrors both.
+ */
+export function Pill({ active = false, href, onClick, children }: PillProps) {
+  const cls = `${BASE} ${active ? ACTIVE : INACTIVE}`;
+  return href ? (
+    <a href={href} className={cls}>
+      {children}
+    </a>
+  ) : (
+    <button type="button" className={cls} onClick={onClick}>
+      {children}
+    </button>
+  );
+}

--- a/design-system/src/SearchBar.stories.tsx
+++ b/design-system/src/SearchBar.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { SearchBar } from "./SearchBar";
+
+const meta: Meta<typeof SearchBar> = {
+  title: "Components/SearchBar",
+  component: SearchBar,
+  args: { placeholder: "Search features…" },
+};
+export default meta;
+
+type Story = StoryObj<typeof SearchBar>;
+
+export const Default: Story = {};

--- a/design-system/src/SearchBar.tsx
+++ b/design-system/src/SearchBar.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+export type SearchBarProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+/**
+ * The full-width search input used on `/features` and `/commands` (the
+ * client-side filter box). Visual only here — the live site layers the filter
+ * script on top. Mirrors the `<input type="search">` in those templates.
+ */
+export function SearchBar({
+  placeholder = "Search…",
+  className = "",
+  ...props
+}: SearchBarProps) {
+  return (
+    <input
+      type="search"
+      autoComplete="off"
+      placeholder={placeholder}
+      className={`w-full rounded-lg border border-slate-700 bg-slate-900 px-4 py-2.5 text-sm placeholder-slate-500 focus:border-sky-500 focus:outline-none ${className}`}
+      {...props}
+    />
+  );
+}

--- a/design-system/src/StatusCard.stories.tsx
+++ b/design-system/src/StatusCard.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { StatusCard } from "./StatusCard";
+
+const meta: Meta<typeof StatusCard> = {
+  title: "Sections/StatusCard",
+  component: StatusCard,
+};
+export default meta;
+
+type Story = StoryObj<typeof StatusCard>;
+
+export const Online: Story = {
+  args: {
+    build: {
+      commit: "1f26d13",
+      committedAt: "2026-06-20",
+      subject: "compose the full site",
+    },
+  },
+};
+export const Unavailable: Story = { args: { build: undefined } };

--- a/design-system/src/StatusCard.tsx
+++ b/design-system/src/StatusCard.tsx
@@ -1,0 +1,87 @@
+import * as React from "react";
+
+export interface StatusBuild {
+  /** Deployed commit SHA. */
+  commit?: string;
+  /** Commit date. */
+  committedAt?: string;
+  /** Latest change subject line. */
+  subject?: string;
+}
+
+export interface StatusCardProps {
+  /** Deployed-build metadata. Absent ⇒ "Status unavailable". */
+  build?: StatusBuild;
+}
+
+function Field({
+  label,
+  wide,
+  children,
+}: {
+  label: string;
+  wide?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={`rounded-lg border border-slate-800 bg-slate-950/40 p-4 ${
+        wide ? "sm:col-span-2" : ""
+      }`}
+    >
+      <dt className="text-slate-500">{label}</dt>
+      <dd className="mt-1 text-slate-100">{children}</dd>
+    </div>
+  );
+}
+
+/**
+ * The `/status` "online as of last deploy" card — an honest, build-time trust
+ * signal (never a live claim): a status dot, the deployed build SHA, its date,
+ * and the latest change. Mirrors `botsite/templates/status.html`.
+ */
+export function StatusCard({ build }: StatusCardProps) {
+  const hasBuild = Boolean(build?.commit);
+  return (
+    <section className="rounded-xl border border-slate-800 bg-slate-900/50 p-6">
+      <div className="flex items-center gap-3">
+        <span
+          className={`inline-block h-3 w-3 rounded-full ${
+            hasBuild ? "bg-emerald-500" : "bg-slate-500"
+          }`}
+        />
+        <span className="text-lg font-semibold">
+          {hasBuild ? "Online as of the last deploy" : "Status unavailable"}
+        </span>
+      </div>
+      {hasBuild ? (
+        <>
+          <dl className="mt-5 grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
+            <Field label="Build">
+              <span className="font-mono">{build?.commit}</span>
+            </Field>
+            {build?.committedAt ? (
+              <Field label="Deployed build date">
+                <time dateTime={build.committedAt}>{build.committedAt}</time>
+              </Field>
+            ) : null}
+            {build?.subject ? (
+              <Field label="Latest change" wide>
+                <span className="text-slate-200">{build.subject}</span>
+              </Field>
+            ) : null}
+          </dl>
+          <p className="mt-4 text-xs text-slate-500">
+            Build identifiers are public (they match the open-source repository).
+            This is a generated snapshot — for a live health check we'd label it
+            "live".
+          </p>
+        </>
+      ) : (
+        <p className="mt-4 text-sm text-slate-400">
+          Build information isn't available right now. Please check back shortly.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/design-system/src/StatusPage.stories.tsx
+++ b/design-system/src/StatusPage.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { StatusPage } from "./StatusPage";
+
+const meta: Meta<typeof StatusPage> = {
+  title: "Pages/StatusPage",
+  component: StatusPage,
+  parameters: { layout: "fullscreen" },
+};
+export default meta;
+
+type Story = StoryObj<typeof StatusPage>;
+
+export const Default: Story = {};

--- a/design-system/src/StatusPage.tsx
+++ b/design-system/src/StatusPage.tsx
@@ -1,0 +1,87 @@
+import * as React from "react";
+
+import { PageHeader } from "./PageHeader";
+import { PageShell } from "./PageShell";
+import { SiteFooter } from "./SiteFooter";
+import { SiteHeader } from "./SiteHeader";
+import { StatusCard, type StatusBuild } from "./StatusCard";
+
+export interface StatusCounts {
+  commands: number;
+  features: number;
+  games: number;
+}
+
+export interface StatusPageProps {
+  /** The "Add to Discord" install URL. */
+  addUrl?: string;
+  /** Deployed-build metadata. */
+  build?: StatusBuild;
+  /** Honest catalogue counts for the "what's in the box" band. */
+  counts?: StatusCounts;
+}
+
+// Sample defaults so the page renders standalone in Storybook / on the canvas.
+const DEFAULT_BUILD: StatusBuild = {
+  commit: "1f26d13",
+  committedAt: "2026-06-20",
+  subject: "design-system: compose the full site",
+};
+
+const DEFAULT_COUNTS: StatusCounts = { commands: 308, features: 36, games: 8 };
+
+/**
+ * The full `/status` page — the honest "online as of last deploy" build card
+ * ({@link StatusCard}) plus a "what's in the box" catalogue-counts band. Mirrors
+ * `botsite/templates/status.html` (a build-time snapshot, never a live claim).
+ */
+export function StatusPage({
+  addUrl = "#",
+  build = DEFAULT_BUILD,
+  counts = DEFAULT_COUNTS,
+}: StatusPageProps) {
+  const bands: [number, string][] = [
+    [counts.commands, "commands"],
+    [counts.features, "feature areas"],
+    [counts.games, "games"],
+  ];
+  return (
+    <PageShell
+      header={
+        <SiteHeader
+          active="status"
+          addUrl={addUrl}
+          hasBuild={Boolean(build?.commit)}
+        />
+      }
+      footer={<SiteFooter build={build} />}
+    >
+      <PageHeader
+        bordered
+        title="Status"
+        badge={{
+          label: "generated",
+          title: "Reflects the last deploy, not a live health check.",
+        }}
+        subtitle="What's running right now, as of the last deploy. This page is a build-time snapshot — it doesn't poll the bot live."
+      />
+      <StatusCard build={build} />
+      <section className="mt-8">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-400">
+          What's in the box
+        </h2>
+        <div className="grid max-w-2xl grid-cols-3 gap-4">
+          {bands.map(([value, label]) => (
+            <div
+              key={label}
+              className="rounded-xl border border-slate-800 bg-slate-900/40 p-5 text-center"
+            >
+              <div className="text-3xl font-bold">{value}</div>
+              <div className="text-sm text-slate-400">{label}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </PageShell>
+  );
+}

--- a/design-system/src/index.ts
+++ b/design-system/src/index.ts
@@ -44,10 +44,46 @@ export type { StepCardProps } from "./StepCard";
 export { CapabilityBand } from "./CapabilityBand";
 export type { CapabilityBandProps, CapabilityStat } from "./CapabilityBand";
 
-// ── Page composition (the canonical surface Claude Design edits) ─────────────
+export { PageHeader } from "./PageHeader";
+export type { PageHeaderProps, PageHeaderBadge } from "./PageHeader";
+
+export { SearchBar } from "./SearchBar";
+export type { SearchBarProps } from "./SearchBar";
+
+export { Pill } from "./Pill";
+export type { PillProps } from "./Pill";
+
+export { FeatureShowcaseCard } from "./FeatureShowcaseCard";
+export type { FeatureShowcaseCardProps } from "./FeatureShowcaseCard";
+
+export { CommandDetail } from "./CommandDetail";
+export type { CommandRecord, PlannedIdea } from "./CommandDetail";
+
+export { CommandEntry } from "./CommandEntry";
+export type { CommandEntryProps } from "./CommandEntry";
+
+export { ChangelogEntry } from "./ChangelogEntry";
+export type { ChangelogEntryProps, ChangelogKind } from "./ChangelogEntry";
+
+export { StatusCard } from "./StatusCard";
+export type { StatusCardProps, StatusBuild } from "./StatusCard";
+
+// ── Page compositions (the per-route surfaces Claude Design edits) ───────────
 export { LandingPage } from "./LandingPage";
 export type {
   LandingPageProps,
   FeatureCategory,
   HowItWorksStep,
 } from "./LandingPage";
+
+export { FeaturesPage } from "./FeaturesPage";
+export type { FeaturesPageProps, FeatureCategoryGroup } from "./FeaturesPage";
+
+export { CommandsPage } from "./CommandsPage";
+export type { CommandsPageProps, CommandCategoryGroup } from "./CommandsPage";
+
+export { ChangelogPage } from "./ChangelogPage";
+export type { ChangelogPageProps, ChangelogItem } from "./ChangelogPage";
+
+export { StatusPage } from "./StatusPage";
+export type { StatusPageProps, StatusCounts } from "./StatusPage";

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,14 +25,16 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/design-system-connector-docs` · **design-system docs: connector-vs-`/design-sync`
-  correction** (owner-directed 2026-06-20 — owner uses the GitHub connector, not `/design-sync`) ·
-  `design-system/README.md` (connector as primary path) · `docs/AGENT_ORIENTATION.md` (new
-  website/design-system route) · `.github/workflows/design-system-ci.yml` (comment) · 2026-06-20 ·
-  **auto-merge on green** (docs-only)
+- `claude/design-system-site-pages` · **design-system: compose the rest of the site** (owner-chosen
+  meantime build 2026-06-20 — make every route editable in Claude Design) · `design-system/src/`
+  (`PageHeader`/`SearchBar`/`Pill`/`FeatureShowcaseCard`/`CommandDetail`/`CommandEntry`/
+  `ChangelogEntry`/`StatusCard` + `FeaturesPage`/`CommandsPage`/`ChangelogPage`/`StatusPage` +
+  stories) · `design-system/README.md` · 2026-06-20 · **auto-merge on green** (additive · verified)
 
 ## Recently cleared
 
+- `claude/design-system-connector-docs` · design-system docs — GitHub-connector workflow + new
+  AGENT_ORIENTATION website route · 2026-06-20 · **PR #1176 (merged)**
 - `claude/magical-cori-t36l2n` · design-system full landing-page composition + hybrid edit loop +
   JS CI leg · 2026-06-20 · **PR #1175 (merged)**
 - `claude/youthful-turing-odgvq6` · design-system component library (6 components) · 2026-06-20 ·


### PR DESCRIPTION
## Why

Follow-up to #1175 (landing page) + #1176 (connector docs). The owner is re-syncing the repo into a fresh Claude Design project and asked to make the **whole site** editable, not just the landing page. This composes the remaining `botsite/` routes as real, source-backed components.

## What

New components, mirrored class-for-class from `botsite/templates/*.html` (audited against the real templates):

- **Building blocks:** `PageHeader` (plain + bordered/"generated"), `SearchBar`, `Pill` (active + link/button), `FeatureShowcaseCard`, `CommandDetail` + `CommandEntry` (native `<details>`, works JS-free), `ChangelogEntry`, `StatusCard`.
- **Full page compositions** (each inside `PageShell` with header/footer, sample-data defaults): **`FeaturesPage`**, **`CommandsPage`**, **`ChangelogPage`**, **`StatusPage`** — joining `LandingPage`.
- A Storybook story per new component + page; `index.ts` exports + README updated (new Sections group + a Pages group).

All five public routes are now real components → Claude Design can edit the whole site, every region mapping back to source. Additive + isolated; production stays Jinja (`botsite/`), ported back by Claude Code.

## Verification

`npm run typecheck` (clean) + `npm run build` (green) in-container; `dist/index.d.ts` 10 KB → 19.4 KB. `design-system-ci` re-runs via the path filter.

## Note

A fidelity audit found the existing landing-page components match `botsite/` exactly except three cosmetic button drifts (hero secondary weight, bottom-CTA size, primary `text-white`) — recorded in the session log, deferred (the owner is restyling on the canvas anyway).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us471wswNwKLxVxdn4JLS4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Us471wswNwKLxVxdn4JLS4)_