### PR TITLE
BTD6 buff-uptime: decode rebuffBlockTime + multi-target (targets=N) uptime

### DIFF
--- a/.sessions/2026-06-21-btd6-buff-uptime-multitarget.md
+++ b/.sessions/2026-06-21-btd6-buff-uptime-multitarget.md
@@ -1,22 +1,70 @@
 # 2026-06-21 — BTD6 buff-uptime: rebuffBlockTime decode + multi-target uptime
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-## Arc (what I'm about to do)
+## Arc
 Owner: "go ahead [wire rebuffBlockTime], any improvements welcome." Follow-up to #1235/#1249.
+The dump's `AddBerserkerBrewToProjectileModel` carries `rebuffBlockTime` (per-target re-buff
+cooldown) — decoded-available but unused. Its real significance is **multi-target** (the floor on
+how soon a tower can be re-buffed → bounds how many towers one alch keeps buffed — the wiki's
+"88% on two towers"). Single-target is unaffected (cadence 8s/6.4s always exceeds the 5s/4s block).
 
-The dump's `AddBerserkerBrewToProjectileModel` carries `rebuffBlockTime` (the per-target
-re-buff cooldown: 5s @ 4-0-0, 4s with Perishing) — decoded-available but unused. Its real
-significance is **multi-target**: it's the floor on how soon a given tower can be re-buffed,
-which is what bounds "how many towers can one alch keep buffed" (the wiki's "88% on two
-towers" framing). Single-target is unaffected (throw cadence 8s/6.4s always exceeds the 5s/4s
-block), so the meaningful improvement is the multi-target case that rebuffBlockTime enables.
+## Shipped (PR #1251)
+- **Parser** — `_buff_window` now returns `rebuffBlockTime` too → emitted as `buff_rebuff_block`;
+  committed `alchemist.json` overlaid (5s @ x-0-0, 4s @ x-2-x; clean, no version bump, idempotent).
+- **Calc** — `buff_uptime(buff_source, target, targets=N)`: round-robin model — a given tower is
+  re-buffed every `max(N × throw_cadence, rebuff_block)`; per-tower uptime = `min(1, window /
+  interval)`. `targets=1` (default) is unchanged. Surfaces `rebuff_block_seconds` /
+  `rebuff_interval_seconds` / `targets` + a multi-target note. `targets` clamped ≥ 1.
+- **Tool** — optional `targets` param.
+- **Docs** — decode-status: rebuffBlockTime now committed + the multi-target model + the honest note
+  that the floor only binds under alch attack-speed buffs (Jungle Drums/Overclock).
 
