### PR TITLE
docs(plan): reaction-roles Carl-bot parity + role-menu overhaul plan

### DIFF
--- a/.sessions/2026-06-21-carl-bot-reaction-roles-research-plan.md
+++ b/.sessions/2026-06-21-carl-bot-reaction-roles-research-plan.md
@@ -1,0 +1,17 @@
+# 2026-06-21 — Carl-bot reaction-roles research + overhaul plan
+
+> **Status:** `in-progress` — researching Carl-bot's reaction-role mechanics + the broader
+> feature gap vs. SuperBot, then writing a build-ready overhaul/parity plan. Docs-only PR.
+> Flips to `complete` as the final step (Q-0133 born-red gate).
+
+## Arc
+
+Owner asked: *"Find out how Carl-bot does its reaction roles, as well as any other functions
+we're missing, then create a plan on how we should implement this and possibly improve on it."*
+
+This is a research + planning deliverable (no runtime code this PR). Producing:
+1. A build-ready plan doc — `docs/planning/reaction-roles-overhaul-plan-2026-06-21.md`.
+2. A broader Carl-bot feature-gap matrix that cross-references the **existing** idea captures
+   (starboard, custom commands, suggestion box, feeds) rather than duplicating them.
+
+(Body filled in at session close.)

--- a/.sessions/2026-06-21-carl-bot-reaction-roles-research-plan.md
+++ b/.sessions/2026-06-21-carl-bot-reaction-roles-research-plan.md
@@ -1,17 +1,110 @@
 # 2026-06-21 — Carl-bot reaction-roles research + overhaul plan
 
-> **Status:** `in-progress` — researching Carl-bot's reaction-role mechanics + the broader
-> feature gap vs. SuperBot, then writing a build-ready overhaul/parity plan. Docs-only PR.
-> Flips to `complete` as the final step (Q-0133 born-red gate).
+> **Status:** `complete` — docs-only research + planning deliverable. Carl-bot reaction-role
+> mechanics + broader feature gap researched; a build-ready 3-PR overhaul/parity plan written.
+> No runtime code. Self-merge on green (Q-0113 — docs-only, additive).
+
+> **Run type:** `manual`
 
 ## Arc
 
 Owner asked: *"Find out how Carl-bot does its reaction roles, as well as any other functions
 we're missing, then create a plan on how we should implement this and possibly improve on it."*
 
-This is a research + planning deliverable (no runtime code this PR). Producing:
-1. A build-ready plan doc — `docs/planning/reaction-roles-overhaul-plan-2026-06-21.md`.
-2. A broader Carl-bot feature-gap matrix that cross-references the **existing** idea captures
-   (starboard, custom commands, suggestion box, feeds) rather than duplicating them.
+Research + planning task (deliverable is a plan, not an implementation). Researched Carl-bot from
+its official docs + the `carlbot-docs` source; mapped our current role subsystem from source (via
+an Explore agent + direct reads); dedup-checked the backlog; wrote the plan; cross-referenced the
+broader gaps to their existing idea captures.
 
