### PR TITLE
xpmenu hub renders the rank image card (visual card-engine H3)

### DIFF
--- a/.sessions/2026-06-24-xpmenu-rank-card-h3.md
+++ b/.sessions/2026-06-24-xpmenu-rank-card-h3.md
@@ -1,6 +1,7 @@
 # 2026-06-24 — `!xpmenu` hub renders the rank image card (visual card-engine H3)
 
-> **Status:** `in-progress`
+> **Status:** `complete` — PR #1413; auto-merge armed; merges on green. Full CI
+> mirror green (12,374 passed; mypy + lint + arch clean).
 
 > **Run type:** `routine · dispatch`
 
@@ -24,3 +25,58 @@ This slice migrates the **direct `!xpmenu` surface** onto the same image card:
 
 Idea→ship is self-initiated (Q-0172) — flagged on the run-report ⚑ Self-initiated line.
 Plus regression tests; full CI mirror green; auto-merge on green.
+
+## Shipped (PR #1413)
+- `views/xp/main_panel.py` — `_XpHubView` gains `build_response(stat) -> (embed, card)`
+  over `xp_helpers.build_rank_response`; a shared `_decorate()` owns the title/footer/
+  admin-button chrome (one place, was duplicated in `build_embed` + each button); the
+  three stat buttons route through `_switch_stat` → `edit_message(attachments=[card] or [])`,
+  mirroring `_RankSelect.callback`. `build_embed` stays embed-only for the help-nav hook.
+- `cogs/xp_cog.py` — `xp_menu` sends `embed, card = await view.build_response()` via
+  `send_panel(..., file=card)`.
+- `tests/unit/views/xp/test_xp_hub_panel.py` (new, 6 tests) — card attaches + embed
+  decorated · Pillow-less embed-only fallback · admin-only footer · stat-switch swaps the
+  card attachment · stat-switch clears the attachment on fallback · the help-nav
+  `build_embed` path never touches the card seam.
+
+## 💡 Session idea (Q-0089)
+The `build_help_menu_view` help-nav hook is **embed-only by contract across the whole
+codebase** — every hub reached *through Help* loses its showpiece image card (profile,
+rank, leaderboard, …), while the same hub reached by its direct command shows it. Idea:
+a **single help-nav attachment seam** — let `build_help_menu_view` optionally return an
+attachment (or a `(embed, view, file)` triple) and teach the ~10 hub-rebuild call sites
+(`views/navigation.py`, `hub_children.py`, `admin_cog._open_child`, …) to forward it.
+Closes the "card via `!rank`, plain embed via Help → XP" inconsistency at the root.
+Dedup-checked — no existing entry; bigger than this slice so flagged for grooming, not built.
+
+## ⟲ Previous-session review (Q-0102)
+Reviewed **2026-06-24-btd6-paragon-elite-boss-damage** (#1402). Did well: it treated a
+curated runtime constant as *unverified* until it had ≥2 independent sources, and held the
+PR born-red for the owner's nod on a contested point — exactly the discipline the BTD6
+arc needs. Its Q-0089 idea (a "paragon vs elite boss effectiveness / hits-to-kill" answer)
+I deliberately **did not** build this run: a hits-to-kill calc needs the paragon's full
+per-second attack profile (multi-component) and would risk the confidently-wrong number the
+owner keeps catching — so an unattended run shouldn't ship it without a live check. **System
+improvement:** the dispatch menu / sector queue could carry a *confidence tag* on idea→build
+candidates (offline-deterministic ✅ vs needs-live-verification 🔵), so an unattended fire
+self-selects the safe ones (like this card slice) and routes the risky ones to an owner
+session — the same auto/review/live split `dispatch_menu --unattended` already applies to
+lanes, extended to promotable ideas.
+
+## Doc audit (Q-0104)
+`check_docs --strict` + `check_consistency` green; ledger check clean. The H3 progress is
+de-staled in `current-state/S1-bot.md` (this slice added to the H3 "remaining" note). No
+owner-decision / router change. Ledger entry for #1413 lands via the next reconciliation
+pass (no placeholder — Q-0052).
+
+## 📤 Run report
+- **Run type:** `routine · dispatch`
+- **Shipped:** PR #1413 — `!xpmenu` hub renders the rank image card (visual card-engine H3).
+- **⚑ Self-initiated:** YES — promoted the S1 consolidation polish-tail H3 item (`!xpmenu`
+  panel → image card) idea→build with no work order, per Q-0172. Contained, reversible,
+  offline-verified, embed fallback.
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none (a merge auto-deploys to Railway).
+- **Next ▶:** the help-nav attachment seam (session idea above) would carry the card through
+  Help too; remaining H3 = the rank/profile **hub** showpiece panels reached via Help, plus
+  the `mining_render` rebase (owner visual decision).

--- a/.sessions/2026-06-24-xpmenu-rank-card-h3.md
+++ b/.sessions/2026-06-24-xpmenu-rank-card-h3.md
@@ -1,0 +1,26 @@
+# 2026-06-24 — `!xpmenu` hub renders the rank image card (visual card-engine H3)
+
+> **Status:** `in-progress`
+
+> **Run type:** `routine · dispatch`
+
+## What I'm about to do
+Scheduled dispatch fire, no work order. Bugs blocked/data-gated (BUG-0009 newest-towers
+needs release-order data · BUG-0011 needs a VPS repro); BUG-0009/0019 rootfix backlog
+both blocked. Taking the **S1 consolidation polish tail · visual card-engine H3**:
+the `!xpmenu` hub panel (`_XpHubView`) currently shows a plain rank **embed** while
+`!rank` already renders the themed image **card** (`utils/rank_render.py`, #1401).
+
+This slice migrates the **direct `!xpmenu` surface** onto the same image card:
+- `_XpHubView.build_response(stat)` → `(embed, card)` via the existing
+  `services.xp_helpers.build_rank_response` (the same fetch-once embed+card the
+  `!rank` view uses); the stat-switch buttons re-render with `attachments=[card]`,
+  exactly mirroring `_RankSelect.callback` (the established H3 toggle grammar).
+- `XpCog.xp_menu` sends the card via `send_panel(..., file=card)` (already supports it).
+- Pillow-less hosts degrade to the embed (card `None`) — byte-identical fallback.
+- `build_help_menu_view` stays **embed-only** (the help-nav seam is embed-only by
+  contract across the whole codebase — threading a file through every hub seam is a
+  separate cross-cutting change, out of scope here).
+
+Idea→ship is self-initiated (Q-0172) — flagged on the run-report ⚑ Self-initiated line.
+Plus regression tests; full CI mirror green; auto-merge on green.

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -83,8 +83,8 @@ class XpCog(commands.Cog):
     async def xp_menu(self, ctx: commands.Context):
         """Open the XP panel showing your rank and quick admin actions."""
         view = _XpHubView(ctx)
-        embed = await view.build_embed()
-        await send_panel(ctx, embed=embed, view=view)
+        embed, card = await view.build_response()
+        await send_panel(ctx, embed=embed, view=view, file=card)
 
     async def build_help_menu_view(
         self,

--- a/disbot/views/xp/main_panel.py
+++ b/disbot/views/xp/main_panel.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import discord
 from discord.ext import commands
 
-from services.xp_helpers import _build_rank_embed
+from services.xp_helpers import _build_rank_embed, build_rank_response
 from views.base import HubView
 
 
@@ -21,8 +21,13 @@ class _XpHubView(HubView):
         super().__init__(ctx.author)
         self.ctx = ctx
 
-    async def build_embed(self) -> discord.Embed:
-        embed = await _build_rank_embed(self.ctx.author, self.ctx.guild, "both")  # type: ignore[arg-type]
+    def _decorate(self, embed: discord.Embed) -> None:
+        """Apply the hub's title / footer / admin-button state to ``embed``.
+
+        Shared by every render path (``build_embed`` for the help-nav hook,
+        ``build_response`` for the direct ``!xpmenu`` surface, and the three
+        stat-switch buttons) so the chrome stays in exactly one place.
+        """
         embed.title = f"🏆 XP Panel — {self.ctx.author.display_name}"
         is_admin = self.ctx.author.guild_permissions.administrator  # type: ignore[union-attr]
         lines = ["Use the buttons below to switch stat views."]
@@ -33,25 +38,53 @@ class _XpHubView(HubView):
         for item in self.children:
             if hasattr(item, "_admin_only"):
                 item.disabled = not is_admin
+
+    async def build_response(
+        self,
+        stat: str = "both",
+    ) -> tuple[discord.Embed, discord.File | None]:
+        """The direct ``!xpmenu`` surface — the rank embed plus its image card.
+
+        Reuses the fetch-once :func:`build_rank_response` (the same embed + card
+        the ``!rank`` view renders, visual card engine H3); the card is ``None``
+        on a Pillow-less host, where the embed stays the source of truth.
+        """
+        embed, card = await build_rank_response(self.ctx.author, self.ctx.guild, stat)  # type: ignore[arg-type]
+        self._decorate(embed)
+        return embed, card
+
+    async def build_embed(self) -> discord.Embed:
+        # Embed-only path for the ``build_help_menu_view`` help-nav hook, which
+        # is embed-only by contract across the codebase (no attachment seam).
+        embed = await _build_rank_embed(self.ctx.author, self.ctx.guild, "both")  # type: ignore[arg-type]
+        self._decorate(embed)
         return embed
+
+    async def _switch_stat(self, interaction: discord.Interaction, stat: str) -> None:
+        """Re-render the hub for ``stat`` in place, swapping the card attachment.
+
+        Mirrors ``views.xp.rank_view._RankSelect.callback`` (the H3 toggle
+        grammar): pass ``attachments`` explicitly so the new card replaces the
+        old one, or clears it (``[]``) on the embed-only fallback.
+        """
+        embed, card = await self.build_response(stat)
+        await interaction.response.edit_message(
+            embed=embed,
+            view=self,
+            attachments=[card] if card is not None else [],
+        )
 
     @discord.ui.button(label="📊 Both", style=discord.ButtonStyle.blurple, row=0)
     async def btn_both(self, interaction: discord.Interaction, _: discord.ui.Button):
-        embed = await _build_rank_embed(self.ctx.author, self.ctx.guild, "both")  # type: ignore[arg-type]
-        embed.title = f"🏆 XP Panel — {self.ctx.author.display_name}"
-        await interaction.response.edit_message(embed=embed, view=self)
+        await self._switch_stat(interaction, "both")
 
     @discord.ui.button(label="🏆 XP", style=discord.ButtonStyle.blurple, row=0)
     async def btn_xp(self, interaction: discord.Interaction, _: discord.ui.Button):
-        embed = await _build_rank_embed(self.ctx.author, self.ctx.guild, "xp")  # type: ignore[arg-type]
-        embed.title = f"🏆 XP Panel — {self.ctx.author.display_name}"
-        await interaction.response.edit_message(embed=embed, view=self)
+        await self._switch_stat(interaction, "xp")
 
     @discord.ui.button(label="🪙 Coins", style=discord.ButtonStyle.blurple, row=0)
     async def btn_coins(self, interaction: discord.Interaction, _: discord.ui.Button):
-        embed = await _build_rank_embed(self.ctx.author, self.ctx.guild, "coins")  # type: ignore[arg-type]
-        embed.title = f"🏆 XP Panel — {self.ctx.author.display_name}"
-        await interaction.response.edit_message(embed=embed, view=self)
+        await self._switch_stat(interaction, "coins")
 
     @discord.ui.button(label="⚙️ Configure", style=discord.ButtonStyle.grey, row=1)
     async def btn_config(self, interaction: discord.Interaction, _: discord.ui.Button):

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -68,9 +68,12 @@
     `mining_render` rebase (owner visual decision). **H3 *embed-feature → image-card* is underway:**
     `/myprofile` (H1) and now **`!rank`** both render real image cards (`utils/rank_render.py`, themed
     grid + level progress bar, re-rendered on the stat-toggle, embed fallback — 2026-06-24 dispatch
-    run); remaining H3 is the rank/profile **hub panels** (`!xpmenu`) + other showpiece embeds —
-    [vision](../ideas/visual-card-engine-vision-2026-06-23.md) · the `channel-deployed-component` roles
-    primitive (idea, not yet built).
+    run). The **`!xpmenu` hub panel** now renders the rank image card too (its direct surface +
+    stat-switch buttons, embed fallback — 2026-06-24 dispatch run, PR #1413); remaining H3 is the
+    rank/profile hub panels **reached via Help** (the `build_help_menu_view` seam is embed-only
+    across the codebase — a single help-nav attachment seam would carry the card there) + other
+    showpiece embeds — [vision](../ideas/visual-card-engine-vision-2026-06-23.md) · the
+    `channel-deployed-component` roles primitive (idea, not yet built).
 - **Fishing follow-ups** (turn-key, on the bait/venue seam) — *(bait speed knob ✅ #1337, sell-value
   re-tune ✅ #1304, bait-crafting ✅ #1338, and the **⛵ boat/deepwater venue** ✅ PR #1340 — shore↔
   deepwater toggle + boat-only species + tougher deep minigame — are all done)* — remaining:

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,12 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`help-nav-attachment-seam-2026-06-24.md`](./help-nav-attachment-seam-2026-06-24.md) —
+  **session-idea (2026-06-24, Q-0089) from the `!xpmenu` H3 slice (#1413):** hub panels show their
+  visual image card when opened by their direct command but a plain embed when reached through Help
+  (`build_help_menu_view` is embed-only across the codebase). Proposes one help-nav attachment seam so
+  the card carries through Help too — closing the inconsistency at the root as the cards go universal.
+  Subsystem: none.
 - [`btd6-runtime-mechanics-from-game-2026-06-23.md`](./btd6-runtime-mechanics-from-game-2026-06-23.md) —
   **owner-raised (2026-06-23):** get the BTD6 *runtime/simulation* layer (freeplay health/speed ramp,
   superceramic swap, per-round RBE & cash) **straight from the game** — the dump only exports entity

--- a/docs/ideas/help-nav-attachment-seam-2026-06-24.md
+++ b/docs/ideas/help-nav-attachment-seam-2026-06-24.md
@@ -1,0 +1,60 @@
+# Help-nav attachment seam — let hub panels carry their image card through Help
+
+> **Status:** `ideas`. Not a plan, not approval. Source code + binding contracts win.
+> **Subsystem:** none
+
+## The inconsistency
+
+The visual card engine (H3) is rolling showpiece **image cards** onto bot features:
+profile (`/myprofile`), rank (`!rank`), the XP hub (`!xpmenu`, PR #1413), the leaderboard
+(`!leaderboard`), etc. Each renders a themed PNG with a clean embed fallback.
+
+But every hub also has a **second entry path**: the `build_help_menu_view` hook, reached
+from the Help tree and the universal hub-child navigation. That seam is **embed-only by
+contract across the whole codebase** — every consumer does:
+
+```python
+embed, view = await cog.build_help_menu_view(interaction)
+await interaction.response.edit_message(embed=embed, view=view)   # no attachment
+```
+
+So the *same* hub shows its card when opened by its direct command, but a **plain embed**
+when reached through Help. As more features become image cards, this split widens: the
+showpiece is invisible on exactly the discovery path (Help) the consolidation/discoverability
+audit just invested in.
+
+## The idea
+
+A single **help-nav attachment seam**: let `build_help_menu_view` optionally return an
+attachment alongside the embed+view (e.g. a `(embed, view, file)` triple, or an optional
+third element / small result object), and teach the ~10 hub-rebuild call sites to forward it
+with `attachments=[file] if file else []` (the same grammar `_RankSelect` / `_XpHubView`
+already use). Known call sites (from `grep build_help_menu_view`):
+
+- `views/navigation.py` (`attach_standard_nav` / hub rebuild)
+- `views/hub_children.py` (`HubChildButton`)
+- `views/community/hub.py`, `views/games/hub.py`, `views/server_management/hub.py`
+- `cogs/admin_cog.py` `_open_child`, `cogs/help/route.py`
+- the slash mirrors that reuse the hook (`settings_cog`, `economy_cog`, `moderation_cog`,
+  `utility_cog`, …) — these `ctx.send`/`response.send_message` and *can* carry a file.
+
+Backward-compatible: a hook that returns no attachment (the default) behaves exactly as today,
+so it can roll out hub-by-hub.
+
+## Why it's worth doing
+
+- Closes the "card via the command, plain embed via Help" inconsistency **at the root** rather
+  than per-feature.
+- Directly amplifies the H3 work and the discoverability audit (the card shows where users
+  actually browse).
+- Bounded and mechanical once the seam is designed; the toggle/fallback grammar already exists.
+
+## Caveats / why not built in #1413
+
+Cross-cutting (~10 call sites, several of them governance-rechecked navigation seams), so it is
+its own slice — out of scope for the single-surface `!xpmenu` migration. Needs a small design
+decision (triple vs. result object) and a per-site audit that the edit-in-place paths can
+actually attach a file (some `edit_message` paths can; a few may need `attachments=`). A good
+next H3 slice once an agent wants to make the cards universal.
+
+*(Captured 2026-06-24, dispatch run, as the Q-0089 session idea from the `!xpmenu` H3 slice — PR #1413.)*

--- a/docs/owner/claims/claude-funny-franklin-6ehowb.md
+++ b/docs/owner/claims/claude-funny-franklin-6ehowb.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-6ehowb` · scope: visual card-engine H3 — render the `!xpmenu` hub panel as the rank image card (S1 consolidation polish tail) · area: disbot/views/xp/main_panel.py, disbot/cogs/xp_cog.py · 2026-06-24

--- a/docs/owner/claims/claude-funny-franklin-6ehowb.md
+++ b/docs/owner/claims/claude-funny-franklin-6ehowb.md
@@ -1,1 +1,0 @@
-- branch `claude/funny-franklin-6ehowb` · scope: visual card-engine H3 — render the `!xpmenu` hub panel as the rank image card (S1 consolidation polish tail) · area: disbot/views/xp/main_panel.py, disbot/cogs/xp_cog.py · 2026-06-24

--- a/tests/unit/views/xp/test_xp_hub_panel.py
+++ b/tests/unit/views/xp/test_xp_hub_panel.py
@@ -1,0 +1,141 @@
+"""Unit tests for the ``!xpmenu`` hub panel (`_XpHubView`).
+
+Pins the visual card-engine **H3** migration of the XP hub: the direct
+``!xpmenu`` surface now renders the same rank **image card** the ``!rank``
+view does, via :func:`services.xp_helpers.build_rank_response`, while the
+``build_help_menu_view`` help-nav hook stays embed-only (that seam carries no
+attachment across the codebase).
+
+These tests stub ``build_rank_response`` at the module seam — they verify the
+hub's *wiring* (does it ask for the card, attach it, decorate the embed, swap
+the attachment on a stat switch, and degrade cleanly without Pillow), not the
+rank data itself (covered by ``test_xp_helpers_rank``).
+"""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from views.xp.main_panel import _XpHubView
+
+
+def _ctx(*, admin: bool = False) -> MagicMock:
+    ctx = MagicMock()
+    author = MagicMock(spec=discord.Member)
+    author.id = 7
+    author.display_name = "AstroFox"
+    author.guild_permissions = MagicMock(administrator=admin)
+    ctx.author = author
+    ctx.guild = MagicMock(spec=discord.Guild)
+    ctx.guild.id = 42
+    return ctx
+
+
+def _fake_card() -> discord.File:
+    return discord.File(io.BytesIO(b"\x89PNG\r\n\x1a\nfake"), filename="rank.png")
+
+
+def _patch_response(card: discord.File | None):
+    """Patch the hub's ``build_rank_response`` seam to return a (fresh embed, card).
+
+    A fresh embed per call so two views decorated in one test don't share (and
+    overwrite) each other's footer.
+    """
+
+    async def _resp(_member, _guild, _stat):
+        return discord.Embed(description="rank"), card
+
+    return patch(
+        "views.xp.main_panel.build_rank_response", new=AsyncMock(side_effect=_resp)
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_response_attaches_card_and_decorates_embed():
+    view = _XpHubView(_ctx())
+    with _patch_response(_fake_card()) as resp:
+        embed, card = await view.build_response()
+
+    resp.assert_awaited_once()
+    assert resp.await_args.args[2] == "both"  # default stat
+    assert isinstance(card, discord.File)
+    # The hub chrome is applied on top of the rank embed.
+    assert embed.title == "🏆 XP Panel — AstroFox"
+    assert "switch stat view" in (embed.footer.text or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_build_response_falls_back_to_embed_only_without_pillow():
+    view = _XpHubView(_ctx())
+    with _patch_response(None):
+        embed, card = await view.build_response()
+
+    assert card is None  # Pillow-less host → embed-only, no attachment
+    assert embed.title == "🏆 XP Panel — AstroFox"
+
+
+@pytest.mark.asyncio
+async def test_admin_footer_only_for_admins():
+    admin_view = _XpHubView(_ctx(admin=True))
+    plain_view = _XpHubView(_ctx(admin=False))
+    with _patch_response(None):
+        admin_embed, _ = await admin_view.build_response()
+        plain_embed, _ = await plain_view.build_response()
+
+    assert "Admin controls" in admin_embed.footer.text
+    assert "Admin controls" not in plain_embed.footer.text
+
+
+@pytest.mark.asyncio
+async def test_stat_switch_swaps_the_card_attachment():
+    view = _XpHubView(_ctx())
+    interaction = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    with _patch_response(_fake_card()) as resp:
+        await view.btn_coins.callback(interaction)
+
+    # Re-rendered for the chosen stat, with the new card passed as attachments.
+    assert resp.await_args.args[2] == "coins"
+    interaction.response.edit_message.assert_awaited_once()
+    kwargs = interaction.response.edit_message.await_args.kwargs
+    assert kwargs["view"] is view
+    assert len(kwargs["attachments"]) == 1
+    assert isinstance(kwargs["attachments"][0], discord.File)
+
+
+@pytest.mark.asyncio
+async def test_stat_switch_clears_attachment_on_embed_only_fallback():
+    view = _XpHubView(_ctx())
+    interaction = MagicMock()
+    interaction.response.edit_message = AsyncMock()
+    with _patch_response(None):
+        await view.btn_xp.callback(interaction)
+
+    kwargs = interaction.response.edit_message.await_args.kwargs
+    # No card → attachments explicitly cleared so the old image is removed.
+    assert kwargs["attachments"] == []
+
+
+@pytest.mark.asyncio
+async def test_help_menu_hook_path_stays_embed_only():
+    # ``build_embed`` (used by the build_help_menu_view help-nav hook) must not
+    # touch the image-card seam — that path carries no attachment.
+    view = _XpHubView(_ctx())
+    embed_stub = discord.Embed(description="rank")
+    with (
+        patch(
+            "views.xp.main_panel._build_rank_embed",
+            new=AsyncMock(return_value=embed_stub),
+        ),
+        patch(
+            "views.xp.main_panel.build_rank_response",
+            new=AsyncMock(side_effect=AssertionError("must not render a card")),
+        ),
+    ):
+        embed = await view.build_embed()
+
+    assert embed.title == "🏆 XP Panel — AstroFox"


### PR DESCRIPTION
## What & why

Scheduled **dispatch** fire (no work order). Open bugs are blocked/data-gated, so this run takes the **S1 consolidation polish tail → visual card-engine H3**: the `!xpmenu` hub panel renders the themed rank **image card** instead of a plain embed.

The `!rank` command already renders the rank card (`utils/rank_render.py`, #1401), but its sibling hub `!xpmenu` (`_XpHubView`) still showed a plain embed. This migrates the **direct `!xpmenu` surface** onto the same card.

## Changes
- `views/xp/main_panel.py` — `_XpHubView` gains `build_response(stat) -> (embed, card)` over the existing `xp_helpers.build_rank_response` (the same fetch-once embed+card `!rank` uses). The three stat-switch buttons (Both / XP / Coins) re-render with `attachments=[card]`, mirroring `_RankSelect.callback` (the established H3 toggle grammar). A shared `_decorate()` sets the hub title / footer / admin-button state in one place.
- `cogs/xp_cog.py` — `xp_menu` sends the card via `send_panel(..., file=card)` (already supported).
- Pillow-less hosts degrade to embed-only (`card is None`) — byte-identical fallback.
- `build_help_menu_view` stays **embed-only** (the help-nav seam is embed-only by contract across the whole codebase; threading a file through every hub seam is a separate cross-cutting change).

## Tests
Regression coverage for the hub response (card attaches + embed points at it; Pillow-less fallback; stat-switch re-render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4JUZnhi3Wcetz3AqpNibE)_