### PR TITLE
feat(btd6): unified round economy reply (RBE + cash + XP)

### DIFF
--- a/.sessions/2026-06-22-round-economy-reply.md
+++ b/.sessions/2026-06-22-round-economy-reply.md
@@ -1,16 +1,82 @@
 # 2026-06-22 — Unified round economy NL reply (RBE + cash + XP)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 Owner-directed (the maintainer approved the round-economy consolidation idea
 filed in the #1324 session: "Yes that's a good idea you can implement that").
-Round economy data (RBE, cash, cumulative cash, XP) is now answered by three
-separate paths — cash via `ai_round_cash_workflow`, XP via the new
-`deterministic_round_xp_reply`, RBE via none. Adding one
-`deterministic_round_economy_reply` that gives all of them in a single grounded
-answer ("what's the economy of round 95?"), matching the round embed's Economy
-field.
+Round economy data (RBE, cash, cumulative cash, XP) was answered by three
+separate paths — cash via `ai_round_cash_workflow`, XP via
+`deterministic_round_xp_reply` (#1324), RBE via none — so "what's the economy of
+round 95?" had no single answer even though the round embed already shows all
+three together. This adds one consolidated reply.
 
 ## Shipped
 
-_(filling in)_
+- **`disbot/services/btd6_context_service.py`** — `deterministic_round_economy_reply`,
+  a pre-emptive BUG-0009 floor builder grounded on `RoundEntry` (RBE / cash /
+  cumulative cash) + `round_base_xp`. Fires on a round number + an economy cue
+  (`economy` / `overview` / `summary` / `stats` / `rewards` / `rbe` /
+  `breakdown`); supports ABR via the standard `_ABR_CUE_RE` (cash + RBE differ
+  between sets, XP does not). Registered **before** `deterministic_round_xp_reply`
+  in `_BTD6_LIST_BUILDERS` so a multi-stat / economy question gets the
+  consolidated answer while a pure "how much xp" (no economy cue) still routes to
+  the narrower XP reply.
+- **Tests** — `test_btd6_round_economy_reply.py` (RBE+cash+XP presence, grounding
+  on the helpers, multiple economy cues, ABR support, the three defer paths,
+  dispatcher routing, and the pure-XP-question-defers-to-XP-builder boundary) +
+  a `_SHOULD_FIRE` corpus entry in the floor-exclusivity invariant.
+
+Verified: economy + xp-reply + floor-exclusivity suites green (52 passed); `mypy`
+clean; `check_architecture --mode strict` 0 errors; full `check_quality --full`
+run before flipping this card ready.
+
+## ⚑ Self-initiated
+
+No — owner-directed (explicit "Yes that's a good idea you can implement that").
+PR #1326 opened born-red → flipped ready; auto-merge armed (Q-0191 owner-directed
+→ merge on green).
+
+## 💡 Session idea (Q-0089)
+
+**Surface the round economy on the embed/`!btd6 round N` path with the *scaled*
+XP, difficulty-aware.** The NL economy reply and the embed both show the Beginner
+base XP; a player on an Expert map earns ×1.3. A small follow-up: let the embed
+(and the economy reply) optionally echo the four difficulty XP values
+(or at least name the scaling) the same way the standalone XP reply already does,
+so the consolidated answer is as difficulty-complete as the dedicated one.
+Genuine: `round_xp_earned` already computes it; it's a formatting extension, not
+new modelling.
+
+## ⟲ Previous-session review (Q-0102)
+
+The #1324 session surfaced round XP in two places and *filed* this consolidation
+as a Q-0089 idea rather than building it — correct scoping (it kept #1324 a clean
+two-surface change), and the idea was specific enough that this session could pick
+it up directly with no re-discovery. That's the idea-backlog loop working as
+designed: a session generates a concrete, buildable idea; the next one ships it.
+System note: the BTD6 round-answer surface now has four builders/paths
+(cash workflow, XP reply, economy reply, embed) — worth a short
+`docs/subsystems/btd6.md` note mapping "round question shape → which path owns it"
+so the next agent doesn't add a fifth overlapping one. Filed as a grooming
+candidate.
+
+## 🔎 Doc audit (Q-0104)
+
+- economy + exclusivity + xp suites + `mypy` + `check_architecture` green; full
+  `check_quality --full` before flipping ready.
+- No owner-decision/router change (a feature build on owner direction).
+- No `current-state` ledger touch — recorded by the auto-triggered Q-0107
+  reconciliation pass. Unmerged PR #1326 correctly absent.
+- The reply is self-documenting (builder docstring + cue-regex comment); the
+  "round-question shape → owning path" map is filed as the Q-0089/grooming note
+  above, not a gap this PR leaves open.
+
+## Context delta
+
+- **Needed but not pointed to:** the dispatcher's order-resolves-genuine-overlap
+  contract — registering the broader economy builder *before* the narrower XP
+  builder is exactly the documented pattern (multi-entity before single), but it
+  is easy to get backwards. The exclusivity invariant + the explicit
+  "pure-XP-defers" test pin it.
+- **Pointed to but didn't need:** nothing notable — a contained, single-builder
+  addition reusing the round-number regex and ABR cue already in the module.

