### PR TITLE
Final Review: flag resource creation before apply (create-count guard)

### DIFF
--- a/.sessions/2026-06-23-setup-create-confirm.md
+++ b/.sessions/2026-06-23-setup-create-confirm.md
@@ -1,8 +1,8 @@
 # 2026-06-23 — Final Review create-count guard + #1351 ledger drift fix
 
-> **Status:** `in-progress` — born-red card (Q-0133). Flip to `complete` as the final step.
+> **Status:** `complete` — born-red card (Q-0133) flipped green as the final step.
 > Owner-directed (chat: "continue from where you left off" → the create-count confirmation summary
-> teed up at the end of the #1357 wedge session). PR auto-merges on green (Q-0123).
+> teed up at the end of the #1357 wedge session). PR #1361 auto-merges on green (Q-0123).
 
 ## Arc
 
@@ -27,6 +27,37 @@ newest-merge lag). Per Q-0166 ("fix drift you can SEE on sight"), fixed it in pa
 
 **Contained:** rendering-only on the read path — no mutation/apply changes.
 
-## Status
+## Shipped (PR #1361)
 
-In progress — born-red. Close-out written as the final step before flipping to `complete`.
+- **`views/setup/final_review.py`** — `_CREATE_OP_KINDS` + `_created_resource_names()` (both staged
+  shapes: `SetupOperation` create kinds → `resource_name`; `SetupRecommendation` `mode="create"` →
+  `target_name`), and a distinct **"➕ N new resource(s) will be created"** field on the pre-apply
+  embed naming the resources, with a "binding is reversible; a created resource must be deleted to
+  undo" caveat. Bind-only plans render byte-identically.
+- **`docs/current-state.md`** — #1351 added to the fishing Recently-shipped bullet (real drift fix,
+  Q-0166).
+- **Tests** — `test_final_review_caveat.py` +4: create op flagged · bind-only not flagged ·
+  recommendation `mode="create"` flagged · `_created_resource_names` handles both shapes.
+
+## Verification
+
+- `python3.10 scripts/check_quality.py --full` → **All checks passed** (12054 passed, 48 skipped, 2 xfailed).
+- `check_architecture --mode strict` → 0 errors (49 pre-existing warnings).
+- Targeted: 73 final-review / draft / ai-review tests green. Ledger `--strict` → exit 0 (only benign
+  newest-merge lag remains).
+
+## Session enders
+
+- **♻ Grooming (Q-0015):** executed this session's predecessor idea (the #1357 create-count guard)
+  — idea → shipped in the next session (Q-0172). Also fixed #1351 ledger drift on sight (Q-0166).
+- **💡 Session idea (Q-0089):** *Per-kind create breakdown in the guard* — the field currently shows
+  a flat count + names; for a large plan, grouping by kind ("2 channels, 1 role, 1 category") would
+  let an operator sanity-check the shape at a glance. Tiny rendering tweak on the same helper (it
+  already has `op.kind`); dedup-checked `docs/ideas/`, not captured.
+- **⟲ Previous-session review (Q-0102):** #1357 did well to ship the create path with full
+  validation + tests AND name the exact next polish in its session idea, which made this session a
+  clean 30-minute slice. *Workflow note:* the SessionStart ledger checker correctly separated benign
+  newest-merge lag (#1355–#1358) from real older-than-marker drift (#1351) — that distinction (Q-0166)
+  is working as designed and stopped me from either ignoring real drift or churning on benign lag.
+- **📋 Doc audit (Q-0104):** no new commands/env-vars → no generated-artifact regen; ledger `--strict`
+  green (real drift cleared); feature + follow-up captured here.

--- a/.sessions/2026-06-23-setup-create-confirm.md
+++ b/.sessions/2026-06-23-setup-create-confirm.md
@@ -1,0 +1,32 @@
+# 2026-06-23 — Final Review create-count guard + #1351 ledger drift fix
+
+> **Status:** `in-progress` — born-red card (Q-0133). Flip to `complete` as the final step.
+> Owner-directed (chat: "continue from where you left off" → the create-count confirmation summary
+> teed up at the end of the #1357 wedge session). PR auto-merges on green (Q-0123).
+
+## Arc
+
+#1355/#1357 gave `/setup-describe` the power to **create** channels/roles from a description.
+Creating resources is higher-impact and harder to undo than binding existing ones, so the apply
+screen should call out *what will be made* before the operator commits — the polish flagged as
+#1357's session idea (Q-0089). This session adds that guard.
+
+Also: the SessionStart ledger check surfaced **#1351 (fishing trophy records) as real drift** — a
+merge older than the reconciliation marker #1352 that the #1352 pass missed (not benign
+newest-merge lag). Per Q-0166 ("fix drift you can SEE on sight"), fixed it in passing.
+
+## Plan (this PR)
+
+- `views/setup/final_review.py` — a `_created_resource_names()` helper (handles both staged shapes:
+  `SetupOperation` create kinds → `resource_name`; `SetupRecommendation` `mode="create"` →
+  `target_name`) and a distinct **"➕ N new resource(s) will be created"** field on the pre-apply
+  embed, naming the resources. Bind-only plans are unchanged.
+- `docs/current-state.md` — add #1351 to the fishing Recently-shipped bullet (drift fix; no new
+  top-level entry, so the ratchet is unaffected).
+- Tests in `test_final_review_caveat.py`.
+
+**Contained:** rendering-only on the read path — no mutation/apply changes.
+
+## Status
+
+In progress — born-red. Close-out written as the final step before flipping to `complete`.

