### PR TITLE
docs: answer open-source/self-host posture under the free-for-everyone North Star

### DIFF
--- a/.sessions/2026-06-21-free-for-everyone-north-star.md
+++ b/.sessions/2026-06-21-free-for-everyone-north-star.md
@@ -106,3 +106,14 @@ nothing consequential left only in chat.
 | Repo-rule trips | 0 |
 | New ideas contributed | 1 (anti-paywall-creep lint, Q-0089) |
 | Ideas groomed | 1 (owner vision → decided North Star + mission doc + roadmap horizon — top-of-lifecycle routing, Q-0015) |
+
+## Follow-up (2026-06-21) — open-source posture answered
+
+The owner answered the open-source / self-host open question (Q-0190 §5.1) later in the same session:
+**eventually reusable, not yet** — *"there's still a lot of moving around to do before this code is
+actually solid."* Grounded it: the repo is **already public + MIT-licensed** (`LICENSE`), so it is
+*legally* reusable **now**; the "not yet" is a **code-maturity recommendation, not a licensing gate**.
+The real path to recommend-able reuse is the existing repo-organization lanes (architecture atlas /
+consistency linter / repo-structure plan). Recorded in the mission doc §5.1 + router Q-0190's Open
+line; shipped as a small follow-up PR (no new session card — non-adopting docs change). No new owner
+decision pending.

--- a/docs/ideas/free-for-everyone-mission-2026-06-21.md
+++ b/docs/ideas/free-for-everyone-mission-2026-06-21.md
@@ -87,10 +87,14 @@ the *primary* sustainability lever, not a fallback:
 
 ## 5. Open questions (captured, not blockers)
 
-1. **Open-source / self-host?** "Free for everyone" here means **free to *use*** (the hosted
-   SuperBot). Whether the *source* is open / self-hostable is a **separate, unraised** question — and
-   arguably in tension with "make other bots go out of business" (giving away the source arms
-   competitors). Out of scope until the owner raises it → route to the router if it comes up.
+1. **Open-source / self-host? — ANSWERED (owner, 2026-06-21).** The repo is **already public and
+   MIT-licensed** (`LICENSE`, © Menno van Hattum), so the source is *legally* reusable by anyone
+   **right now** — and that is the "free for everyone" ethos taken to its conclusion, not a threat to
+   it. The owner's position: reuse should **eventually be easy, but is not recommended yet** —
+   *"there's still a lot of moving around to do before this code is actually solid."* So the gate is
+   **code maturity, not licensing**: the road to recommend-able reuse is the ongoing repo-organization
+   work (architecture atlas · consistency linter · the repo-structure-improvement plan) maturing — not
+   a license or policy change. No "self-host / quickstart" docs until the structure settles.
 2. **Enforcement tooling.** Should a disposable lint (**Q-0105**) flag any new
    "premium/paywall/paid-tier-gate" language creeping into docs or code? The Q-0039 CI invariant
    already guards the *economy* (no supporter predicate in odds/reward/cooldown/fee paths); a

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -6962,9 +6962,11 @@ grammar (AI default-off, tiny per-guild budgets, caching, visible in-world degra
 *primary* sustainability lever, not a fallback — and the voluntary-support surface (§2 of the mission
 doc) is the only money inflow.
 
-**Open (captured, not blocking):** open-source / self-host posture (unraised — "free" = free-to-*use*
-for now); a product-wide anti-paywall-creep lint (Q-0105 disposable; needs an allowlist); the
-`/support` surface itself (allowed, not yet designed).
+**Open (captured, not blocking):** a product-wide anti-paywall-creep lint (Q-0105 disposable; needs an
+allowlist); the `/support` surface itself (allowed, not yet designed). **The open-source / self-host
+question is now ANSWERED (owner, 2026-06-21):** the repo is already public + MIT-licensed (legally
+reusable *now*), but reuse is **not recommended** until the code is reorganized/solid — the gate is
+code maturity, not licensing (mission doc §5.1).
 
 **Home:** [`docs/ideas/free-for-everyone-mission-2026-06-21.md`](../ideas/free-for-everyone-mission-2026-06-21.md)
 (full statement) + `docs/roadmap.md` (product-principle callout) + `docs/current-state.md` ▶ Off-limits


### PR DESCRIPTION
Follow-up to #1226. The owner answered the open-source / self-host question I'd captured as open in **Q-0190 §5.1**.

## The answer (owner, 2026-06-21)

Reuse should **eventually be easy, but is not recommended yet** — *"there's still a lot of moving around to do before this code is actually solid."*

Grounded against the repo's actual license: the repo is **already public + MIT-licensed** (`LICENSE`, © Menno van Hattum), so the source is **legally reusable right now**. The "not yet" is therefore a **code-maturity recommendation, not a licensing gate** — and open-source is the "free for everyone" ethos taken to its conclusion, fully consistent with the North Star. The real path to recommend-able reuse is the existing repo-organization lanes (architecture atlas · consistency linter · repo-structure plan) maturing.

## Changes (docs-only, no new session card)

- `docs/ideas/free-for-everyone-mission-2026-06-21.md` §5.1 — open question → ANSWERED.
- `docs/owner/maintainer-question-router.md` — Q-0190 Open line marked answered.
- `.sessions/2026-06-21-free-for-everyone-north-star.md` — follow-up note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQmuJMQGWjiECWC8QTNDxQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQmuJMQGWjiECWC8QTNDxQ)_