--- a/.sessions/2026-06-22-round-economy-reply.md
+++ b/.sessions/2026-06-22-round-economy-reply.md
@@ -1,0 +1,16 @@
+# 2026-06-22 — Unified round economy NL reply (RBE + cash + XP)
+
+> **Status:** `in-progress`
+
+Owner-directed (the maintainer approved the round-economy consolidation idea
+filed in the #1324 session: "Yes that's a good idea you can implement that").
+Round economy data (RBE, cash, cumulative cash, XP) is now answered by three
+separate paths — cash via `ai_round_cash_workflow`, XP via the new
+`deterministic_round_xp_reply`, RBE via none. Adding one
+`deterministic_round_economy_reply` that gives all of them in a single grounded
+answer ("what's the economy of round 95?"), matching the round embed's Economy
+field.
+
+## Shipped
+
+_(filling in)_

--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -3955,6 +3955,69 @@ def deterministic_round_xp_reply(message_text: str) -> str | None:
     )
 
 
+# --- "Economy of round N" deterministic reply ---------------------------------
+# The consolidated round-economy answer: RBE + cash (+ cumulative) + XP in one
+# grounded reply, matching the round embed's Economy field. Round economy is
+# otherwise spread across three paths (cash → ai_round_cash_workflow, XP →
+# deterministic_round_xp_reply, RBE → none), so "what's the economy of round 95"
+# had no single answer. Registered BEFORE the XP builder so a multi-stat /
+# economy question gets the consolidated answer while a pure "how much xp" (no
+# economy cue) still routes to the narrower XP reply.
+_ROUND_ECONOMY_CUE_RE = re.compile(
+    r"\b(?:economy|economic|overview|summary|breakdown|stats?|rewards?|rbe)\b",
+    re.I,
+)
+
+
+def deterministic_round_economy_reply(message_text: str) -> str | None:
+    """A code-built "economy of round N" answer (RBE + cash + XP), or ``None``.
+
+    Fires on a round number + an economy cue (economy / overview / summary /
+    stats / rewards / rbe / breakdown), served as a pre-emptive floor. Supports
+    ABR via the standard cue (cash/RBE differ between sets; XP does not). Defers
+    (``None``) without an economy cue, without a round number, or for a round not
+    in the set — those reach the narrower builders or the model.
+    """
+    text = (message_text or "").strip()
+    if not text:
+        return None
+    low = text.lower()
+    if not _ROUND_ECONOMY_CUE_RE.search(low):
+        return None
+    number_match = _ROUND_XP_NUMBER_RE.search(low)
+    if number_match is None:
+        return None
+    round_number = int(number_match.group(1) or number_match.group(2))
+
+    from services import btd6_data_service
+
+    roundset = "alternate" if _ABR_CUE_RE.search(low) else "default"
+    entry = btd6_data_service.get_round(round_number, roundset)
+    if entry is None:
+        return None
+    base_xp = btd6_data_service.round_base_xp(round_number)
+
+    set_label = "ABR" if roundset == "alternate" else "default rounds"
+    lines = [f"**Round {round_number} — RBE, cash & XP** ({set_label})"]
+    if entry.rbe is not None:
+        lines.append(f"• **RBE** {entry.rbe:,}")
+    if entry.cash is not None:
+        cumulative = (
+            f" (cumulative ${entry.cumulative_cash:,.0f})"
+            if entry.cumulative_cash is not None
+            else ""
+        )
+        lines.append(f"• **Cash** ${entry.cash:,.0f}{cumulative}")
+    if base_xp is not None:
+        lines.append(
+            f"• **XP** {base_xp:,} (Beginner base, before freeplay/Monkey Knowledge)",
+        )
+    # Nothing groundable beyond the header → defer rather than send an empty card.
+    if len(lines) == 1:
+        return None
+    return "\n".join(lines)
+
+
 # --- BUG-0009 deterministic list-answer dispatcher ----------------------------
 # The ordered floor builders the dispatcher fans out to. Each OWNS its labelled
 # answer and is narrow (returns ``None`` for anything but its exact list shape),
