### PR TITLE
check_consistency Rule 6: settle-once money-safety adoption guard (warn-first)

### DIFF
--- a/.sessions/2026-06-25-settle-once-consistency-guard.md
+++ b/.sessions/2026-06-25-settle-once-consistency-guard.md
@@ -1,0 +1,23 @@
+# 2026-06-25 — settle-once money-safety CI guard (check_consistency Rule 6)
+
+> **Status:** `in-progress`
+> **Run type:** routine · dispatch
+> **Branch:** `claude/funny-franklin-ry0ygk` · **PR:** (born-red, opening)
+
+## What I'm about to do
+
+Scheduled dispatch fire, no work order. Survey found the headline ▶ items across sectors
+mostly gated (owner / prod creds / external-data / design-review) — Project Moon PR 2 and
+absence-guard Layer B both deliberately deferred for a Q-0086 runtime walk; setup PR 3b needs
+live-bot verification. So per Q-0172 I'm promoting a clean, decided-lane, offline-verifiable
+idea and building it:
+
+**`settle-once-architecture-guard-2026-06-24.md`** → a new `scripts/check_consistency.py`
+**Rule 6 (`settle_once_adoption`)**: a wager-settling site (a call to
+`game_wager_workflow.settle_pvp` / `refund_pvp`) must adopt the settle-once guard — either its
+enclosing class mixes in `SettleOnceMixin` / calls `claim_settlement()`, or its enclosing
+function calls `claim_settlement()` (the blackjack module-level-settle shape). Mechanizes the
+by-hand double-settlement review that found BUG-0013 + three more sites (PRs #1444/#1445), for
+a money-safety class. **Warn-first** (severity=`warning`, the idea's prescribed posture +
+the mixin is young) — cannot redden CI. Runs clean today (both wager-settle callers already
+adopt). Self-initiated (flagged on the run report).

--- a/.sessions/2026-06-25-settle-once-consistency-guard.md
+++ b/.sessions/2026-06-25-settle-once-consistency-guard.md
@@ -1,23 +1,126 @@
 # 2026-06-25 — settle-once money-safety CI guard (check_consistency Rule 6)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 > **Run type:** routine · dispatch
-> **Branch:** `claude/funny-franklin-ry0ygk` · **PR:** (born-red, opening)
+> **Branch:** `claude/funny-franklin-ry0ygk` · **PR:** #1454
 
-## What I'm about to do
+## What I did
 
-Scheduled dispatch fire, no work order. Survey found the headline ▶ items across sectors
-mostly gated (owner / prod creds / external-data / design-review) — Project Moon PR 2 and
-absence-guard Layer B both deliberately deferred for a Q-0086 runtime walk; setup PR 3b needs
-live-bot verification. So per Q-0172 I'm promoting a clean, decided-lane, offline-verifiable
-idea and building it:
+Scheduled dispatch fire, no work order → advance the next plan slice. The survey found the
+headline ▶ items across every sector **gated**: Project Moon PR 2 (the AI grounding wiring) and
+absence-guard **Layer B** are both deliberately deferred for a **Q-0086 runtime walk** (gated AI
+hot path — the previous run's explicit, well-reasoned deferral, which I respected); setup **PR 3b**
+needs live-bot verification; BTD6 decode items 3–4 are demand-driven / owner; BUG-0009's remaining
+slice is external-data-gated. This matches `current-state.md`'s own "honest caveat." Per **Q-0172**
+(idea→plan→ship is open when the queue is thin), I promoted a clean, decided-lane, **fully
+offline-verifiable** idea and built it.
 
-**`settle-once-architecture-guard-2026-06-24.md`** → a new `scripts/check_consistency.py`
-**Rule 6 (`settle_once_adoption`)**: a wager-settling site (a call to
-`game_wager_workflow.settle_pvp` / `refund_pvp`) must adopt the settle-once guard — either its
-enclosing class mixes in `SettleOnceMixin` / calls `claim_settlement()`, or its enclosing
-function calls `claim_settlement()` (the blackjack module-level-settle shape). Mechanizes the
-by-hand double-settlement review that found BUG-0013 + three more sites (PRs #1444/#1445), for
-a money-safety class. **Warn-first** (severity=`warning`, the idea's prescribed posture +
-the mixin is young) — cannot redden CI. Runs clean today (both wager-settle callers already
-adopt). Self-initiated (flagged on the run report).
+**Built — `check_consistency.py` Rule 6 (`settle_once_adoption`), warn-first (PR #1454):**
+promotes [`ideas/settle-once-architecture-guard-2026-06-24.md`](../docs/ideas/settle-once-architecture-guard-2026-06-24.md).
+A **wager-settling site** — a call to `game_wager_workflow.settle_pvp` / `refund_pvp` (which pay
+out / refund the escrowed pot) — must adopt the settle-once guard:
+
+- its **enclosing class** mixes in `SettleOnceMixin` or calls `claim_settlement()` (the RPS PvP
+  view shape), **or**
+- its **enclosing function** calls `claim_settlement()` (the blackjack module-level `_settle(state)`
+  shape, where the claim is `state.claim_settlement()`).
+
+A settle site with neither is flagged — the BUG-0013 double-settlement footgun (a finishing button
+*and* `on_timeout`, or two players' callbacks, racing into a second payout). It **mechanizes the
+by-hand review** that found BUG-0013 + three more sites (the `SettleOnceMixin` adopters, #1444/#1445)
+for a **money-safety class**.
+
+Conservative on purpose (the idea's prescribed posture): the **money leg only** (`settle_pvp` /
+`refund_pvp`). The fuzzier "posts a terminal result reachable from `on_timeout`" leg is deferred —
+too false-positive-prone for a warn-clean rule. **Warn-first** (`severity="warning"`) so it **cannot
+redden CI** (`--mode strict` only fails on `error` findings); graduates to `error` once it soaks
+clean a few sessions. Scopes `views/` + `services/` (a state object like `blackjack_state._PvPState`
+lives in `services/`); `game_wager_workflow` only *defines* the helpers (never calls them) so it is
+never matched.
+
+Also fixed **roadmap drift on sight** (Q-0166): the S1 `Now` line listed `▶ games P0-1 wager
+money-safety` as a startable item, but P0-1 **shipped #748** — corrected to mark it ✅ #748 plus the
+settle-once guard layer (#1444/#1445 + #1454).
+
+## Verification
+
+- `python3.10 scripts/check_consistency.py --graduation` → `settle_once_adoption  [warning]
+  findings=0 → ELIGIBLE` (runs clean: both wager-settle callers already adopt the guard).
+- `python3.10 -m pytest tests/unit/scripts/test_check_consistency.py -q` → **64 passed** (11 new
+  Rule-6 tests: unguarded-flag · class-mixin-clean · sibling-claim-clean · module-fn-clean ·
+  refund_pvp · definition-only-out-of-scope · services-scope · allowlist · registry · live-tree-clean).
+- `python3.10 scripts/check_quality.py --check-only` → **All checks passed** (incl. `check_consistency`
+  strict + `check_docs`).
+- `python3.10 scripts/check_current_state_ledger.py --strict` → exit 0 (benign newest-merge lag only).
+
+No `disbot/` runtime touched (a script + its test + docs), so mypy/runtime are unaffected.
+
+## Handoff (the continuation is current-state ▶ Next action)
+
+The unattended-clean queue is thin right now — the high-value next slices are **owner-attended**:
+
+- **Project Moon PR 2** — `AITask.PROJMOON_ANSWER` + a thin `projmoon_context_service` + route on
+  `has_limbus_context` into `core/runtime/ai/natural_language_stage.py`, reusing the BTD6
+  tag/cap/provenance render + the faithfulness guard. **Wants a Q-0086 runtime walk** — prose-grounding
+  faithfulness is the plan's "hardest correctness risk" and shouldn't ship unverified. House anchors in
+  [`planning/project-moon-knowledge-domain-plan-2026-06-21.md`](../docs/planning/project-moon-knowledge-domain-plan-2026-06-21.md) §5/§8.
+- **Setup PR 3b** (rework the Advanced draft→Final-Review editor, Q-E) — heavier, needs live-bot verification.
+- **Absence-guard Layer B** — design-for-review, needs prod creds.
+
+**Clean unattended next:** graduate `card_engine_helper_duplication` (added #1396, 2026-06-24) and
+this `settle_once_adoption` rule to `error` once each has soaked clean a couple more sessions (check
+`check_consistency.py --graduation`); then wire into `code-quality.yml`. Or the next BTD6 offline
+grounding-floor addition.
+
+## 💡 Session idea (Q-0089)
+
+**A `--graduation --json` mode + a "soak counter" for `check_consistency.py`.** Today a rule's
+graduation gate is "stay clean a couple more sessions," but *how many sessions it has been clean* is
+tracked only in human memory / the registry comment. A tiny soak-counter (the rule records the PR
+number it was added at; `--graduation` prints `clean for N merges since #added`) turns "has it soaked
+enough?" from a judgment call into a number — and `--json` lets the dispatch/reconciliation routine
+auto-surface ELIGIBLE-and-soaked rules as a ready-to-graduate nudge. Genuinely useful: it closes the
+loop on the warn-first→error lifecycle the linter already models but currently leaves to memory.
+Dedup-greped `docs/ideas/` — adjacent is the `--graduation` tracker itself (#1060, already built) and
+`success-metric-alignment-*`; no soak-counter idea exists. *(Captured here; not filed as a separate
+idea doc — small, lives in this log per the Q-0089 "substantial ones get a file" bar.)*
+
+## ⟲ Previous-session review (Q-0102)
+
+The previous run (Project Moon Limbus PR 1, #1453) did the **scoping** exactly right: it shipped a
+safe, fully-offline vertical (committed *patch-stable* structural data only) and **deliberately
+deferred** the fragile exact-number ingest *and* the AI-hot-path grounding wiring to a Q-0086 runtime
+walk — naming the deferral in both the session log and the plan's progress note. That clean,
+explicit handoff is precisely why this run could orient fast and respect the boundary rather than
+re-deriving it. One thing it could improve: it left the continuation only in its own log + the plan's
+inline note, not in the S1 `current-state` ▶ startable as a *gated* tag — so a scheduled unattended
+fire reads "Project Moon PR 2" as startable when it actually needs the owner. **System improvement
+this surfaces:** the per-sector ▶ startable lists should carry the same `▶/⛔/👤` gate tags the
+roadmap `Now` lines already use, so a *gated* next-slice is visibly gated at the dispatch-resolution
+point — not just in prose a routine has to read closely. (I applied the spirit of this in my handoff
+above by tagging each next slice with its gate; promoting that to a convention on the S-files is the
+durable fix — a candidate for the S3/S4 sector-map tooling.)
+
+## 📋 Doc audit (Q-0104)
+
+`check_current_state_ledger --strict` exit 0 (benign lag), `check_docs --strict` clean. New work is
+recorded in its durable homes: the idea doc carries a **Built** banner (PR #1454), the roadmap drift
+is fixed, the rule's provenance + reliability + graduation posture live in the registry comment +
+docstring (Q-0105 convention). No owner decision was made (the rule promotion is self-initiated per
+the standing Q-0172 lane, not a new decision), so the question router needs no entry. PR #1454 is a
+benign newer-than-marker merge the next reconciliation pass will record.
+
+## 📤 Run report
+
+- **Did:** built a warn-first money-safety CI guard (settle-once adoption) mechanizing the by-hand
+  double-settlement review · **Outcome:** shipped
+- **Shipped:** #1454 — `check_consistency.py` Rule 6 `settle_once_adoption` + 11 tests + idea-built
+  banner + roadmap drift fix
+- **Run type:** `routine · dispatch`
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** `none`
+- **⚑ Self-initiated:** promoted `ideas/settle-once-architecture-guard-2026-06-24.md` → built as
+  `check_consistency.py` Rule 6 (no dispatch/owner ask; Q-0172 lane)
+- **↪ Next:** the high-value slices (Project Moon PR 2 · setup PR 3b · absence-guard Layer B) are
+  owner-attended (Q-0086 runtime walk / live-bot / prod creds); clean unattended next = graduate the
+  two warn-first consistency rules once soaked, or the next BTD6 offline grounding-floor addition.

--- a/docs/ideas/settle-once-architecture-guard-2026-06-24.md
+++ b/docs/ideas/settle-once-architecture-guard-2026-06-24.md
@@ -1,7 +1,20 @@
 # A `check_architecture` rule: settling game paths must adopt `SettleOnceMixin`
 
-> **Status:** `ideas`. Not a plan, not approval. Source code and the binding contracts win.
+> **Status:** `ideas` — **money leg BUILT** (2026-06-25 dispatch run, PR #1454). Not approval.
+> Source code and the binding contracts win.
 > **Subsystem:** none — an agent-tooling / CI-invariant idea (touches no bot subsystem at runtime).
+
+> **▶ Built (2026-06-25 dispatch run, PR #1454):** the **money leg** shipped as
+> `check_consistency.py` **Rule 6 (`settle_once_adoption`)** — a call to
+> `game_wager_workflow.settle_pvp` / `refund_pvp` must adopt the settle-once guard (enclosing
+> class mixes in `SettleOnceMixin` / calls `claim_settlement()`, or the enclosing function calls
+> `claim_settlement()` — the blackjack module-level-settle shape). **Warn-first** (the posture
+> §"Open / cautions" prescribed — the mixin is young), runs clean today (both callers adopt),
+> scopes `views/` + `services/`. The **broader leg** below ("…*or otherwise posts a terminal
+> result*" reachable from `on_timeout`/a second trigger) is **deliberately deferred** — static
+> "settles via a result message reachable from `on_timeout`" detection is false-positive-prone,
+> and a warn-clean rule must stay precise (the §"Open / cautions" conservatism). Revisit once the
+> money leg graduates to `error` and the mixin has more adopters to key the structural leg on.
 
 > **Provenance:** session idea (Q-0089) from the settle-once terminal-guard dispatch run
 > (2026-06-24, PRs #1444 + #1445). That run found the cross-game double-settlement class by **reading

--- a/docs/owner/claims/claude-funny-franklin-ry0ygk.md
+++ b/docs/owner/claims/claude-funny-franklin-ry0ygk.md
@@ -1,0 +1,1 @@
+- `claude/funny-franklin-ry0ygk` · settle-once money-safety CI guard (check_consistency Rule 6) · `scripts/check_consistency.py` + tests + idea promotion · 2026-06-25

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -107,7 +107,8 @@
   #878** (`tests/evals/smoke.py`, CI-gated); **▶ Layer B** (the absence-guard negative-existential gate)
   is startable; the **⛔ live half** is creds-gated (owner-led P1-4); BUG-0009 open
   ([bug book](health/bug-book.md)). **The P0 integrity spine AND P1-2 are COMPLETE.** Product alternates
-  (owner-steered): **▶ games P0-1 wager money-safety** · **▶ mining structures/skill-tree**
+  (owner-steered): *(games **P0-1 wager money-safety ✅ #748**; the cross-game **settle-once** terminal
+  guard ✅ #1444/#1445 + its **CI adoption guard** ✅ #1454)* · **▶ mining structures/skill-tree**
   ([turn-key plan](planning/mining-structures-skill-tree-plan-2026-06-14.md) — Vault shipped #884;
   skill tree + cap + Forge/Home are startable; **⛔ V-16 phase 2** still owner PNG pack) ·
   **⛔ AI §7 workflow families** (post-prod-check).

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -16,6 +16,15 @@ rules that no import graph can catch (owner directive Q-0170, 2026-06-17):
      collection (``options[:25]``, ``roles[:25]``) instead of paginating.  A Discord
      select caps at 25 options, so the slice silently drops every entry past the cap
      (the #1040 class).  Windowed pagination (``x[start:start+N]``) is not flagged.
+  5. **card-engine helper duplication** — an image renderer (``utils/``) that
+     re-declares a primitive the shared ``utils/card_render.py`` engine already owns.
+  6. **settle-once adoption** — a wager-settling site (a call to
+     ``game_wager_workflow.settle_pvp`` / ``refund_pvp``, which pay out / refund the
+     escrowed pot) whose path does not adopt the settle-once guard
+     (``utils/terminal_guard.SettleOnceMixin`` / ``claim_settlement()``).  A money
+     settlement reachable from more than one trigger (a finishing button *and*
+     ``on_timeout``, or two players' callbacks) double-settles the pot without one
+     atomic claim — the BUG-0013 class the mixin (PRs #1444/#1445) closed by hand.
 
 Scope is **per-rule** (each :class:`Rule` carries a ``roots`` tuple).  Rules 1-2
 scan only ``views/``; rules 3-4 also scan ``cogs/`` — cogs define inline
@@ -870,6 +879,167 @@ def rule_card_engine_helper_duplication(
 
 
 # ---------------------------------------------------------------------------
+# Rule 6 — settle-once adoption (money-safety)
+# ---------------------------------------------------------------------------
+
+# The escrow-paying wager helpers (``services/game_wager_workflow.py``).  A call
+# to either *moves the pot* — a payout or a refund — so running it twice
+# double-settles.  These are the precise, unambiguous money-safety sites; the
+# fuzzier "posts a terminal result" leg the idea also sketches
+# (``settle-once-architecture-guard-2026-06-24.md``) is deliberately NOT
+# implemented here — static "settles via a result message reachable from
+# ``on_timeout``" detection is false-positive-prone, and a warn-clean rule must
+# stay precise (the idea's own "be conservative, warn-first" caution).
+_WAGER_SETTLE_CALLS = frozenset({"settle_pvp", "refund_pvp"})
+
+# The settle-once guard primitive (``utils/terminal_guard.py``).
+_SETTLE_ONCE_MIXIN = "SettleOnceMixin"
+_SETTLE_ONCE_CLAIM = "claim_settlement"
+
+
+def _calls_name_within(node: ast.AST, names: frozenset[str]) -> bool:
+    """True if any ``Call`` under *node* targets a name/attr in *names*.
+
+    Matches both a bare call (``settle_pvp(...)``) and an attribute call
+    (``game_wager_workflow.settle_pvp(...)`` / ``state.claim_settlement()``) by
+    its trailing name — the same shape ``_call_name`` / ``_call_attr`` read.
+    """
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Call) and (
+            _call_name(sub) in names or _call_attr(sub) in names
+        ):
+            return True
+    return False
+
+
+def _wager_settle_sites_with_scope(
+    tree: ast.Module,
+) -> list[tuple[ast.Call, ast.ClassDef | None, ast.AST]]:
+    """Yield each wager-settle call with its enclosing class + function nodes.
+
+    Walks with class/function scope tracked (the ``_front_truncations_with_scope``
+    pattern).  Each result is ``(call, enclosing_class_or_None, enclosing_func)``
+    where ``enclosing_func`` is the innermost ``def``/``async def`` containing the
+    call (or the module node when a settle call somehow sits at module top level —
+    that has no ``claim_settlement`` guard scope and is flagged, which is correct).
+    """
+    results: list[tuple[ast.Call, ast.ClassDef | None, ast.AST]] = []
+
+    def visit(
+        node: ast.AST,
+        cls: ast.ClassDef | None,
+        func: ast.AST,
+    ) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.ClassDef):
+                visit(child, child, func)
+                continue
+            if isinstance(child, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                visit(child, cls, child)
+                continue
+            if isinstance(child, ast.Call) and _call_attr(child) in _WAGER_SETTLE_CALLS:
+                results.append((child, cls, func))
+            visit(child, cls, func)
+
+    visit(tree, None, tree)
+    return results
+
+
+def _settle_site_is_guarded(
+    enclosing_class: ast.ClassDef | None,
+    enclosing_func: ast.AST,
+) -> bool:
+    """True if a wager-settle site adopts the settle-once guard.
+
+    Guarded when **either**:
+
+    - the enclosing class mixes in ``SettleOnceMixin`` (the RPS PvP / deathmatch
+      bot-duel view shape), **or**
+    - ``claim_settlement()`` is called anywhere in the enclosing class body (the
+      claim may live in a sibling method — e.g. RPS claims in ``_resolve`` and
+      settles in another method), **or**
+    - ``claim_settlement()`` is called anywhere in the enclosing function (the
+      blackjack module-level ``_settle(state)`` shape — ``state.claim_settlement()``
+      before the ``settle_pvp`` call, no enclosing class).
+    """
+    if enclosing_class is not None:
+        if _SETTLE_ONCE_MIXIN in _class_bases(enclosing_class):
+            return True
+        if _calls_name_within(enclosing_class, frozenset({_SETTLE_ONCE_CLAIM})):
+            return True
+    return _calls_name_within(enclosing_func, frozenset({_SETTLE_ONCE_CLAIM}))
+
+
+def rule_settle_once_adoption(
+    files: list[Path],
+    exceptions: dict,
+    roots: tuple[str, ...] = ("views/", "services/"),
+) -> list[Finding]:
+    """Flag a wager-settle site that does not adopt the settle-once guard.
+
+    A call to ``game_wager_workflow.settle_pvp`` / ``refund_pvp`` pays out or
+    refunds the escrowed pot.  When that settlement path is reachable from more
+    than one trigger (a finishing button *and* ``on_timeout``, or two players'
+    finish callbacks) without one atomic claim, a racy second entry double-settles
+    — a redundant payout and a duplicate result post (BUG-0013 + the three more
+    sites the 2026-06-24 run found by hand).  ``utils/terminal_guard.SettleOnceMixin``
+    closes that with one ``claim_settlement()`` per terminal transition.
+
+    This makes the by-hand review mechanical: every wager-settle site must adopt
+    the guard — its enclosing class mixes in ``SettleOnceMixin`` / calls
+    ``claim_settlement()``, or its enclosing function calls ``claim_settlement()``.
+    Universal adoption is the safe money-safety stance: a genuinely single-trigger
+    settle taking the claim is harmless (it always wins the first claim), so the
+    rule never asks for a wrong change.
+
+    Warn-only (Q-0105 — the mixin is young; graduate to ``error`` once it stays
+    clean across a few sessions).  Runs clean today (both callers adopt).  Scopes
+    ``views/`` + ``services/`` (the RPS/blackjack views call it; a state object
+    like ``blackjack_state._PvPState`` lives in ``services/``).  ``game_wager_workflow``
+    itself only *defines* ``settle_pvp``/``refund_pvp`` (never calls them), so it is
+    not matched.  Allowlist a verified single-trigger exception in
+    ``consistency_exceptions.yml``.
+    """
+    cfg = exceptions.get("settle_once_adoption", {})
+    findings: list[Finding] = []
+
+    for filepath, rel, tree in _iter_parsed(files, roots):
+        for call, enclosing_class, enclosing_func in _wager_settle_sites_with_scope(
+            tree,
+        ):
+            if _settle_site_is_guarded(enclosing_class, enclosing_func):
+                continue
+            scope_parts = [
+                p.name
+                for p in (enclosing_class, enclosing_func)
+                if isinstance(p, (ast.ClassDef, ast.AsyncFunctionDef, ast.FunctionDef))
+            ]
+            qualname = ".".join(scope_parts)
+            if _is_allowlisted(rel, qualname, cfg):
+                continue
+            findings.append(
+                Finding(
+                    file=filepath,
+                    line=call.lineno,
+                    rule="settle_once_adoption",
+                    qualname=qualname,
+                    message=(
+                        f"`{_call_attr(call)}(...)` pays out / refunds the escrow pot "
+                        f"in `{qualname}` but its path takes no settle-once claim — a "
+                        "second trigger (a finishing button + `on_timeout`, or two "
+                        "players' callbacks) double-settles. Mix in "
+                        "`utils.terminal_guard.SettleOnceMixin` and take "
+                        "`claim_settlement()` at the top of the settling path (before "
+                        "any `await`), or allowlist a verified single-trigger site in "
+                        "consistency_exceptions.yml"
+                    ),
+                ),
+            )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
 # Rule registry — add a (name, fn) entry per future rule
 # ---------------------------------------------------------------------------
 
@@ -952,6 +1122,21 @@ RULES: list[Rule] = [
         "image renderers re-declaring an engine helper (_fonts/_fit/_mix/_initials)",
         severity="warning",
         roots=("utils/",),
+    ),
+    # Rule 6 scans ``views/`` + ``services/`` (the wager-settle callers + state
+    # objects live in both). Warn-first (Q-0105): added 2026-06-25, promoting the
+    # ``settle-once-architecture-guard-2026-06-24.md`` idea — it mechanizes the
+    # by-hand double-settlement review (BUG-0013 + the three sites the #1444/#1445
+    # run found) for a money-safety class. The target primitive
+    # (``SettleOnceMixin``) is young, so this stays warn-only; it runs clean on the
+    # current tree (both wager-settle callers adopt the guard). Graduate to ``error``
+    # once it has stayed quiet across a few sessions (the edit_in_place pattern).
+    Rule(
+        "settle_once_adoption",
+        rule_settle_once_adoption,
+        "wager-settle sites (settle_pvp/refund_pvp) not adopting the settle-once guard",
+        severity="warning",
+        roots=("views/", "services/"),
     ),
 ]
 

--- a/tests/unit/scripts/test_check_consistency.py
+++ b/tests/unit/scripts/test_check_consistency.py
@@ -913,3 +913,187 @@ def test_rule_5_is_registered_and_scoped_to_utils(mod):
     rule = by_name["card_engine_helper_duplication"]
     assert rule.roots == ("utils/",)
     assert rule.severity == "warning"  # warn-first (Q-0105)
+
+
+# ---------------------------------------------------------------------------
+# Rule 6 — settle-once adoption (money-safety)
+# ---------------------------------------------------------------------------
+
+# A wager-settling view with NO settle-once guard (the double-settlement bug):
+# it pays out the escrow pot but takes no atomic claim, so a second trigger
+# (a finishing button + on_timeout) double-settles.
+_SETTLE_NO_GUARD = """\
+import discord
+
+from services import game_wager_workflow
+
+
+class _PvpView(discord.ui.View):
+    async def _resolve(self):
+        await game_wager_workflow.settle_pvp(self.match_id, winner=self.winner)
+
+    async def on_timeout(self):
+        await self._resolve()
+"""
+
+# The RPS PvP shape: the view mixes in SettleOnceMixin and claims in a sibling
+# method before settling — clean.
+_SETTLE_CLASS_MIXIN = """\
+import discord
+
+from services import game_wager_workflow
+from utils.terminal_guard import SettleOnceMixin
+
+
+class _PvpView(SettleOnceMixin, discord.ui.View):
+    async def _resolve(self):
+        if not self.claim_settlement():
+            return
+        await game_wager_workflow.settle_pvp(self.match_id, winner=self.winner)
+
+    async def on_timeout(self):
+        await self._resolve()
+"""
+
+# A class that does not inherit the mixin but calls self.claim_settlement() in a
+# sibling method — the guard is present in the class body, so it is clean.
+_SETTLE_CLASS_CLAIM = """\
+import discord
+
+from services import game_wager_workflow
+
+
+class _PvpView(discord.ui.View):
+    def _guard(self):
+        return self.claim_settlement()
+
+    async def _resolve(self):
+        if not self._guard():
+            return
+        await game_wager_workflow.refund_pvp(self.match_id)
+"""
+
+# The blackjack shape: a module-level settle function guarded by
+# state.claim_settlement() before the settle call (no enclosing class) — clean.
+_SETTLE_MODULE_FN = """\
+from services import game_wager_workflow
+
+
+async def _settle(state):
+    if not state.claim_settlement():
+        return
+    await game_wager_workflow.settle_pvp(state.match_id, winner=state.winner)
+"""
+
+# The workflow module itself only DEFINES settle_pvp/refund_pvp; it never calls
+# them, so the rule must not match a def (out of scope, not a double-settle site).
+_SETTLE_DEFINITION_ONLY = """\
+async def settle_pvp(match_id, winner):
+    return None
+
+
+async def refund_pvp(match_id):
+    return None
+"""
+
+
+def _settle_findings(mod, tmp_path, monkeypatch, src, *, rel="views/pvp.py"):
+    _write(mod, tmp_path, monkeypatch, rel, src)
+    return mod.rule_settle_once_adoption([tmp_path / rel], {})
+
+
+def test_settle_flags_unguarded_wager_settle(mod, tmp_path, monkeypatch):
+    findings = _settle_findings(mod, tmp_path, monkeypatch, _SETTLE_NO_GUARD)
+    assert len(findings) == 1
+    assert findings[0].rule == "settle_once_adoption"
+    assert findings[0].qualname == "_PvpView._resolve"
+    assert findings[0].severity == "warning"
+
+
+def test_settle_class_mixin_is_clean(mod, tmp_path, monkeypatch):
+    assert _settle_findings(mod, tmp_path, monkeypatch, _SETTLE_CLASS_MIXIN) == []
+
+
+def test_settle_class_claim_in_sibling_method_is_clean(mod, tmp_path, monkeypatch):
+    # The claim lives in a sibling method, not the settling one — the rule checks
+    # the whole enclosing class, so this is clean (the RPS resolve/settle split).
+    assert _settle_findings(mod, tmp_path, monkeypatch, _SETTLE_CLASS_CLAIM) == []
+
+
+def test_settle_module_level_function_with_claim_is_clean(mod, tmp_path, monkeypatch):
+    # The blackjack shape: a free function guarded by state.claim_settlement().
+    findings = _settle_findings(
+        mod, tmp_path, monkeypatch, _SETTLE_MODULE_FN, rel="services/bj_settle.py"
+    )
+    assert findings == []
+
+
+def test_settle_refund_pvp_is_also_a_settle_site(mod, tmp_path, monkeypatch):
+    # refund_pvp moves the pot too — an unguarded refund is the same class.
+    src = _SETTLE_NO_GUARD.replace("settle_pvp(self.match_id, winner=self.winner)",
+                                   "refund_pvp(self.match_id)")
+    findings = _settle_findings(mod, tmp_path, monkeypatch, src)
+    assert len(findings) == 1
+    assert "refund_pvp" in findings[0].message
+
+
+def test_settle_definition_only_module_is_out_of_scope(mod, tmp_path, monkeypatch):
+    # `def settle_pvp` is a definition, not a call — the workflow that owns the
+    # helpers must never be flagged.
+    findings = _settle_findings(
+        mod, tmp_path, monkeypatch, _SETTLE_DEFINITION_ONLY,
+        rel="services/game_wager_workflow.py",
+    )
+    assert findings == []
+
+
+def test_settle_rule_scans_services_layer(mod, tmp_path, monkeypatch):
+    # A state object in services/ that settles without a guard IS flagged (the
+    # rule scopes views/ + services/, so a service-layer state object is covered).
+    src = """\
+from services import game_wager_workflow
+
+
+class _PvPState:
+    async def resolve(self):
+        await game_wager_workflow.settle_pvp(self.match_id, winner=self.w)
+"""
+    findings = _settle_findings(
+        mod, tmp_path, monkeypatch, src, rel="services/bj_state.py"
+    )
+    assert len(findings) == 1
+    assert findings[0].qualname == "_PvPState.resolve"
+
+
+def test_settle_allowlist_suppresses_by_qualname(mod, tmp_path, monkeypatch):
+    _write(mod, tmp_path, monkeypatch, "views/pvp.py", _SETTLE_NO_GUARD)
+    cfg = {
+        "settle_once_adoption": {
+            "exceptions": [
+                {
+                    "pattern": "views/pvp.py::_PvpView._resolve",
+                    "reason": "verified single-trigger settle",
+                },
+            ],
+        },
+    }
+    assert mod.rule_settle_once_adoption([tmp_path / "views/pvp.py"], cfg) == []
+
+
+def test_rule_6_is_registered_and_scoped(mod):
+    by_name = {r.name: r for r in mod.RULES}
+    assert "settle_once_adoption" in by_name
+    rule = by_name["settle_once_adoption"]
+    assert rule.roots == ("views/", "services/")
+    assert rule.severity == "warning"  # warn-first (Q-0105)
+
+
+def test_settle_once_rule_runs_clean_on_the_live_tree(mod):
+    """The live tree's wager-settle callers all adopt the guard — the warn-first
+    prerequisite (0 findings) for a future graduation to error."""
+    findings = mod.rule_settle_once_adoption(
+        mod._all_files(), mod._load_exceptions(), ("views/", "services/")
+    )
+    assert findings == [], "settle_once_adoption flagged the live tree: " + "; ".join(
+        f.display(mod.REPO_ROOT) for f in findings
+    )


### PR DESCRIPTION
## What

Adds **Rule 6 (`settle_once_adoption`)** to `scripts/check_consistency.py` — a CI-invariant
that mechanizes the by-hand double-settlement review which found BUG-0013 + three more sites
(PRs #1444/#1445, the `SettleOnceMixin` adopters).

A **wager-settling site** — a call to `game_wager_workflow.settle_pvp` / `refund_pvp` (the
helpers that pay out / refund the escrowed pot) — must adopt the settle-once guard:

- its **enclosing class** mixes in `SettleOnceMixin` or calls `claim_settlement()` (the RPS
  PvP view shape), **or**
- its **enclosing function** calls `claim_settlement()` (the blackjack module-level-settle
  shape, where the claim is `state.claim_settlement()`).

A settle site with neither is flagged — the precise money-safety footgun where a racy second
entry (a finishing button *and* `on_timeout`, or two players' callbacks) double-settles the pot.

## Why

> Turns "an agent noticed it" into "CI enforces it" for a money-safety class.

The target primitive (`utils/terminal_guard.SettleOnceMixin`) now exists and has proven itself
across four adopters. Promotes idea `docs/ideas/settle-once-architecture-guard-2026-06-24.md`.

## Posture

- **Warn-first** (`severity="warning"`) — the idea's prescribed posture (the mixin is young;
  a guard that hard-fails CI on a still-young convention is premature). It **cannot redden CI**
  (`--mode strict` only fails on `error`-severity findings). Graduates to `error` once it stays
  clean a few sessions (the `--graduation` tracker + the existing rule-graduation discipline).
- **Runs clean today** — both wager-settle callers (`views/rps/pvp_play.py`,
  `views/blackjack/pvp_view.py`) already adopt the guard.
- Conservative scope (the money leg only — `settle_pvp`/`refund_pvp`). The fuzzier "posts a
  terminal result reachable from `on_timeout`" leg is deliberately deferred as too
  false-positive-prone for a warn-clean rule (noted in the rule docstring).
- Disposable per the Q-0105 kill-switch posture.

Self-initiated (Q-0172) — flagged on the run report. Routine · dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaaDx9DYpat2pMm5xT7c8y)_