### PR TITLE
Essential Setup: "Choose a log channel" step (binding + auto-create)

### DIFF
--- a/.sessions/2026-06-24-setup-log-channel-step.md
+++ b/.sessions/2026-06-24-setup-log-channel-step.md
@@ -1,0 +1,23 @@
+# Session — 2026-06-24 · Essential Setup step "Choose a log channel"
+
+> **Status:** `in-progress` — born-red hold. Additive direct-apply step on the existing
+> `EssentialFlow`; no new cog/command/artifact → no registration fan-out.
+
+**Trigger:** owner-directed (chat, 2026-06-24): *"Continue the Essential Setup spine — add the
+'Choose a log channel' step (binding write via BindingMutationPipeline — lazy-import it; + optional
+auto-create via ChannelLifecycleService), per the PR-1 note in
+docs/planning/setup-wizard-restructure-plan-2026-06-24.md."* This is the next ▶ follow-on the
+steps-3-4 session left turn-key.
+
+## What I'm about to do
+
+Append a **"Choose a log channel"** `_StepView` to `EssentialFlow._steps`, inserted in plan order
+(after *Block spam*, before *Set up a help desk* — plan §5 step 4). One screen: pick an existing
+channel **or** toggle "make a #server-log for me", then Save. On Save it applies immediately
+(direct lane): turns on `logging.enabled` via the audited `SettingsMutationPipeline` and points all
+server-logging at the chosen channel by writing `logging.mod_channel` through
+`BindingMutationPipeline` (lazy-imported — it's on the setup-view no-top-level-import list). The
+auto-create path runs `ChannelLifecycleService.create_channels(["server-log"])` first, then binds the
+new channel. Plain-language copy (jargon guard stays 154 — new copy adds 0). + tests.
+
+<!-- close-out (what shipped / misses / enders / context delta) written as the final step -->

--- a/.sessions/2026-06-24-setup-log-channel-step.md
+++ b/.sessions/2026-06-24-setup-log-channel-step.md
@@ -1,23 +1,99 @@
 # Session — 2026-06-24 · Essential Setup step "Choose a log channel"
 
-> **Status:** `in-progress` — born-red hold. Additive direct-apply step on the existing
-> `EssentialFlow`; no new cog/command/artifact → no registration fan-out.
+> **Status:** `complete` — additive direct-apply step on the existing `EssentialFlow`; no new
+> cog/command/artifact → no registration fan-out. PR #1429.
 
 **Trigger:** owner-directed (chat, 2026-06-24): *"Continue the Essential Setup spine — add the
 'Choose a log channel' step (binding write via BindingMutationPipeline — lazy-import it; + optional
-auto-create via ChannelLifecycleService), per the PR-1 note in
-docs/planning/setup-wizard-restructure-plan-2026-06-24.md."* This is the next ▶ follow-on the
-steps-3-4 session left turn-key.
+auto-create via ChannelLifecycleService), per the PR-1 note."* The next ▶ follow-on the steps-3-4
+session left turn-key.
 
-## What I'm about to do
+## Open questions asked first (before building)
 
