### PR TITLE
Gate !syncslash global through the diff-aware auto-sync helper (+ force escape)

### DIFF
--- a/.sessions/2026-06-24-syncslash-gated-unification.md
+++ b/.sessions/2026-06-24-syncslash-gated-unification.md
@@ -1,35 +1,101 @@
 # 2026-06-24 — Route `!syncslash global` through the diff-gated auto-sync helper
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Goal (dispatch run, self-initiated idea→ship promotion, Q-0172)
 
-Empty scheduled fire → advance a real plan slice. Promoting the **previous
+Empty scheduled fire → advance a real plan slice. Promoted the **previous
 session's Q-0089 session idea** (`.sessions/2026-06-24-command-tree-auto-sync.md`),
 which survives the sniff test: **route the manual `!syncslash global` through the
 new diff-gated `command_tree_sync.auto_sync_if_changed`** instead of an
 unconditional `tree.sync()`.
 
-Why it's worth shipping:
-- Retires the **last unconditional global `tree.sync()`** in the codebase — one
-  implementation, one place to reason about the global-sync rate limit.
-- Gives operators a **live-vs-local diff preview** ("+N added / -M removed")
-  before/instead of burning a sync, and a clean "already in sync — skipped"
-  outcome.
-- Adds an explicit **`force`** escape (`!syncslash global force`) for "sync
-  anyway" (param/description-only changes the path-diff deliberately misses).
+## What shipped (PR #1426)
 
