### PR TITLE
Essential Setup spine: polish + optional custom naming

### DIFF
--- a/.sessions/2026-06-24-setup-spine-polish.md
+++ b/.sessions/2026-06-24-setup-spine-polish.md
@@ -1,0 +1,28 @@
+# Session — 2026-06-24 · Essential Setup spine polish + optional custom naming
+
+> **Status:** `in-progress` — born-red hold. View-layer polish across all spine steps + 2 modals; no new
+> cog/command/artifact, no new service.
+
+**Trigger:** owner-directed (chat, 2026-06-24) after my spine review. Apply all review findings: fix the
+skip-recap bug, make the Save button position consistent, unify block-spam to a multi-select ("multi
+select is preferred"), settle one Save-label voice, **and add optional typing everywhere it makes sense
+(role names, channel names, etc.) — typing optional, never required**.
+
+## What I'm about to do (one PR, `essential_setup.py` + tests)
+
+1. **Skip-recap bug** — `_StepView.skip()` now calls `flow.record_skipped(self.title)` (it never did), so
+   the summary's "Skipped (you can do these later)" recap actually populates.
+2. **Consistent Save position** — every step's primary button → **row 3**, Back/Skip → **row 4** (base),
+   so Save sits in the same place on every step (was row 4 *below* nav on the log step only).
+3. **Block-spam → multi-select** — replace the 4 on/off toggle buttons with one multi-select (all four
+   pre-selected; untick to disable), matching the log/reward pattern.
+4. **One Save-label voice** — unify the primary button to **"Save & continue"** (per the module
+   docstring's stated pattern), keeping each step's emoji. Reward screen-1 stays "Next" (a transition).
+5. **Optional custom naming (typing optional)** — an "✏️ Type a name" button → a `discord.ui.Modal`
+   (prefilled with the default) wherever the bot *creates* a named thing: the **reward role** (create
+   mode) and the **log channel(s)** it auto-creates. Defaults still work with zero typing; the modal is
+   the only place text is entered and it's never required.
+
+All copy stays jargon-clean (guard 154); modal titles/labels scanned by `check_setup_copy`.
+
+<!-- close-out written as the final step -->

--- a/.sessions/2026-06-24-setup-spine-polish.md
+++ b/.sessions/2026-06-24-setup-spine-polish.md
@@ -1,28 +1,81 @@
 # Session — 2026-06-24 · Essential Setup spine polish + optional custom naming
 
-> **Status:** `in-progress` — born-red hold. View-layer polish across all spine steps + 2 modals; no new
-> cog/command/artifact, no new service.
+> **Status:** `complete` — view-layer polish across all six spine steps + 2 modals. No new
+> cog/command/artifact, no new service. PR #1435.
 
-**Trigger:** owner-directed (chat, 2026-06-24) after my spine review. Apply all review findings: fix the
-skip-recap bug, make the Save button position consistent, unify block-spam to a multi-select ("multi
-select is preferred"), settle one Save-label voice, **and add optional typing everywhere it makes sense
-(role names, channel names, etc.) — typing optional, never required**.
+**Trigger:** owner-directed (chat, 2026-06-24) after an agent review of the spine. Apply every review
+finding + add optional typing everywhere it makes sense (roles, channel names).
 
-## What I'm about to do (one PR, `essential_setup.py` + tests)
+## What shipped (`essential_setup.py` + tests)
 
-1. **Skip-recap bug** — `_StepView.skip()` now calls `flow.record_skipped(self.title)` (it never did), so
-   the summary's "Skipped (you can do these later)" recap actually populates.
-2. **Consistent Save position** — every step's primary button → **row 3**, Back/Skip → **row 4** (base),
-   so Save sits in the same place on every step (was row 4 *below* nav on the log step only).
-3. **Block-spam → multi-select** — replace the 4 on/off toggle buttons with one multi-select (all four
-   pre-selected; untick to disable), matching the log/reward pattern.
-4. **One Save-label voice** — unify the primary button to **"Save & continue"** (per the module
-   docstring's stated pattern), keeping each step's emoji. Reward screen-1 stays "Next" (a transition).
-5. **Optional custom naming (typing optional)** — an "✏️ Type a name" button → a `discord.ui.Modal`
-   (prefilled with the default) wherever the bot *creates* a named thing: the **reward role** (create
-   mode) and the **log channel(s)** it auto-creates. Defaults still work with zero typing; the modal is
-   the only place text is entered and it's never required.
+1. **Skip-recap bug fixed** — `_StepView.skip()` now calls `flow.record_skipped(self.title)` (it never
+   did); the summary's "Skipped (you can do these later)" list was dead code and now populates.
+2. **Consistent Save position + one voice** — every step's primary button → **row 3**, Back/Skip → **row
+   4** (so Save is in the same place on every step; previously the log step's Save sat *below* nav), and
+   all primary buttons unified to **"Save & continue"** (keeping per-step emoji). Reward screen 1 stays
+   "Next" (a transition).
+3. **Block-spam → multi-select** — the four on/off toggle buttons became one multi-select (all
+   pre-selected; untick to disable), matching the log/reward steps. ("multi-select is preferred.")
+4. **Optional custom naming (typing optional, never required)** — an "✏️ Type a name" button opens a
+   `discord.ui.Modal` (prefilled with the default) wherever the bot *creates* a named thing: the reward
+   **role** (create mode) and the log **channel(s)**. Defaults still work with zero typing.
+5. Tests: fixed the block-spam test (dict→set); +3 new (skip-records-skipped, log custom names, reward
+   custom role name). 25 → 28.
 
-All copy stays jargon-clean (guard 154); modal titles/labels scanned by `check_setup_copy`.
+## ✅ Verification
 
-<!-- close-out written as the final step -->
+`check_quality.py --full` → **12483 passed, 48 skipped, 2 xfailed; All checks passed ✓** (modals didn't
+trip mypy — mirrored the `xp/modals.py` `# type: ignore` pattern). Jargon guard **154 (0 new)** —
+modal labels + ✏️ buttons + "Save & continue" all clean; `check_architecture --mode strict` **0 errors**;
+setup sim **PASS**; `check_docs --strict` passed.
+
+## Misses
+
+Nothing surprising. The block-spam test broke as expected when `filters` went dict→set (one-line fix).
+No black/ruff round this time — ran `ruff --fix` + `black` proactively after the big edit batch.
+
+## 💡 Session idea (Q-0089)
+
+**A structural-conformance test over all `_StepView` subclasses** — iterate the spine steps and assert
+each: renders a footer containing "Step", places its primary button on the nav-adjacent row, and contains
+**no `discord.ui.TextInput` outside a modal** (the "typing optional" rule). This session I hand-checked
+exactly those properties across six steps and found a live bug (dead skip-recap) + three inconsistencies
+that had accreted because each step was built in isolation. A conformance test makes the spine's grammar
+*enforced*, not review-dependent — and pins the Q-0205 optional-typing principle for future steps.
+Dedup-checked `docs/ideas/`; not present.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous: **`2026-06-24-setup-reward-activity.md`** (#1434). **Did well:** good source research (caught
+the "no new service" reality), recorded Q-0204. **Missed:** the reward step shipped carrying the *same*
+structural inconsistencies the rest of the spine had (Save-button placement, toggle-vs-multiselect drift,
+no optional typing) — none caught until this dedicated review. **System improvement:** each
+step-adding session optimized its own step but never cross-checked the spine as a whole, so small
+inconsistencies accreted silently. The fix is the Q-0089 conformance test (bake the cross-step check in)
+rather than relying on a human to later ask "are these consistent?" — the self-improving loop should
+*enforce* consistency, not discover it late.
+
+## 📋 Doc audit (Q-0104)
+
+Router **Q-0205** records the directives + the durable optional-typing principle; plan §7 PR-1 note got a
+polish-pass line + the principle on the step-0 preset bullet. `check_docs --strict` passed. No
+`current-state.md` ledger entry until #1435 merges (auto-merges on green; next recon #1440 folds it in).
+Nothing from this session lives only in chat.
+
+## Context delta — for next session
+
+- **The spine is now structurally consistent** (selects rows 0-2 · primary button row 3 · nav row 4 ·
+  optional ✏️ modal where a named resource is created) and **fully optional-typing** per Q-0205. Future
+  steps must follow this.
+- **Only remaining spine follow-on: step 0, the server-type starter preset** — still needs a direct-apply
+  preset path (presets are draft-only today). ⚠ **Verify that against source before building** (the
+  reward-session lesson) — confirm no direct-apply preset path already exists. It must also expose the
+  optional-type-a-name affordance for anything it creates.
+- **Then PR 2** (Extras menu + "Check my setup") and **PR 3** (retire dead sections + rework the Advanced
+  editor, Q-0202(4)/Q-E).
+- **Idea worth doing soon:** the structural-conformance test above — it would have caught everything this
+  review found, automatically.
+
+## ⚑ Self-initiated: NONE — owner-directed (apply the review findings + the optional-typing directive).
+Within-steer specifics (the row-3/row-4 split, the modal design, which spots get optional typing) were my
+calls. Additive view-layer polish, test-covered, old wizard untouched.

--- a/disbot/views/setup/essential_setup.py
+++ b/disbot/views/setup/essential_setup.py
@@ -134,15 +134,19 @@ class _SkipButton(discord.ui.Button):  # type: ignore[type-arg]
 class _StepView(BaseView):
     """One step. Subclasses add their pickers + a Save button and a render()."""
 
+    title = "this step"
     skip_label = "Skip this step"
 
     def __init__(self, flow: EssentialFlow) -> None:
         super().__init__(flow.author, public=False, timeout=600)
         self.flow = flow
         self.build_items()
+        # Nav sits on the bottom row (4); each step's primary button uses row 3,
+        # so "Save & continue" lands in the same place on every step regardless
+        # of how many dropdowns the step has (the log step fills rows 0-2).
         if flow.index > 0:
-            self.add_item(_BackButton(row=3))
-        self.add_item(_SkipButton(row=3, label=self.skip_label))
+            self.add_item(_BackButton(row=4))
+        self.add_item(_SkipButton(row=4, label=self.skip_label))
 
     # --- subclass hooks ---
     def build_items(self) -> None:  # pragma: no cover - trivial in subclasses
@@ -158,6 +162,7 @@ class _StepView(BaseView):
         await interaction.response.edit_message(embed=embed, view=view)
 
     async def skip(self, interaction: discord.Interaction) -> None:
+        self.flow.record_skipped(self.title)
         self.flow.advance()
         await self._show_current(interaction)
 
@@ -232,10 +237,10 @@ class _EntryRoleSelect(discord.ui.RoleSelect):  # type: ignore[type-arg]
 class _GreetSaveButton(discord.ui.Button):  # type: ignore[type-arg]
     def __init__(self) -> None:
         super().__init__(
-            label="Turn on greetings",
+            label="Save & continue",
             emoji="👋",
             style=discord.ButtonStyle.success,
-            row=2,
+            row=3,
         )
 
     async def callback(self, interaction: discord.Interaction) -> None:
@@ -264,7 +269,7 @@ class GreetMembersStep(_StepView):
                 "Send a friendly message when someone joins, and (if you like) "
                 "give every newcomer a role automatically.\n\n"
                 "Pick a channel for the welcome message below, then press "
-                "**Turn on greetings**."
+                "**Save & continue**."
             ),
             color=discord.Color.blurple(),
         )
@@ -341,10 +346,10 @@ class _DmToggleButton(discord.ui.Button):  # type: ignore[type-arg]
 class _ModSaveButton(discord.ui.Button):  # type: ignore[type-arg]
     def __init__(self) -> None:
         super().__init__(
-            label="Save moderators",
+            label="Save & continue",
             emoji="🛡️",
             style=discord.ButtonStyle.success,
-            row=2,
+            row=3,
         )
 
     async def callback(self, interaction: discord.Interaction) -> None:
@@ -431,20 +436,23 @@ _SPAM_FILTERS: list[tuple[str, str]] = [
 ]
 
 
-class _FilterToggle(discord.ui.Button):  # type: ignore[type-arg]
-    def __init__(self, key: str, label: str, on: bool, row: int) -> None:
+class _SpamFilterSelect(discord.ui.Select):  # type: ignore[type-arg]
+    def __init__(self, selected: set[str]) -> None:
+        options = [
+            discord.SelectOption(label=label, value=key, default=key in selected)
+            for key, label in _SPAM_FILTERS
+        ]
         super().__init__(
-            label=f"{label}: {'ON' if on else 'OFF'}",
-            style=(
-                discord.ButtonStyle.success if on else discord.ButtonStyle.secondary
-            ),
-            row=row,
+            placeholder="What should I clean up? (all on by default)",
+            min_values=0,
+            max_values=len(options),
+            options=options,
+            row=0,
         )
-        self._key = key
 
     async def callback(self, interaction: discord.Interaction) -> None:
         view: BlockSpamStep = self.view  # type: ignore[assignment]
-        view.filters[self._key] = not view.filters[self._key]
+        view.filters = set(self.values)
         view.refresh_items()
         await interaction.response.edit_message(embed=view.render(), view=view)
 
@@ -452,10 +460,10 @@ class _FilterToggle(discord.ui.Button):  # type: ignore[type-arg]
 class _SpamSaveButton(discord.ui.Button):  # type: ignore[type-arg]
     def __init__(self) -> None:
         super().__init__(
-            label="Turn on protection",
+            label="Save & continue",
             emoji="🧹",
             style=discord.ButtonStyle.success,
-            row=2,
+            row=3,
         )
 
     async def callback(self, interaction: discord.Interaction) -> None:
@@ -468,7 +476,7 @@ class BlockSpamStep(_StepView):
     skip_label = "Skip spam protection"
 
     def __init__(self, flow: EssentialFlow) -> None:
-        self.filters: dict[str, bool] = {key: True for key, _ in _SPAM_FILTERS}
+        self.filters: set[str] = {key for key, _ in _SPAM_FILTERS}
         super().__init__(flow)
 
     def build_items(self) -> None:
@@ -476,10 +484,9 @@ class BlockSpamStep(_StepView):
 
     def refresh_items(self) -> None:
         for child in list(self.children):
-            if isinstance(child, (_FilterToggle, _SpamSaveButton)):
+            if isinstance(child, (_SpamFilterSelect, _SpamSaveButton)):
                 self.remove_item(child)
-        for i, (key, label) in enumerate(_SPAM_FILTERS):
-            self.add_item(_FilterToggle(key, label, self.filters[key], row=i // 2))
+        self.add_item(_SpamFilterSelect(self.filters))
         self.add_item(_SpamSaveButton())
 
     def render(self) -> discord.Embed:
@@ -487,15 +494,15 @@ class BlockSpamStep(_StepView):
             title=f"🧹 {self.title}",
             description=(
                 "Automatically clean up the noise so you don't have to. "
-                "Everything below is on by default — tap any to turn it off, "
-                "then press **Turn on protection**."
+                "Everything is on by default — untick anything you want to "
+                "allow, then press **Save & continue**."
             ),
             color=discord.Color.blurple(),
         )
         for key, label in _SPAM_FILTERS:
             embed.add_field(
                 name=label,
-                value="On" if self.filters[key] else "Off",
+                value="On" if key in self.filters else "Off",
                 inline=True,
             )
         embed.set_footer(text=self.flow.step_counter())
@@ -505,7 +512,7 @@ class BlockSpamStep(_StepView):
         try:
             await self._set("automod", "enabled", True)
             for key, _ in _SPAM_FILTERS:
-                await self._set("automod", key, self.filters[key])
+                await self._set("automod", key, key in self.filters)
         except Exception:
             logger.exception("essential setup: block-spam step apply failed")
             await interaction.response.send_message(
@@ -513,7 +520,7 @@ class BlockSpamStep(_StepView):
                 ephemeral=True,
             )
             return
-        on_labels = [label for key, label in _SPAM_FILTERS if self.filters[key]]
+        on_labels = [label for key, label in _SPAM_FILTERS if key in self.filters]
         line = "Spam protection on"
         if on_labels:
             line += " · " + ", ".join(on_labels).lower()
@@ -603,13 +610,58 @@ class _LogChannelPicker(discord.ui.ChannelSelect):  # type: ignore[type-arg]
         await interaction.response.edit_message(embed=view.render(), view=view)
 
 
+class _ChannelNamesModal(discord.ui.Modal, title="Name the new channels"):  # type: ignore[call-arg]
+    """Optional: type custom names for the channel(s) we auto-create."""
+
+    mod_name = discord.ui.TextInput(  # type: ignore[var-annotated]
+        label="Moderation log channel name",
+        required=False,
+        max_length=90,
+    )
+    activity_name = discord.ui.TextInput(  # type: ignore[var-annotated]
+        label="Activity log channel name",
+        required=False,
+        max_length=90,
+    )
+
+    def __init__(self, view: LogChannelStep) -> None:
+        super().__init__()
+        self._view = view
+        self.mod_name.default = view.mod_channel_name or _NEW_MOD_CHANNEL_NAME
+        self.activity_name.default = (
+            view.activity_channel_name or _NEW_ACTIVITY_CHANNEL_NAME
+        )
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        self._view.mod_channel_name = self.mod_name.value.strip() or None
+        self._view.activity_channel_name = self.activity_name.value.strip() or None
+        self._view.refresh_items()
+        await interaction.response.edit_message(
+            embed=self._view.render(),
+            view=self._view,
+        )
+
+
+class _NameChannelsButton(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            label="✏️ Name the new channel(s)",
+            style=discord.ButtonStyle.secondary,
+            row=3,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: LogChannelStep = self.view  # type: ignore[assignment]
+        await interaction.response.send_modal(_ChannelNamesModal(view))
+
+
 class _LogSaveButton(discord.ui.Button):  # type: ignore[type-arg]
     def __init__(self) -> None:
         super().__init__(
-            label="Save logging",
+            label="Save & continue",
             emoji="📋",
             style=discord.ButtonStyle.success,
-            row=4,
+            row=3,
         )
 
     async def callback(self, interaction: discord.Interaction) -> None:
@@ -625,13 +677,16 @@ class LogChannelStep(_StepView):
         self.mod_channel_id: int | None = None
         self.activity_channel_id: int | None = None
         self.activity: set[str] = set(_DEFAULT_ACTIVITY)
+        # Optional custom names for channels we auto-create (None = default).
+        self.mod_channel_name: str | None = None
+        self.activity_channel_name: str | None = None
         super().__init__(flow)
 
     def build_items(self) -> None:
         self.refresh_items()
 
     def refresh_items(self) -> None:
-        """(Re)build the controls from current state (rows 0/1/2/4).
+        """(Re)build the controls from current state (rows 0/1/2/3).
 
         Rebuilt on every interaction so the multi-select reflects ``activity``;
         the channel pickers reset visually but the chosen ids persist on the
@@ -640,7 +695,12 @@ class LogChannelStep(_StepView):
         for child in list(self.children):
             if isinstance(
                 child,
-                (_ActivityTypeSelect, _LogChannelPicker, _LogSaveButton),
+                (
+                    _ActivityTypeSelect,
+                    _LogChannelPicker,
+                    _NameChannelsButton,
+                    _LogSaveButton,
+                ),
             ):
                 self.remove_item(child)
         self.add_item(_ActivityTypeSelect(self.activity))
@@ -658,6 +718,7 @@ class LogChannelStep(_StepView):
                 row=2,
             ),
         )
+        self.add_item(_NameChannelsButton())
         self.add_item(_LogSaveButton())
 
     def render(self) -> discord.Embed:
@@ -670,25 +731,30 @@ class LogChannelStep(_StepView):
                 "• an **activity log** — the things you tick below\n\n"
                 "Pick a channel for each, or leave one empty and we'll make it "
                 f"for you (**#{_NEW_MOD_CHANNEL_NAME}** / "
-                f"**#{_NEW_ACTIVITY_CHANNEL_NAME}**). Then press **Save logging**."
+                f"**#{_NEW_ACTIVITY_CHANNEL_NAME}** — or tap ✏️ to name it). "
+                "Then press **Save & continue**."
             ),
             color=discord.Color.blurple(),
         )
         embed.add_field(
             name="Moderation log",
-            value=self._where(self.mod_channel_id, _NEW_MOD_CHANNEL_NAME),
+            value=self._where(
+                self.mod_channel_id,
+                self.mod_channel_name or _NEW_MOD_CHANNEL_NAME,
+            ),
             inline=False,
         )
         if self.activity:
             picked = ", ".join(
                 label for flag, label, _ in _ACTIVITY_TYPES if flag in self.activity
             )
+            activity_where = self._where(
+                self.activity_channel_id,
+                self.activity_channel_name or _NEW_ACTIVITY_CHANNEL_NAME,
+            )
             embed.add_field(
                 name="Activity log",
-                value=(
-                    f"{self._where(self.activity_channel_id, _NEW_ACTIVITY_CHANNEL_NAME)}\n"
-                    f"_Logging: {picked}_"
-                ),
+                value=f"{activity_where}\n_Logging: {picked}_",
                 inline=False,
             )
         else:
@@ -708,25 +774,24 @@ class LogChannelStep(_StepView):
 
     async def apply(self, interaction: discord.Interaction) -> None:
         created: list[str] = []
+        mod_name = self.mod_channel_name or _NEW_MOD_CHANNEL_NAME
+        activity_name = self.activity_channel_name or _NEW_ACTIVITY_CHANNEL_NAME
         # Moderation log is the always-on baseline — resolve (or create) it.
         mod_id = self.mod_channel_id
         if mod_id is None:
-            mod_id = await self._create_channel(interaction, _NEW_MOD_CHANNEL_NAME)
+            mod_id = await self._create_channel(interaction, mod_name)
             if mod_id is None:
                 return  # creation failed; error already surfaced
-            created.append(_NEW_MOD_CHANNEL_NAME)
+            created.append(mod_name)
         # Activity log only when at least one activity category is ticked.
         activity_id: int | None = None
         if self.activity:
             activity_id = self.activity_channel_id
             if activity_id is None:
-                activity_id = await self._create_channel(
-                    interaction,
-                    _NEW_ACTIVITY_CHANNEL_NAME,
-                )
+                activity_id = await self._create_channel(interaction, activity_name)
                 if activity_id is None:
                     return
-                created.append(_NEW_ACTIVITY_CHANNEL_NAME)
+                created.append(activity_name)
         try:
             await self._set("logging", "enabled", True)
             await self._bind("mod_channel", mod_id)
@@ -912,10 +977,10 @@ class _RewardTypeSelect(discord.ui.Select):  # type: ignore[type-arg]
 class _RewardNextButton(discord.ui.Button):  # type: ignore[type-arg]
     def __init__(self, has_rewards: bool) -> None:
         super().__init__(
-            label="Next" if has_rewards else "Save",
+            label="Next" if has_rewards else "Save & continue",
             emoji="🏅",
             style=discord.ButtonStyle.success,
-            row=2,
+            row=3,
         )
 
     async def callback(self, interaction: discord.Interaction) -> None:
@@ -978,13 +1043,50 @@ class _RewardRoleSelect(discord.ui.RoleSelect):  # type: ignore[type-arg]
         await interaction.response.edit_message(embed=view.render(), view=view)
 
 
+class _RoleNameModal(discord.ui.Modal, title="Name the reward role"):  # type: ignore[call-arg]
+    """Optional: type a custom name for the role we create."""
+
+    role_name = discord.ui.TextInput(  # type: ignore[var-annotated]
+        label="Role name",
+        required=False,
+        max_length=90,
+    )
+
+    def __init__(self, view: RewardActivityStep) -> None:
+        super().__init__()
+        self._view = view
+        self.role_name.default = view.new_role_name or _DEFAULT_ROLE_NAME
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        self._view.new_role_name = self.role_name.value.strip() or None
+        self._view.role_source = "create"
+        self._view.refresh_items()
+        await interaction.response.edit_message(
+            embed=self._view.render(),
+            view=self._view,
+        )
+
+
+class _TypeRoleNameButton(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            label="✏️ Type a name",
+            style=discord.ButtonStyle.secondary,
+            row=2,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: RewardActivityStep = self.view  # type: ignore[assignment]
+        await interaction.response.send_modal(_RoleNameModal(view))
+
+
 class _RewardSaveButton(discord.ui.Button):  # type: ignore[type-arg]
     def __init__(self) -> None:
         super().__init__(
-            label="Save rewards",
+            label="Save & continue",
             emoji="🏅",
             style=discord.ButtonStyle.success,
-            row=2,
+            row=3,
         )
 
     async def callback(self, interaction: discord.Interaction) -> None:
@@ -1017,6 +1119,7 @@ class RewardActivityStep(_StepView):
             _RewardNextButton,
             _RoleSourceSelect,
             _RoleNameSelect,
+            _TypeRoleNameButton,
             _RewardRoleSelect,
             _RewardSaveButton,
         )
@@ -1031,6 +1134,7 @@ class RewardActivityStep(_StepView):
             self.add_item(_RoleSourceSelect(self.role_source))
             if self.role_source == "create":
                 self.add_item(_RoleNameSelect(self.new_role_name))
+                self.add_item(_TypeRoleNameButton())
             elif self.role_source == "existing":
                 self.add_item(_RewardRoleSelect())
             self.add_item(_RewardSaveButton())
@@ -1291,10 +1395,10 @@ class _TranscriptChannelSelect(discord.ui.ChannelSelect):  # type: ignore[type-a
 class _HelpDeskSaveButton(discord.ui.Button):  # type: ignore[type-arg]
     def __init__(self) -> None:
         super().__init__(
-            label="Turn on the help desk",
+            label="Save & continue",
             emoji="🎫",
             style=discord.ButtonStyle.success,
-            row=2,
+            row=3,
         )
 
     async def callback(self, interaction: discord.Interaction) -> None:
@@ -1322,7 +1426,7 @@ class HelpDeskStep(_StepView):
             description=(
                 "Let members open a private request that only your staff can "
                 "see. Pick who should answer them; we set up the rest.\n\n"
-                "Then press **Turn on the help desk**."
+                "Then press **Save & continue**."
             ),
             color=discord.Color.blurple(),
         )

