### PR TITLE
U1: AI panels → in-place navigation (Ultracode worker, born-red)

### DIFF
--- a/.sessions/2026-06-23-u1-ai-inplace-nav.md
+++ b/.sessions/2026-06-23-u1-ai-inplace-nav.md
@@ -19,5 +19,47 @@ Drive the 17 `edit_in_place` consistency findings in `disbot/views/ai/` to 0, fo
 
 Scope-fenced to `disbot/views/ai/**` + mirrored tests. Born-red — coordinator flips/merges in Phase 2.
 
+## What I did
+- **panel.py (PR 1):** `policy_btn` / `behavior_btn` / `tools_btn` now
+  `interaction.response.edit_message(...)` the persistent anchor to the chooser page
+  instead of `send_message`-ing a new ephemeral. The `handle_ai_interaction` router
+  fallback (post-restart path) was migrated to `edit_message` too, for parity.
+  `AIPanelView` stays persistent (custom_ids unchanged). → 3 findings cleared.
+- **chooser sub-trees (PR 2):** `PolicyChooserView` (5), `BehaviorChooserView` (5),
+  `ToolsChooserView` (4) — every scope button now `edit_message`-es the anchor to the
+  scope picker / preview / list / matrix / advanced page, each carrying a Back button
+  that rebuilds its parent page in place. → 14 findings cleared.
+- **New `views/ai/_nav.py`:** a small page-swap Back-button helper (synchronous
+  `edit_message` parent rebuild + the AI-home page builder + the 25-component cap
+  contract). Each chooser carries a `↩ AI home` Back button; each scope page carries a
+  `↩ AI <chooser>` Back button.
+- Added `build_{policy,behavior,tools}_chooser_page()` Back-target builders (exported
+  from the package `__init__`s).
+- Reserved ephemerals for confirmations / errors only (the modal submits, the dry-run
+  preview/matrix results, and the guarded `guild is None` validation toast stay
+  ephemeral — none are flagged).
+- Did NOT change view base classes (still `discord.ui.View`); the blanket
+  `canonical_helpers.yaml` `views/ai/` exemption is left as a harmless no-op (Phase 3,
+  coordinator-owned). No scope select exceeds 25 options here (native
+  Channel/Role/Category selects are server-side paginated; presets ≤ 7) so
+  `attach_windowed_select` was not needed and `select_option_truncation` stays clean.
+
+## Verification
+- `python3.10 scripts/check_consistency.py`: **36 → 19** warnings; **`views/ai/`
+  `edit_in_place` findings = 0** (the 19 remaining are all casino/cleanup/roles — other
+  units). Exact drop = 17, as required.
+- `python3.10 scripts/check_quality.py --full`: green (black/isort/ruff/tool-pins/
+  check_docs/check_consistency, mypy 824 files no issues, pytest 12134 passed).
+- `python3.10 scripts/check_architecture.py --mode strict`: exit 0, no `views/ai/`
+  findings.
+- AI test slice: 157 passed (142 existing updated to the in-place contract + 15 new in
+  `test_inplace_nav.py`).
+
+## Findings flagged for coordinator allowlisting
+None — every one of the 17 `views/ai/` findings was a genuine navigation case and was
+**fixed to true in-place**. No `consistency_exceptions.yml` entry requested.
+
 ## ⚑ Self-initiated
-None — owner-directed Ultracode unit (coordinator-assigned U1).
+None — owner-directed Ultracode unit (coordinator-assigned U1). One additive choice
+within scope: the new `views/ai/_nav.py` page-Back helper (a contained convenience,
+fully test-covered, no shared-helper promotion).

--- a/.sessions/2026-06-23-u1-ai-inplace-nav.md
+++ b/.sessions/2026-06-23-u1-ai-inplace-nav.md
@@ -1,6 +1,10 @@
 # Session — U1 AI panels → in-place navigation (Ultracode worker)
 
-> **Status:** `in-progress`
+> **Status:** `complete` — coordinator Phase-2 verified (2026-06-23): diff scoped to `views/ai/**`
+> (incl. new `_nav.py`) + `tests/unit/views/ai/**` + claim/card only; all 17 `views/ai/` `edit_in_place`
+> findings → 0 (36→19, the residual being roles+casino/cleanup handled by other units); both checks green
+> on CI (sole red = the born-red gate); no allowlisting needed (all fixed to true in-place); custom_ids
+> preserved (AIPanelView stays persistent). Flipped + merged by the coordinator.
 
 Ultracode fleet worker **U1**. Branch `claude/u1-ai-inplace-nav` off clean `origin/main`.
 

--- a/.sessions/2026-06-23-u1-ai-inplace-nav.md
+++ b/.sessions/2026-06-23-u1-ai-inplace-nav.md
@@ -1,0 +1,23 @@
+# Session — U1 AI panels → in-place navigation (Ultracode worker)
+
+> **Status:** `in-progress`
+
+Ultracode fleet worker **U1**. Branch `claude/u1-ai-inplace-nav` off clean `origin/main`.
+
+## What I'm about to do
+Drive the 17 `edit_in_place` consistency findings in `disbot/views/ai/` to 0, following
+`docs/planning/ai-panel-inplace-navigation-plan-2026-06-19.md` **PR 1 + PR 2 only**:
+
+- **PR 1 scope:** `AIPanelView.policy_btn`/`behavior_btn`/`tools_btn` (panel.py:215/239/263) —
+  convert from `send_message`-ing a new ephemeral chooser to `interaction.response.edit_message(...)`
+  an in-place page swap of the same anchor (HubView-style page model + Back affordance to AI home).
+  Keep `AIPanelView` persistent (custom_ids unchanged).
+- **PR 2 scope:** the 14 chooser findings — behavior/chooser.py (5), policy/chooser.py (5),
+  tools/chooser.py (4) — migrate chooser -> scope-picker -> confirmation onto in-place `edit_message`
+  page swaps of the one anchor. Ephemerals reserved for confirmations/errors only. Windowed-select
+  (`views/paginated_select.attach_windowed_select`) for >25-option scope selects.
+
+Scope-fenced to `disbot/views/ai/**` + mirrored tests. Born-red — coordinator flips/merges in Phase 2.
+
+## ⚑ Self-initiated
+None — owner-directed Ultracode unit (coordinator-assigned U1).

