### PR TITLE
Fishing bait-crafting — turn caught fish into bait (close the catch→bait loop)

### DIFF
--- a/.sessions/2026-06-23-fishing-bait-crafting.md
+++ b/.sessions/2026-06-23-fishing-bait-crafting.md
@@ -1,0 +1,23 @@
+# 2026-06-23 — Fishing bait-crafting (close the catch→cook→bait economy loop)
+
+> **Status:** `in-progress` — born-red card (Q-0133). Routine · dispatch (empty-fire
+> schedule; promotes the `fishing-bait-crafting-2026-06-22` idea → build, Q-0172).
+> PR auto-merges on green (Q-0123) once flipped `complete`.
+
+## What I'm about to do
+
+Empty-fire dispatch run. Product lanes that need creds/browser/network are gated
+(BTD6 live battery · botsite PR 2 cutover · Project Moon ingest), so I'm promoting
+the cleanest fully-offline-testable S1 idea — **bait crafting from caught fish**
+([idea](../ideas/fishing-bait-crafting-2026-06-22.md)) — to a shipped build. It
+builds directly on the just-shipped bait layer (#1329/#1337) and the cook/campfire
+loop (#1289): small caught fish become a *gameplay-native* second source of bait
+beside the coin shop, closing `catch → craft → bait → bigger catch`.
+
+Scope:
+1. `utils/fishing/bait.py` — pure `BaitRecipe` map (small fish → bait pack), helpers.
+2. `services/fishing_workflow.py` — `craft_bait` workflow op (debit fish + load bait
+   in ONE transaction, mirroring `cook` / `buy_bait`; no coin debit — inventory→bait).
+3. `views/fishing/bait_shop.py` — a "Craft from fish" select + recipe field on the panel.
+4. `cogs/fishing_cog.py` — `!craftbait [bait]` surface.
+5. Tests across utils + workflow.

--- a/.sessions/2026-06-23-fishing-bait-crafting.md
+++ b/.sessions/2026-06-23-fishing-bait-crafting.md
@@ -1,23 +1,86 @@
 # 2026-06-23 — Fishing bait-crafting (close the catch→cook→bait economy loop)
 
-> **Status:** `in-progress` — born-red card (Q-0133). Routine · dispatch (empty-fire
-> schedule; promotes the `fishing-bait-crafting-2026-06-22` idea → build, Q-0172).
-> PR auto-merges on green (Q-0123) once flipped `complete`.
+> **Status:** `complete` — born-red card (Q-0133) flipped green as the final step.
+> Routine · dispatch (empty-fire schedule; promotes the `fishing-bait-crafting-2026-06-22`
+> idea → build, Q-0172). PR #1338 → auto-merges on green (Q-0123).
 
-## What I'm about to do
+## Arc
 
-Empty-fire dispatch run. Product lanes that need creds/browser/network are gated
-(BTD6 live battery · botsite PR 2 cutover · Project Moon ingest), so I'm promoting
-the cleanest fully-offline-testable S1 idea — **bait crafting from caught fish**
-([idea](../ideas/fishing-bait-crafting-2026-06-22.md)) — to a shipped build. It
-builds directly on the just-shipped bait layer (#1329/#1337) and the cook/campfire
-loop (#1289): small caught fish become a *gameplay-native* second source of bait
-beside the coin shop, closing `catch → craft → bait → bigger catch`.
+Empty-fire dispatch run, no work order. The product lanes that need creds/browser/network
+are all gated (BTD6 live `llm_judge` battery · botsite React PR 2 cutover (attended browser) ·
+Project Moon ingest (network/IP-sensitive)), so I promoted the cleanest **fully-offline-testable**
+S1 idea — **bait crafting from caught fish** ([idea](../ideas/fishing-bait-crafting-2026-06-22.md))
+— to a shipped build (idea → build in one hop, Q-0172). It builds directly on the just-shipped
+bait layer (#1329/#1337) and the cook/campfire loop (#1289): small caught fish become a
+*gameplay-native* second source of bait beside the coin shop, closing
+`catch → craft → bait → bigger catch`.
 
-Scope:
-1. `utils/fishing/bait.py` — pure `BaitRecipe` map (small fish → bait pack), helpers.
-2. `services/fishing_workflow.py` — `craft_bait` workflow op (debit fish + load bait
-   in ONE transaction, mirroring `cook` / `buy_bait`; no coin debit — inventory→bait).
-3. `views/fishing/bait_shop.py` — a "Craft from fish" select + recipe field on the panel.
-4. `cogs/fishing_cog.py` — `!craftbait [bait]` surface.
-5. Tests across utils + workflow.
+## Shipped (PR #1338)
+
+- **`utils/fishing/bait.py`** (pure) — `BaitRecipe` + `CRAFT_RECIPES` (worm/minnow = 3 fish ≤ rank 3;
+  grub/spinner = 5 fish ≤ rank 6; lure = 6 fish ≤ rank 9). The premium combo (`feast`) is
+  deliberately **not** craftable — it stays a pure coin sink (the top-end spend reason).
+  `CRAFTABLE_KEYS`, `craft_recipe`, `recipe_text`, `craftable_key_for` (key/name resolver).
+- **`services/fishing_workflow.py`** — `craft_bait` op + `_plan_fish_spend` (smallest-rank-first
+  greedy, so the player keeps their bigger catches). An inventory→bait conversion in ONE
+  `db.transaction()` (Q-0071), mirroring `cook`/`buy_bait` — **no coin debit**, stacks like a
+  same-bait purchase, replaces a different loaded bait. `BaitCraftResult`.
+- **`views/fishing/bait_shop.py`** — a "Craft from fish" select (craftable baits only, recipe in
+  the description) + a "Craft from fish" recipe field on the panel embed.
+- **`cogs/fishing_cog.py`** — `!craftbait [bait]` (alias `baitcraft`): with a name crafts directly,
+  bare opens the bait panel (where the Craft select lives).
+- **Tests:** +9 recipe/resolver cases in `tests/unit/utils/test_fishing_bait.py`; +8 `craft_bait` /
+  `_plan_fish_spend` cases in `tests/unit/services/test_fishing_workflow_bait.py`.
+- **Regenerated generated artifacts** (the new `!craftbait` command): `botsite/data/site.json`,
+  `botsite/site/data.js`, `dashboard/data/dashboard.json` (command count 383 → 384) via
+  `python3.10 scripts/export_dashboard_data.py`.
+
+## Verification
+
+- `python3.10 scripts/check_quality.py --full` → **All checks passed** (11916 passed, 47 skipped,
+  2 xfailed). · `check_architecture --mode strict` → **0 errors** (49 pre-existing warnings).
+- Targeted: 32/32 fishing bait tests; 79/79 freshness + botsite tests.
+
+## Process note (for the next run)
+
+Hit the CLAUDE.md "don't hand-run bare black over a broad scope" trap: after the `--full` flagged
+black, I ran `python3.10 -m black disbot/ tests/ scripts/`, which reformatted **353 files** —
+because **CI excludes `tests/` from black/isort/ruff**, the committed test tree is deliberately
+unformatted, and the broad run churned all of it. Reverted everything except my 6 target files,
+then re-confirmed with `--check-only`. **Lesson: trust `check_quality.py` (pinned scope) — never
+bare-black `tests/` to chase a red signal.**
+
+## Session enders
+
+- **♻ Grooming (Q-0015):** moved the `fishing-bait-crafting-2026-06-22` idea down its lifecycle
+  `ideas → shipped` (idea file re-statused with the as-built note + the implementing symbols).
+- **💡 Session idea (Q-0089):** *A "Cook all" / "Craft all eligible" bulk affordance on the
+  campfire + bait panels.* Both `cook` and now `craft_bait` operate one batch at a time; a player
+  with 40 minnow clicks the craft select repeatedly. A single "use everything eligible" button
+  (bounded by a sane cap) would smooth the grind without changing the economy. Small, contained,
+  on the existing seams — a clean next turn-key slice. Logged, not built here (kept scope to the
+  idea I promoted).
+- **⟲ Previous-session review:** the #1320 tool-pins-CI-guard run was exemplary dispatch hygiene —
+  it not only built the guard but *extended* it to genuinely cover all three pin sources (its own
+  message had been over-promising) and added the first unit test, applying the "a guard that
+  under-checks is worse than none" instinct. What it could not foresee (no fault): the `code-quality`
+  workflow still hard-codes its tool versions inline, so the three-places rule isn't yet collapsed to
+  one — which is exactly the idea it logged. **System note:** the born-red/auto-merge loop worked
+  cleanly again this run; the one rough edge is that the *first* `code-quality` failure webhook
+  (born-red card) looks alarming out of context — a session that didn't know Q-0133 might "fix" a
+  non-bug. Worth a one-line note in the dispatch prompt that the first born-red CI failure is
+  expected and self-resolves on the `complete` flip (captured as a candidate, not applied — CLAUDE.md
+  is read-only to an autonomous run).
+- **📋 Doc audit (Q-0104):** S1 sector file de-staled (bait-crafting moved shipped→done in the
+  "next startable" line + added to recently-shipped); idea re-statused; ledger entry for #1338 is
+  the next reconciliation pass's job (the born-red card is the in-flight signal). No drift spotted
+  in the bug book or current-state hub.
+
+## 📤 Run report
+
+- **Run type:** routine · dispatch
+- **⚑ Self-initiated:** promoted `fishing-bait-crafting-2026-06-22` (idea) → build → ship with no
+  dispatch/owner ask (Q-0172) — a fully reversible, test-covered S1 game feature.
+- **⚑ Owner-decisions:** none
+- **⚑ Owner-manual-steps:** none (merge auto-deploys to Railway, Q-0193; `fishing_bait` table
+  already exists from migration 091 — no new migration).

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-06-23T00:51:14Z",
+    "generated_at": "2026-06-23T03:08:23Z",
     "build": {
-      "commit": "a4f3aac",
-      "subject": "Merge branch 'main' into claude/great-goldberg-extjsi",
-      "committed_at": "2026-06-23T00:51:14Z"
+      "commit": "7173e338",
+      "subject": "Fishing bait-crafting: born-red session card + claim",
+      "committed_at": "2026-06-23T03:08:23Z"
     }
   },
   "counts": {
-    "commands": 383,
+    "commands": 384,
     "features": 41,
     "games": 11
   },
@@ -4414,6 +4414,33 @@
       "examples": [],
       "status": "finished",
       "linked_ideas": [],
+      "notes": null
+    },
+    {
+      "name": "craftbait",
+      "aliases": [
+        "baitcraft"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Craft bait from small caught fish — closes the catch→bait loop.",
+      "description": "Craft bait from small caught fish — closes the catch→bait loop.",
+      "use_cases": null,
+      "examples": [
+        "!craftbait worm"
+      ],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — Bait crafting from caught fish (close the fishing economy loop)",
+          "status": "ideas"
+        },
+        {
+          "title": "The Explore hub — a federated open world (one world, each subsystem its own game)",
+          "status": "ideas"
+        }
+      ],
       "notes": null
     },
     {

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -1532,6 +1532,32 @@ const COMMANDS = [
     "planned": []
   },
   {
+    "name": "craftbait",
+    "area": "games",
+    "status": "in-progress",
+    "summary": "Craft bait from small caught fish — closes the catch→bait loop.",
+    "description": "Craft bait from small caught fish — closes the catch→bait loop.",
+    "usage": "!craftbait",
+    "aliases": [
+      "baitcraft"
+    ],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [
+      "!craftbait worm"
+    ],
+    "planned": [
+      {
+        "status": "idea",
+        "title": "Idea — Bait crafting from caught fish (close the fishing economy loop)"
+      },
+      {
+        "status": "idea",
+        "title": "The Explore hub — a federated open world (one world, each subsystem…"
+      }
+    ]
+  },
+  {
     "name": "create",
     "area": "admin",
     "status": "in-progress",
@@ -6264,7 +6290,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "a4f3aac",
+    "build": "7173e338",
     "title": "New public bot website",
     "changes": [
       {
@@ -6276,7 +6302,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "a4f3aac",
+    "build": "7173e338",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -6288,7 +6314,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "a4f3aac",
+    "build": "7173e338",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-22T23:03:59Z",
+    "generated_at": "2026-06-23T03:08:23Z",
     "build": {
-      "commit": "b4fd137e",
-      "subject": "Casino subsystem — multiplayer card-game table framework + Texas Hold'em poker (#1333)",
-      "committed_at": "2026-06-22T23:03:59Z"
+      "commit": "7173e338",
+      "subject": "Fishing bait-crafting: born-red session card + claim",
+      "committed_at": "2026-06-23T03:08:23Z"
     },
     "counts": {
       "functions": 41,
@@ -15,7 +15,7 @@
       "updates": 60,
       "env_vars": 38,
       "cogs": 51,
-      "commands": 383,
+      "commands": 384,
       "setting_keys": 107,
       "setting_domains": 16,
       "typed_settings": 88,
@@ -2347,6 +2347,22 @@
   "reviews": [],
   "updates": [
     {
+      "file": "2026-06-23-fishing-bait-speed-knob.md",
+      "date": "2026-06-23",
+      "title": "2026-06-23 — Fishing bait speed knob",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": true
+    },
+    {
+      "file": "2026-06-23-fishing-bait-crafting.md",
+      "date": "2026-06-23",
+      "title": "2026-06-23 — Fishing bait-crafting (close the catch→cook→bait economy loop)",
+      "status": "in-progress",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
       "file": "2026-06-22-unattended-fit-dispatch-dimension.md",
       "date": "2026-06-22",
       "title": "2026-06-22 — Unattended-fit dimension for the per-sector dispatch contract",
@@ -2809,22 +2825,6 @@
       "status": "complete",
       "run_type": "manual",
       "self_initiated": false
-    },
-    {
-      "file": "2026-06-21-repo-state-review-cleanup.md",
-      "date": "2026-06-21",
-      "title": "Session — repo-state review cleanup (2026-06-21)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-21-reconcile-band1260.md",
-      "date": "2026-06-21",
-      "title": "2026-06-21 — Nineteenth Q-0107 reconciliation pass (band-#1260, issue #1264)",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": true
     }
   ],
   "bot_changelog": [
@@ -5915,6 +5915,19 @@
           "classification": "",
           "has_panel": true,
           "button_backed": true
+        },
+        {
+          "name": "craftbait",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "baitcraft"
+          ],
+          "brief": "Craft bait from small caught fish — closes the catch→bait loop.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
         },
         {
           "name": "fish",

--- a/disbot/cogs/fishing_cog.py
+++ b/disbot/cogs/fishing_cog.py
@@ -29,6 +29,7 @@ from discord.ext import commands
 from core.runtime import guild_resources as resources
 from services import fishing_workflow, game_xp_service
 from utils import db
+from utils.fishing import bait as bait_mod
 from utils.fishing import rods as rods_mod
 from utils.fishing.fish import SPECIES
 from views.fishing import (
@@ -138,6 +139,30 @@ class FishingCog(commands.Cog):
         embed = build_bait_embed(active, charges, balance)
         view = BaitShopView(ctx.author, ctx.guild.id)
         view.message = await ctx.send(embed=embed, view=view)
+
+    @commands.command(name="craftbait", aliases=["baitcraft"])
+    async def craftbait(self, ctx, *, bait: str = ""):
+        """Craft bait from small caught fish — closes the catch→bait loop.
+
+        With a bait name (e.g. ``!craftbait worm``) crafts that pack directly;
+        with no argument, opens the bait panel where the Craft select lists the
+        recipes. Only the cheaper / mid baits are craftable.
+        """
+        key = bait_mod.craftable_key_for(bait)
+        if not bait:
+            await self.bait(ctx)
+            return
+        if key is None:
+            craftable = ", ".join(
+                bait_mod.bait_by_key(k).name  # type: ignore[union-attr]
+                for k in bait_mod.CRAFTABLE_KEYS
+            )
+            await ctx.send(
+                f"You can't craft **{bait}** from fish. Craftable: {craftable}.",
+            )
+            return
+        result = await fishing_workflow.craft_bait(ctx.author.id, ctx.guild.id, key)
+        await ctx.send(result.message)
 
     # ------------------------------------------------------------------ help hook
 

--- a/disbot/services/fishing_workflow.py
+++ b/disbot/services/fishing_workflow.py
@@ -26,6 +26,7 @@ from utils import db
 from utils.fishing import MAX_LEVEL, Catch
 from utils.fishing import bait as bait_mod
 from utils.fishing import energy as fish_energy
+from utils.fishing import fish as fish_mod
 from utils.fishing import rods as rods_mod
 from utils.fishing import roll_catch
 
@@ -436,6 +437,112 @@ async def buy_bait(
         f"{verb} **{bait.name}** {bait.emoji} ({bait_mod.effect_text(bait)}) — "
         f"**{new_charges}** casts ready for **{bait.price}** 🪙. "
         f"Balance: **{new_balance}** 🪙.",
+        bait=bait,
+        charges=new_charges,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bait crafting — turn small caught fish into bait (the catch→bait loop, idea
+# fishing-bait-crafting-2026-06-22). The gameplay-native second source beside
+# the coin shop: an inventory→bait conversion, NOT a coin sink.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BaitCraftResult:
+    """The outcome of a ``craft_bait`` attempt — a flag + a player-facing message."""
+
+    success: bool
+    message: str
+    #: The bait loaded after the attempt (``None`` on failure / when unchanged).
+    bait: bait_mod.Bait | None = None
+    #: Charges loaded after the attempt.
+    charges: int = 0
+
+
+def _plan_fish_spend(
+    inventory: dict[str, int],
+    recipe: bait_mod.BaitRecipe,
+) -> dict[str, int] | None:
+    """Choose which eligible fish to consume for *recipe* (smallest-first).
+
+    Eligible = a known fish species whose ``size_rank`` is ``≤ recipe.max_size_rank``.
+    Consumes the smallest ranks first (ties broken by name) so the player keeps
+    their bigger catches. Returns a ``{fish_name: count}`` spend map, or ``None``
+    when the player lacks ``recipe.fish_count`` eligible fish.
+    """
+    eligible: list[tuple[int, str, int]] = []  # (size_rank, name, have)
+    for name, have in inventory.items():
+        if have <= 0:
+            continue
+        species = fish_mod.species_by_name(name)
+        if species is None or species.size_rank > recipe.max_size_rank:
+            continue
+        eligible.append((species.size_rank, name, have))
+
+    if sum(have for _, _, have in eligible) < recipe.fish_count:
+        return None
+
+    eligible.sort(key=lambda e: (e[0], e[1]))  # smallest size, then name
+    spend: dict[str, int] = {}
+    remaining = recipe.fish_count
+    for _, name, have in eligible:
+        if remaining <= 0:
+            break
+        take = min(have, remaining)
+        spend[name] = take
+        remaining -= take
+    return spend
+
+
+async def craft_bait(
+    user_id: int,
+    guild_id: int,
+    bait_key: str,
+) -> BaitCraftResult:
+    """Craft one pack of *bait_key* from small caught fish — the catch→bait loop.
+
+    Mirrors :func:`mining_workflow.cook` / :func:`mining_workflow.craft`: an
+    inventory-only conversion (no coins, no external call) — debit the eligible
+    fish and load/stack the bait in ONE ``db.transaction()`` (Q-0071). Like
+    :func:`buy_bait`, crafting the same bait stacks charges and a different bait
+    replaces the loadout. Only baits with a recipe are craftable; the premium
+    combo stays a pure coin sink.
+    """
+    bait = bait_mod.bait_by_key(bait_key)
+    recipe = bait_mod.craft_recipe(bait_key)
+    if bait is None or recipe is None:
+        return BaitCraftResult(
+            False,
+            "That bait can't be crafted from fish — buy it with `!bait`.",
+        )
+
+    inventory = await db.get_mining_inventory(str(user_id), guild_id)
+    spend = _plan_fish_spend(inventory, recipe)
+    if spend is None:
+        return BaitCraftResult(
+            False,
+            f"You need **{recipe.fish_count}** fish of size ≤ "
+            f"**{recipe.max_size_rank}** to craft **{bait.name}** {bait.emoji} — "
+            "catch more small fish with `!fish`.",
+        )
+
+    cur_key, cur_charges = await db.get_active_bait(user_id, guild_id)
+    stacking = cur_key == bait.key and cur_charges > 0
+    new_charges = (cur_charges if stacking else 0) + bait.charges
+
+    deltas = {name: -qty for name, qty in spend.items()}
+    async with db.transaction() as conn:
+        await db.apply_inventory_deltas(str(user_id), guild_id, deltas, conn=conn)
+        await db.set_active_bait(user_id, guild_id, bait.key, new_charges, conn=conn)
+
+    used = ", ".join(f"{qty}× {name}" for name, qty in spend.items())
+    verb = "Topped up" if stacking else "Crafted"
+    return BaitCraftResult(
+        True,
+        f"{verb} **{bait.name}** {bait.emoji} ({bait_mod.effect_text(bait)}) from "
+        f"**{used}** — **{new_charges}** casts ready.",
         bait=bait,
         charges=new_charges,
     )

--- a/disbot/utils/fishing/bait.py
+++ b/disbot/utils/fishing/bait.py
@@ -117,3 +117,81 @@ def effect_text(bait: Bait) -> str:
     if bait.bite_speed < 1.0:
         parts.append(f"−{round((1.0 - bait.bite_speed) * 100)}% wait")
     return " · ".join(parts) or "no effect"
+
+
+# ---------------------------------------------------------------------------
+# Bait crafting — turn caught fish into bait, the gameplay-native second source
+# ---------------------------------------------------------------------------
+#
+# The fishing economy loops back on itself (idea ``fishing-bait-crafting-2026-06-22``):
+# the cook/campfire loop (#1289) made fish a tangible inventory item; crafting lets
+# the *small, common* catches (which otherwise just sell cheap) become the lure that
+# lands the trophy — ``catch → craft → bait → bigger catch``. A recipe consumes
+# ``fish_count`` fish whose ``size_rank`` is ``≤ max_size_rank`` (smallest-first, so
+# the player keeps their bigger fish) and yields one pack (``Bait.charges`` casts).
+#
+# Only the cheaper / mid baits are craftable — the premium combo ("feast") stays a
+# pure coin sink, so spending coins keeps a top-end reason to exist beside fishing.
+
+
+@dataclass(frozen=True)
+class BaitRecipe:
+    """A fish → bait recipe: consume *fish_count* small fish, yield one pack.
+
+    Only fish whose ``size_rank`` is ``≤ max_size_rank`` count as ingredients
+    (so crafting drains the low-rank catches first); the produced pack carries
+    the bait's own :attr:`Bait.charges`.
+    """
+
+    bait_key: str
+    fish_count: int  # number of eligible fish consumed per craft
+    max_size_rank: int  # only fish with size_rank ≤ this are eligible ingredients
+
+
+#: The craft shelf, keyed by bait key. Cheaper baits cost a few of the smallest
+#: fish; better baits want more / larger fish. The premium combo ("feast") is
+#: deliberately ABSENT — it stays a pure coin sink (the top-end spend reason).
+CRAFT_RECIPES: dict[str, BaitRecipe] = {
+    "worm": BaitRecipe("worm", fish_count=3, max_size_rank=3),
+    "minnow": BaitRecipe("minnow", fish_count=3, max_size_rank=3),
+    "grub": BaitRecipe("grub", fish_count=5, max_size_rank=6),
+    "spinner": BaitRecipe("spinner", fish_count=5, max_size_rank=6),
+    "lure": BaitRecipe("lure", fish_count=6, max_size_rank=9),
+}
+
+#: Craftable bait keys, in shelf order (skips any without a recipe).
+CRAFTABLE_KEYS: tuple[str, ...] = tuple(
+    b.key for b in BAIT_CATALOG if b.key in CRAFT_RECIPES
+)
+
+
+def craft_recipe(key: str | None) -> BaitRecipe | None:
+    """The :class:`BaitRecipe` for *key*, or ``None`` if that bait isn't craftable."""
+    if not key:
+        return None
+    return CRAFT_RECIPES.get(key)
+
+
+def recipe_text(recipe: BaitRecipe) -> str:
+    """A short human label of a recipe's cost, e.g. ``3 fish (size ≤ 3)``."""
+    return f"{recipe.fish_count} fish (size ≤ {recipe.max_size_rank})"
+
+
+def craftable_key_for(text: str | None) -> str | None:
+    """Resolve typed *text* (a key or a bait name) to a **craftable** bait key.
+
+    Case-insensitive; matches either the stable key (``worm``) or the display
+    name (``Worm Bait``). Returns ``None`` for empty input or a bait that has no
+    recipe — so ``!craftbait worm`` and ``!craftbait "worm bait"`` both work but
+    a non-craftable bait (the premium combo) does not resolve.
+    """
+    if not text:
+        return None
+    needle = text.strip().lower()
+    for key in CRAFTABLE_KEYS:
+        bait = _BY_KEY.get(key)
+        if bait is None:
+            continue
+        if needle in (key.lower(), bait.name.lower()):
+            return key
+    return None

--- a/disbot/views/fishing/bait_shop.py
+++ b/disbot/views/fishing/bait_shop.py
@@ -52,6 +52,24 @@ def build_bait_embed(
             f"(×{bait.charges} casts, {bait_mod.effect_text(bait)})",
         )
     embed.add_field(name="The shelf", value="\n".join(shelf), inline=False)
+
+    craftable = []
+    for key in bait_mod.CRAFTABLE_KEYS:
+        bait = bait_mod.bait_by_key(key)
+        recipe = bait_mod.craft_recipe(key)
+        if bait is None or recipe is None:
+            continue
+        craftable.append(
+            f"{bait.emoji} **{bait.name}** — {bait_mod.recipe_text(recipe)}",
+        )
+    if craftable:
+        embed.add_field(
+            name="Craft from fish",
+            value="\n".join(craftable)
+            + "\n*Turn small catches into bait — no coins needed.*",
+            inline=False,
+        )
+
     embed.add_field(
         name="Your balance",
         value=f"**{balance}** 🪙",
@@ -100,8 +118,51 @@ class _BaitSelect(discord.ui.Select):
         await safe_edit(interaction, embed=embed, view=view)
 
 
+class _BaitCraftSelect(discord.ui.Select):
+    """Pick a craftable bait — turn small caught fish into a pack (no coins)."""
+
+    def __init__(self) -> None:
+        options = []
+        for key in bait_mod.CRAFTABLE_KEYS:
+            bait = bait_mod.bait_by_key(key)
+            recipe = bait_mod.craft_recipe(key)
+            if bait is None or recipe is None:
+                continue
+            options.append(
+                discord.SelectOption(
+                    label=f"{bait.name} — {bait_mod.recipe_text(recipe)}",
+                    value=bait.key,
+                    emoji=bait.emoji,
+                    description=f"×{bait.charges} casts · {bait_mod.effect_text(bait)}",
+                ),
+            )
+        super().__init__(
+            placeholder="Craft a pack from caught fish…",
+            min_values=1,
+            max_values=1,
+            options=options,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        if not await safe_defer(interaction):
+            return
+        view: BaitShopView = self.view  # type: ignore[assignment]
+        result = await fishing_workflow.craft_bait(
+            view._author.id,
+            view.guild_id,
+            self.values[0],
+        )
+        active, charges = await fishing_workflow.get_active_bait(
+            view._author.id,
+            view.guild_id,
+        )
+        balance = await db.get_coins(view._author.id, view.guild_id)
+        embed = build_bait_embed(active, charges, balance, note=result.message)
+        await safe_edit(interaction, embed=embed, view=view)
+
+
 class BaitShopView(BaseView):
-    """Author-restricted bait-shop panel with a buy select."""
+    """Author-restricted bait-shop panel: buy with coins or craft from fish."""
 
     def __init__(
         self,
@@ -111,3 +172,4 @@ class BaitShopView(BaseView):
         super().__init__(author, timeout=120)
         self.guild_id = guild_id
         self.add_item(_BaitSelect())
+        self.add_item(_BaitCraftSelect())

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -20,20 +20,20 @@
 - **Starboard / Hall-of-Fame** — plan #1254 → PR 1 #1259 → PR 2 #1270.
 - **Fishing minigame** — cast/reel loop + rod ladder + energy (#1296–#1304, incl. the generous
   sell-value rebalance 1–7 → 1–21 in #1304); **Bait layer** — coin-bought consumable with **both**
-  economy knobs: rarity (#1329) + the **bite-speed** half (#1337, this PR) on the same
-  `CastStart`/cast-view seam, plus speed/combo baits.
+  economy knobs: rarity (#1329) + the **bite-speed** half (#1337) on the same
+  `CastStart`/cast-view seam, plus speed/combo baits. **Bait crafting** — turn small caught
+  fish into bait packs (`fishing_workflow.craft_bait`, the `🪱 Bait` Craft select + `!craftbait`),
+  closing `catch → craft → bait → bigger catch` (#1338, this PR).
 - **Casino — multiplayer poker** (PR #1333) — a new Games-hub child for **group** card games with
   **per-player auto-updating ephemeral** hands; v1 = Texas Hold'em (play-chips). Pure `utils/cards/`
   + `utils/poker/` (eval + engine w/ side pots, fully tested) + the `views/casino/` ephemeral
   broadcast table. [design](../planning/casino-poker-design-2026-06-22.md).
 
 **▶ Next startable (one of):**
-- **Fishing follow-ups** (turn-key, on the bait seam) — *(the bait speed knob ✅ #1337 and the
-  sell-value re-tune ✅ #1304 are both done; the two flagged tuning items are closed)* — remaining:
+- **Fishing follow-ups** (turn-key, on the bait seam) — *(bait speed knob ✅ #1337, sell-value
+  re-tune ✅ #1304, and bait-crafting ✅ #1338 are all done)* — remaining:
   **boat/deepwater** venue ([plan](../planning/fishing-minigame-design-2026-06-22.md) §5 +
-  [open-world expansion](../planning/fishing-open-world-expansion-plan-2026-06-18.md)) · the
-  **bait-crafting** idea (turn small caught fish → bait, closing the catch→cook→bait loop —
-  [idea](../ideas/fishing-bait-crafting-2026-06-22.md)).
+  [open-world expansion](../planning/fishing-open-world-expansion-plan-2026-06-18.md)).
 - **Project Moon runtime PR 1** — the `KnowledgeDomain` seam + first ingest
   ([plan](../planning/project-moon-knowledge-domain-plan-2026-06-21.md)).
 - **botsite React-SPA migration PR 2** — serve the built React app from `botsite/` + cutover

--- a/docs/ideas/fishing-bait-crafting-2026-06-22.md
+++ b/docs/ideas/fishing-bait-crafting-2026-06-22.md
@@ -1,8 +1,13 @@
 # Idea — Bait crafting from caught fish (close the fishing economy loop)
 
-> **Status:** `ideas` · **Subsystem:** games (fishing) · **Captured:** 2026-06-22
-> (the bait-layer dispatch run, PR #1329). Builds directly on the now-shipped
-> bait layer + the cook/campfire loop (#1289).
+> **Status:** `historical` — **SHIPPED 2026-06-23 (PR #1338).** · **Subsystem:** games (fishing) ·
+> **Captured:** 2026-06-22 (the bait-layer dispatch run, PR #1329). Built on the
+> shipped bait layer (#1329/#1337) + the cook/campfire loop (#1289).
+>
+> **Shipped as:** `utils/fishing/bait.py` `CRAFT_RECIPES` (small fish → bait, smallest-first
+> spend) + `fishing_workflow.craft_bait` (inventory→bait in one transaction, no coins) +
+> the `🪱 Bait` shop "Craft from fish" select + `!craftbait [bait]`. The premium combo
+> ("feast") stays coin-only as the top-end spend reason.
 
 ## The idea
 

--- a/docs/owner/claims/funny-franklin-yko9ji.md
+++ b/docs/owner/claims/funny-franklin-yko9ji.md
@@ -1,1 +1,0 @@
-- branch `claude/funny-franklin-yko9ji` · scope: fishing bait-crafting (turn caught fish → bait) · files: `disbot/utils/fishing/bait.py`, `disbot/services/fishing_workflow.py`, `disbot/views/fishing/bait_shop.py`, `disbot/cogs/fishing_cog.py`, tests · 2026-06-23

--- a/docs/owner/claims/funny-franklin-yko9ji.md
+++ b/docs/owner/claims/funny-franklin-yko9ji.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-yko9ji` · scope: fishing bait-crafting (turn caught fish → bait) · files: `disbot/utils/fishing/bait.py`, `disbot/services/fishing_workflow.py`, `disbot/views/fishing/bait_shop.py`, `disbot/cogs/fishing_cog.py`, tests · 2026-06-23

--- a/tests/unit/services/test_fishing_workflow_bait.py
+++ b/tests/unit/services/test_fishing_workflow_bait.py
@@ -175,7 +175,9 @@ async def test_begin_cast_consumes_a_bait_charge_and_compounds_rarity():
     with (
         patch.object(wf.time, "time", lambda: 1000),
         patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
-        patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),  # starter, pull 1.0
+        patch.object(
+            wf.db, "get_rod_tier", AsyncMock(return_value=0)
+        ),  # starter, pull 1.0
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("worm", 2))),
         patch.object(wf, "roll_catch", _rarity_recorder(seen)),
@@ -201,7 +203,9 @@ async def test_begin_cast_clears_bait_when_the_last_charge_is_spent():
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("worm", 1))),
-        patch.object(wf, "roll_catch", lambda level, rng=None, *, rarity_pull=1.0: _CATCH),
+        patch.object(
+            wf, "roll_catch", lambda level, rng=None, *, rarity_pull=1.0: _CATCH
+        ),
         patch.object(wf.db, "set_fishing_energy", AsyncMock()),
         patch.object(wf.db, "set_active_bait", AsyncMock()) as set_bait,
         patch.object(wf.db, "clear_active_bait", AsyncMock()) as clear_bait,
@@ -250,7 +254,9 @@ async def test_begin_cast_compounds_bite_speed_from_rod_and_bait():
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=3)),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("spinner", 2))),
-        patch.object(wf, "roll_catch", lambda level, rng=None, *, rarity_pull=1.0: _CATCH),
+        patch.object(
+            wf, "roll_catch", lambda level, rng=None, *, rarity_pull=1.0: _CATCH
+        ),
         patch.object(wf.db, "set_fishing_energy", AsyncMock()),
         patch.object(wf.db, "set_active_bait", AsyncMock()),
         patch.object(wf.db, "clear_active_bait", AsyncMock()),
@@ -258,7 +264,9 @@ async def test_begin_cast_compounds_bite_speed_from_rod_and_bait():
         start = await wf.begin_cast(99, 1)
 
     assert start.bait_used is _SPINNER
-    assert start.effective_bite_speed == pytest.approx(gold.bite_speed * _SPINNER.bite_speed)
+    assert start.effective_bite_speed == pytest.approx(
+        gold.bite_speed * _SPINNER.bite_speed
+    )
 
 
 @pytest.mark.asyncio
@@ -270,7 +278,9 @@ async def test_begin_cast_bite_speed_is_rod_only_without_bait():
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=3)),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
-        patch.object(wf, "roll_catch", lambda level, rng=None, *, rarity_pull=1.0: _CATCH),
+        patch.object(
+            wf, "roll_catch", lambda level, rng=None, *, rarity_pull=1.0: _CATCH
+        ),
         patch.object(wf.db, "set_fishing_energy", AsyncMock()),
         patch.object(wf.db, "set_active_bait", AsyncMock()),
         patch.object(wf.db, "clear_active_bait", AsyncMock()),
@@ -278,3 +288,146 @@ async def test_begin_cast_bite_speed_is_rod_only_without_bait():
         start = await wf.begin_cast(99, 1)
 
     assert start.effective_bite_speed == pytest.approx(gold.bite_speed)  # rod only
+
+
+# ---------------------------------------------------------------------------
+# _plan_fish_spend — choose which eligible fish to consume (smallest-first)
+# ---------------------------------------------------------------------------
+# fish.json size ranks: minnow=1, guppy=2, sardine=3, anchovy=4 … trout=8.
+_WORM_RECIPE = bait_mod.craft_recipe("worm")  # 3 fish, size ≤ 3
+
+
+def test_plan_fish_spend_takes_smallest_eligible_first():
+    inv = {"sardine": 5, "minnow": 5, "guppy": 5, "trout": 5}  # trout is rank 8 (>3)
+    spend = wf._plan_fish_spend(inv, _WORM_RECIPE)
+    assert spend == {"minnow": 3}  # smallest rank fills the recipe, bigger kept
+
+
+def test_plan_fish_spend_spreads_across_ranks_when_needed():
+    inv = {"minnow": 2, "guppy": 5}  # need 3 small fish; only 2 minnow
+    spend = wf._plan_fish_spend(inv, _WORM_RECIPE)
+    assert spend == {"minnow": 2, "guppy": 1}  # smallest first, then next rank
+
+
+def test_plan_fish_spend_returns_none_without_enough_eligible_fish():
+    # 10 trout (rank 8) are all too big for the size-≤-3 recipe → no plan.
+    assert wf._plan_fish_spend({"trout": 10}, _WORM_RECIPE) is None
+    assert wf._plan_fish_spend({"minnow": 2}, _WORM_RECIPE) is None  # short by one
+    assert wf._plan_fish_spend({}, _WORM_RECIPE) is None
+    # non-fish inventory items never count as ingredients
+    assert wf._plan_fish_spend({"copper ore": 50}, _WORM_RECIPE) is None
+
+
+# ---------------------------------------------------------------------------
+# craft_bait — the inventory→bait conversion (catch→bait loop)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_craft_bait_debits_fish_and_loads_a_fresh_pack():
+    sentinel_conn = MagicMock(name="conn")
+
+    @asynccontextmanager
+    async def _ctx():
+        yield sentinel_conn
+
+    with (
+        patch.object(
+            wf.db,
+            "get_mining_inventory",
+            AsyncMock(return_value={"minnow": 5}),
+        ),
+        patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
+        patch.object(wf.db, "transaction", _ctx),
+        patch.object(wf.db, "apply_inventory_deltas", AsyncMock()) as deltas,
+        patch.object(wf.db, "set_active_bait", AsyncMock()) as set_bait,
+        patch.object(wf.economy_service, "debit_in_txn", AsyncMock()) as debit,
+    ):
+        result = await wf.craft_bait(99, 1, "worm")
+
+    assert result.success is True
+    assert result.bait is _WORM
+    assert result.charges == _WORM.charges
+    # consumed 3 minnow (the recipe), no coins ever touched
+    deltas.assert_awaited_once_with("99", 1, {"minnow": -3}, conn=sentinel_conn)
+    set_bait.assert_awaited_once_with(99, 1, "worm", _WORM.charges, conn=sentinel_conn)
+    debit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_craft_bait_stacks_charges_for_the_same_bait():
+    @asynccontextmanager
+    async def _ctx():
+        yield MagicMock()
+
+    with (
+        patch.object(
+            wf.db,
+            "get_mining_inventory",
+            AsyncMock(return_value={"minnow": 9}),
+        ),
+        patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("worm", 4))),
+        patch.object(wf.db, "transaction", _ctx),
+        patch.object(wf.db, "apply_inventory_deltas", AsyncMock()),
+        patch.object(wf.db, "set_active_bait", AsyncMock()) as set_bait,
+    ):
+        result = await wf.craft_bait(99, 1, "worm")
+
+    assert result.charges == 4 + _WORM.charges  # stacked onto the loaded worm
+    _, _, key, charges = set_bait.await_args.args
+    assert (key, charges) == ("worm", 4 + _WORM.charges)
+
+
+@pytest.mark.asyncio
+async def test_craft_bait_replaces_a_different_loaded_bait():
+    @asynccontextmanager
+    async def _ctx():
+        yield MagicMock()
+
+    with (
+        patch.object(
+            wf.db,
+            "get_mining_inventory",
+            AsyncMock(return_value={"minnow": 9}),
+        ),
+        patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("lure", 5))),
+        patch.object(wf.db, "transaction", _ctx),
+        patch.object(wf.db, "apply_inventory_deltas", AsyncMock()),
+        patch.object(wf.db, "set_active_bait", AsyncMock()) as set_bait,
+    ):
+        result = await wf.craft_bait(99, 1, "worm")
+
+    assert result.bait is _WORM
+    assert result.charges == _WORM.charges  # fresh pack, old lure charges dropped
+
+
+@pytest.mark.asyncio
+async def test_craft_bait_without_enough_fish_writes_nothing():
+    with (
+        patch.object(
+            wf.db,
+            "get_mining_inventory",
+            AsyncMock(return_value={"trout": 10}),  # all too big for size ≤ 3
+        ),
+        patch.object(wf.db, "apply_inventory_deltas", AsyncMock()) as deltas,
+        patch.object(wf.db, "set_active_bait", AsyncMock()) as set_bait,
+    ):
+        result = await wf.craft_bait(99, 1, "worm")
+
+    assert result.success is False
+    deltas.assert_not_awaited()
+    set_bait.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_craft_bait_rejects_an_uncraftable_or_unknown_bait():
+    with (
+        patch.object(wf.db, "get_mining_inventory", AsyncMock()) as inv,
+        patch.object(wf.db, "apply_inventory_deltas", AsyncMock()) as deltas,
+    ):
+        feast = await wf.craft_bait(99, 1, "feast")  # premium = coin-only
+        nope = await wf.craft_bait(99, 1, "nonexistent")
+
+    assert feast.success is False and nope.success is False
+    inv.assert_not_awaited()  # bails before reading inventory
+    deltas.assert_not_awaited()

--- a/tests/unit/utils/test_fishing_bait.py
+++ b/tests/unit/utils/test_fishing_bait.py
@@ -25,9 +25,15 @@ def test_every_bait_is_a_meaningful_consumable_sink():
 
 
 def test_both_knob_families_and_a_combo_are_on_the_shelf():
-    rarity_only = [b for b in bait_mod.BAIT_CATALOG if b.rarity_pull > 1.0 and b.bite_speed == 1.0]
-    speed_only = [b for b in bait_mod.BAIT_CATALOG if b.bite_speed < 1.0 and b.rarity_pull == 1.0]
-    combo = [b for b in bait_mod.BAIT_CATALOG if b.rarity_pull > 1.0 and b.bite_speed < 1.0]
+    rarity_only = [
+        b for b in bait_mod.BAIT_CATALOG if b.rarity_pull > 1.0 and b.bite_speed == 1.0
+    ]
+    speed_only = [
+        b for b in bait_mod.BAIT_CATALOG if b.bite_speed < 1.0 and b.rarity_pull == 1.0
+    ]
+    combo = [
+        b for b in bait_mod.BAIT_CATALOG if b.rarity_pull > 1.0 and b.bite_speed < 1.0
+    ]
     assert rarity_only and speed_only and combo  # the orthogonal shelf design
 
 
@@ -35,16 +41,26 @@ def test_pricier_bait_is_stronger_within_each_pure_knob_family():
     # Cross-family price isn't comparable (different knobs), but within a pure
     # family a pricier pack must be at least as strong.
     rarity = sorted(
-        (b for b in bait_mod.BAIT_CATALOG if b.rarity_pull > 1.0 and b.bite_speed == 1.0),
+        (
+            b
+            for b in bait_mod.BAIT_CATALOG
+            if b.rarity_pull > 1.0 and b.bite_speed == 1.0
+        ),
         key=lambda b: b.price,
     )
     assert [b.rarity_pull for b in rarity] == sorted(b.rarity_pull for b in rarity)
     speed = sorted(
-        (b for b in bait_mod.BAIT_CATALOG if b.bite_speed < 1.0 and b.rarity_pull == 1.0),
+        (
+            b
+            for b in bait_mod.BAIT_CATALOG
+            if b.bite_speed < 1.0 and b.rarity_pull == 1.0
+        ),
         key=lambda b: b.price,
     )
     # lower bite_speed = faster, so pricier ⇒ non-increasing bite_speed
-    assert [b.bite_speed for b in speed] == sorted((b.bite_speed for b in speed), reverse=True)
+    assert [b.bite_speed for b in speed] == sorted(
+        (b.bite_speed for b in speed), reverse=True
+    )
 
 
 def test_effect_text_describes_only_the_knobs_a_bait_turns():
@@ -53,7 +69,9 @@ def test_effect_text_describes_only_the_knobs_a_bait_turns():
     combo = bait_mod.bait_by_key("feast")  # both
     assert bait_mod.effect_text(rarity) == "×1.25 rarity"
     assert bait_mod.effect_text(speed) == "−20% wait"
-    assert "rarity" in bait_mod.effect_text(combo) and "wait" in bait_mod.effect_text(combo)
+    assert "rarity" in bait_mod.effect_text(combo) and "wait" in bait_mod.effect_text(
+        combo
+    )
     # a hypothetical neutral bait reads honestly rather than claiming a knob
     neutral = bait_mod.Bait("x", "X", "🧪", rarity_pull=1.0, charges=1, price=1)
     assert bait_mod.effect_text(neutral) == "no effect"
@@ -65,3 +83,70 @@ def test_bait_by_key_resolves_known_and_rejects_unknown():
     assert bait_mod.bait_by_key("nope") is None
     assert bait_mod.bait_by_key("") is None
     assert bait_mod.bait_by_key(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Craft recipes — turn small caught fish into bait (catch→bait loop)
+# ---------------------------------------------------------------------------
+
+
+def test_every_recipe_targets_a_real_craftable_bait():
+    for key, recipe in bait_mod.CRAFT_RECIPES.items():
+        assert recipe.bait_key == key  # the map key matches the recipe's own key
+        assert bait_mod.bait_by_key(key) is not None  # produces a real bait
+        assert recipe.fish_count > 0
+        assert recipe.max_size_rank > 0
+
+
+def test_craftable_keys_mirror_shelf_order_and_skip_uncraftable():
+    # CRAFTABLE_KEYS is the shelf-ordered subset that has a recipe.
+    assert bait_mod.CRAFTABLE_KEYS == tuple(
+        b.key for b in bait_mod.BAIT_CATALOG if b.key in bait_mod.CRAFT_RECIPES
+    )
+    # The premium combo stays a pure coin sink (not craftable).
+    assert "feast" not in bait_mod.CRAFT_RECIPES
+
+
+def test_pricier_craftable_bait_costs_more_or_larger_fish():
+    # A stronger/pricier craftable pack should never be cheaper to craft than a
+    # weaker one — recipe cost rises with the bait's coin price (a monotone sink).
+    ordered = sorted(
+        (bait_mod.bait_by_key(k) for k in bait_mod.CRAFTABLE_KEYS),
+        key=lambda b: b.price,
+    )
+    costs = [
+        (
+            bait_mod.craft_recipe(b.key).fish_count,
+            bait_mod.craft_recipe(b.key).max_size_rank,
+        )
+        for b in ordered
+    ]
+    # both dimensions are non-decreasing as price rises
+    assert costs == sorted(costs)
+
+
+def test_craft_recipe_resolves_known_and_rejects_uncraftable():
+    assert bait_mod.craft_recipe("worm") is bait_mod.CRAFT_RECIPES["worm"]
+    assert bait_mod.craft_recipe("feast") is None  # coin-only premium
+    assert bait_mod.craft_recipe("nope") is None
+    assert bait_mod.craft_recipe("") is None
+    assert bait_mod.craft_recipe(None) is None
+
+
+def test_recipe_text_reads_human():
+    assert (
+        bait_mod.recipe_text(bait_mod.BaitRecipe("worm", 3, 3)) == "3 fish (size ≤ 3)"
+    )
+
+
+def test_craftable_key_for_matches_key_or_name_case_insensitively():
+    assert bait_mod.craftable_key_for("worm") == "worm"
+    assert bait_mod.craftable_key_for("  WORM  ") == "worm"
+    assert bait_mod.craftable_key_for("Worm Bait") == "worm"
+    assert bait_mod.craftable_key_for("shimmer lure") == "lure"
+    # not craftable / unknown / empty → None
+    assert bait_mod.craftable_key_for("feast") is None
+    assert bait_mod.craftable_key_for("Royal Feast") is None
+    assert bait_mod.craftable_key_for("nope") is None
+    assert bait_mod.craftable_key_for("") is None
+    assert bait_mod.craftable_key_for(None) is None


### PR DESCRIPTION
Empty-fire dispatch run. Promotes the `fishing-bait-crafting-2026-06-22` idea → build (Q-0172) while the creds/browser/network lanes are gated.

Adds a **second, gameplay-native source of bait** beside the coin shop: small caught fish craft into bait packs, closing `catch → craft → bait → bigger catch`. Builds on the just-shipped bait layer (#1329/#1337) and the cook/campfire loop (#1289).

## Scope
- `utils/fishing/bait.py` — pure `BaitRecipe` map (small fish → bait pack) + helpers.
- `services/fishing_workflow.py` — `craft_bait` op: debit eligible fish + load/stack the bait in ONE transaction (mirrors `cook` + `buy_bait`; inventory→bait, no coin debit).
- `views/fishing/bait_shop.py` — "Craft from fish" select + a recipe field on the panel.
- `cogs/fishing_cog.py` — `!craftbait [bait]` surface.
- Tests across `utils.fishing.bait` + `fishing_workflow`.

Born-red per Q-0133; auto-merges on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDyBXFke4mWaMcPDZNCmou)_