### PR TITLE
docs: Pokétwo + MusicBot research report → feature-mapping plan

### DIFF
--- a/.sessions/2026-06-20-poketwo-musicbot-feature-plan.md
+++ b/.sessions/2026-06-20-poketwo-musicbot-feature-plan.md
@@ -1,27 +1,115 @@
 # 2026-06-20 — Pokétwo + MusicBot research report → feature mapping plan
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Arc
 
 Owner uploaded a research report on **Pokétwo** (Pokémon catching bot) and **JMusicBot**
 (music bot) and asked: *"review this … create a plan so we can implement as much of these
-features in a proper way."* Owner steered this session to **plan only, build nothing yet**
-(answered in-session), and for the music half **architecture-review pack only** (respect the
-Q-0041 voice gate, don't build playback).
+features in a proper way."* Owner steered this session (in-session `AskUserQuestion`):
+**plan only, build nothing yet**; music half = **architecture-review pack only** (respect the
+Q-0041 voice gate, don't build playback). Docs-only; no runtime (`disbot/`) code.
 
-Deliverable: a docs-only feature-mapping plan + the music architecture-review pack + routing
-of the gated owner decisions. No runtime (`disbot/`) code this session.
+## Shipped (PR #1180, docs-only)
 
-## Plan (what this PR adds)
+- **`docs/planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md`** — the report→repo
+  mapping. Core finding: **most Pokétwo mechanics already have a lane here** (catching =
+  fishing/mining/pets; trading = the economy-marketplace roadmap; "one world" = the federated
+  Explore hub), so the job is *extend + dock*, not clone. Every report feature classified
+  EXTEND / BUILD / GATED / REJECTED / HAVE. Four net-new ungated anti-P2W lanes spec'd as
+  PR-sized work: **A) Wild Encounters** (activity spawning — the one mechanic with *no* analog),
+  **B) collection & filtering** (extend fishing/inventory), **C) quest/achievement** foundation
+  (Q-0182-aware), **D) shiny/rare-variant** layer (cosmetic, not power). Anti-patterns section
+  pins the standing decisions: no premium currency (Q-0039), no standalone marketplace (its own
+  gate), no music now (Q-0041).
+- **`docs/planning/voice-music-architecture-review-2026-06-20.md`** — the Q-0041-required
+  voice/music decision pack: legal lane first (L1 self-host risk / L2 licensed-safe / L3 defer —
+  the report's own DMCA history makes this decisive), infra reality (FFmpeg/Opus/±Lavalink, a
+  second always-on service the repo has never needed), where a music subsystem lands on existing
+  seams (control surface fits cleanly; audio transport is the new costly/risky part), speech-rec
+  stays last. Ends with the ordered go/no-go decision that feeds Q-0041.
+- **`docs/ideas/wild-encounters-activity-spawning-2026-06-20.md`** + README index entry — capture
+  of the signature net-new mechanic.
+- **Router Q-0186** — DISCUSS: which net-new lane to build first + wild-encounter spawn design +
+  guardrail confirmation. The music pack feeds existing **Q-0041** (no new music Q-block — avoided
+  duplicating).
+- Homed both plans in `docs/planning/README.md` (S1 + S5); claim in `active-work.md`.
 
-- `docs/planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md` — the report → repo
-  mapping (every feature classified: extend-existing / buildable-now / owner-gated / rejected),
-  with PR-sized specs for the net-new buildable lanes.
-- `docs/planning/voice-music-architecture-review-2026-06-20.md` — the Q-0041-required
-  voice/music decision pack (legal · infra · architecture fit · permissions · cost).
-- `docs/ideas/wild-encounters-activity-spawning-2026-06-20.md` — capture of the signature
-  net-new mechanic (no existing analog) + README index entry.
-- Router: Q-0186 (Pokétwo build-sequencing DISCUSS) appended; the music pack feeds existing Q-0041.
+Verification: `check_docs.py --strict` ✓ · `check_plan_homing.py` ✓ (38/38 homed). No `disbot/`
+code, so no mypy/pytest scope touched.
 
