### PR TITLE
Mining economy/balance simulation — find a fun, balanced reward configuration

### DIFF
--- a/.sessions/2026-06-22-mining-economy-sim.md
+++ b/.sessions/2026-06-22-mining-economy-sim.md
@@ -1,7 +1,7 @@
 # 2026-06-22 — Mining economy / balance simulation
 
-> **Status:** `in-progress` — building a Monte-Carlo balance sim for the mining game.
-> Born-red card (Q-0133); flipped to `complete` as the deliberate final step.
+> **Status:** `complete` — mining balance sim built + run; recommendation pinned.
+> Owner-directed (in-chat), so auto-merges on green (Q-0191; no review gate). PR #1284.
 
 ## Arc (what I'm about to do)
 
@@ -23,3 +23,83 @@ frequency) is.
   per dig, per session, over time; sweep candidate configs against fun/balance targets.
 - Run it, find the most balanced config, write the numbers into a `docs/planning/` record.
 - Light smoke/invariant test mirroring `test_creature_battle_sim.py`.
+
+## Shipped (PR #1284)
+
+- **`tools/game_sim/mining_economy_sim.py`** — stdlib, deterministic Monte-Carlo simulator of the
+  mining *faucet*. Models one dig (`randint(1,base) × tool_mult × cell_richness × ore_value`,
+  depth-weighted) across four player profiles (newcomer → veteran), measures coins/active-hour against
+  the gated economy benchmark (`!daily` ≈ 1,692/24h), and **sweeps 144 candidate configs** (cooldown ×
+  base roll × tool curve × feature mix) for the lowest-penalty balanced config. Prints a PASS/WARN
+  verdict + the recommended config + a progression curve + concrete deltas vs the live game.
+- **`tests/unit/tools/test_mining_economy_sim.py`** — 11 tests: **parity** (the sim's mirrored
+  constants match the live `utils/mining/{items,rewards,grid}` + `equipment` source — drift guard),
+  diagnosis (current faucet is over-target), sweep finds a balanced config, determinism, main runs.
+- **`docs/planning/mining-economy-balance-2026-06-22.md`** — the sim-pinned design record (diagnosis
+  table, recommended config, balance targets, the energy-vs-cooldown frequency decision, and the
+  when-approved implementation map). Linked from `docs/subsystems/games.md`.
+
+## Findings
+
+- **The owner is right, and the imbalance is large.** Live faucet pays a *fully-geared veteran a full
+  `!daily` (~1,700 coins) in ~1 active minute*; even a fresh newcomer earns one every ~9 min — mining
+  is **7–55× the gated economy's hourly rate**. There is **no cooldown / energy / rate limit** at all,
+  and **25% of cells are lucky strikes** → "too large AND too frequent" quantitatively confirmed.
+- **Recommended config** (penalty 0.00, all profiles ~1–2.7 dailies/active-hr, geared/fresh gap 8.2× →
+  2.7%): a ~10s-equivalent **frequency brake** + base roll `1-3 → 1-2` + flatter tool curve
+  `×1/2/3/4/5 → ×1/1.2/1.3/1.4/1.5` + bonanza `25% → 12%` (treasure richness `×3 → ×2`). Ore values +
+  depth weighting held fixed (gear-coupled).
+- **One owner decision surfaced:** *how* to brake frequency — a per-dig cooldown (trivial to ship) vs
+  an energy/stamina budget (better feel: burst-explore then tap out). The doc recommends energy and
+  gives the equivalent throttle. **No runtime change in this PR** — it's design input to approve.
+
+## ⚑ Self-initiated: none
+
+Owner-directed in-chat ("create/run a simulation that finds the most balanced way for the mining
+game"). Design-only (`tools/` + docs + a test) — no `disbot/` runtime edit, so no review gate
+(Q-0191). The eventual rebalance edit is a separate, owner-approved PR.
+
+## 💡 Session idea (Q-0089)
+
+**A `tools/game_sim/` README + a shared faucet/economy harness.** There are now two design sims
+(`creature_battle_sim`, `mining_economy_sim`) that independently re-derive the *same* economy
+benchmark (`!daily` ≈ 1,692, `!work` ≈ 60/hr) and the same "dailies-per-active-hour" balance lens.
+A small shared `tools/game_sim/economy_benchmark.py` (the gated-faucet constants, with a parity test
+to `economy_helpers.py`) + a one-screen README indexing the sims would stop that benchmark drifting
+per-sim and make "is game X's faucet in line with the rest of the economy?" a one-import question for
+the next game's sim (pets, fishing, idle). Worth it because every future game faces the same
+"is the reward balanced against the economy?" question this session just answered ad-hoc.
+
+## ⟲ Previous-session review (Q-0102)
+
+**Previous session:** `2026-06-22-mining-grid-mine.md` (grid Mine, PR #1281/#1282). **Did well:** kept
+the *balance* in the pure `utils/mining/world.py`/`grid.py` layer so "z = the existing depth band,
+balance carries over unchanged" — which is exactly why this faucet was cleanly simulatable from pure
+functions without a DB/Discord harness. **Missed / could improve:** it shipped a brand-new, more
+*engaging* mine loop (unlimited directional digging, a bonanza every 4th cell) **without re-checking
+the faucet math** — engagement went up but the reward rate (already uncapped) got *easier to farm*,
+which is what prompted the owner's "too large & too frequent." **System improvement it surfaces:** a
+new or reworked **earning** loop should ship with a one-line faucet sanity-check (coins/active-hour vs
+`!daily`) — the same reflex as "new mutation → audit seam." The `mining_economy_sim` + the shared
+benchmark idea above is the tooling that makes that reflex cheap; longer-term it could be a
+lightweight "economy-impact" note in the games pre-PR skill.
+
+## Context delta (reflection interview)
+
+- **Needed but not pointed to:** the **economy benchmark** for "balanced" — `!daily`/`!work` payout
+  tables live in `services/economy_helpers.py` (`_DAILY_TIERS`, `JOBS`), not in the games folio or any
+  mining doc. A "what does a coin/hour *mean*?" pointer (the gated-faucet baseline) belongs in the
+  games folio's economy section; this session reverse-engineered it. (The session-idea harness fixes
+  this durably.)
+- **Pointed to but didn't need:** CodeGraph / the symbol tools — the faucet is a handful of pure
+  functions; `context_map` + targeted reads + one Explore fan-out was the whole job.
+- **Discovered by hand:** the ore **sell** values (stone 1 … diamond 12) are *not* a sell table — they
+  are the `RESOURCE` `value` field in `utils/mining/items.py`, surfaced via `market.sell_price` →
+  `item_value`. Only documented in a `rewards.py` comment. The parity test now pins it.
+- **Decisions made alone:** the four player profiles, the 2.5s active cadence, and the balance-target
+  bands (1k–5k coins/hr ≈ 0.6–3 dailies/hr; ratio ≤ 3.5×; bonanza 8–16%). These define "balanced" and
+  the owner should sanity-check them against his intent — they're stated in the doc's targets section.
+- **Flagged for maintainer / known limits:** the absolute coins/hour depends on the *estimated* 2.5s
+  cadence — confirm against a live play session before treating the numbers as final (the *relative*
+  7–55× finding is robust). And the **frequency-brake mechanic is an open choice** (energy vs
+  cooldown) — the recommendation is a design input, applied in a separate owner-approved PR.

--- a/.sessions/2026-06-22-mining-economy-sim.md
+++ b/.sessions/2026-06-22-mining-economy-sim.md
@@ -1,0 +1,25 @@
+# 2026-06-22 — Mining economy / balance simulation
+
+> **Status:** `in-progress` — building a Monte-Carlo balance sim for the mining game.
+> Born-red card (Q-0133); flipped to `complete` as the deliberate final step.
+
+## Arc (what I'm about to do)
+
+Owner-directed in-chat: the mining grid's first real grid Mine is now live (#1281/#1282), and
+the owner feels **rewards may be too large and too frequent**. He recalled that a prior session
+introduced the idea of *running a simulation to find a balanced configuration*. Task: create and
+run a balance simulation for the mining game so it stays **fun and playable for everyone**, and
+surface a recommended, balanced configuration of the tunables (reward size / frequency / grid
+descent), following the existing `tools/game_sim/` design-sim precedent
+(`creature_battle_sim.py` — stdlib, deterministic, PASS/WARN verdict, config-as-data).
+
+Depth (currently capped at 3) is explicitly *not* the priority — the faucet (reward magnitude +
+frequency) is.
+
+## Plan
+
+- Map the real mining reward + grid mechanics (rewards, drop rates, depth, costs, XP).
+- Build `tools/game_sim/mining_economy_sim.py` — Monte-Carlo a player's session(s): coins/XP
+  per dig, per session, over time; sweep candidate configs against fun/balance targets.
+- Run it, find the most balanced config, write the numbers into a `docs/planning/` record.
+- Light smoke/invariant test mirroring `test_creature_battle_sim.py`.

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -30,11 +30,6 @@ living ledger (`docs/current-state.md`).
   commit/merge/rebase from a wrong/stale branch + institutionalize the "any friction → ship a
   guard" session-ender · `scripts/check_branch_freshness.py` + tests / `.sessions/README.md` /
   `.session-journal.md` / router · 2026-06-22 · **PR (this session, auto-merge on green)**
-- `claude/sweet-sagan-jeyjsy` · **mining economy/balance simulation** (owner-directed, in-chat —
-  "run a simulation to find a balanced way to configure the mining game"; rewards feel too large/frequent) —
-  stdlib Monte-Carlo design sim modelling dig rewards + grid descent, sweeps configs for a fun/balanced
-  faucet · `tools/game_sim/mining_economy_sim.py` (+ config json) / tests / `docs/planning/` record ·
-  2026-06-22 · **PR (this session, auto-merge on green)**
 
 *(2026-06-22 prune, Q-0166 drift-on-sight: the `claude/funny-franklin-h6cjlg` curl-allow claim
 (PR #1274) merged to `main` — pruned here; merged work is in `current-state.md`.)*
@@ -46,6 +41,11 @@ and `claude/funny-franklin-mjvqrx` (PR #1272) — all pruned here. Merged work l
 
 ## Recently cleared
 
+- `claude/sweet-sagan-jeyjsy` · **mining economy/balance simulation** (owner-directed, in-chat —
+  "run a simulation to find a balanced way to configure the mining game") — stdlib Monte-Carlo design
+  sim quantifying the live faucet (7–55× a `!daily`/hr) + a 144-config sweep for a balanced config ·
+  `tools/game_sim/mining_economy_sim.py` + test + `docs/planning/mining-economy-balance-2026-06-22.md` ·
+  2026-06-22 · **PR #1284 (auto-merge on green)**
 - `claude/upbeat-clarke-73fm43` · **mining grid: dig-moves-you** (owner design correction, in-chat) —
   unified movement + Mine-here into one directional `dig(direction)` (each dig moves you one cell and
   mines it) · `mining_workflow.dig` + `grid_mine_view` six dig buttons · 2026-06-22 ·

--- a/docs/owner/active-work.md
+++ b/docs/owner/active-work.md
@@ -30,6 +30,11 @@ living ledger (`docs/current-state.md`).
   commit/merge/rebase from a wrong/stale branch + institutionalize the "any friction → ship a
   guard" session-ender · `scripts/check_branch_freshness.py` + tests / `.sessions/README.md` /
   `.session-journal.md` / router · 2026-06-22 · **PR (this session, auto-merge on green)**
+- `claude/sweet-sagan-jeyjsy` · **mining economy/balance simulation** (owner-directed, in-chat —
+  "run a simulation to find a balanced way to configure the mining game"; rewards feel too large/frequent) —
+  stdlib Monte-Carlo design sim modelling dig rewards + grid descent, sweeps configs for a fun/balanced
+  faucet · `tools/game_sim/mining_economy_sim.py` (+ config json) / tests / `docs/planning/` record ·
+  2026-06-22 · **PR (this session, auto-merge on green)**
 
 *(2026-06-22 prune, Q-0166 drift-on-sight: the `claude/funny-franklin-h6cjlg` curl-allow claim
 (PR #1274) merged to `main` — pruned here; merged work is in `current-state.md`.)*

--- a/docs/planning/mining-economy-balance-2026-06-22.md
+++ b/docs/planning/mining-economy-balance-2026-06-22.md
@@ -1,0 +1,153 @@
+# Mining economy balance — sim-pinned numbers (2026-06-22)
+
+> **Status:** `plan` — design record; numbers produced by a simulation, for the owner
+> to approve before any runtime change. Not binding; source + merged PRs win.
+> Sibling of [`gear-set-numbers-2026-06-11.md`](gear-set-numbers-2026-06-11.md)
+> (the "simulation-sane numbers" discipline) and the creature-game sim record.
+
+## Why this exists
+
+The mining grid's first real grid-`Mine` is live (#1281/#1282). The owner's read:
+**rewards are too large and too frequent**, and he asked for *a simulation that
+finds a balanced way to configure the game so it stays fun and playable for
+everyone.* This record pins the simulator's diagnosis and its recommended
+configuration.
+
+Tool: **`tools/game_sim/mining_economy_sim.py`** (stdlib, deterministic,
+`--seed`). Run it to reproduce every number here:
+
+```
+python3.10 tools/game_sim/mining_economy_sim.py
+```
+
+Depth (the band cap at 3) is **not** the focus — the *faucet* (reward magnitude
++ frequency) is, exactly as the owner framed it.
+
+## How the faucet works today (the model)
+
+One dig yields `(ore, amount)` where
+
+```
+amount = randint(1, 3) * tool_multiplier * cell_richness
+coins  = amount * ore_value(depth-weighted draw)
+```
+
+- tool multiplier ×1/×2/×3/×4/×5 for none / pickaxe / iron / gold / diamond
+  (`rewards.mine_multiplier` = `1 + mining_power // 2`),
+- cell richness 1.0 / 2.0 / 0.5 / 3.0 for NORMAL / RICH / BARREN / TREASURE, with
+  feature weights 60 / 20 / 15 / 5 → **25% of cells are a "lucky strike"**
+  (`utils/mining/grid.py`),
+- ore sells for 1 / 2 / 3 / 4 / 6 / 12 (stone…diamond), and deeper bands draw
+  richer ore (`rewards.ore_weights_for_depth`),
+- **there is no cooldown, no energy, and no rate limit on digging** — the faucet
+  is throttled only by how fast a human can click.
+
+**Benchmark — the rest of the economy is gated.** `!daily` pays a weighted
+500–5000 once / 24h (mean ≈ **1,692 coins**); `!work` pays ~60 coins once / hour
+(`services/economy_helpers.py`). So a casual player earns on the order of
+**~1,700 coins/day** from the gated faucets.
+
+## Diagnosis — the owner is right, and by a lot
+
+At a realistic active cadence (one dig ≈ every 2.5s through the button UI), the
+**current** faucet pays (sim, seed 42):
+
+| profile | coins/dig | coins/active-hour | = dailies/hr |
+|---|---|---|---|
+| Newcomer (no tool, surface) | ~7.8 | ~11,300 | **6.7×** |
+| Casual (pickaxe, cavern) | ~18.9 | ~27,300 | **16×** |
+| Regular (iron pick, deep) | ~34 | ~49,000 | **29×** |
+| Veteran (diamond pick, magma) | ~64 | ~92,000 | **54×** |
+
+- **Too large:** a *fully-geared veteran earns a full `!daily` (~1,700) in ~1
+  active minute*; even a fresh newcomer earns one every ~9 minutes. Mining
+  dwarfs the entire gated economy.
+- **Too frequent:** no cooldown means earnings are bounded only by clicking
+  speed, and **lucky strikes fire on 25% of cells** — a bonanza every fourth dig
+  doesn't feel special.
+- **Not playable-for-everyone:** the geared/fresh gap is **8.2×**, so gear
+  progression runs away from new players.
+
+## Recommended configuration (lowest-penalty sweep result)
+
+The sim sweeps 144 candidate configs (cooldown × base roll × tool curve ×
+feature mix) and scores each against the balance targets below. The winner:
+
+| knob | live | **recommended** |
+|---|---|---|
+| **dig frequency brake** | none | **~10s** equivalent throttle (≈ 360 digs/active-hr) |
+| base roll | `randint(1, 3)` | `randint(1, 2)` |
+| tool multiplier curve | ×1 / 2 / 3 / 4 / 5 | **×1 / 1.2 / 1.3 / 1.4 / 1.5** |
+| cell feature weights | 60 / 20 / 15 / 5 (25% bonanza) | **70 / 10 / 18 / 2 (12% bonanza)** |
+| treasure richness | ×3.0 | **×2.0** |
+| ore values & depth weighting | — | **unchanged** (gear-coupled; do not touch) |
+
+Resulting faucet (sim, seed 42):
+
+| profile | coins/active-hour | = dailies/hr |
+|---|---|---|
+| Newcomer | ~1,675 | **1.0×** |
+| Casual | ~2,280 | 1.3× |
+| Regular | ~3,330 | 2.0× |
+| Veteran | ~4,540 | 2.7× |
+
+geared/fresh ratio **2.7×** (was 8.2×). Progression stays satisfying: a newcomer
+affords their first pickaxe (25c) in ~1 active min, an iron pickaxe (60c) in ~2,
+and the diamond pickaxe (320c) is a ~12-min goal — a real arc, not instant and
+not a slog.
+
+### Balance targets (the operational definition of "fun & playable for everyone")
+
+- every player profile earns **~1,000–5,000 coins / active hour** (≈ 0.6–3
+  dailies/hr) — clearly worth doing, but not trivializing the gated economy;
+- the maxed-veteran : absolute-newcomer hourly ratio stays **≤ 3.5×** (the
+  structural floor is depth-richness ≈1.7× × the tool-curve gap, so this is the
+  tightest a tool-curve change alone reaches);
+- **lucky strikes fire on 8–16% of cells** — special, not constant.
+
+## The one design decision for the owner: how to brake frequency
+
+The sim models the frequency brake as a **per-dig cooldown** because it is the
+single cleanest knob, but a flat 10s lockout between digs can feel sluggish in a
+grid navigator where *dig = move*. Two equivalent ways to deliver the same
+~360-digs-per-active-hour throttle, better-feeling:
+
+1. **Energy / stamina budget** (recommended feel) — e.g. a pool of digs that
+   refills over time (≈ 6 digs/min, cap ~120). Lets a player **burst-explore**
+   the grid, then taps out for a while. Caps the faucet without making every
+   action wait. (New mechanic — a small `mining_energy` column + a refill clock.)
+2. **Per-dig cooldown** — simplest to ship (reuse `utils/cooldowns.py`, as
+   `!daily`/`!work` already do); the number above is the cooldown value.
+
+Magnitude changes (base roll, tool curve, feature mix) are **independent of**
+the frequency choice and are pure-constant edits — see below.
+
+## Implementation map (when approved — not done in this PR)
+
+All magnitude knobs are constants in the pure mining domain:
+
+- base roll `randint(1, 3)` → `randint(1, 2)`: `utils/mining/rewards.py`
+  (`roll_mine_loot`, and mirror in `roll_harvest_amount` if harvest is retuned too).
+- tool curve: `rewards.mine_multiplier` (currently `1 + mining_power // 2`) — or
+  retune the `mining_power` values in `utils/equipment.py`.
+- feature weights + treasure richness: `_FEATURE_WEIGHTS` / `_RICHNESS` in
+  `utils/mining/grid.py`.
+- the frequency brake is a **new** seam in `services/mining_workflow.dig`
+  (cooldown check, or an energy debit/refill) — the audited write path already
+  owns the transaction.
+
+A `tests/unit/tools/test_mining_economy_sim.py` parity test pins the sim's
+mirrored constants to the live source, so this record can't silently drift from
+the bot — when the constants change, update the sim's `CURRENT` config (and the
+parity test will confirm the match).
+
+## Caveats
+
+- **Unverified faucet model.** The 2.5s active cadence and the four profiles are
+  reasonable but estimated; confirm against a real play session before treating
+  the absolute coins/hour as gospel. The *relative* finding (current faucet is
+  ~7–55× the daily; recommended is ~1–3×) is robust to cadence.
+- Harvest (`!chop`) and `!explore` use the same `randint(1,3)` base and were not
+  separately swept; if mining is retuned, sanity-check those for parity.
+- This record changes **no runtime behavior** — it is design input the owner
+  approves (and chooses the frequency mechanic for) before any cog/util edit.

--- a/docs/subsystems/games.md
+++ b/docs/subsystems/games.md
@@ -202,6 +202,12 @@ on **Q-0182**.
   "Mine here".
 - [games-economy-faucet-sink-diagnostic-plan](../planning/games-economy-faucet-sink-diagnostic-plan-2026-06-15.md) —
   read-only economy faucet/sink read model (turn-key).
+- [mining-economy-balance-2026-06-22](../planning/mining-economy-balance-2026-06-22.md) — **sim-pinned
+  rebalance numbers** for the live grid-Mine faucet (owner: "rewards too large & too frequent"). The
+  simulator (`tools/game_sim/mining_economy_sim.py`) quantifies the live faucet at ~7–55× a `!daily`/hr
+  and recommends a config (frequency brake + smaller base roll + flatter tool curve + 12% bonanza) that
+  lands every player at ~1–3 dailies/active-hr. Design record — owner approves + picks the frequency
+  mechanic (energy vs cooldown) before any runtime edit.
 - *Shipped → `historical`:* [mining-structures-skill-tree-plan](../planning/mining-structures-skill-tree-plan-2026-06-14.md)
   (every slice landed) · [games-wager-money-safety-plan](../planning/games-wager-money-safety-plan-2026-06-12.md) (#748).
 

--- a/tests/unit/tools/test_mining_economy_sim.py
+++ b/tests/unit/tools/test_mining_economy_sim.py
@@ -1,0 +1,172 @@
+"""Smoke + parity tests for the mining economy balance sim.
+
+The sim (`tools/game_sim/mining_economy_sim.py`) is a disposable design tool, not
+runtime code, but it is the source of the numbers in the mining-balance design
+doc — so a light guard keeps it runnable, keeps its balance invariants honest,
+and (the important half) **pins its mirrored constants to the live game** so the
+recommendation can't silently drift from what the bot actually does. Mirrors the
+creature-sim parity test (`test_creature_sim_engine_parity.py`); loaded via
+importlib (the repo convention for non-package tool scripts).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import random
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "tools" / "game_sim" / "mining_economy_sim.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("mining_economy_sim_ut", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# --- Parity: the mirrored constants must match the live game -----------------
+
+
+def test_ore_value_parity(mod):
+    """Sim ore values mirror the live RESOURCE catalog (the coin faucet)."""
+    from utils.mining import items
+
+    for ore, value in mod.ORE_VALUE.items():
+        assert items.item_value(ore) == value, ore
+
+
+def test_ore_weight_parity(mod):
+    """Sim surface ore weights + depth re-weighting mirror rewards.py."""
+    from utils.mining import rewards
+
+    for ore, weight in mod.SURFACE_ORE_WEIGHTS.items():
+        assert rewards.ORE_WEIGHTS[ore] == weight, ore
+    # depth weighting matches at every band (0..MAX_DEPTH)
+    for depth in range(mod.MAX_DEPTH + 1):
+        assert mod.ore_weights_for_depth(depth) == rewards.ore_weights_for_depth(
+            depth,
+        ), depth
+
+
+def test_tool_multiplier_parity(mod):
+    """Sim tool multipliers mirror rewards.mine_multiplier for each tool tier."""
+    from utils import equipment
+    from utils.mining import rewards
+
+    tier_to_item = {
+        "none": None,
+        "pickaxe": "pickaxe",
+        "iron": "iron pickaxe",
+        "gold": "gold pickaxe",
+        "diamond": "diamond pickaxe",
+    }
+    for tier, item in tier_to_item.items():
+        equipped = {} if item is None else {equipment.TOOL: item}
+        live = rewards.mine_multiplier(equipped, {})
+        assert mod.TOOL_MULT[tier] == live, tier
+
+
+def test_max_depth_parity(mod):
+    from utils.mining import world
+
+    assert mod.MAX_DEPTH == world.MAX_DEPTH
+
+
+def test_current_config_mirrors_live_feature_mix(mod):
+    """The CURRENT config's cell feature mix mirrors utils/mining/grid.py."""
+    from utils.mining import grid
+
+    cur = mod.CURRENT
+    # weights, in the sim's (NORMAL, RICH, BARREN, TREASURE) order
+    live_w = {f: w for f, w in grid._FEATURE_WEIGHTS}
+    assert cur.feature_weights == (
+        live_w[grid.CellFeature.NORMAL],
+        live_w[grid.CellFeature.RICH],
+        live_w[grid.CellFeature.BARREN],
+        live_w[grid.CellFeature.TREASURE],
+    )
+    assert cur.feature_richness == (
+        grid._RICHNESS[grid.CellFeature.NORMAL],
+        grid._RICHNESS[grid.CellFeature.RICH],
+        grid._RICHNESS[grid.CellFeature.BARREN],
+        grid._RICHNESS[grid.CellFeature.TREASURE],
+    )
+    assert cur.dig_cooldown_s == 0.0  # the live game has no dig cooldown
+
+
+# --- Diagnosis: the sim must detect the imbalance it was built to find -------
+
+
+def test_current_faucet_is_over_target(mod):
+    """The live faucet over-pays every profile vs the hourly target (the bug)."""
+    rng = random.Random(1)
+    score = mod.score_config(mod.CURRENT, 3000, rng)
+    for r in score.results:
+        assert r.coins_per_hour > mod.TARGET_HOUR_HI
+    # and the geared/fresh gap is far past the playable bound
+    assert score.ratio > mod.MAX_VET_NEWCOMER_RATIO
+
+
+def test_deeper_pays_more(mod):
+    """Deeper bands draw richer ore → higher mean coins/dig (the design intent)."""
+    rng = random.Random(2)
+    surface = mod.simulate_profile(
+        mod.CURRENT,
+        mod.Profile("s", "none", 0),
+        4000,
+        rng,
+    )
+    magma = mod.simulate_profile(
+        mod.CURRENT,
+        mod.Profile("m", "none", mod.MAX_DEPTH),
+        4000,
+        rng,
+    )
+    assert magma.coins_per_dig > surface.coins_per_dig
+
+
+# --- Sweep: a balanced config must exist and clear the hard targets ----------
+
+
+def test_sweep_finds_a_balanced_config(mod):
+    scores = mod.sweep(1500, seed=42)
+    best = scores[0]
+    assert best.penalty < 0.5  # the recommendation satisfies the hard targets
+    per_hour = [r.coins_per_hour for r in best.results]
+    for ph in per_hour:
+        assert mod.TARGET_HOUR_LO * 0.9 <= ph <= mod.TARGET_HOUR_HI * 1.1
+    assert best.ratio <= mod.MAX_VET_NEWCOMER_RATIO
+    assert (
+        mod.TARGET_BONANZA_LO <= best.cfg.bonanza_rate() <= mod.TARGET_BONANZA_HI
+    )
+    # the recommendation introduces the missing frequency brake
+    assert best.cfg.dig_cooldown_s > 0
+
+
+def test_sweep_is_deterministic(mod):
+    a = mod.sweep(1000, seed=7)[0]
+    b = mod.sweep(1000, seed=7)[0]
+    assert a.cfg.name == b.cfg.name
+    assert a.penalty == b.penalty
+
+
+def test_bonanza_rate_math(mod):
+    """RICH+TREASURE share of cells — the 'too frequent' lever."""
+    assert mod.CURRENT.bonanza_rate() == pytest.approx(0.25)
+
+
+def test_main_runs_and_reports(mod, capsys, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["sim", "--trials", "400", "--seed", "1"])
+    rc = mod.main()
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "VERDICT:" in out
+    assert "RECOMMENDED" in out

--- a/tools/game_sim/mining_economy_sim.py
+++ b/tools/game_sim/mining_economy_sim.py
@@ -1,0 +1,614 @@
+#!/usr/bin/env python3.10
+"""Mining economy balance simulator (design tool, not runtime).
+
+Why this exists
+---------------
+The mining grid's first real grid-``Mine`` is now live (#1281/#1282) and the
+owner's read is that **rewards are too large and too frequent** — he asked for a
+*simulation that finds a balanced way to configure the game so it stays fun and
+playable for everyone* (the same "simulation-sane numbers" discipline the gear
+sets and the creature game used — ``tools/game_sim/creature_battle_sim.py``,
+``docs/planning/gear-set-numbers-2026-06-11.md``).
+
+This script models the mining **faucet** (coins + XP earned per dig and per
+active hour) for a spread of player profiles, measures it against the rest of
+the bot's *gated* economy, and then **sweeps candidate configurations** to find
+one that is rewarding but in line — i.e. an active mining session pays on the
+order of a daily claim, the gap between a fresh player and a fully-geared
+veteran stays bounded ("playable for everyone"), and lucky strikes feel special
+rather than constant.
+
+What it models (the real game, as of #1282 — see the source refs inline)
+------------------------------------------------------------------------
+One dig yields ``(ore, amount)`` where::
+
+    amount = randint(1, BASE_MAX) * tool_multiplier * cell_richness
+
+- ``BASE_MAX`` = 3                        (``utils/mining/rewards.py:90``)
+- ``tool_multiplier`` ∈ {1,2,3,4,5} for none/pickaxe/iron/gold/diamond
+  (``rewards.mine_multiplier`` = ``1 + mining_power // 2``;
+   powers 0/2/4/6/8 in ``utils/equipment.py``)
+- ``cell_richness`` per feature: NORMAL 1.0, RICH 2.0, BARREN 0.5, TREASURE 3.0
+  with feature weights NORMAL 60 / RICH 20 / BARREN 15 / TREASURE 5
+  (``utils/mining/grid.py``)
+- the ore is drawn from a **depth-weighted** table (deeper = richer ores)
+  (``rewards.ore_weights_for_depth``); ore sells for
+  stone 1 / bronze 2 / iron 3 / silver 4 / gold 6 / diamond 12
+  (``utils/mining/items.py`` ``RESOURCE`` values, sold via ``market.sell_price``)
+- **there is no cooldown, no energy, no rate limit** on digging (verified — the
+  faucet is throttled only by how fast a human clicks).
+
+Economy benchmark (what "balanced" is measured against)
+-------------------------------------------------------
+``!daily`` pays a weighted 500–5000 once / 24h (mean ≈ 1,692) and ``!work`` pays
+~60 coins once / hour (``services/economy_helpers.py``). So the gated economy
+gives a casual player on the order of **~1,700 coins/day**. A mining faucet that
+lets someone out-earn that in minutes is the imbalance this tool quantifies.
+
+It is **stdlib-only, deterministic** (``--seed``) and prints a verdict with
+PASS/WARN flags plus a **recommended config**. Nothing here is imported by the
+bot; it informs a design doc, and the owner decides which knobs to apply.
+
+Run::
+
+    python3.10 tools/game_sim/mining_economy_sim.py
+    python3.10 tools/game_sim/mining_economy_sim.py --trials 8000 --seed 7
+
+Provenance: added 2026-06-22 (owner request — "create/run a simulation that
+finds the most balanced way for the mining game"). Disposable design tool —
+delete once the numbers are pinned into the mining subsystem, or if the approach
+is dropped. **Unverified:** confirm its faucet numbers against a live play
+session a few times before trusting the recommendation as gospel.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import statistics
+from dataclasses import dataclass, field
+
+# ---------------------------------------------------------------------------
+# The real game's constants (mirrored, with source refs — see module docstring).
+# A parity test (tests/unit/tools/test_mining_economy_sim.py) asserts these match
+# the live source so this tool can't silently drift from the bot.
+# ---------------------------------------------------------------------------
+
+# Ore sell value (coins per unit) — utils/mining/items.py RESOURCE values.
+ORE_VALUE: dict[str, int] = {
+    "stone": 1,
+    "bronze": 2,
+    "iron": 3,
+    "silver": 4,
+    "gold": 6,
+    "diamond": 12,
+}
+
+# Surface (depth 0) ore selection weights — utils/mining/rewards.py ORE_WEIGHTS.
+SURFACE_ORE_WEIGHTS: dict[str, float] = {
+    "stone": 3.0,
+    "bronze": 2.5,
+    "iron": 2.0,
+    "silver": 1.5,
+    "gold": 1.0,
+    "diamond": 0.5,
+}
+
+# Tool multipliers by tier — rewards.mine_multiplier (1 + mining_power // 2).
+TOOL_MULT: dict[str, int] = {
+    "none": 1,
+    "pickaxe": 2,
+    "iron": 3,
+    "gold": 4,
+    "diamond": 5,
+}
+
+MAX_DEPTH = 3  # utils/mining/world.py — SURFACE/CAVERN/DEEP/MAGMA (0..3)
+
+
+def ore_weights_for_depth(depth: int) -> dict[str, float]:
+    """Mirror of ``rewards.ore_weights_for_depth`` — deeper = richer odds."""
+    d = max(0, depth)
+    w = SURFACE_ORE_WEIGHTS
+    return {
+        "stone": max(0.5, w["stone"] - d),
+        "bronze": max(0.5, w["bronze"] - 0.5 * d),
+        "iron": w["iron"] + 0.5 * d,
+        "silver": w["silver"] + 0.5 * d,
+        "gold": w["gold"] + 0.5 * d,
+        "diamond": w["diamond"] + 0.5 * d,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Economy benchmark — services/economy_helpers.py (the gated faucets).
+# ---------------------------------------------------------------------------
+
+# _DAILY_TIERS (label, min, max, weight). Expected value ≈ 1,692 coins/24h.
+_DAILY_TIERS: list[tuple[int, int, int]] = [
+    (500, 999, 45),
+    (1000, 1999, 25),
+    (2000, 2999, 15),
+    (3000, 3999, 8),
+    (4000, 4999, 5),
+    (5000, 5000, 2),
+]
+
+
+def expected_daily() -> float:
+    """Mean coins from one ``!daily`` claim (the casual player's daily faucet)."""
+    total_w = sum(w for *_, w in _DAILY_TIERS)
+    return sum((lo + hi) / 2 * w for lo, hi, w in _DAILY_TIERS) / total_w
+
+
+WORK_COINS_PER_HOUR = 62.5  # tier-1 work pay ~50-75, once/hour (economy_helpers)
+
+
+# ---------------------------------------------------------------------------
+# Tunable configuration — the knobs the sweep searches. CURRENT = the live game.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MiningConfig:
+    """A candidate mining configuration. ``CURRENT`` mirrors the live game."""
+
+    name: str
+    base_max: int  # amount = randint(1, base_max) before multipliers
+    # per-tier tool multiplier applied to the base amount
+    tool_mult: dict[str, float]
+    # cell feature weights (NORMAL, RICH, BARREN, TREASURE) and their richness
+    feature_weights: tuple[float, float, float, float]
+    feature_richness: tuple[float, float, float, float]
+    # the frequency brake — seconds a dig is locked out (0 = no cooldown today)
+    dig_cooldown_s: float
+    # ore sell values + depth weighting are gear-coupled → held fixed across the
+    # sweep (changing them would desync the gear economy); kept here for clarity.
+    ore_value: dict[str, int] = field(default_factory=lambda: dict(ORE_VALUE))
+
+    def bonanza_rate(self) -> float:
+        """Share of cells that are a RICH or TREASURE 'lucky strike'."""
+        n, r, b, t = self.feature_weights
+        return (r + t) / (n + r + b + t)
+
+
+CURRENT = MiningConfig(
+    name="CURRENT (live #1282)",
+    base_max=3,
+    tool_mult=dict(TOOL_MULT),
+    feature_weights=(60.0, 20.0, 15.0, 5.0),
+    feature_richness=(1.0, 2.0, 0.5, 3.0),
+    dig_cooldown_s=0.0,
+)
+
+
+# ---------------------------------------------------------------------------
+# Player profiles — "everyone": a fresh player through a fully-geared veteran.
+# cadence_s = realistic seconds between clicks when ACTIVELY mining the button
+# UI (open panel, click, await re-render); the effective dig interval is
+# max(cadence_s, cooldown).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Profile:
+    name: str
+    tool: str
+    depth: int
+
+
+ACTIVE_CADENCE_S = 2.5  # a committed player clicking through the grid UI
+
+PROFILES: list[Profile] = [
+    Profile("Newcomer  (no tool, surface)", "none", 0),
+    Profile("Casual    (pickaxe, cavern)", "pickaxe", 1),
+    Profile("Regular   (iron pick, deep)", "iron", 2),
+    Profile("Veteran   (diamond pick, magma)", "diamond", 3),
+]
+
+
+# ---------------------------------------------------------------------------
+# Core dig model
+# ---------------------------------------------------------------------------
+
+_FEATURE_NAMES = ("NORMAL", "RICH", "BARREN", "TREASURE")
+
+
+def _draw_ore_value(cfg: MiningConfig, depth: int, rng: random.Random) -> int:
+    weights = ore_weights_for_depth(depth)
+    ore = rng.choices(list(weights), weights=list(weights.values()), k=1)[0]
+    return cfg.ore_value[ore]
+
+
+def dig_coins(cfg: MiningConfig, prof: Profile, rng: random.Random) -> int:
+    """Coins from selling the ore of a single dig under ``cfg`` for ``prof``."""
+    # 1. base roll
+    amount = rng.randint(1, cfg.base_max)
+    # 2. tool multiplier
+    amount *= cfg.tool_mult[prof.tool]
+    # 3. cell feature richness (BARREN floors at 1 ore, like the real game)
+    fi = rng.choices(range(4), weights=list(cfg.feature_weights), k=1)[0]
+    richness = cfg.feature_richness[fi]
+    amount = max(1, round(amount * richness))
+    # 4. ore value (depth-weighted draw) → coins
+    return amount * _draw_ore_value(cfg, prof.depth, rng)
+
+
+@dataclass
+class ProfileResult:
+    profile: Profile
+    coins_per_dig: float
+    p95_dig: float  # spike size — a single lucky dig
+    coins_per_hour: float  # at the config's effective dig interval
+    interval_s: float
+
+
+def simulate_profile(
+    cfg: MiningConfig,
+    prof: Profile,
+    trials: int,
+    rng: random.Random,
+) -> ProfileResult:
+    digs = [dig_coins(cfg, prof, rng) for _ in range(trials)]
+    mean = statistics.mean(digs)
+    p95 = sorted(digs)[min(len(digs) - 1, int(0.95 * len(digs)))]
+    interval = max(ACTIVE_CADENCE_S, cfg.dig_cooldown_s)
+    per_hour = mean * (3600.0 / interval)
+    return ProfileResult(prof, mean, float(p95), per_hour, interval)
+
+
+# ---------------------------------------------------------------------------
+# Balance targets — the operational definition of "fun & playable for everyone"
+# ---------------------------------------------------------------------------
+
+# An active hour of mining should pay on the order of one daily claim — clearly
+# worth doing (≈ 0.6-3 dailies/hr) but not trivializing the gated economy. The
+# floor keeps a fresh player's hour meaningful; the ceiling keeps a maxed
+# veteran from out-earning the whole rest of the economy in minutes.
+TARGET_HOUR_LO = 1000.0  # ≈ 0.6 dailies / active hour
+TARGET_HOUR_HI = 5000.0  # ≈ 3.0 dailies / active hour
+# Tools + depth should matter, but a maxed veteran must not out-earn an
+# absolute newcomer (no tool, surface) by a runaway margin — everyone stays in
+# the game ("playable for everyone"). The structural floor on this ratio is the
+# depth ore-value gain (≈1.7×, gear-coupled & fixed) × the tool-curve gap, so a
+# value near 3.5× is the tightest a tool-curve change alone can reach.
+MAX_VET_NEWCOMER_RATIO = 3.5
+# Lucky strikes should feel special, not constant.
+TARGET_BONANZA_LO = 0.08
+TARGET_BONANZA_HI = 0.16
+
+
+@dataclass
+class Score:
+    cfg: MiningConfig
+    penalty: float  # hard target violation — drives the PASS/WARN verdict
+    shaping: float  # tiny tie-breaker among equally-valid (penalty 0) configs
+    results: list[ProfileResult]
+    ratio: float
+
+    @property
+    def rank_key(self) -> tuple[float, float]:
+        return (self.penalty, self.shaping)
+
+
+def _band_penalty(value: float, lo: float, hi: float) -> float:
+    """0 inside [lo, hi]; grows with relative distance outside it."""
+    if value < lo:
+        return (lo - value) / lo
+    if value > hi:
+        return (value - hi) / hi
+    return 0.0
+
+
+def score_config(cfg: MiningConfig, trials: int, rng: random.Random) -> Score:
+    results = [simulate_profile(cfg, p, trials, rng) for p in PROFILES]
+    per_hour = [r.coins_per_hour for r in results]
+    newcomer, veteran = per_hour[0], per_hour[-1]
+    ratio = veteran / newcomer if newcomer else 999.0
+
+    penalty = 0.0
+    # every profile's hourly faucet should sit in the target band
+    for ph in per_hour:
+        penalty += _band_penalty(ph, TARGET_HOUR_LO, TARGET_HOUR_HI)
+    # bound the geared-vs-fresh gap
+    penalty += max(0.0, ratio - MAX_VET_NEWCOMER_RATIO)
+    # lucky-strike frequency
+    penalty += 2.0 * _band_penalty(
+        cfg.bonanza_rate(),
+        TARGET_BONANZA_LO,
+        TARGET_BONANZA_HI,
+    )
+
+    # Shaping: among configs that all satisfy the hard targets, prefer a snappier
+    # cooldown (better feel), a newcomer hour near one daily, and a modest gap.
+    daily = expected_daily()
+    shaping = (
+        0.30 * (cfg.dig_cooldown_s / 15.0)
+        + 0.50 * abs(newcomer / daily - 1.0)
+        + 0.20 * abs(ratio - 2.0)
+    )
+    return Score(cfg, penalty, shaping, results, ratio)
+
+
+# ---------------------------------------------------------------------------
+# Candidate configs for the sweep
+# ---------------------------------------------------------------------------
+
+# Tool-multiplier curves: CURRENT runs away (×1..×5); the alternatives compress
+# the top so a veteran still out-mines a newcomer but within the playable bound.
+_TOOL_CURVES: dict[str, dict[str, float]] = {
+    "steep(1-5)": dict(TOOL_MULT),
+    "compressed(1-3)": {
+        "none": 1.0,
+        "pickaxe": 1.5,
+        "iron": 2.0,
+        "gold": 2.5,
+        "diamond": 3.0,
+    },
+    "gentle(1-2.5)": {
+        "none": 1.0,
+        "pickaxe": 1.4,
+        "iron": 1.8,
+        "gold": 2.2,
+        "diamond": 2.5,
+    },
+    "flat(1-1.5)": {
+        "none": 1.0,
+        "pickaxe": 1.2,
+        "iron": 1.3,
+        "gold": 1.4,
+        "diamond": 1.5,
+    },
+}
+
+# Cell-feature mixes: CURRENT (25% bonanza, treasure ×3) → tempered/calm cut the
+# bonanza rate into the target band and trim the treasure spike.
+_FEATURE_SETS: dict[
+    str,
+    tuple[tuple[float, float, float, float], tuple[float, float, float, float]],
+] = {
+    "live(25% bonanza)": ((60.0, 20.0, 15.0, 5.0), (1.0, 2.0, 0.5, 3.0)),
+    "tempered(15%)": ((66.0, 12.0, 19.0, 3.0), (1.0, 1.7, 0.6, 2.3)),
+    "calm(12%)": ((70.0, 10.0, 18.0, 2.0), (1.0, 1.6, 0.6, 2.0)),
+}
+
+_COOLDOWNS = (4.0, 6.0, 8.0, 10.0, 12.0, 15.0)
+_BASE_MAXES = (2, 3)
+
+
+def candidate_configs() -> list[MiningConfig]:
+    out: list[MiningConfig] = []
+    for cd in _COOLDOWNS:
+        for bm in _BASE_MAXES:
+            for tname, tcurve in _TOOL_CURVES.items():
+                for fname, (fw, fr) in _FEATURE_SETS.items():
+                    out.append(
+                        MiningConfig(
+                            name=(f"cd={cd:g}s base=1-{bm} tool={tname} feat={fname}"),
+                            base_max=bm,
+                            tool_mult=dict(tcurve),
+                            feature_weights=fw,
+                            feature_richness=fr,
+                            dig_cooldown_s=cd,
+                        ),
+                    )
+    return out
+
+
+def sweep(trials: int, seed: int) -> list[Score]:
+    """Score every candidate (each on its own fresh RNG for determinism)."""
+    scores: list[Score] = []
+    for i, cfg in enumerate(candidate_configs()):
+        scores.append(score_config(cfg, trials, random.Random(seed + 1 + i)))
+    scores.sort(key=lambda s: s.rank_key)
+    return scores
+
+
+# ---------------------------------------------------------------------------
+# Progression — digs (and active minutes) to afford each tool upgrade
+# ---------------------------------------------------------------------------
+
+# Buy prices — utils/mining/market.py (the coin sink).
+TOOL_PRICES: list[tuple[str, int]] = [
+    ("torch (10)", 10),
+    ("pickaxe (25)", 25),
+    ("lantern (40)", 40),
+    ("iron pickaxe (60)", 60),
+    ("gold pickaxe (140)", 140),
+    ("diamond lantern (200)", 200),
+    ("diamond pickaxe (320)", 320),
+]
+
+
+def progression(cfg: MiningConfig, prof: Profile, res: ProfileResult) -> list[str]:
+    """Active minutes for ``prof`` to afford each upgrade at ``cfg``'s faucet."""
+    coins_per_min = res.coins_per_hour / 60.0
+    lines = []
+    for label, price in TOOL_PRICES:
+        mins = price / coins_per_min if coins_per_min else 999.0
+        lines.append(f"      {label:<22} ~{mins:5.1f} active min")
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+def _flag(ok: bool) -> str:
+    return "PASS" if ok else "WARN"
+
+
+def _report_config(
+    title: str,
+    cfg: MiningConfig,
+    trials: int,
+    rng: random.Random,
+) -> Score:
+    score = score_config(cfg, trials, rng)
+    daily = expected_daily()
+    print(f"\n{title}")
+    print(f"    {cfg.name}")
+    print(
+        f"    bonanza cells = {cfg.bonanza_rate() * 100:.0f}%  ·  "
+        f"dig cooldown = {cfg.dig_cooldown_s:g}s  ·  base roll = 1-{cfg.base_max}",
+    )
+    print(
+        "    profile                            coins/dig  p95  "
+        "coins/hr   dailies/hr",
+    )
+    for r in score.results:
+        dailies = r.coins_per_hour / daily
+        print(
+            f"    {r.profile.name:<33} {r.coins_per_dig:8.1f} "
+            f"{r.p95_dig:5.0f} {r.coins_per_hour:9.0f}   {dailies:5.1f}×",
+        )
+    print(
+        f"    veteran/newcomer hourly ratio = {score.ratio:.1f}×  "
+        f"(target ≤ {MAX_VET_NEWCOMER_RATIO:g}×)",
+    )
+    return score
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--trials", type=int, default=6000, help="digs per profile.")
+    ap.add_argument("--seed", type=int, default=42, help="RNG seed (determinism).")
+    ap.add_argument(
+        "--top",
+        type=int,
+        default=5,
+        help="how many swept configs to list.",
+    )
+    args = ap.parse_args()
+    rng = random.Random(args.seed)
+    daily = expected_daily()
+
+    print("=" * 74)
+    print(
+        f"Mining economy balance sim  (seed={args.seed}, trials={args.trials})",
+    )
+    print(
+        f"Economy benchmark: !daily ≈ {daily:,.0f} coins/24h · "
+        f"!work ≈ {WORK_COINS_PER_HOUR:g}/hr (gated).",
+    )
+    print(
+        f"Targets: active mining {TARGET_HOUR_LO:,.0f}-{TARGET_HOUR_HI:,.0f} "
+        f"coins/hr · vet/new ≤ {MAX_VET_NEWCOMER_RATIO:g}× · "
+        f"bonanza {TARGET_BONANZA_LO * 100:.0f}-{TARGET_BONANZA_HI * 100:.0f}%.",
+    )
+    print("=" * 74)
+
+    warns = 0
+
+    # 1. Diagnose the current live config (expect: way over the faucet target).
+    cur = _report_config(
+        "[1] CURRENT live faucet — is it too large & too frequent?",
+        CURRENT,
+        args.trials,
+        rng,
+    )
+    over = [r for r in cur.results if r.coins_per_hour > TARGET_HOUR_HI]
+    if over:
+        worst = max(cur.results, key=lambda r: r.coins_per_hour)
+        mins_to_daily = daily / (worst.coins_per_hour / 60.0)
+        print(
+            f"    → DIAGNOSIS: {len(over)}/{len(cur.results)} profiles exceed the "
+            f"hourly target. A '{worst.profile.name.split('(')[0].strip()}' earns a "
+            f"full !daily ({daily:,.0f}) in ~{mins_to_daily:.1f} active min.",
+        )
+        print("    → too large AND too frequent — confirms the owner's read.  WARN")
+        warns += 1
+    if CURRENT.bonanza_rate() > TARGET_BONANZA_HI:
+        print(
+            f"    → lucky strikes fire on {CURRENT.bonanza_rate() * 100:.0f}% of "
+            f"cells (target ≤ {TARGET_BONANZA_HI * 100:.0f}%): rewards too frequent."
+            "  WARN",
+        )
+        warns += 1
+
+    # 2. Sweep candidate configs for the most balanced one.
+    print("\n[2] Config sweep — searching for the most balanced configuration…")
+    scores = sweep(max(1000, args.trials // 3), args.seed)
+    print(f"    evaluated {len(scores)} configs against the targets. Top picks:")
+    print(
+        "    rank  penalty  new/hr  vet/hr  ratio  bonanza  config",
+    )
+    for i, s in enumerate(scores[: args.top], 1):
+        ph = [r.coins_per_hour for r in s.results]
+        print(
+            f"    {i:>4}  {s.penalty:7.2f}  {ph[0]:6.0f}  {ph[-1]:6.0f}  "
+            f"{s.ratio:4.1f}×  {s.cfg.bonanza_rate() * 100:5.0f}%  {s.cfg.name}",
+        )
+
+    best = scores[0]
+    # 3. Detail the recommended config + its progression curve.
+    rec = _report_config(
+        "[3] RECOMMENDED config (lowest penalty)",
+        best.cfg,
+        args.trials,
+        rng,
+    )
+    balanced = best.penalty < 0.5
+    warns += not balanced
+    print(f"    overall balance penalty = {best.penalty:.2f}  {_flag(balanced)}")
+
+    print("\n[4] Progression at the recommended faucet (active minutes to afford):")
+    for r in rec.results:
+        print(f"    {r.profile.name}:")
+        for line in progression(best.cfg, r.profile, r):
+            print(line)
+
+    # 5. Verdict + the concrete deltas vs the live game.
+    print("\n[5] Recommended changes vs the live game:")
+    deltas = _diff_configs(CURRENT, best.cfg)
+    for d in deltas:
+        print(f"    • {d}")
+
+    print("\n" + "=" * 74)
+    verdict = (
+        "BALANCED CONFIG FOUND (no flags)"
+        if warns == 0
+        else f"REVIEW — {warns} warn flag(s) (the current game is unbalanced; "
+        "apply the recommendation)"
+    )
+    print(f"VERDICT: {verdict}")
+    print("=" * 74)
+    return 0
+
+
+def _diff_configs(a: MiningConfig, b: MiningConfig) -> list[str]:
+    out: list[str] = []
+    if a.dig_cooldown_s != b.dig_cooldown_s:
+        out.append(
+            f"ADD a per-dig cooldown of {b.dig_cooldown_s:g}s "
+            f"(currently {a.dig_cooldown_s:g}s — the missing frequency brake).",
+        )
+    if a.base_max != b.base_max:
+        out.append(f"base roll 1-{a.base_max} → 1-{b.base_max} ore.")
+    if a.tool_mult != b.tool_mult:
+        out.append(
+            "compress the tool multiplier curve "
+            f"{_curve_str(a.tool_mult)} → {_curve_str(b.tool_mult)} "
+            "(keeps the geared/fresh gap playable).",
+        )
+    if a.feature_weights != b.feature_weights or (
+        a.feature_richness != b.feature_richness
+    ):
+        out.append(
+            f"retune cell features: bonanza {a.bonanza_rate() * 100:.0f}% → "
+            f"{b.bonanza_rate() * 100:.0f}%, treasure richness "
+            f"×{a.feature_richness[3]:g} → ×{b.feature_richness[3]:g}.",
+        )
+    if not out:
+        out.append("none — the live config already meets the targets.")
+    return out
+
+
+def _curve_str(curve: dict[str, float]) -> str:
+    order = ("none", "pickaxe", "iron", "gold", "diamond")
+    return "×" + "/".join(f"{curve[k]:g}" for k in order)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

The mining grid's first real grid Mine is now live (#1281/#1282). The owner feels **rewards may be too large and too frequent**, and recalled an earlier session's idea of *running a simulation to find a balanced configuration*. This adds a Monte-Carlo **balance simulator** for the mining game (following the `tools/game_sim/creature_battle_sim.py` precedent) and uses it to recommend a configuration that keeps the game **fun and playable for everyone** — slowing/right-sizing the faucet without making it a slog.

Depth (currently capped at 3) is explicitly *not* the focus — the **faucet** (reward magnitude + frequency) is.

## What's here

- `tools/game_sim/mining_economy_sim.py` — stdlib, deterministic Monte-Carlo sim of mining sessions; sweeps candidate configs against fun/balance targets and prints a PASS/WARN verdict + a recommended config.
- A `docs/planning/` record pinning the recommended numbers (the design-sim discipline used for gear/creature tuning).
- A light smoke/invariant test mirroring `test_creature_battle_sim.py`.

> **Status:** born-red session card (`.sessions/2026-06-22-mining-economy-sim.md`) holds the merge until the work is complete (Q-0133). Flipped to `complete` as the final step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ju7Kkqp6AF8D5CbbaN33a

---
_Generated by [Claude Code](https://claude.ai/code/session_017ju7Kkqp6AF8D5CbbaN33a)_