### PR TITLE
feat(setup): AI-setup Edit — re-pick target for bind suggestions

### DIFF
--- a/.sessions/2026-06-23-ai-setup-edit-rebind.md
+++ b/.sessions/2026-06-23-ai-setup-edit-rebind.md
@@ -1,0 +1,31 @@
+# 2026-06-23 — AI-setup Edit: re-pick target for `bind` suggestions (self-initiated)
+
+> **Status:** `in-progress` — **self-initiated follow-on** (Q-0172, flagged below) completing #1386's Edit
+> affordance. #1386 added Accept/Deny/Edit; Edit renames a `create` suggestion but only *explains* on a
+> `bind` one. This lets Edit on a `bind` suggestion **re-pick the existing target** via a channel/role
+> select, in place. Stays propose-only (apply remains the gated Final Review — Q-0199). PR this session;
+> auto-merge on green (Q-0127).
+
+> **Run type:** `manual · self-initiated (contained follow-on)`
+> **⚑ Self-initiated:** completes the Edit feature shipped in #1386 — the follow-on the #1386 / Q-0199
+> session cards both named. Contained, reversible, propose-only, test-covered (Q-0172 "build freely").
+
+## The gap (from #1386)
+
+`per_recommendation.py` `_edit`: for `create` it opens a rename modal; for `bind` (binds an existing
+channel/role/category) it sends an ephemeral "can't rename — Deny + rebind". So the operator can't
+*correct the AI's pick* of an existing resource without leaving the walkthrough.
+
+## Plan
+
+- Factor `_swap_and_accept(old, edited)` out of `apply_edit`; add `apply_retarget(old, *, target_id,
+  target_name)` (re-`dataclasses.replace` the `target_id`/`target_name`, keeping `mode="bind"`).
+- `_edit` on a `bind` rec of a selectable kind (`channel`/`category`/`role`) → opens `_RepickTargetView`
+  (a `discord.ui.ChannelSelect` with the kind's channel types, or `RoleSelect`, + Cancel). On select →
+  `apply_retarget` → advance. Kinds that can't be selected (`thread`/`member`) keep the explain ephemeral.
+- No DB / Discord writes (the module's zero-write contract tests stay green); the re-targeted op still
+  applies only through the gated Final Review.
+- Tests: bind+channel opens the re-pick view; the select callback retargets+accepts+advances;
+  `apply_retarget` swaps id/name into the draft + accepts; unsupported kind still explains.
+
+(Close-out enders at session close.)

--- a/.sessions/2026-06-23-ai-setup-edit-rebind.md
+++ b/.sessions/2026-06-23-ai-setup-edit-rebind.md
@@ -1,6 +1,6 @@
 # 2026-06-23 — AI-setup Edit: re-pick target for `bind` suggestions (self-initiated)
 
-> **Status:** `in-progress` — **self-initiated follow-on** (Q-0172, flagged below) completing #1386's Edit
+> **Status:** `complete` — **self-initiated follow-on** (Q-0172, flagged below) completing #1386's Edit
 > affordance. #1386 added Accept/Deny/Edit; Edit renames a `create` suggestion but only *explains* on a
 > `bind` one. This lets Edit on a `bind` suggestion **re-pick the existing target** via a channel/role
 > select, in place. Stays propose-only (apply remains the gated Final Review — Q-0199). PR this session;
@@ -28,4 +28,30 @@ channel/role/category) it sends an ephemeral "can't rename — Deny + rebind". S
 - Tests: bind+channel opens the re-pick view; the select callback retargets+accepts+advances;
   `apply_retarget` swaps id/name into the draft + accepts; unsupported kind still explains.
 
-(Close-out enders at session close.)
+## Close-out
+
+**Verification:** `mypy disbot/` clean (824 files); full pytest **12202 passed**; `check_architecture
+--mode strict` 0 errors; `check_quality --check-only` green; the module's zero-write contract tests
+(`test_module_has_no_db_imports`, `test_module_has_no_direct_discord_create_calls`) stay green
+(ChannelSelect/RoleSelect are not resource creates); ledger + `check_docs --strict` pass (Q-0104).
+
+**mypy note:** discord.py's `Select` is generic per value-type (the default `Select` is `Select[str]`, so
+`.values` types as `str`); the kind is chosen at runtime, so the re-pick select is held as one `Any`-typed
+handle rather than a `RoleSelect | ChannelSelect` union (the house pattern elsewhere subclasses a single
+select type — not possible when the type is runtime-chosen).
+
+**💡 Session idea (Q-0089):** *Re-pick should pre-filter the select to the same category, when the binding
+implies one.* The current ChannelSelect lists all text/news channels; for a binding whose AI pick sat
+under a specific category (e.g. a staff category), defaulting/scoping the picker to that category would
+make the correction faster. Bounded follow-on on the same seam. (Captured.)
+
+**⟲ Previous-session review (Q-0102):** the previous session (Q-0199 router record) correctly applied its
+own surfaced lesson — *close a small durable-home gap immediately rather than queueing it for
+reconciliation* — which is exactly why this Edit follow-on was reachable as "where I left off" (the gap
+was named, not buried). It did well to keep that PR docs-only and tightly scoped. Nothing it missed of
+note. **System improvement (applied):** this session flagged its self-initiated nature on the card's
+`⚑ Self-initiated:` line (Q-0172 accountability) *before* building — making unprompted work auditable at a
+glance is the discipline that lets the chain self-initiate safely. Keep doing that on every unprompted PR.
+
+**Claim** `docs/owner/claims/claude__ai-setup-edit-rebind.md` deleted at close (Q-0126).
+

