### PR TITLE
fix(ci): pr-conflict-guard — deterministic git merge-tree (kills the "only occasionally red" flake)

### DIFF
--- a/.github/workflows/pr-conflict-guard.yml
+++ b/.github/workflows/pr-conflict-guard.yml
@@ -23,11 +23,20 @@ name: pr-conflict-guard
 # first DIRTY PR actually shows the red `conflict-guard` status and that it clears on resolution.
 # Delete this workflow if it flaps or misreports; conflicts are also visible in the PR UI banner.
 #
-# 2026-06-19 fix: the push:main sweep queried mergeability the instant main moved and saw UNKNOWN
-# (GitHub computes it ASYNCHRONOUSLY — the query is what triggers it), so it skipped the very PR
-# that had just become DIRTY (the #1104 miss — log: "#1104 mergeability not computed yet -> skip").
-# The sweep now polls through that UNKNOWN window (resolve_state) before deciding. Still confirm on
-# the next real DIRTY PR that the red status now appears within ~30s of the conflicting merge.
+# 2026-06-19 fix (SUPERSEDED): the push:main sweep queried mergeability the instant main moved and
+# saw UNKNOWN (GitHub computes it ASYNCHRONOUSLY — the query is what triggers it), so it skipped the
+# very PR that had just become DIRTY (the #1104 miss). That fix polled `mergeStateStatus` through the
+# UNKNOWN window — but polling has no upper bound on GitHub's compute time, so when it ran long
+# (PR-open time, load) the 30s poll gave up, posted nothing, and the PR stayed green until the laggy
+# 3-hour cron. That residual race is the "only works occasionally" the owner observed.
+#
+# 2026-06-20 fix (CURRENT): stop asking GitHub's async mergeability at all — compute the merge
+# OURSELVES with `git merge-tree --write-tree <base> <head>`, which is deterministic and synchronous
+# (exit 0 = clean, exit 1 = conflict). No UNKNOWN window, no poll, no race: the status is decided the
+# moment the job runs. Validated on the runner's git 2.43.0 (conflict→rc1, clean→rc0). We pre-verify
+# both commit objects exist (`git cat-file -e`) because a *missing* object also exits 1 — without
+# that guard a bad sha would false-flag a conflict. Confirm on the next real DIRTY PR that the red
+# `conflict-guard` status appears within seconds of the conflicting merge / PR open.
 
 on:
   push:
@@ -52,6 +61,10 @@ jobs:
     if: github.repository == 'menno420/superbot'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout (full history — git merge-tree needs the merge base reachable)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Reflect merge state as the conflict-guard status
         # GITHUB_TOKEN (not ROUTINE_PAT): posting a commit status needs `statuses: write`, granted by
         # the permissions block above. ROUTINE_PAT is scoped Issues/PRs/Contents and lacks commit-
@@ -63,17 +76,16 @@ jobs:
         run: |
           set -uo pipefail
           # NON-REQUIRED visibility status: never red-flag a PR on a single hiccup (guard + exit 0).
-          # On a PR's own push, evaluate ONLY that PR — the all-PR sweep on every pull_request was
-          # needless noise that confused parallel sessions. On push:main / schedule, sweep all open
-          # PRs, because a PR can newly become DIRTY when main moves (not an event on the stale PR).
+          # On a PR's own push, evaluate ONLY that PR. On push:main / schedule, sweep all open PRs,
+          # because a PR can newly become DIRTY when main moves (not an event on the stale PR).
 
-          post() {  # $1=num  $2=mergeStateStatus  $3=headSha
+          post() {  # $1=num  $2=state(DIRTY|CLEAN|UNKNOWN)  $3=headSha
             local num="$1" state="$2" sha="$3" st desc
             [ -n "$sha" ] || return 0
             case "$state" in
-              DIRTY)      st=failure; desc="Merge conflict with main — merge main in / rebase to resolve." ;;
-              UNKNOWN|"") echo "#$num mergeability not computed yet -> skip"; return 0 ;;
-              *)          st=success; desc="No merge conflict with main." ;;
+              DIRTY)      st=failure; desc="Merge conflict with the base branch — merge it in / rebase to resolve." ;;
+              UNKNOWN|"") echo "#$num merge state UNKNOWN -> skip"; return 0 ;;
+              *)          st=success; desc="No merge conflict with the base branch." ;;
             esac
             if gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$sha" \
                  -f state="$st" -f context=conflict-guard -f description="$desc" >/dev/null 2>&1; then
