### PR TITLE
chore(linter): back_button rule catches dynamically-built (add_item) hubs

### DIFF
--- a/.sessions/2026-06-20-back-button-linter-add-item-detection.md
+++ b/.sessions/2026-06-20-back-button-linter-add-item-detection.md
@@ -1,0 +1,109 @@
+# 2026-06-20 — back_button linter: catch dynamically-built (add_item) hubs
+
+> **Status:** `complete`
+> **Run type:** `manual` — owner greenlit ("Yes go ahead, improvements are always
+> welcome") the follow-up idea filed in the #1177 session log.
+
+## Arc
+
+PR #1177 fixed the Explore world-hub dead-end, but it had shipped past the
+**graduated (error-level) `back_button` consistency rule** — that rule only saw
+`@ui.button`-decorated controls, so registry-driven hubs that build buttons with
+`self.add_item(...)` were invisible to it. This run closes that detection gap so
+the dead-end class is self-policing, and sweeps the tree for any others.
+
+## Shipped (linter-only; no `disbot/` runtime change)
+
+`scripts/check_consistency.py`:
+- **Detect dynamic hubs:** `_class_adds_items_dynamically()` — a HubView that adds
+  controls via `add_item(...)` now counts as a navigable panel (was: only decorated
+  `@ui.button`/`@ui.select`). This is the gap fix.
+- **Smarter back detection** (`_module_has_back_affordance`), so broadening the net
+  didn't create false positives — it now also recognizes:
+  - `transition_to(...)` — the shared nav helper the UX-lab Home buttons route through;
+  - a back-token `label`/`custom_id`/`emoji` on **any** call — covers custom
+    back-button *subclasses* (`_BackToHubButton.__init__ → super().__init__(label="Back
+    to Hub", custom_id="...back", emoji="↩")`), which the `Button(...)`/`@ui.button`
+    checks missed.
+
+Net: the broadened rule first flagged **14**; the two detection improvements cleared
+**10** that had real backs (5 settings sub-panels via `_BackToHubButton`, 2 paragon
+views, deathmatch select, 2 UX-lab benches via `transition_to`); the remaining **4**
+are genuine top-of-stack roots / externally-backed children → allowlisted with reasons
+in `consistency_exceptions.yml` (`_CountingHubView`, `ExploreWorldHubView`,
+`SettingsHubView`, `UxLabHomeView`). `check_consistency --mode strict` = 0 errors.
+
+Tests: `tests/unit/scripts/test_check_consistency.py` +3 — a dynamic add_item hub
+*is* flagged; a custom back-button subclass and a `transition_to` Home button are
+clean.
+
+## Verification
+
+- `check_consistency --mode strict`: 0 errors (17 pre-existing `edit_in_place` warns).
+- `check_quality --check-only`: all green (black/isort/ruff + consistency).
+- `test_check_consistency.py`: 46 passed. Full `--full` suite green.
+- No `disbot/` change → `check_architecture` had nothing to check; nothing to deploy.
+
+## Context delta
+
+- **Discovered by hand:** the `back_button` rule had **three** detection blind spots,
+  not one — dynamic `add_item`, custom back-button subclasses (`super().__init__`),
+  and the `transition_to` nav helper. Fixing only the first (the obvious gap) would
+  have turned 8 panels-with-real-backs into false CI errors. Lesson for the next
+  linter-broadening: when you widen what a rule *catches*, audit what it *recognizes
+  as compliant* in the same pass, or you trade a false negative for false positives.
+- **Decisions made alone:** treated `transition_to` as a back/nav affordance (it can
+  also do sibling nav, but in practice it's the Home-button helper); allowlisted the 4
+  roots rather than adding spurious back buttons to top-of-stack panels.
+- **Flagged for maintainer:** none. Pure tooling hardening; behavior of the bot is
+  unchanged.
+
+## 💡 Session idea
+
+**A root-claim cross-check for the `back_button` allowlist.** Each allowlist entry
+asserts "this is a top-of-stack root (no parent)" — but that's verified by hand and
+can rot (a panel later opened from another hub stays allowlisted and silently keeps a
+dead-end). A tiny check could confirm each allowlisted class is instantiated by a cog
+command path (`send_panel` / a `@commands.command` body) and warn if it's *only* ever
+constructed from inside another `views/` module — i.e. it became a child and the
+"root" reason is now false. Closes the one soft spot left in this rule (the allowlist
+is trust-based). Filed, not built.
+
+## ⟲ Previous-session review
+
+The #1177 session fixed the Explore dead-end at the call site (attached the back
+button in `main_panel`) and *filed* the linter gap as an idea rather than fixing it —
+the right call under time pressure, but it left a graduated CI rule with a known hole
+for a session. Good that it flagged the gap explicitly in the log so this run could
+pick it up cleanly. **System note:** the gap existed because the rule graduated to
+error (#1094) while still only understanding decorated controls — a rule should
+arguably not graduate until its detection covers the dominant construction patterns
+in the tree (decorated *and* dynamic). Worth a line in the linter plan's graduation
+checklist: "confirm the rule sees both `@ui.button` and `add_item` hubs before
+flipping to error."
+
+## 📤 Run report
+
+- **Did:** closed the `back_button` rule's blind spot for dynamically-built (`add_item`)
+  hubs + hardened its back-affordance detection (custom subclasses, `transition_to`);
+  allowlisted 4 verified roots. · **Outcome:** shipped
+- **Shipped:** PR (this run) — linter detection fix; `check_consistency --mode strict`
+  clean. No runtime change.
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none
+- **⚑ Self-initiated:** the idea→build was **owner-greenlit** this run (not unprompted),
+  so not self-initiated; the new root-claim cross-check idea above is filed, not built.
+- **↪ Next:** optional — build the filed root-claim cross-check, or resume the
+  consistency-linter AI-nav lane (rule 1 `edit_in_place`, the 17 remaining `views/ai/`
+  warns).
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 0 at write time (PR open; auto-merge armed) |
+| CI-red rounds | 0 (caught the false-positive class locally before push) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (root-claim cross-check for the allowlist) |
+| Ideas groomed | 1 (executed the #1177 filed linter idea, owner-greenlit) |

--- a/architecture_rules/consistency_exceptions.yml
+++ b/architecture_rules/consistency_exceptions.yml
@@ -67,13 +67,18 @@ edit_in_place:
     - pattern: views/setup/template_picker.py::TemplateConfigView._cancel
       reason: "Terminal 'cancelled — not installed' confirmation toast."
 
-# back_button: a HubView whose module references no back/nav affordance. Triaged
-# 2026-06-19: all current findings are top-of-stack ROOT panels — opened directly
-# by a cog command (no parent to return to), so they correctly have no back
-# button. The rule's real target is a *child* sub-panel missing a back affordance;
-# it will still catch a future one (these allowlists are scoped per root class).
-# Re-verify a root's status before allowlisting a new one: if it is opened FROM
-# another panel, it needs a back button (fix it), not an allowlist entry.
+# back_button: a HubView whose module references no back/nav affordance. The rule
+# covers BOTH decorated (@ui.button) and dynamically-added (add_item) hubs — the
+# latter since 2026-06-20, closing the gap that let the Explore world-hub dead-end
+# ship. Detection recognizes: attach_back*/chain_back, transition_to(...), a
+# back-token label/custom_id/emoji on any call (so custom back-button subclasses
+# like _BackToHubButton count), and back-labelled @ui.button callbacks. Triaged:
+# every current finding is a top-of-stack ROOT panel — opened directly by a cog
+# command (no parent), OR a child whose PARENT attaches the back externally. The
+# rule's real target is a *child* sub-panel with NO back anywhere; it still catches
+# a future one (allowlists are scoped per class). Re-verify before allowlisting a
+# new one: if it is opened FROM another panel and nothing attaches a back, it needs
+# a back button (fix it), not an allowlist entry.
 back_button:
   exceptions:
     - pattern: views/access/explorer.py::AccessExplorerView
@@ -82,12 +87,20 @@ back_button:
       reason: "Root of the channels navigation stack — its sub-panels (create/delete/visibility/move) restore back TO it; it has no parent itself."
     - pattern: views/cleanup/policy_panel.py::CleanupPolicyPanelView
       reason: "Root cleanup-policy panel opened directly by the cleanup cog command; no parent to return to."
+    - pattern: views/counting/hub_panel.py::_CountingHubView
+      reason: "Root `!countingmenu` panel; opened as a `!help`/Games-hub child the parent attaches back externally (HelpCategoryView / attach_back_to_games_button). No parent on the root open."
     - pattern: views/diagnostic/automation_panel.py::AutomationPanelView
       reason: "Root `!platform automation` panel opened via open_panel from the platform command group (not a child of the diagnostics/platform hub); no parent."
     - pattern: views/diagnostic/hub_panel.py::_DiagnosticsHubView
       reason: "Root diagnostics hub opened directly by the diagnostic cog command; top of its stack."
+    - pattern: views/explore/world_hub.py::ExploreWorldHubView
+      reason: "Root `!world` panel; opened as a Mining-hub child the opener attaches '↩ Mining Hub' externally (views/mining/main_panel.py explore_btn). No parent on the root open."
     - pattern: views/games/deathmatch_panel.py::DeathmatchPanelView
       reason: "Root deathmatch game panel opened directly by the deathmatch cog command; no parent."
+    - pattern: views/settings/hub.py::SettingsHubView
+      reason: "Root settings hub opened directly by the settings cog command; opened as a `!help` child the parent attaches back externally. Top of its own stack (its sub-panels return TO it via _BackToHubButton)."
+    - pattern: views/ux_lab/home.py::UxLabHomeView
+      reason: "Root UX-lab gallery home opened directly by the ux_lab cog command; its wings/compare/probes return here via transition_to. No parent."
     - pattern: views/xp/main_panel.py::_XpHubView
       reason: "Root XP hub opened directly by the xp cog command; top of its stack."
 

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -388,6 +388,11 @@ def rule_edit_in_place(
 # one of these in the module is a back affordance.  A button labelled/keyed
 # "back" or a back glyph counts too.
 _BACK_HELPER_PREFIXES = ("attach_back", "chain_back")
+# `transition_to(interaction, builder=...)` is the shared navigation helper
+# (views/navigation.py) a panel's Home/Back button uses to swap to a parent
+# panel — the UX-lab wings + compare/probes bench all route their Home button
+# through it, so a module that calls it is navigable, not a dead-end.
+_NAV_HELPER_NAMES = ("transition_to",)
 _BACK_TOKENS = ("back", "◀", "⬅", "🔙", "↩", "←")
 
 
@@ -419,18 +424,34 @@ def _module_has_back_affordance(tree: ast.Module) -> bool:
 
     - a call to a ``attach_back*`` / ``chain_back`` helper;
     - a ``Button``/``ui.button`` whose label or ``custom_id`` names "back" or a
-      back glyph.
+      back glyph;
+    - any call setting a ``label`` / ``custom_id`` / ``emoji`` keyword to a back
+      token — this catches a **custom back-button subclass** (e.g.
+      ``class _BackToHubButton(discord.ui.Button)`` whose ``__init__`` does
+      ``super().__init__(label="Back to Hub", custom_id="...back", emoji="↩")``
+      and is added via ``add_item``), which the ``Button(...)``/``@ui.button``
+      checks above miss because the call name is ``__init__``.
     """
     for sub in ast.walk(tree):
         if isinstance(sub, ast.Call):
             name = _call_name(sub)
-            if name.startswith(_BACK_HELPER_PREFIXES):
+            if name.startswith(_BACK_HELPER_PREFIXES) or name in _NAV_HELPER_NAMES:
                 return True
             # A constructed Button(..., custom_id="...:back", label="◀ Back").
             if name in {"Button", "button"}:
                 for text in _str_consts(sub):
                     if any(tok in text for tok in _BACK_TOKENS):
                         return True
+            # A back-token label/custom_id/emoji on any call — covers custom
+            # back-button subclasses wired through `super().__init__(...)`.
+            for kw in sub.keywords:
+                if (
+                    kw.arg in {"label", "custom_id", "emoji"}
+                    and isinstance(kw.value, ast.Constant)
+                    and isinstance(kw.value.value, str)
+                    and any(tok in kw.value.value.lower() for tok in _BACK_TOKENS)
+                ):
+                    return True
         # A @ui.button(...) decorated callback whose label/custom_id is a back.
         if isinstance(sub, (ast.AsyncFunctionDef, ast.FunctionDef)):
             for dec in sub.decorator_list:
@@ -446,6 +467,24 @@ def _is_hub_view_class(node: ast.ClassDef) -> bool:
     return any(base.rsplit(".", 1)[-1] == "HubView" for base in _class_bases(node))
 
 
+def _class_adds_items_dynamically(node: ast.ClassDef) -> bool:
+    """True if the class builds controls via ``add_item(...)`` rather than
+    decorated ``@ui.button``/``@ui.select`` callbacks.
+
+    Registry-driven hubs (the Explore world hub, the Games/Community hubs) add
+    their buttons in ``__init__`` with ``self.add_item(SomeButton(...))``. Such a
+    hub has no ``@ui.button`` callback in its class body, so without this signal
+    :func:`rule_back_button` saw it as control-less and skipped it — the exact
+    gap that let the Explore world-hub dead-end ship past this (graduated) rule.
+    """
+    return any(
+        isinstance(sub, ast.Call)
+        and isinstance(sub.func, ast.Attribute)
+        and sub.func.attr == "add_item"
+        for sub in ast.walk(node)
+    )
+
+
 def rule_back_button(
     files: list[Path],
     exceptions: dict,
@@ -453,14 +492,19 @@ def rule_back_button(
 ) -> list[Finding]:
     """Flag a ``HubView`` navigation panel with child controls but no back affordance.
 
-    A ``HubView`` subclass that declares its own ``@ui.button``/``@ui.select``
-    callbacks is a navigable panel — it should offer a way back.  We flag it when
-    **its whole module** references no back affordance (a ``attach_back*`` /
-    ``chain_back`` helper, or a back-labelled button).
+    A ``HubView`` subclass is a navigable panel — it should offer a way back.  We
+    treat it as navigable if it declares its own ``@ui.button``/``@ui.select``
+    callbacks **or** builds controls dynamically via ``add_item`` (registry-driven
+    hubs — the Explore world hub, Games/Community hubs — do the latter, and used to
+    slip through this rule entirely).  We flag such a panel when **its whole module**
+    references no back affordance — see :func:`_module_has_back_affordance` for the
+    recognized signals (``attach_back*`` / ``chain_back`` / ``transition_to``, a
+    back-labelled button, or a back-token ``label``/``custom_id``/``emoji`` on any
+    call, which covers custom back-button subclasses).
 
-    Warn-only + prone to a known false positive: a child panel whose back button
-    is attached *externally* by its parent (a different module) looks bare here —
-    allowlist those in ``consistency_exceptions.yml``.
+    Known false positive: a child panel whose back button is attached *externally*
+    by its parent (a different module) looks bare here — allowlist those in
+    ``consistency_exceptions.yml`` (and a true top-of-stack root has no parent).
     """
     cfg = exceptions.get("back_button", {})
     findings: list[Finding] = []
@@ -476,7 +520,7 @@ def rule_back_button(
                 isinstance(fn, (ast.AsyncFunctionDef, ast.FunctionDef))
                 and _is_ui_callback(fn)
                 for fn in cls.body
-            )
+            ) or _class_adds_items_dynamically(cls)
             if not has_child_control:
                 continue
             if _is_allowlisted(rel, cls.name, cfg):

--- a/tests/unit/scripts/test_check_consistency.py
+++ b/tests/unit/scripts/test_check_consistency.py
@@ -259,6 +259,57 @@ class SettingsHub(HubView):
         return None
 """
 
+# A registry-driven hub: controls added dynamically via add_item (no decorated
+# @ui.button), no back affordance — the gap the Explore world hub exploited.
+_HUB_ADDS_ITEMS_NO_BACK = """\
+import discord
+
+
+class WorldHub(HubView):
+    def __init__(self, author):
+        super().__init__(author)
+        self.add_item(discord.ui.Button(label="Mine", custom_id="explore:open:mine"))
+"""
+
+# Same dynamic hub, but its module defines a custom back-button SUBCLASS wired
+# through super().__init__ (the _BackToHubButton pattern) — not a Button(...)
+# call, so the naive check misses it; the keyword-scan must catch it.
+_HUB_CUSTOM_BACK_SUBCLASS = """\
+import discord
+
+
+class _BackToHubButton(discord.ui.Button):
+    def __init__(self):
+        super().__init__(label="Back to Hub", custom_id="hub.back", emoji="↩")
+
+
+class SettingsHub(HubView):
+    def __init__(self, author):
+        super().__init__(author)
+        self.add_item(_BackToHubButton())
+        self.add_item(discord.ui.Button(label="Roles"))
+"""
+
+# A dynamic hub whose Home button navigates via the shared transition_to helper.
+_HUB_TRANSITION_TO = """\
+import discord
+
+from views.navigation import transition_to
+
+
+class CompareView(HubView):
+    def __init__(self, author, home_builder):
+        super().__init__(author)
+        self._home_builder = home_builder
+        btn = discord.ui.Button(label="Home")
+
+        async def _home(interaction):
+            await transition_to(interaction, builder=self._home_builder)
+
+        btn.callback = _home
+        self.add_item(btn)
+"""
+
 
 def _back_findings(mod, tmp_path, monkeypatch, src, *, rel="views/settings_hub.py"):
     _write(mod, tmp_path, monkeypatch, rel, src)
@@ -283,6 +334,29 @@ def test_back_labelled_button_is_clean(mod, tmp_path, monkeypatch):
 
 def test_hub_without_child_controls_is_out_of_scope(mod, tmp_path, monkeypatch):
     assert _back_findings(mod, tmp_path, monkeypatch, _HUB_NO_CONTROLS) == []
+
+
+def test_back_flags_dynamic_add_item_hub_without_affordance(mod, tmp_path, monkeypatch):
+    """Registry-driven hubs build controls via add_item, not @ui.button — the
+    rule must still flag one with no back (the Explore world-hub dead-end class).
+    """
+    findings = _back_findings(mod, tmp_path, monkeypatch, _HUB_ADDS_ITEMS_NO_BACK)
+    assert len(findings) == 1
+    assert findings[0].qualname == "WorldHub"
+
+
+def test_back_custom_back_button_subclass_is_clean(mod, tmp_path, monkeypatch):
+    """A custom back-button subclass (super().__init__(label='Back...', ...))
+    added via add_item is a real back affordance and must not be flagged.
+    """
+    assert _back_findings(mod, tmp_path, monkeypatch, _HUB_CUSTOM_BACK_SUBCLASS) == []
+
+
+def test_back_transition_to_helper_is_clean(mod, tmp_path, monkeypatch):
+    """A Home/Back button navigating via the shared transition_to helper counts
+    as a nav affordance (the UX-lab compare/probes/wing pattern).
+    """
+    assert _back_findings(mod, tmp_path, monkeypatch, _HUB_TRANSITION_TO) == []
 
 
 def test_back_allowlist_suppresses_by_class(mod, tmp_path, monkeypatch):


### PR DESCRIPTION
Follow-up to #1177 (owner-greenlit). #1177 fixed the Explore world-hub dead-end, but it had shipped past the **graduated, error-level `back_button` consistency rule** — that rule only recognized `@ui.button`-decorated controls, so registry-driven hubs that build buttons via `self.add_item(...)` were invisible to it. This closes the detection gap so the dead-end class is self-policing.

## What changed (`scripts/check_consistency.py`)
- **Detect dynamic hubs:** `_class_adds_items_dynamically()` — a `HubView` that adds controls via `add_item(...)` now counts as a navigable panel (was: only decorated callbacks).
- **Smarter back-affordance detection**, so widening the net didn't create false positives on panels that *do* have a back:
  - recognize `transition_to(...)` — the shared nav helper the UX-lab Home buttons route through;
  - recognize a back-token `label`/`custom_id`/`emoji` on **any** call — covers custom back-button *subclasses* (`_BackToHubButton.__init__ → super().__init__(label="Back to Hub", custom_id="...back", emoji="↩")`), which the `Button(...)`/`@ui.button` checks missed.

## Triage of what the broadened rule surfaced
First pass flagged **14**. The detection fixes cleared **10 that already had real back affordances** (5 settings sub-panels via `_BackToHubButton`, 2 paragon views, the deathmatch challenge select, 2 UX-lab benches via `transition_to`). The remaining **4 are genuine top-of-stack roots** → allowlisted with reasons in `consistency_exceptions.yml`:
`_CountingHubView` (`!countingmenu`), `ExploreWorldHubView` (`!world`), `SettingsHubView` (`!settings`), `UxLabHomeView` (`!uxlab`) — each opened directly by a command, or a child whose parent attaches the back externally.

No other genuine dead-ends turned up — the Explore one (fixed in #1177) was the only real miss.

## Verification
- `check_consistency --mode strict`: 0 errors (17 pre-existing `edit_in_place` warns).
- `check_quality --full`: **11009 passed**, 44 skipped; mypy + check_docs green.
- +3 tests in `test_check_consistency.py` pin the new detection (dynamic hub *is* flagged; custom subclass + `transition_to` are clean).
- Linter-only — no `disbot/` runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ku95MfmRrdDcFSZAqKgJ1Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ku95MfmRrdDcFSZAqKgJ1Y)_