### PR TITLE
Setup-wizard PR 1: Essential Setup spine (linear, direct-apply, plain language)

### DIFF
--- a/.sessions/2026-06-24-setup-spine-build.md
+++ b/.sessions/2026-06-24-setup-spine-build.md
@@ -1,0 +1,13 @@
+# Session — 2026-06-24 · build the essentials spine (PR 1)
+
+> **Status:** `in-progress` — born-red. Owner greenlit (in-session) building the setup-wizard essentials
+> spine with **per-step direct-apply** (Q-A answered: "save each step instantly"). Runtime build.
+
+## What I'm about to do
+
+Build the new linear **Essential Setup** flow per the plan (`setup-wizard-restructure-plan-2026-06-24.md`
+§5): a stepped, plain-language, button/dropdown-only flow where **each step applies its config immediately**
+(direct lane) and the bot **auto-creates** any channel/role it needs. Steps: server type → greet members →
+moderators → block spam → log channel → reward activity → help desk → done. Reuse existing audited config
+services (welcome/moderation/automod/logging/xp+role/ticket); no new mutation primitives. Old wizard stays
+(retired later in PR 3). Full test suite run before push (lesson from the guild sweep).

--- a/.sessions/2026-06-24-setup-spine-build.md
+++ b/.sessions/2026-06-24-setup-spine-build.md
@@ -1,13 +1,78 @@
 # Session — 2026-06-24 · build the essentials spine (PR 1)
 
-> **Status:** `in-progress` — born-red. Owner greenlit (in-session) building the setup-wizard essentials
-> spine with **per-step direct-apply** (Q-A answered: "save each step instantly"). Runtime build.
+> **Status:** `complete` — runtime build (new setup flow + cog). Additive; old wizard untouched.
 
-## What I'm about to do
+**Trigger:** owner answered the two gating questions (`AskUserQuestion`): **Q-A = "save each step
+instantly"** (direct lane) and **"Yes — build the essentials spine."** This session builds PR 1 of the
+setup-wizard restructure plan.
 
-Build the new linear **Essential Setup** flow per the plan (`setup-wizard-restructure-plan-2026-06-24.md`
-§5): a stepped, plain-language, button/dropdown-only flow where **each step applies its config immediately**
-(direct lane) and the bot **auto-creates** any channel/role it needs. Steps: server type → greet members →
-moderators → block spam → log channel → reward activity → help desk → done. Reuse existing audited config
-services (welcome/moderation/automod/logging/xp+role/ticket); no new mutation primitives. Old wizard stays
-(retired later in PR 3). Full test suite run before push (lesson from the guild sweep).
+## What shipped
+
+- **`disbot/views/setup/essential_setup.py`** — the new **linear, plain-language, direct-apply** setup
+  spine: `EssentialFlow` (ordered steps + position) + per-step `BaseView`s with **Save / Skip / Back** and
+  a **"Step X of N"** counter. Two steps live end-to-end — **Greet new members** (welcome
+  enabled/join/channel/optional entry-role) and **Set your moderators** (mod role + DM-on-action) — each
+  applying immediately via the audited `SettingsMutationPipeline` (lazy import, per the setup-views
+  invariant). Plus an **All-done summary**. Jargon-clean (guard adds 0 findings).
+- **`disbot/cogs/quicksetup_cog.py`** — `!quicksetup` / `/quicksetup` entry (admin-gated, server-only),
+  in `INITIAL_EXTENSIONS`. Its own cog because `setup_cog` is at the 800-LOC ceiling. Classified in
+  `architecture_rules/extension_roles.yaml` (bootstrap, backs server_management).
+- Tests (`tests/unit/views/setup/test_essential_setup.py`, 10) + plan PR-1 note + regenerated artifacts
+  (extension crosswalk, dashboard site.json/data.js, env-vars.md).
+
+## The misses (recorded honestly — this PR fought me)
+
+1. **`setup_cog` was already at the 800-LOC ceiling** — adding commands there tripped `test_cog_size`.
+   Fix: a dedicated `quicksetup_cog`. Lesson: check `test_cog_size` headroom before adding to a cog.
+2. **Setup views must not import mutation pipelines at top level** (`test_setup_operations_invariants`).
+   Fix: lazy import inside `_set`. (Also broke a test's `patch.object(es, ...)` target → patch at source.)
+3. **Adding a cog made 4 generated-artifact freshness tests stale** (13 sub-failures): extension
+   crosswalk (needs the new extension **classified in `extension_roles.yaml`** *then* regenerated),
+   dashboard site.json, env-vars.md (config.py line-number shifts). Fix: classify + regenerate all three.
+4. **The PR branch is auto-kept-current with `main`** (enabler merges main in) → non-fast-forward push +
+   a rebase conflict **on the generated artifacts**. Resolution: never hand-merge generated files — reset
+   to the merged remote, re-apply the source edit (overlay), regenerate fresh, push.
+
+**Meta-lesson (the through-line of all four):** *adding a cog/command has a fan-out of required artifact
+updates that only the **full** suite reveals* — run `pytest -q` (whole suite), not just the nearest dir,
+before calling a runtime addition done. The exit-code from backgrounded `pytest`/`check_quality` was
+unreliable again (reported 0 while 13 failed); I trusted the printed summary (Q-0120), which is what
+caught it.
+
+## 💡 Session idea (Q-0089)
+
+**A `scripts/new_cog_checklist.py` (or a Stop-hook nudge) that, when `INITIAL_EXTENSIONS` changes, prints
+the fan-out:** "new extension → classify in `extension_roles.yaml`, then regenerate crosswalk + dashboard
++ env-vars + run the full suite." Every one of this session's four misses is a *known, scriptable*
+consequence of adding a cog; a one-shot checklist would turn a multi-round CI discovery into a pre-push
+reminder. Genuinely believe in it — adding cogs is routine and this fan-out bites every time.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous `.sessions/` log: the **guild→server sweep**. Did well: scripted the bulk reword + lowered the
+ratchet in lock-step. Missed: it called the sweep "zero-risk, no behaviour change" and skipped the full
+suite → 7 copy-asserting tests broke across 4 CI rounds. **System improvement (applied here):** I ran the
+full suite before flipping this PR's card — and it caught the 13 artifact failures *before* a "complete"
+push. The recurring theme across both sessions is **incomplete pre-push verification**; the Q-0089 idea
+(checklist) and a "run the full suite for any runtime/cog change" habit are the durable fixes.
+
+## 📋 Doc audit (Q-0104)
+
+Plan PR-1 note updated; new file jargon-clean (guard 154, unchanged — essential_setup adds 0); generated
+artifacts regenerated + committed; new cog classified in the overlay. No owner *decision* beyond Q-A
+(recorded in the plan header + this card). No `current-state.md` ledger entry until merge.
+
+## Context delta
+
+- **The spine architecture is proven and cheap to extend.** The remaining steps are declarative
+  follow-ons: **block spam** (automod toggles via the same `_set`), **choose log channel** (binding +
+  `ChannelLifecycleService` auto-create), **help desk** (`ticket_mutation`, already direct), **rewards**
+  (needs a small direct-apply role-threshold service — the one genuine gap), **server-type preset** (needs
+  a direct-apply preset path — currently draft-only).
+- **For next session:** add 2-3 more steps to `EssentialFlow._steps` (each ~40 lines + tests), and wire
+  **auto-create** into the welcome/log steps (the channel-create service is ready). Then PR 3 retires the
+  old sections.
+
+## ⚑ Self-initiated: PARTIAL — the *decision* to build now + the direct-apply lane were **owner-directed**
+(`AskUserQuestion`). The *scoping* (which 2 steps to ship first, the own-cog split, deferring the
+preset/reward gap steps) was my call within that greenlight. Additive + test-covered; old wizard intact.

--- a/architecture_rules/extension_roles.yaml
+++ b/architecture_rules/extension_roles.yaml
@@ -221,6 +221,11 @@ extensions:
     role: bootstrap
     backs: server_management
     note: Guided setup wizard; lifecycle-critical, load-order sensitive.
+  quicksetup:
+    role: bootstrap
+    backs: server_management
+    note: Essential Setup front door (!quicksetup / /quicksetup); thin command
+      surface over views.setup.essential_setup (the plain-language spine).
   server_management:
     role: hub
     note: Routing-only hub (moderation/channels/roles/cleanup/setup); holds no

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-06-24T13:29:40Z",
+    "generated_at": "2026-06-24T13:45:19Z",
     "build": {
-      "commit": "30331fd",
-      "subject": "Merge branch 'main' into claude/great-meitner-pnfp0g",
-      "committed_at": "2026-06-24T13:29:40Z"
+      "commit": "e02a66d",
+      "subject": "Merge branch 'main' into claude/serene-mccarthy-lv5z94",
+      "committed_at": "2026-06-24T13:45:19Z"
     }
   },
   "counts": {
-    "commands": 436,
+    "commands": 438,
     "features": 42,
     "games": 11
   },
