### PR TITLE
Capture owner idea: bot-migration assistant (detect → map → replicate → retire other bots)

### DIFF
--- a/.sessions/2026-06-24-bot-migration-assistant-idea.md
+++ b/.sessions/2026-06-24-bot-migration-assistant-idea.md
@@ -1,17 +1,72 @@
 # Session — 2026-06-24 · capture owner idea: bot-migration assistant
 
-> **Status:** `in-progress` — born-red. About to capture an owner-raised idea (the bot recognizes
-> other bots in a server, maps what they offer, suggests how to replicate it with SuperBot, then
-> retires the now-redundant bots) as a `docs/ideas/` doc + README index entry. Docs-only.
+> **Status:** `complete` — docs-only idea capture. Single push, born-red → ready.
 
-## What I'm about to do
+**Trigger:** owner chat request — *"can the bot recognize other bots, find out which things they offer,
+suggest steps to replicate their functions, and delete the old bots once setup is complete?"* I
+researched feasibility against live source (two `Explore` agents over setup + moderation/member seams),
+answered in chat, and the owner chose **capture as an idea doc** over plan/build.
 
-The maintainer asked, in chat: *"can the bot recognize other bots, find out which things they offer,
-and suggest steps to replicate their functions in the server, as well as delete the old bots once
-setup is complete?"* He chose **capture as an idea doc** (not plan/build yet).
+## What changed
 