-## Plan
-1. Parser: emit `buff_rebuff_block` (seconds) from `rebuffBlockTime`; re-overlay committed
-   `alchemist.json` (add the field; keep existing buff fields).
-2. Calc: `buff_uptime(..., targets=N)` — round-robin model: a tower is re-buffed every
-   `max(N × throw_cadence, rebuff_block)`; per-tower uptime = `min(1, window / interval)`.
-   N=1 default = unchanged. Surface `rebuff_block_seconds` + multi-target note.
-3. Tool: optional `targets` param.
-4. Tests (parser fixture + real-data multi-target) + decode-status doc.
+## Verification
+- `python3.10 scripts/check_quality.py --full` → **all checks passed ✓** (11355 passed).
+- Real data: 4-0-0 on 5-0-0 Ninja — targets=1 → 100% (interval 8s); targets=2 → 54.2% (interval
+  16s); targets=3 → 36.2% (interval 24s); permanent unaffected by targets; rebuff_block 5.0 surfaced.
+- Ledger + docs `--strict` green.
+
+## Decisions made alone
+- **Round-robin model** (`max(N × cadence, rebuff_block)`) over a fuller throw-distribution sim — it
+  matches the wiki's per-tower framing, is grounded in the two real numbers (cadence + rebuff_block),
+  and degrades exactly to the verified single-target case at N=1. Noted in the tool/docs that it
+  assumes the alch evenly serves N towers in range.
+- Kept `rebuffBlockTime` wired as the interval **floor** even though it doesn't bind for a standalone
+  alch (cadence > block) — so it's correct the moment an alch attack-speed buff enters the picture.
+
+## Context delta
+- The chain #1235 → #1249 → #1251 is a clean worked example of the decode loop: ship calculator →
+  verify+populate from the real dump → wire the remaining decoded field + the capability it unlocks.
+  Each step left the next obvious.
+
+## ⟲ Previous-session review
+#1249 (verify + populate) was excellent — it cloned the public dump, caught its own predecessor's
+wrong guesses, and populated clean data. Its one small gap: it decoded `rebuffBlockTime` far enough
+to *document* it ("decoded-available, not yet a calc input") but didn't emit it into the data, so the
+field sat in a code comment rather than the committed JSON — a reader couldn't see it without
+re-deriving. **Workflow note (applied here):** when you've already confirmed a field's value against
+the dump, emit it (even if no consumer yet) rather than leaving it as prose — a committed field is
+discoverable + testable; a comment is neither. (It *was* captured as the session idea, so not
+orphaned — this is a "emit-don't-describe" refinement, not a miss.)
+
+## 💡 Session idea
+**Model alch attack-speed buffs in `btd6_buff_uptime`.** `rebuffBlockTime` only *binds* when the
+alch throws faster than the block (Jungle Drums, Overclock, Primary Mentoring, village speed) — the
+exact case the current calc can't express (it reads the static `rate`). A `throw_speed_multiplier`
+input (or a known-buff enum) would let it answer "with Jungle Drums, can one 4-0-0 keep 2 towers at
+100%?" — and it's where the `rebuff_block` floor finally matters. (Captured, not built.)
+
+## 📤 Run report
+- **Did:** Decoded `rebuffBlockTime` into the data + added `targets=N` multi-target uptime ·
+  **Outcome:** shipped (PR #1251)
+- **Shipped:** PR #1251 — `buff_rebuff_block` decode + overlay + `buff_uptime(targets=N)` + tool param
+  + tests + decode-status
+- **Run type:** `manual` (owner: "go ahead, improvements welcome")
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none — data populated, verified
+- **⚑ Self-initiated:** the multi-target `targets=N` capability is an improvement I chose on top of
+  the literal `rebuffBlockTime` ask (Q-0172; owner pre-sanctioned "any improvements welcome")
+- **↪ Next:** model alch attack-speed buffs (this session's 💡), else resume the current-state ▶
+  ungated lane

--- a/.sessions/2026-06-21-btd6-buff-uptime-multitarget.md
+++ b/.sessions/2026-06-21-btd6-buff-uptime-multitarget.md
@@ -1,0 +1,22 @@
+# 2026-06-21 — BTD6 buff-uptime: rebuffBlockTime decode + multi-target uptime
+
+> **Status:** `in-progress`
+
+## Arc (what I'm about to do)
+Owner: "go ahead [wire rebuffBlockTime], any improvements welcome." Follow-up to #1235/#1249.
+
+The dump's `AddBerserkerBrewToProjectileModel` carries `rebuffBlockTime` (the per-target
+re-buff cooldown: 5s @ 4-0-0, 4s with Perishing) — decoded-available but unused. Its real
+significance is **multi-target**: it's the floor on how soon a given tower can be re-buffed,
+which is what bounds "how many towers can one alch keep buffed" (the wiki's "88% on two
+towers" framing). Single-target is unaffected (throw cadence 8s/6.4s always exceeds the 5s/4s
+block), so the meaningful improvement is the multi-target case that rebuffBlockTime enables.
+
+## Plan
+1. Parser: emit `buff_rebuff_block` (seconds) from `rebuffBlockTime`; re-overlay committed
+   `alchemist.json` (add the field; keep existing buff fields).
+2. Calc: `buff_uptime(..., targets=N)` — round-robin model: a tower is re-buffed every
+   `max(N × throw_cadence, rebuff_block)`; per-tower uptime = `min(1, window / interval)`.
+   N=1 default = unchanged. Surface `rebuff_block_seconds` + multi-target note.
+3. Tool: optional `targets` param.
+4. Tests (parser fixture + real-data multi-target) + decode-status doc.

--- a/disbot/data/btd6/stats/alchemist.json
+++ b/disbot/data/btd6/stats/alchemist.json
@@ -5955,7 +5955,8 @@
           "sharedGridRange": 0,
           "filterInvisible": false,
           "buff_duration": 5,
-          "buff_attack_cap": 25
+          "buff_attack_cap": 25,
+          "buff_rebuff_block": 5
         }
       ],
       "targetTypeFirst": true,
