### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-22T17:24:16Z",
+    "generated_at": "2026-06-22T17:29:55Z",
     "build": {
-      "commit": "76f3e7d",
-      "subject": "Fishing menu: real interactive panel (Cast · Rod · Fishdex)",
-      "committed_at": "2026-06-22T17:24:16Z"
+      "commit": "91a3b375",
+      "subject": "Fishing menu: real buttons (Cast · Rod · Fishdex panel) (#1303)",
+      "committed_at": "2026-06-22T17:29:55Z"
     },
     "counts": {
       "functions": 37,


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.