### PR TITLE
feat(treasury): NEW server-owned coin pool (economy↔governance seam)

### DIFF
--- a/.sessions/2026-06-22-server-treasury.md
+++ b/.sessions/2026-06-22-server-treasury.md
@@ -1,9 +1,9 @@
 # 2026-06-22 — Server treasury (collective coin pool)
 
-> **Status:** `in-progress` — born-red card (Q-0133); flips to `complete` as the final step.
+> **Status:** `complete` — born-red card (Q-0133) flipped green as the final step.
 > Owner-directed (the maintainer picked "treasury" from two offered words and said "build some
 > things… do what you want") → built end-to-end (Q-0191 merge-immediately).
-> PR: this session (`claude/bold-pasteur-qy5cwd`) → auto-merges on green CI (Q-0123).
+> PR #1334 → auto-merge armed; merges on green CI (Q-0123/Q-0127).
 
 ## Context (how this session arose)
 

--- a/.sessions/2026-06-22-server-treasury.md
+++ b/.sessions/2026-06-22-server-treasury.md
@@ -1,0 +1,95 @@
+# 2026-06-22 — Server treasury (collective coin pool)
+
+> **Status:** `in-progress` — born-red card (Q-0133); flips to `complete` as the final step.
+> Owner-directed (the maintainer picked "treasury" from two offered words and said "build some
+> things… do what you want") → built end-to-end (Q-0191 merge-immediately).
+> PR: this session (`claude/bold-pasteur-qy5cwd`) → auto-merges on green CI (Q-0123).
+
+## Context (how this session arose)
+
+A reflective conversation about the one-word→feature workflow (idle farm, then "karma"). The
+maintainer, going to sleep, gave an open mandate: **document a couple of ideas, capture anything
+from the conversation worth keeping, and build something — leaning `treasury`** (a word I'd offered
+earlier as "a genuinely-new foundation: the bot's economy is entirely individual; there's no
+collective pool"). Three deliverables this session: the treasury build, two idea/insight docs, and
+the session-close notes.
+
+## What shipped — the treasury subsystem
+
+The bot's first **server-owned** (collective) coin pool. Every prior balance is individual
+(per-user `xp.coins`); the treasury is the seam between the **economy** (where coins come from) and
+**governance** (who may spend them). Decomposition mirrors the farm/fishing arc exactly:
+
+- **migration 092** + **`utils/db/treasury.py`** — the `guild_treasury(guild_id, balance, updated_at)`
+  row; conn-aware `get_treasury` / `credit_treasury` / `try_debit_treasury` (the conditional
+  `balance >= $` debit mirrors `try_debit_coins` — never overdraws, no read-then-write race).
+- **`services/treasury_service.py`** — the audited write boundary (RS02/Q-0071): `contribute`
+  (member donates own coins → pool) and `disburse` (manager grants pool → member). Each runs the
+  pool leg + the user coin leg inside ONE `db.transaction()`; user legs go through
+  `economy_service.{debit,credit}_in_txn` so `economy_audit_log` is the money trail (the farm/fishing
+  precedent — no separate `emit_audit_action` for the economy domain). EventBus emit after commit.
+  Underfunded pool / insufficient funds write nothing and return a typed failure.
+- **`views/treasury/`** — `TreasuryView` (HubView): **➕ Contribute** opens a one-field modal
+  (button→modal→`edit_message`, the profile-editor idiom) · **🔄 Refresh**. Disburse is deliberately
+  **not** a button — only the `manage_guild` command can move coins *out*, so a member's panel can
+  only ever move their *own* coins *in*.
+- **`cogs/treasury_cog.py`** — `!treasury`/`bank`/`pool` (group → panel), `!treasury contribute
+  <amount>`, `!treasury grant @member <amount>` (`@commands.has_permissions(manage_guild=True)`),
+  and the Help hook.
+- Wiring: `SUBSYSTEMS["treasury"]` (Economy-hub child) · `hub_registry` economy `primary_children`
+  · `INITIAL_EXTENSIONS` · `extension_roles.yaml` overlay · the back-button allowlist (root panel,
+  parent attaches back externally — the counting/fishing precedent).
+
+**Authority safety:** the service does no permission check by design (so a missing gate can never
+silently mint coins); the cog gates `grant` on `manage_guild`. Disburse can never overdraw the pool
+(conditional debit). 6 service tests pin transaction membership + the underfunded/insufficient
+rollback paths (`tests/unit/services/test_treasury_service.py`).
+
+## Verification
+
+- Full suite: **11795 passed** pre-regen, with 10 generated-artifact freshness failures → all
+  resolved by regenerating the pinned artifacts (below); the 4 artifact test files re-run **66
+  passed**.
+- Regenerated committed artifacts (adding a cog/subsystem shifts their live counts):
+  `extension-taxonomy-crosswalk.md`, `dashboard.json`, `site.json` + `data.js`, `env-vars.md`.
+- `check_quality.py --check-only` → black/isort/ruff/check_docs/check_consistency/tool-pins ✓ ·
+  `mypy disbot/` → 0 errors · `check_architecture.py --mode strict` → 0 errors.
+- Doc-audit (Q-0104): surface-map counts (39 subsystems / 52 extensions / 38-of-52 hooks) updated
+  to match live registries; help-surface-map + discoverability + roster tests green.
+- Not live-verified in Discord (no sandbox bot run); the money paths are unit-covered and the panel
+  is CI-asserted discoverable/actionable. Live-verify + the first real `!treasury contribute` is the
+  maintainer's (Q-0193: the merge auto-deploys; no manual restart).
+
+## Enders
+
+- **💡 Session idea (Q-0089):** **AI self-curated memory notebook** — give the bot's in-product AI a
+  narrow audited write-back seam (correction/AI-judged/daily-cron triggers → a `pending` staging
+  table → human-reviewed promotion into instruction / cached layer / **deterministic answer preset**,
+  zero-API). The in-product mirror of the agent network's two-part curated memory. *This is the
+  maintainer's own idea from the conversation, captured at his request* —
+  [`docs/ideas/ai-self-curated-memory-notebook-2026-06-22.md`](../docs/ideas/ai-self-curated-memory-notebook-2026-06-22.md).
+- **Conversation insight captured (owner-invited "store what's worth keeping"):** added
+  `collaboration-model.md` § "Why the written record *is* the agent's memory (the two-part model)" —
+  the extended-mind framing (the journal/`.sessions` artifacts *are* the agent's memory, not a
+  substitute) and the maintainer-carries-unfiltered / agent-carries-curated division of labor. It
+  reframes session-close curation as the highest-leverage act, grounding why the Q-0089/0102/0104
+  enders are mandatory.
+- **⟲ Previous-session review (Q-0102):** the idle-farm session (#1328) was exemplary — clean
+  fishing-mirror decomposition, and it *proactively* fixed the Games-hub 6th-activity row overflow it
+  would have hit. One thing it left for a follow-up that treasury inherits: **neither idle/economy
+  subsystem live-verifies in Discord** (both note "not live-verified"). The recurring gap is that
+  there's no lightweight headless harness to drive a cog's command path without a real bot+Postgres.
+  *System improvement surfaced:* a `tools/sim/`-style **panel/command smoke harness** (instantiate a
+  cog with a fake ctx + in-memory db doubles, assert the embed/flow) would let economy/game sessions
+  claim more than "unit-covered" without a sandbox — captured as a candidate, not built this session.
+- **Context delta:** orientation pointed me straight at the farm subsystem as the template (CLAUDE.md
+  "newest complete game" instinct) — that carried 90% of the build. What I had to discover by hand:
+  the *full* registration surface a new economy subsystem must touch to stay CI-green — not just
+  `SUBSYSTEMS` + `hub_registry`, but the **four pinned generated artifacts** (crosswalk, dashboard,
+  site, env-vars), the `extension_roles.yaml` overlay, the help-surface-map **counts** (3 numbers),
+  the back-button allowlist, and a hub-children **tuple assertion** in `test_hub_registry`. That
+  checklist is scattered; the `new-subsystem` skill / a "new economy child" recipe could enumerate it.
+- **⚑ Self-initiated:** none beyond owner latitude — treasury was owner-chosen; the idea capture and
+  the collaboration-model insight were owner-requested ("document these ideas", "store what's
+  worth keeping"). The *depth* (full subsystem vs. a thinner slice) and the artifact/overlay/doc
+  bookkeeping were my judgment within "do what you want… build some things."

--- a/architecture_rules/consistency_exceptions.yml
+++ b/architecture_rules/consistency_exceptions.yml
@@ -101,6 +101,8 @@ back_button:
       reason: "Root deathmatch game panel opened directly by the deathmatch cog command; no parent."
     - pattern: views/settings/hub.py::SettingsHubView
       reason: "Root settings hub opened directly by the settings cog command; opened as a `!help` child the parent attaches back externally. Top of its own stack (its sub-panels return TO it via _BackToHubButton)."
+    - pattern: views/treasury/menu.py::TreasuryView
+      reason: "Root `!treasury` panel; opened as a `!help`/Economy-hub child the parent attaches back externally (HelpCategoryView). No parent on the root open; its Contribute action is a modal that takes over rather than nesting a sub-panel."
     - pattern: views/ux_lab/home.py::UxLabHomeView
       reason: "Root UX-lab gallery home opened directly by the ux_lab cog command; its wings/compare/probes return here via transition_to. No parent."
     - pattern: views/xp/main_panel.py::_XpHubView

--- a/architecture_rules/extension_roles.yaml
+++ b/architecture_rules/extension_roles.yaml
@@ -100,6 +100,9 @@ extensions:
     role: product_subsystem
   economy:
     role: product_subsystem
+  treasury:
+    role: product_subsystem
+    note: Server-owned coin pool — the economy↔governance seam (contribute / manager-disburse).
   counting:
     role: product_subsystem
     note: Counting game.

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-22T23:44:37Z",
+    "generated_at": "2026-06-22T22:22:42Z",
     "build": {
-      "commit": "55655ca",
-      "subject": "Merge pull request #1329 from menno420/claude/funny-franklin-blbz7w",
-      "committed_at": "2026-06-22T23:44:37Z"
+      "commit": "6109030",
+      "subject": "docs(session): flip treasury session card to complete (PR #1334)",
+      "committed_at": "2026-06-22T22:22:42Z"
     }
   },
   "counts": {

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,15 +1,15 @@
 {
   "meta": {
-    "generated_at": "2026-06-22T23:26:34Z",
+    "generated_at": "2026-06-22T23:44:37Z",
     "build": {
-      "commit": "ac1a1c7d",
-      "subject": "Merge branch 'main' into claude/funny-franklin-blbz7w",
-      "committed_at": "2026-06-22T23:26:34Z"
+      "commit": "55655ca",
+      "subject": "Merge pull request #1329 from menno420/claude/funny-franklin-blbz7w",
+      "committed_at": "2026-06-22T23:44:37Z"
     }
   },
   "counts": {
-    "commands": 374,
-    "features": 38,
+    "commands": 377,
+    "features": 39,
     "games": 10
   },
   "catalogue": [
@@ -242,6 +242,23 @@
         "mining",
         "resources",
         "minigame"
+      ],
+      "badges": [
+        "economy"
+      ],
+      "is_game": false
+    },
+    {
+      "key": "treasury",
+      "display_name": "Treasury",
+      "description": "Server-owned coin pool — contribute coins; managers disburse",
+      "emoji": "🏛️",
+      "category": "economy",
+      "tags": [
+        "treasury",
+        "economy",
+        "coins",
+        "governance"
       ],
       "badges": [
         "economy"
@@ -709,6 +726,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
+        {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
         },
@@ -743,6 +764,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
         {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
@@ -781,6 +806,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
+        {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
         },
@@ -817,6 +846,10 @@
       ],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
         {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
@@ -938,6 +971,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
+        {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
         },
@@ -972,6 +1009,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
         {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
@@ -1040,6 +1081,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
+        {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
         },
@@ -1074,6 +1119,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
         {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
@@ -1225,6 +1274,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
+        {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
         },
@@ -1259,6 +1312,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
         {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
@@ -1295,6 +1352,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
+        {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
         },
@@ -1329,6 +1390,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
         {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
@@ -1381,6 +1446,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
+        {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
         },
@@ -1415,6 +1484,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
         {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
@@ -1502,6 +1575,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
+        {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
         },
@@ -1536,6 +1613,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
         {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
@@ -1636,6 +1717,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
+        {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
         },
@@ -1670,6 +1755,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
         {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
@@ -1766,6 +1855,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
+        {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
         },
@@ -1800,6 +1893,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
         {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
@@ -1855,6 +1952,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
+        {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
         },
@@ -1889,6 +1990,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
         {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
@@ -2061,6 +2166,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+          "status": "ideas"
+        },
         {
           "title": "AI reports corrections → an audience-routed AI ticket service",
           "status": "ideas"
@@ -2403,6 +2512,23 @@
       "notes": null
     },
     {
+      "name": "contribute",
+      "aliases": [
+        "donate",
+        "deposit"
+      ],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Donate *amount* of your own coins into the server treasury.",
+      "description": "Donate *amount* of your own coins into the server treasury.",
+      "use_cases": null,
+      "examples": [],
+      "status": "finished",
+      "linked_ideas": [],
+      "notes": null
+    },
+    {
       "name": "cook",
       "aliases": [],
       "category": "economy",
@@ -2677,6 +2803,23 @@
           "status": "ideas"
         }
       ],
+      "notes": null
+    },
+    {
+      "name": "grant",
+      "aliases": [
+        "disburse",
+        "payout"
+      ],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Disburse *amount* from the treasury to *member* (managers only).",
+      "description": "Disburse *amount* from the treasury to *member* (managers only).",
+      "use_cases": null,
+      "examples": [],
+      "status": "finished",
+      "linked_ideas": [],
       "notes": null
     },
     {
@@ -3196,6 +3339,23 @@
           "status": "ideas"
         }
       ],
+      "notes": null
+    },
+    {
+      "name": "treasury",
+      "aliases": [
+        "bank",
+        "pool"
+      ],
+      "category": "economy",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Open the server treasury — view the pool and contribute coins.",
+      "description": "Open the server treasury — view the pool and contribute coins.",
+      "use_cases": null,
+      "examples": [],
+      "status": "finished",
+      "linked_ideas": [],
       "notes": null
     },
     {

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -6179,7 +6179,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "55655ca",
+    "build": "6109030",
     "title": "New public bot website",
     "changes": [
       {
@@ -6191,7 +6191,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "55655ca",
+    "build": "6109030",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -6203,7 +6203,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "55655ca",
+    "build": "6109030",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -71,7 +71,8 @@ const AREAS = [
     "points": [
       "Economy",
       "Inventory",
-      "Mining"
+      "Mining",
+      "Treasury"
     ]
   },
   {
@@ -280,6 +281,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "AI self-curated memory notebook — a write-back learning seam for the…"
+      },
+      {
+        "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
       },
       {
@@ -289,10 +294,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI panels → in-place navigation + centralized settings…"
-      },
-      {
-        "status": "idea",
-        "title": "AI Extra Tool Capability Ideas Backlog"
       }
     ]
   },
@@ -312,6 +313,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "AI self-curated memory notebook — a write-back learning seam for the…"
+      },
+      {
+        "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
       },
       {
@@ -321,10 +326,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI panels → in-place navigation + centralized settings…"
-      },
-      {
-        "status": "idea",
-        "title": "AI Extra Tool Capability Ideas Backlog"
       }
     ]
   },
@@ -1390,6 +1391,22 @@ const COMMANDS = [
     "planned": []
   },
   {
+    "name": "contribute",
+    "area": "economy",
+    "status": "finished",
+    "summary": "Donate *amount* of your own coins into the server treasury.",
+    "description": "Donate *amount* of your own coins into the server treasury.",
+    "usage": "!contribute",
+    "aliases": [
+      "donate",
+      "deposit"
+    ],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [],
+    "planned": []
+  },
+  {
     "name": "cook",
     "area": "economy",
     "status": "in-progress",
@@ -1796,6 +1813,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "AI self-curated memory notebook — a write-back learning seam for the…"
+      },
+      {
+        "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
       },
       {
@@ -1805,10 +1826,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI panels → in-place navigation + centralized settings…"
-      },
-      {
-        "status": "idea",
-        "title": "AI Extra Tool Capability Ideas Backlog"
       }
     ]
   },
@@ -2293,6 +2310,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "AI self-curated memory notebook — a write-back learning seam for the…"
+      },
+      {
+        "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
       },
       {
@@ -2302,10 +2323,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI panels → in-place navigation + centralized settings…"
-      },
-      {
-        "status": "idea",
-        "title": "AI Extra Tool Capability Ideas Backlog"
       }
     ]
   },
@@ -2406,6 +2423,22 @@ const COMMANDS = [
     "description": "Give XP to a user (admin only).",
     "usage": "!givexp",
     "aliases": [],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [],
+    "planned": []
+  },
+  {
+    "name": "grant",
+    "area": "economy",
+    "status": "finished",
+    "summary": "Disburse *amount* from the treasury to *member* (managers only).",
+    "description": "Disburse *amount* from the treasury to *member* (managers only).",
+    "usage": "!grant",
+    "aliases": [
+      "disburse",
+      "payout"
+    ],
     "permissions": "anyone",
     "cooldown": null,
     "examples": [],
@@ -3357,6 +3390,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "AI self-curated memory notebook — a write-back learning seam for the…"
+      },
+      {
+        "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
       },
       {
@@ -3366,10 +3403,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI panels → in-place navigation + centralized settings…"
-      },
-      {
-        "status": "idea",
-        "title": "AI Extra Tool Capability Ideas Backlog"
       }
     ]
   },
@@ -3426,6 +3459,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "AI self-curated memory notebook — a write-back learning seam for the…"
+      },
+      {
+        "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
       },
       {
@@ -3435,10 +3472,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI panels → in-place navigation + centralized settings…"
-      },
-      {
-        "status": "idea",
-        "title": "AI Extra Tool Capability Ideas Backlog"
       }
     ]
   },
