### PR TITLE
fishing tests: consolidate the duplicated roll_catch mock into a shared helper

### DIFF
--- a/.sessions/2026-06-23-fishing-test-helpers.md
+++ b/.sessions/2026-06-23-fishing-test-helpers.md
@@ -1,8 +1,8 @@
 # 2026-06-23 — Fishing test helpers: kill the duplicated roll_catch mock (slice 3)
 
-> **Status:** `in-progress` — born-red card (Q-0133); flips to `complete` as the final step.
+> **Status:** `complete` — born-red card (Q-0133) flipped green as the final step.
 > Routine · dispatch (empty-fire schedule, **slice 3** — after #1340 + #1341 merged). A
-> twice-confirmed test-infra friction fix (workflow improvement = first-class). Auto-merges on green.
+> twice-confirmed test-infra friction fix (workflow improvement = first-class). PR #1342 auto-merges on green.
 
 ## Arc
 
@@ -23,3 +23,54 @@ genuinely earned, so slice 3 lands it.
   assertions to read the shared `record` dict.
 - Pure test refactor — **no production code changes**; the full suite is the proof it's behaviour-
   preserving.
+
+## Shipped (PR #1342)
+
+- **`tests/unit/services/_fishing_helpers.py`** (new) — `CATCH` sentinel + `fake_roll_catch(catch)` /
+  `recording_roll_catch(record)`, both carrying `roll_catch`'s canonical signature in one place.
+- Refactored `test_fishing_workflow.py` + `test_fishing_workflow_bait.py` to use them: **~17 inline
+  `lambda level, rng=None, *, rarity_pull=1.0, venue=…` / `def _roll(…)` / `_rarity_recorder` sites
+  → 0**; the recording assertions now read the shared `record` dict (`rec["level"/"rarity_pull"/
+  "venue"]`). Dropped the now-unused `Catch`/`FishSpecies` imports; `_CATCH = CATCH` keeps the
+  identity asserts pointing at the one sentinel the stubs return.
+- A future `roll_catch` signature change is now a **single** edit (the helper), not 17.
+
+## Verification
+
+- `python3.10 scripts/check_quality.py --full` → green (47 fishing-service tests unchanged in count
+  and behaviour; full suite passes). · `check_architecture --mode strict` → 0 errors. · No production
+  code touched. *(Note: the CI mirror's isort **does** lint these test files even though the project
+  notes say tests/ is excluded from formatters — `check_quality` flagged + I sorted them; trust the
+  mirror over the prose. Worth a CLAUDE.md correction — captured below.)*
+
+## Session enders
+
+- **♻ Grooming (Q-0015):** no idea moved this slice (slice 3 is a test-infra cleanup, not an idea
+  promotion); the run's grooming happened in slices 1–2 (fishing design §5 + weather Other-idea both
+  marked shipped).
+- **💡 Session idea (Q-0089):** *A `check_quality.py` sub-mode (or a one-line note) that states its
+  **real** formatter scope* — this slice showed the "tests/ is excluded from isort" belief in CLAUDE.md
+  is wrong (the mirror lints test imports), which cost a debugging hop. Either fix the doc or have the
+  mirror print "isort scope: <globs>" so the next agent trusts the tool, not the prose. Small, and it
+  hardens the CI-parity contract the whole workflow leans on. Logged, not built (it's a CLAUDE.md/
+  tooling change — proposal, not self-applied).
+- **⟲ Previous-session review:** slices 1 + 2 (this same run) both correctly *predicted* this exact
+  friction in their reviews and logged the fix as a candidate — and this slice cashed it in, which is
+  the self-auditing loop (Q-0102) working as designed: a flagged-then-executed improvement across
+  sessions of one run. What they slightly under-called: the duplication wasn't only the *signature* but
+  the *recording shape* (list-append vs dict), so the consolidation needed two stubs, not one — a
+  reminder that "remove the duplication" estimates should look at the *assertions*, not just the mock.
+- **📋 Doc audit (Q-0104):** no durable-home drift from this slice (test-only; the #1342 ledger entry
+  is the next recon pass's job — marker #1320, next #1350; #1340/#1341/#1342 are benign post-marker
+  lag). The CLAUDE.md isort-scope inaccuracy is flagged as the session idea above (a proposal, since
+  CLAUDE.md is read-only to an autonomous run — Q-0106).
+
+## 📤 Run report
+
+- **Run type:** routine · dispatch
+- **⚑ Self-initiated:** consolidated the fishing test mocks (a twice-confirmed, twice-flagged test-infra
+  friction from this run's own slices 1–2) with no dispatch/owner ask (Q-0172) — pure test refactor,
+  fully reversible, zero production change. (Slice 3 of the run; slices 1–2 = #1340 deepwater venue +
+  #1341 weather forecast, both merged.)
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none (test-only; no deploy effect).

--- a/.sessions/2026-06-23-fishing-test-helpers.md
+++ b/.sessions/2026-06-23-fishing-test-helpers.md
@@ -1,0 +1,25 @@
+# 2026-06-23 — Fishing test helpers: kill the duplicated roll_catch mock (slice 3)
+
+> **Status:** `in-progress` — born-red card (Q-0133); flips to `complete` as the final step.
+> Routine · dispatch (empty-fire schedule, **slice 3** — after #1340 + #1341 merged). A
+> twice-confirmed test-infra friction fix (workflow improvement = first-class). Auto-merges on green.
+
+## Arc
+
+Slices 1 (#1340 deepwater venue) and 2 (#1341 weather forecast) both hit the **same friction**: the
+`services.fishing_workflow.roll_catch` mock signature is hand-duplicated **~17 times** across
+`test_fishing_workflow.py` + `test_fishing_workflow_bait.py`, so each signature change (slice 1 added
+`venue=`, slice 2 added the `current_weather` ambient) meant editing every site by hand — and my first
+scripted insert even broke single-line `with` blocks. Both slice reviews flagged the fix; it's now
+genuinely earned, so slice 3 lands it.
+
+## Plan (this PR)
+
+- **`tests/unit/services/_fishing_helpers.py`** (new) — the canonical-signature stubs in ONE place:
+  `CATCH` sentinel, `fake_roll_catch(catch)` (non-recording), `recording_roll_catch(record)` (captures
+  `{level, rarity_pull, venue}` of the call). A future `roll_catch` signature change is now a **single**
+  edit, not 17.
+- Refactor both fishing service test files to import + use them; update the handful of recording
+  assertions to read the shared `record` dict.
+- Pure test refactor — **no production code changes**; the full suite is the proof it's behaviour-
+  preserving.

--- a/docs/owner/claims/claude__funny-franklin-3z6s2p.md
+++ b/docs/owner/claims/claude__funny-franklin-3z6s2p.md
@@ -1,0 +1,1 @@
+- `claude/funny-franklin-3z6s2p` · fishing test-helper consolidation (slice 3, test-infra) · `tests/unit/services/_fishing_helpers.py`, `tests/unit/services/test_fishing_workflow*.py` · 2026-06-23

--- a/docs/owner/claims/claude__funny-franklin-3z6s2p.md
+++ b/docs/owner/claims/claude__funny-franklin-3z6s2p.md
@@ -1,1 +1,0 @@
-- `claude/funny-franklin-3z6s2p` · fishing test-helper consolidation (slice 3, test-infra) · `tests/unit/services/_fishing_helpers.py`, `tests/unit/services/test_fishing_workflow*.py` · 2026-06-23

--- a/tests/unit/services/_fishing_helpers.py
+++ b/tests/unit/services/_fishing_helpers.py
@@ -1,0 +1,62 @@
+"""Shared stubs for the fishing-workflow service tests.
+
+`services.fishing_workflow.roll_catch` is patched in ~17 places across
+`test_fishing_workflow.py` and `test_fishing_workflow_bait.py`. Each patch has to
+mirror `roll_catch`'s exact signature, so every signature change (the `venue=`
+kwarg added with the deepwater venue, the weather ambient added with the daily
+forecast) used to mean editing every call site by hand. These stubs put that
+signature in **one** place: a future change is a single edit here.
+
+Import-style helpers (the dir is a package — `tests/unit/services/__init__.py`),
+not fixtures, because the tests need a *callable* to hand to `patch.object`.
+"""
+
+from __future__ import annotations
+
+import random
+
+from utils.fishing.fish import Catch, FishSpecies
+
+#: The canonical caught-fish sentinel both test files assert against.
+CATCH = Catch(species=FishSpecies("trout", 8, "🐠"))
+
+
+def fake_roll_catch(catch: Catch | None = CATCH):
+    """A ``roll_catch`` stub that ignores its inputs and returns *catch*.
+
+    Pass ``catch=None`` for the empty-catalog path. Mirrors the real signature
+    so a signature change updates only this helper, not every call site.
+    """
+
+    def _roll(
+        level: int,
+        rng: random.Random | None = None,
+        *,
+        rarity_pull: float = 1.0,
+        venue: str = "shore",
+    ) -> Catch | None:
+        return catch
+
+    return _roll
+
+
+def recording_roll_catch(record: dict, catch: Catch | None = CATCH):
+    """Like :func:`fake_roll_catch`, but records the call's inputs into *record*.
+
+    Captures ``level`` / ``rarity_pull`` / ``venue`` of the (last) call so a test
+    can assert which level gated the roll or which rarity pull / venue reached it.
+    """
+
+    def _roll(
+        level: int,
+        rng: random.Random | None = None,
+        *,
+        rarity_pull: float = 1.0,
+        venue: str = "shore",
+    ) -> Catch | None:
+        record["level"] = level
+        record["rarity_pull"] = rarity_pull
+        record["venue"] = venue
+        return catch
+
+    return _roll

--- a/tests/unit/services/test_fishing_workflow.py
+++ b/tests/unit/services/test_fishing_workflow.py
@@ -11,12 +11,16 @@ from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from tests.unit.services._fishing_helpers import (
+    CATCH,
+    fake_roll_catch,
+    recording_roll_catch,
+)
 
 from services import economy_service
 from services import fishing_workflow as wf
 from services import game_xp_service
 from utils.fishing import MAX_LEVEL, rods
-from utils.fishing.fish import Catch, FishSpecies
 
 
 def _txn(sentinel_conn, events):
@@ -29,7 +33,7 @@ def _txn(sentinel_conn, events):
     return _ctx
 
 
-_CATCH = Catch(species=FishSpecies("trout", 8, "🐠"))
+_CATCH = CATCH  # the shared sentinel the helpers return (identity asserts)
 
 
 def _award(*, game_total, leveled_up=False, level=1, amount=5):
@@ -91,7 +95,7 @@ async def test_both_legs_on_one_conn_and_emit_after_commit():
         assert item == "trout" and qty == 1  # the caught fish enters the inventory
 
     with (
-        patch.object(wf, "roll_catch", lambda level, rng=None, *, rarity_pull=1.0, venue='shore': _CATCH),
+        patch.object(wf, "roll_catch", fake_roll_catch()),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 5})),
         patch.object(wf.db, "transaction", _txn(sentinel_conn, events)),
         patch.object(wf.db, "record_catch", AsyncMock(side_effect=_record)),
@@ -120,7 +124,7 @@ async def test_crossing_a_fishing_level_flags_unlocked_bigger():
 
     # Pre-read xp 50 → level 1; post-award game_total huge → MAX_LEVEL.
     with (
-        patch.object(wf, "roll_catch", lambda level, rng=None, *, rarity_pull=1.0, venue='shore': _CATCH),
+        patch.object(wf, "roll_catch", fake_roll_catch()),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 50})),
         patch.object(wf.db, "transaction", _ctx),
         patch.object(wf.db, "record_catch", AsyncMock()),
