### PR TITLE
docs(plan): buildable Starboard / Hall-of-Fame plan (idea B1 → plan)

### DIFF
--- a/.sessions/2026-06-21-starboard-plan.md
+++ b/.sessions/2026-06-21-starboard-plan.md
@@ -1,0 +1,73 @@
+# 2026-06-21 — Starboard / Hall-of-Fame: buildable plan
+
+> **Status:** `complete` — docs-only (plan). **⚑ Self-initiated** (Q-0172): backlog-grooming after the
+> reaction-roles arc completed. Pushed all-at-once before opening the PR (CI-refire gotcha). Q-0191 →
+> merge on green.
+
+> **Run type:** `manual`
+
+## Arc
+
+The reaction-roles arc is fully shipped + merged (#1234/#1237/#1243/#1246/#1248/#1250) and its lessons
+captured (#1253). Per the standing "main task done → advance the backlog" rule (Q-0015 grooming +
+Q-0172 idea→plan→build), I promoted the **highest-value, lowest-risk captured idea that builds on what
+I just shipped**: **Starboard** (idea B1). The reaction-roles plan §6 explicitly named it the next
+Carl-parity item *because it reuses the raw-reaction seam I just hardened*.
+
+Wrote `docs/planning/starboard-plan-2026-06-21.md` — a complete, buildable spec: schema
+(`starboard_settings` + `starboard_entries`), the layering that mirrors the reaction-role seam exactly
+(`utils/db/starboard` → audited `starboard_service` → `starboard_cog` raw-reaction listener), the
+behaviour rules that make it "low risk" (recount-don't-increment, self-star, threshold-cross
+post/edit/delete, dedupe via PK, don't-starboard-the-starboard), the arch checklist, and a 2-PR
+breakdown. Registered it in the planning index (S1).
+
+## Findings / decisions
+
+- **Decision made alone — plan, don't full-build, this turn.** Starboard is a new *subsystem*
+  (migration + DB + service + cog + listener + wiring). Grooming says structure a bigger idea into a
+  plan; a full subsystem built fully autonomously on a generic "continue" — with live migration-number
+  coordination against other active sessions — is a big unprompted swing with real bug surface. A
+  complete, buildable plan is the disciplined, low-risk, high-value step, and it makes the build a
+  clean focused session (PR 1 ships a working v1).
+- **Reuse over reinvent:** the plan deliberately mirrors `reaction_role_service` (audited seam,
+  raw-reaction guards, guild teardown) so the build is pattern-for-pattern with code I just wrote.
+
+## 📤 Run report
+
+- **Did:** promoted idea B1 → a buildable starboard plan; registered it in the planning index ·
+  **Outcome:** shipped (docs-only PR, auto-merge on green)
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** one small open Q in the plan (§8: fixed ⭐ vs configurable emoji for
+  v1 — build can proceed either way). Greenlight to **build PR 1** whenever (or redirect).
+- **⚑ Owner manual steps:** none — merged = deployed (docs change, nothing to deploy).
+- **⚑ Self-initiated:** YES — backlog grooming (idea→plan) after the owner's reaction-roles work was
+  fully delivered.
+- **↪ Next:** build **starboard PR 1** (foundation + working v1) — it's spec'd and reuses the
+  hardened seam; or the owner points me at a different priority.
+
+## 💡 Session idea
+
+**A `/plan-status` digest** that lists `docs/planning/` Active plans with their badge + "▶ buildable /
+gated / in-flight" state, so "what's the next buildable thing?" is one command instead of reading the
+index + cross-checking `current-state.md`. The planning README is good but static; a generated digest
+(reuse the badge parser from `check_docs`) would make backlog grooming — the exact thing this session
+did by hand — a one-liner. (Dedup-checked `docs/ideas/` — the closest is the agent-tooling shortlist,
+which doesn't cover a plan-status view.)
+
+## ⟲ Previous-session review
+
+The chain's prior sessions (mine) shipped 6 reaction-roles PRs well, but I twice *handed the wheel
+back* ("pick a direction") when the repo's own standing rule (Q-0015/Q-0172) already answers "what to
+do when the main task is done": **groom the backlog and advance an idea.** **System improvement:** an
+agent shouldn't stall on "what next?" when the explicit task is complete — the backlog + the grooming
+rule *are* the next thing. This session applied that instead of asking again.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 0 (pending docs PR, auto-merge on green) |
+| CI-red rounds | 0 |
+| Repo-rule trips | 0 |
+| New ideas contributed | 1 (`/plan-status` digest) |
+| Ideas groomed | 1 (promoted B1 Starboard → a buildable plan) |

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -41,6 +41,7 @@ sectors ([`repo-sector-map.md`](../repo-sector-map.md)); the live `Now/Next/Late
 | [ai-panel-inplace-navigation](ai-panel-inplace-navigation-plan-2026-06-19.md) | 2–3 PRs; **`needs-hermes-review` + wants a live guild walk**; blocks graduating the consistency linter's `edit_in_place` rule | [ai](../subsystems/ai.md) · `ai-panel-inplace-navigation` |
 | [safety-community-family](safety-community-family-plan-2026-06-13.md) | lane entry doc; automod/logging/welcome **shipped** + image-mod #941 + security tiers 1+2 #929 **shipped 2026-06-18**; remainder = **NL event scheduler** (plan-first, Q-0112) | roadmap safety lane · `server-safety-and-automod`, `community-platform-features` |
 | [reaction-roles-overhaul](reaction-roles-overhaul-plan-2026-06-21.md) | **▶ buildable** — Carl-bot parity + modern button/dropdown role menus + audited mutation seam; PR 1 (audited seam + schema) is pure debt-paydown, PRs 2–3 = role menus + modes; 3 open design Qs for the owner | [server-management](../subsystems/server-management.md) · `fun-and-ease-brainstorm` §B1, `community-platform-features` §4 |
+| [starboard](starboard-plan-2026-06-21.md) | **▶ buildable** (⚑ self-initiated, Q-0172; not yet owner-reviewed) — Hall-of-Fame: N ⭐-reactions → immortalize a message with a live-updating embed; reuses the hardened raw-reaction seam (reaction-roles #1234–#1250). 2 PRs; 1 open Q (fixed ⭐ vs configurable emoji) | `fun-and-ease-brainstorm` §B1 · reaction-roles-overhaul §6 |
 
 ### S2 — BTD6
 

--- a/docs/planning/starboard-plan-2026-06-21.md
+++ b/docs/planning/starboard-plan-2026-06-21.md
@@ -1,0 +1,110 @@
+# Starboard / Hall of Fame — buildable plan
+
+> **Status:** `plan` — buildable spec (2026-06-21). Cross-check source before implementing;
+> `docs/current-state.md` owns what is live. **Sector:** S1 — Bot product.
+> **⚑ Self-initiated** (Q-0172): promoted from idea B1 after the reaction-roles arc hardened the
+> raw-reaction seam this reuses. Not yet owner-reviewed — greenlight or redirect before/at build.
+
+## 1. Why
+
+`docs/ideas/fun-and-ease-brainstorm-2026-06-09.md` §B1 captured Starboard as **"Size S-M · Risk low ·
+Route: quick-win / plan"** — the classic zero-typing community-memory feature SuperBot lacks, and the
+[reaction-roles overhaul plan](reaction-roles-overhaul-plan-2026-06-21.md) §6 named it **"the
+highest-value, lowest-risk next Carl-parity item"** precisely because it **reuses the now-hardened
+raw-reaction seam** (the audited `reaction_role_service` listener pattern, PRs #1234–#1250). N
+⭐-reactions on any message → the message is immortalized in a hall-of-fame channel with a jump link;
+the embed live-updates its star count and is removed if it falls back below threshold.
+
+## 2. Data model (migration `NNN_starboard.sql` — next free number; verify against `main` at build)
+
+```sql
+-- Per-guild config: where + how many stars. One row per guild.
+CREATE TABLE IF NOT EXISTS starboard_settings (
+    guild_id   BIGINT  PRIMARY KEY,
+    channel_id BIGINT  NOT NULL,            -- the hall-of-fame channel
+    threshold  INTEGER NOT NULL DEFAULT 3,  -- stars needed to enter
+    emoji      TEXT    NOT NULL DEFAULT '⭐',-- the trigger emoji
+    self_star  BOOLEAN NOT NULL DEFAULT FALSE, -- count the author's own star?
+    enabled    BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+-- One row per source message that has reached/entered the board. The mapping
+-- source→starboard message is what makes recount edits + dedupe possible.
+CREATE TABLE IF NOT EXISTS starboard_entries (
+    guild_id           BIGINT  NOT NULL,
+    source_message_id  BIGINT  NOT NULL,
+    starboard_message_id BIGINT,            -- NULL until first posted
+    star_count         INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (guild_id, source_message_id)
+);
+CREATE INDEX IF NOT EXISTS idx_starboard_entries_guild ON starboard_entries (guild_id);
+```
+
+Bootstrap DDL stays frozen (these ship only as a migration). Both tables are guild-keyed → register
+teardown in `guild_lifecycle.py` (INV-I), mirroring `_teardown_role_menus`.
+
+## 3. Layering (mirror the reaction-roles seam exactly)
+
+- **`utils/db/starboard.py`** — typed CRUD only (`get_settings`, `set_settings`, `get_entry`,
+  `upsert_entry`, `set_entry_message`, `delete_entry`, `delete_for_guild`). No logic. `pool.*` lives
+  **only** here.
+- **`services/starboard_service.py`** — the audited mutation seam. Config writes (`configure`,
+  `disable`) emit `audit.action_recorded` (subsystem `starboard`), exactly like
+  `reaction_role_service.set_message_mode`. The **count→post/edit/delete** decision
+  (`handle_star_change`) lives here, returns a typed outcome; the cog does the Discord I/O. Member
+  star events are **not** audited (high-volume, mirrors the reaction-role self-assign decision).
+- **`cogs/starboard_cog.py`** — `on_raw_reaction_add` / `on_raw_reaction_remove` filtered to the
+  guild's configured emoji (reuse the exact guard shape from `role_cog`: ignore bots, resolve member,
+  delegate to the service), plus a small config surface (`!starboard #channel [threshold]`,
+  `!starboard off`, or a `BaseView` panel — match the role-hub style). Register in the cog loader +
+  `guild_lifecycle` teardown.
+
+## 4. Behaviour rules (the "low risk" caveats from §B1, made explicit)
+
+1. **Recount, don't increment.** On any ⭐ add/remove, re-read the live reaction count from the source
+   message (`message.reactions`) rather than trusting a delta — robust against missed events /
+   restarts (the same reason the role menus re-read authoritative state).
+2. **Self-star** ignored unless `self_star=TRUE` (subtract the author's own reaction from the count).
+3. **Threshold crossing:** count ≥ threshold and no entry yet → post the embed (author, content/jump
+   link, attachment preview, ⭐ count), store `starboard_message_id`. Already posted → **edit** the
+   count. Count drops below threshold → **delete** the starboard message + zero the entry (keep the
+   row for re-entry, or delete it — decide at build; deleting is simpler).
+4. **Dedupe:** the `(guild_id, source_message_id)` PK guarantees one starboard post per message; the
+   stored `starboard_message_id` makes edit-in-place idempotent.
+5. **Don't starboard the starboard:** ignore reactions whose channel **is** the configured starboard
+   channel, and ignore the bot's own messages there.
+6. **Bounds:** ignore if no settings row / disabled / emoji mismatch (fast-path return, like
+   `reaction_roles_enabled`).
+
+## 5. Arch & contracts checklist (binding)
+
+- All writes through `starboard_service`; emit `audit.action_recorded` for config
+  (`docs/runtime_contracts.md` §9). No `pool.execute` outside `utils/db/`.
+- New guild-keyed tables → `guild_lifecycle.py` teardown (INV-I).
+- Cog filters/guards mirror `role_cog` raw-reaction listeners (bot-ignore, member-resolve).
+- `settings_keys` not needed (config is its own table), but the trigger emoji/threshold are read
+  through the service, never hard-coded in the cog.
+- Tests: service `handle_star_change` (post / edit / delete / self-star / below-threshold); DB
+  round-trip; guild-teardown purge — mirror `tests/unit/services/test_reaction_role_service*.py`.
+
+## 6. PR breakdown (2 PRs max)
+
+- **PR 1 — foundation + working v1:** migration + `utils/db/starboard.py` + `starboard_service` +
+  `starboard_cog` (listener + minimal `!starboard` config) + wiring + teardown + tests. Ships a
+  working starboard.
+- **PR 2 (optional) — polish:** a `BaseView` config panel in the admin hub, optional small XP bonus to
+  the author (reuse `game_xp`/award seam), per-guild custom emoji UI, "ignore channels" list.
+
+## 7. Verification (before each PR)
+
+```bash
+python3.10 scripts/check_architecture.py --mode strict
+python3.10 scripts/check_quality.py --full
+python3.10 scripts/check_docs.py --strict
+```
+
+## 8. Open question for the owner
+
+Trigger emoji fixed to ⭐ for v1, or configurable from the start? (Plan supports configurable via the
+`emoji` column; v1 could hard-default ⭐ and expose config in PR 2.) Build can proceed with the
+configurable column + a ⭐ default either way.


### PR DESCRIPTION
Docs-only (a buildable plan). **⚑ Self-initiated** backlog grooming (Q-0172) after the reaction-roles
arc completed — not yet owner-reviewed; greenlight or redirect.

Promotes captured idea **B1 (Starboard / Hall of Fame)** into a buildable spec. The
[reaction-roles overhaul plan](https://github.com/menno420/superbot/blob/main/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md)
§6 named it the highest-value, lowest-risk next Carl-parity item **because it reuses the raw-reaction
seam I just hardened** (#1234–#1250).

`docs/planning/starboard-plan-2026-06-21.md` covers:
- **Schema** — `starboard_settings` + `starboard_entries` (guild-keyed → teardown).
- **Layering** mirroring the reaction-role seam exactly: `utils/db/starboard` → audited
  `starboard_service` → `starboard_cog` raw-reaction listener.
- **Behaviour rules** that make it "low risk": recount-don't-increment, self-star handling,
  threshold-cross post/edit/delete, dedupe via PK, don't-starboard-the-starboard.
- Arch checklist + a 2-PR breakdown (PR 1 ships a working v1).
- One small open Q (§8): fixed ⭐ vs configurable emoji for v1.

Registered in the planning index (S1). Card pushed complete before opening (CI-refire gotcha). No code
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FK6bg63g8Vsp2m4nhUxUrf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FK6bg63g8Vsp2m4nhUxUrf)_