### PR TITLE
docs: BUG-0019 (AI replies to other bots' mentions) + Pokétwo demand signal

### DIFF
--- a/.sessions/2026-06-20-ai-other-bot-mention-bug-note.md
+++ b/.sessions/2026-06-20-ai-other-bot-mention-bug-note.md
@@ -1,6 +1,6 @@
 # 2026-06-20 — BUG note: AI replies to other bots' mentions + Pokétwo demand signal
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Arc
 
@@ -11,17 +11,94 @@ this."* **(2)** a product signal — a real user runs **multiple bots** (poketwo
 lack those features; owner: *"make sure we have a similar/better version of the Pokémon system."*
 
 Docs-only. The AI engagement path is gated/sensitive (Q-0086 wants a runtime walk) and the core
-fix has an owner behavior fork, so this **notes** the bug properly rather than speculatively
-patching it.
+fix carries an owner behavior fork, so this **notes** the bug to the repo standard rather than
+speculatively patching the gated path.
 
-## Plan (what this PR adds)
+## Shipped (PR #1182, docs-only)
 
-- `docs/health/bug-book.md` — **BUG-0019** (OPEN): root-caused both mechanisms (`always_reply`
-  ambient mode answers messages aimed at other bots + the model hallucinates a "you pinged me"
-  greeting because other-user mention tokens aren't stripped; and the `mentioned_in` `@everyone`
-  footgun at `natural_language_stage.py:229`). Proposed fix + the one owner behavior decision.
-- `docs/planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md` — added the **live demand
-  signal** + a one-screen *"what Pokétwo actually does"* reference with our parity map (the owner
-  noted he's unsure what poketwo does).
+- **`docs/health/bug-book.md` — BUG-0019 (OPEN, root cause identified).** Two independent
+  mechanisms: **(1)** `always_reply` ambient mode answers *every* message — including ones aimed at
+  other bots — and the model hallucinates a "you pinged me" greeting because **other** users'
+  mention tokens aren't stripped before the prompt (only SuperBot's own is, via
+  `_strip_bot_mention`); **(2)** `natural_language_stage.py:229` uses `mentioned_in`, which
+  discord.py returns True for on `@everyone`/`@here`, so a server-wide ping reads as a personal
+  one. Proposed fix: the `@everyone` exclusion is an unambiguous hardening (direct-mention check +
+  regression test); the `always_reply` behavior is a **fork routed to the owner** (stay silent when
+  addressed to another bot · strip all mentions + never claim a ping · leave as power-user opt-in).
+  Agent recommendation: option (a) + the `@everyone` hardening.
+- **`docs/planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md`** — added the **live demand
+  signal** callout (a real user runs multiple bots for these features) and a one-screen
+  **"what Pokétwo actually does"** reference + parity map (the owner noted he's unsure what poketwo
+  does; this makes the plan self-contained for his design call).
 
-(In-progress; flipped to `complete` as the final step.)
+Verification: `check_docs.py --strict` ✓ · `check_plan_homing.py` ✓. No `disbot/` code touched.
+
+## Why not patch the AI path this turn
+
+The owner asked to *note* it; the AI engagement behavior is gated (Q-0086 — live AI changes want a
+runtime walk with provider keys), and the central fix (`always_reply` semantics) is a genuine
+design tradeoff — suppressing replies when other users are mentioned could break legitimate
+always_reply use (*"hey @friend look — SuperBot what do you think?"*). Shipping a speculative
+behavior change would risk either not fixing the screenshot (if it's the ambient path) or breaking
+intended use. The faithful move is a precise note + a routed decision, ready to execute on his call.
+
+## Decisions made alone
+
+- Marked BUG-0019 **OPEN** (not a same-PR fix) — justified: the root fix needs an owner behavior
+  decision + a runtime-verified session. Recorded the recommended fix so it's turn-key once decided.
+- Filed the `@everyone` footgun in the **same** entry rather than a separate bug — same "false
+  personal ping" class, same code stage.
+
+## Flagged for maintainer
+
+- **BUG-0019 behavior decision:** in `always_reply` channels, should SuperBot stay silent when a
+  message is addressed to another user/bot (recommended), strip-all-mentions + drop the "pinged me"
+  framing, or stay as-is? Plus: which channel mode is `goals-for-now` actually on? (confirms whether
+  the `@everyone` hardening alone resolves the screenshot). I can implement immediately on his call.
+- **Pokétwo priority:** the live demand signal raises the Pokétwo half's priority — pairs with the
+  open **Q-0186** (which net-new lane first; recommend Lane A Wild Encounters).
+
+## 💡 Session idea (Q-0089)
+
+**An ambient-mode "addressed-to-someone-else" guard as a reusable predicate.** BUG-0019 is really a
+missing primitive: *"is this message directed at a party other than us?"* (mentions another
+user/bot, is a reply to another user, or is a recognized other-bot command-prefix like Carl-bot's
+`?`/`!`). A small pure helper `utils/ai/addressing.py:is_addressed_elsewhere(message, bot_user)`
+would let the natural-language stage cheaply skip barge-ins **and** be unit-tested offline, turning
+a fuzzy behavior call into a testable rule. Genuinely useful beyond this bug (any future ambient
+feature wants it); lane = ai/runtime. (Not built — BUG-0019's fix is owner-gated; captured here.)
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous session (this same chain, #1180 — the feature-mapping plan) did the mapping well and
+correctly respected the owner's plan-only / arch-review-pack steer. **What it could've anticipated:**
+it treated Pokétwo as a "nice extension" lane; one screenshot later the owner reframed it as a
+*real* competitive gap (users leaving for other bots). The plan would have been stronger had it
+asked **"is any of this load-bearing for retention?"** up front — a competitive-gap lens, not just
+an architecture-fit lens. **System improvement it surfaces:** feature-mapping plans should carry a
+short *"demand/retention signal"* field per lane (why does a user want this, what do they use
+instead today?) so priority isn't purely an internal architecture judgment. I added exactly that
+signal to the plan this run; worth making it a standard section in future mapping plans.
+
+## 📤 Run report
+
+- **Did:** root-caused + recorded BUG-0019 (AI replies to other bots' mentions); added the live
+  Pokétwo demand signal + reference to the feature-mapping plan · **Outcome:** shipped (docs-only)
+- **Shipped:** #1182 — BUG-0019 (OPEN, routed) + Pokétwo demand signal/reference
+- **Run type:** `manual · owner-task (bug note + product signal)`
+- **⚑ Owner decisions needed:** BUG-0019 `always_reply` behavior fork (+ which mode `goals-for-now`
+  uses) · Q-0186 Pokétwo lane priority (demand signal raises it)
+- **⚑ Owner manual steps:** none
+- **⚑ Self-initiated:** none (owner-directed: "make a note" + "ensure a Pokémon-system equivalent")
+- **↪ Next:** on the owner's BUG-0019 call → a runtime-verified session ships the fix + guard;
+  on Q-0186 → build Lane A (Wild Encounters)
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs opened this session | 1 (#1182, docs-only, auto-merge on green) |
+| Runtime (`disbot/`) code changed | 0 (bug noted, not patched — gated AI path + owner fork) |
+| Bugs recorded | 1 (BUG-0019, OPEN, root-caused) |
+| CI-red rounds | 1 (by-design born-red session gate only) |
+| New ideas contributed | 1 (addressed-elsewhere ambient guard predicate) |

--- a/.sessions/2026-06-20-ai-other-bot-mention-bug-note.md
+++ b/.sessions/2026-06-20-ai-other-bot-mention-bug-note.md
@@ -1,0 +1,27 @@
+# 2026-06-20 — BUG note: AI replies to other bots' mentions + Pokétwo demand signal
+
+> **Status:** `in-progress`
+
+## Arc
+
+Follow-up to the Pokétwo/MusicBot feature-mapping plan (#1180, merged). The owner shared a
+Discord screenshot showing two things: **(1)** a live bug — SuperBot's AI replied *"Hey! You've
+just pinged me…"* to a message that pinged **`@Carl-bot`**, not SuperBot; owner: *"make a note of
+this."* **(2)** a product signal — a real user runs **multiple bots** (poketwo + music) because we
+lack those features; owner: *"make sure we have a similar/better version of the Pokémon system."*
+
+Docs-only. The AI engagement path is gated/sensitive (Q-0086 wants a runtime walk) and the core
+fix has an owner behavior fork, so this **notes** the bug properly rather than speculatively
+patching it.
+
+## Plan (what this PR adds)
+
+- `docs/health/bug-book.md` — **BUG-0019** (OPEN): root-caused both mechanisms (`always_reply`
+  ambient mode answers messages aimed at other bots + the model hallucinates a "you pinged me"
+  greeting because other-user mention tokens aren't stripped; and the `mentioned_in` `@everyone`
+  footgun at `natural_language_stage.py:229`). Proposed fix + the one owner behavior decision.
+- `docs/planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md` — added the **live demand
+  signal** + a one-screen *"what Pokétwo actually does"* reference with our parity map (the owner
+  noted he's unsure what poketwo does).
+
+(In-progress; flipped to `complete` as the final step.)

--- a/docs/health/bug-book.md
+++ b/docs/health/bug-book.md
@@ -23,6 +23,54 @@
 > later empty-fire dispatch run can pick them up instead of them sitting un-promoted (the
 > trap BUG-0018 hit). Advisory by default; `--strict` exits 1 on a non-empty backlog.
 
+## BUG-0019 — AI replies to messages aimed at *other* bots and claims "you've just pinged me" — OPEN (root cause identified; fix needs one owner behavior decision)
+
+- **Symptom (owner-reported, 2026-06-20, live in a community server):** a user pinged
+  **another** bot — `@Carl-bot (?)` — in a channel, and **SuperBot replied anyway**: *"Hey!
+  You've just pinged me. What can I help you with? … feel free to ask me anything…"*. The
+  owner's words: *"the AI is responding to mentions of other bots."* Context: the report user
+  cited this as a reason he still runs multiple bots.
+- **Expected:** SuperBot should **not** barge into a message clearly addressed to a different
+  user/bot, and should **never** claim it was "pinged" when it was not directly mentioned.
+- **Where:** `disbot/core/runtime/ai/natural_language_stage.py` (the single "should the bot
+  reply?" stage) + `disbot/services/ai_natural_language_policy.py` (the mode gate).
+- **Root cause — two independent mechanisms (the screenshot is almost certainly #1):**
+  1. **`always_reply` ambient mode answers *everything*.** A channel/category/guild AI profile
+     with `mode="always_reply"` (`ai_natural_language_policy.py:122,343`) responds to **every**
+     message regardless of who it addresses — so a message that only pings `@Carl-bot` still gets
+     a reply. The mode gate only special-cases `mention_only` (requires a mention) and `disabled`;
+     `always_reply` has **no "is this addressed to someone else?" guard**. Separately, the model
+     produced a *"you've just pinged me"* greeting for a low-content message even though SuperBot
+     was **not** in `message.mentions` — i.e. the prompt/context does not tell the model "you were
+     NOT actually mentioned; another user/bot was," so it hallucinates the ping framing. (We strip
+     *SuperBot's own* mention from the text — `_strip_bot_mention` — but leave **other** users'
+     mention tokens in, so the model still sees a `<@id>` and reads it as a ping at itself.)
+  2. **`mentioned_in` treats `@everyone`/`@here` as a direct ping (latent footgun).**
+     `natural_language_stage.py:229` — `is_mention = ctx.bot.user.mentioned_in(message)`.
+     discord.py's `mentioned_in` returns **True when `message.mention_everyone` is set**, so a
+     server-wide `@everyone`/`@here` reads as "the bot was personally pinged" and flips the
+     `mention_only` gate open. Independent of the screenshot, but the same "false personal ping"
+     class.
+- **Proposed fix (needs one owner behavior decision — see flag):**
+  - **#2 is unambiguous → hardening:** compute `is_mention` as a **direct** mention only —
+    `bot_user.id in {m.id for m in message.mentions}` (exclude `mention_everyone`). A server-wide
+    `@everyone` should never read as a personal ping. Offline-unit-testable with a stub message;
+    ship a regression test that fails against `mentioned_in`'s `mention_everyone=True` path.
+  - **#1 is a design fork (the owner's call):** in `always_reply` mode, should SuperBot
+    **(a)** stay silent when a message mentions another user/bot and **not** SuperBot (don't barge
+    into others' conversations — the most likely intended behavior), **(b)** keep answering
+    everything but **strip *all* mention tokens** before the model and pass an explicit
+    `is_mention=False` framing so it never says "you pinged me", or **(c)** leave `always_reply` as
+    a power-user opt-in and only fix the "pinged me" copy? These change ambient semantics the owner
+    configured intentionally, so they are flagged, not patched unilaterally.
+- **Stays-fixed guard (to ship with the chosen fix):** a `natural_language_stage` unit test that a
+  message pinging only another user/bot (and `@everyone`) does **not** set `is_mention` / does not
+  trigger a reply under the chosen rule. (Live AI path → also wants a Q-0086 runtime walk.)
+- **Status:** OPEN — root cause identified 2026-06-20; **routed to the owner** for the #1 behavior
+  decision (agent recommendation: option **(a)** + the #2 hardening). Noted per the owner's
+  "make a note of this" instruction; not patched in the gated AI behavior path without his call +
+  a runtime-verified session.
+
 ## BUG-0018 — committed `botsite/data/site.json` drifts red whenever idea docs change (hard equality test over a high-churn derived field) — FIXED (root)
 
 - **Symptom:** `tests/unit/scripts/test_export_dashboard_data.py::test_committed_site_json_matches_a_fresh_build`

--- a/docs/planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md
+++ b/docs/planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md
@@ -10,6 +10,40 @@
 > (in-session answers, 2026-06-20): **plan only, build nothing yet**, and for the music half
 > **architecture-review pack only** (respect the Q-0041 voice gate). This doc is that plan.
 
+> **▶ Live demand signal (2026-06-20):** a real user in the owner's community said he still runs
+> **multiple bots** specifically *"like poketwo and music bot"* because SuperBot lacks those
+> features. The owner's directive: *"we should make sure we have a similar/better version of the
+> Pokémon system."* This **raises the priority** of the Pokétwo half (especially Lane A + the
+> catching/collection lanes below) from "nice extension" to "close a real why-I-need-another-bot
+> gap" — the goal is **feature-parity-or-better with Pokétwo's loop**, built on our own world
+> spine, not a literal Pokémon clone. (Music stays Q-0041-gated; the [arch-review
+> pack](voice-music-architecture-review-2026-06-20.md) is the path to closing that gap too.)
+
+## 0. What Pokétwo actually does (one-screen reference)
+
+So the owner-designer has the loop in front of him (he noted he's *"not sure what poketwo can
+exactly do"*). Pokétwo recreates Pokémon in chat:
+
+1. **Activity spawns** — wild Pokémon appear in a channel after ~N user messages (engagement
+   loop). Players type `catch <name>` to claim; `hint` reveals letters.
+2. **Collection** — every catch goes to a personal inventory; rich **filters/sort** (level, IV,
+   rarity, region, shiny, favourite, duplicates) manage large collections; a Pokédex tracks
+   seen/caught.
+3. **Global marketplace + trading** — list/search/buy Pokémon with in-game currency; plus direct
+   player-to-player trades.
+4. **Battling** — turn-based 3v3 using real Pokémon moves.
+5. **Shiny hunting & rarity** — tiny base shiny chance, boosted by streak "hunts" or a shop charm.
+6. **Two currencies** — earned PokéCoins + premium (buyable) shards; shop sells boosts, evolution
+   items, incense (forces spawns), etc.
+7. **Quests, events, time/weather** — daily quests, seasonal events, time/weather-gated evolutions.
+
+**Our parity map (verdicts in §2):** 1 → **Lane A Wild Encounters** (the missing engine) · 2 →
+**Lane B** (extend fishing/inventory) + a "dex" of seen vs. caught · 3 → the **economy-marketplace
+roadmap** (gated) · 4 → battles (owner-design, P2W-sensitive) · 5 → **Lane D** shiny/variant
+(cosmetic, not buyable) · 6 → **single earned currency only** (Q-0039 rejects buyable advantage —
+this is the deliberate "better, not P2W" divergence) · 7 → **Lane C** quests + (deferred)
+time/weather under the Q-0182 world model.
+
 ## 1. The core reframe — most of this already has a lane
 
 The report reads as "here are two successful bots, copy their features." The proper response in


### PR DESCRIPTION
## What

Follow-up to #1180 from a Discord screenshot the owner shared. **Docs-only.** Records two things:

### 1. BUG-0019 — AI replies to messages aimed at *other* bots
A user pinged **`@Carl-bot`** and SuperBot replied *"Hey! You've just pinged me…"*. Root-caused in `docs/health/bug-book.md` (OPEN):

- **`always_reply` ambient mode answers everything** — `ai_natural_language_policy.py` only special-cases `mention_only`/`disabled`, so a message addressed to another bot still gets a reply; and the model hallucinates a "you pinged me" greeting because **other** users' mention tokens aren't stripped before the prompt (only SuperBot's own is).
- **`mentioned_in` `@everyone` footgun** (`natural_language_stage.py:229`) — discord.py's `mentioned_in` returns True on `mention_everyone`, so `@everyone` reads as a personal ping.

The `@everyone` part is an unambiguous hardening; the `always_reply` part is a **behavior fork** the owner must decide (stay silent when addressed to another bot · strip all mentions + never say "pinged me" · leave as power-user opt-in). Noted per the owner's "make a note of this", **not** speculatively patched in the gated AI path (Q-0086 wants a runtime walk). Agent recommendation: option (a) + the `@everyone` hardening.

### 2. Pokétwo demand signal
A real user runs multiple bots (poketwo + music) because we lack those features; owner wants *"a similar/better version of the Pokémon system."* Added the demand signal + a one-screen *"what Pokétwo actually does"* reference and parity map to the feature-mapping plan.

## Status

🔴 Born-red (session card `in-progress`); flips to `complete` as the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJBXy9mKixJKzjTtch2WmT

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJBXy9mKixJKzjTtch2WmT)_