### PR TITLE
AI setup wedge: propose resource creation from a description (create+bind)

### DIFF
--- a/.sessions/2026-06-23-ai-setup-create.md
+++ b/.sessions/2026-06-23-ai-setup-create.md
@@ -1,0 +1,38 @@
+# 2026-06-23 — AI setup wedge: propose resource CREATION from a description
+
+> **Status:** `in-progress` — born-red card (Q-0133). Flip to `complete` as the final step.
+> Owner-directed (chat: "Yes go ahead" → the full form of the AI-setup wedge: create channels/roles
+> from a description, not just bind existing ones). Builds on #1355. PR auto-merges on green (Q-0123).
+
+## Arc
+
+#1355 shipped `/setup-describe`: describe your server → the advisor proposes binding **existing**
+channels/roles to subsystems. The natural next step (this session's idea, owner-approved) is the
+**full form**: when a described server is *missing* a resource an important binding needs, propose
+**creating** it. The apply seam already supports create+bind in one op — `_apply_resource_create`
+builds a `ProvisioningRequest(mode="create", custom_name=…)` and `ResourceProvisioningPipeline`
+creates the resource **and** binds it. The only missing piece is letting a *recommendation* express
+"create" and threading it through validation + the op adapter + the review UI.
+
+## Plan (this PR)
+
+- `setup_plan.SetupRecommendation`: add `mode: "bind" | "create"` (default `bind`) and make
+  `target_id` optional (`None` for create); `__post_init__` validates bind⇒target_id present,
+  create⇒a proposed name. Deterministic advisor stays bind-only (unchanged behaviour).
+- `setup_ai_advisor`: extend the strict JSON schema (`mode` enum + nullable `target_id`), teach
+  `_validate_ai_payload` to build create recs, and let the prompt propose creating a missing
+  resource. `_validate_against_schema` still gates (subsystem/binding/kind must exist) — create
+  can't invent a binding either.
+- `setup_operations.operations_from_recommendations`: map a create rec → `create_<kind>` op
+  (`resource_mode="create"`, `resource_name=target_name`) so apply runs the existing create+bind
+  pipeline.
+- `views/setup/ai_review/`: render create recs distinctly (➕ create `name` → bind …).
+- Tests across the model / schema / adapter / rendering.
+
+**Contained + reversible:** still no *new* mutation code — create flows through the existing audited
+`ResourceProvisioningPipeline`, applied only on explicit operator confirmation. Schema validation
+still prevents inventing subsystems/bindings/kinds.
+
+## Status
+
+In progress — born-red. Close-out written as the final step before flipping to `complete`.

--- a/.sessions/2026-06-23-ai-setup-create.md
+++ b/.sessions/2026-06-23-ai-setup-create.md
@@ -1,8 +1,8 @@
 # 2026-06-23 — AI setup wedge: propose resource CREATION from a description
 
-> **Status:** `in-progress` — born-red card (Q-0133). Flip to `complete` as the final step.
+> **Status:** `complete` — born-red card (Q-0133) flipped green as the final step.
 > Owner-directed (chat: "Yes go ahead" → the full form of the AI-setup wedge: create channels/roles
-> from a description, not just bind existing ones). Builds on #1355. PR auto-merges on green (Q-0123).
+> from a description, not just bind existing ones). Builds on #1355. PR #1357 auto-merges on green (Q-0123).
 
 ## Arc
 
@@ -33,6 +33,54 @@ creates the resource **and** binds it. The only missing piece is letting a *reco
 `ResourceProvisioningPipeline`, applied only on explicit operator confirmation. Schema validation
 still prevents inventing subsystems/bindings/kinds.
 
-## Status
+## Shipped (PR #1357)
 