@@ -6083,7 +6084,8 @@
           "sharedGridRange": 0,
           "filterInvisible": false,
           "buff_duration": 5,
-          "buff_attack_cap": 25
+          "buff_attack_cap": 25,
+          "buff_rebuff_block": 5
         }
       ],
       "targetTypeFirst": true,
@@ -6211,7 +6213,8 @@
           "sharedGridRange": 0,
           "filterInvisible": false,
           "buff_duration": 5,
-          "buff_attack_cap": 25
+          "buff_attack_cap": 25,
+          "buff_rebuff_block": 5
         }
       ],
       "targetTypeFirst": true,
@@ -6339,7 +6342,8 @@
           "sharedGridRange": 0,
           "filterInvisible": false,
           "buff_duration": 5,
-          "buff_attack_cap": 25
+          "buff_attack_cap": 25,
+          "buff_rebuff_block": 5
         }
       ],
       "targetTypeFirst": true,
@@ -6468,7 +6472,8 @@
           "sharedGridRange": 0,
           "filterInvisible": false,
           "buff_duration": 6,
-          "buff_attack_cap": 40
+          "buff_attack_cap": 40,
+          "buff_rebuff_block": 4
         }
       ],
       "targetTypeFirst": true,
@@ -6596,7 +6601,8 @@
           "sharedGridRange": 0,
           "filterInvisible": false,
           "buff_duration": 12,
-          "buff_attack_cap": 40
+          "buff_attack_cap": 40,
+          "buff_rebuff_block": 5
         }
       ],
       "targetTypeFirst": true,
@@ -6724,7 +6730,8 @@
           "sharedGridRange": 0,
           "filterInvisible": false,
           "buff_duration": 12,
-          "buff_attack_cap": 40
+          "buff_attack_cap": 40,
+          "buff_rebuff_block": 5
         }
       ],
       "targetTypeFirst": true,
@@ -6852,7 +6859,8 @@
           "sharedGridRange": 0,
           "filterInvisible": false,
           "buff_duration": 12,
-          "buff_attack_cap": 40
+          "buff_attack_cap": 40,
+          "buff_rebuff_block": 5
         }
       ],
       "targetTypeFirst": true,
@@ -6980,7 +6988,8 @@
           "sharedGridRange": 0,
           "filterInvisible": false,
           "buff_duration": 12,
-          "buff_attack_cap": 40
+          "buff_attack_cap": 40,
+          "buff_rebuff_block": 5
         }
       ],
       "targetTypeFirst": true,
@@ -7109,7 +7118,8 @@
           "sharedGridRange": 0,
           "filterInvisible": false,
           "buff_duration": 13,
-          "buff_attack_cap": 55
+          "buff_attack_cap": 55,
+          "buff_rebuff_block": 4
         }
       ],
       "targetTypeFirst": true,

--- a/disbot/services/ai_tools.py
+++ b/disbot/services/ai_tools.py
@@ -1666,8 +1666,10 @@ _BTD6_BUFF_UPTIME_SPEC = AIToolSpec(
         "'alchemist 4-0-0', 'Berserker Brew') and target (e.g. 'Grandmaster "
         "Ninja', 'ninja 5-0-0'). Returns which limiter binds (time vs attacks), "
         "the effective window, attacks buffed, and uptime% — the grounded answer; "
-        "do NOT estimate it yourself. Returns found=false with an honest note if "
-        "the buff's duration/cap isn't decoded into the data yet."
+        "do NOT estimate it yourself. Pass targets=N when the one Alchemist is "
+        "buffing N towers in range (it round-robins, so per-tower uptime drops) — "
+        "for 'can one alch keep N towers buffed'. Returns found=false with an "
+        "honest note if the buff's duration/cap isn't decoded into the data yet."
     ),
     parameters={
         "type": "object",
@@ -1686,6 +1688,14 @@ _BTD6_BUFF_UPTIME_SPEC = AIToolSpec(
                     "(e.g. 'Grandmaster Ninja', 'ninja 5-0-0')."
                 ),
             },
