### PR TITLE
docs: creature roster sizing + legal music-bot findings

### DIFF
--- a/.sessions/2026-06-20-creature-roster-and-music-legal-findings.md
+++ b/.sessions/2026-06-20-creature-roster-and-music-legal-findings.md
@@ -1,6 +1,6 @@
 # 2026-06-20 — Creature roster sizing + music-bot legal findings (documentation)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Arc
 
@@ -15,17 +15,83 @@ things and then said *"document all the useful findings of today"*:
 This session routes the useful findings into their durable homes. **Docs only — no `disbot/`
 runtime code.**
 
-## Plan (what this PR adds)
+## Shipped (PR #1185, docs only)
 
-- **Creature design doc** — roster-sizing model (Pokétwo ~1000+ real species; ours = sim-core 12 /
-  v1 launch ~30–40 / data-driven catalog / text-first art), and the *enforcement-economics* reason
-  Pokétwo "can" use real names (survivorship, not permission).
-- **Q-0187** — add the roster-size sub-decision (d).
-- **Voice/music decision pack §1** — the concrete **compliant-source menu** + cost-per-lane table +
-  the royalty-free-radio / Spotify-Connect sweet spot (makes the Q-0041 L2 lane pickable).
-- The shared cross-cutting principle (**growth/visibility is the enforcement trigger; publish-safe
-  means not depending on invisibility**) stated in both planning docs with a cross-link.
+- **Creature design doc §1** — *why Pokétwo "can" use real names*: **survivorship, not permission**
+  (no license; selective enforcement economics; too-small-to-bother, strikeable at any time). States
+  the load-bearing principle: **growth/visibility is the enforcement trigger; publish-safe = a
+  design that doesn't depend on staying invisible** — cross-linked to the music decision.
+- **Creature design doc §2 + new §2a** — roster sizing: Pokétwo ~1,000+ real species (+ forms +
+  shinies); ours = **sim-core 12 → v1 launch ~30–40 → growth in waves**, with a **data-driven JSON
+  catalog** (towers/fish-roster pattern) + **text/emoji-first art** so a bigger roster is cheap and
+  every creature is sim-validated before it ships.
+- **Q-0187** — added sub-decision **(d) roster size** (the tiered/data-driven model, recommended).
+- **Voice/music decision pack — new §1a** — the concrete **L2 compliant-source menu** (royalty-free
+  catalogs · Spotify-Connect remote · preview clips · file jukebox · podcast RSS) + a
+  **cost-per-lane table** + the **royalty-free-radio + Spotify-Connect sweet spot** recommendation;
+  wired into §6 decision-#2 (narrows the open L1/L2/L3 fork to "pick a lane"). Enriched the §1
+  history (Groovy + Rythm Sept-2021 shutdowns, the ToS-not-just-copyright cause, the scale trigger).
 
-## Shipped
+Verification: `check_docs --strict` ✓ · `check_plan_homing` ✓ (39/39) · `check_quality --check-only`
+✓ (the 3 `edit_in_place` WARNs are the pre-existing `views/ai/` AI-nav findings, untouched here).
 