-In progress — born-red. Close-out written as the final step before flipping to `complete`.
+- **`services/setup_plan.py`** — `SetupRecommendation` gained `mode: "bind" | "create"` (default
+  `bind`) with `target_id` now optional (`None` for create); `__post_init__` enforces bind⇒target_id,
+  create⇒target_name. New exports `RecommendationMode`, `RECOMMENDATION_MODES`, `CREATABLE_KINDS`
+  (channel/role/category — members/threads are never fabricated). Field reorder is safe (all
+  construction is keyword; verified by grep).
+- **`services/setup_ai_advisor.py`** — strict JSON schema adds `mode` (enum) + nullable `target_id`;
+  `_validate_ai_payload` builds create recs and drops a create of a non-creatable kind; the system
+  prompt explains bind-vs-create and says "prefer binding an existing resource". `_validate_against_schema`
+  still gates every rec, so create can't invent a subsystem/binding/kind.
+- **`services/setup_operations.py`** — `operations_from_recommendations` maps a create rec →
+  `create_<kind>` op (`resource_mode="create"`, `resource_name=target_name`); the existing
+  `_apply_resource_create` → `ResourceProvisioningPipeline` then **creates the resource and binds it**
+  in one audited step. Bind path unchanged.
+- **`views/setup/ai_review/`** — the aggregate panel marks create recs `→ ➕ create`; the
+  per-recommendation view shows `Create & bind: ➕ name (new kind)` instead of an id.
+- **Tests:** `tests/unit/services/test_setup_create_recommendations.py` (12 — model validation · op
+  mapping for channel/role/category · AI parse of create / non-creatable-drop / explicit-bind · the
+  review embed marks creates). Existing setup suites unchanged and green.
+
+## Why it's contained + reversible
+
+Still **no new mutation code** — create flows through the existing audited `ResourceProvisioningPipeline`,
+applied only on explicit operator confirmation (`can_apply_setup` gates Final Review). Schema validation
+still prevents inventing subsystems/bindings/kinds, and only channel/role/category are creatable.
+
+## Verification
+
+- `python3.10 scripts/check_quality.py --full` → 12044 passed (the only two deltas — a stale
+  `env-vars.md` whose line-number citations shifted with the advisor edit, and a black format — were
+  regenerated/formatted and re-verified green via `--check-only` + the env-vars freshness test).
+- `check_architecture --mode strict` → 0 errors (49 pre-existing warnings).
+- Targeted: 79 setup-plan/advisor/operations/create tests green.
+
+## Session enders
+
+- **♻ Grooming (Q-0015):** executed this session's own forward idea (from #1355's log — "extend the
+  wedge to propose resource creation") in the very next session: idea → shipped in one hop (Q-0172).
+- **💡 Session idea (Q-0089):** *A confirmation guard for create recs in Final Review* — creating
+  channels/roles is higher-impact than binding, so a create-heavy plan could show a distinct
+  "N resources will be created" summary line (and count) before apply, so an operator can't
+  rubber-stamp a plan that spawns ten channels. The data is already there (op.kind); it's a
+  rendering + summary tweak. Small, contained; dedup-checked `docs/ideas/`.
+- **⟲ Previous-session review (Q-0102):** #1355 did well to explicitly defer creation as a "clean
+  follow-up" and name the exact missing pieces (schema + adapter) — that scoping note made this
+  session fast (the design was pre-validated). *Workflow win it surfaced:* writing the deferred-scope
+  paragraph into the PR body / session log is high-leverage — the next session inherits a ready plan.
+  Keep doing that for every deliberately-deferred slice.
+- **📋 Doc audit (Q-0104):** no new commands/env-vars → no generated-artifact regen needed; the
+  feature + follow-up are captured here; ledger recorded on merge.

