### PR TITLE
Essential Setup: "Reward active members" step (XP rate + level/time role rewards)

### DIFF
--- a/.sessions/2026-06-24-setup-reward-activity.md
+++ b/.sessions/2026-06-24-setup-reward-activity.md
@@ -1,0 +1,28 @@
+# Session — 2026-06-24 · Essential Setup step "Reward activity"
+
+> **Status:** `in-progress` — born-red hold. Additive to `EssentialFlow` (no new cog/command/artifact);
+> a 2-screen step. Reuses existing audited services — no new service needed.
+
+**Trigger:** owner-directed (chat, 2026-06-24): build the spine's "Reward active members" step. Owner
+chose: toggle role rewards (both/one/none), selectable XP ranges, **an extra step to choose the reward
+role** (preset / create-your-own / reuse existing) — all via buttons/dropdowns/multi-selects.
+
+## What I'm about to do
+
+Add a **`RewardActivityStep`** to `EssentialFlow` (a 2-screen step via an internal `phase`):
+- **Screen 1:** XP-rate dropdown (Keep current / Relaxed / Standard / Active → sets `xp_min`/`xp_max`/
+  `xp_cooldown` via `SettingsMutationPipeline`) + a reward-types multi-select (level-up roles /
+  time-in-server roles — both/one/none).
+- **Screen 2** (only when ≥1 reward type is on): choose the reward role — **Recommended** (auto-create
+  `@Regular`) / **Create one I name** (suggested-name dropdown) / **Reuse an existing role** (RoleSelect).
+- On Save: set the XP rate if changed; for each enabled trigger call `role_automation.set_xp_threshold`
+  (level 10 default) / `set_time_threshold` (30 days default); auto-create via `RoleLifecycleService.apply
+  (operation="create")`. All services lazy-imported per the setup-view convention.
+
+**Research notes (corrects an earlier assumption):** `role_automation.set_xp_threshold` /
+`set_time_threshold` ALREADY provide the direct-apply audited path (guild_id/role_id/role_name/level|days/
+actor_id) — so **no new service is required** (the context-delta "one genuine gap" was wrong). XP has **no
+guild enable toggle** (always-on, per-user opt-out via participation) — so the step tunes rate + rewards,
+it doesn't "turn XP on".
+
+<!-- close-out written as the final step -->

--- a/.sessions/2026-06-24-setup-reward-activity.md
+++ b/.sessions/2026-06-24-setup-reward-activity.md
@@ -1,28 +1,89 @@
-# Session — 2026-06-24 · Essential Setup step "Reward activity"
+# Session — 2026-06-24 · Essential Setup step "Reward active members"
 
-> **Status:** `in-progress` — born-red hold. Additive to `EssentialFlow` (no new cog/command/artifact);
-> a 2-screen step. Reuses existing audited services — no new service needed.
+> **Status:** `complete` — additive 2-screen step on `EssentialFlow` (no new cog/command/artifact).
+> Reuses existing audited services — **no new service**. PR #1434.
 
-**Trigger:** owner-directed (chat, 2026-06-24): build the spine's "Reward active members" step. Owner
-chose: toggle role rewards (both/one/none), selectable XP ranges, **an extra step to choose the reward
-role** (preset / create-your-own / reuse existing) — all via buttons/dropdowns/multi-selects.
+**Trigger:** owner-directed (chat, 2026-06-24): build the spine's "Reward active members" step — toggle
+role rewards (both/one/none), selectable XP ranges, **an extra screen to choose the reward role**
+(preset / create-your-own / reuse existing), all via buttons/dropdowns/multi-selects (Q-0204).
 
-## What I'm about to do
+## What shipped
 
-Add a **`RewardActivityStep`** to `EssentialFlow` (a 2-screen step via an internal `phase`):
+**`RewardActivityStep`** on `EssentialFlow` (step 5 of 6; a 2-screen step via an internal `phase`):
 - **Screen 1:** XP-rate dropdown (Keep current / Relaxed / Standard / Active → sets `xp_min`/`xp_max`/
   `xp_cooldown` via `SettingsMutationPipeline`) + a reward-types multi-select (level-up roles /
   time-in-server roles — both/one/none).
-- **Screen 2** (only when ≥1 reward type is on): choose the reward role — **Recommended** (auto-create
-  `@Regular`) / **Create one I name** (suggested-name dropdown) / **Reuse an existing role** (RoleSelect).
+- **Screen 2** (only when ≥1 reward type is on): source the reward role — Recommended (auto-create
+  `@Regular`) / Create one I name (suggested-name dropdown) / Reuse an existing role (RoleSelect).
 - On Save: set the XP rate if changed; for each enabled trigger call `role_automation.set_xp_threshold`
-  (level 10 default) / `set_time_threshold` (30 days default); auto-create via `RoleLifecycleService.apply
-  (operation="create")`. All services lazy-imported per the setup-view convention.
+  (level 10) / `set_time_threshold` (30 days); auto-create via `RoleLifecycleService.apply(operation=
+  "create")`. All services lazy-imported per the setup-view invariant.
+- Tests: 7 new (no-rewards-rate-only · keep-rate-noop · enters-role-phase · recommended-creates+sets ·
+  existing-both-triggers · existing-requires-pick · create-failure-blocks). Flow nav 5→6; help-desk
+  index 4→5. Suite 18→25.
 
