### PR TITLE
U3b: casino + cleanup edit_in_place tail (born-red — coordinator allowlists 3 genuine new-message cases)

### DIFF
--- a/.sessions/2026-06-23-u3b-casino-cleanup-tail.md
+++ b/.sessions/2026-06-23-u3b-casino-cleanup-tail.md
@@ -1,0 +1,23 @@
+# 2026-06-23 — U3b: casino + cleanup `edit_in_place` tail
+
+> **Status:** `in-progress`
+
+Ultracode Phase-1 worker. Unit **U3b** (parallel-safety: yellow). Branch
+`claude/u3b-casino-cleanup-tail` off `origin/main`.
+
+## Scope
+Drive the 3 remaining `edit_in_place` consistency findings in casino + cleanup to 0
+(by in-place fix **or** by flagging genuine new-message cases for the coordinator to
+allowlist in Phase 2):
+
+- `disbot/views/casino/hub.py:95`  `CasinoHubView.new_poker`
+- `disbot/views/casino/hub.py:112` `CasinoHubView.roulette`
+- `disbot/views/cleanup/policy_panel.py:765` `CleanupPolicyPanelView.btn_remove`
+
+## What's about to happen
+Read the three callbacks against live source, classify each as fix-in-place vs.
+genuine-new-message, and either convert or flag to the coordinator. `consistency_exceptions.yml`
+is coordinator-owned — workers never edit it; genuine new-message cases are STOPped and
+reported.
+
+> Born red — leave red. The coordinator flips/merges in Phase 2.

--- a/docs/owner/claims/u3b-casino-cleanup-tail.md
+++ b/docs/owner/claims/u3b-casino-cleanup-tail.md
@@ -1,0 +1,1 @@
+- claude/u3b-casino-cleanup-tail · U3b casino+cleanup edit_in_place tail · disbot/views/casino/**, disbot/views/cleanup/** (+ mirrored tests) · 2026-06-23


### PR DESCRIPTION
## Ultracode Phase-1 worker PR — Unit U3b (parallel-safety: yellow)

**BORN RED — leave red.** Coordinator flips the card and merges in Phase 2. Auto-merge is **not** armed.

### Goal
Drive the 3 remaining `edit_in_place` consistency findings in casino + cleanup to 0.

### Outcome: all 3 are GENUINE NEW-MESSAGE cases → flagged for coordinator allowlisting (no source edit)
`consistency_exceptions.yml` is coordinator-owned; per the worker contract I do **not** edit it. Each of the 3 is a real new-message case, not a navigation button that should swap the panel in place. Forcing `edit_message` would create real UX inconsistency. **Coordinator: please allowlist these 3 in `architecture_rules/consistency_exceptions.yml` under `edit_in_place:` in Phase 2.**

| File:line | Callback | Why genuine new-message (suggested reason) |
|---|---|---|
| `disbot/views/casino/hub.py:95` | `CasinoHubView.new_poker` | `poker_table.launch_table()` posts a **separate shared public lobby message** into the channel (`channel.send(...)`, poker_table.py:82). The ephemeral is a per-user confirm pointing at that shared message — the same shared-multiplayer-lobby pattern already allowlisted for `views/rps/registration.py::_RpsRegistrationView.join_btn` and `views/blackjack/tournament_views.py::_TournRegistrationView.join_btn`. Editing the operator's casino hub in place would not show the shared table. |
| `disbot/views/casino/hub.py:112` | `CasinoHubView.roulette` | Permanently `disabled=True` placeholder (`# pragma: no cover`); cannot fire in production. Its "coming soon" ephemeral is a notice, not navigation — there is no panel to swap to. |
| `disbot/views/cleanup/policy_panel.py:765` | `CleanupPolicyPanelView.btn_remove` | Structurally **identical to its sibling `btn_build`** (line 719), which is **already allowlisted** ("Opens the scope-select policy builder sub-flow; the sibling btn_refresh edits the panel in place"). `btn_remove` opens an ephemeral `_RemoveSelect` sub-flow; `_RemoveSelect.callback` does the in-place `edit_message` at the *selection* step. Editing the root panel on the button press would break parity with the allowlisted `btn_build`. Suggested reason: "Opens the remove-select sub-flow; mirrors the allowlisted sibling btn_build (btn_refresh edits the panel in place; _RemoveSelect.callback edits in place on selection)." |

### before/after edit_in_place count (casino + cleanup)
- **before:** 3 (casino 2, cleanup 1) — total repo `edit_in_place` = 36
- **after (this PR's source):** 3 (no source change — all genuine new-message)
- **after coordinator allowlists the 3:** 0 for casino+cleanup → total repo drops by 3 to 33

### Files changed
- `docs/owner/claims/u3b-casino-cleanup-tail.md` (claim — delete at close)
- `.sessions/2026-06-23-u3b-casino-cleanup-tail.md` (born-red card)

No `disbot/` source edited. Existing casino/cleanup tests stay green (38 passed). Stays within ALLOWED FILES; no held-set / cross-unit / forbidden file touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sHpm1BzCvqj4CesshByZg

---
_Generated by [Claude Code](https://claude.ai/code/session_019sHpm1BzCvqj4CesshByZg)_