### PR TITLE
CI-enforce the tool-pin guard (close the #1315 three-places drift class)

### DIFF
--- a/.github/workflows/tool-pins.yml
+++ b/.github/workflows/tool-pins.yml
@@ -1,0 +1,56 @@
+name: Tool-pin guard
+
+# Fails when the formatter/linter pins drift across the three places that MUST agree —
+# `.github/workflows/code-quality.yml`, `requirements-dev.txt`, and `.pre-commit-config.yaml`
+# (CLAUDE.md "Match CI exactly" rule #3). `scripts/check_tool_pins.py` is the same check the
+# local `check_quality.py` runs, but that one is LOCAL-ONLY — so a Dependabot bump of a tool in
+# `requirements-dev.txt` alone (it doesn't track the workflow/pre-commit pins) silently desynced
+# the trio and reached `main` (#1315 → fixed in #1317). This workflow closes that hole: such a
+# PR now fails here instead of merging green.
+#
+# Stdlib-only check (no pip install needed). SHA-pinned checkout + setup-python, matching
+# botsite-ci.yml / dashboard-ci.yml. `paths`-filtered to the pin sources so it only runs when one
+# of them changes (cheap). It is NOT yet a required merge check — making it one (so the desync
+# actually BLOCKS auto-merge, not just shows red) is a one-line owner repo-Settings step, the same
+# posture as botsite-ci.yml / design-system-ci.yml.
+#
+# UNVERIFIED (Q-0105, 2026-06-22): confirm it goes green a few times before trusting it; delete
+# this workflow if it proves flaky/unreliable over multiple sessions (the check itself is the
+# load-bearing part and already runs locally — this only adds the CI trigger).
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "requirements-dev.txt"
+      - ".pre-commit-config.yaml"
+      - ".github/workflows/code-quality.yml"
+      - "scripts/check_tool_pins.py"
+      - ".github/workflows/tool-pins.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "requirements-dev.txt"
+      - ".pre-commit-config.yaml"
+      - ".github/workflows/code-quality.yml"
+      - "scripts/check_tool_pins.py"
+      - ".github/workflows/tool-pins.yml"
+
+concurrency:
+  group: tool-pins-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  tool-pins:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.10"
+
+      - name: Check tool pins are aligned across the three places
+        run: python scripts/check_tool_pins.py

--- a/.sessions/2026-06-22-tool-pins-ci-guard.md
+++ b/.sessions/2026-06-22-tool-pins-ci-guard.md
@@ -1,7 +1,8 @@
 # 2026-06-22 — make `check_tool_pins` a CI guard (close the #1315 drift class at the root)
 
-> **Status:** `in-progress` — born-red card (Q-0133). Flips to `complete` as the final step.
+> **Status:** `complete` — born-red card (Q-0133) flipped green as the final step.
 > Routine · dispatch ("Continue from where you left off"; promotes PR #1317's logged idea).
+> PR #1320 → auto-merges on green (Q-0123).
 
 ## Arc
 
@@ -66,3 +67,13 @@ This PR:
    workflow + a checker extension that's behavior-neutral today + tests — fully reversible → self-merged
    on green. Owner follow-ups flagged: (a) mark `tool-pins` a *required* check to actually block merges;
    (b) the Dependabot-`ignore`-the-trio policy option (deferred as a policy call, not applied unilaterally).
+
+## 📤 Run report
+
+- **Did:** CI-enforced the tool-pin guard — a new `tool-pins.yml` workflow runs `check_tool_pins` on any pin-file change (closing the local-only hole that let #1315 reach `main`), extended the checker to genuinely validate all THREE pin sources (it only checked 2), and added its first unit test. · **Outcome:** shipped
+- **Shipped:** #1320 — `.github/workflows/tool-pins.yml` + `scripts/check_tool_pins.py` (now reads `.pre-commit-config.yaml`, injectable `sources`) + `tests/unit/scripts/test_check_tool_pins.py` (8 cases).
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** (optional, not blocking) mark **`tool-pins`** a *required* check in repo Settings so a pin desync actually BLOCKS auto-merge (today it only shows red); optionally add a Dependabot `ignore` rule for black/isort/ruff/mypy so the desyncing PR is never created.
+- **⚑ Self-initiated:** **yes** — promotes PR #1317's logged idea (CI-enforce the guard) to a build on an empty "continue" fire with gated product lanes; additive CI + behavior-neutral checker extension + tests → self-merged on green.
+- **↪ Next:** product lanes remain the priority once attended/un-gated — botsite React-SPA migration **PR 2** (the live `/` cutover; needs a **manual browser click-through**, best attended) is the top S1 item, its data side now de-risked by #1305/#1308/#1317. Other lanes: Project Moon runtime PR 1 (ingestion — network + IP/licensing-sensitive → weigh ask-first). Tooling backlog from this turn's ideas: collapse the three-places pin to one by having `code-quality.yml` install from `requirements-dev.txt` (a focused/attended slice on the critical workflow).

--- a/.sessions/2026-06-22-tool-pins-ci-guard.md
+++ b/.sessions/2026-06-22-tool-pins-ci-guard.md
@@ -1,0 +1,68 @@
+# 2026-06-22 — make `check_tool_pins` a CI guard (close the #1315 drift class at the root)
+
+> **Status:** `in-progress` — born-red card (Q-0133). Flips to `complete` as the final step.
+> Routine · dispatch ("Continue from where you left off"; promotes PR #1317's logged idea).
+
+## Arc
+
+Three botsite/hygiene PRs already merged this session (#1305, #1308, #1317). #1317 had to *fix* a
+ruff tool-pin drift that reached `main` (#1315 — Dependabot bumped `requirements-dev.txt` alone),
+and I logged the root fix as that session's idea: the `check_tool_pins` guard was **local-only**
+(in `check_quality.py`), so nothing stopped the desync at the PR gate. This PR promotes that idea →
+build (Q-0172). With the product lanes gated (PR 2 cutover needs attended browser verification;
+Project Moon ingestion is network/IP-sensitive), this is the cleanest high-value safe slice.
+
+This PR:
+1. **`tool-pins.yml`** — a dedicated, `paths`-filtered CI workflow (sibling of botsite-ci /
+   design-system-ci) that runs `scripts/check_tool_pins.py` on any change to the three pin sources,
+   so a Dependabot lone-file bump now goes **red on the PR** instead of merging green. (Not yet a
+   *required* check — making it block auto-merge is a one-line owner repo-Settings step, flagged.)
+2. **Extend the checker to genuinely validate all THREE places.** It claimed "three places" in its
+   docstring + error text but only compared `code-quality.yml` ↔ `requirements-dev.txt` —
+   `.pre-commit-config.yaml` was never read (a latent gap: a pre-commit `rev:` drift went
+   undetected). Added a `rev:`-format parser (repo→tool map, strips the inconsistent `v` prefix) and
+   made `check()` compare all three. All currently aligned, so no behavior change today.
+3. **First unit test** (`tests/unit/scripts/test_check_tool_pins.py`) — the checker is now
+   CI-gating + load-bearing, so it gets the Q-0105 "verify before you trust" treatment: parser
+   cases, each pairwise drift (incl. the new pre-commit case), missing-pin, missing-file, and a
+   live "the real repo stays aligned" guard. `check()` gained an injectable `sources` param for
+   hermetic testing.
+
+## Shipped (PR — this session)
+
+- **`.github/workflows/tool-pins.yml`** — new guard workflow (SHA-pinned checkout + setup-python
+  3.10, stdlib check, no pip install). Triggers on `requirements-dev.txt` · `.pre-commit-config.yaml`
+  · `code-quality.yml` · the script · itself. Carries the Q-0105 disposable-guard header.
+- **`scripts/check_tool_pins.py`** — now reads `.pre-commit-config.yaml` too (the third place its
+  own message always named); `check(sources=…)` is injectable; success message names all three.
+- **`tests/unit/scripts/test_check_tool_pins.py`** — 8 cases, all green.
+- **Verification:** new tests 8/8 ✓ · `check_quality --check-only` ✓ · real-repo `check_tool_pins`
+  ✓ · `tool-pins.yml` YAML valid · pre-commit parse verified (black 26.5.1 / isort 8.0.1 /
+  ruff 0.15.14 / mypy 2.1.0, all aligned).
+
+## Session enders
+
+- **♻ Grooming (Q-0015):** promoted PR #1317's logged session idea (the CI-step half) down its
+  lifecycle to a shipped build — idea → build in one hop (Q-0172), the dispatch routine's intended
+  flow when product lanes are gated.
+- **💡 Session idea (Q-0089):** *Auto-derive CI's tool versions from `requirements-dev.txt` so the
+  three-places rule collapses to one.* `code-quality.yml` hard-codes `pip install black==… ruff==…`
+  inline — the root cause of the drift class is that the pin lives in 3 hand-synced spots. If the
+  workflow instead did `pip install -r requirements-dev.txt` (or read the versions from it), CI and
+  the dev install could never disagree, leaving only pre-commit to guard. Bigger change to the
+  critical workflow → wants its own focused/attended slice; logged, not done here.
+- **⟲ Previous-session review:** #1317 (this turn's predecessor) correctly *fixed* the #1315 ruff
+  drift and *logged* the root fix instead of stopping — exactly the "fix the symptom now, capture
+  the durable fix" discipline. What it (understandably) didn't do: notice the checker only covered
+  2 of the 3 places it claimed. **System note:** when you fix a drift a guard *should* have caught,
+  also confirm the guard actually covers what its own message promises — a guard that under-checks
+  is worse than none, because it implies coverage it doesn't have.
+- **🧾 Doc audit (Q-0104):** `check_docs --strict` ✓; no current-state/sector change needed (a CI
+  guard, not a product feature); the new workflow is self-documented (header) + this log; ledger
+  auto-updates for this PR on merge. Nothing left only in chat.
+
+## ⚑ Self-initiated: yes (Q-0172) — promotes my own PR-#1317 logged idea (CI-enforce the tool-pin
+   guard) to a build, no dispatch/owner ask (empty "continue" fire, gated product lanes). Additive CI
+   workflow + a checker extension that's behavior-neutral today + tests — fully reversible → self-merged
+   on green. Owner follow-ups flagged: (a) mark `tool-pins` a *required* check to actually block merges;
+   (b) the Dependabot-`ignore`-the-trio policy option (deferred as a policy call, not applied unilaterally).

--- a/docs/owner/claims/claude__funny-franklin-s56i3y-4.md
+++ b/docs/owner/claims/claude__funny-franklin-s56i3y-4.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-s56i3y-4` · scope: make `check_tool_pins` a CI guard (#1315 drift class) — new `tool-pins.yml` workflow + extend the checker to genuinely validate all THREE pin sources (was 2) + first unit test · area: `.github/workflows/tool-pins.yml`, `scripts/check_tool_pins.py`, `tests/unit/scripts/test_check_tool_pins.py` · 2026-06-22

--- a/scripts/check_tool_pins.py
+++ b/scripts/check_tool_pins.py
@@ -4,16 +4,18 @@
 CLAUDE.md rule #3 (and the header of ``requirements-dev.txt``) requires the
 ``black`` / ``isort`` / ``ruff`` / ``mypy`` versions to be **identical** in:
 
-* ``.github/workflows/code-quality.yml`` — what CI installs (the authority), and
-* ``requirements-dev.txt``              — what local / Claude-Code-web sessions install.
+* ``.github/workflows/code-quality.yml`` — what CI installs (the authority),
+* ``requirements-dev.txt``              — what local / Claude-Code-web sessions install, and
+* ``.pre-commit-config.yaml``           — what the pre-commit hooks run.
 
 When they drift, ``scripts/check_quality.py`` silently stops being a true CI
 mirror: a newer local ruff flags rules the pinned CI ruff doesn't (and vice
 versa) — "passes/fails locally, opposite in CI" churn. This is **not** a
 hypothetical: dependabot PR #1074 bumped ``requirements-dev.txt``'s ruff to
 0.15.18 while CI stayed at 0.15.14, so local runs flagged an ``ERA001`` that CI
-never enforced (BUG-0022). Dependabot bumps the requirements file but not the
-workflow pin, so this trap recurs — hence a guard.
+never enforced (BUG-0022); it recurred in #1315 (fixed #1317). Dependabot bumps
+the requirements file but not the workflow / pre-commit pins, so this trap
+recurs — hence a guard (now also a CI trigger via ``.github/workflows/tool-pins.yml``).
 
 Stdlib-only. Exit 0 = aligned; exit 1 = a mismatch (prints the offenders).
 
@@ -28,10 +30,29 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "code-quality.yml"
 REQUIREMENTS_DEV = REPO_ROOT / "requirements-dev.txt"
+PRE_COMMIT = REPO_ROOT / ".pre-commit-config.yaml"
 
 # The tools whose output changes between releases, so a drift breaks the mirror.
 _TOOLS = ("black", "isort", "ruff", "mypy")
 _PIN = re.compile(r"\b(black|isort|ruff|mypy)==([0-9][0-9A-Za-z.\-]*)")
+
+# Pre-commit identifies a tool by its hook repo, and pins via ``rev:`` (with an
+# inconsistent leading ``v`` — ruff/mypy carry it, black/isort don't), so it needs
+# its own parser rather than the ``tool==version`` regex above.
+_PRECOMMIT_REPO_TO_TOOL = {
+    "psf/black": "black",
+    "pycqa/isort": "isort",
+    "ruff-pre-commit": "ruff",
+    "mirrors-mypy": "mypy",
+}
+_PRECOMMIT_REV = re.compile(r"rev:\s*v?([0-9][0-9A-Za-z.\-]*)")
+
+# Human-readable source labels, in authority order (CI first).
+_SOURCES = (
+    ("code-quality.yml", CI_WORKFLOW),
+    ("requirements-dev.txt", REQUIREMENTS_DEV),
+    (".pre-commit-config.yaml", PRE_COMMIT),
+)
 
 
 def _pins(text: str) -> dict[str, set[str]]:
@@ -42,32 +63,60 @@ def _pins(text: str) -> dict[str, set[str]]:
     return found
 
 
-def check() -> list[str]:
+def _precommit_pins(text: str) -> dict[str, set[str]]:
+    """Tool → ``rev`` versions in a ``.pre-commit-config.yaml`` (``v`` prefix stripped)."""
+    found: dict[str, set[str]] = {t: set() for t in _TOOLS}
+    current: str | None = None
+    for line in text.splitlines():
+        repo = re.search(r"repo:\s*(\S+)", line)
+        if repo:
+            current = next(
+                (
+                    tool
+                    for key, tool in _PRECOMMIT_REPO_TO_TOOL.items()
+                    if key in repo.group(1)
+                ),
+                None,
+            )
+            continue
+        if current:
+            rev = _PRECOMMIT_REV.search(line)
+            if rev:
+                found[current].add(rev.group(1))
+                current = None  # consumed this repo's rev
+    return found
+
+
+def _pins_for(label: str, path: Path) -> dict[str, set[str]]:
+    text = path.read_text(encoding="utf-8")
+    return _precommit_pins(text) if label == ".pre-commit-config.yaml" else _pins(text)
+
+
+def check(sources: tuple[tuple[str, Path], ...] = _SOURCES) -> list[str]:
     """Return a list of human-readable mismatch messages (empty == all aligned)."""
     problems: list[str] = []
-    for path in (CI_WORKFLOW, REQUIREMENTS_DEV):
+    for _label, path in sources:
         if not path.exists():
-            problems.append(f"missing pin source: {path.relative_to(REPO_ROOT)}")
+            problems.append(f"missing pin source: {path}")
     if problems:
         return problems
 
-    ci = _pins(CI_WORKFLOW.read_text(encoding="utf-8"))
-    dev = _pins(REQUIREMENTS_DEV.read_text(encoding="utf-8"))
+    pins = {label: _pins_for(label, path) for label, path in sources}
 
     for tool in _TOOLS:
-        ci_v, dev_v = ci[tool], dev[tool]
-        if not ci_v or not dev_v:
-            # A tool not pinned in one place is its own (softer) problem; report it.
-            if ci_v or dev_v:
-                problems.append(
-                    f"{tool}: pinned in only one place "
-                    f"(code-quality.yml={sorted(ci_v) or '—'}, requirements-dev.txt={sorted(dev_v) or '—'})",
-                )
+        by_source = {label: pins[label][tool] for label, _ in sources}
+        present = {label: v for label, v in by_source.items() if v}
+        if not present:
             continue
-        if ci_v != dev_v:
+        missing = [label for label, _ in sources if not by_source[label]]
+        all_versions = set().union(*present.values())
+        if len(all_versions) > 1 or missing:
+            detail = ", ".join(
+                f"{label}={sorted(by_source[label]) or '—'}" for label, _ in sources
+            )
             problems.append(
-                f"{tool}: CI pins {sorted(ci_v)} but requirements-dev.txt pins {sorted(dev_v)} "
-                f"— align them (CLAUDE.md rule #3) so check_quality.py mirrors CI",
+                f"{tool}: pins disagree ({detail}) "
+                f"— align all three (CLAUDE.md rule #3) so check_quality.py mirrors CI",
             )
     return problems
 
@@ -83,7 +132,10 @@ def main() -> int:
             "and .pre-commit-config.yaml (the three-places rule).",
         )
         return 1
-    print("✓ tool pins aligned — code-quality.yml == requirements-dev.txt")
+    print(
+        "✓ tool pins aligned — code-quality.yml == requirements-dev.txt "
+        "== .pre-commit-config.yaml",
+    )
     return 0
 
 

--- a/tests/unit/scripts/test_check_tool_pins.py
+++ b/tests/unit/scripts/test_check_tool_pins.py
@@ -1,0 +1,143 @@
+"""Tests for scripts/check_tool_pins.py — the three-places tool-pin guard.
+
+The checker became a CI gate (`.github/workflows/tool-pins.yml`) after a lone
+Dependabot bump of ruff in `requirements-dev.txt` (#1315) drifted from the
+workflow + pre-commit pins and reached `main` (fixed #1317) — so it is now
+load-bearing and gets its own tests (the Q-0105 "verify before you trust"
+posture for a guard that can block merges).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO / "scripts" / "check_tool_pins.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_tool_pins_ut", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return _load()
+
+
+# --- the parsers (pure on text) -------------------------------------------
+
+
+def test_pins_parses_equals_pins(mod):
+    text = "pip install black==26.5.1 isort==8.0.1 ruff==0.15.14 mypy==2.1.0"
+    got = {k: sorted(v) for k, v in mod._pins(text).items()}
+    assert got == {
+        "black": ["26.5.1"],
+        "isort": ["8.0.1"],
+        "ruff": ["0.15.14"],
+        "mypy": ["2.1.0"],
+    }
+
+
+def test_precommit_pins_maps_repo_to_tool_and_strips_v_prefix(mod):
+    text = """
+repos:
+  - repo: https://github.com/psf/black
+    rev: 26.5.1
+    hooks: [{id: black}]
+  - repo: https://github.com/pycqa/isort
+    rev: 8.0.1
+    hooks: [{id: isort}]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.14
+    hooks: [{id: ruff}]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v2.1.0
+    hooks: [{id: mypy}]
+"""
+    got = {k: sorted(v) for k, v in mod._precommit_pins(text).items()}
+    # v-prefix stripped so v0.15.14 compares equal to the requirements 0.15.14.
+    assert got == {
+        "black": ["26.5.1"],
+        "isort": ["8.0.1"],
+        "ruff": ["0.15.14"],
+        "mypy": ["2.1.0"],
+    }
+
+
+# --- check() across three synthetic sources -------------------------------
+
+_CI = "pip install black==26.5.1 isort==8.0.1 ruff==0.15.14 mypy==2.1.0"
+_DEV = "black==26.5.1\nisort==8.0.1\nruff==0.15.14\nmypy==2.1.0\n"
+_PRECOMMIT = """
+repos:
+  - repo: https://github.com/psf/black
+    rev: 26.5.1
+    hooks: [{id: black}]
+  - repo: https://github.com/pycqa/isort
+    rev: 8.0.1
+    hooks: [{id: isort}]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.14
+    hooks: [{id: ruff}]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v2.1.0
+    hooks: [{id: mypy}]
+"""
+
+
+def _sources(tmp_path: Path, ci: str, dev: str, precommit: str):
+    (tmp_path / "code-quality.yml").write_text(ci, encoding="utf-8")
+    (tmp_path / "requirements-dev.txt").write_text(dev, encoding="utf-8")
+    (tmp_path / ".pre-commit-config.yaml").write_text(precommit, encoding="utf-8")
+    return (
+        ("code-quality.yml", tmp_path / "code-quality.yml"),
+        ("requirements-dev.txt", tmp_path / "requirements-dev.txt"),
+        (".pre-commit-config.yaml", tmp_path / ".pre-commit-config.yaml"),
+    )
+
+
+def test_check_passes_when_all_three_aligned(mod, tmp_path):
+    assert mod.check(_sources(tmp_path, _CI, _DEV, _PRECOMMIT)) == []
+
+
+def test_check_flags_dev_vs_ci_drift(mod, tmp_path):
+    # The exact #1315 trap: requirements-dev.txt bumped alone.
+    drifted = _DEV.replace("ruff==0.15.14", "ruff==0.15.18")
+    problems = mod.check(_sources(tmp_path, _CI, drifted, _PRECOMMIT))
+    assert any("ruff" in p and "disagree" in p for p in problems)
+
+
+def test_check_flags_precommit_drift(mod, tmp_path):
+    # The latent gap the old (two-file) checker missed: pre-commit alone drifts.
+    drifted = _PRECOMMIT.replace("rev: v0.15.14", "rev: v0.15.18")
+    problems = mod.check(_sources(tmp_path, _CI, _DEV, drifted))
+    assert any("ruff" in p for p in problems)
+
+
+def test_check_flags_pin_missing_in_one_place(mod, tmp_path):
+    dev_without_mypy = _DEV.replace("mypy==2.1.0\n", "")
+    problems = mod.check(_sources(tmp_path, _CI, dev_without_mypy, _PRECOMMIT))
+    assert any("mypy" in p for p in problems)
+
+
+def test_check_reports_missing_source_file(mod, tmp_path):
+    sources = _sources(tmp_path, _CI, _DEV, _PRECOMMIT)
+    (tmp_path / "requirements-dev.txt").unlink()
+    problems = mod.check(sources)
+    assert any("missing pin source" in p for p in problems)
+
+
+# --- the real repo stays aligned (a live guard, not just a unit) -----------
+
+
+def test_real_repo_pins_are_aligned(mod):
+    assert (
+        mod.check() == []
+    ), "the repo's three pin sources have drifted — run the guard"


### PR DESCRIPTION
## What

Promotes PR #1317's logged session idea to a build (Q-0172): make the tool-pin guard a **CI check** so the three-places pin desync that reached `main` in #1315 (Dependabot bumped `requirements-dev.txt`'s ruff alone; #1317 had to fix it) can't recur silently. The guard already existed in `check_quality.py` but was **local-only** — nothing ran it at the PR gate.

## Scope

1. **`.github/workflows/tool-pins.yml`** — a dedicated, `paths`-filtered guard workflow (sibling of `botsite-ci` / `design-system-ci`; SHA-pinned actions, stdlib check, no pip install) that runs `scripts/check_tool_pins.py` on any change to the three pin sources. A lone-file bump now goes **red on the PR** instead of merging green.
   - Not yet a *required* check — making it actually block auto-merge is a one-line owner repo-Settings step (same posture as the sibling CI workflows; flagged for the owner).
2. **Checker now genuinely validates all THREE places.** It claimed "three places" in its docstring + error text but only compared `code-quality.yml` ↔ `requirements-dev.txt` — `.pre-commit-config.yaml` was never read (a latent gap: a pre-commit `rev:` drift went undetected). Added a `rev:`-format parser (repo→tool map, strips the inconsistent `v` prefix) and made `check()` compare all three. All currently aligned → no behavior change today.
3. **First unit test** (`tests/unit/scripts/test_check_tool_pins.py`, 8 cases) — the checker is now CI-gating + load-bearing, so it gets the Q-0105 "verify before you trust" treatment (parsers, each pairwise drift incl. the new pre-commit case, missing-pin, missing-file, and a live "real repo stays aligned" guard). `check()` gained an injectable `sources` param for hermetic testing.

## Owner follow-ups (flagged, not applied)
- Mark `tool-pins` a **required** check to actually block merges (repo Settings).
- Optional: a Dependabot `ignore` rule for black/isort/ruff/mypy so the desyncing PR is never created (deferred — it's an update-policy call, not applied unilaterally).

## Status

🔴 Born-red until close-out, then flipped green. Auto-merges on green (Q-0123).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136PFGC2UQcLifvJZkmB5Y5

---
_Generated by [Claude Code](https://claude.ai/code/session_0136PFGC2UQcLifvJZkmB5Y5)_