### PR TITLE
Mining grid: unify dig + move — each directional dig moves you into the cell

### DIFF
--- a/.sessions/2026-06-22-mining-dig-moves.md
+++ b/.sessions/2026-06-22-mining-dig-moves.md
@@ -1,0 +1,16 @@
+# 2026-06-22 — Mining grid: dig-moves-you (unified mine+move)
+
+> **Status:** `in-progress` — born-red session card (Q-0133). Flip to `complete` last.
+
+## Arc
+
+Owner design correction (in-chat, right after the grid Mine #1281 merged): *"each mining action
+would move you on the grid — mining down goes down one cell, mining forwards goes one cell forward,
+etc."* The shipped grid Mine had **separate** movement buttons + a "Mine here" button; the owner's
+actual intent is **unified directional digging** — every dig moves you one cell in that direction
+**and** mines the cell you move into.
+
+About to change: replace `mining_workflow.move` + `mine_here` with one `dig(direction)` (move into the
+adjacent cell + mine it, atomic); collapse the navigator's 6 move buttons + Mine-here into **6
+directional dig buttons**; update tests + docs. No command-surface change (buttons are ephemeral;
+`!mine`/`!fastmine`/`!mineworld` unchanged) → no artifact regen. Owner-directed → auto-merge on green.

--- a/.sessions/2026-06-22-mining-dig-moves.md
+++ b/.sessions/2026-06-22-mining-dig-moves.md
@@ -1,16 +1,102 @@
 # 2026-06-22 — Mining grid: dig-moves-you (unified mine+move)
 
-> **Status:** `in-progress` — born-red session card (Q-0133). Flip to `complete` last.
+> **Status:** `complete` — shipped; PR #1282 auto-merges on green.
 
 ## Arc
 
-Owner design correction (in-chat, right after the grid Mine #1281 merged): *"each mining action
+Owner design correction in-chat, right after the grid Mine (#1281) merged: *"each mining action
 would move you on the grid — mining down goes down one cell, mining forwards goes one cell forward,
-etc."* The shipped grid Mine had **separate** movement buttons + a "Mine here" button; the owner's
-actual intent is **unified directional digging** — every dig moves you one cell in that direction
-**and** mines the cell you move into.
+etc."* #1281 shipped **separate** movement buttons + a "Mine here" button (built to the
+hub-redesign plan's literal "6 movement buttons + Mine here" sketch). The owner's actual model is
+**unified directional digging**: mining *is* locomotion.
 
-About to change: replace `mining_workflow.move` + `mine_here` with one `dig(direction)` (move into the
-adjacent cell + mine it, atomic); collapse the navigator's 6 move buttons + Mine-here into **6
-directional dig buttons**; update tests + docs. No command-surface change (buttons are ephemeral;
-`!mine`/`!fastmine`/`!mineworld` unchanged) → no artifact regen. Owner-directed → auto-merge on green.
+Reworked it to that model and shipped PR #1282.
+
+## Shipped (PR #1282)
+
+- `mining_workflow.dig(direction)` **replaces** `move` + `mine_here`: resolve the adjacent cell
+  (`_resolve_dig_target` — Down light-gated via `world.descend`, Up ascends, lateral always), then
+  **move into it AND mine that cell** in ONE transaction (position/depth write + loot grant +
+  fog-of-war mark + wear + the down-dig depth-record bonus). `DigResult` replaces `MoveResult` and
+  carries the loot; `MineResult.cell_note` is removed (it existed only for the deleted `mine_here`).
+- `views/mining/grid_mine_view.py` — the six movement buttons + "Mine here" collapse into **six
+  directional dig buttons** (⛏️ North/South/East/West/Deeper/Up); each digs-and-moves, re-rendered
+  in place.
+- `grid.move_phrase(UP)` → "upward" (reads in "You dig upward and mine …").
+- Tests rewritten onto `dig`; the `mine` characterization test stays green (removing `cell_note`
+  left `!fastmine` byte-identical). Plan + games folio updated.
+- **No command-surface change** (`!mine`/`!fastmine`/`!mineworld` unchanged; buttons are ephemeral)
+  → no generated-artifact regen needed (freshness tests stayed green).
+
+## Decisions made alone (ratify if wrong)
+
+- **Every direction digs uniformly** — including Up (you dig upward into the shallower cell). Up is
+  never gated; Down is light-gated. Kept symmetric for simplicity.
+- **Cells are re-mineable** (infinite) — re-digging a cell yields again; the light/depth ladder is
+  the real gate, not depletion. (A "mined-out" depletion layer is noted as a possible future idea.)
+- **No pure-move** — there's no "reposition without mining"; mining is the only locomotion (the
+  owner's stated model). Reversible if they later want a separate move.
+
+## Context delta (reflection interview)
+
+- **Where orientation/plan fell short:** the hub-redesign plan listed the grid's *controls*
+  ("6 movement buttons + Mine here") but not the *interaction model* (does a button move, mine, or
+  both?). #1281 built to the literal control list; the owner meant mining-as-movement. The gap was
+  "buttons named, behaviour-per-button unstated."
+- **Discovered by hand:** `game_xp_service.award` returns `GameXpAward` (I'd guessed `XpAward`) —
+  caught by grep before mypy. Minor; no doc change warranted.
+- **Pointed to but didn't need:** nothing new — this was a contained edit of code I wrote last
+  session, so the file-level context maps were enough.
+
+## ⟲ Previous-session review (#1281 — grid Mine)
+
+- **Did well:** the pure/seam split (pure `grid.py`, audited `mining_workflow`, fog-of-war windowed
+  reads) made *this* rework cheap — swapping move+mine_here for one `dig` touched one workflow op +
+  one view, with the cell model and DB layer untouched. Good seams pay off immediately.
+- **Missed:** it shipped a movement model the owner didn't intend, because I built to the plan's
+  literal button list rather than confirming what each button *does*. The plan's "Proposed v1"
+  sketch even said "Mine here digs the current cell" — I should have flagged "move vs. mine-here is
+  an interaction-model assumption" as a thing to verify, not silently picked the literal reading.
+- **System improvement (the session idea below):** a planning convention — when a plan lists UI
+  controls, state the *behaviour per control against the model*, not just the label.
+
+## 🛠 Friction → guard
+
+- The genuine friction was **conceptual, not tooling** — a plan-ambiguity that produced a
+  build→rework cycle (#1281 → #1282). There's no cheap *enforcing* guard for "did you confirm the
+  interaction model?"; the prevention is the planning convention captured as the session idea. No
+  tooling guard shipped (inventing a checker for human design-intent would be the wrong tool).
+
+## 💡 Session idea
+
+- **Planning convention: a plan that lists UI controls must state the behaviour-per-control against
+  the model, not just the control label.** This session's #1281→#1282 rework happened purely because
+  the plan named "6 movement buttons + Mine here" without pinning whether a dig *moves* you. One line
+  per control ("Mine here = dig current cell, no move" vs "dig N = move north + mine") would have
+  surfaced the fork at plan time. Log-only capture (a convention nudge, not a checker) — promote to
+  a router DISCUSS Q if it recurs.
+
+## 📤 Run report
+
+- **Did:** reworked the grid Mine to the owner's unified model — every directional dig moves you
+  into the cell and mines it (replaced separate move + Mine-here). · **Outcome:** shipped (PR #1282,
+  auto-merge on green)
+- **Shipped:** #1282 — mining grid: dig-moves-you
+- **Run type:** `manual` (owner in-chat design correction)
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** none (merge auto-deploys). *Optional live check:* `!mine` → the six
+  dig buttons; each dig should move you one cell and yield that cell's loot.
+- **⚑ Self-initiated:** none — this was an owner-directed correction; no unprompted build/plan.
+- **↪ Next:** mining grid v2 = **depth-gated sparse encounters** (own session, owner-paced —
+  [idea](../docs/ideas/mining-grid-encounters-2026-06-22.md)); else the current-state ▶ Next action
+  queue.
+
+## 📊 Telemetry
+
+| Metric | Value |
+|---|---|
+| PRs merged this session | 0 at write (#1282 auto-merges on green) |
+| CI-red rounds | 0 real (born-red hold by design; full suite green locally before the completing push) |
+| Repo-rule trips | 0 (formatters clean; arch 0; the `GameXpAward` name caught by grep pre-mypy) |
+| New ideas contributed | 1 (planning convention: behaviour-per-control) |
+| Ideas groomed | 0 (contained owner-directed rework; no backlog move) |

--- a/disbot/services/mining_workflow.py
+++ b/disbot/services/mining_workflow.py
@@ -65,9 +65,6 @@ class MineResult:
     xp_note: str | None = None
     #: Gentle "pack full — stash at the vault" nudge (Slice A; never blocks).
     pack_warning: str | None = None
-    #: Grid-cell flavour ("struck a rich vein", "barren rock") — set only by
-    #: ``mine_here`` (PR 3); ``mine``/``!fastmine`` leave it None (byte-identical).
-    cell_note: str | None = None
 
 
 @dataclass(frozen=True)
@@ -105,21 +102,27 @@ class DescentResult:
 
 
 @dataclass(frozen=True)
-class MoveResult:
-    """One grid-Mine movement (PR 3): lateral N/S/E/W or vertical Up/Down.
+class DigResult:
+    """One directional dig (PR 3): move into the adjacent cell AND mine it.
 
-    Lateral moves always succeed; a vertical move can be blocked (no brighter
-    light to descend, already at the Surface to ascend) — ``moved`` is False and
-    ``hint`` explains why.  ``x``/``y`` are the lateral position; ``depth`` is z.
+    The owner's grid model (in-chat, post-#1281): every dig is locomotion — N/S/E/W
+    tunnel laterally, Down descends a band (light-gated), Up ascends one — and mines
+    the cell you move *into*.  A blocked vertical dig leaves ``moved`` False with a
+    ``hint`` and no loot (``found`` None).  ``x``/``y`` are the new lateral position;
+    ``depth`` is the new band (z).
     """
 
     moved: bool
     x: int
     y: int
     depth: int
-    note: str
+    found: str | None
+    amount: int
+    wear: WearReport
     hint: str | None = None
+    cell_note: str | None = None
     xp_note: str | None = None
+    pack_warning: str | None = None
 
 
 async def wear_tick(
@@ -826,59 +829,6 @@ async def mine(user_id: int, guild_id: int) -> MineResult:
     )
 
 
-async def mine_here(user_id: int, guild_id: int) -> MineResult:
-    """Mine the player's current grid cell (PR 3) — cell-aware loot + wear, atomic.
-
-    Like :func:`mine`, but the seed-deterministic cell at the player's
-    ``(pos_x, pos_y, depth)`` modulates the roll: its richness scales the amount
-    and a rich/treasure cell yields its featured ore (``utils.mining.grid``).
-    Marks the cell discovered (fog of war) in the same transaction as the loot
-    grant + wear, so a swing and what it revealed commit together.
-    """
-    suid = str(user_id)
-    inventory = await db.get_mining_inventory(suid, guild_id)
-    equipped = await db.get_equipment(suid, guild_id)
-    depth = await db.get_depth(suid, guild_id)
-    x, y = await db.get_position(suid, guild_id)
-    seed = await db.get_world_seed(guild_id)
-    cell = grid.cell_at(seed, x, y, depth)
-    found, amount = rewards.roll_mine_loot(
-        has_pickaxe=inventory.get("pickaxe", 0) > 0,
-        depth=depth,
-        multiplier=rewards.mine_multiplier(equipped, inventory),
-    )
-    found, amount, cell_note = grid.apply_cell_to_loot(cell, found, amount)
-    candidates = _wear_candidates(workshop.ACTION_MINE, depth, equipped)
-    wear = await db.get_gear_wear(suid, guild_id) if candidates else {}
-    async with db.transaction() as conn:
-        await db.update_mining_item(suid, guild_id, found, amount, conn=conn)
-        await db.mark_discovered(suid, guild_id, depth, x, y, conn=conn)
-        report = (
-            await _apply_wear_writes(conn, suid, guild_id, candidates, wear)
-            if candidates
-            else WearReport()
-        )
-        xp = await game_xp_service.award(
-            guild_id,
-            user_id,
-            game=game_xp_service.GAME_MINING,
-            action="mine",
-            depth=depth,
-            conn=conn,
-        )
-    if xp is not None:
-        await game_xp_service.emit_award_events(xp)
-    return MineResult(
-        found=found,
-        amount=amount,
-        depth=depth,
-        wear=report,
-        xp_note=xp.note if xp is not None and xp.leveled_up else None,
-        pack_warning=_pack_warning_after(inventory, found),
-        cell_note=cell_note,
-    )
-
-
 async def harvest(user_id: int, guild_id: int) -> HarvestResult:
     """Chop wood (doubled with an axe in the inventory) and grant it."""
     suid = str(user_id)
@@ -1044,103 +994,154 @@ async def ascend(user_id: int, guild_id: int) -> DescentResult:
 
 
 # ---------------------------------------------------------------------------
-# Grid — roam the (x, y, z) world (PR 3); writes mark fog-of-war discovery
+# Grid — dig the (x, y, z) world (PR 3): every dig moves you AND mines the cell
 # ---------------------------------------------------------------------------
 
 
-async def move(user_id: int, guild_id: int, direction: str) -> MoveResult:
-    """Move one cell in the grid (PR 3) — lateral N/S/E/W or vertical Up/Down.
+def _resolve_dig_target(
+    direction: str,
+    x: int,
+    y: int,
+    depth: int,
+    stats: equipment.EffectiveStats,
+) -> tuple[int, int, int] | DigResult:
+    """The cell a *direction* dig moves into — or a blocked :class:`DigResult`.
 
-    Lateral moves change ``(pos_x, pos_y)`` within the current depth band and
-    always succeed.  ``Down`` descends one band (gated by the equipped light — the
-    :func:`descend` rule) and ``Up`` ascends one.  Every successful move marks the
-    cells it touches discovered (fog of war) in one transaction; a depth move that
-    sets a new record also awards the depth-record XP (the :func:`descend`
-    precedent).
+    Lateral digs always resolve to an adjacent cell; ``Down`` is light-gated
+    (the :func:`descend` rule) and ``Up`` stops at the Surface; an unknown token
+    is a no-op.  Pure: it decides the destination, the caller does the I/O.
+    """
+    if direction in grid.LATERAL:
+        nx, ny = grid.step(x, y, direction)
+        return nx, ny, depth
+    if direction == grid.DOWN:
+        new_depth = world.descend(depth, stats)
+        if new_depth == depth:
+            return DigResult(
+                moved=False,
+                x=x,
+                y=y,
+                depth=depth,
+                found=None,
+                amount=0,
+                wear=WearReport(),
+                hint=world.descend_hint(stats),
+            )
+        return x, y, new_depth
+    if direction == grid.UP:
+        new_depth = world.ascend(depth)
+        if new_depth == depth:
+            return DigResult(
+                moved=False,
+                x=x,
+                y=y,
+                depth=depth,
+                found=None,
+                amount=0,
+                wear=WearReport(),
+                hint="You're already at the Surface — nowhere up to dig.",
+            )
+        return x, y, new_depth
+    return DigResult(
+        moved=False,
+        x=x,
+        y=y,
+        depth=depth,
+        found=None,
+        amount=0,
+        wear=WearReport(),
+        hint=f"Unknown direction: {direction}.",
+    )
+
+
+async def dig(user_id: int, guild_id: int, direction: str) -> DigResult:
+    """Dig one cell in *direction* — move into it AND mine it (PR 3, owner model).
+
+    The owner's grid model (post-#1281): mining *is* locomotion.  N/S/E/W tunnel
+    laterally; ``Down`` descends a band (gated by the equipped light — the
+    :func:`descend` rule); ``Up`` ascends one.  The player moves into the adjacent
+    cell and mines **that** cell — its seed-deterministic content (richness +
+    featured ore, depth-weighted) drives the loot.  The move, the loot grant, the
+    fog-of-war mark, and the wear tick all commit in ONE transaction; a down-dig
+    that reaches a new deepest band also awards the depth-record XP (the
+    :func:`descend` precedent).  A blocked vertical dig returns ``moved=False`` with
+    a hint and no loot.
     """
     suid = str(user_id)
     direction = direction.strip().lower()
     x, y = await db.get_position(suid, guild_id)
     depth = await db.get_depth(suid, guild_id)
+    equipped = await db.get_equipment(suid, guild_id)
+    # Gear + allocated skill points gate Down (byte-identical to gear-only when
+    # nothing is allocated — the additive safety property, as in descend()).
+    alloc = await db.get_skills(user_id, guild_id)
+    stats = character.character_stats(equipped, alloc)
 
-    if direction in grid.LATERAL:
-        nx, ny = grid.step(x, y, direction)
-        async with db.transaction() as conn:
+    target = _resolve_dig_target(direction, x, y, depth, stats)
+    if isinstance(target, DigResult):
+        return target  # blocked / unknown — no move, no loot
+    nx, ny, nz = target
+
+    inventory = await db.get_mining_inventory(suid, guild_id)
+    seed = await db.get_world_seed(guild_id)
+    cell = grid.cell_at(seed, nx, ny, nz)
+    found, amount = rewards.roll_mine_loot(
+        has_pickaxe=inventory.get("pickaxe", 0) > 0,
+        depth=nz,
+        multiplier=rewards.mine_multiplier(equipped, inventory),
+    )
+    found, amount, cell_note = grid.apply_cell_to_loot(cell, found, amount)
+    candidates = _wear_candidates(workshop.ACTION_MINE, nz, equipped)
+    wear = await db.get_gear_wear(suid, guild_id) if candidates else {}
+
+    awards: list[game_xp_service.GameXpAward] = []
+    descended = direction == grid.DOWN
+    async with db.transaction() as conn:
+        if direction in grid.LATERAL:
             await db.set_position(suid, guild_id, nx, ny, conn=conn)
-            await db.mark_discovered(suid, guild_id, depth, x, y, conn=conn)
-            await db.mark_discovered(suid, guild_id, depth, nx, ny, conn=conn)
-        return MoveResult(
-            moved=True,
-            x=nx,
-            y=ny,
-            depth=depth,
-            note=f"You head {grid.move_phrase(direction)}.",
+        else:
+            await db.set_depth(suid, guild_id, nz, conn=conn)
+        await db.update_mining_item(suid, guild_id, found, amount, conn=conn)
+        await db.mark_discovered(suid, guild_id, nz, nx, ny, conn=conn)
+        report = (
+            await _apply_wear_writes(conn, suid, guild_id, candidates, wear)
+            if candidates
+            else WearReport()
         )
-
-    if direction == grid.DOWN:
-        equipped = await db.get_equipment(suid, guild_id)
-        alloc = await db.get_skills(user_id, guild_id)
-        stats = character.character_stats(equipped, alloc)
-        new_depth = world.descend(depth, stats)
-        if new_depth == depth:
-            return MoveResult(
-                moved=False,
-                x=x,
-                y=y,
-                depth=depth,
-                note="You can't dig any deeper here.",
-                hint=world.descend_hint(stats),
+        if descended and await db.record_depth(suid, guild_id, nz, conn=conn):
+            record = await game_xp_service.award(
+                guild_id,
+                user_id,
+                game=game_xp_service.GAME_MINING,
+                action="depth_record",
+                conn=conn,
             )
-        xp = None
-        async with db.transaction() as conn:
-            await db.set_depth(suid, guild_id, new_depth, conn=conn)
-            await db.mark_discovered(suid, guild_id, new_depth, x, y, conn=conn)
-            if await db.record_depth(suid, guild_id, new_depth, conn=conn):
-                xp = await game_xp_service.award(
-                    guild_id,
-                    user_id,
-                    game=game_xp_service.GAME_MINING,
-                    action="depth_record",
-                    conn=conn,
-                )
-        if xp is not None:
-            await game_xp_service.emit_award_events(xp)
-        return MoveResult(
-            moved=True,
-            x=x,
-            y=y,
-            depth=new_depth,
-            note=f"You climb down to {world.describe_position(new_depth)}.",
-            xp_note=xp.note if xp is not None and xp.leveled_up else None,
+            if record is not None:
+                awards.append(record)
+        mined = await game_xp_service.award(
+            guild_id,
+            user_id,
+            game=game_xp_service.GAME_MINING,
+            action="mine",
+            depth=nz,
+            conn=conn,
         )
-
-    if direction == grid.UP:
-        new_depth = world.ascend(depth)
-        if new_depth == depth:
-            return MoveResult(
-                moved=False,
-                x=x,
-                y=y,
-                depth=depth,
-                note="You're already at the Surface.",
-            )
-        async with db.transaction() as conn:
-            await db.set_depth(suid, guild_id, new_depth, conn=conn)
-            await db.mark_discovered(suid, guild_id, new_depth, x, y, conn=conn)
-        return MoveResult(
-            moved=True,
-            x=x,
-            y=y,
-            depth=new_depth,
-            note=f"You climb up to {world.describe_position(new_depth)}.",
-        )
-
-    return MoveResult(
-        moved=False,
-        x=x,
-        y=y,
-        depth=depth,
-        note=f"Unknown direction: {direction}.",
+        if mined is not None:
+            awards.append(mined)
+    for award in awards:
+        await game_xp_service.emit_award_events(award)
+    xp_note = next((a.note for a in awards if a.leveled_up), None)
+    return DigResult(
+        moved=True,
+        x=nx,
+        y=ny,
+        depth=nz,
+        found=found,
+        amount=amount,
+        wear=report,
+        cell_note=cell_note,
+        xp_note=xp_note,
+        pack_warning=_pack_warning_after(inventory, found),
     )
 
 
@@ -1196,7 +1197,7 @@ __all__ = [
     "HarvestResult",
     "ExploreActionResult",
     "DescentResult",
-    "MoveResult",
+    "DigResult",
     "wear_tick",
     "repair",
     "craft",
@@ -1210,7 +1211,6 @@ __all__ = [
     "vault_upgrade",
     "build_structure",
     "mine",
-    "mine_here",
     "harvest",
     "explore",
     "use_item",
@@ -1218,7 +1218,7 @@ __all__ = [
     "unequip",
     "descend",
     "ascend",
-    "move",
+    "dig",
     "reseed_world",
     "admin_grant",
     "admin_reset",

--- a/disbot/utils/mining/grid.py
+++ b/disbot/utils/mining/grid.py
@@ -59,7 +59,7 @@ _MOVE_PHRASE: dict[str, str] = {
     SOUTH: "south",
     EAST: "east",
     WEST: "west",
-    UP: "up toward the surface",
+    UP: "upward",
     DOWN: "deeper",
 }
 

--- a/disbot/views/mining/grid_mine_view.py
+++ b/disbot/views/mining/grid_mine_view.py
@@ -68,17 +68,19 @@ async def build_grid_embed(
         inline=False,
     )
     embed.set_footer(
-        text="Move with the arrows · ⛏️ Mine here digs your cell · only you can use this.",
+        text="Each ⛏️ dig moves you one cell and mines it · only you can use this.",
     )
     return embed
 
 
 class MineGridView(BaseView):
-    """The grid Mine navigator (PR 3): roam (x, y, z) + Mine here, in place.
+    """The grid Mine navigator (PR 3): dig the (x, y, z) world, in place.
 
-    Ownership / timeout / error handling come from BaseView.  Each button routes
-    to ``mining_workflow`` (the RS02 write seam) and re-renders this same view on
-    the anchor message.
+    Owner model (post-#1281): every dig is locomotion — a directional dig moves you
+    into the adjacent cell and mines it (N/S/E/W tunnel laterally, Deeper descends a
+    band, Up ascends).  Ownership / timeout / error handling come from BaseView; each
+    button routes to ``mining_workflow.dig`` (the RS02 write seam) and re-renders this
+    same view on the anchor message.
     """
 
     def __init__(
@@ -105,93 +107,87 @@ class MineGridView(BaseView):
         )
         await safe_edit(interaction, embed=embed, view=self)
 
-    async def _do_move(
+    async def _dig(
         self,
         interaction: discord.Interaction,
         direction: str,
     ) -> None:
+        """Dig in *direction* — move into the adjacent cell and mine it, in place."""
         if not await safe_defer(interaction):
             return
-        result = await mining_workflow.move(self.user_id, self.guild_id, direction)
-        note = result.note
-        if not result.moved and result.hint:
-            note = f"{result.note} _{result.hint}_"
-        if result.xp_note:
-            note += "\n" + result.xp_note
-        color = MINING_COLOR if result.moved else ERROR_COLOR
+        result = await mining_workflow.dig(self.user_id, self.guild_id, direction)
+        if not result.moved:
+            note = result.hint or "You can't dig that way."
+            color = ERROR_COLOR
+        else:
+            parts = [
+                f"You dig **{grid.move_phrase(direction)}** and mine "
+                f"**{result.amount}× {result.found}**!",
+            ]
+            if result.cell_note:
+                parts.append(result.cell_note)
+            if result.wear.notes:
+                parts.extend(result.wear.notes)
+            if result.xp_note:
+                parts.append(result.xp_note)
+            if result.pack_warning:
+                parts.append(result.pack_warning)
+            note = "\n".join(parts)
+            color = SUCCESS_COLOR
         await self._rerender(interaction, note=note, color=color)
 
-    # --- lateral movement (D-pad: N top, W / Mine / E middle, S bottom) -----
+    # --- directional digging (D-pad: N top, W / E middle, S bottom) ---------
+    # Every dig moves you one cell in that direction AND mines it (owner model).
 
-    @discord.ui.button(label="⬆️ North", style=discord.ButtonStyle.secondary, row=0)
+    @discord.ui.button(label="⛏️ North", style=discord.ButtonStyle.primary, row=0)
     async def north_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        await self._do_move(interaction, grid.NORTH)
+        await self._dig(interaction, grid.NORTH)
 
-    @discord.ui.button(label="⬅️ West", style=discord.ButtonStyle.secondary, row=1)
+    @discord.ui.button(label="⛏️ West", style=discord.ButtonStyle.primary, row=1)
     async def west_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        await self._do_move(interaction, grid.WEST)
+        await self._dig(interaction, grid.WEST)
 
-    @discord.ui.button(label="⛏️ Mine here", style=discord.ButtonStyle.primary, row=1)
-    async def mine_here_btn(
-        self,
-        interaction: discord.Interaction,
-        _: discord.ui.Button,
-    ) -> None:
-        if not await safe_defer(interaction):
-            return
-        result = await mining_workflow.mine_here(self.user_id, self.guild_id)
-        parts = [f"You mined **{result.amount}× {result.found}**!"]
-        if result.cell_note:
-            parts.append(result.cell_note)
-        if result.wear.notes:
-            parts.extend(result.wear.notes)
-        if result.xp_note:
-            parts.append(result.xp_note)
-        if result.pack_warning:
-            parts.append(result.pack_warning)
-        await self._rerender(interaction, note="\n".join(parts), color=SUCCESS_COLOR)
-
-    @discord.ui.button(label="➡️ East", style=discord.ButtonStyle.secondary, row=1)
+    @discord.ui.button(label="⛏️ East", style=discord.ButtonStyle.primary, row=1)
     async def east_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        await self._do_move(interaction, grid.EAST)
+        await self._dig(interaction, grid.EAST)
 
-    @discord.ui.button(label="⬇️ South", style=discord.ButtonStyle.secondary, row=2)
+    @discord.ui.button(label="⛏️ South", style=discord.ButtonStyle.primary, row=2)
     async def south_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        await self._do_move(interaction, grid.SOUTH)
+        await self._dig(interaction, grid.SOUTH)
 
-    # --- vertical movement (depth band = z) ---------------------------------
+    # --- vertical digging (depth band = z; Deeper is light-gated) ------------
 
-    @discord.ui.button(label="🔽 Down", style=discord.ButtonStyle.success, row=3)
+    @discord.ui.button(label="⛏️ Deeper", style=discord.ButtonStyle.success, row=3)
     async def down_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        await self._do_move(interaction, grid.DOWN)
+        await self._dig(interaction, grid.DOWN)
 
-    @discord.ui.button(label="🔼 Up", style=discord.ButtonStyle.success, row=3)
+    @discord.ui.button(label="⛏️ Up", style=discord.ButtonStyle.success, row=3)
     async def up_btn(
         self,
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        await self._do_move(interaction, grid.UP)
+        await self._dig(interaction, grid.UP)
 
     # --- navigation ---------------------------------------------------------
 

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,6 +25,10 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
+- `claude/upbeat-clarke-73fm43` · **mining grid: dig-moves-you** (owner design correction, in-chat) —
+  unify movement + Mine-here into one directional `dig(direction)` so every dig moves you one cell and
+  mines it (the owner's actual grid intent) · `services/mining_workflow.py` + `utils/mining/grid.py` +
+  `views/mining/grid_mine_view.py` + tests · 2026-06-22 · **PR (this session, auto-merge on green)**
 - `claude/friction-to-guard-reflex` · **wrong-branch guard hook + friction→guard reflex**
   (owner-directed, Q-0194) — extend `check_branch_freshness.py` PreToolUse to warn on
   commit/merge/rebase from a wrong/stale branch + institutionalize the "any friction → ship a

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -25,10 +25,6 @@ living ledger (`docs/current-state.md`).
 
 ## Active claims
 
-- `claude/upbeat-clarke-73fm43` · **mining grid: dig-moves-you** (owner design correction, in-chat) —
-  unify movement + Mine-here into one directional `dig(direction)` so every dig moves you one cell and
-  mines it (the owner's actual grid intent) · `services/mining_workflow.py` + `utils/mining/grid.py` +
-  `views/mining/grid_mine_view.py` + tests · 2026-06-22 · **PR (this session, auto-merge on green)**
 - `claude/friction-to-guard-reflex` · **wrong-branch guard hook + friction→guard reflex**
   (owner-directed, Q-0194) — extend `check_branch_freshness.py` PreToolUse to warn on
   commit/merge/rebase from a wrong/stale branch + institutionalize the "any friction → ship a
@@ -45,6 +41,10 @@ and `claude/funny-franklin-mjvqrx` (PR #1272) — all pruned here. Merged work l
 
 ## Recently cleared
 
+- `claude/upbeat-clarke-73fm43` · **mining grid: dig-moves-you** (owner design correction, in-chat) —
+  unified movement + Mine-here into one directional `dig(direction)` (each dig moves you one cell and
+  mines it) · `mining_workflow.dig` + `grid_mine_view` six dig buttons · 2026-06-22 ·
+  **PR #1282 (auto-merge on green)**
 - `claude/upbeat-clarke-73fm43` · **mining grid Mine (hub-redesign PR 3)** (owner-directed —
   "continue the mining plan") — (x,y,z) seed-deterministic grid + 6-direction movement + fog-of-war,
   replacing the interim linear `MineView` (Q-0173) · `utils/mining/grid.py` + migration 085 +

--- a/docs/planning/mining-hub-redesign-2026-06-15.md
+++ b/docs/planning/mining-hub-redesign-2026-06-15.md
@@ -42,6 +42,10 @@ The Mine action gains **6 movement buttons** so the player roams and discovers a
 this **replaces** the old linear Descend/Ascend.
 
 - Movement: `⬆️ North` · `⬇️ South` · `⬅️ West` · `➡️ East` · `🔼 Up` · `🔽 Down` + `⛏️ Mine here`.
+  **Refined post-build (owner, in-chat 2026-06-22): mining IS movement** — there is no separate
+  move vs. Mine-here; each *directional dig* moves you one cell into it and mines it (dig down →
+  descend a cell, dig north → tunnel north). The six buttons are directional digs; "Mine here" is
+  dropped. Shipped that way in the PR-3 follow-up below.
 - **Proposed v1 (awaiting owner confirm):** a finite grid per depth level — N/S/E/W roam the
   current level (each cell rolls its own resource odds + occasional event/treasure, revealed on
   visit = light fog-of-war); Up/Down change depth (old `0–3` becomes the z-axis, still gated by
@@ -81,16 +85,17 @@ this **replaces** the old linear Descend/Ascend.
    sub-hub (it personalizes the Character card; the plan list predated #910); (b) the main hub's
    new 🗺️ Explore (open-world stub, `custom_id mining:explore_hub`) is a *different concept*
    from the depth-event explore that folded into Mine — routing documented in PR #1131.
-3. **PR 3 — grid Mine** ✅ **SHIPPED (2026-06-22)**: the (x,y,z) world model + 6-direction
-   movement + fog-of-war discovery, built exactly to the Q-0173 sign-off. Pure
-   `utils/mining/grid.py` (seed-deterministic `cell_at` + lateral movement + map render);
-   migration 085 (`pos_x`/`pos_y` on `mining_player_state` [z = the existing `depth`] +
-   `mining_world` per-guild seed + `mining_discovered` fog of war);
-   `utils/db/games/mining_grid.py` on the RS02 boundary ratchet; `mining_workflow.move` /
-   `mine_here` / `reseed_world` (one transaction each); `views/mining/grid_mine_view.py`
-   (`MineGridView`) replacing the interim linear `MineView`; `!mine` opens it + `!mineworld`
-   shows/reseeds the shared seed. **v1 is encounter-free** (owner: encounters are a separate
-   later session — captured below).
+3. **PR 3 — grid Mine** ✅ **SHIPPED (#1281, 2026-06-22)**: the (x,y,z) seed-deterministic world +
+   fog-of-war discovery. Pure `utils/mining/grid.py` (`cell_at` + map render); migration 085
+   (`pos_x`/`pos_y` on `mining_player_state` [z = the existing `depth`] + `mining_world` per-guild
+   seed + `mining_discovered` fog of war); `utils/db/games/mining_grid.py` on the RS02 boundary
+   ratchet; `views/mining/grid_mine_view.py` (`MineGridView`) replacing the interim linear
+   `MineView`; `!mine` opens it + `!mineworld` shows/reseeds the shared seed. **v1 is
+   encounter-free** (owner: encounters are a separate later session — captured below).
+   - **PR 3 follow-up — dig IS movement** ✅ **SHIPPED (2026-06-22, owner correction)**: replaced the
+     separate move + `Mine here` with one `mining_workflow.dig(direction)` — each directional dig moves
+     you into the adjacent cell **and** mines it (the navigator is six directional dig buttons, no
+     Mine-here). Atomic move + loot + fog-mark + wear + the down-dig depth-record bonus.
 4. **Later — encounters** (owner-wanted, own session): depth-gated, *sparse* random encounters
    on top of the grid (the owner's shape — "after a certain depth you can get random
    encounters, but not too many"). Captured in

--- a/docs/subsystems/games.md
+++ b/docs/subsystems/games.md
@@ -188,15 +188,18 @@ on **Q-0182**.
   🧍 Character · 🧰 Gear · 🔨 Workshop); a **Character** sub-hub (`views/mining/character_hub.py`)
   groups Overview/Inventory/Stats/Skills/Vault/Home and an **Explore** stub sub-hub
   (`views/mining/explore_hub.py`) previews the open-world explorer (Fishing/Roam/Quests — early).
-  **PR3 (grid Mine) shipped (2026-06-22):** the Mine action is now a (x, y, z) grid navigator
-  (`views/mining/grid_mine_view.py` `MineGridView`) — six movement buttons + Mine here over a
-  **seed-deterministic procedural world** (pure `utils/mining/grid.py`; z = the existing depth band, so
-  `utils/mining/world.py` balance carries over), with **per-guild shareable seed** + **fog-of-war
-  discovery** (migration 085: `pos_x`/`pos_y` + `mining_world` + `mining_discovered`;
-  `utils/db/games/mining_grid.py` + `mining_workflow.move`/`mine_here`/`reseed_world` on the RS02 seam).
-  `!mine` opens it; `!mineworld` shows/reseeds the shared seed. It **replaced** the interim linear
-  `MineView`. v1 is **encounter-free** (owner Q-0173: encounters are a deferred later session →
+  **PR3 (grid Mine) shipped (2026-06-22, #1281):** the Mine action is now a (x, y, z) grid navigator
+  (`views/mining/grid_mine_view.py` `MineGridView`) over a **seed-deterministic procedural world**
+  (pure `utils/mining/grid.py`; z = the existing depth band, so `utils/mining/world.py` balance carries
+  over), with **per-guild shareable seed** + **fog-of-war discovery** (migration 085: `pos_x`/`pos_y` +
+  `mining_world` + `mining_discovered`; `utils/db/games/mining_grid.py` on the RS02 seam). `!mine` opens
+  it; `!mineworld` shows/reseeds the shared seed. It **replaced** the interim linear `MineView`. v1 is
+  **encounter-free** (owner Q-0173: encounters are a deferred later session →
   [`../ideas/mining-grid-encounters-2026-06-22.md`](../ideas/mining-grid-encounters-2026-06-22.md)).
+  **Dig IS movement (owner correction, 2026-06-22):** the navigator is **six directional dig buttons**
+  — each dig moves you into the adjacent cell **and** mines it (`mining_workflow.dig(direction)`, one
+  transaction: move + loot + fog-mark + wear + the down-dig depth-record bonus); no separate move /
+  "Mine here".
 - [games-economy-faucet-sink-diagnostic-plan](../planning/games-economy-faucet-sink-diagnostic-plan-2026-06-15.md) —
   read-only economy faucet/sink read model (turn-key).
 - *Shipped → `historical`:* [mining-structures-skill-tree-plan](../planning/mining-structures-skill-tree-plan-2026-06-14.md)

--- a/tests/unit/services/test_mining_grid_workflow.py
+++ b/tests/unit/services/test_mining_grid_workflow.py
@@ -1,8 +1,9 @@
-"""mining_workflow grid ops (PR 3) — move / mine_here / reseed_world.
+"""mining_workflow grid op (PR 3) — the unified ``dig`` (move + mine) + reseed_world.
 
-Pins the workflow seam: every successful move marks fog-of-war discovery, a
-blocked vertical move reports the light-gate hint, and ``mine_here`` folds the
-seed-deterministic cell into the loot.  DB writes are mocked; the no-op
+Owner model (post-#1281): every dig is locomotion — it moves you into the adjacent
+cell AND mines that cell.  Pins: lateral digs move + mine the destination, a blocked
+vertical dig reports the light-gate hint with no loot, a down-dig records the depth,
+and a rich cell's featured ore carries through.  DB writes are mocked; the no-op
 transaction mirrors test_mining_workflow_characterization.
 """
 
@@ -15,6 +16,23 @@ import pytest
 
 from services import mining_workflow
 from utils.mining import grid
+
+# Reads every dig path needs up front (position, depth, gear, skills); loot paths
+# additionally read inventory + the world seed.  Per-test overrides layer on top.
+_BASE_READS = dict(
+    get_position=lambda: AsyncMock(return_value=(0, 0)),
+    get_depth=lambda: AsyncMock(return_value=0),
+    get_equipment=lambda: AsyncMock(return_value={}),
+    get_skills=lambda: AsyncMock(return_value={}),
+    get_mining_inventory=lambda: AsyncMock(return_value={}),
+    get_world_seed=lambda: AsyncMock(return_value=123),
+)
+
+
+def _reads(**overrides: object) -> dict[str, object]:
+    base = {name: factory() for name, factory in _BASE_READS.items()}
+    base.update(overrides)
+    return base
 
 
 @pytest.fixture(autouse=True)
@@ -40,157 +58,154 @@ def _null_txn_and_xp():
 
 
 # ---------------------------------------------------------------------------
-# move — lateral
+# dig — lateral (move + mine the destination)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_move_lateral_updates_position_and_marks_both_cells():
+async def test_dig_lateral_moves_into_cell_and_mines_it():
     set_position = AsyncMock()
-    mark_discovered = AsyncMock()
-    with patch.multiple(
-        "services.mining_workflow.db",
-        get_position=AsyncMock(return_value=(0, 0)),
-        get_depth=AsyncMock(return_value=1),
-        set_position=set_position,
-        mark_discovered=mark_discovered,
-    ):
-        result = await mining_workflow.move(7, 99, grid.NORTH)
-
-    assert result.moved is True
-    assert (result.x, result.y, result.depth) == (0, 1, 1)
-    set_position.assert_awaited_once()
-    # Both the origin and the destination are revealed (look-back fog fix).
-    assert mark_discovered.await_count == 2
-
-
-@pytest.mark.asyncio
-async def test_move_unknown_direction_does_not_move():
-    set_position = AsyncMock()
-    with patch.multiple(
-        "services.mining_workflow.db",
-        get_position=AsyncMock(return_value=(2, 3)),
-        get_depth=AsyncMock(return_value=0),
-        set_position=set_position,
-        mark_discovered=AsyncMock(),
-    ):
-        result = await mining_workflow.move(7, 99, "sideways")
-    assert result.moved is False
-    set_position.assert_not_awaited()
-
-
-# ---------------------------------------------------------------------------
-# move — vertical (depth band)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_move_down_blocked_without_light_reports_hint():
-    # Empty gear + no skills ⇒ depth_access 0 ⇒ world.descend stays put.
-    set_depth = AsyncMock()
-    with patch.multiple(
-        "services.mining_workflow.db",
-        get_position=AsyncMock(return_value=(0, 0)),
-        get_depth=AsyncMock(return_value=0),
-        get_equipment=AsyncMock(return_value={}),
-        get_skills=AsyncMock(return_value={}),
-        set_depth=set_depth,
-        mark_discovered=AsyncMock(),
-    ):
-        result = await mining_workflow.move(7, 99, grid.DOWN)
-    assert result.moved is False
-    assert result.hint is not None
-    set_depth.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_move_down_with_light_descends_and_marks_cell():
-    set_depth = AsyncMock()
-    mark_discovered = AsyncMock()
-    with (
-        patch.multiple(
-            "services.mining_workflow.db",
-            get_position=AsyncMock(return_value=(1, 1)),
-            get_depth=AsyncMock(return_value=0),
-            get_equipment=AsyncMock(return_value={}),
-            get_skills=AsyncMock(return_value={}),
-            set_depth=set_depth,
-            record_depth=AsyncMock(return_value=False),
-            mark_discovered=mark_discovered,
-        ),
-        patch(
-            "services.mining_workflow.world.descend",
-            return_value=1,
-        ),
-    ):
-        result = await mining_workflow.move(7, 99, grid.DOWN)
-    assert result.moved is True
-    assert result.depth == 1
-    set_depth.assert_awaited_once_with("7", 99, 1, conn=ANY)
-    mark_discovered.assert_awaited_once_with("7", 99, 1, 1, 1, conn=ANY)
-
-
-@pytest.mark.asyncio
-async def test_move_up_at_surface_does_not_move():
-    set_depth = AsyncMock()
-    with patch.multiple(
-        "services.mining_workflow.db",
-        get_position=AsyncMock(return_value=(0, 0)),
-        get_depth=AsyncMock(return_value=0),
-        set_depth=set_depth,
-        mark_discovered=AsyncMock(),
-    ):
-        result = await mining_workflow.move(7, 99, grid.UP)
-    assert result.moved is False
-    set_depth.assert_not_awaited()
-
-
-# ---------------------------------------------------------------------------
-# mine_here
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_mine_here_grants_loot_and_marks_current_cell():
     update_mining_item = AsyncMock()
     mark_discovered = AsyncMock()
     with patch.multiple(
         "services.mining_workflow.db",
-        get_mining_inventory=AsyncMock(return_value={}),
-        get_equipment=AsyncMock(return_value={}),
-        get_depth=AsyncMock(return_value=0),
-        get_position=AsyncMock(return_value=(0, 0)),
-        get_world_seed=AsyncMock(return_value=123),
-        update_mining_item=update_mining_item,
-        mark_discovered=mark_discovered,
+        **_reads(
+            set_position=set_position,
+            update_mining_item=update_mining_item,
+            mark_discovered=mark_discovered,
+        ),
     ):
-        result = await mining_workflow.mine_here(5, 42)
+        result = await mining_workflow.dig(7, 99, grid.NORTH)
 
-    assert isinstance(result, mining_workflow.MineResult)
-    assert result.amount >= 1
+    assert result.moved is True
+    assert (result.x, result.y, result.depth) == (0, 1, 0)  # North = +y
+    assert result.found is not None and result.amount >= 1
+    set_position.assert_awaited_once_with("7", 99, 0, 1, conn=ANY)
     update_mining_item.assert_awaited_once()
-    mark_discovered.assert_awaited_once_with("5", 42, 0, 0, 0, conn=ANY)
+    # Discovery is marked on the DESTINATION cell.
+    mark_discovered.assert_awaited_once_with("7", 99, 0, 0, 1, conn=ANY)
 
 
 @pytest.mark.asyncio
-async def test_mine_here_rich_cell_sets_a_cell_note():
-    # Force a RICH cell so the flavour note is deterministic.
-    rich = grid.Cell(0, 0, 0, grid.CellFeature.RICH, "gold", 2.0)
+async def test_dig_unknown_direction_does_nothing():
+    set_position = AsyncMock()
+    update_mining_item = AsyncMock()
+    with patch.multiple(
+        "services.mining_workflow.db",
+        **_reads(
+            get_position=AsyncMock(return_value=(2, 3)),
+            set_position=set_position,
+            update_mining_item=update_mining_item,
+            mark_discovered=AsyncMock(),
+        ),
+    ):
+        result = await mining_workflow.dig(7, 99, "sideways")
+
+    assert result.moved is False
+    assert result.found is None and result.amount == 0
+    set_position.assert_not_awaited()
+    update_mining_item.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# dig — vertical (depth band)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dig_down_blocked_without_light_reports_hint_and_no_loot():
+    # Empty gear + no skills ⇒ depth_access 0 ⇒ world.descend stays put.
+    set_depth = AsyncMock()
+    update_mining_item = AsyncMock()
+    with patch.multiple(
+        "services.mining_workflow.db",
+        **_reads(
+            set_depth=set_depth,
+            update_mining_item=update_mining_item,
+            mark_discovered=AsyncMock(),
+        ),
+    ):
+        result = await mining_workflow.dig(7, 99, grid.DOWN)
+
+    assert result.moved is False
+    assert result.hint is not None
+    assert result.found is None
+    set_depth.assert_not_awaited()
+    update_mining_item.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dig_down_with_light_descends_mines_and_records_depth():
+    set_depth = AsyncMock()
+    update_mining_item = AsyncMock()
+    mark_discovered = AsyncMock()
+    record_depth = AsyncMock(return_value=True)
     with (
         patch.multiple(
             "services.mining_workflow.db",
-            get_mining_inventory=AsyncMock(return_value={}),
-            get_equipment=AsyncMock(return_value={}),
-            get_depth=AsyncMock(return_value=0),
-            get_position=AsyncMock(return_value=(0, 0)),
-            get_world_seed=AsyncMock(return_value=123),
-            update_mining_item=AsyncMock(),
+            **_reads(
+                get_position=AsyncMock(return_value=(1, 1)),
+                set_depth=set_depth,
+                update_mining_item=update_mining_item,
+                mark_discovered=mark_discovered,
+                record_depth=record_depth,
+            ),
+        ),
+        patch("services.mining_workflow.world.descend", return_value=1),
+    ):
+        result = await mining_workflow.dig(7, 99, grid.DOWN)
+
+    assert result.moved is True
+    assert result.depth == 1
+    assert result.found is not None
+    set_depth.assert_awaited_once_with("7", 99, 1, conn=ANY)
+    # Mines + reveals the destination cell at the NEW depth.
+    mark_discovered.assert_awaited_once_with("7", 99, 1, 1, 1, conn=ANY)
+    update_mining_item.assert_awaited_once()
+    record_depth.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dig_up_at_surface_does_nothing():
+    set_depth = AsyncMock()
+    update_mining_item = AsyncMock()
+    with patch.multiple(
+        "services.mining_workflow.db",
+        **_reads(
+            set_depth=set_depth,
+            update_mining_item=update_mining_item,
             mark_discovered=AsyncMock(),
+        ),
+    ):
+        result = await mining_workflow.dig(7, 99, grid.UP)
+
+    assert result.moved is False
+    set_depth.assert_not_awaited()
+    update_mining_item.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# dig — cell content carries through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dig_rich_cell_features_its_ore_and_sets_a_note():
+    rich = grid.Cell(0, 1, 0, grid.CellFeature.RICH, "gold", 2.0)
+    with (
+        patch.multiple(
+            "services.mining_workflow.db",
+            **_reads(
+                set_position=AsyncMock(),
+                update_mining_item=AsyncMock(),
+                mark_discovered=AsyncMock(),
+            ),
         ),
         patch("services.mining_workflow.grid.cell_at", return_value=rich),
     ):
-        result = await mining_workflow.mine_here(5, 42)
-    assert result.found == "gold"
+        result = await mining_workflow.dig(7, 99, grid.NORTH)
+
+    assert result.found == "gold"  # the rich vein's featured ore
     assert result.cell_note is not None
 
 

--- a/tests/unit/views/test_mining_grid_view.py
+++ b/tests/unit/views/test_mining_grid_view.py
@@ -1,11 +1,12 @@
-"""Grid Mine navigator view (hub-redesign PR 3).
+"""Grid Mine navigator view (hub-redesign PR 3) — dig-moves-you model.
 
-Replaces the old MineView descent/navigation tests (the linear Descend/Ascend view
-was removed).  Pins:
+Owner model (post-#1281): every dig is locomotion — a directional dig moves you into
+the adjacent cell and mines it.  Pins:
 
-- the navigator's button surface (six movement buttons + Mine here + nav);
+- the navigator's button surface (six directional dig buttons + nav, no Mine-here);
 - ``build_grid_embed`` renders position / depth / seed / map;
-- movement and Mine here route through ``mining_workflow`` and re-render in place;
+- a dig routes through ``mining_workflow.dig`` and re-renders in place with the loot;
+- a blocked dig surfaces the hint;
 - Mining Menu returns to the hub; Help dispatches (with a fallback).
 """
 
@@ -38,11 +39,13 @@ def _find_button(view: discord.ui.View, label_substr: str) -> discord.ui.Button:
 # ---------------------------------------------------------------------------
 
 
-def test_view_carries_six_movement_buttons_plus_mine_here_and_nav():
+def test_view_carries_six_directional_dig_buttons_plus_nav():
     view = MineGridView(MagicMock(id=1), guild_id=2)
     labels = " | ".join(b.label or "" for b in _buttons(view))
-    for token in ("North", "South", "East", "West", "Up", "Down", "Mine here"):
-        assert token in labels, f"missing {token!r} button"
+    for token in ("North", "South", "East", "West", "Deeper", "Up"):
+        assert token in labels, f"missing {token!r} dig button"
+    # The separate "Mine here" button is gone — digging IS moving now.
+    assert "Mine here" not in labels
     assert "Mining Menu" in labels
     assert "Help" in labels
 
@@ -56,9 +59,11 @@ def test_view_locks_to_invoking_user():
 def test_dpad_layout_rows():
     view = MineGridView(MagicMock(id=1), guild_id=2)
     assert _find_button(view, "North").row == 0
-    assert _find_button(view, "Mine here").row == 1
+    assert _find_button(view, "West").row == 1
+    assert _find_button(view, "East").row == 1
     assert _find_button(view, "South").row == 2
-    assert _find_button(view, "Down").row == 3
+    assert _find_button(view, "Deeper").row == 3
+    assert _find_button(view, "Up").row == 3
 
 
 # ---------------------------------------------------------------------------
@@ -86,22 +91,24 @@ async def test_build_grid_embed_shows_position_depth_seed_and_map():
 
 
 # ---------------------------------------------------------------------------
-# Movement routing
+# Dig routing
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_north_button_routes_through_workflow_and_rerenders():
+async def test_north_dig_routes_through_workflow_and_rerenders():
     view = MineGridView(MagicMock(id=1), guild_id=2)
     btn = _find_button(view, "North")
     interaction = MagicMock()
 
-    move_result = mining_workflow.MoveResult(
+    dig_result = mining_workflow.DigResult(
         moved=True,
         x=0,
         y=1,
         depth=0,
-        note="You head north.",
+        found="stone",
+        amount=2,
+        wear=WearReport(),
     )
     with (
         patch(
@@ -110,15 +117,15 @@ async def test_north_button_routes_through_workflow_and_rerenders():
             return_value=True,
         ),
         patch(
-            "views.mining.grid_mine_view.mining_workflow.move",
+            "views.mining.grid_mine_view.mining_workflow.dig",
             new_callable=AsyncMock,
-            return_value=move_result,
-        ) as move,
+            return_value=dig_result,
+        ) as dig,
         patch(
             "views.mining.grid_mine_view.build_grid_embed",
             new_callable=AsyncMock,
             return_value=discord.Embed(title="map"),
-        ),
+        ) as build,
         patch(
             "views.mining.grid_mine_view.safe_edit",
             new_callable=AsyncMock,
@@ -127,24 +134,29 @@ async def test_north_button_routes_through_workflow_and_rerenders():
     ):
         await btn.callback(interaction)
 
-    move.assert_awaited_once_with(1, 2, grid.NORTH)
+    dig.assert_awaited_once_with(1, 2, grid.NORTH)
+    note = build.await_args.kwargs["note"]
+    assert "2× stone" in note
+    assert "north" in note
     edit.assert_awaited_once()
     assert edit.await_args.kwargs["view"] is view  # re-renders in place
 
 
 @pytest.mark.asyncio
-async def test_blocked_move_surfaces_hint_in_the_note():
+async def test_deeper_dig_routes_down_and_shows_cell_note():
     view = MineGridView(MagicMock(id=1), guild_id=2)
-    btn = _find_button(view, "Down")
+    btn = _find_button(view, "Deeper")
     interaction = MagicMock()
 
-    blocked = mining_workflow.MoveResult(
-        moved=False,
+    dig_result = mining_workflow.DigResult(
+        moved=True,
         x=0,
         y=0,
-        depth=0,
-        note="You can't dig any deeper here.",
-        hint="Equip a brighter light.",
+        depth=1,
+        found="gold",
+        amount=4,
+        wear=WearReport(),
+        cell_note="💎 You struck a rich gold vein!",
     )
     with (
         patch(
@@ -153,7 +165,54 @@ async def test_blocked_move_surfaces_hint_in_the_note():
             return_value=True,
         ),
         patch(
-            "views.mining.grid_mine_view.mining_workflow.move",
+            "views.mining.grid_mine_view.mining_workflow.dig",
+            new_callable=AsyncMock,
+            return_value=dig_result,
+        ) as dig,
+        patch(
+            "views.mining.grid_mine_view.build_grid_embed",
+            new_callable=AsyncMock,
+            return_value=discord.Embed(title="map"),
+        ) as build,
+        patch(
+            "views.mining.grid_mine_view.safe_edit",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
+        await btn.callback(interaction)
+
+    dig.assert_awaited_once_with(1, 2, grid.DOWN)
+    note = build.await_args.kwargs["note"]
+    assert "deeper" in note
+    assert "4× gold" in note
+    assert "rich gold vein" in note
+
+
+@pytest.mark.asyncio
+async def test_blocked_dig_surfaces_the_hint():
+    view = MineGridView(MagicMock(id=1), guild_id=2)
+    btn = _find_button(view, "Deeper")
+    interaction = MagicMock()
+
+    blocked = mining_workflow.DigResult(
+        moved=False,
+        x=0,
+        y=0,
+        depth=0,
+        found=None,
+        amount=0,
+        wear=WearReport(),
+        hint="Equip a brighter light to descend.",
+    )
+    with (
+        patch(
+            "views.mining.grid_mine_view.safe_defer",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "views.mining.grid_mine_view.mining_workflow.dig",
             new_callable=AsyncMock,
             return_value=blocked,
         ),
@@ -172,54 +231,6 @@ async def test_blocked_move_surfaces_hint_in_the_note():
 
     note = build.await_args.kwargs["note"]
     assert "brighter light" in note
-
-
-# ---------------------------------------------------------------------------
-# Mine here routing
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_mine_here_button_grants_loot_and_shows_cell_note():
-    view = MineGridView(MagicMock(id=1), guild_id=2)
-    btn = _find_button(view, "Mine here")
-    interaction = MagicMock()
-
-    result = mining_workflow.MineResult(
-        found="gold",
-        amount=4,
-        depth=0,
-        wear=WearReport(),
-        cell_note="💎 You struck a rich gold vein!",
-    )
-    with (
-        patch(
-            "views.mining.grid_mine_view.safe_defer",
-            new_callable=AsyncMock,
-            return_value=True,
-        ),
-        patch(
-            "views.mining.grid_mine_view.mining_workflow.mine_here",
-            new_callable=AsyncMock,
-            return_value=result,
-        ) as mine_here,
-        patch(
-            "views.mining.grid_mine_view.build_grid_embed",
-            new_callable=AsyncMock,
-            return_value=discord.Embed(title="map"),
-        ) as build,
-        patch(
-            "views.mining.grid_mine_view.safe_edit",
-            new_callable=AsyncMock,
-            return_value=True,
-        ),
-    ):
-        await btn.callback(interaction)
-
-    mine_here.assert_awaited_once_with(1, 2)
-    note = build.await_args.kwargs["note"]
-    assert "gold" in note
-    assert "rich gold vein" in note
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Owner design correction (in-chat, right after the grid Mine #1281 merged): *"each mining action
would move you on the grid — mining down goes down one cell, mining forwards goes one cell forward,
etc."*

The shipped grid Mine had **separate** movement buttons + a "Mine here" button. This unifies them
into the owner's actual model: **every dig is directional and moves you into that cell while mining
it.** Mine down → descend a cell; mine north → tunnel north; etc.

## Change

- `mining_workflow.dig(direction)` **replaces** `move` + `mine_here`: resolve the adjacent cell
  (Down is light-gated, Up ascends), then **move into it and mine it** in ONE transaction (position
  write + loot grant + fog-of-war mark + wear + XP, incl. the deepest-record bonus on a down-dig).
- `views/mining/grid_mine_view.py`: the 6 movement buttons + Mine-here collapse into **6 directional
  dig buttons** (⛏️ North/South/East/West/Deeper/Up); each digs-and-moves, re-rendered in place.
- `utils/mining/grid.py`: `move_phrase(UP)` → "upward" (reads naturally in "You dig upward …").
- Tests rewritten onto `dig`; docs (hub-redesign plan + games folio) updated.

No command-surface change (the buttons are ephemeral; `!mine`/`!fastmine`/`!mineworld` unchanged) →
no generated-artifact regen.

## Status

🔴 Born-red (Q-0133); flips to `complete` last. Owner-directed → auto-merge on green (Q-0191).
Reversible: if the separate move/mine model tests better, it's a clean revert of #1281's successor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BdrTSdKyEV4UKuxsTJmMxv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdrTSdKyEV4UKuxsTJmMxv)_