### PR TITLE
docs(journal): capture recurring workflow lessons from the reaction-roles chain

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -266,6 +266,12 @@ PR #676; drift surfaced at boot + `!btd6 status`). Full note:
 - Batch fixes by cog; commit + push each coherent chunk.
 - Prefers self-maintaining checks over hardcoded lists.
 - A PR at session end is a standing expectation (also in `.claude/CLAUDE.md`).
+- **★ Merged = deployed — NEVER tell the maintainer to deploy/restart (2026-06-21, Q-0193).** Railway
+  auto-redeploys `worker` on every merge to `main`; this has **always** been true. CLAUDE.md formerly
+  carried a wrong "merge ≠ deploy" line, so sessions kept (incorrectly) saying "restart it yourself"
+  for *months* — the maintainer had to correct it again on 2026-06-21. #1247 removed the bad line. What
+  stays the maintainer's is **live verification / rollback** + any per-PR *data* step a change names
+  (seed/migration button), not the deploy. Phrase outcomes as "merged → it'll be live within minutes."
 - Prefers planning prompts to be copy-paste-ready and explicit about hidden
   dependencies, forgotten follow-ups, shipped work that must not be duplicated,
   required tests, rollback safety, and stop conditions.
@@ -532,6 +538,23 @@ PR #676; drift surfaced at boot + `!btd6 status`). Full note:
   first deny, so it can't expose an *axis disagreement* (routing vs command-access); you read
   the policy owners directly. Corrected in §16.8 item 6. The "verify cross-agent output vs
   source" rule applies to your own prior session's notes too, not just Codex/ChatGPT.
