### PR TITLE
Harden the help-nav attachment seam — forward-path regression pins (H3)

### DIFF
--- a/.sessions/2026-06-24-help-nav-seam-hardening.md
+++ b/.sessions/2026-06-24-help-nav-seam-hardening.md
@@ -1,27 +1,64 @@
 # 2026-06-24 — Harden the help-nav attachment seam (forward-path regression pins)
 
-> **Status:** `in-progress` — born-red card; flips to `complete` as the deliberate final step.
+> **Status:** `complete` — PR #1431; auto-merge armed; merges on green. Full CI mirror green
+> (12,469 passed, 48 skipped, 2 xfailed; black/isort/ruff/mypy clean) + all checks passed.
 
 > **Run type:** `routine · dispatch`
 
-## What I'm about to do
-Continuation of the same dispatch fire that shipped PR #1430 (the help-nav attachment seam). #1430
-landed and auto-merged cleanly. The seam has **6 render sites** that forward a hub's `help_nav_card`,
-but #1430 only added a *behavioral* forward-path pin on **one** (the navigation back-button) — the two
-**highest-traffic Help-discovery paths** (`HubChildButton` hub-child navigation, and the Help category
-**select** dropdown) relied on the accessor but had **no test that fails if the forward is dropped**.
-A refactor that removed `attachments=help_nav_attachments(...)` from either would pass CI silently.
+## What I did
+Continuation of the same dispatch fire that shipped PR #1430 (the help-nav attachment seam, which
+auto-merged cleanly). The seam has **6 render sites** that forward a hub's `help_nav_card`, but #1430
+added a *behavioral* forward-path pin on only **one** (the navigation back-button). The two
+**highest-traffic Help-discovery paths** — `HubChildButton` hub-child navigation and the Help category
+**select** dropdown — relied on the accessor but had **no test that fails if the `attachments=` forward
+is dropped**. A refactor removing the forward from either would have passed CI silently.
 
-This slice closes that coverage gap — **tests only, no production change**:
-- `tests/unit/views/test_hub_children.py` — a card-bearing child view forwards `attachments=[card]`;
-  a cardless child clears attachments (navigate-away).
-- `tests/unit/help/test_help_category_view.py` — selecting a hub whose panel carries a card forwards
-  `attachments=[card]` on the in-place edit.
+## Shipped (PR #1431) — tests only, no production change
+- `tests/unit/views/test_hub_children.py` — `test_forwards_help_nav_card_as_attachment` (card-bearing
+  child → `attachments=[card]`) + `test_cardless_child_clears_attachments` (navigate-away clears).
+- `tests/unit/help/test_help_category_view.py` — `test_selecting_hub_forwards_help_nav_card`
+  (selecting a card-bearing hub forwards `attachments=[card]` on the in-place edit).
 