--- a/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
+++ b/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
@@ -1,1 +1,0 @@
-claude/blissful-hamilton-xdzbak · Essential Setup spine polish: skip-recap fix · consistent Save row · block-spam→multi-select · unified Save label · optional custom naming (role + channel names via modal) · disbot/views/setup/essential_setup.py + tests · 2026-06-24

--- a/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
+++ b/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
@@ -1,0 +1,1 @@
+claude/blissful-hamilton-xdzbak · Essential Setup spine polish: skip-recap fix · consistent Save row · block-spam→multi-select · unified Save label · optional custom naming (role + channel names via modal) · disbot/views/setup/essential_setup.py + tests · 2026-06-24

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -7454,3 +7454,31 @@ was wrong); role auto-create is `RoleLifecycleService.apply(operation="create")`
 **Home:** this Q-block (canonical) + the plan §5 step 5 / §7 PR-1 note +
 `.sessions/2026-06-24-setup-reward-activity.md`. Related: **Q-A** (direct-apply per step), **Q-0202**/
 **Q-0203** (the analogous log-channel step decisions).
+
+### Q-0205 — ANSWERED (owner directives, in-session): Essential Setup spine polish + the "optional typing everywhere sensible" principle (2026-06-24)
+
+**Context.** After an agent review of the six live spine steps (navigation / consistent structure / typing),
+the owner directed applying every finding and adding optional typing.
+
+**The directives.**
+1. **Multi-select is the preferred idiom** for "pick which of these to turn on." Block-spam's four on/off
+   toggle buttons were converted to one multi-select, matching the log/reward steps.
+2. **Consistent primary-button position + one label voice.** Every step's primary button is **row 3**
+   (Back/Skip on row 4) so "Save" is in the same place on every step, and the label is unified to
+   **"Save & continue"** (the module-docstring voice), keeping each step's emoji.
+3. **Fix the skip-recap bug.** `_StepView.skip()` now records the skipped step (`record_skipped`), so the
+   summary's "Skipped (you can do these later)" list actually populates (it was dead code).
+4. **Optional typing everywhere it makes sense (DURABLE PRINCIPLE).** Wherever the bot *creates a named
+   thing* (a role, a channel), offer an **optional** "✏️ Type a name" path (a `discord.ui.Modal`,
+   prefilled with the default). **Typing is always optional, never required** — every default stays
+   fully selectable via buttons/dropdowns. Applied to the reward **role name** and the log **channel
+   names**. **Future steps must follow this** — e.g. the step-0 server-type preset, and any step that
+   auto-creates a named resource, should expose the same optional-type-a-name affordance.
+
+**Scope.** View-layer polish only (no new service / cog / command / artifact). Default thresholds, rate
+presets, and suggested names are unchanged.
+
+**Applied.** PR **#1435** (`essential_setup.py` + tests).
+
+**Home:** this Q-block (canonical) + `.sessions/2026-06-24-setup-spine-polish.md` + the plan §7 PR-1 note.
+Related: **Q-0202**/**Q-0203**/**Q-0204** (the per-step spine decisions), **Q-A** (direct-apply per step).

