### PR TITLE
docs(plan): reaction-roles presentation & editing (§4.6)

### DIFF
--- a/.sessions/2026-06-21-reaction-roles-presentation-editing.md
+++ b/.sessions/2026-06-21-reaction-roles-presentation-editing.md
@@ -1,8 +1,8 @@
 # 2026-06-21 — Reaction-roles plan: presentation & editing requirements
 
-> **Status:** `in-progress` — follow-up to #1215/#1216. Owner added four requirements: edit an
+> **Status:** `complete` — follow-up to #1215/#1216. Owner added four requirements: edit an
 > existing reaction-role message; embed theme presets; pre-customized starter-message templates;
-> optional PIL image cards. Folding them into the plan. Docs-only. Flips `complete` last (Q-0133).
+> optional PIL image cards. Folded into the plan. Docs-only → self-merge on green.
 
 > **Run type:** `manual`
 
@@ -21,4 +21,22 @@ All four fit existing infra, so they're cheap enhancements on the PR 2 builder, 
 
 Added plan §4.6 + two rows to the §5 "improve on Carl" table (editing, presentation).
 
-(Body filled at close.)
+## 📤 Run report
+
+- **Did:** folded the owner's four presentation/editing requirements into the plan (§4.6) · **Outcome:** shipped (plan refinement)
+- **Shipped:** #1217 — reaction-roles plan §4.6 presentation & editing (docs-only)
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** none new (the §9 design Qs still stand — surface priority + the 3 prior)
+- **⚑ Owner manual steps:** none
+- **⚑ Self-initiated:** none (direct owner request)
+- **↪ Next:** owner answers the §9 design Qs / picks surface; then build reaction-roles PR 1 (audited seam, unblocked) → PR 2 (in-Discord builder incl. edit + themes + templates)
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 2 (#1215, #1216); 1 pending (#1217) |
+| CI-red rounds | 0 |
+| Repo-rule trips | 0 |
+| New ideas contributed | 0 (plan refinement) |
+| Ideas groomed | 0 |

--- a/.sessions/2026-06-21-reaction-roles-presentation-editing.md
+++ b/.sessions/2026-06-21-reaction-roles-presentation-editing.md
@@ -1,0 +1,24 @@
+# 2026-06-21 — Reaction-roles plan: presentation & editing requirements
+
+> **Status:** `in-progress` — follow-up to #1215/#1216. Owner added four requirements: edit an
+> existing reaction-role message; embed theme presets; pre-customized starter-message templates;
+> optional PIL image cards. Folding them into the plan. Docs-only. Flips `complete` last (Q-0133).
+
+> **Run type:** `manual`
+
+## Arc
+
+All four fit existing infra, so they're cheap enhancements on the PR 2 builder, not a new subsystem:
+- **Edit-in-place** — our `role_menus`/`role_menu_options` rows + stored `message_id` make edit =
+  update row → re-render → `message.edit()` (no repost). First-class, folds into PR 2.
+- **Theme presets** — named catalogue on `utils/ui_constants.py` + the pattern-library archetypes;
+  stored in `role_menus.theme`. Folds into PR 2.
+- **Message templates** — starter-message data catalogue (`disbot/data/`, the `general_content.json`
+  precedent) as a builder gallery. Folds into PR 2.
+- **PIL cards** — reuse `utils/welcome_render.py::render_welcome_card()` (lazy PIL, `bytes|None`
+  graceful fallback); a `render_role_menu_card` sibling. Optional **PR 4** (owner-paced), degrades
+  to embed-only when Pillow absent.
+
+Added plan §4.6 + two rows to the §5 "improve on Carl" table (editing, presentation).
+
+(Body filled at close.)

--- a/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
+++ b/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
@@ -262,6 +262,56 @@ operator builds in-panel and deploys to a channel, re-attached on restart. This 
 
 ---
 
+## 4.6 Presentation & editing (owner direction, 2026-06-21)
+
+The owner added four requirements for how a menu *looks and is maintained*. All four fit existing
+infrastructure, so they are cheap enhancements layered on the PR 2 builder — not a new subsystem.
+
+### a) Edit an existing menu/message (first-class, not just create)
+
+A deployed menu must be **editable in place**, not only created. Our model makes this clean: a
+menu's title / description / theme / options / mode / limit all live in the `role_menus` +
+`role_menu_options` rows and we store its `message_id`, so **edit = update the row → re-render →
+`message.edit(...)`** (no repost, link/anchor preserved). The builder (PR 2) and the interactive
+panel (PR 3) both get an **Edit** entry that loads an existing menu back into the builder. For
+legacy emoji bindings on an arbitrary message, "edit" = add/remove bindings (+ edit the message
+body only when the bot authored it — Carl's `rr edit <msg_id> <title|description>` equivalent).
+→ **folds into PR 2.**
+
+### b) Embed theme presets
+
+A small **named theme catalogue** (accent colour + author/footer/styling) — e.g. `Minimal`,
+`Announcement`, `Neon`, `Pastel`, `Game` — surfaced as a one-tap **theme picker** in the builder.
+Pure data built on `utils/ui_constants.py` + the embed archetypes in `docs/ux/pattern-library.md`;
+the chosen key is stored in `role_menus.theme` (no migration beyond that column). → **folds into PR 2.**
+
+### c) Pre-customized message templates (the blank-page killer)
+
+A few **ready-made starter messages** an operator picks then tweaks — embed *or* plain text,
+decorated with emotes / light text-art — e.g. `🎮 Game roles`, `🔔 Notification roles`,
+`🎨 Colour roles`, `✅ Verify to enter`. A data catalogue (JSON in `disbot/data/`, the
+`general_content.json` precedent), shown as a template gallery in the builder so a good-looking
+menu is two taps away. → **folds into PR 2.**
+
+### d) PIL image cards (the owner's "maybe" — cheaper than it sounds)
+
+Optionally render a **banner/header image** to attach to the menu message: a few **preset card
+templates** + optional custom overlay text. **This reuses shipped infrastructure** —
+`utils/welcome_render.py::render_welcome_card()` already renders PIL cards with a **lazy import +
+`bytes | None` graceful fallback** (returns `None` → embed-only when Pillow is absent), and the
+UX-lab gallery exercises the same pattern. So a `render_role_menu_card(theme, title, …)` sibling is
+a small, on-brand addition, not new ground. Store the chosen card template + overlay text on the
+menu row; render at post/edit time; **degrade to embed-only** when Pillow is unavailable (never a
+hard dependency). → **optional PR 4 (owner-paced)** — kept separate so the core feature never
+blocks on image rendering.
+
+**PR-map update:** the core arc stays PR 1–3; **(a) edit + (b) themes + (c) templates fold into
+PR 2** (cheap data + builder UI, and they make the headline feature feel polished from day one);
+**(d) PIL cards are an optional PR 4.** Themes/templates/cards apply to **both** surfaces (the
+in-Discord builder *and*, later, the web builder — §3.5).
+
+---
+
 ## 5. How we improve **on** Carl-bot (the "and improve on it" half)
 
 | Dimension | Carl-bot | SuperBot (this plan) |
@@ -273,6 +323,8 @@ operator builds in-panel and deploys to a channel, re-attached on restart. This 
 | Restart durability | Message-bound | **PersistentView** re-attach on boot |
 | Timed roles | **Patreon-only** | **Free** (stretch, reuses tasks machinery) |
 | Integration | Standalone | Unified role hub with time/XP roles + **exemptions**; capability-gated |
+| Editing | `rr edit` (title/desc text only) | **Edit any field in place** — re-render from the row, message link preserved (§4.6a) |
+| Presentation | Embed builder | Embed builder **+ theme presets + starter-message templates + optional PIL banner cards** (§4.6 b/c/d) |
 | Architecture | n/a | One audited service seam; layer-clean; CI-enforced invariants |
 
 The headline: **Carl is constrained by its emoji-reaction legacy; we start from Discord's modern


### PR DESCRIPTION
Follow-up to #1215/#1216. Folds four owner requirements into the reaction-roles plan. **Docs-only.**

All four fit existing infrastructure, so they're cheap enhancements on the PR 2 builder, not a new subsystem:

- **(a) Edit an existing menu/message in place** — our `role_menus`/`role_menu_options` rows + stored `message_id` make edit = update row → re-render → `message.edit()` (no repost, link preserved). First-class. → **folds into PR 2**
- **(b) Embed theme presets** — a named theme catalogue (`Minimal`/`Announcement`/`Neon`/…) on `utils/ui_constants.py` + the pattern-library archetypes; stored in `role_menus.theme`. → **folds into PR 2**
- **(c) Pre-customized message templates** — starter messages (embed or plain, with emotes/text-art) as a data catalogue (`disbot/data/`, the `general_content.json` precedent) shown as a builder gallery. → **folds into PR 2**
- **(d) PIL image cards** (the owner's "maybe") — reuses the shipped `utils/welcome_render.py::render_welcome_card()` (lazy PIL import, `bytes | None` graceful fallback → embed-only when Pillow absent). A `render_role_menu_card` sibling. → **optional PR 4 (owner-paced)**, kept separate so the core feature never blocks on image rendering.

Themes/templates/cards apply to **both** surfaces (in-Discord builder and the later web builder). Core arc stays PR 1–3; (a)/(b)/(c) fold into PR 2, (d) is an optional PR 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Utjw1fiQUkCKKzAFBdMets

---
_Generated by [Claude Code](https://claude.ai/code/session_01Utjw1fiQUkCKKzAFBdMets)_