### PR TITLE
feat(hooks): SessionStart branch-freshness warning (Q-0188)

### DIFF
--- a/.sessions/2026-06-20-sessionstart-branch-freshness-warning.md
+++ b/.sessions/2026-06-20-sessionstart-branch-freshness-warning.md
@@ -1,0 +1,40 @@
+# 2026-06-20 — SessionStart branch-freshness warning (stop the stale-branch foot-gun at restart)
+
+> **Status:** `in-progress`
+
+## Arc
+
+Owner-directed in-session. The owner *"often has to restart a session multiple times in one chat"*
+(long reply gaps), so PRs merge between restarts and the branch silently goes behind/divergent —
+which then trips the post-squash-merge rebase foot-gun (it bit this very chat three times across the
+#1185/#1187/#1188 work). The reactive guards (#1187 conflict-guard, #1188 auto-update) catch this
+*after* a PR exists; the missing piece is a **proactive** warning at the moment a session restarts.
+
+The existing `scripts/check_branch_freshness.py` already warns on Stop + pre-push, but **not at
+SessionStart** — exactly the restart moment. This wires it there.
+
+## What this PR adds
+
+- **`scripts/check_branch_freshness.py`** — new `--event sessionstart` mode: a concise
+  `N behind / M ahead of origin/main` verdict (time-boxed `git fetch`, exit 1 when behind, exit 0
+  otherwise / on main / detached). The `ahead` count lets the agent tell a purely-behind branch
+  (safe to reset) from a divergent one (already-squash-merged old commits, or real unpushed work).
+- **`scripts/claude_session_summary.py`** — the SessionStart banner now calls it and prints a loud
+  `⚠ STALE BRANCH` block with the safe sync command when behind, or a quiet `Fresh : up to date ✓`
+  line on a current feature branch. Fail-silent.
+- **Router Q-0188** — provenance for the in-session executable-config edit (the live-owner exception).
+
+## Why a warning, not auto-sync
+
+Auto-`reset --hard` in a hook would discard uncommitted work — the exact data-loss foot-gun seen
+earlier this chat. The banner surfaces the state + the `ahead` count so the agent judges and acts.
+
+## Verification
+
+- Dogfooded: on this branch *while it was 1-behind/2-ahead* (post-#1191 merge), the banner printed
+  the `⚠ STALE BRANCH` block correctly; after syncing to main it reads `up to date ✓` (exit 0).
+- `check_quality.py --check-only` → all green.
+
+## Shipped
+
+_(filled at close)_

--- a/.sessions/2026-06-20-sessionstart-branch-freshness-warning.md
+++ b/.sessions/2026-06-20-sessionstart-branch-freshness-warning.md
@@ -1,6 +1,6 @@
 # 2026-06-20 — SessionStart branch-freshness warning (stop the stale-branch foot-gun at restart)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Arc
 
@@ -35,6 +35,55 @@ earlier this chat. The banner surfaces the state + the `ahead` count so the agen
   the `⚠ STALE BRANCH` block correctly; after syncing to main it reads `up to date ✓` (exit 0).
 - `check_quality.py --check-only` → all green.
 
-## Shipped
+## Shipped (PR #1192)
 
-_(filled at close)_
+- `scripts/check_branch_freshness.py` — `--event sessionstart` mode.
+- `scripts/claude_session_summary.py` — banner `⚠ STALE BRANCH` / `Fresh :` line.
+- Router Q-0188 (provenance).
+
+## Decisions made alone
+
+- **Warn, never auto-sync** — data-loss safety (the `reset --hard` foot-gun).
+- **Reuse the existing freshness script** (new event mode) rather than a new script — one home for
+  branch-freshness logic; the summary already orchestrates 3 other check scripts the same way.
+
+## 💡 Session idea (Q-0089)
+
+**Promote the `git fetch origin main && git reset --hard origin/main` sync into a tiny
+`/sync-branch` skill (or a `scripts/sync_branch.sh`) that refuses when the tree is dirty.** The
+banner now *tells* the agent to sync, but the safe sync is a 2-command incantation with a clean-tree
+precondition the agent must remember each time — packaging it as one guarded command removes the
+last manual step and the remaining foot-gun surface. Lane = tooling. (Captured, not built.)
+
+## ⟲ Previous-session review (Q-0102)
+
+The #1191 session (merge-state helper) was solid, but it — like #1188 — **opened its PR on a branch
+behind main** and only discovered it mid-rebase. That's the third occurrence in this chain and is
+*precisely* the gap this session closes: had the SessionStart warning existed, all three would have
+shown a loud `⚠ STALE BRANCH` at the top of the session and been synced in one step. **System
+improvement:** this run is the proactive complement that the reactive #1187/#1188 guards were always
+missing — together (warn-at-start + detect-on-merge + prevent-via-auto-update) the stale/conflict
+class is now covered at all three moments (start, push, post-merge).
+
+## 📤 Run report
+
+- **Did:** added the SessionStart branch-freshness warning (proactive complement to #1187/#1188) ·
+  **Outcome:** shipped
+- **Shipped:** #1192 — `check_branch_freshness.py` sessionstart mode + banner line + Q-0188
+- **Run type:** `manual · owner-directed in-session (executable-config edit, Q-0188 provenance)`
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none (Q-0105 disposable — delete if noisy over a few sessions)
+- **⚑ Self-initiated:** no (owner directed the warning explicitly)
+- **↪ Next:** optional `/sync-branch` guarded-sync skill (captured) removes the last manual step.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs this session | 1 (#1192, hook tooling, auto-merge on green) |
+| Runtime (`disbot/`) code changed | 0 |
+| Files changed | 3 (2 scripts + router Q-0188) |
+| Coverage of the stale/conflict class | now all 3 moments: start (this) · push (#1187) · post-merge (#1188) |
+| Dogfooded | yes — warned on this branch's own 1-behind/2-ahead state, then verified clean post-sync |
+| CI-red rounds | 1 (by-design born-red session gate only) |
+| New ideas contributed | 1 (`/sync-branch` guarded-sync command) |

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -6880,3 +6880,26 @@ design+sim plan §2a.
 own runtime session once (a)/(b) are confirmed. **Home:** the design+sim plan + this Q-block.
 Related: Q-0039 (no P2W), Q-0186 (Pokétwo build sequence), Q-0182 (world model), Q-0041 (the
 parallel music legal-lane decision — same publish-safe logic).
+
+---
+
+### Q-0188 — DONE (owner-directed in-session): SessionStart branch-freshness warning (2026-06-20)
+
+> **APPLIED in-session** (the live-owner exception to the "don't self-edit executable config"
+> rule — owner directed it, owner is the live reviewer, provenance recorded here). The owner
+> *"often has to restart a session multiple times in one chat"* (long reply gaps), so PRs merge
+> between restarts and the branch silently goes **behind/divergent** — which then trips the
+> post-squash-merge rebase foot-gun (it bit this very chat three times: #1185/#1187/#1188 work).
+
+**What shipped:** `scripts/check_branch_freshness.py` gained a `--event sessionstart` mode (concise
+`N behind / M ahead of origin/main` verdict, time-boxed `git fetch`, exit 1 when behind), and
+`scripts/claude_session_summary.py` now calls it so the **SessionStart banner** prints a loud
+`⚠ STALE BRANCH` block with the safe sync command (`git fetch origin main && git reset --hard
+origin/main`, clean-tree-only) when the working branch is behind. The existing Stop / pre-push
+freshness hooks are unchanged; this adds the *restart* moment they missed.
+
+**Why a warning, not auto-sync:** auto-`reset --hard` in a hook would discard uncommitted work — the
+exact data-loss foot-gun seen earlier this chat. The banner surfaces the state + the `ahead` count
+so the agent judges (purely-behind = safe reset; diverged = check whether the local commits are
+already merged) and acts. **Q-0105 disposable:** delete the `sessionstart` branch + the summary call
+if it proves noisy. **Home:** the two scripts + this Q-block.

--- a/scripts/check_branch_freshness.py
+++ b/scripts/check_branch_freshness.py
@@ -12,11 +12,17 @@ Provenance / reliability header (per CLAUDE.md Q-0105 adopt-with-kill-switch):
   multiple sessions** (remove the two settings.json entries + this file); it is a disposable
   convenience guard, not load-bearing.
 
-Two trigger modes (both ALWAYS exit 0 — this is a non-blocking advisory, never a gate):
-- ``--event pretooluse``: wired on Bash. Reads the hook JSON on stdin; acts only when the
-  command is a ``git push``. The "about to ship" moment.
-- ``--event stop``: wired on Stop. Ignores stdin; checks the current branch on every turn,
-  so a branch that fell behind *after* its last push gets flagged next turn (the #857 case).
+Trigger modes:
+- ``--event pretooluse`` (exit 0): wired on Bash. Reads the hook JSON on stdin; acts only when
+  the command is a ``git push``. The "about to ship" moment.
+- ``--event stop`` (exit 0): wired on Stop. Ignores stdin; checks the current branch on every
+  turn, so a branch that fell behind *after* its last push gets flagged next turn (the #857 case).
+- ``--event sessionstart`` (exit 1 when behind, else 0): called by ``claude_session_summary.py``
+  so the SessionStart banner flags a *restart on a stale branch* — common when a chat spans
+  several sessions and PRs merge between them, leaving the branch behind/divergent before any
+  turn ends or push fires (owner-directed, Q-0188, 2026-06-20). Prints a concise one-line verdict
+  to stdout; the non-zero exit is the "behind" signal the summary formats on (it is NOT wired as a
+  Claude hook, so the exit code is free to differ from the always-0 advisory modes).
 
 Robustness: every failure path swallows the error and exits 0. A PreToolUse hook runs before
 *every* Bash call, so it must never block a command or add latency to non-push calls (it
@@ -109,10 +115,45 @@ def _freshness_warning() -> str | None:
     return "\n".join(lines)
 
 
+def _sessionstart_verdict() -> tuple[str, bool]:
+    """(line, behind) for the SessionStart banner.
+
+    ``behind`` is False when on main / detached / already current. The line is a single concise
+    string; the count of commits *ahead* is included so the next session can tell a purely-behind
+    branch (safe to reset) from a divergent one (already-squash-merged old commits, or genuine
+    unpushed work — judge before resetting).
+    """
+    branch = _git("rev-parse", "--abbrev-ref", "HEAD")
+    if not branch or branch in ("HEAD", "main"):
+        return ("on main / detached — n/a", False)
+    _git("fetch", "origin", "main", timeout=12)
+    behind = _git("rev-list", "--count", "HEAD..origin/main")
+    if not behind or behind == "0":
+        return ("up to date with origin/main ✓", False)
+    ahead = _git("rev-list", "--count", "origin/main..HEAD") or "0"
+    return (
+        f"branch '{branch}' is {behind} behind / {ahead} ahead of origin/main",
+        True,
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--event", choices=("pretooluse", "stop"), default="stop")
+    parser.add_argument(
+        "--event",
+        choices=("pretooluse", "stop", "sessionstart"),
+        default="stop",
+    )
     args = parser.parse_args(argv)
+
+    if args.event == "sessionstart":
+        # Called by claude_session_summary.py — print the verdict and signal behind via exit code.
+        try:
+            line, behind = _sessionstart_verdict()
+            print(line)
+            return 1 if behind else 0
+        except Exception:
+            return 0  # never break session start
 
     try:
         if args.event == "pretooluse":

--- a/scripts/claude_session_summary.py
+++ b/scripts/claude_session_summary.py
@@ -111,6 +111,32 @@ def main() -> int:
             f"Ledger : ⚠ {count} merged PR(s) not yet in current-state — reconcile before close",
         )
 
+    # Branch-freshness advisory (Q-0188) — printed at START so a restart on a stale branch syncs
+    # *before* opening a PR on a behind/divergent base. This is the common multi-session-per-chat
+    # case: PRs merge between restarts, leaving the branch behind, and the post-squash-merge
+    # divergence then trips a rebase. Fail-silent; the fetch is time-boxed inside the checker.
+    fresh = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPTS / "check_branch_freshness.py"),
+            "--event",
+            "sessionstart",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        timeout=20,
+    )
+    fresh_line = fresh.stdout.strip().splitlines()[0] if fresh.stdout.strip() else ""
+    if fresh.returncode != 0 and fresh_line:
+        print()
+        print(f"⚠  STALE BRANCH — {fresh_line}")
+        print("   A new PR opened from here may start behind/conflicted.")
+        print("   If your last PR merged, sync first (clean tree only):")
+        print("     git fetch origin main && git reset --hard origin/main")
+    elif fresh_line and "n/a" not in fresh_line:
+        print(f"Fresh  : {fresh_line}")
+
     # Quick commands
     print()
     print("Quick commands:")


### PR DESCRIPTION
Owner-directed in-session. The owner often restarts a session several times in one chat (long reply gaps), so PRs merge between restarts and the branch silently goes **behind/divergent** — which then trips the post-squash-merge rebase foot-gun (it bit this chat **three times** across the #1185/#1187/#1188 work). The reactive guards (#1187/#1188) catch this *after* a PR exists; this adds the missing **proactive** warning at restart.

## What this adds
- **`scripts/check_branch_freshness.py`** — new `--event sessionstart` mode: concise `N behind / M ahead of origin/main` verdict (time-boxed `git fetch`, exit 1 when behind). The `ahead` count distinguishes purely-behind (safe to reset) from divergent (already-squash-merged commits, or real unpushed work).
- **`scripts/claude_session_summary.py`** — the SessionStart banner now calls it and prints a loud `⚠ STALE BRANCH` block with the safe sync command when behind, or a quiet `Fresh : up to date ✓` line otherwise. Fail-silent.
- **Router Q-0188** — provenance for the in-session executable-config edit (the live-owner exception to "don't self-edit hooks").

The existing Stop / pre-push freshness hooks are unchanged — this adds the *restart* moment they missed.

## Why a warning, not auto-sync
Auto-`reset --hard` in a hook would discard uncommitted work — the exact data-loss foot-gun seen earlier this chat. The banner surfaces the state + the `ahead` count so the agent judges and acts.

## Verification
- **Dogfooded:** on this branch while it was 1-behind/2-ahead (post-#1191 merge), the banner printed the `⚠ STALE BRANCH` block; after syncing to main it reads `up to date ✓` (exit 0).
- `check_quality.py --check-only` → all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJBXy9mKixJKzjTtch2WmT)_