--- a/disbot/services/setup_ai_advisor.py
+++ b/disbot/services/setup_ai_advisor.py
@@ -68,6 +68,8 @@ from services import ai_gateway as _ai_gateway_service
 from services.guild_snapshot import GuildSnapshot
 from services.setup_plan import (
     CONFIDENCES,
+    CREATABLE_KINDS,
+    RECOMMENDATION_MODES,
     DeterministicAdvisor,
     SetupPlanDraft,
     SetupRecommendation,
@@ -101,7 +103,11 @@ _RECOMMENDATION_JSON_SCHEMA: dict[str, Any] = {
                         "subsystem": {"type": "string"},
                         "binding_name": {"type": "string"},
                         "target_kind": {"type": "string"},
-                        "target_id": {"type": "integer"},
+                        # ``bind`` → use an existing resource (``target_id`` set);
+                        # ``create`` → make a new resource named ``target_name``
+                        # (``target_id`` null).
+                        "mode": {"type": "string", "enum": ["bind", "create"]},
+                        "target_id": {"type": ["integer", "null"]},
                         "target_name": {"type": "string"},
                         "confidence": {
                             "type": "string",
@@ -109,10 +115,14 @@ _RECOMMENDATION_JSON_SCHEMA: dict[str, Any] = {
                         },
                         "reason": {"type": "string"},
                     },
+                    # Strict structured output requires every property in
+                    # ``required``; ``target_id`` is made optional via its
+                    # nullable type, not by omission from this list.
                     "required": [
                         "subsystem",
                         "binding_name",
                         "target_kind",
+                        "mode",
                         "target_id",
                         "target_name",
                         "confidence",
@@ -146,7 +156,14 @@ _SYSTEM_PROMPT = (
     "JSON schema provided. Never invent a subsystem name, binding name, or "
     "target kind that does not appear in the snapshot's settings_snapshot "
     "or bindings_snapshot. If you are unsure, return fewer recommendations "
-    "rather than guessing."
+    "rather than guessing.\n"
+    "Each recommendation has a `mode`: use `bind` to wire an EXISTING resource "
+    "to a subsystem binding — set `target_id` to that resource's id and "
+    "`target_name` to its name. Use `create` ONLY when the server is clearly "
+    "missing a resource an important binding needs — set `target_id` to null "
+    "and `target_name` to a short, conventional name to create (e.g. "
+    "`mod-logs`, `welcome`). Prefer binding an existing resource over creating "
+    "a new one whenever a reasonable match exists."
 )
 
 # Appended to the system prompt when the operator supplies a free-form
@@ -353,19 +370,40 @@ def _validate_ai_payload(parsed: Any) -> SetupPlanDraft:
                 f"openai: item[{index}] bad confidence {confidence!r}",
             )
             continue
+        # ``mode`` defaults to "bind" so a model that omits it (or an older
+        # payload) keeps the original behaviour. A "create" rec carries no
+        # existing id; a "bind" rec must.
+        mode = item.get("mode", "bind")
+        if mode not in RECOMMENDATION_MODES:
+            dropped.append(f"openai: item[{index}] bad mode {mode!r}")
+            continue
         try:
+            raw_target_id = item["target_id"]
+            target_id = (
+                None
+                if mode == "create" or raw_target_id is None
+                else int(raw_target_id)
+            )
             rec = SetupRecommendation(
                 subsystem=item["subsystem"],
                 binding_name=item["binding_name"],
                 target_kind=item["target_kind"],
-                target_id=int(item["target_id"]),
+                target_id=target_id,
                 target_name=item["target_name"],
                 confidence=confidence,
                 reason=item["reason"],
+                mode=mode,
                 source=OPENAI,
             )
         except (KeyError, TypeError, ValueError) as exc:
             dropped.append(f"openai: item[{index}] {type(exc).__name__}: {exc}")
+            continue
+
+        if rec.mode == "create" and rec.target_kind not in CREATABLE_KINDS:
+            dropped.append(
+                f"openai: {rec.subsystem}.{rec.binding_name}: cannot create "
+                f"a {rec.target_kind!r} (only {sorted(CREATABLE_KINDS)})",
+            )
             continue
 
         reason = _validate_against_schema(rec)

--- a/disbot/services/setup_operations.py
+++ b/disbot/services/setup_operations.py
@@ -181,6 +181,15 @@ _TARGET_KIND_TO_OP_KIND: dict[str, str] = {
     "member": "bind_member",
 }
 
+# A ``create`` recommendation maps to the create-and-bind provisioning op for
+# its resource kind (the pipeline creates the resource, then binds it). Only
+# these three kinds are creatable; anything else stays a binding op.
+_TARGET_KIND_TO_CREATE_OP_KIND: dict[str, str] = {
+    "channel": "create_channel",
+    "role": "create_role",
+    "category": "create_category",
+}
+
 
 @dataclass
 class SetupOperation:
@@ -1001,20 +1010,41 @@ def operations_from_recommendations(
     recs: list[Any],  # list[services.setup_plan.SetupRecommendation]
 ) -> list[SetupOperation]:
     """Adapt :class:`services.setup_plan.SetupRecommendation` objects to
-    :class:`SetupOperation` binding operations.
+    :class:`SetupOperation`s.
 
-    The current recommendation model only produces binding proposals, so every
-    ``SetupRecommendation`` maps to a ``bind_*`` operation.  Unknown
-    ``target_kind`` values produce operations whose kind is not in
-    ``_KNOWN_KINDS`` — the dispatcher will surface them as
-    ``"not_yet_implemented"`` rather than silently dropping them.
+    A ``mode="bind"`` recommendation maps to a ``bind_*`` operation against an
+    existing resource. A ``mode="create"`` recommendation maps to a
+    ``create_<kind>`` operation (``resource_mode="create"``) — the provisioning
+    pipeline creates the resource named ``target_name`` and then binds it to
+    ``subsystem.binding_name`` in one audited step. Unknown ``target_kind``
+    values produce operations whose kind is not in ``_KNOWN_KINDS`` — the
+    dispatcher surfaces them as ``"not_yet_implemented"`` rather than silently
+    dropping them.
 
-    Future recommendation shapes (``set_setting``, ``create_resource``, etc.)
-    will extend this adapter in follow-up PRs.
+    Future recommendation shapes (``set_setting``, …) will extend this adapter.
     """
     result: list[SetupOperation] = []
     for rec in recs:
         raw_kind = (rec.target_kind or "").lower()
+        if getattr(rec, "mode", "bind") == "create":
+            # Create-and-bind: the new resource has no id yet; its name rides
+            # ``resource_name`` for the provisioning pipeline.
+            kind = _TARGET_KIND_TO_CREATE_OP_KIND.get(
+                raw_kind,
+                f"create_{raw_kind}" if raw_kind else "create_unknown",
+            )
+            result.append(
+                SetupOperation(
+                    kind=kind,
+                    subsystem=rec.subsystem,
+                    binding_name=rec.binding_name,
+                    target_kind=rec.target_kind,
+                    resource_name=rec.target_name,
+                    resource_mode="create",
+                    metadata=metadata_from_recommendation(rec),
+                ),
+            )
+            continue
         kind = _TARGET_KIND_TO_OP_KIND.get(
             raw_kind,
             # Unknown target_kind → synthetic kind that the dispatcher

--- a/disbot/services/setup_plan.py
+++ b/disbot/services/setup_plan.py
@@ -48,18 +48,37 @@ CONFIDENCES: frozenset[str] = frozenset({"high", "medium", "low"})
 
 _CONFIDENCE_ORDER = {"high": 0, "medium": 1, "low": 2}
 
+# A recommendation either **binds** an existing resource (the original model —
+# ``target_id`` points at a live channel/role/category) or proposes **creating**
+# a new one (``target_id is None``; ``target_name`` is the name to create, which
+# the provisioning pipeline then binds to ``subsystem.binding_name``).
+RecommendationMode = Literal["bind", "create"]
+
+RECOMMENDATION_MODES: frozenset[str] = frozenset({"bind", "create"})
+
+# Resource kinds the bot can create on the operator's behalf (a ``create``
+# recommendation of any other kind is invalid — we never fabricate members/threads).
+CREATABLE_KINDS: frozenset[str] = frozenset({"channel", "role", "category"})
+
 
 @dataclass(frozen=True)
 class SetupRecommendation:
-    """One proposed binding for the wizard to surface to the operator."""
+    """One proposed setup action for the wizard to surface to the operator.
+
+    ``mode`` distinguishes binding an existing resource (``"bind"`` — the
+    default; ``target_id`` is the live resource) from proposing a new one
+    (``"create"`` — ``target_id is None`` and ``target_name`` is the name to
+    create + bind).
+    """
 
     subsystem: str
     binding_name: str
     target_kind: str  # "channel" / "category" / "role" / "thread" / "member"
-    target_id: int
     target_name: str
     confidence: Confidence
     reason: str
+    target_id: int | None = None  # required for "bind"; None for "create"
+    mode: RecommendationMode = "bind"
     source: str = "deterministic"
 
     def __post_init__(self) -> None:
@@ -68,6 +87,15 @@ class SetupRecommendation:
                 f"confidence must be one of {sorted(CONFIDENCES)}, "
                 f"got {self.confidence!r}",
             )
+        if self.mode not in RECOMMENDATION_MODES:
+            raise ValueError(
+                f"mode must be one of {sorted(RECOMMENDATION_MODES)}, "
+                f"got {self.mode!r}",
+            )
+        if self.mode == "bind" and self.target_id is None:
+            raise ValueError("a 'bind' recommendation requires a target_id")
+        if self.mode == "create" and not self.target_name:
+            raise ValueError("a 'create' recommendation requires a target_name")
 
 
 @dataclass(frozen=True)

--- a/disbot/views/setup/ai_review/main_panel.py
+++ b/disbot/views/setup/ai_review/main_panel.py
@@ -123,8 +123,11 @@ def build_ai_review_embed(draft: SetupPlanDraft) -> discord.Embed:
         lines = []
         for rec in by_sub[subsystem]:
             icon = _CONFIDENCE_ICON[rec.confidence]
+            # A "create" rec proposes making a new resource (➕); a "bind" rec
+            # wires an existing one (→).
+            arrow = "→ ➕ create" if getattr(rec, "mode", "bind") == "create" else "→"
             lines.append(
-                f"{icon} `{rec.binding_name}` → `{rec.target_name}` — {rec.reason}",
+                f"{icon} `{rec.binding_name}` {arrow} `{rec.target_name}` — {rec.reason}",
             )
         value = "\n".join(lines)
         if len(value) > 1000:

--- a/disbot/views/setup/ai_review/per_recommendation.py
+++ b/disbot/views/setup/ai_review/per_recommendation.py
@@ -54,12 +54,20 @@ def build_per_recommendation_embed(
     color = _CONFIDENCE_COLOR[rec.confidence]
     is_accepted = accepted.contains(rec)
     state_label = "✅ accepted" if is_accepted else "⬜ pending"
+    # A "create" rec has no existing id — it proposes making the resource and
+    # binding it; a "bind" rec wires an existing one (shown with its id).
+    if getattr(rec, "mode", "bind") == "create":
+        target_line = (
+            f"**Create & bind:** ➕ `{rec.target_name}` (new `{rec.target_kind}`)\n"
+        )
+    else:
+        target_line = f"**Target:** `{rec.target_name}` (id `{rec.target_id}`)\n"
     embed = discord.Embed(
         title=(f"🤖 Suggestion {safe_index + 1} / {total} · {state_label}"),
         description=(
             f"**Subsystem:** `{rec.subsystem}`\n"
             f"**Binding:** `{rec.binding_name}` (`{rec.target_kind}`)\n"
-            f"**Target:** `{rec.target_name}` (id `{rec.target_id}`)\n"
+            f"{target_line}"
             f"**Confidence:** `{rec.confidence}`\n"
             f"**Source:** `{rec.source}`\n\n"
             f"_{rec.reason}_"

--- a/docs/operations/env-vars.md
+++ b/docs/operations/env-vars.md
@@ -55,12 +55,12 @@ only — never a value**; the values live in Railway service variables
 | `HEALTH_PORT` | healthserver | `disbot/healthserver.py:64` *(default)* |
 | `IDENTITY_CONTRACT_STRICT` | bot1 | `disbot/bot1.py:175` *(default)* |
 | `LOG_LEVEL` | config | `disbot/config.py:114` *(default)* |
-| `OPENAI_API_KEY` | config, core, services | `disbot/config.py:150` *(default)*<br>`disbot/core/runtime/ai/providers/openai_moderation.py:68` *(default)*<br>`disbot/core/runtime/ai/providers/openai_provider.py:74` *(default)*<br>`disbot/services/setup_ai_advisor.py:188` *(default)*<br>`disbot/services/setup_ai_advisor.py:447` *(default)* |
+| `OPENAI_API_KEY` | config, core, services | `disbot/config.py:150` *(default)*<br>`disbot/core/runtime/ai/providers/openai_moderation.py:68` *(default)*<br>`disbot/core/runtime/ai/providers/openai_provider.py:74` *(default)*<br>`disbot/services/setup_ai_advisor.py:205` *(default)*<br>`disbot/services/setup_ai_advisor.py:485` *(default)* |
 | `PARAGON_API_BASE_URL` | config, services | `disbot/config.py:177` *(default)*<br>`disbot/services/paragon_service.py:49` *(default)* |
 | `PARAGON_API_KEY` | config, services | `disbot/config.py:181` *(default)*<br>`disbot/services/paragon_service.py:50` *(default)* |
 | `RAILWAY_GIT_COMMIT_SHA` | core | `disbot/core/runtime/command_manifest.py:243` *(default)* |
-| `SETUP_ADVISOR_OPENAI_MODEL` | config, services | `disbot/config.py:149` *(default)*<br>`disbot/services/setup_ai_advisor.py:186` *(default)* |
-| `SETUP_ADVISOR_PROVIDER` | config, core, services | `disbot/config.py:148` *(default)*<br>`disbot/core/runtime/ai/feature_flags.py:129` *(default)*<br>`disbot/services/setup_ai_advisor.py:434` *(default)* |
+| `SETUP_ADVISOR_OPENAI_MODEL` | config, services | `disbot/config.py:149` *(default)*<br>`disbot/services/setup_ai_advisor.py:203` *(default)* |
+| `SETUP_ADVISOR_PROVIDER` | config, core, services | `disbot/config.py:148` *(default)*<br>`disbot/core/runtime/ai/feature_flags.py:129` *(default)*<br>`disbot/services/setup_ai_advisor.py:472` *(default)* |
 | `STRICT_DISABLED` | bot1 | `disbot/bot1.py:172` *(default)* |
 
 <!-- END GENERATED — everything below is hand-maintained (web-tier env vars the disbot scanner can't see); the scanner preserves it across --write-doc. -->

--- a/docs/owner/claims/claude__ai-setup-create.md
+++ b/docs/owner/claims/claude__ai-setup-create.md
@@ -1,1 +1,0 @@
-claude/ai-setup-create · AI setup wedge: propose resource CREATION from a description (create+bind) · `disbot/services/setup_plan.py`, `disbot/services/setup_ai_advisor.py`, `disbot/services/setup_operations.py`, `disbot/views/setup/ai_review/` · stacked on #1355 · 2026-06-23

--- a/docs/owner/claims/claude__ai-setup-create.md
+++ b/docs/owner/claims/claude__ai-setup-create.md
@@ -1,0 +1,1 @@
+claude/ai-setup-create · AI setup wedge: propose resource CREATION from a description (create+bind) · `disbot/services/setup_plan.py`, `disbot/services/setup_ai_advisor.py`, `disbot/services/setup_operations.py`, `disbot/views/setup/ai_review/` · stacked on #1355 · 2026-06-23

--- a/tests/unit/services/test_setup_create_recommendations.py
+++ b/tests/unit/services/test_setup_create_recommendations.py
@@ -1,0 +1,288 @@
+"""Tests for the create-and-bind setup recommendation path.
+
+Covers the full thread of the "propose resource creation from a description"
+feature: the model's ``mode`` validation, the AI payload parser building create
+recs, the op adapter mapping a create rec to a ``create_<kind>`` provisioning
+op, and the review embed marking creates distinctly.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from core.runtime.subsystem_schema import (
+    BindingKind,
+    BindingSpec,
+    SubsystemSchema,
+)
+from services.guild_snapshot import GuildSnapshot
+from services.setup_ai_advisor import OpenAISetupAdvisor
+from services.setup_operations import operations_from_recommendations
+from services.setup_plan import SetupPlanDraft, SetupRecommendation
+
+
+def _snap() -> GuildSnapshot:
+    return GuildSnapshot(guild_id=1, guild_name="Test", owner_id=9)
+
+
+# ---------------------------------------------------------------------------
+# Model validation
+# ---------------------------------------------------------------------------
+
+
+def test_create_recommendation_allows_null_target_id():
+    rec = SetupRecommendation(
+        subsystem="logging",
+        binding_name="mod_channel",
+        target_kind="channel",
+        target_name="mod-logs",
+        confidence="high",
+        reason="no mod-log channel exists yet",
+        mode="create",
+    )
+    assert rec.mode == "create"
+    assert rec.target_id is None
+
+
+def test_bind_recommendation_requires_target_id():
+    with pytest.raises(ValueError, match="requires a target_id"):
+        SetupRecommendation(
+            subsystem="logging",
+            binding_name="mod_channel",
+            target_kind="channel",
+            target_name="mod-log",
+            confidence="high",
+            reason="match",
+        )  # mode defaults to "bind"; no target_id
+
+
+def test_create_recommendation_requires_target_name():
+    with pytest.raises(ValueError, match="requires a target_name"):
+        SetupRecommendation(
+            subsystem="logging",
+            binding_name="mod_channel",
+            target_kind="channel",
+            target_name="",
+            confidence="high",
+            reason="x",
+            mode="create",
+        )
+
+
+def test_bad_mode_raises():
+    with pytest.raises(ValueError, match="mode must be one of"):
+        SetupRecommendation(
+            subsystem="logging",
+            binding_name="mod_channel",
+            target_kind="channel",
+            target_name="mod-log",
+            confidence="high",
+            reason="x",
+            target_id=1,
+            mode="frobnicate",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Op adapter
+# ---------------------------------------------------------------------------
+
+
+def test_create_rec_maps_to_create_channel_op():
+    rec = SetupRecommendation(
+        subsystem="logging",
+        binding_name="mod_channel",
+        target_kind="channel",
+        target_name="mod-logs",
+        confidence="high",
+        reason="missing",
+        mode="create",
+    )
+    ops = operations_from_recommendations([rec])
+    assert len(ops) == 1
+    op = ops[0]
+    assert op.kind == "create_channel"
+    assert op.resource_mode == "create"
+    assert op.resource_name == "mod-logs"
+    assert op.subsystem == "logging"
+    assert op.binding_name == "mod_channel"
+    assert op.target_id is None
+
+
+def test_create_role_and_category_map_too():
+    role = SetupRecommendation(
+        subsystem="moderation",
+        binding_name="staff_role",
+        target_kind="role",
+        target_name="Staff",
+        confidence="medium",
+        reason="m",
+        mode="create",
+    )
+    cat = SetupRecommendation(
+        subsystem="moderation",
+        binding_name="staff_category",
+        target_kind="category",
+        target_name="Staff Zone",
+        confidence="medium",
+        reason="m",
+        mode="create",
+    )
+    kinds = {op.kind for op in operations_from_recommendations([role, cat])}
+    assert kinds == {"create_role", "create_category"}
+
+
+def test_bind_rec_still_maps_to_bind_op():
+    rec = SetupRecommendation(
+        subsystem="logging",
+        binding_name="mod_channel",
+        target_kind="channel",
+        target_name="mod-log",
+        confidence="high",
+        reason="match",
+        target_id=123,
+    )
+    ops = operations_from_recommendations([rec])
+    assert ops[0].kind == "bind_channel"
+    assert ops[0].target_id == 123
+    assert ops[0].resource_mode is None
+
+
+# ---------------------------------------------------------------------------
+# AI payload parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _logging_schema():
+    schemas = {
+        "logging": SubsystemSchema(
+            subsystem="logging",
+            bindings=(
+                BindingSpec(
+                    name="mod_channel",
+                    kind=BindingKind.CHANNEL,
+                    required=True,
+                    hint="",
+                    capability_required="logging.mod_channel.bind",
+                ),
+            ),
+        ),
+    }
+    with patch(
+        "core.runtime.subsystem_schema.all_schemas",
+        return_value=schemas,
+    ):
+        yield schemas
+
+
+def _fake_client(payload: dict) -> MagicMock:
+    message = MagicMock()
+    message.content = json.dumps(payload)
+    choice = MagicMock()
+    choice.message = message
+    response = MagicMock()
+    response.choices = [choice]
+    client = MagicMock()
+    client.chat = MagicMock()
+    client.chat.completions = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=response)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_ai_create_recommendation_parsed(_logging_schema):
+    payload = {
+        "recommendations": [
+            {
+                "subsystem": "logging",
+                "binding_name": "mod_channel",
+                "target_kind": "channel",
+                "mode": "create",
+                "target_id": None,
+                "target_name": "mod-logs",
+                "confidence": "high",
+                "reason": "no moderation log channel exists",
+            },
+        ],
+    }
+    advisor = OpenAISetupAdvisor(client=_fake_client(payload), api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    assert len(draft.recommendations) == 1
+    rec = draft.recommendations[0]
+    assert rec.mode == "create"
+    assert rec.target_id is None
+    assert rec.target_name == "mod-logs"
+
+
+@pytest.mark.asyncio
+async def test_ai_create_of_noncreatable_kind_dropped(_logging_schema):
+    payload = {
+        "recommendations": [
+            {
+                "subsystem": "logging",
+                "binding_name": "mod_channel",
+                "target_kind": "member",  # members are never created
+                "mode": "create",
+                "target_id": None,
+                "target_name": "x",
+                "confidence": "high",
+                "reason": "y",
+            },
+        ],
+    }
+    advisor = OpenAISetupAdvisor(client=_fake_client(payload), api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    assert draft.recommendations == ()
+    assert any("cannot create" in d for d in draft.dropped)
+
+
+@pytest.mark.asyncio
+async def test_ai_bind_with_explicit_mode_still_validates(_logging_schema):
+    payload = {
+        "recommendations": [
+            {
+                "subsystem": "logging",
+                "binding_name": "mod_channel",
+                "target_kind": "channel",
+                "mode": "bind",
+                "target_id": 555,
+                "target_name": "mod-log",
+                "confidence": "high",
+                "reason": "exact match",
+            },
+        ],
+    }
+    advisor = OpenAISetupAdvisor(client=_fake_client(payload), api_key="sk-test")
+    draft = await advisor.suggest(_snap())
+
+    assert len(draft.recommendations) == 1
+    assert draft.recommendations[0].mode == "bind"
+    assert draft.recommendations[0].target_id == 555
+
+
+# ---------------------------------------------------------------------------
+# Review rendering
+# ---------------------------------------------------------------------------
+
+
+def test_review_embed_marks_create_recs():
+    from views.setup.ai_review.main_panel import build_ai_review_embed
+
+    rec = SetupRecommendation(
+        subsystem="logging",
+        binding_name="mod_channel",
+        target_kind="channel",
+        target_name="mod-logs",
+        confidence="high",
+        reason="missing",
+        mode="create",
+    )
+    embed = build_ai_review_embed(SetupPlanDraft(recommendations=(rec,)))
+    body = " ".join(f.value or "" for f in embed.fields)
+    assert "➕ create" in body


### PR DESCRIPTION
## Why

Follow-up to #1355 (`/setup-describe`, merged). That shipped binding **existing** channels/roles from a natural-language description. This is the full form: when a described server is **missing** a resource an important binding needs, the advisor proposes **creating** it.

The apply seam already supports this — `_apply_resource_create` builds a `ProvisioningRequest(mode="create", custom_name=…)` and `ResourceProvisioningPipeline` creates the resource **and** binds it in one op. The only missing piece was letting a *recommendation* express "create" and threading it through validation, the op adapter, and the review UI.

## What this PR does

- **`setup_plan.SetupRecommendation`** — adds `mode: "bind" | "create"` (default `bind`) and makes `target_id` optional (`None` for create); validates bind⇒`target_id` present, create⇒a proposed name. The deterministic advisor stays bind-only (unchanged).
- **`setup_ai_advisor`** — extends the strict JSON schema (`mode` enum + nullable `target_id`), teaches `_validate_ai_payload` to build create recs, and lets the prompt propose creating a missing resource. `_validate_against_schema` still gates every rec (subsystem/binding/kind must exist) — create can't invent a binding either.
- **`setup_operations.operations_from_recommendations`** — maps a create rec → `create_<kind>` op (`resource_mode="create"`, `resource_name=target_name`) so apply runs the existing create+bind pipeline.
- **`views/setup/ai_review/`** — renders create recs distinctly (➕ create `name` → bind …).
- Tests across the model / schema / adapter / rendering.

**Contained + reversible:** still no *new* mutation code — create flows through the existing audited `ResourceProvisioningPipeline`, applied only on explicit operator confirmation. Schema validation still prevents inventing subsystems/bindings/kinds.

Born-red per Q-0133; auto-merges on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzBMYDtbYx95WgeWPggWJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzBMYDtbYx95WgeWPggWJj)_