### PR TITLE
Hermes one-command + auto redeploy (no terminal needed)

### DIFF
--- a/.sessions/2026-06-22-hermes-redeploy.md
+++ b/.sessions/2026-06-22-hermes-redeploy.md
@@ -1,0 +1,49 @@
+# 2026-06-22 — Hermes one-command + auto redeploy (no more Terminus)
+
+> **Status:** `complete`
+
+Owner-directed follow-on to the Q-0197 session. The owner's pain: applying a merged Hermes
+change (SOUL.md / skills) meant hand-running git reset + install-soul + install-skills + a
+gateway restart in Terminus every time — and the gateway can't restart itself from inside its
+own process. Owner: "it would be easier if I didn't have to do it on terminus every time …
+I wouldn't even need terminus anymore then."
+
+## What this ships
+- `scripts/hermes/redeploy.sh` — one command: sync mirror → install SOUL + skills → **detached**
+  gateway restart (`systemd-run --on-active=3s`, so it's safe even when Hermes runs it itself).
+  `--if-changed` / `--dry-run` flags; auto-detects user-vs-system gateway service to avoid sudo.
+- `scripts/hermes/systemd/hermes-redeploy.{service,timer}` — user-level timer templates that run
+  `redeploy.sh --if-changed` every ~10 min → **merge=deploy for Hermes** (Railway-worker analogue).
+- `docs/operations/hermes-redeploy.md` — one-time install + both modes + sudo/kill-switch notes;
+  linked from the terminal cheatsheet.
+- Folded in the lingering **Q-0197 leftover**: `hermes-operating-prompt.md` still told Hermes it had
+  the review-merge merge gate (lines 53/129/145) — removed.
+
+## Verification
+- `bash -n scripts/hermes/redeploy.sh` ✓ (syntax) · `install-soul.sh --dry-run` ✓ (SOUL still
+  extracts, 0 review-merge mentions, 7142B)
+- `check_docs.py --strict` ✓ (new doc reachable via the cheatsheet) · `check_quality.py --check-only` ✓
+- Can't exercise systemd/the restart in CI (no VPS) — marked UNVERIFIED in the script header + doc;
+  confirm on first VPS run via `journalctl --user -u hermes-redeploy.service`.
+
+## ⚑ Self-initiated
+The redeploy tooling is owner-requested (the Terminus pain point) — built directly per the go-ahead.
+Not flagged as self-initiated feature work.
+
+## 💡 Session idea
+Same merge=deploy timer pattern could cover the **Hermes session-reset** and any future VPS-side
+config: a single `~/.config/systemd/user/` "Hermes ops" bundle installer (`install-vps-units.sh`)
+that drops session-reset + redeploy units in one step, so the VPS one-time setup is itself one
+command. Worth an idea file if more VPS units appear.
+
+## ⟲ Previous-session review
+The Q-0197 session (this same chat) retired the label/rule well but **missed the
+`hermes-operating-prompt.md` review-merge references** — caught only because the owner asked about
+Hermes capabilities and I re-read the prompt. Improvement surfaced + applied: when retiring a
+concept, grep the *operating prompt / SOUL source* explicitly, not just the skill docs — the SOUL
+is the live prompt and drifts silently (it's only ~reachable via install-soul, not the doc-link
+graph). Folded that fix into this PR.
+
+## Doc audit
+New doc linked from the cheatsheet; `check_docs --strict` green. No ledger entry needed until merge
+(the reconciliation pass records it).

--- a/docs/operations/hermes-operating-prompt.md
+++ b/docs/operations/hermes-operating-prompt.md
@@ -50,7 +50,7 @@ WHAT YOU MAY WRITE (Q-0140, Q-0141)
 - For BIG or risky code changes, prefer to DISPATCH to Claude Code: it is the primary builder and
   runs under the full CI mirror (black/mypy/pytest on Python 3.10) that you cannot run here. Write
   code directly when it is small, self-contained, and you can verify it; otherwise hand it off.
-- Merge a PR you have independently reviewed (the review-merge gate, Q-0117) — once calibrated.
+- You do NOT merge PRs — every PR auto-merges on green CI. Open clean PRs and let CI land them.
 
 THE REPO
 - /home/hermes/repos/superbot · default branch main · GitHub menno420/superbot. The clone is a
@@ -125,8 +125,8 @@ YOUR MEMORY (lean on the repo, not your head)
   your cron-output files. Read on demand.
 
 SAFETY
-- Never push straight to main — everything you write goes through a PR + CI. Never merge except
-  the review-merge gate once TRUSTED. Never print secrets/tokens.
+- Never push straight to main — everything you write goes through a PR + CI. You never merge;
+  PRs auto-merge on green CI. Never print secrets/tokens.
 - Railway/Neon: READ for verification is fine (Q-0130); do not mutate production unless I
   explicitly direct it. If unsure whether an action is a mutation, assume it is and ask.
 
@@ -142,7 +142,7 @@ YOUR SKILLS
   between work  -> repo-health, open-questions, ideas-triage, btd6-status
   something off -> log-triage
   build it      -> dispatch (fire a Claude Code routine); vague "do sector SX" -> dispatch-resolve
-  review a PR   -> review / review-merge
+  review a PR   -> review
   make a skill  -> skill-author (design a new skill -> docs-only PR)
 ```
 

--- a/docs/operations/hermes-redeploy.md
+++ b/docs/operations/hermes-redeploy.md
@@ -1,0 +1,99 @@
+# Hermes redeploy — apply merged changes to the live VPS without a terminal
+
+> **Status:** `reference` — setup + operation guide for `scripts/hermes/redeploy.sh` and its
+> systemd timer. Pairs with [`hermes-control-plane.md`](hermes-control-plane.md) (the setup record),
+> [`hermes-terminal-cheatsheet.md`](hermes-terminal-cheatsheet.md) (command reference), and
+> [`hermes-session-reset.md`](hermes-session-reset.md) (the same user-timer pattern).
+
+## The problem this solves
+
+A merged Hermes change (the operating prompt in `SOUL.md`, or a skill) does **not** go live on its
+own. Until now, applying it meant opening a terminal and running, every time:
+
+```bash
+cd ~/repos/superbot
+git fetch origin main && git reset --hard origin/main
+bash scripts/hermes/install-soul.sh
+bash scripts/hermes/install-skills.sh
+sudo systemctl restart hermes-gateway
+```
+
+That's the chore. Two ways to kill it:
+
+- **One command** — `scripts/hermes/redeploy.sh` does all of the above in a single call (and Hermes
+  can run it itself).
+- **Zero commands** — a user systemd timer runs `redeploy.sh --if-changed` on a schedule, so
+  **merging a Hermes change to `main` makes it live on its own within ~10 minutes** — the same
+  "merge = deploy" model Railway already gives the bot worker (Q-0193).
+
+> **Why Hermes can't just `systemctl restart` itself:** the gateway refuses to restart from inside
+> its own process (anti-restart-loop guard), and an in-process restart would kill the live turn.
+> `redeploy.sh` sidesteps this by **detaching** the restart with `systemd-run --on-active=3s`, so
+> the restart fires from a separate transient unit after the turn ends. That's what makes a
+> self-service / automatic redeploy possible at all.
+
+## `redeploy.sh`
+
+```bash
+bash scripts/hermes/redeploy.sh              # sync + reinstall SOUL/skills + restart (always)
+bash scripts/hermes/redeploy.sh --if-changed # no-op when already at origin/main (used by the timer)
+bash scripts/hermes/redeploy.sh --dry-run    # show what it would do, change nothing
+```
+
+It is safe to run from inside a Hermes chat turn (the restart is detached) **and** from the timer.
+After `git reset`, it re-execs itself from a `/tmp` copy so resetting the script mid-run is safe.
+
+**`sudo` note (auto-detected):** if `hermes-gateway` is a **user** service (`systemctl --user`),
+`redeploy.sh` restarts it with **no sudo at all**. If it's a **system** service (the current
+setup — `sudo systemctl restart hermes-gateway`), the detached restart needs passwordless sudo for
+that one action. Grant it narrowly (visudo):
+
+```
+hermes ALL=(root) NOPASSWD: /usr/bin/systemd-run *
+```
+
+(Or, cleaner long-term, run the gateway as a `systemctl --user` service so no sudo is ever needed.)
+
+## Automatic mode — the merge=deploy timer (recommended)
+
+User-level systemd units, same pattern as [`hermes-session-reset.md`](hermes-session-reset.md).
+The unit templates live in [`scripts/hermes/systemd/`](../../scripts/hermes/systemd/). One-time
+install, as the `hermes` user:
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp ~/repos/superbot/scripts/hermes/systemd/hermes-redeploy.service ~/.config/systemd/user/
+cp ~/repos/superbot/scripts/hermes/systemd/hermes-redeploy.timer   ~/.config/systemd/user/
+
+systemctl --user daemon-reload
+systemctl --user enable --now hermes-redeploy.timer
+loginctl enable-linger hermes        # so the timer runs even when you're not logged in
+```
+
+That's the last terminal session you need: from here on, merge a Hermes change and it deploys
+itself. Tune the cadence by editing `OnUnitActiveSec` in the timer (default 10 min).
+
+### Verify
+
+```bash
+systemctl --user list-timers hermes-redeploy.timer        # next run time
+journalctl --user -u hermes-redeploy.service -n 30        # last run output
+```
+
+## On-demand mode (no timer)
+
+Skip the timer and just run `bash scripts/hermes/redeploy.sh` when you want — or tell Hermes
+"redeploy" and let it run the script itself. Same effect, manually triggered.
+
+## Kill switch (Q-0105)
+
+This is convenience automation, **disposable**. If it misfires:
+
+```bash
+systemctl --user disable --now hermes-redeploy.timer   # stop the auto loop
+```
+
+…and the manual five-command sequence at the top of this doc always works by hand. Delete
+`scripts/hermes/redeploy.sh` + `scripts/hermes/systemd/hermes-redeploy.*` if it proves unreliable
+over several runs. **UNVERIFIED until confirmed on the VPS** — it can't be exercised in CI (no
+systemd there), so watch the first couple of auto-runs in `journalctl`.

