### PR TITLE
Setup-wizard PR 1c: Essential Setup steps 3-4 (block spam · help desk)

### DIFF
--- a/.sessions/2026-06-24-essential-setup-steps-3-4.md
+++ b/.sessions/2026-06-24-essential-setup-steps-3-4.md
@@ -1,0 +1,13 @@
+# Session — 2026-06-24 · Essential Setup steps 3-4 (block spam · help desk)
+
+> **Status:** `in-progress` — born-red. Extending the merged Essential Setup spine (#1425) with two more
+> direct-apply steps. **No new cog / command / artifact** — pure additions to `EssentialFlow._steps`, so
+> none of the #1425 registration fan-out recurs. ⚑ Continuation of owner-greenlit spine build.
+
+## What I'm about to do
+
+Add **Block spam and bad links** (automod: enable + spam/invites/caps/mentions toggles, defaults on, via
+`SettingsMutationPipeline`) and **Set up a help desk** (tickets: staff-role + optional log channel via
+`ticket_mutation.update_config`) to the linear flow. Plain-language, each applies instantly. Tests mirror
+the existing `test_essential_setup.py`. Verify: jargon guard clean + essential-setup tests + the surface
+test set (cheap — no new cog) before push.

--- a/.sessions/2026-06-24-essential-setup-steps-3-4.md
+++ b/.sessions/2026-06-24-essential-setup-steps-3-4.md
@@ -1,13 +1,67 @@
 # Session — 2026-06-24 · Essential Setup steps 3-4 (block spam · help desk)
 
-> **Status:** `in-progress` — born-red. Extending the merged Essential Setup spine (#1425) with two more
-> direct-apply steps. **No new cog / command / artifact** — pure additions to `EssentialFlow._steps`, so
-> none of the #1425 registration fan-out recurs. ⚑ Continuation of owner-greenlit spine build.
+> **Status:** `complete` — two additive direct-apply steps. No new cog/command/artifact → no fan-out.
 
-## What I'm about to do
+**Trigger:** continuation of the owner-greenlit spine build, after PR #1425 (the spine framework + first
+two steps) merged. "Continue from where you left off" → the next logical increment is more steps.
 
-Add **Block spam and bad links** (automod: enable + spam/invites/caps/mentions toggles, defaults on, via
-`SettingsMutationPipeline`) and **Set up a help desk** (tickets: staff-role + optional log channel via
-`ticket_mutation.update_config`) to the linear flow. Plain-language, each applies instantly. Tests mirror
-the existing `test_essential_setup.py`. Verify: jargon guard clean + essential-setup tests + the surface
-test set (cheap — no new cog) before push.
+## What shipped
+
+Two new steps on the existing `EssentialFlow`, same direct-apply pattern as #1425:
+
+- **Block spam and bad links** — enables automod with four filters (repeated spam · invite links ·
+  ALL-CAPS · mass pings), each a toggle (default on); applies immediately via `SettingsMutationPipeline`
+  (5 writes: `enabled` + the four `*_enabled`). Defaults are sensible; the operator can deselect any.
+- **Set up a help desk** — staff-role pick (required) + optional log channel; applies via the audited
+  `ticket_mutation.update_config` (lazy import, direct lane), mirroring the existing ticket section.
+
+The spine is now **4 live steps** (greet · moderators · block spam · help desk) + summary. Updated the
+flow-nav test (total 2→4) and added 4 new step tests. Module docstring refreshed. Jargon guard stays
+154 (new copy adds 0). Plan/claim updated.
+
+## The contrast with #1425 (the point worth recording)
+
+#1425 (adding a **cog**) triggered an ~8-layer registration fan-out (cog-size ceiling · no-top-level
+pipeline import · 4 generated artifacts · dashboard cog→subsystem resolution · slash-surface ledger · 2
+hand-maintained docs) — each surfaced one CI round at a time because the background full-suite outputs
+truncated. **This session — adding only view classes (no cog/command/artifact) — has none of that.** That
+confirms the cost model: the fan-out is *per new cog/command*, not per feature. The remaining spine steps
+all extend `EssentialFlow` the same way, so they stay cheap.
+
+## 💡 Session idea (Q-0089)
+
+**A `pytest` marker `@pytest.mark.surface` (or a `tests/surface/` convention) over the ~42 cog/command-
+enumeration test files** I grepped together last session (dashboard, crosswalk, surface ledgers, doc
+counts, reachability/identity). Then `pytest -m surface` (≈60s) is the *one command* that verifies the
+entire "add a cog/command" fan-out class before pushing — collapsing #1425's multi-round CI discovery into
+a single pre-push gate. Pairs with the prior idea (a new-cog checklist); this is its executable half.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous `.sessions/` log: the **spine build (#1425)**. Did well: built the right architecture (a clean
+data-driven-ish `EssentialFlow` + per-step `BaseView`s) that made *this* session trivial — adding 2 steps
+was ~200 lines with zero structural change. What it cost: 6+ CI rounds chasing the cog-registration
+fan-out, because it didn't enumerate the fan-out up front and the background suite hid failures.
+**System improvement (acted on):** I grepped the *entire* surface-test set and ran it in one pass before
+pushing this time — and as predicted there was nothing to chase (no new cog). The durable fix is the
+`-m surface` marker above so the next person doesn't re-derive the grep.
+
+## 📋 Doc audit (Q-0104)
+
+Module docstring updated to 4 live steps; plan PR-1 note already describes the spine + follow-ons; no new
+command/cog/artifact so no ledger/crosswalk/dashboard regen owed; jargon guard 154 unchanged. No owner
+decision this session. No `current-state.md` entry until merge.
+
+## Context delta
+
+- **The flow scales cheaply.** Each remaining step = one `_StepView` subclass + its buttons + a test,
+  appended to `_steps`. No registration cost.
+- **For next session:** **Choose a log channel** (uses `BindingMutationPipeline` — note: that one IS on
+  the forbidden-top-level-import list, so lazy-import it like `_set` does for settings — plus
+  `ChannelLifecycleService` for auto-create) and **Reward activity** (xp toggle is easy; the role-
+  threshold sub-step needs a small new direct-apply service — the one genuine gap). Then the server-type
+  starter preset (needs a direct-apply preset path) and finally PR 3 (retire the old sections).
+
+## ⚑ Self-initiated: continuation of owner-greenlit work (the spine build the owner explicitly approved).
+Scoping (which 2 steps, deferring binding/auto-create + rewards) was my call. Additive, test-covered, old
+wizard untouched.

