### PR TITLE
AI natural-language setup wedge (/setup-describe)

### DIFF
--- a/.sessions/2026-06-23-ai-setup-wedge.md
+++ b/.sessions/2026-06-23-ai-setup-wedge.md
@@ -1,8 +1,8 @@
 # 2026-06-23 — AI natural-language setup wedge (`/setup-describe`)
 
-> **Status:** `in-progress` — born-red card (Q-0133). Flip to `complete` as the final step.
+> **Status:** `complete` — born-red card (Q-0133) flipped green as the final step.
 > Owner-directed (chat: "continue from where you left off" → the AI-setup wedge I teed up after the
-> positioning doc named it the highest-leverage next build). PR auto-merges on green (Q-0123).
+> positioning doc named it the highest-leverage next build). PR #1355 auto-merges on green (Q-0123).
 
 ## Arc
 
@@ -33,6 +33,65 @@ This PR adds exactly that, reusing everything else.
 apply seam, applied only on explicit operator confirmation. Resource *creation* (vs binding existing
 channels/roles) stays a follow-up (the recommendation schema is binding-only today).
 
-## Status
+## Shipped (PR #1355)
 
-In progress — born-red. Close-out written as the final step before flipping to `complete`.
+- **`services/setup_ai_advisor.py`** — `OpenAISetupAdvisor` gained `suggest_with_description` and a
+  shared private `_run(snapshot, *, description)`; `suggest` now delegates to `_run(description=None)`
+  (existing callers `setup_advisor_review` / `launcher` unchanged). When a description is present it
+  appends `_DESCRIPTION_DIRECTIVE` to the system prompt and adds `operator_description` to the
+  payload; everything else (schema, `_validate_ai_payload`, gateway, degraded handling) is reused.
+- **`services/setup_natural_language_advisor.py`** (new) — `suggest_from_description(snapshot,
+  description, *, advisor=None, provider=None)`: folds the description only when the resolved advisor
+  is the OpenAI adapter and the text is non-empty; otherwise plain snapshot-only `suggest` (the
+  deterministic fallback can't use free text → description dropped, never faked). `draft.source`
+  reports which path ran.
+- **`cogs/setup/_describe_entry.py`** (new) — slash + prefix entry points: snapshot → advisor → open
+  the existing `AIReviewPanelView` (accept → `operations_from_recommendations` → audited Final Review
+  apply). Fail-safe (`collect`/advisor errors → friendly note), bounded description (600 chars),
+  `safe_defer` for the LLM round-trip, and a "AI not configured, names used instead" note when the
+  plan came from the deterministic fallback.
+- **`cogs/setup_cog.py`** — `/setup-describe <description>` + `!setupdescribe` (alias `describesetup`),
+  admin-gated, thin delegators.
+- **Tests:** `tests/unit/services/test_setup_natural_language_advisor.py` (4 — fold / blank-skip /
+  deterministic-ignores / CI default) + 2 in `test_setup_ai_advisor.py` (folds & still validates ·
+  plain suggest omits the field).
+- **Regenerated:** `dashboard/data/dashboard.json`, `botsite/data/site.json`, `botsite/site/data.js`
+  (commands 386 → 388), `docs/operations/env-vars.md` (line-number citations shifted by the advisor
+  edit). Pinned the new `/setup-describe` slash route in `test_command_surface_ledger`.
+
+## Why it's contained + reversible
+
+No new mutation code: proposals flow into the **existing audited apply seam** and only on explicit
+operator confirmation (`can_apply_setup` still gates Final Review). The advisor stays read-only
+(its no-DB / no-`guild.create_*` invariants still hold). Resource **creation** (vs. binding existing
+resources) is a clean follow-up — the recommendation schema is binding-only today.
+
+## Verification
+
+- `python3.10 -m mypy disbot/` → no issues (821 files); formatters/lint via
+  `check_quality.py --check-only` → all checks passed.
+- `check_architecture --mode strict` → 0 errors (49 pre-existing warnings).
+- Targeted: 111 advisor/NL/setup-cog tests + the 145 surface/freshness/defer tests that the new
+  command touched.
+
+## Session enders
+
+- **♻ Grooming (Q-0015):** advanced the AI-setup wedge from the positioning north-star
+  (`competitive-positioning-north-star-2026-06-23.md`, pillar 2) into a shipped first slice; the
+  doc's "AI-as-operator, not chatbot" framing directly shaped scoping (reused the existing audited
+  apply path rather than building a new one).
+- **💡 Session idea (Q-0089):** *Extend the wedge to propose resource **creation** from a
+  description* — today it only binds *existing* channels/roles. Letting the advisor emit
+  `create_channel`/`create_role` recommendations (the `SetupOperation` kinds already exist; only the
+  recommendation JSON schema + a creation adapter are missing) turns "describe your server" into
+  genuinely building it from a sentence — the full "whoa". Contained follow-up; dedup-checked
+  `docs/ideas/`, not yet captured.
+- **⟲ Previous-session review (Q-0102):** the positioning-doc session did well to flag its own
+  honesty caveats (vendor-blog bias; the AI-setup lane is contested) — and this session benefited
+  directly: I scoped to *AI-as-operator over the audited seam*, not a bolted-on chatbot. *Workflow
+  note it surfaced:* the deep research fan-out's nested-agent tangle (flagged last session) recurred
+  conceptually — orientation here used **one** Explore agent (flat), which was clean and fast. Keep
+  research/orientation flat.
+- **📋 Doc audit (Q-0104):** ledger unaffected (PR not merged yet — recorded on merge); generated
+  artifacts regenerated + freshness green; no chat-only conclusions left undocumented (the design
+  + follow-up live in this log).

