### PR TITLE
Settle-once terminal guard for game-state views (cross-game double-settlement contract)

### DIFF
--- a/.sessions/2026-06-24-game-settle-once-guard.md
+++ b/.sessions/2026-06-24-game-settle-once-guard.md
@@ -1,0 +1,33 @@
+# Session — 2026-06-24 · settle-once terminal guard for game-state views
+
+> **Status:** `in-progress` — born-red opener. Scheduled dispatch fire (no work order); FIX-phase
+> correctness slice. Building a shared settle-once guard for game-state views to close the
+> "no cross-game test proves terminal controls cannot trigger a second settlement" readiness row.
+
+**Trigger:** scheduled dispatch (empty fire). Phase gate = FIX (bugs/correctness first). The two OPEN
+bug sub-cases (BUG-0019 #1, BUG-0009 newest-towers) are owner/data-gated, so I took the next correctness
+priority: a "Not Done" row in the games production-readiness map
+([map](../planning/production-readiness/games-production-readiness-map-2026-06-12.md)) — *"no cross-game
+test proves terminal controls cannot trigger a second settlement after a result, timeout, or delayed
+duplicate interaction."* Continues the BUG-0013 challenge-timer lineage.
+
+## What I'm about to do
+
+- **`disbot/views/terminal_guard.py`** (new) — a `SettleOnceMixin` giving any game-state view one atomic
+  claim on its terminal/settlement transition (`claim_settlement()` returns `True` exactly once;
+  `is_settled` property). Synchronous check-and-set, race-free on discord.py's single event loop when
+  taken before the handler's first `await`.
+- **Adopt it in the two clearest double-settlement cases:**
+  - **RPS PvP** (`views/rps/pvp_play.py`) — `_resolve()` is reachable twice (both-picks race ·
+    timeout racing a final pick) → today it relies *solely* on the wager workflow's idempotency and
+    still posts a duplicate result embed. Guard `_resolve` at the top.
+  - **Deathmatch bot-duel** (`views/games/deathmatch_panel.py`) — `_finish`/`on_timeout` guard via the
+    bespoke `duel.is_over`; route both through the shared claim.
+- Harden the silently-swallowed timeout `message.edit` failures (`except Exception: pass`) in those two
+  views to log at debug (match `BaseView.on_timeout`).
+- **Tests:** primitive unit test + per-game "settles once / second call short-circuits" regression tests.
+- Flip the games-map row toward Done; sharpen current-state ▶ Next action with the remaining adopters
+  (blackjack PvP) for a follow-up PR.
+
+⚑ Self-initiated: advancing a production-readiness "Not Done" row (correctness/safety), no dispatch/owner
+ask. Contained, reversible, test-covered.

--- a/.sessions/2026-06-24-game-settle-once-guard.md
+++ b/.sessions/2026-06-24-game-settle-once-guard.md
@@ -1,33 +1,89 @@
 # Session — 2026-06-24 · settle-once terminal guard for game-state views
 
-> **Status:** `in-progress` — born-red opener. Scheduled dispatch fire (no work order); FIX-phase
-> correctness slice. Building a shared settle-once guard for game-state views to close the
-> "no cross-game test proves terminal controls cannot trigger a second settlement" readiness row.
+> **Status:** `complete` — shared settle-once guard + adoption in RPS PvP and the deathmatch bot-duel,
+> with a cross-game regression contract. PR #1444.
 
-**Trigger:** scheduled dispatch (empty fire). Phase gate = FIX (bugs/correctness first). The two OPEN
-bug sub-cases (BUG-0019 #1, BUG-0009 newest-towers) are owner/data-gated, so I took the next correctness
-priority: a "Not Done" row in the games production-readiness map
-([map](../planning/production-readiness/games-production-readiness-map-2026-06-12.md)) — *"no cross-game
-test proves terminal controls cannot trigger a second settlement after a result, timeout, or delayed
-duplicate interaction."* Continues the BUG-0013 challenge-timer lineage.
+**Trigger:** scheduled dispatch (empty fire, no work order). Phase gate = FIX (bugs/correctness first).
+The two OPEN bug sub-cases (BUG-0019 #1 — owner design fork; BUG-0009 newest-towers — data-gated) were
+both un-actionable autonomously, so I took the next correctness priority: a "Not Done" row in the games
+production-readiness map — *"no cross-game test proves terminal controls cannot trigger a second
+settlement after a result, timeout, or delayed duplicate interaction."* Continues the BUG-0013
+challenge-timer lineage.
 
-## What I'm about to do
+## What shipped
 
-- **`disbot/views/terminal_guard.py`** (new) — a `SettleOnceMixin` giving any game-state view one atomic
-  claim on its terminal/settlement transition (`claim_settlement()` returns `True` exactly once;
-  `is_settled` property). Synchronous check-and-set, race-free on discord.py's single event loop when
-  taken before the handler's first `await`.
-- **Adopt it in the two clearest double-settlement cases:**
-  - **RPS PvP** (`views/rps/pvp_play.py`) — `_resolve()` is reachable twice (both-picks race ·
-    timeout racing a final pick) → today it relies *solely* on the wager workflow's idempotency and
-    still posts a duplicate result embed. Guard `_resolve` at the top.
-  - **Deathmatch bot-duel** (`views/games/deathmatch_panel.py`) — `_finish`/`on_timeout` guard via the
-    bespoke `duel.is_over`; route both through the shared claim.
-- Harden the silently-swallowed timeout `message.edit` failures (`except Exception: pass`) in those two
-  views to log at debug (match `BaseView.on_timeout`).
-- **Tests:** primitive unit test + per-game "settles once / second call short-circuits" regression tests.
-- Flip the games-map row toward Done; sharpen current-state ▶ Next action with the remaining adopters
-  (blackjack PvP) for a follow-up PR.
+- **`disbot/views/terminal_guard.py`** (new) — `SettleOnceMixin.claim_settlement()` gives any
+  game-state view one atomic claim on its terminal transition (returns `True` exactly once;
+  `is_settled` property). A synchronous check-and-set, race-free on discord.py's single event loop
+  **when taken before the handler's first await** (the documented contract). Mixin, not a base class,
+  because game-state views intentionally extend `discord.ui.View` directly (the `views/base.py`
+  divergence); declares no `__init__` so the class-level `False` default is the unclaimed state.
+- **RPS PvP** (`views/rps/pvp_play.py`) — `_resolve()` is reachable twice (both-picks race · timeout
+  racing a final pick); it previously relied **solely** on the wager-workflow idempotency and still
+  posted a duplicate result embed. Now claims at the top → exactly one settle + one result post.
+- **Deathmatch bot-duel** (`views/games/deathmatch_panel.py`) — `_finish`/`on_timeout` routed through
+  the shared claim (was the bespoke `duel.is_over`, which is kept as the domain flag the embeds read).
+- Silently-swallowed timeout `message.edit` failures in both views now log at debug (match
+  `BaseView.on_timeout`) instead of `except: pass`.
+- **Tests:** `tests/unit/views/test_terminal_guard.py` (primitive: claim-once, per-instance,
+  no-init default) + 2 deathmatch + 2 RPS regression tests proving a second settlement short-circuits.
 
-⚑ Self-initiated: advancing a production-readiness "Not Done" row (correctness/safety), no dispatch/owner
-ask. Contained, reversible, test-covered.
+## ✅ Verification
+
+`check_quality.py --full` → **12523 passed, 48 skipped, 2 xfailed** (mypy + black/isort/ruff green).
+`check_architecture --mode strict` → **0 errors** (49 pre-existing warnings, none new — the two adopted
+views already extended `discord.ui.View` directly). `check_quality --check-only` (docs/consistency) green.
+
+## Handoff — remaining adopter (clearly scoped)
+
+The other money-handling terminal path, **blackjack PvP/tournament settlement**, is *not* yet guarded.
+Its `_resolve_pvp` is a **module-level function over a `_PvPState`** (not a view method), so it needs a
+guard on the state object rather than the view mixin — a different shape, deserving its own focused PR.
+It already `_pvp.pop(key, None)`s at the top but doesn't short-circuit on a missing key, so the
+double-settle exposure remains (idempotent wager settle limits the money impact; the duplicate result
+post is the residual). Durable home for this follow-up: the games-readiness map's "Remaining adopters"
+note (updated this session).
+
+## 💡 Session idea (Q-0089)
+
+**An architecture-rule lint: a game-state view that has a settling path (posts a result / calls
+`settle_pvp`/`refund_pvp`) and is reachable from >1 entry (a button + `on_timeout`) must adopt
+`SettleOnceMixin`.** This session found the double-settle class by reading three views by hand; a
+`check_architecture` rule that flags a `discord.ui.View` subclass calling a wager-settle helper in a
+method *also* reachable from `on_timeout`, without a `claim_settlement()` call, would turn "I noticed it"
+into a CI ratchet — the same shape as the `select_option_truncation` guard. Captured, not built (needs
+the guard to prove itself across a couple of sessions first, per its own kill-switch posture).
+Dedup-checked `docs/ideas/` — no existing settle-once/terminal-guard idea.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous `.sessions/` log: **`2026-06-24-setup-log-channel-rework.md`** (the #1432 two-channel logging
+rework). **Did well:** a clean declarative `LogChannelStep`, full green verification, and an honest
+"misses" section owning the same-day #1429→#1432 rework. **Missed:** nothing in the work itself — the
+recorded lesson (a scope-narrowing owner answer needs "final scope or first slice?" confirmation) is the
+right one. **System improvement this surfaces:** that session's Q-0089 idea (use `AskUserQuestion`'s
+per-option `preview` field for design forks) is genuinely high-leverage and currently sits only in a
+session log. It should be **promoted into `docs/ideas/`** so it's groomable, not buried — a recurring
+pattern where a strong session idea never leaves the log it was born in. (Routing note for the next
+grooming pass; I didn't promote it this session to stay within my claimed lane.)
+
+## 📋 Doc audit (Q-0104)
+
+Games-readiness map updated (the Not Done → Partial row + the two silent-swallow rows). No
+`current-state.md` ledger entry until #1444 merges (the ledger checker keys off merged PRs; the next
+reconciliation/ledger pass picks it up). No owner *decision* made (self-initiated correctness slice). No
+new top-level doc; the new primitive is documented in its own module docstring + the map note.
+`check_docs --strict` green.
+
+## 📤 Run report
+
+- **Run type:** routine · dispatch
+- **What shipped:** PR #1444 — settle-once terminal guard primitive + RPS PvP & deathmatch bot-duel
+  adoption + cross-game regression contract; games-readiness map de-staled.
+- **⚑ Self-initiated:** yes — advanced a production-readiness "Not Done" correctness/safety row
+  (no dispatch/owner ask). Contained, reversible, test-covered.
+- **⚑ Owner-decisions:** none
+- **⚑ Owner-manual-steps:** none
+- **Bug-book:** no entry flipped (BUG-0013 already FIXED; this generalizes its class). BUG-0019 #1 and
+  BUG-0009 newest-towers remain OPEN/gated.
+- **Remarks:** CodeGraph built clean at session start (52415 nodes). Grimp/arch checks ran clean.

--- a/disbot/views/games/deathmatch_panel.py
+++ b/disbot/views/games/deathmatch_panel.py
@@ -26,6 +26,7 @@ from utils import db, equipment
 from utils.ui_constants import GAME_COLOR
 from views.base import HubView
 from views.games.common import BackToPanelButton
+from views.terminal_guard import SettleOnceMixin
 
 if TYPE_CHECKING:
     # Type-only — the panel reuses the deathmatch cog's ``_Duel`` state class
@@ -168,7 +169,7 @@ def build_deathmatch_challenge_picker_embed() -> discord.Embed:
 # ---------------------------------------------------------------------------
 
 
-class _BotDuelView(discord.ui.View):
+class _BotDuelView(SettleOnceMixin, discord.ui.View):
     """Player-vs-bot duel view (PR 6).
 
     Reuses the cog's ``_Duel`` state class for HP / attack / defend /
@@ -277,6 +278,11 @@ class _BotDuelView(discord.ui.View):
         interaction: discord.Interaction,
         action_text: str,
     ) -> None:
+        # Settle-once: a finishing-blow double-click (or a timeout racing the
+        # final move) can re-enter the settlement path; claim it synchronously
+        # before any await so the second caller short-circuits.
+        if not self.claim_settlement():
+            return
         self.duel.is_over = True
         # NOTE: deliberately NO call to ``cog.update_leaderboard`` /
         # ``db.update_deathmatch`` — see plan §13 bot-duel stats rule.
@@ -294,7 +300,9 @@ class _BotDuelView(discord.ui.View):
         self.stop()
 
     async def on_timeout(self) -> None:
-        if self.duel.is_over:
+        # Shares the settle-once claim with ``_finish`` so a timeout firing just
+        # as the duel finishes can't post a second terminal screen.
+        if not self.claim_settlement():
             return
         self.duel.is_over = True
         embed = discord.Embed(
@@ -312,8 +320,8 @@ class _BotDuelView(discord.ui.View):
                     embed=embed,
                     view=_BotDuelResultView(self.player, self.bot_user),
                 )
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("bot-duel on_timeout: message.edit failed: %s", exc)
 
 
 class _BotDuelResultView(HubView):

--- a/disbot/views/rps/pvp_play.py
+++ b/disbot/views/rps/pvp_play.py
@@ -22,11 +22,12 @@ from views.rps._helpers import (
     RPS_PVP_PENDING_VERSION,
     rps_pvp_canonical_user_id,
 )
+from views.terminal_guard import SettleOnceMixin
 
 logger = logging.getLogger("bot.rps.pvp_play")
 
 
-class _RpsPvpPlayView(discord.ui.View):
+class _RpsPvpPlayView(SettleOnceMixin, discord.ui.View):
     """Visible to the channel; each player clicks for their ephemeral picker."""
 
     def __init__(
@@ -105,12 +106,20 @@ class _RpsPvpPlayView(discord.ui.View):
             await self._resolve()
 
     async def _resolve(self):
+        # Settle-once: ``_resolve`` is reachable twice — both players' picks
+        # landing near-simultaneously (the second ``record_choice`` re-sees
+        # ``len == 2`` while the first is still awaiting), or ``on_timeout``
+        # racing a final pick. A second settlement would post a duplicate result
+        # embed and re-call the (idempotent) wager settle. Claim synchronously
+        # before any await so the loser short-circuits.
+        if not self.claim_settlement():
+            return
         for item in self.children:
             item.disabled = True  # type: ignore[attr-defined]
         try:
             await self.message.edit(view=self)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("rps_pvp _resolve: disable-buttons edit failed: %s", exc)
         self.stop()
 
         m1 = self.choices.get(self.p1.id, "forfeit")

--- a/disbot/views/terminal_guard.py
+++ b/disbot/views/terminal_guard.py
@@ -1,0 +1,60 @@
+"""Settle-once guard for game-state views (cross-game terminal contract).
+
+A game-state view can reach its *settlement* path more than once:
+
+- a player double-clicks the finishing button,
+- a timeout fires while a final move is already resolving,
+- a duplicate component interaction is delivered late.
+
+When settlement pays out, records a result, or posts a result message, running
+it twice **double-settles** — a redundant payout attempt and a duplicate result
+post. :class:`SettleOnceMixin` gives a view one atomic claim on that transition:
+the first caller of :meth:`claim_settlement` wins and proceeds; every later
+caller gets ``False`` and must short-circuit.
+
+The claim is a plain *synchronous* check-and-set. discord.py dispatches every
+component callback and ``on_timeout`` on the one asyncio event loop, and no
+``await`` runs between the read and the write, so the critical section is
+race-free **as long as the claim is taken before the handler's first await**.
+That ordering is the contract — take ``claim_settlement()`` at the very top of
+the settling path, before any ``await``.
+
+Production-readiness map: this closes the *"no cross-game test proves terminal
+controls cannot trigger a second settlement"* row in
+``docs/planning/production-readiness/games-production-readiness-map-2026-06-12.md``
+and continues the BUG-0013 challenge-timer lineage (``docs/health/bug-book.md``).
+
+Mixin, not a base class, because game-state views intentionally extend
+``discord.ui.View`` directly (the documented divergence in ``views/base.py``)
+and a mixin composes without disturbing their bespoke lifecycle. It declares no
+``__init__`` — the class-level ``_settlement_claimed = False`` default is the
+unclaimed state, and the first claim writes a per-instance attribute (``bool``
+is immutable, so the class attribute is never mutated and no state leaks
+between instances).
+"""
+
+from __future__ import annotations
+
+
+class SettleOnceMixin:
+    """Give a game-state view one atomic claim on its terminal transition."""
+
+    _settlement_claimed: bool = False
+
+    def claim_settlement(self) -> bool:
+        """Atomically claim the view's terminal transition. ``True`` = you won.
+
+        Call this **synchronously at the very top** of every settling path
+        (finishing button, ``_resolve``, ``on_timeout``) *before any* ``await``.
+        Returns ``True`` exactly once per view instance; later calls return
+        ``False`` and the caller must return without re-settling.
+        """
+        if self._settlement_claimed:
+            return False
+        self._settlement_claimed = True
+        return True
+
+    @property
+    def is_settled(self) -> bool:
+        """Whether the terminal transition has already been claimed."""
+        return self._settlement_claimed

--- a/docs/owner/claims/claude-funny-franklin-fwh3dh.md
+++ b/docs/owner/claims/claude-funny-franklin-fwh3dh.md
@@ -1,0 +1,1 @@
+claude/funny-franklin-fwh3dh · settle-once terminal guard for game-state views (cross-game double-settlement contract) · new disbot/views/terminal_guard.py + disbot/views/rps/pvp_play.py + disbot/views/games/deathmatch_panel.py + tests · 2026-06-24

--- a/docs/owner/claims/claude-funny-franklin-fwh3dh.md
+++ b/docs/owner/claims/claude-funny-franklin-fwh3dh.md
@@ -1,1 +1,0 @@
-claude/funny-franklin-fwh3dh · settle-once terminal guard for game-state views (cross-game double-settlement contract) · new disbot/views/terminal_guard.py + disbot/views/rps/pvp_play.py + disbot/views/games/deathmatch_panel.py + tests · 2026-06-24

--- a/docs/planning/production-readiness/games-production-readiness-map-2026-06-12.md
+++ b/docs/planning/production-readiness/games-production-readiness-map-2026-06-12.md
@@ -175,14 +175,20 @@ has one readiness disposition without turning the inventory into a method-per-ro
 - **Good:** Blackjack solo disables action buttons on finish and provides a replay result
   view; replay behavior has direct tests.
 - **Good:** Deathmatch PvP and bot-duel terminal paths disable controls and stop the view.
-- **Partial:** RPS PvP/challenge and blackjack tournament timeout handlers catch and hide
-  message-edit failures; no shared observable timeout policy exists.
-- **Partial:** Deathmatch bot-duel timeout disables controls only if its stored message can
-  be edited, and the exception is silently ignored.
+- **Partial:** RPS PvP `_resolve` and the deathmatch bot-duel now log their hidden message-edit
+  failures at debug (2026-06-24 dispatch run); RPS challenge and blackjack tournament timeout
+  handlers still catch and hide them, and no shared observable timeout policy exists.
+- **Partial → improving:** Deathmatch bot-duel and RPS PvP now route their settle/timeout edit
+  failures through a debug log (matching `BaseView.on_timeout`) instead of a silent `except: pass`
+  (2026-06-24 dispatch run). Blackjack tournament timeout handlers still swallow silently.
 - **Partial:** Mining views inherit the shared BaseView lifecycle, but real Discord
   interaction expiry/defer/edit sequences have not been live-verified in this review.
-- **Not Done:** no cross-game test proves terminal controls cannot trigger a second
-  settlement after a result, timeout, or delayed duplicate interaction.
+- **Partial (was Not Done — 2026-06-24 dispatch run):** the cross-game terminal contract now has a
+  shared **settle-once guard** (`disbot/views/terminal_guard.py` `SettleOnceMixin.claim_settlement()`)
+  adopted by **RPS PvP** (`_resolve`) and **deathmatch bot-duel** (`_finish`/`on_timeout`), with
+  regression tests proving a second settlement short-circuits (no duplicate result post, no redundant
+  wager settle). **Remaining adopters:** blackjack PvP/tournament settlement (the other money-handling
+  terminal path) — a follow-up PR adopts the same mixin.
 
 ## Gated or accepted limitations
 

--- a/tests/unit/cogs/test_deathmatch_bot_duel.py
+++ b/tests/unit/cogs/test_deathmatch_bot_duel.py
@@ -104,6 +104,55 @@ async def test_bot_duel_does_not_call_update_leaderboard():
 
 
 @pytest.mark.asyncio
+async def test_bot_duel_finish_settles_once_no_double_terminal():
+    """A second terminal transition (finishing-blow double-click / timeout race)
+    must short-circuit — the settle-once guard claims it exactly once."""
+    from views.games.deathmatch_panel import _BotDuelView
+
+    player = _player(100)
+    bot_user = _bot_user(999)
+    view = _BotDuelView(player, bot_user)
+    view.message = MagicMock(id=444)
+    view.message.edit = AsyncMock()
+
+    # Drive the duel to a finish via _finish directly (the settlement path).
+    first = _stub_interaction(player)
+    await view._finish(first, "finishing blow")
+    assert view.is_settled is True
+    assert view.duel.is_over is True
+    first.response.edit_message.assert_awaited_once()
+
+    # A racing duplicate finish must not post a second terminal screen.
+    second = _stub_interaction(player)
+    await view._finish(second, "duplicate finishing blow")
+    second.response.edit_message.assert_not_called()
+
+    # A timeout firing after settlement shares the claim → no extra edit.
+    await view.on_timeout()
+    view.message.edit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bot_duel_timeout_then_finish_settles_once():
+    """A timeout that wins the claim blocks a later finish from double-settling."""
+    from views.games.deathmatch_panel import _BotDuelView
+
+    player = _player(100)
+    bot_user = _bot_user(999)
+    view = _BotDuelView(player, bot_user)
+    view.message = MagicMock(id=444)
+    view.message.edit = AsyncMock()
+
+    await view.on_timeout()
+    assert view.is_settled is True
+    view.message.edit.assert_awaited_once()
+
+    late = _stub_interaction(player)
+    await view._finish(late, "too late")
+    late.response.edit_message.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_bot_duel_does_not_call_db_update_deathmatch():
     """Plan §13: bot duels must not call ``db.update_deathmatch``."""
     from views.games.deathmatch_panel import _BotDuelView

--- a/tests/unit/cogs/test_rps_pvp_pending_persistence.py
+++ b/tests/unit/cogs/test_rps_pvp_pending_persistence.py
@@ -161,6 +161,102 @@ async def test_resolve_clears_persisted_state():
 
 
 @pytest.mark.asyncio
+async def test_resolve_settles_once_no_double_payout_or_post():
+    """``_resolve`` is reachable twice (both-picks race · timeout racing a final
+    pick). The settle-once guard must claim the terminal transition exactly once:
+    a second ``_resolve`` short-circuits — no duplicate result post, no second
+    (idempotent) wager settle, no second state clear.
+    """
+    from views.rps.pvp_play import _RpsPvpPlayView
+
+    p1 = MagicMock()
+    p1.id = 100
+    p1.mention = "<@100>"
+    p2 = MagicMock()
+    p2.id = 200
+    p2.mention = "<@200>"
+    channel = MagicMock()
+    channel.id = 999
+    channel.send = AsyncMock()
+    view = _RpsPvpPlayView(p1, p2, guild_id=111, bet=50, channel=channel)
+    view.message = MagicMock()
+    view.message.edit = AsyncMock()
+    view.choices = {100: "rock", 200: "scissors"}  # rock beats scissors
+
+    with (
+        patch(
+            "views.rps.pvp_play.game_state_service.save",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "views.rps.pvp_play.game_state_service.clear",
+            new_callable=AsyncMock,
+        ) as mock_clear,
+        patch(
+            "views.rps.pvp_play.game_wager_workflow.settle_pvp",
+            new_callable=AsyncMock,
+        ) as mock_settle,
+        patch(
+            "views.rps.pvp_play.game_wager_workflow.refund_pvp",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await view._resolve()
+        assert view.is_settled is True
+        # A racing duplicate resolution must do nothing.
+        await view._resolve()
+
+    mock_settle.assert_awaited_once()
+    channel.send.assert_awaited_once()
+    mock_clear.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_timeout_after_resolve_does_not_double_settle():
+    """If a timeout fires after both players already resolved, ``on_timeout``'s
+    ``_resolve`` shares the claim and short-circuits — no second settlement."""
+    from views.rps.pvp_play import _RpsPvpPlayView
+
+    p1 = MagicMock()
+    p1.id = 100
+    p1.mention = "<@100>"
+    p2 = MagicMock()
+    p2.id = 200
+    p2.mention = "<@200>"
+    channel = MagicMock()
+    channel.id = 999
+    channel.send = AsyncMock()
+    view = _RpsPvpPlayView(p1, p2, guild_id=111, bet=50, channel=channel)
+    view.message = MagicMock()
+    view.message.edit = AsyncMock()
+    view.choices = {100: "rock", 200: "scissors"}
+
+    with (
+        patch(
+            "views.rps.pvp_play.game_state_service.save",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "views.rps.pvp_play.game_state_service.clear",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "views.rps.pvp_play.game_wager_workflow.settle_pvp",
+            new_callable=AsyncMock,
+        ) as mock_settle,
+        patch(
+            "views.rps.pvp_play.game_wager_workflow.refund_pvp",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await view._resolve()
+        await view.on_timeout()  # late timeout → forfeits fill, then _resolve no-ops
+
+    mock_settle.assert_awaited_once()
+    channel.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_cog_load_clears_orphan_rows():
     """On cog_load, _recover_rps_pvp_pending lists every active row and
     clears each by id.  No refund — RPS PvP doesn't pre-debit.

--- a/tests/unit/views/test_terminal_guard.py
+++ b/tests/unit/views/test_terminal_guard.py
@@ -1,0 +1,47 @@
+"""Unit tests for the settle-once game-view terminal guard.
+
+Covers the cross-game terminal contract (``SettleOnceMixin``): the first
+``claim_settlement()`` wins, every later call short-circuits, and the claim is
+per-instance (no class-level state leak between views).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+from views.terminal_guard import SettleOnceMixin  # noqa: E402
+
+
+class _Settleable(SettleOnceMixin):
+    """Minimal host for the mixin (no discord.ui.View needed for the logic)."""
+
+
+def test_first_claim_wins_then_loses() -> None:
+    obj = _Settleable()
+    assert obj.is_settled is False
+    assert obj.claim_settlement() is True
+    assert obj.is_settled is True
+    # Every later claim short-circuits.
+    assert obj.claim_settlement() is False
+    assert obj.claim_settlement() is False
+    assert obj.is_settled is True
+
+
+def test_claim_is_per_instance() -> None:
+    a = _Settleable()
+    b = _Settleable()
+    assert a.claim_settlement() is True
+    # b is untouched — the claim wrote an instance attribute on a, not the class.
+    assert b.is_settled is False
+    assert b.claim_settlement() is True
+
+
+def test_unclaimed_default_is_false_without_init() -> None:
+    # The mixin declares no __init__; the class-level default is the unclaimed
+    # state, so a freshly constructed host reads False before any claim.
+    assert _Settleable().is_settled is False


### PR DESCRIPTION
## What

A shared **settle-once guard** for game-state views, closing the games production-readiness map's
"Not Done" row: *"no cross-game test proves terminal controls cannot trigger a second settlement after
a result, timeout, or delayed duplicate interaction."* Continues the BUG-0013 challenge-timer lineage.

- **`disbot/views/terminal_guard.py`** (new) — `SettleOnceMixin.claim_settlement()` gives a view one
  atomic claim on its terminal transition (returns `True` exactly once; `is_settled` property).
  Synchronous check-and-set, race-free on discord.py's single event loop when taken before the
  handler's first `await`.
- **RPS PvP** (`views/rps/pvp_play.py`) — `_resolve()` is reachable twice (both-picks race · timeout
  racing a final pick); today it relies *solely* on the wager-workflow idempotency and still posts a
  duplicate result embed. Now guarded at the top → exactly one settle + one result post.
- **Deathmatch bot-duel** (`views/games/deathmatch_panel.py`) — `_finish`/`on_timeout` routed through
  the shared claim (was the bespoke `duel.is_over`).
- Silently-swallowed timeout `message.edit` failures in both views now log at debug (match
  `BaseView.on_timeout`).

## Tests
- Primitive unit test (claim-once, idempotent, per-instance isolation).
- Per-game "settles once / second call short-circuits" regression tests.

## Scope / safety
Contained, reversible, behaviour-preserving except in the racy double-settle case it's designed to
prevent. Money safety in RPS was already provided by the wager workflow's idempotency; this adds the
view-level guard as defense-in-depth and removes the duplicate result post.

⚑ Self-initiated: advancing a production-readiness "Not Done" correctness/safety row (FIX phase), no
dispatch/owner ask.

> Born-red until the session card flips to `complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Q5RePpRANA1a1XmDeMtAm)_