### PR TITLE
docs: record Claude Design connector as read-only (resolves migration-plan Decision D)

### DIFF
--- a/design-system/README.md
+++ b/design-system/README.md
@@ -141,7 +141,10 @@ Connectors). Claude Design then reads the component library **straight from the 
 - After a merge, **refresh / reopen the Claude Design project** so it re-reads the latest
   commit. If Claude Design lets you select a branch, you can preview a branch *before* it
   merges.
-- Canvas edits save back to source as commits / PRs on the repo.
+- **The connector is READ-ONLY in this project** (owner-confirmed 2026-06-20): GitHub grants
+  it read access only and exposes no write toggle. So Claude Design **cannot** commit or open
+  PRs back to the repo — canvas edits are exported manually (a handoff zip) and a **Claude Code
+  step commits them**. The read path (repo → Claude Design) is the only automatic half.
 
 ### `/design-sync` (alternative — manual upload)
 

--- a/docs/owner/website-explained.md
+++ b/docs/owner/website-explained.md
@@ -120,7 +120,9 @@ There are **two separate things**, and only one of them is automatic:
    with*. Claude Design connects to the repo via the **GitHub connector** and
    reads this library directly, so **merging component changes to the connected
    branch (main) is the "sync."** You don't upload anything; at most you hit a
-   "refresh/re-read repo" action in Claude Design.
+   "refresh/re-read repo" action in Claude Design. The connector is **read-only**
+   (owner-confirmed 2026-06-20) — it reads the repo but cannot write to it, so
+   Claude Design never opens its own PRs.
 
 2. **Getting a design onto the live site is NOT automatic.** Claude Design
    *produces* a design composed from your components; turning that into what

--- a/docs/planning/botsite-react-spa-migration-plan-2026-06-20.md
+++ b/docs/planning/botsite-react-spa-migration-plan-2026-06-20.md
@@ -87,7 +87,7 @@ A below offers the Railway-builds alternative if preferred.)
 | **A** | Who runs the React build? | (a) **CI builds + commits** the static bundle to `botsite/site/` → Railway stays Python-only; (b) Railway builds (add Node/nixpacks buildpack) | **(a)** — keeps the proven Python-only Railway service and mirrors the existing `data.js` generation pattern |
 | **B** | How does the React app get data? | (a) add a pure **`/site-data.json`** endpoint the app `fetch()`es; (b) reuse `/data.js`'s `window.SBDATA` via a TS adapter | **(a)** — cleaner contract for React; keep `/data.js` during transition for the legacy SPA |
 | **C** | Cutover style | (a) flip `/` to React, keep vanilla SPA + Jinja as fallback for one band, then remove; (b) hard cutover | **(a)** — reversible, low-risk |
-| **D** | Connector write-back | Does Claude Design's GitHub connector have **write** access (can it open its own PRs)? | Confirm in Claude Design settings — if yes, the loop needs *no* Claude Code at all (connector PR → CI → Railway); if no, Claude Code stays as the trivial "merge" step |
+| **D** | Connector write-back | Does Claude Design's GitHub connector have **write** access (can it open its own PRs)? | **RESOLVED (owner-confirmed 2026-06-20): READ-ONLY.** GitHub grants the connector read access only and exposes no write toggle, so Claude Design **cannot** open its own PRs. The loop therefore keeps a **Claude Code step**: design → manual export (handoff zip) → Claude Code commits + opens the PR → CI → Railway. (Still no *porting* once the React migration lands — the export is the built app, not a re-implementation.) |
 
 None of these blocks starting PR 1 except as noted; A/B can default to the recommendation.
 


### PR DESCRIPTION
Records an owner-confirmed finding from this session: the **GitHub connector** backing Claude Design has **read access only**, and GitHub exposes no write toggle for it. Claude Design therefore **cannot** commit or open PRs back to the repo.

This closes **Decision D** in the React-SPA migration plan (previously "unconfirmed") and fixes a now-false doc line.

## Changes
- **`design-system/README.md`** — correct the inaccurate *"canvas edits save back to source as commits / PRs"* bullet (impossible read-only); mark the connector read-only.
- **`docs/planning/botsite-react-spa-migration-plan-2026-06-20.md`** — Decision D marked **RESOLVED: READ-ONLY**; the design loop keeps a Claude Code commit step (design → manual export/handoff → Claude Code opens the PR → CI → Railway).
- **`docs/owner/website-explained.md`** — note the connector is read-only.

## Context
Surfaced while syncing the handoff in #1200: the handoff arrives as a manually downloaded zip (no connector write-back), which is exactly the read-only path. Docs-only; `python3.10 scripts/check_docs.py --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWLrbDEqJuo29oyJou4fWu

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWLrbDEqJuo29oyJou4fWu)_