--- a/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
+++ b/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
@@ -196,7 +196,13 @@ decision with architectural weight → called out as open question Q-A below.
     / `set_time_threshold` already ARE the audited direct-apply paths, and
     `RoleLifecycleService.apply(operation="create")` does the role auto-create. No new service was needed.
   - **Server-type starter preset** (step 0) — **needs a direct-apply preset path** (presets are
-    draft-only today); design decision before building.
+    draft-only today); design decision before building. Must follow the **optional-typing principle**
+    (Q-0205) for any named resource it creates.
+- **PR 1 polish pass (SHIPPED 2026-06-24, `#1435`, owner directives Q-0205):** spine consistency + the
+  optional-typing principle — block-spam → multi-select (the preferred "pick which" idiom), every step's
+  primary button unified to **"Save & continue"** on a consistent row, the skip-recap summary bug fixed
+  (`record_skipped` was never called), and an optional **"✏️ Type a name" modal** added wherever the bot
+  auto-creates a named role/channel (typing always optional, defaults stay fully selectable).
 - **PR 2 — extras + health check:** the **Extras menu** (each existing config surface as a one-action
   step: starboard, counters, security, image-mod, karma, AI, reaction roles, giveaways) + the single
   **"Check my setup"** health button (folds in scan/readiness/diagnostics/suggestions). Wires the

