### PR TITLE
tickets: fully button/dropdown setup + auto-create log channel

### DIFF
--- a/.sessions/2026-06-24-ticket-setup-buttons.md
+++ b/.sessions/2026-06-24-ticket-setup-buttons.md
@@ -1,0 +1,93 @@
+# 2026-06-24 — Ticket setup: all buttons & dropdowns + auto-create
+
+> **Status:** `complete` — ticket setup is fully button/dropdown driven with an auto-create-log option,
+> reachable from both the wizard and `!ticketsetup`. Full CI mirror green (12402 passed); arch 0 errors.
+
+> **Run type:** `manual` — owner request: "make sure setup is configured with buttons and drop-down menus,
+> no way to type a role/channel name wrong; also an option to automatically create the ticket channel."
+
+**Branch:** `claude/ticket-setup-buttons` (off `main`). Fifth in the tickets thread.
+
+## What this session is doing
+
+The wizard section (#1417) already uses RoleSelect + ChannelSelect (dropdowns), and the ticket **category**
+auto-creates on first open. Remaining gaps vs. the owner's ask:
+
+1. **Reusable config panel** — move `TicketSetupSectionView` → `views/tickets/config_panel.py`
+   (`TicketConfigPanelView`), so it's a ticket-domain UI both the setup wizard and `!ticketsetup` open.
+2. **Auto-create log channel** — `ticket_mutation.create_log_channel`: one click creates a private
+   `#ticket-transcripts` channel (staff-only) and sets it as the transcript log, so no pre-existing channel
+   or typing is needed.
+3. **Post-panel button** — post the public open-ticket panel from the config UI (no `!ticketpanel` needed).
+4. **`!ticketsetup` opens the panel** — running it with no args opens the dropdown UI instead of requiring
+   `!ticketsetup @Role #chan`.
+
+The positional `!ticketsetup @Role #chan` form stays for power users.
+
+## What shipped (PR #pending)
+
+- **`views/tickets/config_panel.py`** (new) — `TicketConfigPanelView` + `build_ticket_config_embed` +
+  `open_ticket_config_panel`. Native **RoleSelect** + **ChannelSelect** (no typing), **🪄 Auto-create log
+  channel**, **✅ Enable**, **📋 Post panel** buttons. All writes via the audited `ticket_mutation` direct lane.
+- **`services/ticket_mutation.py`** — `create_log_channel` + `TicketChannelResult`. Creates a private
+  `#ticket-transcripts` channel **through the audited `ChannelLifecycleService` seam** (not a raw
+  `guild.create_*` — the no-silent-auto-create invariant), then locks it down staff-only and sets it as the log.
+- **`views/setup/sections/ticket.py`** — slimmed to a thin wizard adapter that opens the shared panel +
+  marks setup progress (the view moved to the ticket domain so `!ticketsetup` can share it without the
+  ticket domain depending on the setup wizard).
+- **`cogs/ticket_cog.py`** — `!ticketsetup` with no args now opens the dropdown panel; the positional
+  `!ticketsetup @Role #chan` form stays for power users.
+- Regenerated `botsite/data/site.json` (dashboard export) — line-shift artifact.
+- Tests: `tests/unit/views/tickets/test_config_panel.py` (dropdowns, enable, auto-create, post-panel,
+  seeding), `create_log_channel` service tests, slimmed section test.
+
+### Decisions made alone (for owner ratification)
+
+- **Moved the config panel into `views/tickets/`** rather than leaving it in the setup section, so the
+  command and the wizard share one UI without the ticket domain importing the setup wizard. Clean
+  layering; the section is now a 3-line adapter.
+- **`!ticketsetup` (no args) opens the panel** instead of printing a status block — the panel shows current
+  state too, and this furthers the "no long commands" goal. Positional form preserved.
+- The auto-created log channel is named `ticket-transcripts` and is staff-only. Reasonable default; rename
+  later in Discord if desired.
+
+### ⚑ Flagged for maintainer / known limits
+
+- **Self-initiated continuation** of the owner's request (the request itself was owner-directed; the
+  panel-move + `!ticketsetup`-opens-panel were my calls). Revertible.
+- **Not live-verified** (no Discord boot): confirm the dropdowns render, Auto-create makes a staff-only
+  `#ticket-transcripts`, Enable persists, and Post panel drops the public launcher.
+- The ticket **category** still auto-creates on first open (unchanged) — the embed says so, so operators
+  aren't surprised there's no category picker.
+
+## 💡 Session idea
+
+**A `max-open` stepper + `ping-staff` toggle on the same panel.** The panel covers role/log/enable; the two
+remaining knobs (`max_open_per_user`, `ping_staff_on_open`) still need `!ticketlimit` / raw config. A small
+select + toggle would make the panel the complete no-command setup surface. Captured, not built.
+
+## ⟲ Previous-session review
+
+The #1421 (readiness-grades-tickets) session was clean but, like #1417, it shipped a *display* of ticket
+state without making the underlying setup itself fully no-command — which is what the owner actually wanted
+all along (surfaced only when they asked this session). Lesson reinforced: when the goal is "no manual
+commands," check the *configuration* path is button-driven, not just the *discovery* path. **System
+improvement:** none new — the consistency checker (`edit_in_place`) and the no-silent-auto-create invariant
+both caught real issues in this PR before CI, which is exactly the guard-rail system working.
+
+## 🛠 Friction → guard (worked as intended)
+
+Two guards caught real mistakes locally: (1) the **no-silent-auto-create** invariant flagged my raw
+`guild.create_text_channel` → rerouted through `ChannelLifecycleService`; (2) the **edit_in_place**
+consistency rule flagged `post_panel` sending a new ephemeral instead of editing in place → fixed to edit
+the panel. Both are good examples of the invariant suite paying off; no doc change needed.
+
+## 📤 Run report
+
+- **Did:** made ticket setup fully button/dropdown driven + auto-create log channel · **Outcome:** shipped
+- **Shipped:** #pending — dropdowns + auto-create + post-panel, shared by `!setup` and `!ticketsetup`
+- **Run type:** `manual`
+- **⚑ Owner decisions needed:** none — ratify the panel-move + `!ticketsetup`-opens-panel calls if you like
+- **⚑ Owner manual steps:** spot-check the panel live (dropdowns, auto-create, enable, post)
+- **⚑ Self-initiated:** the layering move + command-opens-panel were my calls within the owner's request
+- **↪ Next:** the max-open/ping-staff panel knobs idea, if wanted

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-24T11:05:38Z",
+    "generated_at": "2026-06-24T11:21:08Z",
     "build": {
-      "commit": "beb1dd4",
-      "subject": "btd6: unify five command groups under one /btd6 (Flattest layout)",
-      "committed_at": "2026-06-24T11:05:38Z"
+      "commit": "e337817",
+      "subject": "tickets: fully button/dropdown setup + auto-create log channel",
+      "committed_at": "2026-06-24T11:21:08Z"
     }
   },
   "counts": {
@@ -2590,8 +2590,8 @@
       "category": "community",
       "cooldown": null,
       "permissions": "user",
-      "usage": "Configure tickets: ``!ticketsetup @StaffRole [#log-channel]`` (managers).",
-      "description": "Configure tickets: !ticketsetup @StaffRole [#log-channel] (managers).",
+      "usage": "Configure tickets — opens a button/dropdown panel (managers).",
+      "description": "Configure tickets — opens a button/dropdown panel (managers).",
       "use_cases": null,
       "examples": [
         "!ticketsetup @StaffRole [#log-channel]"

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -5751,8 +5751,8 @@ const COMMANDS = [
     "name": "ticketsetup",
     "area": "community",
     "status": "finished",
-    "summary": "Configure tickets: ``!ticketsetup @StaffRole [#log-channel]`` (managers).",
-    "description": "Configure tickets: !ticketsetup @StaffRole [#log-channel] (managers).",
+    "summary": "Configure tickets — opens a button/dropdown panel (managers).",
+    "description": "Configure tickets — opens a button/dropdown panel (managers).",
     "usage": "!ticketsetup",
     "aliases": [],
     "permissions": "anyone",
@@ -6632,7 +6632,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "beb1dd4",
+    "build": "e337817",
     "title": "New public bot website",
     "changes": [
       {
@@ -6644,7 +6644,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "beb1dd4",
+    "build": "e337817",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -6656,7 +6656,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "beb1dd4",
+    "build": "e337817",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/disbot/cogs/ticket_cog.py
+++ b/disbot/cogs/ticket_cog.py
@@ -34,6 +34,7 @@ from views.tickets import (
     build_confirm_embed,
     build_control_view,
     build_welcome_embed,
+    open_ticket_config_panel,
     open_ticket_hub,
     post_launcher,
 )
@@ -246,35 +247,16 @@ class TicketCog(commands.Cog):
         staff_role: discord.Role | None = None,
         log_channel: discord.TextChannel | None = None,
     ) -> None:
-        """Configure tickets: ``!ticketsetup @StaffRole [#log-channel]`` (managers).
+        """Configure tickets — opens a button/dropdown panel (managers).
 
-        With no arguments, shows the current configuration.
+        With no arguments, opens the interactive setup panel (pick the staff
+        role + log channel from dropdowns, auto-create a log channel, enable,
+        and post the panel — no typing). The positional
+        ``!ticketsetup @StaffRole [#log-channel]`` form stays for power users.
         """
         if staff_role is None:
-            cfg = await ticket_service.get_config(ctx.guild.id)
-            if cfg is None or not cfg.is_set_up:
-                await ctx.send(
-                    "Tickets aren't set up. Run `!ticketsetup @StaffRole [#log]`.",
-                )
-                return
-            role = (
-                guild_resources.resolve_role(ctx.guild, role_id=cfg.staff_role_id)
-                if cfg.staff_role_id
-                else None
-            )
-            log = (
-                ctx.guild.get_channel(cfg.log_channel_id)
-                if cfg.log_channel_id
-                else None
-            )
-            await ctx.send(
-                f"🎫 **Ticket settings**\n"
-                f"• Staff role: {role.mention if role else '—'}\n"
-                f"• Transcript log: "
-                f"{log.mention if isinstance(log, discord.TextChannel) else '—'}\n"
-                f"• Max open per user: {cfg.max_open_per_user}\n"
-                f"• Ping staff on open: {cfg.ping_staff_on_open}",
-            )
+            embed, view = await open_ticket_config_panel(ctx.author, guild=ctx.guild)
+            await ctx.send(embed=embed, view=view)
             return
         await ticket_mutation.update_config(
             ctx.guild.id,

--- a/disbot/services/ticket_mutation.py
+++ b/disbot/services/ticket_mutation.py
@@ -458,6 +458,92 @@ async def remove_participant(
 # --------------------------------------------------------------------------- #
 
 
+_LOG_CHANNEL_NAME = "ticket-transcripts"
+
+
+@dataclass
+class TicketChannelResult:
+    """Outcome of an auto-created ticket channel."""
+
+    success: bool
+    message: str = ""
+    channel_id: int | None = None
+
+
+async def create_log_channel(
+    guild: discord.Guild,
+    actor_id: int,
+    *,
+    staff_role_id: int | None,
+) -> TicketChannelResult:
+    """Auto-create a private ``#ticket-transcripts`` channel + set it as the log.
+
+    Lets an operator wire up transcript logging with one button instead of
+    pre-creating a channel and selecting it (the "no typing, no wrong names"
+    setup goal). Created through the audited ``ChannelLifecycleService`` seam
+    (the same one the ticket-open path uses — never a raw ``guild.create_*``),
+    then locked down staff-only: hidden from ``@everyone``, visible to the bot
+    and the staff role. Best-effort — a creation failure (e.g. missing **Manage
+    Channels**) becomes a clear operator message, never a crash.
+    """
+    result = await ChannelLifecycleService().create_channels(
+        guild,
+        [_LOG_CHANNEL_NAME],
+        actor_id,
+        kind="text",
+        reason="Ticket transcript log (auto-created via setup)",
+    )
+    if result.outcome != lc.SUCCESS or not result.applied:
+        logger.warning(
+            "ticket setup: log channel create failed for guild=%s: %s",
+            guild.id,
+            result.first_error,
+        )
+        return TicketChannelResult(
+            False,
+            "I couldn't create the log channel — I may be missing the "
+            "**Manage Channels** permission.",
+        )
+
+    channel_id = result.applied[0].target_id
+    channel = guild.get_channel(channel_id)
+    if isinstance(channel, discord.TextChannel):
+        overwrites: dict[Any, discord.PermissionOverwrite] = {
+            guild.default_role: discord.PermissionOverwrite(view_channel=False),
+        }
+        me = guild.me
+        if me is not None:
+            overwrites[me] = discord.PermissionOverwrite(
+                view_channel=True,
+                send_messages=True,
+                embed_links=True,
+                attach_files=True,
+                read_message_history=True,
+            )
+        if staff_role_id is not None:
+            staff_role = guild_resources.resolve_role(guild, role_id=staff_role_id)
+            if staff_role is not None:
+                overwrites[staff_role] = discord.PermissionOverwrite(
+                    view_channel=True,
+                    read_message_history=True,
+                )
+        try:
+            await channel.edit(overwrites=overwrites, reason="Ticket log privacy")
+        except Exception:  # pragma: no cover — defensive; channel still usable
+            logger.exception(
+                "ticket setup: log channel overwrite apply failed for %s",
+                channel_id,
+            )
+
+    await update_config(guild.id, actor_id, log_channel_id=channel_id)
+    mention = channel.mention if isinstance(channel, discord.TextChannel) else "the log"
+    return TicketChannelResult(
+        True,
+        f"✅ Created {mention} for ticket transcripts.",
+        channel_id=channel_id,
+    )
+
+
 async def update_config(
     guild_id: int,
     actor_id: int,

--- a/disbot/views/setup/sections/ticket.py
+++ b/disbot/views/setup/sections/ticket.py
@@ -1,18 +1,17 @@
-"""Support-tickets section — enable + configure tickets inside the wizard.
+"""Support-tickets section — opens the ticket config panel inside the wizard.
 
 Tickets were reachable only via ``!help`` → Community hub or the standalone
 ``!ticketsetup`` command — invisible to a new owner running the ``!setup``
 wizard (the surface they actually start from). This section closes that
-discoverability gap: tickets now appear as a wizard step / ``/setup-hub`` button.
+discoverability gap: tickets appear as a wizard step / ``/setup-hub`` button.
 
-Tickets keep their config in a dedicated table (``services.ticket_service`` /
-``ticket_mutation``), **not** the generic ``set_setting`` pipeline, so this
-section writes through the audited ``ticket_mutation.update_config`` directly —
-the same path ``!ticketsetup`` uses. That is the focused / reversible /
-single-domain **direct lane** (``docs/ownership.md`` § "Direct vs. draft
-mutation lanes"); it stages no ``SetupOperation`` draft rows (``op_kinds`` is
-empty), mirroring the ``suggestions`` / ``server_scan`` sections that open their
-own panel rather than feeding Final Review.
+The interactive UI itself lives in the ticket domain
+(:mod:`views.tickets.config_panel`) so the wizard and the ``!ticketsetup``
+command share one fully button/dropdown-driven panel. This section is the thin
+wizard adapter: it opens that panel and marks setup progress. All writes go
+through the audited ``ticket_mutation`` direct lane (ticket config is its own
+table, not the ``set_setting`` pipeline), so this section stages no draft op —
+like the ``suggestions`` / ``server_scan`` sections.
 """
 
 from __future__ import annotations
@@ -22,10 +21,9 @@ from typing import TYPE_CHECKING
 
 import discord
 
-from core.runtime import guild_resources as resources
-from services import setup_session, ticket_mutation, ticket_service
+from services import setup_session
 from services.setup_sections import REGISTRY, SetupSection
-from views.base import BaseView
+from views.tickets import open_ticket_config_panel
 
 if TYPE_CHECKING:
     from views.setup.hub import SetupHubView
@@ -35,191 +33,11 @@ logger = logging.getLogger("bot.views.setup.sections.ticket")
 SLUG = "ticket"
 
 
-# ---------------------------------------------------------------------------
-# Embed
-# ---------------------------------------------------------------------------
-
-
-def build_ticket_setup_embed(
-    *,
-    enabled: bool = False,
-    staff_role_id: int | None = None,
-    log_channel_id: int | None = None,
-    max_open_per_user: int | None = None,
-    guild: discord.Guild | None = None,
-) -> discord.Embed:
-    """Render the ticket section panel, reflecting any pending / current state."""
-    embed = discord.Embed(
-        title="🎫 Support Tickets",
-        description=(
-            "Let members open **private support tickets** — a per-member channel "
-            "only they and your staff can see. They can open one with `!ticket "
-            "new`, a button panel (`!ticketpanel`), or just by asking the AI.\n\n"
-            "Pick a **staff role** (required) and an optional **transcript log "
-            "channel**, then **Enable tickets**."
-        ),
-        color=discord.Color.blurple(),
-    )
-    role_text = "_(not set — required)_"
-    if staff_role_id:
-        role = (
-            resources.resolve_role(guild, role_id=staff_role_id)
-            if guild is not None
-            else None
-        )
-        role_text = role.mention if role is not None else f"`{staff_role_id}`"
-    log_text = "_(none — transcripts won't be archived)_"
-    if log_channel_id:
-        log = guild.get_channel(log_channel_id) if guild is not None else None
-        log_text = (
-            log.mention
-            if isinstance(log, discord.TextChannel)
-            else f"`{log_channel_id}`"
-        )
-    embed.add_field(
-        name="Selected" if not enabled else "Current",
-        value=(
-            f"• Status: **{'enabled' if enabled else 'not enabled yet'}**\n"
-            f"• Staff role: {role_text}\n"
-            f"• Transcript log: {log_text}\n"
-            f"• Max open per user: **{max_open_per_user or 3}**"
-        ),
-        inline=False,
-    )
-    embed.set_footer(
-        text="Tune limits / blacklist later with !ticketlimit and !ticketblacklist.",
-    )
-    return embed
-
-
-# ---------------------------------------------------------------------------
-# Panel
-# ---------------------------------------------------------------------------
-
-
-class _StaffRoleSelect(discord.ui.RoleSelect):
-    """Pick the staff role that can see + manage every ticket."""
-
-    def __init__(self) -> None:
-        super().__init__(
-            placeholder="Staff role (required) — who handles tickets…",
-            min_values=1,
-            max_values=1,
-            row=0,
-        )
-
-    async def callback(self, interaction: discord.Interaction) -> None:
-        view: TicketSetupSectionView = self.view  # type: ignore[assignment]
-        view.staff_role_id = self.values[0].id
-        await interaction.response.edit_message(embed=view.render(), view=view)
-
-
-class _LogChannelSelect(discord.ui.ChannelSelect):
-    """Pick the optional channel that closed-ticket transcripts post to."""
-
-    def __init__(self) -> None:
-        super().__init__(
-            placeholder="Transcript log channel (optional)…",
-            channel_types=[discord.ChannelType.text],
-            min_values=1,
-            max_values=1,
-            row=1,
-        )
-
-    async def callback(self, interaction: discord.Interaction) -> None:
-        view: TicketSetupSectionView = self.view  # type: ignore[assignment]
-        view.log_channel_id = self.values[0].id
-        await interaction.response.edit_message(embed=view.render(), view=view)
-
-
-class TicketSetupSectionView(BaseView):
-    """Direct-lane ticket config: staff role + log channel + Enable."""
-
-    def __init__(
-        self,
-        author: discord.Member | discord.User,
-        *,
-        guild: discord.Guild | None = None,
-        enabled: bool = False,
-        staff_role_id: int | None = None,
-        log_channel_id: int | None = None,
-        max_open_per_user: int | None = None,
-        timeout: int = 300,
-    ) -> None:
-        super().__init__(author, public=False, timeout=timeout)
-        self._guild = guild
-        self._enabled = enabled
-        self.staff_role_id = staff_role_id
-        self.log_channel_id = log_channel_id
-        self._max_open_per_user = max_open_per_user
-        self.add_item(_StaffRoleSelect())
-        self.add_item(_LogChannelSelect())
-
-    def render(self) -> discord.Embed:
-        return build_ticket_setup_embed(
-            enabled=self._enabled,
-            staff_role_id=self.staff_role_id,
-            log_channel_id=self.log_channel_id,
-            max_open_per_user=self._max_open_per_user,
-            guild=self._guild,
-        )
-
-    @discord.ui.button(
-        label="Enable tickets",
-        emoji="🎫",
-        style=discord.ButtonStyle.success,
-        row=2,
-    )
-    async def enable(
-        self,
-        interaction: discord.Interaction,
-        button: discord.ui.Button,  # type: ignore[type-arg]
-    ) -> None:
-        guild = interaction.guild
-        if guild is None:
-            await interaction.response.send_message(
-                "Tickets can only be configured inside a server.",
-                ephemeral=True,
-            )
-            return
-        if self.staff_role_id is None:
-            await interaction.response.send_message(
-                "Pick a **staff role** first — it's who can see and handle tickets.",
-                ephemeral=True,
-            )
-            return
-        await ticket_mutation.update_config(
-            guild.id,
-            interaction.user.id,
-            enabled=True,
-            staff_role_id=self.staff_role_id,
-            log_channel_id=self.log_channel_id,
-        )
-        self._enabled = True
-        for child in self.children:
-            child.disabled = True  # type: ignore[attr-defined]
-        embed = self.render()
-        embed.color = discord.Color.green()
-        embed.set_footer(
-            text="Tickets are live. Post a button panel with !ticketpanel.",
-        )
-        await interaction.response.edit_message(embed=embed, view=self)
-        try:
-            await setup_session.mark_in_progress(guild.id, step=SLUG)
-        except Exception:  # pragma: no cover — progress marker is best-effort
-            logger.exception("ticket section: mark_in_progress failed")
-
-
-# ---------------------------------------------------------------------------
-# Section entry points
-# ---------------------------------------------------------------------------
-
-
 async def _open_panel(
     interaction: discord.Interaction,
     hub: SetupHubView | None,
 ) -> None:
-    """Open the ticket config panel (both the hub button + wizard Customize)."""
+    """Open the shared ticket config panel (hub button + wizard Customize)."""
     del hub
     guild = interaction.guild
     if guild is None:
@@ -228,24 +46,12 @@ async def _open_panel(
             ephemeral=True,
         )
         return
-    cfg = None
+    embed, view = await open_ticket_config_panel(interaction.user, guild=guild)
+    await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
     try:
-        cfg = await ticket_service.get_config(guild.id)
-    except Exception:  # pragma: no cover — read is informational
-        logger.exception("ticket section: get_config failed")
-    view = TicketSetupSectionView(
-        interaction.user,
-        guild=guild,
-        enabled=bool(cfg and cfg.enabled),
-        staff_role_id=cfg.staff_role_id if cfg else None,
-        log_channel_id=cfg.log_channel_id if cfg else None,
-        max_open_per_user=cfg.max_open_per_user if cfg else None,
-    )
-    await interaction.response.send_message(
-        embed=view.render(),
-        view=view,
-        ephemeral=True,
-    )
+        await setup_session.mark_in_progress(guild.id, step=SLUG)
+    except Exception:  # pragma: no cover — progress marker is best-effort
+        logger.exception("ticket section: mark_in_progress failed")
 
 
 async def run(interaction: discord.Interaction, hub: SetupHubView) -> None:
@@ -264,7 +70,7 @@ REGISTRY.register(
         op_kinds=frozenset(),
         description_if_skipped=(
             "Tickets stay disabled — members can't open private support tickets "
-            "until you enable them here or run `!ticketsetup @StaffRole [#log]`."
+            "until you enable them here or run `!ticketsetup`."
         ),
         depths=frozenset({"standard", "advanced"}),
         customize=_open_panel,
@@ -272,9 +78,4 @@ REGISTRY.register(
 )
 
 
-__all__ = [
-    "SLUG",
-    "TicketSetupSectionView",
-    "build_ticket_setup_embed",
-    "run",
-]
+__all__ = ["SLUG", "run"]

--- a/disbot/views/tickets/__init__.py
+++ b/disbot/views/tickets/__init__.py
@@ -8,12 +8,18 @@ from views.tickets._shared import (
     build_welcome_embed,
     is_ticket_staff,
 )
+from views.tickets.config_panel import (
+    TicketConfigPanelView,
+    build_ticket_config_embed,
+    open_ticket_config_panel,
+)
 from views.tickets.confirm import TicketConfirmView, build_confirm_embed
 from views.tickets.control import TicketControlView, build_control_view
 from views.tickets.hub import TicketHubView, open_ticket_hub
 from views.tickets.launcher import TicketLauncherView, post_launcher
 
 __all__ = [
+    "TicketConfigPanelView",
     "TicketConfirmView",
     "TicketControlView",
     "TicketHubView",
@@ -22,8 +28,10 @@ __all__ = [
     "build_confirm_embed",
     "build_control_view",
     "build_launcher_embed",
+    "build_ticket_config_embed",
     "build_welcome_embed",
     "is_ticket_staff",
+    "open_ticket_config_panel",
     "open_ticket_hub",
     "post_launcher",
 ]

--- a/disbot/views/tickets/config_panel.py
+++ b/disbot/views/tickets/config_panel.py
@@ -1,0 +1,298 @@
+"""Ticket configuration panel — fully button/dropdown driven, no typing.
+
+The single interactive surface for standing tickets up: pick a **staff role**
+and **transcript log** from native dropdowns (so a role/channel name can never
+be mistyped), one-click **auto-create** the log channel if you don't have one,
+**Enable**, and **post the open-ticket panel** — all without a command argument.
+
+Reused by two consumers: the `!setup` wizard's Support Tickets section
+(`views/setup/sections/ticket.py`) and the `!ticketsetup` command
+(`cogs/ticket_cog.py`). It lives in the ticket domain (`views/tickets/`) rather
+than the setup wizard so both can depend on it without the ticket domain
+depending on the wizard. All writes go through the audited
+`services.ticket_mutation` seam (the direct lane — focused / reversible /
+single-domain); ticket config lives in its own table, not the `set_setting`
+pipeline, so nothing here stages a draft op.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+
+from core.runtime import guild_resources as resources
+from services import ticket_mutation, ticket_service
+from views.base import BaseView
+
+logger = logging.getLogger("bot.views.tickets.config_panel")
+
+
+def build_ticket_config_embed(
+    *,
+    enabled: bool = False,
+    staff_role_id: int | None = None,
+    log_channel_id: int | None = None,
+    max_open_per_user: int | None = None,
+    guild: discord.Guild | None = None,
+) -> discord.Embed:
+    """Render the config panel, reflecting any pending / current state."""
+    embed = discord.Embed(
+        title="🎫 Support Tickets",
+        description=(
+            "Let members open **private support tickets** — a per-member channel "
+            "only they and your staff can see. They open one with `!ticket new`, "
+            "a button panel, or by asking the AI.\n\n"
+            "**1.** Pick a **staff role** below (required).\n"
+            "**2.** Pick a **transcript log** channel, or tap **Auto-create** to "
+            "make one.\n"
+            "**3.** Tap **Enable tickets** — then **Post panel** so members get a "
+            "button.\n\n"
+            "_Ticket channels are created automatically under a “Tickets” category "
+            "when a member opens one — nothing to set up there._"
+        ),
+        color=discord.Color.blurple(),
+    )
+    role_text = "_(not set — required)_"
+    if staff_role_id:
+        role = (
+            resources.resolve_role(guild, role_id=staff_role_id)
+            if guild is not None
+            else None
+        )
+        role_text = role.mention if role is not None else f"`{staff_role_id}`"
+    log_text = "_(none — tap Auto-create or pick one)_"
+    if log_channel_id:
+        log = guild.get_channel(log_channel_id) if guild is not None else None
+        log_text = (
+            log.mention
+            if isinstance(log, discord.TextChannel)
+            else f"`{log_channel_id}`"
+        )
+    embed.add_field(
+        name="Selected" if not enabled else "Current",
+        value=(
+            f"• Status: **{'enabled' if enabled else 'not enabled yet'}**\n"
+            f"• Staff role: {role_text}\n"
+            f"• Transcript log: {log_text}\n"
+            f"• Max open per user: **{max_open_per_user or 3}**"
+        ),
+        inline=False,
+    )
+    embed.set_footer(
+        text="Tune limits / blacklist later with !ticketlimit and !ticketblacklist.",
+    )
+    return embed
+
+
+class _StaffRoleSelect(discord.ui.RoleSelect):
+    """Pick the staff role that can see + manage every ticket."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Staff role (required) — who handles tickets…",
+            min_values=1,
+            max_values=1,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: TicketConfigPanelView = self.view  # type: ignore[assignment]
+        view.staff_role_id = self.values[0].id
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class _LogChannelSelect(discord.ui.ChannelSelect):
+    """Pick the optional channel that closed-ticket transcripts post to."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Transcript log channel (optional)…",
+            channel_types=[discord.ChannelType.text],
+            min_values=1,
+            max_values=1,
+            row=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: TicketConfigPanelView = self.view  # type: ignore[assignment]
+        view.log_channel_id = self.values[0].id
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class TicketConfigPanelView(BaseView):
+    """Dropdowns + Auto-create + Enable + Post-panel — the no-typing setup UI."""
+
+    # A transient config flow, not a navigable hub panel.
+    STANDARD_NAV = False
+
+    def __init__(
+        self,
+        author: discord.Member | discord.User,
+        *,
+        guild: discord.Guild | None = None,
+        enabled: bool = False,
+        staff_role_id: int | None = None,
+        log_channel_id: int | None = None,
+        max_open_per_user: int | None = None,
+        timeout: int = 300,
+    ) -> None:
+        super().__init__(author, public=False, timeout=timeout)
+        self._guild = guild
+        self._enabled = enabled
+        self.staff_role_id = staff_role_id
+        self.log_channel_id = log_channel_id
+        self._max_open_per_user = max_open_per_user
+        self.add_item(_StaffRoleSelect())
+        self.add_item(_LogChannelSelect())
+
+    def render(self) -> discord.Embed:
+        return build_ticket_config_embed(
+            enabled=self._enabled,
+            staff_role_id=self.staff_role_id,
+            log_channel_id=self.log_channel_id,
+            max_open_per_user=self._max_open_per_user,
+            guild=self._guild,
+        )
+
+    @discord.ui.button(
+        label="Auto-create log channel",
+        emoji="🪄",
+        style=discord.ButtonStyle.secondary,
+        row=2,
+    )
+    async def autocreate_log(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,  # type: ignore[type-arg]
+    ) -> None:
+        guild = interaction.guild
+        if guild is None:
+            await interaction.response.send_message(
+                "Tickets can only be configured inside a server.",
+                ephemeral=True,
+            )
+            return
+        result = await ticket_mutation.create_log_channel(
+            guild,
+            interaction.user.id,
+            staff_role_id=self.staff_role_id,
+        )
+        if not result.success:
+            await interaction.response.send_message(result.message, ephemeral=True)
+            return
+        self.log_channel_id = result.channel_id
+        await interaction.response.edit_message(embed=self.render(), view=self)
+        await interaction.followup.send(result.message, ephemeral=True)
+
+    @discord.ui.button(
+        label="Enable tickets",
+        emoji="✅",
+        style=discord.ButtonStyle.success,
+        row=2,
+    )
+    async def enable(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,  # type: ignore[type-arg]
+    ) -> None:
+        guild = interaction.guild
+        if guild is None:
+            await interaction.response.send_message(
+                "Tickets can only be configured inside a server.",
+                ephemeral=True,
+            )
+            return
+        if self.staff_role_id is None:
+            await interaction.response.send_message(
+                "Pick a **staff role** first — it's who can see and handle tickets.",
+                ephemeral=True,
+            )
+            return
+        await ticket_mutation.update_config(
+            guild.id,
+            interaction.user.id,
+            enabled=True,
+            staff_role_id=self.staff_role_id,
+            log_channel_id=self.log_channel_id,
+        )
+        self._enabled = True
+        embed = self.render()
+        embed.color = discord.Color.green()
+        embed.set_footer(
+            text="Tickets are live. Tap Post panel so members can open one.",
+        )
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(
+        label="Post open-ticket panel here",
+        emoji="📋",
+        style=discord.ButtonStyle.secondary,
+        row=3,
+    )
+    async def post_panel(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,  # type: ignore[type-arg]
+    ) -> None:
+        if not self._enabled:
+            await interaction.response.send_message(
+                "Enable tickets first, then post the panel.",
+                ephemeral=True,
+            )
+            return
+        channel = interaction.channel
+        if not isinstance(channel, discord.TextChannel):
+            await interaction.response.send_message(
+                "Run this in a normal text channel to post the panel.",
+                ephemeral=True,
+            )
+            return
+        from views.tickets import post_launcher
+
+        try:
+            await post_launcher(channel)
+        except discord.Forbidden:
+            await interaction.response.send_message(
+                "I need permission to send messages in this channel.",
+                ephemeral=True,
+            )
+            return
+        # Reflect the result in the config panel itself (edit in place).
+        embed = self.render()
+        embed.color = discord.Color.green()
+        embed.set_footer(text=f"📮 Open-ticket panel posted in #{channel.name}.")
+        await interaction.response.edit_message(embed=embed, view=self)
+
+
+async def open_ticket_config_panel(
+    interaction_or_ctx_author: discord.Member | discord.User,
+    *,
+    guild: discord.Guild,
+) -> tuple[discord.Embed, TicketConfigPanelView]:
+    """Build the embed + view seeded from the guild's current ticket config.
+
+    Returns ``(embed, view)`` for the caller to send (ephemeral from the wizard,
+    or as a normal reply from ``!ticketsetup``). Best-effort config read.
+    """
+    cfg = None
+    try:
+        cfg = await ticket_service.get_config(guild.id)
+    except Exception:  # pragma: no cover — read is informational
+        logger.exception("ticket config panel: get_config failed (guild=%d)", guild.id)
+    view = TicketConfigPanelView(
+        interaction_or_ctx_author,
+        guild=guild,
+        enabled=bool(cfg and cfg.enabled),
+        staff_role_id=cfg.staff_role_id if cfg else None,
+        log_channel_id=cfg.log_channel_id if cfg else None,
+        max_open_per_user=cfg.max_open_per_user if cfg else None,
+    )
+    return view.render(), view
+
+
+__all__ = [
+    "TicketConfigPanelView",
+    "build_ticket_config_embed",
+    "open_ticket_config_panel",
+]

--- a/tests/unit/services/test_ticket_mutation.py
+++ b/tests/unit/services/test_ticket_mutation.py
@@ -169,3 +169,88 @@ async def test_claim_rejects_closed_ticket():
         {"id": 1, "guild_id": 1, "status": "closed", "claimed_by": None}, _member(uid=7)
     )
     assert not out.success
+
+
+# --------------------------------------------------------------------------- #
+# create_log_channel — the auto-create-log-channel setup button's service seam
+# --------------------------------------------------------------------------- #
+
+
+def _autocreate_guild(channel):
+    g = MagicMock()
+    g.id = 1
+    g.default_role = MagicMock(name="everyone")
+    g.me = MagicMock(name="me")
+    g.get_channel.return_value = channel
+    return g
+
+
+def _lifecycle(outcome, *, target_id=4242):
+    return lc.LifecycleResult(
+        mutation_id="m",
+        guild_id=1,
+        domain="channel",
+        operation="create",
+        outcome=outcome,
+        reversibility=lc.COMPENSATABLE,
+        steps=(
+            lc.StepResult(target_id=target_id, target_name="ticket-transcripts", ok=True),
+        )
+        if outcome == lc.SUCCESS
+        else (),
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_log_channel_creates_via_seam_locks_down_sets_config(monkeypatch):
+    import discord
+
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.id = 4242
+    channel.mention = "#ticket-transcripts"
+    channel.edit = AsyncMock()
+    guild = _autocreate_guild(channel)
+
+    create = AsyncMock(return_value=_lifecycle(lc.SUCCESS))
+    monkeypatch.setattr(
+        tm,
+        "ChannelLifecycleService",
+        MagicMock(return_value=MagicMock(create_channels=create)),
+    )
+    monkeypatch.setattr(
+        tm.guild_resources, "resolve_role", lambda *a, **k: MagicMock(name="staff")
+    )
+    update_mock = AsyncMock()
+    monkeypatch.setattr(tm, "update_config", update_mock)
+
+    result = await tm.create_log_channel(guild, 7, staff_role_id=99)
+
+    assert result.success is True
+    assert result.channel_id == 4242
+    # Created through the audited lifecycle seam, not a raw guild.create_*.
+    create.assert_awaited_once()
+    # Locked down staff-only: @everyone denied view.
+    channel.edit.assert_awaited_once()
+    overwrites = channel.edit.await_args.kwargs["overwrites"]
+    assert guild.default_role in overwrites
+    # Config updated through the audited update_config seam.
+    update_mock.assert_awaited_once_with(1, 7, log_channel_id=4242)
+
+
+@pytest.mark.asyncio
+async def test_create_log_channel_handles_creation_blocked(monkeypatch):
+    guild = _autocreate_guild(None)
+    create = AsyncMock(return_value=_lifecycle(lc.BLOCKED))
+    monkeypatch.setattr(
+        tm,
+        "ChannelLifecycleService",
+        MagicMock(return_value=MagicMock(create_channels=create)),
+    )
+    update_mock = AsyncMock()
+    monkeypatch.setattr(tm, "update_config", update_mock)
+
+    result = await tm.create_log_channel(guild, 7, staff_role_id=None)
+
+    assert result.success is False
+    assert "Manage Channels" in result.message
+    update_mock.assert_not_awaited()

--- a/tests/unit/views/setup/sections/test_ticket_section.py
+++ b/tests/unit/views/setup/sections/test_ticket_section.py
@@ -1,14 +1,10 @@
-"""Tests for the support-tickets setup section.
+"""Tests for the support-tickets setup section (thin wizard adapter).
 
-Pins:
-
-* Registration: slug, order, emoji, style, depth, and that ``customize``
-  is wired so the guided-wizard Customize button is enabled.
-* The embed names tickets and renders the staff role / log selection.
-* ``_open_panel`` rejects DM context and opens the config panel in a guild.
-* The Enable button writes through the audited ``ticket_mutation.update_config``
-  (direct lane) with ``enabled=True`` + the selected role/log — and refuses
-  (no write) until a staff role is chosen.
+The interactive UI moved to ``views.tickets.config_panel`` (shared with
+``!ticketsetup``); this section just registers the wizard button and opens that
+panel. Pins: registration metadata, ``customize`` wired (so the guided-wizard
+Customize button is enabled), DM rejection, and that opening it sends the shared
+``TicketConfigPanelView`` + marks setup progress.
 """
 
 from __future__ import annotations
@@ -21,28 +17,7 @@ import pytest
 
 from services.setup_sections import REGISTRY
 from views.setup.sections import ticket
-
-
-def _interaction(guild_id: int = 1):
-    interaction = MagicMock()
-    interaction.user = SimpleNamespace(id=99)
-    interaction.guild_id = guild_id
-    interaction.guild = SimpleNamespace(
-        id=guild_id, name="Test", get_channel=lambda _id: None
-    )
-    interaction.response = MagicMock()
-    interaction.response.send_message = AsyncMock()
-    interaction.response.edit_message = AsyncMock()
-    return interaction
-
-
-def _enable_button(view: ticket.TicketSetupSectionView) -> discord.ui.Button:
-    return next(c for c in view.children if isinstance(c, discord.ui.Button))
-
-
-# ---------------------------------------------------------------------------
-# Registration
-# ---------------------------------------------------------------------------
+from views.tickets import TicketConfigPanelView
 
 
 def test_ticket_section_registered_with_expected_metadata():
@@ -62,45 +37,6 @@ def test_ticket_section_registered_with_expected_metadata():
     assert 1 <= len(section.label) <= 80
 
 
-# ---------------------------------------------------------------------------
-# Embed
-# ---------------------------------------------------------------------------
-
-
-def test_embed_names_tickets_and_shows_required_role():
-    embed = ticket.build_ticket_setup_embed()
-    blob = ((embed.title or "") + (embed.description or "")).lower()
-    assert "ticket" in blob
-    selected = next(
-        (f for f in embed.fields if f.name in ("Selected", "Current")), None
-    )
-    assert selected is not None
-    # No staff role yet → flagged required.
-    assert "required" in selected.value.lower()
-
-
-def test_embed_renders_selected_role_and_log():
-    guild = MagicMock()
-    guild.get_role.return_value = SimpleNamespace(mention="@Staff")
-    log = MagicMock(spec=discord.TextChannel)
-    log.mention = "#tickets-log"
-    guild.get_channel.return_value = log
-    with patch.object(
-        ticket.resources, "resolve_role", return_value=SimpleNamespace(mention="@Staff")
-    ):
-        embed = ticket.build_ticket_setup_embed(
-            staff_role_id=10, log_channel_id=20, guild=guild
-        )
-    field = next(f for f in embed.fields if f.name in ("Selected", "Current"))
-    assert "@Staff" in field.value
-    assert "#tickets-log" in field.value
-
-
-# ---------------------------------------------------------------------------
-# _open_panel
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_open_panel_rejects_dm_context():
     interaction = MagicMock()
@@ -114,63 +50,23 @@ async def test_open_panel_rejects_dm_context():
 
 
 @pytest.mark.asyncio
-async def test_open_panel_opens_config_view_in_guild():
-    interaction = _interaction()
+async def test_open_panel_sends_config_panel_and_marks_progress():
+    interaction = MagicMock()
+    interaction.user = SimpleNamespace(id=99)
+    interaction.guild = SimpleNamespace(id=1, get_channel=lambda _id: None)
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
     with patch(
-        "views.setup.sections.ticket.ticket_service.get_config",
+        "views.tickets.config_panel.ticket_service.get_config",
         new_callable=AsyncMock,
         return_value=None,
-    ):
+    ), patch(
+        "views.setup.sections.ticket.setup_session.mark_in_progress",
+        new_callable=AsyncMock,
+    ) as mark_mock:
         await ticket.run(interaction, MagicMock())
     interaction.response.send_message.assert_awaited_once()
     kwargs = interaction.response.send_message.await_args.kwargs
     assert kwargs.get("ephemeral") is True
-    assert isinstance(kwargs["view"], ticket.TicketSetupSectionView)
-    assert "Tickets" in (kwargs["embed"].title or "")
-
-
-# ---------------------------------------------------------------------------
-# Enable button — the audited direct-lane write
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_enable_refuses_without_staff_role():
-    view = ticket.TicketSetupSectionView(SimpleNamespace(id=99))
-    interaction = _interaction()
-    with patch(
-        "views.setup.sections.ticket.ticket_mutation.update_config",
-        new_callable=AsyncMock,
-    ) as update_mock:
-        await _enable_button(view).callback(interaction)
-    update_mock.assert_not_awaited()
-    interaction.response.send_message.assert_awaited_once()
-    assert "staff role" in interaction.response.send_message.await_args.args[0].lower()
-
-
-@pytest.mark.asyncio
-async def test_enable_writes_through_audited_update_config():
-    view = ticket.TicketSetupSectionView(
-        SimpleNamespace(id=99), staff_role_id=555, log_channel_id=777
-    )
-    interaction = _interaction()
-    with (
-        patch(
-            "views.setup.sections.ticket.ticket_mutation.update_config",
-            new_callable=AsyncMock,
-        ) as update_mock,
-        patch(
-            "views.setup.sections.ticket.setup_session.mark_in_progress",
-            new_callable=AsyncMock,
-        ) as mark_mock,
-    ):
-        await _enable_button(view).callback(interaction)
-    update_mock.assert_awaited_once()
-    kwargs = update_mock.await_args.kwargs
-    assert kwargs["enabled"] is True
-    assert kwargs["staff_role_id"] == 555
-    assert kwargs["log_channel_id"] == 777
-    # actor + guild are positional
-    assert update_mock.await_args.args == (1, 99)
-    interaction.response.edit_message.assert_awaited_once()
+    assert isinstance(kwargs["view"], TicketConfigPanelView)
     mark_mock.assert_awaited_once()

--- a/tests/unit/views/tickets/test_config_panel.py
+++ b/tests/unit/views/tickets/test_config_panel.py
@@ -1,0 +1,153 @@
+"""Tests for the ticket config panel — the no-typing setup UI.
+
+Pins: role + channel pickers are native dropdowns (no free text); Enable writes
+through the audited ``ticket_mutation.update_config`` and refuses without a staff
+role; Auto-create delegates to ``ticket_mutation.create_log_channel`` and adopts
+the returned channel (or surfaces failure); Post panel requires tickets enabled;
+``open_ticket_config_panel`` seeds the view from current config.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from views.tickets import TicketConfigPanelView
+from views.tickets import config_panel as cp
+
+
+def _interaction(guild_id: int = 1):
+    i = MagicMock()
+    i.user = SimpleNamespace(id=99)
+    i.guild = SimpleNamespace(id=guild_id, get_channel=lambda _id: None)
+    i.response = MagicMock()
+    i.response.send_message = AsyncMock()
+    i.response.edit_message = AsyncMock()
+    i.followup = MagicMock()
+    i.followup.send = AsyncMock()
+    return i
+
+
+def _button(view: TicketConfigPanelView, label_sub: str) -> discord.ui.Button:
+    return next(
+        c
+        for c in view.children
+        if isinstance(c, discord.ui.Button) and label_sub in (c.label or "")
+    )
+
+
+def test_embed_names_tickets_and_flags_required_role():
+    embed = cp.build_ticket_config_embed()
+    blob = ((embed.title or "") + (embed.description or "")).lower()
+    assert "ticket" in blob
+    field = next(f for f in embed.fields if f.name in ("Selected", "Current"))
+    assert "required" in field.value.lower()
+
+
+def test_panel_uses_native_dropdowns_not_free_text():
+    view = TicketConfigPanelView(SimpleNamespace(id=99))
+    type_names = {type(c).__name__ for c in view.children}
+    assert any("RoleSelect" in t for t in type_names)
+    assert any("ChannelSelect" in t for t in type_names)
+
+
+@pytest.mark.asyncio
+async def test_enable_refuses_without_staff_role():
+    view = TicketConfigPanelView(SimpleNamespace(id=99))
+    i = _interaction()
+    with patch.object(
+        cp.ticket_mutation, "update_config", new_callable=AsyncMock
+    ) as up:
+        await _button(view, "Enable").callback(i)
+    up.assert_not_awaited()
+    i.response.send_message.assert_awaited_once()
+    assert "staff role" in i.response.send_message.await_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_enable_writes_through_audited_update_config():
+    view = TicketConfigPanelView(
+        SimpleNamespace(id=99), staff_role_id=555, log_channel_id=777
+    )
+    i = _interaction()
+    with patch.object(
+        cp.ticket_mutation, "update_config", new_callable=AsyncMock
+    ) as up:
+        await _button(view, "Enable").callback(i)
+    up.assert_awaited_once()
+    assert up.await_args.kwargs["enabled"] is True
+    assert up.await_args.kwargs["staff_role_id"] == 555
+    assert up.await_args.kwargs["log_channel_id"] == 777
+    assert up.await_args.args == (1, 99)
+    i.response.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_autocreate_log_delegates_and_adopts_channel():
+    view = TicketConfigPanelView(SimpleNamespace(id=99), staff_role_id=555)
+    i = _interaction()
+    result = cp.ticket_mutation.TicketChannelResult(
+        True, "made it", channel_id=4242
+    )
+    with patch.object(
+        cp.ticket_mutation,
+        "create_log_channel",
+        new_callable=AsyncMock,
+        return_value=result,
+    ) as cr:
+        await _button(view, "Auto-create").callback(i)
+    cr.assert_awaited_once()
+    assert cr.await_args.kwargs["staff_role_id"] == 555
+    assert view.log_channel_id == 4242
+    i.response.edit_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_autocreate_log_surfaces_failure_without_adopting():
+    view = TicketConfigPanelView(SimpleNamespace(id=99))
+    i = _interaction()
+    result = cp.ticket_mutation.TicketChannelResult(False, "need Manage Channels")
+    with patch.object(
+        cp.ticket_mutation,
+        "create_log_channel",
+        new_callable=AsyncMock,
+        return_value=result,
+    ):
+        await _button(view, "Auto-create").callback(i)
+    i.response.send_message.assert_awaited_once()
+    assert "manage channels" in i.response.send_message.await_args.args[0].lower()
+    assert view.log_channel_id is None
+
+
+@pytest.mark.asyncio
+async def test_post_panel_requires_enabled():
+    view = TicketConfigPanelView(SimpleNamespace(id=99))  # enabled defaults False
+    i = _interaction()
+    await _button(view, "Post").callback(i)
+    i.response.send_message.assert_awaited_once()
+    assert "enable" in i.response.send_message.await_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_open_ticket_config_panel_seeds_from_config():
+    cfg = SimpleNamespace(
+        enabled=True, staff_role_id=9, log_channel_id=5, max_open_per_user=4
+    )
+    guild = SimpleNamespace(
+        id=1,
+        get_channel=lambda _id: None,
+        get_role=lambda _id: SimpleNamespace(mention="@Staff"),
+    )
+    with patch.object(
+        cp.ticket_service, "get_config", new_callable=AsyncMock, return_value=cfg
+    ):
+        embed, view = await cp.open_ticket_config_panel(
+            SimpleNamespace(id=99), guild=guild
+        )
+    assert isinstance(view, TicketConfigPanelView)
+    assert view.staff_role_id == 9
+    assert view.log_channel_id == 5
+    assert "🎫" in (embed.title or "")


### PR DESCRIPTION
## Ticket setup: all buttons & dropdowns, plus auto-create

You asked that ticket setup work with buttons and drop-down menus — a list of roles and a list of channels to pick from, so a name can never be mistyped — and an option to **automatically create the ticket channel**. This delivers that, end to end.

### What you get
- **Pick from dropdowns, never type a name.** Native **RoleSelect** (staff role) + **ChannelSelect** (transcript log) — Discord renders the real lists; no free-text, no typos.
- **🪄 Auto-create log channel** — one click makes a private, staff-only `#ticket-transcripts` channel and wires it up, so you don't need to pre-make or pick one.
- **✅ Enable** + **📋 Post panel** buttons — enable tickets and drop the public open-ticket button for members, all without a command.
- **Reachable two ways:** the **Support Tickets** step in `!setup`, **and** running **`!ticketsetup`** with no arguments now opens the same panel. (The `!ticketsetup @Role #chan` form still works for power users.)
- Ticket channels themselves already auto-create under a "Tickets" category when a member opens one — the panel says so, so there's nothing to configure there.

### Under the hood
- New `views/tickets/config_panel.py` (`TicketConfigPanelView`) — the shared UI, in the ticket domain so the wizard and the command both use it.
- `ticket_mutation.create_log_channel` creates the channel through the audited **`ChannelLifecycleService`** seam (not a raw `guild.create_*` — satisfies the no-silent-auto-create invariant), then locks it staff-only.
- The setup-wizard section is now a thin adapter that opens the shared panel.

Full CI mirror green (12402 passed); arch 0 errors; consistency + no-silent-auto-create invariants green.

> Continuation of your request — the panel-move and "`!ticketsetup` opens the panel" were my calls within it; flagged self-initiated and trivially revertible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XyHuPzBEE9NkMbEQRcJ6a

---
_Generated by [Claude Code](https://claude.ai/code/session_014XyHuPzBEE9NkMbEQRcJ6a)_