### PR TITLE
botsite React-SPA migration PR 1 — buildable, data-fed React app (foundation)

### DIFF
--- a/.github/workflows/design-system-ci.yml
+++ b/.github/workflows/design-system-ci.yml
@@ -53,5 +53,11 @@ jobs:
       - name: Type-check (tsc --noEmit)
         run: npm run typecheck
 
+      - name: Test (vitest — data adapter)
+        run: npm test
+
       - name: Build (tsup + tailwind)
         run: npm run build
+
+      - name: Build SPA app (vite build:app)
+        run: npm run build:app

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ build/
 ########################################
 node_modules/
 storybook-static/
+dist-app/
 *.tsbuildinfo
 
 ########################################

--- a/.sessions/2026-06-22-botsite-react-spa-pr1.md
+++ b/.sessions/2026-06-22-botsite-react-spa-pr1.md
@@ -1,7 +1,8 @@
 # 2026-06-22 — botsite React-SPA migration PR 1 (foundation: a buildable, data-fed React app)
 
-> **Status:** `in-progress` — born-red card (Q-0133). Flips to `complete` as the final step.
+> **Status:** `complete` — born-red card (Q-0133) flipped green as the final step.
 > Routine · dispatch (scheduled fire, no work order → advance the next S1 plan slice).
+> PR #1305 → auto-merges on green (Q-0123/Q-0191; owner-requested plan lane, not held for review).
 
 ## Arc (what I'm about to do)
 
@@ -37,10 +38,75 @@ This PR (foundation only — no cutover):
 BUG-0023 command-count *breakdown in the public data* (touches the redaction contract — its own
 slice). PR 1 leaves visitors on the vanilla SPA.
 
-## Shipped
+## Shipped (PR #1305)
 
-_(filled at close)_
+- **App shell + hash router** — `design-system/src/app/{main,App}.tsx`. `routeFromHash`
+  (pure, in `data.ts`) maps `#/`, `#/features`, `#/commands`, `#/games`, `#/changelog`,
+  `#/status`; detail hashes (`#/command/foo` …) fall back to their parent list; unknown → home.
+  Each route renders the existing page component with mapped props. `#/games` reuses
+  FeaturesPage with the game catalogue only (a dedicated GamesPage is a PR 2+ component).
+- **Data adapter** — `design-system/src/app/data.ts`: a typed `SiteData` (the `/site-data.json`
+  shape) + pure `to{Landing,Features,Games,Commands,Changelog,Status}Props` mappers +
+  `loadSiteData()` (fetch with a bundled-sample fallback on any failure). The real
+  `ADD_TO_DISCORD_URL` threads onto every page's `addUrl` → the dead `#/` "Add to Discord"
+  CTA is fixed at the data seam.
+- **Build target** — `index.html` + `vite.config.ts`; `build:app` (Vite) → static `dist-app/`
+  (gitignored — PR 2 commits/serves it). The tsup library `build` (dist/, the `/design-sync`
+  artifacts) is untouched and still green.
+- **`GET /site-data.json`** (`botsite/app.py`) — `build_prototype_data` shape +
+  `build`/`counts`/`addUrl`, as pure JSON. No new `disbot/` coupling; same public subset &
+  redaction posture as `/data.js`.
+- **Tests/CI** — `src/app/data.test.ts` (13 vitest cases: route mapping, every mapper,
+  install-URL threading, loader fallback) + `test_site_data_json_is_truthful_for_the_react_app`
+  (botsite). `tsc --noEmit` covers `src/app/`; `design-system-ci.yml` runs `npm test` + `build:app`.
+- **Verification:** `npm run typecheck` ✓ · `npm test` 13/13 ✓ · `npm run build:app` ✓ ·
+  `npm run build` (library) ✓ · `npm ci` lock in sync ✓ · botsite tests 13/13 ✓ ·
+  `check_architecture --mode strict` (no new warnings) · `check_quality --check-only` ✓ ·
+  `check_docs --strict` ✓.
+
+**Deferred (PR 2/3):** serve the React bundle from `botsite/` + cutover; per-detail routes +
+a dedicated GamesPage; the BUG-0023 command-count *breakdown in the public data* (touches the
+`SITE_FIELD_CONTRACT` redaction guard — its own focused slice).
 
 ## Session enders
 
