### PR TITLE
Card-engine consistency guard: ban re-declared engine helpers in utils/ renderers

### DIFF
--- a/.sessions/2026-06-24-card-engine-guard.md
+++ b/.sessions/2026-06-24-card-engine-guard.md
@@ -22,3 +22,58 @@ the 2026-06-24 finding that `mining_render` uses *no fonts* + a specialized rari
 it is a **visual redesign for the owner**, not a clean dedup.
 
 ⚑ **Self-initiated:** yes — building slice-1's own Q-0089 idea with no dispatch/owner ask (Q-0172).
+
+## What changed
+
+Tooling + tests + one docs note (no `disbot/` runtime change):
+
+- **`scripts/check_consistency.py`** — new **Rule 5** `card_engine_helper_duplication` (warn-first,
+  `roots=("utils/",)`): flags an image-render module (one importing Pillow or `card_render`) that
+  defines a private `_fonts`/`_fit`/`_mix`/`_initials`/`_initials_disc` — the helpers the engine
+  already provides. `card_render.py` exempt; `_imports_pillow_or_engine` guard keeps an unrelated
+  `utils/` `_fit`/`_mix` math helper out of scope; allowlistable via `consistency_exceptions.yml`.
+  Registered in `RULES` with a comment recording its #1396 provenance + graduation path.
+- **`tests/unit/scripts/test_check_consistency.py`** — +6 tests (flags a dup; clean migrated renderer;
+  non-render out-of-scope; engine exempt; allowlist suppresses; registry/scope/severity). 54 pass.
+- **`docs/ideas/visual-card-engine-vision-2026-06-23.md`** — corrected the `mining_render` "remaining
+  H2" note: it uses no fonts + a specialized rarity palette, so its rebase is a **visual redesign for
+  the owner**, not a clean dedup; and noted the dedup is now CI-guarded by this rule.
+
+**Verification:** Rule 5 runs **clean on the post-#1396 tree** (0 findings; `--graduation` shows it
+warn-only, `findings=0`); `check_consistency --mode strict` exits 0; `check_quality.py --check-only`
+(CI scope) green; the full mirror confirmed green before flip. The bare-`ruff` "104 errors" seen mid-run
+were default-ruleset `S101` asserts in the test file + `COM812` that CI's scope/config excludes — the
+canonical `check_quality` is the authority and is green.
+
+## 💡 Session idea (Q-0089)
+
+**A `--graduation`-driven nudge in the dispatch close-out: surface consistency rules that are
+`ELIGIBLE` (clean across N sessions) so an empty-fire run graduates one warn→error instead of letting
+proven rules sit warn-only forever.** This session *added* a warn-only rule; the symmetric value is a
+cheap standing task that *graduates* the ones that have earned it (the soak is the only gate left for
+`back_button`-class rules). A one-line `check_consistency.py --graduation --eligible-only` in the
+session-close skill would make "which guard is ready to bite?" a single hop. Dedup-grepped
+`docs/ideas/` — the `--graduation` tracker exists (#1060) but auto-graduation nudging isn't captured.
+
+## ⟲ Previous-session review (Q-0102)
+
+Reviewing **slice 1 of this same fire (#1396)**: it shipped a clean, well-verified migration *and*
+booked its follow-through as a Q-0089 idea rather than letting it evaporate — which is exactly why this
+slice existed to build. The one thing slice 1 got *right* that's worth naming: it **declined** the
+riskier H2 remainder (`mining_render`) instead of forcing a second slice to hit "2–3 slices", then this
+slice investigated `mining_render` concretely and *proved* the deferral correct (no fonts + specialized
+palette → visual redesign, not dedup). That's the completion-bias and the safety-brake resolving the
+right way — ship the contained guard, route the redesign to the owner. **System note:** the pattern
+"slice N generates the idea, slice N+1 builds it, within one fire" is the self-improvement loop working
+at sub-session granularity — worth keeping as an explicit dispatch habit (build your own surfaced idea
+when it's contained and the budget's there).
+
+## 📤 Run report footer
+
+- **Run type:** `routine · dispatch`
+- **PR:** #1397 (born-red → flipped complete; auto-merge armed, merges on green CI).
+- **⚑ Self-initiated:** the `card_engine_helper_duplication` consistency rule — built slice-1's own
+  Q-0089 idea with no dispatch/owner ask (Q-0172). Warn-first, contained, reversible, tested.
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none.
+- **Bug-book:** no entries fixed/opened this run.

--- a/.sessions/2026-06-24-card-engine-guard.md
+++ b/.sessions/2026-06-24-card-engine-guard.md
@@ -1,0 +1,24 @@
+# Session — 2026-06-24 · Card-engine consistency guard (Rule 5)
+
+> **Status:** `in-progress` — born-red card; flips to `complete` as the final step.
+
+**Run type:** `routine · dispatch`. **Branch:** `claude/card-engine-guard`.
+**Trigger:** continuation of this dispatch fire — second slice. The first slice (PR #1396) shipped
+the card-engine **H2** renderer migration and surfaced its own Q-0089 idea: *institutionalize the
+dedup as a CI guard so a renderer can't re-grow the triplication.* Building that idea now
+(idea→build is open, Q-0172).
+
+## What I'm about to do
+
+Add **Rule 5** (`card_engine_helper_duplication`) to `scripts/check_consistency.py`: an image-render
+module under `utils/` (one importing Pillow or `card_render`) that re-declares a private
+`_fonts`/`_fit`/`_mix`/`_initials`/`_initials_disc` — the exact helpers the shared engine provides —
+is flagged. `card_render.py` itself is exempt; warn-first (Q-0105). It runs clean on the post-#1396
+tree (0 findings, verified), so it codifies the just-shipped dedup as a standing invariant — the same
+friction→guard reflex behind #1280 / #1297 / BUG-0017.
+
+Also folds in a **docs de-stale**: the vision doc's `mining_render` "remaining H2" note, corrected with
+the 2026-06-24 finding that `mining_render` uses *no fonts* + a specialized rarity palette, so rebasing
+it is a **visual redesign for the owner**, not a clean dedup.
+
+⚑ **Self-initiated:** yes — building slice-1's own Q-0089 idea with no dispatch/owner ask (Q-0172).

--- a/.sessions/2026-06-24-card-engine-guard.md
+++ b/.sessions/2026-06-24-card-engine-guard.md
@@ -1,6 +1,7 @@
 # Session — 2026-06-24 · Card-engine consistency guard (Rule 5)
 
-> **Status:** `in-progress` — born-red card; flips to `complete` as the final step.
+> **Status:** `complete` — Rule 5 added, runs clean on the post-#1396 tree; full CI mirror green
+> (12262 passed, 48 skipped; black/isort/ruff/mypy + check_consistency/check_docs clean).
 
 **Run type:** `routine · dispatch`. **Branch:** `claude/card-engine-guard`.
 **Trigger:** continuation of this dispatch fire — second slice. The first slice (PR #1396) shipped

--- a/docs/ideas/visual-card-engine-vision-2026-06-23.md
+++ b/docs/ideas/visual-card-engine-vision-2026-06-23.md
@@ -76,9 +76,15 @@ they'd envy. The four moves:
   `render_leaderboard_image` / `render_event_poster`, **and** `role_menu_render` are now rebased onto
   `CardCanvas` (the triplicated dark-blurple palette + the duplicated `_fit`/`_fonts`/`_mix`/`_initials*`
   helpers collapsed onto one engine path; a pure `card_render.mix()` blend helper added for gradients).
-  **Remaining H2 work:** `mining_render` (its pure-spec `build_card_spec` pattern is a larger,
-  riskier rebase, deferred) and **shipping the leaderboard card as a real feature** (wiring
-  `render_leaderboard_image` into `leaderboard_cog` as an optional attachment with embed fallback).
+  **Remaining H2 work:** `mining_render` and **shipping the leaderboard card as a real feature**
+  (wiring `render_leaderboard_image` into `leaderboard_cog` as an optional attachment with embed
+  fallback). **Note on `mining_render` (2026-06-24 finding):** it is **not** a clean dedup rebase — it
+  uses **no fonts at all** (every `draw.text` uses Pillow's default bitmap font, with hardcoded
+  `8 * len(text)` width math) and a deliberately *specialized* rarity palette (`_KIND_COLOR`), so
+  moving it onto `CardCanvas` would *change the card's look* (loaded DejaVu fonts, new metrics) and
+  require re-tuning the layout — a **visual redesign decision for the owner**, not a mechanical rebase.
+  The dedup invariant is now CI-guarded by the `card_engine_helper_duplication` consistency rule (PR
+  after #1396) so no renderer can re-grow the triplication.
 - **H3 — Skinnable feature cards.** A fishing/collection **season card** (the FOOTONCLASH analogue)
   and a cross-game **world identity card** on themed skin packs; "new season = new `Theme` + asset
   pack", no layout code.

--- a/docs/owner/claims/claude-card-engine-guard.md
+++ b/docs/owner/claims/claude-card-engine-guard.md
@@ -1,0 +1,4 @@
+- `claude/card-engine-guard` · card-engine consistency guard: add `check_consistency.py` Rule 5
+  (`card_engine_helper_duplication`) banning private `_fonts`/`_fit`/`_mix`/`_initials*` in
+  `utils/` image renderers outside `card_render` · area: `scripts/check_consistency.py` + its tests +
+  vision-doc de-stale · 2026-06-24

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -784,6 +784,92 @@ def rule_select_option_truncation(
 
 
 # ---------------------------------------------------------------------------
+# Rule 5 — card-engine helper duplication
+# ---------------------------------------------------------------------------
+
+# The private helper names the shared ``utils/card_render.py`` engine already
+# provides (``dejavu_fonts``/``load_font``, ``CardCanvas.fit``, ``mix``,
+# ``initials``/``CardCanvas.initials_disc``).  An image renderer that re-declares
+# one of these is re-introducing the triplication the engine exists to remove.
+_ENGINE_HELPERS = frozenset({"_fonts", "_fit", "_mix", "_initials", "_initials_disc"})
+
+
+def _imports_pillow_or_engine(tree: ast.Module) -> bool:
+    """True if the module imports Pillow or the shared card engine.
+
+    Scopes the rule to *image-render* modules — a ``_fit``/``_mix`` in some
+    unrelated ``utils/`` math helper is not the engine-duplication class.  Walks
+    the whole tree so a lazy function-body ``from PIL import ...`` (the renderers'
+    graceful-degradation idiom) still counts.
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if node.module.startswith("PIL") or "card_render" in node.module:
+                return True
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith("PIL") or "card_render" in alias.name:
+                    return True
+    return False
+
+
+def rule_card_engine_helper_duplication(
+    files: list[Path],
+    exceptions: dict,
+    roots: tuple[str, ...] = ("utils/",),
+) -> list[Finding]:
+    """Flag an image renderer that re-declares an engine-provided helper.
+
+    The shared ``utils/card_render.py`` engine owns the card primitives.  Before
+    the H2 migration (PR #1396) the dark-blurple palette + a ``_fonts``/``_fit``
+    copy lived in *three* renderers (``welcome_render`` / ``ux_patterns.
+    image_builders`` / ``role_menu_render``); the engine exists so there is one
+    home.  An image-render module (one importing Pillow or the engine) that
+    defines its own ``_fonts``/``_fit``/``_mix``/``_initials``/``_initials_disc``
+    is re-growing that drift class — import the engine instead.
+
+    Warn-only (Q-0105 — graduate once it has stayed clean across a few sessions).
+    ``card_render.py`` itself is exempt (it *is* the home; its primitives are the
+    public ``mix``/``initials``/``load_font``, not these private names anyway).  A
+    genuinely engine-independent helper can be allowlisted in
+    ``consistency_exceptions.yml``.
+    """
+    cfg = exceptions.get("card_engine_helper_duplication", {})
+    findings: list[Finding] = []
+
+    for filepath, rel, tree in _iter_parsed(files, roots):
+        if rel.replace("\\", "/").endswith("utils/card_render.py"):
+            continue  # the engine is the one legitimate home
+        if not _imports_pillow_or_engine(tree):
+            continue
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name in _ENGINE_HELPERS
+                and not _is_allowlisted(rel, node.name, cfg)
+            ):
+                findings.append(
+                    Finding(
+                        file=filepath,
+                        line=node.lineno,
+                        rule="card_engine_helper_duplication",
+                        qualname=node.name,
+                        message=(
+                            f"`{node.name}` re-declares a card-engine primitive — "
+                            "import it from `utils.card_render` (`dejavu_fonts`/"
+                            "`load_font`, `CardCanvas.fit`, `mix`, `initials`/"
+                            "`CardCanvas.initials_disc`) instead of a private copy "
+                            "(the pre-#1396 triplication class), or allowlist a "
+                            "genuinely engine-independent helper in "
+                            "consistency_exceptions.yml"
+                        ),
+                    ),
+                )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
 # Rule registry — add a (name, fn) entry per future rule
 # ---------------------------------------------------------------------------
 
@@ -853,6 +939,19 @@ RULES: list[Rule] = [
         "select-building views that front-truncate a collection instead of paginating",
         severity="error",
         roots=("views/", "cogs/"),
+    ),
+    # Rule 5 scans ``utils/`` (where the image renderers live, not views/cogs).
+    # Warn-first (Q-0105): added 2026-06-24 alongside the H2 card-engine migration
+    # (PR #1396) that removed the third private palette + ``_fit`` copy — this rule
+    # institutionalizes that dedup so a renderer can't re-grow the triplication.
+    # It runs clean on the post-#1396 tree (0 findings); graduate to ``error``
+    # once it has stayed quiet across a few sessions (the edit_in_place pattern).
+    Rule(
+        "card_engine_helper_duplication",
+        rule_card_engine_helper_duplication,
+        "image renderers re-declaring an engine helper (_fonts/_fit/_mix/_initials)",
+        severity="warning",
+        roots=("utils/",),
     ),
 ]
 

--- a/tests/unit/scripts/test_check_consistency.py
+++ b/tests/unit/scripts/test_check_consistency.py
@@ -188,9 +188,10 @@ def test_real_tree_produces_no_graduated_rule_errors(mod):
     """
     findings = mod.run_checks(mod._all_files(), mod._load_exceptions())
     errors = [f for f in findings if f.severity == "error"]
-    assert errors == [], (
-        "graduated consistency rule(s) flagged the live tree: "
-        + "; ".join(f.display(mod.REPO_ROOT) for f in errors)
+    assert (
+        errors == []
+    ), "graduated consistency rule(s) flagged the live tree: " + "; ".join(
+        f.display(mod.REPO_ROOT) for f in errors
     )
 
 
@@ -199,7 +200,12 @@ def test_graduated_rules_carry_error_severity(mod):
     ultracode consolidation fleet (#1375) cleared the edit_in_place backlog and
     graduated the last warn-only rule."""
     by_name = {r.name: r for r in mod.RULES}
-    for name in ("edit_in_place", "back_button", "panel_base_class", "select_option_truncation"):
+    for name in (
+        "edit_in_place",
+        "back_button",
+        "panel_base_class",
+        "select_option_truncation",
+    ):
         assert by_name[name].severity == "error", f"{name} should be graduated"
         # A graduated rule carries no leftover blocker note.
         assert by_name[name].graduation_blocker == ""
@@ -398,7 +404,9 @@ def test_back_subsystem_panel_with_auto_nav_is_clean(mod, tmp_path, monkeypatch)
     assert _back_findings(mod, tmp_path, monkeypatch, _HUB_SUBSYSTEM_AUTO_NAV) == []
 
 
-def test_back_flags_subsystem_panel_that_opts_out_of_auto_nav(mod, tmp_path, monkeypatch):
+def test_back_flags_subsystem_panel_that_opts_out_of_auto_nav(
+    mod, tmp_path, monkeypatch
+):
     """STANDARD_NAV = False opts out of auto-nav, so such a panel genuinely has
     no back affordance and must still be flagged.
     """
@@ -480,9 +488,7 @@ def test_base_arch_exempted_paths_are_allowlisted(mod, tmp_path, monkeypatch):
     # specialized-lifecycle path exemptions (canonical_helpers.yaml §
     # base_view.exemptions) — the consistency rule must not re-flag them (Q-0120).
     for rel in ("views/ai/policy/chooser.py", "views/games/deathmatch_panel.py"):
-        assert (
-            _base_findings(mod, tmp_path, monkeypatch, _DIRECT_VIEW, rel=rel) == []
-        )
+        assert _base_findings(mod, tmp_path, monkeypatch, _DIRECT_VIEW, rel=rel) == []
 
 
 def test_base_framework_home_is_allowlisted(mod, tmp_path, monkeypatch):
@@ -771,7 +777,9 @@ def test_panel_base_class_cog_scope_flags_direct_view(mod, tmp_path, monkeypatch
     assert findings[0].qualname == "PickerView"
 
 
-def test_select_option_truncation_cog_scope_flags_truncation(mod, tmp_path, monkeypatch):
+def test_select_option_truncation_cog_scope_flags_truncation(
+    mod, tmp_path, monkeypatch
+):
     """With ``cogs/`` in scope, a cog-layer ``[:25]`` select truncation IS flagged
     (the BUG-0017 / #1040 class living in the cog layer)."""
     _write(mod, tmp_path, monkeypatch, "cogs/widget_cog.py", _TRUNCATES)
@@ -785,7 +793,9 @@ def test_select_option_truncation_cog_scope_flags_truncation(mod, tmp_path, monk
 def test_select_option_truncation_default_scope_skips_cogs(mod, tmp_path, monkeypatch):
     """The default ``views/`` scope leaves a cog-layer truncation unflagged."""
     _write(mod, tmp_path, monkeypatch, "cogs/widget_cog.py", _TRUNCATES)
-    assert mod.rule_select_option_truncation([tmp_path / "cogs/widget_cog.py"], {}) == []
+    assert (
+        mod.rule_select_option_truncation([tmp_path / "cogs/widget_cog.py"], {}) == []
+    )
 
 
 def test_registry_scopes_rules_3_and_4_to_cogs(mod):
@@ -809,3 +819,97 @@ def test_all_files_includes_the_cog_layer(mod):
     rels = {str(f.relative_to(mod.DISBOT_ROOT)) for f in files}
     assert any(r.startswith("cogs/") for r in rels)
     assert any(r.startswith("views/") for r in rels)
+
+
+# ---------------------------------------------------------------------------
+# Rule 5 — card-engine helper duplication
+# ---------------------------------------------------------------------------
+
+# An image-render module (imports Pillow, lazy) that re-declares the engine's
+# private `_fonts` helper — the pre-#1396 triplication class the rule guards.
+_RENDER_DUP = """\
+from __future__ import annotations
+
+
+def _fonts(size_big, size_small):
+    from PIL import ImageFont
+
+    return ImageFont.load_default(), ImageFont.load_default()
+
+
+def render_thing():
+    return _fonts(40, 20)
+"""
+
+# Same renderer, migrated: imports the engine, no private helper (clean).
+_RENDER_CLEAN = """\
+from __future__ import annotations
+
+from utils.card_render import get_theme, new_canvas
+
+
+def render_thing():
+    canvas = new_canvas(100, 50, get_theme("midnight"))
+    return canvas.to_png() if canvas else None
+"""
+
+# A non-render utils module that happens to define `_fit` but imports neither
+# Pillow nor the engine — out of scope (not the duplication class).
+_NON_RENDER = """\
+from __future__ import annotations
+
+
+def _fit(model, data):
+    return model
+"""
+
+
+def _card_findings(mod, tmp_path, monkeypatch, src, *, rel="utils/thing_render.py"):
+    f = _write(mod, tmp_path, monkeypatch, rel, src)
+    return mod.rule_card_engine_helper_duplication([f], {}, ("utils/",))
+
+
+def test_flags_renderer_redeclaring_an_engine_helper(mod, tmp_path, monkeypatch):
+    findings = _card_findings(mod, tmp_path, monkeypatch, _RENDER_DUP)
+    assert len(findings) == 1
+    assert findings[0].rule == "card_engine_helper_duplication"
+    assert findings[0].qualname == "_fonts"
+    assert findings[0].severity == "warning"
+
+
+def test_migrated_renderer_using_the_engine_is_clean(mod, tmp_path, monkeypatch):
+    assert _card_findings(mod, tmp_path, monkeypatch, _RENDER_CLEAN) == []
+
+
+def test_non_render_utils_helper_is_out_of_scope(mod, tmp_path, monkeypatch):
+    # `_fit` in a module importing neither Pillow nor the engine is not the
+    # card-engine-duplication class — no false positive.
+    assert _card_findings(mod, tmp_path, monkeypatch, _NON_RENDER) == []
+
+
+def test_card_render_engine_itself_is_exempt(mod, tmp_path, monkeypatch):
+    # The engine is the one legitimate home; a private helper there is never flagged.
+    findings = _card_findings(
+        mod, tmp_path, monkeypatch, _RENDER_DUP, rel="utils/card_render.py"
+    )
+    assert findings == []
+
+
+def test_allowlist_suppresses_a_genuine_independent_helper(mod, tmp_path, monkeypatch):
+    f = _write(mod, tmp_path, monkeypatch, "utils/thing_render.py", _RENDER_DUP)
+    cfg = {
+        "card_engine_helper_duplication": {
+            "exceptions": [
+                {"pattern": "utils/thing_render.py::_fonts", "reason": "bespoke"},
+            ],
+        },
+    }
+    assert mod.rule_card_engine_helper_duplication([f], cfg, ("utils/",)) == []
+
+
+def test_rule_5_is_registered_and_scoped_to_utils(mod):
+    by_name = {r.name: r for r in mod.RULES}
+    assert "card_engine_helper_duplication" in by_name
+    rule = by_name["card_engine_helper_duplication"]
+    assert rule.roots == ("utils/",)
+    assert rule.severity == "warning"  # warn-first (Q-0105)


### PR DESCRIPTION
## What

Adds **Rule 5** (`card_engine_helper_duplication`) to `scripts/check_consistency.py` — the UX/pattern linter. An image-render module under `utils/` (one importing Pillow or `card_render`) that re-declares a private `_fonts` / `_fit` / `_mix` / `_initials` / `_initials_disc` — the exact primitives the shared `utils/card_render.py` engine provides — is flagged and told to import the engine instead.

## Why

The H2 migration (PR #1396, just merged) removed the **third** private copy of the dark-blurple palette + `_fit`/`_fonts` from the image renderers. The engine exists so there's one home — but nothing stopped the next renderer from pasting its own `_BG = (24,25,31)` / `_fonts()` again (the same drift class that produced the half-migration #1396 cleaned up: #1349 deduped the font loader but left the palette + `_fit` triplicated for a day). This rule makes the dedup a **standing invariant**, not a per-session cleanup — the friction→guard reflex the repo already institutionalized for CI strands (#1280), help-reachability (#1297), and select-truncation (BUG-0017).

This is slice-1's own Q-0089 session idea, built (idea→build is open, Q-0172).

## Behaviour

- **Warn-first** (Q-0105) — never fails CI yet; graduates to `error` once it stays clean across a few sessions (the `edit_in_place` discipline).
- Runs **clean on the post-#1396 tree** (0 findings, verified) — it codifies the just-shipped state.
- Scoped to `utils/` (where the renderers live), guarded to *image-render* modules (imports Pillow/engine) so an unrelated `_fit`/`_mix` math helper isn't a false positive. `card_render.py` itself is exempt; allowlistable in `consistency_exceptions.yml`.

## Also

De-stales the vision doc's `mining_render` "remaining H2" note with the 2026-06-24 finding: `mining_render` uses **no fonts** + a specialized rarity palette, so rebasing it is a **visual redesign for the owner**, not a clean dedup.

## Scope

Tooling + tests + one docs note. No `disbot/` runtime change. +6 tests (flags a dup, clean migrated renderer, non-render out-of-scope, engine exempt, allowlist, registry/scope).

**Self-initiated** (Q-0172): flagged for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3LtH6HubrkjgcNCrmpjdA)_