### PR TITLE
BTD6 buff-uptime: verify parser binding against the real dump + populate Alchemist data

### DIFF
--- a/.sessions/2026-06-21-btd6-buff-uptime-verify-and-populate.md
+++ b/.sessions/2026-06-21-btd6-buff-uptime-verify-and-populate.md
@@ -1,0 +1,25 @@
+# 2026-06-21 — BTD6 buff-uptime: verify binding against the real dump + populate data
+
+> **Status:** `in-progress`
+
+## Arc (what I'm about to do)
+Follow-up to PR #1235 (Alchemist buff-uptime calculator). That PR shipped the parser
+buff-window decode as an **unverified candidate field-set** (no dump in-repo) and left
+data population as an owner manual step. The owner pointed out the dump is the **public
+BTD Mod Helper repo** — clonable. So I cloned it and:
+
+- **Found my candidate set was WRONG** (would've extracted nothing). The real applier is
+  `Add{BerserkerBrew,AcidicMixture}ToProjectileModel` on the thrown projectile:
+  `lifespan` (SECONDS, not frames), nested `…CheckModel.maxCount`, `rebuffBlockTime`.
+- **Rewrote `_buff_window`** to the verified structure; dry-run matches the wiki exactly
+  (300=5s/25, 320=6s/40, 400=12s/40, 420=13s/55, 500=permanent; lead-buff cap 10/12).
+- **Populated the committed data** via a surgical overlay (buff fields only, zero value
+  churn / no version bump) → the bot now answers live: 4-0-0 on 5-0-0 Ninja = attack-cap
+  limited, 100% uptime; base 3-0-0 = 62.5% (time-limited); Acidic Dip = 21.7%.
+
+## Plan
+1. Parser: verified `_buff_window` (done locally) + update the 4 fixture tests to the real
+   `AddBerserkerBrewToProjectileModel` shape.
+2. Data: committed `alchemist.json` overlay (done locally).
+3. Calc: tiny note polish (dedupe "X (X)" when source name == buff label) + a real-data test.
+4. Docs: decode-status → VERIFIED + populated; drop the owner manual-step caveat.

--- a/.sessions/2026-06-21-btd6-buff-uptime-verify-and-populate.md
+++ b/.sessions/2026-06-21-btd6-buff-uptime-verify-and-populate.md
@@ -1,25 +1,85 @@
 # 2026-06-21 — BTD6 buff-uptime: verify binding against the real dump + populate data
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-## Arc (what I'm about to do)
-Follow-up to PR #1235 (Alchemist buff-uptime calculator). That PR shipped the parser
-buff-window decode as an **unverified candidate field-set** (no dump in-repo) and left
-data population as an owner manual step. The owner pointed out the dump is the **public
-BTD Mod Helper repo** — clonable. So I cloned it and:
+## Arc
+Follow-up to PR #1235 (Alchemist buff-uptime calculator). #1235 shipped the parser
+buff-window decode as an **unverified candidate field-set** (I'd wrongly concluded "no
+dump in-repo ⇒ can't verify") and left data population as an owner manual step. The owner
+corrected me: the dump is the **public BTD Mod Helper repo**, clonable. So I cloned it and
+turned the guess into a verified, populated, working feature.
 
-- **Found my candidate set was WRONG** (would've extracted nothing). The real applier is
-  `Add{BerserkerBrew,AcidicMixture}ToProjectileModel` on the thrown projectile:
-  `lifespan` (SECONDS, not frames), nested `…CheckModel.maxCount`, `rebuffBlockTime`.
-- **Rewrote `_buff_window`** to the verified structure; dry-run matches the wiki exactly
-  (300=5s/25, 320=6s/40, 400=12s/40, 420=13s/55, 500=permanent; lead-buff cap 10/12).
-- **Populated the committed data** via a surgical overlay (buff fields only, zero value
-  churn / no version bump) → the bot now answers live: 4-0-0 on 5-0-0 Ninja = attack-cap
-  limited, 100% uptime; base 3-0-0 = 62.5% (time-limited); Acidic Dip = 21.7%.
+## Shipped (PR #1249)
+- **Verified the real structure** — `git clone --depth 1 https://github.com/Btd6ModHelper/btd6-game-data`.
+  My #1235 candidate field-set was **wrong** (would've extracted nothing). The real buff
+  applier is `Add{BerserkerBrew,AcidicMixture}ToProjectileModel` on the thrown projectile:
+  `lifespan` (**seconds**; `lifespanFrames` is 0/unused; `-1` = permanent; absent on the
+  lead buff = cap-only), nested `…CheckModel.maxCount` (cap; `9999999` = permanent),
+  `rebuffBlockTime` (per-target re-buff cd, 5s @ 4-0-0).
+- **Rewrote `parse_gamedata._buff_window`** to that structure. Dry-run against the real dump
+  matches the wiki exactly across every tier + crosspath (300=5s/25, 320=6s/40, 400=12s/40,
+  402=12s/40@6.4, 420=13s/55, 500=permanent; lead cap 10/12).
+- **Populated `stats/alchemist.json`** via a surgical buff-field overlay — `buff_duration` /
+  `buff_attack_cap` / `buff_permanent` only, **zero value churn / no version bump**, idempotent
+  with the parser (next `--all` reproduces it). The bot now answers **live**: 4-0-0 on 5-0-0
+  Ninja = attack-cap-limited 100%; 3-0-0 = 62.5% (time-limited); Acidic Dip = 21.7%.
+- **Calc polish** (dedupe "Berserker Brew (Berserker Brew)" → just the name when the upgrade
+  IS the buff); **fixture tests** rewritten to the real `Add…ToProjectileModel` shape;
+  **real-data calculator tests** (no monkeypatch); decode-status marked VERIFIED + populated,
+  manual-step caveat dropped.
 
-## Plan
-1. Parser: verified `_buff_window` (done locally) + update the 4 fixture tests to the real
-   `AddBerserkerBrewToProjectileModel` shape.
-2. Data: committed `alchemist.json` overlay (done locally).
-3. Calc: tiny note polish (dedupe "X (X)" when source name == buff label) + a real-data test.
-4. Docs: decode-status → VERIFIED + populated; drop the owner manual-step caveat.
+## Verification
+- `python3.10 scripts/check_quality.py --full` → **all checks passed ✓** (11349 passed).
+- Dry-run `map_tower(/tmp/btd6gd, alchemist)` → buff windows match the wiki on every tier.
+- Real-data: `buff_uptime("alchemist 4-0-0","ninja 5-0-0")` → found, `limiter=attacks`,
+  `buff_duration_seconds=12.0`, `buff_attack_cap=40`, `uptime_percent=100.0`.
+- Ledger + docs `--strict` green.
+
+## Decisions made alone
+- **Surgical overlay over `--all` regen**: the cloned dump HEAD is a newer/undetected version
+  (`game_version` came out `""`, `filterInvisible` churn), so a full `--tower`/`--all` regen
+  would be a version bump, not a buff-field add. Overlaying only the three buff fields keeps the
+  diff clean and consistent with the parser. The owner's canonical `--all` at the pinned dump
+  still reproduces the same fields.
+- Left `rebuffBlockTime` decoded-but-unused (captured as the session idea) to keep the calc
+  change minimal; the throw-cadence model already gives correct single-target uptime.
+
+## Context delta
+- **Corrected belief:** "not vendored in our repo" ≠ "unreachable." The BTD Mod Helper dump is
+  public + clonable; the decode-status doc *named the repo* — I should have cloned it in #1235
+  instead of shipping a candidate set. Now stated loudly in decode-status ("no 'no dump in-repo'
+  excuse — clone it").
+
+## ⟲ Previous-session review
+The previous session (this task's #1235) shipped a genuinely useful calculator and was honest
+about the gap — but it **built ahead of verifiable data and guessed the field names** rather than
+checking whether the dump was obtainable, even though its own decode-status entry named the public
+repo. The candidate set was 100% wrong (it would have extracted nothing), so the "fixture-tested
+logic" gave false confidence. **Workflow improvement (applied this session):** before shipping an
+*unverified* decode against an external source, spend one step checking if that source is
+fetchable (public clone / raw URL) — a 30-second `git clone` converts a guess into ground truth.
+"No raw data in our repo" is a prompt to *go get it*, not a license to guess. Worth a
+`.session-journal.md` line.
+
+## 💡 Session idea
+**Make `rebuffBlockTime` a `btd6_buff_uptime` input.** The dump carries a per-target re-buff
+cooldown (5s @ 4-0-0, 4s with Perishing) distinct from the throw cadence — the *real* floor on how
+soon a given tower can be re-buffed. Decoding + feeding it would sharpen single-target uptime
+(and is the natural companion to the multi-target generalization #1235 flagged). The value is
+already decoded-available off the applier; only the calc wiring + an emitted `buff_rebuff_block`
+field remain. (Captured, not built — kept this PR to the verified binding + population.)
+
+## 📤 Run report
+- **Did:** Cloned the public dump, corrected the parser binding to verified, populated the
+  Alchemist buff data so `btd6_buff_uptime` answers live · **Outcome:** shipped (PR #1249)
+- **Shipped:** PR #1249 — verified `_buff_window` + `stats/alchemist.json` overlay + calc polish
+  + real-data tests + decode-status VERIFIED
+- **Run type:** `manual` (owner pointed at the public dump)
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** **none** — the previous manual-step (re-run the dump) is now done;
+  data is populated and the binding is verified. (Future game patches: the normal `--all` refresh
+  reproduces the buff fields automatically.)
+- **⚑ Self-initiated:** this whole follow-up was self-initiated (Q-0172) off the owner's "you can
+  clone it" pointer — verifying + populating beyond the merged #1235.
+- **↪ Next:** wire `rebuffBlockTime` into the calc (this session's 💡) and/or the multi-target
+  generalization; else resume the current-state ▶ ungated lane.

--- a/disbot/data/btd6/stats/alchemist.json
+++ b/disbot/data/btd6/stats/alchemist.json
@@ -4437,7 +4437,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 10
         }
       ],
       "targetTypeFirst": true,
@@ -4535,7 +4536,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 10
         }
       ],
       "targetTypeFirst": true,
@@ -4633,7 +4635,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 10
         }
       ],
       "targetTypeFirst": true,
@@ -4735,7 +4738,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 10
         }
       ],
       "targetTypeFirst": true,
