### PR TITLE
docs(workflow): Q-0189 — open the session PR FAST (within ~2 min of start)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -202,6 +202,15 @@ is **per-file**. Full convention: `docs/owner/ai-project-workflow.md` §9.
   supersedes the "open the PR ready" phrasing above for `claude/*` sessions: **open it born-red,
   flip it ready last.** (`scripts/check_session_gate.py`; ready tokens:
   `complete/done/ready/final/merged/shipped`.)
+  **Open it FAST — target the first ~2 minutes of the session, before the build work (owner
+  directive Q-0189, 2026-06-21).** The born-red card → first push → PR open is your **first
+  action** once you've oriented enough to name your scope and claimed the lane
+  (`active-work.md`) — *not* something deferred until after the bulk of the work is written.
+  The entire value of the early open is the **in-flight signal**: a visible PR (plus the claim
+  line) is how parallel sessions see your lane and avoid duplicating it (the #1221 duplicate-PR
+  lesson — a PR that opens late, after substantial work, is invisible during exactly the window
+  when a collision is most likely). So: orient → decide scope → claim → **open the born-red PR
+  immediately** → then build. Don't let the open slip behind the work.
 - **End every session with a backlog-grooming pass — the standing secondary task (owner
   decision Q-0015).** Once the main task + PR are done and capacity remains, you are *not*
   finished: browse `docs/ideas/` (plus any ideas the maintainer dropped this session) and

--- a/.sessions/2026-06-21-early-pr-mandate.md
+++ b/.sessions/2026-06-21-early-pr-mandate.md
@@ -1,0 +1,21 @@
+# Session — open the session PR FAST (Q-0189, owner-directed in-session)
+
+> **Status:** `in-progress`
+> **Run type:** routine · dispatch
+> **Branch:** `claude/early-pr-mandate`
+
+## What I'm about to do
+
+Owner directed, live in-session: make it mandatory to open the session PR **within
+~2 minutes of session start** (before the build work), not let it drift behind the
+work. Applying under the Q-0106 live-owner carve-out (owner is the reviewer):
+
+- Amend the **Q-0133 born-red bullet** in `.claude/CLAUDE.md` § Session & plan
+  workflow with the timing mandate (orient → decide scope → claim → open the
+  born-red PR immediately → then build).
+- Record provenance **Q-0189** in `docs/owner/maintainer-question-router.md`.
+
+Docs-only; owner is live reviewer → self-merge on green.
+
+## Verification
+`python3.10 scripts/check_docs.py --strict`

--- a/.sessions/2026-06-21-early-pr-mandate.md
+++ b/.sessions/2026-06-21-early-pr-mandate.md
@@ -1,21 +1,41 @@
 # Session — open the session PR FAST (Q-0189, owner-directed in-session)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 > **Run type:** routine · dispatch
-> **Branch:** `claude/early-pr-mandate`
+> **Branch:** `claude/early-pr-mandate` · **PR:** #1224
 
-## What I'm about to do
+## What shipped
 
-Owner directed, live in-session: make it mandatory to open the session PR **within
-~2 minutes of session start** (before the build work), not let it drift behind the
-work. Applying under the Q-0106 live-owner carve-out (owner is the reviewer):
+Owner directed, live in-session: opening the session PR is now mandated to happen
+**within ~2 minutes of session start**, before the build work — applied under the
+Q-0106 live-owner carve-out (owner is the reviewer).
 
-- Amend the **Q-0133 born-red bullet** in `.claude/CLAUDE.md` § Session & plan
-  workflow with the timing mandate (orient → decide scope → claim → open the
-  born-red PR immediately → then build).
-- Record provenance **Q-0189** in `docs/owner/maintainer-question-router.md`.
+- Amended the **Q-0133 born-red bullet** in `.claude/CLAUDE.md` § Session & plan
+  workflow with the timing mandate: *orient → decide scope → claim → open the
+  born-red PR immediately → then build; target the first ~2 minutes, don't let the
+  open slip behind the work.*
+- Recorded provenance **Q-0189** in `docs/owner/maintainer-question-router.md`,
+  framed as the *timing* half of Q-0052 / Q-0103 / Q-0133.
 
-Docs-only; owner is live reviewer → self-merge on green.
+Docs-only; `check_docs --strict` + `check_quality --check-only` green; owner is live
+reviewer → self-merge on green.
 
