### PR TITLE
Setup-wizard PR 1a: banned-jargon CI guard (measured baseline: 207 strings)

### DIFF
--- a/.sessions/2026-06-24-setup-copy-jargon-guard.md
+++ b/.sessions/2026-06-24-setup-copy-jargon-guard.md
@@ -1,0 +1,15 @@
+# Session — 2026-06-24 · setup-copy jargon guard (PR 1a)
+
+> **Status:** `in-progress` — born-red. Building the **banned-jargon CI guard** from the merged
+> setup-wizard restructure plan (#1418) — Law 2's durable enforcement, and the slice of PR 1 that is
+> independent of the still-open architectural Q-A (direct-apply lane). Contained / reversible /
+> test-covered; touches no runtime behaviour. ⚑ Self-initiated (advancing the owner-directed plan).
+
+## What I'm about to do
+
+Add `scripts/check_setup_copy.py` (Q-0105 warn-first disposable guard, mirroring
+`check_settings_reachability.py`): statically scan operator-facing strings in `disbot/views/setup/` for
+the §4 banned-jargon list, report file:line:term, exit 0 in report mode / 1 in --strict. Add a
+ratchet invariant test against a measured baseline (so *new* jargon fails while the existing
+jargon-heavy copy is tolerated until the spine rewrite cleans it). Turns the plan's *modelled* "44
+jargon hits" into a *measured* ground-truth number, and records it in the plan.

--- a/.sessions/2026-06-24-setup-copy-jargon-guard.md
+++ b/.sessions/2026-06-24-setup-copy-jargon-guard.md
@@ -1,15 +1,73 @@
 # Session — 2026-06-24 · setup-copy jargon guard (PR 1a)
 
-> **Status:** `in-progress` — born-red. Building the **banned-jargon CI guard** from the merged
-> setup-wizard restructure plan (#1418) — Law 2's durable enforcement, and the slice of PR 1 that is
-> independent of the still-open architectural Q-A (direct-apply lane). Contained / reversible /
-> test-covered; touches no runtime behaviour. ⚑ Self-initiated (advancing the owner-directed plan).
+> **Status:** `complete` — tooling + test + plan note. No runtime behaviour change.
 
-## What I'm about to do
+**Trigger:** "continue from where you left off" after the setup-wizard restructure plan (#1418) merged.
+The spine (PR 1 proper) is gated on the owner's architectural Q-A (direct-apply lane); the **jargon
+guard** is the slice of PR 1 that is Q-A-independent, contained, reversible, and test-covered — so I
+built it now (⚑ self-initiated, advancing the owner-directed plan).
 
-Add `scripts/check_setup_copy.py` (Q-0105 warn-first disposable guard, mirroring
-`check_settings_reachability.py`): statically scan operator-facing strings in `disbot/views/setup/` for
-the §4 banned-jargon list, report file:line:term, exit 0 in report mode / 1 in --strict. Add a
-ratchet invariant test against a measured baseline (so *new* jargon fails while the existing
-jargon-heavy copy is tolerated until the spine rewrite cleans it). Turns the plan's *modelled* "44
-jargon hits" into a *measured* ground-truth number, and records it in the plan.
+## What changed
+
+- **`scripts/check_setup_copy.py`** — Q-0105 warn-first disposable guard (provenance + kill-switch
+  header, mirrors `check_settings_reachability.py`). AST-scans **operator-facing** strings in
+  `disbot/views/setup/` (UI kwargs + `send`/`followup` args; **excludes docstrings + logging calls**) for
+  the plan §4 banned-jargon list. `--strict` / `--json` modes.
+- **`tests/unit/invariants/test_setup_copy_jargon.py`** — ratchet: total-count ceiling (regression guard)
+  + new-dirty-file guard (new sections must ship plain-language) + a guard-sanity case. 3/3 pass.
+- **Plan updated** — records PR 1a shipped + the **measured baseline: 207 jargon strings across 33
+  files** (top: `stage`×66, `guild`×58, `final review`×46, `operation`×40), vs the sim's modelled 44.
+- CI mirror green (`check_quality --check-only`), `check_docs --strict` green.
+
+## Measurement (the real deliverable beyond the tool)
+
+The plan *modelled* 44 jargon hits on the standard-depth spine. The guard measured **207 across the whole
+setup surface (33 files)** — the jargon problem is ~5× larger than the spine-only model suggested. This
+is the ground-truth baseline the spine rewrite drives to zero, and the number that justifies an *enforced*
+ratchet rather than a one-time cleanup.
+
+## 💡 Session idea (Q-0089)
+
+**Generalise the plain-language guard beyond setup → a `check_ui_copy.py` for all `views/`.** The jargon
+problem isn't unique to the wizard; the same banned-term scan (with a surface-specific allowlist) would
+catch jargon leaking into hub embeds, game panels, and error messages bot-wide. The setup guard is the
+proof-of-concept; if it proves reliable over a few sessions (per its own kill-switch clause), promoting
+the AST UI-string extractor into a shared helper and pointing it at `disbot/views/` would make
+"plain-language everywhere" a project-wide ratchet. Captured here, not built — it should wait until the
+setup guard has earned trust. (Dedup-checked `docs/ideas/`: no existing UI-copy-linter idea.)
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous `.sessions/` log: the **setup-wizard restructure plan + simulator** (PR #1418). Did well: the
+simulator was the right move (the owner asked for one), and the research → sim → plan chain was tight and
+source-grounded. What it missed: it pushed the new `setup_wizard_sim.py` without running the formatters on
+it, so CI red-flagged black+ruff and cost a fix round — the second formatting miss in two sessions on a
+*new Python file added in a docs-focused session*. **System improvement this surfaced (and I acted on it
+this session):** when a "docs/tooling" session adds *any* `.py`, run the full `check_quality --check-only`
+before the first push, not just `check_docs` — I did exactly that here, caught black+ruff locally, and
+pushed clean. Worth promoting into the Stop-hook reminder or the session-close skill: *"new `.py` this
+session? run check_quality --check-only before pushing, even if the session is 'just docs'."* Routing this
+as a candidate rule in the journal Quick-reference.
+
+## 📋 Doc audit (Q-0104)
+
+Guard + test + plan note in place; plan already linked from index + folio (last session). No owner
+*decision* made (still advancing the plan; Q-A–E remain open for the owner). No `current-state.md` ledger
+entry needed until the PR merges (the ledger checker keys off merged PRs; PR #1420 will be picked up by
+the next reconciliation/ledger pass). `check_docs --strict` + `check_quality --check-only` green.
+
+## Context delta
+
+- **Surprise:** the jargon surface is ~5× the spine-only model (207 vs 44) — most of it in the
+  draft/Final-Review machinery (`wizard.py`, `final_review.py`, `role_templates.py`) and the recurring
+  `"…requires a guild context"` error strings (`guild`×58). Those error strings are a cheap early win:
+  s/guild/server/ across setup error copy would clear ~58 findings with near-zero risk, independent of
+  the spine rebuild.
+- **For next session:** the spine (PR 1) still needs Q-A. A zero-risk pre-step available *now*: the
+  guild→server error-copy sweep (~58 findings) — pure string edits, no behaviour change, lowers the
+  ratchet immediately. Could be the next "continue" slice if the owner doesn't answer Q-A.
+
+## ⚑ Self-initiated: YES — building the jargon guard now (PR 1a) was my initiative, advancing the
+owner-directed setup-wizard plan via its Q-A-independent slice. Contained / reversible / test-covered;
+warn-first (no runtime or CI-blocking behaviour change). The plan itself remains owner-directed and
+plan-first; the architectural Q-A (direct-apply lane) is still the owner's to answer before the spine.

--- a/docs/owner/claims/claude-serene-mccarthy-lv5z94.md
+++ b/docs/owner/claims/claude-serene-mccarthy-lv5z94.md
@@ -1,1 +1,0 @@
-claude/serene-mccarthy-lv5z94 · build setup-copy jargon guard (scripts/check_setup_copy.py + invariant test) — PR1a of setup-wizard plan · scripts/ + tests/ · 2026-06-24

--- a/docs/owner/claims/claude-serene-mccarthy-lv5z94.md
+++ b/docs/owner/claims/claude-serene-mccarthy-lv5z94.md
@@ -1,0 +1,1 @@
+claude/serene-mccarthy-lv5z94 · build setup-copy jargon guard (scripts/check_setup_copy.py + invariant test) — PR1a of setup-wizard plan · scripts/ + tests/ · 2026-06-24

--- a/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
+++ b/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
@@ -145,13 +145,21 @@ decision with architectural weight → called out as open question Q-A below.
 
 ## 7. PR breakdown (≤3 PRs)
 
+- **PR 1a — the jargon guard (SHIPPED 2026-06-24, ahead of the spine):** `scripts/check_setup_copy.py`
+  (Q-0105 warn-first disposable tool) + ratchet invariant test
+  (`tests/unit/invariants/test_setup_copy_jargon.py`). It AST-scans operator-facing strings (UI kwargs +
+  `send`/`followup` args, excluding docstrings/logs) in `disbot/views/setup/` for the §4 banned list. It
+  is independent of Q-A, so it shipped first. **Measured ground-truth baseline: 207 jargon strings across
+  33 files** (top offenders: `stage`×66, `guild`×58, `final review`×46, `operation`×40) — far above the
+  *modelled* 44 in the sim, which only counted the standard-depth spine. The ratchet tolerates the
+  existing copy but fails on any *new* jargon or any new dirty setup file; the spine rewrite drives the
+  count to zero, then the guard graduates to `--strict` in CI. This is Law 2's durable enforcement.
 - **PR 1 — the essentials spine (the headline):** a new linear wizard flow (`views/setup/`) rendering
   steps 0–7 above with plain-language copy, **direct-apply** per step, button/dropdown-only input, and
   **auto-create** for the welcome channel, log channels, and reward roles. Add the two missing steps
   (welcome, automod) using their existing config services (`welcome_config`, `automod_config`) — no new
-  mutation primitives. Ships a wizard a non-technical owner can finish. Includes a **jargon CI guard**
-  (`scripts/check_setup_copy.py`, Q-0105 disposable-tool header) that fails if any operator-facing setup
-  string contains a term from the §4 banned list — the durable enforcement of Law 2.
+  mutation primitives. Ships a wizard a non-technical owner can finish. Each cleaned section lowers the
+  PR-1a jargon baseline (`_BASELINE_TOTAL`) toward zero.
 - **PR 2 — extras + health check:** the **Extras menu** (each existing config surface as a one-action
   step: starboard, counters, security, image-mod, karma, AI, reaction roles, giveaways) + the single
   **"Check my setup"** health button (folds in scan/readiness/diagnostics/suggestions). Wires the

--- a/scripts/check_setup_copy.py
+++ b/scripts/check_setup_copy.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Setup-copy jargon guard for SuperBot.
+
+The *plain-language* guard for the setup wizard.  The setup-wizard restructure
+plan (``docs/planning/setup-wizard-restructure-plan-2026-06-24.md``) sets four
+design laws; **Law 2 is "zero jargon"** — a non-technical server owner walking
+``!setup`` must never read a Discord/bot internal term (*draft, operation, bind,
+cog, subsystem, scope, resolver, threshold, seam, pipeline, routing, tier,
+guild, preset, …*).  That law was the recurring failure: the jargon crept back
+in because nothing enforced plain language.  This guard makes "zero jargon" a
+**ratchet** instead of a one-off cleanup.
+
+What it does (static — no live bot, no Postgres): it walks every ``*.py`` under
+``disbot/views/setup/``, AST-extracts string literals, keeps the ones that look
+like **operator-facing prose** (they contain a space — slugs / ``custom_id`` /
+op-kind literals like ``bind_channel`` do not), and flags any that contain a
+banned jargon stem.  Each finding is ``file:line — term … in "<copy>"``.
+
+It is **warn-first and disposable** (Q-0105): in the default ``--mode report`` it
+prints findings and exits 0; ``--mode strict`` exits 1 on any finding.  The
+invariant test (``tests/unit/invariants/test_setup_copy_jargon.py``) ratchets
+against a recorded baseline — the current jargon-heavy copy is tolerated, but
+*new* jargon (or jargon in a *new* setup file) fails.  As the spine rewrite
+(plan PR 1) cleans each section's copy, the baseline shrinks; once it reaches
+zero the guard graduates to ``--mode strict`` in CI.
+
+Provenance / reliability (Q-0105):
+  - Added 2026-06-24 for the setup-wizard restructure plan (Law 2 enforcement):
+    ``docs/planning/setup-wizard-restructure-plan-2026-06-24.md`` §4, §7 (PR 1).
+  - **Unverified:** the "prose vs. machine string" split is a heuristic (has a
+    space → prose).  It can miss a one-word jargon label (rare — real UI copy is
+    phrases) and could in principle flag a benign spaced string that happens to
+    contain a stem.  Confirm a flagged string is really operator-facing before
+    treating it as a true positive, and keep the guard warn-only until proven
+    quiet across a few sessions.
+  - **Delete this guard if it proves unreliable over multiple sessions** — it is
+    a convenience ratchet, not load-bearing runtime code.
+
+Usage:
+    python3.10 scripts/check_setup_copy.py              # report (exit 0)
+    python3.10 scripts/check_setup_copy.py --strict     # exit 1 on any finding
+    python3.10 scripts/check_setup_copy.py --json       # machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SETUP_ROOT = _REPO_ROOT / "disbot" / "views" / "setup"
+
+# Jargon a non-technical owner does not understand (plan §4). Matched as a
+# word-start stem against lowercased prose, so "stage" catches "stages",
+# "operation" catches "operations", "bind" catches "binding"/"bind_channel".
+JARGON_STEMS: tuple[str, ...] = (
+    "draft",
+    "operation",
+    "stage",
+    "bind",
+    "subsystem",
+    "resolver",
+    "precedence",
+    "threshold",
+    "seam",
+    "pipeline",
+    "routing",
+    # multi-word / underscore forms (substring-matched)
+    "final review",
+    "set_setting",
+    "set_role_threshold",
+    "set_cleanup_policy",
+    "set_cog_routing",
+    "cog routing",
+)
+# Standalone words that are jargon on their own but appear inside many benign
+# words; matched with strict word boundaries to avoid false hits.
+JARGON_WORDS: tuple[str, ...] = (
+    "cog",
+    "scope",
+    "tier",
+    "guild",
+    "preset",
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    file: str  # repo-relative path
+    line: int
+    text: str  # the offending string literal
+    terms: tuple[str, ...]  # jargon terms it contains
+
+
+def _terms_in(text: str) -> tuple[str, ...]:
+    low = text.lower()
+    hits: list[str] = []
+    for stem in JARGON_STEMS:
+        if " " in stem or "_" in stem:
+            if stem in low:
+                hits.append(stem)
+        elif re.search(rf"\b{re.escape(stem)}", low):
+            hits.append(stem)
+    for word in JARGON_WORDS:
+        if re.search(rf"\b{re.escape(word)}s?\b", low):
+            hits.append(word)
+    return tuple(dict.fromkeys(hits))  # dedupe, keep order
+
+
+def _is_prose(text: str) -> bool:
+    """Operator-facing prose contains a space; slugs / custom_ids / op-kinds do not."""
+    return " " in text.strip() and any(c.isalpha() for c in text)
+
+
+# Keyword arguments whose string value is rendered to the operator.
+_UI_KWARGS = frozenset(
+    {
+        "label",
+        "description",
+        "placeholder",
+        "title",
+        "content",
+        "text",
+        "value",
+        "name",
+    },
+)
+# Call targets that send/edit operator-facing text (positional string args count).
+_SEND_ATTRS = frozenset(
+    {"send", "send_message", "edit", "edit_message", "edit_original_response"},
+)
+# Logging calls — their string args are developer-facing, never flagged.
+_LOG_ATTRS = frozenset(
+    {"debug", "info", "warning", "warn", "error", "exception", "critical", "log"},
+)
+
+
+def _string_value(node: ast.AST) -> str | None:
+    """Return the literal text of a str Constant or the literal parts of an f-string."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):  # f-string: keep only the literal segments
+        parts = [
+            v.value
+            for v in node.values
+            if isinstance(v, ast.Constant) and isinstance(v.value, str)
+        ]
+        return " ".join(parts) if parts else None
+    return None
+
+
+class _UICopyVisitor(ast.NodeVisitor):
+    """Collect only strings that reach the operator (UI kwargs + send args)."""
+
+    def __init__(self, rel: str) -> None:
+        self.rel = rel
+        self.findings: list[Finding] = []
+
+    def _consider(self, value_node: ast.AST, line: int) -> None:
+        text = _string_value(value_node)
+        if text is None or not _is_prose(text):
+            return
+        terms = _terms_in(text)
+        if terms:
+            self.findings.append(Finding(self.rel, line, text, terms))
+
+    def visit_Call(self, node: ast.Call) -> None:
+        attr = ""
+        if isinstance(node.func, ast.Attribute):
+            attr = node.func.attr
+        elif isinstance(node.func, ast.Name):
+            attr = node.func.id
+        if attr not in _LOG_ATTRS:
+            for kw in node.keywords:
+                if kw.arg in _UI_KWARGS:
+                    self._consider(kw.value, getattr(kw.value, "lineno", node.lineno))
+            if attr in _SEND_ATTRS:
+                for arg in node.args:
+                    self._consider(arg, getattr(arg, "lineno", node.lineno))
+        self.generic_visit(node)
+
+
+def scan_file(path: Path) -> list[Finding]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError):
+        return []
+    visitor = _UICopyVisitor(str(path.relative_to(_REPO_ROOT)))
+    visitor.visit(tree)
+    return visitor.findings
+
+
+def scan_setup_copy(root: Path = _SETUP_ROOT) -> list[Finding]:
+    """Return all jargon findings under *root*, sorted by (file, line)."""
+    findings: list[Finding] = []
+    for path in sorted(root.rglob("*.py")):
+        findings.extend(scan_file(path))
+    return sorted(findings, key=lambda f: (f.file, f.line))
+
+
+def _format(findings: list[Finding]) -> str:
+    lines: list[str] = []
+    for f in findings:
+        snippet = f.text if len(f.text) <= 80 else f.text[:77] + "…"
+        lines.append(f"  {f.file}:{f.line} — {', '.join(f.terms)}  in \"{snippet}\"")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Setup-copy jargon guard.")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit 1 if any jargon is found",
+    )
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args(argv)
+
+    findings = scan_setup_copy()
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "count": len(findings),
+                    "term_totals": _term_totals(findings),
+                    "findings": [
+                        {
+                            "file": f.file,
+                            "line": f.line,
+                            "terms": list(f.terms),
+                            "text": f.text,
+                        }
+                        for f in findings
+                    ],
+                },
+                indent=2,
+            ),
+        )
+        return 1 if (args.strict and findings) else 0
+
+    print("check_setup_copy: setup-wizard plain-language guard (plan §4, Law 2)")
+    print(
+        f"  scanned {_SETUP_ROOT.relative_to(_REPO_ROOT)} — {len(findings)} jargon string(s)",
+    )
+    if findings:
+        print(_format(findings))
+        print("  term totals: " + _term_totals_str(findings))
+        print(
+            "  (warn-first: this is the baseline the spine rewrite drives toward zero;"
+            " new jargon fails the ratchet test.)",
+        )
+    else:
+        print("  no jargon — Law 2 holds ✓")
+    return 1 if (args.strict and findings) else 0
+
+
+def _term_totals(findings: list[Finding]) -> dict[str, int]:
+    totals: dict[str, int] = {}
+    for f in findings:
+        for t in f.terms:
+            totals[t] = totals.get(t, 0) + 1
+    return dict(sorted(totals.items(), key=lambda kv: (-kv[1], kv[0])))
+
+
+def _term_totals_str(findings: list[Finding]) -> str:
+    return ", ".join(f"{t}×{n}" for t, n in _term_totals(findings).items())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/invariants/test_setup_copy_jargon.py
+++ b/tests/unit/invariants/test_setup_copy_jargon.py
@@ -1,0 +1,108 @@
+"""Setup-copy jargon ratchet (setup-wizard restructure plan — Law 2).
+
+Drives ``scripts/check_setup_copy.py`` (the static plain-language guard) and
+**ratchets against a recorded baseline** (Q-0105 warn-first): the current
+jargon-heavy setup copy is tolerated, but the count may only ever go *down* and
+no *new* setup file may introduce jargon.  As the spine rewrite (plan PR 1)
+cleans each section's copy, lower ``_BASELINE_TOTAL`` to lock in the gain; when
+it reaches zero the guard graduates to ``--mode strict`` in CI.
+
+Why two assertions rather than a frozen 207-line baseline: line numbers shift
+constantly, so a per-line baseline is noise.  The two real regressions we must
+catch are (a) an existing file growing *more* jargon and (b) a brand-new setup
+section shipping with jargon — a count ceiling catches (a), the file-set guard
+catches (b).
+
+Baseline measured 2026-06-24 against the pre-restructure wizard:
+  207 operator-facing jargon strings across 33 files (``check_setup_copy --json``).
+
+Sibling invariants: ``test_settings_reachability.py``, ``test_command_reachability.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "check_setup_copy.py"
+
+# Ratchet ceiling — lower this as the spine rewrite cleans copy; never raise it.
+_BASELINE_TOTAL = 207
+
+# The setup files that carry jargon debt today. A finding in any file NOT in
+# this set is new jargon and fails — new sections must ship plain-language.
+_BASELINE_FILES = frozenset(
+    {
+        "disbot/views/setup/ai_review/main_panel.py",
+        "disbot/views/setup/ai_review/per_recommendation.py",
+        "disbot/views/setup/depth_panel.py",
+        "disbot/views/setup/draft_render.py",
+        "disbot/views/setup/final_review.py",
+        "disbot/views/setup/hub.py",
+        "disbot/views/setup/launcher.py",
+        "disbot/views/setup/provisioning/confirm_panel.py",
+        "disbot/views/setup/provisioning/preview_panel.py",
+        "disbot/views/setup/recovery.py",
+        "disbot/views/setup/scan_panel.py",
+        "disbot/views/setup/section_card.py",
+        "disbot/views/setup/sections/ai_setup.py",
+        "disbot/views/setup/sections/btd6.py",
+        "disbot/views/setup/sections/channels.py",
+        "disbot/views/setup/sections/cleanup.py",
+        "disbot/views/setup/sections/cog_routing.py",
+        "disbot/views/setup/sections/diagnostics.py",
+        "disbot/views/setup/sections/final_review.py",
+        "disbot/views/setup/sections/identity.py",
+        "disbot/views/setup/sections/logging_presets.py",
+        "disbot/views/setup/sections/moderation.py",
+        "disbot/views/setup/sections/preset_select.py",
+        "disbot/views/setup/sections/purpose.py",
+        "disbot/views/setup/sections/readiness.py",
+        "disbot/views/setup/sections/role_templates.py",
+        "disbot/views/setup/sections/roles.py",
+        "disbot/views/setup/sections/server_scan.py",
+        "disbot/views/setup/sections/suggestions.py",
+        "disbot/views/setup/sections/ticket.py",
+        "disbot/views/setup/summary.py",
+        "disbot/views/setup/template_picker.py",
+        "disbot/views/setup/wizard.py",
+    },
+)
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("check_setup_copy_ut", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_jargon_count_does_not_regress() -> None:
+    checker = _load_checker()
+    findings = checker.scan_setup_copy()
+    assert len(findings) <= _BASELINE_TOTAL, (
+        f"Setup-copy jargon rose to {len(findings)} (baseline {_BASELINE_TOTAL}). "
+        "New operator-facing jargon was added — see plan §4 for plain-language "
+        "replacements, or run `python3.10 scripts/check_setup_copy.py`."
+    )
+
+
+def test_no_new_setup_file_introduces_jargon() -> None:
+    checker = _load_checker()
+    dirty_files = {f.file for f in checker.scan_setup_copy()}
+    new_dirty = dirty_files - _BASELINE_FILES
+    assert not new_dirty, (
+        "New setup file(s) shipped with operator-facing jargon: "
+        f"{sorted(new_dirty)}. New sections must use plain language (plan Law 2)."
+    )
+
+
+def test_clean_string_is_not_flagged() -> None:
+    """A plain-language label produces no finding; a jargon one does (guard sanity)."""
+    checker = _load_checker()
+    assert checker._terms_in("Greet new members when they join") == ()
+    assert "stage" in checker._terms_in("Each pick stages an operation in the draft")


### PR DESCRIPTION
## What

Ships **PR 1a of the setup-wizard restructure plan** (#1418): the **banned-jargon CI guard** — Law 2's durable enforcement. This is the slice of PR 1 that's independent of the still-open architectural Q-A (direct-apply lane), so it lands first and turns the plan's *modelled* jargon estimate into a *measured* ground-truth baseline.

- `scripts/check_setup_copy.py` — Q-0105 warn-first disposable guard (provenance + kill-switch header, mirrors `check_settings_reachability.py`).
- `tests/unit/invariants/test_setup_copy_jargon.py` — ratchet invariant test.

## How it works

AST-scans **operator-facing strings only** in `disbot/views/setup/` — UI keyword args (`label`/`description`/`placeholder`/`title`/…) and `send`/`followup` args, **excluding docstrings and logging calls** (the heuristic was tightened after a first pass over-matched module docstrings and log lines). Flags any that contain a §4 banned-jargon stem (draft, operation, stage, bind, cog, subsystem, scope, resolver, threshold, seam, pipeline, routing, tier, guild, preset, …).

## Measured baseline

**207 operator-facing jargon strings across 33 setup files** — far above the sim's modelled 44 (which only counted the standard-depth spine). Top offenders: `stage`×66, `guild`×58, `final review`×46, `operation`×40, `preset`×26.

The ratchet tolerates today's jargon-heavy copy but **fails on any new jargon or any new dirty setup file** — so new sections must ship plain-language. As the spine rewrite (PR 1) cleans each section, `_BASELINE_TOTAL` drops toward zero; then the guard graduates to `--strict` in CI.

## Scope

Tooling + test + a one-line plan update recording the baseline. **No runtime behaviour change** — the guard is warn-first and CI-scoped via the invariant test. `check_quality --check-only` green, 3/3 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJiSiWF242E5ShFS5Gq41R)_