@@ -142,18 +146,14 @@ async def test_crossing_a_fishing_level_flags_unlocked_bigger():
 async def test_roll_is_gated_by_the_players_current_fishing_level():
     """The roll is called with the level derived from the pre-read fishing xp."""
     sentinel_conn = MagicMock(name="conn")
-    seen_levels: list[int] = []
+    rec: dict = {}
 
     @asynccontextmanager
     async def _ctx():
         yield sentinel_conn
 
-    def _roll(level, rng=None, *, rarity_pull=1.0, venue='shore'):
-        seen_levels.append(level)
-        return _CATCH
-
     with (
-        patch.object(wf, "roll_catch", _roll),
+        patch.object(wf, "roll_catch", recording_roll_catch(rec)),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "transaction", _ctx),
         patch.object(wf.db, "record_catch", AsyncMock()),
@@ -167,13 +167,13 @@ async def test_roll_is_gated_by_the_players_current_fishing_level():
     ):
         await wf.fish(99, 1)
 
-    assert seen_levels == [1]  # 0 xp → level 1
+    assert rec["level"] == 1  # 0 xp → level 1
 
 
 @pytest.mark.asyncio
 async def test_empty_catalog_writes_nothing():
     with (
-        patch.object(wf, "roll_catch", lambda level, rng=None, *, rarity_pull=1.0, venue='shore': None),
+        patch.object(wf, "roll_catch", fake_roll_catch(None)),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={})),
         patch.object(wf.db, "record_catch", AsyncMock()) as record,
     ):