@@ -10576,6 +10576,36 @@
       "permissions": "",
       "usage": "Cross-linked ResourceRequirement × BindingSpec catalogue (S2.5).",
       "description": "Cross-linked ResourceRequirement × BindingSpec catalogue (S2.5).",
+      "use_cases": null,
+      "examples": [],
+      "status": "finished",
+      "linked_ideas": [],
+      "notes": null
+    },
+    {
+      "name": "quicksetup",
+      "aliases": [
+        "essentialsetup"
+      ],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Open Essential Setup — a few simple steps, each saved instantly.",
+      "description": "Open Essential Setup — a few simple steps, each saved instantly.",
+      "use_cases": null,
+      "examples": [],
+      "status": "finished",
+      "linked_ideas": [],
+      "notes": null
+    },
+    {
+      "name": "quicksetup",
+      "aliases": [],
+      "category": "other",
+      "cooldown": null,
+      "permissions": "",
+      "usage": "Quick guided setup — a few simple steps, no jargon.",
+      "description": "Open Essential Setup — a few simple steps, each saved instantly.",
       "use_cases": null,
       "examples": [],
       "status": "finished",

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -3749,6 +3749,21 @@ const COMMANDS = [
     ]
   },
   {
+    "name": "quicksetup",
+    "area": "other",
+    "status": "finished",
+    "summary": "Open Essential Setup — a few simple steps, each saved instantly.",
+    "description": "Open Essential Setup — a few simple steps, each saved instantly.",
+    "usage": "!quicksetup",
+    "aliases": [
+      "essentialsetup"
+    ],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [],
+    "planned": []
+  },
+  {
     "name": "quote",
     "area": "utility",
     "status": "finished",
@@ -6632,7 +6647,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "30331fd",
+    "build": "e02a66d",
     "title": "New public bot website",
     "changes": [
       {
@@ -6644,7 +6659,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "30331fd",
+    "build": "e02a66d",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -6656,7 +6671,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "30331fd",
+    "build": "e02a66d",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-24T13:29:40Z",
+    "generated_at": "2026-06-24T13:45:19Z",
     "build": {
-      "commit": "30331fd",
-      "subject": "Merge branch 'main' into claude/great-meitner-pnfp0g",
-      "committed_at": "2026-06-24T13:29:40Z"
+      "commit": "e02a66d",
+      "subject": "Merge branch 'main' into claude/serene-mccarthy-lv5z94",
+      "committed_at": "2026-06-24T13:45:19Z"
     },
     "counts": {
       "functions": 42,
@@ -14,8 +14,8 @@
       "reviews_open": 0,
       "updates": 60,
       "env_vars": 39,
-      "cogs": 52,
-      "commands": 436,
+      "cogs": 53,
+      "commands": 438,
       "setting_keys": 107,
       "setting_domains": 16,
       "typed_settings": 88,
@@ -2521,6 +2521,14 @@
       "self_initiated": false
     },
     {
+      "file": "2026-06-24-setup-spine-build.md",
+      "date": "2026-06-24",
+      "title": "Session — 2026-06-24 · build the essentials spine (PR 1)",
+      "status": "in-progress",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
       "file": "2026-06-24-setup-jargon-sweep-guild.md",
       "date": "2026-06-24",
       "title": "Session — 2026-06-24 · setup plain-language sweep 1 (guild→server)",
@@ -2943,14 +2951,6 @@
       "status": "complete",
       "run_type": "manual",
       "self_initiated": true
-    },
-    {
-      "file": "2026-06-23-cleanup-panel-ux.md",
-      "date": "2026-06-23",
-      "title": "2026-06-23 — Cleanup panel UX overhaul: readable whitelist, fixable warnings, custom levels",
-      "status": "complete",
-      "run_type": "manual",
-      "self_initiated": true
     }
   ],
   "bot_changelog": [
@@ -3039,7 +3039,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 169,
+          "line": 170,
           "layer": "config",
           "has_default": true
         },
@@ -3061,7 +3061,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 168,
+          "line": 169,
           "layer": "config",
           "has_default": true
         }
@@ -3094,7 +3094,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 152,
+          "line": 153,
           "layer": "config",
           "has_default": true
         },
@@ -3132,7 +3132,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 215,
+          "line": 216,
           "layer": "config",
           "has_default": true
         }
@@ -3180,7 +3180,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 207,
+          "line": 208,
           "layer": "config",
           "has_default": true
         }
@@ -3228,7 +3228,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 195,
+          "line": 196,
           "layer": "config",
           "has_default": true
         }
@@ -3244,7 +3244,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 198,
+          "line": 199,
           "layer": "config",
           "has_default": true
         }
@@ -3260,7 +3260,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 201,
+          "line": 202,
           "layer": "config",
           "has_default": true
         }
@@ -3420,7 +3420,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 114,
+          "line": 115,
           "layer": "config",
           "has_default": true
         }
@@ -3500,7 +3500,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 115,
+          "line": 116,
           "layer": "config",
           "has_default": true
         }
@@ -3518,7 +3518,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 151,
+          "line": 152,
           "layer": "config",
           "has_default": true
         },
@@ -3559,7 +3559,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 178,
+          "line": 179,
           "layer": "config",
           "has_default": true
         },
@@ -3582,7 +3582,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 182,
+          "line": 183,
           "layer": "config",
           "has_default": true
         },
@@ -3621,7 +3621,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 150,
+          "line": 151,
           "layer": "config",
           "has_default": true
         },
@@ -3645,7 +3645,7 @@
       "usages": [
         {
           "file": "disbot/config.py",
-          "line": 149,
+          "line": 150,
           "layer": "config",
           "has_default": true
         },
@@ -8055,6 +8055,38 @@
           "parent": null,
           "aliases": [],
           "brief": "Grant timed access to #proof; auto-unlocks after duration minutes. Usage: timedprize @winner <minutes>",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        }