-Now the seam's three main user-facing nav flows (back-button #1430 · HubChildButton · category select)
-are all behaviorally guarded. The two secondary render sites (admin `_open_via_help_hook` cross-nav,
+The seam's three main user-facing nav flows (back-button #1430 · HubChildButton · category select) are
+now all behaviorally guarded. The two secondary render sites (admin `_open_via_help_hook` cross-nav,
 typed `!help <cat>` send) stay covered by the accessor unit tests but aren't behaviorally pinned —
-lower-traffic, noted for a future pass rather than force-tested here.
+lower-traffic; noted for a future pass rather than force-tested here.
 
-Self-initiated (Q-0172) — hardening the just-shipped seam; flagged on the run report. Full CI mirror
-green; auto-merge on green.
+## 💡 Session idea (Q-0089)
+A **static seam-completeness guard** would generalise this: a test that greps every help-nav render
+site (the call sites of `build_help_menu_view` results that `edit_message`/`send`) and asserts each one
+also references `help_nav_attachments`/`help_nav_send_kwargs`/`help_nav_card`. That converts "we
+remembered to behaviorally pin the busy ones" into "a *new* render site that forgets the forward fails
+CI" — the same shape as the existing `test_every_visible_subsystem_cog_has_build_help_menu_view`
+reachability guard. Dedup-checked — not in `docs/ideas/`; small, flagged for grooming (a static-AST
+guard is more robust than per-path behavioral mocks, but needs care to enumerate the render sites).
+
+## ⟲ Previous-session review (Q-0102)
+Reviewed the immediately-prior slice in this same run (#1430, the seam itself). Did well: it chose the
+non-viral view-attribute shape over the sketched `(embed, view, file)` triple, avoiding 47-hook churn —
+the right call, and it documented *why* in the code. What it under-did (and this PR fixes): it shipped
+6 render-site forwards but only **1** behavioral pin, leaning on the accessor unit tests for the rest.
+Accessor coverage proves the helper works in isolation; it does **not** prove each call site actually
+*calls* it — exactly the gap a "looks tested" seam hides. **System improvement (acted on here):** when
+a change adds a forwarding helper threaded through N call sites, the same PR should pin at least the
+high-traffic sites behaviorally, not just unit-test the helper — "the helper is correct" ≠ "every caller
+uses it". This run did the second half; folding the instinct into the seam idea above (a static
+completeness guard) would make it automatic.
+
+## Doc audit (Q-0104)
+Tests-only change; no doc/ledger surface touched (the seam's docs were de-staled in #1430). `check_docs`
+unaffected. Ledger entries for #1430 + #1431 land via the next reconciliation pass (band-#1440), no
+placeholder (Q-0052). No owner-decision / router change.
+
+## 📤 Run report
+- **Run type:** `routine · dispatch`
+- **Shipped (this run, 2 PRs):** #1430 (help-nav attachment seam + XP hub consumer) → #1431 (forward-path
+  regression pins on the primary Help-nav paths).
+- **⚑ Self-initiated:** YES — both PRs. #1430 promoted the groomed help-nav-seam idea → build; #1431
+  hardened it. No work order (Q-0172). Contained, reversible, tests-only for #1431.
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none (merges auto-deploy to Railway).
+- **Next ▶:** seam **incremental adoption** (any card-bearing hub sets `help_nav_card` in its hook — no
+  hub other than XP has a card *and* a Help path today, so this waits on a new card-bearing hub) · the
+  static seam-completeness guard idea above · the two secondary render-site pins (admin / typed help) ·
+  unrelated substantial S1 lanes (Project Moon runtime PR 1, botsite React PR 2) for a fresh session.

--- a/.sessions/2026-06-24-help-nav-seam-hardening.md
+++ b/.sessions/2026-06-24-help-nav-seam-hardening.md
@@ -1,0 +1,27 @@
+# 2026-06-24 — Harden the help-nav attachment seam (forward-path regression pins)
+
+> **Status:** `in-progress` — born-red card; flips to `complete` as the deliberate final step.
+
+> **Run type:** `routine · dispatch`
+
+## What I'm about to do
+Continuation of the same dispatch fire that shipped PR #1430 (the help-nav attachment seam). #1430
+landed and auto-merged cleanly. The seam has **6 render sites** that forward a hub's `help_nav_card`,
+but #1430 only added a *behavioral* forward-path pin on **one** (the navigation back-button) — the two
+**highest-traffic Help-discovery paths** (`HubChildButton` hub-child navigation, and the Help category
+**select** dropdown) relied on the accessor but had **no test that fails if the forward is dropped**.
+A refactor that removed `attachments=help_nav_attachments(...)` from either would pass CI silently.
+
+This slice closes that coverage gap — **tests only, no production change**:
+- `tests/unit/views/test_hub_children.py` — a card-bearing child view forwards `attachments=[card]`;
+  a cardless child clears attachments (navigate-away).
+- `tests/unit/help/test_help_category_view.py` — selecting a hub whose panel carries a card forwards
+  `attachments=[card]` on the in-place edit.
+
+Now the seam's three main user-facing nav flows (back-button #1430 · HubChildButton · category select)
+are all behaviorally guarded. The two secondary render sites (admin `_open_via_help_hook` cross-nav,
+typed `!help <cat>` send) stay covered by the accessor unit tests but aren't behaviorally pinned —
+lower-traffic, noted for a future pass rather than force-tested here.
+
+Self-initiated (Q-0172) — hardening the just-shipped seam; flagged on the run report. Full CI mirror
+green; auto-merge on green.

--- a/docs/owner/claims/claude-funny-franklin-7n1117b.md
+++ b/docs/owner/claims/claude-funny-franklin-7n1117b.md
@@ -1,0 +1,1 @@
+- branch `claude/funny-franklin-7n1117b` · scope: harden the help-nav attachment seam — behavioral forward-path regression pins on the primary Help-nav paths (HubChildButton, Help category select) so the just-shipped #1430 seam can't silently regress · area: `tests/unit/views/test_hub_children.py`, `tests/unit/help/test_help_category_view.py` (tests only) · 2026-06-24

--- a/docs/owner/claims/claude-funny-franklin-7n1117b.md
+++ b/docs/owner/claims/claude-funny-franklin-7n1117b.md
@@ -1,1 +1,0 @@
-- branch `claude/funny-franklin-7n1117b` · scope: harden the help-nav attachment seam — behavioral forward-path regression pins on the primary Help-nav paths (HubChildButton, Help category select) so the just-shipped #1430 seam can't silently regress · area: `tests/unit/views/test_hub_children.py`, `tests/unit/help/test_help_category_view.py` (tests only) · 2026-06-24

--- a/tests/unit/help/test_help_category_view.py
+++ b/tests/unit/help/test_help_category_view.py
@@ -235,6 +235,47 @@ async def test_selecting_hub_category_opens_host_cog_panel(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_selecting_hub_forwards_help_nav_card(monkeypatch):
+    """Forward-path pin (help-nav attachment seam, H3): selecting a hub whose
+    panel carries a ``help_nav_card`` must forward it as ``attachments=[card]``
+    on the in-place edit, so a card-bearing hub (the XP hub) shows its image
+    card when opened from the Help category index — not just from its command."""
+    import io
+
+    interaction = _interaction()
+    interaction.data = {"values": ["games"]}
+
+    vis_result = MagicMock()
+    vis_result.visible_subsystems = {"games"}
+    vis_result.member_tier = "owner"
+    monkeypatch.setattr(
+        help_cog.governance_service,
+        "resolve_visibility",
+        AsyncMock(return_value=vis_result),
+    )
+    monkeypatch.setattr(
+        help_cog.GovernanceContext,
+        "from_interaction",
+        lambda i: MagicMock(),
+    )
+
+    panel_view = discord.ui.View()
+    card = discord.File(io.BytesIO(b"\x89PNG\r\n\x1a\nfake"), filename="rank.png")
+    panel_view.help_nav_card = card  # type: ignore[attr-defined]
+    fake_cog = MagicMock()
+    fake_cog.build_help_menu_view = AsyncMock(
+        return_value=(discord.Embed(title="XP Hub"), panel_view),
+    )
+
+    with patch("cogs.help_cog._cog_for_subsystem", return_value=fake_cog):
+        view = HelpCategoryView(member_tier="owner")
+        await view._on_select(interaction)
+
+    kwargs = interaction.response.edit_message.call_args.kwargs
+    assert kwargs["attachments"] == [card]
+
+
+@pytest.mark.asyncio
 async def test_selecting_unknown_hub_sends_ephemeral(monkeypatch):
     interaction = _interaction()
     interaction.data = {"values": ["not_a_real_hub"]}

--- a/tests/unit/views/test_hub_children.py
+++ b/tests/unit/views/test_hub_children.py
@@ -135,6 +135,47 @@ async def test_forwards_to_hook_and_attaches_back():
     back.assert_called_once()  # the hub's Back attacher ran on the child view
 
 
+async def test_forwards_help_nav_card_as_attachment():
+    """Forward-path pin (help-nav attachment seam, H3): when the opened child
+    view carries a ``help_nav_card``, the in-place edit must forward it as
+    ``attachments=[card]`` so a card-bearing hub (e.g. the XP hub) shows its
+    image card when reached through hub navigation, not just its direct command.
+    A regression that drops the forward fails here."""
+    import io
+
+    button = _button()
+    interaction = _interaction()
+    embed = discord.Embed(title="XP")
+    sub_view = discord.ui.View()
+    card = discord.File(io.BytesIO(b"\x89PNG\r\n\x1a\nfake"), filename="rank.png")
+    sub_view.help_nav_card = card  # type: ignore[attr-defined]
+    cog = MagicMock()
+    cog.build_help_menu_view = AsyncMock(return_value=(embed, sub_view))
+
+    with _all_visible(), patch("cogs.help_cog._cog_for_subsystem", return_value=cog):
+        await button.callback(interaction)
+
+    kwargs = interaction.response.edit_message.await_args.kwargs
+    assert kwargs["attachments"] == [card]
+
+
+async def test_cardless_child_clears_attachments():
+    """A child with no card clears any prior screen's attachment (navigate-away),
+    so an image from the panel we came from does not linger."""
+    button = _button()
+    interaction = _interaction()
+    embed = discord.Embed(title="plain")
+    sub_view = discord.ui.View()  # no help_nav_card
+    cog = MagicMock()
+    cog.build_help_menu_view = AsyncMock(return_value=(embed, sub_view))
+
+    with _all_visible(), patch("cogs.help_cog._cog_for_subsystem", return_value=cog):
+        await button.callback(interaction)
+
+    kwargs = interaction.response.edit_message.await_args.kwargs
+    assert kwargs["attachments"] == []
+
+
 async def test_invisible_child_fails_closed():
     button = _button()
     interaction = _interaction()


### PR DESCRIPTION
## What & why

Follow-up hardening for the help-nav attachment seam shipped in #1430 (visual card-engine H3). The seam has **6 render sites** that forward a hub's `help_nav_card`, but #1430 added a *behavioral* forward-path pin on only **one** (the navigation back-button). The two **highest-traffic Help-discovery paths** — `HubChildButton` hub-child navigation and the Help category **select** dropdown — relied on the accessor but had **no test that fails if the `attachments=` forward is dropped**. A refactor that removed the forward from either would pass CI silently.

## Change — tests only, no production change

- `tests/unit/views/test_hub_children.py` — a card-bearing child view forwards `attachments=[card]`; a cardless child clears attachments (navigate-away).
- `tests/unit/help/test_help_category_view.py` — selecting a hub whose panel carries a card forwards `attachments=[card]` on the in-place edit.

The seam's three main user-facing nav flows (back-button #1430 · HubChildButton · category select) are now all behaviorally guarded. The two secondary render sites (admin `_open_via_help_hook`, typed `!help <cat>` send) stay covered by the accessor unit tests; lower-traffic, noted for a future pass.

⚑ Self-initiated (Q-0172): hardening the just-shipped seam, no work order. Tests only — zero production risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWcgdfWWdR7q8UB63gepQT)_