--- a/disbot/views/setup/essential_setup.py
+++ b/disbot/views/setup/essential_setup.py
@@ -19,10 +19,10 @@ Design (plan ``docs/planning/setup-wizard-restructure-plan-2026-06-24.md`` §5):
 
 This module is **additive** — the existing wizard (``views/setup/wizard.py``)
 is untouched and remains the full/advanced path; Essential Setup is the new
-quick spine.  This first installment ships the flow framework + the two
-highest-value steps (greet new members · set moderators) + the summary; the
-remaining steps (block spam · log channel · rewards · help desk) are mechanical
-follow-ons on this same pattern.
+quick spine.  Live steps: greet new members · set your moderators · block spam
+and bad links · set up a help desk (+ the closing summary).  Remaining
+follow-ons on this same pattern: choose a log channel (with auto-create),
+reward activity (xp + auto-role), and the server-type starter preset.
 """
 
 from __future__ import annotations
@@ -67,6 +67,8 @@ class EssentialFlow:
         self._steps: list[Callable[[EssentialFlow], _StepView]] = [
             GreetMembersStep,
             ModeratorsStep,
+            BlockSpamStep,
+            HelpDeskStep,
         ]
 
     @property
@@ -411,6 +413,221 @@ class ModeratorsStep(_StepView):
             interaction,
             f"Moderator role set to <@&{self.mod_role_id}>"
             + (" · members told why" if self.dm_on else ""),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — Block spam and bad links  (automod)
+# ---------------------------------------------------------------------------
+
+# (setting name, operator-facing label)
+_SPAM_FILTERS: list[tuple[str, str]] = [
+    ("spam_enabled", "Repeated spam"),
+    ("invites_enabled", "Invite links"),
+    ("caps_enabled", "ALL-CAPS shouting"),
+    ("mentions_enabled", "Mass pings"),
+]
+
+
+class _FilterToggle(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self, key: str, label: str, on: bool, row: int) -> None:
+        super().__init__(
+            label=f"{label}: {'ON' if on else 'OFF'}",
+            style=(
+                discord.ButtonStyle.success if on else discord.ButtonStyle.secondary
+            ),
+            row=row,
+        )
+        self._key = key
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: BlockSpamStep = self.view  # type: ignore[assignment]
+        view.filters[self._key] = not view.filters[self._key]
+        view.refresh_items()
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class _SpamSaveButton(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            label="Turn on protection",
+            emoji="🧹",
+            style=discord.ButtonStyle.success,
+            row=2,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: BlockSpamStep = self.view  # type: ignore[assignment]
+        await view.apply(interaction)
+
+
+class BlockSpamStep(_StepView):
+    title = "Block spam and bad links"
+    skip_label = "Skip spam protection"
+
+    def __init__(self, flow: EssentialFlow) -> None:
+        self.filters: dict[str, bool] = {key: True for key, _ in _SPAM_FILTERS}
+        super().__init__(flow)
+
+    def build_items(self) -> None:
+        self.refresh_items()
+
+    def refresh_items(self) -> None:
+        for child in list(self.children):
+            if isinstance(child, (_FilterToggle, _SpamSaveButton)):
+                self.remove_item(child)
+        for i, (key, label) in enumerate(_SPAM_FILTERS):
+            self.add_item(_FilterToggle(key, label, self.filters[key], row=i // 2))
+        self.add_item(_SpamSaveButton())
+
+    def render(self) -> discord.Embed:
+        embed = discord.Embed(
+            title=f"🧹 {self.title}",
+            description=(
+                "Automatically clean up the noise so you don't have to. "
+                "Everything below is on by default — tap any to turn it off, "
+                "then press **Turn on protection**."
+            ),
+            color=discord.Color.blurple(),
+        )
+        for key, label in _SPAM_FILTERS:
+            embed.add_field(
+                name=label,
+                value="On" if self.filters[key] else "Off",
+                inline=True,
+            )
+        embed.set_footer(text=self.flow.step_counter())
+        return embed
+
+    async def apply(self, interaction: discord.Interaction) -> None:
+        try:
+            await self._set("automod", "enabled", True)
+            for key, _ in _SPAM_FILTERS:
+                await self._set("automod", key, self.filters[key])
+        except Exception:
+            logger.exception("essential setup: block-spam step apply failed")
+            await interaction.response.send_message(
+                "Something went wrong turning on protection — please try again.",
+                ephemeral=True,
+            )
+            return
+        on_labels = [label for key, label in _SPAM_FILTERS if self.filters[key]]
+        line = "Spam protection on"
+        if on_labels:
+            line += " · " + ", ".join(on_labels).lower()
+        await self.complete(interaction, line)
+
+
+# ---------------------------------------------------------------------------
+# Step 4 — Set up a help desk  (tickets)
+# ---------------------------------------------------------------------------
+
+
+class _StaffRoleSelect(discord.ui.RoleSelect):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Who answers support requests? (staff role)",
+            min_values=1,
+            max_values=1,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: HelpDeskStep = self.view  # type: ignore[assignment]
+        view.staff_role_id = self.values[0].id
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class _TranscriptChannelSelect(discord.ui.ChannelSelect):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Where to save closed-request logs? (optional)",
+            channel_types=[discord.ChannelType.text],
+            min_values=1,
+            max_values=1,
+            row=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: HelpDeskStep = self.view  # type: ignore[assignment]
+        view.log_channel_id = self.values[0].id
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class _HelpDeskSaveButton(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            label="Turn on the help desk",
+            emoji="🎫",
+            style=discord.ButtonStyle.success,
+            row=2,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: HelpDeskStep = self.view  # type: ignore[assignment]
+        await view.apply(interaction)
+
+
+class HelpDeskStep(_StepView):
+    title = "Set up a help desk"
+    skip_label = "Skip help desk"
+
+    def __init__(self, flow: EssentialFlow) -> None:
+        self.staff_role_id: int | None = None
+        self.log_channel_id: int | None = None
+        super().__init__(flow)
+
+    def build_items(self) -> None:
+        self.add_item(_StaffRoleSelect())
+        self.add_item(_TranscriptChannelSelect())
+        self.add_item(_HelpDeskSaveButton())
+
+    def render(self) -> discord.Embed:
+        embed = discord.Embed(
+            title=f"🎫 {self.title}",
+            description=(
+                "Let members open a private request that only your staff can "
+                "see. Pick who should answer them; we set up the rest.\n\n"
+                "Then press **Turn on the help desk**."
+            ),
+            color=discord.Color.blurple(),
+        )
+        staff = (
+            f"<@&{self.staff_role_id}>" if self.staff_role_id else "_not chosen yet_"
+        )
+        log = f"<#{self.log_channel_id}>" if self.log_channel_id else "_none_"
+        embed.add_field(name="Who answers requests", value=staff, inline=False)
+        embed.add_field(name="Save chat logs to", value=log, inline=False)
+        embed.set_footer(text=self.flow.step_counter())
+        return embed
+
+    async def apply(self, interaction: discord.Interaction) -> None:
+        if self.staff_role_id is None:
+            await interaction.response.send_message(
+                "Pick a **staff role** first — it's who can see and answer requests.",
+                ephemeral=True,
+            )
+            return
+        try:
+            from services import ticket_mutation
+
+            await ticket_mutation.update_config(
+                self.flow.guild.id,
+                self.flow.author.id,
+                enabled=True,
+                staff_role_id=self.staff_role_id,
+                log_channel_id=self.log_channel_id,
+            )
+        except Exception:
+            logger.exception("essential setup: help-desk step apply failed")
+            await interaction.response.send_message(
+                "Something went wrong setting up the help desk — please try again.",
+                ephemeral=True,
+            )
+            return
+        await self.complete(
+            interaction,
+            f"Help desk on, answered by <@&{self.staff_role_id}>",
         )
 
 

--- a/docs/owner/claims/claude-serene-mccarthy-lv5z94.md
+++ b/docs/owner/claims/claude-serene-mccarthy-lv5z94.md
@@ -1,1 +1,0 @@
-claude/serene-mccarthy-lv5z94 · add 2 spine steps (block spam · help desk) to Essential Setup — no new cog · disbot/views/setup/essential_setup.py + tests · 2026-06-24

--- a/docs/owner/claims/claude-serene-mccarthy-lv5z94.md
+++ b/docs/owner/claims/claude-serene-mccarthy-lv5z94.md
@@ -1,1 +1,1 @@
-claude/serene-mccarthy-lv5z94 · BUILD setup-wizard essentials spine (PR 1): linear direct-apply flow, plain language, auto-create · disbot/views/setup/ + disbot/cogs/setup/ + tests/ · 2026-06-24
+claude/serene-mccarthy-lv5z94 · add 2 spine steps (block spam · help desk) to Essential Setup — no new cog · disbot/views/setup/essential_setup.py + tests · 2026-06-24

--- a/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
+++ b/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
@@ -166,16 +166,21 @@ decision with architectural weight → called out as open question Q-A below.
   instantly" (direct lane), 2026-06-24.** Installment 1 SHIPPED: `disbot/views/setup/essential_setup.py`
   — a new **linear, plain-language, direct-apply** flow (`EssentialFlow` + per-step `BaseView`s with
   Save/Skip/Back + "Step X of N"), opened by a new **`!quicksetup` / `/quicksetup`** cog
-  (`cogs/quicksetup_cog.py`, admin-gated, server-only). Two highest-value steps live end-to-end —
-  **Greet new members** (welcome enabled/join/channel/entry-role) and **Set your moderators** (mod role +
-  DM-on-action) — each writing through the audited `SettingsMutationPipeline` immediately (no draft, no
-  Final Review), plus an **All-done summary**. Additive: the old wizard is untouched (retired in PR 3).
-  Jargon-clean (guard: new file adds 0 findings). **Remaining steps are mechanical follow-ons on this
-  exact pattern:** block spam (`automod` toggles) · choose log channel (binding + auto-create) · reward
-  activity (xp + role-threshold — needs a small direct-apply role-threshold service) · help desk (reuse
-  `ticket_mutation`) · server-type starter preset (needs a direct-apply preset path — currently
-  draft-only). Auto-create channels/roles (`ChannelLifecycleService`/`RoleLifecycleService`) folds into
-  the channel/reward steps.
+  (`cogs/quicksetup_cog.py`, admin-gated, server-only). **Four steps live end-to-end** (each writes
+  through its audited service immediately — no draft, no Final Review — plus an **All-done summary**):
+  **Greet new members** (welcome) `#1425` · **Set your moderators** (moderation) `#1425` · **Block spam
+  and bad links** (automod toggles) `#1427` · **Set up a help desk** (`ticket_mutation`) `#1427`.
+  Additive: the old wizard is untouched (retired in PR 3). Jargon-clean (guard: the new file adds 0
+  findings). **Remaining steps are mechanical follow-ons on the exact same pattern — append a `_StepView`
+  subclass to `EssentialFlow._steps` + a test; no new cog/command/artifact, so no registration fan-out:**
+  - **Choose a log channel** *(next)* — a binding write via `BindingMutationPipeline` (⚠ on the
+    no-top-level-import list — **lazy-import it** inside the step, like `_set` does for settings) + an
+    optional **auto-create** via `ChannelLifecycleService.create_channels`.
+  - **Reward activity** — the `xp` enable toggle is trivial via `_set`; the role-threshold sub-step
+    **needs a small new direct-apply role-threshold service** (the one genuine gap — no direct-apply path
+    exists today) + `RoleLifecycleService.create_role` for auto-create.
+  - **Server-type starter preset** (step 0) — **needs a direct-apply preset path** (presets are
+    draft-only today); design decision before building.
 - **PR 2 — extras + health check:** the **Extras menu** (each existing config surface as a one-action
   step: starboard, counters, security, image-mod, karma, AI, reaction roles, giveaways) + the single
   **"Check my setup"** health button (folds in scan/readiness/diagnostics/suggestions). Wires the

--- a/tests/unit/views/setup/test_essential_setup.py
+++ b/tests/unit/views/setup/test_essential_setup.py
@@ -53,20 +53,24 @@ def pipeline():
 
 def test_flow_counter_and_navigation():
     flow = es.EssentialFlow(_member(), _guild())
-    assert flow.total == 2
-    assert flow.step_counter() == "Step 1 of 2"
-    assert isinstance(flow.current_view(), es.GreetMembersStep)
+    assert flow.total == 4
+    assert flow.step_counter() == "Step 1 of 4"
+    expected = [
+        es.GreetMembersStep,
+        es.ModeratorsStep,
+        es.BlockSpamStep,
+        es.HelpDeskStep,
+    ]
+    for i, cls in enumerate(expected):
+        assert flow.step_counter() == f"Step {i + 1} of 4"
+        assert isinstance(flow.current_view(), cls)
+        flow.advance()
 
-    flow.advance()
-    assert flow.step_counter() == "Step 2 of 2"
-    assert isinstance(flow.current_view(), es.ModeratorsStep)
-
-    flow.advance()
     assert flow.done
     assert isinstance(flow.current_view(), es.EssentialSummaryView)
 
     flow.back()
-    assert isinstance(flow.current_view(), es.ModeratorsStep)
+    assert isinstance(flow.current_view(), es.HelpDeskStep)
 
 
 def test_first_step_has_no_back_button():
@@ -153,6 +157,79 @@ async def test_moderators_applies_role_and_dm(pipeline):
     assert ("moderation", "moderator_role") in calls
     assert ("moderation", "dm_on_action") in calls
     assert flow.index == 1
+
+
+# ---------------------------------------------------------------------------
+# Block spam
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_block_spam_applies_automod_with_all_filters(pipeline):
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 2
+    step = es.BlockSpamStep(flow)
+    await step.apply(_interaction())
+    # enabled + 4 filters = 5 immediate writes, all to automod
+    assert pipeline.set_value.await_count == 5
+    subsystems = {c.args[1] for c in pipeline.set_value.await_args_list}
+    assert subsystems == {"automod"}
+    names = {c.args[2] for c in pipeline.set_value.await_args_list}
+    assert names == {
+        "enabled",
+        "spam_enabled",
+        "invites_enabled",
+        "caps_enabled",
+        "mentions_enabled",
+    }
+    assert flow.index == 3
+
+
+@pytest.mark.asyncio
+async def test_block_spam_respects_toggled_off_filter(pipeline):
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 2
+    step = es.BlockSpamStep(flow)
+    step.filters["caps_enabled"] = False
+    await step.apply(_interaction())
+    by_name = {c.args[2]: c.args[3] for c in pipeline.set_value.await_args_list}
+    assert by_name["caps_enabled"] is False
+    assert by_name["spam_enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# Help desk
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_help_desk_requires_staff_role():
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 3
+    step = es.HelpDeskStep(flow)
+    interaction = _interaction()
+    with patch("services.ticket_mutation.update_config", new=AsyncMock()) as upd:
+        await step.apply(interaction)
+    upd.assert_not_awaited()
+    assert flow.index == 3
+    assert "staff" in interaction.response.send_message.await_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_help_desk_enables_tickets_and_advances():
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 3
+    step = es.HelpDeskStep(flow)
+    step.staff_role_id = 321
+    step.log_channel_id = 654
+    with patch("services.ticket_mutation.update_config", new=AsyncMock()) as upd:
+        await step.apply(_interaction())
+    upd.assert_awaited_once()
+    kwargs = upd.await_args.kwargs
+    assert kwargs["enabled"] is True
+    assert kwargs["staff_role_id"] == 321
+    assert kwargs["log_channel_id"] == 654
+    assert flow.index == 4
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Extends the Essential Setup spine (merged in #1425) with **two more direct-apply steps**, on the proven pattern:

- **Block spam and bad links** (step 3) — enables automod with sensible defaults: spam, invite-link, excessive-caps, and mass-mention filters (each a toggle, default on). Applies immediately via `SettingsMutationPipeline`.
- **Set up a help desk** (step 4) — lets members open private support requests; pick a staff role (required) + optional transcript channel. Applies via the audited `ticket_mutation.update_config` (direct lane, like the existing ticket section).

Both are plain-language, button/dropdown-only, and **save the instant you press the button** (owner's Q-A choice).

## No fan-out this time

Unlike #1425, this adds **no new cog, command, extension, or generated artifact** — just two step classes appended to `EssentialFlow._steps`. So none of #1425's registration fan-out (cog-size, surface ledgers, dashboard/crosswalk/doc regen) recurs.

## Verification

New flow tests mirror `test_essential_setup.py`; jargon guard stays clean; lint/mypy/arch green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJiSiWF242E5ShFS5Gq41R)_