### PR TITLE
Route mining-grid encounters design to the owner (router Q-0198)

### DIFF
--- a/.sessions/2026-06-22-route-mining-encounters.md
+++ b/.sessions/2026-06-22-route-mining-encounters.md
@@ -1,7 +1,8 @@
 # 2026-06-22 — route the mining-grid-encounters design to the owner (Q-0198)
 
-> **Status:** `in-progress` — born-red card (Q-0133). Flips to `complete` as the final step.
+> **Status:** `complete` — born-red card (Q-0133) flipped green as the final step.
 > Routine · dispatch ("Continue from where you left off"; grooming-routes an owner-reserved idea).
+> PR #1325 → auto-merges on green (Q-0123).
 
 ## Arc
 
@@ -27,10 +28,55 @@ This PR (docs-only):
    grounded in the shipped systems, so it's a quick approve-or-tweak, not an open essay.
 2. **Idea status** → routed to Q-0198 (so the lifecycle pointer resolves both ways).
 
-## Shipped
+## Shipped (PR #1325)
 
-_(filled at close)_
+- **Router Q-0198 (DISCUSS)** in `docs/owner/maintainer-question-router.md` — poses the 4
+  mining-grid-encounter design decisions to the owner, each with a concrete recommended default +
+  rationale grounded in shipped systems: (1) depth z≥10 / ~8% per action / ~5-action cooldown, all
+  config-driven; (2) loot/flavour-only v1, reuse creature/deathmatch engine if combat is added (never
+  a third model); (3) live roll gated by depth (terrain deterministic, events live); (4) buttons on
+  the existing navigator embed. Cross-links Q-0173 (grid design) + Q-0186 (wild-encounters — the
+  *shared resolution engine* opportunity) + the anti-mandatory (Q-0087) / atomic-workflow (Q-0071) rails.
+- **Idea status** — `mining-grid-encounters-2026-06-22.md` Open-questions section now marked ROUTED
+  to Q-0198 (lifecycle pointer resolves both ways; "don't build ahead of the answer" noted).
+- **Verification:** `check_docs --strict` ✓. Docs-only; no runtime/CI scope.
 
 ## Session enders
 
