### PR TITLE
BUG-0023 root fix: scanner discovers app_commands.Group attribute slash commands

### DIFF
--- a/.sessions/2026-06-22-bug0023-slash-scan-coverage.md
+++ b/.sessions/2026-06-22-bug0023-slash-scan-coverage.md
@@ -1,7 +1,8 @@
 # 2026-06-22 — BUG-0023 root fix: scanner discovers `app_commands.Group` attribute slash commands
 
-> **Status:** `in-progress` — Dispatch routine (no work order). Empty-fire run; bugs-first picked the
+> **Status:** `complete` — Dispatch routine (no work order). Empty-fire run; bugs-first picked the
 > top offline-fixable bug-book item: **BUG-0023 slash under-coverage**. Self-initiated (Q-0172).
+> PR #1272, auto-merge armed on green.
 
 > **Run type:** `routine · dispatch`
 
@@ -35,4 +36,88 @@ dashboard/site data, and close BUG-0023's slash under-coverage at the root with 
 
 ## What shipped
 
-_(filled at completion)_
+- **`scripts/scan_commands.py`** — `_find_attr_groups(class_node)` detects class-attribute group
+  assignments (`X = app_commands.Group(...)` / `HybridGroup`) → maps the variable name to
+  `(command name, type, brief)`. `_scan_class` merges these into the `groups` map (so `@X.command`
+  subcommands resolve their parent + slash/both type exactly like method-group subcommands already did)
+  and emits a synthesized `is_group` record per attr-group. Added `_GROUP_CONSTRUCTORS`. The scanner's
+  `by_type["slash"]` went **25 → 71** (matches the live `bot.tree.walk_commands()` count); total
+  commands 322 → 368 (+40 subcommands +6 groups).
+- **`tests/unit/scripts/test_scan_commands.py`** — `test_attribute_assigned_app_command_group_is_scanned`
+  (a sample cog whose attribute slash group + subcommand are now scanned — fails against the pre-fix
+  decorator-only behaviour) + `test_attribute_app_group_subcommands_counted_in_real_repo` (real-repo
+  slash total reconciles to the bot tree, `>= 70`).
+- **Regenerated** `dashboard/data/dashboard.json` · `botsite/data/site.json` · `botsite/site/data.js`
+  (commands 322 → 368) so the website command explorer now documents the 46 previously-missing slash
+  commands. `check_dashboard_data` self-consistent (counts derived from array lengths); committed-vs-fresh
+  + data.js-sync tests green.
+- **`docs/health/bug-book.md`** — BUG-0023 slash under-coverage marked **FIXED (root)**; corrected the
+  wrong "dynamically-registered / can't see statically" hypothesis with the real cause + the
+  25+40+6=71 reconciliation; status line updated.
+
+## Findings / decisions
+
+- **The bug-book hypothesis was wrong, and that itself is the lesson (Q-0120 instinct).** The entry
+  guessed "context menus / dynamic registration the AST cannot see" and scoped the fix to a
+  *runtime-aware* session. A 10-minute investigation (grep for context_menu / tree.add_command /
+  hybrids → all zero; grep for `app_commands.Group(` → 6 hits) showed the entire gap is **statically
+  discoverable**. A scoping note based on an unverified root-cause guess can defer a cheap fix
+  indefinitely — verify the cause before trusting the scope.
+- **Synthesize the group record (not just the subcommands).** The live `walk_commands()` counts the
+  group object itself plus each leaf; emitting an `is_group` record for the attr-group makes the
+  scanner's count reconcile exactly to 71 and matches how decorated-method groups already render.
+- **Decision made alone — this is the slash-under-coverage (#3) root fix only.** BUG-0023's count
+  *display* reconciliation (#1/#2, the `prefix · slash` breakdown on the site) stays folded into the
+  React-migration PR 1, unchanged.
+
+## 💡 Session idea
+
+**A `scan_commands.py` ↔ live-tree reconciliation check (CI guard, Q-0105-disposable).** This bug
+existed because nothing compared the static scan's slash total to the bot's live `tree.walk_commands()`
+count — they silently diverged by 46. A tiny check that asserts the scanner's `by_type` reconciles to a
+*recorded* live-tree snapshot (refreshed when the bot boots, the way the command-surface ledger already
+captures a live snapshot) would catch the *next* AST-blind-spot class automatically — a new slash
+group-declaration idiom the scanner doesn't yet recognise would fail the guard instead of quietly
+under-documenting the website. (Dedup-checked: `test_manifest_drift.py` demotes the scanner vs the
+runtime manifest spine but doesn't assert the slash *count* reconciles; this is the count-level guard.)
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous dispatch run (Starboard PR 2 #1270 + `band_pr_status --themes` #1271) was strong — two
+complete slices, both self-initiated and flagged, with a clean Q-0089 idea that mechanizes the
+reconciliation routine. **Where it could improve:** its own card noted the `ruff --fix tests/` foot-gun
+(339 files mutated, recovered) and filed a "`--changed-only` guard" idea — but the fix it reached for
+already largely exists (`check_quality.py` default mode auto-fixes within CI's exact scope, *excluding*
+`tests/`); the real gap is only "scope to my changed files," a narrow add. The lesson worth promoting:
+**reach for `check_quality.py` (interpreter- and scope-pinned), never a bare `ruff --fix <path>`** — the
+journal already says this, so the durable fix is habit, not new tooling. **System improvement
+(initiated):** the session-idea above (a static-scan ↔ live-tree count reconciliation guard) is the
+kind of cheap invariant that turns "an agent eventually notices the divergence" into "CI catches it" —
+the same detector→guard shape the bug-book rewards.
+
+## 📤 Run report
+
+- **Did:** BUG-0023 slash under-coverage root fix (scanner discovers attribute-assigned
+  `app_commands.Group` slash commands) · **Outcome:** shipped (PR #1272, self-merge on green)
+- **Shipped:** #1272 — BUG-0023 slash-scan coverage root fix
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none — merged = deployed (the scanner/data change is build-time; no runtime
+  data step). The site only reflects the 46 newly-documented commands at its next data export/deploy,
+  which is automatic.
+- **⚑ Self-initiated:** yes — empty-fire dispatch, no work order; bugs-first picked the top
+  offline-fixable bug-book item (Q-0172). Contained, reversible, test-covered; flagged for owner review.
+- **↪ Next:** BUG-0023's remaining piece is the count-*display* reconciliation (#1/#2 — show the bot's
+  `prefix · slash` breakdown on the site), folded into the botsite React-migration **PR 1**. Other
+  ungated lanes untouched: Project Moon runtime PR 1 (`needs-hermes-review`, needs network ingestion),
+  creature leaderboards UI (gated on Explore-hub Q-0182), procedures→skills Batch 2
+  (`needs-hermes-review`). Open bug-book root-fix backlog stays BUG-0019 #1 (owner decision) + BUG-0009
+  newest-towers (data-gated) — both still gated, not offline-startable.
+
+## ⟳ Doc audit (Q-0104)
+
+`check_current_state_ledger --strict` + `check_docs --strict` green; bug-book BUG-0023 entry de-staled
+to FIXED (root) with the corrected root cause. current-state Recently-shipped is deliberately **not**
+touched (merged-PRs-only convention; #1272 isn't merged yet — the next reconciliation pass records it,
+benign newest-merge lag). No new owner decisions (nothing for the router). The regenerated data
+artifacts keep `check_dashboard_data` self-consistent.

--- a/.sessions/2026-06-22-bug0023-slash-scan-coverage.md
+++ b/.sessions/2026-06-22-bug0023-slash-scan-coverage.md
@@ -1,0 +1,38 @@
+# 2026-06-22 — BUG-0023 root fix: scanner discovers `app_commands.Group` attribute slash commands
+
+> **Status:** `in-progress` — Dispatch routine (no work order). Empty-fire run; bugs-first picked the
+> top offline-fixable bug-book item: **BUG-0023 slash under-coverage**. Self-initiated (Q-0172).
+
+> **Run type:** `routine · dispatch`
+
+## What I'm about to do
+
+BUG-0023's one real gap — *"static scan finds **25** slash, the live tree has **71** → the website
+under-documents slash commands"* — was hypothesised in the bug book as *"dynamically-registered app
+commands / context menus the AST cannot see."* **That hypothesis is wrong.** Investigated this run:
+
+- 0 context menus, 0 `tree.add_command`, 0 hybrids in the codebase.
+- The gap is **`app_commands.Group` declared as a class *attribute*** (`ai_app_group =
+  app_commands.Group(name="ai", …)`) with subcommands decorated `@ai_app_group.command(…)`, in 6 cogs
+  (ai · btd6 · btd6_events · btd6_ops · btd6_reference · btd6_strategy).
+- `scan_commands._find_groups` only detects groups declared as **decorated methods**
+  (`@app_commands.group`), so it misses these groups **and every subcommand under them**.
+- Exact reconciliation: **25 standalone + 40 subcommands + 6 groups = 71** = the live tree count. All
+  46 missing commands are **statically discoverable** — no runtime-aware counting needed.
+
+This run: teach `scan_commands.py` to detect attribute-assigned `app_commands.Group` (and
+`HybridGroup`) groups so their subcommands are scanned and the groups counted, regenerate the
+dashboard/site data, and close BUG-0023's slash under-coverage at the root with a regression test.
+
+## Files (planned)
+
+- `scripts/scan_commands.py` — detect `X = app_commands.Group(...)` class-attr groups → register the
+  group + scan its `@X.command` subcommands (inherit `slash`/`both`); emit the synthesized group record.
+- `tests/unit/scripts/test_scan_commands.py` — a sample cog with an attribute-assigned slash group +
+  subcommands; assert the group and its subcommands are scanned (fails against the pre-fix behaviour).
+- regenerate `dashboard/data/dashboard.json` · `botsite/data/site.json` · `botsite/site/data.js`.
+- `docs/health/bug-book.md` — mark BUG-0023 slash under-coverage FIXED (root) with the reconciliation.
+
+## What shipped
+
+_(filled at completion)_

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-06-22T00:09:51Z",
+    "generated_at": "2026-06-22T03:11:21Z",
     "build": {
-      "commit": "3f874fb3",
-      "subject": "session(born-red): Starboard PR 2 — config panel + polish — card + claim",
-      "committed_at": "2026-06-22T00:09:51Z"
+      "commit": "9b9df82d",
+      "subject": "BUG-0023 slash-scan coverage: born-red session card + lane claim",
+      "committed_at": "2026-06-22T03:11:21Z"
     }
   },
   "counts": {
-    "commands": 322,
+    "commands": 368,
     "features": 37,
     "games": 9
   },
@@ -684,6 +684,41 @@
       "category": "admin",
       "cooldown": null,
       "permissions": "administrator",
+      "usage": "AI Platform diagnostics (administrator only).",
+      "description": "Open the AI Platform panel.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "AI reports corrections → an audience-routed AI ticket service",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord users across conversations",
+          "status": "ideas"
+        },
+        {
+          "title": "AI panels → in-place navigation + centralized settings (owner-requested, 2026-06-11)",
+          "status": "ideas"
+        },
+        {
+          "title": "AI Extra Tool Capability Ideas Backlog",
+          "status": "ideas"
+        },
+        {
+          "title": "Settings presets everywhere + AI template advisor — idea capture (2026-06-10)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "ai",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
       "usage": "Open the AI Platform panel.",
       "description": "Open the AI Platform panel.",
       "use_cases": null,
@@ -909,6 +944,41 @@
     },
     {
       "name": "diagnostics",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Full AI gateway diagnostics snapshot.",
+      "description": null,
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "AI reports corrections → an audience-routed AI ticket service",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord users across conversations",
+          "status": "ideas"
+        },
+        {
+          "title": "AI panels → in-place navigation + centralized settings (owner-requested, 2026-06-11)",
+          "status": "ideas"
+        },
+        {
+          "title": "AI Extra Tool Capability Ideas Backlog",
+          "status": "ideas"
+        },
+        {
+          "title": "Settings presets everywhere + AI template advisor — idea capture (2026-06-10)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "diagnostics",
       "aliases": [
         "diag"
       ],
@@ -946,6 +1016,41 @@
       "cooldown": null,
       "permissions": "administrator",
       "usage": "Flush the chat-memory cache for THIS channel.",
+      "description": "Flush the chat-memory cache for THIS channel.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "AI reports corrections → an audience-routed AI ticket service",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord users across conversations",
+          "status": "ideas"
+        },
+        {
+          "title": "AI panels → in-place navigation + centralized settings (owner-requested, 2026-06-11)",
+          "status": "ideas"
+        },
+        {
+          "title": "AI Extra Tool Capability Ideas Backlog",
+          "status": "ideas"
+        },
+        {
+          "title": "Settings presets everywhere + AI template advisor — idea capture (2026-06-10)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "forget",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Flush the chat-memory cache for this channel.",
       "description": "Flush the chat-memory cache for THIS channel.",
       "use_cases": null,
       "examples": [],
@@ -1125,12 +1230,82 @@
       "notes": null
     },
     {
+      "name": "policy",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Show the effective AI policy for a channel (dry-run resolver).",
+      "description": "Show the effective AI policy for a channel (dry-run resolver).",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "AI reports corrections → an audience-routed AI ticket service",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord users across conversations",
+          "status": "ideas"
+        },
+        {
+          "title": "AI panels → in-place navigation + centralized settings (owner-requested, 2026-06-11)",
+          "status": "ideas"
+        },
+        {
+          "title": "AI Extra Tool Capability Ideas Backlog",
+          "status": "ideas"
+        },
+        {
+          "title": "Settings presets everywhere + AI template advisor — idea capture (2026-06-10)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "providers",
       "aliases": [],
       "category": "admin",
       "cooldown": null,
       "permissions": "administrator",
       "usage": "",
+      "description": null,
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "AI reports corrections → an audience-routed AI ticket service",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord users across conversations",
+          "status": "ideas"
+        },
+        {
+          "title": "AI panels → in-place navigation + centralized settings (owner-requested, 2026-06-11)",
+          "status": "ideas"
+        },
+        {
+          "title": "AI Extra Tool Capability Ideas Backlog",
+          "status": "ideas"
+        },
+        {
+          "title": "Settings presets everywhere + AI template advisor — idea capture (2026-06-10)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "providers",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "List configured AI providers.",
       "description": null,
       "use_cases": null,
       "examples": [],
@@ -1182,6 +1357,41 @@
       "cooldown": null,
       "permissions": "administrator",
       "usage": "Run the full AI readiness chain check.",
+      "description": "Run the full AI readiness chain check.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "AI reports corrections → an audience-routed AI ticket service",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord users across conversations",
+          "status": "ideas"
+        },
+        {
+          "title": "AI panels → in-place navigation + centralized settings (owner-requested, 2026-06-11)",
+          "status": "ideas"
+        },
+        {
+          "title": "AI Extra Tool Capability Ideas Backlog",
+          "status": "ideas"
+        },
+        {
+          "title": "Settings presets everywhere + AI template advisor — idea capture (2026-06-10)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "readiness",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Run the AI readiness chain check (provider, policy, perms, memory).",
       "description": "Run the full AI readiness chain check.",
       "use_cases": null,
       "examples": [],
@@ -1268,6 +1478,41 @@
       "cooldown": null,
       "permissions": "administrator",
       "usage": "",
+      "description": null,
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "AI reports corrections → an audience-routed AI ticket service",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord users across conversations",
+          "status": "ideas"
+        },
+        {
+          "title": "AI panels → in-place navigation + centralized settings (owner-requested, 2026-06-11)",
+          "status": "ideas"
+        },
+        {
+          "title": "AI Extra Tool Capability Ideas Backlog",
+          "status": "ideas"
+        },
+        {
+          "title": "Settings presets everywhere + AI template advisor — idea capture (2026-06-10)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "routing",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Show the routing table for AI tasks.",
       "description": null,
       "use_cases": null,
       "examples": [],
@@ -1401,6 +1646,41 @@
       "category": "admin",
       "cooldown": null,
       "permissions": "administrator",
+      "usage": "Open the AI Platform settings panel.",
+      "description": "Open the AI Platform settings panel directly.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "AI reports corrections → an audience-routed AI ticket service",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord users across conversations",
+          "status": "ideas"
+        },
+        {
+          "title": "AI panels → in-place navigation + centralized settings (owner-requested, 2026-06-11)",
+          "status": "ideas"
+        },
+        {
+          "title": "AI Extra Tool Capability Ideas Backlog",
+          "status": "ideas"
+        },
+        {
+          "title": "Settings presets everywhere + AI template advisor — idea capture (2026-06-10)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "settings",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
       "usage": "Open the Settings Manager hub (browse + edit/reset scalars).",
       "description": "Entry-point command for the Settings Manager subsystem.",
       "use_cases": null,
@@ -1496,6 +1776,41 @@
       "category": "admin",
       "cooldown": null,
       "permissions": "administrator",
+      "usage": "AI gateway status summary.",
+      "description": null,
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "AI reports corrections → an audience-routed AI ticket service",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord users across conversations",
+          "status": "ideas"
+        },
+        {
+          "title": "AI panels → in-place navigation + centralized settings (owner-requested, 2026-06-11)",
+          "status": "ideas"
+        },
+        {
+          "title": "AI Extra Tool Capability Ideas Backlog",
+          "status": "ideas"
+        },
+        {
+          "title": "Settings presets everywhere + AI template advisor — idea capture (2026-06-10)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "status",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
       "usage": "Show this guild's server-logging configuration + counters.",
       "description": "Show this guild's server-logging configuration + counters.",
       "use_cases": null,
@@ -1516,6 +1831,41 @@
       "cooldown": null,
       "permissions": "administrator",
       "usage": "Render a copy-pasteable support report from recent audit (PR-H).",
+      "description": "Render a copy-pasteable support report from recent audit (PR-H).",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "AI reports corrections → an audience-routed AI ticket service",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord users across conversations",
+          "status": "ideas"
+        },
+        {
+          "title": "AI panels → in-place navigation + centralized settings (owner-requested, 2026-06-11)",
+          "status": "ideas"
+        },
+        {
+          "title": "AI Extra Tool Capability Ideas Backlog",
+          "status": "ideas"
+        },
+        {
+          "title": "Settings presets everywhere + AI template advisor — idea capture (2026-06-10)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "support-report",
+      "aliases": [],
+      "category": "admin",
+      "cooldown": null,
+      "permissions": "administrator",
+      "usage": "Render a copy-paste AI support report (no delivery).",
       "description": "Render a copy-pasteable support report from recent audit (PR-H).",
       "use_cases": null,
       "examples": [],
@@ -2851,12 +3201,84 @@
       "notes": null
     },
     {
+      "name": "announcechannel",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Set/clear the BTD6 new-version announcement channel (admin).",
+      "description": "Set/clear the BTD6 new-version announcement channel (administrator).",
+      "use_cases": null,
+      "examples": [
+        "!btd6ops announcechannel #updates"
+      ],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "ask",
       "aliases": [],
       "category": "games",
       "cooldown": null,
       "permissions": "user",
       "usage": "Deterministic Q&A. Module 5 adds optional AI augmentation.",
+      "description": "Deterministic Q&A. Module 5 adds optional AI augmentation.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "ask",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Ask a BTD6 question.",
       "description": "Deterministic Q&A. Module 5 adds optional AI augmentation.",
       "use_cases": null,
       "examples": [],
@@ -2981,6 +3403,76 @@
       "notes": null
     },
     {
+      "name": "browse",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Browse published BTD6 strategies.",
+      "description": "Browse published BTD6 strategies (PR-F).",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "btd6",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "BTD6 Assistant — panel, status, ask, diagnostics.",
+      "description": "Open the BTD6 panel.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "btd6",
       "aliases": [],
       "category": "games",
@@ -2988,6 +3480,41 @@
       "permissions": "user",
       "usage": "Open the BTD6 panel.",
       "description": "Open the BTD6 panel.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "btd6events",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "BTD6 live events, leaderboards, and data sources.",
+      "description": "BTD6 live events, leaderboards, and data-source diagnostics.",
       "use_cases": null,
       "examples": [],
       "status": "in-progress",
@@ -3160,6 +3687,76 @@
       "notes": null
     },
     {
+      "name": "btd6ops",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "BTD6 ingestion operations (staff readable; toggles are admin).",
+      "description": "BTD6 ingestion operations (staff readable; toggles are admin).",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "btd6ref",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "BTD6 reference — tower/hero/round/relic/CT lookups.",
+      "description": "BTD6 reference lookups (towers / heroes / rounds / relics / CT).",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "btd6ref",
       "aliases": [],
       "category": "games",
@@ -3167,6 +3764,41 @@
       "permissions": "user",
       "usage": "BTD6 reference lookups (towers / heroes / rounds / relics / CT).",
       "description": "BTD6 reference lookups (towers / heroes / rounds / relics / CT).",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "btd6strat",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "BTD6 strategy memory — browse, submit, review.",
+      "description": "BTD6 strategy memory (browse / submit / review).",
       "use_cases": null,
       "examples": [],
       "status": "in-progress",
@@ -3382,6 +4014,41 @@
       "notes": null
     },
     {
+      "name": "ct",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Browse active Contested Territory events and relic tiles.",
+      "description": "Browse active Contested Territory events and their relic tiles.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "ctteam",
       "aliases": [],
       "category": "games",
@@ -3519,6 +4186,41 @@
       "notes": null
     },
     {
+      "name": "diagnostics",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "BTD6 dataset diagnostics.",
+      "description": null,
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "dm_challenge",
       "aliases": [
         "deathmatch",
@@ -3575,6 +4277,43 @@
       "cooldown": null,
       "permissions": "user",
       "usage": "Show one specific BTD6 event with its tower restrictions.",
+      "description": "Show one specific BTD6 event with its tower restrictions.",
+      "use_cases": null,
+      "examples": [
+        "!btd6events live <kind>"
+      ],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "event",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show one specific BTD6 event with tower restrictions.",
       "description": "Show one specific BTD6 event with its tower restrictions.",
       "use_cases": null,
       "examples": [
@@ -3748,12 +4487,82 @@
       "notes": null
     },
     {
+      "name": "grounding",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Grounding facts that fed an AI response.",
+      "description": "Show the grounding facts that fed an AI response (PR-D).",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "hero",
       "aliases": [],
       "category": "games",
       "cooldown": null,
       "permissions": "user",
       "usage": "",
+      "description": null,
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "hero",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Look up a hero.",
       "description": null,
       "use_cases": null,
       "examples": [],
@@ -3818,12 +4627,82 @@
       "notes": null
     },
     {
+      "name": "latest-data",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Newest fact envelope per entity_kind.",
+      "description": "Show newest fact envelope per entity_kind (PR-D).",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "leaderboard",
       "aliases": [],
       "category": "games",
       "cooldown": null,
       "permissions": "user",
       "usage": "Top-N race or boss leaderboard. No event_id = newest active.",
+      "description": "Top-N race or boss leaderboard. No event_id = newest active.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "leaderboard",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show race / boss leaderboard.",
       "description": "Top-N race or boss leaderboard. No event_id = newest active.",
       "use_cases": null,
       "examples": [],
@@ -3904,12 +4783,82 @@
       "notes": null
     },
     {
+      "name": "live",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show recent live events (race/boss/ct/odyssey/event).",
+      "description": "Show recent live events for kind (race / boss / ct / odyssey / event).",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "mine",
       "aliases": [],
       "category": "games",
       "cooldown": null,
       "permissions": "user",
       "usage": "List my own strategy submissions in this guild (PR-F).",
+      "description": "List my own strategy submissions in this guild (PR-F).",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "mine",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "List my own strategy submissions in this guild.",
       "description": "List my own strategy submissions in this guild (PR-F).",
       "use_cases": null,
       "examples": [],
@@ -3974,6 +4923,41 @@
       "notes": null
     },
     {
+      "name": "pending",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "List pending strategy submissions (staff-only).",
+      "description": "List pending strategy submissions with review buttons.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "readiness",
       "aliases": [],
       "category": "games",
@@ -3981,6 +4965,76 @@
       "permissions": "user",
       "usage": "",
       "description": null,
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "readiness",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show BTD6 ingestion readiness.",
+      "description": null,
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "refresh-source",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Manually refresh one Ninja Kiwi source (staff-only).",
+      "description": "Manually refresh one Ninja Kiwi source (staff-only).",
       "use_cases": null,
       "examples": [],
       "status": "in-progress",
@@ -4079,6 +5133,41 @@
       "notes": null
     },
     {
+      "name": "relic",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Look up a Contested Territory relic's effect and tile.",
+      "description": "CT relic effect + current tile (by name / abbrev e.g. SMS / alias).",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "removelimit",
       "aliases": [],
       "category": "games",
@@ -4117,6 +5206,41 @@
       "cooldown": null,
       "permissions": "user",
       "usage": "",
+      "description": null,
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "round",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Look up a round.",
       "description": null,
       "use_cases": null,
       "examples": [],
@@ -4318,12 +5442,82 @@
       "notes": null
     },
     {
+      "name": "runs",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show recent BTD6 ingestion runs.",
+      "description": null,
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "seed-data",
       "aliases": [],
       "category": "games",
       "cooldown": null,
       "permissions": "user",
       "usage": "Seed the Postgres data store from the bundled files (administrator).",
+      "description": "Seed the Postgres data store from the bundled files (administrator).",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "seed-data",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Seed the Postgres data store from the bundled files (admin).",
       "description": "Seed the Postgres data store from the bundled files (administrator).",
       "use_cases": null,
       "examples": [],
@@ -4420,7 +5614,112 @@
       "notes": null
     },
     {
+      "name": "source-health",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "BTD6 source registry freshness overview.",
+      "description": "Show source registry freshness (PR-D).",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "source_disable",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "",
+      "description": null,
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "source_disable",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Disable a BTD6 ingestion source (administrator only).",
+      "description": null,
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "source_enable",
       "aliases": [],
       "category": "games",
       "cooldown": null,
@@ -4460,8 +5759,43 @@
       "category": "games",
       "cooldown": null,
       "permissions": "user",
-      "usage": "",
+      "usage": "Enable a BTD6 ingestion source (administrator only).",
       "description": null,
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "sources",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "List BTD6 source registry rows.",
+      "description": "List BTD6 source registry rows.",
       "use_cases": null,
       "examples": [],
       "status": "in-progress",
@@ -4576,6 +5910,76 @@
       "notes": null
     },
     {
+      "name": "status",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "BTD6 assistant status.",
+      "description": null,
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "strategies",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "List strategy memory entries available in this guild.",
+      "description": "List strategy memory entries available in this guild.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "strategies",
       "aliases": [],
       "category": "games",
@@ -4646,12 +6050,82 @@
       "notes": null
     },
     {
+      "name": "strategy",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show one strategy in detail.",
+      "description": "Show one strategy in detail (PR-F).",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "strategy-audit",
       "aliases": [],
       "category": "games",
       "cooldown": null,
       "permissions": "user",
       "usage": "Show the per-strategy audit log (PR-F).",
+      "description": "Show the per-strategy audit log (PR-F).",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "strategy-audit",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Per-strategy audit log.",
       "description": "Show the per-strategy audit log (PR-F).",
       "use_cases": null,
       "examples": [],
@@ -4716,12 +6190,82 @@
       "notes": null
     },
     {
+      "name": "submit",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Submit a BTD6 strategy.",
+      "description": "Open a strategy submission modal (slash-only on Discord).",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "test-intent",
       "aliases": [],
       "category": "games",
       "cooldown": null,
       "permissions": "user",
       "usage": "",
+      "description": null,
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "test-intent",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show what the resolver extracted from a message.",
       "description": null,
       "use_cases": null,
       "examples": [],
@@ -4818,12 +6362,82 @@
       "notes": null
     },
     {
+      "name": "tower",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Look up a tower.",
+      "description": null,
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "why-no-response",
       "aliases": [],
       "category": "games",
       "cooldown": null,
       "permissions": "user",
       "usage": "Show the most recent BTD6 denials / skips for this guild.",
+      "description": "Show the most recent BTD6 denials / skips for this guild.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "why-no-response",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Recent BTD6 denials/skips for this guild.",
       "description": "Show the most recent BTD6 denials / skips for this guild.",
       "use_cases": null,
       "examples": [],

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -270,7 +270,7 @@ const COMMANDS = [
     "name": "ai",
     "area": "admin",
     "status": "in-progress",
-    "summary": "Open the AI Platform panel.",
+    "summary": "AI Platform diagnostics (administrator only).",
     "description": "Open the AI Platform panel.",
     "usage": "!ai",
     "aliases": [],
@@ -654,7 +654,7 @@ const COMMANDS = [
     "name": "btd6",
     "area": "games",
     "status": "in-progress",
-    "summary": "Open the BTD6 panel.",
+    "summary": "BTD6 Assistant — panel, status, ask, diagnostics.",
     "description": "Open the BTD6 panel.",
     "usage": "!btd6",
     "aliases": [],
@@ -684,7 +684,7 @@ const COMMANDS = [
     "name": "btd6events",
     "area": "games",
     "status": "in-progress",
-    "summary": "BTD6 live events, leaderboards, and data-source diagnostics.",
+    "summary": "BTD6 live events, leaderboards, and data sources.",
     "description": "BTD6 live events, leaderboards, and data-source diagnostics.",
     "usage": "!btd6events",
     "aliases": [],
@@ -776,7 +776,7 @@ const COMMANDS = [
     "name": "btd6ref",
     "area": "games",
     "status": "in-progress",
-    "summary": "BTD6 reference lookups (towers / heroes / rounds / relics / CT).",
+    "summary": "BTD6 reference — tower/hero/round/relic/CT lookups.",
     "description": "BTD6 reference lookups (towers / heroes / rounds / relics / CT).",
     "usage": "!btd6ref",
     "aliases": [],
@@ -806,7 +806,7 @@ const COMMANDS = [
     "name": "btd6strat",
     "area": "games",
     "status": "in-progress",
-    "summary": "BTD6 strategy memory (browse / submit / review).",
+    "summary": "BTD6 strategy memory — browse, submit, review.",
     "description": "BTD6 strategy memory (browse / submit / review).",
     "usage": "!btd6strat",
     "aliases": [],
@@ -5816,7 +5816,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "3f874fb3",
+    "build": "9b9df82d",
     "title": "New public bot website",
     "changes": [
       {
@@ -5828,7 +5828,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "3f874fb3",
+    "build": "9b9df82d",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -5840,7 +5840,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "3f874fb3",
+    "build": "9b9df82d",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-22T00:09:51Z",
+    "generated_at": "2026-06-22T03:11:21Z",
     "build": {
-      "commit": "3f874fb3",
-      "subject": "session(born-red): Starboard PR 2 — config panel + polish — card + claim",
-      "committed_at": "2026-06-22T00:09:51Z"
+      "commit": "9b9df82d",
+      "subject": "BUG-0023 slash-scan coverage: born-red session card + lane claim",
+      "committed_at": "2026-06-22T03:11:21Z"
     },
     "counts": {
       "functions": 37,
@@ -15,7 +15,7 @@
       "updates": 60,
       "env_vars": 38,
       "cogs": 47,
-      "commands": 322,
+      "commands": 368,
       "setting_keys": 104,
       "setting_domains": 15,
       "typed_settings": 85,
@@ -2135,9 +2135,25 @@
       "file": "2026-06-22-starboard-pr2-config-polish.md",
       "date": "2026-06-22",
       "title": "2026-06-22 — Starboard PR 2: self-star exclusion + ignore-channels + config panel",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": true
+    },
+    {
+      "file": "2026-06-22-bug0023-slash-scan-coverage.md",
+      "date": "2026-06-22",
+      "title": "2026-06-22 — BUG-0023 root fix: scanner discovers `app_commands.Group` attribute slash commands",
       "status": "in-progress",
       "run_type": "routine",
       "self_initiated": false
+    },
+    {
+      "file": "2026-06-22-band-pr-themes-classifier.md",
+      "date": "2026-06-22",
+      "title": "2026-06-22 — `band_pr_status --themes`: draft grouped-entry skeleton",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": true
     },
     {
       "file": "2026-06-21-website-count-and-pin-fixes.md",
@@ -2594,22 +2610,6 @@
       "status": "complete",
       "run_type": "routine",
       "self_initiated": false
-    },
-    {
-      "file": "2026-06-20-reconcile.md",
-      "date": "2026-06-20",
-      "title": "2026-06-20 — Docs reconciliation (sixteenth Q-0107 pass, band-#1170)",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-06-20-reconcile-band1200.md",
-      "date": "2026-06-20",
-      "title": "2026-06-20 — Docs reconciliation (seventeenth Q-0107 pass, band-#1200)",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": true
     }
   ],
   "bot_changelog": [
@@ -3351,6 +3351,17 @@
       "commands": [
         {
           "name": "ai",
+          "type": "slash",
+          "is_group": true,
+          "parent": null,
+          "aliases": [],
+          "brief": "AI Platform diagnostics (administrator only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "ai",
           "type": "prefix",
           "is_group": true,
           "parent": null,
@@ -3394,6 +3405,17 @@
           "button_backed": false
         },
         {
+          "name": "diagnostics",
+          "type": "slash",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "Full AI gateway diagnostics snapshot.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "forget",
           "type": "prefix",
           "is_group": false,
@@ -3405,8 +3427,30 @@
           "button_backed": false
         },
         {
+          "name": "forget",
+          "type": "slash",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "Flush the chat-memory cache for this channel.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "policy",
           "type": "prefix",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "Show the effective AI policy for a channel (dry-run resolver).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "policy",
+          "type": "slash",
           "is_group": false,
           "parent": "ai",
           "aliases": [],
@@ -3427,12 +3471,34 @@
           "button_backed": false
         },
         {
+          "name": "providers",
+          "type": "slash",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "List configured AI providers.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "readiness",
           "type": "prefix",
           "is_group": false,
           "parent": "ai",
           "aliases": [],
           "brief": "Run the full AI readiness chain check.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "readiness",
+          "type": "slash",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "Run the AI readiness chain check (provider, policy, perms, memory).",
           "classification": "",
           "has_panel": false,
           "button_backed": false
@@ -3449,12 +3515,34 @@
           "button_backed": false
         },
         {
+          "name": "routing",
+          "type": "slash",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "Show the routing table for AI tasks.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "settings",
           "type": "prefix",
           "is_group": false,
           "parent": "ai",
           "aliases": [],
           "brief": "Open the AI Platform settings panel directly.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "settings",
+          "type": "slash",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "Open the AI Platform settings panel.",
           "classification": "",
           "has_panel": true,
           "button_backed": true
@@ -3471,12 +3559,34 @@
           "button_backed": false
         },
         {
+          "name": "status",
+          "type": "slash",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "AI gateway status summary.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "support-report",
           "type": "prefix",
           "is_group": false,
           "parent": "ai",
           "aliases": [],
           "brief": "Render a copy-pasteable support report from recent audit (PR-H).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "support-report",
+          "type": "slash",
+          "is_group": false,
+          "parent": "ai",
+          "aliases": [],
+          "brief": "Render a copy-paste AI support report (no delivery).",
           "classification": "",
           "has_panel": false,
           "button_backed": false
@@ -3658,6 +3768,17 @@
       "commands": [
         {
           "name": "btd6",
+          "type": "slash",
+          "is_group": true,
+          "parent": null,
+          "aliases": [],
+          "brief": "BTD6 Assistant — panel, status, ask, diagnostics.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "btd6",
           "type": "prefix",
           "is_group": true,
           "parent": null,
@@ -3701,6 +3822,17 @@
           "button_backed": false
         },
         {
+          "name": "ask",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6",
+          "aliases": [],
+          "brief": "Ask a BTD6 question.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "ctteam",
           "type": "prefix",
           "is_group": false,
@@ -3723,12 +3855,34 @@
           "button_backed": false
         },
         {
+          "name": "diagnostics",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6",
+          "aliases": [],
+          "brief": "BTD6 dataset diagnostics.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "status",
           "type": "prefix",
           "is_group": false,
           "parent": "btd6",
           "aliases": [],
           "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "status",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6",
+          "aliases": [],
+          "brief": "BTD6 assistant status.",
           "classification": "",
           "has_panel": false,
           "button_backed": false
@@ -3743,6 +3897,17 @@
           "classification": "",
           "has_panel": false,
           "button_backed": false
+        },
+        {
+          "name": "test-intent",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6",
+          "aliases": [],
+          "brief": "Show what the resolver extracted from a message.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
         }
       ]
     },
@@ -3752,6 +3917,17 @@
       "subsystem": "btd6",
       "is_cog": true,
       "commands": [
+        {
+          "name": "btd6events",
+          "type": "slash",
+          "is_group": true,
+          "parent": null,
+          "aliases": [],
+          "brief": "BTD6 live events, leaderboards, and data sources.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
         {
           "name": "btd6events",
           "type": "prefix",
@@ -3775,12 +3951,34 @@
           "button_backed": false
         },
         {
+          "name": "event",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6events",
+          "aliases": [],
+          "brief": "Show one specific BTD6 event with tower restrictions.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "grounding",
           "type": "prefix",
           "is_group": false,
           "parent": "btd6events",
           "aliases": [],
           "brief": "Show the grounding facts that fed an AI response (PR-D).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "grounding",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6events",
+          "aliases": [],
+          "brief": "Grounding facts that fed an AI response.",
           "classification": "",
           "has_panel": false,
           "button_backed": false
@@ -3797,12 +3995,34 @@
           "button_backed": false
         },
         {
+          "name": "latest-data",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6events",
+          "aliases": [],
+          "brief": "Newest fact envelope per entity_kind.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "leaderboard",
           "type": "prefix",
           "is_group": false,
           "parent": "btd6events",
           "aliases": [],
           "brief": "Top-N race or boss leaderboard. No event_id = newest active.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "leaderboard",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6events",
+          "aliases": [],
+          "brief": "Show race / boss leaderboard.",
           "classification": "",
           "has_panel": false,
           "button_backed": false
@@ -3819,8 +4039,30 @@
           "button_backed": false
         },
         {
+          "name": "live",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6events",
+          "aliases": [],
+          "brief": "Show recent live events (race/boss/ct/odyssey/event).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "refresh-source",
           "type": "prefix",
+          "is_group": false,
+          "parent": "btd6events",
+          "aliases": [],
+          "brief": "Manually refresh one Ninja Kiwi source (staff-only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "refresh-source",
+          "type": "slash",
           "is_group": false,
           "parent": "btd6events",
           "aliases": [],
@@ -3841,8 +4083,30 @@
           "button_backed": false
         },
         {
+          "name": "source-health",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6events",
+          "aliases": [],
+          "brief": "BTD6 source registry freshness overview.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "sources",
           "type": "prefix",
+          "is_group": false,
+          "parent": "btd6events",
+          "aliases": [],
+          "brief": "List BTD6 source registry rows.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "sources",
+          "type": "slash",
           "is_group": false,
           "parent": "btd6events",
           "aliases": [],
@@ -3859,6 +4123,17 @@
       "subsystem": "btd6",
       "is_cog": true,
       "commands": [
+        {
+          "name": "btd6ops",
+          "type": "slash",
+          "is_group": true,
+          "parent": null,
+          "aliases": [],
+          "brief": "BTD6 ingestion operations (staff readable; toggles are admin).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
         {
           "name": "btd6ops",
           "type": "prefix",
@@ -3882,12 +4157,34 @@
           "button_backed": false
         },
         {
+          "name": "announcechannel",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6ops",
+          "aliases": [],
+          "brief": "Set/clear the BTD6 new-version announcement channel (admin).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "readiness",
           "type": "prefix",
           "is_group": false,
           "parent": "btd6ops",
           "aliases": [],
           "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "readiness",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6ops",
+          "aliases": [],
+          "brief": "Show BTD6 ingestion readiness.",
           "classification": "",
           "has_panel": false,
           "button_backed": false
@@ -3904,12 +4201,34 @@
           "button_backed": false
         },
         {
+          "name": "runs",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6ops",
+          "aliases": [],
+          "brief": "Show recent BTD6 ingestion runs.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "seed-data",
           "type": "prefix",
           "is_group": false,
           "parent": "btd6ops",
           "aliases": [],
           "brief": "Seed the Postgres data store from the bundled files (administrator).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "seed-data",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6ops",
+          "aliases": [],
+          "brief": "Seed the Postgres data store from the bundled files (admin).",
           "classification": "",
           "has_panel": false,
           "button_backed": false
@@ -3926,12 +4245,34 @@
           "button_backed": false
         },
         {
+          "name": "source_disable",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6ops",
+          "aliases": [],
+          "brief": "Disable a BTD6 ingestion source (administrator only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "source_enable",
           "type": "prefix",
           "is_group": false,
           "parent": "btd6ops",
           "aliases": [],
           "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "source_enable",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6ops",
+          "aliases": [],
+          "brief": "Enable a BTD6 ingestion source (administrator only).",
           "classification": "",
           "has_panel": false,
           "button_backed": false
@@ -3944,6 +4285,17 @@
       "subsystem": "btd6",
       "is_cog": true,
       "commands": [
+        {
+          "name": "btd6ref",
+          "type": "slash",
+          "is_group": true,
+          "parent": null,
+          "aliases": [],
+          "brief": "BTD6 reference — tower/hero/round/relic/CT lookups.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
         {
           "name": "btd6ref",
           "type": "prefix",
@@ -3967,12 +4319,34 @@
           "button_backed": false
         },
         {
+          "name": "ct",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6ref",
+          "aliases": [],
+          "brief": "Browse active Contested Territory events and relic tiles.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "hero",
           "type": "prefix",
           "is_group": false,
           "parent": "btd6ref",
           "aliases": [],
           "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "hero",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6ref",
+          "aliases": [],
+          "brief": "Look up a hero.",
           "classification": "",
           "has_panel": false,
           "button_backed": false
@@ -3989,12 +4363,34 @@
           "button_backed": false
         },
         {
+          "name": "relic",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6ref",
+          "aliases": [],
+          "brief": "Look up a Contested Territory relic's effect and tile.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "round",
           "type": "prefix",
           "is_group": false,
           "parent": "btd6ref",
           "aliases": [],
           "brief": "",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "round",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6ref",
+          "aliases": [],
+          "brief": "Look up a round.",
           "classification": "",
           "has_panel": false,
           "button_backed": false
@@ -4009,6 +4405,17 @@
           "classification": "",
           "has_panel": false,
           "button_backed": false
+        },
+        {
+          "name": "tower",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6ref",
+          "aliases": [],
+          "brief": "Look up a tower.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
         }
       ]
     },
@@ -4018,6 +4425,17 @@
       "subsystem": "btd6",
       "is_cog": true,
       "commands": [
+        {
+          "name": "btd6strat",
+          "type": "slash",
+          "is_group": true,
+          "parent": null,
+          "aliases": [],
+          "brief": "BTD6 strategy memory — browse, submit, review.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
         {
           "name": "btd6strat",
           "type": "prefix",
@@ -4041,12 +4459,34 @@
           "button_backed": false
         },
         {
+          "name": "browse",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6strat",
+          "aliases": [],
+          "brief": "Browse published BTD6 strategies.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "mine",
           "type": "prefix",
           "is_group": false,
           "parent": "btd6strat",
           "aliases": [],
           "brief": "List my own strategy submissions in this guild (PR-F).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "mine",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6strat",
+          "aliases": [],
+          "brief": "List my own strategy submissions in this guild.",
           "classification": "",
           "has_panel": false,
           "button_backed": false
@@ -4063,8 +4503,30 @@
           "button_backed": true
         },
         {
+          "name": "pending",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6strat",
+          "aliases": [],
+          "brief": "List pending strategy submissions (staff-only).",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
           "name": "strategies",
           "type": "prefix",
+          "is_group": false,
+          "parent": "btd6strat",
+          "aliases": [],
+          "brief": "List strategy memory entries available in this guild.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "strategies",
+          "type": "slash",
           "is_group": false,
           "parent": "btd6strat",
           "aliases": [],
@@ -4085,12 +4547,34 @@
           "button_backed": false
         },
         {
+          "name": "strategy",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6strat",
+          "aliases": [],
+          "brief": "Show one strategy in detail.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "strategy-audit",
           "type": "prefix",
           "is_group": false,
           "parent": "btd6strat",
           "aliases": [],
           "brief": "Show the per-strategy audit log (PR-F).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "strategy-audit",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6strat",
+          "aliases": [],
+          "brief": "Per-strategy audit log.",
           "classification": "",
           "has_panel": false,
           "button_backed": false
@@ -4107,12 +4591,34 @@
           "button_backed": false
         },
         {
+          "name": "submit",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6strat",
+          "aliases": [],
+          "brief": "Submit a BTD6 strategy.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "why-no-response",
           "type": "prefix",
           "is_group": false,
           "parent": "btd6strat",
           "aliases": [],
           "brief": "Show the most recent BTD6 denials / skips for this guild.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "why-no-response",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6strat",
+          "aliases": [],
+          "brief": "Recent BTD6 denials/skips for this guild.",
           "classification": "",
           "has_panel": false,
           "button_backed": false

--- a/docs/health/bug-book.md
+++ b/docs/health/bug-book.md
@@ -23,7 +23,7 @@
 > later empty-fire dispatch run can pick them up instead of them sitting un-promoted (the
 > trap BUG-0018 hit). Advisory by default; `--strict` exits 1 on a non-empty backlog.
 
-## BUG-0023 — public command counts differ between the bot status embed and the website (354 = 283 prefix · 71 slash vs ~280) — EXPECTED (documented); slash under-coverage = INVESTIGATE
+## BUG-0023 — public command counts differ between the bot status embed and the website (354 = 283 prefix · 71 slash vs ~280) — EXPECTED (documented); slash under-coverage = FIXED (root)
 
 - **Symptom (owner-reported, 2026-06-20, live):** the bot's `Bot Online` embed shows **`Commands
   354 (283 prefix · 71 slash)`**, the public website shows **~280**, and `site.json` says **308** —
@@ -40,18 +40,37 @@
      surface (a dual-surface command is counted in *both* 283 and 71 → "mostly duplicates"); the site
      **dedupes by name** (308 source defs → 280 unique, one page per `#/command/<name>`). Verified:
      source scan = **283 prefix + 25 slash = 308**, prefix matching the bot **exactly**.
-  3. **Slash under-coverage (the one real gap — INVESTIGATE):** static scan finds **25** slash, the
-     live tree has **71**. `scan_commands.py` already expands slash *group* subcommands, so the ~46
-     missing are most likely **dynamically-registered app commands / context menus / tree additions**
-     the AST cannot see → the website under-documents slash commands.
-- **Fix (this entry — documentation):** reconciled in
-  [`website-explained.md`](../owner/website-explained.md) ("why the counts differ") and the
-  [React-migration plan §9](../planning/botsite-react-spa-migration-plan-2026-06-20.md). The *display*
-  reconciliation (show the bot's `prefix · slash` breakdown on the site) needs an `app.js`/React edit
-  → folded into the migration **PR 1**. The slash under-coverage (root) is left scoped: it needs
-  runtime-aware counting, **not** an unattended wide-blast data regen, so it gets a focused session.
-- **Status:** **EXPECTED / documented** for the count *difference*; **slash under-coverage =
-  INVESTIGATE** (root fix scoped, not yet built).
+  3. **Slash under-coverage (the one real gap — ROOT-CAUSED + FIXED 2026-06-22):** static scan found
+     **25** slash, the live tree has **71**. The earlier hypothesis here — *"dynamically-registered app
+     commands / context menus / tree additions the AST cannot see"* — was **wrong** (investigated
+     2026-06-22: 0 context menus, 0 `tree.add_command`, 0 hybrids in the codebase). The real cause: 6
+     cogs (ai · btd6 · btd6_events · btd6_ops · btd6_reference · btd6_strategy) declare their slash
+     group as a **class *attribute*** — `ai_app_group = app_commands.Group(name="ai", …)` — with
+     subcommands decorated `@ai_app_group.command(…)`. `scan_commands._find_groups` only detected groups
+     declared as **decorated methods** (`@app_commands.group`), so it missed these 6 groups **and all 40
+     subcommands under them**. Exact reconciliation: **25 standalone + 40 subcommands + 6 groups = 71** =
+     the live tree count → every missing command is **statically discoverable** (no runtime-aware
+     counting needed; the prior "needs a runtime-aware session" scoping note was based on the wrong
+     hypothesis).
+- **Fix:**
+  - **Count-*difference* (#1 + #2): documentation** — reconciled in
+    [`website-explained.md`](../owner/website-explained.md) ("why the counts differ") and the
+    [React-migration plan §9](../planning/botsite-react-spa-migration-plan-2026-06-20.md). The *display*
+    reconciliation (show the bot's `prefix · slash` breakdown on the site) is still an `app.js`/React
+    edit folded into the migration **PR 1**.
+  - **Slash under-coverage (#3): root fix (2026-06-22)** — `scripts/scan_commands.py` now detects
+    attribute-assigned `app_commands.Group` / `HybridGroup` groups (`_find_attr_groups`), registers
+    them so their `@<group>.command` subcommands are scanned (inheriting slash/both), and emits the
+    synthesized group record. The scanner's `by_type["slash"]` is now **71** (was 25), matching the live
+    tree; the regenerated `site.json` / `dashboard.json` / `data.js` carry the 46 previously-missing
+    commands so the website documents them.
+- **Stays-fixed guard:** `tests/unit/scripts/test_scan_commands.py` ::
+  `test_attribute_assigned_app_command_group_is_scanned` (a sample cog whose slash group + subcommand
+  are now scanned — fails against the pre-fix decorator-only behaviour) +
+  `test_attribute_app_group_subcommands_counted_in_real_repo` (the real-repo slash total reconciles to
+  the bot tree, `>= 70`).
+- **Status:** **EXPECTED / documented** for the count *difference* (#1 + #2); **slash under-coverage
+  (#3) = FIXED (root) 2026-06-22** (PR #1272).
 
 ## BUG-0022 — full test suite rewrites the tracked `botsite/site/data.js` (live-HEAD build sha) → `git add -A` reddens botsite-tests — FIXED
 

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,16 +25,16 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/funny-franklin-m4ocsx` · **Starboard PR 2 — config panel + polish** (dispatch routine,
-  band-#1260 queue B1; builds on the freshly-merged #1259) — `self_star` exclusion (correctness) +
-  ignore-channels list (feature) + a `BaseView` admin-hub config panel (UX); the optional XP bonus is
-  deferred (economy/star-farming risk → wants owner input) · `disbot/migrations/084_*` /
-  `utils/db/starboard.py` / `services/starboard_service.py` / `cogs/starboard_cog.py` /
-  `disbot/views/…` · 2026-06-22 · **PR (this session, auto-merge on green)**
+- `claude/funny-franklin-mjvqrx` · **BUG-0023 slash under-coverage root fix** (dispatch routine,
+  empty-fire, bugs-first) — teach `scan_commands.py` to detect attribute-assigned `app_commands.Group`
+  groups so their 40 subcommands + 6 groups are scanned (closes the static-25-vs-live-71 gap at the
+  root) + regen dashboard/site data + mark the bug FIXED · `scripts/scan_commands.py` /
+  `tests/unit/scripts/test_scan_commands.py` / regenerated data artifacts / `docs/health/bug-book.md`
+  · 2026-06-22 · **PR (this session, self-merge on green)**
 
-*(2026-06-22 prune, Q-0166: every prior Active claim's PR had merged — `list_pull_requests` (state=open)
-returned empty — so the whole block was stale and polluting `check_lane_overlap.py`. Pruned to the one
-live claim above; the merged work is recorded in `current-state.md` + Recently cleared below.)*
+*(2026-06-22 prune, Q-0166: the prior Starboard-PR-2 claim was stale — its PR #1270 merged and
+`list_pull_requests` (state=open) returned empty — so it was pruned; merged work is in
+`current-state.md` + Recently cleared below.)*
 
 ## Recently cleared
 

--- a/scripts/scan_commands.py
+++ b/scripts/scan_commands.py
@@ -55,6 +55,18 @@ _COMMAND_DECORATORS: dict[str, tuple[str, bool]] = {
     "tree.command": ("slash", False),
 }
 _SUBCOMMAND_LEAVES = {"command", "group", "subcommand"}
+# Group *constructors* assigned to a class attribute (vs. the decorated-method form
+# handled by _COMMAND_DECORATORS). discord.py slash groups are very commonly declared
+# as a class attribute — ``my_group = app_commands.Group(name="…", …)`` — with their
+# subcommands decorated ``@my_group.command(…)``. The decorator-only scan missed both
+# the group and every subcommand under it (BUG-0023 slash under-coverage). Maps the
+# constructor's dotted path -> invocation type.
+_GROUP_CONSTRUCTORS: dict[str, str] = {
+    "app_commands.Group": "slash",
+    "Group": "slash",
+    "commands.HybridGroup": "both",
+    "HybridGroup": "both",
+}
 _PANEL_TOKENS = ("panel_manager", "send_panel", "View(", "view=")
 # Acronym-aware CamelCase -> snake_case: split before a Capitalised word that
 # follows an acronym run (HTTPServer -> HTTP_Server) and between a lower/digit
@@ -179,6 +191,44 @@ def _find_groups(class_node: ast.ClassDef) -> dict[str, tuple[str, str]]:
     return groups
 
 
+def _find_attr_groups(
+    class_node: ast.ClassDef,
+) -> dict[str, tuple[str, str, str]]:
+    """Map an attribute-assigned group's *variable* name -> (command name, type, brief).
+
+    Catches the ``my_group = app_commands.Group(name="…", description="…")`` form
+    (and ``HybridGroup``) that ``_find_groups`` (decorated *methods* only) misses.
+    The variable name is the key because subcommands reference it as
+    ``@my_group.command`` -> the same ``parts[0]`` lookup ``_scan_method`` already
+    does for method groups. The command name is the ``name=`` kwarg when set, else
+    the variable name; the brief is the ``description=`` kwarg.
+    """
+    out: dict[str, tuple[str, str, str]] = {}
+    for item in class_node.body:
+        targets: list[str] = []
+        value: ast.expr | None = None
+        if isinstance(item, ast.Assign):
+            value = item.value
+            for tgt in item.targets:
+                if isinstance(tgt, ast.Name):
+                    targets.append(tgt.id)
+        elif isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+            value = item.value
+            targets.append(item.target.id)
+        if not targets or not isinstance(value, ast.Call):
+            continue
+        kind = _GROUP_CONSTRUCTORS.get(_decorator_path(value))
+        if kind is None:
+            continue
+        name = _kwarg(value, "name")
+        desc = _kwarg(value, "description")
+        brief = desc if isinstance(desc, str) else ""
+        for var in targets:
+            cmd_name = name if isinstance(name, str) else var
+            out[var] = (cmd_name, kind, brief)
+    return out
+
+
 def _scan_method(
     method: ast.AST,
     source: str,
@@ -233,7 +283,28 @@ def _scan_method(
 
 def _scan_class(class_node: ast.ClassDef, source: str, rel_path: str) -> dict | None:
     groups = _find_groups(class_node)
+    attr_groups = _find_attr_groups(class_node)
+    # Attribute-assigned groups feed subcommand resolution the same way method
+    # groups do (``@<var>.command`` -> parent lookup on ``parts[0]``).
+    groups.update({var: (name, kind) for var, (name, kind, _) in attr_groups.items()})
     commands: list[dict] = []
+    # Synthesize a record for each attribute-assigned group so it is counted like a
+    # decorated-method group (which _scan_method already emits). The bot's live tree
+    # counts the group itself plus each subcommand (BUG-0023 reconciliation).
+    for _var, (name, kind, brief) in attr_groups.items():
+        commands.append(
+            {
+                "name": name,
+                "type": kind,
+                "is_group": True,
+                "parent": None,
+                "aliases": [],
+                "brief": _truncate(brief, 160),
+                "classification": "",
+                "has_panel": False,
+                "button_backed": False,
+            },
+        )
     for item in class_node.body:
         cmd = _scan_method(item, source, groups)
         if cmd is not None:

--- a/tests/unit/scripts/test_scan_commands.py
+++ b/tests/unit/scripts/test_scan_commands.py
@@ -58,6 +58,14 @@ class SampleCog(commands.Cog):
     async def grp_sub(self, ctx):
         """A subcommand."""
 
+    # Slash group declared as a class *attribute* (not a decorated method) — the
+    # very common discord.py form that the decorator-only scan missed (BUG-0023).
+    appgrp = app_commands.Group(name="ag", description="An app-command group.")
+
+    @appgrp.command(name="agsub", description="An app-group subcommand.")
+    async def appgrp_sub(self, interaction):
+        """App-group subcommand."""
+
 
 class SampleMixin:
     """A command-bearing mixin — not a real Cog."""
@@ -102,6 +110,38 @@ def test_scan_commands_types_aliases_and_buttons(mod, tmp_path):
     assert by_name["panelcmd"]["button_backed"] is True
     assert by_name["opensview"]["button_backed"] is True
     assert by_name["sub"]["parent"] == "grp"
+
+
+def test_attribute_assigned_app_command_group_is_scanned(mod, tmp_path):
+    """A slash group declared as a class attribute + its subcommands are scanned.
+
+    Regression for BUG-0023 (slash under-coverage): before the fix, an
+    ``app_commands.Group`` assigned to a class attribute and its ``@<attr>.command``
+    subcommands were invisible to the scanner — it only detected decorated-method
+    groups. Both the group record and the subcommand must now appear, typed slash.
+    """
+    by_cog = {c["cog"]: c for c in mod.scan_commands(_write_repo(tmp_path))}
+    by_name = {c["name"]: c for c in by_cog["SampleCog"]["commands"]}
+    # the group itself, counted like a decorated-method group
+    assert by_name["ag"]["type"] == "slash"
+    assert by_name["ag"]["is_group"] is True
+    assert by_name["ag"]["parent"] is None
+    # its subcommand, slash-typed and parented to the group
+    assert by_name["agsub"]["type"] == "slash"
+    assert by_name["agsub"]["parent"] == "ag"
+
+
+def test_attribute_app_group_subcommands_counted_in_real_repo(mod):
+    """The real repo's attribute-assigned slash groups now reconcile to the bot tree.
+
+    The 6 cogs declaring ``app_commands.Group`` as a class attribute (ai / the five
+    btd6 cogs) contribute their groups + subcommands, so the scanner's slash total
+    matches the live ``bot.tree.walk_commands()`` count instead of under-reporting.
+    """
+    summary = mod.summarise(mod.scan_commands())
+    # by_type counts every command of a type (groups + subcommands + standalone);
+    # this is the metric that aligns with the bot's slash count (BUG-0023).
+    assert summary["by_type"]["slash"] >= 70
 
 
 def test_cog_to_subsystem_is_acronym_aware(mod):


### PR DESCRIPTION
## What & why

Closes **BUG-0023's one real gap** — the slash under-coverage where the static command scan finds
**25** slash commands but the live bot tree has **71**, so the website under-documents slash commands.

The bug book hypothesised this was *"dynamically-registered app commands / context menus the AST cannot
see."* **Investigated this run — that hypothesis is wrong.** The codebase has 0 context menus, 0
`tree.add_command`, 0 hybrids. The gap is entirely **`app_commands.Group` declared as a class
*attribute*** (`ai_app_group = app_commands.Group(name="ai", …)`) with subcommands decorated
`@ai_app_group.command(…)`, across 6 cogs (ai · btd6 · btd6_events · btd6_ops · btd6_reference ·
btd6_strategy). `scan_commands._find_groups` only detected groups declared as **decorated methods**, so
it missed these groups **and every subcommand under them**.

**Exact reconciliation: 25 standalone + 40 subcommands + 6 groups = 71** = the live tree count. All 46
missing commands are statically discoverable — no runtime-aware counting needed.

## Changes

- `scripts/scan_commands.py` — detect attribute-assigned `app_commands.Group` / `HybridGroup` groups,
  register them so their `@<group>.command` subcommands are scanned (inheriting slash/both), and emit
  the synthesized group record.
- `tests/unit/scripts/test_scan_commands.py` — regression case (fails against the pre-fix behaviour).
- Regenerated `dashboard/data/dashboard.json` · `botsite/data/site.json` · `botsite/site/data.js`.
- `docs/health/bug-book.md` — BUG-0023 slash under-coverage marked FIXED (root) with the reconciliation.

## Verification

`python3.10 scripts/check_quality.py --full` + `check_architecture.py --mode strict` green.

Dispatch routine, empty-fire, bugs-first. ⚑ Self-initiated (Q-0172).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvbLLGcXoRx1dkEHaKSntr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvbLLGcXoRx1dkEHaKSntr)_