### PR TITLE
Reaction roles: gradient presets gallery (one-tap styled colour roles)

### DIFF
--- a/.sessions/2026-06-21-reaction-roles-gradient-presets.md
+++ b/.sessions/2026-06-21-reaction-roles-gradient-presets.md
@@ -1,23 +1,92 @@
 # 2026-06-21 — Reaction roles: gradient presets gallery
 
-> **Status:** `in-progress` — born-red HOLD (Q-0133). **⚑ Self-initiated** continuation of the
-> colour/gradient work (#1237) — the captured #1237 session idea, built under Q-0172 (ideas exist to
-> be built) + the standing act-and-improve directive. Fresh branch (Q-0014).
+> **Status:** `complete` — **⚑ Self-initiated** continuation of #1237 (Q-0172). PR #1246.
 
 > **Run type:** `manual`
 
-## What I'm about to do
+## Arc
 
-Finish the colour-role thread with a **gradient presets gallery** — a small curated catalogue of
-tasteful two-colour gradients (Sunset / Ocean / Berry / Forest / Fire / Candy) offered as one-tap
-picks in the role-menu builder's 🎨 Colours flow. Each preset auto-creates a gradient colour role via
-the already-shipped `reaction_role_service.ensure_color_role` seam and adds it to the menu — the
-"blank-page killer" for styled roles, mirroring the message-template gallery.
+The reaction-roles arc the owner directed (#1234 multi-emote + reuse, #1237 channel + colour +
+gradient, #1243 message picker) was all merged and there was no pending request. Per the standing
+autonomy directive (Q-0172 "ideas exist to be built" + "default to acting and improving"), I built the
+captured #1237 session idea: a **gradient presets gallery** finishing the colour/gradient thread.
 
 - `utils/role_menu_presentation.py` — a `GradientPreset` catalogue + `gradient_presets()` (pure data,
-  the themes/templates precedent).
-- `views/roles/role_menu_builder.py::_ColourRolesView` — a gradient-presets select, **only added when
-  the guild has the Enhanced-Role-Styles perk** (`supports_role_gradients`); reuses the tested
-  `_commit_colour_roles` path (so the solid-colour fallback still applies if the perk lapses).
+  the themes/templates precedent): Sunset / Ocean / Berry / Forest / Fire / Candy (each a curated
+  two-colour gradient).
+- `views/roles/role_menu_builder.py::_ColourRolesView` — a gradient-presets multi-select **added only
+  when the guild has the Enhanced-Role-Styles perk** (`supports_role_gradients`). Each pick routes
+  through the existing `_commit_colour_roles` → `ensure_color_role` (audited `RoleLifecycleService`),
+  so reuse-if-same-name and the solid-colour fallback both still apply. No new service/DB/schema.
 
