### PR TITLE
Help-nav attachment seam — hub image cards through Help (visual card-engine H3)

### DIFF
--- a/.sessions/2026-06-24-help-nav-attachment-seam.md
+++ b/.sessions/2026-06-24-help-nav-attachment-seam.md
@@ -1,0 +1,35 @@
+# 2026-06-24 — Help-nav attachment seam (visual card-engine H3)
+
+> **Status:** `in-progress` — born-red card; flips to `complete` as the deliberate final step.
+
+> **Run type:** `routine · dispatch`
+
+## What I'm about to do
+Scheduled dispatch fire, no work order. Bugs blocked/gated for an unattended run (BUG-0019 #1 =
+owner design fork · BUG-0009 remaining slices need BTD6 release-order data + plan-level work · the
+two rootfix-backlog entries are both the same gated cases). Taking the **explicitly handed-off next
+▶ H3 slice** from PR #1413: the **help-nav attachment seam** ([idea](../ideas/help-nav-attachment-seam-2026-06-24.md)).
+
+The inconsistency: hubs opened by their **direct command** render their showpiece image card (XP hub
+via `!xpmenu`, #1413), but the **same** hub reached *through Help / hub navigation* shows a plain
+embed — `build_help_menu_view` is embed-only across the codebase. As more features become image
+cards, the showpiece is invisible on exactly the discovery path the consolidation audit invested in.
+
+Design (chosen to be **non-viral + backward-compatible**, no 47-cog signature churn): the **view
+object carries its own card** via a duck-typed `view.help_nav_card` attribute. A `build_help_menu_view`
+hook with a card sets it on the view it returns; the central help-nav **render** sites forward it via
+the `file=` / `attachments=` support that already exists (`safe_edit` already supports `attachments`,
+built for exactly this PIL-card-on-one-anchor use). A view without the attribute (the default — every
+embed-only hub) yields `None` → unchanged embed-only behaviour, so it rolls out hub-by-hub and any
+render site I don't touch keeps working.
+
+- New accessor `views/navigation.py:help_nav_card(view) -> discord.File | None`.
+- Forward at the central render sites: `cogs/help_cog.py` (typed `!help <cat>` prefix + slash),
+  `cogs/help/panels.py` (Help category select), `views/navigation.py` (back-button + hub-opener
+  `safe_edit`), `views/hub_children.py` (`HubChildButton`), `cogs/admin_cog.py` (`_open_via_help_hook`).
+- First real consumer: `XpCog.build_help_menu_view` sets `view.help_nav_card` from the rank card the
+  `_XpHubView.build_response()` already produces — so the XP hub shows its card through Help too.
+- Regression tests for the accessor + the migrated hook + the forward path.
+
+Idea→ship is self-initiated (Q-0172) — flagged on the run-report ⚑ Self-initiated line. Full CI mirror
+green; auto-merge on green. Aiming for a second slice (more card-bearing hubs) if room remains.

--- a/.sessions/2026-06-24-help-nav-attachment-seam.md
+++ b/.sessions/2026-06-24-help-nav-attachment-seam.md
@@ -1,35 +1,93 @@
 # 2026-06-24 — Help-nav attachment seam (visual card-engine H3)
 
-> **Status:** `in-progress` — born-red card; flips to `complete` as the deliberate final step.
+> **Status:** `complete` — PR #1430; auto-merge armed; merges on green. Full CI mirror green
+> (12,465 passed, 48 skipped, 2 xfailed; black/isort/ruff/mypy clean) + arch 0 errors +
+> check_docs/check_consistency/ledger clean.
 
 > **Run type:** `routine · dispatch`
 
-## What I'm about to do
+## What I did
 Scheduled dispatch fire, no work order. Bugs blocked/gated for an unattended run (BUG-0019 #1 =
-owner design fork · BUG-0009 remaining slices need BTD6 release-order data + plan-level work · the
-two rootfix-backlog entries are both the same gated cases). Taking the **explicitly handed-off next
-▶ H3 slice** from PR #1413: the **help-nav attachment seam** ([idea](../ideas/help-nav-attachment-seam-2026-06-24.md)).
+owner design fork · BUG-0009 remaining slices need BTD6 release-order data + plan-level work — the
+two rootfix-backlog entries are exactly those gated cases), so I took the **explicitly handed-off
+next ▶ H3 slice** from PR #1413: the **help-nav attachment seam**
+([idea](../ideas/help-nav-attachment-seam-2026-06-24.md)).
 
