### PR TITLE
feat(hook): wrong-branch guard + institutionalize the friction→guard reflex

### DIFF
--- a/.session-journal.md
+++ b/.session-journal.md
@@ -96,11 +96,25 @@ one source of truth** over per-panel patches. Full set under **Rules / Conventio
      the drift). The tracker is authoritative for shipped/queued.
   4. **Session log** — write a new `.sessions/<date>-<slug>.md` file (link to the PR +
      the authoritative doc; don't restate per-PR detail). Before writing it, **run the
-     reflection interview** — the standing six-question self-interview in
+     reflection interview** — the standing seven-question self-interview in
      `.sessions/README.md` (route miss / route excess / discovered-by-hand / decisions
-     made alone / weak point of what shipped / one change that would have helped) — and
-     fold the answers into the log's **`Context delta`** + flag lines. The maintainer
-     used to ask these manually in chat nearly every session; standing since 2026-06-09.
+     made alone / weak point of what shipped / one change that would have helped /
+     **friction → guard**) — and fold the answers into the log's **`Context delta`** +
+     flag lines. The maintainer used to ask these manually in chat nearly every session;
+     standing since 2026-06-09.
+  4b. **Friction → guard reflex (Q-0194, owner-directed) — the self-prevention loop.**
+     If *anything interrupted your workflow this session* — a command that silently failed,
+     a wrong/stale-branch trap, a footgun, a repeated manual fixup — **you ship (or propose)
+     the cheapest *enforcing* prevention before ending, not just a note** ("enforce, don't
+     exhort", Q-0132). Order of preference: **checker / CI guard / test → hook → journal
+     Rule.** Free to ship now: docs / journal / test / checker. Owner-gated (build only if
+     owner-directed in-session per Q-0106, else propose a router DISCUSS Q): a **hook**,
+     **`.claude/settings.json`**, or a **binding `CLAUDE.md` rule**. Record it on the log's
+     `🛠 Friction → guard` line. *The point the owner made (2026-06-22): catching these
+     should not depend on the owner spotting them — the agent that hit the friction is the
+     one positioned to prevent its recurrence.* This session is the canonical example: a
+     masked-pipe `git checkout` failure → a wrong-branch `git merge` → the extended
+     `check_branch_freshness.py` PreToolUse branch guard (Q-0194).
      **Also mandatory since 2026-06-10 (Q-0089): one new `💡 Session idea`** you genuinely
      believe in (bot or network, any size; dedup-grep `docs/ideas/` first; substantial
      ones get an idea file).
@@ -556,6 +570,20 @@ PR #676; drift surfaced at boot + `!btd6 status`). Full note:
   just unbroken).
 
 ### Cross-agent & git workflow
+- **★ Sync to `origin/main` and branch fresh BEFORE any PR activity — especially on a
+  *resumed* session (2026-06-22).** A resumed session lands you on your *last* branch, which
+  may already be merged (the SessionStart banner flags it `STALE BRANCH`). Building/merging
+  from there is the wrong-branch trap. First action of PR work: `git fetch origin main &&
+  git checkout -b <slug> origin/main`. The extended `check_branch_freshness.py` now warns on
+  `git commit`/`merge`/`rebase` from a behind/detached/on-main state (Q-0194), but the habit
+  is the real guard.
+- **★ Never mask a command's exit code behind a pipe when you branch on its success
+  (2026-06-22).** `git checkout … 2>&1 | tail -2 || fallback` runs the fallback off **`tail`'s**
+  exit (always 0), so a *failed* checkout silently looks like success — this is exactly how a
+  `git merge` landed on the wrong branch this session (the checkout had failed; I never saw it).
+  Don't pipe a command whose `$?` you rely on; and **after any `git checkout`/`switch`, confirm
+  `git branch --show-current`** before a state-changing git op. (The `git push` wrong-branch slip
+  is separately guarded by the freshness hook; this is the `commit`/`merge` half — Q-0194.)
 - **`send_later` is NOT provisioned in this environment — don't chase it (2026-06-14, Q-0129).**
   The remote/web harness system prompt now tells PR-watching sessions to "arm a `send_later`
   self check-in (claude-code-remote MCP) before ending your turn, *if available*." It is **not

