### PR TITLE
Reaction roles: message picker for the Add flow (no more copy-paste message ID)

### DIFF
--- a/.sessions/2026-06-21-reaction-roles-message-picker.md
+++ b/.sessions/2026-06-21-reaction-roles-message-picker.md
@@ -1,0 +1,23 @@
+# 2026-06-21 — Reaction roles: message picker (no more copy-paste message ID)
+
+> **Status:** `in-progress` — born-red HOLD (Q-0133). Owner-directed follow-up to #1234/#1237
+> (Q-0191 → merge on green). Fresh branch (Q-0014).
+
+> **Run type:** `manual`
+
+## What I'm about to do
+
+The emoji reaction-role **Add** flow still asks the operator to paste a raw Message ID — the
+clunkiest step (a frequent Carl complaint). Replace it with native message-source options, mirroring
+Carl's three setup methods, on `ReactionRolesPanel`:
+
+- **📍 Most recent** — bind to the latest message in this channel (no ID).
+- **📜 Pick recent** — choose from a list of recent messages (author + preview).
+- **🆕 New message** — the bot posts a message/embed, then binds to it.
+- **🔢 By ID** — the existing modal, kept as a fallback.
+
+Each path lands in the existing per-emote role flow (`_BindEmotesView`). Respects Discord's
+"modal must be the first response" constraint (recent-pick → select → modal; new-message → one modal
+that also takes the emotes). Pure helpers (message label/most-recent resolution) get unit tests.
+
+Verify: `check_quality.py --full` + `check_architecture.py --mode strict`.

--- a/.sessions/2026-06-21-reaction-roles-message-picker.md
+++ b/.sessions/2026-06-21-reaction-roles-message-picker.md
@@ -1,23 +1,97 @@
 # 2026-06-21 — Reaction roles: message picker (no more copy-paste message ID)
 
-> **Status:** `in-progress` — born-red HOLD (Q-0133). Owner-directed follow-up to #1234/#1237
-> (Q-0191 → merge on green). Fresh branch (Q-0014).
+> **Status:** `complete` — owner-directed follow-up to #1234/#1237 (Q-0191 → merge on green). PR #1243.
 
 > **Run type:** `manual`
 
-## What I'm about to do
+## Arc
 
-The emoji reaction-role **Add** flow still asks the operator to paste a raw Message ID — the
-clunkiest step (a frequent Carl complaint). Replace it with native message-source options, mirroring
-Carl's three setup methods, on `ReactionRolesPanel`:
+The emoji reaction-role **Add** flow still asked the operator to paste a raw Message ID — the
+clunkiest step, and a frequent Carl complaint. Replaced it with a source chooser on
+`ReactionRolesPanel`: **➕ Add → `_AddSourceView`** with four ways to identify the message —
 
-- **📍 Most recent** — bind to the latest message in this channel (no ID).
-- **📜 Pick recent** — choose from a list of recent messages (author + preview).
-- **🆕 New message** — the bot posts a message/embed, then binds to it.
-- **🔢 By ID** — the existing modal, kept as a fallback.
+- **📍 Most recent** — binds to the latest message in this channel (no id).
+- **📜 Pick recent** — a select of recent messages (`author: preview`), windowed via
+  `PaginatedSelectView`.
+- **🆕 New message** — `_NewMessageModal` posts an embed/text message, then binds to it.
+- **🔢 By ID** — the original `_AddBindingModal`, kept as a fallback.
 
-Each path lands in the existing per-emote role flow (`_BindEmotesView`). Respects Discord's
-"modal must be the first response" constraint (recent-pick → select → modal; new-message → one modal
-that also takes the emotes). Pure helpers (message label/most-recent resolution) get unit tests.
+Every path lands in the existing per-emote role picker (`_BindEmotesView`), so "multiple emotes →
+each its own role" (from #1234) still holds. The old `_MoreEmotesModal` was generalised to
+`_EmotesModal` (used by the picker paths *and* the "add more emotes" toast).
 
