### PR TITLE
feat(settings): static settings-reachability guard (consolidation audit — settings half)

### DIFF
--- a/.sessions/2026-06-23-settings-centralization.md
+++ b/.sessions/2026-06-23-settings-centralization.md
@@ -1,6 +1,6 @@
 # 2026-06-23 — Settings centralization: a static settings-reachability guard
 
-> **Status:** `in-progress` — owner-directed (the last unstarted item in the five-part consolidation
+> **Status:** `complete` — owner-directed (the last unstarted item in the five-part consolidation
 > goal). Builds the **static settings-reachability guard** — the settings analog of the #1370 command
 > guard — so "every cog's settings reachable from the `!settings` hub" (brief §3.4) becomes
 > un-regressable. PR this session; auto-merge armed on green (Q-0127); owner-directed → merge immediately
@@ -34,4 +34,30 @@ but isn't homed, or grows a `.configure` capability without either a schema or a
 - `tests/unit/invariants/test_settings_reachability.py` — the CI invariant (warn-first ratchet baseline).
 - `docs/audits/settings-reachability-2026-06-23.md` — the finding + exemption ledger.
 
-(Close-out enders at session close.)
+## Close-out
+
+**Verification:** `check_quality --full` green — **12164 passed**; `check_settings_reachability` →
+19 reachable · 3 exempt · 0 GAP; new invariant (5 cases) green; ledger + `check_docs --strict` pass
+(Q-0104 — the new audit doc is linked from the brief §3.4, no orphan). No `disbot/` runtime change, so
+mypy/architecture unaffected. Merged the GitHub branch-auto-update (#1384 btd6, disjoint) before close.
+
+**💡 Session idea (Q-0089):** *Graduate the settings-reachability guard to `--mode strict` in CI once it's
+run clean across a couple of sessions* — same lifecycle the `edit_in_place` rule followed (warn→error).
+The guard is already strict-clean (0 gaps, baseline empty); the only reason it isn't wired into
+`check_quality`/CI as a hard gate yet is the Q-0105 "prove it quiet first" discipline. A future session
+should add it to the quality run's strict set so a new decentralized-config subsystem *fails the build*,
+not just a test — closing the loop on "settings stay centralized." (Captured; small follow-on.)
+
+**⟲ Previous-session review (Q-0102):** the previous session (this same chat, PRs #1382/#1383 — the
+never-stranded nav + game-result continuations) did well to *fix the checker in the same PR as the
+mechanism* (#1383 taught the `back_button` rule about auto-nav), which is exactly the "checker and
+mechanism must not drift" lesson it recorded. What it could have surfaced earlier: the broader
+consolidation plan had a *measurable remaining list* (`current-state/S1-bot.md` line 65) that I only
+re-grounded in when the owner asked for status — a session ending should always re-read its sector's
+`▶ Remaining` line and name the next item, not wait to be asked. **System improvement (applied):** this
+session opened by re-deriving the plan state from the authoritative ledger before acting, and picked the
+last unstarted item deliberately. Worth making routine: end-of-session, restate the sector's remaining
+queue so the chain is self-navigating.
+
+**Claim** `docs/owner/claims/claude__settings-centralization.md` deleted at close (Q-0126).
+

--- a/.sessions/2026-06-23-settings-centralization.md
+++ b/.sessions/2026-06-23-settings-centralization.md
@@ -1,0 +1,37 @@
+# 2026-06-23 — Settings centralization: a static settings-reachability guard
+
+> **Status:** `in-progress` — owner-directed (the last unstarted item in the five-part consolidation
+> goal). Builds the **static settings-reachability guard** — the settings analog of the #1370 command
+> guard — so "every cog's settings reachable from the `!settings` hub" (brief §3.4) becomes
+> un-regressable. PR this session; auto-merge armed on green (Q-0127); owner-directed → merge immediately
+> (Q-0191).
+
+> **Run type:** `manual · owner-directed`
+
+## Finding (code-verified, no live bot)
+
+The settings surface is already **structurally centralized**, but it was only *checkable* via a live-bot
+catalogue build (`customization_catalogue.build_catalogue(bot)` needs loaded cogs — static `bot=None`
+over-reports 41/41). The AST-verifiable facts:
+
+- **19 subsystems declare a `SubsystemSchema`** (`cogs/*/schemas.py`) → auto-dispatched into `!settings`
+  via `actionable_settings_groups()`. **All 19 are reachable** (non-internal + homed) — 0 gaps.
+- **3 subsystems have a `.configure`/`.settings.*` capability but no schema:** `counting` + `chain`
+  (per-**channel** game enablement, configured in their own `!countingmenu`/`!chainmenu` panels — a
+  bespoke per-channel data model, *not* a guild-scalar setting) and `channel` (`channel.visibility.configure`
+  is an admin **action**, not stored config). These are **intentionally domain-panel-configured**, not a
+  centralization gap → explicit allowlist with reasons (mirrors how #1370 allowlists reachable-via-panel
+  commands).
+
+So there is no schema to *add* (inventing one for per-channel game setup would be wrong); the work is the
+**guard + documented allowlist** that pins the boundary and fails CI if a *new* subsystem adds a schema
+but isn't homed, or grows a `.configure` capability without either a schema or an allowlist entry.
+
+## Deliverable (mirrors #1370)
+
+- `scripts/check_settings_reachability.py` — static guard (registry + AST scan of `cogs/*/schemas.py`).
+- `architecture_rules/settings_reachability_exceptions.yml` — allowlist (counting/chain/channel + reasons).
+- `tests/unit/invariants/test_settings_reachability.py` — the CI invariant (warn-first ratchet baseline).
+- `docs/audits/settings-reachability-2026-06-23.md` — the finding + exemption ledger.
+
+(Close-out enders at session close.)

--- a/architecture_rules/settings_reachability_exceptions.yml
+++ b/architecture_rules/settings_reachability_exceptions.yml
@@ -1,0 +1,23 @@
+# Allowlist for scripts/check_settings_reachability.py (the settings-reachability
+# guard — consolidation/discoverability audit, settings half, 2026-06-23).
+#
+# This is the ONLY valid way to exempt a subsystem from the settings-reachability
+# check — never suppress the check itself. Each entry is a `subsystem` (the
+# registry key) plus a `reason`.
+#
+# Keep entries genuine: an exception documents a subsystem whose config is
+# correctly NOT in the centralized `!settings` schema hub — because the config is
+# a domain-specific per-channel / per-game setup owned by the cog's own panel, or
+# because the `*.configure` capability is an admin *action* rather than stored
+# guild config. It is NOT a way to mute a real centralization gap that should be
+# fixed by adding a SubsystemSchema.
+#
+# Full write-up + disposition: docs/audits/settings-reachability-2026-06-23.md
+
+exceptions:
+  - subsystem: counting
+    reason: "Configured via its own !countingmenu panel — per-channel game enablement (which channels count, their mode, reset) is a bespoke per-channel data model, not a guild-scalar setting that fits the SubsystemSchema → !settings model. Intentionally domain-panel-owned (counting.game.configure)."
+  - subsystem: chain
+    reason: "Configured via its own !chainmenu panel — like counting, per-channel word-chain enablement is per-channel game setup, not a guild-scalar setting. Intentionally domain-panel-owned (chain.game.configure)."
+  - subsystem: channel
+    reason: "`channel.visibility.configure` is an administrator *action* (restrict/unrestrict a channel via the Channels panel), not stored guild configuration — there is no persistent 'channel settings' to surface in the !settings hub. The Channels admin panel is reached via the Server & Admin hub."

--- a/docs/audits/settings-reachability-2026-06-23.md
+++ b/docs/audits/settings-reachability-2026-06-23.md
@@ -1,0 +1,61 @@
+# Settings-reachability — 2026-06-23
+
+> **Status:** `audit` — the finding + exemption ledger for the settings half of the
+> consolidation/discoverability audit
+> ([brief](../planning/consolidation-discoverability-audit-brief-2026-06-23.md) §3.4). Emitted/checked by
+> `scripts/check_settings_reachability.py` (the static guard) + `tests/unit/invariants/test_settings_reachability.py`
+> (the CI ratchet). Source code + merged PRs win over this doc.
+
+## The goal, made checkable
+
+The audit's §3.4 terminal: *"every cog's settings reachable from the `!settings` hub — no per-cog
+settings unreachable."* A subsystem's config surfaces in `!settings` via
+`services.customization_catalogue.actionable_settings_groups()`, which includes it iff it is
+**non-internal** and declares a `SubsystemSchema` with an actionable surface. So config is *centralized
++ reachable* exactly when the subsystem declares a schema and is non-internal.
+
+That signal was previously only verifiable with a **live bot** (the catalogue needs loaded cogs; a static
+`build_catalogue(None)` over-reports 41/41). This guard makes the same invariant **statically checkable**
+— the settings analog of the `#1370` per-command reachability guard.
+
+## Result (code-verified, 2026-06-23)
+
+`check_settings_reachability` → **19 reachable · 3 exempt · 0 GAP**.
+
+- **19 reachable** — every subsystem declaring a `SubsystemSchema` (`ai`, `automod`, `blackjack`, `btd6`,
+  `cleanup`, `counters`, `deathmatch`, `economy`, `help`, `image_moderation`, `karma`, `logging`,
+  `moderation`, `proof_channel`, `role`, `rps_tournament`, `security`, `welcome`, `xp`) is non-internal,
+  so it auto-surfaces in the `!settings` hub. **Settings are already structurally centralized.**
+- **0 genuine gaps.**
+
+## The 3 exemptions (intentional domain-panel config)
+
+These declare a `*.configure` capability but no `SubsystemSchema`. Their config is correctly **not** in the
+centralized `!settings` schema hub — so they are reasoned allowlist entries
+(`architecture_rules/settings_reachability_exceptions.yml`), not gaps:
+
+| Subsystem | Capability | Why it's exempt (verified) |
+|---|---|---|
+| `counting` | `counting.game.configure` | Per-**channel** game enablement (which channels count, mode, reset) — a bespoke per-channel data model owned by the `!countingmenu` panel, not a guild-scalar setting that fits the `SubsystemSchema` → `!settings` model. |
+| `chain` | `chain.game.configure` | Per-channel word-chain enablement, same shape as counting — owned by the `!chainmenu` panel. |
+| `channel` | `channel.visibility.configure` | An administrator **action** (restrict/unrestrict a channel via the Channels panel), not stored guild config — there is nothing persistent to surface in `!settings`. |
+
+## How to clear / change an entry
+
+- **A new subsystem adds a `SubsystemSchema`** → it must be non-internal to be reachable; the guard flags
+  a schema'd-but-`internal` subsystem as a gap (its config would be hidden).
+- **A new subsystem grows a `*.configure` / `*.settings.*` capability** without a schema → the guard flags
+  it as a gap until you either add a schema (centralize it) or add a reasoned allowlist entry.
+- When a domain-panel case is genuinely centralized later (a real `SubsystemSchema` is added), remove its
+  allowlist entry; `check_settings_reachability` then classifies it `reachable`.
+
+Re-run `python3.10 scripts/check_settings_reachability.py` to confirm.
+
+## Notes / caveats
+
+- **Warn-first + disposable** (Q-0105). The static schema scan keys off `cogs/<sub>/schemas.py` declaring
+  `SubsystemSchema(subsystem="…")`; it mirrors the live `actionable_settings_groups()` rule but cannot
+  exercise the bot-dependent catalogue signals (`subsystems_missing_help_hook`, `undiscoverable_surfaces`)
+  — those still want a **live-bot** build to fully verify. Confirm a flagged subsystem really lacks a
+  Settings-hub surface in a live guild before centralizing it. Delete the guard if it proves unreliable
+  over multiple sessions.

--- a/docs/owner/claims/claude__settings-centralization.md
+++ b/docs/owner/claims/claude__settings-centralization.md
@@ -1,8 +1,0 @@
-- `claude/settings-centralization` · **Settings-reachability guard (consolidation audit — settings half)** —
-  the static settings analog of the #1370 command-reachability guard. Asserts every subsystem declaring a
-  `SubsystemSchema` is reachable from the `!settings` hub (non-internal + homed), and that every
-  `.configure`/`.settings.*`-capability subsystem is either schema'd or explicitly allowlisted (the
-  intentional domain-panel cases: counting/chain game-channel setup, channel visibility action). Makes the
-  brief §3.4 "every cog's settings reachable from a hub" un-regressable. Scope: `scripts/`,
-  `architecture_rules/settings_reachability_exceptions.yml`, `tests/unit/invariants/`, `docs/audits/`.
-  2026-06-23 · PR (this session, auto-merge on green)

--- a/docs/owner/claims/claude__settings-centralization.md
+++ b/docs/owner/claims/claude__settings-centralization.md
@@ -1,0 +1,8 @@
+- `claude/settings-centralization` · **Settings-reachability guard (consolidation audit — settings half)** —
+  the static settings analog of the #1370 command-reachability guard. Asserts every subsystem declaring a
+  `SubsystemSchema` is reachable from the `!settings` hub (non-internal + homed), and that every
+  `.configure`/`.settings.*`-capability subsystem is either schema'd or explicitly allowlisted (the
+  intentional domain-panel cases: counting/chain game-channel setup, channel visibility action). Makes the
+  brief §3.4 "every cog's settings reachable from a hub" un-regressable. Scope: `scripts/`,
+  `architecture_rules/settings_reachability_exceptions.yml`, `tests/unit/invariants/`, `docs/audits/`.
+  2026-06-23 · PR (this session, auto-merge on green)

--- a/docs/planning/consolidation-discoverability-audit-brief-2026-06-23.md
+++ b/docs/planning/consolidation-discoverability-audit-brief-2026-06-23.md
@@ -161,6 +161,15 @@ the audit should mine:
 zero**. The audit still needs a *live-bot* build to exercise the `bot`-dependent signals
 (`subsystems_missing_help_hook`, `undiscoverable_surfaces`), which the no-bot static build skips.
 
+**SHIPPED 2026-06-23 — the static settings-reachability guard** (the settings analog of the #1370
+command guard): `scripts/check_settings_reachability.py` + `tests/unit/invariants/test_settings_reachability.py`
+assert every subsystem that declares a `SubsystemSchema` is non-internal (so it surfaces in `!settings`)
+and that every `*.configure`/`*.settings.*`-capability subsystem is either schema'd or explicitly
+allowlisted (`architecture_rules/settings_reachability_exceptions.yml`). Result: **19 reachable · 3 exempt
+· 0 GAP** — settings are structurally centralized, and now *un-regressably* so. Finding + exemption
+ledger: [`audits/settings-reachability-2026-06-23.md`](../audits/settings-reachability-2026-06-23.md).
+The *live-bot* signal verification above remains the owner's (it needs a running bot).
+
 ### 3.5 Setup wizard + AI advisor (two named finalize targets)
 
 - **Setup wizard** (`cogs/setup/`, `views/setup/sections/`, `services/setup_session.py`,

--- a/scripts/check_settings_reachability.py
+++ b/scripts/check_settings_reachability.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Settings-reachability guard for SuperBot.
+
+The *settings* analog of ``scripts/check_command_reachability.py`` (the
+per-command help guard).  Where that one guards that every member command is
+reachable by clicking through ``!help``, this one guards the consolidation
+audit's §3.4 goal — **every cog's configurable settings are reachable from the
+``!settings`` hub** — and makes it un-regressable.
+
+A subsystem's config surfaces in ``!settings`` via
+``services.customization_catalogue.actionable_settings_groups()``, which
+includes a subsystem iff it is **non-internal** and declares a
+``SubsystemSchema`` with at least one actionable surface (an editable setting,
+binding, resource requirement, or domain panel).  So a subsystem's config is
+*centralized + reachable* exactly when it declares a schema and is non-internal.
+
+The check is static (no live bot, no Postgres).  For every registered subsystem
+that **declares config** — it has a ``cogs/<sub>/schemas.py`` ``SubsystemSchema``
+*or* a ``*.configure`` / ``*.settings.*`` capability — it classifies the
+subsystem as:
+
+  * **reachable** — declares a schema and is non-internal → it appears in the
+    Settings hub;
+  * **exempt** — an ``internal`` subsystem (never in the hub by design), or
+    allowlisted in ``architecture_rules/settings_reachability_exceptions.yml``
+    with a documented reason (the intentional domain-panel cases: per-channel
+    game setup like counting/chain, or a ``*.configure`` capability that is an
+    admin *action* rather than stored config);
+  * **gap** — declares config (a ``*.configure`` capability, or a schema) but is
+    NOT reachable from ``!settings`` and is not allowlisted.  This is the
+    actionable finding: add a ``SubsystemSchema`` (centralize the config) or
+    allowlist it with a reason.
+
+It is **warn-first and disposable** (Q-0105): every finding is a warning,
+nothing fails CI in ``--mode report``.  The invariant test
+(``tests/unit/invariants/test_settings_reachability.py``) ratchets against a
+recorded baseline so *new* gaps fail while any pre-existing ones are tolerated.
+The guard graduates to ``--mode strict`` (exit 1 on any gap) once the baseline
+is empty and it has run clean across a few sessions.
+
+Provenance / reliability (Q-0105):
+  - Added 2026-06-23 for the consolidation/discoverability audit (settings half):
+    `docs/planning/consolidation-discoverability-audit-brief-2026-06-23.md` §3.4.
+  - **Unverified:** the static schema scan keys off ``cogs/<sub>/schemas.py``
+    declaring ``SubsystemSchema(subsystem="…")``; it mirrors the live
+    ``actionable_settings_groups()`` rule but cannot exercise the bot-dependent
+    catalogue signals.  Confirm a flagged subsystem really lacks a Settings-hub
+    surface in a live guild before centralizing it, and keep the rule warn-only
+    until proven quiet.
+  - **Delete this guard if it proves unreliable over multiple sessions** — it is
+    a convenience ratchet, not load-bearing runtime code.
+
+Usage:
+    python3.10 scripts/check_settings_reachability.py              # report
+    python3.10 scripts/check_settings_reachability.py --json       # machine-readable
+    python3.10 scripts/check_settings_reachability.py --mode strict # exit 1 on a gap
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DISBOT_ROOT = REPO_ROOT / "disbot"
+COGS_DIR = DISBOT_ROOT / "cogs"
+RULES_DIR = REPO_ROOT / "architecture_rules"
+_EXCEPTIONS_FILE = "settings_reachability_exceptions.yml"
+
+if str(DISBOT_ROOT) not in sys.path:
+    sys.path.insert(0, str(DISBOT_ROOT))
+
+from utils.subsystem_registry import SUBSYSTEMS  # noqa: E402
+
+# A capability whose action implies configurable state lives in one of these
+# namespaces — ``{sub}.settings.configure`` / ``{sub}.settings.view`` or a
+# ``{sub}.{resource}.configure`` operation.
+_CONFIG_CAP_MARKERS = (".configure", ".settings.")
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One subsystem's settings-reachability classification."""
+
+    subsystem: str
+    status: str  # "reachable" | "exempt" | "gap"
+    reason: str
+
+    @property
+    def key(self) -> str:
+        """Stable identity used by the baseline ratchet."""
+        return self.subsystem
+
+    def display(self) -> str:
+        tag = {"reachable": "ok", "exempt": "exempt", "gap": "GAP"}[self.status]
+        return f"  [{tag}] {self.subsystem}  —  {self.reason}"
+
+
+def _load_exceptions() -> dict:
+    path = RULES_DIR / _EXCEPTIONS_FILE
+    if not path.exists():
+        return {}
+    with path.open() as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def _allowlisted(subsystem: str, exceptions: dict) -> str | None:
+    """Return the documented reason if ``subsystem`` is allowlisted, else None."""
+    for exc in exceptions.get("exceptions", []):
+        if exc.get("subsystem") == subsystem:
+            return str(exc.get("reason", "(no reason given)"))
+    return None
+
+
+def _schema_subsystems() -> set[str]:
+    """Subsystems that declare a ``SubsystemSchema`` in ``cogs/<sub>/schemas.py``.
+
+    Static AST scan for a ``SubsystemSchema(subsystem="X", …)`` call — the
+    declaration the cog registers into the customization catalogue at load.
+    """
+    found: set[str] = set()
+    for schema_file in COGS_DIR.glob("*/schemas.py"):
+        try:
+            tree = ast.parse(schema_file.read_text(), filename=str(schema_file))
+        except (OSError, SyntaxError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = (
+                func.attr
+                if isinstance(func, ast.Attribute)
+                else getattr(func, "id", "")
+            )
+            if name != "SubsystemSchema":
+                continue
+            for kw in node.keywords:
+                if (
+                    kw.arg == "subsystem"
+                    and isinstance(kw.value, ast.Constant)
+                    and isinstance(kw.value.value, str)
+                ):
+                    found.add(kw.value.value)
+    return found
+
+
+def _config_capabilities(meta: dict) -> list[str]:
+    return [
+        cap
+        for cap in meta.get("capabilities", ())
+        if any(marker in cap for marker in _CONFIG_CAP_MARKERS)
+    ]
+
+
+def collect_findings() -> list[Finding]:
+    """Classify every config-declaring subsystem's Settings-hub reachability."""
+    schema_subs = _schema_subsystems()
+    exceptions = _load_exceptions()
+    findings: list[Finding] = []
+
+    for name in sorted(SUBSYSTEMS):
+        meta = SUBSYSTEMS[name]
+        has_schema = name in schema_subs
+        config_caps = _config_capabilities(meta)
+        if not (has_schema or config_caps):
+            continue  # no configurable surface → nothing to centralize
+
+        internal = meta.get("visibility_mode") == "internal"
+        # Reachable from !settings == declares a schema (the actionable surface
+        # actionable_settings_groups() requires) AND is non-internal.
+        if has_schema and not internal:
+            findings.append(
+                Finding(
+                    name,
+                    "reachable",
+                    "schema declared; surfaces in the !settings hub",
+                ),
+            )
+            continue
+
+        allow_reason = _allowlisted(name, exceptions)
+        if allow_reason is not None:
+            findings.append(Finding(name, "exempt", f"allowlisted — {allow_reason}"))
+            continue
+        if internal and not config_caps and has_schema:
+            # An internal subsystem with a schema: hidden from the hub by design.
+            findings.append(
+                Finding(
+                    name,
+                    "exempt",
+                    "internal subsystem (not in the Settings hub by design)",
+                ),
+            )
+            continue
+
+        if config_caps and not has_schema:
+            reason = (
+                f"declares config capability {config_caps} but no SubsystemSchema — "
+                "its settings are not reachable from the !settings hub "
+                "(add a schema to centralize, or allowlist with a reason)"
+            )
+        else:  # has_schema and internal
+            reason = (
+                "declares a SubsystemSchema but is visibility_mode=internal, so "
+                "actionable_settings_groups() hides it from the !settings hub"
+            )
+        findings.append(Finding(name, "gap", reason))
+
+    return findings
+
+
+def gaps(findings: list[Finding]) -> list[Finding]:
+    return [f for f in findings if f.status == "gap"]
+
+
+def _print_report(findings: list[Finding]) -> None:
+    reachable = [f for f in findings if f.status == "reachable"]
+    exempt = [f for f in findings if f.status == "exempt"]
+    g = gaps(findings)
+    print(
+        f"check_settings_reachability — {len(reachable)} reachable · "
+        f"{len(exempt)} exempt · {len(g)} GAP\n",
+    )
+    if not g:
+        print("  every config-declaring subsystem is reachable from !settings ✓")
+    else:
+        print("  GAPS — configurable subsystems not reachable from the !settings hub:")
+        for f in g:
+            print(f.display())
+    if exempt:
+        print("\n  exempt (allowlisted / internal):")
+        for f in exempt:
+            print(f.display())
+
+
+def _print_json(findings: list[Finding]) -> None:
+    print(
+        json.dumps(
+            {
+                "reachable": [f.subsystem for f in findings if f.status == "reachable"],
+                "exempt": [f.subsystem for f in findings if f.status == "exempt"],
+                "gaps": [
+                    {"subsystem": f.subsystem, "reason": f.reason}
+                    for f in gaps(findings)
+                ],
+            },
+            indent=2,
+        ),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=["report", "strict"], default="report")
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args()
+
+    findings = collect_findings()
+    if args.json:
+        _print_json(findings)
+    else:
+        _print_report(findings)
+
+    if args.mode == "strict" and gaps(findings):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/invariants/test_settings_reachability.py
+++ b/tests/unit/invariants/test_settings_reachability.py
@@ -1,0 +1,119 @@
+"""Settings-reachability invariant (consolidation audit — settings half).
+
+The *settings* companion to ``test_command_reachability.py``.  Where that guards
+that every member command is reachable through ``!help``, this guards the audit's
+§3.4 goal — **every cog's configurable settings are reachable from the
+``!settings`` hub** — and makes it un-regressable.
+
+It drives ``scripts/check_settings_reachability.py`` (the static checker) and
+**ratchets against a recorded baseline** (Q-0105 warn-first): the baseline is the
+set of accepted pre-existing gaps, and any *new* gap fails.  The baseline is
+currently **empty** — every config-declaring subsystem either surfaces in the
+Settings hub (declares a ``SubsystemSchema``, non-internal) or is an explicit,
+reasoned allowlist entry (the intentional domain-panel cases: counting/chain
+per-channel game setup, the channel-visibility admin action).
+
+Full write-up + exemption disposition:
+  docs/audits/settings-reachability-2026-06-23.md
+
+Sibling invariants: ``test_command_reachability.py`` (per-command help),
+``test_discoverability.py`` (subsystem-level homing).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "check_settings_reachability.py"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location(
+        "check_settings_reachability_ut", _SCRIPT
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_CHECK = _load_checker()
+
+
+# ---------------------------------------------------------------------------
+# Baseline — accepted pre-existing settings-reachability gaps (none).
+#
+# Each entry would be a subsystem that declares configurable settings but is not
+# reachable from the !settings hub and is not (yet) allowlisted.  There are none:
+# the 3 configure-capability-without-schema subsystems (counting/chain/channel)
+# are *intentional* domain-panel cases, recorded as reasoned allowlist entries in
+# architecture_rules/settings_reachability_exceptions.yml — not gaps.  REMOVE an
+# entry here only when its subsystem becomes reachable; never add one to mute a
+# real gap that should be fixed by adding a SubsystemSchema.
+# ---------------------------------------------------------------------------
+_BASELINE: frozenset[str] = frozenset()
+
+
+def _current_gap_keys() -> set[str]:
+    return {f.key for f in _CHECK.gaps(_CHECK.collect_findings())}
+
+
+# ---------------------------------------------------------------------------
+# The ratchet
+# ---------------------------------------------------------------------------
+
+
+def test_no_new_settings_reachability_gaps():
+    """No config-declaring subsystem is unreachable from !settings beyond the
+    accepted baseline. A *new* gap (a schema marked internal, or a new
+    ``*.configure`` capability with neither a schema nor an allowlist entry)
+    fails here — that is what keeps settings centralized.
+    """
+    new = _current_gap_keys() - _BASELINE
+    assert not new, (
+        "New settings-reachability gap(s): "
+        f"{sorted(new)}. Centralize the config (add a SubsystemSchema so it "
+        "surfaces in !settings) or allowlist it with a reason in "
+        "architecture_rules/settings_reachability_exceptions.yml."
+    )
+
+
+def test_baseline_has_no_stale_entries():
+    """The baseline only ever shrinks: an entry that is no longer a gap must be
+    removed so the ledger can never go stale.
+    """
+    stale = _BASELINE - _current_gap_keys()
+    assert (
+        not stale
+    ), f"Baseline entries that are no longer gaps — remove them: {sorted(stale)}"
+
+
+def test_known_schema_subsystems_are_reachable():
+    """A spot-check that real schema-bearing subsystems classify as reachable."""
+    by_sub = {f.subsystem: f for f in _CHECK.collect_findings()}
+    for sub in ("economy", "moderation", "ai", "xp", "karma"):
+        assert sub in by_sub, f"{sub!r} should appear in the findings"
+        assert (
+            by_sub[sub].status == "reachable"
+        ), f"{sub!r} should be reachable: {by_sub[sub].reason}"
+
+
+def test_allowlisted_domain_panel_subsystems_are_exempt_not_gaps():
+    """counting/chain/channel are intentional domain-panel cases — exempt, never gaps."""
+    by_sub = {f.subsystem: f for f in _CHECK.collect_findings()}
+    for sub in ("counting", "chain", "channel"):
+        assert sub in by_sub, f"{sub!r} should appear in the findings"
+        assert (
+            by_sub[sub].status == "exempt"
+        ), f"{sub!r} should be exempt: {by_sub[sub].reason}"
+
+
+def test_strict_mode_is_clean():
+    """With the baseline empty and all gaps allowlisted, the guard is strict-clean —
+    so it can graduate to ``--mode strict`` failing CI on any future gap.
+    """
+    assert _current_gap_keys() == set()


### PR DESCRIPTION
## What & why

The last unstarted item in the five-part consolidation/discoverability goal: **settings centralization**, made *checkable*. This adds the **static settings-reachability guard** — the settings analog of the `#1370` command-reachability guard — so the brief's §3.4 goal *"every cog's settings reachable from the `!settings` hub"* becomes un-regressable.

## Finding (code-verified, no live bot)

The settings surface is already **structurally centralized**, but was only verifiable via a live-bot catalogue build (`customization_catalogue` needs loaded cogs; static `bot=None` over-reports 41/41). The AST-verifiable facts:

- **19 subsystems declare a `SubsystemSchema`** → auto-dispatched into `!settings`. **All 19 reachable** (non-internal + homed), 0 gaps.
- **3 subsystems** have a `.configure`/`.settings.*` capability but no schema — `counting` + `chain` (per-**channel** game enablement, configured in their own panels — bespoke per-channel data, not a guild-scalar setting) and `channel` (`channel.visibility.configure` is an admin **action**). These are **intentionally domain-panel-configured** → explicit allowlist with reasons (mirrors how `#1370` allowlists reachable-via-panel commands).

There is no schema to *add* — the work is the guard + documented allowlist that pins the boundary and fails CI if a new subsystem adds a schema but isn't homed, or grows a `.configure` capability without either a schema or an allowlist entry.

## Deliverable

- `scripts/check_settings_reachability.py` — static guard (registry + AST scan).
- `architecture_rules/settings_reachability_exceptions.yml` — allowlist.
- `tests/unit/invariants/test_settings_reachability.py` — CI invariant (warn-first ratchet).
- `docs/audits/settings-reachability-2026-06-23.md` — finding + exemption ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzLEHqxK5CAuKynxjuiVKz)_