### PR TITLE
feat(roles): PR 2 — in-Discord role-menu builder (reaction-roles overhaul)

### DIFF
--- a/.sessions/2026-06-21-reaction-roles-pr2-menu-builder.md
+++ b/.sessions/2026-06-21-reaction-roles-pr2-menu-builder.md
@@ -1,0 +1,36 @@
+# 2026-06-21 — Reaction-roles PR 2: in-Discord role-menu builder
+
+> **Status:** `in-progress` — building PR 2 of the reaction-roles overhaul
+> ([plan](../docs/planning/reaction-roles-overhaul-plan-2026-06-21.md)): the modern in-Discord
+> role-menu builder (Surface B) — dropdown-default `RoleMenuView` + operator builder with
+> edit-in-place / theme presets / message templates, all writes through the audited
+> `reaction_role_service`. **HOLD:** depends on PR 1 (foundation) being built in a parallel
+> session; this card stays red until PR 1 has merged and this branch is reconciled onto it.
+
+> **Run type:** `manual`
+
+## Arc (what this session is about to do)
+
+PR 2 from the locked plan (§4 + §4.6, owner decisions §9):
+- `views/roles/role_menu_view.py` — `RoleMenuView(PersistentView)`: dropdown (default) or buttons,
+  server-side mode enforcement (unique / max_roles), ephemeral confirms, re-attached on restart.
+- `views/roles/role_menu_builder.py` — operator builder off the Reaction Roles panel: title/desc,
+  windowed role picker, style/mode/limit, **theme presets**, **message templates**, **edit-in-place**, Post.
+- `utils/role_menu_presentation.py` — theme + template catalogues (pure data on `ui_constants`).
+- All writes via `reaction_role_service` (audited); re-attach loop wired in `bot1.on_ready`.
+
+## ⚠️ PR 1 coordination
+
+PR 1 (parallel session) owns: `services/reaction_role_service.py` (creation), migration 078,
+`utils/db/role_menus.py`, the cog reaction-listener re-routing, the `guild_lifecycle.py` hook.
+This branch includes a copy of the foundation it strictly needs, built to the plan's **locked
+spec**, so PR 2 is self-contained + CI-green. **Reconcile before merge:** rebase onto PR 1, take
+PR 1's foundation, keep only PR 2's additions (menu service methods + the new view/builder files).
+
+## 📤 Run report (filled at close)
+
+- **Did:** _pending_
+- **Shipped:** _pending PR #_
+- **Run type:** `manual`
+- **⚑ Self-initiated:** none (owner-requested task: build PR 2→PR 5 of the reaction-roles overhaul)
+- **↪ Next:** PR 3 (Carl-parity modes + interactive emoji panel) · PR 4 (free temp roles) · PR 5 (analytics)

--- a/.sessions/2026-06-21-reaction-roles-pr2-menu-builder.md
+++ b/.sessions/2026-06-21-reaction-roles-pr2-menu-builder.md
@@ -1,36 +1,87 @@
 # 2026-06-21 — Reaction-roles PR 2: in-Discord role-menu builder
 
-> **Status:** `in-progress` — building PR 2 of the reaction-roles overhaul
+> **Status:** `complete` — PR 2 of the reaction-roles overhaul
 > ([plan](../docs/planning/reaction-roles-overhaul-plan-2026-06-21.md)): the modern in-Discord
-> role-menu builder (Surface B) — dropdown-default `RoleMenuView` + operator builder with
-> edit-in-place / theme presets / message templates, all writes through the audited
-> `reaction_role_service`. **HOLD:** depends on PR 1 (foundation) being built in a parallel
-> session; this card stays red until PR 1 has merged and this branch is reconciled onto it.
+> role-menu builder (Surface B). Built in parallel with PR 1 (the foundation), then **reconciled
+> onto PR 1 after it merged as #1220** — this branch now sits on PR 1's authoritative
+> `reaction_role_service` / `utils/db/role_menus` / migration 078, with PR 2's menu methods +
+> view/builder layered on top. Full CI green; boot-verified.
 
-> **Run type:** `manual`
+> **Run type:** `manual` · **PR:** #1219 (`needs-hermes-review`)
 
-## Arc (what this session is about to do)
+## Arc
 
