### PR TITLE
U3: migrate Games hub child-buttons onto shared HubChildButton

### DIFF
--- a/.sessions/2026-06-23-u3-games-hubchildbutton.md
+++ b/.sessions/2026-06-23-u3-games-hubchildbutton.md
@@ -1,0 +1,13 @@
+# 2026-06-23 — U3 Games hub child-button migration onto shared `HubChildButton`
+
+> **Status:** `in-progress`
+
+Ultracode fleet worker (U3). Behaviour-preserving deduplication: migrate the Games
+hub's `_GameHubButton` + `GamesHubView.handle_select` onto the shared
+`views.hub_children.HubChildButton` (the #1373 "first consolidation" primitive),
+following the proven Community/Utility pattern. Drop the dropdown-legacy guards
+(`__none__` / wrong-parent) that direct buttons never reach. Keep `custom_ids`,
+button order, and the `discover`/`attach_back`/`_build_no_panel_embed` seams
+byte-identical so persistent anchors keep routing.
+
+Worker leaves this card RED — the coordinator flips/merges (Phase 2).

--- a/.sessions/2026-06-23-u3-games-hubchildbutton.md
+++ b/.sessions/2026-06-23-u3-games-hubchildbutton.md
@@ -1,6 +1,10 @@
 # 2026-06-23 — U3 Games hub child-button migration onto shared `HubChildButton`
 
-> **Status:** `in-progress`
+> **Status:** `complete` — coordinator Phase-2 verified (2026-06-23): diff scoped to
+> `views/games/hub.py` + its tests only; `check_quality.py --full` + `check_architecture --mode strict`
+> green on CI (sole red was the born-red gate); `check_consistency` flat at 36 (no new findings);
+> custom_ids (`games:open:<sub>`, `games:back`) + button order preserved (tests pin it). −77 net lines
+> in `hub.py` (`handle_select` + dropdown-legacy guards removed). Flipped + merged by the coordinator.
 
 Ultracode fleet worker (U3). Behaviour-preserving deduplication: migrate the Games
 hub's `_GameHubButton` + `GamesHubView.handle_select` onto the shared

--- a/disbot/views/games/hub.py
+++ b/disbot/views/games/hub.py
@@ -31,25 +31,19 @@ avoiding duplicates.
 
 from __future__ import annotations
 
-import logging
-
 import discord
 from discord.ext import commands
 
 from services import governance_service
 from services.governance_service import GovernanceContext
-from utils.subsystem_registry import SUBSYSTEMS
 from utils.ui_constants import GAME_COLOR
 from views.base import HubView
-from views.hub_children import discover_hub_children
+from views.hub_children import HubChildButton, discover_hub_children
 from views.navigation import (
     BackTarget,
     attach_back_button,
-    attach_back_target,
     chain_back,
 )
-
-logger = logging.getLogger("bot.views.games")
 
 # Hub group rendering order. Groups not listed sort last (alphabetically).
 _GROUP_ORDER: dict[str, int] = {"competitive": 0, "activities": 1}
@@ -272,13 +266,20 @@ def _build_no_panel_embed(name: str, meta: dict) -> discord.Embed:
     return embed
 
 
-class _GameHubButton(discord.ui.Button):
-    """Direct game button on the Games hub (PR 2).
+class _GameHubButton(HubChildButton):
+    """Direct game button on the Games hub.
 
-    Routes to the child cog's ``build_help_menu_view`` hook by
-    delegating to :meth:`GamesHubView.handle_select` — the same routing
-    brain the legacy dropdown used, so click-time governance recheck,
-    missing-cog fallback, and exception handling stay identical.
+    Thin subclass of the shared :class:`views.hub_children.HubChildButton` (the
+    consolidation's "first consolidation"): it binds the Games ``hub_key`` + the
+    Back-to-Games attacher + the in-place no-panel fallback, and inherits all the
+    forwarding logic (click-time governance recheck → resolve the child cog →
+    ``build_help_menu_view`` → back-nav → edit in place). Unlike Community/Utility,
+    Games passes ``fallback_builder=_build_no_panel_embed`` so a child with no panel
+    edits the hub message to a graceful "no panel yet" embed in place rather than
+    failing closed with an ephemeral — preserving the prior Games behaviour exactly.
+
+    ``custom_id`` stays ``f"games:open:{subsystem}"`` (via ``hub_key="games"``) so
+    persistent anchors keep routing.
     """
 
     def __init__(
@@ -290,22 +291,14 @@ class _GameHubButton(discord.ui.Button):
         row: int,
     ) -> None:
         super().__init__(
+            hub_key="games",
+            subsystem=subsystem,
             label=label,
             style=style,
-            custom_id=f"games:open:{subsystem}",
             row=row,
+            back_attacher=attach_back_to_games_button,
+            fallback_builder=_build_no_panel_embed,
         )
-        self._subsystem = subsystem
-
-    async def callback(self, interaction: discord.Interaction) -> None:
-        view = self.view
-        if not isinstance(view, GamesHubView):
-            await interaction.response.send_message(
-                "This button is no longer attached to the Games hub.",
-                ephemeral=True,
-            )
-            return
-        await view.handle_select(interaction, self._subsystem)
 
 
 class GamesHubView(HubView):
@@ -313,11 +306,12 @@ class GamesHubView(HubView):
 
     Discovers ``parent_hub == "games"`` children from
     :data:`utils.subsystem_registry.SUBSYSTEMS` and renders one direct
-    button per child, grouped by ``hub_group`` (competitive on row 0,
-    activities on row 1). Clicking a button calls that child cog's
-    ``build_help_menu_view`` hook via :meth:`handle_select`; if the
-    hook is missing the hub falls back to a typed-command embed so the
-    operator can still discover commands.
+    :class:`_GameHubButton` per child, grouped by ``hub_group``
+    (competitive on row 0, activities on row 1). Clicking a button (the
+    shared :class:`views.hub_children.HubChildButton` callback) calls that
+    child cog's ``build_help_menu_view`` hook; if the cog or hook is
+    missing the button falls back in place to a typed-command embed
+    (``_build_no_panel_embed``) so the operator can still discover commands.
 
     The view itself contains zero game logic — pure routing.
     """
@@ -341,8 +335,9 @@ class GamesHubView(HubView):
         # :func:`build_games_hub_panel` so only governance-visible
         # subsystems render. ``None`` falls back to the unfiltered
         # discovery — used by tests and any caller that constructs
-        # the view directly. Click-time recheck in :meth:`handle_select`
-        # still gates correctly even on the unfiltered path.
+        # the view directly. Click-time recheck in the shared
+        # :class:`views.hub_children.HubChildButton` callback still gates
+        # correctly even on the unfiltered path.
         if children is None:
             children = discover_game_children()
         self._game_children = children
@@ -379,75 +374,3 @@ class GamesHubView(HubView):
                 ),
             )
             col += 1