@@ -4837,7 +4841,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 10
         },
         {
           "name": "RubberToGoldAttack",
@@ -4977,7 +4982,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 10
         },
         {
           "name": "RubberToGoldAttack",
@@ -5151,7 +5157,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 10
         }
       ],
       "targetTypeFirst": true,
@@ -5250,7 +5257,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 12
         }
       ],
       "targetTypeFirst": true,
@@ -5349,7 +5357,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 12
         },
         {
           "name": "Unstable Concoction",
@@ -5500,7 +5509,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 12
         },
         {
           "name": "Unstable Concoction",
@@ -5680,7 +5690,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 12
         },
         {
           "name": "Unstable Concoction",
@@ -5914,7 +5925,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 10
         },
         {
           "name": "BeserkerBrewAttack",
@@ -5941,7 +5953,9 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_duration": 5,
+          "buff_attack_cap": 25
         }
       ],
       "targetTypeFirst": true,
@@ -6039,7 +6053,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 10
         },
         {
           "name": "BeserkerBrewAttack",
@@ -6066,7 +6081,9 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_duration": 5,
+          "buff_attack_cap": 25
         }
       ],
       "targetTypeFirst": true,
@@ -6164,7 +6181,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 10
         },
         {
           "name": "BeserkerBrewAttack",
@@ -6191,7 +6209,9 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_duration": 5,
+          "buff_attack_cap": 25
         }
       ],
       "targetTypeFirst": true,
