### PR TITLE
fix(ai): @everyone/@here no longer reads as a personal ping (BUG-0019 #2)

### DIFF
--- a/.sessions/2026-06-20-bug0019-everyone-false-ping-hardening.md
+++ b/.sessions/2026-06-20-bug0019-everyone-false-ping-hardening.md
@@ -1,24 +1,83 @@
 # Session — funny-franklin · BUG-0019 #2 false-personal-ping hardening
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 **Run type:** routine · dispatch
-**Branch:** `claude/funny-franklin-tfnzra`
+**Branch:** `claude/funny-franklin-tfnzra` · **PR:** #1186
 
-## What I'm about to do
-Ship the **unambiguous half of BUG-0019** (the open AI-reply bug). The bug entry splits into
-two mechanisms: **#1** (`always_reply` ambient mode barges into others' conversations) is a
-design fork **routed to the owner** — not touched. **#2** is flagged in the bug book as
-*"unambiguous → hardening"*: `ClientUser.mentioned_in(message)` returns `True` on an
-`@everyone`/`@here` blast (`message.mention_everyone`), so a server-wide ping reads as a
-**personal** mention and flips the `mention_only` policy gate open. Fix: compute `is_mention`
-as a **direct** mention only — the bot's own id present in `message.mentions`, excluding
-`mention_everyone`.
+## What this PR does (CLASS: fix — bugs-first)
+Shipped the **unambiguous half of the open AI-reply bug, BUG-0019**. The bug splits into two
+mechanisms; the bug book flags **#2** as *"unambiguous → hardening"* and **#1** as a design fork
+for the owner.
 
-- Replace the `mentioned_in` call in `natural_language_stage.py` with a `_is_direct_bot_mention`
-  helper (membership in `message.mentions`).
-- Ship the stays-fixed guard: a `natural_language_stage` unit test where `@everyone`
-  (`mention_everyone=True`) does **not** set `is_mention`, and a direct `<@bot>` still does.
-- Record BUG-0019 #2 as FIXED in the bug book (entry stays OPEN for the #1 owner decision).
+- **Root cause (#2):** the natural-language stage computed `is_mention` via
+  `ctx.bot.user.mentioned_in(message)`. discord.py's `ClientUser.mentioned_in` short-circuits
+  `True` on `message.mention_everyone`, so an `@everyone`/`@here` blast read as a **personal**
+  mention and flipped the `mention_only` policy gate open — the bot replied to a message that
+  never pinged it.
+- **Fix:** `is_mention` is now `natural_language_stage._is_direct_bot_mention(message, bot_user)`
+  — membership of the bot's own id in `message.mentions`. Only a literal `<@bot_id>` counts; an
+  everyone/here blast does not. Defensive (missing id / non-iterable `mentions` → `False`).
+- **Stays-fixed guard:** `tests/unit/runtime/ai/test_natural_language_stage.py` ::
+  `test_everyone_blast_is_not_a_personal_ping` (+ direct-mention / other-user /
+  direct-alongside-everyone / defensive cases). Two existing stage test fixtures that drove
+  `is_mention` through the old `mentioned_in` double were updated to supply a real
+  `message.mentions` list (also in `test_natural_language_stage_memory.py` +
+  `test_btd6_central_policy_integration.py`).
+- Recorded BUG-0019 **#2 → FIXED** in the bug book (entry stays OPEN for the #1 owner decision)
+  and added a Recently-shipped ledger entry for #1186.
 
-CLASS: fix — bugs-first, contained/reversible/test-covered → self-merge on green.
+**Mechanism #1 (untouched):** `always_reply` ambient mode barges into others' conversations — a
+design fork that changes ambient semantics the owner configured intentionally. Stays OPEN, routed
+to the owner (agent recommendation: option (a) — stay silent when a message pings another
+user/bot and not SuperBot; wants a Q-0086 runtime-verified session).
+
+## Verification
+- `python3.10 scripts/check_quality.py --full` → **All checks passed** (black/isort/ruff/check_docs/
+  check_consistency 0-err/mypy/**11011 passed, 44 skipped**).
+- `python3.10 scripts/check_architecture.py --mode strict` → clean (pre-existing WARN only).
+
+## ⟲ Previous-session review (Q-0102)
+The previous run (`funny-franklin-session-enders-claim-gap`) was a clean docs-only session-ender
+pass — it correctly did the standing enders a minimal earlier card skipped, and surfaced a genuine
+systemic gap (the claim ledger doesn't cover bug-book pickups → captured as an idea). What it
+*could* have done better: with a clean tree, main healthy, and an **OPEN bug already in the bug
+book carrying an explicitly-unambiguous, offline-testable sub-fix (BUG-0019 #2)**, the bugs-first
+rule pointed at real code work it left on the table in favor of a docs-only pass. **System
+improvement surfaced:** an empty-fire dispatch should grep the bug book for `PARTIALLY`/`OPEN`
+entries whose *proposed fix* is self-labelled "unambiguous"/"hardening" before concluding "no
+ungated code lane" — that signal (a bug author pre-clearing a sub-fix) is a high-value, low-risk
+startable the current ▶ Next-action prose doesn't index. Candidate: have
+`check_bug_book_rootfix_backlog.py` also surface OPEN entries with an unambiguous sub-fix, not just
+deferred-root ones.
+
+## 💡 Session idea (Q-0089)
+**`bug-book-unambiguous-subfix-signal`** — when a bug entry is OPEN/PARTIALLY-FIXED because *part*
+of it needs an owner decision but another mechanism is self-described as "unambiguous → hardening"
+(exactly BUG-0019 #2), that ship-ready sub-fix is invisible to the empty-fire dispatch heuristics,
+which read "OPEN bug → needs owner" and move on. Idea: extend
+`scripts/check_bug_book_rootfix_backlog.py` (or a sibling) to flag entries whose proposed-fix text
+contains an "unambiguous"/"hardening"/"offline-unit-testable" sub-fix marker, so the next empty
+dispatch finds it as a startable. Genuine — this run *was* that missed startable. (Not built this
+run; would itself be a small stdlib guard a later run can promote.)
+
+## 💡 Doc audit (Q-0104)
+Bug book updated (BUG-0019 #2 FIXED, header → PARTIALLY FIXED, status fork preserved). Recently-shipped
+ledger entry added for #1186. No new owner decisions (mechanism #1 was already routed to the owner in
+the prior run's entry). `check_docs --strict` green in the full mirror.
+
+## 📤 Run report
+- **Run type:** routine · dispatch
+- **PRs:** #1186 (BUG-0019 #2 hardening) — self-mergeable, auto-merge armed by the enabler workflow.
+- ⚑ **Owner-decisions:** none (mechanism #1 remains routed to the owner from the prior entry — no new
+  decision raised this run).
+- ⚑ **Owner-manual-steps:** none (a merge auto-deploys; no data file changed, no `!btd6ops seed-data`).
+- ⚑ **Self-initiated:** none (BUG-0019 is an owner-reported bug in the bug book — bugs-first, not an
+  invented feature).
+
+## Handoff — ▶ next
+This run took the bugs-first lane (BUG-0019 #2). The ungated self-merge backlog beyond it stays thin
+(per the band-#1170 pass): next startables are the remaining `public-data-contract-field-snapshot`
+small guard, or a substantial `needs-hermes-review` lane (consistency-linter AI-nav PR 1 /
+procedures→skills Batch 2). **BUG-0019 #1** is the one live owner-gated follow-up: the `always_reply`
+barge-in design fork — needs the owner's option (a)/(b)/(c) call + a Q-0086 runtime-verified session.

--- a/.sessions/2026-06-20-bug0019-everyone-false-ping-hardening.md
+++ b/.sessions/2026-06-20-bug0019-everyone-false-ping-hardening.md
@@ -1,0 +1,24 @@
+# Session — funny-franklin · BUG-0019 #2 false-personal-ping hardening
+
+> **Status:** `in-progress`
+
+**Run type:** routine · dispatch
+**Branch:** `claude/funny-franklin-tfnzra`
+
+## What I'm about to do
+Ship the **unambiguous half of BUG-0019** (the open AI-reply bug). The bug entry splits into
+two mechanisms: **#1** (`always_reply` ambient mode barges into others' conversations) is a
+design fork **routed to the owner** — not touched. **#2** is flagged in the bug book as
+*"unambiguous → hardening"*: `ClientUser.mentioned_in(message)` returns `True` on an
+`@everyone`/`@here` blast (`message.mention_everyone`), so a server-wide ping reads as a
+**personal** mention and flips the `mention_only` policy gate open. Fix: compute `is_mention`
+as a **direct** mention only — the bot's own id present in `message.mentions`, excluding
+`mention_everyone`.
+
+- Replace the `mentioned_in` call in `natural_language_stage.py` with a `_is_direct_bot_mention`
+  helper (membership in `message.mentions`).
+- Ship the stays-fixed guard: a `natural_language_stage` unit test where `@everyone`
+  (`mention_everyone=True`) does **not** set `is_mention`, and a direct `<@bot>` still does.
+- Record BUG-0019 #2 as FIXED in the bug book (entry stays OPEN for the #1 owner decision).
+
+CLASS: fix — bugs-first, contained/reversible/test-covered → self-merge on green.

--- a/disbot/core/runtime/ai/natural_language_stage.py
+++ b/disbot/core/runtime/ai/natural_language_stage.py
@@ -127,6 +127,32 @@ def _maybe_typing(channel: object) -> AbstractAsyncContextManager[None]:
     return _NullAsyncContext()
 
 
+def _is_direct_bot_mention(
+    message: discord.Message,
+    bot_user: object | None,
+) -> bool:
+    """True only when the bot is *directly, personally* mentioned.
+
+    discord.py's :meth:`ClientUser.mentioned_in` returns ``True`` for an
+    ``@everyone``/``@here`` blast (it short-circuits on
+    ``message.mention_everyone``), so a server-wide ping would read as a
+    personal mention and flip the ``mention_only`` policy gate open
+    (BUG-0019 #2 — the "false personal ping" class). We instead test
+    membership of the bot's own id in ``message.mentions``, so only a
+    literal ``<@bot_id>`` token counts — never an ``@everyone``/``@here``
+    blast. Defensive: a missing bot id or a non-iterable ``mentions``
+    (a duck-typed test double) yields ``False`` rather than raising.
+    """
+    bot_id = getattr(bot_user, "id", None)
+    if bot_id is None:
+        return False
+    try:
+        mentioned = list(getattr(message, "mentions", None) or ())
+    except TypeError:
+        return False
+    return any(getattr(member, "id", None) == bot_id for member in mentioned)
+
+
 def _strip_bot_mention(text: str, *, bot_user_id: int | None) -> str:
     """Remove all mentions of the bot from ``text``.
 
@@ -226,7 +252,7 @@ class AINaturalLanguageStage:
             getattr(message.channel, "category_id", None) if message.channel else None
         )
         user_id = message.author.id
-        is_mention = ctx.bot.user is not None and ctx.bot.user.mentioned_in(message)
+        is_mention = _is_direct_bot_mention(message, ctx.bot.user)
         bot_user_id = getattr(getattr(ctx.bot, "user", None), "id", None)
 
         # The model sees the message with the bot mention stripped out

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -222,6 +222,12 @@ Source code and merged PRs win over anything written here.
 > auto-opens a `reconcile` issue at the boundary that fires the docs-reconciliation routine). Reset
 > this marker to the latest PR after a pass.
 
+- **#1186 (2026-06-20, BUG-0019 #2 — `@everyone`/`@here` false-personal-ping hardening)** — the AI
+  natural-language stage computed `is_mention` via `ClientUser.mentioned_in`, which short-circuits
+  `True` on `message.mention_everyone`, so a server-wide blast flipped the `mention_only` policy gate
+  open. Replaced with `natural_language_stage._is_direct_bot_mention` (bot id in `message.mentions`);
+  stays-fixed guard `test_everyone_blast_is_not_a_personal_ping`. Bug-book mechanism **#1** (the
+  `always_reply` "barge into others' conversations" design fork) stays OPEN, routed to the owner.
 - **#1156 · #1158 · #1160 (2026-06-19/20, federated Explore-hub spine + world registry)** — spine
   **PR 1** (#1156): a top-level Explore *world* hub (town-square) + the world registry, re-parenting the
   #1131 mining Explore sub-hub. **PR 3** (#1160): the cross-game world card — `game_xp_service.world_identity()`

--- a/docs/health/bug-book.md
+++ b/docs/health/bug-book.md
@@ -23,7 +23,7 @@
 > later empty-fire dispatch run can pick them up instead of them sitting un-promoted (the
 > trap BUG-0018 hit). Advisory by default; `--strict` exits 1 on a non-empty backlog.
 
-## BUG-0019 — AI replies to messages aimed at *other* bots and claims "you've just pinged me" — OPEN (root cause identified; fix needs one owner behavior decision)
+## BUG-0019 — AI replies to messages aimed at *other* bots and claims "you've just pinged me" — PARTIALLY FIXED (mechanism #2 hardened; #1 awaits one owner behavior decision)
 
 - **Symptom (owner-reported, 2026-06-20, live in a community server):** a user pinged
   **another** bot — `@Carl-bot (?)` — in a channel, and **SuperBot replied anyway**: *"Hey!
@@ -52,10 +52,17 @@
      `mention_only` gate open. Independent of the screenshot, but the same "false personal ping"
      class.
 - **Proposed fix (needs one owner behavior decision — see flag):**
-  - **#2 is unambiguous → hardening:** compute `is_mention` as a **direct** mention only —
-    `bot_user.id in {m.id for m in message.mentions}` (exclude `mention_everyone`). A server-wide
-    `@everyone` should never read as a personal ping. Offline-unit-testable with a stub message;
-    ship a regression test that fails against `mentioned_in`'s `mention_everyone=True` path.
+  - **#2 is unambiguous → hardening — DONE (2026-06-20 dispatch run):** `is_mention` is now computed
+    by `natural_language_stage._is_direct_bot_mention(message, bot_user)` — membership of the bot's
+    own id in `message.mentions` — replacing the `ctx.bot.user.mentioned_in(message)` call (which
+    short-circuits `True` on `message.mention_everyone`). A server-wide `@everyone`/`@here` blast no
+    longer reads as a personal ping and so can no longer flip the `mention_only` policy gate open.
+    The helper is defensive (missing bot id / non-iterable `mentions` → `False`, never raises).
+    **Stays-fixed guard (same PR):** `tests/unit/runtime/ai/test_natural_language_stage.py` ::
+    `test_everyone_blast_is_not_a_personal_ping` (+ `…_direct_bot_mention_is_a_personal_ping` /
+    `…_mention_of_another_user_or_bot…` / `…_direct_mention_alongside_everyone…` /
+    `…_missing_bot_id_or_uniterable_mentions…`) — the everyone-blast case fails against the old
+    `mentioned_in` path. **Mechanism #1 is untouched** (the `always_reply` design fork below).
   - **#1 is a design fork (the owner's call):** in `always_reply` mode, should SuperBot
     **(a)** stay silent when a message mentions another user/bot and **not** SuperBot (don't barge
     into others' conversations — the most likely intended behavior), **(b)** keep answering
@@ -66,10 +73,13 @@
 - **Stays-fixed guard (to ship with the chosen fix):** a `natural_language_stage` unit test that a
   message pinging only another user/bot (and `@everyone`) does **not** set `is_mention` / does not
   trigger a reply under the chosen rule. (Live AI path → also wants a Q-0086 runtime walk.)
-- **Status:** OPEN — root cause identified 2026-06-20; **routed to the owner** for the #1 behavior
-  decision (agent recommendation: option **(a)** + the #2 hardening). Noted per the owner's
-  "make a note of this" instruction; not patched in the gated AI behavior path without his call +
-  a runtime-verified session.
+- **Status:** PARTIALLY FIXED — mechanism **#2** (the `@everyone`/`@here` false-personal-ping
+  footgun) was root-fixed + regression-guarded 2026-06-20 (dispatch run); it was offline-unit-
+  testable and unambiguous, so it shipped on its own. Mechanism **#1** (the `always_reply`
+  ambient-mode "barge into others' conversations" design fork) stays **OPEN, routed to the owner**
+  (agent recommendation: option **(a)** — stay silent when a message pings another user/bot and not
+  SuperBot) — it changes ambient semantics the owner configured intentionally and wants a
+  Q-0086 runtime-verified session, so it is not patched unilaterally.
 
 ## BUG-0018 — committed `botsite/data/site.json` drifts red whenever idea docs change (hard equality test over a high-churn derived field) — FIXED (root)
 

--- a/tests/unit/runtime/ai/test_natural_language_stage.py
+++ b/tests/unit/runtime/ai/test_natural_language_stage.py
@@ -33,6 +33,7 @@ from core.runtime.ai.contracts import (
 from core.runtime.ai.natural_language_stage import (
     AINaturalLanguageStage,
     _invoke_gateway,
+    _is_direct_bot_mention,
 )
 from core.runtime.message_pipeline import MessagePipelineContext
 
@@ -68,6 +69,11 @@ def _make_message(*, guild_id: int = 99, channel_id: int = 1, user_id: int = 42)
     msg.author.id = user_id
     msg.author.bot = False
     msg.author.roles = []
+    # A real discord Message always exposes ``mentions`` as a list and
+    # ``mention_everyone`` as a bool. Default: nobody pinged. Tests that
+    # need a direct bot mention set these explicitly.
+    msg.mentions = []
+    msg.mention_everyone = False
     return msg
 
 
@@ -642,9 +648,11 @@ _BOT_ID = 555000000000000111
 
 
 def _make_message_with_mention(content: str, *, user_id: int = 42):
-    """Discord message whose content is exactly ``content``."""
+    """Discord message whose content is exactly ``content`` and which
+    directly, personally pings the bot (the bot's id is in ``mentions``)."""
     msg = _make_message(user_id=user_id)
     msg.content = content
+    msg.mentions = [SimpleNamespace(id=_BOT_ID)]
     return msg
 
 
@@ -1865,3 +1873,60 @@ async def test_btd6_meta_question_serves_answerability_summary(
     assert "towers (25)" in sent
     assert stub_services[-1]["decision"] == "replied"
     assert stub_services[-1]["reason_code"] is PolicyDenialReason.NONE
+
+
+# ---------------------------------------------------------------------------
+# BUG-0019 #2 — @everyone / @here must NOT read as a direct personal ping.
+#
+# discord.py's ``ClientUser.mentioned_in`` returns True on
+# ``message.mention_everyone``, so a server-wide blast used to flip the
+# ``mention_only`` policy gate open ("false personal ping" class). The fix
+# computes ``is_mention`` as membership of the bot's own id in
+# ``message.mentions`` only. These guards fail against the old behaviour.
+# ---------------------------------------------------------------------------
+
+
+def _mention_msg(*, mentions, mention_everyone=False):
+    return SimpleNamespace(mentions=list(mentions), mention_everyone=mention_everyone)
+
+
+def test_direct_bot_mention_is_a_personal_ping():
+    bot = SimpleNamespace(id=_BOT_ID)
+    msg = _mention_msg(mentions=[SimpleNamespace(id=_BOT_ID)])
+    assert _is_direct_bot_mention(msg, bot) is True
+
+
+def test_everyone_blast_is_not_a_personal_ping():
+    """The regression: @everyone/@here (mention_everyone=True, empty
+    ``mentions``) must NOT register as a direct mention even though
+    discord.py's ``mentioned_in`` would have returned True."""
+    bot = SimpleNamespace(id=_BOT_ID)
+    msg = _mention_msg(mentions=[], mention_everyone=True)
+    assert _is_direct_bot_mention(msg, bot) is False
+
+
+def test_mention_of_another_user_or_bot_is_not_a_personal_ping():
+    """A message pinging only some other user/bot does not ping us."""
+    bot = SimpleNamespace(id=_BOT_ID)
+    msg = _mention_msg(mentions=[SimpleNamespace(id=_BOT_ID + 999)])
+    assert _is_direct_bot_mention(msg, bot) is False
+
+
+def test_direct_mention_alongside_everyone_still_counts():
+    """If we are genuinely in ``mentions`` it is a real ping, regardless
+    of an accompanying @everyone."""
+    bot = SimpleNamespace(id=_BOT_ID)
+    msg = _mention_msg(
+        mentions=[SimpleNamespace(id=_BOT_ID + 1), SimpleNamespace(id=_BOT_ID)],
+        mention_everyone=True,
+    )
+    assert _is_direct_bot_mention(msg, bot) is True
+
+
+def test_missing_bot_id_or_uniterable_mentions_is_false():
+    """Defensive: no bot id, or a non-iterable ``mentions`` double, never
+    raises — it yields False."""
+    assert _is_direct_bot_mention(_mention_msg(mentions=[]), None) is False
+    assert _is_direct_bot_mention(_mention_msg(mentions=[]), SimpleNamespace()) is False
+    weird = SimpleNamespace(mentions=object(), mention_everyone=False)
+    assert _is_direct_bot_mention(weird, SimpleNamespace(id=_BOT_ID)) is False

--- a/tests/unit/runtime/ai/test_natural_language_stage_memory.py
+++ b/tests/unit/runtime/ai/test_natural_language_stage_memory.py
@@ -51,6 +51,10 @@ def _make_message(
     msg.author.id = user_id
     msg.author.bot = is_bot
     msg.author.roles = []
+    # A real discord Message always exposes ``mentions``/``mention_everyone``;
+    # default to "nobody pinged" so ``is_mention`` reads from real data.
+    msg.mentions = []
+    msg.mention_everyone = False
     return msg
 
 
@@ -146,6 +150,9 @@ async def test_stage_skips_empty_text(monkeypatch):
 def _make_mention_ctx(message, *, bot_id: int = 555000000000000111):
     bot = MagicMock()
     bot.user = SimpleNamespace(id=bot_id, mentioned_in=lambda _msg: True)
+    # The bot is directly, personally pinged: put its id in ``mentions`` so
+    # ``_is_direct_bot_mention`` registers a real mention.
+    message.mentions = [SimpleNamespace(id=bot_id)]
     return MessagePipelineContext(bot=bot, message=message)
 
 

--- a/tests/unit/services/test_btd6_central_policy_integration.py
+++ b/tests/unit/services/test_btd6_central_policy_integration.py
@@ -131,6 +131,8 @@ def _btd6_message(*, guild_id: int = 1, channel_id: int = 100):
     msg.author.id = 42
     msg.author.bot = False
     msg.author.roles = []
+    msg.mentions = []
+    msg.mention_everyone = False
     return msg
 
 


### PR DESCRIPTION
## BUG-0019 #2 — the "false personal ping" footgun

The open AI-reply bug splits into two mechanisms. **#1** (`always_reply` ambient mode barging
into others' conversations) is a design fork that changes ambient semantics the owner configured
intentionally — it stays **OPEN, routed to the owner** (agent recommendation: option (a)). This
PR ships only **#2**, which the bug book flags as *"unambiguous → hardening"*.

**Root cause:** the stage computed `is_mention` via `ctx.bot.user.mentioned_in(message)`.
discord.py's `ClientUser.mentioned_in` short-circuits `True` on `message.mention_everyone`, so a
server-wide `@everyone`/`@here` blast read as a **personal** mention and flipped the `mention_only`
policy gate open — the bot would reply to a message that never pinged it.

**Fix:** `is_mention` is now `natural_language_stage._is_direct_bot_mention(message, bot_user)` —
membership of the bot's own id in `message.mentions`. Only a literal `<@bot_id>` token counts; an
`@everyone`/`@here` blast no longer does. The helper is defensive (missing bot id / non-iterable
`mentions` → `False`, never raises).

**Stays-fixed guard** (`tests/unit/runtime/ai/test_natural_language_stage.py`):
`test_everyone_blast_is_not_a_personal_ping` (+ direct-mention, other-user, direct-alongside-everyone,
and defensive cases) — the everyone-blast case fails against the old `mentioned_in` path. The two
other stage test fixtures that drove `is_mention` via the old `mentioned_in` double were updated to
provide a real `message.mentions` list.

CLASS: fix · bugs-first · contained/reversible/test-covered. Full CI mirror green (11011 passed),
arch strict clean. Mechanism #1 remains OPEN in the bug book for the owner's behavior decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAFXUj2FTyMAk9R7feCmsk)_