-
-    async def handle_select(
-        self,
-        interaction: discord.Interaction,
-        sub_name: str,
-    ) -> None:
-        """Open the selected child's help panel in place."""
-        if sub_name == "__none__":
-            await interaction.response.send_message(
-                "No games are routed to the Games hub yet.",
-                ephemeral=True,
-            )
-            return
-
-        meta = SUBSYSTEMS.get(sub_name)
-        if meta is None or meta.get("parent_hub") != "games":
-            await interaction.response.send_message(
-                "That game is no longer routed to the Games hub.",
-                ephemeral=True,
-            )
-            return
-
-        # PR D: click-time governance recheck. If the subsystem has
-        # become invisible between render and click (visibility change,
-        # role removal, channel scope override), fail closed with an
-        # ephemeral. ``resolve_visibility`` is cached by
-        # ``(guild_id, channel_id, tier, role_ids)`` so the re-check is
-        # essentially free in steady state.
-        gctx = GovernanceContext.from_interaction(interaction)
-        vis_result = await governance_service.resolve_visibility(gctx)
-        if sub_name not in vis_result.visible_subsystems:
-            await interaction.response.send_message(
-                "That feature is no longer available in this channel.",
-                ephemeral=True,
-            )
-            return
-
-        # Local import keeps the helper out of module-import time and
-        # avoids dragging the help cog into every consumer of this view.
-        from cogs.help_cog import _cog_for_subsystem
-
-        cog = _cog_for_subsystem(interaction.client, sub_name)  # type: ignore[arg-type]
-        if cog is None:
-            embed = _build_no_panel_embed(sub_name, dict(meta))
-            await interaction.response.edit_message(embed=embed, view=self)
-            return
-
-        build_panel = getattr(cog, "build_help_menu_view", None)
-        if not callable(build_panel):
-            embed = _build_no_panel_embed(sub_name, dict(meta))
-            await interaction.response.edit_message(embed=embed, view=self)
-            return
-
-        try:
-            embed, sub_view = await build_panel(interaction)
-        except Exception as exc:  # noqa: BLE001 — navigation must not crash
-            logger.warning(
-                "Games hub: build_help_menu_view failed for subsystem=%r: %s",
-                sub_name,
-                exc,
-                exc_info=True,
-            )
-            fallback = _build_no_panel_embed(sub_name, dict(meta))
-            await interaction.response.edit_message(embed=fallback, view=self)
-            return
-
-        back_target: BackTarget | None = getattr(self, "_back_target", None)
-        attach_back_to_games_button(sub_view, self._author, grandparent=back_target)
-        if back_target is not None:
-            attach_back_target(sub_view, back_target)
-        sub_view._back_target = back_target  # type: ignore[attr-defined]
-        await interaction.response.edit_message(embed=embed, view=sub_view)

