### PR TITLE
feat(games): game-result continuation buttons (never-stranded follow-up)

### DIFF
--- a/.sessions/2026-06-23-game-result-continuations.md
+++ b/.sessions/2026-06-23-game-result-continuations.md
@@ -1,0 +1,28 @@
+# 2026-06-23 — Game-result continuation buttons (never-stranded follow-up)
+
+> **Status:** `in-progress` — owner-directed follow-up to PR #1382. That PR made every *panel* one
+> click from Help + its hub; this one fixes the **game-result dead-ends** it explicitly left: terminal
+> game-state views that disable all their buttons and strand the player with no continuation. PR this
+> session; auto-merge armed on green (Q-0127); owner-directed → merge immediately (Q-0191).
+
+> **Run type:** `manual · owner-directed`
+
+## The dead-ends (owner-reported)
+
+- **Deathmatch vs bot** — `_BotDuelView._finish` / `on_timeout` disable every button and re-render the
+  result with the same dead view → **no continuation at all** (the worst case; explicitly reported).
+- **Fishing** — `FishingCastView` interaction terminals (`_finish` catch, `_terminate_interaction`)
+  `_disable()` + `view=self`; only a footer hint ("!fish to cast again") → soft dead-end (forces a command).
+- **Casino** — `PokerEndView` already has **Deal next hand / End table**; not a dead-end → left as-is.
+
+## Approach (reuses PR #1382's mechanism)
+
+Terminal screens become **`HubView`s with `SUBSYSTEM` set** so `attach_standard_nav` auto-gives them
+**📚 Help + ↩ ‹hub›**, plus a game-specific **"… again"** button:
+
+- `_BotDuelResultView(HubView, SUBSYSTEM="deathmatch")` — **🔁 Play again** (re-fetch gear, fresh
+  `_BotDuelView`) + auto Help + Back-to-Games. Used in `_finish` and `on_timeout`.
+- `_FishingDoneView(HubView, SUBSYSTEM="fishing")` — **🎣 Cast again** (mirrors `FishingMenuView.cast_btn`
+  → `prepare_cast`) + auto Help + Back-to-Games. Used in the interaction terminals.
+
+(Close-out enders at session close.)

--- a/.sessions/2026-06-23-game-result-continuations.md
+++ b/.sessions/2026-06-23-game-result-continuations.md
@@ -1,6 +1,6 @@
 # 2026-06-23 — Game-result continuation buttons (never-stranded follow-up)
 
-> **Status:** `in-progress` — owner-directed follow-up to PR #1382. That PR made every *panel* one
+> **Status:** `complete` — owner-directed follow-up to PR #1382. That PR made every *panel* one
 > click from Help + its hub; this one fixes the **game-result dead-ends** it explicitly left: terminal
 > game-state views that disable all their buttons and strand the player with no continuation. PR this
 > session; auto-merge armed on green (Q-0127); owner-directed → merge immediately (Q-0191).
