### PR TITLE
docs(owner): plain-language website explainer + Claude Design loop

### DIFF
--- a/.sessions/2026-06-20-website-explainer-doc.md
+++ b/.sessions/2026-06-20-website-explainer-doc.md
@@ -1,0 +1,60 @@
+# 2026-06-20 — Plain-language website explainer doc (owner-requested)
+
+> **Status:** `complete`
+
+## Arc
+
+Follow-up to the SPA-wiring session (PR #1196, merged). The owner — still learning the web/design
+side — asked for a plain-language explanation of "what Jinja and the SPA mean etc., plus other
+useful stuff," and how to continue working in Claude Design ("do I just tell it to sync to main?").
+
+## Shipped
+
+- **`docs/owner/website-explained.md`** (`owner-guidance`) — plain-English tour: server-rendered
+  (Jinja) vs. SPA, hash routing / `window.SBDATA` / no-build, static vs. dynamic data, the
+  `disbot → site.json → data.js → SPA` pipeline, the three web folders (`botsite`/`dashboard`/
+  `design-system`), the **Claude Design loop** (GitHub connector = sync of the *library*; porting a
+  design onto the live site is a separate Claude-Code step; data is fully automatic), and a
+  supporting-cast glossary (FastAPI/route/API/Railway/CI/linter/auto-merge/PR).
+- Linked from `docs/AGENT_ORIENTATION.md` (website route, item 0) + `botsite/README.md`; corrected
+  the orientation's "production stays Jinja" line to reflect the SPA-as-front-end reality, and
+  flagged the design-system README's now-stale "port into Jinja" framing as a reconcile-when-convenient.
+
+Verification: `check_docs --strict` ✓ (doc reachable, badged `owner-guidance`).
+
+## Answer to the owner's Claude Design question (captured in the doc)
+
+"Sync to main" updates what Claude Design *reads* (the `design-system/` component library, via the
+GitHub connector) — but it does **not** push a design onto the live site by itself; that still needs
+a Claude-Code port step. Data is separate and automatic. The one thing to *set* in Claude Design is
+the "Add to Discord" link (still a placeholder).
+
+## ⚑ Self-initiated
+
+None — owner-directed (write the explainer + answer the Claude Design question).
+
+## 💡 Session idea (Q-0089)
+
+**Reconcile the design-system↔front-end story now that the SPA is live.** The `design-system/`
+README still says "production stays Jinja; port designs into Jinja." With the SPA shipped, a small
+decision + doc update is owed: does the React component library now feed the SPA (retiring the port
+step), or do both stay? Capturing it as a router/idea prevents the two docs drifting further. (Noted
+here + flagged in AGENT_ORIENTATION; not generalized this run.)
+
+## ⟲ Previous-session review (Q-0102)
+
+The SPA-wiring session (#1196) shipped end-to-end and its sync-guard test caught a real
+data.js/site.json drift in CI — good. **What it could have done better:** it left the
+design-system↔SPA story inconsistent (README still says "Jinja only"), which this doc had to flag.
+**System improvement:** when a session changes *which* front-end is live, it should update the
+design-system README in the same PR — a "front-end-of-record" pointer in one place would stop the
+two docs disagreeing.
+
+## 📤 Run report
+
+- **Did:** wrote the plain-language website explainer + answered the Claude Design workflow question ·
+  **Outcome:** shipped (docs-only)
+- **Run type:** `manual · owner-task (docs)`
+- **⚑ Owner decisions needed:** design-system↔SPA reconcile (non-urgent; flagged)
+- **⚑ Owner manual steps:** set the "Add to Discord" link in Claude Design
+- **↪ Next:** on request — reconcile the design-system README to the SPA; wire the install URL

--- a/botsite/README.md
+++ b/botsite/README.md
@@ -1,5 +1,10 @@
 # SuperBot — public bot site
 
+> **New here / learning the web side?** Read
+> [`docs/owner/website-explained.md`](../docs/owner/website-explained.md) first — a
+> plain-language tour of Jinja vs. the SPA, the data pipeline, and how to work with
+> Claude Design.
+
 The **public marketing + reference website** for SuperBot, deployed as its own
 Railway service (separate from both the bot and the developer dashboard). It is the
 public half of the website two-site split — full design, topology, security model,

--- a/docs/AGENT_ORIENTATION.md
+++ b/docs/AGENT_ORIENTATION.md
@@ -151,12 +151,18 @@ read **`docs/helper-policy.md`** first.
 
 ### Touching the public site (`botsite/`) / design-system / Claude Design
 
+0. `docs/owner/website-explained.md` — **plain-language orientation** (Jinja vs. SPA, the
+   `site.json` → `data.js` data pipeline, and the Claude Design loop). Read this first if the
+   web/design vocabulary is unfamiliar.
 1. `design-system/README.md` — **the contract for the Claude Design workflow**: the
    React/Tailwind component library that mirrors `botsite/`, how Claude Design reads it (the
    **GitHub connector** — primary — or `/design-sync`), the hybrid design→port→preview loop,
    and how to preview without redeploying.
-2. `botsite/` — the live server-rendered Jinja2 + Tailwind site (what actually ships). Canvas
-   designs are ported back into these templates; production stays Jinja.
+2. `botsite/` — the live public site. The front-end is now the **Claude-Design SPA**
+   (`botsite/site/`, served at `/`) whose data layer is generated from `site.json`
+   (`botsite/site_data.py` → live `/data.js` + committed fallback). The earlier server-rendered
+   Jinja2 templates (`botsite/templates/`) remain wired as a fallback. (Note: the design-system
+   README still frames the loop as "port into Jinja" — reconcile when convenient.)
 3. `.github/workflows/design-system-ci.yml` / `botsite-ci.yml` — the JS / site CI legs.
 
 ### Touching settings / bindings / resource provisioning

--- a/docs/owner/website-explained.md
+++ b/docs/owner/website-explained.md
@@ -1,0 +1,183 @@
+<!-- badge: owner-guidance -->
+# The website, explained (plain language)
+
+> **Status:** `owner-guidance` — a learning/orientation doc for the maintainer.
+> Plain-English explanation of how SuperBot's public website works and how to
+> keep working on it (incl. Claude Design). Source code wins over this doc.
+
+This page exists because the website has a few moving parts that are easy to
+confuse. It's written for someone who is comfortable directing the work but is
+still learning the web/design vocabulary.
+
+---
+
+## The core idea: two ways to build a web page
+
+A web page is just **HTML** (the content + structure a browser shows). The only
+real question is *who assembles that HTML, and when?* There are two answers, and
+this repo contains both.
+
+### 1. Server-rendered (the "Jinja" way)
+
+The **server** builds the finished HTML *before* sending it to the browser. The
+browser receives a complete, ready-to-show page.
+
+- **Jinja** is a *templating language* — an HTML file with fill-in-the-blanks
+  (`Hello {{ name }}`). The server plugs in real values and out comes plain HTML.
+- In this repo: `botsite/templates/commands.html` is a Jinja template. Visiting
+  `/commands` makes `botsite/app.py` load the data, fill the template, and ship a
+  finished page.
+- **Analogy:** a restaurant kitchen cooks the whole meal and brings out a plate.
+- **Trade-off:** every click is a new request and a full page reload — simple and
+  robust, but feels less "appy."
+
+### 2. SPA — Single-Page Application (the Claude-Design site)
+
+The server sends **one mostly-empty HTML shell + JavaScript, once.** After that,
+**JavaScript running in the browser** draws each page and swaps content without
+reloading.
+
+- "Single-page" = the browser loads one real HTML file (`index.html`); everything
+  after is JavaScript redrawing the screen.
+- In this repo: `botsite/site/` is the SPA. `index.html` is nearly empty
+  (`<main id="app"></main>`); `app.js` fills that `<main>` depending on the page.
+- **Analogy:** a food truck hands you a chef once, who re-plates different dishes
+  instantly without you walking back to the counter.
+- **Trade-off:** snappier and modern; but the first load is "empty until the
+  JavaScript runs," and it needs that JavaScript to work.
+
+**Today the SPA is the live public site** (served at `/`). The Jinja pages remain
+in the repo as a working fallback.
+
+---
+
+## Vocabulary that comes up around the SPA
+
+- **Hash routing (`/#/commands`).** The part after `#` is **never sent to the
+  server** — the server only ever sees `/`, hands over the SPA, and the
+  JavaScript reads `#/commands` to decide what to draw. That's how a single-page
+  app fakes many "pages" without bothering the server, and why `app.py` only needs
+  to serve the SPA at `/`.
+- **`window.SBDATA`.** `window` is the browser's global scratchpad. `data.js`
+  dumps all the bot's data (commands, games, …) onto `window.SBDATA`, and `app.js`
+  reads from it. It's just "the one bucket of data the app reads."
+- **No build step.** The Claude-Design SPA is *plain* JavaScript — the browser
+  runs it directly, no compile needed (that's why "just open `index.html`" works).
+  The `design-system/` folder, by contrast, is React and *does* need building.
+- **Static vs dynamic data.** *Static* = a frozen file (`botsite/site/data.js`,
+  committed). *Dynamic* = generated when requested (the `/data.js` route, built
+  fresh from the latest data each time). The live site serves the dynamic version;
+  the committed file is a fallback so the prototype still works opened on its own.
+
+---
+
+## The data pipeline (the most important part)
+
+The bot is the **single source of truth**. Data flows one way and is never typed
+twice, so the site can't silently drift out of date:
+
+```
+disbot/                              ← the bot's actual code (source of truth)
+  │  scripts/export_dashboard_data.py reads the bot and writes ↓
+  ▼
+botsite/data/site.json               ← a clean, PUBLIC, safe summary of the bot
+  │  botsite/site_data.py reshapes it into the SPA's shape ↓
+  ▼
+window.SBDATA  →  served live at /data.js   (+ committed botsite/site/data.js fallback)
+  │
+  ▼
+the SPA (app.js) reads it and draws every page
+```
+
+To update the site's content you **do not touch the website** — you change the
+bot, re-run the export, and the data flows through automatically.
+
+- **JSON** (`site.json`) is a universal plain-text data format both Python and
+  JavaScript read natively — that's why it's the hand-off point between the bot
+  (Python) and the site (JavaScript).
+- **Safety:** `botsite/` **never imports the bot's code** and only reads the
+  *public* `site.json`. Even a fully-compromised public site cannot reach the bot,
+  its database, or any secret. That's why `site_data.py` lives inside `botsite/`
+  and never touches `disbot/`.
+
+---
+
+## The three web things in the repo (easy to confuse)
+
+| Folder | What it is | Who sees it | Tech |
+|---|---|---|---|
+| `botsite/` | **Public marketing/reference site** (the main one) | Everyone | FastAPI + the SPA |
+| `dashboard/` | **Private developer dashboard** (full internal data) | Owner/admins | FastAPI + Jinja |
+| `design-system/` | **Reusable UI building blocks** (React), viewable in Storybook | Designers/devs | React + build step |
+
+---
+
+## Working with Claude Design
+
+There are **two separate things**, and only one of them is automatic:
+
+1. **The component library (`design-system/`)** is what Claude Design *builds
+   with*. Claude Design connects to the repo via the **GitHub connector** and
+   reads this library directly, so **merging component changes to the connected
+   branch (main) is the "sync."** You don't upload anything; at most you hit a
+   "refresh/re-read repo" action in Claude Design.
+
+2. **Getting a design onto the live site is NOT automatic.** Claude Design
+   *produces* a design composed from your components; turning that into what
+   visitors see still needs a **Claude Code step** to port it into `botsite/`.
+   Claude Design designs the UI — it does not deploy it.
+
+3. **Data is a third, separate thing** — it comes from the bot via the pipeline
+   above. Claude Design never touches data, so you never "arrange" data there.
+
+**So the loop is:**
+
+```
+edit on the Claude Design canvas  →  hand the result to Claude Code (or say what changed)
+        →  Claude Code ports it into botsite/ and opens a PR  →  data stays automatic
+```
+
+The one concrete thing to *set* in Claude Design is the **"Add to Discord"
+button**: in the shipped SPA it is still a placeholder (`href="#/"`). The
+design-handoff rule is *do not hand-edit `index.html`/`app.js`/`app.css`* — so
+fix it in Claude Design (or add an `install_url` field the SPA reads, which keeps
+it data-driven).
+
+> **Open decision (worth your call):** the `design-system/` README still describes
+> the loop as *"production stays Jinja; port designs back into the Jinja
+> templates."* But the live front-end is now the **SPA**. Those two stories
+> disagree. Nothing is broken, but at some point decide whether the design-system
+> library should feed the **SPA** going forward (and retire the Jinja port step).
+
+---
+
+## Supporting cast (terms you'll keep seeing)
+
+- **FastAPI** — the Python web framework running `botsite`. Each `@app.get("/x")`
+  is a **route** / **endpoint**: "when someone visits this URL, run this function."
+- **API** — a way for programs (not humans) to talk to each other. `/data.js` and
+  `/healthz` are tiny APIs.
+- **Railway** — the host that runs `botsite` on the internet; it redeploys
+  automatically when code merges to `main`. The bot, dashboard, and public site
+  each run as separate Railway services.
+- **CI / GitHub Actions** — robots that run the tests + linters on every PR.
+  `botsite-tests` and `code-quality` are CI checks; green = safe to merge.
+- **Linter / formatter (ruff, black)** — tools that enforce consistent code style.
+  "FAILED: black" just means "not formatted the standard way," not "broken."
+- **Auto-merge** — once CI is green, GitHub merges the PR by itself (we don't merge
+  by hand; we make CI green).
+- **PR (Pull Request)** — a proposed bundle of changes, reviewed + tested before
+  it joins the main code.
+
+---
+
+## Try it locally (the fastest way to make this concrete)
+
+```bash
+pip install -r botsite/requirements.txt
+python3.10 scripts/export_dashboard_data.py --targets site   # regenerate site.json + data.js
+uvicorn botsite.app:app --reload                             # → http://127.0.0.1:8000 (the SPA)
+```
+
+Click around. Seeing the SPA draw pages from `/data.js` makes everything above
+click into place.


### PR DESCRIPTION
## What & why

Owner-requested learning doc (the owner is still learning the web/design side and asked for a plain-language explanation + how to continue in Claude Design).

Adds **`docs/owner/website-explained.md`** covering:
- **Jinja (server-rendered) vs. the SPA** — the two ways to build a page, grounded in this repo's files.
- SPA vocabulary: **hash routing**, `window.SBDATA`, **no build step**, **static vs. dynamic** data.
- The **data pipeline** (`disbot → site.json → data.js → SPA`) and why the bot is the single source of truth.
- The **three web folders** (`botsite` / `dashboard` / `design-system`).
- **Working with Claude Design** — the key clarification: the GitHub connector "sync" updates the *component library* Claude Design reads, but porting a design onto the **live site** is a separate Claude-Code step, and **data is fully automatic**. Flags the still-placeholder "Add to Discord" link.
- A supporting-cast glossary (FastAPI/route/API/Railway/CI/linter/auto-merge/PR) + local run steps.

Linked from `docs/AGENT_ORIENTATION.md` (website route) and `botsite/README.md`. Also **corrected** the orientation's stale "production stays Jinja" line to reflect the now-live SPA, and flagged the design-system README's "port into Jinja" framing as a reconcile-when-convenient (non-urgent).

## Verification

- `check_docs --strict` ✓ (doc reachable + badged `owner-guidance`).
- Docs-only — no runtime/code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KMym2t7s6BB8dF4DpKjiPk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMym2t7s6BB8dF4DpKjiPk)_