### PR TITLE
fix: check_quality isort scope drifted from CI (false-red on tests/) + parity guard

### DIFF
--- a/.sessions/2026-06-23-check-quality-isort-parity.md
+++ b/.sessions/2026-06-23-check-quality-isort-parity.md
@@ -1,0 +1,22 @@
+# 2026-06-23 — Fix: check_quality isort scope drifted from CI (false-red on tests/)
+
+> **Status:** `in-progress` — born-red card (Q-0133); flips to `complete` as the final step.
+> Routine · dispatch, owner-present (maintainer said "fix it"). CLASS: fix. Auto-merges on green.
+
+## Root cause
+
+`scripts/check_quality.py` (the "true CI mirror") runs isort with
+`--skip-glob "*/(\.github|tests|venv|env|build|dist)/*"`. isort's `--skip-glob` takes a **glob**,
+not a regex — the `(a|b)` alternation matches nothing, so isort silently scans `tests/`. CI itself
+hit this exact bug and **fixed it on 2026-06-15** by switching to directory-name `--skip` flags
+(`code-quality.yml` L126-131), but `check_quality.py` kept the old broken form — so the two drifted:
+CI excludes tests/ from isort, the mirror does not. Result: the mirror throws **false-red isort
+failures on test files CI would never flag** (it misled this run's slice-3 into needlessly isort-ing
+test files). CLAUDE.md's "CI excludes tests/ from isort" is CORRECT; the mirror was the wrong half.
+
+## Fix
+
+- `check_quality.py`: replace the broken `--skip-glob <regex>` with CI's exact
+  `--skip .github --skip tests --skip venv --skip env --skip build --skip dist` form.
+- Add `tests/unit/scripts/test_check_quality_ci_parity.py` — parses `code-quality.yml` and asserts
+  check_quality's black/isort/ruff exclude scopes cover the same dirs, so this drift class can't recur.

--- a/.sessions/2026-06-23-check-quality-isort-parity.md
+++ b/.sessions/2026-06-23-check-quality-isort-parity.md
@@ -1,7 +1,7 @@
 # 2026-06-23 — Fix: check_quality isort scope drifted from CI (false-red on tests/)
 
-> **Status:** `in-progress` — born-red card (Q-0133); flips to `complete` as the final step.
-> Routine · dispatch, owner-present (maintainer said "fix it"). CLASS: fix. Auto-merges on green.
+> **Status:** `complete` — born-red card (Q-0133) flipped green as the final step.
+> Routine · dispatch, owner-present (maintainer said "fix it"). CLASS: fix. PR #1343 auto-merges on green.
 
 ## Root cause
 
@@ -20,3 +20,49 @@ test files). CLAUDE.md's "CI excludes tests/ from isort" is CORRECT; the mirror 
   `--skip .github --skip tests --skip venv --skip env --skip build --skip dist` form.
 - Add `tests/unit/scripts/test_check_quality_ci_parity.py` — parses `code-quality.yml` and asserts
   check_quality's black/isort/ruff exclude scopes cover the same dirs, so this drift class can't recur.
