### PR TITLE
Guard: every RankProvider.card_theme must be a registered engine skin

### DIFF
--- a/.sessions/2026-06-24-card-theme-conformance-guard.md
+++ b/.sessions/2026-06-24-card-theme-conformance-guard.md
@@ -1,6 +1,7 @@
 # 2026-06-24 — Provider `card_theme` conformance guard
 
-> **Status:** `in-progress`
+> **Status:** `complete` — the invariant test runs clean over all 10 providers; full CI mirror green
+> (12289 passed, 48 skipped; black/isort/ruff/mypy clean).
 
 > **Run type:** `routine · dispatch`
 
@@ -24,6 +25,21 @@ Tests-only, no runtime change, fully reversible.
 
 CI mirror green before flipping to `complete`.
 
-## What shipped
+## What shipped (PR #1403)
 
-_(filled at close)_
+`tests/unit/invariants/test_provider_card_theme_registered.py` — parametrized over every registered
+`RankProvider`; asserts each `card_theme` is a key in `card_render.THEMES`, plus a meta-test pinning
+that a bogus key is genuinely absent (so the assertion is real, not vacuous). A skin typo is now a
+red build, not a silent default-skin render. Tests-only; no runtime change.
+
+## 📤 Run report footer
+
+- **Run type:** `routine · dispatch`
+- **PR:** #1403 (provider `card_theme` conformance guard) — slice 2 of this dispatch fire (slice 1 =
+  #1401, `!rank` image card). Full session enders (the Q-0089 new idea, the Q-0102 previous-session
+  review, the Q-0104 doc audit) are in the slice-1 card `2026-06-24-rank-card-image.md`; this slice
+  builds *that* card's Q-0089 idea.
+- **⚑ Self-initiated:** yes — built slice-1's own captured Q-0089 idea (Q-0172). Tests-only, reversible.
+- **⚑ Owner-decisions:** none
+- **⚑ Owner-manual-steps:** none
+- **Bug-book:** no new bugs; none fixed.

--- a/.sessions/2026-06-24-card-theme-conformance-guard.md
+++ b/.sessions/2026-06-24-card-theme-conformance-guard.md
@@ -1,0 +1,29 @@
+# 2026-06-24 — Provider `card_theme` conformance guard
+
+> **Status:** `in-progress`
+
+> **Run type:** `routine · dispatch`
+
+**Branch:** `claude/card-theme-conformance-guard`. **Trigger:** continuation of this dispatch fire —
+second slice. The first slice (PR #1401) brought `!rank` onto the card engine and surfaced its own
+Q-0089 idea: *a skin typo in a `RankProvider.card_theme` renders the wrong (default) skin silently.*
+Building that guard now (idea→build is open, Q-0172). Independent of #1401 — touches only
+`rank_providers` + `card_render.THEMES`, both already on main (themes shipped #1399, registry #1349).
+
+## What I'm about to do
+
+Add a one-shot invariant test `tests/unit/invariants/test_provider_card_theme_registered.py`:
+every `RankProvider.card_theme` must be a registered key in `utils.card_render.THEMES`. Today
+`get_theme` falls back to the default skin on an unknown key with **no error** — so `"abyss "` /
+`"emberr"` would quietly render midnight instead of the intended skin, a silent visual bug with no
+red signal. The guard makes a skin typo a failing test (the friction→guard reflex: #1280 / #1297 /
+BUG-0017).
+
+⚑ **Self-initiated:** yes — building slice-1's own Q-0089 idea, no dispatch/owner ask (Q-0172).
+Tests-only, no runtime change, fully reversible.
+
+CI mirror green before flipping to `complete`.
+
+## What shipped
+
+_(filled at close)_

--- a/docs/owner/claims/claude-card-theme-conformance-guard.md
+++ b/docs/owner/claims/claude-card-theme-conformance-guard.md
@@ -1,3 +1,0 @@
-- `claude/card-theme-conformance-guard` · invariant test: every RankProvider.card_theme is a
-  registered card_render.THEMES key (silent-skin-typo guard) · scope:
-  `tests/unit/invariants/test_provider_card_theme_registered.py` (tests-only) · 2026-06-24

--- a/docs/owner/claims/claude-card-theme-conformance-guard.md
+++ b/docs/owner/claims/claude-card-theme-conformance-guard.md
@@ -1,0 +1,3 @@
+- `claude/card-theme-conformance-guard` · invariant test: every RankProvider.card_theme is a
+  registered card_render.THEMES key (silent-skin-typo guard) · scope:
+  `tests/unit/invariants/test_provider_card_theme_registered.py` (tests-only) · 2026-06-24

--- a/tests/unit/invariants/test_provider_card_theme_registered.py
+++ b/tests/unit/invariants/test_provider_card_theme_registered.py
@@ -1,0 +1,36 @@
+"""Invariant: every ``RankProvider.card_theme`` is a registered engine skin.
+
+A provider names its leaderboard / rank-card skin with a free string
+(``card_theme``), resolved by :func:`utils.card_render.get_theme`, which falls
+back to the **default** skin on an unknown key *with no error*.  That silent
+fallback means a typo (``"abyss "`` / ``"emberr"``) would quietly render the
+wrong skin and never go red — exactly the silent-misconfiguration class the
+dead-binding self-heal and tool-pin guards exist to catch elsewhere.
+
+This test makes a skin typo a failing build instead of a quiet visual bug
+(the friction→guard reflex: #1280 / #1297 / BUG-0017).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.rank_providers import get_provider, provider_names
+from utils.card_render import THEMES
+
+
+@pytest.mark.parametrize("name", provider_names())
+def test_every_provider_card_theme_is_registered(name: str) -> None:
+    provider = get_provider(name)
+    assert provider is not None  # provider_names() only yields registered keys
+    assert provider.card_theme in THEMES, (
+        f"RankProvider {name!r} declares card_theme={provider.card_theme!r}, which is not a key in "
+        f"card_render.THEMES ({sorted(THEMES)}). get_theme() would silently fall back to the default "
+        f"skin — fix the typo or register the theme."
+    )
+
+
+def test_guard_would_catch_an_unregistered_theme() -> None:
+    # Pin that the assertion above is real: a bogus theme key is NOT in THEMES,
+    # so a provider carrying it would fail the parametrized test.
+    assert "definitely-not-a-real-skin" not in THEMES


### PR DESCRIPTION
## A conformance guard for the card-engine skins

Second slice of this dispatch fire (first: PR #1401, `!rank` as a themed image). Builds the Q-0089
idea that slice surfaced: a `RankProvider.card_theme` is a free string resolved by
`card_render.get_theme`, which **silently falls back to the default skin** on an unknown key with no
error. So a typo (`"abyss "` / `"emberr"`) would quietly render the wrong skin and never go red.

### What it does
- `tests/unit/invariants/test_provider_card_theme_registered.py` — parametrized over every registered
  provider; asserts each `card_theme` is a key in `card_render.THEMES`. A skin typo is now a failing
  build instead of a quiet visual bug (the friction→guard reflex: #1280 / #1297 / BUG-0017).

Tests-only, no runtime change, fully reversible. Independent of #1401 (touches only `rank_providers`
+ `card_render.THEMES`, both already on main).

⚑ **Self-initiated** (Q-0172): builds slice-1's own captured idea, no dispatch/owner ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGsnpB9N8u9ZVAq9Yg1RTP)_