--- a/.sessions/2026-06-23-ai-setup-wedge.md
+++ b/.sessions/2026-06-23-ai-setup-wedge.md
@@ -1,0 +1,38 @@
+# 2026-06-23 — AI natural-language setup wedge (`/setup-describe`)
+
+> **Status:** `in-progress` — born-red card (Q-0133). Flip to `complete` as the final step.
+> Owner-directed (chat: "continue from where you left off" → the AI-setup wedge I teed up after the
+> positioning doc named it the highest-leverage next build). PR auto-merges on green (Q-0123).
+
+## Arc
+
+The positioning north-star (#1352) named the **AI-setup wedge** — *"describe your server, it
+configures itself"* — as the one capability that's both a genuine "whoa" demo and structurally hard
+for incumbents to retrofit. Orientation found the infrastructure **already largely exists**:
+`services/setup_ai_advisor.OpenAISetupAdvisor` turns a `GuildSnapshot` into a schema-validated
+`SetupPlanDraft`, and `views/setup/ai_review/AIReviewPanelView` renders that draft → accept →
+`operations_from_recommendations` → the audited Final Review apply path. The **only missing piece**
+is a *natural-language input* path — folding the operator's free-form description into that prompt.
+
+This PR adds exactly that, reusing everything else.
+
+## Plan (this PR)
+
+- `OpenAISetupAdvisor.suggest_with_description(snapshot, description)` (+ a shared private `_run`) —
+  folds the operator's description into the prompt/payload; reuses the existing JSON schema,
+  `_validate_ai_payload`, gateway, and degraded handling unchanged.
+- `services/setup_natural_language_advisor.suggest_from_description(...)` — thin entry: builds the
+  configured advisor, uses the description only when the AI advisor is available, else falls back to
+  the deterministic snapshot-only plan (description simply unused, never an error).
+- `cogs/setup/_describe_entry.py` — snapshot → advisor → open the existing `AIReviewPanelView`
+  ephemerally (admin-gated; apply stays gated by `can_apply_setup` inside Final Review).
+- `/setup-describe <description>` + `!setupdescribe` commands in `setup_cog` (thin delegators).
+- Tests for the advisor + the NL entry.
+
+**Contained + reversible:** no new mutation code — the proposal flows into the existing audited
+apply seam, applied only on explicit operator confirmation. Resource *creation* (vs binding existing
+channels/roles) stays a follow-up (the recommendation schema is binding-only today).
+
+## Status
+
+In progress — born-red. Close-out written as the final step before flipping to `complete`.

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-06-23T09:16:14Z",
+    "generated_at": "2026-06-23T09:37:22Z",
     "build": {
-      "commit": "a622a83",
-      "subject": "Competitive-positioning north-star vision doc (what makes people choose us) (#1352)",
-      "committed_at": "2026-06-23T09:16:14Z"
+      "commit": "b6bf85d",
+      "subject": "Open AI natural-language setup wedge session (born-red): claim + card",
+      "committed_at": "2026-06-23T09:37:22Z"
     }
   },
   "counts": {
-    "commands": 386,
+    "commands": 388,
     "features": 41,
     "games": 11
   },