+
+## The "verify before fixing" pivot (worth keeping)
+
+The owner said "fix it" about the item I'd flagged at close-out: *"CLAUDE.md is wrong — CI lints
+tests/ imports."* But following the binding rule (a tool verdict that fights the evidence is the
+tool's bug — verify against ground truth first), I checked the **actual** CI config before touching
+the doc. `code-quality.yml` plainly excludes tests/ (`--skip tests`, with its own NOTE about this
+exact glob trap). So **CLAUDE.md was right all along** — the bug was the *mirror* diverging from CI,
+not the doc. The fix went to the real root (`check_quality.py`) and **CLAUDE.md needs no change**.
+Had I "fixed" the doc on my slice-3 hunch, I'd have *introduced* drift into a correct file. This is
+the Q-0120 false-green instinct paying off in reverse.
+
+## Verification
+
+- Behavioural proof: planted a deliberately mis-sorted import in `tests/`, ran `check_quality.py
+  --check-only` → isort **passed** (tests/ now excluded, matching CI); pre-fix it would have failed.
+- `check_quality.py --full` → **11964 passed** (incl. the 5 new parity tests), all formatters green
+  (the edited `scripts/check_quality.py` is itself in formatter scope and clean). ·
+  `check_architecture --mode strict` → 0 errors.
+
+## Session enders
+
+- **♻ Grooming (Q-0015):** no idea moved (this is an owner-directed bug fix, not an idea promotion);
+  the run's grooming happened in slices 1–2 (fishing design §5 + weather Other-idea marked shipped).
+- **💡 Session idea (Q-0089):** *Generalise the parity guard to a "mirror-vs-CI" meta-check* — this
+  drift (the script keeping a stale form while CI moved on) is the same class as the three-places
+  tool-pin drift (#1320). A single `check_ci_mirror.py` that asserts **every** flag `check_quality.py`
+  passes to black/isort/ruff/mypy/pytest matches `code-quality.yml`'s would catch the *next* divergence
+  (e.g. a new `--exclude` CI adds) before it produces a false signal. Logged, not built (its own slice).
+- **⟲ Previous-session review:** slices 1–3 of this run were solid, but slice 3's close-out made a
+  **confident wrong call** — it asserted "CLAUDE.md is wrong" from a single observation without
+  checking the CI config, and only the owner's "fix it" prompt (plus the verify-first rule) caught it
+  before that wrong conclusion propagated into a doc edit. **System lesson:** a flagged
+  "the docs are wrong" should carry *"unverified against source"* until checked — the same humility the
+  CodeGraph `dead-unresolved` / Q-0120 false-green rules encode. A good candidate note for the
+  dispatch close-out checklist (captured, not applied — CLAUDE.md is read-only to an autonomous run).
+- **📋 Doc audit (Q-0104):** no doc change needed (CLAUDE.md was correct); the #1343 ledger entry is
+  the next recon pass's job (marker #1320, next #1350). No other drift spotted.
+
+## 📤 Run report
+
+- **Run type:** routine · dispatch
+- **⚑ Self-initiated:** no — owner-directed in-session ("fix it if you want, I'm here now"). Root-caused
+  + fixed the check_quality↔CI isort-scope drift + added a parity guard.
+- **⚑ Owner-decisions:** none (the "fix" turned out to be a tool bug, not a doc/policy call).
+- **⚑ Owner-manual-steps:** none (dev-tooling + test only; no runtime/deploy effect).

--- a/docs/owner/claims/claude__funny-franklin-3z6s2p.md
+++ b/docs/owner/claims/claude__funny-franklin-3z6s2p.md
@@ -1,1 +1,0 @@
-- `claude/funny-franklin-3z6s2p` · fix check_quality isort scope drift from CI + parity guard · `scripts/check_quality.py`, `tests/unit/scripts/test_check_quality_ci_parity.py` · 2026-06-23

--- a/docs/owner/claims/claude__funny-franklin-3z6s2p.md
+++ b/docs/owner/claims/claude__funny-franklin-3z6s2p.md
@@ -1,0 +1,1 @@
+- `claude/funny-franklin-3z6s2p` · fix check_quality isort scope drift from CI + parity guard · `scripts/check_quality.py`, `tests/unit/scripts/test_check_quality_ci_parity.py` · 2026-06-23

--- a/scripts/check_quality.py
+++ b/scripts/check_quality.py
@@ -46,10 +46,15 @@ def _tool(name: str, *args: str) -> list[str]:
 #     turned the prescribed pre-push check permanently red for no real
 #     reason and caused wasted back-and-forth.
 #   * CI runs mypy only against disbot/.
-# black --exclude / ruff --exclude take a regex / comma-list; isort uses
-# --skip-glob. Kept byte-for-byte aligned with the workflow.
+# black --exclude / ruff --exclude take a regex / comma-list. isort's
+# --skip-glob takes a GLOB (not a regex): the old "*/(\.github|tests|...)/*" was
+# regex alternation inside a glob, so it matched nothing and isort silently
+# scanned tests/ — diverging from CI, which excludes tests/ via directory-name
+# --skip flags (code-quality.yml, fixed 2026-06-15). We mirror CI exactly: one
+# --skip <dir> per excluded directory (recurses). Kept aligned with the workflow;
+# tests/unit/scripts/test_check_quality_ci_parity.py guards against re-drift.
 _BLACK_EXCLUDE = r"(\.github|tests|venv|env|build|dist)"
-_ISORT_SKIP_GLOB = r"*/(\.github|tests|venv|env|build|dist)/*"
+_ISORT_SKIP_DIRS = (".github", "tests", "venv", "env", "build", "dist")
 _RUFF_EXCLUDE = ".github,tests,venv,env,build,dist"
 
 
@@ -98,8 +103,11 @@ def run_formatters(*, check_only: bool) -> list[tuple[str, int]]:
                     "isort",
                     *(["--check-only"] if check_only else []),
                     ".",
-                    "--skip-glob",
-                    _ISORT_SKIP_GLOB,
+                    *(
+                        arg
+                        for directory in _ISORT_SKIP_DIRS
+                        for arg in ("--skip", directory)
+                    ),
                 ),
             ),
         ),