@@ -3965,6 +4028,7 @@ def deterministic_round_xp_reply(message_text: str) -> str | None:
 # *live* tuple — a builder added here is automatically held to the one-fires
 # contract, no test edit needed. Append a new list family here.
 _BTD6_LIST_BUILDERS: tuple[Callable[[str], str | None], ...] = (
+    deterministic_round_economy_reply,
     deterministic_round_xp_reply,
     deterministic_mk_reference_reply,
     deterministic_mk_category_roster_reply,

--- a/docs/owner/claims/claude__round-economy-reply.md
+++ b/docs/owner/claims/claude__round-economy-reply.md
@@ -1,1 +1,0 @@
-- claude/round-economy-reply · unified round economy NL reply (RBE+cash+XP in one) · btd6_context_service.py + tests · 2026-06-22

--- a/docs/owner/claims/claude__round-economy-reply.md
+++ b/docs/owner/claims/claude__round-economy-reply.md
@@ -1,0 +1,1 @@
+- claude/round-economy-reply · unified round economy NL reply (RBE+cash+XP in one) · btd6_context_service.py + tests · 2026-06-22

--- a/docs/owner/claims/claude__round-xp-replies.md
+++ b/docs/owner/claims/claude__round-xp-replies.md
@@ -1,1 +1,0 @@
-- claude/round-xp-replies · surface BTD6 round XP (NL floor reply + round-embed Economy field) · btd6_context_service.py + btd6_knowledge_service.py + btd6_response_builder.py + tests · 2026-06-22

--- a/tests/unit/invariants/test_btd6_floor_builder_exclusivity.py
+++ b/tests/unit/invariants/test_btd6_floor_builder_exclusivity.py
@@ -112,6 +112,10 @@ _SHOULD_FIRE: tuple[tuple[str, str], ...] = (
         "how much xp does round 63 give",
         "deterministic_round_xp_reply",
     ),
+    (
+        "what's the economy of round 95",
+        "deterministic_round_economy_reply",
+    ),
 )
 
 # Ordinary BTD6 questions / strategy / single-entity lookups — zero builders fire.

