### PR TITLE
BTD6 buff-uptime: model attack-speed buffs on the Alchemist (alch_speed)

### DIFF
--- a/.sessions/2026-06-21-btd6-buff-uptime-alch-speed.md
+++ b/.sessions/2026-06-21-btd6-buff-uptime-alch-speed.md
@@ -1,24 +1,64 @@
 # 2026-06-21 — BTD6 buff-uptime: model attack-speed buffs on the Alchemist
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Arc (owner-chosen via question panel)
-The capstone of buff-uptime realism: when the **Alchemist itself** is sped up (Jungle Drums,
-Monkey Boost, Overclock, …), its brew-throw cadence drops — and below the per-target
-`rebuffBlockTime` floor it can keep MORE towers buffed. This is the one scenario where the
-`rebuffBlockTime` decoded in #1251 finally binds, and the case the calc couldn't express.
+The capstone of buff-uptime realism: when the **Alchemist itself** is sped up, its brew-throw
+cadence drops, and below the per-target `rebuffBlockTime` floor (decoded #1251) it keeps MORE
+towers buffed — the one scenario where that floor binds. **Under the ~2-PR estimate:** the speed
+multipliers are already in committed data, so no decode pass — one clean calc PR.
 
-**Good news vs the ~2-PR estimate:** the speed multipliers are **already in committed data**, so
-no decode pass is needed — this is one clean PR:
-- "Jungle Drums" → Monkey Village 2-0-0 `RateSupport` ×0.85 (resolve_upgrade → tier rate buff).
-- "Monkey Boost" → power `rate_scale` 0.5 (already decoded).
-- "Overclock" → Engineer rate buff ×0.25 (same upgrade-buff path).
+## Shipped (PR #1268)
+- `buff_uptime(buff_source, target, targets=1, alch_speed=None)` — `alch_speed` resolves
+  **grounded** to a cooldown multiplier: a Power's `rate_scale` (Monkey Boost ×0.5), else an
+  upgrade's attack-speed `rateMultiplier` (Jungle Drums = Village 2-0-0 ×0.85, Overclock ×0.25)
+  via `resolve_upgrade` → the tier's rate buff. `effective_cadence = cadence × mult`;
+  `rebuff_interval = max(targets × effective_cadence, rebuff_block)`. Surfaces
+  `alch_speed_source/multiplier`, `effective_throw_cadence_seconds`, `rebuff_floor_binds`.
+  Unknown / non-speed source → honest `found=False`.
+- `btd6_buff_uptime` tool: optional `alch_speed` param.
+- Tests (Monkey Boost + Jungle Drums real-data, floor-binds, multi-target improvement, unknown
+  source) + decode-status note.
 
-## Plan
-1. `buff_uptime(..., alch_speed=<source>)` — resolve the source → a cooldown multiplier
-   (Power `rate_scale`, else an upgrade's `rateMultiplier` < 1); `effective_cadence = base ×
-   mult`; `rebuff_interval = max(targets × effective_cadence, rebuff_block)`. Honest found=False
-   for an unknown/non-speed source.
-2. `btd6_buff_uptime` tool: optional `alch_speed` param.
-3. Tests (real data: Jungle Drums / Monkey Boost on 4-0-0 → 5-0-0 Ninja, single + multi-target,
-   rebuffBlockTime binding; unknown source) + docs.
+## Verification
+- `python3.10 scripts/check_quality.py --full` → all checks passed (11412 passed).
+- Real data: 4-0-0 → 5-0-0 Ninja, 2 targets — unboosted 54.2%; **Monkey Boost 100%** (×0.5 throw,
+  5s floor binds at N=1); Jungle Drums 63.8%. Unknown source → found=False. Ledger + docs green.
+
+## Decisions made alone
+- **Two grounded resolution paths** (Power `rate_scale`, upgrade `rateMultiplier<1`) rather than a
+  raw numeric multiplier param — keeps it fabrication-free (the AI names a buff; the number comes
+  from data). Unknown source fails closed with the supported kinds named.
+
+## Context delta
+- Mid-build I corrected a wrong assumption: **Jungle Drums is Monkey Village 2-0-0, not a Druid
+  buff** — and its ×0.85 aura was already in committed data on every top-path-≥2 tier. So the
+  feared "~2 PRs incl. a decode pass" collapsed to one calc PR. (Lesson: verify the buff's
+  tower/tier via `resolve_upgrade` before assuming a decode gap.)
+
+## ⟲ Previous-session review
+#1263 (seed-data changed-file report) was a clean, correctly-scoped small PR — and notably it was
+the FIRST in this BTD6 chain that *didn't* spawn a follow-up "one more consumer" PR, because the
+content_drift consumers were finally exhausted. This alch_speed PR applied the #1263 review's own
+lesson: it shipped the whole feature (resolver + tool param + both real-data + edge tests) in one
+pass instead of dribbling consumers across PRs. Workflow holding well; nothing to fix.
+
+## 💡 Session idea
+**Symmetric feature — speed buffs on the TARGET.** A sped-up *buffed tower* (e.g. a Monkey-Boosted
+Ninja) attacks faster → burns the alch buff's attack-cap SOONER → LOWER uptime (the inverse of
+this PR). `buff_uptime(..., target_speed=…)` would reuse the exact same grounded resolver
+(`_alch_speed_multiplier`) applied to `tgt_cd` instead of the cadence. Small, symmetric, grounded.
+(Captured, not built.)
+
+## 📤 Run report
+- **Did:** Modeled attack-speed buffs on the alch in buff_uptime (alch_speed) · **Outcome:** shipped (PR #1268)
+- **Shipped:** PR #1268 — `alch_speed` resolver + tool param + tests + decode-status
+- **Run type:** `manual` (owner-chosen via question panel)
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** still the one-time `!btd6ops seed-data` for the buff window data
+  (unchanged; this PR adds no new data).
+- **⚑ Self-initiated:** no — owner-directed (the AskUserQuestion pick). Came in under the
+  estimate (1 PR, no decode needed).
+- **↪ Next:** the symmetric target-speed idea (this 💡), or a fresh lane — BTD6 buff-uptime is now
+  comprehensively complete (calc · data · multi-target · auto-seed · drift warning · seed receipt ·
+  alch-speed).

--- a/.sessions/2026-06-21-btd6-buff-uptime-alch-speed.md
+++ b/.sessions/2026-06-21-btd6-buff-uptime-alch-speed.md
@@ -1,0 +1,24 @@
+# 2026-06-21 — BTD6 buff-uptime: model attack-speed buffs on the Alchemist
+
+> **Status:** `in-progress`
+
+## Arc (owner-chosen via question panel)
+The capstone of buff-uptime realism: when the **Alchemist itself** is sped up (Jungle Drums,
+Monkey Boost, Overclock, …), its brew-throw cadence drops — and below the per-target
+`rebuffBlockTime` floor it can keep MORE towers buffed. This is the one scenario where the
+`rebuffBlockTime` decoded in #1251 finally binds, and the case the calc couldn't express.
+
+**Good news vs the ~2-PR estimate:** the speed multipliers are **already in committed data**, so
+no decode pass is needed — this is one clean PR:
+- "Jungle Drums" → Monkey Village 2-0-0 `RateSupport` ×0.85 (resolve_upgrade → tier rate buff).
+- "Monkey Boost" → power `rate_scale` 0.5 (already decoded).
+- "Overclock" → Engineer rate buff ×0.25 (same upgrade-buff path).
+
+## Plan
+1. `buff_uptime(..., alch_speed=<source>)` — resolve the source → a cooldown multiplier
+   (Power `rate_scale`, else an upgrade's `rateMultiplier` < 1); `effective_cadence = base ×
+   mult`; `rebuff_interval = max(targets × effective_cadence, rebuff_block)`. Honest found=False
+   for an unknown/non-speed source.
+2. `btd6_buff_uptime` tool: optional `alch_speed` param.
+3. Tests (real data: Jungle Drums / Monkey Boost on 4-0-0 → 5-0-0 Ninja, single + multi-target,
+   rebuffBlockTime binding; unknown source) + docs.

--- a/disbot/services/ai_tools.py
+++ b/disbot/services/ai_tools.py
@@ -1696,6 +1696,15 @@ _BTD6_BUFF_UPTIME_SPEC = AIToolSpec(
                     "(default 1). The alch round-robins its throws across them."
                 ),
             },
+            "alch_speed": {
+                "type": "string",
+                "description": (
+                    "Optional attack-speed buff ON THE ALCHEMIST itself (e.g. "
+                    "'Monkey Boost', 'Jungle Drums', 'Overclock') — it speeds the "
+                    "brew throw, so the alch keeps more towers buffed. Use for "
+                    "'with Jungle Drums, can my alch keep N towers buffed'."
+                ),
+            },
         },
         "required": ["buff_source", "target"],
         "additionalProperties": False,
@@ -1716,7 +1725,13 @@ async def _btd6_buff_uptime(arguments: dict[str, Any]) -> dict[str, Any]:
         targets = max(1, int(raw_targets))
     except (TypeError, ValueError):
         targets = 1
-    return btd6_upgrade_detail_service.buff_uptime(buff_source, target, targets=targets)
+    alch_speed = str(arguments.get("alch_speed") or "").strip() or None
+    return btd6_upgrade_detail_service.buff_uptime(
+        buff_source,
+        target,
+        targets=targets,
+        alch_speed=alch_speed,
+    )
 
 
 # --- btd6_paragon_calculate --------------------------------------------------

--- a/disbot/services/btd6_upgrade_detail_service.py
+++ b/disbot/services/btd6_upgrade_detail_service.py
@@ -538,7 +538,60 @@ def _alch_buff_attack(tower_id: str, code: str) -> dict[str, Any] | None:
     return brew or acidic
 
 
-def buff_uptime(buff_source: str, target: str, targets: int = 1) -> dict[str, Any]:
+def _tier_rate_buff_multiplier(tower_id: str, code: str) -> float | None:
+    """The attack-speed (cooldown) multiplier of a tier's rate buff, or ``None``.
+
+    Reads the committed ``buffs[].rateMultiplier`` — a value ``< 1`` means a
+    *speed-up* (lower cooldown). Used to ground an Alchemist-speed source like
+    Jungle Drums (Village 2-0-0, ×0.85) or Overclock (Engineer, ×0.25).
+    """
+    stats = btd6_stats_service.get_tower_stats(tower_id)
+    tier = stats.tier(code) if stats is not None else None
+    for buff in (tier or {}).get("buffs", []) or []:
+        if isinstance(buff, dict):
+            mult = buff.get("rateMultiplier")
+            if (
+                isinstance(mult, (int, float))
+                and not isinstance(mult, bool)
+                and 0 < mult < 1
+            ):
+                return float(mult)
+    return None
+
+
+def _alch_speed_multiplier(name: str) -> tuple[float, str] | None:
+    """Resolve an attack-speed source on the Alchemist → ``(cooldown_multiplier,
+    display)`` where ``multiplier < 1`` = faster throwing, or ``None``.
+
+    Grounded, two paths: a **Power**'s ``rate_scale`` (Monkey Boost → 0.5), else
+    an **upgrade**'s attack-speed ``rateMultiplier`` (Jungle Drums → 0.85,
+    Overclock → 0.25). ``None`` when it resolves to nothing or to something with
+    no attack-speed buff — never a fabricated number.
+    """
+    from services import btd6_data_service
+
+    query = name.strip()
+    if not query:
+        return None
+    power = btd6_data_service.find_power(query)
+    if power is not None:
+        rate_scale = (power.effect or {}).get("rate_scale")
+        if isinstance(rate_scale, (int, float)) and 0 < rate_scale < 1:
+            return float(rate_scale), power.canonical
+    res = btd6_upgrade_service.resolve_upgrade(query)
+    if res.upgrade is not None:
+        mult = _tier_rate_buff_multiplier(res.upgrade.tower_id, res.upgrade.code)
+        if mult is not None:
+            return mult, res.upgrade.canonical
+    return None
+
+
+def buff_uptime(
+    buff_source: str,
+    target: str,
+    targets: int = 1,
+    alch_speed: str | None = None,
+) -> dict[str, Any]:
     """Compute an Alchemist buff's uptime on a target tower — the grounded
     compute behind the ``btd6_buff_uptime`` tool.
 
@@ -552,9 +605,15 @@ def buff_uptime(buff_source: str, target: str, targets: int = 1) -> dict[str, An
     round-robins its throws, so a given tower is re-buffed every
     ``max(targets × throw_cadence, rebuff_block)`` seconds (``rebuff_block`` =
     the dump's per-target ``rebuffBlockTime`` floor). ``targets=1`` is the
-    single-tower case. Returns ``found=False`` with an honest note when the buff
-    isn't an Alchemist buff, the window isn't decoded, or the target has no
-    attack stat — never a fabricated number.
+    single-tower case.
+
+    ``alch_speed`` is an attack-speed buff *on the Alchemist itself* (e.g.
+    "Monkey Boost", "Jungle Drums", "Overclock"): it speeds the brew throw
+    (``effective_cadence = throw_cadence × multiplier``), which lets the alch keep
+    more towers buffed — until the fixed ``rebuff_block`` floor binds. Returns
+    ``found=False`` with an honest note when the buff isn't an Alchemist buff, the
+    window isn't decoded, the target has no attack stat, or ``alch_speed`` doesn't
+    resolve to a known attack-speed source — never a fabricated number.
     """
     targets = max(1, int(targets))
     src = _resolve_stat_target(buff_source)
@@ -624,6 +683,22 @@ def buff_uptime(buff_source: str, target: str, targets: int = 1) -> dict[str, An
             ),
         }
 
+    # Optional attack-speed buff ON THE ALCHEMIST (speeds the brew throw).
+    speed_mult: float | None = None
+    speed_label: str | None = None
+    if alch_speed and alch_speed.strip():
+        resolved = _alch_speed_multiplier(alch_speed)
+        if resolved is None:
+            return {
+                "found": False,
+                "note": (
+                    f"couldn't resolve an Alchemist attack-speed source from "
+                    f"{alch_speed!r} — pass a Power (e.g. 'Monkey Boost') or an "
+                    "attack-speed buff (e.g. 'Jungle Drums', 'Overclock')."
+                ),
+            }
+        speed_mult, speed_label = resolved
+
     out: dict[str, Any] = {
         "found": True,
         "buff": buff_label,
@@ -637,6 +712,13 @@ def buff_uptime(buff_source: str, target: str, targets: int = 1) -> dict[str, An
     }
     if isinstance(cadence, (int, float)) and cadence > 0:
         out["throw_cadence_seconds"] = float(cadence)
+        if speed_mult is not None:
+            out["alch_speed_source"] = speed_label
+            out["alch_speed_multiplier"] = speed_mult
+            out["effective_throw_cadence_seconds"] = round(
+                float(cadence) * speed_mult,
+                3,
+            )
     if isinstance(rebuff_block, (int, float)) and rebuff_block > 0:
         out["rebuff_block_seconds"] = float(rebuff_block)
 
@@ -691,12 +773,20 @@ def buff_uptime(buff_source: str, target: str, targets: int = 1) -> dict[str, An
     out["attacks_under_buff"] = int(min(filter(None, [cap, window / tgt_cd])))
 
     # Re-buff interval for one of the `targets` towers: the alch round-robins its
-    # throws, so each tower's turn comes every `targets × throw_cadence` — but no
-    # faster than the per-target `rebuff_block` floor.
+    # throws, so each tower's turn comes every `targets × effective_cadence` — but
+    # no faster than the per-target `rebuff_block` floor. An attack-speed buff on
+    # the alch lowers `effective_cadence`, so it can serve more towers until that
+    # fixed floor binds.
     if isinstance(cadence, (int, float)) and cadence > 0:
+        effective_cadence = float(cadence) * (
+            speed_mult if speed_mult is not None else 1.0
+        )
         floor = float(rebuff_block) if isinstance(rebuff_block, (int, float)) else 0.0
-        rebuff_interval = max(float(cadence) * targets, floor)
+        rebuff_interval = max(effective_cadence * targets, floor)
         out["rebuff_interval_seconds"] = round(rebuff_interval, 3)
+        out["rebuff_floor_binds"] = bool(
+            floor > 0 and effective_cadence * targets < floor,
+        )
         uptime = min(1.0, window / rebuff_interval)
         out["uptime"] = round(uptime, 3)
         out["uptime_percent"] = round(uptime * 100.0, 1)
@@ -707,18 +797,29 @@ def buff_uptime(buff_source: str, target: str, targets: int = 1) -> dict[str, An
         if limiter == "attacks"
         else f"the {float(duration)}s time limit"
     )
+    speed_txt = (
+        f" (sped up by {speed_label} → {out['effective_throw_cadence_seconds']}s throw)"
+        if speed_mult is not None
+        else ""
+    )
+    floor_txt = (
+        f" The {rebuff_block}s re-buff floor binds."
+        if out.get("rebuff_floor_binds")
+        else ""
+    )
     if "uptime_percent" in out:
         if targets > 1:
             uptime_txt = (
-                f" Buffing {targets} towers, each gets re-thrown every "
+                f" Buffing {targets} towers{speed_txt}, each re-thrown every "
                 f"~{out['rebuff_interval_seconds']}s → {out['uptime_percent']}% "
-                f"uptime per tower."
+                f"uptime per tower.{floor_txt}"
             )
         else:
             uptime_txt = (
-                f" Re-thrown every {float(cadence)}s → {out['uptime_percent']}% "
+                f" Re-thrown every {out['rebuff_interval_seconds']}s{speed_txt} → "
+                f"{out['uptime_percent']}% "
                 f"uptime{' (continuous)' if out.get('uptime', 0) >= 1.0 else ''} "
-                f"on {tgt_display}."
+                f"on {tgt_display}.{floor_txt}"
             )
     else:
         uptime_txt = ""

--- a/docs/btd6/btd6-gamedata-decode-status.md
+++ b/docs/btd6/btd6-gamedata-decode-status.md
@@ -58,6 +58,13 @@ works** (the traps we hit), and what is still un-decoded.
 > block 5s/4s) — it matters under alch attack-speed buffs (Jungle Drums, Overclock) that speed
 > throwing below the floor.
 >
+> **Attack-speed buffs on the alch (PR #1268):** `btd6_buff_uptime(..., alch_speed=…)` speeds the
+> brew throw — resolved **grounded** to a cooldown multiplier (a Power's `rate_scale`, e.g. Monkey
+> Boost ×0.5; else an upgrade's `rateMultiplier`, e.g. Jungle Drums = Village 2-0-0 ×0.85, Overclock
+> ×0.25 — all already in committed data, no decode needed). `effective_cadence = cadence × mult`;
+> below `rebuff_block` the floor binds (the case it exists for). Example: a 4-0-0 under Monkey Boost
+> holds **2** Ninjas at 100% (vs ~54% unboosted). Unknown/non-speed source → honest `found=false`.
+>
 > **Verified windows (game-data == Bloons-wiki cross-check):** Acidic Mixture Dip 2-0-0
 > = **10 shots** (12 @ 2-2-0); Berserker Brew 3-0-0 = **5s / 25 attacks**, 3-2-0 = 6s/40; Stronger
 > Stimulant 4-0-0 = **12s / 40 attacks**, 4-2-0 = 13s/55; Permanent Brew 5-0-0 = permanent. Throw

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,8 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/peaceful-mayer-rgc20t` · **BTD6 buff-uptime — attack-speed buffs on the alch** (owner-chosen) — `buff_uptime(alch_speed=…)` resolves Jungle Drums/Monkey Boost/Overclock → cooldown multiplier (grounded; no decode needed) → rebuffBlockTime binds · `btd6_upgrade_detail_service` / `ai_tools` · 2026-06-21 · **PR (this session, auto-merge on green)**
+
 - `claude/modest-gates-0ble76` · **PR-mergeability: trust the git check, not GitHub `mergeable_state`**
   (owner-directed — the #1256 false-dirty finding) — `scripts/check_pr_mergeable.py` (git-based, reuses
   `git_merge_state.py`) + journal note + tighten `pr-conflict-guard` schedule backstop ·

--- a/tests/unit/services/test_btd6_upgrade_detail_service.py
+++ b/tests/unit/services/test_btd6_upgrade_detail_service.py
@@ -416,7 +416,9 @@ def test_buff_start_of_round_trigger_renders_each_round_not_seconds():
             "duration_rounds": 3,
         },
     )
