### PR TITLE
test(creature): guard sim↔engine combat-constant parity

### DIFF
--- a/.sessions/2026-06-21-creature-sim-engine-parity-guard.md
+++ b/.sessions/2026-06-21-creature-sim-engine-parity-guard.md
@@ -1,0 +1,26 @@
+# 2026-06-21 — Creature sim↔engine constant parity guard (PR 2)
+
+> **Status:** `in-progress` — born-red HOLD (Q-0133). Small stdlib test + a contained refactor of a
+> disposable design tool → **ungated self-merge on green** (Q-0113), not `needs-hermes-review`.
+
+> **Run type:** routine · dispatch
+
+## What I'm about to do
+
+Same dispatch run, continuation after PR #1213 (the creature battle engine) **merged** to main.
+Building the Q-0089 idea I filed this run —
+[`creature-sim-engine-constant-parity-guard`](../docs/ideas/creature-sim-engine-constant-parity-guard-2026-06-21.md):
+the combat design constants now live in **both** `tools/game_sim/creature_battle_sim.py` (the
+balance simulator) and `disbot/utils/creatures/battle.py` (the runtime engine that graduated them).
+That's a two-sources-of-truth drift class — tune one, the other silently diverges, and the sim's
+"PLAYABLE" verdict stops describing what players actually play.
+
+**Plan:** (1) lift the sim's archetype-weights dict from a local in `_roster()` to a module
+constant `ARCHETYPE_WEIGHTS` (it's the only design constant the sim keeps local — every other one
+is already module-level), so it's importable/comparable; (2) add
+`tests/unit/tools/test_creature_sim_engine_parity.py` (importlib-loads the sim, the repo convention
+for tool scripts) asserting the sim and engine agree on every shared design constant: type-chart
+multipliers, element cycle, rarity budgets, archetype weights, move powers, buff step/cap, signature
+move names, level-scaling rates, team size.
+
+Disposable, stdlib-only, fully CI-verifiable — no Discord runtime.

--- a/.sessions/2026-06-21-creature-sim-engine-parity-guard.md
+++ b/.sessions/2026-06-21-creature-sim-engine-parity-guard.md
@@ -1,26 +1,61 @@
 # 2026-06-21 — Creature sim↔engine constant parity guard (PR 2)
 
-> **Status:** `in-progress` — born-red HOLD (Q-0133). Small stdlib test + a contained refactor of a
-> disposable design tool → **ungated self-merge on green** (Q-0113), not `needs-hermes-review`.
+> **Status:** `complete` — small stdlib test + a contained refactor of a disposable design tool →
+> **ungated self-merge on green** (Q-0113); auto-merge armed, born-red HOLD lifted as the final step.
 
 > **Run type:** routine · dispatch
 
-## What I'm about to do
+## What I did
 
 Same dispatch run, continuation after PR #1213 (the creature battle engine) **merged** to main.
-Building the Q-0089 idea I filed this run —
-[`creature-sim-engine-constant-parity-guard`](../docs/ideas/creature-sim-engine-constant-parity-guard-2026-06-21.md):
-the combat design constants now live in **both** `tools/game_sim/creature_battle_sim.py` (the
-balance simulator) and `disbot/utils/creatures/battle.py` (the runtime engine that graduated them).
-That's a two-sources-of-truth drift class — tune one, the other silently diverges, and the sim's
-"PLAYABLE" verdict stops describing what players actually play.
+Built the Q-0089 idea I filed earlier this run —
+[`creature-sim-engine-constant-parity-guard`](../docs/ideas/creature-sim-engine-constant-parity-guard-2026-06-21.md).
+With #1213's engine now on main, the dependency that blocked a clean second slice was resolved, and
+the parity guard is exactly the kind of small, fully-CI-verifiable, ungated self-merge follow-on the
+dispatch prompt asks for (2–3 slices, not one) — and it directly hardens what #1213 shipped.
 
-**Plan:** (1) lift the sim's archetype-weights dict from a local in `_roster()` to a module
-constant `ARCHETYPE_WEIGHTS` (it's the only design constant the sim keeps local — every other one
-is already module-level), so it's importable/comparable; (2) add
-`tests/unit/tools/test_creature_sim_engine_parity.py` (importlib-loads the sim, the repo convention
-for tool scripts) asserting the sim and engine agree on every shared design constant: type-chart
-multipliers, element cycle, rarity budgets, archetype weights, move powers, buff step/cap, signature
-move names, level-scaling rates, team size.
+### The drift it closes
+#1213 **graduated** the combat math from the disposable sim (`tools/game_sim/creature_battle_sim.py`)
+into the runtime engine (`disbot/utils/creatures/battle.py`). Graduation *copies* the math (correct —
+the sim must never be a runtime dependency), so the design constants now live in two places: tune one,
+the other silently diverges, and the sim's "PLAYABLE" verdict stops describing what players play. Same
+two-sources-of-truth class the repo already guards with the `#1166` allowlist↔arch-frozenset test.
 
