### PR TITLE
docs(ideas): log BTD6 cash-model empirical validation

### DIFF
--- a/.sessions/2026-06-23-btd6-cash-empirical-validation.md
+++ b/.sessions/2026-06-23-btd6-cash-empirical-validation.md
@@ -1,0 +1,26 @@
+# 2026-06-23 — BTD6 cash model: empirical validation (capture)
+
+> **Status:** `complete` — owner-driven investigation, docs-only capture.
+
+Long owner-driven Q&A debugging the BTD6 late-game cash numbers against a real in-game
+measurement. Outcome: **our cash model is validated** (within ~3% on pop cash, once the
+double-cash modifier, the absent-in-sandbox round bonus, and the CHIMPS≠sandbox mode
+difference are accounted for), and **CyberQuincy over-counts fortified bloons** (the game
+gives fortified-independent cash, exactly as our model assumes). Captured the full finding
++ the owner's planned per-round verification in the runtime-extraction idea doc so the
+next session starts from it.
+
+## 💡 Session idea (Q-0089)
+Already filed this arc's idea (runtime-extraction, PR #1391). Sub-idea logged in the doc:
+the owner's per-round in-game capture becomes the **oracle** a drift test pins to — turning
+a manual verification into a standing regression guard.
+
+## ⟲ Previous-session review (Q-0102)
+Reviewed the #1391 idea capture. It did well to frame the *runtime layer* as the gap; what
+today added is the **empirical proof** that the gap is real and that secondary calculators
+(CQ over-counts fortified, topper stale decay) genuinely disagree with the game — the
+strongest possible motivation for the idea, now recorded in its validation log.
+
+## Doc audit (Q-0104)
+Docs-only. Finding lives in its durable home (the idea doc's Empirical validation log).
+`check_docs --strict` before push. No ledger/owner-decision change.

--- a/docs/ideas/btd6-runtime-mechanics-from-game-2026-06-23.md
+++ b/docs/ideas/btd6-runtime-mechanics-from-game-2026-06-23.md
@@ -61,6 +61,31 @@ game-authoritative source for the *runtime* layer ends that whole class of bug.
   planning effort when capacity allows; a first slice could target just the freeplay
   health curve + per-round RBE/cash (the exact things we fought this session).
 
+## Empirical validation log — 2026-06-23 (cash)
+
+First real-game data point against the cash model (owner-run, BTD6 **sandbox**), and a
+preview of why the controlled per-round capture matters:
+
+- **r100→r120, clean** (2 paragons, no income, every round sent fully): cash gained
+  **$176,369**.
+- **Three confounds nearly caused wrong "fixes":** (1) **double cash** active (÷2);
+  (2) **sandbox has no `$100+n` round bonus**; (3) **CHIMPS ≠ sandbox**. Removing them:
+  de-doubled pop cash ≈ **$88,185** vs our model's pop cash **$85,468** → **within ~3%.
+  Cash model VALIDATED.** (Each confound flipped the conclusion mid-thread — the whole
+  point of the runtime-extraction idea: read clean engine values under known conditions.)
+- **Settled the calculator spread.** CyberQuincy ($139k for r100–120) **over-counts
+  fortified bloons** — it pays extra cash for fortified, and the per-round divergence from
+  us tracks fortified density exactly (r100 *no fortified* → matches us to the cent;
+  r101/r102 *heavily fortified* → 1.6–1.7× our pop cash; r140 *half-fortified* → 1.48×).
+  The game gives **fortified-independent cash**, confirming our `modifier-independent`
+  assumption — **CQ is the one that's off**; topper is low (stale 0.02 decay past r120).
+- **Residual ~3%** = the superceramic payout (we treat superceramic = normal ceramic; the
+  +$86 may pay a hair more than exact compensation) and/or screenshot timing — too small to
+  chase by fitting one measurement.
+- **Owner's next step (planned):** a detailed **per-round** in-game cash capture (every
+  round, no modifiers) → diff against our per-round numbers to pin that ~3% exactly. That
+  table is the oracle the runtime-extraction mod (or a drift test) pins to.
+
 ## Links
 - `docs/btd6/btd6-game-file-extraction-plan.md` — Phase 1 (models), historical.
 - `docs/btd6/btd6-gamedata-dictionary.md` § "Runtime-formula facts the dump does NOT store".


### PR DESCRIPTION
## What & why

Docs-only. Captures the outcome of today's owner-driven in-game cash investigation so it doesn't evaporate before the planned per-round verification.

**Finding:** the BTD6 cash model is **validated within ~3%** against a real in-game measurement, once three confounds are removed — **double cash** (÷2), **sandbox has no `$100+n` round bonus**, and **CHIMPS ≠ sandbox**. De-doubled pop cash ≈ $88,185 vs our model's $85,468.

It also settles the calculator spread: **CyberQuincy over-counts fortified bloons** (per-round divergence tracks fortified density exactly — r100 with no fortified matches us to the cent; fortified-heavy r101/r102 diverge 1.6–1.7×). The game gives **fortified-independent cash**, exactly as our `modifier-independent` model assumes — so CQ is the one that's off, and topper is low (stale 0.02 decay past r120).

Appended as an "Empirical validation log" to the runtime-extraction idea doc (#1391), plus a session card. Records the owner's planned per-round in-game capture as the future oracle. `check_docs --strict` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hydy3uLzrkCmqHWT2VoEKG)_