-    assert text == "Start-of-round buff: x0.25 attack cooldown at the start of each round"
+    assert (
+        text == "Start-of-round buff: x0.25 attack cooldown at the start of each round"
+    )
     assert "3s" not in text and "3 round" not in text
 
 
@@ -525,7 +527,8 @@ def test_power_effect_grounds_monkey_boost_on_a_real_upgrade():
     assert res["rate_scale"] == 0.5
     assert res["duration_seconds"] == 15
     assert res["boosted_cooldown_seconds"] == round(
-        res["base_cooldown_seconds"] * 0.5, 4
+        res["base_cooldown_seconds"] * 0.5,
+        4,
     )
     # Independent rounding of base vs boosted leaves a sub-0.01 gap.
     gap = abs(res["boosted_attacks_per_second"] - 2 * res["base_attacks_per_second"])
@@ -570,7 +573,8 @@ def test_power_effect_handles_unknown_power_and_unknown_tower():
 
 def _inject_buff_window(monkeypatch, *, duration=None, cap=None, permanent=False):
     """Patch the buff-attack lookup so the Alchemist tier reports a decoded
-    window (mirrors what parse_gamedata._buff_window will attach)."""
+    window (mirrors what parse_gamedata._buff_window will attach).
+    """
     real = det._alch_buff_attack
 
     def fake(tower_id, code):
@@ -737,3 +741,63 @@ def test_buff_uptime_targets_floor_is_at_least_one():
     res = det.buff_uptime("alchemist 4-0-0", "ninja 5-0-0", targets=0)
     assert res["targets"] == 1
     assert res["uptime_percent"] == 100.0
+
+
+# --- alch_speed (attack-speed buffs ON the Alchemist) -----------------------
+
+
+def test_buff_uptime_monkey_boost_resolves_via_power():
+    # Monkey Boost (a Power, rate_scale 0.5) speeds the brew throw 8s → 4s.
+    res = det.buff_uptime("alchemist 4-0-0", "ninja 5-0-0", alch_speed="Monkey Boost")
+    assert res["found"] is True
+    assert res["alch_speed_source"] == "Monkey Boost"
+    assert res["alch_speed_multiplier"] == 0.5
+    assert res["effective_throw_cadence_seconds"] == 4.0
+
+
+def test_buff_uptime_speed_buff_lets_alch_hold_more_towers():
+    # Unboosted, a 4-0-0 alch holds ~1 Ninja at 100% but only ~54% on two.
+    # Monkey Boost (×0.5 throw) lets it hold BOTH at 100%.
+    plain = det.buff_uptime("alchemist 4-0-0", "ninja 5-0-0", targets=2)
+    boosted = det.buff_uptime(
+        "alchemist 4-0-0",
+        "ninja 5-0-0",
+        targets=2,
+        alch_speed="Monkey Boost",
+    )
+    assert plain["uptime_percent"] < 100.0
+    assert boosted["uptime_percent"] == 100.0
+    assert boosted["uptime_percent"] > plain["uptime_percent"]
+
+
+def test_buff_uptime_rebuff_floor_binds_under_fast_throwing():
+    # Monkey Boost makes the throw 4s, below the 5s rebuff_block floor → the
+    # floor binds (a tower can't be re-buffed faster than 5s, however fast the
+    # alch throws). This is the case rebuffBlockTime exists for.
+    res = det.buff_uptime("alchemist 4-0-0", "ninja 5-0-0", alch_speed="Monkey Boost")
+    assert res["effective_throw_cadence_seconds"] == 4.0
+    assert res["rebuff_interval_seconds"] == 5.0  # floored at rebuff_block, not 4s
+    assert res["rebuff_floor_binds"] is True
+
+
+def test_buff_uptime_jungle_drums_resolves_via_upgrade_rate_buff():
+    # Jungle Drums (Monkey Village 2-0-0, RateSupport ×0.85) resolves through the
+    # upgrade → tier rate-buff path and improves multi-target uptime.
+    plain = det.buff_uptime("alchemist 4-0-0", "ninja 5-0-0", targets=2)
+    jd = det.buff_uptime(
+        "alchemist 4-0-0",
+        "ninja 5-0-0",
+        targets=2,
+        alch_speed="Jungle Drums",
+    )
+    assert jd["found"] is True
+    assert jd["alch_speed_source"] == "Jungle Drums"
+    assert jd["alch_speed_multiplier"] == 0.85
+    assert jd["uptime_percent"] > plain["uptime_percent"]
+
+
+def test_buff_uptime_unknown_alch_speed_is_honest():
+    res = det.buff_uptime("alchemist 4-0-0", "ninja 5-0-0", alch_speed="Banana")
+    assert res["found"] is False
+    assert "couldn't resolve" in res["note"]
+    assert "Monkey Boost" in res["note"]  # names the supported kinds


### PR DESCRIPTION
## Why

The capstone of buff-uptime realism (owner-chosen). When the **Alchemist itself** is sped up (Jungle Drums, Monkey Boost, Overclock, …), its brew-throw cadence drops — and below the per-target `rebuffBlockTime` floor (decoded in #1251) it can keep **more** towers buffed. This is the one scenario where `rebuffBlockTime` actually binds, and the case the calc couldn't express.

**Came in under the ~2-PR estimate:** the speed multipliers are **already in committed data**, so no decode pass is needed — one clean calc PR.

## What

- `buff_uptime(buff_source, target, targets=1, alch_speed=None)` — resolve `alch_speed` → a cooldown multiplier (grounded, no fabrication):
  - a **Power** (Monkey Boost) → `rate_scale` (0.5),
  - else an **upgrade with an attack-speed buff** (Jungle Drums → Village 2-0-0 `rateMultiplier` 0.85; Overclock → Engineer 0.25) via `resolve_upgrade` → the tier's rate buff.
  - unknown / non-speed source → honest `found=False`.
  - `effective_cadence = base_throw_cadence × multiplier`; `rebuff_interval = max(targets × effective_cadence, rebuff_block)`. Surfaces `alch_speed_source` / `alch_speed_multiplier` / `effective_throw_cadence_seconds`.
- `btd6_buff_uptime` tool gains an optional `alch_speed` param.
- Tests (real data: Jungle Drums / Monkey Boost on 4-0-0 → 5-0-0 Ninja, single + multi-target, the rebuffBlockTime-binds case, unknown source) + docs.

Example: a 4-0-0 alch under **Monkey Boost** (×0.5) throws every 4s, so the 5s `rebuffBlockTime` floor binds — it can hold ~2 towers where the unboosted alch held ~1.

## Status

Opened **born-red** (session card `in-progress`); flips to `complete` last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAfgtUqA1bzZ3gsSrFwaw8

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAfgtUqA1bzZ3gsSrFwaw8)_