--- a/docs/owner/claims/u3-games-hubchildbutton.md
+++ b/docs/owner/claims/u3-games-hubchildbutton.md
@@ -1,0 +1,1 @@
+- `claude/u3-games-hubchildbutton` · U3 Games hub child-button migration onto shared `HubChildButton` (behaviour-preserving dedup) · `disbot/views/games/hub.py` + `tests/unit/views/test_games_hub_view.py` · 2026-06-23

--- a/tests/unit/views/test_games_hub_view.py
+++ b/tests/unit/views/test_games_hub_view.py
@@ -13,9 +13,11 @@ buttons. The shape contract this file pins:
 * Component count stays safely below Discord's 25-component cap
   (worst case includes Back-to-Help added by the Help layer).
 * ``attach_back_to_games_button`` adds a button and no-ops at the cap.
-* The child-open callback routes through
-  ``GamesHubView.handle_select``, gracefully handling missing cog,
-  missing ``build_help_menu_view`` hook, and exceptions from the hook.
+* The child-open callback routes through the shared
+  ``views.hub_children.HubChildButton.callback`` (``_GameHubButton`` is now a
+  thin subclass), gracefully handling missing cog, missing
+  ``build_help_menu_view`` hook, and exceptions from the hook (in-place
+  no-panel fallback embed).
 * Click-time governance recheck fails closed for stale visibility.
 """
 
@@ -38,6 +40,7 @@ from views.games.hub import (
     build_games_hub_embed,
     discover_game_children,
 )
+from views.hub_children import HubChildButton
 
 
 def _author(id_: int = 1) -> MagicMock:
@@ -46,15 +49,39 @@ def _author(id_: int = 1) -> MagicMock:
     return author
 
 
+def _interaction() -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.client = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    return interaction
+
+
+def _game_button(subsystem: str = "blackjack") -> _GameHubButton:
+    """Build a standalone ``_GameHubButton`` for callback tests.
+
+    Mirrors the Community hub's button-callback tests: the routing brain
+    now lives in the shared ``HubChildButton.callback`` the button
+    inherits, so each routing case exercises the button directly.
+    """
+    return _GameHubButton(
+        subsystem=subsystem,
+        label="🃏 Blackjack",
+        style=discord.ButtonStyle.primary,
+        row=0,
+    )
+
+
 @contextmanager
 def _all_visible():
     """Stub resolve_visibility to return every subsystem visible.
 
