### PR TITLE
Bulk role creation via preset packs

### DIFF
--- a/.sessions/2026-06-22-bulk-role-creation-packs.md
+++ b/.sessions/2026-06-22-bulk-role-creation-packs.md
@@ -1,6 +1,6 @@
 # 2026-06-22 — Bulk role creation via preset packs
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 Owner-relayed user request: add **bulk role creation** modelled on the existing
 colour-reaction-role flow — pick a category (gaming / moderation / …), then a
@@ -9,20 +9,103 @@ all in one step. Mirrors the shipped 🎨 Colours auto-create UX
 (`role_menu_builder._ColourRolesView` → `ensure_color_role`) but with curated
 *functional* role packs instead of colours.
 
-## Plan (about to build)
+## Shipped (PR #1300)
 
-1. **Catalogue** — `disbot/utils/role_packs.py` (pure data, mirrors
-   `role_menu_presentation.py`): `RolePack`/`PackRole` dataclasses + curated
-   categories (Gaming, Staff/Moderation, Pronouns, Notifications, Region,
-   Interests). Accessors `packs()` / `get_pack()`.
-2. **Seam** — generalize the reuse-or-create logic into
-   `reaction_role_service.ensure_role`; `ensure_color_role` delegates (no
-   behaviour change; existing tests stay green).
-3. **Surface A — standalone create** (`RoleCreatePanel`): 📦 Role Packs button →
-   category select → role multiselect → audited bulk create into the server.
-4. **Surface B — into a menu** (`role_menu_builder`): 📦 Packs button beside
-   🎨 Colours → bulk-create + add to the menu draft (the literal "colour reaction
-   roles" mirror).
-5. Tests + docs.
+- **`disbot/utils/role_packs.py`** — pure-data catalogue (`RolePack` / `PackRole`
+  + `packs()` / `get_pack()`), mirroring `role_menu_presentation.py`. Seven
+  curated categories: Gaming · Staff/Moderation (hoisted) · Pronouns ·
+  Notifications · Region · Interests · Platforms. Each ≤25 roles (select cap);
+  colours as hex strings (same `_parse_color` as `ROLE_PRESETS`/`_COLOR_OPTIONS`).
+- **`reaction_role_service.ensure_role`** — generalised the colour reuse-or-create
+  core into a public seam (name/colour/hoist/mentionable/gradient + solid
+  fallback). `ensure_color_role` is now a thin colour-specialised wrapper that
+  keeps the Enhanced-Role-Styles perk gate and delegates — **no behaviour change**
+  (the four existing `ensure_color_role` tests stay green).
+- **`disbot/views/roles/_role_pack_flow.RolePackView`** — shared two-step flow
+  (pick pack → multiselect roles → audited bulk create), with an optional
+  `on_created` hook. Authority (`manage_roles`) re-checked at commit time.
+- **Two surfaces:** a **📦 Role Packs** button on `RoleCreatePanel` (the `!roles`
+  → 📝 Create panel — bulk-create into the server) and a **📦 Packs** button beside
+  🎨 Colours in `RoleMenuBuilder` (bulk-create **and** fold into the menu draft —
+  the literal "colour reaction roles" mirror).
+- **Tests** (+ all CI-safe, no gateway): catalogue well-formedness
+  (`tests/unit/utils/test_role_packs.py`), `ensure_role` reuse/create/blank-name
+  (added to `test_reaction_role_service_menus.py`), and the flow commit
+  (`tests/unit/views/test_role_pack_flow.py` — creates per name, runs the hook,
+  manage-roles gate, empty no-op).
+- **Docs:** refinement note on the reaction-roles overhaul plan.
+- Gates: `check_quality --full` ✓ (black/isort/ruff + mypy 776 files + 11582
+  passed), `check_architecture --mode strict` 0 errors, `check_docs --strict` ✓.
 
-Owner-directed (Q-0191): PR opens ready, auto-merge armed, not held for review.
+Owner-relayed (Q-0191 — owner-directed = the review): PR opened ready, auto-merge
+armed, **not** `needs-hermes-review`.
+
+## Decisions
+
+- **Placement = both surfaces.** "Bulk role creation" reads most naturally in the
+  standalone create panel; the explicit "like the colour reaction roles" reference
+  reads as the menu builder. Both share one catalogue + one seam, so doing both is
+  cheap and faithful — chose both rather than guess one (Q-0014: pick and ship).
+- **No reaction-menu auto-build on the create panel path.** The standalone flow
+  just creates roles; wiring them into a menu is the *menu-builder* surface's job
+  (where 📦 Packs adds to the draft). Keeps each surface single-purpose.
+- **Generalise rather than duplicate.** Factored the colour create-or-reuse into
+  `ensure_role` instead of copying it, so there is one audited create path.
+
+## ⚑ Self-initiated
+
+None — the feature is owner-relayed. The only unprompted choice was building
+**both** surfaces (vs one); flagged here for visibility but it is squarely within
+the request's "function the same way to create [colour reaction] roles" framing.
+
+## 💡 Session idea (Q-0089)
+
+**Make the role-pack catalogue operator-extensible per guild** — today
+`role_packs.py` is a fixed code catalogue (like `ROLE_PRESETS`). A natural next
+step: a `guild_role_packs` table + a small editor so an admin can define their
+*own* named pack ("Our Games", "Our Pings") once and bulk-create/refresh it,
+reusing the exact `RolePackView` + `ensure_role` seam shipped here. It turns a
+nice convenience into a reusable server-setup primitive and dovetails with the
+gated web builder (Surface A) — the same catalogue would render there. Captured,
+not built (keeps this PR tight); worth a `docs/ideas/` entry if it recurs.
+
+## ⟲ Previous-session review (Q-0102)
+
+Reviewed the Help-menu regrouping session (PR #1297 + the grouping sim). **Did
+well:** it built a *simulation* to find the grouping before touching code, and
+turned the one-off into a standing CI guard (#1297 — the session idea became the
+very next merge), which is exactly the "leave the next session better-equipped"
+ethos. **Could have done better / system improvement:** that session's own
+context-delta flagged that homing a subsystem under Games silently imposes the
+*actionability contract* — an invisible coupling with no pointer in the registry.
+The concrete workflow improvement is a one-line note in `hub_registry.py` (or the
+surface map) naming that consequence, so the next editor doesn't learn it from a
+red test. Same class of "make the invisible coupling visible" lesson this
+session hit with the black↔ruff trailing-comma tension (below).
+
+## 🔎 Doc audit (Q-0104)
+
+- `check_quality --full` ✓ · `check_architecture --mode strict` 0 errors ·
+  `check_docs --strict` ✓ · `check_current_state_ledger --strict` shows only the
+  benign #1294–#1298 newest-merge lag (Q-0124: the recon pass at #1320 records it;
+  this PR is correctly absent from the live ledger until merged).
+- New durable content homed: the feature is noted on the reaction-roles overhaul
+  plan (the established home for this arc's refinements). The new `utils/role_packs`
+  catalogue is self-documenting pure data; no new top-level doc needed.
+
+## Context delta
+
+- **Needed and well-pointed-to:** the `PreToolUse` context maps + the colour flow
+  (`_ColourRolesView` / `_commit_colour_roles` / `ensure_color_role`) were an
+  near-perfect template — the request literally *is* "that, with role names."
+  Reading those three first made the whole build a pattern-match.
+- **Friction worth a guard:** black and ruff (COM812) disagreed on one-line
+  `PackRole(...)` calls — black collapsed them, ruff demanded a trailing comma.
+  The resolution is always `ruff --fix` *then* `black` (ruff adds the comma →
+  black expands to multiline). `check_quality --check-only` catches it, but the
+  fix order isn't written down anywhere; a one-line note in the CI-parity section
+  of CLAUDE.md ("when black & ruff fight over trailing commas, run ruff --fix
+  first") would save the next agent the iteration. (Recorded here, not self-edited
+  into CLAUDE.md per Q-0106.)
+- **Pointed to but not needed:** CodeGraph — a localized, pattern-mirroring change
+  across known files; `context_map.py` + targeted reads carried it.

--- a/.sessions/2026-06-22-bulk-role-creation-packs.md
+++ b/.sessions/2026-06-22-bulk-role-creation-packs.md
@@ -1,0 +1,28 @@
+# 2026-06-22 — Bulk role creation via preset packs
+
+> **Status:** `in-progress`
+
+Owner-relayed user request: add **bulk role creation** modelled on the existing
+colour-reaction-role flow — pick a category (gaming / moderation / …), then a
+**multiselect of predefined roles** that match the type, and the bot creates them
+all in one step. Mirrors the shipped 🎨 Colours auto-create UX
+(`role_menu_builder._ColourRolesView` → `ensure_color_role`) but with curated
+*functional* role packs instead of colours.
+
+## Plan (about to build)
+
+1. **Catalogue** — `disbot/utils/role_packs.py` (pure data, mirrors
+   `role_menu_presentation.py`): `RolePack`/`PackRole` dataclasses + curated
+   categories (Gaming, Staff/Moderation, Pronouns, Notifications, Region,
+   Interests). Accessors `packs()` / `get_pack()`.
+2. **Seam** — generalize the reuse-or-create logic into
+   `reaction_role_service.ensure_role`; `ensure_color_role` delegates (no
+   behaviour change; existing tests stay green).
+3. **Surface A — standalone create** (`RoleCreatePanel`): 📦 Role Packs button →
+   category select → role multiselect → audited bulk create into the server.
+4. **Surface B — into a menu** (`role_menu_builder`): 📦 Packs button beside
+   🎨 Colours → bulk-create + add to the menu draft (the literal "colour reaction
+   roles" mirror).
+5. Tests + docs.
+
+Owner-directed (Q-0191): PR opens ready, auto-merge armed, not held for review.

--- a/disbot/services/reaction_role_service.py
+++ b/disbot/services/reaction_role_service.py
@@ -486,20 +486,31 @@ def supports_role_gradients(guild: discord.Guild) -> bool:
     return any("ROLE" in f and ("COLOR" in f or "COLOUR" in f) for f in feats)
 
 
-async def ensure_color_role(
+async def ensure_role(
     guild: discord.Guild,
     *,
     name: str,
     color: discord.Color,
+    hoist: bool = False,
+    mentionable: bool = False,
     secondary: discord.Color | None = None,
     tertiary: discord.Color | None = None,
     actor: object | None,
+    reason: str = "Bulk role creation",
 ) -> tuple[int | None, bool, str]:
-    """Reuse a same-named role, or create a colour role via the audited seam.
+    """Reuse a same-named role, or create one via the audited lifecycle seam.
 
-    Returns ``(role_id, created, note)``. A gradient/holographic style is applied
-    only when the guild supports Enhanced Role Styles; a gradient create Discord
-    rejects anyway falls back to a solid colour so the operator still gets a role.
+    The general "make sure this role exists" primitive shared by the colour
+    auto-create flow (:func:`ensure_color_role`) and the bulk role-pack flows
+    (creation panel + menu builder). Returns ``(role_id, created, note)``.
+
+    When ``secondary`` is given it attempts an Enhanced-Role-Styles gradient; a
+    gradient Discord rejects falls back to a solid colour so the operator still
+    gets a role. The **caller** decides whether a gradient is appropriate (e.g.
+    only on guilds with the perk — see :func:`ensure_color_role`); this seam just
+    attempts what it's handed and degrades. Creation goes through the audited
+    ``RoleLifecycleService`` (the only sanctioned ``create_role`` caller), never
+    raw ``guild.create_role`` from a view.
     """
     from core.runtime import resources
     from services.role_lifecycle_service import (
@@ -507,7 +518,7 @@ async def ensure_color_role(
         RoleLifecycleService,
     )
 
-    name = (name or "").strip()[:100] or "colour"
+    name = (name or "").strip()[:100] or "role"
     existing = resources.resolve_role(guild, name=name)
     if existing is not None:
         return existing.id, False, ""
@@ -524,9 +535,11 @@ async def ensure_color_role(
                 operation="create",
                 name=name,
                 color=color,
+                hoist=hoist,
+                mentionable=mentionable,
                 secondary_color=sec,
                 tertiary_color=ter,
-                reason="Colour role (reaction-role menu)",
+                reason=reason,
             ),
             actor,
             actor_type="admin",
@@ -536,17 +549,42 @@ async def ensure_color_role(
             return int(applied[0].target_id), ""
         return None, result.first_error
 
-    want_gradient = secondary is not None and supports_role_gradients(guild)
-    role_id, note = await _create(
-        secondary if want_gradient else None,
-        tertiary if want_gradient else None,
-    )
-    if role_id is None and want_gradient:
-        # The perk may be unavailable after all — retry as a plain solid colour.
+    role_id, note = await _create(secondary, tertiary)
+    if role_id is None and secondary is not None:
+        # The gradient may have been rejected — retry as a plain solid colour.
         role_id, note = await _create(None, None)
         if role_id is not None:
             note = "Gradient unavailable here — created a solid colour role."
     return role_id, role_id is not None, note
+
+
+async def ensure_color_role(
+    guild: discord.Guild,
+    *,
+    name: str,
+    color: discord.Color,
+    secondary: discord.Color | None = None,
+    tertiary: discord.Color | None = None,
+    actor: object | None,
+) -> tuple[int | None, bool, str]:
+    """Reuse a same-named role, or create a colour role via the audited seam.
+
+    Thin colour-specialised wrapper over :func:`ensure_role`: a gradient/
+    holographic style is offered **only** when the guild supports Enhanced Role
+    Styles (the perk gate lives here; the create + solid fallback live in
+    ``ensure_role``). Returns ``(role_id, created, note)``.
+    """
+    name = (name or "").strip()[:100] or "colour"
+    want_gradient = secondary is not None and supports_role_gradients(guild)
+    return await ensure_role(
+        guild,
+        name=name,
+        color=color,
+        secondary=secondary if want_gradient else None,
+        tertiary=tertiary if want_gradient else None,
+        actor=actor,
+        reason="Colour role (reaction-role menu)",
+    )
 
 
 async def delete_menu(
@@ -890,6 +928,7 @@ __all__ = [
     "create_menu",
     "delete_menu",
     "ensure_color_role",
+    "ensure_role",
     "get_binding",
     "get_menu",
     "get_menu_options",

--- a/disbot/utils/role_packs.py
+++ b/disbot/utils/role_packs.py
@@ -1,0 +1,213 @@
+"""Curated role packs for bulk role creation.
+
+Pure data — no DB, no Discord I/O — so every surface reads one catalogue: the
+standalone role-creation panel (:class:`views.roles.creation_panel.RoleCreatePanel`)
+and the role-menu builder (:mod:`views.roles.role_menu_builder`) both offer a
+**📦 Role Packs** flow that mirrors the shipped 🎨 Colours auto-create UX (pick a
+category → multiselect predefined roles → the bot bulk-creates them through the
+audited :class:`services.role_lifecycle_service.RoleLifecycleService`).
+
+This is the *functional* sibling of the colour presets (``_COLOR_OPTIONS``) and
+the gradient gallery (``role_menu_presentation.gradient_presets``): instead of
+colours, a pack is a themed set of common server roles (game roles, staff roles,
+pronouns, notification pings, regions, interests). Like ``ROLE_PRESETS`` they are
+**creation conveniences only** — a starting point an operator picks instead of
+typing each role by hand; they persist nothing until the operator actually
+creates them, and they never touch automation, diagnostics, or any other surface.
+
+Layer note: lives in ``utils/`` (may import stdlib + discord only) so any view
+can import it without crossing a layer boundary. Extend freely — it is plain
+data; keep each pack to ≤25 roles (Discord's select-option cap).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+__all__ = [
+    "PackRole",
+    "RolePack",
+    "get_pack",
+    "packs",
+]
+
+
+@dataclass(frozen=True)
+class PackRole:
+    """One predefined role in a pack — a name + appearance starting point.
+
+    ``color`` is a hex string (e.g. ``"#3498db"``), matching ``RolePreset`` /
+    ``_COLOR_OPTIONS`` so the same ``_parse_color`` helper applies. ``emoji`` is
+    purely decorative — it labels the multiselect option; it is not applied to
+    the created role (role icons need server boosts and are out of scope here).
+    """
+
+    name: str
+    color: str = "#99aab5"  # Discord "greyple" — a neutral default
+    hoist: bool = False
+    emoji: str | None = None
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class RolePack:
+    """A named category of predefined roles shown as one bulk-create choice."""
+
+    key: str
+    label: str  # picker text, e.g. "🎮 Gaming"
+    description: str
+    roles: tuple[PackRole, ...] = field(default_factory=tuple)
+
+
+# Ordered so every picker renders the catalogue deterministically. Curated to be
+# generic (not tied to one server's theme); colours drawn from a readable palette.
+_PACKS: tuple[RolePack, ...] = (
+    RolePack(
+        "gaming",
+        "🎮 Gaming",
+        "Per-game roles members opt into for squads and pings.",
+        roles=(
+            PackRole("Valorant", "#fa4454", emoji="🎯"),
+            PackRole("League of Legends", "#1e90ff", emoji="⚔️"),
+            PackRole("Minecraft", "#5d8a3a", emoji="⛏️"),
+            PackRole("Fortnite", "#7b2ff7", emoji="🛡️"),
+            PackRole("CS2", "#f0a500", emoji="💣"),
+            PackRole("Apex Legends", "#cd3333", emoji="🔺"),
+            PackRole("Overwatch", "#f99e1a", emoji="🟠"),
+            PackRole("Rocket League", "#1f8fff", emoji="🚗"),
+            PackRole("Call of Duty", "#3b3b3b", emoji="🎖️"),
+            PackRole("Among Us", "#c51111", emoji="🔪"),
+            PackRole("Roblox", "#e2231a", emoji="🧱"),
+            PackRole("Genshin Impact", "#4fc3f7", emoji="🌀"),
+        ),
+    ),
+    RolePack(
+        "staff",
+        "🛡️ Staff / Moderation",
+        "Hoisted team roles for server staff.",
+        roles=(
+            PackRole(
+                "Admin",
+                "#e74c3c",
+                hoist=True,
+                emoji="👑",
+                description="Administrator.",
+            ),
+            PackRole(
+                "Moderator",
+                "#3498db",
+                hoist=True,
+                emoji="🛡️",
+                description="Moderation team.",
+            ),
+            PackRole(
+                "Trial Mod",
+                "#5dade2",
+                hoist=True,
+                emoji="🔰",
+                description="Moderator in training.",
+            ),
+            PackRole(
+                "Helper",
+                "#2ecc71",
+                hoist=True,
+                emoji="🤝",
+                description="Community helper.",
+            ),
+            PackRole(
+                "Event Manager",
+                "#9b59b6",
+                hoist=True,
+                emoji="🎉",
+                description="Runs events.",
+            ),
+            PackRole(
+                "Bot Manager",
+                "#1abc9c",
+                hoist=True,
+                emoji="🤖",
+                description="Manages the bots.",
+            ),
+        ),
+    ),
+    RolePack(
+        "pronouns",
+        "🏷️ Pronouns",
+        "Self-assignable pronoun roles.",
+        roles=(
+            PackRole("He/Him", "#3498db", emoji="💙"),
+            PackRole("She/Her", "#e84393", emoji="💗"),
+            PackRole("They/Them", "#2ecc71", emoji="💚"),
+            PackRole("Any Pronouns", "#f1c40f", emoji="💛"),
+            PackRole("Ask Pronouns", "#95a5a6", emoji="❔"),
+        ),
+    ),
+    RolePack(
+        "notifications",
+        "🔔 Notifications",
+        "Opt-in ping roles for announcements and events.",
+        roles=(
+            PackRole("Announcements", "#e67e22", emoji="📣"),
+            PackRole("Events", "#9b59b6", emoji="📅"),
+            PackRole("Giveaways", "#f1c40f", emoji="🎁"),
+            PackRole("Updates", "#3498db", emoji="🆕"),
+            PackRole("Polls", "#1abc9c", emoji="📊"),
+            PackRole("Streams", "#9146ff", emoji="📺"),
+        ),
+    ),
+    RolePack(
+        "region",
+        "🌍 Region",
+        "Where members are based, for timezone-friendly grouping.",
+        roles=(
+            PackRole("North America", "#3498db", emoji="🌎"),
+            PackRole("South America", "#2ecc71", emoji="🌎"),
+            PackRole("Europe", "#9b59b6", emoji="🌍"),
+            PackRole("Asia", "#e74c3c", emoji="🌏"),
+            PackRole("Oceania", "#1abc9c", emoji="🌏"),
+            PackRole("Africa", "#e67e22", emoji="🌍"),
+        ),
+    ),
+    RolePack(
+        "interests",
+        "🎨 Interests",
+        "Hobby and interest roles for finding like-minded members.",
+        roles=(
+            PackRole("Music", "#e74c3c", emoji="🎵"),
+            PackRole("Movies", "#3498db", emoji="🎬"),
+            PackRole("Art", "#9b59b6", emoji="🎨"),
+            PackRole("Anime", "#e84393", emoji="🌸"),
+            PackRole("Sports", "#2ecc71", emoji="⚽"),
+            PackRole("Tech", "#1abc9c", emoji="💻"),
+            PackRole("Books", "#d35400", emoji="📚"),
+            PackRole("Cooking", "#f39c12", emoji="🍳"),
+            PackRole("Photography", "#34495e", emoji="📷"),
+        ),
+    ),
+    RolePack(
+        "platforms",
+        "🕹️ Platforms",
+        "Which platform members play on.",
+        roles=(
+            PackRole("PC", "#5865f2", emoji="🖥️"),
+            PackRole("PlayStation", "#003791", emoji="🎮"),
+            PackRole("Xbox", "#107c10", emoji="🎮"),
+            PackRole("Nintendo Switch", "#e60012", emoji="🎮"),
+            PackRole("Mobile", "#f1c40f", emoji="📱"),
+        ),
+    ),
+)
+
+_PACK_BY_KEY: dict[str, RolePack] = {p.key: p for p in _PACKS}
+
+
+def packs() -> tuple[RolePack, ...]:
+    """Every role pack, in display order."""
+    return _PACKS
+
+
+def get_pack(key: str | None) -> RolePack | None:
+    """Return the pack for ``key``, or ``None`` if unknown/absent."""
+    if not key:
+        return None
+    return _PACK_BY_KEY.get(key)

--- a/disbot/views/roles/_role_pack_flow.py
+++ b/disbot/views/roles/_role_pack_flow.py
@@ -1,0 +1,189 @@
+"""Shared **📦 Role Packs** flow — bulk role creation from a curated catalogue.
+
+Mirrors the 🎨 Colours auto-create UX (``role_menu_builder._ColourRolesView``):
+pick a **category** (gaming / staff / pronouns / …), then a **multiselect** of the
+predefined roles in it, and the bot bulk-creates them in one step (reuse a
+same-named role, else create through the audited
+:func:`services.reaction_role_service.ensure_role` → ``RoleLifecycleService``).
+
+Used by two surfaces so the behaviour is identical on both:
+
+* the standalone role-creation panel (:class:`views.roles.creation_panel.RoleCreatePanel`)
+  — bulk-create roles into the server;
+* the role-menu builder (:mod:`views.roles.role_menu_builder`) — bulk-create **and**
+  add the new roles to the menu draft (pass an ``on_created`` hook).
+
+Layer: a thin UI over the service — no DB writes, no role math here. Authority
+(``manage_roles``) is re-checked at commit time (``.claude/rules/discord-views.md``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+import discord
+
+from core.runtime.interaction_helpers import safe_defer
+from utils import role_packs
+from views.base import BaseView
+from views.roles._helpers import _parse_color
+from views.selectors import attach_multi_select
+
+# Invoked after roles are created/reused, with the resulting role ids — lets the
+# menu builder fold the new roles into its draft. ``None`` = create-only.
+OnRolesReady = Callable[[discord.Interaction, "list[int]"], Awaitable[None]]
+
+
+def _can_manage(interaction: discord.Interaction) -> bool:
+    perms = getattr(interaction.user, "guild_permissions", None)
+    return bool(perms is not None and (perms.manage_roles or perms.administrator))
+
+
+class _PackCategorySelect(discord.ui.Select):
+    """Pick which role pack (category) to create roles from."""
+
+    def __init__(self, flow: RolePackView) -> None:
+        self._flow = flow
+        super().__init__(
+            placeholder="Pick a role pack…",
+            row=0,
+            options=[
+                discord.SelectOption(
+                    label=pack.label[:100],
+                    value=pack.key,
+                    description=(pack.description[:100] or None),
+                )
+                for pack in role_packs.packs()
+            ],
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await self._flow._on_pack(interaction, self.values[0])
+
+
+class RolePackView(BaseView):
+    """Two-step bulk-create flow: pick a pack → multiselect its roles → create."""
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        guild: discord.Guild,
+        *,
+        on_created: OnRolesReady | None = None,
+    ) -> None:
+        super().__init__(author, timeout=180)
+        self.guild = guild
+        self.on_created = on_created
+        self._pack: role_packs.RolePack | None = None
+        self.add_item(_PackCategorySelect(self))
+
+    async def _on_pack(self, interaction: discord.Interaction, key: str) -> None:
+        pack = role_packs.get_pack(key)
+        if pack is None:  # pragma: no cover - select can only emit known keys
+            await safe_defer(interaction)
+            return
+        self._pack = pack
+        self.clear_items()
+        options = [
+            discord.SelectOption(
+                label=role.name[:100],
+                value=role.name,
+                description=(role.description[:100] or None),
+                emoji=role.emoji,
+            )
+            for role in pack.roles
+        ]
+        attach_multi_select(
+            self,
+            options,
+            self._on_roles,
+            placeholder=f"Roles to create from {pack.label}…"[:150],
+            max_values=len(options),
+            select_row=0,
+        )
+        await interaction.response.edit_message(
+            content=(
+                f"Pick the roles to create from **{pack.label}** "
+                "(existing same-named roles are reused, not duplicated):"
+            ),
+            view=self,
+        )
+
+    async def _on_roles(
+        self,
+        interaction: discord.Interaction,
+        values: list[str],
+    ) -> None:
+        await _commit_pack_roles(interaction, self, values)
+
+
+async def _commit_pack_roles(
+    interaction: discord.Interaction,
+    view: RolePackView,
+    names: list[str],
+) -> None:
+    """Create/reuse one role per picked name; report, then run the on_created hook."""
+    from services import reaction_role_service
+
+    if not _can_manage(interaction):
+        await interaction.response.send_message(
+            "You need the **Manage Roles** permission to do that.",
+            ephemeral=True,
+        )
+        return
+    pack = view._pack
+    if pack is None or not names:
+        await interaction.response.send_message(
+            "Pick at least one role.",
+            ephemeral=True,
+        )
+        return
+    # Creating several roles is multiple API calls — defer first, report after.
+    if not await safe_defer(interaction, ephemeral=True, thinking=True):
+        return
+
+    by_name = {role.name: role for role in pack.roles}
+    created: list[str] = []
+    reused: list[str] = []
+    role_ids: list[int] = []
+    notes: list[str] = []
+    for name in names:
+        spec = by_name.get(name)
+        if spec is None:  # pragma: no cover - select only emits catalogue names
+            continue
+        try:
+            color = _parse_color(spec.color)
+        except (ValueError, OverflowError):  # pragma: no cover - constant data
+            color = discord.Color.default()
+        role_id, was_created, note = await reaction_role_service.ensure_role(
+            view.guild,
+            name=spec.name,
+            color=color,
+            hoist=spec.hoist,
+            actor=interaction.user,
+            reason="Bulk role creation (role pack)",
+        )
+        if role_id is None:
+            notes.append(f"{name}: {note or 'could not be created'}")
+            continue
+        role_ids.append(role_id)
+        (created if was_created else reused).append(name)
+        if note:
+            notes.append(f"{name}: {note}")
+
+    parts: list[str] = []
+    if created:
+        parts.append(f"📦 Created {', '.join(created)}")
+    if reused:
+        parts.append(f"♻️ Reused existing {', '.join(reused)}")
+    if notes:
+        parts.append("\n".join(notes))
+    await interaction.followup.send(
+        "\n".join(parts) or "No roles were created.",
+        ephemeral=True,
+    )
+    if view.on_created is not None and role_ids:
+        await view.on_created(interaction, role_ids)
+
+
+__all__ = ["OnRolesReady", "RolePackView"]

--- a/disbot/views/roles/creation_panel.py
+++ b/disbot/views/roles/creation_panel.py
@@ -87,7 +87,9 @@ class RoleCreatePanel(BaseView):
             title="📝 Create a Role",
             description=(
                 "Pick a **name** and a **colour** below, then press **✅ Create** — "
-                "or press **✏️ Custom…** to type your own.\n\n"
+                "or press **✏️ Custom…** to type your own.\n"
+                "Need several at once? **📦 Role Packs** bulk-creates a whole "
+                "category (gaming, staff, pronouns, …) in one step.\n\n"
                 f"**Name:** {self.pending_name or '*(none yet)*'}\n"
                 f"**Colour:** {self.pending_color_label}\n"
                 f"**Shown separately:** {'yes' if self.pending_hoist else 'no'}"
@@ -137,6 +139,34 @@ class RoleCreatePanel(BaseView):
         _: discord.ui.Button,
     ) -> None:
         await interaction.response.send_modal(RoleCreateModal(self.ctx))
+
+    @discord.ui.button(
+        label="📦 Role Packs",
+        style=discord.ButtonStyle.secondary,
+        row=3,
+    )
+    async def packs_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not interaction.user.guild_permissions.manage_roles:  # type: ignore[union-attr]
+            await interaction.response.send_message(
+                "❌ You need **Manage Roles** permission.",
+                ephemeral=True,
+            )
+            return
+        from views.roles._role_pack_flow import RolePackView
+
+        view = RolePackView(interaction.user, interaction.guild)
+        await interaction.response.send_message(
+            content=(
+                "📦 **Bulk-create roles from a pack.** Pick a category, then the "
+                "roles to create — existing same-named roles are reused:"
+            ),
+            view=view,
+            ephemeral=True,
+        )
 
     @discord.ui.button(label="✅ Create", style=discord.ButtonStyle.green, row=2)
     async def create_btn(

--- a/disbot/views/roles/role_menu_builder.py
+++ b/disbot/views/roles/role_menu_builder.py
@@ -616,6 +616,40 @@ class RoleMenuBuilder(BaseView):
             ephemeral=True,
         )
 
+    @discord.ui.button(label="📦 Packs", style=discord.ButtonStyle.grey, row=0)
+    async def packs_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        if not _can_manage(interaction):
+            await _deny(interaction)
+            return
+        from views.roles._role_pack_flow import RolePackView
+
+        view = RolePackView(
+            interaction.user,
+            self.guild,
+            on_created=self._add_pack_roles,
+        )
+        await interaction.response.send_message(
+            "Bulk-create roles from a pack and add them to this menu — pick a "
+            "category, then the roles:",
+            view=view,
+            ephemeral=True,
+        )
+
+    async def _add_pack_roles(
+        self,
+        interaction: discord.Interaction,
+        role_ids: list[int],
+    ) -> None:
+        """on_created hook: fold the newly created pack roles into the draft."""
+        for role_id in role_ids:
+            if role_id not in self.role_ids and len(self.role_ids) < MAX_MENU_ROLES:
+                self.role_ids.append(role_id)
+        await self._rerender()
+
     @discord.ui.button(label="🧩 Template", style=discord.ButtonStyle.grey, row=0)
     async def template_btn(
         self,

--- a/docs/owner/claims/claude__awesome-brahmagupta-md107p.md
+++ b/docs/owner/claims/claude__awesome-brahmagupta-md107p.md
@@ -1,0 +1,1 @@
+- `claude/awesome-brahmagupta-md107p` · bulk role creation via preset packs (category → multiselect → audited bulk create) · `disbot/utils/role_packs.py`, `disbot/views/roles/creation_panel.py`, `disbot/views/roles/role_menu_builder.py`, `disbot/services/reaction_role_service.py` · 2026-06-22

--- a/docs/owner/claims/claude__awesome-brahmagupta-md107p.md
+++ b/docs/owner/claims/claude__awesome-brahmagupta-md107p.md
@@ -1,1 +1,0 @@
-- `claude/awesome-brahmagupta-md107p` · bulk role creation via preset packs (category → multiselect → audited bulk create) · `disbot/utils/role_packs.py`, `disbot/views/roles/creation_panel.py`, `disbot/views/roles/role_menu_builder.py`, `disbot/services/reaction_role_service.py` · 2026-06-22

--- a/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
+++ b/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
@@ -65,6 +65,17 @@
 > creation-side cause was fixed in #1234; this clears rows already left behind. (The Add-modal
 > `💀 ❤️ 😘` placeholder is an intended multi-emote preview and stays.)
 >
+> **▶ Refinement (2026-06-22, owner-relayed user request — PR #1300):** **bulk role creation via
+> preset packs.** Modelled on the 🎨 Colours auto-create flow: pick a **category** (gaming / staff /
+> pronouns / notifications / region / interests / platforms), then a **multiselect of predefined
+> roles**, and the bot bulk-creates them in one step (reuse a same-named role, else create through the
+> audited seam). New pure-data catalogue `utils/role_packs.py` (`RolePack`/`PackRole`); the colour
+> auto-create core generalised to `reaction_role_service.ensure_role` (`ensure_color_role` now delegates,
+> no behaviour change); shared flow `views/roles/_role_pack_flow.RolePackView` surfaced on **two**
+> surfaces — a **📦 Role Packs** button on the standalone `RoleCreatePanel` (bulk-create into the server)
+> and a **📦 Packs** button beside 🎨 Colours in `RoleMenuBuilder` (bulk-create + add to the menu draft).
+> Pure data + UI on the existing audited `RoleLifecycleService` create path; no schema change.
+>
 > **▶ Refinement (2026-06-21 — PR #1250):** **listener self-heal** makes #1248's cleanup automatic —
 > `reaction_role_service._self_heal_dead_binding` drops a binding whose role was deleted the moment a
 > member reacts (or un-reacts) on it, audited as a **`system`** action (an `actor_type` param was

--- a/tests/unit/services/test_reaction_role_service_menus.py
+++ b/tests/unit/services/test_reaction_role_service_menus.py
@@ -434,3 +434,71 @@ async def test_ensure_color_role_falls_back_to_solid_on_gradient_failure():
     assert "solid" in note.lower()
     assert apply_mock.await_count == 2
     assert apply_mock.await_args_list[1].args[1].secondary_color is None
+
+
+# ---------------------------------------------------------------------------
+# ensure_role — the general reuse-or-create seam (bulk role packs)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ensure_role_reuses_existing_same_name_role():
+    guild = SimpleNamespace(id=1, features=[])
+    with patch(
+        "core.runtime.resources.resolve_role",
+        return_value=SimpleNamespace(id=321),
+    ):
+        role_id, created, note = await svc.ensure_role(
+            guild,
+            name="Moderator",
+            color=_PRIMARY,
+            hoist=True,
+            actor=SimpleNamespace(id=9),
+        )
+    assert (role_id, created, note) == (321, False, "")
+
+
+@pytest.mark.asyncio
+async def test_ensure_role_creates_with_hoist_and_no_gradient():
+    guild = SimpleNamespace(id=1, features=[])
+    apply_mock = AsyncMock(return_value=_applied(654))
+    with (
+        patch("core.runtime.resources.resolve_role", return_value=None),
+        patch(
+            "services.role_lifecycle_service.RoleLifecycleService.apply",
+            new=apply_mock,
+        ),
+    ):
+        role_id, created, _ = await svc.ensure_role(
+            guild,
+            name="Valorant",
+            color=_PRIMARY,
+            hoist=True,
+            actor=SimpleNamespace(id=9),
+        )
+    assert (role_id, created) == (654, True)
+    req = apply_mock.await_args.args[1]
+    assert req.operation == "create"
+    assert req.name == "Valorant"
+    assert req.hoist is True
+    assert req.secondary_color is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_role_blank_name_falls_back():
+    guild = SimpleNamespace(id=1, features=[])
+    apply_mock = AsyncMock(return_value=_applied(1))
+    with (
+        patch("core.runtime.resources.resolve_role", return_value=None),
+        patch(
+            "services.role_lifecycle_service.RoleLifecycleService.apply",
+            new=apply_mock,
+        ),
+    ):
+        await svc.ensure_role(
+            guild,
+            name="   ",
+            color=_PRIMARY,
+            actor=SimpleNamespace(id=9),
+        )
+    assert apply_mock.await_args.args[1].name == "role"

--- a/tests/unit/utils/test_role_packs.py
+++ b/tests/unit/utils/test_role_packs.py
@@ -1,0 +1,43 @@
+"""The curated role-pack catalogue (utils.role_packs) is well-formed."""
+
+from __future__ import annotations
+
+import pytest
+
+from utils import role_packs
+from views.roles._helpers import _parse_color
+
+
+def test_packs_nonempty_with_unique_keys():
+    packs = role_packs.packs()
+    assert packs, "the catalogue must offer at least one pack"
+    keys = [p.key for p in packs]
+    assert len(keys) == len(set(keys)), "pack keys must be unique"
+
+
+def test_each_pack_has_roles_within_select_limit():
+    for pack in role_packs.packs():
+        assert pack.roles, f"pack {pack.key!r} has no roles"
+        # Discord's select-option cap (a single multiselect page).
+        assert len(pack.roles) <= 25, f"pack {pack.key!r} exceeds 25 roles"
+        names = [r.name for r in pack.roles]
+        assert len(names) == len(set(names)), f"pack {pack.key!r} has duplicate names"
+
+
+def test_every_pack_role_colour_parses():
+    for pack in role_packs.packs():
+        for role in pack.roles:
+            # A bad hex would raise — the bulk-create flow relies on this.
+            assert _parse_color(role.color) is not None
+
+
+def test_get_pack_resolves_and_handles_unknown():
+    first = role_packs.packs()[0]
+    assert role_packs.get_pack(first.key) is first
+    assert role_packs.get_pack("does-not-exist") is None
+    assert role_packs.get_pack(None) is None
+
+
+@pytest.mark.parametrize("key", ["gaming", "staff", "pronouns"])
+def test_expected_core_packs_present(key: str):
+    assert role_packs.get_pack(key) is not None

--- a/tests/unit/views/test_role_pack_flow.py
+++ b/tests/unit/views/test_role_pack_flow.py
@@ -1,0 +1,108 @@
+"""The shared 📦 Role Packs bulk-create flow (views.roles._role_pack_flow).
+
+CI-safe with no Discord gateway: the category step swaps to a role multiselect,
+and committing creates one role per picked name through the audited
+``ensure_role`` seam, then hands the new ids to the ``on_created`` hook.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from utils import role_packs
+from views.roles import _role_pack_flow
+from views.roles._role_pack_flow import RolePackView
+
+
+def _interaction() -> SimpleNamespace:
+    return SimpleNamespace(
+        user=SimpleNamespace(
+            id=42,
+            guild_permissions=SimpleNamespace(manage_roles=True, administrator=False),
+        ),
+        response=SimpleNamespace(
+            is_done=lambda: False,
+            defer=AsyncMock(),
+            edit_message=AsyncMock(),
+            send_message=AsyncMock(),
+        ),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+
+
+def _view(on_created=None) -> RolePackView:
+    return RolePackView(
+        SimpleNamespace(id=42),
+        SimpleNamespace(id=1),
+        on_created=on_created,
+    )
+
+
+@pytest.mark.asyncio
+async def test_on_pack_swaps_to_role_multiselect() -> None:
+    view = _view()
+    interaction = _interaction()
+    await view._on_pack(interaction, "pronouns")
+    assert view._pack is role_packs.get_pack("pronouns")
+    interaction.response.edit_message.assert_awaited_once()
+    # The category select is gone; a multiselect now occupies the view.
+    assert not any(
+        isinstance(c, _role_pack_flow._PackCategorySelect) for c in view.children
+    )
+
+
+@pytest.mark.asyncio
+async def test_commit_creates_each_role_and_runs_hook() -> None:
+    on_created = AsyncMock()
+    view = _view(on_created=on_created)
+    view._pack = role_packs.get_pack("pronouns")
+    interaction = _interaction()
+
+    ids = iter([101, 102])
+    ensure = AsyncMock(side_effect=lambda *a, **k: (next(ids), True, ""))
+    with patch("services.reaction_role_service.ensure_role", new=ensure):
+        await _role_pack_flow._commit_pack_roles(
+            interaction,
+            view,
+            ["He/Him", "She/Her"],
+        )
+
+    assert ensure.await_count == 2
+    # Names + appearance come straight from the catalogue spec.
+    created_names = {c.kwargs["name"] for c in ensure.await_args_list}
+    assert created_names == {"He/Him", "She/Her"}
+    interaction.response.defer.assert_awaited_once()
+    interaction.followup.send.assert_awaited_once()
+    on_created.assert_awaited_once()
+    assert on_created.await_args.args[1] == [101, 102]
+
+
+@pytest.mark.asyncio
+async def test_commit_requires_manage_roles() -> None:
+    view = _view()
+    view._pack = role_packs.get_pack("pronouns")
+    interaction = _interaction()
+    interaction.user.guild_permissions = SimpleNamespace(
+        manage_roles=False,
+        administrator=False,
+    )
+    ensure = AsyncMock()
+    with patch("services.reaction_role_service.ensure_role", new=ensure):
+        await _role_pack_flow._commit_pack_roles(interaction, view, ["He/Him"])
+    ensure.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_commit_with_no_names_is_a_noop() -> None:
+    view = _view()
+    view._pack = role_packs.get_pack("pronouns")
+    interaction = _interaction()
+    ensure = AsyncMock()
+    with patch("services.reaction_role_service.ensure_role", new=ensure):
+        await _role_pack_flow._commit_pack_roles(interaction, view, [])
+    ensure.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()


### PR DESCRIPTION
## Bulk role creation via preset packs

Owner-relayed user request: add **bulk role creation** modelled on the existing colour-reaction-role flow — pick a category (gaming / moderation / …), then a **multiselect of predefined roles** that match the type, and the bot creates them all in one step.

### What it does
A new **📦 Role Packs** flow that mirrors the shipped 🎨 Colours auto-create UX exactly: **category → multiselect of predefined roles → audited bulk create** (reuse-if-same-name), through the audited `RoleLifecycleService` (the only sanctioned `create_role` caller).

### Surfaces
- **Standalone create** (`RoleCreatePanel`, the `!roles` → 📝 Create panel): bulk-create a pack of roles into the server.
- **Into a menu** (`role_menu_builder`, beside 🎨 Colours): bulk-create + add the pack to the role-menu draft — the literal "colour reaction roles" mirror.

### Pieces
- `disbot/utils/role_packs.py` — pure-data catalogue (`RolePack`/`PackRole` + curated categories), mirroring `role_menu_presentation.py`.
- `reaction_role_service.ensure_role` — generalized reuse-or-create seam; `ensure_color_role` now delegates to it (no behaviour change).
- Builder + creation-panel UI + tests + docs.

Owner-directed (Q-0191): opened ready, auto-merge armed — lands on green.

> **Status:** born-red (`in-progress` session card) until the work is complete; flips to `complete` as the final step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8UXtfQAdPitwWyzYQnvj1)_