-## Verification
-`python3.10 scripts/check_docs.py --strict`
+## Session enders
+
+**⟲ Previous-session review (Q-0102):** this is the third lane in one chat. The
+first (duplicate reaction-roles PR 2) failed by skipping the `active-work.md` +
+open-PR pre-scan; the second fixed the tool that should catch that (claim-ledger
+scan in `check_lane_overlap.py`, #1223 merged); this third pins the *timing* of the
+early PR open so the in-flight signal is visible sooner. Together they harden the
+exact failure mode that started the chat — a tight self-auditing loop.
+
+**📚 Doc audit (Q-0104):** rule lives in `.claude/CLAUDE.md` (Q-0133 bullet) with
+provenance in the router (Q-0189). `active-work.md` claim added. No `current-state`
+change needed.
+
+## 📤 Run report
+- **Run type:** routine · dispatch
+- **What shipped:** Q-0189 — open the session PR within ~2 min of start (CLAUDE.md + router).
+- **⚑ Self-initiated:** no — owner directed it live in-session.
+- **⚑ Owner-decisions:** Q-0189 (recorded in the router).
+- **⚑ Owner-manual-steps:** none.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,10 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/early-pr-mandate` · **Q-0189 — open the session PR within ~2 min of start** (owner-directed
+  in-session rule) · `.claude/CLAUDE.md` (Q-0133 bullet) + `docs/owner/maintainer-question-router.md`
+  · 2026-06-21 · **auto-merge on green** (docs-only · owner is live reviewer)
+
 - `claude/lane-overlap-claim-scan` · **check_lane_overlap.py — add the active-work.md claim-ledger
   scan** (closes the gap that let a duplicate reaction-roles PR 2 get built: the tool only scanned
   recently-MERGED commits, not the earliest "owns PR 2–5" claim signal) · `scripts/check_lane_overlap.py`

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -6903,3 +6903,28 @@ exact data-loss foot-gun seen earlier this chat. The banner surfaces the state +
 so the agent judges (purely-behind = safe reset; diverged = check whether the local commits are
 already merged) and acts. **Q-0105 disposable:** delete the `sessionstart` branch + the summary call
 if it proves noisy. **Home:** the two scripts + this Q-block.
+
+---
+
+### Q-0189 — DONE (owner-directed in-session): open the session PR FAST — within ~2 min of start (2026-06-21)
+
+> **APPLIED in-session** (the live-owner exception to the "don't self-edit `.claude/CLAUDE.md`"
+> rule — owner directed it, owner is the live reviewer, provenance recorded here). Trigger: this
+> chat duplicated reaction-roles **PR 2** (rebuilt as #1221) because the in-flight signal of the
+> parallel session's lane wasn't seen early — and the owner observed that session PRs *"sometimes
+> take a while to open,"* when *"ideally that should happen within the first 2 minutes of a session
+> start."*
+
+**The rule (added to the Q-0133 born-red bullet in `.claude/CLAUDE.md` § Session & plan workflow):**
+the born-red session card → first push → PR open is the session's **first action** once scope is
+known and the lane is claimed (`active-work.md`) — **target the first ~2 minutes**, *before* the
+build work, not deferred until after the bulk is written. Sequence: **orient → decide scope → claim →
+open the born-red PR immediately → then build.**
+
+**Why:** the early open's entire value is the **in-flight signal**. A visible PR (+ the claim line) is
+how parallel sessions see your lane and avoid duplicating it; a PR that opens late — after substantial
+work — is invisible during exactly the window when a collision is most likely (the #1221 lesson). This
+is the *timing* half of Q-0052 (open right after first push) / Q-0103 (open ready) / Q-0133 (born-red
+first commit): those said *open early*; this pins *how* early. **Home:** the Q-0133 bullet in
+`.claude/CLAUDE.md` + this Q-block. No new tooling; if a SessionStart nudge later proves useful it is a
+separate, disposable add (route it).


### PR DESCRIPTION
## Owner-directed in-session rule (Q-0189)

The maintainer directed, live: it should be **mandatory to open the session PR within ~2 minutes of session start**, before the build work — *"sometimes it takes a while for it to open, but ideally that should happen within the first 2 minutes."*

This is the **timing** half of the existing early-PR rules (Q-0052 open after first push · Q-0103 open ready · Q-0133 born-red first commit): those said *open early*; this pins *how* early. It ties directly to today's lesson — this chat duplicated reaction-roles PR 2 (#1221, since closed) because the parallel lane's in-flight signal wasn't seen early enough. A visible PR (+ the `active-work.md` claim line) is how parallel sessions avoid collisions, and a PR that opens late — after substantial work — is invisible during exactly the window when a collision is most likely.

### What changes
- Amends the **Q-0133 born-red bullet** in `.claude/CLAUDE.md` § Session & plan workflow: *orient → decide scope → claim → **open the born-red PR immediately** → then build; target the first ~2 minutes, don't let the open slip behind the work.*
- Records provenance **Q-0189** in `docs/owner/maintainer-question-router.md`.

### Gate
Applied under the Q-0106 live-owner carve-out (owner directed it in-session, owner is the live reviewer) — docs-only, **self-merge on green**. No new tooling (a SessionStart nudge, if useful later, is a separate disposable add).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvC391yTi6q72EtCK9ysyz

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvC391yTi6q72EtCK9ysyz)_