### PR TITLE
Grooming: promote two ideas into docs/ideas (preview-fork + settle-once arch guard)

### DIFF
--- a/.sessions/2026-06-24-idea-grooming.md
+++ b/.sessions/2026-06-24-idea-grooming.md
@@ -1,0 +1,69 @@
+# Session — 2026-06-24 · idea grooming (settle-once run, slice 3)
+
+> **Status:** `complete` — docs-only. Two ideas promoted into `docs/ideas/` + indexed. The standing
+> grooming/idea-ender (Q-0015 / Q-0089) for this dispatch run, after the two-PR settle-once arc
+> (#1444/#1445) merged. PR for this slice.
+
+**Trigger:** continuation of the settle-once dispatch run. With the main correctness arc shipped and
+merged, capacity remained, so I executed the standing **backlog-grooming + new-idea enders** as a small
+contained slice rather than leaving them only as session-log flags.
+
+## What shipped
+
+- **`docs/ideas/askuserquestion-preview-for-design-forks-2026-06-24.md`** — *grooming move* (Q-0015):
+  rescued the `AskUserQuestion` per-option `preview` idea out of `.sessions/2026-06-24-setup-log-channel-rework.md`,
+  where it was stranded (a strong idea a session log can't surface to grooming). It proposes rendering a
+  mockup of each option's resulting UX for design/UX forks — motivated by the same-day #1429→#1432 setup
+  rework.
+- **`docs/ideas/settle-once-architecture-guard-2026-06-24.md`** — *new idea* (Q-0089): a
+  `check_architecture` rule flagging a game view/state object whose settlement path is reachable from >1
+  trigger but doesn't adopt `SettleOnceMixin` — the CI ratchet form of the by-hand double-settle hunt
+  this run did across four views.
+- Both indexed in `docs/ideas/README.md` (the 2026-06-24 block). Dedup-checked before writing — neither
+  existed.
+
+## ✅ Verification
+
+`check_docs --strict` green (both new files reachable from the README index). Docs-only — no `disbot/`
+code, no test impact.
+
+## 💡 Session idea (Q-0089)
+
+Covered by the deliverable itself: the **settle-once architecture guard** is this session's new idea
+(now a backlog file, not just a log flag — which is exactly the anti-stranding behaviour the *other*
+promoted idea is about). Meta-note worth keeping: this slice is the answer to its own
+previous-session-review finding — *don't let a good idea die in the log it was born in* — applied in the
+same run that surfaced it.
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous: this run's **slice 2** (`2026-06-24-blackjack-settle-once.md`, PR #1445). **Did well:** caught
+the `services → views` layering trap *before* writing code and relocated the mixin to `utils/` at the
+root (helper-policy-correct), rather than hacking a local flag onto `_PvPState` — and named the residual
+(blackjack tournament) instead of silently skipping it. **Missed:** nothing in the slice itself; its own
+review already nailed the real lesson (choose a shared primitive's home by its *eventual* adopter set,
+not the first one). **System improvement this run as a whole surfaced:** strong session ideas kept
+needing rescue from logs across all three slices — the durable fix is the grooming discipline I just
+executed *plus* the standing reminder that an idea worth having is worth a `docs/ideas/` file the same
+session, not a log line a later grooming pass has to find. (No rule change proposed — Q-0089/Q-0015
+already mandate this; the gap was execution, which this slice closes.)
+
+## 📋 Doc audit (Q-0104)
+
+Two new idea files + index entries; `check_docs --strict` green. No `current-state.md` ledger entry (the
+ledger keys off merged code PRs; an idea-grooming docs PR is picked up by the next reconciliation pass).
+No owner decision. No binding-doc change.
+
+## 📤 Run report
+
+- **Run type:** routine · dispatch
+- **What shipped this slice:** a docs-only idea-grooming PR — 2 ideas promoted into `docs/ideas/` +
+  indexed. (This dispatch run also shipped #1444 + #1445, the settle-once correctness arc.)
+- **⚑ Self-initiated:** yes — the standing grooming + new-idea enders (Q-0015 / Q-0089), no dispatch/owner
+  ask. Docs-only, fully reversible.
+- **⚑ Owner-decisions:** none
+- **⚑ Owner-manual-steps:** none
+- **Bug-book:** unchanged.
+- **Remarks:** end of this dispatch run — three slices total (#1444 correctness, #1445 correctness, this
+  docs grooming). Handing off at a clean boundary; the next dispatch's startable work is the unchanged S1
+  queue (Project Moon runtime PR 1 · botsite React migration PR 2) per `current-state/S1-bot.md`.

--- a/docs/ideas/README.md
+++ b/docs/ideas/README.md
@@ -46,6 +46,18 @@ Current broad captures:
   (`build_help_menu_view` is embed-only across the codebase). Proposes one help-nav attachment seam so
   the card carries through Help too — closing the inconsistency at the root as the cards go universal.
   Subsystem: none.
+- [`askuserquestion-preview-for-design-forks-2026-06-24.md`](./askuserquestion-preview-for-design-forks-2026-06-24.md) —
+  **grooming promotion (2026-06-24, from a session log):** use `AskUserQuestion`'s per-option `preview`
+  field to render a mockup of each option's resulting UX for **design/UX forks**, so the owner picks the
+  option that *looks* best, not the one that *reads* safest. Motivated by the same-day #1429→#1432 setup
+  rework (a scope-narrowing answer read as final). Rescued from `.sessions/` so grooming can find it.
+  Subsystem: none.
+- [`settle-once-architecture-guard-2026-06-24.md`](./settle-once-architecture-guard-2026-06-24.md) —
+  **session-idea (2026-06-24, Q-0089) from the settle-once dispatch run (#1444/#1445):** a
+  `check_architecture` rule that flags a game view / state object whose settlement path (posts a result
+  or calls `settle_pvp`/`refund_pvp`) is reachable from >1 trigger but doesn't adopt `SettleOnceMixin` —
+  the CI ratchet form of the by-hand double-settle hunt that run did across four views. Warn-first, after
+  the mixin earns more trust. Subsystem: none.
 - [`btd6-runtime-mechanics-from-game-2026-06-23.md`](./btd6-runtime-mechanics-from-game-2026-06-23.md) —
   **owner-raised (2026-06-23):** get the BTD6 *runtime/simulation* layer (freeplay health/speed ramp,
   superceramic swap, per-round RBE & cash) **straight from the game** — the dump only exports entity

--- a/docs/ideas/askuserquestion-preview-for-design-forks-2026-06-24.md
+++ b/docs/ideas/askuserquestion-preview-for-design-forks-2026-06-24.md
@@ -1,0 +1,56 @@
+# Use `AskUserQuestion`'s per-option `preview` to show design-fork mockups
+
+> **Status:** `ideas`. Not a plan, not approval. Source code and the binding contracts win.
+> **Subsystem:** none — an agent-workflow / owner-interaction convention (touches no bot subsystem).
+
+> **Provenance:** first captured as a session idea in
+> `.sessions/2026-06-24-setup-log-channel-rework.md` (Q-0089), then re-surfaced twice in the
+> settle-once dispatch run (2026-06-24) as an example of a *strong idea stranded in a session log
+> where grooming can't find it*. Promoted here during the run's grooming pass (Q-0015) so it lives in
+> the backlog. The deeper lesson it carries — *don't let a good idea die in the log it was born in* —
+> is the reason this file exists.
+
+## The gap
+
+When an agent asks the maintainer to choose between design options with the `AskUserQuestion` tool, it
+passes each option a `label` + `description` — plain text. The tool **also supports a per-option
+`preview` field** that we don't use for design/UX forks. For a choice whose *whole point* is "which
+resulting screen do you want?", a text description under-communicates: the owner can't see what he's
+picking, so he picks the option that *reads* safest rather than the one that *looks* best.
+
+## The cost this caused (the motivating case)
+
+In the 2026-06-24 setup-log-channel work, the agent offered "Moderation log only (Recommended)" vs a
+two-channel multi-select as plain-text options. The owner picked the narrower "Recommended" one — read
+as a *permanent* scope cap — then clarified the next day he meant a *first slice* and wanted the richer
+flow. Result: a full PR (#1429) built and **reworked the same day** (#1432). Had each option rendered a
+quick mockup of its resulting step screen, the owner would likely have seen the richer flow was what he
+wanted and skipped the rework.
+
+## The idea
+
+For **design/UX-shaped** `AskUserQuestion` forks (not yes/no or factual questions), populate each
+option's `preview` with a compact rendering of that option's outcome:
+
+- the resulting embed/panel layout (an ASCII or fielded mock of the step screen),
+- or the concrete settings bundle it would apply,
+- or a before/after of the surface it changes.
+
+Pair it with a framing convention for **scope-narrowing** options: when one option is narrower than
+another, the question should state whether the narrow choice is a *final scope* or a *starting slice*
+(the second half of the motivating miss — recommending the narrowest option as "(Recommended)" without
+that framing is what nudged the misread).
+
+## Why it's worth having
+
+- Cheap: the tool already supports `preview`; this is a usage convention + a small per-option mock
+  builder, not new infrastructure.
+- Directly prevents the same-day-rework class (a real, logged cost).
+- Reinforces the self-improving-workflow premise: the owner *designs/visualizes*, so showing him the
+  visual of each fork is exactly the altitude he works at (`docs/owner/maintainer-working-profile.md`).
+
+## Not yet decided / open
+
+- Which question shapes qualify as "design forks" (a heuristic, or an explicit agent judgment call).
+- Whether to build a shared `preview`-mock helper or leave it per-call. Start per-call; promote to a
+  helper only if 2–3 uses share structure (helper-policy).

--- a/docs/ideas/settle-once-architecture-guard-2026-06-24.md
+++ b/docs/ideas/settle-once-architecture-guard-2026-06-24.md
@@ -1,0 +1,51 @@
+# A `check_architecture` rule: settling game paths must adopt `SettleOnceMixin`
+
+> **Status:** `ideas`. Not a plan, not approval. Source code and the binding contracts win.
+> **Subsystem:** none — an agent-tooling / CI-invariant idea (touches no bot subsystem at runtime).
+
+> **Provenance:** session idea (Q-0089) from the settle-once terminal-guard dispatch run
+> (2026-06-24, PRs #1444 + #1445). That run found the cross-game double-settlement class by **reading
+> four game views by hand** (RPS PvP, deathmatch bot-duel, blackjack PvP, plus the BUG-0013 challenge
+> view) and adopting the new `SettleOnceMixin` (`disbot/utils/terminal_guard.py`) in each. The manual
+> hunt is the part worth mechanizing.
+
+## The gap
+
+The double-settlement class is structural and recurring: a game view (or game state object) whose
+**settlement path** — it posts a result, or calls `game_wager_workflow.settle_pvp` / `refund_pvp`, or
+records a terminal result — is reachable from **more than one trigger** (a finishing button *and*
+`on_timeout`, or two players' finish callbacks). Without a single atomic claim, a racy second entry
+double-posts and re-settles. BUG-0013 was one instance; the 2026-06-24 run found three more. Nothing
+*prevents the next one* — a new game added next month repeats the pattern, and only a careful reviewer
+catches it.
+
+## The idea
+
+A `scripts/check_architecture.py` rule (or a standalone Q-0105 disposable guard) that flags a
+`discord.ui.View` subclass **or** a game state object when:
+
+1. it (or a method it owns) calls a wager-settle helper (`settle_pvp` / `refund_pvp`) or otherwise
+   posts a terminal result, **and**
+2. that settling method is reachable from `on_timeout` *or* a second trigger (a button callback, a
+   `on_finish` callback), **and**
+3. the class does **not** mix in `SettleOnceMixin` / call `claim_settlement()` on its settling path.
+
+The CI ratchet form of the by-hand review the run just did. Same shape as the existing
+`select_option_truncation` consistency rule (a structural footgun caught statically).
+
+## Why it's worth having
+
+- Turns "an agent noticed it" into "CI enforces it" for a money-safety class.
+- The target primitive now **exists and has proven itself** across three adopters (RPS, deathmatch,
+  blackjack) — so the rule has a concrete, stable thing to require, not a hypothetical.
+
+## Open / cautions
+
+- Static reachability of "settling method called from `on_timeout`" is the hard part — an AST rule may
+  need to be conservative (warn, allowlist) to avoid false positives on views that settle but are
+  single-trigger by construction.
+- **Build only after the mixin earns a couple more sessions of trust** (its own Q-0105 kill-switch
+  posture) — a guard that hard-fails CI on a still-young convention is premature. Warn-first first.
+- Dedup-checked `docs/ideas/` (2026-06-24): no existing settle-once / terminal-guard / double-settle
+  idea. Adjacent but distinct: `ultracode-worker-pr-scope-guard-2026-06-23.md` (a *diff-scope* guard,
+  not a runtime-safety one).


### PR DESCRIPTION
## What

Docs-only grooming slice closing out the settle-once dispatch run (after #1444 + #1445 merged). Executes
the standing backlog-grooming (Q-0015) + new-idea (Q-0089) enders by promoting two ideas out of session
logs into the groomable backlog:

- **`askuserquestion-preview-for-design-forks-2026-06-24.md`** — *grooming move*: rescued the
  `AskUserQuestion` per-option `preview` idea (render a mockup of each option's resulting UX for
  design/UX forks) from `.sessions/2026-06-24-setup-log-channel-rework.md`, where it was stranded.
  Motivated by the same-day #1429→#1432 setup rework.
- **`settle-once-architecture-guard-2026-06-24.md`** — *new idea*: a `check_architecture` rule flagging a
  game view/state object whose settlement path is reachable from >1 trigger but doesn't adopt
  `SettleOnceMixin` — the CI ratchet form of the by-hand double-settle hunt this run did across four views.

Both indexed in `docs/ideas/README.md`; dedup-checked before writing.

## Scope / safety
Docs-only. No `disbot/` code, no test impact. `check_docs --strict` green (both files reachable). Fully
reversible.

⚑ Self-initiated: the standing grooming/idea session-enders, no dispatch/owner ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Q5RePpRANA1a1XmDeMtAm)_