### PR TITLE
fix(ci): CI-reliability batch — BUG-0020 trim floor-pointer + BUG-0021 flaky lock test + BUG-0022 suite clobbers data.js

### DIFF
--- a/.sessions/2026-06-21-bug0020-trim-floor-pointer-prose.md
+++ b/.sessions/2026-06-21-bug0020-trim-floor-pointer-prose.md
@@ -1,88 +1,102 @@
-# 2026-06-21 — BUG-0020: trim_recently_shipped floor-pointer prose contamination (+ ruff-pin drift)
+# 2026-06-21 — CI-reliability batch: BUG-0020 + BUG-0021 + BUG-0022
 
-> **Status:** `complete` — tooling/docs only (no `disbot/` runtime) → self-merge on green (Q-0113).
+> **Status:** `complete` — tooling/test/docs only (no `disbot/` runtime changed) → self-merge on
+> green (Q-0113).
 
 > **Run type:** routine · dispatch
 
 ## What I did
 
-Scheduled dispatch, no work order → advanced the next plan slice. Picked **bugs-first**: closed the
-one OPEN tooling bug (BUG-0020) at the root with a regression test, and fixed a drift bug I spotted
-along the way (the ruff pin).
+Scheduled dispatch, no work order → advanced the plan **bugs-first**. Started on the one OPEN
+tooling bug (BUG-0020); shipping it surfaced two more CI-reliability bugs (a flaky test, then a
+test that clobbers a tracked file), each root-caused and fixed with a stays-fixed guard in the
+same PR. All three are test/tooling hygiene — no runtime code touched.
 
-### Slice 1 — BUG-0020 (root fix + guard)
+### Slice 1 — BUG-0020: trim floor-pointer prose contamination (root)
 `scripts/trim_recently_shipped.py`'s floor-pointer recompute scanned the **whole** archive for `#N`
-and took min/max over all matches, so it picked up stray prose references (a `band-#1170`
-parenthetical note, `#1` rank notation) and wrote a wrong `Older merges (#HIGH … #LOW)` span — caught
-on the actuator's first real use (seventeenth Q-0107 pass wrote `#1170 … #1` for a true span of
-`#1129 … #535`).
-- **Fix:** new `_archive_span_numbers(archive_text)` reads **only archived bullet headers**
-  (`^- \*\*#…`), taking each bullet's leading `#A · #B …` cluster (the run before the first ` (` date
-  paren or `**` bold close). Grouped non-monotonic bands (`#690 · #721`) still contribute their newest
-  member; free-floating `#N` in prose no longer counts. `_rewrite_floor` calls it instead of the
-  whole-archive `_pr_numbers`. Module docstring de-staled ("whole archive" → "bullet headers").
-- **Guard:** `tests/unit/scripts/test_trim_recently_shipped.py::test_floor_pointer_ignores_stray_pr_refs_in_prose`
-  feeds an archive whose prose carries a stray high (`band-#9999`) + low (`#1`) `#N` and asserts the
-  span ignores both. The existing non-monotonic-band test still passes (proves the cluster path keeps
-  grouped members).
-- Bug-book BUG-0020 → **FIXED**.
+and took min/max over all matches, picking up stray prose refs (a `band-#1170` note, `#1` rank
+notation) → wrong `Older merges (#HIGH … #LOW)` span (it wrote `#1170 … #1` for a true `#1129 …
+#535` on its first real use).
+- **Fix:** new `_archive_span_numbers()` reads **only archived bullet headers**, taking each
+  bullet's leading `#A · #B …` cluster (before the first ` (` or `**`). Grouped non-monotonic bands
+  (`#690 · #721`) still contribute their newest member; prose `#N` no longer counts.
+- **Guard:** `test_floor_pointer_ignores_stray_pr_refs_in_prose`.
 
