### PR TITLE
Reaction roles: clean up dead bindings (role-deleted) + panel hint

### DIFF
--- a/.sessions/2026-06-21-reaction-roles-cleanup-dead-bindings.md
+++ b/.sessions/2026-06-21-reaction-roles-cleanup-dead-bindings.md
@@ -1,21 +1,89 @@
 # 2026-06-21 — Reaction roles: clean up dead bindings
 
-> **Status:** `in-progress` — born-red HOLD (Q-0133). Owner-directed (screenshots: a stale
-> `💀❤️😘 → (deleted role)` binding that should not remain). Q-0191 → merge on green. Fresh branch.
+> **Status:** `complete` — owner-directed (screenshots). Q-0191 → merge on green. PR #1248.
 
 > **Run type:** `manual`
 
-## What I'm about to do
+## Arc
 
-Owner reported leftover cruft in the Reaction Roles panel: an old pre-#1234 binding
-(`1518271910256054385 · 💀❤️😘 → (deleted role 1515523817881993439)`) whose role was deleted. They
-want it gone. (The modal placeholder `💀 ❤️ 😘` is a *good* preview and **stays** — no change there.)
+Owner reported (with screenshots) that the Reaction Roles panel kept showing leftover cruft from old
+pre-#1234 testing: `1518271910256054385 · 💀❤️😘 → (deleted role 1515523817881993439)` — a binding
+whose role was deleted. They want it gone; the modal `💀 ❤️ 😘` placeholder is a *good* multi-emote
+preview and **stays** (no change).
 
-- `services/reaction_role_service.py` — `prune_dead_bindings(guild, *, actor_id)`: removes every emoji
-  binding whose role no longer resolves (audited via `unbind_emoji`), returns the removed rows.
-- `views/roles/reaction_panel.py` — a **🧹 Clean up** button (row 1) that prunes + reports + re-renders,
-  and a build_embed hint ("⚠️ N binding(s) point to a deleted role — tap 🧹 Clean up") so the cruft is
-  self-explanatory and one tap from gone. Root cause (concatenated-emoji creation) was already fixed by
-  #1234; this clears existing dead rows.
+Built a dead-binding cleanup:
+- `services/reaction_role_service.py` — `prune_dead_bindings(guild, *, actor_id)` removes every emoji
+  binding whose role no longer resolves (each through the audited `unbind_emoji`), returns the removed
+  rows; `count_dead_bindings(guild)` is the read-only counterpart.
+- `views/roles/reaction_panel.py` — a **🧹 Clean up** button (row 1) that prunes + reports what it
+  removed + re-renders, and a `build_embed` "⚠️ Needs cleanup" hint when any binding points to a
+  deleted role, so the cruft is self-explanatory and one tap from gone.
 