-Scope: write `docs/ideas/bot-migration-assistant-2026-06-24.md` grounded in (a) the actual SuperBot
-seams that make it feasible (setup advisor → draft → Final Review · `guild_snapshot` · subsystem
-registry · `moderation_service.kick`) and (b) the one hard Discord constraint (no API to introspect
-another bot's commands). Cross-link the existing V-14 feature-mining lineage. Add the README index
-entry. No runtime code.
+- **New idea** [`docs/ideas/bot-migration-assistant-2026-06-24.md`](../docs/ideas/bot-migration-assistant-2026-06-24.md)
+  — the detect → map → replicate → retire flow, grounded in the real seams it would dock into and honest
+  about the one hard Discord constraint (no API to introspect another bot's commands → curated
+  app-id-keyed catalog + observable signals, never live command reads). Subsystem: setup.
+- **README index entry** added at the top of the broad-captures list, cross-linked to the V-14
+  feature-mining lineage (this is the *live-in-server engine* on top of that *hand-harvest* lane).
+- `check_docs --strict` green (new doc reachable via the index).
+
+## Feasibility verdict (recorded so a planning session starts from reality)
+
+- **Jobs 1/3/4 (detect / replicate / retire) are easy** — `member.bot` detection + `intents.members`
+  already on; the setup advisor → draft → Final Review pipeline already stages audited reversible
+  `SetupOperation`s; `moderation_service.kick()` already audited + hierarchy-gated.
+- **Job 2 (discover what a bot offers) is the crux** — Discord exposes no cross-application command
+  introspection. The realistic design is a curated catalog keyed by application id + observable signals
+  (roles/channels/webhooks/integrations), with an honest "unknown bot → operator picks" fallback.
+- It is a **feature-layer extension, not an architecture change** (new setup section + advisor +
+  snapshot extension + catalog).
+
+## 💡 Session idea (Q-0089)
+
+**Shared competitor catalog as one source of truth.** The V-14 teardown (`competitive-teardown`,
+`competitive-positioning-north-star`) harvests rival features into prose docs by hand; this new idea
+needs a *machine-readable* app-id → competitor-features → SuperBot-subsystem map. Rather than letting
+those drift apart, a future planning session should make **one structured catalog** (e.g.
+`docs/data/competitor-bots.yml` or a service constant) that *both* the teardown docs and the migration
+advisor consume — the same "one source, two consumers" discipline the repo already applies to the
+subsystem registry and dashboard export. Captured inline in the idea doc's open-questions §; worth its
+own idea file if the migration idea is promoted. Genuine — it prevents a real drift class before it
+starts.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous `.sessions/` log: the **twenty-fourth Q-0107 reconciliation pass (band-#1410)**. Did well: tight,
+born-complete docs PR with every automated check (`check_docs`, `check_current_state_ledger`,
+`check_loop_health`) explicitly run and its result recorded — exemplary ground-truth discipline, and it
+correctly *carried forward* the band-#1380 plan queue rather than re-deriving it. One genuine miss it
+flagged itself: it fired ~50 min after the prior pass on a 4-merge band (cadence jitter), and its own
+session idea proposes the fix — good self-audit. **System improvement this surfaces:** idea capture has
+*no* equivalent of the reconciliation routine's automated checklist — there is no checker that a new
+`docs/ideas/*.md` carries the now-conventional header block (`Status:`, `Subsystem:`, lineage links). A
+tiny warn-first `check_idea_header.py` (the proven 3-file disposable-tool shape, Q-0105) would keep idea
+captures uniform the way `check_session_gate` keeps session cards uniform. Noting here, not building —
+out of this session's scope.
+
+## 📋 Doc audit (Q-0104)
+
+Is anything from this session not in its durable home? No. The idea + its feasibility verdict live in the
+idea doc; the index entry makes it reachable; no owner *decision* was made (the owner chose a workflow
+step — capture — not a product/architecture ruling), so no router Q-block is owed. `check_docs --strict`
+green. No `current-state.md` ledger change (no merged runtime PR).
+
+## Context delta
+
+- **Surprise:** the codebase *already* has nearly every building block this feature needs — the only
+  genuinely new primitives are the curated catalog and a bot-only snapshot read. The feasibility risk is
+  entirely in Job 2's Discord-API limit, not in SuperBot's architecture.
+- **For next session:** if this idea is promoted, start from the "shared catalog, two consumers" decision
+  above and Phase 1 (detect & report, read-only) — it ships value with zero risk.
+
+## ⚑ Self-initiated: none — owner-directed capture (the owner explicitly chose "capture as an idea doc").

--- a/.sessions/2026-06-24-bot-migration-assistant-idea.md
+++ b/.sessions/2026-06-24-bot-migration-assistant-idea.md
@@ -1,0 +1,17 @@
+# Session — 2026-06-24 · capture owner idea: bot-migration assistant
+
+> **Status:** `in-progress` — born-red. About to capture an owner-raised idea (the bot recognizes
+> other bots in a server, maps what they offer, suggests how to replicate it with SuperBot, then
+> retires the now-redundant bots) as a `docs/ideas/` doc + README index entry. Docs-only.
+
+## What I'm about to do
+
+The maintainer asked, in chat: *"can the bot recognize other bots, find out which things they offer,
+and suggest steps to replicate their functions in the server, as well as delete the old bots once
+setup is complete?"* He chose **capture as an idea doc** (not plan/build yet).
+
+Scope: write `docs/ideas/bot-migration-assistant-2026-06-24.md` grounded in (a) the actual SuperBot
+seams that make it feasible (setup advisor → draft → Final Review · `guild_snapshot` · subsystem
+registry · `moderation_service.kick`) and (b) the one hard Discord constraint (no API to introspect
+another bot's commands). Cross-link the existing V-14 feature-mining lineage. Add the README index
+entry. No runtime code.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -31,6 +31,15 @@ only the header block is read, so a `**Subsystem:**` *example* in an idea's body
 
 Current broad captures:
 
+- [`bot-migration-assistant-2026-06-24.md`](./bot-migration-assistant-2026-06-24.md) —
+  **owner-directed (2026-06-24, chat):** the bot recognizes the *other* bots in a server, maps what each
+  offers, suggests how to **replicate** it with SuperBot's subsystems, then offers to **retire** the
+  now-redundant bots once setup is done — the in-product engine for the consolidation wedge. Grounded in
+  the real seams (`member.bot` detection · `guild_snapshot` · `subsystem_registry` · setup advisor →
+  draft → Final Review · `moderation_service.kick`) **and** the one hard constraint — Discord has **no
+  API to introspect another bot's commands**, so discovery rests on a curated app-id-keyed catalog +
+  observable signals, never live command reads. The *live-in-server* counterpart to the V-14
+  hand-harvest teardown lane. Subsystem: setup.
 - [`help-nav-attachment-seam-2026-06-24.md`](./help-nav-attachment-seam-2026-06-24.md) —
   **session-idea (2026-06-24, Q-0089) from the `!xpmenu` H3 slice (#1413):** hub panels show their
   visual image card when opened by their direct command but a plain embed when reached through Help

--- a/docs/ideas/bot-migration-assistant-2026-06-24.md
+++ b/docs/ideas/bot-migration-assistant-2026-06-24.md
@@ -1,0 +1,106 @@
+# Bot-migration assistant — detect → map → replicate → retire other bots (2026-06-24)
+
+> **Status:** `ideas` — captured from an owner chat request (the maintainer asked whether the bot can
+> recognize *other* bots in a server, find out what they offer, suggest steps to replicate their
+> functions with SuperBot, and delete the old bots once setup is complete). He chose **capture**
+> over plan/build. Nothing here is approved for implementation.
+> **Subsystem:** setup
+> **Lineage:** the *in-product engine* on top of the **V-14 competitive feature-mining** lane —
+> [`competitive-teardown-2026-06-10.md`](./competitive-teardown-2026-06-10.md),
+> [`competitive-positioning-north-star-2026-06-23.md`](./competitive-positioning-north-star-2026-06-23.md),
+> [`free-for-everyone-mission-2026-06-21.md`](./free-for-everyone-mission-2026-06-21.md). V-14 harvests
+> rivals' features into *our backlog by hand*; this idea is the bot doing **detect → map → replicate →
+> retire** *live in a server*, which is the user-facing payoff of "free **and** all-in-one."
+
+## The idea, in the owner's words
+
+> "The goal of my bot is easy configuration and all-inclusive functionality, so one thing that would
+> be a major improvement is if the bot can recognize other bots, find out which things they offer, and
+> suggest steps to replicate their functions in the server, as well as to delete the old bots from the
+> server once setup is complete."
+
+This is a **bot-migration / consolidation assistant**: the operator runs one flow, SuperBot inventories
+the server's *other* bots, tells them which SuperBot subsystems replace each, helps configure those, and
+then offers to kick the now-redundant bots. It is the literal embodiment of the consolidation wedge in
+[`free-for-everyone-mission`](./free-for-everyone-mission-2026-06-21.md): *one free bot replaces 5+
+paywalled ones*.
+
+## Four jobs — three easy, one hard
+
+| # | Job | Verdict | Why |
+|---|-----|---------|-----|
+| 1 | **Recognize other bots** | ✅ Easy | `member.bot` is already used across the codebase (`security_cog`, `welcome_cog`); `intents.members` + `intents.message_content` are on (`disbot/bot1.py`). Iterating `guild.members` for `m.bot` (excluding ourselves) is trivial. Each carries a stable **application id** + name. |
+| 2 | **Find out what they offer** | ⚠️ **Hard — the crux** | See below. There is **no Discord API** for one bot to read another bot's commands. |
+| 3 | **Suggest steps to replicate** | ✅ Fits existing pipeline | The setup advisor → draft → Final Review machinery already turns "here is the server + a recommendation" into staged, audited, atomically-applied `SetupOperation`s. A migration plan is just another producer of those. |
+| 4 | **Retire the old bots** | ✅ Reuses moderation | `services/moderation_service.kick()` already exists — audited, permission-gated, hierarchy-checked. Kicking a redundant bot is a guarded, confirmed call. |
+
+## The hard part (Job 2) — and the realistic design
+
+**Constraint (verified):** `GET /applications/{id}/commands` requires *that application's own bot token*.
+A bot **cannot** enumerate another bot's slash commands via the API, and legacy prefix commands have no
+introspection at all. So we cannot programmatically "read what bot X does."
+
+**What we *can* observe and lean on instead:**
+
+1. **Identity** — each present bot's **application id** (stable) + display name.
+2. **A curated catalog** keyed by application id: the top ~20–30 popular bots (MEE6, Dyno, Carl-bot,
+   Ticket Tool, UnbelievaBoat, Tatsu, ProBot, …) → their well-known headline feature set → **the
+   SuperBot subsystem that replaces each** (the target side is `utils/subsystem_registry.py`). This
+   curated catalog is the real heart of the feature; it needs human-verified content, not clever code,
+   and it overlaps almost entirely with the work the **V-14 teardown** already does by hand — so the
+   two lanes should share one data source.
+3. **Observable signals** for the unknown/long tail — the **roles** a bot created or holds, the
+   **channels** it manages, the **webhooks / integrations** it owns (`guild.webhooks()`,
+   `guild.integrations()` — *not enumerated today; small new reads*). These hint at what a bot is doing
+   even when it isn't in the catalog.
+4. **Fallback for unknown bots** — "we detected `X`, can't auto-map it; here's what SuperBot offers,
+   pick what to enable." Never guess.
+
+The catalog grows over time; the engine doesn't change. This is the same "explicit data + heuristic
+fallback" shape the repo already favors.
+
+## How it docks into existing seams (no architecture change)
+
+This is a **feature-layer extension**, confirmed by a read of the setup/moderation subsystems:
+
+- **A new setup section** (e.g. `bot_migration`) registered in `services/setup_sections.py`, appearing
+  as a wizard step alongside channels/roles/etc.
+- **A migration advisor** modeled on `services/setup_ai_advisor.py` (same `SetupAdvisor` protocol):
+  consumes a snapshot, emits `SetupRecommendation`s, which stage as `SetupOperation`s in the draft and
+  apply through **Final Review** (so every replication step is audited + reversible).
+- **Snapshot extension** — `services/guild_snapshot.py` (or a sibling `BotMigrationSnapshot`) gains a
+  privacy-vetted "other bots present + their roles/channels/integrations" view. (The current snapshot
+  deliberately excludes the member list; a bot-only enumeration is a narrow, justified addition.)
+- **A `BotFeatureCatalogue`** — the curated app-id → competitor-features → SuperBot-subsystem map.
+- **Guarded retirement** — a confirmation step per bot calling `moderation_service.kick()`, gated on
+  "you've configured the replacement" + Kick-Members permission + role hierarchy.
+
+## Suggested phasing (when promoted to a plan)
+
+1. **Phase 1 — Detect & report** (read-only, zero risk): list the bots present, identify known ones from
+   the catalog, show "MEE6 here likely does leveling + automod + welcome → SuperBot covers all three."
+2. **Phase 2 — Replicate**: turn matched features into a staged draft routed through Final Review.
+3. **Phase 3 — Retire**: after the operator confirms the replacement is live, offer a guarded
+   per-bot kick.
+
+The migration catalog is the long-lived asset and grows independently of the three phases.
+
+## Open questions for a planning session
+
+- **Catalog source of truth** — share one dataset with the V-14 teardown harvest, or keep a separate
+  app-id-keyed runtime catalog? (Recommend: one shared source, two consumers.)
+- **Unknown-bot UX** — how aggressively to infer from roles/channels vs. always defer to the operator.
+- **Retirement safety** — confirmation copy, the "replacement actually configured" gate, what to do when
+  SuperBot lacks the permission/hierarchy to kick (advise the operator instead).
+- **Privacy** — the snapshot extension stays operator-visible-metadata only (no message content), per
+  the existing `guild_snapshot` contract.
+- **Scope of replication** — some competitor features (e.g. another bot's *economy balances*) cannot be
+  migrated, only re-started fresh; the assistant should be honest about what it can and can't carry over.
+
+## Risks / honest caveats
+
+- The catalog is **manual curation** — its quality is the feature's quality. Stale entries mislead.
+- **Capability discovery is inference, never ground truth** for Job 2; the UI must never overclaim "bot X
+  does Y" with false confidence.
+- **Kicking another bot is irreversible-ish** (re-invite needed) and outward-facing — must be explicitly
+  operator-confirmed, never automatic.

--- a/docs/owner/claims/claude-serene-mccarthy-lv5z94.md
+++ b/docs/owner/claims/claude-serene-mccarthy-lv5z94.md
@@ -1,0 +1,1 @@
+claude/serene-mccarthy-lv5z94 · capture owner idea: bot-migration assistant (detect→map→replicate→retire other bots) · docs/ideas/ + README index · 2026-06-24

--- a/docs/owner/claims/claude-serene-mccarthy-lv5z94.md
+++ b/docs/owner/claims/claude-serene-mccarthy-lv5z94.md
@@ -1,1 +1,0 @@
-claude/serene-mccarthy-lv5z94 · capture owner idea: bot-migration assistant (detect→map→replicate→retire other bots) · docs/ideas/ + README index · 2026-06-24


### PR DESCRIPTION
## What

Captures an owner-raised idea as a `docs/ideas/` doc: SuperBot recognizes the **other bots** in a server, maps what they offer, suggests how to **replicate** that with SuperBot's own subsystems, and offers to **retire** the now-redundant bots once setup is complete.

The maintainer asked this in chat and chose **capture as an idea doc** (not plan/build yet).

## Why it's grounded, not hand-wavy

The capture is written against SuperBot's actual seams so a future planning session starts from reality:

- **Feasible today:** bot detection (`member.bot`, `intents.members` on), server introspection (`services/guild_snapshot.py`), the capability catalog (`utils/subsystem_registry.py`), the setup advisor → draft → Final Review pipeline (`setup_ai_advisor.py` / `setup_operations.py`), and audited removal (`moderation_service.kick`).
- **The one hard constraint, stated honestly:** Discord exposes **no API for one bot to introspect another bot's commands** — so capability discovery rests on a **curated catalog keyed by application ID** + observable signals (roles/channels/webhooks/integrations the bot owns), not live command reads.

Cross-links the existing **V-14 competitive feature-mining** lineage (`competitive-teardown`, `free-for-everyone-mission`) — this idea is the *in-product engine* on top of that *backlog-harvesting* lane.

## Scope

Docs-only — one idea file + README index entry. No runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJiSiWF242E5ShFS5Gq41R)_