+      ]
+    },
+    {
+      "cog": "QuickSetupCog",
+      "file": "disbot/cogs/quicksetup_cog.py",
+      "subsystem": "quick_setup",
+      "is_cog": true,
+      "commands": [
+        {
+          "name": "quicksetup",
+          "type": "prefix",
+          "is_group": false,
+          "parent": null,
+          "aliases": [
+            "essentialsetup"
+          ],
+          "brief": "Open Essential Setup — a few simple steps, each saved instantly.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "quicksetup",
+          "type": "slash",
+          "is_group": false,
+          "parent": null,
+          "aliases": [],
+          "brief": "Quick guided setup — a few simple steps, no jargon.",
           "classification": "",
           "has_panel": false,
           "button_backed": false

--- a/disbot/cogs/quicksetup_cog.py
+++ b/disbot/cogs/quicksetup_cog.py
@@ -1,0 +1,45 @@
+"""Quick Setup cog — the front door to Essential Setup.
+
+A thin command surface (prefix + slash) that opens the plain-language,
+direct-apply setup spine in :mod:`views.setup.essential_setup`.  Kept as its
+own small cog rather than crowding ``setup_cog`` (which is at the size ceiling).
+"""
+
+from __future__ import annotations
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+
+class QuickSetupCog(commands.Cog):
+    """Opens Essential Setup (the short, jargon-free guided spine)."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @commands.command(name="quicksetup", aliases=["essentialsetup"])
+    @commands.guild_only()
+    @commands.has_permissions(administrator=True)
+    async def quicksetup_cmd(self, ctx: commands.Context) -> None:
+        """Open Essential Setup — a few simple steps, each saved instantly."""
+        from views.setup.essential_setup import open_essential_setup_prefix
+
+        await open_essential_setup_prefix(ctx)
+
+    @app_commands.command(
+        name="quicksetup",
+        description="Quick guided setup — a few simple steps, no jargon.",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.checks.has_permissions(administrator=True)
+    @app_commands.guild_only()
+    async def quicksetup_slash(self, interaction: discord.Interaction) -> None:
+        """Slash front door for Essential Setup (admin-gated)."""
+        from views.setup.essential_setup import open_essential_setup
+
+        await open_essential_setup(interaction)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(QuickSetupCog(bot))

--- a/disbot/config.py
+++ b/disbot/config.py
@@ -103,6 +103,7 @@ INITIAL_EXTENSIONS = [
     "cogs.ticket_cog",
     "cogs.security_cog",
     "cogs.setup_cog",
+    "cogs.quicksetup_cog",
     "cogs.server_management_cog",
     "cogs.hermes_cog",
     "cogs.ux_lab_cog",

--- a/disbot/views/setup/essential_setup.py
+++ b/disbot/views/setup/essential_setup.py
@@ -1,0 +1,518 @@
+"""Essential Setup — the plain-language, one-action-per-step setup spine.
+
+The rebuilt setup experience the maintainer asked for: a short, linear,
+button/dropdown-only flow that needs **zero Discord/bot knowledge**, uses **no
+jargon**, and where **every step applies immediately** (the direct lane — owner
+decision Q-A, 2026-06-24: "save each step instantly").  Each step is one
+complete action that actually finishes a piece of setup; nothing is "staged"
+for a later Final Review.
+
+Design (plan ``docs/planning/setup-wizard-restructure-plan-2026-06-24.md`` §5):
+
+* **Linear** — one screen at a time, with *Save & continue* / *Skip* / *Back*
+  and a "Step X of N" counter.  No grid of buttons.
+* **Direct-apply** — each step writes through its existing **audited** service
+  (``SettingsMutationPipeline`` / ``moderation`` / ``welcome`` settings), so the
+  change is live the instant you press the button.  No new mutation primitives.
+* **Plain language** — the operator never reads "guild", "binding", "draft",
+  "operation".  (Enforced by ``scripts/check_setup_copy.py``.)
+
+This module is **additive** — the existing wizard (``views/setup/wizard.py``)
+is untouched and remains the full/advanced path; Essential Setup is the new
+quick spine.  This first installment ships the flow framework + the two
+highest-value steps (greet new members · set moderators) + the summary; the
+remaining steps (block spam · log channel · rewards · help desk) are mechanical
+follow-ons on this same pattern.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import discord
+
+from views.base import BaseView
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Flow state
+# ---------------------------------------------------------------------------
+
+
+class EssentialFlow:
+    """Ordered list of steps + where the operator is in it.
+
+    Holds no Discord objects beyond the author + guild; each step view is built
+    fresh from the flow when the operator moves, so there is no stale-component
+    state to manage.
+    """
+
+    def __init__(
+        self,
+        author: discord.Member,
+        guild: discord.Guild,
+    ) -> None:
+        self.author = author
+        self.guild = guild
+        self.index = 0
+        self.applied: list[str] = []
+        self.skipped: list[str] = []
+        # Step factories, in order. Add new steps here as they are built.
+        self._steps: list[Callable[[EssentialFlow], _StepView]] = [
+            GreetMembersStep,
+            ModeratorsStep,
+        ]
+
+    @property
+    def total(self) -> int:
+        return len(self._steps)
+
+    @property
+    def done(self) -> bool:
+        return self.index >= self.total
+
+    def current_view(self) -> BaseView:
+        if self.done:
+            return EssentialSummaryView(self)
+        return self._steps[self.index](self)
+
+    def step_counter(self) -> str:
+        return f"Step {self.index + 1} of {self.total}"
+
+    def advance(self) -> None:
+        self.index += 1
+
+    def back(self) -> None:
+        if self.index > 0:
+            self.index -= 1
+
+    def record_applied(self, line: str) -> None:
+        self.applied.append(line)
+
+    def record_skipped(self, line: str) -> None:
+        self.skipped.append(line)
+
+
+# ---------------------------------------------------------------------------
+# Nav buttons (shared)
+# ---------------------------------------------------------------------------
+
+
+class _BackButton(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self, row: int) -> None:
+        super().__init__(label="Back", style=discord.ButtonStyle.secondary, row=row)
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: _StepView = self.view  # type: ignore[assignment]
+        await view.go_back(interaction)
+
+
+class _SkipButton(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self, row: int, label: str) -> None:
+        super().__init__(label=label, style=discord.ButtonStyle.secondary, row=row)
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: _StepView = self.view  # type: ignore[assignment]
+        await view.skip(interaction)
+
+
+# ---------------------------------------------------------------------------
+# Step base
+# ---------------------------------------------------------------------------
+
+
+class _StepView(BaseView):
+    """One step. Subclasses add their pickers + a Save button and a render()."""
+
+    skip_label = "Skip this step"
+
+    def __init__(self, flow: EssentialFlow) -> None:
+        super().__init__(flow.author, public=False, timeout=600)
+        self.flow = flow
+        self.build_items()
+        if flow.index > 0:
+            self.add_item(_BackButton(row=3))
+        self.add_item(_SkipButton(row=3, label=self.skip_label))
+
+    # --- subclass hooks ---
+    def build_items(self) -> None:  # pragma: no cover - trivial in subclasses
+        raise NotImplementedError
+
+    def render(self) -> discord.Embed:  # pragma: no cover - trivial in subclasses
+        raise NotImplementedError
+
+    # --- navigation (shared) ---
+    async def _show_current(self, interaction: discord.Interaction) -> None:
+        view = self.flow.current_view()
+        embed = view.render() if hasattr(view, "render") else None
+        await interaction.response.edit_message(embed=embed, view=view)
+
+    async def skip(self, interaction: discord.Interaction) -> None:
+        self.flow.advance()
+        await self._show_current(interaction)
+
+    async def go_back(self, interaction: discord.Interaction) -> None:
+        self.flow.back()
+        await self._show_current(interaction)
+
+    async def complete(
+        self,
+        interaction: discord.Interaction,
+        summary_line: str,
+    ) -> None:
+        """Record the applied change and advance to the next step."""
+        self.flow.record_applied(summary_line)
+        self.flow.advance()
+        await self._show_current(interaction)
+
+    async def _set(self, subsystem: str, name: str, value: object) -> None:
+        """Apply one setting immediately through the audited pipeline.
+
+        Imported lazily: setup view files must not import concrete mutation
+        pipelines at module top level (``test_setup_operations_invariants``).
+        """
+        from services.settings_mutation import SettingsMutationPipeline
+
+        await SettingsMutationPipeline().set_value(
+            self.flow.guild,
+            subsystem,
+            name,
+            value,
+            self.flow.author,
+            actor_type="user",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — Greet new members  (welcome)
+# ---------------------------------------------------------------------------
+
+
+class _WelcomeChannelSelect(discord.ui.ChannelSelect):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Where should the welcome message appear?",
+            channel_types=[discord.ChannelType.text],
+            min_values=1,
+            max_values=1,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: GreetMembersStep = self.view  # type: ignore[assignment]
+        view.channel_id = self.values[0].id
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class _EntryRoleSelect(discord.ui.RoleSelect):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Give newcomers a role (optional)…",
+            min_values=0,
+            max_values=1,
+            row=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: GreetMembersStep = self.view  # type: ignore[assignment]
+        view.entry_role_id = self.values[0].id if self.values else None
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class _GreetSaveButton(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            label="Turn on greetings",
+            emoji="👋",
+            style=discord.ButtonStyle.success,
+            row=2,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: GreetMembersStep = self.view  # type: ignore[assignment]
+        await view.apply(interaction)
+
+
+class GreetMembersStep(_StepView):
+    title = "Greet new members"
+    skip_label = "Skip greetings"
+
+    def __init__(self, flow: EssentialFlow) -> None:
+        self.channel_id: int | None = None
+        self.entry_role_id: int | None = None
+        super().__init__(flow)
+
+    def build_items(self) -> None:
+        self.add_item(_WelcomeChannelSelect())
+        self.add_item(_EntryRoleSelect())
+        self.add_item(_GreetSaveButton())
+
+    def render(self) -> discord.Embed:
+        embed = discord.Embed(
+            title=f"👋 {self.title}",
+            description=(
+                "Send a friendly message when someone joins, and (if you like) "
+                "give every newcomer a role automatically.\n\n"
+                "Pick a channel for the welcome message below, then press "
+                "**Turn on greetings**."
+            ),
+            color=discord.Color.blurple(),
+        )
+        chan = f"<#{self.channel_id}>" if self.channel_id else "_not chosen yet_"
+        role = f"<@&{self.entry_role_id}>" if self.entry_role_id else "_none_"
+        embed.add_field(name="Welcome message channel", value=chan, inline=False)
+        embed.add_field(name="Role for newcomers", value=role, inline=False)
+        embed.set_footer(text=self.flow.step_counter())
+        return embed
+
+    async def apply(self, interaction: discord.Interaction) -> None:
+        if self.channel_id is None:
+            await interaction.response.send_message(
+                "Pick a **channel** for the welcome message first.",
+                ephemeral=True,
+            )
+            return
+        try:
+            await self._set("welcome", "enabled", True)
+            await self._set("welcome", "join_enabled", True)
+            await self._set("welcome", "channel", str(self.channel_id))
+            if self.entry_role_id is not None:
+                await self._set("welcome", "entry_role", str(self.entry_role_id))
+        except Exception:
+            logger.exception("essential setup: greet step apply failed")
+            await interaction.response.send_message(
+                "Something went wrong turning on greetings — please try again.",
+                ephemeral=True,
+            )
+            return
+        line = f"Greetings on, posting in <#{self.channel_id}>"
+        if self.entry_role_id is not None:
+            line += f" · newcomers get <@&{self.entry_role_id}>"
+        await self.complete(interaction, line)
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — Set moderators  (governance / moderation defaults)
+# ---------------------------------------------------------------------------
+
+
+class _ModRoleSelect(discord.ui.RoleSelect):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Which role can warn and remove people?",
+            min_values=1,
+            max_values=1,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: ModeratorsStep = self.view  # type: ignore[assignment]
+        view.mod_role_id = self.values[0].id
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class _DmToggleButton(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self, on: bool) -> None:
+        super().__init__(
+            label=("Tell members why: ON" if on else "Tell members why: OFF"),
+            style=(
+                discord.ButtonStyle.success if on else discord.ButtonStyle.secondary
+            ),
+            row=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: ModeratorsStep = self.view  # type: ignore[assignment]
+        view.dm_on = not view.dm_on
+        view.refresh_items()
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class _ModSaveButton(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            label="Save moderators",
+            emoji="🛡️",
+            style=discord.ButtonStyle.success,
+            row=2,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: ModeratorsStep = self.view  # type: ignore[assignment]
+        await view.apply(interaction)
+
+
+class ModeratorsStep(_StepView):
+    title = "Set your moderators"
+    skip_label = "Skip moderators"
+
+    def __init__(self, flow: EssentialFlow) -> None:
+        self.mod_role_id: int | None = None
+        self.dm_on: bool = True
+        super().__init__(flow)
+
+    def build_items(self) -> None:
+        self.refresh_items()
+
+    def refresh_items(self) -> None:
+        """(Re)build the row-0/1/2 controls — used after the DM toggle flips."""
+        for child in list(self.children):
+            if isinstance(child, (_ModRoleSelect, _DmToggleButton, _ModSaveButton)):
+                self.remove_item(child)
+        self.add_item(_ModRoleSelect())
+        self.add_item(_DmToggleButton(self.dm_on))
+        self.add_item(_ModSaveButton())
+
+    def render(self) -> discord.Embed:
+        embed = discord.Embed(
+            title=f"🛡️ {self.title}",
+            description=(
+                "Choose the role for people who can warn and remove others. "
+                "We'll use safe defaults for everything else.\n\n"
+                "“Tell members why” sends someone a short note when they're "
+                "warned or removed, so they know what happened."
+            ),
+            color=discord.Color.blurple(),
+        )
+        role = f"<@&{self.mod_role_id}>" if self.mod_role_id else "_not chosen yet_"
+        embed.add_field(name="Moderator role", value=role, inline=False)
+        embed.add_field(
+            name="Tell members why",
+            value="On" if self.dm_on else "Off",
+            inline=False,
+        )
+        embed.set_footer(text=self.flow.step_counter())
+        return embed
+
+    async def apply(self, interaction: discord.Interaction) -> None:
+        if self.mod_role_id is None:
+            await interaction.response.send_message(
+                "Pick a **moderator role** first.",
+                ephemeral=True,
+            )
+            return
+        try:
+            await self._set("moderation", "moderator_role", str(self.mod_role_id))
+            await self._set("moderation", "dm_on_action", self.dm_on)
+        except Exception:
+            logger.exception("essential setup: moderators step apply failed")
+            await interaction.response.send_message(
+                "Something went wrong saving your moderators — please try again.",
+                ephemeral=True,
+            )
+            return
+        await self.complete(
+            interaction,
+            f"Moderator role set to <@&{self.mod_role_id}>"
+            + (" · members told why" if self.dm_on else ""),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Summary (after the last step)
+# ---------------------------------------------------------------------------
+
+
+class _FinishButton(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            label="All done",
+            emoji="✅",
+            style=discord.ButtonStyle.success,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: EssentialSummaryView = self.view  # type: ignore[assignment]
+        for child in view.children:
+            child.disabled = True  # type: ignore[attr-defined]
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class EssentialSummaryView(BaseView):
+    """Closing screen — a plain-language recap of what was switched on."""
+
+    def __init__(self, flow: EssentialFlow) -> None:
+        super().__init__(flow.author, public=False, timeout=600)
+        self.flow = flow
+        self.add_item(_FinishButton())
+
+    def render(self) -> discord.Embed:
+        embed = discord.Embed(
+            title="✅ Setup complete",
+            description="Here's what you switched on. You can change any of it later.",
+            color=discord.Color.green(),
+        )
+        if self.flow.applied:
+            embed.add_field(
+                name="Turned on",
+                value="\n".join(f"• {line}" for line in self.flow.applied),
+                inline=False,
+            )
+        else:
+            embed.description = (
+                "You skipped every step — nothing was changed. "
+                "Run setup again any time."
+            )
+        if self.flow.skipped:
+            embed.add_field(
+                name="Skipped (you can do these later)",
+                value="\n".join(f"• {line}" for line in self.flow.skipped),
+                inline=False,
+            )
+        return embed
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+_NOT_IN_SERVER = "This can only be used in a server."
+_NOT_ADMIN = "Only a server admin can run setup."
+
+
+def _first_embed(flow: EssentialFlow) -> discord.Embed:
+    return flow.current_view().render()  # type: ignore[attr-defined,no-any-return]
+
+
+async def open_essential_setup(interaction: discord.Interaction) -> None:
+    """Open the Essential Setup flow from a slash command. Admin-gated."""
+    guild = interaction.guild
+    member = interaction.user
+    if guild is None or not isinstance(member, discord.Member):
+        await interaction.response.send_message(_NOT_IN_SERVER, ephemeral=True)
+        return
+    if not member.guild_permissions.administrator:
+        await interaction.response.send_message(_NOT_ADMIN, ephemeral=True)
+        return
+    flow = EssentialFlow(member, guild)
+    await interaction.response.send_message(
+        embed=_first_embed(flow),
+        view=flow.current_view(),
+    )
+
+
+async def open_essential_setup_prefix(ctx: object) -> None:
+    """Open the Essential Setup flow from a prefix command. Admin-gated.
+
+    ``ctx`` is a ``commands.Context`` (typed loosely so this view module does
+    not import the ``commands`` extension).
+    """
+    guild = getattr(ctx, "guild", None)
+    member = getattr(ctx, "author", None)
+    send = ctx.send  # type: ignore[attr-defined]
+    if guild is None or not isinstance(member, discord.Member):
+        await send(_NOT_IN_SERVER)
+        return
+    if not member.guild_permissions.administrator:
+        await send(_NOT_ADMIN)
+        return
+    flow = EssentialFlow(member, guild)
+    await send(embed=_first_embed(flow), view=flow.current_view())

--- a/docs/architecture/extension-taxonomy-crosswalk.md
+++ b/docs/architecture/extension-taxonomy-crosswalk.md
@@ -5,7 +5,7 @@
 > `architecture_rules/extension_roles.yaml`. Sources: `disbot/config.py` (`INITIAL_EXTENSIONS`),
 > `disbot/utils/subsystem_registry.py` (`SUBSYSTEMS`), and that overlay. `--check` guards staleness.
 
-_Generator:_ `scripts/extension_crosswalk.py` `v1`  ·  **55** extensions  ·  **42** registered subsystems  ·  **13** non-1:1 extensions.
+_Generator:_ `scripts/extension_crosswalk.py` `v1`  ·  **56** extensions  ·  **42** registered subsystems  ·  **14** non-1:1 extensions.
 
 Every loaded extension classified by **role** (editorial — in `architecture_rules/extension_roles.yaml`) and joined to the registry. A ✓ in *Registered* means the extension is a 1:1 subsystem identity; the non-1:1 rows are surfaces/maintenance/adapters that **back** a subsystem or the platform.
 
@@ -13,7 +13,7 @@ Every loaded extension classified by **role** (editorial — in `architecture_ru
 
 | Role | Count | Meaning |
 |---|---:|---|
-| `bootstrap` | 2 | Load-order / lifecycle-critical admission or setup; sensitive to INITIAL_EXTENSIONS ordering. |
+| `bootstrap` | 3 | Load-order / lifecycle-critical admission or setup; sensitive to INITIAL_EXTENSIONS ordering. |
 | `hub` | 3 | A routing/composition layer that surfaces other subsystems; owns little or no domain state of its own. |
 | `lab` | 1 | A development / UX laboratory surface; not a production product surface. |
 | `maintenance` | 3 | A background-loop cog (scheduled work) with no subsystem identity; runtime/ops, not a product surface. |
@@ -78,9 +78,10 @@ Every loaded extension classified by **role** (editorial — in `architecture_ru
 | 50 | `ticket` | `product_subsystem` | ✓ |  | Support tickets — private channels, claim/close/transcript; opens by command, panel, or AI. |
 | 51 | `security` | `product_subsystem` | ✓ |  | Security tiers 1+2 — raid detection + account-age filter (Q-0111). |
 | 52 | `setup` | `bootstrap` | — | `server_management` | Guided setup wizard; lifecycle-critical, load-order sensitive. |
-| 53 | `server_management` | `hub` | ✓ |  | Routing-only hub (moderation/channels/roles/cleanup/setup); holds no capability of its own. |
-| 54 | `hermes` | `operational_adapter` | — |  | Bridge to the Hermes control plane / external operation. |
-| 55 | `ux_lab` | `lab` | ✓ |  | Zero-write UX pattern gallery (admin-gated); design vocabulary, not a product surface. |
+| 53 | `quicksetup` | `bootstrap` | — | `server_management` | Essential Setup front door (!quicksetup / /quicksetup); thin command surface over views.setup.essential_setup (the plain-language spine). |
+| 54 | `server_management` | `hub` | ✓ |  | Routing-only hub (moderation/channels/roles/cleanup/setup); holds no capability of its own. |
+| 55 | `hermes` | `operational_adapter` | — |  | Bridge to the Hermes control plane / external operation. |
+| 56 | `ux_lab` | `lab` | ✓ |  | Zero-write UX pattern gallery (admin-gated); design vocabulary, not a product surface. |
 
 ## Non-1:1 extensions (no registry identity)
 
@@ -98,4 +99,5 @@ These load as extensions but are **not** registered subsystems — they are clas
 - `paragon` (`specialized_surface` → backs `btd6`) — BTD6 paragon grounding surface.
 - `btd6_ops` (`specialized_surface` → backs `btd6`) — BTD6 data-ops (seed/refresh); operational flavor within the BTD6 vertical.
 - `setup` (`bootstrap` → backs `server_management`) — Guided setup wizard; lifecycle-critical, load-order sensitive.
+- `quicksetup` (`bootstrap` → backs `server_management`) — Essential Setup front door (!quicksetup / /quicksetup); thin command surface over views.setup.essential_setup (the plain-language spine).
 - `hermes` (`operational_adapter`) — Bridge to the Hermes control plane / external operation.

--- a/docs/help-command-surface-map.md
+++ b/docs/help-command-surface-map.md
@@ -23,14 +23,16 @@ Post-PR-#142 routing summary (relevant to every row in §2):
   routes call the host cog's `build_help_menu_view` hook for hub +
   subsystem destinations and fall back to a command-list embed only
   when the hook is missing or raises.
-- 41 of the 55 loaded extensions (`config.INITIAL_EXTENSIONS`) define
+- 41 of the 56 loaded extensions (`config.INITIAL_EXTENSIONS`) define
   `build_help_menu_view` — equivalently, 41 of the 42 subsystem-owning
-  cogs expose it. The 14 extensions without the hook: the bootstrap
+  cogs expose it. The 15 extensions without the hook: the bootstrap
   access guard (not a Help surface), `help_cog` itself (it IS the Help
   surface), the five split BTD6 support cogs (`btd6_reference` /
   `btd6_events` / `btd6_strategy` / `paragon` / `btd6_ops` — their
   commands route under the one `btd6` subsystem via `btd6_cog`'s hook),
   `setup_cog` (an orchestrator with no `SUBSYSTEMS` row),
+  `quicksetup_cog` (the Essential Setup front door `!quicksetup` —
+  no subsystem row),
   `hermes_cog` (the Hermes→Claude dispatch bridge — admin-only slash
   commands, no subsystem row), `media_maintenance_cog` (the YouTube
   cache-retention task owner — no commands, no subsystem row),
@@ -92,9 +94,9 @@ so every feature is reachable in ≤ 3 clicks with no paginated-Advanced detour.
 ## 2. Subsystem inventory
 
 42 registered subsystems in `utils/subsystem_registry.py` (one row
-each below); 55 loaded extensions in `config.INITIAL_EXTENSIONS` (the
+each below); 56 loaded extensions in `config.INITIAL_EXTENSIONS` (the
 extension↔subsystem mapping is many-to-one — see the routing summary
-above for the 14 extensions without a hook). Every subsystem's host cog
+above for the 15 extensions without a hook). Every subsystem's host cog
 defines `build_help_menu_view` except `help` itself, so the Help route
 resolver opens a real panel for every subsystem except `help`, and only
 falls back to the command-list embed when the hook is missing or raises.

--- a/docs/operations/env-vars.md
+++ b/docs/operations/env-vars.md
@@ -27,20 +27,20 @@ only — never a value**; the values live in Railway service variables
 
 | Variable | Layers | Usages |
 |---|---|---|
-| `AI_DEFAULT_PROVIDER` | config, core | `disbot/config.py:169` *(default)*<br>`disbot/core/runtime/ai/feature_flags.py:66` *(default)* |
-| `AI_ENABLED` | config | `disbot/config.py:168` *(default)* |
+| `AI_DEFAULT_PROVIDER` | config, core | `disbot/config.py:170` *(default)*<br>`disbot/core/runtime/ai/feature_flags.py:66` *(default)* |
+| `AI_ENABLED` | config | `disbot/config.py:169` *(default)* |
 | `AI_FALLBACK_PROVIDER` | core | `disbot/core/runtime/ai/routing.py:128` *(default)* |
-| `ANTHROPIC_API_KEY` | config, core | `disbot/config.py:152` *(default)*<br>`disbot/core/runtime/ai/providers/anthropic_provider.py:93` *(default)* |
+| `ANTHROPIC_API_KEY` | config, core | `disbot/config.py:153` *(default)*<br>`disbot/core/runtime/ai/providers/anthropic_provider.py:93` *(default)* |
 | `AUTOMATION_SCHEDULER_ENABLED` | services | `disbot/services/automation_scheduler.py:397` *(default)* |
-| `AUTO_SYNC_COMMANDS` | config | `disbot/config.py:215` *(default)* |
+| `AUTO_SYNC_COMMANDS` | config | `disbot/config.py:216` *(default)* |
 | `BOT_OWNER_USER_ID` | config | `disbot/config.py:40` *(default)* |
 | `BOT_PREFIX` | config | `disbot/config.py:28` *(default)* |
-| `BTD6_AUTO_SEED` | config | `disbot/config.py:207` *(default)* |
+| `BTD6_AUTO_SEED` | config | `disbot/config.py:208` *(default)* |
 | `BTD6_CONFIDENCE_THRESHOLD` | cogs | `disbot/cogs/btd6/stage.py:94` *(default)* |
 | `BTD6_COOLDOWN_SECONDS` | cogs | `disbot/cogs/btd6/stage.py:102` *(default)* |
-| `BTD6_DATA_BACKEND` | config | `disbot/config.py:195` *(default)* |
-| `BTD6_DATA_BASE_URL` | config | `disbot/config.py:198` *(default)* |
-| `BTD6_DATA_CACHE_DIR` | config | `disbot/config.py:201` *(default)* |
+| `BTD6_DATA_BACKEND` | config | `disbot/config.py:196` *(default)* |
+| `BTD6_DATA_BASE_URL` | config | `disbot/config.py:199` *(default)* |
+| `BTD6_DATA_CACHE_DIR` | config | `disbot/config.py:202` *(default)* |
 | `BTD6_INGESTION_DEFAULT_INTERVAL_S` | services | `disbot/services/btd6_ingestion_supervisor.py:35` *(default)* |
 | `BTD6_INGESTION_ENABLED` | services | `disbot/services/btd6_ingestion_supervisor.py:32` *(default)* |
 | `BTD6_INGESTION_STARTUP_DELAY_S` | services | `disbot/services/btd6_ingestion_supervisor.py:34` *(default)* |
@@ -50,18 +50,18 @@ only — never a value**; the values live in Railway service variables
 | `CLAUDE_ROUTINE_TOKEN` | cogs | `disbot/cogs/hermes_cog.py:50` *(default)* |
 | `CLAUDE_ROUTINE_VERSION` | cogs | `disbot/cogs/hermes_cog.py:52` *(default)* |
 | `CONTROL_API_TOKEN` | control_api | `disbot/control_api.py:111` *(default)* |
-| `DISCORD_WEBHOOK_URL` | config | `disbot/config.py:114` *(default)* |
+| `DISCORD_WEBHOOK_URL` | config | `disbot/config.py:115` *(default)* |
 | `HEALTH_GROUPED_FINDINGS` | services | `disbot/services/health_snapshot_service.py:267` *(default)* |
 | `HEALTH_HOST` | healthserver | `disbot/healthserver.py:70` *(default)* |
 | `HEALTH_PORT` | healthserver | `disbot/healthserver.py:64` *(default)* |
 | `IDENTITY_CONTRACT_STRICT` | bot1 | `disbot/bot1.py:175` *(default)* |
-| `LOG_LEVEL` | config | `disbot/config.py:115` *(default)* |
-| `OPENAI_API_KEY` | config, core, services | `disbot/config.py:151` *(default)*<br>`disbot/core/runtime/ai/providers/openai_moderation.py:68` *(default)*<br>`disbot/core/runtime/ai/providers/openai_provider.py:74` *(default)*<br>`disbot/services/setup_ai_advisor.py:205` *(default)*<br>`disbot/services/setup_ai_advisor.py:485` *(default)* |
-| `PARAGON_API_BASE_URL` | config, services | `disbot/config.py:178` *(default)*<br>`disbot/services/paragon_service.py:49` *(default)* |
-| `PARAGON_API_KEY` | config, services | `disbot/config.py:182` *(default)*<br>`disbot/services/paragon_service.py:50` *(default)* |
+| `LOG_LEVEL` | config | `disbot/config.py:116` *(default)* |
+| `OPENAI_API_KEY` | config, core, services | `disbot/config.py:152` *(default)*<br>`disbot/core/runtime/ai/providers/openai_moderation.py:68` *(default)*<br>`disbot/core/runtime/ai/providers/openai_provider.py:74` *(default)*<br>`disbot/services/setup_ai_advisor.py:205` *(default)*<br>`disbot/services/setup_ai_advisor.py:485` *(default)* |
+| `PARAGON_API_BASE_URL` | config, services | `disbot/config.py:179` *(default)*<br>`disbot/services/paragon_service.py:49` *(default)* |
+| `PARAGON_API_KEY` | config, services | `disbot/config.py:183` *(default)*<br>`disbot/services/paragon_service.py:50` *(default)* |
 | `RAILWAY_GIT_COMMIT_SHA` | core | `disbot/core/runtime/command_manifest.py:243` *(default)* |
-| `SETUP_ADVISOR_OPENAI_MODEL` | config, services | `disbot/config.py:150` *(default)*<br>`disbot/services/setup_ai_advisor.py:203` *(default)* |
-| `SETUP_ADVISOR_PROVIDER` | config, core, services | `disbot/config.py:149` *(default)*<br>`disbot/core/runtime/ai/feature_flags.py:129` *(default)*<br>`disbot/services/setup_ai_advisor.py:472` *(default)* |
+| `SETUP_ADVISOR_OPENAI_MODEL` | config, services | `disbot/config.py:151` *(default)*<br>`disbot/services/setup_ai_advisor.py:203` *(default)* |
+| `SETUP_ADVISOR_PROVIDER` | config, core, services | `disbot/config.py:150` *(default)*<br>`disbot/core/runtime/ai/feature_flags.py:129` *(default)*<br>`disbot/services/setup_ai_advisor.py:472` *(default)* |
 | `STRICT_DISABLED` | bot1 | `disbot/bot1.py:172` *(default)* |
 
 <!-- END GENERATED — everything below is hand-maintained (web-tier env vars the disbot scanner can't see); the scanner preserves it across --write-doc. -->

--- a/docs/owner/claims/claude-serene-mccarthy-lv5z94.md
+++ b/docs/owner/claims/claude-serene-mccarthy-lv5z94.md
@@ -1,0 +1,1 @@
+claude/serene-mccarthy-lv5z94 · BUILD setup-wizard essentials spine (PR 1): linear direct-apply flow, plain language, auto-create · disbot/views/setup/ + disbot/cogs/setup/ + tests/ · 2026-06-24

--- a/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
+++ b/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
@@ -162,12 +162,20 @@ decision with architectural weight → called out as open question Q-A below.
   This is the Q-A-independent half of the copy cleanup; the structural jargon (`stage`/`draft`/`final
   review`/`operation`, the remaining ~154) is reworded *as part of* the spine rebuild (PR 1), since its
   wording depends on the direct-apply vs. Final-Review decision (Q-A).
-- **PR 1 — the essentials spine (the headline):** a new linear wizard flow (`views/setup/`) rendering
-  steps 0–7 above with plain-language copy, **direct-apply** per step, button/dropdown-only input, and
-  **auto-create** for the welcome channel, log channels, and reward roles. Add the two missing steps
-  (welcome, automod) using their existing config services (`welcome_config`, `automod_config`) — no new
-  mutation primitives. Ships a wizard a non-technical owner can finish. Each cleaned section lowers the
-  PR-1a jargon baseline (`_BASELINE_TOTAL`) toward zero.
+- **PR 1 — the essentials spine (the headline). Owner greenlit + Q-A answered "save each step
+  instantly" (direct lane), 2026-06-24.** Installment 1 SHIPPED: `disbot/views/setup/essential_setup.py`
+  — a new **linear, plain-language, direct-apply** flow (`EssentialFlow` + per-step `BaseView`s with
+  Save/Skip/Back + "Step X of N"), opened by a new **`!quicksetup` / `/quicksetup`** cog
+  (`cogs/quicksetup_cog.py`, admin-gated, server-only). Two highest-value steps live end-to-end —
+  **Greet new members** (welcome enabled/join/channel/entry-role) and **Set your moderators** (mod role +
+  DM-on-action) — each writing through the audited `SettingsMutationPipeline` immediately (no draft, no
+  Final Review), plus an **All-done summary**. Additive: the old wizard is untouched (retired in PR 3).
+  Jargon-clean (guard: new file adds 0 findings). **Remaining steps are mechanical follow-ons on this
+  exact pattern:** block spam (`automod` toggles) · choose log channel (binding + auto-create) · reward
+  activity (xp + role-threshold — needs a small direct-apply role-threshold service) · help desk (reuse
+  `ticket_mutation`) · server-type starter preset (needs a direct-apply preset path — currently
+  draft-only). Auto-create channels/roles (`ChannelLifecycleService`/`RoleLifecycleService`) folds into
+  the channel/reward steps.
 - **PR 2 — extras + health check:** the **Extras menu** (each existing config surface as a one-action
   step: starboard, counters, security, image-mod, karma, AI, reaction roles, giveaways) + the single
   **"Check my setup"** health button (folds in scan/readiness/diagnostics/suggestions). Wires the

--- a/docs/setup-platform/settings-customization-command-map.md
+++ b/docs/setup-platform/settings-customization-command-map.md
@@ -98,7 +98,8 @@ role product, no subsystem row), `creature_battle_cog` (the creature PvP
 `!cbattle` command — part of the Creatures subsystem, surfaced via
 `creature_cog`'s hook, no subsystem row), `starboard_cog` (the Starboard /
 Hall-of-Fame raw-reaction listener + the `!starboard` config command — no
-subsystem row), `setup_cog` (the setup wizard surface), and the
+subsystem row), `setup_cog` (the setup wizard surface), `quicksetup_cog`
+(the Essential Setup front door `!quicksetup`, no subsystem row), and the
 five split BTD6 cogs (`btd6_reference_cog`, `btd6_events_cog`,
 `btd6_strategy_cog`, `paragon_cog`, `btd6_ops_cog`), which all surface under
 the single `btd6` subsystem. (Counts re-verified against source 2026-06-21;

--- a/scripts/check_dashboard_data.py
+++ b/scripts/check_dashboard_data.py
@@ -74,6 +74,10 @@ _UNREGISTERED_COG_ALLOWLIST = frozenset(
         # Temp-role expiry sweep + the !temprole grant command; backs the role
         # product but registers no subsystem of its own (reaction-roles PR 4).
         "RoleGrantsCog",
+        # Essential Setup front door (!quicksetup / /quicksetup) — a thin command
+        # surface over views.setup.essential_setup; like SetupCog it backs the
+        # setup/server_management surface but registers no subsystem of its own.
+        "QuickSetupCog",
         "SetupCog",
         # Starboard / Hall-of-Fame raw-reaction listener + the !starboard config
         # command (idea B1); registers no subsystem of its own.

--- a/tests/unit/runtime/test_command_surface_ledger.py
+++ b/tests/unit/runtime/test_command_surface_ledger.py
@@ -1043,6 +1043,7 @@ EXPECTED_SLASH_SURFACE: dict[str, str | None] = {
     "moderation": None,
     "myprofile": None,
     "platform": None,
+    "quicksetup": None,  # Essential Setup front door (plain-language spine)
     "server-management": None,
     "settings": None,
     "setup": None,

--- a/tests/unit/views/setup/test_essential_setup.py
+++ b/tests/unit/views/setup/test_essential_setup.py
@@ -1,0 +1,199 @@
+"""Tests for Essential Setup — the plain-language, direct-apply setup spine.
+
+Pins:
+* Flow navigation: advance / back / current_view / step counter / summary.
+* Each step applies its config IMMEDIATELY through the audited
+  ``SettingsMutationPipeline`` (direct lane) — and refuses (no write) until the
+  required pick is made.
+* The entry point is admin-gated and server-only.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from views.setup import essential_setup as es
+
+
+def _member(admin: bool = True):
+    return SimpleNamespace(
+        id=99,
+        guild_permissions=SimpleNamespace(administrator=admin),
+    )
+
+
+def _guild(gid: int = 1):
+    return SimpleNamespace(id=gid, name="Test")
+
+
+def _interaction():
+    interaction = MagicMock()
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.edit_message = AsyncMock()
+    return interaction
+
+
+@pytest.fixture
+def pipeline():
+    # The pipeline is imported lazily inside the step (setup views must not
+    # import mutation pipelines at top level), so patch it at its source.
+    with patch("services.settings_mutation.SettingsMutationPipeline") as cls:
+        cls.return_value.set_value = AsyncMock()
+        yield cls.return_value
+
+
+# ---------------------------------------------------------------------------
+# Flow
+# ---------------------------------------------------------------------------
+
+
+def test_flow_counter_and_navigation():
+    flow = es.EssentialFlow(_member(), _guild())
+    assert flow.total == 2
+    assert flow.step_counter() == "Step 1 of 2"
+    assert isinstance(flow.current_view(), es.GreetMembersStep)
+
+    flow.advance()
+    assert flow.step_counter() == "Step 2 of 2"
+    assert isinstance(flow.current_view(), es.ModeratorsStep)
+
+    flow.advance()
+    assert flow.done
+    assert isinstance(flow.current_view(), es.EssentialSummaryView)
+
+    flow.back()
+    assert isinstance(flow.current_view(), es.ModeratorsStep)
+
+
+def test_first_step_has_no_back_button():
+    flow = es.EssentialFlow(_member(), _guild())
+    step = es.GreetMembersStep(flow)
+    assert not any(isinstance(c, es._BackButton) for c in step.children)
+    # the second step does get a Back button
+    flow.advance()
+    step2 = es.ModeratorsStep(flow)
+    assert any(isinstance(c, es._BackButton) for c in step2.children)
+
+
+# ---------------------------------------------------------------------------
+# Greet members
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_greet_requires_channel_before_applying(pipeline):
+    flow = es.EssentialFlow(_member(), _guild())
+    step = es.GreetMembersStep(flow)
+    interaction = _interaction()
+
+    await step.apply(interaction)
+
+    pipeline.set_value.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+    assert "channel" in interaction.response.send_message.await_args.args[0].lower()
+    assert flow.index == 0  # did not advance
+
+
+@pytest.mark.asyncio
+async def test_greet_applies_welcome_settings_and_advances(pipeline):
+    flow = es.EssentialFlow(_member(), _guild())
+    step = es.GreetMembersStep(flow)
+    step.channel_id = 555
+    step.entry_role_id = 777
+    interaction = _interaction()
+
+    await step.apply(interaction)
+
+    # enabled + join_enabled + channel + entry_role = 4 immediate writes
+    assert pipeline.set_value.await_count == 4
+    subsystems = {c.args[1] for c in pipeline.set_value.await_args_list}
+    names = {c.args[2] for c in pipeline.set_value.await_args_list}
+    assert subsystems == {"welcome"}
+    assert {"enabled", "join_enabled", "channel", "entry_role"} == names
+    assert flow.index == 1  # advanced
+    assert flow.applied and "555" in flow.applied[0]
+
+
+@pytest.mark.asyncio
+async def test_greet_without_role_writes_three_settings(pipeline):
+    flow = es.EssentialFlow(_member(), _guild())
+    step = es.GreetMembersStep(flow)
+    step.channel_id = 555
+    await step.apply(_interaction())
+    assert pipeline.set_value.await_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Moderators
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_moderators_requires_role(pipeline):
+    flow = es.EssentialFlow(_member(), _guild())
+    step = es.ModeratorsStep(flow)
+    interaction = _interaction()
+    await step.apply(interaction)
+    pipeline.set_value.assert_not_awaited()
+    assert flow.index == 0
+
+
+@pytest.mark.asyncio
+async def test_moderators_applies_role_and_dm(pipeline):
+    flow = es.EssentialFlow(_member(), _guild())
+    step = es.ModeratorsStep(flow)
+    step.mod_role_id = 4242
+    await step.apply(_interaction())
+    assert pipeline.set_value.await_count == 2
+    calls = {(c.args[1], c.args[2]) for c in pipeline.set_value.await_args_list}
+    assert ("moderation", "moderator_role") in calls
+    assert ("moderation", "dm_on_action") in calls
+    assert flow.index == 1
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+
+def test_summary_lists_applied_changes():
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.record_applied("Greetings on")
+    flow.record_applied("Moderator role set")
+    embed = es.EssentialSummaryView(flow).render()
+    blob = (embed.description or "") + " ".join(f.value for f in embed.fields)
+    assert "Greetings on" in blob
+    assert "Moderator role set" in blob
+
+
+# ---------------------------------------------------------------------------
+# Entry gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_entry_rejects_dm():
+    interaction = _interaction()
+    interaction.guild = None
+    interaction.user = _member()
+    await es.open_essential_setup(interaction)
+    interaction.response.send_message.assert_awaited_once()
+    assert "server" in interaction.response.send_message.await_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_entry_rejects_non_admin():
+    interaction = _interaction()
+    interaction.guild = _guild()
+    member = MagicMock()
+    member.guild_permissions.administrator = False
+    interaction.user = member
+    # isinstance(member, discord.Member) must hold for the admin branch; patch it.
+    with patch.object(es.discord, "Member", MagicMock):
+        await es.open_essential_setup(interaction)
+    interaction.response.send_message.assert_awaited_once()
+    assert "admin" in interaction.response.send_message.await_args.args[0].lower()


### PR DESCRIPTION
## What

**PR 1 of the setup-wizard restructure** (#1418) — the **essentials spine**, owner-greenlit in chat with **Q-A answered: "save each step instantly"** (direct lane). Installment 1: the flow framework + the two highest-value steps working end-to-end.

`disbot/views/setup/essential_setup.py` — a new **linear, plain-language, direct-apply** setup flow:
- `EssentialFlow` (ordered steps + position) + per-step `BaseView`s with **Save / Skip / Back** and a **"Step X of N"** counter — one screen at a time, buttons/dropdowns only, **no jargon**.
- **Each step applies immediately** through the audited `SettingsMutationPipeline` (lazy import per the setup-views invariant) — no draft, no Final Review.
- Two steps live: **Greet new members** (welcome enabled/join/channel/optional entry-role) and **Set your moderators** (mod role + "tell members why" DM toggle), plus an **All-done summary**.
- `cogs/quicksetup_cog.py` — `!quicksetup` / `/quicksetup` entry (admin-gated, server-only), registered in `INITIAL_EXTENSIONS`. Its own cog because `setup_cog` is at the 800-LOC ceiling.

## Why this shape

Answers the owner's brief directly: each step is **one complete action that finishes for real**, zero Discord/bot knowledge needed, plain language (the jargon guard confirms the new file adds **0** findings). Reuses existing audited services — **no new mutation primitives**.

## Additive & safe

The existing wizard (`views/setup/wizard.py`) is **untouched** and remains the full/advanced path (retired later in PR 3). The remaining spine steps (block spam · log channel · rewards · help desk · server-type preset) are mechanical follow-ons on this exact pattern, noted in the plan.

## Verification

10 new flow tests; 457 invariants green (cog-size, setup-views-no-top-level-pipeline-import, reachability/identity for the new cog); mypy + lint + arch strict + docs clean. Full suite running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJiSiWF242E5ShFS5Gq41R)_