### PR TITLE
btd6: AI floor coverage — range RBE + paragon elite-boss multiplier

### DIFF
--- a/.sessions/2026-06-24-btd6-ai-floor-coverage-fixes.md
+++ b/.sessions/2026-06-24-btd6-ai-floor-coverage-fixes.md
@@ -1,0 +1,34 @@
+# 2026-06-24 — BTD6 AI floor coverage: range RBE + paragon elite-boss multiplier
+
+> **Status:** `in-progress` — owner-reported bugs (Discord screenshots). Born-red
+> card; flips to `complete` last. PR pending.
+
+> **Run type:** `manual · owner-directed`
+
+Owner showed three live failures (all the *same* root cause — deterministic-floor
+coverage gaps, so the model is left to freelance and refuses / gets faithfulness-
+rejected):
+1. **"rbe of r20 to r80"** → returns only Round 20. `deterministic_round_economy_reply`
+   matches the "rbe" cue, grabs the first round number (`r20`) via the single-number
+   regex, and ignores the range. (Regression: "rounds 8 to 66 in ABR" still works —
+   "rounds" doesn't match the single-number regex, so it defers to the round_composition
+   tool. Only the `rN`-shorthand range form broke.)
+2. **"elite boss multiplier for paragons"** (general) → "no verified data" refusal. The
+   #1402 elite grounding lives in `_render_paragon_stats`, which only runs when a
+   *specific* paragon resolves — the general question gets no grounding.
+3. **"elite boss multiplier for the dart paragon"** (named) → "I drafted an answer but
+   held it back" = the faithfulness floor killing a model draft. Grounding alone isn't
+   surviving.
+
+## What I'm about to do
+- **Fix 1 — range-aware economy floor:** when `deterministic_round_economy_reply` sees
+  exactly one round range, return a deterministic range-total reply (total RBE base +
+  freeplay-scaled via `round_rbe`, total cash via `round_cash`, heaviest rounds via
+  `round_composition`). ≥2 ranges defers to the §7.5 comparison floor. Verified: this
+  reproduces the proven 06/18 answer (ABR 8-66 = 168,518 RBE; heaviest R65/R63/R62).
+- **Fix 2 — deterministic paragon elite floor:** new `deterministic_paragon_elite_reply`
+  in `_BTD6_LIST_BUILDERS`, fires on elite+paragon+(multiplier/damage) cues, returns the
+  ×2 rule (×2 at Degree 1 → ×4.5 at Degree 100; global, runtime constant). Bypasses the
+  model + faithfulness floor entirely, so it can't refuse — works for both the general
+  and the named-paragon question.
+- Tests for both + the floor-exclusivity invariant; full CI mirror before flip.

--- a/.sessions/2026-06-24-btd6-ai-floor-coverage-fixes.md
+++ b/.sessions/2026-06-24-btd6-ai-floor-coverage-fixes.md
@@ -1,34 +1,69 @@
 # 2026-06-24 — BTD6 AI floor coverage: range RBE + paragon elite-boss multiplier
 
-> **Status:** `in-progress` — owner-reported bugs (Discord screenshots). Born-red
-> card; flips to `complete` last. PR pending.
+> **Status:** `complete` — owner-reported bugs (Discord screenshots), fixed and
+> verified live through the dispatcher. PR #1408; auto-merge armed; merges on green.
 
 > **Run type:** `manual · owner-directed`
 