-    Click-time recheck inside ``handle_select`` and the rebuilt-hub
-    path inside ``attach_back_to_games_button`` go through
-    ``build_games_hub_panel`` which resolves governance; tests that
-    aren't designed to exercise the gating need a stub so the factory
-    doesn't hit the real DB.
+    Click-time recheck inside ``HubChildButton.callback`` (the shared
+    button ``_GameHubButton`` subclasses) and the rebuilt-hub path inside
+    ``attach_back_to_games_button`` go through ``resolve_visibility`` /
+    ``build_games_hub_panel``; tests that aren't designed to exercise the
+    gating need a stub so the recheck doesn't hit the real DB.
     """
     vis_result = VisibilityResult(
         visible_subsystems=set(SUBSYSTEMS),
@@ -157,6 +184,22 @@ def test_view_has_no_select_components():
         "Games Hub v2 uses buttons exclusively; the legacy "
         "_GamesHubSelect dropdown was removed in PR 2."
     )
+
+
+def test_game_hub_button_is_hubchildbutton_subclass():
+    """Consolidation pin (U3): the Games child button must be a thin
+    subclass of the shared ``views.hub_children.HubChildButton`` — the
+    single child-forwarding seam every hub delegates to (#1373). If a
+    future refactor reintroduces a bespoke button/``handle_select`` this
+    fails loudly.
+    """
+    assert issubclass(_GameHubButton, HubChildButton)
+    btn = _game_button("blackjack")
+    assert isinstance(btn, HubChildButton)
+    # The shared button owns the routing logic — the subclass adds none.
+    assert _GameHubButton.callback is HubChildButton.callback
+    # GamesHubView no longer carries a hand-rolled routing method.
+    assert not hasattr(GamesHubView, "handle_select")
 
 
 def test_view_renders_one_game_hub_button_per_visible_child():
@@ -367,75 +410,71 @@ def test_attach_back_button_noops_at_25_children():
 
 
 # ---------------------------------------------------------------------------
-# handle_select routing (shared by every _GameHubButton)
+# Button callback routing (inherited from the shared HubChildButton)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_handle_select_unknown_subsystem_sends_ephemeral():
-    view = GamesHubView(_author())
-    interaction = MagicMock(spec=discord.Interaction)
-    interaction.client = MagicMock()
-    interaction.response = MagicMock()
-    interaction.response.send_message = AsyncMock()
-    interaction.response.edit_message = AsyncMock()
+async def test_button_missing_cog_renders_fallback_in_place():
+    """No cog loaded for the subsystem → Games keeps its in-place
+    no-panel fallback embed (``fallback_builder``), not an ephemeral.
+    """
+    btn = _game_button("blackjack")
+    interaction = _interaction()
 
-    await view.handle_select(interaction, "not_a_real_subsystem")
-
-    interaction.response.send_message.assert_awaited_once()
-    interaction.response.edit_message.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_handle_select_missing_cog_renders_fallback():
-    view = GamesHubView(_author())
-    interaction = MagicMock(spec=discord.Interaction)
-    interaction.client = MagicMock()
-    interaction.response = MagicMock()
-    interaction.response.send_message = AsyncMock()
-    interaction.response.edit_message = AsyncMock()
-
-    with _all_visible(), patch("views.games.hub.SUBSYSTEMS") as fake_subs:
-        sub_name = "blackjack"
-        fake_subs.get.return_value = dict(SUBSYSTEMS[sub_name])
-        with patch("cogs.help_cog._cog_for_subsystem", return_value=None):
-            await view.handle_select(interaction, sub_name)
+    with _all_visible(), patch("cogs.help_cog._cog_for_subsystem", return_value=None):
+        await btn.callback(interaction)
 
     interaction.response.edit_message.assert_awaited_once()
-    args, kwargs = interaction.response.edit_message.call_args
-    assert kwargs["view"] is view  # falls back to the hub itself + back btn
+    _args, kwargs = interaction.response.edit_message.call_args
     embed: discord.Embed = kwargs["embed"]
     assert "Blackjack" in (embed.title or "")
+    interaction.response.send_message.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_handle_select_hook_failure_renders_fallback():
-    view = GamesHubView(_author())
-    interaction = MagicMock(spec=discord.Interaction)
-    interaction.client = MagicMock()
-    interaction.response = MagicMock()
-    interaction.response.send_message = AsyncMock()
-    interaction.response.edit_message = AsyncMock()
+async def test_button_cog_without_hook_renders_fallback_in_place():
+    """Cog present but no ``build_help_menu_view`` → in-place fallback."""
+    btn = _game_button("blackjack")
+    fake_cog = MagicMock(spec=[])  # no build_help_menu_view attr
+    interaction = _interaction()
 
+    with (
+        _all_visible(),
+        patch("cogs.help_cog._cog_for_subsystem", return_value=fake_cog),
+    ):
+        await btn.callback(interaction)
+
+    interaction.response.edit_message.assert_awaited_once()
+    interaction.response.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_button_hook_failure_renders_fallback_in_place():
+    btn = _game_button("blackjack")
     fake_cog = MagicMock()
     fake_cog.build_help_menu_view = AsyncMock(side_effect=RuntimeError("boom"))
+    interaction = _interaction()
 
     with _all_visible(), patch(
         "cogs.help_cog._cog_for_subsystem", return_value=fake_cog,
     ):
-        await view.handle_select(interaction, "blackjack")
+        await btn.callback(interaction)
 
     interaction.response.edit_message.assert_awaited_once()
     fake_cog.build_help_menu_view.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_handle_select_success_attaches_back_button():
-    view = GamesHubView(_author())
-    interaction = MagicMock(spec=discord.Interaction)
-    interaction.client = MagicMock()
-    interaction.response = MagicMock()
-    interaction.response.edit_message = AsyncMock()
+async def test_button_success_attaches_back_to_games_button():
+    """Successful child open edits in place and attaches Back-to-Games."""
+    parent_view = GamesHubView(_author())
+    btn = next(
+        c
+        for c in parent_view.children
+        if isinstance(c, _GameHubButton) and c._subsystem == "blackjack"  # type: ignore[attr-defined]
+    )
+    interaction = _interaction()
 
     child_view = discord.ui.View()
     child_embed = discord.Embed(title="Blackjack")
@@ -445,10 +484,10 @@ async def test_handle_select_success_attaches_back_button():
     with _all_visible(), patch(
         "cogs.help_cog._cog_for_subsystem", return_value=fake_cog,
     ):
-        await view.handle_select(interaction, "blackjack")
+        await btn.callback(interaction)
 
     interaction.response.edit_message.assert_awaited_once()
-    args, kwargs = interaction.response.edit_message.call_args
+    _args, kwargs = interaction.response.edit_message.call_args
     assert kwargs["embed"] is child_embed
     assert kwargs["view"] is child_view
     back_buttons = [
@@ -460,25 +499,38 @@ async def test_handle_select_success_attaches_back_button():
 
 
 @pytest.mark.asyncio
-async def test_button_callback_delegates_to_handle_select():
-    """Clicking a ``_GameHubButton`` must call
-    ``GamesHubView.handle_select`` with its bound subsystem — that is
-    how it shares the routing brain with the legacy dropdown's path.
+async def test_button_fails_closed_when_subsystem_invisible():
+    """Click-time recheck: if the subsystem drops out of visibility
+    between render and click, the button surfaces an ephemeral and does
+    NOT call into the cog.
     """
-    view = GamesHubView(_author())
-    btn = next(
-        c
-        for c in view.children
-        if isinstance(c, _GameHubButton) and c._subsystem == "blackjack"  # type: ignore[attr-defined]
+    btn = _game_button("blackjack")
+    interaction = _interaction()
+    interaction.user = _author()
+    interaction.guild_id = 7
+    interaction.channel = MagicMock()
+
+    vis_result = VisibilityResult(
+        visible_subsystems=set(),
+        member_tier="member",
+        resolved_from={},
+        traces={},
     )
-    interaction = MagicMock(spec=discord.Interaction)
-    with patch.object(
-        GamesHubView,
-        "handle_select",
-        new=AsyncMock(),
-    ) as mock_handle:
+    cog_lookup = MagicMock()
+    with patch(
+        "services.governance_service.resolve_visibility",
+        new_callable=AsyncMock,
+        return_value=vis_result,
+    ), patch("cogs.help_cog._cog_for_subsystem", cog_lookup):
         await btn.callback(interaction)
-    mock_handle.assert_awaited_once_with(interaction, "blackjack")
+
+    interaction.response.send_message.assert_awaited_once()
+    args, kwargs = interaction.response.send_message.call_args
+    message = args[0] if args else kwargs.get("content", "")
+    assert "no longer available" in message
+    assert kwargs.get("ephemeral") is True
+    cog_lookup.assert_not_called()
+    interaction.response.edit_message.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -642,42 +694,3 @@ async def test_build_games_hub_panel_raises_without_context():
 
     with pytest.raises(ValueError, match="interaction or ctx"):
         await build_games_hub_panel(_author())
-
-
-@pytest.mark.asyncio
-async def test_handle_select_fails_closed_when_subsystem_invisible():
-    """Click-time recheck: if a subsystem drops out of visibility
-    between render and click, ``handle_select`` must surface an
-    ephemeral and NOT call into the cog.
-    """
-    view = GamesHubView(_author())
-    interaction = MagicMock(spec=discord.Interaction)
-    interaction.client = MagicMock()
-    interaction.user = _author()
-    interaction.guild_id = 7
-    interaction.channel = MagicMock()
-    interaction.response = MagicMock()
-    interaction.response.send_message = AsyncMock()
-    interaction.response.edit_message = AsyncMock()
-
-    vis_result = VisibilityResult(
-        visible_subsystems=set(),
-        member_tier="member",
-        resolved_from={},
-        traces={},
-    )
-    cog_lookup = MagicMock()
-    with patch(
-        "services.governance_service.resolve_visibility",
-        new_callable=AsyncMock,
-        return_value=vis_result,
-    ), patch("cogs.help_cog._cog_for_subsystem", cog_lookup):
-        await view.handle_select(interaction, "blackjack")
-
-    interaction.response.send_message.assert_awaited_once()
-    args, kwargs = interaction.response.send_message.call_args
-    message = args[0] if args else kwargs.get("content", "")
-    assert "no longer available" in message
-    assert kwargs.get("ephemeral") is True
-    cog_lookup.assert_not_called()
-    interaction.response.edit_message.assert_not_called()

--- a/tests/unit/views/test_mining_back_to_games.py
+++ b/tests/unit/views/test_mining_back_to_games.py
@@ -1,9 +1,9 @@
 """Regression tests for PR #1 — Games → Mining attaches Back-to-Games.
 
-Live Discord testing reported that opening Mining from the Games hub
-dropdown did not show a visible Back-to-Games button. Code inspection
-of ``GamesHubView.handle_select`` shows ``attach_back_to_games_button``
-IS called on the child view at line 296 of ``disbot/views/games/hub.py``.
+Live Discord testing reported that opening Mining from the Games hub did
+not show a visible Back-to-Games button. The Games child button (now the
+shared ``views.hub_children.HubChildButton`` that ``_GameHubButton``
+subclasses) calls ``attach_back_to_games_button`` on the child view.
 
 These tests pin the model-level contract: after Games → Mining the
 returned view carries ``custom_id="games:back"``. They reuse the
@@ -25,7 +25,7 @@ import pytest
 
 from governance.models import VisibilityResult
 from utils.subsystem_registry import SUBSYSTEMS
-from views.games.hub import GamesHubView, attach_back_to_games_button
+from views.games.hub import GamesHubView, _GameHubButton, attach_back_to_games_button
 from views.mining.main_panel import MiningHubView
 
 
@@ -53,12 +53,18 @@ def test_attach_back_to_games_button_adds_games_back_id():
 
 
 @pytest.mark.asyncio
-async def test_games_hub_select_attaches_back_to_games_on_child(monkeypatch):
-    """End-to-end via ``GamesHubView.handle_select``: picking Mining
-    from the Games hub must call ``attach_back_to_games_button`` on the
-    child MiningHubView so the user can return to Games.
+async def test_games_hub_button_attaches_back_to_games_on_child(monkeypatch):
+    """End-to-end via the Games child button (the shared
+    ``HubChildButton`` callback ``_GameHubButton`` inherits): clicking
+    Mining from the Games hub must call ``attach_back_to_games_button``
+    on the child MiningHubView so the user can return to Games.
     """
     hub = GamesHubView(_author())
+    button = next(
+        c
+        for c in hub.children
+        if isinstance(c, _GameHubButton) and c._subsystem == "mining"  # type: ignore[attr-defined]
+    )
 
     mining_view = MiningHubView()
     mining_embed = discord.Embed(title="Mining")
@@ -67,7 +73,7 @@ async def test_games_hub_select_attaches_back_to_games_on_child(monkeypatch):
         return_value=(mining_embed, mining_view),
     )
 
-    # ``handle_select`` does a local import; patch the help-cog symbol
+    # The shared callback does a local import; patch the help-cog symbol
     # it pulls in at that point.
     monkeypatch.setattr(
         "cogs.help_cog._cog_for_subsystem",
@@ -79,9 +85,9 @@ async def test_games_hub_select_attaches_back_to_games_on_child(monkeypatch):
     interaction.client = MagicMock()
     interaction.response.edit_message = AsyncMock()
 
-    # PR D: GamesHubView.handle_select now re-resolves governance at
-    # click time. Stub it to return every subsystem visible so the test
-    # exercises the routing path, not the gating.
+    # The button re-resolves governance at click time. Stub it to return
+    # every subsystem visible so the test exercises the routing path, not
+    # the gating.
     vis_result = VisibilityResult(
         visible_subsystems=set(SUBSYSTEMS),
         member_tier="moderator",
@@ -93,7 +99,7 @@ async def test_games_hub_select_attaches_back_to_games_on_child(monkeypatch):
         new_callable=AsyncMock,
         return_value=vis_result,
     ):
-        await hub.handle_select(interaction, "mining")
+        await button.callback(interaction)
 
     interaction.response.edit_message.assert_awaited_once()
     kwargs = interaction.response.edit_message.await_args.kwargs
@@ -101,7 +107,7 @@ async def test_games_hub_select_attaches_back_to_games_on_child(monkeypatch):
     assert swapped is mining_view
     assert _has_back_to_games(swapped), (
         "Games → Mining must carry custom_id='games:back' attached by "
-        "GamesHubView.handle_select via attach_back_to_games_button."
+        "the shared HubChildButton callback via attach_back_to_games_button."
     )
 
 


### PR DESCRIPTION
Ultracode consolidation fleet worker **U3**. Behaviour-preserving deduplication.

## What
Migrate `disbot/views/games/hub.py`'s `_GameHubButton` + `GamesHubView.handle_select`
onto the shared `views.hub_children.HubChildButton` (the #1373 "first consolidation"
primitive), following the proven Community/Utility pattern (`_CommunityChildButton`).

- `_GameHubButton` becomes a thin `HubChildButton` subclass binding `hub_key="games"`,
  `back_attacher=attach_back_to_games_button`, `fallback_builder=_build_no_panel_embed`.
- `GamesHubView.handle_select` is removed — the shared button's `callback` replaces it.
  The dropdown-legacy guards inside it (`__none__` / wrong-parent) are dead for direct
  buttons and are dropped.
- `custom_ids` (`games:open:<sub>`), button order, `discover_hub_children`,
  `attach_back_to_games_button`, and `_build_no_panel_embed` stay byte-identical so
  persistent anchors keep routing.

## Status
**Born-red** — worker leaves the session card red; the coordinator reviews + merges
(Phase 2). Do not auto-merge.

⚑ Self-initiated consolidation (planned fleet follow-on, Q-0172).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sHpm1BzCvqj4CesshByZg

---
_Generated by [Claude Code](https://claude.ai/code/session_019sHpm1BzCvqj4CesshByZg)_