--- a/disbot/views/ai/_nav.py
+++ b/disbot/views/ai/_nav.py
@@ -1,0 +1,97 @@
+"""In-place navigation helper for the AI admin panel page-stack.
+
+The AI Platform panel is **one anchor message** (the persistent
+:class:`views.ai.panel.AIPanelView`). Every chooser / scope-picker is a
+*page* of that same message: a button callback ``edit_message``-es the
+anchor to the next page instead of spawning a new ephemeral (the
+"matches the rest of the bot" doctrine — V-02 navigation, settings hub,
+mining hub). Ephemerals are reserved for confirmations / errors only.
+
+This module provides the **Back affordance** every non-home page needs:
+:func:`add_back_button` appends a secondary button whose callback
+rebuilds the parent ``(embed, view)`` synchronously and ``edit_message``-es
+the same anchor. The builder is a plain callable so a page can point Back
+at the AI home, at its chooser, or at any intermediate page without a
+router or a serialized stack.
+
+Why a local helper and not ``views.navigation.attach_back_button``: that
+helper defers then ``safe_edit``-s (an ``edit_original_response`` /
+``edit``) — correct for the cross-cog hub chains it serves, but the AI
+pages are a single synchronous ``edit_message`` swap with no async
+parent rebuild, so a direct ``interaction.response.edit_message`` keeps
+the page swap inside the 3-second ack window and reads as the same idiom
+the consistency linter rewards (``edit_in_place``). The two coexist.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+
+import discord
+
+logger = logging.getLogger("bot.views.ai.nav")
+
+# A page builder returns the ``(embed, view)`` pair for a page. It is
+# synchronous: AI pages are built from already-loaded state (an embed
+# builder + a fresh view), so no await is needed to render the parent.
+PageBuilder = Callable[[], "tuple[discord.Embed, discord.ui.View]"]
+
+# Discord's per-view component cap (a view may hold at most 25 items).
+_MAX_COMPONENTS = 25
+
+
+class _BackButton(discord.ui.Button):
+    """A Back button that rebuilds a parent page in place on the anchor."""
+
+    def __init__(self, *, label: str, builder: PageBuilder, row: int) -> None:
+        super().__init__(label=label, style=discord.ButtonStyle.secondary, row=row)
+        self._builder = builder
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        embed, view = self._builder()
+        await interaction.response.edit_message(embed=embed, view=view)
+
+
+def add_back_button(
+    view: discord.ui.View,
+    *,
+    label: str,
+    builder: PageBuilder,
+    row: int = 4,
+) -> bool:
+    """Append a Back button to ``view`` that swaps the anchor to its parent.
+
+    Args:
+        view: the page view being rendered onto the anchor.
+        label: button label (e.g. ``"↩ Back"`` / ``"↩ AI home"``).
+        builder: zero-arg callable returning the parent ``(embed, view)``.
+            Invoked at click time so the parent is always freshly built.
+        row: Discord row index (default 4 — the bottom row).
+
+    Returns ``True`` if the button was added, ``False`` if the view is
+    already at Discord's 25-component cap (a WARNING is logged so the
+    lost-nav case is visible). Mirrors
+    :func:`views.navigation.attach_back_button`'s cap contract.
+    """
+    if len(view.children) >= _MAX_COMPONENTS:
+        logger.warning(
+            "ai._nav.add_back_button: %s already has %d children — "
+            "%r button skipped.",
+            type(view).__name__,
+            len(view.children),
+            label,
+        )
+        return False
+    view.add_item(_BackButton(label=label, builder=builder, row=row))
+    return True
+
+
+def ai_home_page() -> tuple[discord.Embed, discord.ui.View]:
+    """Build the AI Platform home page ``(embed, view)`` for a Back target."""
+    from views.ai.panel import AIPanelView, build_ai_panel_embed
+
+    return build_ai_panel_embed(), AIPanelView()
+
+
+__all__ = ["PageBuilder", "add_back_button", "ai_home_page"]

--- a/disbot/views/ai/behavior/__init__.py
+++ b/disbot/views/ai/behavior/__init__.py
@@ -18,7 +18,12 @@ from __future__ import annotations
 
 from views.ai.behavior.chooser import (  # noqa: F401
     BehaviorChooserView,
+    build_behavior_chooser_page,
     build_behavior_embed,
 )
 
-__all__ = ["BehaviorChooserView", "build_behavior_embed"]
+__all__ = [
+    "BehaviorChooserView",
+    "build_behavior_chooser_page",
+    "build_behavior_embed",
+]

--- a/disbot/views/ai/behavior/chooser.py
+++ b/disbot/views/ai/behavior/chooser.py
@@ -6,8 +6,11 @@ Top-level workflow dispatcher. Rows:
 * Row 1: ``Preview`` (reuses PR4B :class:`PreviewChannelSelectView`)
   and ``Advanced`` (opens the PR4A policy chooser for raw edits).
 
-The chooser is ephemeral and times out; it carries no persistent
-state. Each button opens its own ephemeral follow-up.
+The chooser is a **page of the one AI anchor message** (AI nav plan
+PR 2): each button ``edit_message``-es the anchor to the next page
+(scope picker / preview / advanced) with a Back button, instead of
+spawning a new ephemeral. The chooser carries no persistent state and
+times out.
 """
 
 from __future__ import annotations
@@ -20,6 +23,11 @@ logger = logging.getLogger("bot.views.ai.behavior.chooser")
 
 _PANEL_COLOR = discord.Color.blurple()
 _CHOOSER_TIMEOUT_SECONDS = 180
+
+
+def build_behavior_chooser_page() -> tuple[discord.Embed, BehaviorChooserView]:
+    """Return the chooser ``(embed, view)`` — the Back target for its pages."""
+    return build_behavior_embed(), BehaviorChooserView()
 
 
 def build_behavior_embed() -> discord.Embed:
@@ -84,6 +92,9 @@ class BehaviorChooserView(discord.ui.View):
 
     def __init__(self) -> None:
         super().__init__(timeout=_CHOOSER_TIMEOUT_SECONDS)
+        from views.ai._nav import add_back_button, ai_home_page
+
+        add_back_button(self, label="↩ AI home", builder=ai_home_page)
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         member = interaction.user
@@ -108,10 +119,14 @@ class BehaviorChooserView(discord.ui.View):
     ) -> None:
         from views.ai.behavior.scope_picker import BehaviorChannelSelectView
 
