### PR TITLE
Reaction roles: post-channel picker + auto-created colour roles (with gradient/holographic)

### DIFF
--- a/.sessions/2026-06-21-reaction-roles-channel-and-color-roles.md
+++ b/.sessions/2026-06-21-reaction-roles-channel-and-color-roles.md
@@ -1,0 +1,25 @@
+# 2026-06-21 — Reaction roles: channel picker + auto-created colour/gradient roles
+
+> **Status:** `in-progress` — born-red HOLD (Q-0133). Owner-directed follow-up to #1234
+> (Q-0191 → merge immediately on green). New branch (not `claude/lucid-carson-qsn1gc`, which
+> just merged and is contested by the parallel creature-PvP session — Q-0014: branch identity
+> is not significant).
+
+> **Run type:** `manual`
+
+## What I'm about to do
+
+Three owner-requested enhancements to the role-menu builder:
+
+1. **Choose the post channel** — a 📍 Channel picker on `RoleMenuBuilder` so a menu can be posted
+   to a dedicated reaction-roles channel, not just the channel the panel is open in.
+2. **Auto-create colour roles** — pick colours that don't exist yet as roles and have the bot
+   create them in one smooth action, then add them to the menu. Routed through the audited
+   `RoleLifecycleService` (the only sanctioned `create_role` caller), reusing a same-named role
+   when one already exists.
+3. **Gradient / holographic roles** — discord.py 2.7.1 supports `secondary_colour`/`tertiary_colour`
+   on `create_role`/`Role.edit`. Discord gates the *Enhanced Role Styles* perk on **3 applied
+   server boosts**, so the gradient UI is offered only when `guild.features` shows the perk, with a
+   solid-colour fallback (and a caught-400 belt-and-suspenders).
+
+Verify: `check_quality.py --full` + `check_architecture.py --mode strict`.

--- a/.sessions/2026-06-21-reaction-roles-channel-and-color-roles.md
+++ b/.sessions/2026-06-21-reaction-roles-channel-and-color-roles.md
@@ -1,25 +1,103 @@
 # 2026-06-21 — Reaction roles: channel picker + auto-created colour/gradient roles
 
-> **Status:** `in-progress` — born-red HOLD (Q-0133). Owner-directed follow-up to #1234
-> (Q-0191 → merge immediately on green). New branch (not `claude/lucid-carson-qsn1gc`, which
-> just merged and is contested by the parallel creature-PvP session — Q-0014: branch identity
-> is not significant).
+> **Status:** `complete` — owner-directed follow-up to #1234 (Q-0191 → merge on green). PR #1237.
 
 > **Run type:** `manual`
 
-## What I'm about to do
+## Arc
 
-Three owner-requested enhancements to the role-menu builder:
+Three owner-requested enhancements to the role-menu builder, on a fresh branch
+(`claude/reaction-roles-channel-and-colors`, not the merged+contested
+`claude/lucid-carson-qsn1gc` — Q-0014: branch identity is not significant):
 
-1. **Choose the post channel** — a 📍 Channel picker on `RoleMenuBuilder` so a menu can be posted
-   to a dedicated reaction-roles channel, not just the channel the panel is open in.
-2. **Auto-create colour roles** — pick colours that don't exist yet as roles and have the bot
-   create them in one smooth action, then add them to the menu. Routed through the audited
-   `RoleLifecycleService` (the only sanctioned `create_role` caller), reusing a same-named role
-   when one already exists.
-3. **Gradient / holographic roles** — discord.py 2.7.1 supports `secondary_colour`/`tertiary_colour`
-   on `create_role`/`Role.edit`. Discord gates the *Enhanced Role Styles* perk on **3 applied
-   server boosts**, so the gradient UI is offered only when `guild.features` shows the perk, with a
-   solid-colour fallback (and a caught-400 belt-and-suspenders).
+1. **📍 Post-channel picker** — `RoleMenuBuilder` gained a Channel control so a menu can be posted
+   to a dedicated reaction-roles channel, not just the channel the panel is open in. Reuses
+   `views.selectors.attach_channel_select`; the target is shown in the builder embed.
+2. **🎨 Auto-created colour roles** — a Colours flow: a multi-select of the 8 `_COLOR_OPTIONS`
+   presets + a Custom modal (name + 1–3 hex colours). Each chosen colour becomes a role —
+   reuse-if-same-name, else create via `reaction_role_service.ensure_color_role` →
+   `RoleLifecycleService` (the audited, allowlisted `create_role` caller) — then added to the menu.
+3. **✨ Gradient / holographic roles** — `RoleLifecycleRequest` + the create/edit paths now carry
+   `secondary_color`/`tertiary_color`; `supports_role_gradients(guild)` gates the gradient UI on the
+   guild advertising the Enhanced-Role-Styles feature, with a caught-failure solid-colour fallback.
 