-Verify: `check_quality.py --full` + `check_architecture.py --mode strict`.
+## Findings / decisions
+
+- **Decision made alone — explicit cleanup, not silent auto-prune.** A binding to a deleted role is
+  100% dead, so auto-removing it on render would be defensible — but silent data mutation on a *read*
+  path (`build_embed`) is an anti-pattern, and the owner benefits from *seeing* the cruft + a one-tap
+  fix. So: flag it in the embed + a dedicated button. After one tap it's gone, and #1234 stopped new
+  dead rows from being created, so "should not remain" holds going forward.
+- **Decision made alone — scope = emoji bindings only.** Menus already skip deleted roles on render
+  (`build_menu_embed`) and have a Delete action, so the visible rot is the emoji surface. Kept the
+  change tight to that.
+- **Root cause was already fixed (#1234):** the old concatenated-emoji binding (`💀❤️😘` as one key)
+  came from the pre-#1234 single-emote modal; this PR is purely the cleanup for rows left behind.
+
+## Context delta
+
+- **Needed but not pointed to:** nothing new — `list_bindings` + `resources.resolve_role` +
+  `unbind_emoji` (all from the existing seam) were everything. The cleanup is the actionable form of
+  the health-audit idea I'd queued, so the prior session's idea fed straight into this owner request.
+- **Pointed to but didn't need:** the `check_quality --full` mypy leg — the change is small + typed.
+- **Discovered by hand:** the legacy `reaction_roles` table stores no `channel_id`, so message-deleted
+  (vs role-deleted) bindings can't be detected without the channel — hence cleanup keys on *role*
+  deletion (which is the owner's case and the common rot). Worth knowing for any future audit.
+- **Decisions made alone:** explicit-cleanup-not-auto; emoji-bindings-only (see Findings).
+- **Weak point / unverified:** not live-walked — the button + prune are unit-tested with mocks; the
+  actual removal on the owner's server happens when they tap 🧹 Clean up after deploy.
+- **One docs/tooling change that would help:** still the modal-first-response rule for
+  `discord-views.md` (carried from #1243/#1246; owner-governed, needs a router Q-block).
+
+## 📤 Run report
+
+- **Did:** dead-binding cleanup (🧹 Clean up button + `prune_dead_bindings` + panel hint) ·
+  **Outcome:** shipped (PR #1248, auto-merge on green)
+- **Shipped:** #1248 — reaction-roles dead-binding cleanup
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** none (owner-directed)
+- **⚑ Owner manual steps:** after deploy, open `!roles → Reaction Roles → 🧹 Clean up` once to remove
+  the existing `💀❤️😘 → (deleted role)` binding. (Deploy itself is automatic on merge per Q-0193.)
+- **⚑ Self-initiated:** none (direct owner request)
+- **↪ Next:** reaction-roles is feature-complete + self-healing; the modal-first-response docs rule
+  remains the one open workflow follow-up (router DISCUSS).
+
+## 💡 Session idea
+
+**Auto-prune dead bindings on the reaction listener's miss path.** When `on_raw_reaction_add` fires
+for a bound emoji whose role no longer resolves, that's a definitive signal the binding is dead —
+the listener could opportunistically remove it (audited) right then, so dead config self-heals
+without anyone opening the panel. Cheaper + more thorough than a manual sweep; gated behind the
+existing `reaction_roles_enabled`. (Dedup-checked `docs/ideas/` — not captured.)
+
+## ⟲ Previous-session review
+
+The #1246 (self-initiated gradient presets) session was a clean, small, flagged increment — good
+example of the autonomy loop. But it (and I, this chain) kept *queuing* a "reaction-role health
+audit" idea while the owner actually wanted the **actionable** version (remove the rot, not just
+report it). **System improvement:** when an idea is "detect/surface problem X," prefer shipping the
+*fix-X* action over a read-only audit unless the fix is risky — an audit that only lists a problem
+the operator must then fix by hand is half a feature. The owner's report confirmed it: they didn't
+want to *see* the dead binding flagged, they wanted it *gone*.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 0 (pending #1248, auto-merge on green) |
+| CI-red rounds | 0 real (born-red HOLD only, by design) |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (listener-path dead-binding self-heal) |
+| Ideas groomed | 1 (turned the queued health-audit idea into the shipped cleanup) |

--- a/.sessions/2026-06-21-reaction-roles-cleanup-dead-bindings.md
+++ b/.sessions/2026-06-21-reaction-roles-cleanup-dead-bindings.md
@@ -1,0 +1,21 @@
+# 2026-06-21 — Reaction roles: clean up dead bindings
+
+> **Status:** `in-progress` — born-red HOLD (Q-0133). Owner-directed (screenshots: a stale
+> `💀❤️😘 → (deleted role)` binding that should not remain). Q-0191 → merge on green. Fresh branch.
+
+> **Run type:** `manual`
+
+## What I'm about to do
+
+Owner reported leftover cruft in the Reaction Roles panel: an old pre-#1234 binding
+(`1518271910256054385 · 💀❤️😘 → (deleted role 1515523817881993439)`) whose role was deleted. They
+want it gone. (The modal placeholder `💀 ❤️ 😘` is a *good* preview and **stays** — no change there.)
+
+- `services/reaction_role_service.py` — `prune_dead_bindings(guild, *, actor_id)`: removes every emoji
+  binding whose role no longer resolves (audited via `unbind_emoji`), returns the removed rows.
+- `views/roles/reaction_panel.py` — a **🧹 Clean up** button (row 1) that prunes + reports + re-renders,
+  and a build_embed hint ("⚠️ N binding(s) point to a deleted role — tap 🧹 Clean up") so the cruft is
+  self-explanatory and one tap from gone. Root cause (concatenated-emoji creation) was already fixed by
+  #1234; this clears existing dead rows.
+
+Verify: `check_quality.py --full` + `check_architecture.py --mode strict`.

--- a/disbot/services/reaction_role_service.py
+++ b/disbot/services/reaction_role_service.py
@@ -93,6 +93,46 @@ async def list_bindings(guild_id: int) -> list[dict]:
     return await db.get_all_reaction_roles(guild_id)
 
 
+async def count_dead_bindings(guild: discord.Guild) -> int:
+    """How many emoji bindings point to a role that no longer exists (read-only)."""
+    from core.runtime import resources
+
+    return sum(
+        1
+        for r in await list_bindings(guild.id)
+        if resources.resolve_role(guild, role_id=int(r["role_id"])) is None
+    )
+
+
+async def prune_dead_bindings(
+    guild: discord.Guild,
+    *,
+    actor_id: int | None,
+) -> list[dict]:
+    """Remove every emoji binding whose role no longer exists (audited).
+
+    Reaction-role config silently rots when a bound role is deleted — the binding
+    lingers as ``emoji → (deleted role N)`` and can never assign anything. This
+    clears those dead rows through the audited :func:`unbind_emoji` seam and
+    returns the removed rows (for an operator-facing summary). Live bindings are
+    untouched. The creation-side fix lives in the Add flow (#1234); this is the
+    cleanup for rows already left behind.
+    """
+    from core.runtime import resources
+
+    removed: list[dict] = []
+    for r in await list_bindings(guild.id):
+        if resources.resolve_role(guild, role_id=int(r["role_id"])) is None:
+            await unbind_emoji(
+                guild.id,
+                int(r["message_id"]),
+                r["emoji"],
+                actor_id=actor_id,
+            )
+            removed.append(r)
+    return removed
+
+
 # ===========================================================================
 # Emoji-surface modes (PR 3) — Carl's `rr <mode> <msg_id>`, per message
 # ===========================================================================
@@ -811,6 +851,7 @@ __all__ = [
     "apply_selection",
     "bind_emoji",
     "clear_message_mode",
+    "count_dead_bindings",
     "create_menu",
     "delete_menu",
     "ensure_color_role",
@@ -824,6 +865,7 @@ __all__ = [
     "list_menus",
     "list_message_modes",
     "list_posted_menus",
+    "prune_dead_bindings",
     "reaction_roles_enabled",
     "set_menu_location",
     "set_menu_message",

--- a/disbot/views/roles/reaction_panel.py
+++ b/disbot/views/roles/reaction_panel.py
@@ -77,10 +77,13 @@ class ReactionRolesPanel(BaseView):
         menus = await reaction_role_service.list_menus(self.ctx.guild.id)
 
         embed = discord.Embed(title="💬 Reaction Roles", color=ROLE_COLOR)
+        dead = 0
         if rows:
             lines = []
             for r in rows:
                 role = resources.resolve_role(self.ctx.guild, role_id=r["role_id"])
+                if role is None:
+                    dead += 1
                 role_str = role.mention if role else f"*(deleted role {r['role_id']})*"
                 lines.append(f"`{r['message_id']}` · {r['emoji']} → {role_str}")
             embed.description = "\n".join(lines)[:4096]
@@ -108,6 +111,15 @@ class ReactionRolesPanel(BaseView):
             ),
             inline=False,
         )
+        if dead:
+            embed.add_field(
+                name="⚠️ Needs cleanup",
+                value=(
+                    f"{dead} binding(s) point to a **deleted role** — tap "
+                    "**🧹 Clean up** to remove them."
+                ),
+                inline=False,
+            )
         embed.set_footer(text="One tap to self-assign; modes mirror Carl-bot.")
         return embed
 
@@ -305,6 +317,32 @@ class ReactionRolesPanel(BaseView):
             embed=await self.build_embed(),
             view=self,
         )
+
+    @discord.ui.button(label="🧹 Clean up", style=discord.ButtonStyle.grey, row=1)
+    async def cleanup_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not _can_manage(interaction):
+            await _deny(interaction)
+            return
+        from services import reaction_role_service
+
+        removed = await reaction_role_service.prune_dead_bindings(
+            self.ctx.guild,
+            actor_id=interaction.user.id,
+        )
+        if removed:
+            lines = "\n".join(
+                f"{r['emoji']} (deleted role) on message `{r['message_id']}`"
+                for r in removed
+            )
+            content = f"🧹 Removed {len(removed)} dead binding(s):\n{lines}"[:1900]
+        else:
+            content = "✅ No dead bindings — every binding points to a live role."
+        await interaction.response.send_message(content, ephemeral=True)
+        await self._rerender()
 
 
 # ---------------------------------------------------------------------------

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,11 +25,6 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/reaction-roles-cleanup` · **reaction-roles dead-binding cleanup** (owner-directed,
-  screenshots) — 🧹 Clean up button + `prune_dead_bindings` to remove bindings whose role was deleted ·
-  `disbot/services/reaction_role_service.py` + `disbot/views/roles/reaction_panel.py` · 2026-06-21 ·
-  **PR (this session, merge on green)**
-
 - `claude/dispatch-next` · **prune stale Active claims (drift-on-sight, Q-0166)** — every prior
   claim had merged, polluting `check_lane_overlap.py` with false positives · `docs/owner/active-work.md`
   · 2026-06-21 · **auto-merge on green** (docs-only)
@@ -49,6 +44,10 @@ session holds it, no claim line needed here.)*
 
 ## Recently cleared
 
+- `claude/reaction-roles-cleanup` · **reaction-roles dead-binding cleanup** (owner-directed,
+  screenshots) — 🧹 Clean up button + `prune_dead_bindings` (+ panel hint) to remove bindings whose
+  role was deleted · `disbot/services/reaction_role_service.py` + `disbot/views/roles/reaction_panel.py`
+  · 2026-06-21 · **PR #1248 (merge on green)**
 - `claude/ecstatic-babbage-8bf0g6` · **"Merge = deploy" clarity** (owner directive Q-0193, in-chat) —
   killed the "restart is yours" misinformation at the roots (`production-deployment.md` lead +
   `.claude/CLAUDE.md` binding line + router Q-0193 + journal) · 2026-06-21 · **PR #1247 (auto-merge on green)**

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,11 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/reaction-roles-cleanup` · **reaction-roles dead-binding cleanup** (owner-directed,
+  screenshots) — 🧹 Clean up button + `prune_dead_bindings` to remove bindings whose role was deleted ·
+  `disbot/services/reaction_role_service.py` + `disbot/views/roles/reaction_panel.py` · 2026-06-21 ·
+  **PR (this session, merge on green)**
+
 - `claude/dispatch-next` · **prune stale Active claims (drift-on-sight, Q-0166)** — every prior
   claim had merged, polluting `check_lane_overlap.py` with false positives · `docs/owner/active-work.md`
   · 2026-06-21 · **auto-merge on green** (docs-only)

--- a/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
+++ b/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
@@ -57,6 +57,14 @@
 > Each pick auto-creates a gradient role via the shipped `ensure_color_role` seam; reuses
 > `_commit_colour_roles`, so the solid-colour fallback still applies. Pure data + one conditional select.
 >
+> **▶ Refinement (2026-06-21, owner-directed — PR #1248):** **dead-binding cleanup.** Reaction-role
+> config silently rots when a bound role is deleted (binding lingers as `emoji → (deleted role N)`).
+> `reaction_role_service.prune_dead_bindings` removes every binding whose role no longer resolves
+> (audited via `unbind_emoji`); a **🧹 Clean up** button on `ReactionRolesPanel` runs it + reports, and
+> `build_embed` shows a "⚠️ N binding(s) point to a deleted role — tap 🧹 Clean up" hint. The
+> creation-side cause was fixed in #1234; this clears rows already left behind. (The Add-modal
+> `💀 ❤️ 😘` placeholder is an intended multi-emote preview and stays.)
+>
 > **One-line goal:** bring SuperBot's self-assignable-role surface to **parity-plus** with
 > Carl-bot — lead with native **buttons + dropdown menus** (Carl's are a secondary/premium
 > add; emoji reactions are its core), keep emoji reaction-roles working for compatibility,

--- a/tests/unit/services/test_reaction_role_service.py
+++ b/tests/unit/services/test_reaction_role_service.py
@@ -335,3 +335,63 @@ async def test_record_pickups_swallows_errors():
         new=AsyncMock(side_effect=RuntimeError("db down")),
     ):
         await rrs._record_pickups(1, (10,), ())  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Dead-binding cleanup (owner-directed, 2026-06-21) — remove bindings whose role
+# was deleted; live bindings untouched.
+# ---------------------------------------------------------------------------
+
+
+def _resolve_only(*live_ids: int):
+    def _fake(_guild, *, role_id):
+        return object() if role_id in live_ids else None
+
+    return _fake
+
+
+@pytest.mark.asyncio
+async def test_prune_dead_bindings_removes_only_deleted_role_bindings():
+    rows = [
+        {"message_id": 1, "emoji": "💀", "role_id": 10},  # live
+        {"message_id": 1, "emoji": "❤️", "role_id": 20},  # dead
+        {"message_id": 2, "emoji": "🔥", "role_id": 30},  # dead
+    ]
+    with (
+        patch.object(rrs, "list_bindings", new=AsyncMock(return_value=rows)),
+        patch("core.runtime.resources.resolve_role", side_effect=_resolve_only(10)),
+        patch.object(rrs, "unbind_emoji", new=AsyncMock()) as unbind,
+    ):
+        removed = await rrs.prune_dead_bindings(_Guild(1), actor_id=99)
+
+    assert [r["emoji"] for r in removed] == ["❤️", "🔥"]
+    assert unbind.await_count == 2
+    unbind.assert_any_await(1, 1, "❤️", actor_id=99)
+    unbind.assert_any_await(1, 2, "🔥", actor_id=99)
+
+
+@pytest.mark.asyncio
+async def test_prune_dead_bindings_noop_when_all_live():
+    rows = [{"message_id": 1, "emoji": "💀", "role_id": 10}]
+    with (
+        patch.object(rrs, "list_bindings", new=AsyncMock(return_value=rows)),
+        patch("core.runtime.resources.resolve_role", side_effect=_resolve_only(10)),
+        patch.object(rrs, "unbind_emoji", new=AsyncMock()) as unbind,
+    ):
+        removed = await rrs.prune_dead_bindings(_Guild(1), actor_id=99)
+
+    assert removed == []
+    unbind.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_count_dead_bindings():
+    rows = [
+        {"message_id": 1, "emoji": "💀", "role_id": 10},
+        {"message_id": 1, "emoji": "❤️", "role_id": 20},
+    ]
+    with (
+        patch.object(rrs, "list_bindings", new=AsyncMock(return_value=rows)),
+        patch("core.runtime.resources.resolve_role", side_effect=_resolve_only(10)),
+    ):
+        assert await rrs.count_dead_bindings(_Guild(1)) == 1


### PR DESCRIPTION
Owner-directed (reported with screenshots). The Reaction Roles panel kept showing leftover cruft
from old pre-#1234 testing — a binding `1518271910256054385 · 💀❤️😘 → (deleted role
1515523817881993439)` whose role was since deleted. It should not remain.

(The modal placeholder `💀 ❤️ 😘` is a *good* illustrative preview of multi-emote entry and **stays** —
no change there.)

## Change
- `services/reaction_role_service.py` — `prune_dead_bindings(guild, *, actor_id)`: removes every emoji
  binding whose role no longer resolves, each through the audited `unbind_emoji`; returns the removed
  rows for reporting.
- `views/roles/reaction_panel.py` — a **🧹 Clean up** button that prunes dead bindings, reports what it
  removed, and re-renders; plus a build_embed hint ("⚠️ N binding(s) point to a deleted role — tap
  🧹 Clean up") so the cruft is self-explanatory and one tap from gone.

The root cause (the old concatenated-emoji binding creation) was already fixed in #1234; this clears
the existing dead rows it left behind. No schema change.

Born-red HOLD (Q-0133) until the session card flips to `complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK6bg63g8Vsp2m4nhUxUrf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK6bg63g8Vsp2m4nhUxUrf)_