### PR TITLE
fishing: daily weather forecast (a date-seeded global bias)

### DIFF
--- a/.sessions/2026-06-23-fishing-weather-forecast.md
+++ b/.sessions/2026-06-23-fishing-weather-forecast.md
@@ -1,0 +1,27 @@
+# 2026-06-23 — Fishing: daily weather forecast (slice 2)
+
+> **Status:** `in-progress` — born-red card (Q-0133); flips to `complete` as the final step.
+> Routine · dispatch (empty-fire schedule, **slice 2** of this run — after #1340 merged).
+> Promotes this run's own Q-0089 session idea → build (Q-0172). PR auto-merges on green (Q-0123).
+
+## Arc
+
+Slice 1 (#1340, merged) shipped the boat/deepwater venue + the `VenueProfile` seam. Slice 2 builds
+directly on it: a **daily, date-seeded global weather forecast** that biases fishing for the day —
+this run's own logged session idea (the fishing design's "Other ideas" §"weather/time-of-day").
+Same offline-testable S1 lane, same fresh mental context, zero conflict (main is clean post-merge).
+
+## Plan (this PR)
+
+- **`utils/fishing/weather.py`** (new, pure) — a `Weather` dataclass (bite-speed × rarity multipliers
+  + flavour) + a small weighted `CONDITIONS` table (clear most common; storm rare); deterministic
+  `weather_for_date(date)` (sha256 of the ISO date → weighted pick, so it's the **same for everyone
+  on the same day** — a shared talking point) + `current_weather()`.
+- **`services/fishing_workflow.py`** — `begin_cast` compounds the day's weather onto the already-
+  threaded `effective_bite_speed` / `effective_pull`; `CastStart.weather` carries it for the embed.
+  A `get_forecast()` read for the command/menu.
+- **UI** — the cast embed + menu show today's forecast; a `!forecast` command.
+- **Tests** — determinism (same date → same weather), weighting sanity, the begin_cast compounding,
+  the forecast surface.
+
+No new DB / migration (weather is derived from the date, not stored — ADR-001/002 friendly).

--- a/.sessions/2026-06-23-fishing-weather-forecast.md
+++ b/.sessions/2026-06-23-fishing-weather-forecast.md
@@ -1,8 +1,8 @@
 # 2026-06-23 — Fishing: daily weather forecast (slice 2)
 
-> **Status:** `in-progress` — born-red card (Q-0133); flips to `complete` as the final step.
+> **Status:** `complete` — born-red card (Q-0133) flipped green as the final step.
 > Routine · dispatch (empty-fire schedule, **slice 2** of this run — after #1340 merged).
-> Promotes this run's own Q-0089 session idea → build (Q-0172). PR auto-merges on green (Q-0123).
+> Promotes this run's own Q-0089 session idea → build (Q-0172). PR #1341 auto-merges on green (Q-0123).
 
 ## Arc
 
@@ -25,3 +25,60 @@ Same offline-testable S1 lane, same fresh mental context, zero conflict (main is
   the forecast surface.
 
 No new DB / migration (weather is derived from the date, not stored — ADR-001/002 friendly).
+
+## Shipped (PR #1341)
+
+- **`utils/fishing/weather.py`** (new, pure) — `Weather` (bite-speed × rarity multipliers + flavour +
+  weight) + a 5-condition `CONDITIONS` table (clear 38 / rain 22 / calm 18 / fog 14 / storm 8);
+  deterministic `weather_for_date(date)` (sha256 of the ISO date → weighted pick — stable across
+  processes, *not* Python's salted `hash`), `current_weather(now=)` (injectable clock), `effect_text`.
+- **`services/fishing_workflow.py`** — `begin_cast` compounds the day's weather onto
+  `effective_pull` / `effective_bite_speed` (rod × bait × **weather**); `CastStart.weather` carries
+  it; `get_forecast()` read.
+- **UI** — the cast embed shows a forecast field when weather is non-neutral (clear stays silent);
+  the fishing menu shows a "Today's forecast" field; new `!forecast` (aliases `fishforecast`,
+  `fishingweather`).
+- **Tests** — new `test_fishing_weather.py` (10: determinism, full-coverage over a 3-yr horizon,
+  weight distribution, neutral-clear, storm risk/reward, effect-text) + workflow weather-compounding
+  + `get_forecast` + a menu forecast-field test; pinned neutral weather in the exact-value
+  `begin_cast` knob tests so they stay deterministic regardless of run date.
+- **Regenerated** site/dashboard artifacts (command 385 → 386 for `!forecast`).
+
+## Verification
+
+- `python3.10 scripts/check_quality.py --full` → **11959 passed**, 47 skipped, 2 xfailed. ·
+  `check_architecture --mode strict` → **0 errors**. · Distribution over 5 yrs tracks the weights
+  (clear ≫ rain ≫ storm; storm < 15%).
+
+## Session enders
+
+- **♻ Grooming (Q-0015):** marked the fishing design's "weather/time-of-day" Other-idea **✅ SHIPPED**
+  with the as-built note; de-staled the S1 sector "next startable" line (weather done → remaining:
+  the owner shore-cap rebalance · trophy records per species · the Phase-2 boat-as-structure/travel
+  layer).
+- **💡 Session idea (Q-0089):** *A "this week's fishing event" — a longer (multi-day) weather streak or
+  a weekend-only rare-species window, layered on the same date-seed.* The daily forecast gives a
+  reason to fish *today*; a weekly cadence (e.g. "Migration weekend: marlin running") would give a
+  reason to come back *this week* and a softer, scheduled goal — reusing the `weather.py` date-seed
+  with a week-bucketed seed. Small, contained, on the new seam. Logged, not built (kept scope).
+- **⟲ Previous-session review:** slice 1 (#1340, this same run) was a clean, complete vertical feature,
+  but it left a real friction this slice hit immediately — the fishing test files duplicate the
+  `roll_catch`/`begin_cast` mock signatures across three files, so adding the `weather` knob meant
+  pinning `current_weather` in ~9 `begin_cast` test blocks by hand (and my first scripted insert broke
+  single-line `with` statements). The slice-1 review *predicted* exactly this (a shared
+  `_fake_roll_catch`/fishing test-conftest helper would remove it). **System note:** that test-helper
+  consolidation is now a genuinely earned, twice-confirmed small slice — a good turn-key pick for a
+  future dispatch run (captured, not built; CLAUDE.md/test-infra is its own scope).
+- **📋 Doc audit (Q-0104):** S1 sector file + design plan de-staled (above); the #1341 ledger entry is
+  the next reconciliation pass's job (recon marker #1320, next at #1350; #1340 + #1341 are benign
+  post-marker lag). The new `!forecast` command is in the regenerated artifacts. No drift spotted in
+  the bug book or current-state hub.
+
+## 📤 Run report
+
+- **Run type:** routine · dispatch
+- **⚑ Self-initiated:** built the **daily weather forecast** (this run's own Q-0089 session idea) with
+  no dispatch/owner ask (Q-0172) — a fully reversible, test-covered, no-DB additive S1 game feature on
+  the venue seam. (Slice 2 of the run; slice 1 = the deepwater venue #1340, merged.)
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none (merge auto-deploys to Railway, Q-0193; no migration / no data step).

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-06-23T06:10:51Z",
+    "generated_at": "2026-06-23T06:42:29Z",
     "build": {
-      "commit": "16efe539",
-      "subject": "fishing: open deepwater-venue session (born-red card + claim)",
-      "committed_at": "2026-06-23T06:10:51Z"
+      "commit": "7968e5e1",
+      "subject": "fishing: open weather-forecast session (born-red card + claim)",
+      "committed_at": "2026-06-23T06:42:29Z"
     }
   },
   "counts": {
-    "commands": 385,
+    "commands": 386,
     "features": 41,
     "games": 11
   },
@@ -4905,6 +4905,28 @@
       "permissions": "user",
       "usage": "Show this server's top anglers by total fish caught.",
       "description": "Show this server's top anglers by total fish caught.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "The Explore hub — a federated open world (one world, each subsystem its own game)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "forecast",
+      "aliases": [
+        "fishforecast",
+        "fishingweather"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show today's fishing forecast — the date-seeded weather everyone shares.",
+      "description": "Show today's fishing forecast — the date-seeded weather everyone shares.",
       "use_cases": null,
       "examples": [],
       "status": "in-progress",

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -2286,6 +2286,27 @@ const COMMANDS = [
     "planned": []
   },
   {
+    "name": "forecast",
+    "area": "games",
+    "status": "in-progress",
+    "summary": "Show today's fishing forecast — the date-seeded weather everyone shares.",
+    "description": "Show today's fishing forecast — the date-seeded weather everyone shares.",
+    "usage": "!forecast",
+    "aliases": [
+      "fishforecast",
+      "fishingweather"
+    ],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [],
+    "planned": [
+      {
+        "status": "idea",
+        "title": "The Explore hub — a federated open world (one world, each subsystem…"
+      }
+    ]
+  },
+  {
     "name": "forge",
     "area": "economy",
     "status": "in-progress",
@@ -6285,7 +6306,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "16efe539",
+    "build": "7968e5e1",
     "title": "New public bot website",
     "changes": [
       {
@@ -6297,7 +6318,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "16efe539",
+    "build": "7968e5e1",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -6309,7 +6330,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "16efe539",
+    "build": "7968e5e1",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-23T06:10:51Z",
+    "generated_at": "2026-06-23T06:42:29Z",
     "build": {
-      "commit": "16efe539",
-      "subject": "fishing: open deepwater-venue session (born-red card + claim)",
-      "committed_at": "2026-06-23T06:10:51Z"
+      "commit": "7968e5e1",
+      "subject": "fishing: open weather-forecast session (born-red card + claim)",
+      "committed_at": "2026-06-23T06:42:29Z"
     },
     "counts": {
       "functions": 41,
@@ -15,7 +15,7 @@
       "updates": 60,
       "env_vars": 38,
       "cogs": 51,
-      "commands": 385,
+      "commands": 386,
       "setting_keys": 107,
       "setting_domains": 16,
       "typed_settings": 88,
@@ -2347,12 +2347,20 @@
   "reviews": [],
   "updates": [
     {
-      "file": "2026-06-23-fishing-deepwater-venue.md",
+      "file": "2026-06-23-fishing-weather-forecast.md",
       "date": "2026-06-23",
-      "title": "2026-06-23 — Fishing: the boat / deepwater venue (⛵ Set sail / Dock)",
+      "title": "2026-06-23 — Fishing: daily weather forecast (slice 2)",
       "status": "in-progress",
       "run_type": "",
       "self_initiated": false
+    },
+    {
+      "file": "2026-06-23-fishing-deepwater-venue.md",
+      "date": "2026-06-23",
+      "title": "2026-06-23 — Fishing: the boat / deepwater venue (⛵ Set sail / Dock)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": true
     },
     {
       "file": "2026-06-23-fishing-bait-speed-knob.md",
@@ -2817,14 +2825,6 @@
       "status": "complete",
       "run_type": "manual",
       "self_initiated": true
-    },
-    {
-      "file": "2026-06-21-site-field-level-redaction-contract.md",
-      "date": "2026-06-21",
-      "title": "2026-06-21 — site.json field-level redaction contract",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": false
     }
   ],
   "bot_changelog": [
@@ -5975,6 +5975,20 @@
             "topfishers"
           ],
           "brief": "Show this server's top anglers by total fish caught.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "forecast",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "fishforecast",
+            "fishingweather"
+          ],
+          "brief": "Show today's fishing forecast — the date-seeded weather everyone shares.",
           "classification": "",
           "has_panel": false,
           "button_backed": false

--- a/disbot/cogs/fishing_cog.py
+++ b/disbot/cogs/fishing_cog.py
@@ -31,6 +31,7 @@ from services import fishing_workflow, game_xp_service
 from utils import db
 from utils.fishing import bait as bait_mod
 from utils.fishing import rods as rods_mod
+from utils.fishing import weather as weather_mod
 from utils.fishing.fish import SPECIES
 from views.fishing import (
     BaitShopView,
@@ -80,6 +81,25 @@ class FishingCog(commands.Cog):
             embed=build_menu_embed(energy, profile),
             view=view,
         )
+
+    @commands.command(name="forecast", aliases=["fishforecast", "fishingweather"])
+    async def forecast(self, ctx):
+        """Show today's fishing forecast — the date-seeded weather everyone shares.
+
+        Weather biases every cast for the day (faster/slower bites, rarer fish);
+        it's the same for everyone, so it's a shared reason to fish *today*.
+        """
+        w = fishing_workflow.get_forecast()
+        embed = discord.Embed(
+            title=f"{w.emoji} Today's fishing forecast: {w.name}",
+            description=(
+                f"{w.blurb}\n\n"
+                f"**Effect on every cast:** {weather_mod.effect_text(w)}"
+            ),
+            color=_FISHING_COLOR,
+        )
+        embed.set_footer(text="Same for everyone today · 🎣 !fish to cast")
+        await ctx.send(embed=embed)
 
     @commands.command(name="sail", aliases=["setsail", "dock"])
     async def sail(self, ctx):

--- a/disbot/services/fishing_workflow.py
+++ b/disbot/services/fishing_workflow.py
@@ -30,6 +30,7 @@ from utils.fishing import fish as fish_mod
 from utils.fishing import rods as rods_mod
 from utils.fishing import roll_catch
 from utils.fishing import venue as venue_mod
+from utils.fishing import weather as weather_mod
 
 logger = logging.getLogger("bot.fishing_workflow")
 
@@ -200,6 +201,9 @@ class CastStart:
     #: The venue profile this cast runs at — the source of the bite band, reaction
     #: window, and base escape the cast view feeds into the minigame math.
     venue_profile: venue_mod.VenueProfile = venue_mod.SHORE_PROFILE
+    #: The day's weather, already compounded into ``effective_bite_speed`` /
+    #: the roll's rarity pull — carried for the cast-panel forecast note.
+    weather: weather_mod.Weather = weather_mod.CONDITIONS[0]
 
 
 def _fmt_wait(seconds: int) -> str:
@@ -258,12 +262,19 @@ async def begin_cast(user_id: int, guild_id: int) -> CastStart:
     rod = rods_mod.rod_for_tier(await db.get_rod_tier(user_id, guild_id))
     venue = await db.get_fishing_venue(user_id, guild_id)
     profile = venue_mod.profile_for(venue)
+    weather = weather_mod.current_weather()
     bait, bait_charges = await get_active_bait(user_id, guild_id)
-    # Bait's two knobs compound on the rod's: rarity_pull (both ≥ 1) pulls the
-    # catch toward the big end of the SAME unlocked band (never a new band); and
-    # bite_speed (both ≤ 1) shortens the bite wait so a loaded lure bites sooner.
-    effective_pull = rod.rarity_pull * (bait.rarity_pull if bait else 1.0)
-    effective_bite_speed = rod.bite_speed * (bait.bite_speed if bait else 1.0)
+    # Three "how-well" knobs compound: rod × bait × the day's weather. rarity_pull
+    # (all ≥ 1) pulls the catch toward the big end of the SAME unlocked band (never
+    # a new band — that stays the fishing-level axis); bite_speed (rod/bait ≤ 1,
+    # weather either way) scales the bite wait. Weather is the transient, shared,
+    # free knob (a storm makes a rarer catch likelier but the wait longer).
+    effective_pull = (
+        rod.rarity_pull * (bait.rarity_pull if bait else 1.0) * weather.rarity_mult
+    )
+    effective_bite_speed = (
+        rod.bite_speed * (bait.bite_speed if bait else 1.0) * weather.bite_speed_mult
+    )
     cast = await roll_cast(
         user_id,
         guild_id,
@@ -304,7 +315,16 @@ async def begin_cast(user_id: int, guild_id: int) -> CastStart:
         bait_used=bait,
         bait_charges_left=charges_left,
         venue_profile=profile,
+        weather=weather,
     )
+
+
+def get_forecast() -> weather_mod.Weather:
+    """Today's fishing weather (UTC date) — for the menu / ``!forecast`` command.
+
+    Pure read of the date-seeded weather; the same for everyone on a given day.
+    """
+    return weather_mod.current_weather()
 
 
 # ---------------------------------------------------------------------------

--- a/disbot/utils/fishing/__init__.py
+++ b/disbot/utils/fishing/__init__.py
@@ -35,8 +35,15 @@ from utils.fishing.venue import (
     profile_for,
     toggle,
 )
+from utils.fishing.weather import (
+    CONDITIONS,
+    Weather,
+    current_weather,
+    weather_for_date,
+)
 
 __all__ = [
+    "CONDITIONS",
     "DEEPWATER",
     "FISH_PER_LEVEL",
     "MAX_LEVEL",
@@ -46,6 +53,8 @@ __all__ = [
     "Catch",
     "FishSpecies",
     "VenueProfile",
+    "Weather",
+    "current_weather",
     "max_size_rank_for_level",
     "profile_for",
     "roll_catch",
@@ -54,4 +63,5 @@ __all__ = [
     "toggle",
     "unlocked_species",
     "venue_size_cap",
+    "weather_for_date",
 ]

--- a/disbot/utils/fishing/weather.py
+++ b/disbot/utils/fishing/weather.py
@@ -1,0 +1,150 @@
+"""Fishing weather — a daily, date-seeded global bias (owner design "Other ideas").
+
+The fishing design's surfaced idea (``docs/planning/fishing-minigame-design-2026-06-22.md``
+§"Other ideas surfaced"): *"a global daily bias (e.g. 'storm: rare fish biting,
+shorter windows') gives a reason to fish today and a shared talking point."*
+
+The weather is **derived from the calendar date**, not stored — the same ISO date
+always maps to the same condition (a deterministic sha256-seeded weighted pick),
+so **everyone in every guild sees the same weather on the same day** (the shared
+talking point) and it costs no DB / no scheduler (ADR-001/002 friendly). Clear is
+the common default; storms are rare. Each condition compounds two multipliers onto
+the cast that the workflow already threads:
+
+* ``bite_speed_mult`` (≤ 1 = faster bites) multiplies the rod×bait bite speed;
+* ``rarity_mult`` (≥ 1 = biases bigger) multiplies the rod×bait rarity pull.
+
+So weather is a *third* "how-well" knob beside the rod and bait, but a transient,
+shared, free one — it changes the *feel* of a day without touching progression
+(it never unlocks a new size band; that stays the fishing-level axis).
+
+Pure + stdlib-only (no Discord, no DB, no ambient clock in the core picker — the
+date is passed in) so every number here is unit-testable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+
+
+@dataclass(frozen=True)
+class Weather:
+    """One weather condition — its identity, flavour, and the two cast knobs."""
+
+    key: str
+    name: str
+    emoji: str
+    #: Multiplier on the bite wait (≤ 1 = faster bites, > 1 = slower/patient).
+    bite_speed_mult: float
+    #: Multiplier on the rarity pull (≥ 1 = biases the catch toward bigger fish).
+    rarity_mult: float
+    #: Selection weight — higher = more common across days (clear dominates).
+    weight: int
+    #: One-line player-facing flavour for the forecast / cast embeds.
+    blurb: str
+
+
+#: The weather table. Weights sum to 100 (read as rough %-of-days). The spread is
+#: a deliberate risk/reward: rain = fast & common, storm = slow but the rarest
+#: fish run, fog = patient but rarer, calm = a gently better all-rounder.
+CONDITIONS: tuple[Weather, ...] = (
+    Weather(
+        "clear",
+        "Clear skies",
+        "☀️",
+        bite_speed_mult=1.0,
+        rarity_mult=1.0,
+        weight=38,
+        blurb="Calm and clear — a steady, ordinary day to fish.",
+    ),
+    Weather(
+        "rain",
+        "Rain",
+        "🌧️",
+        bite_speed_mult=0.85,
+        rarity_mult=1.0,
+        weight=22,
+        blurb="Rain stirs the surface — the fish are biting fast today.",
+    ),
+    Weather(
+        "calm",
+        "Glassy calm",
+        "🌅",
+        bite_speed_mult=0.92,
+        rarity_mult=1.08,
+        weight=18,
+        blurb="Glassy, still water — quick bites and a touch more chance at a prize.",
+    ),
+    Weather(
+        "fog",
+        "Fog",
+        "🌫️",
+        bite_speed_mult=1.15,
+        rarity_mult=1.12,
+        weight=14,
+        blurb="Thick fog — slow, patient bites, but rarer fish lurk beneath.",
+    ),
+    Weather(
+        "storm",
+        "Storm",
+        "⛈️",
+        bite_speed_mult=1.12,
+        rarity_mult=1.30,
+        weight=8,
+        blurb="Storm's up — choppy and slow, but the big, rare ones are running.",
+    ),
+)
+
+#: Neutral fallback (never selected; guards a malformed/empty table).
+_NEUTRAL = CONDITIONS[0]
+
+_TOTAL_WEIGHT = sum(c.weight for c in CONDITIONS)
+
+
+def _date_fraction(d: date) -> float:
+    """A deterministic uniform fraction in [0, 1) seeded by the ISO date.
+
+    Uses sha256 (not Python's salted ``hash``) so the mapping is stable across
+    processes and machines — every agent / shard computes the same weather for a
+    given day.
+    """
+    digest = hashlib.sha256(d.isoformat().encode("utf-8")).digest()
+    # First 8 bytes → a 64-bit int → a fraction of its range.
+    value = int.from_bytes(digest[:8], "big")
+    return value / float(1 << 64)
+
+
+def weather_for_date(d: date) -> Weather:
+    """The weather for calendar date *d* — deterministic, weighted by frequency."""
+    if _TOTAL_WEIGHT <= 0:
+        return _NEUTRAL
+    target = _date_fraction(d) * _TOTAL_WEIGHT
+    cumulative = 0.0
+    for condition in CONDITIONS:
+        cumulative += condition.weight
+        if target < cumulative:
+            return condition
+    return CONDITIONS[-1]  # float-edge guard
+
+
+def current_weather(now: datetime | None = None) -> Weather:
+    """Today's weather (UTC date). *now* is injectable for tests."""
+    moment = now or datetime.now(timezone.utc)
+    return weather_for_date(moment.date())
+
+
+def effect_text(weather: Weather) -> str:
+    """A compact "what it does" line, e.g. ``faster bites · rarer fish``.
+
+    Only names the knobs that actually move, so ``clear`` reads as "no effect".
+    """
+    parts: list[str] = []
+    if weather.bite_speed_mult < 1.0:
+        parts.append("faster bites")
+    elif weather.bite_speed_mult > 1.0:
+        parts.append("slower bites")
+    if weather.rarity_mult > 1.0:
+        parts.append("rarer fish")
+    return " · ".join(parts) if parts else "no effect — a fair, ordinary day"

--- a/disbot/views/fishing/cast_view.py
+++ b/disbot/views/fishing/cast_view.py
@@ -45,6 +45,7 @@ from services import fishing_workflow
 from utils.fishing import energy, minigame
 from utils.fishing import rods as rods_mod
 from utils.fishing import venue as venue_mod
+from utils.fishing import weather as weather_mod
 from utils.fishing.fish import max_size_rank_for_level, species_for_venue
 from utils.ui_constants import ERROR_COLOR, GAME_COLOR, SUCCESS_COLOR
 from views.base import handle_view_error as _on_view_error
@@ -107,6 +108,14 @@ async def prepare_cast(
         ),
         color=GAME_COLOR,
     )
+    w = start.weather
+    if w.bite_speed_mult != 1.0 or w.rarity_mult != 1.0:
+        # Only show the forecast when it actually changes the cast (clear = silent).
+        embed.add_field(
+            name=f"{w.emoji} {w.name}",
+            value=f"*{w.blurb}* ({weather_mod.effect_text(w)})",
+            inline=False,
+        )
     footer = f"{profile.emoji} {profile.name} · " + energy.bar(start.energy_current)
     if start.bait_used is not None:
         footer += (

--- a/disbot/views/fishing/menu.py
+++ b/disbot/views/fishing/menu.py
@@ -23,6 +23,7 @@ from utils import db
 from utils.fishing import energy as fish_energy
 from utils.fishing import rods as rods_mod
 from utils.fishing import venue as venue_mod
+from utils.fishing import weather as weather_mod
 from utils.fishing.fish import (
     MAX_LEVEL,
     max_size_rank_for_level,
@@ -67,6 +68,12 @@ def build_menu_embed(
     embed.add_field(
         name="Fishing from",
         value=f"{profile.emoji} **{profile.name}** — {profile.blurb}",
+        inline=False,
+    )
+    forecast = weather_mod.current_weather()
+    embed.add_field(
+        name=f"Today's forecast: {forecast.emoji} {forecast.name}",
+        value=f"*{forecast.blurb}* ({weather_mod.effect_text(forecast)})",
         inline=False,
     )
     if energy_current is not None:

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -23,12 +23,15 @@
   economy knobs: rarity (#1329) + the **bite-speed** half (#1337) on the same
   `CastStart`/cast-view seam, plus speed/combo baits. **Bait crafting** — turn small caught
   fish into bait packs (`fishing_workflow.craft_bait`, the `🪱 Bait` Craft select + `!craftbait`),
-  closing `catch → craft → bait → bigger catch` (#1338). **⛵ Boat/deepwater venue** (#1340, this
-  PR) — a persisted shore↔deepwater toggle (`!sail` + the menu button, migration 094
-  `fishing_venue`); deepwater holds 11 **boat-only species** (uncatchable from shore) and runs a
-  **tougher minigame** (6–12 s bites · 22% base escape) so the rod escape-resist knob finally pays
-  off — additive (the original 21 shore fish unchanged), the literal §5 shore-cap rebalance left as
-  an owner balance call.
+  closing `catch → craft → bait → bigger catch` (#1338). **⛵ Boat/deepwater venue** (#1340) — a
+  persisted shore↔deepwater toggle (`!sail` + the menu button, migration 094 `fishing_venue`);
+  deepwater holds 11 **boat-only species** (uncatchable from shore) and runs a **tougher minigame**
+  (6–12 s bites · 22% base escape) so the rod escape-resist knob finally pays off — additive (the
+  original 21 shore fish unchanged), the literal §5 shore-cap rebalance left as an owner balance
+  call. **Daily weather forecast** (#1341, this PR) — a date-seeded global bias
+  (`utils/fishing/weather.py`, no DB) compounding onto the cast as a third how-well knob
+  (rod × bait × weather): clear/rain/calm/fog/storm, the same for everyone each day; `!forecast` +
+  a menu/cast forecast line.
 - **Casino — multiplayer poker** (PR #1333) — a new Games-hub child for **group** card games with
   **per-player auto-updating ephemeral** hands; v1 = Texas Hold'em (play-chips). Pure `utils/cards/`
   + `utils/poker/` (eval + engine w/ side pots, fully tested) + the `views/casino/` ephemeral
@@ -39,7 +42,7 @@
   re-tune ✅ #1304, bait-crafting ✅ #1338, and the **⛵ boat/deepwater venue** ✅ PR #1340 — shore↔
   deepwater toggle + boat-only species + tougher deep minigame — are all done)* — remaining:
   the literal §5 **shore-cap-at-12 rebalance** (owner balance call, flagged in #1340) ·
-  **weather/time-of-day modifier** · **trophy records per species**
+  *(weather/time-of-day modifier ✅ #1341)* · **trophy records per species**
   ([plan](../planning/fishing-minigame-design-2026-06-22.md) §"Other ideas" +
   [open-world expansion](../planning/fishing-open-world-expansion-plan-2026-06-18.md) Phase 2+: the
   boat-as-structure / travel-timer / destinations layer).

--- a/docs/owner/claims/claude__funny-franklin-3z6s2p.md
+++ b/docs/owner/claims/claude__funny-franklin-3z6s2p.md
@@ -1,0 +1,1 @@
+- `claude/funny-franklin-3z6s2p` · fishing daily weather forecast (slice 2, on the venue seam) · `disbot/utils/fishing/weather.py`, `disbot/services/fishing_workflow.py`, `disbot/views/fishing/`, `disbot/cogs/fishing_cog.py`, fishing tests · 2026-06-23

--- a/docs/owner/claims/claude__funny-franklin-3z6s2p.md
+++ b/docs/owner/claims/claude__funny-franklin-3z6s2p.md
@@ -1,1 +1,0 @@
-- `claude/funny-franklin-3z6s2p` · fishing daily weather forecast (slice 2, on the venue seam) · `disbot/utils/fishing/weather.py`, `disbot/services/fishing_workflow.py`, `disbot/views/fishing/`, `disbot/cogs/fishing_cog.py`, fishing tests · 2026-06-23

--- a/docs/planning/fishing-minigame-design-2026-06-22.md
+++ b/docs/planning/fishing-minigame-design-2026-06-22.md
@@ -197,9 +197,12 @@ Your `cast → wait → BITE → reel` instinct is **right**. Three data-driven 
   texture. *(captured as an idea — see `docs/ideas/`)*
 - **Fake-out bites** — converts waiting from dead time into a nerve-holding skill; makes the
   `premature_grace` rod knob meaningful. Cheap, big feel-payoff.
-- **Weather / time-of-day modifier** — a global daily bias (e.g. "storm: rare fish biting,
-  shorter windows") gives a reason to fish *today* and a shared talking point, reusing any existing
-  daily-seed. Optional, Phase 2-ish.
+- **Weather / time-of-day modifier** — **✅ SHIPPED 2026-06-23 (PR #1341).** A date-seeded global
+  bias (`disbot/utils/fishing/weather.py`, no DB — derived from the calendar date so it's the same
+  for everyone each day) that compounds onto the cast as a third how-well knob beside the rod and
+  bait: clear (common) / rain (faster bites) / calm / fog (patient, rarer) / storm (rare, slow but
+  the big ones run). Surfaced via `!forecast` + a menu/cast forecast line. *(The "shorter windows"
+  half was left out to keep the cast view untouched; bite-speed + rarity carry the feel.)*
 - **Trophy records per species** (biggest caught) — a cheap long-tail goal layered on the existing
   catch-log; "personal best" beats raw counts for retention.
 - **Line-snap as a soft-fail, not a hard-fail** — an escaped fish could leave a clue ("a *big* one

--- a/tests/unit/services/test_fishing_workflow.py
+++ b/tests/unit/services/test_fishing_workflow.py
@@ -385,6 +385,7 @@ async def test_begin_cast_spends_energy_and_rolls_when_charged():
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
+        patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
         patch.object(wf, "roll_catch", lambda level, rng=None, *, rarity_pull=1.0, venue='shore': _CATCH),
         patch.object(wf.db, "set_fishing_energy", AsyncMock()) as set_energy,
     ):
@@ -422,6 +423,7 @@ async def test_begin_cast_does_not_charge_on_an_empty_catalog():
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
+        patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
         patch.object(wf, "roll_catch", lambda level, rng=None, *, rarity_pull=1.0, venue='shore': None),
         patch.object(wf.db, "set_fishing_energy", AsyncMock()) as set_energy,
     ):
@@ -477,6 +479,7 @@ async def test_set_venue_deepwater_message_names_the_tradeoff():
 async def test_toggle_venue_flips_from_the_stored_value():
     with (
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
+        patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
         patch.object(wf.db, "set_fishing_venue", AsyncMock()) as set_v,
     ):
         change = await wf.toggle_venue(99, 1)
@@ -498,6 +501,7 @@ async def test_begin_cast_threads_the_stored_venue_into_the_roll_and_profile():
         patch.object(wf.time, "time", lambda: 1000),
         patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="deepwater")),
+        patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
@@ -510,3 +514,53 @@ async def test_begin_cast_threads_the_stored_venue_into_the_roll_and_profile():
     assert seen["venue"] == "deepwater"  # the stored venue gated the roll
     assert start.venue_profile is venue_mod.DEEPWATER_PROFILE  # ...and the view's tuning
     assert start.cast.venue == "deepwater"
+
+
+# ---------------------------------------------------------------------------
+# Weather — the daily date-seeded bias compounds onto the cast (Q-0089 idea)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_begin_cast_compounds_the_days_weather_onto_the_knobs():
+    """Weather multiplies the rod×bait bite-speed/rarity and rides on CastStart."""
+    from utils.fishing import rods, venue
+    from utils.fishing import weather as weather_mod
+
+    storm = next(c for c in weather_mod.CONDITIONS if c.key == "storm")
+    seen: dict[str, float] = {}
+
+    def _roll(level, rng=None, *, rarity_pull=1.0, venue="shore"):
+        seen["pull"] = rarity_pull
+        return _CATCH
+
+    gold = rods.rod_for_tier(3)
+    with (
+        patch.object(wf.time, "time", lambda: 1000),
+        patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
+        patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
+        patch.object(wf.weather_mod, "current_weather", lambda: storm),
+        patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=3)),
+        patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
+        patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
+        patch.object(wf, "roll_catch", _roll),
+        patch.object(wf.db, "set_fishing_energy", AsyncMock()),
+    ):
+        start = await wf.begin_cast(99, 1)
+
+    assert start.weather is storm
+    # rod-only knobs, each scaled by the storm multiplier (no bait here).
+    assert seen["pull"] == pytest.approx(gold.rarity_pull * storm.rarity_mult)
+    assert start.effective_bite_speed == pytest.approx(
+        gold.bite_speed * storm.bite_speed_mult,
+    )
+    assert start.effective_bite_speed != pytest.approx(gold.bite_speed)  # weather moved it
+
+
+@pytest.mark.asyncio
+async def test_get_forecast_returns_todays_weather():
+    from utils.fishing import weather as weather_mod
+
+    rain = next(c for c in weather_mod.CONDITIONS if c.key == "rain")
+    with patch.object(wf.weather_mod, "current_weather", lambda: rain):
+        assert wf.get_forecast() is rain

--- a/tests/unit/services/test_fishing_workflow_bait.py
+++ b/tests/unit/services/test_fishing_workflow_bait.py
@@ -176,6 +176,7 @@ async def test_begin_cast_consumes_a_bait_charge_and_compounds_rarity():
         patch.object(wf.time, "time", lambda: 1000),
         patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
+        patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
         patch.object(
             wf.db, "get_rod_tier", AsyncMock(return_value=0)
         ),  # starter, pull 1.0
@@ -202,6 +203,7 @@ async def test_begin_cast_clears_bait_when_the_last_charge_is_spent():
         patch.object(wf.time, "time", lambda: 1000),
         patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
+        patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("worm", 1))),
@@ -226,6 +228,7 @@ async def test_begin_cast_without_bait_uses_only_the_rod_pull():
         patch.object(wf.time, "time", lambda: 1000),
         patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
+        patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
@@ -255,6 +258,7 @@ async def test_begin_cast_compounds_bite_speed_from_rod_and_bait():
         patch.object(wf.time, "time", lambda: 1000),
         patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
+        patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=3)),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("spinner", 2))),
@@ -280,6 +284,7 @@ async def test_begin_cast_bite_speed_is_rod_only_without_bait():
         patch.object(wf.time, "time", lambda: 1000),
         patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
+        patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=3)),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),

--- a/tests/unit/utils/test_fishing_weather.py
+++ b/tests/unit/utils/test_fishing_weather.py
@@ -1,0 +1,78 @@
+"""utils.fishing.weather — the date-seeded daily fishing bias (owner "Other ideas")."""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import date, datetime, timezone
+
+from utils.fishing import weather
+
+
+def test_weather_is_deterministic_for_a_date():
+    d = date(2026, 6, 23)
+    assert weather.weather_for_date(d) is weather.weather_for_date(d)
+
+
+def test_different_dates_can_yield_different_weather():
+    # Across a month at least two distinct conditions appear (not a constant).
+    seen = {weather.weather_for_date(date(2026, 6, day)).key for day in range(1, 29)}
+    assert len(seen) >= 2
+
+
+def test_every_condition_is_reachable_over_a_long_horizon():
+    seen = {
+        weather.weather_for_date(date.fromordinal(o)).key
+        for o in range(739000, 739000 + 365 * 3)  # ~3 years
+    }
+    assert seen == {c.key for c in weather.CONDITIONS}
+
+
+def test_distribution_roughly_tracks_the_weights():
+    # Clear is the most common day; storm is the rarest — the weighted pick holds.
+    counts = Counter(
+        weather.weather_for_date(date.fromordinal(o)).key
+        for o in range(739000, 739000 + 365 * 5)  # 5 years of days
+    )
+    assert counts["clear"] > counts["rain"] > counts["storm"]
+    # Storm should be genuinely rare (its weight is 8/100).
+    total = sum(counts.values())
+    assert counts["storm"] / total < 0.15
+
+
+def test_current_weather_uses_the_injected_now():
+    moment = datetime(2026, 6, 23, 14, 30, tzinfo=timezone.utc)
+    assert weather.current_weather(moment) is weather.weather_for_date(date(2026, 6, 23))
+
+
+def test_weights_sum_to_one_hundred_and_clear_dominates():
+    assert sum(c.weight for c in weather.CONDITIONS) == 100
+    clear = next(c for c in weather.CONDITIONS if c.key == "clear")
+    assert clear.weight == max(c.weight for c in weather.CONDITIONS)
+
+
+def test_multipliers_are_in_sane_ranges():
+    for c in weather.CONDITIONS:
+        # bite speed within ±20%, rarity never below neutral, both finite.
+        assert 0.8 <= c.bite_speed_mult <= 1.2
+        assert c.rarity_mult >= 1.0
+        assert c.rarity_mult <= 1.4
+
+
+def test_clear_is_a_true_no_op():
+    clear = next(c for c in weather.CONDITIONS if c.key == "clear")
+    assert clear.bite_speed_mult == 1.0
+    assert clear.rarity_mult == 1.0
+    assert weather.effect_text(clear) == "no effect — a fair, ordinary day"
+
+
+def test_storm_is_the_high_risk_high_reward_day():
+    storm = next(c for c in weather.CONDITIONS if c.key == "storm")
+    assert storm.rarity_mult > 1.0  # the rare fish run
+    assert storm.bite_speed_mult > 1.0  # ...but the bites are slower
+    assert "rarer fish" in weather.effect_text(storm)
+    assert "slower bites" in weather.effect_text(storm)
+
+
+def test_effect_text_names_only_the_knobs_that_move():
+    rain = next(c for c in weather.CONDITIONS if c.key == "rain")  # faster bites only
+    assert weather.effect_text(rain) == "faster bites"

--- a/tests/unit/views/test_fishing_menu.py
+++ b/tests/unit/views/test_fishing_menu.py
@@ -57,6 +57,12 @@ def test_menu_embed_advertises_the_actions():
     assert "Cast" in text and "Rod" in text and "Fishdex" in text
 
 
+def test_menu_embed_shows_todays_forecast():
+    # The daily weather is surfaced as a field so the menu is a reason to fish today.
+    field_names = [f.name for f in build_menu_embed().fields]
+    assert any("forecast" in n.lower() for n in field_names)
+
+
 def test_fishlog_embed_counts_only_known_species():
     log = {"minnow": 3, "golden koi": 99}  # the koi is a legacy/unknown row
     embed = build_fishlog_embed("Anya", log, level=7)


### PR DESCRIPTION
## What

Slice 2 of this dispatch run (slice 1 = the boat/deepwater venue #1340, merged): a **daily, date-seeded global fishing weather forecast** that biases fishing for the day — this run's own logged session idea, and the fishing design's "Other ideas" §"weather/time-of-day modifier".

A small weighted weather table (clear most common; storm rare) picked **deterministically from the calendar date** (sha256 of the ISO date), so the weather is the **same for everyone on the same day** — a shared talking point and a reason to fish *today*. Each condition compounds onto the already-threaded `effective_bite_speed` / `effective_pull` in `begin_cast`:

| | effect |
|---|---|
| ☀️ Clear | neutral (the common default) |
| 🌧️ Rain | faster bites (fish active) |
| 🌅 Glassy calm | slightly faster bites + a touch rarer |
| 🌫️ Fog | slower, patient bites but rarer fish |
| ⛈️ Storm | choppy/slow, but the big rare ones are running |

Surfaced in the cast embed, the fishing menu, and a new `!forecast` command. No DB / migration — weather is derived from the date (ADR-001/002 friendly).

## Born-red

Opened born-red per Q-0133; flips to `complete` (auto-merge on green) as the final step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAXoXLXCZu62iY2MAJDNpJ)_