@@ -6289,7 +6309,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 10
         },
         {
           "name": "BeserkerBrewAttack",
@@ -6316,7 +6337,9 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_duration": 5,
+          "buff_attack_cap": 25
         }
       ],
       "targetTypeFirst": true,
@@ -6415,7 +6438,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 12
         },
         {
           "name": "BeserkerBrewAttack",
@@ -6442,7 +6466,9 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_duration": 6,
+          "buff_attack_cap": 40
         }
       ],
       "targetTypeFirst": true,
@@ -6540,7 +6566,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 10
         },
         {
           "name": "BeserkerBrewAttack",
@@ -6567,7 +6594,9 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_duration": 12,
+          "buff_attack_cap": 40
         }
       ],
       "targetTypeFirst": true,
@@ -6665,7 +6694,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 10
         },
         {
           "name": "BeserkerBrewAttack",
@@ -6692,7 +6722,9 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_duration": 12,
+          "buff_attack_cap": 40
         }
       ],
       "targetTypeFirst": true,
@@ -6790,7 +6822,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 10
         },
         {
           "name": "BeserkerBrewAttack",
@@ -6817,7 +6850,9 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_duration": 12,
+          "buff_attack_cap": 40
         }
       ],
       "targetTypeFirst": true,
@@ -6915,7 +6950,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 10
         },
         {
           "name": "BeserkerBrewAttack",
@@ -6942,7 +6978,9 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_duration": 12,
+          "buff_attack_cap": 40
         }
       ],
       "targetTypeFirst": true,
@@ -7041,7 +7079,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_attack_cap": 12
         },
         {
           "name": "BeserkerBrewAttack",
@@ -7068,7 +7107,9 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_duration": 13,
+          "buff_attack_cap": 55
         }
       ],
       "targetTypeFirst": true,
@@ -7166,7 +7207,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_permanent": true
         },
         {
           "name": "BeserkerBrewAttack",
@@ -7193,7 +7235,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_permanent": true
         }
       ],
       "targetTypeFirst": true,
@@ -7291,7 +7334,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_permanent": true
         },
         {
           "name": "BeserkerBrewAttack",
@@ -7318,7 +7362,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_permanent": true
         }
       ],
       "targetTypeFirst": true,
@@ -7416,7 +7461,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_permanent": true
         },
         {
           "name": "BeserkerBrewAttack",
@@ -7443,7 +7489,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_permanent": true
         }
       ],
       "targetTypeFirst": true,
@@ -7541,7 +7588,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_permanent": true
         },
         {
           "name": "BeserkerBrewAttack",
@@ -7568,7 +7616,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_permanent": true
         }
       ],
       "targetTypeFirst": true,
@@ -7667,7 +7716,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_permanent": true
         },
         {
           "name": "BeserkerBrewAttack",
@@ -7694,7 +7744,8 @@
           "attackThroughWalls": true,
           "framesBeforeRetarget": 0,
           "sharedGridRange": 0,
-          "filterInvisible": false
+          "filterInvisible": false,
+          "buff_permanent": true
         }
       ],
       "targetTypeFirst": true,

--- a/disbot/services/btd6_upgrade_detail_service.py
+++ b/disbot/services/btd6_upgrade_detail_service.py
@@ -585,6 +585,11 @@ def buff_uptime(buff_source: str, target: str) -> dict[str, Any]:
         str(attack.get("name") or ""),
         "Alchemist buff",
     )
+    # The buff's own name + the upgrade it comes from, deduped — "Berserker Brew
+    # (Stronger Stimulant)", but just "Berserker Brew" when the upgrade IS the buff.
+    source_label = (
+        buff_label if src_display == buff_label else f"{buff_label} ({src_display})"
+    )
     cadence = attack.get("rate")
     duration = attack.get("buff_duration")
     cap = attack.get("buff_attack_cap")
