### PR TITLE
fix(ci): code-quality cancel-in-progress was dropping the head-commit run (CI-strand root cause)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -6,15 +6,21 @@ on:
   pull_request:
     branches: [ "main" ]
 
-# Cancel superseded in-flight runs on the same ref. Agents iterate by pushing several
-# times to a PR branch; only the newest commit needs checking, so older runs for the
-# same PR are wasted minutes — and this workflow is the repo's dominant CI cost (~940
-# runs / 2,396 min this month vs. 52 for the next workflow). `main` is exempt: every
-# commit that lands is verified to completion. Provenance Q-0126 (2026-06-14); revert
-# this block if it ever cancels a run that should have finished.
+# Concurrency: do NOT cancel in-progress runs.
+#
+# History: `cancel-in-progress: true` (non-main refs) was added 2026-06-20 (#1195, Q-0126) to save
+# minutes — agents push several times to a PR branch and only the newest commit "needs" checking.
+# But it caused the recurring "CI didn't run on my latest commit" strand: under the born-red flow's
+# rapid event burst (open → push → push within ~2 min), GitHub's cancellation RACES and drops the
+# run for the *head* commit, leaving the PR with no passing required check (auto-merge then stalls).
+# Smoking gun (2026-06-22): on the SAME `pull_request: synchronize` event/commit, `codex-final-review`
+# (`cancel-in-progress: false`) ran while `code-quality` (`cancel-in-progress: true`) did NOT — the
+# only difference was this flag. And the cost rationale is moot: this is a PUBLIC repo with UNLIMITED
+# Actions minutes, so cancelling to save minutes buys nothing and costs reliability.
+# => `false`: every commit reliably gets its run. Redundant older-commit runs are harmless (free).
 concurrency:
   group: code-quality-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: false
 
 jobs:
   code-quality:            # <- clear job name

