### PR TITLE
feat(tooling): check_lane_overlap.py reads the active-work.md claim ledger

### DIFF
--- a/.sessions/2026-06-21-lane-overlap-claim-scan.md
+++ b/.sessions/2026-06-21-lane-overlap-claim-scan.md
@@ -1,0 +1,84 @@
+# Session — check_lane_overlap.py gains an active-work.md claim-ledger scan
+
+> **Status:** `complete`
+> **Run type:** routine · dispatch
+> **Branch:** `claude/lane-overlap-claim-scan`
+
+## Arc — a process failure, then the fix for it
+
+This run started by **duplicating work already in flight**: an empty scheduled fire,
+I took the live ▶ Next action (reaction-roles overhaul) and built **PR 2** (the
+in-Discord role-menu builder) as PR #1221 — without first scanning the
+`active-work.md` claim ledger, which reserved **"PR 2–5"** for the parallel
+`claude/reaction-roles-pr1-foundation` session. The owner flagged the conflict; the
+parallel session's PR 2 had in fact already merged as **#1219**. I **closed #1221**
+as a duplicate (nothing from it reached `main`).
+
+That is exactly the waste the pre-start claim scan (Q-0126) exists to prevent — and
+the failure was *skipping a manual step*. So instead of leaving it as "be more
+careful next time," this session **gives the existing guard teeth for the case that
+bit me**.
+
+## Shipped — `scripts/check_lane_overlap.py` now reads the claim ledger
+
+`check_lane_overlap.py` previously scanned only **recently-merged commits** (local
+git) — it says so itself: *"partial by construction … the open-PR half needs
+GitHub."* The blind spot it had is the **earliest** duplicate signal: an
+`active-work.md` **claim line exists before any PR or commit does**. The
+reaction-roles claim ("owns PR 2–5") was pure ledger text the tool never read, so it
+could not have warned me.
+
+- Added `parse_claims()` (pure: ledger text → `{branch, summary, paths}` entries,
+  excluding the `## Recently cleared` block), `scan_claims()`, and path-overlap
+  helpers that normalize away an inconsistent leading `disbot/` so `services/x.py`
+  (claim) matches `disbot/services/x.py` (scope).
+- `main()` now prints a **⚠ CLAIMED** section (naming the owning branch) ahead of the
+  existing **⚠ OVERLAP** merged-commit section; `--strict` exits 1 on either.
+- Live check: `check_lane_overlap.py disbot/services/reaction_role_service.py` now
+  fires **CLAIMED → `claude/reaction-roles-pr1-foundation`** — the warning that would
+  have stopped this session's mistake.
+- 8 unit tests (`tests/unit/scripts/test_check_lane_overlap.py`, the file had none).
+
+stdlib-only dev tooling (Q-0105, disposable), additive, touches only the script +
+its new test → **self-merge on green**. Not wired into any hook/CI gate (that is
+executable config — left for a router proposal if it proves trustworthy across
+sessions).
+
+## Verification
+
+`check_quality.py --check-only` (black/isort/ruff + check_docs + consistency) green;
+`mypy scripts/check_lane_overlap.py` clean; `pytest tests/unit/scripts/` green.
+(No `disbot/` runtime code touched, so the full bot suite is unaffected.)
+
+## Session enders
+
+**💡 Session idea (Q-0089):** wire `check_lane_overlap.py --strict` (now that it reads
+both the merged half *and* the claim ledger) into the **dispatch pre-flight** as an
+advisory step — e.g. a SessionStart banner that runs it against the branch's likely
+scope, or a `/pre-edit-check` skill step — so the scan happens *by default* instead of
+depending on an agent remembering to run it. The whole lesson of this session is that
+a guard only helps if it can't be skipped. (Wiring = executable config → propose via a
+router Q, don't self-wire.)
+
+**⟲ Previous-session review (Q-0102):** the immediately-prior run on this same
+container (`2026-06-21-allow-force-with-lease`) was clean. The sharper review is of
+**this session's own first half**: the real miss was mine — I skipped the
+`active-work.md` + `list_pull_requests` pre-start scan that CLAUDE.md § Session
+workflow mandates (Q-0126), and only the owner catching it prevented a wasted
+needs-hermes-review PR. The systemic improvement is the idea above: make the
+overlap scan a *default* pre-flight, not a remembered manual step.
+
+**📚 Doc audit (Q-0104):** `active-work.md` claim added for this lane. No
+`current-state.md` / plan changes needed (the closed #1221 never reached `main`; the
+parallel session owns the reaction-roles ledger entries). No owner decisions to route.
+
+## 📤 Run report
+
+- **Run type:** routine · dispatch
+- **What shipped:** `check_lane_overlap.py` active-work.md claim-ledger scan + first
+  test suite for it (this branch / new PR).
+- **⚑ Self-initiated:** yes — pivoted to this tooling fix after closing the duplicate
+  reaction-roles PR #1221; contained stdlib dev-tooling, self-merge on green.
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none. *(Heads-up, not an action: reaction-roles PR 2 is the
+  parallel session's #1219 — already merged; my duplicate #1221 is closed.)*

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,12 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/lane-overlap-claim-scan` · **check_lane_overlap.py — add the active-work.md claim-ledger
+  scan** (closes the gap that let a duplicate reaction-roles PR 2 get built: the tool only scanned
+  recently-MERGED commits, not the earliest "owns PR 2–5" claim signal) · `scripts/check_lane_overlap.py`
+  + `tests/unit/scripts/test_check_lane_overlap.py` · 2026-06-21 · **auto-merge on green** (stdlib
+  dev-tooling · additive)
+
 - `claude/clever-maxwell-690qrj` · **Pokétwo + MusicBot research report → feature-mapping plan**
   (docs-only, owner-steered plan-only) · `docs/planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md`
   + `docs/planning/voice-music-architecture-review-2026-06-20.md` + `docs/ideas/` + router Q-0186 ·

--- a/scripts/check_lane_overlap.py
+++ b/scripts/check_lane_overlap.py
@@ -28,11 +28,25 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import re
 import subprocess
 from fnmatch import fnmatch
+from pathlib import Path
+from typing import cast
 
 _RS = "\x1e"  # record separator between commits
 _US = "\x1f"  # unit separator between hash and subject
+
+# The claim ledger (Q-0126) — the *earliest* duplicate-work signal: a claim line
+# exists before any PR or commit does, so it catches overlap the merged-commit
+# scan structurally cannot (the #1221 duplicate-reaction-roles-PR2 lesson).
+_ACTIVE_WORK = Path(__file__).resolve().parents[1] / "docs" / "owner" / "active-work.md"
+
+# A backtick token is a *path* (not a branch/component name) when it contains a
+# "/" or ends in a source extension — and is not a branch ref.
+_PATH_EXTS = (".py", ".sql", ".md", ".yml", ".yaml", ".json", ".ts", ".tsx", ".js")
+_BRANCH_PREFIXES = ("claude/", "bot/", "origin/")
+_BACKTICK = re.compile(r"`([^`]+)`")
 
 
 def _recent_commits(limit: int) -> list[tuple[str, str, list[str]]]:
@@ -62,6 +76,103 @@ def _matches(path: str, scope: str) -> bool:
     return any(ch in scope for ch in "*?[") and fnmatch(path, scope)
 
 
+# ---------------------------------------------------------------------------
+# Claim-ledger scan (active-work.md)
+# ---------------------------------------------------------------------------
+
+
+def _norm_path(p: str) -> str:
+    """Normalize for cross-comparison: drop a leading ``disbot/``, trailing ``/``.
+
+    Claim lines write repo-relative paths inconsistently (``services/x.py`` vs
+    ``disbot/services/x.py``); stripping the package prefix aligns both forms.
+    """
+    p = p.strip().rstrip("/")
+    return p[len("disbot/") :] if p.startswith("disbot/") else p
+
+
+def _is_path_token(tok: str) -> bool:
+    if tok.startswith(_BRANCH_PREFIXES):
+        return False
+    return "/" in tok or tok.endswith(_PATH_EXTS)
+
+
+def _paths_overlap(a: str, b: str) -> bool:
+    """True when normalized paths ``a`` and ``b`` are the same or nest either way."""
+    a, b = _norm_path(a), _norm_path(b)
+    if not a or not b:
+        return False
+    return a == b or a.startswith(b + "/") or b.startswith(a + "/")
+
+
+def parse_claims(text: str) -> list[dict[str, object]]:
+    """Parse the ``## Active claims`` block into ``{branch, summary, paths}`` entries.
+
+    Pure (text in, structured out) so it is unit-testable without the real file.
+    """
+    lines = text.splitlines()
+    try:
+        start = next(
+            i for i, ln in enumerate(lines) if ln.strip().lower() == "## active claims"
+        )
+    except StopIteration:
+        return []
+    block: list[str] = []
+    for ln in lines[start + 1 :]:
+        if ln.startswith("## "):  # next section ends the block
+            break
+        block.append(ln)
+
+    claims: list[dict[str, object]] = []
+    current: list[str] = []
+
+    def _flush() -> None:
+        if not current:
+            return
+        entry_text = " ".join(s.strip() for s in current).strip()
+        tokens = _BACKTICK.findall(entry_text)
+        branch = next((t for t in tokens if t.startswith(_BRANCH_PREFIXES)), "?")
+        paths = [t for t in tokens if _is_path_token(t)]
+        # The human-readable scope is the bold **...** title, when present.
+        m = re.search(r"\*\*(.+?)\*\*", entry_text)
+        summary = m.group(1) if m else entry_text[:80]
+        claims.append({"branch": branch, "summary": summary, "paths": paths})
+
+    for ln in block:
+        if ln.lstrip().startswith("- "):  # new claim entry
+            _flush()
+            current = [ln]
+        elif current:  # continuation line of the current claim
+            current.append(ln)
+    _flush()
+    return claims
+
+
+def scan_claims(
+    scopes: list[str],
+    claims: list[dict[str, object]],
+) -> dict[str, list[dict[str, object]]]:
+    """Map each scope -> the active claims whose declared paths overlap it."""
+    hits: dict[str, list[dict[str, object]]] = {}
+    for scope in scopes:
+        matched: list[dict[str, object]] = []
+        for claim in claims:
+            paths = cast("list[str]", claim["paths"])
+            overlap = [p for p in paths if _paths_overlap(p, scope)]
+            if overlap:
+                matched.append({**claim, "matched": overlap})
+        if matched:
+            hits[scope] = matched
+    return hits
+
+
+def _load_claims() -> list[dict[str, object]]:
+    try:
+        return parse_claims(_ACTIVE_WORK.read_text(encoding="utf-8"))
+    except OSError:
+        return []
+
+
 def scan(scopes: list[str], limit: int) -> dict[str, list[tuple[str, str, list[str]]]]:
     """Map each scope -> the recent commits whose files overlap it."""
     commits = _recent_commits(limit)
@@ -78,8 +189,9 @@ def scan(scopes: list[str], limit: int) -> dict[str, list[tuple[str, str, list[s
 
 
 _FOOTER = (
-    "\n  NOTE: this covers the recently-MERGED half only (local git). The OPEN-PR half "
-    "(a concurrent unmerged PR on the same files) needs GitHub — ALSO run `list_pull_requests`."
+    "\n  NOTE: this covers the recently-MERGED commits (local git) + the active-work.md "
+    "claim ledger. The OPEN-PR half (a concurrent unmerged PR with no claim line) still "
+    "needs GitHub — ALSO run `list_pull_requests`."
 )
 
 
@@ -104,26 +216,42 @@ def main() -> int:
     args = ap.parse_args()
 
     hits = scan(args.scopes, args.limit)
-    if not hits:
+    claim_hits = scan_claims(args.scopes, _load_claims())
+
+    if not hits and not claim_hits:
         print(
-            f"check_lane_overlap: no recently-merged commit (last {args.limit}) touched "
-            f"{', '.join(args.scopes)} ✓" + _FOOTER,
+            f"check_lane_overlap: no recently-merged commit (last {args.limit}) and no "
+            f"active-work.md claim touch {', '.join(args.scopes)} ✓" + _FOOTER,
         )
         return 0
 
-    print(
-        "check_lane_overlap: ⚠ OVERLAP — this scope was touched by recently-merged work. "
-        "Verify it didn't already ship your lane (drop/re-scope before dispatch):\n",
-    )
-    for scope, overlaps in hits.items():
-        print(f"  scope `{scope}`:")
-        for short_hash, subject, matched in overlaps:
-            shown = ", ".join(matched[:4])
-            more = "" if len(matched) <= 4 else f" (+{len(matched) - 4})"
-            print(f"    {short_hash}  {subject[:72]}")
-            print(f"             ↳ {shown}{more}")
+    if claim_hits:
+        print(
+            "check_lane_overlap: ⚠ CLAIMED — this scope is claimed by a parallel session "
+            "in active-work.md. Coordinate or pick another lane before building:\n",
+        )
+        for scope, claims in claim_hits.items():
+            print(f"  scope `{scope}`:")
+            for claim in claims:
+                shown = ", ".join(cast("list[str]", claim["matched"])[:4])
+                print(f"    {claim['branch']}  {claim['summary']}")
+                print(f"             ↳ {shown}")
+        print()
+
+    if hits:
+        print(
+            "check_lane_overlap: ⚠ OVERLAP — this scope was touched by recently-merged work. "
+            "Verify it didn't already ship your lane (drop/re-scope before dispatch):\n",
+        )
+        for scope, overlaps in hits.items():
+            print(f"  scope `{scope}`:")
+            for short_hash, subject, matched in overlaps:
+                shown = ", ".join(matched[:4])
+                more = "" if len(matched) <= 4 else f" (+{len(matched) - 4})"
+                print(f"    {short_hash}  {subject[:72]}")
+                print(f"             ↳ {shown}{more}")
     print(_FOOTER)
-    return 1 if args.strict else 0
+    return 1 if (args.strict and (hits or claim_hits)) else 0
 
 
 if __name__ == "__main__":

--- a/tests/unit/scripts/test_check_lane_overlap.py
+++ b/tests/unit/scripts/test_check_lane_overlap.py
@@ -1,0 +1,97 @@
+"""Tests for scripts/check_lane_overlap.py — the active-work.md claim-ledger scan.
+
+The claim scan closes the gap that let a duplicate reaction-roles PR 2 get built:
+the merged-commit scan structurally cannot see a claim that exists *before* any PR
+or commit. These cover the pure parse + overlap logic (no git, no real file).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "check_lane_overlap",
+    Path(__file__).resolve().parents[3] / "scripts" / "check_lane_overlap.py",
+)
+assert _SPEC and _SPEC.loader
+clo = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(clo)
+
+
+_LEDGER = """# Active work
+
+## Active claims
+
+- `claude/reaction-roles-pr1-foundation` · **Reaction-roles overhaul PR 1 — audited seam**
+  (owner-directed) · `services/reaction_role_service.py` + `utils/db/role_menus.py` +
+  migration `078_reaction_role_menus.sql` · 2026-06-21 · **auto-merge on green**.
+  **Parallel session owns PR 2-5; do not recreate these.**
+
+- `claude/design-system-site-pages` · **design-system: compose the rest of the site** ·
+  `design-system/src/` (`PageHeader`/`SearchBar`) · 2026-06-20 · **auto-merge on green**
+
+## Recently cleared
+
+- `claude/old-branch` · something · `scripts/gone.py` · **PR #1 (merged)**
+"""
+
+
+def test_parse_claims_extracts_branch_paths_and_summary():
+    claims = clo.parse_claims(_LEDGER)
+    assert len(claims) == 2  # the "Recently cleared" entry is excluded
+    first = claims[0]
+    assert first["branch"] == "claude/reaction-roles-pr1-foundation"
+    assert "Reaction-roles overhaul PR 1" in first["summary"]
+    # Branch + non-path backtick tokens are excluded; real paths are kept.
+    assert "services/reaction_role_service.py" in first["paths"]
+    assert "utils/db/role_menus.py" in first["paths"]
+    assert "078_reaction_role_menus.sql" in first["paths"]
+    assert "claude/reaction-roles-pr1-foundation" not in first["paths"]
+
+
+def test_component_names_are_not_treated_as_paths():
+    claims = clo.parse_claims(_LEDGER)
+    design = claims[1]
+    assert "design-system/src/" in design["paths"]
+    # Bare component names (no slash, no extension) are not paths.
+    assert "PageHeader" not in design["paths"]
+    assert "SearchBar" not in design["paths"]
+
+
+def test_scan_claims_flags_overlapping_scope_ignoring_disbot_prefix():
+    claims = clo.parse_claims(_LEDGER)
+    # Scope uses the disbot/ prefix; the claim omits it — they must still match.
+    hits = clo.scan_claims(["disbot/services/reaction_role_service.py"], claims)
+    assert "disbot/services/reaction_role_service.py" in hits
+    matched = hits["disbot/services/reaction_role_service.py"]
+    assert matched[0]["branch"] == "claude/reaction-roles-pr1-foundation"
+
+
+def test_scan_claims_dir_scope_nests_a_claimed_file():
+    claims = clo.parse_claims(_LEDGER)
+    hits = clo.scan_claims(["disbot/services/"], claims)
+    assert "disbot/services/" in hits
+
+
+def test_scan_claims_no_overlap_is_empty():
+    claims = clo.parse_claims(_LEDGER)
+    assert clo.scan_claims(["disbot/cogs/mining_cog.py"], claims) == {}
+
+
+def test_paths_overlap_directionality():
+    assert clo._paths_overlap("services/x.py", "disbot/services/x.py")
+    assert clo._paths_overlap("disbot/services/", "services/x.py")
+    assert clo._paths_overlap("services/x.py", "services/")
+    assert not clo._paths_overlap("services/x.py", "services/y.py")
+    assert not clo._paths_overlap("", "services/")
+
+
+def test_recently_cleared_entries_are_not_claims():
+    # A path under a "Recently cleared" line must not produce a claim hit.
+    claims = clo.parse_claims(_LEDGER)
+    assert clo.scan_claims(["scripts/gone.py"], claims) == {}
+
+
+def test_parse_claims_handles_missing_section():
+    assert clo.parse_claims("# Doc\n\nno claims section here\n") == []


### PR DESCRIPTION
## Close the duplicate-work blind spot that just bit a session

`scripts/check_lane_overlap.py` flagged whether a scope was touched by **recently-merged commits** (local git) — and said so honestly: *"partial by construction … the open-PR half needs GitHub."* But it never read the **`active-work.md` claim ledger**, which is the **earliest** duplicate-work signal: a claim line ("Parallel session owns PR 2–5") exists *before* any PR or commit does. That gap let a duplicate reaction-roles **PR 2** get built this session before the owner caught it (the parallel session's PR 2 had already merged as #1219).

### What changes
- `parse_claims()` / `scan_claims()` + path-overlap helpers — parse the `## Active claims` block (excluding `## Recently cleared`) into `{branch, summary, paths}`, normalizing away an inconsistent leading `disbot/` so `services/x.py` (claim) matches `disbot/services/x.py` (scope).
- `main()` prints a **⚠ CLAIMED** section (naming the owning branch) ahead of the existing **⚠ OVERLAP** merged-commit section; `--strict` exits 1 on either.
- First test suite for the script (`tests/unit/scripts/test_check_lane_overlap.py`, 8 tests).

Live: `check_lane_overlap.py disbot/services/reaction_role_service.py` now fires **CLAIMED → `claude/reaction-roles-pr1-foundation`** — the warning that would have prevented this session's duplicate.

### Gate
stdlib-only dev tooling (Q-0105, disposable), additive, touches only the script + its new test → **self-merge on green**. Not wired into any hook/CI gate (executable config — left for a router proposal if it proves trustworthy across sessions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvC391yTi6q72EtCK9ysyz

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvC391yTi6q72EtCK9ysyz)_