@@ -631,7 +636,7 @@ def buff_uptime(buff_source: str, target: str) -> dict[str, Any]:
         out["uptime"] = 1.0
         out["uptime_percent"] = 100.0
         out["note"] = (
-            f"{buff_label} from {src_display} is permanent — 100% uptime on "
+            f"{source_label} is permanent — 100% uptime on "
             f"{tgt_display} once buffed (it never expires)."
         )
         return out
@@ -694,7 +699,7 @@ def buff_uptime(buff_source: str, target: str) -> dict[str, Any]:
         else ""
     )
     out["note"] = (
-        f"{buff_label} ({src_display}) on {tgt_display}: limited by {limiter_txt}, "
+        f"{source_label} on {tgt_display}: limited by {limiter_txt}, "
         f"so it lasts ~{round(window, 2)}s per throw and buffs "
         f"{out['attacks_under_buff']} attacks.{uptime_txt}"
     )

--- a/docs/btd6/btd6-gamedata-decode-status.md
+++ b/docs/btd6/btd6-gamedata-decode-status.md
@@ -24,32 +24,33 @@ works** (the traps we hit), and what is still un-decoded.
 
 ## ⭐ Next session — start here (updated 2026-06-10 — **cutover DONE (#649) · VERIFIED (#655) · carry-forwards DECODED (#653+#655) · Ask parity + dark renders (#658) · items 6a–c + the Navarch routing fix (#662) · item 7 slice 1 + zero-fact sweep (#668; probe tool #666); next = item 3 (demand-driven) + item 4 (maintainer spot-check)**)
 