--- a/tests/unit/views/setup/test_essential_setup.py
+++ b/tests/unit/views/setup/test_essential_setup.py
@@ -132,6 +132,21 @@ def test_first_step_has_no_back_button():
     assert any(isinstance(c, es._BackButton) for c in step2.children)
 
 
+@pytest.mark.asyncio
+async def test_skip_records_step_for_summary():
+    flow = es.EssentialFlow(_member(), _guild())
+    step = es.GreetMembersStep(flow)
+
+    await step.skip(_interaction())
+
+    # Skipping records the step so the summary's "Skipped" recap can list it.
+    assert flow.skipped == ["Greet new members"]
+    assert flow.index == 1
+    summary = es.EssentialSummaryView(flow).render()
+    blob = (summary.description or "") + " ".join(f.value for f in summary.fields)
+    assert "Greet new members" in blob
+
+
 # ---------------------------------------------------------------------------
 # Greet members
 # ---------------------------------------------------------------------------
@@ -239,7 +254,7 @@ async def test_block_spam_respects_toggled_off_filter(pipeline):
     flow = es.EssentialFlow(_member(), _guild())
     flow.index = 2
     step = es.BlockSpamStep(flow)
-    step.filters["caps_enabled"] = False
+    step.filters.discard("caps_enabled")  # untick one in the multi-select
     await step.apply(_interaction())
     by_name = {c.args[2]: c.args[3] for c in pipeline.set_value.await_args_list}
     assert by_name["caps_enabled"] is False