--- a/.sessions/2026-06-22-friction-to-guard-reflex.md
+++ b/.sessions/2026-06-22-friction-to-guard-reflex.md
@@ -1,0 +1,96 @@
+# 2026-06-22 — Wrong-branch guard hook + the "friction → guard" self-prevention reflex
+
+> **Status:** `complete` — owner-directed. Two halves: (1) build the recommended advisory
+> wrong-branch hook; (2) the owner's deeper ask — harden the guides so agents *self-generate*
+> these prevention fixes, instead of the owner having to spot inconsistencies. Owner-directed
+> (Q-0194, Q-0191) → merge on green; no `needs-hermes-review`.
+
+> **Run type:** `manual · owner-directed`
+
+## What shipped
+
+**Part A — the wrong-branch guard (the concrete fix).** Extended `scripts/check_branch_freshness.py`
+(the existing Q-0138/Q-0188 advisory hook): its PreToolUse(Bash) trigger now also fires on
+`git commit`/`merge`/`rebase` with a **network-free** branch guard — warns on **detached HEAD**,
+**on `main`**, or **behind `origin/main`** (local refs only, so zero latency on the frequent commit
+path; `git push` keeps the authoritative network freshness check). Advisory, never blocking, same
+Q-0105 kill-switch. No `.claude/settings.json` change needed (the existing `Bash` matcher already
+routes to the script). +4 tests; black/ruff clean; 11/11 green.
+
+This directly catches this session's own slip: a piped `git checkout` (`… | tail -2 || fallback`)
+masked the checkout's failed exit behind `tail`'s, so a `git merge origin/main` ran on an
+already-merged branch. The guard makes a detached/behind/wrong branch loud at the `commit`/`merge`
+moment.
+
+**Part B — the systemic half (so the owner doesn't have to spot these).**
+- `.sessions/README.md` — added **reflection-interview question 7: "What interrupted your workflow —
+  and did you ship a guard so the next session can't hit it?"** with the preference order
+  (checker/CI/test → hook → journal Rule) and the free-vs-owner-gated ownership split → a
+  `🛠 Friction → guard` log line.
+- `.session-journal.md` — added END-protocol **step 4b (the friction → guard reflex)** and two
+  **Cross-agent & git workflow** Rules: *sync to `origin/main` & branch fresh before PR work
+  (esp. resumed sessions)* and *never mask a command's `$?` behind a pipe; confirm
+  `git branch --show-current` after a checkout*.
+- `docs/owner/maintainer-question-router.md` — **Q-0194** records the directive + a DISCUSS item to
+  optionally elevate the reflex into binding `CLAUDE.md`.
+
+## Findings / decisions
+
+- **Advisory, not blocking (decided).** A fresh branch also has an empty diff vs `main`, so a hard
+  block on "looks merged" would misfire; and squash-merges make "already merged" undetectable from
+  git alone. The reliable, low-false-positive signal is the existing behind/detached/on-main check,
+  surfaced at the dangerous moment — matching the hook's disposable-advisory philosophy.
+- **The real fix is the reflex, not the hook.** The hook prevents *this* footgun; question 7 + step
+  4b make the *next* session convert *its* friction into a guard without the owner prompting — which
+  was the owner's actual ask. The hook is the dogfooded example of the reflex.
+- **Decision made alone — CLAUDE.md elevation left as a proposal.** The reflex is fully operative via
+  the journal/README enders (run every session); promoting it into binding CLAUDE.md is propose-first
+  (Q-0035), so it's a DISCUSS item, not self-applied.
+
+## 🛠 Friction → guard (Q-0194)
+
+**Friction:** a masked-pipe `git checkout` failure → a `git merge` on the wrong (already-merged)
+branch; root-caused to (a) not syncing to `origin/main` first on a resumed session, (b) `cmd | tail
+|| fallback` swallowing the real exit code, (c) not verifying the branch after the checkout.
+**Guard shipped:** the extended `check_branch_freshness.py` PreToolUse branch guard (Q-0194) + two
+journal Rules + the standing reflex itself (so this class self-prevents going forward).
+
+## 💡 Session idea
+
+**A tiny `scripts/check_no_exit_masking.py` lint (Q-0105-disposable).** The root trigger was a shell
+anti-pattern — piping a command whose exit code you then branch on (`cmd | tail || fallback`). A
+warn-only checker that flags `… | <filter> (&&|\|\|) …` shapes in committed shell/scripts (and could
+advise in PreToolUse on Bash) would catch the *class*, not just the git instance. Dedup-checked: no
+existing checker inspects shell exit-code handling. (Filed as the forward idea, not built this run —
+the branch guard already covers the concrete git case.)
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous turn (un-sticking #1274) was sound — it correctly diagnosed the stuck PR as the dropped
+CI run + a real `active-work.md` conflict I had caused, and resolved it cleanly. **Where it (and I)
+fell short:** the wrong-branch slip *inside* that work should have triggered a guard immediately,
+unprompted — instead it took the owner asking "isn't there a rule?" to surface it. That gap is
+exactly what this session's reflex (Q7 + step 4b) institutionalizes. **System improvement
+(initiated):** the friction→guard reflex closes the loop so "an agent hit friction" reliably becomes
+"the next agent can't" — the internal version of the owner-as-reviewer safety net, but self-served.
+
+## 📤 Run report
+
+- **Did:** built the advisory wrong-branch hook + institutionalized the friction→guard reflex
+  (reflection Q7, journal step 4b + Rules, router Q-0194) · **Outcome:** shipped (this PR, auto-merge
+  on green)
+- **Run type:** `manual · owner-directed`
+- **⚑ Owner decisions needed:** Q-0194 DISCUSS — optionally elevate the friction→guard reflex into
+  binding `CLAUDE.md` (it is already operative at journal/README level).
+- **⚑ Owner manual steps:** none — docs + a disposable advisory hook; merged = deployed.
+- **⚑ Self-initiated:** no — owner-directed (build the hook + improve the guides). The `💡` shell
+  exit-masking lint idea is filed, not built.
+- **↪ Next:** ungated build lanes (current-state ▶) untouched. If the owner greenlights the DISCUSS
+  item, add the one-line CLAUDE.md principle.
+
+## ⟳ Doc audit (Q-0104)
+
+`check_docs --strict` + `check_current_state_ledger --strict` green; hook test 11/11; script
+black/ruff clean. Q-0194 recorded in the router with provenance; the hook header carries the Q
+(Q-0105 reliability header convention). No current-state ledger entry (no merged PR yet — this
+session's PR is recorded next reconciliation, benign lag).

--- a/.sessions/README.md
+++ b/.sessions/README.md
@@ -40,6 +40,18 @@ anchor, so any two concurrently-open PRs collided there (it bit #529→#530 and
      → the log's **Flagged for maintainer** / known-limits line.
   6. **What one docs/tooling change would have most helped this session?**
      → execute it in the grooming pass if small, else file it under `docs/ideas/`.
+  7. **What interrupted your workflow — and did you ship a guard so the next session can't
+     hit it?** A footgun, a silently-failed command, a stale/wrong-state trap, a manual
+     fixup you had to repeat, anything that cost recovery time. **The reflex: don't just note
+     it — convert it into the cheapest *durable, enforcing* prevention,** and do it *this*
+     session (that's the "enforce, don't exhort" rule — a prose reminder is the weakest
+     option). Prefer, in order: **a checker / CI guard / test** that fails on the bad state →
+     **a hook** (`scripts/*` + `.claude/settings.json`) → **a journal Rule** as the last
+     resort. Route by ownership: a docs/journal/test/checker guard is **free to ship now**; a
+     **hook / `.claude/settings.json` / binding-`CLAUDE.md` rule** is **owner-gated** — build
+     it if the owner directed it in-session (Q-0106), else propose it as a router DISCUSS Q.
+     → the log's **`🛠 Friction → guard`** line (name the friction + the guard you shipped or
+     proposed; `none` only if the run genuinely hit no friction — never invent one).
   Answer honestly and specifically — a near-miss is more valuable written down than a
   success story. A periodic REVIEW (`.session-journal.md`) mines these deltas and
   promotes recurring gaps into the orientation route / folios. Keep it to what you'd

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,14 +25,14 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/funny-franklin-h6cjlg` · **allow read-only network probes (curl)** (dispatch routine,
-  owner-directed in-session) — move `curl` `ask`→`allow` in `.claude/settings.json` + the `timeout`
-  wrapper; prune the stale BUG-0023 claim · `.claude/settings.json` / `docs/owner/active-work.md` ·
-  2026-06-22 · **PR (this session, owner-directed self-merge on green)**
+- `claude/friction-to-guard-reflex` · **wrong-branch guard hook + friction→guard reflex**
+  (owner-directed, Q-0194) — extend `check_branch_freshness.py` PreToolUse to warn on
+  commit/merge/rebase from a wrong/stale branch + institutionalize the "any friction → ship a
+  guard" session-ender · `scripts/check_branch_freshness.py` + tests / `.sessions/README.md` /
+  `.session-journal.md` / router · 2026-06-22 · **PR (this session, auto-merge on green)**
 
-*(2026-06-22 prune, Q-0166: the BUG-0023 slash-under-coverage claim on `claude/funny-franklin-mjvqrx`
-was stale — its PR #1272 merged (in `git log`, bug-book marked FIXED) and `list_pull_requests`
-(state=open) returned empty — so it was pruned; merged work is in `current-state.md` + the bug-book.)*
+*(2026-06-22 prune, Q-0166 drift-on-sight: the `claude/funny-franklin-h6cjlg` curl-allow claim
+(PR #1274) merged to `main` — pruned here; merged work is in `current-state.md`.)*
 
 *(2026-06-22 prune, Q-0166 drift-on-sight: the merge from `main` carried in several already-merged
 claims — `claude/fix-ci-synchronize-journal-claim` (PR #1278), `claude/modest-gates-0ble76` (PR #1267)

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -7081,3 +7081,45 @@ Q); `.session-journal.md` got a one-line prevention note next to the auto-deploy
 
 **Home:** this Q-block (canonical) + `docs/operations/production-deployment.md` (the operational truth) +
 the `.claude/CLAUDE.md` auto-merge bullet (the binding rule).
+
+---
+
+### Q-0194 — ANSWERED (owner directive in-session): make agents self-generate workflow guards; wrong-branch hook (2026-06-22)
+
+**Context.** A session hit a wrong-branch slip: a piped `git checkout` (`… 2>&1 | tail -2 || fallback`)
+masked the checkout's failure behind `tail`'s exit code, so a `git merge origin/main` ran on an
+already-merged branch (caught + reset, nothing pushed). The owner first asked whether a sync-to-main
+rule existed (it does — the orient / SessionStart freshness guard), then asked to turn the prevention
+into a hook — and made the **meta-point**: *catching these inconsistencies should not depend on the
+owner. The repo is built so agents think for themselves; anytime a session hits something that
+interrupts the workflow, it should itself produce a way to prevent it for the next session. Most of
+this already works (the session enders / reflection interview), but cases like this still slip by.*
+
+**The decision / directive.**
+1. **Build the wrong-branch guard (recommended advisory option).** Extend
+   `scripts/check_branch_freshness.py` (the existing Q-0138/Q-0188 PreToolUse(Bash)+Stop+SessionStart
+   hook) so PreToolUse also fires on `git commit`/`merge`/`rebase` with a **network-free** branch guard
+   (detached-HEAD / on-`main` / behind-`origin/main`) — advisory, never blocking, same Q-0105
+   kill-switch. `git push` keeps the authoritative network freshness check. (Built in-session under the
+   Q-0106 live-owner exception for executable config; no `.claude/settings.json` change needed — the
+   existing `Bash` matcher already routes to the script.)
+2. **Standing reflex — "friction → guard" (the systemic half).** Any time something interrupts a
+   session's workflow, the session must convert it into the **cheapest *enforcing* prevention** before
+   ending — **checker/CI/test → hook → journal Rule**, in that order ("enforce, don't exhort", Q-0132) —
+   not merely note it. Ownership split: docs/journal/test/checker guards are **free to ship now**; a
+   hook / `.claude/settings.json` / binding-`CLAUDE.md` rule is **owner-gated** (build if owner-directed
+   in-session, else propose a router DISCUSS Q).
+
+**Applied this session (in-session authority + free-to-edit):** extended `check_branch_freshness.py`
++ tests (Q-0106 exception; the hook provenance header carries this Q); added reflection-interview
+**question 7 (friction → guard)** to `.sessions/README.md`; added END-protocol **step 4b** + two
+**Cross-agent & git workflow** Rules (sync-fresh-before-PR-work; never mask a command's `$?` behind a
+pipe / confirm `git branch --show-current` after a checkout) to `.session-journal.md`.
+
+**▶ DISCUSS (owner, optional):** elevate the friction→guard reflex from the journal/README into the
+`.claude/CLAUDE.md` Working agreement as a one-line binding principle. Left as a proposal because
+CLAUDE.md content is propose-first (Q-0035) and the reflex is already operative via the session enders;
+the owner can promote it if he wants it binding rather than guidebook-level.
+
+**Home:** this Q-block (canonical) + `scripts/check_branch_freshness.py` header (the hook) +
+`.sessions/README.md` Q7 + `.session-journal.md` END step 4b & Rules (the operative reflex).

--- a/scripts/check_branch_freshness.py
+++ b/scripts/check_branch_freshness.py
@@ -11,10 +11,17 @@ Provenance / reliability header (per CLAUDE.md Q-0105 adopt-with-kill-switch):
   sessions before fully trusting it. **Delete this hook if it proves noisy/unreliable over
   multiple sessions** (remove the two settings.json entries + this file); it is a disposable
   convenience guard, not load-bearing.
+- Extended: 2026-06-22 (owner-directed in-session, Q-0194). The PreToolUse trigger now also
+  fires on ``git commit``/``merge``/``rebase`` with a **network-free** branch guard
+  (detached-HEAD / on-main / behind-origin-main), so a *wrong-branch* state is loud at the
+  dangerous moment — the slip that landed a ``git merge origin/main`` on an already-merged
+  branch when a piped ``git checkout``'s failure was masked. Same kill-switch as above.
 
 Trigger modes:
-- ``--event pretooluse`` (exit 0): wired on Bash. Reads the hook JSON on stdin; acts only when
-  the command is a ``git push``. The "about to ship" moment.
+- ``--event pretooluse`` (exit 0): wired on Bash. Reads the hook JSON on stdin. On ``git push``
+  it runs the authoritative network freshness check (the "about to ship" moment); on
+  ``git commit``/``merge``/``rebase`` it runs the cheap, network-free ``_branch_guard_line``
+  (wrong-branch / unsynced slip); any other command is a no-op (zero overhead).
 - ``--event stop`` (exit 0): wired on Stop. Ignores stdin; checks the current branch on every
   turn, so a branch that fell behind *after* its last push gets flagged next turn (the #857 case).
 - ``--event sessionstart`` (exit 1 when behind, else 0): called by ``claude_session_summary.py``
@@ -62,20 +69,79 @@ def _git(*args: str, timeout: int = 15) -> str:
         return ""
 
 
-def _is_git_push(stdin_text: str) -> bool:
-    """True if the PreToolUse payload is a ``git push`` Bash command."""
+# State-changing git ops the PreToolUse hook reacts to. ``push`` is the authoritative
+# "about to ship" moment (worth a network fetch); commit/merge/rebase get a cheap,
+# network-free branch guard (the wrong-branch / spent-branch slip).
+_STATE_CHANGING_OPS = ("commit", "merge", "rebase")
+
+
+def _state_changing_git_op(stdin_text: str) -> str | None:
+    """Return the state-changing git subcommand in a PreToolUse Bash payload, else None.
+
+    ``push`` wins over the others — a ``… && git push`` chain is the ship moment even when it
+    also commits — so it is checked across *all* segments first; otherwise the first
+    commit/merge/rebase segment is returned. Matches chained commands (``a && git merge``).
+    """
     try:
         payload = json.loads(stdin_text)
     except (ValueError, TypeError):
-        return False
+        return None
     if payload.get("tool_name") != "Bash":
-        return False
+        return None
     command = str(payload.get("tool_input", {}).get("command", ""))
-    # Match `git push` even when chained (`a && git push ...`) or flagged.
-    return any(
-        seg.strip().startswith("git push")
-        for seg in command.replace("&&", ";").replace("|", ";").split(";")
-    )
+    segs = [
+        seg.strip()
+        for seg in command.replace("&&", ";")
+        .replace("||", ";")
+        .replace("|", ";")
+        .split(";")
+    ]
+    if any(seg.startswith("git push") for seg in segs):
+        return "push"
+    for seg in segs:
+        for op in _STATE_CHANGING_OPS:
+            if seg.startswith(f"git {op}"):
+                return op
+    return None
+
+
+def _is_git_push(stdin_text: str) -> bool:
+    """True if the PreToolUse payload is (or chains) a ``git push`` Bash command."""
+    return _state_changing_git_op(stdin_text) == "push"
+
+
+def _branch_guard_line() -> str | None:
+    """Network-free guard surfaced before a ``git commit``/``merge``/``rebase``.
+
+    Catches the *wrong-branch* / *unsynced* slip — where a silently-failed
+    ``git checkout``/``switch`` leaves you on a spent or stale branch and the next
+    state-changing op lands on it (the 2026-06-22 incident: a ``git merge origin/main`` ran on
+    an already-merged branch because a piped checkout's failure was masked). Local refs only —
+    no fetch, so it never adds latency to the frequent commit path; ``git push`` keeps the
+    authoritative network freshness check.
+    """
+    branch = _git("rev-parse", "--abbrev-ref", "HEAD")
+    if not branch:
+        return None
+    if branch == "HEAD":
+        return (
+            "⚠️  state-changing git op in DETACHED HEAD — you are not on a branch (a prior "
+            "checkout/switch may have silently failed). Check out your intended branch and "
+            "confirm `git branch --show-current` before committing/merging."
+        )
+    if branch == "main":
+        return (
+            "⚠️  you are on `main` — branch first "
+            "(`git checkout -b <slug> origin/main`) before committing PR work."
+        )
+    behind = _git("rev-list", "--count", "HEAD..origin/main")  # local ref, no fetch
+    if behind and behind != "0":
+        return (
+            f"⎇  on '{branch}' — {behind} behind origin/main (local view). If this is not the "
+            "branch you meant to be on, or it is already merged, sync before PR work: "
+            "`git fetch origin main && git checkout -b <slug> origin/main`."
+        )
+    return None
 
 
 def _freshness_warning() -> str | None:
@@ -157,10 +223,17 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         if args.event == "pretooluse":
-            # Only the "about to push" case warrants the network round-trip.
             stdin_text = sys.stdin.read() if not sys.stdin.isatty() else ""
-            if not _is_git_push(stdin_text):
+            op = _state_changing_git_op(stdin_text)
+            if op is None:
+                return 0  # not a state-changing git op → zero overhead
+            if op != "push":
+                # commit/merge/rebase → cheap, network-free wrong-branch guard.
+                line = _branch_guard_line()
+                if line:
+                    print(line, file=sys.stderr)
                 return 0
+            # op == "push" → fall through to the authoritative network freshness check.
         warning = _freshness_warning()
         if warning:
             # stderr so it surfaces in the transcript without being parsed as tool output.

--- a/tests/unit/scripts/test_check_branch_freshness.py
+++ b/tests/unit/scripts/test_check_branch_freshness.py
@@ -36,6 +36,84 @@ def test_is_git_push_rejects_non_push_and_other_tools() -> None:
     assert cbf._is_git_push("not json") is False
 
 
+# --- _state_changing_git_op + _branch_guard_line ----------------------------------------
+
+
+def test_state_changing_git_op_classifies() -> None:
+    mk = lambda cmd: f'{{"tool_name":"Bash","tool_input":{{"command":"{cmd}"}}}}'
+    assert cbf._state_changing_git_op(mk("git push origin x")) == "push"
+    # push wins over a chained commit — it is the authoritative ship moment.
+    assert cbf._state_changing_git_op(mk("git add -A && git commit -m x && git push")) == "push"
+    assert cbf._state_changing_git_op(mk("git commit -m x")) == "commit"
+    assert cbf._state_changing_git_op(mk("git merge origin/main --no-edit")) == "merge"
+    assert cbf._state_changing_git_op(mk("git rebase origin/main")) == "rebase"
+    assert cbf._state_changing_git_op(mk("git status")) is None
+    assert cbf._state_changing_git_op(mk("git commit -m 'ready to push'")) == "commit"
+    assert cbf._state_changing_git_op("not json") is None
+
+
+def test_branch_guard_line_flags_detached_main_and_behind(monkeypatch) -> None:
+    # Detached HEAD → loud "you are not on a branch" (the masked-checkout slip).
+    monkeypatch.setattr(cbf, "_git", _fake_git({("rev-parse", "--abbrev-ref", "HEAD"): "HEAD"}))
+    assert "DETACHED HEAD" in (cbf._branch_guard_line() or "")
+    # On main → branch-first reminder.
+    monkeypatch.setattr(cbf, "_git", _fake_git({("rev-parse", "--abbrev-ref", "HEAD"): "main"}))
+    assert "on `main`" in (cbf._branch_guard_line() or "")
+    # Behind origin/main (local view) → wrong/stale-branch reminder, naming the branch.
+    monkeypatch.setattr(
+        cbf,
+        "_git",
+        _fake_git(
+            {
+                ("rev-parse", "--abbrev-ref", "HEAD"): "claude/spent-branch",
+                ("rev-list", "--count", "HEAD..origin/main"): "1",
+            }
+        ),
+    )
+    line = cbf._branch_guard_line() or ""
+    assert "claude/spent-branch" in line and "behind origin/main" in line
+    # In sync (0 behind) → silent.
+    monkeypatch.setattr(
+        cbf,
+        "_git",
+        _fake_git(
+            {
+                ("rev-parse", "--abbrev-ref", "HEAD"): "claude/fresh",
+                ("rev-list", "--count", "HEAD..origin/main"): "0",
+            }
+        ),
+    )
+    assert cbf._branch_guard_line() is None
+
+
+def test_branch_guard_line_does_no_network_fetch(monkeypatch) -> None:
+    # The commit/merge/rebase guard must never `git fetch` (latency on the hot commit path).
+    calls: list[tuple[str, ...]] = []
+
+    def _spy_git(*args: str, timeout: int = 15) -> str:
+        calls.append(args)
+        return {
+            ("rev-parse", "--abbrev-ref", "HEAD"): "claude/x",
+            ("rev-list", "--count", "HEAD..origin/main"): "0",
+        }.get(args, "")
+
+    monkeypatch.setattr(cbf, "_git", _spy_git)
+    cbf._branch_guard_line()
+    assert not any(a and a[0] == "fetch" for a in calls)
+
+
+def test_main_pretooluse_commit_runs_guard_not_freshness(monkeypatch, capsys) -> None:
+    # A `git commit` fires the cheap guard, never the network freshness check.
+    monkeypatch.setattr(cbf, "_freshness_warning", lambda: (_ for _ in ()).throw(AssertionError("network!")))
+    monkeypatch.setattr(cbf, "_branch_guard_line", lambda: "⎇ guard fired")
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(
+        sys.stdin, "read", lambda: '{"tool_name":"Bash","tool_input":{"command":"git commit -m x"}}'
+    )
+    assert cbf.main(["--event", "pretooluse"]) == 0
+    assert "guard fired" in capsys.readouterr().err
+
+
 # --- _freshness_warning -----------------------------------------------------------------
 
 


### PR DESCRIPTION
## Why

Owner-directed (Q-0194). After a wrong-branch slip this session, the owner asked for two things:
the concrete prevention as a hook, **and** — more importantly — for the repo's guides to make
agents *self-generate* these prevention fixes, so catching workflow inconsistencies doesn't depend
on the owner spotting them.

## Part A — the wrong-branch guard (the concrete fix)

Extends the existing advisory hook `scripts/check_branch_freshness.py`. Its PreToolUse(Bash) trigger
now also fires on **`git commit` / `merge` / `rebase`** with a **network-free** branch guard —
warns on **detached HEAD**, **on `main`**, or **behind `origin/main`** (local refs only → zero
latency on the frequent commit path; `git push` keeps the authoritative network freshness check).
Advisory, never blocking, same Q-0105 kill-switch. No `.claude/settings.json` change (the existing
`Bash` matcher already routes to the script). +4 tests; 11/11 green; black/ruff clean.

This catches the exact slip that prompted it: a piped `git checkout` (`… | tail -2 || fallback`)
masked the checkout's failed exit behind `tail`'s, so a `git merge origin/main` ran on an
already-merged branch.

## Part B — the systemic half (so the owner needn't spot these)

- **`.sessions/README.md`** — reflection-interview **question 7: "What interrupted your workflow —
  and did you ship a guard so the next session can't hit it?"** with a preference order
  (checker/CI/test → hook → journal Rule) and the free-vs-owner-gated split.
- **`.session-journal.md`** — END-protocol **step 4b (friction → guard reflex)** + two
  **Cross-agent & git workflow** Rules (sync-fresh-before-PR-work; never mask a command's `$?`
  behind a pipe / confirm `git branch --show-current` after a checkout).
- **`docs/owner/maintainer-question-router.md`** — **Q-0194** records the directive, with a DISCUSS
  item to optionally elevate the reflex into binding `CLAUDE.md`.

## Design note

Advisory, not blocking: a *fresh* branch also has an empty diff vs `main`, and squash-merges make
"already merged" undetectable from git alone — so a hard block would misfire. The reliable signal is
behind/detached/on-main, surfaced at the dangerous moment.

Full write-up: `.sessions/2026-06-22-friction-to-guard-reflex.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5YfrKwM49UaUNdgurdTh9)_