-Disposable, stdlib-only, fully CI-verifiable — no Discord runtime.
+### What shipped (PR #1227)
+- `tools/game_sim/creature_battle_sim.py` — lifted the archetype-weights dict from a local in
+  `_roster()` to a module constant `ARCHETYPE_WEIGHTS` (it was the *only* design constant the sim
+  kept local; every other is module-level), so the guard can compare it. Pure refactor — `_roster`
+  now reads the constant; no behavior change (the existing `test_creature_battle_sim.py` still green).
+- `tests/unit/tools/test_creature_sim_engine_parity.py` — importlib-loads the sim (repo convention for
+  tool scripts) and asserts sim↔engine agreement on: type-chart multipliers, element cycle, rarity
+  budgets, archetype weights, move powers, buff step/cap, signature move names, level-scaling rates,
+  team size — **plus** two behavioral checks: `effectiveness()` agrees for every (attacker, defender)
+  pair, and `derive_stats()` produces the same stat line the sim does for the whole live catalog
+  (the strongest form — survives a representation refactor, fails a real re-wire). An inert-guard
+  assertion (`checked > 0`) fails loudly if the catalog and roster ever stop overlapping.
+
+## Verification
+- `python3.10 scripts/check_quality.py --check-only` → exit 0 (true CI mirror; sim file ruff-clean in
+  CI scope; the test file's `S101`/`PT018` are in `tests/`, which CI excludes from ruff).
+- `python3.10 scripts/check_quality.py --full` → green (see run).
+- Targeted: 45 creature tests pass (10 new parity + 11 existing sim + 24 engine).
+
+## 📤 Run report
+
+- **Did:** built the Q-0089 sim↔engine constant **parity guard** (filed earlier this run), hardening
+  #1213's graduated combat math against silent drift · **Outcome:** shipped (self-merge on green)
+- **Shipped:** #1227 — parity guard + sim `ARCHETYPE_WEIGHTS` module-constant lift; ungated self-merge.
+  (This run also shipped #1213 — the battle engine — which MERGED; see its card.)
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** `none`
+- **⚑ Self-initiated:** the parity guard (#1227) — promoted my own Q-0089 idea → build with no
+  dispatched order or owner ask (Q-0172). Contained, reversible, test-only + a disposable-tool
+  refactor; flagged here for review. (The idea was filed openly in #1213; the build is the
+  self-initiated step.)
+- **↪ Next:** unchanged from #1213's handoff — the user-facing creature **PvP flow**
+  (runtime-verified `needs-hermes-review`): `cogs/creature_battle/` + `views/creature_battle/` panels
+  mirroring `rps`/`deathmatch`, a thin `services/` boundary to read each player's team from the
+  collection-log and (later) record results. Build on `utils.creatures.battle.{resolve_battle,
+  standard_team, build_team, Combatant, BattleOutcome}`; the parity guard now keeps the sim honest
+  as the engine evolves.

--- a/docs/ideas/creature-sim-engine-constant-parity-guard-2026-06-21.md
+++ b/docs/ideas/creature-sim-engine-constant-parity-guard-2026-06-21.md
@@ -1,7 +1,15 @@
 # Idea — a parity guard tying the creature sim to the runtime battle engine
 
-> **Status:** `ideas` · captured 2026-06-21 (creature PvP battle-engine session, PR #1213).
+> **Status:** `ideas` · captured 2026-06-21 (creature PvP battle-engine session, PR #1213) ·
+> **BUILT 2026-06-21 (PR #1227)** — same dispatch run, after #1213 merged.
 > Not a plan, not approval. Source + binding contracts win.
+
+> **▶ SHIPPED (PR #1227):** `tests/unit/tools/test_creature_sim_engine_parity.py` loads both modules
+> and asserts they agree on every shared design constant (type chart · element cycle · rarity
+> budgets · archetype weights · move powers · buff step/cap · signature move names · level-scaling
+> rates · team size) **plus** a behavioral end-to-end check (the engine derives the same stat line
+> the sim does for the whole catalog). The sim's archetype-weights dict was lifted from a local in
+> `_roster()` to a module constant `ARCHETYPE_WEIGHTS` so it's comparable. This idea is now closed.
 > **Lane:** decided/small — a stdlib parity test, no owner decision needed.
 > **Subsystem:** games (creatures) · tooling.
 

--- a/tests/unit/tools/test_creature_sim_engine_parity.py
+++ b/tests/unit/tools/test_creature_sim_engine_parity.py
@@ -1,0 +1,147 @@
+"""Parity guard — the creature sim and the runtime battle engine must agree.
+
+The runtime PvP battle engine (``disbot/utils/creatures/battle.py``, PR #1213)
+**graduated** its combat math from the disposable playability simulator
+(``tools/game_sim/creature_battle_sim.py``). Graduation copies the math rather than
+importing it — correctly, because the sim is a *design tool* that must never become
+a runtime dependency. The cost of that copy is a **two-sources-of-truth drift
+class**: the owner tunes a number in the sim to fix balance, the runtime engine
+keeps the old value, and the sim's "PLAYABLE" verdict silently stops describing what
+players actually play.
+
+This guard closes that gap. It loads both modules and asserts they agree on every
+**shared design constant**. A tuning change to either side that isn't mirrored fails
+CI with a clear "sim and engine disagree on X" message. Same shape as the
+``panel_base_class`` allowlist↔arch-frozenset parity test (PR #1166).
+
+The sim is loaded via :mod:`importlib` (the repo convention for non-package tool
+scripts — mirrors ``tests/unit/tools/test_creature_battle_sim.py``). The engine is a
+normal package import.
+
+Provenance + reliability (Q-0105): added 2026-06-21 (the PR #1213 Q-0089 idea,
+``docs/ideas/creature-sim-engine-constant-parity-guard-2026-06-21.md``). Disposable:
+delete it if the sim is ever retired — at that point the engine is the sole source
+of truth and there is nothing left to compare (the sim's own header says it is
+deletable once its numbers are pinned into the real subsystem).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from utils.creatures import battle as engine
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "tools" / "game_sim" / "creature_battle_sim.py"
+
+
+@pytest.fixture(scope="module")
+def sim():
+    spec = importlib.util.spec_from_file_location(
+        "creature_battle_sim_parity_ut", _SCRIPT,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# --------------------------------------------------------------------------- type chart
+
+
+def test_element_cycle_matches(sim) -> None:
+    """The engine's canonical ELEMENT_CYCLE is the sim's ELEMENTS tuple (same order)."""
+    assert engine.ELEMENT_CYCLE == sim.ELEMENTS
+
+
+def test_type_multipliers_match(sim) -> None:
+    assert engine.STRONG_MULT == sim.STRONG_MULT
+    assert engine.WEAK_MULT == sim.WEAK_MULT
+    assert engine.NEUTRAL_MULT == sim.NEUTRAL_MULT
+    assert engine.NORMAL_TYPE == sim.NORMAL_TYPE
+
+
+def test_effectiveness_agrees_for_every_pair(sim) -> None:
+    """The whole type chart agrees — including Normal and every element ordering.
+
+    The strongest form of parity: not just the constants but the *function output*
+    for every (attacker, defender) pair, so a refactor that changes representation
+    but not behavior still passes, and a re-wired cycle fails.
+    """
+    types = (engine.NORMAL_TYPE, *engine.ELEMENT_CYCLE)
+    for atk in types:
+        for dfd in engine.ELEMENT_CYCLE:
+            assert engine.effectiveness(atk, dfd) == sim.effectiveness(atk, dfd), (
+                atk,
+                dfd,
+            )
+
+
+# --------------------------------------------------------------------------- stats
+
+
+def test_rarity_budget_matches(sim) -> None:
+    assert engine.RARITY_BUDGET == sim.RARITY_BUDGET
+
+
+def test_archetype_weights_match(sim) -> None:
+    assert engine.ARCHETYPE_WEIGHTS == sim.ARCHETYPE_WEIGHTS
+
+
+def test_level_scaling_rates_match(sim) -> None:
+    assert engine.HP_PER_LVL == sim.HP_PER_LVL
+    assert engine.OFF_PER_LVL == sim.OFF_PER_LVL
+
+
+# --------------------------------------------------------------------------- moves
+
+
+def test_move_powers_and_buffs_match(sim) -> None:
+    assert engine.NORMAL_POWER == sim.NORMAL_POWER
+    assert engine.ELEMENT_POWER == sim.ELEMENT_POWER
+    assert engine.BUFF_STEP == sim.BUFF_STEP
+    assert engine.BUFF_CAP == sim.BUFF_CAP
+
+
+def test_team_size_matches(sim) -> None:
+    assert engine.TEAM_SIZE == sim.TEAM_SIZE
+
+
+def test_signature_move_names_match(sim) -> None:
+    """The per-element signature-move display names are identical (no Pokémon IP)."""
+    assert engine.ELEMENT_MOVE_NAME == sim._ELEMENT_MOVE
+
+
+def test_derived_stats_agree_for_the_whole_catalog(sim) -> None:
+    """End-to-end: the engine derives the same HP/ATK/DEF/SPD the sim does.
+
+    The sim derives stats inside ``_roster`` (rarity budget split by archetype
+    weights); the engine derives them in ``derive_stats``. Walk the live catalog and
+    assert they produce identical stat lines for every creature — the behavioral
+    proof that the budget + weight + rounding pipeline is shared, not just the
+    constants feeding it.
+    """
+    sim_by_name = {s.name: s for s in sim.ROSTER}
+    from utils.creatures.creature import CREATURES
+
+    checked = 0
+    for creature in CREATURES:
+        species = sim_by_name.get(creature.name)
+        if species is None:
+            continue  # roster/catalog drift is its own test's concern, not this one
+        stats = engine.derive_stats(creature)
+        assert (stats.hp, stats.atk, stats.df, stats.spd) == (
+            species.hp,
+            species.atk,
+            species.df,
+            species.spd,
+        ), creature.name
+        checked += 1
+    assert (
+        checked > 0
+    ), "no overlap between engine catalog and sim roster — guard is inert"

--- a/tools/game_sim/creature_battle_sim.py
+++ b/tools/game_sim/creature_battle_sim.py
@@ -100,6 +100,15 @@ RARITY_BUDGET: dict[str, int] = {
     "Rare": 260,
     "Epic": 300,
 }
+# Archetype stat weights (hp, atk, df, spd) — the budget is split in these
+# proportions. Module-level (not a local in ``_roster``) so the runtime engine's
+# parity guard can compare it (``tests/unit/tools/test_creature_sim_engine_parity.py``).
+ARCHETYPE_WEIGHTS: dict[str, tuple[float, float, float, float]] = {
+    "attacker": (0.9, 1.3, 0.7, 1.1),
+    "tank": (1.3, 0.8, 1.3, 0.6),
+    "balanced": (1.0, 1.0, 1.0, 1.0),
+    "speedster": (0.8, 1.2, 0.7, 1.3),
+}
 # Base catch chance per rarity at player level 1 (before level/curve bonuses).
 RARITY_CATCH_BASE: dict[str, float] = {
     "Common": 0.55,
@@ -152,12 +161,7 @@ def _roster() -> list[Species]:
     Archetype weights (hp, atk, df, spd): attacker .9/1.3/.7/1.1, tank 1.3/.8/1.3/.6,
     balanced 1/1/1/1, speedster .8/1.2/.7/1.3.
     """
-    arche = {
-        "attacker": (0.9, 1.3, 0.7, 1.1),
-        "tank": (1.3, 0.8, 1.3, 0.6),
-        "balanced": (1.0, 1.0, 1.0, 1.0),
-        "speedster": (0.8, 1.2, 0.7, 1.3),
-    }
+    arche = ARCHETYPE_WEIGHTS
     catalog = json.loads((Path(__file__).with_name("creatures.json")).read_text())
     out: list[Species] = []
     for c in catalog["creatures"]:


### PR DESCRIPTION
## Creature sim↔engine constant parity guard

Follow-on to #1213 (the creature battle engine, now merged). That PR graduated the validated sim's combat math into `disbot/utils/creatures/battle.py`, which means the combat **design constants now live in two places**: the simulator (`tools/game_sim/creature_battle_sim.py`) and the runtime engine. Tune one without the other and the sim's "PLAYABLE" verdict silently stops describing what players actually play — the same two-sources-of-truth drift class the repo already guards with the `#1166` allowlist↔arch-frozenset parity test.

### What ships
- `tools/game_sim/creature_battle_sim.py` — lift the archetype-weights dict from a local in `_roster()` to a module constant `ARCHETYPE_WEIGHTS` (it was the *only* design constant the sim kept local; every other is module-level), so it's importable/comparable. Pure refactor, no behavior change.
- `tests/unit/tools/test_creature_sim_engine_parity.py` — importlib-loads the sim (the repo convention for tool scripts) and asserts the sim and engine agree on every shared design constant: type-chart multipliers, element cycle, rarity budgets, archetype weights, move powers, buff step/cap, signature move names, level-scaling rates, team size. A tuning change to either side that isn't mirrored now fails CI with a clear message.

### Gate
Small, stdlib-only, fully CI-verifiable (no Discord runtime) → ungated self-merge on green (Q-0113). Disposable: deletes itself out of relevance if the sim is ever retired (at which point the engine is the sole source of truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0125Jkb5gfa4RpLRxzdCMEn1)_