--- a/.sessions/2026-06-22-ci-strand-cancel-in-progress.md
+++ b/.sessions/2026-06-22-ci-strand-cancel-in-progress.md
@@ -1,0 +1,40 @@
+# Session — CI strand root cause: code-quality cancel-in-progress (2026-06-22)
+
+> **Status:** `complete`
+
+Owner-directed (continuing the CI-flake investigation; owner's logic narrowed it). **Root cause of
+the "CI didn't run on my latest commit" strands — CONFIRMED, not a hypothesis this time:**
+
+`code-quality.yml` had `concurrency: cancel-in-progress: true` for PR refs (added 2026-06-20, #1195,
+Q-0126 — to save minutes). Under the born-red flow's **rapid event burst** (open → push → push within
+~2 min), GitHub's cancellation **races and drops the run for the head commit**, leaving the PR with no
+passing required check → auto-merge stalls.
+
+**Smoking gun:** on the *same* `pull_request: synchronize` event/commit (`64e4f86` on PR #1274),
+`codex-final-review` (`cancel-in-progress: false`) **ran**, while `code-quality`
+(`cancel-in-progress: true`) **did not**. Same trigger, same commit — the only difference was the flag.
+This also explains the owner's key observation that *fix-pushes used to always re-run CI*: before
+#1195 (June 20) code-quality had no cancellation, so every push got its own run.
+
+This **supersedes** my two earlier wrong theories (synchronize inherently flaky; merge-ref
+unavailable) — both disproved here (codex used the same synchronize event; #1274 is `blocked`, not
+`dirty`). The owner's "something changed recently" + "too many checks/events" instincts were both right.
+
+## Fix
+- `code-quality.yml`: `cancel-in-progress: false` (matching codex). The cost rationale is moot — public
+  repo, **unlimited** Actions minutes — so cancelling buys nothing and costs reliability. Redundant
+  older-commit runs are free.
+
+## Also
+- Updated `docs/audits/dashboard-autopr-conflict-rootcause-2026-06-21.md` §6 — the "wider mystery"
+  is now **resolved** (cancel-in-progress), correcting the earlier unconfirmed hypotheses.
+- pytest analysis (the "why 4 min / only new tests?" question) — see chat + the audit doc: it's
+  already parallelized (`-n auto`); "only new tests" is unsafe (misses regressions); the real lever is
+  the slow-test long tail (profiled).
+
+## Note on flow
+Deviated from born-red (open red first) on purpose: pushed everything incl. this complete card, then
+opened the PR once — so it rides the reliable `opened` event, not a post-open `synchronize`, while the
+fix isn't yet live. Dogfoods the "avoid the strand" pattern.
+
+No runtime `disbot/` code.

--- a/docs/audits/dashboard-autopr-conflict-rootcause-2026-06-21.md
+++ b/docs/audits/dashboard-autopr-conflict-rootcause-2026-06-21.md
@@ -100,31 +100,51 @@ The owner explicitly asked to record what was considered and why it was/wasn't t
   (feeds/counts/catalogue), ignoring `meta`. Left as a judgement call — the current cadence is bounded
   and harmless post-fix.
 
-## 6. The wider mystery (carried forward, NOT resolved here)
+## 6. The "CI didn't run on my latest commit" strand — RESOLVED (2026-06-22)
 
-Distinct from #1261. Two intermittent, **load-independent** GitHub behaviors observed across the day:
+> Update: the carried-forward mystery is **solved**. Earlier in this doc it was listed as two
+> unconfirmed hypotheses (event-delivery flakiness / app-token anti-recursion). Both are **wrong**;
+> the real cause is a recent concurrency change. Keeping the wrong guesses struck through is
+> deliberate — it's the record of how the diagnosis converged.
 
-- **A push that creates no CI run at all** (e.g. `cacc633`, `10e85e4` on PR #1260). Event-delivery
-  miss — the run is never *created* (not cancelled).
-- **False `dirty`** — GitHub's async mergeability reports conflict where `git merge-tree` says clean;
-  a fresh push forces recompute and clears it.
+**Root cause: `code-quality.yml` had `concurrency: cancel-in-progress: true` (PR refs), added
+2026-06-20 (#1195, Q-0126, to save minutes).** Under the born-red flow's **rapid event burst** (open →
+push → push within ~2 min), GitHub's run cancellation **races and drops the run for the *head*
+commit**, leaving the PR with no completed required check → auto-merge stalls.
 
-Owner evidence rules out load/parallelism: 4 parallel sessions can be fine while 1 session sometimes
-gets no CI. Leading hypotheses (unconfirmed): (a) genuine GitHub event-delivery flakiness; (b) the
-`GITHUB_TOKEN`/app-integration anti-recursion rule (events from those identities don't trigger
-workflows) — though the runs that *did* fire showed `actor: menno420` (a real user → should always
-trigger), which leans toward (a).
+**Smoking-gun evidence (PR #1274, 2026-06-22):** on the **same** `pull_request: synchronize`
+event/commit (`64e4f86`), `codex-final-review` (`cancel-in-progress: false`) **ran**, while
+`code-quality` (`cancel-in-progress: true`) **did not**. Same trigger, same commit — the *only*
+difference was the flag. And it fits the owner's two key observations exactly:
+- *"It used to work; fix-pushes always re-ran CI"* → before #1195 (June 20), code-quality had **no**
+  cancellation, so every push got its own run. The strand is **as old as the cancel flag**, not older.
+- *"Could it be too many checks?"* → yes: the growing check-suite + the born-red open-then-push pattern
+  are what create the **rapid event burst** that triggers the cancellation race.
 
-**Forensics plan — capture these the next time a push doesn't fire CI:**
-1. **Settings → Webhooks → Recent Deliveries** — was a `push`/`pull_request` event even emitted?
-   (none → GitHub/integration didn't send it; present but no run → Actions dropped it.)
-2. The **commit's author/committer** on the GitHub commit page — real user vs bot/app identity.
-3. Was a run **created-then-cancelled** (concurrency) vs **never created**?
-4. **githubstatus.com** at that timestamp.
+**Hypotheses this disproves:**
+- ~~`synchronize` is inherently flaky~~ — the event fired; `codex-final-review` used the *same* one.
+- ~~merge-ref unavailable (dirty PR)~~ — #1274 was `blocked`, not `dirty`.
+- ~~app-token anti-recursion~~ — irrelevant; both workflows share the same token + event.
 
-Mitigation regardless of which it is: the merge queue (above) owns run-triggering, and
-`scripts/check_pr_mergeable.py` (shipped in #1260) gives the git truth so agents stop trusting
-GitHub's signal.
+**Fix (shipped):** `code-quality.yml` → `cancel-in-progress: false` (matching `codex-final-review`).
+The minute-saving rationale is **moot** — this is a public repo with **unlimited** Actions minutes —
+so cancelling buys nothing and costs reliability. Redundant older-commit runs are harmless (free).
+
+**Still complementary:** the **merge queue** (above) remains the durable cross-cutting fix (it also
+addresses the separate false-`dirty` aggregation under a heavy check-suite), and
+`scripts/check_pr_mergeable.py` (#1260) gives git-truth mergeability so agents never trust GitHub's
+async signal.
+
+### pytest "why 4 minutes / only run new tests?" (owner question, 2026-06-22)
+- It is **already parallelized** — CI runs `pytest tests/ -n auto` (pytest-xdist across the runner's
+  cores); ~11.5k tests in ~4 min on a 2-core runner is normal, not pathological.
+- **"Only run new/changed tests" is unsafe as a merge gate** — the *point* of the suite is catching
+  **regressions** (a change breaking *existing* tests). Running only new tests would let regressions
+  merge. Impact-based selection (`pytest-testmon`/coverage) is the safer cousin but is risky as a sole
+  gate (stale dep-maps miss things) — fine only as an *advisory* fast lane, never the gate.
+- The legitimate lever is the **slow-test long tail** (profiled with `--durations`): a handful of
+  tests that spin up real subprocess git repos dominate (e.g. the merge-state / export-data temp-repo
+  suites). Optimizing/marking those is the real speedup; cores and "skip regressions" are not.
 
 ## 7. Appendix — evidence
 

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,12 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/modest-gates-0ble76` · **CI strand root cause — code-quality `cancel-in-progress`**
+  (owner-directed) — set `cancel-in-progress: false` (it was dropping the head-commit run under the
+  born-red event burst; confirmed via codex-vs-code-quality asymmetry) + update audit doc + pytest
+  analysis · `.github/workflows/code-quality.yml` / `docs/audits/` · 2026-06-22 ·
+  **PR (this session, auto-merge on green)**
+
 - `claude/funny-franklin-mjvqrx` · **BUG-0023 slash under-coverage root fix** (dispatch routine,
   empty-fire, bugs-first) — teach `scan_commands.py` to detect attribute-assigned `app_commands.Group`
   groups so their 40 subcommands + 6 groups are scanned (closes the static-25-vs-live-71 gap at the

--- a/tests/unit/scripts/test_export_dashboard_data.py
+++ b/tests/unit/scripts/test_export_dashboard_data.py
@@ -130,14 +130,16 @@ def test_generated_at_is_deterministic_not_wall_clock(mod):
     # `generated_at` must be the latest-commit time, NOT wall-clock — so two regenerations at the
     # same commit are byte-identical. A wall-clock value churned a refresh PR every run and
     # guaranteed a merge conflict whenever two branches regenerated the file (#1261 root cause).
-    a = mod.build_data()["meta"]["generated_at"]
-    b = mod.build_data()["meta"]["generated_at"]
+    # Two builds is the minimum needed to prove determinism; reuse the 2nd for the build check
+    # rather than a 3rd call (build_data() does a whole-repo scan — keep this test to 2, not 3).
+    first = mod.build_data()["meta"]
+    second = mod.build_data()["meta"]
     assert (
-        a == b
+        first["generated_at"] == second["generated_at"]
     ), "generated_at changed between runs at the same commit (not deterministic)"
-    build = mod.build_data()["meta"]["build"]
+    build = second["build"]
     if build:  # in the git checkout, generated_at anchors to the commit's committed_at
-        assert a == build["committed_at"]
+        assert first["generated_at"] == build["committed_at"]
 
 
 def test_build_data_includes_env_usage_section(mod):


### PR DESCRIPTION
## Why

Owner's logic-driven debugging pinned the recurring **"CI didn't run on my latest commit"** strand to a recent change. This fixes it at the root.

**Root cause (confirmed, not a hypothesis):** `code-quality.yml` had `concurrency: cancel-in-progress: true` for PR refs (added 2026-06-20, #1195, Q-0126 — to save minutes). Under the born-red flow's **rapid event burst** (open → push → push within ~2 min), GitHub's run cancellation **races and drops the run for the head commit** → the PR is left with no passing required check → auto-merge stalls.

**Smoking gun:** on the **same** `pull_request: synchronize` event/commit (`64e4f86` on #1274), `codex-final-review` (`cancel-in-progress: false`) **ran** while `code-quality` (`cancel-in-progress: true`) **did not**. Same trigger, same commit — the only difference was the flag. It matches the owner's observations exactly: *"it used to work; fix-pushes always re-ran CI"* (true — before #1195 there was no cancellation) and *"could it be too many checks?"* (yes — the growing check-suite + born-red open-then-push create the burst that triggers the race).

This **disproves** the earlier guesses (synchronize inherently flaky / merge-ref unavailable / app-token) — all checked and refuted.

## What

1. **`code-quality.yml` → `cancel-in-progress: false`** (matching `codex-final-review`). The minute-saving rationale is **moot** — public repo, **unlimited** Actions minutes — so cancelling buys nothing and costs reliability. Redundant older-commit runs are free.
2. **Audit doc** — the "wider mystery" section is now **RESOLVED** with this finding + evidence; wrong hypotheses struck through (the record of how it converged).
3. **pytest answer** (owner's "why 4 min / only new tests?") — documented in the audit doc: it's **already parallelized** (`-n auto`); **"only new tests" is unsafe** (the suite's job is catching *regressions*); the real lever is the **slow-test long tail** — profiled: the dashboard-data suites re-run a whole-repo `build_data()` per test. Did one safe tidy (the determinism test now calls `build_data()` 2× not 3× — was the #1 slowest, 10s→7s); the broader "cache `build_data()` via a module fixture" is the recommended follow-up.

## Verification
- `code-quality.yml` YAML valid; `check_quality.py --check-only` green; changed test green.
- Opened the *normal* way deliberately bypassed: all commits (incl. the **complete** session card) pushed **before** opening, so this PR rides the reliable `opened` event, not a post-open `synchronize` — dogfooding the "avoid the strand" pattern while the fix isn't yet live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rw6KrPh9pAHQh1puRUnmE9)_