### PR TITLE
feat(setup): AI-setup advisor — Accept · Deny · Edit (Q-0048 finalize)

### DIFF
--- a/.sessions/2026-06-23-ai-setup-edit-button.md
+++ b/.sessions/2026-06-23-ai-setup-edit-button.md
@@ -1,0 +1,41 @@
+# 2026-06-23 — AI-setup advisor: Accept · Deny · Edit (the Q-0048 finalize)
+
+> **Status:** `in-progress` — owner-directed. **Q-0048 decision (owner, 2026-06-23):** *"AI should apply
+> them but only after a confirmation; AI should spawn three buttons — accept, deny, edit."* The
+> propose→stage→Final-Review→audited-apply path already exists; this adds the missing **Edit** affordance
+> so each AI suggestion is Accept · Deny · Edit. PR this session; auto-merge armed on green (Q-0127);
+> owner-directed → merge immediately (Q-0191).
+
+> **Run type:** `manual · owner-directed`
+
+## What already exists (code-verified)
+
+The generative AI-setup wedge is built end-to-end:
+- **Propose** — `services/setup_natural_language_advisor.py` + `setup_plan.py` (`SetupRecommendation` /
+  `SetupPlanDraft`, `mode="create"|"bind"`); reached via `/setup-describe` (#1355) + propose-resource
+  (#1357).
+- **Review** — `views/setup/ai_review/main_panel.py` (`AIReviewPanelView`: Accept-all-high · Review
+  one-by-one · Reject-all · Rerun · **Stage & open Final review**) + `per_recommendation.py`
+  (`PerRecommendationView`: Accept · Reject · Skip · Back, building an `AcceptedSet`).
+- **Apply (gated)** — *Stage & open Final review* adapts the accepted set to `SetupOperation`s via
+  `setup_draft.replace_recommended_for_section` → `FinalReviewView` → the audited dispatcher, behind a
+  `setup_access.can_apply_setup` permission check. **So "apply only after confirmation" already holds.**
+
+## The gap (the Q-0048 ask)
+
+The per-suggestion walkthrough has Accept / **Reject** / Skip / Back — **no Edit**, and "Reject" ≠ the
+owner's "Deny". The owner wants each AI suggestion to show **Accept · Deny · Edit**.
+
+## Plan (one focused change, propose-only)
+
+- `per_recommendation.py`: reshape the action row to **Accept · Deny · Edit** (rename `_reject`→`_deny`,
+  label "Deny"; keep Skip/Back as nav on row 1). Add an **Edit** button → `_EditRecommendationModal`
+  (a single name field) that, on submit, rewrites the `create` suggestion's `target_name`
+  (`dataclasses.replace`), swaps it into the draft, accepts it, and advances. For a `bind` suggestion
+  (binds an *existing* resource) Edit explains it only applies to resources the bot will create — Deny +
+  rebind manually. **No DB / Discord writes** (the module's zero-write contract tests stay green); the
+  edited op still applies only through the gated Final Review.
+- Tests: the Edit flow (modal submit renames + accepts + advances), the bind-mode explain path, the
+  Deny rename.
+
+(Close-out enders at session close.)

--- a/.sessions/2026-06-23-ai-setup-edit-button.md
+++ b/.sessions/2026-06-23-ai-setup-edit-button.md
@@ -1,6 +1,6 @@
 # 2026-06-23 — AI-setup advisor: Accept · Deny · Edit (the Q-0048 finalize)
 
-> **Status:** `in-progress` — owner-directed. **Q-0048 decision (owner, 2026-06-23):** *"AI should apply
+> **Status:** `complete` — owner-directed. **Q-0048 decision (owner, 2026-06-23):** *"AI should apply
 > them but only after a confirmation; AI should spawn three buttons — accept, deny, edit."* The
 > propose→stage→Final-Review→audited-apply path already exists; this adds the missing **Edit** affordance
 > so each AI suggestion is Accept · Deny · Edit. PR this session; auto-merge armed on green (Q-0127);
@@ -38,4 +38,32 @@ owner's "Deny". The owner wants each AI suggestion to show **Accept · Deny · E
 - Tests: the Edit flow (modal submit renames + accepts + advances), the bind-mode explain path, the
   Deny rename.
 
-(Close-out enders at session close.)
+## Close-out
+
+**Verification:** `check_quality --full` green — **12187 passed**; new Edit-flow tests (modal-open for
+`create`, explain for `bind`, `apply_edit` swap+accept, modal-submit advance) pass; the module's
+zero-write contract tests (`test_module_has_no_db_imports`, `test_module_has_no_direct_discord_create_calls`)
+stay green; `check_architecture --mode strict` 0 errors; ledger + `check_docs --strict` pass (Q-0104).
+
+**Q-0048 recorded:** the owner's decision (AI applies setup changes only after confirmation; per-suggestion
+Accept/Deny/Edit) is captured here as the provenance for this change. Should also be appended to the
+question router as a formal owner decision (the durable home) — flagged for the docs-reconciliation pass.
+
+**💡 Session idea (Q-0089):** *Edit-the-binding for `bind` suggestions, not just rename-for-`create`.* This
+PR's Edit renames a resource the bot will create; a `bind` suggestion (AI picked an existing channel/role)
+can currently only be Denied + rebound manually. A natural follow-on: Edit on a `bind` rec opens a
+`discord.ui.ChannelSelect`/`RoleSelect` to re-pick the target in place (re-`dataclasses.replace` the
+`target_id`/`target_name`), so the operator can correct the AI's pick without leaving the walkthrough.
+Bounded, reuses the same `apply_edit` seam. (Captured; small follow-on.)
+
+**⟲ Previous-session review (Q-0102):** the previous session (settings-reachability guard, #1385) did well
+to *investigate before building* — it discovered the catalogue is bot-dependent and avoided inventing
+schemas that don't belong, shipping an honest guard instead. The same instinct paid off here: I read the
+existing `ai_review/` surface before coding and found the apply path was **already built and gated**, so
+the Q-0048 ask reduced to one missing button rather than a from-scratch feature — saving a large mis-scoped
+build. **System improvement (applied):** when an owner asks for a capability that sounds large ("AI applies
+setup changes"), *first map what already exists end-to-end* — the gap is often far smaller than the ask
+implies. Routine worth keeping: read the live surface before estimating scope.
+
+**Claim** `docs/owner/claims/claude__ai-setup-edit-button.md` deleted at close (Q-0126).
+

--- a/disbot/views/setup/ai_review/per_recommendation.py
+++ b/disbot/views/setup/ai_review/per_recommendation.py
@@ -1,27 +1,31 @@
 """Per-recommendation review view — Phase 9f / Track 5 PR 14.
 
-One-at-a-time walkthrough over a :class:`SetupPlanDraft`. The
-operator advances index-by-index and accepts / rejects each
-recommendation into the shared :class:`AcceptedSet`.
+One-at-a-time walkthrough over a :class:`SetupPlanDraft`. The operator advances
+index-by-index, deciding each AI suggestion with the **Accept · Deny · Edit**
+controls (the Q-0048 finalize) into the shared :class:`AcceptedSet`.
 
 Buttons:
 
 * **Accept** — adds the current recommendation to :class:`AcceptedSet`
   and advances to the next index.
-* **Reject** — removes any existing acceptance and advances.
+* **Deny** — removes any existing acceptance and advances.
+* **Edit** — for a ``create`` suggestion, opens a modal to rename the resource
+  the bot will create, then accepts the edited version and advances. A ``bind``
+  suggestion (an existing resource) can't be renamed — Edit explains that.
 * **Skip** — advances without changing the accepted set.
 * **Back to overview** — returns to :class:`AIReviewPanelView`.
 
-The current index is bounded ``[0, len(recommendations))``. Once
-the operator advances past the last recommendation the view
-auto-returns to the overview panel.
+The current index is bounded ``[0, len(recommendations))``. Once the operator
+advances past the last recommendation the view auto-returns to the overview.
 
-No DB writes, no Discord resource creation — only state mutations on
-the shared :class:`AcceptedSet`.
+No DB writes, no Discord resource creation — only state mutations on the shared
+:class:`AcceptedSet` and the in-memory draft. The accepted (possibly edited)
+operations apply only later, through the gated Final Review.
 """
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 from typing import TYPE_CHECKING
 
@@ -74,8 +78,16 @@ def build_per_recommendation_embed(
         ),
         color=color,
     )
+    edit_hint = (
+        " · Edit to rename before accepting"
+        if getattr(rec, "mode", "bind") == "create"
+        else ""
+    )
     embed.set_footer(
-        text=f"Accepted set: {accepted.count} · use Skip to defer, Back to return.",
+        text=(
+            f"Accepted set: {accepted.count} · Accept / Deny / Edit"
+            f"{edit_hint} · Skip to defer, Back to return."
+        ),
     )
     return embed
 
@@ -153,7 +165,33 @@ class PerRecommendationView(BaseView):
             view=self.parent_view,
         )
 
-    @discord.ui.button(label="Accept", style=discord.ButtonStyle.success)
+    def apply_edit(
+        self,
+        old: SetupRecommendation,
+        new_name: str,
+    ) -> SetupRecommendation:
+        """Rewrite the current ``create`` recommendation's target name in place.
+
+        Swaps the edited copy into both this view's draft and the parent
+        overview's draft (so the change survives the return), then accepts the
+        edited recommendation. Pure in-memory state mutation — no DB write, no
+        Discord resource creation (the edited op still applies only through the
+        gated Final Review). Returns the edited recommendation.
+        """
+        edited = dataclasses.replace(old, target_name=new_name)
+        recs = list(self.draft.recommendations)
+        if 0 <= self.index < len(recs):
+            recs[self.index] = edited
+        self.draft = dataclasses.replace(self.draft, recommendations=tuple(recs))
+        if self.parent_view is not None:
+            self.parent_view.draft = self.draft
+        # Reflect the edit in the accepted set: drop any prior acceptance of this
+        # binding, then accept the edited version.
+        self.accepted.remove(old.subsystem, old.binding_name)
+        self.accepted.add(edited)
+        return edited
+
+    @discord.ui.button(label="Accept", style=discord.ButtonStyle.success, row=0)
     async def _accept(
         self,
         interaction: discord.Interaction,
@@ -167,8 +205,8 @@ class PerRecommendationView(BaseView):
         self.accepted.add(rec)
         await self._advance_or_return(interaction)
 
-    @discord.ui.button(label="Reject", style=discord.ButtonStyle.danger)
-    async def _reject(
+    @discord.ui.button(label="Deny", style=discord.ButtonStyle.danger, row=0)
+    async def _deny(
         self,
         interaction: discord.Interaction,
         button: discord.ui.Button,
@@ -181,7 +219,32 @@ class PerRecommendationView(BaseView):
         self.accepted.remove(rec.subsystem, rec.binding_name)
         await self._advance_or_return(interaction)
 
-    @discord.ui.button(label="Skip", style=discord.ButtonStyle.secondary)
+    @discord.ui.button(label="Edit", style=discord.ButtonStyle.primary, row=0)
+    async def _edit(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        rec = self.current
+        if rec is None:
+            await self._return_to_overview(interaction)
+            return
+        # Edit rewrites the name of a resource the bot will CREATE. A "bind"
+        # suggestion points at an existing resource — we never rename those, so
+        # editing it would mislabel; tell the operator to Deny + rebind instead.
+        if getattr(rec, "mode", "bind") != "create":
+            await interaction.response.send_message(
+                f"**Edit** only changes the name of a `{rec.target_kind}` the bot "
+                f"will create. This suggestion binds an existing `{rec.target_kind}` "
+                f"(`{rec.target_name}`) — **Deny** it and bind a different one if "
+                "it isn't right.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_modal(_EditRecommendationModal(self, rec))
+
+    @discord.ui.button(label="Skip", style=discord.ButtonStyle.secondary, row=1)
     async def _skip(
         self,
         interaction: discord.Interaction,
@@ -193,6 +256,7 @@ class PerRecommendationView(BaseView):
     @discord.ui.button(
         label="Back to overview",
         style=discord.ButtonStyle.secondary,
+        row=1,
     )
     async def _back(
         self,
@@ -201,6 +265,44 @@ class PerRecommendationView(BaseView):
     ) -> None:
         del button
         await self._return_to_overview(interaction)
+
+
+class _EditRecommendationModal(discord.ui.Modal, title="Edit suggestion"):
+    """Edit the name of a ``create`` suggestion before accepting it.
+
+    A single text field pre-filled with the AI-proposed name. On submit it
+    rewrites the recommendation (via :meth:`PerRecommendationView.apply_edit`),
+    accepts the edited version, and advances the walkthrough. No DB / Discord
+    writes — the edit only changes what the gated Final Review will create.
+    """
+
+    def __init__(
+        self,
+        view: PerRecommendationView,
+        rec: SetupRecommendation,
+    ) -> None:
+        super().__init__()
+        self._view = view
+        self._rec = rec
+        self.name_input: discord.ui.TextInput = discord.ui.TextInput(
+            label=f"{rec.target_kind.title()} name to create",
+            default=rec.target_name,
+            min_length=1,
+            max_length=100,
+            required=True,
+        )
+        self.add_item(self.name_input)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        new_name = self.name_input.value.strip()
+        if not new_name:
+            await interaction.response.send_message(
+                "The name can't be empty — nothing was changed.",
+                ephemeral=True,
+            )
+            return
+        self._view.apply_edit(self._rec, new_name)
+        await self._view._advance_or_return(interaction)
 
 
 __all__ = [

--- a/docs/owner/claims/claude__ai-setup-edit-button.md
+++ b/docs/owner/claims/claude__ai-setup-edit-button.md
@@ -1,8 +1,0 @@
-- `claude/ai-setup-edit-button` · **AI-setup advisor: Accept · Deny · Edit (the Q-0048 finalize)** —
-  owner-directed (Q-0048 decision 2026-06-23: AI applies setup changes but only after confirmation, with
-  three per-suggestion buttons accept/deny/edit). The propose→stage→Final-Review→audited-apply path already
-  exists (#1355/#1357/#1361 + `views/setup/ai_review/`); this adds the missing **Edit** affordance on the
-  per-recommendation walkthrough (rename Reject→Deny; add Edit → modal to rename a `create` suggestion before
-  accepting). Stays propose-only (no DB/Discord writes here — apply remains the gated Final Review). Scope:
-  `disbot/views/setup/ai_review/per_recommendation.py`, `tests/unit/views/setup/ai_review/`. 2026-06-23 ·
-  PR (this session, auto-merge on green)

--- a/docs/owner/claims/claude__ai-setup-edit-button.md
+++ b/docs/owner/claims/claude__ai-setup-edit-button.md
@@ -1,0 +1,8 @@
+- `claude/ai-setup-edit-button` · **AI-setup advisor: Accept · Deny · Edit (the Q-0048 finalize)** —
+  owner-directed (Q-0048 decision 2026-06-23: AI applies setup changes but only after confirmation, with
+  three per-suggestion buttons accept/deny/edit). The propose→stage→Final-Review→audited-apply path already
+  exists (#1355/#1357/#1361 + `views/setup/ai_review/`); this adds the missing **Edit** affordance on the
+  per-recommendation walkthrough (rename Reject→Deny; add Edit → modal to rename a `create` suggestion before
+  accepting). Stays propose-only (no DB/Discord writes here — apply remains the gated Final Review). Scope:
+  `disbot/views/setup/ai_review/per_recommendation.py`, `tests/unit/views/setup/ai_review/`. 2026-06-23 ·
+  PR (this session, auto-merge on green)

--- a/tests/unit/views/setup/ai_review/test_ai_review_panels.py
+++ b/tests/unit/views/setup/ai_review/test_ai_review_panels.py
@@ -70,7 +70,22 @@ def _interaction(*, guild_id=1):
     interaction.response = MagicMock()
     interaction.response.send_message = AsyncMock()
     interaction.response.edit_message = AsyncMock()
+    interaction.response.send_modal = AsyncMock()
     return interaction
+
+
+def _create_rec(*, subsystem="welcome", binding="welcome_channel", name="welcome"):
+    """A ``create``-mode recommendation (target_id=None) — the Edit case."""
+    return SetupRecommendation(
+        subsystem=subsystem,
+        binding_name=binding,
+        target_kind="channel",
+        target_name=name,
+        confidence="high",
+        reason="x",
+        mode="create",
+        source="openai",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -399,7 +414,7 @@ async def test_per_recommendation_accept_advances():
 
 
 @pytest.mark.asyncio
-async def test_per_recommendation_reject_removes_and_advances():
+async def test_per_recommendation_deny_removes_and_advances():
     draft = SetupPlanDraft(recommendations=(_rec(),))
     accepted = AcceptedSet()
     accepted.add(draft.recommendations[0])
@@ -413,10 +428,88 @@ async def test_per_recommendation_reject_removes_and_advances():
     )
     interaction = _interaction()
 
-    await view._reject.callback(interaction)
+    await view._deny.callback(interaction)
 
     assert accepted.count == 0
     # End of list → returns to overview (parent's embed gets edited in).
+    interaction.response.edit_message.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Edit (Q-0048 finalize — Accept / Deny / Edit)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_recommendation_edit_opens_modal_for_create_rec():
+    """A `create` suggestion's Edit button opens the rename modal."""
+    draft = SetupPlanDraft(recommendations=(_create_rec(),))
+    view = PerRecommendationView(_author(), draft=draft, accepted=AcceptedSet(), index=0)
+    interaction = _interaction()
+
+    await view._edit.callback(interaction)
+
+    interaction.response.send_modal.assert_awaited_once()
+    interaction.response.edit_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_per_recommendation_edit_explains_for_bind_rec():
+    """A `bind` suggestion can't be renamed — Edit sends an ephemeral, no modal."""
+    draft = SetupPlanDraft(recommendations=(_rec(),))  # _rec() is bind-mode
+    view = PerRecommendationView(_author(), draft=draft, accepted=AcceptedSet(), index=0)
+    interaction = _interaction()
+
+    await view._edit.callback(interaction)
+
+    interaction.response.send_modal.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+    assert interaction.response.send_message.await_args.kwargs.get("ephemeral") is True
+
+
+def test_apply_edit_rewrites_name_swaps_draft_and_accepts():
+    rec = _create_rec(name="welcome")
+    draft = SetupPlanDraft(recommendations=(rec,))
+    accepted = AcceptedSet()
+    parent = AIReviewPanelView(_author(), draft=draft, accepted=accepted)
+    view = PerRecommendationView(
+        _author(), draft=draft, accepted=accepted, index=0, parent_view=parent,
+    )
+
+    edited = view.apply_edit(rec, "greetings")
+
+    assert edited.target_name == "greetings"
+    assert edited.mode == "create"
+    # Swapped into both this view's draft and the parent overview's draft.
+    assert view.draft.recommendations[0].target_name == "greetings"
+    assert parent.draft.recommendations[0].target_name == "greetings"
+    # The edited recommendation is now accepted (exactly once — keyed by binding).
+    assert accepted.count == 1
+    assert accepted.recommendations[0].target_name == "greetings"
+
+
+@pytest.mark.asyncio
+async def test_edit_modal_submit_applies_and_advances():
+    from views.setup.ai_review.per_recommendation import _EditRecommendationModal
+
+    rec = _create_rec(name="welcome")
+    draft = SetupPlanDraft(recommendations=(rec,))
+    accepted = AcceptedSet()
+    parent = AIReviewPanelView(_author(), draft=draft, accepted=accepted)
+    view = PerRecommendationView(
+        _author(), draft=draft, accepted=accepted, index=0, parent_view=parent,
+    )
+    modal = _EditRecommendationModal(view, rec)
+    modal.name_input.default = "greetings"
+    # Simulate the submitted value (TextInput.value reads the live component).
+    object.__setattr__(modal.name_input, "_value", "greetings")
+    interaction = _interaction()
+
+    await modal.on_submit(interaction)
+
+    assert accepted.count == 1
+    assert accepted.recommendations[0].target_name == "greetings"
+    # End of single-item list → returned to overview.
     interaction.response.edit_message.assert_awaited()
 
 


### PR DESCRIPTION
## What & why

The **Q-0048 finalize** of the AI setup advisor. Owner decision (2026-06-23): *"AI should apply them but only after a confirmation; AI should spawn three buttons — accept, deny, edit."*

The propose → stage → **Final Review → audited apply** path already exists (`#1355`/`#1357`/`#1361` + `views/setup/ai_review/`), and apply is already gated behind a confirmation + `can_apply_setup` permission check — so *"apply only after confirmation"* already holds. The missing piece was the **Edit** affordance.

## Change (one focused, propose-only edit)

`views/setup/ai_review/per_recommendation.py` — the one-by-one walkthrough now shows each AI suggestion as **Accept · Deny · Edit**:

- **Deny** — renamed from "Reject" (the owner's wording).
- **Edit** — opens a modal to rename a `create` suggestion's target (`dataclasses.replace`), swaps it into the draft, accepts the edited version, and advances. For a `bind` suggestion (binds an *existing* resource) Edit explains it applies only to resources the bot will create — Deny + rebind manually.
- Skip / Back remain as navigation.

**No DB or Discord writes** here — the module keeps its zero-write contract; the edited operation still applies only through the gated Final Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzLEHqxK5CAuKynxjuiVKz)_