### PR TITLE
tickets: wire into the !setup wizard + bot-join welcome (discoverability)

### DIFF
--- a/.sessions/2026-06-24-ticket-setup-discoverability.md
+++ b/.sessions/2026-06-24-ticket-setup-discoverability.md
@@ -1,0 +1,21 @@
+# 2026-06-24 — Tickets: setup-wizard discoverability
+
+> **Status:** `in-progress` — wiring tickets into the `!setup` wizard + bot-join launcher so a new server
+> owner discovers tickets exist and need `!ticketsetup`. (Born-red card; flipped to `complete` as the last step.)
+
+> **Run type:** `manual` — owner asked "how easy is it for owners to discover this setup?", then said continue.
+
+**Branch:** `claude/ticket-setup-discoverability` (off `main`). Follows the ticket subsystem (#1405) + AI
+confirm rework (#1410). A discoverability audit found tickets are reachable via `!help` → Community hub, but
+**absent from the `!setup` wizard and the bot-join welcome** — the surfaces a new owner actually hits first.
+
+## What this session is doing
+
+- **New `views/setup/sections/ticket.py`** — a setup-wizard section so tickets appear in `!setup` / `/setup-hub`.
+  Direct-lane config panel (RoleSelect staff role + ChannelSelect log + Enable) writing through the audited
+  `ticket_mutation.update_config` — the same path `!ticketsetup` uses. Tickets store config in their own
+  table (not the generic `set_setting` pipeline), so it stages no draft ops (like `suggestions`/`server_scan`).
+- **Launcher mention** — a line in the bot-join welcome embed pointing at the Support Tickets step / `!ticketsetup`.
+- Tests + the section-registration pin updated.
+
+(close-out notes appended at session end)

--- a/.sessions/2026-06-24-ticket-setup-discoverability.md
+++ b/.sessions/2026-06-24-ticket-setup-discoverability.md
@@ -1,7 +1,7 @@
 # 2026-06-24 — Tickets: setup-wizard discoverability
 
-> **Status:** `in-progress` — wiring tickets into the `!setup` wizard + bot-join launcher so a new server
-> owner discovers tickets exist and need `!ticketsetup`. (Born-red card; flipped to `complete` as the last step.)
+> **Status:** `complete` — tickets now appear in the `!setup` wizard + the bot-join welcome. Full CI mirror
+> green (12390 passed); arch 0 errors. Shipped as PR #1417.
 
 > **Run type:** `manual` — owner asked "how easy is it for owners to discover this setup?", then said continue.
 
@@ -18,4 +18,45 @@ confirm rework (#1410). A discoverability audit found tickets are reachable via 
 - **Launcher mention** — a line in the bot-join welcome embed pointing at the Support Tickets step / `!ticketsetup`.
 - Tests + the section-registration pin updated.
 
-(close-out notes appended at session end)
+### ⚑ Flagged for maintainer / known limits
+
+- **Not live-verified** (no Discord boot here): confirm tickets show up in `!setup` (standard/advanced
+  depth) and `/setup-hub`, the panel's RoleSelect + ChannelSelect + Enable flow writes config, and the
+  bot-join welcome shows the new line. The Enable path reuses the audited `update_config` that
+  `!ticketsetup` already exercises, so the write seam is the proven one.
+- The section is **standard + advanced** depth (not `quick`) — tickets aren't a day-one essential. Reasonable
+  default; flag if you'd rather they appear in the quick path too.
+
+## 💡 Session idea
+
+**Readiness scan should grade tickets.** The setup readiness scan (`build_setup_readiness_embed`) rates how
+configured a server is, but doesn't know about tickets yet. Adding a "🎫 Tickets: enabled / not set up" line
+would both grade them and act as another discovery nudge. Small, follows the existing readiness-row pattern.
+
+## ⟲ Previous-session review
+
+The previous two sessions (#1405, #1410) built the ticket subsystem and AI flow well, but **both declared
+the feature "done" while it was effectively undiscoverable through the wizard** — the gap this session
+found only because the owner asked. Lesson: "shipped" for a user-facing subsystem should include *how a
+user finds it*, not just that the code works. **System improvement:** the `new-subsystem` skill / subsystem
+registry could carry a checklist item — "is this wired into `!setup` and the launcher?" — so a new
+subsystem can't be marked complete while invisible to the setup flow. Captured as the session idea's cousin;
+worth a router note if it recurs.
+
+## Context delta
+
+- **Needed but not pointed to:** the rule that a setup section can write **directly** (not draft-staged)
+  when its domain owns a dedicated audited mutation — `suggestions`/`server_scan` model it, but it isn't
+  spelled out in the setup-section docs. Worth a one-liner in the section-authoring guide.
+- **🛠 Friction → guard:** none new — `check_quality.py --full` + the section-registration pin caught
+  everything; the moderation section was a clean template.
+
+## 📤 Run report
+
+- **Did:** wired tickets into the `!setup` wizard + bot-join welcome · **Outcome:** shipped
+- **Shipped:** #1417 — tickets discoverable via `!setup` / `/setup-hub` + the welcome embed
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** none
+- **⚑ Owner manual steps:** after deploy, spot-check tickets appear in `!setup` and the panel enables them
+- **⚑ Self-initiated:** none — owner asked the discoverability question, then said continue (directed work)
+- **↪ Next:** live-verify; optionally the "readiness scan grades tickets" idea

--- a/disbot/views/setup/launcher.py
+++ b/disbot/views/setup/launcher.py
@@ -28,7 +28,9 @@ _LAUNCHER_DESC = (
     "**Quick commands:** `!setup` / `/setup` to open the guided wizard, "
     "`/setup-hub` for the advanced section list, "
     "`/setup-status` for a read-only peek, `/setup-reset` to clear "
-    "staged operations."
+    "staged operations.\n\n"
+    "🎫 The wizard includes a **Support Tickets** step — enable private "
+    "member↔staff tickets there, or run `!ticketsetup @StaffRole [#log]`."
 )
 
 

--- a/disbot/views/setup/sections/__init__.py
+++ b/disbot/views/setup/sections/__init__.py
@@ -31,6 +31,7 @@ from views.setup.sections import (  # noqa: F401 — import side-effect
     roles,
     server_scan,
     suggestions,
+    ticket,
 )
 
 __all__ = [
@@ -51,4 +52,5 @@ __all__ = [
     "roles",
     "server_scan",
     "suggestions",
+    "ticket",
 ]

--- a/disbot/views/setup/sections/ticket.py
+++ b/disbot/views/setup/sections/ticket.py
@@ -1,0 +1,280 @@
+"""Support-tickets section — enable + configure tickets inside the wizard.
+
+Tickets were reachable only via ``!help`` → Community hub or the standalone
+``!ticketsetup`` command — invisible to a new owner running the ``!setup``
+wizard (the surface they actually start from). This section closes that
+discoverability gap: tickets now appear as a wizard step / ``/setup-hub`` button.
+
+Tickets keep their config in a dedicated table (``services.ticket_service`` /
+``ticket_mutation``), **not** the generic ``set_setting`` pipeline, so this
+section writes through the audited ``ticket_mutation.update_config`` directly —
+the same path ``!ticketsetup`` uses. That is the focused / reversible /
+single-domain **direct lane** (``docs/ownership.md`` § "Direct vs. draft
+mutation lanes"); it stages no ``SetupOperation`` draft rows (``op_kinds`` is
+empty), mirroring the ``suggestions`` / ``server_scan`` sections that open their
+own panel rather than feeding Final Review.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+
+from core.runtime import guild_resources as resources
+from services import setup_session, ticket_mutation, ticket_service
+from services.setup_sections import REGISTRY, SetupSection
+from views.base import BaseView
+
+if TYPE_CHECKING:
+    from views.setup.hub import SetupHubView
+
+logger = logging.getLogger("bot.views.setup.sections.ticket")
+
+SLUG = "ticket"
+
+
+# ---------------------------------------------------------------------------
+# Embed
+# ---------------------------------------------------------------------------
+
+
+def build_ticket_setup_embed(
+    *,
+    enabled: bool = False,
+    staff_role_id: int | None = None,
+    log_channel_id: int | None = None,
+    max_open_per_user: int | None = None,
+    guild: discord.Guild | None = None,
+) -> discord.Embed:
+    """Render the ticket section panel, reflecting any pending / current state."""
+    embed = discord.Embed(
+        title="🎫 Support Tickets",
+        description=(
+            "Let members open **private support tickets** — a per-member channel "
+            "only they and your staff can see. They can open one with `!ticket "
+            "new`, a button panel (`!ticketpanel`), or just by asking the AI.\n\n"
+            "Pick a **staff role** (required) and an optional **transcript log "
+            "channel**, then **Enable tickets**."
+        ),
+        color=discord.Color.blurple(),
+    )
+    role_text = "_(not set — required)_"
+    if staff_role_id:
+        role = (
+            resources.resolve_role(guild, role_id=staff_role_id)
+            if guild is not None
+            else None
+        )
+        role_text = role.mention if role is not None else f"`{staff_role_id}`"
+    log_text = "_(none — transcripts won't be archived)_"
+    if log_channel_id:
+        log = guild.get_channel(log_channel_id) if guild is not None else None
+        log_text = (
+            log.mention
+            if isinstance(log, discord.TextChannel)
+            else f"`{log_channel_id}`"
+        )
+    embed.add_field(
+        name="Selected" if not enabled else "Current",
+        value=(
+            f"• Status: **{'enabled' if enabled else 'not enabled yet'}**\n"
+            f"• Staff role: {role_text}\n"
+            f"• Transcript log: {log_text}\n"
+            f"• Max open per user: **{max_open_per_user or 3}**"
+        ),
+        inline=False,
+    )
+    embed.set_footer(
+        text="Tune limits / blacklist later with !ticketlimit and !ticketblacklist.",
+    )
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Panel
+# ---------------------------------------------------------------------------
+
+
+class _StaffRoleSelect(discord.ui.RoleSelect):
+    """Pick the staff role that can see + manage every ticket."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Staff role (required) — who handles tickets…",
+            min_values=1,
+            max_values=1,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: TicketSetupSectionView = self.view  # type: ignore[assignment]
+        view.staff_role_id = self.values[0].id
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class _LogChannelSelect(discord.ui.ChannelSelect):
+    """Pick the optional channel that closed-ticket transcripts post to."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Transcript log channel (optional)…",
+            channel_types=[discord.ChannelType.text],
+            min_values=1,
+            max_values=1,
+            row=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: TicketSetupSectionView = self.view  # type: ignore[assignment]
+        view.log_channel_id = self.values[0].id
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class TicketSetupSectionView(BaseView):
+    """Direct-lane ticket config: staff role + log channel + Enable."""
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        guild: discord.Guild | None = None,
+        enabled: bool = False,
+        staff_role_id: int | None = None,
+        log_channel_id: int | None = None,
+        max_open_per_user: int | None = None,
+        timeout: int = 300,
+    ) -> None:
+        super().__init__(author, public=False, timeout=timeout)
+        self._guild = guild
+        self._enabled = enabled
+        self.staff_role_id = staff_role_id
+        self.log_channel_id = log_channel_id
+        self._max_open_per_user = max_open_per_user
+        self.add_item(_StaffRoleSelect())
+        self.add_item(_LogChannelSelect())
+
+    def render(self) -> discord.Embed:
+        return build_ticket_setup_embed(
+            enabled=self._enabled,
+            staff_role_id=self.staff_role_id,
+            log_channel_id=self.log_channel_id,
+            max_open_per_user=self._max_open_per_user,
+            guild=self._guild,
+        )
+
+    @discord.ui.button(
+        label="Enable tickets",
+        emoji="🎫",
+        style=discord.ButtonStyle.success,
+        row=2,
+    )
+    async def enable(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,  # type: ignore[type-arg]
+    ) -> None:
+        guild = interaction.guild
+        if guild is None:
+            await interaction.response.send_message(
+                "Tickets can only be configured inside a server.",
+                ephemeral=True,
+            )
+            return
+        if self.staff_role_id is None:
+            await interaction.response.send_message(
+                "Pick a **staff role** first — it's who can see and handle tickets.",
+                ephemeral=True,
+            )
+            return
+        await ticket_mutation.update_config(
+            guild.id,
+            interaction.user.id,
+            enabled=True,
+            staff_role_id=self.staff_role_id,
+            log_channel_id=self.log_channel_id,
+        )
+        self._enabled = True
+        for child in self.children:
+            child.disabled = True  # type: ignore[attr-defined]
+        embed = self.render()
+        embed.color = discord.Color.green()
+        embed.set_footer(
+            text="Tickets are live. Post a button panel with !ticketpanel.",
+        )
+        await interaction.response.edit_message(embed=embed, view=self)
+        try:
+            await setup_session.mark_in_progress(guild.id, step=SLUG)
+        except Exception:  # pragma: no cover — progress marker is best-effort
+            logger.exception("ticket section: mark_in_progress failed")
+
+
+# ---------------------------------------------------------------------------
+# Section entry points
+# ---------------------------------------------------------------------------
+
+
+async def _open_panel(
+    interaction: discord.Interaction,
+    hub: SetupHubView | None,
+) -> None:
+    """Open the ticket config panel (both the hub button + wizard Customize)."""
+    del hub
+    guild = interaction.guild
+    if guild is None:
+        await interaction.response.send_message(
+            "The tickets section requires a guild context.",
+            ephemeral=True,
+        )
+        return
+    cfg = None
+    try:
+        cfg = await ticket_service.get_config(guild.id)
+    except Exception:  # pragma: no cover — read is informational
+        logger.exception("ticket section: get_config failed")
+    view = TicketSetupSectionView(
+        interaction.user,
+        guild=guild,
+        enabled=bool(cfg and cfg.enabled),
+        staff_role_id=cfg.staff_role_id if cfg else None,
+        log_channel_id=cfg.log_channel_id if cfg else None,
+        max_open_per_user=cfg.max_open_per_user if cfg else None,
+    )
+    await interaction.response.send_message(
+        embed=view.render(),
+        view=view,
+        ephemeral=True,
+    )
+
+
+async def run(interaction: discord.Interaction, hub: SetupHubView) -> None:
+    """Section entry — open the ticket config panel."""
+    await _open_panel(interaction, hub)
+
+
+REGISTRY.register(
+    SetupSection(
+        slug=SLUG,
+        label="Support Tickets",
+        style=discord.ButtonStyle.secondary,
+        run=run,
+        emoji="🎫",
+        order=72,
+        op_kinds=frozenset(),
+        description_if_skipped=(
+            "Tickets stay disabled — members can't open private support tickets "
+            "until you enable them here or run `!ticketsetup @StaffRole [#log]`."
+        ),
+        depths=frozenset({"standard", "advanced"}),
+        customize=_open_panel,
+    ),
+)
+
+
+__all__ = [
+    "SLUG",
+    "TicketSetupSectionView",
+    "build_ticket_setup_embed",
+    "run",
+]

--- a/tests/unit/views/setup/sections/test_section_registration.py
+++ b/tests/unit/views/setup/sections/test_section_registration.py
@@ -29,6 +29,7 @@ def test_all_production_sections_are_registered():
         "diagnostics",
         "cog_routing",
         "final_review",
+        "ticket",
     }
     assert (
         expected <= slugs

--- a/tests/unit/views/setup/sections/test_ticket_section.py
+++ b/tests/unit/views/setup/sections/test_ticket_section.py
@@ -1,0 +1,176 @@
+"""Tests for the support-tickets setup section.
+
+Pins:
+
+* Registration: slug, order, emoji, style, depth, and that ``customize``
+  is wired so the guided-wizard Customize button is enabled.
+* The embed names tickets and renders the staff role / log selection.
+* ``_open_panel`` rejects DM context and opens the config panel in a guild.
+* The Enable button writes through the audited ``ticket_mutation.update_config``
+  (direct lane) with ``enabled=True`` + the selected role/log — and refuses
+  (no write) until a staff role is chosen.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from services.setup_sections import REGISTRY
+from views.setup.sections import ticket
+
+
+def _interaction(guild_id: int = 1):
+    interaction = MagicMock()
+    interaction.user = SimpleNamespace(id=99)
+    interaction.guild_id = guild_id
+    interaction.guild = SimpleNamespace(
+        id=guild_id, name="Test", get_channel=lambda _id: None
+    )
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    return interaction
+
+
+def _enable_button(view: ticket.TicketSetupSectionView) -> discord.ui.Button:
+    return next(c for c in view.children if isinstance(c, discord.ui.Button))
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_ticket_section_registered_with_expected_metadata():
+    section = REGISTRY.get("ticket")
+    assert section is not None
+    assert section.slug == "ticket"
+    assert section.order == 72
+    assert section.emoji == "🎫"
+    assert section.style == discord.ButtonStyle.secondary
+    # Standard/advanced — not a "quick" essential.
+    assert "quick" not in section.depths
+    assert {"standard", "advanced"} <= section.depths
+    # Customize wired → the guided-wizard Customize button is enabled.
+    assert section.customize is ticket._open_panel
+    # Direct-lane section: it stages no draft ops.
+    assert section.op_kinds == frozenset()
+    assert 1 <= len(section.label) <= 80
+
+
+# ---------------------------------------------------------------------------
+# Embed
+# ---------------------------------------------------------------------------
+
+
+def test_embed_names_tickets_and_shows_required_role():
+    embed = ticket.build_ticket_setup_embed()
+    blob = ((embed.title or "") + (embed.description or "")).lower()
+    assert "ticket" in blob
+    selected = next(
+        (f for f in embed.fields if f.name in ("Selected", "Current")), None
+    )
+    assert selected is not None
+    # No staff role yet → flagged required.
+    assert "required" in selected.value.lower()
+
+
+def test_embed_renders_selected_role_and_log():
+    guild = MagicMock()
+    guild.get_role.return_value = SimpleNamespace(mention="@Staff")
+    log = MagicMock(spec=discord.TextChannel)
+    log.mention = "#tickets-log"
+    guild.get_channel.return_value = log
+    with patch.object(
+        ticket.resources, "resolve_role", return_value=SimpleNamespace(mention="@Staff")
+    ):
+        embed = ticket.build_ticket_setup_embed(
+            staff_role_id=10, log_channel_id=20, guild=guild
+        )
+    field = next(f for f in embed.fields if f.name in ("Selected", "Current"))
+    assert "@Staff" in field.value
+    assert "#tickets-log" in field.value
+
+
+# ---------------------------------------------------------------------------
+# _open_panel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_panel_rejects_dm_context():
+    interaction = MagicMock()
+    interaction.user = SimpleNamespace(id=99)
+    interaction.guild = None
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    await ticket._open_panel(interaction, None)
+    interaction.response.send_message.assert_awaited_once()
+    assert "guild" in interaction.response.send_message.await_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_open_panel_opens_config_view_in_guild():
+    interaction = _interaction()
+    with patch(
+        "views.setup.sections.ticket.ticket_service.get_config",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        await ticket.run(interaction, MagicMock())
+    interaction.response.send_message.assert_awaited_once()
+    kwargs = interaction.response.send_message.await_args.kwargs
+    assert kwargs.get("ephemeral") is True
+    assert isinstance(kwargs["view"], ticket.TicketSetupSectionView)
+    assert "Tickets" in (kwargs["embed"].title or "")
+
+
+# ---------------------------------------------------------------------------
+# Enable button — the audited direct-lane write
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enable_refuses_without_staff_role():
+    view = ticket.TicketSetupSectionView(SimpleNamespace(id=99))
+    interaction = _interaction()
+    with patch(
+        "views.setup.sections.ticket.ticket_mutation.update_config",
+        new_callable=AsyncMock,
+    ) as update_mock:
+        await _enable_button(view).callback(interaction)
+    update_mock.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+    assert "staff role" in interaction.response.send_message.await_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_enable_writes_through_audited_update_config():
+    view = ticket.TicketSetupSectionView(
+        SimpleNamespace(id=99), staff_role_id=555, log_channel_id=777
+    )
+    interaction = _interaction()
+    with (
+        patch(
+            "views.setup.sections.ticket.ticket_mutation.update_config",
+            new_callable=AsyncMock,
+        ) as update_mock,
+        patch(
+            "views.setup.sections.ticket.setup_session.mark_in_progress",
+            new_callable=AsyncMock,
+        ) as mark_mock,
+    ):
+        await _enable_button(view).callback(interaction)
+    update_mock.assert_awaited_once()
+    kwargs = update_mock.await_args.kwargs
+    assert kwargs["enabled"] is True
+    assert kwargs["staff_role_id"] == 555
+    assert kwargs["log_channel_id"] == 777
+    # actor + guild are positional
+    assert update_mock.await_args.args == (1, 99)
+    interaction.response.edit_message.assert_awaited_once()
+    mark_mock.assert_awaited_once()


### PR DESCRIPTION
## Make support tickets discoverable in the setup flow

Follow-up to the ticket subsystem (#1405) + AI confirm rework (#1410). A discoverability audit found tickets were reachable only via `!help` → Community hub or the standalone `!ticketsetup` command — and were **absent from the `!setup` wizard and the bot-join welcome**, the surfaces a new server owner actually starts from. So a manager running `!setup` would never learn tickets exist or need configuring.

### Change
- **`views/setup/sections/ticket.py`** — new wizard section, so tickets appear in `!setup` / `/setup-hub`. A direct-lane config panel (staff **RoleSelect** + optional log **ChannelSelect** + **Enable**) writes through the audited `ticket_mutation.update_config` — the same path `!ticketsetup` uses. Tickets keep config in their own table (not the `set_setting` pipeline), so the section stages no draft ops (like `suggestions`/`server_scan`). `customize` is wired so the guided-wizard **Customize** button is enabled.
- **`views/setup/sections/__init__.py`** — register the section at import.
- **`views/setup/launcher.py`** — the bot-join welcome embed now mentions the **Support Tickets** step + `!ticketsetup`.
- Tests: new `test_ticket_section.py` (registration, embed, panel, audited Enable write, refuse-without-staff-role); section-registration pin updated.

Full CI mirror green (12390 passed); arch 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XyHuPzBEE9NkMbEQRcJ6a

---
_Generated by [Claude Code](https://claude.ai/code/session_014XyHuPzBEE9NkMbEQRcJ6a)_