-Verify: `check_quality.py --full` + `check_architecture.py --mode strict`.
+## Findings / decisions
+
+- **Decision made alone — the controlling constraint is Discord's "a modal must be the *first*
+  response to an interaction."** That shaped the whole flow: paths needing an async lookup before the
+  message is known can't then open a modal in the same interaction. So **pick-recent** resolves the
+  message via a select first, and the *select pick* opens the emotes modal (modal = first response to
+  the select); **new-message** uses one modal that captures title+text+**emotes** together, posts,
+  then continues to role-picking; **most-recent** does a small `history(limit=5)` then opens the modal
+  (one fast call, inside the 3s window).
+- **Decision made alone:** the picker excludes the panel's own message (`_panel_message_id`) so it's
+  never offered as a target, and `_recent_messages` degrades to `[]` when history can't be read
+  (missing permission) — routing the operator to By-ID / New-message instead of erroring.
+- **No new service/DB/schema** — this is entirely the `reaction_panel` view; it reuses the audited
+  `bind_emoji` seam and `parse_emotes` from #1234.
+
+## Context delta
+
+- **Needed but not pointed to:** the "modal must be the first interaction response" rule is the single
+  most important Discord-UI constraint for multi-step flows, and it isn't in the orientation route or
+  `.claude/rules/discord-views.md`. It dictates flow shape (you cannot `defer()`/`await` then
+  `send_modal`). Worth a one-line rule in `discord-views.md`.
+- **Pointed to but didn't need:** nothing new — the existing `reaction_panel` Add flow (#1234) was the
+  only context needed; I reused its `_BindEmotesView`/`parse_emotes` wholesale.
+- **Discovered by hand:** `PaginatedSelectView`'s on-pick callback receives an *unconsumed*
+  interaction, so a select pick can open a modal directly — the linchpin that makes pick-recent work.
+- **Decisions made alone:** see Findings (modal-first flow shaping; panel-message exclusion; history
+  degrade).
+- **Weak point / unverified:** the picker is **not live-walked** — `history()` latency vs. the 3s
+  modal window on most-recent, and the select→modal handoff, want a runtime smoke. Pure helpers are
+  unit-tested; the interaction wiring is a thin shell over them.
+- **One docs/tooling change that would help:** add the modal-first-response rule to
+  `.claude/rules/discord-views.md` (did not self-edit — owner-governed file; flagged here instead).
+
+## 📤 Run report
+
+- **Did:** replaced the raw-message-ID Add step with a native message picker (most-recent / pick /
+  new / by-id) · **Outcome:** shipped (PR #1243, auto-merge on green)
+- **Shipped:** #1243 — reaction-roles Add message picker
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** none (owner-directed)
+- **⚑ Owner manual steps:** none — merge ≠ deploy; the prod restart stays yours. (The picker needs the
+  bot's **Read Message History** permission for most-recent/pick-recent; it degrades to By-ID/New if
+  absent.)
+- **⚑ Self-initiated:** none (direct owner request, picked via the next-step question)
+- **↪ Next:** the gradient-presets-gallery idea (from #1237) is still on the shelf; otherwise a live
+  smoke-walk of the three reaction-roles PRs (#1234/#1237/#1243).
+
+## 💡 Session idea
+
+**Add the "modal-must-be-first-response" rule to `.claude/rules/discord-views.md`.** It bit the flow
+shape of this PR (and is implicit in several existing views). A one-line binding rule — *"a modal can
+only be opened as the first response to an interaction; if you must `await`/`defer` first, route
+through a button/select whose callback opens the modal"* — would save the next agent the
+reverse-engineering. (Proposed, not applied — `.claude/` is owner-governed; routing as a router
+DISCUSS item would be the channel.)
+
+## ⟲ Previous-session review
+
+The #1237 session shipped a lot (channel + colour + gradient) cleanly and answered the gradient
+question with ground-truth introspection (good instinct). What it could have done better: it created
+**a third same-day branch** for tightly-related reaction-roles work, when the prior two had already
+shown the parallel-session branch-name collision risk. **System improvement (carried from #1237's own
+review):** `check_lane_overlap.py` should flag two live sessions targeting the same `claude/*` branch,
+not just overlapping files — the recurring collision axis this session-chain keeps hitting. (This run
+used a fresh, uniquely-named branch precisely to avoid it.)
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 0 (pending #1243, auto-merge on green) |
+| CI-red rounds | 0 real (born-red HOLD only, by design) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (modal-first-response rule for discord-views) |
+| Ideas groomed | 0 |

--- a/disbot/views/roles/reaction_panel.py
+++ b/disbot/views/roles/reaction_panel.py
@@ -126,7 +126,11 @@ class ReactionRolesPanel(BaseView):
         if not _can_manage(interaction):
             await _deny(interaction)
             return
-        await interaction.response.send_modal(_AddBindingModal(self))
+        await interaction.response.send_message(
+            "Which message should these reaction roles go on?",
+            view=_AddSourceView(self),
+            ephemeral=True,
+        )
 
     @discord.ui.button(label="🗑️ Remove", style=discord.ButtonStyle.red, row=0)
     async def remove_btn(
@@ -304,12 +308,243 @@ class ReactionRolesPanel(BaseView):
 
 
 # ---------------------------------------------------------------------------
-# Sub-flow: add bindings (message-id + emoji modal → per-emote role pickers)
+# Sub-flow: add bindings (pick the message → emote(s) → per-emote role pickers)
 # ---------------------------------------------------------------------------
 # One message can carry many emotes, each mapped to its OWN role (owner
-# direction, 2026-06-21). The operator types one or more emotes; the flow then
-# walks each emote in turn, picking its role, so 💀→A, ❤️→B, 😘→C bind in a
-# single pass instead of one tediously-repeated single-emote add.
+# direction, 2026-06-21). The operator first chooses WHICH message via
+# `_AddSourceView` — most-recent / pick-recent / new-message / by-id, mirroring
+# Carl's setup methods so nobody has to copy-paste a raw id — then types one or
+# more emotes, and the flow walks each emote picking its role (💀→A, ❤️→B, 😘→C).
+
+
+def _message_label(message: object) -> str:
+    """A one-line picker label for a message: ``author: preview``."""
+    author = getattr(getattr(message, "author", None), "display_name", "") or "unknown"
+    content = " ".join((getattr(message, "content", "") or "").split())
+    if not content:
+        if getattr(message, "embeds", None):
+            content = "[embed]"
+        elif getattr(message, "attachments", None):
+            content = "[attachment]"
+        else:
+            content = "[no text]"
+    return f"{author}: {content}"
+
+
+def _message_desc(message: object) -> str:
+    """The select-option description for a recent message (its id)."""
+    return f"id {getattr(message, 'id', '?')}"
+
+
+def _panel_message_id(panel: ReactionRolesPanel) -> int | None:
+    """The panel's own message id, so the picker never offers it as a target."""
+    return getattr(getattr(panel, "message", None), "id", None)
+
+
+async def _recent_messages(
+    channel: discord.abc.Messageable,
+    *,
+    exclude_id: int | None,
+    limit: int = 20,
+) -> list[discord.Message]:
+    """Recent messages in a channel (newest first), minus the panel's own.
+
+    Degrades to an empty list when history can't be read (missing permission),
+    so the caller can route the operator to By-ID / New-message instead.
+    """
+    out: list[discord.Message] = []
+    try:
+        async for message in channel.history(limit=limit):
+            if exclude_id is not None and message.id == exclude_id:
+                continue
+            out.append(message)
+    except (discord.Forbidden, discord.HTTPException):
+        return []
+    return out
+
+
+class _AddSourceView(BaseView):
+    """Choose how to identify the message to bind reaction roles to.
+
+    Replaces the bare "type a Message ID" step with Carl-style setup methods;
+    every path lands in the same per-emote role picker (:class:`_BindEmotesView`).
+    """
+
+    def __init__(self, panel: ReactionRolesPanel) -> None:
+        super().__init__(panel.ctx.author, timeout=180)
+        self.panel = panel
+
+    @discord.ui.button(label="📍 Most recent", style=discord.ButtonStyle.grey, row=0)
+    async def recent_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not _can_manage(interaction):
+            await _deny(interaction)
+            return
+        channel = interaction.channel
+        if not isinstance(channel, discord.abc.Messageable):
+            await interaction.response.send_message(
+                "Open this in a server text channel.",
+                ephemeral=True,
+            )
+            return
+        messages = await _recent_messages(
+            channel,
+            exclude_id=_panel_message_id(self.panel),
+            limit=5,
+        )
+        if not messages:
+            await interaction.response.send_message(
+                "I couldn't find a recent message here — try **🔢 By ID** or "
+                "**🆕 New message**.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_modal(_EmotesModal(self.panel, messages[0].id))
+
+    @discord.ui.button(label="📜 Pick recent", style=discord.ButtonStyle.grey, row=0)
+    async def pick_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not _can_manage(interaction):
+            await _deny(interaction)
+            return
+        channel = interaction.channel
+        if not isinstance(channel, discord.abc.Messageable):
+            await interaction.response.send_message(
+                "Open this in a server text channel.",
+                ephemeral=True,
+            )
+            return
+        messages = await _recent_messages(
+            channel,
+            exclude_id=_panel_message_id(self.panel),
+            limit=20,
+        )
+        if not messages:
+            await interaction.response.send_message(
+                "No recent messages here — try **🔢 By ID** or **🆕 New message**.",
+                ephemeral=True,
+            )
+            return
+        options = [
+            discord.SelectOption(
+                label=_message_label(m)[:100],
+                value=str(m.id),
+                description=_message_desc(m)[:100],
+            )
+            for m in messages
+        ]
+        panel = self.panel
+
+        async def _on_pick(pick: discord.Interaction, values: list[str]) -> None:
+            await pick.response.send_modal(_EmotesModal(panel, int(values[0])))
+
+        await interaction.response.edit_message(
+            content="Pick the message to add reaction roles to:",
+            view=PaginatedSelectView(
+                interaction.user,
+                options,
+                _on_pick,
+                placeholder="Recent messages…",
+            ),
+        )
+
+    @discord.ui.button(label="🆕 New message", style=discord.ButtonStyle.green, row=0)
+    async def new_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not _can_manage(interaction):
+            await _deny(interaction)
+            return
+        await interaction.response.send_modal(_NewMessageModal(self.panel))
+
+    @discord.ui.button(label="🔢 By ID", style=discord.ButtonStyle.grey, row=0)
+    async def id_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not _can_manage(interaction):
+            await _deny(interaction)
+            return
+        await interaction.response.send_modal(_AddBindingModal(self.panel))
+
+
+class _NewMessageModal(discord.ui.Modal, title="Post a reaction-role message"):  # type: ignore[call-arg]
+    """Post a fresh message/embed, then bind reaction roles to it."""
+
+    title_in = discord.ui.TextInput(  # type: ignore[var-annotated]
+        label="Embed title (optional)",
+        placeholder="e.g. Pick your roles",
+        required=False,
+        max_length=100,
+    )
+    text_in = discord.ui.TextInput(  # type: ignore[var-annotated]
+        label="Message text",
+        style=discord.TextStyle.paragraph,
+        placeholder="React below to pick up a role!",
+        max_length=2000,
+    )
+    emoji_in = discord.ui.TextInput(  # type: ignore[var-annotated]
+        label="Emoji(s)",
+        placeholder="💀 ❤️ 😘  — one or more (each gets its own role)",
+        max_length=200,
+    )
+
+    def __init__(self, panel: ReactionRolesPanel) -> None:
+        super().__init__()
+        self.panel = panel
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        emotes = parse_emotes(self.emoji_in.value)
+        if not emotes:
+            await interaction.response.send_message(
+                "❌ Enter at least one emoji.",
+                ephemeral=True,
+            )
+            return
+        channel = interaction.channel
+        if not isinstance(channel, discord.abc.Messageable):
+            await interaction.response.send_message(
+                "I can't post a message in this channel.",
+                ephemeral=True,
+            )
+            return
+        title = self.title_in.value.strip()
+        text = self.text_in.value.strip()
+        try:
+            if title:
+                message = await channel.send(
+                    embed=discord.Embed(
+                        title=title,
+                        description=text or None,
+                        color=ROLE_COLOR,
+                    ),
+                )
+            else:
+                message = await channel.send(
+                    content=text or "React below to pick up a role:",
+                )
+        except (discord.Forbidden, discord.HTTPException):
+            await interaction.response.send_message(
+                "I couldn't post a message here — I'm missing permission to send "
+                "messages in this channel.",
+                ephemeral=True,
+            )
+            return
+        view = _BindEmotesView(self.panel, message.id, emotes)
+        await interaction.response.send_message(
+            content=view.prompt(),
+            view=view,
+            ephemeral=True,
+        )
 
 
 class _AddBindingModal(discord.ui.Modal, title="Add reaction role"):  # type: ignore[call-arg]
@@ -353,8 +588,13 @@ class _AddBindingModal(discord.ui.Modal, title="Add reaction role"):  # type: ig
         )
 
 
-class _MoreEmotesModal(discord.ui.Modal, title="Add more emotes"):  # type: ignore[call-arg]
-    """Bind further emotes to the SAME message without re-typing its ID."""
+class _EmotesModal(discord.ui.Modal, title="Add reaction emotes"):  # type: ignore[call-arg]
+    """Collect emote(s) for an already-chosen message → per-emote role pickers.
+
+    Used once the message is known (the picker / most-recent paths), and by the
+    "add more emotes" toast on an existing binding — so the operator never re-types
+    the message id.
+    """
 
     emoji_in = discord.ui.TextInput(  # type: ignore[var-annotated]
         label="Emoji(s)",
@@ -504,5 +744,5 @@ class _AfterBindView(BaseView):
             await _deny(interaction)
             return
         await interaction.response.send_modal(
-            _MoreEmotesModal(self.panel, self.message_id),
+            _EmotesModal(self.panel, self.message_id),
         )

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,10 +25,6 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/reaction-roles-message-picker` · **reaction-roles follow-up** (owner-directed) — emoji-add
-  message picker (most-recent / pick-recent / new-message / by-id) replacing the raw message-ID step ·
-  `disbot/views/roles/reaction_panel.py` · 2026-06-21 · **PR (this session, merge on green)**
-
 - `claude/dispatch-next` · **prune stale Active claims (drift-on-sight, Q-0166)** — every prior
   claim had merged, polluting `check_lane_overlap.py` with false positives · `docs/owner/active-work.md`
   · 2026-06-21 · **auto-merge on green** (docs-only)
@@ -48,6 +44,9 @@ session holds it, no claim line needed here.)*
 
 ## Recently cleared
 
+- `claude/reaction-roles-message-picker` · **reaction-roles follow-up** (owner-directed) — emoji-add
+  message picker (most-recent / pick-recent / new-message / by-id) replacing the raw message-ID step ·
+  `disbot/views/roles/reaction_panel.py` · 2026-06-21 · **PR #1243 (merge on green)**
 - `claude/reaction-roles-channel-and-colors` · **reaction-roles follow-up** (owner-directed) — menu
   post-channel picker + auto-created colour roles + gradient/holographic (audited
   `RoleLifecycleService` seam, gated on Enhanced-Role-Styles) · 2026-06-21 · **PR #1237 (merge on green)**

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,10 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/reaction-roles-message-picker` · **reaction-roles follow-up** (owner-directed) — emoji-add
+  message picker (most-recent / pick-recent / new-message / by-id) replacing the raw message-ID step ·
+  `disbot/views/roles/reaction_panel.py` · 2026-06-21 · **PR (this session, merge on green)**
+
 - `claude/dispatch-next` · **prune stale Active claims (drift-on-sight, Q-0166)** — every prior
   claim had merged, polluting `check_lane_overlap.py` with false positives · `docs/owner/active-work.md`
   · 2026-06-21 · **auto-merge on green** (docs-only)

--- a/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
+++ b/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
@@ -43,6 +43,13 @@
 > boosts**, so the gradient UI is offered only when `guild.features` advertises it
 > (`supports_role_gradients`), with a caught-400 solid-colour fallback.
 >
+> **▶ Refinement (2026-06-21, owner-directed — PR #1243):** the emoji **Add** flow no longer makes
+> the operator paste a raw Message ID. `ReactionRolesPanel` Add now opens `_AddSourceView` —
+> **📍 Most recent · 📜 Pick recent · 🆕 New message · 🔢 By ID** (Carl's setup methods) — and every
+> path lands in the existing per-emote role picker (`_BindEmotesView`). Respects Discord's
+> "modal-must-be-first-response" rule (pick-recent → select → emotes modal; new-message → one modal
+> that also captures the emotes). The old `_MoreEmotesModal` is generalised to `_EmotesModal`.
+>
 > **One-line goal:** bring SuperBot's self-assignable-role surface to **parity-plus** with
 > Carl-bot — lead with native **buttons + dropdown menus** (Carl's are a secondary/premium
 > add; emoji reactions are its core), keep emoji reaction-roles working for compatibility,

--- a/tests/unit/views/test_reaction_panel_message_picker.py
+++ b/tests/unit/views/test_reaction_panel_message_picker.py
@@ -1,0 +1,81 @@
+"""Tests for the reaction-role Add message-picker helpers (owner direction).
+
+Covers the pure helpers behind the picker — the select label/description for a
+recent message, the panel-message exclusion, and the history fetch (including its
+graceful degrade when history can't be read). The interaction wiring
+(`_AddSourceView` / `_NewMessageModal`) is a thin shell over these + the existing
+`_BindEmotesView`, which has its own tests.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import discord
+import pytest
+
+from views.roles import reaction_panel as rp
+
+
+def _msg(mid, author="Menno", content="hi", embeds=(), attachments=()):
+    return SimpleNamespace(
+        id=mid,
+        author=SimpleNamespace(display_name=author),
+        content=content,
+        embeds=list(embeds),
+        attachments=list(attachments),
+    )
+
+
+class _FakeChannel:
+    """Minimal channel with an async ``history`` matching discord.py's shape."""
+
+    def __init__(self, messages, *, exc=None):
+        self._messages = messages
+        self._exc = exc
+
+    def history(self, *, limit):
+        messages = list(self._messages)[:limit]
+        exc = self._exc
+
+        async def _gen():
+            if exc is not None:
+                raise exc
+            for message in messages:
+                yield message
+
+        return _gen()
+
+
+def test_message_label_variants():
+    assert rp._message_label(_msg(1, "Menno", "Hello   world")) == "Menno: Hello world"
+    assert rp._message_label(_msg(2, "Bot", "", embeds=[object()])) == "Bot: [embed]"
+    assert (
+        rp._message_label(_msg(3, "Bot", "", attachments=[object()]))
+        == "Bot: [attachment]"
+    )
+    assert rp._message_label(_msg(4, "Bot", "")) == "Bot: [no text]"
+
+
+def test_message_desc():
+    assert rp._message_desc(_msg(77)) == "id 77"
+
+
+def test_panel_message_id():
+    assert rp._panel_message_id(SimpleNamespace(message=None)) is None
+    assert rp._panel_message_id(SimpleNamespace(message=SimpleNamespace(id=9))) == 9
+
+
+@pytest.mark.asyncio
+async def test_recent_messages_excludes_panel_and_preserves_order():
+    channel = _FakeChannel([_msg(10), _msg(20), _msg(30)])
+    out = await rp._recent_messages(channel, exclude_id=20, limit=10)
+    assert [m.id for m in out] == [10, 30]
+
+
+@pytest.mark.asyncio
+async def test_recent_messages_degrades_to_empty_when_history_forbidden():
+    forbidden = discord.Forbidden(SimpleNamespace(status=403, reason="Forbidden"), "no")
+    channel = _FakeChannel([_msg(10)], exc=forbidden)
+    out = await rp._recent_messages(channel, exclude_id=None, limit=10)
+    assert out == []


### PR DESCRIPTION
Owner-directed follow-up to #1234/#1237. The emoji reaction-role **Add** flow still required pasting
a raw Message ID — the clunkiest step (a frequent Carl complaint). This replaces it with native
message-source options on `ReactionRolesPanel`, mirroring Carl's three setup methods:

- **📍 Most recent** — bind to the latest message in the channel (no ID).
- **📜 Pick recent** — choose from a list of recent messages (author + preview).
- **🆕 New message** — the bot posts a message/embed, then binds reaction roles to it.
- **🔢 By ID** — the original modal, kept as a fallback.

Every path lands in the existing per-emote role flow (`_BindEmotesView`), so multiple emotes →
their own roles still works. Respects Discord's "a modal must be the first response to an
interaction" constraint (recent-pick → select → emotes modal; new-message → one modal that also
captures the emotes).

Born-red HOLD (Q-0133) until the session card flips to `complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK6bg63g8Vsp2m4nhUxUrf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK6bg63g8Vsp2m4nhUxUrf)_