### PR TITLE
Essential Setup PR 2 — extras menu + "Check my setup"

### DIFF
--- a/.sessions/2026-06-25-essential-setup-pr2-extras-health.md
+++ b/.sessions/2026-06-25-essential-setup-pr2-extras-health.md
@@ -1,0 +1,17 @@
+# Session — 2026-06-25 · Essential Setup PR 2 — extras menu + "Check my setup"
+
+> **Status:** `in-progress` — building. Run type: routine · dispatch.
+
+## What I'm about to do
+
+Empty-fire dispatch run. The bug-book root-fix backlog is gated (BUG-0009 newest-towers is
+data-gated; BUG-0019 #1 is an owner design fork), so I take the explicit S1 ▶-next plan slice:
+**Essential Setup wizard restructure — PR 2** (the marquee S1 arc, plan
+`docs/planning/setup-wizard-restructure-plan-2026-06-24.md` §7). PR 2 = the **Extras menu** (the
+optional features the spine doesn't cover — each surfaced with its setup command) + the single
+**"Check my setup"** plain-language health button, both wired into the "All done" summary.
+
+Scope: additive, no new cog/command. New plain-language views in `disbot/views/setup/essential_setup.py`
+(jargon-guard-clean — the file is not in the baseline, so new copy must be plain). Tests in
+`tests/unit/views/setup/`.
+

--- a/.sessions/2026-06-25-essential-setup-pr2-extras-health.md
+++ b/.sessions/2026-06-25-essential-setup-pr2-extras-health.md
@@ -1,17 +1,78 @@
 # Session — 2026-06-25 · Essential Setup PR 2 — extras menu + "Check my setup"
 
-> **Status:** `in-progress` — building. Run type: routine · dispatch.
+> **Status:** `complete` — shipped. Run type: routine · dispatch.
 
-## What I'm about to do
+## What I did
 
 Empty-fire dispatch run. The bug-book root-fix backlog is gated (BUG-0009 newest-towers is
-data-gated; BUG-0019 #1 is an owner design fork), so I take the explicit S1 ▶-next plan slice:
-**Essential Setup wizard restructure — PR 2** (the marquee S1 arc, plan
-`docs/planning/setup-wizard-restructure-plan-2026-06-24.md` §7). PR 2 = the **Extras menu** (the
-optional features the spine doesn't cover — each surfaced with its setup command) + the single
-**"Check my setup"** plain-language health button, both wired into the "All done" summary.
+data-gated; BUG-0019 #1 is an owner design fork), so I took the explicit S1 ▶-next plan slice:
+**Essential Setup wizard restructure — PR 2** (plan
+`docs/planning/setup-wizard-restructure-plan-2026-06-24.md` §7). PR **#1449**.
 
-Scope: additive, no new cog/command. New plain-language views in `disbot/views/setup/essential_setup.py`
-(jargon-guard-clean — the file is not in the baseline, so new copy must be plain). Tests in
-`tests/unit/views/setup/`.
+Both additions hang off the "All done" summary (`EssentialSummaryView`), both plain-language (the
+jargon guard covers `essential_setup.py` — it's not in the baseline, so any banned term fails CI):
+
+- **More to set up (Extras menu)** — `ExtrasMenuView` + `build_extras_embed` + `_Extra`/`_EXTRAS`: a
+  one-screen menu of the seven optional features the spine doesn't cover (Hall of Fame `!starboard` ·
+  live member counts `!counters` · raid/new-account protection `!security` · image filtering `!imagemod`
+  · Thanks & Karma `!karma` · AI helper `!aimenu` · reaction roles `!reactroles`), each with what it does
+  + the command to open its full setup, and a Back button to the summary.
+- **Check my setup** — `build_check_setup_embed` over `services.setup_readiness.collect`: a "how set up
+  are you" headline + a ✅/➖ list of the six essentials in outcome language (no bindings/settings/
+  subsystem vocabulary), shown ephemerally.
+
+**Deviation noted (judgment over plan):** the original spec said each extra is "a one-action step". I
+surfaced each with its **setup command** (the discoverability win — the audit's core goal) rather than
+re-implementing every feature's config inside the spine (a much larger per-feature effort duplicating
+the existing panels). Full per-extra in-wizard config is a later follow-on. **Native giveaways are
+intentionally absent** — that subsystem isn't built yet; listing a command would mislead.
+
+Files: `disbot/views/setup/essential_setup.py` (+ ~190 LOC, additive — no new cog/command/artifact),
+`tests/unit/views/setup/test_essential_setup.py` (+11 tests, 57 total green). Docs de-staled: the plan
+(§7 + build-progress banner) and the S1 sector file. **CI mirror green** (`check_quality.py --full`:
+12534 passed; `check_architecture.py --mode strict`: 0 new; jargon guard: 0 new; `setup_wizard_sim.py`:
+PASS).
+
+## Handoff / next
+
+**S1 ▶ next = setup-wizard PR 3** (retire dead/legacy spine sections + **rework** the Advanced
+draft→Final-Review editor — Q-E: "currently most of it does not do anything"). PR 3 is heavier and
+riskier than PR 2 (it audits each Final-Review action and wires up or strips the dead ones), so it
+wants its own focused session and likely `needs-hermes-review`... *(retired — every PR auto-merges on
+green now, Q-0197)* — just open it born-red and let it merge on green. Other live S1 startables
+unchanged: Project Moon runtime PR 1 · botsite React-SPA migration PR 2.
+
+## 💡 Session idea (Q-0089)
+
+*Extras-menu live status badges* — the extras menu currently lists every optional feature with its
+command, but doesn't show whether each is already on. A cheap follow-up: have `build_extras_embed`
+take the same readiness snapshot `build_check_setup_embed` already fetches and prefix each extra with
+✅/➖ (and re-word "Open with `!x`" → "Already on — manage with `!x`" when configured). One readiness
+read, big discoverability gain — the operator instantly sees what's left. Captured here rather than a
+full idea file (it's a small, decided-lane follow-on to this PR, not a standalone concept).
+
+## ⟲ Previous-session review (Q-0102)
+
+Previous run = the **25th Q-0107 reconciliation pass** (band-#1440, #1441). It did the reconciliation
+discipline well — grouped ledger entries, trimmed to 20, reset the marker, planned a full next band
+with no THIN flag, and even caught/avoided the "claim in prose, forget the file edit" drift class by
+re-badging the band-#1410 record `historical`. One genuine miss: it left a **stale claim file**
+(`docs/owner/claims/claude-jolly-johnson-rqf8wt.md`, the band-#1380 pass, long since merged) in place —
+the per-claim-file layout (Q-0195) is supposed to be self-cleaning on session close, but a
+reconciliation routine that only touches docs apparently skipped the claim sweep. **System
+improvement:** `scripts/check_session_log.py` (or the Stop hook) could flag claim files whose branch
+has no matching open PR *and* is already merged to `main` — a one-line "stale claim, delete it" nudge
+would close this leak. I deleted the stale claim this run.
+
+## 📤 Run report
+
+- **Run type:** routine · dispatch
+- **What shipped:** PR #1449 — Essential Setup PR 2 (extras menu + "Check my setup").
+- **⚑ Self-initiated:** none (took the explicit S1 ▶-next plan slice; the deviation is an
+  implementation choice within that slice, flagged above).
+- **⚑ Owner-decisions:** none (no new owner decisions; works within Q-0202–Q-0205, Q-A).
+- **⚑ Owner-manual-steps:** none (a merge auto-deploys; no data/seed step — no data file changed).
+- **Bug-book:** no entries fixed (the two open root-fix-backlog items stay gated); none newly opened.
+- **Doc audit (Q-0104):** ledger in sync (no merged-PR delta this run beyond the born-red card);
+  plan + S1 sector de-staled; deleted the stale `claude-jolly-johnson-rqf8wt` claim.
 

--- a/disbot/views/setup/essential_setup.py
+++ b/disbot/views/setup/essential_setup.py
@@ -1764,6 +1764,222 @@ class HelpDeskStep(_StepView):
 
 
 # ---------------------------------------------------------------------------
+# Extras menu — optional features the spine doesn't cover
+# ---------------------------------------------------------------------------
+#
+# Plan §5 "off-spine": the spine handles the universal essentials; everything
+# else the bot can do is offered here as a one-tap menu of extras you skipped
+# (reachable from the "All done" summary).  Each extra is surfaced with what it
+# does and the exact command to open its full setup — the discoverability win
+# the consolidation audit asked for — rather than re-implementing every
+# feature's config inside the spine (a much larger per-feature effort that would
+# duplicate the existing panels).  Native giveaways are intentionally absent:
+# that feature isn't built yet, so listing a command would mislead.
+
+
+@dataclass(frozen=True)
+class _Extra:
+    """One optional feature shown in the extras menu."""
+
+    emoji: str
+    label: str
+    blurb: str  # one plain line of what it does
+    command: str  # the command that opens its full setup
+
+
+_EXTRAS: tuple[_Extra, ...] = (
+    _Extra(
+        "🏆",
+        "Hall of Fame",
+        "pin the messages your members love the most",
+        "!starboard",
+    ),
+    _Extra(
+        "🔢",
+        "Live member counts",
+        "show member and online counts right in your channel list",
+        "!counters",
+    ),
+    _Extra(
+        "🛡️",
+        "Raid & new-account protection",
+        "slow down raids and hold brand-new accounts for a look",
+        "!security",
+    ),
+    _Extra(
+        "🖼️",
+        "Image filtering",
+        "catch unwanted images automatically",
+        "!imagemod",
+    ),
+    _Extra(
+        "🙏",
+        "Thanks & Karma",
+        "let members thank each other and build up reputation",
+        "!karma",
+    ),
+    _Extra(
+        "🤖",
+        "AI helper",
+        "let members ask the bot questions in plain language",
+        "!aimenu",
+    ),
+    _Extra(
+        "🎭",
+        "Reaction roles",
+        "let members pick their own roles by reacting",
+        "!reactroles",
+    ),
+)
+
+
+def build_extras_embed() -> discord.Embed:
+    """Render the one-screen extras menu (kept here so its copy stays plain)."""
+    embed = discord.Embed(
+        title="✨ More you can set up",
+        description=(
+            "These are all optional — turn on any that fit your server. "
+            "Run the command shown under each one to set it up."
+        ),
+        color=discord.Color.blurple(),
+    )
+    for extra in _EXTRAS:
+        embed.add_field(
+            name=f"{extra.emoji} {extra.label}",
+            value=f"{extra.blurb}\nOpen with `{extra.command}`",
+            inline=False,
+        )
+    return embed
+
+
+# ---------------------------------------------------------------------------
+# Check my setup — a plain-language health check
+# ---------------------------------------------------------------------------
+#
+# Plan §3: the read-only scan / readiness / diagnostics steps move *out* of the
+# completion path into one optional "Check my setup" button.  It reads the same
+# data the advanced diagnostics use (``services.setup_readiness.collect``) but
+# renders it in outcome language — a "how set up are you" headline plus a
+# ✅ / ➖ list of the essentials — with none of the bindings/settings vocabulary
+# the raw diagnostics embed exposes.
+
+#: Essentials shown in the health check, mapped to plain operator-facing labels.
+_CHECK_ESSENTIALS: tuple[tuple[str, str], ...] = (
+    ("welcome", "Greeting new members"),
+    ("moderation", "Moderator tools"),
+    ("automod", "Spam & bad-link protection"),
+    ("logging", "Activity logging"),
+    ("xp", "Member rewards"),
+    ("ticket", "Help desk"),
+)
+
+
+async def build_check_setup_embed(guild: discord.Guild) -> discord.Embed:
+    """Render the "Check my setup" health embed (plain language, no jargon)."""
+    from services import setup_readiness
+
+    report = await setup_readiness.collect(guild.id, guild=guild)
+    by_name = {sr.subsystem: sr for sr in report.per_subsystem}
+
+    lines: list[str] = []
+    done = 0
+    for key, label in _CHECK_ESSENTIALS:
+        sr = by_name.get(key)
+        configured = sr is not None and (sr.bindings_bound + sr.settings_configured) > 0
+        if configured:
+            done += 1
+        lines.append(f"{'✅' if configured else '➖'} {label}")
+
+    total = len(_CHECK_ESSENTIALS)
+    if done == total:
+        headline = "🎉 Everything essential is set up — nice work!"
+        color = discord.Color.green()
+    elif done == 0:
+        headline = "Nothing essential is set up yet — run setup to get started."
+        color = discord.Color.orange()
+    else:
+        headline = f"You've set up **{done} of {total}** essentials so far."
+        color = discord.Color.blurple()
+
+    embed = discord.Embed(
+        title="🔎 How set up are you?",
+        description=headline,
+        color=color,
+    )
+    embed.add_field(name="Essentials", value="\n".join(lines), inline=False)
+    if done < total:
+        embed.add_field(
+            name="Want to finish the rest?",
+            value=(
+                "Run setup again any time — each step saves the moment you "
+                "press its button, so you only do what's left."
+            ),
+            inline=False,
+        )
+    return embed
+
+
+class _ExtrasMenuButton(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            label="More to set up",
+            emoji="✨",
+            style=discord.ButtonStyle.primary,
+            row=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: EssentialSummaryView = self.view  # type: ignore[assignment]
+        extras = ExtrasMenuView(view.flow)
+        await interaction.response.edit_message(embed=extras.render(), view=extras)
+
+
+class _CheckSetupButton(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            label="Check my setup",
+            emoji="🔎",
+            style=discord.ButtonStyle.secondary,
+            row=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        guild = interaction.guild
+        if guild is None:
+            await interaction.response.send_message(_NOT_IN_SERVER, ephemeral=True)
+            return
+        embed = await build_check_setup_embed(guild)
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+class _BackToSummaryButton(discord.ui.Button):  # type: ignore[type-arg]
+    def __init__(self) -> None:
+        super().__init__(
+            label="Back",
+            emoji="◀",
+            style=discord.ButtonStyle.secondary,
+            row=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view: ExtrasMenuView = self.view  # type: ignore[assignment]
+        summary = EssentialSummaryView(view.flow)
+        await interaction.response.edit_message(embed=summary.render(), view=summary)
+
+
+class ExtrasMenuView(BaseView):
+    """The optional-extras menu, opened from the "All done" summary."""
+
+    def __init__(self, flow: EssentialFlow) -> None:
+        super().__init__(flow.author, public=False, timeout=600)
+        self.flow = flow
+        self.add_item(_BackToSummaryButton())
+
+    def render(self) -> discord.Embed:
+        return build_extras_embed()
+
+
+# ---------------------------------------------------------------------------
 # Summary (after the last step)
 # ---------------------------------------------------------------------------
 
@@ -1791,6 +2007,8 @@ class EssentialSummaryView(BaseView):
         super().__init__(flow.author, public=False, timeout=600)
         self.flow = flow
         self.add_item(_FinishButton())
+        self.add_item(_ExtrasMenuButton())
+        self.add_item(_CheckSetupButton())
 
     def render(self) -> discord.Embed:
         embed = discord.Embed(
@@ -1815,6 +2033,15 @@ class EssentialSummaryView(BaseView):
                 value="\n".join(f"• {line}" for line in self.flow.skipped),
                 inline=False,
             )
+        embed.add_field(
+            name="What next?",
+            value=(
+                "✨ **More to set up** — optional extras like a Hall of Fame, "
+                "reaction roles, or an AI helper.\n"
+                "🔎 **Check my setup** — a quick look at what's on and what isn't."
+            ),
+            inline=False,
+        )
         return embed
 
 

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -56,8 +56,10 @@
   (owner-directed, 2026-06-24):** Essential Setup is now the **primary `!setup` / `/setup`** (was
   `!quicksetup`); the old section-list wizard moved to **`!setupadvanced` / `/setup-advanced`**; Essential
   Setup now opens in a separate **`#superbot-setup`** channel (not the invoking channel) and is what the
-  on-join launcher's **Start Setup** opens. **▶ Next:** PR 2 (extras menu + "Check my setup") · PR 3
-  (retire dead/legacy sections + rework the Advanced editor). Tracker:
+  on-join launcher's **Start Setup** opens. **PR 2 (extras menu + "Check my setup") SHIPPED 2026-06-25**
+  (dispatch run) — the "All done" summary now offers **More to set up** (a plain menu of the optional
+  features the spine skips, each with its setup command) + **Check my setup** (a jargon-free readiness
+  health check). **▶ Next:** PR 3 (retire dead/legacy sections + rework the Advanced editor). Tracker:
   [`planning/setup-wizard-restructure-plan-2026-06-24.md`](../planning/setup-wizard-restructure-plan-2026-06-24.md).
 - **✅ Consolidation / discoverability audit — COMPLETE (owner-directed, 2026-06-23).** All five goals
   shipped and CI-guarded where possible. Staging brief + per-cog rubric:

--- a/docs/owner/claims/claude-funny-franklin-krp063.md
+++ b/docs/owner/claims/claude-funny-franklin-krp063.md
@@ -1,0 +1,1 @@
+claude/funny-franklin-krp063 · Essential Setup PR 2 (extras menu + Check-my-setup) · disbot/views/setup/essential_setup.py + tests/unit/views/setup/ · 2026-06-25

--- a/docs/owner/claims/claude-funny-franklin-krp063.md
+++ b/docs/owner/claims/claude-funny-franklin-krp063.md
@@ -1,1 +1,0 @@
-claude/funny-franklin-krp063 · Essential Setup PR 2 (extras menu + Check-my-setup) · disbot/views/setup/essential_setup.py + tests/unit/views/setup/ · 2026-06-25

--- a/docs/owner/claims/claude-jolly-johnson-rqf8wt.md
+++ b/docs/owner/claims/claude-jolly-johnson-rqf8wt.md
@@ -1,1 +1,0 @@
-claude/jolly-johnson-rqf8wt · docs reconciliation band-#1380 (Q-0107 pass 23) · docs/current-state*.md + planning/ + ideas/ + dashboard export · 2026-06-24

--- a/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
+++ b/docs/planning/setup-wizard-restructure-plan-2026-06-24.md
@@ -16,8 +16,9 @@
 > §5/§7 below). **Cutover (owner-directed, 2026-06-24):** Essential Setup is now the primary **`!setup` /
 > `/setup`** (was `!quicksetup`); the old section-list wizard moved to **`!setupadvanced` /
 > `/setup-advanced`**; Essential Setup now opens in a separate **`#superbot-setup`** channel (not the
-> invoking channel) and is what the on-join launcher's **Start Setup** opens. **Remaining:** **PR 2** =
-> extras menu + "Check my setup", **PR 3** = retire dead/legacy sections + rework the Advanced editor (Q-E).
+> invoking channel) and is what the on-join launcher's **Start Setup** opens. **PR 2 (extras menu +
+> "Check my setup") SHIPPED 2026-06-25** (dispatch run — both reachable from the "All done" summary; §7).
+> **Remaining:** **PR 3** = retire dead/legacy sections + rework the Advanced editor (Q-E).
 >
 > **Sim:** [`tools/sim/setup_wizard_sim.py`](../../tools/sim/setup_wizard_sim.py) (runnable) —
 > models a non-technical owner walking the flow. Current standard-depth flow scores **~4% finish**
@@ -219,10 +220,21 @@ decision with architectural weight → called out as open question Q-A below.
   primary button unified to **"Save & continue"** on a consistent row, the skip-recap summary bug fixed
   (`record_skipped` was never called), and an optional **"✏️ Type a name" modal** added wherever the bot
   auto-creates a named role/channel (typing always optional, defaults stay fully selectable).
-- **PR 2 — extras + health check:** the **Extras menu** (each existing config surface as a one-action
-  step: starboard, counters, security, image-mod, karma, AI, reaction roles, giveaways) + the single
-  **"Check my setup"** health button (folds in scan/readiness/diagnostics/suggestions). Wires the
-  bot-migration assistant in as the "Replace another bot" extra once that plan ships.
+- **PR 2 — extras + health check (SHIPPED 2026-06-25, dispatch run).** Both reachable from the "All
+  done" summary, both plain-language (the jargon guard covers `essential_setup.py`):
+  - **More to set up (Extras menu)** — `ExtrasMenuView` + `build_extras_embed`: a one-screen menu of the
+    optional features the spine doesn't cover (Hall of Fame `!starboard` · live member counts `!counters`
+    · raid/new-account protection `!security` · image filtering `!imagemod` · Thanks & Karma `!karma` ·
+    AI helper `!aimenu` · reaction roles `!reactroles`), each with what it does + the command to open its
+    full setup, and a Back button to the summary. **Deviation from the original spec:** each extra is
+    surfaced with its **setup command** (the discoverability win) rather than re-implementing every
+    feature's config inside the spine (a much larger per-feature effort duplicating the existing panels) —
+    full in-wizard config per extra is a later follow-on. **Native giveaways are intentionally absent**
+    (not built yet — listing a command would mislead; the bot-migration "Replace another bot" extra wires
+    in once [that plan](bot-migration-assistant-plan-2026-06-24.md) ships).
+  - **Check my setup** — `build_check_setup_embed`: a plain-language health check over
+    `services.setup_readiness.collect` — a "how set up are you" headline + a ✅/➖ list of the essentials
+    in outcome language (no bindings/settings/subsystem vocabulary), shown ephemerally.
 - **PR 3 — retire the dead/legacy sections:** delete or demote `purpose`(old), `identity`, `btd6`,
   `ai_setup`(link-only), `server_scan`/`readiness`/`diagnostics`/`suggestions` as *standalone spine
   sections* (their function now lives in step 0 / Check-my-setup), and move `cog_routing` + `cleanup`

--- a/tests/unit/views/setup/test_essential_setup.py
+++ b/tests/unit/views/setup/test_essential_setup.py
@@ -806,6 +806,133 @@ def test_summary_lists_applied_changes():
 
 
 # ---------------------------------------------------------------------------
+# Extras menu + Check my setup (PR 2)
+# ---------------------------------------------------------------------------
+
+
+def _find(view, button_cls):
+    """Return the first child of ``view`` that is an instance of ``button_cls``."""
+    return next(c for c in view.children if isinstance(c, button_cls))
+
+
+def test_summary_offers_extras_and_check_buttons():
+    flow = es.EssentialFlow(_member(), _guild())
+    view = es.EssentialSummaryView(flow)
+    assert any(isinstance(c, es._ExtrasMenuButton) for c in view.children)
+    assert any(isinstance(c, es._CheckSetupButton) for c in view.children)
+
+
+def test_extras_embed_lists_every_feature_with_its_command():
+    embed = es.build_extras_embed()
+    names = " ".join(f.name for f in embed.fields)
+    values = " ".join(f.value for f in embed.fields)
+    for extra in es._EXTRAS:
+        assert extra.label in names
+        assert extra.command in values
+
+
+def test_extras_menu_excludes_unbuilt_giveaways():
+    # Native giveaways aren't built yet — listing a command would mislead.
+    commands = {extra.command for extra in es._EXTRAS}
+    assert not any("giveaway" in cmd or cmd == "!gw" for cmd in commands)
+
+
+@pytest.mark.asyncio
+async def test_extras_button_opens_the_extras_menu():
+    flow = es.EssentialFlow(_member(), _guild())
+    summary = es.EssentialSummaryView(flow)
+    button = _find(summary, es._ExtrasMenuButton)
+    interaction = _interaction()
+
+    await button.callback(interaction)
+
+    interaction.response.edit_message.assert_awaited_once()
+    new_view = interaction.response.edit_message.await_args.kwargs["view"]
+    assert isinstance(new_view, es.ExtrasMenuView)
+
+
+@pytest.mark.asyncio
+async def test_extras_back_returns_to_summary():
+    flow = es.EssentialFlow(_member(), _guild())
+    extras = es.ExtrasMenuView(flow)
+    button = _find(extras, es._BackToSummaryButton)
+    interaction = _interaction()
+
+    await button.callback(interaction)
+
+    interaction.response.edit_message.assert_awaited_once()
+    new_view = interaction.response.edit_message.await_args.kwargs["view"]
+    assert isinstance(new_view, es.EssentialSummaryView)
+
+
+def _readiness_report(configured: set[str]):
+    """A ``ReadinessReport`` double: subsystems in ``configured`` read as set up."""
+    per = [
+        SimpleNamespace(
+            subsystem=key,
+            bindings_bound=1 if key in configured else 0,
+            settings_configured=0,
+        )
+        for key, _label in es._CHECK_ESSENTIALS
+    ]
+    return SimpleNamespace(per_subsystem=tuple(per))
+
+
+@pytest.mark.asyncio
+async def test_check_setup_embed_marks_configured_and_unconfigured():
+    report = _readiness_report({"welcome", "moderation"})
+    with patch("services.setup_readiness.collect", new=AsyncMock(return_value=report)):
+        embed = await es.build_check_setup_embed(_guild())
+
+    blob = (embed.description or "") + " ".join(f.value for f in embed.fields)
+    # Two of six essentials configured → the partial headline + per-line marks.
+    assert "2 of 6" in blob
+    assert "✅ Greeting new members" in blob
+    assert "➖ Help desk" in blob
+
+
+@pytest.mark.asyncio
+async def test_check_setup_embed_all_configured_celebrates():
+    report = _readiness_report({key for key, _ in es._CHECK_ESSENTIALS})
+    with patch("services.setup_readiness.collect", new=AsyncMock(return_value=report)):
+        embed = await es.build_check_setup_embed(_guild())
+    assert "Everything essential is set up" in (embed.description or "")
+    # Nothing left → no "want to finish the rest?" prompt.
+    assert not any("finish the rest" in f.name.lower() for f in embed.fields)
+
+
+@pytest.mark.asyncio
+async def test_check_setup_button_sends_ephemeral_health_embed():
+    flow = es.EssentialFlow(_member(), _guild())
+    summary = es.EssentialSummaryView(flow)
+    button = _find(summary, es._CheckSetupButton)
+    interaction = _interaction()
+    interaction.guild = _guild()
+    report = _readiness_report(set())
+
+    with patch("services.setup_readiness.collect", new=AsyncMock(return_value=report)):
+        await button.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    assert interaction.response.send_message.await_args.kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_check_setup_button_requires_a_server():
+    flow = es.EssentialFlow(_member(), _guild())
+    summary = es.EssentialSummaryView(flow)
+    button = _find(summary, es._CheckSetupButton)
+    interaction = _interaction()
+    interaction.guild = None
+
+    await button.callback(interaction)
+
+    interaction.response.send_message.assert_awaited_once()
+    msg = interaction.response.send_message.await_args.args[0]
+    assert "server" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
 # Restart revive (migration 099)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Empty-fire **dispatch** run. The bug-book root-fix backlog is gated (BUG-0009 newest-towers is data-gated; BUG-0019 #1 is an owner design fork), so this takes the explicit **S1 ▶-next** plan slice: **Essential Setup wizard restructure — PR 2** (plan `docs/planning/setup-wizard-restructure-plan-2026-06-24.md` §7).

## What PR 2 adds (the "All done" extras + health check)

The Essential Setup spine (steps 0–6) was complete and cut over to the primary `!setup` / `/setup`. PR 2 builds the two things the plan's "All done" step (§5 step 7) promised: *"a plain summary of what's on + a one-tap menu of extras you skipped"* and the *"Check my setup"* health button.

- **More to set up (Extras menu)** — a one-screen, plain-language menu of the optional features the spine doesn't cover (Hall of Fame · live member counts · raid & new-account protection · image filtering · Thanks & Karma · AI helper · reaction roles), each with what it does and the exact command to open its full setup. Reachable from the "All done" summary; Back returns to the summary.
- **Check my setup** — a plain-language readiness health check (built on `services.setup_readiness.collect`), shown ephemerally. Reports an overall "how set up are you" line + a ✅/➖ list of the essentials, in outcome language (no bindings/settings/subsystem jargon).

## Notes / deviation

- The extras menu surfaces each optional feature with its **setup command** (the discoverability deliverable — the audit's core goal) rather than re-implementing every feature's config inside the spine (a much larger per-feature effort that would duplicate existing panels). Full in-wizard config per extra stays a later follow-on.
- Native giveaways are **not** in the menu — that subsystem isn't built yet (it's a separate Next-candidate, "native giveaway PR 1"). Listing a command that doesn't exist would mislead.
- All new operator-facing copy is **jargon-guard-clean**: `essential_setup.py` is not in the jargon baseline, so any banned term would fail `test_no_new_setup_file_introduces_jargon`.

Verification: `check_quality.py --full`, `check_architecture.py --mode strict`, the new view tests, and `tools/sim/setup_wizard_sim.py` (must stay PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VyhJNB9UVJW8kaRrTSYpaP

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyhJNB9UVJW8kaRrTSYpaP)_