+> **⚑ Self-initiated:** none — all three fixes are owner-reported production refusals.
+
 Owner showed three live failures (all the *same* root cause — deterministic-floor
 coverage gaps, so the model is left to freelance and refuses / gets faithfulness-
-rejected):
-1. **"rbe of r20 to r80"** → returns only Round 20. `deterministic_round_economy_reply`
-   matches the "rbe" cue, grabs the first round number (`r20`) via the single-number
-   regex, and ignores the range. (Regression: "rounds 8 to 66 in ABR" still works —
-   "rounds" doesn't match the single-number regex, so it defers to the round_composition
-   tool. Only the `rN`-shorthand range form broke.)
-2. **"elite boss multiplier for paragons"** (general) → "no verified data" refusal. The
-   #1402 elite grounding lives in `_render_paragon_stats`, which only runs when a
-   *specific* paragon resolves — the general question gets no grounding.
-3. **"elite boss multiplier for the dart paragon"** (named) → "I drafted an answer but
-   held it back" = the faithfulness floor killing a model draft. Grounding alone isn't
-   surviving.
+rejected). Notably, two of them were gaps left by *this same session-arc's* prior
+PRs (#1402 elite, #1404 round commands) — the data/grounding shipped, but the live
+answer path still refused.
 
-## What I'm about to do
-- **Fix 1 — range-aware economy floor:** when `deterministic_round_economy_reply` sees
-  exactly one round range, return a deterministic range-total reply (total RBE base +
-  freeplay-scaled via `round_rbe`, total cash via `round_cash`, heaviest rounds via
-  `round_composition`). ≥2 ranges defers to the §7.5 comparison floor. Verified: this
-  reproduces the proven 06/18 answer (ABR 8-66 = 168,518 RBE; heaviest R65/R63/R62).
-- **Fix 2 — deterministic paragon elite floor:** new `deterministic_paragon_elite_reply`
-  in `_BTD6_LIST_BUILDERS`, fires on elite+paragon+(multiplier/damage) cues, returns the
-  ×2 rule (×2 at Degree 1 → ×4.5 at Degree 100; global, runtime constant). Bypasses the
-  model + faithfulness floor entirely, so it can't refuse — works for both the general
-  and the named-paragon question.
-- Tests for both + the floor-exclusivity invariant; full CI mirror before flip.
+## Shipped (PR #1408)
+Both fixes are deterministic floors in `btd6_context_service.py` — immune to model
+refusal / the faithfulness floor:
+
+1. **Range-aware economy floor.** `deterministic_round_economy_reply` now detects a
+   single round range and returns deterministic range totals via
+   `_round_range_economy_reply` (total RBE base + freeplay-scaled from `round_rbe`,
+   total cash from `round_cash`, heaviest rounds from `round_composition`); ≥2 ranges
+   defer to the §7.5 comparison floor. **Verified it reproduces the proven 06/18
+   answer exactly:** ABR rounds 8-66 = **168,518** RBE, heaviest R65/R63/R62.
+   - Was: `rbe of r20 to r80` → only Round 20 (the single-number regex grabbed `r20`).
+2. **`deterministic_paragon_elite_reply`** (new floor, registered + corpus-pinned).
+   Owns the elite-boss-multiplier question — general *and* named paragon — returning
+   the global runtime constant (×2 every degree, ×2→×4.5, paragon-category-wide).
+   - Was: general → "no verified data" refusal; named (`dart paragon`) → faithfulness
+     floor held the model draft back.
+
+Tests: range totals + the 168,518 anchor (`test_btd6_round_economy_reply.py`); the
+elite floor incl. value-pinning to `paragon_degrees` (`test_btd6_paragon_elite_reply.py`);
+floor-exclusivity invariant extended. Full CI mirror green.
+
+## 💡 Session idea (Q-0089)
+A **`_MUST_ANSWER` regression corpus** — sibling to the exclusivity test's
+`_SHOULD_FIRE` / `_SHOULD_DEFER` — seeded with the owner's *actual production-failed*
+phrasings ("rbe of r20 to r80", "elite boss multiplier for the dart paragon", …),
+asserting `deterministic_btd6_list_reply` returns non-`None`. Every prod refusal the
+owner reports becomes a permanent entry, so the *same* refusal can't regress. Cheap,
+directly motivated by today's three-in-a-row. Dedup-checked: the exclusivity corpora
+test fire/defer routing, not must-not-refuse. (Not built; flagged for grooming.)
+
+## ⟲ Previous-session review (Q-0102)
+Reviewed **2026-06-24-btd6-per-round-economy-commands** (#1404, merged hours ago).
+Did well: clean, fully-verified feature; caught + fixed its own `round_composition`
+duplication at the mirror. **What it (and #1402) missed:** both shipped *data +
+grounding* but never ran the **live natural-language questions** through
+`deterministic_btd6_list_reply` / the answer pipeline to confirm the bot actually
+**answers** — so both left prod refusals the owner had to find. **System improvement
+(the real lesson of today):** *grounding present ≠ question answered.* After any BTD6
+data/grounding change, run a handful of representative end-user phrasings through the
+answer path, not just the unit-level data function. The Q-0089 must-answer corpus
+would make that a CI guard instead of a manual habit. This session is the correction.
+
+## Backlog grooming (Q-0015)
+`round-range-comparison-bare-range-list-2026-06-16.md` is now **partially delivered**:
+the range-economy floor handles a single round range with an economy/rbe cue. The
+idea's remaining piece — comma-list phrasing ("rounds 1-30, 30-60") for the *cash
+comparison* floor — is still open (it lives in `_extract_round_ranges` bare-range
+parsing + the ≥2-range comparison floor). Noted on the idea; not promoted here.
+
+## Doc audit (Q-0104)
+`check_docs --strict` ✓, ledger ✓, full mirror green. No new runtime-formula fact
+(elite ×2 already in the gamedata-dictionary from #1402); the floors are internal
+answer-path coverage. No owner-decision/router change. Ledger entries for #1408 land
+via the next reconciliation pass (Q-0052).

--- a/disbot/services/btd6_context_service.py
+++ b/disbot/services/btd6_context_service.py
@@ -4112,6 +4112,42 @@ _ROUND_ECONOMY_CUE_RE = re.compile(
 )
 
 
+def _round_range_economy_reply(lo: int, hi: int, roundset: str) -> str | None:
+    """Deterministic "total RBE + cash across rounds ``lo``-``hi``" answer, or ``None``.
+
+    The range case of :func:`deterministic_round_economy_reply`, off the same audited
+    engines the ``/btd6ref`` commands use — total RBE (base + freeplay-scaled) via
+    ``round_rbe``, total cash via ``round_cash``, heaviest rounds via
+    ``round_composition``. ``None`` when the range is unknown (the data layer fails
+    closed), so the query falls through to the model rather than inventing a partial sum.
+    """
+    from services import btd6_data_service
+
+    rbe = btd6_data_service.round_rbe(lo, hi, roundset)
+    if not rbe.get("found") or rbe.get("base_rbe_total") is None:
+        return None
+    set_label = "ABR" if roundset == "alternate" else "default rounds"
+    base_total = rbe["base_rbe_total"]
+    eff_total = rbe.get("effective_rbe_total")
+    lines = [f"**Rounds {lo}–{hi} — totals** ({set_label})"]
+    if rbe.get("scaled") and eff_total is not None and eff_total != base_total:
+        lines.append(
+            f"• **Total RBE** {base_total:,} base → **{eff_total:,}** with "
+            "MOAB-class freeplay scaling",
+        )
+    else:
+        lines.append(f"• **Total RBE** {base_total:,}")
+    cash = btd6_data_service.round_cash(lo, hi, roundset)
+    if cash.get("found") and cash.get("range_cash") is not None:
+        lines.append(f"• **Total cash** ${cash['range_cash']:,.0f}")
+    comp = btd6_data_service.round_composition(lo, hi, roundset=roundset)
+    heaviest = comp.get("heaviest_by_rbe") if comp.get("found") else None
+    if heaviest:
+        top = ", ".join(f"R{h['round']} ({h['rbe']:,} RBE)" for h in heaviest[:3])
+        lines.append(f"• **Heaviest rounds:** {top}")
+    return "\n".join(lines)
+
+
 def deterministic_round_economy_reply(message_text: str) -> str | None:
     """A code-built "economy of round N" answer (RBE + cash + XP), or ``None``.
 
@@ -4127,14 +4163,26 @@ def deterministic_round_economy_reply(message_text: str) -> str | None:
     low = text.lower()
     if not _ROUND_ECONOMY_CUE_RE.search(low):
         return None
-    number_match = _ROUND_XP_NUMBER_RE.search(low)
-    if number_match is None:
-        return None
-    round_number = int(number_match.group(1) or number_match.group(2))
 
     from services import btd6_data_service
 
     roundset = "alternate" if _ABR_CUE_RE.search(low) else "default"
+
+    # A round RANGE ("r20 to r80", "rounds 8-66") asks for the range TOTAL, not one
+    # round's economy. Without this, the single-number regex below grabs the first
+    # endpoint and answers for that one round — the "rbe of r20 to r80 → only Round
+    # 20" regression. Two+ ranges is the §7.5 comparison floor's job; defer there.
+    proper_ranges = [(lo, hi) for lo, hi in _extract_round_ranges(low) if lo != hi]
+    if len(proper_ranges) >= 2:
+        return None
+    if len(proper_ranges) == 1:
+        lo, hi = proper_ranges[0]
+        return _round_range_economy_reply(lo, hi, roundset)
+
+    number_match = _ROUND_XP_NUMBER_RE.search(low)
+    if number_match is None:
+        return None
+    round_number = int(number_match.group(1) or number_match.group(2))
     entry = btd6_data_service.get_round(round_number, roundset)
     if entry is None:
         return None
@@ -4193,6 +4241,60 @@ def deterministic_round_economy_reply(message_text: str) -> str | None:
     return "\n".join(lines)
 
 
+_ELITE_CUE_RE = re.compile(r"\belite\b", re.I)
+_PARAGON_WORD_RE = re.compile(r"\bparagons?\b", re.I)
+_ELITE_MULT_CUE_RE = re.compile(
+    r"\b(?:multiplier|damage|dmg|bonus|double|doubled|x\s?2|×\s?2)\b",
+    re.I,
+)
+
+
+def deterministic_paragon_elite_reply(message_text: str) -> str | None:
+    """A code-built "paragon Elite-Boss damage multiplier" answer, or ``None``.
+
+    Owns the elite-boss-multiplier question for paragons — general ("the elite boss
+    multiplier for paragons") or a named one ("for the dart paragon"). Both refused
+    in production: the #1402 elite grounding only fires for a *resolved* paragon, and
+    the faithfulness floor killed the model's draft even when it did. The answer is a
+    global runtime constant — paragons deal DOUBLE their boss damage to Elite Bosses,
+    at every degree — so a deterministic reply is correct AND refusal-proof.
+
+    Fires on ``elite`` + a damage/multiplier cue + paragon context (the word, or a
+    resolvable paragon name); defers otherwise. Narrow enough to stay exclusive with
+    the other paragon floors (cost/abilities), which carry no ``elite`` cue.
+    """
+    text = (message_text or "").strip()
+    if not text:
+        return None
+    low = text.lower()
+    if not (_ELITE_CUE_RE.search(low) and _ELITE_MULT_CUE_RE.search(low)):
+        return None
+
+    from services import btd6_stats_service
+    from utils.btd6 import paragon_degrees
+
+    has_paragon = bool(_PARAGON_WORD_RE.search(low)) or (
+        btd6_stats_service.resolve_paragon(text) is not None
+    )
+    if not has_paragon:
+        return None
+
+    boss100 = paragon_degrees.boss_multiplier(100)
+    elite1 = paragon_degrees.elite_boss_multiplier(1)
+    elite100 = paragon_degrees.elite_boss_multiplier(100)
+    return (
+        "**Paragon Elite-Boss damage** — against **Elite** Bosses, every Paragon "
+        "deals **double** its boss damage.\n"
+        "• A flat **×2** on top of the boss-damage multiplier, at **every degree** "
+        "(from Degree 1).\n"
+        f"• So the elite-boss multiplier = 2 × the boss multiplier: **×{elite1:g} at "
+        f"Degree 1**, rising to **×{elite100:g} at Degree 100** (boss is ×{boss100:g} "
+        "at Degree 100).\n"
+        "• Global to the whole Paragon category — not per-paragon — and a runtime "
+        "constant, so it is not in the game's exported data."
+    )
+
+
 # --- BUG-0009 deterministic list-answer dispatcher ----------------------------
 # The ordered floor builders the dispatcher fans out to. Each OWNS its labelled
 # answer and is narrow (returns ``None`` for anything but its exact list shape),
@@ -4218,6 +4320,7 @@ _BTD6_LIST_BUILDERS: tuple[Callable[[str], str | None], ...] = (
     deterministic_relic_roster_reply,
     deterministic_hero_ability_roster_reply,
     deterministic_paragon_ability_roster_reply,
+    deterministic_paragon_elite_reply,
     deterministic_paragon_cost_comparison_reply,
     deterministic_hero_cost_comparison_reply,
     deterministic_power_cost_comparison_reply,

--- a/docs/owner/claims/claude-great-meitner-pnfp0g.md
+++ b/docs/owner/claims/claude-great-meitner-pnfp0g.md
@@ -1,3 +1,0 @@
-# Claim
-
-- `claude/great-meitner-pnfp0g` · BTD6 AI floor coverage: range-RBE + paragon elite-boss multiplier (owner-reported refusals) · `disbot/services/btd6_context_service.py`, tests · 2026-06-24

--- a/docs/owner/claims/claude-great-meitner-pnfp0g.md
+++ b/docs/owner/claims/claude-great-meitner-pnfp0g.md
@@ -1,0 +1,3 @@
+# Claim
+
+- `claude/great-meitner-pnfp0g` · BTD6 AI floor coverage: range-RBE + paragon elite-boss multiplier (owner-reported refusals) · `disbot/services/btd6_context_service.py`, tests · 2026-06-24

--- a/tests/unit/invariants/test_btd6_floor_builder_exclusivity.py
+++ b/tests/unit/invariants/test_btd6_floor_builder_exclusivity.py
@@ -105,6 +105,10 @@ _SHOULD_FIRE: tuple[tuple[str, str], ...] = (
         "deterministic_paragon_ability_roster_reply",
     ),
     (
+        "what's the elite boss damage multiplier for paragons",
+        "deterministic_paragon_elite_reply",
+    ),
+    (
         "which bosses are immune to fire",
         "deterministic_boss_immunity_reply",
     ),

--- a/tests/unit/services/test_btd6_paragon_elite_reply.py
+++ b/tests/unit/services/test_btd6_paragon_elite_reply.py
@@ -1,0 +1,78 @@
+"""Deterministic paragon Elite-Boss damage-multiplier floor.
+
+Owner-reported (2026-06-24): "elite boss multiplier for paragons" refused with
+"no verified data", and the named-paragon form ("for the dart paragon") got
+faithfulness-rejected. Both are now owned by a deterministic floor — the answer
+is a global runtime constant (paragons deal ×2 their boss damage to Elite Bosses,
+every degree), so it can be served without the model and can't refuse.
+
+The ×2 / ×4.5 figures are pinned to ``utils.btd6.paragon_degrees`` so the reply
+can't drift from the shipped constant.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from services import btd6_context_service  # noqa: E402
+from utils.btd6 import paragon_degrees  # noqa: E402
+
+_reply = btd6_context_service.deterministic_paragon_elite_reply
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "whats the elite boss damage multiplier for paragons",
+        "what's the elite boss multiplier for the dart paragon",
+        "elite boss bonus for the glaive dominus paragon",
+        "how much extra damage do paragons do to elite bosses, doubled?",
+    ],
+)
+def test_fires_on_general_and_named_paragon_elite_questions(phrase):
+    reply = _reply(phrase)
+    assert reply is not None
+    assert "double" in reply.lower()
+
+
+def test_values_match_the_shipped_constant():
+    reply = _reply("elite boss damage multiplier for paragons")
+    assert reply is not None
+    # x2 at degree 1, x4.5 at degree 100 — from paragon_degrees, not hardcoded.
+    assert f"×{paragon_degrees.elite_boss_multiplier(1):g}" in reply  # ×2
+    assert f"×{paragon_degrees.elite_boss_multiplier(100):g}" in reply  # ×4.5
+    assert f"×{paragon_degrees.boss_multiplier(100):g}" in reply  # ×2.25
+    # The key facts the owner needed: global + runtime constant.
+    assert "every degree" in reply.lower()
+    assert "not per-paragon" in reply.lower()
+
+
+def test_defers_without_an_elite_cue():
+    # Boss multiplier (non-elite) is a different question — not ours.
+    assert _reply("what's the boss multiplier for paragons") is None
+
+
+def test_defers_without_paragon_context():
+    # "elite boss damage" with no paragon (worded or resolvable) is not ours —
+    # it belongs to the boss floors / model.
+    assert _reply("how much damage does an elite boss take") is None
+
+
+def test_defers_without_a_damage_or_multiplier_cue():
+    # "elite lych for paragons to fight" — no multiplier/damage cue.
+    assert _reply("which paragon is best against an elite lych") is None
+
+
+def test_dispatcher_routes_the_elite_reply():
+    reply = btd6_context_service.deterministic_btd6_list_reply(
+        "whats the elite boss damage multiplier for paragons",
+    )
+    assert reply is not None
+    assert "Elite-Boss" in reply

--- a/tests/unit/services/test_btd6_round_economy_reply.py
+++ b/tests/unit/services/test_btd6_round_economy_reply.py
@@ -119,3 +119,53 @@ def test_pure_xp_question_routes_to_the_xp_builder_not_economy():
         )
         is None
     )
+
+
+# --- range totals (regression: "rbe of r20 to r80" used to return only Round 20) ---
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "what's the rbe of r20 to r80",
+        "what's the total rbe of r20 to r80",
+        "rbe of rounds 20-80",
+    ],
+)
+def test_range_query_returns_total_not_single_round(phrase):
+    reply = btd6_context_service.deterministic_round_economy_reply(phrase)
+    assert reply is not None
+    assert "Rounds 20" in reply and "80" in reply
+    assert "Total RBE" in reply
+    # The bug was returning the single first-round card instead of the range.
+    assert "Round 20 — RBE, cash & XP" not in reply
+
+
+def test_range_total_reproduces_the_proven_abr_anchor():
+    # The 06/18 known-good answer: ABR rounds 8-66 = 168,518 total RBE, heaviest
+    # R65/R63/R62. Pin it so the deterministic range reply can't drift from it.
+    reply = btd6_context_service.deterministic_round_economy_reply(
+        "how much rbe is in rounds 8 to 66 in abr",
+    )
+    assert reply is not None
+    assert "ABR" in reply
+    assert "168,518" in reply
+    assert "R65" in reply and "R63" in reply
+
+
+def test_single_round_economy_still_works():
+    reply = btd6_context_service.deterministic_round_economy_reply(
+        "what's the rbe of round 20",
+    )
+    assert reply is not None
+    assert "Round 20 — RBE, cash & XP" in reply
+
+
+def test_two_ranges_defer_to_the_comparison_floor():
+    # ≥2 ranges is the §7.5 comparison floor's job — the economy floor must defer.
+    assert (
+        btd6_context_service.deterministic_round_economy_reply(
+            "rbe of rounds 1-30 or rounds 30-60",
+        )
+        is None
+    )