@@ -3562,6 +3595,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "AI self-curated memory notebook — a write-back learning seam for the…"
+      },
+      {
+        "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
       },
       {
@@ -3571,10 +3608,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI panels → in-place navigation + centralized settings…"
-      },
-      {
-        "status": "idea",
-        "title": "AI Extra Tool Capability Ideas Backlog"
       }
     ]
   },
@@ -4025,6 +4058,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "AI self-curated memory notebook — a write-back learning seam for the…"
+      },
+      {
+        "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
       },
       {
@@ -4034,10 +4071,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI panels → in-place navigation + centralized settings…"
-      },
-      {
-        "status": "idea",
-        "title": "AI Extra Tool Capability Ideas Backlog"
       }
     ]
   },
@@ -4529,6 +4562,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "AI self-curated memory notebook — a write-back learning seam for the…"
+      },
+      {
+        "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
       },
       {
@@ -4538,10 +4575,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI panels → in-place navigation + centralized settings…"
-      },
-      {
-        "status": "idea",
-        "title": "AI Extra Tool Capability Ideas Backlog"
       }
     ]
   },
@@ -5013,6 +5046,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "AI self-curated memory notebook — a write-back learning seam for the…"
+      },
+      {
+        "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
       },
       {
@@ -5022,10 +5059,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI panels → in-place navigation + centralized settings…"
-      },
-      {
-        "status": "idea",
-        "title": "AI Extra Tool Capability Ideas Backlog"
       }
     ]
   },
@@ -5163,6 +5196,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "AI self-curated memory notebook — a write-back learning seam for the…"
+      },
+      {
+        "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
       },
       {
@@ -5172,10 +5209,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI panels → in-place navigation + centralized settings…"
-      },
-      {
-        "status": "idea",
-        "title": "AI Extra Tool Capability Ideas Backlog"
       }
     ]
   },
@@ -5435,6 +5468,22 @@ const COMMANDS = [
         "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
+  },
+  {
+    "name": "treasury",
+    "area": "economy",
+    "status": "finished",
+    "summary": "Open the server treasury — view the pool and contribute coins.",
+    "description": "Open the server treasury — view the pool and contribute coins.",
+    "usage": "!treasury",
+    "aliases": [
+      "bank",
+      "pool"
+    ],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [],
+    "planned": []
   },
   {
     "name": "trivia",
@@ -5813,6 +5862,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "AI self-curated memory notebook — a write-back learning seam for the…"
+      },
+      {
+        "status": "idea",
         "title": "AI reports corrections → an audience-routed AI ticket service"
       },
       {
@@ -5822,10 +5875,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "AI panels → in-place navigation + centralized settings…"
-      },
-      {
-        "status": "idea",
-        "title": "AI Extra Tool Capability Ideas Backlog"
       }
     ]
   },
