### PR TITLE
Fix Essential Setup logging step: defer before slow channel-creation work

### DIFF
--- a/.sessions/2026-06-24-essential-setup-logging-defer.md
+++ b/.sessions/2026-06-24-essential-setup-logging-defer.md
@@ -1,6 +1,7 @@
 # Session — 2026-06-24 · Essential Setup logging step: defer before slow work
 
-> **Status:** `in-progress` — fixing the live logging-step bug in the new setup wizard.
+> **Status:** `complete` — root-cause fix for the live logging-step bug in the new setup wizard.
+> CI mirror green (12495 passed); arch 0 new; PR #1439.
 
 **Trigger:** Owner screen recording — the new setup wizard's logging step "is kinda broken and
 just keeps building new logging channels and saying that the step failed."
@@ -12,20 +13,73 @@ calls + seven audited settings/binding writes before its only `interaction.respo
 final navigation `edit_message` inside `complete()`). That work runs past Discord's **3-second
 interaction-token deadline**, so the final edit 404s → the Discord client shows **"This interaction
 failed"** — *after* the channels were already created. Each retry creates another `#mod-log` /
-`#server-log` pair (collision-safe names → `-2`, `-3`, …). Both reported symptoms, one cause.
+`#server-log` pair (collision-safe names → `-2`, `-3`, …). **Two symptoms, one cause.**
 
 The other six spine steps only do a few fast DB writes, so they squeak under the deadline — which is
-why only logging is broken. The codebase already has the prescribed remedy
-(`core.runtime.interaction_helpers.safe_defer/safe_edit/safe_followup`, whose docstring names this
-exact "Interaction Failed" symptom); Essential Setup just never adopted it.
+why only logging is broken. The codebase already ships the prescribed remedy
+(`core.runtime.interaction_helpers.safe_defer/safe_edit/safe_followup`, whose docstring literally
+names this "Interaction Failed" symptom, CRIT-2); Essential Setup just never adopted it, while the
+other slow setup views (`wizard.py`, `final_review.py`) all do.
 
-## Fix (planned)
+## What changed (`disbot/views/setup/essential_setup.py` + its test)
 