### PR DESCRIPTION
## Owner-reported refusals — three symptoms, one root cause

All three are **deterministic-floor coverage gaps**: the query shape isn't owned by a floor, so the model freelances and either refuses or gets faithfulness-rejected.

1. **`rbe of r20 to r80`** → returned only Round 20. `deterministic_round_economy_reply` matched the `rbe` cue, grabbed the first round number (`r20`), and ignored the range. (Regression on the `rN`-shorthand range form; `rounds 8 to 66 in ABR` still worked because `rounds` doesn't match the single-number regex.)
2. **`elite boss multiplier for paragons`** (general) → "no verified data" refusal — the #1402 elite grounding only fires for a *specific* resolved paragon.
3. **`elite boss multiplier for the dart paragon`** (named) → "I drafted an answer but held it back" = the faithfulness floor killing the model draft.

## Fixes (both deterministic — immune to refusal/faithfulness)
- **Range-aware economy floor:** one round range → deterministic range totals (RBE base + freeplay-scaled via `round_rbe`, cash via `round_cash`, heaviest rounds via `round_composition`); ≥2 ranges defers to the §7.5 comparison floor. Reproduces the proven 06/18 answer (ABR 8-66 = **168,518** RBE; heaviest R65/R63/R62).
- **`deterministic_paragon_elite_reply`:** new floor on elite+paragon+(multiplier/damage) cues, returns the ×2 rule (×2 at Degree 1 → ×4.5 at Degree 100; global paragon-category runtime constant). Answers both the general and named-paragon question with no model dependency.

Tests for both + the floor-exclusivity invariant. Born-red card; auto-merges on green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hydy3uLzrkCmqHWT2VoEKG)_