-_(filled at close)_
+- **♻ Grooming (Q-0015):** advanced the botsite React-SPA migration plan down its lifecycle —
+  PR 1 (foundation) now real; PR 2 (serve + cutover) is the next ▶ startable on the S1 sector
+  file, which I de-staled (PR 1 moved to "In flight").
+- **💡 Session idea (Q-0089):** *A `site-data` ↔ page-props contract guard.* The adapter maps a
+  JSON payload onto strongly-typed page props, but a field the Python `/site-data.json` route
+  renames/drops would only surface as a silent `undefined` at runtime (the pages fall back to
+  sample defaults, masking it). Idea: a tiny CI check (botsite + design-system) that asserts the
+  `/site-data.json` keys the route emits == the keys `data.ts` reads — the design↔data contract
+  the plan §6 flags, made executable. Cheap; logged here (not yet an idea file — promote if PR 2
+  makes the contract load-bearing).
+- **⟲ Previous-session review:** the fishing-PR3 session (#1301) modelled exactly the discipline
+  this repo wants — a born-red card, a clearly-scoped "deferred to PR4+" list, and a *forward seam*
+  (PR2 left `escape_resist` defaulted-0 so PR3 turned it with zero churn). Its own review note —
+  *pin invariants on behaviour, not module shape* — is a genuinely reusable rule. **One thing it
+  (and the fishing arc) could do better:** four single-slice PRs in a day on one minigame is a lot
+  of merge/CI overhead for tightly-coupled work; some of those slices (rod ladder + energy pacing)
+  could have been one PR. **System note:** the "small PRs for risky runtime" rule (CLAUDE.md) is
+  right, but *sequential same-file slices* that each rev the same workflow/migration chain pay the
+  full CI cost N times — worth a journal note that closely-coupled game slices can batch when the
+  blast radius is one cog + its pure-domain module.
+- **🧾 Doc audit (Q-0104):** `check_docs --strict` ✓; S1 sector file de-staled (PR 1 in-flight,
+  PR 2 next); ledger auto-updates on merge (the recently-shipped reconciliation routine owns it).
+  Nothing left only in chat. The plan's PR-1 §4 checklist is fully covered (per-detail routes +
+  cutover were always PR 2/3, not PR 1).
+
+## ⚑ Self-initiated: none — this advances an owner-requested, owner-approved plan lane
+   (botsite React-SPA migration, the plan's PR 1). The empty scheduled fire → "advance the next
+   non-gated plan slice" is the dispatch routine's standing instruction, not an unprompted feature.
+   The two in-PR design picks (hash router over `react-router-dom`; `#/games` reusing FeaturesPage
+   until a GamesPage exists) are implementation choices within the plan, flagged in the PR.
+
+## 📤 Run report
+
+- **Did:** built the botsite React-SPA migration **PR 1** — a runnable, routable, data-fed React app (the foundation that removes the manual React→vanilla port). · **Outcome:** shipped
+- **Shipped:** #1305 — `design-system/src/app/` (hash router + page wiring), `data.ts` adapter + 13 vitest cases, `build:app` → `dist-app/`, botsite `GET /site-data.json` + test, design-system CI runs vitest + build:app. Additive — live vanilla SPA untouched.
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** `none` (a merge auto-deploys; PR 2 handles the live cutover)
+- **⚑ Self-initiated:** `none` — advances the owner-requested/approved botsite-react-spa-migration plan (its PR 1)
+- **↪ Next:** botsite React-SPA migration **PR 2** — serve the built React bundle from `botsite/` (CI build → `botsite/site/`, avoid the `static/` #970 gotcha) + keep the vanilla SPA/Jinja as a one-band fallback, flip `/` to React last. Per-detail routes + a GamesPage component, and the BUG-0023 count-breakdown-in-data slice, remain. Project Moon runtime PR 1 (ingestion — network + IP/licensing-sensitive, weigh ask-first) is the other S1 lane.

--- a/.sessions/2026-06-22-botsite-react-spa-pr1.md
+++ b/.sessions/2026-06-22-botsite-react-spa-pr1.md
@@ -1,0 +1,46 @@
+# 2026-06-22 — botsite React-SPA migration PR 1 (foundation: a buildable, data-fed React app)
+
+> **Status:** `in-progress` — born-red card (Q-0133). Flips to `complete` as the final step.
+> Routine · dispatch (scheduled fire, no work order → advance the next S1 plan slice).
+
+## Arc (what I'm about to do)
+
+Empty scheduled dispatch fire. Fishing PR4 (#1304) and reaction-roles PR6 (#1279) are in
+flight (not mine). S2 is creds-gated; the procedures→skills batch edits CLAUDE.md (Q-0106,
+owner-review territory). The cleanest non-gated high-value S1 startable item is the
+**botsite React-SPA migration** ([plan](../docs/planning/botsite-react-spa-migration-plan-2026-06-20.md))
+— owner-requested, removes the manual "port React → vanilla SPA" step. Building **PR 1**
+(additive, the live vanilla SPA stays serving until PR 2).
+
+This PR (foundation only — no cutover):
+1. **App shell + hash router** — `design-system/src/app/` (`main.tsx` + `App.tsx`) routing the
+   existing page components: `#/` → LandingPage · `#/features` → FeaturesPage · `#/commands` →
+   CommandsPage · `#/games` → games view (FeaturesPage games group) · `#/changelog` →
+   ChangelogPage · `#/status` → StatusPage. Hash router (matches the SPA URL scheme; no server
+   route changes).
+2. **Data adapter** — `design-system/src/app/data.ts`: `fetch()` the live `/site-data.json`,
+   map the SBDATA shape (`areas/commands/games/changelog/status` + `addUrl`) onto each page's
+   props. Pure mappers + a bundled sample for fallback/tests.
+3. **Install URL fix** — thread the real `ADD_TO_DISCORD_URL` (already in `botsite/chrome.py`)
+   through `/site-data.json` → adapter → every page's `addUrl`, so the live "Add to Discord"
+   CTA stops being a dead `#/` link.
+4. **Build target** — `build:app` (Vite, already a devDep) → static `dist-app/`; the existing
+   `build` (tsup library + tailwind) untouched.
+5. **Data delivery (Decision B(a))** — `botsite/` route `GET /site-data.json` returning the same
+   data `build_prototype_data` produces, as pure JSON (no new disbot coupling; same public subset).
+6. **Tests/CI** — vitest data-adapter smoke test (sample SBDATA → valid page props) + a botsite
+   test that `/site-data.json` is truthful; `tsc --noEmit` covers `src/app/`; `design-system-ci.yml`
+   gains a `build:app` + `test` step.
+
+**Deferred (later PRs / out of scope):** serving the React build from `botsite/` + cutover
+(PR 2/3); per-detail routes (`#/command/<name>` etc.) and a dedicated GamesPage component;
+BUG-0023 command-count *breakdown in the public data* (touches the redaction contract — its own
+slice). PR 1 leaves visitors on the vanilla SPA.
+
+## Shipped
+
+_(filled at close)_
+
+## Session enders
+
+_(filled at close)_

--- a/botsite/app.py
+++ b/botsite/app.py
@@ -34,6 +34,7 @@ block in ``base.html``.
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -137,6 +138,42 @@ def spa_data() -> Response:
     return Response(
         content=js,
         media_type="application/javascript",
+        headers={"Cache-Control": "no-cache"},
+    )
+
+
+@app.get("/site-data.json")
+def site_data_json() -> Response:
+    """The React-SPA data layer — the same public data as ``/data.js``, as pure JSON.
+
+    The migrated React site (``design-system/src/app``) ``fetch()``es this instead of
+    parsing the legacy ``window.SBDATA`` script. It returns the
+    :func:`site_data.build_prototype_data` shape (``areas`` / ``commands`` / ``games``
+    / ``changelog`` / ``status``) plus the ``build`` provenance, public ``counts``, and
+    the real ``addUrl`` install link — so the React app needs no second data path and
+    its "Add to Discord" CTA resolves. Same public subset, same redaction posture as
+    ``/data.js``; ``botsite`` never imports ``disbot``.
+    """
+    site = data_loader.load_site_data()
+    proto = site_data.build_prototype_data(site)
+    meta = (site.get("meta") or {}).get("build") or {}
+    payload = {
+        "addUrl": chrome.ADD_TO_DISCORD_URL,
+        "build": {
+            "commit": meta.get("commit") or "",
+            "committedAt": meta.get("committed_at") or "",
+            "subject": meta.get("subject") or "",
+        },
+        "counts": site.get("counts") or {},
+        "areas": proto["areas"],
+        "commands": proto["commands"],
+        "games": proto["games"],
+        "changelog": proto["changelog"],
+        "status": proto["status"],
+    }
+    return Response(
+        content=json.dumps(payload, ensure_ascii=False),
+        media_type="application/json",
         headers={"Cache-Control": "no-cache"},
     )
 

--- a/design-system/index.html
+++ b/design-system/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SuperBot — the best bot ever made</title>
+    <meta
+      name="description"
+      content="SuperBot — games, moderation, economy, AI tools and more for your Discord server."
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/app/main.tsx"></script>
+  </body>
+</html>

--- a/design-system/package-lock.json
+++ b/design-system/package-lock.json
@@ -21,7 +21,8 @@
         "tailwindcss": "^3.4.15",
         "tsup": "^8.3.5",
         "typescript": "^5.6.3",
-        "vite": "^8.0.16"
+        "vite": "^8.0.16",
+        "vitest": "^3.2.6"
       },
       "peerDependencies": {
         "react": "^18.0.0",
@@ -2656,6 +2657,77 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vitest/spy": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
@@ -3288,6 +3360,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
@@ -3369,6 +3448,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-glob": {
@@ -4956,6 +5045,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4975,6 +5071,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/storybook": {
       "version": "10.4.6",
@@ -5058,6 +5168,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -5163,6 +5293,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
@@ -5185,6 +5322,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/tinyrainbow": {
@@ -5993,12 +6140,1338 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/ws": {
       "version": "8.21.0",

--- a/design-system/package.json
+++ b/design-system/package.json
@@ -8,16 +8,26 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" },
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
     "./styles.css": "./dist/styles.css"
   },
-  "files": ["dist"],
-  "sideEffects": ["**/*.css"],
+  "files": [
+    "dist"
+  ],
+  "sideEffects": [
+    "**/*.css"
+  ],
   "scripts": {
     "build:js": "tsup",
     "build:css": "tailwindcss -i ./src/styles.css -o ./dist/styles.css --minify",
     "build": "npm run build:js && npm run build:css",
+    "build:app": "vite build",
+    "dev:app": "vite",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
@@ -39,6 +49,7 @@
     "tailwindcss": "^3.4.15",
     "tsup": "^8.3.5",
     "typescript": "^5.6.3",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^3.2.6"
   }
 }

--- a/design-system/src/app/App.tsx
+++ b/design-system/src/app/App.tsx
@@ -1,0 +1,81 @@
+import * as React from "react";
+
+import { LandingPage } from "../LandingPage";
+import { FeaturesPage } from "../FeaturesPage";
+import { CommandsPage } from "../CommandsPage";
+import { ChangelogPage } from "../ChangelogPage";
+import { StatusPage } from "../StatusPage";
+
+import {
+  loadSiteData,
+  routeFromHash,
+  toLandingProps,
+  toFeaturesProps,
+  toGamesProps,
+  toCommandsProps,
+  toChangelogProps,
+  toStatusProps,
+  type Route,
+  type SiteData,
+} from "./data";
+
+/**
+ * The live SuperBot website as a React SPA — the runnable composition of the
+ * design-system page components, fed real bot data from `/site-data.json`.
+ *
+ * This is PR 1 of the React-SPA migration: additive (the live vanilla SPA still
+ * serves visitors). It exists so a Claude Design edit to a page component can,
+ * once PR 2 cuts over, land on the live site with no hand-written port.
+ *
+ * Routing is hash-based to match the existing SPA URL scheme (`#/commands`, …) and
+ * to keep botsite serving a single static shell (no server route changes).
+ */
+export function App() {
+  const route = useHashRoute();
+  const data = useSiteData();
+  return renderRoute(route, data);
+}
+
+export function renderRoute(route: Route, data: SiteData): React.ReactElement {
+  switch (route) {
+    case "features":
+      return <FeaturesPage {...toFeaturesProps(data)} />;
+    case "commands":
+      return <CommandsPage {...toCommandsProps(data)} />;
+    case "games":
+      return <FeaturesPage {...toGamesProps(data)} />;
+    case "changelog":
+      return <ChangelogPage {...toChangelogProps(data)} />;
+    case "status":
+      return <StatusPage {...toStatusProps(data)} />;
+    case "home":
+    default:
+      return <LandingPage {...toLandingProps(data)} />;
+  }
+}
+
+function useHashRoute(): Route {
+  const [route, setRoute] = React.useState<Route>(() =>
+    routeFromHash(typeof window !== "undefined" ? window.location.hash : ""),
+  );
+  React.useEffect(() => {
+    const onHash = () => setRoute(routeFromHash(window.location.hash));
+    window.addEventListener("hashchange", onHash);
+    return () => window.removeEventListener("hashchange", onHash);
+  }, []);
+  return route;
+}
+
+function useSiteData(): SiteData {
+  const [data, setData] = React.useState<SiteData>({});
+  React.useEffect(() => {
+    let alive = true;
+    loadSiteData().then((d) => {
+      if (alive) setData(d);
+    });
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return data;
+}

--- a/design-system/src/app/data.test.ts
+++ b/design-system/src/app/data.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  SAMPLE_SITE_DATA,
+  loadSiteData,
+  routeFromHash,
+  toLandingProps,
+  toFeaturesProps,
+  toGamesProps,
+  toCommandsProps,
+  toChangelogProps,
+  toStatusProps,
+  type SiteData,
+} from "./data";
+
+describe("routeFromHash", () => {
+  it("maps the top-level SPA hashes", () => {
+    expect(routeFromHash("")).toBe("home");
+    expect(routeFromHash("#")).toBe("home");
+    expect(routeFromHash("#/")).toBe("home");
+    expect(routeFromHash("#/features")).toBe("features");
+    expect(routeFromHash("#/commands")).toBe("commands");
+    expect(routeFromHash("#/games")).toBe("games");
+    expect(routeFromHash("#/changelog")).toBe("changelog");
+    expect(routeFromHash("#/status")).toBe("status");
+  });
+
+  it("falls a detail hash back to its parent list", () => {
+    expect(routeFromHash("#/command/blackjack")).toBe("commands");
+    expect(routeFromHash("#/feature/games")).toBe("features");
+    expect(routeFromHash("#/game/blackjack")).toBe("games");
+  });
+
+  it("falls an unknown hash back to home", () => {
+    expect(routeFromHash("#/nonsense")).toBe("home");
+  });
+});
+
+describe("data adapter — sample → valid page props", () => {
+  const data = SAMPLE_SITE_DATA;
+
+  it("threads the real install URL onto every page", () => {
+    const url = data.addUrl;
+    expect(url).toContain("discord.com/oauth2/authorize");
+    expect(toLandingProps(data).addUrl).toBe(url);
+    expect(toFeaturesProps(data).addUrl).toBe(url);
+    expect(toGamesProps(data).addUrl).toBe(url);
+    expect(toCommandsProps(data).addUrl).toBe(url);
+    expect(toChangelogProps(data).addUrl).toBe(url);
+    expect(toStatusProps(data).addUrl).toBe(url);
+  });
+
+  it("maps landing counts + feature categories", () => {
+    const p = toLandingProps(data);
+    expect(p.counts).toEqual({ commands: 372, features: 37, games: 9 });
+    expect(p.features?.map((f) => f.category)).toEqual(["games", "moderation"]);
+    expect(p.build?.commit).toBe("abc1234");
+  });
+
+  it("groups features by area, marking the game-bearing command", () => {
+    const groups = toFeaturesProps(data).groups ?? [];
+    const games = groups.find((g) => g.category === "games");
+    expect(games?.features.some((f) => f.name === "blackjack" && f.isGame)).toBe(true);
+  });
+
+  it("renders the games view from the game catalogue only", () => {
+    const groups = toGamesProps(data).groups ?? [];
+    expect(groups).toHaveLength(1);
+    expect(groups[0].category).toBe("games");
+    expect(groups[0].features.every((f) => f.isGame)).toBe(true);
+  });
+
+  it("groups commands under their area display name with full records", () => {
+    const groups = toCommandsProps(data).groups ?? [];
+    const cats = groups.map((g) => g.category).sort();
+    expect(cats).toEqual(["games", "moderation"]);
+    const warn = groups
+      .flatMap((g) => g.commands)
+      .find((c) => c.name === "warn");
+    expect(warn?.permissions).toBe("Moderator");
+    expect(warn?.examples).toContain("!warn @user spamming");
+  });
+
+  it("maps changelog change-types onto ChangelogKind", () => {
+    const entries = toChangelogProps(data).entries ?? [];
+    expect(entries[0]).toMatchObject({
+      kind: "feature",
+      title: "Fishing minigame",
+    });
+    expect(entries[0].summary).toContain("rod ladder");
+  });
+
+  it("maps the status build + counts", () => {
+    const p = toStatusProps(data);
+    expect(p.build?.subject).toBe("sample");
+    expect(p.counts?.games).toBe(9);
+  });
+});
+
+describe("loadSiteData fallback", () => {
+  it("falls back to the sample when the fetch fails", async () => {
+    const failing: typeof fetch = async () => {
+      throw new Error("offline");
+    };
+    const out = await loadSiteData("/site-data.json", failing);
+    expect(out).toBe(SAMPLE_SITE_DATA);
+  });
+
+  it("falls back to the sample on a non-ok response", async () => {
+    const notOk: typeof fetch = async () =>
+      ({ ok: false, status: 404 }) as Response;
+    const out = await loadSiteData("/site-data.json", notOk);
+    expect(out).toBe(SAMPLE_SITE_DATA);
+  });
+
+  it("returns the parsed payload on success", async () => {
+    const payload: SiteData = { counts: { commands: 1, features: 2, games: 3 } };
+    const ok: typeof fetch = async () =>
+      ({ ok: true, status: 200, json: async () => payload }) as Response;
+    const out = await loadSiteData("/site-data.json", ok);
+    expect(out).toEqual(payload);
+  });
+});

--- a/design-system/src/app/data.ts
+++ b/design-system/src/app/data.ts
@@ -1,0 +1,345 @@
+// Data adapter — maps the live `/site-data.json` payload onto the design-system
+// page props. This is the design↔data contract: the page components own the look;
+// this file owns turning the public bot data into the props they take. Kept pure
+// (the mappers) + a thin async `loadSiteData()` so the mapping is unit-testable
+// without a DOM or a network (the PR-1 smoke test feeds a sample here).
+//
+// Source of truth stays `disbot/ → site.json` (served by botsite's `/site-data.json`).
+// This app reads ONLY that public subset — it never imports the bot.
+
+import type { BuildMeta } from "../SiteFooter";
+import type { StatusBuild } from "../StatusCard";
+import type { LandingPageProps, FeatureCategory } from "../LandingPage";
+import type { FeaturesPageProps, FeatureCategoryGroup } from "../FeaturesPage";
+import type { CommandsPageProps, CommandCategoryGroup } from "../CommandsPage";
+import type { ChangelogPageProps, ChangelogItem } from "../ChangelogPage";
+import type { StatusPageProps, StatusCounts } from "../StatusPage";
+import type { ChangelogKind } from "../ChangelogEntry";
+import type { CommandRecord, PlannedIdea } from "../CommandDetail";
+import type { FeatureShowcaseCardProps } from "../FeatureShowcaseCard";
+
+// ── The `/site-data.json` payload shape (mirrors botsite/site_data.build_prototype_data
+//    + the meta/counts/addUrl the route folds in). Only the fields the pages consume
+//    are typed; unknown extras are ignored. ───────────────────────────────────────
+export interface SiteArea {
+  id: string;
+  name: string;
+  icon?: string;
+  color?: string;
+  title?: string;
+  tagline?: string;
+  description?: string;
+  points?: string[];
+}
+
+export interface SiteCommand {
+  name: string;
+  area: string;
+  status?: "finished" | "in-progress";
+  summary?: string;
+  description?: string;
+  usage?: string;
+  aliases?: string[];
+  permissions?: string;
+  cooldown?: string | null;
+  examples?: string[];
+  planned?: { status: string; title: string }[];
+}
+
+export interface SiteGame {
+  id: string;
+  name: string;
+  command?: string;
+  tagline?: string;
+  description?: string;
+  beta?: boolean;
+}
+
+export interface SiteChangelogEntry {
+  date: string;
+  title: string;
+  changes?: { type: string; text: string }[];
+}
+
+export interface SiteData {
+  /** The real "Add to Discord" OAuth URL (from botsite/chrome.ADD_TO_DISCORD_URL). */
+  addUrl?: string;
+  /** Deployed-build provenance. */
+  build?: { commit?: string; committedAt?: string; subject?: string };
+  /** Honest catalogue counts (never server/user totals). */
+  counts?: { commands: number; features: number; games: number };
+  areas?: SiteArea[];
+  commands?: SiteCommand[];
+  games?: SiteGame[];
+  changelog?: SiteChangelogEntry[];
+}
+
+/** The hash routes this app serves (mirrors the vanilla SPA's URL scheme). */
+export type Route =
+  | "home"
+  | "features"
+  | "commands"
+  | "games"
+  | "changelog"
+  | "status";
+
+const _ROUTES: Route[] = [
+  "home",
+  "features",
+  "commands",
+  "games",
+  "changelog",
+  "status",
+];
+
+/**
+ * Map a `window.location.hash` to a top-level route. `#/`, `#`, and `""` are home;
+ * `#/commands` → commands; detail hashes (`#/command/foo`, `#/feature/bar`,
+ * `#/game/baz`) fall back to their parent list; anything unknown is home.
+ */
+export function routeFromHash(hash: string): Route {
+  const path = (hash || "").replace(/^#\/?/, "").split("/")[0].toLowerCase();
+  if (!path) return "home";
+  if (path === "feature") return "features";
+  if (path === "command") return "commands";
+  if (path === "game") return "games";
+  return (_ROUTES.find((r) => r === path) ?? "home") as Route;
+}
+
+// ── Build metadata ────────────────────────────────────────────────────────────
+export function toBuildMeta(data: SiteData): BuildMeta | undefined {
+  const b = data.build;
+  if (!b || !b.commit) return undefined;
+  return { commit: b.commit, committedAt: b.committedAt };
+}
+
+export function toStatusBuild(data: SiteData): StatusBuild | undefined {
+  const b = data.build;
+  if (!b || !b.commit) return undefined;
+  return { commit: b.commit, committedAt: b.committedAt, subject: b.subject };
+}
+
+function counts(data: SiteData): StatusCounts | undefined {
+  return data.counts;
+}
+
+// ── Per-page mappers (pure) ─────────────────────────────────────────────────────
+export function toLandingProps(data: SiteData): LandingPageProps {
+  const features: FeatureCategory[] = (data.areas ?? []).map((a) => ({
+    category: a.name || a.id,
+    items: pickAreaFeatureItems(a, data.commands ?? []),
+  }));
+  return {
+    addUrl: data.addUrl,
+    counts: data.counts,
+    features: features.length ? features : undefined,
+    build: toBuildMeta(data),
+  };
+}
+
+// The landing "What it does" grid shows a few representative items per area. We use
+// the area's `points` (its curated subsystem display names) as the item labels — the
+// same data the vanilla SPA's feature cards surface — capped to keep the grid tidy.
+function pickAreaFeatureItems(area: SiteArea, _commands: SiteCommand[]) {
+  return (area.points ?? []).slice(0, 4).map((name) => ({ name }));
+}
+
+export function toFeaturesProps(data: SiteData): FeaturesPageProps {
+  return {
+    addUrl: data.addUrl,
+    groups: buildFeatureGroups(data),
+    build: toBuildMeta(data),
+  };
+}
+
+// The /games view reuses FeaturesPage with only the game-bearing entries — a faithful
+// "just the games" slice until a dedicated GamesPage component lands (PR 2+).
+export function toGamesProps(data: SiteData): FeaturesPageProps {
+  const games: FeatureShowcaseCardProps[] = (data.games ?? []).map((g) => ({
+    name: g.name,
+    description: g.tagline || g.description,
+    isGame: true,
+    tags: g.beta ? ["beta"] : undefined,
+    commandsHref: g.command ? `#/commands` : undefined,
+  }));
+  const groups: FeatureCategoryGroup[] = games.length
+    ? [{ category: "games", features: games }]
+    : [];
+  return {
+    addUrl: data.addUrl,
+    groups: groups.length ? groups : undefined,
+    build: toBuildMeta(data),
+  };
+}
+
+function buildFeatureGroups(data: SiteData): FeatureCategoryGroup[] | undefined {
+  const areas = data.areas ?? [];
+  const commands = data.commands ?? [];
+  const games = new Set((data.games ?? []).map((g) => g.command));
+  const groups: FeatureCategoryGroup[] = [];
+  for (const area of areas) {
+    const inArea = commands.filter((c) => c.area === area.id);
+    if (!inArea.length) continue;
+    const features: FeatureShowcaseCardProps[] = inArea.map((c) => ({
+      name: c.name,
+      description: c.summary || c.description,
+      tags: c.aliases?.length ? c.aliases.slice(0, 3) : undefined,
+      isGame: games.has(c.name),
+      commandsHref: `#/command/${c.name}`,
+    }));
+    groups.push({ category: area.name || area.id, features });
+  }
+  return groups.length ? groups : undefined;
+}
+
+export function toCommandsProps(data: SiteData): CommandsPageProps {
+  const areaName = new Map((data.areas ?? []).map((a) => [a.id, a.name || a.id]));
+  const byCategory = new Map<string, CommandRecord[]>();
+  for (const c of data.commands ?? []) {
+    const cat = areaName.get(c.area) || c.area || "other";
+    const rec: CommandRecord = {
+      name: c.name,
+      usage: c.usage || c.summary,
+      status: c.status,
+      description: c.description || c.summary,
+      aliases: c.aliases?.length ? c.aliases : undefined,
+      permissions: c.permissions,
+      cooldown: c.cooldown ?? undefined,
+      examples: c.examples?.length ? c.examples : undefined,
+      plannedIdeas: c.planned?.length ? (c.planned as PlannedIdea[]) : undefined,
+    };
+    const list = byCategory.get(cat) ?? [];
+    list.push(rec);
+    byCategory.set(cat, list);
+  }
+  const groups: CommandCategoryGroup[] = [...byCategory.entries()].map(
+    ([category, commands]) => ({ category, commands }),
+  );
+  return {
+    addUrl: data.addUrl,
+    groups: groups.length ? groups : undefined,
+    build: toBuildMeta(data),
+  };
+}
+
+const _CHANGE_KIND: Record<string, ChangelogKind> = {
+  added: "feature",
+  improved: "improvement",
+  fixed: "fix",
+  removed: "update",
+};
+
+export function toChangelogProps(data: SiteData): ChangelogPageProps {
+  const entries: ChangelogItem[] = (data.changelog ?? []).map((e) => {
+    const first = e.changes?.[0];
+    const kind: ChangelogKind = first
+      ? (_CHANGE_KIND[first.type] ?? "update")
+      : "update";
+    const summary = (e.changes ?? []).map((c) => c.text).filter(Boolean).join(" ");
+    return { date: e.date, kind, title: e.title, summary: summary || undefined };
+  });
+  return {
+    addUrl: data.addUrl,
+    entries: entries.length ? entries : undefined,
+    build: toBuildMeta(data),
+  };
+}
+
+export function toStatusProps(data: SiteData): StatusPageProps {
+  return {
+    addUrl: data.addUrl,
+    build: toStatusBuild(data),
+    counts: counts(data),
+  };
+}
+
+// ── Loader ──────────────────────────────────────────────────────────────────────
+// Fetches the live public data; on any failure (offline canvas, missing route) it
+// falls back to the bundled sample so the app still renders — the pages also carry
+// their own sample defaults, so a partial payload degrades gracefully too.
+export async function loadSiteData(
+  url = "/site-data.json",
+  fetchImpl: typeof fetch = fetch,
+): Promise<SiteData> {
+  try {
+    const res = await fetchImpl(url, { headers: { Accept: "application/json" } });
+    if (!res.ok) throw new Error(`site-data ${res.status}`);
+    return (await res.json()) as SiteData;
+  } catch {
+    return SAMPLE_SITE_DATA;
+  }
+}
+
+// A minimal, self-contained sample used as the offline fallback and in the smoke test.
+// Mirrors the `/site-data.json` shape; the real payload is far larger.
+export const SAMPLE_SITE_DATA: SiteData = {
+  addUrl: "https://discord.com/oauth2/authorize?client_id=1403818430758654132",
+  build: { commit: "abc1234", committedAt: "2026-06-22T00:00:00Z", subject: "sample" },
+  counts: { commands: 372, features: 37, games: 9 },
+  areas: [
+    {
+      id: "games",
+      name: "games",
+      icon: "gamepad",
+      color: "var(--g)",
+      title: "Games, ready to play",
+      tagline: "Quick, replayable fun.",
+      description: "A suite of games members can play right in chat.",
+      points: ["Blackjack", "Fishing", "Mining"],
+    },
+    {
+      id: "moderation",
+      name: "moderation",
+      icon: "shield",
+      color: "var(--sky)",
+      title: "Keep the peace",
+      tagline: "Healthy community without the busywork.",
+      description: "Automatic and manual moderation with a full audit trail.",
+      points: ["Automod", "Warnings", "Timeouts"],
+    },
+  ],
+  commands: [
+    {
+      name: "blackjack",
+      area: "games",
+      status: "finished",
+      summary: "Play blackjack against the bot.",
+      description: "Start a game of blackjack against the bot.",
+      usage: "!blackjack",
+      aliases: ["bj"],
+      permissions: "anyone",
+      cooldown: null,
+      examples: ["!blackjack 100"],
+      planned: [],
+    },
+    {
+      name: "warn",
+      area: "moderation",
+      status: "finished",
+      summary: "Issue a warning to a member.",
+      description: "Issue a warning to a member.",
+      usage: "!warn",
+      aliases: [],
+      permissions: "Moderator",
+      cooldown: null,
+      examples: ["!warn @user spamming"],
+      planned: [],
+    },
+  ],
+  games: [
+    {
+      id: "blackjack",
+      name: "Blackjack",
+      command: "blackjack",
+      tagline: "Beat the dealer.",
+      description: "Card game against the bot.",
+    },
+  ],
+  changelog: [
+    {
+      date: "Jun 22, 2026",
+      title: "Fishing minigame",
+      changes: [{ type: "added", text: "A new fishing minigame with a rod ladder." }],
+    },
+  ],
+};

--- a/design-system/src/app/main.tsx
+++ b/design-system/src/app/main.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+import "../styles.css";
+
+const container = document.getElementById("root");
+if (!container) {
+  throw new Error("missing #root element");
+}
+createRoot(container).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/design-system/vite.config.ts
+++ b/design-system/vite.config.ts
@@ -1,0 +1,23 @@
+/// <reference types="vitest/config" />
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+// Vite config for the runnable SPA (`build:app` → dist-app/). This is SEPARATE from
+// the tsup library build (`build` → dist/, the component artifacts /design-sync ships):
+// here we bundle src/app/main.tsx into a static HTML+JS+CSS site botsite can serve
+// (PR 2). Relative base so the bundle works from any path under botsite/site/.
+//
+// `vitest/config`'s defineConfig is a superset of vite's, so it also carries the
+// `test` block for the data-adapter smoke test (pure mappers → Node env, no DOM).
+export default defineConfig({
+  plugins: [react()],
+  base: "./",
+  build: {
+    outDir: "dist-app",
+    emptyOutDir: true,
+  },
+  test: {
+    environment: "node",
+    include: ["src/app/**/*.test.ts"],
+  },
+});

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -21,10 +21,11 @@
 **▶ Next startable (one of):**
 - **Project Moon runtime PR 1** — the `KnowledgeDomain` seam + first ingest
   ([plan](../planning/project-moon-knowledge-domain-plan-2026-06-21.md)).
-- **botsite React-SPA migration**
-  ([plan](../planning/botsite-react-spa-migration-plan-2026-06-20.md)).
+- **botsite React-SPA migration PR 2** — serve the built React app from `botsite/` + cutover
+  (PR 1 foundation shipped; [plan](../planning/botsite-react-spa-migration-plan-2026-06-20.md)).
 
-**In flight (don't duplicate):** Starboard PR 2 (#1270) config polish.
+**In flight (don't duplicate):** Starboard PR 2 (#1270) config polish · botsite React-SPA
+migration **PR 1** (#1305 — runnable data-fed React app + `/site-data.json`; foundation).
 
 **Owner-paced / gated:** reaction-roles PR 6 + web builder · creature PvP balance + art (Q-0187) ·
 website rollout ·

--- a/docs/owner/claims/claude__funny-franklin-s56i3y.md
+++ b/docs/owner/claims/claude__funny-franklin-s56i3y.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-s56i3y` · scope: botsite React-SPA migration **PR 1** (foundation) · area: `design-system/src/app/`, `design-system/{index.html,vite.config.ts,package.json}`, `botsite/app.py` (+ `/site-data.json` route), `.github/workflows/design-system-ci.yml` · 2026-06-22

--- a/tests/unit/botsite/test_app.py
+++ b/tests/unit/botsite/test_app.py
@@ -94,6 +94,27 @@ def test_data_js_is_generated_live_and_truthful(client, app_module):
         assert forbidden not in lowered
 
 
+def test_site_data_json_is_truthful_for_the_react_app(client, app_module):
+    # /site-data.json is the React-SPA data seam — the same public data as /data.js,
+    # as pure JSON. It must carry the real bot data + the install URL the React pages
+    # thread onto every "Add to Discord" CTA, with no server/user totals.
+    resp = client.get("/site-data.json")
+    assert resp.status_code == 200
+    assert "application/json" in resp.headers["content-type"]
+    payload = resp.json()
+    # The shape the React data adapter consumes.
+    for key in ("addUrl", "build", "counts", "areas", "commands", "games", "changelog"):
+        assert key in payload, f"missing {key}"
+    # The real install link (not a dead #/) — the BUG the migration fixes.
+    assert payload["addUrl"] == app_module.chrome.ADD_TO_DISCORD_URL
+    assert "discord.com/oauth2/authorize" in payload["addUrl"]
+    # Real data: a known command name from site.json appears.
+    names = {c["name"] for c in payload["commands"]}
+    assert "blackjack" in names
+    # Honest posture: only catalogue counts, never server/user totals.
+    assert set(payload["counts"]) <= {"commands", "features", "games"}
+
+
 def test_submit_page_shares_chrome_with_working_install_cta(client, app_module):
     # /submit is rendered by submit.py's SEPARATE Jinja env; it must share
     # chrome.site_context so base.html's nav "Add to Discord" button isn't a dead
@@ -130,6 +151,7 @@ def test_every_route_is_wired(app_module):
         "/app.js",
         "/app.css",
         "/data.js",  # the SPA shell + dynamic data
+        "/site-data.json",  # the React-SPA JSON data seam
         "/commands",
         "/features",
         "/changelog",


### PR DESCRIPTION
## What

**PR 1** of the botsite React-SPA migration ([plan](../blob/main/docs/planning/botsite-react-spa-migration-plan-2026-06-20.md)) — make `design-system/`'s existing React pages a **runnable, routable, data-fed app**, so a Claude Design edit can eventually land on the live site with **no manual port**. **Additive only** — the live vanilla SPA keeps serving until PR 2.

Routine · dispatch (scheduled fire, no work order → advance the next non-gated S1 plan slice).

## Scope (foundation only — no cutover)

- **App shell + hash router** — `design-system/src/app/` wires the existing page components to the SPA's URL scheme (`#/`, `#/features`, `#/commands`, `#/games`, `#/changelog`, `#/status`).
- **Data adapter** (`src/app/data.ts`) — `fetch()`es the live `/site-data.json` and maps the `SBDATA` shape onto each page's props; pure mappers + a bundled sample for fallback/tests.
- **Install-URL fix** — threads the real `ADD_TO_DISCORD_URL` (already in `botsite/chrome.py`) through the data → every page's `addUrl`, so the live "Add to Discord" CTA stops being a dead `#/` link.
- **`build:app`** (Vite, already a devDep) → static `dist-app/`; the existing tsup library `build` untouched.
- **`GET /site-data.json`** (Decision B(a)) — `botsite/` route returning the same data `build_prototype_data` produces, as pure JSON (no new `disbot/` coupling; same public subset).
- **Tests/CI** — vitest data-adapter smoke test + a botsite `/site-data.json` test; `tsc --noEmit` covers `src/app/`; `design-system-ci.yml` gains `build:app` + `test`.

**Deferred:** serving the React build + cutover (PR 2/3); per-detail routes + a dedicated GamesPage; the BUG-0023 count *breakdown in the public data* (touches the redaction contract — its own slice).

## Invariants preserved (§5)
`botsite/` never imports `disbot/`; secret-free static surface; single data source of truth (`disbot/ → site.json`); no `static/` dir; Python-side CI/parity unchanged.

## Status

🔴 Born-red until the slice + tests land, then flipped green. Owner-directed plan lane → auto-merges on green (Q-0191/Q-0123).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136PFGC2UQcLifvJZkmB5Y5

---
_Generated by [Claude Code](https://claude.ai/code/session_0136PFGC2UQcLifvJZkmB5Y5)_