### PR TITLE
Docs: "Merge = deploy" clarity — Railway auto-deploys on merge (Q-0193)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -187,11 +187,15 @@ is **per-file**. Full convention: `docs/owner/ai-project-workflow.md` §9.
   the review: open the PR **ready**, do **not** label it `needs-hermes-review` / `do-not-automerge`, and arm
   auto-merge so it lands the instant CI is green. The `needs-hermes-review` carve-out is for *self-initiated*
   substantial/risky runtime work only — the distinction is **who chose the task**, not how big it is.
-  "Merge immediately" means *merge the moment it's mergeable* (still requires CI green), not bypass CI or
-  deploy. **Merge ≠ deploy** — production
-  restart/prod-checks stay the maintainer's. *If you ever merge by hand* (a carve-out, or
-  auto-merge is down): re-verify **CI green on the final head** and **never defer the merge to
-  the maintainer's next message** — that deferral was the #778 root cause.
+  "Merge immediately" means *merge the moment it's mergeable* (still requires CI green), not bypass CI.
+  **Merging IS deploying (owner directive Q-0193, 2026-06-21):** Railway auto-redeploys `worker` on every
+  merge to `main`, so a merged change is **live on its own within minutes** — you neither perform nor wait
+  for a manual deploy, and the deploy *is* the restart. **Never tell the maintainer to "restart" or "deploy"
+  a merge to apply it** (the misinformation this Q corrects). What stays his is **live verification /
+  rollback** + any per-PR *data* step a change names (e.g. `!btd6ops seed-data`, or an operator button to
+  clear stale rows) — not the deploy. Canonical: `docs/operations/production-deployment.md`. *If you ever
+  merge by hand* (a carve-out, or auto-merge is down): re-verify **CI green on the final head** and **never
+  defer the merge to the maintainer's next message** — that deferral was the #778 root cause.
 - **Open your session card born-red as the FIRST commit; flip it green as the LAST (owner
   directive Q-0133, 2026-06-14).** Auto-merge fires the instant **Code Quality** is green, so a
   session that pushes code first and its close-out docs (ledger entry, `.sessions/` log) second

