### PR TITLE
runtime: diff-gated startup command-tree auto-sync (+ post-unification docs cleanup)

### DIFF
--- a/.sessions/2026-06-24-command-tree-auto-sync.md
+++ b/.sessions/2026-06-24-command-tree-auto-sync.md
@@ -1,0 +1,47 @@
+# 2026-06-24 — Startup command-tree auto-sync + post-unification docs cleanup
+
+> **Status:** `in-progress`
+
+## Goal (owner-directed, follow-up to #1419)
+
+After the BTD6 unification (#1419) the maintainer said: *"you can finish up with
+the auto sync, then end the session by cleaning up stale docs."* Two pieces:
+
+1. **Startup command-tree auto-sync** — retire the manual `!syncslash` toil. The
+   recurring pain (duplicate commands #1409, the big unification re-sync #1419)
+   all trace to "remember to sync after a command change." Build a *safe* auto
+   sync so a command change goes live on deploy with no manual step.
+2. **Docs cleanup** — sweep the reference docs that still describe the old
+   five-group BTD6 layout (flagged in the #1419 session log).
+
+## Design — diff-gated, no storage, no false positives
+
+`services/command_tree_sync.py`: on startup, fetch the live global commands from
+Discord (`tree.fetch_commands()` — already used in `views/setup/sections/ai_setup`)
+and compare the **set of qualified command paths** to the local tree. Call
+`tree.sync()` **only** when they differ. Conservative on purpose — it compares
+*paths* (add/remove/rename of commands + subcommands), not param/description
+details, because Discord normalises option payloads and a fuller diff would
+false-positive and re-sync every boot (the rate-limit risk). Param/description-
+only changes still use manual `!syncslash`.
+
+- Wired into the `on_ready` one-shot path (`bot1.py`, mirrors
+  `_maybe_report_startup_health`) so it fires once per process, reconnect-safe.
+- Kill-switch: `AUTO_SYNC_COMMANDS=0` (env; default on). Failures are non-fatal.
+- Merging = deploying (Railway), so the next deploy auto-syncs the unified
+  `/btd6` tree — the maintainer's `!syncslash global` step becomes optional.
+
+## Status checklist
+- [ ] `services/command_tree_sync.py` — path-diff + gated sync (+ kill-switch parse)
+- [ ] `config.AUTO_SYNC_COMMANDS` env flag
+- [ ] Wire one-shot into `bot1.py` `on_ready`
+- [ ] Tests: path extraction (local + remote), disabled / unchanged / changed /
+      fetch-fail / sync-fail
+- [ ] Docs cleanup: command-map + platform-mapping + agent index + subsystems/btd6
+- [ ] `check_quality --full` green + arch strict
+- [ ] Flip card → auto-merge
+
+## Notes
+- Reliability header (Q-0105): the auto-sync is **unverified** — confirm it fires
+  correctly across a few real deploys before fully trusting; kill-switch + the
+  manual `!syncslash` remain. Delete the seam if it proves flaky.

--- a/.sessions/2026-06-24-command-tree-auto-sync.md
+++ b/.sessions/2026-06-24-command-tree-auto-sync.md
@@ -1,47 +1,85 @@
 # 2026-06-24 — Startup command-tree auto-sync + post-unification docs cleanup
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Goal (owner-directed, follow-up to #1419)
 
 After the BTD6 unification (#1419) the maintainer said: *"you can finish up with
-the auto sync, then end the session by cleaning up stale docs."* Two pieces:
+the auto sync, then end the session by cleaning up stale docs."*
 
-1. **Startup command-tree auto-sync** — retire the manual `!syncslash` toil. The
-   recurring pain (duplicate commands #1409, the big unification re-sync #1419)
-   all trace to "remember to sync after a command change." Build a *safe* auto
-   sync so a command change goes live on deploy with no manual step.
-2. **Docs cleanup** — sweep the reference docs that still describe the old
-   five-group BTD6 layout (flagged in the #1419 session log).
+## What shipped (PR #1424)
 
-## Design — diff-gated, no storage, no false positives
+**1. Diff-gated startup command auto-sync** — `services/command_tree_sync.py`:
+on boot, fetch the live global commands from Discord (`tree.fetch_commands()`)
+and compare the **set of qualified command paths** to the local tree; call
+`tree.sync()` **only** when they differ. Conservative by design — compares
+command *paths* (add/remove/rename of commands + subcommands), not
+param/description details, because Discord normalises option payloads and a
+fuller diff would false-positive and re-sync every boot (the rate-limit risk).
 
-`services/command_tree_sync.py`: on startup, fetch the live global commands from
-Discord (`tree.fetch_commands()` — already used in `views/setup/sections/ai_setup`)
-and compare the **set of qualified command paths** to the local tree. Call
-`tree.sync()` **only** when they differ. Conservative on purpose — it compares
-*paths* (add/remove/rename of commands + subcommands), not param/description
-details, because Discord normalises option payloads and a fuller diff would
-false-positive and re-sync every boot (the rate-limit risk). Param/description-
-only changes still use manual `!syncslash`.
+- Wired into `bot1.on_ready` as a reconnect-safe one-shot (mirrors
+  `_maybe_report_startup_health`), spawned via the task supervisor.
+- Kill-switch `AUTO_SYNC_COMMANDS=0` (config; default on). Every failure path is
+  non-fatal — it can't crash startup.
+- Result: a command change goes live on the next deploy with no manual
+  `!syncslash`. Manual `!syncslash` stays for instant guild refresh.
+- 23 service tests (path extraction vs the real unified tree + the fetched
+  model; disabled / unchanged / changed / fetch-fail / sync-fail).
 
-- Wired into the `on_ready` one-shot path (`bot1.py`, mirrors
-  `_maybe_report_startup_health`) so it fires once per process, reconnect-safe.
-- Kill-switch: `AUTO_SYNC_COMMANDS=0` (env; default on). Failures are non-fatal.
-- Merging = deploying (Railway), so the next deploy auto-syncs the unified
-  `/btd6` tree — the maintainer's `!syncslash global` step becomes optional.
+**2. Docs cleanup** — swept the reference docs still describing the old
+five-group BTD6 layout: `docs/subsystems/btd6.md` (the binding area doc) and
+`docs/setup-platform/settings-customization-command-map.md` (the five BTD6
+sub-sections → unified `/btd6 …` + hidden-alias notes). Regenerated
+`docs/operations/env-vars.md` (the new flag) + dashboard artifacts.
 
 ## Status checklist
-- [ ] `services/command_tree_sync.py` — path-diff + gated sync (+ kill-switch parse)
-- [ ] `config.AUTO_SYNC_COMMANDS` env flag
-- [ ] Wire one-shot into `bot1.py` `on_ready`
-- [ ] Tests: path extraction (local + remote), disabled / unchanged / changed /
-      fetch-fail / sync-fail
-- [ ] Docs cleanup: command-map + platform-mapping + agent index + subsystems/btd6
-- [ ] `check_quality --full` green + arch strict
-- [ ] Flip card → auto-merge
+- [x] `services/command_tree_sync.py` — path-diff + gated sync + kill-switch
+- [x] `config.AUTO_SYNC_COMMANDS` env flag
+- [x] Wire one-shot into `bot1.on_ready`
+- [x] Tests (23) — all outcome branches + real-tree path extraction
+- [x] Docs cleanup (subsystems/btd6 + command-map; env-vars + artifacts regen)
+- [x] `check_quality --full` green (12428 passed) + arch strict (0 errors)
+- [x] Flip card → auto-merge
 
-## Notes
-- Reliability header (Q-0105): the auto-sync is **unverified** — confirm it fires
-  correctly across a few real deploys before fully trusting; kill-switch + the
-  manual `!syncslash` remain. Delete the seam if it proves flaky.
+## Scope notes (deliberately deferred, flagged not orphaned)
+- `docs/agent/index.yml` source_roots stay valid as-is (the `cogs/btd6/` package
+  entry already covers `_unified.py`); not re-pack'd to avoid churn for no gain.
+- `docs/planning/platform-mapping-a-user-surface.md` left untouched — under
+  another active claim (`claude-jolly-johnson`, docs reconciliation band).
+- `docs/operations/production-deployment.md` still frames `!syncslash` as the
+  post-deploy step; once this PR is live, auto-sync handles propagation — a small
+  runbook update is the natural next touch (noted, not done here to bound scope).
+
+## 💡 Session idea (Q-0089)
+**Make the manual `!syncslash` reuse `command_tree_sync.auto_sync_if_changed`.**
+Right now `admin_cog.sync_slash_commands` does an *unconditional* `tree.sync()`,
+while the new startup path is diff-gated. Routing the manual command through the
+same gated helper (with an explicit `--force` escape for "sync anyway") would
+give one implementation, one place to reason about rate limits, and a
+`!syncslash` that can *report the live-vs-local diff* before acting. Small,
+contained, and it retires the last unconditional sync. Worth an idea file if it
+survives next session's sniff test.
+
+## ⟲ Previous-session review (Q-0102)
+Previous in-chain: the #1419 unification. **Did well:** comprehensive and green
+in one pass, and it caught + fixed a real latent bug (the dashboard scanner was
+blind to module-level command trees) rather than just working around it.
+**Missed / could improve:** the PR *body* was written before the implementation
+shape settled (it said `cogs/btd6/_commands/` — a dir — but the build landed as
+`_unified.py`, a file), so the body needed a post-open correction. **System
+improvement:** when opening the born-red PR *first* (the right call for the
+in-flight signal), keep the body's "How" section deliberately high-level until
+the approach is locked, then fill specifics at flip-to-complete — avoids a
+published-then-corrected description. Minor, but it's a clean rule.
+
+## 📝 Doc audit (Q-0104)
+- `check_quality --full` green; `check_architecture --mode strict` 0 errors.
+- New env var `AUTO_SYNC_COMMANDS` is in its durable home (`config.py` +
+  generated `docs/operations/env-vars.md`); the kill-switch + reliability header
+  are in the service docstring.
+- Owner decision: this PR executes an in-chat owner directive ("finish up with
+  the auto sync, then clean stale docs") — no new router Q needed.
+- Ledger: PR #1424 in-flight; #1419 just merged — both recorded by the next
+  reconciliation pass (the `claude-jolly-johnson` claim owns current-state, so
+  this session does not edit it). `check_current_state_ledger --strict` shows
+  only benign newest-merge lag, not drift.

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-24T11:21:08Z",
+    "generated_at": "2026-06-24T13:29:40Z",
     "build": {
-      "commit": "e337817",
-      "subject": "tickets: fully button/dropdown setup + auto-create log channel",
-      "committed_at": "2026-06-24T11:21:08Z"
+      "commit": "30331fd",
+      "subject": "Merge branch 'main' into claude/great-meitner-pnfp0g",
+      "committed_at": "2026-06-24T13:29:40Z"
     }
   },
   "counts": {

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -6632,7 +6632,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "e337817",
+    "build": "30331fd",
     "title": "New public bot website",
     "changes": [
       {
@@ -6644,7 +6644,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "e337817",
+    "build": "30331fd",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -6656,7 +6656,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "e337817",
+    "build": "30331fd",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-24T11:05:38Z",
+    "generated_at": "2026-06-24T13:29:40Z",
     "build": {
-      "commit": "beb1dd4",
-      "subject": "btd6: unify five command groups under one /btd6 (Flattest layout)",
-      "committed_at": "2026-06-24T11:05:38Z"
+      "commit": "30331fd",
+      "subject": "Merge branch 'main' into claude/great-meitner-pnfp0g",
+      "committed_at": "2026-06-24T13:29:40Z"
     },
     "counts": {
       "functions": 42,
@@ -13,7 +13,7 @@
       "reviews": 0,
       "reviews_open": 0,
       "updates": 60,
-      "env_vars": 38,
+      "env_vars": 39,
       "cogs": 52,
       "commands": 436,
       "setting_keys": 107,
@@ -2489,6 +2489,14 @@
       "self_initiated": false
     },
     {
+      "file": "2026-06-24-ticket-setup-buttons.md",
+      "date": "2026-06-24",
+      "title": "2026-06-24 — Ticket setup: all buttons & dropdowns + auto-create",
+      "status": "complete",
+      "run_type": "manual",
+      "self_initiated": true
+    },
+    {
       "file": "2026-06-24-ticket-ai-confirm.md",
       "date": "2026-06-24",
       "title": "2026-06-24 — Ticket AI open: one-click confirm (follow-up to #1405)",
@@ -2508,6 +2516,14 @@
       "file": "2026-06-24-setup-wizard-restructure-plan.md",
       "date": "2026-06-24",
       "title": "Session — 2026-06-24 · setup-wizard restructure plan",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
+      "file": "2026-06-24-setup-jargon-sweep-guild.md",
+      "date": "2026-06-24",
+      "title": "Session — 2026-06-24 · setup plain-language sweep 1 (guild→server)",
       "status": "complete",
       "run_type": "",
       "self_initiated": false
@@ -2567,6 +2583,14 @@
       "status": "complete",
       "run_type": "routine",
       "self_initiated": true
+    },
+    {
+      "file": "2026-06-24-command-tree-auto-sync.md",
+      "date": "2026-06-24",
+      "title": "2026-06-24 — Startup command-tree auto-sync + post-unification docs cleanup",
+      "status": "complete",
+      "run_type": "",
+      "self_initiated": false
     },
     {
       "file": "2026-06-24-card-theme-conformance-guard.md",
@@ -2927,30 +2951,6 @@
       "status": "complete",
       "run_type": "manual",
       "self_initiated": true
-    },
-    {
-      "file": "2026-06-23-cleanup-panel-access-hint.md",
-      "date": "2026-06-23",
-      "title": "2026-06-23 — Cleanup panel: hint pointing at Command Access delete toggle",
-      "status": "complete",
-      "run_type": "manual",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-06-23-cleanup-custom-selects.md",
-      "date": "2026-06-23",
-      "title": "2026-06-23 — Button/select-driven Custom cleanup level (no typing)",
-      "status": "complete",
-      "run_type": "manual",
-      "self_initiated": true
-    },
-    {
-      "file": "2026-06-23-check-quality-isort-parity.md",
-      "date": "2026-06-23",
-      "title": "2026-06-23 — Fix: check_quality isort scope drifted from CI (false-red on tests/)",
-      "status": "complete",
-      "run_type": "routine",
-      "self_initiated": true
     }
   ],
   "bot_changelog": [
@@ -3118,6 +3118,22 @@
           "file": "disbot/services/automation_scheduler.py",
           "line": 397,
           "layer": "services",
+          "has_default": true
+        }
+      ]
+    },
+    {
+      "name": "AUTO_SYNC_COMMANDS",
+      "required": false,
+      "usage_count": 1,
+      "layers": [
+        "config"
+      ],
+      "usages": [
+        {
+          "file": "disbot/config.py",
+          "line": 215,
+          "layer": "config",
           "has_default": true
         }
       ]
@@ -8693,10 +8709,10 @@
           "is_group": false,
           "parent": null,
           "aliases": [],
-          "brief": "Configure tickets: ``!ticketsetup @StaffRole [#log-channel]`` (managers).",
+          "brief": "Configure tickets — opens a button/dropdown panel (managers).",
           "classification": "",
-          "has_panel": false,
-          "button_backed": false
+          "has_panel": true,
+          "button_backed": true
         },
         {
           "name": "add",

--- a/disbot/bot1.py
+++ b/disbot/bot1.py
@@ -188,6 +188,11 @@ signal.signal(signal.SIGTERM, _begin_shutdown)
 # and must not re-report. Mirrors lifecycle._startup_duration_observed.
 _startup_health_reported = False
 
+# One-shot guard so the diff-gated command-tree auto-sync
+# (services.command_tree_sync) runs exactly once per process — a gateway
+# reconnect re-fires on_ready and must not re-sync.
+_commands_auto_synced = False
+
 
 async def _report_startup_health() -> None:
     """Collect + cache the settled-startup health snapshot (best-effort).
@@ -277,6 +282,28 @@ def _maybe_report_startup_health() -> None:
     _runtime_tasks.spawn("startup:health_report", _report_startup_health())
 
 
+def _maybe_auto_sync_commands() -> None:
+    """Spawn the diff-gated command-tree auto-sync once per process.
+
+    Reconnect-safe (a gateway reconnect re-fires ``on_ready``). Runs off the
+    on_ready path via the task supervisor and is fully non-fatal — see
+    ``services.command_tree_sync``. Kill-switch: ``AUTO_SYNC_COMMANDS=0``.
+    """
+    global _commands_auto_synced
+    if _commands_auto_synced:
+        return
+    _commands_auto_synced = True
+    from services import command_tree_sync
+
+    _runtime_tasks.spawn(
+        "startup:command_sync",
+        command_tree_sync.auto_sync_if_changed(
+            bot,
+            enabled=command_tree_sync.env_enabled(config.AUTO_SYNC_COMMANDS),
+        ),
+    )
+
+
 @bot.event
 async def on_ready() -> None:
     bot.uptime = datetime.datetime.now(tz=datetime.timezone.utc)  # type: ignore[attr-defined]
@@ -302,6 +329,9 @@ async def on_ready() -> None:
         _lifecycle.set_phase(_lifecycle.Phase.RUNNING, reason="on_ready")
     # Bot-awareness PR3: post-ready startup-health snapshot, exactly once.
     _maybe_report_startup_health()
+    # Diff-gated command-tree auto-sync — push a changed slash tree to Discord on
+    # deploy (no manual !syncslash), exactly once per process. Non-fatal.
+    _maybe_auto_sync_commands()
 
 
 @bot.event

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -205,3 +205,11 @@ BTD6_DATA_CACHE_DIR = os.getenv("BTD6_DATA_CACHE_DIR", "")
 # no-op for the file backend (reads bundled files directly) and the cloud backend
 # (seeded via its own upload script).
 BTD6_AUTO_SEED = os.getenv("BTD6_AUTO_SEED", "1")
+
+# Startup auto-sync of the application-command tree: on boot, diff the bot's
+# local slash tree against Discord's registered commands and ``tree.sync()`` only
+# when they differ, so a command change (e.g. the BTD6 unification) goes live on
+# deploy with no manual ``!syncslash``. Default on; set to "0"/"false"/"no"/"off"
+# to disable (kill-switch). Failures are non-fatal. See
+# ``services/command_tree_sync.py``.
+AUTO_SYNC_COMMANDS = os.getenv("AUTO_SYNC_COMMANDS", "1")

--- a/disbot/services/command_tree_sync.py
+++ b/disbot/services/command_tree_sync.py
@@ -1,0 +1,138 @@
+"""Diff-gated startup auto-sync of the application-command tree.
+
+After a command change (e.g. the BTD6 unification, #1419) Discord's registered
+slash commands lag the bot's local tree until someone runs ``!syncslash``. This
+service closes that gap automatically **and safely**: on startup it fetches the
+live global commands from Discord and compares their *structure* — the set of
+qualified command paths — to the local tree, and calls ``tree.sync()`` **only**
+when they differ. An unchanged tree never burns a (rate-limited) global sync.
+
+Conservative on purpose: it compares command **paths** (add / remove / rename of
+commands and subcommands), not parameter or description details, because Discord
+normalises option payloads and a fuller comparison would false-positive and
+re-sync on every boot. Parameter/description-only changes still use manual
+``!syncslash``. This bias — *miss a cosmetic change rather than re-sync every
+boot* — is deliberate: an auto sync that fires spuriously would be worse than
+none (it would chew the global-sync rate limit).
+
+Wiring: called once per process from ``bot1.on_ready`` (reconnect-safe one-shot).
+Kill-switch: ``AUTO_SYNC_COMMANDS=0`` (env; default on). Every failure path is
+non-fatal — a fetch or sync error is logged and reported, never raised, so it
+cannot crash startup.
+
+Reliability (Q-0105): **unverified** — added 2026-06-24; confirm it fires
+correctly across a few real deploys before fully trusting it (the kill-switch +
+manual ``!syncslash`` remain the backstop). Delete this seam if it proves flaky.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+import discord
+from discord import app_commands
+
+logger = logging.getLogger("bot.command_sync")
+
+# Option types that denote a *nested command* (vs. a parameter) on a fetched
+# AppCommand — used to walk the remote tree to the same leaf paths as the local.
+_SUBCOMMAND_TYPES = {
+    discord.AppCommandOptionType.subcommand,
+    discord.AppCommandOptionType.subcommand_group,
+}
+
+
+def env_enabled(raw: str | None) -> bool:
+    """Parse the ``AUTO_SYNC_COMMANDS`` flag — default-on; only explicit falsy
+    strings disable (mirrors the ``BTD6_AUTO_SEED`` convention: unset/empty = on).
+    """
+    return (raw or "").strip().lower() not in ("0", "false", "no", "off")
+
+
+def _local_paths(commands: Iterable[object], prefix: str = "") -> set[str]:
+    """Qualified command paths for the LOCAL tree (``Command`` / ``Group``)."""
+    out: set[str] = set()
+    for cmd in commands:
+        path = f"{prefix}{cmd.name}"  # type: ignore[attr-defined]
+        out.add(path)
+        if isinstance(cmd, app_commands.Group):
+            out |= _local_paths(cmd.commands, prefix=f"{path} ")
+    return out
+
+
+def _remote_paths(commands: Iterable[object], prefix: str = "") -> set[str]:
+    """Qualified command paths for the REMOTE tree (fetched ``AppCommand`` objects).
+
+    ``AppCommand`` and ``AppCommandGroup`` both expose ``.name`` + ``.options``;
+    an option is a nested command iff its ``.type`` is a (sub)command type — a
+    parameter has a value type and is skipped — so the same recursion reaches the
+    same leaf paths the local walk produces.
+    """
+    out: set[str] = set()
+    for cmd in commands:
+        path = f"{prefix}{cmd.name}"  # type: ignore[attr-defined]
+        out.add(path)
+        subs = [
+            opt
+            for opt in (getattr(cmd, "options", None) or [])
+            if getattr(opt, "type", None) in _SUBCOMMAND_TYPES
+        ]
+        out |= _remote_paths(subs, prefix=f"{path} ")
+    return out
+
+
+@dataclass(frozen=True)
+class SyncOutcome:
+    """What the auto-sync did, for logging + tests (it never raises)."""
+
+    synced: bool
+    reason: str  # disabled | fetch_failed | unchanged | sync_failed | synced
+    added: tuple[str, ...] = ()  # paths now present locally but not on Discord
+    removed: tuple[str, ...] = ()  # paths on Discord but gone locally
+
+
+async def auto_sync_if_changed(bot: object, *, enabled: bool) -> SyncOutcome:
+    """Sync the global command tree iff its paths differ from Discord's.
+
+    Returns a :class:`SyncOutcome`; never raises (a fetch/sync failure is logged
+    and reported so it cannot crash startup).
+    """
+    if not enabled:
+        logger.debug("auto-sync: disabled via AUTO_SYNC_COMMANDS")
+        return SyncOutcome(False, "disabled")
+
+    tree = bot.tree  # type: ignore[attr-defined]
+    try:
+        local = _local_paths(tree.get_commands())
+        remote = _remote_paths(await tree.fetch_commands())
+    except Exception:
+        logger.warning("auto-sync: fetch/compare failed (non-fatal)", exc_info=True)
+        return SyncOutcome(False, "fetch_failed")
+
+    if local == remote:
+        logger.info(
+            "auto-sync: command tree already in sync (%d commands) — skipped",
+            len(local),
+        )
+        return SyncOutcome(False, "unchanged")
+
+    added = tuple(sorted(local - remote))
+    removed = tuple(sorted(remote - local))
+    try:
+        synced = await tree.sync()
+    except discord.HTTPException as exc:
+        logger.warning("auto-sync: tree.sync() failed (non-fatal): %s", exc)
+        return SyncOutcome(False, "sync_failed", added, removed)
+
+    logger.info(
+        "auto-sync: tree changed (+%d/-%d) — synced %d global commands. "
+        "added=%s removed=%s",
+        len(added),
+        len(removed),
+        len(synced),
+        list(added[:8]),
+        list(removed[:8]),
+    )
+    return SyncOutcome(True, "synced", added, removed)

--- a/docs/operations/env-vars.md
+++ b/docs/operations/env-vars.md
@@ -13,7 +13,7 @@ it reads it, and whether it is **required** (read without a default anywhere) or
 only — never a value**; the values live in Railway service variables
 (see [`production-deployment.md`](production-deployment.md)).
 
-**38 variables** — 3 required · 35 optional.
+**39 variables** — 3 required · 36 optional.
 
 ## Required (read without a default — the deploy must set these)
 
@@ -32,6 +32,7 @@ only — never a value**; the values live in Railway service variables
 | `AI_FALLBACK_PROVIDER` | core | `disbot/core/runtime/ai/routing.py:128` *(default)* |
 | `ANTHROPIC_API_KEY` | config, core | `disbot/config.py:152` *(default)*<br>`disbot/core/runtime/ai/providers/anthropic_provider.py:93` *(default)* |
 | `AUTOMATION_SCHEDULER_ENABLED` | services | `disbot/services/automation_scheduler.py:397` *(default)* |
+| `AUTO_SYNC_COMMANDS` | config | `disbot/config.py:215` *(default)* |
 | `BOT_OWNER_USER_ID` | config | `disbot/config.py:40` *(default)* |
 | `BOT_PREFIX` | config | `disbot/config.py:28` *(default)* |
 | `BTD6_AUTO_SEED` | config | `disbot/config.py:207` *(default)* |

--- a/docs/owner/claims/claude-great-meitner-pnfp0g.md
+++ b/docs/owner/claims/claude-great-meitner-pnfp0g.md
@@ -1,0 +1,1 @@
+claude/great-meitner-pnfp0g · startup command-tree auto-sync (owner-approved) + post-unification docs cleanup · disbot/services/command_tree_sync.py + disbot/bot1.py + disbot/config.py + tests + docs/setup-platform + docs/planning + docs/agent + docs/subsystems/btd6.md · 2026-06-24

--- a/docs/owner/claims/claude-great-meitner-pnfp0g.md
+++ b/docs/owner/claims/claude-great-meitner-pnfp0g.md
@@ -1,1 +1,0 @@
-claude/great-meitner-pnfp0g · startup command-tree auto-sync (owner-approved) + post-unification docs cleanup · disbot/services/command_tree_sync.py + disbot/bot1.py + disbot/config.py + tests + docs/setup-platform + docs/planning + docs/agent + docs/subsystems/btd6.md · 2026-06-24

--- a/docs/setup-platform/settings-customization-command-map.md
+++ b/docs/setup-platform/settings-customization-command-map.md
@@ -1745,14 +1745,18 @@ deliberately absent — no external calls, no PII stored.
 
 1. **cog_module**: `disbot/cogs/btd6_cog.py`
 2. **subsystem**: `btd6`
-3. **current_commands**: `!btd6` (group), `!btd6 status`,
-   `!btd6 diagnostics`, `!btd6 ask <question>`, `!btd6 test-intent <text>`,
-   `!btd6 ctteam`, `!btd6menu`. Slash equivalents (`/btd6 ...`, `/btd6menu`)
-   mirror the prefix surface. The reference / events / strategy command
-   groups now live in sibling cogs (see `btd6_reference`, `btd6_events`,
-   `btd6_strategy` below) so `btd6_cog.py` stays under the 800-LOC ceiling;
-   the mother cog keeps the panel, core diagnostics, and the schema +
-   ingestion-supervisor lifecycle.
+3. **current_commands**: the whole BTD6 surface is now **one unified `/btd6`
+   (`!btd6`) tree** (owner request, 2026-06-24): everyday lookups flat
+   (`/btd6 income`, `/btd6 round`, `/btd6 rbe`, `/btd6 tower`, `/btd6 hero`,
+   `/btd6 relic`, `/btd6 ct`, `/btd6 ask`, `/btd6 status`, `/btd6 diagnostics`,
+   `/btd6 test-intent`; `!btd6 ctteam` is prefix-only) and the bigger buckets
+   nested (`/btd6 strat …`, `/btd6 ops …`, `/btd6 events …`). The tree is
+   module-level in `disbot/cogs/btd6/_unified.py` (cogs can't cleanly share one
+   `app_commands.Group`); the mother `btd6_cog` registers it and keeps the panel
+   (`!btd6menu`) + the schema / ingestion-supervisor lifecycle. The old
+   `btd6_reference` / `btd6_events` / `btd6_strategy` / `btd6_ops` cogs (below)
+   remain only as **hidden prefix aliases** (`!btd6ref …` etc.) so existing
+   muscle-memory keeps working.
 4. **current_command_groups**: `!btd6` group (user-tier).
 5. **current_command_panel_or_menu**: `!btd6menu` (alias for `!btd6`)
    opens the persistent panel `BTD6PanelView`.
@@ -1780,7 +1784,7 @@ deliberately absent — no external calls, no PII stored.
     `BTD6_VERSION_ANNOUNCEMENT_CHANNEL` (the **legacy fallback lane** for the
     version-announcement channel since Settings Phase 2/Q-0064 — the
     `btd6.version_announce_channel` binding takes precedence when bound;
-    `!btd6ops announcechannel` still writes this KV pointer and warns when a
+    `!btd6 ops announcechannel` still writes this KV pointer and warns when a
     binding shadows it; read through `services.btd6_version_announce`), all
     in `disbot/utils/settings_keys/btd6.py`.
 11. **existing_BindingSpec_entries**: `btd6.strategy_submission_channel`
@@ -1821,13 +1825,16 @@ deliberately absent — no external calls, no PII stored.
 ### btd6_reference
 
 1. **cog_module**: `disbot/cogs/btd6_reference_cog.py`
-2. **subsystem**: `btd6` (sibling cog — static game-data lookups split out so
-   `btd6_cog.py` stays under the 800-LOC ceiling; class name maps to no
-   SUBSYSTEMS key, so it shares the `btd6` subsystem like `btd6_ops`).
-3. **current_commands**: `!btd6ref tower <name>`, `!btd6ref hero <name>`,
-   `!btd6ref round <N>`, `!btd6ref relic <name>`, `!btd6ref ct`. Slash twins
-   under `/btd6ref`. Also reachable from `BTD6PanelView` (`!btd6`).
-4. **current_command_groups**: `btd6ref` (prefix) / `/btd6ref` (app group).
+2. **subsystem**: `btd6` (now a **hidden prefix alias** — static game-data
+   lookups. The canonical surface is the unified `/btd6` tree
+   (`cogs/btd6/_unified.py`); this cog keeps `!btd6ref …` so old muscle-memory
+   keeps working).
+3. **current_commands** (canonical): `!btd6 tower <name>`, `!btd6 hero <name>`,
+   `!btd6 round <N>`, `!btd6 rbe <N>`, `!btd6 income <N>`, `!btd6 relic <name>`,
+   `!btd6 ct` (+ slash `/btd6 tower …`). The legacy `!btd6ref tower …` prefix
+   still works (hidden alias). Also reachable from `BTD6PanelView` (`!btd6`).
+4. **current_command_groups**: flat lookups under the unified `/btd6` (`!btd6`)
+   tree; `btd6ref` survives as a hidden **prefix-only** alias (no slash twin).
 5. **current_command_panel_or_menu**: none of its own — surfaced via the
    shared `BTD6PanelView`.
 6. **help_menu_discoverable**: via the BTD6 panel (the `btd6` subsystem owns
@@ -1840,14 +1847,17 @@ deliberately absent — no external calls, no PII stored.
 ### btd6_events
 
 1. **cog_module**: `disbot/cogs/btd6_events_cog.py`
-2. **subsystem**: `btd6` (sibling cog — live Ninja Kiwi events / leaderboards /
-   source diagnostics / grounding, split out of `btd6_cog`).
-3. **current_commands**: `!btd6events live`, `!btd6events event`,
-   `!btd6events leaderboard`, `!btd6events sources`,
-   `!btd6events source-health`, `!btd6events latest-data`,
-   `!btd6events refresh-source <key>` (manage-guild), `!btd6events grounding`.
-   Slash twins under `/btd6events`.
-4. **current_command_groups**: `btd6events` (prefix) / `/btd6events` (app group).
+2. **subsystem**: `btd6` (now a **hidden prefix alias** — live Ninja Kiwi
+   events / leaderboards / source diagnostics / grounding. Canonical surface:
+   the unified `/btd6 events …` subgroup in `cogs/btd6/_unified.py`).
+3. **current_commands** (canonical): `!btd6 events live`, `!btd6 events event`,
+   `!btd6 events leaderboard`, `!btd6 events sources`,
+   `!btd6 events source-health`, `!btd6 events latest-data`,
+   `!btd6 events refresh-source <key>` (manage-guild), `!btd6 events grounding`
+   (+ slash `/btd6 events …`). The legacy `!btd6events …` prefix still works
+   (hidden alias).
+4. **current_command_groups**: `/btd6 events …` (nested under the unified tree);
+   `btd6events` survives as a hidden **prefix-only** alias (no slash twin).
 5. **current_command_panel_or_menu**: none of its own — surfaced via
    `BTD6PanelView`.
 6. **help_menu_discoverable**: via the BTD6 panel.
@@ -1859,14 +1869,17 @@ deliberately absent — no external calls, no PII stored.
 ### btd6_strategy
 
 1. **cog_module**: `disbot/cogs/btd6_strategy_cog.py`
-2. **subsystem**: `btd6` (sibling cog — strategy memory browse/submit/review +
-   `why-no-response`, split out of `btd6_cog`).
-3. **current_commands**: `!btd6strat browse`, `!btd6strat mine`,
-   `!btd6strat strategy <id>`, `!btd6strat strategy-audit <id>`,
-   `!btd6strat submit` (slash opens a modal), `!btd6strat pending`
-   (manage-guild), `!btd6strat strategies`, `!btd6strat why-no-response`.
-   Slash twins under `/btd6strat`.
-4. **current_command_groups**: `btd6strat` (prefix) / `/btd6strat` (app group).
+2. **subsystem**: `btd6` (now a **hidden prefix alias** — strategy memory
+   browse/submit/review + `why-no-response`. Canonical surface: the unified
+   `/btd6 strat …` subgroup in `cogs/btd6/_unified.py`).
+3. **current_commands** (canonical): `!btd6 strat browse`, `!btd6 strat mine`,
+   `!btd6 strat strategy <id>`, `!btd6 strat strategy-audit <id>`,
+   `!btd6 strat submit` (slash opens a modal), `!btd6 strat pending`
+   (manage-guild), `!btd6 strat strategies`, `!btd6 strat why-no-response`
+   (+ slash `/btd6 strat …`). The legacy `!btd6strat …` prefix still works
+   (hidden alias).
+4. **current_command_groups**: `/btd6 strat …` (nested under the unified tree);
+   `btd6strat` survives as a hidden **prefix-only** alias (no slash twin).
 5. **current_command_panel_or_menu**: none of its own — surfaced via
    `BTD6PanelView`.
 6. **help_menu_discoverable**: via the BTD6 panel.
@@ -1915,13 +1928,17 @@ deliberately absent — no external calls, no PII stored.
 ### btd6_ops
 
 1. **cog_module**: `disbot/cogs/btd6_ops_cog.py`
-2. **subsystem**: `btd6` (operator surface for BTD6 ingestion — given its own
-   thin cog so `btd6_cog.py` stays under the 800-LOC ceiling).
-3. **current_commands**: `!btd6ops readiness` (ingestion readiness verdict),
-   `!btd6ops runs` (recent ingestion runs), `!btd6ops source_enable <key>` /
-   `!btd6ops source_disable <key>` (toggle a source). Slash twins under
-   `/btd6ops`. Also reachable from the 🛠️ Admin sub-panel on `!btd6`.
-4. **current_command_groups**: `btd6ops` (prefix group) / `/btd6ops` (app group).
+2. **subsystem**: `btd6` (now a **hidden prefix alias** — operator surface for
+   BTD6 ingestion. Canonical surface: the unified `/btd6 ops …` subgroup in
+   `cogs/btd6/_unified.py`; shared formatters in `cogs/btd6/_ops_helpers.py`).
+3. **current_commands** (canonical): `!btd6 ops readiness` (ingestion readiness
+   verdict), `!btd6 ops runs` (recent ingestion runs), `!btd6 ops source_enable
+   <key>` / `!btd6 ops source_disable <key>` (toggle a source), `!btd6 ops
+   seed-data`, `!btd6 ops announcechannel` (+ slash `/btd6 ops …`). The legacy
+   `!btd6ops …` prefix still works (hidden alias). Also reachable from the 🛠️
+   Admin sub-panel on `!btd6`.
+4. **current_command_groups**: `/btd6 ops …` (nested under the unified tree);
+   `btd6ops` survives as a hidden **prefix-only** alias (no slash twin).
 5. **current_command_panel_or_menu**: the BTD6 Admin panel
    (`views.btd6.admin_panel.BTD6AdminView`) exposes Readiness, Recent Runs, and
    a source enable/disable select + buttons.
@@ -1946,7 +1963,7 @@ deliberately absent — no external calls, no PII stored.
     `services.btd6_source_mutation.set_enabled` (audited); reads via
     `services.btd6_ops_readiness_service` + `utils.db.btd6_sources`.
 21. **target_help_or_menu_route**: existing; the BTD6 hub Admin panel and
-    `!btd6ops` / `/btd6ops`.
+    `!btd6 ops` / `/btd6 ops` (legacy `!btd6ops` still works, hidden).
 22. **provisionable_resources**: none.
 23. **priority**: `P2` — BTD6 ingestion operations.
 24. **recommended_PR_phase**: ships with the BTD6 operator-visibility feature.

--- a/docs/subsystems/btd6.md
+++ b/docs/subsystems/btd6.md
@@ -58,14 +58,14 @@ files, `disbot/services/btd6_*`, `disbot/views/btd6/`, `disbot/utils/db/btd6_*`,
   defensive, kill-switch `BTD6_AUTO_SEED=0`). So a **version bump** is zero-touch
   (merge → deploy → current). **A same-`version` data edit (e.g. a buff-stat fix
   with no version bump) is NOT auto-applied** — by the owner's strict-(b) choice
-  (2026-06-21) it still needs a one-time `!btd6ops seed-data`. Code deploys
+  (2026-06-21) it still needs a one-time `!btd6 ops seed-data`. Code deploys
   themselves are Railway auto-deploy-on-merge; `!restart` exits nonzero since
   PR #675 so the platform relaunches it.
 - **Same-version drift is now surfaced (PR #1258):** since strict (b) ignores
   same-`version` edits and `served_data_drift()` is version-only, a buff/stat fix
   with no version bump used to stay stale silently. `content_drift()` (sha over the
   canonical JSON, the seed digest) now flags those at boot **and** in `!btd6 status`
-  with a "run `!btd6ops seed-data`" reminder — warn-only, no auto-write.
+  with a "run `!btd6 ops seed-data`" reminder — warn-only, no auto-write.
 
 ## Plans / pending approval
 

--- a/tests/unit/services/test_command_tree_sync.py
+++ b/tests/unit/services/test_command_tree_sync.py
@@ -1,0 +1,194 @@
+"""Tests for the diff-gated startup command-tree auto-sync.
+
+Pins: env kill-switch parsing; that local/remote path extraction reach the same
+qualified paths from the two different object models (so the diff is meaningful);
+and that ``auto_sync_if_changed`` syncs ONLY on a real diff and is non-fatal on
+every failure path.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import discord
+import pytest
+
+from services import command_tree_sync as cts
+
+_SUB = discord.AppCommandOptionType.subcommand
+_GROUP = discord.AppCommandOptionType.subcommand_group
+_STR = discord.AppCommandOptionType.string
+
+
+# ---------------------------------------------------------------------------
+# env_enabled — kill-switch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw", ["1", "true", "yes", "on", "TRUE", "anything", "", None])
+def test_env_enabled_default_on(raw):
+    assert cts.env_enabled(raw) is True
+
+
+@pytest.mark.parametrize("raw", ["0", "false", "no", "off", " OFF ", "False"])
+def test_env_enabled_explicit_off(raw):
+    assert cts.env_enabled(raw) is False
+
+
+# ---------------------------------------------------------------------------
+# path extraction — local (real unified tree) and remote (fetched model)
+# ---------------------------------------------------------------------------
+
+
+def test_local_paths_walk_the_real_unified_tree():
+    from cogs.btd6 import _unified
+
+    paths = cts._local_paths([_unified.btd6_app])
+    assert "btd6" in paths
+    assert "btd6 income" in paths  # flat lookup
+    assert "btd6 strat" in paths  # nested subgroup
+    assert "btd6 strat browse" in paths  # nested leaf
+    assert "btd6 ops seed-data" in paths
+
+
+def test_local_paths_treats_a_plain_command_as_a_leaf():
+    cmd = SimpleNamespace(name="help")
+    assert cts._local_paths([cmd]) == {"help"}
+
+
+def _remote(name, options=None):
+    return SimpleNamespace(name=name, options=options or [])
+
+
+def _opt(name, type_, options=None):
+    return SimpleNamespace(name=name, type=type_, options=options or [])
+
+
+def test_remote_paths_recurse_through_subcommand_groups_and_skip_params():
+    btd6 = _remote(
+        "btd6",
+        options=[
+            _opt("income", _SUB, options=[_opt("start_round", _STR)]),  # param skipped
+            _opt(
+                "strat",
+                _GROUP,
+                options=[_opt("browse", _SUB)],
+            ),
+        ],
+    )
+    paths = cts._remote_paths([btd6])
+    assert paths == {"btd6", "btd6 income", "btd6 strat", "btd6 strat browse"}
+    assert "btd6 income start_round" not in paths  # a parameter is not a path
+
+
+def test_local_and_remote_paths_match_for_an_equivalent_tree():
+    # _local_paths uses isinstance(app_commands.Group), so build the local side
+    # from a real Group; the remote side from the fetched-AppCommand model. Both
+    # must reach the same qualified paths for the diff to be meaningful.
+    from discord import app_commands
+
+    grp = app_commands.Group(name="x", description="d")
+
+    @grp.command(name="a", description="d")
+    async def _a(interaction):  # pragma: no cover - registration only
+        pass
+
+    @grp.command(name="b", description="d")
+    async def _b(interaction):  # pragma: no cover - registration only
+        pass
+
+    local = cts._local_paths([grp])
+    remote = cts._remote_paths(
+        [_remote("x", options=[_opt("a", _SUB), _opt("b", _SUB)])],
+    )
+    assert local == remote == {"x", "x a", "x b"}
+
+
+# ---------------------------------------------------------------------------
+# auto_sync_if_changed — the gate
+# ---------------------------------------------------------------------------
+
+
+class _Tree:
+    def __init__(self, *, local, remote, sync_result=None, fetch_exc=None, sync_exc=None):
+        self._local = local
+        self._remote = remote
+        self._sync_result = sync_result if sync_result is not None else []
+        self._fetch_exc = fetch_exc
+        self._sync_exc = sync_exc
+        self.sync_calls = 0
+        self.fetch_calls = 0
+
+    def get_commands(self):
+        return self._local
+
+    async def fetch_commands(self):
+        self.fetch_calls += 1
+        if self._fetch_exc:
+            raise self._fetch_exc
+        return self._remote
+
+    async def sync(self):
+        self.sync_calls += 1
+        if self._sync_exc:
+            raise self._sync_exc
+        return self._sync_result
+
+
+def _bot(tree):
+    return SimpleNamespace(tree=tree)
+
+
+@pytest.mark.asyncio
+async def test_disabled_does_nothing():
+    tree = _Tree(local=[_remote("help")], remote=[])
+    out = await cts.auto_sync_if_changed(_bot(tree), enabled=False)
+    assert out.synced is False and out.reason == "disabled"
+    assert tree.fetch_calls == 0 and tree.sync_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_unchanged_tree_does_not_sync():
+    tree = _Tree(local=[SimpleNamespace(name="help")], remote=[_remote("help")])
+    out = await cts.auto_sync_if_changed(_bot(tree), enabled=True)
+    assert out.synced is False and out.reason == "unchanged"
+    assert tree.fetch_calls == 1 and tree.sync_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_changed_tree_syncs_and_reports_diff():
+    # local has /new that Discord lacks; Discord has /old that's gone locally.
+    tree = _Tree(
+        local=[SimpleNamespace(name="help"), SimpleNamespace(name="new")],
+        remote=[_remote("help"), _remote("old")],
+        sync_result=[SimpleNamespace(name="help"), SimpleNamespace(name="new")],
+    )
+    out = await cts.auto_sync_if_changed(_bot(tree), enabled=True)
+    assert out.synced is True and out.reason == "synced"
+    assert tree.sync_calls == 1
+    assert out.added == ("new",)
+    assert out.removed == ("old",)
+
+
+@pytest.mark.asyncio
+async def test_fetch_failure_is_non_fatal():
+    tree = _Tree(local=[], remote=[], fetch_exc=discord.HTTPException(
+        response=SimpleNamespace(status=503, reason="x"), message="boom"))
+    out = await cts.auto_sync_if_changed(_bot(tree), enabled=True)
+    assert out.synced is False and out.reason == "fetch_failed"
+    assert tree.sync_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_sync_failure_is_non_fatal():
+    tree = _Tree(
+        local=[SimpleNamespace(name="new")],
+        remote=[],
+        sync_exc=discord.HTTPException(
+            response=SimpleNamespace(status=429, reason="rate"), message="rate limited"
+        ),
+    )
+    out = await cts.auto_sync_if_changed(_bot(tree), enabled=True)
+    assert out.synced is False and out.reason == "sync_failed"
+    assert tree.sync_calls == 1
+    assert out.added == ("new",)


### PR DESCRIPTION
## Owner request (follow-up to #1419)

> *"you can finish up with the auto sync, then end the session by cleaning up stale docs."*

After the BTD6 unification (#1419), retire the manual `!syncslash` toil so a command change goes live on deploy automatically — **safely**.

## The auto-sync — diff-gated, no storage, no false positives

`services/command_tree_sync.py`: on startup, fetch the live global commands from Discord (`tree.fetch_commands()`) and compare the **set of qualified command paths** to the local tree. Call `tree.sync()` **only** when they differ.

- **Conservative on purpose** — compares command *paths* (add / remove / rename of commands + subcommands), not parameter/description details, because Discord normalises option payloads and a fuller diff would false-positive and re-sync every boot (the rate-limit risk). Param/description-only changes still use manual `!syncslash`.
- Wired into the `on_ready` **one-shot** path (mirrors `_maybe_report_startup_health`) — fires once per process, reconnect-safe.
- **Kill-switch:** `AUTO_SYNC_COMMANDS=0`. Failures are non-fatal (logged, never crash startup).
- Merging = deploying (Railway), so the next deploy auto-syncs the unified `/btd6` tree — the `!syncslash global` step becomes optional.

## Docs cleanup
Sweep the reference docs that still describe the old five-group BTD6 layout (flagged in the #1419 session log): command-map, platform-mapping, agent index, `subsystems/btd6.md`.

## Reliability (Q-0105)
The auto-sync is marked **unverified** — confirm it fires correctly across a few real deploys before fully trusting; the kill-switch + manual `!syncslash` remain as the backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hydy3uLzrkCmqHWT2VoEKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hydy3uLzrkCmqHWT2VoEKG)_