### PR TITLE
Settle-once guard for blackjack PvP + relocate mixin to utils (cross-layer reuse)

### DIFF
--- a/.sessions/2026-06-24-blackjack-settle-once.md
+++ b/.sessions/2026-06-24-blackjack-settle-once.md
@@ -1,0 +1,24 @@
+# Session — 2026-06-24 · settle-once guard for blackjack PvP (slice 2)
+
+> **Status:** `in-progress` — born-red opener. Continues the same dispatch run that shipped PR #1444
+> (settle-once terminal guard). This slice completes the money-path coverage: blackjack PvP settlement.
+
+**Trigger:** continuation of this run's own handoff. PR #1444 closed the cross-game terminal contract for
+RPS PvP + deathmatch bot-duel; the documented remaining adopter is **blackjack PvP/tournament
+settlement** — the other money-handling terminal path.
+
+## What I'm about to do
+
+- **Relocate `SettleOnceMixin` → `disbot/utils/terminal_guard.py`** (from `views/`). Blackjack's terminal
+  state is `_PvPState`, which lives in `services/` — and **`services/` may not import `views/`**
+  (zero-tolerance arch rule). The mixin is pure logic with no view dependency, and is now needed by both
+  `services/` and `views/`, so per `docs/helper-policy.md` its correct home is `utils/`. Update the two
+  existing importers (RPS PvP, deathmatch bot-duel) + move its unit test.
+- **Adopt in blackjack PvP:** `_PvPState(SettleOnceMixin)`; guard `_resolve_pvp` at the top so a second
+  settlement (a `BlackjackView` terminal firing `on_finish` twice, or any re-entry) short-circuits — no
+  duplicate result embed, no redundant (idempotent) wager settle. Today the `_pvp.pop(key, None)` is a
+  de-facto guard but doesn't short-circuit.
+- Blackjack regression test (settles once / second `_resolve_pvp` no-ops); update the games-map doc path.
+
+⚑ Self-initiated: completing a production-readiness "Not Done"→Done correctness/safety row, no
+dispatch/owner ask. Contained, reversible, test-covered.

--- a/.sessions/2026-06-24-blackjack-settle-once.md
+++ b/.sessions/2026-06-24-blackjack-settle-once.md
@@ -1,24 +1,89 @@
 # Session — 2026-06-24 · settle-once guard for blackjack PvP (slice 2)
 
-> **Status:** `in-progress` — born-red opener. Continues the same dispatch run that shipped PR #1444
-> (settle-once terminal guard). This slice completes the money-path coverage: blackjack PvP settlement.
+> **Status:** `complete` — blackjack PvP adoption + relocation of `SettleOnceMixin` to `utils/`.
+> Continues the same dispatch run that shipped PR #1444. PR #1445.
 
 **Trigger:** continuation of this run's own handoff. PR #1444 closed the cross-game terminal contract for
-RPS PvP + deathmatch bot-duel; the documented remaining adopter is **blackjack PvP/tournament
-settlement** — the other money-handling terminal path.
+RPS PvP + deathmatch bot-duel; the documented remaining adopter was **blackjack PvP settlement** — the
+third money-handling terminal path.
 
-## What I'm about to do
+## What shipped
 