@@ -8773,6 +8773,20 @@
       "notes": null
     },
     {
+      "name": "setup-describe",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Describe your server; the AI proposes a setup plan to review.",
+      "description": "Ephemeral natural-language setup proposal (admin-gated).",
+      "use_cases": null,
+      "examples": [],
+      "status": "finished",
+      "linked_ideas": [],
+      "notes": null
+    },
+    {
       "name": "setup-hub",
       "aliases": [],
       "category": "other",
@@ -8867,6 +8881,22 @@
       "permissions": "",
       "usage": "Remove a section from the skipped set (owner/delegated admin only).",
       "description": "Drop section from the session's skipped_sections set.",
+      "use_cases": null,
+      "examples": [],
+      "status": "finished",
+      "linked_ideas": [],
+      "notes": null
+    },
+    {
+      "name": "setupdescribe",
+      "aliases": [
+        "describesetup"
+      ],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Describe your server in words; propose how to wire it to the bot.",
+      "description": "Describe your server in words; propose how to wire it to the bot.",
       "use_cases": null,
       "examples": [],
       "status": "finished",

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -4725,6 +4725,19 @@ const COMMANDS = [
     "planned": []
   },
   {
+    "name": "setup-describe",
+    "area": "other",
+    "status": "finished",
+    "summary": "Describe your server; the AI proposes a setup plan to review.",
+    "description": "Ephemeral natural-language setup proposal (admin-gated).",
+    "usage": "!setup-describe",
+    "aliases": [],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [],
+    "planned": []
+  },
+  {
     "name": "setup-hub",
     "area": "other",
     "status": "finished",
@@ -4813,6 +4826,21 @@ const COMMANDS = [
     "description": "Drop section from the session's skipped_sections set.",
     "usage": "!setup-unskip",
     "aliases": [],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [],
+    "planned": []
+  },
+  {
+    "name": "setupdescribe",
+    "area": "other",
+    "status": "finished",
+    "summary": "Describe your server in words; propose how to wire it to the bot.",
+    "description": "Describe your server in words; propose how to wire it to the bot.",
+    "usage": "!setupdescribe",
+    "aliases": [
+      "describesetup"
+    ],
     "permissions": "anyone",
     "cooldown": null,
     "examples": [],
@@ -6310,7 +6338,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "a622a83",
+    "build": "b6bf85d",
     "title": "New public bot website",
     "changes": [
       {
@@ -6322,7 +6350,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "a622a83",
+    "build": "b6bf85d",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -6334,7 +6362,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "a622a83",
+    "build": "b6bf85d",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-23T09:16:14Z",
+    "generated_at": "2026-06-23T09:37:22Z",
     "build": {
-      "commit": "a622a83",
-      "subject": "Competitive-positioning north-star vision doc (what makes people choose us) (#1352)",
-      "committed_at": "2026-06-23T09:16:14Z"
+      "commit": "b6bf85d",
+      "subject": "Open AI natural-language setup wedge session (born-red): claim + card",
+      "committed_at": "2026-06-23T09:37:22Z"
     },
     "counts": {
       "functions": 41,
@@ -15,7 +15,7 @@
       "updates": 60,
       "env_vars": 38,
       "cogs": 51,
-      "commands": 386,
+      "commands": 388,
       "setting_keys": 107,
       "setting_domains": 16,
       "typed_settings": 88,
@@ -2389,6 +2389,14 @@
       "self_initiated": false
     },
     {
+      "file": "2026-06-23-reconcile.md",
+      "date": "2026-06-23",
+      "title": "2026-06-23 — Docs reconciliation pass (band-#1350, Q-0107)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": false
+    },
+    {
       "file": "2026-06-23-new-subsystem-checker-gaps.md",
       "date": "2026-06-23",
       "title": "Session — 2026-06-23 · Close the new-subsystem checker's blind spots",
@@ -2491,6 +2499,14 @@
       "status": "complete",
       "run_type": "routine",
       "self_initiated": true
+    },
+    {
+      "file": "2026-06-23-ai-setup-wedge.md",
+      "date": "2026-06-23",
+      "title": "2026-06-23 — AI natural-language setup wedge (`/setup-describe`)",
+      "status": "in-progress",
+      "run_type": "",
+      "self_initiated": false
     },
     {
       "file": "2026-06-22-unattended-fit-dispatch-dimension.md",
@@ -2842,22 +2858,6 @@
       "title": "2026-06-22 — Bulk role creation enhancements",
       "status": "complete",
       "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-22-bug0023-slash-scan-coverage.md",
-      "date": "2026-06-22",
-      "title": "2026-06-22 — BUG-0023 root fix: scanner discovers `app_commands.Group` attribute slash commands",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-06-22-bug-0024-dashboard-flake.md",
-      "date": "2026-06-22",
-      "title": "2026-06-22 — BUG-0024: make the dashboard `generated_at` determinism test hermetic",
-      "status": "complete",
-      "run_type": "manual",
       "self_initiated": false
     }
   ],
@@ -3428,13 +3428,13 @@
         },
         {
           "file": "disbot/services/setup_ai_advisor.py",
-          "line": 175,
+          "line": 188,
           "layer": "services",
           "has_default": true
         },
         {
           "file": "disbot/services/setup_ai_advisor.py",
-          "line": 406,
+          "line": 447,
           "layer": "services",
           "has_default": true
         }
@@ -3519,7 +3519,7 @@
         },
         {
           "file": "disbot/services/setup_ai_advisor.py",
-          "line": 173,
+          "line": 186,
           "layer": "services",
           "has_default": true
         }
@@ -3549,7 +3549,7 @@
         },
         {
           "file": "disbot/services/setup_ai_advisor.py",
-          "line": 393,
+          "line": 434,
           "layer": "services",
           "has_default": true
         }
@@ -7973,6 +7973,17 @@
           "button_backed": false
         },
         {
+          "name": "setup-describe",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Describe your server; the AI proposes a setup plan to review.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
           "name": "setup-hub",
           "type": "slash",
           "is_group": false,
@@ -8034,6 +8045,19 @@
           "parent": null,
           "aliases": [],
           "brief": "Remove a section from the skipped set (owner/delegated admin only).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "setupdescribe",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "describesetup"
+          ],
+          "brief": "Describe your server in words; propose how to wire it to the bot.",
           "classification": "",
           "has_panel": false,
           "button_backed": false

