### PR TITLE
docs(ideas): capture BTD6 runtime-mechanics extraction (owner-raised)

### DIFF
--- a/.sessions/2026-06-23-btd6-runtime-extraction-idea.md
+++ b/.sessions/2026-06-23-btd6-runtime-extraction-idea.md
@@ -1,0 +1,32 @@
+# 2026-06-23 — Capture: BTD6 runtime mechanics straight from the game
+
+> **Status:** `complete` — owner-raised idea capture (docs-only), no runtime code.
+
+Follow-on to the freeplay-curve/RBE + cash investigation (PRs #1384/#1387). The owner
+reflected that the **original plan to pull data straight from the game** is still worth
+doing "eventually," *because we see so many different stats and numbers everywhere.*
+
+Captured it as `docs/ideas/btd6-runtime-mechanics-from-game-2026-06-23.md` + README index
+entry. The sharpened framing: Phase 1 (consume the Mod Helper **model** dump) is done; the
+recurring number disputes all live in the **runtime/simulation layer** the model export
+omits (freeplay health ramp, superceramic swap, per-round RBE & cash). Proposes a BTD Mod
+Helper **runtime-extraction mod** as the game-sourced oracle, pairing with the drift-check
+idea so our curated sidecars become game-verified rather than community-derived.
+
+## 💡 Session idea (Q-0089)
+The capture itself is the idea (owner-raised + agent-sharpened). Distinct sub-idea worth
+flagging: a **first slice** scoped to just the freeplay health curve + per-round RBE/cash
+(the exact things contested this session) would de-risk the larger extraction effort and
+immediately replace the topper64 cross-checks with a game oracle.
+
+## ⟲ Previous-session review (Q-0102)
+Reviewed **2026-06-23-btd6-freeplay-curve-and-rbe** (#1387). Did well: caught + fixed its
+own predecessor's (#1384) wrong brackets, validated against two anchors, and flagged the
+fortified-RBE 0.1% gap honestly. What this capture adds: #1387's residual uncertainty (one
+anchor for superceramic RBE, fortified ~0.1% off, topper-as-source) is *exactly* the
+"secondary sources disagree" pain this idea targets — the session-chain surfaced the root
+cause, and this routes it instead of letting it recur.
+
+## Doc audit (Q-0104)
+Docs-only; idea filed in its durable home (`docs/ideas/` + README index). No ledger/owner
+decision to record. `check_docs --strict` run before push.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,12 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`btd6-runtime-mechanics-from-game-2026-06-23.md`](./btd6-runtime-mechanics-from-game-2026-06-23.md) —
+  **owner-raised (2026-06-23):** get the BTD6 *runtime/simulation* layer (freeplay health/speed ramp,
+  superceramic swap, per-round RBE & cash) **straight from the game** — the dump only exports entity
+  *models*, so every "conflicting numbers" dispute (topper64 vs cyberquincy vs us: cash ~300K/350K/400K;
+  the wrong r>100 health brackets in #1384) comes from re-deriving runtime mechanics against contradictory
+  secondary sources. Proposes a BTD Mod Helper runtime-extraction mod as the game-sourced oracle. Subsystem: btd6.
 - [`ultracode-worker-pr-scope-guard-2026-06-23.md`](./ultracode-worker-pr-scope-guard-2026-06-23.md) —
   **session-idea (2026-06-23, Q-0089) from the ultracode consolidation fleet (#1375):** a coordinator-side
   `scripts/check_worker_pr_scope.py` that asserts a worker PR's diff touches *only* its declared ALLOWED

--- a/docs/ideas/btd6-runtime-mechanics-from-game-2026-06-23.md
+++ b/docs/ideas/btd6-runtime-mechanics-from-game-2026-06-23.md
@@ -1,0 +1,67 @@
+# BTD6 runtime/simulation mechanics — extract straight from the game
+
+> **Status:** `ideas` — capture, not a plan, not approval.
+> **Subsystem:** btd6
+> **Owner-raised** (2026-06-23, in-chat): *"our original plan was once to get the data
+> straight from the original game … because we see so many different stats and numbers
+> everywhere."*
+
+## The problem this fixes
+
+Every BTD6 number dispute we've had traces to the same root: **the data we have is
+*entity models*, but the numbers people argue about are produced by the *runtime
+engine*.** Community calculators (topper64, cyberquincy, bloonswiki) each re-derive the
+runtime layer independently, and they disagree — sometimes badly:
+
+- **Freeplay health scaling** — not in the dump at all; sourced from topper64 (PR #1384
+  shipped *wrong* unverified brackets, fixed in #1387 only after a second anchor exposed
+  them: r140 fortified BAD is 200,000 HP / ×5.0, not the ×2.38 we first shipped).
+- **Round-scaled RBE** — a spawn-tree recompute with MOAB ×v(r) + superceramics; we
+  reproduced `BAD@100 = 67,200` exactly, but only by reverse-engineering the superceramic
+  RBE (68) against one anchor.
+- **Cumulative cash at r140** — three sources, three answers: cyberquincy ~400K, our bot
+  ~350K, topper ~300K. Ours is the best-grounded (the cash-per-pop decay **is** in the
+  dump, `IncomeSets/`), but nobody can point to a single authoritative figure.
+
+We keep playing detective against contradictory secondary sources. A single
+game-authoritative source for the *runtime* layer ends that whole class of bug.
+
+## What we already have vs. the gap
+
+- **Have (Phase 1, done):** the **model** data via BTD Mod Helper's "Export Game Data"
+  dump — `Bloons/` base stats, `Rounds/` composition+timing, `Towers/`, `Upgrades/`,
+  `IncomeSets/` cash decay. See `docs/btd6/btd6-game-file-extraction-plan.md` (historical).
+- **Gap:** the **runtime/simulation mechanics** the model export omits — the freeplay
+  health/speed ramp `v(r)`, the superceramic swap (60 HP shell, halved children, the
+  +$86 compensation), per-round RBE, and how cash-per-pop is actually applied. These live
+  in the compiled `Assembly-CSharp` (Il2Cpp) simulation code, not in any exported model.
+
+## Two routes (recommendation: the runtime mod)
+
+1. **Runtime-extraction mod (preferred).** A BTD Mod Helper mod that walks the *live*
+   `Simulation`: for each round set × round × bloon, read the **engine-computed** health,
+   speed, RBE, and cash. Dump it to JSON the same way "Export Game Data" already does.
+   This is empirical ground truth, uses the toolchain we already depend on, and produces a
+   table our curated sidecars (`bloon_scaling.json`, round cash/RBE) can be **pinned to**
+   — replacing the topper64/cyberquincy cross-checks with a game-sourced oracle.
+2. **Decompilation.** Read the constants/formulas directly from `Assembly-CSharp` (the
+   freeplay-scale function, the superceramic model, the cash application). More precise on
+   *formula shape*, but a heavier, more brittle toolchain (Il2Cpp dumping per patch).
+
+## Value & shape
+
+- **Kills the recurring "conflicting numbers" bug class** at the root — the motivation the
+  owner named. Turns `bloon_scaling.json` / round cash / RBE from *community-derived* into
+  *game-verified*.
+- **Pairs with the drift-check idea** (`.sessions/2026-06-23-btd6-freeplay-curve-and-rbe.md`
+  §idea): once we have game-sourced runtime values, they become the test oracle, and a CI
+  check catches an NK rebalance as a red test instead of a user complaint.
+- **Scope: large, "eventually"** (owner's word) — a modding/extraction toolchain, run per
+  game patch. Not urgent, must not derail current work. Best sequenced as its own
+  planning effort when capacity allows; a first slice could target just the freeplay
+  health curve + per-round RBE/cash (the exact things we fought this session).
+
+## Links
+- `docs/btd6/btd6-game-file-extraction-plan.md` — Phase 1 (models), historical.
+- `docs/btd6/btd6-gamedata-dictionary.md` § "Runtime-formula facts the dump does NOT store".
+- PRs #1384 / #1387 (freeplay health + RBE), and this session's cash investigation.


### PR DESCRIPTION
## What & why

Docs-only. Captures the owner-raised idea (2026-06-23, in-chat) to get BTD6 data **straight from the game** — *"because we see so many different stats and numbers everywhere."*

Follow-on to PRs #1384/#1387 (freeplay health + RBE) and this session's cash investigation, which all hit the same root cause: the BTD Mod Helper dump exports entity **models**, but every number dispute lives in the **runtime/simulation layer** the export omits — the freeplay health/speed ramp, the superceramic swap, per-round RBE & cash. We've been re-deriving that layer against contradictory secondary sources (topper64 vs cyberquincy vs us: cumulative cash at r140 ≈ 300K / 350K / 400K; and #1384 shipped *wrong* r>100 health brackets that only a second anchor exposed).

The capture proposes a **BTD Mod Helper runtime-extraction mod** (walk the live `Simulation`, dump engine-computed health/speed/RBE/cash per round×bloon) as the game-sourced oracle, pairing with the drift-check idea so our curated sidecars become game-verified instead of community-derived. Scoped as "eventually" per the owner; a first slice could target just the freeplay curve + per-round RBE/cash.

## Changes
- `docs/ideas/btd6-runtime-mechanics-from-game-2026-06-23.md` — the capture (`ideas` badge, Subsystem: btd6).
- `docs/ideas/README.md` — index entry (newest-first).
- `.sessions/2026-06-23-btd6-runtime-extraction-idea.md` — session card.

No runtime/`disbot/` code. `check_docs --strict` green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hydy3uLzrkCmqHWT2VoEKG)_