@@ -192,7 +192,7 @@ async def test_empty_catalog_writes_nothing():
 async def test_roll_cast_reads_the_level_and_rolls_without_writing():
     """The read-only half: a cast rolls a catch but touches no write seam."""
     with (
-        patch.object(wf, "roll_catch", lambda level, rng=None, *, rarity_pull=1.0, venue='shore': _CATCH),
+        patch.object(wf, "roll_catch", fake_roll_catch()),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "record_catch", AsyncMock()) as record,
         patch.object(wf.db, "update_mining_item", AsyncMock()) as grant,
@@ -254,37 +254,27 @@ async def test_commit_catch_on_empty_cast_writes_nothing():
 
 @pytest.mark.asyncio
 async def test_roll_cast_passes_the_rods_rarity_pull_to_the_roll():
-    seen = {}
-
-    def _roll(level, rng=None, *, rarity_pull=1.0, venue='shore'):
-        seen["pull"] = rarity_pull
-        return _CATCH
-
+    rec: dict = {}
     gold = rods.rod_for_tier(3)
     with (
-        patch.object(wf, "roll_catch", _roll),
+        patch.object(wf, "roll_catch", recording_roll_catch(rec)),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
     ):
         await wf.roll_cast(99, 1, gold)
 
-    assert seen["pull"] == gold.rarity_pull  # the rod knob reaches the roll
+    assert rec["rarity_pull"] == gold.rarity_pull  # the rod knob reaches the roll
 
 
 @pytest.mark.asyncio
 async def test_roll_cast_defaults_to_the_starter_rod():
