### PR TITLE
Essential Setup: "Choose a log channel" → two channels (mod + activity) + multi-select

### DIFF
--- a/.sessions/2026-06-24-setup-log-channel-rework.md
+++ b/.sessions/2026-06-24-setup-log-channel-rework.md
@@ -1,0 +1,24 @@
+# Session — 2026-06-24 · "Choose a log channel" rework (two-channel + multi-select)
+
+> **Status:** `in-progress` — born-red hold. Reworks the just-merged (#1429) moderation-only step;
+> additive to `EssentialFlow` (no new cog/command/artifact).
+
+**Trigger:** owner clarification (chat, 2026-06-24): the earlier "moderation only" answer (Q-0202) was
+meant as the *first slice*, not a permanent cap. Owner wants owners to **choose a few important logging
+types via a quick multi-select**, and chose a **two-channel** layout (moderation + activity) — "should
+not become too much work for server owners, but they should have the option."
+
+## What I'm about to do
+
+Rework `LogChannelStep` from one-channel/moderation-only into a **two-channel + multi-select** step:
+- **Multi-select** of activity types: members joining/leaving (default on) · role changes (default on) ·
+  message edits/deletions (⚠️ shows content, default off).
+- **Two channel pickers**: moderation/main channel + activity channel. **Leave blank → auto-create**
+  `#mod-log` / `#server-log` (so accepting defaults is one tap).
+- On Save (direct lane): `logging.enabled = True`; bind `mod_channel` → mod channel (moderation
+  baseline, always on); if any activity type chosen, set the category flags + bind `events_channel` →
+  activity channel. Auto-create via `ChannelLifecycleService.create_channels`; bindings via
+  `BindingMutationPipeline` (both lazy-imported per the setup-view invariant).
+- Supersede Q-0202 (router + plan); rework tests.
+
+<!-- close-out (what shipped / misses / enders / context delta) written as the final step -->

--- a/.sessions/2026-06-24-setup-log-channel-rework.md
+++ b/.sessions/2026-06-24-setup-log-channel-rework.md
@@ -1,24 +1,80 @@
 # Session — 2026-06-24 · "Choose a log channel" rework (two-channel + multi-select)
 
-> **Status:** `in-progress` — born-red hold. Reworks the just-merged (#1429) moderation-only step;
-> additive to `EssentialFlow` (no new cog/command/artifact).
+> **Status:** `complete` — reworks the same-day #1429 moderation-only step. Additive view-class change
+> on `EssentialFlow` (no new cog/command/artifact). PR #1432.
 
-**Trigger:** owner clarification (chat, 2026-06-24): the earlier "moderation only" answer (Q-0202) was
-meant as the *first slice*, not a permanent cap. Owner wants owners to **choose a few important logging
-types via a quick multi-select**, and chose a **two-channel** layout (moderation + activity) — "should
-not become too much work for server owners, but they should have the option."
+**Trigger:** owner clarification (chat, 2026-06-24): the earlier "moderation only" answer (Q-0202(1))
+was the *first slice*, not a permanent cap. Owner wants a **quick multi-select of logging types**, kept
+light, and chose a **two-channel** layout (moderation + activity) via `AskUserQuestion`.
 
-## What I'm about to do
+## What shipped
 
-Rework `LogChannelStep` from one-channel/moderation-only into a **two-channel + multi-select** step:
-- **Multi-select** of activity types: members joining/leaving (default on) · role changes (default on) ·
-  message edits/deletions (⚠️ shows content, default off).
-- **Two channel pickers**: moderation/main channel + activity channel. **Leave blank → auto-create**
-  `#mod-log` / `#server-log` (so accepting defaults is one tap).
-- On Save (direct lane): `logging.enabled = True`; bind `mod_channel` → mod channel (moderation
-  baseline, always on); if any activity type chosen, set the category flags + bind `events_channel` →
-  activity channel. Auto-create via `ChannelLifecycleService.create_channels`; bindings via
-  `BindingMutationPipeline` (both lazy-imported per the setup-view invariant).
-- Supersede Q-0202 (router + plan); rework tests.
+`LogChannelStep` reworked from one-channel/moderation-only → **two-channel + multi-select**:
+- **Multi-select** (`_ActivityTypeSelect`) of activity types — members joining/leaving (default on) ·
+  role changes (default on) · message edits/deletions (⚠️ shows content, default **off**).
+- **Two channel pickers** (`_LogChannelPicker`, reused for both slots) — a moderation/main channel +
+  an activity channel. **Leave either blank → auto-create** `#mod-log` / `#server-log` (one-tap
+  defaults; no required-pick error).
+- On Save (direct lane): `logging.enabled=True`; bind `logging.mod_channel` → mod channel (always-on
+  baseline); set `members_enabled`/`roles_enabled`/`messages_enabled` per the multi-select; bind
+  `logging.events_channel` → activity channel when any activity type is on. Auto-create via
+  `ChannelLifecycleService.create_channels`; bindings via `BindingMutationPipeline` (both lazy-imported
+  per the setup-view invariant).
+- Tests reworked (4): defaults-create-both-and-bind · picked-channels-no-create · activity-off
+  (moderation only) · create-failure-blocks. Suite 18 → 18 (replaced, not added).
+- Docs: router **Q-0203** (supersedes Q-0202(1)); Q-0202(1) marked superseded; plan §5 step 4 + §7
+  PR-1 note updated. Naming/preset/editor decisions (Q-0202 #2–4) untouched.
 
-<!-- close-out (what shipped / misses / enders / context delta) written as the final step -->
+## ✅ Verification
+
+`check_quality.py --full` → **12473 passed, 48 skipped, 2 xfailed** ✓. Jargon guard **154 (0 new —
+`essential_setup.py` clean)**; `check_architecture --mode strict` **0 errors**; setup sim **PASS**;
+`check_docs --strict` passed.
+
+## Misses
+
+The cost worth recording: I shipped #1429 (moderation-only) and **reworked it the same day** (#1432)
+because I read the owner's "Moderation log only (Recommended)" answer as a *permanent* scope cap, when
+it meant *first slice*. The architecture made the rework cheap (~declarative), but a full PR was spent
+on a superseded version. Root cause: the scope question didn't distinguish "starting scope, expandable"
+from "final scope" — and recommending the **narrowest** option nudged toward it.
+
+## 💡 Session idea (Q-0089)
+
+**Use `AskUserQuestion`'s `preview` field to show a mockup of each option's resulting UX for setup/design
+choices.** Had the "moderation only" vs "two-channel multi-select" options each rendered a quick preview
+of the resulting step screen, the owner would likely have picked the richer one first and skipped the
+#1429→#1432 rework. The tool already supports per-option `preview`; we just don't use it for design
+forks. Concrete, low-cost, and directly motivated by today's same-day rework. Dedup-checked
+`docs/ideas/` — not present.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous: **`2026-06-24-setup-log-channel-step.md`** (the #1429 moderation-only step — this session's own
+predecessor). **Did well:** clean declarative `LogChannelStep`, recorded Q-0202, full green verification;
+the declarative design is exactly why *this* rework was cheap. **Missed:** it treated a scope-narrowing
+answer as final and built copy/code/docs around "moderation only" — when the owner meant a first slice,
+forcing a same-day rework. **System improvement:** when an owner picks a scope-*narrowing* option,
+confirm whether it's the **final scope or a starting slice** (and prefer the Q-0089 per-option previews
+so the trade-off is visible up front). Recommending the narrowest option as "(Recommended)" without that
+framing is what nudged the misread.
+
+## 📋 Doc audit (Q-0104)
+
+Router Q-0203 added + Q-0202(1) marked superseded; plan §5/§7 updated; `check_docs --strict` passed. No
+`current-state.md` ledger entry until #1432 merges (auto-merges on green; next recon pass at #1440 folds
+it in). Nothing from this session lives only in chat.
+
+## Context delta — for next session
+
+- **The log step is now final (Q-0203): two-channel + multi-select.** No further logging work planned in
+  the spine; the full per-category surface stays in the `!logging` admin UI.
+- **Next ▶ spine step still "Reward activity"** — XP toggle is trivial; the role-reward sub-step needs a
+  **new direct-apply role-threshold service** (the one genuine gap) + `RoleLifecycleService.create_role`
+  for auto-create. That's service-layer work → its own focused PR.
+- **Pattern confirmed twice now:** appending/reworking an `EssentialFlow` step is cheap and fan-out-free
+  (view classes only). The expensive part is *getting the scope right up front* — hence the Q-0089 idea.
+
+## ⚑ Self-initiated: NONE — owner-directed. The rework + the two-channel choice came from the owner
+(chat clarification + `AskUserQuestion`). Within-steer specifics (multi-select defaults, blank→auto-create
+UX, message-content default-off for privacy) were my calls. Additive, test-covered, old wizard untouched.

--- a/disbot/views/setup/essential_setup.py
+++ b/disbot/views/setup/essential_setup.py
@@ -520,56 +520,84 @@ class BlockSpamStep(_StepView):
 
 
 # ---------------------------------------------------------------------------
-# Step 4 — Choose a log channel  (logging: enable + bind the catch-all channel)
+# Step 4 — Choose a log channel  (logging: enable + bind mod & activity channels)
 # ---------------------------------------------------------------------------
 #
-# Scope is **moderation log only** (owner decision, 2026-06-24): one channel for
-# moderation actions (warn/timeout/kick/ban) and anything else the bot reports.
-# Member-activity / message logging stay OFF — they are a later follow-on. So
-# the step writes exactly two things on Save: ``logging.enabled = True`` and the
-# ``logging.mod_channel`` binding (the slot every other logging route falls back
-# to), which is the literal "choose a log channel" the PR-1 note describes.
+# Two channels (owner decision, 2026-06-24, superseding the moderation-only
+# Q-0202): a **moderation log** — always on, ``logging.mod_channel``, the
+# catch-all every route falls back to — and an optional **activity log**
+# (``logging.events_channel``) for the server-activity categories the operator
+# ticks in a quick multi-select (members joining/leaving, role changes, message
+# edits/deletions — each its own ``*_enabled`` flag).  Leave a channel empty and
+# we auto-create it (#mod-log / #server-log), so accepting the defaults is one
+# tap.  Every write goes through the audited Settings + Binding pipelines
+# (lazy-imported per the setup-view no-top-level-pipeline-import invariant).
 
-# Plain-language default name for the channel we offer to create.
-_NEW_LOG_CHANNEL_NAME = "mod-log"
+# Plain-language default names for the channels we offer to create.
+_NEW_MOD_CHANNEL_NAME = "mod-log"
+_NEW_ACTIVITY_CHANNEL_NAME = "server-log"
+
+# Optional server-activity categories: (logging flag, operator label, default-on).
+# Message logging defaults OFF — it exposes edited/deleted content (a privacy
+# trade-off the schema warns about); the privacy-safe two default on.
+_ACTIVITY_TYPES: list[tuple[str, str, bool]] = [
+    ("members_enabled", "Members joining & leaving", True),
+    ("roles_enabled", "Role changes", True),
+    ("messages_enabled", "Message edits & deletions", False),
+]
+_DEFAULT_ACTIVITY: set[str] = {flag for flag, _, on in _ACTIVITY_TYPES if on}
 
 
-class _LogChannelSelect(discord.ui.ChannelSelect):  # type: ignore[type-arg]
-    def __init__(self) -> None:
+class _ActivityTypeSelect(discord.ui.Select):  # type: ignore[type-arg]
+    def __init__(self, selected: set[str]) -> None:
+        options = [
+            discord.SelectOption(
+                label=label,
+                value=flag,
+                default=flag in selected,
+                description=(
+                    "Shows the content members edited or deleted"
+                    if flag == "messages_enabled"
+                    else None
+                ),
+            )
+            for flag, label, _ in _ACTIVITY_TYPES
+        ]
         super().__init__(
-            placeholder="Pick a channel for the bot's log…",
-            channel_types=[discord.ChannelType.text],
+            placeholder="What should the activity channel log?",
             min_values=0,
-            max_values=1,
+            max_values=len(options),
+            options=options,
             row=0,
         )
 
     async def callback(self, interaction: discord.Interaction) -> None:
         view: LogChannelStep = self.view  # type: ignore[assignment]
-        view.channel_id = self.values[0].id if self.values else None
-        # Picking an existing channel turns off "make one for me".
-        if view.channel_id is not None:
-            view.auto_create = False
+        view.activity = set(self.values)
         view.refresh_items()
         await interaction.response.edit_message(embed=view.render(), view=view)
 
 
-class _AutoCreateLogButton(discord.ui.Button):  # type: ignore[type-arg]
-    def __init__(self, on: bool) -> None:
+class _LogChannelPicker(discord.ui.ChannelSelect):  # type: ignore[type-arg]
+    """One channel picker, reused for both the moderation and activity slots."""
+
+    def __init__(self, *, target: str, placeholder: str, row: int) -> None:
+        self.target = target  # "mod" | "activity"
         super().__init__(
-            label=f"Make a #{_NEW_LOG_CHANNEL_NAME} channel: {'ON' if on else 'OFF'}",
-            style=(
-                discord.ButtonStyle.success if on else discord.ButtonStyle.secondary
-            ),
-            row=1,
+            placeholder=placeholder,
+            channel_types=[discord.ChannelType.text],
+            min_values=0,
+            max_values=1,
+            row=row,
         )
 
     async def callback(self, interaction: discord.Interaction) -> None:
         view: LogChannelStep = self.view  # type: ignore[assignment]
-        view.auto_create = not view.auto_create
-        # Choosing "make one for me" clears any existing pick (one target wins).
-        if view.auto_create:
-            view.channel_id = None
+        chosen = self.values[0].id if self.values else None
+        if self.target == "mod":
+            view.mod_channel_id = chosen
+        else:
+            view.activity_channel_id = chosen
         view.refresh_items()
         await interaction.response.edit_message(embed=view.render(), view=view)
 
@@ -577,10 +605,10 @@ class _AutoCreateLogButton(discord.ui.Button):  # type: ignore[type-arg]
 class _LogSaveButton(discord.ui.Button):  # type: ignore[type-arg]
     def __init__(self) -> None:
         super().__init__(
-            label="Save log channel",
+            label="Save logging",
             emoji="📋",
             style=discord.ButtonStyle.success,
-            row=2,
+            row=4,
         )
 
     async def callback(self, interaction: discord.Interaction) -> None:
@@ -593,83 +621,150 @@ class LogChannelStep(_StepView):
     skip_label = "Skip logging"
 
     def __init__(self, flow: EssentialFlow) -> None:
-        self.channel_id: int | None = None
-        self.auto_create: bool = False
+        self.mod_channel_id: int | None = None
+        self.activity_channel_id: int | None = None
+        self.activity: set[str] = set(_DEFAULT_ACTIVITY)
         super().__init__(flow)
 
     def build_items(self) -> None:
         self.refresh_items()
 
     def refresh_items(self) -> None:
-        """(Re)build the row-0/1/2 controls — used after a pick / toggle flips."""
+        """(Re)build the controls from current state (rows 0/1/2/4).
+
+        Rebuilt on every interaction so the multi-select reflects ``activity``;
+        the channel pickers reset visually but the chosen ids persist on the
+        view and are shown in the embed.
+        """
         for child in list(self.children):
             if isinstance(
                 child,
-                (_LogChannelSelect, _AutoCreateLogButton, _LogSaveButton),
+                (_ActivityTypeSelect, _LogChannelPicker, _LogSaveButton),
             ):
                 self.remove_item(child)
-        self.add_item(_LogChannelSelect())
-        self.add_item(_AutoCreateLogButton(self.auto_create))
+        self.add_item(_ActivityTypeSelect(self.activity))
+        self.add_item(
+            _LogChannelPicker(
+                target="mod",
+                placeholder="Moderation log channel (or leave empty)…",
+                row=1,
+            ),
+        )
+        self.add_item(
+            _LogChannelPicker(
+                target="activity",
+                placeholder="Activity log channel (or leave empty)…",
+                row=2,
+            ),
+        )
         self.add_item(_LogSaveButton())
 
     def render(self) -> discord.Embed:
         embed = discord.Embed(
             title=f"📋 {self.title}",
             description=(
-                "Keep a record of what the bot does — warnings, timeouts, "
-                "kicks and bans, plus anything else it needs to report — all "
-                "in one channel.\n\n"
-                "Pick a channel below, or let us make a fresh "
-                f"**#{_NEW_LOG_CHANNEL_NAME}** for you, then press "
-                "**Save log channel**."
+                "Keep a tidy record of what happens on your server, in two "
+                "channels:\n"
+                "• a **moderation log** — warnings, timeouts, kicks and bans\n"
+                "• an **activity log** — the things you tick below\n\n"
+                "Pick a channel for each, or leave one empty and we'll make it "
+                f"for you (**#{_NEW_MOD_CHANNEL_NAME}** / "
+                f"**#{_NEW_ACTIVITY_CHANNEL_NAME}**). Then press **Save logging**."
             ),
             color=discord.Color.blurple(),
         )
-        if self.channel_id:
-            where = f"<#{self.channel_id}>"
-        elif self.auto_create:
-            where = f"a new **#{_NEW_LOG_CHANNEL_NAME}** channel"
+        embed.add_field(
+            name="Moderation log",
+            value=self._where(self.mod_channel_id, _NEW_MOD_CHANNEL_NAME),
+            inline=False,
+        )
+        if self.activity:
+            picked = ", ".join(
+                label for flag, label, _ in _ACTIVITY_TYPES if flag in self.activity
+            )
+            embed.add_field(
+                name="Activity log",
+                value=(
+                    f"{self._where(self.activity_channel_id, _NEW_ACTIVITY_CHANNEL_NAME)}\n"
+                    f"_Logging: {picked}_"
+                ),
+                inline=False,
+            )
         else:
-            where = "_not chosen yet_"
-        embed.add_field(name="The log goes to", value=where, inline=False)
+            embed.add_field(
+                name="Activity log",
+                value="_off — tick any activity above to turn it on_",
+                inline=False,
+            )
         embed.set_footer(text=self.flow.step_counter())
         return embed
 
+    @staticmethod
+    def _where(channel_id: int | None, default_name: str) -> str:
+        if channel_id:
+            return f"<#{channel_id}>"
+        return f"a new **#{default_name}** channel"
+
     async def apply(self, interaction: discord.Interaction) -> None:
-        channel_id = self.channel_id
-        created = False
-        if channel_id is None and self.auto_create:
-            channel_id = await self._create_log_channel(interaction)
-            if channel_id is None:
-                return  # creation failed; the error was already surfaced
-            created = True
-        if channel_id is None:
-            await interaction.response.send_message(
-                f"Pick a channel, or choose **Make a #{_NEW_LOG_CHANNEL_NAME} "
-                "channel** first.",
-                ephemeral=True,
-            )
-            return
+        created: list[str] = []
+        # Moderation log is the always-on baseline — resolve (or create) it.
+        mod_id = self.mod_channel_id
+        if mod_id is None:
+            mod_id = await self._create_channel(interaction, _NEW_MOD_CHANNEL_NAME)
+            if mod_id is None:
+                return  # creation failed; error already surfaced
+            created.append(_NEW_MOD_CHANNEL_NAME)
+        # Activity log only when at least one activity category is ticked.
+        activity_id: int | None = None
+        if self.activity:
+            activity_id = self.activity_channel_id
+            if activity_id is None:
+                activity_id = await self._create_channel(
+                    interaction,
+                    _NEW_ACTIVITY_CHANNEL_NAME,
+                )
+                if activity_id is None:
+                    return
+                created.append(_NEW_ACTIVITY_CHANNEL_NAME)
         try:
             await self._set("logging", "enabled", True)
-            await self._bind_log_channel(channel_id)
+            await self._bind("mod_channel", mod_id)
+            for flag, _, _ in _ACTIVITY_TYPES:
+                await self._set("logging", flag, flag in self.activity)
+            if activity_id is not None:
+                await self._bind("events_channel", activity_id)
         except Exception:
             logger.exception("essential setup: log-channel step apply failed")
             await interaction.response.send_message(
-                "Something went wrong saving your log channel — please try again.",
+                "Something went wrong saving your log channels — please try again.",
                 ephemeral=True,
             )
             return
-        line = f"Logging on, posting to <#{channel_id}>"
-        if created:
-            line += " (created for you)"
-        await self.complete(interaction, line)
+        await self.complete(interaction, self._summary(mod_id, activity_id, created))
 
-    async def _create_log_channel(
+    def _summary(
+        self,
+        mod_id: int,
+        activity_id: int | None,
+        created: list[str],
+    ) -> str:
+        parts = [f"moderation → <#{mod_id}>"]
+        if activity_id is not None:
+            picked = ", ".join(
+                label for flag, label, _ in _ACTIVITY_TYPES if flag in self.activity
+            ).lower()
+            parts.append(f"activity ({picked}) → <#{activity_id}>")
+        line = "Logging on · " + " · ".join(parts)
+        if created:
+            line += " · created " + ", ".join(f"#{name}" for name in created)
+        return line
+
+    async def _create_channel(
         self,
         interaction: discord.Interaction,
+        name: str,
     ) -> int | None:
-        """Create the #mod-log channel through the audited lifecycle creator.
+        """Create *name* through the audited lifecycle creator.
 
         Returns the new channel's id, or ``None`` after surfacing an error (the
         caller then stops without writing anything).  ``ChannelLifecycleService``
@@ -680,30 +775,30 @@ class LogChannelStep(_StepView):
 
         result = await ChannelLifecycleService().create_channels(
             self.flow.guild,
-            [_NEW_LOG_CHANNEL_NAME],
+            [name],
             self.flow.author,
         )
         if not result.applied:
             logger.warning(
-                "essential setup: log channel create failed (guild=%s): %s",
+                "essential setup: log channel %r create failed (guild=%s): %s",
+                name,
                 self.flow.guild.id,
                 result.first_error,
             )
             await interaction.response.send_message(
-                "Couldn't make the channel — please pick an existing one instead.",
+                "Couldn't make a channel — please pick existing ones instead.",
                 ephemeral=True,
             )
             return None
         return result.applied[0].target_id
 
-    async def _bind_log_channel(self, channel_id: int) -> None:
-        """Point the bot's log at *channel_id* through the audited write path.
+    async def _bind(self, binding_name: str, channel_id: int) -> None:
+        """Bind ``logging.<binding_name>`` to *channel_id* through the audited
+        write path.
 
         ``BindingMutationPipeline`` is on the setup-view no-top-level-import list
         (``test_setup_operations_invariants``), so it — and ``BindingKind`` — are
-        imported lazily here, exactly like ``_set`` does for settings.  We bind
-        ``logging.mod_channel`` (the slot every other logging route falls back
-        to), so a single pick lights up the whole moderation/catch-all log.
+        imported lazily here, exactly like ``_set`` does for settings.
         """
         from core.runtime.subsystem_schema import BindingKind
         from services.binding_mutation import BindingMutationPipeline
@@ -711,7 +806,7 @@ class LogChannelStep(_StepView):
         await BindingMutationPipeline().set_binding(
             self.flow.guild,
             "logging",
-            "mod_channel",
+            binding_name,
             BindingKind.CHANNEL,
             channel_id,
             self.flow.author,

--- a/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
+++ b/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
@@ -1,1 +1,0 @@
-claude/blissful-hamilton-xdzbak · Essential Setup "Choose a log channel" rework → two-channel (mod + activity) + multi-select of activity types (supersedes Q-0202 moderation-only) · disbot/views/setup/essential_setup.py + tests/unit/views/setup/test_essential_setup.py · 2026-06-24

--- a/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
+++ b/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
@@ -1,0 +1,1 @@
+claude/blissful-hamilton-xdzbak · Essential Setup "Choose a log channel" rework → two-channel (mod + activity) + multi-select of activity types (supersedes Q-0202 moderation-only) · disbot/views/setup/essential_setup.py + tests/unit/views/setup/test_essential_setup.py · 2026-06-24

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -7362,12 +7362,12 @@ needed the owner. Asked as one `AskUserQuestion` batch; answers verbatim below. 
 (scope, name); two settle *later* PRs (step-0 preset = Q-C, the Advanced editor = Q-E) "while you're here".
 
 **The decisions.**
-1. **Log scope = moderation log only.** The step is *one* channel: it turns on `logging.enabled` and binds
-   `logging.mod_channel` (the catch-all slot every other logging route falls back to) to the picked-or-
-   created channel. **Member-activity (joins/leaves/roles) and message-content logging stay OFF** — they
-   are a later follow-on, not this step. This supersedes the plan §5 "log channel pair" framing and matches
-   the PR-1 note's "*a* binding write" (singular). The step copy was corrected to stop promising
-   joins/edits.
+1. **Log scope = moderation log only.** ⚠️ **SUPERSEDED by Q-0203 (2026-06-24, same day).** The step is
+   *one* channel: it turns on `logging.enabled` and binds `logging.mod_channel` (the catch-all slot every
+   other logging route falls back to) to the picked-or-created channel. **Member-activity (joins/leaves/
+   roles) and message-content logging stay OFF** — they are a later follow-on, not this step. *(Reversed
+   the same day: the owner clarified "moderation only" was the first slice, not a cap, and asked for a quick
+   multi-select of logging types across two channels — see Q-0203. Decisions 2–4 below still stand.)*
 2. **Auto-create naming (plan Q-D) = plain-language names.** Auto-created channels/roles use the short §4
    wording — `#mod-log` / `#server-log`, "Level 10", "Regular" — **not** the longer `bot-`-prefixed
    `suggested_name` convention. (The log step creates `#mod-log`.)
@@ -7391,3 +7391,36 @@ and binds `logging.mod_channel` via `BindingMutationPipeline` (lazy-imported per
 **Home:** this Q-block (canonical) + the plan §7 PR-1 note / §5 step 4 / §10 (Q-C/Q-D/Q-E) +
 `.sessions/2026-06-24-setup-log-channel-step.md`. Related: **Q-A** (direct-apply per step), the
 setup-wizard restructure plan.
+
+### Q-0203 — ANSWERED (owner decision, in-session): the "Choose a log channel" step is a two-channel + multi-select, not moderation-only (2026-06-24)
+
+**Context.** Q-0202(1) scoped the log step to **moderation only** and shipped it that way (#1429). Same
+day, the owner clarified that "moderation only" was meant as the **first slice of a multi-step logging
+config, not a permanent cap** — and that owners should be able to **choose a few important logging types**
+via a **quick multi-select**, kept light ("should not become too much work for server owners, but they
+should have the option"). Asked where the chosen logs should go (one channel / two channels / per-type
+channels via `AskUserQuestion`), the owner chose **two channels (moderation + activity)**.
+
+**The decision.** The step now offers a **quick multi-select of activity types** — members joining/leaving
+(default on) · role changes (default on) · message edits/deletions (⚠️ shows content, default **off**) —
+across **two channels**: a **moderation log** (always on → `logging.mod_channel`, the catch-all) and an
+**activity log** (→ `logging.events_channel`) for the ticked categories. **Leave a channel empty and the
+bot auto-creates it** (`#mod-log` / `#server-log`), so accepting the defaults is one tap. On Save (direct
+lane): `logging.enabled=True`; bind `mod_channel`; set the `members_enabled`/`roles_enabled`/
+`messages_enabled` flags per the multi-select; bind `events_channel` when any activity type is on. Message
+logging stays opt-in because it exposes edited/deleted content (the schema's privacy warning).
+
+**Scope / non-generalization.** This **supersedes Q-0202(1) only** — the naming (Q-0202(2): `#mod-log` /
+`#server-log`), the step-0 preset (Q-0202(3)=Q-C), and the Advanced-editor rework (Q-0202(4)=Q-E)
+decisions are unaffected. It does **not** promote the full per-category logging surface (the other ~10
+channel slots + per-category routing) into the spine — that stays in the existing `!logging` admin UI; the
+spine offers a curated few.
+
+**Applied.** PR **#1432** reworks `LogChannelStep` on `EssentialFlow` into the two-channel + multi-select
+design above (multi-select + two `_LogChannelPicker`s + auto-create blanks via
+`ChannelLifecycleService.create_channels`; bindings via `BindingMutationPipeline`, both lazy-imported per
+the setup-view invariant). Reworked tests cover defaults-create-both, picked-channels, activity-off
+(moderation only), and create-failure.
+
+**Home:** this Q-block (canonical) + the plan §5 step 4 / §7 PR-1 note + Q-0202(1) (superseded) +
+`.sessions/2026-06-24-setup-log-channel-rework.md`. Related: **Q-0202**, **Q-A** (direct-apply per step).

--- a/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
+++ b/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
@@ -106,10 +106,12 @@ The fix is not more sections — it is a **structure** built from four laws.
    (DM-on-action, require-reason). (`moderation` + governance mod role.)
 3. **Block spam and bad links** *(NEW)* — one screen of toggles with sensible pre-filled limits.
    (`automod` spam/invites/caps/mentions.)
-4. **Where should activity appear?** — pick **or auto-create** a log channel.
-   (`logging` enable + the `mod_channel` binding.) **Shipped scoped to a single moderation/catch-all
-   channel** (owner decision 2026-06-24, `#1429`); the "pair" + member/message activity is a later
-   follow-on, not this step.
+4. **Where should activity appear?** — a quick **multi-select** of logging types across **two channels**:
+   a **moderation log** (always on → `mod_channel`) and an **activity log** (→ `events_channel`) for the
+   ticked categories (members join/leave · role changes · message edits ⚠️). Pick or **auto-create** each
+   (`#mod-log` / `#server-log`). **Shipped:** moderation-only first (`#1429`), then reworked to the
+   two-channel multi-select (`#1432`, owner decision Q-0203 — "moderation only" was the first slice, not a
+   cap). Full per-category routing stays in the advanced `!logging` UI.
 5. **Reward active members** — turn on levels; optionally auto-grant a role as members stay & chat —
    **the bot creates the roles**. (`xp` + `roles` + `role_templates`, dead-end removed.)
 6. **Set up a help desk** — let members open private support; pick who answers; bot makes the rest.
@@ -175,14 +177,15 @@ decision with architectural weight → called out as open question Q-A below.
   Additive: the old wizard is untouched (retired in PR 3). Jargon-clean (guard: the new file adds 0
   findings). **Remaining steps are mechanical follow-ons on the exact same pattern — append a `_StepView`
   subclass to `EssentialFlow._steps` + a test; no new cog/command/artifact, so no registration fan-out:**
-  - **Choose a log channel** *(SHIPPED 2026-06-24, `#1429`)* — a binding write via
-    `BindingMutationPipeline` (⚠ on the no-top-level-import list — **lazy-imported** inside the step,
-    like `_set` does for settings) + an optional **auto-create** via
-    `ChannelLifecycleService.create_channels`. **Scope = moderation log only (owner decision,
-    2026-06-24):** one screen turns on `logging.enabled` and binds `logging.mod_channel` (the
-    catch-all slot every other route falls back to) to the picked-or-created channel; auto-create makes
-    a `#mod-log`. Member-activity / message-content logging stay OFF — they are a later follow-on, not
-    this step. (The earlier §5 "log channel pair" framing is superseded by this single-channel answer.)
+  - **Choose a log channel** *(SHIPPED 2026-06-24 — `#1429` moderation-only, then reworked in `#1432`)* —
+    binding writes via `BindingMutationPipeline` + auto-create via `ChannelLifecycleService.create_channels`
+    (⚠ both on the no-top-level-import list — **lazy-imported** inside the step, like `_set` does for
+    settings). **Final scope = two-channel + multi-select (owner decision Q-0203, superseding the Q-0202
+    moderation-only answer):** a quick multi-select of activity types (members join/leave + role changes on
+    by default; message edits/deletions ⚠️ off by default) across a **moderation log** (always on →
+    `logging.mod_channel`) and an **activity log** (→ `logging.events_channel`). On Save: `logging.enabled`,
+    bind `mod_channel`, set the `*_enabled` flags per the multi-select, bind `events_channel` when any
+    activity is on. **Leave a channel empty → auto-create** `#mod-log` / `#server-log` (one-tap defaults).
   - **Reward activity** — the `xp` enable toggle is trivial via `_set`; the role-threshold sub-step
     **needs a small new direct-apply role-threshold service** (the one genuine gap — no direct-apply path
     exists today) + `RoleLifecycleService.create_role` for auto-create.

--- a/tests/unit/views/setup/test_essential_setup.py
+++ b/tests/unit/views/setup/test_essential_setup.py
@@ -223,75 +223,100 @@ async def test_block_spam_respects_toggled_off_filter(pipeline):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_log_channel_requires_a_pick_or_create(
-    pipeline,
-    binding_pipeline,
-    channel_service,
-):
-    flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 3
-    step = es.LogChannelStep(flow)
-    interaction = _interaction()
-
-    await step.apply(interaction)
-
-    # Nothing picked and auto-create off → no writes, no advance.
-    pipeline.set_value.assert_not_awaited()
-    binding_pipeline.set_binding.assert_not_awaited()
-    channel_service.create_channels.assert_not_awaited()
-    interaction.response.send_message.assert_awaited_once()
-    assert "channel" in interaction.response.send_message.await_args.args[0].lower()
-    assert flow.index == 3
-
-
-@pytest.mark.asyncio
-async def test_log_channel_binds_picked_channel_and_advances(pipeline, binding_pipeline):
-    flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 3
-    step = es.LogChannelStep(flow)
-    step.channel_id = 8800
-
-    await step.apply(_interaction())
-
-    # logging.enabled flipped on through the settings pipeline …
-    assert ("logging", "enabled") in {
-        (c.args[1], c.args[2]) for c in pipeline.set_value.await_args_list
-    }
-    # … and mod_channel bound to the picked channel through the binding pipeline.
-    binding_pipeline.set_binding.assert_awaited_once()
-    args = binding_pipeline.set_binding.await_args.args
-    assert args[1] == "logging"
-    assert args[2] == "mod_channel"
-    assert args[3] == BindingKind.CHANNEL
-    assert args[4] == 8800
-    assert flow.index == 4
-    assert flow.applied and "8800" in flow.applied[0]
-
-
-@pytest.mark.asyncio
-async def test_log_channel_auto_creates_then_binds(
-    pipeline,
-    binding_pipeline,
-    channel_service,
-):
-    flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 3
-    step = es.LogChannelStep(flow)
-    step.auto_create = True
-    channel_service.create_channels.return_value = SimpleNamespace(
-        applied=(SimpleNamespace(target_id=4321),),
+def _created(target_id: int):
+    return SimpleNamespace(
+        applied=(SimpleNamespace(target_id=target_id),),
         first_error="",
     )
 
+
+@pytest.mark.asyncio
+async def test_log_channel_defaults_create_both_and_bind(
+    pipeline,
+    binding_pipeline,
+    channel_service,
+):
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 3
+    step = es.LogChannelStep(flow)  # defaults: members + roles on, messages off
+    # No channels picked → auto-create both (mod first, then activity).
+    channel_service.create_channels.side_effect = [_created(111), _created(222)]
+
     await step.apply(_interaction())
 
-    channel_service.create_channels.assert_awaited_once()
-    # the created channel id is bound, and the summary notes it was created.
-    binding_pipeline.set_binding.assert_awaited_once()
-    assert binding_pipeline.set_binding.await_args.args[4] == 4321
+    # Both default channels created, in order.
+    assert channel_service.create_channels.await_count == 2
+    names = [c.args[1][0] for c in channel_service.create_channels.await_args_list]
+    assert names == ["mod-log", "server-log"]
+    # logging enabled + the three category flags applied per the defaults.
+    settings = {
+        (c.args[1], c.args[2]): c.args[3] for c in pipeline.set_value.await_args_list
+    }
+    assert settings[("logging", "enabled")] is True
+    assert settings[("logging", "members_enabled")] is True
+    assert settings[("logging", "roles_enabled")] is True
+    assert settings[("logging", "messages_enabled")] is False  # privacy: off default
+    # mod_channel → the mod log, events_channel → the activity log.
+    binds = {
+        c.args[2]: c.args[4] for c in binding_pipeline.set_binding.await_args_list
+    }
+    assert binds == {"mod_channel": 111, "events_channel": 222}
+    assert all(
+        c.args[3] == BindingKind.CHANNEL
+        for c in binding_pipeline.set_binding.await_args_list
+    )
     assert flow.index == 4
-    assert flow.applied and "created" in flow.applied[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_log_channel_picked_channels_bind_without_create(
+    pipeline,
+    binding_pipeline,
+    channel_service,
+):
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 3
+    step = es.LogChannelStep(flow)
+    step.mod_channel_id = 700
+    step.activity_channel_id = 800
+
+    await step.apply(_interaction())
+
+    channel_service.create_channels.assert_not_awaited()
+    binds = {
+        c.args[2]: c.args[4] for c in binding_pipeline.set_binding.await_args_list
+    }
+    assert binds == {"mod_channel": 700, "events_channel": 800}
+    assert flow.index == 4
+
+
+@pytest.mark.asyncio
+async def test_log_channel_no_activity_logs_moderation_only(
+    pipeline,
+    binding_pipeline,
+    channel_service,
+):
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 3
+    step = es.LogChannelStep(flow)
+    step.activity = set()  # operator unticked every activity type
+    step.mod_channel_id = 700
+
+    await step.apply(_interaction())
+
+    # Only the moderation channel is bound — no activity channel, no create.
+    channel_service.create_channels.assert_not_awaited()
+    assert {
+        c.args[2] for c in binding_pipeline.set_binding.await_args_list
+    } == {"mod_channel"}
+    # The three activity flags are explicitly written off.
+    settings = {
+        (c.args[1], c.args[2]): c.args[3] for c in pipeline.set_value.await_args_list
+    }
+    assert settings[("logging", "members_enabled")] is False
+    assert settings[("logging", "roles_enabled")] is False
+    assert settings[("logging", "messages_enabled")] is False
+    assert flow.index == 4
 
 
 @pytest.mark.asyncio
@@ -302,8 +327,7 @@ async def test_log_channel_create_failure_blocks(
 ):
     flow = es.EssentialFlow(_member(), _guild())
     flow.index = 3
-    step = es.LogChannelStep(flow)
-    step.auto_create = True
+    step = es.LogChannelStep(flow)  # defaults; no channels picked → tries mod create
     channel_service.create_channels.return_value = SimpleNamespace(
         applied=(),
         first_error="missing permission",
@@ -312,7 +336,7 @@ async def test_log_channel_create_failure_blocks(
 
     await step.apply(interaction)
 
-    # Creation failed → surfaced an error, wrote nothing, did not advance.
+    # The mod-channel create failed → surfaced an error, wrote nothing, no advance.
     channel_service.create_channels.assert_awaited_once()
     binding_pipeline.set_binding.assert_not_awaited()
     pipeline.set_value.assert_not_awaited()


### PR DESCRIPTION
Reworks the "Choose a log channel" essentials step (shipped moderation-only in #1429) into a **two-channel + multi-select** design — owner clarification (chat, 2026-06-24): the earlier "moderation only" answer was the first slice, not a cap; owners should be able to pick a few important logging types, with moderation and activity in **separate channels**.

## What changes
The step now offers:
- **A quick multi-select of activity types** → members joining/leaving (on by default) · role changes (on by default) · message edits/deletions (⚠️ shows content, off by default).
- **Two channel pickers** — a moderation/main channel and an activity channel. **Leave either blank and the bot auto-creates `#mod-log` / `#server-log`**, so accepting the defaults is a single tap.

On Save (direct lane, applies immediately):
- `logging.enabled = True`;
- bind `logging.mod_channel` → the moderation channel (the always-on baseline / catch-all);
- if any activity type is selected: set the `members_enabled` / `roles_enabled` / `messages_enabled` flags accordingly and bind `logging.events_channel` → the activity channel (so server-activity events route there, kept out of the moderation channel).

## Notes
- Supersedes **Q-0202** (moderation-only) — recorded in the router + plan.
- `BindingMutationPipeline` (+ `BindingKind`) and `ChannelLifecycleService` stay **lazy-imported inside the step** (setup-view no-top-level-pipeline-import invariant).
- Additive view-class rework (no new cog/command/artifact). Plain-language copy — jargon guard stays clean.
- Tests reworked for the two-channel + multi-select behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PPgD6XUGaxHBD6JVYxbDp

---
_Generated by [Claude Code](https://claude.ai/code/session_016PPgD6XUGaxHBD6JVYxbDp)_