-        await interaction.response.send_message(
-            "Pick a channel — the next step lists the available presets.",
-            view=BehaviorChannelSelectView(),
-            ephemeral=True,
+        view = BehaviorChannelSelectView()
+        _add_back_to_behavior(view)
+        await interaction.response.edit_message(
+            embed=_behavior_page_embed(
+                "Behavior · channel",
+                "Pick a channel — the next step lists the available presets.",
+            ),
+            view=view,
         )
 
     @discord.ui.button(
@@ -126,10 +141,14 @@ class BehaviorChooserView(discord.ui.View):
     ) -> None:
         from views.ai.behavior.scope_picker import BehaviorCategorySelectView
 
-        await interaction.response.send_message(
-            "Pick a category — the next step lists the available presets.",
-            view=BehaviorCategorySelectView(),
-            ephemeral=True,
+        view = BehaviorCategorySelectView()
+        _add_back_to_behavior(view)
+        await interaction.response.edit_message(
+            embed=_behavior_page_embed(
+                "Behavior · category",
+                "Pick a category — the next step lists the available presets.",
+            ),
+            view=view,
         )
 
     @discord.ui.button(
@@ -146,10 +165,14 @@ class BehaviorChooserView(discord.ui.View):
         # path.
         from views.ai.policy.preview_view import PreviewChannelSelectView
 
-        await interaction.response.send_message(
-            "Pick a channel to preview the effective AI policy as your user.",
-            view=PreviewChannelSelectView(),
-            ephemeral=True,
+        view = PreviewChannelSelectView()
+        _add_back_to_behavior(view)
+        await interaction.response.edit_message(
+            embed=_behavior_page_embed(
+                "Behavior · preview (dry-run)",
+                "Pick a channel to preview the effective AI policy as your user.",
+            ),
+            view=view,
         )
 
     @discord.ui.button(
@@ -166,10 +189,14 @@ class BehaviorChooserView(discord.ui.View):
         # the resolver runs in dry-run mode.
         from views.ai.routing import RoutingMatrixSelectView
 
-        await interaction.response.send_message(
-            "Pick a channel to dry-run the AI routing matrix.",
-            view=RoutingMatrixSelectView(),
-            ephemeral=True,
+        view = RoutingMatrixSelectView()
+        _add_back_to_behavior(view)
+        await interaction.response.edit_message(
+            embed=_behavior_page_embed(
+                "Behavior · routing matrix",
+                "Pick a channel to dry-run the AI routing matrix.",
+            ),
+            view=view,
         )
 
     @discord.ui.button(
@@ -183,17 +210,32 @@ class BehaviorChooserView(discord.ui.View):
         _: discord.ui.Button,
     ) -> None:
         # Punt to the existing raw policy chooser (PR4A); the sentinel
-        # PR-C-pre landed means partial edits there are now safe.
-        from views.ai.policy.chooser import (
-            PolicyChooserView,
-            build_chooser_embed,
-        )
+        # PR-C-pre landed means partial edits there are now safe. Swap
+        # the anchor to the policy chooser page in place.
+        from views.ai.policy.chooser import build_policy_chooser_page
 
-        await interaction.response.send_message(
-            embed=build_chooser_embed(),
-            view=PolicyChooserView(),
-            ephemeral=True,
-        )
+        embed, view = build_policy_chooser_page()
+        await interaction.response.edit_message(embed=embed, view=view)
 
 
-__all__ = ["BehaviorChooserView", "build_behavior_embed"]
+def _behavior_page_embed(title: str, instruction: str) -> discord.Embed:
+    """A focused page embed for a Behavior sub-page rendered on the anchor."""
+    return discord.Embed(
+        title=title,
+        description=instruction,
+        color=_PANEL_COLOR,
+    ).set_footer(text="Administrator-only · in-place navigation.")
+
+
+def _add_back_to_behavior(view: discord.ui.View) -> None:
+    """Attach a Back button that returns the anchor to the Behavior chooser."""
+    from views.ai._nav import add_back_button
+
+    add_back_button(view, label="↩ AI Behavior", builder=build_behavior_chooser_page)
+
+
+__all__ = [
+    "BehaviorChooserView",
+    "build_behavior_chooser_page",
+    "build_behavior_embed",
+]

--- a/disbot/views/ai/panel.py
+++ b/disbot/views/ai/panel.py
@@ -203,19 +203,19 @@ class AIPanelView(PersistentView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        # PR4A: open the policy chooser as an ephemeral follow-up.
+        # In-place navigation (AI nav plan PR 1): swap the anchor message
+        # to the policy chooser *page* instead of opening a new ephemeral.
         # The chooser dispatches each scope (channel / category / role /
-        # list) into its own ephemeral view. Writes flow through
+        # list) on the same anchor; writes flow through
         # ``services.ai_policy_mutation`` from inside those scope views.
         from views.ai.policy.chooser import (
             PolicyChooserView,
             build_chooser_embed,
         )
 
-        await interaction.response.send_message(
+        await interaction.response.edit_message(
             embed=build_chooser_embed(),
             view=PolicyChooserView(),
-            ephemeral=True,
         )
 
     @discord.ui.button(
@@ -229,17 +229,17 @@ class AIPanelView(PersistentView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        # PR-C: open the usability-first Behavior chooser as an ephemeral
-        # follow-up. Bind presets without learning the raw policy knobs.
+        # In-place navigation (AI nav plan PR 1): swap the anchor to the
+        # usability-first Behavior chooser page. Bind presets without
+        # learning the raw policy knobs.
         from views.ai.behavior import (
             BehaviorChooserView,
             build_behavior_embed,
         )
 
-        await interaction.response.send_message(
+        await interaction.response.edit_message(
             embed=build_behavior_embed(),
             view=BehaviorChooserView(),
-            ephemeral=True,
         )
 
     @discord.ui.button(
@@ -253,17 +253,19 @@ class AIPanelView(PersistentView):
         interaction: discord.Interaction,
         _: discord.ui.Button,
     ) -> None:
-        # Phase 3: open the Tools & Workflows chooser (orchestration profiles).
+        # In-place navigation (AI nav plan PR 1): swap the anchor to the
+        # Tools & Workflows chooser page (orchestration profiles).
         # Reads the snapshot best-effort so the chooser shows the current
         # guild-default profile + override counts; writes flow through
         # services.ai_orchestration_mutation from inside the scope views.
         from views.ai.tools import ToolsChooserView, build_tools_embed
 
         snapshot = await _best_effort_ai_snapshot(interaction.guild_id)
-        await interaction.response.send_message(
+        if interaction.response.is_done():
+            return
+        await interaction.response.edit_message(
             embed=build_tools_embed(snapshot),
             view=ToolsChooserView(),
-            ephemeral=True,
         )
 
 
@@ -375,10 +377,12 @@ async def handle_ai_interaction(
                 build_chooser_embed,
             )
 
-            await interaction.response.send_message(
+            # Post-restart fallback: the in-memory view is gone but the
+            # anchor message persists, so navigate it in place (matching
+            # the live button path) rather than spawning a new ephemeral.
+            await interaction.response.edit_message(
                 embed=build_chooser_embed(),
                 view=PolicyChooserView(),
-                ephemeral=True,
             )
             return
 
@@ -388,10 +392,9 @@ async def handle_ai_interaction(
                 build_behavior_embed,
             )
 
-            await interaction.response.send_message(
+            await interaction.response.edit_message(
                 embed=build_behavior_embed(),
                 view=BehaviorChooserView(),
-                ephemeral=True,
             )
             return
 
@@ -401,10 +404,9 @@ async def handle_ai_interaction(
             snapshot = await _best_effort_ai_snapshot(interaction.guild_id)
             if interaction.response.is_done():
                 return
-            await interaction.response.send_message(
+            await interaction.response.edit_message(
                 embed=build_tools_embed(snapshot),
                 view=ToolsChooserView(),
-                ephemeral=True,
             )
             return
 

--- a/disbot/views/ai/policy/chooser.py
+++ b/disbot/views/ai/policy/chooser.py
@@ -1,10 +1,13 @@
 """Entry-point chooser for the AI policy admin UI (PR4A).
 
 Reached from the main :class:`views.ai.panel.AIPanelView` ``Policy``
-button. The chooser is sent as an ephemeral follow-up so the operator
-sees a private window with the four scope buttons (Channel / Category
-/ Role / List). Each scope button opens its own ephemeral follow-up
-in the same conversation.
+button. The chooser is a **page of the one anchor message** (AI nav
+plan PR 2): the Policy button ``edit_message``-es the anchor to this
+chooser, and each scope button (Channel / Category / Role / Effective
+policy / List) ``edit_message``-es the anchor to that scope's picker —
+navigation happens in place on the same message, with a Back button
+unwinding the page stack. Ephemerals are reserved for the modal
+confirmations / errors the scope pickers raise.
 
 The chooser View is transient — created per click, not persisted —
 because the user is actively interacting and the timeout handles
@@ -21,6 +24,11 @@ logger = logging.getLogger("bot.views.ai.policy.chooser")
 
 _PANEL_COLOR = discord.Color.blurple()
 _CHOOSER_TIMEOUT_SECONDS = 180
+
+
+def build_policy_chooser_page() -> tuple[discord.Embed, PolicyChooserView]:
+    """Return the chooser ``(embed, view)`` — the Back target for scope pages."""
+    return build_chooser_embed(), PolicyChooserView()
 
 
 def build_chooser_embed() -> discord.Embed:
@@ -74,6 +82,9 @@ class PolicyChooserView(discord.ui.View):
 
     def __init__(self) -> None:
         super().__init__(timeout=_CHOOSER_TIMEOUT_SECONDS)
+        from views.ai._nav import add_back_button, ai_home_page
+
+        add_back_button(self, label="↩ AI home", builder=ai_home_page)
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         member = interaction.user
@@ -94,10 +105,14 @@ class PolicyChooserView(discord.ui.View):
     ) -> None:
         from views.ai.policy.channel_view import ChannelPolicySelectView
 
-        await interaction.response.send_message(
-            "Pick a channel to set its AI policy.",
-            view=ChannelPolicySelectView(),
-            ephemeral=True,
+        view = ChannelPolicySelectView()
+        _add_back_to_policy(view)
+        await interaction.response.edit_message(
+            embed=_scope_page_embed(
+                "Channel AI policy",
+                "Pick a channel to set its AI policy.",
+            ),
+            view=view,
         )
 
     @discord.ui.button(label="Category", style=discord.ButtonStyle.primary, row=0)
@@ -108,10 +123,14 @@ class PolicyChooserView(discord.ui.View):
     ) -> None:
         from views.ai.policy.category_view import CategoryPolicySelectView
 
-        await interaction.response.send_message(
-            "Pick a category to set its AI policy.",
-            view=CategoryPolicySelectView(),
-            ephemeral=True,
+        view = CategoryPolicySelectView()
+        _add_back_to_policy(view)
+        await interaction.response.edit_message(
+            embed=_scope_page_embed(
+                "Category AI policy",
+                "Pick a category to set its AI policy.",
+            ),
+            view=view,
         )
 
     @discord.ui.button(label="Role", style=discord.ButtonStyle.primary, row=0)
@@ -122,10 +141,14 @@ class PolicyChooserView(discord.ui.View):
     ) -> None:
         from views.ai.policy.role_view import RolePolicySelectView
 
-        await interaction.response.send_message(
-            "Pick a role to set its AI policy.",
-            view=RolePolicySelectView(),
-            ephemeral=True,
+        view = RolePolicySelectView()
+        _add_back_to_policy(view)
+        await interaction.response.edit_message(
+            embed=_scope_page_embed(
+                "Role AI policy",
+                "Pick a role to set its AI policy.",
+            ),
+            view=view,
         )
 
     @discord.ui.button(
@@ -144,10 +167,14 @@ class PolicyChooserView(discord.ui.View):
         # callback name (preview_btn) is its custom_id contract.
         from views.ai.policy.preview_view import PreviewChannelSelectView
 
-        await interaction.response.send_message(
-            "Pick a channel to see the effective AI policy as your user.",
-            view=PreviewChannelSelectView(),
-            ephemeral=True,
+        view = PreviewChannelSelectView()
+        _add_back_to_policy(view)
+        await interaction.response.edit_message(
+            embed=_scope_page_embed(
+                "Effective AI policy (dry-run)",
+                "Pick a channel to see the effective AI policy as your user.",
+            ),
+            view=view,
         )
 
     @discord.ui.button(
@@ -167,6 +194,7 @@ class PolicyChooserView(discord.ui.View):
         )
 
         if interaction.guild is None:
+            # Genuine validation error → ephemeral toast (reserved use).
             await interaction.response.send_message(
                 "❌ Listing overrides requires a guild context.",
                 ephemeral=True,
@@ -174,11 +202,25 @@ class PolicyChooserView(discord.ui.View):
             return
         entries = await collect_entries(interaction.guild.id)
         embed, _total = build_list_embed(entries, page=1)
-        await interaction.response.send_message(
-            embed=embed,
-            view=PolicyListView(entries, page=1),
-            ephemeral=True,
-        )
+        view = PolicyListView(entries, page=1)
+        _add_back_to_policy(view)
+        await interaction.response.edit_message(embed=embed, view=view)
 
 
-__all__ = ["PolicyChooserView", "build_chooser_embed"]
+def _scope_page_embed(title: str, instruction: str) -> discord.Embed:
+    """A focused page embed for a policy scope picker rendered on the anchor."""
+    return discord.Embed(
+        title=title,
+        description=instruction,
+        color=_PANEL_COLOR,
+    ).set_footer(text="Administrator-only · in-place navigation.")
+
+
+def _add_back_to_policy(view: discord.ui.View) -> None:
+    """Attach a Back button that returns the anchor to the policy chooser."""
+    from views.ai._nav import add_back_button
+
+    add_back_button(view, label="↩ AI Policy", builder=build_policy_chooser_page)
+
+
+__all__ = ["PolicyChooserView", "build_chooser_embed", "build_policy_chooser_page"]

--- a/disbot/views/ai/tools/__init__.py
+++ b/disbot/views/ai/tools/__init__.py
@@ -5,6 +5,14 @@ Reached from the AI panel's ``Tools`` button. See
 ``docs/ai-config-ownership.md`` (orchestration mutation seam).
 """
 
-from views.ai.tools.chooser import ToolsChooserView, build_tools_embed
+from views.ai.tools.chooser import (
+    ToolsChooserView,
+    build_tools_chooser_page,
+    build_tools_embed,
+)
 
-__all__ = ["ToolsChooserView", "build_tools_embed"]
+__all__ = [
+    "ToolsChooserView",
+    "build_tools_chooser_page",
+    "build_tools_embed",
+]

--- a/disbot/views/ai/tools/chooser.py
+++ b/disbot/views/ai/tools/chooser.py
@@ -1,9 +1,11 @@
 """Entry-point chooser for the Tools & Workflows admin UI (Phase 3).
 
 Reached from the main :class:`views.ai.panel.AIPanelView` ``Tools`` button. The
-chooser is an ephemeral follow-up with one button per scope (Guild / Channel /
-Category) plus a dry-run Preview. Each opens its own ephemeral follow-up; writes
-flow through :mod:`services.ai_orchestration_mutation`.
+chooser is a **page of the one AI anchor message** (AI nav plan PR 2) with one
+button per scope (Guild / Channel / Category) plus a dry-run Preview. Each button
+``edit_message``-es the anchor to that scope's picker with a Back button, instead
+of opening a new ephemeral; writes flow through
+:mod:`services.ai_orchestration_mutation`.
 
 This is the "Tools & workflows" surface the orchestration plan §9.4 asks for —
 an operator narrows toolsets / requires a grounding group for a channel without
@@ -22,6 +24,16 @@ logger = logging.getLogger("bot.views.ai.tools.chooser")
 
 _PANEL_COLOR = discord.Color.blurple()
 _CHOOSER_TIMEOUT_SECONDS = 180
+
+
+def build_tools_chooser_page() -> tuple[discord.Embed, ToolsChooserView]:
+    """Return the chooser ``(embed, view)`` — the Back target for its pages.
+
+    The static intro embed (no snapshot) is used for Back navigation; the
+    live "Current" decoration is only rendered on the first entry from the
+    AI panel, where the snapshot is read best-effort.
+    """
+    return build_tools_embed(None), ToolsChooserView()
 
 
 def build_tools_embed(snapshot: Any = None) -> discord.Embed:
@@ -81,6 +93,9 @@ class ToolsChooserView(discord.ui.View):
 
     def __init__(self) -> None:
         super().__init__(timeout=_CHOOSER_TIMEOUT_SECONDS)
+        from views.ai._nav import add_back_button, ai_home_page
+
+        add_back_button(self, label="↩ AI home", builder=ai_home_page)
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         member = interaction.user
@@ -101,10 +116,14 @@ class ToolsChooserView(discord.ui.View):
     ) -> None:
         from views.ai.tools.scope_view import GuildToolsProfileView
 
-        await interaction.response.send_message(
-            "Pick the guild-default orchestration profile.",
-            view=GuildToolsProfileView(),
-            ephemeral=True,
+        view = GuildToolsProfileView()
+        _add_back_to_tools(view)
+        await interaction.response.edit_message(
+            embed=_tools_page_embed(
+                "Tools · guild default",
+                "Pick the guild-default orchestration profile.",
+            ),
+            view=view,
         )
 
     @discord.ui.button(label="Channel", style=discord.ButtonStyle.primary, row=0)
@@ -115,10 +134,14 @@ class ToolsChooserView(discord.ui.View):
     ) -> None:
         from views.ai.tools.scope_view import ChannelToolsSelectView
 
-        await interaction.response.send_message(
-            "Pick a channel — the next step lists the orchestration profiles.",
-            view=ChannelToolsSelectView(),
-            ephemeral=True,
+        view = ChannelToolsSelectView()
+        _add_back_to_tools(view)
+        await interaction.response.edit_message(
+            embed=_tools_page_embed(
+                "Tools · channel",
+                "Pick a channel — the next step lists the orchestration profiles.",
+            ),
+            view=view,
         )
 
     @discord.ui.button(label="Category", style=discord.ButtonStyle.primary, row=0)
@@ -129,10 +152,14 @@ class ToolsChooserView(discord.ui.View):
     ) -> None:
         from views.ai.tools.scope_view import CategoryToolsSelectView
 
-        await interaction.response.send_message(
-            "Pick a category — the next step lists the orchestration profiles.",
-            view=CategoryToolsSelectView(),
-            ephemeral=True,
+        view = CategoryToolsSelectView()
+        _add_back_to_tools(view)
+        await interaction.response.edit_message(
+            embed=_tools_page_embed(
+                "Tools · category",
+                "Pick a category — the next step lists the orchestration profiles.",
+            ),
+            view=view,
         )
 
     @discord.ui.button(
@@ -147,11 +174,35 @@ class ToolsChooserView(discord.ui.View):
     ) -> None:
         from views.ai.tools.preview_view import ToolsPreviewChannelSelectView
 
-        await interaction.response.send_message(
-            "Pick a channel to preview the resolved AI tool orchestration.",
-            view=ToolsPreviewChannelSelectView(),
-            ephemeral=True,
+        view = ToolsPreviewChannelSelectView()
+        _add_back_to_tools(view)
+        await interaction.response.edit_message(
+            embed=_tools_page_embed(
+                "Tools · preview (dry-run)",
+                "Pick a channel to preview the resolved AI tool orchestration.",
+            ),
+            view=view,
         )
 
 
-__all__ = ["ToolsChooserView", "build_tools_embed"]
+def _tools_page_embed(title: str, instruction: str) -> discord.Embed:
+    """A focused page embed for a Tools sub-page rendered on the anchor."""
+    return discord.Embed(
+        title=title,
+        description=instruction,
+        color=_PANEL_COLOR,
+    ).set_footer(text="Administrator-only · in-place navigation.")
+
+
+def _add_back_to_tools(view: discord.ui.View) -> None:
+    """Attach a Back button that returns the anchor to the Tools chooser."""
+    from views.ai._nav import add_back_button
+
+    add_back_button(view, label="↩ AI Tools", builder=build_tools_chooser_page)
+
+
+__all__ = [
+    "ToolsChooserView",
+    "build_tools_chooser_page",
+    "build_tools_embed",
+]

--- a/docs/owner/claims/u1-ai-inplace-nav.md
+++ b/docs/owner/claims/u1-ai-inplace-nav.md
@@ -1,0 +1,1 @@
+- `claude/u1-ai-inplace-nav` · AI panels → in-place navigation (Ultracode U1) · `disbot/views/ai/**` (+ mirrored tests `tests/unit/views/ai/**`, `tests/unit/cogs/ai/**`) · 2026-06-23

--- a/tests/unit/views/ai/behavior/test_behavior_chooser.py
+++ b/tests/unit/views/ai/behavior/test_behavior_chooser.py
@@ -58,7 +58,8 @@ async def test_admin_gate_rejects_non_admin():
 @pytest.mark.asyncio
 async def test_preview_button_reuses_preview_channel_select_view(monkeypatch):
     """The Preview button must reuse the PR4B view, never reimplement
-    the dry-run flow.
+    the dry-run flow. In-place navigation (AI nav plan PR 2): the anchor
+    is edited to the preview page rather than a new ephemeral.
     """
     from types import SimpleNamespace
     from unittest.mock import AsyncMock, MagicMock
@@ -70,12 +71,12 @@ async def test_preview_button_reuses_preview_channel_select_view(monkeypatch):
         guild_permissions=SimpleNamespace(administrator=True),
     )
 
-    async def _send_message(*args, **kwargs):
+    async def _edit_message(*args, **kwargs):
         captured.update(kwargs)
         if args:
             captured["content"] = args[0]
 
-    interaction.response.send_message = AsyncMock(side_effect=_send_message)
+    interaction.response.edit_message = AsyncMock(side_effect=_edit_message)
 
     view = BehaviorChooserView()
     # Find the preview button by label.
@@ -103,12 +104,12 @@ async def test_advanced_button_reuses_policy_chooser(monkeypatch):
         guild_permissions=SimpleNamespace(administrator=True),
     )
 
-    async def _send_message(*args, **kwargs):
+    async def _edit_message(*args, **kwargs):
         captured.update(kwargs)
         if args:
             captured["content"] = args[0]
 
-    interaction.response.send_message = AsyncMock(side_effect=_send_message)
+    interaction.response.edit_message = AsyncMock(side_effect=_edit_message)
 
     view = BehaviorChooserView()
     advanced = next(

--- a/tests/unit/views/ai/test_inplace_nav.py
+++ b/tests/unit/views/ai/test_inplace_nav.py
@@ -1,0 +1,189 @@
+"""AI panel in-place navigation (AI nav plan PR 1 + PR 2).
+
+Pins the new page-swap model: the AI Platform anchor is one message, and
+every chooser / scope page is reached by ``interaction.response.edit_message``
+on that same anchor, with a Back button that unwinds the page stack.
+
+* The ``views.ai._nav`` helper attaches a Back button that rebuilds its
+  parent page in place.
+* Each chooser carries a "↩ AI home" Back button.
+* Each scope-picker page carries a "↩ AI <chooser>" Back button.
+* The panel entry buttons (policy / behavior / tools) edit the anchor in
+  place rather than sending a new ephemeral.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+_DISBOT = Path(__file__).parents[4] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from views.ai import _nav  # noqa: E402
+
+
+def _admin_interaction() -> MagicMock:
+    interaction = MagicMock()
+    interaction.user.guild_permissions.administrator = True
+    interaction.guild_id = 999
+    interaction.guild = MagicMock()
+    interaction.guild.id = 999
+    interaction.response.is_done.return_value = False
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    return interaction
+
+
+# --- the _nav helper --------------------------------------------------------
+
+
+def test_add_back_button_appends_a_button() -> None:
+    view = discord.ui.View()
+    before = len(view.children)
+    added = _nav.add_back_button(
+        view,
+        label="↩ Back",
+        builder=lambda: (discord.Embed(title="x"), discord.ui.View()),
+    )
+    assert added is True
+    assert len(view.children) == before + 1
+    btn = view.children[-1]
+    assert isinstance(btn, discord.ui.Button)
+    assert btn.label == "↩ Back"
+
+
+def test_add_back_button_skips_when_at_component_cap() -> None:
+    view = discord.ui.View()
+    # Fill the view to the 25-component cap with disabled buttons.
+    for i in range(25):
+        view.add_item(discord.ui.Button(label=f"b{i}", row=i // 5))
+    added = _nav.add_back_button(
+        view,
+        label="↩ Back",
+        builder=lambda: (discord.Embed(title="x"), discord.ui.View()),
+    )
+    assert added is False
+    assert len(view.children) == 25
+
+
+async def test_back_button_edits_message_to_parent_page() -> None:
+    sentinel_embed = discord.Embed(title="parent")
+    sentinel_view = discord.ui.View()
+
+    view = discord.ui.View()
+    _nav.add_back_button(
+        view,
+        label="↩ Back",
+        builder=lambda: (sentinel_embed, sentinel_view),
+    )
+    back = view.children[-1]
+    interaction = _admin_interaction()
+    await back.callback(interaction)
+    interaction.response.edit_message.assert_awaited_once()
+    _, kwargs = interaction.response.edit_message.call_args
+    assert kwargs["embed"] is sentinel_embed
+    assert kwargs["view"] is sentinel_view
+
+
+def test_ai_home_page_builds_panel_view() -> None:
+    from views.ai.panel import AIPanelView
+
+    embed, view = _nav.ai_home_page()
+    assert isinstance(embed, discord.Embed)
+    assert isinstance(view, AIPanelView)
+
+
+# --- choosers carry a Back-to-home button -----------------------------------
+
+
+def test_policy_chooser_has_back_to_home() -> None:
+    from views.ai.policy.chooser import PolicyChooserView
+
+    view = PolicyChooserView()
+    labels = {c.label for c in view.children if getattr(c, "label", None)}
+    assert "↩ AI home" in labels
+
+
+def test_behavior_chooser_has_back_to_home() -> None:
+    from views.ai.behavior import BehaviorChooserView
+
+    view = BehaviorChooserView()
+    labels = {c.label for c in view.children if getattr(c, "label", None)}
+    assert "↩ AI home" in labels
+
+
+def test_tools_chooser_has_back_to_home() -> None:
+    from views.ai.tools import ToolsChooserView
+
+    view = ToolsChooserView()
+    labels = {c.label for c in view.children if getattr(c, "label", None)}
+    assert "↩ AI home" in labels
+
+
+# --- scope pages carry a Back-to-chooser button -----------------------------
+
+
+@pytest.mark.parametrize(
+    ("attr", "back_label"),
+    [
+        ("channel_btn", "↩ AI Policy"),
+        ("category_btn", "↩ AI Policy"),
+        ("role_btn", "↩ AI Policy"),
+    ],
+)
+async def test_policy_scope_pages_carry_back_button(attr, back_label) -> None:
+    from views.ai.policy.chooser import PolicyChooserView
+
+    view = PolicyChooserView()
+    interaction = _admin_interaction()
+    await getattr(view, attr).callback(interaction)
+    interaction.response.edit_message.assert_awaited_once()
+    _, kwargs = interaction.response.edit_message.call_args
+    page_view = kwargs["view"]
+    labels = {c.label for c in page_view.children if getattr(c, "label", None)}
+    assert back_label in labels
+
+
+async def test_tools_scope_page_carries_back_button() -> None:
+    from views.ai.tools import ToolsChooserView
+
+    view = ToolsChooserView()
+    interaction = _admin_interaction()
+    await view.guild_btn.callback(interaction)
+    interaction.response.edit_message.assert_awaited_once()
+    _, kwargs = interaction.response.edit_message.call_args
+    labels = {c.label for c in kwargs["view"].children if getattr(c, "label", None)}
+    assert "↩ AI Tools" in labels
+
+
+async def test_behavior_scope_page_carries_back_button() -> None:
+    from views.ai.behavior import BehaviorChooserView
+
+    view = BehaviorChooserView()
+    interaction = _admin_interaction()
+    await view.channel_btn.callback(interaction)
+    interaction.response.edit_message.assert_awaited_once()
+    _, kwargs = interaction.response.edit_message.call_args
+    labels = {c.label for c in kwargs["view"].children if getattr(c, "label", None)}
+    assert "↩ AI Behavior" in labels
+
+
+# --- panel entry buttons swap the anchor in place ---------------------------
+
+
+@pytest.mark.parametrize("attr", ["policy_btn", "behavior_btn", "tools_btn"])
+async def test_panel_entry_buttons_navigate_in_place(attr) -> None:
+    from views.ai.panel import AIPanelView
+
+    view = AIPanelView()
+    interaction = _admin_interaction()
+    # Drive the decorated button callback directly.
+    await getattr(view, attr).callback(interaction)
+    interaction.response.edit_message.assert_awaited_once()
+    interaction.response.send_message.assert_not_awaited()

--- a/tests/unit/views/ai/test_policy_category_view.py
+++ b/tests/unit/views/ai/test_policy_category_view.py
@@ -189,8 +189,9 @@ async def test_chooser_category_button_opens_real_select_view():
     view = PolicyChooserView()
     interaction = MagicMock()
     interaction.user.guild_permissions.administrator = True
-    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    # In-place navigation (AI nav plan PR 2): the anchor is edited to the
+    # category-policy page rather than a new ephemeral.
     await view.category_btn.callback(interaction)
-    _, kwargs = interaction.response.send_message.call_args
+    _, kwargs = interaction.response.edit_message.call_args
     assert isinstance(kwargs["view"], CategoryPolicySelectView)
-    assert kwargs.get("ephemeral") is True

--- a/tests/unit/views/ai/test_policy_chooser.py
+++ b/tests/unit/views/ai/test_policy_chooser.py
@@ -20,6 +20,7 @@ def _admin_interaction() -> MagicMock:
     interaction = MagicMock()
     interaction.user.guild_permissions.administrator = True
     interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
     return interaction
 
 
@@ -74,11 +75,11 @@ async def test_channel_button_opens_channel_select_view():
     view = PolicyChooserView()
     interaction = _admin_interaction()
     await view.channel_btn.callback(interaction)
-    interaction.response.send_message.assert_awaited_once()
-    _, kwargs = interaction.response.send_message.call_args
-    # The follow-up is ephemeral and carries a view (the
-    # ChannelPolicySelectView created lazily inside the callback).
-    assert kwargs.get("ephemeral") is True
+    # In-place navigation (AI nav plan PR 2): the anchor message is
+    # edited to the channel-policy page, not a new ephemeral.
+    interaction.response.edit_message.assert_awaited_once()
+    interaction.response.send_message.assert_not_awaited()
+    _, kwargs = interaction.response.edit_message.call_args
     assert kwargs.get("view") is not None
     # Imported here so the test does not force the module to load
     # at collection time.
@@ -98,11 +99,11 @@ async def test_all_scope_buttons_have_real_implementations():
 
 
 def test_chooser_view_has_one_button_per_scope():
-    """Smoke check: five buttons (Channel / Category / Role on row 0,
-    Effective policy / List overrides on row 1) sit on the chooser.
-    The Preview button was renamed to Effective policy in PR-2; the
-    underlying ``preview_btn`` handler (and its custom_id contract)
-    is unchanged.
+    """Smoke check: five scope buttons (Channel / Category / Role on row 0,
+    Effective policy / List overrides on row 1) sit on the chooser, plus
+    an in-place "↩ AI home" Back button (AI nav plan PR 2). The Preview
+    button was renamed to Effective policy in PR-2; the underlying
+    ``preview_btn`` handler (and its custom_id contract) is unchanged.
     """
     view = PolicyChooserView()
     labels = sorted(
@@ -116,4 +117,5 @@ def test_chooser_view_has_one_button_per_scope():
         "Effective policy",
         "List overrides",
         "Role",
+        "↩ AI home",
     ]

--- a/tests/unit/views/ai/test_policy_list_view.py
+++ b/tests/unit/views/ai/test_policy_list_view.py
@@ -228,12 +228,13 @@ async def test_chooser_list_button_opens_real_list_view(monkeypatch):
     interaction.user.guild_permissions.administrator = True
     interaction.guild = MagicMock()
     interaction.guild.id = 999
-    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    # In-place navigation (AI nav plan PR 2): the anchor is edited to the
+    # override-list page rather than a new ephemeral.
     await view.list_btn.callback(interaction)
 
-    _, kwargs = interaction.response.send_message.call_args
+    _, kwargs = interaction.response.edit_message.call_args
     assert isinstance(kwargs["view"], PolicyListView)
-    assert kwargs.get("ephemeral") is True
     embed = kwargs["embed"]
     assert "AI policy overrides" in (embed.title or "")
 

--- a/tests/unit/views/ai/test_policy_panel_button.py
+++ b/tests/unit/views/ai/test_policy_panel_button.py
@@ -52,10 +52,12 @@ def test_policy_button_is_on_the_second_row_next_to_settings():
     assert policy_btn.style == discord.ButtonStyle.success
 
 
-async def test_router_handler_dispatches_policy_action_as_ephemeral():
+async def test_router_handler_dispatches_policy_action_in_place():
     """When the View's callback path is bypassed (e.g. after a process
     restart, where the in-memory view is gone), the router handler
-    must still serve the policy action and send an ephemeral chooser.
+    must still serve the policy action by swapping the anchor message to
+    the chooser page in place (AI nav plan PR 2) — the persistent anchor
+    message survives a restart, so navigation stays in place.
     """
     interaction = _admin_panel_interaction()
     await panel.handle_ai_interaction(
@@ -64,17 +66,15 @@ async def test_router_handler_dispatches_policy_action_as_ephemeral():
         session=None,
         request_id="req-test",
     )
-    interaction.response.send_message.assert_awaited_once()
-    _, kwargs = interaction.response.send_message.call_args
-    assert kwargs.get("ephemeral") is True
+    interaction.response.edit_message.assert_awaited_once()
+    _, kwargs = interaction.response.edit_message.call_args
     assert kwargs.get("embed") is not None
     assert kwargs.get("view") is not None
     from views.ai.policy.chooser import PolicyChooserView
 
     assert isinstance(kwargs["view"], PolicyChooserView)
-    # The router path uses send_message (ephemeral follow-up), NOT
-    # edit_message — the persistent main panel stays intact.
-    interaction.response.edit_message.assert_not_awaited()
+    # In-place navigation: no new ephemeral message is spawned.
+    interaction.response.send_message.assert_not_awaited()
 
 
 async def test_router_handler_rejects_non_admin_for_policy():

--- a/tests/unit/views/ai/test_policy_preview_view.py
+++ b/tests/unit/views/ai/test_policy_preview_view.py
@@ -220,11 +220,12 @@ async def test_chooser_preview_button_opens_preview_view():
     view = PolicyChooserView()
     interaction = MagicMock()
     interaction.user.guild_permissions.administrator = True
-    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    # In-place navigation (AI nav plan PR 2): the anchor is edited to the
+    # effective-policy preview page rather than a new ephemeral.
     await view.preview_btn.callback(interaction)
-    _, kwargs = interaction.response.send_message.call_args
+    _, kwargs = interaction.response.edit_message.call_args
     assert isinstance(kwargs["view"], PreviewChannelSelectView)
-    assert kwargs.get("ephemeral") is True
 
 
 def test_chooser_has_preview_button_on_row_one_with_list():

--- a/tests/unit/views/ai/test_policy_role_view.py
+++ b/tests/unit/views/ai/test_policy_role_view.py
@@ -243,8 +243,9 @@ async def test_chooser_role_button_opens_real_select_view():
     view = PolicyChooserView()
     interaction = MagicMock()
     interaction.user.guild_permissions.administrator = True
-    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    # In-place navigation (AI nav plan PR 2): the anchor is edited to the
+    # role-policy page rather than a new ephemeral.
     await view.role_btn.callback(interaction)
-    _, kwargs = interaction.response.send_message.call_args
+    _, kwargs = interaction.response.edit_message.call_args
     assert isinstance(kwargs["view"], RolePolicySelectView)
-    assert kwargs.get("ephemeral") is True

--- a/tests/unit/views/ai/test_tools_panel.py
+++ b/tests/unit/views/ai/test_tools_panel.py
@@ -63,7 +63,7 @@ def test_tools_button_is_success_on_second_row() -> None:
 # --- router fallback -------------------------------------------------------
 
 
-async def test_router_dispatches_tools_as_ephemeral() -> None:
+async def test_router_dispatches_tools_in_place() -> None:
     interaction = _admin_interaction()
     await panel.handle_ai_interaction(
         interaction,
@@ -71,11 +71,12 @@ async def test_router_dispatches_tools_as_ephemeral() -> None:
         session=None,
         request_id="req",
     )
-    interaction.response.send_message.assert_awaited_once()
-    _, kwargs = interaction.response.send_message.call_args
-    assert kwargs.get("ephemeral") is True
+    # In-place navigation (AI nav plan PR 2): the persistent anchor is
+    # edited to the Tools chooser page, not a new ephemeral.
+    interaction.response.edit_message.assert_awaited_once()
+    _, kwargs = interaction.response.edit_message.call_args
     assert isinstance(kwargs.get("view"), ToolsChooserView)
-    interaction.response.edit_message.assert_not_awaited()
+    interaction.response.send_message.assert_not_awaited()
 
 
 async def test_router_rejects_non_admin_for_tools() -> None:


### PR DESCRIPTION
## Ultracode fleet worker U1 — born-red

Drives the **17 `edit_in_place` consistency findings in `disbot/views/ai/`** to **0**, following
`docs/planning/ai-panel-inplace-navigation-plan-2026-06-19.md` **PR 1 + PR 2 only** (not its PR 3 —
settings centralization / exemption narrowing / generative advisor).

### Scope (views/ai/ only)
- **PR 1 work:** `AIPanelView.policy_btn`/`behavior_btn`/`tools_btn` (panel.py) — convert from
  `send_message`-ing a new ephemeral chooser to `interaction.response.edit_message(...)` an in-place
  page swap of the same persistent anchor, with a Back affordance to the AI home page. `AIPanelView`
  stays persistent (custom_ids unchanged).
- **PR 2 work:** the 14 chooser findings (behavior/chooser.py ×5, policy/chooser.py ×5,
  tools/chooser.py ×4) — migrate chooser → scope-picker → confirmation onto in-place `edit_message`
  page swaps of the one anchor. Ephemerals reserved for confirmations/errors only. Windowed-select for
  >25-option scope selects.

### Acceptance signal
`python3.10 scripts/check_consistency.py` — `views/ai/` `edit_in_place` findings gone (overall 36 → 19).

> **Born-red** — the session card is `in-progress`; the coordinator flips it green and merges in Phase 2.
> Do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sHpm1BzCvqj4CesshByZg

---
_Generated by [Claude Code](https://claude.ai/code/session_019sHpm1BzCvqj4CesshByZg)_