### PR TITLE
docs(plan): reaction-roles UI direction — web dashboard vs in-Discord

### DIFF
--- a/.sessions/2026-06-21-reaction-roles-ui-direction.md
+++ b/.sessions/2026-06-21-reaction-roles-ui-direction.md
@@ -1,8 +1,10 @@
 # 2026-06-21 — Reaction-roles plan: UI-direction refinement (web vs in-Discord)
 
-> **Status:** `in-progress` — follow-up to #1215. The owner shared a screen recording of Carl's
+> **Status:** `complete` — follow-up to #1215. The owner shared a screen recording of Carl's
 > reaction-role "menu we need" and asked whether it's even possible in discord.py + to make it
-> nicer/smoother. Refining the plan to settle that. Docs-only. Flips to `complete` last (Q-0133).
+> nicer/smoother. Refined the plan to settle that. Docs-only → self-merge on green.
+
+> **Run type:** `manual`
 
 ## Arc
 
@@ -16,4 +18,32 @@ Adding §3.5 to `reaction-roles-overhaul-plan-2026-06-21.md`: the web-vs-Discord
 two-surface direction (A = web builder, control-API-gated; B = in-Discord modern builder,
 buildable now) + a 4th owner design Q (surface priority).
 
-(Body filled at close.)
+## Findings / decisions
+
+- **Verified from the video** (extracted frames via `imageio-ffmpeg`, since `ffmpeg` wasn't
+  installed): it is unambiguously a **mobile browser** rendering Carl's dashboard — Android status
+  bar + nav buttons, web `<select>`/radio/multiselect controls, a "Get Premium" upsell card. Each
+  mode's live description is captured in §3.5 (unique/verify/drop/limit/binding all shown).
+- **Decision made alone:** framed the feature as **two surfaces on one foundation** and recommended
+  **Surface B (in-Discord) first** because Surface A (web) is control-API-gated. Routed the call to
+  the owner as plan §9 Q4 rather than presuming it.
+
+## 📤 Run report
+
+- **Did:** settled the "is Carl's menu possible in discord.py?" question (it's a web app, not a Discord UI) and added the two-surface UI direction to the plan · **Outcome:** shipped (plan refinement)
+- **Shipped:** #1216 — reaction-roles plan §3.5 UI direction (docs-only)
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** plan §9 Q4 — ship in-Discord builder (Surface B) first, then the web builder when the control-API write side opens? (+ the 3 prior design Qs)
+- **⚑ Owner manual steps:** none
+- **⚑ Self-initiated:** none (direct owner request)
+- **↪ Next:** owner picks the surface priority (Q4) + answers Q1–Q3; then build reaction-roles PR 1 (audited seam, unblocked) → PR 2 (Surface B in-Discord builder)
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 1 (#1215); 1 pending (#1216) |
+| CI-red rounds | 0 |
+| Repo-rule trips | 0 |
+| New ideas contributed | 0 (this is a refinement of the #1215 idea/plan) |
+| Ideas groomed | 0 |

--- a/.sessions/2026-06-21-reaction-roles-ui-direction.md
+++ b/.sessions/2026-06-21-reaction-roles-ui-direction.md
@@ -1,0 +1,19 @@
+# 2026-06-21 — Reaction-roles plan: UI-direction refinement (web vs in-Discord)
+
+> **Status:** `in-progress` — follow-up to #1215. The owner shared a screen recording of Carl's
+> reaction-role "menu we need" and asked whether it's even possible in discord.py + to make it
+> nicer/smoother. Refining the plan to settle that. Docs-only. Flips to `complete` last (Q-0133).
+
+## Arc
+
+The recording is **Carl-bot's web dashboard** (`carl.gg/dashboard`) in a phone browser — HTML
+web-form UI (native `<select>` modes, radio list, role multi-selects, Get Premium upsell), **not**
+a Discord message. So the "exact menu" is unbuildable in *any* Discord library — it's a website.
+discord.py renders Discord components (buttons/selects/modals), not web forms. But we already own a
+website + React/Tailwind design system, so we can build it **nicer** — on two surfaces.
+
+Adding §3.5 to `reaction-roles-overhaul-plan-2026-06-21.md`: the web-vs-Discord answer + the
+two-surface direction (A = web builder, control-API-gated; B = in-Discord modern builder,
+buildable now) + a 4th owner design Q (surface priority).
+
+(Body filled at close.)

--- a/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
+++ b/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
@@ -116,6 +116,46 @@ Reaction / Diagnostics panels.
 
 ---
 
+## 3.5 UI direction — the owner's Carl reference is a **web dashboard** (2026-06-21)
+
+The owner shared a screen recording of "the menu we need." **Important clarification it
+settles:** that menu is **Carl-bot's web dashboard** (`carl.gg/dashboard`) opened in a phone
+**browser** — *not* the Discord app. Everything in it is **HTML web-form UI**: a native
+`Message type` `<select>` (the modes `normal / unique / verify / drop / reversed / limit /
+binding / temp`, each with a live description), radio-button mode list, a numeric `limit` field,
+two "Select option" role **multi-selects** (allow-list + blacklist), a `Show embed builder`
+toggle, an `Add emoji` button, a yellow **"Get Premium"** upsell for `temp`, and Cancel/Create.
+
+**This answers the "is this even possible in discord.py?" question — and the answer has two
+halves:**
+
+- **The *exact* screen is not a Discord UI at all**, so no Discord library (discord.py or
+  otherwise) can render it. It's a **website** talking to the bot over an API. The bot's
+  language is a red herring — Carl's backend is Python too; the recording is its *web frontend*
+  (JS/HTML/CSS). discord.py can only render **Discord's own components** (buttons, string/role
+  selects, modals — incl. label-wrapped selects) **inside Discord**, not an arbitrary scrolling
+  web form with radio lists + multiple dropdowns on one page.
+- **We are unusually well-placed to build this — and make it nicer.** SuperBot already ships a
+  website + dashboard and a **Claude-Design React/Tailwind design system** (`design-system/`,
+  `botsite/`, the dashboard control-API lanes). Carl's form looks **dated**; ours can be a clean,
+  modern, mobile-smooth page on infrastructure we already own. That is the owner's
+  "make it look nicer and work smoother" — realized on our design system, not by copying Carl's form.
+
+**So the feature targets two complementary surfaces** (same audited service + data model
+underneath — §4 PR 1 serves both):
+
+| Surface | What it is | Status |
+|---|---|---|
+| **A — Web builder** (the video) | a reaction-role/menu builder **page in our own dashboard** (React/Tailwind), writing through the control-API → bot. The "nicer, smoother" target. | **gated on the control-API write side** (owner-paced + security review — already a tracked lane in `current-state.md`). Not the first buildable slice. |
+| **B — In-Discord builder** (§4 PR 2) | a modern in-Discord builder using **buttons + select menus + modals** — laid out as a short multi-step flow (Discord's 5-row/25-option limits forbid one giant form), strictly nicer than Carl's emoji-reaction core. | **buildable now** — no web/control-API dependency. |
+
+**Sequencing implication:** build B first (it's unblocked and delivers the feature in-Discord),
+and add A as the polished web surface when the control-API write side opens. Both sit on the same
+PR 1 foundation, so neither is wasted. The owner's "nicer/smoother" bar applies to **both** — B
+uses our component design vocabulary (`docs/ux/pattern-library.md`), A uses the design system.
+
+---
+
 ## 4. The plan — three PRs (foundation → headline → parity)
 
 Per repo rule, a plan spans 2–3 PRs: **PR 1 fixes root causes/foundation; PR 2–3 build on top.**
@@ -171,10 +211,11 @@ model to support menus/modes — with **zero behaviour change** for existing emo
 
 **Risk:** low. Internal refactor + additive schema; existing reaction-roles behave identically.
 
-### PR 2 — Interactive role menus (the headline improvement)
+### PR 2 — Interactive role menus (the headline improvement = **Surface B**, §3.5)
 
 **Goal:** the modern, native surface Carl lacks at its core — a button/dropdown role menu an
-operator builds in-panel and deploys to a channel, re-attached on restart.
+operator builds in-panel and deploys to a channel, re-attached on restart. This is the
+**buildable-now in-Discord builder** (the web builder, Surface A, rides the control-API later).
 
 - **`disbot/views/roles/role_menu_view.py`** — a `RoleMenuView(PersistentView)` that renders
   either buttons (one per role, ≤25) or a `discord.ui.Select` (multi-select up to `max_roles`).
@@ -299,6 +340,10 @@ python3.10 scripts/check_docs.py --strict           # this plan must stay linked
 2. **Audit member assignments?** Config changes: yes. Per-click member toggles could be high
    volume — recommend **off by default**, behind a flag.
 3. **Free temp roles** (§4 PR 3 stretch) — worth the extra table + sweep loop, or defer?
+4. **Surface priority (§3.5):** the owner's reference is the **web builder (Surface A)** but it's
+   control-API-gated. Confirm: ship the **in-Discord builder (Surface B) first** (recommended —
+   unblocked, delivers the feature now), then the web builder when the control-API write side
+   opens? Or hold the whole feature for the web surface?
 
 These are visualize-and-decide calls for the maintainer; none block PR 1 (the foundation), which
 is pure debt-paydown and safe to build immediately.


### PR DESCRIPTION
Follow-up to #1215, refining the reaction-roles plan after the owner shared a screen recording of Carl's reaction-role "menu we need" and asked whether it's possible in discord.py + to make it nicer/smoother.

**Docs-only.**

### The clarification
The recording is **Carl-bot's web dashboard** (`carl.gg/dashboard`) viewed in a phone **browser** — native `<select>` mode dropdown, radio-button mode list, role multi-selects, a "Get Premium" upsell, Cancel/Create. That's **HTML web-form UI, not a Discord message** — so the *exact* menu can't be built in discord.py (or any Discord library); it's a website. The bot's language is a red herring (Carl's backend is Python too; that screen is its web frontend).

### What §3.5 adds to the plan
- Settles the "is this possible in discord.py?" question (no — it's a web app; discord.py renders Discord components, not web forms).
- The **two-surface direction** (same audited PR-1 foundation underneath):
  - **Surface A — web builder** (the video): a reaction-role builder page in *our own* dashboard on the Claude-Design React/Tailwind system → the "nicer/smoother" target. **Control-API-gated** (owner-paced/security review).
  - **Surface B — in-Discord builder** (PR 2): modern buttons + select menus + modals, **buildable now**, strictly nicer than Carl's emoji-reaction core. Ship first.
- A 4th owner design question on surface priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Utjw1fiQUkCKKzAFBdMets

---
_Generated by [Claude Code](https://claude.ai/code/session_01Utjw1fiQUkCKKzAFBdMets)_