--- a/disbot/cogs/setup/_describe_entry.py
+++ b/disbot/cogs/setup/_describe_entry.py
@@ -1,0 +1,162 @@
+"""Entry points for ``/setup-describe`` and ``!setupdescribe`` — the
+natural-language setup wedge.
+
+Both invocations route through the same flow: collect the live guild snapshot,
+ask the configured advisor for a plan *informed by the operator's free-form
+description*
+(:func:`services.setup_natural_language_advisor.suggest_from_description`), and
+open the existing :class:`views.setup.ai_review.main_panel.AIReviewPanelView`
+so the operator reviews → accepts → applies through the audited Final Review
+path. Nothing is created or changed here; this surface only *proposes*.
+
+Extracted from :mod:`cogs.setup_cog` to keep the cog file under the 800-LOC
+ceiling, matching the sibling :mod:`cogs.setup._wizard_entry`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord.ext import commands
+
+logger = logging.getLogger("bot.cogs.setup.describe_entry")
+
+# Keep the free-form description bounded so an accidental paste can't bloat the
+# prompt payload; the wedge only needs a sentence or two of intent.
+_MAX_DESCRIPTION = 600
+
+_EMPTY_HINT = (
+    "Describe your server in a sentence or two and I'll propose how to wire it "
+    "up — e.g. `a small gaming community; #mod-logs is for moderation logging "
+    "and #welcome greets new members`."
+)
+
+# Shown when a description was given but the AI advisor isn't configured, so the
+# plan came from deterministic name-matching and the description went unused.
+_DETERMINISTIC_NOTE = (
+    "ℹ️ AI isn't configured on this instance, so I matched by channel and role "
+    "**names** instead — your description wasn't used. The suggestions below are "
+    "still safe to review and apply."
+)
+
+
+async def _build_draft_and_note(
+    guild: discord.Guild,
+    description: str,
+):  # noqa: ANN202 — returns (draft | None, snapshot | None, note)
+    """Collect a snapshot and build a description-informed plan.
+
+    Fail-safe: any snapshot/advisor error is logged and returned as
+    ``(None, None, message)`` so the caller shows a friendly note instead of
+    raising. Returns ``(draft, snapshot, note)`` on success, where *note* is an
+    optional one-line caption for the reply.
+    """
+    from services import guild_snapshot
+    from services.setup_natural_language_advisor import suggest_from_description
+
+    try:
+        snapshot = await guild_snapshot.collect(guild)
+    except Exception:
+        logger.exception("setup-describe: snapshot collect failed")
+        return None, None, "I couldn't read this server's state to build a plan."
+
+    try:
+        draft = await suggest_from_description(snapshot, description)
+    except Exception:
+        logger.exception("setup-describe: advisor failed")
+        return None, None, "The setup advisor couldn't produce a plan right now."
+
+    note = _DETERMINISTIC_NOTE if draft.source != "openai" else None
+    return draft, snapshot, note
+
+
+def _clean_description(raw: str) -> str:
+    return (raw or "").strip()[:_MAX_DESCRIPTION]
+
+
+async def open_describe_from_slash(
+    interaction: discord.Interaction,
+    description: str,
+) -> None:
+    """Slash entry point. Ephemeral throughout."""
+    guild = interaction.guild
+    member = interaction.user
+    if guild is None or not isinstance(member, discord.Member):
+        await interaction.response.send_message(
+            "Use `/setup-describe` from inside the server.",
+            ephemeral=True,
+        )
+        return
+
+    text = _clean_description(description)
+    if not text:
+        await interaction.response.send_message(_EMPTY_HINT, ephemeral=True)
+        return
+
+    # Snapshot + (possibly) an LLM round-trip can exceed the 3s ack window.
+    from core.runtime.interaction_helpers import safe_defer
+
+    if not await safe_defer(interaction, ephemeral=True, thinking=True):
+        return
+    draft, snapshot, note = await _build_draft_and_note(guild, text)
+    if draft is None:
+        await interaction.followup.send(
+            note or "Couldn't build a plan.",
+            ephemeral=True,
+        )
+        return
+
+    from views.setup.ai_review.main_panel import (
+        AIReviewPanelView,
+        build_ai_review_embed,
+    )
+
+    view = AIReviewPanelView(member, draft=draft, snapshot=snapshot)
+    message = await interaction.followup.send(
+        content=note,
+        embed=build_ai_review_embed(draft),
+        view=view,
+        ephemeral=True,
+        wait=True,
+    )
+    view.message = message
+
+
+async def open_describe_from_prefix(
+    ctx: commands.Context,
+    description: str,
+) -> None:
+    """Prefix entry point. Posts in the invoking channel (no ephemerals)."""
+    guild = ctx.guild
+    member = ctx.author
+    if guild is None or not isinstance(member, discord.Member):
+        await ctx.send("Run `!setupdescribe` from inside the server.")
+        return
+
+    text = _clean_description(description)
+    if not text:
+        await ctx.send(_EMPTY_HINT)
+        return
+
+    async with ctx.typing():
+        draft, snapshot, note = await _build_draft_and_note(guild, text)
+    if draft is None:
+        await ctx.send(note or "Couldn't build a plan.")
+        return
+
+    from views.setup.ai_review.main_panel import (
+        AIReviewPanelView,
+        build_ai_review_embed,
+    )
+
+    view = AIReviewPanelView(member, draft=draft, snapshot=snapshot)
+    message = await ctx.send(
+        content=note,
+        embed=build_ai_review_embed(draft),
+        view=view,
+    )
+    view.message = message
+
+
+__all__ = ["open_describe_from_prefix", "open_describe_from_slash"]

--- a/disbot/cogs/setup_cog.py
+++ b/disbot/cogs/setup_cog.py
@@ -110,6 +110,46 @@ class SetupCog(commands.Cog):
 
         await open_wizard_from_slash(interaction)
 
+    @commands.command(name="setupdescribe", aliases=["describesetup"])
+    @commands.guild_only()
+    @commands.has_permissions(administrator=True)
+    async def setup_describe_cmd(
+        self,
+        ctx: commands.Context,
+        *,
+        description: str = "",
+    ) -> None:
+        """Describe your server in words; propose how to wire it to the bot.
+
+        Natural-language setup wedge: the configured advisor reads your
+        description **and** the live server, then proposes which channels/roles
+        bind to which subsystems. Read-only — nothing changes until you accept
+        and apply in the review panel (still gated by setup access).
+        """
+        from cogs.setup._describe_entry import open_describe_from_prefix
+
+        await open_describe_from_prefix(ctx, description)
+
+    @app_commands.command(
+        name="setup-describe",
+        description="Describe your server; the AI proposes a setup plan to review.",
+    )
+    @app_commands.describe(
+        description="What your server is for and how it's organised.",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.guild_only()
+    async def setup_describe_slash(
+        self,
+        interaction: discord.Interaction,
+        description: str,
+    ) -> None:
+        """Ephemeral natural-language setup proposal (admin-gated)."""
+        from cogs.setup._describe_entry import open_describe_from_slash
+
+        await open_describe_from_slash(interaction, description)
+
     @app_commands.command(
         name="setup-hub",
         description="Open the legacy section-list hub (compat).",

--- a/disbot/services/setup_ai_advisor.py
+++ b/disbot/services/setup_ai_advisor.py
@@ -149,6 +149,19 @@ _SYSTEM_PROMPT = (
     "rather than guessing."
 )
 
+# Appended to the system prompt when the operator supplies a free-form
+# description of their server (the natural-language setup wedge). The
+# description adds *intent* the channel names alone can't convey, but it must
+# never widen the mutation surface — every recommendation is still re-validated
+# against the subsystem schema, so an off-schema suggestion is dropped.
+_DESCRIPTION_DIRECTIVE = (
+    " The operator has ALSO described, in their own words, what their server is "
+    "for and how it is organised (field `operator_description`). Use that intent "
+    "to choose better bindings — it can disambiguate a channel whose name is not "
+    "self-explanatory. You still must NEVER invent a subsystem, binding, or "
+    "target kind that is absent from the snapshot."
+)
+
 
 class OpenAISetupAdvisor:
     """OpenAI structured-output adapter.
