### PR TITLE
Fishing: soft-fail clue + heaviest-catch leaderboard

### DIFF
--- a/.sessions/2026-06-23-fishing-trophy-followups.md
+++ b/.sessions/2026-06-23-fishing-trophy-followups.md
@@ -1,6 +1,6 @@
 # 2026-06-23 — Fishing trophy follow-ups: soft-fail clue + heaviest-catch leaderboard
 
-> **Status:** `in-progress` — born-red session card (Q-0133). Flip to `complete` last.
+> **Status:** `complete` — fishing trophy follow-ups shipped (PR #1356), full CI mirror green.
 
 > **Run type:** `routine · dispatch`
 
@@ -21,4 +21,64 @@ Additive — no money/safety seam (ADR-002 game-state). Tests across minigame/db
 
 ## What shipped
 
-_(filled in at close)_
+Two follow-ups on the merged #1351 weight seam (PR #1356):
+
+1. **Soft-fail clue** — `minigame.escape_clue(species, level)` returns a teasing, species-named
+   line *only* for a **trophy** (the top of the unlocked band, reusing `is_trophy`); ordinary
+   fish return `None`. `cast_view._got_away(text)` appends it, routed through every got-away
+   site (too-slow reel, the fight snap, both background window-expiry fails). A lost big fish
+   now baits the next cast ("💭 *...it looked like a real **Marlin**, too.*") instead of a flat
+   denial — the design's "Other ideas" soft-fail item, trivially reachable now catches carry a
+   species on the line.
+2. **Heaviest-catch leaderboard** — `db.top_trophies(guild, known_species)` (`ORDER BY
+   best_weight DESC`, current-catalog + `best_weight > 0` filtered, mirroring `top_fishers`) +
+   the `!trophies` command (aliases `bigfish` / `fishtrophy`): a "Biggest Catches" hall of fame
+   where trophies compete server-wide off each angler's per-species `best_weight` record.
+
+**Tests:** `escape_clue` (trophy-only + names the fish + progression band) in the minigame
+suite; `top_trophies` (ordering + catalog/weight filters + empty short-circuit) in the db
+suite; `_got_away` clue behaviour in the cast-view suite. **Regenerated the dashboard
+artifacts** (`botsite/data/site.json`, `dashboard/data/dashboard.json`, `botsite/site/data.js`)
+so the committed `commands` reference includes `!trophies` — the generated-artifact freshness
+guard (`check_generated_artifacts_fresh`) fails otherwise (caught by the local CI mirror, the
+exact trap a new command introduces). Full CI mirror green (arch strict 0 errors).
+
+## Findings / decisions
+
+- **No new bugs.** Pure-additive UX + a read-only leaderboard query; no money/safety seam.
+- The artifact-freshness failure (4 tests) was **expected drift, not a defect** — any new
+  command changes the fresh `site.json`/`dashboard.json` build, so regenerating the committed
+  copy is the standard step. Worth remembering: *adding a bot command means re-running
+  `scripts/export_dashboard_data.py`* (noted for the next session — see review below).
+
+## 💡 Session idea
+
+**Pre-edit "did you add a command?" reminder in the cog-edit rule.** This run lost a CI cycle
+to the generated-artifact drift a new command causes — the fix (`scripts/export_dashboard_data.py`)
+is well-known but easy to forget because the failure surfaces in an unrelated-looking
+`test_export_dashboard_data` rather than near the cog. A one-line trigger in the cog-edit path
+(the `pre-edit-check` skill / a `.claude/rules/` note: "added/renamed/removed a `@commands.command`?
+→ re-run `scripts/export_dashboard_data.py` before pushing") would close the loop at the point
+of the edit. Cheap, high-leverage — routed to `docs/ideas/` candidacy, not yet a plan.
+
+## ⟲ Previous-session review
+
+The previous slice (this run's own #1351, trophy records) did the hard part well — a clean,
+well-tested weight seam with a thoughtful migration (re-adding `best_weight` with an honest
+provenance comment) — but it **missed the artifact-regeneration step is needed when a command
+is added**, which is exactly the cost *this* slice paid: #1351 added no command so it didn't
+hit it, but it also didn't leave a breadcrumb that the dashboard export is command-coupled.
+**System improvement:** the gap is real and generalizes (any command PR hits it), so rather than
+just absorb it I've turned it into this session's 💡 idea (a pre-edit reminder in the cog rule).
+That converts a stubbed-toe into a durable guard — the self-auditing loop working as intended.
+
+## 📤 Run report
+
+- **Run type:** `routine · dispatch`
+- **Slices shipped this run:** 2 — #1351 (trophy records, merged) + #1356 (this: soft-fail
+  clue + heaviest-catch leaderboard).
+- **⚑ Self-initiated:** none — both slices trace to the S1 fishing "Next startable" list + the
+  design's "Other ideas" (this one was #1351's captured session idea), not invented features.
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none — no migration this slice; the merge auto-deploys.
+- **Bug-book:** no entries opened or closed.

--- a/.sessions/2026-06-23-fishing-trophy-followups.md
+++ b/.sessions/2026-06-23-fishing-trophy-followups.md
@@ -1,0 +1,24 @@
+# 2026-06-23 — Fishing trophy follow-ups: soft-fail clue + heaviest-catch leaderboard
+
+> **Status:** `in-progress` — born-red session card (Q-0133). Flip to `complete` last.
+
+> **Run type:** `routine · dispatch`
+
+## What I'm about to do
+
+Second slice of this dispatch run, now unblocked by PR #1351 (trophy records, merged). Both
+build directly on the merged weight seam — captured as #1351's 💡 session idea, the fishing
+design's §"Other ideas":
+
+1. **Soft-fail clue** ("a big one got away") — when a *trophy* fish escapes the reel, the cast
+   view names it (`minigame.escape_clue`) so the loss baits the next cast instead of a flat
+   denial. Ordinary fish keep the plain line.
+2. **Heaviest-catch leaderboard** — `!trophies` (aliases `bigfish`/`fishtrophy`): the server's
+   biggest catches off the `best_weight` column #1351 added (`db.top_trophies`, `ORDER BY
+   best_weight DESC`), so trophies compete server-wide.
+
+Additive — no money/safety seam (ADR-002 game-state). Tests across minigame/db/cast-view.
+
+## What shipped
+
+_(filled in at close)_

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-06-23T09:16:14Z",
+    "generated_at": "2026-06-23T09:42:20Z",
     "build": {
-      "commit": "a622a83",
-      "subject": "Competitive-positioning north-star vision doc (what makes people choose us) (#1352)",
-      "committed_at": "2026-06-23T09:16:14Z"
+      "commit": "b390928e",
+      "subject": "Fishing trophy follow-ups: born-red session card + claim",
+      "committed_at": "2026-06-23T09:42:20Z"
     }
   },
   "counts": {
-    "commands": 386,
+    "commands": 387,
     "features": 41,
     "games": 11
   },
@@ -6994,6 +6994,28 @@
         },
         {
           "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "trophies",
+      "aliases": [
+        "bigfish",
+        "fishtrophy"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show this server's heaviest catches — the biggest-fish hall of fame.",
+      "description": "Show this server's heaviest catches — the biggest-fish hall of fame.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "The Explore hub — a federated open world (one world, each subsystem its own game)",
           "status": "ideas"
         }
       ],

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -5616,6 +5616,27 @@ const COMMANDS = [
     "planned": []
   },
   {
+    "name": "trophies",
+    "area": "games",
+    "status": "in-progress",
+    "summary": "Show this server's heaviest catches — the biggest-fish hall of fame.",
+    "description": "Show this server's heaviest catches — the biggest-fish hall of fame.",
+    "usage": "!trophies",
+    "aliases": [
+      "bigfish",
+      "fishtrophy"
+    ],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [],
+    "planned": [
+      {
+        "status": "idea",
+        "title": "The Explore hub — a federated open world (one world, each subsystem…"
+      }
+    ]
+  },
+  {
     "name": "unban",
     "area": "moderation",
     "status": "in-progress",
@@ -6310,7 +6331,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "a622a83",
+    "build": "b390928e",
     "title": "New public bot website",
     "changes": [
       {
@@ -6322,7 +6343,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "a622a83",
+    "build": "b390928e",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -6334,7 +6355,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "a622a83",
+    "build": "b390928e",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-23T09:16:14Z",
+    "generated_at": "2026-06-23T09:42:20Z",
     "build": {
-      "commit": "a622a83",
-      "subject": "Competitive-positioning north-star vision doc (what makes people choose us) (#1352)",
-      "committed_at": "2026-06-23T09:16:14Z"
+      "commit": "b390928e",
+      "subject": "Fishing trophy follow-ups: born-red session card + claim",
+      "committed_at": "2026-06-23T09:42:20Z"
     },
     "counts": {
       "functions": 41,
@@ -15,7 +15,7 @@
       "updates": 60,
       "env_vars": 38,
       "cogs": 51,
-      "commands": 386,
+      "commands": 387,
       "setting_keys": 107,
       "setting_domains": 16,
       "typed_settings": 88,
@@ -2389,6 +2389,14 @@
       "self_initiated": false
     },
     {
+      "file": "2026-06-23-reconcile.md",
+      "date": "2026-06-23",
+      "title": "2026-06-23 — Docs reconciliation pass (band-#1350, Q-0107)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": false
+    },
+    {
       "file": "2026-06-23-new-subsystem-checker-gaps.md",
       "date": "2026-06-23",
       "title": "Session — 2026-06-23 · Close the new-subsystem checker's blind spots",
@@ -2419,6 +2427,22 @@
       "status": "complete",
       "run_type": "routine",
       "self_initiated": true
+    },
+    {
+      "file": "2026-06-23-fishing-trophy-records.md",
+      "date": "2026-06-23",
+      "title": "2026-06-23 — Fishing trophy records (per-species biggest-caught)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-06-23-fishing-trophy-followups.md",
+      "date": "2026-06-23",
+      "title": "2026-06-23 — Fishing trophy follow-ups: soft-fail clue + heaviest-catch leaderboard",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": false
     },
     {
       "file": "2026-06-23-fishing-test-helpers.md",
@@ -2834,30 +2858,6 @@
       "title": "2026-06-22 — Bulk role creation via preset packs",
       "status": "complete",
       "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-22-bulk-role-creation-enhancements.md",
-      "date": "2026-06-22",
-      "title": "2026-06-22 — Bulk role creation enhancements",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-22-bug0023-slash-scan-coverage.md",
-      "date": "2026-06-22",
-      "title": "2026-06-22 — BUG-0023 root fix: scanner discovers `app_commands.Group` attribute slash commands",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-06-22-bug-0024-dashboard-flake.md",
-      "date": "2026-06-22",
-      "title": "2026-06-22 — BUG-0024: make the dashboard `generated_at` determinism test hermetic",
-      "status": "complete",
-      "run_type": "manual",
       "self_initiated": false
     }
   ],
@@ -6051,6 +6051,20 @@
             "dock"
           ],
           "brief": "Set sail for deepwater (or dock back on shore) — toggles your fishing venue.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "trophies",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "bigfish",
+            "fishtrophy"
+          ],
+          "brief": "Show this server's heaviest catches — the biggest-fish hall of fame.",
           "classification": "",
           "has_panel": false,
           "button_backed": false

--- a/disbot/cogs/fishing_cog.py
+++ b/disbot/cogs/fishing_cog.py
@@ -32,7 +32,7 @@ from utils import db
 from utils.fishing import bait as bait_mod
 from utils.fishing import rods as rods_mod
 from utils.fishing import weather as weather_mod
-from utils.fishing.fish import SPECIES
+from utils.fishing.fish import SPECIES, species_by_name
 from views.fishing import (
     BaitShopView,
     FishingMenuView,
@@ -149,6 +149,34 @@ class FishingCog(commands.Cog):
             lines.append(
                 f"{prefix} {name} — **{caught}** caught "
                 f"({species}/{len(SPECIES)} species)",
+            )
+        embed.description = "\n".join(lines)
+        await ctx.send(embed=embed)
+
+    @commands.command(
+        name="trophies",
+        aliases=["bigfish", "fishtrophy"],
+    )
+    async def trophies(self, ctx):
+        """Show this server's heaviest catches — the biggest-fish hall of fame."""
+        rows = await db.top_trophies(ctx.guild.id, [s.name for s in SPECIES])
+        embed = discord.Embed(title="🏅 Biggest Catches", color=_FISHING_COLOR)
+        if not rows:
+            embed.description = (
+                "No trophies landed yet — reel in a big one with `!fish`!"
+            )
+            await ctx.send(embed=embed)
+            return
+        medals = ["🥇", "🥈", "🥉"]
+        lines = []
+        for rank, (user_id, species, weight) in enumerate(rows):
+            prefix = medals[rank] if rank < len(medals) else f"**{rank + 1}.**"
+            member = resources.resolve_member(ctx.guild, user_id)
+            name = member.display_name if member else f"User {user_id}"
+            fish = species_by_name(species)
+            emoji = fish.emoji if fish else "🐟"
+            lines.append(
+                f"{prefix} {emoji} **{weight:g} kg** {species.title()} — {name}",
             )
         embed.description = "\n".join(lines)
         await ctx.send(embed=embed)

--- a/disbot/utils/db/__init__.py
+++ b/disbot/utils/db/__init__.py
@@ -101,6 +101,7 @@ from utils.db.games.fishing import (
     get_fishing_records,
     record_catch,
     top_fishers,
+    top_trophies,
 )
 from utils.db.games.fishing_bait import (
     clear_active_bait,
@@ -428,6 +429,7 @@ __all__ = [
     "get_fishing_records",
     "record_catch",
     "top_fishers",
+    "top_trophies",
     "get_rod_tier",
     "set_rod_tier",
     "get_fishing_energy",

--- a/disbot/utils/db/games/fishing.py
+++ b/disbot/utils/db/games/fishing.py
@@ -119,3 +119,29 @@ async def top_fishers(
         (guild_id, known_species, limit),
     )
     return [(r["user_id"], r["caught"], r["species"]) for r in rows]
+
+
+async def top_trophies(
+    guild_id: int,
+    known_species: list[str],
+    *,
+    limit: int = 10,
+) -> list[tuple[int, str, float]]:
+    """``[(user_id, species, best_weight)]`` — the guild's heaviest catches.
+
+    A "biggest fish" hall of fame: the single heaviest catch rows server-wide,
+    ordered by weight, so a trophy lunker competes against everyone (the catch
+    log's per-(user, species) ``best_weight`` is each angler's record for that
+    fish). An angler can appear more than once for different species. Filtered to
+    the current catalog (like :func:`top_fishers`) so legacy rows never show, and
+    to ``best_weight > 0`` so pre-trophy-era rows (migration 095) are skipped.
+    """
+    if not known_species:
+        return []
+    rows = await pool.fetchall(
+        "SELECT user_id, species, best_weight FROM fishing_catch_log "
+        "WHERE guild_id=$1 AND species = ANY($2::text[]) AND best_weight > 0 "
+        "ORDER BY best_weight DESC LIMIT $3",
+        (guild_id, known_species, limit),
+    )
+    return [(r["user_id"], r["species"], r["best_weight"]) for r in rows]

--- a/disbot/utils/fishing/minigame.py
+++ b/disbot/utils/fishing/minigame.py
@@ -105,6 +105,21 @@ def is_trophy(
     return species.size_rank > threshold
 
 
+def escape_clue(species: FishSpecies, fishing_level: int) -> str | None:
+    """A "the one that got away" clue when a *trophy* slips the hook (else ``None``).
+
+    The design's soft-fail idea (``fishing-minigame-design-2026-06-22.md``
+    §"Other ideas"): an escaped *big* fish should leave a teasing, species-named
+    clue that baits the next cast, rather than a flat denial. Only trophies (the
+    top of the unlocked band, :func:`is_trophy`) earn a story — losing an
+    ordinary minnow does not, so this returns ``None`` for them and the caller
+    keeps its plain "got away" line.
+    """
+    if not is_trophy(species, fishing_level):
+        return None
+    return f"💭 *...it looked like a real **{species.name.title()}**, too.*"
+
+
 def reel_fight_taps(species: FishSpecies) -> int:
     """How many reel taps it takes to land *species* — scales with its size.
 

--- a/disbot/views/fishing/cast_view.py
+++ b/disbot/views/fishing/cast_view.py
@@ -217,7 +217,9 @@ class FishingCastView(discord.ui.View):
         await asyncio.sleep(self._window)
         if self._resolved or self._round_id != my_id:
             return
-        await self._fail(self._got_away("🌊 *...the line goes slack. The fish got away.*"))
+        await self._fail(
+            self._got_away("🌊 *...the line goes slack. The fish got away.*"),
+        )
 
     async def _run_fight_round(self) -> None:
         """One reel-fight round: a suspense beat, arm the tap, expire if ignored."""
@@ -234,7 +236,9 @@ class FishingCastView(discord.ui.View):
         if self._resolved or self._round_id != my_id:
             return
         await self._fail(
-            self._got_away("🌊 You let the line go slack — it thrashed free and escaped."),
+            self._got_away(
+                "🌊 You let the line go slack — it thrashed free and escaped.",
+            ),
         )
 
     # ------------------------------------------------------------------ the button

--- a/disbot/views/fishing/cast_view.py
+++ b/disbot/views/fishing/cast_view.py
@@ -217,7 +217,7 @@ class FishingCastView(discord.ui.View):
         await asyncio.sleep(self._window)
         if self._resolved or self._round_id != my_id:
             return
-        await self._fail("🌊 *...the line goes slack. The fish got away.*")
+        await self._fail(self._got_away("🌊 *...the line goes slack. The fish got away.*"))
 
     async def _run_fight_round(self) -> None:
         """One reel-fight round: a suspense beat, arm the tap, expire if ignored."""
@@ -233,9 +233,24 @@ class FishingCastView(discord.ui.View):
         await asyncio.sleep(self._window)
         if self._resolved or self._round_id != my_id:
             return
-        await self._fail("🌊 You let the line go slack — it thrashed free and escaped.")
+        await self._fail(
+            self._got_away("🌊 You let the line go slack — it thrashed free and escaped."),
+        )
 
     # ------------------------------------------------------------------ the button
+
+    def _got_away(self, text: str) -> str:
+        """A 'got away' line, with a trophy clue appended when a big one escaped.
+
+        Soft-fail UX (the design's "Other ideas"): if the fish on the line was a
+        trophy, name it so the loss baits the next cast (``minigame.escape_clue``)
+        instead of a flat denial. Ordinary fish keep the plain *text*.
+        """
+        species = self.cast.catch.species if self.cast.catch else None
+        if species is None:
+            return text
+        clue = minigame.escape_clue(species, self.cast.level_before)
+        return f"{text}\n{clue}" if clue else text
 
     @discord.ui.button(label="🎣 Waiting for a bite…", style=discord.ButtonStyle.grey)
     async def reel_btn(
@@ -268,7 +283,7 @@ class FishingCastView(discord.ui.View):
         if not minigame.reel_is_in_time(elapsed, self._window):
             await self._terminate_interaction(
                 interaction,
-                "🌊 *...too slow. The fish got away.*",
+                self._got_away("🌊 *...too slow. The fish got away.*"),
             )
             return
 
@@ -309,7 +324,9 @@ class FishingCastView(discord.ui.View):
         ):
             await self._terminate_interaction(
                 interaction,
-                "💥 It gave one last thrash, **snapped the line**, and bolted!",
+                self._got_away(
+                    "💥 It gave one last thrash, **snapped the line**, and bolted!",
+                ),
             )
             return
 

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -31,10 +31,14 @@
   call. **Daily weather forecast** (#1341) — a date-seeded global bias
   (`utils/fishing/weather.py`, no DB) compounding onto the cast as a third how-well knob
   (rod × bait × weather): clear/rain/calm/fog/storm, the same for everyone each day; `!forecast` +
-  a menu/cast forecast line. **Trophy records per species** (#1351, this PR) — each catch now rolls
+  a menu/cast forecast line. **Trophy records per species** (#1351) — each catch now rolls
   an individual weight (`utils/fishing/weight.py`); the catch-log keeps your heaviest of each species
   (migration 095 re-adds `best_weight`), the Fishdex shows the personal-best beside each tally, and a
   fresh record celebrates "🏅 New personal best!" on the catch — a cheap long-tail retention goal.
+  **Trophy follow-ups** (#1356, this PR) — the **soft-fail clue** (a *trophy* that slips the hook now
+  names itself, `minigame.escape_clue`, so a lost big fish baits the next cast) + the **heaviest-catch
+  leaderboard** `!trophies` (`bigfish`/`fishtrophy`, `db.top_trophies` off the `best_weight` record) —
+  a "Biggest Catches" hall of fame where trophies compete server-wide.
 - **Casino — multiplayer poker** (PR #1333) — a new Games-hub child for **group** card games with
   **per-player auto-updating ephemeral** hands; v1 = Texas Hold'em (play-chips). Pure `utils/cards/`
   + `utils/poker/` (eval + engine w/ side pots, fully tested) + the `views/casino/` ephemeral
@@ -45,12 +49,11 @@
   re-tune ✅ #1304, bait-crafting ✅ #1338, and the **⛵ boat/deepwater venue** ✅ PR #1340 — shore↔
   deepwater toggle + boat-only species + tougher deep minigame — are all done)* — remaining:
   the literal §5 **shore-cap-at-12 rebalance** (owner balance call, flagged in #1340) ·
-  *(weather/time-of-day modifier ✅ #1341 · trophy records per species ✅ #1351)* ·
-  the **open-world expansion**
+  *(weather/time-of-day modifier ✅ #1341 · trophy records per species ✅ #1351 · soft-fail clue +
+  heaviest-catch leaderboard ✅ #1356)* · the **open-world expansion**
   ([plan](../planning/fishing-open-world-expansion-plan-2026-06-18.md) Phase 2+: the
   boat-as-structure / travel-timer / destinations layer) ·
-  the **soft-fail clue** ("a *big* one got away") + fake-out bites
-  ([design](../planning/fishing-minigame-design-2026-06-22.md) §"Other ideas").
+  **fake-out bites** ([design](../planning/fishing-minigame-design-2026-06-22.md) §"Other ideas").
 - **Project Moon runtime PR 1** — the `KnowledgeDomain` seam + first ingest
   ([plan](../planning/project-moon-knowledge-domain-plan-2026-06-21.md)).
 - **botsite React-SPA migration PR 2** — serve the built React app from `botsite/` + cutover

--- a/docs/owner/claims/claude-funny-franklin-trophy-follow.md
+++ b/docs/owner/claims/claude-funny-franklin-trophy-follow.md
@@ -1,0 +1,1 @@
+- `claude/funny-franklin-trophy-follow` · fishing trophy follow-ups: soft-fail clue + heaviest-catch leaderboard · `disbot/utils/fishing/minigame.py` + `views/fishing/cast_view.py` + `utils/db/games/fishing.py` + `cogs/fishing_cog.py` · 2026-06-23

--- a/docs/owner/claims/claude-funny-franklin-trophy-follow.md
+++ b/docs/owner/claims/claude-funny-franklin-trophy-follow.md
@@ -1,1 +1,0 @@
-- `claude/funny-franklin-trophy-follow` · fishing trophy follow-ups: soft-fail clue + heaviest-catch leaderboard · `disbot/utils/fishing/minigame.py` + `views/fishing/cast_view.py` + `utils/db/games/fishing.py` + `cogs/fishing_cog.py` · 2026-06-23

--- a/docs/planning/fishing-minigame-design-2026-06-22.md
+++ b/docs/planning/fishing-minigame-design-2026-06-22.md
@@ -210,8 +210,11 @@ Your `cast → wait → BITE → reel` instinct is **right**. Three data-driven 
   now that weight has a purpose). The Fishdex shows your personal-best weight beside each tally, and a
   fresh record celebrates with "🏅 New personal best!" on the catch. A cheap long-tail goal —
   "personal best" beats raw counts for retention.
-- **Line-snap as a soft-fail, not a hard-fail** — an escaped fish could leave a clue ("a *big* one
-  got away") to bait the next cast rather than just denying the reward — keeps frustration low.
+- **Line-snap as a soft-fail, not a hard-fail** — **✅ SHIPPED 2026-06-23 (PR #1356).** An escaped
+  **trophy** now leaves a teasing, species-named clue (`minigame.escape_clue` → "💭 *...it looked like
+  a real **Marlin**, too.*") at every got-away site, baiting the next cast instead of a flat denial;
+  ordinary fish keep the plain line. Shipped alongside the **heaviest-catch leaderboard** (`!trophies`
+  / `bigfish` — a "Biggest Catches" hall of fame off the #1351 `best_weight` record).
 
 ## Owner decisions (resolved 2026-06-22, via AskUserQuestion)
 

--- a/tests/unit/db/test_fishing_db.py
+++ b/tests/unit/db/test_fishing_db.py
@@ -45,6 +45,35 @@ async def test_record_catch_first_catch_returns_none():
 
 
 @pytest.mark.asyncio
+async def test_top_trophies_orders_by_weight_and_filters_known_species():
+    known = ["minnow", "trout", "shark"]
+    with patch(
+        "utils.db.games.fishing.pool.fetchall",
+        new_callable=AsyncMock,
+        return_value=[{"user_id": 7, "species": "shark", "best_weight": 12.5}],
+    ) as mock_fetch:
+        out = await fishing.top_trophies(1, known, limit=5)
+    query, params = mock_fetch.await_args.args
+    flat = " ".join(query.split())
+    assert "ORDER BY best_weight DESC" in flat
+    assert "species = ANY($2::text[])" in flat  # current-catalog allow-list
+    assert "best_weight > 0" in flat  # pre-trophy-era rows excluded
+    assert params == (1, known, 5)
+    assert out == [(7, "shark", 12.5)]
+
+
+@pytest.mark.asyncio
+async def test_top_trophies_empty_allow_list_short_circuits():
+    with patch(
+        "utils.db.games.fishing.pool.fetchall",
+        new_callable=AsyncMock,
+    ) as mock_fetch:
+        out = await fishing.top_trophies(1, [])
+    assert out == []
+    mock_fetch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_get_fishing_records_returns_species_to_best_weight():
     with patch(
         "utils.db.games.fishing.pool.fetchall",

--- a/tests/unit/db/test_fishing_db.py
+++ b/tests/unit/db/test_fishing_db.py
@@ -19,11 +19,17 @@ async def test_record_catch_upserts_count_and_tracks_best_weight():
         prev = await fishing.record_catch(99, 1, "trout", 3.4)
     query, params = mock_fetch.await_args.args
     flat = " ".join(query.split())
-    assert "INSERT INTO fishing_catch_log (user_id, guild_id, species, count, best_weight)" in flat
+    assert (
+        "INSERT INTO fishing_catch_log (user_id, guild_id, species, count, best_weight)"
+        in flat
+    )
     assert "ON CONFLICT (user_id, guild_id, species) DO UPDATE" in flat
     assert "count = fishing_catch_log.count + 1" in flat
     # best_weight only ever grows (GREATEST against the incoming catch).
-    assert "best_weight = GREATEST(fishing_catch_log.best_weight, EXCLUDED.best_weight)" in flat
+    assert (
+        "best_weight = GREATEST(fishing_catch_log.best_weight, EXCLUDED.best_weight)"
+        in flat
+    )
     # The prior best is captured (CTE) and returned so the caller can detect a PB.
     assert "WITH prev AS" in flat
     assert "RETURNING (SELECT best_weight FROM prev) AS prev_best" in flat
@@ -124,7 +130,10 @@ async def test_get_fishing_log_returns_species_to_count():
     with patch(
         "utils.db.games.fishing.pool.fetchall",
         new_callable=AsyncMock,
-        return_value=[{"species": "trout", "count": 4}, {"species": "bass", "count": 1}],
+        return_value=[
+            {"species": "trout", "count": 4},
+            {"species": "bass", "count": 1},
+        ],
     ):
         log = await fishing.get_fishing_log(99, 1)
     assert log == {"trout": 4, "bass": 1}

--- a/tests/unit/utils/test_fishing_minigame.py
+++ b/tests/unit/utils/test_fishing_minigame.py
@@ -133,12 +133,8 @@ def test_roll_escape_matches_its_probability():
 def test_bite_speed_shortens_the_wait_but_respects_the_floor():
     import random as _random
 
-    fast = [
-        minigame.roll_bite_delay(_random.Random(i), speed=0.7) for i in range(500)
-    ]
-    slow = [
-        minigame.roll_bite_delay(_random.Random(i), speed=1.0) for i in range(500)
-    ]
+    fast = [minigame.roll_bite_delay(_random.Random(i), speed=0.7) for i in range(500)]
+    slow = [minigame.roll_bite_delay(_random.Random(i), speed=1.0) for i in range(500)]
     assert sum(fast) / len(fast) < sum(slow) / len(slow)  # faster rod bites sooner
     assert all(d >= minigame.BITE_DELAY_FLOOR for d in fast)  # never below the floor
 

--- a/tests/unit/utils/test_fishing_minigame.py
+++ b/tests/unit/utils/test_fishing_minigame.py
@@ -73,6 +73,22 @@ def test_trophy_scales_with_progression():
     assert minigame.is_trophy(fish, fishing_level=7) is False
 
 
+def test_escape_clue_only_fires_for_a_trophy_and_names_the_fish():
+    big = FishSpecies("whopper", 3, "🐠")
+    small = FishSpecies("minnow", 1, "🐟")
+    clue = minigame.escape_clue(big, fishing_level=1)
+    assert clue is not None
+    assert "Whopper" in clue  # the species is named so the loss baits the next cast
+    # An ordinary fish gets no story — only big ones leave a clue.
+    assert minigame.escape_clue(small, fishing_level=1) is None
+
+
+def test_escape_clue_follows_the_progression_band():
+    fish = FishSpecies("whopper", 3, "🐠")
+    assert minigame.escape_clue(fish, fishing_level=1) is not None
+    assert minigame.escape_clue(fish, fishing_level=7) is None  # no longer a trophy
+
+
 # ---------------------------------------------------------------------------
 # Reel-fight (trophy) helpers
 # ---------------------------------------------------------------------------

--- a/tests/unit/views/test_fishing_cast_view.py
+++ b/tests/unit/views/test_fishing_cast_view.py
@@ -121,7 +121,9 @@ async def test_ordinary_fish_commits_on_the_first_reel():
             AsyncMock(return_value=result),
         ) as commit,
         patch("views.fishing.cast_view.safe_defer", AsyncMock(return_value=True)),
-        patch("views.fishing.cast_view.safe_edit", AsyncMock(return_value=True)) as edit,
+        patch(
+            "views.fishing.cast_view.safe_edit", AsyncMock(return_value=True)
+        ) as edit,
     ):
         await _reel(view, interaction)
 
@@ -152,7 +154,9 @@ async def test_caught_embed_shows_weight_and_personal_best():
             AsyncMock(return_value=result),
         ),
         patch("views.fishing.cast_view.safe_defer", AsyncMock(return_value=True)),
-        patch("views.fishing.cast_view.safe_edit", AsyncMock(return_value=True)) as edit,
+        patch(
+            "views.fishing.cast_view.safe_edit", AsyncMock(return_value=True)
+        ) as edit,
     ):
         await _reel(view, interaction)
 
@@ -310,7 +314,9 @@ async def test_extra_taps_between_fight_rounds_are_ignored():
 
     with (
         patch.object(fishing_workflow, "commit_catch", AsyncMock()) as commit,
-        patch("views.fishing.cast_view.safe_defer", AsyncMock(return_value=True)) as defer,
+        patch(
+            "views.fishing.cast_view.safe_defer", AsyncMock(return_value=True)
+        ) as defer,
     ):
         await _reel(view, interaction)
 

--- a/tests/unit/views/test_fishing_cast_view.py
+++ b/tests/unit/views/test_fishing_cast_view.py
@@ -183,6 +183,16 @@ async def test_reel_too_late_lets_the_fish_get_away():
     assert (1, 99) not in active_casts
 
 
+def test_got_away_appends_a_clue_for_a_trophy_but_not_an_ordinary_fish():
+    base = "🌊 *...the fish got away.*"
+    # A trophy that escapes leaves a teasing, species-named clue (soft-fail UX).
+    trophy_text = _make_view(_TROPHY)._got_away(base)
+    assert base in trophy_text
+    assert "Trout" in trophy_text
+    # An ordinary fish keeps the plain line — no story for a lost minnow.
+    assert _make_view(_ORDINARY)._got_away(base) == base
+
+
 # ---------------------------------------------------------------------------
 # Trophy reel-fight
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Second dispatch slice, unblocked by #1351 (trophy records, merged) — both build on the `best_weight` weight seam it added. From the fishing design's §"Other ideas" (captured as #1351's session idea):

1. **Soft-fail clue** — when a **trophy** fish slips the hook, the cast view names it (`💭 ...it looked like a real **Marlin**, too.`) instead of a flat "it got away", so a lost big fish baits the next cast. Ordinary fish keep the plain line. (`minigame.escape_clue`, routed through every got-away site in `cast_view`.)
2. **Heaviest-catch leaderboard** — `!trophies` (aliases `bigfish` / `fishtrophy`): the server's biggest catches, off the per-angler `best_weight` record #1351 added (`db.top_trophies`, `ORDER BY best_weight DESC`, current-catalog + `best_weight > 0` filtered). Trophies now compete server-wide.

Additive game feature — no money/safety seam (ADR-002 game-state). Tests across minigame / db / cast-view.

> Born-red (Q-0133): merges on green CI once the card flips to `complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015aFLgUJMXzdgVoHvXtqwn7)_