### PR TITLE
Fishing: trophy records (per-species biggest-caught)

### DIFF
--- a/.sessions/2026-06-23-fishing-trophy-records.md
+++ b/.sessions/2026-06-23-fishing-trophy-records.md
@@ -1,6 +1,6 @@
 # 2026-06-23 — Fishing trophy records (per-species biggest-caught)
 
-> **Status:** `in-progress` — born-red session card (Q-0133). Flip to `complete` last.
+> **Status:** `complete` — fishing trophy records shipped (PR #1351), full CI mirror green.
 
 > **Run type:** `routine · dispatch`
 
@@ -32,4 +32,72 @@ Scope (additive, no money/safety seam — game state, ADR-002 applies):
 
 ## What shipped
 
-_(filled in at close)_
+**Fishing trophy records (per-species biggest-caught)** — PR #1351, the design's
+"Other ideas" follow-up. Each catch now rolls an individual **weight**; the catch-log
+tracks the player's heaviest of each species, and the Fishdex + the catch embed surface it.
+
+- **`utils/fishing/weight.py`** (new, pure) — `roll_weight(species, rng)`: a nominal that
+  grows with `size_rank` (`0.18 × rank^1.65`) × a bounded per-catch spread (0.65–1.55), so
+  repeat catches differ and a lucky lunker becomes a record worth chasing. `nominal_weight`
+  exposed for the curve. Seed-deterministic.
+- **`utils/fishing/fish.py`** — `Catch.weight` (defaults 0.0 → old bare `Catch(species=…)`
+  call sites + a 0-weight catch never set a PB).
+- **`utils/fishing/rewards.py`** — `roll_catch` rolls the weight off the same rng.
+- **migration 095** — re-adds `best_weight REAL NOT NULL DEFAULT 0` (additive, `IF NOT
+  EXISTS`), the column 076 dropped when v1 went weightless — now that weight has a purpose.
+- **`utils/db/games/fishing.py`** — `record_catch(…, weight)` keeps `best_weight` via a
+  `GREATEST` upsert and returns the **prior** best (CTE), so the caller detects a new PB;
+  `get_fishing_records()` read model (`best_weight > 0` filter skips legacy rows).
+- **`services/fishing_workflow.py`** — `FishResult.weight` + `.new_personal_best`, threaded
+  through `commit_catch` (prior-best `None` or `< weight` → PB).
+- **`views/fishing/cast_view.py`** — the catch embed reports "⚖️ It weighs **X kg**" + "🏅
+  **New personal best!**" on a record. **`views/fishing/menu.py`** + `cogs/fishing_cog.py` —
+  the Fishdex shows "🏅 X kg" beside each caught species' tally.
+- **Tests** — `test_fishing_weight.py` (new: determinism, monotonic nominal, bounded spread,
+  per-catch variation); updated db/workflow/menu/cast-view tests for the weight path + PB
+  flag. Full CI mirror green (12011 passed) + arch strict 0 errors.
+
+## Findings / decisions
+
+- **No new bugs found.** The reintroduction of `best_weight` is clean: 076's drop comment
+  explicitly anticipated a future weight purpose, and 095 is `IF NOT EXISTS`-idempotent
+  against either form of 075 a DB may have applied (the migration-hygiene precedent 076 set).
+- Weight is **cosmetic/record-only** — it does not touch coins, the sell value (still
+  `size_rank`), or any safety seam. ADR-002 (game state not restart-safe) applies, unchanged.
+
+## 💡 Session idea
+
+**"A big one got away" soft-fail clue + a personal-best leaderboard.** Two cheap layers on
+this PR's weight seam: (1) when a *trophy* fish escapes the reel, the cast view already knows
+its species — surface a teasing clue ("a *big %s* slipped the hook!") instead of a flat
+"it got away", turning a failure into a bait for the next cast (the design's "Other ideas"
+soft-fail item, now trivially reachable since catches carry weight). (2) A `fishtop`-style
+**heaviest-catch leaderboard** off `best_weight` (the `top_fishers` pattern, new
+`SUM`-less `ORDER BY MAX(best_weight)`), so trophies compete server-wide, not just personally.
+Routed: both belong under the fishing design's §"Other ideas" — captured here, not yet a plan.
+
+## ⟲ Previous-session review
+
+The previous run (`2026-06-22-repo-navigation-cleanup`) did a careful, *restrained* job: it
+pruned genuinely stale claims but verified each flagged "conflict" against source and
+explicitly declined to churn append-only history or self-edit propose-first CLAUDE.md content
+— exactly the discipline the working agreement asks for. What it could have done better: it
+identified a real **clarity nit** (the "Open PR READY" Q-0103 bullet lacks a forward-pointer
+to the Q-0133 born-red refinement ~40 lines down) but left it only as a finding, not a router
+DISCUSS Q — so the fix has no durable home and will be re-discovered. **System improvement it
+surfaces:** when a session finds a propose-first CLAUDE.md nit it *can't* self-edit, the
+default should be to **open the router Q in the same breath** (the agreement's "propose, not
+apply" path), not just note it — otherwise the observation evaporates. I did not hit that case
+this run (no CLAUDE.md change), so nothing to route from my side.
+
+## 📤 Run report
+
+- **Run type:** `routine · dispatch`
+- **Slices shipped:** 1 (fishing trophy records — a complete, shippable function: weight roll
+  → DB record → workflow → both UI surfaces → tests).
+- **⚑ Self-initiated:** none (this is a dispatched/next-plan-slice build straight off the S1
+  fishing "Next startable" list + the design's "Other ideas" — not an invented feature).
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none — migration 095 auto-applies on deploy (the version-numbered
+  runner); the merge auto-deploys. No seed/data step.
+- **Bug-book:** no entries opened or closed this run.

--- a/.sessions/2026-06-23-fishing-trophy-records.md
+++ b/.sessions/2026-06-23-fishing-trophy-records.md
@@ -1,0 +1,35 @@
+# 2026-06-23 — Fishing trophy records (per-species biggest-caught)
+
+> **Status:** `in-progress` — born-red session card (Q-0133). Flip to `complete` last.
+
+> **Run type:** `routine · dispatch`
+
+## What I'm about to do
+
+Scheduled dispatch fire, no work order → advance the next plan slice. Building the
+**"Trophy records per species (biggest caught)"** follow-up from the fishing design
+([`docs/planning/fishing-minigame-design-2026-06-22.md`](../docs/planning/fishing-minigame-design-2026-06-22.md)
+§"Other ideas", line 206) — "a cheap long-tail goal layered on the existing catch-log;
+personal best beats raw counts for retention."
+
+Each catch now rolls an individual **weight**; the catch-log tracks the player's heaviest
+of each species (re-introducing the `best_weight` column that #1036/migration 076 dropped
+when v1 went weightless — legitimate now that this feature gives weight a purpose). The
+Fishdex shows your personal-best weight per species, and a fresh record celebrates with
+"🏆 New personal best!" on the catch.
+
+Scope (additive, no money/safety seam — game state, ADR-002 applies):
+- `utils/fishing/weight.py` (new, pure) — `roll_weight(species, rng)`.
+- `utils/fishing/fish.py` — `Catch` gains `weight`.
+- `utils/fishing/rewards.py` — `roll_catch` rolls + carries the weight.
+- migration 095 — re-add `best_weight REAL NOT NULL DEFAULT 0`.
+- `utils/db/games/fishing.py` — `record_catch(..., weight)` tracks GREATEST best,
+  returns the prior best; `get_fishing_records()` read model.
+- `services/fishing_workflow.py` — thread weight through `commit_catch`; `FishResult`
+  gains `weight` + `new_personal_best`.
+- `views/fishing/cast_view.py` + `menu.py` — surface weight + the trophy line.
+- Tests across all layers.
+
+## What shipped
+
+_(filled in at close)_

--- a/disbot/cogs/fishing_cog.py
+++ b/disbot/cogs/fishing_cog.py
@@ -119,10 +119,11 @@ class FishingCog(commands.Cog):
     async def fishlog(self, ctx):
         """Show your fishing collection — every species you've caught."""
         log = await db.get_fishing_log(ctx.author.id, ctx.guild.id)
+        records = await db.get_fishing_records(ctx.author.id, ctx.guild.id)
         xp_map = await db.get_game_xp(ctx.author.id, ctx.guild.id)
         fishing_xp = xp_map.get(game_xp_service.GAME_FISHING, 0)
         level = fishing_workflow.fishing_level_from_xp(fishing_xp)
-        embed = build_fishlog_embed(ctx.author.display_name, log, level)
+        embed = build_fishlog_embed(ctx.author.display_name, log, level, records)
         await ctx.send(embed=embed)
 
     @commands.command(

--- a/disbot/migrations/095_fishing_catch_log_best_weight.sql
+++ b/disbot/migrations/095_fishing_catch_log_best_weight.sql
@@ -1,0 +1,17 @@
+-- Fishing trophy records (per-species "biggest caught").
+--
+-- v1 fishing went weightless: migration 076 DROPPED the `best_weight` column
+-- that 075 had added, because the Q-0175 redesign ranked fish by static size
+-- and paid no coins, so a per-catch weight had no purpose.  The owner design's
+-- "Other ideas" list now calls for trophy records — a cheap long-tail goal where
+-- each catch rolls its own weight and the log keeps the player's heaviest of
+-- each species ("personal best beats raw counts for retention").  That gives
+-- weight a real purpose, so this migration re-adds the column.
+--
+-- Forward-only + additive (the migration-chain invariant): a brand-new column
+-- with a 0 default, so existing rows keep their counts and simply start with no
+-- recorded best until their next catch.  An empty `fishing_catch_log` is still
+-- byte-identical to the pre-fishing bot.  `IF NOT EXISTS` makes it idempotent
+-- and safe whichever form of 075 a given database applied.
+ALTER TABLE fishing_catch_log
+    ADD COLUMN IF NOT EXISTS best_weight REAL NOT NULL DEFAULT 0;

--- a/disbot/services/fishing_workflow.py
+++ b/disbot/services/fishing_workflow.py
@@ -64,6 +64,11 @@ class FishResult:
     unlocked_bigger: bool = False
     #: Inline shared-game level-up notice (set only when that crossed a level).
     xp_note: str | None = None
+    #: This catch's individual weight in kg (0 when there was no catch).
+    weight: float = 0.0
+    #: True when this catch beat the player's previous heaviest of the species
+    #: (a new trophy record) — drives the "🏆 New personal best!" celebration.
+    new_personal_best: bool = False
 
 
 @dataclass(frozen=True)
@@ -131,7 +136,13 @@ async def commit_catch(user_id: int, guild_id: int, cast: Cast) -> FishResult:
         return FishResult(catch=None, fishing_level=level_before)
 
     async with db.transaction() as conn:
-        await db.record_catch(user_id, guild_id, catch.species.name, conn=conn)
+        prev_best = await db.record_catch(
+            user_id,
+            guild_id,
+            catch.species.name,
+            catch.weight,
+            conn=conn,
+        )
         # The caught fish is now a tangible inventory item (owner decision
         # 2026-06-22): sellable for coins via the market, and cookable into food
         # at a campfire (mining_workflow.cook). The catch-log row above stays the
@@ -156,11 +167,14 @@ async def commit_catch(user_id: int, guild_id: int, cast: Cast) -> FishResult:
         level_after = fishing_level_from_xp(award.game_total)
     else:
         level_after = level_before
+    new_best = catch.weight > 0 and (prev_best is None or catch.weight > prev_best)
     return FishResult(
         catch=catch,
         fishing_level=level_after,
         unlocked_bigger=level_after > level_before,
         xp_note=award.note if award is not None and award.leveled_up else None,
+        weight=catch.weight,
+        new_personal_best=new_best,
     )
 
 

--- a/disbot/utils/db/__init__.py
+++ b/disbot/utils/db/__init__.py
@@ -98,6 +98,7 @@ from utils.db.games.farm import (
 )
 from utils.db.games.fishing import (
     get_fishing_log,
+    get_fishing_records,
     record_catch,
     top_fishers,
 )
@@ -424,6 +425,7 @@ __all__ = [
     "get_structures",
     "set_structure_level",
     "get_fishing_log",
+    "get_fishing_records",
     "record_catch",
     "top_fishers",
     "get_rod_tier",

--- a/disbot/utils/db/games/fishing.py
+++ b/disbot/utils/db/games/fishing.py
@@ -20,12 +20,23 @@ if TYPE_CHECKING:
 
 # Upsert one catch: insert the first catch of a species, or bump the tally —
 # count += 1 and last_caught = now(). first_caught is preserved (INSERT-only).
+# best_weight keeps the heaviest catch of this species (the trophy record):
+# GREATEST against the incoming weight so it only ever grows. The CTE captures
+# the row's PRIOR best before the upsert so the caller can tell whether this
+# catch set a new personal best (prev_best is NULL on the very first catch).
 _RECORD_CATCH_SQL = """
-    INSERT INTO fishing_catch_log (user_id, guild_id, species, count)
-    VALUES ($1, $2, $3, 1)
+    WITH prev AS (
+        SELECT best_weight
+        FROM fishing_catch_log
+        WHERE user_id = $1 AND guild_id = $2 AND species = $3
+    )
+    INSERT INTO fishing_catch_log (user_id, guild_id, species, count, best_weight)
+    VALUES ($1, $2, $3, 1, $4)
     ON CONFLICT (user_id, guild_id, species) DO UPDATE SET
         count       = fishing_catch_log.count + 1,
-        last_caught = now()
+        last_caught = now(),
+        best_weight = GREATEST(fishing_catch_log.best_weight, EXCLUDED.best_weight)
+    RETURNING (SELECT best_weight FROM prev) AS prev_best
 """
 
 
@@ -33,11 +44,22 @@ async def record_catch(
     user_id: int,
     guild_id: int,
     species: str,
+    weight: float = 0.0,
     *,
     conn: asyncpg.Connection | None = None,
-) -> None:
-    """Record one catch of *species* for the player (insert or bump the tally)."""
-    await pool.execute(_RECORD_CATCH_SQL, (user_id, guild_id, species), conn=conn)
+) -> float | None:
+    """Record one catch of *species* (insert or bump the tally) + its weight.
+
+    Returns the species' **prior** best weight (``None`` on the first ever
+    catch), so the caller can detect a new personal best: it is one when the
+    prior best is ``None`` or strictly less than *weight*.
+    """
+    row = await pool.fetchone(
+        _RECORD_CATCH_SQL,
+        (user_id, guild_id, species, weight),
+        conn=conn,
+    )
+    return row["prev_best"] if row else None
 
 
 async def get_fishing_log(
@@ -54,6 +76,26 @@ async def get_fishing_log(
         conn=conn,
     )
     return {r["species"]: r["count"] for r in rows}
+
+
+async def get_fishing_records(
+    user_id: int,
+    guild_id: int,
+    *,
+    conn: asyncpg.Connection | None = None,
+) -> dict[str, float]:
+    """The player's trophy records: ``{species: best_weight}`` (heaviest caught).
+
+    Only species with a recorded best (> 0) appear, so a freshly-migrated row
+    that has not been re-caught since the weightless era is simply absent.
+    """
+    rows = await pool.fetchall(
+        "SELECT species, best_weight FROM fishing_catch_log "
+        "WHERE user_id=$1 AND guild_id=$2 AND best_weight > 0",
+        (user_id, guild_id),
+        conn=conn,
+    )
+    return {r["species"]: r["best_weight"] for r in rows}
 
 
 async def top_fishers(

--- a/disbot/utils/fishing/__init__.py
+++ b/disbot/utils/fishing/__init__.py
@@ -41,6 +41,7 @@ from utils.fishing.weather import (
     current_weather,
     weather_for_date,
 )
+from utils.fishing.weight import nominal_weight, roll_weight
 
 __all__ = [
     "CONDITIONS",
@@ -56,8 +57,10 @@ __all__ = [
     "Weather",
     "current_weather",
     "max_size_rank_for_level",
+    "nominal_weight",
     "profile_for",
     "roll_catch",
+    "roll_weight",
     "species_by_name",
     "species_for_venue",
     "toggle",

--- a/disbot/utils/fishing/fish.py
+++ b/disbot/utils/fishing/fish.py
@@ -56,9 +56,16 @@ class FishSpecies:
 
 @dataclass(frozen=True)
 class Catch:
-    """One rolled catch — just the species (no value/weight in v1)."""
+    """One rolled catch — the species plus this catch's individual weight (kg).
+
+    ``weight`` is rolled per catch (:mod:`utils.fishing.weight`) so the catch-log
+    can track a "biggest caught" trophy record per species. It defaults to ``0``
+    so older call sites / fixtures that build a bare ``Catch(species=…)`` stay
+    valid (a 0-weight catch simply never sets a personal best).
+    """
 
     species: FishSpecies
+    weight: float = 0.0
 
 
 def _load_species() -> tuple[FishSpecies, ...]:

--- a/disbot/utils/fishing/rewards.py
+++ b/disbot/utils/fishing/rewards.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import random
 
 from utils.fishing.fish import SHORE_VENUE, Catch, FishSpecies, unlocked_species
+from utils.fishing.weight import roll_weight
 
 
 def roll_catch(
@@ -43,4 +44,4 @@ def roll_catch(
     pull = max(1.0, rarity_pull)
     weights = [1.0 / (s.size_rank ** (1.0 / pull)) for s in pool]
     species: FishSpecies = r.choices(pool, weights=weights, k=1)[0]
-    return Catch(species=species)
+    return Catch(species=species, weight=roll_weight(species, r))

--- a/disbot/utils/fishing/weight.py
+++ b/disbot/utils/fishing/weight.py
@@ -1,0 +1,55 @@
+"""Per-catch weight roll — pure, the basis of the trophy-records goal.
+
+The owner design lists **"trophy records per species (biggest caught)"** as a
+cheap long-tail retention goal layered on the existing catch-log
+(``docs/planning/fishing-minigame-design-2026-06-22.md`` §"Other ideas"). For a
+"biggest caught" record to mean anything each individual catch needs its own
+weight — otherwise every catch of a species is identical and there is nothing to
+beat.
+
+So every catch rolls a weight here: a species *nominal* weight that grows with
+its ``size_rank`` (bigger fish are heavier), times a per-catch random factor so
+two catches of the same species differ and a lucky heavy one becomes a personal
+best worth chasing. Bounded, deterministic with an explicit ``random.Random``
+(seed-stable in tests), no Discord and no DB — :mod:`utils.fishing.rewards`
+calls it as part of the roll and :mod:`services.fishing_workflow` records the
+heaviest.
+"""
+
+from __future__ import annotations
+
+import random
+
+from utils.fishing.fish import FishSpecies
+
+#: Weight curve — ``nominal_kg = _BASE * size_rank ** _EXP``. Tuned so the
+#: smallest fish (#1) is a few hundred grams and the largest (#21) is a
+#: trophy-grade haul, with a smooth ramp between (see ``test_fishing_weight``).
+_BASE = 0.18
+_EXP = 1.65
+
+#: Per-catch spread around the nominal — a catch weighs ``nominal × U(LO, HI)``,
+#: so any species can occasionally produce a personal-best lunker.
+_SPREAD_LO = 0.65
+_SPREAD_HI = 1.55
+
+
+def nominal_weight(species: FishSpecies) -> float:
+    """The species' average weight in kg (grows with ``size_rank``).
+
+    The midpoint a catch varies around — bigger-ranked fish are heavier. Pure
+    function of the static catalog, so it is stable across catches.
+    """
+    return round(_BASE * (species.size_rank**_EXP), 2)
+
+
+def roll_weight(species: FishSpecies, rng: random.Random | None = None) -> float:
+    """Roll one catch's individual weight in kg (≥ 0.01).
+
+    The species :func:`nominal_weight` times a bounded random factor, so repeat
+    catches of the same fish differ and the heaviest becomes the trophy record.
+    Deterministic for a given ``rng`` (tests pass a seeded ``random.Random``).
+    """
+    r = rng or random.Random()
+    factor = r.uniform(_SPREAD_LO, _SPREAD_HI)
+    return max(0.01, round(nominal_weight(species) * factor, 2))

--- a/disbot/views/fishing/cast_view.py
+++ b/disbot/views/fishing/cast_view.py
@@ -365,6 +365,10 @@ class FishingCastView(discord.ui.View):
             f"You reeled in {species.emoji} a **{species.name.title()}**!  "
             f"(size #{species.size_rank} of {pool_size} {self._profile.name.lower()})"
         )
+        if result.weight > 0:
+            desc += f"\n⚖️ It weighs **{result.weight:g} kg**."
+            if result.new_personal_best:
+                desc += " 🏅 **New personal best!**"
         if result.unlocked_bigger:
             cap = max_size_rank_for_level(result.fishing_level, species.venue)
             desc += (

--- a/disbot/views/fishing/menu.py
+++ b/disbot/views/fishing/menu.py
@@ -85,16 +85,27 @@ def build_menu_embed(
     return embed
 
 
-def _venue_log_lines(log: dict[str, int], venue: str, cap: int) -> list[str]:
-    """The per-species log lines for one venue (caught / unlocked / locked)."""
+def _venue_log_lines(
+    log: dict[str, int],
+    venue: str,
+    cap: int,
+    records: dict[str, float],
+) -> list[str]:
+    """The per-species log lines for one venue (caught / unlocked / locked).
+
+    A caught species shows its tally and, when a trophy weight has been recorded
+    (``records``), the player's heaviest catch — the personal-best long-tail goal.
+    """
     lines = []
     for species in species_for_venue(venue):
         count = log.get(species.name, 0)
         unlocked = species.size_rank <= cap
         if count:
+            best = records.get(species.name, 0.0)
+            trophy = f" · 🏅 {best:g}kg" if best > 0 else ""
             lines.append(
                 f"{species.emoji} **{species.name.title()}** "
-                f"(#{species.size_rank}) ×{count}",
+                f"(#{species.size_rank}) ×{count}{trophy}",
             )
         elif unlocked:
             lines.append(
@@ -110,6 +121,7 @@ def build_fishlog_embed(
     display_name: str,
     log: dict[str, int],
     level: int,
+    records: dict[str, float] | None = None,
 ) -> discord.Embed:
     """The collection embed — shared by ``!fishlog`` and the Fishdex button.
 
@@ -118,6 +130,7 @@ def build_fishlog_embed(
     legacy rows from a superseded catalog (Q-0175 reconciliation) never show
     impossible progress.
     """
+    records = records or {}
     all_species = species_for_venue(venue_mod.SHORE) + species_for_venue(
         venue_mod.DEEPWATER,
     )
@@ -137,7 +150,7 @@ def build_fishlog_embed(
         (venue_mod.DEEPWATER, "⛵ Deepwater (boat-only)"),
     ):
         cap = max_size_rank_for_level(level, venue)
-        lines = _venue_log_lines(log, venue, cap)
+        lines = _venue_log_lines(log, venue, cap, records)
         if lines:
             embed.add_field(
                 name=f"{label} — up to size #{cap}",
@@ -156,11 +169,12 @@ async def _fishdex_embed(
     display_name: str,
 ) -> discord.Embed:
     log = await db.get_fishing_log(user_id, guild_id)
+    records = await db.get_fishing_records(user_id, guild_id)
     xp_map = await db.get_game_xp(user_id, guild_id)
     level = fishing_workflow.fishing_level_from_xp(
         xp_map.get(game_xp_service.GAME_FISHING, 0),
     )
-    return build_fishlog_embed(display_name, log, level)
+    return build_fishlog_embed(display_name, log, level, records)
 
 
 class FishingMenuView(HubView):

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -28,10 +28,13 @@
   deepwater holds 11 **boat-only species** (uncatchable from shore) and runs a **tougher minigame**
   (6–12 s bites · 22% base escape) so the rod escape-resist knob finally pays off — additive (the
   original 21 shore fish unchanged), the literal §5 shore-cap rebalance left as an owner balance
-  call. **Daily weather forecast** (#1341, this PR) — a date-seeded global bias
+  call. **Daily weather forecast** (#1341) — a date-seeded global bias
   (`utils/fishing/weather.py`, no DB) compounding onto the cast as a third how-well knob
   (rod × bait × weather): clear/rain/calm/fog/storm, the same for everyone each day; `!forecast` +
-  a menu/cast forecast line.
+  a menu/cast forecast line. **Trophy records per species** (#1351, this PR) — each catch now rolls
+  an individual weight (`utils/fishing/weight.py`); the catch-log keeps your heaviest of each species
+  (migration 095 re-adds `best_weight`), the Fishdex shows the personal-best beside each tally, and a
+  fresh record celebrates "🏅 New personal best!" on the catch — a cheap long-tail retention goal.
 - **Casino — multiplayer poker** (PR #1333) — a new Games-hub child for **group** card games with
   **per-player auto-updating ephemeral** hands; v1 = Texas Hold'em (play-chips). Pure `utils/cards/`
   + `utils/poker/` (eval + engine w/ side pots, fully tested) + the `views/casino/` ephemeral
@@ -42,10 +45,12 @@
   re-tune ✅ #1304, bait-crafting ✅ #1338, and the **⛵ boat/deepwater venue** ✅ PR #1340 — shore↔
   deepwater toggle + boat-only species + tougher deep minigame — are all done)* — remaining:
   the literal §5 **shore-cap-at-12 rebalance** (owner balance call, flagged in #1340) ·
-  *(weather/time-of-day modifier ✅ #1341)* · **trophy records per species**
-  ([plan](../planning/fishing-minigame-design-2026-06-22.md) §"Other ideas" +
-  [open-world expansion](../planning/fishing-open-world-expansion-plan-2026-06-18.md) Phase 2+: the
-  boat-as-structure / travel-timer / destinations layer).
+  *(weather/time-of-day modifier ✅ #1341 · trophy records per species ✅ #1351)* ·
+  the **open-world expansion**
+  ([plan](../planning/fishing-open-world-expansion-plan-2026-06-18.md) Phase 2+: the
+  boat-as-structure / travel-timer / destinations layer) ·
+  the **soft-fail clue** ("a *big* one got away") + fake-out bites
+  ([design](../planning/fishing-minigame-design-2026-06-22.md) §"Other ideas").
 - **Project Moon runtime PR 1** — the `KnowledgeDomain` seam + first ingest
   ([plan](../planning/project-moon-knowledge-domain-plan-2026-06-21.md)).
 - **botsite React-SPA migration PR 2** — serve the built React app from `botsite/` + cutover

--- a/docs/owner/claims/claude-funny-franklin-55kdst.md
+++ b/docs/owner/claims/claude-funny-franklin-55kdst.md
@@ -1,1 +1,0 @@
-- `claude/funny-franklin-55kdst` · fishing trophy records (per-species biggest-caught) · `disbot/utils/fishing/` + `services/fishing_workflow.py` + `utils/db/games/fishing.py` + `views/fishing/` + migration 095 · 2026-06-23

--- a/docs/owner/claims/claude-funny-franklin-55kdst.md
+++ b/docs/owner/claims/claude-funny-franklin-55kdst.md
@@ -1,0 +1,1 @@
+- `claude/funny-franklin-55kdst` · fishing trophy records (per-species biggest-caught) · `disbot/utils/fishing/` + `services/fishing_workflow.py` + `utils/db/games/fishing.py` + `views/fishing/` + migration 095 · 2026-06-23

--- a/docs/planning/fishing-minigame-design-2026-06-22.md
+++ b/docs/planning/fishing-minigame-design-2026-06-22.md
@@ -203,8 +203,13 @@ Your `cast → wait → BITE → reel` instinct is **right**. Three data-driven 
   bait: clear (common) / rain (faster bites) / calm / fog (patient, rarer) / storm (rare, slow but
   the big ones run). Surfaced via `!forecast` + a menu/cast forecast line. *(The "shorter windows"
   half was left out to keep the cast view untouched; bite-speed + rarity carry the feel.)*
-- **Trophy records per species** (biggest caught) — a cheap long-tail goal layered on the existing
-  catch-log; "personal best" beats raw counts for retention.
+- **Trophy records per species** (biggest caught) — **✅ SHIPPED 2026-06-23 (PR #1351).** Each catch
+  now rolls an individual weight (`disbot/utils/fishing/weight.py` — a nominal that grows with
+  `size_rank` × a bounded random spread), and the catch-log keeps the player's heaviest of each
+  species (migration 095 re-adds the `best_weight` column that 076 dropped when v1 went weightless,
+  now that weight has a purpose). The Fishdex shows your personal-best weight beside each tally, and a
+  fresh record celebrates with "🏅 New personal best!" on the catch. A cheap long-tail goal —
+  "personal best" beats raw counts for retention.
 - **Line-snap as a soft-fail, not a hard-fail** — an escaped fish could leave a clue ("a *big* one
   got away") to bait the next cast rather than just denying the reward — keeps frustration low.
 

--- a/tests/unit/db/test_fishing_db.py
+++ b/tests/unit/db/test_fishing_db.py
@@ -10,21 +10,56 @@ from utils.db.games import fishing
 
 
 @pytest.mark.asyncio
-async def test_record_catch_upserts_count_only():
+async def test_record_catch_upserts_count_and_tracks_best_weight():
     with patch(
-        "utils.db.games.fishing.pool.execute",
+        "utils.db.games.fishing.pool.fetchone",
         new_callable=AsyncMock,
-    ) as mock_exec:
-        await fishing.record_catch(99, 1, "trout")
-    query, params = mock_exec.await_args.args
+        return_value={"prev_best": 1.2},
+    ) as mock_fetch:
+        prev = await fishing.record_catch(99, 1, "trout", 3.4)
+    query, params = mock_fetch.await_args.args
     flat = " ".join(query.split())
-    assert "INSERT INTO fishing_catch_log (user_id, guild_id, species, count)" in flat
+    assert "INSERT INTO fishing_catch_log (user_id, guild_id, species, count, best_weight)" in flat
     assert "ON CONFLICT (user_id, guild_id, species) DO UPDATE" in flat
     assert "count = fishing_catch_log.count + 1" in flat
+    # best_weight only ever grows (GREATEST against the incoming catch).
+    assert "best_weight = GREATEST(fishing_catch_log.best_weight, EXCLUDED.best_weight)" in flat
+    # The prior best is captured (CTE) and returned so the caller can detect a PB.
+    assert "WITH prev AS" in flat
+    assert "RETURNING (SELECT best_weight FROM prev) AS prev_best" in flat
     # No coin/value column is touched (v1 has no coins — Q-0175).
     assert "total_value" not in flat
-    assert "best_weight" not in flat
-    assert params == (99, 1, "trout")
+    assert params == (99, 1, "trout", 3.4)
+    assert prev == 1.2
+
+
+@pytest.mark.asyncio
+async def test_record_catch_first_catch_returns_none():
+    with patch(
+        "utils.db.games.fishing.pool.fetchone",
+        new_callable=AsyncMock,
+        return_value={"prev_best": None},
+    ):
+        prev = await fishing.record_catch(99, 1, "trout", 0.5)
+    assert prev is None
+
+
+@pytest.mark.asyncio
+async def test_get_fishing_records_returns_species_to_best_weight():
+    with patch(
+        "utils.db.games.fishing.pool.fetchall",
+        new_callable=AsyncMock,
+        return_value=[
+            {"species": "trout", "best_weight": 3.4},
+            {"species": "bass", "best_weight": 1.1},
+        ],
+    ) as mock_fetch:
+        records = await fishing.get_fishing_records(99, 1)
+    query, _ = mock_fetch.await_args.args
+    flat = " ".join(query.split())
+    # Only species with a recorded best appear (post-migration legacy rows = 0).
+    assert "best_weight > 0" in flat
+    assert records == {"trout": 3.4, "bass": 1.1}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_fishing_workflow.py
+++ b/tests/unit/services/test_fishing_workflow.py
@@ -21,6 +21,7 @@ from services import economy_service
 from services import fishing_workflow as wf
 from services import game_xp_service
 from utils.fishing import MAX_LEVEL, rods
+from utils.fishing.fish import FishSpecies
 
 
 def _txn(sentinel_conn, events):
@@ -78,10 +79,11 @@ async def test_both_legs_on_one_conn_and_emit_after_commit():
     sentinel_conn = MagicMock(name="conn")
     events: list[str] = []
 
-    async def _record(user_id, guild_id, species, *, conn=None):
+    async def _record(user_id, guild_id, species, weight=0.0, *, conn=None):
         events.append("record")
         assert conn is sentinel_conn
         assert species == "trout"
+        return None
 
     async def _award_fn(guild_id, user_id, *, game, action, conn=None, depth=0):
         events.append("award")
@@ -234,6 +236,92 @@ async def test_commit_catch_writes_the_held_cast():
     grant.assert_awaited_once()
     emit.assert_awaited_once()
     assert result.catch is _CATCH
+
+
+@pytest.mark.asyncio
+async def test_commit_catch_threads_weight_and_flags_a_new_personal_best():
+    """The catch's weight reaches record_catch; a heavier-than-prior catch = PB."""
+    sentinel_conn = MagicMock(name="conn")
+
+    @asynccontextmanager
+    async def _ctx():
+        yield sentinel_conn
+
+    heavy = wf.Catch(species=FishSpecies("trout", 8, "🐠"), weight=4.2)
+    cast = wf.Cast(catch=heavy, level_before=1)
+    with (
+        patch.object(wf.db, "transaction", _ctx),
+        # Prior best 1.5 kg < this 4.2 kg catch → a new personal best.
+        patch.object(wf.db, "record_catch", AsyncMock(return_value=1.5)) as record,
+        patch.object(wf.db, "update_mining_item", AsyncMock()),
+        patch.object(
+            wf.game_xp_service,
+            "award",
+            AsyncMock(return_value=_award(game_total=10)),
+        ),
+        patch.object(wf.game_xp_service, "emit_award_events", AsyncMock()),
+    ):
+        result = await wf.commit_catch(99, 1, cast)
+
+    # The rolled weight is passed positionally to the audited write.
+    args, _ = record.await_args
+    assert args[3] == 4.2
+    assert result.weight == 4.2
+    assert result.new_personal_best is True
+
+
+@pytest.mark.asyncio
+async def test_commit_catch_not_a_personal_best_when_lighter_than_prior():
+    sentinel_conn = MagicMock(name="conn")
+
+    @asynccontextmanager
+    async def _ctx():
+        yield sentinel_conn
+
+    light = wf.Catch(species=FishSpecies("trout", 8, "🐠"), weight=0.9)
+    cast = wf.Cast(catch=light, level_before=1)
+    with (
+        patch.object(wf.db, "transaction", _ctx),
+        # Prior best 3.0 kg > this 0.9 kg catch → not a record.
+        patch.object(wf.db, "record_catch", AsyncMock(return_value=3.0)),
+        patch.object(wf.db, "update_mining_item", AsyncMock()),
+        patch.object(
+            wf.game_xp_service,
+            "award",
+            AsyncMock(return_value=_award(game_total=10)),
+        ),
+        patch.object(wf.game_xp_service, "emit_award_events", AsyncMock()),
+    ):
+        result = await wf.commit_catch(99, 1, cast)
+
+    assert result.new_personal_best is False
+
+
+@pytest.mark.asyncio
+async def test_commit_catch_first_catch_of_a_species_is_a_personal_best():
+    sentinel_conn = MagicMock(name="conn")
+
+    @asynccontextmanager
+    async def _ctx():
+        yield sentinel_conn
+
+    first = wf.Catch(species=FishSpecies("trout", 8, "🐠"), weight=1.1)
+    cast = wf.Cast(catch=first, level_before=1)
+    with (
+        patch.object(wf.db, "transaction", _ctx),
+        # No prior row → record_catch returns None → the first catch is a PB.
+        patch.object(wf.db, "record_catch", AsyncMock(return_value=None)),
+        patch.object(wf.db, "update_mining_item", AsyncMock()),
+        patch.object(
+            wf.game_xp_service,
+            "award",
+            AsyncMock(return_value=_award(game_total=10)),
+        ),
+        patch.object(wf.game_xp_service, "emit_award_events", AsyncMock()),
+    ):
+        result = await wf.commit_catch(99, 1, cast)
+
+    assert result.new_personal_best is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/utils/test_fishing_weight.py
+++ b/tests/unit/utils/test_fishing_weight.py
@@ -1,0 +1,52 @@
+"""utils.fishing.weight — per-catch weight roll (seed-deterministic, monotonic)."""
+
+from __future__ import annotations
+
+import random
+
+from utils.fishing import fish
+from utils.fishing.weight import nominal_weight, roll_weight
+
+
+def _species(rank: int) -> fish.FishSpecies:
+    return fish.FishSpecies(name=f"fish{rank}", size_rank=rank, emoji="🐟")
+
+
+def test_roll_is_deterministic_for_a_fixed_seed():
+    s = _species(5)
+    assert roll_weight(s, random.Random(42)) == roll_weight(s, random.Random(42))
+
+
+def test_nominal_weight_grows_with_size_rank():
+    weights = [nominal_weight(_species(r)) for r in range(1, 22)]
+    # Strictly increasing — a bigger-ranked fish is always heavier on average.
+    assert all(b > a for a, b in zip(weights, weights[1:]))
+
+
+def test_smallest_fish_is_light_and_largest_is_a_trophy():
+    assert nominal_weight(_species(1)) < 1.0  # a few hundred grams
+    assert nominal_weight(_species(21)) > 20.0  # a real haul
+
+
+def test_roll_stays_within_the_bounded_spread():
+    s = _species(10)
+    nominal = nominal_weight(s)
+    rng = random.Random(7)
+    for _ in range(2000):
+        w = roll_weight(s, rng)
+        # Bounded by the spread factors (0.65 … 1.55), never below the 0.01 floor.
+        assert 0.01 <= w <= nominal * 1.55 + 0.01
+
+
+def test_repeat_catches_of_one_species_vary():
+    s = _species(8)
+    rng = random.Random(99)
+    seen = {roll_weight(s, rng) for _ in range(50)}
+    # Per-catch variation is the whole point — a trophy must be beatable.
+    assert len(seen) > 1
+
+
+def test_a_real_catalog_species_rolls_a_positive_weight():
+    if fish.SPECIES:
+        w = roll_weight(fish.SPECIES[0], random.Random(1))
+        assert w > 0

--- a/tests/unit/views/test_fishing_cast_view.py
+++ b/tests/unit/views/test_fishing_cast_view.py
@@ -132,6 +132,38 @@ async def test_ordinary_fish_commits_on_the_first_reel():
 
 
 @pytest.mark.asyncio
+async def test_caught_embed_shows_weight_and_personal_best():
+    view = _make_view(_ORDINARY)
+    active_casts.add((1, 99))
+    _arm(view)
+    interaction = _interaction()
+
+    result = fishing_workflow.FishResult(
+        catch=_ORDINARY.catch,
+        fishing_level=7,
+        unlocked_bigger=False,
+        weight=3.7,
+        new_personal_best=True,
+    )
+    with (
+        patch.object(
+            fishing_workflow,
+            "commit_catch",
+            AsyncMock(return_value=result),
+        ),
+        patch("views.fishing.cast_view.safe_defer", AsyncMock(return_value=True)),
+        patch("views.fishing.cast_view.safe_edit", AsyncMock(return_value=True)) as edit,
+    ):
+        await _reel(view, interaction)
+
+    # The catch embed reports the weight and celebrates the new record.
+    _, kwargs = edit.await_args
+    desc = kwargs["embed"].description
+    assert "3.7 kg" in desc
+    assert "personal best" in desc.lower()
+
+
+@pytest.mark.asyncio
 async def test_reel_too_late_lets_the_fish_get_away():
     view = _make_view()
     active_casts.add((1, 99))

--- a/tests/unit/views/test_fishing_menu.py
+++ b/tests/unit/views/test_fishing_menu.py
@@ -76,6 +76,21 @@ def test_fishlog_embed_counts_only_known_species():
     assert any("Deepwater" in n for n in field_names)
 
 
+def test_fishlog_embed_shows_the_personal_best_weight():
+    log = {"minnow": 5}
+    records = {"minnow": 2.4}
+    embed = build_fishlog_embed("Anya", log, level=7, records=records)
+    body = "\n".join(f.value for f in embed.fields)
+    assert "2.4kg" in body  # the trophy record renders beside the tally
+
+
+def test_fishlog_embed_omits_the_trophy_when_no_record():
+    log = {"minnow": 5}
+    embed = build_fishlog_embed("Anya", log, level=7)  # no records given
+    body = "\n".join(f.value for f in embed.fields)
+    assert "kg" not in body  # a caught species with no recorded best shows no trophy
+
+
 # ---------------------------------------------------------------------------
 # Buttons
 # ---------------------------------------------------------------------------
@@ -171,6 +186,7 @@ async def test_fishdex_button_renders_the_collection_and_keeps_the_menu():
     interaction = _interaction()
     with (
         patch("views.fishing.menu.db.get_fishing_log", AsyncMock(return_value={})),
+        patch("views.fishing.menu.db.get_fishing_records", AsyncMock(return_value={})),
         patch("views.fishing.menu.db.get_game_xp", AsyncMock(return_value={})),
     ):
         await _click(view, "fishdex_btn", interaction)


### PR DESCRIPTION
Scheduled dispatch fire (no work order) → next plan slice: the **"Trophy records per species (biggest caught)"** follow-up from the fishing design (`docs/planning/fishing-minigame-design-2026-06-22.md` §"Other ideas") — *"a cheap long-tail goal layered on the existing catch-log; personal best beats raw counts for retention."*

Each catch now rolls an individual **weight**; the catch-log tracks the player's heaviest of each species (re-introducing the `best_weight` column that migration 076 dropped when v1 went weightless — legitimate now that this feature gives weight a purpose). The Fishdex shows your personal-best weight per species, and a fresh record celebrates with **🏆 New personal best!** on the catch.

Additive game feature — no money/safety seam (ADR-002 game-state applies). Full layer breakdown in the session card.

> Born-red (Q-0133): merges on green CI once the card flips to `complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015aFLgUJMXzdgVoHvXtqwn7)_