### PR TITLE
Reaction roles: auto-heal dead bindings on the reaction listener path

### DIFF
--- a/.sessions/2026-06-21-reaction-roles-self-heal.md
+++ b/.sessions/2026-06-21-reaction-roles-self-heal.md
@@ -1,26 +1,90 @@
 # 2026-06-21 — Reaction roles: listener self-heal for dead bindings
 
-> **Status:** `in-progress` — born-red HOLD (Q-0133). Owner-accepted continuation (offered at #1248
-> close; owner said "continue"). Q-0191 → merge on green. Fresh branch.
+> **Status:** `complete` — owner-accepted continuation of #1248 (offered at its close; "continue").
+> Q-0191 → merge on green. PR #1250.
 
 > **Run type:** `manual`
 
-## What I'm about to do
+## Arc
 
-The #1248 manual 🧹 Clean up button removes bindings whose role was deleted. This makes that cleanup
+#1248 added a manual 🧹 Clean up button for bindings whose role was deleted. This makes that cleanup
 **automatic**: when a member reacts (or un-reacts) on a binding whose role no longer resolves, the
-binding is removed on the spot, so dead config self-heals without anyone opening the panel.
+binding is removed on the spot — dead config self-heals without anyone opening the panel.
 
-- `services/reaction_role_service.py` — `_self_heal_dead_binding(guild, message_id, emoji, role_id)`
-  removes a binding whose role is gone (audited as a **`system`** action) and is called early in
-  `handle_reaction_add` / `handle_reaction_remove`. Threaded an `actor_type` param through
-  `unbind_emoji` / `_emit` so the automatic cleanup is distinguishable from an operator removal.
-  Safe because discord.py fully caches roles → `resolve_role` returning `None` means genuinely deleted.
+- `services/reaction_role_service.py`:
+  - `_self_heal_dead_binding(guild, message_id, emoji, role_id)` — removes a dead-role binding, audited
+    as a **`system`** action; called early in `handle_reaction_add` / `handle_reaction_remove` (before
+    the mode logic, so a dead binding never reaches `_apply`).
+  - threaded an `actor_type` param through `unbind_emoji` / `_emit` (default `"admin"`; self-heal passes
+    `"system"`) so automatic cleanup is distinguishable from an operator removal in the audit stream.
 
-## Note (owner clarification, this session)
+## Findings / decisions
 
