### PR TITLE
Promote loose session ideas into the docs/ideas backlog (session-close audit)

### DIFF
--- a/.sessions/2026-06-23-session-idea-capture.md
+++ b/.sessions/2026-06-23-session-idea-capture.md
@@ -1,0 +1,31 @@
+# 2026-06-23 — Promote loose session ideas into the docs/ideas backlog
+
+> **Status:** `in-progress` — born-red card (Q-0133). Flip to `complete` as the final step.
+> Owner-directed (chat: "make sure all ideas etc are properly documented so nothing important from
+> this session is lost"). Docs-only. PR auto-merges on green (Q-0123).
+
+## Arc
+
+Session-close documentation audit for the 2026-06-23 visual-engine / AI-setup arc (#1349 card
+engine · #1352 positioning · #1355 + #1357 `/setup-describe` · #1361 create-count guard). Audit
+findings:
+
+- **Shipped work is durably captured:** the Dank Memer visual research → the card-engine vision doc;
+  the 15-bot competitive research → the positioning north-star doc + the competitive-positioning
+  session log's "Research provenance" section; every feature → its `.sessions/` log, all merged.
+- **#1361 is still open (auto-merging on green)** — it carries the create-count guard, the #1351
+  ledger drift fix, and its session log; nothing lost, lands on merge. (So the #1351 "real drift" the
+  SessionStart checker flags on main is already fixed in the pending PR — NOT re-fixed here.)
+- **Gap closed by this PR:** three forward-ideas (Q-0089) lived only in `.sessions/` logs, invisible
+  to anyone browsing the `docs/ideas/` conveyor. Promoted them into the backlog.
+
+## Shipped (this PR)
+
+- `docs/ideas/session-followups-visual-ai-setup-2026-06-23.md` — the three open ideas with
+  provenance: (1) golden-image card-engine snapshot tests, (2) a user-visible cosmetic-only
+  monetization pledge surface, (3) a per-kind breakdown in the #1361 create-count guard.
+- `docs/ideas/README.md` index entry.
+
+## Status
+
+In progress — born-red. Close-out written as the final step before flipping to `complete`.

--- a/.sessions/2026-06-23-session-idea-capture.md
+++ b/.sessions/2026-06-23-session-idea-capture.md
@@ -1,8 +1,8 @@
 # 2026-06-23 — Promote loose session ideas into the docs/ideas backlog
 
-> **Status:** `in-progress` — born-red card (Q-0133). Flip to `complete` as the final step.
+> **Status:** `complete` — born-red card (Q-0133) flipped green as the final step.
 > Owner-directed (chat: "make sure all ideas etc are properly documented so nothing important from
-> this session is lost"). Docs-only. PR auto-merges on green (Q-0123).
+> this session is lost"). Docs-only. PR #1362 auto-merges on green (Q-0123).
 
 ## Arc
 

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,13 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`session-followups-visual-ai-setup-2026-06-23.md`](./session-followups-visual-ai-setup-2026-06-23.md) —
+  **session-idea promotion (2026-06-23, Q-0089):** the three open forward-ideas from the visual-engine /
+  AI-setup arc (PRs #1349/#1352/#1355/#1357/#1361), lifted out of their `.sessions/` logs into the
+  backlog so grooming finds them — **(1)** golden-image snapshot tests for the card engine (catches
+  layout regressions the byte-check misses; load-bearing at engine roadmap H2), **(2)** a user-visible
+  *cosmetic-only monetization pledge* surface (the north-star's Pillar 1, user-facing half), **(3)** a
+  per-kind breakdown in the #1361 setup create-count guard. Cross-cutting; build-when-convenient.
 - [`new-subsystem-followup-tracker-2026-06-23.md`](./new-subsystem-followup-tracker-2026-06-23.md) —
   **reconciliation idea (2026-06-23, band-#1350 Q-0089):** the band stood up **four** new subsystems
   (farm/karma/casino/treasury), each with obvious follow-up depth that lives only in scattered session-card

--- a/docs/ideas/session-followups-visual-ai-setup-2026-06-23.md
+++ b/docs/ideas/session-followups-visual-ai-setup-2026-06-23.md
@@ -1,0 +1,54 @@
+# Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)
+
+> **Status:** `ideas` — capture only, not approval, not a plan. Source + binding contracts win.
+> **Subsystem:** none (cross-cutting). Promoted out of their `.sessions/` logs into the backlog so
+> grooming finds them without grepping session history (the Q-0089 "substantial ideas get a backlog
+> home" follow-through).
+
+These are the genuine forward ideas generated during the 2026-06-23 visual / AI-setup arc (PRs
+#1349 card engine · #1352 positioning · #1355 + #1357 `/setup-describe` · #1361 create-count guard).
+The two *implemented* ideas from the same arc (resource **creation** from a description → #1357; the
+**create-count guard** → #1361) are already shipped and need no capture. These three remain open.
+
+## 1. Golden-image snapshot tests for the card engine
+
+**From:** `.sessions/2026-06-23-visual-card-engine.md` (Q-0089). **Lane:** dev quality / tooling.
+
+The card renderers (`utils/card_render.py`, `utils/profile_render.py`, and the older
+`mining_render` / `welcome_render` / `character_render`) are only asserted on "returns PNG bytes /
+doesn't crash". A **layout** regression — a panel shifting, a bar overflowing, a theme colour
+swapped — passes silently. A small golden-image harness (hash or pixel-diff a rendered card against
+a committed reference per theme, with a tolerance for font anti-aliasing) would catch visual
+regressions the byte-check can't. **It becomes load-bearing at card-engine roadmap H2**, when the
+existing renderers migrate onto `CardCanvas` — that refactor is exactly where a silent visual
+regression would slip in. Contained, dev-only (Pillow already present; gate the dep with
+`pytest.importorskip`). See `docs/ideas/visual-card-engine-vision-2026-06-23.md` (the engine roadmap).
+
+## 2. User-visible "cosmetic-only monetization" pledge surface
+
+**From:** `.sessions/2026-06-23-competitive-positioning.md` (Q-0089). **Lane:** product / positioning.
+
+The competitive research (`docs/ideas/competitive-positioning-north-star-2026-06-23.md`) found that
+the **monetization *promise itself* is a differentiator** — the MEE6 backlash, ProBot's retroactive
+paywall, and the `alternativestomee6.com` migration movement all stem from paywalling utility users
+*depended on*. The inverse — a credible, **stated** *"we will never paywall a feature you rely on;
+we only ever sell cosmetics"* — is the lowest-friction trust wedge, and it costs nothing we'd
+otherwise sell. Idea: a small user-visible surface (e.g. a line in `!about` / an info command, or a
+short pledge page) that states the principle, turning an internal value into marketing. Tiny,
+contained; it's the user-facing half of the north-star's Pillar 1.
+
+## 3. Per-kind breakdown in the setup create-count guard
+
+**From:** `.sessions/2026-06-23-setup-create-confirm.md` (Q-0089). **Lane:** setup UX (small).
+
+The Final Review create-count guard (#1361) shows a flat *"➕ N new resource(s) will be created"*
+with names. For a large plan, grouping by kind — *"2 channels, 1 role, 1 category"* — lets an
+operator sanity-check the *shape* at a glance before applying. The data is already there
+(`op.kind` / `target_kind` in `_created_resource_names`); it's a rendering tweak on the existing
+helper. Small contained follow-up to #1361.
+
+## Routing
+
+All three are **build-when-convenient** follow-ups (no owner decision needed; reversible,
+test-coverable). #1 is the highest-value (it protects the whole visual investment as it scales);
+#2 is the cheapest win; #3 is polish. Groom one down per the standing secondary-task cadence.

--- a/docs/owner/claims/claude__session-idea-capture.md
+++ b/docs/owner/claims/claude__session-idea-capture.md
@@ -1,0 +1,1 @@
+claude/session-idea-capture · promote loose session ideas (visual/AI-setup arc) into docs/ideas backlog · `docs/ideas/` · 2026-06-23

--- a/docs/owner/claims/claude__session-idea-capture.md
+++ b/docs/owner/claims/claude__session-idea-capture.md
@@ -1,1 +1,0 @@
-claude/session-idea-capture · promote loose session ideas (visual/AI-setup arc) into docs/ideas backlog · `docs/ideas/` · 2026-06-23


### PR DESCRIPTION
## Why

Session-close documentation audit for the 2026-06-23 visual-engine / AI-setup arc (#1349 card engine · #1352 positioning · #1355 + #1357 `/setup-describe` · #1361 create-count guard), to make sure nothing important from the session is lost.

**Audit result — almost everything was already captured durably:**
- The Dank Memer visual research → the card-engine vision doc; the 15-bot competitive research → the positioning north-star doc + the competitive-positioning session log's "Research provenance" section; every feature → its `.sessions/` log (all merged).
- #1361 (open, auto-merging) carries the create-count guard + the #1351 ledger fix + its session log — lands on merge.

**The one gap:** three forward-ideas (Q-0089) lived only in `.sessions/` logs, invisible to anyone browsing the `docs/ideas/` conveyor. This PR promotes them:

- `docs/ideas/session-followups-visual-ai-setup-2026-06-23.md` — (1) golden-image card-engine snapshot tests, (2) a user-visible cosmetic-only monetization pledge surface, (3) a per-kind breakdown in the #1361 create-count guard — each with provenance back to its session log.
- `docs/ideas/README.md` index entry.

Docs-only; `check_docs --strict` green. Born-red per Q-0133; auto-merges on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzBMYDtbYx95WgeWPggWJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzBMYDtbYx95WgeWPggWJj)_