### PR TITLE
btd6: round-scaled bloon health (late-game/freeplay MOAB-class HP ramp)

### DIFF
--- a/.sessions/2026-06-23-btd6-bloon-health-round-scaling.md
+++ b/.sessions/2026-06-23-btd6-bloon-health-round-scaling.md
@@ -1,27 +1,97 @@
 # 2026-06-23 — BTD6 late-game/freeplay bloon health scaling (round-scaled HP)
 
-> **Status:** `in-progress`
+> **Status:** `complete` — owner-directed (Discord screenshot → "find it on the web"
+> → "continue"). The bot answered "BAD on r100" with a flat **20,000** and asserted
+> "round 100 doesn't change the BAD's base health." Wrong: a BAD first spawns on
+> round 100 already at **28,000 HP**. This session adds the missing round-relative
+> MOAB-class health scaling. PR #1384; auto-merge armed on green (Q-0127);
+> owner-directed → merges immediately (Q-0191).
 
-Owner-directed (Discord screenshot). The bot answered "how much health does a BAD
-have on r100?" with a flat **20,000** and asserted "round 100 doesn't change the
-BAD's base health." A community member (kthxbye) corrected it: **28k — 20k base ×
-1.4 by r100.** This session adds the missing round-relative health scaling.
+> **Run type:** `manual · owner-directed`
 
-## What I'm about to do
-- Research-verified (web, this session): BTD6 applies a **runtime** late-game /
-  freeplay health ramp to **MOAB-class** bloons — +2% of base HP per round from
-  round 81, piecewise-linear (`v(100)=1.40`), so a BAD first spawns on round 100
-  already at **28,000 HP** (20,000 × 1.4), 67,200 RBE. **Not in the dump** (round
-  files = composition/timing only; `BloonModel` stores base `maxHealth` only) —
-  same shape as per-round XP/cash, which we already curate.
-- Encode the curve as a curated `disbot/data/btd6/bloon_scaling.json` (mirrors the
-  `round_xp.json` source-noted pattern), add `moab_class_health_multiplier()` /
-  `bloon_health_at_round()` to `btd6_data_service`, surface it in
-  `btd6_context_service` (a deterministic "bloon HP at round N" floor reply +
-  MOAB-class grounding note), and pin the verified anchors (r100 = 1.4, BAD =
-  28,000) in tests.
+## The bug (from the channel)
 