@@ -366,6 +381,27 @@ async def test_log_channel_create_failure_blocks(
     pipeline.set_value.assert_not_awaited()
     interaction.response.send_message.assert_awaited_once()
     assert flow.index == 3
+
+
+@pytest.mark.asyncio
+async def test_log_channel_custom_names_used_when_creating(
+    pipeline,
+    binding_pipeline,
+    channel_service,
+):
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 3
+    step = es.LogChannelStep(flow)
+    # Optional typing: custom names for both auto-created channels.
+    step.mod_channel_name = "staff-log"
+    step.activity_channel_name = "member-log"
+    channel_service.create_channels.side_effect = [_created(11), _created(22)]
+
+    await step.apply(_interaction())
+
+    names = [c.args[1][0] for c in channel_service.create_channels.await_args_list]
+    assert names == ["staff-log", "member-log"]
+    assert flow.index == 4
 
 
 # ---------------------------------------------------------------------------
@@ -520,6 +556,34 @@ async def test_reward_role_create_failure_blocks(
     pipeline.set_value.assert_not_awaited()
     interaction.response.send_message.assert_awaited_once()
     assert flow.index == 4
+
+
+@pytest.mark.asyncio
+async def test_reward_create_uses_custom_role_name(
+    pipeline,
+    role_automation,
+    role_service,
+):
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 4
+    step = es.RewardActivityStep(flow)
+    step.rewards = {"level"}
+    step.phase = "roles"
+    step.role_source = "create"
+    step.new_role_name = "Champion"  # optional typing → custom role name
+    role_service.apply.return_value = SimpleNamespace(
+        applied=(SimpleNamespace(target_id=909),),
+        first_error="",
+    )
+
+    await step.apply(_interaction())
+
+    # The role is created with the typed name, and the reward is set on it.
+    request = role_service.apply.await_args.args[1]
+    assert request.name == "Champion"
+    assert role_automation.set_xp_threshold.await_args.kwargs["role_name"] == "Champion"
+    assert role_automation.set_xp_threshold.await_args.kwargs["role_id"] == 909
+    assert flow.index == 5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Applies the spine review findings + adds optional custom naming. View-layer polish across `essential_setup.py` (no new cog/command/artifact, no new service).

## Changes
1. **Fix: skip-recap bug** — `_StepView.skip()` never recorded the skip, so the summary's *"Skipped (you can do these later)"* list was always empty/dead. It now records `flow.record_skipped(title)`, so the recap populates.
2. **Consistent Save position** — every step's primary button is now **row 3** and Back/Skip **row 4**, so Save sits in the same place on every step (previously the log-channel step's Save sat *below* Back/Skip because 3 dropdowns filled rows 0–2).
3. **Block-spam → multi-select** — the four on/off toggle buttons become one multi-select (all four pre-selected; untick to disable), matching the log/reward steps. ("multi select is preferred.")
4. **One Save-label voice** — unified to **"Save & continue"** (the module docstring's stated pattern), keeping each step's emoji. Reward screen 1 stays "Next" (a transition, not a save).
5. **Optional custom naming (typing optional, never required)** — an "✏️ Type a name" button opens a `discord.ui.Modal` (prefilled with the default) wherever the bot *creates* a named thing: the **reward role** (create mode) and the **log channel(s)** it auto-creates. All defaults still work with zero typing; the modal is the only place text is entered, and every field is optional.

Copy stays jargon-clean; modal titles/labels are covered by `check_setup_copy`. Tests updated/added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PPgD6XUGaxHBD6JVYxbDp

---
_Generated by [Claude Code](https://claude.ai/code/session_016PPgD6XUGaxHBD6JVYxbDp)_