-> **2026-06-21 (PR #1235 — Alchemist buff-uptime + buff-WINDOW decode · ONE OPEN BINDING STEP):**
+> **2026-06-21 (PR #1235 + #1249 — Alchemist buff-uptime + buff-WINDOW decode · VERIFIED + DATA POPULATED):**
 > owner live-test ("uptime of a 4-0-0 Alch on a 5-0-0 Ninja") — the bot had the brew **throw
 > cadence** (`BeserkerBrewAttack.rate` = 8s) but not the buff **window**, so it punted. Shipped the
 > calculator (`btd6_buff_uptime` tool → `btd6_upgrade_detail_service.buff_uptime()`): it joins
 > cadence + the target's `attacks[0].rate` + the buff window to report which limiter binds and the
 > uptime%. The buff is **dual-limited** (time OR attacks, whichever first) — a 5-0-0 Ninja (0.217s)
-> burns 40 attacks in ~8.7s, so it's **attack-cap-limited**.
+> burns 40 attacks in ~8.7s, so it's **attack-cap-limited** (100% uptime); base 3-0-0 is time-limited
+> (5s, 62.5%); the Acidic lead buff drains in 10 shots (21.7%).
 >
 > **The decode gap this exposed:** the Berserker Brew / Acidic Mixture Dip buff is **projectile-applied**
 > (it lives inside the `BeserkerBrewAttack` / `AcidicMixture` weapon's projectile), so the top-level
-> `_buffs()` support-model walker **never saw it** — the Alchemist has *zero* committed buffs. Added
-> `parse_gamedata._buff_window()`: for those named buff-throwing attacks it reads the buff
-> **duration** (frame fields ÷60, like `_BUFF_FRAME_FIELDS`) + **attack-cap** off the projectile's
-> behaviors (excluding the `Travel*Model` flight-time `lifespan`, the 0.6s false-positive) → emits
+> `_buffs()` support-model walker **never saw it** — the Alchemist had *zero* committed buffs.
+> `parse_gamedata._buff_window()` now reads it off the buff-applying projectile and emits
 > `buff_duration` / `buff_attack_cap` / `buff_permanent` on the attack node.
 >
-> **⚠️ OPEN — one binding step (Q-0105, no live dump in-repo to verify against):** the exact
-> dump field names for the projectile buff window are a **candidate set** (`_BUFF_DURATION_*` /
-> `_BUFF_ATTACK_CAP_FIELDS` in `parse_gamedata.py`). The decode *logic* is fixture-tested; the live
-> *binding* is unconfirmed. **Next dump run:** `--dump <clone> --tower alchemist --dry-run` and
-> confirm `buff_duration`/`buff_attack_cap` appear; `--audit` them against the verified wiki windows
-> below. If a candidate name never matches, read the real field off the dry-run and add it (then
-> delete the dead candidates). Until then `btd6_buff_uptime` honestly returns `found=false` with the
-> cadence + target speed it *does* know.
+> **✅ VERIFIED against the live dump (PR #1249).** #1235's first cut guessed the field names; #1249
+> cloned the public BTD Mod Helper dump (`Btd6ModHelper/btd6-game-data`) and corrected them. The real
+> applier is **`Add{BerserkerBrew,AcidicMixture}ToProjectileModel`** on the projectile:
+> `lifespan` (**seconds** — `lifespanFrames` is 0/unused; `-1` = Permanent-Brew sentinel; ABSENT on the
+> lead buff = attack-cap-only), nested **`…CheckModel.maxCount`** (cap; `9999999` = permanent sentinel),
+> and `rebuffBlockTime` (per-target re-buff cooldown, 5s @ 4-0-0 — decoded-available, not yet a calc
+> input). The committed `stats/alchemist.json` is **populated** (surgical buff-field overlay, no value
+> churn / no version bump; idempotent — the next `--all` reproduces it), so `btd6_buff_uptime` answers
+> live. The dump is **public + clonable** (`git clone --depth 1 https://github.com/Btd6ModHelper/btd6-game-data`)
+> — there is no "no dump in-repo" excuse; clone it to re-verify.
 >
-> **Verified windows (Bloons-wiki cross-check — the `--audit` target):** Acidic Mixture Dip 2-0-0
+> **Verified windows (game-data == Bloons-wiki cross-check):** Acidic Mixture Dip 2-0-0
 > = **10 shots** (12 @ 2-2-0); Berserker Brew 3-0-0 = **5s / 25 attacks**, 3-2-0 = 6s/40; Stronger
 > Stimulant 4-0-0 = **12s / 40 attacks**, 4-2-0 = 13s/55; Permanent Brew 5-0-0 = permanent. Throw
 > cadence (already committed): `BeserkerBrewAttack.rate` 8s (6.4s with Faster Throwing x-0-1/2).

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,11 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/peaceful-mayer-rgc20t` · **BTD6 buff-uptime — verify binding + populate data** (follow-up to
+  #1235; owner pointed at the public dump) — cloned BTD Mod Helper dump, corrected `_buff_window` to
+  the verified `Add…ToProjectileModel` shape, overlaid buff fields onto committed `alchemist.json` ·
+  `scripts/parse_gamedata.py` / `disbot/data/btd6/stats/alchemist.json` / `btd6_upgrade_detail_service`
+  · 2026-06-21 · **PR (this session, auto-merge on green)**
 - `claude/dispatch-next` · **prune stale Active claims (drift-on-sight, Q-0166)** — every prior
   claim had merged, polluting `check_lane_overlap.py` with false positives · `docs/owner/active-work.md`
   · 2026-06-21 · **auto-merge on green** (docs-only)

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -402,97 +402,97 @@ def _eject(weapon: dict) -> str | None:
 # emitted; this decodes the *window* (``buff_duration`` seconds + ``buff_attack_cap``)
 # off the buff-applying projectile so ``btd6_buff_uptime`` can ground an uptime.
 #
-# UNVERIFIED — Q-0105 reliability note (2026-06-21): the exact buff-applying
-# model class + field names are not confirmable without a live dump in-repo, so
-# the field names below are a documented *candidate set* spanning the dump's known
-# conventions (frame counts ÷60 → seconds, like ``_BUFF_FRAME_FIELDS``). The
-# decode LOGIC is fixture-tested; the live BINDING is confirmed on the next
-# ``--all`` run via ``--audit`` against the verified wiki windows (Berserker Brew
-# 3-0-0 = 5 s / 25 attacks, Stronger Stimulant 4-0-0 = 12 s / 40, Acidic Mixture
-# Dip 2-0-0 = 10 shots). If a name here never matches a real dump, delete it.
+# VERIFIED against the live dump (2026-06-21, Alchemist-{200,300,320,400,420,500}):
+# the buff applier is ``Add{BerserkerBrew,AcidicMixture}ToProjectileModel`` on the
+# thrown projectile —
+#   * ``lifespan`` — the time window in SECONDS (``lifespanFrames`` is 0, unused);
+#     ``-1`` is the Permanent-Brew "never expires" sentinel; ABSENT on the Acidic
+#     Mixture Dip lead buff (it is attack-cap-only, no time limit).
+#   * nested ``…CheckModel.maxCount`` — the attack-count cap; ``9999999`` is the
+#     permanent / no-limit sentinel.
+#   * ``rebuffBlockTime`` (seconds) — the per-target re-buff cooldown (5 s @
+#     4-0-0); left undecoded for now (a future ``btd6_buff_uptime`` input).
+# Decoded values match the wiki cross-check exactly: Berserker Brew 300 = 5 s/25,
+# 320 = 6 s/40, Stronger Stimulant 400 = 12 s/40, 420 = 13 s/55, Permanent Brew
+# 500 = permanent; Acidic Mixture Dip cap 10 (12 @ x-2-x).
 _BUFF_WINDOW_ATTACK_NAMES: frozenset[str] = frozenset(
     {"BeserkerBrewAttack", "AcidicMixture"},
 )
-_BUFF_DURATION_FRAME_FIELDS: tuple[str, ...] = (
-    "lifespanFrames",
-    "buffTimeFrames",
-    "durationFrames",
-)
-_BUFF_DURATION_SECOND_FIELDS: tuple[str, ...] = ("buffTime", "buffLifespan", "duration")
-_BUFF_ATTACK_CAP_FIELDS: tuple[str, ...] = (
-    "attackCap",
-    "attacksToExpire",
-    "numberOfAttacks",
-    "attackLimit",
-    "numUses",
-    "maxUses",
-    "usesToExpire",
-)
+# A lifespan/maxCount at or above this is the dump's "permanent / no limit"
+# sentinel (Permanent Brew emits lifespan -1 + maxCount 9999999).
+_BUFF_NO_LIMIT_SENTINEL = 1_000_000
 
 
-def _iter_buff_behaviors(attack: dict):
-    """Yield raw behavior dicts from a buff-throwing attack's projectile tree.
+def _buff_applier(attack: dict) -> dict | None:
+    """The ``Add…ToProjectileModel`` that applies the buff, off a buff-throwing
+    attack's weapon projectile, or ``None``.
 
-    Excludes ``Travel*Model`` behaviors — their ``lifespan`` is the projectile's
-    flight time (~0.6 s), NOT the buff window, and would be a false positive.
+    This is the verified carrier of the buff's ``lifespan`` + nested ``maxCount``
+    — NOT the projectile's ``Travel*Model`` (whose ``lifespan`` is flight time).
     """
-    stack: list[dict] = []
     for w in attack.get("weapons", []) or []:
-        if isinstance(w, dict) and isinstance(w.get("projectile"), dict):
-            stack.append(w["projectile"])
-    seen = 0
-    while stack and seen < 200:
-        node = stack.pop()
-        seen += 1
-        if not isinstance(node, dict):
+        if not isinstance(w, dict):
             continue
-        for b in node.get("behaviors", []) or []:
-            if not isinstance(b, dict):
-                continue
-            if _short_type(b).startswith("Travel"):
-                continue
-            yield b
-            for child in _spawned_projectiles(b):
-                if isinstance(child, dict):
-                    stack.append(child)
+        proj = w.get("projectile")
+        if not isinstance(proj, dict):
+            continue
+        for b in proj.get("behaviors", []) or []:
+            if isinstance(b, dict):
+                short = _short_type(b)
+                if short.startswith("Add") and short.endswith("ToProjectileModel"):
+                    return b
+    return None
+
+
+def _deep_find_number(node: Any, key: str) -> float | None:
+    """First numeric ``key`` anywhere in ``node``'s subtree.
+
+    The attack cap (``maxCount``) lives in a nested ``…CheckModel``, not directly
+    on the applier, so a flat read misses it.
+    """
+    if isinstance(node, dict):
+        value = node.get(key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+        for child in node.values():
+            found = _deep_find_number(child, key)
+            if found is not None:
+                return found
+    elif isinstance(node, list):
+        for child in node:
+            found = _deep_find_number(child, key)
+            if found is not None:
+                return found
+    return None
 
 
 def _buff_window(attack: dict) -> tuple[float | None, int | None, bool]:
     """``(buff_duration_seconds, buff_attack_cap, permanent)`` off a buff attack.
 
-    A negative duration is the dump's "never expires" sentinel (Permanent Brew) →
-    ``permanent=True`` with no numeric duration. Returns ``(None, None, False)``
-    when no candidate field matches (so the window simply stays undecoded — never
-    a fabricated number).
+    Permanent Brew (lifespan ``-1`` / maxCount ``9999999``) → ``permanent=True``
+    with no numeric duration/cap. The Acidic Mixture Dip lead buff has no
+    ``lifespan`` → cap-only. ``(None, None, False)`` when no applier is present.
     """
-    duration: float | None = None
-    cap: int | None = None
+    applier = _buff_applier(attack)
+    if applier is None:
+        return None, None, False
     permanent = False
-    for b in _iter_buff_behaviors(attack):
-        if duration is None and not permanent:
-            for f in _BUFF_DURATION_FRAME_FIELDS:
-                v = b.get(f)
-                if isinstance(v, (int, float)) and not isinstance(v, bool):
-                    if v < 0:
-                        permanent = True
-                    else:
-                        duration = _num(v / 60.0)
-                    break
-        if duration is None and not permanent:
-            for f in _BUFF_DURATION_SECOND_FIELDS:
-                v = b.get(f)
-                if isinstance(v, (int, float)) and not isinstance(v, bool):
-                    if v < 0:
-                        permanent = True
-                    else:
-                        duration = _num(v)
-                    break
-        if cap is None:
-            for f in _BUFF_ATTACK_CAP_FIELDS:
-                v = b.get(f)
-                if isinstance(v, (int, float)) and not isinstance(v, bool) and v > 0:
-                    cap = int(v)
-                    break
+    duration: float | None = None
+    lifespan = applier.get("lifespan")
+    if isinstance(lifespan, (int, float)) and not isinstance(lifespan, bool):
+        if lifespan < 0:
+            permanent = True
+        elif lifespan > 0:
+            duration = _num(lifespan)
+    cap: int | None = None
+    max_count = _deep_find_number(applier, "maxCount")
+    if max_count is not None:
+        if max_count >= _BUFF_NO_LIMIT_SENTINEL:
+            # No cap (permanent) — and if there is also no time window, the buff
+            # itself is permanent.
+            permanent = permanent or duration is None
+        elif max_count > 0:
+            cap = int(max_count)
     return duration, cap, permanent
 
 

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -2860,16 +2860,24 @@ def test_farm_income_extraction(mod, tmp_path):
 # --- buff window (Alchemist-style dual limit: time OR attack cap) ------------
 
 
-def _buff_projectile(*, frames=None, seconds=None, cap=None) -> dict:
-    """A buff-applying projectile: a Travel model (flight-time ``lifespan`` that
-    must be IGNORED) + a buff behavior carrying the window fields the decoder reads."""
-    buff: dict = {"$type": _t("AddBehaviorToTowerModel"), "name": "BuffModel_"}
-    if frames is not None:
-        buff["lifespanFrames"] = frames
-    if seconds is not None:
-        buff["buffTime"] = seconds
+def _buff_projectile(*, lifespan=None, cap=None) -> dict:
+    """A buff-applying projectile mirroring the real dump shape: a Travel model
+    (flight-time ``lifespan`` that must be IGNORED) + an ``Add…ToProjectileModel``
+    whose ``lifespan`` is the buff window (seconds) and whose **nested**
+    ``…CheckModel.maxCount`` is the attack cap (verified against Alchemist-400)."""
+    applier: dict = {
+        "$type": _t("AddBerserkerBrewToProjectileModel"),
+        "name": "AddBerserkerBrewToProjectileModel_",
+    }
+    if lifespan is not None:
+        applier["lifespan"] = lifespan
+        applier["lifespanFrames"] = 0  # real dump: frames unused, seconds authoritative
+        applier["rebuffBlockTime"] = 5.0
     if cap is not None:
-        buff["attackCap"] = cap
+        applier["checkModel"] = {
+            "$type": _t("BerserkerBrewCheckModel"),
+            "maxCount": cap,  # nested, NOT on the applier directly
+        }
     return {
         "$type": _t("ProjectileModel"),
         "id": "Projectile",
@@ -2877,40 +2885,43 @@ def _buff_projectile(*, frames=None, seconds=None, cap=None) -> dict:
         "pierce": 1.0,
         "behaviors": [
             {"$type": _t("TravelStraitModel"), "speed": 300.0, "lifespan": 0.6},
-            buff,
+            applier,
         ],
     }
 
 
-def test_buff_window_decodes_frames_and_attack_cap(mod):
-    # Stronger Stimulant shape: 720 frames (=12 s) OR 40 attacks. The projectile's
-    # travel lifespan (0.6 s flight time) must NOT be mistaken for the buff window.
-    attack = _attack(_buff_projectile(frames=720, cap=40), name="BeserkerBrewAttack")
+def test_buff_window_decodes_seconds_and_nested_cap(mod):
+    # Stronger Stimulant shape: lifespan 12 s (seconds, not frames) OR 40 attacks
+    # (nested in a CheckModel). The projectile's travel lifespan (0.6 s flight
+    # time) must NOT be mistaken for the buff window.
+    attack = _attack(_buff_projectile(lifespan=12.0, cap=40), name="BeserkerBrewAttack")
     out = mod._clean_attack(attack, 0)
     assert out["name"] == "BeserkerBrewAttack"
     assert out["buff_duration"] == 12.0
     assert out["buff_attack_cap"] == 40
 
 
-def test_buff_window_accepts_seconds_fields(mod):
-    attack = _attack(_buff_projectile(seconds=5.0, cap=25), name="AcidicMixture")
+def test_buff_window_lead_buff_is_cap_only(mod):
+    # Acidic Mixture Dip: no lifespan (attack-cap-only), cap 10.
+    attack = _attack(_buff_projectile(cap=10), name="AcidicMixture")
     out = mod._clean_attack(attack, 0)
-    assert out["buff_duration"] == 5.0
-    assert out["buff_attack_cap"] == 25
+    assert out["buff_attack_cap"] == 10
+    assert "buff_duration" not in out
 
 
-def test_buff_window_negative_duration_is_permanent(mod):
-    # Permanent Brew sentinel: a negative lifespan means "never expires".
-    attack = _attack(_buff_projectile(frames=-1), name="BeserkerBrewAttack")
+def test_buff_window_permanent_sentinels(mod):
+    # Permanent Brew: lifespan -1 + maxCount 9999999 → permanent, no numbers.
+    attack = _attack(_buff_projectile(lifespan=-1.0, cap=9999999), name="BeserkerBrewAttack")
     out = mod._clean_attack(attack, 0)
     assert out.get("buff_permanent") is True
     assert "buff_duration" not in out
+    assert "buff_attack_cap" not in out
 
 
 def test_buff_window_only_decoded_for_buff_attacks(mod):
     # An ordinary attack with the same fields present must NOT gain buff_* keys —
     # the decode is scoped to the named buff-throwing attacks.
-    attack = _attack(_buff_projectile(frames=720, cap=40), name="Attack")
+    attack = _attack(_buff_projectile(lifespan=12.0, cap=40), name="Attack")
     out = mod._clean_attack(attack, 0)
     assert "buff_duration" not in out
     assert "buff_attack_cap" not in out

--- a/tests/unit/services/test_btd6_upgrade_detail_service.py
+++ b/tests/unit/services/test_btd6_upgrade_detail_service.py
@@ -624,14 +624,27 @@ def test_buff_uptime_permanent_brew_is_full_uptime(monkeypatch):
     assert res["uptime"] == 1.0
 
 
-def test_buff_uptime_honest_when_window_not_decoded():
-    # The live data has no buff window yet: don't fabricate one. Say what IS
-    # known (throw cadence + target attack speed) and name the fix.
+def test_buff_uptime_honest_when_window_not_decoded(monkeypatch):
+    # Defensive: if a buff attack ever lacks a decoded window (cadence known, but
+    # no duration/cap/permanent), don't fabricate — say what IS known (throw
+    # cadence + target attack speed) and never emit an uptime.
+    real = det._alch_buff_attack
+
+    def windowless(tower_id, code):
+        node = real(tower_id, code)
+        if node is None:
+            return None
+        node = dict(node)
+        for k in ("buff_duration", "buff_attack_cap", "buff_permanent"):
+            node.pop(k, None)
+        return node
+
+    monkeypatch.setattr(det, "_alch_buff_attack", windowless)
     res = det.buff_uptime("Stronger Stimulant", "Grandmaster Ninja")
     assert res["found"] is False
     assert res["buff"] == "Berserker Brew"
-    assert "8.0s" in res["note"]  # throw cadence is in the data
-    assert "0.217" in res["note"]  # target attack speed is in the data
+    assert "8.0s" in res["note"]  # throw cadence still surfaced
+    assert "0.217" in res["note"]  # target attack speed still surfaced
     assert "uptime" not in res
 
 
@@ -653,3 +666,47 @@ def test_buff_uptime_tier_without_a_buff_throw_is_honest():
     res = det.buff_uptime("Alchemist", "Dart Monkey")
     assert res["found"] is False
     assert "no buff throw" in res["note"]
+
+
+# --- buff_uptime on the REAL committed data (no injection) -------------------
+# The buff window (duration + attack cap) is now decoded into stats/alchemist.json
+# from the game-data dump, so these resolve end to end without monkeypatching.
+
+
+def test_buff_uptime_real_data_stronger_stimulant_on_ninja():
+    # The owner's live-test question, fully grounded: 4-0-0 = 12s / 40 attacks; a
+    # 5-0-0 Ninja (0.217s) burns the cap in ~8.7s → attack-cap-limited, 100%.
+    res = det.buff_uptime("alchemist 4-0-0", "ninja 5-0-0")
+    assert res["found"] is True
+    assert res["buff"] == "Berserker Brew"
+    assert res["buff_duration_seconds"] == 12.0
+    assert res["buff_attack_cap"] == 40
+    assert res["limiter"] == "attacks"
+    assert res["uptime_percent"] == 100.0
+
+
+def test_buff_uptime_real_data_base_brew_is_time_limited_on_ninja():
+    # Base Berserker Brew (3-0-0) = 5s / 25: a Ninja makes only ~23 attacks in 5s,
+    # so TIME binds (not the cap), and thrown every 8s it is NOT continuous.
+    res = det.buff_uptime("alchemist 3-0-0", "ninja 5-0-0")
+    assert res["found"] is True
+    assert res["buff_duration_seconds"] == 5.0
+    assert res["limiter"] == "time"
+    assert res["uptime_percent"] < 100.0
+
+
+def test_buff_uptime_real_data_permanent_brew():
+    res = det.buff_uptime("Permanent Brew", "ninja 5-0-0")
+    assert res["found"] is True
+    assert res["limiter"] == "permanent"
+    assert res["uptime"] == 1.0
+
+
+def test_buff_uptime_real_data_lead_buff_is_cap_limited():
+    # Acidic Mixture Dip = 10 shots, no time limit → cap-limited on any tower.
+    res = det.buff_uptime("Acidic Mixture Dip", "ninja 5-0-0")
+    assert res["found"] is True
+    assert res["buff"] == "Acidic Mixture Dip"
+    assert res["buff_attack_cap"] == 10
+    assert res["limiter"] == "attacks"
+    assert "buff_duration_seconds" not in res  # lead buff has no time window


### PR DESCRIPTION
## Why

Follow-up to #1235 (Alchemist buff-uptime calculator). That PR shipped the parser's buff-window decode as an **unverified candidate field-set** (no dump was vendored) and left data population as an owner manual step. The owner pointed out the dump is the **public BTD Mod Helper repo** — clonable — so I cloned it and verified against the real game data.

**Finding:** my shipped candidate field names were **wrong** — they'd have extracted nothing. The real buff applier is `Add{BerserkerBrew,AcidicMixture}ToProjectileModel` on the thrown projectile:
- `lifespan` — the time window in **seconds** (`lifespanFrames` is 0/unused); `-1` = Permanent-Brew sentinel; **absent** on the Acidic Mixture Dip lead buff (attack-cap-only).
- nested `…CheckModel.maxCount` — the attack cap; `9999999` = permanent sentinel.

Decoded values match the wiki cross-check **exactly**: Berserker Brew 300 = 5s/25, 320 = 6s/40, Stronger Stimulant 400 = 12s/40, 420 = 13s/55, Permanent Brew 500 = permanent; Acidic Mixture Dip cap 10 (12 @ x-2-x).

## What

1. **Parser** — rewrote `_buff_window` to the verified `Add…ToProjectileModel` structure (`lifespan` seconds + nested `maxCount`, permanent sentinels); dry-run against the real dump matches the wiki across all tiers + crosspaths.
2. **Data populated** — surgical overlay of `buff_duration` / `buff_attack_cap` / `buff_permanent` onto the committed `stats/alchemist.json` (**buff fields only, zero value churn, no version bump**; idempotent with the parser so the next `--all` reproduces it). The bot now answers **live**.
3. **Calc polish** + real-data test; fixture tests updated to the real model shape; decode-status marked VERIFIED and the owner manual-step caveat dropped.

The bot now grounds, on real data: 4-0-0 on a 5-0-0 Ninja = attack-cap-limited, 100% uptime; base 3-0-0 = 62.5% (time-limited); Acidic Mixture Dip = 21.7% (drains in 10 shots).

## Status

Opened **born-red** (session card `in-progress`); flips to `complete` last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAfgtUqA1bzZ3gsSrFwaw8

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAfgtUqA1bzZ3gsSrFwaw8)_