### PR TITLE
feat(game-sim): data-driven 36-creature catalog, sim-validated PLAYABLE

### DIFF
--- a/.sessions/2026-06-20-creature-catalog-data-driven.md
+++ b/.sessions/2026-06-20-creature-catalog-data-driven.md
@@ -1,6 +1,6 @@
 # 2026-06-20 — Creature roster as a data-driven catalog (sim-validate ~36 at launch scale)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Arc
 
@@ -30,6 +30,68 @@ data + sim; Q-0172 idea→build).
 - `pytest tests/unit/tools/` → 6/6. `check_quality --check-only`, `check_docs --strict`,
   `check_plan_homing` → all green.
 
-## Shipped
+## Shipped (PR #1193)
 
-_(filled at close)_
+- `tools/game_sim/creatures.json` (36 creatures) + `creature_battle_sim.py` loads it +
+  `test_creature_battle_sim.py` updated + design doc §2a marked BUILT.
+
+## Decisions made alone (owner said "pick good defaults")
+
+- **36 creatures** (6/element, 12C/12U/6R/6E) — middle of the recommended 30–40 band; enough dex
+  depth, not an art/balance overreach. Reversible data.
+- **Default flavor (names) mine to set, owner refines** — gear-paper-doll precedent (I build the
+  system + a working default; owner swaps the creative skin). Kept the original 12's iconic names
+  (Cindling, Magmaul, Rippling, Abysscale, Sproutle, Thornmaw, Voltkit, Stormfang, Pebblet,
+  Boulderon, Zephyrl, Galeon) and added 24 in the same voice.
+- **Uniform Common/balanced per-element starter** (slot 0) — makes the type-balance check
+  apples-to-apples, which is why spread fell to 1.0pt.
+
+## Flagged for maintainer
+
+- **Roster flavor is a default, not a design lock** — names/themes are yours to rename anytime
+  (it's one JSON file); the *engineering* (data-driven loading + sim-proven balance at launch
+  scale) is what's locked in. Q-0187(a–d) confirmations still open (this builds on the
+  recommended path, doesn't pre-empt the decision).
+
+## 💡 Session idea (Q-0089)
+
+**A `--roster <path>` flag on the sim so an owner/agent can A/B a *candidate* roster JSON without
+editing the committed catalog.** Now that the roster is data, balance-testing a proposed change
+(new creature, retuned rarity budget) should be a one-liner against a scratch file, not an edit +
+revert. Tiny argparse addition; makes the balance-before-build gate frictionless for the next
+roster change. Lane = tooling. (Captured, not built.)
+
+## ⟲ Previous-session review (Q-0102)
+
+The #1192 (branch-freshness) session closed the stale-branch class well — and this session is the
+first to *benefit* from it: the SessionStart banner flagged this branch `1 behind / 2 ahead`, I
+synced in one step, and opened #1193 on a clean base (no rebase foot-gun this time). That's the
+proactive guard working end-to-end on its very next use. **System improvement:** the one remaining
+manual step is the agent *remembering* to run the sync the banner prints — the captured `/sync-branch`
+guarded command (from #1192) would close that last gap; worth promoting next.
+
+## 📤 Run report
+
+- **Did:** turned the creature roster into a sim-validated data-driven catalog (36, PLAYABLE) ·
+  **Outcome:** shipped (design tooling + docs)
+- **Shipped:** #1193 — `creatures.json` (36) + sim loads it + test/doc updates
+- **Run type:** `manual · self-initiated product step (Q-0172; §2a next step)`
+- **⚑ Owner decisions needed:** Q-0187(a–d) still open (this builds the recommended path)
+- **⚑ Owner manual steps:** none (rename creature flavor anytime — it's one JSON file)
+- **⚑ Self-initiated:** YES — promoted the §2a "build the catalog" step without waiting (Q-0172);
+  flagged here. Flavor is a default, owner refines.
+- **↪ Next:** the gated runtime build (Lane A catch engine, Q-0186) graduates this catalog to
+  `disbot/data/`; or deepen the sim (real moves/abilities) before runtime.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs this session | 1 (#1193, design tooling + docs, auto-merge on green) |
+| Runtime (`disbot/`) code changed | 0 |
+| Roster | 12 (hardcoded) → 36 (data-driven JSON) |
+| Sim verdict at launch scale | PLAYABLE (no flags), seeds 42 + 7; type-balance spread 1.0pt |
+| Tests | 6/6 (`tests/unit/tools/`) |
+| Branch-freshness guard | fired on this session's own stale branch → synced cleanly (first real use) |
+| CI-red rounds | 1 (by-design born-red session gate only) |
+| New ideas contributed | 1 (sim `--roster <path>` A/B flag) |

--- a/.sessions/2026-06-20-creature-catalog-data-driven.md
+++ b/.sessions/2026-06-20-creature-catalog-data-driven.md
@@ -1,0 +1,35 @@
+# 2026-06-20 — Creature roster as a data-driven catalog (sim-validate ~36 at launch scale)
+
+> **Status:** `in-progress`
+
+## Arc
+
+Product progress on the creature game (the CI/branch-hygiene thread is complete: #1187/#1188/#1191/
+#1192 all merged). This executes the §2a "natural next design step" named last session: make
+"creature = a data row" real and **prove ~30–40 balances** before any runtime build — the
+balance-before-build gate. Design tooling only — no `disbot/` runtime, no owner gate (reversible
+data + sim; Q-0172 idea→build).
+
+## What this PR adds
+
+- **`tools/game_sim/creatures.json`** — the v1 launch catalog: **36 original creatures** (6 per
+  element; 12 Common / 12 Uncommon / 6 Rare / 6 Epic). Each is just `{name, element, rarity,
+  archetype}` — **stats are derived at load** (`budget = RARITY_BUDGET[rarity]` split by archetype
+  weights), so there are no stored stats to drift.
+- **`creature_battle_sim.py`** — `_roster()` now **loads from the catalog** instead of a hardcoded
+  list of 12. Adding a creature is now a data row, not a code edit (Q-0187d).
+- **`test_creature_battle_sim.py`** — `test_roster_well_formed` now asserts the launch band
+  (30–40) + an even per-element spread, not the old fixed 12.
+- **Design doc §2a** — marked the catalog **BUILT** with the sim result.
+
+## Verification
+
+- Sim on the full 36 → **PLAYABLE (no flags)**, both seed 42 and seed 7. Type balance *tighter* than
+  the 12-roster: per-element 49.6–50.6%, **spread 1.0pt** (uniform Common/balanced per-element
+  starter makes the type check apples-to-apples); catch grind ~7 at L1.
+- `pytest tests/unit/tools/` → 6/6. `check_quality --check-only`, `check_docs --strict`,
+  `check_plan_homing` → all green.
+
+## Shipped
+
+_(filled at close)_

--- a/docs/planning/creature-game-design-and-sim-2026-06-20.md
+++ b/docs/planning/creature-game-design-and-sim-2026-06-20.md
@@ -95,8 +95,17 @@ fun (a dex you fill in one sitting isn't a hook). Two choices make ~30–40 chea
    fish-roster pattern), so *adding* a creature is a data row, not code. This is what makes
    "ship 12 → grow to ~40 → seasons" a non-event architecturally, and it lets the **same
    `creature_battle_sim.py`** validate the *whole* launch roster before it ships (the
-   balance-before-build gate). Building that catalog + sim-validating ~30–40 is the natural next
-   design step before any catch-engine build.
+   balance-before-build gate).
+
+**★ BUILT (2026-06-20):** the v1 launch catalog is real — **`tools/game_sim/creatures.json`, 36
+original creatures** (6 per element; 12 Common / 12 Uncommon / 6 Rare / 6 Epic), and the sim now
+**loads the roster from it** (stats derived: `budget = RARITY_BUDGET[rarity]` split by archetype
+weights — no stored stats to drift). Re-running the sim on the full 36 still reports **PLAYABLE (no
+flags)**, with type balance even *tighter* than the 12-roster (per-element 49.6–50.6%, **spread
+1.0pt** — the uniform Common/balanced per-element "starter" makes it apples-to-apples) and catch
+grind ~7 at L1. So **~30–40 is proven balanceable, not just asserted** (Q-0187d). *Flavor (names) is
+owner-refinable — like the gear paper-doll, the system + a working default ship; the owner swaps the
+creative skin. The catalog graduates to `disbot/data/` at the gated runtime build (Q-0186).*
 
 ## 3. Simulator + headline findings
 

--- a/tests/unit/tools/test_creature_battle_sim.py
+++ b/tests/unit/tools/test_creature_battle_sim.py
@@ -42,8 +42,12 @@ def test_type_chart_is_symmetric(mod):
 
 
 def test_roster_well_formed(mod):
-    assert len(mod.ROSTER) == 12
+    # v1 launch roster is data-driven (creatures.json) and sized for collection depth
+    # (Q-0187d: sim-core 12 -> launch ~30-40). Assert the launch band + a clean per-element spread.
+    assert 30 <= len(mod.ROSTER) <= 40
     assert {s.element for s in mod.ROSTER} == set(mod.ELEMENTS)
+    per_element = {el: sum(s.element == el for s in mod.ROSTER) for el in mod.ELEMENTS}
+    assert len(set(per_element.values())) == 1, f"uneven per-element spread: {per_element}"
     for s in mod.ROSTER:
         # budget spread rounds, so allow ±2 of the rarity budget
         assert abs(s.budget - mod.RARITY_BUDGET[s.rarity]) <= 2

--- a/tools/game_sim/creature_battle_sim.py
+++ b/tools/game_sim/creature_battle_sim.py
@@ -34,10 +34,12 @@ dropped or once its numbers are pinned into the real subsystem.
 from __future__ import annotations
 
 import argparse
+import json
 import random
 import statistics
 from dataclasses import dataclass, field
 from itertools import product
+from pathlib import Path
 
 # ---------------------------------------------------------------------------
 # v1 ruleset — elements, effectiveness, roster (ORIGINAL names, no Pokémon IP)
@@ -116,10 +118,15 @@ def _spread(
 
 
 def _roster() -> list[Species]:
-    """12 original creatures: 2 per element, varied rarity + archetype.
+    """Load the original creature roster from ``creatures.json`` (creature-as-data).
 
-    Archetype weights (hp, atk, df, spd): attacker .9/1.3/.7/1.1,
-    tank 1.3/.8/1.3/.6, balanced 1/1/1/1, speedster .8/1.2/.7/1.3.
+    Stats are *derived*, not stored: each creature's budget = ``RARITY_BUDGET[rarity]`` split
+    across HP/ATK/DEF/SPD by archetype weights. This is the "adding a creature is a data row, not
+    code" design (Q-0187d) — the catalog is the v1 launch roster (~36), and the same sim below
+    validates the *whole* roster's balance before any of it touches ``disbot/``.
+
+    Archetype weights (hp, atk, df, spd): attacker .9/1.3/.7/1.1, tank 1.3/.8/1.3/.6,
+    balanced 1/1/1/1, speedster .8/1.2/.7/1.3.
     """
     arche = {
         "attacker": (0.9, 1.3, 0.7, 1.1),
@@ -127,25 +134,11 @@ def _roster() -> list[Species]:
         "balanced": (1.0, 1.0, 1.0, 1.0),
         "speedster": (0.8, 1.2, 0.7, 1.3),
     }
-    # (name, element, rarity, archetype) — two per element, spread across rarity.
-    spec = [
-        ("Cindling", "Ember", "Common", "attacker"),
-        ("Magmaul", "Ember", "Rare", "tank"),
-        ("Rippling", "Tide", "Common", "balanced"),
-        ("Abysscale", "Tide", "Epic", "tank"),
-        ("Sproutle", "Bramble", "Common", "balanced"),
-        ("Thornmaw", "Bramble", "Rare", "attacker"),
-        ("Voltkit", "Spark", "Uncommon", "speedster"),
-        ("Stormfang", "Spark", "Epic", "attacker"),
-        ("Pebblet", "Stone", "Common", "tank"),
-        ("Boulderon", "Stone", "Rare", "tank"),
-        ("Zephyrl", "Gust", "Uncommon", "speedster"),
-        ("Galeon", "Gust", "Rare", "speedster"),
-    ]
+    catalog = json.loads((Path(__file__).with_name("creatures.json")).read_text())
     out: list[Species] = []
-    for name, el, rar, arch in spec:
-        hp, atk, df, spd = _spread(RARITY_BUDGET[rar], *arche[arch])
-        out.append(Species(name, el, rar, hp, atk, df, spd))
+    for c in catalog["creatures"]:
+        hp, atk, df, spd = _spread(RARITY_BUDGET[c["rarity"]], *arche[c["archetype"]])
+        out.append(Species(c["name"], c["element"], c["rarity"], hp, atk, df, spd))
     return out
 
 

--- a/tools/game_sim/creatures.json
+++ b/tools/game_sim/creatures.json
@@ -1,0 +1,47 @@
+{
+  "_README": "v1 default creature roster for the catch+battle game (DESIGN ARTIFACT, not runtime). Creature = a data row (the towers.json / fish-roster pattern) so adding one is data, not code. Stats are DERIVED at load: budget = RARITY_BUDGET[rarity], split across HP/ATK/DEF/SPD by archetype weights (see creature_battle_sim.py). 36 creatures = 6 per element, validated PLAYABLE by the sim. FLAVOR (names) is owner-refinable — like the gear paper-doll, the system + a working default ship here; the owner swaps the creative skin. Graduates to disbot/data/ at the gated runtime build (Q-0186). Per-element slot 0 is the Common/balanced 'starter' (uniform across elements so the type-balance check is apples-to-apples).",
+  "elements": ["Ember", "Tide", "Bramble", "Spark", "Stone", "Gust"],
+  "creatures": [
+    {"name": "Cindling",   "element": "Ember",   "rarity": "Common",   "archetype": "balanced"},
+    {"name": "Emberpaw",   "element": "Ember",   "rarity": "Common",   "archetype": "attacker"},
+    {"name": "Ashpyre",    "element": "Ember",   "rarity": "Uncommon", "archetype": "speedster"},
+    {"name": "Cinderhorn", "element": "Ember",   "rarity": "Uncommon", "archetype": "tank"},
+    {"name": "Magmaul",    "element": "Ember",   "rarity": "Rare",     "archetype": "attacker"},
+    {"name": "Infernox",   "element": "Ember",   "rarity": "Epic",     "archetype": "tank"},
+
+    {"name": "Rippling",   "element": "Tide",    "rarity": "Common",   "archetype": "balanced"},
+    {"name": "Splashfin",  "element": "Tide",    "rarity": "Common",   "archetype": "attacker"},
+    {"name": "Brinejet",   "element": "Tide",    "rarity": "Uncommon", "archetype": "speedster"},
+    {"name": "Shellback",  "element": "Tide",    "rarity": "Uncommon", "archetype": "tank"},
+    {"name": "Coralisk",   "element": "Tide",    "rarity": "Rare",     "archetype": "tank"},
+    {"name": "Abysscale",  "element": "Tide",    "rarity": "Epic",     "archetype": "balanced"},
+
+    {"name": "Sproutle",   "element": "Bramble", "rarity": "Common",   "archetype": "balanced"},
+    {"name": "Thornkit",   "element": "Bramble", "rarity": "Common",   "archetype": "attacker"},
+    {"name": "Fernwhisk",  "element": "Bramble", "rarity": "Uncommon", "archetype": "speedster"},
+    {"name": "Barkhide",   "element": "Bramble", "rarity": "Uncommon", "archetype": "tank"},
+    {"name": "Thornmaw",   "element": "Bramble", "rarity": "Rare",     "archetype": "balanced"},
+    {"name": "Verdankor",  "element": "Bramble", "rarity": "Epic",     "archetype": "speedster"},
+
+    {"name": "Voltkit",    "element": "Spark",   "rarity": "Common",   "archetype": "balanced"},
+    {"name": "Sparkpup",   "element": "Spark",   "rarity": "Common",   "archetype": "attacker"},
+    {"name": "Glimmerfly", "element": "Spark",   "rarity": "Uncommon", "archetype": "speedster"},
+    {"name": "Voltaic",    "element": "Spark",   "rarity": "Uncommon", "archetype": "tank"},
+    {"name": "Arcwing",    "element": "Spark",   "rarity": "Rare",     "archetype": "speedster"},
+    {"name": "Stormfang",  "element": "Spark",   "rarity": "Epic",     "archetype": "attacker"},
+
+    {"name": "Pebblet",    "element": "Stone",   "rarity": "Common",   "archetype": "balanced"},
+    {"name": "Gravelpup",  "element": "Stone",   "rarity": "Common",   "archetype": "attacker"},
+    {"name": "Slatewing",  "element": "Stone",   "rarity": "Uncommon", "archetype": "speedster"},
+    {"name": "Cobbleshell", "element": "Stone",  "rarity": "Uncommon", "archetype": "tank"},
+    {"name": "Boulderon",  "element": "Stone",   "rarity": "Rare",     "archetype": "tank"},
+    {"name": "Tectonix",   "element": "Stone",   "rarity": "Epic",     "archetype": "balanced"},
+
+    {"name": "Zephyrl",    "element": "Gust",    "rarity": "Common",   "archetype": "balanced"},
+    {"name": "Gustling",   "element": "Gust",    "rarity": "Common",   "archetype": "attacker"},
+    {"name": "Breezle",    "element": "Gust",    "rarity": "Uncommon", "archetype": "speedster"},
+    {"name": "Cloudhide",  "element": "Gust",    "rarity": "Uncommon", "archetype": "tank"},
+    {"name": "Galeon",     "element": "Gust",    "rarity": "Rare",     "archetype": "balanced"},
+    {"name": "Tempestra",  "element": "Gust",    "rarity": "Epic",     "archetype": "speedster"}
+  ]
+}


### PR DESCRIPTION
Product progress on the creature game (the CI/branch-hygiene thread #1187/#1188/#1191/#1192 is complete). Executes the design doc §2a next step: make **"creature = a data row"** real and **prove ~30–40 balances** before any runtime build — the balance-before-build gate. Design tooling only — no `disbot/` runtime.

## What this adds
- **`tools/game_sim/creatures.json`** — v1 launch catalog: **36 original creatures** (6 per element; 12 Common / 12 Uncommon / 6 Rare / 6 Epic). Each row is `{name, element, rarity, archetype}`; **stats derived at load** (`budget = RARITY_BUDGET[rarity]` split by archetype weights) so nothing can drift.
- **`creature_battle_sim.py`** — `_roster()` now **loads from the catalog**. Adding a creature is a data row, not a code edit (Q-0187d).
- **`test_creature_battle_sim.py`** — `test_roster_well_formed` asserts the launch band (30–40) + even per-element spread.
- **Design doc §2a** — marked the catalog **BUILT** with the sim result.

## Verification
- Sim on the full 36 → **PLAYABLE (no flags)** on seed 42 **and** seed 7. Type balance *tighter* than the 12-roster: per-element 49.6–50.6%, **spread 1.0pt**; catch grind ~7 at L1.
- `pytest tests/unit/tools/` 6/6; `check_quality --check-only`, `check_docs --strict`, `check_plan_homing` all green.

Flavor (names) is owner-refinable — like the gear paper-doll, the system + a working default ship; the owner swaps the creative skin. The catalog graduates to `disbot/data/` at the gated runtime build (Q-0186).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJBXy9mKixJKzjTtch2WmT)_