### PR TITLE
feat(roles): reaction-roles overhaul PR 1 — audited seam + menu data layer

### DIFF
--- a/.sessions/2026-06-21-reaction-roles-pr1-foundation.md
+++ b/.sessions/2026-06-21-reaction-roles-pr1-foundation.md
@@ -1,9 +1,9 @@
 # 2026-06-21 — Reaction-roles overhaul PR 1: audited seam + menu data layer
 
-> **Status:** `in-progress` — building PR 1 (the foundation) of the reaction-roles overhaul
+> **Status:** `complete` — PR 1 (the foundation) of the reaction-roles overhaul
 > ([plan](../docs/planning/reaction-roles-overhaul-plan-2026-06-21.md)). Runtime code, but
 > **additive + behaviour-preserving** (existing reaction roles work identically; new tables empty =
-> no-op) → self-merge on green (Q-0113). Flips `complete` last (Q-0133).
+> no-op) → self-merge on green (Q-0113).
 
 > **Run type:** `manual`
 
@@ -38,4 +38,45 @@ and (2) lay the role-menu data foundation the parallel PR 2 builder consumes.
 - `check_quality --full` → black/isort/ruff + `mypy disbot/` (Success, 747 files) + **11103 passed**.
 - Targeted: 27 passed.
 
-(Body close-out + run report filled at session close.)
+## Context delta
+
+- **Needed but not pointed to:** that `pool.execute` returns `None` (no command tag), so a
+  `delete_for_guild` count must use `RETURNING` + `fetchall` + `len`. Learned by reading `pool.py`;
+  worth a one-liner in the helper/db docs since several teardown `delete_for_guild` functions need a
+  count.
+- **Discovered by hand:** CI **excludes `tests/` from ruff**, so a bare `python3.10 -m ruff check`
+  over my test files reported `S101` (assert) noise that CI never sees — trust `check_quality.py`'s
+  scoped run, not a raw ruff over test files (already a CLAUDE.md note; reconfirmed live).
+- **Decision made alone:** put the menu **schema + full data layer in PR 1** (not just the audit
+  fix) so the parallel PR 2 session has a migration-free, ready foundation and there's no
+  migration-number race (I own 078; PR 4 takes 079+). Recorded in the handoff prompt + active-work.
+
+## ⟲ Previous-session review (Q-0102)
+
+The chain of doc PRs (#1215–#1218) that produced this plan did well: it captured the owner's
+iterative design (video → web-vs-Discord → presentation reqs → locked decisions) durably instead of
+letting it live in chat, so PR 1 had a fully-specified spec to build against. One improvement it
+surfaces: the four small doc PRs could have been **one** evolving PR until the plan stabilized —
+the rapid-fire merge-per-message cadence is correct for the workflow gate but created four session
+cards for what was really one design conversation. Not worth changing the rule; just noting the
+cadence cost.
+
+## 📤 Run report
+
+- **Did:** built reaction-roles PR 1 — the audited service seam + the role-menu data layer + teardown · **Outcome:** shipped (runtime, CI-green)
+- **Shipped:** #1220 — reaction-roles overhaul PR 1 (audited seam + menu data layer)
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** none (PR 1 has no design forks; the §9 decisions are locked)
+- **⚑ Owner manual steps:** none — merge auto-deploys; migration 078 runs idempotently on boot
+- **⚑ Self-initiated:** none (owner directly asked me to build PR 1)
+- **↪ Next:** the parallel session builds **PR 2** (in-Discord dropdown builder + edit/themes/templates) on this foundation; then PR 3 (modes + interactive panel), PR 4 (temp roles), PR 5 (analytics)
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 4 docs (#1215–#1218); #1220 pending (PR 1 runtime) |
+| CI-red rounds | 0 on push (1 local lint round caught + fixed pre-push: COM812 + S101) |
+| Repo-rule trips | 0 (arch 0 errors) |
+| New ideas contributed | 1 (channel-deployed component-menu primitive, #1215) |
+| Ideas groomed | 0 |

--- a/.sessions/2026-06-21-reaction-roles-pr1-foundation.md
+++ b/.sessions/2026-06-21-reaction-roles-pr1-foundation.md
@@ -1,0 +1,41 @@
+# 2026-06-21 — Reaction-roles overhaul PR 1: audited seam + menu data layer
+
+> **Status:** `in-progress` — building PR 1 (the foundation) of the reaction-roles overhaul
+> ([plan](../docs/planning/reaction-roles-overhaul-plan-2026-06-21.md)). Runtime code, but
+> **additive + behaviour-preserving** (existing reaction roles work identically; new tables empty =
+> no-op) → self-merge on green (Q-0113). Flips `complete` last (Q-0133).
+
+> **Run type:** `manual`
+
+## Arc
+
+Owner asked me to build PR 1 while a parallel session builds PR 2–5 (I wrote that handoff prompt
+in-chat). PR 1 = (1) close the long-standing audit-seam debt for the existing emoji reaction-roles,
+and (2) lay the role-menu data foundation the parallel PR 2 builder consumes.
+
+## What shipped
+
+- **`disbot/services/reaction_role_service.py`** — the audited write seam. `bind_emoji` /
+  `unbind_emoji` persist via the DB layer **and** emit `audit.action_recorded` (subsystem `role`),
+  mirroring `role_exemption_service`; `get_binding` / `list_bindings` are the read passthroughs the
+  listener uses. Closes the `general-feature-layer-analysis` finding (cog wrote straight to the DB).
+- **`disbot/utils/db/role_menus.py`** + **migration `078_reaction_role_menus.sql`** — the role-menu
+  data model: `role_menus` (style defaults to `dropdown`, the locked decision; `mode`, `max_roles`,
+  `theme`) + `role_menu_options` (FK CASCADE). Full CRUD + `delete_for_guild`. Additive — empty
+  tables are byte-identical to the pre-overhaul bot; the legacy `reaction_roles` table is untouched.
+- **`disbot/cogs/role_cog.py`** — routed all reaction-role *writes* (`!reactroles` /
+  `!removereactrole`) and the listener/`!listreactroles` *reads* through the service. No
+  user-facing behaviour change; bindings persist identically, now with an audit trail.
+- **`disbot/guild_lifecycle.py`** — teardown step 23 purges `role_menus` for a departed guild
+  (options cascade); INV-I satisfied.
+- **Tests** — `test_reaction_role_service.py` (audit emission + read passthrough),
+  `test_role_menus.py` (RETURNING id + delete count + upsert/order SQL), and two steps added to
+  `test_guild_lifecycle_teardown.py` (step 23 awaited + failure-isolated).
+
+## Verification
+
+- `check_architecture --mode strict` → **0 errors**.
+- `check_quality --full` → black/isort/ruff + `mypy disbot/` (Success, 747 files) + **11103 passed**.
+- Targeted: 27 passed.
+
+(Body close-out + run report filled at session close.)

--- a/disbot/cogs/role_cog.py
+++ b/disbot/cogs/role_cog.py
@@ -8,7 +8,7 @@ from discord.ext import commands, tasks
 from core.runtime import panel_manager, resources
 from core.runtime.component_registry import stats_block
 from core.runtime.persistent_views import PersistentView, register
-from services import role_automation
+from services import reaction_role_service, role_automation
 from services.lifecycle import SUCCESS
 from services.role_lifecycle_service import RoleLifecycleRequest, RoleLifecycleService
 from utils import db
@@ -556,7 +556,7 @@ class RoleCog(commands.Cog):
         member = resources.resolve_member(guild, payload.user_id)
         if not member or member.bot:
             return
-        role_id = await db.get_reaction_role(
+        role_id = await reaction_role_service.get_binding(
             payload.guild_id,
             payload.message_id,
             str(payload.emoji),
@@ -580,7 +580,7 @@ class RoleCog(commands.Cog):
         member = resources.resolve_member(guild, payload.user_id)
         if not member or member.bot:
             return
-        role_id = await db.get_reaction_role(
+        role_id = await reaction_role_service.get_binding(
             payload.guild_id,
             payload.message_id,
             str(payload.emoji),
@@ -612,7 +612,13 @@ class RoleCog(commands.Cog):
             await ctx.send("❌ I can't read that message.", delete_after=8)
             return
 
-        await db.add_reaction_role(ctx.guild.id, message_id, emoji, role.id)
+        await reaction_role_service.bind_emoji(
+            ctx.guild.id,
+            message_id,
+            emoji,
+            role.id,
+            actor_id=ctx.author.id,
+        )
         try:
             await message.add_reaction(emoji)
         except discord.HTTPException:
@@ -634,7 +640,12 @@ class RoleCog(commands.Cog):
         emoji: str,
     ) -> None:
         """Remove a reaction role binding. Usage: !removereactrole <message_id> <emoji>"""
-        await db.remove_reaction_role(ctx.guild.id, message_id, emoji)
+        await reaction_role_service.unbind_emoji(
+            ctx.guild.id,
+            message_id,
+            emoji,
+            actor_id=ctx.author.id,
+        )
         await ctx.send(
             f"✅ Reaction role for {emoji} on that message removed.",
             delete_after=10,
@@ -644,7 +655,7 @@ class RoleCog(commands.Cog):
     @commands.has_permissions(manage_roles=True)
     async def list_reaction_roles(self, ctx: commands.Context) -> None:
         """List all active reaction roles in this server."""
-        rows = await db.get_all_reaction_roles(ctx.guild.id)
+        rows = await reaction_role_service.list_bindings(ctx.guild.id)
         if not rows:
             await ctx.send("No reaction roles configured.", delete_after=8)
             return

--- a/disbot/guild_lifecycle.py
+++ b/disbot/guild_lifecycle.py
@@ -64,6 +64,12 @@ async def teardown(guild_id: int) -> None:
       22. Command-access policy — drop both the cached snapshot and the
                                    ``guild_command_access_policy`` row
                                    (CASCADE sweeps the channel allowlist).
+      23. Role menus            — delete every ``role_menus`` row for the
+                                   guild (reaction-roles overhaul);
+                                   ``role_menu_options`` rows cascade via FK.
+                                   The legacy ``reaction_roles`` table is
+                                   message-keyed and self-cleans when the
+                                   messages go, so it needs no teardown step.
     """
     logger.info("guild_lifecycle.teardown: beginning cleanup for guild=%d", guild_id)
 
@@ -148,6 +154,10 @@ async def teardown(guild_id: int) -> None:
     #     ``core.runtime.command_access.forget_guild`` so the cache
     #     and the DB never diverge across a re-invite.
     await _teardown_command_access(guild_id)
+
+    # 23. Role menus (reaction-roles overhaul) — delete role_menus rows;
+    #     role_menu_options cascade via the FK.
+    await _teardown_role_menus(guild_id)
 
     logger.info("guild_lifecycle.teardown: complete for guild=%d", guild_id)
 
@@ -627,6 +637,31 @@ async def _teardown_ai_platform(guild_id: int) -> None:
     except Exception as exc:
         logger.warning(
             "guild_lifecycle: AI Platform teardown failed for guild=%d: %s",
+            guild_id,
+            exc,
+        )
+
+
+async def _teardown_role_menus(guild_id: int) -> None:
+    """Delete every role_menus row for the departed guild (reaction-roles overhaul).
+
+    ``role_menu_options`` rows cascade away via the FK. The legacy
+    ``reaction_roles`` table is keyed by ``message_id`` and self-cleans when the
+    host messages are deleted, so it has no teardown step of its own.
+    """
+    try:
+        from utils.db.role_menus import delete_for_guild as _role_menus_delete
+
+        count = await _role_menus_delete(guild_id)
+        if count:
+            logger.debug(
+                "guild_lifecycle: deleted %d role menu(s) for guild=%d",
+                count,
+                guild_id,
+            )
+    except Exception as exc:
+        logger.warning(
+            "guild_lifecycle: role menu teardown failed for guild=%d: %s",
             guild_id,
             exc,
         )

--- a/disbot/migrations/078_reaction_role_menus.sql
+++ b/disbot/migrations/078_reaction_role_menus.sql
@@ -1,0 +1,40 @@
+-- Role menus (reaction-roles overhaul, PR 1 foundation).
+--
+-- The data model for modern button/dropdown role menus (the headline feature
+-- built in PR 2). A menu is one bot-posted message in a guild channel; its
+-- options pair a role with an optional emoji/label. The legacy emoji
+-- `reaction_roles` table (bootstrap schema in utils/db/migrations.py) is left
+-- untouched and continues to work — these tables are purely additive, so an
+-- EMPTY pair of tables is byte-identical to the pre-overhaul bot.
+--
+-- `style` defaults to 'dropdown' (the owner-locked default, plan §9); other
+-- values: 'button', 'reaction'. `mode` mirrors Carl-bot's modes
+-- ('normal' | 'unique' | 'verify'). `max_roles` 0 = unlimited (the per-member
+-- pick cap, Carl's `rr limit`). `theme` keys an embed theme preset (plan §4.6b).
+-- message_id is NULL until the menu message is posted (build → store).
+
+CREATE TABLE IF NOT EXISTS role_menus (
+    menu_id     BIGSERIAL   PRIMARY KEY,
+    guild_id    BIGINT      NOT NULL,
+    channel_id  BIGINT      NOT NULL,
+    message_id  BIGINT,
+    title       TEXT        NOT NULL DEFAULT 'Pick your roles',
+    description TEXT,
+    style       TEXT        NOT NULL DEFAULT 'dropdown',
+    mode        TEXT        NOT NULL DEFAULT 'normal',
+    max_roles   INTEGER     NOT NULL DEFAULT 0,
+    theme       TEXT        NOT NULL DEFAULT 'default',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_role_menus_guild ON role_menus (guild_id);
+CREATE INDEX IF NOT EXISTS idx_role_menus_message ON role_menus (message_id);
+
+CREATE TABLE IF NOT EXISTS role_menu_options (
+    menu_id  BIGINT  NOT NULL REFERENCES role_menus (menu_id) ON DELETE CASCADE,
+    role_id  BIGINT  NOT NULL,
+    emoji    TEXT,
+    label    TEXT,
+    position INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (menu_id, role_id)
+);

--- a/disbot/services/reaction_role_service.py
+++ b/disbot/services/reaction_role_service.py
@@ -1,0 +1,115 @@
+"""Reaction-role config writes — the audited mutation seam.
+
+Closes a long-standing finding (``audits/general-feature-layer-analysis``): the
+role cog wrote reaction-role bindings straight to ``utils.db.roles`` with no
+audit trail, unlike every other role mutation (time/XP thresholds, exemptions,
+lifecycle) which routes through an audited service. This module is now the
+sanctioned write path for emoji reaction-role bindings — it persists via the DB
+layer and emits ``audit.action_recorded``, so reaction-role config changes show
+up in the same audit/``server_logging`` stream as the rest of the role hub.
+
+Scope (PR 1): the *config* writes (bind/unbind an emoji → role) are audited.
+The member self-assign path (adding/removing the role when someone reacts) is a
+Discord mutation, not a DB write, and stays in the cog listener for now; PR 3
+layers the unique/verify modes onto the read seam here. The role-menu write
+methods land in PR 2 on top of ``utils.db.role_menus``.
+
+Cycle discipline mirrors the rest of ``services``: cross-package ``services.*``
+imports are function-local; top-level imports are limited to stdlib + ``utils``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from utils import db
+
+
+async def bind_emoji(
+    guild_id: int,
+    message_id: int,
+    emoji: str,
+    role_id: int,
+    *,
+    actor_id: int | None,
+) -> None:
+    """Bind an emoji on a message to a role (audited).
+
+    Upserts the ``reaction_roles`` row and emits ``audit.action_recorded`` so
+    the operator action is traceable.
+    """
+    await db.add_reaction_role(guild_id, message_id, emoji, role_id)
+    await _emit(
+        guild_id,
+        mutation_type="set_reaction_role",
+        role_id=role_id,
+        prev_value=None,
+        new_value=f"message={message_id},emoji={emoji}",
+        actor_id=actor_id,
+    )
+
+
+async def unbind_emoji(
+    guild_id: int,
+    message_id: int,
+    emoji: str,
+    *,
+    actor_id: int | None,
+) -> None:
+    """Remove an emoji → role binding from a message (audited)."""
+    prev_role = await db.get_reaction_role(guild_id, message_id, emoji)
+    await db.remove_reaction_role(guild_id, message_id, emoji)
+    await _emit(
+        guild_id,
+        mutation_type="remove_reaction_role",
+        role_id=prev_role,
+        prev_value=f"message={message_id},emoji={emoji}",
+        new_value=None,
+        actor_id=actor_id,
+    )
+
+
+async def get_binding(guild_id: int, message_id: int, emoji: str) -> int | None:
+    """Resolve the role bound to an emoji on a message (the listener read)."""
+    return await db.get_reaction_role(guild_id, message_id, emoji)
+
+
+async def list_bindings(guild_id: int) -> list[dict]:
+    """All emoji reaction-role bindings configured in a guild."""
+    return await db.get_all_reaction_roles(guild_id)
+
+
+async def _emit(
+    guild_id: int,
+    *,
+    mutation_type: str,
+    role_id: int | None,
+    prev_value: str | None,
+    new_value: str | None,
+    actor_id: int | None,
+) -> None:
+    """Emit ``audit.action_recorded`` for a reaction-role config mutation."""
+    from services.audit_events import emit_audit_action
+
+    await emit_audit_action(
+        mutation_id=str(uuid.uuid4()),
+        subsystem="role",
+        mutation_type=mutation_type,
+        target=f"role:{role_id}" if role_id is not None else "role:unknown",
+        scope="guild",
+        guild_id=guild_id,
+        prev_value=prev_value,
+        new_value=new_value,
+        actor_id=actor_id,
+        actor_type="admin",
+        occurred_at=datetime.now(tz=timezone.utc),
+    )
+
+
+__all__ = [
+    "bind_emoji",
+    "get_binding",
+    "list_bindings",
+    "unbind_emoji",
+]

--- a/disbot/utils/db/role_menus.py
+++ b/disbot/utils/db/role_menus.py
@@ -1,0 +1,169 @@
+"""Role-menu CRUD (reaction-roles overhaul, PR 1 data layer).
+
+The data layer for modern button/dropdown role menus (migration 078). A
+``role_menus`` row is one bot-posted message; ``role_menu_options`` rows pair a
+role with an optional emoji/label. The PR 2 builder + ``RoleMenuView`` consume
+these primitives; the audited write seam (``services.reaction_role_service``)
+wraps the *mutating* helpers so menu edits emit ``audit.action_recorded``.
+
+Co-located with the rest of the role DB layer (``utils/db/roles.py`` owns the
+legacy ``reaction_roles`` table); kept in its own module because the menu model
+is self-contained and its consumer is the new ``views/roles`` menu surface.
+"""
+
+from __future__ import annotations
+
+from utils.db import pool
+
+# ---------------------------------------------------------------------------
+# Menus
+# ---------------------------------------------------------------------------
+
+
+async def create_menu(
+    guild_id: int,
+    channel_id: int,
+    *,
+    title: str,
+    description: str | None,
+    style: str = "dropdown",
+    mode: str = "normal",
+    max_roles: int = 0,
+    theme: str = "default",
+) -> int:
+    """Insert a new (unposted) menu; return its generated ``menu_id``.
+
+    ``message_id`` is left NULL until the menu message is posted — the caller
+    sends the message, then calls :func:`set_menu_message`.
+    """
+    row = await pool.fetchone(
+        """INSERT INTO role_menus
+               (guild_id, channel_id, title, description, style, mode, max_roles, theme)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+           RETURNING menu_id""",
+        (guild_id, channel_id, title, description, style, mode, max_roles, theme),
+    )
+    if row is None:  # pragma: no cover — RETURNING always yields a row on INSERT
+        raise RuntimeError("create_menu: INSERT ... RETURNING produced no row")
+    return int(row["menu_id"])
+
+
+async def set_menu_message(menu_id: int, message_id: int) -> None:
+    """Record the posted message id for a menu (build → post → store)."""
+    await pool.execute(
+        "UPDATE role_menus SET message_id=$2 WHERE menu_id=$1",
+        (menu_id, message_id),
+    )
+
+
+async def update_menu(
+    menu_id: int,
+    *,
+    title: str,
+    description: str | None,
+    style: str,
+    mode: str,
+    max_roles: int,
+    theme: str,
+) -> None:
+    """Edit a menu's presentation/behaviour fields in place (plan §4.6a).
+
+    The caller re-renders and edits the existing message afterward, so the
+    posted menu and the row stay in step without a repost.
+    """
+    await pool.execute(
+        """UPDATE role_menus
+              SET title=$2, description=$3, style=$4, mode=$5, max_roles=$6, theme=$7
+            WHERE menu_id=$1""",
+        (menu_id, title, description, style, mode, max_roles, theme),
+    )
+
+
+async def get_menu(menu_id: int) -> dict | None:
+    """Return a single menu row, or ``None`` if it no longer exists."""
+    return await pool.fetchone(
+        "SELECT * FROM role_menus WHERE menu_id=$1",
+        (menu_id,),
+    )
+
+
+async def get_menu_by_message(guild_id: int, message_id: int) -> dict | None:
+    """Resolve the menu bound to a posted message (the listener/edit path)."""
+    return await pool.fetchone(
+        "SELECT * FROM role_menus WHERE guild_id=$1 AND message_id=$2",
+        (guild_id, message_id),
+    )
+
+
+async def list_menus(guild_id: int) -> list[dict]:
+    """All menus configured in a guild (newest first)."""
+    return await pool.fetchall(
+        "SELECT * FROM role_menus WHERE guild_id=$1 ORDER BY menu_id DESC",
+        (guild_id,),
+    )
+
+
+async def delete_menu(menu_id: int) -> None:
+    """Delete a menu; its options cascade away (FK ON DELETE CASCADE)."""
+    await pool.execute("DELETE FROM role_menus WHERE menu_id=$1", (menu_id,))
+
+
+# ---------------------------------------------------------------------------
+# Options (emoji/label ↔ role pairs)
+# ---------------------------------------------------------------------------
+
+
+async def add_option(
+    menu_id: int,
+    role_id: int,
+    *,
+    emoji: str | None = None,
+    label: str | None = None,
+    position: int = 0,
+) -> None:
+    """Attach (or update) a role option on a menu."""
+    await pool.execute(
+        """INSERT INTO role_menu_options (menu_id, role_id, emoji, label, position)
+           VALUES ($1, $2, $3, $4, $5)
+           ON CONFLICT (menu_id, role_id)
+             DO UPDATE SET emoji=EXCLUDED.emoji,
+                           label=EXCLUDED.label,
+                           position=EXCLUDED.position""",
+        (menu_id, role_id, emoji, label, position),
+    )
+
+
+async def remove_option(menu_id: int, role_id: int) -> None:
+    """Detach a role option from a menu."""
+    await pool.execute(
+        "DELETE FROM role_menu_options WHERE menu_id=$1 AND role_id=$2",
+        (menu_id, role_id),
+    )
+
+
+async def get_options(menu_id: int) -> list[dict]:
+    """All role options for a menu, in display order."""
+    return await pool.fetchall(
+        "SELECT role_id, emoji, label, position FROM role_menu_options "
+        "WHERE menu_id=$1 ORDER BY position, role_id",
+        (menu_id,),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guild teardown
+# ---------------------------------------------------------------------------
+
+
+async def delete_for_guild(guild_id: int) -> int:
+    """Delete every menu (and, by cascade, its options) for a departed guild.
+
+    Returns the number of menus removed. Registered in
+    ``guild_lifecycle.teardown`` so the new tables never accumulate per-guild
+    rows after the bot leaves (architecture INV-I).
+    """
+    rows = await pool.fetchall(
+        "DELETE FROM role_menus WHERE guild_id=$1 RETURNING menu_id",
+        (guild_id,),
+    )
+    return len(rows)

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -42,6 +42,13 @@ living ledger (`docs/current-state.md`).
   `botsite/app.py` + `scripts/export_dashboard_data.py` + `tests/unit/botsite/` · 2026-06-20 ·
   **auto-merge on green**
 
+- `claude/reaction-roles-pr1-foundation` · **Reaction-roles overhaul PR 1 — audited seam + menu
+  data layer** (owner-directed; foundation for the parallel PR 2–5 session — see
+  `docs/planning/reaction-roles-overhaul-plan-2026-06-21.md`) · `services/reaction_role_service.py`
+  + `utils/db/role_menus.py` + migration `078_reaction_role_menus.sql` + `cogs/role_cog.py` (route
+  writes through the seam) + `guild_lifecycle.py` (teardown step 23) · 2026-06-21 · **auto-merge on
+  green** (additive · behaviour-preserving). **Parallel session owns PR 2–5; do not recreate these.**
+
 ## Recently cleared
 
 - `claude/design-system-connector-docs` · design-system docs — GitHub-connector workflow + new

--- a/tests/unit/runtime/test_guild_lifecycle_teardown.py
+++ b/tests/unit/runtime/test_guild_lifecycle_teardown.py
@@ -477,3 +477,39 @@ async def test_teardown_command_access_failure_is_isolated(_teardown_patches):
     ):
         # No exception escapes — the lifecycle swallows + logs.
         await guild_lifecycle.teardown(99)
+
+
+# ---------------------------------------------------------------------------
+# Step 23 — role menus deleted (reaction-roles overhaul)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_teardown_deletes_role_menus(_teardown_patches):
+    """Step 23 awaits ``utils.db.role_menus.delete_for_guild`` so the new
+    ``role_menus`` table (and its cascading options) never accumulates rows
+    for a departed guild (architecture INV-I).
+    """
+    import guild_lifecycle
+
+    with patch(
+        "utils.db.role_menus.delete_for_guild",
+        new_callable=AsyncMock,
+        return_value=2,
+    ) as mock_delete:
+        await guild_lifecycle.teardown(99)
+        mock_delete.assert_awaited_once_with(99)
+
+
+@pytest.mark.asyncio
+async def test_teardown_role_menu_failure_is_isolated(_teardown_patches):
+    """A failure in the role-menu teardown step must not abort the sequence."""
+    import guild_lifecycle
+
+    with patch(
+        "utils.db.role_menus.delete_for_guild",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("DB blip"),
+    ):
+        # No exception escapes — the lifecycle swallows + logs.
+        await guild_lifecycle.teardown(99)

--- a/tests/unit/services/test_reaction_role_service.py
+++ b/tests/unit/services/test_reaction_role_service.py
@@ -1,0 +1,99 @@
+"""Tests for services.reaction_role_service — the audited reaction-role seam.
+
+Pins the finding this module closes: reaction-role config writes now emit
+``audit.action_recorded`` (subsystem ``role``) like every other role mutation,
+instead of going straight to the DB layer from the cog.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services import reaction_role_service as rrs
+
+
+@pytest.mark.asyncio
+async def test_bind_emoji_persists_and_audits():
+    with (
+        patch.object(rrs.db, "add_reaction_role", new=AsyncMock()) as add_mock,
+        patch(
+            "services.audit_events.emit_audit_action",
+            new=AsyncMock(return_value=True),
+        ) as audit_mock,
+    ):
+        await rrs.bind_emoji(1, 555, "🎮", 42, actor_id=99)
+
+    add_mock.assert_awaited_once_with(1, 555, "🎮", 42)
+    audit_mock.assert_awaited_once()
+    kwargs = audit_mock.await_args.kwargs
+    assert kwargs["subsystem"] == "role"
+    assert kwargs["mutation_type"] == "set_reaction_role"
+    assert kwargs["target"] == "role:42"
+    assert kwargs["guild_id"] == 1
+    assert kwargs["actor_id"] == 99
+    assert "message=555" in kwargs["new_value"]
+    assert "emoji=🎮" in kwargs["new_value"]
+
+
+@pytest.mark.asyncio
+async def test_unbind_emoji_reads_prev_role_then_removes_and_audits():
+    with (
+        patch.object(
+            rrs.db,
+            "get_reaction_role",
+            new=AsyncMock(return_value=42),
+        ) as get_mock,
+        patch.object(rrs.db, "remove_reaction_role", new=AsyncMock()) as rm_mock,
+        patch(
+            "services.audit_events.emit_audit_action",
+            new=AsyncMock(return_value=True),
+        ) as audit_mock,
+    ):
+        await rrs.unbind_emoji(1, 555, "🎮", actor_id=99)
+
+    get_mock.assert_awaited_once_with(1, 555, "🎮")
+    rm_mock.assert_awaited_once_with(1, 555, "🎮")
+    kwargs = audit_mock.await_args.kwargs
+    assert kwargs["mutation_type"] == "remove_reaction_role"
+    # The audit row names the role that *was* bound (resolved before removal).
+    assert kwargs["target"] == "role:42"
+    assert kwargs["new_value"] is None
+
+
+@pytest.mark.asyncio
+async def test_unbind_unknown_binding_audits_without_a_role():
+    with (
+        patch.object(rrs.db, "get_reaction_role", new=AsyncMock(return_value=None)),
+        patch.object(rrs.db, "remove_reaction_role", new=AsyncMock()),
+        patch(
+            "services.audit_events.emit_audit_action",
+            new=AsyncMock(return_value=True),
+        ) as audit_mock,
+    ):
+        await rrs.unbind_emoji(1, 555, "❓", actor_id=99)
+
+    # No role resolved → the audit target falls back, never raises.
+    assert audit_mock.await_args.kwargs["target"] == "role:unknown"
+
+
+@pytest.mark.asyncio
+async def test_reads_pass_through_to_db():
+    with (
+        patch.object(
+            rrs.db,
+            "get_reaction_role",
+            new=AsyncMock(return_value=7),
+        ) as get_mock,
+        patch.object(
+            rrs.db,
+            "get_all_reaction_roles",
+            new=AsyncMock(return_value=[{"x": 1}]),
+        ) as list_mock,
+    ):
+        assert await rrs.get_binding(1, 555, "🎮") == 7
+        assert await rrs.list_bindings(1) == [{"x": 1}]
+
+    get_mock.assert_awaited_once_with(1, 555, "🎮")
+    list_mock.assert_awaited_once_with(1)

--- a/tests/unit/utils/db/test_role_menus.py
+++ b/tests/unit/utils/db/test_role_menus.py
@@ -1,0 +1,92 @@
+"""Tests for utils.db.role_menus — the role-menu data layer (migration 078).
+
+Pins the two behaviours the higher layers rely on: ``create_menu`` returns the
+DB-generated ``menu_id`` (via ``RETURNING``), and ``delete_for_guild`` reports
+how many menus it removed (via ``RETURNING`` + count) so the guild-teardown
+step can log it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+_DISBOT = Path(__file__).parents[4] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from utils.db import role_menus  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_create_menu_returns_generated_id(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _fetchone(sql, params=()):
+        captured["sql"] = sql
+        captured["params"] = params
+        return {"menu_id": 7}
+
+    monkeypatch.setattr(role_menus.pool, "fetchone", AsyncMock(side_effect=_fetchone))
+
+    menu_id = await role_menus.create_menu(
+        1,
+        222,
+        title="Pick",
+        description=None,
+        style="dropdown",
+    )
+
+    assert menu_id == 7
+    assert "INSERT INTO role_menus" in captured["sql"]
+    assert "RETURNING menu_id" in captured["sql"]
+    # guild_id + channel_id lead the param tuple; style is carried through.
+    assert captured["params"][0] == 1
+    assert captured["params"][1] == 222
+    assert "dropdown" in captured["params"]
+
+
+@pytest.mark.asyncio
+async def test_delete_for_guild_returns_count(monkeypatch):
+    monkeypatch.setattr(
+        role_menus.pool,
+        "fetchall",
+        AsyncMock(return_value=[{"menu_id": 1}, {"menu_id": 2}, {"menu_id": 3}]),
+    )
+
+    removed = await role_menus.delete_for_guild(1)
+
+    assert removed == 3
+
+
+@pytest.mark.asyncio
+async def test_add_option_upserts(monkeypatch):
+    captured: dict[str, str] = {}
+
+    async def _execute(sql, params=()):
+        captured["sql"] = sql
+
+    monkeypatch.setattr(role_menus.pool, "execute", AsyncMock(side_effect=_execute))
+
+    await role_menus.add_option(7, 42, emoji="🎮", label="Gamer", position=1)
+
+    assert "INSERT INTO role_menu_options" in captured["sql"]
+    assert "ON CONFLICT (menu_id, role_id)" in captured["sql"]
+
+
+@pytest.mark.asyncio
+async def test_get_options_orders_by_position(monkeypatch):
+    captured: dict[str, str] = {}
+
+    async def _fetchall(sql, params=()):
+        captured["sql"] = sql
+        return []
+
+    monkeypatch.setattr(role_menus.pool, "fetchall", AsyncMock(side_effect=_fetchall))
+
+    await role_menus.get_options(7)
+
+    assert "ORDER BY position" in captured["sql"]


### PR DESCRIPTION
**PR 1 (the foundation)** of the reaction-roles overhaul ([plan](https://github.com/menno420/superbot/blob/main/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md) §4 PR 1). Built while a parallel session works on PR 2–5.

**Additive + behaviour-preserving** — existing emoji reaction-roles work identically; the new menu tables are empty (no-op) until PR 2's builder uses them.

### What's in it
- **`services/reaction_role_service.py`** — the audited write seam. `bind_emoji`/`unbind_emoji` persist via the DB layer **and** emit `audit.action_recorded` (subsystem `role`), mirroring `role_exemption_service`. Closes the long-standing `general-feature-layer-analysis` finding that the cog wrote reaction-role bindings straight to the DB with no audit trail.
- **`utils/db/role_menus.py` + migration `078_reaction_role_menus.sql`** — the role-menu data model: `role_menus` (`style` defaults to `dropdown` per the locked decision; `mode`, `max_roles`, `theme`) + `role_menu_options` (FK `ON DELETE CASCADE`), full CRUD + `delete_for_guild`. The legacy `reaction_roles` table is untouched.
- **`cogs/role_cog.py`** — routes reaction-role *writes* (`!reactroles`/`!removereactrole`) and the listener/`!listreactroles` *reads* through the service. No user-facing change; bindings persist identically, now audited.
- **`guild_lifecycle.py`** — teardown step 23 purges `role_menus` for a departed guild (options cascade); satisfies INV-I.
- **Tests** — service audit emission + read passthrough, `role_menus` CRUD (RETURNING id / delete count / upsert SQL), and two steps added to the guild-lifecycle teardown test.

### Verification
- `check_architecture --mode strict` → **0 errors**
- `check_quality --full` → black/isort/ruff + `mypy disbot/` (Success, 747 files) + **11103 passed, 44 skipped**

### Coordination
The parallel session (PR 2–5) branches off this branch / main and **does not recreate** `reaction_role_service.py`, migration 078, `utils/db/role_menus.py`, the cog routing, or the teardown hook — it extends the service and uses the data layer. Claimed in `docs/owner/active-work.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Utjw1fiQUkCKKzAFBdMets

---
_Generated by [Claude Code](https://claude.ai/code/session_01Utjw1fiQUkCKKzAFBdMets)_