@@ -83,39 +95,37 @@ jobs:
             fi
           }
 
-          # Poll through the UNKNOWN window GitHub shows right after main moves: mergeability is
-          # computed ASYNCHRONOUSLY and a query is what triggers it, so the push:main sweep (which
-          # runs seconds after a merge) would otherwise see UNKNOWN and skip the very PR that just
-          # went DIRTY — the #1104 miss. Returns a settled state, or UNKNOWN only if it never settles.
-          resolve_state() {  # $1=num -> echoes mergeStateStatus
-            local num="$1" s tries=0
-            while :; do
-              s=$(gh pr view "$num" --repo "$GITHUB_REPOSITORY" --json mergeStateStatus \
-                    --jq '.mergeStateStatus' 2>/dev/null || echo "")
-              case "$s" in
-                UNKNOWN|"") : ;;                        # not computed yet — keep polling
-                *)          printf '%s' "$s"; return 0 ;;
-              esac
-              tries=$((tries + 1))
-              if [ "$tries" -ge 10 ]; then printf '%s' "UNKNOWN"; return 0; fi
-              sleep 3
-            done
+          # DETERMINISTIC conflict test: fetch the PR head + its base branch and let git compute the
+          # merge with `git merge-tree --write-tree` (exit 0 = clean, 1 = conflict). This replaces the
+          # old async `mergeStateStatus` poll entirely — no UNKNOWN window, no race, decided the moment
+          # this job runs. A missing object also exits 1, so we pre-verify both commits exist first.
+          evaluate() {  # $1=num  $2=baseRef
+            local num="$1" base="$2" baseSha headSha rc
+            git fetch --quiet --no-tags origin "$base"             2>/dev/null || { echo "#$num: base fetch failed -> skip"; return 0; }
+            baseSha=$(git rev-parse --verify --quiet FETCH_HEAD)               || { echo "#$num: base rev-parse failed -> skip"; return 0; }
+            git fetch --quiet --no-tags origin "refs/pull/$num/head" 2>/dev/null || { echo "#$num: head fetch failed -> skip"; return 0; }
+            headSha=$(git rev-parse --verify --quiet FETCH_HEAD)              || { echo "#$num: head rev-parse failed -> skip"; return 0; }
+            if ! { git cat-file -e "$baseSha^{commit}" 2>/dev/null && git cat-file -e "$headSha^{commit}" 2>/dev/null; }; then
+              post "$num" UNKNOWN "$headSha"; return 0
+            fi
+            git merge-tree --write-tree "$baseSha" "$headSha" >/dev/null 2>&1
+            rc=$?
+            case "$rc" in
+              0) post "$num" CLEAN   "$headSha" ;;
+              1) post "$num" DIRTY   "$headSha" ;;
+              *) post "$num" UNKNOWN "$headSha" ;;   # merge-tree error (rc>1) — don't false-flag
+            esac
           }
 
           if [ "${EVENT:-}" = "pull_request" ]; then
-            sha=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-                    --json headRefOid --jq '.headRefOid' 2>/dev/null || true)
-            post "$PR_NUMBER" "$(resolve_state "$PR_NUMBER")" "$sha"
+            base=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json baseRefName --jq '.baseRefName' 2>/dev/null || echo "main")
+            evaluate "$PR_NUMBER" "${base:-main}"
           else
-            prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
-                    --json number,mergeStateStatus,headRefOid \
-                    --jq '.[] | "\(.number) \(.mergeStateStatus) \(.headRefOid)"' || true)
+            prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number,baseRefName \
+                    --jq '.[] | "\(.number) \(.baseRefName)"' || true)
             if [ -z "${prs:-}" ]; then echo "no open PRs to evaluate"; exit 0; fi
-            # Every open PR is briefly UNKNOWN right after main moves — re-resolve those by polling
-            # instead of skipping them (the bug this fixes).
-            printf '%s\n' "$prs" | while read -r num state sha; do
-              case "$state" in UNKNOWN|"") state="$(resolve_state "$num")" ;; esac
-              post "$num" "$state" "$sha"
+            printf '%s\n' "$prs" | while read -r num base; do
+              evaluate "$num" "${base:-main}"
             done
           fi
           exit 0

--- a/.sessions/2026-06-20-conflict-guard-deterministic-fix.md
+++ b/.sessions/2026-06-20-conflict-guard-deterministic-fix.md
@@ -1,6 +1,6 @@
 # 2026-06-20 — pr-conflict-guard: deterministic merge test (fix the "only occasionally red" flake)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Arc
 
