### PR TITLE
docs(coordination): prune stale active-work.md claims (drift-on-sight)

### DIFF
--- a/.sessions/2026-06-21-prune-stale-claims.md
+++ b/.sessions/2026-06-21-prune-stale-claims.md
@@ -1,0 +1,23 @@
+# Session — prune stale active-work.md claims (drift-on-sight)
+
+> **Status:** `in-progress`
+> **Run type:** routine · dispatch
+> **Branch:** `claude/dispatch-next`
+
+## What I'm about to do
+
+Resume after the duplicate-work cleanup chat. With every substantial buildable lane
+either in-flight (#1213 creature PvP) or owner/review-gated, the genuinely free,
+on-theme task is **fixing visible claim-ledger drift** (Q-0166): all six `active-work.md`
+"Active claims" had already merged (#1178/#1196/#1220/#1223/#1224 + clever-maxwell's
+#1193–#1197), yet sat under Active claims — which feeds **false positives into the
+`check_lane_overlap.py` claim scan I just shipped (#1223)**, undermining the very
+duplicate-prevention tool.
+
+- Verified each claimed branch is merged (GitHub PR state), then moved all six to
+  Recently cleared with PR numbers; Active claims now holds only this lane.
+
+Docs-only; self-merge on green.
+
+## Verification
+`python3.10 scripts/check_docs.py --strict`

--- a/.sessions/2026-06-21-prune-stale-claims.md
+++ b/.sessions/2026-06-21-prune-stale-claims.md
@@ -1,8 +1,8 @@
 # Session — prune stale active-work.md claims (drift-on-sight)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 > **Run type:** routine · dispatch
-> **Branch:** `claude/dispatch-next`
+> **Branch:** `claude/dispatch-next` · **PR:** #1225
 
 ## What I'm about to do
 
@@ -20,4 +20,33 @@ duplicate-prevention tool.
 Docs-only; self-merge on green.
 
 ## Verification
-`python3.10 scripts/check_docs.py --strict`
+`check_docs --strict` ✓. After the prune, `check_lane_overlap.py` on a free scope
+(`disbot/cogs/mining_cog.py`) reads clean — no false-positive CLAIMED hits.
+
+## Session enders
+
+**💡 Session idea (Q-0089):** sessions repeatedly forget to clear their `active-work.md`
+claim at close (all six were stale here), so the ledger steadily accrues false positives.
+A cheap fix: a **Stop-hook reminder** (or a `check_active_work_staleness.py` advisory) that,
+at session close, flags any Active claim whose branch already has a merged/closed PR — the
+mirror of the Q-0188 branch-freshness banner, but for the claim ledger. Routes as a disposable
+guard; not built here (would be its own lane). Captured, not forced.
+
+**⟲ Previous-session review (Q-0102):** this chat's through-line held — duplicate PR (#1221,
+closed) → the tool that detects that class (#1223) → the timing rule that surfaces it sooner
+(#1224, Q-0189) → and now clearing the stale ledger state that would have *fed the new tool
+false positives*. Each step hardened the same failure mode. The remaining gap is *entry hygiene*
+(claims left stale at close), which the idea above targets — the natural next link.
+
+**📚 Doc audit (Q-0104):** `active-work.md` reconciled (6 stale claims → Recently cleared with
+PR #s). `check_docs --strict` green. No `current-state` change (no shipped feature). No owner
+decisions to route.
+
+## 📤 Run report
+- **Run type:** routine · dispatch
+- **What shipped:** pruned 6 stale `active-work.md` claims → Recently cleared (#1225).
+- **⚑ Self-initiated:** yes — drift-on-sight cleanup (Q-0166), no dispatch/owner ask; docs-only,
+  self-merge on green.
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none. *(Heads-up: #1213 creature-PvP engine is the only open PR,
+  `needs-hermes-review` — owned by its session, awaiting a human merge.)*

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,40 +25,28 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/early-pr-mandate` · **Q-0189 — open the session PR within ~2 min of start** (owner-directed
-  in-session rule) · `.claude/CLAUDE.md` (Q-0133 bullet) + `docs/owner/maintainer-question-router.md`
-  · 2026-06-21 · **auto-merge on green** (docs-only · owner is live reviewer)
+- `claude/dispatch-next` · **prune stale Active claims (drift-on-sight, Q-0166)** — every prior
+  claim had merged, polluting `check_lane_overlap.py` with false positives · `docs/owner/active-work.md`
+  · 2026-06-21 · **auto-merge on green** (docs-only)
 
-- `claude/lane-overlap-claim-scan` · **check_lane_overlap.py — add the active-work.md claim-ledger
-  scan** (closes the gap that let a duplicate reaction-roles PR 2 get built: the tool only scanned
-  recently-MERGED commits, not the earliest "owns PR 2–5" claim signal) · `scripts/check_lane_overlap.py`
-  + `tests/unit/scripts/test_check_lane_overlap.py` · 2026-06-21 · **auto-merge on green** (stdlib
-  dev-tooling · additive)
-
-- `claude/clever-maxwell-690qrj` · **Pokétwo + MusicBot research report → feature-mapping plan**
-  (docs-only, owner-steered plan-only) · `docs/planning/poketwo-musicbot-feature-mapping-plan-2026-06-20.md`
-  + `docs/planning/voice-music-architecture-review-2026-06-20.md` + `docs/ideas/` + router Q-0186 ·
-  2026-06-20 · **auto-merge on green (docs-only)**
-
-- `claude/design-system-site-pages` · **design-system: compose the rest of the site** (owner-chosen
-  meantime build 2026-06-20 — make every route editable in Claude Design) · `design-system/src/`
-  (`PageHeader`/`SearchBar`/`Pill`/`FeatureShowcaseCard`/`CommandDetail`/`CommandEntry`/
-  `ChangelogEntry`/`StatusCard` + `FeaturesPage`/`CommandsPage`/`ChangelogPage`/`StatusPage` +
-  stories) · `design-system/README.md` · 2026-06-20 · **auto-merge on green** (additive · verified)
-
-- `claude/compassionate-mccarthy-8u4xvy` · **Wire the Claude-Design SPA into the bot site + live
-  data** (owner-directed; SPA-as-front-end + dynamic data endpoint, confirmed via AskUserQuestion) ·
-  `botsite/site/` (design SPA, verbatim) + `botsite/site_data.py` (site.json→SBDATA generator) +
-  `botsite/app.py` + `scripts/export_dashboard_data.py` + `tests/unit/botsite/` · 2026-06-20 ·
-  **auto-merge on green**
-
-- `claude/reaction-roles-pr1-foundation` · **Reaction-roles overhaul PR 1 — audited seam + menu
-  data layer** (owner-directed; foundation for the parallel PR 2–5 session — see
-  `docs/planning/reaction-roles-overhaul-plan-2026-06-21.md`) · `services/reaction_role_service.py`
-  + `utils/db/role_menus.py` + migration `078_reaction_role_menus.sql` + `cogs/role_cog.py` (route
-  writes through the seam) + `guild_lifecycle.py` (teardown step 23) · 2026-06-21 · **PR #1220 (merged)**.
+*(Beyond the claim above, the only open PR is **#1213** creature-PvP battle engine on
+`claude/funny-franklin-mw3hxj`, a `needs-hermes-review` foundation slice — its owning
+session holds it, no claim line needed here.)*
 
 ## Recently cleared
+
+- `claude/early-pr-mandate` · **Q-0189 — open the session PR within ~2 min of start** (owner-directed
+  in-session rule) · `.claude/CLAUDE.md` (Q-0133 bullet) + `docs/owner/maintainer-question-router.md`
+  · 2026-06-21 · **PR #1224 (merged)**
+- `claude/lane-overlap-claim-scan` · **check_lane_overlap.py — active-work.md claim-ledger scan** ·
+  `scripts/check_lane_overlap.py` + `tests/unit/scripts/test_check_lane_overlap.py` · 2026-06-21 ·
+  **PR #1223 (merged)**
+- `claude/clever-maxwell-690qrj` · **creature-game design/sim + Pokétwo/MusicBot plan** ·
+  `tools/game_sim/` + `docs/planning/` + router Q-0186 · 2026-06-20 · **#1193/#1194/#1195/#1197 (merged)**
+- `claude/design-system-site-pages` · **design-system: compose the rest of the site** ·
+  `design-system/src/` · 2026-06-20 · **PR #1178 (merged)**
+- `claude/compassionate-mccarthy-8u4xvy` · **wire the Claude-Design SPA into the bot site** ·
+  `botsite/` · 2026-06-20 · **PR #1196 (merged)**
 
 - `claude/vibrant-sagan-0rr5u7` · **reaction-roles PR 2** — in-Discord role-menu builder (Surface B):
   `RoleMenuView` + builder/manager + theme/template presets + edit-in-place + `reattach_role_menus`,


### PR DESCRIPTION
## Why

All six entries under `active-work.md` **Active claims** had already merged — `clever-maxwell` (#1193–#1197), `design-system-site-pages` (#1178), `compassionate-mccarthy` (#1196), `reaction-roles-pr1-foundation` (#1220), and my own two from this chat, `lane-overlap-claim-scan` (#1223) + `early-pr-mandate` (#1224). Verified each via GitHub PR state.

Stale claims aren't harmless: they feed **false positives into the `check_lane_overlap.py` claim scan that just shipped in #1223** (a scope would show "CLAIMED" against an already-merged lane), which erodes trust in the exact duplicate-prevention tool that chat built. Fixing it on sight is the Q-0166 drift directive.

## What changes
- Moves all six merged claims to **Recently cleared** with their PR numbers.
- **Active claims** now holds only this cleanup lane; a note points at the one genuinely-open PR (#1213 creature-PvP engine, owned by its session).

Docs-only coordination whiteboard — **self-merge on green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvC391yTi6q72EtCK9ysyz

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvC391yTi6q72EtCK9ysyz)_