--- a/.session-journal.md
+++ b/.session-journal.md
@@ -228,7 +228,10 @@ confidence; do not treat booting as gated.
 
 **Production (the maintainer's real bot — for diagnosis, never touched from here):**
 Railway service `worker`, **auto-deploys `main` on every merge** (restart policy
-is on-failure — why `!restart` must exit **nonzero**, PR #675). BTD6 data in prod
+is on-failure — why `!restart` must exit **nonzero**, PR #675). **So a merged change is
+live on its own within minutes — the deploy *is* the restart; NEVER tell the owner to
+"restart"/"deploy" a merge to apply it (mistake made 2026-06-21 → Q-0193; only live
+verification/rollback + any per-PR data step like seed-data stay his).** BTD6 data in prod
 is the **postgres blob lane** (`BTD6_DATA_BACKEND=postgres`): merged data PRs do
 NOT change what prod serves until `!btd6ops seed-data` runs (self-applying since
 PR #676; drift surfaced at boot + `!btd6 status`). Full note:

--- a/.sessions/2026-06-21-merge-equals-deploy-clarity.md
+++ b/.sessions/2026-06-21-merge-equals-deploy-clarity.md
@@ -1,0 +1,32 @@
+# 2026-06-21 — "Merge = deploy" clarity (kill the "restart is yours" misinformation)
+
+> **Status:** `in-progress` — born-red HOLD (Q-0133). Flip to `complete` as the final step.
+
+> **Run type:** `manual` (owner-directed, in-chat)
+
+## Arc
+
+Owner caught a real error: at the end of the role-presets session (#1245) I told him "the production
+restart is still yours" — but **Railway auto-deploys `main` on every merge**, so a merged change is
+live on its own. The owner's point was two-fold: (1) the factual claim is wrong, and (2) the fact that
+I parroted it means the deploy reality is buried / the docs are too crowded.
+
+This is a docs-only correction at the **roots** so the next agent stops repeating it — not more text:
+
+1. **`docs/operations/production-deployment.md`** — a single unmissable "Merge = deploy" lead on
+   *How code reaches production* (it already said this correctly, just not loudly), and drop the
+   misleading "restarts … stay the maintainer's" shorthand from the consequence bullet.
+2. **`.claude/CLAUDE.md`** — fix the binding shorthand "**Merge ≠ deploy** — production
+   restart/prod-checks stay the maintainer's" (the line agents internalize and copy) to the accurate
+   "**Merging IS deploying** … never tell the maintainer to restart/deploy a merge; only live
+   verification / rollback stay his." Owner-directed in-session → applied directly under the Q-0106
+   live-owner exception, citing **Q-0193**.
+3. **`docs/owner/maintainer-question-router.md`** — **Q-0193** provenance.
+4. **`.session-journal.md`** — one prevention line next to the already-accurate auto-deploy fact.
+
+## Status: building. (close-out notes on flip-to-complete.)
+
+## 📤 Run report
+
+- **Did:** (in progress)
+- **Run type:** `manual`

--- a/.sessions/2026-06-21-merge-equals-deploy-clarity.md
+++ b/.sessions/2026-06-21-merge-equals-deploy-clarity.md
@@ -1,6 +1,6 @@
 # 2026-06-21 — "Merge = deploy" clarity (kill the "restart is yours" misinformation)
 
-> **Status:** `in-progress` — born-red HOLD (Q-0133). Flip to `complete` as the final step.
+> **Status:** `complete` — owner directive Q-0193 (in-chat). PR #1247, auto-merge on green.
 
 > **Run type:** `manual` (owner-directed, in-chat)
 
@@ -11,22 +11,91 @@ restart is still yours" — but **Railway auto-deploys `main` on every merge**, 
 live on its own. The owner's point was two-fold: (1) the factual claim is wrong, and (2) the fact that
 I parroted it means the deploy reality is buried / the docs are too crowded.
 
-This is a docs-only correction at the **roots** so the next agent stops repeating it — not more text:
+Fixed at the **roots** so the next agent stops repeating it — *less* noise, not more:
 
-1. **`docs/operations/production-deployment.md`** — a single unmissable "Merge = deploy" lead on
-   *How code reaches production* (it already said this correctly, just not loudly), and drop the
+1. **`docs/operations/production-deployment.md`** — added an unmissable **"Merge = deploy"** lead on
+   *How code reaches production* (it already said this correctly, just not loudly), and dropped the
    misleading "restarts … stay the maintainer's" shorthand from the consequence bullet.
-2. **`.claude/CLAUDE.md`** — fix the binding shorthand "**Merge ≠ deploy** — production
-   restart/prod-checks stay the maintainer's" (the line agents internalize and copy) to the accurate
-   "**Merging IS deploying** … never tell the maintainer to restart/deploy a merge; only live
-   verification / rollback stay his." Owner-directed in-session → applied directly under the Q-0106
-   live-owner exception, citing **Q-0193**.
+2. **`.claude/CLAUDE.md`** — rewrote the binding shorthand "**Merge ≠ deploy** — production
+   restart/prod-checks stay the maintainer's" (the line agents internalize and copy) to "**Merging IS
+   deploying** … never tell the maintainer to restart/deploy a merge." Owner-directed in-session →
+   applied under the Q-0106 live-owner exception, citing **Q-0193**.
 3. **`docs/owner/maintainer-question-router.md`** — **Q-0193** provenance.
 4. **`.session-journal.md`** — one prevention line next to the already-accurate auto-deploy fact.
 
-## Status: building. (close-out notes on flip-to-complete.)
+## Findings / decisions
+
+- **The canonical doc was already right, just buried.** `production-deployment.md` literally said "an
+  agent merging a green session PR *is* triggering a production deploy" — but it was the *second* bullet,
+  under a heading that led with the GitHub-integration mechanics, and it repeated the same "Merge ≠
+  deploy / restarts stay the maintainer's" shorthand that misleads. The fix was a loud lead + dropping
+  the shorthand, not new facts.
+- **The misinformation spread by copy.** Session cards free-write the `⚑ Owner manual steps` line by
+  copying prior cards; "Merge ≠ deploy: prod restart stays yours" propagated that way (it's in several
+  `.sessions/*` cards, incl. my own #1245). Fixing the *binding* line in CLAUDE.md + the canonical doc
+  cuts it at the source agents copy from. (See Session idea for a guard.)
+- **Accurate division of labour (now stated once, clearly):** merge → Railway auto-redeploy `worker` →
+  live in minutes (deploy = restart). Maintainer's: **live verification, rollback, eval walks** + any
+  per-PR *data* step a change explicitly names (`!btd6ops seed-data`; an operator button to clear stale
+  rows — e.g. the #1245 "🧹 Clear Missing"). NOT the deploy/restart.
+
+## Context delta
+
+- **Needed but not pointed to:** that the "restart is yours" claim was *already* flagged "scattered and
+  partly wrong" by the 2026-06-16 act-on-review session — yet it persisted because that pass fixed the
+  *autonomous-loop* docs but left the CLAUDE.md auto-merge bullet + the session-card habit. The lesson:
+  a misinformation fix has to hit the *most-copied* surface (the binding bullet), not just one doc.
+- **Decision made alone:** treat this as a docs-root fix + a Q-block, not a sprawling find-and-replace
+  of every `.sessions/*` card (those are immutable history; rewriting them is noise — fix the source).
+- **Weak point / unverified:** I did *not* grep-replace the stale phrasing out of older `.sessions/*`
+  cards (history, left as-is) or the terser `ai-project-workflow.md:410` "Merge ≠ deploy." (it's in the
+  Q-0084 autonomy-grant context where it's defensible) — both deliberate, to avoid the crowding the
+  owner objected to. The Session idea proposes a guard instead.
+- **One docs/tooling change that would help:** the guard below.
 
 ## 📤 Run report
 
-- **Did:** (in progress)
+- **Did:** corrected "Merge = deploy" at the canonical doc + binding CLAUDE.md line + router Q-0193 +
+  journal · **Outcome:** shipped (PR #1247, docs-only, auto-merge on green)
+- **Shipped:** #1247 — "Merge = deploy" clarity (Q-0193)
 - **Run type:** `manual`
+- **CI:** `check_quality.py --check-only` green (black/isort/ruff/check_docs/check_consistency); docs-only,
+  no mypy/pytest impact.
+- **⚑ Owner decisions needed:** none (owner-directed correction).
+- **⚑ Owner manual steps:** none — and that is the whole point: **this PR auto-deploys on merge like any
+  other; nothing for you to restart or deploy.**
+- **⚑ Self-initiated:** none (direct owner directive). The router Q-0193 + journal note are the
+  durable-home parts of the same directive.
+- **↪ Next:** optional — the regression guard in the Session idea.
+
+## 💡 Session idea
+
+**A banned-phrase guard for the "Merge = deploy" canon.** Now that Q-0193 makes "Merge = deploy" the
+canonical statement, add a tiny `check_docs`/`check_consistency` rule (or a `scripts/` grep guard) that
+**fails CI if a tracked doc or a new `.sessions/*` card reintroduces** "Merge ≠ deploy", "restart is
+yours", or "prod restart stays the maintainer's" *without* naming a concrete per-PR data step. It would
+have caught my #1245 card at write time — the exact surface the misinformation spreads through — and
+keeps the fix from silently regressing as cards keep getting copied. Cheap (one regex over `docs/` +
+`.sessions/`), warn-then-error like the consistency linter. Dedup-checked `docs/ideas/` — not captured
+(the closest, `settings-presets`, is unrelated).
+
+## ⟲ Previous-session review
+
+The previous session (`2026-06-21-role-presets-and-management-ux.md`, #1245) — my own — did the
+four-thread role overhaul well and caught two real issues locally via `--full` before pushing. **What it
+got wrong:** its run report's `⚑ Owner manual steps` line said "Merge ≠ deploy: the prod restart stays
+yours" — copied uncritically from the prior reaction-roles card, and *factually wrong* (Railway
+auto-deploys). That single stale-by-copy line is what prompted this whole session. **System improvement:**
+exactly the banned-phrase guard above — the session-card `⚑ Owner manual steps` line is a high-traffic
+copy surface, and a one-line CI check there stops a wrong operational claim from propagating across dozens
+of cards. The self-audit loop worked as designed: session N+1 caught session N's drift.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 0 (pending #1247, auto-merge on green) |
+| CI-red rounds | 0 real (born-red HOLD only, by design) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (banned-phrase "Merge = deploy" guard) |
+| Ideas groomed | 0 (focused owner-directed correction) |

--- a/docs/operations/production-deployment.md
+++ b/docs/operations/production-deployment.md
@@ -22,14 +22,21 @@
 
 ## How code reaches production
 
+> **Merge = deploy.** Merging a PR to `main` triggers an **immediate Railway auto-deploy** of
+> `worker` — the change is **live within minutes, on its own, with no manual deploy or restart**.
+> The deploy *is* the restart (a fresh container). **Never tell the maintainer to "restart" or
+> "deploy" a merged change to make it take effect** — that just happened automatically. What
+> genuinely stays the maintainer's is **live verification, rollback, and eval walks**, plus any
+> per-PR *data* step a change explicitly names (e.g. `!btd6ops seed-data`, or clicking an
+> operator button to clear stale rows).
+
 - The Railway GitHub integration **auto-builds and deploys `worker` on every push to
   `main`** — each merge commit shows up as a deployment ("Merge pull request #NNN …
   via GitHub" in the dashboard).
-- **Consequence for Q-0084 merge autonomy:** an agent merging a green session PR
-  *is* triggering a production deploy — that has always been true for the
-  maintainer's merges too. "Merge ≠ deploy" in the grant means **restarts, prod
-  verification, rollbacks, and live eval walks stay the maintainer's**, not that
-  merges don't reach prod.
+- **Consequence for merge autonomy (Q-0084):** an agent merging a green session PR
+  *is* shipping to production — true for the maintainer's merges too. It does **not**
+  mean a separate manual deploy/restart is needed; it means **prod verification,
+  rollback, and live eval walks** (not the deploy) stay the maintainer's.
 - **Builder:** [railpack](https://railpack.com) (v0.27.x at write time). It detects
   Python + pip, creates `/app/.venv`, runs `pip install -r requirements.txt`, and
   starts the `worker` command from the **`Procfile`**: `python disbot/bot1.py`.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -37,6 +37,9 @@ living ledger (`docs/current-state.md`).
 - `claude/dreamy-cerf-voar4q` · **Project Moon knowledge domain** (owner-directed Q-0192: full parity) —
   feasibility **#1238** + program plan **#1239** merged; now pre-build recon (data sources + seam contract)
   · `docs/planning/project-moon-prebuild-recon-2026-06-21.md` · 2026-06-21 · **auto-merge on green** (docs-only)
+- `claude/ecstatic-babbage-8bf0g6` · **"Merge = deploy" clarity** (owner directive Q-0193, in-chat) — kill
+  the "restart is yours" misinformation: `production-deployment.md` + `.claude/CLAUDE.md` + router Q-0193 +
+  journal · 2026-06-21 · **auto-merge on green** (docs-only)
 
 *(Beyond the claim above, the only open PR is **#1213** creature-PvP battle engine on
 `claude/funny-franklin-mw3hxj`, a `needs-hermes-review` foundation slice — its owning

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -37,9 +37,6 @@ living ledger (`docs/current-state.md`).
 - `claude/dreamy-cerf-voar4q` · **Project Moon knowledge domain** (owner-directed Q-0192: full parity) —
   feasibility **#1238** + program plan **#1239** merged; now pre-build recon (data sources + seam contract)
   · `docs/planning/project-moon-prebuild-recon-2026-06-21.md` · 2026-06-21 · **auto-merge on green** (docs-only)
-- `claude/ecstatic-babbage-8bf0g6` · **"Merge = deploy" clarity** (owner directive Q-0193, in-chat) — kill
-  the "restart is yours" misinformation: `production-deployment.md` + `.claude/CLAUDE.md` + router Q-0193 +
-  journal · 2026-06-21 · **auto-merge on green** (docs-only)
 
 *(Beyond the claim above, the only open PR is **#1213** creature-PvP battle engine on
 `claude/funny-franklin-mw3hxj`, a `needs-hermes-review` foundation slice — its owning
@@ -47,6 +44,9 @@ session holds it, no claim line needed here.)*
 
 ## Recently cleared
 
+- `claude/ecstatic-babbage-8bf0g6` · **"Merge = deploy" clarity** (owner directive Q-0193, in-chat) —
+  killed the "restart is yours" misinformation at the roots (`production-deployment.md` lead +
+  `.claude/CLAUDE.md` binding line + router Q-0193 + journal) · 2026-06-21 · **PR #1247 (auto-merge on green)**
 - `claude/reaction-roles-gradient-presets` · **reaction-roles gradient presets** (⚑ self-initiated,
   Q-0172) — curated `GradientPreset` catalogue + one-tap presets in the Colours flow (perk-gated) ·
   `disbot/utils/role_menu_presentation.py` + `disbot/views/roles/role_menu_builder.py` · 2026-06-21 ·

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -7055,3 +7055,29 @@ session's work.
 **Home:** this Q-block + `docs/planning/project-moon-knowledge-domain-plan-2026-06-21.md` (the program
 plan) + the idea capture `docs/ideas/project-moon-wiki-knowledge-domain-2026-06-21.md` (resolved) +
 `docs/planning/README.md` S2 index.
+
+### Q-0193 — ANSWERED (owner directive in-session): "Merge = deploy" — kill the "restart is yours" misinformation (2026-06-21)
+
+**Context.** Closing the role-presets session (#1245), an agent told the owner "the production restart is
+still yours." The owner corrected it: **Railway auto-deploys `main` on every merge**, so a merged change is
+live on its own — there is no manual restart to perform. He added the meta-point: *the fact that an agent
+parroted "restart is your job" means the deploy reality is buried and the docs are too crowded.*
+
+**The decision / correction.** **Merging IS deploying.** A merge to `main` triggers an immediate Railway
+auto-redeploy of `worker` (the deploy *is* the container restart); the change is live within minutes with
+no manual step. Agents must **never** tell the maintainer to "restart" or "deploy" a merge to apply it.
+What genuinely stays the maintainer's is **live verification, rollback, and eval walks**, plus any per-PR
+*data* step a change explicitly names (e.g. `!btd6ops seed-data`, or an operator button to clear stale
+rows) — **not** the deploy/restart. (This sharpens, not contradicts, the Q-0084 "merge ≠ deploy"
+autonomy grant: that grant meant *verification/rollback* stay the owner's, never that a separate manual
+deploy is required. The misleading "Merge ≠ deploy — restart stays yours" shorthand was the bug.)
+
+**Applied this session (docs-only):** the canonical `docs/operations/production-deployment.md` § *How code
+reaches production* gained an unmissable "Merge = deploy" lead and dropped the "restarts … stay the
+maintainer's" phrasing; the `.claude/CLAUDE.md` auto-merge bullet's "**Merge ≠ deploy** — production
+restart/prod-checks stay the maintainer's" was rewritten to "**Merging IS deploying** … never tell the
+maintainer to restart/deploy a merge" (edited in-session under the Q-0106 live-owner exception, citing this
+Q); `.session-journal.md` got a one-line prevention note next to the auto-deploy fact.
+
+**Home:** this Q-block (canonical) + `docs/operations/production-deployment.md` (the operational truth) +
+the `.claude/CLAUDE.md` auto-merge bullet (the binding rule).


### PR DESCRIPTION
Owner-directed in-chat. Closing the role-presets session (#1245) I told the maintainer "the production
restart is still yours" — which is **wrong**: Railway auto-deploys `worker` on every merge to `main`, so a
merged change is live on its own within minutes (the deploy *is* the restart). The owner's point was
two-fold: the claim is wrong, **and** the fact that an agent parroted it means the deploy reality is buried
/ the docs are too crowded.

This fixes it at the **roots** (net *less* noise, not more):

- **`docs/operations/production-deployment.md`** — an unmissable **"Merge = deploy"** lead on *How code
  reaches production* (it already said this, just not loudly), and drops the misleading "restarts … stay
  the maintainer's" phrasing from the consequence bullet.
- **`.claude/CLAUDE.md`** — rewrites the auto-merge bullet's binding shorthand "**Merge ≠ deploy** —
  production restart/prod-checks stay the maintainer's" (the line agents internalize and copy) to
  "**Merging IS deploying** … never tell the maintainer to restart/deploy a merge to apply it." Edited
  in-session under the Q-0106 live-owner exception, citing **Q-0193**.
- **`docs/owner/maintainer-question-router.md`** — **Q-0193** provenance.
- **`.session-journal.md`** — one prevention line next to the already-accurate auto-deploy fact, so the
  next session doesn't repeat the mistake.

What genuinely stays the maintainer's is unchanged and now stated accurately: **live verification,
rollback, eval walks**, plus any per-PR *data* step a change names (e.g. `!btd6ops seed-data`, or an
operator button to clear stale rows) — not the deploy/restart.

Docs-only. Born-red HOLD (Q-0133) until the session card flips to `complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LmPmCzVPSzo8TVYDwExGG

---
_Generated by [Claude Code](https://claude.ai/code/session_019LmPmCzVPSzo8TVYDwExGG)_