### PR TITLE
Creature PvP: 🔄 Rematch button on the outcome embed (self-initiated)

### DIFF
--- a/.sessions/2026-06-21-creature-pvp-rematch-button.md
+++ b/.sessions/2026-06-21-creature-pvp-rematch-button.md
@@ -1,20 +1,100 @@
 # 2026-06-21 — Creature PvP: rematch button (⚑ self-initiated)
 
-> **Status:** `in-progress` — born-red HOLD; flips to `complete` as the final step.
+> **Status:** `complete` — PR #1262. **⚑ Self-initiated** (Q-0172).
 
 > **Run type:** `routine · dispatch`
 
-## What I'm about to do
+## Arc
 
-Second slice of this dispatch run (the first — creature-PvP result-recording + leaderboard, PR #1257 —
-merged). With the dispatched lane (a) consumed and budget remaining, I'm building **one contained,
-captured idea** (Q-0172 self-initiated): a **🔄 Rematch button** on the creature-PvP outcome embed.
+Second slice of this dispatch run. The first (creature-PvP result-recording + win/loss records +
+leaderboard, **PR #1257**) merged. With the dispatched ▶ Next action lane (a) consumed and budget
+remaining, I built **one contained captured idea** (Q-0172 self-initiated, "ideas exist to be built"):
+a **🔄 Rematch button** on the creature-PvP outcome embed, completing the creature-PvP v1 UX.
 
-- `views/creature_battle/rematch.py` — `CreatureRematchView(BaseView)`: a two-participant
-  `interaction_check` (either fighter may click — specialized lifecycle, commented) + one Rematch button
-  that re-issues a fresh `CreatureBattleChallengeView` (clicker = challenger, other = opponent).
-- `challenge.py` attaches the rematch view to the outcome message.
-- No new service/DB/schema — reuses the existing challenge flow + the #1257 audited result-recording on
-  the next battle automatically.
+## What shipped (PR #1262)
 
-⚑ Self-initiated (Q-0172) — captured first in `docs/ideas/creature-pvp-rematch-button-2026-06-21.md`.
+- `views/creature_battle/rematch.py` — `CreatureRematchView(BaseView)`: a **two-participant**
+  `interaction_check` (either fighter may click; a third party gets an ephemeral nudge — specialized
+  lifecycle, commented, since `public=False` locks to one author and `public=True` opens to the whole
+  channel) + one Rematch button that re-issues a fresh `CreatureBattleChallengeView` (clicker =
+  challenger, other fighter = opponent, who Accepts/Declines as usual). **No new battle logic** — the
+  next battle reuses the existing challenge flow and the #1257 audited result-recording path.
+- `challenge.py` attaches the rematch view to the outcome message (`wait=True` so `.message` is set for
+  on-timeout disable).
+- `__init__.py` exports `CreatureRematchView`.
+- idea doc captured first (`docs/ideas/creature-pvp-rematch-button-2026-06-21.md` + README index entry).
+- `tests/unit/views/test_creature_rematch.py` — the view has the button; both fighters pass the check;
+  a third party is rejected with an ephemeral message.
+
+## Findings / decisions
+
+- **Self-initiation (the decision itself):** with the dispatched lane done and budget left, I built one
+  small reversible captured idea rather than stop after one PR (the routine's "never just after one PR").
+  Flagged ⚑ self-initiated on the run report + the idea doc + the claim, so it's trivially reviewable.
+  Kept it to a single increment (no new arc).
+- **Decision made alone — one-click rematch, not mutual-consent.** A single click re-issues a *challenge*
+  (which the other fighter then Accepts/Declines) rather than requiring both to opt in up front — the
+  existing Accept/Decline step IS the agreement, so a second gate would be redundant friction.
+- **Decision made alone — two-participant view.** `BaseView` is single-author; I widened
+  `interaction_check` to the two fighters rather than inventing a new base class (the rps/deathmatch
+  game-view precedent for specialized lifecycle, documented in a comment).
+
+## Context delta
+
+- **Needed but not pointed to:** nothing new — `views/rps/solo_play.py`'s `🔁 Play again` button was the
+  shape precedent, and `CreatureBattleChallengeView` (#1230) did all the heavy lifting on re-issue.
+- **Discovered by hand:** (1) `interaction.followup.send(...)` is typed to return `None` unless
+  `wait=True` — mypy `func-returns-value` when you assign the result to `.message`; pass `wait=True`.
+  (2) a late `from ... import CreatureBattleChallengeView` inside the callback breaks the
+  challenge↔rematch import cycle (the rps late-import precedent). (3) a new `docs/ideas/` file must be
+  badged `ideas` and linked from the README or `check_docs` flags it as an orphan.
+- **Decisions made alone:** see Findings (self-initiation; one-click rematch; two-participant view).
+- **Weak point / unverified:** not live-walked — the rematch round-trip (click → new challenge → accept →
+  resolve → record) wants a runtime smoke on a real guild with two collections + Postgres. The
+  interaction lifecycle is offline-tested only at the construction/`interaction_check` level (no live
+  Discord here).
+
+## 📤 Run report
+
+- **Did:** built a 🔄 Rematch button on the creature-PvP outcome embed (either fighter re-challenges in
+  one tap) · **Outcome:** shipped (PR #1262, full CI mirror green, auto-merge armed by owner)
+- **Shipped:** #1262 — creature PvP rematch button
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** none — but this was **self-initiated**; if you'd rather not have a
+  rematch button (or want it mutual-consent), it's a small one-file revert.
+- **⚑ Owner manual steps:** none — merge auto-deploys; no migration/data step (view-only).
+- **⚑ Self-initiated:** **YES** — the rematch button (captured idea, built under Q-0172). The earlier
+  slice this run (#1257) was the *dispatched* lane (a), not self-initiated.
+- **↪ Next:** creature-game PvP v1 is now feature-complete (catch · dex · battle · records · leaderboard ·
+  rematch). Remaining creature slices are later/gated (Explore-hub Lane-B battle panel · balance/art
+  Q-0187). Next ungated build = ▶ Next action lane (b) botsite React-SPA migration, (c) a
+  `needs-hermes-review` lane, or (d) a fresh idea (Q-0172).
+
+## 💡 Session idea
+
+**A `!cbattle` AFK/timeout forfeit nudge.** The challenge view times out after 60s with no explicit
+"challenge expired" message (it just disables silently on timeout). A one-line `on_timeout` edit —
+"⌛ {opponent} didn't respond — challenge expired" — would close the loop the way the deathmatch
+challenge does (BUG-0013's domain), so a hanging challenge reads as resolved rather than dead. Cheap,
+pure-view, and improves the same PvP UX. (Dedup-checked `docs/ideas/` — not captured.)
+
+## ⟲ Previous-session review
+
+This run's *own* first slice (#1257) was solid but its handoff under-weighted one thing: it declared
+creature PvP "buildable-complete for v1" while the outcome embed still had no replay affordance — a gap
+a player feels immediately. The fix was this very slice, which is the system working as intended (the
+"don't stop after one PR" rule caught it). **System improvement:** "buildable-complete" claims in the
+▶ Next action would be more trustworthy if they enumerated the *user-facing* loop (catch → battle →
+**replay**) rather than the *backend* surfaces (migration/service/command) — a feature can be
+backend-complete and still feel unfinished. Worth a one-line convention in the reconciliation prompt:
+when marking a game lane "complete," sanity-check the *player's* loop, not just the data/service seams.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs this run | 2 (#1257 merged · #1262 auto-merge on green) |
+| CI-red rounds (this slice) | 1 real (mypy `func-returns-value` + COM812 + doc orphan — all fixed; born-red HOLD otherwise) |
+| Self-caught pre-push | `followup.send` wait-flag · import-cycle late-import · idea-doc badge/orphan |
+| New ideas contributed | 1 (challenge-expired timeout nudge) |
+| Ideas groomed | 1 (built the captured rematch-button idea) |

--- a/.sessions/2026-06-21-creature-pvp-rematch-button.md
+++ b/.sessions/2026-06-21-creature-pvp-rematch-button.md
@@ -1,0 +1,20 @@
+# 2026-06-21 — Creature PvP: rematch button (⚑ self-initiated)
+
+> **Status:** `in-progress` — born-red HOLD; flips to `complete` as the final step.
+
+> **Run type:** `routine · dispatch`
+
+## What I'm about to do
+
+Second slice of this dispatch run (the first — creature-PvP result-recording + leaderboard, PR #1257 —
+merged). With the dispatched lane (a) consumed and budget remaining, I'm building **one contained,
+captured idea** (Q-0172 self-initiated): a **🔄 Rematch button** on the creature-PvP outcome embed.
+
+- `views/creature_battle/rematch.py` — `CreatureRematchView(BaseView)`: a two-participant
+  `interaction_check` (either fighter may click — specialized lifecycle, commented) + one Rematch button
+  that re-issues a fresh `CreatureBattleChallengeView` (clicker = challenger, other = opponent).
+- `challenge.py` attaches the rematch view to the outcome message.
+- No new service/DB/schema — reuses the existing challenge flow + the #1257 audited result-recording on
+  the next battle automatically.
+
+⚑ Self-initiated (Q-0172) — captured first in `docs/ideas/creature-pvp-rematch-button-2026-06-21.md`.

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-21T21:34:20Z",
+    "generated_at": "2026-06-21T21:51:39Z",
     "build": {
-      "commit": "ec8a8d68",
-      "subject": "Merge remote-tracking branch 'origin/main' into claude/funny-franklin-m1xdmf",
-      "committed_at": "2026-06-21T21:34:16Z",
+      "commit": "decbda35",
+      "subject": "Merge remote-tracking branch 'origin/claude/funny-franklin-m1xdmf' into claude/funny-franklin-m1xdmf",
+      "committed_at": "2026-06-21T21:51:28Z",
       "branch": "claude/funny-franklin-m1xdmf"
     }
   },
@@ -3245,6 +3245,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Creature PvP — rematch button on the outcome embed",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — a parity guard tying the creature sim to the runtime battle engine",
           "status": "ideas"
         }
@@ -3445,6 +3449,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Creature PvP — rematch button on the outcome embed",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — a parity guard tying the creature sim to the runtime battle engine",
           "status": "ideas"
         }
@@ -3465,6 +3473,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Creature PvP — rematch button on the outcome embed",
+          "status": "ideas"
+        },
         {
           "title": "Idea — a parity guard tying the creature sim to the runtime battle engine",
           "status": "ideas"

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -992,6 +992,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Creature PvP — rematch button on the outcome embed"
+      },
+      {
+        "status": "idea",
         "title": "Idea — a parity guard tying the creature sim to the runtime battle…"
       }
     ]
@@ -1644,6 +1648,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Creature PvP — rematch button on the outcome embed"
+      },
+      {
+        "status": "idea",
         "title": "Idea — a parity guard tying the creature sim to the runtime battle…"
       }
     ]
