### PR TITLE
fix(farm): fresh coop no longer starts full + "while you were away" idle summary

### DIFF
--- a/.sessions/2026-06-22-farm-freshstart-and-idle-summary.md
+++ b/.sessions/2026-06-22-farm-freshstart-and-idle-summary.md
@@ -1,24 +1,60 @@
 # 2026-06-22 — farm fresh-start faucet fix + "while you were away" idle summary
 
-> **Status:** `in-progress` — born-red card (Q-0133); flips to `complete` as the final step.
-> Continuation of the idle-farm session (#1328 merged). PR auto-merges on green (Q-0123).
+> **Status:** `complete` — born-red card (Q-0133) flipped green as the final step.
+> Continuation of the idle-farm session (#1328 merged). PR #1331 → auto-merges on green (Q-0123).
 
-## What I'm about to do
+## What shipped
 
-Two cohesive changes on the chicken farm's accrual read path:
+Two cohesive changes on the chicken farm's accrual read path.
 
-1. **Bug fix (root, jumps the queue):** a brand-new farm's coop settles to **full** because
-   `chicken_farm.eggs_updated_at` defaults to epoch 0 — `settle()` then measures elapsed time
-   from 1970, so every new player can collect a free full coop (~40 coins) on first `!farm`.
-   Fix at the root: normalize an uninitialized timestamp (`ts == 0`) to *now* in the workflow
-   read path, so idle accrual starts from first contact (empty coop), not from 1970. One
-   helper used by `get_state` / `collect` / `buy_chicken` / `upgrade_coop`. + a regression test.
+### 1. Bug fix (root, jumped the queue)
+A brand-new farm's coop settled to **full** because `chicken_farm.eggs_updated_at` defaults to
+epoch `0` — `settle()` measured elapsed time from 1970, so every new player could collect a free
+full coop (~40 coins) on their first `!farm`. Verified before fixing (fresh `settle` → 20/20 eggs
+→ 40 coins). **Fixed at the root:** `farm_workflow._stored_state` normalizes an uninitialized
+timestamp (`ts == 0`) to *now*, so idle accrual starts from first contact (an empty coop), never
+retroactively. One helper, used by `get_state` / `collect` / `buy_chicken` / `upgrade_coop`.
+Regression-pinned (`tests/unit/services/test_farm_workflow.py`: fresh = empty; real ts preserved).
 
-2. **Idea → build (Q-0172):** the "while you were away" offline-progress summary I captured
-   last session ([`docs/ideas/idle-game-offline-summary-2026-06-22.md`]). A pure
-   `utils/idle_summary.py` (`format_duration` + `summarize_idle_gain`) that narrates the
-   return-moment ("While you were away (2h 14m), your hens laid **17** eggs"); the farm panel
-   shows it on open. Reuses the existing settle deltas; `format_duration` also replaces the
-   farm menu's local `_fmt_wait` (de-dup, the rule-of-three start).
+### 2. Idea → build (Q-0172): "while you were away" idle summary
+Built last session's captured idea (`docs/ideas/idle-game-offline-summary-2026-06-22.md`):
+- **`utils/idle_summary.py`** (pure, game-agnostic): `format_duration` + `summarize_idle_gain`
+  → "🌙 While you were away (2h 14m) you gained **17** eggs." Returns `None` when nothing
+  accrued, so it only narrates a real return-moment (and stays quiet on rapid re-opens).
+- **`farm_workflow.get_status`** — a read-only `FarmStatus(state, eggs_gained, elapsed_seconds,
+  at_capacity)` measuring the delta vs the *stored* state (fresh farm → 0/0, no spurious blurb).
+- **Farm panel** shows the blurb as a "🌙 Welcome back" field on open/refresh; `format_duration`
+  also replaced the menu's local `_fmt_wait` (the de-dup the idea flagged as the rule-of-three
+  start). After a collect, the delta is 0 → no blurb (clean).
 
-Will fill in Shipped / Verification / enders below before flipping to `complete`.
+## Verification
+- `python3.10 -m pytest tests/unit` → **11719 passed, 47 skipped, 2 xfailed, 0 failed**
+  (incl. 8 new idle-summary + 5 new farm-workflow tests).
+- `check_quality --check-only` (black/isort/ruff/check_docs/check_consistency/tool-pins) ✓ ·
+  `mypy disbot/` 0 · `check_architecture --mode strict` 0.
+- No balance change beyond removing the unintended free-coins faucet — safe alongside play-test
+  tuning. Not live-verified in Discord (no sandbox run); unit-covered + panel CI-asserted actionable.
+
+## Enders
+- **💡 Session idea (Q-0089):** the offline-summary helper is now built but **single-consumer** —
+  the genuine next idea is to **fold the mining + fishing energy hubs onto `idle_summary`** (and,
+  on that third occurrence, extract the shared `settle/spend` core into one `utils` home). That is
+  the rule-of-three the farm's `settle()` copy already flags — recorded in the idea file's live
+  remainder + the games folio, not a new file (it's a continuation, not a new direction).
+- **🧹 Grooming (Q-0015):** moved `idle-game-offline-summary` one full step down its lifecycle
+  (`ideas` → built/`historical`), draining it from the backlog; README + folio updated.
+- **⟲ Previous-session review (Q-0102):** the previous session (the idle-farm build) shipped a
+  clean, well-layered subsystem from a one-word prompt — strong. **What it missed:** the
+  fresh-start faucet bug (epoch-0 timestamp → full coop) — a logic gap the unit tests didn't
+  catch because none exercised the *fresh-player* path (they all built `FarmState` with explicit
+  timestamps). *Workflow improvement it surfaces:* when a new feature defaults a timestamp/counter
+  column, add a "fresh row / zero-default" test case by reflex — the default-value path is exactly
+  the one hand-written test states skip. This session added that case; the lesson generalizes to
+  any `(value, timestamp)` settle system.
+- **📚 Doc audit (Q-0104):** games folio gained the fresh-start contract + return-moment notes;
+  idea file + ideas README marked built; `check_current_state_ledger --strict` + `check_docs
+  --strict` clean. No current-state ledger entry (PR unmerged — next reconciliation records it).
+
+## ⚑ Self-initiated: the offline-summary build (promoting last session's captured idea, Q-0172)
+and the fresh-start bug fix (a root-cause bug found while wiring the summary's elapsed/delta read —
+bugs-first, not scope creep). No new unprompted *direction*.

--- a/.sessions/2026-06-22-farm-freshstart-and-idle-summary.md
+++ b/.sessions/2026-06-22-farm-freshstart-and-idle-summary.md
@@ -1,0 +1,24 @@
+# 2026-06-22 — farm fresh-start faucet fix + "while you were away" idle summary
+
+> **Status:** `in-progress` — born-red card (Q-0133); flips to `complete` as the final step.
+> Continuation of the idle-farm session (#1328 merged). PR auto-merges on green (Q-0123).
+
+## What I'm about to do
+
+Two cohesive changes on the chicken farm's accrual read path:
+
+1. **Bug fix (root, jumps the queue):** a brand-new farm's coop settles to **full** because
+   `chicken_farm.eggs_updated_at` defaults to epoch 0 — `settle()` then measures elapsed time
+   from 1970, so every new player can collect a free full coop (~40 coins) on first `!farm`.
+   Fix at the root: normalize an uninitialized timestamp (`ts == 0`) to *now* in the workflow
+   read path, so idle accrual starts from first contact (empty coop), not from 1970. One
+   helper used by `get_state` / `collect` / `buy_chicken` / `upgrade_coop`. + a regression test.
+
+2. **Idea → build (Q-0172):** the "while you were away" offline-progress summary I captured
+   last session ([`docs/ideas/idle-game-offline-summary-2026-06-22.md`]). A pure
+   `utils/idle_summary.py` (`format_duration` + `summarize_idle_gain`) that narrates the
+   return-moment ("While you were away (2h 14m), your hens laid **17** eggs"); the farm panel
+   shows it on open. Reuses the existing settle deltas; `format_duration` also replaces the
+   farm menu's local `_fmt_wait` (de-dup, the rule-of-three start).
+
+Will fill in Shipped / Verification / enders below before flipping to `complete`.

--- a/disbot/services/farm_workflow.py
+++ b/disbot/services/farm_workflow.py
@@ -36,16 +36,65 @@ BUY_CHICKEN_REASON = "farm:buy_chicken"
 UPGRADE_COOP_REASON = "farm:upgrade_coop"
 
 
+def _stored_state(
+    now: int,
+    chickens: int,
+    eggs: int,
+    ts: int,
+    coop: int,
+) -> farm_mod.FarmState:
+    """Build the stored ``FarmState``, normalizing an uninitialized timestamp.
+
+    A fresh ``chicken_farm`` row defaults ``eggs_updated_at`` to ``0`` (the unix
+    epoch). Settling from 1970 would instantly fill the coop — a free full collect
+    for every brand-new player — so a zero timestamp means **uninitialized**:
+    accrual starts from *now* (an empty coop), never retroactively from 1970. The
+    first collect/buy/upgrade then persists a real timestamp. This is the single
+    place the normalization lives, used by every read/write path below.
+    """
+    return farm_mod.FarmState(chickens, eggs, ts or now, coop)
+
+
 async def get_state(user_id: int, guild_id: int) -> farm_mod.FarmState:
     """The player's *settled* farm state (read-only — writes nothing).
 
     Accrual is pure (a stored value + a timestamp), so showing the panel never
     needs to persist; only the coin-moving ops below settle-and-write.
     """
+    now = int(time.time())
     chickens, eggs, ts, coop = await db.get_chicken_farm(user_id, guild_id)
-    return farm_mod.settle(
-        farm_mod.FarmState(chickens, eggs, ts, coop),
-        int(time.time()),
+    return farm_mod.settle(_stored_state(now, chickens, eggs, ts, coop), now)
+
+
+@dataclass(frozen=True)
+class FarmStatus:
+    """A settled read plus the deltas the "while you were away" blurb needs."""
+
+    state: farm_mod.FarmState
+    #: Eggs accrued since the last action (stored → settled); 0 for a fresh farm.
+    eggs_gained: int
+    #: Seconds since the last action (``now - stored.updated_at``); 0 for fresh.
+    elapsed_seconds: int
+    #: True when the coop is at capacity (so the blurb can nudge a collect).
+    at_capacity: bool
+
+
+async def get_status(user_id: int, guild_id: int) -> FarmStatus:
+    """Read + settle the farm and report what accrued since the last action.
+
+    Read-only (the same no-persist contract as :func:`get_state`). The deltas are
+    measured against the *stored* state, so a fresh farm (normalized to *now*)
+    reports ``eggs_gained=0`` / ``elapsed_seconds=0`` — no spurious return-moment.
+    """
+    now = int(time.time())
+    chickens, eggs, ts, coop = await db.get_chicken_farm(user_id, guild_id)
+    stored = _stored_state(now, chickens, eggs, ts, coop)
+    settled = farm_mod.settle(stored, now)
+    return FarmStatus(
+        state=settled,
+        eggs_gained=max(0, settled.eggs - stored.eggs),
+        elapsed_seconds=max(0, now - stored.updated_at),
+        at_capacity=settled.eggs >= farm_mod.coop_capacity(settled.coop_level),
     )
 
 
@@ -72,7 +121,7 @@ async def collect(user_id: int, guild_id: int) -> CollectResult:
     """
     now = int(time.time())
     chickens, eggs, ts, coop = await db.get_chicken_farm(user_id, guild_id)
-    settled = farm_mod.settle(farm_mod.FarmState(chickens, eggs, ts, coop), now)
+    settled = farm_mod.settle(_stored_state(now, chickens, eggs, ts, coop), now)
     if settled.eggs <= 0:
         return CollectResult(
             False,
@@ -154,7 +203,7 @@ async def buy_chicken(user_id: int, guild_id: int) -> PurchaseResult:
             f"🐔 Your flock is at the cap of **{farm_mod.MAX_CHICKENS}** hens — "
             "that's a lot of clucking!",
         )
-    settled = farm_mod.settle(farm_mod.FarmState(chickens, eggs, ts, coop), now)
+    settled = farm_mod.settle(_stored_state(now, chickens, eggs, ts, coop), now)
     price = farm_mod.chicken_price(chickens)
 
     try:
@@ -213,7 +262,7 @@ async def upgrade_coop(user_id: int, guild_id: int) -> PurchaseResult:
             f"🏠 Your coop is already maxed at level **{farm_mod.MAX_COOP_LEVEL}** "
             f"(holds **{farm_mod.coop_capacity(coop)}** eggs).",
         )
-    settled = farm_mod.settle(farm_mod.FarmState(chickens, eggs, ts, coop), now)
+    settled = farm_mod.settle(_stored_state(now, chickens, eggs, ts, coop), now)
     price = farm_mod.coop_upgrade_price(coop)
     new_capacity = farm_mod.coop_capacity(coop + 1)
 

--- a/disbot/utils/idle_summary.py
+++ b/disbot/utils/idle_summary.py
@@ -1,0 +1,59 @@
+"""Idle-game shared helpers — the "while you were away" return-moment (pure).
+
+The satisfying core of any *idle* game is the **return moment**: you come back
+and the bot tells you what accrued while you were gone. The accrual math already
+lives in each game's pure ``settle()`` (``utils/farm``, ``utils/fishing/energy``,
+``utils/mining/energy``); this module only **renders the delta** so the copy is
+consistent across every idle surface.
+
+Captured as an idea alongside the idle chicken farm
+(``docs/ideas/idle-game-offline-summary-2026-06-22.md``) and built as its first
+consumer (the farm panel). It is deliberately game-agnostic — the caller passes
+the noun and an optional capped note — so a second idle system reuses it as-is.
+
+Pure functions only (no DB, no Discord), so the formatting is unit-testable.
+"""
+
+from __future__ import annotations
+
+
+def format_duration(seconds: int) -> str:
+    """Human-readable elapsed/remaining time — ``now`` / ``45s`` / ``2m 05s`` / ``1h 03m``.
+
+    The one duration formatter for idle surfaces (the farm panel's "fills in" and
+    the "while you were away" blurb both use it — the de-duplication the idea
+    flagged as the rule-of-three start).
+    """
+    if seconds <= 0:
+        return "now"
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m {seconds % 60:02d}s"
+    return f"{seconds // 3600}h {(seconds % 3600) // 60:02d}m"
+
+
+def summarize_idle_gain(
+    gained: int,
+    elapsed_seconds: int,
+    *,
+    noun_singular: str,
+    noun_plural: str,
+    capped: bool = False,
+    capped_note: str | None = None,
+) -> str | None:
+    """The "while you were away" blurb, or ``None`` when nothing accrued.
+
+    Returns ``None`` for a non-positive *gained* — so a panel only narrates the
+    return moment once something has actually accrued since the last action (and
+    so rapid re-opens within one accrual tick stay quiet). When *capped* and a
+    *capped_note* is given, the note is appended to nudge the player to collect.
+    """
+    if gained <= 0:
+        return None
+    noun = noun_singular if gained == 1 else noun_plural
+    when = format_duration(elapsed_seconds)
+    msg = f"🌙 While you were away (**{when}**) you gained **{gained}** {noun}."
+    if capped and capped_note:
+        msg = f"{msg} {capped_note}"
+    return msg

--- a/disbot/views/farm/menu.py
+++ b/disbot/views/farm/menu.py
@@ -21,19 +21,12 @@ import discord
 from services import farm_workflow
 from utils import db
 from utils import farm as farm_mod
+from utils import idle_summary
 from utils.ui_constants import GAME_COLOR
 from views.base import HubView
 
-
-def _fmt_wait(seconds: int) -> str:
-    """Human "fills in" — ``45s`` / ``2m 05s`` / ``1h 03m``."""
-    if seconds <= 0:
-        return "now"
-    if seconds < 60:
-        return f"{seconds}s"
-    if seconds < 3600:
-        return f"{seconds // 60}m {seconds % 60:02d}s"
-    return f"{seconds // 3600}h {(seconds % 3600) // 60:02d}m"
+#: The capped nudge for the farm's "while you were away" blurb.
+_COOP_FULL_NOTE = "The coop is full — collect to keep your hens laying!"
 
 
 def build_farm_embed(
@@ -41,8 +34,13 @@ def build_farm_embed(
     balance: int,
     *,
     seconds_to_full: int = 0,
+    away_summary: str | None = None,
 ) -> discord.Embed:
-    """The main farm-panel embed — flock, coop fill, lay rate, and balance."""
+    """The main farm-panel embed — flock, coop fill, lay rate, and balance.
+
+    *away_summary* (the optional "while you were away" blurb) renders as the first
+    field when something accrued since the player's last action.
+    """
     capacity = farm_mod.coop_capacity(state.coop_level)
     rate = farm_mod.lay_rate_per_hour(state.chickens)
     pending_value = farm_mod.collect_value(state.eggs)
@@ -54,10 +52,12 @@ def build_farm_embed(
         ),
         color=GAME_COLOR,
     )
+    if away_summary:
+        embed.add_field(name="🌙 Welcome back", value=away_summary, inline=False)
     fill = (
         "**full!**"
         if state.eggs >= capacity
-        else f"fills in {_fmt_wait(seconds_to_full)}"
+        else f"fills in {idle_summary.format_duration(seconds_to_full)}"
     )
     embed.add_field(
         name="Coop",
@@ -123,12 +123,20 @@ def build_shop_embed(
 async def _panel_data(
     user_id: int,
     guild_id: int,
-) -> tuple[farm_mod.FarmState, int, int]:
-    """Read the settled state, balance, and seconds-to-full for a redraw."""
-    state = await farm_workflow.get_state(user_id, guild_id)
+) -> tuple[farm_mod.FarmState, int, int, str | None]:
+    """Read the settled state, balance, seconds-to-full, and the away blurb."""
+    status = await farm_workflow.get_status(user_id, guild_id)
     balance = await db.get_coins(user_id, guild_id)
-    to_full = farm_mod.seconds_until_full(state, int(time.time()))
-    return state, balance, to_full
+    to_full = farm_mod.seconds_until_full(status.state, int(time.time()))
+    away = idle_summary.summarize_idle_gain(
+        status.eggs_gained,
+        status.elapsed_seconds,
+        noun_singular="egg",
+        noun_plural="eggs",
+        capped=status.at_capacity,
+        capped_note=_COOP_FULL_NOTE,
+    )
+    return status.state, balance, to_full, away
 
 
 async def open_farm_panel(
@@ -140,9 +148,14 @@ async def open_farm_panel(
     The one entry point shared by ``!farm``, the Help hook, and the Explore-world
     opener, so none of them duplicate the read-then-build sequence.
     """
-    state, balance, to_full = await _panel_data(user.id, guild_id)
+    state, balance, to_full, away = await _panel_data(user.id, guild_id)
     return (
-        build_farm_embed(state, balance, seconds_to_full=to_full),
+        build_farm_embed(
+            state,
+            balance,
+            seconds_to_full=to_full,
+            away_summary=away,
+        ),
         FarmMenuView(user, guild_id),
     )
 
@@ -159,11 +172,19 @@ class FarmMenuView(HubView):
         interaction: discord.Interaction,
         flash: str | None,
     ) -> None:
-        state, balance, to_full = await _panel_data(self._author.id, self.guild_id)
+        state, balance, to_full, away = await _panel_data(
+            self._author.id,
+            self.guild_id,
+        )
         # Redraw onto a fresh view instance so the panel's timeout clock resets
         # on every interaction (and the classifier sees a real in-place update).
         view = FarmMenuView(self._author, self.guild_id)
-        embed = build_farm_embed(state, balance, seconds_to_full=to_full)
+        embed = build_farm_embed(
+            state,
+            balance,
+            seconds_to_full=to_full,
+            away_summary=away,
+        )
         if flash:
             embed.description = f"{flash}\n\n{embed.description}"
         await interaction.response.edit_message(embed=embed, view=view)
@@ -213,7 +234,7 @@ class FarmShopView(HubView):
         interaction: discord.Interaction,
         flash: str | None,
     ) -> None:
-        state, balance, _ = await _panel_data(self._author.id, self.guild_id)
+        state, balance, _, _ = await _panel_data(self._author.id, self.guild_id)
         view = FarmShopView(self._author, self.guild_id)
         embed = build_shop_embed(state, balance)
         if flash:
@@ -249,10 +270,18 @@ class FarmShopView(HubView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        state, balance, to_full = await _panel_data(self._author.id, self.guild_id)
+        state, balance, to_full, away = await _panel_data(
+            self._author.id,
+            self.guild_id,
+        )
         view = FarmMenuView(self._author, self.guild_id)
         await interaction.response.edit_message(
-            embed=build_farm_embed(state, balance, seconds_to_full=to_full),
+            embed=build_farm_embed(
+                state,
+                balance,
+                seconds_to_full=to_full,
+                away_summary=away,
+            ),
             view=view,
         )
         view.message = interaction.message

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -178,10 +178,9 @@ Current broad captures:
   claimer gets a reward routed through `economy`/`game_xp`/inventory. The **one Pokétwo mechanic with no
   analog** (fishing/mining are command-only); net-new, ungated, anti-P2W, docks into the Explore world hub.
 - [`idle-game-offline-summary-2026-06-22.md`](./idle-game-offline-summary-2026-06-22.md) —
-  **captured alongside the new idle chicken farm (2026-06-22):** a shared `utils/idle_summary.py`
-  that narrates the "while you were away, +N eggs" return-moment when an idle panel opens — the
-  cheap polish that makes idle games feel idle. Reuses the existing `settle()` deltas; a clean
-  rule-of-three extraction candidate (farm + the two energy bars). Small single-PR slice.
+  **BUILT 2026-06-22 (PR #1331):** `utils/idle_summary.py` narrates the "🌙 while you were away,
+  +N eggs" return-moment on the farm panel. Kept for provenance; the live remainder is reusing
+  the helper from a *second* idle system (the rule-of-three `settle/spend` extraction).
 - [`mining-grid-encounters-2026-06-22.md`](./mining-grid-encounters-2026-06-22.md) —
   **owner-named follow-up to the grid Mine (Q-0173):** the grid Mine (hub-redesign PR 3) shipped
   encounter-free by decision; this captures the deferred **depth-gated, sparse** random encounters while

--- a/docs/ideas/idle-game-offline-summary-2026-06-22.md
+++ b/docs/ideas/idle-game-offline-summary-2026-06-22.md
@@ -1,6 +1,9 @@
 # Idea — "while you were away" offline-progress summary for idle games
 
-> **Status:** `ideas` — captured 2026-06-22. Not approved; refine into a plan before building.
+> **Status:** `historical` — **BUILT 2026-06-22** (PR #1331): `utils/idle_summary.py`
+> (`format_duration` + `summarize_idle_gain`) shipped + wired into the farm panel as its
+> first consumer. Kept for provenance. The reuse-by-a-second-idle-system step is the live
+> remainder (fold the mining/fishing energy hubs onto the same helper on the rule of three).
 
 ## The idea
 

--- a/docs/owner/claims/claude__affectionate-darwin-xnyxrj.md
+++ b/docs/owner/claims/claude__affectionate-darwin-xnyxrj.md
@@ -1,1 +1,0 @@
-- claude/affectionate-darwin-xnyxrj · farm fresh-start faucet fix + "while you were away" idle summary · services/farm_workflow.py + utils/idle_summary.py + views/farm/menu.py + tests · 2026-06-22

--- a/docs/owner/claims/claude__affectionate-darwin-xnyxrj.md
+++ b/docs/owner/claims/claude__affectionate-darwin-xnyxrj.md
@@ -1,0 +1,1 @@
+- claude/affectionate-darwin-xnyxrj · farm fresh-start faucet fix + "while you were away" idle summary · services/farm_workflow.py + utils/idle_summary.py + views/farm/menu.py + tests · 2026-06-22

--- a/docs/subsystems/games.md
+++ b/docs/subsystems/games.md
@@ -66,10 +66,21 @@ also reachable via `!farm` and the Explore world hub.
   "rewards too large & too frequent" caution. Buying hens scales the faucet but
   each costs more coins (the sink), so the loop stays self-balancing. Tunables are
   pure constants in `utils/farm/farm.py`.
+- **Return-moment summary (`utils/idle_summary.py`, PR #1331):** a pure, game-agnostic
+  helper (`format_duration` + `summarize_idle_gain`) renders the "🌙 While you were away
+  (2h 14m) you gained N eggs" blurb on the farm panel from the settle delta
+  (`farm_workflow.get_status` reports `eggs_gained`/`elapsed_seconds`/`at_capacity`). A
+  second idle system reuses it as-is — the rule-of-three start the shared-`settle()`
+  extraction will follow.
+- **Fresh-start contract (PR #1331):** `chicken_farm.eggs_updated_at` defaults to epoch 0,
+  and settling from 1970 would instantly fill a new coop (a free full collect). The
+  workflow's `_stored_state` normalizes a zero timestamp to *now* so idle accrual starts
+  from first contact (an empty coop) — pinned by `tests/unit/services/test_farm_workflow.py`.
+  Any new idle system on the `(value, timestamp)` pattern must apply the same normalization.
 - **Adding another idle game:** follow this layering, register a `GAME_*` constant in
   `game_xp_service`, add the `SUBSYSTEMS` entry under the Games hub, and reuse
-  `settle()` (extract the shared core into `utils/` only on the rule of three — a
-  *third* settle-based system).
+  `settle()` + `idle_summary` (extract the shared `settle/spend` core into `utils/` only on
+  the rule of three — a *third* settle-based system).
 
 ## Rules & approved structures (binding — link, don't restate)
 

--- a/tests/unit/help/test_help_actionability_contract.py
+++ b/tests/unit/help/test_help_actionability_contract.py
@@ -293,12 +293,20 @@ def _panel_construction_patches(subsystem: str):
             )
         )
     if subsystem == "farm":
+        from services.farm_workflow import FarmStatus
         from utils.farm import FarmState
 
         patches.append(
             patch(
-                "views.farm.menu.farm_workflow.get_state",
-                new=AsyncMock(return_value=FarmState(1, 0, 0, 0)),
+                "views.farm.menu.farm_workflow.get_status",
+                new=AsyncMock(
+                    return_value=FarmStatus(
+                        state=FarmState(1, 0, 0, 0),
+                        eggs_gained=0,
+                        elapsed_seconds=0,
+                        at_capacity=False,
+                    ),
+                ),
             )
         )
         patches.append(

--- a/tests/unit/services/test_farm_workflow.py
+++ b/tests/unit/services/test_farm_workflow.py
@@ -1,0 +1,87 @@
+"""Farm workflow tests — the fresh-start fix + the get_status return-moment deltas.
+
+The headline pin is the regression guard: a brand-new farm must start **empty**,
+not full. ``chicken_farm.eggs_updated_at`` defaults to epoch 0, and settling from
+1970 would instantly cap the coop (a free full collect for every new player), so
+``_stored_state`` normalizes a zero timestamp to *now*.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services import farm_workflow
+from utils import farm as farm_mod
+
+_NOW = 1_000_000_000
+
+
+# --------------------------------------------------------------- fresh-start fix
+
+
+def test_fresh_farm_starts_empty_not_full():
+    # Fresh row defaults (chickens=1, eggs=0, eggs_updated_at=0, coop_level=0).
+    stored = farm_workflow._stored_state(_NOW, 1, 0, 0, 0)
+    assert stored.updated_at == _NOW  # epoch-0 normalized to now, not 1970
+    settled = farm_mod.settle(stored, _NOW)
+    assert settled.eggs == 0  # empty coop — no free full collect
+    assert farm_mod.collect_value(settled.eggs) == 0
+
+
+def test_real_timestamp_is_preserved():
+    earlier = _NOW - 5 * farm_mod.LAY_INTERVAL_SECONDS
+    stored = farm_workflow._stored_state(_NOW, 1, 0, earlier, 0)
+    assert stored.updated_at == earlier  # a real timestamp is untouched
+    settled = farm_mod.settle(stored, _NOW)
+    assert settled.eggs == 5  # 5 intervals × 1 hen → 5 eggs accrued
+
+
+# ------------------------------------------------------------------- get_status
+
+
+@pytest.mark.asyncio
+async def test_get_status_fresh_farm_reports_no_away_progress():
+    with patch(
+        "services.farm_workflow.db.get_chicken_farm",
+        new=AsyncMock(return_value=(1, 0, 0, 0)),
+    ):
+        status = await farm_workflow.get_status(123, 456)
+    assert status.eggs_gained == 0
+    assert status.elapsed_seconds == 0
+    assert status.state.eggs == 0
+    assert status.at_capacity is False
+
+
+@pytest.mark.asyncio
+async def test_get_status_reports_accrued_delta():
+    # 2 hens, last action 3 intervals ago, started with 1 stored egg.
+    interval = farm_mod.LAY_INTERVAL_SECONDS
+    ts = 1_700_000_000
+    with (
+        patch(
+            "services.farm_workflow.db.get_chicken_farm",
+            new=AsyncMock(return_value=(2, 1, ts, 0)),
+        ),
+        patch("services.farm_workflow.time.time", return_value=ts + 3 * interval),
+    ):
+        status = await farm_workflow.get_status(123, 456)
+    # 2 hens × 3 intervals = 6 new eggs on top of the 1 stored.
+    assert status.eggs_gained == 6
+    assert status.state.eggs == 7
+    assert status.elapsed_seconds == 3 * interval
+
+
+@pytest.mark.asyncio
+async def test_get_status_flags_capacity():
+    with (
+        patch(
+            "services.farm_workflow.db.get_chicken_farm",
+            new=AsyncMock(return_value=(1, 0, 1, 0)),
+        ),
+        patch("services.farm_workflow.time.time", return_value=10**9),
+    ):
+        status = await farm_workflow.get_status(123, 456)
+    assert status.at_capacity is True
+    assert status.state.eggs == farm_mod.coop_capacity(0)

--- a/tests/unit/utils/test_idle_summary.py
+++ b/tests/unit/utils/test_idle_summary.py
@@ -1,0 +1,99 @@
+"""Pure idle-summary tests — duration formatting + the "while you were away" blurb."""
+
+from __future__ import annotations
+
+import pytest
+
+from utils import idle_summary
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [
+        (0, "now"),
+        (-5, "now"),
+        (45, "45s"),
+        (65, "1m 05s"),
+        (125, "2m 05s"),
+        (3600, "1h 00m"),
+        (3780, "1h 03m"),
+    ],
+)
+def test_format_duration(seconds, expected):
+    assert idle_summary.format_duration(seconds) == expected
+
+
+def test_summary_none_when_nothing_gained():
+    assert (
+        idle_summary.summarize_idle_gain(
+            0,
+            10_000,
+            noun_singular="egg",
+            noun_plural="eggs",
+        )
+        is None
+    )
+    assert (
+        idle_summary.summarize_idle_gain(
+            -3,
+            10_000,
+            noun_singular="egg",
+            noun_plural="eggs",
+        )
+        is None
+    )
+
+
+def test_summary_pluralizes_and_formats_elapsed():
+    one = idle_summary.summarize_idle_gain(
+        1,
+        45,
+        noun_singular="egg",
+        noun_plural="eggs",
+    )
+    assert one is not None
+    assert "**1** egg." in one
+    assert "45s" in one
+
+    many = idle_summary.summarize_idle_gain(
+        17,
+        8040,  # 2h 14m
+        noun_singular="egg",
+        noun_plural="eggs",
+    )
+    assert many is not None
+    assert "**17** eggs." in many
+    assert "2h 14m" in many
+
+
+def test_summary_appends_capped_note_only_when_capped():
+    note = "The coop is full — collect!"
+    capped = idle_summary.summarize_idle_gain(
+        20,
+        99_999,
+        noun_singular="egg",
+        noun_plural="eggs",
+        capped=True,
+        capped_note=note,
+    )
+    assert capped is not None and note in capped
+
+    not_capped = idle_summary.summarize_idle_gain(
+        5,
+        600,
+        noun_singular="egg",
+        noun_plural="eggs",
+        capped=False,
+        capped_note=note,
+    )
+    assert not_capped is not None and note not in not_capped
+
+    # Capped but no note supplied → no suffix, no crash.
+    no_note = idle_summary.summarize_idle_gain(
+        20,
+        99_999,
+        noun_singular="egg",
+        noun_plural="eggs",
+        capped=True,
+    )
+    assert no_note is not None and no_note.endswith("eggs.")


### PR DESCRIPTION
Continuation of the idle-farm session (#1328 merged) — two cohesive changes on the farm's
accrual read path.

## 1. Bug fix (root) — a fresh farm started full
A brand-new farm's coop settled to **full** because `chicken_farm.eggs_updated_at` defaults to
epoch `0`: `settle()` then measures elapsed time from 1970, so every new player could collect a
free full coop (~40 coins) on their first `!farm`. Verified before fixing (fresh `settle` → 20/20
eggs → 40 coins).

**Root fix:** normalize an uninitialized timestamp (`ts == 0`) to *now* in the workflow read path,
so idle accrual starts from first contact (an **empty** coop), not from 1970. One helper used by
`get_state` / `collect` / `buy_chicken` / `upgrade_coop`. + a regression test pinning "fresh farm
is empty, then accrues."

## 2. Idea → build (Q-0172) — "while you were away" idle summary
Builds the offline-progress idea captured last session
(`docs/ideas/idle-game-offline-summary-2026-06-22.md`): a pure `utils/idle_summary.py`
(`format_duration` + `summarize_idle_gain`) that narrates the return-moment — *"While you were
away (2h 14m), your hens laid **17** eggs."* The farm panel shows it on open. Reuses the existing
settle deltas; `format_duration` also replaces the farm menu's local `_fmt_wait` (de-dup — the
rule-of-three start the idea flagged).

No balance change beyond removing the unintended free-coins faucet — safe to land alongside any
play-test tuning.

PR opens **born red** (Q-0133 in-progress card); flips green as the final step → auto-merges on
green CI (Q-0123).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkKKGVhvj4hF4SY7n4WKwQ)_