### PR TITLE
Ship the leaderboard image card as a real feature (H2 card-engine tail)

### DIFF
--- a/.sessions/2026-06-24-leaderboard-image-card.md
+++ b/.sessions/2026-06-24-leaderboard-image-card.md
@@ -1,6 +1,6 @@
 # 2026-06-24 — Leaderboard image card: ship the H2 card-engine tail as a real feature
 
-> **Status:** `in-progress` — born-red gate holds the merge until this card flips to `complete`.
+> **Status:** `complete`
 
 > **Run type:** `routine · dispatch`
 
@@ -27,3 +27,71 @@ Plan:
 Also cleaned a stale claim file (`claude-card-engine-guard.md` — its PR #1397 is already merged HEAD).
 
 CI mirror green + arch strict before flipping this card to `complete`.
+
+## What shipped (PR #1398)
+
+- **`services.rank_providers.RankEntry`** gained optional `name` / `score` / `value_text` (defaults
+  `None` → embeds, which render from `label`, are byte-unchanged). All **10** providers populate the
+  projection.
+- **`render_leaderboard_image`** now takes a `title` + per-row `value_texts` and guards empty rows
+  (`None`); the UX-lab sample-data default is preserved (gallery preview + its test stay green).
+- **`leaderboard_cog`** fetches the rows once (`_build_provider_response`) and attaches the rendered
+  card via embed `set_image(attachment://leaderboard.jpg)` when the top rows are structured; otherwise
+  posts the embed unchanged (Pillow-less host, empty board, card-less category). The category select
+  passes `attachments=[card]` / `[]` so a switch replaces or clears the prior image. The old
+  `_build_provider_embed(provider, guild)` is kept (now delegating) so the existing tests are unbroken.
+- Removed the stale claim `claude-card-engine-guard.md` (its PR #1397 is merged HEAD — drift-on-sight).
+- Tests: `tests/unit/cogs/test_leaderboard_card.py` (attach/fallback + titled/empty renderer) +
+  a structured-projection pin in `test_rank_providers.py`. Full mirror green (12271 passed); arch 0.
+
+## Handoff — ▶ next
+
+The card-engine **H2** tail is now essentially done. Remaining:
+- **`mining_render` rebase** — explicitly **owner-gated** (a visual redesign decision, not a mechanical
+  dedup: it uses no loaded fonts + a specialized rarity palette). Do **not** auto-rebase it.
+- **H3 (embed-feature → image-card)** — `!rank` (`views/xp/rank_view.py`) and `/myprofile` rank/profile
+  are still plain embeds; converting them to image cards on `CardCanvas` is the next horizon (its own
+  plan, per the vision doc — "not approval for H2–H5").
+- Optional polish on this feature: the card title forwards `provider.display_title` verbatim, so its
+  leading emoji renders as a missing-glyph box under DejaVu (same as the pre-existing sample title) —
+  strip/replace the emoji if a later art pass wants clean glyphs.
+
+## 💡 Session idea (Q-0089)
+
+**A `theme` knob on the leaderboard card keyed to the category.** The engine already ships 4 skins
+(`midnight`/`ember`/`verdant`/`abyss`); the board always renders `midnight`. Letting each provider name
+a theme (combat categories → `ember`, nature/creatures → `verdant`, economy → `midnight`) would make the
+boards visually distinct at a glance for ~one line per provider and zero new art — a cheap step toward
+the H3/H5 "per-world identity" the vision wants, and it dogfoods the Theme-registry's whole reason to
+exist (a new look = a few RGB tuples, not layout code). → relates `card_render.THEMES` ·
+`rank_providers` · the visual-card-engine vision.
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous run (#1397 — card-engine consistency guard) did exactly the right *durable* thing: it
+shipped a `check_consistency.py` rule that **prevents the triplication from re-growing** before moving on,
+so the dedup it protects can't quietly rot — a strong "ship the guard with the cleanup" instinct. Its one
+gap (the thing that left this run a job to do) was stopping at the *guard* and not taking the small,
+turn-key *feature* the same vision doc flagged one bullet away (the leaderboard card) — understandable
+scope discipline, but the feature was contained enough to fold in. **System improvement:** the vision
+doc's H-horizon bullets carry an inline `🟡 partially shipped / remaining:` status that made this run's
+pickup unambiguous — that "status-tagged horizon bullet" convention is worth making standard in every
+`docs/ideas/*-vision-*.md` roadmap so a dispatch run can resolve "what's the next turn-key slice here?"
+in one read (it worked perfectly here).
+
+## 📋 Doc audit (Q-0104)
+
+Durable homes updated: the vision doc's H2 bullet + `current-state/S1-bot.md` ▶-next both record the
+card as shipped. `check_current_state_ledger --strict` ✓ (no merged-PR ledger edit owed — PR not yet
+merged; the listed newer PRs are benign newest-merge lag), `check_docs --strict` ✓, arch 0, mypy clean.
+No new owner decision → no router entry owed. Reconciliation marker untouched.
+
+## 📤 Run report
+
+- **Run type:** `routine · dispatch`
+- **What shipped:** PR #1398 — leaderboard top-N image card as a real feature (card-engine H2 tail) +
+  stale-claim cleanup.
+- **⚑ Self-initiated:** none — the slice is the next item on an existing approved roadmap (vision doc
+  H2 "remaining"), not an invented feature. (The Q-0089 idea above is captured, not built.)
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none (a merge auto-deploys; no data step — no `*.json` changed).

--- a/.sessions/2026-06-24-leaderboard-image-card.md
+++ b/.sessions/2026-06-24-leaderboard-image-card.md
@@ -1,0 +1,29 @@
+# 2026-06-24 — Leaderboard image card: ship the H2 card-engine tail as a real feature
+
+> **Status:** `in-progress` — born-red gate holds the merge until this card flips to `complete`.
+
+> **Run type:** `routine · dispatch`
+
+## What I'm about to do
+
+No work order this fire → take the next real plan slice. S1 ▶ remaining (visual card-engine H2 tail):
+the renderer-dedup half is shipped, and the explicit remaining turn-key item is **shipping the
+leaderboard card as a real feature** — wiring `utils/ux_patterns/image_builders.render_leaderboard_image`
+into `leaderboard_cog` as an optional image attachment with embed fallback. (`mining_render` is
+explicitly *not* a clean rebase — owner visual decision — so it's out of scope.)
+
+Plan:
+1. Extend `services.rank_providers.RankEntry` with optional `name` / `score` / `value_text` so a
+   provider can expose structured rows for the image card (defaults `None` → fully backward-compatible;
+   embeds keep using `label`).
+2. Populate the new fields in every provider (each already computes the name + a numeric primary stat).
+3. Generalize `render_leaderboard_image` to accept a `title` + per-row value text (keep the UX-lab
+   sample-data default so the gallery preview + existing test stay green).
+4. Wire the cog: when the top rows carry numeric scores, attach the rendered card (embed
+   `set_image(attachment://…)`); when Pillow is unavailable or scores are missing, post the embed
+   unchanged. Pure graceful-fallback, same discipline as the welcome card.
+5. Tests for the new fields, the titled renderer, and the cog attach/fallback paths.
+
+Also cleaned a stale claim file (`claude-card-engine-guard.md` — its PR #1397 is already merged HEAD).
+
+CI mirror green + arch strict before flipping this card to `complete`.

--- a/disbot/cogs/leaderboard_cog.py
+++ b/disbot/cogs/leaderboard_cog.py
@@ -9,29 +9,35 @@ new category means registering a provider, not touching this file.
 
 from __future__ import annotations
 
+import io
+
 import discord
 from discord.ext import commands
 
 from core.runtime.interaction_helpers import safe_defer
 from services.rank_providers import (
     ALIASES,
+    RankEntry,
     RankProvider,
     get_provider,
     provider_names,
 )
 from utils.ui_constants import ECONOMY_COLOR, UTILITY_COLOR
+from utils.ux_patterns.image_builders import render_leaderboard_image
 from views.base import BaseView
 
 MEDALS = ["🥇", "🥈", "🥉"]
 
+# The image card the board attaches when a provider exposes structured rows.
+_CARD_FILENAME = "leaderboard.jpg"
 
-async def _build_provider_embed(
+
+def _embed_from_entries(
     provider: RankProvider,
-    guild: discord.Guild,
+    entries: list[RankEntry],
 ) -> discord.Embed:
-    """Render a leaderboard embed from a provider's top-N rows."""
+    """Build the leaderboard embed from already-fetched provider rows."""
     embed = discord.Embed(title=provider.display_title, color=ECONOMY_COLOR)
-    entries = await provider.top(guild)
     if not entries:
         embed.description = provider.empty_hint
         return embed
@@ -41,6 +47,61 @@ async def _build_provider_embed(
         lines.append(f"{icon} {entry.label}")
     embed.description = "\n".join(lines)
     return embed
+
+
+def _render_card(
+    provider: RankProvider,
+    entries: list[RankEntry],
+) -> discord.File | None:
+    """Render the top-N rows as an image card, or ``None`` for embed-only.
+
+    ``None`` (caller keeps the plain embed) when: Pillow is unavailable, the
+    board is empty, or any displayed entry lacks the structured
+    ``(name, score)`` projection the bars need — so a provider that hasn't
+    opted into the card degrades cleanly rather than rendering a broken board.
+    """
+    rows = [
+        (entry.name, entry.score)
+        for entry in entries
+        if entry.name is not None and entry.score is not None
+    ]
+    if not rows or len(rows) != len(entries):
+        return None
+    value_texts = tuple((entry.value_text or "") for entry in entries)
+    jpeg = render_leaderboard_image(
+        tuple(rows),
+        title=provider.display_title,
+        value_texts=value_texts,
+    )
+    if jpeg is None:  # Pillow unavailable → embed-only fallback.
+        return None
+    return discord.File(io.BytesIO(jpeg), filename=_CARD_FILENAME)
+
+
+async def _build_provider_embed(
+    provider: RankProvider,
+    guild: discord.Guild,
+) -> discord.Embed:
+    """Render a leaderboard embed from a provider's top-N rows."""
+    return _embed_from_entries(provider, await provider.top(guild))
+
+
+async def _build_provider_response(
+    provider: RankProvider,
+    guild: discord.Guild,
+) -> tuple[discord.Embed, discord.File | None]:
+    """Fetch once and return the embed plus an optional image card.
+
+    The card is the showpiece (Q-0023 visual card engine, H2); the embed
+    stays the source of truth and the fallback, so a card-less category or a
+    Pillow-less host renders exactly as before.
+    """
+    entries = await provider.top(guild)
+    embed = _embed_from_entries(provider, entries)
+    card = _render_card(provider, entries)
+    if card is not None:
+        embed.set_image(url=f"attachment://{_CARD_FILENAME}")
+    return embed, card
 
 
 def _build_overview_embed() -> discord.Embed:
@@ -113,8 +174,14 @@ class _CategorySelect(discord.ui.Select):
                 ephemeral=True,
             )
             return
-        embed = await _build_provider_embed(provider, view.guild)
-        await interaction.edit_original_response(embed=embed, view=view)
+        embed, card = await _build_provider_response(provider, view.guild)
+        # Pass attachments explicitly so switching categories replaces (or
+        # clears, with []) any card from the previously-selected category.
+        await interaction.edit_original_response(
+            embed=embed,
+            view=view,
+            attachments=[card] if card is not None else [],
+        )
 
 
 class LeaderboardCog(commands.Cog, name="Leaderboard"):  # type: ignore[call-arg]
@@ -159,12 +226,16 @@ class LeaderboardCog(commands.Cog, name="Leaderboard"):  # type: ignore[call-arg
             provider = get_provider(category) if category else None
 
         view = LeaderboardView(ctx.guild, ctx.channel, ctx.author)  # type: ignore[arg-type]
+        card: discord.File | None = None
         if provider is not None:
-            embed = await _build_provider_embed(provider, ctx.guild)
+            embed, card = await _build_provider_response(provider, ctx.guild)
         else:
             embed = _build_overview_embed()
 
-        view.message = await ctx.send(embed=embed, view=view)
+        if card is not None:
+            view.message = await ctx.send(embed=embed, view=view, file=card)
+        else:
+            view.message = await ctx.send(embed=embed, view=view)
 
     async def build_help_menu_view(
         self,

--- a/disbot/services/rank_providers.py
+++ b/disbot/services/rank_providers.py
@@ -42,9 +42,21 @@ class RankEntry:
     prefix — e.g. ``"**Alice** — Level 5 (250 XP)"``. Providers own
     their own formatting so the registry doesn't need a per-category
     schema.
+
+    ``name`` / ``score`` / ``value_text`` are the *structured* projection
+    of the same row, consumed by the leaderboard **image card**
+    (``render_leaderboard_image``): the plain display name (no markdown),
+    the numeric primary statistic that drives the bar width, and the short
+    value text drawn at the bar's end (e.g. ``"250 XP"`` / ``"5W / 2L"``).
+    They default to ``None`` so every existing consumer (the embeds, which
+    render from ``label``) is unaffected; a provider opts a category into
+    the image card by populating all three.
     """
 
     label: str
+    name: str | None = None
+    score: float | None = None
+    value_text: str | None = None
 
 
 class RankProvider(ABC):
@@ -98,15 +110,18 @@ class XpProvider(RankProvider):
             "ORDER BY xp DESC LIMIT 10",
             (guild.id,),
         )
-        return [
-            RankEntry(
-                label=(
-                    f"**{resources.member_display(guild, row['user_id'])}** "
-                    f"— Level {row['level']} ({row['xp']} XP)"
+        entries: list[RankEntry] = []
+        for row in rows:
+            name = resources.member_display(guild, row["user_id"])
+            entries.append(
+                RankEntry(
+                    label=f"**{name}** — Level {row['level']} ({row['xp']} XP)",
+                    name=name,
+                    score=float(row["xp"]),
+                    value_text=f"{row['xp']:,} XP",
                 ),
             )
-            for row in rows
-        ]
+        return entries
 
     async def member_rank(
         self,
@@ -138,15 +153,18 @@ class CoinsProvider(RankProvider):
             "ORDER BY coins DESC LIMIT 10",
             (guild.id,),
         )
-        return [
-            RankEntry(
-                label=(
-                    f"**{resources.member_display(guild, row['user_id'])}** "
-                    f"— {row['coins']} 🪙"
+        entries: list[RankEntry] = []
+        for row in rows:
+            name = resources.member_display(guild, row["user_id"])
+            entries.append(
+                RankEntry(
+                    label=f"**{name}** — {row['coins']} 🪙",
+                    name=name,
+                    score=float(row["coins"]),
+                    value_text=f"{row['coins']:,} 🪙",
                 ),
             )
-            for row in rows
-        ]
+        return entries
 
     async def member_rank(
         self,
@@ -172,15 +190,18 @@ class MiningProvider(RankProvider):
 
     async def top(self, guild: discord.Guild) -> list[RankEntry]:
         rows = await db.get_all_mining_totals(guild.id)
-        return [
-            RankEntry(
-                label=(
-                    f"**{resources.member_display(guild, user_id)}** "
-                    f"— {total} items"
+        entries: list[RankEntry] = []
+        for user_id, total in rows[:10]:
+            name = resources.member_display(guild, user_id)
+            entries.append(
+                RankEntry(
+                    label=f"**{name}** — {total} items",
+                    name=name,
+                    score=float(total),
+                    value_text=f"{total:,} items",
                 ),
             )
-            for user_id, total in rows[:10]
-        ]
+        return entries
 
     async def member_rank(
         self,
@@ -215,15 +236,18 @@ class CreaturesProvider(RankProvider):
 
     async def top(self, guild: discord.Guild) -> list[RankEntry]:
         rows = await db.top_collectors(guild.id, creature_names())
-        return [
-            RankEntry(
-                label=(
-                    f"**{resources.member_display(guild, user_id)}** "
-                    f"— {self._render(caught, species)}"
+        entries: list[RankEntry] = []
+        for user_id, caught, species in rows[:10]:
+            name = resources.member_display(guild, user_id)
+            entries.append(
+                RankEntry(
+                    label=f"**{name}** — {self._render(caught, species)}",
+                    name=name,
+                    score=float(caught),
+                    value_text=f"{caught:,} caught",
                 ),
             )
-            for user_id, caught, species in rows[:10]
-        ]
+        return entries
 
     async def member_rank(
         self,
@@ -256,15 +280,19 @@ class GameXpProvider(RankProvider):
 
     async def top(self, guild: discord.Guild) -> list[RankEntry]:
         rows = await db.top_total_xp(guild.id)
-        return [
-            RankEntry(
-                label=(
-                    f"**{resources.member_display(guild, user_id)}** "
-                    f"— {self._render(total)}"
+        entries: list[RankEntry] = []
+        for user_id, total in rows[:10]:
+            name = resources.member_display(guild, user_id)
+            level, _, _ = db.level_progress(total)
+            entries.append(
+                RankEntry(
+                    label=f"**{name}** — {self._render(total)}",
+                    name=name,
+                    score=float(total),
+                    value_text=f"Lv {level} · {total:,} XP",
                 ),
             )
-            for user_id, total in rows[:10]
-        ]
+        return entries
 
     async def member_rank(
         self,
@@ -289,15 +317,18 @@ class CraftingProvider(RankProvider):
 
     async def top(self, guild: discord.Guild) -> list[RankEntry]:
         rows = await db.top_game_xp(guild.id, "crafting")
-        return [
-            RankEntry(
-                label=(
-                    f"**{resources.member_display(guild, user_id)}** "
-                    f"— {xp} crafting XP"
+        entries: list[RankEntry] = []
+        for user_id, xp in rows[:10]:
+            name = resources.member_display(guild, user_id)
+            entries.append(
+                RankEntry(
+                    label=f"**{name}** — {xp} crafting XP",
+                    name=name,
+                    score=float(xp),
+                    value_text=f"{xp:,} XP",
                 ),
             )
-            for user_id, xp in rows[:10]
-        ]
+        return entries
 
     async def member_rank(
         self,
@@ -322,15 +353,18 @@ class DeathmatchProvider(RankProvider):
 
     async def top(self, guild: discord.Guild) -> list[RankEntry]:
         rows = await db.get_deathmatch_leaderboard(guild.id)
-        return [
-            RankEntry(
-                label=(
-                    f"**{resources.member_display(guild, row['user_id'])}** "
-                    f"— {row['wins']}W / {row['losses']}L"
+        entries: list[RankEntry] = []
+        for row in rows[:10]:
+            name = resources.member_display(guild, row["user_id"])
+            entries.append(
+                RankEntry(
+                    label=f"**{name}** — {row['wins']}W / {row['losses']}L",
+                    name=name,
+                    score=float(row["wins"]),
+                    value_text=f"{row['wins']}W / {row['losses']}L",
                 ),
             )
-            for row in rows[:10]
-        ]
+        return entries
 
     async def member_rank(
         self,
@@ -357,15 +391,20 @@ class RpsProvider(RankProvider):
         # The RPS leaderboard query already returns a "name" column —
         # display name is captured at game time, so don't re-resolve.
         rows = await db.rps_get_leaderboard(guild.id)
-        return [
-            RankEntry(
-                label=(
-                    f"**{row['name']}** — "
-                    f"{row['wins']}W / {row['losses']}L / {row['ties']}T"
+        entries: list[RankEntry] = []
+        for row in rows[:10]:
+            entries.append(
+                RankEntry(
+                    label=(
+                        f"**{row['name']}** — "
+                        f"{row['wins']}W / {row['losses']}L / {row['ties']}T"
+                    ),
+                    name=str(row["name"]),
+                    score=float(row["wins"]),
+                    value_text=f"{row['wins']}W / {row['losses']}L / {row['ties']}T",
                 ),
             )
-            for row in rows[:10]
-        ]
+        return entries
 
     async def member_rank(
         self,
@@ -411,12 +450,18 @@ class CountingProvider(RankProvider):
 
     async def top(self, guild: discord.Guild) -> list[RankEntry]:
         sorted_totals = await self._all_totals(guild)
-        return [
-            RankEntry(
-                label=f"**{resources.member_display(guild, uid)}** — {cnt} counts",
+        entries: list[RankEntry] = []
+        for uid, cnt in sorted_totals[:10]:
+            name = resources.member_display(guild, uid)
+            entries.append(
+                RankEntry(
+                    label=f"**{name}** — {cnt} counts",
+                    name=name,
+                    score=float(cnt),
+                    value_text=f"{cnt:,} counts",
+                ),
             )
-            for uid, cnt in sorted_totals[:10]
-        ]
+        return entries
 
     async def member_rank(
         self,
@@ -439,15 +484,18 @@ class KarmaProvider(RankProvider):
 
     async def top(self, guild: discord.Guild) -> list[RankEntry]:
         rows = await db.top_karma(guild.id, 10)
-        return [
-            RankEntry(
-                label=(
-                    f"**{resources.member_display(guild, row['user_id'])}** "
-                    f"— {row['karma_points']} ✨"
+        entries: list[RankEntry] = []
+        for row in rows:
+            name = resources.member_display(guild, row["user_id"])
+            entries.append(
+                RankEntry(
+                    label=f"**{name}** — {row['karma_points']} ✨",
+                    name=name,
+                    score=float(row["karma_points"]),
+                    value_text=f"{row['karma_points']:,} ✨",
                 ),
             )
-            for row in rows
-        ]
+        return entries
 
     async def member_rank(
         self,

--- a/disbot/utils/ux_patterns/image_builders.py
+++ b/disbot/utils/ux_patterns/image_builders.py
@@ -26,32 +26,56 @@ from utils.welcome_render import render_welcome_card
 _THEME = "midnight"
 
 
+_DEFAULT_LEADERBOARD_ROWS: tuple[tuple[str, float], ...] = (
+    ("AstroFox", 13_370),
+    ("BananaMage", 11_204),
+    ("CinderWolf", 9_876),
+    ("DuskRunner", 8_545),
+    ("EmberLynx", 7_002),
+)
+
+
 def render_leaderboard_image(
-    rows: tuple[tuple[str, int], ...] = (
-        ("AstroFox", 13_370),
-        ("BananaMage", 11_204),
-        ("CinderWolf", 9_876),
-        ("DuskRunner", 8_545),
-        ("EmberLynx", 7_002),
-    ),
+    rows: tuple[tuple[str, float], ...] = _DEFAULT_LEADERBOARD_ROWS,
+    *,
+    title: str = "🏆 Top members",
+    value_texts: tuple[str, ...] | None = None,
 ) -> bytes | None:
-    """Top-N horizontal bars — the image alternative to the embed board."""
+    """Top-N horizontal bars — the image alternative to the embed board.
+
+    ``rows`` are ``(name, score)`` pairs (highest first); ``score`` only
+    drives the bar width.  ``title`` lets the live feature stamp the
+    category ("🏆 XP Leaderboard").  ``value_texts``, when given, supplies
+    the per-row label drawn at each bar's end (e.g. ``"5W / 2L"``) so a
+    category whose statistic isn't a bare count still reads correctly;
+    when omitted the score is shown formatted with thousands separators.
+    Returns ``None`` when Pillow is unavailable so the caller keeps its
+    embed fallback.
+    """
+    if not rows:  # empty board → let the caller post its embed-only empty state.
+        return None
     canvas = new_canvas(720, 96 + 64 * len(rows), get_theme(_THEME))
     if canvas is None:  # Pillow unavailable → caller keeps the embed fallback.
         return None
     t = canvas.theme
-    canvas.text((32, 24), "🏆 Top members", size=36, bold=True, color=t.gold)
-    top = rows[0][1] if rows else 1
+    canvas.text((32, 24), title, size=36, bold=True, color=t.gold, max_width=656)
+    top = rows[0][1] or 1
     for i, (name, score) in enumerate(rows):
         y = 96 + i * 64
-        width = int(420 * score / top)
-        canvas.draw.rounded_rectangle(
-            (200, y, 200 + width, y + 40),
-            radius=8,
-            fill=t.accent if i else t.gold,
+        width = int(420 * score / top) if top else 0
+        if width > 0:
+            canvas.draw.rounded_rectangle(
+                (200, y, 200 + width, y + 40),
+                radius=8,
+                fill=t.accent if i else t.gold,
+            )
+        canvas.text((32, y + 6), f"{i + 1}. {name}", size=24, max_width=160)
+        value = (
+            value_texts[i]
+            if value_texts is not None and i < len(value_texts)
+            else f"{score:,.0f}"
         )
-        canvas.text((32, y + 6), f"{i + 1}. {name}", size=24)
-        canvas.text((210 + width, y + 6), f"{score:,}", size=24, color=t.subtle)
+        canvas.text((210 + width, y + 6), value, size=24, color=t.subtle)
     return canvas.to_jpeg(quality=85)
 
 

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -63,8 +63,10 @@
     unit U10 — confirm every *manual* section yields a real op / honest link-only; the AI-describe side
     is done) · the **visual card-engine migration** — engine **H2** *renderer-dedup* half **🟡 partially
     shipped (welcome / UX-lab leaderboard+poster / role-menu rebased onto `CardCanvas`, 2026-06-24
-    dispatch run)**; remaining is `mining_render` rebase + leaderboard-as-real-feature (H2) and the
-    **H3** *embed-feature → image-card* move (rank/profile/leaderboard, still plain embeds) —
+    dispatch run)**; the **leaderboard card now ships as a real feature** (`!leaderboard` attaches a
+    rendered top-N image with embed fallback, 2026-06-24 dispatch run) — remaining H2 is only the
+    `mining_render` rebase (owner visual decision) and the **H3** *embed-feature → image-card* move
+    (rank/profile, still plain embeds) —
     [vision](../ideas/visual-card-engine-vision-2026-06-23.md) · the `channel-deployed-component` roles
     primitive (idea, not yet built).
 - **Fishing follow-ups** (turn-key, on the bait/venue seam) — *(bait speed knob ✅ #1337, sell-value

--- a/docs/ideas/visual-card-engine-vision-2026-06-23.md
+++ b/docs/ideas/visual-card-engine-vision-2026-06-23.md
@@ -76,9 +76,12 @@ they'd envy. The four moves:
   `render_leaderboard_image` / `render_event_poster`, **and** `role_menu_render` are now rebased onto
   `CardCanvas` (the triplicated dark-blurple palette + the duplicated `_fit`/`_fonts`/`_mix`/`_initials*`
   helpers collapsed onto one engine path; a pure `card_render.mix()` blend helper added for gradients).
-  **Remaining H2 work:** `mining_render` and **shipping the leaderboard card as a real feature**
-  (wiring `render_leaderboard_image` into `leaderboard_cog` as an optional attachment with embed
-  fallback). **Note on `mining_render` (2026-06-24 finding):** it is **not** a clean dedup rebase — it
+  **The leaderboard card is now a real feature (2026-06-24, dispatch run):** `render_leaderboard_image`
+  gained a `title` + per-row `value_texts`, `RankEntry` exposes a structured `(name, score, value_text)`
+  projection populated by every provider, and `leaderboard_cog` attaches the rendered card to the board
+  (embed `set_image(attachment://…)`) with a clean embed-only fallback when Pillow is unavailable, the
+  board is empty, or a category hasn't opted in. **Remaining H2 work:** only `mining_render`.
+  **Note on `mining_render` (2026-06-24 finding):** it is **not** a clean dedup rebase — it
   uses **no fonts at all** (every `draw.text` uses Pillow's default bitmap font, with hardcoded
   `8 * len(text)` width math) and a deliberately *specialized* rarity palette (`_KIND_COLOR`), so
   moving it onto `CardCanvas` would *change the card's look* (loaded DejaVu fonts, new metrics) and

--- a/docs/owner/claims/claude-card-engine-guard.md
+++ b/docs/owner/claims/claude-card-engine-guard.md
@@ -1,4 +1,0 @@
-- `claude/card-engine-guard` · card-engine consistency guard: add `check_consistency.py` Rule 5
-  (`card_engine_helper_duplication`) banning private `_fonts`/`_fit`/`_mix`/`_initials*` in
-  `utils/` image renderers outside `card_render` · area: `scripts/check_consistency.py` + its tests +
-  vision-doc de-stale · 2026-06-24

--- a/docs/owner/claims/claude-funny-franklin-qvy92e.md
+++ b/docs/owner/claims/claude-funny-franklin-qvy92e.md
@@ -1,0 +1,3 @@
+- `claude/funny-franklin-qvy92e` · ship the leaderboard image card as a real feature (H2 card-engine
+  tail) · scope: `services/rank_providers.py` (RankEntry name/score/value), `utils/ux_patterns/image_builders.py`
+  (titled renderer), `cogs/leaderboard_cog.py` (optional attachment + embed fallback) + tests · 2026-06-24

--- a/tests/unit/cogs/test_leaderboard_card.py
+++ b/tests/unit/cogs/test_leaderboard_card.py
@@ -1,0 +1,136 @@
+"""The leaderboard **image card** (Q-0023 visual card engine, H2).
+
+The board attaches a rendered top-N image when a provider exposes the
+structured ``(name, score, value_text)`` projection, and falls back to the
+plain embed otherwise — Pillow-less hosts, empty boards, and card-less
+categories must all degrade cleanly. These tests pin that contract at the
+cog seam without a real Pillow render (the renderer is mocked to isolate the
+attach/fallback decision; the renderer's own byte output is covered in
+``tests/unit/views/test_ux_lab_layout_image_wings.py``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs import leaderboard_cog
+from cogs.leaderboard_cog import _CARD_FILENAME, _render_card
+from services.rank_providers import RankEntry, get_provider
+from utils.ux_patterns.image_builders import render_leaderboard_image
+
+
+def _guild() -> MagicMock:
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 1
+    return guild
+
+
+def _structured_entries() -> list[RankEntry]:
+    return [
+        RankEntry(label="**Alice** — 250 XP", name="Alice", score=250.0, value_text="250 XP"),
+        RankEntry(label="**Bob** — 100 XP", name="Bob", score=100.0, value_text="100 XP"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _render_card — the attach/fallback decision
+# ---------------------------------------------------------------------------
+
+
+def test_render_card_returns_file_when_rows_are_structured():
+    provider = get_provider("xp")
+    assert provider is not None
+    with patch(
+        "cogs.leaderboard_cog.render_leaderboard_image",
+        return_value=b"\xff\xd8jpeg-bytes",
+    ) as render:
+        card = _render_card(provider, _structured_entries())
+    assert isinstance(card, discord.File)
+    assert card.filename == _CARD_FILENAME
+    # The provider title + value texts are forwarded to the renderer.
+    _args, kwargs = render.call_args
+    assert kwargs["title"] == provider.display_title
+    assert kwargs["value_texts"] == ("250 XP", "100 XP")
+
+
+def test_render_card_is_none_for_empty_board():
+    provider = get_provider("xp")
+    assert provider is not None
+    assert _render_card(provider, []) is None
+
+
+def test_render_card_is_none_when_any_entry_lacks_projection():
+    """A category that hasn't opted into the card (no name/score) renders
+    embed-only — never a partial/broken board."""
+    provider = get_provider("xp")
+    assert provider is not None
+    mixed = [
+        RankEntry(label="**Alice** — 250 XP", name="Alice", score=250.0),
+        RankEntry(label="**Bob** — legacy row"),  # no name/score
+    ]
+    assert _render_card(provider, mixed) is None
+
+
+def test_render_card_is_none_when_pillow_unavailable():
+    provider = get_provider("xp")
+    assert provider is not None
+    with patch("cogs.leaderboard_cog.render_leaderboard_image", return_value=None):
+        assert _render_card(provider, _structured_entries()) is None
+
+
+# ---------------------------------------------------------------------------
+# _build_provider_response — embed image wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_response_sets_embed_image_when_card_present():
+    provider = get_provider("xp")
+    assert provider is not None
+    with patch.object(
+        provider, "top", new=AsyncMock(return_value=_structured_entries())
+    ), patch(
+        "cogs.leaderboard_cog.render_leaderboard_image",
+        return_value=b"\xff\xd8jpeg",
+    ):
+        embed, card = await leaderboard_cog._build_provider_response(provider, _guild())
+    assert card is not None
+    assert embed.image.url == f"attachment://{_CARD_FILENAME}"
+    # The embed text board stays the source of truth / fallback.
+    assert "Alice" in (embed.description or "")
+
+
+@pytest.mark.asyncio
+async def test_response_has_no_image_when_card_absent():
+    provider = get_provider("xp")
+    assert provider is not None
+    with patch.object(
+        provider, "top", new=AsyncMock(return_value=_structured_entries())
+    ), patch("cogs.leaderboard_cog.render_leaderboard_image", return_value=None):
+        embed, card = await leaderboard_cog._build_provider_response(provider, _guild())
+    assert card is None
+    assert embed.image.url is None
+    assert "Alice" in (embed.description or "")
+
+
+# ---------------------------------------------------------------------------
+# render_leaderboard_image — title / value_texts / empty
+# ---------------------------------------------------------------------------
+
+
+def test_renderer_returns_none_for_empty_rows():
+    # No PIL needed — the empty guard precedes any canvas work.
+    assert render_leaderboard_image(()) is None
+
+
+def test_renderer_honours_title_and_value_texts():
+    pytest.importorskip("PIL")
+    data = render_leaderboard_image(
+        (("Alice", 250.0), ("Bob", 100.0)),
+        title="🏆 XP Leaderboard",
+        value_texts=("250 XP", "100 XP"),
+    )
+    assert data is not None and len(data) > 0

--- a/tests/unit/services/test_rank_providers.py
+++ b/tests/unit/services/test_rank_providers.py
@@ -133,6 +133,49 @@ async def test_xp_top_returns_rank_entries():
 
 
 @pytest.mark.asyncio
+async def test_top_entries_carry_structured_projection_for_the_image_card():
+    """Every category populates ``name``/``score``/``value_text`` so the
+    leaderboard image card can draw bars without re-parsing ``label``.
+
+    Each provider is exercised through its own ``top`` so the projection is
+    pinned end-to-end (not just on the dataclass default).
+    """
+    cases = [
+        ("xp", "db.fetchall", [{"user_id": 1, "xp": 250, "level": 5}], 250.0),
+        ("coins", "db.fetchall", [{"user_id": 1, "coins": 99}], 99.0),
+        (
+            "deathmatch",
+            "db.get_deathmatch_leaderboard",
+            [{"user_id": 1, "wins": 7, "losses": 2}],
+            7.0,
+        ),
+        (
+            "karma",
+            "db.top_karma",
+            [{"user_id": 1, "karma_points": 12}],
+            12.0,
+        ),
+    ]
+    for cat, target, rows, expected_score in cases:
+        provider = get_provider(cat)
+        assert provider is not None
+        with patch(
+            f"services.rank_providers.{target}",
+            new_callable=AsyncMock,
+            return_value=rows,
+        ), patch(
+            "services.rank_providers.resources.member_display",
+            side_effect=lambda g, uid: f"User{uid}",
+        ):
+            entries = await provider.top(_guild())
+        top = entries[0]
+        assert top.name, cat
+        assert "*" not in (top.name or ""), f"{cat}: name must be markdown-free"
+        assert top.score == expected_score, cat
+        assert top.value_text, cat
+
+
+@pytest.mark.asyncio
 async def test_xp_member_rank_finds_user_on_board():
     provider = get_provider("xp")
     rows = [


### PR DESCRIPTION
Scheduled dispatch (no work order) → next plan slice: the visual card-engine **H2** tail.

The renderer-dedup half of H2 already shipped. The explicit remaining turn-key item
([vision §H2](docs/ideas/visual-card-engine-vision-2026-06-23.md)) is **shipping the leaderboard card
as a real feature** — wiring `utils/ux_patterns/image_builders.render_leaderboard_image` into
`leaderboard_cog` as an optional image attachment with embed fallback. (`mining_render` is explicitly
*not* a clean rebase — owner visual decision — so it stays out of scope.)

## What this does
- `services.rank_providers.RankEntry` gains optional `name` / `score` / `value_text` so a provider can
  expose structured rows for the image card. Defaults are `None` → fully backward-compatible; embeds
  keep rendering from `label`.
- Every provider populates the new fields (each already computes the display name + a numeric primary stat).
- `render_leaderboard_image` is generalized to accept a `title` + per-row value text, keeping the UX-lab
  sample-data default so the gallery preview + its test stay green.
- `leaderboard_cog` attaches the rendered card when the top rows carry numeric scores; when Pillow is
  unavailable or scores are missing it posts the embed unchanged (same graceful-fallback discipline as
  the welcome card).
- Cleaned a stale claim file (`claude-card-engine-guard.md` — its PR #1397 is already merged HEAD).

Born-red per Q-0133; flips to `complete` once the CI mirror is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vynxh4QUuAA1gRo2nikBzM)_