@@ -1662,6 +1670,10 @@ const COMMANDS = [
     "cooldown": null,
     "examples": [],
     "planned": [
+      {
+        "status": "idea",
+        "title": "Creature PvP — rematch button on the outcome embed"
+      },
       {
         "status": "idea",
         "title": "Idea — a parity guard tying the creature sim to the runtime battle…"
@@ -5720,7 +5732,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "ec8a8d68",
+    "build": "decbda35",
     "title": "New public bot website",
     "changes": [
       {
@@ -5732,7 +5744,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "ec8a8d68",
+    "build": "decbda35",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -5744,7 +5756,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "ec8a8d68",
+    "build": "decbda35",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,15 +1,15 @@
 {
   "meta": {
-    "generated_at": "2026-06-21T21:34:20Z",
+    "generated_at": "2026-06-21T21:51:39Z",
     "build": {
-      "commit": "ec8a8d68",
-      "subject": "Merge remote-tracking branch 'origin/main' into claude/funny-franklin-m1xdmf",
-      "committed_at": "2026-06-21T21:34:16Z",
+      "commit": "decbda35",
+      "subject": "Merge remote-tracking branch 'origin/claude/funny-franklin-m1xdmf' into claude/funny-franklin-m1xdmf",
+      "committed_at": "2026-06-21T21:51:28Z",
       "branch": "claude/funny-franklin-m1xdmf"
     },
     "counts": {
       "functions": 37,
-      "ideas": 114,
+      "ideas": 115,
       "bugs": 23,
       "reviews": 0,
       "reviews_open": 0,
@@ -1006,6 +1006,14 @@
       "subsystems": [
         "role"
       ]
+    },
+    {
+      "file": "creature-pvp-rematch-button-2026-06-21.md",
+      "title": "Creature PvP — rematch button on the outcome embed",
+      "status": "ideas",
+      "date": "2026-06-21",
+      "summary": "The creature PvP flow (`!cbattle`, shipped #1230 + #1257) ends with a static outcome embed; to play",
+      "subsystems": null
     },
     {
       "file": "creature-sim-engine-constant-parity-guard-2026-06-21.md",
@@ -2365,6 +2373,14 @@
       "self_initiated": false
     },
     {
+      "file": "2026-06-21-creature-pvp-rematch-button.md",
+      "date": "2026-06-21",
+      "title": "2026-06-21 — Creature PvP: rematch button (⚑ self-initiated)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": true
+    },
+    {
       "file": "2026-06-21-creature-pvp-battle-flow.md",
       "date": "2026-06-21",
       "title": "2026-06-21 — Creature PvP battle flow (cog + views + service)",
@@ -2411,6 +2427,14 @@
       "status": "complete",
       "run_type": "routine",
       "self_initiated": false
+    },
+    {
+      "file": "2026-06-21-btd6-seed-data-changed-report.md",
+      "date": "2026-06-21",
+      "title": "2026-06-21 — BTD6: seed-data reports which files it changed",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": true
     },
     {
       "file": "2026-06-21-btd6-data-auto-seed.md",
@@ -2579,22 +2603,6 @@
       "status": "complete",
       "run_type": "routine",
       "self_initiated": false
-    },
-    {
-      "file": "2026-06-20-federated-explore-world-card.md",
-      "date": "2026-06-20",
-      "title": "2026-06-20 — Federated Explore-hub PR 3: cross-game world card",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-20-design-system-site-pages.md",
-      "date": "2026-06-20",
-      "title": "2026-06-20 — Design-system: compose the rest of the site (Features/Commands/Changelog/Status)",
-      "status": "complete",
-      "run_type": "manual",
-      "self_initiated": true
     }
   ],
   "bot_changelog": [

--- a/disbot/views/creature_battle/__init__.py
+++ b/disbot/views/creature_battle/__init__.py
@@ -10,9 +10,11 @@ player's team lives in :mod:`services.creature_battle_service`.
 from __future__ import annotations
 
 from views.creature_battle.challenge import CreatureBattleChallengeView
+from views.creature_battle.rematch import CreatureRematchView
 from views.creature_battle.render import build_result_embed
 
 __all__ = [
     "CreatureBattleChallengeView",
+    "CreatureRematchView",
     "build_result_embed",
 ]

--- a/disbot/views/creature_battle/challenge.py
+++ b/disbot/views/creature_battle/challenge.py
@@ -16,6 +16,7 @@ import discord
 
 from services import creature_battle_service
 from views.base import BaseView
+from views.creature_battle.rematch import CreatureRematchView
 from views.creature_battle.render import build_result_embed
 
 logger = logging.getLogger("bot.creature_battle.challenge")
@@ -73,7 +74,13 @@ class CreatureBattleChallengeView(BaseView):
             records=records,
             xp_note=recorded.xp_note,
         )
-        await interaction.followup.send(embed=embed)
+        # Attach a rematch button so either fighter can re-challenge in one tap.
+        rematch = CreatureRematchView(self.challenger, self.opponent, self.guild_id)
+        rematch.message = await interaction.followup.send(
+            embed=embed,
+            view=rematch,
+            wait=True,
+        )
         self.stop()
 
     @discord.ui.button(label="Decline", style=discord.ButtonStyle.red, emoji="❌")

--- a/disbot/views/creature_battle/rematch.py
+++ b/disbot/views/creature_battle/rematch.py
@@ -1,0 +1,81 @@
+"""Creature PvP rematch view (creature-game v1).
+
+Attached to the battle-outcome embed so either fighter can fire a fresh challenge
+without re-typing ``!cbattle @x`` — the continuous-laddering affordance, mirroring
+the rps ``🔁 Play again`` button. The button re-issues a brand-new
+:class:`views.creature_battle.challenge.CreatureBattleChallengeView` (the clicker
+becomes the challenger, the other fighter the opponent, who Accepts/Declines as
+usual), so there is **no new battle logic** — the next battle reuses the existing
+challenge flow and the audited result-recording path.
+
+Specialized lifecycle: unlike a standard single-author ``BaseView``, the rematch
+button is interactable by **either** participant. The check below allows the two
+fighters and no one else; ``BaseView(public=False)`` would lock it to one author,
+``public=True`` would open it to the whole channel — neither is right here.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from views.base import BaseView
+
+logger = logging.getLogger("bot.creature_battle.rematch")
+
+
+class CreatureRematchView(BaseView):
+    """A single 🔄 Rematch button either fighter may press to re-challenge."""
+
+    def __init__(
+        self,
+        player_a: discord.Member,
+        player_b: discord.Member,
+        guild_id: int,
+    ) -> None:
+        # author=player_a satisfies BaseView; interaction_check below widens the
+        # allowed clickers to both fighters (specialized two-participant lifecycle).
+        super().__init__(player_a, timeout=120)
+        self.player_a = player_a
+        self.player_b = player_b
+        self.guild_id = guild_id
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.user.id in (self.player_a.id, self.player_b.id):
+            return True
+        await interaction.response.send_message(
+            "Only the two fighters can start a rematch — challenge with `!cbattle` "
+            "to play your own.",
+            ephemeral=True,
+        )
+        return False
+
+    @discord.ui.button(label="Rematch", style=discord.ButtonStyle.primary, emoji="🔄")
+    async def rematch(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        # The clicker re-challenges; the other fighter becomes the opponent who
+        # must Accept/Decline (the existing challenge flow IS the agreement step).
+        challenger = (
+            self.player_a if interaction.user.id == self.player_a.id else self.player_b
+        )
+        opponent = self.player_b if challenger.id == self.player_a.id else self.player_a
+
+        button.disabled = True
+        await interaction.response.edit_message(view=self)
+        self.stop()
+
+        # Late import: challenge.py attaches this view to the outcome message, so a
+        # module-level import here would create a cycle.
+        from views.creature_battle.challenge import CreatureBattleChallengeView
+
+        view = CreatureBattleChallengeView(challenger, opponent, self.guild_id)
+        view.message = await interaction.followup.send(
+            f"{opponent.mention} — {challenger.mention} wants a rematch! "
+            "Teams are level-normalized; your collection and type matchups decide it.",
+            view=view,
+            wait=True,
+        )

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -413,6 +413,11 @@ Current broad captures:
   asserts they agree) keeps the sim's "PLAYABLE" verdict honest about the bot players actually play.
   Self-merge lane; disposable once the sim is retired. → relates `tests/unit/tools/` ·
   `tests/unit/views/test_panel_base_class_allowlist_parity.py` (the same parity-guard shape).
+- [`creature-pvp-rematch-button-2026-06-21.md`](./creature-pvp-rematch-button-2026-06-21.md) —
+  **⚑ self-initiated (2026-06-21, Q-0172, built #1262):** a 🔄 Rematch button on the creature-PvP
+  outcome embed, clickable by either fighter, re-issuing a fresh `!cbattle` challenge — continuous
+  laddering with no new battle logic (reuses the challenge flow + the #1257 audited result-recording).
+  Mirrors the rps `🔁 Play again` affordance. → relates `disbot/views/creature_battle/`.
 - [`reference-integrity-invariants-2026-06-16.md`](./reference-integrity-invariants-2026-06-16.md) —
   **session idea (2026-06-16, Q-0089, from the BUG-0014 `!coglist`-loop fix PR #949):** BUG-0014 was a
   dangling reference (a synonym → a command that didn't exist) that failed *silently*. Extract the

--- a/docs/ideas/creature-pvp-rematch-button-2026-06-21.md
+++ b/docs/ideas/creature-pvp-rematch-button-2026-06-21.md
@@ -1,0 +1,28 @@
+# Creature PvP — rematch button on the outcome embed
+
+> **Status:** `in-progress` — ⚑ self-initiated (Q-0172). Captured + built 2026-06-21.
+
+## Idea
+
+The creature PvP flow (`!cbattle`, shipped #1230 + #1257) ends with a static outcome embed; to play
+again both players must re-type `!cbattle @x`. A single **🔄 Rematch** button on the outcome embed —
+clickable by *either* participant — re-issues a fresh challenge (the clicker becomes the challenger,
+the other the opponent, who then Accepts/Declines as usual). This makes laddering feel continuous,
+mirroring the rps `🔁 Play again` affordance, with **no new battle logic** — it just reuses the
+existing `CreatureBattleChallengeView`.
+
+## Why it's worth having
+
+- Removes friction from the core PvP loop (re-typing the command + mention each round).
+- Pure view addition — no new service / DB / schema; reuses the audited result-recording path on the
+  next battle automatically.
+- Completes the creature-PvP v1 UX (the catch/dex/battle/leaderboard cluster).
+
+## Shape
+
+- `views/creature_battle/rematch.py` — `CreatureRematchView(BaseView)` with a two-participant
+  `interaction_check` (either fighter may click) and one Rematch button that posts a fresh
+  `CreatureBattleChallengeView`.
+- `challenge.py` attaches the rematch view to the outcome message.
+
+Dedup-checked `docs/ideas/` (2026-06-21) — not previously captured.

--- a/docs/ideas/creature-pvp-rematch-button-2026-06-21.md
+++ b/docs/ideas/creature-pvp-rematch-button-2026-06-21.md
@@ -1,6 +1,6 @@
 # Creature PvP — rematch button on the outcome embed
 
-> **Status:** `in-progress` — ⚑ self-initiated (Q-0172). Captured + built 2026-06-21.
+> **Status:** `ideas` — ⚑ self-initiated (Q-0172). Captured + built (#1262) 2026-06-21.
 
 ## Idea
 

--- a/tests/unit/views/test_creature_rematch.py
+++ b/tests/unit/views/test_creature_rematch.py
@@ -1,0 +1,51 @@
+"""creature_battle rematch view — two-participant interaction gating.
+
+The rematch button is interactable by *either* fighter and no one else (a
+specialized two-participant lifecycle, unlike a standard single-author BaseView).
+These pins keep that gate honest without needing a live Discord.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from views.creature_battle.rematch import CreatureRematchView
+
+
+def _member(uid: int):
+    return SimpleNamespace(id=uid, mention=f"<@{uid}>", display_name=f"U{uid}")
+
+
+def _interaction(user_id: int):
+    return SimpleNamespace(
+        user=SimpleNamespace(id=user_id),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+
+def test_view_has_a_single_rematch_button():
+    view = CreatureRematchView(_member(1), _member(2), 99)
+    labels = [getattr(c, "label", None) for c in view.children]
+    assert "Rematch" in labels
+
+
+@pytest.mark.asyncio
+async def test_either_fighter_passes_the_interaction_check():
+    view = CreatureRematchView(_member(1), _member(2), 99)
+    for uid in (1, 2):
+        interaction = _interaction(uid)
+        assert await view.interaction_check(interaction) is True
+        interaction.response.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_third_party_is_rejected_with_an_ephemeral_nudge():
+    view = CreatureRematchView(_member(1), _member(2), 99)
+    interaction = _interaction(3)
+    assert await view.interaction_check(interaction) is False
+    interaction.response.send_message.assert_awaited_once()
+    _, kwargs = interaction.response.send_message.await_args
+    assert kwargs.get("ephemeral") is True


### PR DESCRIPTION
**Born-red** (session card `in-progress`). **⚑ Self-initiated** (Q-0172) second slice of this dispatch
run — the first (creature-PvP result-recording + leaderboard, #1257) merged. With the dispatched lane
consumed and budget remaining, this builds one small captured idea that completes the creature-PvP v1 UX.

## What this ships

A **🔄 Rematch button** on the creature-PvP outcome embed (the `!cbattle` flow). Either participant can
click it; the clicker becomes the challenger and the other the opponent in a fresh
`CreatureBattleChallengeView` (who Accepts/Declines as usual). Mirrors the rps `🔁 Play again`
affordance — **no new battle logic, no service/DB/schema**; the next battle reuses the #1257 audited
result-recording path automatically.

- `views/creature_battle/rematch.py` — `CreatureRematchView(BaseView)` with a two-participant
  `interaction_check` (either fighter; specialized lifecycle, commented) + one Rematch button.
- `challenge.py` attaches the rematch view to the outcome message.
- idea doc captured first (`docs/ideas/creature-pvp-rematch-button-2026-06-21.md`); unit tests for the
  view (construction + the two-participant check rejecting a third party).

Small, contained, reversible — self-merge on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GphmwrVwYwzW3H3QzEdXNc)_