### PR TITLE
Role list colours + optional per-role colour for bulk custom roles

### DIFF
--- a/.sessions/2026-06-22-role-list-colours-and-per-role-bulk-colour.md
+++ b/.sessions/2026-06-22-role-list-colours-and-per-role-bulk-colour.md
@@ -1,0 +1,24 @@
+# 2026-06-22 — Role list colours + per-role bulk colour
+
+> **Status:** `in-progress`
+
+Owner-relayed, two asks (screenshots: the 🗂️ Role Management list is plain white
+text, while the 💬 Reaction Roles panel shows coloured role mentions):
+
+1. **Make the Role Management list show each role's colour** like the reaction-role
+   menu does — i.e. render roles as **mentions** (`role.mention`), which Discord
+   auto-colours, instead of plain bold `role.name`.
+2. **For bulk roles, add an optional per-role colour chooser**, using the same
+   "walk each one with a picker" method the reaction-role flow uses to match emotes
+   to roles (`_BindEmotesView`). Apply to the **custom bulk** path (typed names),
+   alongside the existing "one colour for all" / "no colour".
+
+## Plan
+
+- `management_panel.py` build_embed: `**{role.name}**` → `{role.mention}`.
+- `_role_pack_flow.py`: add a "🎨 Per-role colours" button on `_BulkColourView`
+  that opens a `_PerRoleColourView` walker (one colour preset select per name,
+  including a "no colour" option), then bulk-creates via the shared `_create_roles`.
+- Tests for both.
+
+Owner-directed (Q-0191): PR ready, auto-merge armed.

