### PR TITLE
docs(router): record Q-0199 — AI-setup apply decision (Q-0048 write lift)

### DIFF
--- a/.sessions/2026-06-23-q0199-ai-setup-apply.md
+++ b/.sessions/2026-06-23-q0199-ai-setup-apply.md
@@ -1,0 +1,41 @@
+# 2026-06-23 — Record Q-0199 (AI-setup apply decision) in the router
+
+> **Status:** `complete` — docs-only. Records the owner's in-session Q-0048 per-exposure **write**
+> decision (AI may apply generated setup changes, but only after confirmation, via per-suggestion
+> Accept/Deny/Edit) as an append-only **Q-0199** block in the question router — the durable home for owner
+> decisions, which the session card for PR #1386 flagged as still owed. PR this session; auto-merge armed
+> on green (Q-0127); owner-directed → merge immediately (Q-0191).
+
+> **Run type:** `manual · owner-directed (docs hygiene)`
+
+## Why
+
+PR #1386 implemented the owner's decision (AI-setup Accept/Deny/Edit) but the **decision itself** — a real
+per-exposure write lift under Q-0048, granting AI the ability to mutate a guild (after confirmation) — only
+lived in the session card. Owner decisions about irreversible capabilities belong in the question router
+(CLAUDE.md: "route durable conclusions to their correct documentation home"). This closes that gap.
+
+## Change
+
+One append-only Q-block (`Q-0199`) in `docs/owner/maintainer-question-router.md`: context, the decision
+(AI applies only through the human-gated Accept/Deny/Edit + audited Final Review path; does not generalize
+to other AI write surfaces), what shipped (#1386), and the noted follow-on (bind-target re-pick).
+
+## Close-out
+
+**Verification:** `check_docs --strict` + ledger pass (docs-only; no code/tests touched).
+
+**💡 Session idea (Q-0089):** *A `check_docs` lint that flags an implemented owner decision whose Q-block
+is missing from the router.* This session existed because a decision (Q-0048 setup-apply) shipped in code
+(#1386) a session before its router entry. A heuristic guard — e.g. a session card that records a
+`Q-00NN` decision in its body should have a matching router block within N PRs — would catch
+decision→router drift the way the ledger checker catches PR→ledger drift. (Captured; small follow-on.)
+
+**⟲ Previous-session review (Q-0102):** the previous (AI-setup Edit) session correctly *flagged* this
+router gap in its own close-out ("should also be appended to the question router … flagged for the
+docs-reconciliation pass") — good drift-awareness — but deferred it to a future pass rather than closing
+it. **System improvement (applied):** a decision-recording follow-up that's one paragraph of docs is
+cheaper to do immediately than to track; when a session surfaces a *small* durable-home gap, close it the
+next session rather than queueing it for reconciliation. Did that here.
+
+**Claim** `docs/owner/claims/claude__q0199-ai-setup-apply.md` deleted at close (Q-0126).

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -7256,3 +7256,34 @@ runtime-verified. **Home:** this Q-block (canonical) + the
 [`planning/mining-hub-redesign-2026-06-15.md`](../planning/mining-hub-redesign-2026-06-15.md) (PR 3's
 "Later — encounters"). Related: **Q-0173** (grid design), **Q-0186** (wild-encounters spawn design —
 shared engine), Q-0087 (never mandatory), Q-0071 (atomic workflow).
+
+### Q-0199 — ANSWERED (owner decision, in-session): AI may APPLY setup changes, but only after confirmation — per-suggestion Accept/Deny/Edit (2026-06-23)
+
+**Context.** The generative AI-setup wedge — *"describe your server → AI proposes channels/roles/automod
+→ staged ops → apply"* — had its read/propose seams shipped (`/setup-describe` #1355, propose-resource
+#1357, Final-Review create-count guard #1361, `views/setup/ai_review/`), but the **apply** (guild-mutating)
+step was the one remaining consolidation item, deliberately held under **Q-0048**'s rule (AI *writes* need
+a per-exposure design + owner decision before shipping). Asked for the decision, the owner directed,
+in-session: *"yes AI should apply them but only after a confirmation, AI should spawn three buttons —
+accept, deny, edit."*
+
+**The decision.** AI **may apply** the setup changes it generates (create/bind channels, roles, categories,
+automod config from a described plan) — but **never autonomously**. Every applied change is **human-gated**:
+each AI suggestion is decided per-item with **Accept · Deny · Edit**, and the accepted set applies **only**
+through the existing audited **Final Review** confirmation (`setup_draft` → `FinalReviewView` → the audited
+dispatcher, behind the `setup_access.can_apply_setup` permission floor). The AI never writes to a guild
+without an operator pressing apply on a reviewed plan. This is the per-exposure **write** lift Q-0048
+reserves — granted for *this* exposure (setup provisioning) with the confirmation guardrail above; it does
+**not** generalize to other AI write surfaces (each still needs its own lift).
+
+**Applied this session.** The propose→stage→Final-Review→audited-apply path already existed; PR **#1386**
+added the missing **Edit** affordance (and renamed Reject→Deny) on the per-recommendation walkthrough
+(`views/setup/ai_review/per_recommendation.py`): Edit opens a modal to rename a `create` suggestion before
+accepting; a `bind` suggestion can't be renamed (Deny + rebind). The review surface stays **propose-only**
+(zero DB/Discord writes there — the module's zero-write contract tests hold); application remains the gated
+Final Review. A noted follow-on (not yet built): Edit could re-pick the *target* of a `bind` suggestion via
+a channel/role select.
+
+**Home:** this Q-block (canonical) + `.sessions/2026-06-23-ai-setup-edit-button.md` +
+`docs/subsystems/settings-bindings-provisioning.md`. Related: **Q-0048** (AI exposure gate / per-exposure
+write lift — the parent rule), Q-0123 (auto-merge on green).


### PR DESCRIPTION
## What & why

Docs-only. Records the owner's in-session decision — *"AI should apply [setup changes] but only after a confirmation; AI should spawn three buttons — accept, deny, edit"* — as an append-only **Q-0199** block in the question router.

This is a real per-exposure **write** lift under **Q-0048** (AI mutating a guild after confirmation), implemented in `#1386` (AI-setup Accept/Deny/Edit). Owner decisions about irreversible capabilities belong in the router (their durable home); until now this one lived only in the `#1386` session card. This closes that decision→router gap.

The Q-block records: the decision (AI applies only through the human-gated Accept/Deny/Edit + audited Final Review path; does **not** generalize to other AI write surfaces), what shipped, and the noted follow-on (bind-target re-pick).

No code or tests touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzLEHqxK5CAuKynxjuiVKz)_