### PR TITLE
Competitive-positioning north-star vision doc (what makes people choose us)

### DIFF
--- a/.sessions/2026-06-23-competitive-positioning.md
+++ b/.sessions/2026-06-23-competitive-positioning.md
@@ -1,9 +1,9 @@
 # 2026-06-23 — Competitive-positioning north-star (what makes people choose us)
 
-> **Status:** `in-progress` — born-red card (Q-0133). Flip to `complete` as the final step.
+> **Status:** `complete` — born-red card (Q-0133) flipped green as the final step.
 > Owner-directed (chat follow-up to the Dank Memer visual work: "what would make people prefer
 > ours over any other"; owner picked *capture a positioning vision doc* + *deep-research
-> competitors* via AskUserQuestion). Docs-only PR. Auto-merges on green (Q-0123).
+> competitors* via AskUserQuestion). Docs-only PR #1352. Auto-merges on green (Q-0123).
 
 ## Arc
 
@@ -24,6 +24,58 @@ captures the synthesis as a north-star positioning doc.
   roadmap implication.
 - `docs/ideas/README.md` index entry.
 
-## Status
+## Shipped (PR #1352)
 
-In progress — born-red. Close-out written as the final step before flipping to `complete`.
+- **`docs/ideas/competitive-positioning-north-star-2026-06-23.md`** — the north-star: four universal
+  incumbent failure modes (utility paywalls · pay-to-win · setup friction · jack-of-all-trades),
+  our wedge (AI-*operated*, best-in-class-per-feature, cosmetic-only-by-promise), five pillars ranked
+  by defensibility × evidence confidence, the honest counter-arguments, and the roadmap implication.
+- **`docs/ideas/README.md`** — index entry.
+
+## Research provenance (the per-bot findings behind the doc)
+
+Fan-out research pass (agents, web-sourced, citations in transcripts). Key load-bearing findings:
+- **MEE6 backlash** is the central validation: it paywalled once-free *utility* (role rewards, custom
+  commands, leveling config) at ~$11.95/mo *per server* → spawned `alternativestomee6.com` + durable
+  "cash grab" sentiment. Lesson: paywalling depended-on utility breeds migration movements.
+- **ProBot** retroactively paywalled leveling + reset levels + deleted non-payer data (purest bait-and-switch).
+- **UnbelievaBoat** 2025 sub-switch froze legacy buyers; 25-item free cap.
+- **Pay-to-win resented** everywhere it buys *advantage* (PokéMeow "locked out without Patreon",
+  Pokétwo incense/charm, Mudae premium rolls, IdleRPG cooldown cuts + donor class, Tatsu 5× exchange cap);
+  **OwO praised** because Patreon perks are *tradeable* → "fair". Cosmetic/tradeable accepted, advantage-for-cash rejected.
+- **Setup friction** is the highest-confidence unsolved gap (Carl-bot "admin console"/JSON embeds, YAGPDB,
+  UnbelievaBoat item→role, multiple-dashboards "four points of failure"); MEE6/ProBot win on ease then upsell.
+- **AI lane:** "bolted-on chatbot" is crowded + shallow (Discord's own Clyde launched + killed in <1yr);
+  the open lane is **AI-as-operator** (conversational config / NL admin / context-aware mod), claimed only by
+  tiny unproven 2026 startups (PeakBot/VibeBot). Win = depth/execution, not the label.
+- **Counter-thesis to respect:** CommunityOne's "specialize as you grow" — all-in-ones risk
+  jack-of-all-trades; our answer must be genuine per-feature quality. Plus Discord's 2026 gambling
+  headwind against casino-heavy economies.
+
+## Verification
+
+- `check_docs --strict` → all checks passed (new doc reachable from the ideas README; 432 docs).
+- Docs-only PR — no `disbot/` code, so no arch/test surface changed.
+
+## Session enders
+
+- **♻ Grooming (Q-0015):** captured + routed one new idea (this positioning north-star) into the
+  backlog with its README index entry; it gives future sessions a lens for prioritising the
+  card-engine roadmap and the AI-setup wedge.
+- **💡 Session idea (Q-0089):** *A user-visible "cosmetic-only monetization" pledge surface* — e.g. a
+  short `!pledge` / about-page line stating "we will never paywall a feature you rely on." The
+  research shows the *promise itself* is a differentiator (it's the inverse of the MEE6 betrayal
+  narrative), so making it explicit and discoverable converts an internal principle into marketing.
+  Tiny, contained. Dedup-checked `docs/ideas/` — not yet captured.
+- **⟲ Previous-session review (Q-0102):** the predecessor batch (card-engine PR #1349, same session)
+  executed cleanly — engine + first card + dedup + tests + vision doc, green CI, merged. *Did well:*
+  built the foundation rather than only reporting, and sent the owner rendered theme samples (showed,
+  didn't tell). *Workflow improvement it surfaces:* the research fan-out this batch spawned a **deep
+  nested agent tree** (a parent that spawned children that spawned grandchildren), and resuming the
+  top parent via a fresh `Agent` call (instead of continuing the same agent) started a confused new
+  agent. Lesson for the workflow: **for fan-out research, prefer one flat batch of sibling agents
+  over deep nesting**, and continue an existing agent by its id rather than re-spawning — deep trees
+  make synthesis-collection error-prone.
+- **📋 Doc audit (Q-0104):** `check_docs --strict` green; the full competitive research is preserved
+  in this session log (not left chat-only); the positioning doc is reachable and cross-linked to the
+  visual-card-engine vision + the superbot product vision.

--- a/.sessions/2026-06-23-competitive-positioning.md
+++ b/.sessions/2026-06-23-competitive-positioning.md
@@ -1,0 +1,29 @@
+# 2026-06-23 — Competitive-positioning north-star (what makes people choose us)
+
+> **Status:** `in-progress` — born-red card (Q-0133). Flip to `complete` as the final step.
+> Owner-directed (chat follow-up to the Dank Memer visual work: "what would make people prefer
+> ours over any other"; owner picked *capture a positioning vision doc* + *deep-research
+> competitors* via AskUserQuestion). Docs-only PR. Auto-merges on green (Q-0123).
+
+## Arc
+
+Second batch of the visual/strategy session (first batch = the card engine, PR #1349, merged). The
+owner asked the broader question: not just "beat Dank Memer's visuals" but "what makes people pick
+us over **any** bot." Ran a fan-out of research agents across the whole competitive field —
+economy/games (Dank Memer, UnbelievaBoat, IdleRPG, Pokétwo/PokéMeow, OwO, Mudae), leveling/engagement
+(MEE6, Arcane, Amari, Tatsu, Lurkr), moderation/all-in-one (Carl-bot, Dyno, ProBot, Wick, Sapphire),
+and an AI-native + market-gaps synthesis. The patterns were strikingly consistent. This batch
+captures the synthesis as a north-star positioning doc.
+
+## Plan (this PR)
+
+- `docs/ideas/competitive-positioning-north-star-2026-06-23.md` — the grounded positioning thesis:
+  the universal incumbent failure modes (utility paywalls / pay-to-win / setup friction /
+  jack-of-all-trades), our wedge (AI-operated, best-in-class-per-feature, cosmetic-only
+  monetization), pillars ranked by defensibility, the honest counter-arguments, and the
+  roadmap implication.
+- `docs/ideas/README.md` index entry.
+
+## Status
+
+In progress — born-red. Close-out written as the final step before flipping to `complete`.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,15 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`competitive-positioning-north-star-2026-06-23.md`](./competitive-positioning-north-star-2026-06-23.md) —
+  **owner-directed (2026-06-23):** follow-up to the Dank Memer visual work — *"what would make people prefer
+  ours over any other bot?"* Grounded in a fan-out research pass across 15+ bots (Dank Memer, UnbelievaBoat,
+  MEE6, Carl-bot, Dyno, ProBot, Wick, Tatsu, Lurkr, Amari, Pokétwo/PokéMeow, OwO, Mudae, IdleRPG, Sapphire +
+  an AI-native/market-gaps synthesis). Finding: **four failure modes recur in nearly every incumbent** —
+  utility paywalls (the MEE6 backlash), pay-to-win, setup friction, and jack-of-all-trades mediocrity. Our
+  wedge: the **AI-operated, best-in-class-per-feature all-in-one with cosmetic-only monetization by promise**.
+  Pillars ranked by defensibility + the honest counter-arguments (the "specialize-as-you-grow" objection; the
+  AI-setup lane is now contested; Discord's 2026 gambling headwind). Product-positioning north-star. Subsystem: none.
 - [`visual-card-engine-vision-2026-06-23.md`](./visual-card-engine-vision-2026-06-23.md) —
   **owner-directed (2026-06-23):** the maintainer shared a Dank Memer fishing season-card screenshot and
   asked us to enumerate DM's commands/functions, dissect its *visual* approach, and plan how to **beat** it.

--- a/docs/ideas/competitive-positioning-north-star-2026-06-23.md
+++ b/docs/ideas/competitive-positioning-north-star-2026-06-23.md
@@ -1,0 +1,141 @@
+# Vision: competitive positioning — what makes people choose us over any other bot
+
+> **Status:** `ideas` (north-star positioning) — not approval, not a plan, not a spec. A captured
+> strategy to steer future sessions. Binding contracts, source, and owner decisions win over
+> anything here. **Subsystem:** none (cross-cutting product positioning).
+
+**Captured:** 2026-06-23 (owner-directed follow-up to the Dank Memer visual work: *"what would make
+people prefer ours over any other?"*). Grounded in a fan-out competitive-research pass across 15+
+bots — economy/games (Dank Memer, UnbelievaBoat, IdleRPG, Pokétwo/PokéMeow, OwO, Mudae),
+leveling/engagement (MEE6, Arcane, Amari, Tatsu, Lurkr), moderation/all-in-one (Carl-bot, Dyno,
+ProBot, Wick, Sapphire), plus an AI-native + market-gaps synthesis. Sources are in the research
+transcripts; the load-bearing claims are cited inline below.
+
+## The one-line thesis
+
+**Be the AI-*operated*, genuinely best-in-class-per-feature all-in-one whose monetization is
+cosmetic-only by explicit promise** — inverting, in one product, the three failures every incumbent
+shares. Visuals and breadth get us *compared*; this is what makes people *switch*.
+
+## The market read: four failure modes every incumbent shares
+
+The striking finding across the whole field is how *consistent* the complaints are. Four patterns
+recur in nearly every bot, and each is an opening:
+
+1. **Utility paywalls / retroactive monetization (the trust-killer).** The single most damaging,
+   most-repeated grievance.
+   - **MEE6** progressively moved once-free core features (role rewards, custom commands, leveling
+     config, reaction-role capacity) behind an ~$11.95/mo, *per-server* paywall — "more than Discord
+     Nitro itself." It spawned an entire migration movement (`alternativestomee6.com`) and durable
+     "cash grab" / "greed" sentiment (Trustpilot, Medium "Why People Hate MEE6"). The leveling case
+     is the sharpest: *role rewards are the entire point of an XP system, and they're premium* — so
+     "free" leveling feels hollow.
+   - **ProBot** retroactively made leveling premium, **reset members' levels**, and reportedly
+     **deleted data** for servers that didn't pay — the purest bait-and-switch in the set.
+   - **UnbelievaBoat** switched Premium from one-time to subscription in 2025 and **froze legacy
+     buyers out** of new perks; its 25-item free cap is the standing functional gripe.
+   - **Amari / Tatsu** quietly move cosmetics (rank cards, backgrounds) and conveniences behind a
+     supporter tier.
+   - **The lesson:** the damage comes specifically from **paywalling utility users already
+     depended on**. That breeds the "they took what I had" narrative and active migration.
+
+2. **Pay-to-win resentment (the fairness-killer).** In every game bot where money buys *advantage*
+   rather than *cosmetics*, it's the top complaint: PokéMeow ("incredibly pay-to-win… practically
+   locked out without Patreon"), Pokétwo (incense/shiny-charm "hidden-paywall feel"), Mudae
+   (premium rolls/kakera/lower claim thresholds), IdleRPG (paid adventure-cooldown cuts + a
+   donor-exclusive class), Tatsu (5× credit-exchange cap for supporters). **The praised
+   counter-example proves the rule:** OwO's Patreon perks are *tradeable* to free players, so the
+   community calls the model **fair**. Cosmetic/tradeable = accepted; advantage-for-cash = resented.
+
+3. **Setup / onboarding friction (the adoption-killer).** The highest-confidence *unsolved* gap.
+   - Carl-bot is "powerful but an admin console" — JSON embeds, "hours of reading docs," the
+     steepest learning curve. YAGPDB is worse. UnbelievaBoat's item→role linking is "the hardest
+     part for beginners." IdleRPG's `$help` is "too long to grasp." Amari has silent
+     permission/`AmariMod`-role failure modes.
+   - The structural pain is **multiple dashboards** — "four dashboards and four points of failure"
+     to assemble mod + roles + leveling + economy from specialists.
+   - MEE6/ProBot win precisely on *ease* — and MEE6 then weaponizes that ease to upsell. Easy
+     onboarding is clearly what new owners reward; nobody pairs it with depth *and* honesty.
+
+4. **Jack-of-all-trades mediocrity (the all-in-one trap).** "All-in-one" is **already claimed by
+   MEE6 and tainted**, and the strongest *independent* counter-thesis (CommunityOne) says mature
+   servers should **deliberately specialize as they grow** because all-in-ones "don't excel in any
+   particular area." Any all-in-one pitch must answer this objection head-on, not ignore it.
+
+Two cross-cutting trust themes sit underneath: **privacy/data** (the "third-party bots vacuum your
+messages into a data lake" unease; MEE6's NFT-email + OAuth-scope dings) and **reliability/permanence**
+(the music-bot graveyard — Rythm/Groovy killed overnight; Pokécord's shutdown; IdleRPG's abandoned
+servers). Neither wins an install on its own, but both *lose* trust when breached.
+
+## Our wedge: invert all four at once
+
+We are unusually positioned to attack all four because of what the bot already is (per the codebase
+audit): broad (economy/games + mod/automod + logging + roles + XP + **native AI** + knowledge
+systems), tested, audited, with a setup wizard and now a themeable visual card engine.
+
+**The positioning, pillar by pillar (ranked by defensibility × evidence confidence):**
+
+- **Pillar 1 — Cosmetic-only monetization, as a stated promise. [highest confidence]**
+  *"We will never paywall a feature you rely on."* The MEE6 backlash is direct market validation
+  that this is a *positioning wedge*, not just an ethic: it sidesteps the exact failure mode that
+  spawns migration movements. Charge only for non-functional cosmetics — card themes, embed colours,
+  vanity flair, profile backgrounds (the engine from #1349 is the delivery vehicle). No
+  "alternativesto-us.com" can ever form. This is the cheapest, most credible differentiator and it
+  costs us nothing we'd otherwise sell.
+
+- **Pillar 2 — AI-as-*operator*, not AI-as-chatbot. [high confidence, execution-dependent]**
+  Be careful here: the "bolted-on GPT chatbot" lane is **crowded and shallow**, and Discord's own
+  first-party Clyde AI was launched and **killed within a year** — users don't want a chatbot
+  stapled on. The genuinely open lane is **AI that operates the bot**: *"describe your server, it
+  configures itself"* (channels, roles, automod, welcome flow from one sentence — our wizard + AI),
+  natural-language admin (*"mute anyone posting crypto links"*), and context-aware moderation that
+  understands nuance instead of keyword lists. A few tiny 2026 startups (PeakBot, VibeBot) *claim*
+  this ground but are unproven (thousands of servers vs. incumbents' millions) and no
+  millions-of-servers incumbent is AI-native in this deep sense. The lane is open but **the win is
+  depth + execution, not the label "AI bot."**
+
+- **Pillar 3 — Best-in-class *per feature*, not merely bundled. [medium — this is the objection to beat]**
+  The all-in-one pitch only works if each surface is genuinely good — directly answering the
+  "specialize as you grow" critique. Concretely: free role rewards (the thing MEE6 paywalls),
+  Carl-bot-grade reaction roles, Dyno-grade automod, real leveling — all free, all in one bot.
+  Discipline: **every surface we ship should feel finished, or it drags the whole bot's perceived
+  quality down.** Breadth-without-polish is our main self-inflicted risk.
+
+- **Pillar 4 — Trust as a retention moat: permanence + transparent data posture. [medium]**
+  Owner-controlled, you-don't-lose-it-overnight (the music-bot lesson), a real privacy policy, and —
+  because we're AI-native — **proactive transparency about what gets sent to the LLM** (a first-order
+  trust problem for any AI bot, and a cheap differentiator while incumbents' trust is already dinged).
+
+- **Pillar 5 — One identity across everything. [retention engine]**
+  A single player identity (one level, one profile, cosmetics that show across fishing/mining/games,
+  a season pass spanning all of them) is stickier than any single minigame — and Tatsu's *global*
+  economy shows the failure mode to avoid (it "dilutes *your* server"); keep identity unified but
+  let engagement stay server-meaningful.
+
+## The honest counter-arguments (design against these, don't ignore them)
+
+- **"Specialize as you grow" is a real, independent thesis.** Large servers may deliberately
+  fragment toward specialists. Our answer must be genuine per-feature quality, not a bundle discount.
+- **The AI-setup lane is no longer empty.** First-mover advantage is partly gone; PeakBot/VibeBot
+  are pitching the same "one install replaces 4 bots." We win on execution/depth or not at all.
+- **Gambling/economy headwind.** Discord's 2026 teen-safety/age-gating push targets gambling
+  mechanics; an economy bot leaning on casino loops inherits regulatory + reputational risk. Favour
+  collection/progression depth over slot-machine dopamine.
+- **Vendor-blog bias.** Much of the "AI-native is the future" content is the marketing of the bots
+  selling it. Treat the *demand* as unproven and validate with real users before over-investing.
+
+## What this means for the roadmap
+
+This doc doesn't approve features; it sets the lens. Concretely it argues future work should bias
+toward: **(a)** finishing the visual/cosmetic layer as the monetization vehicle (the card-engine
+roadmap H2–H5); **(b)** the **AI-setup wedge** as the headline "whoa" capability (prototype:
+"describe your server, it configures itself" on the existing wizard + AI); **(c)** making each
+already-present surface best-in-class and free where incumbents paywall it (role rewards first);
+and **(d)** a stated **cosmetic-only monetization principle** somewhere user-visible. Lead marketing
+with AI-operation + the no-paywall promise; let breadth and visuals close the comparison.
+
+## Related
+
+- `docs/ideas/visual-card-engine-vision-2026-06-23.md` (the visual half — cosmetic monetization vehicle)
+- `docs/ideas/superbot-vision-2026-06-10.md` (the 2-minute-setup product vision this sharpens)
+- `.sessions/2026-06-23-competitive-positioning.md` (research provenance + the per-bot findings)

--- a/docs/owner/claims/claude__competitive-positioning.md
+++ b/docs/owner/claims/claude__competitive-positioning.md
@@ -1,0 +1,1 @@
+claude/competitive-positioning · competitive-differentiation positioning vision doc (docs-only) · `docs/ideas/`, `.sessions/` · 2026-06-23

--- a/docs/owner/claims/claude__competitive-positioning.md
+++ b/docs/owner/claims/claude__competitive-positioning.md
@@ -1,1 +1,0 @@
-claude/competitive-positioning · competitive-differentiation positioning vision doc (docs-only) · `docs/ideas/`, `.sessions/` · 2026-06-23


### PR DESCRIPTION
## Why

Follow-up to the Dank Memer visual work (#1349, merged). The owner asked the broader question — not "beat Dank Memer's visuals" but **"what would make people prefer ours over any other bot."** This captures the answer as a durable north-star positioning doc, grounded in a fan-out competitive-research pass (15+ bots across economy/games, leveling/engagement, and moderation/all-in-one, plus an AI-native + market-gaps synthesis).

## What this PR does (docs-only)

- `docs/ideas/competitive-positioning-north-star-2026-06-23.md` — the grounded thesis:
  - the **universal incumbent failure modes** (utility paywalls · pay-to-win · setup friction · jack-of-all-trades mediocrity),
  - our **wedge** (AI-*operated*, best-in-class-per-feature all-in-one, **cosmetic-only monetization by promise**),
  - differentiation pillars ranked by **defensibility + evidence confidence**,
  - the honest counter-arguments (the "specialize as you grow" objection; the AI-setup lane is now contested by early startups; Discord's 2026 gambling policy headwind),
  - the roadmap implication.
- `docs/ideas/README.md` index entry.

No runtime/`disbot/` code. Born-red per Q-0133; auto-merges on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzBMYDtbYx95WgeWPggWJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzBMYDtbYx95WgeWPggWJj)_