-PR 2 from the locked plan (§4 + §4.6, owner decisions §9):
-- `views/roles/role_menu_view.py` — `RoleMenuView(PersistentView)`: dropdown (default) or buttons,
-  server-side mode enforcement (unique / max_roles), ephemeral confirms, re-attached on restart.
-- `views/roles/role_menu_builder.py` — operator builder off the Reaction Roles panel: title/desc,
-  windowed role picker, style/mode/limit, **theme presets**, **message templates**, **edit-in-place**, Post.
+The modern button/dropdown self-role surface Carl-bot lacks at its core (plan §4 PR 2 / Surface B,
+owner decisions §9). **Dropdown is the default** (decision #2); server-side mode enforcement
+(`unique` / `verify` / `max_roles`) means no stale reactions and an ephemeral confirm per click.
+
+- `views/roles/role_menu_view.py` — `RoleMenuView(PersistentView)`: dropdown or one-button-per-role,
+  restart-durable via static `role_menu:{menu_id}:*` custom_ids + `reattach_role_menus()` wired into
+  `bot1.on_ready`. Deliberately **not** registered in the anchor registry (it's a public data-driven
+  message re-bound by its own loop, not a per-user anchor panel — registering collided with
+  `RoleHubPanelView`'s `SUBSYSTEM='role'` and tripped the identity-contract check; caught at boot).
+- `views/roles/role_menu_builder.py` — operator builder + manager off the Reaction Roles panel:
+  title/description, windowed role picker, style/mode/limit, **theme presets** (§4.6b), **template
+  gallery** (§4.6c), **edit-in-place** (§4.6a, re-render → `message.edit`).
 - `utils/role_menu_presentation.py` — theme + template catalogues (pure data on `ui_constants`).
-- All writes via `reaction_role_service` (audited); re-attach loop wired in `bot1.on_ready`.
+- Service additions on PR 1's `reaction_role_service` — `create_menu`/`update_menu`/`delete_menu`
+  (audited), `toggle_role` (button) + `apply_selection` (dropdown) with server-side mode enforcement;
+  member self-assign is **not** audited (high-volume + opt-in, §9). Two DB helpers added to PR 1's
+  `role_menus.py`: `replace_options` (transactional full-list replace) + `list_posted_menus` (reattach).
 
-## ⚠️ PR 1 coordination
+## ⚙️ PR 1 reconciliation (the headline coordination)
 
-PR 1 (parallel session) owns: `services/reaction_role_service.py` (creation), migration 078,
-`utils/db/role_menus.py`, the cog reaction-listener re-routing, the `guild_lifecycle.py` hook.
-This branch includes a copy of the foundation it strictly needs, built to the plan's **locked
-spec**, so PR 2 is self-contained + CI-green. **Reconcile before merge:** rebase onto PR 1, take
-PR 1's foundation, keep only PR 2's additions (menu service methods + the new view/builder files).
+PR 1 was built in a parallel session and **merged as #1220** mid-session. A workflow auto-merged
+`main` into this PR branch. PR 1's actual API diverged from the plan's "recommended" copy
+(`get_options` not `get_menu_options`, `set_menu_message`, `delete_for_guild`, **no `template`
+column**, `theme` NOT NULL, no `replace_options`/`list_posted_menus`). Reconciled by resetting to
+PR 1's foundation, restoring only PR 2's non-overlapping files, then layering the menu methods onto
+PR 1's real API + dropping `template` *persistence* (the gallery still pre-fills). PR 1's
+`test_reaction_role_service.py` (emoji) + `test_guild_lifecycle_teardown.py` + `test_role_menus.py`
+all kept intact; my menu tests live in a separate `test_reaction_role_service_menus.py`.
 
-## 📤 Run report (filled at close)
+## ✅ Verification
 
-- **Did:** _pending_
-- **Shipped:** _pending PR #_
+`python3.10 scripts/check_quality.py --full` → **11165 passed, 10 skipped**, mypy clean.
+`check_architecture --mode strict` → 0 errors. **Booted the test bot** (Galaxy Bot#6724): cogs load,
+migration 078 applied, `reattach_role_menus` runs, no Traceback, identity-contract warning resolved.
+Not live-interaction-tested in Discord (no interactive click harness here) → `needs-hermes-review`.
+
+## 📤 Run report
+
+- **Did:** built reaction-roles PR 2 (in-Discord role-menu builder, Surface B) + reconciled onto
+  PR 1's merged foundation · **Outcome:** shipped to PR #1219 (`needs-hermes-review`, CI green)
+- **Shipped:** #1219 (this PR, human-merge-gated) — builds on #1220 (PR 1, merged)
 - **Run type:** `manual`
-- **⚑ Self-initiated:** none (owner-requested task: build PR 2→PR 5 of the reaction-roles overhaul)
-- **↪ Next:** PR 3 (Carl-parity modes + interactive emoji panel) · PR 4 (free temp roles) · PR 5 (analytics)
+- **⚑ Self-initiated:** none (owner-requested: build PR 2→5 of the reaction-roles overhaul; this
+  session delivered PR 2 end-to-end + the PR-1 reconciliation)
+- **⚑ Owner manual steps:** review + merge #1219 (runtime UI; merge ≠ deploy — prod restart stays
+  the maintainer's). Then PR 3/4/5/6 are unblocked.
+- **↪ Next:** PR 3 (Carl-parity modes on the emoji surface + interactive emoji panel + settings
+  bridge) · PR 4 (free temp roles — `role_grants` migration **079** + expiry sweep loop) · PR 5
+  (role-pickup analytics, §10) · PR 6 optional (PIL banner cards). All ride the PR 1+2 seam.
+
+## 💡 Session idea (Q-0089)
+
+**CI guard: a registered `PersistentView` whose `SUBSYSTEM` isn't in `SUBSYSTEMS` should fail the
+build, not just warn at boot.** This session's `SUBSYSTEM='role_menu'` mistake surfaced only as a
+runtime `bot.identity_contract` **warning** at boot — the strict identity test (`test_identity_
+contract_strict.py`) stayed green. A small invariant that iterates `persistent_views._REGISTRY` and
+asserts every `SUBSYSTEM` ∈ `SUBSYSTEMS` (the parity the boot check already computes) would catch
+this class pre-merge instead of needing a live boot. Cheap, stdlib-only, closes a "boot caught it,
+CI didn't" gap. (Filed mentally; would be a `tests/unit/registry/` invariant.)
+
+## ⟲ Previous-session review (Q-0102)
+
+**Reviewed: the PR 1 foundation session (#1220).** *Did well:* a clean, well-tested audited seam +
+data layer + teardown + a faithful migration that honored the owner-locked `dropdown` default and the
+§4.6b `theme` column. *Could have gone better:* its DB/service **API names diverged** from the plan's
+"recommended shape" copy that PR 2 was told to build against (`get_options` vs `get_menu_options`,
+no `replace_options`/`list_posted_menus`, `template` dropped) — which made the parallel-PR-2
+reconciliation non-trivial (rename every `menus_db.*` call, drop template persistence). **System
+improvement it surfaces:** when a *foundation* PR and its *consumer* PR are built in parallel, the
+foundation session should publish its **exact public signatures early** — either by pushing an API
+stub first or by updating the plan's code block with the final names — so the consumer builds against
+the real API, not a guessed copy. A lightweight convention worth adding to the parallel-execution
+guidance in `ai-project-workflow.md` §9. (This is the internal-mirror of the Hermes-reviewer loop:
+each session audits its predecessor's seams.)

--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -287,6 +287,12 @@ async def on_ready() -> None:
     from core.runtime import live_update_scheduler, message_anchor_manager
 
     await message_anchor_manager.restore_anchors(bot)
+    # Re-bind a persistent view to every posted role menu (data-driven, keyed on
+    # the role_menus rows rather than per-user anchors) so self-role clicks
+    # survive a restart. Idempotent — guarded against on_ready re-fires.
+    from views.roles.role_menu_view import reattach_role_menus
+
+    await reattach_role_menus(bot)
     live_update_scheduler.setup(bot)
     if reporter:
         await reporter.on_startup(bot)

--- a/disbot/services/reaction_role_service.py
+++ b/disbot/services/reaction_role_service.py
@@ -8,11 +8,17 @@ sanctioned write path for emoji reaction-role bindings — it persists via the D
 layer and emits ``audit.action_recorded``, so reaction-role config changes show
 up in the same audit/``server_logging`` stream as the rest of the role hub.
 
-Scope (PR 1): the *config* writes (bind/unbind an emoji → role) are audited.
-The member self-assign path (adding/removing the role when someone reacts) is a
-Discord mutation, not a DB write, and stays in the cog listener for now; PR 3
-layers the unique/verify modes onto the read seam here. The role-menu write
-methods land in PR 2 on top of ``utils.db.role_menus``.
+Scope: the emoji *config* writes (bind/unbind an emoji → role) are audited.
+The emoji member self-assign path (adding/removing the role when someone reacts)
+is a Discord mutation, not a DB write, and stays in the cog listener for now;
+PR 3 layers the unique/verify modes onto the read seam here.
+
+PR 2 adds the role-**menu** surface on top of ``utils.db.role_menus``: the
+audited menu config writes (``create_menu`` / ``update_menu`` / ``delete_menu``)
+and the server-side member assignment (``toggle_role`` for the button surface,
+``apply_selection`` for the dropdown) with ``unique`` / ``verify`` / ``max_roles``
+enforcement. Menu config changes are audited; member self-assignment is not
+(high-volume + opt-in per plan §9 — the PR 5 pickup analytics cover usage).
 
 Cycle discipline mirrors the rest of ``services``: cross-package ``services.*``
 imports are function-local; top-level imports are limited to stdlib + ``utils``.
@@ -21,9 +27,13 @@ imports are function-local; top-level imports are limited to stdlib + ``utils``.
 from __future__ import annotations
 
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timezone
 
-from utils import db
+import discord
+
+from utils import db, role_feasibility
+from utils.db import role_menus as menus_db
 
 
 async def bind_emoji(
@@ -80,6 +90,385 @@ async def list_bindings(guild_id: int) -> list[dict]:
     return await db.get_all_reaction_roles(guild_id)
 
 
+# ===========================================================================
+# Role menus (PR 2) — config writes (audited) + member assignment (not audited)
+# ===========================================================================
+
+# Menu surface styles + assignment modes, validated at the service boundary so a
+# bad value never reaches the DB or the renderer.
+VALID_STYLES = ("dropdown", "button", "reaction")
+VALID_MODES = ("normal", "unique", "verify")
+
+
+@dataclass(frozen=True)
+class RoleOption:
+    """One role a menu offers (an immutable view of a ``role_menu_options`` row)."""
+
+    role_id: int
+    emoji: str | None = None
+    label: str | None = None
+
+
+@dataclass(frozen=True)
+class RoleMenuOutcome:
+    """Result of a member interaction, for the ephemeral confirmation."""
+
+    added: tuple[int, ...] = ()
+    removed: tuple[int, ...] = ()
+    blocked: tuple[int, ...] = ()
+    note: str = ""
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.added or self.removed)
+
+
+async def create_menu(
+    *,
+    guild_id: int,
+    channel_id: int,
+    title: str,
+    description: str | None,
+    style: str,
+    mode: str,
+    max_roles: int,
+    options: list[RoleOption],
+    theme: str = "default",
+    actor_id: int | None,
+) -> int:
+    """Create a role menu (+ its options) and return ``menu_id`` (audited)."""
+    style = _validate_style(style)
+    mode = _validate_mode(mode)
+    max_roles = max(0, int(max_roles))
+
+    menu_id = await menus_db.create_menu(
+        guild_id,
+        channel_id,
+        title=title,
+        description=description,
+        style=style,
+        mode=mode,
+        max_roles=max_roles,
+        theme=theme or "default",
+    )
+    await menus_db.replace_options(menu_id, _options_to_rows(options))
+    await _emit_menu_audit(
+        mutation_type="create_role_menu",
+        menu_id=menu_id,
+        guild_id=guild_id,
+        actor_id=actor_id,
+        prev_value=None,
+        new_value=_summarize(title, style, mode, max_roles, options),
+    )
+    return menu_id
+
+
+async def update_menu(
+    *,
+    menu_id: int,
+    guild_id: int,
+    title: str,
+    description: str | None,
+    style: str,
+    mode: str,
+    max_roles: int,
+    options: list[RoleOption],
+    theme: str = "default",
+    actor_id: int | None,
+) -> None:
+    """Overwrite a menu's fields + options in place (edit-in-place, audited)."""
+    style = _validate_style(style)
+    mode = _validate_mode(mode)
+    max_roles = max(0, int(max_roles))
+
+    prev = await menus_db.get_menu(menu_id)
+    prev_opts = await menus_db.get_options(menu_id)
+
+    await menus_db.update_menu(
+        menu_id,
+        title=title,
+        description=description,
+        style=style,
+        mode=mode,
+        max_roles=max_roles,
+        theme=theme or "default",
+    )
+    await menus_db.replace_options(menu_id, _options_to_rows(options))
+    await _emit_menu_audit(
+        mutation_type="update_role_menu",
+        menu_id=menu_id,
+        guild_id=guild_id,
+        actor_id=actor_id,
+        prev_value=(
+            _summarize(
+                prev["title"],
+                prev["style"],
+                prev["mode"],
+                prev["max_roles"],
+                [RoleOption(int(o["role_id"])) for o in prev_opts],
+            )
+            if prev
+            else None
+        ),
+        new_value=_summarize(title, style, mode, max_roles, options),
+    )
+
+
+async def set_menu_message(menu_id: int, message_id: int) -> None:
+    """Record the posted message id (part of the create/post flow, not audited)."""
+    await menus_db.set_menu_message(menu_id, message_id)
+
+
+async def delete_menu(
+    *,
+    menu_id: int,
+    guild_id: int,
+    actor_id: int | None,
+) -> None:
+    """Delete a menu and its options (audited)."""
+    prev = await menus_db.get_menu(menu_id)
+    await menus_db.delete_menu(menu_id)
+    await _emit_menu_audit(
+        mutation_type="delete_role_menu",
+        menu_id=menu_id,
+        guild_id=guild_id,
+        actor_id=actor_id,
+        prev_value=(prev["title"] if prev else None),
+        new_value=None,
+    )
+
+
+# --- Reads (thin pass-throughs so callers never import the DB layer directly) --
+
+
+async def get_menu(menu_id: int) -> dict | None:
+    return await menus_db.get_menu(menu_id)
+
+
+async def get_menu_options(menu_id: int) -> list[RoleOption]:
+    rows = await menus_db.get_options(menu_id)
+    return [RoleOption(int(r["role_id"]), r.get("emoji"), r.get("label")) for r in rows]
+
+
+async def list_menus(guild_id: int) -> list[dict]:
+    return await menus_db.list_menus(guild_id)
+
+
+async def list_posted_menus() -> list[dict]:
+    return await menus_db.list_posted_menus()
+
+
+# --- Member self-assignment (server-side mode enforcement, NOT audited) --------
+
+
+async def toggle_role(
+    *,
+    menu_id: int,
+    member: discord.Member,
+    guild: discord.Guild,
+    clicked_role_id: int,
+) -> RoleMenuOutcome:
+    """Toggle one role for a member (button surface), honoring the menu's mode.
+
+    Re-reads the menu + options from the DB so the menu config (mode / limit) is
+    always authoritative — the caller's view state is never trusted for a
+    privileged mutation.
+    """
+    menu = await menus_db.get_menu(menu_id)
+    if menu is None:
+        return RoleMenuOutcome(note="This menu no longer exists.")
+    option_ids = await _option_ids(menu_id)
+    if clicked_role_id not in option_ids:
+        return RoleMenuOutcome(note="That role isn't part of this menu.")
+
+    mode = menu["mode"]
+    max_roles = int(menu["max_roles"])
+    held = _held_menu_roles(member, option_ids)
+    has_clicked = clicked_role_id in held
+
+    if has_clicked and mode != "verify":
+        return await _apply(
+            member,
+            to_add=(),
+            to_remove=(clicked_role_id,),
+            guild=guild,
+        )
+    if has_clicked and mode == "verify":
+        return RoleMenuOutcome(note="You already have that role (verify menu).")
+
+    # Adding a role the member doesn't hold yet.
+    if mode == "unique":
+        siblings = tuple(r for r in held if r != clicked_role_id)
+        return await _apply(
+            member,
+            to_add=(clicked_role_id,),
+            to_remove=siblings,
+            guild=guild,
+        )
+    if max_roles and len(held) >= max_roles:
+        return RoleMenuOutcome(
+            blocked=(clicked_role_id,),
+            note=f"You can pick at most {max_roles} role(s) here — remove one first.",
+        )
+    return await _apply(member, to_add=(clicked_role_id,), to_remove=(), guild=guild)
+
+
+async def apply_selection(
+    *,
+    menu_id: int,
+    member: discord.Member,
+    guild: discord.Guild,
+    selected_ids: list[int],
+) -> RoleMenuOutcome:
+    """Reconcile a member's menu roles to ``selected_ids`` (dropdown surface).
+
+    The dropdown is stateless on a shared message, so each submission *sets* the
+    member's menu-roles to exactly what they picked: add the newly-selected,
+    remove the de-selected. Mode rules: ``unique`` keeps at most one; ``verify``
+    only ever adds; ``max_roles`` caps the count.
+    """
+    menu = await menus_db.get_menu(menu_id)
+    if menu is None:
+        return RoleMenuOutcome(note="This menu no longer exists.")
+    option_ids = await _option_ids(menu_id)
+    mode = menu["mode"]
+    max_roles = int(menu["max_roles"])
+
+    desired = [rid for rid in selected_ids if rid in option_ids]
+    if mode == "unique":
+        desired = desired[:1]
+    elif max_roles:
+        desired = desired[:max_roles]
+    desired_set = set(desired)
+
+    held = _held_menu_roles(member, option_ids)
+    to_add = tuple(rid for rid in desired_set if rid not in held)
+    # verify mode never removes a role the member already earned.
+    to_remove = (
+        () if mode == "verify" else tuple(rid for rid in held if rid not in desired_set)
+    )
+    return await _apply(member, to_add=to_add, to_remove=to_remove, guild=guild)
+
+
+# --- Internal helpers ------------------------------------------------------
+
+
+async def _option_ids(menu_id: int) -> set[int]:
+    rows = await menus_db.get_options(menu_id)
+    return {int(r["role_id"]) for r in rows}
+
+
+def _held_menu_roles(member: discord.Member, option_ids: set[int]) -> set[int]:
+    """The subset of this menu's roles the member currently holds."""
+    return {r.id for r in member.roles} & option_ids
+
+
+async def _apply(
+    member: discord.Member,
+    *,
+    to_add: tuple[int, ...],
+    to_remove: tuple[int, ...],
+    guild: discord.Guild,
+) -> RoleMenuOutcome:
+    """Resolve role ids, drop ones the bot can't manage, then add/remove."""
+    add_roles, add_blocked = _resolve_manageable(guild, to_add)
+    remove_roles, remove_blocked = _resolve_manageable(guild, to_remove)
+
+    added: tuple[int, ...] = ()
+    removed: tuple[int, ...] = ()
+    blocked = tuple(add_blocked) + tuple(remove_blocked)
+
+    if add_roles:
+        try:
+            await member.add_roles(*add_roles, reason="Role menu")
+            added = tuple(r.id for r in add_roles)
+        except discord.Forbidden:
+            blocked += tuple(r.id for r in add_roles)
+    if remove_roles:
+        try:
+            await member.remove_roles(*remove_roles, reason="Role menu")
+            removed = tuple(r.id for r in remove_roles)
+        except discord.Forbidden:
+            blocked += tuple(r.id for r in remove_roles)
+
+    note = ""
+    if blocked and not (added or removed):
+        note = "I can't manage that role (it's above my highest role)."
+    return RoleMenuOutcome(added=added, removed=removed, blocked=blocked, note=note)
+
+
+def _resolve_manageable(
+    guild: discord.Guild,
+    role_ids: tuple[int, ...],
+) -> tuple[list[discord.Role], list[int]]:
+    """Split role ids into (manageable Role objects, blocked ids)."""
+    from core.runtime import resources
+
+    manageable: list[discord.Role] = []
+    blocked: list[int] = []
+    for rid in role_ids:
+        role = resources.resolve_role(guild, role_id=rid)
+        if role is None:
+            blocked.append(rid)
+            continue
+        if role_feasibility.evaluate_role(role, bot_member=guild.me).ok:
+            manageable.append(role)
+        else:
+            blocked.append(rid)
+    return manageable, blocked
+
+
+def _validate_style(style: str) -> str:
+    return style if style in VALID_STYLES else "dropdown"
+
+
+def _validate_mode(mode: str) -> str:
+    return mode if mode in VALID_MODES else "normal"
+
+
+def _options_to_rows(
+    options: list[RoleOption],
+) -> list[tuple[int, str | None, str | None]]:
+    return [(o.role_id, o.emoji, o.label) for o in options]
+
+
+def _summarize(
+    title: str,
+    style: str,
+    mode: str,
+    max_roles: int,
+    options: list[RoleOption],
+) -> str:
+    limit = "∞" if not max_roles else str(max_roles)
+    return f"{title!r} [{style}/{mode}, limit={limit}, {len(options)} role(s)]"
+
+
+async def _emit_menu_audit(
+    *,
+    mutation_type: str,
+    menu_id: int,
+    guild_id: int,
+    actor_id: int | None,
+    prev_value: str | None,
+    new_value: str | None,
+) -> None:
+    from services.audit_events import emit_audit_action
+
+    await emit_audit_action(
+        mutation_id=str(uuid.uuid4()),
+        subsystem="role",
+        mutation_type=mutation_type,
+        target=f"role_menu:{menu_id}",
+        scope="guild",
+        guild_id=guild_id,
+        prev_value=prev_value,
+        new_value=new_value,
+        actor_id=actor_id,
+        actor_type="admin",
+        occurred_at=datetime.now(tz=timezone.utc),
+    )
+
+
 async def _emit(
     guild_id: int,
     *,
@@ -108,8 +497,22 @@ async def _emit(
 
 
 __all__ = [
+    "VALID_MODES",
+    "VALID_STYLES",
+    "RoleMenuOutcome",
+    "RoleOption",
+    "apply_selection",
     "bind_emoji",
+    "create_menu",
+    "delete_menu",
     "get_binding",
+    "get_menu",
+    "get_menu_options",
     "list_bindings",
+    "list_menus",
+    "list_posted_menus",
+    "set_menu_message",
+    "toggle_role",
     "unbind_emoji",
+    "update_menu",
 ]

--- a/disbot/utils/db/role_menus.py
+++ b/disbot/utils/db/role_menus.py
@@ -13,6 +13,8 @@ is self-contained and its consumer is the new ``views/roles`` menu surface.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from utils.db import pool
 
 # ---------------------------------------------------------------------------
@@ -147,6 +149,57 @@ async def get_options(menu_id: int) -> list[dict]:
         "SELECT role_id, emoji, label, position FROM role_menu_options "
         "WHERE menu_id=$1 ORDER BY position, role_id",
         (menu_id,),
+    )
+
+
+async def replace_options(
+    menu_id: int,
+    options: Sequence[tuple[int, str | None, str | None]],
+) -> None:
+    """Replace a menu's full option list in one transaction (PR 2 builder).
+
+    ``options`` is an ordered sequence of ``(role_id, emoji, label)`` — the index
+    becomes the stored ``position``, so the caller controls display order by
+    ordering the sequence. The builder always re-sends the whole list on
+    create/edit, so a transactional delete + bulk-insert is simpler and safer
+    than diffing against :func:`add_option` / :func:`remove_option` (and a
+    concurrent reader never sees a half-applied list). Mirrors
+    ``command_access.set_channels``.
+    """
+    deduped: list[tuple[int, str | None, str | None]] = []
+    seen: set[int] = set()
+    for role_id, emoji, label in options:
+        rid = int(role_id)
+        if rid in seen:
+            continue
+        seen.add(rid)
+        deduped.append((rid, emoji, label))
+
+    async with pool.get().acquire() as conn, conn.transaction():
+        await conn.execute(
+            "DELETE FROM role_menu_options WHERE menu_id=$1",
+            menu_id,
+        )
+        if deduped:
+            await conn.executemany(
+                """INSERT INTO role_menu_options
+                       (menu_id, role_id, emoji, label, position)
+                   VALUES ($1, $2, $3, $4, $5)""",
+                [
+                    (menu_id, rid, emoji, label, pos)
+                    for pos, (rid, emoji, label) in enumerate(deduped)
+                ],
+            )
+
+
+async def list_posted_menus() -> list[dict]:
+    """Every menu that has been posted (``message_id`` set), across all guilds.
+
+    Used by the boot re-attach loop to re-bind a persistent view to each live
+    menu message (PR 2).
+    """
+    return await pool.fetchall(
+        "SELECT * FROM role_menus WHERE message_id IS NOT NULL",
     )
 
 

--- a/disbot/utils/role_menu_presentation.py
+++ b/disbot/utils/role_menu_presentation.py
@@ -1,0 +1,181 @@
+"""Theme presets + starter-message templates for role menus (plan §4.6 b/c).
+
+Pure data on top of :mod:`utils.ui_constants` and the embed archetypes in
+``docs/ux/pattern-library.md`` — no DB, no Discord I/O — so both the in-Discord
+builder (PR 2) and, later, the web builder (Surface A) read the same catalogue.
+
+* **Themes** (§4.6b) — a named accent-colour + footer catalogue surfaced as a
+  one-tap picker in the builder. The chosen ``key`` is stored in
+  ``role_menus.theme`` and re-applied on render/edit/restart.
+* **Templates** (§4.6c) — ready-made starter messages (title + decorated
+  description + a suggested theme/style) shown as a gallery so a good-looking
+  menu is two taps away. The template only *pre-fills* the builder; the operator
+  then tweaks the title/description that actually get stored.
+
+Layer note: lives in ``utils/`` (may import stdlib + discord only) so any view
+can import it without crossing a layer boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import discord
+
+from utils import ui_constants
+
+# The key persisted when a menu has no explicit theme.
+DEFAULT_THEME_KEY = "default"
+
+
+@dataclass(frozen=True)
+class MenuTheme:
+    """A named accent-colour preset for a role-menu embed."""
+
+    key: str
+    label: str
+    color: discord.Color
+    footer: str | None = None
+
+
+@dataclass(frozen=True)
+class MenuTemplate:
+    """A ready-made starter message an operator picks then tweaks."""
+
+    key: str
+    label: str  # gallery button text, e.g. "🎮 Game roles"
+    title: str
+    description: str
+    theme: str = DEFAULT_THEME_KEY
+    style: str = "dropdown"
+
+
+# Ordered so the builder renders them deterministically.  Colours reference
+# ui_constants where one fits, with explicit RGB for the decorative themes.
+_THEMES: tuple[MenuTheme, ...] = (
+    MenuTheme(
+        "default",
+        "Default",
+        ui_constants.ROLE_COLOR,
+        footer="Pick the roles you want — tap again to remove.",
+    ),
+    MenuTheme(
+        "minimal",
+        "Minimal",
+        discord.Color.from_rgb(47, 49, 54),  # Discord dark — blends into the channel
+    ),
+    MenuTheme(
+        "announcement",
+        "Announcement",
+        ui_constants.ECONOMY_COLOR,  # gold
+        footer="React below to opt in.",
+    ),
+    MenuTheme(
+        "neon",
+        "Neon",
+        discord.Color.from_rgb(255, 0, 200),
+    ),
+    MenuTheme(
+        "pastel",
+        "Pastel",
+        discord.Color.from_rgb(181, 199, 255),
+    ),
+    MenuTheme(
+        "game",
+        "Game",
+        ui_constants.GAME_COLOR,  # purple
+        footer="Choose your squads.",
+    ),
+)
+
+_THEME_BY_KEY: dict[str, MenuTheme] = {t.key: t for t in _THEMES}
+
+
+_TEMPLATES: tuple[MenuTemplate, ...] = (
+    MenuTemplate(
+        "game_roles",
+        "🎮 Game roles",
+        title="🎮 Game Roles",
+        description=(
+            "Pick the games you play to get pinged for squads and find teammates.\n\n"
+            "Use the menu below to add or remove your game roles."
+        ),
+        theme="game",
+    ),
+    MenuTemplate(
+        "notification_roles",
+        "🔔 Notification roles",
+        title="🔔 Notification Roles",
+        description=(
+            "Choose which announcements you want to be pinged for.\n\n"
+            "Only opt into what you care about — you can change this anytime."
+        ),
+        theme="announcement",
+    ),
+    MenuTemplate(
+        "colour_roles",
+        "🎨 Colour roles",
+        title="🎨 Colour Roles",
+        description=(
+            "Give your name some colour! Pick **one** colour role below.\n\n"
+            "Selecting a new colour replaces your current one."
+        ),
+        theme="pastel",
+        # A colour menu is naturally single-choice — the builder pre-selects
+        # unique mode when this template is chosen.
+    ),
+    MenuTemplate(
+        "verify",
+        "✅ Verify to enter",
+        title="✅ Verify",
+        description=(
+            "Welcome! Tap below to verify you're human and unlock the rest of the "
+            "server.\n\nThis only ever **adds** your member role."
+        ),
+        theme="minimal",
+        style="button",
+    ),
+)
+
+_TEMPLATE_BY_KEY: dict[str, MenuTemplate] = {t.key: t for t in _TEMPLATES}
+
+
+def themes() -> tuple[MenuTheme, ...]:
+    """Every theme preset, in display order."""
+    return _THEMES
+
+
+def get_theme(key: str | None) -> MenuTheme:
+    """Return the theme for ``key``, falling back to the default preset."""
+    if key and key in _THEME_BY_KEY:
+        return _THEME_BY_KEY[key]
+    return _THEME_BY_KEY[DEFAULT_THEME_KEY]
+
+
+def theme_color(key: str | None) -> discord.Color:
+    """Convenience: the accent colour for a theme key (default-safe)."""
+    return get_theme(key).color
+
+
+def templates() -> tuple[MenuTemplate, ...]:
+    """Every starter-message template, in display order."""
+    return _TEMPLATES
+
+
+def get_template(key: str | None) -> MenuTemplate | None:
+    """Return the template for ``key``, or ``None`` if unknown/absent."""
+    if not key:
+        return None
+    return _TEMPLATE_BY_KEY.get(key)
+
+
+__all__ = [
+    "DEFAULT_THEME_KEY",
+    "MenuTemplate",
+    "MenuTheme",
+    "get_template",
+    "get_theme",
+    "templates",
+    "theme_color",
+    "themes",
+]

--- a/disbot/views/roles/reaction_panel.py
+++ b/disbot/views/roles/reaction_panel.py
@@ -34,7 +34,10 @@ class ReactionRolesPanel(BaseView):
             )
 
     async def build_embed(self) -> discord.Embed:
+        from services import reaction_role_service
+
         rows = await db.get_all_reaction_roles(self.ctx.guild.id)
+        menus = await reaction_role_service.list_menus(self.ctx.guild.id)
         embed = discord.Embed(title="💬 Reaction Roles", color=ROLE_COLOR)
         if rows:
             lines = []
@@ -45,12 +48,42 @@ class ReactionRolesPanel(BaseView):
             embed.description = "\n".join(lines)
         else:
             embed.description = (
-                "No reaction roles configured.\n\n"
-                "Use `!reactroles <message_id> <emoji> <@role>` to add one.\n"
-                "Use `!removereactrole <message_id> <emoji>` to remove one."
+                "No emoji reaction roles configured.\n\n"
+                "Use `!reactroles <message_id> <emoji> <@role>` to add one — or tap "
+                "**🛠️ Role Menus** for the modern button/dropdown surface (no reactions "
+                "needed)."
             )
-        embed.set_footer(text="Members react to earn their role automatically.")
+        embed.add_field(
+            name="🛠️ Role menus",
+            value=(
+                f"{len(menus)} button/dropdown menu(s) configured."
+                if menus
+                else "None yet — tap **🛠️ Role Menus** to build one."
+            ),
+            inline=False,
+        )
+        embed.set_footer(text="Members self-assign with one tap; no reactions needed.")
         return embed
+
+    @discord.ui.button(label="🛠️ Role Menus", style=discord.ButtonStyle.green, row=0)
+    async def menus_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        from views.roles.role_menu_builder import RoleMenuListView
+
+        view = RoleMenuListView(
+            interaction.user,
+            interaction.guild,
+            interaction.channel,
+            parent=self,
+        )
+        await interaction.response.edit_message(
+            embed=await view.build_embed(),
+            view=view,
+        )
+        view.message = interaction.message
 
     @discord.ui.button(label="🔄 Refresh", style=discord.ButtonStyle.grey, row=0)
     async def refresh_btn(

--- a/disbot/views/roles/role_menu_builder.py
+++ b/disbot/views/roles/role_menu_builder.py
@@ -1,0 +1,792 @@
+"""Operator-facing role-menu builder + manager (plan §4 PR 2, §4.6 a/b/c).
+
+Reached from the Reaction Roles panel. ``RoleMenuListView`` is the manager (list /
+new / edit / delete); ``RoleMenuBuilder`` is the build-or-edit panel. Discord's
+5-row / 25-option limits forbid one giant form, so the builder is a compact preview
+panel whose fields are set through modals + ephemeral sub-pickers, then **Post**
+(new) or **Save** (edit-in-place — §4.6a) commits through the audited
+:mod:`services.reaction_role_service`.
+
+Layer: a thin UI over the service — no DB writes here, no role math. Authority is
+re-checked at callback time (``manage_roles``), per ``.claude/rules/discord-views.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from core.runtime import resources
+from core.runtime.interaction_helpers import safe_defer
+from utils import role_feasibility
+from utils import role_menu_presentation as presentation
+from views.base import BaseView
+from views.navigation import attach_back_button
+from views.paginated_select import PaginatedSelectView
+from views.roles.role_menu_view import MAX_MENU_ROLES, RoleMenuView, build_menu_embed
+from views.selectors import attach_multi_role_select
+
+logger = logging.getLogger("bot.views.role_menu_builder")
+
+_STYLE_LABEL = {"dropdown": "Dropdown", "button": "Buttons"}
+_MODE_LABEL = {
+    "normal": "Normal — pick any",
+    "unique": "Unique — one only",
+    "verify": "Verify — add-only",
+}
+
+
+def _can_manage(interaction: discord.Interaction) -> bool:
+    perms = getattr(interaction.user, "guild_permissions", None)
+    return bool(perms is not None and (perms.manage_roles or perms.administrator))
+
+
+async def _deny(interaction: discord.Interaction) -> None:
+    await interaction.response.send_message(
+        "You need the **Manage Roles** permission to do that.",
+        ephemeral=True,
+    )
+
+
+# A guild channel a menu can be posted in — all have ``.send`` / ``.mention`` /
+# ``.id`` (narrower than ``MessageableChannel``, which also covers DM/group).
+_GuildMessageable = (
+    discord.TextChannel | discord.Thread | discord.VoiceChannel | discord.StageChannel
+)
+
+
+def _as_messageable(channel: object) -> _GuildMessageable | None:
+    """Narrow an interaction/guild channel to a postable guild channel, or None."""
+    if isinstance(
+        channel,
+        (
+            discord.TextChannel,
+            discord.Thread,
+            discord.VoiceChannel,
+            discord.StageChannel,
+        ),
+    ):
+        return channel
+    return None
+
+
+def _option_dicts(options: list) -> list[dict]:  # type: ignore[type-arg]
+    """Convert service ``RoleOption`` rows → the dicts the view/embed read."""
+    return [{"role_id": o.role_id, "emoji": o.emoji, "label": o.label} for o in options]
+
+
+# ---------------------------------------------------------------------------
+# Manager — list / new / edit / delete
+# ---------------------------------------------------------------------------
+
+
+class RoleMenuListView(BaseView):
+    """Lists a guild's role menus with New / Edit / Delete entry points."""
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        guild: discord.Guild,
+        channel: discord.abc.MessageableChannel,
+        parent: BaseView | None = None,
+    ) -> None:
+        super().__init__(author, timeout=300)
+        self.guild = guild
+        self.channel = channel
+        self.parent = parent
+        if parent is not None:
+
+            async def _build_parent(
+                _interaction: discord.Interaction,
+            ) -> tuple[discord.Embed, discord.ui.View]:
+                return await parent.build_embed(), parent  # type: ignore[attr-defined]
+
+            attach_back_button(
+                self,
+                label="↩ Back",
+                custom_id="role:menus:back",
+                parent_builder=_build_parent,
+                row=1,
+            )
+
+    async def build_embed(self) -> discord.Embed:
+        from services import reaction_role_service
+
+        menus = await reaction_role_service.list_menus(self.guild.id)
+        embed = discord.Embed(
+            title="🛠️ Role Menus",
+            color=presentation.theme_color(None),
+        )
+        if menus:
+            lines = []
+            for m in menus:
+                opts = await reaction_role_service.get_menu_options(int(m["menu_id"]))
+                posted = "📌 posted" if m.get("message_id") else "📝 draft"
+                lines.append(
+                    f"**{m['title']}** — {_STYLE_LABEL.get(m['style'], m['style'])}"
+                    f" · {m['mode']} · {len(opts)} role(s) · {posted}",
+                )
+            embed.description = "\n".join(lines)
+        else:
+            embed.description = (
+                "No role menus yet.\n\n"
+                "Tap **➕ New Menu** to build a button/dropdown self-role menu — the "
+                "modern alternative to emoji reaction roles."
+            )
+        embed.set_footer(text="Members self-assign with one tap; no reactions needed.")
+        return embed
+
+    async def _rerender(self) -> None:
+        if self.message:
+            await self.message.edit(embed=await self.build_embed(), view=self)
+
+    @discord.ui.button(label="➕ New Menu", style=discord.ButtonStyle.green, row=0)
+    async def new_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not _can_manage(interaction):
+            await _deny(interaction)
+            return
+        channel = _as_messageable(interaction.channel)
+        if channel is None:
+            await interaction.response.send_message(
+                "Open this in a server text channel so the menu can be posted there.",
+                ephemeral=True,
+            )
+            return
+        builder = RoleMenuBuilder(
+            interaction.user,
+            self.guild,
+            channel,
+            parent=self,
+        )
+        await interaction.response.edit_message(
+            embed=builder.build_embed(),
+            view=builder,
+        )
+        builder.message = interaction.message
+
+    @discord.ui.button(label="✏️ Edit", style=discord.ButtonStyle.blurple, row=0)
+    async def edit_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not _can_manage(interaction):
+            await _deny(interaction)
+            return
+        await self._pick_menu(interaction, self._open_editor, "Pick a menu to edit:")
+
+    @discord.ui.button(label="🗑️ Delete", style=discord.ButtonStyle.red, row=0)
+    async def delete_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not _can_manage(interaction):
+            await _deny(interaction)
+            return
+        await self._pick_menu(interaction, self._delete_menu, "Pick a menu to delete:")
+
+    async def _pick_menu(self, interaction, on_pick, prompt: str) -> None:  # type: ignore[no-untyped-def]
+        from services import reaction_role_service
+
+        menus = await reaction_role_service.list_menus(self.guild.id)
+        if not menus:
+            await interaction.response.send_message(
+                "There are no menus yet.",
+                ephemeral=True,
+            )
+            return
+        options = [
+            discord.SelectOption(
+                label=m["title"][:100],
+                value=str(m["menu_id"]),
+                description=f"{m['style']} · {m['mode']}"[:100],
+            )
+            for m in menus
+        ]
+        await interaction.response.send_message(
+            prompt,
+            view=PaginatedSelectView(
+                interaction.user,
+                options,
+                on_pick,
+                placeholder="Choose a menu…",
+            ),
+            ephemeral=True,
+        )
+
+    async def _open_editor(
+        self,
+        interaction: discord.Interaction,
+        values: list[str],
+    ) -> None:
+        from services import reaction_role_service
+
+        menu_id = int(values[0])
+        menu = await reaction_role_service.get_menu(menu_id)
+        if menu is None:
+            await interaction.response.send_message(
+                "That menu no longer exists.",
+                ephemeral=True,
+            )
+            return
+        opts = await reaction_role_service.get_menu_options(menu_id)
+        builder = RoleMenuBuilder.from_menu(
+            interaction.user,
+            self.guild,
+            menu,
+            opts,
+            parent=self,
+        )
+        await interaction.response.edit_message(content="Opening editor…", view=None)
+        if self.message:
+            await self.message.edit(embed=builder.build_embed(), view=builder)
+            builder.message = self.message
+
+    async def _delete_menu(
+        self,
+        interaction: discord.Interaction,
+        values: list[str],
+    ) -> None:
+        from services import reaction_role_service
+
+        menu_id = int(values[0])
+        menu = await reaction_role_service.get_menu(menu_id)
+        await reaction_role_service.delete_menu(
+            menu_id=menu_id,
+            guild_id=self.guild.id,
+            actor_id=interaction.user.id,
+        )
+        # Best-effort: remove the posted menu message too.
+        if menu and menu.get("message_id") and menu.get("channel_id"):
+            channel = resources.resolve_channel(
+                self.guild,
+                channel_id=int(menu["channel_id"]),
+            )
+            if isinstance(channel, discord.abc.Messageable):
+                try:
+                    message = await channel.fetch_message(int(menu["message_id"]))
+                    await message.delete()
+                except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+                    pass
+        await interaction.response.edit_message(
+            content="🗑️ Menu deleted.",
+            view=None,
+        )
+        await self._rerender()
+
+
+# ---------------------------------------------------------------------------
+# Builder — build a new menu or edit an existing one in place
+# ---------------------------------------------------------------------------
+
+
+class RoleMenuBuilder(BaseView):
+    """Compact preview panel for building / editing one role menu."""
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        guild: discord.Guild,
+        channel: _GuildMessageable | None,
+        *,
+        parent: BaseView | None = None,
+        menu_id: int | None = None,
+    ) -> None:
+        super().__init__(author, timeout=600)
+        self.guild = guild
+        self.channel = channel
+        self.parent = parent
+        self.menu_id = menu_id
+        # Draft state (dropdown default per owner decision §9 #2).
+        self.title = "Pick your roles"
+        self.description: str | None = None
+        self.style = "dropdown"
+        self.mode = "normal"
+        self.max_roles = 0
+        self.theme = presentation.DEFAULT_THEME_KEY
+        self.template: str | None = None
+        self.role_ids: list[int] = []
+
+        if parent is not None:
+
+            async def _build_parent(
+                _interaction: discord.Interaction,
+            ) -> tuple[discord.Embed, discord.ui.View]:
+                return await parent.build_embed(), parent  # type: ignore[attr-defined]
+
+            attach_back_button(
+                self,
+                label="↩ Back",
+                custom_id="role:builder:back",
+                parent_builder=_build_parent,
+                row=2,
+            )
+
+    @classmethod
+    def from_menu(
+        cls,
+        author: discord.Member | discord.User,
+        guild: discord.Guild,
+        menu: dict,
+        options: list,  # type: ignore[type-arg]
+        parent: BaseView | None = None,
+    ) -> RoleMenuBuilder:
+        """Load an existing menu's state into a fresh builder (edit-in-place)."""
+        channel = _as_messageable(
+            resources.resolve_channel(guild, channel_id=int(menu["channel_id"])),
+        )
+        builder = cls(
+            author,
+            guild,
+            channel,
+            parent=parent,
+            menu_id=int(menu["menu_id"]),
+        )
+        builder.title = menu["title"]
+        builder.description = menu.get("description")
+        builder.style = menu.get("style", "dropdown")
+        builder.mode = menu.get("mode", "normal")
+        builder.max_roles = int(menu.get("max_roles") or 0)
+        builder.theme = menu.get("theme") or presentation.DEFAULT_THEME_KEY
+        builder.template = menu.get("template")
+        builder.role_ids = [o.role_id for o in options]
+        return builder
+
+    # -- preview ------------------------------------------------------------
+
+    def build_embed(self) -> discord.Embed:
+        theme = presentation.get_theme(self.theme)
+        verb = "Editing" if self.menu_id else "Building"
+        embed = discord.Embed(
+            title=f"🛠️ {verb}: {self.title}",
+            description=self.description or "*(no description)*",
+            color=theme.color,
+        )
+        if self.role_ids:
+            names = []
+            for rid in self.role_ids:
+                role = resources.resolve_role(self.guild, role_id=rid)
+                names.append(role.mention if role else f"*(deleted {rid})*")
+            embed.add_field(name="Roles", value=", ".join(names), inline=False)
+        else:
+            embed.add_field(
+                name="Roles",
+                value="*none yet — tap 🏷️ Roles*",
+                inline=False,
+            )
+        limit = "unlimited" if not self.max_roles else str(self.max_roles)
+        embed.add_field(
+            name="Settings",
+            value=(
+                f"Style: **{_STYLE_LABEL.get(self.style, self.style)}**\n"
+                f"Mode: **{_MODE_LABEL.get(self.mode, self.mode)}**\n"
+                f"Limit: **{limit}** · Theme: **{theme.label}**"
+            ),
+            inline=False,
+        )
+        embed.set_footer(
+            text="Set the fields, then Post (new) or Save (edit). Roles required.",
+        )
+        return embed
+
+    async def _rerender(self) -> None:
+        if self.message:
+            await self.message.edit(embed=self.build_embed(), view=self)
+
+    # -- field editors ------------------------------------------------------
+
+    @discord.ui.button(label="📝 Text", style=discord.ButtonStyle.grey, row=0)
+    async def text_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await interaction.response.send_modal(_TextModal(self))
+
+    @discord.ui.button(label="🏷️ Roles", style=discord.ButtonStyle.grey, row=0)
+    async def roles_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        manageable, _excluded = role_feasibility.manageable_roles(
+            self.guild.roles,
+            bot_member=self.guild.me,
+            actor=(
+                interaction.user
+                if isinstance(interaction.user, discord.Member)
+                else None
+            ),
+        )
+        if not manageable:
+            await interaction.response.send_message(
+                "I can't manage any of this server's roles (they're all above my "
+                "highest role). Move my role up, then try again.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_message(
+            "Pick the roles this menu offers (up to 25):",
+            view=_RolePickView(self, manageable),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(label="🧩 Template", style=discord.ButtonStyle.grey, row=0)
+    async def template_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        options = [
+            discord.SelectOption(label=t.label[:100], value=t.key)
+            for t in presentation.templates()
+        ]
+        await interaction.response.send_message(
+            "Start from a template (you can still tweak everything):",
+            view=PaginatedSelectView(
+                interaction.user,
+                options,
+                self._apply_template,
+                placeholder="Pick a starter template…",
+            ),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(label="🎭 Theme", style=discord.ButtonStyle.grey, row=1)
+    async def theme_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        options = [
+            discord.SelectOption(
+                label=t.label,
+                value=t.key,
+                default=t.key == self.theme,
+            )
+            for t in presentation.themes()
+        ]
+        await interaction.response.send_message(
+            "Pick an embed theme:",
+            view=PaginatedSelectView(
+                interaction.user,
+                options,
+                self._apply_theme,
+                placeholder="Theme…",
+            ),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(label="⚙️ Mode", style=discord.ButtonStyle.grey, row=1)
+    async def mode_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        options = [
+            discord.SelectOption(label=_MODE_LABEL[m], value=m, default=m == self.mode)
+            for m in ("normal", "unique", "verify")
+        ]
+        await interaction.response.send_message(
+            "How should members pick from this menu?",
+            view=PaginatedSelectView(
+                interaction.user,
+                options,
+                self._apply_mode,
+                placeholder="Mode…",
+            ),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(label="🎚️ Style", style=discord.ButtonStyle.grey, row=1)
+    async def style_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        self.style = "button" if self.style == "dropdown" else "dropdown"
+        if not await safe_defer(interaction):
+            return
+        await self._rerender()
+
+    @discord.ui.button(label="🔢 Limit", style=discord.ButtonStyle.grey, row=1)
+    async def limit_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await interaction.response.send_modal(_LimitModal(self))
+
+    @discord.ui.button(label="🚀 Post", style=discord.ButtonStyle.green, row=2)
+    async def post_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not _can_manage(interaction):
+            await _deny(interaction)
+            return
+        if not self.role_ids:
+            await interaction.response.send_message(
+                "Add at least one role first (🏷️ Roles).",
+                ephemeral=True,
+            )
+            return
+        await self._commit(interaction)
+
+    # -- sub-step callbacks -------------------------------------------------
+
+    async def _apply_template(
+        self,
+        interaction: discord.Interaction,
+        values: list[str],
+    ) -> None:
+        tpl = presentation.get_template(values[0])
+        if tpl is not None:
+            self.title = tpl.title
+            self.description = tpl.description
+            self.theme = tpl.theme
+            self.style = tpl.style
+            self.template = tpl.key
+            if tpl.key == "colour_roles":
+                self.mode = "unique"
+            elif tpl.key == "verify":
+                self.mode = "verify"
+        await interaction.response.edit_message(
+            content="✓ Template applied.",
+            view=None,
+        )
+        await self._rerender()
+
+    async def _apply_theme(
+        self,
+        interaction: discord.Interaction,
+        values: list[str],
+    ) -> None:
+        self.theme = values[0]
+        await interaction.response.edit_message(content="✓ Theme set.", view=None)
+        await self._rerender()
+
+    async def _apply_mode(
+        self,
+        interaction: discord.Interaction,
+        values: list[str],
+    ) -> None:
+        self.mode = values[0]
+        await interaction.response.edit_message(content="✓ Mode set.", view=None)
+        await self._rerender()
+
+    # -- commit (Post new / Save edit) -------------------------------------
+
+    async def _commit(self, interaction: discord.Interaction) -> None:
+        from services import reaction_role_service
+        from services.reaction_role_service import RoleOption
+
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        # Snapshot the current role names as option labels so the rendered menu is
+        # self-describing without re-resolving the guild (role_thresholds precedent).
+        options = []
+        for rid in self.role_ids:
+            role = resources.resolve_role(self.guild, role_id=rid)
+            if role is None:
+                continue
+            options.append(RoleOption(role_id=rid, emoji=None, label=role.name))
+
+        if self.menu_id is None:
+            await self._post_new(interaction, reaction_role_service, options)
+        else:
+            await self._save_edit(interaction, reaction_role_service, options)
+
+    async def _post_new(self, interaction, service, options) -> None:  # type: ignore[no-untyped-def]
+        channel = self.channel
+        if channel is None:
+            await interaction.followup.send(
+                "I can't find a channel to post this menu in — re-open the builder "
+                "in a text channel.",
+                ephemeral=True,
+            )
+            return
+        menu_id = await service.create_menu(
+            guild_id=self.guild.id,
+            channel_id=channel.id,
+            title=self.title,
+            description=self.description,
+            style=self.style,
+            mode=self.mode,
+            max_roles=self.max_roles,
+            options=options,
+            theme=self.theme,
+            actor_id=interaction.user.id,
+        )
+        menu = await service.get_menu(menu_id)
+        opt_dicts = _option_dicts(await service.get_menu_options(menu_id))
+        view = RoleMenuView(menu, opt_dicts)
+        try:
+            message = await channel.send(
+                embed=build_menu_embed(menu, opt_dicts, self.guild),
+                view=view,
+            )
+        except discord.Forbidden:
+            await interaction.followup.send(
+                "I couldn't post the menu — I lack permission to send messages here.",
+                ephemeral=True,
+            )
+            return
+        await service.set_menu_message(menu_id, message.id)
+        interaction.client.add_view(view, message_id=message.id)
+        await interaction.followup.send(
+            f"🚀 Posted **{self.title}** to {channel.mention}.",
+            ephemeral=True,
+        )
+        if self.parent is not None and self.message:
+            await self.message.edit(
+                embed=await self.parent.build_embed(),  # type: ignore[attr-defined]
+                view=self.parent,
+            )
+
+    async def _save_edit(self, interaction, service, options) -> None:  # type: ignore[no-untyped-def]
+        if self.menu_id is None:  # pragma: no cover - guarded by _commit
+            return
+        await service.update_menu(
+            menu_id=self.menu_id,
+            guild_id=self.guild.id,
+            title=self.title,
+            description=self.description,
+            style=self.style,
+            mode=self.mode,
+            max_roles=self.max_roles,
+            options=options,
+            theme=self.theme,
+            actor_id=interaction.user.id,
+        )
+        menu = await service.get_menu(self.menu_id)
+        opt_dicts = _option_dicts(await service.get_menu_options(self.menu_id))
+        view = RoleMenuView(menu, opt_dicts)
+        edited = False
+        if menu and menu.get("message_id") and menu.get("channel_id"):
+            channel = resources.resolve_channel(
+                self.guild,
+                channel_id=int(menu["channel_id"]),
+            )
+            if isinstance(channel, discord.abc.Messageable):
+                try:
+                    message = await channel.fetch_message(int(menu["message_id"]))
+                    await message.edit(
+                        embed=build_menu_embed(menu, opt_dicts, self.guild),
+                        view=view,
+                    )
+                    interaction.client.add_view(view, message_id=message.id)
+                    edited = True
+                except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+                    edited = False
+        result_text = (
+            "💾 Saved — the live menu was updated."
+            if edited
+            else "💾 Saved. (The posted message couldn't be edited; re-post if needed.)"
+        )
+        await interaction.followup.send(result_text, ephemeral=True)
+        if self.parent is not None and self.message:
+            await self.message.edit(
+                embed=await self.parent.build_embed(),  # type: ignore[attr-defined]
+                view=self.parent,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Sub-views + modals
+# ---------------------------------------------------------------------------
+
+
+class _RolePickView(BaseView):
+    """Ephemeral windowed multi-role picker feeding the builder draft."""
+
+    def __init__(self, builder: RoleMenuBuilder, roles: list[discord.Role]) -> None:
+        super().__init__(builder._author, timeout=180)
+        self.builder = builder
+        attach_multi_role_select(
+            self,
+            roles,
+            self._on_pick,
+            placeholder="Select the menu's roles…",
+            max_values=min(len(roles), 25),
+        )
+
+    async def _on_pick(
+        self,
+        interaction: discord.Interaction,
+        role_ids: list[int],
+    ) -> None:
+        # The windowed multi-select already caps a page's selection; bound the
+        # stored set to a menu's hard role cap (Discord's 25 component/option max).
+        self.builder.role_ids = role_ids[:MAX_MENU_ROLES]
+        await interaction.response.edit_message(
+            content=f"✓ {len(self.builder.role_ids)} role(s) selected.",
+            view=None,
+        )
+        await self.builder._rerender()
+
+
+class _TextModal(discord.ui.Modal, title="Menu text"):  # type: ignore[call-arg]
+    title_in = discord.ui.TextInput(  # type: ignore[var-annotated]
+        label="Title",
+        placeholder="Pick your roles",
+        max_length=100,
+    )
+    desc_in = discord.ui.TextInput(  # type: ignore[var-annotated]
+        label="Description",
+        style=discord.TextStyle.paragraph,
+        required=False,
+        max_length=2000,
+    )
+
+    def __init__(self, builder: RoleMenuBuilder) -> None:
+        super().__init__()
+        self.builder = builder
+        self.title_in.default = builder.title
+        self.desc_in.default = builder.description or ""
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        self.builder.title = self.title_in.value.strip() or "Pick your roles"
+        self.builder.description = self.desc_in.value.strip() or None
+        if not await safe_defer(interaction):
+            return
+        await self.builder._rerender()
+
+
+class _LimitModal(discord.ui.Modal, title="Per-member limit"):  # type: ignore[call-arg]
+    limit_in = discord.ui.TextInput(  # type: ignore[var-annotated]
+        label="Max roles a member can pick (0 = unlimited)",
+        placeholder="0",
+        max_length=2,
+        required=False,
+    )
+
+    def __init__(self, builder: RoleMenuBuilder) -> None:
+        super().__init__()
+        self.builder = builder
+        self.limit_in.default = str(builder.max_roles)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        raw = self.limit_in.value.strip()
+        try:
+            value = max(0, int(raw)) if raw else 0
+        except ValueError:
+            await interaction.response.send_message(
+                "❌ Enter a whole number (0 for unlimited).",
+                ephemeral=True,
+            )
+            return
+        self.builder.max_roles = value
+        if not await safe_defer(interaction):
+            return
+        await self.builder._rerender()
+
+
+__all__ = ["RoleMenuBuilder", "RoleMenuListView"]

--- a/disbot/views/roles/role_menu_view.py
+++ b/disbot/views/roles/role_menu_view.py
@@ -1,0 +1,366 @@
+"""The member-facing role menu — a restart-durable button/dropdown self-role panel.
+
+This is the modern surface Carl-bot lacks at its core (plan §4 PR 2 / Surface B):
+a public message anyone can click to self-assign roles, with **server-side** mode
+enforcement (``unique`` / ``verify`` / ``max_roles``) and an **ephemeral**
+confirmation — no stale reactions, no "un-react to remove" confusion.
+
+It is a :class:`PersistentView` so it survives restarts: every component carries a
+static ``role_menu:{menu_id}:…`` custom_id, and :func:`reattach_role_menus` re-binds
+a fresh view to each posted menu message at boot. The view holds only the menu's
+*immutable config* (menu id + the option list), never per-user state — every click
+acts on ``interaction.user`` and the authoritative menu row is re-read inside the
+audited service.
+
+All assignment goes through :mod:`services.reaction_role_service`; this module is a
+thin UI over that seam (no DB writes, no role math here).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord.ext import commands
+
+from core.runtime import resources
+from core.runtime.persistent_views import PersistentView
+from utils import role_menu_presentation as presentation
+from views.base import handle_view_error
+
+logger = logging.getLogger("bot.views.role_menu")
+
+# Discord caps a select at 25 options and a view at 25 components (5×5 buttons),
+# so a menu offers at most this many roles (the builder enforces it too).
+MAX_MENU_ROLES = 25
+
+
+def build_menu_embed(
+    menu: dict,
+    options: list[dict],
+    guild: discord.Guild,
+) -> discord.Embed:
+    """Render a menu row + its options into its themed embed."""
+    theme = presentation.get_theme(menu.get("theme"))
+    embed = discord.Embed(
+        title=menu.get("title") or "Pick your roles",
+        description=menu.get("description") or None,
+        color=theme.color,
+    )
+
+    lines: list[str] = []
+    for opt in options:
+        role = resources.resolve_role(guild, role_id=int(opt["role_id"]))
+        if role is None:
+            continue
+        emoji = opt.get("emoji")
+        prefix = f"{emoji} " if emoji else ""
+        label = opt.get("label") or role.name
+        lines.append(
+            (
+                f"{prefix}{role.mention} — {label}"
+                if opt.get("label")
+                else f"{prefix}{role.mention}"
+            ),
+        )
+    if lines:
+        embed.add_field(name="Roles", value="\n".join(lines), inline=False)
+
+    mode = menu.get("mode", "normal")
+    max_roles = int(menu.get("max_roles") or 0)
+    hint = {
+        "unique": "Pick one — choosing another swaps it.",
+        "verify": "Tap to claim — this menu only ever adds a role.",
+    }.get(mode)
+    if not hint and max_roles:
+        hint = f"You can hold up to {max_roles} of these roles."
+    embed.set_footer(text=hint or theme.footer or "Pick the roles you want.")
+    return embed
+
+
+def _select_bounds(mode: str, max_roles: int, option_count: int) -> tuple[int, int]:
+    """Return ``(min_values, max_values)`` for a dropdown given the menu's mode."""
+    if mode == "unique":
+        max_values = 1
+    elif max_roles:
+        max_values = min(max_roles, option_count)
+    else:
+        max_values = option_count
+    return 0, max(1, min(max_values, MAX_MENU_ROLES))
+
+
+class _RoleButton(discord.ui.Button):
+    """One role-per-button toggle (the ``style='button'`` surface)."""
+
+    def __init__(
+        self,
+        menu_id: int,
+        role_id: int,
+        label: str,
+        emoji: str | None,
+    ) -> None:
+        super().__init__(
+            label=label[:80],
+            emoji=emoji or None,
+            style=discord.ButtonStyle.secondary,
+            custom_id=f"role_menu:{menu_id}:role:{role_id}",
+        )
+        self._menu_id = menu_id
+        self._role_id = role_id
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await _handle_toggle(interaction, self._menu_id, self._role_id)
+
+
+class _RoleSelect(discord.ui.Select):
+    """The multi-select dropdown surface (the default)."""
+
+    def __init__(
+        self,
+        menu_id: int,
+        options: list[discord.SelectOption],
+        *,
+        min_values: int,
+        max_values: int,
+    ) -> None:
+        super().__init__(
+            custom_id=f"role_menu:{menu_id}:select",
+            placeholder="Pick your roles…",
+            min_values=min_values,
+            max_values=max_values,
+            options=options or [discord.SelectOption(label="— no roles —", value="0")],
+            disabled=not options,
+        )
+        self._menu_id = menu_id
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        selected = [int(v) for v in self.values if v != "0"]
+        await _handle_selection(interaction, self._menu_id, selected)
+
+
+class RoleMenuView(PersistentView):
+    """A restart-durable self-role menu rendered from a ``role_menus`` row.
+
+    Construct with the menu row + its option rows. The no-argument form yields an
+    empty view; real instances come from :func:`reattach_role_menus` and the
+    builder's Post.
+
+    NOT registered in the persistent-view anchor registry (no ``register()``):
+    a role menu is a **public, data-driven message** (one persistent view per
+    ``role_menus`` row), re-bound at boot by :func:`reattach_role_menus` keyed on
+    the table — unlike the per-user, anchor-owned hub panels the registry's
+    ``restore_anchors`` path is for (``RoleHubPanelView`` owns ``SUBSYSTEM='role'``
+    there). Registering it would both collide with that key and trip the
+    identity-contract ``SUBSYSTEMS`` parity check. Persistence still works: each
+    component carries a static ``role_menu:{menu_id}:*`` custom_id and the view is
+    bound with ``bot.add_view(..., message_id=...)``.
+    """
+
+    # The menu is a public, shared message — any member self-assigns — so the
+    # anchor-ownership check in PersistentView does not apply (overridden below).
+
+    def __init__(
+        self,
+        menu: dict | None = None,
+        options: list[dict] | None = None,
+    ) -> None:
+        super().__init__()
+        self.menu = menu
+        self.options = options or []
+        if menu is None:
+            return
+        menu_id = int(menu["menu_id"])
+        style = menu.get("style", "dropdown")
+        if style == "button":
+            self._build_buttons(menu_id)
+        else:
+            self._build_select(menu_id)
+
+    def _build_buttons(self, menu_id: int) -> None:
+        for opt in self.options[:MAX_MENU_ROLES]:
+            label = opt.get("label") or f"Role {opt['role_id']}"
+            self.add_item(
+                _RoleButton(menu_id, int(opt["role_id"]), label, opt.get("emoji")),
+            )
+
+    def _build_select(self, menu_id: int) -> None:
+        if self.menu is None:  # pragma: no cover - guarded by __init__
+            return
+        select_options: list[discord.SelectOption] = []
+        for opt in self.options[:MAX_MENU_ROLES]:
+            select_options.append(
+                discord.SelectOption(
+                    label=(opt.get("label") or f"Role {opt['role_id']}")[:100],
+                    value=str(opt["role_id"]),
+                    emoji=opt.get("emoji") or None,
+                ),
+            )
+        min_values, max_values = _select_bounds(
+            self.menu.get("mode", "normal"),
+            int(self.menu.get("max_roles") or 0),
+            len(select_options),
+        )
+        self.add_item(
+            _RoleSelect(
+                menu_id,
+                select_options,
+                min_values=min_values,
+                max_values=max_values,
+            ),
+        )
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        """Public menu — any guild member may self-assign (no ownership gate)."""
+        return interaction.guild is not None and isinstance(
+            interaction.user,
+            discord.Member,
+        )
+
+    async def on_error(
+        self,
+        interaction: discord.Interaction,
+        error: Exception,
+        item: discord.ui.Item,  # type: ignore[type-arg]
+    ) -> None:
+        await handle_view_error(self, interaction, error, item)
+
+
+# ---------------------------------------------------------------------------
+# Interaction handlers (shared by both surfaces) — thin over the audited service
+# ---------------------------------------------------------------------------
+
+
+async def _handle_toggle(
+    interaction: discord.Interaction,
+    menu_id: int,
+    role_id: int,
+) -> None:
+    from services import reaction_role_service
+
+    member, guild = _require_member(interaction)
+    if member is None or guild is None:
+        return
+    outcome = await reaction_role_service.toggle_role(
+        menu_id=menu_id,
+        member=member,
+        guild=guild,
+        clicked_role_id=role_id,
+    )
+    await interaction.response.send_message(
+        _format_outcome(guild, outcome),
+        ephemeral=True,
+    )
+
+
+async def _handle_selection(
+    interaction: discord.Interaction,
+    menu_id: int,
+    selected_ids: list[int],
+) -> None:
+    from services import reaction_role_service
+
+    member, guild = _require_member(interaction)
+    if member is None or guild is None:
+        return
+    outcome = await reaction_role_service.apply_selection(
+        menu_id=menu_id,
+        member=member,
+        guild=guild,
+        selected_ids=selected_ids,
+    )
+    await interaction.response.send_message(
+        _format_outcome(guild, outcome),
+        ephemeral=True,
+    )
+
+
+def _require_member(
+    interaction: discord.Interaction,
+) -> tuple[discord.Member | None, discord.Guild | None]:
+    if interaction.guild is None or not isinstance(interaction.user, discord.Member):
+        return None, None
+    return interaction.user, interaction.guild
+
+
+def _format_outcome(guild: discord.Guild, outcome) -> str:  # type: ignore[no-untyped-def]
+    """Turn a service ``RoleMenuOutcome`` into an ephemeral confirmation string."""
+
+    def names(ids: tuple[int, ...]) -> str:
+        out = []
+        for rid in ids:
+            role = resources.resolve_role(guild, role_id=rid)
+            out.append(f"**{role.name}**" if role else f"role {rid}")
+        return ", ".join(out)
+
+    parts: list[str] = []
+    if outcome.added:
+        parts.append(f"✅ Added {names(outcome.added)}")
+    if outcome.removed:
+        parts.append(f"➖ Removed {names(outcome.removed)}")
+    if outcome.note:
+        parts.append(f"⚠️ {outcome.note}")
+    if not parts:
+        return "No changes."
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Restart recovery — re-bind a fresh view to every posted menu message at boot
+# ---------------------------------------------------------------------------
+
+_REATTACHED_ONCE = False
+
+
+def reset_reattach_state() -> None:
+    """Clear the once-guard so the next :func:`reattach_role_menus` runs (tests)."""
+    global _REATTACHED_ONCE
+    _REATTACHED_ONCE = False
+
+
+async def reattach_role_menus(bot: commands.Bot) -> int:
+    """Re-bind a :class:`RoleMenuView` to every posted menu so clicks survive a restart.
+
+    Mirrors ``message_anchor_manager.restore_anchors`` but keyed on the
+    ``role_menus`` rows (each menu is a public, data-driven message rather than a
+    per-user anchor). Idempotent: a no-op after the first call so an ``on_ready``
+    re-fire on gateway reconnect doesn't double-bind.
+    """
+    global _REATTACHED_ONCE
+    if _REATTACHED_ONCE:
+        return 0
+    _REATTACHED_ONCE = True
+
+    from services import reaction_role_service
+
+    menus = await reaction_role_service.list_posted_menus()
+    restored = 0
+    for menu in menus:
+        message_id = menu.get("message_id")
+        if not message_id:
+            continue
+        try:
+            opts = await reaction_role_service.get_menu_options(int(menu["menu_id"]))
+            options = [
+                {"role_id": o.role_id, "emoji": o.emoji, "label": o.label} for o in opts
+            ]
+            bot.add_view(RoleMenuView(menu, options), message_id=int(message_id))
+            restored += 1
+        except Exception as exc:
+            logger.warning(
+                "reattach_role_menus: could not re-bind menu %s (msg=%s): %s",
+                menu.get("menu_id"),
+                message_id,
+                exc,
+            )
+    if restored:
+        logger.info("reattach_role_menus: re-bound %d role menu(s)", restored)
+    return restored
+
+
+__all__ = [
+    "MAX_MENU_ROLES",
+    "RoleMenuView",
+    "build_menu_embed",
+    "reattach_role_menus",
+    "reset_reattach_state",
+]

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,12 +25,6 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/vibrant-sagan-0rr5u7` · **reaction-roles PR 2** — in-Discord role-menu builder (Surface B):
-  `views/roles/role_menu_view.py` (RoleMenuView) + `views/roles/role_menu_builder.py` +
-  `utils/role_menu_presentation.py` + re-attach in `bot1` · **depends on PR 1 (parallel)**; carries a
-  to-spec copy of migration 078 / `utils/db/role_menus.py` / `reaction_role_service.py` for self-contained
-  CI — reconcile onto PR 1 before green · 2026-06-21 · **HOLD until PR 1 merges**
-
 - `claude/clever-maxwell-690qrj` · **Pokétwo + MusicBot research report → feature-mapping plan**
   (docs-only, owner-steered plan-only) · `docs/planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md`
   + `docs/planning/voice-music-architecture-review-2026-06-20.md` + `docs/ideas/` + router Q-0186 ·
@@ -52,10 +46,15 @@ living ledger (`docs/current-state.md`).
   data layer** (owner-directed; foundation for the parallel PR 2–5 session — see
   `docs/planning/reaction-roles-overhaul-plan-2026-06-21.md`) · `services/reaction_role_service.py`
   + `utils/db/role_menus.py` + migration `078_reaction_role_menus.sql` + `cogs/role_cog.py` (route
-  writes through the seam) + `guild_lifecycle.py` (teardown step 23) · 2026-06-21 · **auto-merge on
-  green** (additive · behaviour-preserving). **Parallel session owns PR 2–5; do not recreate these.**
+  writes through the seam) + `guild_lifecycle.py` (teardown step 23) · 2026-06-21 · **PR #1220 (merged)**.
 
 ## Recently cleared
+
+- `claude/vibrant-sagan-0rr5u7` · **reaction-roles PR 2** — in-Discord role-menu builder (Surface B):
+  `RoleMenuView` + builder/manager + theme/template presets + edit-in-place + `reattach_role_menus`,
+  on PR 1's seam (reconciled onto #1220) · 2026-06-21 · **PR #1219 (`needs-hermes-review`)**
+- `claude/reaction-roles-pr1-foundation` · reaction-roles PR 1 foundation (audited seam + menu data
+  layer + teardown) · 2026-06-21 · **PR #1220 (merged)**
 
 - `claude/design-system-connector-docs` · design-system docs — GitHub-connector workflow + new
   AGENT_ORIENTATION website route · 2026-06-20 · **PR #1176 (merged)**

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,12 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/vibrant-sagan-0rr5u7` · **reaction-roles PR 2** — in-Discord role-menu builder (Surface B):
+  `views/roles/role_menu_view.py` (RoleMenuView) + `views/roles/role_menu_builder.py` +
+  `utils/role_menu_presentation.py` + re-attach in `bot1` · **depends on PR 1 (parallel)**; carries a
+  to-spec copy of migration 078 / `utils/db/role_menus.py` / `reaction_role_service.py` for self-contained
+  CI — reconcile onto PR 1 before green · 2026-06-21 · **HOLD until PR 1 merges**
+
 - `claude/clever-maxwell-690qrj` · **Pokétwo + MusicBot research report → feature-mapping plan**
   (docs-only, owner-steered plan-only) · `docs/planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md`
   + `docs/planning/voice-music-architecture-review-2026-06-20.md` + `docs/ideas/` + router Q-0186 ·

--- a/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
+++ b/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
@@ -1,8 +1,18 @@
 # Reaction Roles — Carl-bot parity + modern role-menu overhaul
 
-> **Status:** `plan` — buildable spec (2026-06-21). Cross-check source before implementing;
+> **Status:** `plan` — buildable spec (2026-06-21), PR 1 merged + PR 2 in flight (see Build progress).
+> Cross-check source before implementing;
 > `docs/current-state.md` owns what is live. **Sector:** S1 — Bot product. **Folio:**
 > [`docs/subsystems/server-management.md`](../subsystems/server-management.md).
+>
+> **▶ Build progress (2026-06-21):** **PR 1 MERGED (#1220)** — audited `reaction_role_service` seam +
+> `utils/db/role_menus` data layer + migration 078 + cog routing + teardown. **PR 2 IN FLIGHT
+> (#1219, `needs-hermes-review`)** — the in-Discord builder (Surface B): `RoleMenuView` (dropdown
+> default, server-side modes, restart re-attach) + the operator builder/manager with edit-in-place +
+> theme presets + template gallery; all on PR 1's seam. **Next: PR 3** (Carl-parity modes on the emoji
+> surface + interactive emoji panel + settings bridge) · **PR 4** (free temp roles — `role_grants`
+> migration **079** + expiry sweep loop) · **PR 5** (role-pickup analytics §10) · **PR 6** optional
+> (PIL banner cards §4.6d).
 >
 > **One-line goal:** bring SuperBot's self-assignable-role surface to **parity-plus** with
 > Carl-bot — lead with native **buttons + dropdown menus** (Carl's are a secondary/premium

--- a/tests/unit/db/test_role_menus_integration.py
+++ b/tests/unit/db/test_role_menus_integration.py
@@ -1,0 +1,83 @@
+"""Real-Postgres integration for the PR 2 additions to utils.db.role_menus.
+
+PR 1's ``test_role_menus.py`` covers the base CRUD; this file exercises only the
+two helpers PR 2 adds — ``replace_options`` (transactional full-list replace, the
+builder's create/edit path) and ``list_posted_menus`` (the boot re-attach query).
+
+CI safety: no shared Postgres fixture and CI runs no Postgres service, so the
+module-local ``postgres_pool`` fixture ``pytest.skip()``s when ``DATABASE_URL`` is
+unset (CI) or the DB is unreachable. Isolation: rows live under a reserved test
+``guild_id`` swept on entry + exit.
+"""
+
+from __future__ import annotations
+
+import os
+
+import asyncpg
+import pytest
+import pytest_asyncio
+
+from utils.db import pool
+from utils.db import role_menus as menus
+
+_TEST_GUILD = 9_000_000_000_000_000_078
+
+
+async def _sweep() -> None:
+    await pool.execute("DELETE FROM role_menus WHERE guild_id=$1", (_TEST_GUILD,))
+
+
+@pytest_asyncio.fixture
+async def postgres_pool():
+    if not os.environ.get("DATABASE_URL"):
+        pytest.skip("DATABASE_URL unset — real-Postgres integration test skipped (CI)")
+    try:
+        await pool.init()
+    except (OSError, asyncpg.PostgresError) as exc:
+        pytest.skip(f"Postgres unreachable ({type(exc).__name__}) — skipped")
+    await _sweep()
+    try:
+        yield pool
+    finally:
+        await _sweep()
+        await pool.close()
+
+
+async def _new_menu() -> int:
+    return await menus.create_menu(
+        _TEST_GUILD,
+        123,
+        title="A",
+        description=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_replace_options_sets_ordered_list(postgres_pool):
+    menu_id = await _new_menu()
+    await menus.replace_options(menu_id, [(10, None, "Gamer"), (20, "🎨", "Artist")])
+    opts = await menus.get_options(menu_id)
+    assert [o["role_id"] for o in opts] == [10, 20]  # position order preserved
+    assert opts[1]["emoji"] == "🎨"
+
+
+@pytest.mark.asyncio
+async def test_replace_options_replaces_and_dedupes(postgres_pool):
+    menu_id = await _new_menu()
+    await menus.replace_options(menu_id, [(10, None, None), (20, None, None)])
+    # Replace with a new set that also contains a duplicate role id.
+    await menus.replace_options(menu_id, [(30, None, None), (30, None, None)])
+    opts = await menus.get_options(menu_id)
+    assert [o["role_id"] for o in opts] == [30]  # replaced + deduped
+
+
+@pytest.mark.asyncio
+async def test_list_posted_menus_only_after_message_set(postgres_pool):
+    menu_id = await _new_menu()
+    posted_ids = {m["menu_id"] for m in await menus.list_posted_menus()}
+    assert menu_id not in posted_ids  # not posted yet
+
+    await menus.set_menu_message(menu_id, 7777)
+    posted_ids = {m["menu_id"] for m in await menus.list_posted_menus()}
+    assert menu_id in posted_ids

--- a/tests/unit/services/test_reaction_role_service_menus.py
+++ b/tests/unit/services/test_reaction_role_service_menus.py
@@ -1,0 +1,284 @@
+"""Tests for the PR 2 role-menu methods of services.reaction_role_service.
+
+(PR 1's emoji-binding methods are covered by ``test_reaction_role_service.py``.)
+Covers, CI-safe with no DB: server-side mode enforcement (normal / unique /
+verify / max_roles) for both the button (``toggle_role``) and dropdown
+(``apply_selection``) surfaces, and that menu *config* changes emit
+``audit.action_recorded`` while member self-assignment does not.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services import reaction_role_service as svc
+
+# ---------------------------------------------------------------------------
+# Minimal Discord fakes (positions chosen so the bot can manage every role)
+# ---------------------------------------------------------------------------
+
+
+class FakeRole:
+    def __init__(self, rid: int, *, position: int = 1, name: str = "Role") -> None:
+        self.id = rid
+        self.position = position
+        self.name = name
+        self.managed = False
+
+    def is_default(self) -> bool:
+        return False
+
+    @property
+    def mention(self) -> str:
+        return f"<@&{self.id}>"
+
+
+class FakeMember:
+    def __init__(self, roles: list[FakeRole]) -> None:
+        self.roles = roles
+        self.add_roles = AsyncMock()
+        self.remove_roles = AsyncMock()
+
+
+class FakeGuild:
+    def __init__(self, roles: list[FakeRole]) -> None:
+        self._roles = {r.id: r for r in roles}
+        # Bot top-role well above the menu roles → everything is manageable.
+        self.me = SimpleNamespace(
+            top_role=FakeRole(99999, position=100, name="Bot"),
+            guild_permissions=SimpleNamespace(manage_roles=True),
+        )
+
+    def get_role(self, rid: int) -> FakeRole | None:
+        return self._roles.get(rid)
+
+
+def _menu(mode: str = "normal", max_roles: int = 0) -> dict:
+    return {"menu_id": 1, "mode": mode, "max_roles": max_roles, "style": "dropdown"}
+
+
+def _patch_menu(menu: dict, option_ids: list[int]):
+    opts = [{"role_id": rid} for rid in option_ids]
+    return (
+        patch.object(svc.menus_db, "get_menu", new=AsyncMock(return_value=menu)),
+        patch.object(svc.menus_db, "get_options", new=AsyncMock(return_value=opts)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# toggle_role — the button surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_toggle_adds_role_when_absent():
+    guild = FakeGuild([FakeRole(10), FakeRole(20)])
+    member = FakeMember(roles=[])
+    p1, p2 = _patch_menu(_menu("normal"), [10, 20])
+    with p1, p2:
+        out = await svc.toggle_role(
+            menu_id=1, member=member, guild=guild, clicked_role_id=10
+        )
+    assert out.added == (10,)
+    assert out.removed == ()
+    member.add_roles.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_toggle_removes_role_when_held():
+    held = FakeRole(10)
+    guild = FakeGuild([held, FakeRole(20)])
+    member = FakeMember(roles=[held])
+    p1, p2 = _patch_menu(_menu("normal"), [10, 20])
+    with p1, p2:
+        out = await svc.toggle_role(
+            menu_id=1, member=member, guild=guild, clicked_role_id=10
+        )
+    assert out.removed == (10,)
+    assert out.added == ()
+    member.remove_roles.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_toggle_unique_clears_sibling():
+    a, b = FakeRole(10), FakeRole(20)
+    guild = FakeGuild([a, b])
+    member = FakeMember(roles=[a])  # already holds the sibling
+    p1, p2 = _patch_menu(_menu("unique"), [10, 20])
+    with p1, p2:
+        out = await svc.toggle_role(
+            menu_id=1, member=member, guild=guild, clicked_role_id=20
+        )
+    assert out.added == (20,)
+    assert out.removed == (10,)  # sibling cleared
+
+
+@pytest.mark.asyncio
+async def test_toggle_verify_never_removes():
+    held = FakeRole(10)
+    guild = FakeGuild([held])
+    member = FakeMember(roles=[held])
+    p1, p2 = _patch_menu(_menu("verify"), [10])
+    with p1, p2:
+        out = await svc.toggle_role(
+            menu_id=1, member=member, guild=guild, clicked_role_id=10
+        )
+    assert out.added == ()
+    assert out.removed == ()
+    assert "verify" in out.note.lower()
+    member.remove_roles.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_toggle_max_roles_blocks_extra_pick():
+    a, b = FakeRole(10), FakeRole(20)
+    guild = FakeGuild([a, b])
+    member = FakeMember(roles=[a])  # already at the cap of 1
+    p1, p2 = _patch_menu(_menu("normal", max_roles=1), [10, 20])
+    with p1, p2:
+        out = await svc.toggle_role(
+            menu_id=1, member=member, guild=guild, clicked_role_id=20
+        )
+    assert out.added == ()
+    assert out.blocked == (20,)
+    member.add_roles.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_toggle_unknown_role_is_rejected():
+    guild = FakeGuild([FakeRole(10)])
+    member = FakeMember(roles=[])
+    p1, p2 = _patch_menu(_menu("normal"), [10])
+    with p1, p2:
+        out = await svc.toggle_role(
+            menu_id=1, member=member, guild=guild, clicked_role_id=999
+        )
+    assert not out.changed
+    member.add_roles.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# apply_selection — the dropdown surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_selection_reconciles_add_and_remove():
+    a, b, c = FakeRole(10), FakeRole(20), FakeRole(30)
+    guild = FakeGuild([a, b, c])
+    member = FakeMember(roles=[a])  # holds A
+    p1, p2 = _patch_menu(_menu("normal"), [10, 20, 30])
+    with p1, p2:
+        out = await svc.apply_selection(
+            menu_id=1, member=member, guild=guild, selected_ids=[20, 30]
+        )
+    assert set(out.added) == {20, 30}
+    assert out.removed == (10,)  # A deselected
+
+
+@pytest.mark.asyncio
+async def test_apply_selection_verify_only_adds():
+    a, b = FakeRole(10), FakeRole(20)
+    guild = FakeGuild([a, b])
+    member = FakeMember(roles=[a])
+    p1, p2 = _patch_menu(_menu("verify"), [10, 20])
+    with p1, p2:
+        out = await svc.apply_selection(
+            menu_id=1, member=member, guild=guild, selected_ids=[20]
+        )
+    assert out.added == (20,)
+    assert out.removed == ()  # verify never removes the held role
+
+
+@pytest.mark.asyncio
+async def test_apply_selection_unique_keeps_one():
+    a, b = FakeRole(10), FakeRole(20)
+    guild = FakeGuild([a, b])
+    member = FakeMember(roles=[])
+    p1, p2 = _patch_menu(_menu("unique"), [10, 20])
+    with p1, p2:
+        out = await svc.apply_selection(
+            menu_id=1, member=member, guild=guild, selected_ids=[10, 20]
+        )
+    # Unique caps the desired set to one role.
+    assert len(out.added) == 1
+
+
+# ---------------------------------------------------------------------------
+# Config writes are audited; member assignment is not
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_menu_emits_audit_and_validates():
+    with (
+        patch.object(
+            svc.menus_db, "create_menu", new=AsyncMock(return_value=7)
+        ) as create,
+        patch.object(svc.menus_db, "replace_options", new=AsyncMock()) as setopts,
+        patch(
+            "services.audit_events.emit_audit_action",
+            new=AsyncMock(return_value=True),
+        ) as audit,
+    ):
+        menu_id = await svc.create_menu(
+            guild_id=1,
+            channel_id=2,
+            title="Roles",
+            description=None,
+            style="bogus",  # invalid → coerced
+            mode="weird",  # invalid → coerced
+            max_roles=-5,  # clamped to 0
+            options=[svc.RoleOption(10), svc.RoleOption(20)],
+            actor_id=99,
+        )
+    assert menu_id == 7
+    setopts.assert_awaited_once()
+    # invalid style/mode coerced; negative limit clamped.
+    assert create.await_args.kwargs["style"] == "dropdown"
+    assert create.await_args.kwargs["mode"] == "normal"
+    assert create.await_args.kwargs["max_roles"] == 0
+    audit.assert_awaited_once()
+    kw = audit.await_args.kwargs
+    assert kw["subsystem"] == "role"
+    assert kw["mutation_type"] == "create_role_menu"
+    assert kw["target"] == "role_menu:7"
+    assert kw["guild_id"] == 1
+    assert kw["actor_id"] == 99
+
+
+@pytest.mark.asyncio
+async def test_delete_menu_emits_audit():
+    with (
+        patch.object(
+            svc.menus_db,
+            "get_menu",
+            new=AsyncMock(return_value={"menu_id": 5, "title": "Old"}),
+        ),
+        patch.object(svc.menus_db, "delete_menu", new=AsyncMock()) as delete,
+        patch(
+            "services.audit_events.emit_audit_action",
+            new=AsyncMock(return_value=True),
+        ) as audit,
+    ):
+        await svc.delete_menu(menu_id=5, guild_id=1, actor_id=99)
+    delete.assert_awaited_once_with(5)
+    kw = audit.await_args.kwargs
+    assert kw["mutation_type"] == "delete_role_menu"
+    assert kw["new_value"] is None
+
+
+@pytest.mark.asyncio
+async def test_toggle_does_not_emit_audit():
+    """Member self-assignment is high-volume + opt-in — never auto-audited (§9)."""
+    guild = FakeGuild([FakeRole(10)])
+    member = FakeMember(roles=[])
+    p1, p2 = _patch_menu(_menu("normal"), [10])
+    with p1, p2, patch("services.audit_events.emit_audit_action") as audit:
+        await svc.toggle_role(
+            menu_id=1, member=member, guild=guild, clicked_role_id=10
+        )
+    audit.assert_not_called()

--- a/tests/unit/utils/test_role_menu_presentation.py
+++ b/tests/unit/utils/test_role_menu_presentation.py
@@ -1,0 +1,47 @@
+"""Tests for utils.role_menu_presentation — theme + template catalogues (§4.6 b/c)."""
+
+from __future__ import annotations
+
+import discord
+
+from services.reaction_role_service import VALID_STYLES
+from utils import role_menu_presentation as presentation
+
+
+def test_themes_are_non_empty_and_unique():
+    themes = presentation.themes()
+    assert themes
+    keys = [t.key for t in themes]
+    assert len(keys) == len(set(keys))  # no duplicate keys
+    for theme in themes:
+        assert isinstance(theme.color, discord.Color)
+        assert theme.label
+
+
+def test_get_theme_falls_back_to_default():
+    assert presentation.get_theme(None).key == presentation.DEFAULT_THEME_KEY
+    assert presentation.get_theme("bogus").key == presentation.DEFAULT_THEME_KEY
+    assert presentation.get_theme("neon").key == "neon"
+
+
+def test_theme_color_is_default_safe():
+    assert isinstance(presentation.theme_color(None), discord.Color)
+    assert presentation.theme_color("neon") == presentation.get_theme("neon").color
+
+
+def test_templates_reference_valid_themes_and_styles():
+    templates = presentation.templates()
+    assert templates
+    theme_keys = {t.key for t in presentation.themes()}
+    for tpl in templates:
+        assert tpl.theme in theme_keys, f"{tpl.key} → unknown theme {tpl.theme!r}"
+        assert tpl.style in VALID_STYLES, f"{tpl.key} → bad style {tpl.style!r}"
+        assert tpl.title and tpl.description
+
+
+def test_get_template_lookup():
+    assert presentation.get_template(None) is None
+    assert presentation.get_template("bogus") is None
+    verify = presentation.get_template("verify")
+    assert verify is not None
+    assert verify.style == "button"

--- a/tests/unit/views/test_role_menu_view.py
+++ b/tests/unit/views/test_role_menu_view.py
@@ -1,0 +1,141 @@
+"""Tests for views.roles.role_menu_view — the member-facing persistent menu."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from utils import role_menu_presentation as presentation
+from views.roles import role_menu_view as rmv
+
+
+class FakeRole:
+    def __init__(self, rid: int, name: str = "Role") -> None:
+        self.id = rid
+        self.name = name
+
+    @property
+    def mention(self) -> str:
+        return f"<@&{self.id}>"
+
+
+class FakeGuild:
+    def __init__(self, roles: list[FakeRole]) -> None:
+        self._roles = {r.id: r for r in roles}
+
+    def get_role(self, rid: int) -> FakeRole | None:
+        return self._roles.get(rid)
+
+
+def _menu(style: str = "dropdown", mode: str = "normal", max_roles: int = 0) -> dict:
+    return {
+        "menu_id": 1,
+        "title": "Pick your roles",
+        "description": "desc",
+        "style": style,
+        "mode": mode,
+        "max_roles": max_roles,
+        "theme": "neon",
+        "channel_id": 9,
+        "message_id": 555,
+    }
+
+
+def _opts() -> list[dict]:
+    return [
+        {"role_id": 10, "label": "Gamer", "emoji": None},
+        {"role_id": 20, "label": "Artist", "emoji": None},
+    ]
+
+
+def test_no_arg_construction_is_empty_and_safe():
+    """The registry / manifest may instantiate the class with no args."""
+    view = rmv.RoleMenuView()
+    assert len(view.children) == 0
+
+
+def test_dropdown_menu_builds_single_select_with_scoped_custom_id():
+    view = rmv.RoleMenuView(_menu("dropdown"), _opts())
+    selects = [c for c in view.children if isinstance(c, discord.ui.Select)]
+    assert len(selects) == 1
+    assert selects[0].custom_id == "role_menu:1:select"
+    assert selects[0].max_values == 2  # both roles selectable
+
+
+def test_button_menu_builds_one_button_per_role():
+    view = rmv.RoleMenuView(_menu("button"), _opts())
+    buttons = [c for c in view.children if isinstance(c, discord.ui.Button)]
+    assert {b.custom_id for b in buttons} == {
+        "role_menu:1:role:10",
+        "role_menu:1:role:20",
+    }
+
+
+def test_select_bounds_honour_mode():
+    assert rmv._select_bounds("unique", 0, 5) == (0, 1)
+    assert rmv._select_bounds("normal", 3, 10) == (0, 3)
+    assert rmv._select_bounds("normal", 0, 40) == (0, rmv.MAX_MENU_ROLES)
+
+
+def test_build_menu_embed_uses_theme_colour():
+    guild = FakeGuild([FakeRole(10, "Gamer"), FakeRole(20, "Artist")])
+    embed = rmv.build_menu_embed(_menu(), _opts(), guild)
+    assert embed.title == "Pick your roles"
+    assert embed.color == presentation.theme_color("neon")
+    # Roles field lists the live mentions.
+    roles_field = next(f for f in embed.fields if f.name == "Roles")
+    assert "<@&10>" in roles_field.value
+
+
+def test_view_is_persistent_but_not_in_anchor_registry():
+    """A role menu is a public data-driven message re-bound by reattach_role_menus,
+    not a per-user anchor panel — so it is intentionally NOT register()'d (which
+    would collide with RoleHubPanelView's SUBSYSTEM='role' and trip the
+    identity-contract SUBSYSTEMS parity check)."""
+    from core.runtime import persistent_views
+
+    assert issubclass(rmv.RoleMenuView, persistent_views.PersistentView)
+    # Not registered, and must not have hijacked the 'role' hub's registry slot.
+    assert persistent_views.get_view_class("role_menu") is None
+    assert persistent_views.get_view_class("role") is not rmv.RoleMenuView
+
+
+@pytest.mark.asyncio
+async def test_reattach_binds_each_posted_menu():
+    rmv.reset_reattach_state()
+    bot = MagicMock()
+    menus = [_menu()]
+    options = [
+        __import__(
+            "services.reaction_role_service", fromlist=["RoleOption"],
+        ).RoleOption(10),
+    ]
+    with (
+        patch(
+            "services.reaction_role_service.list_posted_menus",
+            new=AsyncMock(return_value=menus),
+        ),
+        patch(
+            "services.reaction_role_service.get_menu_options",
+            new=AsyncMock(return_value=options),
+        ),
+    ):
+        count = await rmv.reattach_role_menus(bot)
+    assert count == 1
+    bot.add_view.assert_called_once()
+    assert bot.add_view.call_args.kwargs["message_id"] == 555
+
+
+@pytest.mark.asyncio
+async def test_reattach_is_idempotent():
+    rmv.reset_reattach_state()
+    bot = MagicMock()
+    with patch(
+        "services.reaction_role_service.list_posted_menus",
+        new=AsyncMock(return_value=[]),
+    ):
+        await rmv.reattach_role_menus(bot)
+        second = await rmv.reattach_role_menus(bot)  # guarded no-op
+    assert second == 0


### PR DESCRIPTION
## Reaction-roles overhaul — PR 2: the in-Discord role-menu builder (Surface B)

Implements **PR 2** of the [reaction-roles overhaul plan](https://github.com/menno420/superbot/blob/main/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md) (owner decisions **locked** in §9): the modern, native role-menu surface Carl lacks at its core — **dropdown-default** (decision #2) buttons/dropdown menus an operator builds in-panel and deploys to a channel, re-attached on restart, with **edit-in-place** (§4.6a), **theme presets** (§4.6b), and **message templates** (§4.6c). All writes route through the audited `reaction_role_service`.

### ⚠️ Depends on PR 1 (parallel session) — do not merge before reconciling
PR 1 (the foundation) is being built in a **parallel session** and is not yet merged. To stay self-contained + CI-green, this branch carries a copy of the foundation it strictly needs — migration `078_reaction_role_menus.sql`, `utils/db/role_menus.py`, and the menu methods of `services/reaction_role_service.py` — built to the plan's **locked spec**. **Before merge:** rebase onto PR 1, take PR 1's foundation, keep only PR 2's additions (the menu service methods + the new view/builder/presentation files + the `bot1` re-attach wiring). The session card holds this PR **red** until that reconciliation is done.

### What ships (PR 2 surface)
- `disbot/views/roles/role_menu_view.py` — `RoleMenuView(PersistentView)`: renders a dropdown (default) or one-button-per-role; **server-side** mode enforcement (`unique` clears siblings, `max_roles` caps); ephemeral confirms; re-attached on restart.
- `disbot/views/roles/role_menu_builder.py` — operator builder off the Reaction Roles panel: title/description, windowed role picker, style/mode/limit, theme picker, template gallery, **Edit** an existing menu in place, **Post**.
- `disbot/utils/role_menu_presentation.py` — theme + template catalogues (pure data on `ui_constants`).
- Re-attach loop wired into `bot1.on_ready`.

### Verification
`python3.10 scripts/check_quality.py --full` + `python3.10 scripts/check_architecture.py --mode strict` (both green before flipping the card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KggeFU5ou3BCKsbGC6fhSS)_