### PR TITLE
Bulk role creation enhancements: enlarged multi-select presets, bulk custom roles, optional colour presets

### DIFF
--- a/.sessions/2026-06-22-bulk-role-creation-enhancements.md
+++ b/.sessions/2026-06-22-bulk-role-creation-enhancements.md
@@ -1,29 +1,95 @@
 # 2026-06-22 — Bulk role creation enhancements
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 Owner follow-up to #1300 (bulk role packs). Three asks + "find the most efficient
-way, compare options":
+way, compare options".
 
-1. **Enlarge the standard preset roles** (`ROLE_PRESETS`) **and make them
-   multi-select** (bulk-create several at once).
-2. **Bulk custom-role creation** — type many role names → create them all.
-3. **Optional colour preset select** — pick a colour from a preset list (easy,
-   no hex typing); optional.
+## The comparison (the owner's explicit ask)
 
-## Approach (compared in the response; chosen = reuse the shipped flow)
+How to add multi-select presets + bulk custom + optional colour:
 
-Most efficient = reuse the just-shipped `RolePackView` + `ensure_role`:
-- **Essentials pack** in `role_packs.py` (the enlarged standard roles) → appears in
-  the existing category multiselect for free → "multi-select standard presets".
-  `_helpers.ROLE_PRESETS` derived from it (one data source; single-create panel +
-  test unchanged).
-- **✏️ Custom (bulk)** button on `RolePackView` → names modal (one per line /
-  comma-separated) → **optional** colour preset select (enlarged `_COLOR_OPTIONS`)
-  or "create with no colour" → `ensure_role` loop.
-- Enlarge `_COLOR_OPTIONS` for the preset colour selects.
+| Option | What it is | Verdict |
+|---|---|---|
+| **1 — Extend the single-create panel in place** | convert `_PresetNameSelect` to multi, add custom + colour controls onto `RoleCreatePanel` | ❌ row-budget pressure (panel already near Discord's 5-row limit) **and** muddles the "create one, tweak hoist/colour, add XP automation" flow with multi-select semantics on the same select |
+| **2 — Reuse the shipped `RolePackView` + `ensure_role`** | presets become an ⭐ Essentials *pack* (free multi-select); add a ✏️ Custom-bulk button + optional colour to the same flow | ✅ **chosen** — most code reuse (the create+report+hook tail already exists), clean single-vs-bulk separation, no row pressure, works on both surfaces for free |
+| **3 — Unify everything into the pack catalogue** | make custom-bulk a "pack", one model | ❌ custom names are free text, not catalogue data — doesn't fit the pack model; awkward |
 
-No schema change; pure data + UI on the existing audited create seam. Works on
-both surfaces (creation panel + menu builder) since they share `RolePackView`.
+**Most efficient = Option 2.** It rides infrastructure shipped hours earlier, so
+each ask was a small addition, not a new subsystem.
+
+## Shipped (PR #1302)
+
+1. **Enlarged standard presets, now multi-select** — promoted to the **⭐ Essentials**
+   pack (`utils/role_packs.py`, 6 → 15 roles). `_helpers.ROLE_PRESETS` is now
+   *derived* from that pack — **one data source**, so the single-create dropdown and
+   the multi-select pack can never drift (pinned by a test).
+2. **✏️ Custom (bulk)** on `RolePackView` — a modal takes many names (one per line /
+   comma-separated), `_parse_role_names` splits + case-insensitive-dedups + caps at
+   25, then bulk-creates via `ensure_role`.
+3. **Optional preset colour** — `_COLOR_OPTIONS` enlarged 8 → 20; after typing custom
+   names you pick one colour for the whole batch via a preset select, or **Create with
+   no colour** (default). Optional, exactly as asked.
+- **Refactor:** both bulk paths share one `_create_roles` tail + the `on_created`
+  hook, so everything works on both surfaces (creation panel + menu builder).
+- **Tests:** parse/dedupe/cap, custom-bulk commit (colour applied + hook + default),
+  essentials present, `ROLE_PRESETS` derived from essentials.
+- Gates: `check_quality --full` ✓ (black/isort/ruff + mypy 776 files + 11596 passed),
+  `check_architecture --mode strict` 0 errors, `check_docs --strict` ✓.
 
 Owner-directed (Q-0191): PR ready, auto-merge armed.
+
+## ⚑ Self-initiated
+
+None — all three enhancements + the comparison are owner-requested. The only
+unprompted call was the data-unification (presets *derived from* the Essentials
+pack rather than a parallel list); flagged for visibility — it removes a drift
+class rather than adding scope.
+
+## 💡 Session idea (Q-0089)
+
+**A "preview before create" step for bulk role creation** — before committing a
+pack/custom batch, show a one-embed preview (names + colour swatches + hoist
+flags + which already exist and will be reused) with a Confirm button. The
+data's all in hand at commit time; it would catch "oops, 20 roles with the wrong
+colour" before 20 API calls fire, and reuse the same `_create_roles` tail behind
+a confirm gate. Cheap, and it dovetails with the gated web builder (Surface A),
+where a live preview is expected. Captured, not built (kept this PR tight).
+
+## ⟲ Previous-session review (Q-0102)
+
+Reviewed #1300 (my own prior session — bulk role packs). **Did well:** it
+generalised `ensure_color_role` → `ensure_role` *as it went* instead of copying
+the colour logic, which is exactly why this follow-up was cheap — the seam was
+already there to extend. That's the "leave the next session better-equipped"
+ethos paying off one session later. **Could have done better:** #1300 hard-coded
+the standard presets and the new pack catalogue as **two** separate role lists
+(`ROLE_PRESETS` vs the packs) — a latent drift source the owner's "enlarge the
+presets + make them multi-select" ask walked straight into. This session fixed it
+by deriving one from the other; the lesson worth carrying is **spot the
+"two lists of the same thing" smell at creation time**, not a session later.
+System improvement it surfaces: the same "one data source" instinct could be a
+lightweight check (warn when two module-level catalogues share ≥N identical
+names) — noted as a candidate, not built.
+
+## 🔎 Doc audit (Q-0104)
+
+- `check_quality --full` ✓ · `check_architecture --mode strict` 0 errors ·
+  `check_docs --strict` ✓. The feature is homed on the reaction-roles overhaul
+  plan (this arc's refinement home). Catalogue is self-documenting pure data.
+- `check_current_state_ledger` lag is the benign newest-merge class (Q-0124); the
+  recon pass at #1320 records #1300/#1302. This PR is correctly absent until merged.
+
+## Context delta
+
+- **Confirmed-good pointer:** the CI-parity rule in CLAUDE.md ("CI excludes
+  `tests/` from ruff — don't chase a red signal from running ruff over tests/")
+  was load-bearing this session: ruff flagged 30 `S101`/`ARG005` errors *in the
+  test files*, which would have been a false fix target. `check_quality
+  --check-only` (CI's real scope) was green. The doc note saved a wrong edit —
+  exactly the trap it warns about.
+- **Black↔ruff trailing-comma tension** recurred (same as #1300): fix order is
+  `ruff --fix` then `black`. Still worth a one-line CLAUDE.md CI-parity note
+  (recorded, not self-edited — Q-0106).
+- **Pointed to but not needed:** CodeGraph — pattern-mirroring extension of files
+  I'd just written; `context_map.py` + the prior session's mental model carried it.

--- a/.sessions/2026-06-22-bulk-role-creation-enhancements.md
+++ b/.sessions/2026-06-22-bulk-role-creation-enhancements.md
@@ -1,0 +1,29 @@
+# 2026-06-22 — Bulk role creation enhancements
+
+> **Status:** `in-progress`
+
+Owner follow-up to #1300 (bulk role packs). Three asks + "find the most efficient
+way, compare options":
+
+1. **Enlarge the standard preset roles** (`ROLE_PRESETS`) **and make them
+   multi-select** (bulk-create several at once).
+2. **Bulk custom-role creation** — type many role names → create them all.
+3. **Optional colour preset select** — pick a colour from a preset list (easy,
+   no hex typing); optional.
+
+## Approach (compared in the response; chosen = reuse the shipped flow)
+
+Most efficient = reuse the just-shipped `RolePackView` + `ensure_role`:
+- **Essentials pack** in `role_packs.py` (the enlarged standard roles) → appears in
+  the existing category multiselect for free → "multi-select standard presets".
+  `_helpers.ROLE_PRESETS` derived from it (one data source; single-create panel +
+  test unchanged).
+- **✏️ Custom (bulk)** button on `RolePackView` → names modal (one per line /
+  comma-separated) → **optional** colour preset select (enlarged `_COLOR_OPTIONS`)
+  or "create with no colour" → `ensure_role` loop.
+- Enlarge `_COLOR_OPTIONS` for the preset colour selects.
+
+No schema change; pure data + UI on the existing audited create seam. Works on
+both surfaces (creation panel + menu builder) since they share `RolePackView`.
+
+Owner-directed (Q-0191): PR ready, auto-merge armed.

--- a/disbot/utils/role_packs.py
+++ b/disbot/utils/role_packs.py
@@ -63,6 +63,78 @@ class RolePack:
 # generic (not tied to one server's theme); colours drawn from a readable palette.
 _PACKS: tuple[RolePack, ...] = (
     RolePack(
+        "essentials",
+        "⭐ Essentials",
+        "Common server roles — a general starter set (the standard presets).",
+        roles=(
+            PackRole("Member", "#2ecc71", emoji="🙂", description="General member."),
+            PackRole(
+                "Verified",
+                "#1abc9c",
+                emoji="✅",
+                description="Passed verification.",
+            ),
+            PackRole("Newcomer", "#95a5a6", emoji="🌱", description="Just joined."),
+            PackRole("Active", "#3498db", emoji="⚡", description="Active member."),
+            PackRole("Regular", "#9b59b6", emoji="🔆", description="Long-time member."),
+            PackRole(
+                "VIP",
+                "#f1c40f",
+                hoist=True,
+                emoji="💎",
+                description="Supporter / VIP — shown separately.",
+            ),
+            PackRole(
+                "Supporter",
+                "#e91e63",
+                emoji="💖",
+                description="Supports the server.",
+            ),
+            PackRole(
+                "Content Creator",
+                "#e67e22",
+                emoji="🎥",
+                description="Streams / makes content.",
+            ),
+            PackRole("DJ", "#1abc9c", emoji="🎧", description="Music DJ."),
+            PackRole("Bot", "#5865f2", emoji="🤖", description="Bot account."),
+            PackRole(
+                "Helper",
+                "#2ecc71",
+                hoist=True,
+                emoji="🤝",
+                description="Community helper.",
+            ),
+            PackRole(
+                "Event Host",
+                "#9b59b6",
+                hoist=True,
+                emoji="🎉",
+                description="Runs events.",
+            ),
+            PackRole(
+                "Moderator",
+                "#3498db",
+                hoist=True,
+                emoji="🛡️",
+                description="Moderation team.",
+            ),
+            PackRole(
+                "Admin",
+                "#e74c3c",
+                hoist=True,
+                emoji="👑",
+                description="Administrator.",
+            ),
+            PackRole(
+                "Muted",
+                "#607d8b",
+                emoji="🔇",
+                description="Restricted (used by moderation).",
+            ),
+        ),
+    ),
+    RolePack(
         "gaming",
         "🎮 Gaming",
         "Per-game roles members opt into for squads and pings.",

--- a/disbot/views/roles/_helpers.py
+++ b/disbot/views/roles/_helpers.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 
 import discord
 
+from utils import role_packs
 from views.selectors._resource_helpers import _find_role_normalized
 
 __all__ = [
@@ -36,11 +37,23 @@ __all__ = [
 
 _COLOR_OPTIONS = [
     ("Red", "#e74c3c"),
-    ("Blue", "#3498db"),
-    ("Green", "#2ecc71"),
-    ("Yellow", "#f1c40f"),
-    ("Purple", "#9b59b6"),
+    ("Crimson", "#c0392b"),
     ("Orange", "#e67e22"),
+    ("Gold", "#f1c40f"),
+    ("Yellow", "#ffeb3b"),
+    ("Lime", "#a4d007"),
+    ("Green", "#2ecc71"),
+    ("Emerald", "#1abc9c"),
+    ("Teal", "#009688"),
+    ("Cyan", "#00bcd4"),
+    ("Blue", "#3498db"),
+    ("Blurple", "#5865f2"),
+    ("Navy", "#34495e"),
+    ("Purple", "#9b59b6"),
+    ("Magenta", "#e91e63"),
+    ("Pink", "#ff79c6"),
+    ("Brown", "#795548"),
+    ("Grey", "#95a5a6"),
     ("White", "#ffffff"),
     ("Black", "#000000"),
 ]
@@ -65,31 +78,15 @@ class RolePreset:
     description: str = ""
 
 
-# A small, generic starter set — common server roles, not tied to any one
-# server's theme.  "A few presets" (owner constraint); extend freely.  Colours
-# are drawn from the same palette as ``_COLOR_OPTIONS``.
+# The quick-create presets ARE the ⭐ Essentials role pack (``utils.role_packs``)
+# — one data source, so enlarging the pack enlarges this single-create dropdown
+# too (and the bulk-create flow shows the same names as a multiselect). Converted
+# to ``RolePreset`` for the creation menu's name+colour staging, which only reads
+# name / color / hoist / description. Extend via the pack, not here.
+_ESSENTIALS = role_packs.get_pack("essentials")
 ROLE_PRESETS: list[RolePreset] = [
-    RolePreset("Member", "#2ecc71", description="General member."),
-    RolePreset("Verified", "#1abc9c", description="Passed verification."),
-    RolePreset(
-        "VIP",
-        "#f1c40f",
-        hoist=True,
-        description="Supporter / VIP — shown separately.",
-    ),
-    RolePreset(
-        "Moderator",
-        "#3498db",
-        hoist=True,
-        description="Staff — shown separately.",
-    ),
-    RolePreset(
-        "Admin",
-        "#e74c3c",
-        hoist=True,
-        description="Administrator — shown separately.",
-    ),
-    RolePreset("Muted", "#607d8b", description="Restricted (used by moderation)."),
+    RolePreset(r.name, r.color, hoist=r.hoist, description=r.description)
+    for r in (_ESSENTIALS.roles if _ESSENTIALS else ())
 ]
 
 

--- a/disbot/views/roles/_role_pack_flow.py
+++ b/disbot/views/roles/_role_pack_flow.py
@@ -19,6 +19,7 @@ Layer: a thin UI over the service — no DB writes, no role math here. Authority
 
 from __future__ import annotations
 
+import re
 from collections.abc import Awaitable, Callable
 
 import discord
@@ -26,7 +27,7 @@ import discord
 from core.runtime.interaction_helpers import safe_defer
 from utils import role_packs
 from views.base import BaseView
-from views.roles._helpers import _parse_color
+from views.roles._helpers import _COLOR_OPTIONS, _parse_color
 from views.selectors import attach_multi_select
 
 # Invoked after roles are created/reused, with the resulting role ids — lets the
@@ -77,6 +78,25 @@ class RolePackView(BaseView):
         self._pack: role_packs.RolePack | None = None
         self.add_item(_PackCategorySelect(self))
 
+    @discord.ui.button(
+        label="✏️ Custom (bulk)",
+        style=discord.ButtonStyle.blurple,
+        row=1,
+    )
+    async def custom_bulk_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        """Type several custom role names → optional colour → bulk-create them."""
+        if not _can_manage(interaction):
+            await interaction.response.send_message(
+                "You need the **Manage Roles** permission to do that.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_modal(_CustomBulkModal(self))
+
     async def _on_pack(self, interaction: discord.Interaction, key: str) -> None:
         pack = role_packs.get_pack(key)
         if pack is None:  # pragma: no cover - select can only emit known keys
@@ -122,9 +142,7 @@ async def _commit_pack_roles(
     view: RolePackView,
     names: list[str],
 ) -> None:
-    """Create/reuse one role per picked name; report, then run the on_created hook."""
-    from services import reaction_role_service
-
+    """Create/reuse one role per picked pack name; report + run the on_created hook."""
     if not _can_manage(interaction):
         await interaction.response.send_message(
             "You need the **Manage Roles** permission to do that.",
@@ -138,15 +156,8 @@ async def _commit_pack_roles(
             ephemeral=True,
         )
         return
-    # Creating several roles is multiple API calls — defer first, report after.
-    if not await safe_defer(interaction, ephemeral=True, thinking=True):
-        return
-
     by_name = {role.name: role for role in pack.roles}
-    created: list[str] = []
-    reused: list[str] = []
-    role_ids: list[int] = []
-    notes: list[str] = []
+    specs: list[tuple[str, discord.Color, bool]] = []
     for name in names:
         spec = by_name.get(name)
         if spec is None:  # pragma: no cover - select only emits catalogue names
@@ -155,13 +166,177 @@ async def _commit_pack_roles(
             color = _parse_color(spec.color)
         except (ValueError, OverflowError):  # pragma: no cover - constant data
             color = discord.Color.default()
+        specs.append((spec.name, color, spec.hoist))
+    await _create_roles(interaction, view, specs, reason="Bulk role creation (pack)")
+
+
+# ---------------------------------------------------------------------------
+# Custom bulk creation — type many names, optional preset colour
+# ---------------------------------------------------------------------------
+
+
+def _parse_role_names(raw: str, *, limit: int = 25) -> list[str]:
+    """Split free-text into role names (one per line / comma-separated), deduped.
+
+    Case-insensitive de-dup preserving first-seen order; names capped at 100
+    chars (Discord's limit) and the batch capped at ``limit`` (extras dropped).
+    """
+    seen: set[str] = set()
+    names: list[str] = []
+    for part in re.split(r"[\n,]+", raw or ""):
+        name = part.strip()[:100]
+        if not name:
+            continue
+        key = name.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        names.append(name)
+        if len(names) >= limit:
+            break
+    return names
+
+
+class _CustomBulkModal(discord.ui.Modal, title="Bulk-create custom roles"):  # type: ignore[call-arg]
+    """Collect several custom role names, then offer an optional preset colour."""
+
+    names_in = discord.ui.TextInput(  # type: ignore[var-annotated]
+        label="Role names",
+        style=discord.TextStyle.paragraph,
+        placeholder="One per line, or comma-separated — e.g.\nArtist\nWriter, Gamer",
+        max_length=2000,
+    )
+
+    def __init__(self, flow: RolePackView) -> None:
+        super().__init__()
+        self.flow = flow
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        names = _parse_role_names(self.names_in.value)
+        if not names:
+            await interaction.response.send_message(
+                "❌ Enter at least one role name.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_message(
+            content=(
+                f"Creating **{len(names)}** role(s): {', '.join(names)[:1500]}\n\n"
+                "Pick a colour for them (optional), or **Create with no colour**:"
+            ),
+            view=_BulkColourView(self.flow, names),
+            ephemeral=True,
+        )
+
+
+class _ColourPresetSelect(discord.ui.Select):
+    """Single-pick preset colour applied to every custom role in the batch."""
+
+    def __init__(self, view: _BulkColourView) -> None:
+        self._view = view
+        super().__init__(
+            placeholder="Pick a colour for these roles (optional)…",
+            row=0,
+            max_values=1,
+            options=[
+                discord.SelectOption(label=label, value=hex_value)
+                for label, hex_value in _COLOR_OPTIONS
+            ],
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        try:
+            color = _parse_color(self.values[0])
+        except (ValueError, OverflowError):  # pragma: no cover - constant data
+            color = None
+        await _commit_custom_roles(interaction, self._view, color)
+
+
+class _BulkColourView(BaseView):
+    """Optional preset-colour picker for a batch of custom roles."""
+
+    def __init__(self, flow: RolePackView, names: list[str]) -> None:
+        super().__init__(flow._author, timeout=180)
+        self.flow = flow
+        self.names = names
+        self.add_item(_ColourPresetSelect(self))
+
+    @discord.ui.button(
+        label="Create with no colour",
+        style=discord.ButtonStyle.grey,
+        row=1,
+    )
+    async def no_colour_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await _commit_custom_roles(interaction, self, None)
+
+
+async def _commit_custom_roles(
+    interaction: discord.Interaction,
+    view: _BulkColourView,
+    color: discord.Color | None,
+) -> None:
+    """Bulk-create the typed custom names with one shared colour (or default)."""
+    if not _can_manage(interaction):
+        await interaction.response.send_message(
+            "You need the **Manage Roles** permission to do that.",
+            ephemeral=True,
+        )
+        return
+    specs = [(name, color or discord.Color.default(), False) for name in view.names]
+    await _create_roles(
+        interaction,
+        view.flow,
+        specs,
+        reason="Bulk role creation (custom)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared creator
+# ---------------------------------------------------------------------------
+
+
+async def _create_roles(
+    interaction: discord.Interaction,
+    flow: RolePackView,
+    specs: list[tuple[str, discord.Color, bool]],
+    *,
+    reason: str,
+) -> None:
+    """Create/reuse each ``(name, colour, hoist)`` spec; report + run on_created.
+
+    The shared tail of both bulk paths (pack picks + custom names): defer (several
+    role creations are multiple API calls), create through the audited
+    ``ensure_role`` seam, report created/reused/failed, then fold the new ids into
+    the menu draft via the optional ``on_created`` hook.
+    """
+    from services import reaction_role_service
+
+    if not specs:
+        await interaction.response.send_message(
+            "Nothing to create.",
+            ephemeral=True,
+        )
+        return
+    if not await safe_defer(interaction, ephemeral=True, thinking=True):
+        return
+
+    created: list[str] = []
+    reused: list[str] = []
+    role_ids: list[int] = []
+    notes: list[str] = []
+    for name, color, hoist in specs:
         role_id, was_created, note = await reaction_role_service.ensure_role(
-            view.guild,
-            name=spec.name,
+            flow.guild,
+            name=name,
             color=color,
-            hoist=spec.hoist,
+            hoist=hoist,
             actor=interaction.user,
-            reason="Bulk role creation (role pack)",
+            reason=reason,
         )
         if role_id is None:
             notes.append(f"{name}: {note or 'could not be created'}")
@@ -182,8 +357,8 @@ async def _commit_pack_roles(
         "\n".join(parts) or "No roles were created.",
         ephemeral=True,
     )
-    if view.on_created is not None and role_ids:
-        await view.on_created(interaction, role_ids)
+    if flow.on_created is not None and role_ids:
+        await flow.on_created(interaction, role_ids)
 
 
 __all__ = ["OnRolesReady", "RolePackView"]

--- a/disbot/views/roles/creation_panel.py
+++ b/disbot/views/roles/creation_panel.py
@@ -161,8 +161,9 @@ class RoleCreatePanel(BaseView):
         view = RolePackView(interaction.user, interaction.guild)
         await interaction.response.send_message(
             content=(
-                "📦 **Bulk-create roles from a pack.** Pick a category, then the "
-                "roles to create — existing same-named roles are reused:"
+                "📦 **Bulk-create roles.** Pick a category and multiselect its "
+                "roles, or **✏️ Custom (bulk)** to type your own names with an "
+                "optional preset colour — existing same-named roles are reused:"
             ),
             view=view,
             ephemeral=True,

--- a/disbot/views/roles/role_menu_builder.py
+++ b/disbot/views/roles/role_menu_builder.py
@@ -633,8 +633,8 @@ class RoleMenuBuilder(BaseView):
             on_created=self._add_pack_roles,
         )
         await interaction.response.send_message(
-            "Bulk-create roles from a pack and add them to this menu — pick a "
-            "category, then the roles:",
+            "Bulk-create roles and add them to this menu — pick a category and "
+            "multiselect its roles, or **✏️ Custom (bulk)** to type your own:",
             view=view,
             ephemeral=True,
         )

--- a/docs/owner/claims/claude__bulk-role-creation-enhancements.md
+++ b/docs/owner/claims/claude__bulk-role-creation-enhancements.md
@@ -1,0 +1,1 @@
+- `claude/bulk-role-creation-enhancements` · bulk-create enhancements: enlarge standard presets + make them multi-select (⭐ Essentials pack), bulk custom-role creation, optional colour preset select · `disbot/utils/role_packs.py`, `disbot/views/roles/_helpers.py`, `disbot/views/roles/_role_pack_flow.py` · 2026-06-22

--- a/docs/owner/claims/claude__bulk-role-creation-enhancements.md
+++ b/docs/owner/claims/claude__bulk-role-creation-enhancements.md
@@ -1,1 +1,0 @@
-- `claude/bulk-role-creation-enhancements` · bulk-create enhancements: enlarge standard presets + make them multi-select (⭐ Essentials pack), bulk custom-role creation, optional colour preset select · `disbot/utils/role_packs.py`, `disbot/views/roles/_helpers.py`, `disbot/views/roles/_role_pack_flow.py` · 2026-06-22

--- a/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
+++ b/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
@@ -76,6 +76,16 @@
 > and a **📦 Packs** button beside 🎨 Colours in `RoleMenuBuilder` (bulk-create + add to the menu draft).
 > Pure data + UI on the existing audited `RoleLifecycleService` create path; no schema change.
 >
+> **▶ Refinement (2026-06-22, owner follow-up — PR #1302):** **bulk-create enhancements** (built on
+> #1300's `RolePackView` + `ensure_role` — the most-efficient option, no new subsystem). (1) The
+> standard presets were **enlarged and made multi-select** by promoting them to the **⭐ Essentials**
+> pack in `utils/role_packs.py`; `_helpers.ROLE_PRESETS` is now *derived* from that pack (one data
+> source — the single-create dropdown and the multi-select pack never drift). (2) **✏️ Custom (bulk)**
+> on `RolePackView` — type many names (one per line / comma-separated, deduped + capped) → bulk-create.
+> (3) An **optional preset colour select** (`_COLOR_OPTIONS` enlarged 8 → 20) applied to the whole
+> custom batch, or "create with no colour". Both bulk paths share one `_create_roles` tail and the
+> `on_created` hook, so they work on both surfaces (creation panel + menu builder).
+>
 > **▶ Refinement (2026-06-21 — PR #1250):** **listener self-heal** makes #1248's cleanup automatic —
 > `reaction_role_service._self_heal_dead_binding` drops a binding whose role was deleted the moment a
 > member reacts (or un-reacts) on it, audited as a **`system`** action (an `actor_type` param was

--- a/tests/unit/utils/test_role_packs.py
+++ b/tests/unit/utils/test_role_packs.py
@@ -38,6 +38,19 @@ def test_get_pack_resolves_and_handles_unknown():
     assert role_packs.get_pack(None) is None
 
 
-@pytest.mark.parametrize("key", ["gaming", "staff", "pronouns"])
+@pytest.mark.parametrize("key", ["essentials", "gaming", "staff", "pronouns"])
 def test_expected_core_packs_present(key: str):
     assert role_packs.get_pack(key) is not None
+
+
+def test_role_presets_are_derived_from_the_essentials_pack():
+    """The single-create dropdown (`ROLE_PRESETS`) and the multi-select Essentials
+    pack share one data source, so they never drift apart.
+    """
+    from views.roles._helpers import ROLE_PRESETS
+
+    essentials = role_packs.get_pack("essentials")
+    assert essentials is not None
+    assert [p.name for p in ROLE_PRESETS] == [r.name for r in essentials.roles]
+    # Enlarged well past the original six-name starter set.
+    assert len(ROLE_PRESETS) >= 10

--- a/tests/unit/views/test_role_pack_flow.py
+++ b/tests/unit/views/test_role_pack_flow.py
@@ -106,3 +106,60 @@ async def test_commit_with_no_names_is_a_noop() -> None:
         await _role_pack_flow._commit_pack_roles(interaction, view, [])
     ensure.assert_not_awaited()
     interaction.response.send_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Custom bulk creation
+# ---------------------------------------------------------------------------
+
+
+def test_parse_role_names_splits_dedups_and_caps() -> None:
+    raw = "Artist\nWriter, Gamer\n artist \n\nWriter"
+    # newlines + commas split; case-insensitive dedup; first-seen order kept.
+    assert _role_pack_flow._parse_role_names(raw) == ["Artist", "Writer", "Gamer"]
+    # batch cap drops extras.
+    many = ",".join(f"R{i}" for i in range(40))
+    assert len(_role_pack_flow._parse_role_names(many, limit=25)) == 25
+    assert _role_pack_flow._parse_role_names("   \n , ") == []
+
+
+@pytest.mark.asyncio
+async def test_custom_bulk_commit_applies_colour_and_runs_hook() -> None:
+    import discord
+
+    on_created = AsyncMock()
+    flow = _view(on_created=on_created)
+    bulk = _role_pack_flow._BulkColourView(flow, ["Artist", "Writer"])
+    interaction = _interaction()
+
+    ids = iter([201, 202])
+    ensure = AsyncMock(side_effect=lambda *a, **k: (next(ids), True, ""))
+    with patch("services.reaction_role_service.ensure_role", new=ensure):
+        await _role_pack_flow._commit_custom_roles(
+            interaction,
+            bulk,
+            discord.Color(0x3498DB),
+        )
+
+    assert ensure.await_count == 2
+    names = [c.kwargs["name"] for c in ensure.await_args_list]
+    assert names == ["Artist", "Writer"]
+    # The chosen preset colour is applied to every role in the batch.
+    assert all(
+        c.kwargs["color"] == discord.Color(0x3498DB) for c in ensure.await_args_list
+    )
+    on_created.assert_awaited_once()
+    assert on_created.await_args.args[1] == [201, 202]
+
+
+@pytest.mark.asyncio
+async def test_custom_bulk_commit_no_colour_uses_default() -> None:
+    import discord
+
+    flow = _view()
+    bulk = _role_pack_flow._BulkColourView(flow, ["Artist"])
+    interaction = _interaction()
+    ensure = AsyncMock(return_value=(301, True, ""))
+    with patch("services.reaction_role_service.ensure_role", new=ensure):
+        await _role_pack_flow._commit_custom_roles(interaction, bulk, None)
+    assert ensure.await_args.kwargs["color"] == discord.Color.default()


### PR DESCRIPTION
Owner follow-up to #1300. Three enhancements, built on the shipped `RolePackView` + `ensure_role` seam (most-efficient option — see the comparison in the chat):

1. **Enlarged standard presets, now multi-select** — the standard roles become an **⭐ Essentials** pack, so they're multi-select via the existing pack flow; `ROLE_PRESETS` is derived from it (one data source; single-create panel unchanged).
2. **Bulk custom-role creation** — a **✏️ Custom (bulk)** entry: type many names (one per line / comma-separated) → create them all.
3. **Optional colour preset select** — after typing custom names, optionally pick a colour from an enlarged preset palette (no hex typing), or create with no colour.

No schema change; pure data + UI on the existing audited create path. Works on both surfaces (creation panel + menu builder) since they share `RolePackView`.

Owner-directed (Q-0191): opened ready, auto-merge armed.

> **Status:** born-red (`in-progress` card) until complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8UXtfQAdPitwWyzYQnvj1)_