### PR TITLE
chore(dashboard): refresh generated data

### DIFF
--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-23T00:51:14Z",
+    "generated_at": "2026-06-22T23:03:59Z",
     "build": {
-      "commit": "a4f3aac",
-      "subject": "Merge branch 'main' into claude/great-goldberg-extjsi",
-      "committed_at": "2026-06-23T00:51:14Z"
+      "commit": "b4fd137e",
+      "subject": "Casino subsystem — multiplayer card-game table framework + Texas Hold'em poker (#1333)",
+      "committed_at": "2026-06-22T23:03:59Z"
     },
     "counts": {
       "functions": 41,


### PR DESCRIPTION
Automated refresh of `dashboard/data/dashboard.json` — a source that feeds the website's Updates/Ideas/Bugs panels changed on main. Regenerated data only (no code); auto-merges once Code Quality is green. Generated by .github/workflows/dashboard-data-refresh.yml.