-(Body filled in at session close.)
+## What shipped (docs only)
+
+- `docs/planning/reaction-roles-overhaul-plan-2026-06-21.md` — the plan: Carl-bot mechanics, our
+  code-grounded current state, the 3-PR arc (audited seam → button/dropdown role menus → modes +
+  interactive panel), how we beat Carl, the full Carl feature-gap matrix, and 3 owner design Qs.
+- `docs/ideas/channel-deployed-component-menu-primitive-2026-06-21.md` — the Q-0089 session idea
+  (a shared deploy-a-persistent-component-message primitive that role menus / starboard / polls share).
+- Index/homing wiring: `docs/planning/README.md` (S1 row), `docs/subsystems/server-management.md`
+  (Plans pointer), `docs/ideas/README.md` (idea entry).
+
+## Findings (the research, condensed)
+
+- **Carl-bot reaction roles are emoji-reaction-first.** Modes `normal/unique/verify/drop/reversed/
+  binding/temp`; per-message `limit` + `maxroles` + role black/whitelist; multi-message `link`;
+  20 RR/message, ~250 total; `temp` (timed) is **Patreon-only**. Buttons/dropdowns are a secondary
+  surface — its core is reactions, which is precisely the weakness to improve on.
+- **We already have basic emoji reaction-roles** (`reaction_roles` table, raw listeners, 3 prefix
+  commands, read-only panel) — but they're the project's clearest documented architectural debt:
+  **direct DB writes (no audit seam)**, no modes/limits, read-only management UI. This is already
+  flagged in `general-feature-layer-analysis` + `ui-view-adoption-audit`, and "self-role menu" is
+  already on the command-expansion backlog. The plan **consolidates** that, it doesn't invent.
+- **Most broader Carl gaps are already captured as ideas** — starboard (`fun-and-ease` §B1), custom
+  commands (`community-platform-features` §4, Someday), suggestion box (`superbot-vision` AG-15),
+  feeds (roadmap Later). Cross-referenced, not duplicated.
+- **Automod already exists** (`automod_cog`: spam/invites/caps/mentions) — so content-moderation is
+  *not* a Carl gap (only word/link/attachment-spam sub-filters are missing). Avoided mis-listing it.
+
+## Decisions made alone (ratify if wrong)
+
+- **Deliver a plan, not an implementation.** The ask said "create a plan"; role menus are a
+  UX-heavy feature the owner-designer will want to visualize, so plan-first (not "smallest safe
+  slice", but the right altitude). PR 1 (audited seam) is pure debt-paydown and safe to build
+  immediately whenever greenlit.
+- **Lead with native buttons/dropdowns** as the headline (vs. extending the emoji surface) — the
+  modern component model is strictly nicer than Carl's reaction legacy.
+- **New `role_menus`/`role_menu_options` tables** (migration 078) rather than overloading
+  `reaction_roles` — keeps the emoji surface untouched in PR 1.
+
+## ⟲ Previous-session review (Q-0102)
+
+Reviewed `2026-06-21-creature-game-catch-collection.md` (#1208 — creature catch+collection v1).
+**Did well:** textbook discipline — mirrored the fishing subsystem exactly (pure domain → audited
+workflow → CRUD → hub-less cog), one-transaction write with emit-after-commit (Q-0071), fail-safe
+catalog load, known-catalog allow-list on the leaderboard (carrying the fishing reconciliation
+lesson forward). A clean, low-risk additive slice.
+**Could improve / system observation:** creatures shipped **hub-less "exactly like fishing"** — but
+the federated **Explore-hub** plan is now active, so that's *two* subsystems (fishing + creatures)
+the hub will later have to retrofit. **Workflow improvement:** when a known-incoming plan (Explore
+hub) will absorb a new subsystem, let the subsystem **declare its future world-hub membership at
+creation** (a `subsystem_registry` field / folio note) instead of being retrofitted later — cheap
+now, avoids a "wire N hub-less cogs into the hub" sweep when the hub lands. (Captured here; promote
+to an idea file if a third hub-less game subsystem ships before the Explore hub does.)
+
+## Context delta (self-improvement loop)
+
+- **Needed but not pointed to:** the *current* reaction-role architecture debt (direct DB writes,
+  read-only panel) is the crux of this task but lives only in two dated audit docs
+  (`general-feature-layer-analysis`, `ui-view-adoption-audit`) — not surfaced from the role folio or
+  current-state. A reader planning role work wouldn't be routed to it. → the server-management folio
+  now links the overhaul plan, which names the debt; a folio "known debt" line would help more.
+- **Pointed to but didn't need:** the large `current-state.md` ▶ Next callout (40K tokens) — none of
+  it touched roles; the task-specific reads (folio + role source) carried the work. Confirms the
+  "load context in layers, don't read the whole tree" guidance.
+- **Discovered by hand:** that **automod already exists** (`automod_cog`) — the repo-navigation cheat
+  sheet doesn't list an `automod` row (it predates the Q-0108 automod cog), so a quick grep was the
+  only way to avoid mis-listing it as a Carl gap. → nav-map subsystem cheat sheet is mildly stale
+  (missing automod / image_moderation / security / creature / fishing rows vs. the live cog glob).
+- **Decisions made alone:** see above (deliver-a-plan; buttons-first; new tables).
+- **Genuine weak point:** the plan's migration/table shape (§4 PR 1) is a *recommendation* designed
+  from the schema, not yet validated against the persistent-view runtime — the building session
+  should confirm the `role_menus.message_id`-nullable-until-posted flow against
+  `core/runtime/persistent_views.py` before locking the schema.
+
+## 📤 Run report
+
+- **Did:** researched Carl-bot reaction roles + the broader feature gap and wrote a build-ready 3-PR overhaul/parity plan · **Outcome:** shipped (plan)
+- **Shipped:** #1215 — reaction-roles Carl-bot parity + role-menu overhaul plan (docs-only)
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** 3 design calls in the plan §9 — default surface (dropdown vs button), whether to audit per-member toggles, and whether to build free temp-roles. None block PR 1.
+- **⚑ Owner manual steps:** none
+- **⚑ Self-initiated:** the Q-0089 idea [`channel-deployed-component-menu-primitive`](../docs/ideas/channel-deployed-component-menu-primitive-2026-06-21.md) (capture only, not built); the *plan itself* was the directly-requested deliverable, not self-initiated
+- **↪ Next:** greenlight reaction-roles **PR 1** (audited `reaction_role_service` + migration 078) — pure debt-paydown, safe to build immediately; or answer the §9 design Qs to unblock PRs 2–3
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 0 at write (1 pending auto-merge: #1215) |
+| CI-red rounds | 0 |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (Q-0089: channel-deployed component-menu primitive) |
+| Ideas groomed | 0 (research/plan session — routed 4 existing captures into the plan matrix) |

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,14 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`channel-deployed-component-menu-primitive-2026-06-21.md`](./channel-deployed-component-menu-primitive-2026-06-21.md) —
+  **session idea (2026-06-21, Q-0089, from the Carl-bot reaction-roles overhaul plan):** a shared
+  primitive for an operator-deployed, DB-persisted `PersistentView` message in a guild channel
+  (post → store `message_id` → re-attach on boot → guild-teardown). Three captured features share the
+  shape — role menus (the overhaul plan PR 2), starboard (`fun-and-ease` §B1), polls/suggestions
+  (`superbot-vision` AG-15) — so extract it at consumer #1 (role menus) and starboard reuses it free.
+  → relates `core/runtime/persistent_views.py` · `core/runtime/message_anchor_manager.py` ·
+  `planning/reaction-roles-overhaul-plan-2026-06-21.md`.
 - [`permission-overlap-guard-2026-06-21.md`](./permission-overlap-guard-2026-06-21.md) —
   **agent-observed, SHIPPED (2026-06-21, self-initiated Q-0172):** a stdlib config-lint
   (`scripts/check_permission_overlap.py`) that flags an `allow` rule shadowed by a broader

--- a/docs/ideas/channel-deployed-component-menu-primitive-2026-06-21.md
+++ b/docs/ideas/channel-deployed-component-menu-primitive-2026-06-21.md
@@ -1,0 +1,38 @@
+# Channel-deployed component-menu primitive (role menus · starboard · polls)
+
+> **Status:** `ideas` — capture only, not a plan, not approval. Source + binding contracts win.
+> **Subsystem:** role
+>
+> **Session idea (2026-06-21, Q-0089, from the Carl-bot reaction-roles overhaul plan).**
+
+## The pattern
+
+The reaction-roles overhaul plan ([`planning/reaction-roles-overhaul-plan-2026-06-21.md`](../planning/reaction-roles-overhaul-plan-2026-06-21.md))
+needs a `PersistentView` an operator **deploys to an arbitrary channel**: build it in a panel →
+post the message → store its `message_id` → re-attach on restart → toggle state server-side. That
+exact shape recurs in at least three captured features:
+
+- **Role menus** (this plan, PR 2).
+- **Starboard** ([`fun-and-ease-brainstorm-2026-06-09.md`](./fun-and-ease-brainstorm-2026-06-09.md) §B1) — a posted, persisted highlight message that accrues reactions.
+- **Polls / suggestion board** ([`superbot-vision-2026-06-10.md`](./superbot-vision-2026-06-10.md) AG-15) — a posted message with vote components.
+
+Today each would hand-roll "post a message, remember its id, re-bind the view on boot." We already
+have the *pieces* — `core/runtime/persistent_views.py` and `core/runtime/message_anchor_manager.py`
+— but no single seam for **"an operator-deployed, DB-persisted component message in a guild channel."**
+
+## The idea
+
+A small shared primitive (`views/` or `core/runtime/`) — provisionally `deploy_component_message(...)`
++ a `deployed_messages(guild_id, channel_id, message_id, kind, ref_id)` registry — that owns the
+post → persist `message_id` → re-attach-on-boot lifecycle, so role-menu / starboard / poll features
+are each ~"define the view + the toggle handler," not "re-implement message persistence." Build it
+**as part of** reaction-roles PR 2 (first real consumer), then starboard reuses it for free — the
+classic "extract the second time you'd copy it" rule, but the second consumer is already on the
+backlog so the extraction is justified at consumer #1.
+
+**Why it's worth having:** it turns "modernize emoji reactions → components" from a per-feature
+rewrite into a one-time platform capability, and gives every deployed message restart-durability +
+guild-teardown for free (the INV-I hook lives in one place, not three).
+
+→ relates `core/runtime/persistent_views.py` · `core/runtime/message_anchor_manager.py` ·
+`planning/reaction-roles-overhaul-plan-2026-06-21.md` · `ideas/fun-and-ease-brainstorm-2026-06-09.md` §B1.

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -40,6 +40,7 @@ sectors ([`repo-sector-map.md`](../repo-sector-map.md)); the live `Now/Next/Late
 | [settings-pointer-lane-convergence](settings-pointer-lane-convergence-plan-2026-06-13.md) | P0-3; families 1+2 done, **pointer retirement gated** | [settings](../subsystems/settings-bindings-provisioning.md) |
 | [ai-panel-inplace-navigation](ai-panel-inplace-navigation-plan-2026-06-19.md) | 2–3 PRs; **`needs-hermes-review` + wants a live guild walk**; blocks graduating the consistency linter's `edit_in_place` rule | [ai](../subsystems/ai.md) · `ai-panel-inplace-navigation` |
 | [safety-community-family](safety-community-family-plan-2026-06-13.md) | lane entry doc; automod/logging/welcome **shipped** + image-mod #941 + security tiers 1+2 #929 **shipped 2026-06-18**; remainder = **NL event scheduler** (plan-first, Q-0112) | roadmap safety lane · `server-safety-and-automod`, `community-platform-features` |
+| [reaction-roles-overhaul](reaction-roles-overhaul-plan-2026-06-21.md) | **▶ buildable** — Carl-bot parity + modern button/dropdown role menus + audited mutation seam; PR 1 (audited seam + schema) is pure debt-paydown, PRs 2–3 = role menus + modes; 3 open design Qs for the owner | [server-management](../subsystems/server-management.md) · `fun-and-ease-brainstorm` §B1, `community-platform-features` §4 |
 
 ### S2 — BTD6
 

--- a/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
+++ b/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
@@ -1,0 +1,304 @@
+# Reaction Roles — Carl-bot parity + modern role-menu overhaul
+
+> **Status:** `plan` — buildable spec (2026-06-21). Cross-check source before implementing;
+> `docs/current-state.md` owns what is live. **Sector:** S1 — Bot product. **Folio:**
+> [`docs/subsystems/server-management.md`](../subsystems/server-management.md).
+>
+> **One-line goal:** bring SuperBot's self-assignable-role surface to **parity-plus** with
+> Carl-bot — lead with native **buttons + dropdown menus** (Carl's are a secondary/premium
+> add; emoji reactions are its core), keep emoji reaction-roles working for compatibility,
+> layer Carl's modes (unique / verify / limit) on top, and route every assignment through an
+> **audited mutation seam** — closing the documented architectural debt along the way.
+
+---
+
+## 1. Why this plan exists
+
+Three things converged:
+
+1. **Owner ask** — research how Carl-bot does reaction roles + what we're missing, then plan
+   how to implement and improve on it.
+2. **SuperBot already has a basic reaction-role feature** but it is the project's clearest
+   piece of **documented architectural debt**: it writes to the DB directly (no audit), has no
+   modes/limits, and its management panel is read-only. See
+   [`audits/general-feature-layer-analysis-2026-06-05.md`](../audits/general-feature-layer-analysis-2026-06-05.md)
+   ("reaction-role CRUD … use direct DB/Discord mutation paths") and
+   [`audits/ui-view-adoption-audit.md`](../audits/ui-view-adoption-audit.md) (the
+   `ReactionRolesPanel` is hand-rolled, P1).
+3. **"Self-role menu / reaction-role setup" is already on the backlog**
+   ([`building-roadmap/command-expansion-backlog.md`](../building-roadmap/command-expansion-backlog.md)
+   §"Self-role menu; Reaction-role setup") and the
+   [`server-management-status`](server-management-status-2026-06-05.md) remaining queue
+   ("reaction roles / automation add_roles/remove_roles; role reorder; templates"). This plan
+   **consolidates** that scattered backlog into one coherent, buildable arc — it is not
+   net-new invention.
+
+So this is a **fix-debt + ship-headline-feature** plan, not a greenfield one.
+
+---
+
+## 2. How Carl-bot does reaction roles (researched 2026-06-21)
+
+Sources: [official docs](https://docs.carl.gg/) and the
+[`carlbot-docs` source](https://github.com/CarlGroth/carlbot-docs/blob/master/roles/reaction-roles.md).
+
+**Core model.** Members self-assign roles by reacting with an emoji on a bot-tracked message.
+Carl is fundamentally **emoji-reaction based**; button/dropdown menus are a newer/secondary
+surface, and timed roles are a Patreon perk.
+
+**Setup methods** (three): post a new embed; turn an existing message into a reaction-role
+message by ID; or use the most recent message in a channel. Plus all-in-one one-shot commands
+(`rr aio`, `aiou`, `aiov`, `aioi`) and a standalone `embed` builder.
+
+**Modes** (applied per message via `rr <mode> <msg_id>`):
+
+| Mode | Behaviour |
+|---|---|
+| `normal` | React = add role, un-react = remove role (the default). |
+| `unique` | Only one role per message; reacting auto-removes the member's previous pick. |
+| `verify` | React **only adds** (never removes); the bot removes the reaction afterward. |
+| `drop` | Inverse of verify — reacting **only removes** a role. |
+| `reversed` | Reacting removes the role; un-reacting adds it. |
+| `binding` | `verify` + `unique` — a single lifetime choice across linked messages. |
+| `temp <time>` | Role auto-removed after a duration (**Patreon-only**). |
+
+**Message controls:** `rr lock` (freeze distribution), `rr selfdestruct <time>` (auto-delete
+message + roles after a period).
+
+**Access restrictions:** `rr limit <n>` (cap how many roles a member can claim from a message),
+`rr maxroles <role> <n>` (cap total members holding a role), role **blacklist/whitelist**
+(`rr bl` / `rr wl` and their clears).
+
+**Multi-message linking:** `rr link` makes "one role across all linked messages" work — Carl's
+workaround for its **20-reaction-roles-per-message** Discord limit (their total cap is **250**).
+
+**Management commands:** `rr setup/make`, `list/show`, `edit`, `add`, `addmany`, `remove`,
+`move` (transfer roles between messages, including purged ones), `clear`, `colour`.
+
+**Key limits to remember:** 20 reaction-roles per message (Discord's reaction cap), ~250 total.
+`reversed`/`verify` exist precisely because **emoji reactions are clumsy** — stale reactions
+linger, "remove your reaction to lose the role" is unintuitive, and adding a reaction needs the
+emoji to be addable. **This is the weakness we improve on.**
+
+---
+
+## 3. What SuperBot has today (code-grounded)
+
+Full inventory: the role subsystem is mature. Reaction roles specifically:
+
+- **Schema:** `reaction_roles (guild_id, message_id, emoji, role_id)`, PK
+  `(guild_id, message_id, emoji)` — bootstrap table in
+  `disbot/utils/db/migrations.py:284`. CRUD in `disbot/utils/db/roles.py:201-240`.
+- **Assignment:** raw listeners `on_raw_reaction_add` / `on_raw_reaction_remove` in
+  `disbot/cogs/role_cog.py:546-594` → `member.add_roles` / `remove_roles`. **Emoji-only.**
+- **Commands** (`role_cog.py:596-661`): `!reactroles <msg_id> <emoji> <@role>`,
+  `!removereactrole <msg_id> <emoji>`, `!listreactroles`.
+- **Panel:** `disbot/views/roles/reaction_panel.py` — **read-only** display + a refresh button;
+  configuration is command-only.
+
+**Adjacent role features already shipped** (do **not** rebuild these): time/tenure roles + XP
+roles (`services/role_automation.py`, audited), per-role automation exemptions
+(`services/role_exemption_service.py`, audited), role lifecycle create/edit/delete
+(`services/role_lifecycle_service.py`, audited), diagnostics, and the entry/join role
+(`welcome_service`). The role hub (`!roles`) already routes Create / Manage / Time / XP /
+Reaction / Diagnostics panels.
+
+### The three gaps vs. our own standards
+
+1. **No audited seam.** Time/XP/exemption/lifecycle role writes all emit
+   `audit.action_recorded`; reaction-role writes go straight to `utils/db/roles.py` from the
+   cog. This violates the mutation contract (`docs/runtime_contracts.md` §9) and is the
+   long-standing audit finding above.
+2. **No interactive UI.** The panel can't add/edit/remove — operators must hand-type a message
+   ID + emoji into a prefix command.
+3. **Emoji-only, no menus, no modes, no limits** — the entire Carl feature surface (buttons,
+   dropdowns, unique/verify, per-message limits) is absent.
+
+---
+
+## 4. The plan — three PRs (foundation → headline → parity)
+
+Per repo rule, a plan spans 2–3 PRs: **PR 1 fixes root causes/foundation; PR 2–3 build on top.**
+PR 1 is a safe internal refactor (no UX change); the user-visible feature lands in PR 2.
+
+### PR 1 — Audited seam + data model (foundation, low-risk)
+
+**Goal:** route every reaction-role mutation through an audited service, and extend the data
+model to support menus/modes — with **zero behaviour change** for existing emoji reaction-roles.
+
+- **New `disbot/services/reaction_role_service.py`** — the audited writer, mirroring
+  `role_exemption_service.py`: thin methods (`bind_emoji`, `unbind_emoji`, `assign`, `unassign`,
+  list/read helpers) that wrap the existing `utils/db/roles.py` CRUD and emit
+  `services.audit_events.emit_audit_action()` for operator config changes (binding add/remove)
+  and, optionally, for member assignment (behind a flag — assignment volume may be high).
+- **Route the cog through it.** The `role_cog.py` listeners + the three commands call the
+  service instead of `db.*` directly. This **closes the audit-seam finding** and the
+  `general-feature-layer-analysis` items.
+- **Migration `078_reaction_role_menus.sql`** (next free number is 078; highest today is 077).
+  Add the menu/mode data model. Recommended shape — a new pair of tables so menus and raw-emoji
+  bindings coexist cleanly, rather than overloading `reaction_roles`:
+  ```sql
+  CREATE TABLE IF NOT EXISTS role_menus (
+      menu_id     BIGSERIAL PRIMARY KEY,
+      guild_id    BIGINT NOT NULL,
+      channel_id  BIGINT NOT NULL,
+      message_id  BIGINT,                       -- set once the menu message is posted
+      title       TEXT   NOT NULL DEFAULT 'Pick your roles',
+      description TEXT,
+      style       TEXT   NOT NULL DEFAULT 'button',  -- 'button' | 'dropdown' | 'reaction'
+      mode        TEXT   NOT NULL DEFAULT 'normal',  -- 'normal' | 'unique' | 'verify'
+      max_roles   INT    NOT NULL DEFAULT 0,         -- 0 = unlimited (Carl's `rr limit`)
+      created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+  );
+  CREATE TABLE IF NOT EXISTS role_menu_options (
+      menu_id  BIGINT NOT NULL REFERENCES role_menus(menu_id) ON DELETE CASCADE,
+      role_id  BIGINT NOT NULL,
+      emoji    TEXT,                              -- optional button/option emoji
+      label    TEXT,                              -- optional override label
+      position INT NOT NULL DEFAULT 0,
+      PRIMARY KEY (menu_id, role_id)
+  );
+  ```
+  The legacy `reaction_roles` table stays as-is (emoji surface = `style='reaction'` conceptually;
+  no data migration needed in PR 1).
+- **DB module** `disbot/utils/db/roles.py` (or a new `utils/db/role_menus.py` if `roles.py` is
+  getting large) — typed CRUD for the two tables.
+- **`disbot/guild_lifecycle.py`** — register `delete_for_guild` teardown for `role_menus`
+  (cascade handles `role_menu_options`). Required for any new guild-keyed table
+  (`docs/architecture.md` INV-I).
+- **Tests:** service-level audit-emission test (mirror `test_role_exemption_service.py`); DB
+  round-trip; a guild-teardown test asserting the new table is purged.
+
+**Risk:** low. Internal refactor + additive schema; existing reaction-roles behave identically.
+
+### PR 2 — Interactive role menus (the headline improvement)
+
+**Goal:** the modern, native surface Carl lacks at its core — a button/dropdown role menu an
+operator builds in-panel and deploys to a channel, re-attached on restart.
+
+- **`disbot/views/roles/role_menu_view.py`** — a `RoleMenuView(PersistentView)` that renders
+  either buttons (one per role, ≤25) or a `discord.ui.Select` (multi-select up to `max_roles`).
+  Click/select **toggles** the role with an **ephemeral confirmation** ("✅ Added **Gamer**").
+  Mode enforcement is **server-side**: `unique` clears the member's other menu roles; `max_roles`
+  caps selections — no stale reactions, no "un-react to remove" confusion. Follows the
+  `PersistentView` contract (`docs/runtime_contracts.md` §3) so menus survive restarts via the
+  persistent-view registry (`core/runtime/persistent_views.py`).
+- **`disbot/views/roles/role_menu_builder.py`** — the operator builder panel (reached from the
+  Reaction Roles panel / role hub): set title/description, pick roles
+  (`views/selectors/` role selector — windowed via `attach_windowed_select`, the repo's
+  >25-option pattern), choose button vs dropdown, choose mode, set the per-member limit, then
+  **Post** (creates the `role_menus` row, sends the message, stores `message_id`).
+- **All writes through `reaction_role_service`** (audited). The view is a thin UI over the
+  service — no DB writes in views (`docs/architecture.md` layer rules).
+- **Capability-gated** like the rest of the role hub (`manage_roles` / the role config
+  capability); re-check authority at callback time (`.claude/rules/discord-views.md`).
+- **Tests:** view-renders-from-menu-row; toggle adds/removes via the service; unique-mode clears
+  siblings; persistent-view re-attach registration.
+
+**Risk:** medium (new persistent view + runtime wiring) — scoped to the new tables, additive.
+
+### PR 3 — Carl-parity modes + interactive emoji-panel + settings bridge
+
+**Goal:** finish parity and close the read-only-panel finding.
+
+- **Modes on the emoji surface too:** add `unique` / `verify` to the raw-reaction path in the
+  service (verify = add-only + remove the reaction; unique = clear sibling emoji roles on this
+  message). Stored per `role_menus` row (or a small `reaction_role_modes` map for legacy
+  message-keyed bindings).
+- **Convert `ReactionRolesPanel` to interactive** — add/edit/remove buttons (modal for
+  message-id+emoji+role, picker for removal), and a list of deployed **menus** with edit/delete.
+  Closes the `ui-view-adoption-audit` P1 finding (hand-rolled → standard add/edit/remove panel).
+- **Settings bridge (optional):** wire the `reaction_roles_enabled` /
+  role-menu-channel keys already anticipated in
+  [`operator-settings-presets.md`](../setup-platform/operator-settings-presets.md) so the feature
+  is toggleable per guild and presettable.
+- **Stretch (beats Carl's paywall): free temporary roles.** Carl gates `temp` behind Patreon. We
+  can offer it free by reusing the managed-task / scheduled-maintenance machinery — but it needs
+  a `role_grants(guild_id, member_id, role_id, expires_at)` persistence table + a sweep loop.
+  **Mark as a follow-up**, not in the parity core, to keep PR 3 bounded.
+
+**Risk:** low-medium; mostly UI + small service additions on the PR 1/2 seam.
+
+---
+
+## 5. How we improve **on** Carl-bot (the "and improve on it" half)
+
+| Dimension | Carl-bot | SuperBot (this plan) |
+|---|---|---|
+| Primary surface | Emoji reactions (buttons/menus secondary) | **Native buttons + dropdowns first**; emoji kept for compatibility |
+| Stale-reaction problem | Inherent (reactions linger) | **None** — clicks are stateless, server-side toggle |
+| Mobile / permission UX | Needs add-reaction perms, fiddly | One tap, ephemeral confirm; no reaction perms |
+| Audit trail | None per assignment | **Every config change audited** (`audit.action_recorded` → `server_logging`) |
+| Restart durability | Message-bound | **PersistentView** re-attach on boot |
+| Timed roles | **Patreon-only** | **Free** (stretch, reuses tasks machinery) |
+| Integration | Standalone | Unified role hub with time/XP roles + **exemptions**; capability-gated |
+| Architecture | n/a | One audited service seam; layer-clean; CI-enforced invariants |
+
+The headline: **Carl is constrained by its emoji-reaction legacy; we start from Discord's modern
+component model**, so our default surface is strictly nicer, and we get auditability + restart
+durability Carl can't offer.
+
+---
+
+## 6. Broader "other functions we're missing" — Carl-bot feature matrix
+
+Beyond reaction roles, here is the full Carl-bot surface vs. SuperBot. **Most gaps are already
+captured as ideas** — this plan routes/cross-references them, it does not re-capture them.
+
+| Carl-bot feature | SuperBot status | Where captured / recommendation |
+|---|---|---|
+| **Reaction roles** | ✅ basic (emoji-only) | **← this plan** |
+| **Automod** (spam, invites, caps, mentions) | ✅ shipped (`automod_cog`, Q-0108) | — |
+| Automod **word-filter / link-filter / attachment-spam** | ❌ sub-gap | Small extension to `automod_cog` — add to the safety lane |
+| **Logging** | ✅ shipped (`logging_cog`) | — |
+| **Moderation** (+ image moderation) | ✅ shipped | — |
+| **Levels** | ✅ shipped (`xp_cog`) | — |
+| **Greetings / Welcome** | ✅ shipped (`welcome_cog`) | — |
+| **Starboard / Hall of Fame** | ❌ missing | Captured: [`ideas/fun-and-ease-brainstorm-2026-06-09.md`](../ideas/fun-and-ease-brainstorm-2026-06-09.md) §B1 (quick-win; reuses the raw-reaction precedent this plan hardens) |
+| **Custom commands / Tags & Triggers** | ❌ missing | Captured: [`ideas/community-platform-features-2026-06-12.md`](../ideas/community-platform-features-2026-06-12.md) §4 (Roadmap **Someday** — TagScript sandboxing risk) |
+| **Suggestions** (community upvote/downvote board) | ❌ missing | Captured: [`ideas/superbot-vision-2026-06-10.md`](../ideas/superbot-vision-2026-06-10.md) AG-15 (tickets / suggestion box) |
+| **Feeds / Notifications** (YouTube / Twitch / Reddit / RSS) | ⚠️ partial (media-youtube is content-fetch, not subscription pings) | Roadmap **Later** ([`roadmap.md`](../roadmap.md)) |
+| **Tags / embeds builder** (user-facing) | ❌ minor gap | Fold a small `embed` builder into the role-menu builder / `utility_cog` |
+| **Fun / Games** | ✅ extensive (blackjack, rps, mining, fishing, creature, …) | We **exceed** Carl here |
+
+**Recommendation:** ship the reaction-role overhaul first (debt + headline feature in one), then
+**starboard** is the highest-value, lowest-risk next Carl-parity item (already a captured
+quick-win and it reuses the hardened raw-reaction seam). Custom commands and feeds stay
+Someday/Later per their existing routing (sandboxing / external-poll cost).
+
+---
+
+## 7. Architecture & contracts checklist (binding)
+
+- **Mutation seam:** all writes through `reaction_role_service`; emit `audit.action_recorded`
+  (`docs/runtime_contracts.md` §9, `.claude/rules/mutation-and-db.md`). No `pool.execute` outside
+  `utils/db/`.
+- **Layers:** views never import cogs; service never imports views; DB only in `utils/db/`
+  (`docs/architecture.md`).
+- **PersistentView:** the role menu follows the §3 contract; registered in
+  `core/runtime/persistent_views.py`.
+- **Guild teardown:** new tables registered in `guild_lifecycle.py` (INV-I).
+- **Settings/capability:** capability-gated like the role hub; optional `reaction_roles_enabled`
+  via the settings schema.
+- **Smoke test:** the role hub panels are pinned by
+  [`smoke-test-checklist.md`](../smoke-test-checklist.md) ("TimeRoles / ReactionRoles return to
+  RoleHubView") — keep the back-nav contract green when the panel becomes interactive.
+
+## 8. Verification (before each PR ships)
+
+```bash
+python3.10 scripts/check_architecture.py --mode strict
+python3.10 scripts/check_quality.py --full          # black/isort/ruff + mypy + pytest
+python3.10 scripts/check_docs.py --strict           # this plan must stay linked
+```
+
+## 9. Open questions for the owner (design calls, not blockers)
+
+1. **Default surface:** lead operators toward **dropdown** (compact, one message, multi-select) or
+   **buttons** (one tap, more visible)? Recommend dropdown as the default, buttons as a toggle.
+2. **Audit member assignments?** Config changes: yes. Per-click member toggles could be high
+   volume — recommend **off by default**, behind a flag.
+3. **Free temp roles** (§4 PR 3 stretch) — worth the extra table + sweep loop, or defer?
+
+These are visualize-and-decide calls for the maintainer; none block PR 1 (the foundation), which
+is pure debt-paydown and safe to build immediately.

--- a/docs/subsystems/server-management.md
+++ b/docs/subsystems/server-management.md
@@ -169,6 +169,13 @@ Hub) was built 2026-06-08** (registered first-class as the `server_management` s
 owner decision Q-0016; key snake_cased per Q-0026). The only remaining item is the gated PR13 AI generation layer. Link to
 the tracker for exact order and dependencies rather than copying them here.
 
+**Reaction-role overhaul (2026-06-21, `plan`):** the role hub's reaction-role surface is the
+clearest piece of documented debt (direct DB writes / no audit / read-only panel — see the
+audits below) and "self-role menu" is on the command-expansion backlog. The buildable plan to
+reach **Carl-bot parity-plus** — audited mutation seam (PR 1), native button/dropdown role menus
+(PR 2), Carl-style modes + interactive panel (PR 3) — is
+[`planning/reaction-roles-overhaul-plan-2026-06-21.md`](../planning/reaction-roles-overhaul-plan-2026-06-21.md).
+
 ## Ideas (not approved)
 
 Arbitrary channel before/after positioning, revert-safe-changes UX, first-class


### PR DESCRIPTION
## What

Research deliverable + build-ready plan answering: *"Find out how Carl-bot does its reaction roles, plus any other functions we're missing, then plan how to implement and improve on it."*

**Docs-only — no runtime code in this PR.**

### New
- `docs/planning/reaction-roles-overhaul-plan-2026-06-21.md` — the plan.
- `.sessions/2026-06-21-carl-bot-reaction-roles-research-plan.md` — session log.

### The findings
- **Carl-bot's reaction roles** are fundamentally *emoji-reaction* based (buttons/menus are secondary; timed roles are Patreon-only). Modes: `normal / unique / verify / drop / reversed / binding / temp`; per-message `limit`, `maxroles`, role black/whitelist, multi-message `link`; 20 RR/message, ~250 total.
- **SuperBot already has basic emoji reaction-roles** — but they're the project's clearest documented architectural debt: direct DB writes (no audit seam), no modes/limits, a read-only management panel. "Self-role menu" is already on the command-expansion backlog.
- **Most broader Carl gaps are already captured as ideas** (starboard, custom commands, suggestion box, feeds) — the plan cross-references those rather than duplicating them. Note: **automod already exists** (spam/invites/caps/mentions), so content-moderation is *not* a gap.

### The plan (3 PRs, parity-plus)
1. **Foundation** — audited `reaction_role_service` + migration 078 (`role_menus` / `role_menu_options`), routing existing reaction-roles through the audited seam. Pure debt-paydown, zero behaviour change.
2. **Headline** — native **button/dropdown role menus** as a `PersistentView` (the surface Carl lacks at its core: no stale reactions, server-side unique/limit, restart-durable).
3. **Parity** — Carl-style modes (unique/verify/limit) on both surfaces + convert the read-only panel to interactive (closes the `ui-view-adoption-audit` finding).

**How we beat Carl:** native components first, every change audited, PersistentView re-attach, free timed roles (stretch), and unification with the existing role hub (time/XP roles + exemptions).

3 open design questions for the owner are listed in §9 (none block PR 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Utjw1fiQUkCKKzAFBdMets

---
_Generated by [Claude Code](https://claude.ai/code/session_01Utjw1fiQUkCKKzAFBdMets)_