-Verify: `check_quality.py --full` + `check_architecture.py --mode strict`.
+## Findings / decisions
+
+- **Gradient roles — researched + answered (the owner's question).** discord.py **2.7.1** (our pin)
+  *does* support it: `Guild.create_role` and `Role.edit` both accept `secondary_colour`/`secondary_color`
+  and `tertiary_colour`/`tertiary_color` (verified by introspecting the installed lib — ground truth,
+  not docs). Two colours = gradient, three = holographic. **Discord gates it server-side:** the
+  *Enhanced Role Styles* perk needs **3 applied server boosts** (independent of boost *level*); without
+  it the API 400s, and if the perk lapses Discord reverts styled roles to their primary solid colour.
+  ([support](https://support.discord.com/hc/en-us/articles/31444213087255-Enhanced-Role-Styles),
+  [blog](https://discord.com/blog/get-more-from-your-boosts-with-new-server-perks)).
+- **Decision made alone:** colour-role creation routes through `RoleLifecycleService` (audited,
+  event-emitting, on the `test_no_silent_auto_create` allowlist) rather than a raw `guild.create_role`
+  in the view — keeps the create auditable and arch-clean. `ensure_color_role` reuses a same-named
+  role rather than making duplicates.
+- **Decision made alone:** gradient is **double-gated** — `supports_role_gradients` (a *defensive
+  substring* match on `guild.features`, since the exact flag shifted during rollout) decides whether to
+  *offer* it, and the create path **retries solid** if a gradient create is rejected anyway. A stale
+  feature read is therefore never fatal.
+- **Decision made alone:** the post-channel picker offers `guild.text_channels`; Duplicate/Repost
+  channel semantics from #1234 are unchanged.
+
+## Context delta
+
+- **Needed but not pointed to:** which discord.py version we run + whether it supports gradients —
+  resolved by `python3.10 -c "import discord; inspect.signature(Guild.create_role)"` (ground truth >
+  docs). Worth a journal note: *introspect the installed lib for "does our version support X" before
+  reaching for docs.*
+- **Discovered by hand:** `RoleLifecycleService` is the **single sanctioned `create_role` caller**
+  (allowlisted by `tests/unit/invariants/test_no_silent_auto_create.py`) — any new role creation MUST
+  go through it or the invariant fails. This is in the service docstring but not the orientation route.
+- **Pointed to but didn't need:** the broad `docs/current-state.md` callouts — the plan doc +
+  `role_lifecycle_service` docstring were the load-bearing context.
+- **Decisions made alone:** see Findings (audited create; double-gated gradient).
+- **Weak point / unverified:** the gradient + colour-create paths are unit-tested with the API mocked;
+  **not live-walked** against a real boosted guild — the actual `create_role(secondary_color=…)` round
+  trip and the 400→solid fallback want a runtime smoke on a 3-boost server.
+- **One docs/tooling change that would help:** an orientation line "creating a role at runtime? → only
+  via `RoleLifecycleService` (invariant-guarded)" so the next agent doesn't reach for `guild.create_role`.
+
+## 📤 Run report
+
+- **Did:** menu post-channel picker + auto-created colour roles + gradient/holographic support ·
+  **Outcome:** shipped (PR #1237, auto-merge on green)
+- **Shipped:** #1237 — reaction-roles channel picker + colour/gradient role auto-create
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** none (owner-directed)
+- **⚑ Owner manual steps:** **gradient/holographic roles need the server to have applied 3 boosts**
+  (Enhanced Role Styles) — without it the bot creates solid-colour roles. Merge ≠ deploy: the prod
+  restart stays yours.
+- **⚑ Self-initiated:** none (direct owner request)
+- **↪ Next:** optional live-walk on a boosted guild to confirm the gradient round-trip; the
+  message-picker idea from #1234 still stands.
+
+## 💡 Session idea
+
+**Gradient/holographic presets gallery.** Now that gradient roles are wired, a curated gallery of
+ready-made two/three-colour styles (e.g. "Sunset", "Ocean", "Holographic") as one-tap picks in the
+Colours flow — the blank-page killer for styled roles, mirroring the message-template gallery. Cheap
+(pure data + the existing `ensure_color_role` path), only surfaced when the guild has the perk.
+(Dedup-checked `docs/ideas/` — not captured.)
+
+## ⟲ Previous-session review
+
+The #1234 session (this chain's predecessor) handled the mid-session branch collision well (clean
+rebase, no force-push) and corrected the multi-role misread fast. What it could have done better:
+its session card claimed the work "merge on green" while a **parallel session shared the same branch
+name** — the collision was only caught at push time. **System improvement:** the claim ledger keys on
+*scope*, but the real collision axis is the *branch name*; `check_lane_overlap.py` (shipped #1223)
+should also flag when two live sessions target the same `claude/*` branch, not just overlapping files —
+that would have surfaced the #1234/creature collision *before* the first push.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 0 (pending #1237, auto-merge on green) |
+| CI-red rounds | 0 real (born-red HOLD only, by design) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (gradient presets gallery) |
+| Ideas groomed | 0 |

--- a/disbot/services/reaction_role_service.py
+++ b/disbot/services/reaction_role_service.py
@@ -388,6 +388,93 @@ async def set_menu_location(menu_id: int, channel_id: int, message_id: int) -> N
     await menus_db.set_menu_location(menu_id, channel_id, message_id)
 
 
+# ===========================================================================
+# Colour-role auto-create — pick a colour, get a role (audited via lifecycle)
+# ===========================================================================
+# The builder lets an operator pick colours that don't exist as roles yet and
+# have the bot create them in one step (owner direction, 2026-06-21). Creation
+# goes through the audited ``RoleLifecycleService`` (the only sanctioned
+# ``create_role`` caller), never raw ``guild.create_role`` from the view.
+
+
+def supports_role_gradients(guild: discord.Guild) -> bool:
+    """Whether the guild can use Enhanced Role Styles (gradient / holographic).
+
+    Discord unlocks the perk at **3 applied server boosts** (independent of boost
+    *level*) and advertises it as a guild feature. Matched defensively — the exact
+    flag string shifted during rollout — so the builder offers gradient options
+    only when the server can actually use them. The create path also degrades on a
+    rejected gradient, so a stale ``True`` here is never fatal.
+    """
+    feats = {str(f).upper() for f in (getattr(guild, "features", None) or [])}
+    if {"ENHANCED_ROLE_COLORS", "ENHANCED_ROLE_COLOURS"} & feats:
+        return True
+    return any("ROLE" in f and ("COLOR" in f or "COLOUR" in f) for f in feats)
+
+
+async def ensure_color_role(
+    guild: discord.Guild,
+    *,
+    name: str,
+    color: discord.Color,
+    secondary: discord.Color | None = None,
+    tertiary: discord.Color | None = None,
+    actor: object | None,
+) -> tuple[int | None, bool, str]:
+    """Reuse a same-named role, or create a colour role via the audited seam.
+
+    Returns ``(role_id, created, note)``. A gradient/holographic style is applied
+    only when the guild supports Enhanced Role Styles; a gradient create Discord
+    rejects anyway falls back to a solid colour so the operator still gets a role.
+    """
+    from core.runtime import resources
+    from services.role_lifecycle_service import (
+        RoleLifecycleRequest,
+        RoleLifecycleService,
+    )
+
+    name = (name or "").strip()[:100] or "colour"
+    existing = resources.resolve_role(guild, name=name)
+    if existing is not None:
+        return existing.id, False, ""
+
+    svc = RoleLifecycleService()
+
+    async def _create(
+        sec: discord.Color | None,
+        ter: discord.Color | None,
+    ) -> tuple[int | None, str]:
+        result = await svc.apply(
+            guild,
+            RoleLifecycleRequest(
+                operation="create",
+                name=name,
+                color=color,
+                secondary_color=sec,
+                tertiary_color=ter,
+                reason="Colour role (reaction-role menu)",
+            ),
+            actor,
+            actor_type="admin",
+        )
+        applied = result.applied
+        if applied and applied[0].target_id:
+            return int(applied[0].target_id), ""
+        return None, result.first_error
+
+    want_gradient = secondary is not None and supports_role_gradients(guild)
+    role_id, note = await _create(
+        secondary if want_gradient else None,
+        tertiary if want_gradient else None,
+    )
+    if role_id is None and want_gradient:
+        # The perk may be unavailable after all — retry as a plain solid colour.
+        role_id, note = await _create(None, None)
+        if role_id is not None:
+            note = "Gradient unavailable here — created a solid colour role."
+    return role_id, role_id is not None, note
+
+
 async def delete_menu(
     *,
     menu_id: int,
@@ -726,6 +813,7 @@ __all__ = [
     "clear_message_mode",
     "create_menu",
     "delete_menu",
+    "ensure_color_role",
     "get_binding",
     "get_menu",
     "get_menu_options",
@@ -740,6 +828,7 @@ __all__ = [
     "set_menu_location",
     "set_menu_message",
     "set_message_mode",
+    "supports_role_gradients",
     "toggle_role",
     "unbind_emoji",
     "update_menu",

--- a/disbot/services/role_lifecycle_service.py
+++ b/disbot/services/role_lifecycle_service.py
@@ -65,7 +65,14 @@ class RoleLifecycleRequest:
     operation: str  # "create" | "edit" | "delete"
     role_id: int | None = None  # edit / delete target
     name: str | None = None  # create (required) / edit (rename)
-    color: discord.Color | None = None  # create / edit
+    color: discord.Color | None = None  # create / edit (primary colour)
+    # Enhanced Role Styles (discord.py 2.6+): a second colour makes a gradient,
+    # a third makes a holographic style. Discord gates the feature on the guild
+    # holding the "Enhanced Role Styles" perk (3 applied boosts); callers should
+    # only set these when the guild supports it, and the API rejects them with a
+    # 400 otherwise (surfaced as a failed step, not a raise).
+    secondary_color: discord.Color | None = None  # create / edit (gradient)
+    tertiary_color: discord.Color | None = None  # create / edit (holographic)
     hoist: bool | None = None  # create / edit
     mentionable: bool | None = None  # create / edit
     reason: str | None = None
@@ -284,17 +291,25 @@ class RoleLifecycleService:
     ) -> discord.Role:
         reason = request.reason
         if operation == "create":
-            return await guild.create_role(
-                name=request.name or "new-role",
-                color=(
+            create_kwargs: dict[str, Any] = {
+                "name": request.name or "new-role",
+                "color": (
                     request.color
                     if request.color is not None
                     else discord.Color.default()
                 ),
-                hoist=bool(request.hoist),
-                mentionable=bool(request.mentionable),
-                reason=reason,
-            )
+                "hoist": bool(request.hoist),
+                "mentionable": bool(request.mentionable),
+                "reason": reason,
+            }
+            # Only pass gradient colours when set — omitting them keeps a plain
+            # solid role and avoids the Enhanced-Role-Styles 400 on guilds without
+            # the perk (callers gate on it; this is the seam-level guard).
+            if request.secondary_color is not None:
+                create_kwargs["secondary_color"] = request.secondary_color
+            if request.tertiary_color is not None:
+                create_kwargs["tertiary_color"] = request.tertiary_color
+            return await guild.create_role(**create_kwargs)
         if role is None:  # apply() resolves edit/delete targets before dispatch
             raise ValueError(f"{operation} requires a resolved role")
         if operation == "edit":
@@ -309,6 +324,10 @@ class RoleLifecycleService:
             kwargs["name"] = request.name
         if request.color is not None:
             kwargs["color"] = request.color
+        if request.secondary_color is not None:
+            kwargs["secondary_color"] = request.secondary_color
+        if request.tertiary_color is not None:
+            kwargs["tertiary_color"] = request.tertiary_color
         if request.hoist is not None:
             kwargs["hoist"] = request.hoist
         if request.mentionable is not None:

--- a/disbot/views/roles/role_menu_builder.py
+++ b/disbot/views/roles/role_menu_builder.py
@@ -24,8 +24,13 @@ from utils import role_menu_presentation as presentation
 from views.base import BaseView
 from views.navigation import attach_back_button
 from views.paginated_select import PaginatedSelectView
+from views.roles._helpers import _COLOR_OPTIONS, _parse_color
 from views.roles.role_menu_view import MAX_MENU_ROLES, RoleMenuView, build_menu_embed
-from views.selectors import attach_multi_role_select
+from views.selectors import (
+    attach_channel_select,
+    attach_multi_role_select,
+    attach_multi_select,
+)
 
 logger = logging.getLogger("bot.views.role_menu_builder")
 
@@ -527,13 +532,24 @@ class RoleMenuBuilder(BaseView):
                 value="*none yet — tap 🏷️ Roles*",
                 inline=False,
             )
+        from services.reaction_role_service import supports_role_gradients
+
         limit = "unlimited" if not self.max_roles else str(self.max_roles)
+        channel_str = (
+            self.channel.mention if self.channel is not None else "*(current channel)*"
+        )
+        gradient_note = (
+            "\n✨ Enhanced role styles available — gradient/holographic colour roles."
+            if supports_role_gradients(self.guild)
+            else ""
+        )
         embed.add_field(
             name="Settings",
             value=(
                 f"Style: **{_STYLE_LABEL.get(self.style, self.style)}**\n"
                 f"Mode: **{_MODE_LABEL.get(self.mode, self.mode)}**\n"
-                f"Limit: **{limit}** · Theme: **{theme.label}**"
+                f"Limit: **{limit}** · Theme: **{theme.label}**\n"
+                f"Channel: {channel_str}{gradient_note}"
             ),
             inline=False,
         )
@@ -581,6 +597,22 @@ class RoleMenuBuilder(BaseView):
         await interaction.response.send_message(
             "Pick the roles this menu offers (up to 25):",
             view=_RolePickView(self, manageable),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(label="🎨 Colours", style=discord.ButtonStyle.grey, row=0)
+    async def colours_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not _can_manage(interaction):
+            await _deny(interaction)
+            return
+        await interaction.response.send_message(
+            "Pick preset colours to auto-create as roles, or **✏️ Custom** for a "
+            "custom colour or gradient — each becomes a role added to this menu:",
+            view=_ColourRolesView(self),
             ephemeral=True,
         )
 
@@ -669,6 +701,27 @@ class RoleMenuBuilder(BaseView):
         _: discord.ui.Button,
     ) -> None:
         await interaction.response.send_modal(_LimitModal(self))
+
+    @discord.ui.button(label="📍 Channel", style=discord.ButtonStyle.grey, row=1)
+    async def channel_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not _can_manage(interaction):
+            await _deny(interaction)
+            return
+        if not list(self.guild.text_channels):
+            await interaction.response.send_message(
+                "This server has no text channels to post in.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_message(
+            "Pick the channel to post this menu in:",
+            view=_ChannelPickView(self),
+            ephemeral=True,
+        )
 
     @discord.ui.button(label="🚀 Post", style=discord.ButtonStyle.green, row=2)
     async def post_btn(
@@ -934,6 +987,205 @@ class _LimitModal(discord.ui.Modal, title="Per-member limit"):  # type: ignore[c
         if not await safe_defer(interaction):
             return
         await self.builder._rerender()
+
+
+# ---------------------------------------------------------------------------
+# Sub-flows: post-channel picker + colour-role auto-create
+# ---------------------------------------------------------------------------
+
+
+class _ChannelPickView(BaseView):
+    """Ephemeral picker that sets the builder's post-target channel."""
+
+    def __init__(self, builder: RoleMenuBuilder) -> None:
+        super().__init__(builder._author, timeout=180)
+        self.builder = builder
+        attach_channel_select(
+            self,
+            list(builder.guild.text_channels),
+            self._on_pick,
+            placeholder="Channel to post the menu in…",
+        )
+
+    async def _on_pick(
+        self,
+        interaction: discord.Interaction,
+        channel_id: int,
+    ) -> None:
+        target = _as_messageable(
+            resources.resolve_channel(self.builder.guild, channel_id=channel_id),
+        )
+        if target is None:
+            await interaction.response.edit_message(
+                content="That channel can't be posted to — pick a text channel.",
+                view=None,
+            )
+            return
+        self.builder.channel = target
+        await interaction.response.edit_message(
+            content=f"✓ This menu will post to {target.mention}.",
+            view=None,
+        )
+        await self.builder._rerender()
+
+
+def _safe_parse_color(value: str | None) -> discord.Color | None:
+    """Parse an optional hex colour; return ``None`` when blank or invalid."""
+    if not value or not value.strip():
+        return None
+    try:
+        return _parse_color(value)
+    except (ValueError, TypeError):
+        return None
+
+
+class _ColourRolesView(BaseView):
+    """Pick preset colours (auto-created as roles) or open the custom/gradient modal."""
+
+    def __init__(self, builder: RoleMenuBuilder) -> None:
+        super().__init__(builder._author, timeout=180)
+        self.builder = builder
+        options = [
+            discord.SelectOption(label=name, value=hex_value)
+            for name, hex_value in _COLOR_OPTIONS
+        ]
+        attach_multi_select(
+            self,
+            options,
+            self._on_presets,
+            placeholder="Preset colours to create as roles…",
+            max_values=len(options),
+            select_row=0,
+        )
+
+    @discord.ui.button(
+        label="✏️ Custom / gradient…",
+        style=discord.ButtonStyle.blurple,
+        row=1,
+    )
+    async def custom_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await interaction.response.send_modal(_CustomColourModal(self.builder))
+
+    async def _on_presets(
+        self,
+        interaction: discord.Interaction,
+        values: list[str],
+    ) -> None:
+        by_hex = {hex_value: name for name, hex_value in _COLOR_OPTIONS}
+        specs: list[
+            tuple[str, discord.Color, discord.Color | None, discord.Color | None]
+        ] = [
+            (by_hex.get(hex_value, hex_value), _parse_color(hex_value), None, None)
+            for hex_value in values
+        ]
+        await _commit_colour_roles(interaction, self.builder, specs)
+
+
+class _CustomColourModal(discord.ui.Modal, title="Custom colour role"):  # type: ignore[call-arg]
+    name_in = discord.ui.TextInput(  # type: ignore[var-annotated]
+        label="Role name",
+        placeholder="e.g. Sunset",
+        max_length=100,
+    )
+    primary_in = discord.ui.TextInput(  # type: ignore[var-annotated]
+        label="Colour (hex)",
+        placeholder="#e67e22",
+        max_length=7,
+    )
+    secondary_in = discord.ui.TextInput(  # type: ignore[var-annotated]
+        label="Gradient 2nd colour (hex, optional)",
+        placeholder="#f1c40f — needs Enhanced Role Styles",
+        required=False,
+        max_length=7,
+    )
+    tertiary_in = discord.ui.TextInput(  # type: ignore[var-annotated]
+        label="Holographic 3rd colour (hex, optional)",
+        required=False,
+        max_length=7,
+    )
+
+    def __init__(self, builder: RoleMenuBuilder) -> None:
+        super().__init__()
+        self.builder = builder
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        primary = _safe_parse_color(self.primary_in.value)
+        if primary is None:
+            await interaction.response.send_message(
+                "❌ The colour must be a hex value like `#e67e22`.",
+                ephemeral=True,
+            )
+            return
+        name = self.name_in.value.strip() or "Colour"
+        await _commit_colour_roles(
+            interaction,
+            self.builder,
+            [
+                (
+                    name,
+                    primary,
+                    _safe_parse_color(self.secondary_in.value),
+                    _safe_parse_color(self.tertiary_in.value),
+                ),
+            ],
+        )
+
+
+async def _commit_colour_roles(
+    interaction: discord.Interaction,
+    builder: RoleMenuBuilder,
+    specs: list[tuple[str, discord.Color, discord.Color | None, discord.Color | None]],
+) -> None:
+    """Create/reuse a colour role per spec and add it to the builder's draft."""
+    from services import reaction_role_service
+
+    if not specs:
+        await interaction.response.send_message(
+            "Pick at least one colour.",
+            ephemeral=True,
+        )
+        return
+    # Creating several roles is multiple API calls — defer first, report after.
+    if not await safe_defer(interaction, ephemeral=True, thinking=True):
+        return
+
+    created: list[str] = []
+    reused: list[str] = []
+    notes: list[str] = []
+    for name, primary, secondary, tertiary in specs:
+        role_id, was_created, note = await reaction_role_service.ensure_color_role(
+            builder.guild,
+            name=name,
+            color=primary,
+            secondary=secondary,
+            tertiary=tertiary,
+            actor=interaction.user,
+        )
+        if role_id is None:
+            notes.append(f"{name}: {note or 'could not be created'}")
+            continue
+        if role_id not in builder.role_ids and len(builder.role_ids) < MAX_MENU_ROLES:
+            builder.role_ids.append(role_id)
+        (created if was_created else reused).append(name)
+        if note:
+            notes.append(f"{name}: {note}")
+
+    parts: list[str] = []
+    if created:
+        parts.append(f"🎨 Created {', '.join(created)}")
+    if reused:
+        parts.append(f"♻️ Reused existing {', '.join(reused)}")
+    if notes:
+        parts.append("\n".join(notes))
+    await interaction.followup.send(
+        "\n".join(parts) or "No colour roles were added.",
+        ephemeral=True,
+    )
+    await builder._rerender()
 
 
 __all__ = ["RoleMenuBuilder", "RoleMenuListView"]

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,11 +25,6 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/reaction-roles-channel-and-colors` · **reaction-roles follow-up** (owner-directed) —
-  menu post-channel picker + auto-created colour roles + gradient/holographic (via audited
-  `RoleLifecycleService`) · `disbot/services/{role_lifecycle,reaction_role}_service.py` +
-  `disbot/views/roles/role_menu_builder.py` · 2026-06-21 · **PR (this session, merge on green)**
-
 - `claude/dispatch-next` · **prune stale Active claims (drift-on-sight, Q-0166)** — every prior
   claim had merged, polluting `check_lane_overlap.py` with false positives · `docs/owner/active-work.md`
   · 2026-06-21 · **auto-merge on green** (docs-only)
@@ -43,6 +38,9 @@ session holds it, no claim line needed here.)*
 
 ## Recently cleared
 
+- `claude/reaction-roles-channel-and-colors` · **reaction-roles follow-up** (owner-directed) — menu
+  post-channel picker + auto-created colour roles + gradient/holographic (audited
+  `RoleLifecycleService` seam, gated on Enhanced-Role-Styles) · 2026-06-21 · **PR #1237 (merge on green)**
 - `claude/lucid-carson-qsn1gc` · **reaction-roles refinement** (owner-directed) — multiple emotes
   per message each with its own role (`utils/emoji_tokens` + Add-flow rewrite, no schema change) +
   role-menu **Repost/Duplicate** reuse (`set_menu_location`) · 2026-06-21 · **PR #1234 (merge on green)**

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,11 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/reaction-roles-channel-and-colors` · **reaction-roles follow-up** (owner-directed) —
+  menu post-channel picker + auto-created colour roles + gradient/holographic (via audited
+  `RoleLifecycleService`) · `disbot/services/{role_lifecycle,reaction_role}_service.py` +
+  `disbot/views/roles/role_menu_builder.py` · 2026-06-21 · **PR (this session, merge on green)**
+
 - `claude/dispatch-next` · **prune stale Active claims (drift-on-sight, Q-0166)** — every prior
   claim had merged, polluting `check_lane_overlap.py` with false positives · `docs/owner/active-work.md`
   · 2026-06-21 · **auto-merge on green** (docs-only)

--- a/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
+++ b/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
@@ -32,6 +32,17 @@
 > menu into a new one). NB this is *one role per emote* (an emote→multiple-roles reading was corrected
 > by the owner mid-session).
 >
+> **▶ Refinement (2026-06-21, owner-directed — PR #1237):** three more builder enhancements.
+> **(1) Post-channel picker** — a 📍 Channel control on `RoleMenuBuilder` so a menu can target a
+> dedicated reaction-roles channel, not just the panel's channel. **(2) Auto-created colour roles** —
+> a 🎨 Colours flow picks preset/custom colours that don't exist as roles yet and the bot creates
+> them in one step (reuse-if-same-name), via `reaction_role_service.ensure_color_role` →
+> the audited `RoleLifecycleService` (the only sanctioned `create_role` caller). **(3) Gradient /
+> holographic roles** — discord.py 2.7.1 supports `secondary_colour`/`tertiary_colour` on
+> `create_role`/`Role.edit`; Discord gates the *Enhanced Role Styles* perk on **3 applied server
+> boosts**, so the gradient UI is offered only when `guild.features` advertises it
+> (`supports_role_gradients`), with a caught-400 solid-colour fallback.
+>
 > **One-line goal:** bring SuperBot's self-assignable-role surface to **parity-plus** with
 > Carl-bot — lead with native **buttons + dropdown menus** (Carl's are a secondary/premium
 > add; emoji reactions are its core), keep emoji reaction-roles working for compatibility,

--- a/tests/unit/services/test_reaction_role_service_menus.py
+++ b/tests/unit/services/test_reaction_role_service_menus.py
@@ -295,3 +295,142 @@ async def test_set_menu_location_passes_through_without_audit():
         await svc.set_menu_location(7, 222, 333)
     loc.assert_awaited_once_with(7, 222, 333)
     audit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Colour-role auto-create (owner direction, 2026-06-21)
+# ---------------------------------------------------------------------------
+
+# Opaque colour sentinels — RoleLifecycleService.apply is mocked, so colours just
+# pass through and are compared by identity.
+_PRIMARY = object()
+_SECONDARY = object()
+_TERTIARY = object()
+
+
+def test_supports_role_gradients_matches_feature_variants():
+    assert svc.supports_role_gradients(SimpleNamespace(features=["ENHANCED_ROLE_COLORS"]))
+    # Defensive substring match survives a rollout rename.
+    assert svc.supports_role_gradients(SimpleNamespace(features=["GUILD_ROLE_COLOURS_X"]))
+    assert not svc.supports_role_gradients(SimpleNamespace(features=["COMMUNITY"]))
+    assert not svc.supports_role_gradients(SimpleNamespace(features=[]))
+
+
+def _applied(target_id: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        applied=[SimpleNamespace(target_id=target_id)],
+        first_error="",
+    )
+
+
+def _failed(reason: str = "400") -> SimpleNamespace:
+    return SimpleNamespace(applied=[], first_error=reason)
+
+
+@pytest.mark.asyncio
+async def test_ensure_color_role_reuses_existing_same_name_role():
+    guild = SimpleNamespace(id=1, features=[])
+    with patch(
+        "core.runtime.resources.resolve_role",
+        return_value=SimpleNamespace(id=555),
+    ):
+        role_id, created, note = await svc.ensure_color_role(
+            guild,
+            name="Red",
+            color=_PRIMARY,
+            actor=SimpleNamespace(id=9),
+        )
+    assert (role_id, created, note) == (555, False, "")
+
+
+@pytest.mark.asyncio
+async def test_ensure_color_role_creates_solid_when_no_gradient():
+    guild = SimpleNamespace(id=1, features=[])
+    apply_mock = AsyncMock(return_value=_applied(777))
+    with (
+        patch("core.runtime.resources.resolve_role", return_value=None),
+        patch(
+            "services.role_lifecycle_service.RoleLifecycleService.apply",
+            new=apply_mock,
+        ),
+    ):
+        role_id, created, _ = await svc.ensure_color_role(
+            guild,
+            name="Sunset",
+            color=_PRIMARY,
+            actor=SimpleNamespace(id=9),
+        )
+    assert (role_id, created) == (777, True)
+    req = apply_mock.await_args.args[1]  # (guild, request, actor) — mock is unbound
+    assert req.secondary_color is None
+    assert req.tertiary_color is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_color_role_drops_gradient_without_perk():
+    guild = SimpleNamespace(id=1, features=[])  # no Enhanced Role Styles
+    apply_mock = AsyncMock(return_value=_applied(777))
+    with (
+        patch("core.runtime.resources.resolve_role", return_value=None),
+        patch(
+            "services.role_lifecycle_service.RoleLifecycleService.apply",
+            new=apply_mock,
+        ),
+    ):
+        await svc.ensure_color_role(
+            guild,
+            name="Grad",
+            color=_PRIMARY,
+            secondary=_SECONDARY,
+            tertiary=_TERTIARY,
+            actor=SimpleNamespace(id=9),
+        )
+    req = apply_mock.await_args.args[1]
+    assert req.secondary_color is None  # guild lacks the perk → solid only
+
+
+@pytest.mark.asyncio
+async def test_ensure_color_role_applies_gradient_with_perk():
+    guild = SimpleNamespace(id=1, features=["ENHANCED_ROLE_COLORS"])
+    apply_mock = AsyncMock(return_value=_applied(777))
+    with (
+        patch("core.runtime.resources.resolve_role", return_value=None),
+        patch(
+            "services.role_lifecycle_service.RoleLifecycleService.apply",
+            new=apply_mock,
+        ),
+    ):
+        await svc.ensure_color_role(
+            guild,
+            name="Grad",
+            color=_PRIMARY,
+            secondary=_SECONDARY,
+            actor=SimpleNamespace(id=9),
+        )
+    req = apply_mock.await_args.args[1]
+    assert req.secondary_color is _SECONDARY
+
+
+@pytest.mark.asyncio
+async def test_ensure_color_role_falls_back_to_solid_on_gradient_failure():
+    guild = SimpleNamespace(id=1, features=["ENHANCED_ROLE_COLORS"])
+    # First (gradient) create fails; the solid retry succeeds.
+    apply_mock = AsyncMock(side_effect=[_failed("400"), _applied(888)])
+    with (
+        patch("core.runtime.resources.resolve_role", return_value=None),
+        patch(
+            "services.role_lifecycle_service.RoleLifecycleService.apply",
+            new=apply_mock,
+        ),
+    ):
+        role_id, created, note = await svc.ensure_color_role(
+            guild,
+            name="Grad",
+            color=_PRIMARY,
+            secondary=_SECONDARY,
+            actor=SimpleNamespace(id=9),
+        )
+    assert (role_id, created) == (888, True)
+    assert "solid" in note.lower()
+    assert apply_mock.await_count == 2
+    assert apply_mock.await_args_list[1].args[1].secondary_color is None

--- a/tests/unit/services/test_role_lifecycle_service.py
+++ b/tests/unit/services/test_role_lifecycle_service.py
@@ -92,6 +92,38 @@ async def test_create_calls_create_role_and_succeeds(svc):
 
 
 @pytest.mark.asyncio
+async def test_create_passes_gradient_colours_when_set(svc):
+    guild = _guild(created=_role(999, "Sunset"))
+    await svc.apply(
+        guild,
+        RoleLifecycleRequest(
+            operation="create",
+            name="Sunset",
+            color=discord.Color(0x1),
+            secondary_color=discord.Color(0x2),
+            tertiary_color=discord.Color(0x3),
+        ),
+        _actor(),
+    )
+    kwargs = guild.create_role.await_args.kwargs
+    assert kwargs["secondary_color"] == discord.Color(0x2)
+    assert kwargs["tertiary_color"] == discord.Color(0x3)
+
+
+@pytest.mark.asyncio
+async def test_create_omits_gradient_colours_when_absent(svc):
+    guild = _guild(created=_role(999, "Plain"))
+    await svc.apply(
+        guild,
+        RoleLifecycleRequest(operation="create", name="Plain", color=discord.Color(0x1)),
+        _actor(),
+    )
+    kwargs = guild.create_role.await_args.kwargs
+    assert "secondary_color" not in kwargs
+    assert "tertiary_color" not in kwargs
+
+
+@pytest.mark.asyncio
 async def test_edit_calls_role_edit_with_changed_fields(svc):
     role = _role(10, "Old")
     guild = _guild([role])


### PR DESCRIPTION
Owner-directed follow-up to #1234 — three enhancements to the role-menu builder.

## 1. Choose which channel to post in
A 📍 **Channel** picker on the menu builder so a menu can be posted to a **dedicated
reaction-roles channel**, not only the channel the panel happens to be open in.

## 2. Auto-create colour roles (one smooth action)
Pick colours that don't exist yet as roles and have the bot **create them**, then add them to the
menu — no more "make the roles first, then build the menu". Reuses a same-named role when one
already exists; every creation flows through the audited `RoleLifecycleService` (the only
sanctioned `create_role` caller).

## 3. Gradient / holographic roles
discord.py 2.7.1 supports `secondary_colour` (2-colour gradient) and `tertiary_colour`
(3-colour holographic) on `create_role`/`Role.edit`. Discord gates the **Enhanced Role Styles**
perk on **3 applied server boosts** (separate from boost *level*), so the gradient UI is only
offered when `guild.features` shows the perk, with a solid-colour fallback (and a caught-400 as a
safety net). If a server later loses the perk, Discord reverts styled roles to their primary colour
automatically.

Born-red HOLD (Q-0133) until the session card flips to `complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK6bg63g8Vsp2m4nhUxUrf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK6bg63g8Vsp2m4nhUxUrf)_