### PR TITLE
Essential Setup step 0: server-type starter preset (direct-apply)

### DIFF
--- a/.sessions/2026-06-24-setup-step0-server-type-preset.md
+++ b/.sessions/2026-06-24-setup-step0-server-type-preset.md
@@ -1,0 +1,31 @@
+# 2026-06-24 — Essential Setup step 0: server-type starter preset (direct-apply)
+
+> **Status:** `in-progress` — born-red card; auto-merge holds until flipped `complete`.
+
+> **Run type:** `routine · dispatch`
+
+## What I'm about to do
+Scheduled dispatch fire, no work order. Open bugs are blocked/data-gated for an
+unattended run (BUG-0009 remaining slices need BTD6 release-order data + plan-level
+work; BUG-0011 needs a VPS repro; BUG-0019 #1 is an owner design fork). So I take the
+**owner-directed ▶ next** for the Essential Setup spine: **step 0 — "What kind of
+server is this?"** (the server-type starter preset), the explicit remaining item in
+[`planning/setup-wizard-restructure-plan-2026-06-24.md`](../docs/planning/setup-wizard-restructure-plan-2026-06-24.md)
+§5 / §7 (PR 1 tail).
+
+**The design decision the plan flagged ("presets are draft-only today; needs a
+direct-apply path"):** step-0 starter sets are **pure settings bundles** applied
+through the same audited `SettingsMutationPipeline` (`_StepView._set`) every other
+spine step uses — *not* the draft-only `automation_templates.SERVER_PRESETS` (those
+bind channels / create roles+rules → need operator picks + Final Review, the wrong
+shape for Q-C's "fastest, nothing irreversible"). Every value is a channel-independent
+boolean/scalar, so picking a type never creates or binds anything and is fully
+reversible from each feature's own panel later.
+
+Five server types (Community · Gaming · Support · Creator · Just exploring), each a
+curated bundle of automod toggles + `moderation.dm_on_action` + an XP rate (reusing
+`_XP_RATES`). Inserted as the new first step; tests updated for the index shift +
+new step coverage.
+
+## Shipped
+- (filling in as I go)

--- a/.sessions/2026-06-24-setup-step0-server-type-preset.md
+++ b/.sessions/2026-06-24-setup-step0-server-type-preset.md
@@ -1,6 +1,9 @@
 # 2026-06-24 — Essential Setup step 0: server-type starter preset (direct-apply)
 
-> **Status:** `in-progress` — born-red card; auto-merge holds until flipped `complete`.
+> **Status:** `complete` — PR #1437; auto-merge armed (MCP-created, so armed
+> manually per Q-0127); merges on green. Full CI mirror green (12,488 passed, 48
+> skipped, 2 xfailed; mypy + lint + arch 0 errors). The one CI red before this flip
+> was the **born-red session gate** doing its job (Q-0133) — not a real failure.
 
 > **Run type:** `routine · dispatch`
 
@@ -27,5 +30,87 @@ curated bundle of automod toggles + `moderation.dm_on_action` + an XP rate (reus
 `_XP_RATES`). Inserted as the new first step; tests updated for the index shift +
 new step coverage.
 
-## Shipped
-- (filling in as I go)
+## Shipped (PR #1437)
+- `disbot/views/setup/essential_setup.py` — **`ServerTypeStep`** (the new first
+  step), `_ServerTypePreset` (frozen dataclass), `_SERVER_TYPES` (the five starter
+  sets), `_server_type` lookup, `_ServerTypeSelect` + `_ServerTypeSaveButton`.
+  Inserted first in `EssentialFlow._steps` (flow now **7 steps**). Each starter set
+  is a curated bundle of **channel-independent** settings — automod toggles (the same
+  `enabled`/`spam_enabled`/`invites_enabled`/`caps_enabled`/`mentions_enabled` names
+  the block-spam step writes) + `moderation.dm_on_action` + an XP rate (reusing
+  `_XP_RATES`) — applied verbatim through the inherited audited `_set`
+  (`SettingsMutationPipeline`). Community/Creator caps-allowed; Gaming invites-allowed;
+  Support strict; Just-exploring = basic spam only (XP untouched).
+- `tests/unit/views/setup/test_essential_setup.py` — +4 step-0 tests (requires a
+  pick · community bundle + the resolved `_XP_RATES` triplet · exploring minimal +
+  skips XP · gaming allows invites) + a **known-settings invariant** pinning every
+  starter set to channel-independent keys + a resolvable `xp_rate`. Existing step
+  tests shifted for the new index ordering (ServerType=0 … HelpDesk=6).
+- Docs de-staled: plan §Build-progress + §5 + §7, and `current-state/S1-bot.md`.
+
+### The design decision the plan flagged
+The plan left open: *"presets are draft-only today; needs a direct-apply path;
+design decision before building."* Resolved by **not** reusing
+`automation_templates.SERVER_PRESETS` — those bind channels and create roles/rules,
+so they need operator picks + a Final Review (the wrong shape for Q-C's one-tap,
+instant, fully-reversible starter). The starter sets are pure settings bundles on the
+direct lane, so picking a type creates/binds nothing and is reversible from each
+feature's own panel. No named resource → Q-0205 optional-typing satisfied trivially.
+
+## 💡 Session idea (Q-0089)
+**Show the active starter set on the "All done" summary as an at-a-glance baseline
+card.** Step 0 now establishes a server-type baseline, but the closing
+`EssentialSummaryView` only lists the per-step `applied` lines — it doesn't surface
+*which server type* shaped the run or which later steps refined vs. inherited that
+baseline. Idea: have the summary lead with "Starter set: 🎮 Gaming" and mark each
+following line as *(from starter set)* vs *(you customised)*, so an operator who
+clicked through fast sees exactly what their one pick turned on. Cheap (the data is
+already in `flow.applied`); makes the fast-path's value legible. Dedup-checked — not
+in `docs/ideas/`; smaller than a plan, flagged for grooming.
+
+## ⟲ Previous-session review (Q-0102)
+Reviewed **2026-06-24-xpmenu-rank-card-h3** (#1413). **Did well:** tight, single-
+surface H3 migration with a clean shared `_decorate()` extraction (killed real
+duplication) and a focused 6-test pin including the help-nav-stays-embed contract —
+exactly the "complete a function, don't pad" discipline. **Could improve / system
+note:** it (and the two H3 runs before it) each shipped one small card surface, and
+the running S1 ▶ Remaining note has grown into a dense multi-clause paragraph
+tracking "H1 ✅ / H2 🟡 / H3 incremental" inline. That inline progress-ledger is
+drifting toward the same restate-everywhere pattern the one-fact-one-home rule warns
+about. **Improvement:** the visual-card-engine rollout now has enough moving parts
+(H1/H2/H3 × per-surface adoption) to deserve a tiny `planning/` rollout-tracker with
+a checkbox table, so the S1 sector line can shrink to a one-line pointer instead of
+absorbing a new clause every dispatch run. (Flagged here, not built — out of this
+PR's scope; a grooming candidate.)
+
+## ✅ Doc audit (Q-0104)
+- `check_docs --strict` green in CI (this run); `check_quality --full` green locally.
+- New owner decisions: **none** (executed existing plan + Q-C/Q-0205, no new ones).
+- Plan + S1 sector updated in lock-step with the merge; no chat-only facts left
+  un-homed. `check_current_state_ledger` not run for #1437 (not merged yet — the next
+  reconciliation pass folds it; benign newest-merge lag, Q-0166).
+
+## 📤 Run report
+- **Run type:** `routine · dispatch`
+- **PR:** #1437 (Essential Setup step 0 — server-type starter preset).
+- **⚑ Owner-decisions:** none
+- **⚑ Owner-manual-steps:** none (merge auto-deploys; no off-repo action)
+- **⚑ Self-initiated:** none (executed the documented owner-directed ▶ next plan
+  slice — setup-wizard restructure plan §5/§7 step 0)
+
+## Handoff — next dispatch
+- **DONE:** Essential Setup **PR 1 spine is now fully complete** (all 7 steps incl.
+  step 0). Step 0 ships the direct-apply starter-set pattern; `_SERVER_TYPES` is the
+  extension point (add a type = one tuple).
+- **▶ NEXT (setup lane):** **PR 2 — extras menu + "Check my setup"**
+  (`planning/setup-wizard-restructure-plan-2026-06-24.md` §7). Each existing config
+  surface (starboard, counters, security, image-mod, karma, AI, reaction roles,
+  giveaways) as a one-action extra reachable from "All done" / `/setup`, plus a single
+  read-only "Check my setup" health button folding in scan/readiness/diagnostics. Then
+  **PR 3** retires the dead/legacy sections + reworks the Advanced editor (Q-E).
+- **Other startable S1 lanes** (unchanged): Project Moon runtime PR 1 · botsite React
+  PR 2 · the visual-card-engine H3 incremental adoption (thin remaining surface — see
+  the previous-session note above; consider the rollout-tracker idea first).
+- **Bugs:** still blocked/gated for an unattended run — BUG-0009 (BTD6 release-order
+  data + plan-level), BUG-0011 (VPS repro), BUG-0019 #1 (owner design fork).
+- **Env:** CodeGraph up (v3.11.2); Grimp available; no arch warnings I introduced.

--- a/disbot/views/setup/essential_setup.py
+++ b/disbot/views/setup/essential_setup.py
@@ -19,15 +19,15 @@ Design (plan ``docs/planning/setup-wizard-restructure-plan-2026-06-24.md`` §5):
 
 This module is **additive** — the existing wizard (``views/setup/wizard.py``)
 is untouched and remains the full/advanced path; Essential Setup is the new
-quick spine.  Live steps: greet new members · set your moderators · block spam
-and bad links · choose a log channel · reward active members · set up a help
-desk (+ the closing summary).  Remaining follow-on on this same pattern: the
-server-type starter preset.
+quick spine.  Live steps: what kind of server is this (starter set) · greet new
+members · set your moderators · block spam and bad links · choose a log channel
+· reward active members · set up a help desk (+ the closing summary).
 """
 
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import discord
@@ -65,6 +65,7 @@ class EssentialFlow:
         self.skipped: list[str] = []
         # Step factories, in order. Add new steps here as they are built.
         self._steps: list[Callable[[EssentialFlow], _StepView]] = [
+            ServerTypeStep,
             GreetMembersStep,
             ModeratorsStep,
             BlockSpamStep,
@@ -195,6 +196,240 @@ class _StepView(BaseView):
             value,
             self.flow.author,
             actor_type="user",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Step 0 — What kind of server is this?  (server-type starter set)
+# ---------------------------------------------------------------------------
+#
+# The opening step makes the old metadata-only ``purpose`` section actually *do*
+# something: you pick what kind of server you run and we instantly switch on a
+# curated bundle of safe defaults for it (owner decision Q-C, 2026-06-24 —
+# "fastest, nothing irreversible").
+#
+# Design decision — the direct-apply path (the plan flagged "presets are
+# draft-only today; needs a design decision before building"): these starter
+# sets are **pure settings bundles** applied through the same audited
+# ``SettingsMutationPipeline`` every other spine step uses (``_set``).  They
+# deliberately do **not** reuse the draft-only
+# ``services.automation_templates.SERVER_PRESETS``, which bind channels and
+# create roles/rules and so need operator picks plus a Final Review — the wrong
+# shape for a one-tap, instant, fully-reversible starter.  Every value here is a
+# channel-independent boolean/scalar, so picking a type never creates or binds
+# anything and can be changed later from each feature's own panel.
+
+
+@dataclass(frozen=True)
+class _ServerTypePreset:
+    """One server-type starter set — a bundle of safe, reversible settings."""
+
+    key: str
+    label: str
+    emoji: str
+    blurb: str  # one-line plain summary of what it switches on
+    # (subsystem, setting-name, value), applied verbatim through ``_set``.
+    settings: tuple[tuple[str, str, object], ...]
+    # Key into ``_XP_RATES`` (resolved at apply time), or None to leave XP as-is.
+    xp_rate: str | None = None
+
+
+# The five starter sets.  Each uses only the channel-independent settings the
+# other spine steps already write (automod toggles, moderation dm-on-action, the
+# XP rate), so nothing here needs a channel/role pick or creates a resource.
+_SERVER_TYPES: tuple[_ServerTypePreset, ...] = (
+    _ServerTypePreset(
+        key="community",
+        label="Community",
+        emoji="💬",
+        blurb="balanced spam protection, members told why they're actioned, steady XP",
+        settings=(
+            ("automod", "enabled", True),
+            ("automod", "spam_enabled", True),
+            ("automod", "invites_enabled", True),
+            ("automod", "caps_enabled", False),
+            ("automod", "mentions_enabled", True),
+            ("moderation", "dm_on_action", True),
+        ),
+        xp_rate="standard",
+    ),
+    _ServerTypePreset(
+        key="gaming",
+        label="Gaming",
+        emoji="🎮",
+        blurb="spam & mass-ping protection (invite links allowed), faster XP",
+        settings=(
+            ("automod", "enabled", True),
+            ("automod", "spam_enabled", True),
+            ("automod", "invites_enabled", False),
+            ("automod", "caps_enabled", False),
+            ("automod", "mentions_enabled", True),
+            ("moderation", "dm_on_action", True),
+        ),
+        xp_rate="active",
+    ),
+    _ServerTypePreset(
+        key="support",
+        label="Support / Help desk",
+        emoji="🛟",
+        blurb="strict protection on everything, members told why, relaxed XP",
+        settings=(
+            ("automod", "enabled", True),
+            ("automod", "spam_enabled", True),
+            ("automod", "invites_enabled", True),
+            ("automod", "caps_enabled", True),
+            ("automod", "mentions_enabled", True),
+            ("moderation", "dm_on_action", True),
+        ),
+        xp_rate="relaxed",
+    ),
+    _ServerTypePreset(
+        key="creator",
+        label="Creator / Content",
+        emoji="🎨",
+        blurb="balanced spam protection, members told why, steady XP",
+        settings=(
+            ("automod", "enabled", True),
+            ("automod", "spam_enabled", True),
+            ("automod", "invites_enabled", True),
+            ("automod", "caps_enabled", False),
+            ("automod", "mentions_enabled", True),
+            ("moderation", "dm_on_action", True),
+        ),
+        xp_rate="standard",
+    ),
+    _ServerTypePreset(
+        key="exploring",
+        label="Just exploring",
+        emoji="🧭",
+        blurb="just basic spam protection — set everything else up yourself",
+        settings=(
+            ("automod", "enabled", True),
+            ("automod", "spam_enabled", True),
+        ),
+        xp_rate=None,
+    ),
+)
+
+
+def _server_type(key: str) -> _ServerTypePreset | None:
+    for preset in _SERVER_TYPES:
+        if preset.key == key:
+            return preset
+    return None
+
+
+class _ServerTypeSelect(discord.ui.Select):  # type: ignore[type-arg]
+    def __init__(self, current: str | None) -> None:
+        options = [
+            discord.SelectOption(
+                label=preset.label,
+                value=preset.key,
+                emoji=preset.emoji,
+                description=preset.blurb[:100],
+                default=preset.key == current,
+            )
+            for preset in _SERVER_TYPES
+        ]
+        super().__init__(
+            placeholder="What kind of server is this?",
+            options=options,
+            row=0,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: ServerTypeStep = self.view  # type: ignore[assignment]
+        view.server_type = self.values[0]
+        await interaction.response.edit_message(embed=view.render(), view=view)
+
+
+class _ServerTypeSaveButton(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            label="Save & continue",
+            emoji="✨",
+            style=discord.ButtonStyle.success,
+            row=3,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: ServerTypeStep = self.view  # type: ignore[assignment]
+        await view.apply(interaction)
+
+
+class ServerTypeStep(_StepView):
+    title = "What kind of server is this?"
+    skip_label = "Skip — set things up myself"
+
+    def __init__(self, flow: EssentialFlow) -> None:
+        self.server_type: str | None = None
+        super().__init__(flow)
+
+    def build_items(self) -> None:
+        self.add_item(_ServerTypeSelect(self.server_type))
+        self.add_item(_ServerTypeSaveButton())
+
+    def render(self) -> discord.Embed:
+        embed = discord.Embed(
+            title="✨ What kind of server is this?",
+            description=(
+                "Pick the closest match and we'll switch on a set of safe, "
+                "sensible defaults right away — you can change any of it later. "
+                "We won't create or delete anything; this just turns on a few "
+                "settings to get you started.\n\n"
+                "Then press **Save & continue**."
+            ),
+            color=discord.Color.blurple(),
+        )
+        if self.server_type:
+            preset = _server_type(self.server_type)
+            if preset is not None:
+                embed.add_field(
+                    name="Starter set",
+                    value=f"{preset.emoji} **{preset.label}** — {preset.blurb}",
+                    inline=False,
+                )
+        else:
+            embed.add_field(
+                name="Starter set",
+                value="_pick one above_",
+                inline=False,
+            )
+        embed.set_footer(text=self.flow.step_counter())
+        return embed
+
+    async def apply(self, interaction: discord.Interaction) -> None:
+        if self.server_type is None:
+            await interaction.response.send_message(
+                "Pick the kind of server you run first — or press Skip.",
+                ephemeral=True,
+            )
+            return
+        preset = _server_type(self.server_type)
+        if preset is None:  # defensive — the picker only offers known keys
+            await interaction.response.send_message(
+                "That server type isn't available — please pick another.",
+                ephemeral=True,
+            )
+            return
+        try:
+            for subsystem, name, value in preset.settings:
+                await self._set(subsystem, name, value)
+            if preset.xp_rate is not None:
+                _label, xp_min, xp_max, cooldown = _XP_RATES[preset.xp_rate]
+                await self._set("xp", "xp_min", xp_min)
+                await self._set("xp", "xp_max", xp_max)
+                await self._set("xp", "xp_cooldown", cooldown)
+        except Exception:
+            logger.exception("essential setup: server-type step apply failed")
+            await interaction.response.send_message(
+                "Something went wrong applying the starter set — please try again.",
+                ephemeral=True,
+            )
+            return
+        await self.complete(
+            interaction,
+            f"{preset.emoji} {preset.label} starter set on · {preset.blurb}",
         )
 
 

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -51,7 +51,7 @@
   members · help desk + summary), separate from and additive to the legacy `!setup` wizard. Each step
   applies immediately (direct lane) through an audited service; typing is optional everywhere (Q-0205).
   Shipped #1425/#1427/#1429/#1432/#1434 + polish #1435; decisions Q-0202/Q-0203/Q-0204/Q-0205. **Step 0
-  (server-type starter preset) shipped 2026-06-24** — `ServerTypeStep`, the new first step; five starter
+  (server-type starter preset) shipped 2026-06-24 (#1437)** — `ServerTypeStep`, the new first step; five starter
   sets applied as pure direct-apply settings bundles (`_SERVER_TYPES`, automod/moderation/XP-rate),
   instant + reversible, no resource creation (the draft-only `SERVER_PRESETS` deliberately not reused).
   **▶ Next:** PR 2 (extras menu + "Check my setup") · PR 3 (retire dead/legacy sections + rework the

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -45,14 +45,17 @@
   broadcast table. [design](../planning/casino-poker-design-2026-06-22.md).
 
 **▶ Next startable (one of):**
-- **Essential Setup spine (`!quicksetup`) — PR 1 COMPLETE + polished (owner-directed, 2026-06-24).** A
-  new plain-language, button/dropdown/multi-select-only quick-setup flow (6 steps: greet · moderators ·
-  block spam · choose a log channel · reward active members · help desk + summary), separate from and
-  additive to the legacy `!setup` wizard. Each step applies immediately (direct lane) through an audited
-  service; typing is optional everywhere (Q-0205). Shipped #1425/#1427/#1429/#1432/#1434 + polish #1435;
-  decisions Q-0202/Q-0203/Q-0204/Q-0205. **▶ Next:** step 0 (server-type starter preset — needs a
-  direct-apply preset path, verify source first) · PR 2 (extras menu + "Check my setup") · PR 3 (retire
-  dead/legacy sections + rework the Advanced editor). Tracker:
+- **Essential Setup spine (`!quicksetup`) — PR 1 COMPLETE + polished, incl. step 0 (owner-directed,
+  2026-06-24).** A new plain-language, button/dropdown/multi-select-only quick-setup flow (**7 steps**:
+  what kind of server is this · greet · moderators · block spam · choose a log channel · reward active
+  members · help desk + summary), separate from and additive to the legacy `!setup` wizard. Each step
+  applies immediately (direct lane) through an audited service; typing is optional everywhere (Q-0205).
+  Shipped #1425/#1427/#1429/#1432/#1434 + polish #1435; decisions Q-0202/Q-0203/Q-0204/Q-0205. **Step 0
+  (server-type starter preset) shipped 2026-06-24** — `ServerTypeStep`, the new first step; five starter
+  sets applied as pure direct-apply settings bundles (`_SERVER_TYPES`, automod/moderation/XP-rate),
+  instant + reversible, no resource creation (the draft-only `SERVER_PRESETS` deliberately not reused).
+  **▶ Next:** PR 2 (extras menu + "Check my setup") · PR 3 (retire dead/legacy sections + rework the
+  Advanced editor). Tracker:
   [`planning/setup-wizard-restructure-plan-2026-06-24.md`](../planning/setup-wizard-restructure-plan-2026-06-24.md).
 - **✅ Consolidation / discoverability audit — COMPLETE (owner-directed, 2026-06-23).** All five goals
   shipped and CI-guarded where possible. Staging brief + per-cog rubric:

--- a/docs/owner/claims/claude-funny-franklin-ghmwpe.md
+++ b/docs/owner/claims/claude-funny-franklin-ghmwpe.md
@@ -1,0 +1,1 @@
+claude/funny-franklin-ghmwpe · setup spine step 0 (server-type starter preset, direct-apply) · disbot/views/setup/essential_setup.py + tests/unit/views/setup/test_essential_setup.py · 2026-06-24

--- a/docs/owner/claims/claude-funny-franklin-ghmwpe.md
+++ b/docs/owner/claims/claude-funny-franklin-ghmwpe.md
@@ -1,1 +1,0 @@
-claude/funny-franklin-ghmwpe · setup spine step 0 (server-type starter preset, direct-apply) · disbot/views/setup/essential_setup.py + tests/unit/views/setup/test_essential_setup.py · 2026-06-24

--- a/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
+++ b/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
@@ -8,13 +8,13 @@
 > jargon, quick with buttons/dropdowns, each step is one complete action that actually completes a setup
 > step properly."* This plan answers that directly. Plan-first: greenlight before build.
 >
-> **▶ Build progress:** **PR 1 (the jargon-free essentials spine) COMPLETE + polished.** Six live steps
-> (greet · moderators · block spam · choose a log channel · reward active members · help desk) + the
-> All-done summary, opened by `!quicksetup` / `/quicksetup`; shipped across #1425/#1427/#1429/#1432/#1434
-> and given a consistency + optional-typing polish pass (#1435, Q-0205). **Remaining:** step 0
-> (server-type starter preset — needs a direct-apply preset path; verify against source first), then
-> **PR 2** = extras menu + "Check my setup", **PR 3** = retire dead/legacy sections + rework the Advanced
-> editor (Q-E).
+> **▶ Build progress:** **PR 1 (the jargon-free essentials spine) COMPLETE + polished, incl. step 0.**
+> Seven live steps (**what kind of server is this** · greet · moderators · block spam · choose a log
+> channel · reward active members · help desk) + the All-done summary, opened by `!quicksetup` /
+> `/quicksetup`; shipped across #1425/#1427/#1429/#1432/#1434, polished (#1435, Q-0205), and the
+> **server-type starter preset (step 0) shipped 2026-06-24** (direct-apply path resolved — see §5/§7
+> below). **Remaining:** **PR 2** = extras menu + "Check my setup", **PR 3** = retire dead/legacy
+> sections + rework the Advanced editor (Q-E).
 >
 > **Sim:** [`tools/sim/setup_wizard_sim.py`](../../tools/sim/setup_wizard_sim.py) (runnable) —
 > models a non-technical owner walking the flow. Current standard-depth flow scores **~4% finish**
@@ -103,8 +103,13 @@ The fix is not more sections — it is a **structure** built from four laws.
 
 **Spine — the guided essentials (each applies immediately, direct lane):**
 
-0. **What kind of server is this?** — Community · Gaming · Support · Creator · Just exploring. Applies a
-   matching **starter set** of safe defaults right away (this is `purpose` made actionable + `preset`).
+0. **What kind of server is this?** *(SHIPPED 2026-06-24)* — Community · Gaming · Support · Creator · Just
+   exploring. Applies a matching **starter set** of safe defaults right away (this is `purpose` made
+   actionable + `preset`). **Direct-apply path resolved:** each starter set is a **pure settings bundle**
+   (channel-independent automod toggles + `moderation.dm_on_action` + an XP rate) applied through the
+   same audited `SettingsMutationPipeline` (`_set`) as every other spine step — *not* the draft-only
+   `automation_templates.SERVER_PRESETS` (those bind channels / create roles+rules, needing operator
+   picks + Final Review). So picking a type is instant and fully reversible; nothing is created or bound.
 1. **Greet new members** *(NEW)* — turn on a welcome message; pick **or auto-create** the channel;
    optionally give newcomers a role. (`welcome` + entry role.)
 2. **Who are your moderators?** — pick the role that can warn/remove people; set safe defaults
@@ -200,9 +205,12 @@ decision with architectural weight → called out as open question Q-A below.
     direct-apply role-threshold service (the one genuine gap)" was wrong — `role_automation.set_xp_threshold`
     / `set_time_threshold` already ARE the audited direct-apply paths, and
     `RoleLifecycleService.apply(operation="create")` does the role auto-create. No new service was needed.
-  - **Server-type starter preset** (step 0) — **needs a direct-apply preset path** (presets are
-    draft-only today); design decision before building. Must follow the **optional-typing principle**
-    (Q-0205) for any named resource it creates.
+  - **Server-type starter preset** (step 0) *(SHIPPED 2026-06-24)* — `ServerTypeStep`, the new **first**
+    step. The direct-apply path the plan flagged is resolved by **not** reusing the draft-only
+    `SERVER_PRESETS`: the five starter sets are pure settings bundles (`_SERVER_TYPES` in
+    `essential_setup.py`) applied verbatim through the audited `_set` (settings pipeline), so each pick
+    is instant + reversible and creates/binds nothing. No named resource is created, so the Q-0205
+    optional-typing principle is satisfied trivially (nothing to name).
 - **PR 1 polish pass (SHIPPED 2026-06-24, `#1435`, owner directives Q-0205):** spine consistency + the
   optional-typing principle — block-spam → multi-select (the preferred "pick which" idiom), every step's
   primary button unified to **"Save & continue"** on a consistent row, the skip-recap summary bug fixed

--- a/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
+++ b/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
@@ -12,7 +12,7 @@
 > Seven live steps (**what kind of server is this** · greet · moderators · block spam · choose a log
 > channel · reward active members · help desk) + the All-done summary, opened by `!quicksetup` /
 > `/quicksetup`; shipped across #1425/#1427/#1429/#1432/#1434, polished (#1435, Q-0205), and the
-> **server-type starter preset (step 0) shipped 2026-06-24** (direct-apply path resolved — see §5/§7
+> **server-type starter preset (step 0) shipped 2026-06-24 (#1437)** (direct-apply path resolved — see §5/§7
 > below). **Remaining:** **PR 2** = extras menu + "Check my setup", **PR 3** = retire dead/legacy
 > sections + rework the Advanced editor (Q-E).
 >
@@ -103,7 +103,7 @@ The fix is not more sections — it is a **structure** built from four laws.
 
 **Spine — the guided essentials (each applies immediately, direct lane):**
 
-0. **What kind of server is this?** *(SHIPPED 2026-06-24)* — Community · Gaming · Support · Creator · Just
+0. **What kind of server is this?** *(SHIPPED 2026-06-24, #1437)* — Community · Gaming · Support · Creator · Just
    exploring. Applies a matching **starter set** of safe defaults right away (this is `purpose` made
    actionable + `preset`). **Direct-apply path resolved:** each starter set is a **pure settings bundle**
    (channel-independent automod toggles + `moderation.dm_on_action` + an XP rate) applied through the
@@ -205,7 +205,7 @@ decision with architectural weight → called out as open question Q-A below.
     direct-apply role-threshold service (the one genuine gap)" was wrong — `role_automation.set_xp_threshold`
     / `set_time_threshold` already ARE the audited direct-apply paths, and
     `RoleLifecycleService.apply(operation="create")` does the role auto-create. No new service was needed.
-  - **Server-type starter preset** (step 0) *(SHIPPED 2026-06-24)* — `ServerTypeStep`, the new **first**
+  - **Server-type starter preset** (step 0) *(SHIPPED 2026-06-24, #1437)* — `ServerTypeStep`, the new **first**
     step. The direct-apply path the plan flagged is resolved by **not** reusing the draft-only
     `SERVER_PRESETS`: the five starter sets are pure settings bundles (`_SERVER_TYPES` in
     `essential_setup.py`) applied verbatim through the audited `_set` (settings pipeline), so each pick

--- a/tests/unit/views/setup/test_essential_setup.py
+++ b/tests/unit/views/setup/test_essential_setup.py
@@ -100,9 +100,10 @@ def role_service():
 
 def test_flow_counter_and_navigation():
     flow = es.EssentialFlow(_member(), _guild())
-    assert flow.total == 6
-    assert flow.step_counter() == "Step 1 of 6"
+    assert flow.total == 7
+    assert flow.step_counter() == "Step 1 of 7"
     expected = [
+        es.ServerTypeStep,
         es.GreetMembersStep,
         es.ModeratorsStep,
         es.BlockSpamStep,
@@ -111,7 +112,7 @@ def test_flow_counter_and_navigation():
         es.HelpDeskStep,
     ]
     for i, cls in enumerate(expected):
-        assert flow.step_counter() == f"Step {i + 1} of 6"
+        assert flow.step_counter() == f"Step {i + 1} of 7"
         assert isinstance(flow.current_view(), cls)
         flow.advance()
 
@@ -124,27 +125,125 @@ def test_flow_counter_and_navigation():
 
 def test_first_step_has_no_back_button():
     flow = es.EssentialFlow(_member(), _guild())
-    step = es.GreetMembersStep(flow)
+    step = es.ServerTypeStep(flow)
     assert not any(isinstance(c, es._BackButton) for c in step.children)
     # the second step does get a Back button
     flow.advance()
-    step2 = es.ModeratorsStep(flow)
+    step2 = es.GreetMembersStep(flow)
     assert any(isinstance(c, es._BackButton) for c in step2.children)
 
 
 @pytest.mark.asyncio
 async def test_skip_records_step_for_summary():
     flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 1
     step = es.GreetMembersStep(flow)
 
     await step.skip(_interaction())
 
     # Skipping records the step so the summary's "Skipped" recap can list it.
     assert flow.skipped == ["Greet new members"]
-    assert flow.index == 1
+    assert flow.index == 2
     summary = es.EssentialSummaryView(flow).render()
     blob = (summary.description or "") + " ".join(f.value for f in summary.fields)
     assert "Greet new members" in blob
+
+
+# ---------------------------------------------------------------------------
+# Server type (step 0)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_server_type_requires_a_pick(pipeline):
+    flow = es.EssentialFlow(_member(), _guild())
+    step = es.ServerTypeStep(flow)
+    interaction = _interaction()
+
+    await step.apply(interaction)
+
+    pipeline.set_value.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+    assert flow.index == 0  # did not advance
+
+
+@pytest.mark.asyncio
+async def test_server_type_community_applies_bundle_and_xp_rate(pipeline):
+    flow = es.EssentialFlow(_member(), _guild())
+    step = es.ServerTypeStep(flow)
+    step.server_type = "community"
+
+    await step.apply(_interaction())
+
+    settings = {
+        (c.args[1], c.args[2]): c.args[3] for c in pipeline.set_value.await_args_list
+    }
+    # The curated automod + moderation bundle is applied verbatim.
+    assert settings[("automod", "enabled")] is True
+    assert settings[("automod", "caps_enabled")] is False  # community: caps allowed
+    assert settings[("moderation", "dm_on_action")] is True
+    # The "standard" XP rate triplet is applied (resolved from _XP_RATES).
+    rate = es._XP_RATES["standard"]
+    assert settings[("xp", "xp_min")] == rate[1]
+    assert settings[("xp", "xp_max")] == rate[2]
+    assert settings[("xp", "xp_cooldown")] == rate[3]
+    assert flow.index == 1  # advanced
+    assert flow.applied and "Community" in flow.applied[0]
+
+
+@pytest.mark.asyncio
+async def test_server_type_exploring_is_minimal_and_skips_xp(pipeline):
+    flow = es.EssentialFlow(_member(), _guild())
+    step = es.ServerTypeStep(flow)
+    step.server_type = "exploring"
+
+    await step.apply(_interaction())
+
+    settings = {
+        (c.args[1], c.args[2]): c.args[3] for c in pipeline.set_value.await_args_list
+    }
+    # Exploring = just basic spam protection; XP left untouched (xp_rate=None).
+    assert settings == {
+        ("automod", "enabled"): True,
+        ("automod", "spam_enabled"): True,
+    }
+    assert not any(c.args[1] == "xp" for c in pipeline.set_value.await_args_list)
+    assert flow.index == 1
+
+
+@pytest.mark.asyncio
+async def test_server_type_gaming_allows_invites(pipeline):
+    flow = es.EssentialFlow(_member(), _guild())
+    step = es.ServerTypeStep(flow)
+    step.server_type = "gaming"
+
+    await step.apply(_interaction())
+
+    settings = {
+        (c.args[1], c.args[2]): c.args[3] for c in pipeline.set_value.await_args_list
+    }
+    # Gaming servers share invite links → that filter is off; mass-ping on.
+    assert settings[("automod", "invites_enabled")] is False
+    assert settings[("automod", "mentions_enabled")] is True
+    assert flow.index == 1
+
+
+def test_every_server_type_uses_only_known_settings():
+    # Step 0 must stay channel-independent: only the proven settings the other
+    # spine steps write, and an xp_rate that resolves in _XP_RATES.
+    allowed = {
+        ("automod", "enabled"),
+        ("automod", "spam_enabled"),
+        ("automod", "invites_enabled"),
+        ("automod", "caps_enabled"),
+        ("automod", "mentions_enabled"),
+        ("moderation", "dm_on_action"),
+    }
+    for preset in es._SERVER_TYPES:
+        for subsystem, name, _value in preset.settings:
+            assert (subsystem, name) in allowed, f"{preset.key}: {subsystem}.{name}"
+        if preset.xp_rate is not None:
+            assert preset.xp_rate in es._XP_RATES
 
 
 # ---------------------------------------------------------------------------
@@ -155,6 +254,7 @@ async def test_skip_records_step_for_summary():
 @pytest.mark.asyncio
 async def test_greet_requires_channel_before_applying(pipeline):
     flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 1
     step = es.GreetMembersStep(flow)
     interaction = _interaction()
 
@@ -163,12 +263,13 @@ async def test_greet_requires_channel_before_applying(pipeline):
     pipeline.set_value.assert_not_awaited()
     interaction.response.send_message.assert_awaited_once()
     assert "channel" in interaction.response.send_message.await_args.args[0].lower()
-    assert flow.index == 0  # did not advance
+    assert flow.index == 1  # did not advance
 
 
 @pytest.mark.asyncio
 async def test_greet_applies_welcome_settings_and_advances(pipeline):
     flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 1
     step = es.GreetMembersStep(flow)
     step.channel_id = 555
     step.entry_role_id = 777
@@ -182,13 +283,14 @@ async def test_greet_applies_welcome_settings_and_advances(pipeline):
     names = {c.args[2] for c in pipeline.set_value.await_args_list}
     assert subsystems == {"welcome"}
     assert {"enabled", "join_enabled", "channel", "entry_role"} == names
-    assert flow.index == 1  # advanced
+    assert flow.index == 2  # advanced
     assert flow.applied and "555" in flow.applied[0]
 
 
 @pytest.mark.asyncio
 async def test_greet_without_role_writes_three_settings(pipeline):
     flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 1
     step = es.GreetMembersStep(flow)
     step.channel_id = 555
     await step.apply(_interaction())
@@ -203,16 +305,18 @@ async def test_greet_without_role_writes_three_settings(pipeline):
 @pytest.mark.asyncio
 async def test_moderators_requires_role(pipeline):
     flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 2
     step = es.ModeratorsStep(flow)
     interaction = _interaction()
     await step.apply(interaction)
     pipeline.set_value.assert_not_awaited()
-    assert flow.index == 0
+    assert flow.index == 2
 
 
 @pytest.mark.asyncio
 async def test_moderators_applies_role_and_dm(pipeline):
     flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 2
     step = es.ModeratorsStep(flow)
     step.mod_role_id = 4242
     await step.apply(_interaction())
@@ -220,7 +324,7 @@ async def test_moderators_applies_role_and_dm(pipeline):
     calls = {(c.args[1], c.args[2]) for c in pipeline.set_value.await_args_list}
     assert ("moderation", "moderator_role") in calls
     assert ("moderation", "dm_on_action") in calls
-    assert flow.index == 1
+    assert flow.index == 3
 
 
 # ---------------------------------------------------------------------------
@@ -231,7 +335,7 @@ async def test_moderators_applies_role_and_dm(pipeline):
 @pytest.mark.asyncio
 async def test_block_spam_applies_automod_with_all_filters(pipeline):
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 2
+    flow.index = 3
     step = es.BlockSpamStep(flow)
     await step.apply(_interaction())
     # enabled + 4 filters = 5 immediate writes, all to automod
@@ -246,13 +350,13 @@ async def test_block_spam_applies_automod_with_all_filters(pipeline):
         "caps_enabled",
         "mentions_enabled",
     }
-    assert flow.index == 3
+    assert flow.index == 4
 
 
 @pytest.mark.asyncio
 async def test_block_spam_respects_toggled_off_filter(pipeline):
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 2
+    flow.index = 3
     step = es.BlockSpamStep(flow)
     step.filters.discard("caps_enabled")  # untick one in the multi-select
     await step.apply(_interaction())
@@ -280,7 +384,7 @@ async def test_log_channel_defaults_create_both_and_bind(
     channel_service,
 ):
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 3
+    flow.index = 4
     step = es.LogChannelStep(flow)  # defaults: members + roles on, messages off
     # No channels picked → auto-create both (mod first, then activity).
     channel_service.create_channels.side_effect = [_created(111), _created(222)]
@@ -306,7 +410,7 @@ async def test_log_channel_defaults_create_both_and_bind(
         c.args[3] == BindingKind.CHANNEL
         for c in binding_pipeline.set_binding.await_args_list
     )
-    assert flow.index == 4
+    assert flow.index == 5
 
 
 @pytest.mark.asyncio
@@ -316,7 +420,7 @@ async def test_log_channel_picked_channels_bind_without_create(
     channel_service,
 ):
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 3
+    flow.index = 4
     step = es.LogChannelStep(flow)
     step.mod_channel_id = 700
     step.activity_channel_id = 800
@@ -326,7 +430,7 @@ async def test_log_channel_picked_channels_bind_without_create(
     channel_service.create_channels.assert_not_awaited()
     binds = {c.args[2]: c.args[4] for c in binding_pipeline.set_binding.await_args_list}
     assert binds == {"mod_channel": 700, "events_channel": 800}
-    assert flow.index == 4
+    assert flow.index == 5
 
 
 @pytest.mark.asyncio
@@ -336,7 +440,7 @@ async def test_log_channel_no_activity_logs_moderation_only(
     channel_service,
 ):
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 3
+    flow.index = 4
     step = es.LogChannelStep(flow)
     step.activity = set()  # operator unticked every activity type
     step.mod_channel_id = 700
@@ -355,7 +459,7 @@ async def test_log_channel_no_activity_logs_moderation_only(
     assert settings[("logging", "members_enabled")] is False
     assert settings[("logging", "roles_enabled")] is False
     assert settings[("logging", "messages_enabled")] is False
-    assert flow.index == 4
+    assert flow.index == 5
 
 
 @pytest.mark.asyncio
@@ -365,7 +469,7 @@ async def test_log_channel_create_failure_blocks(
     channel_service,
 ):
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 3
+    flow.index = 4
     step = es.LogChannelStep(flow)  # defaults; no channels picked → tries mod create
     channel_service.create_channels.return_value = SimpleNamespace(
         applied=(),
@@ -380,7 +484,7 @@ async def test_log_channel_create_failure_blocks(
     binding_pipeline.set_binding.assert_not_awaited()
     pipeline.set_value.assert_not_awaited()
     interaction.response.send_message.assert_awaited_once()
-    assert flow.index == 3
+    assert flow.index == 4
 
 
 @pytest.mark.asyncio
@@ -390,7 +494,7 @@ async def test_log_channel_custom_names_used_when_creating(
     channel_service,
 ):
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 3
+    flow.index = 4
     step = es.LogChannelStep(flow)
     # Optional typing: custom names for both auto-created channels.
     step.mod_channel_name = "staff-log"
@@ -401,7 +505,7 @@ async def test_log_channel_custom_names_used_when_creating(
 
     names = [c.args[1][0] for c in channel_service.create_channels.await_args_list]
     assert names == ["staff-log", "member-log"]
-    assert flow.index == 4
+    assert flow.index == 5
 
 
 # ---------------------------------------------------------------------------
@@ -414,7 +518,7 @@ async def test_reward_no_rewards_applies_rate_only(
     pipeline, role_automation, role_service
 ):
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 4
+    flow.index = 5
     step = es.RewardActivityStep(flow)
     step.xp_rate = "active"  # rewards stay empty
 
@@ -425,26 +529,26 @@ async def test_reward_no_rewards_applies_rate_only(
     assert {("xp", "xp_min"), ("xp", "xp_max"), ("xp", "xp_cooldown")} <= names
     role_automation.set_xp_threshold.assert_not_awaited()
     role_service.apply.assert_not_awaited()
-    assert flow.index == 5
+    assert flow.index == 6
 
 
 @pytest.mark.asyncio
 async def test_reward_keep_rate_no_rewards_is_noop_advance(pipeline, role_automation):
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 4
+    flow.index = 5
     step = es.RewardActivityStep(flow)  # xp_rate="keep", rewards empty
 
     await step.on_next(_interaction())
 
     pipeline.set_value.assert_not_awaited()
     role_automation.set_xp_threshold.assert_not_awaited()
-    assert flow.index == 5
+    assert flow.index == 6
 
 
 @pytest.mark.asyncio
 async def test_reward_next_with_rewards_enters_role_phase(pipeline):
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 4
+    flow.index = 5
     step = es.RewardActivityStep(flow)
     step.rewards = {"level"}
 
@@ -453,7 +557,7 @@ async def test_reward_next_with_rewards_enters_role_phase(pipeline):
     # Moves to screen 2 without applying or advancing.
     assert step.phase == "roles"
     pipeline.set_value.assert_not_awaited()
-    assert flow.index == 4
+    assert flow.index == 5
 
 
 @pytest.mark.asyncio
@@ -463,7 +567,7 @@ async def test_reward_recommended_creates_role_and_sets_level(
     role_service,
 ):
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 4
+    flow.index = 5
     step = es.RewardActivityStep(flow)
     step.rewards = {"level"}
     step.phase = "roles"
@@ -485,7 +589,7 @@ async def test_reward_recommended_creates_role_and_sets_level(
     assert kwargs["guild_id"] == 1
     assert kwargs["actor_id"] == 99
     role_automation.set_time_threshold.assert_not_awaited()
-    assert flow.index == 5
+    assert flow.index == 6
 
 
 @pytest.mark.asyncio
@@ -495,7 +599,7 @@ async def test_reward_existing_role_both_triggers(
     role_service,
 ):
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 4
+    flow.index = 5
     step = es.RewardActivityStep(flow)
     step.rewards = {"level", "time"}
     step.phase = "roles"
@@ -510,13 +614,13 @@ async def test_reward_existing_role_both_triggers(
     assert role_automation.set_xp_threshold.await_args.kwargs["role_id"] == 555
     assert role_automation.set_time_threshold.await_args.kwargs["role_id"] == 555
     assert role_automation.set_time_threshold.await_args.kwargs["days"] == 30
-    assert flow.index == 5
+    assert flow.index == 6
 
 
 @pytest.mark.asyncio
 async def test_reward_existing_requires_a_pick(pipeline, role_automation, role_service):
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 4
+    flow.index = 5
     step = es.RewardActivityStep(flow)
     step.rewards = {"level"}
     step.phase = "roles"
@@ -528,7 +632,7 @@ async def test_reward_existing_requires_a_pick(pipeline, role_automation, role_s
     role_service.apply.assert_not_awaited()
     role_automation.set_xp_threshold.assert_not_awaited()
     interaction.response.send_message.assert_awaited_once()
-    assert flow.index == 4  # did not advance
+    assert flow.index == 5  # did not advance
 
 
 @pytest.mark.asyncio
@@ -538,7 +642,7 @@ async def test_reward_role_create_failure_blocks(
     role_service,
 ):
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 4
+    flow.index = 5
     step = es.RewardActivityStep(flow)
     step.rewards = {"level"}
     step.phase = "roles"
@@ -555,7 +659,7 @@ async def test_reward_role_create_failure_blocks(
     role_automation.set_xp_threshold.assert_not_awaited()
     pipeline.set_value.assert_not_awaited()
     interaction.response.send_message.assert_awaited_once()
-    assert flow.index == 4
+    assert flow.index == 5
 
 
 @pytest.mark.asyncio
@@ -565,7 +669,7 @@ async def test_reward_create_uses_custom_role_name(
     role_service,
 ):
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 4
+    flow.index = 5
     step = es.RewardActivityStep(flow)
     step.rewards = {"level"}
     step.phase = "roles"
@@ -583,7 +687,7 @@ async def test_reward_create_uses_custom_role_name(
     assert request.name == "Champion"
     assert role_automation.set_xp_threshold.await_args.kwargs["role_name"] == "Champion"
     assert role_automation.set_xp_threshold.await_args.kwargs["role_id"] == 909
-    assert flow.index == 5
+    assert flow.index == 6
 
 
 # ---------------------------------------------------------------------------
@@ -594,20 +698,20 @@ async def test_reward_create_uses_custom_role_name(
 @pytest.mark.asyncio
 async def test_help_desk_requires_staff_role():
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 5
+    flow.index = 6
     step = es.HelpDeskStep(flow)
     interaction = _interaction()
     with patch("services.ticket_mutation.update_config", new=AsyncMock()) as upd:
         await step.apply(interaction)
     upd.assert_not_awaited()
-    assert flow.index == 5
+    assert flow.index == 6
     assert "staff" in interaction.response.send_message.await_args.args[0].lower()
 
 
 @pytest.mark.asyncio
 async def test_help_desk_enables_tickets_and_advances():
     flow = es.EssentialFlow(_member(), _guild())
-    flow.index = 5
+    flow.index = 6
     step = es.HelpDeskStep(flow)
     step.staff_role_id = 321
     step.log_channel_id = 654
@@ -618,7 +722,7 @@ async def test_help_desk_enables_tickets_and_advances():
     assert kwargs["enabled"] is True
     assert kwargs["staff_role_id"] == 321
     assert kwargs["log_channel_id"] == 654
-    assert flow.index == 6
+    assert flow.index == 7
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Adds the opening **"What kind of server is this?"** step (`ServerTypeStep`) to the Essential Setup spine — the owner-directed **step 0** follow-on from the [setup-wizard restructure plan](https://github.com/menno420/superbot/blob/main/docs/planning/setup-wizard-restructure-plan-2026-06-24.md) §5/§7 (PR 1 tail).

Five server-type starter sets — **Community · Gaming · Support · Creator · Just exploring** — each a curated bundle of safe, reversible defaults applied the instant you pick one (owner decision **Q-C**: *"fastest, nothing irreversible"*). The flow is now 7 steps, with this as the new first step.

## The design decision the plan flagged
The plan noted *"presets are draft-only today; needs a direct-apply path; design decision before building."* Resolved by **not** reusing `automation_templates.SERVER_PRESETS` — those bind channels and create roles/rules, so they need operator picks + a Final Review (the wrong shape for a one-tap instant starter). Instead, each starter set is a **pure settings bundle** (`_SERVER_TYPES`) applied verbatim through the same audited `SettingsMutationPipeline` (`_set`) every other spine step uses. Every value is a channel-independent automod toggle / `moderation.dm_on_action` / XP rate, so picking a type **creates and binds nothing** and is fully reversible from each feature's own panel later. No named resource is created → the Q-0205 optional-typing principle is satisfied trivially.

## Changes
- `disbot/views/setup/essential_setup.py` — `ServerTypeStep` + `_ServerTypePreset` + `_SERVER_TYPES` + `_server_type`; inserted first in `EssentialFlow._steps`.
- `tests/unit/views/setup/test_essential_setup.py` — +4 step-0 tests (requires-a-pick · community bundle + XP rate · exploring minimal/skips XP · gaming allows invites · known-settings invariant); existing step tests shifted for the new index ordering.
- Plan + S1 sector ledger de-staled.

## Verification
- `python3.10 scripts/check_quality.py --full` → **12,488 passed**, 48 skipped, 2 xfailed; mypy + lint clean.
- `python3.10 scripts/check_architecture.py --mode strict` → **0 errors**.
- `python3.10 scripts/check_setup_copy.py` → new file adds **0 jargon findings** (ratchet test green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017e9ARt8cnPovHxaNBLehgK

---
_Generated by [Claude Code](https://claude.ai/code/session_017e9ARt8cnPovHxaNBLehgK)_