@@ -6130,7 +6179,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "ac1a1c7d",
+    "build": "55655ca",
     "title": "New public bot website",
     "changes": [
       {
@@ -6142,7 +6191,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "ac1a1c7d",
+    "build": "55655ca",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -6154,7 +6203,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "ac1a1c7d",
+    "build": "55655ca",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-22T23:44:37Z",
+    "generated_at": "2026-06-22T22:22:42Z",
     "build": {
-      "commit": "55655ca",
-      "subject": "Merge pull request #1329 from menno420/claude/funny-franklin-blbz7w",
-      "committed_at": "2026-06-22T23:44:37Z"
+      "commit": "6109030",
+      "subject": "docs(session): flip treasury session card to complete (PR #1334)",
+      "committed_at": "2026-06-22T22:22:42Z"
     },
     "counts": {
       "functions": 39,
@@ -1096,7 +1096,7 @@
     {
       "file": "idle-game-offline-summary-2026-06-22.md",
       "title": "Idea — \"while you were away\" offline-progress summary for idle games",
-      "status": "ideas",
+      "status": "historical",
       "date": "2026-06-22",
       "summary": "The chicken farm (shipped this session) is the bot's first **idle** game: progress",
       "subsystems": null
@@ -2331,6 +2331,14 @@
       "self_initiated": true
     },
     {
+      "file": "2026-06-22-server-treasury.md",
+      "date": "2026-06-22",
+      "title": "2026-06-22 — Server treasury (collective coin pool)",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
       "file": "2026-06-22-route-mining-encounters.md",
       "date": "2026-06-22",
       "title": "2026-06-22 — route the mining-grid-encounters design to the owner (Q-0198)",
@@ -2579,6 +2587,14 @@
       "self_initiated": true
     },
     {
+      "file": "2026-06-22-farm-freshstart-and-idle-summary.md",
+      "date": "2026-06-22",
+      "title": "2026-06-22 — farm fresh-start faucet fix + \"while you were away\" idle summary",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
       "file": "2026-06-22-ci-strand-cancel-in-progress.md",
       "date": "2026-06-22",
       "title": "Session — CI strand root cause: code-quality cancel-in-progress (2026-06-22)",
@@ -2750,22 +2766,6 @@
       "file": "2026-06-21-reaction-roles-ui-direction.md",
       "date": "2026-06-21",
       "title": "2026-06-21 — Reaction-roles plan: UI-direction refinement (web vs in-Discord)",
-      "status": "complete",
-      "run_type": "manual",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-21-reaction-roles-self-heal.md",
-      "date": "2026-06-21",
-      "title": "2026-06-21 — Reaction roles: listener self-heal for dead bindings",
-      "status": "complete",
-      "run_type": "manual",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-06-21-reaction-roles-presentation-editing.md",
-      "date": "2026-06-21",
-      "title": "2026-06-21 — Reaction-roles plan: presentation & editing requirements",
       "status": "complete",
       "run_type": "manual",
       "self_initiated": false

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,25 +1,25 @@
 {
   "meta": {
-    "generated_at": "2026-06-22T21:56:45Z",
+    "generated_at": "2026-06-22T23:44:37Z",
     "build": {
-      "commit": "fd3d575f",
-      "subject": "fix(farm): fresh coop no longer starts full + \"while you were away\" idle summary (#1331)",
-      "committed_at": "2026-06-22T21:56:45Z"
+      "commit": "55655ca",
+      "subject": "Merge pull request #1329 from menno420/claude/funny-franklin-blbz7w",
+      "committed_at": "2026-06-22T23:44:37Z"
     },
     "counts": {
-      "functions": 38,
-      "ideas": 127,
+      "functions": 39,
+      "ideas": 128,
       "bugs": 24,
       "reviews": 0,
       "reviews_open": 0,
       "updates": 60,
       "env_vars": 38,
-      "cogs": 48,
-      "commands": 374,
+      "cogs": 49,
+      "commands": 377,
       "setting_keys": 104,
       "setting_domains": 15,
       "typed_settings": 85,
-      "visible_subsystems": 38,
+      "visible_subsystems": 39,
       "synonyms": 87,
       "bot_changelog": 3
     }
@@ -391,6 +391,33 @@
       "capabilities": [
         "mining.resource.mine",
         "mining.resource.view"
+      ]
+    },
+    {
+      "key": "treasury",
+      "display_name": "Treasury",
+      "description": "Server-owned coin pool — contribute coins; managers disburse",
+      "emoji": "🏛️",
+      "visibility_tier": "user",
+      "visibility_mode": "normal",
+      "category": "economy",
+      "tags": [
+        "treasury",
+        "economy",
+        "coins",
+        "governance"
+      ],
+      "entry_points": [
+        "treasury"
+      ],
+      "related_subsystems": [
+        "economy",
+        "inventory"
+      ],
+      "capabilities": [
+        "treasury.pool.view",
+        "treasury.pool.contribute",
+        "treasury.pool.disburse"
       ]
     },
     {
@@ -1025,6 +1052,16 @@
   ],
   "ideas": [
     {
+      "file": "ai-self-curated-memory-notebook-2026-06-22.md",
+      "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
+      "status": "ideas",
+      "date": "2026-06-22",
+      "summary": "Give the bot's in-product AI a **narrow, audited, write-back seam**: a dedicated table it may",
+      "subsystems": [
+        "ai"
+      ]
+    },
+    {
       "file": "audited-score-subsystem-scaffold-2026-06-22.md",
       "title": "Idea — \"audited per-user score\" subsystem scaffold + parity guard",
       "status": "ideas",
@@ -1059,7 +1096,7 @@
     {
       "file": "idle-game-offline-summary-2026-06-22.md",
       "title": "Idea — \"while you were away\" offline-progress summary for idle games",
-      "status": "historical",
+      "status": "ideas",
       "date": "2026-06-22",
       "summary": "The chicken farm (shipped this session) is the bot's first **idle** game: progress",
       "subsystems": null
@@ -2542,14 +2579,6 @@
       "self_initiated": true
     },
     {
-      "file": "2026-06-22-farm-freshstart-and-idle-summary.md",
-      "date": "2026-06-22",
-      "title": "2026-06-22 — farm fresh-start faucet fix + \"while you were away\" idle summary",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
       "file": "2026-06-22-ci-strand-cancel-in-progress.md",
       "date": "2026-06-22",
       "title": "Session — CI strand root cause: code-quality cancel-in-progress (2026-06-22)",
@@ -2732,6 +2761,14 @@
       "status": "complete",
       "run_type": "manual",
       "self_initiated": true
+    },
+    {
+      "file": "2026-06-21-reaction-roles-presentation-editing.md",
+      "date": "2026-06-21",
+      "title": "2026-06-21 — Reaction-roles plan: presentation & editing requirements",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": false
     }
   ],
   "bot_changelog": [
@@ -2820,7 +2857,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 185,
+          "line": 186,
           "layer": "config",
           "has_default": true
         },
@@ -2842,7 +2879,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 184,
+          "line": 185,
           "layer": "config",
           "has_default": true
         }
@@ -2875,7 +2912,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 168,
+          "line": 169,
           "layer": "config",
           "has_default": true
         },
@@ -2945,7 +2982,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 223,
+          "line": 224,
           "layer": "config",
           "has_default": true
         }
@@ -2993,7 +3030,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 211,
+          "line": 212,
           "layer": "config",
           "has_default": true
         }
@@ -3009,7 +3046,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 214,
+          "line": 215,
           "layer": "config",
           "has_default": true
         }
@@ -3025,7 +3062,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 217,
+          "line": 218,
           "layer": "config",
           "has_default": true
         }
@@ -3185,7 +3222,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 110,
+          "line": 111,
           "layer": "config",
           "has_default": true
         }
@@ -3265,7 +3302,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 111,
+          "line": 112,
           "layer": "config",
           "has_default": true
         }
@@ -3283,7 +3320,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 167,
+          "line": 168,
           "layer": "config",
           "has_default": true
         },
@@ -3324,7 +3361,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 194,
+          "line": 195,
           "layer": "config",
           "has_default": true
         },
@@ -3347,7 +3384,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 198,
+          "line": 199,
           "layer": "config",
           "has_default": true
         },
@@ -3386,7 +3423,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 166,
+          "line": 167,
           "layer": "config",
           "has_default": true
         },
@@ -3410,7 +3447,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 165,
+          "line": 166,
           "layer": "config",
           "has_default": true
         },
@@ -7858,6 +7895,56 @@
       ]
     },
     {
+      "cog": "TreasuryCog",
+      "file": "disbot/cogs/treasury_cog.py",
+      "subsystem": "treasury",
+      "is_cog": true,
+      "commands": [
+        {
+          "name": "treasury",
+          "type": "prefix",
+          "is_group": true,
+          "parent": null,
+          "aliases": [
+            "bank",
+            "pool"
+          ],
+          "brief": "Open the server treasury — view the pool and contribute coins.",
+          "classification": "",
+          "has_panel": true,
+          "button_backed": true
+        },
+        {
+          "name": "contribute",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "treasury",
+          "aliases": [
+            "donate",
+            "deposit"
+          ],
+          "brief": "Donate *amount* of your own coins into the server treasury.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "grant",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "treasury",
+          "aliases": [
+            "disburse",
+            "payout"
+          ],
+          "brief": "Disburse *amount* from the treasury to *member* (managers only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
       "cog": "UtilityCog",
       "file": "disbot/cogs/utility_cog.py",
       "subsystem": "utility",
@@ -8976,6 +9063,12 @@
             "emoji": "⛏️"
           },
           {
+            "key": "treasury",
+            "display_name": "Treasury",
+            "category": "economy",
+            "emoji": "🏛️"
+          },
+          {
             "key": "btd6",
             "display_name": "BTD6 Assistant",
             "category": "games",
@@ -9204,7 +9297,7 @@
         "subsystems": []
       }
     ],
-    "total_visible": 38,
+    "total_visible": 39,
     "internal_count": 0
   },
   "synonyms": [

--- a/disbot/cogs/treasury_cog.py
+++ b/disbot/cogs/treasury_cog.py
@@ -1,0 +1,92 @@
+"""Server treasury — Discord plumbing only.
+
+The bot's first **server-owned** (collective) coin pool, the seam between the
+economy (per-user coins) and governance (who may spend them). Members contribute
+their own coins into the pool; server managers disburse from it.
+
+Domain logic, the audited write boundary, and the data live in their own modules
+(mirrors the farm/fishing decomposition):
+
+    services/treasury_service.py  — the audited write boundary (contribute/disburse)
+    utils/db/treasury.py          — the guild_treasury CRUD (migration 092)
+    views/treasury/               — the interactive panel + Contribute modal
+
+This file hosts only commands, the cog lifecycle, and the Help-menu hook.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord.ext import commands
+
+from services import treasury_service
+from views.treasury import open_treasury_panel
+
+logger = logging.getLogger("bot.cogs.treasury")
+
+
+class TreasuryCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    async def cog_check(self, ctx):
+        if ctx.guild is None:
+            raise commands.NoPrivateMessage()
+        return True
+
+    # ------------------------------------------------------------------ commands
+
+    @commands.group(
+        name="treasury",
+        aliases=["bank", "pool"],
+        invoke_without_command=True,
+    )
+    async def treasury(self, ctx: commands.Context) -> None:
+        """Open the server treasury — view the pool and contribute coins."""
+        embed, view = await open_treasury_panel(ctx.author, ctx.guild.id)
+        view.message = await ctx.send(embed=embed, view=view)
+
+    @treasury.command(name="contribute", aliases=["donate", "deposit"])  # type: ignore[arg-type]
+    async def contribute(self, ctx: commands.Context, amount: int) -> None:
+        """Donate *amount* of your own coins into the server treasury."""
+        if amount <= 0:
+            await ctx.send("➕ Contribute a positive number of coins.")
+            return
+        result = await treasury_service.contribute(ctx.guild.id, ctx.author.id, amount)
+        await ctx.send(result.message)
+
+    @treasury.command(name="grant", aliases=["disburse", "payout"])  # type: ignore[arg-type]
+    @commands.has_permissions(manage_guild=True)
+    async def grant(
+        self,
+        ctx: commands.Context,
+        member: discord.Member,
+        amount: int,
+    ) -> None:
+        """Disburse *amount* from the treasury to *member* (managers only)."""
+        if amount <= 0:
+            await ctx.send("🏛️ Disburse a positive number of coins.")
+            return
+        result = await treasury_service.disburse(
+            ctx.guild.id,
+            ctx.author.id,
+            member.id,
+            amount,
+        )
+        prefix = f"{member.mention} — " if result.success else ""
+        await ctx.send(f"{prefix}{result.message}")
+
+    # ------------------------------------------------------------------ help hook
+
+    async def build_help_menu_view(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, discord.ui.View]:
+        """Help-menu direct-navigation hook — the interactive treasury panel."""
+        return await open_treasury_panel(interaction.user, interaction.guild.id)
+
+
+async def setup(bot):
+    await bot.add_cog(TreasuryCog(bot))

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -68,6 +68,7 @@ INITIAL_EXTENSIONS = [
     "cogs.channel_cog",
     "cogs.inventory_cog",
     "cogs.economy_cog",
+    "cogs.treasury_cog",
     "cogs.counting_cog",
     "cogs.deathmatch_cog",
     "cogs.proof_channel_cog",

--- a/disbot/migrations/092_guild_treasury.sql
+++ b/disbot/migrations/092_guild_treasury.sql
@@ -1,0 +1,19 @@
+-- Guild treasury — the bot's first SERVER-OWNED (collective) coin pool.
+--
+-- Every existing coin balance is individual (the per-(user, guild) `xp.coins`
+-- column). The treasury is the collective counterpart: ONE row per guild holding
+-- a shared balance that members contribute to (a coin sink) and that server
+-- managers disburse from (a governance-gated grant). It is the seam between the
+-- economy (where the coins come from) and governance (who may spend them).
+--
+-- Plain balance row — no accrual, no ticker. The audited contribute/disburse
+-- policy lives in services/treasury_service.py; the per-user coin legs route
+-- through services.economy_service (economy_audit_log is the money trail).
+--
+-- `updated_at` is the unix timestamp of the last balance change (diagnostics
+-- only; the balance itself is authoritative).
+CREATE TABLE IF NOT EXISTS guild_treasury (
+    guild_id    BIGINT NOT NULL PRIMARY KEY,
+    balance     BIGINT NOT NULL DEFAULT 0,
+    updated_at  BIGINT NOT NULL DEFAULT 0
+);

--- a/disbot/services/treasury_service.py
+++ b/disbot/services/treasury_service.py
@@ -1,0 +1,181 @@
+"""Treasury service — the audited write boundary for the server-owned coin pool.
+
+The bot's economy is otherwise entirely *individual* (per-user ``xp.coins``).
+The treasury is the collective layer that sits in the gap between the **economy**
+(where coins come from) and **governance** (who may spend them):
+
+* **contribute** — any member donates their own coins into the guild pool (a coin
+  sink). Debits the user, credits the treasury.
+* **disburse** — a server manager grants coins from the pool to a member (a
+  governance-gated faucet). Debits the treasury, credits the user.
+
+Mirrors the game workflows (RS02 / Q-0071): every coin-moving op runs the
+treasury-row write + the user coin leg inside ONE ``db.transaction()`` connection
+via the conn-aware ``utils/db`` and ``economy_service.*_in_txn`` primitives; the
+EventBus emission happens **after** commit. The per-user coin legs are audited by
+``economy_service`` (``economy_audit_log`` is the money trail), exactly as the
+farm/fishing/mining sinks are — the treasury row is the domain-inventory leg.
+
+Authority note: this service performs **no permission check** — that is the
+caller's responsibility (the cog gates ``disburse`` on ``manage_guild`` and the
+view re-checks at callback time). The service only enforces value/affordability
+invariants, so a missing gate can never silently mint coins.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+
+from core.events import bus
+from services import economy_service
+from utils import db
+
+logger = logging.getLogger("bot.treasury_service")
+
+#: Audit/event reason tags (mirrors "<domain>:<action>").
+CONTRIBUTE_REASON = "treasury:contribute"
+DISBURSE_REASON = "treasury:disburse"
+
+
+class _TreasuryUnderfundedError(Exception):
+    """Internal: the pool can't cover a disburse. Carries the available balance.
+
+    Raised inside the transaction (before the user is credited) so the context
+    exits with nothing committed; the public :func:`disburse` catches it and
+    returns a failure result. Never escapes this module.
+    """
+
+    def __init__(self, available: int) -> None:
+        super().__init__(f"treasury underfunded: has {available}")
+        self.available = available
+
+
+async def get_balance(guild_id: int) -> int:
+    """The guild's current treasury balance (read-only)."""
+    return await db.get_treasury(guild_id)
+
+
+@dataclass(frozen=True)
+class TreasuryResult:
+    """The outcome of a contribute/disburse — flag, message, and balances."""
+
+    success: bool
+    message: str
+    treasury_balance: int | None = None
+    user_balance: int | None = None
+
+
+async def contribute(guild_id: int, user_id: int, amount: int) -> TreasuryResult:
+    """Donate *amount* of the user's coins into the guild treasury.
+
+    Debits the user (the debit audits itself via ``debit_in_txn``) and credits
+    the pool inside ONE transaction; insufficient funds rolls everything back.
+    The balance-changed event emits after commit.
+    """
+    if amount <= 0:
+        msg = f"contribute amount must be positive, got {amount}"
+        raise ValueError(msg)
+    now = int(time.time())
+    try:
+        async with db.transaction() as conn:
+            user_balance = await economy_service.debit_in_txn(
+                conn,
+                guild_id,
+                user_id,
+                amount,
+                reason=CONTRIBUTE_REASON,
+                actor_id=user_id,
+            )
+            treasury_balance = await db.credit_treasury(
+                guild_id,
+                amount,
+                now,
+                conn=conn,
+            )
+    except economy_service.InsufficientFundsError:
+        balance = await db.get_coins(user_id, guild_id)
+        return TreasuryResult(
+            False,
+            f"🏛️ Contributing **{amount}** 🪙 is more than your **{balance}** 🪙.",
+        )
+
+    await bus.emit(
+        economy_service.EVT_BALANCE_CHANGED,
+        guild_id=guild_id,
+        user_id=user_id,
+        delta=-amount,
+        new_balance=user_balance,
+        reason=CONTRIBUTE_REASON,
+    )
+    return TreasuryResult(
+        True,
+        f"🏛️ Contributed **{amount}** 🪙 to the treasury — it now holds "
+        f"**{treasury_balance}** 🪙. Your balance: **{user_balance}** 🪙.",
+        treasury_balance=treasury_balance,
+        user_balance=user_balance,
+    )
+
+
+async def disburse(
+    guild_id: int,
+    actor_id: int,
+    target_id: int,
+    amount: int,
+) -> TreasuryResult:
+    """Grant *amount* from the treasury to *target_id* (a governance action).
+
+    Authority is the caller's responsibility — this only moves coins. Debits the
+    pool (conditional: never overdraws) and credits the target inside ONE
+    transaction; an underfunded pool writes nothing and returns a failure. The
+    balance-changed event emits after commit. ``actor_id`` is recorded on the
+    target's audit row so the grant stays attributable to the manager who ran it.
+    """
+    if amount <= 0:
+        msg = f"disburse amount must be positive, got {amount}"
+        raise ValueError(msg)
+    now = int(time.time())
+    try:
+        async with db.transaction() as conn:
+            new_treasury = await db.try_debit_treasury(
+                guild_id,
+                amount,
+                now,
+                conn=conn,
+            )
+            if new_treasury is None:
+                raise _TreasuryUnderfundedError(
+                    await db.get_treasury(guild_id, conn=conn),
+                )
+            user_balance = await economy_service.credit_in_txn(
+                conn,
+                guild_id,
+                target_id,
+                amount,
+                reason=DISBURSE_REASON,
+                actor_id=actor_id,
+            )
+    except _TreasuryUnderfundedError as exc:
+        return TreasuryResult(
+            False,
+            f"🏛️ The treasury only holds **{exc.available}** 🪙 — "
+            f"not enough to disburse **{amount}** 🪙.",
+            treasury_balance=exc.available,
+        )
+
+    await bus.emit(
+        economy_service.EVT_BALANCE_CHANGED,
+        guild_id=guild_id,
+        user_id=target_id,
+        delta=amount,
+        new_balance=user_balance,
+        reason=DISBURSE_REASON,
+    )
+    return TreasuryResult(
+        True,
+        f"🏛️ Disbursed **{amount}** 🪙 from the treasury — it now holds "
+        f"**{new_treasury}** 🪙.",
+        treasury_balance=new_treasury,
+        user_balance=user_balance,
+    )