-- **Relocate `SettleOnceMixin` → `disbot/utils/terminal_guard.py`** (from `views/`). Blackjack's terminal
-  state is `_PvPState`, which lives in `services/` — and **`services/` may not import `views/`**
-  (zero-tolerance arch rule). The mixin is pure logic with no view dependency, and is now needed by both
-  `services/` and `views/`, so per `docs/helper-policy.md` its correct home is `utils/`. Update the two
-  existing importers (RPS PvP, deathmatch bot-duel) + move its unit test.
-- **Adopt in blackjack PvP:** `_PvPState(SettleOnceMixin)`; guard `_resolve_pvp` at the top so a second
-  settlement (a `BlackjackView` terminal firing `on_finish` twice, or any re-entry) short-circuits — no
-  duplicate result embed, no redundant (idempotent) wager settle. Today the `_pvp.pop(key, None)` is a
-  de-facto guard but doesn't short-circuit.
-- Blackjack regression test (settles once / second `_resolve_pvp` no-ops); update the games-map doc path.
+- **Relocated `SettleOnceMixin` → `disbot/utils/terminal_guard.py`** (from `views/`). Blackjack's terminal
+  state is `_PvPState`, which lives in `services/`, and **`services/` may not import `views/`**
+  (zero-tolerance arch rule). The mixin is pure logic with no view dependency and is now needed by both
+  layers → per `docs/helper-policy.md` its correct home is `utils/`. Pure move: the two existing adopters
+  (RPS PvP, deathmatch bot-duel) re-point their import; the unit test moves to `tests/unit/utils/`. No
+  behaviour change for them.
+- **Blackjack PvP** (`views/blackjack/pvp_view.py`): `_PvPState(SettleOnceMixin)`; `_resolve_pvp` claims
+  the terminal transition at the top, so a second settlement (a per-player `BlackjackView` firing
+  `on_finish` twice, or a late duplicate) short-circuits — no duplicate result embed, no redundant
+  (idempotent) wager settle. The pre-existing `_pvp.pop(key, None)` stays (drops the live-match registry
+  entry) but is no longer load-bearing as the double-settle guard.
+- **Tests:** relocated primitive test + 2 blackjack regression tests (win settles once / tie refunds once,
+  each with a racing second `_resolve_pvp` proven a no-op).
+- **Games-readiness map:** the terminal-contract row flipped **Not Done → Done** (all three money/terminal
+  paths now guarded); doc path reference updated to `utils/`.
 
