### PR TITLE
Per-category leaderboard card themes (card-engine H2 polish)

### DIFF
--- a/.sessions/2026-06-24-leaderboard-card-themes.md
+++ b/.sessions/2026-06-24-leaderboard-card-themes.md
@@ -1,6 +1,6 @@
 # 2026-06-24 — Per-category leaderboard card themes (card-engine H2 polish)
 
-> **Status:** `in-progress` — born-red gate holds the merge until this card flips to `complete`.
+> **Status:** `complete`
 
 > **Run type:** `routine · dispatch`
 
@@ -25,3 +25,59 @@ Plan:
 roadmap item). Contained, reversible, test-covered.
 
 CI mirror green + arch strict before flipping to `complete`.
+
+## What shipped (PR #1399)
+
+- `RankProvider.card_theme: str = "midnight"`; overrides mining→`abyss`, creatures→`verdant`,
+  crafting+deathmatch→`ember`; economy/progression keep `midnight`. `get_theme` falls back on an
+  unknown key, so an override can never break a render.
+- `render_leaderboard_image` gained a `theme` param (defaults to the wing skin → UX-lab preview
+  byte-unchanged); `leaderboard_cog._render_card` forwards `provider.card_theme`.
+- Tests: every provider declares a *registered* theme + the set is differentiated; the cog forwards
+  the theme; the renderer renders in all four skins. Full mirror green; arch 0; mypy clean.
+
+## Handoff — ▶ next
+
+Card-engine **H2** is now done except `mining_render` (owner-gated visual redesign — do not
+auto-rebase). The next horizon is **H3** (embed-feature → image-card for `!rank` /
+`views/xp/rank_view.py` and `/myprofile`), which the vision doc says needs its own plan. Other
+S1-startable lanes unchanged: Project Moon runtime PR 1, botsite React-SPA PR 2, fishing open-world
+Phase 2 (shore-cap rebalance is an owner balance call).
+
+## 💡 Session idea (Q-0089)
+
+**A per-user cosmetic card theme.** The engine + the per-category theming now prove the registry works;
+the natural H5 "exceed move" is letting a *member* pick their own card skin (stored on their profile,
+applied to their profile/rank cards). It's the lowest-friction cosmetic-not-power surface the vision
+calls out (and the mission doc permits — cosmetics never gate features). A small slice would add a
+`user_card_theme` setting + a picker; the render path already takes a theme name. → relates
+`card_render.THEMES` · `profile_render` · `free-for-everyone-mission`.
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous slice (PR #1398, this same fire) was solid and shipped clean, and it did the right thing by
+*capturing* this theming idea in its Q-0089 line rather than scope-creeping it into the feature PR — which
+is exactly why this slice was a clean, unambiguous pickup. The one thing both slices share as a watch-item:
+the card title forwards `display_title` verbatim, so leading emoji render as missing-glyph boxes under
+DejaVu — still cosmetic and pre-existing, but now it shows on *four* skins; a later art pass should strip
+or font-swap the emoji. **System improvement:** the two-slices-one-fire pattern worked well here because
+slice 1 merged before slice 2 opened (no shared-file conflict) — worth noting in the dispatch runbook that
+when two slices touch the same files, sequencing them through merge (not parallel branches) is the safe
+default.
+
+## 📋 Doc audit (Q-0104)
+
+Durable home updated: the vision doc's H2 bullet records the per-category theming. `check_docs --strict`
+✓, arch 0, mypy clean. No new owner decision → no router entry. No merged-PR ledger edit owed (PR not yet
+merged). Reconciliation marker untouched.
+
+## 📤 Run report
+
+- **Run type:** `routine · dispatch`
+- **What shipped (this fire, 2 slices):** PR #1398 (leaderboard image card, merged) + PR #1399
+  (per-category card themes).
+- **⚑ Self-initiated:** PR #1399 — promotes my own Q-0089 idea (cosmetic polish adjacent to a roadmap
+  item, not dispatched). Contained, reversible, fully test-covered. (PR #1398 was the next item on the
+  approved roadmap — not self-initiated.)
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none (merge auto-deploys; no data file changed).