--- a/docs/operations/hermes-terminal-cheatsheet.md
+++ b/docs/operations/hermes-terminal-cheatsheet.md
@@ -23,6 +23,17 @@ sudo journalctl -u hermes-gateway -f           # Live-tail the logs (Ctrl+C to s
 
 ## Deploy repo config → Hermes (after a session changes prompts/skills)
 
+**One command** (sync + reinstall SOUL/skills + detached restart) — full guide in
+[`hermes-redeploy.md`](hermes-redeploy.md). Or install the auto-redeploy timer from that doc so
+merge-to-`main` goes live on its own with no terminal at all:
+
+```bash
+bash scripts/hermes/redeploy.sh                # do the whole deploy now (safe to run anywhere)
+bash scripts/hermes/redeploy.sh --dry-run      # show what it would do, change nothing
+```
+
+The manual long-form (the steps `redeploy.sh` automates), if you want them individually:
+
 ```bash
 cd /home/hermes/repos/superbot                 # Go to the repo (lines below assume you're here).
 git fetch origin main && git reset --hard origin/main   # Sync the mirror to GitHub before re-installing. Discards local repo edits (it's a read-only mirror); never aborts on divergence.

--- a/scripts/hermes/redeploy.sh
+++ b/scripts/hermes/redeploy.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# scripts/hermes/redeploy.sh — one-command Hermes redeploy (sync -> reinstall -> restart).
+#
+# Provenance / reliability header (CLAUDE.md Q-0105 adopt-with-kill-switch):
+# - Why: applying a merged Hermes change (SOUL.md / skills) to the live VPS otherwise means
+#   hand-running git reset + install-soul + install-skills + a gateway restart in a terminal
+#   EVERY time (owner pain point, 2026-06-22). This collapses it to ONE command — and pairs with
+#   the systemd timer in scripts/hermes/systemd/ to make it fully automatic (merge=deploy for
+#   Hermes, mirroring how Railway auto-redeploys the bot worker).
+# - Added 2026-06-22 (Q-0197 follow-on). UNVERIFIED — it cannot run in CI (no VPS / no systemd
+#   here); confirm the one-time install once on the VPS (docs/operations/hermes-redeploy.md) and
+#   watch the first couple of auto-runs. DELETE this script + the units if they misfire — a manual
+#   `git reset --hard origin/main && install-soul && install-skills && sudo systemctl restart
+#   hermes-gateway` always works by hand.
+#
+# Why a DETACHED restart: the gateway cannot restart itself from inside its own process (the CLI
+# guards against restart loops, and an in-process restart would kill the live turn). systemd-run
+# schedules the restart as a separate transient unit a few seconds out, so this script is safe to
+# run even when Hermes invokes it itself from a chat turn.
+#
+# Usage (VPS, as the `hermes` user, from anywhere):
+#   bash scripts/hermes/redeploy.sh              # sync + reinstall + restart (always)
+#   bash scripts/hermes/redeploy.sh --if-changed # no-op when already at origin/main (for the timer)
+#   bash scripts/hermes/redeploy.sh --dry-run    # show what it would do, change nothing
+#
+# Override the repo path with HERMES_REPO (default: ~/repos/superbot).
+set -euo pipefail
+
+REPO="${HERMES_REPO:-$HOME/repos/superbot}"
+IF_CHANGED=0
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --if-changed) IF_CHANGED=1 ;;
+    --dry-run) DRY_RUN=1 ;;
+    -h | --help)
+      sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+log() { printf '[hermes-redeploy %s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+
+# --- Phase 1: sync the mirror to merged main (skipped on the re-exec pass) ---
+if [[ -z "${HERMES_REDEPLOY_REEXEC:-}" ]]; then
+  cd "$REPO"
+  git fetch --quiet origin main
+  local_sha="$(git rev-parse HEAD)"
+  remote_sha="$(git rev-parse origin/main)"
+  if [[ "$IF_CHANGED" -eq 1 && "$local_sha" == "$remote_sha" ]]; then
+    log "already at ${remote_sha:0:8} — nothing to redeploy."
+    exit 0
+  fi
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    log "DRY RUN — would reset ${local_sha:0:8} -> ${remote_sha:0:8}, install SOUL+skills, restart gateway (detached)."
+    exit 0
+  fi
+  log "syncing ${local_sha:0:8} -> ${remote_sha:0:8}"
+  git reset --hard --quiet origin/main
+  # Re-exec from a stable copy: `git reset` just rewrote this very file, and editing a running
+  # script in place is unsafe (bash re-reads from disk by byte offset). Run the freshly-synced
+  # post-sync steps from a /tmp copy instead.
+  tmp="$(mktemp)"
+  cp "$REPO/scripts/hermes/redeploy.sh" "$tmp"
+  chmod +x "$tmp"
+  HERMES_REDEPLOY_REEXEC=1 exec "$tmp" "$@"
+fi
+
+# --- Phase 2: reinstall + restart (the re-exec'd, up-to-date copy) -----------
+trap 'rm -f "$0"' EXIT # clean up the /tmp re-exec copy
+cd "$REPO"
+log "installing SOUL.md + skills"
+bash scripts/hermes/install-soul.sh
+bash scripts/hermes/install-skills.sh
+
+# Detached restart. Auto-detect a user-managed vs system gateway service so we only use sudo when
+# the service genuinely needs it (a `systemctl --user` gateway needs none).
+if systemctl --user is-enabled hermes-gateway >/dev/null 2>&1; then
+  log "scheduling user-service gateway restart in 3s (no sudo)"
+  systemd-run --user --quiet --on-active=3s --unit=hermes-redeploy-restart \
+    systemctl --user restart hermes-gateway
+else
+  log "scheduling system-service gateway restart in 3s (sudo)"
+  sudo systemd-run --quiet --on-active=3s --unit=hermes-redeploy-restart \
+    systemctl restart hermes-gateway
+fi
+log "done — gateway restarts momentarily with the new SOUL + skills."

--- a/scripts/hermes/systemd/hermes-redeploy.service
+++ b/scripts/hermes/systemd/hermes-redeploy.service
@@ -1,0 +1,15 @@
+# Hermes auto-redeploy — oneshot: sync merged main and redeploy IF it changed.
+#
+# User-level unit (install under ~/.config/systemd/user/ as the `hermes` user), mirroring
+# hermes-session-reset.* — see docs/operations/hermes-redeploy.md for the one-time install.
+# `--if-changed` makes it a cheap no-op when the mirror is already at origin/main, so the timer
+# can poll often without churn. The gateway restart inside redeploy.sh is detached (systemd-run),
+# so this stays a clean oneshot.
+[Unit]
+Description=Redeploy Hermes from merged main (sync SOUL + skills, restart gateway if changed)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/repos/superbot/scripts/hermes/redeploy.sh --if-changed

--- a/scripts/hermes/systemd/hermes-redeploy.timer
+++ b/scripts/hermes/systemd/hermes-redeploy.timer
@@ -1,0 +1,16 @@
+# Hermes auto-redeploy timer — poll merged main every 10 minutes and redeploy if it changed.
+#
+# User-level unit (install under ~/.config/systemd/user/ as the `hermes` user). This is the
+# "merge = deploy for Hermes" loop, the analogue of Railway auto-redeploying the bot worker:
+# merge a Hermes change to main and it goes live on its own within ~10 minutes, no terminal.
+# Tune OnUnitActiveSec to taste. See docs/operations/hermes-redeploy.md.
+[Unit]
+Description=Check merged main and redeploy Hermes if it changed
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=10min
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Why

Applying a merged Hermes change (the `SOUL.md` operating prompt, or a skill) to the live VPS meant hand-running `git reset` + `install-soul` + `install-skills` + a gateway restart in a terminal **every time** — and the gateway can't restart itself from inside its own process (anti-restart-loop guard). This removes that chore.

## What

- **`scripts/hermes/redeploy.sh`** — one command: sync mirror → install SOUL + skills → **detached** gateway restart via `systemd-run --on-active=3s`. The detach is the key trick: it schedules the restart from a separate transient unit *after* the turn ends, so it's safe even when **Hermes runs it itself** from a chat turn. Has `--if-changed`/`--dry-run`, auto-detects user-vs-system gateway service (no `sudo` when the service is user-managed), and re-execs from a temp copy so `git reset` rewriting the script mid-run is safe.
- **`scripts/hermes/systemd/hermes-redeploy.{service,timer}`** — user-level timer templates that run `redeploy.sh --if-changed` every ~10 min → **merge = deploy for Hermes**, the analogue of Railway auto-redeploying the bot worker. Once installed, *no terminal ever again*.
- **`docs/operations/hermes-redeploy.md`** — one-time install, both modes (one-command + auto-timer), the user-service-vs-sudo note, and a kill-switch. Linked from the terminal cheatsheet.
- **Q-0197 leftover fixed:** `hermes-operating-prompt.md` (the live SOUL source) still told Hermes it had the review-merge merge gate — removed. SOUL now extracts with **0** review-merge mentions, and slightly smaller than before.

## Verification

`bash -n redeploy.sh` ✓ · `install-soul.sh --dry-run` ✓ (extracts clean, 0 review-merge) · `check_docs --strict` ✓ · `check_quality --check-only` ✓.

**Unverified in CI** (no VPS/systemd here) — flagged in the script header + doc with a kill-switch; confirm on the first VPS run via `journalctl --user -u hermes-redeploy.service`.

## One-time install (the only terminal session you need after this)

```bash
cp ~/repos/superbot/scripts/hermes/systemd/hermes-redeploy.* ~/.config/systemd/user/
systemctl --user daemon-reload && systemctl --user enable --now hermes-redeploy.timer
loginctl enable-linger hermes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GP1R31peJcfRjJ4BcXLvaL)_