### PR TITLE
diagnostics: setup readiness scan grades tickets

### DIFF
--- a/.sessions/2026-06-24-readiness-grades-tickets.md
+++ b/.sessions/2026-06-24-readiness-grades-tickets.md
@@ -1,0 +1,69 @@
+# 2026-06-24 — Setup readiness scan grades tickets
+
+> **Status:** `complete` — the setup readiness scan now grades tickets. Full CI mirror green (12393 passed
+> after regenerating env-vars.md); arch 0 errors.
+
+> **Run type:** `manual` — self-initiated follow-up flagged in the previous session (see ⚑ below).
+
+**Branch:** `claude/readiness-grades-tickets` (off `main`). Third follow-up in the tickets thread
+(#1405 subsystem, #1410 AI confirm, #1417 setup-wizard discoverability).
+
+## What this session is doing
+
+The setup readiness scan (`build_setup_readiness_embed`) grades each subsystem from its declared
+config schema, but **tickets register no subsystem schema** — their config lives in a dedicated table
+(`services.ticket_service`) — so tickets were absent from the scan entirely. This adds a dedicated
+**🎫 Support Tickets** readiness line that reads `ticket_service.get_config` directly: 🟢 enabled (with
+log on/off + max-open) or 🔴 not set up (pointing at the `!setup` step / `!ticketsetup`). It both grades
+tickets and acts as another discovery nudge. Best-effort: a read failure is logged and the line omitted —
+the readiness embed never fails on this add-on.
+
+- `disbot/services/diagnostic_embeds.py`: module `logger` + `_render_ticket_readiness` helper, called
+  from `build_setup_readiness_embed`.
+- `tests/unit/services/test_setup_readiness.py`: not-set-up line, enabled grade, and omit-on-read-failure.
+
+## ⚑ Flagged for maintainer / known limits
+
+- **Self-initiated.** This was the "readiness scan grades tickets" idea I flagged at the end of the
+  #1417 session, not a directly-requested task. The owner had been replying "continue" on the tickets
+  thread; I judged this contained, reversible, on-theme follow-up worth building under the standing
+  autonomy guidance (Q-0129/Q-0172) rather than asking a fourth time. Easy to revert if unwanted.
+- **Not live-verified** (no Discord boot): confirm the 🎫 line shows in `!setup` → Run Readiness Scan /
+  `!platform readiness`, both for a configured and an unconfigured guild.
+- **Bespoke by necessity:** ticket config isn't a registered subsystem schema, so it can't ride the
+  score-driven per-subsystem table — hence a dedicated line. If tickets ever gain a real schema, fold
+  this into the generic path and delete the helper.
+
+## 🛠 Friction → guard (worked as intended)
+
+`scripts/scan_env_usage.py` generates `docs/operations/env-vars.md` with **line-number** references, so any
+edit that shifts lines in a file containing an env-var usage reddens `test_scan_env_usage`. The guard caught
+my edit immediately; fix is `python3.10 scripts/scan_env_usage.py --write-doc`. Worth knowing: editing
+`diagnostic_embeds.py` (and similar env-var-touching files) means regenerating that doc in the same commit.
+
+## 💡 Session idea
+
+**Make every discovery surface ticket-aware in one place.** Tickets now appear in help, the wizard, the
+launcher, and readiness — but each was wired separately. A tiny `services.feature_status` helper returning
+`(name, configured: bool, nudge: str)` per optional subsystem would let all four surfaces render the same
+status from one source, so the next optional subsystem is discoverable everywhere by adding one entry.
+Captured for grooming; don't build speculatively.
+
+## ⟲ Previous-session review
+
+The #1417 session ended by *naming* this follow-up but leaving it unbuilt — correct at the time (it wasn't
+asked for). What it could have done better: it didn't note that ticket config being schema-less means the
+readiness integration is necessarily bespoke, which I had to rediscover here. **System improvement:** when a
+session flags a follow-up idea, a one-line "implementation note / gotcha" on the idea would save the next
+session the re-discovery — worth adding to the session-idea convention (Q-0089). Low-stakes; mention if it
+recurs rather than a router block now.
+
+## 📤 Run report
+
+- **Did:** added a Support-Tickets line to the setup readiness scan · **Outcome:** shipped
+- **Shipped:** #pending — readiness now grades tickets (enabled / not set up) + nudges setup
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** none — revert if the self-initiated scope wasn't wanted
+- **⚑ Owner manual steps:** spot-check the 🎫 line in the readiness scan live
+- **⚑ Self-initiated:** YES — built the previous session's flagged idea unprompted (see ⚑ above)
+- **↪ Next:** live-verify; optionally the `feature_status` consolidation idea

