### PR TITLE
docs: record license decision — stay MIT for now (free-use-only deferred)

### DIFF
--- a/docs/ideas/free-for-everyone-mission-2026-06-21.md
+++ b/docs/ideas/free-for-everyone-mission-2026-06-21.md
@@ -95,6 +95,17 @@ the *primary* sustainability lever, not a fallback:
    **code maturity, not licensing**: the road to recommend-able reuse is the ongoing repo-organization
    work (architecture atlas · consistency linter · the repo-structure-improvement plan) maturing — not
    a license or policy change. No "self-host / quickstart" docs until the structure settles.
+
+   **License posture revisited (owner, 2026-06-21, later same session) — STAY MIT FOR NOW.** The owner
+   weighed adding a *"reuse only if the derivative stays 100% free to use"* restriction — a
+   mission-protective **"keep-it-free"** rule so nobody can paywall a fork. After reviewing the
+   trade-off (it moves SuperBot **off MIT and off formal open-source** into source-available/
+   free-use-only; it can't be appended to MIT, whose grant is "without restriction"; it would need a
+   coherent standard like **PolyForm Noncommercial** or a custom clause), he chose to **stay MIT for
+   now** — keeping open-source status + maximum reusability, and accepting that a derivative *could* in
+   theory be paid. **Revisit trigger:** reconsider a free-use-only license only if a paid derivative
+   actually appears. (Copies already taken under MIT stay MIT; any relicense binds only future
+   versions.)
 2. **Enforcement tooling.** Should a disposable lint (**Q-0105**) flag any new
    "premium/paywall/paid-tier-gate" language creeping into docs or code? The Q-0039 CI invariant
    already guards the *economy* (no supporter predicate in odds/reward/cooldown/fee paths); a

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -6966,7 +6966,11 @@ doc) is the only money inflow.
 allowlist); the `/support` surface itself (allowed, not yet designed). **The open-source / self-host
 question is now ANSWERED (owner, 2026-06-21):** the repo is already public + MIT-licensed (legally
 reusable *now*), but reuse is **not recommended** until the code is reorganized/solid — the gate is
-code maturity, not licensing (mission doc §5.1).
+code maturity, not licensing (mission doc §5.1). The owner additionally weighed a **free-use-only**
+"keep-it-free" license restriction (so a fork can't be paywalled) and chose to **stay MIT for now**
+(2026-06-21) — keeping open-source status + max reusability, accepting that a derivative could in
+theory be paid; revisit (PolyForm-Noncommercial-style) only if that actually happens (already-
+distributed MIT copies stay MIT).
 
 **Home:** [`docs/ideas/free-for-everyone-mission-2026-06-21.md`](../ideas/free-for-everyone-mission-2026-06-21.md)
 (full statement) + `docs/roadmap.md` (product-principle callout) + `docs/current-state.md` ▶ Off-limits


### PR DESCRIPTION
Records an owner decision made in-session (follow-up to #1226/#1228, under **Q-0190**).

## Decision

The owner weighed adding a **"reuse only if the derivative stays 100% free to use"** restriction — a mission-protective "keep-it-free" rule so nobody can paywall a fork. After reviewing the trade-off — it moves SuperBot **off MIT / off formal open-source** into source-available, can't be appended to MIT (whose grant is "without restriction"), and would need a coherent standard (e.g. PolyForm Noncommercial) or a custom clause — he chose to **stay MIT for now**, keeping open-source status and maximum reusability, and accepting that a derivative *could* in theory be paid.

**Revisit trigger:** reconsider a free-use-only license only if a paid derivative actually appears. (Copies already taken under MIT stay MIT; a relicense binds only future versions.)

**No license file change** — this just records the considered-and-deferred decision so it isn't re-litigated.

## Changes (docs-only, no new session card)

- `docs/ideas/free-for-everyone-mission-2026-06-21.md` §5.1 — "License posture revisited" note.
- `docs/owner/maintainer-question-router.md` — Q-0190 Open line: deferral + revisit trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQmuJMQGWjiECWC8QTNDxQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQmuJMQGWjiECWC8QTNDxQ)_