+            "targets": {
+                "type": "integer",
+                "minimum": 1,
+                "description": (
+                    "How many towers in range the one Alchemist is buffing "
+                    "(default 1). The alch round-robins its throws across them."
+                ),
+            },
         },
         "required": ["buff_source", "target"],
         "additionalProperties": False,
@@ -1701,7 +1711,12 @@ async def _btd6_buff_uptime(arguments: dict[str, Any]) -> dict[str, Any]:
     target = str(arguments.get("target") or "").strip()
     if not buff_source or not target:
         return {"found": False, "note": "both buff_source and target are required"}
-    return btd6_upgrade_detail_service.buff_uptime(buff_source, target)
+    raw_targets = arguments.get("targets", 1)
+    try:
+        targets = max(1, int(raw_targets))
+    except (TypeError, ValueError):
+        targets = 1
+    return btd6_upgrade_detail_service.buff_uptime(buff_source, target, targets=targets)
 
 
 # --- btd6_paragon_calculate --------------------------------------------------

--- a/disbot/services/btd6_upgrade_detail_service.py
+++ b/disbot/services/btd6_upgrade_detail_service.py
@@ -538,7 +538,7 @@ def _alch_buff_attack(tower_id: str, code: str) -> dict[str, Any] | None:
     return brew or acidic
 
 
-def buff_uptime(buff_source: str, target: str) -> dict[str, Any]:
+def buff_uptime(buff_source: str, target: str, targets: int = 1) -> dict[str, Any]:
     """Compute an Alchemist buff's uptime on a target tower — the grounded
     compute behind the ``btd6_buff_uptime`` tool.
 
@@ -546,11 +546,17 @@ def buff_uptime(buff_source: str, target: str) -> dict[str, Any]:
     data) with the target's attack speed to report **which limiter binds** (time
     vs attacks) and the resulting uptime. e.g. a 4-0-0 (Stronger Stimulant: 12s
     or 40 attacks, thrown every 8s) on a 5-0-0 Ninja (0.217s) burns the 40-attack
-    cap in ~8.7s, so it is attack-cap-limited. Returns ``found=False`` with an
-    honest note when the buff isn't an Alchemist buff, the buff's
-    duration/attack-cap isn't decoded into the data yet, or the target has no
+    cap in ~8.7s, so it is attack-cap-limited.
+
+    ``targets`` is how many towers in range the one Alchemist is buffing: it
+    round-robins its throws, so a given tower is re-buffed every
+    ``max(targets × throw_cadence, rebuff_block)`` seconds (``rebuff_block`` =
+    the dump's per-target ``rebuffBlockTime`` floor). ``targets=1`` is the
+    single-tower case. Returns ``found=False`` with an honest note when the buff
+    isn't an Alchemist buff, the window isn't decoded, or the target has no
     attack stat — never a fabricated number.
     """
+    targets = max(1, int(targets))
     src = _resolve_stat_target(buff_source)
     if src is None:
         return {
@@ -594,6 +600,7 @@ def buff_uptime(buff_source: str, target: str) -> dict[str, Any]:
     duration = attack.get("buff_duration")
     cap = attack.get("buff_attack_cap")
     permanent = bool(attack.get("buff_permanent"))
+    rebuff_block = attack.get("buff_rebuff_block")
 
     tgt = _resolve_stat_target(target)
     if tgt is None:
@@ -626,9 +633,12 @@ def buff_uptime(buff_source: str, target: str) -> dict[str, Any]:
         "target_tier_code": tgt_code,
         "target_cooldown_seconds": round(tgt_cd, 4),
         "target_attacks_per_second": round(1.0 / tgt_cd, 3),
+        "targets": targets,
     }
     if isinstance(cadence, (int, float)) and cadence > 0:
         out["throw_cadence_seconds"] = float(cadence)
+    if isinstance(rebuff_block, (int, float)) and rebuff_block > 0:
+        out["rebuff_block_seconds"] = float(rebuff_block)
 
     # Permanent Brew (5-0-0): the buff never expires once applied.
     if permanent:
