### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-22T23:26:34Z",
+    "generated_at": "2026-06-22T21:56:45Z",
     "build": {
-      "commit": "ac1a1c7d",
-      "subject": "Merge branch 'main' into claude/funny-franklin-blbz7w",
-      "committed_at": "2026-06-22T23:26:34Z"
+      "commit": "fd3d575f",
+      "subject": "fix(farm): fresh coop no longer starts full + \"while you were away\" idle summary (#1331)",
+      "committed_at": "2026-06-22T21:56:45Z"
     },
     "counts": {
       "functions": 38,
@@ -1059,7 +1059,7 @@
     {
       "file": "idle-game-offline-summary-2026-06-22.md",
       "title": "Idea — \"while you were away\" offline-progress summary for idle games",
-      "status": "ideas",
+      "status": "historical",
       "date": "2026-06-22",
       "summary": "The chicken farm (shipped this session) is the bot's first **idle** game: progress",
       "subsystems": null
@@ -2542,6 +2542,14 @@
       "self_initiated": true
     },
     {
+      "file": "2026-06-22-farm-freshstart-and-idle-summary.md",
+      "date": "2026-06-22",
+      "title": "2026-06-22 — farm fresh-start faucet fix + \"while you were away\" idle summary",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
       "file": "2026-06-22-ci-strand-cancel-in-progress.md",
       "date": "2026-06-22",
       "title": "Session — CI strand root cause: code-quality cancel-in-progress (2026-06-22)",
@@ -2724,14 +2732,6 @@
       "status": "complete",
       "run_type": "manual",
       "self_initiated": true
-    },
-    {
-      "file": "2026-06-21-reaction-roles-presentation-editing.md",
-      "date": "2026-06-21",
-      "title": "2026-06-21 — Reaction-roles plan: presentation & editing requirements",
-      "status": "complete",
-      "run_type": "manual",
-      "self_initiated": false
     }
   ],
   "bot_changelog": [


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.