### PR TITLE
Route claim-GC automation (Q-0206) + Essential Setup badges follow-on

### DIFF
--- a/.sessions/2026-06-25-stale-claim-detector.md
+++ b/.sessions/2026-06-25-stale-claim-detector.md
@@ -1,0 +1,65 @@
+# Session — 2026-06-25 · slice 2 — route claim-GC + badges findings
+
+> **Status:** `complete` — docs/routing slice. Run type: routine · dispatch.
+
+## What this slice is (and the pivot)
+
+Slice 2 of this dispatch run (slice 1 = Essential Setup PR 2, merged #1449). I set out to **build** a
+stale-claim detector — the previous-session review (#1449's card) flagged that the 25th reconciliation
+pass left a stale claim (`claude-jolly-johnson-rqf8wt.md`, branch merged via #1407). **Investigation
+reversed the premise:** `scripts/check_stale_claims.py` **already exists** (built 2026-06-22, `--prune` +
+5 tests), works correctly (verified — it catches that exact branch), and the reconciliation routine
+prompt (`docs/operations/autonomous-routines.md` L162–163) **already mandates** running it with
+`--prune`. So the tool is sound; the stale claim survived because the routine **skipped its own GC
+step** across two passes. That's an execution-discipline gap, not a tooling gap — and the durable fix
+(automation) is a *workflow proposal*, which CLAUDE.md says I route to the owner, never apply myself.
+
+Also investigated (and dropped) the **extras-menu live status badges** follow-on to PR 2: it needs to
+map each extra to a readiness subsystem, but reaction-roles has **no dedicated readiness subsystem**
+(per-message data under `role`), and the schema registry is empty in an offline probe — so I can't
+verify the mapping without a running bot. Shipping badges that might show wrong status is worse than
+none (the repo's "verify against ground truth" rule). Routed, not built.
+
+## What shipped (docs/routing only)
+
+- **Router Q-0206 (DISCUSS)** — automate the claim-GC sweep so a skipped reconciliation step can't
+  leave stale claims (the tool exists; only its *invocation* is forgettable).
+- **S1 sector** — recorded the extras-badges follow-on (with its running-bot-verification blocker) in
+  the PR-2 polish tail, so a future bot-access session can do it correctly.
+
+No runtime code. CI mirror: `check_quality --check-only` + `check_docs --strict`.
+
+## 💡 Session idea (Q-0089)
+
+*A single plain-language "feature status" read model.* Building PR 2, both `build_check_setup_embed` and
+(the dropped) extras badges needed the same thing: "is feature X configured, in operator words?" Today
+that's an ad-hoc `_CHECK_ESSENTIALS` subsystem→label map plus a `setup_readiness` lookup, re-derived per
+surface. A small `services`/`utils` read model — `feature_status(guild) -> {plain_label: on/off}` over
+`setup_readiness.collect`, with one canonical subsystem→plain-label table — would let Check-my-setup, the
+extras menu badges, the on-join welcome, and any future setup surface share one verified mapping (and is
+exactly what would unblock the badges follow-on cleanly). One source of truth for "what's set up."
+
+## ⟲ Previous-slice note (Q-0102 — run-level review in #1449's card)
+
+This slice's own lesson: my slice-1 previous-session review *recommended building* a stale-claim
+detector that **already existed** — I proposed a fix without first grepping for it. The discipline
+Q-0200 is pushing (grep before defining) generalizes to *review notes too*: before proposing "we should
+build X", `grep`/`ls` for X. I caught it here only because slice 2 started by reading the claims README,
+which name-dropped the existing script. Cheap habit, real save.
+
+## 📤 Run report (whole dispatch run — slices 1 + 2)
+
+- **Run type:** routine · dispatch
+- **What shipped:** **PR #1449** (merged) — Essential Setup PR 2 (extras menu + Check-my-setup); **this
+  PR** — docs/routing: router **Q-0206** (DISCUSS, claim-GC automation) + S1 badges follow-on note.
+- **⚑ Self-initiated:** none built unprompted (slice 1 = explicit S1 ▶-next plan slice; slice 2 = routing
+  findings from slice-1's mandated review + grooming enders — no self-promoted idea→build).
+- **⚑ Owner-decisions:** **Q-0206 raised (DISCUSS, needs owner)** — automate the claim-GC sweep.
+- **⚑ Owner-manual-steps:** none (merges auto-deploy; no data/seed step — no data file changed).
+- **Bug-book:** none fixed (the two open root-fix-backlog items stay gated); none newly opened.
+- **Doc audit (Q-0104):** ledger in sync; plan + S1 sector de-staled (slice 1); router + S1 updated
+  (slice 2); deleted the stale `claude-jolly-johnson-rqf8wt` claim on sight.
+- **Handoff (▶ Next):** S1 = setup-wizard **PR 3** (retire dead spine sections + rework the Advanced
+  draft→Final-Review editor, Q-E) — heavier/own-session. The extras-badges follow-on + Q-0206 are
+  captured for a future bot-access / owner-decision pickup. Other S1 startables unchanged (Project Moon
+  PR 1 · botsite React PR 2).

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -77,7 +77,11 @@
     `HubChildButton` (#1371/#1373); `views/navigation.py` `attach_standard_nav` (#1382).
   - **▶ Remaining (optional polish tail, not blocking):** the setup-wizard **per-section walk** (fleet
     unit U10 — confirm every *manual* section yields a real op / honest link-only; the AI-describe side
-    is done) · the **visual card-engine migration** — engine **H2** *renderer-dedup* half **🟡 partially
+    is done) · **Essential Setup extras-menu live status badges** (follow-on to PR 2 #1449 — prefix each
+    extra with ✅/➖ using the same `setup_readiness.collect` snapshot `build_check_setup_embed` already
+    fetches; **blocked on running-bot verification** — reaction-roles has no dedicated readiness
+    subsystem, so the extra→subsystem mapping can't be confirmed offline; a bot-access session should
+    do it) · the **visual card-engine migration** — engine **H2** *renderer-dedup* half **🟡 partially
     shipped (welcome / UX-lab leaderboard+poster / role-menu rebased onto `CardCanvas`, 2026-06-24
     dispatch run)**; the **leaderboard card now ships as a real feature** (`!leaderboard` attaches a
     rendered top-N image with embed fallback, 2026-06-24 dispatch run) — remaining H2 is only the

--- a/docs/owner/maintainer-question-router.md
+++ b/docs/owner/maintainer-question-router.md
@@ -7482,3 +7482,40 @@ presets, and suggested names are unchanged.
 
 **Home:** this Q-block (canonical) + `.sessions/2026-06-24-setup-spine-polish.md` + the plan §7 PR-1 note.
 Related: **Q-0202**/**Q-0203**/**Q-0204** (the per-step spine decisions), **Q-A** (direct-apply per step).
+
+### Q-0206 — DISCUSS: automate the claim-GC sweep so a skipped reconciliation step can't leave stale claims (2026-06-25)
+
+> **PROPOSED — surfaced by a dispatch run (2026-06-25).** Captured here, not applied: this is a
+> *workflow* change, which CLAUDE.md says an agent **proposes** (router DISCUSS), never self-applies.
+
+**The observation.** This dispatch run found a **stale claim file** left on `main`:
+`docs/owner/claims/claude-jolly-johnson-rqf8wt.md`, for a branch that merged via **#1407** (band-#1380,
+reconciliation pass 23). It survived **two** later reconciliation passes (24 and 25) before this run
+deleted it on sight (Q-0166 drift-on-sight).
+
+**Why it's not a tooling bug.** The guard already exists and works: `scripts/check_stale_claims.py`
+(built 2026-06-22, with `--prune` + 5 tests) correctly flags exactly this claim (re-verified this run —
+it reports the branch as `gone`). The reconciliation routine's saved prompt
+(`docs/operations/autonomous-routines.md` L162–163) **already mandates** running it with `--prune`.
+The claim lingered because the routine **skipped that step** — a forgettable manual sub-bullet. So the
+gap is **execution discipline**, and the durable fix is to make the sweep *not skippable*.
+
+**Options (owner's call — each is a different automation surface):**
+1. **A tiny scheduled / merge-triggered workflow** that runs `check_stale_claims.py --prune` and commits
+   the deletions. Most automatic; but an auto-commit-to-`main` workflow needs the recursion-guard care
+   the #778 class taught us, so it's the heaviest option.
+2. **A warn-only `code-quality` step** (`check_stale_claims.py`, advisory) so every PR run surfaces a
+   lingering stale claim in its log. Cheap + safe (never blocks merges; an *open* PR's own branch isn't
+   merged yet, so it's never falsely flagged), but it only *surfaces* — a human/agent still prunes.
+3. **Leave it manual but make the prompt step louder** — promote the GC line from a sub-bullet to a
+   first-class numbered step in the reconciliation procedure (lowest effort; relies on discipline,
+   which is exactly what failed here).
+4. **A Stop-hook advisory** (`scripts/claude_stop_check.py`) that flags a stale-claim count at session
+   close — but hooks are executable config an agent does not self-edit (Q-0106), so this is an
+   owner-only change.
+
+*Agent recommendation:* **option 2** (warn-only CI surfacing) as the cheap, safe, recursion-free
+default, optionally paired with **option 3**. Option 1 only if the owner wants it fully hands-off.
+
+**Home:** this Q-block (canonical) + `.sessions/2026-06-25-stale-claim-detector.md`. Related: **Q-0195**
+(one-file-per-claim), **Q-0166** (drift-on-sight), **Q-0105** (disposable-tool posture).


### PR DESCRIPTION
Slice 2 of a dispatch run (slice 1 = Essential Setup PR 2, **#1449**, merged). **Docs/routing only — no runtime code.**

## Why this is routing, not building

The slice-1 previous-session review flagged a **stale claim file** left on `main` (`claude-jolly-johnson-rqf8wt.md`, branch merged via #1407, survived two reconciliation passes) and suggested *building* a stale-claim detector. Investigation reversed that premise:

- `scripts/check_stale_claims.py` **already exists** (built 2026-06-22, with `--prune` + 5 tests) and **works** — re-verified this run, it catches that exact branch.
- The reconciliation routine prompt (`docs/operations/autonomous-routines.md` L162–163) **already mandates** running it with `--prune`.
- The claim lingered because the routine **skipped that step** — an execution-discipline gap, not a tooling gap.

The durable fix (make the sweep non-skippable) is a **workflow change**, which CLAUDE.md says an agent **proposes** (router DISCUSS), never self-applies. So:

## What's here

- **Router Q-0206 (DISCUSS)** — automate the claim-GC sweep; four options laid out (scheduled prune-commit workflow · warn-only `code-quality` step · louder prompt step · Stop-hook advisory), with an agent recommendation (warn-only CI surfacing).
- **S1 sector note** — records the **extras-menu live status badges** follow-on to PR 2 (✅/➖ per extra), with its blocker: reaction-roles has no dedicated readiness subsystem, so the extra→subsystem mapping can't be verified offline — a bot-access session should do it. (Investigated and *not* shipped this run rather than ship possibly-wrong status.)
- **Session card** for the run.

Verification: `check_docs.py --strict`, `check_quality.py --check-only`, session gate — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VyhJNB9UVJW8kaRrTSYpaP

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyhJNB9UVJW8kaRrTSYpaP)_