--- a/.sessions/2026-06-24-leaderboard-card-themes.md
+++ b/.sessions/2026-06-24-leaderboard-card-themes.md
@@ -1,0 +1,27 @@
+# 2026-06-24 — Per-category leaderboard card themes (card-engine H2 polish)
+
+> **Status:** `in-progress` — born-red gate holds the merge until this card flips to `complete`.
+
+> **Run type:** `routine · dispatch`
+
+## What I'm about to do
+
+Second slice this fire (first was PR #1398 — the leaderboard image card, merged). Promote the
+Q-0089 idea I captured in #1398: the board always renders the `midnight` skin, but the engine
+already ships 4 themes (`midnight`/`ember`/`verdant`/`abyss`). Let each provider name a card
+theme so boards are visually distinct at a glance — the engine's whole reason to exist ("a new
+look = a few RGB tuples, not layout code").
+
+Plan:
+1. `RankProvider.card_theme: str = "midnight"` (safe default; `get_theme` already falls back on an
+   unknown key so a bad value never breaks a render).
+2. Per-provider overrides by category flavour (combat/forge → `ember`, nature → `verdant`,
+   underground → `abyss`, economy/progression → `midnight`).
+3. `render_leaderboard_image` gains a `theme` param (defaults to the module skin so the UX-lab
+   preview is unchanged); `leaderboard_cog._render_card` forwards `provider.card_theme`.
+4. Tests: every provider declares a registered theme; the cog forwards it; the renderer honours it.
+
+⚑ Self-initiated: yes — promotes my own captured idea (not dispatched, adjacent polish to a
+roadmap item). Contained, reversible, test-covered.
+
+CI mirror green + arch strict before flipping to `complete`.

--- a/disbot/cogs/leaderboard_cog.py
+++ b/disbot/cogs/leaderboard_cog.py
@@ -72,6 +72,7 @@ def _render_card(
         tuple(rows),
         title=provider.display_title,
         value_texts=value_texts,
+        theme=provider.card_theme,
     )
     if jpeg is None:  # Pillow unavailable → embed-only fallback.
         return None

--- a/disbot/services/rank_providers.py
+++ b/disbot/services/rank_providers.py
@@ -72,6 +72,12 @@ class RankProvider(ABC):
     select_label: str
     select_emoji: str | None
     empty_hint: str
+    # The card_render skin the leaderboard image card renders in. A safe
+    # default ("midnight"); get_theme() falls back to the default skin on an
+    # unknown key, so an override can never take a render down. Overridden
+    # per category for at-a-glance visual distinction (zero new art — the
+    # engine's "a new look = a few RGB tuples" property, in practice).
+    card_theme: str = "midnight"
 
     @abstractmethod
     async def top(self, guild: discord.Guild) -> list[RankEntry]:
@@ -187,6 +193,7 @@ class MiningProvider(RankProvider):
     select_label = "Mining"
     select_emoji = "⛏️"
     empty_hint = "No mining records yet. Use `!mine` to start collecting items."
+    card_theme = "abyss"  # the underground / deep-cave skin
 
     async def top(self, guild: discord.Guild) -> list[RankEntry]:
         rows = await db.get_all_mining_totals(guild.id)
@@ -229,6 +236,7 @@ class CreaturesProvider(RankProvider):
     select_label = "Creatures"
     select_emoji = "🐾"
     empty_hint = "No creatures caught yet. Use `!catch` to start your collection."
+    card_theme = "verdant"  # the nature / collection skin
 
     @staticmethod
     def _render(caught: int, species: int) -> str:
@@ -314,6 +322,7 @@ class CraftingProvider(RankProvider):
     select_label = "Crafting"
     select_emoji = "🔧"
     empty_hint = "No crafting XP yet. Craft or repair gear at the 🔧 Workshop."
+    card_theme = "ember"  # the forge / fire skin
 
     async def top(self, guild: discord.Guild) -> list[RankEntry]:
         rows = await db.top_game_xp(guild.id, "crafting")
@@ -350,6 +359,7 @@ class DeathmatchProvider(RankProvider):
     empty_hint = (
         "No deathmatch results yet. Start a match with `!deathmatch` to appear here."
     )
+    card_theme = "ember"  # the combat / fire skin
 
     async def top(self, guild: discord.Guild) -> list[RankEntry]:
         rows = await db.get_deathmatch_leaderboard(guild.id)

--- a/disbot/utils/ux_patterns/image_builders.py
+++ b/disbot/utils/ux_patterns/image_builders.py
@@ -40,6 +40,7 @@ def render_leaderboard_image(
     *,
     title: str = "🏆 Top members",
     value_texts: tuple[str, ...] | None = None,
+    theme: str | None = None,
 ) -> bytes | None:
     """Top-N horizontal bars — the image alternative to the embed board.
 
@@ -49,12 +50,15 @@ def render_leaderboard_image(
     the per-row label drawn at each bar's end (e.g. ``"5W / 2L"``) so a
     category whose statistic isn't a bare count still reads correctly;
     when omitted the score is shown formatted with thousands separators.
+    ``theme`` names the card skin (one of :data:`card_render.THEMES`); it
+    defaults to this wing's dark-blurple ``midnight`` and falls back to the
+    engine default on an unknown key, so the call can never break a render.
     Returns ``None`` when Pillow is unavailable so the caller keeps its
     embed fallback.
     """
     if not rows:  # empty board → let the caller post its embed-only empty state.
         return None
-    canvas = new_canvas(720, 96 + 64 * len(rows), get_theme(_THEME))
+    canvas = new_canvas(720, 96 + 64 * len(rows), get_theme(theme or _THEME))
     if canvas is None:  # Pillow unavailable → caller keeps the embed fallback.
         return None
     t = canvas.theme

--- a/docs/ideas/visual-card-engine-vision-2026-06-23.md
+++ b/docs/ideas/visual-card-engine-vision-2026-06-23.md
@@ -80,7 +80,10 @@ they'd envy. The four moves:
   gained a `title` + per-row `value_texts`, `RankEntry` exposes a structured `(name, score, value_text)`
   projection populated by every provider, and `leaderboard_cog` attaches the rendered card to the board
   (embed `set_image(attachment://…)`) with a clean embed-only fallback when Pillow is unavailable, the
-  board is empty, or a category hasn't opted in. **Remaining H2 work:** only `mining_render`.
+  board is empty, or a category hasn't opted in. **Each category also renders in its own skin**
+  (`RankProvider.card_theme`: combat/forge → `ember`, nature → `verdant`, underground → `abyss`,
+  economy → `midnight`) — the first real consumer of the multi-theme registry, dogfooding "a new look =
+  a few RGB tuples". **Remaining H2 work:** only `mining_render`.
   **Note on `mining_render` (2026-06-24 finding):** it is **not** a clean dedup rebase — it
   uses **no fonts at all** (every `draw.text` uses Pillow's default bitmap font, with hardcoded
   `8 * len(text)` width math) and a deliberately *specialized* rarity palette (`_KIND_COLOR`), so

--- a/docs/owner/claims/claude-funny-franklin-qvy92e.md
+++ b/docs/owner/claims/claude-funny-franklin-qvy92e.md
@@ -1,3 +1,3 @@
-- `claude/funny-franklin-qvy92e` · ship the leaderboard image card as a real feature (H2 card-engine
-  tail) · scope: `services/rank_providers.py` (RankEntry name/score/value), `utils/ux_patterns/image_builders.py`
-  (titled renderer), `cogs/leaderboard_cog.py` (optional attachment + embed fallback) + tests · 2026-06-24
+- `claude/funny-franklin-qvy92e` · per-category leaderboard card themes (card-engine H2 polish) ·
+  scope: `services/rank_providers.py` (RankProvider.card_theme), `utils/ux_patterns/image_builders.py`
+  (theme param), `cogs/leaderboard_cog.py` (forward provider theme) + tests · 2026-06-24

--- a/tests/unit/cogs/test_leaderboard_card.py
+++ b/tests/unit/cogs/test_leaderboard_card.py
@@ -56,6 +56,19 @@ def test_render_card_returns_file_when_rows_are_structured():
     assert kwargs["value_texts"] == ("250 XP", "100 XP")
 
 
+def test_render_card_forwards_the_provider_theme():
+    """The board renders in the provider's declared skin (the H2-polish slice)."""
+    provider = get_provider("mining")  # declares card_theme="abyss"
+    assert provider is not None
+    with patch(
+        "cogs.leaderboard_cog.render_leaderboard_image",
+        return_value=b"\xff\xd8jpeg-bytes",
+    ) as render:
+        _render_card(provider, _structured_entries())
+    _args, kwargs = render.call_args
+    assert kwargs["theme"] == "abyss"
+
+
 def test_render_card_is_none_for_empty_board():
     provider = get_provider("xp")
     assert provider is not None
@@ -133,4 +146,11 @@ def test_renderer_honours_title_and_value_texts():
         title="🏆 XP Leaderboard",
         value_texts=("250 XP", "100 XP"),
     )