--- a/.sessions/2026-06-22-role-list-colours-and-per-role-bulk-colour.md
+++ b/.sessions/2026-06-22-role-list-colours-and-per-role-bulk-colour.md
@@ -1,24 +1,94 @@
 # 2026-06-22 — Role list colours + per-role bulk colour
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
-Owner-relayed, two asks (screenshots: the 🗂️ Role Management list is plain white
-text, while the 💬 Reaction Roles panel shows coloured role mentions):
+Owner-relayed follow-up to the bulk-role work (#1300/#1302), two asks from
+screenshots: the 🗂️ Role Management list was plain white text while the 💬 Reaction
+Roles panel showed coloured role mentions.
 
-1. **Make the Role Management list show each role's colour** like the reaction-role
-   menu does — i.e. render roles as **mentions** (`role.mention`), which Discord
-   auto-colours, instead of plain bold `role.name`.
-2. **For bulk roles, add an optional per-role colour chooser**, using the same
-   "walk each one with a picker" method the reaction-role flow uses to match emotes
-   to roles (`_BindEmotesView`). Apply to the **custom bulk** path (typed names),
-   alongside the existing "one colour for all" / "no colour".
+## Shipped (PR #1306)
 
-## Plan
+1. **Role Management list shows role colours.** `ManagementPanel.build_embed` now
+   renders each role as a **mention** (`role.mention`) — Discord auto-colours
+   mentions, and mentions in an embed description never ping — instead of plain
+   bold `role.name`. Falls back to the plain name for any role that somehow can't
+   mention. This is the *only* way to show per-role colour in a Discord embed
+   (embeds have no arbitrary text colour), and it matches the reaction-role panel
+   the owner pointed at.
+2. **Optional per-role colour for bulk custom roles.** A new **🎨 Per-role colours**
+   button on `_BulkColourView` opens `_PerRoleColourView`, which walks each typed
+   role name with its own colour preset picker (one at a time, advancing) — the
+   exact method the reaction-role flow uses to match emotes to roles
+   (`_BindEmotesView`). Each step's select includes a "⬜ No colour (default)"
+   option; after the last pick it bulk-creates via the shared `_create_roles`.
+   Sits alongside the existing "one colour for all" and "create with no colour".
 
-- `management_panel.py` build_embed: `**{role.name}**` → `{role.mention}`.
-- `_role_pack_flow.py`: add a "🎨 Per-role colours" button on `_BulkColourView`
-  that opens a `_PerRoleColourView` walker (one colour preset select per name,
-  including a "no colour" option), then bulk-creates via the shared `_create_roles`.
-- Tests for both.
+- **Tests:** management list renders mentions (+ excludes @everyone, counts
+  correct); per-role walk creates each role with its picked colour, "no colour" →
+  default, runs the `on_created` hook.
+- Gates: `check_quality --full` ✓ (black/isort/ruff + mypy + 11628 passed),
+  `check_architecture --mode strict` 0 errors, `check_docs --strict` ✓.
 
 Owner-directed (Q-0191): PR ready, auto-merge armed.
+
+## Decisions
+
+- **Mentions, not a colour swatch.** Discord embeds can't colour arbitrary text;
+  a role *mention* is the only built-in coloured-text primitive (it's exactly what
+  the reaction-role panel uses). So "show the role colour" = render as a mention.
+- **Per-role colour applied to the custom-bulk path only.** Pack roles already
+  carry curated catalogue colours; the per-role walk is where colour choice is
+  actually missing (typed names). Kept it there to match the ask without bloating
+  the pre-coloured pack flow.
+
+## ⚑ Self-initiated
+
+None — both changes are owner-relayed (the two screenshot asks).
+
+## 💡 Session idea (Q-0089)
+
+**A "colour all from a palette theme" shortcut for bulk roles** — when bulk-creating
+(pack or custom), offer one tap to auto-assign colours from a coherent palette
+(e.g. rainbow spread, or a single-hue gradient across the batch) instead of one
+flat colour or a per-role walk. The gradient-preset catalogue
+(`role_menu_presentation.gradient_presets`) already proves the "curated palette"
+data pattern; a `palette_spread(n)` helper returning n evenly-spaced hues would
+make a freshly-created game/colour pack look intentional in one tap. Captured, not
+built (the per-role walk covers the precise-control case this session).
+
+## ⟲ Previous-session review (Q-0102)
+
+Reviewed #1302 (my own prior session — bulk-create enhancements). **Did well:** it
+refactored both bulk paths onto one `_create_roles` tail *before* adding the third
+(custom) path — which is exactly why this session's per-role walk was a ~30-line
+add: it just builds `specs` and calls the same seam. The shared-tail investment
+paid off one session later (again). **Could have done better:** #1302's custom-bulk
+report and #1300's pack report still list created roles as **plain names**, not
+coloured mentions — the same gap the owner flagged for the management list this
+session. Consistency-wise I could have coloured those reports here too (resolve the
+new ids → mentions). I scoped to the explicit asks to keep the PR tight, but the
+"created roles" report is the obvious next consistency win. System note: a
+lightweight convention — "render any user-facing role list as `role.mention`, not
+`role.name`" — would be worth a one-line entry in the hub-UI standard doc so the
+next role surface gets colour for free instead of being a follow-up.
+
+## 🔎 Doc audit (Q-0104)
+
+- `check_quality --full` ✓ · `check_architecture --mode strict` 0 errors ·
+  `check_docs --strict` ✓. Feature homed on the reaction-roles overhaul plan
+  (this arc's refinement home).
+- `check_current_state_ledger` lag is the benign newest-merge class (Q-0124); the
+  recon pass at #1320 records #1300/#1302/#1306. This PR is correctly absent until
+  merged.
+
+## Context delta
+
+- **Confirmed-good pointer:** the PreToolUse context map for `management_panel.py`
+  named `docs/building-roadmap/hub-ui-standard.md` as a related doc — that's the
+  natural home for the "render role lists as mentions for colour" convention noted
+  above (a candidate one-liner, not self-edited).
+- **Pattern reuse worked as intended:** `_BindEmotesView` was a near-exact template
+  for the per-role colour walk (walk-index + re-attach-per-step + finish). Reading
+  it first (already in context from #1300) made the walker mechanical.
+- **Pointed to but not needed:** CodeGraph — a two-file UI change on code written
+  earlier this conversation; targeted reads carried it.

--- a/disbot/views/roles/_role_pack_flow.py
+++ b/disbot/views/roles/_role_pack_flow.py
@@ -221,8 +221,9 @@ class _CustomBulkModal(discord.ui.Modal, title="Bulk-create custom roles"):  # t
             return
         await interaction.response.send_message(
             content=(
-                f"Creating **{len(names)}** role(s): {', '.join(names)[:1500]}\n\n"
-                "Pick a colour for them (optional), or **Create with no colour**:"
+                f"Creating **{len(names)}** role(s): {', '.join(names)[:1400]}\n\n"
+                "Pick **one colour for them all**, **🎨 Per-role colours** to choose "
+                "each one, or **Create with no colour**:"
             ),
             view=_BulkColourView(self.flow, names),
             ephemeral=True,
@@ -262,6 +263,26 @@ class _BulkColourView(BaseView):
         self.add_item(_ColourPresetSelect(self))
 
     @discord.ui.button(
+        label="🎨 Per-role colours",
+        style=discord.ButtonStyle.blurple,
+        row=1,
+    )
+    async def per_role_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        """Walk each name with its own colour picker (the emote→role-walk method)."""
+        if not _can_manage(interaction):
+            await interaction.response.send_message(
+                "You need the **Manage Roles** permission to do that.",
+                ephemeral=True,
+            )
+            return
+        walker = _PerRoleColourView(self.flow, self.names)
+        await interaction.response.edit_message(content=walker.prompt(), view=walker)
+
+    @discord.ui.button(
         label="Create with no colour",
         style=discord.ButtonStyle.grey,
         row=1,
@@ -293,6 +314,91 @@ async def _commit_custom_roles(
         specs,
         reason="Bulk role creation (custom)",
     )
+
+
+# ---------------------------------------------------------------------------
+# Per-role colour walk — one colour picker per name (the emote→role-walk method)
+# ---------------------------------------------------------------------------
+
+
+class _PerRoleColourSelect(discord.ui.Select):
+    """One step of the walk: pick the current role's colour (or no colour)."""
+
+    def __init__(self, walker: _PerRoleColourView) -> None:
+        self._walker = walker
+        super().__init__(
+            placeholder=f"Colour for {walker.current_name}…"[:150],
+            row=0,
+            max_values=1,
+            options=[
+                discord.SelectOption(label="⬜ No colour (default)", value=""),
+                *(
+                    discord.SelectOption(label=label, value=hex_value)
+                    for label, hex_value in _COLOR_OPTIONS
+                ),
+            ],
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await self._walker._on_pick(interaction, self.values[0])
+
+
+class _PerRoleColourView(BaseView):
+    """Walk each custom name, picking its own colour — mirrors ``_BindEmotesView``.
+
+    The reaction-role flow walks each emote with its own role picker; this walks
+    each role name with its own colour picker, then bulk-creates them all with
+    their chosen colours through the shared :func:`_create_roles` seam.
+    """
+
+    def __init__(self, flow: RolePackView, names: list[str]) -> None:
+        super().__init__(flow._author, timeout=300)
+        self.flow = flow
+        self.names = names
+        self.index = 0
+        self.specs: list[tuple[str, discord.Color, bool]] = []
+        self._attach()
+
+    @property
+    def current_name(self) -> str:
+        return self.names[self.index]
+
+    def prompt(self) -> str:
+        return (
+            f"Pick a colour for **{self.current_name}** "
+            f"({self.index + 1}/{len(self.names)}):"
+        )
+
+    def _attach(self) -> None:
+        self.clear_items()
+        self.add_item(_PerRoleColourSelect(self))
+
+    async def _on_pick(self, interaction: discord.Interaction, hex_value: str) -> None:
+        if self.index >= len(self.names):  # pragma: no cover - guards a stale click
+            await safe_defer(interaction)
+            return
+        color = discord.Color.default()
+        if hex_value:
+            try:
+                color = _parse_color(hex_value)
+            except (ValueError, OverflowError):  # pragma: no cover - constant data
+                color = discord.Color.default()
+        self.specs.append((self.current_name, color, False))
+        self.index += 1
+        if self.index < len(self.names):
+            self._attach()
+            await interaction.response.edit_message(content=self.prompt(), view=self)
+            return
+        # All colours chosen — clear the picker, then create through the shared seam
+        # (safe_defer is a no-op once the response is done, so followup still works).
+        await interaction.response.edit_message(content="🎨 Creating roles…", view=None)
+        self.stop()
+        await _create_roles(
+            interaction,
+            self.flow,
+            self.specs,
+            reason="Bulk role creation (custom, per-role colour)",
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/disbot/views/roles/management_panel.py
+++ b/disbot/views/roles/management_panel.py
@@ -40,8 +40,11 @@ class ManagementPanel(BaseView):
 
     async def build_embed(self) -> discord.Embed:
         guild = self.ctx.guild
+        # Render each role as a mention so Discord shows it in the role's own
+        # colour (matching the reaction-role panel) — mentions in an embed never
+        # ping. Falls back to the plain name for the rare role that can't mention.
         lines = [
-            f"**{role.name}** — "
+            f"{getattr(role, 'mention', None) or f'**{role.name}**'} — "
             f"{sum(1 for m in guild.members if role in m.roles)} members"
             for role in reversed(guild.roles)
             if role != guild.default_role

--- a/docs/owner/claims/claude__role-list-colours-and-per-role-bulk-colour.md
+++ b/docs/owner/claims/claude__role-list-colours-and-per-role-bulk-colour.md
@@ -1,0 +1,1 @@
+- `claude/role-list-colours-and-per-role-bulk-colour` · (1) Role Management list shows role colours via mentions; (2) optional per-role colour walk for bulk custom roles (mirrors emote→role walk) · `disbot/views/roles/management_panel.py`, `disbot/views/roles/_role_pack_flow.py` · 2026-06-22

--- a/docs/owner/claims/claude__role-list-colours-and-per-role-bulk-colour.md
+++ b/docs/owner/claims/claude__role-list-colours-and-per-role-bulk-colour.md
@@ -1,1 +1,0 @@
-- `claude/role-list-colours-and-per-role-bulk-colour` · (1) Role Management list shows role colours via mentions; (2) optional per-role colour walk for bulk custom roles (mirrors emote→role walk) · `disbot/views/roles/management_panel.py`, `disbot/views/roles/_role_pack_flow.py` · 2026-06-22

--- a/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
+++ b/docs/planning/reaction-roles-overhaul-plan-2026-06-21.md
@@ -86,6 +86,15 @@
 > custom batch, or "create with no colour". Both bulk paths share one `_create_roles` tail and the
 > `on_created` hook, so they work on both surfaces (creation panel + menu builder).
 >
+> **▶ Refinement (2026-06-22, owner-relayed — PR #1306):** two UX asks from screenshots. **(1) The
+> 🗂️ Role Management list now shows each role in its own colour** — `ManagementPanel.build_embed`
+> renders roles as **mentions** (`role.mention`, which Discord auto-colours and never pings in an
+> embed) instead of plain bold `role.name`, matching the reaction-role panel. **(2) Optional per-role
+> colour for bulk custom roles** — a **🎨 Per-role colours** path on `_BulkColourView` opens
+> `_PerRoleColourView`, which walks each typed name with its own colour preset picker (the exact
+> emote→role walk method from `_BindEmotesView`), then bulk-creates via the shared `_create_roles`.
+> Sits alongside the existing "one colour for all" / "create with no colour". Pure UI; no schema change.
+>
 > **▶ Refinement (2026-06-21 — PR #1250):** **listener self-heal** makes #1248's cleanup automatic —
 > `reaction_role_service._self_heal_dead_binding` drops a binding whose role was deleted the moment a
 > member reacts (or un-reacts) on it, audited as a **`system`** action (an `actor_type` param was

--- a/tests/unit/views/test_role_management_panel.py
+++ b/tests/unit/views/test_role_management_panel.py
@@ -33,6 +33,33 @@ def _parent() -> MagicMock:
 
 
 @pytest.mark.asyncio
+async def test_management_list_renders_role_mentions_for_colour():
+    """The role list renders each role as a mention (Discord colours it), not as
+    plain bold text — matching the reaction-role panel (owner ask, 2026-06-22).
+    """
+    from views.roles.management_panel import ManagementPanel
+
+    red = SimpleNamespace(id=10, name="Red", mention="<@&10>")
+    blue = SimpleNamespace(id=20, name="Blue", mention="<@&20>")
+    everyone = SimpleNamespace(id=1, name="@everyone", mention="@everyone")
+    member = SimpleNamespace(roles=[red])
+    guild = SimpleNamespace(
+        roles=[everyone, red, blue],
+        default_role=everyone,
+        members=[member],
+    )
+    ctx = SimpleNamespace(author=SimpleNamespace(id=7), guild=guild)
+
+    embed = await ManagementPanel(ctx).build_embed()
+    desc = embed.description
+
+    assert "<@&10> — 1 members" in desc
+    assert "<@&20> — 0 members" in desc
+    assert "**Red**" not in desc  # no longer plain bold names
+    assert "@everyone" not in desc  # default role excluded
+
+
+@pytest.mark.asyncio
 async def test_edit_role_modal_edits_the_picked_role_by_id():
     """The Edit modal acts on the already-picked role (id-first) and routes the
     change through the audited RoleLifecycleService, then re-renders the panel.

--- a/tests/unit/views/test_role_pack_flow.py
+++ b/tests/unit/views/test_role_pack_flow.py
@@ -163,3 +163,32 @@ async def test_custom_bulk_commit_no_colour_uses_default() -> None:
     with patch("services.reaction_role_service.ensure_role", new=ensure):
         await _role_pack_flow._commit_custom_roles(interaction, bulk, None)
     assert ensure.await_args.kwargs["color"] == discord.Color.default()
+
+
+@pytest.mark.asyncio
+async def test_per_role_colour_walk_creates_each_with_its_colour() -> None:
+    import discord
+
+    on_created = AsyncMock()
+    flow = _view(on_created=on_created)
+    walker = _role_pack_flow._PerRoleColourView(flow, ["Artist", "Writer"])
+    # The first step names the first role + its position in the walk.
+    assert "Artist" in walker.prompt()
+    assert "1/2" in walker.prompt()
+
+    interaction = _interaction()
+    ids = iter([401, 402])
+    ensure = AsyncMock(side_effect=lambda *a, **k: (next(ids), True, ""))
+    with patch("services.reaction_role_service.ensure_role", new=ensure):
+        await walker._on_pick(interaction, "#e74c3c")  # Artist → red, advance
+        assert walker.index == 1
+        assert "Writer" in walker.prompt()
+        await walker._on_pick(interaction, "")  # Writer → no colour, finish
+
+    assert ensure.await_count == 2
+    assert [c.kwargs["name"] for c in ensure.await_args_list] == ["Artist", "Writer"]
+    colours = [c.kwargs["color"] for c in ensure.await_args_list]
+    assert colours[0] == discord.Color(0xE74C3C)  # picked colour
+    assert colours[1] == discord.Color.default()  # "no colour" → default
+    on_created.assert_awaited_once()
+    assert on_created.await_args.args[1] == [401, 402]


### PR DESCRIPTION
Owner-relayed follow-up (two asks from screenshots):

1. **Role Management list shows role colours** — the 🗂️ Role Management list rendered roles as plain bold text; now it renders them as **mentions** (`role.mention`), which Discord auto-colours, matching the look of the 💬 Reaction Roles panel.
2. **Optional per-role colour for bulk custom roles** — a **🎨 Per-role colours** path on the custom-bulk flow that walks each typed role name with a colour preset picker (one at a time), exactly like the reaction-role emote→role walk (`_BindEmotesView`). Sits alongside the existing "one colour for all" and "create with no colour".

Pure UI on the shipped `_create_roles` / `RolePackView` seam; no schema change.

Owner-directed (Q-0191): opened ready, auto-merge armed.

> **Status:** born-red (`in-progress` card) until complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8UXtfQAdPitwWyzYQnvj1)_