### PR TITLE
Visual card-engine migration (H2): rebase image renderers onto CardCanvas

### DIFF
--- a/.sessions/2026-06-24-card-engine-migration.md
+++ b/.sessions/2026-06-24-card-engine-migration.md
@@ -1,6 +1,7 @@
 # Session — 2026-06-24 · Visual card-engine migration (H2)
 
-> **Status:** `in-progress` — born-red card; flips to `complete` as the final step.
+> **Status:** `complete` — three image renderers rebased onto the shared card engine; full CI mirror
+> green (12256 passed, 48 skipped; black/isort/ruff/mypy clean) + arch 0 errors.
 
 **Run type:** `routine · dispatch`. **Branch:** `claude/funny-franklin-cm5vdw`.
 **Trigger:** scheduled dispatch fire, **no work order** → advance the next S1 plan slice. The S1
@@ -34,3 +35,84 @@ UX-lab views + welcome service + role-menu callers are untouched).
 
 ⚑ **Self-initiated:** yes — promoted the listed card-engine H2 polish item to a build with no
 dispatch/owner ask (Q-0172 idea→build is open; flagged here for owner review).
+
+## What changed
+
+Pure `utils/` refactor (no `services`/`core`/`cogs`/DB change; identical public signatures, so the
+welcome service + UX-lab views + role-menu view callers are untouched):
+
+- **`utils/card_render.py`** — added a pure `mix(a, b, t)` RGB-blend helper (engine home for gradient
+  math, `[0,1]`-clamped) + exported it. The engine the renderers now share.
+- **`utils/welcome_render.py`** — rebased `render_welcome_card` onto `CardCanvas` (theme `midnight`).
+  Dropped its private palette, `_initials_disc`, `_initials`, `_fit`, `_fonts`. Now uses
+  `canvas.initials_disc` / `canvas.text(max_width=…)` / `canvas.to_jpeg`.
+- **`utils/ux_patterns/image_builders.py`** — rebased `render_leaderboard_image` + `render_event_poster`
+  onto `CardCanvas`. Dropped its private palette + `_fonts`.
+- **`utils/role_menu_render.py`** — rebased `render_role_menu_card` (+ `_draw_background`) onto
+  `CardCanvas` + `mix`. Dropped its private palette, `_fonts`, `_fit`, `_mix`. The four preset styles
+  (banner/gradient/minimal/spotlight) + the per-call `accent` override are preserved.
+- **Tests** — repointed the two `test_fit_truncates_to_width` tests (welcome + role_menu) that reached
+  private `_fonts`/`_fit` onto the engine's `CardCanvas.fit`; added `test_mix_blends_and_clamps` to
+  `test_card_render.py`. All public-behaviour render tests (format markers, overflow, no-Pillow → None)
+  unchanged and green.
+
+**Net dedup:** 3 copies of the dark-blurple palette → 1 theme; `_fit` ×3 → `CardCanvas.fit`; `_fonts`
+×2 → the engine; `_mix` → `card_render.mix`; `_initials*` → `card_render.initials` + `initials_disc`.
+Exactly the Dank-Memer "one templated engine" property (#1352 north-star).
+
+**Contract preserved:** lazy PIL, `bytes | None` graceful fallback, same output format (welcome /
+leaderboard / poster = JPEG; role-menu = PNG), no-network.
+
+**Verification:** `python3.10 scripts/check_quality.py --full` → green (12256 passed, 48 skipped, 2
+xfailed; black/isort/ruff/mypy clean — one COM812/black whitespace fix on `role_menu_render`); arch
+`--mode strict` → 0 errors. Targeted: `test_card_render` / `test_welcome_render` /
+`test_role_menu_render` / `test_ux_lab_*` all pass.
+
+## Handoff — ▶ Next action (remaining H2)
+
+The renderer-dedup half of card-engine **H2** is partially shipped. Clearly-scoped remainder for a
+later dispatch (both contained, both `utils/`):
+1. **`mining_render` rebase** — deferred this run: it uses a pure-spec `build_card_spec` pattern + a
+   distinct (non-blurple) palette and per-kind row colours, so the rebase is larger/riskier than the
+   three flat renderers done here. Keep `CardSpec` pure; migrate only the pixel-push onto `CardCanvas`.
+2. **Ship the leaderboard card as a real feature** — wire `render_leaderboard_image` into
+   `leaderboard_cog` as an optional image attachment with the embed fallback (H2's "ship as a feature"
+   tail). This is light feature-wiring + likely a display toggle — confirm the surface with the owner.
+Then H3 (embed features → image cards) is the next horizon. State home: the
+[vision doc](../ideas/visual-card-engine-vision-2026-06-23.md) H2/H3.
+
+## 💡 Session idea (Q-0089)
+
+**A `check_consistency` rule (or AST test) banning a re-declared card palette / font loader outside
+`utils/card_render.py`.** This PR removed the *third* private copy of the dark-blurple palette + the
+*third* `_fit`; the engine exists precisely so there's one home, but nothing stops the next renderer
+from pasting its own `_BG = (24, 25, 31)` / `_fonts()` again (the same drift class the consistency
+linter already guards for views/select-truncation). A tiny rule — *a module under `utils/*render*` or
+`ux_patterns` that defines an RGB-tuple palette constant or a private `_fonts`/`_fit` and is **not**
+`card_render` is a finding* — would make the dedup a standing invariant, not a per-session cleanup.
+Dedup-grepped `docs/ideas/` — not already captured.
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous dispatch chain (the 2026-06-23 burst: new economy/game subsystems #1328–#1344, fishing
+polish #1329–#1356, the card engine **H1** #1349) executed prolifically and, notably, **#1349 left H2/H3
+as a clean, well-documented vision doc with named targets** — which is exactly why this session could
+pick up H2 cold in minutes. That's the workflow working as designed. **One miss it surfaced:** #1349
+shipped the engine and immediately had `welcome_render`/`image_builders` *delegate* their `_fonts` to it
+(`dejavu_fonts`) but stopped there — leaving the palette + `_fit` + the raw-PIL draw paths duplicated. A
+half-migration reads as "done" in a grep for `_fonts` but isn't; the cheap follow-through (this PR) sat
+unbooked for a day. **System improvement:** the Q-0089 idea above (a linter rule banning re-declared
+palettes/font-loaders outside the engine) would have *flagged* that half-migration the moment #1349
+merged, converting "remembered polish" into an enforced invariant — the same friction→guard reflex the
+repo already institutionalized for CI strands (#1280) and select-truncation (BUG-0017).
+
+## 📤 Run report footer
+
+- **Run type:** `routine · dispatch`
+- **PR:** #1396 (born-red → flipped complete; auto-merge armed, merges on green CI).
+- **⚑ Self-initiated:** card-engine **H2** renderer-dedup (welcome / UX-lab leaderboard+poster /
+  role-menu rebased onto `CardCanvas` + the `mix` engine helper). Promoted a listed S1 polish-tail item
+  → build with no dispatch/owner ask (Q-0172). Contained, reversible, pure `utils/`, fully tested.
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none (pure refactor; a merge auto-deploys, no data step).
+- **Bug-book:** no entries fixed/opened this run.

--- a/.sessions/2026-06-24-card-engine-migration.md
+++ b/.sessions/2026-06-24-card-engine-migration.md
@@ -1,0 +1,36 @@
+# Session — 2026-06-24 · Visual card-engine migration (H2)
+
+> **Status:** `in-progress` — born-red card; flips to `complete` as the final step.
+
+**Run type:** `routine · dispatch`. **Branch:** `claude/funny-franklin-cm5vdw`.
+**Trigger:** scheduled dispatch fire, **no work order** → advance the next S1 plan slice. The S1
+queue lists the **visual card-engine migration (§3.6 — rank/profile/leaderboard onto `card_render`,
+still plain embeds)** as a remaining polish-tail item, and the
+[card-engine vision](../ideas/visual-card-engine-vision-2026-06-23.md) **H2** is exactly "migrate
+existing renderers onto the engine … so all cards share one look and one code path."
+
+## What I'm about to do
+
+The engine (`utils/card_render.py`, `CardCanvas` + `THEMES`) shipped in #1349 (H1) and its own
+docstring names the renderers that still re-declare their own palette + font loader: `welcome_render`,
+`ux_patterns.image_builders`, `role_menu_render`. Rebase those three onto `CardCanvas` so the
+triplicated dark-blurple palette, the duplicated `_fit` (×3) / `_fonts` (×2) / `_mix` / `_initials*`
+helpers collapse to the one engine code path (the exact Dank-Memer "one templated engine" property).
+
+Plan (one cohesive low-risk pure-`utils/` PR):
+1. Add a pure `mix(a, b, t)` RGB-blend helper to `card_render` (engine home for the gradient math
+   `role_menu_render` needs) + export it.
+2. Rebase `welcome_render.render_welcome_card` onto `CardCanvas`/theme `midnight` (drop `_BG…`,
+   `_initials_disc`, `_initials`, `_fit`, `_fonts`).
+3. Rebase `image_builders.render_leaderboard_image` + `render_event_poster` onto `CardCanvas`.
+4. Rebase `role_menu_render.render_role_menu_card` onto `CardCanvas` + `mix` (drop its private
+   palette/`_fonts`/`_fit`/`_mix`); per-call `accent` stays an override.
+5. Repoint the two `test_fit_truncates_to_width` tests (welcome + role_menu) that reach private
+   `_fonts`/`_fit` onto the engine, add a `mix` test, keep every public-behaviour test green.
+
+Contract preserved throughout: lazy PIL, `bytes | None` graceful fallback, same output format
+(welcome/leaderboard/poster = JPEG; role-menu = PNG), no-network, identical signatures (so the
+UX-lab views + welcome service + role-menu callers are untouched).
+
+⚑ **Self-initiated:** yes — promoted the listed card-engine H2 polish item to a build with no
+dispatch/owner ask (Q-0172 idea→build is open; flagged here for owner review).

--- a/disbot/utils/card_render.py
+++ b/disbot/utils/card_render.py
@@ -166,6 +166,25 @@ def dejavu_fonts(size_big: int, size_small: int):  # noqa: ANN201
     return load_font((_DEJAVU_BOLD,), size_big), load_font((_DEJAVU,), size_small)
 
 
+def mix(a: RGB, b: RGB, t: float) -> RGB:
+    """Linear blend of two RGB colours at fraction *t* (0 → *a*, 1 → *b*).
+
+    Pure colour math — the one home for the per-channel lerp that gradient
+    backgrounds need (``role_menu_render`` grew it privately as ``_mix``).  *t*
+    is clamped to ``[0, 1]`` so an out-of-range fraction can never produce an
+    invalid channel value.
+    """
+    if t < 0:
+        t = 0.0
+    elif t > 1:
+        t = 1.0
+    return (
+        round(a[0] + (b[0] - a[0]) * t),
+        round(a[1] + (b[1] - a[1]) * t),
+        round(a[2] + (b[2] - a[2]) * t),
+    )
+
+
 def initials(name: str) -> str:
     """First two alphanumerics of *name*, upper-cased (``?`` if none).
 
@@ -386,6 +405,7 @@ __all__ = [
     "get_theme",
     "load_font",
     "dejavu_fonts",
+    "mix",
     "initials",
     "CardCanvas",
     "new_canvas",

--- a/disbot/utils/role_menu_render.py
+++ b/disbot/utils/role_menu_render.py
@@ -14,15 +14,7 @@ The preset *catalogue* (which styles exist + their labels) lives in
 
 from __future__ import annotations
 
-import io
-
-# Shared card palette (dark-theme friendly) — mirrors welcome_render so the two
-# card families read as one visual system.
-_BG = (24, 25, 31)
-_PANEL = (32, 34, 42)
-_TEXT = (235, 236, 240)
-_SUBTLE = (148, 155, 164)
-_DEFAULT_ACCENT = (88, 101, 242)  # blurple
+from utils.card_render import RGB, CardCanvas, get_theme, mix, new_canvas
 
 # Card geometry — a wide banner that sits above the menu embed.
 _WIDTH = 960
@@ -33,78 +25,31 @@ _HEIGHT = 240
 KNOWN_STYLES = ("banner", "gradient", "minimal", "spotlight")
 
 
-def _fonts(size_big: int, size_small: int):  # noqa: ANN202 — PIL lazy types
-    """Best-effort font pair; Pillow's default bitmap font as the fallback."""
-    from PIL import ImageFont  # lazy: optional at import time
+def _draw_background(canvas: CardCanvas, style: str, accent: RGB) -> None:
+    """Paint the card background for the chosen preset style (in place).
 
-    big: ImageFont.FreeTypeFont | ImageFont.ImageFont
-    small: ImageFont.FreeTypeFont | ImageFont.ImageFont
-    try:
-        big = ImageFont.truetype(
-            "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
-            size_big,
-        )
-        small = ImageFont.truetype(
-            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
-            size_small,
-        )
-    except Exception:  # noqa: BLE001 — font availability is environmental
-        big = ImageFont.load_default()
-        small = ImageFont.load_default()
-    return big, small
-
-
-def _fit(draw, text: str, font, max_width: int) -> str:  # noqa: ANN001
-    """Ellipsise ``text`` until it fits within ``max_width`` px (welcome_render rule)."""
-    if draw.textlength(text, font=font) <= max_width:
-        return text
-    ellipsis = "…"
-    while text and draw.textlength(text + ellipsis, font=font) > max_width:
-        text = text[:-1]
-    return (text + ellipsis) if text else ellipsis
-
-
-def _mix(
-    a: tuple[int, int, int],
-    b: tuple[int, int, int],
-    t: float,
-) -> tuple[int, int, int]:
-    """Linear blend of two RGB colours at fraction ``t`` (0 → a, 1 → b)."""
-    return (
-        round(a[0] + (b[0] - a[0]) * t),
-        round(a[1] + (b[1] - a[1]) * t),
-        round(a[2] + (b[2] - a[2]) * t),
-    )
-
-
-def _draw_background(
-    img,
-    draw,
-    style: str,
-    accent: tuple[int, int, int],
-) -> None:  # noqa: ANN001
-    """Paint the card background for the chosen preset style (in place)."""
+    Drawn through the engine's :class:`~utils.card_render.CardCanvas` (the
+    ``midnight`` skin = the dark-blurple palette this card always used) plus
+    the shared :func:`~utils.card_render.mix` blend, so the role-menu and
+    welcome cards read as one visual system off one code path.
+    """
+    draw = canvas.draw
+    t = canvas.theme
     if style == "gradient":
         # Vertical accent → dark gradient (one horizontal line per row).
-        top = _mix(accent, _BG, 0.35)
+        top = mix(accent, t.bg, 0.35)
         for y in range(_HEIGHT):
-            draw.line(
-                ((0, y), (_WIDTH, y)),
-                fill=_mix(top, _BG, y / max(1, _HEIGHT - 1)),
-            )
+            draw.line(((0, y), (_WIDTH, y)), fill=mix(top, t.bg, y / max(1, _HEIGHT - 1)))
     elif style == "spotlight":
         # Dark panel with a bold accent block down the left third.
-        draw.rectangle((0, 0, _WIDTH, _HEIGHT), fill=_PANEL)
+        draw.rectangle((0, 0, _WIDTH, _HEIGHT), fill=t.panel)
         draw.rectangle((0, 0, 18, _HEIGHT), fill=accent)
-        draw.rectangle(
-            (_WIDTH - 280, 0, _WIDTH, _HEIGHT),
-            fill=_mix(accent, _PANEL, 0.78),
-        )
+        draw.rectangle((_WIDTH - 280, 0, _WIDTH, _HEIGHT), fill=mix(accent, t.panel, 0.78))
     elif style == "minimal":
         # Flat channel-blending dark; the accent shows only as a thin underline.
-        draw.rectangle((0, 0, _WIDTH, _HEIGHT), fill=_BG)
+        draw.rectangle((0, 0, _WIDTH, _HEIGHT), fill=t.bg)
     else:  # "banner" (default) — dark panel + a left accent bar.
-        draw.rectangle((0, 0, _WIDTH, _HEIGHT), fill=_PANEL)
+        draw.rectangle((0, 0, _WIDTH, _HEIGHT), fill=t.panel)
         draw.rectangle((0, 0, 14, _HEIGHT), fill=accent)
 
 
@@ -113,7 +58,7 @@ def render_role_menu_card(
     style: str = "banner",
     title: str = "Pick your roles",
     overlay: str | None = None,
-    accent: tuple[int, int, int] | None = None,
+    accent: RGB | None = None,
 ) -> bytes | None:
     """Render a role-menu banner card → PNG bytes, or ``None`` without Pillow.
 
@@ -123,38 +68,37 @@ def render_role_menu_card(
     defaulting to blurple. Pure / no-network — callers fall back to embed-only when
     this returns ``None``.
     """
-    try:
-        from PIL import Image, ImageDraw  # lazy: degrade gracefully
-    except Exception:  # noqa: BLE001
+    canvas = new_canvas(_WIDTH, _HEIGHT, get_theme("midnight"))
+    if canvas is None:  # Pillow unavailable → caller keeps the embed fallback.
         return None
 
     style = style if style in KNOWN_STYLES else "banner"
-    rgb = accent or _DEFAULT_ACCENT
-    img = Image.new("RGB", (_WIDTH, _HEIGHT), _BG)
-    draw = ImageDraw.Draw(img)
-    _draw_background(img, draw, style, rgb)
+    rgb = accent or canvas.theme.accent
+    _draw_background(canvas, style, rgb)
 
-    big, small = _fonts(58, 30)
     # Text column: leave room for the left accent bar / block on the side styles.
     text_x = 60 if style in ("banner", "gradient") else 70
     text_max = _WIDTH - text_x - 80
-    heading = _fit(draw, title or "Pick your roles", big, text_max)
+    heading = title or "Pick your roles"
 
     if overlay:
-        sub = _fit(draw, overlay, small, text_max)
-        draw.text((text_x, 78), heading, font=big, fill=_TEXT)
-        draw.text((text_x + 2, 158), sub, font=small, fill=_SUBTLE)
+        canvas.text((text_x, 78), heading, size=58, bold=True, max_width=text_max)
+        canvas.text(
+            (text_x + 2, 158),
+            overlay,
+            size=30,
+            color=canvas.theme.subtle,
+            max_width=text_max,
+        )
     else:
         # Centre the single line vertically when there is no overlay.
-        draw.text((text_x, 96), heading, font=big, fill=_TEXT)
+        canvas.text((text_x, 96), heading, size=58, bold=True, max_width=text_max)
 
     if style == "minimal":
         # The accent is a thin underline beneath the heading rather than a panel.
-        draw.line((text_x, 170, _WIDTH - 80, 170), fill=rgb, width=4)
+        canvas.draw.line((text_x, 170, _WIDTH - 80, 170), fill=rgb, width=4)
 
-    buf = io.BytesIO()
-    img.save(buf, format="PNG")
-    return buf.getvalue()
+    return canvas.to_png()
 
 
 __all__ = ["KNOWN_STYLES", "render_role_menu_card"]

--- a/disbot/utils/role_menu_render.py
+++ b/disbot/utils/role_menu_render.py
@@ -39,12 +39,18 @@ def _draw_background(canvas: CardCanvas, style: str, accent: RGB) -> None:
         # Vertical accent → dark gradient (one horizontal line per row).
         top = mix(accent, t.bg, 0.35)
         for y in range(_HEIGHT):
-            draw.line(((0, y), (_WIDTH, y)), fill=mix(top, t.bg, y / max(1, _HEIGHT - 1)))
+            draw.line(
+                ((0, y), (_WIDTH, y)),
+                fill=mix(top, t.bg, y / max(1, _HEIGHT - 1)),
+            )
     elif style == "spotlight":
         # Dark panel with a bold accent block down the left third.
         draw.rectangle((0, 0, _WIDTH, _HEIGHT), fill=t.panel)
         draw.rectangle((0, 0, 18, _HEIGHT), fill=accent)
-        draw.rectangle((_WIDTH - 280, 0, _WIDTH, _HEIGHT), fill=mix(accent, t.panel, 0.78))
+        draw.rectangle(
+            (_WIDTH - 280, 0, _WIDTH, _HEIGHT),
+            fill=mix(accent, t.panel, 0.78),
+        )
     elif style == "minimal":
         # Flat channel-blending dark; the accent shows only as a thin underline.
         draw.rectangle((0, 0, _WIDTH, _HEIGHT), fill=t.bg)

--- a/disbot/utils/ux_patterns/image_builders.py
+++ b/disbot/utils/ux_patterns/image_builders.py
@@ -14,29 +14,16 @@ fallback), pure inputs in / bytes out.
 
 from __future__ import annotations
 
-import io
+from utils.card_render import get_theme, new_canvas
 
 # The welcome card graduated to a real feature; re-export the production
 # renderer so the UX-lab gallery previews the exact card members receive.
 from utils.welcome_render import render_welcome_card
 
-# Shared sample palette (dark-theme friendly).
-_BG = (24, 25, 31)
-_PANEL = (32, 34, 42)
-_ACCENT = (88, 101, 242)  # blurple
-_TEXT = (235, 236, 240)
-_SUBTLE = (148, 155, 164)
-_GOLD = (240, 178, 50)
-
-
-def _fonts(size_big: int, size_small: int):  # noqa: ANN202 — PIL lazy types
-    """Best-effort (bold-big, regular-small) DejaVu pair.
-
-    Delegates to the shared card engine — one font loader, not three.
-    """
-    from utils.card_render import dejavu_fonts
-
-    return dejavu_fonts(size_big, size_small)
+# Both candidate cards draw on the shared engine's "midnight" skin — the
+# dark-blurple palette these prototypes always used — so they share the one
+# palette + font loader rather than re-declaring their own.
+_THEME = "midnight"
 
 
 def render_leaderboard_image(
@@ -49,28 +36,23 @@ def render_leaderboard_image(
     ),
 ) -> bytes | None:
     """Top-N horizontal bars — the image alternative to the embed board."""
-    try:
-        from PIL import Image, ImageDraw  # lazy: degrade gracefully
-    except Exception:  # noqa: BLE001
+    canvas = new_canvas(720, 96 + 64 * len(rows), get_theme(_THEME))
+    if canvas is None:  # Pillow unavailable → caller keeps the embed fallback.
         return None
-    img = Image.new("RGB", (720, 96 + 64 * len(rows)), _BG)
-    draw = ImageDraw.Draw(img)
-    big, small = _fonts(36, 24)
-    draw.text((32, 24), "🏆 Top members", font=big, fill=_GOLD)
+    t = canvas.theme
+    canvas.text((32, 24), "🏆 Top members", size=36, bold=True, color=t.gold)
     top = rows[0][1] if rows else 1
     for i, (name, score) in enumerate(rows):
         y = 96 + i * 64
         width = int(420 * score / top)
-        draw.rounded_rectangle(
+        canvas.draw.rounded_rectangle(
             (200, y, 200 + width, y + 40),
             radius=8,
-            fill=_ACCENT if i else _GOLD,
+            fill=t.accent if i else t.gold,
         )
-        draw.text((32, y + 6), f"{i + 1}. {name}", font=small, fill=_TEXT)
-        draw.text((210 + width, y + 6), f"{score:,}", font=small, fill=_SUBTLE)
-    buf = io.BytesIO()
-    img.save(buf, format="JPEG", quality=85)
-    return buf.getvalue()
+        canvas.text((32, y + 6), f"{i + 1}. {name}", size=24)
+        canvas.text((210 + width, y + 6), f"{score:,}", size=24, color=t.subtle)
+    return canvas.to_jpeg(quality=85)
 
 
 def render_event_poster(
@@ -79,27 +61,19 @@ def render_event_poster(
     host: str = "AstroFox",
 ) -> bytes | None:
     """Event-poster candidate (the Q-0112 scheduler's visual upgrade)."""
-    try:
-        from PIL import Image, ImageDraw  # lazy: degrade gracefully
-    except Exception:  # noqa: BLE001
+    canvas = new_canvas(800, 420, get_theme(_THEME))
+    if canvas is None:  # Pillow unavailable → caller keeps the embed fallback.
         return None
-    img = Image.new("RGB", (800, 420), _PANEL)
-    draw = ImageDraw.Draw(img)
-    big, small = _fonts(52, 28)
-    draw.rectangle((0, 0, 800, 12), fill=_ACCENT)
-    draw.rectangle((0, 408, 800, 420), fill=_ACCENT)
-    draw.text((48, 96), title, font=big, fill=_TEXT)
-    draw.text((50, 190), when, font=small, fill=_GOLD)
-    draw.text((50, 240), f"Hosted by {host}", font=small, fill=_SUBTLE)
-    draw.text(
-        (50, 320),
-        "RSVP with the buttons below ✅ ❔ ❌",
-        font=small,
-        fill=_TEXT,
-    )
-    buf = io.BytesIO()
-    img.save(buf, format="JPEG", quality=85)
-    return buf.getvalue()
+    t = canvas.theme
+    # Panel-fill body (not the theme bg) with accent rails top and bottom.
+    canvas.draw.rectangle((0, 0, 800, 420), fill=t.panel)
+    canvas.draw.rectangle((0, 0, 800, 12), fill=t.accent)
+    canvas.draw.rectangle((0, 408, 800, 420), fill=t.accent)
+    canvas.text((48, 96), title, size=52, bold=True)
+    canvas.text((50, 190), when, size=28, color=t.gold)
+    canvas.text((50, 240), f"Hosted by {host}", size=28, color=t.subtle)
+    canvas.text((50, 320), "RSVP with the buttons below ✅ ❔ ❌", size=28)
+    return canvas.to_jpeg(quality=85)
 
 
 __all__ = [

--- a/disbot/utils/welcome_render.py
+++ b/disbot/utils/welcome_render.py
@@ -16,72 +16,11 @@ or fail on a CDN round-trip.  The real avatar still rides the embed thumbnail.
 
 from __future__ import annotations
 
-import io
-
-# Shared card palette (dark-theme friendly) — mirrors the Discord blurple set.
-_BG = (24, 25, 31)
-_PANEL = (32, 34, 42)
-_ACCENT = (88, 101, 242)  # blurple
-_TEXT = (235, 236, 240)
-_SUBTLE = (148, 155, 164)
-_GOLD = (240, 178, 50)
+from utils.card_render import get_theme, initials, new_canvas
 
 # Card geometry.
 _WIDTH = 960
 _HEIGHT = 360
-
-
-def _fonts(size_big: int, size_small: int):  # noqa: ANN202 — PIL lazy types
-    """Best-effort (bold-big, regular-small) DejaVu pair.
-
-    Delegates to the shared card engine so the font loader lives in exactly one
-    place (was triplicated across the renderers).
-    """
-    from utils.card_render import dejavu_fonts
-
-    return dejavu_fonts(size_big, size_small)
-
-
-def _initials_disc(
-    draw,
-    *,
-    cx: int,
-    cy: int,
-    r: int,
-    initials: str,
-    font,
-) -> None:  # noqa: ANN001
-    """The no-network avatar: accent ring + initials disc."""
-    draw.ellipse(
-        (cx - r - 6, cy - r - 6, cx + r + 6, cy + r + 6),
-        outline=_ACCENT,
-        width=6,
-    )
-    draw.ellipse((cx - r, cy - r, cx + r, cy + r), fill=_PANEL)
-    box = draw.textbbox((0, 0), initials, font=font)
-    tw, th = box[2] - box[0], box[3] - box[1]
-    draw.text((cx - tw / 2, cy - th / 2 - box[1]), initials, font=font, fill=_TEXT)
-
-
-def _initials(name: str) -> str:
-    """First two alphanumerics of the display name, upper-cased (``?`` if none)."""
-    letters = [c for c in name if c.isalnum()]
-    return ("".join(letters[:2]) or "?").upper()
-
-
-def _fit(draw, text: str, font, max_width: int) -> str:  # noqa: ANN001
-    """Truncate ``text`` with an ellipsis until it fits within ``max_width`` px.
-
-    Discord names and server names are unbounded, so a long one would run off
-    the right edge of the fixed-width card.  This clamps any string to the
-    drawable area, ellipsising the overflow.
-    """
-    if draw.textlength(text, font=font) <= max_width:
-        return text
-    ellipsis = "…"
-    while text and draw.textlength(text + ellipsis, font=font) > max_width:
-        text = text[:-1]
-    return (text + ellipsis) if text else ellipsis
 
 
 def render_welcome_card(
@@ -94,39 +33,40 @@ def render_welcome_card(
     Pure / no-network; returns JPEG bytes, or ``None`` when Pillow is absent so
     callers fall back to the embed-only greeting.  The defaults make it a
     self-contained gallery sample (the UX-lab preview calls it bare).
+
+    Drawn on the shared :class:`utils.card_render.CardCanvas` (theme
+    ``midnight`` — the dark-blurple palette this card always used), so the
+    palette, font loader, width-fit and initials-disc primitives are the one
+    engine code path, not private copies.
     """
-    try:
-        from PIL import Image, ImageDraw  # lazy: degrade gracefully
-    except Exception:  # noqa: BLE001
+    canvas = new_canvas(_WIDTH, _HEIGHT, get_theme("midnight"))
+    if canvas is None:  # Pillow unavailable → caller keeps the embed fallback.
         return None
-    img = Image.new("RGB", (_WIDTH, _HEIGHT), _BG)
-    draw = ImageDraw.Draw(img)
-    big, small = _fonts(56, 30)
-    _initials_disc(
-        draw,
-        cx=180,
-        cy=180,
-        r=96,
-        initials=_initials(member_name),
-        font=big,
-    )
+    canvas.initials_disc((180, 180), 96, initials(member_name), size=56)
     # Text column: x=340 to the right margin — clamp both lines so an unbounded
     # member/server name can never run off the card edge.
     text_x = 340
     text_max = _WIDTH - text_x - 60
-    greeting = _fit(draw, f"Welcome, {member_name}!", big, text_max)
-    subtitle = _fit(
-        draw,
-        f"You are member #{member_number:,} of {server_name}",
-        small,
-        text_max,
+    canvas.text(
+        (text_x, 110),
+        f"Welcome, {member_name}!",
+        size=56,
+        bold=True,
+        max_width=text_max,
     )
-    draw.text((text_x, 110), greeting, font=big, fill=_TEXT)
-    draw.text((text_x + 2, 196), subtitle, font=small, fill=_SUBTLE)
-    draw.line((text_x, 260, _WIDTH - 60, 260), fill=_ACCENT, width=3)
-    buf = io.BytesIO()
-    img.save(buf, format="JPEG", quality=85)
-    return buf.getvalue()
+    canvas.text(
+        (text_x + 2, 196),
+        f"You are member #{member_number:,} of {server_name}",
+        size=30,
+        color=canvas.theme.subtle,
+        max_width=text_max,
+    )
+    canvas.draw.line(
+        (text_x, 260, _WIDTH - 60, 260),
+        fill=canvas.theme.accent,
+        width=3,
+    )
+    return canvas.to_jpeg(quality=85)
 
 
 __all__ = ["render_welcome_card"]

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -61,8 +61,12 @@
     `HubChildButton` (#1371/#1373); `views/navigation.py` `attach_standard_nav` (#1382).
   - **▶ Remaining (optional polish tail, not blocking):** the setup-wizard **per-section walk** (fleet
     unit U10 — confirm every *manual* section yields a real op / honest link-only; the AI-describe side
-    is done) · the **visual card-engine migration** (§3.6 — rank/profile/leaderboard onto `card_render`,
-    still plain embeds) · the `channel-deployed-component` roles primitive (idea, not yet built).
+    is done) · the **visual card-engine migration** — engine **H2** *renderer-dedup* half **🟡 partially
+    shipped (welcome / UX-lab leaderboard+poster / role-menu rebased onto `CardCanvas`, 2026-06-24
+    dispatch run)**; remaining is `mining_render` rebase + leaderboard-as-real-feature (H2) and the
+    **H3** *embed-feature → image-card* move (rank/profile/leaderboard, still plain embeds) —
+    [vision](../ideas/visual-card-engine-vision-2026-06-23.md) · the `channel-deployed-component` roles
+    primitive (idea, not yet built).
 - **Fishing follow-ups** (turn-key, on the bait/venue seam) — *(bait speed knob ✅ #1337, sell-value
   re-tune ✅ #1304, bait-crafting ✅ #1338, and the **⛵ boat/deepwater venue** ✅ PR #1340 — shore↔
   deepwater toggle + boat-only species + tougher deep minigame — are all done)* — remaining:

--- a/docs/ideas/visual-card-engine-vision-2026-06-23.md
+++ b/docs/ideas/visual-card-engine-vision-2026-06-23.md
@@ -72,6 +72,13 @@ they'd envy. The four moves:
 - **H2 — Migrate existing renderers onto the engine.** Re-base `mining_render` /
   `welcome_render` / the UX-lab leaderboard + event-poster prototypes on `CardCanvas` so all cards
   share one look and one code path; ship the leaderboard card as a real feature.
+  **🟡 Partially shipped (2026-06-24, dispatch run):** `welcome_render`, the UX-lab
+  `render_leaderboard_image` / `render_event_poster`, **and** `role_menu_render` are now rebased onto
+  `CardCanvas` (the triplicated dark-blurple palette + the duplicated `_fit`/`_fonts`/`_mix`/`_initials*`
+  helpers collapsed onto one engine path; a pure `card_render.mix()` blend helper added for gradients).
+  **Remaining H2 work:** `mining_render` (its pure-spec `build_card_spec` pattern is a larger,
+  riskier rebase, deferred) and **shipping the leaderboard card as a real feature** (wiring
+  `render_leaderboard_image` into `leaderboard_cog` as an optional attachment with embed fallback).
 - **H3 — Skinnable feature cards.** A fishing/collection **season card** (the FOOTONCLASH analogue)
   and a cross-game **world identity card** on themed skin packs; "new season = new `Theme` + asset
   pack", no layout code.

--- a/docs/owner/claims/claude-funny-franklin-cm5vdw.md
+++ b/docs/owner/claims/claude-funny-franklin-cm5vdw.md
@@ -1,0 +1,4 @@
+- `claude/funny-franklin-cm5vdw` · visual card-engine migration (H2): rebase `welcome_render` ·
+  `ux_patterns/image_builders` · `role_menu_render` onto `utils/card_render.CardCanvas` (drop the
+  triplicated palettes/`_fit`/`_fonts`/`_mix`) · area: `disbot/utils/*render*` + `card_render` +
+  their tests · 2026-06-24

--- a/docs/owner/claims/claude-funny-franklin-cm5vdw.md
+++ b/docs/owner/claims/claude-funny-franklin-cm5vdw.md
@@ -1,4 +1,0 @@
-- `claude/funny-franklin-cm5vdw` · visual card-engine migration (H2): rebase `welcome_render` ·
-  `ux_patterns/image_builders` · `role_menu_render` onto `utils/card_render.CardCanvas` (drop the
-  triplicated palettes/`_fit`/`_fonts`/`_mix`) · area: `disbot/utils/*render*` + `card_render` +
-  their tests · 2026-06-24

--- a/tests/unit/utils/test_card_render.py
+++ b/tests/unit/utils/test_card_render.py
@@ -29,6 +29,19 @@ def test_initials_falls_back_to_question_mark():
     assert card_render.initials("") == "?"
 
 
+def test_mix_blends_and_clamps():
+    black, white = (0, 0, 0), (255, 255, 255)
+    # Endpoints are exact; the midpoint rounds per channel.
+    assert card_render.mix(black, white, 0.0) == black
+    assert card_render.mix(black, white, 1.0) == white
+    assert card_render.mix(black, white, 0.5) == (128, 128, 128)
+    # Out-of-range fractions clamp to [0, 1] — never an invalid channel value.
+    assert card_render.mix(black, white, -3.0) == black
+    assert card_render.mix(black, white, 9.0) == white
+    # Asymmetric channels blend independently.
+    assert card_render.mix((10, 20, 30), (30, 60, 90), 0.5) == (20, 40, 60)
+
+
 def test_get_theme_resolves_known_and_falls_back():
     assert card_render.get_theme("ember").name == "ember"
     # Unknown / None never raises — it returns the default skin.

--- a/tests/unit/utils/test_role_menu_render.py
+++ b/tests/unit/utils/test_role_menu_render.py
@@ -84,11 +84,14 @@ def test_render_returns_none_without_pillow(monkeypatch):
 
 
 def test_fit_truncates_to_width():
-    from PIL import Image, ImageDraw
+    """The migrated renderer clamps overflow via the shared engine's
+    ``CardCanvas.fit`` (the private ``_fit`` copy is gone)."""
+    from utils.card_render import get_theme, new_canvas
 
-    draw = ImageDraw.Draw(Image.new("RGB", (10, 10)))
-    big, _ = role_menu_render._fonts(58, 30)
-    fitted = role_menu_render._fit(draw, "Z" * 200, big, 400)
+    canvas = new_canvas(10, 10, get_theme("midnight"))
+    assert canvas is not None
+    font = canvas.font(58, bold=True)
+    fitted = canvas.fit("Z" * 200, font, 400)
     assert fitted.endswith("…")
-    assert draw.textlength(fitted, font=big) <= 400
-    assert role_menu_render._fit(draw, "Hi", big, 400) == "Hi"
+    assert canvas.draw.textlength(fitted, font=font) <= 400
+    assert canvas.fit("Hi", font, 400) == "Hi"

--- a/tests/unit/utils/test_welcome_render.py
+++ b/tests/unit/utils/test_welcome_render.py
@@ -58,17 +58,19 @@ def test_render_handles_overlong_names_without_error():
 
 
 def test_fit_truncates_to_width():
-    """The width-clamp helper ellipsises text that exceeds the budget."""
-    from PIL import Image, ImageDraw
+    """The migrated renderer ellipsises overflow via the shared engine's
+    ``CardCanvas.fit`` (the private ``_fit`` copy is gone)."""
+    from utils.card_render import get_theme, new_canvas
 
-    draw = ImageDraw.Draw(Image.new("RGB", (10, 10)))
-    big, _ = welcome_render._fonts(56, 30)
+    canvas = new_canvas(10, 10, get_theme("midnight"))
+    assert canvas is not None
+    font = canvas.font(56, bold=True)
     long = "Welcome, " + "Z" * 100 + "!"
-    fitted = welcome_render._fit(draw, long, big, 400)
+    fitted = canvas.fit(long, font, 400)
     assert fitted.endswith("…")
-    assert draw.textlength(fitted, font=big) <= 400
+    assert canvas.draw.textlength(fitted, font=font) <= 400
     # A short string is returned unchanged (no needless ellipsis).
-    assert welcome_render._fit(draw, "Hi!", big, 400) == "Hi!"
+    assert canvas.fit("Hi!", font, 400) == "Hi!"
 
 
 def test_gallery_reexports_the_production_renderer():


### PR DESCRIPTION
## What

H2 of the [visual card-engine vision](../blob/main/docs/ideas/visual-card-engine-vision-2026-06-23.md) — *"migrate existing renderers onto the engine so all cards share one look and one code path."* Rebases the three image renderers the engine's own docstring names as still re-declaring their own palette + font loader onto `utils/card_render.CardCanvas`:

- `utils/welcome_render.py` — the join greeting card
- `utils/ux_patterns/image_builders.py` — the UX-lab leaderboard + event-poster prototypes
- `utils/role_menu_render.py` — the role-menu banner card

This collapses the triplicated dark-blurple palette, the duplicated `_fit` (×3) / `_fonts` (×2) / `_mix` / `_initials*` helpers onto the one engine code path — the Dank-Memer "one templated engine, re-skinned per season" property, in code.

## Why

Listed on the S1 polish-tail queue (`docs/current-state/S1-bot.md` → "the visual card-engine migration (§3.6 … onto `card_render`)"). Advances the #1352 competitive-positioning north-star (out-visual competitors) by unifying every card on one re-skinnable engine.

## Contract preserved

Lazy PIL, `bytes | None` graceful fallback, same output format (welcome/leaderboard/poster = JPEG; role-menu = PNG), no-network, **identical public signatures** — so the UX-lab views, the welcome service, and the role-menu callers are untouched.

## Scope

Pure `utils/` refactor + tests. No `services`/`core`/`cogs` changes, no DB, no runtime behaviour change beyond pixel-identical-intent rendering.

**Self-initiated** (Q-0172): promoted the listed H2 polish item to a build with no dispatch/owner ask — flagged for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3LtH6HubrkjgcNCrmpjdA)_