-Sources: bloons.fandom.com *Late Game and Freeplay (BTD6)* + *Big Airship of Doom*
-(28,000 / 67,200 RBE @ r100) + topper64.co.uk *BTD6 Rounds* ("+2% health/round
-after round 80"). r≤100 bracket cross-verified; >100 brackets are the wiki's
-documented continuation.
+`@SuperBot how much health does a BAD have … And on r100?` → bot: "20,000 … round
+100 keeps its 20,000 HP base." A community member (kthxbye) corrected it: *28k — 20k
+base × 1.4 by r100.* kthxbye was right.
+
+## Root cause
+
+BTD6 applies a **runtime late-game/freeplay health ramp to MOAB-class bloons** that
+is **not in the game-data dump**: round files store only composition + spawn timing,
+and `BloonModel` stores only base `maxHealth`. Our `bloons.json` therefore had the
+20,000 base and nothing round-relative, so the model "knew" only the base and
+confidently flattened the nuance. Same shape as per-round XP/cash, already curated.
+
+## Verified mechanic (web research, this session)
+
+MOAB-class bloons (MOAB/BFB/ZOMG/DDT/BAD) gain **+2% of base HP per round from round
+81**, piecewise-linear with step-ups at 101/151/201/252:
+
+```
+v(r) = 1.0                    r ≤ 80
+v(r) = 1.0 + (r−80)·0.02      81 ≤ r ≤ 100   → v(100) = 1.40
+v(r) = 1.6 + (r−101)·0.02     101 ≤ r ≤ 150
+v(r) = 3.0 + (r−151)·0.02     151 ≤ r ≤ 200
+v(r) = 4.5 + (r−201)·0.02     201 ≤ r ≤ 251
+v(r) = 6.0 + (r−252)·0.02     r ≥ 252
+```
+
+`BAD @ r100 = 20,000 × 1.40 = 28,000` (67,200 RBE) — cross-verified by three sources
+(Late Game and Freeplay / BAD wiki / topper64 "+2% health/round after round 80").
+The **r ≤ 100 bracket is cross-verified**; the > 100 brackets are the wiki's
+documented continuation (flagged in the data file's source note). The Fandom/Blooncyclopedia
+pages 403 to fetchers (Cloudflare); the formula was pulled via WebSearch summaries + the
+topper64 cross-check, not a direct page fetch.
+
+## Shipped (PR #1384)
+
+- **`disbot/data/btd6/bloon_scaling.json`** — the curve as curated data with a
+  `scaling_source` note stating it is NOT in the dump (sibling of `round_xp.json`).
+- **`btd6_data_service`** — `HealthScalingBracket`, dataset fields
+  `moab_health_scaling` / `moab_health_start_round`, and
+  `moab_class_health_multiplier(round)` + `bloon_health_at_round(id, round, *, fortified=)`.
+- **`btd6_context_service`** — `deterministic_bloon_health_reply` floor (owns "HP of
+  <bloon> at round N" so the model can't re-flatten it) + a MOAB-class grounding note
+  in `_render_fixture_bloon` for conversational follow-ups ("and on r100?").
+- **Tests** — `test_btd6_bloon_scaling.py` (18) pins the loader, multiplier math,
+  per-bloon scaled HP (BAD 28k / fortified 56k, non-MOAB unchanged), and the reply;
+  plus the floor-builder exclusivity corpus entry.
+- **`btd6-gamedata-dictionary.md`** — a "Runtime-formula facts the dump does NOT
+  store" section so the next agent doesn't re-investigate "where's the round HP modifier."
+- Full CI mirror green (`check_quality.py --full`: 12,172 passed); arch strict clean.
+
+## 💡 Session idea (Q-0089)
+
+**Round-scaled RBE, not just HP.** The same ramp means a BAD's *RBE* at r100 is
+**67,200**, but `rounds.json` still lists the unscaled **55,760** (and the
+round-economy reply repeats it). Extend `bloon_scaling` consumption to recompute
+MOAB-class RBE at a round (RBE = HP-of-this-layer + Σ children, with the multiplier
+applied per MOAB-class layer) and surface it in `deterministic_round_economy_reply`
+and the round grounding — so "RBE of round 100" matches the in-game 67,200. Scoped,
+verifiable (same three-source anchor), and closes the other half of this bug class.
+*(Dedup-checked docs/ideas/ + roadmap: no existing round-scaled-RBE entry.)*
+
+## ⟲ Previous-session review (Q-0102)
+
+Reviewed **2026-06-23-panel-back-nav-fix** (#1383, universal panel Help/Back nav).
+**Did well:** fixed the *root cause* — leaf panels lost externally-attached nav on
+`edit_in_place` redraw onto a fresh instance — with a registry-driven `attach_standard_nav`
+self-attach, instead of patching each of ~8 panels (one mechanism vs. N patches; the
+right altitude). **Could improve / system note:** its `_self_navigates` guard is a
+**heuristic on the codebase's stable button copy** (string-matching label text) — a
+later copy tweak silently breaks the guard and either double-attaches or skips nav.
+A *structural* marker (a `SELF_NAVIGATES` class attribute or a mixin) would be
+robust to wording changes. **Workflow improvement it surfaces:** when a guard keys on
+human-facing strings, add a test that asserts the guard's verdict for each live panel
+class (so a copy change that flips the verdict fails CI) — the same "executable contract
+over the live tuple" discipline this repo already uses for the floor-builder exclusivity
+corpus (which is exactly what caught my new builder this session).
+
+## Doc audit (Q-0104)
+
+`check_current_state_ledger --strict` exit 0 (24 PRs newer than marker #1352 = benign
+lag, not drift, Q-0166); `check_docs --strict` passed. New mechanic has a durable home
+(the data file's `scaling_source` + the gamedata-dictionary section + this log). No
+owner decision to route. Ledger entry for #1384 lands via the next reconciliation pass
+(no placeholder — Q-0052).

--- a/.sessions/2026-06-23-btd6-bloon-health-round-scaling.md
+++ b/.sessions/2026-06-23-btd6-bloon-health-round-scaling.md
@@ -1,0 +1,27 @@
+# 2026-06-23 — BTD6 late-game/freeplay bloon health scaling (round-scaled HP)
+
+> **Status:** `in-progress`
+
+Owner-directed (Discord screenshot). The bot answered "how much health does a BAD
+have on r100?" with a flat **20,000** and asserted "round 100 doesn't change the
+BAD's base health." A community member (kthxbye) corrected it: **28k — 20k base ×
+1.4 by r100.** This session adds the missing round-relative health scaling.
+
+## What I'm about to do
+- Research-verified (web, this session): BTD6 applies a **runtime** late-game /
+  freeplay health ramp to **MOAB-class** bloons — +2% of base HP per round from
+  round 81, piecewise-linear (`v(100)=1.40`), so a BAD first spawns on round 100
+  already at **28,000 HP** (20,000 × 1.4), 67,200 RBE. **Not in the dump** (round
+  files = composition/timing only; `BloonModel` stores base `maxHealth` only) —
+  same shape as per-round XP/cash, which we already curate.
+- Encode the curve as a curated `disbot/data/btd6/bloon_scaling.json` (mirrors the
+  `round_xp.json` source-noted pattern), add `moab_class_health_multiplier()` /
+  `bloon_health_at_round()` to `btd6_data_service`, surface it in
+  `btd6_context_service` (a deterministic "bloon HP at round N" floor reply +
+  MOAB-class grounding note), and pin the verified anchors (r100 = 1.4, BAD =
+  28,000) in tests.
+
+Sources: bloons.fandom.com *Late Game and Freeplay (BTD6)* + *Big Airship of Doom*
+(28,000 / 67,200 RBE @ r100) + topper64.co.uk *BTD6 Rounds* ("+2% health/round
+after round 80"). r≤100 bracket cross-verified; >100 brackets are the wiki's
+documented continuation.

--- a/disbot/data/btd6/bloon_scaling.json
+++ b/disbot/data/btd6/bloon_scaling.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "data_version": "1.0",
+  "game_version": "55.1",
+  "source": "bloons.fandom.com Late Game and Freeplay (BTD6) + Big Airship of Doom + topper64.co.uk/nk/btd6/rounds (CC BY-NC-SA / community)",
+  "scaling_source": "Round-relative bloon health scaling is NOT in the BTD Mod Helper game data dump: round files store only bloon composition + spawn timing, and BloonModel stores only the BASE maxHealth (BAD = 20000). BTD6 applies a RUNTIME late-game/freeplay health ramp to MOAB-class bloons (MOAB/BFB/ZOMG/DDT/BAD): from round 81 they gain +2% of base health per round, a piecewise-linear curve with step-ups at rounds 101/151/201/252. v(100)=1.40, so a BAD first naturally spawns on round 100 already at 20000*1.40=28000 HP (67200 RBE). The r<=100 bracket is cross-verified (BAD=28000 HP / 67200 RBE @ r100, three independent sources); the >100 brackets are the wiki's documented continuation (extend/verify against the live Late Game and Freeplay table). Regular (non-MOAB-class) bloons do NOT take this multiplier - ceramics are instead swapped for superceramics at round 81. multiplier(r) = base + (r - anchor_round) * per_round, clamped to the bracket whose min_round <= r <= max_round; rounds below the first bracket are 1.0 (unscaled).",
+  "moab_class_health": {
+    "applies_to_category": "moab_class",
+    "start_round": 81,
+    "per_round_pct_of_base": 0.02,
+    "brackets": [
+      { "min_round": 1, "max_round": 80, "anchor_round": 80, "base": 1.0, "per_round": 0.0 },
+      { "min_round": 81, "max_round": 100, "anchor_round": 80, "base": 1.0, "per_round": 0.02 },
+      { "min_round": 101, "max_round": 150, "anchor_round": 101, "base": 1.6, "per_round": 0.02 },
+      { "min_round": 151, "max_round": 200, "anchor_round": 151, "base": 3.0, "per_round": 0.02 },
+      { "min_round": 201, "max_round": 251, "anchor_round": 201, "base": 4.5, "per_round": 0.02 },
+      { "min_round": 252, "max_round": 1000, "anchor_round": 252, "base": 6.0, "per_round": 0.02 }
+    ]
+  }
+}

--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -1038,6 +1038,28 @@ def _render_fixture_bloon(entry: Any) -> list[str]:
             ),
         )
 
+    # MOAB-class bloons take a runtime late-game/freeplay health ramp (+2% of base
+    # HP per round from round 81; ×1.40 by round 100) that is NOT in the game files,
+    # so the base `health` above is only the round-≤80 value. Surface it so the
+    # model never claims a BAD "keeps its 20,000 base" on a late round (the bug this
+    # fixes) — this is the conversational-follow-up complement to the deterministic
+    # "HP of <bloon> at round N" floor.
+    if str(getattr(entry, "category", "")) == "moab_class" and isinstance(health, int):
+        from services import btd6_data_service
+
+        mult100 = btd6_data_service.moab_class_health_multiplier(100)
+        if mult100 is not None:
+            r100 = int(round(health * mult100))
+            lines.append(
+                _cap(
+                    f"[btd6_bloon] {canonical} — late-game/freeplay scaling: MOAB-class "
+                    f"health ramps +2% of base per round from round 81 (×{mult100:g} by "
+                    f"round 100), so {health:,} HP holds only through round 80; it first "
+                    f"appears on round 100 at {r100:,} HP. Runtime ramp, not in the game "
+                    f"files (source: {_dataset_label()}).",
+                ),
+            )
+
     if description:
         lines.append(
             _cap(
@@ -3252,6 +3274,110 @@ def _format_bloon_immunity_roster(label: str, hits: list[Any]) -> str:
     return f"**BTD6 bloons immune to {label} damage ({len(hits)}):** {names}."
 
 
+# --- "HP of <bloon> at round N" deterministic reply ---------------------------
+# Owns the round-scaled bloon-health answer. The bot previously said a BAD "keeps
+# its 20,000 HP base" on round 100 — wrong: MOAB-class bloons take a runtime
+# late-game/freeplay health ramp (+2%/round from round 81; v(100)=1.40), so a BAD
+# first spawns on round 100 already at 28,000 HP. The ramp is not in the dump
+# (curated in bloon_scaling.json), and the base-only grounding let the model
+# flatten it — so the deterministic layer OWNS the round-specific value. Fires
+# only on a bloon + a round number + a health cue; otherwise defers (the base
+# "how much HP does a BAD have" question still reaches the model with grounding).
+_BLOON_HEALTH_CUE_RE = re.compile(r"\b(?:health|hp|hit\s?points?|hitpoints?)\b", re.I)
+_BLOON_FORTIFIED_CUE_RE = re.compile(r"\bfortif(?:ied|y|ication)\b", re.I)
+
+
+def _resolve_bloon_in_text(text_lower: str) -> Any | None:
+    """The BloonEntry whose name/alias appears in ``text_lower``, or ``None``.
+
+    Whole-word match against every bloon's id / canonical / aliases (modifier
+    marker rows excluded), preferring the longest matched surface so "big airship
+    of doom" beats a stray "bad" and a specific blimp beats a generic word.
+    """
+    from services import btd6_data_service
+
+    best: Any | None = None
+    best_len = 0
+    for bloon in btd6_data_service.get_dataset().bloons:
+        if bloon.category == "modifier":
+            continue
+        surfaces = {
+            bloon.id,
+            bloon.canonical.lower(),
+            *(a.lower() for a in bloon.aliases),
+        }
+        for surface in surfaces:
+            if not surface:
+                continue
+            if (
+                re.search(rf"\b{re.escape(surface)}\b", text_lower)
+                and len(surface) > best_len
+            ):
+                best, best_len = bloon, len(surface)
+    return best
+
+
+def deterministic_bloon_health_reply(message_text: str) -> str | None:
+    """A code-built "HP of <bloon> on round N" answer, or ``None``.
+
+    Fires on a resolvable bloon + a round number + a health/HP cue, served as a
+    pre-emptive floor. For MOAB-class bloons it applies the late-game/freeplay
+    ramp (``bloon_health_at_round``); for everything else it states the flat base
+    health and that only MOAB-class bloons scale. Defers (``None``) without all
+    three signals, or when the bloon's base health / scaling data is unavailable —
+    those reach the model.
+    """
+    text = (message_text or "").strip()
+    if not text:
+        return None
+    low = text.lower()
+    if not _BLOON_HEALTH_CUE_RE.search(low):
+        return None
+    number_match = _ROUND_XP_NUMBER_RE.search(low)
+    if number_match is None:
+        return None
+    round_number = int(number_match.group(1) or number_match.group(2))
+    bloon = _resolve_bloon_in_text(low)
+    if bloon is None:
+        return None
+
+    from services import btd6_data_service
+
+    fortified = bool(_BLOON_FORTIFIED_CUE_RE.search(low))
+    base = bloon.health_fortified if fortified else bloon.health
+    if not isinstance(base, int):
+        return None
+    fort_label = "fortified " if fortified else ""
+
+    if bloon.category != "moab_class":
+        return (
+            f"A {fort_label}**{bloon.canonical}** has **{base:,} HP** — its health "
+            f"is the same on every round. Only MOAB-class bloons "
+            f"(MOAB/BFB/ZOMG/DDT/BAD) scale with the round: in late game / freeplay "
+            f"they gain +2% of base health per round from round 81."
+        )
+
+    scaled = btd6_data_service.bloon_health_at_round(
+        bloon.id,
+        round_number,
+        fortified=fortified,
+    )
+    multiplier = btd6_data_service.moab_class_health_multiplier(round_number)
+    if scaled is None or multiplier is None:
+        return None
+    r100 = int(
+        round(base * (btd6_data_service.moab_class_health_multiplier(100) or 1.0)),
+    )
+    return (
+        f"A {fort_label}**{bloon.canonical}** has **{scaled:,} HP** on "
+        f"**round {round_number}** — base **{base:,}** × **{multiplier:g}** "
+        f"late-game/freeplay scaling. MOAB-class bloons gain +2% of base health "
+        f"per round from round 81, so a {fort_label}{bloon.canonical} first appears "
+        f"on round 100 already at **{r100:,} HP**, not its {base:,} base. "
+        f"(The ramp is a runtime formula, not in the game files.)"
+    )
+
+
 def deterministic_bloon_roster_reply(message_text: str) -> str | None:
     """A code-built bloon roster — MOAB-class list or immunity roster — or ``None``.
 
@@ -4035,6 +4161,7 @@ _BTD6_LIST_BUILDERS: tuple[Callable[[str], str | None], ...] = (
     deterministic_geraldo_per_level_reply,
     deterministic_modes_reply,
     deterministic_capability_roster_reply,
+    deterministic_bloon_health_reply,
     deterministic_bloon_roster_reply,
     deterministic_bloon_modifier_reply,
     deterministic_boss_immunity_reply,

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -158,6 +158,26 @@ class RoundXpEntry:
 
 
 @dataclass(frozen=True)
+class HealthScalingBracket:
+    """One piece of the MOAB-class late-game/freeplay health-multiplier curve.
+
+    ``multiplier(r) = base + (r - anchor_round) * per_round`` for any round ``r``
+    in ``[min_round, max_round]``. BTD6 ramps MOAB-class HP from round 81 (+2% of
+    base/round); ``v(100) = 1.40`` so a BAD first spawns on round 100 at 28,000 HP
+    (20,000 base). The ramp is a **runtime formula, absent from the game dump**, so
+    it is curated in ``bloon_scaling.json`` (see that file's ``scaling_source``) —
+    the health analogue of ``round_xp.json``. Pinned by
+    tests/unit/services/test_btd6_bloon_scaling.py.
+    """
+
+    min_round: int
+    max_round: int
+    anchor_round: int
+    base: float
+    per_round: float
+
+
+@dataclass(frozen=True)
 class BloonEntry:
     id: str
     canonical: str
@@ -334,6 +354,11 @@ class BTD6DataSet:
     round_xp: tuple[RoundXpEntry, ...] = ()
     xp_difficulty_multipliers: dict[str, float] = field(default_factory=dict)
     xp_freeplay_multipliers: dict[str, float] = field(default_factory=dict)
+    # MOAB-class late-game/freeplay health-multiplier curve (bloon_scaling.json).
+    # The ramp is a runtime formula (not in the dump), so it is its own curated
+    # table rather than a per-BloonEntry field. Empty when the fixture is absent.
+    moab_health_scaling: tuple[HealthScalingBracket, ...] = ()
+    moab_health_start_round: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -645,6 +670,26 @@ def _parse_round_xp(raw: dict[str, Any]) -> RoundXpEntry:
     return RoundXpEntry(round_number=round_number, base_xp=int(xp_raw))
 
 
+def _parse_health_bracket(raw: dict[str, Any]) -> HealthScalingBracket:
+    try:
+        bracket = HealthScalingBracket(
+            min_round=int(raw["min_round"]),
+            max_round=int(raw["max_round"]),
+            anchor_round=int(raw["anchor_round"]),
+            base=float(raw["base"]),
+            per_round=float(raw["per_round"]),
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise BTD6DataValidationError(
+            f"bloon_scaling bracket {raw!r}: {exc}",
+        ) from exc
+    if bracket.min_round > bracket.max_round:
+        raise BTD6DataValidationError(
+            f"bloon_scaling bracket {raw!r}: min_round > max_round",
+        )
+    return bracket
+
+
 def _parse_bloon(raw: dict[str, Any]) -> BloonEntry:
     _require_keys(raw, _REQUIRED_BLOON_FIELDS, where=f"bloon {raw.get('id')!r}")
     category = str(raw["category"])
@@ -838,6 +883,7 @@ _OPTIONAL_FIXTURES = (
     "bosses.json",
     "abr_rounds.json",
     "round_xp.json",
+    "bloon_scaling.json",
 )
 
 
@@ -1166,6 +1212,9 @@ def _load_dataset() -> BTD6DataSet:
     # round_xp.json is the base XP per round (bloonswiki-sourced formula; the
     # game dump has no XP field). Optional like the other sidecars.
     round_xp_raw = _load_file_optional("round_xp.json")
+    # bloon_scaling.json is the MOAB-class late-game/freeplay health-multiplier
+    # curve — also a runtime formula the dump omits (sibling of round_xp.json).
+    bloon_scaling_raw = _load_file_optional("bloon_scaling.json")
 
     towers = tuple(_parse_tower(t) for t in towers_raw.get("towers", []))
     heroes = tuple(_parse_hero(h) for h in heroes_raw.get("heroes", []))
@@ -1182,6 +1231,15 @@ def _load_dataset() -> BTD6DataSet:
         if round_xp_raw is not None
         else ()
     )
+    moab_health_block = (
+        bloon_scaling_raw.get("moab_class_health", {}) or {}
+        if bloon_scaling_raw is not None
+        else {}
+    )
+    moab_health_scaling = tuple(
+        _parse_health_bracket(b) for b in moab_health_block.get("brackets", [])
+    )
+    moab_health_start_round = int(moab_health_block.get("start_round", 0) or 0)
     bloons = (
         tuple(_parse_bloon(b) for b in bloons_raw.get("bloons", []))
         if bloons_raw is not None
@@ -1318,6 +1376,8 @@ def _load_dataset() -> BTD6DataSet:
         sources["abr_rounds"] = str(abr_rounds_raw["source"])
     if round_xp_raw is not None:
         sources["round_xp"] = str(round_xp_raw["source"])
+    if bloon_scaling_raw is not None:
+        sources["bloon_scaling"] = str(bloon_scaling_raw["source"])
 
     xp_difficulty_multipliers = (
         {str(k): float(v) for k, v in round_xp_raw["difficulty_multipliers"].items()}
@@ -1349,6 +1409,8 @@ def _load_dataset() -> BTD6DataSet:
         round_xp=round_xp,
         xp_difficulty_multipliers=xp_difficulty_multipliers,
         xp_freeplay_multipliers=xp_freeplay_multipliers,
+        moab_health_scaling=moab_health_scaling,
+        moab_health_start_round=moab_health_start_round,
     )
 
 
@@ -1820,6 +1882,61 @@ def bloon_modifiers() -> tuple[BloonEntry, ...]:
     the deterministic layer OWNS the grounded explanation.
     """
     return tuple(b for b in get_dataset().bloons if b.category == "modifier")
+
+
+def moab_class_health_multiplier(round_number: int) -> float | None:
+    """The late-game/freeplay health multiplier applied to MOAB-class bloons on
+    ``round_number``, or ``None`` when the ``bloon_scaling.json`` fixture is absent.
+
+    BTD6 ramps MOAB-class HP from round 81 (+2% of base per round, piecewise-
+    linear), so ``v(100) = 1.40``. The multiplier is a runtime formula — *not* in
+    the game dump — so it is curated (see ``bloon_scaling.json:scaling_source``).
+    Regular (non-MOAB-class) bloons do not take this multiplier. Rounds below the
+    first bracket are unscaled (``1.0``); rounds past the last clamp to its end.
+    """
+    brackets = get_dataset().moab_health_scaling
+    if not brackets:
+        return None
+    for bracket in brackets:
+        if bracket.min_round <= round_number <= bracket.max_round:
+            value = (
+                bracket.base + (round_number - bracket.anchor_round) * bracket.per_round
+            )
+            return round(value, 4)
+    if round_number < brackets[0].min_round:
+        return 1.0
+    last = brackets[-1]
+    return round(last.base + (last.max_round - last.anchor_round) * last.per_round, 4)
+
+
+def bloon_health_at_round(
+    bloon_id: str,
+    round_number: int,
+    *,
+    fortified: bool = False,
+) -> int | None:
+    """A bloon's effective health when it appears on ``round_number``.
+
+    Applies the MOAB-class late-game/freeplay ramp
+    (:func:`moab_class_health_multiplier`) to the base ``health`` (or
+    ``health_fortified`` when ``fortified``). Non-MOAB-class bloons return their
+    base health unchanged (the ramp is MOAB-class-only; ceramics instead become
+    superceramics). ``None`` when the bloon or its base health is unknown, or when
+    the scaling fixture is absent. Example: ``bloon_health_at_round("bad", 100)``
+    ``== 28000`` (20,000 base × 1.40).
+    """
+    bloon = get_bloon(bloon_id)
+    if bloon is None:
+        return None
+    base = bloon.health_fortified if fortified else bloon.health
+    if not isinstance(base, int):
+        return None
+    if bloon.category != "moab_class":
+        return base
+    multiplier = moab_class_health_multiplier(round_number)
+    if multiplier is None:
+        return None
+    return int(round(base * multiplier))
 
 
 def resolve_bloon_id(name: str) -> str | None:

--- a/docs/btd6/btd6-gamedata-dictionary.md
+++ b/docs/btd6/btd6-gamedata-dictionary.md
@@ -122,3 +122,20 @@ old label), `rogueData.json` (Rogue Legends spin-off balance),
   the wiki).
 - **Rounds (all modes) / IncomeSets** → only standard rounds come from the wiki
   today; the dump has every mode + the income curves.
+
+## Runtime-formula facts the dump does NOT store (curated sidecars)
+
+Some per-round quantities are **engine formulas**, not data — the dump's round
+files hold only bloon *composition + spawn timing*, and `BloonModel` stores only
+*base* stats. These live as curated, source-noted sidecars under
+`disbot/data/btd6/` (each carries a `*_source` note stating it is absent from the
+dump, mirroring the validation discipline):
+
+- **Per-round XP / cash** → `round_xp.json` (`xp_source`); cash is derived from
+  composition. Neither is a dump field.
+- **MOAB-class late-game/freeplay health scaling** → `bloon_scaling.json`
+  (`scaling_source`). MOAB-class bloons gain **+2% of base HP per round from round
+  81** (`v(100)=1.40`), so a **BAD first spawns on round 100 already at 28,000 HP**
+  (20,000 base), not 20,000. `bloons.json` holds only the round-≤80 base; the ramp
+  is applied at runtime by `btd6_data_service.bloon_health_at_round()`. So "where
+  is the per-round health modifier in the dump?" → it isn't; it's this curve.

--- a/docs/owner/claims/claude-great-meitner-pnfp0g.md
+++ b/docs/owner/claims/claude-great-meitner-pnfp0g.md
@@ -1,0 +1,1 @@
+- `claude/great-meitner-pnfp0g` · BTD6 late-game/freeplay MOAB-class health scaling (round-scaled bloon HP grounding) · `disbot/data/btd6/bloon_scaling.json`, `disbot/services/btd6_data_service.py`, `disbot/services/btd6_context_service.py`, `tests/unit/services/` · 2026-06-23

--- a/docs/owner/claims/claude-great-meitner-pnfp0g.md
+++ b/docs/owner/claims/claude-great-meitner-pnfp0g.md
@@ -1,1 +1,0 @@
-- `claude/great-meitner-pnfp0g` · BTD6 late-game/freeplay MOAB-class health scaling (round-scaled bloon HP grounding) · `disbot/data/btd6/bloon_scaling.json`, `disbot/services/btd6_data_service.py`, `disbot/services/btd6_context_service.py`, `tests/unit/services/` · 2026-06-23

--- a/tests/unit/invariants/test_btd6_floor_builder_exclusivity.py
+++ b/tests/unit/invariants/test_btd6_floor_builder_exclusivity.py
@@ -89,6 +89,10 @@ _SHOULD_FIRE: tuple[tuple[str, str], ...] = (
         "deterministic_bloon_modifier_reply",
     ),
     (
+        "how much health does a bad have on round 100",
+        "deterministic_bloon_health_reply",
+    ),
+    (
         "what economy relics are there",
         "deterministic_relic_roster_reply",
     ),

--- a/tests/unit/services/test_btd6_bloon_scaling.py
+++ b/tests/unit/services/test_btd6_bloon_scaling.py
@@ -1,0 +1,153 @@
+"""BTD6 late-game/freeplay MOAB-class health scaling.
+
+Round-relative bloon health scaling is NOT in the BTD Mod Helper game data dump
+(round files store only composition + timing; ``BloonModel`` stores base
+``maxHealth`` only). BTD6 applies a runtime ramp to MOAB-class bloons: +2% of base
+HP per round from round 81, piecewise-linear, so ``v(100) = 1.40`` and a BAD first
+spawns on round 100 already at 28,000 HP. The curve is curated in
+``bloon_scaling.json`` (sibling of ``round_xp.json``). These tests pin the loader,
+the multiplier math, the per-bloon scaled health, and the deterministic
+"HP of <bloon> at round N" reply against the cross-verified anchor (BAD = 28,000 @
+r100, three independent sources: Late Game and Freeplay / BAD wiki / topper64).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).parents[3]
+_DISBOT = _REPO / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from services import btd6_context_service  # noqa: E402
+from services import btd6_data_service  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    btd6_data_service.reset_cache()
+    yield
+    btd6_data_service.reset_cache()
+
+
+# --- the runtime loader -------------------------------------------------------
+
+
+def test_dataset_loads_scaling_curve():
+    dataset = btd6_data_service.get_dataset()
+    assert dataset.moab_health_scaling  # non-empty
+    assert dataset.moab_health_start_round == 81
+    assert "bloon_scaling" in dataset.sources
+
+
+def test_committed_json_anchor_is_28000_at_round_100():
+    # The verified cross-check that motivated this work: a BAD first appears on
+    # round 100 at 28,000 HP. If the committed curve or base health drifts so this
+    # no longer holds, fail here rather than in production.
+    committed = json.loads(
+        (_DISBOT / "data" / "btd6" / "bloon_scaling.json").read_text("utf-8"),
+    )
+    assert committed["moab_class_health"]["start_round"] == 81
+    assert btd6_data_service.bloon_health_at_round("bad", 100) == 28000
+
+
+# --- the multiplier math ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("rnd", "expected"),
+    [
+        (1, 1.0),
+        (80, 1.0),  # no ramp through round 80
+        (81, 1.02),  # +2% of base per round kicks in
+        (100, 1.40),  # the verified anchor (BAD 20k -> 28k)
+        (101, 1.60),  # step up into the next bracket
+        (150, 2.58),
+        (151, 3.00),
+    ],
+)
+def test_moab_class_health_multiplier(rnd: int, expected: float):
+    assert btd6_data_service.moab_class_health_multiplier(rnd) == pytest.approx(
+        expected
+    )
+
+
+# --- per-bloon scaled health --------------------------------------------------
+
+
+def test_bad_scaled_health_standard_and_fortified():
+    assert btd6_data_service.bloon_health_at_round("bad", 100) == 28000
+    assert btd6_data_service.bloon_health_at_round("bad", 100, fortified=True) == 56000
+    # Through round 80 the base is unchanged.
+    assert btd6_data_service.bloon_health_at_round("bad", 80) == 20000
+
+
+def test_other_moab_class_bloons_scale():
+    assert btd6_data_service.bloon_health_at_round("zomg", 100) == 5600  # 4000 * 1.4
+    assert btd6_data_service.bloon_health_at_round("moab", 100) == 280  # 200 * 1.4
+
+
+def test_non_moab_bloon_does_not_scale():
+    # Regular bloons keep their base health on every round (only MOAB-class ramp;
+    # ceramics instead become superceramics, which is a swap, not a multiplier).
+    red = btd6_data_service.get_bloon("red")
+    assert red is not None
+    assert btd6_data_service.bloon_health_at_round("red", 50) == red.health
+    assert btd6_data_service.bloon_health_at_round("red", 200) == red.health
+
+
+def test_unknown_bloon_returns_none():
+    assert btd6_data_service.bloon_health_at_round("not_a_bloon", 100) is None
+
+
+# --- the deterministic floor reply --------------------------------------------
+
+
+def test_reply_owns_bad_at_round_100():
+    reply = btd6_context_service.deterministic_bloon_health_reply(
+        "how much health does a BAD have on round 100",
+    )
+    assert reply is not None
+    assert "28,000" in reply
+    assert "20,000" in reply  # names the base too
+
+
+def test_reply_handles_fortified():
+    reply = btd6_context_service.deterministic_bloon_health_reply(
+        "hp of a fortified bad on r100",
+    )
+    assert reply is not None
+    assert "56,000" in reply
+
+
+def test_reply_defers_without_a_round_number():
+    # The base "how much HP does a BAD have" question stays with the model (which
+    # answers the 20,000 base from grounding) — the floor only owns round-specific.
+    assert (
+        btd6_context_service.deterministic_bloon_health_reply(
+            "how much health does a BAD have",
+        )
+        is None
+    )
+
+
+def test_reply_defers_without_a_health_cue():
+    assert (
+        btd6_context_service.deterministic_bloon_health_reply(
+            "what spawns on round 100",
+        )
+        is None
+    )
+
+
+def test_reply_states_non_moab_bloons_do_not_scale():
+    reply = btd6_context_service.deterministic_bloon_health_reply(
+        "how much health does a red bloon have on round 80",
+    )
+    assert reply is not None
+    assert "every round" in reply.lower()


### PR DESCRIPTION
## What & why

The bot answered *"how much health does a BAD have on r100?"* with a flat **20,000** and asserted *"round 100 doesn't change the BAD's base health."* That's wrong: a BAD **first naturally spawns on round 100 already at 28,000 HP** (67,200 RBE). A community member corrected it in-channel (`28k — 20k base × 1.4 by r100`).

Root cause: BTD6 applies a **runtime late-game/freeplay health ramp to MOAB-class bloons** that is **not in the game-data dump** — round files store only composition + spawn timing, and `BloonModel` stores only base `maxHealth`. Our `bloons.json` therefore has the 20,000 base and nothing round-relative, so the model "knew" only the base and confidently flattened the nuance. Same shape as per-round XP/cash, which we already curate as derived data.

## The verified mechanic (researched this session)

MOAB-class bloons (MOAB/BFB/ZOMG/DDT/BAD) gain **+2% of base HP per round from round 81**, piecewise-linear with step-ups at 101/151/201/252:

```
v(r) = 1.0                       r ≤ 80
v(r) = 1.0 + (r − 80)·0.02       81 ≤ r ≤ 100   → v(100) = 1.40
v(r) = 1.6 + (r − 101)·0.02      101 ≤ r ≤ 150
v(r) = 3.0 + (r − 151)·0.02      151 ≤ r ≤ 200
v(r) = 4.5 + (r − 201)·0.02      201 ≤ r ≤ 251
v(r) = 6.0 + (r − 252)·0.02      r ≥ 252
```

`BAD @ r100 = 20,000 × 1.40 = 28,000` ✓ (cross-checked: 28,000 HP / 67,200 RBE, three sources). The **r ≤ 100 bracket is cross-verified**; the > 100 brackets are the wiki's documented continuation (flagged in the data file's source note).

Sources: [Late Game and Freeplay (BTD6)](https://bloons.fandom.com/wiki/Late_Game_and_Freeplay_(BTD6)) · [Big Airship of Doom](https://bloons.fandom.com/wiki/Big_Airship_of_Doom_(BAD)) · [topper64 BTD6 Rounds](https://topper64.co.uk/nk/btd6/rounds/) ("+2% health/round after round 80").

## Approach (mirrors the `round_xp.json` curated-derived pattern)

- **`disbot/data/btd6/bloon_scaling.json`** — the curve as curated data, with a source note stating it is NOT in the dump (sibling of `round_xp.json`'s `xp_source`).
- **`btd6_data_service`** — `moab_class_health_multiplier(round)` + `bloon_health_at_round(bloon_id, round, *, fortified=)`.
- **`btd6_context_service`** — a deterministic *"HP of <bloon> at round N"* floor reply (owns the answer so the model can't re-flatten it) + a MOAB-class grounding note so conversational follow-ups ("and on r100?") are answered correctly.
- **Tests** pin the verified anchors (`v(100)=1.4`, `BAD@100 = 28,000`).

PR opens **born-red** (session card HOLD per Q-0133); flips green as the final step.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hydy3uLzrkCmqHWT2VoEKG)_