-Verify: `check_quality.py --full` + `check_architecture.py --mode strict`.
+## Findings / decisions
+
+- **Decision made alone (the self-initiation itself):** with the owner's explicit asks complete, I
+  chose to build *one* small, reversible, captured idea rather than ask again — flagged ⚑ self-initiated
+  on the run report (and the active-work claim + PR title) per the accountability requirement, so it's
+  trivially reviewable/revertible. I deliberately kept it to a single small increment, not a new arc.
+- **Decision made alone:** the gradient select is **conditionally added** (perk-gated) rather than
+  always-shown-then-erroring — no dead UI. Holographic (3-colour) presets were *excluded*: Discord's
+  holographic is a fixed-value style and I couldn't verify the exact API colour triple, so shipping
+  arbitrary 3-colour combos risked wrong-looking roles. Two-colour gradients are arbitrary and safe.
+
+## Context delta
+
+- **Needed but not pointed to:** nothing new — `role_menu_presentation` (themes/templates) was the
+  obvious home for a preset catalogue, and `_commit_colour_roles`/`ensure_color_role` (from #1237) did
+  all the heavy lifting. This is the payoff of the #1237 seam being clean.
+- **Pointed to but didn't need:** the context-map's helper-policy/repo-navigation reads — this was
+  additive pure data in an existing catalogue module, no new helper placement question.
+- **Discovered by hand:** the PostToolUse auto-fixer had already added a type annotation to
+  `_on_presets`'s `specs` (my remembered text was stale) — re-grep before anchoring an edit on
+  recently-auto-fixed code.
+- **Decisions made alone:** see Findings (self-initiation; perk-gated select; holographic excluded).
+- **Weak point / unverified:** not live-walked — the perk-gated select only appears on a 3-boost
+  guild, so the gradient round-trip wants a runtime smoke on such a server (shared with #1237's caveat).
+  The preset colours are a taste call; trivially editable in `gradient_presets()`.
+- **One docs/tooling change that would help:** still the modal-first-response rule for
+  `discord-views.md` (carried from #1243 — not applied; owner-governed file).
+
+## 📤 Run report
+
+- **Did:** gradient presets gallery in the Colours flow (perk-gated, one-tap styled colour roles) ·
+  **Outcome:** shipped (PR #1246, auto-merge on green)
+- **Shipped:** #1246 — reaction-roles gradient presets gallery
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** none — but this was **self-initiated**; if you'd rather not have
+  preset gradients (or want different colours/names), it's a one-file revert/edit (`gradient_presets()`).
+- **⚑ Owner manual steps:** none — merge ≠ deploy. The presets only render on servers with Enhanced
+  Role Styles (3 boosts).
+- **⚑ Self-initiated:** **YES** — gradient presets gallery (captured #1237 idea, built under Q-0172).
+- **↪ Next:** reaction-roles is feature-complete (Carl parity-plus). Natural remaining items are a
+  live smoke-walk of #1234/#1237/#1243/#1246 and the modal-first-response docs rule (router DISCUSS).
+
+## 💡 Session idea
+
+**A `/reactionroles` quick-test / self-audit command** that lists every reaction-role binding and
+menu in the guild with a ✅/⚠️ health flag (role still exists? bot can manage it? message still
+present? reaction still on it?). Reaction-role config silently rots when roles/messages are deleted;
+a one-shot audit surfaces dead bindings the way the Diagnostics panel does for other subsystems.
+(Dedup-checked `docs/ideas/` — not captured; the Diagnostics panel covers pickup stats, not binding
+health.)
+
+## ⟲ Previous-session review
+
+The #1243 session correctly identified Discord's modal-first-response constraint and shaped the flow
+around it — good. What it (and this chain generally) keeps deferring: the **modal-first-response rule
+never made it into `.claude/rules/discord-views.md`**, because that file is owner-governed and the
+agent can only propose via the router — but no router Q-block was actually filed. **System
+improvement:** when a session surfaces a durable rule it *can't* self-apply, it should file the router
+DISCUSS Q-block in the same session (cheap, append-only) instead of only noting it in the card, or the
+insight evaporates. (I'm flagging it here again rather than filing unprompted, since router edits
+during a self-initiated run warrant owner visibility first — but it should be filed.)
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 0 (pending #1246, auto-merge on green) |
+| CI-red rounds | 0 real (born-red HOLD only, by design) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (reaction-role health-audit command) |
+| Ideas groomed | 1 (built the captured #1237 gradient-presets idea) |

--- a/.sessions/2026-06-21-reaction-roles-gradient-presets.md
+++ b/.sessions/2026-06-21-reaction-roles-gradient-presets.md
@@ -1,0 +1,23 @@
+# 2026-06-21 — Reaction roles: gradient presets gallery
+
+> **Status:** `in-progress` — born-red HOLD (Q-0133). **⚑ Self-initiated** continuation of the
+> colour/gradient work (#1237) — the captured #1237 session idea, built under Q-0172 (ideas exist to
+> be built) + the standing act-and-improve directive. Fresh branch (Q-0014).
+
+> **Run type:** `manual`
+
+## What I'm about to do
+
+Finish the colour-role thread with a **gradient presets gallery** — a small curated catalogue of
+tasteful two-colour gradients (Sunset / Ocean / Berry / Forest / Fire / Candy) offered as one-tap
+picks in the role-menu builder's 🎨 Colours flow. Each preset auto-creates a gradient colour role via
+the already-shipped `reaction_role_service.ensure_color_role` seam and adds it to the menu — the
+"blank-page killer" for styled roles, mirroring the message-template gallery.
+
+- `utils/role_menu_presentation.py` — a `GradientPreset` catalogue + `gradient_presets()` (pure data,
+  the themes/templates precedent).
+- `views/roles/role_menu_builder.py::_ColourRolesView` — a gradient-presets select, **only added when
+  the guild has the Enhanced-Role-Styles perk** (`supports_role_gradients`); reuses the tested
+  `_commit_colour_roles` path (so the solid-colour fallback still applies if the perk lapses).
+
+Verify: `check_quality.py --full` + `check_architecture.py --mode strict`.

--- a/disbot/utils/role_menu_presentation.py
+++ b/disbot/utils/role_menu_presentation.py
@@ -169,12 +169,52 @@ def get_template(key: str | None) -> MenuTemplate | None:
     return _TEMPLATE_BY_KEY.get(key)
 
 
+# ---------------------------------------------------------------------------
+# Gradient presets (Enhanced Role Styles) — one-tap styled colour roles
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GradientPreset:
+    """A ready-made two-colour gradient an operator applies as a styled role.
+
+    ``primary`` / ``secondary`` are ``0xRRGGBB`` ints (→ :class:`discord.Color`).
+    Only renders on guilds with the Enhanced Role Styles perk (3 applied boosts);
+    the builder gates on it and falls back to the primary solid colour otherwise.
+    """
+
+    key: str
+    label: str  # gallery text, e.g. "🌅 Sunset"
+    name: str  # the created role's name, e.g. "Sunset"
+    primary: int
+    secondary: int
+
+
+# Ordered for the builder gallery. Colours chosen to read well as Discord role
+# names (decent contrast against both light and dark themes).
+_GRADIENT_PRESETS: tuple[GradientPreset, ...] = (
+    GradientPreset("sunset", "🌅 Sunset", "Sunset", 0xFF7E5F, 0xFEB47B),
+    GradientPreset("ocean", "🌊 Ocean", "Ocean", 0x2193B0, 0x6DD5ED),
+    GradientPreset("berry", "🍇 Berry", "Berry", 0x8E2DE2, 0x4A00E0),
+    GradientPreset("forest", "🌲 Forest", "Forest", 0x11998E, 0x38EF7D),
+    GradientPreset("fire", "🔥 Fire", "Fire", 0xF12711, 0xF5AF19),
+    GradientPreset("candy", "🍬 Candy", "Candy", 0xFF6FD8, 0x3813C2),
+)
+
+
+def gradient_presets() -> tuple[GradientPreset, ...]:
+    """Every gradient preset, in gallery order."""
+    return _GRADIENT_PRESETS
+
+
 __all__ = [
     "DEFAULT_THEME_KEY",
+    "GradientPreset",
     "MenuTemplate",
     "MenuTheme",
     "get_template",
     "get_theme",
+    "gradient_presets",
     "templates",
     "theme_color",
     "themes",

--- a/disbot/views/roles/role_menu_builder.py
+++ b/disbot/views/roles/role_menu_builder.py
@@ -1043,6 +1043,8 @@ class _ColourRolesView(BaseView):
     """Pick preset colours (auto-created as roles) or open the custom/gradient modal."""
 
     def __init__(self, builder: RoleMenuBuilder) -> None:
+        from services.reaction_role_service import supports_role_gradients
+
         super().__init__(builder._author, timeout=180)
         self.builder = builder
         options = [
@@ -1057,6 +1059,22 @@ class _ColourRolesView(BaseView):
             max_values=len(options),
             select_row=0,
         )
+        # Gradient presets only render on Enhanced-Role-Styles guilds (3 boosts);
+        # offered solely when the perk is present so we never show a styled option
+        # that would silently fall back to solid.
+        if supports_role_gradients(builder.guild):
+            gradient_options = [
+                discord.SelectOption(label=p.label, value=p.key, description=p.name)
+                for p in presentation.gradient_presets()
+            ]
+            attach_multi_select(
+                self,
+                gradient_options,
+                self._on_gradient_presets,
+                placeholder="✨ Gradient colours (Enhanced Role Styles)…",
+                max_values=len(gradient_options),
+                select_row=2,
+            )
 
     @discord.ui.button(
         label="✏️ Custom / gradient…",
@@ -1082,6 +1100,29 @@ class _ColourRolesView(BaseView):
             (by_hex.get(hex_value, hex_value), _parse_color(hex_value), None, None)
             for hex_value in values
         ]
+        await _commit_colour_roles(interaction, self.builder, specs)
+
+    async def _on_gradient_presets(
+        self,
+        interaction: discord.Interaction,
+        values: list[str],
+    ) -> None:
+        by_key = {p.key: p for p in presentation.gradient_presets()}
+        specs: list[
+            tuple[str, discord.Color, discord.Color | None, discord.Color | None]
+        ] = []
+        for key in values:
+            preset = by_key.get(key)
+            if preset is None:
+                continue
+            specs.append(
+                (
+                    preset.name,
+                    discord.Color(preset.primary),
+                    discord.Color(preset.secondary),
+                    None,
+                ),
+            )
         await _commit_colour_roles(interaction, self.builder, specs)
 
 

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,11 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/reaction-roles-gradient-presets` · **reaction-roles gradient presets** (⚑ self-initiated,
+  Q-0172) — curated gradient catalogue + one-tap presets in the Colours flow (perk-gated) ·
+  `disbot/utils/role_menu_presentation.py` + `disbot/views/roles/role_menu_builder.py` · 2026-06-21 ·
+  **PR (this session, merge on green)**
+
 - `claude/dispatch-next` · **prune stale Active claims (drift-on-sight, Q-0166)** — every prior
   claim had merged, polluting `check_lane_overlap.py` with false positives · `docs/owner/active-work.md`
   · 2026-06-21 · **auto-merge on green** (docs-only)

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,11 +25,6 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/reaction-roles-gradient-presets` · **reaction-roles gradient presets** (⚑ self-initiated,
-  Q-0172) — curated gradient catalogue + one-tap presets in the Colours flow (perk-gated) ·
-  `disbot/utils/role_menu_presentation.py` + `disbot/views/roles/role_menu_builder.py` · 2026-06-21 ·
-  **PR (this session, merge on green)**
-
 - `claude/dispatch-next` · **prune stale Active claims (drift-on-sight, Q-0166)** — every prior
   claim had merged, polluting `check_lane_overlap.py` with false positives · `docs/owner/active-work.md`
   · 2026-06-21 · **auto-merge on green** (docs-only)
@@ -49,6 +44,10 @@ session holds it, no claim line needed here.)*
 
 ## Recently cleared
 
+- `claude/reaction-roles-gradient-presets` · **reaction-roles gradient presets** (⚑ self-initiated,
+  Q-0172) — curated `GradientPreset` catalogue + one-tap presets in the Colours flow (perk-gated) ·
+  `disbot/utils/role_menu_presentation.py` + `disbot/views/roles/role_menu_builder.py` · 2026-06-21 ·
+  **PR #1246 (merge on green)**
 - `claude/reaction-roles-message-picker` · **reaction-roles follow-up** (owner-directed) — emoji-add
   message picker (most-recent / pick-recent / new-message / by-id) replacing the raw message-ID step ·
   `disbot/views/roles/reaction_panel.py` · 2026-06-21 · **PR #1243 (merge on green)**

--- a/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
+++ b/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
@@ -50,6 +50,13 @@
 > "modal-must-be-first-response" rule (pick-recent → select → emotes modal; new-message → one modal
 > that also captures the emotes). The old `_MoreEmotesModal` is generalised to `_EmotesModal`.
 >
+> **▶ Refinement (2026-06-21, ⚑ self-initiated — PR #1246):** a **gradient presets gallery** finishes
+> the colour/gradient thread — `role_menu_presentation.gradient_presets()` (a curated `GradientPreset`
+> catalogue: Sunset/Ocean/Berry/Forest/Fire/Candy) surfaced as a one-tap select in the builder's
+> 🎨 Colours flow, **only when the guild has the Enhanced-Role-Styles perk** (`supports_role_gradients`).
+> Each pick auto-creates a gradient role via the shipped `ensure_color_role` seam; reuses
+> `_commit_colour_roles`, so the solid-colour fallback still applies. Pure data + one conditional select.
+>
 > **One-line goal:** bring SuperBot's self-assignable-role surface to **parity-plus** with
 > Carl-bot — lead with native **buttons + dropdown menus** (Carl's are a secondary/premium
 > add; emoji reactions are its core), keep emoji reaction-roles working for compatibility,

--- a/tests/unit/utils/test_role_menu_presentation.py
+++ b/tests/unit/utils/test_role_menu_presentation.py
@@ -45,3 +45,17 @@ def test_get_template_lookup():
     verify = presentation.get_template("verify")
     assert verify is not None
     assert verify.style == "button"
+
+
+def test_gradient_presets_are_non_empty_unique_and_valid_colours():
+    presets = presentation.gradient_presets()
+    assert presets
+    keys = [p.key for p in presets]
+    assert len(keys) == len(set(keys))  # no duplicate keys
+    for preset in presets:
+        assert preset.label and preset.name
+        # primary/secondary must convert to a discord.Color (valid 0xRRGGBB int).
+        assert isinstance(discord.Color(preset.primary), discord.Color)
+        assert isinstance(discord.Color(preset.secondary), discord.Color)
+        assert 0 <= preset.primary <= 0xFFFFFF
+        assert 0 <= preset.secondary <= 0xFFFFFF


### PR DESCRIPTION
**⚑ Self-initiated** continuation of the colour/gradient work (#1237) — building the captured #1237
session idea under Q-0172 ("ideas exist to be built"). Easy to revert if you'd rather not have it.

Finishes the colour-role thread with a **gradient presets gallery**: a small curated catalogue of
tasteful two-colour gradients (Sunset / Ocean / Berry / Forest / Fire / Candy) offered as one-tap
picks in the role-menu builder's 🎨 Colours flow — the "blank-page killer" for styled roles, mirroring
the existing message-template gallery.

- `utils/role_menu_presentation.py` — a `GradientPreset` catalogue + `gradient_presets()` (pure data,
  the themes/templates precedent).
- `views/roles/role_menu_builder.py::_ColourRolesView` — a gradient-presets select, **only shown when
  the guild has the Enhanced-Role-Styles perk** (`supports_role_gradients`); each pick auto-creates a
  gradient role via the shipped `ensure_color_role` seam (audited `RoleLifecycleService`) and adds it
  to the menu. Reuses the tested `_commit_colour_roles` path, so the solid-colour fallback still
  applies if the perk lapses mid-flight.

No new service/DB/schema — pure data + one conditional select.

Born-red HOLD (Q-0133) until the session card flips to `complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK6bg63g8Vsp2m4nhUxUrf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK6bg63g8Vsp2m4nhUxUrf)_