--- a/tests/unit/services/test_btd6_round_economy_reply.py
+++ b/tests/unit/services/test_btd6_round_economy_reply.py
@@ -1,0 +1,121 @@
+"""Deterministic "economy of round N" floor reply — RBE + cash + XP in one answer.
+
+Consolidates the three round-economy stats (otherwise split across the cash
+workflow, the XP floor reply, and no RBE reply) into one grounded answer that
+mirrors the round embed's Economy field. These cover the reply's grounding,
+roundset support, and defer paths; exclusivity with the narrower XP builder is
+pinned by test_btd6_floor_builder_exclusivity.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from services import btd6_context_service, btd6_data_service  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_dataset_cache():
+    btd6_data_service.reset_cache()
+    yield
+    btd6_data_service.reset_cache()
+
+
+def test_reply_includes_rbe_cash_and_xp():
+    reply = btd6_context_service.deterministic_round_economy_reply(
+        "what's the economy of round 63",
+    )
+    assert reply is not None
+    entry = btd6_data_service.get_round(63)
+    assert entry is not None
+    assert entry.rbe is not None and f"{entry.rbe:,}" in reply
+    assert entry.cash is not None and f"${entry.cash:,.0f}" in reply
+    base_xp = btd6_data_service.round_base_xp(63)
+    assert base_xp is not None and f"{base_xp:,}" in reply
+    assert "Round 63" in reply
+
+
+def test_reply_grounds_on_the_data_not_hardcoded():
+    for rnd in (5, 50, 95):
+        reply = btd6_context_service.deterministic_round_economy_reply(
+            f"round {rnd} economy overview",
+        )
+        entry = btd6_data_service.get_round(rnd)
+        assert reply is not None and entry is not None
+        assert entry.rbe is not None and f"{entry.rbe:,}" in reply
+
+
+def test_various_economy_cues_fire():
+    for phrase in (
+        "round 40 stats",
+        "round 40 rewards",
+        "round 40 summary",
+        "what is the rbe of round 40",
+        "round 40 economy breakdown",
+    ):
+        assert (
+            btd6_context_service.deterministic_round_economy_reply(phrase) is not None
+        ), phrase
+
+
+def test_abr_roundset_is_supported():
+    default_reply = btd6_context_service.deterministic_round_economy_reply(
+        "economy of round 60",
+    )
+    abr_reply = btd6_context_service.deterministic_round_economy_reply(
+        "economy of round 60 in abr",
+    )
+    assert default_reply is not None and abr_reply is not None
+    assert "ABR" in abr_reply
+    # ABR cash differs from the default set, so the two answers are not identical.
+    assert abr_reply != default_reply
+
+
+def test_defers_without_an_economy_cue():
+    # No economy/stats/rbe cue → a bare "tell me about round 63" is not ours.
+    assert (
+        btd6_context_service.deterministic_round_economy_reply("tell me about round 63")
+        is None
+    )
+
+
+def test_defers_without_a_round():
+    assert (
+        btd6_context_service.deterministic_round_economy_reply(
+            "what economy relics exist"
+        )
+        is None
+    )
+
+
+def test_defers_for_out_of_range_round():
+    assert (
+        btd6_context_service.deterministic_round_economy_reply("economy of round 999")
+        is None
+    )
+
+
+def test_dispatcher_routes_the_economy_reply():
+    reply = btd6_context_service.deterministic_btd6_list_reply(
+        "what's the economy of round 95",
+    )
+    assert reply is not None
+    assert "Round 95" in reply
+
+
+def test_pure_xp_question_routes_to_the_xp_builder_not_economy():
+    # "how much xp does round 63 give" has no economy cue → economy defers and the
+    # narrower XP builder owns it, even though economy is registered first.
+    assert (
+        btd6_context_service.deterministic_round_economy_reply(
+            "how much xp does round 63 give",
+        )
+        is None
+    )


### PR DESCRIPTION
Owner-directed follow-up (the consolidation idea filed in the #1324 session, approved: *"Yes that's a good idea you can implement that"*).

## Problem

Round economy data is now answered by **three** disjoint paths:
- **Cash** → `ai_round_cash_workflow` (heavy orchestration)
- **XP** → `deterministic_round_xp_reply` (#1324)
- **RBE** → no dedicated NL reply at all

So "what's the economy of round 95?" has no single answer, even though the round **embed** already shows all three together (the Economy field).

## This PR

Adds `deterministic_round_economy_reply` — one pre-emptive BUG-0009 floor builder that gives **RBE + cash (+ cumulative) + XP** in a single grounded answer, sourced from `RoundEntry` + `round_base_xp`. Fires on a round number **plus** an economy cue (`economy` / `overview` / `summary` / `stats` / `rewards` / `rbe` / `breakdown`); supports ABR via the standard cue. It's registered **before** the XP builder, so a pure "how much xp does round N give" still routes to the narrower XP reply (no economy cue), while a multi-stat / economy question gets the consolidated answer.

Example: *"what's the economy of round 63?"* →
> **Round 63 — RBE, cash & XP**
> • **RBE** 14,413
> • **Cash** $2,826 (cumulative $60,578)
> • **XP** 2,790 (Beginner base, before freeplay/Monkey Knowledge)

## Verification
- New tests for the reply (RBE/cash/XP presence, grounding on the helpers, ABR, defer paths) + an exclusivity-corpus entry confirming exactly one builder fires.
- `check_quality --full` + `check_architecture --mode strict` before the card flips ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkmmB6VkKZYCynpobaZUu5)_