-_(filled at close)_
+## Decisions made alone
+
+None binding — all findings are *recommendations routed to the owner* (Q-0187d roster size; Q-0041
+music legal-lane menu). Editorial choices only (where each finding's durable home is). Reversible.
+
+## Flagged for maintainer
+
+- **Q-0187(d)** — confirm the tiered/data-driven roster model (sim-core 12 → v1 ~30–40 → waves).
+- **Q-0041 decision #2** — the music legal lane is now a concrete menu; the agent recommendation is
+  **royalty-free radio + Spotify-Connect remote** (low-cost, publish-safe).
+
+## 💡 Session idea (Q-0089)
+
+**A one-page `docs/research/ip-and-tos-safety.md` "publish-safe checklist" for any feature that
+wraps a third-party service or IP.** Today the same principle — *growth/visibility is the
+enforcement trigger; don't depend on invisibility* — independently governed two unrelated decisions
+(creature names, music sourcing), and each doc re-derived it from scratch. A tiny shared checklist
+("does survival depend on staying small/unpromoted? does it breach a ToS/copyright? is there a
+licensed/original alternative?") would let the *next* such feature (e.g. a future API integration)
+get the answer in one read instead of re-litigating the music-bot history each time. Lane =
+research/docs. (Captured, not built this run — dedup-checked `docs/research/`:
+`external-systems-watchlist.md` is agent-workflow-focused, not this product/legal axis.)
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous run (#1183, the creature sim + design) did the **hard part right**: it built a runnable
+simulator that *proved* playability and surfaced the level-normalization rule before any `disbot/`
+code — exactly the balance-before-build discipline. **What it left on the table:** it fixed the
+roster at "12 for v1" without distinguishing *balance-core* from *launch collection* size — so when
+the owner asked "how many creatures?", the doc had no answer and this session had to add §2a. The
+lesson: a design doc that picks a number should say **what the number is for** (validation vs.
+launch vs. growth), because the next person will ask. **System improvement:** the
+balance-before-build idea (#1183's Q-0089) is stronger if it's explicit that the *sim roster* and
+the *launch roster* are different artifacts — the sim validates a small representative set, but the
+plan must also name the launch-scale target and how it grows. Folded that distinction into §2a so
+the convention is concrete, not implied.
+
+## 📤 Run report
+
+- **Did:** documented the day's creature-roster + music-legal findings into their durable homes ·
+  **Outcome:** shipped (docs only)
+- **Shipped:** #1185 — creature design §1/§2/§2a + Q-0187(d) + voice/music §1a menu & cost table
+- **Run type:** `manual · owner-task (document findings)`
+- **⚑ Owner decisions needed:** Q-0187(d) roster model · Q-0041 #2 music legal lane (menu provided)
+- **⚑ Owner manual steps:** none
+- **⚑ Self-initiated:** none (owner-directed: "document all the useful findings of today")
+- **↪ Next:** build the **~30–40 original creature JSON catalog** + sim-validate it (the named §2a
+  next design step), then the catch half (Lane A / Q-0186); music stays gated on Q-0041 #2.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs opened this session | 1 (#1185, docs only, auto-merge on green) |
+| Runtime (`disbot/`) code changed | 0 |
+| Docs updated | 3 (creature design+sim plan · voice/music pack · question router) |
+| Findings documented | 5 (roster size · Pokétwo-name survivorship · music history · legal-music menu · the shared publish-safe principle) |
+| New owner sub-decisions routed | 1 (Q-0187d) + 1 narrowed (Q-0041 #2) |
+| CI-red rounds | 1 (by-design born-red session gate only) |
+| New ideas contributed | 1 (`ip-and-tos-safety.md` publish-safe checklist) |

--- a/.sessions/2026-06-20-creature-roster-and-music-legal-findings.md
+++ b/.sessions/2026-06-20-creature-roster-and-music-legal-findings.md
@@ -1,0 +1,31 @@
+# 2026-06-20 — Creature roster sizing + music-bot legal findings (documentation)
+
+> **Status:** `in-progress`
+
+## Arc
+
+Continuation of the Pokétwo / creature-game + music lane. In conversation the owner asked four
+things and then said *"document all the useful findings of today"*:
+
+1. *"How many creatures should we use? How many does Pokétwo use? What kind?"*
+2. *"How is it possible that Pokétwo can use the original names?"*
+3. *"What happened to the music bots and why weren't they allowed?"*
+4. *"How would we create a music bot while staying within the rules?"*
+
+This session routes the useful findings into their durable homes. **Docs only — no `disbot/`
+runtime code.**
+
+## Plan (what this PR adds)
+
+- **Creature design doc** — roster-sizing model (Pokétwo ~1000+ real species; ours = sim-core 12 /
+  v1 launch ~30–40 / data-driven catalog / text-first art), and the *enforcement-economics* reason
+  Pokétwo "can" use real names (survivorship, not permission).
+- **Q-0187** — add the roster-size sub-decision (d).
+- **Voice/music decision pack §1** — the concrete **compliant-source menu** + cost-per-lane table +
+  the royalty-free-radio / Spotify-Connect sweet spot (makes the Q-0041 L2 lane pickable).
+- The shared cross-cutting principle (**growth/visibility is the enforcement trigger; publish-safe
+  means not depending on invisibility**) stated in both planning docs with a cross-link.
+
+## Shipped
+
+_(filled at close)_

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -6868,6 +6868,14 @@ decide. Raw levels still matter for PvE/collection prestige. Confirm normalized 
 **(c) Art.** Emoji/text v1 → an **original sprite pack** later (same path as the gear paper-doll —
 owner drops art into `disbot/assets/`). Confirm the v1 visual bar.
 
+**(d) Roster size.** For scale, **Pokétwo uses ~1,000+** real species (full National Dex + forms +
+shinies) — we can't/shouldn't mirror that (each original creature is a design/balance/art cost). Even
+art-team originals are small (Temtem ~160, Coromon ~120). **Recommendation: tier it** — **sim-core 12
+→ v1 launch ~30–40 → growth in waves**, with a **data-driven JSON catalog** (the `towers.json` /
+fish-roster pattern) and **text/emoji-first art**, so a bigger roster is cheap *and* every creature is
+sim-validated before it ships. 12 proves balance; ~30–40 gives the collection "dex" feel. See the
+design+sim plan §2a.
+
 **Agent note:** none of this blocks the *catch* half (Lane A, Q-0186). The battle subsystem is its
 own runtime session once (a)/(b) are confirmed. **Home:** the design+sim plan + this Q-block.
 Related: Q-0039 (no P2W), Q-0186 (Pokétwo build sequence), Q-0182 (world model), Q-0041 (the

--- a/docs/planning/creature-game-design-and-sim-2026-06-20.md
+++ b/docs/planning/creature-game-design-and-sim-2026-06-20.md
@@ -29,6 +29,20 @@
   posture that took down the music bots (the report's own Rythm/Hydra history). For a bot we want to
   **publicly launch** (the bot-site ambition), inheriting that risk is the wrong trade.
 
+**Why Pokétwo "can" use real names — survivorship, not permission (owner asked directly).** It has
+**no license** and is straightforwardly infringing. It survives on *enforcement economics*, not a
+right: Nintendo enforces **selectively** (suing every fan project is costly and bad PR), and
+prioritizes targets that distribute the actual games/ROMs or ripped assets, make real money off the
+IP, compete with a Nintendo product, or get big press. A niche Discord bot trafficking in *data* +
+community art has dodged all four — so far. That is not safety; it is being **too small to bother
+with**, and it can be struck at any time (AM2R, Pokémon Uranium, and the music bots all were). **The
+load-bearing principle:** what makes Pokétwo possible — staying small and unpromoted — is the
+*opposite* of what we want (a bot we **publicly launch and market** on the bot-site). **Growth /
+visibility is the enforcement trigger; "publish-safe" means a design that does not depend on staying
+invisible.** This same principle governs the parallel music-legal decision
+([voice/music decision pack](voice-music-architecture-review-2026-06-20.md) §1) — there it forbids
+YouTube-ripping; here it forbids real Pokémon names.
+
 **Decision (recommended, routed as Q-0187):** **build an original creature roster** — our own
 names, types, and (later) art. This is the proven path of Temtem / Cassette Beasts / Coromon /
 Palworld: the *loop* people love, none of the IP risk, and it's **publishable**. It also fits our
@@ -40,8 +54,10 @@ The v1 roster below is original (Cindling, Magmaul, Rippling, …).
 - **Elements (6, original):** Ember · Tide · Bramble · Spark · Stone · Gust. Symmetric type chart —
   each is **strong vs the next two**, **weak vs the previous two**, neutral vs its opposite. (`1.5×`
   / `0.67×` / `1.0×`.) Symmetric by construction so no element is inherently best.
-- **Creatures:** 12 for v1 (2 per element), spread across **rarity** (Common→Epic, bigger stat
-  budget) and **archetype** (attacker / tank / balanced / speedster). Stats: HP / ATK / DEF / SPD.
+- **Creatures (roster size — see §2a):** **12** in the sim core (2 per element) for balance
+  validation; the **v1 launch target is ~30–40** original creatures for collection depth. Each is
+  spread across **rarity** (Common→Epic, bigger stat budget) and **archetype**
+  (attacker / tank / balanced / speedster). Stats: HP / ATK / DEF / SPD.
 - **Catch:** wild encounters (Lane A) spawn a creature; catch chance = rarity base × a small
   player-level bonus. Rarer = harder. Caught creatures join your collection (reuses the
   fishing-style catch log + `game_xp`).
@@ -52,6 +68,35 @@ The v1 roster below is original (Cindling, Magmaul, Rippling, …).
   grind/whale-fest — exactly the **pay-to-win** outcome Q-0039 forbids. Normalizing to a flat level
   (competitive-Pokémon style) makes **types + team-building + ordering** decide, so PvP rewards
   *skill*, not *time spent*. (Raw levels still matter for PvE/collection prestige.)
+
+## 2a. Roster size — how many creatures (owner asked: "how many should we use?")
+
+**For scale: Pokétwo uses ~1,000+** real Pokémon (the full National Dex, currently 1,025 species)
+**plus hundreds of alternate forms** (regional / mega / Gigantamax / event) and a **shiny variant of
+every one** — a multi-hundred-hour completion grind that is itself a big part of the hook. We **can't
+and shouldn't** mirror that: every original creature is a design + balance + (eventually) art cost we
+own. Original monster-catchers ship far smaller even *with* art teams — Temtem ~160, Coromon ~120,
+Cassette Beasts ~140, Palworld ~150.
+
+**The v1 model (recommended, routed as Q-0187d) — tier the roster, make it data-driven:**
+
+| Stage | Count | Purpose |
+|---|---|---|
+| **Sim / playable core** | **12** (current) | Prove the loop + balance — done, verdict PLAYABLE |
+| **v1 launch roster** | **~30–40** (5–7 per element, spread across rarities) | Enough for a satisfying "dex" + real team variety, without art-blocking |
+| **Growth ("waves" / seasons)** | +10–20 each | Expand like real catchers add generations — keeps the collection alive |
+
+Twelve is right for *balance validation* but too thin for the *collection feel* that makes catching
+fun (a dex you fill in one sitting isn't a hook). Two choices make ~30–40 cheap **and** safe:
+
+1. **Text/emoji-first art (§5c)** — a bigger roster costs ~nothing when a creature is an emoji + name
+   + stat block; sprites come later, like the gear paper-doll did.
+2. **Creature-as-data** — the engine loads creatures from a **JSON catalog** (the `towers.json` /
+   fish-roster pattern), so *adding* a creature is a data row, not code. This is what makes
+   "ship 12 → grow to ~40 → seasons" a non-event architecturally, and it lets the **same
+   `creature_battle_sim.py`** validate the *whole* launch roster before it ships (the
+   balance-before-build gate). Building that catalog + sim-validating ~30–40 is the natural next
+   design step before any catch-engine build.
 
 ## 3. Simulator + headline findings
 
@@ -89,8 +134,10 @@ for.
 
 Routed to **Q-0187**: (a) confirm **original creatures** (recommended) vs. real Pokémon names;
 (b) confirm **PvP = level-normalized** (recommended) vs. raw-level PvP; (c) creature *art* approach
-(emoji/text v1 → original sprite pack later, like the gear paper-doll). Build sequencing for the
-catch half stays under **Q-0186** (Lane A first).
+(emoji/text v1 → original sprite pack later, like the gear paper-doll); **(d) roster size — confirm
+the tiered model (§2a): sim-core 12 → v1 launch ~30–40 → growth in waves, with a data-driven JSON
+catalog and text-first art** (recommended). Build sequencing for the catch half stays under
+**Q-0186** (Lane A first).
 
 → relates [feature-mapping plan](poketwo-musicbot-feature-mapping-plan-2026-06-20.md) ·
 [explore-hub spine](explore-hub-federated-world-plan-2026-06-19.md) ·

--- a/docs/planning/voice-music-architecture-review-2026-06-20.md
+++ b/docs/planning/voice-music-architecture-review-2026-06-20.md
@@ -15,10 +15,16 @@
 
 ## 1. The decisive constraint, stated first — legal
 
-The report itself documents the history: **Rythm and Hydra received cease-and-desists** after
-YouTube's enforcement; the original Rythm shut down, Hydra pivoted away from music, Rythm later
-returned **only with official licensing + premium tiers**. Any music feature here lives or dies on
-this, so it is the **first** decision, not an afterthought.
+The report itself documents the history: in **September 2021**, after YouTube enforcement,
+**Groovy and Rythm — among the largest Discord bots in existence (Rythm ~560M users / ~20M
+servers) — were shut down within weeks**, and **Hydra** survived only by pivoting away from YouTube
+music; **Rythm later returned only with official licensing + premium tiers**. The cause was a **ToS**
+breach as much as song copyright — YouTube's terms explicitly forbid separating audio from video and
+streaming it through unofficial clients, which is exactly what every YouTube-sourced music bot does
+(bypassing the ads/Premium that pay rightsholders). The decisive lesson: these bots ran *for years*
+while tolerated, and **scale + visibility — not a change in the law — is what triggered enforcement**
+(the same publish-safe principle as §1a / the creature-IP decision). Any music feature here lives or
+dies on this, so it is the **first** decision, not an afterthought.
 
 **The fork the owner must choose:**
 
@@ -36,6 +42,52 @@ this, so it is the **first** decision, not an afterthought.
 **Recommendation:** if music ships at all, **L2** for anything public-facing; **L1** only as an
 explicitly-private, owner-risk-accepted instance. Decide L1/L2/L3 **before** any infra is built —
 it changes every layer below.
+
+### 1a. The L2 compliant-source menu — *how* you stay inside the rules (owner asked directly)
+
+The core principle (shared with the creature-IP decision — **growth/visibility is the enforcement
+trigger; publish-safe = a design that does not depend on staying invisible**; see
+[creature design+sim](creature-game-design-and-sim-2026-06-20.md) §1): the thing that killed Rythm
+wasn't "music," it was **ripping audio from a source whose ToS forbids it** (YouTube). So the whole
+game is **sourcing audio from somewhere that actually permits programmatic playback.** The legal
+ways:
+
+1. **Royalty-free / Creative-Commons / public-domain catalogs** — YouTube Audio Library, Pixabay
+   Music, Free Music Archive, **Jamendo** (real API), ccMixter, Incompetech, public-domain classical.
+   Freely streamable → a 100%-safe lofi / ambient / gaming-radio bot. (Not the commercial Top-40 —
+   that's the trade.)
+2. **Remote-control the user's *own* licensed player (Spotify-Connect pattern)** — Spotify's API
+   **won't** stream full tracks, but its **Connect API** lets the bot control playback on the user's
+   own Spotify **Premium** client. Their licensed app plays; the bot is a queue / now-playing /
+   vote-skip remote. Legal because the bot never touches the audio stream — **and it needs no audio
+   path at all** (no FFmpeg, no Lavalink).
+3. **Preview clips** — Spotify / Apple Music / Deezer expose legal **30-second previews**.
+4. **User-uploaded / self-owned files (jukebox)** — members upload audio *they* hold rights to; the
+   bot just plays the file.
+5. **Podcasts / public RSS audio** — most feeds publish freely-distributable audio URLs.
+
+**Permanently off-limits (this *is* the Rythm violation):** `yt-dlp`-ripping YouTube/SoundCloud full
+tracks into voice; streaming **full commercial tracks** from any source without a streaming license.
+**The honest constraint:** there is **no legal way to offer "type any song → hear the full
+commercial track, free"** — that exact capability is *inherently* the infringing one, which is why
+every bot offering it was killed or had to license (the report's note: **Rythm only returned with
+official licensing + premium tiers**).
+
+**Cost-per-lane (ties to §2 infra):**
+
+| Legal model | What users get | Infra / cost |
+|---|---|---|
+| Royalty-free radio | Lofi/ambient/gaming, full playback | **Low** — lightweight FFmpeg over a fixed catalog; **no per-request extraction node** |
+| Spotify-Connect remote | Control their *own* Premium playback | Medium — OAuth; users need Premium; **no audio path** |
+| Preview clips | 30s samples | Low |
+| File jukebox | Whatever they upload | Low (FFmpeg play of an uploaded file) |
+
+**Sweet spot (agent recommendation, challengeable):** a **royalty-free "lofi/gaming radio"** lane,
+optionally **+ Spotify-Connect remote** for users who want their own music — both fully inside the
+rules, both **low-cost** (they dodge the Lavalink/per-request-extraction expense that, alongside
+legal risk, was the historical bot-killer), and both a clean fit for a community/gaming bot's
+identity. This narrows the §6 decision-#2 "legal lane" from an open L1/L2/L3 fork to **"pick a lane
+from the menu above."**
 
 ## 2. Infrastructure fit (the part the rest of the bot has never needed)
 
@@ -101,7 +153,9 @@ To lift the Q-0041 voice gate, the owner needs to decide, **in order**:
 
 1. **Go / no-go / later** on music at all (vs. keeping the bot's identity games/AI/community).
 2. **Legal lane** — L1 self-host (private only, risk-accepted) vs. L2 licensed/preview-only
-   (public-safe) vs. L3 defer. *Everything else depends on this.*
+   (public-safe) vs. L3 defer. *Everything else depends on this.* **§1a narrows L2 to a concrete
+   pickable menu** (royalty-free radio · Spotify-Connect remote · previews · file jukebox), with the
+   royalty-free-radio + Spotify-remote sweet spot recommended.
 3. **Infra acceptance** — willing to host/pay for an audio path (FFmpeg ± Lavalink) on Railway?
 4. **Prerequisite ordering** — Q-0041 wants the YouTube/Twitch **alert** provider contract proven
    first; build that before voice, or run voice as an independent track?


### PR DESCRIPTION
Documents the useful findings from today's creature-game + music conversation into their durable homes (docs only — no `disbot/` runtime code).

## What this routes

**Creature roster sizing** (`docs/planning/creature-game-design-and-sim-2026-06-20.md` §2)
- Pokétwo uses ~1,000+ real Pokémon (full National Dex + forms + shinies) — the collection grind is its hook.
- Our model: **sim-core 12** (balance validation, done) → **v1 launch ~30–40** original creatures → **growth in waves**. **Data-driven catalog** (creature = a JSON row, like the fish roster) + **text/emoji-first art** make a bigger roster cheap and safe.

**Why Pokétwo can use real names** (§1)
- It can't, legally — it's *survivorship*, not permission. Enforcement economics (selective, scale-triggered). The same "stay invisible" posture that killed the music bots → wrong for a bot we want to publicly launch.

**Legal music bot** (`docs/planning/voice-music-architecture-review-2026-06-20.md` §1)
- Concrete **compliant-source menu** (royalty-free catalogs · Spotify-Connect remote · preview clips · file jukebox · podcast RSS) + **cost-per-lane table** + the **royalty-free-radio + Spotify-Connect sweet spot** — makes the existing Q-0041 L2 lane a single pick.

**Cross-cutting principle**
- *Growth/visibility is the enforcement trigger; publish-safe means not depending on invisibility* — stated in both planning docs, links the creature-IP and music-legal decisions.

**Router**
- Q-0187 gains the roster-size sub-decision (d).

## Verification
- `check_docs --strict`, `check_plan_homing`, `check_quality --check-only` green (run before final push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJBXy9mKixJKzjTtch2WmT)_