-Corrected my own framing: Railway has **always** auto-deployed `worker` on merge — the recent change
-(Q-0193 / #1247) was only *removing the wrong "merge ≠ deploy" line from CLAUDE.md*, not a behaviour
-change. Merged = deployed. (No "restart it yourself" guidance.)
+- **Decision made alone — safe to auto-delete here.** Auto-removing config is normally risky, but a
+  binding to a *deleted role* can never assign anything, and discord.py **fully caches guild roles**
+  (unlike members), so `resolve_role` returning `None` means genuinely deleted, not a transient cache
+  miss. So the self-heal won't wrongly drop a live binding. The manual 🧹 button (#1248) remains for
+  bindings on messages that never get reacted on.
+- **Decision made alone — audit as `system`, not `admin`.** An automatic cleanup has no human actor;
+  threading `actor_type` keeps the audit honest (`actor_id=None`, `actor_type="system"`) and required
+  only a small, backward-compatible param on `unbind_emoji`/`_emit`.
+- **Process note:** the early born-red PR (Q-0189) slipped this run — an owner message (the deploy
+  clarification) interrupted right as the build started, so the card/PR went up after the code was
+  written. No partial-merge risk (everything pushed together, born-red still held the merge).
 
-Verify: `check_quality.py --full` + `check_architecture.py --mode strict`.
+## Context delta
+
+- **Needed but not pointed to:** the fact that **discord.py caches roles fully** (so `resolve_role`
+  None ⇒ deleted) is the safety linchpin for auto-deleting dead bindings — it's not written down
+  anywhere; I relied on library knowledge. Worth a one-line note wherever role-resolution is documented.
+- **Discovered by hand:** the existing `handle_reaction` tests' fake `_Guild` had no `get_role`, so the
+  new `resolve_role` call broke them — the fake had to gain a (configurable) `get_role`. A test fake
+  that omits a method the production path now calls is a quiet trap.
+- **Decisions made alone:** auto-delete-is-safe-here; audit-as-system (see Findings).
+- **Weak point / unverified:** not live-walked — the self-heal only fires on a real reaction to a
+  dead binding; unit-tested with mocks (resolve→None path), but the live gateway round-trip is unverified.
+- **One docs/tooling change that would help:** still the modal-first-response rule for
+  `discord-views.md` (carried; owner-governed, needs a router Q-block) — and a note that discord.py
+  roles are fully cached.
+
+## 📤 Run report
+
+- **Did:** automatic dead-binding self-heal on the reaction listener path · **Outcome:** shipped
+  (PR #1250, auto-merge on green)
+- **Shipped:** #1250 — reaction-roles listener self-heal
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none — **merged = deployed** (Railway auto-deploys `worker` on merge; this
+  has always been true — the old "merge ≠ deploy" CLAUDE.md line was wrong and was removed in #1247).
+- **⚑ Self-initiated:** continuation I offered at #1248 close; owner greenlit via "continue".
+- **↪ Next:** reaction-roles is complete *and* self-healing (manual + automatic). No further
+  reaction-roles work queued; the open cross-cutting item is the modal-first-response docs rule.
+
+## 💡 Session idea
+
+**Persist the "merged = deployed" fact where sessions actually read it at the moment they'd misstate
+it.** Q-0193 fixed CLAUDE.md, but the misinformation persisted for *months* because each session
+re-derived "you should deploy" at PR-close time. A tiny Stop-hook / `/session-close` line — "never
+tell the maintainer to deploy/restart; merge auto-deploys (Q-0193)" — would catch the misstatement at
+the exact point it's made, not just in a doc someone has to recall. (Dedup-checked — Q-0193 fixed the
+doc; this is about the *reminder surface*.)
+
+## ⟲ Previous-session review
+
+The #1248 session correctly chose the *actionable* cleanup over a read-only audit (good call, owner
+confirmed). What this session exposed about the chain: I repeatedly told the owner "merge ≠ deploy,
+restart is yours" — wrong, and the owner had to correct me. The root (a wrong CLAUDE.md line) was
+fixed in #1247, but my messaging lagged the fix. **System improvement (this run's idea):** put the
+"merged = deployed" reminder on the session-close surface, not only in a doc — recurring
+misinformation needs a reminder at the point of utterance, which is exactly the kind of "improve the
+workflow so the next agent gets it right" the project values.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 0 (pending #1250, auto-merge on green) |
+| CI-red rounds | 0 real (born-red HOLD only, by design) |
+| Repo-rule trips | 1 (early-PR mandate slipped due to an owner-message interrupt — noted) |
+| New ideas contributed | 1 (merged=deployed reminder on the close surface) |
+| Ideas groomed | 1 (built the #1248 listener-self-heal idea) |

--- a/.sessions/2026-06-21-reaction-roles-self-heal.md
+++ b/.sessions/2026-06-21-reaction-roles-self-heal.md
@@ -1,0 +1,26 @@
+# 2026-06-21 — Reaction roles: listener self-heal for dead bindings
+
+> **Status:** `in-progress` — born-red HOLD (Q-0133). Owner-accepted continuation (offered at #1248
+> close; owner said "continue"). Q-0191 → merge on green. Fresh branch.
+
+> **Run type:** `manual`
+
+## What I'm about to do
+
+The #1248 manual 🧹 Clean up button removes bindings whose role was deleted. This makes that cleanup
+**automatic**: when a member reacts (or un-reacts) on a binding whose role no longer resolves, the
+binding is removed on the spot, so dead config self-heals without anyone opening the panel.
+
+- `services/reaction_role_service.py` — `_self_heal_dead_binding(guild, message_id, emoji, role_id)`
+  removes a binding whose role is gone (audited as a **`system`** action) and is called early in
+  `handle_reaction_add` / `handle_reaction_remove`. Threaded an `actor_type` param through
+  `unbind_emoji` / `_emit` so the automatic cleanup is distinguishable from an operator removal.
+  Safe because discord.py fully caches roles → `resolve_role` returning `None` means genuinely deleted.
+
+## Note (owner clarification, this session)
+
+Corrected my own framing: Railway has **always** auto-deployed `worker` on merge — the recent change
+(Q-0193 / #1247) was only *removing the wrong "merge ≠ deploy" line from CLAUDE.md*, not a behaviour
+change. Merged = deployed. (No "restart it yourself" guidance.)
+
+Verify: `check_quality.py --full` + `check_architecture.py --mode strict`.

--- a/disbot/services/reaction_role_service.py
+++ b/disbot/services/reaction_role_service.py
@@ -69,8 +69,14 @@ async def unbind_emoji(
     emoji: str,
     *,
     actor_id: int | None,
+    actor_type: str = "admin",
 ) -> None:
-    """Remove an emoji → role binding from a message (audited)."""
+    """Remove an emoji → role binding from a message (audited).
+
+    ``actor_type`` defaults to ``"admin"`` (an operator removal); the listener
+    self-heal passes ``"system"`` so an automatic dead-binding cleanup is
+    distinguishable in the audit stream.
+    """
     prev_role = await db.get_reaction_role(guild_id, message_id, emoji)
     await db.remove_reaction_role(guild_id, message_id, emoji)
     await _emit(
@@ -80,6 +86,7 @@ async def unbind_emoji(
         prev_value=f"message={message_id},emoji={emoji}",
         new_value=None,
         actor_id=actor_id,
+        actor_type=actor_type,
     )
 
 
@@ -222,6 +229,8 @@ async def handle_reaction_add(
         return None, False
     if not await reaction_roles_enabled(guild.id):
         return None, False
+    if await _self_heal_dead_binding(guild, message_id, emoji, role_id):
+        return None, False
     mode = await db.get_reaction_message_mode(guild.id, message_id)
     if mode == "unique":
         siblings = await _held_sibling_reaction_roles(
@@ -268,10 +277,35 @@ async def handle_reaction_remove(
         return None
     if not await reaction_roles_enabled(guild.id):
         return None
+    if await _self_heal_dead_binding(guild, message_id, emoji, role_id):
+        return None
     mode = await db.get_reaction_message_mode(guild.id, message_id)
     if mode == "verify":
         return None
     return await _apply(member, to_add=(), to_remove=(role_id,), guild=guild)
+
+
+async def _self_heal_dead_binding(
+    guild: discord.Guild,
+    message_id: int,
+    emoji: str,
+    role_id: int,
+) -> bool:
+    """Drop a binding whose role was deleted, the moment a member reacts on it.
+
+    A binding to a deleted role can never assign anything, so the first reaction
+    that hits it is a definitive signal it is dead — remove it (audited as a
+    ``system`` action) so dead config self-heals without an operator opening the
+    panel (the manual 🧹 Clean up button covers the rest). Roles are fully cached
+    in discord.py, so ``resolve_role`` returning ``None`` means genuinely deleted,
+    not a transient cache miss.
+    """
+    from core.runtime import resources
+
+    if resources.resolve_role(guild, role_id=role_id) is not None:
+        return False
+    await unbind_emoji(guild.id, message_id, emoji, actor_id=None, actor_type="system")
+    return True
 
 
 async def _held_sibling_reaction_roles(
@@ -824,6 +858,7 @@ async def _emit(
     prev_value: str | None,
     new_value: str | None,
     actor_id: int | None,
+    actor_type: str = "admin",
 ) -> None:
     """Emit ``audit.action_recorded`` for a reaction-role config mutation."""
     from services.audit_events import emit_audit_action
@@ -838,7 +873,7 @@ async def _emit(
         prev_value=prev_value,
         new_value=new_value,
         actor_id=actor_id,
-        actor_type="admin",
+        actor_type=actor_type,
         occurred_at=datetime.now(tz=timezone.utc),
     )
 

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,11 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/reaction-roles-self-heal` · **reaction-roles listener self-heal** (owner-accepted
+  continuation) — auto-remove a dead-role binding when reacted on (`_self_heal_dead_binding` +
+  `actor_type` thread) · `disbot/services/reaction_role_service.py` · 2026-06-21 ·
+  **PR (this session, merge on green)**
+
 - `claude/dispatch-next` · **prune stale Active claims (drift-on-sight, Q-0166)** — every prior
   claim had merged, polluting `check_lane_overlap.py` with false positives · `docs/owner/active-work.md`
   · 2026-06-21 · **auto-merge on green** (docs-only)

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,11 +25,6 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/reaction-roles-self-heal` · **reaction-roles listener self-heal** (owner-accepted
-  continuation) — auto-remove a dead-role binding when reacted on (`_self_heal_dead_binding` +
-  `actor_type` thread) · `disbot/services/reaction_role_service.py` · 2026-06-21 ·
-  **PR (this session, merge on green)**
-
 - `claude/dispatch-next` · **prune stale Active claims (drift-on-sight, Q-0166)** — every prior
   claim had merged, polluting `check_lane_overlap.py` with false positives · `docs/owner/active-work.md`
   · 2026-06-21 · **auto-merge on green** (docs-only)
@@ -49,6 +44,10 @@ session holds it, no claim line needed here.)*
 
 ## Recently cleared
 
+- `claude/reaction-roles-self-heal` · **reaction-roles listener self-heal** (owner-accepted
+  continuation) — auto-remove a dead-role binding when reacted on (`_self_heal_dead_binding` +
+  `actor_type` thread, audited as `system`) · `disbot/services/reaction_role_service.py` · 2026-06-21 ·
+  **PR #1250 (merge on green)**
 - `claude/reaction-roles-cleanup` · **reaction-roles dead-binding cleanup** (owner-directed,
   screenshots) — 🧹 Clean up button + `prune_dead_bindings` (+ panel hint) to remove bindings whose
   role was deleted · `disbot/services/reaction_role_service.py` + `disbot/views/roles/reaction_panel.py`

--- a/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
+++ b/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
@@ -65,6 +65,13 @@
 > creation-side cause was fixed in #1234; this clears rows already left behind. (The Add-modal
 > `💀 ❤️ 😘` placeholder is an intended multi-emote preview and stays.)
 >
+> **▶ Refinement (2026-06-21 — PR #1250):** **listener self-heal** makes #1248's cleanup automatic —
+> `reaction_role_service._self_heal_dead_binding` drops a binding whose role was deleted the moment a
+> member reacts (or un-reacts) on it, audited as a **`system`** action (an `actor_type` param was
+> threaded through `unbind_emoji`/`_emit`). Called early in `handle_reaction_add`/`handle_reaction_remove`;
+> safe because discord.py fully caches roles (a `None` resolve = genuinely deleted). The manual 🧹 button
+> still covers bindings on messages that never get reacted on.
+>
 > **One-line goal:** bring SuperBot's self-assignable-role surface to **parity-plus** with
 > Carl-bot — lead with native **buttons + dropdown menus** (Carl's are a secondary/premium
 > add; emoji reactions are its core), keep emoji reaction-roles working for compatibility,

--- a/tests/unit/services/test_reaction_role_service.py
+++ b/tests/unit/services/test_reaction_role_service.py
@@ -115,8 +115,16 @@ class _Member:
 
 
 class _Guild:
-    def __init__(self, gid: int = 1) -> None:
+    def __init__(self, gid: int = 1, *, live_roles: set[int] | None = None) -> None:
         self.id = gid
+        # ``None`` → every role resolves (the default for the assignment tests, so
+        # the dead-binding self-heal never fires); a set → only those ids resolve.
+        self._live_roles = live_roles
+
+    def get_role(self, rid: int) -> _Role | None:
+        if self._live_roles is None or rid in self._live_roles:
+            return _Role(rid)
+        return None
 
 
 def _enabled(value: bool = True) -> AsyncMock:
@@ -395,3 +403,57 @@ async def test_count_dead_bindings():
         patch("core.runtime.resources.resolve_role", side_effect=_resolve_only(10)),
     ):
         assert await rrs.count_dead_bindings(_Guild(1)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Listener self-heal — a reaction on a binding whose role was deleted drops it
+# automatically (owner idea, 2026-06-21).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_self_heal_removes_binding_when_role_deleted():
+    guild = _Guild(1, live_roles=set())  # role 42 no longer exists
+    with patch.object(rrs, "unbind_emoji", new=AsyncMock()) as unbind:
+        healed = await rrs._self_heal_dead_binding(guild, 555, "💀", 42)
+    assert healed is True
+    unbind.assert_awaited_once_with(1, 555, "💀", actor_id=None, actor_type="system")
+
+
+@pytest.mark.asyncio
+async def test_self_heal_keeps_binding_when_role_live():
+    guild = _Guild(1, live_roles={42})
+    with patch.object(rrs, "unbind_emoji", new=AsyncMock()) as unbind:
+        healed = await rrs._self_heal_dead_binding(guild, 555, "💀", 42)
+    assert healed is False
+    unbind.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_reaction_add_self_heals_dead_binding():
+    guild = _Guild(1, live_roles=set())  # the bound role 42 was deleted
+    with (
+        patch.object(rrs.db, "get_reaction_role", new=AsyncMock(return_value=42)),
+        patch.object(rrs, "reaction_roles_enabled", new=_enabled(True)),
+        patch.object(rrs, "unbind_emoji", new=AsyncMock()) as unbind,
+        patch.object(rrs, "_apply", new=AsyncMock()) as apply_mock,
+    ):
+        outcome, strip = await rrs.handle_reaction_add(guild, _Member([]), 555, "💀")
+    assert (outcome, strip) == (None, False)
+    apply_mock.assert_not_awaited()  # dead binding → no assignment attempted
+    unbind.assert_awaited_once_with(1, 555, "💀", actor_id=None, actor_type="system")
+
+
+@pytest.mark.asyncio
+async def test_handle_reaction_remove_self_heals_dead_binding():
+    guild = _Guild(1, live_roles=set())
+    with (
+        patch.object(rrs.db, "get_reaction_role", new=AsyncMock(return_value=42)),
+        patch.object(rrs, "reaction_roles_enabled", new=_enabled(True)),
+        patch.object(rrs, "unbind_emoji", new=AsyncMock()) as unbind,
+        patch.object(rrs, "_apply", new=AsyncMock()) as apply_mock,
+    ):
+        outcome = await rrs.handle_reaction_remove(guild, _Member([42]), 555, "💀")
+    assert outcome is None
+    apply_mock.assert_not_awaited()
+    unbind.assert_awaited_once_with(1, 555, "💀", actor_id=None, actor_type="system")


### PR DESCRIPTION
Owner-accepted continuation of #1248 (offered at its close; greenlit with "continue").

The #1248 manual **🧹 Clean up** button removes bindings whose role was deleted. This makes that
cleanup **automatic**: when a member reacts (or un-reacts) on a binding whose role no longer
resolves, the binding is removed on the spot — dead config self-heals without anyone opening the
panel.

- `services/reaction_role_service.py`:
  - `_self_heal_dead_binding(guild, message_id, emoji, role_id)` — removes a binding whose role is
    gone, audited as a **`system`** action; called early in `handle_reaction_add` /
    `handle_reaction_remove` (before mode logic).
  - threaded an `actor_type` param through `unbind_emoji` / `_emit` (default `"admin"`; self-heal
    passes `"system"`) so an automatic cleanup is distinguishable from an operator removal in the
    audit stream.

Safe because discord.py fully caches guild roles, so `resolve_role` returning `None` means the role
was genuinely deleted (not a transient cache miss). The manual button stays for sweeping bindings on
messages that never get reacted on. No schema change.

Born-red HOLD (Q-0133) until the session card flips to `complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK6bg63g8Vsp2m4nhUxUrf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK6bg63g8Vsp2m4nhUxUrf)_