-    seen = {}
-
-    def _roll(level, rng=None, *, rarity_pull=1.0, venue='shore'):
-        seen["pull"] = rarity_pull
-        return _CATCH
-
+    rec: dict = {}
     with (
-        patch.object(wf, "roll_catch", _roll),
+        patch.object(wf, "roll_catch", recording_roll_catch(rec)),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={})),
     ):
         await wf.roll_cast(99, 1)  # no rod given
 
-    assert seen["pull"] == 1.0  # starter → neutral pull
+    assert rec["rarity_pull"] == 1.0  # starter → neutral pull
 
 
 # ---------------------------------------------------------------------------
@@ -386,7 +376,7 @@ async def test_begin_cast_spends_energy_and_rolls_when_charged():
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
         patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
-        patch.object(wf, "roll_catch", lambda level, rng=None, *, rarity_pull=1.0, venue='shore': _CATCH),
+        patch.object(wf, "roll_catch", fake_roll_catch()),
         patch.object(wf.db, "set_fishing_energy", AsyncMock()) as set_energy,
     ):
         start = await wf.begin_cast(99, 1)
@@ -424,7 +414,7 @@ async def test_begin_cast_does_not_charge_on_an_empty_catalog():
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
         patch.object(wf.db, "get_fishing_venue", AsyncMock(return_value="shore")),
         patch.object(wf.weather_mod, "current_weather", lambda: wf.weather_mod.CONDITIONS[0]),
-        patch.object(wf, "roll_catch", lambda level, rng=None, *, rarity_pull=1.0, venue='shore': None),
+        patch.object(wf, "roll_catch", fake_roll_catch(None)),
         patch.object(wf.db, "set_fishing_energy", AsyncMock()) as set_energy,
     ):
         start = await wf.begin_cast(99, 1)
@@ -491,12 +481,7 @@ async def test_toggle_venue_flips_from_the_stored_value():
 async def test_begin_cast_threads_the_stored_venue_into_the_roll_and_profile():
     from utils.fishing import venue as venue_mod
 
-    seen: dict[str, str] = {}
-
-    def _roll(level, rng=None, *, rarity_pull=1.0, venue="shore"):
-        seen["venue"] = venue
-        return _CATCH
-
+    rec: dict = {}
     with (
         patch.object(wf.time, "time", lambda: 1000),
         patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
@@ -505,13 +490,13 @@ async def test_begin_cast_threads_the_stored_venue_into_the_roll_and_profile():
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
-        patch.object(wf, "roll_catch", _roll),
+        patch.object(wf, "roll_catch", recording_roll_catch(rec)),
         patch.object(wf.db, "set_fishing_energy", AsyncMock()),
     ):
         start = await wf.begin_cast(99, 1)
 
     assert start.ok is True
-    assert seen["venue"] == "deepwater"  # the stored venue gated the roll
+    assert rec["venue"] == "deepwater"  # the stored venue gated the roll
     assert start.venue_profile is venue_mod.DEEPWATER_PROFILE  # ...and the view's tuning
     assert start.cast.venue == "deepwater"
 