@@ -680,8 +690,14 @@ def buff_uptime(buff_source: str, target: str) -> dict[str, Any]:
     out["effective_window_seconds"] = round(window, 3)
     out["attacks_under_buff"] = int(min(filter(None, [cap, window / tgt_cd])))
 
+    # Re-buff interval for one of the `targets` towers: the alch round-robins its
+    # throws, so each tower's turn comes every `targets × throw_cadence` — but no
+    # faster than the per-target `rebuff_block` floor.
     if isinstance(cadence, (int, float)) and cadence > 0:
-        uptime = min(1.0, window / float(cadence))
+        floor = float(rebuff_block) if isinstance(rebuff_block, (int, float)) else 0.0
+        rebuff_interval = max(float(cadence) * targets, floor)
+        out["rebuff_interval_seconds"] = round(rebuff_interval, 3)
+        uptime = min(1.0, window / rebuff_interval)
         out["uptime"] = round(uptime, 3)
         out["uptime_percent"] = round(uptime * 100.0, 1)
 
@@ -691,13 +707,21 @@ def buff_uptime(buff_source: str, target: str) -> dict[str, Any]:
         if limiter == "attacks"
         else f"the {float(duration)}s time limit"
     )
-    uptime_txt = (
-        f" Re-thrown every {float(cadence)}s → {out['uptime_percent']}% uptime"
-        f"{' (continuous)' if out.get('uptime', 0) >= 1.0 else ''}"
-        f" on {tgt_display}."
-        if "uptime_percent" in out
-        else ""
-    )
+    if "uptime_percent" in out:
+        if targets > 1:
+            uptime_txt = (
+                f" Buffing {targets} towers, each gets re-thrown every "
+                f"~{out['rebuff_interval_seconds']}s → {out['uptime_percent']}% "
+                f"uptime per tower."
+            )
+        else:
+            uptime_txt = (
+                f" Re-thrown every {float(cadence)}s → {out['uptime_percent']}% "
+                f"uptime{' (continuous)' if out.get('uptime', 0) >= 1.0 else ''} "
+                f"on {tgt_display}."
+            )
+    else:
+        uptime_txt = ""
     out["note"] = (
         f"{source_label} on {tgt_display}: limited by {limiter_txt}, "
         f"so it lasts ~{round(window, 2)}s per throw and buffs "

--- a/docs/btd6/btd6-gamedata-decode-status.md
+++ b/docs/btd6/btd6-gamedata-decode-status.md
@@ -44,11 +44,19 @@ works** (the traps we hit), and what is still un-decoded.
 > applier is **`Add{BerserkerBrew,AcidicMixture}ToProjectileModel`** on the projectile:
 > `lifespan` (**seconds** — `lifespanFrames` is 0/unused; `-1` = Permanent-Brew sentinel; ABSENT on the
 > lead buff = attack-cap-only), nested **`…CheckModel.maxCount`** (cap; `9999999` = permanent sentinel),
-> and `rebuffBlockTime` (per-target re-buff cooldown, 5s @ 4-0-0 — decoded-available, not yet a calc
-> input). The committed `stats/alchemist.json` is **populated** (surgical buff-field overlay, no value
-> churn / no version bump; idempotent — the next `--all` reproduces it), so `btd6_buff_uptime` answers
-> live. The dump is **public + clonable** (`git clone --depth 1 https://github.com/Btd6ModHelper/btd6-game-data`)
-> — there is no "no dump in-repo" excuse; clone it to re-verify.
+> and `rebuffBlockTime` (per-target re-buff cooldown, 5s @ 4-0-0 / 4s @ x-2-x → committed as
+> `buff_rebuff_block`; PR #1251). The committed `stats/alchemist.json` is **populated** (surgical
+> buff-field overlay, no value churn / no version bump; idempotent — the next `--all` reproduces it),
+> so `btd6_buff_uptime` answers live. The dump is **public + clonable**
+> (`git clone --depth 1 https://github.com/Btd6ModHelper/btd6-game-data`) — there is no "no dump
+> in-repo" excuse; clone it to re-verify.
+>
+> **Multi-target (PR #1251):** `btd6_buff_uptime(..., targets=N)` models one alch buffing N towers —
+> it round-robins throws, so a given tower is re-buffed every `max(N × throw_cadence, rebuff_block)`
+> (the `rebuffBlockTime` floor) and per-tower uptime falls ~1/N (4-0-0 on a 5-0-0 Ninja: 100% on one,
+> ~54% split across two). `rebuffBlockTime` rarely binds for a *standalone* alch (cadence 8s/6.4s >
+> block 5s/4s) — it matters under alch attack-speed buffs (Jungle Drums, Overclock) that speed
+> throwing below the floor.
 >
 > **Verified windows (game-data == Bloons-wiki cross-check):** Acidic Mixture Dip 2-0-0
 > = **10 shots** (12 @ 2-2-0); Berserker Brew 3-0-0 = **5s / 25 attacks**, 3-2-0 = 6s/40; Stronger

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,8 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/peaceful-mayer-rgc20t` · **BTD6 buff-uptime — rebuffBlockTime + multi-target** (owner: improvements welcome) — decode `rebuffBlockTime`, add `targets=N` round-robin uptime · `scripts/parse_gamedata.py` / `disbot/data/btd6/stats/alchemist.json` / `btd6_upgrade_detail_service` / `ai_tools` · 2026-06-21 · **PR (this session, auto-merge on green)**
+
 - `claude/peaceful-mayer-rgc20t` · **BTD6 buff-uptime — verify binding + populate data** (follow-up to
   #1235; owner pointed at the public dump) — cloned BTD Mod Helper dump, corrected `_buff_window` to
   the verified `Add…ToProjectileModel` shape, overlaid buff fields onto committed `alchemist.json` ·

--- a/scripts/parse_gamedata.py
+++ b/scripts/parse_gamedata.py
@@ -466,16 +466,21 @@ def _deep_find_number(node: Any, key: str) -> float | None:
     return None
 
 
-def _buff_window(attack: dict) -> tuple[float | None, int | None, bool]:
-    """``(buff_duration_seconds, buff_attack_cap, permanent)`` off a buff attack.
+def _buff_window(
+    attack: dict,
+) -> tuple[float | None, int | None, bool, float | None]:
+    """``(buff_duration_seconds, buff_attack_cap, permanent, rebuff_block_seconds)``.
 
     Permanent Brew (lifespan ``-1`` / maxCount ``9999999``) → ``permanent=True``
     with no numeric duration/cap. The Acidic Mixture Dip lead buff has no
-    ``lifespan`` → cap-only. ``(None, None, False)`` when no applier is present.
+    ``lifespan`` → cap-only (and no ``rebuffBlockTime``). ``rebuff_block`` is the
+    per-target re-buff cooldown (the floor on how soon a tower can be re-buffed);
+    ``None`` when absent or the ``-1`` permanent sentinel. ``(None, None, False,
+    None)`` when no applier is present.
     """
     applier = _buff_applier(attack)
     if applier is None:
-        return None, None, False
+        return None, None, False, None
     permanent = False
     duration: float | None = None
     lifespan = applier.get("lifespan")
@@ -493,7 +498,11 @@ def _buff_window(attack: dict) -> tuple[float | None, int | None, bool]:
             permanent = permanent or duration is None
         elif max_count > 0:
             cap = int(max_count)
-    return duration, cap, permanent
+    rebuff_block: float | None = None
+    rebuff = applier.get("rebuffBlockTime")
+    if isinstance(rebuff, (int, float)) and not isinstance(rebuff, bool) and rebuff > 0:
+        rebuff_block = _num(rebuff)
+    return duration, cap, permanent, rebuff_block
 
 
 def _clean_attack(attack: dict, index: int) -> dict:
@@ -548,13 +557,15 @@ def _clean_attack(attack: dict, index: int) -> dict:
     # Buff-throwing attacks: decode the dual-limit window (time + attack cap) the
     # buff applies to its target, so btd6_buff_uptime can ground an uptime.
     if out["name"] in _BUFF_WINDOW_ATTACK_NAMES:
-        duration, cap, permanent = _buff_window(attack)
+        duration, cap, permanent, rebuff_block = _buff_window(attack)
         if permanent:
             out["buff_permanent"] = True
         if duration is not None:
             out["buff_duration"] = duration
         if cap is not None:
             out["buff_attack_cap"] = cap
+        if rebuff_block is not None:
+            out["buff_rebuff_block"] = rebuff_block
     return out
 
 

--- a/tests/unit/scripts/test_parse_gamedata.py
+++ b/tests/unit/scripts/test_parse_gamedata.py
@@ -2899,6 +2899,7 @@ def test_buff_window_decodes_seconds_and_nested_cap(mod):
     assert out["name"] == "BeserkerBrewAttack"
     assert out["buff_duration"] == 12.0
     assert out["buff_attack_cap"] == 40
+    assert out["buff_rebuff_block"] == 5.0  # rebuffBlockTime (per-target floor)
 
 
 def test_buff_window_lead_buff_is_cap_only(mod):

--- a/tests/unit/services/test_btd6_upgrade_detail_service.py
+++ b/tests/unit/services/test_btd6_upgrade_detail_service.py
@@ -710,3 +710,30 @@ def test_buff_uptime_real_data_lead_buff_is_cap_limited():
     assert res["buff_attack_cap"] == 10
     assert res["limiter"] == "attacks"
     assert "buff_duration_seconds" not in res  # lead buff has no time window
+
+
+def test_buff_uptime_real_data_surfaces_rebuff_block():
+    # rebuffBlockTime is decoded from the dump (5s @ 4-0-0).
+    res = det.buff_uptime("alchemist 4-0-0", "ninja 5-0-0")
+    assert res["rebuff_block_seconds"] == 5.0
+    assert res["targets"] == 1
+
+
+def test_buff_uptime_multi_target_drops_per_tower_uptime():
+    # One alch buffing N towers round-robins its throws, so per-tower uptime falls
+    # ~1/N: 4-0-0 on a 5-0-0 Ninja is 100% on one tower but ~54% split across two.
+    one = det.buff_uptime("alchemist 4-0-0", "ninja 5-0-0", targets=1)
+    two = det.buff_uptime("alchemist 4-0-0", "ninja 5-0-0", targets=2)
+    assert one["uptime_percent"] == 100.0
+    assert two["targets"] == 2
+    assert two["rebuff_interval_seconds"] == 16.0  # max(2 × 8s, 5s floor)
+    assert 50.0 <= two["uptime_percent"] <= 60.0
+    assert two["uptime_percent"] < one["uptime_percent"]
+    assert "2 towers" in two["note"]
+
+
+def test_buff_uptime_targets_floor_is_at_least_one():
+    # A nonsensical targets=0 is clamped to 1 (no divide-by-zero, no 0-target math).
+    res = det.buff_uptime("alchemist 4-0-0", "ninja 5-0-0", targets=0)
+    assert res["targets"] == 1
+    assert res["uptime_percent"] == 100.0


### PR DESCRIPTION
## Why

Follow-up to #1235/#1249 (owner: "go ahead, any improvements welcome"). The dump's `AddBerserkerBrewToProjectileModel` carries **`rebuffBlockTime`** — the per-target re-buff cooldown (5s @ 4-0-0, 4s with Perishing) — decoded-available but unused.

Its real significance is **multi-target**: single-target uptime is unaffected (the throw cadence, 8s/6.4s, always exceeds the 5s/4s block), but `rebuffBlockTime` is the floor on how soon a given tower can be re-buffed — which is what bounds *how many towers one Alchemist can keep buffed* (the wiki's "88% on two towers" framing).

## What

1. **Parser** — emit `buff_rebuff_block` (seconds) from `rebuffBlockTime`; re-overlay the committed `alchemist.json` (adds the field, keeps existing buff fields; clean, no version bump).
2. **Calculator** — `buff_uptime(buff_source, target, targets=N)`: round-robin model — a given tower is re-buffed every `max(N × throw_cadence, rebuff_block)`; per-tower uptime = `min(1, effective_window / interval)`. `targets=1` (default) is unchanged. Surfaces `rebuff_block_seconds` + a multi-target note.
3. **AI tool** — optional `targets` parameter.
4. Tests (parser fixture + real-data multi-target) + decode-status doc.

## Status

Opened **born-red** (session card `in-progress`); flips to `complete` last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAfgtUqA1bzZ3gsSrFwaw8

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAfgtUqA1bzZ3gsSrFwaw8)_