@@ -183,9 +196,37 @@ class OpenAISetupAdvisor:
             )
 
     async def suggest(self, snapshot: GuildSnapshot) -> SetupPlanDraft:
+        return await self._run(snapshot, description=None)
+
+    async def suggest_with_description(
+        self,
+        snapshot: GuildSnapshot,
+        description: str,
+    ) -> SetupPlanDraft:
+        """Like :meth:`suggest`, but folds the operator's free-form
+        description of the server into the prompt — the natural-language
+        setup wedge. Consumed by
+        :mod:`services.setup_natural_language_advisor`. The description only
+        adds intent signal; recommendations are still re-validated against the
+        subsystem schema, so it can never widen the mutation surface.
+        """
+        return await self._run(snapshot, description=description)
+
+    async def _run(
+        self,
+        snapshot: GuildSnapshot,
+        *,
+        description: str | None,
+    ) -> SetupPlanDraft:
         provider_override = None
         if self._client is not None:
             provider_override = OpenAIProvider(client=self._client)
+
+        system_prompt = _SYSTEM_PROMPT
+        payload = _snapshot_to_prompt(snapshot)
+        if description:
+            system_prompt = _SYSTEM_PROMPT + _DESCRIPTION_DIRECTIVE
+            payload = {**payload, "operator_description": description}
 
         request = AIRequest(
             context=AIRequestContext(
@@ -194,8 +235,8 @@ class OpenAISetupAdvisor:
                 guild_id=snapshot.guild_id,
                 source="setup_ai_advisor",
             ),
-            system_prompt=_SYSTEM_PROMPT,
-            payload=_snapshot_to_prompt(snapshot),
+            system_prompt=system_prompt,
+            payload=payload,
             mode=AIResponseMode.JSON,
             response_schema=_RECOMMENDATION_JSON_SCHEMA,
             # Multi-recommendation plans can be large; give the structured

--- a/disbot/services/setup_natural_language_advisor.py
+++ b/disbot/services/setup_natural_language_advisor.py
@@ -1,0 +1,60 @@
+"""Natural-language setup wedge — "describe your server, get a proposed plan".
+
+The thin entry that folds an operator's free-form server description into the
+existing setup-advisor pipeline (:mod:`services.setup_ai_advisor`). It reuses
+that pipeline's structured output + subsystem-schema validation + deterministic
+fallback wholesale: the description only adds *intent* signal to the prompt; it
+can never extend the mutation surface, because every recommendation is still
+re-validated against the live subsystem schema before it surfaces.
+
+Graceful degradation mirrors the rest of the AI stack. With no OpenAI key
+(CI / the default ``SETUP_ADVISOR_PROVIDER=deterministic``), :func:`build_advisor`
+returns the deterministic name-matcher, which cannot reason about free text — so
+the description is simply unused and the snapshot-only plan is returned. A bad
+provider, missing key, or advisor error never raises into the caller.
+
+Layering: ``services`` may import ``services`` / ``core`` / ``utils`` /
+``governance``. This module imports only sibling services, so it stays clear of
+the views/cogs layers (the command surface lives in ``cogs/setup``).
+"""
+
+from __future__ import annotations
+
+from services.guild_snapshot import GuildSnapshot
+from services.setup_ai_advisor import (
+    OpenAISetupAdvisor,
+    SetupAdvisor,
+    build_advisor,
+)
+from services.setup_plan import SetupPlanDraft
+
+
+async def suggest_from_description(
+    snapshot: GuildSnapshot,
+    description: str,
+    *,
+    advisor: SetupAdvisor | None = None,
+    provider: str | None = None,
+) -> SetupPlanDraft:
+    """Produce a setup plan from a guild snapshot plus a free-form description.
+
+    *advisor* is injectable for tests; otherwise the configured advisor is
+    resolved via :func:`services.setup_ai_advisor.build_advisor`. When the
+    resolved advisor is the OpenAI adapter and a non-empty description is
+    given, the description is folded into the prompt
+    (:meth:`OpenAISetupAdvisor.suggest_with_description`); otherwise the plain
+    snapshot-only :meth:`~SetupAdvisor.suggest` runs — the deterministic
+    fallback has no way to use free text, so the description is dropped rather
+    than faked.
+
+    Returns a :class:`SetupPlanDraft`; whether the description was actually
+    used is observable via ``draft.source`` (``"openai"`` vs ``"deterministic"``).
+    """
+    text = (description or "").strip()
+    resolved = advisor if advisor is not None else build_advisor(provider)
+    if isinstance(resolved, OpenAISetupAdvisor) and text:
+        return await resolved.suggest_with_description(snapshot, text)
+    return await resolved.suggest(snapshot)
+
+
+__all__ = ["suggest_from_description"]

--- a/docs/operations/env-vars.md
+++ b/docs/operations/env-vars.md
@@ -55,12 +55,12 @@ only — never a value**; the values live in Railway service variables
 | `HEALTH_PORT` | healthserver | `disbot/healthserver.py:64` *(default)* |
 | `IDENTITY_CONTRACT_STRICT` | bot1 | `disbot/bot1.py:175` *(default)* |
 | `LOG_LEVEL` | config | `disbot/config.py:114` *(default)* |
-| `OPENAI_API_KEY` | config, core, services | `disbot/config.py:150` *(default)*<br>`disbot/core/runtime/ai/providers/openai_moderation.py:68` *(default)*<br>`disbot/core/runtime/ai/providers/openai_provider.py:74` *(default)*<br>`disbot/services/setup_ai_advisor.py:175` *(default)*<br>`disbot/services/setup_ai_advisor.py:406` *(default)* |
+| `OPENAI_API_KEY` | config, core, services | `disbot/config.py:150` *(default)*<br>`disbot/core/runtime/ai/providers/openai_moderation.py:68` *(default)*<br>`disbot/core/runtime/ai/providers/openai_provider.py:74` *(default)*<br>`disbot/services/setup_ai_advisor.py:188` *(default)*<br>`disbot/services/setup_ai_advisor.py:447` *(default)* |
 | `PARAGON_API_BASE_URL` | config, services | `disbot/config.py:177` *(default)*<br>`disbot/services/paragon_service.py:49` *(default)* |
 | `PARAGON_API_KEY` | config, services | `disbot/config.py:181` *(default)*<br>`disbot/services/paragon_service.py:50` *(default)* |
 | `RAILWAY_GIT_COMMIT_SHA` | core | `disbot/core/runtime/command_manifest.py:243` *(default)* |
-| `SETUP_ADVISOR_OPENAI_MODEL` | config, services | `disbot/config.py:149` *(default)*<br>`disbot/services/setup_ai_advisor.py:173` *(default)* |
-| `SETUP_ADVISOR_PROVIDER` | config, core, services | `disbot/config.py:148` *(default)*<br>`disbot/core/runtime/ai/feature_flags.py:129` *(default)*<br>`disbot/services/setup_ai_advisor.py:393` *(default)* |
+| `SETUP_ADVISOR_OPENAI_MODEL` | config, services | `disbot/config.py:149` *(default)*<br>`disbot/services/setup_ai_advisor.py:186` *(default)* |
+| `SETUP_ADVISOR_PROVIDER` | config, core, services | `disbot/config.py:148` *(default)*<br>`disbot/core/runtime/ai/feature_flags.py:129` *(default)*<br>`disbot/services/setup_ai_advisor.py:434` *(default)* |
 | `STRICT_DISABLED` | bot1 | `disbot/bot1.py:172` *(default)* |
 
 <!-- END GENERATED — everything below is hand-maintained (web-tier env vars the disbot scanner can't see); the scanner preserves it across --write-doc. -->

--- a/docs/owner/claims/claude__ai-setup-plan.md
+++ b/docs/owner/claims/claude__ai-setup-plan.md
@@ -1,1 +1,0 @@
-claude/ai-setup-plan · AI natural-language setup wedge (`/setup-describe`) · `disbot/services/setup_natural_language_advisor.py`, `disbot/services/setup_ai_advisor.py`, `disbot/cogs/setup/_describe_entry.py`, `disbot/cogs/setup_cog.py` · 2026-06-23

--- a/docs/owner/claims/claude__ai-setup-plan.md
+++ b/docs/owner/claims/claude__ai-setup-plan.md
@@ -1,0 +1,1 @@
+claude/ai-setup-plan · AI natural-language setup wedge (`/setup-describe`) · `disbot/services/setup_natural_language_advisor.py`, `disbot/services/setup_ai_advisor.py`, `disbot/cogs/setup/_describe_entry.py`, `disbot/cogs/setup_cog.py` · 2026-06-23

--- a/tests/unit/runtime/test_command_surface_ledger.py
+++ b/tests/unit/runtime/test_command_surface_ledger.py
@@ -1048,6 +1048,7 @@ EXPECTED_SLASH_SURFACE: dict[str, str | None] = {
     "setup": None,
     "setup-delegate": None,
     "setup-depth": None,
+    "setup-describe": None,  # natural-language setup wedge
     "setup-hub": "legacy_duplicate",  # FIND-B07: explicit compat UI
     "setup-reset": None,
     "setup-skip": None,

--- a/tests/unit/services/test_setup_ai_advisor.py
+++ b/tests/unit/services/test_setup_ai_advisor.py
@@ -365,6 +365,60 @@ async def test_openai_advisor_handles_empty_response():
     assert any("empty response" in r for r in draft.dropped)
 
 
+@pytest.mark.asyncio
+async def test_suggest_with_description_folds_and_still_validates(_logging_schema):
+    """``suggest_with_description`` produces the same validated output as
+    ``suggest`` AND forwards the operator's words into the provider call."""
+    payload = {
+        "recommendations": [
+            {
+                "subsystem": "logging",
+                "binding_name": "mod_channel",
+                "target_kind": "channel",
+                "target_id": 100,
+                "target_name": "mod-log",
+                "confidence": "high",
+                "reason": "the operator said this is their moderation log",
+            },
+        ],
+    }
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(
+        return_value=_fake_openai_response(payload),
+    )
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    draft = await advisor.suggest_with_description(
+        _snap(),
+        "this is a moderation-heavy server; mod-log is for mod actions",
+    )
+
+    assert len(draft.recommendations) == 1
+    assert draft.recommendations[0].binding_name == "mod_channel"
+    sent = str(fake_client.chat.completions.create.call_args)
+    assert "operator_description" in sent
+    assert "moderation-heavy server" in sent
+
+
+@pytest.mark.asyncio
+async def test_suggest_without_description_omits_operator_field(_logging_schema):
+    """Plain ``suggest`` must not leak an ``operator_description`` field."""
+    fake_client = MagicMock()
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = AsyncMock(
+        return_value=_fake_openai_response({"recommendations": []}),
+    )
+
+    advisor = OpenAISetupAdvisor(client=fake_client, api_key="sk-test")
+    await advisor.suggest(_snap())
+
+    sent = str(fake_client.chat.completions.create.call_args)
+    assert "operator_description" not in sent
+
+
 # ---------------------------------------------------------------------------
 # Module invariants
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_setup_natural_language_advisor.py
+++ b/tests/unit/services/test_setup_natural_language_advisor.py
@@ -1,0 +1,97 @@
+"""Tests for the natural-language setup wedge.
+
+Pins ``suggest_from_description``'s routing:
+
+* an OpenAI advisor + a non-empty description folds the description into the
+  prompt (``operator_description`` + the text reach the provider call);
+* an empty/whitespace description does NOT fold (plain snapshot-only suggest);
+* a non-OpenAI (deterministic) advisor ignores the description entirely;
+* with no injected advisor it builds the configured one (deterministic in CI).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.guild_snapshot import GuildSnapshot
+from services.setup_ai_advisor import OpenAISetupAdvisor
+from services.setup_natural_language_advisor import suggest_from_description
+from services.setup_plan import DeterministicAdvisor, SetupPlanDraft
+
+
+def _snap() -> GuildSnapshot:
+    return GuildSnapshot(guild_id=1, guild_name="Test", owner_id=99)
+
+
+def _fake_openai_client(payload: dict) -> MagicMock:
+    message = MagicMock()
+    message.content = json.dumps(payload)
+    choice = MagicMock()
+    choice.message = message
+    response = MagicMock()
+    response.choices = [choice]
+    client = MagicMock()
+    client.chat = MagicMock()
+    client.chat.completions = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=response)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_description_folded_into_openai_prompt():
+    client = _fake_openai_client({"recommendations": []})
+    advisor = OpenAISetupAdvisor(client=client, api_key="sk-test")
+
+    draft = await suggest_from_description(
+        _snap(),
+        "a competitive gaming server with mod logs",
+        advisor=advisor,
+    )
+
+    assert isinstance(draft, SetupPlanDraft)
+    client.chat.completions.create.assert_awaited_once()
+    sent = str(client.chat.completions.create.call_args)
+    # The directive (carrying the field name) + the operator's words both
+    # reach the provider — the prompt is genuinely description-informed.
+    assert "operator_description" in sent
+    assert "competitive gaming server" in sent
+
+
+@pytest.mark.asyncio
+async def test_blank_description_is_not_folded():
+    client = _fake_openai_client({"recommendations": []})
+    advisor = OpenAISetupAdvisor(client=client, api_key="sk-test")
+
+    draft = await suggest_from_description(_snap(), "   ", advisor=advisor)
+
+    assert isinstance(draft, SetupPlanDraft)
+    client.chat.completions.create.assert_awaited_once()
+    sent = str(client.chat.completions.create.call_args)
+    assert "operator_description" not in sent
+
+
+@pytest.mark.asyncio
+async def test_deterministic_advisor_ignores_description():
+    draft = await suggest_from_description(
+        _snap(),
+        "any description at all",
+        advisor=DeterministicAdvisor(),
+    )
+
+    assert isinstance(draft, SetupPlanDraft)
+    # Deterministic can't use free text — it stays snapshot-only.
+    assert draft.source == "deterministic"
+
+
+@pytest.mark.asyncio
+async def test_defaults_to_built_advisor_in_ci(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("SETUP_ADVISOR_PROVIDER", raising=False)
+
+    draft = await suggest_from_description(_snap(), "desc")
+
+    assert isinstance(draft, SetupPlanDraft)
+    assert draft.source == "deterministic"


### PR DESCRIPTION
## Why

The competitive-positioning north-star (#1352) named the **AI-setup wedge** — *"describe your server, it configures itself"* — as the highest-leverage next build: a genuine "whoa" demo that's structurally hard for incumbents (MEE6/Dyno/Carl-bot) to retrofit, and the direct answer to the **setup-friction** failure mode every competitor shares.

## What this PR does

Orientation found the infrastructure **already largely exists** — `OpenAISetupAdvisor` turns a guild snapshot into a schema-validated `SetupPlanDraft`, and `AIReviewPanelView` renders it → accept → the **audited Final Review apply path**. The only missing piece was a **natural-language input**. This PR adds it, reusing everything else:

- **`OpenAISetupAdvisor.suggest_with_description`** (+ a shared private `_run`) — folds the operator's free-form description into the prompt/payload; reuses the existing strict JSON schema, `_validate_ai_payload`, gateway, and degraded handling unchanged.
- **`services/setup_natural_language_advisor.py`** — thin entry; uses the description only when an AI advisor is configured, else falls back to the deterministic snapshot-only plan (the description is simply unused, never an error — CI-safe).
- **`cogs/setup/_describe_entry.py`** + **`/setup-describe` / `!setupdescribe`** — snapshot → advisor → open the existing review panel ephemerally.
- Tests.

**Contained + reversible:** no new mutation code. Proposals flow into the existing audited apply seam and are applied only on explicit operator confirmation (`can_apply_setup` still gates Final Review). Resource *creation* (vs. binding existing channels/roles) stays a clean follow-up — the recommendation schema is binding-only today.

Born-red per Q-0133; auto-merges on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzBMYDtbYx95WgeWPggWJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzBMYDtbYx95WgeWPggWJj)_