@@ -524,16 +509,11 @@ async def test_begin_cast_threads_the_stored_venue_into_the_roll_and_profile():
 @pytest.mark.asyncio
 async def test_begin_cast_compounds_the_days_weather_onto_the_knobs():
     """Weather multiplies the rod×bait bite-speed/rarity and rides on CastStart."""
-    from utils.fishing import rods, venue
+    from utils.fishing import rods
     from utils.fishing import weather as weather_mod
 
     storm = next(c for c in weather_mod.CONDITIONS if c.key == "storm")
-    seen: dict[str, float] = {}
-
-    def _roll(level, rng=None, *, rarity_pull=1.0, venue="shore"):
-        seen["pull"] = rarity_pull
-        return _CATCH
-
+    rec: dict = {}
     gold = rods.rod_for_tier(3)
     with (
         patch.object(wf.time, "time", lambda: 1000),
@@ -543,14 +523,14 @@ async def test_begin_cast_compounds_the_days_weather_onto_the_knobs():
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=3)),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
-        patch.object(wf, "roll_catch", _roll),
+        patch.object(wf, "roll_catch", recording_roll_catch(rec)),
         patch.object(wf.db, "set_fishing_energy", AsyncMock()),
     ):
         start = await wf.begin_cast(99, 1)
 
     assert start.weather is storm
     # rod-only knobs, each scaled by the storm multiplier (no bait here).
-    assert seen["pull"] == pytest.approx(gold.rarity_pull * storm.rarity_mult)
+    assert rec["rarity_pull"] == pytest.approx(gold.rarity_pull * storm.rarity_mult)
     assert start.effective_bite_speed == pytest.approx(
         gold.bite_speed * storm.bite_speed_mult,
     )

--- a/tests/unit/services/test_fishing_workflow_bait.py
+++ b/tests/unit/services/test_fishing_workflow_bait.py
@@ -11,14 +11,18 @@ from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from tests.unit.services._fishing_helpers import (
+    CATCH,
+    fake_roll_catch,
+    recording_roll_catch,
+)
 
 from services import economy_service
 from services import fishing_workflow as wf
 from utils.fishing import bait as bait_mod
 from utils.fishing import rods as rods_mod
-from utils.fishing.fish import Catch, FishSpecies
 
-_CATCH = Catch(species=FishSpecies("trout", 8, "🐠"))
+_CATCH = CATCH  # the shared sentinel the helpers return (identity asserts)
 _WORM = bait_mod.bait_by_key("worm")
 _LURE = bait_mod.bait_by_key("lure")
 _SPINNER = bait_mod.bait_by_key("spinner")  # a pure speed bait (bite_speed < 1)
@@ -161,17 +165,9 @@ async def test_buy_bait_rejects_an_unknown_key():
 # ---------------------------------------------------------------------------
 
 
-def _rarity_recorder(seen: list[float]):
-    def _roll(level, rng=None, *, rarity_pull=1.0, venue='shore'):
-        seen.append(rarity_pull)
-        return _CATCH
-
-    return _roll
-
-
 @pytest.mark.asyncio
 async def test_begin_cast_consumes_a_bait_charge_and_compounds_rarity():
-    seen: list[float] = []
+    rec: dict = {}
     with (
         patch.object(wf.time, "time", lambda: 1000),
         patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
@@ -182,7 +178,7 @@ async def test_begin_cast_consumes_a_bait_charge_and_compounds_rarity():
         ),  # starter, pull 1.0
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("worm", 2))),
-        patch.object(wf, "roll_catch", _rarity_recorder(seen)),
+        patch.object(wf, "roll_catch", recording_roll_catch(rec)),
         patch.object(wf.db, "set_fishing_energy", AsyncMock()),
         patch.object(wf.db, "set_active_bait", AsyncMock()) as set_bait,
         patch.object(wf.db, "clear_active_bait", AsyncMock()) as clear_bait,
@@ -192,7 +188,7 @@ async def test_begin_cast_consumes_a_bait_charge_and_compounds_rarity():
     assert start.ok is True
     assert start.bait_used is _WORM
     assert start.bait_charges_left == 1  # spent one of the two
-    assert seen == [pytest.approx(_WORM.rarity_pull)]  # 1.0 (rod) × worm pull
+    assert rec["rarity_pull"] == pytest.approx(_WORM.rarity_pull)  # 1.0 (rod) × worm pull
     set_bait.assert_awaited_once_with(99, 1, "worm", 1)
     clear_bait.assert_not_awaited()
 
