### PR TITLE
btd6: per-round economy slash commands (cash / RBE / bloons)

### DIFF
--- a/.sessions/2026-06-24-btd6-per-round-economy-commands.md
+++ b/.sessions/2026-06-24-btd6-per-round-economy-commands.md
@@ -1,9 +1,12 @@
 # 2026-06-24 — BTD6 per-round economy slash commands (cash / RBE / bloons)
 
-> **Status:** `in-progress` — owner-directed (Discord screen recording). Born-red
-> card; flips to `complete` as the final step once the work + close-out land.
+> **Status:** `complete` — owner-directed (Discord screen recording). PR #1404;
+> auto-merge armed; merges on green. Full CI mirror green (12,329 passed).
 
 > **Run type:** `manual · owner-directed`
+
+> **⚑ Self-initiated:** none — the feature itself was owner-directed (the
+> recording). The AI-tool follow-up (below) is *captured*, not built.
 
 Owner ask (Discord, screen recording of CyberQuincy's `/income start_round:100
 end_round:120`): *"so people can see cash, rbe, bloons etc per round via slash
@@ -12,29 +15,75 @@ CyberQuincy's `/income`, but extended to RBE + bloon composition, and showing
 **our verified numbers** (last session proved CyberQuincy over-counts: its
 $139,067 for r100-120 vs our $89,878, which matched the in-game double-cash test).
 
-## What I'm about to do
-All the per-round data already exists from this session-arc — this is an
-exposure layer, not new modelling:
-- **Cash** → `btd6_data_service.round_cash(start, end, roundset)` (verified model;
-  r100-120 = $89,877.6, vs CyberQuincy's inflated $139,067).
-- **RBE** → base (wiki `RoundEntry.rbe`) + effective freeplay-scaled
-  (`bloon_rbe_at_round` summed over `groups`; verified anchor BAD r100 = 67,200,
-  vs 55,760 base). Base and effective diverge for rounds 81+ (MOAB scaling +
-  superceramic swap) — both shown, clearly labelled, neither misrepresented.
-- **Bloons** → `RoundEntry.groups` (wiki composition).
+## Shipped (PR #1404)
+All per-round data already existed from this session-arc — this is an exposure
+layer, not new modelling. Prefix + slash twins in `btd6_reference_cog` via
+`cogs.btd6._builders` (shared-backbone parity held):
+- **`/btd6ref income <start> [end] [roundset]`** — verified cash table
+  (`round_cash`): per-round + cumulative + range total. r100-120 = **$89,878**
+  (vs CyberQuincy's inflated $139,067). Public, not ephemeral (shareable, like
+  the demo). Full `_CASH_ASSUMPTIONS` in the footer.
+- **`/btd6ref rbe <start> [end]`** — **new `round_rbe`**: base (wiki
+  `RoundEntry.rbe`) + effective freeplay-scaled (`bloon_rbe_at_round` summed over
+  groups). Two columns where they diverge (81+); collapses to one ≤ r80. Anchor
+  BAD r100 = 67,200 vs 55,760 base.
+- **`/btd6ref round <n>`** (enhanced) — now lists the bloon **composition**
+  (canonical + camo/regrow/fortified tags) and the effective RBE for 81+.
+- `btd6-gamedata-dictionary.md` — breadcrumb: these facts are now player-queryable
+  via the commands.
 
-Plan (mirrors the existing `btd6ref` tower/hero/round pattern; prefix + slash
-twins via `cogs.btd6._builders`):
-1. `btd6_data_service.round_rbe(start, end=None, roundset)` — base+effective per
-   round, structured like `round_cash` (+ per-bloon breakdown for a single round).
-2. `btd6_data_service.round_composition(round, roundset)` — resolved spawn groups.
-3. `_builders.build_income_embed` / `build_rbe_embed`; enhance `build_round_embed`
-   to add composition + effective RBE for 81+.
-4. `btd6_reference_cog`: `income` / `rbe` commands (prefix + slash), enhanced
-   `round`.
-5. Tests: round_rbe (r100 eff 67200 / base 55760; r6 equal; range shape),
-   round_composition, builders. Full CI mirror green before flip.
+**Rigor:** the load-bearing invariant — effective RBE *reconstructs* base for
+every round ≤80 (test-pinned), so the 81+ divergence is provably the freeplay
+rules, not a methodology mismatch. Effective is labelled "freeplay-scaled (model)"
+vs the wiki base; neither is misrepresented. 22 new tests; full mirror green.
 
-Rigor note: effective RBE is our engine's output, verified at the r100 anchor and
-labelled "freeplay-scaled (model)"; base RBE is the directly-sourced wiki value.
-Cash carries its `_CASH_ASSUMPTIONS` (Medium, no income towers, standard set).
+## Mid-session course-corrections (both caught by the full mirror, then fixed)
+1. **Duplicated an existing function.** I wrote a second `round_composition`
+   (single-round, resolved) that shadowed the *existing* range/AI one — breaking
+   its AI-tool + ABR tests. Root cause: my pre-build dedup grep keyed on the
+   *concepts* (cash/income/rbe) and command names, not the **exact function name**
+   I was about to define. Fix: deleted the duplicate, reused the existing function;
+   the round embed formats composition from raw `RoundEntry.groups` (which also
+   surfaces the modifiers the existing function drops). `round_rbe` was unique — no
+   collision.
+2. **Command count 389 → 393** (income + rbe, ×2 surfaces) is baked into generated
+   artifacts — regenerated `site.json` / `dashboard.json` / `data.js` and updated
+   the per-cog leaf-set test (`test_btd6_split_command_parity`).
+
+## 💡 Session idea (Q-0089)
+**Wire `round_rbe` into the AI grounding/tools**, alongside the *already-wired*
+`round_cash` + `round_composition` AI tools. Right now the bot answers per-round
+cash and composition in free text, but for RBE it only has the base figure in
+grounding — so "what's the *real* RBE at round 120?" gets 258k (base), not 432k
+(effective). Wiring `round_rbe` (a thin `_btd6_round_rbe` tool spec, mirroring
+`_btd6_round_composition`) closes that — the bot would answer freeplay-scaled RBE
+with the same engine the new `/btd6ref rbe` command uses. Dedup-checked: no
+existing `round_rbe` AI tool. Small, contained, builds directly on today.
+
+## ⟲ Previous-session review (Q-0102)
+Reviewed **2026-06-24-btd6-paragon-elite-boss-damage**. Did well: held the PR
+born-red until the elite ×2 *constancy* was independently re-verified (2nd Fandom
+source) rather than shipping on the one screenshot — exactly the discipline the
+owner keeps having to enforce. **System improvement surfaced this session:** the
+"claim before starting / don't duplicate" rule (and `helper-policy.md`) should
+add one concrete step — *before defining a new service function, grep `def
+<exact_name>` in the target module AND for the nearest concept synonyms.* My
+collision (#1) is the precise failure that step prevents: I checked for income/
+cash/rbe and command names, but never grepped `def round_composition`. Cheap,
+mechanical, and would have caught it pre-implementation instead of at the full
+mirror. (Routing this as a router DISCUSS Q is the right next move — it's a
+CLAUDE.md/helper-policy rule change, which I propose, not self-apply.)
+
+## Backlog grooming (Q-0015)
+Reviewed the per-round-economy ideas. `round-range-comparison-bare-range-list-
+2026-06-16.md` (accept comma-list "rounds 1-30, 30-60" phrasing in the §7.5 cash
+floor) remains the most-ready **decided-lane** item — small, test-bounded, AI-
+floor surface (distinct from today's slash commands). Teed up as a clean next-
+session quick win; not promoted here to stay focused on the owner-directed build.
+
+## Doc audit (Q-0104)
+`check_docs --strict` ✓, `check_current_state_ledger --strict` exit 0,
+`check_quality --full` green. New commands expose *existing* curated facts (no new
+runtime-formula fact); the gamedata-dictionary breadcrumb is the durable home for
+discoverability. No owner-decision/router change beyond the proposed DISCUSS Q
+above. Ledger entry for #1404 lands via the next reconciliation pass (Q-0052).

--- a/.sessions/2026-06-24-btd6-per-round-economy-commands.md
+++ b/.sessions/2026-06-24-btd6-per-round-economy-commands.md
@@ -1,0 +1,40 @@
+# 2026-06-24 — BTD6 per-round economy slash commands (cash / RBE / bloons)
+
+> **Status:** `in-progress` — owner-directed (Discord screen recording). Born-red
+> card; flips to `complete` as the final step once the work + close-out land.
+
+> **Run type:** `manual · owner-directed`
+
+Owner ask (Discord, screen recording of CyberQuincy's `/income start_round:100
+end_round:120`): *"so people can see cash, rbe, bloons etc per round via slash
+commands."* He wants **our** bot to have per-round economy lookups — like
+CyberQuincy's `/income`, but extended to RBE + bloon composition, and showing
+**our verified numbers** (last session proved CyberQuincy over-counts: its
+$139,067 for r100-120 vs our $89,878, which matched the in-game double-cash test).
+
+## What I'm about to do
+All the per-round data already exists from this session-arc — this is an
+exposure layer, not new modelling:
+- **Cash** → `btd6_data_service.round_cash(start, end, roundset)` (verified model;
+  r100-120 = $89,877.6, vs CyberQuincy's inflated $139,067).
+- **RBE** → base (wiki `RoundEntry.rbe`) + effective freeplay-scaled
+  (`bloon_rbe_at_round` summed over `groups`; verified anchor BAD r100 = 67,200,
+  vs 55,760 base). Base and effective diverge for rounds 81+ (MOAB scaling +
+  superceramic swap) — both shown, clearly labelled, neither misrepresented.
+- **Bloons** → `RoundEntry.groups` (wiki composition).
+
+Plan (mirrors the existing `btd6ref` tower/hero/round pattern; prefix + slash
+twins via `cogs.btd6._builders`):
+1. `btd6_data_service.round_rbe(start, end=None, roundset)` — base+effective per
+   round, structured like `round_cash` (+ per-bloon breakdown for a single round).
+2. `btd6_data_service.round_composition(round, roundset)` — resolved spawn groups.
+3. `_builders.build_income_embed` / `build_rbe_embed`; enhance `build_round_embed`
+   to add composition + effective RBE for 81+.
+4. `btd6_reference_cog`: `income` / `rbe` commands (prefix + slash), enhanced
+   `round`.
+5. Tests: round_rbe (r100 eff 67200 / base 55760; r6 equal; range shape),
+   round_composition, builders. Full CI mirror green before flip.
+
+Rigor note: effective RBE is our engine's output, verified at the r100 anchor and
+labelled "freeplay-scaled (model)"; base RBE is the directly-sourced wiki value.
+Cash carries its `_CASH_ASSUMPTIONS` (Medium, no income towers, standard set).

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-06-23T10:09:05Z",
+    "generated_at": "2026-06-24T07:18:58Z",
     "build": {
-      "commit": "0f0f04a3",
-      "subject": "Merge remote-tracking branch 'origin/claude/funny-franklin-trophy-follow' into claude/funny-franklin-trophy-follow",
-      "committed_at": "2026-06-23T10:09:05Z"
+      "commit": "7b458bb",
+      "subject": "btd6: open per-round economy commands session (born-red card)",
+      "committed_at": "2026-06-24T07:18:58Z"
     }
   },
   "counts": {
-    "commands": 389,
+    "commands": 393,
     "features": 41,
     "games": 11
   },
@@ -762,6 +762,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
+        {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
         },
@@ -800,6 +804,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
         {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
@@ -842,6 +850,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
+        {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
         },
@@ -882,6 +894,10 @@
       ],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
         {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
@@ -1007,6 +1023,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
+        {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
         },
@@ -1045,6 +1065,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
         {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
@@ -1117,6 +1141,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
+        {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
         },
@@ -1155,6 +1183,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
         {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
@@ -1310,6 +1342,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
+        {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
         },
@@ -1348,6 +1384,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
         {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
@@ -1388,6 +1428,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
+        {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
         },
@@ -1426,6 +1470,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
         {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
@@ -1482,6 +1530,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
+        {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
         },
@@ -1520,6 +1572,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
         {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
@@ -1611,6 +1667,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
+        {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
         },
@@ -1649,6 +1709,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
         {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
@@ -1753,6 +1817,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
+        {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
         },
@@ -1791,6 +1859,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
         {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
@@ -1891,6 +1963,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
+        {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
         },
@@ -1929,6 +2005,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
         {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
@@ -1988,6 +2068,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
+        {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
         },
@@ -2026,6 +2110,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
         {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
@@ -2202,6 +2290,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "Session follow-up ideas — visual engine + AI-setup wedge arc (2026-06-23)",
+          "status": "ideas"
+        },
         {
           "title": "AI self-curated memory notebook — a write-back learning seam for the bot's AI",
           "status": "ideas"
@@ -2905,8 +2997,13 @@
       "description": "Show your (or another user's) unified inventory hub.",
       "use_cases": null,
       "examples": [],
-      "status": "finished",
-      "linked_ideas": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Idea — a `check_subsystem_inventory_homed` guard (close the inventory-table drift class)",
+          "status": "ideas"
+        }
+      ],
       "notes": null
     },
     {
@@ -3600,6 +3697,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -3637,6 +3738,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -3672,6 +3777,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -3706,6 +3815,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -3824,6 +3937,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -3858,6 +3975,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -3894,6 +4015,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -3928,6 +4053,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -3964,6 +4093,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -3998,6 +4131,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -4036,6 +4173,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -4073,6 +4214,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -4108,6 +4253,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -4142,6 +4291,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -4178,6 +4331,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -4212,6 +4369,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -4248,6 +4409,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -4282,6 +4447,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -4472,6 +4641,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -4507,6 +4680,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -4541,6 +4718,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -4644,6 +4825,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -4678,6 +4863,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -4766,6 +4955,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -4802,6 +4995,10 @@
       ],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -5005,6 +5202,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -5039,6 +5240,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -5075,6 +5280,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -5109,6 +5318,88 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "income",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Verified cash per round — single round or an inclusive range.",
+      "description": "Verified cash per round — single round or an inclusive range.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "income",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Verified cash earned per round (single round or a range).",
+      "description": "Verified cash per round — single round or an inclusive range.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -5145,6 +5436,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -5179,6 +5474,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -5215,6 +5514,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -5249,6 +5552,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -5301,6 +5608,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -5335,6 +5646,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -5371,6 +5686,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -5405,6 +5724,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -5441,6 +5764,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -5475,6 +5802,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -5515,6 +5846,84 @@
       "notes": null
     },
     {
+      "name": "rbe",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "RBE per round (base + freeplay-scaled) — single round or a range.",
+      "description": "RBE per round (base + freeplay-scaled) — single round or a range.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "rbe",
+      "aliases": [],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "RBE per round — base + freeplay-scaled (single round or a range).",
+      "description": "RBE per round (base + freeplay-scaled) — single round or a range.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
+          "status": "ideas"
+        },
+        {
+          "title": "BTD6 community-shorthand corpus eval (router-class regression guard)",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a generated \"deterministic floor catalogue\" index",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — round-range comparison: accept round-anchored bare-range lists",
+          "status": "ideas"
+        },
+        {
+          "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
       "name": "readiness",
       "aliases": [],
       "category": "games",
@@ -5526,6 +5935,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -5562,6 +5975,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -5597,6 +6014,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -5631,6 +6052,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -5667,6 +6092,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -5701,6 +6130,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -5791,6 +6224,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -5825,6 +6262,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -5998,6 +6439,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -6032,6 +6477,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -6092,6 +6541,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -6126,6 +6579,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -6194,6 +6651,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -6229,6 +6690,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -6263,6 +6728,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -6299,6 +6768,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -6333,6 +6806,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -6369,6 +6846,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -6404,6 +6885,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -6438,6 +6923,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -6490,6 +6979,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -6525,6 +7018,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -6560,6 +7057,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -6594,6 +7095,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -6630,6 +7135,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -6664,6 +7173,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -6700,6 +7213,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -6734,6 +7251,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -6770,6 +7291,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -6804,6 +7329,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -6840,6 +7369,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -6874,6 +7407,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -6942,6 +7479,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -6976,6 +7517,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
@@ -7034,6 +7579,10 @@
       "status": "in-progress",
       "linked_ideas": [
         {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
+        {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"
         },
@@ -7068,6 +7617,10 @@
       "examples": [],
       "status": "in-progress",
       "linked_ideas": [
+        {
+          "title": "BTD6 runtime/simulation mechanics — extract straight from the game",
+          "status": "ideas"
+        },
         {
           "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map",
           "status": "ideas"

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -281,6 +281,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
+      },
+      {
+        "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
       },
       {
@@ -290,10 +294,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
-      },
-      {
-        "status": "idea",
-        "title": "AI panels → in-place navigation + centralized settings…"
       }
     ]
   },
@@ -313,6 +313,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
+      },
+      {
+        "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
       },
       {
@@ -322,10 +326,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
-      },
-      {
-        "status": "idea",
-        "title": "AI panels → in-place navigation + centralized settings…"
       }
     ]
   },
@@ -358,6 +358,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -367,10 +371,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -414,6 +414,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -423,10 +427,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -660,6 +660,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -669,10 +673,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -690,6 +690,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -699,10 +703,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -720,6 +720,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -729,10 +733,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -752,6 +752,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -761,10 +765,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -782,6 +782,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -791,10 +795,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -812,6 +812,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -821,10 +825,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -842,6 +842,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -851,10 +855,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -1603,6 +1603,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -1612,10 +1616,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -1633,6 +1633,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -1642,10 +1646,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -1848,6 +1848,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
+      },
+      {
+        "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
       },
       {
@@ -1857,10 +1861,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
-      },
-      {
-        "status": "idea",
-        "title": "AI panels → in-place navigation + centralized settings…"
       }
     ]
   },
@@ -2017,6 +2017,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -2026,10 +2030,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -2350,6 +2350,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
+      },
+      {
+        "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
       },
       {
@@ -2359,10 +2363,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
-      },
-      {
-        "status": "idea",
-        "title": "AI panels → in-place navigation + centralized settings…"
       }
     ]
   },
@@ -2511,6 +2511,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -2520,10 +2524,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -2569,6 +2569,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -2578,10 +2582,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -2660,6 +2660,36 @@ const COMMANDS = [
     ]
   },
   {
+    "name": "income",
+    "area": "games",
+    "status": "in-progress",
+    "summary": "Verified cash per round — single round or an inclusive range.",
+    "description": "Verified cash per round — single round or an inclusive range.",
+    "usage": "!income",
+    "aliases": [],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [],
+    "planned": [
+      {
+        "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
+        "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
+      },
+      {
+        "status": "idea",
+        "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
+      },
+      {
+        "status": "idea",
+        "title": "Idea — a generated \"deterministic floor catalogue\" index"
+      }
+    ]
+  },
+  {
     "name": "info",
     "area": "utility",
     "status": "finished",
@@ -2675,7 +2705,7 @@ const COMMANDS = [
   {
     "name": "inventory",
     "area": "economy",
-    "status": "finished",
+    "status": "in-progress",
     "summary": "Show your (or another user's) unified inventory hub.",
     "description": "Show your (or another user's) unified inventory hub.",
     "usage": "!inventory",
@@ -2685,7 +2715,12 @@ const COMMANDS = [
     "permissions": "anyone",
     "cooldown": null,
     "examples": [],
-    "planned": []
+    "planned": [
+      {
+        "status": "idea",
+        "title": "Idea — a `check_subsystem_inventory_homed` guard (close the…"
+      }
+    ]
   },
   {
     "name": "invite",
@@ -2808,6 +2843,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -2817,10 +2856,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -2838,6 +2873,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -2847,10 +2886,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -2935,6 +2970,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -2944,10 +2983,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -3392,6 +3427,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -3401,10 +3440,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -3465,6 +3500,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
+      },
+      {
+        "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
       },
       {
@@ -3474,10 +3513,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
-      },
-      {
-        "status": "idea",
-        "title": "AI panels → in-place navigation + centralized settings…"
       }
     ]
   },
@@ -3534,6 +3569,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
+      },
+      {
+        "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
       },
       {
@@ -3543,10 +3582,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
-      },
-      {
-        "status": "idea",
-        "title": "AI panels → in-place navigation + centralized settings…"
       }
     ]
   },
@@ -3637,6 +3672,36 @@ const COMMANDS = [
     "planned": []
   },
   {
+    "name": "rbe",
+    "area": "games",
+    "status": "in-progress",
+    "summary": "RBE per round (base + freeplay-scaled) — single round or a range.",
+    "description": "RBE per round (base + freeplay-scaled) — single round or a range.",
+    "usage": "!rbe",
+    "aliases": [],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [],
+    "planned": [
+      {
+        "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
+        "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
+      },
+      {
+        "status": "idea",
+        "title": "BTD6 community-shorthand corpus eval (router-class regression guard)"
+      },
+      {
+        "status": "idea",
+        "title": "Idea — a generated \"deterministic floor catalogue\" index"
+      }
+    ]
+  },
+  {
     "name": "reactroles",
     "area": "management",
     "status": "in-progress",
@@ -3670,6 +3735,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
+      },
+      {
+        "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
       },
       {
@@ -3679,10 +3748,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
-      },
-      {
-        "status": "idea",
-        "title": "AI panels → in-place navigation + centralized settings…"
       }
     ]
   },
@@ -3715,6 +3780,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -3724,10 +3793,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -3763,6 +3828,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -3772,10 +3841,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -4081,6 +4146,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -4090,10 +4159,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -4129,6 +4194,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
+      },
+      {
+        "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
       },
       {
@@ -4138,10 +4207,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
-      },
-      {
-        "status": "idea",
-        "title": "AI panels → in-place navigation + centralized settings…"
       }
     ]
   },
@@ -4289,6 +4354,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -4298,10 +4367,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -4390,6 +4455,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -4399,10 +4468,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -4656,6 +4721,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
+      },
+      {
+        "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
       },
       {
@@ -4665,10 +4734,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
-      },
-      {
-        "status": "idea",
-        "title": "AI panels → in-place navigation + centralized settings…"
       }
     ]
   },
@@ -4960,6 +5025,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -4969,10 +5038,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -4990,6 +5055,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -4999,10 +5068,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -5020,6 +5085,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -5029,10 +5098,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -5050,6 +5115,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -5059,10 +5128,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -5168,6 +5233,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
+      },
+      {
+        "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
       },
       {
@@ -5177,10 +5246,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
-      },
-      {
-        "status": "idea",
-        "title": "AI panels → in-place navigation + centralized settings…"
       }
     ]
   },
@@ -5198,6 +5263,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -5207,10 +5276,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -5228,6 +5293,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -5237,10 +5306,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -5258,6 +5323,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -5267,10 +5336,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -5288,6 +5353,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -5297,10 +5366,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -5318,6 +5383,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
+      },
+      {
+        "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
       },
       {
@@ -5327,10 +5396,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
-      },
-      {
-        "status": "idea",
-        "title": "AI panels → in-place navigation + centralized settings…"
       }
     ]
   },
@@ -5435,6 +5500,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -5444,10 +5513,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -5598,6 +5663,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "BTD6 runtime/simulation mechanics — extract straight from the game"
+      },
+      {
+        "status": "idea",
         "title": "Idea — enrich the BTD6 CT event detail with relics + the hex map"
       },
       {
@@ -5607,10 +5676,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea — a generated \"deterministic floor catalogue\" index"
-      },
-      {
-        "status": "idea",
-        "title": "Idea — round-range comparison: accept round-anchored bare-range lists"
       }
     ]
   },
@@ -6028,6 +6093,10 @@ const COMMANDS = [
     "planned": [
       {
         "status": "idea",
+        "title": "Session follow-up ideas — visual engine + AI-setup wedge arc…"
+      },
+      {
+        "status": "idea",
         "title": "AI self-curated memory notebook — a write-back learning seam for the…"
       },
       {
@@ -6037,10 +6106,6 @@ const COMMANDS = [
       {
         "status": "idea",
         "title": "Idea: per-user AI memory for the bot (Honcho) — remember Discord…"
-      },
-      {
-        "status": "idea",
-        "title": "AI panels → in-place navigation + centralized settings…"
       }
     ]
   },
@@ -6359,7 +6424,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "0f0f04a3",
+    "build": "7b458bb",
     "title": "New public bot website",
     "changes": [
       {
@@ -6371,7 +6436,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "0f0f04a3",
+    "build": "7b458bb",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -6383,7 +6448,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "0f0f04a3",
+    "build": "7b458bb",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-24T05:36:36Z",
+    "generated_at": "2026-06-24T07:18:58Z",
     "build": {
-      "commit": "8d5a40ef",
-      "subject": "Merge pull request #1399 from menno420/claude/funny-franklin-qvy92e",
-      "committed_at": "2026-06-24T05:36:36Z"
+      "commit": "7b458bb",
+      "subject": "btd6: open per-round economy commands session (born-red card)",
+      "committed_at": "2026-06-24T07:18:58Z"
     },
     "counts": {
       "functions": 41,
@@ -15,7 +15,7 @@
       "updates": 60,
       "env_vars": 38,
       "cogs": 51,
-      "commands": 389,
+      "commands": 393,
       "setting_keys": 107,
       "setting_domains": 16,
       "typed_settings": 88,
@@ -2415,6 +2415,14 @@
   "reviews": [],
   "updates": [
     {
+      "file": "2026-06-24-rank-card-image.md",
+      "date": "2026-06-24",
+      "title": "2026-06-24 — Rank card as a themed image (card-engine H3, first feature card)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": true
+    },
+    {
       "file": "2026-06-24-leaderboard-image-card.md",
       "date": "2026-06-24",
       "title": "2026-06-24 — Leaderboard image card: ship the H2 card-engine tail as a real feature",
@@ -2426,6 +2434,14 @@
       "file": "2026-06-24-leaderboard-card-themes.md",
       "date": "2026-06-24",
       "title": "2026-06-24 — Per-category leaderboard card themes (card-engine H2 polish)",
+      "status": "complete",
+      "run_type": "routine",
+      "self_initiated": true
+    },
+    {
+      "file": "2026-06-24-card-theme-conformance-guard.md",
+      "date": "2026-06-24",
+      "title": "2026-06-24 — Provider `card_theme` conformance guard",
       "status": "complete",
       "run_type": "routine",
       "self_initiated": true
@@ -2445,6 +2461,22 @@
       "status": "complete",
       "run_type": "routine",
       "self_initiated": true
+    },
+    {
+      "file": "2026-06-24-btd6-per-round-economy-commands.md",
+      "date": "2026-06-24",
+      "title": "2026-06-24 — BTD6 per-round economy slash commands (cash / RBE / bloons)",
+      "status": "in-progress",
+      "run_type": "manual",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-06-24-btd6-paragon-elite-boss-damage.md",
+      "date": "2026-06-24",
+      "title": "2026-06-24 — BTD6 paragon elite-boss damage multiplier",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": false
     },
     {
       "file": "2026-06-23-wordfilter-deobfuscation.md",
@@ -2861,38 +2893,6 @@
       "status": "complete",
       "run_type": "routine",
       "self_initiated": true
-    },
-    {
-      "file": "2026-06-22-state-file-restructure.md",
-      "date": "2026-06-22",
-      "title": "2026-06-22 — State-file restructure: per-claim active-work + per-sector current-state",
-      "status": "complete",
-      "run_type": "manual",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-22-starboard-pr2-config-polish.md",
-      "date": "2026-06-22",
-      "title": "2026-06-22 — Starboard PR 2: self-star exclusion + ignore-channels + config panel",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-06-22-site-data-contract-guard.md",
-      "date": "2026-06-22",
-      "title": "2026-06-22 — botsite↔design-system data-contract guard (de-risking the React-SPA cutover)",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-06-22-server-treasury.md",
-      "date": "2026-06-22",
-      "title": "2026-06-22 — Server treasury (collective coin pool)",
-      "status": "complete",
-      "run_type": "",
-      "self_initiated": false
     }
   ],
   "bot_changelog": [
@@ -4630,6 +4630,50 @@
           "parent": "btd6ref",
           "aliases": [],
           "brief": "Look up a hero.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "income",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6ref",
+          "aliases": [],
+          "brief": "Verified cash per round — single round or an inclusive range.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "income",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6ref",
+          "aliases": [],
+          "brief": "Verified cash earned per round (single round or a range).",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "rbe",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "btd6ref",
+          "aliases": [],
+          "brief": "RBE per round (base + freeplay-scaled) — single round or a range.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "rbe",
+          "type": "slash",
+          "is_group": false,
+          "parent": "btd6ref",
+          "aliases": [],
+          "brief": "RBE per round — base + freeplay-scaled (single round or a range).",
           "classification": "",
           "has_panel": false,
           "button_backed": false

--- a/disbot/cogs/btd6/_builders.py
+++ b/disbot/cogs/btd6/_builders.py
@@ -138,8 +138,14 @@ async def build_hero_embed(name: str) -> discord.Embed:
 
 
 async def build_round_embed(number: int) -> discord.Embed:
-    """Render the round lookup embed. Static fixture; no DB access."""
+    """Render the round lookup embed: danger / economy + bloon composition.
+
+    The base economy line (RBE / cash / XP) comes from the round fact; this adds
+    the spawn composition and, for freeplay rounds (81+), the effective MOAB-class
+    scaled RBE next to the wiki base figure (see ``btd6_data_service.round_rbe``).
+    """
     from cogs.btd6._embeds import response_to_embed as _response_to_embed
+    from services import btd6_data_service
     from services.btd6_knowledge_service import round_fact
     from services.btd6_resolver_service import resolve
     from services.btd6_response_builder import for_round, for_unresolved
@@ -147,7 +153,221 @@ async def build_round_embed(number: int) -> discord.Embed:
     fact = round_fact(number)
     if fact is None:
         return _response_to_embed(for_unresolved(resolve(f"round {number}")))
-    return _response_to_embed(for_round(fact))
+    embed = _response_to_embed(for_round(fact))
+
+    rbe = btd6_data_service.round_rbe(number)
+    if rbe.get("found") and rbe.get("scaled") and rbe.get("effective_rbe") is not None:
+        embed.add_field(
+            name="Effective RBE (freeplay-scaled)",
+            value=(
+                f"**{rbe['effective_rbe']:,}** — the round-{number} spawn at scaled "
+                f"health (MOAB-class HP ramp + superceramics). Wiki base "
+                f"(unscaled): {rbe['base_rbe']:,}."
+            ),
+            inline=False,
+        )
+    round_entry = btd6_data_service.get_round(number)
+    if round_entry is not None and round_entry.groups:
+        total = sum(int(g.get("count", 0)) for g in round_entry.groups)
+        embed.add_field(
+            name=f"Bloons this round — {total:,} spawned",
+            value=_format_composition(round_entry.groups),
+            inline=False,
+        )
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# per-round economy: income (cash) / rbe tables + composition
+# ---------------------------------------------------------------------------
+
+# Modifier tags shown next to a bloon in the composition list. Plain text (not
+# emoji) so it renders identically across clients.
+_MOD_TAGS = ("fortified", "regrow", "camo")
+
+
+def _format_composition(groups: Sequence[dict[str, Any]]) -> str:
+    """A compact ``<count>× <Bloon> — <modifiers>`` list from a round's raw spawn
+    groups (``{bloon_id, count, modifiers}``), canonical names resolved. Capped at
+    25 lines.
+    """
+    from services import btd6_data_service
+
+    lines = []
+    for g in groups[:25]:
+        bloon = btd6_data_service.get_bloon(str(g.get("bloon_id")))
+        name = bloon.canonical if bloon is not None else str(g.get("bloon_id"))
+        mods = [m for m in _MOD_TAGS if m in (g.get("modifiers") or ())]
+        suffix = f" — {', '.join(mods)}" if mods else ""
+        lines.append(f"`{int(g.get('count', 0)):>5,}×` {name}{suffix}")
+    if len(groups) > 25:
+        lines.append(f"…and {len(groups) - 25} more groups")
+    return "\n".join(lines) or "—"
+
+
+def _elide(rows: list[Any], head: int = 11, tail: int = 9) -> tuple[list[Any], bool]:
+    """Head+tail slice of ``rows`` for a bounded table, plus whether it elided."""
+    if len(rows) <= head + tail + 1:
+        return rows, False
+    return rows[:head] + rows[-tail:], True
+
+
+def _code_table(header: str, rule: str, body_lines: list[str]) -> str:
+    """Wrap a monospace table in a fenced code block."""
+    return "```\n" + "\n".join([header, rule, *body_lines]) + "\n```"
+
+
+async def build_income_embed(
+    round_start: int,
+    round_end: int | None = None,
+    roundset: str = "default",
+) -> discord.Embed:
+    """Per-round cash for a round or inclusive range — our verified model.
+
+    Mirrors the familiar ``/income`` table but with SuperBot's audited cash
+    (``btd6_data_service.round_cash``): Standard/Medium, no income towers. Fails
+    closed with the structured reason when the range is unknown.
+    """
+    from services import btd6_data_service
+
+    res = btd6_data_service.round_cash(round_start, round_end, roundset)
+    if not res.get("found"):
+        return discord.Embed(
+            title="🐵 BTD6 income — no data",
+            description=res.get("note") or "No cash data for that round range.",
+            color=discord.Color.red(),
+        )
+    assumptions = res.get("assumptions") or "Standard/Medium, no income towers."
+
+    if res.get("single_round"):
+        cumulative = res.get("cumulative_cash")
+        cum = f" (cumulative **${cumulative:,.0f}**)" if cumulative is not None else ""
+        embed = discord.Embed(
+            title=f"🐵 BTD6 income — round {res['round_start']}",
+            description=f"Earns **${res['round_cash']:,.1f}**{cum} this round.",
+            color=discord.Color.green(),
+        )
+        embed.set_footer(text=assumptions)
+        return embed
+
+    lo, hi = res["round_start"], res["round_end"]
+    rows, elided = _elide(res.get("per_round", []))
+    body = [
+        f"{('r' + str(r['round'])):>5} │ {r['cash']:>9,.1f} │ {r['cumulative_cash']:>11,.0f}"
+        for r in rows
+    ]
+    if elided:
+        body.insert(len(body) - 9, f"{'⋮':>5} │ {'⋮':>9} │ {'⋮':>11}")
+    table = _code_table(
+        f"{'round':>5} │ {'cash':>9} │ {'cumulative':>11}",
+        "──────┼───────────┼─────────────",
+        body,
+    )
+    embed = discord.Embed(
+        title=f"🐵 BTD6 income — rounds {lo}–{hi}",
+        description=(
+            f"You earn **${res['range_cash']:,.0f}** across rounds {lo}–{hi} "
+            f"({res['rounds_counted']} rounds, both endpoints).\n{table}"
+        ),
+        color=discord.Color.green(),
+    )
+    note = assumptions
+    if res.get("truncated"):
+        note += " · breakdown truncated; total is the full range"
+    embed.set_footer(text=note)
+    return embed
+
+
+async def build_rbe_embed(
+    round_start: int,
+    round_end: int | None = None,
+    roundset: str = "default",
+) -> discord.Embed:
+    """Per-round RBE for a round or inclusive range.
+
+    Shows the wiki **base** RBE and, where the freeplay rules bite (round 81+),
+    the **effective** MOAB-class-scaled RBE alongside it
+    (``btd6_data_service.round_rbe``). Identical columns collapse to one through
+    round 80.
+    """
+    from services import btd6_data_service
+
+    res = btd6_data_service.round_rbe(round_start, round_end, roundset)
+    if not res.get("found"):
+        return discord.Embed(
+            title="🐵 BTD6 RBE — no data",
+            description=res.get("note") or "No RBE data for that round range.",
+            color=discord.Color.red(),
+        )
+
+    scaled = res.get("scaled")
+    scaling_note = (
+        "Effective RBE applies freeplay MOAB-class HP scaling + superceramic swap "
+        "(our model, verified BAD r100 = 67,200); base is the wiki composition at "
+        "base health. Identical through round 80."
+    )
+
+    if res.get("single_round"):
+        base = res.get("base_rbe")
+        eff = res.get("effective_rbe")
+        if scaled and eff is not None:
+            desc = (
+                f"**{eff:,}** effective RBE (freeplay-scaled)\n"
+                f"Wiki base (unscaled): **{base:,}**"
+            )
+        else:
+            desc = f"**{base:,}** RBE"
+        embed = discord.Embed(
+            title=f"🐵 BTD6 RBE — round {res['round']}",
+            description=desc,
+            color=discord.Color.blue(),
+        )
+        if scaled:
+            embed.set_footer(text=scaling_note)
+        return embed
+
+    lo, hi = res["round_start"], res["round_end"]
+    rows, elided = _elide(res.get("per_round", []))
+    if scaled:
+        body = [
+            (
+                f"{('r' + str(r['round'])):>5} │ {r['base_rbe']:>12,} │ "
+                f"{(r['effective_rbe'] if r['effective_rbe'] is not None else '—'):>12,}"
+                if r["effective_rbe"] is not None
+                else f"{('r' + str(r['round'])):>5} │ {r['base_rbe']:>12,} │ {'—':>12}"
+            )
+            for r in rows
+        ]
+        if elided:
+            body.insert(len(body) - 9, f"{'⋮':>5} │ {'⋮':>12} │ {'⋮':>12}")
+        table = _code_table(
+            f"{'round':>5} │ {'base RBE':>12} │ {'effective':>12}",
+            "──────┼──────────────┼──────────────",
+            body,
+        )
+        eff_total = res.get("effective_rbe_total")
+        totals = f"Totals — base **{res['base_rbe_total']:,}**" + (
+            f", effective **{eff_total:,}**" if eff_total is not None else ""
+        )
+    else:
+        body = [f"{('r' + str(r['round'])):>5} │ {r['base_rbe']:>12,}" for r in rows]
+        if elided:
+            body.insert(len(body) - 9, f"{'⋮':>5} │ {'⋮':>12}")
+        table = _code_table(
+            f"{'round':>5} │ {'RBE':>12}",
+            "──────┼──────────────",
+            body,
+        )
+        totals = f"Total RBE — **{res['base_rbe_total']:,}**"
+
+    embed = discord.Embed(
+        title=f"🐵 BTD6 RBE — rounds {lo}–{hi}",
+        description=f"{totals} across {res['rounds_counted']} rounds.\n{table}",
+        color=discord.Color.blue(),
+    )
+    if scaled:
+        embed.set_footer(text=scaling_note)
+    return embed
 
 
 async def build_tower_embed(name: str) -> discord.Embed:

--- a/disbot/cogs/btd6_reference_cog.py
+++ b/disbot/cogs/btd6_reference_cog.py
@@ -54,6 +54,26 @@ class BTD6ReferenceCog(commands.Cog):
     async def btd6_round(self, ctx: commands.Context, number: int) -> None:
         await ctx.send(embed=await _builders.build_round_embed(number))
 
+    @btd6ref_group.command(name="income")  # type: ignore[arg-type]
+    async def btd6_income(
+        self,
+        ctx: commands.Context,
+        start_round: int,
+        end_round: int | None = None,
+    ) -> None:
+        """Verified cash per round — single round or an inclusive range."""
+        await ctx.send(embed=await _builders.build_income_embed(start_round, end_round))
+
+    @btd6ref_group.command(name="rbe")  # type: ignore[arg-type]
+    async def btd6_rbe(
+        self,
+        ctx: commands.Context,
+        start_round: int,
+        end_round: int | None = None,
+    ) -> None:
+        """RBE per round (base + freeplay-scaled) — single round or a range."""
+        await ctx.send(embed=await _builders.build_rbe_embed(start_round, end_round))
+
     @btd6ref_group.command(name="relic")  # type: ignore[arg-type]
     async def btd6_relic(self, ctx: commands.Context, *, name: str) -> None:
         """CT relic effect + current tile (by name / abbrev e.g. SMS / alias)."""
@@ -100,6 +120,42 @@ class BTD6ReferenceCog(commands.Cog):
     ) -> None:
         embed = await _builders.build_round_embed(number)
         await interaction.response.send_message(embed=embed, ephemeral=True)
+
+    @btd6ref_app_group.command(
+        name="income",
+        description="Verified cash earned per round (single round or a range).",
+    )
+    @app_commands.describe(
+        start_round="The round (or first round of a range).",
+        end_round="Last round of an inclusive range (omit for a single round).",
+        roundset="Round set: 'default' (standard) or 'abr' (alternate).",
+    )
+    async def btd6_income_slash(
+        self,
+        interaction: discord.Interaction,
+        start_round: int,
+        end_round: int | None = None,
+        roundset: str = "default",
+    ) -> None:
+        embed = await _builders.build_income_embed(start_round, end_round, roundset)
+        await interaction.response.send_message(embed=embed)
+
+    @btd6ref_app_group.command(
+        name="rbe",
+        description="RBE per round — base + freeplay-scaled (single round or a range).",
+    )
+    @app_commands.describe(
+        start_round="The round (or first round of a range).",
+        end_round="Last round of an inclusive range (omit for a single round).",
+    )
+    async def btd6_rbe_slash(
+        self,
+        interaction: discord.Interaction,
+        start_round: int,
+        end_round: int | None = None,
+    ) -> None:
+        embed = await _builders.build_rbe_embed(start_round, end_round)
+        await interaction.response.send_message(embed=embed)
 
     @btd6ref_app_group.command(
         name="relic",

--- a/disbot/services/btd6_data_service.py
+++ b/disbot/services/btd6_data_service.py
@@ -2461,6 +2461,198 @@ def round_cash(
     return result
 
 
+def _group_fortified(group: dict[str, Any]) -> bool:
+    """Whether a round spawn group carries the ``fortified`` modifier."""
+    mods = group.get("modifiers") or ()
+    return any(str(m).lower() == "fortified" for m in mods)
+
+
+def _bloon_base_rbe(bloon_id: str, *, fortified: bool) -> int | None:
+    """A bloon's stored base RBE (``rbe_fortified`` when fortified, if present)."""
+    bloon = get_bloon(bloon_id)
+    if bloon is None:
+        return None
+    if fortified and bloon.rbe_fortified is not None:
+        return int(bloon.rbe_fortified)
+    return int(bloon.rbe) if bloon.rbe is not None else None
+
+
+def _bloon_label(bloon_id: str) -> str:
+    """A bloon's canonical name, falling back to its id."""
+    bloon = get_bloon(bloon_id)
+    return bloon.canonical if bloon is not None else bloon_id
+
+
+def _effective_round_rbe(entry: RoundEntry) -> int | None:
+    """A round's freeplay-scaled RBE: each group's count x the per-bloon scaled
+    RBE at this round (:func:`bloon_rbe_at_round`). ``None`` if any group's bloon
+    RBE is unknown (so the caller shows only the base figure, never a partial sum
+    passed off as the whole). Identical to ``entry.rbe`` through round 80 — the
+    sum reconstructs the stored base RBE exactly when no scaling applies, which is
+    what makes the 81+ divergence purely the freeplay rules (pinned by
+    ``tests/unit/services/test_btd6_round_rbe.py``).
+    """
+    if not entry.groups:
+        return None
+    total = 0
+    for group in entry.groups:
+        per = bloon_rbe_at_round(
+            str(group.get("bloon_id")),
+            entry.round_number,
+            fortified=_group_fortified(group),
+        )
+        if per is None:
+            return None
+        total += int(group.get("count", 0)) * per
+    return total
+
+
+def round_rbe(
+    round_start: int,
+    round_end: int | None = None,
+    roundset: str = "default",
+) -> dict[str, Any]:
+    """Base and freeplay-scaled RBE for a round or inclusive round range.
+
+    Two RBE notions, identical through round 80 and divergent past it (the
+    freeplay zone) — both returned so neither is misrepresented as the other:
+
+    * ``base_rbe`` — the stored :attr:`RoundEntry.rbe`, the wiki Module:BTD6_rounds
+      total at *base* bloon health. The standard reference figure.
+    * ``effective_rbe`` — the same spawn tree recomputed with the two freeplay
+      rules (every MOAB-class layer's health x :func:`moab_class_health_multiplier`,
+      every Ceramic -> Super Ceramic), via :func:`bloon_rbe_at_round` summed over
+      the round's groups. The RBE you actually face from round 81. Verified at the
+      canonical anchor ``round_rbe(100)["effective_rbe"] == 67200`` (vs 55760 base).
+      The superceramic swap can *lower* it (r81) while MOAB scaling *raises* it
+      (r140 ~4x); ``None`` if a group's bloon RBE is unknown.
+
+    A ``scaled`` flag is True when the two differ. A single round additionally
+    carries a per-bloon ``breakdown``. Mirrors :func:`round_cash`'s structured-dict
+    contract: always ``found``; out-of-range / partial / unknown-set fail closed
+    with a ``reason`` (never a fabricated number); ``per_round`` capped at
+    :data:`_ROUND_DETAIL_CAP` while the range is summed in full.
+    """
+    resolved = resolve_roundset(roundset)
+    if resolved is None:
+        return {
+            "found": False,
+            "reason": "unknown_roundset",
+            "note": f"unknown round set: {roundset!r} (default or alternate/abr)",
+        }
+    set_label = "standard" if resolved == "default" else "alternate (ABR)"
+
+    lo = round_start
+    hi = round_start if round_end is None else round_end
+    normalized = lo > hi
+    if normalized:
+        lo, hi = hi, lo
+
+    rbe_rounds = [
+        r
+        for r in _rounds_for_set(resolved)
+        if r.roundset == resolved and r.rbe is not None
+    ]
+    if not rbe_rounds:
+        return {
+            "found": False,
+            "reason": "no_rbe_data",
+            "note": f"no {set_label} round RBE data is loaded",
+        }
+    available = {r.round_number for r in rbe_rounds}
+    valid_min, valid_max = min(available), max(available)
+
+    in_range = [r for r in rbe_rounds if lo <= r.round_number <= hi]
+    if not in_range:
+        return {
+            "found": False,
+            "reason": "invalid_range",
+            "round_start": lo,
+            "round_end": hi,
+            "note": f"no {set_label} rounds in {lo}-{hi} (valid {valid_min}-{valid_max})",
+        }
+    missing = [n for n in range(lo, hi + 1) if n not in available]
+    if missing:
+        return {
+            "found": False,
+            "reason": "rbe_unavailable",
+            "round_start": lo,
+            "round_end": hi,
+            "note": (
+                f"RBE data is only available for rounds {valid_min}-{valid_max}; "
+                f"missing: {missing[:10]}"
+            ),
+        }
+
+    by_n = {r.round_number: r for r in rbe_rounds}
+
+    if lo == hi:
+        entry = by_n[lo]
+        base = int(entry.rbe) if entry.rbe is not None else None
+        effective = _effective_round_rbe(entry)
+        breakdown = []
+        for g in entry.groups:
+            bid = str(g["bloon_id"])
+            fort = _group_fortified(g)
+            breakdown.append(
+                {
+                    "bloon": _bloon_label(bid),
+                    "bloon_id": bid,
+                    "count": g.get("count"),
+                    "fortified": fort,
+                    "base_rbe_each": _bloon_base_rbe(bid, fortified=fort),
+                    "effective_rbe_each": bloon_rbe_at_round(bid, lo, fortified=fort),
+                },
+            )
+        return {
+            "found": True,
+            "roundset": resolved,
+            "single_round": True,
+            "round": lo,
+            "base_rbe": base,
+            "effective_rbe": effective,
+            "scaled": effective is not None and base is not None and effective != base,
+            "breakdown": breakdown,
+        }
+
+    per_round = [
+        {
+            "round": r.round_number,
+            "base_rbe": int(r.rbe) if r.rbe is not None else None,
+            "effective_rbe": _effective_round_rbe(r),
+        }
+        for r in in_range[:_ROUND_DETAIL_CAP]
+    ]
+    base_total = sum(int(r.rbe) for r in in_range if r.rbe is not None)
+    eff_each = [_effective_round_rbe(r) for r in in_range]
+    effective_total = (
+        sum(e for e in eff_each if e is not None)
+        if all(e is not None for e in eff_each)
+        else None
+    )
+    any_scaled = any(
+        row["effective_rbe"] is not None
+        and row["base_rbe"] is not None
+        and row["effective_rbe"] != row["base_rbe"]
+        for row in per_round
+    )
+    return {
+        "found": True,
+        "roundset": resolved,
+        "single_round": False,
+        "inclusive": True,
+        "normalized": normalized,
+        "round_start": lo,
+        "round_end": hi,
+        "rounds_counted": hi - lo + 1,
+        "base_rbe_total": base_total,
+        "effective_rbe_total": effective_total,
+        "scaled": any_scaled,
+        "per_round": per_round,
+        "truncated": len(in_range) > _ROUND_DETAIL_CAP,
+    }
+
+
 def _find_by_surface(entries: tuple, name: str):
     """First entry whose id / canonical / alias matches ``name`` (case-insensitive)."""
     key = (name or "").strip().lower()

--- a/docs/btd6/btd6-gamedata-dictionary.md
+++ b/docs/btd6/btd6-gamedata-dictionary.md
@@ -154,3 +154,10 @@ dump, mirroring the validation discipline):
   1"). So `elite_boss_multiplier(d) = boss_multiplier(d) × 2`. Same class as the
   freeplay/cash constants — the dump stores the base boss bonus, the engine doubles
   it for elite.
+
+These per-round quantities are **player-queryable** via the reference commands
+(prefix + slash): `/btd6ref income <start> [end]` (verified `round_cash`),
+`/btd6ref rbe <start> [end]` (base + freeplay-scaled `round_rbe`), and
+`/btd6ref round <n>` (composition + effective RBE). The income table deliberately
+shows our audited total, which is *lower* than CyberQuincy's (it over-counts
+fortified) — same divergence proven in the r100-120 cash validation.

--- a/docs/owner/claims/claude-great-meitner-pnfp0g.md
+++ b/docs/owner/claims/claude-great-meitner-pnfp0g.md
@@ -1,3 +1,0 @@
-# Claim
-
-- `claude/great-meitner-pnfp0g` · per-round economy slash commands (income/rbe + round composition) · `disbot/cogs/btd6_reference_cog.py`, `disbot/cogs/btd6/_builders.py`, `disbot/services/btd6_data_service.py`, tests · 2026-06-24

--- a/docs/owner/claims/claude-great-meitner-pnfp0g.md
+++ b/docs/owner/claims/claude-great-meitner-pnfp0g.md
@@ -1,0 +1,3 @@
+# Claim
+
+- `claude/great-meitner-pnfp0g` · per-round economy slash commands (income/rbe + round composition) · `disbot/cogs/btd6_reference_cog.py`, `disbot/cogs/btd6/_builders.py`, `disbot/services/btd6_data_service.py`, tests · 2026-06-24

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -7287,3 +7287,33 @@ a channel/role select.
 **Home:** this Q-block (canonical) + `.sessions/2026-06-23-ai-setup-edit-button.md` +
 `docs/subsystems/settings-bindings-provisioning.md`. Related: **Q-0048** (AI exposure gate / per-exposure
 write lift — the parent rule), Q-0123 (auto-merge on green).
+
+### Q-0200 — DISCUSS: add a "grep `def <exact_name>` before defining a new service function" step to the dedup discipline (2026-06-24)
+
+> **PROPOSED — surfaced by a real collision this session** (`.sessions/2026-06-24-btd6-per-round-economy-commands.md`).
+> This proposes a rule addition, so it routes here rather than self-editing CLAUDE.md / `helper-policy.md`
+> (the binding-rule channel). The owner is the live reviewer when present; otherwise it waits.
+
+**Context:** building the per-round economy commands (PR #1404), I added a new `round_composition` to
+`btd6_data_service` **without noticing one already existed** (the range/AI variant). Python took my later
+definition, shadowing the original and breaking its AI-tool + ABR tests — caught only at the full CI
+mirror, not pre-implementation. Root cause: the "claim before starting / don't duplicate" scan (CLAUDE.md
+§ Session workflow) and `helper-policy.md` both aim at *file/area* overlap, but my dedup grep was keyed on
+the **concepts** (`cash`/`income`/`rbe`) and command names — I never grepped the **exact function name** I
+was about to define. `round_rbe` (genuinely new) was fine; `round_composition` was a name I should have
+checked.
+
+**The proposal:** add one mechanical line to the dedup discipline (in `helper-policy.md`, mirrored in the
+CLAUDE.md helper rules): *before defining a new `services/`-or-`utils/` function, grep `def <exact_name>`
+in the target module **and** its sibling modules, plus the 1-2 nearest concept synonyms.* Cheap,
+deterministic, and it converts a class of "shadowed an existing symbol" bug from a full-mirror catch into
+a five-second pre-write check.
+
+**Open question for the owner:** worth codifying as a rule, or leave as session-log lore? It's the kind of
+tiny guard the kill-switch convention (Q-0105) covers — adopt it, delete it later if it proves noise.
+Recommendation: **adopt** in `helper-policy.md` (not a CI gate — a checklist line), since the failure it
+prevents is silent until CI and trivially avoidable.
+
+**Home:** this Q-block (canonical) + the session log. Related: **Q-0014** (claim/dedup before starting),
+**helper-policy.md** (the durable home if adopted), Q-0120 (verify-tool-vs-evidence — same "catch it
+earlier" instinct).

--- a/tests/unit/cogs/test_btd6_income_rbe_builders.py
+++ b/tests/unit/cogs/test_btd6_income_rbe_builders.py
@@ -1,0 +1,91 @@
+"""Embed builders for the per-round economy commands (income / rbe / round).
+
+These render the verified per-round data (``btd6_data_service.round_cash`` /
+``round_rbe`` / ``round_composition``) into the ``/btd6ref`` embeds. The numbers
+themselves are pinned by the service-layer tests; here we assert the embeds
+*surface* them correctly and fail visibly (red embed) on a bad range.
+"""
+
+from __future__ import annotations
+
+import discord
+import pytest
+
+from cogs.btd6 import _builders
+
+
+@pytest.mark.asyncio
+async def test_income_range_shows_verified_total_and_table() -> None:
+    embed = await _builders.build_income_embed(100, 120)
+    assert embed.color == discord.Color.green()
+    assert "rounds 100–120" in embed.title
+    # Our audited total — not CyberQuincy's inflated $139,067.
+    assert "$89,878" in embed.description
+    assert "```" in embed.description  # the monospace table
+    assert "r100" in embed.description and "r120" in embed.description
+    assert "income towers" in embed.footer.text  # assumptions surfaced verbatim
+
+
+@pytest.mark.asyncio
+async def test_income_single_round() -> None:
+    embed = await _builders.build_income_embed(100)
+    assert "round 100" in embed.title
+    assert "$1,534.6" in embed.description
+    assert "180,374" in embed.description  # cumulative
+
+
+@pytest.mark.asyncio
+async def test_income_bad_range_is_red_and_explains() -> None:
+    embed = await _builders.build_income_embed(200, 250)
+    assert embed.color == discord.Color.red()
+    assert "1-140" in embed.description
+
+
+@pytest.mark.asyncio
+async def test_income_full_range_elides_with_marker() -> None:
+    embed = await _builders.build_income_embed(1, 140)
+    assert "⋮" in embed.description  # head+tail elision marker
+    assert "truncated" in embed.footer.text
+
+
+@pytest.mark.asyncio
+async def test_rbe_scaled_range_shows_both_columns_and_note() -> None:
+    embed = await _builders.build_rbe_embed(99, 103)
+    assert embed.color == discord.Color.blue()
+    assert "base RBE" in embed.description and "effective" in embed.description
+    assert "67,200" in embed.description  # the r100 anchor, effective column
+    assert "verified BAD r100 = 67,200" in embed.footer.text
+
+
+@pytest.mark.asyncio
+async def test_rbe_unscaled_range_is_single_column_no_footer() -> None:
+    embed = await _builders.build_rbe_embed(5, 8)
+    # No "effective" column header when nothing in range scales.
+    assert "effective" not in embed.description
+    assert embed.footer.text is None
+
+
+@pytest.mark.asyncio
+async def test_rbe_single_round_shows_effective_over_base() -> None:
+    embed = await _builders.build_rbe_embed(100)
+    assert "67,200" in embed.description
+    assert "55,760" in embed.description
+
+
+@pytest.mark.asyncio
+async def test_round_embed_adds_composition_and_effective_rbe() -> None:
+    embed = await _builders.build_round_embed(100)
+    names = {f.name for f in embed.fields}
+    assert any("Bloons this round" in n for n in names)
+    assert any("Effective RBE" in n for n in names)
+    comp = next(f for f in embed.fields if "Bloons this round" in f.name)
+    assert "BAD" in comp.value
+
+
+@pytest.mark.asyncio
+async def test_round_embed_below_freeplay_has_no_effective_rbe_field() -> None:
+    embed = await _builders.build_round_embed(6)
+    names = {f.name for f in embed.fields}
+    # Composition is always shown; the effective-RBE field only when it scales.
+    assert any("Bloons this round" in n for n in names)
+    assert not any("Effective RBE" in n for n in names)

--- a/tests/unit/cogs/test_btd6_split_command_parity.py
+++ b/tests/unit/cogs/test_btd6_split_command_parity.py
@@ -21,7 +21,7 @@ from cogs.btd6_reference_cog import BTD6ReferenceCog
 from cogs.btd6_strategy_cog import BTD6StrategyCog
 
 _EXPECTED: dict[type[commands.Cog], set[str]] = {
-    BTD6ReferenceCog: {"tower", "hero", "round", "relic", "ct"},
+    BTD6ReferenceCog: {"tower", "hero", "round", "relic", "ct", "income", "rbe"},
     BTD6EventsCog: {
         "live",
         "event",

--- a/tests/unit/services/test_btd6_round_rbe.py
+++ b/tests/unit/services/test_btd6_round_rbe.py
@@ -1,0 +1,107 @@
+"""Per-round RBE lookup (``round_rbe``) — base and freeplay-scaled.
+
+``round_rbe`` exposes two RBE notions that must stay honest:
+
+* ``base_rbe`` — the wiki Module:BTD6_rounds total at base bloon health.
+* ``effective_rbe`` — the same spawn tree recomputed with the freeplay rules
+  (MOAB-class HP scaling + superceramic swap), via ``bloon_rbe_at_round``.
+
+The load-bearing invariant is that the effective sum *reconstructs* the stored
+base RBE for every round through 80 (no scaling applies there), so the 81+
+divergence is provably the freeplay rules and not a methodology mismatch. The
+canonical freeplay anchor is BAD @ r100 = 67,200 (vs 55,760 base), the same
+value pinned by ``test_btd6_bloon_scaling.py``.
+
+(Bloon *composition* per round is the pre-existing ``round_composition``; this
+file only covers the new RBE function. The round embed's composition rendering
+is covered by ``tests/unit/cogs/test_btd6_income_rbe_builders.py``.)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.btd6_data_service import round_rbe
+
+
+def test_single_round_base_and_effective_at_the_r100_anchor() -> None:
+    res = round_rbe(100)
+    assert res["found"] is True
+    assert res["single_round"] is True
+    assert res["base_rbe"] == 55760
+    assert res["effective_rbe"] == 67200  # the verified freeplay anchor
+    assert res["scaled"] is True
+    # Breakdown names the one bloon and both per-bloon figures.
+    assert len(res["breakdown"]) == 1
+    row = res["breakdown"][0]
+    assert row["bloon"] == "BAD"
+    assert row["count"] == 1
+    assert row["base_rbe_each"] == 55760
+    assert row["effective_rbe_each"] == 67200
+
+
+def test_single_round_below_freeplay_is_not_scaled() -> None:
+    res = round_rbe(6)
+    assert res["scaled"] is False
+    assert res["base_rbe"] == res["effective_rbe"]
+
+
+def test_effective_reconstructs_base_through_round_80() -> None:
+    # The methodology proof: with no freeplay scaling (rounds <= 80), summing
+    # each group's count x bloon_rbe_at_round must equal the stored base RBE.
+    for n in range(1, 81):
+        res = round_rbe(n)
+        if res.get("base_rbe") is None:
+            continue
+        assert (
+            res["effective_rbe"] == res["base_rbe"]
+        ), f"round {n} diverged below freeplay"
+        assert res["scaled"] is False, f"round {n} should not be scaled"
+
+
+def test_freeplay_rounds_diverge_from_base() -> None:
+    # Superceramic swap can lower RBE (r81), MOAB scaling raises it (r140).
+    assert round_rbe(81)["effective_rbe"] < round_rbe(81)["base_rbe"]
+    assert round_rbe(140)["effective_rbe"] > round_rbe(140)["base_rbe"]
+
+
+def test_range_totals_and_rows() -> None:
+    res = round_rbe(100, 120)
+    assert res["found"] is True
+    assert res["single_round"] is False
+    assert res["rounds_counted"] == 21
+    assert len(res["per_round"]) == 21
+    assert res["scaled"] is True
+    # Totals equal the sum of the per-round rows we expose.
+    assert res["base_rbe_total"] == sum(r["base_rbe"] for r in res["per_round"])
+    assert res["effective_rbe_total"] == sum(
+        r["effective_rbe"] for r in res["per_round"]
+    )
+    # Effective beats base once blimps scale.
+    assert res["effective_rbe_total"] > res["base_rbe_total"]
+
+
+def test_range_normalizes_reversed_endpoints() -> None:
+    res = round_rbe(120, 100)
+    assert res["normalized"] is True
+    assert res["round_start"] == 100
+    assert res["round_end"] == 120
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "reason"),
+    [
+        (200, 250, "invalid_range"),
+        (100, 200, "rbe_unavailable"),  # straddles the edge of the known set
+    ],
+)
+def test_out_of_range_fails_closed(start: int, end: int, reason: str) -> None:
+    res = round_rbe(start, end)
+    assert res["found"] is False
+    assert res["reason"] == reason
+
+
+def test_unknown_roundset_fails_closed() -> None:
+    res = round_rbe(1, 10, roundset="nonsense")
+    assert res["found"] is False
+    assert res["reason"] == "unknown_roundset"


### PR DESCRIPTION
## Per-round economy lookups — `/btd6ref income`, `/btd6ref rbe`, enhanced `/btd6ref round`

Owner-directed (Discord screen recording of CyberQuincy's `/income`): let people
see **cash, RBE, and bloons per round** via slash (and prefix) commands — with
**our verified numbers**.

This is an exposure layer over data this session-arc already built and verified;
no new modelling.

### Commands (prefix `!btd6ref` + slash `/btd6ref`, mirrored via `cogs.btd6._builders`)
- **`income <start> [end] [roundset]`** — verified per-round cash + cumulative +
  range total. Engine: `round_cash()`. r100-120 = **$89,878** (matches the in-game
  double-cash test + round bonus; CyberQuincy's $139,067 over-counts fortified).
- **`rbe <start> [end]`** — base (wiki composition) and **effective freeplay-scaled**
  RBE per round. Diverge for rounds 81+ (MOAB scaling + superceramic swap); both
  shown, labelled. Verified anchor: BAD r100 effective = 67,200 vs 55,760 base.
- **`round <n>`** (enhanced) — now lists the bloon **composition** and the effective
  RBE for late rounds, on top of the existing danger / cash / XP.

### Rigor
- **Cash** is the verified model (carries `_CASH_ASSUMPTIONS`: Medium, no income
  towers, standard set).
- **Effective RBE** is our engine's output (`bloon_rbe_at_round`), verified at the
  r100 anchor and labelled "freeplay-scaled (model)"; **base RBE** is the directly
  wiki-sourced value. Neither is presented as the other.

Born-red session card; auto-merges on green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hydy3uLzrkCmqHWT2VoEKG)_