@@ -25,4 +25,35 @@ Terminal screens become **`HubView`s with `SUBSYSTEM` set** so `attach_standard_
 - `_FishingDoneView(HubView, SUBSYSTEM="fishing")` — **🎣 Cast again** (mirrors `FishingMenuView.cast_btn`
   → `prepare_cast`) + auto Help + Back-to-Games. Used in the interaction terminals.
 
-(Close-out enders at session close.)
+## Close-out
+
+**Verification:** `check_quality --full` green — **12157 passed**, 48 skipped; `mypy disbot/` clean;
+`check_architecture --mode strict` 0 errors; `check_consistency` green (incl. the new auto-nav
+exemption + opt-out tests); ledger + `check_docs --strict` pass (Q-0104).
+
+**Durable fix beyond the two views:** the static `back_button` consistency rule (`scripts/check_consistency.py`)
+now recognises a `SUBSYSTEM`-declaring panel as having a back affordance via `attach_standard_nav` (the
+runtime auto-nav), so it no longer false-flags the leaf panels PR #1382's mechanism already covers —
+and it still flags a `STANDARD_NAV = False` opt-out (Q-0120: a check that contradicts the evidence is a
+bug in the check). Two new tests pin both directions.
+
+**💡 Session idea (Q-0089):** *A runtime "no terminal dead-end" invariant for game-state views.* PR #1382
+made the static checker understand panels; this PR fixed two game-result dead-ends by hand. The gap that
+remains: `discord.ui.View`-direct game-state views (blackjack hands, rps rounds, the casino seat views)
+have no machine guarantee that their *terminal* state offers a continuation. A test that drives each
+game's terminal path (or asserts every `self.stop()`-reaching render swaps to a view with ≥1 enabled
+control) would convert "never stranded" into a contract for game screens too, not just panels. Distinct
+from the `back_button` rule (which only covers `HubView` panels, not transient game-state views).
+
+**⟲ Previous-session review (Q-0102):** the previous session (PR #1382, universal panel nav) shipped the
+mechanism cleanly and even *flagged* this exact follow-up ("game-result dead-ends … separate small fix")
+in its PR body and session card — good forward-handoff discipline; this session just executed that named
+item, which is the system working as intended. What it could have done better: it left the static
+`back_button` checker unaware of the new auto-nav, so the very first leaf panel built on the new
+mechanism (`_FishingDoneView`) tripped a false-positive — i.e. the mechanism and its checker shipped a
+session apart. **System improvement (applied):** when a PR introduces a new "the constructor provides X"
+mechanism, update the static checker that asserts X *in the same PR*, so the checker and the mechanism
+never drift. Did that here for `back_button`.
+
+**Claim** `docs/owner/claims/claude__game-result-continuations.md` deleted at close (Q-0126).
+

--- a/disbot/views/fishing/cast_view.py
+++ b/disbot/views/fishing/cast_view.py
@@ -48,6 +48,7 @@ from utils.fishing import venue as venue_mod
 from utils.fishing import weather as weather_mod
 from utils.fishing.fish import max_size_rank_for_level, species_for_venue
 from utils.ui_constants import ERROR_COLOR, GAME_COLOR, SUCCESS_COLOR
+from views.base import HubView
 from views.base import handle_view_error as _on_view_error
 
 logger = logging.getLogger("bot.views.fishing")
@@ -417,9 +418,15 @@ class FishingCastView(discord.ui.View):
         if result.xp_note:
             desc += f"\n{result.xp_note}"
         embed = discord.Embed(title=title, description=desc, color=SUCCESS_COLOR)
-        embed.set_footer(text="!fish to cast again · !fishlog for your collection")
-        self._disable()
-        await safe_edit(interaction, embed=embed, view=self)
+        embed.set_footer(text="🎣 Cast again · !fishlog for your collection")
+        # Hand off to the terminal continuation view (Cast again + standard nav)
+        # so a landed catch is never a dead-end (owner directive 2026-06-23).
+        await safe_edit(
+            interaction,
+            embed=embed,
+            view=_FishingDoneView(interaction.user, self.guild_id),
+        )
+        self.stop()
 
     def _disable(self) -> None:
         for item in self.children:
@@ -456,11 +463,16 @@ class FishingCastView(discord.ui.View):
         if not already_terminal:
             self._resolved = True
             self._release()
-        self._disable()
         if not await safe_defer(interaction):
             self.stop()
             return
-        await safe_edit(interaction, embed=self._embed(text, ERROR_COLOR), view=self)
+        # Continuation view (Cast again + standard nav) — even a fish that got
+        # away leaves the player one click from another cast, the hub, and Help.
+        await safe_edit(
+            interaction,
+            embed=self._embed(text, ERROR_COLOR),
+            view=_FishingDoneView(interaction.user, self.guild_id),
+        )
         self.stop()
 
     def _terminate_silent(self) -> None:
@@ -501,3 +513,43 @@ class FishingCastView(discord.ui.View):
     ) -> None:
         self._release()
         await _on_view_error(self, interaction, error, item)
+
+
+class _FishingDoneView(HubView):
+    """Terminal screen after a cast resolves — never a dead-end.
+
+    A ``HubView`` with ``SUBSYSTEM = "fishing"`` so
+    :func:`views.navigation.attach_standard_nav` auto-attaches **📚 Help** and
+    **↩ Games** — the player is one click from the Games hub and Help. The
+    **🎣 Cast again** button re-runs :func:`prepare_cast`, mirroring
+    ``FishingMenuView.cast_btn`` so a landed (or escaped) catch flows straight
+    into the next cast.
+    """
+
+    SUBSYSTEM = "fishing"
+
+    def __init__(self, author: discord.Member | discord.User, guild_id: int) -> None:
+        super().__init__(author)
+        self.guild_id = guild_id
+
+    @discord.ui.button(
+        label="Cast again",
+        emoji="🎣",
+        style=discord.ButtonStyle.success,
+        custom_id="fishing_done:cast_again",
+        row=0,
+    )
+    async def cast_again(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        prepared = await prepare_cast(self._author.id, self.guild_id)
+        if isinstance(prepared, str):
+            await interaction.response.send_message(prepared, ephemeral=True)
+            return
+        embed, view = prepared
+        await interaction.response.edit_message(embed=embed, view=view)
+        view.message = interaction.message
+        view.start()
+        self.stop()

--- a/disbot/views/games/deathmatch_panel.py
+++ b/disbot/views/games/deathmatch_panel.py
@@ -278,10 +278,10 @@ class _BotDuelView(discord.ui.View):
         action_text: str,
     ) -> None:
         self.duel.is_over = True
-        for item in self.children:
-            item.disabled = True  # type: ignore[attr-defined]
         # NOTE: deliberately NO call to ``cog.update_leaderboard`` /
         # ``db.update_deathmatch`` — see plan §13 bot-duel stats rule.
+        # Swap to the terminal result view (Play again + standard nav) so the
+        # finished duel is never a dead-end (owner directive 2026-06-23).
         await interaction.response.edit_message(
             embed=build_bot_duel_result_embed(
                 self.duel,
@@ -289,7 +289,7 @@ class _BotDuelView(discord.ui.View):
                 self.bot_user,
                 action_text,
             ),
-            view=self,
+            view=_BotDuelResultView(self.player, self.bot_user),
         )
         self.stop()
 
@@ -297,8 +297,6 @@ class _BotDuelView(discord.ui.View):
         if self.duel.is_over:
             return
         self.duel.is_over = True
-        for item in self.children:
-            item.disabled = True  # type: ignore[attr-defined]
         embed = discord.Embed(
             title="⚔️ Bot Duel — Timeout",
             description=(
@@ -310,9 +308,56 @@ class _BotDuelView(discord.ui.View):
         )
         if self.message:
             try:
-                await self.message.edit(embed=embed, view=self)
+                await self.message.edit(
+                    embed=embed,
+                    view=_BotDuelResultView(self.player, self.bot_user),
+                )
             except Exception:
                 pass
+
+
+class _BotDuelResultView(HubView):
+    """Terminal screen after a bot duel — never a dead-end.
+
+    A ``HubView`` with ``SUBSYSTEM = "deathmatch"`` so
+    :func:`views.navigation.attach_standard_nav` auto-attaches **📚 Help** and
+    **↩ Games** — the player is one click from the Deathmatch hub and Help.
+    The **🔁 Play again** button re-runs the Fight Bot flow (re-fetched gear,
+    a fresh :class:`_BotDuelView`), mirroring ``DeathmatchPanelView.btn_fight_bot``.
+    """
+
+    SUBSYSTEM = "deathmatch"
+
+    def __init__(
+        self,
+        player: discord.Member | discord.User,
+        bot_user: discord.User | discord.ClientUser,
+    ) -> None:
+        super().__init__(player)
+        self.player = player
+        self.bot_user = bot_user
+
+    @discord.ui.button(
+        label="🔁 Play again",
+        style=discord.ButtonStyle.success,
+        custom_id="bot_duel_result:again",
+        row=0,
+    )
+    async def btn_again(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button,
+    ) -> None:
+        bot_user = interaction.client.user or self.bot_user
+        player_stats = equipment.compute_stats(
+            await db.get_equipment(str(interaction.user.id), interaction.guild_id or 0),
+        )
+        view = _BotDuelView(interaction.user, bot_user, player_stats=player_stats)
+        await interaction.response.edit_message(
+            embed=build_bot_duel_embed(view.duel, interaction.user, bot_user),
+            view=view,
+        )
+        view.message = interaction.message
 
 
 # ---------------------------------------------------------------------------

--- a/docs/owner/claims/claude__game-result-continuations.md
+++ b/docs/owner/claims/claude__game-result-continuations.md
@@ -1,7 +1,0 @@
-- `claude/game-result-continuations` · **Game-result continuation buttons (never-stranded follow-up)** —
-  the game-RESULT dead-ends left by PR #1382's panel auto-nav: terminal game-state views
-  (`discord.ui.View` directly) that disable all buttons and strand the player. Add a HubView terminal
-  view (SUBSYSTEM → auto Help + Back-to-hub) + a game-specific "again" button. Scope:
-  `disbot/views/games/deathmatch_panel.py` (`_BotDuelView` finish/timeout), `disbot/views/fishing/cast_view.py`
-  (interaction terminals), `tests/`. Casino `PokerEndView` already has Deal-next/End — left as-is. 2026-06-23 ·
-  PR (this session, auto-merge on green)

--- a/docs/owner/claims/claude__game-result-continuations.md
+++ b/docs/owner/claims/claude__game-result-continuations.md
@@ -1,0 +1,7 @@
+- `claude/game-result-continuations` · **Game-result continuation buttons (never-stranded follow-up)** —
+  the game-RESULT dead-ends left by PR #1382's panel auto-nav: terminal game-state views
+  (`discord.ui.View` directly) that disable all buttons and strand the player. Add a HubView terminal
+  view (SUBSYSTEM → auto Help + Back-to-hub) + a game-specific "again" button. Scope:
+  `disbot/views/games/deathmatch_panel.py` (`_BotDuelView` finish/timeout), `disbot/views/fishing/cast_view.py`
+  (interaction terminals), `tests/`. Casino `PokerEndView` already has Deal-next/End — left as-is. 2026-06-23 ·
+  PR (this session, auto-merge on green)

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -467,6 +467,45 @@ def _is_hub_view_class(node: ast.ClassDef) -> bool:
     return any(base.rsplit(".", 1)[-1] == "HubView" for base in _class_bases(node))
 
 
+def _class_gets_auto_nav(node: ast.ClassDef) -> bool:
+    """True if the class auto-attaches standard nav (the never-stranded mechanism).
+
+    A panel that declares a non-empty ``SUBSYSTEM`` (and does not opt out with
+    ``STANDARD_NAV = False``) gets a ``📚 Help`` (+ ``↩ <hub>``) control on
+    construction from ``views.navigation.attach_standard_nav`` (run in the
+    ``BaseView`` / ``PersistentView`` ``__init__``). It is therefore never a
+    back/nav gap, even when its module references no ``attach_back_button`` —
+    the auto-nav IS the affordance. Recognising it here keeps this static rule
+    from false-flagging the leaf panels the universal mechanism already covers
+    (the Q-0120 "a check that contradicts the evidence is a bug in the check").
+    """
+    has_subsystem = False
+    standard_nav_off = False
+    for stmt in node.body:
+        targets: list[ast.expr] = []
+        value: ast.expr | None = None
+        if isinstance(stmt, ast.Assign):
+            targets, value = stmt.targets, stmt.value
+        elif isinstance(stmt, ast.AnnAssign):
+            targets, value = [stmt.target], stmt.value
+        for tgt in targets:
+            if not isinstance(tgt, ast.Name):
+                continue
+            if (
+                tgt.id == "SUBSYSTEM"
+                and isinstance(value, ast.Constant)
+                and bool(value.value)
+            ):
+                has_subsystem = True
+            if (
+                tgt.id == "STANDARD_NAV"
+                and isinstance(value, ast.Constant)
+                and value.value is False
+            ):
+                standard_nav_off = True
+    return has_subsystem and not standard_nav_off
+
+
 def _class_adds_items_dynamically(node: ast.ClassDef) -> bool:
     """True if the class builds controls via ``add_item(...)`` rather than
     decorated ``@ui.button``/``@ui.select`` callbacks.
@@ -522,6 +561,11 @@ def rule_back_button(
                 for fn in cls.body
             ) or _class_adds_items_dynamically(cls)
             if not has_child_control:
+                continue
+            # A SUBSYSTEM-declaring panel auto-attaches standard nav in its
+            # constructor (attach_standard_nav) — the affordance is present at
+            # runtime even though no attach_back_button call appears statically.
+            if _class_gets_auto_nav(cls):
                 continue
             if _is_allowlisted(rel, cls.name, cfg):
                 continue

--- a/tests/unit/scripts/test_check_consistency.py
+++ b/tests/unit/scripts/test_check_consistency.py
@@ -311,6 +311,37 @@ class CompareView(HubView):
 """
 
 
+# A dynamic hub that declares SUBSYSTEM — attach_standard_nav auto-attaches its
+# 📚 Help / ↩ <hub> control in __init__, so it is NOT a back gap even though the
+# module references no attach_back_button (the never-stranded mechanism).
+_HUB_SUBSYSTEM_AUTO_NAV = """\
+import discord
+
+
+class FishingDone(HubView):
+    SUBSYSTEM = "fishing"
+
+    def __init__(self, author):
+        super().__init__(author)
+        self.add_item(discord.ui.Button(label="Cast again", custom_id="x:again"))
+"""
+
+# Same, but opts out of auto-nav (STANDARD_NAV = False) — it genuinely has no
+# nav, so the rule must still flag it.
+_HUB_SUBSYSTEM_NAV_OPT_OUT = """\
+import discord
+
+
+class DemoHub(HubView):
+    SUBSYSTEM = "ux_lab"
+    STANDARD_NAV = False
+
+    def __init__(self, author):
+        super().__init__(author)
+        self.add_item(discord.ui.Button(label="Ping", custom_id="x:ping"))
+"""
+
+
 def _back_findings(mod, tmp_path, monkeypatch, src, *, rel="views/settings_hub.py"):
     _write(mod, tmp_path, monkeypatch, rel, src)
     return mod.rule_back_button([tmp_path / rel], {})
@@ -357,6 +388,23 @@ def test_back_transition_to_helper_is_clean(mod, tmp_path, monkeypatch):
     as a nav affordance (the UX-lab compare/probes/wing pattern).
     """
     assert _back_findings(mod, tmp_path, monkeypatch, _HUB_TRANSITION_TO) == []
+
+
+def test_back_subsystem_panel_with_auto_nav_is_clean(mod, tmp_path, monkeypatch):
+    """A SUBSYSTEM-declaring panel auto-attaches standard nav (📚 Help / ↩ hub)
+    in its constructor — the affordance is present at runtime, so the static
+    rule must not flag it even with no attach_back_button in the module.
+    """
+    assert _back_findings(mod, tmp_path, monkeypatch, _HUB_SUBSYSTEM_AUTO_NAV) == []
+
+
+def test_back_flags_subsystem_panel_that_opts_out_of_auto_nav(mod, tmp_path, monkeypatch):
+    """STANDARD_NAV = False opts out of auto-nav, so such a panel genuinely has
+    no back affordance and must still be flagged.
+    """
+    findings = _back_findings(mod, tmp_path, monkeypatch, _HUB_SUBSYSTEM_NAV_OPT_OUT)
+    assert len(findings) == 1
+    assert findings[0].qualname == "DemoHub"
 
 
 def test_back_allowlist_suppresses_by_class(mod, tmp_path, monkeypatch):

--- a/tests/unit/views/test_game_result_continuations.py
+++ b/tests/unit/views/test_game_result_continuations.py
@@ -1,0 +1,73 @@
+"""Game-result continuation pins (never-stranded follow-up to PR #1382).
+
+PR #1382 gave every *panel* a Help + Back-to-hub control. The game-RESULT
+screens (terminal ``discord.ui.View`` game-state views) were left out and
+dead-ended with all buttons disabled. These tests pin that the terminal views
+now carry a game-specific "… again" button AND the universal standard nav
+(``nav:help`` + ``nav:hub:games``) so the player is never stranded.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from views.fishing.cast_view import _FishingDoneView  # noqa: E402
+from views.games.deathmatch_panel import (  # noqa: E402
+    _BotDuelResultView,
+    _BotDuelView,
+)
+
+
+def _ids(view: discord.ui.View) -> set[str]:
+    return {
+        c.custom_id  # type: ignore[attr-defined]
+        for c in view.children
+        if getattr(c, "custom_id", None)
+    }
+
+
+def _player(id_: int = 100) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=id_, display_name="Player", mention=f"<@{id_}>", bot=False
+    )
+
+
+def _bot_user(id_: int = 999) -> SimpleNamespace:
+    return SimpleNamespace(id=id_, display_name="Bot", mention=f"<@{id_}>", bot=True)
+
+
+def test_bot_duel_result_view_offers_play_again_and_standard_nav():
+    view = _BotDuelResultView(_player(), _bot_user())
+    assert _ids(view) == {"bot_duel_result:again", "nav:help", "nav:hub:games"}
+
+
+def test_fishing_done_view_offers_cast_again_and_standard_nav():
+    view = _FishingDoneView(_player(), guild_id=42)
+    assert _ids(view) == {"fishing_done:cast_again", "nav:help", "nav:hub:games"}
+
+
+@pytest.mark.asyncio
+async def test_bot_duel_finish_swaps_to_a_continuation_view_not_a_dead_end():
+    """``_BotDuelView._finish`` must render the result on a continuation view
+    (Play again + nav), never the old all-disabled ``self``.
+    """
+    duel = _BotDuelView(_player(), _bot_user())
+    interaction = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+
+    await duel._finish(interaction, "Final blow!")
+
+    interaction.response.edit_message.assert_awaited_once()
+    swapped = interaction.response.edit_message.await_args.kwargs["view"]
+    assert isinstance(swapped, _BotDuelResultView)
+    assert {"nav:help", "nav:hub:games", "bot_duel_result:again"} <= _ids(swapped)


### PR DESCRIPTION
## What & why

Follow-up to #1382. That PR made every **panel** one click from Help + its hub; this fixes the **game-result dead-ends** it explicitly left — terminal game-state views (`discord.ui.View` directly) that disable all their buttons and strand the player with no continuation.

## Dead-ends (owner-reported)

- **Deathmatch vs bot** — `_BotDuelView._finish` / `on_timeout` disable every button and re-render the result with the same dead view → no continuation at all (explicitly reported, worst case).
- **Fishing** — `FishingCastView` interaction terminals disable buttons with only a "type !fish again" footer hint → soft dead-end.
- **Casino** — `PokerEndView` already has **Deal next hand / End table**; not a dead-end → left as-is.

## Approach (reuses #1382's mechanism)

Terminal screens become **`HubView`s with `SUBSYSTEM` set**, so `attach_standard_nav` auto-attaches **📚 Help + ↩ ‹hub›**, plus a game-specific "… again" button:

- `_BotDuelResultView(SUBSYSTEM="deathmatch")` — 🔁 **Play again** + auto Help/Back-to-Games.
- `_FishingDoneView(SUBSYSTEM="fishing")` — 🎣 **Cast again** + auto Help/Back-to-Games.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzLEHqxK5CAuKynxjuiVKz)_