-Contained, reversible, test-covered. The guild/clear scopes are unrelated
-(guild-local `copy_global_to` / `clear`) and stay as-is.
+**Slice 1 — gated `!syncslash global` (runtime + tests).**
+- `!syncslash global` now flows through `command_tree_sync.auto_sync_if_changed`
+  (the same helper the #1424 startup auto-sync uses): fetch live global commands,
+  diff command *paths* vs the local tree, and only `tree.sync()` when they differ.
+  Reports the `+N added / -M removed` diff (with a short path preview) or a clean
+  "already in sync — nothing to do".
+- New **`force`** modifier (`!syncslash global force`) → the old unconditional
+  `tree.sync()`, for parameter/description-only edits the conservative path-diff
+  deliberately misses. This **retires the last unconditional global sync** — one
+  implementation, one place to reason about Discord's global-sync rate limit.
+- The `guild` / `clear` scopes (guild-local `copy_global_to` / `clear`) are
+  unrelated and untouched.
+- **Decomposition:** extracted the global-sync logic + operator-message rendering
+  to `cogs/admin/_slash_sync.py` (`run_global_sync` / `format_sync_diff`), matching
+  the `cog_manager.py` pattern, to keep `admin_cog.py` under the S4.6 800-LOC
+  ceiling (the cog was already at ~787 LOC; inlining would have broken the
+  `test_cog_size_under_fail_threshold` invariant — caught locally, fixed at the
+  root rather than bumping the ceiling). Cog now 788 LOC.
 
-## Plan
-- [ ] Route `!syncslash global` through `auto_sync_if_changed`; report the
-      SyncOutcome (synced / unchanged / fetch_failed / sync_failed) with the diff.
-- [ ] Add a `force` modifier → unconditional `tree.sync()` (the old behaviour,
-      explicit) for cosmetic-only changes.
-- [ ] Tests for both branches + the unchanged/failed outcomes.
-- [ ] `check_quality --full` green + arch strict.
+**Slice 2 — operator docs.** `docs/operations/production-deployment.md` "How code
+reaches production" now documents that **slash-command propagation is automatic**
+(#1424) — no manual `!syncslash` post-deploy — with the gated manual command +
+`force` escape as the backstop. (Outside the active docs-reconciliation claim's
+scope: that claim covers `current-state*.md` + `planning/` + `ideas/` + dashboard.)
 
-## ⚑ Self-initiated (Q-0172)
-Promoted the previous run's Q-0089 idea (manual-sync unification) to a build with
-no dispatch/owner ask. Reversible; flagged here for owner review.
+## Status checklist
+- [x] `cogs/admin/_slash_sync.py` — gated `run_global_sync` + `format_sync_diff`
+- [x] `admin_cog.sync_slash_commands` — `force` modifier, thin call, under 800 LOC
+- [x] Tests (23): both branches + every SyncOutcome reason (synced/unchanged/
+      fetch_failed/sync_failed) + the `force` unconditional path + its HTTP failure
+- [x] `docs/operations/production-deployment.md` auto-sync note
+- [x] `check_quality --full` green (12441 passed) + arch strict (0 errors) + lint/docs
+- [x] Flip card → auto-merge
+
+## Handoff / continuation (next dispatch)
+This slice is **self-contained and complete** — no remaining sub-step. The active
+queue is unchanged; pick the next S1 ▶ startable item (current-state/S1-bot.md):
+Project Moon runtime PR 1, botsite React-SPA migration PR 2, or the visual
+card-engine H3 tail (rank/profile hub panels reached via Help). Note: the
+setup-wizard spine (PR #1425) merged this session; its remaining spine steps
+(block spam · log channel · rewards · help desk · server-type preset) are
+turn-key follow-ons on the `essential_setup.py` pattern.
+
+## 💡 Session idea (Q-0089)
+**A `!slashes diff` subcommand (read-only) that prints the live-vs-local command
+path delta without syncing.** The gated `auto_sync_if_changed` already computes
+`added`/`removed`; a pure read-only diff view (no `tree.sync()`) would let an
+operator *see* whether a deploy propagated correctly before deciding to `force`,
+and would make the "is the tree in sync?" question answerable without the
+side-effect-bearing `!syncslash`. Small — it reuses `_local_paths`/`_remote_paths`
++ `format_sync_diff`. Worth an idea file if it survives next session's sniff test.
+
+## ⟲ Previous-session review (Q-0102)
+Previous in-chain: #1424 (startup command-tree auto-sync). **Did well:** it
+shipped the diff-gated helper *and* flagged the manual-sync unification as a clean
+Q-0089 idea — which is exactly why this session could pick it up turn-key (the
+idea→ship loop working as designed). **Could improve:** #1424 left the manual
+`!syncslash global` doing an unconditional `tree.sync()` while introducing a gated
+helper right next to it — a one-session inconsistency where the obviously-better
+shape was already in hand. **System improvement:** when a PR introduces a "safe"
+helper that an *existing* command duplicates unsafely, prefer routing the existing
+command through it **in the same PR** when it's small (this was ~60 LOC) — the
+"capture as an idea for next session" path is correct for bigger lifts, but a tiny
+adjacent unification is cheaper to finish than to hand off. (Counter-weight: the
+born-red/claim machinery makes a same-session follow-up cheap, so this is a soft
+preference, not a rule.)
+
+## 📝 Doc audit (Q-0104)
+- `check_quality --full` green; `check_architecture --mode strict` 0 errors.
+- The auto-sync/`force` behaviour is documented in two durable homes: the
+  `_slash_sync.py` module docstring + `docs/operations/production-deployment.md`.
+- Owner decision: none — this is a self-initiated idea→ship promotion (Q-0172),
+  flagged below; no new router Q.
+- Ledger: PR #1426 in-flight; `current-state.md` is under the active
+  `claude-jolly-johnson` reconciliation claim, so this session does not edit it
+  (its next pass records #1425/#1426). `check_current_state_ledger --strict` shows
+  only benign newest-merge lag.
+
+## 📤 Run report
+- **Run type:** routine · dispatch
+- **What:** gated `!syncslash global` (diff-aware, + `force` escape) + the
+  auto-sync deployment-doc note; PR #1426.
+- **⚑ Self-initiated (Q-0172):** promoted the previous run's Q-0089 idea
+  (manual-sync unification) to a build with no dispatch/owner ask — reversible,
+  flagged for owner review.
+- **⚑ Owner-decisions:** none
+- **⚑ Owner-manual-steps:** none

--- a/.sessions/2026-06-24-syncslash-gated-unification.md
+++ b/.sessions/2026-06-24-syncslash-gated-unification.md
@@ -1,0 +1,35 @@
+# 2026-06-24 — Route `!syncslash global` through the diff-gated auto-sync helper
+
+> **Status:** `in-progress`
+
+## Goal (dispatch run, self-initiated idea→ship promotion, Q-0172)
+
+Empty scheduled fire → advance a real plan slice. Promoting the **previous
+session's Q-0089 session idea** (`.sessions/2026-06-24-command-tree-auto-sync.md`),
+which survives the sniff test: **route the manual `!syncslash global` through the
+new diff-gated `command_tree_sync.auto_sync_if_changed`** instead of an
+unconditional `tree.sync()`.
+
+Why it's worth shipping:
+- Retires the **last unconditional global `tree.sync()`** in the codebase — one
+  implementation, one place to reason about the global-sync rate limit.
+- Gives operators a **live-vs-local diff preview** ("+N added / -M removed")
+  before/instead of burning a sync, and a clean "already in sync — skipped"
+  outcome.
+- Adds an explicit **`force`** escape (`!syncslash global force`) for "sync
+  anyway" (param/description-only changes the path-diff deliberately misses).
+
+Contained, reversible, test-covered. The guild/clear scopes are unrelated
+(guild-local `copy_global_to` / `clear`) and stay as-is.
+
+## Plan
+- [ ] Route `!syncslash global` through `auto_sync_if_changed`; report the
+      SyncOutcome (synced / unchanged / fetch_failed / sync_failed) with the diff.
+- [ ] Add a `force` modifier → unconditional `tree.sync()` (the old behaviour,
+      explicit) for cosmetic-only changes.
+- [ ] Tests for both branches + the unchanged/failed outcomes.
+- [ ] `check_quality --full` green + arch strict.
+
+## ⚑ Self-initiated (Q-0172)
+Promoted the previous run's Q-0089 idea (manual-sync unification) to a build with
+no dispatch/owner ask. Reversible; flagged here for owner review.

--- a/disbot/cogs/admin/_slash_sync.py
+++ b/disbot/cogs/admin/_slash_sync.py
@@ -1,0 +1,72 @@
+"""Global slash-tree sync rendering for ``!syncslash global``.
+
+Extracted from ``cogs/admin_cog.py`` to keep that file under the S4.6 800-LOC
+ceiling. The module owns the *logic + operator-message rendering* for the
+``global`` scope; the cog method stays a thin "run it and send the string".
+
+The default (un-forced) global path flows through the diff-gated
+:func:`services.command_tree_sync.auto_sync_if_changed` — the same helper the
+startup auto-sync uses — so a manual sync only burns a (rate-limited) global
+sync when the command *paths* actually changed, and previews the diff. ``force``
+keeps the old unconditional ``tree.sync()`` for parameter/description-only
+changes the conservative path-diff deliberately misses.
+"""
+
+from __future__ import annotations
+
+import discord
+
+from services import command_tree_sync
+
+
+def format_sync_diff(
+    added: tuple[str, ...],
+    removed: tuple[str, ...],
+) -> str:
+    """One-line ``+N added / -M removed`` summary with a short path preview."""
+    summary = f"+{len(added)} added, -{len(removed)} removed"
+    preview = list(added[:5]) + [f"-{p}" for p in removed[:5]]
+    if preview:
+        summary += " — " + ", ".join(f"`{p}`" for p in preview)
+    return summary
+
+
+async def run_global_sync(bot: object, *, force: bool) -> str:
+    """Sync (or diff-check) the global command tree and return the operator
+    message to display. Never raises — a sync failure is rendered as text.
+    """
+    tree = bot.tree  # type: ignore[attr-defined]
+
+    if force:
+        try:
+            synced = await tree.sync()
+        except discord.HTTPException as exc:
+            return f"⚠️ Global sync failed: `{type(exc).__name__}`: {exc}"
+        return (
+            f"✅ Force-synced **{len(synced)}** slash commands globally. "
+            "Propagation may take up to an hour."
+        )
+
+    outcome = await command_tree_sync.auto_sync_if_changed(bot, enabled=True)
+    if outcome.reason == "fetch_failed":
+        return (
+            "⚠️ Couldn't fetch the live command list from Discord (logged). "
+            "Try again, or `!syncslash global force` to sync anyway."
+        )
+    if outcome.reason == "unchanged":
+        return (
+            "✅ Global command tree already in sync — nothing to do. "
+            "(Use `!syncslash global force` to resync param/description-only "
+            "changes the path diff doesn't see.)"
+        )
+
+    diff = format_sync_diff(outcome.added, outcome.removed)
+    if outcome.reason == "sync_failed":
+        return (
+            f"⚠️ The tree changed ({diff}) but `tree.sync()` failed (logged). "
+            "Try again shortly."
+        )
+    return (
+        f"✅ Synced global slash commands ({diff}). "
+        "Propagation may take up to an hour."
+    )

--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -6,6 +6,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from cogs.admin import _slash_sync
 from cogs.admin.cog_manager import (  # noqa: F401 — re-exported for back-compat (callers may import here)
     COGS_DIR,
     _all_cog_modules,
@@ -199,6 +200,7 @@ class AdminCog(commands.Cog):
         self,
         ctx: commands.Context,
         scope: str = "guild",
+        modifier: str = "",
     ) -> None:
         """Sync the app-command tree for slash commands (owner only).
 
@@ -211,14 +213,24 @@ class AdminCog(commands.Cog):
 
             !syncslash             # sync this guild (default — fast)
             !syncslash guild       # sync this guild (explicit)
-            !syncslash global      # sync globally — rate-limited;
-                                   #   propagation can take up to 1 h
+            !syncslash global      # sync globally IFF the tree changed —
+                                   #   previews the diff, skips when in sync
+            !syncslash global force  # sync globally unconditionally (cosmetic
+                                     #   param/description-only changes)
             !syncslash clear       # remove this guild's command COPIES
 
         ``guild`` scope is the right choice in almost every case:
         Discord rate-limits global sync, and per-guild sync makes
         new commands appear immediately. ``global`` is only needed
         if the bot deploys to a guild that hasn't seen the tree yet.
+
+        The ``global`` path now flows through the same diff-gated helper as the
+        startup auto-sync (``command_tree_sync.auto_sync_if_changed``): it fetches
+        the live global commands, compares command *paths* to the local tree, and
+        only calls ``tree.sync()`` when they differ — reporting the add/remove
+        diff or a clean "already in sync". The path-diff deliberately misses
+        parameter/description-only edits (Discord normalises option payloads), so
+        ``global force`` keeps the old unconditional sync for those cosmetic cases.
 
         **Do not run ``guild`` and ``global`` for the same environment.**
         A command synced *both* globally and into a guild renders **twice**
@@ -233,17 +245,11 @@ class AdminCog(commands.Cog):
             return
 
         if scope == "global":
-            try:
-                synced = await self.bot.tree.sync()
-            except discord.HTTPException as exc:
-                await ctx.send(
-                    f"⚠️ Global sync failed: `{type(exc).__name__}`: {exc}",
-                )
-                return
-            await ctx.send(
-                f"✅ Synced **{len(synced)}** slash commands globally. "
-                "Propagation may take up to an hour.",
+            message = await _slash_sync.run_global_sync(
+                self.bot,
+                force=modifier.lower() == "force",
             )
+            await ctx.send(message)
             return
 
         guild = ctx.guild

--- a/docs/operations/production-deployment.md
+++ b/docs/operations/production-deployment.md
@@ -40,6 +40,15 @@
 - **Builder:** [railpack](https://railpack.com) (v0.27.x at write time). It detects
   Python + pip, creates `/app/.venv`, runs `pip install -r requirements.txt`, and
   starts the `worker` command from the **`Procfile`**: `python disbot/bot1.py`.
+- **Slash-command propagation is automatic (#1424).** On boot the bot diff-checks its
+  local app-command tree against Discord's live global commands and only calls
+  `tree.sync()` when the command *paths* changed — so a deploy that adds/removes/renames
+  a slash command propagates on its own, **with no manual `!syncslash`**. (Kill-switch:
+  `AUTO_SYNC_COMMANDS=0`.) The manual command stays the backstop: `!syncslash global`
+  previews the live-vs-local diff and syncs only if it changed, and `!syncslash global
+  force` resyncs unconditionally for parameter/description-only edits the conservative
+  path-diff deliberately misses (`!syncslash guild` is still the instant per-guild dev
+  refresh). So slash propagation is **not** a maintainer post-deploy step.
 
 ## Python version — pinned, and why
 

--- a/docs/owner/claims/claude-funny-franklin-bv7u0u.md
+++ b/docs/owner/claims/claude-funny-franklin-bv7u0u.md
@@ -1,0 +1,1 @@
+claude/funny-franklin-bv7u0u · route manual !syncslash global through the diff-gated auto_sync helper (retire last unconditional tree.sync) + diff preview + force escape · disbot/cogs/admin_cog.py, disbot/services/command_tree_sync.py, tests · 2026-06-24

--- a/docs/owner/claims/claude-funny-franklin-bv7u0u.md
+++ b/docs/owner/claims/claude-funny-franklin-bv7u0u.md
@@ -1,1 +1,0 @@
-claude/funny-franklin-bv7u0u · route manual !syncslash global through the diff-gated auto_sync helper (retire last unconditional tree.sync) + diff preview + force escape · disbot/cogs/admin_cog.py, disbot/services/command_tree_sync.py, tests · 2026-06-24

--- a/tests/unit/cogs/test_admin_slash_sync.py
+++ b/tests/unit/cogs/test_admin_slash_sync.py
@@ -18,13 +18,14 @@ Pins:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
 from discord.ext import commands
 
 from cogs.admin_cog import AdminCog
+from services.command_tree_sync import SyncOutcome
 
 
 def _ctx(*, guild: bool = True) -> MagicMock:
@@ -47,6 +48,7 @@ def _admin_cog() -> AdminCog:
     bot.tree.copy_global_to = MagicMock()
     bot.tree.clear_commands = MagicMock()
     bot.tree.get_commands = MagicMock(return_value=[])
+    bot.tree.fetch_commands = AsyncMock(return_value=[])
     return AdminCog(bot=bot)
 
 
@@ -113,28 +115,123 @@ async def test_syncslash_explicit_guild_scope():
 
 
 # ---------------------------------------------------------------------------
-# !syncslash — global scope
+# !syncslash — global scope (now diff-gated through auto_sync_if_changed)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_syncslash_global_scope_calls_sync_without_guild():
+async def test_syncslash_global_default_goes_through_gated_helper():
+    """Plain ``global`` routes through the diff-gated helper, not an
+    unconditional ``tree.sync()``."""
     cog = _admin_cog()
-    cog.bot.tree.sync.return_value = [_fake_command("help")]
     ctx = _ctx()
+    outcome = SyncOutcome(
+        synced=True,
+        reason="synced",
+        added=("btd6 round",),
+        removed=("oldcmd",),
+    )
 
-    await cog.sync_slash_commands.callback(cog, ctx, "global")
+    with patch(
+        "cogs.admin._slash_sync.command_tree_sync.auto_sync_if_changed",
+        AsyncMock(return_value=outcome),
+    ) as helper:
+        await cog.sync_slash_commands.callback(cog, ctx, "global")
 
-    cog.bot.tree.sync.assert_awaited_once_with()
+    helper.assert_awaited_once_with(cog.bot, enabled=True)
     cog.bot.tree.copy_global_to.assert_not_called()
     args, kwargs = ctx.send.call_args
     msg = args[0] if args else kwargs.get("content", "")
-    assert "globally" in msg
+    assert "Synced global" in msg
+    assert "+1 added" in msg and "-1 removed" in msg
+    assert "`btd6 round`" in msg
     assert "Propagation" in msg
 
 
 @pytest.mark.asyncio
-async def test_syncslash_global_handles_http_failure():
+async def test_syncslash_global_unchanged_skips_with_message():
+    cog = _admin_cog()
+    ctx = _ctx()
+    outcome = SyncOutcome(synced=False, reason="unchanged")
+
+    with patch(
+        "cogs.admin._slash_sync.command_tree_sync.auto_sync_if_changed",
+        AsyncMock(return_value=outcome),
+    ):
+        await cog.sync_slash_commands.callback(cog, ctx, "global")
+
+    args, kwargs = ctx.send.call_args
+    msg = args[0] if args else kwargs.get("content", "")
+    assert "already in sync" in msg
+    assert "force" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_syncslash_global_fetch_failed_surfaces_message():
+    cog = _admin_cog()
+    ctx = _ctx()
+    outcome = SyncOutcome(synced=False, reason="fetch_failed")
+
+    with patch(
+        "cogs.admin._slash_sync.command_tree_sync.auto_sync_if_changed",
+        AsyncMock(return_value=outcome),
+    ):
+        await cog.sync_slash_commands.callback(cog, ctx, "global")
+
+    args, kwargs = ctx.send.call_args
+    msg = args[0] if args else kwargs.get("content", "")
+    assert "Couldn't fetch" in msg
+    assert "force" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_syncslash_global_sync_failed_reports_diff_and_failure():
+    cog = _admin_cog()
+    ctx = _ctx()
+    outcome = SyncOutcome(
+        synced=False,
+        reason="sync_failed",
+        added=("new",),
+        removed=(),
+    )
+
+    with patch(
+        "cogs.admin._slash_sync.command_tree_sync.auto_sync_if_changed",
+        AsyncMock(return_value=outcome),
+    ):
+        await cog.sync_slash_commands.callback(cog, ctx, "global")
+
+    args, kwargs = ctx.send.call_args
+    msg = args[0] if args else kwargs.get("content", "")
+    assert "failed" in msg.lower()
+    assert "+1 added" in msg
+
+
+@pytest.mark.asyncio
+async def test_syncslash_global_force_does_unconditional_sync():
+    """``global force`` bypasses the diff gate and always calls tree.sync()."""
+    cog = _admin_cog()
+    cog.bot.tree.sync.return_value = [_fake_command("help")]
+    ctx = _ctx()
+
+    with patch(
+        "cogs.admin._slash_sync.command_tree_sync.auto_sync_if_changed",
+        AsyncMock(),
+    ) as helper:
+        await cog.sync_slash_commands.callback(cog, ctx, "global", "force")
+
+    helper.assert_not_awaited()
+    cog.bot.tree.sync.assert_awaited_once_with()
+    cog.bot.tree.copy_global_to.assert_not_called()
+    args, kwargs = ctx.send.call_args
+    msg = args[0] if args else kwargs.get("content", "")
+    assert "Force-synced" in msg
+    assert "**1**" in msg
+    assert "Propagation" in msg
+
+
+@pytest.mark.asyncio
+async def test_syncslash_global_force_handles_http_failure():
     cog = _admin_cog()
     cog.bot.tree.sync.side_effect = discord.HTTPException(
         response=MagicMock(),
@@ -142,7 +239,7 @@ async def test_syncslash_global_handles_http_failure():
     )
     ctx = _ctx()
 
-    await cog.sync_slash_commands.callback(cog, ctx, "global")
+    await cog.sync_slash_commands.callback(cog, ctx, "global", "force")
 
     args, kwargs = ctx.send.call_args
     msg = args[0] if args else kwargs.get("content", "")


### PR DESCRIPTION
## What

Routes the manual **`!syncslash global`** path through the same diff-gated
`command_tree_sync.auto_sync_if_changed` helper the startup auto-sync uses
(#1424), instead of an unconditional `tree.sync()`. Promotes the previous
session's Q-0089 idea (self-initiated, Q-0172 — flagged on the run report).

## Why

- Retires the **last unconditional global `tree.sync()`** in the codebase — one
  implementation, one place to reason about Discord's global-sync rate limit.
- `!syncslash global` now **previews the live-vs-local diff** (`+N added /
  -M removed`) and reports a clean **"already in sync — skipped"** when nothing
  changed, rather than always burning a rate-limited global sync.
- Adds an explicit **`force`** escape (`!syncslash global force`) for the
  param/description-only changes the conservative path-diff deliberately misses
  — the old unconditional behaviour, now opt-in.

The `guild` / `clear` scopes are unrelated (guild-local `copy_global_to` /
`clear`) and are untouched.

## How (high-level)

`sync_slash_commands` parses an optional `force` token after `global`; the gated
branch calls `auto_sync_if_changed(self.bot, enabled=True)` and renders each
`SyncOutcome` reason (synced / unchanged / fetch_failed / sync_failed) with the
added/removed paths. `force` keeps the direct `tree.sync()` for cosmetic-only
resyncs.

## Verification

New unit tests cover both branches + every outcome reason; full CI mirror
(`check_quality.py --full`) + `check_architecture --mode strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMgM5vB5YoeMV6VizaLar5)_