-The inconsistency: hubs opened by their **direct command** render their showpiece image card (XP hub
-via `!xpmenu`, #1413), but the **same** hub reached *through Help / hub navigation* shows a plain
-embed — `build_help_menu_view` is embed-only across the codebase. As more features become image
-cards, the showpiece is invisible on exactly the discovery path the consolidation audit invested in.
+The inconsistency it closes: a hub opened by its **direct command** renders its showpiece image card
+(XP hub via `!xpmenu`, #1413), but the **same** hub reached *through Help / hub navigation* showed a
+plain embed — `build_help_menu_view` was embed-only across the codebase, so the showpiece disappeared
+on exactly the discovery path the consolidation audit invested in.
 
-Design (chosen to be **non-viral + backward-compatible**, no 47-cog signature churn): the **view
-object carries its own card** via a duck-typed `view.help_nav_card` attribute. A `build_help_menu_view`
-hook with a card sets it on the view it returns; the central help-nav **render** sites forward it via
-the `file=` / `attachments=` support that already exists (`safe_edit` already supports `attachments`,
-built for exactly this PIL-card-on-one-anchor use). A view without the attribute (the default — every
-embed-only hub) yields `None` → unchanged embed-only behaviour, so it rolls out hub-by-hub and any
-render site I don't touch keeps working.
+## Shipped (PR #1430)
+**Design — non-viral + backward-compatible.** Rather than change the `(embed, view)` return shape of
+all ~47 `build_help_menu_view` hooks, the **view object carries its own card** via a duck-typed
+`help_nav_card` attribute (declared on `BaseView`, default `None` = embed-only — today's behaviour).
+The central help-nav **render** sites forward it via the `file=` / `attachments=` support that already
+exists (`safe_edit` already supports `attachments`, built for exactly this PIL-card-on-one-anchor
+case). A view without a card, or a render site not yet wired, behaves exactly as before — so the seam
+rolls out hub-by-hub.
 
-- New accessor `views/navigation.py:help_nav_card(view) -> discord.File | None`.
-- Forward at the central render sites: `cogs/help_cog.py` (typed `!help <cat>` prefix + slash),
-  `cogs/help/panels.py` (Help category select), `views/navigation.py` (back-button + hub-opener
-  `safe_edit`), `views/hub_children.py` (`HubChildButton`), `cogs/admin_cog.py` (`_open_via_help_hook`).
-- First real consumer: `XpCog.build_help_menu_view` sets `view.help_nav_card` from the rank card the
-  `_XpHubView.build_response()` already produces — so the XP hub shows its card through Help too.
-- Regression tests for the accessor + the migrated hook + the forward path.
+- `views/navigation.py` — `help_nav_card(view)` (defensive: non-`File`/missing → `None`),
+  `help_nav_attachments(view)` (`[card]` sets / `[]` clears for in-place edits),
+  `help_nav_send_kwargs(view)` (`{"file": card}` for fresh sends — never `file=None`, which
+  `InteractionResponse.send_message` mis-reads as a broken attachment).
+- `views/base.py` — `BaseView.help_nav_card: discord.File | None = None` (the seam's typed default).
+- Wired render sites: `cogs/help_cog.py` typed `!help <cat>` (prefix `ctx.send` + slash
+  `response.send_message`), `cogs/help/panels.py` category select (`edit_message`),
+  `views/navigation.py` back-button + `transition_to` hub-opener (`safe_edit`),
+  `views/hub_children.py` `HubChildButton` (`edit_message`), `cogs/admin_cog.py`
+  `_open_via_help_hook` (`safe_edit`).
+- First real consumer: `XpCog.build_help_menu_view` stashes the rank card from
+  `_XpHubView.build_response()` (the same card `!xpmenu` shows) — the XP hub now shows its card
+  through Help. `build_embed` (the config-panel back-nav path) stays embed-only; its drifted
+  "for the help-nav hook" docstring was corrected.
+- Tests: `tests/unit/views/test_navigation.py` (accessor unit tests + a **forward-path pin** that
+  the back-button render forwards `attachments=[card]`) · `tests/unit/views/xp/test_xp_hub_panel.py`
+  (the cog hook stashes the card + Pillow-less embed-only fallback; the repurposed `build_embed`
+  test renamed to reflect it's the config-panel path).
 
-Idea→ship is self-initiated (Q-0172) — flagged on the run-report ⚑ Self-initiated line. Full CI mirror
-green; auto-merge on green. Aiming for a second slice (more card-bearing hubs) if room remains.
+## 💡 Session idea (Q-0089)
+The help-nav seam now forwards the card on **edit-in-place** and **fresh send**, but Discord
+`edit_message`/`send_message` only accept a **single** attachment cleanly through these helpers — a
+future multi-image card (e.g. a hub that wants a banner *and* a stat card) has no path. Idea: widen
+the seam to `help_nav_cards: list[discord.File]` (the singular `help_nav_card` becoming sugar for a
+one-element list) so the same render sites forward `attachments=cards` / `files=cards` unchanged.
+Cheap, fully backward-compatible (one card = today), and it future-proofs the engine before a second
+multi-image consumer forces an awkward retrofit. Dedup-checked — not in `docs/ideas/`; smaller than a
+plan, flagged for grooming.
+
+## ⟲ Previous-session review (Q-0102)
+Reviewed **2026-06-24-xpmenu-rank-card-h3** (#1413). Did well: it migrated a *single* surface
+cleanly, explicitly scoped the help-nav seam *out* ("a separate cross-cutting change"), and — the
+part that made this run fast — **groomed the cut work into a proper idea doc** with the call-site
+list and the triple-vs-result-object design question already framed. That handoff turned a
+breadth-unknown cross-cutting task into a 90-minute slice. One thing it could have done better: it
+asserted the help-nav seam was "embed-only by contract" without noting `safe_edit` *already* supported
+`attachments` — the infrastructure was there the whole time, so the "separate cross-cutting change"
+framing slightly over-stated the cost. **System improvement:** the idea doc sketched a `(embed, view,
+file)` *triple* as the shape, but the actually-correct shape was a *view attribute* (non-viral, no
+47-hook churn). A groomed idea that proposes an implementation shape should carry a one-line
+**"shape not yet validated — confirm against the consumer signatures before committing"** caveat, so
+the building session re-derives the cheapest shape rather than anchoring on the sketch. (This run did
+re-derive it — but only because I read all the call sites first.)
+
+## Doc audit (Q-0104)
+`check_docs --strict` + `check_consistency` + `check_current_state_ledger --strict` all green; arch 0
+errors. De-staled `current-state/S1-bot.md` H3 note (seam shipped; remaining H3 = incremental
+adoption). Marked the idea doc `historical` (built) with the as-shipped design recorded (it differs
+from the sketched triple — noted so the next reader isn't misled). No owner-decision / router change.
+Ledger entry for #1430 lands via the next reconciliation pass (band-#1440), no placeholder (Q-0052).
+
+## 📤 Run report
+- **Run type:** `routine · dispatch`
+- **Shipped:** PR #1430 — help-nav attachment seam (the seam + accessors + XP hub as first consumer + tests).
+- **⚑ Self-initiated:** YES — promoted the groomed `help-nav-attachment-seam` idea → build with no
+  work order, per Q-0172. Contained, reversible, offline-verified, fully backward-compatible
+  (embed-only default unchanged).
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none (a merge auto-deploys to Railway).
+- **Next ▶:** **incremental adoption** of the seam — any other card-bearing hub sets
+  `view.help_nav_card = card` in its `build_help_menu_view` hook and the render sites already forward
+  it (profile/rank hubs reached via Help are the next natural adopters; the leaderboard *overview* is
+  genuinely embed-only — it's a category picker, not a card). Plus the `mining_render` rebase (owner
+  visual decision) and the multi-card seam idea above.

--- a/disbot/cogs/admin_cog.py
+++ b/disbot/cogs/admin_cog.py
@@ -20,7 +20,7 @@ from core.runtime import lifecycle, resources
 from core.runtime.interaction_helpers import help_ctx_shim, safe_defer, safe_edit
 from utils.ui_constants import ADMIN_COLOR, INFO_COLOR, SUCCESS_COLOR  # noqa: F401
 from views.base import HubView, send_panel
-from views.navigation import attach_back_button
+from views.navigation import attach_back_button, help_nav_attachments
 
 
 class AdminCog(commands.Cog):
@@ -751,7 +751,12 @@ class _AdminPanelView(HubView):
             await safe_edit(interaction, embed=embed, view=self)
             return
         attach_back_to_admin_button(sub_view, interaction.user)
-        await safe_edit(interaction, embed=sub_embed, view=sub_view)
+        await safe_edit(
+            interaction,
+            embed=sub_embed,
+            view=sub_view,
+            attachments=help_nav_attachments(sub_view),
+        )
 
 
 class _LogLevelModal(discord.ui.Modal, title="Set Log Level"):  # type: ignore[call-arg]

--- a/disbot/cogs/help/panels.py
+++ b/disbot/cogs/help/panels.py
@@ -29,6 +29,7 @@ from cogs.help.route import resolve_route as _resolve_route
 from core.runtime.persistent_views import PersistentView, register
 from services.governance_service import GovernanceContext
 from services.help_projection import HelpProjection
+from views.navigation import help_nav_attachments
 
 logger = logging.getLogger("bot")
 
@@ -130,7 +131,11 @@ class HelpCategoryView(PersistentView):
         # Attach Back-to-Help on every interactive surface opened from
         # the category index so the user has a one-click return.
         _attach_back_to_help_button(sub_view)
-        await interaction.response.edit_message(embed=embed, view=sub_view)
+        await interaction.response.edit_message(
+            embed=embed,
+            view=sub_view,
+            attachments=help_nav_attachments(sub_view),
+        )
 
 
 __all__ = [

--- a/disbot/cogs/help_cog.py
+++ b/disbot/cogs/help_cog.py
@@ -311,9 +311,16 @@ class HelpCog(commands.Cog):
 
             # For typed Help with a hub/subsystem surface, send the panel
             # as a fresh message and attach Back-to-Help so the user can
-            # return to the category index.
+            # return to the category index. Forward any help-nav image card the
+            # hub carries (visual card engine H3) so the card shows through Help.
+            from views.navigation import help_nav_send_kwargs  # noqa: PLC0415
+
             _attach_back_to_help_button(sub_view)
-            await ctx.send(embed=embed, view=sub_view)
+            await ctx.send(
+                embed=embed,
+                view=sub_view,
+                **help_nav_send_kwargs(sub_view),
+            )
             return
 
         # The top of Help is the mother-hub category index.
@@ -409,12 +416,15 @@ class HelpCog(commands.Cog):
 
             # Mirror the prefix path: any hub/subsystem surface gets a
             # Back-to-Help button so the user can return to the category
-            # index in place.
+            # index in place. Forward any help-nav image card (H3).
+            from views.navigation import help_nav_send_kwargs  # noqa: PLC0415
+
             _attach_back_to_help_button(sub_view)
             await interaction.response.send_message(
                 embed=embed,
                 view=sub_view,
                 ephemeral=True,
+                **help_nav_send_kwargs(sub_view),
             )
             return
 

--- a/disbot/cogs/xp_cog.py
+++ b/disbot/cogs/xp_cog.py
@@ -90,9 +90,19 @@ class XpCog(commands.Cog):
         self,
         interaction: discord.Interaction,
     ) -> tuple[discord.Embed, discord.ui.View]:
-        """Help-menu direct-navigation hook (returns the XP hub panel)."""
+        """Help-menu direct-navigation hook (returns the XP hub panel).
+
+        Renders the same rank **image card** the direct ``!xpmenu`` surface shows
+        (visual card engine H3): the card is stashed on the view as
+        ``help_nav_card`` and every help-nav render site forwards it
+        (``views.navigation.help_nav_card``), so the XP hub looks identical
+        whether opened by command or reached through Help / hub navigation. On a
+        Pillow-less host the card is ``None`` and the embed stays the source of
+        truth — byte-identical to the prior embed-only behaviour.
+        """
         view = _XpHubView(help_ctx_shim(interaction))
-        embed = await view.build_embed()
+        embed, card = await view.build_response()
+        view.help_nav_card = card
         return embed, view
 
     # ------------------------------------------------------------------ commands

--- a/disbot/views/base.py
+++ b/disbot/views/base.py
@@ -135,6 +135,12 @@ class BaseView(discord.ui.View):
         self._author = author
         self._public = public
         self.message: discord.Message | None = None
+        # Optional help-nav image card (visual card engine H3): a
+        # ``build_help_menu_view`` hook that renders a showpiece image card sets
+        # this so every help-nav render site forwards it (the same card the
+        # direct command shows). Default ``None`` = embed-only, the historical
+        # behaviour for every panel. See ``views.navigation.help_nav_card``.
+        self.help_nav_card: discord.File | None = None
         from views.navigation import attach_standard_nav
 
         attach_standard_nav(self)

--- a/disbot/views/hub_children.py
+++ b/disbot/views/hub_children.py
@@ -34,7 +34,12 @@ import discord
 from services import governance_service
 from services.governance_service import GovernanceContext
 from utils.subsystem_registry import SUBSYSTEMS
-from views.navigation import BackTarget, attach_back_target, has_standard_nav
+from views.navigation import (
+    BackTarget,
+    attach_back_target,
+    has_standard_nav,
+    help_nav_attachments,
+)
 
 logger = logging.getLogger("bot.views.hub_children")
 
@@ -213,4 +218,8 @@ class HubChildButton(discord.ui.Button):
                 attach_back_target(sub_view, back_target)
             sub_view._back_target = back_target  # type: ignore[attr-defined]
 
-        await interaction.response.edit_message(embed=embed, view=sub_view)
+        await interaction.response.edit_message(
+            embed=embed,
+            view=sub_view,
+            attachments=help_nav_attachments(sub_view),
+        )

--- a/disbot/views/navigation.py
+++ b/disbot/views/navigation.py
@@ -68,6 +68,56 @@ ParentBuilder: TypeAlias = Callable[
 ]
 
 
+def help_nav_card(view: discord.ui.View | None) -> discord.File | None:
+    """The optional image card a help-nav hub panel wants rendered.
+
+    The visual card engine (H3) renders showpiece image cards for hubs opened by
+    their **direct command** (the XP hub via ``!xpmenu``, ``!rank``, …). The same
+    hub reached *through Help / hub navigation* goes through the
+    ``build_help_menu_view`` hook, which is embed-only by contract across the
+    codebase — so the showpiece disappears on exactly the discovery path Help is.
+
+    This is the seam that closes that split **without** changing the return shape
+    of all ~47 hooks: a hook that has a card sets it on the view it returns
+    (``view.help_nav_card = card``); every help-nav render site forwards the
+    result here as ``file=`` (fresh send) or ``attachments=`` (in-place edit —
+    ``safe_edit`` already supports it, built for exactly this PIL-card-on-one-
+    anchor case). A view without the attribute — every embed-only hub, the
+    default — yields ``None`` → unchanged embed-only behaviour, so the seam rolls
+    out hub-by-hub and any render site not yet wired keeps working.
+
+    Defensive: a non-``discord.File`` value (or a missing attribute) → ``None``,
+    never raises, so a stray attribute can't crash navigation.
+    """
+    card = getattr(view, "help_nav_card", None)
+    return card if isinstance(card, discord.File) else None
+
+
+def help_nav_attachments(view: discord.ui.View | None) -> list[discord.File]:
+    """``attachments=`` value for an **in-place edit** that opens ``view``.
+
+    ``[card]`` when the panel carries a help-nav card (sets it), else ``[]``
+    (clears any prior screen's attachment so a card from the panel we navigated
+    *away* from does not linger — the documented ``safe_edit`` convention). Fresh
+    sends use :func:`help_nav_card` directly as ``file=``.
+    """
+    card = help_nav_card(view)
+    return [card] if card is not None else []
+
+
+def help_nav_send_kwargs(view: discord.ui.View | None) -> dict[str, discord.File]:
+    """``**kwargs`` carrying ``file=`` for a **fresh send** that opens ``view``.
+
+    ``{"file": card}`` when the panel has a help-nav card, else ``{}``. Used as
+    ``await ctx.send(..., **help_nav_send_kwargs(view))`` /
+    ``interaction.response.send_message(..., **help_nav_send_kwargs(view))`` so a
+    cardless hub never passes ``file=None`` — ``InteractionResponse.send_message``
+    treats ``None`` as a real (broken) attachment rather than "no file".
+    """
+    card = help_nav_card(view)
+    return {"file": card} if card is not None else {}
+
+
 @dataclass(frozen=True)
 class BackTarget:
     """A captured "what comes above me" for back-chain composition (AB2).
@@ -186,7 +236,12 @@ def attach_back_button(
                     send_exc,
                 )
             return
-        await safe_edit(interaction, embed=embed, view=parent_view)
+        await safe_edit(
+            interaction,
+            embed=embed,
+            view=parent_view,
+            attachments=help_nav_attachments(parent_view),
+        )
 
     btn.callback = _back_callback  # type: ignore[method-assign]
     try:
@@ -435,7 +490,12 @@ async def transition_to(
                 send_exc,
             )
         return
-    await safe_edit(interaction, embed=embed, view=view)
+    await safe_edit(
+        interaction,
+        embed=embed,
+        view=view,
+        attachments=help_nav_attachments(view),
+    )
 
 
 def attach_back_target(view: discord.ui.View, target: BackTarget) -> bool:
@@ -518,5 +578,8 @@ __all__ = [
     "carry_back",
     "chain_back",
     "has_standard_nav",
+    "help_nav_attachments",
+    "help_nav_card",
+    "help_nav_send_kwargs",
     "transition_to",
 ]

--- a/disbot/views/xp/main_panel.py
+++ b/disbot/views/xp/main_panel.py
@@ -24,9 +24,11 @@ class _XpHubView(HubView):
     def _decorate(self, embed: discord.Embed) -> None:
         """Apply the hub's title / footer / admin-button state to ``embed``.
 
-        Shared by every render path (``build_embed`` for the help-nav hook,
-        ``build_response`` for the direct ``!xpmenu`` surface, and the three
-        stat-switch buttons) so the chrome stays in exactly one place.
+        Shared by every render path (``build_response`` for the direct
+        ``!xpmenu`` surface *and* the ``build_help_menu_view`` help-nav hook —
+        both now render the image card via the help-nav attachment seam — the
+        three stat-switch buttons, and ``build_embed`` for the config-panel
+        back-navigation) so the chrome stays in exactly one place.
         """
         embed.title = f"🏆 XP Panel — {self.ctx.author.display_name}"
         is_admin = self.ctx.author.guild_permissions.administrator  # type: ignore[union-attr]
@@ -54,8 +56,10 @@ class _XpHubView(HubView):
         return embed, card
 
     async def build_embed(self) -> discord.Embed:
-        # Embed-only path for the ``build_help_menu_view`` help-nav hook, which
-        # is embed-only by contract across the codebase (no attachment seam).
+        # Embed-only path for the config-panel back-navigation, which rebuilds
+        # the parent hub embed (``XpConfigView`` → ``parent.build_embed()``). The
+        # help-nav hook and the direct ``!xpmenu`` surface both render the image
+        # card via ``build_response`` + the help-nav attachment seam.
         embed = await _build_rank_embed(self.ctx.author, self.ctx.guild, "both")  # type: ignore[arg-type]
         self._decorate(embed)
         return embed

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -69,10 +69,15 @@
     `/myprofile` (H1) and now **`!rank`** both render real image cards (`utils/rank_render.py`, themed
     grid + level progress bar, re-rendered on the stat-toggle, embed fallback — 2026-06-24 dispatch
     run). The **`!xpmenu` hub panel** now renders the rank image card too (its direct surface +
-    stat-switch buttons, embed fallback — 2026-06-24 dispatch run, PR #1413); remaining H3 is the
-    rank/profile hub panels **reached via Help** (the `build_help_menu_view` seam is embed-only
-    across the codebase — a single help-nav attachment seam would carry the card there) + other
-    showpiece embeds — [vision](../ideas/visual-card-engine-vision-2026-06-23.md) · the
+    stat-switch buttons, embed fallback — 2026-06-24 dispatch run, PR #1413). The **help-nav
+    attachment seam** then shipped (PR #1430, 2026-06-24 dispatch run) — hubs reached *through Help /
+    hub navigation* now carry their image card too (`views.navigation.help_nav_card`, a non-viral
+    duck-typed `view.help_nav_card` the central render sites forward; XP hub is the first consumer),
+    closing the "card via the command, plain embed via Help" split at the root. Remaining H3 is
+    **incremental adoption** (other card-bearing hubs set `help_nav_card` in their hook — profile/rank
+    hubs are the next adopters) + other showpiece embeds —
+    [vision](../ideas/visual-card-engine-vision-2026-06-23.md) ·
+    [seam idea](../ideas/help-nav-attachment-seam-2026-06-24.md) · the
     `channel-deployed-component` roles primitive (idea, not yet built).
 - **Fishing follow-ups** (turn-key, on the bait/venue seam) — *(bait speed knob ✅ #1337, sell-value
   re-tune ✅ #1304, bait-crafting ✅ #1338, and the **⛵ boat/deepwater venue** ✅ PR #1340 — shore↔

--- a/docs/ideas/help-nav-attachment-seam-2026-06-24.md
+++ b/docs/ideas/help-nav-attachment-seam-2026-06-24.md
@@ -1,7 +1,23 @@
 # Help-nav attachment seam — let hub panels carry their image card through Help
 
-> **Status:** `ideas`. Not a plan, not approval. Source code + binding contracts win.
+> **Status:** `historical` — **built** 2026-06-24 (dispatch run, PR #1430 — the seam + the XP hub as
+> the first consumer). The remaining work is **incremental adoption** (migrate the other card-bearing
+> hubs' hooks one at a time — see "Adoption tail" below). Source code + binding contracts win.
 > **Subsystem:** none
+
+> **Built (PR #1430):** the seam landed with a **non-viral, backward-compatible** shape that differs
+> from the `(embed, view, file)` triple sketched below — the **view object carries its own card** via
+> a duck-typed `help_nav_card` attribute (declared on `BaseView`, default `None` = embed-only), and the
+> central render sites forward it with the `file=`/`attachments=` support that already exists. No tuple
+> signature changed, so the ~47 hooks were untouched. Accessors: `views.navigation.help_nav_card` /
+> `help_nav_attachments` / `help_nav_send_kwargs`. Wired render sites: `help_cog` typed `!help` (prefix
+> + slash), `help/panels` category select, `navigation` back-button + hub-opener, `hub_children`
+> `HubChildButton`, `admin._open_via_help_hook`. First consumer: `XpCog.build_help_menu_view`.
+>
+> **Adoption tail (incremental, turn-key):** any other hub whose `build_help_menu_view` can render a
+> card just sets `view.help_nav_card = card` before returning — the render sites already forward it. The
+> leaderboard *overview* hook is genuinely embed-only (it's a category picker, not a card); profile/rank
+> hubs reached through Help are the next natural adopters.
 
 ## The inconsistency
 

--- a/docs/owner/claims/claude-funny-franklin-7n1117.md
+++ b/docs/owner/claims/claude-funny-franklin-7n1117.md
@@ -1,1 +1,0 @@
-- branch `claude/funny-franklin-7n1117` · scope: help-nav attachment seam (visual card-engine H3) — let hub panels carry their image card through Help/hub navigation · area: `disbot/views/navigation.py`, `disbot/cogs/help/`, `disbot/cogs/help_cog.py`, `disbot/views/hub_children.py`, `disbot/cogs/admin_cog.py`, `disbot/cogs/xp_cog.py` + tests · 2026-06-24

--- a/docs/owner/claims/claude-funny-franklin-7n1117.md
+++ b/docs/owner/claims/claude-funny-franklin-7n1117.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-7n1117` · scope: help-nav attachment seam (visual card-engine H3) — let hub panels carry their image card through Help/hub navigation · area: `disbot/views/navigation.py`, `disbot/cogs/help/`, `disbot/cogs/help_cog.py`, `disbot/views/hub_children.py`, `disbot/cogs/admin_cog.py`, `disbot/cogs/xp_cog.py` + tests · 2026-06-24

--- a/tests/unit/views/test_navigation.py
+++ b/tests/unit/views/test_navigation.py
@@ -212,6 +212,48 @@ async def test_attach_back_button_callback_defers_before_calling_builder():
     _args, kwargs = patched_edit.call_args
     assert kwargs["embed"] is parent_embed
     assert kwargs["view"] is parent_view
+    # A cardless parent clears any prior screen's attachment (navigate-away).
+    assert kwargs["attachments"] == []
+
+
+@pytest.mark.asyncio
+async def test_attach_back_button_callback_forwards_the_parent_help_nav_card():
+    """Forward-path pin (help-nav attachment seam, H3): when the rebuilt parent
+    carries a ``help_nav_card``, the in-place edit must forward it as
+    ``attachments=[card]`` so the card survives the back-navigation. A future
+    edit that drops the forwarding fails here."""
+    view = discord.ui.View()
+    parent_embed = discord.Embed(title="parent")
+    parent_view = discord.ui.View()
+    card = discord.File(io.BytesIO(b"\x89PNG\r\n\x1a\nfake"), filename="card.png")
+    parent_view.help_nav_card = card  # type: ignore[attr-defined]
+
+    async def fake_builder(_interaction):
+        return parent_embed, parent_view
+
+    attach_back_button(
+        view,
+        label="↩ Back",
+        custom_id="test:back",
+        parent_builder=fake_builder,
+    )
+
+    interaction = _interaction()
+    btn = view.children[0]
+    with (
+        patch(
+            "core.runtime.interaction_helpers.safe_defer",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "core.runtime.interaction_helpers.safe_edit",
+            AsyncMock(return_value=True),
+        ) as patched_edit,
+    ):
+        await btn.callback(interaction)  # type: ignore[union-attr,misc]
+
+    _args, kwargs = patched_edit.call_args
+    assert kwargs["attachments"] == [card]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/views/test_navigation.py
+++ b/tests/unit/views/test_navigation.py
@@ -33,6 +33,7 @@ implementation without failing CI.
 
 from __future__ import annotations
 
+import io
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
@@ -48,6 +49,9 @@ from views.navigation import (
     carry_back,
     chain_back,
     has_standard_nav,
+    help_nav_attachments,
+    help_nav_card,
+    help_nav_send_kwargs,
     transition_to,
 )
 
@@ -971,3 +975,59 @@ def test_has_standard_nav_detects_hub_back_without_help():
         view, label="↩ Games", custom_id="nav:hub:games", parent_builder=_parent_builder
     )
     assert has_standard_nav(view)
+
+
+# ---------------------------------------------------------------------------
+# Help-nav attachment seam (visual card-engine H3): the view carries its own
+# image card via ``help_nav_card``; render sites forward it. A view without the
+# attribute (every embed-only hub, the default) yields no card → embed-only.
+# ---------------------------------------------------------------------------
+
+
+class _CardView(discord.ui.View):
+    """Minimal view that opts into the help-nav card seam."""
+
+    def __init__(self, card: object) -> None:
+        super().__init__()
+        self.help_nav_card = card  # type: ignore[assignment]
+
+
+def _png() -> discord.File:
+    return discord.File(io.BytesIO(b"\x89PNG\r\n\x1a\nfake"), filename="card.png")
+
+
+def test_help_nav_card_returns_the_file_when_present():
+    card = _png()
+    assert help_nav_card(_CardView(card)) is card
+
+
+def test_help_nav_card_is_none_when_absent_or_view_is_none():
+    # A plain view (no attribute) and ``None`` both yield no card — the default
+    # embed-only behaviour every un-migrated hub keeps.
+    assert help_nav_card(discord.ui.View()) is None
+    assert help_nav_card(None) is None
+
+
+def test_help_nav_card_ignores_a_non_file_attribute():
+    # Defensive: a stray non-File value must not crash navigation.
+    assert help_nav_card(_CardView("not-a-file")) is None
+    assert help_nav_card(_CardView(None)) is None
+
+
+def test_help_nav_attachments_sets_or_clears():
+    card = _png()
+    # A card → ``[card]`` (sets it on the in-place edit).
+    assert help_nav_attachments(_CardView(card)) == [card]
+    # No card → ``[]`` (clears any prior screen's attachment).
+    assert help_nav_attachments(_CardView(None)) == []
+    assert help_nav_attachments(discord.ui.View()) == []
+
+
+def test_help_nav_send_kwargs_omits_file_when_no_card():
+    card = _png()
+    # A card → ``{"file": card}``; no card → ``{}`` so a fresh send never passes
+    # ``file=None`` (which ``InteractionResponse.send_message`` mis-reads as a
+    # broken attachment rather than "no file").
+    assert help_nav_send_kwargs(_CardView(card)) == {"file": card}
+    assert help_nav_send_kwargs(_CardView(None)) == {}
+    assert help_nav_send_kwargs(discord.ui.View()) == {}

--- a/tests/unit/views/xp/test_xp_hub_panel.py
+++ b/tests/unit/views/xp/test_xp_hub_panel.py
@@ -121,9 +121,11 @@ async def test_stat_switch_clears_attachment_on_embed_only_fallback():
 
 
 @pytest.mark.asyncio
-async def test_help_menu_hook_path_stays_embed_only():
-    # ``build_embed`` (used by the build_help_menu_view help-nav hook) must not
-    # touch the image-card seam — that path carries no attachment.
+async def test_build_embed_stays_embed_only():
+    # ``build_embed`` is the config-panel back-navigation path (XpConfigView →
+    # parent.build_embed()); it must not touch the image-card seam — that path
+    # rebuilds the parent hub embed only. (The help-nav hook and the direct
+    # ``!xpmenu`` surface render the card via ``build_response``.)
     view = _XpHubView(_ctx())
     embed_stub = discord.Embed(description="rank")
     with (
@@ -139,3 +141,45 @@ async def test_help_menu_hook_path_stays_embed_only():
         embed = await view.build_embed()
 
     assert embed.title == "🏆 XP Panel — AstroFox"
+
+
+@pytest.mark.asyncio
+async def test_build_help_menu_view_stashes_the_card_for_the_nav_seam():
+    # The cog's help-nav hook renders the same image card the direct ``!xpmenu``
+    # surface does and stashes it on the view as ``help_nav_card`` so every
+    # help-nav render site forwards it (visual card engine H3).
+    from cogs.xp_cog import XpCog
+    from views.navigation import help_nav_card
+
+    cog = XpCog(bot=MagicMock())
+    interaction = MagicMock()
+    with (
+        patch("cogs.xp_cog.help_ctx_shim", return_value=_ctx()),
+        _patch_response(_fake_card()),
+    ):
+        embed, view = await cog.build_help_menu_view(interaction)
+
+    assert embed.title == "🏆 XP Panel — AstroFox"
+    assert isinstance(view.help_nav_card, discord.File)
+    # The accessor the render sites use sees exactly that card.
+    assert help_nav_card(view) is view.help_nav_card
+
+
+@pytest.mark.asyncio
+async def test_build_help_menu_view_no_card_without_pillow():
+    # Pillow-less host → no card → the nav seam yields ``None`` → embed-only,
+    # byte-identical to the prior help-nav behaviour.
+    from cogs.xp_cog import XpCog
+    from views.navigation import help_nav_card
+
+    cog = XpCog(bot=MagicMock())
+    interaction = MagicMock()
+    with (
+        patch("cogs.xp_cog.help_ctx_shim", return_value=_ctx()),
+        _patch_response(None),
+    ):
+        embed, view = await cog.build_help_menu_view(interaction)
+
+    assert embed.title == "🏆 XP Panel — AstroFox"
+    assert view.help_nav_card is None
+    assert help_nav_card(view) is None


### PR DESCRIPTION
## What & why

Closes the visual card-engine (H3) inconsistency the previous dispatch run (PR #1413) handed off as the next ▶ slice: a hub opened by its **direct command** renders its showpiece image card, but the **same hub reached through Help / hub navigation** shows a plain embed — `build_help_menu_view` is embed-only across the whole codebase. As more features become image cards, the showpiece is invisible on exactly the discovery path the consolidation/discoverability audit just invested in. ([idea](../docs/ideas/help-nav-attachment-seam-2026-06-24.md))

## Design — non-viral, backward-compatible

The **view object carries its own card** via a duck-typed `view.help_nav_card` attribute — no 47-cog signature churn, no tuple-shape changes. A hook with a card sets it on the view it returns; the central help-nav **render** sites forward it via the `file=`/`attachments=` support that already exists (`safe_edit` already supports `attachments`, built for exactly this PIL-card-on-one-anchor case). A view without the attribute (the default — every embed-only hub) yields `None` → unchanged behaviour, so it rolls out hub-by-hub and any render site not yet wired keeps working.

- New accessor `views/navigation.py:help_nav_card(view)`.
- Forwarded at the central render sites (typed `!help <cat>` prefix + slash, Help category select, back-button + hub-opener `safe_edit`, `HubChildButton`, admin `_open_via_help_hook`).
- First real consumer: `XpCog.build_help_menu_view` sets `view.help_nav_card` from the rank card `_XpHubView.build_response()` already produces — the XP hub now shows its card through Help.

## Tests
Regression coverage for the accessor, the migrated hook, and graceful (embed-only) fallback.

⚑ Self-initiated (Q-0172): promoted the groomed help-nav-attachment-seam idea → build, no work order. Contained, reversible, offline-verified, embed fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWcgdfWWdR7q8UB63gepQT)_