-Append a **"Choose a log channel"** `_StepView` to `EssentialFlow._steps`, inserted in plan order
-(after *Block spam*, before *Set up a help desk* — plan §5 step 4). One screen: pick an existing
-channel **or** toggle "make a #server-log for me", then Save. On Save it applies immediately
-(direct lane): turns on `logging.enabled` via the audited `SettingsMutationPipeline` and points all
-server-logging at the chosen channel by writing `logging.mod_channel` through
-`BindingMutationPipeline` (lazy-imported — it's on the setup-view no-top-level-import list). The
-auto-create path runs `ChannelLifecycleService.create_channels(["server-log"])` first, then binds the
-new channel. Plain-language copy (jargon guard stays 154 — new copy adds 0). + tests.
+A server error wiped my in-flight `AskUserQuestion`; the owner recovered the four questions from chat.
+Answers (now Q-0202 in the router + plan §10):
+1. **Log scope → moderation log only.** One channel: enable `logging.enabled` + bind
+   `logging.mod_channel` (the catch-all). Member/message activity deferred (NOT this step). This
+   superseded the plan §5 "pair" framing and forced a **copy fix** — my first draft promised
+   "joins, removals, edits", which the moderation-only scope does not deliver.
+2. **Auto-create name → plain-language `#mod-log`** (Q-D; not the `bot-`-prefixed `suggested_name`).
+3. **Step-0 server-type preset → auto-apply safe reversible defaults** (Q-C; future PR).
+4. **Advanced bulk editor → keep but REWORK** ("most of it does not do anything") — sharpens PR-3
+   scope from "demote" to "audit + wire-up-or-strip the dead actions" (Q-E).
 
-<!-- close-out (what shipped / misses / enders / context delta) written as the final step -->
+## What shipped
+
+- **`disbot/views/setup/essential_setup.py`** — new **`LogChannelStep`** on `EssentialFlow`, inserted
+  in plan order (after *Block spam*, before *Set up a help desk* → 4 steps becomes 5). One screen: pick
+  an existing channel **or** toggle "Make a #mod-log channel: ON" (mutually exclusive — picking clears
+  the toggle and vice-versa), then **Save log channel**. On Save (direct lane, applies immediately):
+  `logging.enabled = True` via `SettingsMutationPipeline`, then `logging.mod_channel` bound to the
+  channel via `BindingMutationPipeline`. Auto-create runs `ChannelLifecycleService.create_channels(
+  ["mod-log"])` first, then binds the new channel; a create failure surfaces an error and writes
+  nothing. Both `BindingMutationPipeline` (+ `BindingKind`) and `ChannelLifecycleService` are
+  **lazy-imported inside the step** per the setup-view no-top-level-pipeline-import invariant.
+- **Tests** (`tests/unit/views/setup/test_essential_setup.py`, 14 → 18): flow nav updated (4→5;
+  help-desk index 3→4); 4 new step tests — require-a-pick-or-create / bind-picked-channel /
+  auto-create-then-bind / create-failure-blocks.
+- **Docs**: plan §7 PR-1 note (step SHIPPED, moderation-only) + §5 step 4 + §10 (Q-C/Q-D/Q-E ANSWERED);
+  router **Q-0202** (the four decisions). Module docstring "Live steps" line refreshed.
+
+## Misses
+
+None of note — this was a clean view-class-only addition (the steps-3-4 session's prediction held:
+fan-out is per *cog/command*, not per feature). The one real catch was **self-caught**: my initial
+embed copy over-promised the log's contents before the owner pinned scope to moderation-only; surfacing
+the question first (rather than building on the §5 "pair" assumption) is what caught it.
+
+## ✅ Verification
+
+Full CI mirror green: `check_quality.py --full` → **12462 passed, 48 skipped, 2 xfailed**. Jargon guard
+**154 (0 new — `essential_setup.py` clean)**; `check_architecture --mode strict` no new violations;
+setup sim **PASS**; `check_docs --strict` passed; ledger `--strict` EXIT=0 (16 PRs are benign
+newest-merge lag past marker #1410, recorded by the #1440 recon pass — not drift).
+
+## 💡 Session idea (Q-0089)
+
+**Persist a pending `AskUserQuestion` batch into the born-red session card before calling it** — under
+an `⏸ Awaiting owner answers` heading (the questions + options verbatim). This session lost its
+in-flight questions to a server error and the *owner* had to recover them from chat by hand; a card
+write immediately before the tool call makes the exact questions recoverable from the repo after any
+context loss. Cheap (one write), directly motivated by today's failure, dedup-checked against
+`docs/ideas/` (the 3 `AskUserQuestion` hits are all decision-provenance mentions, not this). Genuinely
+believe in it.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous: **`2026-06-24-essential-setup-steps-3-4.md`**. **Did well:** its "Context delta / For next
+session" named *exactly* this step **with the `BindingMutationPipeline` lazy-import gotcha called out**
+— that handoff made my build frictionless and is the self-improving-workflow loop working as intended.
+**Missed:** it presented "Choose a log channel" as a purely *mechanical* follow-on, but the step
+actually carried an **unresolved scope decision** (the plan §5 "pair" vs the PR-1 note's singular "a
+binding write", plus moderation-vs-activity) — which is precisely what I had to stop and ask the owner
+about. **System improvement:** a handoff/plan that calls a step "turn-key" should cross-check it against
+the plan's own §10 open-questions; if the step touches an unresolved Q, label it **decision-bearing**,
+not mechanical, so the next agent asks *before* drafting copy/code on an assumption. (I caught it by
+asking; the durable fix is making that cross-check explicit in the handoff convention.)
+
+## 📋 Doc audit (Q-0104)
+
+`check_current_state_ledger.py --strict` EXIT=0; `check_docs --strict` passed. New owner decisions
+recorded in the router (Q-0202) and the plan §10. No `current-state.md` ledger entry until #1429 merges
+(it auto-merges on green; the next reconciliation pass at #1440 folds it into the living ledger). Plan
+"Build progress" + PR-1 note reflect the shipped step. Nothing from this session lives only in chat.
+
+## Context delta — for next session
+
+- **Spine is now 5 live steps** (greet · moderators · block spam · choose a log channel · help desk) +
+  summary. Each remaining step is still a cheap `_StepView` subclass + tests appended to `_steps`.
+- **Next ▶ spine step: "Reward activity"** — the `xp` enable toggle is trivial via `_set`, but the
+  role-threshold sub-step **needs a small new direct-apply role-threshold service** (the one genuine
+  gap — no direct-apply path exists today) + `RoleLifecycleService.create_role` for auto-create.
+- **Then step 0 "server-type starter preset"** — now *decided* (Q-C: auto-apply safe reversible
+  defaults) but still **needs a direct-apply preset path** (presets are draft-only today).
+- **PR 3 scope sharpened (Q-E):** not just "demote cog_routing/cleanup under Advanced" — also **rework
+  the Advanced bulk editor**, auditing and wiring-up-or-stripping its dead actions.
+
+## ⚑ Self-initiated: NONE — fully owner-directed (the task + all four design answers came from the
+owner). Within-session scoping was minimal (I followed the answers; the moderation-only copy fix was
+the owner's scope call, not mine). Additive, test-covered, old wizard untouched.

--- a/disbot/views/setup/essential_setup.py
+++ b/disbot/views/setup/essential_setup.py
@@ -20,9 +20,9 @@ Design (plan ``docs/planning/setup-wizard-restructure-plan-2026-06-24.md`` §5):
 This module is **additive** — the existing wizard (``views/setup/wizard.py``)
 is untouched and remains the full/advanced path; Essential Setup is the new
 quick spine.  Live steps: greet new members · set your moderators · block spam
-and bad links · set up a help desk (+ the closing summary).  Remaining
-follow-ons on this same pattern: choose a log channel (with auto-create),
-reward activity (xp + auto-role), and the server-type starter preset.
+and bad links · choose a log channel · set up a help desk (+ the closing
+summary).  Remaining follow-ons on this same pattern: reward activity (xp +
+auto-role) and the server-type starter preset.
 """
 
 from __future__ import annotations
@@ -68,6 +68,7 @@ class EssentialFlow:
             GreetMembersStep,
             ModeratorsStep,
             BlockSpamStep,
+            LogChannelStep,
             HelpDeskStep,
         ]
 
@@ -519,7 +520,207 @@ class BlockSpamStep(_StepView):
 
 
 # ---------------------------------------------------------------------------
-# Step 4 — Set up a help desk  (tickets)
+# Step 4 — Choose a log channel  (logging: enable + bind the catch-all channel)
+# ---------------------------------------------------------------------------
+#
+# Scope is **moderation log only** (owner decision, 2026-06-24): one channel for
+# moderation actions (warn/timeout/kick/ban) and anything else the bot reports.
+# Member-activity / message logging stay OFF — they are a later follow-on. So
+# the step writes exactly two things on Save: ``logging.enabled = True`` and the
+# ``logging.mod_channel`` binding (the slot every other logging route falls back
+# to), which is the literal "choose a log channel" the PR-1 note describes.
+
+# Plain-language default name for the channel we offer to create.
+_NEW_LOG_CHANNEL_NAME = "mod-log"
+
+
+class _LogChannelSelect(discord.ui.ChannelSelect):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Pick a channel for the bot's log…",
+            channel_types=[discord.ChannelType.text],
+            min_values=0,
+            max_values=1,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: LogChannelStep = self.view  # type: ignore[assignment]
+        view.channel_id = self.values[0].id if self.values else None
+        # Picking an existing channel turns off "make one for me".
+        if view.channel_id is not None:
+            view.auto_create = False
+        view.refresh_items()
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class _AutoCreateLogButton(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self, on: bool) -> None:
+        super().__init__(
+            label=f"Make a #{_NEW_LOG_CHANNEL_NAME} channel: {'ON' if on else 'OFF'}",
+            style=(
+                discord.ButtonStyle.success if on else discord.ButtonStyle.secondary
+            ),
+            row=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: LogChannelStep = self.view  # type: ignore[assignment]
+        view.auto_create = not view.auto_create
+        # Choosing "make one for me" clears any existing pick (one target wins).
+        if view.auto_create:
+            view.channel_id = None
+        view.refresh_items()
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class _LogSaveButton(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            label="Save log channel",
+            emoji="📋",
+            style=discord.ButtonStyle.success,
+            row=2,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: LogChannelStep = self.view  # type: ignore[assignment]
+        await view.apply(interaction)
+
+
+class LogChannelStep(_StepView):
+    title = "Choose a log channel"
+    skip_label = "Skip logging"
+
+    def __init__(self, flow: EssentialFlow) -> None:
+        self.channel_id: int | None = None
+        self.auto_create: bool = False
+        super().__init__(flow)
+
+    def build_items(self) -> None:
+        self.refresh_items()
+
+    def refresh_items(self) -> None:
+        """(Re)build the row-0/1/2 controls — used after a pick / toggle flips."""
+        for child in list(self.children):
+            if isinstance(
+                child,
+                (_LogChannelSelect, _AutoCreateLogButton, _LogSaveButton),
+            ):
+                self.remove_item(child)
+        self.add_item(_LogChannelSelect())
+        self.add_item(_AutoCreateLogButton(self.auto_create))
+        self.add_item(_LogSaveButton())
+
+    def render(self) -> discord.Embed:
+        embed = discord.Embed(
+            title=f"📋 {self.title}",
+            description=(
+                "Keep a record of what the bot does — warnings, timeouts, "
+                "kicks and bans, plus anything else it needs to report — all "
+                "in one channel.\n\n"
+                "Pick a channel below, or let us make a fresh "
+                f"**#{_NEW_LOG_CHANNEL_NAME}** for you, then press "
+                "**Save log channel**."
+            ),
+            color=discord.Color.blurple(),
+        )
+        if self.channel_id:
+            where = f"<#{self.channel_id}>"
+        elif self.auto_create:
+            where = f"a new **#{_NEW_LOG_CHANNEL_NAME}** channel"
+        else:
+            where = "_not chosen yet_"
+        embed.add_field(name="The log goes to", value=where, inline=False)
+        embed.set_footer(text=self.flow.step_counter())
+        return embed
+
+    async def apply(self, interaction: discord.Interaction) -> None:
+        channel_id = self.channel_id
+        created = False
+        if channel_id is None and self.auto_create:
+            channel_id = await self._create_log_channel(interaction)
+            if channel_id is None:
+                return  # creation failed; the error was already surfaced
+            created = True
+        if channel_id is None:
+            await interaction.response.send_message(
+                f"Pick a channel, or choose **Make a #{_NEW_LOG_CHANNEL_NAME} "
+                "channel** first.",
+                ephemeral=True,
+            )
+            return
+        try:
+            await self._set("logging", "enabled", True)
+            await self._bind_log_channel(channel_id)
+        except Exception:
+            logger.exception("essential setup: log-channel step apply failed")
+            await interaction.response.send_message(
+                "Something went wrong saving your log channel — please try again.",
+                ephemeral=True,
+            )
+            return
+        line = f"Logging on, posting to <#{channel_id}>"
+        if created:
+            line += " (created for you)"
+        await self.complete(interaction, line)
+
+    async def _create_log_channel(
+        self,
+        interaction: discord.Interaction,
+    ) -> int | None:
+        """Create the #mod-log channel through the audited lifecycle creator.
+
+        Returns the new channel's id, or ``None`` after surfacing an error (the
+        caller then stops without writing anything).  ``ChannelLifecycleService``
+        is imported lazily to match the setup-view convention (services /
+        pipelines are not imported at module top level here).
+        """
+        from services.channel_lifecycle_service import ChannelLifecycleService
+
+        result = await ChannelLifecycleService().create_channels(
+            self.flow.guild,
+            [_NEW_LOG_CHANNEL_NAME],
+            self.flow.author,
+        )
+        if not result.applied:
+            logger.warning(
+                "essential setup: log channel create failed (guild=%s): %s",
+                self.flow.guild.id,
+                result.first_error,
+            )
+            await interaction.response.send_message(
+                "Couldn't make the channel — please pick an existing one instead.",
+                ephemeral=True,
+            )
+            return None
+        return result.applied[0].target_id
+
+    async def _bind_log_channel(self, channel_id: int) -> None:
+        """Point the bot's log at *channel_id* through the audited write path.
+
+        ``BindingMutationPipeline`` is on the setup-view no-top-level-import list
+        (``test_setup_operations_invariants``), so it — and ``BindingKind`` — are
+        imported lazily here, exactly like ``_set`` does for settings.  We bind
+        ``logging.mod_channel`` (the slot every other logging route falls back
+        to), so a single pick lights up the whole moderation/catch-all log.
+        """
+        from core.runtime.subsystem_schema import BindingKind
+        from services.binding_mutation import BindingMutationPipeline
+
+        await BindingMutationPipeline().set_binding(
+            self.flow.guild,
+            "logging",
+            "mod_channel",
+            BindingKind.CHANNEL,
+            channel_id,
+            self.flow.author,
+            actor_type="user",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Step 5 — Set up a help desk  (tickets)
 # ---------------------------------------------------------------------------
 
 

--- a/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
+++ b/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
@@ -1,0 +1,1 @@
+claude/blissful-hamilton-xdzbak · Essential Setup spine: "Choose a log channel" step (binding via BindingMutationPipeline + optional auto-create via ChannelLifecycleService) · disbot/views/setup/essential_setup.py + tests/unit/views/setup/test_essential_setup.py · 2026-06-24

--- a/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
+++ b/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
@@ -1,1 +1,0 @@
-claude/blissful-hamilton-xdzbak · Essential Setup spine: "Choose a log channel" step (binding via BindingMutationPipeline + optional auto-create via ChannelLifecycleService) · disbot/views/setup/essential_setup.py + tests/unit/views/setup/test_essential_setup.py · 2026-06-24

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -7353,3 +7353,41 @@ design). The follow-up PR **#pending** implements the owner's confirm-button cho
 **Home:** this Q-block (canonical) + `.sessions/2026-06-24-support-tickets.md` +
 `.sessions/2026-06-24-ticket-ai-confirm.md` + the `ai_tools.py` module docstring. Related: **Q-0048** (the
 parent AI-exposure gate), **Q-0199** (the setup-apply write lift, also click-gated), Q-0123 (auto-merge).
+
+### Q-0202 — ANSWERED (owner decisions, in-session): Essential Setup "Choose a log channel" scope + naming + the step-0 preset + the Advanced editor (2026-06-24)
+
+**Context.** While building the Essential Setup "Choose a log channel" step (plan
+`docs/planning/setup-wizard-restructure-plan-2026-06-24.md`, PR 1; PR **#1429**), four design decisions
+needed the owner. Asked as one `AskUserQuestion` batch; answers verbatim below. Two settle *this* step
+(scope, name); two settle *later* PRs (step-0 preset = Q-C, the Advanced editor = Q-E) "while you're here".
+
+**The decisions.**
+1. **Log scope = moderation log only.** The step is *one* channel: it turns on `logging.enabled` and binds
+   `logging.mod_channel` (the catch-all slot every other logging route falls back to) to the picked-or-
+   created channel. **Member-activity (joins/leaves/roles) and message-content logging stay OFF** — they
+   are a later follow-on, not this step. This supersedes the plan §5 "log channel pair" framing and matches
+   the PR-1 note's "*a* binding write" (singular). The step copy was corrected to stop promising
+   joins/edits.
+2. **Auto-create naming (plan Q-D) = plain-language names.** Auto-created channels/roles use the short §4
+   wording — `#mod-log` / `#server-log`, "Level 10", "Regular" — **not** the longer `bot-`-prefixed
+   `suggested_name` convention. (The log step creates `#mod-log`.)
+3. **Step-0 server-type preset (plan Q-C) = auto-apply safe defaults.** Picking Community/Gaming/Support/
+   Creator instantly switches on a curated, **reversible** bundle (nothing irreversible) — *not* recommend-
+   and-confirm-each. Not built this PR; settles the future step-0 preset path.
+4. **Advanced bulk editor (plan Q-E) = keep but REWORK.** Keep the draft → Final Review editor for power
+   users, but the owner sharpened the offered "keep as-is" to **"keep but rework it — currently most of it
+   does not do anything."** So PR 3 is not only "demote cog_routing/cleanup under Advanced"; it must audit
+   that editor and wire up or strip its dead actions.
+
+**Scope / non-generalization.** (1) and (2) are live in #1429. (3) and (4) are recorded direction for the
+step-0 and PR-3 sessions respectively — no code yet.
+
+**Applied.** PR **#1429** ships the moderation-only log-channel step (decisions 1+2): a `LogChannelStep`
+on `EssentialFlow` that picks or auto-creates a `#mod-log`, enables logging via `SettingsMutationPipeline`,
+and binds `logging.mod_channel` via `BindingMutationPipeline` (lazy-imported per the setup-view invariant)
++ `ChannelLifecycleService.create_channels` for auto-create. Decisions 3+4 are recorded in the plan §10
+(Q-C/Q-E ANSWERED) for their future PRs.
+
+**Home:** this Q-block (canonical) + the plan §7 PR-1 note / §5 step 4 / §10 (Q-C/Q-D/Q-E) +
+`.sessions/2026-06-24-setup-log-channel-step.md`. Related: **Q-A** (direct-apply per step), the
+setup-wizard restructure plan.

--- a/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
+++ b/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
@@ -106,8 +106,10 @@ The fix is not more sections — it is a **structure** built from four laws.
    (DM-on-action, require-reason). (`moderation` + governance mod role.)
 3. **Block spam and bad links** *(NEW)* — one screen of toggles with sensible pre-filled limits.
    (`automod` spam/invites/caps/mentions.)
-4. **Where should activity appear?** — pick **or auto-create** a tidy log channel pair.
-   (`logging` Balanced preset + `channels`.)
+4. **Where should activity appear?** — pick **or auto-create** a log channel.
+   (`logging` enable + the `mod_channel` binding.) **Shipped scoped to a single moderation/catch-all
+   channel** (owner decision 2026-06-24, `#1429`); the "pair" + member/message activity is a later
+   follow-on, not this step.
 5. **Reward active members** — turn on levels; optionally auto-grant a role as members stay & chat —
    **the bot creates the roles**. (`xp` + `roles` + `role_templates`, dead-end removed.)
 6. **Set up a help desk** — let members open private support; pick who answers; bot makes the rest.
@@ -173,9 +175,14 @@ decision with architectural weight → called out as open question Q-A below.
   Additive: the old wizard is untouched (retired in PR 3). Jargon-clean (guard: the new file adds 0
   findings). **Remaining steps are mechanical follow-ons on the exact same pattern — append a `_StepView`
   subclass to `EssentialFlow._steps` + a test; no new cog/command/artifact, so no registration fan-out:**
-  - **Choose a log channel** *(next)* — a binding write via `BindingMutationPipeline` (⚠ on the
-    no-top-level-import list — **lazy-import it** inside the step, like `_set` does for settings) + an
-    optional **auto-create** via `ChannelLifecycleService.create_channels`.
+  - **Choose a log channel** *(SHIPPED 2026-06-24, `#1429`)* — a binding write via
+    `BindingMutationPipeline` (⚠ on the no-top-level-import list — **lazy-imported** inside the step,
+    like `_set` does for settings) + an optional **auto-create** via
+    `ChannelLifecycleService.create_channels`. **Scope = moderation log only (owner decision,
+    2026-06-24):** one screen turns on `logging.enabled` and binds `logging.mod_channel` (the
+    catch-all slot every other route falls back to) to the picked-or-created channel; auto-create makes
+    a `#mod-log`. Member-activity / message-content logging stay OFF — they are a later follow-on, not
+    this step. (The earlier §5 "log channel pair" framing is superseded by this single-channel answer.)
   - **Reward activity** — the `xp` enable toggle is trivial via `_set`; the role-threshold sub-step
     **needs a small new direct-apply role-threshold service** (the one genuine gap — no direct-apply path
     exists today) + `RoleLifecycleService.create_role` for auto-create.
@@ -223,10 +230,13 @@ python3.10 scripts/check_docs.py --strict
   the existing ticket section + the canonical lane rule.)
 - **Q-B:** is the **6-step spine** (0–6 above) the right essentials set, or do you want a different
   cut — e.g. tickets as an extra rather than a spine step, or reaction-roles promoted into the spine?
-- **Q-C:** **starter sets** (step 0) — happy for "Community/Gaming/Support/Creator" to each switch on a
-  curated default bundle automatically, or should step 0 only *recommend* and let the operator confirm
-  each? (Plan auto-applies safe, reversible defaults.)
-- **Q-D:** **auto-create naming** — default channel names (`#welcome`, `#server-log`, `#mod-log`) and
-  role names ("Level 10", "Regular") — fine as-is, or do you want to pick the wording?
-- **Q-E:** keep the **Advanced** bulk editor (draft → Final Review) for power users, or retire it once the
-  spine + extras cover everything? (Plan keeps it — it's harmless and serves multi-setting edits.)
+- **Q-C — ANSWERED (owner, 2026-06-24): auto-apply safe defaults.** When someone picks a server type
+  (step 0), it instantly switches on a curated, **reversible** bundle of defaults — fastest, nothing
+  irreversible. (Not built this PR; settles the step-0 preset follow-on.)
+- **Q-D — ANSWERED (owner, 2026-06-24): plain-language names.** Auto-created channels/roles use the
+  short, friendly §4 wording (`#mod-log` / `#server-log`, "Level 10", "Regular") rather than the longer
+  `bot-`-prefixed `suggested_name` convention. (Log step `#1429` creates `#mod-log` accordingly.)
+- **Q-E — ANSWERED (owner, 2026-06-24): keep but REWORK.** Keep the Advanced bulk editor for power
+  users, but **rework it — "currently most of it does not do anything."** So PR 3 is not just "demote
+  cog_routing/cleanup under Advanced"; it must audit the draft → Final Review editor and either wire up
+  or strip its dead actions. (Was: "keep as-is"; the owner sharpened it to keep-and-fix.)

--- a/tests/unit/views/setup/test_essential_setup.py
+++ b/tests/unit/views/setup/test_essential_setup.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from core.runtime.subsystem_schema import BindingKind
 from views.setup import essential_setup as es
 
 
@@ -46,6 +47,25 @@ def pipeline():
         yield cls.return_value
 
 
+@pytest.fixture
+def binding_pipeline():
+    # BindingMutationPipeline is also lazy-imported inside the log-channel step
+    # (no-top-level-pipeline-import invariant) — patch at its source.
+    with patch("services.binding_mutation.BindingMutationPipeline") as cls:
+        cls.return_value.set_binding = AsyncMock()
+        yield cls.return_value
+
+
+@pytest.fixture
+def channel_service():
+    # ChannelLifecycleService (auto-create) is lazy-imported inside the step.
+    with patch(
+        "services.channel_lifecycle_service.ChannelLifecycleService",
+    ) as cls:
+        cls.return_value.create_channels = AsyncMock()
+        yield cls.return_value
+
+
 # ---------------------------------------------------------------------------
 # Flow
 # ---------------------------------------------------------------------------
@@ -53,16 +73,17 @@ def pipeline():
 
 def test_flow_counter_and_navigation():
     flow = es.EssentialFlow(_member(), _guild())
-    assert flow.total == 4
-    assert flow.step_counter() == "Step 1 of 4"
+    assert flow.total == 5
+    assert flow.step_counter() == "Step 1 of 5"
     expected = [
         es.GreetMembersStep,
         es.ModeratorsStep,
         es.BlockSpamStep,
+        es.LogChannelStep,
         es.HelpDeskStep,
     ]
     for i, cls in enumerate(expected):
-        assert flow.step_counter() == f"Step {i + 1} of 4"
+        assert flow.step_counter() == f"Step {i + 1} of 5"
         assert isinstance(flow.current_view(), cls)
         flow.advance()
 
@@ -198,6 +219,108 @@ async def test_block_spam_respects_toggled_off_filter(pipeline):
 
 
 # ---------------------------------------------------------------------------
+# Choose a log channel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_log_channel_requires_a_pick_or_create(
+    pipeline,
+    binding_pipeline,
+    channel_service,
+):
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 3
+    step = es.LogChannelStep(flow)
+    interaction = _interaction()
+
+    await step.apply(interaction)
+
+    # Nothing picked and auto-create off → no writes, no advance.
+    pipeline.set_value.assert_not_awaited()
+    binding_pipeline.set_binding.assert_not_awaited()
+    channel_service.create_channels.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+    assert "channel" in interaction.response.send_message.await_args.args[0].lower()
+    assert flow.index == 3
+
+
+@pytest.mark.asyncio
+async def test_log_channel_binds_picked_channel_and_advances(pipeline, binding_pipeline):
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 3
+    step = es.LogChannelStep(flow)
+    step.channel_id = 8800
+
+    await step.apply(_interaction())
+
+    # logging.enabled flipped on through the settings pipeline …
+    assert ("logging", "enabled") in {
+        (c.args[1], c.args[2]) for c in pipeline.set_value.await_args_list
+    }
+    # … and mod_channel bound to the picked channel through the binding pipeline.
+    binding_pipeline.set_binding.assert_awaited_once()
+    args = binding_pipeline.set_binding.await_args.args
+    assert args[1] == "logging"
+    assert args[2] == "mod_channel"
+    assert args[3] == BindingKind.CHANNEL
+    assert args[4] == 8800
+    assert flow.index == 4
+    assert flow.applied and "8800" in flow.applied[0]
+
+
+@pytest.mark.asyncio
+async def test_log_channel_auto_creates_then_binds(
+    pipeline,
+    binding_pipeline,
+    channel_service,
+):
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 3
+    step = es.LogChannelStep(flow)
+    step.auto_create = True
+    channel_service.create_channels.return_value = SimpleNamespace(
+        applied=(SimpleNamespace(target_id=4321),),
+        first_error="",
+    )
+
+    await step.apply(_interaction())
+
+    channel_service.create_channels.assert_awaited_once()
+    # the created channel id is bound, and the summary notes it was created.
+    binding_pipeline.set_binding.assert_awaited_once()
+    assert binding_pipeline.set_binding.await_args.args[4] == 4321
+    assert flow.index == 4
+    assert flow.applied and "created" in flow.applied[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_log_channel_create_failure_blocks(
+    pipeline,
+    binding_pipeline,
+    channel_service,
+):
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 3
+    step = es.LogChannelStep(flow)
+    step.auto_create = True
+    channel_service.create_channels.return_value = SimpleNamespace(
+        applied=(),
+        first_error="missing permission",
+    )
+    interaction = _interaction()
+
+    await step.apply(interaction)
+
+    # Creation failed → surfaced an error, wrote nothing, did not advance.
+    channel_service.create_channels.assert_awaited_once()
+    binding_pipeline.set_binding.assert_not_awaited()
+    pipeline.set_value.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+    assert flow.index == 3
+
+
+# ---------------------------------------------------------------------------
 # Help desk
 # ---------------------------------------------------------------------------
 
@@ -205,20 +328,20 @@ async def test_block_spam_respects_toggled_off_filter(pipeline):
 @pytest.mark.asyncio
 async def test_help_desk_requires_staff_role():
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 3
+    flow.index = 4
     step = es.HelpDeskStep(flow)
     interaction = _interaction()
     with patch("services.ticket_mutation.update_config", new=AsyncMock()) as upd:
         await step.apply(interaction)
     upd.assert_not_awaited()
-    assert flow.index == 3
+    assert flow.index == 4
     assert "staff" in interaction.response.send_message.await_args.args[0].lower()
 
 
 @pytest.mark.asyncio
 async def test_help_desk_enables_tickets_and_advances():
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 3
+    flow.index = 4
     step = es.HelpDeskStep(flow)
     step.staff_role_id = 321
     step.log_channel_id = 654
@@ -229,7 +352,7 @@ async def test_help_desk_enables_tickets_and_advances():
     assert kwargs["enabled"] is True
     assert kwargs["staff_role_id"] == 321
     assert kwargs["log_channel_id"] == 654
-    assert flow.index == 4
+    assert flow.index == 5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Continues the Essential Setup spine (plan `docs/planning/setup-wizard-restructure-plan-2026-06-24.md`, PR 1). Adds the **"Choose a log channel"** step — owner-directed (chat, 2026-06-24).

## What it does
One plain-language screen, inserted in plan order (after *Block spam*, before *Set up a help desk* — §5 step 4):
- Pick an **existing** channel, **or** toggle "make a `#server-log` for me".
- On Save (direct lane — applies immediately):
  - turns on `logging.enabled` via the audited `SettingsMutationPipeline`, and
  - points all server-logging at the chosen channel by writing `logging.mod_channel` through **`BindingMutationPipeline`** (the universal log-channel slot everything falls back to).
- Auto-create path runs **`ChannelLifecycleService.create_channels(["server-log"])`** first, then binds the new channel.

## Notes
- `BindingMutationPipeline` (+ `BindingKind`) and `ChannelLifecycleService` are **lazy-imported inside the step**, per the setup-view no-top-level-pipeline-import invariant (`test_setup_operations_invariants`) — same pattern `_set` uses for settings.
- Additive: a view-class-only addition (no new cog/command/artifact → no registration fan-out). Old wizard untouched.
- Plain-language copy — jargon guard stays at 154 (new copy adds 0 findings).
- Tests: flow nav updated (4→5 steps); 4 new step tests (require-a-choice / bind-picked / auto-create-then-bind / create-failure-blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PPgD6XUGaxHBD6JVYxbDp

---
_Generated by [Claude Code](https://claude.ai/code/session_016PPgD6XUGaxHBD6JVYxbDp)_