### PR TITLE
Role presets + role-management UX overhaul (remove hardcoded German tier names)

### DIFF
--- a/.sessions/2026-06-21-role-presets-and-management-ux.md
+++ b/.sessions/2026-06-21-role-presets-and-management-ux.md
@@ -1,28 +1,119 @@
 # 2026-06-21 — Role presets + role-management UX overhaul
 
-> **Status:** `in-progress` — born-red HOLD (Q-0133). Flip to `complete` as the deliberate
-> final step once the work + close-out docs land.
+> **Status:** `complete` — owner-directed (Q-0191 → merge on green). PR #1245.
 
 > **Run type:** `manual` (owner-directed, screenshots + in-chat requirements)
 
 ## Arc
 
-Owner-directed from a `!roles` diagnostics screenshot ("Role Automation ⚠️ missing: Neu, Normal,
-Iron, Gold, Diamand, Netherite, Beacon") plus three follow-up UX asks. Four threads, all inside
-the role-management subsystem (`disbot/views/roles/` + `cogs/role_cog.py` + `_helpers`):
+Owner-directed from a `!roles` → 🔧 Diagnostics screenshot ("Role Automation ⚠️ missing: Neu,
+Normal, Iron, Gold, Diamand, Netherite, Beacon") plus three follow-up UX asks (Create/Edit/Delete
+screenshots). Four threads, all inside the role-management subsystem
+(`disbot/views/roles/` + `cogs/role_cog.py` + `_helpers`):
 
-1. **Remove the hardcoded German/Minecraft tier names** (`_DEFAULT_THRESHOLDS` =
-   Neu/Normal/Iron/Gold/Diamand/Netherite/Beacon) and the `_ensure_defaults` seeding entirely —
-   role automation now loads **only real server roles**; add a **🧹 Clear missing** purge so the
-   phantom stale rows those names left in the DB can be cleared (the diagnostics "missing:" line).
-2. **Create role** — a creation *menu* with **preset role names** + **colour presets** to pick,
-   custom (full modal) still available. Presets live ONLY in this menu (owner constraint).
-3. **Edit role** — pick the role from a **select** instead of typing its name.
-4. **Delete role** — **multi-select + confirmation** instead of single immediate delete.
+1. **Removed the hardcoded German/Minecraft tier names.** Deleted `_DEFAULT_THRESHOLDS`
+   (`Neu/Normal/Iron/Gold/Diamand/Netherite/Beacon`) and the `_ensure_defaults` seed routine
+   entirely (4 call sites: `main_panel`, `role_cog` ×3). Role automation now loads **only roles that
+   exist on the server**. The "🔄 Seed Defaults" button (which seeded those names) is replaced by a
+   **🧹 Clear Missing** button that bulk-clears stale/phantom threshold rows through the audited
+   `role_automation.clear_time_threshold` seam — directly clears the "missing:" diagnostics line.
+2. **Create role** is now a *menu* (`RoleCreatePanel`): a **preset role-name** select
+   (`ROLE_PRESETS` — 6 generic roles) + a **colour preset** select (`_COLOR_OPTIONS`), with
+   **✏️ Custom…** still opening the full free-text modal. Presets are surfaced **only here**
+   (owner constraint) — never in automation/diagnostics. Create routes through the audited
+   `RoleLifecycleService`, then offers the same XP-automation follow-up as the modal.
+3. **Edit role** opens a **role picker** (windowed, filtered to bot+admin-manageable via
+   `manageable_roles`) → the edit modal, instead of typing the role name. The modal shows the
+   chosen role in its title and edits id-first.
+4. **Delete role** is a **multi-select** of deletable roles → an explicit **confirmation** listing
+   every role → batched delete via `RoleLifecycleService`. (Was: single-select, immediate delete.)
 
-## Status: building. (placeholder — close-out notes below on flip-to-complete.)
+## Findings / decisions
+
+- **`RoleLifecycleService` is the only sanctioned `create_role`/edit/delete caller** (allowlisted by
+  `tests/unit/invariants/test_no_silent_auto_create.py`, audited). Every create/edit/delete path —
+  the new preset Create, the edit modal, the batched delete — routes through it; no raw
+  `guild.*_role`. (Learned from the #1237 session card; still not in the orientation route.)
+- **Decision made alone — presets are a `views/roles/_helpers` constant, not persisted.** "A few
+  presets" → 6 generic roles (Member/Verified/VIP/Moderator/Admin/Muted) with palette colours, not
+  the old server-specific tiers. Per-guild custom presets are deferred (see Session idea).
+- **Decision made alone — the modal-can't-hold-a-select constraint forced Create into a panel.**
+  Discord modals only contain text inputs, so "pick a preset name + colour" can't live *inside* the
+  Create Role modal; the three entry buttons (`main_panel`, `role_cog` persistent view,
+  `management_panel`) now open `RoleCreatePanel` (an ephemeral view) instead of `send_modal`.
+- **Decision made alone — "Clear Missing" over leaving the phantom rows.** The German names showed
+  as "missing" because old seeding persisted them; removing the code doesn't purge live DB rows, so
+  the operator needs a one-click purge. Scoped to the time field (`clear_time_threshold`), which is
+  exactly what the diagnostics "missing:" line reads.
+- **Edit/Delete pickers filter via `utils.role_feasibility.manageable_roles`** (bot perms +
+  hierarchy + @everyone/managed) so the picker only offers roles the action can succeed on.
+
+## Context delta
+
+- **Needed but not pointed to:** that `RoleLifecycleService` is the *single* allowlisted role-object
+  mutator — discovered via the #1237 session card, not the orientation route. Same gap that card
+  flagged; worth an `AGENT_ORIENTATION` line "runtime role create/edit/delete → only via
+  `RoleLifecycleService`".
+- **Reusable building blocks that saved time:** `views.selectors.attach_role_select` /
+  `attach_multi_role_select` (windowed, #1040-safe) gave the edit picker + delete multi-select for
+  free; `manageable_roles` gave the filter. No bespoke selects needed.
+- **Two invariants caught real drift during `--full`:** `test_no_raw_defer` (a defensive
+  `interaction.response.defer()` in the preset callback → `safe_defer`) and the mypy `name-defined`
+  on a *fourth* `_ensure_defaults` call site I'd missed (the persistent-view `time_roles_btn`). The
+  CI mirror earned its keep.
+- **Decisions made alone:** see Findings (presets-as-constant; panel-not-modal; Clear-Missing).
+- **Weak point / unverified:** the new panels are unit-tested with Discord mocked; **not live-walked**
+  on a real guild. The multi-page multi-select delete carries the documented caveat (selection does
+  not persist across a >25-role page flip) — fine for typical servers, noted in `paginated_select`.
+- **One docs/tooling change that would help:** the orientation line above
+  (`RoleLifecycleService` as the one role mutator).
 
 ## 📤 Run report
 
-- **Did:** (in progress)
+- **Did:** removed hardcoded German tier names + seeding; Create-menu name/colour presets;
+  Edit-by-select; Delete multi-select + confirm; Clear-Missing purge · **Outcome:** shipped
+  (PR #1245, auto-merge on green)
+- **Shipped:** #1245 — role presets + role-management UX overhaul
 - **Run type:** `manual`
+- **CI:** `check_quality.py --full` green (11328 passed, 47 skipped); arch strict 0 new; mypy clean.
+- **⚑ Owner decisions needed:** none (owner-directed). Preset *names/colours* are a judgement pick —
+  trivially editable in `views/roles/_helpers.py` `ROLE_PRESETS` if you want a different set.
+- **⚑ Owner manual steps:** Merge ≠ deploy — prod restart stays yours. After deploy, the German
+  "missing" rows clear with one click of **!roles → ⏱️ Time Roles → 🧹 Clear Missing** (they're live
+  DB rows; the code no longer reseeds them, but existing rows persist until purged).
+- **⚑ Self-initiated:** none (direct owner request). The **🧹 Clear Missing** button is a small
+  adjacent completion of "roles only from the server" (the audit's long-flagged missing bulk-clear).
+- **↪ Next:** optional live-walk of the four flows; per-guild custom presets (Session idea).
+
+## 💡 Session idea
+
+**Per-guild custom role presets.** `ROLE_PRESETS` is a global code constant today. Let server admins
+save their *own* quick-create presets (name + colour + hoist) that appear in `RoleCreatePanel`
+alongside the built-ins — a small audited table + a "➕ Save as preset" affordance on the creation
+menu. This is the natural next step from what shipped: the owner asked for "a few presets", and the
+most-used real-world presets are server-specific (the very German tiers we just removed were *one
+server's* presets baked into everyone's code). Cheap (one table + the existing `RoleLifecycleService`
+create path) and surfaced only in the creation menu, preserving this session's constraint.
+Dedup-checked `docs/ideas/` — `settings-presets-and-ai-template-advisor.md` is about *settings*
+presets, not role presets; this is distinct.
+
+## ⟲ Previous-session review
+
+The previous session (`2026-06-21-prune-stale-claims.md`) correctly applied the Q-0166 drift-on-sight
+rule — every prior `active-work.md` claim had merged, polluting `check_lane_overlap.py` with false
+positives, so pruning them was exactly right. What it surfaces: the claim ledger keeps going stale
+because **claim removal is a manual session-close step that sessions forget** (the same lag that made
+a whole prune session necessary). **System improvement:** fold the claim-line removal into the
+`/session-close` skill (it already drives the card flip + ledger checks) so a session that closes
+also clears its own `active-work.md` line — turning the periodic manual prune into a no-op. The
+lane-overlap scan (#1223) reads the ledger; keeping the ledger self-cleaning is the missing half.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 0 (pending #1245, auto-merge on green) |
+| CI-red rounds | 0 real (born-red HOLD only, by design); 3 issues caught + fixed pre-push locally |
+| Repo-rule trips | 2 caught locally by `--full` (raw-defer invariant · mypy missed call site) |
+| New ideas contributed | 1 (per-guild custom role presets) |
+| Ideas groomed | 0 (large owner-directed build; grooming deferred) |

--- a/.sessions/2026-06-21-role-presets-and-management-ux.md
+++ b/.sessions/2026-06-21-role-presets-and-management-ux.md
@@ -1,0 +1,28 @@
+# 2026-06-21 — Role presets + role-management UX overhaul
+
+> **Status:** `in-progress` — born-red HOLD (Q-0133). Flip to `complete` as the deliberate
+> final step once the work + close-out docs land.
+
+> **Run type:** `manual` (owner-directed, screenshots + in-chat requirements)
+
+## Arc
+
+Owner-directed from a `!roles` diagnostics screenshot ("Role Automation ⚠️ missing: Neu, Normal,
+Iron, Gold, Diamand, Netherite, Beacon") plus three follow-up UX asks. Four threads, all inside
+the role-management subsystem (`disbot/views/roles/` + `cogs/role_cog.py` + `_helpers`):
+
+1. **Remove the hardcoded German/Minecraft tier names** (`_DEFAULT_THRESHOLDS` =
+   Neu/Normal/Iron/Gold/Diamand/Netherite/Beacon) and the `_ensure_defaults` seeding entirely —
+   role automation now loads **only real server roles**; add a **🧹 Clear missing** purge so the
+   phantom stale rows those names left in the DB can be cleared (the diagnostics "missing:" line).
+2. **Create role** — a creation *menu* with **preset role names** + **colour presets** to pick,
+   custom (full modal) still available. Presets live ONLY in this menu (owner constraint).
+3. **Edit role** — pick the role from a **select** instead of typing its name.
+4. **Delete role** — **multi-select + confirmation** instead of single immediate delete.
+
+## Status: building. (placeholder — close-out notes below on flip-to-complete.)
+
+## 📤 Run report
+
+- **Did:** (in progress)
+- **Run type:** `manual`

--- a/disbot/cogs/role_cog.py
+++ b/disbot/cogs/role_cog.py
@@ -15,7 +15,7 @@ from utils import db
 from utils.guild_config_accessors import invalidate_xp_threshold_roles
 from utils.helpers import normalize_name
 from utils.ui_constants import ROLE_COLOR
-from views.roles._helpers import _ensure_defaults, _find_role_normalized, _parse_color
+from views.roles._helpers import _find_role_normalized, _parse_color
 
 logger = logging.getLogger("bot")
 
@@ -95,9 +95,14 @@ class RoleHubPanelView(PersistentView):
                 ephemeral=True,
             )
             return
-        from views.roles.creation_panel import RoleCreateModal
+        from views.roles.creation_panel import RoleCreatePanel
 
-        await interaction.response.send_modal(RoleCreateModal(_CtxAdapter(interaction)))
+        panel = RoleCreatePanel(_CtxAdapter(interaction))
+        await interaction.response.send_message(
+            embed=panel.build_embed(),
+            view=panel,
+            ephemeral=True,
+        )
 
     @discord.ui.button(
         label="🗂️ Manage",
@@ -145,7 +150,6 @@ class RoleHubPanelView(PersistentView):
             return
         from views.roles.time_roles_panel import TimeRolesPanel
 
-        await _ensure_defaults(interaction.guild)
         self.message = interaction.message
         panel = TimeRolesPanel(_CtxAdapter(interaction), parent=self)
         panel.message = interaction.message
@@ -297,7 +301,6 @@ class RoleCog(commands.Cog):
         the guild-wide batch shares logic with
         :meth:`on_member_join`.
         """
-        await _ensure_defaults(guild)
         thresholds = await db.get_role_thresholds(guild.id)
         if not thresholds:
             if ctx:
@@ -687,7 +690,6 @@ class RoleCog(commands.Cog):
     async def on_member_join(self, member: discord.Member) -> None:
         if member.bot:
             return
-        await _ensure_defaults(member.guild)
         thresholds = await db.get_role_thresholds(member.guild.id)
         if not thresholds:
             return

--- a/disbot/views/roles/_helpers.py
+++ b/disbot/views/roles/_helpers.py
@@ -1,15 +1,26 @@
 """Shared helpers for the role-management panel views.
 
-Hosts the time-based threshold defaults, the color-picker presets, the
-``_ensure_defaults`` seeding routine, and the ``_parse_color`` helper.
+Hosts the colour-picker presets (``_COLOR_OPTIONS``), the role-creation presets
+(``ROLE_PRESETS`` — quick-create templates shown ONLY in the role creation
+menu), and the ``_parse_color`` helper.
 
 The generic ``_find_role_normalized`` lookup now lives in
 ``views.selectors._resource_helpers`` so it can be consumed by code that
 does not belong to the role-management subsystem (Phase 0 of the
 platform roadmap). This module re-exports it for back-compat.
+
+**2026-06-21:** the hardcoded ``_DEFAULT_THRESHOLDS`` tier names
+(``Neu/Normal/Iron/Gold/Diamand/Netherite/Beacon``) and the ``_ensure_defaults``
+seed routine were **removed** (owner directive).  Role automation now loads only
+roles that exist on the server — no fictional name-based rows are ever
+persisted.  Curated *names* live on as ``ROLE_PRESETS``, but exclusively as a
+convenience in the role creation menu (``RoleCreatePanel``); they never touch
+automation, diagnostics, or any other surface.
 """
 
 from __future__ import annotations
+
+from dataclasses import dataclass
 
 import discord
 
@@ -17,20 +28,10 @@ from views.selectors._resource_helpers import _find_role_normalized
 
 __all__ = [
     "_COLOR_OPTIONS",
-    "_DEFAULT_THRESHOLDS",
-    "_ensure_defaults",
+    "ROLE_PRESETS",
+    "RolePreset",
     "_find_role_normalized",
     "_parse_color",
-]
-
-_DEFAULT_THRESHOLDS: list[tuple[str, int]] = [
-    ("Neu", 0),
-    ("Normal", 1),
-    ("Iron", 7),
-    ("Gold", 30),
-    ("Diamand", 365),
-    ("Netherite", 730),
-    ("Beacon", 1825),
 ]
 
 _COLOR_OPTIONS = [
@@ -45,35 +46,51 @@ _COLOR_OPTIONS = [
 ]
 
 
-async def _ensure_defaults(guild: discord.Guild) -> None:
-    """Seed default time tiers for a guild that has none yet — *suggestions only*.
+@dataclass(frozen=True)
+class RolePreset:
+    """A quick-create role template.
 
-    PR6: only a default whose named role **actually exists** is seeded (capturing
-    its ``role_id`` + name snapshot), so this path never persists a threshold for
-    a nonexistent role.  A brand-new guild without the default-named roles is left
-    empty; operators add tiers via the selector or the panel's "Seed Defaults"
-    button.  Accepts the guild (not just its id) to resolve role existence.
+    Presets are *creation conveniences only* — a name + appearance starting
+    point an operator can pick instead of typing everything by hand.  They are
+    surfaced **exclusively** in the role creation menu (``RoleCreatePanel``):
+    deliberately absent from diagnostics, time/XP automation, and every other
+    surface, and they persist nothing until the operator actually creates the
+    role.  This replaced the old hardcoded ``_DEFAULT_THRESHOLDS`` tier names,
+    which leaked into automation as phantom "missing role" rows.
     """
-    from core.runtime import resources
-    from services import role_automation
-    from utils import db
 
-    existing = await db.get_role_thresholds(guild.id)
-    if existing:
-        return
-    for name, days in _DEFAULT_THRESHOLDS:
-        role = resources.resolve_role(guild, name=name)
-        if role is None:
-            continue
-        # Audited seam (P0C); system-seeded, so no human actor.
-        await role_automation.set_time_threshold(
-            guild_id=guild.id,
-            role_id=role.id,
-            role_name=role.name,
-            days=days,
-            actor_id=None,
-            actor_type="system",
-        )
+    name: str
+    color: str  # hex, e.g. "#3498db"
+    hoist: bool = False
+    description: str = ""
+
+
+# A small, generic starter set — common server roles, not tied to any one
+# server's theme.  "A few presets" (owner constraint); extend freely.  Colours
+# are drawn from the same palette as ``_COLOR_OPTIONS``.
+ROLE_PRESETS: list[RolePreset] = [
+    RolePreset("Member", "#2ecc71", description="General member."),
+    RolePreset("Verified", "#1abc9c", description="Passed verification."),
+    RolePreset(
+        "VIP",
+        "#f1c40f",
+        hoist=True,
+        description="Supporter / VIP — shown separately.",
+    ),
+    RolePreset(
+        "Moderator",
+        "#3498db",
+        hoist=True,
+        description="Staff — shown separately.",
+    ),
+    RolePreset(
+        "Admin",
+        "#e74c3c",
+        hoist=True,
+        description="Administrator — shown separately.",
+    ),
+    RolePreset("Muted", "#607d8b", description="Restricted (used by moderation)."),
+]
 
 
 def _parse_color(value: str) -> discord.Color:

--- a/disbot/views/roles/creation_panel.py
+++ b/disbot/views/roles/creation_panel.py
@@ -5,14 +5,182 @@ import logging
 import discord
 from discord.ext import commands
 
+from core.runtime.interaction_helpers import safe_defer
 from services import role_automation
 from services.lifecycle import SUCCESS
 from services.role_lifecycle_service import RoleLifecycleRequest, RoleLifecycleService
 from utils.guild_config_accessors import invalidate_xp_threshold_roles
+from utils.ui_constants import ROLE_COLOR
 from views.base import BaseView
-from views.roles._helpers import _parse_color
+from views.roles._helpers import _COLOR_OPTIONS, ROLE_PRESETS, _parse_color
 
 logger = logging.getLogger("bot")
+
+
+class _PresetNameSelect(discord.ui.Select):
+    """Quick-pick a preset role *name* (the creation-menu-only ``ROLE_PRESETS``)."""
+
+    def __init__(self, panel: RoleCreatePanel) -> None:
+        self._panel = panel
+        super().__init__(
+            placeholder="Pick a preset name…",
+            row=0,
+            options=[
+                discord.SelectOption(
+                    label=p.name,
+                    value=p.name,
+                    description=(p.description or None),
+                )
+                for p in ROLE_PRESETS
+            ],
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await self._panel._on_name_preset(interaction, self.values[0])
+
+
+class _PresetColorSelect(discord.ui.Select):
+    """Quick-pick a preset colour (the shared ``_COLOR_OPTIONS`` palette)."""
+
+    def __init__(self, panel: RoleCreatePanel) -> None:
+        self._panel = panel
+        super().__init__(
+            placeholder="Pick a colour…",
+            row=1,
+            options=[
+                discord.SelectOption(label=label, value=hex_value)
+                for label, hex_value in _COLOR_OPTIONS
+            ],
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await self._panel._on_color_preset(interaction, self.values[0])
+
+
+class RoleCreatePanel(BaseView):
+    """The role *creation menu*: pick a preset name + colour, or go custom.
+
+    Presets (``ROLE_PRESETS`` names + ``_COLOR_OPTIONS`` colours) are surfaced
+    **only here** — never in diagnostics, automation, or any other panel
+    (owner constraint).  "✏️ Custom…" opens the full free-text modal; "✅ Create"
+    creates the staged role through the audited
+    :class:`~services.role_lifecycle_service.RoleLifecycleService` and then offers
+    the same XP-automation follow-up as the modal path.
+    """
+
+    def __init__(self, ctx: commands.Context, parent: BaseView | None = None) -> None:
+        super().__init__(ctx.author, timeout=300)
+        self.ctx = ctx
+        self.parent = parent
+        self.pending_name: str | None = None
+        self.pending_color: discord.Color = discord.Color.default()
+        self.pending_color_label: str = "*(default)*"
+        self.pending_hoist: bool = False
+        self.pending_mentionable: bool = False
+        # An explicit colour pick wins over a preset's default colour.
+        self._color_explicit = False
+        self.add_item(_PresetNameSelect(self))
+        self.add_item(_PresetColorSelect(self))
+
+    def build_embed(self) -> discord.Embed:
+        return discord.Embed(
+            title="📝 Create a Role",
+            description=(
+                "Pick a **name** and a **colour** below, then press **✅ Create** — "
+                "or press **✏️ Custom…** to type your own.\n\n"
+                f"**Name:** {self.pending_name or '*(none yet)*'}\n"
+                f"**Colour:** {self.pending_color_label}\n"
+                f"**Shown separately:** {'yes' if self.pending_hoist else 'no'}"
+            ),
+            color=ROLE_COLOR,
+        )
+
+    async def _rerender(self, interaction: discord.Interaction) -> None:
+        await interaction.response.edit_message(embed=self.build_embed(), view=self)
+
+    async def _on_name_preset(
+        self,
+        interaction: discord.Interaction,
+        name: str,
+    ) -> None:
+        preset = next((p for p in ROLE_PRESETS if p.name == name), None)
+        if preset is None:  # pragma: no cover - select can only emit known values
+            await safe_defer(interaction)
+            return
+        self.pending_name = preset.name
+        self.pending_hoist = preset.hoist
+        if not self._color_explicit:
+            try:
+                self.pending_color = _parse_color(preset.color)
+                self.pending_color_label = preset.color
+            except (ValueError, OverflowError):  # pragma: no cover - constant data
+                pass
+        await self._rerender(interaction)
+
+    async def _on_color_preset(
+        self,
+        interaction: discord.Interaction,
+        hex_value: str,
+    ) -> None:
+        try:
+            self.pending_color = _parse_color(hex_value)
+            self.pending_color_label = hex_value
+            self._color_explicit = True
+        except (ValueError, OverflowError):  # pragma: no cover - constant data
+            pass
+        await self._rerender(interaction)
+
+    @discord.ui.button(label="✏️ Custom…", style=discord.ButtonStyle.secondary, row=2)
+    async def custom_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await interaction.response.send_modal(RoleCreateModal(self.ctx))
+
+    @discord.ui.button(label="✅ Create", style=discord.ButtonStyle.green, row=2)
+    async def create_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not self.pending_name:
+            await interaction.response.send_message(
+                "Pick a preset name first, or use **✏️ Custom…** to type your own.",
+                ephemeral=True,
+            )
+            return
+        result = await RoleLifecycleService().apply(
+            interaction.guild,
+            RoleLifecycleRequest(
+                operation="create",
+                name=self.pending_name,
+                color=self.pending_color,
+                hoist=self.pending_hoist,
+                mentionable=self.pending_mentionable,
+            ),
+            interaction.user,
+            actor_type="admin",
+        )
+        if result.outcome != SUCCESS:
+            await interaction.response.send_message(
+                f"❌ Could not create role: {result.first_error}",
+                ephemeral=True,
+            )
+            return
+        role_name = result.steps[0].target_name
+        role_id = result.steps[0].target_id
+        automation_view = RoleAutomationView(self.ctx, role_name, role_id)
+        await interaction.response.edit_message(
+            content=(
+                f"✅ Created role **{role_name}**.\n"
+                "Would you like to configure XP-based auto-assignment for this role?"
+            ),
+            embed=None,
+            view=automation_view,
+        )
+        automation_view.message = interaction.message
+        self.stop()
 
 
 class RoleCreateModal(discord.ui.Modal, title="Create Role"):  # type: ignore[call-arg]

--- a/disbot/views/roles/main_panel.py
+++ b/disbot/views/roles/main_panel.py
@@ -5,7 +5,6 @@ from discord.ext import commands
 
 from utils.ui_constants import ROLE_COLOR
 from views.base import BaseView
-from views.roles._helpers import _ensure_defaults
 
 
 class RoleHubView(BaseView):
@@ -44,9 +43,14 @@ class RoleHubView(BaseView):
                 ephemeral=True,
             )
             return
-        from views.roles.creation_panel import RoleCreateModal
+        from views.roles.creation_panel import RoleCreatePanel
 
-        await interaction.response.send_modal(RoleCreateModal(self.ctx))
+        panel = RoleCreatePanel(self.ctx)
+        await interaction.response.send_message(
+            embed=panel.build_embed(),
+            view=panel,
+            ephemeral=True,
+        )
 
     @discord.ui.button(label="🗂️ Manage", style=discord.ButtonStyle.blurple, row=0)
     async def manage_btn(
@@ -83,7 +87,6 @@ class RoleHubView(BaseView):
             return
         from views.roles.time_roles_panel import TimeRolesPanel
 
-        await _ensure_defaults(interaction.guild)
         panel = TimeRolesPanel(self.ctx, parent=self)
         panel.message = self.message
         await interaction.response.edit_message(

--- a/disbot/views/roles/management_panel.py
+++ b/disbot/views/roles/management_panel.py
@@ -7,11 +7,12 @@ from core.runtime import resources
 from core.runtime.interaction_helpers import safe_defer
 from services.lifecycle import SUCCESS
 from services.role_lifecycle_service import RoleLifecycleRequest, RoleLifecycleService
+from utils.role_feasibility import manageable_roles
 from utils.ui_constants import ROLE_COLOR
 from views.base import BaseView
 from views.navigation import attach_back_button
-from views.paginated_select import PaginatedSelectView
-from views.roles._helpers import _find_role_normalized, _parse_color
+from views.roles._helpers import _parse_color
+from views.selectors import attach_multi_role_select, attach_role_select
 
 
 class ManagementPanel(BaseView):
@@ -56,15 +57,39 @@ class ManagementPanel(BaseView):
         embed.set_footer(text="Create · Edit · Delete roles using the buttons below.")
         return embed
 
+    async def _rerender(self) -> None:
+        if self.message:
+            await self.message.edit(embed=await self.build_embed(), view=self)
+
+    def _editable_roles(self, interaction: discord.Interaction) -> list[discord.Role]:
+        """Roles the bot AND the acting member can manage (edit/delete targets).
+
+        Filters out @everyone, integration-managed roles, and anything at/above
+        the bot's or the actor's top role — the same partition the lifecycle
+        service enforces, so the picker only offers roles the action can succeed
+        on.
+        """
+        manageable, _excluded = manageable_roles(
+            interaction.guild.roles,
+            bot_member=interaction.guild.me,
+            actor=interaction.user,
+        )
+        return manageable
+
     @discord.ui.button(label="📝 Create", style=discord.ButtonStyle.green, row=0)
     async def create_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        from views.roles.creation_panel import RoleCreateModal
+        from views.roles.creation_panel import RoleCreatePanel
 
-        await interaction.response.send_modal(RoleCreateModal(self.ctx))
+        panel = RoleCreatePanel(self.ctx)
+        await interaction.response.send_message(
+            embed=panel.build_embed(),
+            view=panel,
+            ephemeral=True,
+        )
 
     @discord.ui.button(label="✏️ Edit Role", style=discord.ButtonStyle.blurple, row=0)
     async def edit_btn(
@@ -72,7 +97,18 @@ class ManagementPanel(BaseView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        await interaction.response.send_modal(EditRoleModal(self))
+        roles = self._editable_roles(interaction)
+        if not roles:
+            await interaction.response.send_message(
+                "No roles you can edit (all are above me/you, managed, or @everyone).",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_message(
+            "Pick a role to edit:",
+            view=_EditRolePickView(self, roles),
+            ephemeral=True,
+        )
 
     @discord.ui.button(label="🗑️ Delete Role", style=discord.ButtonStyle.red, row=0)
     async def delete_btn(
@@ -80,29 +116,44 @@ class ManagementPanel(BaseView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        guild = interaction.guild
-        roles = [
-            r for r in guild.roles if r != guild.default_role and r < guild.me.top_role
-        ]
+        roles = self._editable_roles(interaction)
         if not roles:
             await interaction.response.send_message(
                 "No deletable roles available.",
                 ephemeral=True,
             )
             return
-        view = _build_delete_role_view(self, roles)
         await interaction.response.send_message(
-            "Select a role to delete:",
-            view=view,
+            "Select one or more roles to delete, then press **🗑️ Delete Selected**:",
+            view=_DeleteRolesView(self, roles),
             ephemeral=True,
         )
 
 
+class _EditRolePickView(BaseView):
+    """Ephemeral picker: choose the role to edit, then open the edit modal."""
+
+    def __init__(self, parent: ManagementPanel, roles: list[discord.Role]) -> None:
+        super().__init__(parent._author, timeout=120)
+        self.parent = parent
+        attach_role_select(self, roles, self._on_select)
+
+    async def _on_select(
+        self,
+        interaction: discord.Interaction,
+        role_id: int,
+    ) -> None:
+        role = resources.resolve_role(interaction.guild, role_id=role_id)
+        if role is None:
+            await interaction.response.send_message(
+                "That role no longer exists.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_modal(EditRoleModal(self.parent, role))
+
+
 class EditRoleModal(discord.ui.Modal, title="Edit Role"):  # type: ignore[call-arg]
-    role_name = discord.ui.TextInput(  # type: ignore[var-annotated]
-        label="Current role name (to find it)",
-        max_length=100,
-    )
     new_name = discord.ui.TextInput(  # type: ignore[var-annotated]
         label="New name (blank = keep)",
         max_length=100,
@@ -114,15 +165,20 @@ class EditRoleModal(discord.ui.Modal, title="Edit Role"):  # type: ignore[call-a
         required=False,
     )
 
-    def __init__(self, parent: ManagementPanel) -> None:
+    def __init__(self, parent: ManagementPanel, role: discord.Role) -> None:
         super().__init__()
         self.parent = parent
+        self.role = role
+        # The role is already chosen (no "find by name" field): show which one
+        # in the modal title so the operator has confirmation.
+        self.title = f"Edit Role: {role.name}"[:45]
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
-        role = _find_role_normalized(interaction.guild, self.role_name.value.strip())
-        if not role:
+        # Resolve id-first so a rename between picking and submitting is caught.
+        role = resources.resolve_role(interaction.guild, role_id=self.role.id)
+        if role is None:
             await interaction.response.send_message(
-                f"❌ Role **{self.role_name.value}** not found.",
+                f"❌ Role **{self.role.name}** no longer exists.",
                 ephemeral=True,
             )
             return
@@ -166,64 +222,131 @@ class EditRoleModal(discord.ui.Modal, title="Edit Role"):  # type: ignore[call-a
             return
         if not await safe_defer(interaction):
             return
-        if self.parent.message:
-            await self.parent.message.edit(
-                embed=await self.parent.build_embed(),
-                view=self.parent,
-            )
+        await self.parent._rerender()
 
 
-def _build_delete_role_view(
-    panel: ManagementPanel,
-    roles: list[discord.Role],
-) -> PaginatedSelectView:
-    """Role-delete picker — windows the deletable roles so a guild with more
-    than 25 of them stays fully selectable (previously ``[:25]`` silently
-    dropped every role past the 25th — the #1040 class).
+class _DeleteRolesView(BaseView):
+    """Ephemeral multi-select of deletable roles → a confirmation step.
+
+    Replaces the old single-select-deletes-immediately flow: an operator picks
+    one or more roles, then presses **Delete Selected** to reach an explicit
+    confirmation before anything is removed.
     """
-    options = [discord.SelectOption(label=r.name[:100], value=str(r.id)) for r in roles]
 
-    async def _on_role_picked(
-        interaction: discord.Interaction,
-        values: list[str],
-    ) -> None:
-        if not values:
-            return
-        role = resources.resolve_role(interaction.guild, role_id=values[0])
-        if not role:
-            await interaction.response.send_message(
-                "❌ Role no longer exists.",
-                ephemeral=True,
-            )
-            return
-        name = role.name
-        result = await RoleLifecycleService().apply(
-            interaction.guild,
-            RoleLifecycleRequest(operation="delete", role_id=role.id),
-            interaction.user,
-            confirmed=True,
-            actor_type="admin",
+    def __init__(self, parent: ManagementPanel, roles: list[discord.Role]) -> None:
+        super().__init__(parent._author, timeout=120)
+        self.parent = parent
+        self._roles_by_id = {r.id: r for r in roles}
+        self.selected_ids: list[int] = []
+        attach_multi_role_select(
+            self,
+            roles,
+            self._on_pick,
+            placeholder="Select roles to delete…",
+            min_values=0,
+            select_row=0,
+            nav_row=1,
         )
-        if result.outcome == SUCCESS:
-            await interaction.response.send_message(
-                f"🗑️ Deleted role **{name}**.",
-                ephemeral=True,
-            )
-            if panel.message:
-                await panel.message.edit(
-                    embed=await panel.build_embed(),
-                    view=panel,
-                )
-        else:
-            await interaction.response.send_message(
-                f"❌ Could not delete **{name}**: {result.first_error}",
-                ephemeral=True,
-            )
 
-    return PaginatedSelectView(
-        panel._author,
-        options,
-        _on_role_picked,
-        placeholder="Choose a role to delete…",
-        timeout=60,
+    async def _on_pick(
+        self,
+        interaction: discord.Interaction,
+        role_ids: list[int],
+    ) -> None:
+        self.selected_ids = role_ids
+        # Just record the selection; the Delete-Selected button drives the
+        # confirmation. Ack without changing the message.
+        await safe_defer(interaction)
+
+    @discord.ui.button(
+        label="🗑️ Delete Selected",
+        style=discord.ButtonStyle.red,
+        row=2,
     )
+    async def confirm_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        names = [
+            self._roles_by_id[i].name
+            for i in self.selected_ids
+            if i in self._roles_by_id
+        ]
+        if not names:
+            await interaction.response.send_message(
+                "Pick at least one role first.",
+                ephemeral=True,
+            )
+            return
+        listing = "\n".join(f"• {n}" for n in names)
+        await interaction.response.edit_message(
+            content=(
+                f"⚠️ Delete these **{len(names)}** role(s)? This cannot be undone.\n"
+                f"{listing}"
+            ),
+            view=_ConfirmDeleteView(self.parent, list(self.selected_ids)),
+        )
+
+
+class _ConfirmDeleteView(BaseView):
+    """Final confirm/cancel for a batched role delete."""
+
+    def __init__(self, parent: ManagementPanel, role_ids: list[int]) -> None:
+        super().__init__(parent._author, timeout=60)
+        self.parent = parent
+        self.role_ids = role_ids
+
+    @discord.ui.button(
+        label="✅ Confirm delete",
+        style=discord.ButtonStyle.red,
+        row=0,
+    )
+    async def confirm(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not await safe_defer(interaction, ephemeral=True):
+            return
+        deleted: list[str] = []
+        failed: list[str] = []
+        for rid in self.role_ids:
+            role = resources.resolve_role(interaction.guild, role_id=rid)
+            if role is None:
+                continue
+            name = role.name
+            result = await RoleLifecycleService().apply(
+                interaction.guild,
+                RoleLifecycleRequest(operation="delete", role_id=role.id),
+                interaction.user,
+                confirmed=True,
+                actor_type="admin",
+            )
+            if result.outcome == SUCCESS:
+                deleted.append(name)
+            else:
+                failed.append(f"{name} ({result.first_error})")
+        parts: list[str] = []
+        if deleted:
+            parts.append(f"🗑️ Deleted {len(deleted)}: {', '.join(deleted)}.")
+        if failed:
+            parts.append(f"❌ Failed {len(failed)}: {'; '.join(failed)}.")
+        await interaction.followup.send(
+            " ".join(parts) or "Nothing deleted.",
+            ephemeral=True,
+        )
+        await self.parent._rerender()
+        self.stop()
+
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.secondary, row=0)
+    async def cancel(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await interaction.response.edit_message(
+            content="Cancelled — no roles deleted.",
+            view=None,
+        )
+        self.stop()

--- a/disbot/views/roles/time_roles_panel.py
+++ b/disbot/views/roles/time_roles_panel.py
@@ -12,7 +12,6 @@ from utils.ui_constants import ROLE_COLOR
 from views.base import BaseView
 from views.navigation import attach_back_button
 from views.paginated_select import PaginatedSelectView
-from views.roles._helpers import _DEFAULT_THRESHOLDS
 from views.selectors import attach_role_select
 
 
@@ -156,42 +155,40 @@ class TimeRolesPanel(BaseView):
         )
         await self._rerender()
 
-    @discord.ui.button(label="🔄 Seed Defaults", style=discord.ButtonStyle.grey, row=0)
-    async def reset_btn(
+    @discord.ui.button(label="🧹 Clear Missing", style=discord.ButtonStyle.grey, row=0)
+    async def clear_missing_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        # Defaults are suggestions, not phantom rows: seed only the default tiers
-        # whose role actually exists in this guild (capturing its id), and report
-        # which suggestions were skipped because no matching role exists.
-        seeded: list[str] = []
-        skipped: list[str] = []
-        for name, days in _DEFAULT_THRESHOLDS:
-            role = resources.resolve_role(interaction.guild, name=name)
-            if role is None:
-                skipped.append(name)
-                continue
-            await role_automation.set_time_threshold(
+        # Roles are loaded dynamically from the server now (no hardcoded
+        # defaults).  A threshold whose role no longer resolves is a phantom row
+        # — it can never assign anything and shows as "missing" in diagnostics.
+        # Bulk-clear them through the audited seam so the operator does not have
+        # to remove each one by hand.
+        thresholds = await db.get_role_thresholds(self.ctx.guild.id)
+        stale = [r for r in thresholds if _row_is_stale(self.ctx.guild, r)]
+        if not stale:
+            await interaction.response.send_message(
+                "No missing-role thresholds to clear.",
+                ephemeral=True,
+            )
+            return
+        cleared: list[str] = []
+        for r in stale:
+            await role_automation.clear_time_threshold(
                 guild_id=interaction.guild.id,
-                role_id=role.id,
-                role_name=role.name,
-                days=days,
+                role_name=r["role_name"],
                 actor_id=interaction.user.id,
             )
-            seeded.append(role.name)
+            cleared.append(r["role_name"])
+        invalidate_xp_threshold_roles(interaction.guild.id)
         if not await safe_defer(interaction, ephemeral=True):
             return
         await self._rerender()
-        parts = []
-        if seeded:
-            parts.append(f"Seeded {len(seeded)}: {', '.join(seeded)}.")
-        if skipped:
-            parts.append(
-                f"Skipped {len(skipped)} (no matching role): {', '.join(skipped)}.",
-            )
         await interaction.followup.send(
-            " ".join(parts) or "No default roles matched this server.",
+            f"🧹 Cleared {len(cleared)} missing-role threshold(s): "
+            f"{', '.join(cleared)}.",
             ephemeral=True,
         )
 

--- a/docs/audits/helper-debt-inventory.md
+++ b/docs/audits/helper-debt-inventory.md
@@ -185,7 +185,7 @@ The real setup ↔ diagnostic edge is documented in § 7 as
 
 | View helper file | Symbols | Intra-subsystem leak | **Cross-subsystem leak** |
 |---|---|---|---|
-| `views/roles/_helpers.py` | 5 (`_DEFAULT_THRESHOLDS`, `_COLOR_OPTIONS`, `_ensure_defaults`, `_parse_color`, `_find_role_normalized`) | `_ensure_defaults` → `cogs/role_cog.py` (intra-subsystem) | — |
+| `views/roles/_helpers.py` | 4 (`_COLOR_OPTIONS`, `ROLE_PRESETS`/`RolePreset`, `_parse_color`, `_find_role_normalized`) — *`_DEFAULT_THRESHOLDS` + `_ensure_defaults` removed 2026-06-21 (owner directive); roles load dynamically + presets are creation-menu only* | — | — |
 | `views/channels/_helpers.py` | 4 (`_NAME_PRESETS`, `_CATEGORY_PRESETS`, `_ChannelSelect`, `_build_channel_options`) | `_build_channel_options` → `cogs/channel_cog.py` (intra-subsystem) | — |
 | `views/rps/_helpers.py` | 7 (`_RPS_WINS`, `_RPS_EMOJI`, `_FREE_WIN`, `_rps_pvp_pending`, `RPS_PVP_PENDING_SUBSYSTEM`, `RPS_PVP_PENDING_VERSION`, `rps_pvp_canonical_user_id`) | — | **`_FREE_WIN` → `views/games/rps_panel.py:63` + `cogs/rps_tournament/_quickplay.py:19`**; **`_rps_pvp_pending`, `RPS_PVP_PENDING_SUBSYSTEM`, `RPS_PVP_PENDING_VERSION` → `cogs/rps_tournament/_persistence.py:166,223`**. RPS view helpers imported by games view + rps_tournament cog. |
 

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -37,10 +37,6 @@ living ledger (`docs/current-state.md`).
 - `claude/dreamy-cerf-voar4q` · **Project Moon knowledge domain** (owner-directed Q-0192: full parity) —
   feasibility **#1238** + program plan **#1239** merged; now pre-build recon (data sources + seam contract)
   · `docs/planning/project-moon-prebuild-recon-2026-06-21.md` · 2026-06-21 · **auto-merge on green** (docs-only)
-- `claude/ecstatic-babbage-8bf0g6` · **role presets + role-management UX** (owner-directed screenshots) —
-  remove hardcoded German tier names (`_DEFAULT_THRESHOLDS`/`_ensure_defaults`) + 🧹 Clear-missing purge;
-  Create-role preset names + colour presets (creation menu only); Edit by role-select; Delete multi-select +
-  confirm · `disbot/views/roles/*` + `cogs/role_cog.py` + `_helpers` · 2026-06-21 · **auto-merge on green**
 
 *(Beyond the claim above, the only open PR is **#1213** creature-PvP battle engine on
 `claude/funny-franklin-mw3hxj`, a `needs-hermes-review` foundation slice — its owning
@@ -55,6 +51,10 @@ session holds it, no claim line needed here.)*
 - `claude/reaction-roles-message-picker` · **reaction-roles follow-up** (owner-directed) — emoji-add
   message picker (most-recent / pick-recent / new-message / by-id) replacing the raw message-ID step ·
   `disbot/views/roles/reaction_panel.py` · 2026-06-21 · **PR #1243 (merge on green)**
+- `claude/ecstatic-babbage-8bf0g6` · **role presets + role-management UX** (owner-directed screenshots) —
+  removed hardcoded German tier names (`_DEFAULT_THRESHOLDS`/`_ensure_defaults`) + 🧹 Clear-missing purge;
+  Create-menu preset names + colour presets (creation-menu only); Edit by role-select; Delete multi-select +
+  confirm · 2026-06-21 · **PR #1245 (auto-merge on green)**
 - `claude/reaction-roles-channel-and-colors` · **reaction-roles follow-up** (owner-directed) — menu
   post-channel picker + auto-created colour roles + gradient/holographic (audited
   `RoleLifecycleService` seam, gated on Enhanced-Role-Styles) · 2026-06-21 · **PR #1237 (merge on green)**

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -37,6 +37,10 @@ living ledger (`docs/current-state.md`).
 - `claude/dreamy-cerf-voar4q` · **Project Moon knowledge domain** (owner-directed Q-0192: full parity) —
   feasibility **#1238** + program plan **#1239** merged; now pre-build recon (data sources + seam contract)
   · `docs/planning/project-moon-prebuild-recon-2026-06-21.md` · 2026-06-21 · **auto-merge on green** (docs-only)
+- `claude/ecstatic-babbage-8bf0g6` · **role presets + role-management UX** (owner-directed screenshots) —
+  remove hardcoded German tier names (`_DEFAULT_THRESHOLDS`/`_ensure_defaults`) + 🧹 Clear-missing purge;
+  Create-role preset names + colour presets (creation menu only); Edit by role-select; Delete multi-select +
+  confirm · `disbot/views/roles/*` + `cogs/role_cog.py` + `_helpers` · 2026-06-21 · **auto-merge on green**
 
 *(Beyond the claim above, the only open PR is **#1213** creature-PvP battle engine on
 `claude/funny-franklin-mw3hxj`, a `needs-hermes-review` foundation slice — its owning

--- a/docs/ownership.md
+++ b/docs/ownership.md
@@ -405,8 +405,9 @@ per-surface map in
 **Known drift to normalize before automation:**
 
 - ✅ **Role-threshold writes — NORMALIZED (P0C, 2026-06-08).** All six time/XP
-  threshold write sites (the role panels' Seed-Defaults, time/XP modals, the
-  created-role XP companion, the `_ensure_defaults` boot seed, and the `!setrole`
+  threshold write sites (the role panels' Seed-Defaults *(removed 2026-06-21 —
+  see below)*, time/XP modals, the created-role XP companion, the
+  `_ensure_defaults` boot seed *(removed 2026-06-21)*, and the `!setrole`
   command) now route through the audited
   `services.role_automation.set_time_threshold` / `set_xp_threshold` seam (DB write
   **plus** `audit.action_recorded`, and the XP path also invalidates the XP-threshold
@@ -419,6 +420,14 @@ per-surface map in
   `role_automation.clear_{time,xp}_threshold` methods (old-value read → clear →
   XP-cache invalidate → audit emit), and the invariant now fences **every** threshold
   mutation primitive — setters, clears, and the full-row `remove_role_threshold`.
+  **Hardcoded tier names removed 2026-06-21 (owner directive):** the
+  `_DEFAULT_THRESHOLDS` German/Minecraft tier names (`Neu/Normal/Iron/Gold/Diamand/
+  Netherite/Beacon`) + the `_ensure_defaults` seed routine were deleted — role
+  automation now loads only roles that exist on the server, and the Time panel's
+  "Seed Defaults" button was replaced by a **🧹 Clear Missing** purge (which clears
+  stale rows through the same audited `clear_time_threshold` seam). Curated *names*
+  survive as `ROLE_PRESETS`, but exclusively as a convenience in the role creation
+  menu (`RoleCreatePanel`) — never in automation/diagnostics.
 - ✅ **Channel create/edit lifecycle — converged (P0-4, Q-0100).** Every operator
   channel mutation now routes through one canonical audited writer: change ops
   (rename/move/delete/reorder), `set_overwrite`, and `clone` (P0-4 PR 1), plus **ad-hoc

--- a/tests/unit/cogs/test_role_cog_routing.py
+++ b/tests/unit/cogs/test_role_cog_routing.py
@@ -65,10 +65,6 @@ async def test_assign_roles_delegates_to_role_automation():
 
     with (
         patch(
-            "cogs.role_cog._ensure_defaults",
-            new_callable=AsyncMock,
-        ),
-        patch(
             "cogs.role_cog.db.get_role_thresholds",
             new_callable=AsyncMock,
             return_value=[
@@ -117,7 +113,6 @@ async def test_assign_roles_excludes_xp_auto_assign_roles():
     guild.members = []
 
     with (
-        patch("cogs.role_cog._ensure_defaults", new_callable=AsyncMock),
         patch(
             "cogs.role_cog.db.get_role_thresholds",
             new_callable=AsyncMock,
@@ -169,10 +164,6 @@ async def test_assign_roles_returns_zero_when_no_thresholds():
 
     with (
         patch(
-            "cogs.role_cog._ensure_defaults",
-            new_callable=AsyncMock,
-        ),
-        patch(
             "cogs.role_cog.db.get_role_thresholds",
             new_callable=AsyncMock,
             return_value=[],
@@ -215,10 +206,6 @@ async def test_on_member_join_delegates_to_role_automation():
 
     with (
         patch(
-            "cogs.role_cog._ensure_defaults",
-            new_callable=AsyncMock,
-        ),
-        patch(
             "cogs.role_cog.db.get_role_thresholds",
             new_callable=AsyncMock,
             return_value=[
@@ -255,10 +242,6 @@ async def test_on_member_join_skips_when_no_plan():
 
     with (
         patch(
-            "cogs.role_cog._ensure_defaults",
-            new_callable=AsyncMock,
-        ),
-        patch(
             "cogs.role_cog.db.get_role_thresholds",
             new_callable=AsyncMock,
             return_value=[{"role_name": "Newbie", "days_required": 0}],
@@ -292,7 +275,6 @@ async def test_on_member_join_excludes_xp_auto_assign_roles():
     member.guild = MagicMock(id=1)
 
     with (
-        patch("cogs.role_cog._ensure_defaults", new_callable=AsyncMock),
         patch(
             "cogs.role_cog.db.get_role_thresholds",
             new_callable=AsyncMock,

--- a/tests/unit/invariants/test_no_direct_role_threshold_writes.py
+++ b/tests/unit/invariants/test_no_direct_role_threshold_writes.py
@@ -15,7 +15,11 @@ see ``docs/ownership.md`` § "Direct vs. draft mutation lanes" and
 ``RoleAutomationModal``, ``_helpers._ensure_defaults``, ``xp_roles_panel``
 ``XpLevelModal``, and ``role_cog.setrole``) were converted, so
 ``_ALLOWED_DIRECT_THRESHOLD_FILES`` is now **empty** and this invariant is the
-absolute rule: *no direct threshold writes anywhere in the role surface*. It
+absolute rule: *no direct threshold writes anywhere in the role surface*.
+(*2026-06-21:* the ``Seed-Defaults`` button + ``_helpers._ensure_defaults`` were
+later **removed** — roles load dynamically now — and the Time panel's new
+``Clear Missing`` purge routes through the audited
+``role_automation.clear_time_threshold`` seam, so the fence still holds.) It
 began as a *shrinking ratchet* — the allowlist pinned the known-remaining sites
 and forbade new drift; emptying it is how P0C records "done". A **new** direct
 write in any scanned file now fails immediately.

--- a/tests/unit/views/test_role_management_panel.py
+++ b/tests/unit/views/test_role_management_panel.py
@@ -1,0 +1,186 @@
+"""Role management panel — edit-by-select + multi-select-delete-with-confirm.
+
+Owner-directed UX overhaul (2026-06-21): you no longer type a role name to edit
+(pick it from a select), and delete is a multi-select gated behind an explicit
+confirmation step instead of a single select that deleted immediately.  These
+pin the new control flow against regression.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _interaction() -> MagicMock:
+    interaction = MagicMock()
+    interaction.guild = MagicMock()
+    interaction.guild.id = 99
+    interaction.user.id = 7
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _parent() -> MagicMock:
+    parent = MagicMock()
+    parent._author = SimpleNamespace(id=7)
+    parent._rerender = AsyncMock()
+    return parent
+
+
+@pytest.mark.asyncio
+async def test_edit_role_modal_edits_the_picked_role_by_id():
+    """The Edit modal acts on the already-picked role (id-first) and routes the
+    change through the audited RoleLifecycleService, then re-renders the panel.
+    """
+    from services.lifecycle import SUCCESS
+    from views.roles.management_panel import EditRoleModal
+
+    parent = _parent()
+    role = SimpleNamespace(id=555, name="OldName")
+    modal = EditRoleModal(parent, role)
+    modal.new_name = MagicMock(value="NewName")
+    modal.new_color = MagicMock(value="")
+
+    interaction = _interaction()
+    svc = MagicMock()
+    svc.apply = AsyncMock(return_value=SimpleNamespace(outcome=SUCCESS, first_error=None))
+    with (
+        patch(
+            "views.roles.management_panel.resources.resolve_role",
+            return_value=role,
+        ),
+        patch(
+            "views.roles.management_panel.RoleLifecycleService",
+            return_value=svc,
+        ),
+        patch(
+            "views.roles.management_panel.safe_defer",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        await modal.on_submit(interaction)
+
+    svc.apply.assert_awaited_once()
+    req = svc.apply.await_args.args[1]
+    assert req.operation == "edit"
+    assert req.role_id == 555
+    assert req.name == "NewName"
+    parent._rerender.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_edit_role_modal_rejects_an_empty_change():
+    """Blank name + blank colour is a no-op, surfaced to the operator without a
+    lifecycle call.
+    """
+    from views.roles.management_panel import EditRoleModal
+
+    parent = _parent()
+    role = SimpleNamespace(id=555, name="X")
+    modal = EditRoleModal(parent, role)
+    modal.new_name = MagicMock(value="   ")
+    modal.new_color = MagicMock(value="")
+
+    interaction = _interaction()
+    svc = MagicMock()
+    svc.apply = AsyncMock()
+    with (
+        patch(
+            "views.roles.management_panel.resources.resolve_role",
+            return_value=role,
+        ),
+        patch(
+            "views.roles.management_panel.RoleLifecycleService",
+            return_value=svc,
+        ),
+    ):
+        await modal.on_submit(interaction)
+
+    svc.apply.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_view_requires_at_least_one_selection():
+    """Pressing Delete Selected with nothing chosen prompts instead of deleting."""
+    from views.roles.management_panel import _DeleteRolesView
+
+    parent = _parent()
+    roles = [SimpleNamespace(id=1, name="A"), SimpleNamespace(id=2, name="B")]
+    view = _DeleteRolesView(parent, roles)  # selected_ids empty
+
+    interaction = _interaction()
+    await _DeleteRolesView.confirm_btn(view, interaction, MagicMock())
+
+    interaction.response.send_message.assert_awaited_once()
+    interaction.response.edit_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_view_advances_to_a_confirmation_step():
+    """A multi-selection routes to an explicit confirmation listing every role —
+    nothing is deleted yet.
+    """
+    from views.roles.management_panel import _ConfirmDeleteView, _DeleteRolesView
+
+    parent = _parent()
+    roles = [SimpleNamespace(id=1, name="Alpha"), SimpleNamespace(id=2, name="Beta")]
+    view = _DeleteRolesView(parent, roles)
+    view.selected_ids = [1, 2]
+
+    interaction = _interaction()
+    with patch("views.roles.management_panel.RoleLifecycleService") as svc:
+        await _DeleteRolesView.confirm_btn(view, interaction, MagicMock())
+
+    # Confirmation only — no deletion happened at this stage.
+    svc.assert_not_called()
+    interaction.response.edit_message.assert_awaited_once()
+    kwargs = interaction.response.edit_message.await_args.kwargs
+    assert "Alpha" in kwargs["content"] and "Beta" in kwargs["content"]
+    assert isinstance(kwargs["view"], _ConfirmDeleteView)
+
+
+@pytest.mark.asyncio
+async def test_confirm_delete_deletes_every_selected_role():
+    """Confirming the batch deletes each selected role through the audited
+    lifecycle service and re-renders the panel.
+    """
+    from services.lifecycle import SUCCESS
+    from views.roles.management_panel import _ConfirmDeleteView
+
+    parent = _parent()
+    view = _ConfirmDeleteView(parent, [1, 2])
+    roles = {
+        1: SimpleNamespace(id=1, name="Alpha"),
+        2: SimpleNamespace(id=2, name="Beta"),
+    }
+
+    interaction = _interaction()
+    svc = MagicMock()
+    svc.apply = AsyncMock(return_value=SimpleNamespace(outcome=SUCCESS, first_error=None))
+    with (
+        patch(
+            "views.roles.management_panel.resources.resolve_role",
+            side_effect=lambda _g, *, role_id: roles.get(role_id),
+        ),
+        patch(
+            "views.roles.management_panel.RoleLifecycleService",
+            return_value=svc,
+        ),
+        patch(
+            "views.roles.management_panel.safe_defer",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        await _ConfirmDeleteView.confirm(view, interaction, MagicMock())
+
+    assert svc.apply.await_count == 2
+    deleted_ops = {svc.apply.await_args_list[i].args[1].operation for i in range(2)}
+    assert deleted_ops == {"delete"}
+    parent._rerender.assert_awaited_once()
+    interaction.followup.send.assert_awaited_once()

--- a/tests/unit/views/test_role_threshold_selectors.py
+++ b/tests/unit/views/test_role_threshold_selectors.py
@@ -3,8 +3,13 @@
 The free-text role-name modal is replaced by a role picker → numeric modal, so a
 persisted threshold always references a role that exists (capturing its id + name
 snapshot).  Pins: the modals persist ``role_id`` + ``display_name``; the stale
-helper flags a row whose role can no longer be resolved; and ``_ensure_defaults``
-seeds only defaults whose role actually exists (no phantom-name rows).
+helper flags a row whose role can no longer be resolved; and the Time panel's
+**🧹 Clear Missing** button bulk-clears those stale rows through the audited seam.
+
+**2026-06-21:** the hardcoded ``_DEFAULT_THRESHOLDS`` tier names + the
+``_ensure_defaults`` seed routine were removed (owner directive — roles load
+dynamically from the server now).  The old "Seed Defaults" button is gone; the
+**Clear Missing** purge replaces it, and is covered here.
 
 **P0C (2026-06-08):** every threshold write now routes through the audited
 ``services.role_automation.set_{time,xp}_threshold`` seam (write + audit emit,
@@ -12,8 +17,7 @@ and the XP path also invalidates the XP-threshold cache) instead of calling
 ``utils.db.roles.set_role_*`` directly — so these tests assert the *seam* call
 (with its ``actor_id``), and the drift fence
 ``tests/unit/invariants/test_no_direct_role_threshold_writes.py`` keeps it that
-way.  The ``role_id`` capture / staleness / seed-existing-only behaviour is
-unchanged.
+way.  The ``role_id`` capture / staleness behaviour is unchanged.
 """
 
 from __future__ import annotations
@@ -76,18 +80,22 @@ async def test_time_days_modal_rejects_negative():
 
 
 @pytest.mark.asyncio
-async def test_seed_defaults_button_routes_through_seam():
-    """The Time panel's "Seed Defaults" button seeds only defaults whose role
-    exists, routing each write through the audited seam with ``actor_id`` = the
-    clicking user.
+async def test_clear_missing_button_clears_only_stale_rows():
+    """The Time panel's "🧹 Clear Missing" button bulk-clears thresholds whose
+    role no longer resolves — routing each removal through the audited clear
+    seam with ``actor_id`` = the clicking user — and leaves resolvable rows
+    untouched.  (Replaces the removed hardcoded-defaults "Seed Defaults" path.)
     """
-    from views.roles._helpers import _DEFAULT_THRESHOLDS
     from views.roles.time_roles_panel import TimeRolesPanel
 
-    first_name, first_days = _DEFAULT_THRESHOLDS[0]
+    rows = [
+        {"role_id": 1, "role_name": "Ghost", "days_required": 7},
+        {"role_id": 2, "role_name": "Veteran", "days_required": 30},
+    ]
 
     def _resolve(_guild, *, name=None, role_id=None):
-        return SimpleNamespace(id=808, name=first_name) if name == first_name else None
+        # Only role_id=2 (Veteran) still resolves; Ghost (id=1) is stale.
+        return SimpleNamespace(id=2, name="Veteran") if role_id == 2 else None
 
     ctx = MagicMock()
     ctx.guild.id = 99
@@ -96,24 +104,26 @@ async def test_seed_defaults_button_routes_through_seam():
     interaction = _interaction()
     with (
         patch(
+            "views.roles.time_roles_panel.db.get_role_thresholds",
+            new=AsyncMock(return_value=rows),
+        ),
+        patch(
             "views.roles.time_roles_panel.resources.resolve_role",
             side_effect=_resolve,
         ),
         patch(
-            "views.roles.time_roles_panel.role_automation.set_time_threshold",
+            "views.roles.time_roles_panel.role_automation.clear_time_threshold",
             new_callable=AsyncMock,
         ) as seam,
+        patch("views.roles.time_roles_panel.invalidate_xp_threshold_roles"),
         patch("views.roles.time_roles_panel.safe_defer", AsyncMock(return_value=True)),
     ):
-        # The @discord.ui.button decorator shadows the instance attr with a
-        # Button; the original coroutine stays on the class.
-        await TimeRolesPanel.reset_btn(panel, interaction, MagicMock())
-    # Only the one existing default is seeded — through the seam, id-first.
+        # The @discord.ui.button decorator leaves the coroutine on the class.
+        await TimeRolesPanel.clear_missing_btn(panel, interaction, MagicMock())
+    # Only the stale row is cleared — through the audited seam, actor = clicker.
     seam.assert_awaited_once_with(
         guild_id=99,
-        role_id=808,
-        role_name=first_name,
-        days=first_days,
+        role_name="Ghost",
         actor_id=7,
     )
 
@@ -197,55 +207,80 @@ def test_row_is_stale_legacy_name_fallback():
         assert res.resolve_role.call_args.kwargs.get("name") == "Ghost"
 
 
+def test_hardcoded_defaults_and_ensure_defaults_are_removed():
+    """Regression guard for the owner directive: the hardcoded German/Minecraft
+    tier names (``_DEFAULT_THRESHOLDS``) and the ``_ensure_defaults`` seed
+    routine must NOT come back — roles load dynamically from the server now.
+    """
+    import views.roles._helpers as helpers
+
+    assert not hasattr(helpers, "_DEFAULT_THRESHOLDS")
+    assert not hasattr(helpers, "_ensure_defaults")
+
+
+def test_role_presets_are_creation_only_and_drop_old_tier_names():
+    """``ROLE_PRESETS`` exists (a few quick-create names) and never re-introduces
+    the old hardcoded tier names.
+    """
+    from views.roles._helpers import ROLE_PRESETS
+
+    names = {p.name for p in ROLE_PRESETS}
+    assert names, "expected a few creation presets"
+    # The old hardcoded tier names must not reappear as presets.
+    assert not (names & {"Neu", "Normal", "Iron", "Gold", "Diamand", "Netherite", "Beacon"})
+
+
 @pytest.mark.asyncio
-async def test_ensure_defaults_seeds_only_existing_roles():
-    from views.roles._helpers import _DEFAULT_THRESHOLDS, _ensure_defaults
+async def test_role_create_panel_create_routes_pending_through_lifecycle():
+    """The creation menu's ✅ Create stages the picked preset name/colour/hoist
+    and creates the role through the audited RoleLifecycleService.
+    """
+    import discord
 
-    existing_name, existing_days = _DEFAULT_THRESHOLDS[0]
+    from services.lifecycle import SUCCESS
+    from views.roles.creation_panel import RoleCreatePanel
 
-    def _resolve(_guild, *, name=None, role_id=None):
-        if name == existing_name:
-            return SimpleNamespace(id=500, name=name)
-        return None
+    ctx = MagicMock()
+    ctx.guild.id = 99
+    panel = RoleCreatePanel(ctx)
+    panel.pending_name = "Moderator"
+    panel.pending_color = discord.Color(0x3498DB)
+    panel.pending_hoist = True
 
-    guild = MagicMock()
-    guild.id = 7
-    with (
-        patch("utils.db.get_role_thresholds", new=AsyncMock(return_value=[])),
-        patch(
-            "services.role_automation.set_time_threshold",
-            new=AsyncMock(),
-        ) as seam,
-        patch("core.runtime.resources.resolve_role", side_effect=_resolve),
-    ):
-        await _ensure_defaults(guild)
-    # Only the one default whose role exists is seeded — with its captured id,
-    # through the audited seam, system-actored (no human behind a boot seed).
-    seam.assert_awaited_once_with(
-        guild_id=7,
-        role_id=500,
-        role_name=existing_name,
-        days=existing_days,
-        actor_id=None,
-        actor_type="system",
+    interaction = _interaction()
+    interaction.response.edit_message = AsyncMock()
+    interaction.message = MagicMock()
+
+    fake_result = SimpleNamespace(
+        outcome=SUCCESS,
+        steps=[SimpleNamespace(target_name="Moderator", target_id=999)],
+        first_error=None,
     )
+    svc = MagicMock()
+    svc.apply = AsyncMock(return_value=fake_result)
+    with patch("views.roles.creation_panel.RoleLifecycleService", return_value=svc):
+        await RoleCreatePanel.create_btn(panel, interaction, MagicMock())
+
+    svc.apply.assert_awaited_once()
+    req = svc.apply.await_args.args[1]
+    assert req.operation == "create"
+    assert req.name == "Moderator"
+    assert req.hoist is True
+    interaction.response.edit_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_ensure_defaults_noop_when_thresholds_exist():
-    from views.roles._helpers import _ensure_defaults
+async def test_role_create_panel_create_requires_a_name():
+    """✅ Create with nothing staged tells the operator to pick/Custom first and
+    never touches the lifecycle service.
+    """
+    from views.roles.creation_panel import RoleCreatePanel
 
-    guild = MagicMock()
-    guild.id = 7
-    with (
-        patch(
-            "utils.db.get_role_thresholds",
-            new=AsyncMock(return_value=[{"role_name": "X", "days_required": 1}]),
-        ),
-        patch(
-            "services.role_automation.set_time_threshold",
-            new=AsyncMock(),
-        ) as seam,
-    ):
-        await _ensure_defaults(guild)
-    seam.assert_not_awaited()
+    ctx = MagicMock()
+    ctx.guild.id = 99
+    panel = RoleCreatePanel(ctx)  # pending_name is None
+    interaction = _interaction()
+    with patch("views.roles.creation_panel.RoleLifecycleService") as svc:
+        await RoleCreatePanel.create_btn(panel, interaction, MagicMock())
+    svc.assert_not_called()
+    interaction.response.send_message.assert_awaited_once()


### PR DESCRIPTION
Owner-directed from a `!roles` → 🔧 Diagnostics screenshot ("Role Automation ⚠️ missing: **Neu,
Normal, Iron, Gold, Diamand, Netherite, Beacon**") plus three follow-up UX asks (Create/Edit/Delete
screenshots). All changes are inside the role-management subsystem.

### 1. Remove the hardcoded German/Minecraft tier names
- Delete `_DEFAULT_THRESHOLDS` (`Neu/Normal/Iron/Gold/Diamand/Netherite/Beacon`) and the
  `_ensure_defaults` boot/seed routine entirely. Role automation now loads **only roles that exist
  on the server** — no fictional name-based rows are ever persisted.
- Drop the **🔄 Seed Defaults** button (it seeded those names) and add a **🧹 Clear Missing** button
  to the Time-Roles panel so an operator can purge the phantom stale rows the old seeding left behind
  (the rows showing as "missing:" in diagnostics).

### 2. Create role — presets in the creation menu only
- The **📝 Create** button now opens a creation *menu* (`RoleCreatePanel`) with:
  - a **preset role-name** select (a few generic server roles), and
  - a **colour preset** select (the existing 8 `_COLOR_OPTIONS`),
  - plus **✏️ Custom…** (the full name/colour/hoist/mentionable modal, unchanged).
- Presets are surfaced **only here** — never in diagnostics, automation, or any other panel.

### 3. Edit role — pick from a select
- **✏️ Edit Role** now opens a role **picker** (windowed, filtered to roles the bot + admin can
  manage) → the Edit modal, instead of making you type the current role name.

### 4. Delete role — multi-select + confirmation
- **🗑️ Delete Role** is now a **multi-select** of deletable roles → a **confirmation step**
  ("Delete these N roles?") → batched delete through the audited `RoleLifecycleService`, instead of a
  single select that deleted immediately.

All role mutations stay on the audited `RoleLifecycleService` / `role_automation` seams (no new direct
writes). Born-red HOLD (Q-0133) until the session card flips to `complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LmPmCzVPSzo8TVYDwExGG

---
_Generated by [Claude Code](https://claude.ai/code/session_019LmPmCzVPSzo8TVYDwExGG)_