-**Research notes (corrects an earlier assumption):** `role_automation.set_xp_threshold` /
-`set_time_threshold` ALREADY provide the direct-apply audited path (guild_id/role_id/role_name/level|days/
-actor_id) — so **no new service is required** (the context-delta "one genuine gap" was wrong). XP has **no
-guild enable toggle** (always-on, per-user opt-out via participation) — so the step tunes rate + rewards,
-it doesn't "turn XP on".
+## ✅ Verification
 
-<!-- close-out written as the final step -->
+`check_quality.py --full` → **12480 passed, 48 skipped, 2 xfailed; All checks passed ✓**. Jargon guard
+**154 (0 new)**; `check_architecture --mode strict` **0 errors**; setup sim **PASS**; `check_docs
+--strict` passed. (One formatting round: a large multi-class insert needed a manual `black` + `ruff
+--fix COM812` pass — see misses.)
+
+## Misses
+
+1. **An unverified context-delta claim nearly caused redundant work.** The handoff from prior sessions
+   asserted "Reward activity **needs a small new direct-apply role-threshold service** (the one genuine
+   gap — no direct-apply path exists today)." Researching the seams *first* showed that was **wrong**:
+   `role_automation.set_xp_threshold` / `set_time_threshold` already ARE the audited direct-apply paths.
+   The claim had propagated across ≥3 session handoffs unchecked. Caught it only by reading source. Plan
+   §7 corrected.
+2. **black↔ruff round.** After the big insert, `black` reformatted and then ruff wanted a COM812 trailing
+   comma; needed a manual `ruff --fix` + re-`black`. The full suite's `pytest` was green throughout — only
+   the formatters were red. (Trusted the printed summary per Q-0120.)
+
+## 💡 Session idea (Q-0089)
+
+**Mark *absence/gap claims* in a session log's "Context delta / for next session" as assumptions to
+verify, not facts** — e.g. a `⚠ unverified` tag on lines like "no X exists today" / "needs a new Y". This
+session's delta-claim ("needs a new role-threshold service — the one genuine gap") was false and had
+ridden through several handoffs; a next agent who trusts it builds a redundant service. The fix is the
+same instinct as the binding "cross-agent output is input to verify, not an order" rule (Q-0120),
+extended to our *own* forward handoffs. Cheap (a tag + a habit), directly motivated by today's near-miss,
+dedup-checked against `docs/ideas/`.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous: **`2026-06-24-setup-log-channel-rework.md`** (#1432). **Did well:** clean two-channel rework,
+recorded the decision reversal as Q-0203, full green — and its "Reward activity is next, needs a new
+service" handoff *did* point me at the right area. **Missed:** it copied the **"needs a new direct-apply
+role-threshold service (the one genuine gap)"** claim forward **without verifying it against source** — and
+it was wrong (`role_automation` already had the setters). **System improvement:** the Q-0089 tag above —
+forward-handoff absence-claims should be flagged unverified so the next agent greps before building. The
+self-improving loop only works if handoff *facts* are trustworthy; an unchecked guess dressed as a fact is
+worse than no note.
+
+## 📋 Doc audit (Q-0104)
+
+Plan §5 step 5 + §7 PR-1 note updated to SHIPPED **and corrected** (removed the false "new service / one
+genuine gap" claim). Owner design decisions recorded in router **Q-0204**. `check_docs --strict` passed.
+No `current-state.md` ledger entry until #1434 merges (auto-merges on green; next recon pass #1440 folds
+it in). Nothing from this session lives only in chat.
+
+## Context delta — for next session
+
+- **The spine is now 6 live steps** (greet · moderators · block spam · log channel · reward · help desk)
+  + summary. Only **step 0 "server-type starter preset"** remains as a spine follow-on — it **needs a
+  direct-apply preset path** (presets are draft-only today; Q-C decided auto-apply safe defaults, so the
+  *behaviour* is settled, the *apply path* is the work). ⚠ **Verify that against source before building**
+  (this session's lesson) — confirm no direct-apply preset path already exists.
+- **Then PR 2** (Extras menu + "Check my setup" health button) and **PR 3** (retire dead sections +
+  **rework** the Advanced bulk editor per Q-0202(4)/Q-E).
+- **Pattern:** `role_automation` (xp/time thresholds) + `RoleLifecycleService` (role create) +
+  `ChannelLifecycleService` (channel create) + `BindingMutationPipeline` (bindings) + `_set` (settings)
+  are the five audited seams the spine steps compose — all lazy-imported. No new service was needed for
+  any step so far.
+
+## ⚑ Self-initiated: NONE — owner-directed (the step + its full shape came from the owner: option 1 +
+the extra role-sourcing screen + both/one/none + selectable XP). Within-steer specifics (rate presets,
+default level 10 / 30 days, suggested role names, the 2-phase nav) were my calls. Additive, test-covered,
+old wizard untouched.

--- a/disbot/views/setup/essential_setup.py
+++ b/disbot/views/setup/essential_setup.py
@@ -20,9 +20,9 @@ Design (plan ``docs/planning/setup-wizard-restructure-plan-2026-06-24.md`` §5):
 This module is **additive** — the existing wizard (``views/setup/wizard.py``)
 is untouched and remains the full/advanced path; Essential Setup is the new
 quick spine.  Live steps: greet new members · set your moderators · block spam
-and bad links · choose a log channel · set up a help desk (+ the closing
-summary).  Remaining follow-ons on this same pattern: reward activity (xp +
-auto-role) and the server-type starter preset.
+and bad links · choose a log channel · reward active members · set up a help
+desk (+ the closing summary).  Remaining follow-on on this same pattern: the
+server-type starter preset.
 """
 
 from __future__ import annotations
@@ -69,6 +69,7 @@ class EssentialFlow:
             ModeratorsStep,
             BlockSpamStep,
             LogChannelStep,
+            RewardActivityStep,
             HelpDeskStep,
         ]
 
@@ -815,7 +816,444 @@ class LogChannelStep(_StepView):
 
 
 # ---------------------------------------------------------------------------
-# Step 5 — Set up a help desk  (tickets)
+# Step 5 — Reward active members  (xp rate + level/time role rewards)
+# ---------------------------------------------------------------------------
+#
+# Two screens in one step (an internal ``phase``).  Screen 1: pick an XP rate
+# (or keep the current one) and which role rewards to switch on (level-up and/or
+# time-in-server — both/one/none).  Screen 2 (only when a reward is on): choose
+# the reward role — recommended (auto-create @Regular) / create one you name /
+# reuse an existing role.  On Save: set the XP rate scalars through the audited
+# Settings pipeline, then call ``role_automation.set_xp_threshold`` /
+# ``set_time_threshold`` (the existing direct-apply audited paths) on the role,
+# auto-creating it via ``RoleLifecycleService`` when asked.  Every service is
+# lazy-imported per the setup-view no-top-level-pipeline-import convention.  XP
+# itself is always on (no guild enable; per-user opt-out lives in participation),
+# so this step tunes the *reward experience* — it does not switch XP on.
+
+# XP rate presets: key -> (operator label, xp_min, xp_max, cooldown_seconds).
+# "standard" mirrors the schema defaults (15/25/60).
+_XP_RATES: dict[str, tuple[str, int, int, int]] = {
+    "relaxed": ("Relaxed — slower leveling", 10, 15, 120),
+    "standard": ("Standard — balanced", 15, 25, 60),
+    "active": ("Active — faster leveling", 20, 40, 30),
+}
+# Reward triggers: key -> operator label.
+_REWARD_TYPES: list[tuple[str, str]] = [
+    ("level", "When members reach a level"),
+    ("time", "When members stay a while"),
+]
+# How to source the reward role: key -> operator label.
+_ROLE_SOURCES: list[tuple[str, str]] = [
+    ("recommended", "Recommended — make a @Regular role"),
+    ("create", "Create a role I name"),
+    ("existing", "Use a role I already have"),
+]
+_SUGGESTED_ROLE_NAMES: tuple[str, ...] = (
+    "Regular",
+    "Member",
+    "Trusted",
+    "Veteran",
+    "Active",
+    "VIP",
+)
+_DEFAULT_ROLE_NAME = "Regular"
+_DEFAULT_LEVEL = 10
+_DEFAULT_DAYS = 30
+
+
+class _XpRateSelect(discord.ui.Select):  # type: ignore[type-arg]
+    def __init__(self, current: str) -> None:
+        options = [
+            discord.SelectOption(
+                label="Keep current XP rate",
+                value="keep",
+                default=current == "keep",
+            ),
+            *[
+                discord.SelectOption(label=spec[0], value=key, default=current == key)
+                for key, spec in _XP_RATES.items()
+            ],
+        ]
+        super().__init__(
+            placeholder="How fast should members earn XP?",
+            options=options,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: RewardActivityStep = self.view  # type: ignore[assignment]
+        view.xp_rate = self.values[0]
+        view.refresh_items()
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class _RewardTypeSelect(discord.ui.Select):  # type: ignore[type-arg]
+    def __init__(self, selected: set[str]) -> None:
+        options = [
+            discord.SelectOption(label=label, value=key, default=key in selected)
+            for key, label in _REWARD_TYPES
+        ]
+        super().__init__(
+            placeholder="Give a role as a reward for… (optional)",
+            min_values=0,
+            max_values=len(options),
+            options=options,
+            row=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: RewardActivityStep = self.view  # type: ignore[assignment]
+        view.rewards = set(self.values)
+        view.refresh_items()
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class _RewardNextButton(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self, has_rewards: bool) -> None:
+        super().__init__(
+            label="Next" if has_rewards else "Save",
+            emoji="🏅",
+            style=discord.ButtonStyle.success,
+            row=2,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: RewardActivityStep = self.view  # type: ignore[assignment]
+        await view.on_next(interaction)
+
+
+class _RoleSourceSelect(discord.ui.Select):  # type: ignore[type-arg]
+    def __init__(self, current: str) -> None:
+        options = [
+            discord.SelectOption(label=label, value=key, default=key == current)
+            for key, label in _ROLE_SOURCES
+        ]
+        super().__init__(
+            placeholder="Where should the reward role come from?",
+            options=options,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: RewardActivityStep = self.view  # type: ignore[assignment]
+        view.role_source = self.values[0]
+        view.refresh_items()
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class _RoleNameSelect(discord.ui.Select):  # type: ignore[type-arg]
+    def __init__(self, current: str | None) -> None:
+        options = [
+            discord.SelectOption(label=name, value=name, default=name == current)
+            for name in _SUGGESTED_ROLE_NAMES
+        ]
+        super().__init__(placeholder="Name for the new role…", options=options, row=1)
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: RewardActivityStep = self.view  # type: ignore[assignment]
+        view.new_role_name = self.values[0]
+        view.refresh_items()
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class _RewardRoleSelect(discord.ui.RoleSelect):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            placeholder="Pick the role to grant…",
+            min_values=0,
+            max_values=1,
+            row=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: RewardActivityStep = self.view  # type: ignore[assignment]
+        if self.values:
+            view.existing_role_id = self.values[0].id
+            view.existing_role_name = self.values[0].name
+        else:
+            view.existing_role_id = None
+            view.existing_role_name = None
+        view.refresh_items()
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class _RewardSaveButton(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            label="Save rewards",
+            emoji="🏅",
+            style=discord.ButtonStyle.success,
+            row=2,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: RewardActivityStep = self.view  # type: ignore[assignment]
+        await view.apply(interaction)
+
+
+class RewardActivityStep(_StepView):
+    title = "Reward active members"
+    skip_label = "Skip rewards"
+
+    def __init__(self, flow: EssentialFlow) -> None:
+        self.phase: str = "config"  # "config" | "roles"
+        self.xp_rate: str = "keep"
+        self.rewards: set[str] = set()
+        self.role_source: str = "recommended"
+        self.new_role_name: str | None = None
+        self.existing_role_id: int | None = None
+        self.existing_role_name: str | None = None
+        super().__init__(flow)
+
+    def build_items(self) -> None:
+        self.refresh_items()
+
+    def refresh_items(self) -> None:
+        """(Re)build the controls for the current phase (rows 0/1/2)."""
+        own = (
+            _XpRateSelect,
+            _RewardTypeSelect,
+            _RewardNextButton,
+            _RoleSourceSelect,
+            _RoleNameSelect,
+            _RewardRoleSelect,
+            _RewardSaveButton,
+        )
+        for child in list(self.children):
+            if isinstance(child, own):
+                self.remove_item(child)
+        if self.phase == "config":
+            self.add_item(_XpRateSelect(self.xp_rate))
+            self.add_item(_RewardTypeSelect(self.rewards))
+            self.add_item(_RewardNextButton(bool(self.rewards)))
+        else:
+            self.add_item(_RoleSourceSelect(self.role_source))
+            if self.role_source == "create":
+                self.add_item(_RoleNameSelect(self.new_role_name))
+            elif self.role_source == "existing":
+                self.add_item(_RewardRoleSelect())
+            self.add_item(_RewardSaveButton())
+
+    async def go_back(self, interaction: discord.Interaction) -> None:
+        # Screen 2 "Back" returns to screen 1; screen 1 "Back" leaves the step.
+        if self.phase == "roles":
+            self.phase = "config"
+            self.refresh_items()
+            await interaction.response.edit_message(embed=self.render(), view=self)
+        else:
+            await super().go_back(interaction)
+
+    def render(self) -> discord.Embed:
+        return self._render_config() if self.phase == "config" else self._render_roles()
+
+    def _render_config(self) -> discord.Embed:
+        embed = discord.Embed(
+            title=f"🏅 {self.title}",
+            description=(
+                "Members earn XP as they chat and level up. Choose how fast XP "
+                "comes in, and — if you like — give members a role when they "
+                "reach a level or stay a while.\n\n"
+                "Pick what you want, then press **Next**."
+            ),
+            color=discord.Color.blurple(),
+        )
+        rate = "Keep current" if self.xp_rate == "keep" else _XP_RATES[self.xp_rate][0]
+        embed.add_field(name="XP rate", value=rate, inline=False)
+        if self.rewards:
+            picked = ", ".join(
+                label for key, label in _REWARD_TYPES if key in self.rewards
+            )
+            embed.add_field(name="Give a reward role", value=picked, inline=False)
+        else:
+            embed.add_field(
+                name="Give a reward role",
+                value="_off — no role rewards_",
+                inline=False,
+            )
+        embed.set_footer(text=self.flow.step_counter())
+        return embed
+
+    def _render_roles(self) -> discord.Embed:
+        embed = discord.Embed(
+            title="🏅 Choose the reward role",
+            description=(
+                "Which role should members earn?\n"
+                "• **Recommended** — we make a fresh **@Regular**\n"
+                "• **Create a role I name** — pick a name, we make it\n"
+                "• **Use a role I already have** — choose one below"
+            ),
+            color=discord.Color.blurple(),
+        )
+        if self.role_source == "existing":
+            role = (
+                f"<@&{self.existing_role_id}>"
+                if self.existing_role_id
+                else "_pick one below_"
+            )
+        elif self.role_source == "create":
+            role = f"a new **@{self.new_role_name or _DEFAULT_ROLE_NAME}**"
+        else:
+            role = f"a new **@{_DEFAULT_ROLE_NAME}**"
+        embed.add_field(name="Reward role", value=role, inline=False)
+        triggers = []
+        if "level" in self.rewards:
+            triggers.append(f"at level {_DEFAULT_LEVEL}")
+        if "time" in self.rewards:
+            triggers.append(f"after {_DEFAULT_DAYS} days")
+        embed.add_field(name="Granted", value=" and ".join(triggers), inline=False)
+        embed.set_footer(text=self.flow.step_counter())
+        return embed
+
+    async def on_next(self, interaction: discord.Interaction) -> None:
+        if not self.rewards:
+            # No role rewards — apply the XP rate (if changed) and finish.
+            await self._apply_and_complete(
+                interaction,
+                role_id=None,
+                role_name=None,
+                created=False,
+            )
+            return
+        self.phase = "roles"
+        self.refresh_items()
+        await interaction.response.edit_message(embed=self.render(), view=self)
+
+    async def apply(self, interaction: discord.Interaction) -> None:
+        # Screen 2 "Save" — resolve the reward role, then apply everything.
+        role_id, role_name, created = await self._resolve_role(interaction)
+        if role_id is None:
+            return  # error already surfaced
+        await self._apply_and_complete(
+            interaction,
+            role_id=role_id,
+            role_name=role_name,
+            created=created,
+        )
+
+    async def _apply_and_complete(
+        self,
+        interaction: discord.Interaction,
+        *,
+        role_id: int | None,
+        role_name: str | None,
+        created: bool,
+    ) -> None:
+        try:
+            if self.xp_rate != "keep":
+                _label, xp_min, xp_max, cooldown = _XP_RATES[self.xp_rate]
+                await self._set("xp", "xp_min", xp_min)
+                await self._set("xp", "xp_max", xp_max)
+                await self._set("xp", "xp_cooldown", cooldown)
+            if self.rewards and role_id is not None and role_name is not None:
+                await self._set_rewards(role_id, role_name)
+        except Exception:
+            logger.exception("essential setup: reward step apply failed")
+            await interaction.response.send_message(
+                "Something went wrong saving rewards — please try again.",
+                ephemeral=True,
+            )
+            return
+        await self.complete(interaction, self._summary(role_id, created))
+
+    async def _resolve_role(
+        self,
+        interaction: discord.Interaction,
+    ) -> tuple[int | None, str | None, bool]:
+        """Resolve the reward role to (id, name, created?), or (None, …) on error."""
+        if self.role_source == "existing":
+            if self.existing_role_id is None:
+                await interaction.response.send_message(
+                    "Pick a role to grant, or switch to **Recommended** to make one.",
+                    ephemeral=True,
+                )
+                return None, None, False
+            return self.existing_role_id, self.existing_role_name, False
+        name = (
+            self.new_role_name
+            if self.role_source == "create" and self.new_role_name
+            else _DEFAULT_ROLE_NAME
+        )
+        created_id = await self._create_role(interaction, name)
+        if created_id is None:
+            return None, None, False
+        return created_id, name, True
+
+    async def _create_role(
+        self,
+        interaction: discord.Interaction,
+        name: str,
+    ) -> int | None:
+        """Create the reward role through the audited role-lifecycle creator."""
+        from services.role_lifecycle_service import (
+            RoleLifecycleRequest,
+            RoleLifecycleService,
+        )
+
+        result = await RoleLifecycleService().apply(
+            self.flow.guild,
+            RoleLifecycleRequest(operation="create", name=name),
+            self.flow.author,
+            confirmed=True,
+        )
+        if not result.applied:
+            logger.warning(
+                "essential setup: reward role create failed (guild=%s): %s",
+                self.flow.guild.id,
+                result.first_error,
+            )
+            await interaction.response.send_message(
+                "Couldn't make the role — please reuse an existing one instead.",
+                ephemeral=True,
+            )
+            return None
+        return result.applied[0].target_id
+
+    async def _set_rewards(self, role_id: int, role_name: str) -> None:
+        """Set the level / time role rewards through ``role_automation`` (the
+        existing direct-apply audited path).  Lazy-imported per the setup-view
+        convention.
+        """
+        from services import role_automation
+
+        if "level" in self.rewards:
+            await role_automation.set_xp_threshold(
+                guild_id=self.flow.guild.id,
+                role_id=role_id,
+                role_name=role_name,
+                level=_DEFAULT_LEVEL,
+                actor_id=self.flow.author.id,
+            )
+        if "time" in self.rewards:
+            await role_automation.set_time_threshold(
+                guild_id=self.flow.guild.id,
+                role_id=role_id,
+                role_name=role_name,
+                days=_DEFAULT_DAYS,
+                actor_id=self.flow.author.id,
+            )
+
+    def _summary(self, role_id: int | None, created: bool) -> str:
+        parts: list[str] = []
+        if self.xp_rate != "keep":
+            parts.append(
+                f"XP rate {_XP_RATES[self.xp_rate][0].split(' — ')[0].lower()}",
+            )
+        if self.rewards and role_id is not None:
+            triggers = []
+            if "level" in self.rewards:
+                triggers.append(f"level {_DEFAULT_LEVEL}")
+            if "time" in self.rewards:
+                triggers.append(f"{_DEFAULT_DAYS} days")
+            verb = "new role" if created else "role"
+            parts.append(f"{verb} <@&{role_id}> at {' / '.join(triggers)}")
+        if not parts:
+            return "Rewards: no changes"
+        return "Rewards on · " + " · ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Step 6 — Set up a help desk  (tickets)
 # ---------------------------------------------------------------------------
 
 

--- a/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
+++ b/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
@@ -1,0 +1,1 @@
+claude/blissful-hamilton-xdzbak · Essential Setup spine: "Reward activity" step (XP rate + level/time role rewards, 2-screen with role-sourcing choice) · disbot/views/setup/essential_setup.py + tests/unit/views/setup/test_essential_setup.py · 2026-06-24

--- a/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
+++ b/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
@@ -1,1 +1,0 @@
-claude/blissful-hamilton-xdzbak · Essential Setup spine: "Reward activity" step (XP rate + level/time role rewards, 2-screen with role-sourcing choice) · disbot/views/setup/essential_setup.py + tests/unit/views/setup/test_essential_setup.py · 2026-06-24

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -7424,3 +7424,33 @@ the setup-view invariant). Reworked tests cover defaults-create-both, picked-cha
 
 **Home:** this Q-block (canonical) + the plan §5 step 4 / §7 PR-1 note + Q-0202(1) (superseded) +
 `.sessions/2026-06-24-setup-log-channel-rework.md`. Related: **Q-0202**, **Q-A** (direct-apply per step).
+
+### Q-0204 — ANSWERED (owner decisions, in-session): the "Reward active members" step shape — toggleable rewards + selectable XP rate + an extra role-sourcing screen (2026-06-24)
+
+**Context.** Building the spine's "Reward active members" step (plan §5 step 5; PR **#1434**), the owner
+specified the shape over a short exchange: confirmed XP = the per-message earning system, then directed
+the step's controls.
+
+**The decisions.**
+1. **Role rewards are fully toggleable — both / just one / none.** The owner can switch on level-up roles
+   and/or time-in-server roles, or neither.
+2. **XP rate is selectable** (the per-message XP range + cooldown) — via a dropdown of presets (Keep
+   current / Relaxed / Standard / Active), not free-text.
+3. **An extra screen chooses the reward role**, with three sources: **preset** (auto-create a recommended
+   `@Regular`) / **create your own** (pick a name) / **reuse an existing role**.
+4. **Everything via buttons / dropdowns / multi-selects** — no "type an ID / value" anywhere.
+5. **Recommended depth = option 1** (one config screen + the extra role screen; sensible default
+   thresholds level 10 / 30 days, tunable later in the role panels) — chosen over cramming threshold
+   pickers in or a full multi-screen hub.
+
+**Scope / non-generalization.** Default thresholds (level 10 / 30 days) and the role-name suggestions are
+implementation defaults, tunable in the existing `!roles` panels — not owner decisions. **Build note (not
+a decision):** the step needed **no new service** — `role_automation.set_xp_threshold` /
+`set_time_threshold` are the existing audited direct-apply paths (an earlier "one genuine gap" assumption
+was wrong); role auto-create is `RoleLifecycleService.apply(operation="create")`.
+
+**Applied.** PR **#1434** ships `RewardActivityStep` (2-screen) implementing decisions 1–5.
+
+**Home:** this Q-block (canonical) + the plan §5 step 5 / §7 PR-1 note +
+`.sessions/2026-06-24-setup-reward-activity.md`. Related: **Q-A** (direct-apply per step), **Q-0202**/
+**Q-0203** (the analogous log-channel step decisions).

--- a/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
+++ b/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
@@ -112,8 +112,10 @@ The fix is not more sections — it is a **structure** built from four laws.
    (`#mod-log` / `#server-log`). **Shipped:** moderation-only first (`#1429`), then reworked to the
    two-channel multi-select (`#1432`, owner decision Q-0203 — "moderation only" was the first slice, not a
    cap). Full per-category routing stays in the advanced `!logging` UI.
-5. **Reward active members** — turn on levels; optionally auto-grant a role as members stay & chat —
-   **the bot creates the roles**. (`xp` + `roles` + `role_templates`, dead-end removed.)
+5. **Reward active members** *(SHIPPED 2026-06-24, `#1434`)* — pick an XP rate + optionally grant a role
+   at a level and/or after N days in the server (both/one/none); the bot creates the role (or reuses one
+   you pick). (`xp` settings + `role_automation` XP/time thresholds + `RoleLifecycleService` create;
+   dead-end removed.)
 6. **Set up a help desk** — let members open private support; pick who answers; bot makes the rest.
    (`ticket`, already direct-apply.)
 7. **All done** — plain summary of what's on + a one-tap menu of extras you skipped.
@@ -186,9 +188,13 @@ decision with architectural weight → called out as open question Q-A below.
     `logging.mod_channel`) and an **activity log** (→ `logging.events_channel`). On Save: `logging.enabled`,
     bind `mod_channel`, set the `*_enabled` flags per the multi-select, bind `events_channel` when any
     activity is on. **Leave a channel empty → auto-create** `#mod-log` / `#server-log` (one-tap defaults).
-  - **Reward activity** — the `xp` enable toggle is trivial via `_set`; the role-threshold sub-step
-    **needs a small new direct-apply role-threshold service** (the one genuine gap — no direct-apply path
-    exists today) + `RoleLifecycleService.create_role` for auto-create.
+  - **Reward activity** *(SHIPPED 2026-06-24, `#1434`)* — `RewardActivityStep`, a 2-screen step: an
+    XP-rate dropdown (sets `xp_min`/`xp_max`/`xp_cooldown`) + a reward-types multi-select (level-up /
+    time-in-server, both/one/none) → an extra screen to source the reward role (recommended auto-create
+    `@Regular` / create one you name / reuse an existing role). **Correction:** the assumed "small new
+    direct-apply role-threshold service (the one genuine gap)" was wrong — `role_automation.set_xp_threshold`
+    / `set_time_threshold` already ARE the audited direct-apply paths, and
+    `RoleLifecycleService.apply(operation="create")` does the role auto-create. No new service was needed.
   - **Server-type starter preset** (step 0) — **needs a direct-apply preset path** (presets are
     draft-only today); design decision before building.
 - **PR 2 — extras + health check:** the **Extras menu** (each existing config surface as a one-action

--- a/tests/unit/views/setup/test_essential_setup.py
+++ b/tests/unit/views/setup/test_essential_setup.py
@@ -66,6 +66,33 @@ def channel_service():
         yield cls.return_value
 
 
+@pytest.fixture
+def role_automation():
+    # role_automation's threshold setters are lazy-imported inside the reward
+    # step (`from services import role_automation`) — patch at the module.
+    with (
+        patch(
+            "services.role_automation.set_xp_threshold",
+            new=AsyncMock(),
+        ) as xp,
+        patch(
+            "services.role_automation.set_time_threshold",
+            new=AsyncMock(),
+        ) as time,
+    ):
+        yield SimpleNamespace(set_xp_threshold=xp, set_time_threshold=time)
+
+
+@pytest.fixture
+def role_service():
+    # RoleLifecycleService (role auto-create) is lazy-imported inside the step.
+    with patch(
+        "services.role_lifecycle_service.RoleLifecycleService",
+    ) as cls:
+        cls.return_value.apply = AsyncMock()
+        yield cls.return_value
+
+
 # ---------------------------------------------------------------------------
 # Flow
 # ---------------------------------------------------------------------------
@@ -73,17 +100,18 @@ def channel_service():
 
 def test_flow_counter_and_navigation():
     flow = es.EssentialFlow(_member(), _guild())
-    assert flow.total == 5
-    assert flow.step_counter() == "Step 1 of 5"
+    assert flow.total == 6
+    assert flow.step_counter() == "Step 1 of 6"
     expected = [
         es.GreetMembersStep,
         es.ModeratorsStep,
         es.BlockSpamStep,
         es.LogChannelStep,
+        es.RewardActivityStep,
         es.HelpDeskStep,
     ]
     for i, cls in enumerate(expected):
-        assert flow.step_counter() == f"Step {i + 1} of 5"
+        assert flow.step_counter() == f"Step {i + 1} of 6"
         assert isinstance(flow.current_view(), cls)
         flow.advance()
 
@@ -257,9 +285,7 @@ async def test_log_channel_defaults_create_both_and_bind(
     assert settings[("logging", "roles_enabled")] is True
     assert settings[("logging", "messages_enabled")] is False  # privacy: off default
     # mod_channel → the mod log, events_channel → the activity log.
-    binds = {
-        c.args[2]: c.args[4] for c in binding_pipeline.set_binding.await_args_list
-    }
+    binds = {c.args[2]: c.args[4] for c in binding_pipeline.set_binding.await_args_list}
     assert binds == {"mod_channel": 111, "events_channel": 222}
     assert all(
         c.args[3] == BindingKind.CHANNEL
@@ -283,9 +309,7 @@ async def test_log_channel_picked_channels_bind_without_create(
     await step.apply(_interaction())
 
     channel_service.create_channels.assert_not_awaited()
-    binds = {
-        c.args[2]: c.args[4] for c in binding_pipeline.set_binding.await_args_list
-    }
+    binds = {c.args[2]: c.args[4] for c in binding_pipeline.set_binding.await_args_list}
     assert binds == {"mod_channel": 700, "events_channel": 800}
     assert flow.index == 4
 
@@ -306,9 +330,9 @@ async def test_log_channel_no_activity_logs_moderation_only(
 
     # Only the moderation channel is bound — no activity channel, no create.
     channel_service.create_channels.assert_not_awaited()
-    assert {
-        c.args[2] for c in binding_pipeline.set_binding.await_args_list
-    } == {"mod_channel"}
+    assert {c.args[2] for c in binding_pipeline.set_binding.await_args_list} == {
+        "mod_channel"
+    }
     # The three activity flags are explicitly written off.
     settings = {
         (c.args[1], c.args[2]): c.args[3] for c in pipeline.set_value.await_args_list
@@ -345,6 +369,160 @@ async def test_log_channel_create_failure_blocks(
 
 
 # ---------------------------------------------------------------------------
+# Reward active members
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reward_no_rewards_applies_rate_only(
+    pipeline, role_automation, role_service
+):
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 4
+    step = es.RewardActivityStep(flow)
+    step.xp_rate = "active"  # rewards stay empty
+
+    await step.on_next(_interaction())
+
+    # XP-rate scalars applied; no role work; advanced past the step.
+    names = {(c.args[1], c.args[2]) for c in pipeline.set_value.await_args_list}
+    assert {("xp", "xp_min"), ("xp", "xp_max"), ("xp", "xp_cooldown")} <= names
+    role_automation.set_xp_threshold.assert_not_awaited()
+    role_service.apply.assert_not_awaited()
+    assert flow.index == 5
+
+
+@pytest.mark.asyncio
+async def test_reward_keep_rate_no_rewards_is_noop_advance(pipeline, role_automation):
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 4
+    step = es.RewardActivityStep(flow)  # xp_rate="keep", rewards empty
+
+    await step.on_next(_interaction())
+
+    pipeline.set_value.assert_not_awaited()
+    role_automation.set_xp_threshold.assert_not_awaited()
+    assert flow.index == 5
+
+
+@pytest.mark.asyncio
+async def test_reward_next_with_rewards_enters_role_phase(pipeline):
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 4
+    step = es.RewardActivityStep(flow)
+    step.rewards = {"level"}
+
+    await step.on_next(_interaction())
+
+    # Moves to screen 2 without applying or advancing.
+    assert step.phase == "roles"
+    pipeline.set_value.assert_not_awaited()
+    assert flow.index == 4
+
+
+@pytest.mark.asyncio
+async def test_reward_recommended_creates_role_and_sets_level(
+    pipeline,
+    role_automation,
+    role_service,
+):
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 4
+    step = es.RewardActivityStep(flow)
+    step.rewards = {"level"}
+    step.phase = "roles"
+    step.role_source = "recommended"
+    role_service.apply.return_value = SimpleNamespace(
+        applied=(SimpleNamespace(target_id=900),),
+        first_error="",
+    )
+
+    await step.apply(_interaction())
+
+    # A role was created and the XP-level reward was set on it.
+    role_service.apply.assert_awaited_once()
+    role_automation.set_xp_threshold.assert_awaited_once()
+    kwargs = role_automation.set_xp_threshold.await_args.kwargs
+    assert kwargs["role_id"] == 900
+    assert kwargs["role_name"] == "Regular"
+    assert kwargs["level"] == 10
+    assert kwargs["guild_id"] == 1
+    assert kwargs["actor_id"] == 99
+    role_automation.set_time_threshold.assert_not_awaited()
+    assert flow.index == 5
+
+
+@pytest.mark.asyncio
+async def test_reward_existing_role_both_triggers(
+    pipeline,
+    role_automation,
+    role_service,
+):
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 4
+    step = es.RewardActivityStep(flow)
+    step.rewards = {"level", "time"}
+    step.phase = "roles"
+    step.role_source = "existing"
+    step.existing_role_id = 555
+    step.existing_role_name = "Member"
+
+    await step.apply(_interaction())
+
+    # No role created; both rewards set on the existing role.
+    role_service.apply.assert_not_awaited()
+    assert role_automation.set_xp_threshold.await_args.kwargs["role_id"] == 555
+    assert role_automation.set_time_threshold.await_args.kwargs["role_id"] == 555
+    assert role_automation.set_time_threshold.await_args.kwargs["days"] == 30
+    assert flow.index == 5
+
+
+@pytest.mark.asyncio
+async def test_reward_existing_requires_a_pick(pipeline, role_automation, role_service):
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 4
+    step = es.RewardActivityStep(flow)
+    step.rewards = {"level"}
+    step.phase = "roles"
+    step.role_source = "existing"  # existing_role_id stays None
+    interaction = _interaction()
+
+    await step.apply(interaction)
+
+    role_service.apply.assert_not_awaited()
+    role_automation.set_xp_threshold.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+    assert flow.index == 4  # did not advance
+
+
+@pytest.mark.asyncio
+async def test_reward_role_create_failure_blocks(
+    pipeline,
+    role_automation,
+    role_service,
+):
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 4
+    step = es.RewardActivityStep(flow)
+    step.rewards = {"level"}
+    step.phase = "roles"
+    step.role_source = "recommended"
+    role_service.apply.return_value = SimpleNamespace(
+        applied=(),
+        first_error="missing permission",
+    )
+    interaction = _interaction()
+
+    await step.apply(interaction)
+
+    role_service.apply.assert_awaited_once()
+    role_automation.set_xp_threshold.assert_not_awaited()
+    pipeline.set_value.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+    assert flow.index == 4
+
+
+# ---------------------------------------------------------------------------
 # Help desk
 # ---------------------------------------------------------------------------
 
@@ -352,20 +530,20 @@ async def test_log_channel_create_failure_blocks(
 @pytest.mark.asyncio
 async def test_help_desk_requires_staff_role():
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 4
+    flow.index = 5
     step = es.HelpDeskStep(flow)
     interaction = _interaction()
     with patch("services.ticket_mutation.update_config", new=AsyncMock()) as upd:
         await step.apply(interaction)
     upd.assert_not_awaited()
-    assert flow.index == 4
+    assert flow.index == 5
     assert "staff" in interaction.response.send_message.await_args.args[0].lower()
 
 
 @pytest.mark.asyncio
 async def test_help_desk_enables_tickets_and_advances():
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 4
+    flow.index = 5
     step = es.HelpDeskStep(flow)
     step.staff_role_id = 321
     step.log_channel_id = 654
@@ -376,7 +554,7 @@ async def test_help_desk_enables_tickets_and_advances():
     assert kwargs["enabled"] is True
     assert kwargs["staff_role_id"] == 321
     assert kwargs["log_channel_id"] == 654
-    assert flow.index == 5
+    assert flow.index == 6
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds the **"Reward active members"** essentials step (plan `setup-wizard-restructure-plan-2026-06-24.md` §5 step 5) — owner-directed.

A 2-screen step on `EssentialFlow`:
- **Screen 1** — an **XP-rate** dropdown (Keep current / Relaxed / Standard / Active → sets `xp_min` / `xp_max` / `xp_cooldown` via `SettingsMutationPipeline`) and a **reward-types multi-select** (level-up roles / time-in-server roles — both / one / none).
- **Screen 2** (shown only when ≥1 reward type is on) — choose the reward role: **Recommended** (auto-create `@Regular`) / **Create one I name** (suggested-name dropdown) / **Reuse an existing role** (role picker).

On Save (direct lane): set the XP rate if changed, then for each enabled trigger call `role_automation.set_xp_threshold` (level 10 default) / `set_time_threshold` (30 days default) on the chosen role; auto-create the role via `RoleLifecycleService.apply(operation="create")` when needed.

## Notes
- **No new service** — `role_automation` already exposes the direct-apply audited XP/time threshold setters (corrects an earlier "one genuine gap" assumption). XP has no guild enable toggle (always-on, per-user opt-out), so the step tunes rate + rewards rather than "turning XP on".
- All services (`role_automation`, `role_lifecycle_service`, settings) lazy-imported per the setup-view no-top-level-pipeline-import invariant.
- Additive view-class step (no new cog/command/artifact). Plain-language copy. Tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PPgD6XUGaxHBD6JVYxbDp

---
_Generated by [Claude Code](https://claude.ai/code/session_016PPgD6XUGaxHBD6JVYxbDp)_