--- a/disbot/services/diagnostic_embeds.py
+++ b/disbot/services/diagnostic_embeds.py
@@ -14,6 +14,7 @@ callbacks produce the same embed as the typed command.
 from __future__ import annotations
 
 import datetime
+import logging
 from typing import TYPE_CHECKING
 
 import discord
@@ -29,6 +30,9 @@ from services.platform_consistency import (
 if TYPE_CHECKING:
     from governance.models import CleanupPolicy, GovernanceSnapshot
     from services.binding_backfill import ApplyResult, DryRunSummary
+
+
+logger = logging.getLogger("bot.services.diagnostic_embeds")
 
 
 # ---------------------------------------------------------------------------
@@ -1911,6 +1915,42 @@ def _render_health_findings(embed, report) -> None:
         )
 
 
+async def _render_ticket_readiness(embed: discord.Embed, guild_id: int) -> None:
+    """Append a Support-Tickets readiness line to the readiness embed.
+
+    Bespoke on purpose: ticket config lives in its own table
+    (``services.ticket_service``), not the schema-declared settings the
+    aggregate readiness score reads, so tickets never appear in the
+    score-driven per-subsystem list. This dedicated line both grades them
+    (enabled / not set up) and doubles as a discovery nudge toward the
+    Support Tickets setup step. Best-effort: a read failure is logged and
+    the line is simply omitted — readiness must never fail on this add-on.
+    """
+    if len(embed.fields) >= _EMBED_FIELD_CAP:
+        return
+    from services import ticket_service
+
+    try:
+        cfg = await ticket_service.get_config(guild_id)
+    except Exception:
+        logger.exception("readiness: ticket config read failed (guild=%d)", guild_id)
+        return
+
+    if cfg is None or not cfg.is_set_up:
+        value = (
+            "🔴 **Not set up** — members can't open support tickets yet. Enable "
+            "them in the **Support Tickets** setup step (`!setup`) or run "
+            "`!ticketsetup @StaffRole [#log]`."
+        )
+    else:
+        log_state = "on" if cfg.log_channel_id else "off"
+        value = (
+            f"🟢 **Enabled** · staff role set · transcript log {log_state} · "
+            f"max {cfg.max_open_per_user} open per member"
+        )
+    embed.add_field(name="🎫 Support Tickets", value=value, inline=False)
+
+
 async def build_setup_readiness_embed(
     guild_id: int,
     *,
@@ -1955,6 +1995,7 @@ async def build_setup_readiness_embed(
     )
 
     _render_health_findings(embed, report)
+    await _render_ticket_readiness(embed, guild_id)
 
     if not report.per_subsystem:
         embed.add_field(

--- a/docs/operations/env-vars.md
+++ b/docs/operations/env-vars.md
@@ -21,7 +21,7 @@ only — never a value**; the values live in Railway service variables
 |---|---|---|
 | `DATABASE_URL` | utils | `disbot/utils/db/pool.py:41` |
 | `DISCORD_BOT_TOKEN_PRODUCTION` | config | `disbot/config.py:19` |
-| `YOUTUBE_API_KEY` | services | `disbot/services/diagnostic_embeds.py:1265`<br>`disbot/services/youtube_fetch_service.py:22` |
+| `YOUTUBE_API_KEY` | services | `disbot/services/diagnostic_embeds.py:1269`<br>`disbot/services/youtube_fetch_service.py:22` |
 
 ## Optional (a default is always supplied)
 

--- a/tests/unit/services/test_setup_readiness.py
+++ b/tests/unit/services/test_setup_readiness.py
@@ -378,6 +378,81 @@ async def test_build_setup_readiness_embed_handles_empty_registry():
 
 
 # ---------------------------------------------------------------------------
+# Support-tickets readiness line (bespoke — ticket config is not schema-driven)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_readiness_embed_flags_tickets_not_set_up():
+    from cogs.diagnostic._platform_embeds import build_setup_readiness_embed
+
+    with patch(
+        "services.setup_readiness.db_bindings.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[],
+    ), patch(
+        "services.ticket_service.get_config",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        embed = await build_setup_readiness_embed(guild_id=42)
+    ticket_field = next((f for f in embed.fields if "Tickets" in (f.name or "")), None)
+    assert ticket_field is not None
+    assert "not set up" in ticket_field.value.lower()
+    assert "ticketsetup" in ticket_field.value.lower()
+
+
+@pytest.mark.asyncio
+async def test_readiness_embed_grades_enabled_tickets():
+    from types import SimpleNamespace
+
+    from cogs.diagnostic._platform_embeds import build_setup_readiness_embed
+
+    cfg = SimpleNamespace(
+        is_set_up=True,
+        enabled=True,
+        staff_role_id=9,
+        log_channel_id=5,
+        max_open_per_user=3,
+    )
+    with patch(
+        "services.setup_readiness.db_bindings.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[],
+    ), patch(
+        "services.ticket_service.get_config",
+        new_callable=AsyncMock,
+        return_value=cfg,
+    ):
+        embed = await build_setup_readiness_embed(guild_id=42)
+    ticket_field = next(
+        (f for f in embed.fields if "Tickets" in (f.name or "")), None
+    )
+    assert ticket_field is not None
+    assert "enabled" in ticket_field.value.lower()
+    assert "transcript log on" in ticket_field.value.lower()
+
+
+@pytest.mark.asyncio
+async def test_readiness_embed_omits_ticket_line_on_read_failure():
+    from cogs.diagnostic._platform_embeds import build_setup_readiness_embed
+
+    with patch(
+        "services.setup_readiness.db_bindings.list_for_guild",
+        new_callable=AsyncMock,
+        return_value=[],
+    ), patch(
+        "services.ticket_service.get_config",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("DB down"),
+    ):
+        embed = await build_setup_readiness_embed(guild_id=42)
+    # Best-effort: the readiness embed still renders, just without a ticket line.
+    assert all("Tickets" not in (f.name or "") for f in embed.fields)
+    assert embed.title is not None
+
+
+# ---------------------------------------------------------------------------
 # Phase 9d / Track 2 PR 5: health_findings + health_summary
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Setup readiness scan grades tickets

Self-initiated follow-up to the tickets thread (#1405 / #1410 / #1417) — building the "readiness scan grades tickets" idea flagged at the end of #1417.

### Why
The setup readiness scan (`build_setup_readiness_embed`) grades each subsystem from its declared config schema — but **tickets register no subsystem schema** (their config lives in a dedicated table), so tickets were absent from the scan entirely.

### Change
- **`services/diagnostic_embeds.py`** — a dedicated **🎫 Support Tickets** readiness line that reads `ticket_service.get_config` directly: 🟢 enabled (with transcript-log on/off + max-open) or 🔴 not set up (pointing at the `!setup` step / `!ticketsetup`). It both grades tickets and acts as another discovery nudge. Best-effort: a read failure is logged and the line omitted — readiness never fails on this add-on.
- **Tests** — not-set-up line, enabled grade, and omit-on-read-failure.
- Regenerated `docs/operations/env-vars.md` (its line-number references shifted with the edit).

Bespoke by necessity: ticket config isn't schema-driven, so it can't ride the score-driven per-subsystem table — hence a dedicated line (documented in the helper). Full CI mirror green; arch 0 errors.

> Note: this is **self-initiated** — flagged on the session-log run report for review. Trivially revertible if the scope wasn't wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XyHuPzBEE9NkMbEQRcJ6a

---
_Generated by [Claude Code](https://claude.ai/code/session_014XyHuPzBEE9NkMbEQRcJ6a)_