-_(filled at close)_
+- **♻ Grooming (Q-0015):** this turn *was* the grooming task in its "route an ambiguous idea to a
+  router discussion" form — advanced the one owner-named product follow-up toward buildability without
+  deciding its design unprompted. Deliberately chose this over a 7th infra guard to break the
+  infra-bound pattern.
+- **💡 Session idea (Q-0089):** *Build the shared `utils/.../encounter.py` resolution engine once, two
+  triggers.* Q-0198 (grid/exploration-triggered) and Q-0186 (chat-activity-triggered) both need an
+  encounter table + an audited resolution op; the only real difference is the *trigger*. When the
+  owner greenlights either, design the pure engine (table → roll → audited `*_workflow` reward op) as a
+  shared `utils` module both cogs call, so the second trigger is a thin add, not a second engine.
+  Logged in both idea files' "shared engine" notes; this elevates it to a build-time directive.
+- **⟲ Previous-session review:** the run of turns before this one (5 PRs, 4 infra) was *individually*
+  sound — each guard fixed a real recurring tax — but *collectively* drifted infra-bound while the
+  product roadmap sat untouched. **This turn is the correction:** when the only "decided/small" ideas
+  left are guards, the right move isn't a 7th guard — it's to *unblock* the gated product work
+  (route the owner's decision), which is higher leverage than building more scaffolding around an
+  un-advancing product. **System note (carried from last turn):** a dispatch run still can't *see* "0
+  ungated product lanes" vs "I judged them gated" — a `current-state`/`dispatch_menu` signal that
+  distinguishes them would let a run pick "route the gated item to the owner" *deliberately* instead
+  of discovering it by exhaustion.
+- **🧾 Doc audit (Q-0104):** `check_docs --strict` ✓; the router Q + idea pointer cross-resolve; no
+  current-state change needed (an open design question, not shipped state); ledger auto-updates for
+  #1325 on merge. Nothing left only in chat.
+
+## ⚑ Self-initiated: yes (Q-0172) — grooming-routed an owner-reserved idea (mining-grid encounters) to
+   a router DISCUSS Q-0198 with recommended defaults; no dispatch/owner ask. Docs-only, no design
+   *decided* (the idea + Q-0173 explicitly reserve the design for the owner) — it poses, doesn't decide.
+   Fully reversible.
+
+## 📤 Run report
+
+- **Did:** routed the one owner-named mining-grid follow-up (encounters) to the owner as router DISCUSS **Q-0198** — 4 design decisions with recommended defaults — instead of building a 7th infra guard, so the highest-value gated *product* item is ready for his quick approve-or-tweak. · **Outcome:** shipped
+- **Shipped:** #1325 — Q-0198 (DISCUSS) + the idea status → routed. Docs-only.
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** **Q-0198** — mining-grid encounters: depth threshold/chance/cooldown · loot-vs-combat (+ engine) · determinism · resolution UI (defaults proposed; a quick ✓/tweak unblocks the build).
+- **⚑ Owner manual steps:** `none`
+- **⚑ Self-initiated:** **yes** — grooming-routed an owner-reserved idea to the router (poses, doesn't decide); docs-only, reversible.
+- **↪ Next:** **the fleet is product-gated and the owner is the unblock.** Top items needing him: (1) **botsite React-SPA PR 2** — the live `/` cutover; needs a browser look (verify locally via `npm --prefix design-system run dev:app`, its data side de-risked by #1305/#1308/#1317/#1320); (2) **Q-0198** — answer the encounter design to unblock that build; (3) optional ops: mark the new `tool-pins` check *required* + the Dependabot-ignore policy call (#1320). Still gated without him: Project Moon ingestion (network/IP → ask-first), BUG-0009 (data/provenance + creds), BUG-0019 (ambient-AI design fork). The docs reconciliation (Recon DUE at #1320) is the separate routine's job (Q-0124), not a dispatch session's.

--- a/.sessions/2026-06-22-route-mining-encounters.md
+++ b/.sessions/2026-06-22-route-mining-encounters.md
@@ -1,0 +1,36 @@
+# 2026-06-22 — route the mining-grid-encounters design to the owner (Q-0198)
+
+> **Status:** `in-progress` — born-red card (Q-0133). Flips to `complete` as the final step.
+> Routine · dispatch ("Continue from where you left off"; grooming-routes an owner-reserved idea).
+
+## Arc
+
+Six PRs already merged this session (#1305 React foundation, #1308 contract guard, #1317 ledger/CI
+hygiene, #1320 tool-pin CI guard, #1322 migration-collision guard — and #1279's reaction-roles PR 6
+landed mid-session). Four of those were infra/guards because **every product lane is gated** — I
+flagged that infra-bound drift myself last turn. This turn deliberately breaks the pattern: instead
+of building a 7th guard, advance the highest-value **product** item as far as is safe.
+
+That item is **mining-grid encounters** — the *one owner-named* grid follow-up
+([idea](../docs/ideas/mining-grid-encounters-2026-06-22.md), origin Q-0173). The owner shipped the
+grid Mine *encounter-free by explicit decision* and said encounters "ARE wanted, as a separate later
+session." The idea file itself instructs: **"route to a router Q before building, don't decide
+unprompted"** (4 open design questions). So the sanctioned grooming step (Q-0015: route an ambiguous
+idea to a router discussion) — **not** an unprompted build — is to pose those decisions to the owner
+with concrete recommended defaults, so on his return he can ✓/adjust in minutes and the next session
+builds immediately. (Q-0172 "build freely" yields here to the owner's explicit design reservation +
+the idea's own route-first instruction.)
+
+This PR (docs-only):
+1. **Router Q-0198 (DISCUSS)** — the 4 design decisions (depth threshold/chance/cooldown · encounter
+   content & combat engine · determinism · resolution UI), each with a recommended default + rationale
+   grounded in the shipped systems, so it's a quick approve-or-tweak, not an open essay.
+2. **Idea status** → routed to Q-0198 (so the lifecycle pointer resolves both ways).
+
+## Shipped
+
+_(filled at close)_
+
+## Session enders
+
+_(filled at close)_

--- a/docs/ideas/mining-grid-encounters-2026-06-22.md
+++ b/docs/ideas/mining-grid-encounters-2026-06-22.md
@@ -41,7 +41,11 @@ one is **exploration-triggered** while actively roaming the mine grid (depth-gat
 could **share one encounter-resolution engine** (a pure `utils/.../encounter.py` table + an audited
 workflow op) with two different *triggers* — worth designing the engine once if both are built.
 
-## Open design questions (route to a router Q before building, don't decide unprompted)
+## Open design questions — ROUTED to the owner as router **Q-0198** (DISCUSS, 2026-06-22)
+
+The four decisions below are now posed to the owner with recommended defaults in
+[`docs/owner/maintainer-question-router.md` § Q-0198](../owner/maintainer-question-router.md) — once
+he answers, a runtime session builds it (small PRs, runtime-verified). Do **not** build ahead of that.
 
 1. **Depth threshold + per-action chance + cooldown** (config-driven; the "not too many" tuning).
 2. **Encounter content** — pure flavour/loot events vs. light combat (and if combat, which engine).

--- a/docs/owner/claims/claude__funny-franklin-s56i3y-6.md
+++ b/docs/owner/claims/claude__funny-franklin-s56i3y-6.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-s56i3y-6` · scope: route the mining-grid-encounters design (Q-0173 follow-up) to the owner — new router DISCUSS Q-0198 with 4 decisions + recommended defaults; mark the idea routed. Docs-only. · area: `docs/owner/maintainer-question-router.md`, `docs/ideas/mining-grid-encounters-2026-06-22.md` · 2026-06-22

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -7210,3 +7210,49 @@ is now unreferenced and harmless). PR for this change: branch `claude/jolly-saga
 
 **Home:** this Q-block (canonical) + `.claude/CLAUDE.md` § Session & plan workflow +
 `docs/operations/hermes-skills/README.md`.
+
+### Q-0198 — DISCUSS: mining-grid encounters — depth threshold, content, determinism, resolution UI (2026-06-22)
+
+> **PROPOSED — surfaced by a dispatch grooming pass** (product lanes were gated, so instead of a 7th
+> infra guard this routes the *one owner-named* grid follow-up toward buildability). Origin **Q-0173**:
+> the owner shipped the grid Mine (`views/mining/grid_mine_view.py`, hub-redesign PR 3) *encounter-free
+> by explicit decision* — *"v1 = free movement, NO encounters … encounters ARE wanted, as a separate
+> later session."* The [idea](../ideas/mining-grid-encounters-2026-06-22.md) itself says **"route to a
+> router Q before building, don't decide unprompted"** — so this poses the decisions, with defaults,
+> rather than building. Q-0172 "build freely" yields here to the owner's explicit design reservation.
+
+**Context:** layer **sparse, depth-gated random encounters** onto the shipped grid navigator — a
+low-probability event on a `move` / `Mine here` action once deep enough, resolved through the audited
+`mining_workflow` seam (RS02/Q-0071), never a direct view write, and **never mandatory-feeling**
+(Q-0087). The grid already persists a seed-deterministic `(seed, x, y, z)` world, so encounters can be
+deterministic + shareable for free. **Distinct from Q-0186 / the [wild-encounters
+idea](../ideas/wild-encounters-activity-spawning-2026-06-20.md):** that one is *chat-activity-triggered*
+channel spawns; this is *exploration-triggered* while roaming the grid. They could share **one pure
+`encounter` resolution engine** with two triggers — worth building the engine once if both land.
+
+**The questions (the agent recommends; the owner-designer decides):**
+1. **Depth threshold + per-action chance + cooldown** (the "not too many" tuning). *Recommendation:*
+   no encounters above depth **z ≥ 10** (surface bands stay calm for casual play); **~8 %** per qualifying
+   `move`/`mine` action; a **per-player cooldown of ~5 actions** so roaming isn't interrupt-spam. All
+   config-driven constants (sim-tunable like the economy constants), off-by-default-safe.
+2. **Encounter content — flavour/loot vs. light combat.** *Recommendation:* **start loot/flavour-only**
+   for v1 (a small table: ore vein / hazard that costs energy / abandoned cache of coins), routed through
+   `economy_service` / `update_mining_item` / `game_xp_service` exactly like `mine_here`. **If combat is
+   wanted, reuse the creature/deathmatch engine** — never a third bespoke combat model (the idea's
+   anti-pattern). Combat can be a fast-follow once the loot loop proves out.
+3. **Determinism — fully seed-deterministic per cell vs. a live roll.** *Recommendation:* **a live roll
+   gated by depth/cooldown**, *not* per-cell-deterministic — two players' runs should differ and a cell
+   shouldn't farm the same encounter on every revisit (the grid's *terrain* stays deterministic; the
+   *events* are live). Keeps it an event, not a map feature.
+4. **Resolution UI — extra buttons on the navigator vs. a swapped sub-view.** *Recommendation:* **extra
+   buttons on the existing navigator embed** (Fight/Flee/Loot as the content dictates) — stays in the
+   one grid surface, no view juggling; matches the calm, in-place UX the grid already uses.
+
+**Agent note:** these gate the *build*, not a plan — the shape is small + additive (the same discipline
+grid v1 followed) and ungated apart from this design call; once answered, a runtime session builds it in
+small PRs (pure `utils/mining/encounter.py` table + an audited `mining_workflow` op + navigator buttons),
+runtime-verified. **Home:** this Q-block (canonical) + the
+[mining-grid-encounters idea](../ideas/mining-grid-encounters-2026-06-22.md) +
+[`planning/mining-hub-redesign-2026-06-15.md`](../planning/mining-hub-redesign-2026-06-15.md) (PR 3's
+"Later — encounters"). Related: **Q-0173** (grid design), **Q-0186** (wild-encounters spawn design —
+shared engine), Q-0087 (never mandatory), Q-0071 (atomic workflow).


### PR DESCRIPTION
## What

Grooming (Q-0015) advances the **one owner-named** mining-grid follow-up — [grid encounters](../blob/main/docs/ideas/mining-grid-encounters-2026-06-22.md) (origin Q-0173) — down its lifecycle by **routing its design decisions to the owner**, not building unprompted. The owner shipped the grid Mine *encounter-free by explicit decision* ("encounters ARE wanted, as a separate later session"), and the idea file itself says *"route to a router Q before building, don't decide unprompted."*

So this is the sanctioned next step: a router **DISCUSS Q-0198** posing the 4 open design decisions, each with a **concrete recommended default + rationale** grounded in the already-shipped systems — a quick approve-or-tweak for the owner on his return, after which a session can build it immediately.

## Why this, not another guard

This session shipped 6 PRs but 4 were infra/guards because the product lanes are all gated. Rather than build a 7th guard (over-rotating), this teees up the highest-value *product* item for the owner — the thing that actually needs him.

## Scope (docs-only)

- `docs/owner/maintainer-question-router.md` — new Q-0198 (DISCUSS) with the 4 decisions + defaults.
- `docs/ideas/mining-grid-encounters-2026-06-22.md` — status → routed to Q-0198.

## Status

🔴 Born-red until close-out, then flipped green. Auto-merges on green (Q-0123).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136PFGC2UQcLifvJZkmB5Y5

---
_Generated by [Claude Code](https://claude.ai/code/session_0136PFGC2UQcLifvJZkmB5Y5)_