@@ -37,6 +37,72 @@ synchronous, decided the instant the job runs. No UNKNOWN window, no poll, no ra
   false-flag).
 - YAML parses; `bash -n` clean on the embedded run script.
 
-## Shipped
+## Shipped (PR #1187)
 
-_(filled at close)_
+- `.github/workflows/pr-conflict-guard.yml` — conflict detection rewritten from async
+  `mergeStateStatus` polling to a **deterministic `git merge-tree --write-tree`** computation;
+  added `actions/checkout`; object-existence guard against false-flags. Reliable red on every
+  DIRTY PR, no race.
+
+## Decisions made alone
+
+- Kept the guard **non-required** (Q-0154's documented design) rather than folding it into the
+  required `code-quality` gate — the owner's ask was a *reliable red signal*, and GitHub already
+  blocks the actual merge of a dirty PR, so hard-blocking adds nothing. Making it required would be
+  a branch-protection change (ask-first). Reversible.
+
+## Flagged for maintainer
+
+- This is **UNVERIFIED until the next real DIRTY PR** confirms the red `conflict-guard` status
+  appears within seconds (the workflow header carries the same Q-0105 "confirm / delete if it
+  flaps" note). The logic is validated locally (merge-tree exit codes + decision cases), but the
+  full path (checkout → fetch PR head → post status) only exercises on a live conflicted PR.
+- Optional follow-up if you want conflicts to *hard-block* (not just signal): make `conflict-guard`
+  a required check in branch protection — say the word and I'll note it (it's a settings change).
+
+## 💡 Session idea (Q-0089)
+
+**A `tools/game_sim/`-style "CI signal smoke test" for the meta-workflow guards.** This guard has now
+been fixed ≥3 times and kept regressing because its failure mode (a race) only shows on a *live*
+conflicted PR — exactly when it's most costly. A tiny harness that, in a throwaway temp repo,
+constructs a known-conflicting branch pair and asserts the *detection logic* returns DIRTY would
+make these meta-guards regression-proof the way the balance sim makes game mechanics regression-proof.
+The detection here is now pure `git merge-tree`, which *is* unit-testable in a temp repo (no GitHub).
+Lane = tooling. (Captured, not built — dedup-checked `scripts/` + `tests/`: no existing
+workflow-logic test harness.)
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous step (the #1185 docs PR, same chat) shipped clean — but it **opened born-dirty** (the
+branch carried duplicate squashed #1183 commits) and *that* is what exposed today's guard bug. The
+prior creature-sim session's own process note had already flagged the post-squash-merge foot-gun and
+recommended "branch fresh off main over resetting a dirty tree" — had that been promoted into the
+runbook, #1185 likely wouldn't have opened dirty at all. **System improvement:** the recurring
+class is *branches not re-based after their predecessor squash-merges*. Two durable guards would
+kill it: (1) the now-reliable conflict-guard (this PR) catches it loudly; (2) a session-start check
+that warns "your branch base is N commits behind main; rebase before opening a PR" would catch it
+*before* the PR. Worth routing the latter as a small guard idea.
+
+## 📤 Run report
+
+- **Did:** root-caused + fixed the flaky conflict-guard (async race → deterministic git merge-tree) ·
+  **Outcome:** shipped
+- **Shipped:** #1187 — `pr-conflict-guard.yml` deterministic merge test
+- **Run type:** `manual · owner-directed bug fix (bugs-first)`
+- **⚑ Owner decisions needed:** none (optional: make conflict-guard a required check — offered)
+- **⚑ Owner manual steps:** verify the red status on the next real DIRTY PR (UNVERIFIED guard)
+- **⚑ Self-initiated:** none (owner reported the bug in-session and directed the fix)
+- **↪ Next:** confirm on the next live conflict; optionally promote the "branch-behind-main"
+  session-start warning + the workflow-logic smoke-test harness (both captured above).
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs this session-step | 1 (#1187, CI-config fix, auto-merge on green) |
+| Runtime (`disbot/`) code changed | 0 |
+| Root cause | async `mergeStateStatus` poll race → deterministic `git merge-tree` |
+| Files changed | 1 (`.github/workflows/pr-conflict-guard.yml`) |
+| Local validation | merge-tree exit codes + 3 decision cases + YAML + `bash -n` all green |
+| CI-red rounds | 1 (by-design born-red session gate only) |
+| New ideas contributed | 1 (workflow-logic smoke-test harness) |

--- a/.sessions/2026-06-20-conflict-guard-deterministic-fix.md
+++ b/.sessions/2026-06-20-conflict-guard-deterministic-fix.md
@@ -1,0 +1,42 @@
+# 2026-06-20 — pr-conflict-guard: deterministic merge test (fix the "only occasionally red" flake)
+
+> **Status:** `in-progress`
+
+## Arc
+
+Bugs-first. While shipping #1185 the owner hit a **merge conflict that CI did not turn red on**, and
+noted this is recurring: *"there have been a lot of attempts to fix that so CI would turn red on a
+dirty PR, but for some reason this only seems to work occasionally."*
+
+## Root cause
+
+`.github/workflows/pr-conflict-guard.yml` detected conflicts by reading GitHub's
+**asynchronously-computed** `mergeStateStatus`. Right after a push/merge GitHub reports `UNKNOWN`
+(the query is what *triggers* the computation), so the guard polled through that window — but the
+poll had a fixed 30s budget with no relation to GitHub's actual compute time. When computation ran
+long (PR-open time, load), the poll **gave up, posted nothing, and the PR stayed green** until the
+laggy 3-hour cron. That residual race *is* the "only works occasionally."
+
+## Fix (this PR)
+
+Stop asking GitHub's async mergeability entirely — **compute the merge ourselves** with
+`git merge-tree --write-tree <base> <head>` (exit 0 = clean, 1 = conflict): deterministic,
+synchronous, decided the instant the job runs. No UNKNOWN window, no poll, no race.
+
+- Added an `actions/checkout` (fetch-depth 0) so the merge base is reachable.
+- `evaluate()` fetches the base branch + `refs/pull/N/head`, pre-verifies **both commit objects
+  exist** (`git cat-file -e` — a missing object *also* exits 1, which would false-flag), then runs
+  `merge-tree` and posts the `conflict-guard` commit status (failure/success/skip).
+- Kept the design unchanged otherwise: non-required visibility status (Q-0154), same triggers
+  (`push:main` · `pull_request` · `schedule` backstop), same token model.
+
+## Verification
+
+- `git merge-tree` exit codes on the runner's git 2.43.0: conflict→1, clean→0 (validated locally).
+- Decision logic simulated locally: conflict→DIRTY, clean→CLEAN, missing-object→UNKNOWN (no
+  false-flag).
+- YAML parses; `bash -n` clean on the embedded run script.
+
+## Shipped
+
+_(filled at close)_


### PR DESCRIPTION
## Problem
A merge-conflicted (DIRTY) PR was supposed to show a red `conflict-guard` status, but it **only worked occasionally** — multiple prior attempts never fully fixed it.

## Root cause
`pr-conflict-guard.yml` detected conflicts by reading GitHub's **asynchronously-computed** `mergeStateStatus`. Right after a push/merge GitHub reports `UNKNOWN` (the query itself triggers the computation), so the guard polled through that window — but with a fixed 30s budget unrelated to GitHub's actual compute time. When computation ran long (PR-open time, load), the poll **gave up, posted nothing, and the PR stayed green** until the laggy 3-hour cron. That residual race is the flake.

## Fix
Stop asking GitHub's async mergeability — **compute the merge ourselves** with `git merge-tree --write-tree <base> <head>` (exit `0` = clean, `1` = conflict): deterministic, synchronous, decided the instant the job runs. No UNKNOWN window, no poll, no race.

- Adds `actions/checkout` (fetch-depth 0) so the merge base is reachable.
- `evaluate()` fetches the base branch + `refs/pull/N/head`, **pre-verifies both commit objects exist** (`git cat-file -e` — a missing object *also* exits 1, which would otherwise false-flag a conflict), then runs `merge-tree` and posts the `conflict-guard` commit status.
- Design otherwise unchanged: non-required visibility status (Q-0154), same triggers (`push:main` · `pull_request` · `schedule` backstop), same token model.

## Verification
- `git merge-tree` exit codes on the runner's git 2.43.0: conflict→`1`, clean→`0` (validated locally).
- Decision logic simulated locally: conflict→DIRTY, clean→CLEAN, missing-object→UNKNOWN (no false-flag).
- YAML parses; `bash -n` clean on the embedded run script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJBXy9mKixJKzjTtch2WmT)_