### PR TITLE
Rank card as a themed image (card-engine H3, first feature card)

### DIFF
--- a/.sessions/2026-06-24-rank-card-image.md
+++ b/.sessions/2026-06-24-rank-card-image.md
@@ -1,0 +1,40 @@
+# 2026-06-24 — Rank card as a themed image (card-engine H3, first feature card)
+
+> **Status:** `in-progress`
+
+> **Run type:** `routine · dispatch`
+
+**Branch:** `claude/funny-franklin-n8lnux`. **Trigger:** scheduled dispatch fire, **no work order**
+→ advance the next S1 plan slice. The S1 queue lists the visual card-engine **H3** *embed-feature →
+image-card move (rank/profile)* as the remaining card-engine tail; `/myprofile` already renders an
+image (H1), the leaderboard ships an image card (H2), so the flagship single-user **`!rank`** XP card
+is the obvious next "image-as-screen" feature.
+
+## What I'm about to do
+
+Render `!rank` (the XP/coins rank card) as a designed image on the shared card engine, with a clean
+embed fallback — the exact vision grammar: *the image is the screen; the stat-toggle dropdown is the
+control; each toggle re-renders the card.*
+
+Plan (one cohesive low-risk PR):
+1. New pure `utils/rank_render.py` → `render_rank_card(*, display_name, subtitle, stats, progress,
+   theme, footer)` — a header band (initials disc + name/subtitle) + a 3-column stat-panel **grid**
+   (up to 6 panels, so the "both" card's XP-rank/level/total-XP/messages/coin-rank/coins all show) +
+   the level progress bar. Pure `utils/` on `CardCanvas`; `bytes | None` graceful fallback.
+2. `services/xp_helpers.py`: a `RankCardData` value object + `build_rank_card_data(member, guild,
+   stat)` so the rank stats are fetched **once**; `_build_rank_embed` consumes it (byte-identical
+   embed output); `build_rank_response(...) -> (Embed, File | None)` returns the embed + optional
+   image card (sets `attachment://rank.png`, embed-only when Pillow is unavailable).
+3. Wire it: `xp_cog.rank` sends the card with the file; `_RankSelect.callback` re-renders the image
+   and replaces the attachment on each stat toggle (the "re-render on interaction" grammar).
+4. Tests: the renderer (theme/grid/fallback), the single-fetch data builder, the embed parity, and
+   the toggle re-render.
+
+⚑ **Self-initiated:** yes — advances the card-engine vision's H3 with no dispatch/owner ask
+(idea→build is open, Q-0172). Contained, reversible, test-covered, additive (embed fallback intact).
+
+CI mirror green + arch strict before flipping to `complete`.
+
+## What shipped
+
+_(filled at close)_

--- a/.sessions/2026-06-24-rank-card-image.md
+++ b/.sessions/2026-06-24-rank-card-image.md
@@ -1,6 +1,7 @@
 # 2026-06-24 — Rank card as a themed image (card-engine H3, first feature card)
 
-> **Status:** `in-progress`
+> **Status:** `complete` — `!rank` (XP/coins **and** every category) now renders a themed image card;
+> full CI mirror green (12296 passed, 48 skipped; black/isort/ruff/mypy clean) + arch 0.
 
 > **Run type:** `routine · dispatch`
 
@@ -35,6 +36,77 @@ Plan (one cohesive low-risk PR):
 
 CI mirror green + arch strict before flipping to `complete`.
 
-## What shipped
+## What shipped (PR #1401)
 
-_(filled at close)_
+The flagship single-user `!rank` card is now a themed image on the shared card engine — `/myprofile`
+(H1) and the leaderboard (H2) already render images, this brings `!rank` onto the same path.
+
+- **`utils/rank_render.py`** (new, pure) — `render_rank_card(...)`: header band (initials disc +
+  name/subtitle) + a 3-column stat-panel **grid** (up to 6 panels, so the "both" view shows
+  XP-rank / level / total-XP / messages / coin-rank / coins) + the level progress bar, all on
+  `CardCanvas`. `bytes | None` graceful fallback. The sibling of `profile_render`.
+- **`services/xp_helpers.py`** — a frozen `RankCardData` value object + `build_rank_card_data()`
+  (single DB+registry fetch), `_build_rank_embed` refactored to consume it (embed output unchanged),
+  and `build_rank_response() -> (embed, File | None)` that builds both faces from the one fetch and
+  points the embed image at `attachment://rank.png` when the card renders.
+- **`cogs/xp_cog.py`** — `!rank` (XP/coins) sends the card; **`!rank <category>`** (mining /
+  deathmatch / crafting / creatures / …) now also renders an image **on the provider's own
+  `card_theme`** (abyss / ember / verdant / …) — the same per-category skinning the leaderboard uses;
+  unranked / Pillow-less → the plain embed.
+- **`views/xp/rank_view.py`** — the stat-toggle dropdown re-renders the image and swaps the
+  attachment on each switch (the "image is the screen, the control re-runs the renderer" grammar).
+- **Tests** — `tests/unit/utils/test_rank_render.py` (render/grid/theme/fallback),
+  `tests/unit/services/test_xp_helpers_rank.py` (single-fetch, embed parity, fallback),
+  `tests/unit/cogs/test_xp_cog_rank_provider.py` (themed provider card + empty-state/Pillow fallback).
+
+**Deliberately out of scope (clean boundary):** the `!xpmenu` **hub panel** (`_XpHubView`) stays
+embed-only — it's an admin control panel with a different `build_embed()` shape; threading an
+attachment through `send_panel`/`edit_message` there is a separate follow-up. `_build_rank_embed`
+is kept intact for it (and `main_panel`).
+
+## Handoff / next
+
+The card-engine **H3** thread continues: (1) the **`!xpmenu` hub panel** + other showpiece embeds
+onto image cards (the rank/profile *hub* surfaces); (2) the genuine **season/world skin packs** the
+vision's H3 names (a fishing/collection season card). Both are turn-key on the now-proven
+`render_rank_card` / `render_profile_card` + `THEMES` pattern. Remaining H2 is only the `mining_render`
+rebase (an owner *visual* decision — it uses no fonts + a specialized rarity palette).
+
+## 💡 Session idea
+
+**A `card_theme` provider-conformance test.** Each `RankProvider.card_theme` is a free string resolved
+by `card_render.get_theme` with a silent default-on-unknown fallback — so a typo (`"abyss "` /
+`"emberr"`) would *silently* render the wrong (default) skin with no error, exactly the class the
+`dead-binding self-heal` and tool-pin guards exist to catch elsewhere. A one-line invariant test
+(`test_every_provider_card_theme_is_registered`) asserting every provider's `card_theme` is a key in
+`card_render.THEMES` would make a skin typo a red test instead of a quiet visual bug. Cheap, high-signal,
+fits the friction→guard reflex (#1280 / #1297 / BUG-0017). Worth having — not built this run (kept the
+PR to the feature); flagged for the next dispatch.
+
+## ⟲ Previous-session review
+
+The previous run (`2026-06-24-leaderboard-card-themes`, PR #1399) did the per-category leaderboard
+themes well — it correctly *dogfooded* the multi-theme registry (`RankProvider.card_theme`), which is
+exactly what made **this** session's provider rank cards a two-line change (the themes were already
+declared). One thing it could have done better: it shipped `card_theme` as a plain string with no guard
+that the value is a registered theme — the silent-fallback footgun my Session idea above proposes
+closing. **System improvement surfaced:** the card-engine now has *three* consumers
+(`profile_render`, leaderboard `image_builders`, `rank_render`) each re-composing the same
+header-band + initials-disc + panel-grid layout. The `card_engine_helper_duplication` consistency rule
+(Rule 5, #1396) guards the *helper* layer (`_fonts`/`_fit`/…) but not the *composition* layer — if a
+fourth card re-types the header-band geometry, nothing flags it. Worth considering a shared
+`hero_header(canvas, name, subtitle, theme)` composition primitive on `CardCanvas` before the H3 hub
+cards add a fourth re-implementation.
+
+## 📤 Run report footer
+
+- **Run type:** `routine · dispatch`
+- **PR:** #1401 (card-engine H3 — `!rank` as a themed image)
+- **⚑ Self-initiated:** yes — advanced the card-engine vision's H3 with no dispatch/owner ask
+  (idea→build is open, Q-0172). Contained, reversible, test-covered, additive (embed fallback intact).
+- **⚑ Owner-decisions:** none
+- **⚑ Owner-manual-steps:** none (a merge auto-deploys; no data/seed step — pure rendering, no schema
+  change)
+- **Bug-book:** no new bugs; none fixed this run.
+- **Doc audit:** S1-bot.md + the card-engine vision doc de-staled to reflect H3 underway; claim file
+  added at open and removed at close; ledger unaffected (PR will be reconciled by the next pass).

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import logging
 
 import discord
@@ -8,8 +9,9 @@ from discord.ext import commands
 from core.runtime.interaction_helpers import help_ctx_shim
 from services import xp_service
 from services.rank_providers import get_provider
-from services.xp_helpers import _STAT_TYPES, _build_rank_embed
+from services.xp_helpers import _STAT_TYPES, RANK_CARD_FILENAME, build_rank_response
 from utils import embeds as em
+from utils.rank_render import render_rank_card
 from utils.ui_constants import ECONOMY_COLOR
 from views.base import send_panel
 from views.xp.config_panel import XpConfigView
@@ -19,18 +21,21 @@ from views.xp.rank_view import _RankView
 logger = logging.getLogger("bot")
 
 
-async def _build_rank_provider_embed(
+async def _build_rank_provider_response(
     provider,
     member: discord.Member,
     guild: discord.Guild,
-) -> discord.Embed:
+) -> tuple[discord.Embed, discord.File | None]:
     """Render a single-user rank card for any non-XP provider.
 
     XP and coins keep their richer level / progress-bar card via
-    :func:`cogs.xp._helpers._build_rank_embed`. Everything else uses
-    this thinner card: title from the provider, a single field with
-    the member's rank + provider-formatted value, or an empty-state
-    line when the member has no entry.
+    :func:`services.xp_helpers.build_rank_response`. Everything else uses
+    this thinner card: title from the provider, the member's rank +
+    provider-formatted value, or an empty-state line when the member has no
+    entry. The image rides the provider's own ``card_theme`` (so ``!rank
+    mining`` shows the abyss skin, ``!rank crafting`` the ember skin, etc.) —
+    the same per-category skinning the leaderboard card uses; an unranked
+    member or a Pillow-less host falls back to the plain embed.
     """
     rank_pos, rendered = await provider.member_rank(guild, member.id)
     embed = discord.Embed(
@@ -40,10 +45,20 @@ async def _build_rank_provider_embed(
     embed.set_thumbnail(url=member.display_avatar.url)
     if rank_pos is None:
         embed.description = provider.empty_hint
-    else:
-        embed.add_field(name="Rank", value=f"#{rank_pos}", inline=True)
-        embed.add_field(name="Value", value=rendered, inline=True)
-    return embed
+        return embed, None
+
+    embed.add_field(name="Rank", value=f"#{rank_pos}", inline=True)
+    embed.add_field(name="Value", value=rendered, inline=True)
+    png = render_rank_card(
+        display_name=member.display_name,
+        subtitle=provider.display_title,
+        stats=[("Rank", f"#{rank_pos}"), (provider.select_label, rendered)],
+        theme=provider.card_theme,
+    )
+    if png is None:
+        return embed, None
+    embed.set_image(url=f"attachment://{RANK_CARD_FILENAME}")
+    return embed, discord.File(io.BytesIO(png), filename=RANK_CARD_FILENAME)
 
 
 class XpCog(commands.Cog):
@@ -121,14 +136,24 @@ class XpCog(commands.Cog):
         if category is not None:
             provider = get_provider(category)
             assert provider is not None  # noqa: S101 — guarded above
-            embed = await _build_rank_provider_embed(provider, member, ctx.guild)
-            await ctx.send(embed=embed)
+            embed, card = await _build_rank_provider_response(
+                provider,
+                member,
+                ctx.guild,
+            )
+            if card is not None:
+                await ctx.send(embed=embed, file=card)
+            else:
+                await ctx.send(embed=embed)
             return
 
         stat = stat or "both"
-        embed = await _build_rank_embed(member, ctx.guild, stat)
+        embed, card = await build_rank_response(member, ctx.guild, stat)
         view = _RankView(member, ctx.guild, stat)
-        view.message = await ctx.send(embed=embed, view=view)
+        if card is not None:
+            view.message = await ctx.send(embed=embed, view=view, file=card)
+        else:
+            view.message = await ctx.send(embed=embed, view=view)
 
     @commands.command(name="givexp")
     @commands.has_permissions(administrator=True)

--- a/disbot/services/xp_helpers.py
+++ b/disbot/services/xp_helpers.py
@@ -16,13 +16,20 @@ with the historical naming so the diff stays small):
 
 from __future__ import annotations
 
+import io
+from dataclasses import dataclass
+
 import discord
 
 from utils import db
 from utils.guild_config_accessors import get_xp_config
+from utils.rank_render import render_rank_card
 from utils.ui_constants import UTILITY_COLOR
 
 _STAT_TYPES: set[str] = {"xp", "coins", "both"}
+
+# Filename for the attached rank image card (the `attachment://` embed image).
+RANK_CARD_FILENAME = "rank.png"
 
 
 async def _guild_xp_settings(guild_id: int) -> tuple[int, int, int]:
@@ -41,12 +48,32 @@ def _progress_bar(current: int, needed: int, width: int = 10) -> str:
     return "█" * filled + "░" * (width - filled)
 
 
-async def _build_rank_embed(
+@dataclass(frozen=True)
+class RankCardData:
+    """One member's rank standing — fetched once, rendered to embed *and* image.
+
+    The single source of truth for the ``!rank`` card so the embed and the
+    image card never drift and the DB / rank-registry lookups run a single
+    time per render (the leaderboard's fetch-once pattern).
+    """
+
+    display_name: str
+    avatar_url: str
+    xp_rank: int | str
+    co_rank: int | str
+    level: int
+    total_xp: int
+    messages: int
+    coins: int
+    current: int
+    needed: int
+
+
+async def build_rank_card_data(
     member: discord.Member,
     guild: discord.Guild,
-    stat: str,
-) -> discord.Embed:
-    """Build the rank card embed for a member.
+) -> RankCardData:
+    """Resolve a member's rank standing once.
 
     Ranks come from the canonical :mod:`services.rank_providers` registry
     (its docstring names this builder as a consumer) — the inline rank SQL
@@ -64,26 +91,118 @@ async def _build_rank_embed(
         position, _ = await provider.member_rank(guild, member.id)
         return position if position is not None else "?"
 
-    xp_rank = await _rank("xp")
-    co_rank = await _rank("coins")
+    return RankCardData(
+        display_name=member.display_name,
+        avatar_url=member.display_avatar.url,
+        xp_rank=await _rank("xp"),
+        co_rank=await _rank("coins"),
+        level=level,
+        total_xp=row["xp"],
+        messages=row["messages"],
+        coins=row.get("coins", 0),
+        current=current,
+        needed=needed,
+    )
 
-    embed = discord.Embed(title=f"📊 {member.display_name}", color=UTILITY_COLOR)
-    embed.set_thumbnail(url=member.display_avatar.url)
+
+def _rank_embed_from_data(data: RankCardData, stat: str) -> discord.Embed:
+    """Build the rank-card embed from already-fetched data (byte-identical to
+    the historical inline builder — the embed stays the source of truth and the
+    Pillow-less fallback).
+    """
+    embed = discord.Embed(title=f"📊 {data.display_name}", color=UTILITY_COLOR)
+    embed.set_thumbnail(url=data.avatar_url)
 
     if stat in ("both", "xp"):
-        bar = _progress_bar(current, needed)
-        embed.add_field(name="XP Rank", value=f"#{xp_rank}", inline=True)
-        embed.add_field(name="Level", value=str(level), inline=True)
-        embed.add_field(name="Total XP", value=str(row["xp"]), inline=True)
+        bar = _progress_bar(data.current, data.needed)
+        embed.add_field(name="XP Rank", value=f"#{data.xp_rank}", inline=True)
+        embed.add_field(name="Level", value=str(data.level), inline=True)
+        embed.add_field(name="Total XP", value=str(data.total_xp), inline=True)
         embed.add_field(
             name="Progress",
-            value=f"`{bar}` {current}/{needed} XP",
+            value=f"`{bar}` {data.current}/{data.needed} XP",
             inline=False,
         )
-        embed.add_field(name="Messages", value=str(row["messages"]), inline=True)
+        embed.add_field(name="Messages", value=str(data.messages), inline=True)
 
     if stat in ("both", "coins"):
-        embed.add_field(name="Coin Rank", value=f"#{co_rank}", inline=True)
-        embed.add_field(name="🪙 Coins", value=str(row.get("coins", 0)), inline=True)
+        embed.add_field(name="Coin Rank", value=f"#{data.co_rank}", inline=True)
+        embed.add_field(name="🪙 Coins", value=str(data.coins), inline=True)
 
     return embed
+
+
+def _rank_card_stats(data: RankCardData, stat: str) -> list[tuple[str, str]]:
+    """The grid panels for the image card — same content as the embed fields."""
+    stats: list[tuple[str, str]] = []
+    if stat in ("both", "xp"):
+        stats.extend(
+            [
+                ("XP Rank", f"#{data.xp_rank}"),
+                ("Level", str(data.level)),
+                ("Total XP", str(data.total_xp)),
+                ("Messages", str(data.messages)),
+            ],
+        )
+    if stat in ("both", "coins"):
+        stats.extend(
+            [
+                ("Coin Rank", f"#{data.co_rank}"),
+                ("Coins", str(data.coins)),
+            ],
+        )
+    return stats
+
+
+def _render_rank_image(
+    data: RankCardData,
+    guild: discord.Guild,
+    stat: str,
+) -> bytes | None:
+    """Render the rank card as a PNG, or ``None`` for the embed-only fallback."""
+    progress: tuple[str, float] | None = None
+    if stat in ("both", "xp"):
+        fraction = (data.current / data.needed) if data.needed else 1.0
+        progress = (
+            f"Level {data.level} → {data.level + 1} · {data.current}/{data.needed} XP",
+            fraction,
+        )
+    return render_rank_card(
+        display_name=data.display_name,
+        subtitle=f"{guild.name} · rank",
+        stats=_rank_card_stats(data, stat),
+        progress=progress,
+    )
+
+
+async def _build_rank_embed(
+    member: discord.Member,
+    guild: discord.Guild,
+    stat: str,
+) -> discord.Embed:
+    """Build the rank-card embed for a member (embed-only; the fetch-once data
+    path is :func:`build_rank_response`).
+    """
+    data = await build_rank_card_data(member, guild)
+    return _rank_embed_from_data(data, stat)
+
+
+async def build_rank_response(
+    member: discord.Member,
+    guild: discord.Guild,
+    stat: str,
+) -> tuple[discord.Embed, discord.File | None]:
+    """Fetch once and return the rank embed plus an optional image card.
+
+    The image is the showpiece (visual card engine, H3); the embed stays the
+    source of truth and the fallback, so a Pillow-less host renders exactly as
+    before.  When the image renders, the embed's image is pointed at the
+    attachment so Discord shows the card.
+    """
+    data = await build_rank_card_data(member, guild)
+    embed = _rank_embed_from_data(data, stat)
+    png = _render_rank_image(data, guild, stat)
+    if png is None:
+        return embed, None
+    embed.set_image(url=f"attachment://{RANK_CARD_FILENAME}")
+    return embed, discord.File(io.BytesIO(png), filename=RANK_CARD_FILENAME)

--- a/disbot/utils/rank_render.py
+++ b/disbot/utils/rank_render.py
@@ -1,0 +1,161 @@
+"""Rank-card renderer — the single-user ``!rank`` card on the themeable engine.
+
+Renders a member's rank standing (``!rank``) as a designed image — avatar
+initials disc + name/subtitle, a grid of stat panels (rank position, level,
+totals, coins…), and the level progress bar — instead of a plain text embed.
+The sibling of :mod:`utils.profile_render`: same engine, a different feature
+card.  Where the profile card is a fixed four-panel hero strip, the rank card
+lays its panels out in a **grid** (up to six) so the "both" view's
+XP-rank / level / total-XP / messages / coin-rank / coins all show at once.
+
+Contract (identical to every other renderer): pure presentation inputs in,
+``bytes | None`` out (``None`` = Pillow unavailable → the caller keeps its text
+embed).  No Discord, no DB, no network — the caller resolves data and passes
+plain values.  Layering: ``utils`` may import stdlib + discord only; this module
+imports neither services/core/cogs nor Discord — it is pure rendering.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+from utils.card_render import get_theme, initials, new_canvas
+
+# Card geometry.  Fixed width; the height grows with the number of stat rows so
+# a two-row ("both") card and a one-row ("coins") card both read cleanly.
+_WIDTH = 900
+_HEADER_H = 150
+_MARGIN = 28
+_COLS = 3
+_COL_GAP = 18
+_ROW_GAP = 16
+_PANEL_H = 100
+_GRID_TOP_PAD = 24
+_PROG_H = 70
+_FOOTER_H = 44
+
+
+def render_rank_card(
+    *,
+    display_name: str,
+    subtitle: str,
+    stats: Sequence[tuple[str, str]],
+    progress: tuple[str, float] | None = None,
+    theme: str | None = None,
+    footer: str = "SuperBot",
+) -> bytes | None:
+    """Render the single-user rank card.
+
+    Parameters
+    ----------
+    display_name:
+        The member's display name (header, ellipsised to fit).
+    subtitle:
+        A one-line context string under the name (e.g. ``"Demo Server · rank"``).
+    stats:
+        ``(label, value)`` headline panels, laid out in a 3-column grid (up to
+        six are drawn; extras are ignored).
+    progress:
+        Optional ``(label, fraction)`` level-progress bar; ``fraction`` is
+        clamped to ``[0, 1]`` by the engine.
+    theme:
+        A :data:`utils.card_render.THEMES` key; unknown/None → default skin.
+    footer:
+        Subtle bottom-left caption.
+
+    Returns PNG bytes, or ``None`` when Pillow is unavailable.
+    """
+    panels = list(stats)[:6]
+    cols = min(len(panels), _COLS) or 1
+    rows = math.ceil(len(panels) / cols) if panels else 0
+
+    grid_top = _HEADER_H + _GRID_TOP_PAD
+    grid_h = rows * _PANEL_H + max(0, rows - 1) * _ROW_GAP
+    prog_h = _PROG_H if progress is not None else 0
+    height = grid_top + grid_h + prog_h + _FOOTER_H
+
+    t = get_theme(theme)
+    canvas = new_canvas(_WIDTH, height, t)
+    if canvas is None:
+        return None
+
+    # Header band + identity (mirrors the profile hero card so the two single-
+    # user cards share a visual language).
+    canvas.header_band(_HEADER_H)
+    canvas.draw.rectangle((0, _HEADER_H - 4, _WIDTH, _HEADER_H), fill=t.accent)
+
+    disc_cx, disc_cy, disc_r = 92, _HEADER_H // 2, 52
+    canvas.initials_disc(
+        (disc_cx, disc_cy),
+        disc_r,
+        initials(display_name),
+        size=42,
+    )
+
+    text_x = disc_cx + disc_r + 32
+    text_max = _WIDTH - text_x - _MARGIN
+    canvas.text(
+        (text_x, 42),
+        display_name,
+        size=46,
+        bold=True,
+        max_width=text_max,
+    )
+    canvas.text(
+        (text_x, 98),
+        subtitle,
+        size=24,
+        color=t.subtle,
+        max_width=text_max,
+    )
+
+    # Stat-panel grid — left-aligned; the last row may hold fewer than `cols`.
+    if panels:
+        avail = _WIDTH - 2 * _MARGIN
+        pw = (avail - _COL_GAP * (cols - 1)) // cols
+        for i, (label, value) in enumerate(panels):
+            col = i % cols
+            row = i // cols
+            px0 = _MARGIN + col * (pw + _COL_GAP)
+            py0 = grid_top + row * (_PANEL_H + _ROW_GAP)
+            canvas.panel((px0, py0, px0 + pw, py0 + _PANEL_H), radius=16)
+            canvas.text(
+                (px0 + 18, py0 + 16),
+                label.upper(),
+                size=18,
+                color=t.subtle,
+                max_width=pw - 36,
+            )
+            canvas.text(
+                (px0 + 18, py0 + 44),
+                value,
+                size=38,
+                bold=True,
+                color=t.text,
+                max_width=pw - 36,
+            )
+
+    # Level progress bar (when present).
+    if progress is not None:
+        label, fraction = progress
+        by = height - _FOOTER_H - 30
+        canvas.text((_MARGIN, by - 28), label, size=20, color=t.subtle)
+        canvas.progress_bar(
+            (_MARGIN, by, _WIDTH - _MARGIN, by + 22),
+            fraction,
+            fill=t.accent_alt,
+        )
+
+    # Footer.
+    canvas.text(
+        (_MARGIN, height - 32),
+        footer,
+        size=18,
+        color=t.subtle,
+    )
+
+    return canvas.to_png()
+
+
+__all__ = ["render_rank_card"]

--- a/disbot/views/xp/rank_view.py
+++ b/disbot/views/xp/rank_view.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import discord
 
-from services.xp_helpers import _build_rank_embed
+from services.xp_helpers import build_rank_response
 
 
 # Extends discord.ui.View directly (not BaseView): specialized lifecycle —
@@ -77,9 +77,16 @@ class _RankSelect(discord.ui.Select):
         stat = self.values[0]
         for opt in self.options:
             opt.default = opt.value == stat
-        embed = await _build_rank_embed(
+        embed, card = await build_rank_response(
             self._rank_view.member,
             self._rank_view.guild,
             stat,
         )
-        await interaction.response.edit_message(embed=embed, view=self.view)
+        # Re-render on toggle (the "image is the screen, controls re-render it"
+        # grammar): pass attachments explicitly so the new card replaces the
+        # old one, or clears it ([]) on a Pillow-less embed-only fallback.
+        await interaction.response.edit_message(
+            embed=embed,
+            view=self.view,
+            attachments=[card] if card is not None else [],
+        )

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -65,8 +65,10 @@
     shipped (welcome / UX-lab leaderboard+poster / role-menu rebased onto `CardCanvas`, 2026-06-24
     dispatch run)**; the **leaderboard card now ships as a real feature** (`!leaderboard` attaches a
     rendered top-N image with embed fallback, 2026-06-24 dispatch run) — remaining H2 is only the
-    `mining_render` rebase (owner visual decision) and the **H3** *embed-feature → image-card* move
-    (rank/profile, still plain embeds) —
+    `mining_render` rebase (owner visual decision). **H3 *embed-feature → image-card* is underway:**
+    `/myprofile` (H1) and now **`!rank`** both render real image cards (`utils/rank_render.py`, themed
+    grid + level progress bar, re-rendered on the stat-toggle, embed fallback — 2026-06-24 dispatch
+    run); remaining H3 is the rank/profile **hub panels** (`!xpmenu`) + other showpiece embeds —
     [vision](../ideas/visual-card-engine-vision-2026-06-23.md) · the `channel-deployed-component` roles
     primitive (idea, not yet built).
 - **Fishing follow-ups** (turn-key, on the bait/venue seam) — *(bait speed knob ✅ #1337, sell-value

--- a/docs/ideas/visual-card-engine-vision-2026-06-23.md
+++ b/docs/ideas/visual-card-engine-vision-2026-06-23.md
@@ -94,6 +94,16 @@ they'd envy. The four moves:
 - **H3 — Skinnable feature cards.** A fishing/collection **season card** (the FOOTONCLASH analogue)
   and a cross-game **world identity card** on themed skin packs; "new season = new `Theme` + asset
   pack", no layout code.
+  **🟢 Started (2026-06-24, dispatch run):** the flagship single-user **`!rank`** card now renders as
+  a themed image (`utils/card_render.py` engine → `utils/profile_render.py` for `/myprofile` (H1) and
+  the new `utils/rank_render.py` for `!rank`) — a header band + a 3-column stat-panel **grid** (up to
+  six panels, so the "both" view shows XP-rank/level/total-XP/messages/coin-rank/coins) + the level
+  progress bar. The `_RankView` stat-toggle re-renders the card and swaps the attachment on each
+  switch — the literal *"image is the screen; the dropdown is the control; each click re-runs the
+  renderer"* grammar. `services.xp_helpers.build_rank_response` fetches the rank data **once** (a
+  `RankCardData` value object) and builds both the embed and the image from it, with a clean
+  embed-only fallback when Pillow is unavailable. **Remaining H3:** the rank/profile **hub panels**
+  (`!xpmenu`) + the genuine season/world skin packs.
 - **H4 — Real art + fonts.** Owner art pack lands file-for-file; brand fonts named per theme.
 - **H5 — Animation + per-user themes (the exceed move).** Frame-sequence animated cards and a
   cosmetic theme picker (premium-gated), the visual differentiator over DM.

--- a/docs/owner/claims/claude-funny-franklin-n8lnux.md
+++ b/docs/owner/claims/claude-funny-franklin-n8lnux.md
@@ -1,4 +1,0 @@
-- `claude/funny-franklin-n8lnux` · rank card as a themed image (card-engine H3 first feature card) ·
-  scope: new `utils/rank_render.py`, `services/xp_helpers.py` (single-fetch rank data + image
-  response), `cogs/xp_cog.py` + `views/xp/rank_view.py` (attach image + re-render on toggle) + tests ·
-  2026-06-24

--- a/docs/owner/claims/claude-funny-franklin-n8lnux.md
+++ b/docs/owner/claims/claude-funny-franklin-n8lnux.md
@@ -1,0 +1,4 @@
+- `claude/funny-franklin-n8lnux` · rank card as a themed image (card-engine H3 first feature card) ·
+  scope: new `utils/rank_render.py`, `services/xp_helpers.py` (single-fetch rank data + image
+  response), `cogs/xp_cog.py` + `views/xp/rank_view.py` (attach image + re-render on toggle) + tests ·
+  2026-06-24

--- a/docs/owner/claims/claude-funny-franklin-qvy92e.md
+++ b/docs/owner/claims/claude-funny-franklin-qvy92e.md
@@ -1,3 +1,0 @@
-- `claude/funny-franklin-qvy92e` · per-category leaderboard card themes (card-engine H2 polish) ·
-  scope: `services/rank_providers.py` (RankProvider.card_theme), `utils/ux_patterns/image_builders.py`
-  (theme param), `cogs/leaderboard_cog.py` (forward provider theme) + tests · 2026-06-24

--- a/tests/unit/cogs/test_xp_cog_rank_provider.py
+++ b/tests/unit/cogs/test_xp_cog_rank_provider.py
@@ -1,0 +1,89 @@
+"""Unit tests for the non-XP provider rank card (`!rank <category>`).
+
+Pins the H3 extension: a category rank (mining / deathmatch / …) renders as a
+themed image card on the provider's own ``card_theme``, with the embed pointed
+at the attachment; an unranked member or a Pillow-less host falls back to the
+plain embed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from cogs import xp_cog
+
+
+def _member() -> MagicMock:
+    member = MagicMock(spec=discord.Member)
+    member.id = 7
+    member.display_name = "AstroFox"
+    avatar = MagicMock()
+    avatar.url = "https://cdn.example/avatar.png"
+    member.display_avatar = avatar
+    return member
+
+
+def _guild() -> MagicMock:
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 42
+    guild.name = "Demo Server"
+    return guild
+
+
+def _provider(rank, rendered) -> MagicMock:
+    provider = MagicMock()
+    provider.display_title = "⛏️ Mining Leaderboard"
+    provider.select_label = "Mining"
+    provider.empty_hint = "No mining records yet."
+    provider.card_theme = "abyss"
+    provider.member_rank = AsyncMock(return_value=(rank, rendered))
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_ranked_member_gets_themed_image_card():
+    provider = _provider(3, "1,200 blocks")
+    with patch.object(
+        xp_cog, "render_rank_card", return_value=b"\x89PNG\r\n\x1a\nfake"
+    ) as render:
+        embed, card = await xp_cog._build_rank_provider_response(
+            provider, _member(), _guild()
+        )
+
+    assert isinstance(card, discord.File)
+    assert embed.image.url == f"attachment://{xp_cog.RANK_CARD_FILENAME}"
+    # The card rides the provider's own skin and labels the value panel.
+    _, kwargs = render.call_args
+    assert kwargs["theme"] == "abyss"
+    assert ("Mining", "1,200 blocks") in kwargs["stats"]
+    assert ("Rank", "#3") in kwargs["stats"]
+
+
+@pytest.mark.asyncio
+async def test_unranked_member_stays_plain_embed_with_hint():
+    provider = _provider(None, None)
+    with patch.object(xp_cog, "render_rank_card") as render:
+        embed, card = await xp_cog._build_rank_provider_response(
+            provider, _member(), _guild()
+        )
+
+    assert card is None
+    assert embed.description == "No mining records yet."
+    render.assert_not_called()  # no render attempt for an empty state
+
+
+@pytest.mark.asyncio
+async def test_pillow_unavailable_falls_back_to_embed_only():
+    provider = _provider(3, "1,200 blocks")
+    with patch.object(xp_cog, "render_rank_card", return_value=None):
+        embed, card = await xp_cog._build_rank_provider_response(
+            provider, _member(), _guild()
+        )
+
+    assert card is None
+    assert embed.image.url is None
+    # The numeric fields still render in the fallback embed.
+    assert [f.name for f in embed.fields] == ["Rank", "Value"]

--- a/tests/unit/services/test_xp_helpers_rank.py
+++ b/tests/unit/services/test_xp_helpers_rank.py
@@ -1,0 +1,164 @@
+"""Unit tests for the rank-card data + image-response builders (xp_helpers).
+
+Pins the H3 rank-card seam:
+
+* ``build_rank_card_data`` fetches the XP row + ranks once and projects them.
+* ``build_rank_response`` returns the embed plus an optional image card, with
+  the embed image pointed at the attachment when the card renders, and a clean
+  embed-only fallback when Pillow is unavailable.
+* The embed produced from the fetched data is byte-identical to the historical
+  ``_build_rank_embed`` field layout (no drift between embed and image).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from services import xp_helpers
+
+
+def _member() -> MagicMock:
+    member = MagicMock(spec=discord.Member)
+    member.id = 7
+    member.display_name = "AstroFox"
+    avatar = MagicMock()
+    avatar.url = "https://cdn.example/avatar.png"
+    member.display_avatar = avatar
+    return member
+
+
+def _guild() -> MagicMock:
+    guild = MagicMock(spec=discord.Guild)
+    guild.id = 42
+    guild.name = "Demo Server"
+    return guild
+
+
+def _patch_ranks(xp_rank, coin_rank):
+    """Patch get_xp + the rank providers; returns the get_xp mock."""
+    xp_provider = MagicMock()
+    xp_provider.member_rank = AsyncMock(return_value=(xp_rank, "x"))
+    coin_provider = MagicMock()
+    coin_provider.member_rank = AsyncMock(return_value=(coin_rank, "c"))
+
+    def _get_provider(name):
+        return {"xp": xp_provider, "coins": coin_provider}.get(name)
+
+    row = {"user_id": 7, "guild_id": 42, "xp": 150, "messages": 1337, "coins": 910}
+    get_xp = AsyncMock(return_value=row)
+    return get_xp, _get_provider
+
+
+@pytest.mark.asyncio
+async def test_build_rank_card_data_fetches_once_and_projects():
+    get_xp, get_provider = _patch_ranks(3, 5)
+    with (
+        patch.object(xp_helpers.db, "get_xp", get_xp),
+        patch(
+            "services.rank_providers.get_provider",
+            side_effect=get_provider,
+        ),
+    ):
+        data = await xp_helpers.build_rank_card_data(_member(), _guild())
+
+    get_xp.assert_awaited_once()  # single DB read
+    assert data.display_name == "AstroFox"
+    assert data.avatar_url == "https://cdn.example/avatar.png"
+    assert data.xp_rank == 3 and data.co_rank == 5
+    assert data.total_xp == 150 and data.messages == 1337 and data.coins == 910
+    # level_progress(150) is deterministic from the curve.
+    expected_level, expected_current, expected_needed = xp_helpers.db.level_progress(
+        150
+    )
+    assert data.level == expected_level
+    assert data.current == expected_current and data.needed == expected_needed
+
+
+@pytest.mark.asyncio
+async def test_build_rank_card_data_off_board_member_uses_question_mark():
+    xp_provider = MagicMock()
+    xp_provider.member_rank = AsyncMock(return_value=(None, None))
+    coin_provider = MagicMock()
+    coin_provider.member_rank = AsyncMock(return_value=(None, None))
+
+    def _get_provider(name):
+        return {"xp": xp_provider, "coins": coin_provider}.get(name)
+
+    row = {"user_id": 7, "guild_id": 42, "xp": 0, "messages": 0, "coins": 0}
+    with (
+        patch.object(xp_helpers.db, "get_xp", AsyncMock(return_value=row)),
+        patch(
+            "services.rank_providers.get_provider",
+            side_effect=_get_provider,
+        ),
+    ):
+        data = await xp_helpers.build_rank_card_data(_member(), _guild())
+
+    assert data.xp_rank == "?" and data.co_rank == "?"
+
+
+@pytest.mark.asyncio
+async def test_build_rank_response_attaches_card_and_points_embed_at_it():
+    get_xp, get_provider = _patch_ranks(3, 5)
+    with (
+        patch.object(xp_helpers.db, "get_xp", get_xp),
+        patch(
+            "services.rank_providers.get_provider",
+            side_effect=get_provider,
+        ),
+        patch.object(
+            xp_helpers, "render_rank_card", return_value=b"\x89PNG\r\n\x1a\nfake"
+        ),
+    ):
+        embed, card = await xp_helpers.build_rank_response(_member(), _guild(), "both")
+
+    assert isinstance(card, discord.File)
+    assert card.filename == xp_helpers.RANK_CARD_FILENAME
+    assert embed.image.url == f"attachment://{xp_helpers.RANK_CARD_FILENAME}"
+    # Embed parity: the "both" view carries every field the historical builder did.
+    field_names = [f.name for f in embed.fields]
+    assert field_names == [
+        "XP Rank",
+        "Level",
+        "Total XP",
+        "Progress",
+        "Messages",
+        "Coin Rank",
+        "🪙 Coins",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_build_rank_response_falls_back_to_embed_only_without_pillow():
+    get_xp, get_provider = _patch_ranks(3, 5)
+    with (
+        patch.object(xp_helpers.db, "get_xp", get_xp),
+        patch(
+            "services.rank_providers.get_provider",
+            side_effect=get_provider,
+        ),
+        patch.object(xp_helpers, "render_rank_card", return_value=None),
+    ):
+        embed, card = await xp_helpers.build_rank_response(_member(), _guild(), "both")
+
+    assert card is None
+    assert embed.image.url is None  # no attachment image set on the fallback
+
+
+@pytest.mark.asyncio
+async def test_coins_view_omits_xp_fields_and_progress():
+    get_xp, get_provider = _patch_ranks(3, 5)
+    with (
+        patch.object(xp_helpers.db, "get_xp", get_xp),
+        patch(
+            "services.rank_providers.get_provider",
+            side_effect=get_provider,
+        ),
+        patch.object(xp_helpers, "render_rank_card", return_value=None),
+    ):
+        embed, _ = await xp_helpers.build_rank_response(_member(), _guild(), "coins")
+
+    assert [f.name for f in embed.fields] == ["Coin Rank", "🪙 Coins"]

--- a/tests/unit/utils/test_rank_render.py
+++ b/tests/unit/utils/test_rank_render.py
@@ -1,0 +1,109 @@
+"""Unit tests for the rank-card renderer (utils.rank_render)."""
+
+from __future__ import annotations
+
+import pytest
+
+from utils import rank_render
+
+
+def _pillow_available() -> bool:
+    try:
+        import PIL  # noqa: F401
+    except Exception:  # noqa: BLE001
+        return False
+    return True
+
+
+pytestmark = pytest.mark.skipif(
+    not _pillow_available(),
+    reason="Pillow not installed — renderer degrades to None (covered separately)",
+)
+
+
+def _render(**overrides):
+    kwargs = dict(
+        display_name="AstroFox",
+        subtitle="Demo Server · rank",
+        stats=[
+            ("XP Rank", "#3"),
+            ("Level", "12"),
+            ("Total XP", "8421"),
+            ("Messages", "1337"),
+            ("Coin Rank", "#5"),
+            ("Coins", "910"),
+        ],
+        progress=("Level 12 → 13 · 21/100 XP", 0.21),
+    )
+    kwargs.update(overrides)
+    return rank_render.render_rank_card(**kwargs)
+
+
+def test_render_returns_png_bytes():
+    out = _render()
+    assert isinstance(out, bytes) and out[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+def test_render_two_stats_one_row():
+    # The "coins" view: two panels, no progress bar — must render cleanly.
+    out = _render(stats=[("Coin Rank", "#5"), ("Coins", "910")], progress=None)
+    assert isinstance(out, bytes) and out
+
+
+def test_render_four_stats_xp_view():
+    out = _render(
+        stats=[
+            ("XP Rank", "#3"),
+            ("Level", "12"),
+            ("Total XP", "8421"),
+            ("Messages", "1337"),
+        ]
+    )
+    assert isinstance(out, bytes) and out
+
+
+def test_render_without_progress():
+    out = _render(progress=None)
+    assert isinstance(out, bytes) and out
+
+
+def test_render_with_no_stats_still_renders_identity():
+    out = _render(stats=[], progress=None)
+    assert isinstance(out, bytes) and out
+
+
+def test_render_caps_stats_at_six_panels():
+    # More than six stats must not overflow / crash — they are clamped to six.
+    out = _render(stats=[(f"S{i}", str(i)) for i in range(10)])
+    assert isinstance(out, bytes) and out
+
+
+def test_render_tolerates_overlong_and_symbolic_names():
+    out = _render(display_name="🎉" + "Z" * 200)
+    assert isinstance(out, bytes) and out
+
+
+def test_unknown_theme_falls_back_not_crashes():
+    out = _render(theme="no-such-theme")
+    assert isinstance(out, bytes) and out
+
+
+def test_each_theme_renders():
+    from utils.card_render import THEMES
+
+    for name in THEMES:
+        assert isinstance(_render(theme=name), bytes)
+
+
+def test_render_returns_none_without_pillow(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fail_pil(name, *args, **kwargs):
+        if name.startswith("PIL"):
+            raise ImportError("no pillow")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fail_pil)
+    assert _render() is None


### PR DESCRIPTION
## Card-engine H3 — render `!rank` as a themed image

Scheduled dispatch fire, no work order → advancing the next S1 plan slice: the visual card-engine
**H3** *embed-feature → image-card* move. `/myprofile` already renders an image (H1), the leaderboard
ships an image card (H2); this brings the flagship single-user **`!rank`** XP/coins card onto the
engine.

The vision grammar: *the image is the screen; the stat-toggle dropdown is the control; each toggle
re-renders the card.*

### What it does
- New pure `utils/rank_render.py` → `render_rank_card(...)`: header band (initials disc + name +
  subtitle) + a 3-column stat-panel **grid** (up to 6 panels) + the level progress bar, all on the
  shared `CardCanvas`. `bytes | None` graceful fallback (Pillow-less host keeps the embed).
- `services/xp_helpers.py`: a `RankCardData` value object + `build_rank_card_data()` (single fetch),
  `_build_rank_embed` refactored to consume it (byte-identical embed), and `build_rank_response()`
  returning `(embed, image-or-None)`.
- `xp_cog.rank` attaches the card; `_RankSelect.callback` re-renders + replaces the attachment on
  each stat toggle.

Additive and reversible — every path falls back to the existing embed when Pillow is unavailable.

⚑ **Self-initiated** (Q-0172): advances the card-engine vision's H3, no dispatch/owner ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGsnpB9N8u9ZVAq9Yg1RTP)_