-⚑ Self-initiated: completing a production-readiness "Not Done"→Done correctness/safety row, no
-dispatch/owner ask. Contained, reversible, test-covered.
+## ✅ Verification
+
+`check_quality.py --full` → **12525 passed, 48 skipped, 2 xfailed** (mypy + black/isort/ruff green).
+`check_architecture --mode strict` → **0 errors** (49 pre-existing warnings, none new) — confirms the
+relocation removed the would-be `services → views` edge cleanly. `check_quality --check-only` green
+(isort auto-fixed the two re-pointed imports pre-push). No stale `views.terminal_guard` references remain.
+
+## Note for a future session
+
+Blackjack **tournament** settlement (`tournament_views.py`) is a separate multi-round flow, not a
+single-shot PvP settle — I did not force the mixin onto it. If a double-settle vector is found in the
+per-round tournament payout, the same `SettleOnceMixin` (now in `utils/`) is the ready primitive. Flagged
+in the games-map row, not left as silent debt.
+
+## 💡 Session idea (Q-0089)
+
+**Promote last session's `AskUserQuestion` per-option `preview` idea into `docs/ideas/`.** (Carried from
+this run's slice-1 review: a strong session idea — render a mockup of each option's resulting UX for setup
+/design forks — currently lives only in the `2026-06-24-setup-log-channel-rework.md` log, where it isn't
+groomable.) My *own* new idea this session: **a `check_architecture` rule "a `discord.ui.View` (or game
+state object) that calls a wager-settle helper in a method also reachable from `on_timeout`/a finish
+callback must adopt `SettleOnceMixin`"** — the CI ratchet form of the manual double-settle hunt this run
+did across four views by hand. Same shape as the slice-1 idea but now sharper (the mixin exists and has
+proven itself across three adopters, so the guard has a concrete target). Dedup-checked `docs/ideas/` — no
+settle-once/terminal-guard idea present. Captured, not built (the guard should earn a couple more
+sessions of trust first, per its own Q-0105 kill-switch posture).
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous: **this run's slice 1** (`2026-06-24-game-settle-once-guard.md`, PR #1444). **Did well:** scoped
+slice 1 to two views as a focused PR and explicitly *named the residual* (blackjack, different shape) in
+both the games-map and the handoff — which is exactly what let slice 2 start cleanly. **Missed:** it put
+the new `SettleOnceMixin` in `views/` without checking whether a *non-view* adopter would soon need it —
+which it did, one slice later, forcing this session's relocation to `utils/`. **System improvement:** when
+introducing a shared primitive, ask "which layers will adopt this?" *before* choosing its home —
+`docs/helper-policy.md` already says cross-layer helpers go in `utils/`, but slice 1 placed by the *first*
+adopter's layer, not the *eventual* set. A cheap habit: a primitive with an obvious second adopter in
+another layer should start in `utils/`. (No CLAUDE.md edit — helper-policy already covers it; this is a
+recall failure, not a missing rule.)
+
+## 📋 Doc audit (Q-0104)
+
+Games-readiness map updated (row → Done, path → `utils/`). No `current-state.md` ledger entry until #1445
+merges (ledger checker keys off merged PRs; the next reconciliation pass picks up #1444 + #1445). No owner
+*decision* made (self-initiated correctness slice). The new primitive's home + rationale are documented in
+its own module docstring. `check_docs --strict` green.
+
+## 📤 Run report
+
+- **Run type:** routine · dispatch
+- **What shipped this slice:** PR #1445 — `SettleOnceMixin` relocated to `utils/` + blackjack PvP adoption
+  + the cross-game terminal-contract row closed (Not Done → Done). (This run also shipped PR #1444, the
+  primitive + RPS/deathmatch adoption.)
+- **⚑ Self-initiated:** yes — completed a production-readiness "Not Done" → Done correctness/safety row
+  (no dispatch/owner ask). Contained, reversible, test-covered.
+- **⚑ Owner-decisions:** none
+- **⚑ Owner-manual-steps:** none
+- **Bug-book:** no entry flipped (this generalizes the BUG-0013 class, already FIXED). BUG-0019 #1 and
+  BUG-0009 newest-towers remain OPEN/gated.
+- **Remarks:** CodeGraph rebuilt clean on resume (52428 nodes). Two slices shipped this run (#1444, #1445)
+  — well under the ~700K ceiling; stopping here at a clean boundary (the terminal-contract row is now
+  fully Done across all three money paths).

--- a/disbot/services/blackjack_state.py
+++ b/disbot/services/blackjack_state.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import discord
 
 from services.blackjack_engine import new_deck as _new_deck
+from utils.terminal_guard import SettleOnceMixin
 from utils.tournaments import TournamentRegistration
 
 # ---------------------------------------------------------------------------
@@ -102,7 +103,7 @@ class _Game:
             self.dealer.append(self.deck.pop())
 
 
-class _PvPState:
+class _PvPState(SettleOnceMixin):
     def __init__(self, p1: int, p2: int, guild_id: int, bet: int, channel_id: int):
         self.p1 = p1
         self.p2 = p2

--- a/disbot/utils/terminal_guard.py
+++ b/disbot/utils/terminal_guard.py
@@ -24,13 +24,18 @@ controls cannot trigger a second settlement"* row in
 ``docs/planning/production-readiness/games-production-readiness-map-2026-06-12.md``
 and continues the BUG-0013 challenge-timer lineage (``docs/health/bug-book.md``).
 
-Mixin, not a base class, because game-state views intentionally extend
-``discord.ui.View`` directly (the documented divergence in ``views/base.py``)
-and a mixin composes without disturbing their bespoke lifecycle. It declares no
-``__init__`` — the class-level ``_settlement_claimed = False`` default is the
+Lives in ``utils/`` (not ``views/``) because the terminal state it guards lives
+in different layers: a ``discord.ui.View`` subclass for RPS PvP / the deathmatch
+bot-duel, but a plain ``services`` state object (``_PvPState``) for blackjack
+PvP. A shared helper needed by both ``services/`` and ``views/`` belongs in
+``utils/`` (``docs/helper-policy.md``), and ``services/`` may not import
+``views/`` at all. It is a mixin, not a base class, so it composes onto views
+that intentionally extend ``discord.ui.View`` directly (the documented
+divergence in ``views/base.py``) and onto bare state objects alike. It declares
+no ``__init__`` — the class-level ``_settlement_claimed = False`` default is the
 unclaimed state, and the first claim writes a per-instance attribute (``bool``
-is immutable, so the class attribute is never mutated and no state leaks
-between instances).
+is immutable, so the class attribute is never mutated and no state leaks between
+instances).
 """
 
 from __future__ import annotations

--- a/disbot/views/blackjack/pvp_view.py
+++ b/disbot/views/blackjack/pvp_view.py
@@ -191,6 +191,15 @@ async def _start_pvp(
 
 
 async def _resolve_pvp(state: _PvPState, channel: discord.TextChannel):
+    # Settle-once: ``_resolve_pvp`` is reachable from both players' finish
+    # callbacks and the instant-blackjack path; a re-entry (a per-player
+    # ``BlackjackView`` firing ``on_finish`` twice, or a late duplicate) would
+    # post a second result embed and re-call the (idempotent) wager settle.
+    # Claim the terminal transition synchronously before any await so the second
+    # caller short-circuits. (The ``_pvp.pop`` below stays — it drops the live
+    # match registry entry — but is no longer the de-facto double-settle guard.)
+    if not state.claim_settlement():
+        return
     key = frozenset({state.p1, state.p2})
     _pvp.pop(key, None)
     # PR G3 — match is fully resolved; drop the persisted gameplay row.

--- a/disbot/views/games/deathmatch_panel.py
+++ b/disbot/views/games/deathmatch_panel.py
@@ -23,10 +23,10 @@ from typing import TYPE_CHECKING
 import discord
 
 from utils import db, equipment
+from utils.terminal_guard import SettleOnceMixin
 from utils.ui_constants import GAME_COLOR
 from views.base import HubView
 from views.games.common import BackToPanelButton
-from views.terminal_guard import SettleOnceMixin
 
 if TYPE_CHECKING:
     # Type-only — the panel reuses the deathmatch cog's ``_Duel`` state class

--- a/disbot/views/rps/pvp_play.py
+++ b/disbot/views/rps/pvp_play.py
@@ -15,6 +15,7 @@ import logging
 import discord
 
 from services import game_state_service, game_wager_workflow
+from utils.terminal_guard import SettleOnceMixin
 from utils.ui_constants import GAME_COLOR, SUCCESS_COLOR
 from views.rps._helpers import (
     RPS_PVP_ESCROW_SUBSYSTEM,
@@ -22,7 +23,6 @@ from views.rps._helpers import (
     RPS_PVP_PENDING_VERSION,
     rps_pvp_canonical_user_id,
 )
-from views.terminal_guard import SettleOnceMixin
 
 logger = logging.getLogger("bot.rps.pvp_play")
 

--- a/docs/owner/claims/claude-funny-franklin-fwh3dh-bj.md
+++ b/docs/owner/claims/claude-funny-franklin-fwh3dh-bj.md
@@ -1,1 +1,0 @@
-claude/funny-franklin-fwh3dh-bj · settle-once guard for blackjack PvP settlement + relocate SettleOnceMixin to utils/ (cross-layer reuse) · disbot/utils/terminal_guard.py + services/blackjack_state.py + views/blackjack/pvp_view.py + the 2 prior adopters · 2026-06-24

--- a/docs/owner/claims/claude-funny-franklin-fwh3dh-bj.md
+++ b/docs/owner/claims/claude-funny-franklin-fwh3dh-bj.md
@@ -1,0 +1,1 @@
+claude/funny-franklin-fwh3dh-bj · settle-once guard for blackjack PvP settlement + relocate SettleOnceMixin to utils/ (cross-layer reuse) · disbot/utils/terminal_guard.py + services/blackjack_state.py + views/blackjack/pvp_view.py + the 2 prior adopters · 2026-06-24

--- a/docs/planning/production-readiness/games-production-readiness-map-2026-06-12.md
+++ b/docs/planning/production-readiness/games-production-readiness-map-2026-06-12.md
@@ -183,12 +183,14 @@ has one readiness disposition without turning the inventory into a method-per-ro
   (2026-06-24 dispatch run). Blackjack tournament timeout handlers still swallow silently.
 - **Partial:** Mining views inherit the shared BaseView lifecycle, but real Discord
   interaction expiry/defer/edit sequences have not been live-verified in this review.
-- **Partial (was Not Done — 2026-06-24 dispatch run):** the cross-game terminal contract now has a
-  shared **settle-once guard** (`disbot/views/terminal_guard.py` `SettleOnceMixin.claim_settlement()`)
-  adopted by **RPS PvP** (`_resolve`) and **deathmatch bot-duel** (`_finish`/`on_timeout`), with
-  regression tests proving a second settlement short-circuits (no duplicate result post, no redundant
-  wager settle). **Remaining adopters:** blackjack PvP/tournament settlement (the other money-handling
-  terminal path) — a follow-up PR adopts the same mixin.
+- **Done (was Not Done — 2026-06-24 dispatch run):** the cross-game terminal contract now has a shared
+  **settle-once guard** (`disbot/utils/terminal_guard.py` `SettleOnceMixin.claim_settlement()`) adopted by
+  all three money/terminal paths — **RPS PvP** (`_resolve`), **deathmatch bot-duel**
+  (`_finish`/`on_timeout`), and **blackjack PvP** (`_resolve_pvp`, via the `_PvPState` carrier) — each
+  with regression tests proving a second settlement short-circuits (no duplicate result post, no redundant
+  wager settle). The mixin lives in `utils/` so the `services`-layer `_PvPState` can adopt it without the
+  banned `services → views` import. *(Blackjack **tournament** settlement is a separate multi-round flow,
+  not a single-shot PvP settle; revisit if a double-settle vector is found there.)*
 
 ## Gated or accepted limitations
 

--- a/tests/unit/utils/test_terminal_guard.py
+++ b/tests/unit/utils/test_terminal_guard.py
@@ -14,7 +14,7 @@ _DISBOT = Path(__file__).parents[3] / "disbot"
 if str(_DISBOT) not in sys.path:
     sys.path.insert(0, str(_DISBOT))
 
-from views.terminal_guard import SettleOnceMixin  # noqa: E402
+from utils.terminal_guard import SettleOnceMixin  # noqa: E402
 
 
 class _Settleable(SettleOnceMixin):

--- a/tests/unit/views/test_blackjack_pvp_settle_once.py
+++ b/tests/unit/views/test_blackjack_pvp_settle_once.py
@@ -1,0 +1,86 @@
+"""Blackjack PvP settle-once contract.
+
+``_resolve_pvp`` is reachable from both players' finish callbacks and the
+instant-blackjack path. The ``SettleOnceMixin`` claim on ``_PvPState`` must make
+a second resolution a no-op — no duplicate result embed, no redundant (idempotent)
+wager settle. Part of the cross-game terminal contract
+(``docs/planning/production-readiness/games-production-readiness-map-2026-06-12.md``).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_DISBOT = Path(__file__).parents[3] / "disbot"
+if str(_DISBOT) not in sys.path:
+    sys.path.insert(0, str(_DISBOT))
+
+
+@pytest.mark.asyncio
+async def test_resolve_pvp_settles_once_no_double_payout_or_post():
+    from services.blackjack_state import _PvPState
+    from views.blackjack.pvp_view import _resolve_pvp
+
+    state = _PvPState(p1=100, p2=200, guild_id=111, bet=50, channel_id=333)
+    state.results = {100: 20, 200: 18}  # p1 wins
+    channel = MagicMock()
+    channel.send = AsyncMock()
+
+    with (
+        patch(
+            "views.blackjack.pvp_view._clear_pvp_match",
+            new_callable=AsyncMock,
+        ) as mock_clear,
+        patch(
+            "views.blackjack.pvp_view.game_wager_workflow.settle_pvp",
+            new_callable=AsyncMock,
+        ) as mock_settle,
+        patch(
+            "views.blackjack.pvp_view.game_wager_workflow.refund_pvp",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await _resolve_pvp(state, channel)
+        assert state.is_settled is True
+        # A racing duplicate resolution must do nothing.
+        await _resolve_pvp(state, channel)
+
+    mock_settle.assert_awaited_once()
+    channel.send.assert_awaited_once()
+    mock_clear.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resolve_pvp_tie_refunds_once():
+    from services.blackjack_state import _PvPState
+    from views.blackjack.pvp_view import _resolve_pvp
+
+    state = _PvPState(p1=100, p2=200, guild_id=111, bet=50, channel_id=333)
+    state.results = {100: 19, 200: 19}  # tie → refund
+    channel = MagicMock()
+    channel.send = AsyncMock()
+
+    with (
+        patch(
+            "views.blackjack.pvp_view._clear_pvp_match",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "views.blackjack.pvp_view.game_wager_workflow.settle_pvp",
+            new_callable=AsyncMock,
+        ) as mock_settle,
+        patch(
+            "views.blackjack.pvp_view.game_wager_workflow.refund_pvp",
+            new_callable=AsyncMock,
+        ) as mock_refund,
+    ):
+        await _resolve_pvp(state, channel)
+        await _resolve_pvp(state, channel)
+
+    mock_refund.assert_awaited_once()
+    mock_settle.assert_not_called()
+    channel.send.assert_awaited_once()


### PR DESCRIPTION
## What

Slice 2 of this dispatch run's settle-once work (PR #1444 was slice 1). Completes the money-path coverage
of the cross-game terminal contract: **blackjack PvP settlement**.

- **Relocate `SettleOnceMixin` → `disbot/utils/terminal_guard.py`** (from `disbot/views/`). Blackjack's
  terminal state object `_PvPState` lives in `services/`, and **`services/` may not import `views/`**
  (the zero-tolerance arch rule). The mixin is pure logic with no view dependency and is now needed by
  both layers, so per `docs/helper-policy.md` its correct home is `utils/`. The two existing adopters
  (RPS PvP, deathmatch bot-duel) and the unit test move to the new import path.
- **Adopt in blackjack PvP** (`views/blackjack/pvp_view.py`): `_PvPState(SettleOnceMixin)`; `_resolve_pvp`
  claims the terminal transition at the top, so a second settlement (a `BlackjackView` terminal firing
  `on_finish` twice, or any re-entry) short-circuits — no duplicate result embed, no redundant
  (idempotent) wager settle. The pre-existing `_pvp.pop(key, None)` was a de-facto guard that didn't
  short-circuit.

## Tests
- Relocated primitive unit test (now `tests/unit/utils/test_terminal_guard.py`).
- Blackjack regression test: a racing second `_resolve_pvp` settles/posts nothing.

## Scope / safety
Contained, reversible, behaviour-preserving except in the racy double-settle case. The relocation is a
pure move (same logic); RPS + deathmatch behaviour is unchanged. This flips the games-readiness map's
terminal-contract row to fully covered for all three money/terminal paths.

⚑ Self-initiated: completing a production-readiness correctness/safety row (FIX phase), no dispatch/owner
ask.

> Born-red until the session card flips to `complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Q5RePpRANA1a1XmDeMtAm)_