+
+### Discord interactions / views
+- **★ A modal can only be opened as the *first* response to an interaction (2026-06-21, #1243/#1246).**
+  `interaction.response.send_modal(...)` must be the initial response — you **cannot** `defer()` or
+  `await` slow work and *then* send a modal (the token is already consumed/expired). This shaped the
+  whole reaction-role message-picker flow: paths that need an async lookup before the modal route
+  through an intermediate **button/select whose callback opens the modal** (e.g. pick-recent → message
+  select → emotes modal; new-message → one modal that *also* captures the emotes). A small `await`
+  (one `channel.history(limit=5)`) before `send_modal` is tolerable only because it's well under the
+  3-second window — anything slower must defer+followup with no modal, or split the step.
+  *(Candidate for `.claude/rules/discord-views.md`; flagged unpromoted across #1243/#1246/#1248/#1250.)*
+- **A test fake must gain any method the production path newly calls, or every test through that path
+  breaks at once (2026-06-21, #1250).** Adding `resources.resolve_role(...)` to the reaction listener
+  made 4 existing `handle_reaction_*` tests fail with `AttributeError: '_Guild' has no attribute
+  'get_role'` — the fake guild predated the new call. When you add a resolver/lookup to a hot path,
+  grep its tests' fakes and extend them (ideally configurable, so the new branch is *tested*, not
+  just unbroken).
 
 ### Cross-agent & git workflow
 - **`send_later` is NOT provisioned in this environment — don't chase it (2026-06-14, Q-0129).**

--- a/.sessions/2026-06-21-journal-workflow-lessons.md
+++ b/.sessions/2026-06-21-journal-workflow-lessons.md
@@ -1,0 +1,70 @@
+# 2026-06-21 — Journal: capture recurring workflow lessons from the reaction-roles chain
+
+> **Status:** `complete` — docs-only (journal, free-rein). Pushed all-at-once before opening the PR
+> (journal gotcha line 62: a synchronize push may not re-fire CI). Q-0191 → merge on green.
+
+> **Run type:** `manual`
+
+## Arc
+
+The reaction-roles arc is complete (6 merged PRs: #1234 multi-emote + reuse, #1237 channel + colour +
+gradient, #1243 message picker, #1246 gradient presets, #1248 dead-binding cleanup, #1250 listener
+self-heal). Across those sessions I kept surfacing the same workflow lessons in `Context delta` /
+`⚑` lines that **evaporate into per-session cards** instead of reaching the next agent. This session
+moves the durable ones into `.session-journal.md`, where the next session actually reads them:
+
+- **`### Discord interactions / views`** (new): the **modal-must-be-first-response** constraint
+  (shaped the #1243 picker flow) + the **test-fake-must-gain-new-methods** trap (the #1250
+  `_Guild.get_role` break). Both flagged ★ / candidate for `.claude/rules/discord-views.md`.
+- **Operating Preferences**: **merged = deployed — never tell the maintainer to deploy/restart**
+  (Q-0193). The maintainer had to correct this misinformation again this session; capturing it where
+  sessions re-derive it (at PR close) is the fix the doc-only Q-0193 edit didn't fully achieve.
+
+## Findings / decisions
+
+- **Decision made alone:** journal-only (free-rein) rather than directly editing
+  `.claude/rules/discord-views.md` — that file is owner-governed; the modal rule lands as a ★ candidate
+  for promotion at the next REVIEW, not a unilateral binding edit.
+- **Recognized the loop honestly:** the reaction-roles feature is genuinely complete + self-healing;
+  rather than manufacture more micro-features (over-engineering a finished feature), this captures the
+  ecosystem lessons and hands the next substantive direction back to the owner.
+
+## 📤 Run report
+
+- **Did:** captured the modal-first-response + test-fake + merged=deployed lessons in the journal ·
+  **Outcome:** shipped (docs-only PR, auto-merge on green)
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** the modal-first-response ★ candidate is ready to promote to
+  `.claude/rules/discord-views.md` at your next REVIEW (I can't self-edit that file).
+- **⚑ Owner manual steps:** none — merged = deployed.
+- **⚑ Self-initiated:** YES — workflow-lesson capture (first-class per CLAUDE.md), after the owner's
+  reaction-roles requests were all delivered.
+- **↪ Next:** reaction-roles is complete; **next substantive direction is the owner's to set** — a new
+  feature area, a hardening/live-walk pass, or promote the captured candidates.
+
+## 💡 Session idea
+
+**Put the "merged = deployed" reminder on the session-close surface, not only in a doc.** Q-0193 fixed
+CLAUDE.md, yet the misinformation persisted for months because each session re-derives "you should
+deploy" at PR close. A one-line `/session-close` (or Stop-hook) check — "never tell the maintainer to
+deploy/restart; merge auto-deploys" — catches the misstatement at the point it's made. (Owner-governed
+hook → would be a router proposal, not a self-edit.)
+
+## ⟲ Previous-session review
+
+The #1250 session shipped the listener self-heal cleanly, but the broader pattern this chain exposed:
+I gave the owner **repeated wrong deploy guidance** and re-discovered the **same Discord-UI / context
+lessons** every session without them ever landing somewhere the next agent reads. **System
+improvement (this session's action):** stop letting `Context delta` findings die in cards — promote the
+recurring ones to the journal's Rules/Conventions the moment they recur, which is exactly what this
+session does.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 0 (pending docs PR, auto-merge on green) |
+| CI-red rounds | 0 |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (merged=deployed reminder on the close surface) |
+| Ideas groomed | 0 (capture/grooming of prior-session lessons into the journal) |


### PR DESCRIPTION
Docs-only (journal, free-rein). After the reaction-roles arc completed (6 merged PRs: #1234, #1237,
#1243, #1246, #1248, #1250), this captures the recurring workflow lessons that kept evaporating into
per-session cards instead of reaching the next agent — moving them into `.session-journal.md` where
sessions actually read them.

- **New `### Discord interactions / views`** candidate rules:
  - **A modal can only be opened as the *first* response to an interaction** — can't `defer()`/`await`
    then `send_modal` (shaped the #1243 message-picker flow). ★ candidate for
    `.claude/rules/discord-views.md`.
  - **A test fake must gain any method the production path newly calls** (the #1250 `_Guild.get_role`
    break that failed 4 existing tests at once).
- **Operating Preferences:** **merged = deployed — never tell the maintainer to deploy/restart**
  (Q-0193). The misinformation kept being re-derived at PR close despite the doc fix.

The card was pushed complete before opening (journal gotcha line 62: a synchronize push may not
re-fire CI). No code/schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK6bg63g8Vsp2m4nhUxUrf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK6bg63g8Vsp2m4nhUxUrf)_