@@ -208,7 +204,7 @@ async def test_begin_cast_clears_bait_when_the_last_charge_is_spent():
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("worm", 1))),
         patch.object(
-            wf, "roll_catch", lambda level, rng=None, *, rarity_pull=1.0, venue='shore': _CATCH
+            wf, "roll_catch", fake_roll_catch()
         ),
         patch.object(wf.db, "set_fishing_energy", AsyncMock()),
         patch.object(wf.db, "set_active_bait", AsyncMock()) as set_bait,
@@ -223,7 +219,7 @@ async def test_begin_cast_clears_bait_when_the_last_charge_is_spent():
 
 @pytest.mark.asyncio
 async def test_begin_cast_without_bait_uses_only_the_rod_pull():
-    seen: list[float] = []
+    rec: dict = {}
     with (
         patch.object(wf.time, "time", lambda: 1000),
         patch.object(wf.db, "get_fishing_energy", AsyncMock(return_value=(10, 1000))),
@@ -232,7 +228,7 @@ async def test_begin_cast_without_bait_uses_only_the_rod_pull():
         patch.object(wf.db, "get_rod_tier", AsyncMock(return_value=0)),
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
-        patch.object(wf, "roll_catch", _rarity_recorder(seen)),
+        patch.object(wf, "roll_catch", recording_roll_catch(rec)),
         patch.object(wf.db, "set_fishing_energy", AsyncMock()),
         patch.object(wf.db, "set_active_bait", AsyncMock()) as set_bait,
         patch.object(wf.db, "clear_active_bait", AsyncMock()) as clear_bait,
@@ -240,7 +236,7 @@ async def test_begin_cast_without_bait_uses_only_the_rod_pull():
         start = await wf.begin_cast(99, 1)
 
     assert start.bait_used is None
-    assert seen == [pytest.approx(1.0)]  # bare starter, no bait
+    assert rec["rarity_pull"] == pytest.approx(1.0)  # bare starter, no bait
     set_bait.assert_not_awaited()
     clear_bait.assert_not_awaited()
 
@@ -263,7 +259,7 @@ async def test_begin_cast_compounds_bite_speed_from_rod_and_bait():
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("spinner", 2))),
         patch.object(
-            wf, "roll_catch", lambda level, rng=None, *, rarity_pull=1.0, venue='shore': _CATCH
+            wf, "roll_catch", fake_roll_catch()
         ),
         patch.object(wf.db, "set_fishing_energy", AsyncMock()),
         patch.object(wf.db, "set_active_bait", AsyncMock()),
@@ -289,7 +285,7 @@ async def test_begin_cast_bite_speed_is_rod_only_without_bait():
         patch.object(wf.db, "get_game_xp", AsyncMock(return_value={"fishing": 0})),
         patch.object(wf.db, "get_active_bait", AsyncMock(return_value=("", 0))),
         patch.object(
-            wf, "roll_catch", lambda level, rng=None, *, rarity_pull=1.0, venue='shore': _CATCH
+            wf, "roll_catch", fake_roll_catch()
         ),
         patch.object(wf.db, "set_fishing_energy", AsyncMock()),
         patch.object(wf.db, "set_active_bait", AsyncMock()),


### PR DESCRIPTION
## What

Slice 3 of this dispatch run (slices 1–2 = the deepwater venue #1340 + weather forecast #1341, both merged) — a **test-infra cleanup** that removes a friction both prior slices hit.

The `services.fishing_workflow.roll_catch` mock signature was hand-duplicated **~17 times** across `test_fishing_workflow.py` + `test_fishing_workflow_bait.py`. Slice 1 (adding `venue=`) and slice 2 (the `current_weather` ambient) each meant editing every site by hand — and a scripted insert even broke single-line `with` blocks. Both slice reviews flagged this; it's now genuinely earned.

This PR adds `tests/unit/services/_fishing_helpers.py` with the canonical-signature stubs in **one** place (`fake_roll_catch` / `recording_roll_catch` + the shared `CATCH` sentinel) and refactors both test files to use them. A future `roll_catch` signature change is now a **single** edit, not 17.

**Pure test refactor — no production code changes.** The full suite passing is the proof it's behaviour-preserving.

## Born-red

Opened born-red per Q-0133; flips to `complete` (auto-merge on green) as the final step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAXoXLXCZu62iY2MAJDNpJ)_