-- `LogChannelStep.apply` — `safe_defer` up front; errors via `safe_followup`.
-- `RewardActivityStep` — same latent bug (creates a role); defer its write/create paths too.
-- `_StepView._show_current` → `safe_edit` (defer-tolerant nav foundation for all steps).
-- Regression test: pin that the log step defers *before* creating channels.
+- **`LogChannelStep.apply`** — `safe_defer` up front (ACK within 3 s); the two error paths
+  (`_create_channel`, the apply `except`) route through `safe_followup`.
+- **`RewardActivityStep`** — same latent bug (it creates a role): `apply` and the no-rewards
+  `on_next` branch defer; its three error paths + the phase-swap nav route through the safe helpers.
+- **`_StepView._show_current`** → `safe_edit`, so navigation edits the wizard message in place
+  whether or not the step deferred (a defer-tolerant foundation every step inherits).
+- **Tests** — the interaction double is now defer-stateful (`is_done()` flips after ack); 3 asserts
+  updated to the followup route; **new regression test** `test_log_channel_defers_before_slow_work`
+  pins that the step defers *before* any channel is created. 39/39 in the file; 698 across the setup
+  surface; full `check_quality --full` green.
+
+No copy/schema changes — the setting/binding names were already valid; the only defect was the
+missing acknowledgement.
+
+## 💡 Session idea (Q-0089)
+
+**A static guard for "I/O before defer" in interaction callbacks.** This whole bug is the CRIT-2
+class `interaction_helpers.py` was built for ("Adoption across cogs lands in F5") — but nothing
+*enforces* adoption, so a brand-new flow shipped without it and reached production. A disposable
+Q-0105 AST checker (sibling of `check_setup_copy.py`) could flag any `async def callback`/`apply`
+that `await`s a known-slow seam (`create_channels`, `set_value`, `set_binding`, `RoleLifecycleService`,
+`ChannelLifecycleService`, `*MutationPipeline`) **before** any `safe_defer` / `response.defer` /
+`response.send_message`. Warn-first, scoped to `views/` + `cogs/`. That converts "remember to defer"
+from tribal knowledge into a ratchet — and would have caught this PR's bug at author time.
+(Dedup-checked `docs/ideas/`: no existing defer/interaction-deadline-lint idea — grep empty.)
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous `.sessions/` log: the **setup-copy jargon guard** (PR #1420). Did well: built the
+Q-A-independent slice and *measured* the real jargon baseline (207 vs the modelled 44) — exactly the
+"leave the next session better-equipped" discipline. What the *arc* missed: the Essential Setup spine
+was **cut over to the primary `!setup` / `/setup` the same day (#1435 + 63b83e2)**, and we guarded its
+*copy* (the jargon ratchet) but had no guard — and apparently no live interaction-latency walk — for
+the *3-second-deadline behavioural class* that actually broke in front of the owner. **System
+improvement (this session acts on it via the Q-0089 idea):** when a new interactive flow is promoted
+to *primary*, a "slow-callback defer audit" (lint or a one-time live walk) should be part of the
+cutover checklist, not discovered by a screen recording. We had a copy ratchet on the spine; the
+missing peer is a *deferral* ratchet.
+
+## 📋 Doc audit (Q-0104)
+
+`check_current_state_ledger.py --strict` green (in sync); `check_docs --strict` + `check_consistency`
+green. No owner *decision* was made (owner-directed bug fix, no new Q). No `current-state.md` ledger
+entry needed yet — the ledger checker keys off **merged** PRs, so the next reconciliation pass picks
+up #1439 (same convention the jargon-guard session used for #1420). Claim file deleted at close.
+
+## Context delta
+
+- **Surprise:** the fix the codebase *already had* (`interaction_helpers`) was simply never wired
+  into the new wizard — the bug wasn't a missing capability, it was un-adopted infrastructure. That
+  is the strongest argument for the Q-0089 *enforcement* idea: the remedy exists; only adoption was
+  optional.
+- **For next session:** if the owner wants belt-and-suspenders, the remaining fast spine steps
+  (ServerType has 9 writes) could also defer — they're proven under-deadline today but would be
+  immune to future write-count growth. Low priority; not done here to keep the fix surgical.
 
 ## ⚑ Self-initiated: NO — owner-directed bug fix (the screen recording is the directive). The
-RewardActivityStep hardening is the same root-cause class, fixed in the same pass per the
-"fix adjacent bugs properly" working agreement.
+RewardActivityStep hardening + the `_show_current` foundation are the same root-cause class, fixed in
+the same pass per the "fix adjacent bugs properly / approving the goal approves the path" working
+agreement. The Q-0089 defer-lint is captured as an *idea*, not built.

--- a/.sessions/2026-06-24-essential-setup-logging-defer.md
+++ b/.sessions/2026-06-24-essential-setup-logging-defer.md
@@ -1,0 +1,31 @@
+# Session — 2026-06-24 · Essential Setup logging step: defer before slow work
+
+> **Status:** `in-progress` — fixing the live logging-step bug in the new setup wizard.
+
+**Trigger:** Owner screen recording — the new setup wizard's logging step "is kinda broken and
+just keeps building new logging channels and saying that the step failed."
+
+## Diagnosis (root cause)
+
+`LogChannelStep.apply` (`disbot/views/setup/essential_setup.py`) does **two channel-creation REST
+calls + seven audited settings/binding writes before its only `interaction.response` call** (the
+final navigation `edit_message` inside `complete()`). That work runs past Discord's **3-second
+interaction-token deadline**, so the final edit 404s → the Discord client shows **"This interaction
+failed"** — *after* the channels were already created. Each retry creates another `#mod-log` /
+`#server-log` pair (collision-safe names → `-2`, `-3`, …). Both reported symptoms, one cause.
+
+The other six spine steps only do a few fast DB writes, so they squeak under the deadline — which is
+why only logging is broken. The codebase already has the prescribed remedy
+(`core.runtime.interaction_helpers.safe_defer/safe_edit/safe_followup`, whose docstring names this
+exact "Interaction Failed" symptom); Essential Setup just never adopted it.
+
+## Fix (planned)
+
+- `LogChannelStep.apply` — `safe_defer` up front; errors via `safe_followup`.
+- `RewardActivityStep` — same latent bug (creates a role); defer its write/create paths too.
+- `_StepView._show_current` → `safe_edit` (defer-tolerant nav foundation for all steps).
+- Regression test: pin that the log step defers *before* creating channels.
+
+## ⚑ Self-initiated: NO — owner-directed bug fix (the screen recording is the directive). The
+RewardActivityStep hardening is the same root-cause class, fixed in the same pass per the
+"fix adjacent bugs properly" working agreement.

--- a/disbot/views/setup/essential_setup.py
+++ b/disbot/views/setup/essential_setup.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING
 
 import discord
 
+from core.runtime.interaction_helpers import safe_defer, safe_edit, safe_followup
 from views.base import BaseView
 
 if TYPE_CHECKING:
@@ -160,7 +161,12 @@ class _StepView(BaseView):
     async def _show_current(self, interaction: discord.Interaction) -> None:
         view = self.flow.current_view()
         embed = view.render() if hasattr(view, "render") else None
-        await interaction.response.edit_message(embed=embed, view=view)
+        # ``safe_edit`` edits the wizard message in place whether or not the
+        # step deferred first.  Resource-creating steps (log channel, reward
+        # role) defer to beat Discord's 3-second interaction deadline, so the
+        # navigation that runs after their slow work must not assume the
+        # response is still un-acknowledged.
+        await safe_edit(interaction, embed=embed, view=view)
 
     async def skip(self, interaction: discord.Interaction) -> None:
         self.flow.record_skipped(self.title)
@@ -1008,6 +1014,15 @@ class LogChannelStep(_StepView):
         return f"a new **#{default_name}** channel"
 
     async def apply(self, interaction: discord.Interaction) -> None:
+        # Creating up to two channels + writing the logging settings/bindings
+        # runs well past Discord's 3-second interaction-token deadline, so
+        # acknowledge the click FIRST.  Without this the channels are created
+        # but the final navigation edit 404s ("This interaction failed") — and
+        # because the create already happened, every retry leaks another
+        # #mod-log / #server-log pair (the reported "keeps building logging
+        # channels and says the step failed" bug).
+        if not await safe_defer(interaction):
+            return
         created: list[str] = []
         mod_name = self.mod_channel_name or _NEW_MOD_CHANNEL_NAME
         activity_name = self.activity_channel_name or _NEW_ACTIVITY_CHANNEL_NAME
@@ -1036,7 +1051,8 @@ class LogChannelStep(_StepView):
                 await self._bind("events_channel", activity_id)
         except Exception:
             logger.exception("essential setup: log-channel step apply failed")
-            await interaction.response.send_message(
+            await safe_followup(
+                interaction,
                 "Something went wrong saving your log channels — please try again.",
                 ephemeral=True,
             )
@@ -1086,7 +1102,8 @@ class LogChannelStep(_StepView):
                 self.flow.guild.id,
                 result.first_error,
             )
-            await interaction.response.send_message(
+            await safe_followup(
+                interaction,
                 "Couldn't make a channel — please pick existing ones instead.",
                 ephemeral=True,
             )
@@ -1379,7 +1396,7 @@ class RewardActivityStep(_StepView):
         if self.phase == "roles":
             self.phase = "config"
             self.refresh_items()
-            await interaction.response.edit_message(embed=self.render(), view=self)
+            await safe_edit(interaction, embed=self.render(), view=self)
         else:
             await super().go_back(interaction)
 
@@ -1447,6 +1464,10 @@ class RewardActivityStep(_StepView):
     async def on_next(self, interaction: discord.Interaction) -> None:
         if not self.rewards:
             # No role rewards — apply the XP rate (if changed) and finish.
+            # XP-rate writes can run past the 3s deadline, so acknowledge first
+            # (same deadline reasoning as LogChannelStep.apply).
+            if not await safe_defer(interaction):
+                return
             await self._apply_and_complete(
                 interaction,
                 role_id=None,
@@ -1454,12 +1475,19 @@ class RewardActivityStep(_StepView):
                 created=False,
             )
             return
+        # Instant in-memory screen swap — no slow work, so no defer needed.
         self.phase = "roles"
         self.refresh_items()
-        await interaction.response.edit_message(embed=self.render(), view=self)
+        await safe_edit(interaction, embed=self.render(), view=self)
 
     async def apply(self, interaction: discord.Interaction) -> None:
-        # Screen 2 "Save" — resolve the reward role, then apply everything.
+        # Screen 2 "Save" — creating a role + writing the XP rate and reward
+        # thresholds runs past Discord's 3-second deadline, so acknowledge
+        # first (mirrors LogChannelStep.apply; without it a created role would
+        # be orphaned on the "interaction failed" retry).
+        if not await safe_defer(interaction):
+            return
+        # Resolve the reward role, then apply everything.
         role_id, role_name, created = await self._resolve_role(interaction)
         if role_id is None:
             return  # error already surfaced
@@ -1488,7 +1516,8 @@ class RewardActivityStep(_StepView):
                 await self._set_rewards(role_id, role_name)
         except Exception:
             logger.exception("essential setup: reward step apply failed")
-            await interaction.response.send_message(
+            await safe_followup(
+                interaction,
                 "Something went wrong saving rewards — please try again.",
                 ephemeral=True,
             )
@@ -1502,7 +1531,8 @@ class RewardActivityStep(_StepView):
         """Resolve the reward role to (id, name, created?), or (None, …) on error."""
         if self.role_source == "existing":
             if self.existing_role_id is None:
-                await interaction.response.send_message(
+                await safe_followup(
+                    interaction,
                     "Pick a role to grant, or switch to **Recommended** to make one.",
                     ephemeral=True,
                 )
@@ -1541,7 +1571,8 @@ class RewardActivityStep(_StepView):
                 self.flow.guild.id,
                 result.first_error,
             )
-            await interaction.response.send_message(
+            await safe_followup(
+                interaction,
                 "Couldn't make the role — please reuse an existing one instead.",
                 ephemeral=True,
             )

--- a/docs/owner/claims/claude-friendly-keller-e8ofhk.md
+++ b/docs/owner/claims/claude-friendly-keller-e8ofhk.md
@@ -1,1 +1,0 @@
-- branch `claude/friendly-keller-e8ofhk` · scope: fix Essential Setup logging step (interaction-deadline bug — "keeps building channels, step failed") · files: `disbot/views/setup/essential_setup.py` + its test · 2026-06-24

--- a/docs/owner/claims/claude-friendly-keller-e8ofhk.md
+++ b/docs/owner/claims/claude-friendly-keller-e8ofhk.md
@@ -1,0 +1,1 @@
+- branch `claude/friendly-keller-e8ofhk` · scope: fix Essential Setup logging step (interaction-deadline bug — "keeps building channels, step failed") · files: `disbot/views/setup/essential_setup.py` + its test · 2026-06-24

--- a/tests/unit/views/setup/test_essential_setup.py
+++ b/tests/unit/views/setup/test_essential_setup.py
@@ -31,10 +31,30 @@ def _guild(gid: int = 1):
 
 
 def _interaction():
+    """A Discord interaction double that tracks acknowledgement state.
+
+    ``response.is_done()`` starts False and flips True after a defer / send /
+    edit, so the ``safe_defer`` / ``safe_edit`` / ``safe_followup`` helpers
+    route exactly as they would against a real interaction: ``response.*``
+    before the first ack, ``followup.*`` / ``edit_original_response`` after.
+    Resource-creating steps (log channel, reward role) defer before their slow
+    work, so their later edits/errors land on the followup webhook.
+    """
     interaction = MagicMock()
+    state = {"done": False}
+
+    def _ack(*_a, **_k):
+        state["done"] = True
+
     interaction.response = MagicMock()
-    interaction.response.send_message = AsyncMock()
-    interaction.response.edit_message = AsyncMock()
+    interaction.response.is_done = MagicMock(side_effect=lambda: state["done"])
+    interaction.response.defer = AsyncMock(side_effect=_ack)
+    interaction.response.send_message = AsyncMock(side_effect=_ack)
+    interaction.response.edit_message = AsyncMock(side_effect=_ack)
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    interaction.followup.edit_message = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
     return interaction
 
 
@@ -480,10 +500,12 @@ async def test_log_channel_create_failure_blocks(
     await step.apply(interaction)
 
     # The mod-channel create failed → surfaced an error, wrote nothing, no advance.
+    # The step defers first, so the error lands on the followup webhook.
     channel_service.create_channels.assert_awaited_once()
     binding_pipeline.set_binding.assert_not_awaited()
     pipeline.set_value.assert_not_awaited()
-    interaction.response.send_message.assert_awaited_once()
+    interaction.response.defer.assert_awaited_once()
+    interaction.followup.send.assert_awaited_once()
     assert flow.index == 4
 
 
@@ -505,6 +527,47 @@ async def test_log_channel_custom_names_used_when_creating(
 
     names = [c.args[1][0] for c in channel_service.create_channels.await_args_list]
     assert names == ["staff-log", "member-log"]
+    assert flow.index == 5
+
+
+@pytest.mark.asyncio
+async def test_log_channel_defers_before_slow_work(
+    pipeline,
+    binding_pipeline,
+    channel_service,
+):
+    """Regression (the reported bug): the log step must ACK the interaction
+    *before* it creates channels + writes settings/bindings.
+
+    Two channel creations + seven audited writes run well past Discord's
+    3-second interaction deadline.  Without an upfront defer the final
+    navigation edit 404s ("This interaction failed") *after* the channels were
+    already created, so every retry leaked another #mod-log / #server-log pair.
+    Pin that (a) the defer happens and (b) it happens before any channel is
+    created, and that navigation lands via the followup webhook — never a stale
+    ``response.edit_message``.
+    """
+    flow = es.EssentialFlow(_member(), _guild())
+    flow.index = 4
+    step = es.LogChannelStep(flow)  # defaults: members + roles on → creates both
+    interaction = _interaction()
+    deferred_before_create = {"ok": False}
+
+    async def _create(*_a, **_k):
+        # Capture whether the interaction was already acknowledged at the moment
+        # the (slow) channel create runs.
+        deferred_before_create["ok"] = interaction.response.is_done()
+        return _created(111)
+
+    channel_service.create_channels.side_effect = _create
+
+    await step.apply(interaction)
+
+    interaction.response.defer.assert_awaited_once()
+    assert deferred_before_create["ok"], "must defer BEFORE creating channels"
+    # Post-defer navigation uses the followup webhook, not response.edit_message.
+    interaction.followup.edit_message.assert_awaited_once()
+    interaction.response.edit_message.assert_not_awaited()
     assert flow.index == 5
 
 
@@ -631,7 +694,8 @@ async def test_reward_existing_requires_a_pick(pipeline, role_automation, role_s
 
     role_service.apply.assert_not_awaited()
     role_automation.set_xp_threshold.assert_not_awaited()
-    interaction.response.send_message.assert_awaited_once()
+    # The step defers first, so the "pick a role" prompt is a followup.
+    interaction.followup.send.assert_awaited_once()
     assert flow.index == 5  # did not advance
 
 
@@ -658,7 +722,8 @@ async def test_reward_role_create_failure_blocks(
     role_service.apply.assert_awaited_once()
     role_automation.set_xp_threshold.assert_not_awaited()
     pipeline.set_value.assert_not_awaited()
-    interaction.response.send_message.assert_awaited_once()
+    # The step defers first, so the create-failure error is a followup.
+    interaction.followup.send.assert_awaited_once()
     assert flow.index == 5
 
 


### PR DESCRIPTION
## The bug

The new Essential Setup wizard's **logging step** "keeps building new logging channels and says the step failed" (owner screen recording).

## Root cause

`LogChannelStep.apply` (`disbot/views/setup/essential_setup.py`) performs **two channel-creation REST calls + seven audited settings/binding writes _before_ its only `interaction.response` call** (the navigation `edit_message` inside `complete()`). That work runs past Discord's **3-second interaction-token deadline**, so the final edit `404`s and the Discord client shows **"This interaction failed"** — *after* the channels were already created. Each retry creates another collision-safe `#mod-log` / `#server-log` pair (`-2`, `-3`, …). Both symptoms, one cause.

The other six spine steps only do a few fast DB writes, so they squeak under the deadline — which is why **only logging** is broken. The codebase already ships the prescribed remedy, `core.runtime.interaction_helpers.safe_defer/safe_edit/safe_followup` (its docstring names this exact "Interaction Failed" symptom); Essential Setup simply never adopted it, while the other slow setup views (`wizard.py`, `final_review.py`) all do.

## The fix

- **`LogChannelStep.apply`** — `safe_defer` up front (ACK within 3 s); errors routed through `safe_followup`.
- **`RewardActivityStep`** — the same latent bug (it creates a role); its role-creating / XP-write paths now defer too.
- **`_StepView._show_current`** — routed through `safe_edit`, so navigation edits the wizard message in place whether or not the step deferred (defer-tolerant foundation for every step).
- **Regression test** pinning that the log step defers *before* it creates any channel, plus a defer-stateful interaction test-double.

No copy changes, no schema changes — the setting/binding names were already valid; the only defect was the missing acknowledgement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113NtbrjkzJx7rKnZNWgKBQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0113NtbrjkzJx7rKnZNWgKBQ)_