-(In-progress; flipped to `complete` as the final step.)
+## Context delta (Q-0102 self-audit input)
+
+- **Needed and pointed to well:** the `world_registry`/federated-hub plan, the
+  economy-marketplace roadmap, and the Q-0039/Q-0041 router entries were all exactly where the
+  orientation route said — the mapping wrote itself once those were read.
+- **Needed but had to discover:** that **activity-based spawning has no analog anywhere** — only
+  confirmed by a broad source sweep (two Explore agents), not by any single doc. Worth a one-line
+  "what the bot does NOT have" inventory somewhere durable (see session idea).
+- **Pointed to but didn't need:** the giant `current-state.md` ▶ Next-action paragraph — irrelevant
+  to a report-mapping task; the *grep-for-the-live-sentence* cost is the same scaling smell the
+  previous session flagged.
+
+## Decisions made alone
+
+- **No separate music Q-block** — routed the music decision into the *existing* Q-0041 (the voice
+  gate it already owns) via the arch-review pack, rather than minting a duplicate. Reversible.
+- **Recommended Lane A first** in Q-0186 (didn't pre-decide it) — engagement leverage + it feeds
+  B/C/D; left the call to the owner-designer.
+
+## Flagged for maintainer
+
+- **Q-0186** — which net-new Pokétwo lane to build first + wild-encounter spawn defaults + confirm
+  the anti-P2W/anti-spam guardrails. Nothing builds until answered.
+- **Q-0041 (music)** — the arch-review pack is ready; owner makes the go/no-go + legal-lane (L1/L2/
+  L3) call to lift the voice gate.
+
+## 💡 Session idea (Q-0089)
+
+**A durable "what the bot does NOT have" capabilities-gap inventory.** This session's highest-value
+finding — that activity-based spawning, player-to-player trading, and quests have *no* code analog —
+took two fan-out Explore agents to establish, because the repo documents what *exists* exhaustively
+but never what's *absent*. A short, curated `docs/subsystems/capability-gaps.md` (or a section in the
+games folio) listing "deliberately-absent / greenfield" mechanics would let a future feature-mapping
+or competitive-analysis task answer "do we already have X?" without a full source sweep. Genuinely
+useful, low-maintenance (only changes when a gap is filled); lane = docs/orientation. (Not built this
+run — kept the PR single-purpose; clean grooming candidate.)
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous run (`arch-ratchet-cog-layer`, #1163) extended the `baseview_inheritance` arch ratchet
+to the cog layer — a genuinely good parity fix (the arch checker now matches the consistency linter's
+cog scope) and it correctly *routed* the broader residence-guard decision instead of building it
+unilaterally. **What it could've done better:** its own Q-0102 note already nailed the issue — the
+`current-state.md` ▶ Next-action paragraph has grown to ~30KB on one logical line and the *live*
+sentence is hard to find. I hit the exact same friction this run. **System improvement it surfaces
+(and I second):** a future reconciliation pass should *physically truncate* the historical band-tail
+out of ▶ Next action into the band pass-record docs it already links — the "trust THIS sentence,
+never a lower ▶" convention is holding, but it's compensating for a layout problem that a 5-minute
+trim would remove. Two consecutive sessions flagging the same ergonomics smell is the signal to act.
+
+## 📤 Run report
+
+- **Did:** turned the owner's Pokétwo/JMusicBot research report into a feature-mapping plan +
+  music architecture-review pack; routed the build decisions · **Outcome:** shipped (docs-only)
+- **Shipped:** #1180 — feature-mapping plan · voice/music arch-review pack · wild-encounters idea ·
+  Q-0186
+- **Run type:** `manual · owner-task`
+- **⚑ Owner decisions needed:** Q-0186 (Pokétwo build sequence + spawn design) · Q-0041 (music
+  go/no-go + legal lane, now that the arch-review pack exists)
+- **⚑ Owner manual steps:** none
+- **⚑ Self-initiated:** none (owner-directed task; the wild-encounters idea + Q-0186 are *routed*,
+  not built — no idea→plan→build promotion this session)
+- **↪ Next:** owner answers Q-0186 → a runtime-verified session builds Lane A (Wild Encounters) in
+  small PRs; music waits on the Q-0041 decision
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs opened this session | 1 (#1180, docs-only, auto-merge armed on green) |
+| Runtime (`disbot/`) code changed | 0 (plan-only, per owner steer) |
+| CI-red rounds | 1 (by-design born-red session gate only) |
+| Docs added | 3 (2 plans + 1 idea) · 1 router Q-block · 4 index/claim edits |
+| New ideas contributed | 1 (capability-gaps inventory) |
+| Ideas groomed | 1 (wild-encounters captured + spec'd into Lane A) |

--- a/.sessions/2026-06-20-poketwo-musicbot-feature-plan.md
+++ b/.sessions/2026-06-20-poketwo-musicbot-feature-plan.md
@@ -1,0 +1,27 @@
+# 2026-06-20 — Pokétwo + MusicBot research report → feature mapping plan
+
+> **Status:** `in-progress`
+
+## Arc
+
+Owner uploaded a research report on **Pokétwo** (Pokémon catching bot) and **JMusicBot**
+(music bot) and asked: *"review this … create a plan so we can implement as much of these
+features in a proper way."* Owner steered this session to **plan only, build nothing yet**
+(answered in-session), and for the music half **architecture-review pack only** (respect the
+Q-0041 voice gate, don't build playback).
+
+Deliverable: a docs-only feature-mapping plan + the music architecture-review pack + routing
+of the gated owner decisions. No runtime (`disbot/`) code this session.
+
+## Plan (what this PR adds)
+
+- `docs/planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md` — the report → repo
+  mapping (every feature classified: extend-existing / buildable-now / owner-gated / rejected),
+  with PR-sized specs for the net-new buildable lanes.
+- `docs/planning/voice-music-architecture-review-2026-06-20.md` — the Q-0041-required
+  voice/music decision pack (legal · infra · architecture fit · permissions · cost).
+- `docs/ideas/wild-encounters-activity-spawning-2026-06-20.md` — capture of the signature
+  net-new mechanic (no existing analog) + README index entry.
+- Router: Q-0186 (Pokétwo build-sequencing DISCUSS) appended; the music pack feeds existing Q-0041.
+
+(In-progress; flipped to `complete` as the final step.)

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -86,6 +86,13 @@ Current broad captures:
   [`planning/explore-hub-federated-world-plan-2026-06-19`](../planning/explore-hub-federated-world-plan-2026-06-19.md)
   (ungated spine: top-level hub + world registry + global/per-game XP split; deferred layers routed as
   **Q-0182**). → relates `planning/{explore-hub-federated-world-plan,fishing-open-world-expansion,mining-hub-redesign,rpg-survival-difficulty-design}`.
+- [`wild-encounters-activity-spawning-2026-06-20.md`](./wild-encounters-activity-spawning-2026-06-20.md) —
+  **from the owner's Pokétwo/JMusicBot research report (2026-06-20):** activity-based **wild encounters** —
+  non-bot messages accrue a per-channel counter → the bot spawns a Claim-button encounter → first valid
+  claimer gets a reward routed through `economy`/`game_xp`/inventory. The **one Pokétwo mechanic with no
+  analog** (fishing/mining are command-only); net-new, ungated, anti-P2W, docks into the Explore world hub.
+  **SPEC'D → plan (Lane A):** [`planning/poketwo-musicbot-feature-mapping-plan-2026-06-20`](../planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md);
+  build sequence + spawn design routed as **Q-0186**. → relates `planning/{explore-hub-federated-world-plan,fishing-open-world-expansion}`.
 - [`plan-homing-guard-2026-06-19.md`](./plan-homing-guard-2026-06-19.md) — **SHIPPED 2026-06-20 (PR #1174).**
   **session idea (2026-06-19, Q-0089, from the planning-map cleanup):** a stdlib
   `scripts/check_plan_homing.py` asserting every non-`historical` `docs/planning/` doc is linked from a

--- a/docs/ideas/wild-encounters-activity-spawning-2026-06-20.md
+++ b/docs/ideas/wild-encounters-activity-spawning-2026-06-20.md
@@ -1,0 +1,53 @@
+# Wild Encounters — activity-based spawning (2026-06-20)
+
+> **Status:** `ideas`. **Not a plan, not approval.** Capture doc. Source + binding contracts +
+> `docs/current-state.md` win. **Subsystem:** games.
+>
+> Origin: the owner's Pokétwo/JMusicBot research report (2026-06-20). The report's strongest,
+> most-repeated Pokétwo lesson — *spawns linked to chat activity drive conversation and
+> community* — is the **one mechanic with no analog anywhere in the repo** (fishing and mining
+> are both manual command-only; there is no passive, message-triggered event). Promoted into a
+> PR-sized spec in [`planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md`](../planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md)
+> § "Lane A".
+
+## The idea
+
+A new **Encounters** subsystem: non-bot messages in an opted-in channel accrue a debounced
+activity counter; at a configurable threshold the bot spawns a **wild encounter** (embed +
+**Claim** button) in that channel. The first valid claimer (capability re-checked at callback
+time, stranger-grade Q-0080) receives a reward **routed through existing seams** — a
+fishing/mining item, coins via `economy_service`, and `game_xp` for a new `GAME_ENCOUNTERS`.
+
+It is deliberately **not** a Pokémon clone: there's no creature roster to license, no battles, no
+new currency. It's a thin engagement engine that **reuses** the economy/XP/inventory/world-hub
+seams and **docks** into the federated Explore hub (`world_registry`).
+
+## Why it's worth having
+
+- **Engagement leverage:** passive spawns reward genuine conversation (the report's core lesson),
+  unlike every current game which only fires on an explicit command.
+- **Net-new, ungated, anti-P2W:** no existing analog to duplicate; rewards are free and earned by
+  activity (no conflict with Q-0039); read/claim is stranger-grade.
+- **Feeds the other lanes:** the items/variants it drops are exactly what a future
+  collection-filter (Lane B), shiny/variant layer (Lane D), quest engine (Lane C), and eventually
+  the gated marketplace would operate on.
+
+## Open design questions (route to Q-0186, don't decide unprompted)
+
+1. **Default threshold + debounce** (the report's "~24 messages" — config-driven, off by default).
+2. **Reward pool** — fishing/mining items vs. coins vs. a dedicated encounter catalogue.
+3. **Claim shape** — first-click vs. "name the catch" guess (folds in the report's hint mechanic).
+4. **Anti-abuse** — per-claimer cooldown, one live spawn per channel, channel allow-list,
+   no-auto-catch (the report's own anti-spam rule).
+
+## Anti-patterns
+
+- ❌ A parallel "catching game" — catching already lives in fishing/mining/pets; this is a
+  *spawn+claim* engine, not a second collection game.
+- ❌ A new currency or buyable boost (Q-0039).
+- ❌ Unbounded spawns / DM spam — off by default, per-channel opt-in, rate-limited.
+
+→ relates [feature-mapping plan](../planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md)
+· [explore-hub plan](../planning/explore-hub-federated-world-plan-2026-06-19.md) ·
+[fishing plan](../planning/fishing-open-world-expansion-plan-2026-06-18.md) · Q-0186 · Q-0039
+(no P2W) · Q-0080 (stranger-grade) · Q-0071 (atomic workflow).

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,11 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/clever-maxwell-690qrj` · **Pokétwo + MusicBot research report → feature-mapping plan**
+  (docs-only, owner-steered plan-only) · `docs/planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md`
+  + `docs/planning/voice-music-architecture-review-2026-06-20.md` + `docs/ideas/` + router Q-0186 ·
+  2026-06-20 · **auto-merge on green (docs-only)**
+
 - `claude/design-system-site-pages` · **design-system: compose the rest of the site** (owner-chosen
   meantime build 2026-06-20 — make every route editable in Claude Design) · `design-system/src/`
   (`PageHeader`/`SearchBar`/`Pill`/`FeatureShowcaseCard`/`CommandDetail`/`CommandEntry`/

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -6806,3 +6806,37 @@ mining/fishing/blackjack · a BTD6-knowledgeable AI assistant · welcome cards).
 audience should drive the wording — agents should **not** invent the public-facing brand line.
 **Home:** this Q-block + the website-split plan's "Layout & UX guidance" section. Related: Q-0042
 (staged Someday website), Q-0178 (two-site split), Q-0179 (control-panel placement).
+
+---
+
+### Q-0186 — DISCUSS: Pokétwo-inspired features — which net-new lane to build first + spawn design (2026-06-20)
+
+> **PROPOSED — surfaced while turning the owner's Pokétwo/JMusicBot research report into a plan**
+> ([`planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md`](../planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md)).
+> The owner steered the report session to **plan only, build nothing yet**; this routes the build
+> decisions for when a future session executes. The mapping already settled the gated/rejected
+> items (marketplace = its own roadmap gate; premium currency = rejected Q-0039; music = Q-0041
+> arch-review pack).
+
+**Context:** most Pokétwo mechanics already have lanes here (catching = fishing/mining/pets;
+trading = the economy-marketplace roadmap; "one world" = the federated Explore hub). The mapping
+identified **four net-new, ungated, anti-P2W lanes**: **A) Wild Encounters** (activity-based
+spawning — the signature mechanic with *no* existing analog), **B) Collection & filtering**
+upgrade (extend fishing/inventory), **C) Quest/achievement** foundation (Q-0182-aware), **D)
+Shiny/rare-variant** layer (cosmetic prestige, rides on A/fishing).
+
+**The questions (the agent recommends, but the owner-designer decides):**
+1. **Build order** — which lane first? *Agent recommendation: **Lane A (Wild Encounters)*** — highest
+   engagement leverage, no gate, and it feeds B/C/D. Lane B is the low-risk parallel/warm-up.
+2. **Wild-encounter spawn defaults** — threshold/debounce (report's "~24 messages", config-driven,
+   off by default); **reward pool** (fishing/mining items vs. coins vs. a dedicated catalogue);
+   **claim shape** (first-click vs. "name the catch" guess folding in the hint mechanic).
+3. **Confirm the guardrails** — earned-only/no buyable power (Q-0039), per-channel opt-in +
+   rate-limit + no auto-catch (the report's own anti-spam rule), stranger-grade claims (Q-0080).
+
+**Agent note:** these gate the *build*, not the plan — the spec is written and ungated; it just
+needs the owner's sequence + spawn-design call before a runtime session executes (small focused
+PRs, runtime-verified). **Home:** the feature-mapping plan + the
+[wild-encounters idea](../ideas/wild-encounters-activity-spawning-2026-06-20.md) + this Q-block.
+Related: Q-0041 (music gate), Q-0039 (no P2W), Q-0182 (world model), Q-0040 (AI quests from
+bounded menus), Q-0080 (stranger-grade), Q-0071 (atomic workflow).

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -33,6 +33,7 @@ sectors ([`repo-sector-map.md`](../repo-sector-map.md)); the live `Now/Next/Late
 | Plan | Status / gate | Folio · related ideas |
 |---|---|---|
 | [fishing-open-world-expansion](fishing-open-world-expansion-plan-2026-06-18.md) | Phase 1 (fishing v1 + gear-switching) **▶ buildable**; the unified-loadout / value-cook-sell / minigame tail is **owner-design-gated (Q-0175)** | [games](../subsystems/games.md) · `mining_exploration_brainstorm` |
+| [poketwo-musicbot-feature-mapping](poketwo-musicbot-feature-mapping-plan-2026-06-20.md) | maps the owner's Pokétwo/JMusicBot research report → repo lanes; net-new lanes (Wild Encounters · collection filters · quests · shiny) spec'd, **build sequence gated on Q-0186**; marketplace/premium-currency = gated/rejected, music → arch-review pack | [games](../subsystems/games.md) · `wild-encounters-activity-spawning` |
 | [mining-hub-redesign](mining-hub-redesign-2026-06-15.md) | owner-picked Option A; **not yet built** (no hub-redesign commits) — ▶ startable | [games](../subsystems/games.md) · `voice-mode-planning-capture` |
 | [myprofile-foundation](myprofile-foundation-plan-2026-06-10.md) | PR A/B shipped (#938/#940); only **PR C onboarding** remains, **owner-gated (Q-0147)** | [settings](../subsystems/settings-bindings-provisioning.md) |
 | [settings-pointer-lane-convergence](settings-pointer-lane-convergence-plan-2026-06-13.md) | P0-3; families 1+2 done, **pointer retirement gated** | [settings](../subsystems/settings-bindings-provisioning.md) |
@@ -69,6 +70,7 @@ sectors ([`repo-sector-map.md`](../repo-sector-map.md)); the live `Now/Next/Late
 |---|---|---|
 | [web-tier-centralization-proposal](web-tier-centralization-proposal-2026-06-19.md) | web-CI matrix consolidation (`dashboard-ci` + `botsite-ci` → one matrix); **owner-greenlight gated** | tracked in [website-split-next-steps §2a](../operations/website-split-next-steps-2026-06-19.md) |
 | [loop-health-gh-fallback](loop-health-gh-fallback-plan-2026-06-20.md) | 1 PR; **ungated, self-merge on green**; `urllib` REST fallback so `check_loop_health.py` verifies the ROUTINE_PAT row in-container (Q-0135) instead of SKIPping | `loop-health-gh-unavailable-fallback` |
+| [voice-music-architecture-review](voice-music-architecture-review-2026-06-20.md) | the **Q-0041-required** voice/music decision pack (legal · infra · architecture fit · permissions · cost); **no playback code** — owner makes the go/no-go + legal-lane call to lift the gate | tracked under Q-0041 · `voice-mode-planning-capture` |
 
 ### Dashboard / control-API / website — the cross-cutting initiative
 

--- a/docs/planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md
+++ b/docs/planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md
@@ -1,0 +1,178 @@
+# Pokétwo + MusicBot research report → feature-mapping plan (2026-06-20)
+
+> **Status:** `plan` — routing/mapping plan. **Not implementation approval.** Source code,
+> the binding contracts, owner decisions (router `Q-####`), and `docs/current-state.md` win
+> over this doc. **Subsystem:** games, ai, media.
+>
+> **Provenance:** the owner uploaded a research report comparing **Pokétwo** (the Pokémon
+> catching Discord bot) and **JMusicBot/Rythm/Jockie** (music bots) and asked to *"implement
+> as much of these features in a proper way."* The owner then steered this session
+> (in-session answers, 2026-06-20): **plan only, build nothing yet**, and for the music half
+> **architecture-review pack only** (respect the Q-0041 voice gate). This doc is that plan.
+
+## 1. The core reframe — most of this already has a lane
+
+The report reads as "here are two successful bots, copy their features." The proper response in
+*this* repo is **not** to clone Pokémon or bolt on a music player. Two facts from the research
+change the shape of the work:
+
+1. **Most Pokétwo mechanics already exist or are already planned here.** Catching → **fishing**
+   and **mining** are shipped; **pets-companions** is planned. Trading → the
+   **economy-marketplace roadmap** exists (gated on economy-health evidence). The "one world
+   each game plugs into" → the **federated Explore hub** (`services/world_registry.py`, shipped
+   #1156). So the job is mostly **extend + dock into existing seams**, governed by the repo's
+   hard *"do not duplicate existing systems"* rule.
+2. **Several report "improvements" are already owner-decided — some the *opposite* way.** The
+   report pitches a **two-currency premium economy** (PokéCoins + buyable shards); the owner
+   **rejected** purchasable advantage (**Q-0039**, cosmetic-only donations, no P2W). The report
+   pitches **music**; the owner **wants it but gated it** behind a dedicated voice architecture
+   review sequenced *after* alert integrations (**Q-0041**). Building either "as described"
+   would violate a standing decision.
+
+So this plan does three things: **(A)** map every report feature to its lane and verdict;
+**(B)** spec the genuinely net-new, ungated, owner-aligned slices as PR-sized work; **(C)** route
+the owner-decision forks instead of guessing them.
+
+## 2. The mapping — every report feature → repo lane → verdict
+
+Legend: **EXTEND** = grow an existing system · **BUILD** = net-new, ungated, owner-aligned ·
+**GATED** = needs an owner decision / evidence first · **REJECTED** = conflicts with a standing
+owner decision · **HAVE** = already shipped, nothing to do.
+
+### Pokétwo half
+
+| Report feature | Closest repo lane (verified) | Verdict |
+|---|---|---|
+| **Activity-based spawning** (chat messages accrue → a wild encounter appears) | **No analog anywhere.** Fishing/mining are manual command-only; there is no message-activity passive event in the repo. | **BUILD** — the signature net-new mechanic. See §3 Lane A. |
+| **Catching a creature** | `fishing` (`!fish`, level-gated rolls, `fishing_catch_log`) + `mining`; `pets-companions` plan (eggs/hatch/care, no battles) | **EXTEND** — Lane A's claim routes a catch through these seams; do **not** build a parallel "Pokémon" game. |
+| **Collection + robust filters** (region/level/IV/shiny/favourite/forms) | `fishing_catch_log` (per-species count + timestamps), `inventory_cog` (rarity/category, UI-only filters) | **EXTEND** — Lane B: real filter/sort/favourite layer over the existing logs. |
+| **Hints / alternate names** | `utils/synonyms.py` (`find_command`), the AI's BTD6 name-resolution patterns | **EXTEND** (small) — folds into Lane A's encounter "guess the name" option if wanted. |
+| **Global marketplace + trading** (listings, search, escrow, buy/sell) | **`economy-marketplace-rewards-roadmap-2026-06-08.md`** — designed, **gated** on economy-health evidence + anti-fraud/legality review; no trading code exists today. | **GATED** — do not build until the roadmap's gates clear. Lane A/B feed the *items* it would trade. |
+| **Two currencies — PokéCoins + buyable shards** | `economy_service` is single-currency (coins); **Q-0039** rejects purchasable advantage. | **REJECTED** as "buyable premium currency." A *second earned* token (non-buyable) is a separate economy-balance decision, not this. |
+| **Battling (3v3, moves)** | `deathmatch`/`rps`/`blackjack` exist; pets plan says **no pet battles**; no creature-battle lane. | **GATED** — a creature/world battle system is its own design effort + owner sign-off (P2W risk). Not in this plan. |
+| **Shiny hunting / rarity / hunt streaks** | Loot rarity exists in mining/fishing; no "shiny variant" or streak mechanic. | **BUILD** (thin) — Lane D: a rare-variant flag riding on Lane A / fishing, anti-P2W (cosmetic prestige, not power). |
+| **Quests / achievements / events** | Only **derived titles** (mining) exist; no quest log, achievement/badge store, or timed events. Captured in vision docs, intersects the open world-model questions (**Q-0182**). | **BUILD** (foundation) — Lane C, but it touches Q-0182; spec is foundation-only. |
+| **Time & weather mechanics** | None. | **GATED/defer** — flavor layer best decided with the Q-0182 world model (biome/map fork). |
+| **Modern UI (slash commands, buttons, embeds, dashboard)** | The repo is **already** button/HubView/panel-driven; a web dashboard + control API are shipped. | **HAVE** — the report's headline "improvement" is largely realized. |
+| **Open-source / modular / public API** | Strict layered architecture, registries, EventBus; public bot-site in flight. | **HAVE** — keep docking new games into `world_registry`. |
+
+### Music half (JMusicBot / Rythm / Jockie)
+
+| Report feature | Repo reality | Verdict |
+|---|---|---|
+| **Music playback** (multi-source streaming, queue, DJ role, search, lyrics, playlists, control panel) | **Zero voice capability today.** Owner **wants** music but **Q-0041** sequences it behind a *dedicated voice architecture review*, itself behind YouTube→Twitch→Spotify alert integrations. | **GATED** — owner chose **architecture-review pack only** this session. See [`voice-music-architecture-review-2026-06-20.md`](voice-music-architecture-review-2026-06-20.md). Build no playback. |
+| **DJ-role / role-based control / vote-skip** | `governance/` capability + `role` subsystem would supply this *if* music ships. | Maps cleanly **when** the gate lifts — captured in the arch-review pack. |
+| **Legal/licensing posture** (the report's own DMCA/cease-and-desist warning) | The decisive constraint; Rythm/Hydra history is in the report. | The arch-review pack makes this the **first** decision, not an afterthought. |
+
+## 3. The buildable lanes (specs only — nothing built this session)
+
+Each lane is written so a future approved session can execute it cold. All four respect:
+**route every mint/award through `economy_service` / `game_xp_service`; write through the
+domain's audited `*_workflow`/`*_mutation` seam; dock UI into the world hub; stay anti-P2W
+(free, earned by play — never buyable power).**
+
+### Lane A — Wild Encounters (activity-based spawning) ★ highest-leverage net-new
+
+The one Pokétwo mechanic with **no analog** and **no owner gate**, and the report's strongest
+lesson ("spawns linked to activity encourage conversation"). It is also the engine the other
+lanes feed.
+
+- **New subsystem** `cogs/encounters_cog.py` (+ `cogs/encounters/`), `views/encounters/`,
+  `services/encounter_service.py` (audited), `utils/db/encounters.py`, a migration for
+  `encounter_spawn` / `encounter_claim` tables, and a `delete_for_guild` hook in
+  `guild_lifecycle.py`. Use `scripts/new_subsystem.py` / the `/new-subsystem` skill.
+- **Spawn loop:** a message listener accrues a per-channel activity counter (debounced, bot
+  messages excluded — mirror the report's "~24 messages" but **config-driven**, off by default).
+  At threshold, `encounter_service` spawns an encounter embed + **Claim** button in that channel
+  (rate-limited; one live spawn per channel; respects the channel allow-list). **Anti-spam:**
+  no auto-catch; cooldown per claimer; the threshold + enabled-per-channel are settings.
+- **Claim → reward:** the first valid claimer (capability re-checked at callback time, Q-0080
+  stranger-grade) gets a reward **routed through existing seams** — a fishing/mining item, coins
+  via `economy_service`, and `game_xp` for a new `GAME_ENCOUNTERS`. No new currency.
+- **Dock into the world hub:** register an Encounters `WorldEntry`; surface stats on the world
+  card (`world_identity()`).
+- **Tests:** spawn-threshold math (pure, in `utils/`), claim atomicity + double-claim guard,
+  capability re-check, guild-teardown.
+- **Owner forks (Q-0186):** default threshold + which reward pool; whether claiming is
+  first-click vs. a "name the catch" guess (folds in the hint mechanic).
+- **Why a real PR, not a one-liner:** new table + service + listener + view + world dock; size it
+  as a small foundation PR (spawn+claim+reward) then a follow-up PR (filters/variety). Runtime
+  code → small focused PRs (per CLAUDE.md), runtime-verified session.
+
+### Lane B — Collection & filtering upgrade (EXTEND fishing + inventory)
+
+The report's "robust filters" lesson, applied to what we already store.
+
+- Add a real **filter/sort/favourite** layer over `fishing_catch_log` (and the unified
+  `inventory` display): filter by rarity/level/owned-vs-missing/favourite; sort by count/recency;
+  paginated `BaseView` (reuse `views/paginated_select.py` / `attach_windowed_select`).
+- **Favourite** = one new boolean column on the catch log (audited via the fishing workflow); no
+  new subsystem.
+- Smallest, safest lane; good warm-up or parallel slice. Tests: filter predicates (pure),
+  favourite write through the workflow.
+
+### Lane C — Quest / achievement foundation (BUILD, but Q-0182-aware)
+
+The report's quests/achievements/events. **Foundation only** — full design intersects the open
+world-model questions (Q-0182), so this lane builds the *engine*, not a content catalogue.
+
+- `services/quest_service.py` (audited) + `quest_progress` / `achievement_grant` tables + a
+  read-only quest-log panel. A quest = `{key, predicate over existing events, reward}`; progress
+  is driven by **existing EventBus events** (`game_xp.awarded`, `EVT_BALANCE_CHANGED`,
+  encounter claims) — no new instrumentation, no polling.
+- Achievements = milestone grants (generalizes mining's derived **titles**; reuse that prior
+  art, don't fork it).
+- **Defer**: timed/seasonal *events* and quest *content authoring* until Q-0182 fixes the world
+  model (and per Q-0040, AI-chosen quests come from **bounded menus**, not free narration).
+
+### Lane D — Shiny / rare-variant layer (BUILD, thin, anti-P2W)
+
+The report's shiny hunting, reframed as **cosmetic prestige, never power**.
+
+- A low-probability **variant flag** on a catch/encounter (e.g. `is_variant` + variant name),
+  rolled at claim time; surfaced with a sparkle in collection views and the world card. Optional
+  **streak** boost (deterministic, server-activity-driven) per the report — but **no buyable
+  charm** (that would be Q-0039 P2W). Rides on Lane A or fishing; tiny schema add.
+
+## 4. Anti-patterns (what "proper" explicitly rules out)
+
+- ❌ **A new "Pokémon" catching game.** Catching already lives in fishing/mining/pets — extend
+  and dock, don't duplicate (hard repo rule + Q-0182 world model).
+- ❌ **A buyable premium currency / shards.** Q-0039 rejects purchasable advantage. Earned-only.
+- ❌ **A standalone marketplace now.** Q-gated on economy-health evidence + fraud/legality review
+  (economy-marketplace roadmap). Lanes A/B/D produce the *items* it will later trade.
+- ❌ **Music playback now.** Q-0041 gate; this session ships the architecture-review pack only.
+- ❌ **Creature battles / time-weather as a free-for-all.** Each is its own owner-design decision
+  (battles = P2W risk; time/weather = Q-0182 biome fork).
+
+## 5. Recommended sequencing + the open owner decision
+
+1. **Owner answers Q-0186** (which net-new lane first; spawn defaults; reward pool). Recommended
+   first build: **Lane A (Wild Encounters)** — highest engagement leverage, no gate, feeds the
+   others. **Lane B** is the low-risk parallel/warm-up.
+2. **Music:** owner reviews the [architecture-review pack](voice-music-architecture-review-2026-06-20.md)
+   and makes the go/no-go + legal-lane call that **Q-0041** parks. Nothing builds until then.
+3. **Lane C/D** follow Lane A; **marketplace** waits on its own roadmap gates; **battles /
+   time-weather** wait on Q-0182 + their own design sessions.
+
+Each lane, when greenlit, is its own runtime-verified, small-PR session — not a single mega-PR.
+
+## 6. House-style anchors (so an executor builds a lane cold)
+
+- New subsystem: `scripts/new_subsystem.py`, the `/new-subsystem` skill, `docs/architecture.md`
+  § "Where to add a new subsystem".
+- World dock: `services/world_registry.py`, `views/explore/world_hub.py`,
+  [explore-hub plan](explore-hub-federated-world-plan-2026-06-19.md).
+- Audited mutation / economy / XP seams: `services/economy_service.py`,
+  `services/game_xp_service.py`, the `*_workflow.py` atomic pattern (Q-0071),
+  `docs/runtime_contracts.md` § 9, `docs/ownership.md`.
+- Pre-edit: `python3.10 scripts/context_map.py <file>` + `check_architecture.py --mode strict`.
+
+→ relates [explore-hub plan](explore-hub-federated-world-plan-2026-06-19.md) ·
+[economy-marketplace roadmap](economy-marketplace-rewards-roadmap-2026-06-08.md) ·
+[pets-companions plan](pets-companions-plan-2026-06-09.md) ·
+[fishing plan](fishing-open-world-expansion-plan-2026-06-18.md) ·
+[voice/music arch-review pack](voice-music-architecture-review-2026-06-20.md) ·
+[wild-encounters idea](../ideas/wild-encounters-activity-spawning-2026-06-20.md) ·
+Q-0186 (build sequencing) · Q-0041 (voice gate) · Q-0039 (no P2W) · Q-0182 (world model) ·
+Q-0040 (AI quests from bounded menus) · Q-0080 (stranger-grade) · Q-0071 (atomic workflow).

--- a/docs/planning/voice-music-architecture-review-2026-06-20.md
+++ b/docs/planning/voice-music-architecture-review-2026-06-20.md
@@ -1,0 +1,125 @@
+# Voice / Music — architecture-review decision pack (2026-06-20)
+
+> **Status:** `plan` — the **Q-0041-required architecture review**, in decision-pack form.
+> **Not implementation approval and not playback code.** Owner steered this session to produce
+> *the pack only* (respect the Q-0041 voice gate). Source, binding contracts, and `Q-0041`
+> win over this draft. **Subsystem:** media (voice).
+>
+> **Why this exists:** the research report pitches a full JMusicBot-style player. **Q-0041**
+> (2026-06-09) says music is *wanted* but **gated behind a dedicated voice architecture review**,
+> itself sequenced **after** the YouTube→Twitch→Spotify alert integrations, with **speech
+> recognition last (deferred, not dropped)**. This pack *is* that review — it lays out the
+> decisions the owner must make to lift the gate, so a future approved session can build cleanly.
+> Companion to [`integrations-media-voice-website-roadmap-2026-06-08.md`](integrations-media-voice-website-roadmap-2026-06-08.md)
+> § "Phase 5 — voice concept".
+
+## 1. The decisive constraint, stated first — legal
+
+The report itself documents the history: **Rythm and Hydra received cease-and-desists** after
+YouTube's enforcement; the original Rythm shut down, Hydra pivoted away from music, Rythm later
+returned **only with official licensing + premium tiers**. Any music feature here lives or dies on
+this, so it is the **first** decision, not an afterthought.
+
+**The fork the owner must choose:**
+
+- **(L1) Self-hosted streaming (JMusicBot/Lavaplayer model).** Stream YouTube/SoundCloud/etc.
+  directly. *Lowest cost, highest legal exposure* — this is exactly what drew the takedowns. Viable
+  only for a private/personal-scale bot the owner accepts the risk for; **not** appropriate for the
+  public bot-site launch.
+- **(L2) Licensed / API-sanctioned sources only.** Spotify (preview/SDK within ToS), Apple Music
+  previews, royalty-free / Creative-Commons catalogues, podcast RSS, direct-upload by server
+  owners. *Higher integration effort, defensible legally.* The report's own "make it better"
+  recommendation #5 ("partner with services for official API access, use preview APIs to avoid
+  DMCA").
+- **(L3) Defer indefinitely.** Keep voice out; the bot's identity is community/games/AI, not music.
+
+**Recommendation:** if music ships at all, **L2** for anything public-facing; **L1** only as an
+explicitly-private, owner-risk-accepted instance. Decide L1/L2/L3 **before** any infra is built —
+it changes every layer below.
+
+## 2. Infrastructure fit (the part the rest of the bot has never needed)
+
+Music is **architecturally unlike** everything in this repo today. The bot is a `discord.py`
+text/command + Postgres + EventBus system with **no audio path**. Voice adds:
+
+- **A voice gateway connection + Opus audio pipeline.** `discord.py[voice]`, native **Opus** libs,
+  and **FFmpeg** on the host. None are present; FFmpeg is a non-trivial runtime dependency.
+- **An audio source/queue engine.** Either an in-process source (FFmpeg/youtube-dl-style
+  extractor) or an external **Lavalink** node (the Java audio server most modern bots use to keep
+  audio off the bot process). Lavalink = **a second always-on service to host, monitor, and pay
+  for** — relevant given the deployment is Railway and the report flags scaling/cost as the
+  historical killer (Pokécord/music shutdowns were cost-driven).
+- **Persistent voice sessions** — long-lived per-guild connections with their own lifecycle,
+  reconnection, and idle-timeout. This does **not** fit the repo's request/response + audited-DB
+  mutation model; it is closer to the `core/runtime/tasks` supervised-loop pattern and needs its
+  own lifecycle contract in `docs/runtime_contracts.md`.
+- **Hosting reality:** voice + FFmpeg + (optionally) a Lavalink node materially raises the
+  process/host footprint vs. today's single worker. The owner must accept this cost or scope L2 to
+  preview-clip playback that avoids a streaming node.
+
+## 3. Where a music subsystem would land (if greenlit)
+
+Mapped onto the existing architecture so an executor isn't inventing placement later:
+
+| Concern | Home | Notes |
+|---|---|---|
+| Cog entry / commands | `cogs/music_cog.py` (+ `cogs/music/`) | `!play`/`!queue`/`!skip`/`!np` + slash variants; the report's command set. |
+| Voice session lifecycle | `core/runtime/` (new `voice_session_manager`) | Supervised, idle-timeout, reconnect; **must not** import cogs/services. Needs a `runtime_contracts.md` § entry. |
+| Queue / playback engine | `services/music_service.py` (or a Lavalink client wrapper) | Pure-ish queue state + source resolution; provider seam mirrors ADR-007 media ownership. |
+| Provider adapters | reuse the **ADR-007 media seam** (`youtube_*_service` prior art) | Q-0041 explicitly wants the alert-integration provider contract proven *first* and reused here. |
+| UI control panel | `views/music/` (`BaseView`/`PersistentView`) | The report's Rythm-style `/control` button panel — fits the repo's panel model directly. |
+| Permissions (DJ role, vote-skip, requester-only-skip) | `governance/` capability + `role` subsystem | No new auth system — reuse capability re-check at callback time (Q-0080). |
+| Settings (per-guild prefix already exists; DJ role, allowed channels, default volume) | `utils/settings_keys/music.py` + `SettingsMutationPipeline` | Mirrors the report's admin controls. |
+| State that must persist | minimal (saved playlists / autoplaylist) → a migration + `utils/db/music.py` | Live queue state is in-memory; only saved playlists are durable. |
+
+**Key architectural truth:** the *control surface* (panels, DJ permissions, settings, provider
+adapters) maps **cleanly** onto what the repo already does well. The *audio transport* (voice
+gateway, FFmpeg/Opus/Lavalink, persistent sessions, legal sourcing) is the genuinely new, costly,
+risk-bearing part — and it's entirely a function of the §1 legal choice and §2 infra acceptance.
+
+## 4. Privacy — speech recognition stays last
+
+Q-0041 keeps **speech recognition deferred, not dropped**, with its own consent/retention
+decision. This pack **excludes** it: voice *input* (listening to users) is the most
+privacy-sensitive surface in the whole product and must not ride in on a music-*output* feature.
+If ever pursued, it is a separate review (consent, retention, transcript minimization per P0-2).
+
+## 5. Operational cost, scaling, abuse
+
+- **Cost:** an always-on Lavalink node and/or FFmpeg streaming is the dominant new cost; the
+  report names cost as the historical bot-killer. L2 preview-clips minimize this; L1 streaming
+  maximizes both cost and legal risk.
+- **Abuse:** queue hogging, NSFW/illegal source URLs, voice-channel join spam. Mitigations:
+  per-requester queue caps + vote-skip (report's lessons), DJ-role gating, source allow-listing,
+  and — for any URL ingestion — the same provenance/moderation discipline as ADR-007 media.
+- **Degraded-service:** provider outages must fail quiet (Q-0041's "fail-quiet degradation"),
+  matching the existing media-seam behavior.
+
+## 6. The decision the owner must make (this feeds Q-0041)
+
+To lift the Q-0041 voice gate, the owner needs to decide, **in order**:
+
+1. **Go / no-go / later** on music at all (vs. keeping the bot's identity games/AI/community).
+2. **Legal lane** — L1 self-host (private only, risk-accepted) vs. L2 licensed/preview-only
+   (public-safe) vs. L3 defer. *Everything else depends on this.*
+3. **Infra acceptance** — willing to host/pay for an audio path (FFmpeg ± Lavalink) on Railway?
+4. **Prerequisite ordering** — Q-0041 wants the YouTube/Twitch **alert** provider contract proven
+   first; build that before voice, or run voice as an independent track?
+
+**Agent recommendation (challengeable):** **L2 + preview/licensed sources**, control surface built
+on the existing panel/governance/settings seams, audio transport scoped to the cheapest viable
+path, speech recognition firmly out. If the owner wants L1 self-host, scope it to an explicitly
+private instance, never the public bot-site. If neither legal lane is acceptable, **L3 defer** is
+the honest answer — and the control-surface work has near-zero standalone value without audio, so
+don't pre-build it.
+
+## 7. What this pack deliberately does NOT do
+
+No voice code, no dependency added, no migration, no provider key. It is the review Q-0041 asks
+for. Implementation still needs: this decision pack answered → normal promotion → a runtime-verified
+session (or an explicitly-private instance) → its own small-PR build.
+
+→ relates [media/voice/website roadmap](integrations-media-voice-website-roadmap-2026-06-08.md) ·
+[feature-mapping plan](poketwo-musicbot-feature-mapping-plan-2026-06-20.md) · ADR-007 (media seam)
+· Q-0041 (voice gate + provider order) · Q-0042 (website) · Q-0080 (stranger-grade) · P0-2 (data
+minimization, for the deferred speech layer).


### PR DESCRIPTION
## What

Reviews the owner-uploaded research report on **Pokétwo** (Pokémon catching bot) and **JMusicBot** (music bot) and turns it into a **proper feature-mapping plan**. **Docs-only — no runtime (`disbot/`) code.** Owner steered this session to **plan only, build nothing yet**, and for music **architecture-review pack only** (respect the Q-0041 voice gate).

## Why this isn't a "clone Pokétwo / add a music player" PR

Research established that **most Pokétwo mechanics already have lanes in the repo** (fishing/mining/pets = catching; economy-marketplace roadmap = trading; federated Explore hub = the world spine), the owner **rejected premium currency** (Q-0039, anti-P2W), and **music is owner-gated** behind a dedicated voice architecture review (Q-0041, sequenced after YouTube/Twitch/Spotify alerts). The proper move is to **map every feature to its lane** and **build only the net-new, ungated, owner-aligned slices** — after the owner picks the sequence.

## Contents

- `docs/planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md` — full report→repo mapping; every feature classified (extend-existing / buildable-now / owner-gated / rejected) with PR-sized specs for the net-new lanes (Wild Encounters · collection filters · quest engine · shiny/rare-variant layer).
- `docs/planning/voice-music-architecture-review-2026-06-20.md` — the Q-0041-required voice/music decision pack (legal · infra · architecture fit · permissions · cost).
- `docs/ideas/wild-encounters-activity-spawning-2026-06-20.md` — capture of the signature net-new mechanic + README index entry.
- Router **Q-0186** (Pokétwo build-sequencing DISCUSS); the music pack feeds existing **Q-0041**.

## Status

🔴 Born-red — the session card is `in-progress` (the `check_session_gate` hold). Flips to `complete` as the final commit once the docs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJBXy9mKixJKzjTtch2WmT

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJBXy9mKixJKzjTtch2WmT)_