-### Slice 1b — ruff-pin drift (spotted while running the CI mirror; Q-0166 fix-on-sight)
-Running `check_quality.py` locally raised a false ERA001 in `botsite/app.py` (a file I didn't touch).
-Root cause: Dependabot's `chore(deps-dev)` bump (#2b035a3d) raised **only** `requirements-dev.txt`
-to `ruff==0.15.18`, leaving `code-quality.yml` + `.pre-commit-config.yaml` at `0.15.14` — the exact
-"bump all three places together" drift CLAUDE.md warns about. 0.15.18 flags an ERA001 false positive
-on a genuine prose comment that 0.15.14 (CI's actual version) does not. Realigned the dev pin back to
-`0.15.14` (the value CI + pre-commit enforce) with an inline note. Adopting 0.15.18 would be a separate
-deliberate three-place bump + suppressing that ERA001 FP — not done here.
+### Slice 1b — ruff-pin drift (Q-0166 fix-on-sight)
+Dependabot's `chore(deps-dev)` bump raised **only** `requirements-dev.txt` to `ruff==0.15.18`, leaving
+`code-quality.yml` + `.pre-commit-config.yaml` at `0.15.14` — the "bump all three together" drift
+CLAUDE.md warns about. 0.15.18 raised a false ERA001 on a genuine prose comment in `botsite/app.py`
+that CI's actual 0.15.14 does not. Realigned the dev pin to `0.15.14`.
+
+### Slice 2 — BUG-0021: flaky `acquire_lock_or_exit` wait-timeout test (root)
+`test_acquire_lock_or_exit_exits_zero_after_wait_timeout` drove the lock loop against the **real**
+`time.monotonic` with a 0.05 s budget (sleep mocked instant) and asserted `await_count >= 2`. Under
+parallel-xdist CPU starvation the budget could elapse after one attempt → intermittent red.
+- **Fix:** fake the clock — it only advances when the mocked `asyncio.sleep` runs; one sleep jumps
+  past the budget, so the loop gives up on exactly attempt 2 (`await_count == 2`). No runtime code
+  changed. Verified 5× + full file green.
+
+### Slice 3 — BUG-0022: full suite clobbers tracked `botsite/site/data.js` (root)
+Diagnosing why CI reddened on `data.js` stale-vs-`site.json`: `scripts/export_dashboard_data.py
+main()` wrote the SPA data layer to a **hardcoded** real path, ignoring its output args, stamped with
+the live `git rev-parse --short HEAD`. The CLI tests drive `main()` with `tmp_path` for
+dashboard/site.json but data.js still hit the **tracked** repo file → every full-suite run rewrote it
+with the session sha → `git add -A` swept it into the commit, desynced from the committed site.json →
+red botsite-tests. This is what corrupted my own first push (`data.js` build = my born-red sha).
+- **Fix (root):** `main()` takes `--data-js-output` (default = real path, so the reconciliation
+  routine's regen is unchanged); the two CLI tests redirect it to tmp.
+- **Guard:** `test_cli_does_not_clobber_tracked_data_js_when_redirected` snapshots the real
+  `DATA_JS_OUTPUT_FILE`, runs `main()` redirected, asserts the tracked file is byte-identical after.
+- Restored the accidentally-committed `botsite/site/data.js` to `origin/main`'s version.
 
 ## What shipped
-- `scripts/trim_recently_shipped.py` — `_archive_span_numbers` helper + `_rewrite_floor` rewire + docstring.
-- `tests/unit/scripts/test_trim_recently_shipped.py` — new prose-contamination regression test.
+- `scripts/trim_recently_shipped.py` + `tests/unit/scripts/test_trim_recently_shipped.py` (BUG-0020).
 - `requirements-dev.txt` — ruff `0.15.18` → `0.15.14` (drift realign).
-- `docs/health/bug-book.md` — BUG-0020 FIXED.
+- `tests/unit/services/test_runtime.py` — deterministic clock fake (BUG-0021).
+- `scripts/export_dashboard_data.py` + `tests/unit/scripts/test_export_dashboard_data.py` (BUG-0022).
+- `botsite/site/data.js` — restored to main (revert accidental inclusion).
+- `docs/health/bug-book.md` — BUG-0020/0021/0022 all FIXED.
 
 ## Verification
-- `python3.10 -m pytest tests/unit/scripts/test_trim_recently_shipped.py` → 10 passed.
-- `python3.10 scripts/check_quality.py --full` → lint + mypy clean, 11036 passed (after pinning ruff
-  to CI's 0.15.14). One pre-existing **flaky** failure under `-n auto` —
-  `test_runtime.py::test_acquire_lock_or_exit_exits_zero_after_wait_timeout` — passes in isolation
-  (real-`time.monotonic` 0.05s budget, CPU-starvation flake). Captured as **BUG-0021** (OPEN) for a
-  deterministic fix; not caused by this change.
-- No `disbot/` runtime touched → arch check trivially unaffected.
+- BUG-0020: `pytest test_trim_recently_shipped.py` → 10 passed (incl. new guard).
+- BUG-0021: target test 5× green + full `test_runtime.py` (21) green.
+- BUG-0022: `pytest test_export_dashboard_data.py` → 31 passed; real `data.js` md5 unchanged before/after.
+- `check_quality.py --check-only` green (ruff 0.15.14); `check_docs.py --strict`,
+  `check_current_state_ledger.py --strict` green.
 
 ## Handoff
-BUG-0020 is closed at the root. Next: **BUG-0021** (flaky `acquire_lock_or_exit` wait-timeout test) is
-captured OPEN with a proposed deterministic fix (mock `time.monotonic`); a good small next slice. The
-substantial ungated lanes in current-state ▶ Next action still stand: creature-game v1 runtime cog,
-botsite React-SPA migration, the `public-data-contract-field-snapshot` guard.
+Three CI-reliability bugs closed at the root. The substantial ungated lanes in current-state ▶ Next
+action still stand for the next dispatch: **creature-game v1 runtime cog**, **botsite React-SPA
+migration**, the `public-data-contract-field-snapshot` guard, or a `needs-hermes-review` lane
+(consistency-linter AI-nav PR 1 · procedures→skills Batch 2).
 
 ## ⚑ Self-initiated
-None — BUG-0020 was the OPEN bug-book queue (bugs-first), and the ruff-pin realign is fix-on-sight
-drift (Q-0166). No invented feature.
+None — all three were bugs-first (BUG-0020 from the OPEN queue; BUG-0021/BUG-0022 root-caused while
+shipping it). The ruff realign is fix-on-sight drift (Q-0166). No invented feature.
 
 ## 💡 Session idea
-**Dependabot dev-dep bumps that touch a tool pinned in 3 places should fail a CI guard unless all
-three move together.** This run's ruff drift (`requirements-dev.txt` bumped alone) is the second
-"pinned-in-three-places drifted" incident; a tiny `scripts/check_tool_pin_parity.py` (stdlib: parse
-the black/isort/ruff/mypy versions from `code-quality.yml`, `requirements-dev.txt`,
-`.pre-commit-config.yaml` and assert equality) wired into `code-quality.yml` would turn the prose rule
-into an enforced one and red-flag an incomplete Dependabot bump at PR time. Worth having — captured for
-grooming.
+**A `scripts/check_tool_pin_parity.py` (stdlib) wired into `code-quality.yml`** that parses the
+black/isort/ruff/mypy versions from `code-quality.yml`, `requirements-dev.txt`, and
+`.pre-commit-config.yaml` and fails unless all three agree. This run's ruff drift is the second
+"pinned-in-three-places drifted" incident; the rule is currently prose-only. Such a guard would
+red-flag an incomplete Dependabot bump at PR time instead of leaking a false-positive lint into a
+dispatch session. Captured for grooming.
 
 ## ⟲ Previous-session review
-The previous session (world-registry parity invariant, #1156 follow-up) was a clean, well-scoped
-self-merge slice and correctly declined the heavier gated lanes (PR 2 migration, CLAUDE.md edits) with
-explicit reasons — good judgment. One thing it could have done: while it was the *first* session after
-the seventeenth reconciliation pass that surfaced BUG-0020, it left that OPEN tooling bug for a later
-run; a bugs-first sweep of the freshly-written bug-book at session start would have caught a
-same-shape, same-day fixable item. System improvement it surfaces: the **tool-pin parity guard** above
-— had it existed, the ruff drift this run chased would never have reached a dispatch session.
+The previous session (world-registry parity invariant, #1156 follow-up) was clean and correctly
+declined the gated heavy lanes — good judgment. What it (and several prior sessions) missed is
+systemic, not local: **BUG-0022 means any session that ran `check_quality.py --full` and then
+`git add -A` could silently ship a corrupted `data.js`** — a latent trap that had been live since the
+botsite data layer landed. None of the recent botsite-touching sessions caught it because the
+symptom only appears when the regenerated file is *committed*. System improvement it surfaces (now
+acted on): tests must never write tracked files — the `--data-js-output` redirect is the fix, and the
+broader lesson is the **tool-pin parity guard** idea above plus a possible "no test writes a tracked
+path" sweep as a future check.
 
 ## 📤 Run report
 - **Run type:** routine · dispatch
-- **What shipped:** BUG-0020 floor-pointer prose-contamination root fix + regression guard; ruff dev-pin
-  drift realign (0.15.18 → 0.15.14); BUG-0021 captured.
+- **What shipped:** BUG-0020 (trim floor-pointer prose) + BUG-0021 (flaky lock-wait test) + BUG-0022
+  (suite clobbers tracked data.js) — all root fixes with stays-fixed guards; ruff dev-pin drift realign.
 - **⚑ Owner-decisions:** none
 - **⚑ Owner-manual-steps:** none
 - **⚑ Self-initiated:** none

--- a/.sessions/2026-06-21-bug0020-trim-floor-pointer-prose.md
+++ b/.sessions/2026-06-21-bug0020-trim-floor-pointer-prose.md
@@ -1,0 +1,19 @@
+# 2026-06-21 — BUG-0020: trim_recently_shipped floor-pointer prose contamination
+
+> **Status:** `in-progress` — born-red session card (Q-0133). Will flip to `complete` as the
+> deliberate final step once CI is green.
+
+> **Run type:** routine · dispatch
+
+## What I'm about to do
+
+Fix **BUG-0020** (OPEN, tooling) at the root: `scripts/trim_recently_shipped.py`'s floor-pointer
+recompute scans the *whole* archive for `#N` and takes min/max over **all** matches, so it picks up
+stray references in prose (a `band-#1170` parenthetical note, `#1` rank notation) and writes a wrong
+`Older merges (#HIGH … #LOW)` span. The fix: recompute the span from **archived bullet headers only**
+— each bullet's leading PR-reference cluster (so grouped non-monotonic bands like `#690 · #721` still
+contribute their newest member), never free-floating `#N` in prose. Ships with a regression test that
+feeds an archive whose prose carries a stray high/low `#N` and asserts the span ignores it.
+
+Contained, reversible, test-covered, docs/tooling only (no `disbot/` runtime) → self-merge on green
+(Q-0113).

--- a/.sessions/2026-06-21-bug0020-trim-floor-pointer-prose.md
+++ b/.sessions/2026-06-21-bug0020-trim-floor-pointer-prose.md
@@ -1,19 +1,88 @@
-# 2026-06-21 — BUG-0020: trim_recently_shipped floor-pointer prose contamination
+# 2026-06-21 — BUG-0020: trim_recently_shipped floor-pointer prose contamination (+ ruff-pin drift)
 
-> **Status:** `in-progress` — born-red session card (Q-0133). Will flip to `complete` as the
-> deliberate final step once CI is green.
+> **Status:** `complete` — tooling/docs only (no `disbot/` runtime) → self-merge on green (Q-0113).
 
 > **Run type:** routine · dispatch
 
-## What I'm about to do
+## What I did
 
-Fix **BUG-0020** (OPEN, tooling) at the root: `scripts/trim_recently_shipped.py`'s floor-pointer
-recompute scans the *whole* archive for `#N` and takes min/max over **all** matches, so it picks up
-stray references in prose (a `band-#1170` parenthetical note, `#1` rank notation) and writes a wrong
-`Older merges (#HIGH … #LOW)` span. The fix: recompute the span from **archived bullet headers only**
-— each bullet's leading PR-reference cluster (so grouped non-monotonic bands like `#690 · #721` still
-contribute their newest member), never free-floating `#N` in prose. Ships with a regression test that
-feeds an archive whose prose carries a stray high/low `#N` and asserts the span ignores it.
+Scheduled dispatch, no work order → advanced the next plan slice. Picked **bugs-first**: closed the
+one OPEN tooling bug (BUG-0020) at the root with a regression test, and fixed a drift bug I spotted
+along the way (the ruff pin).
 
-Contained, reversible, test-covered, docs/tooling only (no `disbot/` runtime) → self-merge on green
-(Q-0113).
+### Slice 1 — BUG-0020 (root fix + guard)
+`scripts/trim_recently_shipped.py`'s floor-pointer recompute scanned the **whole** archive for `#N`
+and took min/max over all matches, so it picked up stray prose references (a `band-#1170`
+parenthetical note, `#1` rank notation) and wrote a wrong `Older merges (#HIGH … #LOW)` span — caught
+on the actuator's first real use (seventeenth Q-0107 pass wrote `#1170 … #1` for a true span of
+`#1129 … #535`).
+- **Fix:** new `_archive_span_numbers(archive_text)` reads **only archived bullet headers**
+  (`^- \*\*#…`), taking each bullet's leading `#A · #B …` cluster (the run before the first ` (` date
+  paren or `**` bold close). Grouped non-monotonic bands (`#690 · #721`) still contribute their newest
+  member; free-floating `#N` in prose no longer counts. `_rewrite_floor` calls it instead of the
+  whole-archive `_pr_numbers`. Module docstring de-staled ("whole archive" → "bullet headers").
+- **Guard:** `tests/unit/scripts/test_trim_recently_shipped.py::test_floor_pointer_ignores_stray_pr_refs_in_prose`
+  feeds an archive whose prose carries a stray high (`band-#9999`) + low (`#1`) `#N` and asserts the
+  span ignores both. The existing non-monotonic-band test still passes (proves the cluster path keeps
+  grouped members).
+- Bug-book BUG-0020 → **FIXED**.
+
+### Slice 1b — ruff-pin drift (spotted while running the CI mirror; Q-0166 fix-on-sight)
+Running `check_quality.py` locally raised a false ERA001 in `botsite/app.py` (a file I didn't touch).
+Root cause: Dependabot's `chore(deps-dev)` bump (#2b035a3d) raised **only** `requirements-dev.txt`
+to `ruff==0.15.18`, leaving `code-quality.yml` + `.pre-commit-config.yaml` at `0.15.14` — the exact
+"bump all three places together" drift CLAUDE.md warns about. 0.15.18 flags an ERA001 false positive
+on a genuine prose comment that 0.15.14 (CI's actual version) does not. Realigned the dev pin back to
+`0.15.14` (the value CI + pre-commit enforce) with an inline note. Adopting 0.15.18 would be a separate
+deliberate three-place bump + suppressing that ERA001 FP — not done here.
+
+## What shipped
+- `scripts/trim_recently_shipped.py` — `_archive_span_numbers` helper + `_rewrite_floor` rewire + docstring.
+- `tests/unit/scripts/test_trim_recently_shipped.py` — new prose-contamination regression test.
+- `requirements-dev.txt` — ruff `0.15.18` → `0.15.14` (drift realign).
+- `docs/health/bug-book.md` — BUG-0020 FIXED.
+
+## Verification
+- `python3.10 -m pytest tests/unit/scripts/test_trim_recently_shipped.py` → 10 passed.
+- `python3.10 scripts/check_quality.py --full` → lint + mypy clean, 11036 passed (after pinning ruff
+  to CI's 0.15.14). One pre-existing **flaky** failure under `-n auto` —
+  `test_runtime.py::test_acquire_lock_or_exit_exits_zero_after_wait_timeout` — passes in isolation
+  (real-`time.monotonic` 0.05s budget, CPU-starvation flake). Captured as **BUG-0021** (OPEN) for a
+  deterministic fix; not caused by this change.
+- No `disbot/` runtime touched → arch check trivially unaffected.
+
+## Handoff
+BUG-0020 is closed at the root. Next: **BUG-0021** (flaky `acquire_lock_or_exit` wait-timeout test) is
+captured OPEN with a proposed deterministic fix (mock `time.monotonic`); a good small next slice. The
+substantial ungated lanes in current-state ▶ Next action still stand: creature-game v1 runtime cog,
+botsite React-SPA migration, the `public-data-contract-field-snapshot` guard.
+
+## ⚑ Self-initiated
+None — BUG-0020 was the OPEN bug-book queue (bugs-first), and the ruff-pin realign is fix-on-sight
+drift (Q-0166). No invented feature.
+
+## 💡 Session idea
+**Dependabot dev-dep bumps that touch a tool pinned in 3 places should fail a CI guard unless all
+three move together.** This run's ruff drift (`requirements-dev.txt` bumped alone) is the second
+"pinned-in-three-places drifted" incident; a tiny `scripts/check_tool_pin_parity.py` (stdlib: parse
+the black/isort/ruff/mypy versions from `code-quality.yml`, `requirements-dev.txt`,
+`.pre-commit-config.yaml` and assert equality) wired into `code-quality.yml` would turn the prose rule
+into an enforced one and red-flag an incomplete Dependabot bump at PR time. Worth having — captured for
+grooming.
+
+## ⟲ Previous-session review
+The previous session (world-registry parity invariant, #1156 follow-up) was a clean, well-scoped
+self-merge slice and correctly declined the heavier gated lanes (PR 2 migration, CLAUDE.md edits) with
+explicit reasons — good judgment. One thing it could have done: while it was the *first* session after
+the seventeenth reconciliation pass that surfaced BUG-0020, it left that OPEN tooling bug for a later
+run; a bugs-first sweep of the freshly-written bug-book at session start would have caught a
+same-shape, same-day fixable item. System improvement it surfaces: the **tool-pin parity guard** above
+— had it existed, the ruff drift this run chased would never have reached a dispatch session.
+
+## 📤 Run report
+- **Run type:** routine · dispatch
+- **What shipped:** BUG-0020 floor-pointer prose-contamination root fix + regression guard; ruff dev-pin
+  drift realign (0.15.18 → 0.15.14); BUG-0021 captured.
+- **⚑ Owner-decisions:** none
+- **⚑ Owner-manual-steps:** none
+- **⚑ Self-initiated:** none

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -5502,7 +5502,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "4c616685",
+    "build": "f652dc97",
     "title": "New public bot website",
     "changes": [
       {
@@ -5514,7 +5514,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "4c616685",
+    "build": "f652dc97",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -5526,7 +5526,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "4c616685",
+    "build": "f652dc97",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -5502,7 +5502,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "f652dc97",
+    "build": "4c616685",
     "title": "New public bot website",
     "changes": [
       {
@@ -5514,7 +5514,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "f652dc97",
+    "build": "4c616685",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -5526,7 +5526,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "f652dc97",
+    "build": "4c616685",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/docs/health/bug-book.md
+++ b/docs/health/bug-book.md
@@ -23,7 +23,32 @@
 > later empty-fire dispatch run can pick them up instead of them sitting un-promoted (the
 > trap BUG-0018 hit). Advisory by default; `--strict` exits 1 on a non-empty backlog.
 
-## BUG-0021 — `test_acquire_lock_or_exit_exits_zero_after_wait_timeout` is flaky under `pytest -n auto` (real-clock dependent) — OPEN
+## BUG-0022 — full test suite rewrites the tracked `botsite/site/data.js` (live-HEAD build sha) → `git add -A` reddens botsite-tests — FIXED
+
+- **Symptom (found 2026-06-21, dispatch run):** an unrelated PR (a tooling/docs fix) reddened **both**
+  `botsite-tests` and `code-quality` on `test_committed_data_js_is_in_sync_with_site_json` — the
+  committed `botsite/site/data.js` was "stale" vs `site.json`. The data.js in the commit carried the
+  session's own HEAD short-sha in its CHANGELOG `build` field while `site.json` still carried the older
+  committed sha, so the two disagreed.
+- **Expected:** running the test suite (or `check_quality.py --full`) never modifies a tracked repo
+  file; a broad `git add -A` cannot accidentally capture a regenerated artifact.
+- **Root cause:** `scripts/export_dashboard_data.py main()` wrote the SPA data layer to a **hardcoded**
+  `REPO_ROOT/botsite/site/data.js`, ignoring its output args. The CLI tests
+  (`test_cli_targets_both_writes_both`, `test_cli_targets_site_writes_only_site_json`) drive `main()`
+  with `tmp_path` outputs for dashboard.json + site.json — but data.js was still written to the **real**
+  tracked path, stamped with `git rev-parse --short HEAD` (the live session commit, line ~618). So every
+  full-suite run silently rewrote the working-tree data.js; the next `git add -A` swept it into the
+  commit, desynced from the committed site.json → red botsite-tests.
+- **Fix (root):** `main()` now takes a `--data-js-output` arg (default `DATA_JS_OUTPUT_FILE` = the real
+  path, so the reconciliation routine's `python3.10 scripts/export_dashboard_data.py` is unchanged), and
+  the two CLI tests redirect it to `tmp_path`. The suite can no longer touch the tracked file.
+- **Stays-fixed guard:** `tests/unit/scripts/test_export_dashboard_data.py::test_cli_does_not_clobber_tracked_data_js_when_redirected`
+  snapshots the real `DATA_JS_OUTPUT_FILE`, runs `main()` with all outputs redirected, and asserts the
+  tracked file is byte-identical afterward (fails against the pre-fix hardcoded-path behavior).
+- **Status:** FIXED 2026-06-21 (dispatch run, PR #1206). Note for future sessions: this is *why* a stray
+  `M botsite/site/data.js` could appear after running tests — that recurrence is now closed at the root.
+
+## BUG-0021 — `test_acquire_lock_or_exit_exits_zero_after_wait_timeout` is flaky under `pytest -n auto` (real-clock dependent) — FIXED
 
 - **Symptom (observed 2026-06-21, dispatch run, during a `check_quality.py --full` mirror):**
   `tests/unit/services/test_runtime.py::test_acquire_lock_or_exit_exits_zero_after_wait_timeout`
@@ -43,8 +68,12 @@
   the already-mocked `asyncio.sleep` so the whole loop is clock-controlled.
 - **Stays-fixed guard:** the same test, made deterministic, run under `-n auto` — it can no longer
   depend on real elapsed time.
-- **Status:** OPEN — captured 2026-06-21; the flake is intermittent and pre-existing, so it does not
-  block unrelated PRs. A good small bugs-first slice for a follow-up dispatch run.
+- **Status:** FIXED 2026-06-21 (dispatch run, PR #1206) — the test now patches
+  `services.runtime.time.monotonic` with a fake clock that only advances when the (already-mocked)
+  `asyncio.sleep` runs; one sleep jumps it past the 0.05 s budget, so the loop gives up on exactly the
+  second attempt (`assert try_acquire.await_count == 2`, tightened from the timing-dependent `>= 2`).
+  No runtime code changed — the production `time.monotonic` path is unaltered. Verified deterministic
+  (5× + full file green).
 
 ## BUG-0020 — `trim_recently_shipped.py` floor-pointer recompute matches stray `#N` in prose (writes a wrong "Older merges (#HIGH … #LOW)" span) — FIXED
 

--- a/docs/health/bug-book.md
+++ b/docs/health/bug-book.md
@@ -23,7 +23,30 @@
 > later empty-fire dispatch run can pick them up instead of them sitting un-promoted (the
 > trap BUG-0018 hit). Advisory by default; `--strict` exits 1 on a non-empty backlog.
 
-## BUG-0020 — `trim_recently_shipped.py` floor-pointer recompute matches stray `#N` in prose (writes a wrong "Older merges (#HIGH … #LOW)" span) — OPEN (tooling; symptom hand-corrected)
+## BUG-0021 — `test_acquire_lock_or_exit_exits_zero_after_wait_timeout` is flaky under `pytest -n auto` (real-clock dependent) — OPEN
+
+- **Symptom (observed 2026-06-21, dispatch run, during a `check_quality.py --full` mirror):**
+  `tests/unit/services/test_runtime.py::test_acquire_lock_or_exit_exits_zero_after_wait_timeout`
+  failed once in a parallel (`-n auto`) run, then **passed in isolation** on re-run. A classic
+  real-wall-clock flake, not a logic bug — and not caused by the change under test (a docs/tooling PR).
+- **Expected:** the test is deterministic regardless of host load / parallel scheduling.
+- **Root cause:** the test drives `runtime.acquire_lock_or_exit(boot_wait_seconds=0.05,
+  boot_poll_seconds=0.01)` against the **real** `time.monotonic` clock (deliberately un-mocked — the
+  inline comment says "Use a tiny budget so the test finishes quickly without mocking time.monotonic"),
+  while `asyncio.sleep` is mocked to return instantly. The loop therefore spins doing `try_acquire`
+  calls until 0.05 s of real wall-clock elapses, and asserts `try_acquire.await_count >= 2`. Under
+  CPU starvation (many parallel xdist workers) the process can be scheduled out so that the 0.05 s
+  budget elapses after only **one** attempt → the `>= 2` assertion fails.
+- **Proposed fix (test-only — needs no runtime change):** patch `services.runtime.time.monotonic` with
+  a controlled fake that returns a deterministic increasing sequence (e.g. `0.0, 0.0, 0.06`), so the
+  deadline crosses *after* exactly the intended number of attempts independent of host timing. Mirrors
+  the already-mocked `asyncio.sleep` so the whole loop is clock-controlled.
+- **Stays-fixed guard:** the same test, made deterministic, run under `-n auto` — it can no longer
+  depend on real elapsed time.
+- **Status:** OPEN — captured 2026-06-21; the flake is intermittent and pre-existing, so it does not
+  block unrelated PRs. A good small bugs-first slice for a follow-up dispatch run.
+
+## BUG-0020 — `trim_recently_shipped.py` floor-pointer recompute matches stray `#N` in prose (writes a wrong "Older merges (#HIGH … #LOW)" span) — FIXED
 
 - **Symptom (caught 2026-06-20, seventeenth Q-0107 reconciliation pass, first real use of the actuator):**
   after `scripts/trim_recently_shipped.py --apply` moved the 8 oldest Recently-shipped bullets to the
@@ -43,10 +66,15 @@
   `#N` and asserts the computed span ignores it.
 - **Stays-fixed guard (to ship with the fix):** the `tests/unit/scripts/` case above, failing against the
   current all-`#N`-match behavior.
-- **Status:** OPEN — caught + symptom-corrected by hand this pass (the live `current-state.md` pointer reads
-  `#1129 … #535`); the actuator script itself is unfixed. Q-0105 note: this is the actuator's *first* real
-  outing and it already mis-wrote the one value it exists to keep correct — keep an eye on it; if it proves
-  unreliable across a couple more passes, prefer reverting to the hand-trim over working around it.
+- **Status:** FIXED 2026-06-21 (dispatch run, PR #1206) — root fix: `_rewrite_floor` now derives the span
+  from a new `_archive_span_numbers(archive_text)` helper that reads **only archived bullet headers**
+  (`^- \*\*#…`), taking each bullet's leading `#A · #B …` cluster (the run before the first ` (` date paren
+  or `**` bold close). Grouped non-monotonic bands (`#690 · #721`) still contribute their newest member;
+  free-floating `#N` in prose (a `band-#1170` note, a `#1` rank token) no longer widens the span.
+  Stays-fixed guard: `tests/unit/scripts/test_trim_recently_shipped.py::test_floor_pointer_ignores_stray_pr_refs_in_prose`
+  feeds an archive whose prose carries a stray high (`band-#9999`) + low (`#1`) `#N` and asserts the
+  recomputed span ignores both. The Q-0105 "keep an eye on it" note stands for the *rest* of the actuator,
+  but its one mis-writing failure mode is now closed at the root with a regression test.
 
 ## BUG-0019 — AI replies to messages aimed at *other* bots and claims "you've just pinged me" — PARTIALLY FIXED (mechanism #2 hardened; #1 awaits one owner behavior decision)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@
 # .pre-commit-config.yaml in the same change.
 black==26.5.1
 isort==8.0.1
-ruff==0.15.18
+ruff==0.15.14  # MUST match code-quality.yml + .pre-commit-config.yaml (Dependabot bumped this alone → drift; see below)
 mypy==2.1.0
 pytest==9.1.0
 pytest-asyncio==1.4.0

--- a/scripts/export_dashboard_data.py
+++ b/scripts/export_dashboard_data.py
@@ -55,6 +55,11 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 OUTPUT_FILE = REPO_ROOT / "dashboard" / "data" / "dashboard.json"
 SITE_OUTPUT_FILE = REPO_ROOT / "botsite" / "data" / "site.json"
+# The SPA data layer regenerated alongside site.json. Exposed as a CLI arg
+# (``--data-js-output``) so a test driving ``main()`` with tmp paths cannot clobber
+# the tracked repo file (BUG-0022): the live-HEAD build sha would desync it from the
+# committed site.json and redden botsite-tests for an unrelated `git add -A`.
+DATA_JS_OUTPUT_FILE = REPO_ROOT / "botsite" / "site" / "data.js"
 
 # The ONLY top-level keys the public ``site.json`` subset is allowed to carry
 # (plan §5 / §2.2). This is the redaction guarantee for the marketing bot site:
@@ -1132,6 +1137,12 @@ def main(argv: list[str] | None = None) -> int:
         help="site.json (public subset) output path",
     )
     parser.add_argument(
+        "--data-js-output",
+        default=str(DATA_JS_OUTPUT_FILE),
+        help="botsite/site/data.js (SPA data layer) output path; redirect in tests "
+        "so they never clobber the tracked repo file",
+    )
+    parser.add_argument(
         "--check",
         action="store_true",
         help="print the meta summary without writing any file",
@@ -1163,10 +1174,10 @@ def main(argv: list[str] | None = None) -> int:
         site_data = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(site_data)
 
-        data_js = REPO_ROOT / "botsite" / "site" / "data.js"
+        data_js = Path(args.data_js_output)
         data_js.parent.mkdir(parents=True, exist_ok=True)
         data_js.write_text(site_data.render_from_site(subset), encoding="utf-8")
-        print(f"wrote {data_js.relative_to(REPO_ROOT)} (SPA data layer)")
+        print(f"wrote {data_js} (SPA data layer)")
     return 0
 
 

--- a/scripts/trim_recently_shipped.py
+++ b/scripts/trim_recently_shipped.py
@@ -17,7 +17,9 @@ This is the **actuator** complement to that **detector**: given the two files, i
    **oldest (bottom) N** bullets *verbatim* from ``current-state.md`` into the archive's
    ``## Recently shipped — archived`` section (prepended — they are newest in the archive now);
 2. recomputes the **"Older merges (#HIGH … #LOW)"** floor pointer from the **actual** PR-number
-   span of the whole archive after the move, so the pointer can't drift from reality;
+   span of the archive's **bullet headers** after the move, so the pointer can't drift from
+   reality (BUG-0020: it reads only each bullet's leading ``#A · #B …`` cluster, never a stray
+   ``#N`` in prose);
 3. runs **idempotently** and prints a unified-diff dry-run first (``--check``), so a pass previews
    the move before committing it (``--apply``).
 
@@ -119,9 +121,36 @@ def live_entry_count(cs_text: str) -> int:
     )
 
 
+def _archive_span_numbers(archive_text: str) -> set[int]:
+    """PR numbers from archived **bullet headers only** — never free-floating ``#N`` in prose.
+
+    The floor pointer ``(#HIGH … #LOW)`` must reflect the highest/lowest archived *PR bullet*,
+    not a stray reference elsewhere in the archive prose (BUG-0020): the original recompute
+    scanned the whole archive and so picked up a ``band-#1170`` parenthetical note and ``#1``
+    rank notation, writing a wrong span.
+
+    For each bullet header line (``- **#…``) we read only its **leading PR-reference cluster**
+    — the ``#A · #B …`` run before the first ``" ("`` (the date/context paren) or ``"**"`` (the
+    bold close). A grouped non-monotonic band bullet (``#690 · #721``) still contributes its
+    newest member; a ``#1`` rank token or a ``band-#1170`` note in prose does not.
+    """
+    nums: set[int] = set()
+    for ln in archive_text.splitlines():
+        if not _PR_BULLET_RE.match(ln):
+            continue
+        cluster = ln[len("- **") :]  # strip the bullet prefix; now starts at "#…"
+        cut = len(cluster)
+        for marker in (" (", "**"):
+            idx = cluster.find(marker)
+            if idx != -1:
+                cut = min(cut, idx)
+        nums.update(_pr_numbers(cluster[:cut]))
+    return nums
+
+
 def _rewrite_floor(lines: list[str], archive_text: str) -> None:
     """Rewrite the floor pointer's ``(#HIGH … #LOW)`` from the archive's true PR span (in place)."""
-    nums = _pr_numbers(archive_text)
+    nums = _archive_span_numbers(archive_text)
     if not nums:
         return
     span = f"(#{max(nums)} … #{min(nums)})"

--- a/tests/unit/scripts/test_export_dashboard_data.py
+++ b/tests/unit/scripts/test_export_dashboard_data.py
@@ -495,6 +495,7 @@ def test_committed_site_json_matches_a_fresh_build(mod):
 def test_cli_targets_site_writes_only_site_json(mod, tmp_path):
     dash = tmp_path / "dashboard.json"
     site = tmp_path / "site.json"
+    data_js = tmp_path / "data.js"
     rc = mod.main(
         [
             "--targets",
@@ -503,20 +504,49 @@ def test_cli_targets_site_writes_only_site_json(mod, tmp_path):
             str(dash),
             "--site-output",
             str(site),
+            "--data-js-output",
+            str(data_js),
         ],
     )
     assert rc == 0
     assert site.exists()
+    assert data_js.exists()  # the SPA layer is written alongside, to the redirected path
     assert not dash.exists()  # --targets site must not write the dashboard payload
 
 
 def test_cli_targets_both_writes_both(mod, tmp_path):
     dash = tmp_path / "dashboard.json"
     site = tmp_path / "site.json"
-    rc = mod.main(["--output", str(dash), "--site-output", str(site)])
+    data_js = tmp_path / "data.js"
+    rc = mod.main(
+        ["--output", str(dash), "--site-output", str(site), "--data-js-output", str(data_js)],
+    )
     assert rc == 0
     assert dash.exists() and site.exists()
     import json
 
     site_data = json.loads(site.read_text(encoding="utf-8"))
     assert set(site_data) == set(mod.SITE_TOPLEVEL_KEYS)
+
+
+def test_cli_does_not_clobber_tracked_data_js_when_redirected(mod, tmp_path):
+    """BUG-0022 guard: driving ``main()`` with redirected outputs must NOT touch the
+    real tracked ``botsite/site/data.js`` — the live-HEAD build sha would desync it
+    from the committed site.json and redden botsite-tests for an unrelated commit."""
+    tracked = mod.DATA_JS_OUTPUT_FILE
+    before = tracked.read_text(encoding="utf-8") if tracked.exists() else None
+    rc = mod.main(
+        [
+            "--targets",
+            "site",
+            "--output",
+            str(tmp_path / "dashboard.json"),
+            "--site-output",
+            str(tmp_path / "site.json"),
+            "--data-js-output",
+            str(tmp_path / "data.js"),
+        ],
+    )
+    assert rc == 0
+    after = tracked.read_text(encoding="utf-8") if tracked.exists() else None
+    assert after == before, "main() with redirected outputs must not rewrite the tracked data.js"

--- a/tests/unit/scripts/test_trim_recently_shipped.py
+++ b/tests/unit/scripts/test_trim_recently_shipped.py
@@ -148,6 +148,27 @@ def test_non_monotonic_band_bullet_floor_uses_max_number(tr):
     assert "(#721 … #535)" in new_cs
 
 
+def test_floor_pointer_ignores_stray_pr_refs_in_prose(tr):
+    # BUG-0020: the recompute must read only the *bullet headers'* leading PR cluster, never a
+    # free-floating "#N" in prose — a high "band-#9999" parenthetical note or a low "#1" rank
+    # token in a continuation line must NOT widen the span beyond the real bullets (#700 … #535).
+    cs = _cs(
+        "- **#702 (a)** d",
+        "- **#701 (b)** d",
+        "- **#700 (c)** d",
+        floor="(#600 … #535)",
+    )
+    arch = _archive(
+        "- **#599 (z)** d",
+        "  trimmed from band-#9999 — a stray high ref in a note, ranked #1 overall",
+        "- **#535 (y)** oldest",
+    )
+    new_cs, _, _ = tr.trim(cs, arch, budget=2)
+    # The moved #700 makes the true archive span #700 … #535; the prose #9999 / #1 are ignored.
+    assert "(#700 … #535)" in new_cs
+    assert "#9999" not in new_cs and "(#9999" not in new_cs
+
+
 # --- idempotence --------------------------------------------------------------------------
 
 

--- a/tests/unit/services/test_runtime.py
+++ b/tests/unit/services/test_runtime.py
@@ -128,7 +128,13 @@ async def test_acquire_lock_or_exit_polls_until_peer_releases():
 @pytest.mark.asyncio
 async def test_acquire_lock_or_exit_exits_zero_after_wait_timeout():
     """LP-4: a peer that never releases causes the loop to give up
-    after ``boot_wait_seconds`` and exit with code 0 (idle, not crash)."""
+    after ``boot_wait_seconds`` and exit with code 0 (idle, not crash).
+
+    The clock is faked (not real ``time.monotonic``) so the deadline crosses
+    deterministically after exactly two attempts, independent of host load /
+    parallel-xdist scheduling — see bug-book BUG-0021. The fake only advances
+    when the (mocked) sleep runs, and one sleep jumps it well past the budget.
+    """
     fake_result = rl_db.AcquireResult(
         acquired=False,
         holder_boot_id=uuid.uuid4(),
@@ -136,23 +142,29 @@ async def test_acquire_lock_or_exit_exits_zero_after_wait_timeout():
         reason="row_fresh",
     )
     try_acquire = AsyncMock(return_value=fake_result)
-    sleep_mock = AsyncMock()
+
+    clock = {"now": 0.0}
+
+    def fake_monotonic() -> float:
+        return clock["now"]
+
+    async def fake_sleep(_seconds: float) -> None:
+        clock["now"] += 1.0  # one poll interval jumps past the 0.05s budget
 
     with (
         patch.object(rl_db, "try_acquire", try_acquire),
-        patch("services.runtime.asyncio.sleep", sleep_mock),
+        patch.object(runtime.time, "monotonic", fake_monotonic),
+        patch("services.runtime.asyncio.sleep", fake_sleep),
     ):
         with pytest.raises(SystemExit) as exc_info:
-            # Use a tiny budget so the test finishes quickly without
-            # mocking ``time.monotonic``.
             await runtime.acquire_lock_or_exit(
                 boot_wait_seconds=0.05,
                 boot_poll_seconds=0.01,
             )
         assert exc_info.value.code == 0
-    # At least two attempts: one immediate + one after a sleep before
-    # the deadline elapses.
-    assert try_acquire.await_count >= 2
+    # Exactly two attempts: one immediate + one after the single sleep that
+    # crosses the deadline (deterministic — no dependency on real elapsed time).
+    assert try_acquire.await_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A bugs-first dispatch run. Started on the one OPEN tooling bug (BUG-0020); shipping it surfaced two
more CI-reliability bugs, each root-caused with a stays-fixed guard in this PR. **No `disbot/` runtime
code changed** — all test/tooling/docs.

## BUG-0020 — trim floor pointer reads stray `#N` from archive prose (root)
`scripts/trim_recently_shipped.py` scanned the **whole** archive for `#N` and took min/max over all
matches, so prose refs (a `band-#1170` note, `#1` rank notation) corrupted the
`Older merges (#HIGH … #LOW)` span (it wrote `#1170 … #1` for a true `#1129 … #535`). New
`_archive_span_numbers()` reads only archived **bullet headers'** leading `#A · #B …` cluster — grouped
non-monotonic bands still contribute their newest member, prose `#N` no longer counts. Guard:
`test_floor_pointer_ignores_stray_pr_refs_in_prose`.

## BUG-0021 — flaky `acquire_lock_or_exit` wait-timeout test (root)
The test drove the lock loop against the **real** `time.monotonic` (0.05 s budget, sleep mocked
instant) and asserted `await_count >= 2` — under parallel-xdist CPU starvation the budget could elapse
after one attempt → intermittent red. Now the clock is faked (advances only when the mocked sleep
runs; one sleep crosses the budget), so the loop gives up on exactly attempt 2 (`== 2`). No runtime
code changed.

## BUG-0022 — full suite rewrites the tracked `botsite/site/data.js` (root)
`scripts/export_dashboard_data.py main()` wrote the SPA data layer to a **hardcoded** real path,
ignoring its output args, stamped with the live `git rev-parse --short HEAD`. The CLI tests drive
`main()` with `tmp_path` for dashboard/site.json but data.js still hit the **tracked** file → every
full-suite run rewrote it with the session sha → a later `git add -A` desynced it from the committed
`site.json` → red `botsite-tests`/`code-quality` (this is exactly what reddened this PR's first push).
Fix: add `--data-js-output` (default = real path, so the reconciliation routine's regen is unchanged),
redirect it in the two CLI tests, add `test_cli_does_not_clobber_tracked_data_js_when_redirected`.

## Also
- `requirements-dev.txt`: ruff `0.15.18` → `0.15.14` — realign the drift from a Dependabot dev-deps
  bump that moved only this file (CI + pre-commit stayed `0.15.14`), restoring the three-place pin
  invariant CLAUDE.md requires.

Self-merge on green (Q-0113).

🤖 Generated with [Claude Code](https://claude.com/claude-code)