--- a/disbot/views/setup/final_review.py
+++ b/disbot/views/setup/final_review.py
@@ -127,6 +127,32 @@ def _render_pending_line(item: Any) -> str:
     )
 
 
+# Op kinds that *create* a Discord resource (vs. binding an existing one).
+# Mirrors the resource-provisioning phase of :data:`_PHASE_ORDER`.
+_CREATE_OP_KINDS: frozenset[str] = frozenset(
+    {"create_channel", "create_role", "create_category"},
+)
+
+
+def _created_resource_names(accepted: list[Any] | tuple[Any, ...]) -> list[str]:
+    """Names of resources a staged plan would CREATE (not just bind).
+
+    Handles both staged shapes: a :class:`SetupOperation` (``kind`` in the
+    create set → ``resource_name``) and a :class:`SetupRecommendation`
+    (``mode == "create"`` → ``target_name``). Returns the display names so the
+    apply screen can call out exactly what will be made before the operator
+    commits — creating channels/roles is higher-impact than binding, so it
+    should never be rubber-stamped.
+    """
+    names: list[str] = []
+    for item in accepted:
+        if getattr(item, "kind", None) in _CREATE_OP_KINDS:
+            names.append(str(getattr(item, "resource_name", None) or "?"))
+        elif getattr(item, "mode", "bind") == "create":
+            names.append(str(getattr(item, "target_name", None) or "?"))
+    return names
+
+
 def build_final_review_embed(
     accepted: list[Any] | tuple[Any, ...],
     *,
@@ -178,6 +204,23 @@ def build_final_review_embed(
         if len(value) > 1000:
             value = value[:997] + "..."
         embed.add_field(name="Pending", value=value, inline=False)
+        # Call out resource CREATION distinctly: creating channels/roles is
+        # higher-impact + harder to undo than binding existing ones, so the
+        # operator should see the count + names before committing.
+        created = _created_resource_names(accepted)
+        if created:
+            shown = ", ".join(f"`{n}`" for n in created[:10])
+            if len(created) > 10:
+                shown += f" _+{len(created) - 10} more_"
+            embed.add_field(
+                name=f"➕ {len(created)} new resource(s) will be created",
+                value=(
+                    f"Applying this plan **creates** these and binds them: {shown}. "
+                    "Binding an existing resource is reversible; a created "
+                    "channel/role/category is new and must be deleted to undo."
+                ),
+                inline=False,
+            )
         # No-rollback caveat (plan §D3): apply has no automatic undo.
         # Operations run through idempotent pipelines in phase order; if
         # one fails midway, the ones already applied stay applied.

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -231,11 +231,12 @@ Source code and merged PRs win over anything written here.
   thanks/upvote reputation subsystem (#1332, plan #1330); a **Casino** subsystem — a multiplayer card-game
   **table framework + Texas Hold'em poker** (#1333); and a **Treasury** — a server-owned coin pool on the
   economy↔governance seam (#1334) with a Treasury button wired into the Economy panel (panel-link fix, #1344).
-- **#1329 · #1337 · #1338 · #1340 · #1341 · #1342 (2026-06-23, fishing minigame — economy knobs + venues + polish)** —
+- **#1329 · #1337 · #1338 · #1340 · #1341 · #1342 · #1351 (2026-06-23, fishing minigame — economy knobs + venues + polish)** —
   the fishing game gained its second pre-cast economy knob, **Bait** (coin sink + rarity bias, #1329), a **bait
   speed knob** (faster bites, #1337) and **bait-crafting** (turn caught fish into bait — closes the catch→bait
   loop, #1338); plus a **deepwater boat venue** (⛵ Set sail / Dock, #1340), a **daily weather forecast**
-  (date-seeded global bias, #1341), and a test-helper consolidation of the duplicated `roll_catch` mock (#1342).
+  (date-seeded global bias, #1341), a test-helper consolidation of the duplicated `roll_catch` mock (#1342),
+  and **per-species trophy records** (your heaviest catch per species in the Fishdex, #1351).
 - **#1324 · #1325 · #1326 (2026-06-23, BTD6 round economy)** — surfaced **round XP** in the NL reply +
   round-embed Economy field (#1324), then the **unified round-economy reply** (RBE + cash + XP in one answer,
   #1326), backed by validated **XP-per-round data** (`round_xp.json`, #1318 — merged via #1325, which also

--- a/docs/owner/claims/claude__setup-create-confirm.md
+++ b/docs/owner/claims/claude__setup-create-confirm.md
@@ -1,0 +1,1 @@
+claude/setup-create-confirm · Final Review create-count guard (➕ N new resources will be created) + #1351 ledger drift fix · `disbot/views/setup/final_review.py`, `docs/current-state.md` · 2026-06-23

--- a/docs/owner/claims/claude__setup-create-confirm.md
+++ b/docs/owner/claims/claude__setup-create-confirm.md
@@ -1,1 +1,0 @@
-claude/setup-create-confirm · Final Review create-count guard (➕ N new resources will be created) + #1351 ledger drift fix · `disbot/views/setup/final_review.py`, `docs/current-state.md` · 2026-06-23

--- a/tests/unit/views/test_final_review_caveat.py
+++ b/tests/unit/views/test_final_review_caveat.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from services.setup_operations import SetupOperation
+from services.setup_plan import SetupRecommendation
 from views.setup import final_review
-from views.setup.final_review import ApplySummary, build_final_review_embed
+from views.setup.final_review import (
+    ApplySummary,
+    _created_resource_names,
+    build_final_review_embed,
+)
 
 
 def _op(binding_name="announce_channel"):
@@ -17,6 +22,17 @@ def _op(binding_name="announce_channel"):
         subsystem="xp",
         binding_name=binding_name,
         target_name="#general",
+        metadata={},
+    )
+
+
+def _create_op(resource_name="mod-logs", kind="create_channel"):
+    return SetupOperation(
+        kind=kind,
+        subsystem="logging",
+        binding_name="mod_channel",
+        resource_name=resource_name,
+        resource_mode="create",
         metadata={},
     )
 
@@ -47,6 +63,52 @@ def test_full_success_embed_has_no_rollback_field():
     # The complete state is celebratory; the heads-up belongs on the
     # pre-apply screen, not after a clean apply.
     assert "heads-up" not in {f.name.lower() for f in embed.fields}
+
+
+def test_pre_apply_embed_flags_resource_creation():
+    """A create op surfaces a distinct 'N new resource(s) will be created' field
+    naming the resource — so creation is never rubber-stamped."""
+    embed = build_final_review_embed([_create_op("mod-logs"), _op()])
+    field_names = " ".join(f.name for f in embed.fields).lower()
+    text = _all_text(embed)
+    assert "new resource(s) will be created" in field_names
+    assert "1 new resource" in field_names
+    assert "mod-logs" in text
+
+
+def test_bind_only_plan_has_no_create_field():
+    embed = build_final_review_embed([_op(), _op("rules_channel")])
+    field_names = " ".join(f.name for f in embed.fields).lower()
+    assert "will be created" not in field_names
+
+
+def test_create_recommendation_also_flagged():
+    """The recommendation shape (mode='create') triggers the same guard."""
+    rec = SetupRecommendation(
+        subsystem="logging",
+        binding_name="mod_channel",
+        target_kind="channel",
+        target_name="mod-logs",
+        confidence="high",
+        reason="missing",
+        mode="create",
+    )
+    embed = build_final_review_embed([rec])
+    assert "will be created" in " ".join(f.name for f in embed.fields).lower()
+
+
+def test_created_resource_names_handles_both_shapes():
+    rec = SetupRecommendation(
+        subsystem="logging",
+        binding_name="mod_channel",
+        target_kind="role",
+        target_name="Staff",
+        confidence="medium",
+        reason="m",
+        mode="create",
+    )
+    names = _created_resource_names([_create_op("mod-logs"), _op(), rec])
+    assert names == ["mod-logs", "Staff"]
 
 
 def test_final_review_view_has_ai_review_button():


### PR DESCRIPTION
## Why

Follow-up to #1355/#1357, which gave `/setup-describe` the power to **create** channels/roles from a description. Creating resources is higher-impact and harder to undo than binding existing ones, so the apply screen should call out *what will be made* before the operator commits (the polish flagged as #1357's session idea).

## What this PR does

- **`views/setup/final_review.py`** — a `_created_resource_names()` helper (handles both staged shapes: `SetupOperation` create kinds → `resource_name`; `SetupRecommendation` `mode="create"` → `target_name`) and a distinct **"➕ N new resource(s) will be created"** field on the pre-apply embed, naming the resources. Bind-only plans render unchanged. Rendering-only — no mutation/apply changes.
- Tests in `test_final_review_caveat.py` (create op flagged · bind-only not flagged · recommendation shape flagged · helper handles both shapes).

Also records **#1351** (fishing trophy records) in `docs/current-state.md` — real ledger drift older than the reconciliation marker #1352 that the #1352 pass missed (Q-0166 "fix drift on sight"; no new top-level entry, so the ratchet is unaffected).

Born-red per Q-0133; auto-merges on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzBMYDtbYx95WgeWPggWJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzBMYDtbYx95WgeWPggWJj)_