### PR TITLE
!temproles member-facing temp-role listing (reaction-roles loose end)

### DIFF
--- a/.sessions/2026-06-21-temproles-member-view.md
+++ b/.sessions/2026-06-21-temproles-member-view.md
@@ -1,22 +1,103 @@
 # 2026-06-21 — `!temproles` member-facing temp-role listing
 
-> **Status:** `in-progress` — building the flagged loose-end from the reaction-roles
-> PR 3–5 session: a member-facing view consuming the orphaned
-> `role_grants.list_for_member`. Additive runtime (a new read-only command + a
-> read seam on the existing audited service); existing behaviour unchanged.
+> **Status:** `complete` — built the flagged loose-end from the reaction-roles PR 3–5
+> session: a member-facing view consuming the orphaned `role_grants.list_for_member`.
+> Additive runtime (a new read-only command + a read seam on the existing audited
+> service); existing grant/sweep behaviour unchanged → self-merge on green.
 
 > **Run type:** `routine · dispatch`
 
-## Plan (about to do)
+## Arc
 
-The reaction-roles overhaul shipped free temp roles (#1227) with `grant`/`sweep`,
-but `role_grants.list_for_member` was left with no UI consumer (flagged loose end).
-This session adds:
+Empty scheduled fire (no work order). Oriented → no open PRs, no actionable ungated open
+bug (BUG-0019 #1 owner-routed design fork; BUG-0009 newest-towers data-gated; the previous
+session's Q-0089 config-extension-integrity idea was **already implemented** —
+`tests/unit/invariants/test_extension_integrity.py`). Took the explicit `↪ Next` handoff
+from the reaction-roles PR 3–5 session: *"a member-facing `!temproles` view consuming
+`role_grants.list_for_member`."*
 
-1. `role_grants_service.list_active_grants(guild, member_id)` — a pure read seam
-   that resolves roles, drops vanished roles + already-lapsed-but-unswept grants.
-2. `!temproles [@member]` on `RoleGrantsCog` — lists the caller's own active temp
-   roles (role + relative expiry); an optional `@member` is staff-only (manage_roles).
-3. Tests for the service read + the command.
+## What shipped
 
-CI mirror green + arch strict before flip-to-complete.
+- **`role_grants_service.list_active_grants(guild, member_id)`** — a pure read seam over
+  `utils.db.role_grants.list_for_member` that resolves roles and drops two kinds the caller
+  should never see: a grant whose role has vanished, and an already-lapsed grant the 5-min
+  sweep has not yet collected (so the listing only ever names a role the member still
+  effectively holds). No mutation, no audit — reads stay off the audited write path.
+- **`!temproles [@member]`** on `RoleGrantsCog` — `@guild_only`; lists the caller's own
+  active temp roles (role mention + relative `<t:…:R>` expiry). An optional `@member` is
+  **staff-only** (`isinstance(author, discord.Member)` + `manage_roles`); a non-staff
+  attempt to view another member is denied without touching the DB.
+- Tests: service read (lapsed/vanished filtering · empty) + the command
+  (self-list · empty · other-denied · staff-views-other · staff-self-phrasing).
+- Regenerated the command-count artifacts (313 → 314): `botsite/data/site.json`,
+  `botsite/site/data.js`, `dashboard/data/dashboard.json` via
+  `scripts/export_dashboard_data.py`.
+
+## Verification
+
+- `check_quality.py --full` (CI mirror: black/isort/ruff + `mypy disbot/` + full pytest) →
+  **GREEN — 11328 passed, 47 skipped**, mypy clean (761 files), all formatters/consistency pass.
+- `check_architecture --mode strict` → 0 errors (pre-existing `[known]` warnings only).
+- Not live-interaction-tested in Discord (no click harness in-env).
+
+## Context delta
+
+- **Needed but not pointed to:** nothing new — the role-grants stack (#1227) was well
+  factored; `list_for_member` was deliberately left for this consumer.
+- **Decision made alone:** the active-listing filter (drop lapsed-but-unswept + vanished
+  roles) lives on the **service** read, not the cog, keeping the cog a thin shell consistent
+  with its existing contract. The optional `@member` staff view is a low-cost addition over
+  the minimal "your own" listing.
+
+## 💡 Session idea (Q-0089)
+
+**A `!temproles` member self-cancel (`!temprole cancel @role`) — let a member voluntarily drop
+a temp role early.** Today only the 5-min sweep or a staff role-removal ends a grant; a member
+who picked up a temp role (e.g. an opt-in event role) cannot release it themselves before
+expiry. The audited seam already exists (`role_grants.remove` + a `member.remove_roles`
+through a new `role_grants_service.release_own_grant`), so it's a small additive slice — and
+it pairs naturally with this listing (list → release). Dedup-checked: no such command exists;
+not in `docs/ideas/`. Worth an idea file if not built next.
+
+## ⟲ Previous-session review (Q-0102)
+
+**Reviewed: the reaction-roles PR 3–5 session (#1227).** *Did well:* a disciplined
+loose-end handoff — it explicitly flagged `list_for_member` as an unconsumed seam in both
+its run-report `↪ Next` and its Context-delta, which is exactly what let *this* session pick
+up a clean, well-scoped slice with zero rediscovery. That is the handoff loop working as
+designed. *What it could have done better:* it bundled PR 3+4+5 into one PR (defensible for
+the shared migration sequence) but that makes the **per-feature** revert granularity coarser —
+if PR 5's analytics had a bug, reverting it also reverts the temp-roles + modes work.
+**System improvement:** when bundling N plan-PRs onto one branch for migration-sequence
+reasons, keep them as **separate commits with feature-scoped messages** (the session did this)
+*and* note the bundling rationale in the plan's Build-progress (it did) — this is already good
+practice; the only gap is there's no lightweight convention reminding a bundling session to
+record *how to partially revert* (which commit drops which feature). A one-line "partial-revert
+map" in such a session's card would close it. Captured here rather than as a rule proposal —
+it's a soft convention, not binding.
+
+## 📤 Run report
+
+- **Did:** added `role_grants_service.list_active_grants` + the `!temproles [@member]` member
+  command consuming the previously-orphaned `list_for_member`; regenerated command-count
+  artifacts · **Outcome:** shipped (routine dispatch, self-merge on green)
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions recorded:** none
+- **⚑ Owner manual steps:** none — merge auto-deploys; no migration (reads an existing table).
+- **⚑ Self-initiated:** the whole slice — taken from the previous session's `↪ Next` handoff
+  (not a dispatched work order; the empty scheduled fire advances the plan). Contained,
+  reversible, additive, test-covered.
+- **↪ Next:** the session idea above (`!temprole cancel` member self-release); else a fresh
+  ▶ ungated startable from current-state — creature-PvP **leaderboards** (reuse `game_xp`,
+  additive) or the **botsite React-SPA migration**.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs this session | 1 (#1242, routine dispatch, self-merge on green) |
+| Migrations added | 0 (reads existing `role_grants`) |
+| New tests | 7 (2 service read + 5 command) |
+| CI-red rounds | 2 — round 1: command-count artifact drift (313→314, regenerated) + 1 mypy union-attr (`guild_permissions` on `User|Member`, fixed with isinstance); round 2 green |
+| Repo-rule trips | 0 (arch 0 errors; `role_grants_cog` 143 LOC) |
+| New ideas contributed | 1 (`!temprole cancel` member self-release) |

--- a/.sessions/2026-06-21-temproles-member-view.md
+++ b/.sessions/2026-06-21-temproles-member-view.md
@@ -1,0 +1,22 @@
+# 2026-06-21 — `!temproles` member-facing temp-role listing
+
+> **Status:** `in-progress` — building the flagged loose-end from the reaction-roles
+> PR 3–5 session: a member-facing view consuming the orphaned
+> `role_grants.list_for_member`. Additive runtime (a new read-only command + a
+> read seam on the existing audited service); existing behaviour unchanged.
+
+> **Run type:** `routine · dispatch`
+
+## Plan (about to do)
+
+The reaction-roles overhaul shipped free temp roles (#1227) with `grant`/`sweep`,
+but `role_grants.list_for_member` was left with no UI consumer (flagged loose end).
+This session adds:
+
+1. `role_grants_service.list_active_grants(guild, member_id)` — a pure read seam
+   that resolves roles, drops vanished roles + already-lapsed-but-unswept grants.
+2. `!temproles [@member]` on `RoleGrantsCog` — lists the caller's own active temp
+   roles (role + relative expiry); an optional `@member` is staff-only (manage_roles).
+3. Tests for the service read + the command.
+
+CI mirror green + arch strict before flip-to-complete.

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,15 +1,15 @@
 {
   "meta": {
-    "generated_at": "2026-06-21T15:38:23Z",
+    "generated_at": "2026-06-21T18:11:06Z",
     "build": {
-      "commit": "f25356b9",
-      "subject": "feat(creatures): user-facing PvP battle flow + extension-integrity guard",
-      "committed_at": "2026-06-21T15:38:10Z",
-      "branch": "HEAD"
+      "commit": "2e5955c0",
+      "subject": "session: open temproles member-view PR (born-red card)",
+      "committed_at": "2026-06-21T18:07:30Z",
+      "branch": "claude/funny-franklin-8ha49t"
     }
   },
   "counts": {
-    "commands": 313,
+    "commands": 314,
     "features": 37,
     "games": 9
   },
@@ -6618,6 +6618,20 @@
       "permissions": "",
       "usage": "Give a member a role for a limited time. Usage: !temprole @member 2h @role",
       "description": "Give a member a role for a limited time. Usage: !temprole @member 2h @role",
+      "use_cases": null,
+      "examples": [],
+      "status": "finished",
+      "linked_ideas": [],
+      "notes": null
+    },
+    {
+      "name": "temproles",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "List active temporary roles. Usage: !temproles (yours) or !temproles @member (staff).",
+      "description": "List active temporary roles. Usage: !temproles (yours) or !temproles @member (staff).",
       "use_cases": null,
       "examples": [],
       "status": "finished",

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -4850,6 +4850,19 @@ const COMMANDS = [
     "planned": []
   },
   {
+    "name": "temproles",
+    "area": "other",
+    "status": "finished",
+    "summary": "List active temporary roles. Usage: !temproles (yours) or !temproles @member (staff).",
+    "description": "List active temporary roles. Usage: !temproles (yours) or !temproles @member (staff).",
+    "usage": "!temproles",
+    "aliases": [],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [],
+    "planned": []
+  },
+  {
     "name": "test",
     "area": "admin",
     "status": "in-progress",
@@ -5676,7 +5689,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "f25356b9",
+    "build": "2e5955c0",
     "title": "New public bot website",
     "changes": [
       {
@@ -5688,7 +5701,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "f25356b9",
+    "build": "2e5955c0",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -5700,7 +5713,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "f25356b9",
+    "build": "2e5955c0",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,11 +1,11 @@
 {
   "meta": {
-    "generated_at": "2026-06-21T17:51:15Z",
+    "generated_at": "2026-06-21T18:11:06Z",
     "build": {
-      "commit": "61fb3144",
-      "subject": "Merge pull request #1235 from menno420/claude/peaceful-mayer-rgc20t",
-      "committed_at": "2026-06-21T19:07:45Z",
-      "branch": "main"
+      "commit": "2e5955c0",
+      "subject": "session: open temproles member-view PR (born-red card)",
+      "committed_at": "2026-06-21T18:07:30Z",
+      "branch": "claude/funny-franklin-8ha49t"
     },
     "counts": {
       "functions": 37,
@@ -16,7 +16,7 @@
       "updates": 60,
       "env_vars": 37,
       "cogs": 46,
-      "commands": 313,
+      "commands": 314,
       "setting_keys": 104,
       "setting_domains": 15,
       "typed_settings": 85,
@@ -2125,6 +2125,14 @@
       "self_initiated": true
     },
     {
+      "file": "2026-06-21-temproles-member-view.md",
+      "date": "2026-06-21",
+      "title": "2026-06-21 — `!temproles` member-facing temp-role listing",
+      "status": "in-progress",
+      "run_type": "routine",
+      "self_initiated": false
+    },
+    {
       "file": "2026-06-21-site-field-level-redaction-contract.md",
       "date": "2026-06-21",
       "title": "2026-06-21 — site.json field-level redaction contract",
@@ -2586,14 +2594,6 @@
       "title": "2026-06-20 — Extend the `baseview_inheritance` arch ratchet to the cog layer",
       "status": "complete",
       "run_type": "routine",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-20-ai-other-bot-mention-bug-note.md",
-      "date": "2026-06-20",
-      "title": "2026-06-20 — BUG note: AI replies to other bots' mentions + Pokétwo demand signal",
-      "status": "complete",
-      "run_type": "manual",
       "self_initiated": false
     }
   ],
@@ -6784,6 +6784,17 @@
           "parent": null,
           "aliases": [],
           "brief": "Give a member a role for a limited time. Usage: !temprole @member 2h @role",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "temproles",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "List active temporary roles. Usage: !temproles (yours) or !temproles @member (staff).",
           "classification": "",
           "has_panel": false,
           "button_backed": false

--- a/disbot/cogs/role_grants_cog.py
+++ b/disbot/cogs/role_grants_cog.py
@@ -102,6 +102,41 @@ class RoleGrantsCog(commands.Cog):
             f"— expires <t:{int(expires.timestamp())}:R>.",
         )
 
+    @commands.command(name="temproles")
+    @commands.guild_only()
+    async def temproles(
+        self,
+        ctx: commands.Context,
+        member: discord.Member | None = None,
+    ) -> None:
+        """List active temporary roles. Usage: !temproles (yours) or !temproles @member (staff)."""
+        author = ctx.author
+        target = member or author
+        is_self = target.id == author.id
+        author_is_staff = (
+            isinstance(author, discord.Member) and author.guild_permissions.manage_roles
+        )
+        if not is_self and not author_is_staff:
+            await ctx.send(
+                "❌ You can only view your own temp roles — viewing another "
+                "member's needs Manage Roles.",
+                delete_after=10,
+            )
+            return
+
+        grants = await role_grants_service.list_active_grants(ctx.guild, target.id)
+        whose = "You have" if is_self else f"**{target.display_name}** has"
+        if not grants:
+            await ctx.send(f"📭 {whose} no active temp roles.")
+            return
+
+        lines = [
+            f"• {role.mention} — expires <t:{int(expires.timestamp())}:R>"
+            for role, expires in grants
+        ]
+        header = f"⏳ {whose} {len(grants)} active temp role(s):"
+        await ctx.send(header + "\n" + "\n".join(lines))
+
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(RoleGrantsCog(bot))

--- a/disbot/services/role_grants_service.py
+++ b/disbot/services/role_grants_service.py
@@ -63,6 +63,33 @@ async def grant_temp_role(
     return expires_at
 
 
+async def list_active_grants(
+    guild: discord.Guild,
+    member_id: int,
+) -> list[tuple[discord.Role, datetime]]:
+    """A member's still-active temp grants as ``(role, expires_at)``, soonest first.
+
+    Reads through :func:`utils.db.role_grants.list_for_member` (which returns every
+    grant row for the member, oldest expiry first) and drops two kinds the caller
+    should never be shown: a grant whose role has vanished from the guild, and an
+    already-lapsed grant the periodic sweep has not yet collected — so the listing
+    only ever names a role the member still effectively holds. Pure read: no
+    mutation, no audit.
+    """
+    now = _utcnow()
+    rows = await grants_db.list_for_member(guild.id, member_id)
+    active: list[tuple[discord.Role, datetime]] = []
+    for row in rows:
+        expires_at = row["expires_at"]
+        if expires_at <= now:
+            continue
+        role = resources.resolve_role(guild, role_id=int(row["role_id"]))
+        if role is None:
+            continue
+        active.append((role, expires_at))
+    return active
+
+
 async def sweep_expired(guild: discord.Guild) -> int:
     """Remove every lapsed temp role in ``guild`` and drop its row.
 
@@ -142,4 +169,4 @@ async def _emit(
     )
 
 
-__all__ = ["grant_temp_role", "sweep_expired"]
+__all__ = ["grant_temp_role", "list_active_grants", "sweep_expired"]

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -149,4 +149,9 @@ session holds it, no claim line needed here.)*
   (`game_xp_service.world_identity` + `views/explore/world_card.py` + `🪪 World Card` hub button +
   `!worldcard`/`!mystats`) · 2026-06-20 · **PR (this session, self-merge on green)**
 
+- `claude/funny-franklin-8ha49t` · **`!temproles` member-facing temp-role listing** (loose-end
+  from reaction-roles PR 3–5) — read seam `role_grants_service.list_active_grants` + `!temproles`
+  command on `RoleGrantsCog` · `disbot/services/role_grants_service.py` / `disbot/cogs/role_grants_cog.py`
+  + tests · 2026-06-21 · **routine dispatch, self-merge on green**
+
 _(move claims here with their PR # as they close, then prune older entries)_

--- a/tests/unit/cogs/test_role_grants_cog_temproles.py
+++ b/tests/unit/cogs/test_role_grants_cog_temproles.py
@@ -1,0 +1,110 @@
+"""Tests for the ``!temproles`` member-facing listing on ``RoleGrantsCog``.
+
+The command reads through ``role_grants_service.list_active_grants`` (a pure read
+seam) and renders the caller's — or, with Manage Roles, another member's — active
+temp roles. These tests drive the command callback directly with stubbed ctx.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs.role_grants_cog import RoleGrantsCog
+
+
+def _ctx(author, guild):
+    return SimpleNamespace(author=author, guild=guild, send=AsyncMock())
+
+
+def _author(uid: int, *, manage_roles: bool = False, name: str = "Asker"):
+    # spec=discord.Member so the cog's ``isinstance(author, discord.Member)``
+    # staff check sees a Member (as it would in a guild context).
+    author = MagicMock(spec=discord.Member)
+    author.id = uid
+    author.display_name = name
+    author.guild_permissions = SimpleNamespace(manage_roles=manage_roles)
+    return author
+
+
+@pytest.mark.asyncio
+async def test_temproles_lists_own_active_grants():
+    cog = RoleGrantsCog(MagicMock())
+    author = _author(5)
+    guild = SimpleNamespace(id=1)
+    ctx = _ctx(author, guild)
+    expires = datetime(2026, 6, 21, 14, 0, tzinfo=timezone.utc)
+    role = SimpleNamespace(id=42, mention="<@&42>")
+
+    with patch(
+        "cogs.role_grants_cog.role_grants_service.list_active_grants",
+        new=AsyncMock(return_value=[(role, expires)]),
+    ) as list_mock:
+        await cog.temproles.callback(cog, ctx, None)
+
+    list_mock.assert_awaited_once_with(guild, 5)
+    sent = ctx.send.await_args.args[0]
+    assert "You have" in sent and "1 active temp role" in sent
+    assert "<@&42>" in sent and str(int(expires.timestamp())) in sent
+
+
+@pytest.mark.asyncio
+async def test_temproles_empty_message_when_none():
+    cog = RoleGrantsCog(MagicMock())
+    ctx = _ctx(_author(5), SimpleNamespace(id=1))
+    with patch(
+        "cogs.role_grants_cog.role_grants_service.list_active_grants",
+        new=AsyncMock(return_value=[]),
+    ):
+        await cog.temproles.callback(cog, ctx, None)
+    assert "no active temp roles" in ctx.send.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_temproles_other_member_denied_without_manage_roles():
+    cog = RoleGrantsCog(MagicMock())
+    ctx = _ctx(_author(5, manage_roles=False), SimpleNamespace(id=1))
+    other = _author(7, name="Other")
+    with patch(
+        "cogs.role_grants_cog.role_grants_service.list_active_grants",
+        new=AsyncMock(),
+    ) as list_mock:
+        await cog.temproles.callback(cog, ctx, other)
+
+    list_mock.assert_not_awaited()
+    assert "Manage Roles" in ctx.send.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_temproles_staff_can_view_other_member():
+    cog = RoleGrantsCog(MagicMock())
+    ctx = _ctx(_author(5, manage_roles=True), SimpleNamespace(id=1))
+    other = _author(7, name="Other")
+    expires = datetime(2026, 6, 21, 14, 0, tzinfo=timezone.utc)
+    role = SimpleNamespace(id=42, mention="<@&42>")
+    with patch(
+        "cogs.role_grants_cog.role_grants_service.list_active_grants",
+        new=AsyncMock(return_value=[(role, expires)]),
+    ) as list_mock:
+        await cog.temproles.callback(cog, ctx, other)
+
+    list_mock.assert_awaited_once_with(ctx.guild, 7)
+    sent = ctx.send.await_args.args[0]
+    assert "**Other** has" in sent and "<@&42>" in sent
+
+
+@pytest.mark.asyncio
+async def test_temproles_staff_viewing_self_uses_you_phrasing():
+    cog = RoleGrantsCog(MagicMock())
+    author = _author(5, manage_roles=True)
+    ctx = _ctx(author, SimpleNamespace(id=1))
+    with patch(
+        "cogs.role_grants_cog.role_grants_service.list_active_grants",
+        new=AsyncMock(return_value=[]),
+    ):
+        await cog.temproles.callback(cog, ctx, author)
+    assert "You have" in ctx.send.await_args.args[0]

--- a/tests/unit/services/test_role_grants_service.py
+++ b/tests/unit/services/test_role_grants_service.py
@@ -118,3 +118,40 @@ async def test_sweep_cleans_up_when_member_gone():
     assert resolved == 1
     del_mock.assert_awaited_once_with(7)
     audit_mock.assert_not_awaited()  # no role mutation happened
+
+
+@pytest.mark.asyncio
+async def test_list_active_grants_filters_lapsed_and_vanished_roles():
+    from datetime import datetime, timedelta, timezone
+
+    now = datetime(2026, 6, 21, 12, 0, tzinfo=timezone.utc)
+    role_live = SimpleNamespace(id=42, name="VIP")
+    # role 99 is still active by expiry but has vanished from the guild;
+    # role 7 has already lapsed (sweep has not run yet) — both must be dropped.
+    rows = [
+        {"role_id": 7, "expires_at": now - timedelta(minutes=1)},
+        {"role_id": 42, "expires_at": now + timedelta(hours=2)},
+        {"role_id": 99, "expires_at": now + timedelta(hours=5)},
+    ]
+
+    def _get_role(rid: int):
+        return role_live if rid == 42 else None
+
+    guild = SimpleNamespace(id=1, get_role=MagicMock(side_effect=_get_role))
+    with (
+        patch.object(svc.grants_db, "list_for_member", new=AsyncMock(return_value=rows)),
+        patch.object(svc, "_utcnow", return_value=now),
+    ):
+        active = await svc.list_active_grants(guild, member_id=5)
+
+    assert active == [(role_live, now + timedelta(hours=2))]
+
+
+@pytest.mark.asyncio
+async def test_list_active_grants_empty_when_no_rows():
+    guild = SimpleNamespace(id=1, get_role=MagicMock(return_value=None))
+    with patch.object(
+        svc.grants_db, "list_for_member", new=AsyncMock(return_value=[])
+    ):
+        active = await svc.list_active_grants(guild, member_id=5)
+    assert active == []


### PR DESCRIPTION
## What

Closes the flagged loose end from the reaction-roles PR 3–5 session: the free temp-roles
feature (#1227) shipped `grant` + `sweep` but left `utils.db.role_grants.list_for_member`
with **no UI consumer**. This adds the member-facing read.

- **`role_grants_service.list_active_grants(guild, member_id)`** — a pure read seam over
  `list_for_member` that resolves roles, drops vanished roles + already-lapsed-but-unswept
  grants (so the listing never shows a role the member no longer effectively holds). No
  mutation, no audit.
- **`!temproles [@member]`** on `RoleGrantsCog` — lists the caller's own active temp roles
  (role + relative expiry); an optional `@member` is **staff-only** (`manage_roles`).
- Tests for the service read + the command.

## Why this shape

The cog stays a thin shell (its existing contract); the read + role-resolution + active
filtering live on the service next to the audited writes. Additive + behaviour-preserving —
existing temp-role grant/sweep is untouched.

## Verification

`python3.10 scripts/check_quality.py --full` + `check_architecture --mode strict` (to be run
before flip-to-complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoBaPn9B3YRx3kGG9VWF9N

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoBaPn9B3YRx3kGG9VWF9N)_