### PR TITLE
docs: reconcile setup-wizard plan + S1 state with the shipped Essential Setup spine

### DIFF
--- a/.sessions/2026-06-24-doc-staleness-audit.md
+++ b/.sessions/2026-06-24-doc-staleness-audit.md
@@ -1,24 +1,63 @@
 # Session — 2026-06-24 · Doc-staleness audit (Essential Setup spine)
 
-> **Status:** `in-progress` — born-red hold. Docs-only; closes out the session's spine work + fixes
-> the two stale pointers the audit found.
+> **Status:** `complete` — docs-only. Caps the session that shipped the Essential Setup spine
+> end-to-end and reconciles its forward pointers. PR #1436.
 
 **Trigger:** owner-directed (chat, 2026-06-24): *"check if everything is properly documented and the
-plans and current state/active work aren't stale, then end the session."* This caps a session that
-shipped the Essential Setup spine end-to-end (#1429 log-channel, #1432 rework, #1434 reward, #1435
-polish — all merged).
+plans and current state/active work aren't stale, then end the session."*
 
 ## Audit result
 
-- **Automated checks green:** `check_docs --strict` ✓; `check_current_state_ledger --strict` EXIT=0 —
-  the 23 PRs past reconciliation marker #1410 are flagged **benign newest-merge lag** (the #1440 recon
-  pass records them; the carve-out says do NOT hand-add them, so I don't).
-- **Router** Q-0202/0203/0204/0205 all recorded; each spine PR has its `.sessions/` card.
-- **Two stale pointers found → fixing here:**
-  1. `setup-wizard-restructure-plan-2026-06-24.md` **"▶ Build progress: not started"** — PR 1 (the
-     essentials spine) is in fact COMPLETE + polished. Updated to reflect reality.
-  2. `current-state/S1-bot.md` (+ the S1 summary row) — referenced only the *old* `!setup` wizard's
-     per-section walk, never the new **Essential Setup spine** (`!quicksetup`). Added its status so the
-     work stream is discoverable, not orphaned.
+- **Automated checks green:** `check_docs --strict` ✓; doc tests 70 ✓; `check_current_state_ledger
+  --strict` EXIT=0 — the 23 PRs past reconciliation marker #1410 are **benign newest-merge lag** (the
+  #1440 recon pass records them; the carve-out forbids hand-adding, so I didn't).
+- **Router** Q-0202/Q-0203/Q-0204/Q-0205 recorded; each spine PR (#1429/#1432/#1434/#1435) has its
+  `.sessions/` card.
+- **Two stale forward-pointers found + fixed:**
+  1. `setup-wizard-restructure-plan-2026-06-24.md` **"▶ Build progress: not started"** → updated to
+     "PR 1 COMPLETE + polished" with the remaining work (step 0 / PR 2 / PR 3).
+  2. `current-state/S1-bot.md` + the S1 summary row in `current-state.md` — both referenced only the
+     *old* `!setup` wizard; added the new **Essential Setup spine (`!quicksetup`)** status + plan link.
 
-<!-- close-out written as the final step -->
+## What shipped
+
+The three doc edits above. No code, no ledger entries (benign-lag carve-out).
+
+## 💡 Session idea (Q-0089)
+
+**A `check_docs` rule that flags a plan whose top-line "Build progress"/"Status" contradicts its body** —
+e.g. "▶ Build progress: not started" while §7 bullets are marked `SHIPPED`. This audit's #1 finding was
+exactly that: every spine PR diligently updated the per-step §7 notes but nobody updated the single
+shared top-line summary, so it sat at "not started" through six merged PRs. A cheap string check
+(top-line says not-started/planned **and** body contains "SHIPPED" → warn) makes this drift class
+self-catching. Dedup-checked `docs/ideas/`; not present.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous: **`2026-06-24-setup-spine-polish.md`** (#1435). **Did well:** thorough polish + recorded the
+durable Q-0205 principle + flagged the conformance-test idea. **Missed:** like every spine session before
+it, it updated the *detailed* plan notes (§5/§7) and its own card but left the plan's **top-line "Build
+progress" summary** and the **S1 sector pointer** untouched — the drift this audit then had to fix.
+**System improvement:** shared *summary* lines (a plan's Build-progress, a sector's live-state) have no
+natural owner among per-step PRs, so they rot; either each shipping PR updates the summary too, or the
+Q-0089 check enforces it. The pattern across the whole session: detail stayed fresh, summaries drifted.
+
+## 📋 Doc audit (Q-0104)
+
+This session *is* the audit. Post-fix: `check_docs --strict` ✓, doc tests ✓, ledger EXIT=0 (benign lag
+only). Plan + both current-state surfaces now reflect the shipped spine. Nothing left in chat.
+
+## Context delta — for next session
+
+- **Docs are reconciled.** The Essential Setup spine (PR 1) is now discoverable from `current-state.md`
+  (S1 row), `S1-bot.md`, and the plan's Build-progress line — not just buried in §7.
+- **Next setup work:** step 0 (server-type preset — needs a direct-apply preset path; ⚠ verify against
+  source first), then PR 2 (extras + "Check my setup") and PR 3 (retire dead sections + rework the
+  Advanced editor, Q-E).
+- **Two pending workflow ideas worth doing:** the spine **structural-conformance test** (#1435 card) and
+  the **plan build-progress drift check** (above) — both make the spine's correctness/freshness
+  self-enforcing.
+
+## ⚑ Self-initiated: NONE — owner-directed (the audit + fixes were requested). Which specific lines were
+stale and how to reword them were my calls within "make sure they aren't stale." Docs-only, fully
+test-/checker-verified.

--- a/.sessions/2026-06-24-doc-staleness-audit.md
+++ b/.sessions/2026-06-24-doc-staleness-audit.md
@@ -1,0 +1,24 @@
+# Session — 2026-06-24 · Doc-staleness audit (Essential Setup spine)
+
+> **Status:** `in-progress` — born-red hold. Docs-only; closes out the session's spine work + fixes
+> the two stale pointers the audit found.
+
+**Trigger:** owner-directed (chat, 2026-06-24): *"check if everything is properly documented and the
+plans and current state/active work aren't stale, then end the session."* This caps a session that
+shipped the Essential Setup spine end-to-end (#1429 log-channel, #1432 rework, #1434 reward, #1435
+polish — all merged).
+
+## Audit result
+
+- **Automated checks green:** `check_docs --strict` ✓; `check_current_state_ledger --strict` EXIT=0 —
+  the 23 PRs past reconciliation marker #1410 are flagged **benign newest-merge lag** (the #1440 recon
+  pass records them; the carve-out says do NOT hand-add them, so I don't).
+- **Router** Q-0202/0203/0204/0205 all recorded; each spine PR has its `.sessions/` card.
+- **Two stale pointers found → fixing here:**
+  1. `setup-wizard-restructure-plan-2026-06-24.md` **"▶ Build progress: not started"** — PR 1 (the
+     essentials spine) is in fact COMPLETE + polished. Updated to reflect reality.
+  2. `current-state/S1-bot.md` (+ the S1 summary row) — referenced only the *old* `!setup` wizard's
+     per-section walk, never the new **Essential Setup spine** (`!quicksetup`). Added its status so the
+     work stream is discoverable, not orphaned.
+
+<!-- close-out written as the final step -->

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -13,7 +13,7 @@
 >
 > | Sector | Live state | One-line status |
 > |---|---|---|
-> | **S1 Bot product** | [`current-state/S1-bot.md`](current-state/S1-bot.md) | reaction-roles arc Carl-bot-mature; creature game + mining grid live; Starboard PR 1+2 shipped (#1259/#1270); karma shipped (#1332); **consolidation/discoverability audit ✅ COMPLETE (2026-06-23)** ([brief](planning/consolidation-discoverability-audit-brief-2026-06-23.md)); ▶ next: Project Moon runtime PR 1 / botsite React migration / consolidation polish tail |
+> | **S1 Bot product** | [`current-state/S1-bot.md`](current-state/S1-bot.md) | reaction-roles arc Carl-bot-mature; creature game + mining grid live; Starboard PR 1+2 shipped (#1259/#1270); karma shipped (#1332); **consolidation/discoverability audit ✅ COMPLETE (2026-06-23)** ([brief](planning/consolidation-discoverability-audit-brief-2026-06-23.md)); **Essential Setup spine `!quicksetup` PR 1 ✅ + polished (2026-06-24, #1435)** ([plan](planning/setup-wizard-restructure-plan-2026-06-24.md)); ▶ next: setup step-0 preset / Project Moon runtime PR 1 / botsite React migration |
 > | **S2 BTD6** | [`current-state/S2-btd6.md`](current-state/S2-btd6.md) | buff-uptime + data auto-seed/drift shipped (manual `seed-data` step closed); ▶ decode items 3–4 / absence-guard Layer B |
 > | **S3 AI-Memory** | [`current-state/S3-ai-memory.md`](current-state/S3-ai-memory.md) | per-claim/per-sector restructure (this PR); ▶ consistency-linter AI-nav PR 1 / procedures→skills Batch 2 |
 > | **S4 Docs system** | [`current-state/S4-docs.md`](current-state/S4-docs.md) | 24th Q-0107 pass done (band-#1410); next recon at #1440; **no PLAN-BACKLOG-THIN flag** |

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -45,6 +45,15 @@
   broadcast table. [design](../planning/casino-poker-design-2026-06-22.md).
 
 **▶ Next startable (one of):**
+- **Essential Setup spine (`!quicksetup`) — PR 1 COMPLETE + polished (owner-directed, 2026-06-24).** A
+  new plain-language, button/dropdown/multi-select-only quick-setup flow (6 steps: greet · moderators ·
+  block spam · choose a log channel · reward active members · help desk + summary), separate from and
+  additive to the legacy `!setup` wizard. Each step applies immediately (direct lane) through an audited
+  service; typing is optional everywhere (Q-0205). Shipped #1425/#1427/#1429/#1432/#1434 + polish #1435;
+  decisions Q-0202/Q-0203/Q-0204/Q-0205. **▶ Next:** step 0 (server-type starter preset — needs a
+  direct-apply preset path, verify source first) · PR 2 (extras menu + "Check my setup") · PR 3 (retire
+  dead/legacy sections + rework the Advanced editor). Tracker:
+  [`planning/setup-wizard-restructure-plan-2026-06-24.md`](../planning/setup-wizard-restructure-plan-2026-06-24.md).
 - **✅ Consolidation / discoverability audit — COMPLETE (owner-directed, 2026-06-23).** All five goals
   shipped and CI-guarded where possible. Staging brief + per-cog rubric:
   [`planning/consolidation-discoverability-audit-brief-2026-06-23.md`](../planning/consolidation-discoverability-audit-brief-2026-06-23.md).

--- a/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
+++ b/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
@@ -1,1 +1,0 @@
-claude/blissful-hamilton-xdzbak · Doc-staleness audit + fixes: setup-wizard plan "Build progress" (PR 1 done) + S1 sector Essential Setup spine status · docs only · 2026-06-24

--- a/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
+++ b/docs/owner/claims/claude-blissful-hamilton-xdzbak.md
@@ -1,0 +1,1 @@
+claude/blissful-hamilton-xdzbak · Doc-staleness audit + fixes: setup-wizard plan "Build progress" (PR 1 done) + S1 sector Essential Setup spine status · docs only · 2026-06-24

--- a/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
+++ b/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
@@ -8,8 +8,13 @@
 > jargon, quick with buttons/dropdowns, each step is one complete action that actually completes a setup
 > step properly."* This plan answers that directly. Plan-first: greenlight before build.
 >
-> **▶ Build progress:** not started. PR 1 = the jargon-free essentials spine; PR 2 = extras + health
-> check; PR 3 = retire the dead/legacy sections.
+> **▶ Build progress:** **PR 1 (the jargon-free essentials spine) COMPLETE + polished.** Six live steps
+> (greet · moderators · block spam · choose a log channel · reward active members · help desk) + the
+> All-done summary, opened by `!quicksetup` / `/quicksetup`; shipped across #1425/#1427/#1429/#1432/#1434
+> and given a consistency + optional-typing polish pass (#1435, Q-0205). **Remaining:** step 0
+> (server-type starter preset — needs a direct-apply preset path; verify against source first), then
+> **PR 2** = extras menu + "Check my setup", **PR 3** = retire dead/legacy sections + rework the Advanced
+> editor (Q-E).
 >
 > **Sim:** [`tools/sim/setup_wizard_sim.py`](../../tools/sim/setup_wizard_sim.py) (runnable) —
 > models a non-technical owner walking the flow. Current standard-depth flow scores **~4% finish**


### PR DESCRIPTION
Caps the Essential Setup spine session with a documentation-staleness audit + the two fixes it found. **Docs only** — no code.

## Audit result
- `check_docs --strict` ✓; `check_current_state_ledger --strict` EXIT=0 — the 23 PRs past reconciliation marker #1410 are **benign newest-merge lag** (recorded by the #1440 recon pass; the carve-out says not to hand-add them, so this PR doesn't).
- Router decisions Q-0202 / Q-0203 / Q-0204 / Q-0205 all recorded; every spine PR has its `.sessions/` card.

## Fixes
1. **`setup-wizard-restructure-plan-2026-06-24.md`** — the top **"▶ Build progress: not started"** line was stale: PR 1 (the essentials spine) is in fact complete + polished. Updated to reflect reality (PR 1 ✅; PR 2/3 + step-0 preset remaining).
2. **`current-state/S1-bot.md`** + the S1 summary row in **`current-state.md`** — both referenced only the *old* `!setup` wizard's per-section walk, never the new **Essential Setup spine** (`!quicksetup`). Added its status + plan link so the work stream is discoverable rather than orphaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PPgD6XUGaxHBD6JVYxbDp

---
_Generated by [Claude Code](https://claude.ai/code/session_016PPgD6XUGaxHBD6JVYxbDp)_