--- a/disbot/views/setup/ai_review/per_recommendation.py
+++ b/disbot/views/setup/ai_review/per_recommendation.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import discord
 
@@ -165,31 +165,57 @@ class PerRecommendationView(BaseView):
             view=self.parent_view,
         )
 
-    def apply_edit(
+    def _swap_and_accept(
         self,
         old: SetupRecommendation,
-        new_name: str,
+        edited: SetupRecommendation,
     ) -> SetupRecommendation:
-        """Rewrite the current ``create`` recommendation's target name in place.
+        """Swap ``edited`` in for ``old`` at the current index and accept it.
 
-        Swaps the edited copy into both this view's draft and the parent
-        overview's draft (so the change survives the return), then accepts the
-        edited recommendation. Pure in-memory state mutation — no DB write, no
-        Discord resource creation (the edited op still applies only through the
-        gated Final Review). Returns the edited recommendation.
+        Updates both this view's draft and the parent overview's draft (so the
+        change survives the return), then re-accepts under the (unchanged)
+        binding key. Pure in-memory state mutation — no DB write, no Discord
+        resource creation (the edited op still applies only through the gated
+        Final Review). Returns the edited recommendation.
         """
-        edited = dataclasses.replace(old, target_name=new_name)
         recs = list(self.draft.recommendations)
         if 0 <= self.index < len(recs):
             recs[self.index] = edited
         self.draft = dataclasses.replace(self.draft, recommendations=tuple(recs))
         if self.parent_view is not None:
             self.parent_view.draft = self.draft
-        # Reflect the edit in the accepted set: drop any prior acceptance of this
-        # binding, then accept the edited version.
         self.accepted.remove(old.subsystem, old.binding_name)
         self.accepted.add(edited)
         return edited
+
+    def apply_edit(
+        self,
+        old: SetupRecommendation,
+        new_name: str,
+    ) -> SetupRecommendation:
+        """Rewrite a ``create`` recommendation's target name, then accept it."""
+        return self._swap_and_accept(
+            old,
+            dataclasses.replace(old, target_name=new_name),
+        )
+
+    def apply_retarget(
+        self,
+        old: SetupRecommendation,
+        *,
+        target_id: int,
+        target_name: str,
+    ) -> SetupRecommendation:
+        """Re-point a ``bind`` recommendation at a different existing resource.
+
+        Used by the Edit → re-pick flow: the operator corrects which live
+        channel/role/category the AI proposed to bind. ``mode`` stays ``bind``;
+        only the target id + name change. Then accept it.
+        """
+        return self._swap_and_accept(
+            old,
+            dataclasses.replace(old, target_id=target_id, target_name=target_name),
+        )
 
     @discord.ui.button(label="Accept", style=discord.ButtonStyle.success, row=0)
     async def _accept(
@@ -230,19 +256,24 @@ class PerRecommendationView(BaseView):
         if rec is None:
             await self._return_to_overview(interaction)
             return
-        # Edit rewrites the name of a resource the bot will CREATE. A "bind"
-        # suggestion points at an existing resource — we never rename those, so
-        # editing it would mislabel; tell the operator to Deny + rebind instead.
-        if getattr(rec, "mode", "bind") != "create":
+        # A "create" suggestion → rename the resource the bot will create (modal).
+        if getattr(rec, "mode", "bind") == "create":
+            await interaction.response.send_modal(_EditRecommendationModal(self, rec))
+            return
+        # A "bind" suggestion points at an existing resource. For a selectable
+        # kind, let the operator re-pick the target in place; otherwise we can't
+        # offer a picker, so tell them to Deny + rebind.
+        if rec.target_kind not in _REPICKABLE_KINDS:
             await interaction.response.send_message(
-                f"**Edit** only changes the name of a `{rec.target_kind}` the bot "
-                f"will create. This suggestion binds an existing `{rec.target_kind}` "
-                f"(`{rec.target_name}`) — **Deny** it and bind a different one if "
-                "it isn't right.",
+                f"**Edit** can't re-pick a `{rec.target_kind}` here — **Deny** this "
+                "suggestion and bind a different one if it isn't right.",
                 ephemeral=True,
             )
             return
-        await interaction.response.send_modal(_EditRecommendationModal(self, rec))
+        await interaction.response.edit_message(
+            embed=_build_repick_embed(rec),
+            view=_RepickTargetView(self._author, per_view=self, rec=rec),
+        )
 
     @discord.ui.button(label="Skip", style=discord.ButtonStyle.secondary, row=1)
     async def _skip(
@@ -303,6 +334,97 @@ class _EditRecommendationModal(discord.ui.Modal, title="Edit suggestion"):
             return
         self._view.apply_edit(self._rec, new_name)
         await self._view._advance_or_return(interaction)
+
+
+# Resource kinds the Edit → re-pick flow can offer a native picker for. Threads
+# and members have no component select here, so a "bind" suggestion of those
+# kinds keeps the Deny + rebind path.
+_REPICKABLE_KINDS: frozenset[str] = frozenset({"channel", "category", "role"})
+
+_CHANNEL_TYPES_FOR_KIND: dict[str, list[discord.ChannelType]] = {
+    "channel": [discord.ChannelType.text, discord.ChannelType.news],
+    "category": [discord.ChannelType.category],
+}
+
+
+def _build_repick_embed(rec: SetupRecommendation) -> discord.Embed:
+    """Prompt embed for the Edit → re-pick target sub-view."""
+    return discord.Embed(
+        title="✏️ Re-pick target",
+        description=(
+            f"Choose a different `{rec.target_kind}` to bind to "
+            f"`{rec.subsystem}.{rec.binding_name}`.\n"
+            f"The AI proposed **{rec.target_name}**. Your pick is accepted "
+            "immediately — it still applies only through Final Review."
+        ),
+        color=_CONFIDENCE_COLOR.get(rec.confidence, discord.Color.blurple()),
+    )
+
+
+class _RepickTargetView(BaseView):
+    """Edit → re-pick the existing target of a ``bind`` suggestion.
+
+    Shows a kind-appropriate :class:`discord.ui.ChannelSelect` /
+    :class:`discord.ui.RoleSelect`; selecting a resource re-points the
+    recommendation (via :meth:`PerRecommendationView.apply_retarget`), accepts
+    it, and advances. Cancel returns to the suggestion unchanged. No DB /
+    Discord writes — only the in-memory draft/accepted set change.
+    """
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        per_view: PerRecommendationView,
+        rec: SetupRecommendation,
+    ) -> None:
+        super().__init__(author, public=per_view._public, timeout=per_view.timeout)
+        self._per = per_view
+        self._rec = rec
+        # discord.py's Select is generic per value-type (RoleSelect[Role] vs
+        # ChannelSelect[channel] vs the default Select[str]); the kind is chosen
+        # at runtime, so keep one ``Any``-typed handle rather than a union.
+        self._select: Any
+        if rec.target_kind == "role":
+            self._select = discord.ui.RoleSelect(
+                placeholder=f"Pick a role for {rec.binding_name}…",
+                min_values=1,
+                max_values=1,
+            )
+        else:
+            self._select = discord.ui.ChannelSelect(
+                channel_types=_CHANNEL_TYPES_FOR_KIND.get(rec.target_kind, []),
+                placeholder=f"Pick a {rec.target_kind} for {rec.binding_name}…",
+                min_values=1,
+                max_values=1,
+            )
+        self._select.callback = self._on_select
+        self.add_item(self._select)
+
+    async def _on_select(self, interaction: discord.Interaction) -> None:
+        picked = self._select.values[0]
+        self._per.apply_retarget(
+            self._rec,
+            target_id=picked.id,
+            target_name=getattr(picked, "name", str(picked.id)),
+        )
+        await self._per._advance_or_return(interaction)
+
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.secondary, row=1)
+    async def _cancel(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        del button
+        await interaction.response.edit_message(
+            embed=build_per_recommendation_embed(
+                self._per.draft,
+                self._per.index,
+                self._per.accepted,
+            ),
+            view=self._per,
+        )
 
 
 __all__ = [

--- a/docs/owner/claims/claude__ai-setup-edit-rebind.md
+++ b/docs/owner/claims/claude__ai-setup-edit-rebind.md
@@ -1,6 +1,0 @@
-- `claude/ai-setup-edit-rebind` · **AI-setup Edit: re-pick target for `bind` suggestions (self-initiated)** —
-  completes #1386's Edit affordance. Currently Edit renames `create` suggestions and only *explains* for
-  `bind`; this lets Edit on a `bind` suggestion open a channel/role select to re-pick the existing target
-  in place (apply_retarget → swap target_id/name → accept → advance). Propose-only (no writes; applies via
-  the gated Final Review). Self-initiated follow-on (flagged per Q-0172). Scope:
-  `disbot/views/setup/ai_review/per_recommendation.py`, `tests/`. 2026-06-23 · PR (this session, auto-merge on green)

--- a/docs/owner/claims/claude__ai-setup-edit-rebind.md
+++ b/docs/owner/claims/claude__ai-setup-edit-rebind.md
@@ -1,0 +1,6 @@
+- `claude/ai-setup-edit-rebind` · **AI-setup Edit: re-pick target for `bind` suggestions (self-initiated)** —
+  completes #1386's Edit affordance. Currently Edit renames `create` suggestions and only *explains* for
+  `bind`; this lets Edit on a `bind` suggestion open a channel/role select to re-pick the existing target
+  in place (apply_retarget → swap target_id/name → accept → advance). Propose-only (no writes; applies via
+  the gated Final Review). Self-initiated follow-on (flagged per Q-0172). Scope:
+  `disbot/views/setup/ai_review/per_recommendation.py`, `tests/`. 2026-06-23 · PR (this session, auto-merge on green)

--- a/tests/unit/views/setup/ai_review/test_ai_review_panels.py
+++ b/tests/unit/views/setup/ai_review/test_ai_review_panels.py
@@ -454,17 +454,94 @@ async def test_per_recommendation_edit_opens_modal_for_create_rec():
 
 
 @pytest.mark.asyncio
-async def test_per_recommendation_edit_explains_for_bind_rec():
-    """A `bind` suggestion can't be renamed — Edit sends an ephemeral, no modal."""
-    draft = SetupPlanDraft(recommendations=(_rec(),))  # _rec() is bind-mode
+async def test_per_recommendation_edit_opens_repick_for_bind_channel():
+    """A `bind` channel suggestion's Edit opens the re-pick target sub-view."""
+    from views.setup.ai_review.per_recommendation import _RepickTargetView
+
+    draft = SetupPlanDraft(recommendations=(_rec(),))  # _rec() is a bind channel
     view = PerRecommendationView(_author(), draft=draft, accepted=AcceptedSet(), index=0)
     interaction = _interaction()
 
     await view._edit.callback(interaction)
 
     interaction.response.send_modal.assert_not_awaited()
+    interaction.response.edit_message.assert_awaited_once()
+    assert isinstance(
+        interaction.response.edit_message.await_args.kwargs["view"],
+        _RepickTargetView,
+    )
+
+
+@pytest.mark.asyncio
+async def test_per_recommendation_edit_explains_for_unselectable_bind_kind():
+    """A `bind` suggestion of a non-pickable kind (thread/member) still explains."""
+    thread_rec = SetupRecommendation(
+        subsystem="logging",
+        binding_name="thread_target",
+        target_kind="thread",
+        target_id=55,
+        target_name="some-thread",
+        confidence="medium",
+        reason="x",
+    )
+    draft = SetupPlanDraft(recommendations=(thread_rec,))
+    view = PerRecommendationView(_author(), draft=draft, accepted=AcceptedSet(), index=0)
+    interaction = _interaction()
+
+    await view._edit.callback(interaction)
+
+    interaction.response.send_modal.assert_not_awaited()
+    interaction.response.edit_message.assert_not_awaited()
     interaction.response.send_message.assert_awaited_once()
     assert interaction.response.send_message.await_args.kwargs.get("ephemeral") is True
+
+
+def test_apply_retarget_swaps_id_and_name_and_accepts():
+    rec = _rec(target_id=100)  # bind channel, target_name "mod_channel-100"
+    draft = SetupPlanDraft(recommendations=(rec,))
+    accepted = AcceptedSet()
+    parent = AIReviewPanelView(_author(), draft=draft, accepted=accepted)
+    view = PerRecommendationView(
+        _author(), draft=draft, accepted=accepted, index=0, parent_view=parent,
+    )
+
+    edited = view.apply_retarget(rec, target_id=777, target_name="staff-logs")
+
+    assert edited.target_id == 777
+    assert edited.target_name == "staff-logs"
+    assert edited.mode == "bind"
+    assert view.draft.recommendations[0].target_id == 777
+    assert parent.draft.recommendations[0].target_id == 777
+    assert accepted.count == 1
+    assert accepted.recommendations[0].target_id == 777
+
+
+@pytest.mark.asyncio
+async def test_repick_select_retargets_and_advances():
+    from views.setup.ai_review.per_recommendation import _RepickTargetView
+
+    rec = _rec(target_id=100)
+    draft = SetupPlanDraft(recommendations=(rec,))
+    accepted = AcceptedSet()
+    parent = AIReviewPanelView(_author(), draft=draft, accepted=accepted)
+    per = PerRecommendationView(
+        _author(), draft=draft, accepted=accepted, index=0, parent_view=parent,
+    )
+    repick = _RepickTargetView(_author(), per_view=per, rec=rec)
+    # Simulate the operator picking a channel (#777 "staff-logs"). NB: ``name``
+    # is a reserved MagicMock kwarg, so set the attribute explicitly.
+    picked = MagicMock(id=777)
+    picked.name = "staff-logs"
+    repick._select = MagicMock(values=[picked])
+    interaction = _interaction()
+
+    await repick._on_select(interaction)
+
+    assert accepted.count == 1
+    assert accepted.recommendations[0].target_id == 777
+    assert accepted.recommendations[0].target_name == "staff-logs"
+    # End of single-item list → returned to overview.
+    interaction.response.edit_message.assert_awaited()
 
 
 def test_apply_edit_rewrites_name_swaps_draft_and_accepts():


### PR DESCRIPTION
## What & why

**Self-initiated follow-on** completing the Edit affordance shipped in `#1386` (the one named in the `#1386` / Q-0199 session cards). `#1386` added Accept/Deny/Edit; Edit renames a `create` suggestion but only *explains* on a `bind` one. This lets **Edit on a `bind` suggestion re-pick its target** — correct the AI's choice of an existing channel/role in place, instead of having to Deny + rebind manually.

## Change

`views/setup/ai_review/per_recommendation.py`:
- Factored `_swap_and_accept(old, edited)` out of `apply_edit`; added `apply_retarget(old, *, target_id, target_name)`.
- `_edit` on a `bind` suggestion of a selectable kind (`channel`/`category`/`role`) opens `_RepickTargetView` — a `discord.ui.ChannelSelect` (kind-appropriate channel types) or `RoleSelect`, plus Cancel. On select it retargets the recommendation, accepts it, and advances. `thread`/`member` kinds (not selectable) keep the explain ephemeral.

Stays **propose-only** — no DB / Discord writes (the module's zero-write contract tests hold); the re-targeted op still applies only through the gated Final Review (Q-0199).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzLEHqxK5CAuKynxjuiVKz)_