+    assert data is not None and len(data) > 0
+
+
+@pytest.mark.parametrize("theme", ["midnight", "ember", "verdant", "abyss"])
+def test_renderer_renders_in_every_named_theme(theme):
+    pytest.importorskip("PIL")
+    data = render_leaderboard_image((("Alice", 250.0),), theme=theme)
     assert data is not None and len(data) > 0

--- a/tests/unit/services/test_rank_providers.py
+++ b/tests/unit/services/test_rank_providers.py
@@ -91,6 +91,23 @@ def test_historical_aliases_match_pre_pr_g_map():
         assert (get_provider(alias) or MagicMock()).name == canonical
 
 
+def test_each_provider_declares_a_registered_card_theme():
+    """Every provider's leaderboard-card skin must be a real engine theme so
+    the boards render in a known palette (not silently fall back)."""
+    from utils.card_render import THEMES
+
+    for name in provider_names():
+        provider = get_provider(name)
+        assert provider is not None
+        assert provider.card_theme in THEMES, f"{name}: {provider.card_theme!r}"
+
+
+def test_card_themes_are_differentiated_across_categories():
+    """The whole point of the slice: boards are not all one skin."""
+    themes = {get_provider(n).card_theme for n in provider_names()}  # type: ignore[union-attr]
+    assert len(themes) >= 3
+
+
 def test_each_provider_has_select_metadata():
     """Select options in the leaderboard view come from providers —
     every provider must declare label/emoji/title so the registry


### PR DESCRIPTION
Second slice of this dispatch fire (the first, PR #1398 — the leaderboard image card — merged).

Promotes the Q-0089 idea captured in #1398: the board always rendered the engine's `midnight` skin,
but `card_render.THEMES` already ships four (`midnight`/`ember`/`verdant`/`abyss`). Letting each
leaderboard category name a card theme makes boards visually distinct at a glance for ~one line per
provider and **zero new art** — exactly the engine's reason to exist ("a new season/world = a few RGB
tuples, not layout code"), per the [visual-card-engine vision](docs/ideas/visual-card-engine-vision-2026-06-23.md).

## What this does
- `RankProvider.card_theme: str = "midnight"` — a safe default; `get_theme` already falls back to the
  default skin on an unknown key, so a bad value can never take a render down.
- Per-provider overrides by category flavour: combat/forge (`deathmatch`, `crafting`) → `ember`,
  nature/collection (`creatures`) → `verdant`, underground (`mining`) → `abyss`, economy/progression
  (`xp`, `coins`, `gamexp`, `rps`, `counting`, `karma`) → `midnight`.
- `render_leaderboard_image` gains a `theme` param (defaults to the module skin so the UX-lab gallery
  preview is byte-unchanged); `leaderboard_cog._render_card` forwards `provider.card_theme`.

Pure cosmetic, fully reversible. **⚑ Self-initiated** (promotes my own captured idea — adjacent polish
to a roadmap item, not a dispatched order). Born-red per Q-0133; flips to `complete` on green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vynxh4QUuAA1gRo2nikBzM)_