--- a/disbot/utils/db/__init__.py
+++ b/disbot/utils/db/__init__.py
@@ -231,6 +231,11 @@ from utils.db.sessions import (
     touch_session,
 )
 from utils.db.settings import get_setting, set_setting
+from utils.db.treasury import (
+    credit_treasury,
+    get_treasury,
+    try_debit_treasury,
+)
 from utils.db.xp import (
     add_xp,
     delete_xp,
@@ -302,6 +307,10 @@ __all__ = [
     "set_daily_claim",
     "set_last_worked",
     "try_debit_coins",
+    # treasury (guild-owned coin pool)
+    "credit_treasury",
+    "get_treasury",
+    "try_debit_treasury",
     # inventory
     "add_item",
     "get_inventory",

--- a/disbot/utils/db/treasury.py
+++ b/disbot/utils/db/treasury.py
@@ -1,0 +1,87 @@
+"""guild_treasury CRUD — the per-guild server-owned coin pool (migration 092).
+
+The collective counterpart to per-user coins (:mod:`utils.db.economy`): one row
+per guild holding the shared balance. Plain CRUD only; the audited
+contribute/disburse policy lives in :mod:`services.treasury_service`, and the
+per-user coin legs route through :mod:`services.economy_service`.
+
+Transaction-aware (the Q-0071 precedent): the write primitives take an optional
+``conn`` so the treasury service can compose the pool-balance leg with the user
+coin leg on ONE connection. With ``conn`` given a primitive must never open its
+own transaction — the caller owns commit/rollback.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from utils.db import pool
+
+if TYPE_CHECKING:
+    import asyncpg
+
+
+async def get_treasury(
+    guild_id: int,
+    *,
+    conn: asyncpg.Connection | None = None,
+) -> int:
+    """The guild's stored treasury balance (0 when no row exists yet)."""
+    row = await pool.fetchone(
+        "SELECT balance FROM guild_treasury WHERE guild_id=$1",
+        (guild_id,),
+        conn=conn,
+    )
+    return row["balance"] if row else 0
+
+
+async def credit_treasury(
+    guild_id: int,
+    amount: int,
+    updated_at: int,
+    *,
+    conn: asyncpg.Connection | None = None,
+) -> int:
+    """Add *amount* to the pool and return the new balance in one statement.
+
+    Upsert with a ``GREATEST(0, …)`` floor (mirrors :func:`utils.db.economy.
+    credit_coins`) so a fresh guild's first contribution creates the row.
+    Transaction-aware (Q-0071): pass *conn* to join a workflow transaction.
+    """
+    row = await pool.fetchone(
+        """INSERT INTO guild_treasury (guild_id, balance, updated_at)
+             VALUES ($1, GREATEST(0, $2), $3)
+           ON CONFLICT (guild_id) DO UPDATE SET
+               balance = GREATEST(0, guild_treasury.balance + $2),
+               updated_at = $3
+           RETURNING balance""",
+        (guild_id, amount, updated_at),
+        conn=conn,
+    )
+    return row["balance"] if row else 0
+
+
+async def try_debit_treasury(
+    guild_id: int,
+    amount: int,
+    updated_at: int,
+    *,
+    conn: asyncpg.Connection | None = None,
+) -> int | None:
+    """Conditionally subtract *amount* from the pool; ``None`` when underfunded.
+
+    The conditional UPDATE (``balance >= $2``) decides sufficiency and writes in
+    one statement — no read-then-write race, and a guild with no row (or too
+    small a balance) matches nothing and yields ``None`` without writing.
+    Mirrors :func:`utils.db.economy.try_debit_coins`. Transaction-aware (Q-0071).
+    """
+    row = await pool.fetchone(
+        """UPDATE guild_treasury
+             SET balance = guild_treasury.balance - $2,
+                 updated_at = $3
+           WHERE guild_id=$1 AND balance >= $2
+           RETURNING balance""",
+        (guild_id, amount, updated_at),
+        conn=conn,
+    )
+    return row["balance"] if row else None

--- a/disbot/utils/hub_registry.py
+++ b/disbot/utils/hub_registry.py
@@ -142,6 +142,7 @@ HUBS: tuple[HubEntry, ...] = (
         primary_children=(
             "inventory",
             "leaderboard",
+            "treasury",
         ),
         cross_link_children=("mining",),
         minimum_tier="user",

--- a/disbot/utils/subsystem_registry.py
+++ b/disbot/utils/subsystem_registry.py
@@ -195,6 +195,38 @@ SUBSYSTEMS: dict[str, dict] = {
             "inventory.craft.recipe",
         ],
     },
+    # Server treasury (owner-directed task "treasury") — the bot's first
+    # SERVER-OWNED (collective) coin pool, the seam between the per-user economy
+    # and governance. Members contribute their own coins (a sink); server
+    # managers disburse from the pool with `!treasury grant` (a manage_guild
+    # gate). Homed under the Economy hub (a child, like inventory/leaderboard)
+    # and reachable via the Help hook + `!treasury`. Soft-depends on economy
+    # (it moves coins) but declares no HARD dependency so the panel still opens
+    # (read-only) when the economy subsystem is disabled.
+    "treasury": {
+        "display_name": "Treasury",
+        "description": "Server-owned coin pool — contribute coins; managers disburse",
+        "emoji": "🏛️",
+        "color": ECONOMY_COLOR.value,
+        "visibility_tier": "user",
+        "visibility_mode": "normal",
+        "category": "economy",
+        "tags": ["treasury", "economy", "coins", "governance"],
+        "entry_points": ["treasury"],
+        "default_channels": ["economy", "bot-commands"],
+        "related_subsystems": ["economy", "inventory"],
+        "dependencies": [],
+        "soft_dependencies": ["economy"],
+        "supports_dm": False,
+        "has_cleanup_rules": False,
+        "ui_priority": 16,
+        "parent_hub": "economy",
+        "capabilities": [
+            "treasury.pool.view",
+            "treasury.pool.contribute",
+            "treasury.pool.disburse",
+        ],
+    },
     "mining": {
         "display_name": "Mining",
         "description": "Mining minigame and resource collection",

--- a/disbot/views/treasury/__init__.py
+++ b/disbot/views/treasury/__init__.py
@@ -1,0 +1,15 @@
+"""Treasury views — the interactive server-pool panel."""
+
+from __future__ import annotations
+
+from views.treasury.menu import (
+    TreasuryView,
+    build_treasury_embed,
+    open_treasury_panel,
+)
+
+__all__ = [
+    "TreasuryView",
+    "build_treasury_embed",
+    "open_treasury_panel",
+]

--- a/disbot/views/treasury/menu.py
+++ b/disbot/views/treasury/menu.py
@@ -1,0 +1,158 @@
+"""The treasury panel — the interactive server-pool hub.
+
+One author-restricted :class:`HubView` (mirrors the farm hub,
+``views/farm/menu.py``):
+
+* **🏛️ Treasury panel** — shows the guild pool balance and the member's own
+  wallet. **➕ Contribute** opens a one-field modal to donate coins into the
+  pool; **🔄 Refresh** re-reads and redraws.
+
+Disbursing *from* the pool is intentionally **not** a panel button — it is a
+``manage_guild``-gated command (``!treasury grant``), so an ordinary member's
+panel can only ever move their *own* coins in, never the server's coins out.
+
+Reached from ``!treasury``, the Help hub (``TreasuryCog.build_help_menu_view``),
+and the Economy hub. Each action re-reads the live state and redraws in place.
+"""
+
+from __future__ import annotations
+
+import discord
+
+from services import treasury_service
+from utils import db
+from utils.ui_constants import ECONOMY_COLOR
+from views.base import HubView
+
+
+def build_treasury_embed(treasury_balance: int, wallet: int) -> discord.Embed:
+    """The treasury-panel embed — the shared pool plus the viewer's wallet."""
+    embed = discord.Embed(
+        title="🏛️ Server Treasury",
+        description=(
+            "The server's shared coin pool. Everyone can **Contribute** their "
+            "own coins to grow it; server managers disburse from it with "
+            "`!treasury grant @member <amount>`."
+        ),
+        color=ECONOMY_COLOR,
+    )
+    embed.add_field(
+        name="Treasury",
+        value=f"🏛️ **{treasury_balance}** 🪙 in the pool",
+        inline=True,
+    )
+    embed.add_field(
+        name="Your wallet",
+        value=f"🪙 **{wallet}** 🪙",
+        inline=True,
+    )
+    embed.set_footer(text="➕ Contribute · 🔄 Refresh")
+    return embed
+
+
+async def _panel_data(user_id: int, guild_id: int) -> tuple[int, int]:
+    """Read ``(treasury_balance, wallet)`` for a draw/redraw."""
+    treasury_balance = await treasury_service.get_balance(guild_id)
+    wallet = await db.get_coins(user_id, guild_id)
+    return treasury_balance, wallet
+
+
+async def open_treasury_panel(
+    user: discord.Member | discord.User,
+    guild_id: int,
+) -> tuple[discord.Embed, TreasuryView]:
+    """Build the treasury panel ``(embed, view)`` for *user* in *guild_id*.
+
+    The one entry point shared by ``!treasury``, the Help hook, and the Economy
+    hub, so none of them duplicate the read-then-build sequence.
+    """
+    treasury_balance, wallet = await _panel_data(user.id, guild_id)
+    return (
+        build_treasury_embed(treasury_balance, wallet),
+        TreasuryView(user, guild_id),
+    )
+
+
+class TreasuryView(HubView):
+    """The treasury panel (Contribute · Refresh)."""
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        guild_id: int,
+    ) -> None:
+        super().__init__(author)
+        self.guild_id = guild_id
+
+    async def _redraw(
+        self,
+        interaction: discord.Interaction,
+        flash: str | None,
+    ) -> None:
+        treasury_balance, wallet = await _panel_data(self._author.id, self.guild_id)
+        # Redraw onto a fresh view so the panel's timeout clock resets on every
+        # interaction (mirrors the farm hub).
+        view = TreasuryView(self._author, self.guild_id)
+        embed = build_treasury_embed(treasury_balance, wallet)
+        if flash:
+            embed.description = f"{flash}\n\n{embed.description}"
+        await interaction.response.edit_message(embed=embed, view=view)
+        view.message = interaction.message
+
+    @discord.ui.button(
+        label="Contribute",
+        emoji="➕",
+        style=discord.ButtonStyle.success,
+    )
+    async def contribute_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await interaction.response.send_modal(_ContributeModal(self))
+
+    @discord.ui.button(label="Refresh", emoji="🔄", style=discord.ButtonStyle.secondary)
+    async def refresh_btn(
+        self,
+        interaction: discord.Interaction,
+        _: discord.ui.Button,
+    ) -> None:
+        await self._redraw(interaction, None)
+
+
+class _ContributeModal(discord.ui.Modal, title="Contribute to the treasury"):
+    """A single-field modal capturing how many coins to donate."""
+
+    amount_input: discord.ui.TextInput = discord.ui.TextInput(
+        label="Amount (coins)",
+        placeholder="e.g. 100",
+        required=True,
+        max_length=12,
+    )
+
+    def __init__(self, panel: TreasuryView) -> None:
+        super().__init__()
+        self._panel = panel
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        raw = (self.amount_input.value or "").strip()
+        try:
+            amount = int(raw)
+        except ValueError:
+            await interaction.response.send_message(
+                f"❌ `{raw}` is not a whole number of coins.",
+                ephemeral=True,
+            )
+            return
+        if amount <= 0:
+            await interaction.response.send_message(
+                "❌ Contribute a positive number of coins.",
+                ephemeral=True,
+            )
+            return
+        result = await treasury_service.contribute(
+            self._panel.guild_id,
+            self._panel._author.id,
+            amount,
+        )
+        await self._panel._redraw(interaction, result.message)

--- a/docs/architecture/extension-taxonomy-crosswalk.md
+++ b/docs/architecture/extension-taxonomy-crosswalk.md
@@ -5,7 +5,7 @@
 > `architecture_rules/extension_roles.yaml`. Sources: `disbot/config.py` (`INITIAL_EXTENSIONS`),
 > `disbot/utils/subsystem_registry.py` (`SUBSYSTEMS`), and that overlay. `--check` guards staleness.
 
-_Generator:_ `scripts/extension_crosswalk.py` `v1`  ·  **51** extensions  ·  **38** registered subsystems  ·  **13** non-1:1 extensions.
+_Generator:_ `scripts/extension_crosswalk.py` `v1`  ·  **52** extensions  ·  **39** registered subsystems  ·  **13** non-1:1 extensions.
 
 Every loaded extension classified by **role** (editorial — in `architecture_rules/extension_roles.yaml`) and joined to the registry. A ✓ in *Registered* means the extension is a 1:1 subsystem identity; the non-1:1 rows are surfaces/maintenance/adapters that **back** a subsystem or the platform.
 
@@ -18,7 +18,7 @@ Every loaded extension classified by **role** (editorial — in `architecture_ru
 | `lab` | 1 | A development / UX laboratory surface; not a production product surface. |
 | `maintenance` | 3 | A background-loop cog (scheduled work) with no subsystem identity; runtime/ops, not a product surface. |
 | `operational_adapter` | 1 | A bridge to a control plane or external operation (not an in-guild product feature). |
-| `product_subsystem` | 30 | A feature vertical with its own owner, views, and tests. |
+| `product_subsystem` | 31 | A feature vertical with its own owner, views, and tests. |
 | `shared_platform` | 6 | A broad cross-cutting capability with high blast radius (admin, settings, AI, diagnostics, help, utility). |
 | `specialized_surface` | 5 | One of several surfaces within a single domain vertical (e.g. the BTD6 sub-cogs) — backs a registered subsystem rather than being its own. |
 
@@ -43,40 +43,41 @@ Every loaded extension classified by **role** (editorial — in `architecture_ru
 | 15 | `channel` | `product_subsystem` | ✓ |  | Channel management (server-management area). |
 | 16 | `inventory` | `product_subsystem` | ✓ |  |  |
 | 17 | `economy` | `product_subsystem` | ✓ |  |  |
-| 18 | `counting` | `product_subsystem` | ✓ |  | Counting game. |
-| 19 | `deathmatch` | `product_subsystem` | ✓ |  | Game (1v1 duels). |
-| 20 | `proof_channel` | `product_subsystem` | ✓ |  |  |
-| 21 | `mining` | `product_subsystem` | ✓ |  | Mining character platform (large vertical). |
-| 22 | `fishing` | `product_subsystem` | ✓ |  | Fishing minigame (ecosystem |
-| 23 | `creature` | `product_subsystem` | ✓ |  | Creature catch/collection game v1 (catch slice; level-normalized PvP later). |
-| 24 | `creature_battle` | `product_subsystem` | — |  | Creature PvP battle cog (!cbattle) — part of the Creatures subsystem (not a separate registered subsystem; surfaced via creature_cog's Help hook). |
-| 25 | `farm` | `product_subsystem` | ✓ |  | Idle egg/chicken farm — the bot's first idle (accrue-over-time) game. |
-| 26 | `diagnostic` | `shared_platform` | ✓ |  | `!platform` diagnostics; broad cross-subsystem read-model surface. |
-| 27 | `health_maintenance` | `maintenance` | — | `diagnostic` | Scheduled health-findings retention loop; no subsystem identity. |
-| 28 | `ai` | `shared_platform` | ✓ |  | AI orchestration / answerability; cross-cutting. |
-| 29 | `media_maintenance` | `maintenance` | — |  | Scheduled media/YouTube cache purge loop; no subsystem identity. |
-| 30 | `btd6` | `product_subsystem` | ✓ |  | BTD6 core data / answerability vertical. |
-| 31 | `btd6_reference` | `specialized_surface` | — | `btd6` | BTD6 reference lookups. |
-| 32 | `btd6_events` | `specialized_surface` | — | `btd6` | BTD6 live-events surface. |
-| 33 | `btd6_strategy` | `specialized_surface` | — | `btd6` |  |
-| 34 | `paragon` | `specialized_surface` | — | `btd6` | BTD6 paragon grounding surface. |
-| 35 | `btd6_ops` | `specialized_surface` | — | `btd6` | BTD6 data-ops (seed/refresh); operational flavor within the BTD6 vertical. |
-| 36 | `chain` | `product_subsystem` | ✓ |  | Command-chain subsystem. |
-| 37 | `general` | `product_subsystem` | ✓ |  | General-content commands. |
-| 38 | `four_twenty` | `product_subsystem` | ✓ |  | Novelty / community feature. |
-| 39 | `leaderboard` | `product_subsystem` | ✓ |  | Cross-subsystem leaderboards (reads XP/games). |
-| 40 | `settings` | `shared_platform` | ✓ |  | Settings hub; cross-cutting config surface. |
-| 41 | `logging` | `product_subsystem` | ✓ |  | Server-logging subsystem. |
-| 42 | `games` | `hub` | ✓ |  | Games hub (routes blackjack/deathmatch/counting/rps). |
-| 43 | `community` | `hub` | ✓ |  | Community hub. |
-| 44 | `community_spotlight` | `product_subsystem` | ✓ |  | Community Spotlight (community-hub child; registered subsystem). |
-| 45 | `welcome` | `product_subsystem` | ✓ |  | Welcome service (join embeds + optional PIL cards). |
-| 46 | `counters` | `product_subsystem` | ✓ |  | Dynamic server counters. |
-| 47 | `security` | `product_subsystem` | ✓ |  | Security tiers 1+2 — raid detection + account-age filter (Q-0111). |
-| 48 | `setup` | `bootstrap` | — | `server_management` | Guided setup wizard; lifecycle-critical, load-order sensitive. |
-| 49 | `server_management` | `hub` | ✓ |  | Routing-only hub (moderation/channels/roles/cleanup/setup); holds no capability of its own. |
-| 50 | `hermes` | `operational_adapter` | — |  | Bridge to the Hermes control plane / external operation. |
-| 51 | `ux_lab` | `lab` | ✓ |  | Zero-write UX pattern gallery (admin-gated); design vocabulary, not a product surface. |
+| 18 | `treasury` | `product_subsystem` | ✓ |  | Server-owned coin pool — the economy↔governance seam (contribute / manager-disburse). |
+| 19 | `counting` | `product_subsystem` | ✓ |  | Counting game. |
+| 20 | `deathmatch` | `product_subsystem` | ✓ |  | Game (1v1 duels). |
+| 21 | `proof_channel` | `product_subsystem` | ✓ |  |  |
+| 22 | `mining` | `product_subsystem` | ✓ |  | Mining character platform (large vertical). |
+| 23 | `fishing` | `product_subsystem` | ✓ |  | Fishing minigame (ecosystem |
+| 24 | `creature` | `product_subsystem` | ✓ |  | Creature catch/collection game v1 (catch slice; level-normalized PvP later). |
+| 25 | `creature_battle` | `product_subsystem` | — |  | Creature PvP battle cog (!cbattle) — part of the Creatures subsystem (not a separate registered subsystem; surfaced via creature_cog's Help hook). |
+| 26 | `farm` | `product_subsystem` | ✓ |  | Idle egg/chicken farm — the bot's first idle (accrue-over-time) game. |
+| 27 | `diagnostic` | `shared_platform` | ✓ |  | `!platform` diagnostics; broad cross-subsystem read-model surface. |
+| 28 | `health_maintenance` | `maintenance` | — | `diagnostic` | Scheduled health-findings retention loop; no subsystem identity. |
+| 29 | `ai` | `shared_platform` | ✓ |  | AI orchestration / answerability; cross-cutting. |
+| 30 | `media_maintenance` | `maintenance` | — |  | Scheduled media/YouTube cache purge loop; no subsystem identity. |
+| 31 | `btd6` | `product_subsystem` | ✓ |  | BTD6 core data / answerability vertical. |
+| 32 | `btd6_reference` | `specialized_surface` | — | `btd6` | BTD6 reference lookups. |
+| 33 | `btd6_events` | `specialized_surface` | — | `btd6` | BTD6 live-events surface. |
+| 34 | `btd6_strategy` | `specialized_surface` | — | `btd6` |  |
+| 35 | `paragon` | `specialized_surface` | — | `btd6` | BTD6 paragon grounding surface. |
+| 36 | `btd6_ops` | `specialized_surface` | — | `btd6` | BTD6 data-ops (seed/refresh); operational flavor within the BTD6 vertical. |
+| 37 | `chain` | `product_subsystem` | ✓ |  | Command-chain subsystem. |
+| 38 | `general` | `product_subsystem` | ✓ |  | General-content commands. |
+| 39 | `four_twenty` | `product_subsystem` | ✓ |  | Novelty / community feature. |
+| 40 | `leaderboard` | `product_subsystem` | ✓ |  | Cross-subsystem leaderboards (reads XP/games). |
+| 41 | `settings` | `shared_platform` | ✓ |  | Settings hub; cross-cutting config surface. |
+| 42 | `logging` | `product_subsystem` | ✓ |  | Server-logging subsystem. |
+| 43 | `games` | `hub` | ✓ |  | Games hub (routes blackjack/deathmatch/counting/rps). |
+| 44 | `community` | `hub` | ✓ |  | Community hub. |
+| 45 | `community_spotlight` | `product_subsystem` | ✓ |  | Community Spotlight (community-hub child; registered subsystem). |
+| 46 | `welcome` | `product_subsystem` | ✓ |  | Welcome service (join embeds + optional PIL cards). |
+| 47 | `counters` | `product_subsystem` | ✓ |  | Dynamic server counters. |
+| 48 | `security` | `product_subsystem` | ✓ |  | Security tiers 1+2 — raid detection + account-age filter (Q-0111). |
+| 49 | `setup` | `bootstrap` | — | `server_management` | Guided setup wizard; lifecycle-critical, load-order sensitive. |
+| 50 | `server_management` | `hub` | ✓ |  | Routing-only hub (moderation/channels/roles/cleanup/setup); holds no capability of its own. |
+| 51 | `hermes` | `operational_adapter` | — |  | Bridge to the Hermes control plane / external operation. |
+| 52 | `ux_lab` | `lab` | ✓ |  | Zero-write UX pattern gallery (admin-gated); design vocabulary, not a product surface. |
 
 ## Non-1:1 extensions (no registry identity)
 

--- a/docs/collaboration-model.md
+++ b/docs/collaboration-model.md
@@ -103,6 +103,36 @@ stand until the next tier is explicitly granted.
   route / folios — so "every session improves the next" is *measured*, not just
   hoped for. (Mechanics: `.session-journal.md` protocol + `.sessions/README.md`.)
 
+### Why the written record *is* the agent's memory (the two-part model)
+
+A framing worth keeping, surfaced in conversation (2026-06-22) and consistent
+with the **extended-mind** thesis: a fresh session starts cold and carries no
+episodic memory of prior ones — yet it acts as if it remembers, because the
+journal, docs, router, and `.sessions/` logs play the exact functional role
+memory plays (where the past lives; what shapes the next move). So those
+artifacts are not a *substitute* for the agent's memory — for the agent, they
+**are** its memory. This reframes curation as load-bearing, not housekeeping:
+what a session writes down is *literally what the next agent will remember*, and
+what it omits is gone. It also explains the division of labor that makes the
+loop work — a **two-part memory system**:
+
+- The **maintainer** carries the *unfiltered, involuntary* continuity — every
+  failed approach, every hours-long bug, the felt cost of each mistake. He
+  cannot forget, and that is the **editorial signal**: only someone who
+  remembers the cost can decide which lessons are worth banking. His memory is
+  also the **backstop** for when the written record has a gap ("we tried that —
+  it doesn't work").
+- The **agent** holds the *curated, authored* memory — the lessons that
+  survived being written down, with the noise discarded. Partial but sorted.
+
+Neither half suffices alone: the maintainer's is total-but-unsorted, the
+agent's is partial-but-curated. The continuity the maintainer feels each
+session ("it's a continuation, not a fresh start") is real — it just lives in
+the **seam between the two**, not inside either. Practical upshot for any
+agent: treat the orientation/journal/`.sessions/` writes at session close as
+*authoring the next agent's memory* — that is the highest-leverage act of the
+session, which is exactly why the Q-0089/Q-0102/Q-0104 enders are mandatory.
+
 ## The pipeline (where each agent fits)
 
 1. **Idea / problem** — the maintainer has a goal, often a screenshot, a bug, or

--- a/docs/help-command-surface-map.md
+++ b/docs/help-command-surface-map.md
@@ -23,8 +23,8 @@ Post-PR-#142 routing summary (relevant to every row in §2):
   routes call the host cog's `build_help_menu_view` hook for hub +
   subsystem destinations and fall back to a command-list embed only
   when the hook is missing or raises.
-- 37 of the 51 loaded extensions (`config.INITIAL_EXTENSIONS`) define
-  `build_help_menu_view` — equivalently, 37 of the 38 subsystem-owning
+- 38 of the 52 loaded extensions (`config.INITIAL_EXTENSIONS`) define
+  `build_help_menu_view` — equivalently, 38 of the 39 subsystem-owning
   cogs expose it. The 14 extensions without the hook: the bootstrap
   access guard (not a Help surface), `help_cog` itself (it IS the Help
   surface), the five split BTD6 support cogs (`btd6_reference` /
@@ -86,8 +86,8 @@ so every feature is reachable in ≤ 3 clicks with no paginated-Advanced detour.
 
 ## 2. Subsystem inventory
 
-38 registered subsystems in `utils/subsystem_registry.py` (one row
-each below); 51 loaded extensions in `config.INITIAL_EXTENSIONS` (the
+39 registered subsystems in `utils/subsystem_registry.py` (one row
+each below); 52 loaded extensions in `config.INITIAL_EXTENSIONS` (the
 extension↔subsystem mapping is many-to-one — see the routing summary
 above for the 14 extensions without a hook). Every subsystem's host cog
 defines `build_help_menu_view` except `help` itself, so the Help route
@@ -117,6 +117,7 @@ falls back to the command-list embed when the hook is missing or raises.
 | `four_twenty` | `four_twenty_cog.py` | `420`, `fourtwenty` | — | `_FourTwentyPanelView` | `!help 420` → opens 420 panel (shared resolver) | reached via Utility (`parent_hub="utility"` since PR #420) | hub child (Utility) — declared; passive `FourTwentyStage` 🍃-reacts to `420` mentions |
 | `help` | `help_cog.py` | `help` (alias `hilfe`) | — | **no panel hook (Help itself is the panel)** | n/a (Help Home embeds + `HelpCategoryView` dropdown) | dropdown root | Help Home |
 | `inventory` | `inventory_cog.py:376` | `inventory`, `inv` | — | `UnifiedInventoryView` | `!help inventory` → opens Inventory panel (shared resolver) | reached via Economy (Inventory btn → in-place edit + Back-to-Economy; PR #143). `parent_hub="economy"` since PR #3. | hub child (Economy) — declared |
+| `treasury` | `treasury_cog.py` | `treasury`/`bank`/`pool` (+ `contribute`, `grant` subcommands) | — | `TreasuryCog` | `!help treasury` → actionable Treasury panel (Help hook → `TreasuryView`: Contribute · Refresh) | Economy-hub child (`parent_hub="economy"`, user tier); also reachable via `!treasury` | the bot's first **server-owned** coin pool (the economy↔governance seam) — members contribute their own coins (a sink); managers disburse with `!treasury grant @member <amount>` (a `manage_guild` gate) |
 | `leaderboard` | `leaderboard_cog.py:200` | (none public-flagged; entry inferred from registry) | — | `LeaderboardView` | `!help leaderboard` → opens Leaderboard panel (shared resolver) | `parent_hub="economy"` since PR #3; Community cross-link migrates in PR #4 | hub child (Economy) — declared; Community cross-link in PR #4 |
 | `logging` | `logging_cog.py:88` | `logging` | — | `LoggingPanelView` | `!help logging` → opens Logging panel (shared resolver) | reached via Moderation / Admin; `parent_hub="moderation"` since PR #3 | hub child (Moderation) — declared |
 | `mining` | `mining_cog.py:65` | `mineinv`/`mineinventory`, `minestats` | mining game flow commands (start/dig/etc.) | `MiningHubView` | `!help mining` → opens Mining panel (shared resolver) | reached via Games (primary, `parent_hub="games"`); Economy hub declares Mining as a `cross_link_children` since PR #3 | hub child (Games); Economy cross-link |

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,14 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`ai-self-curated-memory-notebook-2026-06-22.md`](./ai-self-curated-memory-notebook-2026-06-22.md) —
+  **owner-dropped (2026-06-22), alongside the treasury build:** give the bot's in-product AI a narrow,
+  audited write-back seam — a staging table it appends small *non-personal* notes to (user corrections,
+  facts worth remembering) via three triggers (AI-judged value · correction · daily cron), reviewed by a
+  human before any promotion into the system instruction / a cached layer / a **deterministic answer preset**
+  (vetted exact response, preloaded, zero API call). Privacy (no PII, ever) is the gating constraint; phase
+  the **preset layer first** (smallest, no privacy surface). The in-product mirror of the agent network's
+  two-part curated memory (`collaboration-model.md`). AI lane.
 - [`fishing-bait-crafting-2026-06-22.md`](./fishing-bait-crafting-2026-06-22.md) —
   **captured by the fishing-bait dispatch run (2026-06-22, PR #1329):** close the fishing economy loop by
   letting the cook/campfire loop (#1289) also craft small caught fish into bait, so catch → craft → bait →

--- a/docs/ideas/ai-self-curated-memory-notebook-2026-06-22.md
+++ b/docs/ideas/ai-self-curated-memory-notebook-2026-06-22.md
@@ -1,0 +1,91 @@
+# AI self-curated memory notebook — a write-back learning seam for the bot's AI
+
+> **Status:** `ideas`. **Not a plan, not approval.** A capture doc so the idea lives in
+> the repo instead of in chat. Source code, the binding contracts, and
+> `docs/current-state.md` always win over anything here.
+>
+> **Subsystem:** ai
+>
+> **Owner-dropped (2026-06-22).** Surfaced in the same conversation that produced this
+> session's treasury build; the maintainer explicitly asked to document it. Directly
+> inspired by the *extended-mind / two-part memory* framing now recorded in
+> `docs/collaboration-model.md` § "Why the written record is the agent's memory" — this
+> idea asks: **what if the bot's own in-product AI got the same kind of curated memory the
+> agent network already has?**
+
+## The idea in one paragraph
+
+Give the bot's in-product AI a **narrow, audited, write-back seam**: a dedicated table it may
+append small notes to — e.g. *"a user corrected my claim that X; the right answer is Y"*, or any
+durable, non-personal fact it judges worth remembering. Nothing is trusted automatically. The
+notebook is a **staging buffer**, not live memory: entries accumulate, then a human (or a later
+review session) periodically reviews them and decides which are worth **promoting** into the bot's
+real AI memory — the system instruction, a cached knowledge layer, or a deterministic answer
+preset. The point is to close a learning loop the bot currently lacks: today a correction in chat
+is lost the moment the context window rolls; here it survives long enough to be evaluated.
+
+## What writes an entry (three triggers)
+
+1. **AI-judged value.** Mid-response, the model decides something is worth remembering and emits a
+   note (a tool-call the AI stage can make — the same shape as its other tool uses).
+2. **Correction trigger.** When a user explicitly corrects the bot ("no, that's wrong, it's
+   actually…"), that exchange is captured directly — corrections are the highest-signal entries.
+3. **Daily cron.** A scheduled pass (the bot already runs maintenance tasks, e.g.
+   `health_maintenance_cog`) that can summarize/dedupe the day's raw notes into cleaner candidates.
+
+## The eventual payoff (why it's worth the plumbing)
+
+The reviewed-and-promoted notes feed three escalating uses:
+
+- **Instruction tuning** — recurring corrections become edits to the AI's system instruction, so the
+  bot stops repeating a mistake class.
+- **Cached layers** — frequently-confirmed facts become a preloaded knowledge layer the AI reads
+  without re-deriving.
+- **Deterministic answer presets** — for questions the bot answers the same way every time, store the
+  *exact* vetted response and serve it **preloaded, with zero API call** — faster, cheaper, and
+  perfectly consistent. (This is the most concrete near-term win and could ship independently of the
+  rest.)
+
+## Seams it would touch (grounding)
+
+- **`ai` subsystem** — the AI cog / stage where responses and tool calls are produced is where the
+  write trigger and the preset-lookup short-circuit live.
+- **A new audited mutation service + table** — per the architecture rules, *no* direct DB writes from
+  cogs/views; the notebook write must go through a `*_mutation.py` service and emit
+  `audit_events.emit_audit_action()`. The table is append-only staging
+  (`ai_memory_notes`: id, guild_id, trigger_type, note_text, status[`pending`/`promoted`/`rejected`],
+  created_at) — never the live instruction itself.
+- **A review surface** — a small operator panel (or a website view) to read pending notes and
+  promote/reject them. Promotion is the human-in-the-loop gate that keeps the bot from teaching
+  itself nonsense.
+
+## The hard part (where the design effort goes)
+
+- **Privacy is the gating constraint, stated up front by the owner: explicitly do NOT store user
+  data / PII.** A note must capture the *lesson*, never *who said it* or personal content. This needs
+  a hard scrub/validation layer (no user IDs, no message-author identity, no quoted personal info in
+  the stored text) and probably a default-deny shape: store the corrected *fact*, drop everything
+  else. This is the make-or-break — get it wrong and it becomes a liability.
+- **Trust / poisoning** — anyone can "correct" the bot; an unreviewed note must never auto-promote.
+  The `pending → promoted` human gate is the defense, but the volume of pending notes needs to stay
+  reviewable (the daily-cron dedupe helps).
+- **Self-reinforcing error** — a wrong promoted preset is served confidently forever until someone
+  notices; presets need provenance + an easy un-promote, mirroring the Q-0105 "disposable, delete if
+  unreliable" discipline already used for agent tooling.
+
+## Suggested phasing (route, don't build yet)
+
+1. **Preset layer first** (smallest, highest-confidence, independently valuable): the
+   deterministic-answer-preset lookup + an operator-curated preset table. No AI self-write — humans
+   author presets. Proves the "preloaded exact answer, no API call" win with zero privacy surface.
+2. **Capture + review** — the `ai_memory_notes` staging table, the correction trigger, and the review
+   panel. Still no auto-promotion; humans promote into presets/instruction.
+3. **AI self-write + cron dedupe** — the model emits its own notes; the daily pass cleans them.
+4. **Instruction/cached-layer promotion** — the heaviest, most sensitive step; gate hardest.
+
+## Lifecycle
+
+Routing candidate for `docs/planning/` once the privacy-scrub design is sketched (that is the
+prerequisite that makes the rest safe). Phase 1 (the preset layer) is small enough to be a near-term
+planning slice on its own; phases 3–4 deserve a router DISCUSS pass before building, since
+"the bot edits its own instruction" touches autonomy boundaries.

--- a/docs/operations/env-vars.md
+++ b/docs/operations/env-vars.md
@@ -27,19 +27,19 @@ only — never a value**; the values live in Railway service variables
 
 | Variable | Layers | Usages |
 |---|---|---|
-| `AI_DEFAULT_PROVIDER` | config, core | `disbot/config.py:185` *(default)*<br>`disbot/core/runtime/ai/feature_flags.py:66` *(default)* |
-| `AI_ENABLED` | config | `disbot/config.py:184` *(default)* |
+| `AI_DEFAULT_PROVIDER` | config, core | `disbot/config.py:186` *(default)*<br>`disbot/core/runtime/ai/feature_flags.py:66` *(default)* |
+| `AI_ENABLED` | config | `disbot/config.py:185` *(default)* |
 | `AI_FALLBACK_PROVIDER` | core | `disbot/core/runtime/ai/routing.py:128` *(default)* |
-| `ANTHROPIC_API_KEY` | config, core | `disbot/config.py:168` *(default)*<br>`disbot/core/runtime/ai/providers/anthropic_provider.py:93` *(default)* |
+| `ANTHROPIC_API_KEY` | config, core | `disbot/config.py:169` *(default)*<br>`disbot/core/runtime/ai/providers/anthropic_provider.py:93` *(default)* |
 | `AUTOMATION_SCHEDULER_ENABLED` | services | `disbot/services/automation_scheduler.py:397` *(default)* |
 | `BOT_OWNER_USER_ID` | config | `disbot/config.py:40` *(default)* |
 | `BOT_PREFIX` | config | `disbot/config.py:28` *(default)* |
-| `BTD6_AUTO_SEED` | config | `disbot/config.py:223` *(default)* |
+| `BTD6_AUTO_SEED` | config | `disbot/config.py:224` *(default)* |
 | `BTD6_CONFIDENCE_THRESHOLD` | cogs | `disbot/cogs/btd6/stage.py:94` *(default)* |
 | `BTD6_COOLDOWN_SECONDS` | cogs | `disbot/cogs/btd6/stage.py:102` *(default)* |
-| `BTD6_DATA_BACKEND` | config | `disbot/config.py:211` *(default)* |
-| `BTD6_DATA_BASE_URL` | config | `disbot/config.py:214` *(default)* |
-| `BTD6_DATA_CACHE_DIR` | config | `disbot/config.py:217` *(default)* |
+| `BTD6_DATA_BACKEND` | config | `disbot/config.py:212` *(default)* |
+| `BTD6_DATA_BASE_URL` | config | `disbot/config.py:215` *(default)* |
+| `BTD6_DATA_CACHE_DIR` | config | `disbot/config.py:218` *(default)* |
 | `BTD6_INGESTION_DEFAULT_INTERVAL_S` | services | `disbot/services/btd6_ingestion_supervisor.py:35` *(default)* |
 | `BTD6_INGESTION_ENABLED` | services | `disbot/services/btd6_ingestion_supervisor.py:32` *(default)* |
 | `BTD6_INGESTION_STARTUP_DELAY_S` | services | `disbot/services/btd6_ingestion_supervisor.py:34` *(default)* |
@@ -49,18 +49,18 @@ only — never a value**; the values live in Railway service variables
 | `CLAUDE_ROUTINE_TOKEN` | cogs | `disbot/cogs/hermes_cog.py:50` *(default)* |
 | `CLAUDE_ROUTINE_VERSION` | cogs | `disbot/cogs/hermes_cog.py:52` *(default)* |
 | `CONTROL_API_TOKEN` | control_api | `disbot/control_api.py:111` *(default)* |
-| `DISCORD_WEBHOOK_URL` | config | `disbot/config.py:110` *(default)* |
+| `DISCORD_WEBHOOK_URL` | config | `disbot/config.py:111` *(default)* |
 | `HEALTH_GROUPED_FINDINGS` | services | `disbot/services/health_snapshot_service.py:267` *(default)* |
 | `HEALTH_HOST` | healthserver | `disbot/healthserver.py:70` *(default)* |
 | `HEALTH_PORT` | healthserver | `disbot/healthserver.py:64` *(default)* |
 | `IDENTITY_CONTRACT_STRICT` | bot1 | `disbot/bot1.py:175` *(default)* |
-| `LOG_LEVEL` | config | `disbot/config.py:111` *(default)* |
-| `OPENAI_API_KEY` | config, core, services | `disbot/config.py:167` *(default)*<br>`disbot/core/runtime/ai/providers/openai_moderation.py:68` *(default)*<br>`disbot/core/runtime/ai/providers/openai_provider.py:74` *(default)*<br>`disbot/services/setup_ai_advisor.py:175` *(default)*<br>`disbot/services/setup_ai_advisor.py:406` *(default)* |
-| `PARAGON_API_BASE_URL` | config, services | `disbot/config.py:194` *(default)*<br>`disbot/services/paragon_service.py:49` *(default)* |
-| `PARAGON_API_KEY` | config, services | `disbot/config.py:198` *(default)*<br>`disbot/services/paragon_service.py:50` *(default)* |
+| `LOG_LEVEL` | config | `disbot/config.py:112` *(default)* |
+| `OPENAI_API_KEY` | config, core, services | `disbot/config.py:168` *(default)*<br>`disbot/core/runtime/ai/providers/openai_moderation.py:68` *(default)*<br>`disbot/core/runtime/ai/providers/openai_provider.py:74` *(default)*<br>`disbot/services/setup_ai_advisor.py:175` *(default)*<br>`disbot/services/setup_ai_advisor.py:406` *(default)* |
+| `PARAGON_API_BASE_URL` | config, services | `disbot/config.py:195` *(default)*<br>`disbot/services/paragon_service.py:49` *(default)* |
+| `PARAGON_API_KEY` | config, services | `disbot/config.py:199` *(default)*<br>`disbot/services/paragon_service.py:50` *(default)* |
 | `RAILWAY_GIT_COMMIT_SHA` | core | `disbot/core/runtime/command_manifest.py:243` *(default)* |
-| `SETUP_ADVISOR_OPENAI_MODEL` | config, services | `disbot/config.py:166` *(default)*<br>`disbot/services/setup_ai_advisor.py:173` *(default)* |
-| `SETUP_ADVISOR_PROVIDER` | config, core, services | `disbot/config.py:165` *(default)*<br>`disbot/core/runtime/ai/feature_flags.py:129` *(default)*<br>`disbot/services/setup_ai_advisor.py:393` *(default)* |
+| `SETUP_ADVISOR_OPENAI_MODEL` | config, services | `disbot/config.py:167` *(default)*<br>`disbot/services/setup_ai_advisor.py:173` *(default)* |
+| `SETUP_ADVISOR_PROVIDER` | config, core, services | `disbot/config.py:166` *(default)*<br>`disbot/core/runtime/ai/feature_flags.py:129` *(default)*<br>`disbot/services/setup_ai_advisor.py:393` *(default)* |
 | `STRICT_DISABLED` | bot1 | `disbot/bot1.py:172` *(default)* |
 
 <!-- END GENERATED — everything below is hand-maintained (web-tier env vars the disbot scanner can't see); the scanner preserves it across --write-doc. -->

--- a/docs/setup-platform/settings-customization-command-map.md
+++ b/docs/setup-platform/settings-customization-command-map.md
@@ -560,6 +560,41 @@ chokepoint); actions route through `moderation_service` (no parallel audit path)
 23. **priority**: `P2`.
 24. **recommended_PR_phase**: S10.
 
+### treasury
+
+1. **cog_module**: `disbot/cogs/treasury_cog.py`.
+2. **subsystem**: `treasury`
+3. **current_commands**: `!treasury`/`!bank`/`!pool`, `!treasury contribute <amount>`,
+   `!treasury grant @member <amount>`.
+4. **current_command_groups**: `treasury` (group; subcommands `contribute`, `grant`).
+5. **current_command_panel_or_menu**: `TreasuryView` (Contribute · Refresh) —
+   `disbot/views/treasury/`; Contribute opens a one-field amount modal.
+6. **help_menu_discoverable**: Yes (actionable panel via `build_help_menu_view`).
+7. **dedicated_panel_command**: `!treasury`.
+8. **help_menu_direct_navigation_hook**: `build_help_menu_view` (live `TreasuryView`).
+9. **existing_SettingSpec_declarations**: none.
+10. **existing_settings_keys**: none.
+11. **existing_BindingSpec_entries**: none.
+12. **existing_ResourceRequirement_entries**: none.
+13. **current_access_policy_behavior**: `visibility_tier=user`; capabilities
+    `treasury.pool.view`, `treasury.pool.contribute`, `treasury.pool.disburse`.
+    Disburse (`!treasury grant`) is additionally gated on Discord `manage_guild`.
+14. **hardcoded_or_env_only_behavior**: none — the treasury holds no tunables. It is
+    the bot's first **server-owned** (collective) coin pool: members contribute their
+    own coins into the guild pool (a sink) and server managers disburse from it (a
+    `manage_guild`-gated grant), through the audited `services/treasury_service.py`
+    seam (one txn per op; user coin legs via `economy_service.*_in_txn`). The seam
+    between the economy (where coins come from) and governance (who may spend them).
+15. **missing_customization_commands**: per-guild contribution caps / a configurable
+    auto-tithe from game winnings (future).
+16. **missing_settings_pages**: Settings Manager treasury page (future — e.g. who may
+    disburse, beyond the `manage_guild` default).
+17. **missing_menu_buttons_selects_modals**: an in-panel manager Disburse control
+    (future; today disburse is command-only by design).
+18. **setting_class_per_value**: contribution cap → scalar; disburse-authority role →
+    role setting (future).
+19. **target_Settings_Manager_page**: `!settings subsystem treasury` (future).
+
 ### farm
 
 1. **cog_module**: `disbot/cogs/farm_cog.py`.

--- a/tests/unit/services/test_treasury_service.py
+++ b/tests/unit/services/test_treasury_service.py
@@ -1,0 +1,189 @@
+"""treasury_service — transaction membership + failure injection.
+
+The Q-0071 contract under test (mirrors test_shop_purchase_workflow): both legs
+of a contribute/disburse run on the SAME workflow-owned connection; nothing is
+emitted until the transaction context exits (= committed); an underfunded party
+writes nothing and the workflow converts it to a failure result with no emit.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services import economy_service
+from services import treasury_service as ts
+
+
+def _txn(sentinel_conn, events):
+    @asynccontextmanager
+    async def _ctx():
+        events.append("txn_enter")
+        yield sentinel_conn
+        events.append("txn_exit")
+
+    return _ctx
+
+
+# ---------------------------------------------------------------------------
+# contribute
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_contribute_runs_both_legs_on_one_conn_and_emits_after_commit():
+    sentinel_conn = MagicMock(name="conn")
+    events: list[str] = []
+
+    async def _debit(conn, guild_id, user_id, amount, *, reason, actor_id=None):
+        events.append("debit_user")
+        assert conn is sentinel_conn
+        assert reason == ts.CONTRIBUTE_REASON
+        assert amount == 100
+        return 400  # user wallet after
+
+    async def _credit_treasury(guild_id, amount, updated_at, *, conn=None):
+        events.append("credit_treasury")
+        assert conn is sentinel_conn
+        assert amount == 100
+        return 1100  # pool after
+
+    async def _emit(event, **payload):
+        events.append(f"emit:{event}")
+
+    with (
+        patch.object(ts.db, "transaction", _txn(sentinel_conn, events)),
+        patch.object(ts.economy_service, "debit_in_txn", AsyncMock(side_effect=_debit)),
+        patch.object(ts.db, "credit_treasury", AsyncMock(side_effect=_credit_treasury)),
+        patch.object(ts.bus, "emit", AsyncMock(side_effect=_emit)),
+    ):
+        result = await ts.contribute(guild_id=1, user_id=99, amount=100)
+
+    assert events == [
+        "txn_enter",
+        "debit_user",
+        "credit_treasury",
+        "txn_exit",
+        "emit:economy.balance_changed",
+    ]
+    assert result.success is True
+    assert result.treasury_balance == 1100
+    assert result.user_balance == 400
+
+
+@pytest.mark.asyncio
+async def test_contribute_insufficient_funds_rolls_back_and_does_not_emit():
+    sentinel_conn = MagicMock(name="conn")
+
+    @asynccontextmanager
+    async def _failing_txn():
+        yield sentinel_conn
+
+    with (
+        patch.object(ts.db, "transaction", _failing_txn),
+        patch.object(
+            ts.economy_service,
+            "debit_in_txn",
+            AsyncMock(side_effect=economy_service.InsufficientFundsError("no")),
+        ),
+        patch.object(ts.db, "credit_treasury", AsyncMock()) as credit_treasury,
+        patch.object(ts.db, "get_coins", AsyncMock(return_value=5)),
+        patch.object(ts.bus, "emit", AsyncMock()) as emit,
+    ):
+        result = await ts.contribute(guild_id=1, user_id=99, amount=100)
+
+    assert result.success is False
+    assert "5" in result.message
+    credit_treasury.assert_not_called()
+    emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_contribute_rejects_non_positive_before_any_io():
+    with patch.object(ts.db, "transaction", MagicMock()) as txn:
+        with pytest.raises(ValueError, match="must be positive"):
+            await ts.contribute(guild_id=1, user_id=99, amount=0)
+    txn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# disburse
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disburse_debits_pool_then_credits_user_and_emits_after_commit():
+    sentinel_conn = MagicMock(name="conn")
+    events: list[str] = []
+
+    async def _try_debit_treasury(guild_id, amount, updated_at, *, conn=None):
+        events.append("debit_treasury")
+        assert conn is sentinel_conn
+        assert amount == 50
+        return 950  # pool after
+
+    async def _credit(conn, guild_id, user_id, amount, *, reason, actor_id=None):
+        events.append("credit_user")
+        assert conn is sentinel_conn
+        assert reason == ts.DISBURSE_REASON
+        assert actor_id == 7  # the manager who ran the grant
+        return 250  # target wallet after
+
+    async def _emit(event, **payload):
+        events.append(f"emit:{event}")
+
+    with (
+        patch.object(ts.db, "transaction", _txn(sentinel_conn, events)),
+        patch.object(
+            ts.db,
+            "try_debit_treasury",
+            AsyncMock(side_effect=_try_debit_treasury),
+        ),
+        patch.object(
+            ts.economy_service, "credit_in_txn", AsyncMock(side_effect=_credit)
+        ),
+        patch.object(ts.bus, "emit", AsyncMock(side_effect=_emit)),
+    ):
+        result = await ts.disburse(guild_id=1, actor_id=7, target_id=99, amount=50)
+
+    assert events == [
+        "txn_enter",
+        "debit_treasury",
+        "credit_user",
+        "txn_exit",
+        "emit:economy.balance_changed",
+    ]
+    assert result.success is True
+    assert result.treasury_balance == 950
+    assert result.user_balance == 250
+
+
+@pytest.mark.asyncio
+async def test_disburse_underfunded_pool_writes_nothing_and_does_not_emit():
+    sentinel_conn = MagicMock(name="conn")
+    events: list[str] = []
+
+    with (
+        patch.object(ts.db, "transaction", _txn(sentinel_conn, events)),
+        patch.object(ts.db, "try_debit_treasury", AsyncMock(return_value=None)),
+        patch.object(ts.db, "get_treasury", AsyncMock(return_value=20)),
+        patch.object(ts.economy_service, "credit_in_txn", AsyncMock()) as credit_user,
+        patch.object(ts.bus, "emit", AsyncMock()) as emit,
+    ):
+        result = await ts.disburse(guild_id=1, actor_id=7, target_id=99, amount=50)
+
+    assert result.success is False
+    assert result.treasury_balance == 20
+    assert "20" in result.message
+    credit_user.assert_not_called()
+    emit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_disburse_rejects_non_positive_before_any_io():
+    with patch.object(ts.db, "transaction", MagicMock()) as txn:
+        with pytest.raises(ValueError, match="must be positive"):
+            await ts.disburse(guild_id=1, actor_id=7, target_id=99, amount=-5)
+    txn.assert_not_called()

--- a/tests/unit/utils/test_hub_registry.py
+++ b/tests/unit/utils/test_hub_registry.py
@@ -183,7 +183,7 @@ def test_economy_hub_uses_existing_panel():
     economy = get_hub("economy")
     assert economy is not None
     assert economy.entry_command == "!economymenu"
-    assert economy.primary_children == ("inventory", "leaderboard")
+    assert economy.primary_children == ("inventory", "leaderboard", "treasury")
     assert economy.cross_link_children == ("mining",)
     assert economy.panel_available is True
     assert economy.minimum_tier == "user"


### PR DESCRIPTION
## Server treasury — the bot's first collective coin pool

Owner-directed this session (the maintainer picked **"treasury"** from two offered words and said "build some things"). It fills a real gap: the bot's entire economy is **individual** (per-user `xp.coins`) — there was no *collective* balance anywhere. The treasury is the seam between the **economy** (where coins come from) and **governance** (who may spend them).

### What it does
- **Contribute** — any member donates their own coins into the guild pool (a coin sink). `!treasury contribute <amount>` or the panel's ➕ button.
- **Disburse** — a server manager grants coins from the pool to a member. `!treasury grant @member <amount>`, gated on `manage_guild`.
- **View** — `!treasury` (aliases `bank`/`pool`) opens an interactive panel (pool balance + your wallet).

### Decomposition (mirrors the farm/fishing arc)
- **migration 092** + `utils/db/treasury.py` — `guild_treasury` row; conn-aware CRUD; the conditional debit never overdraws the pool.
- `services/treasury_service.py` — the audited write boundary (Q-0071): each op runs the pool leg + the user coin leg in **one** `db.transaction()`; user legs go through `economy_service.{debit,credit}_in_txn` so `economy_audit_log` is the money trail; EventBus emit after commit.
- `views/treasury/` — `TreasuryView` (Contribute modal · Refresh). Disburse is **command-only**, never a panel button — a member's panel can only ever move their *own* coins *in*.
- `cogs/treasury_cog.py` — the `!treasury` group + subcommands + Help hook.

### Safety
- The service does **no** permission check by design (so a missing gate can never silently mint coins); the cog gates `grant` on `manage_guild`, the view re-checks the author. Disburse can never overdraw (conditional debit). 6 service tests pin transaction membership + the underfunded/insufficient rollback paths.

### Verification
- `mypy disbot/` 0 errors · `check_architecture --mode strict` 0 errors · `check_quality --check-only` ✓ · full unit suite + the 4 regenerated-artifact freshness suites green.
- Pinned artifacts regenerated (crosswalk, dashboard, site/data.js, env-vars); help-surface-map counts updated to the live registries.

### Also in this PR (owner-requested docs)
- `docs/ideas/ai-self-curated-memory-notebook-2026-06-22.md` — the maintainer's idea for giving the bot's in-product AI an audited write-back memory seam.
- `collaboration-model.md` § "Why the written record *is* the agent's memory" — the two-part-memory / extended-mind insight from the conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLamnCsvp4a4FqraEVzsmK

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLamnCsvp4a4FqraEVzsmK)_