--- a/tests/unit/scripts/test_check_quality_ci_parity.py
+++ b/tests/unit/scripts/test_check_quality_ci_parity.py
@@ -1,0 +1,94 @@
+"""CI-parity guard for scripts/check_quality.py — the "true CI mirror".
+
+`check_quality.py` is only trustworthy if its formatter scope matches
+`.github/workflows/code-quality.yml` exactly (*"green here means green in CI"*).
+They drifted once: CI switched isort from a broken `--skip-glob <regex>` to
+directory-name `--skip` flags (2026-06-15), but the script kept the old glob, so
+the mirror silently scanned `tests/` and threw false-red isort failures CI never
+would. This test pins the black/isort/ruff *exclude scopes* of the two in sync so
+that class can't recur.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO / "scripts" / "check_quality.py"
+_WORKFLOW = _REPO / ".github" / "workflows" / "code-quality.yml"
+
+#: The directories CI excludes from every formatter (the single canonical set).
+_EXPECTED_DIRS = {".github", "tests", "venv", "env", "build", "dist"}
+
+
+def _load_check_quality():
+    spec = importlib.util.spec_from_file_location("check_quality_ut", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return _load_check_quality()
+
+
+@pytest.fixture(scope="module")
+def workflow_text() -> str:
+    return _WORKFLOW.read_text(encoding="utf-8")
+
+
+def _dirs_from_regex_alternation(pattern: str) -> set[str]:
+    """``(\\.github|tests|venv)`` → ``{".github", "tests", "venv"}``."""
+    inner = pattern.strip().lstrip("(").rstrip(")")
+    return {part.replace("\\.", ".") for part in inner.split("|")}
+
+
+# --- the script's own declared scope --------------------------------------
+
+
+def test_check_quality_declares_the_canonical_scope(mod):
+    assert _dirs_from_regex_alternation(mod._BLACK_EXCLUDE) == _EXPECTED_DIRS
+    assert set(mod._ISORT_SKIP_DIRS) == _EXPECTED_DIRS
+    assert set(mod._RUFF_EXCLUDE.split(",")) == _EXPECTED_DIRS
+
+
+# --- the workflow's actual scope (parsed from the YAML run: lines) ---------
+
+
+def test_workflow_black_scope_matches(workflow_text):
+    m = re.search(r"black --check \. --exclude '([^']*)'", workflow_text)
+    assert m, "could not find the black --exclude line in code-quality.yml"
+    assert _dirs_from_regex_alternation(m.group(1)) == _EXPECTED_DIRS
+
+
+def test_workflow_isort_scope_matches(workflow_text):
+    # isort uses repeated `--skip <dir>` (NOT --skip-glob — that was the bug).
+    m = re.search(r"isort --check-only \. (.+)", workflow_text)
+    assert m, "could not find the isort line in code-quality.yml"
+    skips = set(re.findall(r"--skip (\S+)", m.group(1)))
+    assert skips == _EXPECTED_DIRS
+    assert "--skip-glob" not in m.group(1)  # the regex-in-a-glob trap stays gone
+
+
+def test_workflow_ruff_scope_matches(workflow_text):
+    m = re.search(r"ruff check \. --exclude (\S+)", workflow_text)
+    assert m, "could not find the ruff --exclude line in code-quality.yml"
+    assert set(m.group(1).split(",")) == _EXPECTED_DIRS
+
+
+def test_mirror_and_workflow_agree_per_tool(mod, workflow_text):
+    """The whole point: the script's scope == the workflow's scope, per tool."""
+    black = re.search(r"black --check \. --exclude '([^']*)'", workflow_text)
+    isort = re.search(r"isort --check-only \. (.+)", workflow_text)
+    ruff = re.search(r"ruff check \. --exclude (\S+)", workflow_text)
+    assert _dirs_from_regex_alternation(mod._BLACK_EXCLUDE) == (
+        _dirs_from_regex_alternation(black.group(1))
+    )
+    assert set(mod._ISORT_SKIP_DIRS) == set(re.findall(r"--skip (\S+)", isort.group(1)))
+    assert set(mod._RUFF_EXCLUDE.split(",")) == set(ruff.group(1).split(","))


### PR DESCRIPTION
## What

`scripts/check_quality.py` — the "true CI mirror" the whole pre-push workflow trusts (*"green here means green in CI, red means red"*) — diverged from CI on isort scope.

**Root cause:** the script runs isort with `--skip-glob "*/(\.github|tests|venv|env|build|dist)/*"`. isort's `--skip-glob` takes a **glob**, not a regex — the `(a|b)` alternation matches nothing, so isort silently scans `tests/`. CI hit this exact bug and **fixed it on 2026-06-15** by switching to directory-name `--skip` flags (`code-quality.yml`), but `check_quality.py` kept the old broken form. So the two drifted: **CI excludes `tests/` from isort; the mirror does not** — producing false-red isort failures on test files CI would never flag (this run's slice-3 was misled by exactly this into needlessly isort-ing test files). CLAUDE.md's "CI excludes tests/ from isort" was correct all along; the mirror was the wrong half.

## Fix

- `check_quality.py`: replace the broken `--skip-glob <regex>` with CI's exact `--skip .github --skip tests --skip venv --skip env --skip build --skip dist` form (the black/ruff scopes were already correct).
- New `tests/unit/scripts/test_check_quality_ci_parity.py`: parses `code-quality.yml` and asserts the mirror's black/isort/ruff exclude scopes cover the same directories as CI — so this drift class (the script keeping a stale form while CI moves on) can't silently recur.

## Born-red

Opened born-red per Q-0133; flips to `complete` (auto-merge on green) as the final step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAXoXLXCZu62iY2MAJDNpJ)_