### PR TITLE
Project Moon — Limbus Sinner literary origins (Slice A lore depth)

### DIFF
--- a/.sessions/2026-06-25-projmoon-sinner-literary-origins.md
+++ b/.sessions/2026-06-25-projmoon-sinner-literary-origins.md
@@ -1,18 +1,90 @@
 # Session — 2026-06-25 · Project Moon — Limbus Sinner literary origins
 
-> **Status:** `in-progress` — born-red card (Q-0133). Run type: routine · dispatch.
+> **Status:** `complete` — ready to merge (Q-0133). Run type: routine · dispatch.
 
-## What I'm about to do
+## What this run did
 
-Empty-fire dispatch → advance the S1 ▶ Project Moon program. PR 1 (#1453) shipped the standalone Limbus
-knowledge domain, but each of the 12 Sinners carries only a generic description ("one of the twelve fixed
+Empty-fire dispatch → advanced the S1 ▶ Project Moon program. PR 1 (#1453) shipped the standalone Limbus
+knowledge domain, but each of the 12 Sinners carried only a generic description ("one of the twelve fixed
 roster Sinners"). This run adds the **defining structural/lore fact** for each Sinner — its **canonical
-literary origin** (the work + author each Limbus Sinner is drawn from, e.g. Faust → Goethe, Outis →
-Homer's *Odyssey*, Gregor → Kafka's *Metamorphosis*) — as a provenanced `literary_origin` field, surfaced
-in the browse detail card + a new "Origins" cross-reference view.
+literary origin** (the work + author each Limbus Sinner is drawn from) — as a provenanced
+`literary_origin` field, surfaced in the browse detail card + a new "Origins" cross-reference view.
 
-Offline, read-only, no DB / no AI hot-path change (the gated AI grounding path stays PR 2). Advances the
-program's "browsable structured lookups + lore" goal.
+**PR #1456 — Limbus Sinner literary origins (Slice A lore depth).**
+- **Data** (`disbot/data/projmoon/limbus/sinners.json`): each of the 12 Sinners gains a
+  `literary_origin: {work, author}` (Yi Sang→Yi Sang's poetry, Faust→Goethe, Don Quixote→Cervantes,
+  Ryōshū→Akutagawa's *Hell Screen*, Meursault→Camus' *The Stranger*, Hong Lu→*Dream of the Red Chamber*,
+  Heathcliff→*Wuthering Heights*, Ishmael→*Moby-Dick*, Rodion→Dostoevsky's *Crime and Punishment*,
+  Sinclair→Hesse's *Demian*, Outis→Homer's *Odyssey*, Gregor→Kafka's *Metamorphosis*) plus a one-line
+  real description each; `data_version` bumped; README provenance updated (source literature noted).
+- **Service** (`projmoon_data_service.py`): `literary_origin` added to `_EXTRA_FIELDS["sinner"]` with
+  shape validation (must be a `{work, author}` mapping, both non-empty); a typed `sinner_origins()`
+  accessor + `SinnerOrigin` dataclass returns the roster-ordered cross-reference.
+- **Surface** (`views/projmoon/browse.py` + `project_moon_cog.py`): the detail card renders a "Literary
+  origin" line; a new `build_origins_embed()` lists all 12 ↔ their source work, reachable via a 📖
+  **Origins** browse-panel button and `!pm origins` (aliases `origin`/`literary`).
+- **Tests:** +7 (data: every-Sinner-has-origin, accessor full-roster + order, malformed-origin rejected;
+  cog/view: detail card shows origin, origins embed lists all 12, `!pm origins` command).
+
+Read-only, offline, no DB / no AI hot-path change (the gated AI grounding path stays PR 2).
 
 ## Verification
-- (pending) `check_quality.py --full` GREEN · `check_architecture --mode strict` exit 0.
+- `check_quality.py --full` GREEN (12499+ passed; the 4 generated-artifact tests went red on the new
+  `origins` command → regenerated via `scripts/export_dashboard_data.py`, re-confirmed green) ·
+  `check_architecture --mode strict` exit 0 (pre-existing rank_view WARN only) · `--check-only` all
+  green (black/isort/ruff/check_docs/check_consistency). One ruff COM812 + a black collapse on the new
+  button were fixed (multiline + trailing comma, matching the sibling buttons).
+
+## Deferred → PR 2 (needs live-bot / Q-0086 walk)
+The AI grounding path (`AITask.PROJMOON_ANSWER` + `projmoon_context_service` wired into
+`natural_language_stage.py`) stays the next slice — it touches the gated AI hot-path (faithfulness
+guard, deterministic floors) and wants a runtime walk; building it offline-byte-identical is feasible
+but the verification belongs to the owner's walk, so I did not force it this run. The `has_limbus_context`
+detector is already complete (Sinner names present, ambiguous ones deliberately excluded) — PR 2 reuses
+it as-is.
+
+## 💡 Session idea (Q-0089)
+*A committed-data ↔ keyword-detector coverage guard for knowledge domains.* The Limbus
+`literary_origin` data and the `has_limbus_context` keyword list both enumerate the same 12 Sinner names
+by hand, in two files, with no link — exactly the drift class BTD6 hit repeatedly (a new entity in the
+data, never added to the router keywords, so it never grounds). A tiny disposable check —
+`check_knowledge_domain_keywords.py` — could assert that every *distinctive* canonical name in
+`disbot/data/projmoon/limbus/*.json` (and the BTD6 dataset) is reachable by its domain's
+`has_*_context` detector (directly or via the resolver), flagging a data entity the router will never
+route. It turns "remember to also add it to keywords" into a CI invariant, and it generalises across the
+`KnowledgeDomain` seam the program is heading toward. (Genuinely useful, tied to today's two-list edit —
+not filler.)
+
+## ⟲ Previous-session review (Q-0102)
+The previous run (2026-06-25 setup-wizard PR 3a) did its best work in *disposition discipline*: retiring 7
+dead wizard sections by judging each against the plan's "does this step do real work?" rubric, and
+correctly splitting the contained offline half (PR 3a) from the live-bot half (PR 3b) instead of
+half-doing both. What it could have done better: nothing major — but its own Q-0102 note nailed a real
+gap, that the ▶ Next handoff mixes offline-buildable and needs-live-bot startables with no tag, and an
+autonomous run only learns which is which by spelunking the plan. **This run is direct evidence:** I
+spent a chunk of orient-time discovering that PR 3b (setup) *and* Project Moon PR 2 *and* botsite cutover
+are all needs-live-bot/owner-gated, and only the data-depth slice was cleanly offline. **System
+improvement it surfaces (carrying the prior note forward into a concrete proposal):** make the
+`offline` / `needs-live-bot` / `owner-gated` tag a **convention on every ▶ Next startable** in the
+per-sector `current-state/*` files, and teach `scripts/dispatch_menu.py --unattended` to read it directly
+rather than re-deriving fit from roadmap prose (its current `🟢/🟡/🔵` inference was close but listed a
+stale "P1-1 BTD6 eval cases" lane whose offline half already shipped). That would cut every autonomous
+run's orient cost. Worth a router DISCUSS block if it recurs once more.
+
+## Doc audit (Q-0104)
+Ledger in sync (`check_current_state_ledger --strict` green; the #1442–#1455 merges newer than the #1441
+marker are benign newest-merge lag, Q-0166). S1 sector ▶ Project Moon bullet + the plan progress banner
+de-staled to this slice. No owner decision this run (executes the owner-greenlit Q-0192 program along its
+stated Slice A lore arc). `check_docs --strict` + `check_consistency` green. Claim file deleted at close.
+
+## 📤 Run report
+- **Run type:** routine · dispatch
+- **What shipped:** **PR #1456** — Project Moon Limbus Sinner `literary_origin` data + `sinner_origins()`
+  accessor + the `!pm origins` / Origins-button cross-reference surface; +7 tests; dashboard data
+  regenerated; S1 sector + plan banner de-staled.
+- **⚑ Self-initiated:** none — this is the S1 ▶ Project Moon program (owner-directed Q-0192), advanced
+  along its own Slice A lore arc via an empty-fire dispatch.
+- **⚑ Owner-decisions:** none.
+- **⚑ Owner-manual-steps:** none (data + read-only surface; merge auto-deploys; no seed/data step).
+- **Bug-book:** none fixed (BUG-0009 newest-towers data-gated, BUG-0011 needs VPS repro, BUG-0019 #1
+  awaits an owner behavior decision — all stay OPEN).

--- a/.sessions/2026-06-25-projmoon-sinner-literary-origins.md
+++ b/.sessions/2026-06-25-projmoon-sinner-literary-origins.md
@@ -1,0 +1,18 @@
+# Session — 2026-06-25 · Project Moon — Limbus Sinner literary origins
+
+> **Status:** `in-progress` — born-red card (Q-0133). Run type: routine · dispatch.
+
+## What I'm about to do
+
+Empty-fire dispatch → advance the S1 ▶ Project Moon program. PR 1 (#1453) shipped the standalone Limbus
+knowledge domain, but each of the 12 Sinners carries only a generic description ("one of the twelve fixed
+roster Sinners"). This run adds the **defining structural/lore fact** for each Sinner — its **canonical
+literary origin** (the work + author each Limbus Sinner is drawn from, e.g. Faust → Goethe, Outis →
+Homer's *Odyssey*, Gregor → Kafka's *Metamorphosis*) — as a provenanced `literary_origin` field, surfaced
+in the browse detail card + a new "Origins" cross-reference view.
+
+Offline, read-only, no DB / no AI hot-path change (the gated AI grounding path stays PR 2). Advances the
+program's "browsable structured lookups + lore" goal.
+
+## Verification
+- (pending) `check_quality.py --full` GREEN · `check_architecture --mode strict` exit 0.

--- a/botsite/data/site.json
+++ b/botsite/data/site.json
@@ -1,14 +1,14 @@
 {
   "meta": {
-    "generated_at": "2026-06-25T06:11:34Z",
+    "generated_at": "2026-06-25T12:12:54Z",
     "build": {
-      "commit": "94657db6",
-      "subject": "chore(session): open born-red card — Project Moon Limbus knowledge domain PR 1",
-      "committed_at": "2026-06-25T06:11:34Z"
+      "commit": "4bf2f55d",
+      "subject": "chore(session): open born-red card — Project Moon Limbus Sinner literary origins",
+      "committed_at": "2026-06-25T12:12:54Z"
     }
   },
   "counts": {
-    "commands": 447,
+    "commands": 448,
     "features": 43,
     "games": 12
   },
@@ -6473,6 +6473,28 @@
         },
         {
           "title": "Idea — a reusable \"completeness-claim\" grounding primitive (the BUG-0009 net)",
+          "status": "ideas"
+        }
+      ],
+      "notes": null
+    },
+    {
+      "name": "origins",
+      "aliases": [
+        "origin",
+        "literary"
+      ],
+      "category": "games",
+      "cooldown": null,
+      "permissions": "user",
+      "usage": "Show every Sinner ↔ the literary work it is drawn from.",
+      "description": "Show every Sinner ↔ the literary work it is drawn from.",
+      "use_cases": null,
+      "examples": [],
+      "status": "in-progress",
+      "linked_ideas": [
+        {
+          "title": "Project Moon wiki as a bot knowledge domain — feasibility (2026-06-21)",
           "status": "ideas"
         }
       ],

--- a/botsite/site/data.js
+++ b/botsite/site/data.js
@@ -3545,6 +3545,27 @@ const COMMANDS = [
     ]
   },
   {
+    "name": "origins",
+    "area": "games",
+    "status": "in-progress",
+    "summary": "Show every Sinner ↔ the literary work it is drawn from.",
+    "description": "Show every Sinner ↔ the literary work it is drawn from.",
+    "usage": "!origins",
+    "aliases": [
+      "origin",
+      "literary"
+    ],
+    "permissions": "anyone",
+    "cooldown": null,
+    "examples": [],
+    "planned": [
+      {
+        "status": "idea",
+        "title": "Project Moon wiki as a bot knowledge domain — feasibility (2026-06-21)"
+      }
+    ]
+  },
+  {
     "name": "panel",
     "area": "other",
     "status": "finished",
@@ -6803,7 +6824,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.19",
     "date": "Jun 19, 2026",
-    "build": "94657db6",
+    "build": "4bf2f55d",
     "title": "New public bot website",
     "changes": [
       {
@@ -6815,7 +6836,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.12",
     "date": "Jun 12, 2026",
-    "build": "94657db6",
+    "build": "4bf2f55d",
     "title": "Owner review inbox on the dashboard",
     "changes": [
       {
@@ -6827,7 +6848,7 @@ const CHANGELOG = [
   {
     "version": "2026.06.08",
     "date": "Jun 08, 2026",
-    "build": "94657db6",
+    "build": "4bf2f55d",
     "title": "Command-alias suggestions",
     "changes": [
       {

--- a/dashboard/data/dashboard.json
+++ b/dashboard/data/dashboard.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "generated_at": "2026-06-25T11:26:32Z",
+    "generated_at": "2026-06-25T12:12:54Z",
     "build": {
-      "commit": "c45a6c19",
-      "subject": "Merge pull request #1454 from menno420/claude/funny-franklin-ry0ygk",
-      "committed_at": "2026-06-25T11:26:32Z"
+      "commit": "4bf2f55d",
+      "subject": "chore(session): open born-red card — Project Moon Limbus Sinner literary origins",
+      "committed_at": "2026-06-25T12:12:54Z"
     },
     "counts": {
       "functions": 43,
@@ -15,7 +15,7 @@
       "updates": 60,
       "env_vars": 39,
       "cogs": 54,
-      "commands": 447,
+      "commands": 448,
       "setting_keys": 107,
       "setting_domains": 16,
       "typed_settings": 88,
@@ -2547,6 +2547,14 @@
       "self_initiated": true
     },
     {
+      "file": "2026-06-25-projmoon-sinner-literary-origins.md",
+      "date": "2026-06-25",
+      "title": "Session — 2026-06-25 · Project Moon — Limbus Sinner literary origins",
+      "status": "in-progress",
+      "run_type": "",
+      "self_initiated": false
+    },
+    {
       "file": "2026-06-25-projmoon-limbus-domain.md",
       "date": "2026-06-25",
       "title": "2026-06-25 — Project Moon (Limbus) knowledge domain — runtime PR 1",
@@ -2992,14 +3000,6 @@
       "title": "2026-06-23 — Docs reconciliation pass (band-#1350, Q-0107)",
       "status": "complete",
       "run_type": "routine",
-      "self_initiated": false
-    },
-    {
-      "file": "2026-06-23-q0199-ai-setup-apply.md",
-      "date": "2026-06-23",
-      "title": "2026-06-23 — Record Q-0199 (AI-setup apply decision) in the router",
-      "status": "complete",
-      "run_type": "manual",
       "self_initiated": false
     }
   ],
@@ -8126,6 +8126,20 @@
             "what"
           ],
           "brief": "Resolve any Limbus name/term across every category.",
+          "classification": "",
+          "has_panel": false,
+          "button_backed": false
+        },
+        {
+          "name": "origins",
+          "type": "prefix",
+          "is_group": false,
+          "parent": "pm",
+          "aliases": [
+            "origin",
+            "literary"
+          ],
+          "brief": "Show every Sinner ↔ the literary work it is drawn from.",
           "classification": "",
           "has_panel": false,
           "button_backed": false

--- a/disbot/cogs/project_moon_cog.py
+++ b/disbot/cogs/project_moon_cog.py
@@ -36,6 +36,7 @@ from views.projmoon import (
     LimbusBrowseView,
     build_entry_embed,
     build_kind_embed,
+    build_origins_embed,
     build_overview_embed,
 )
 
@@ -128,6 +129,11 @@ class ProjectMoonCog(commands.Cog):
             )
             return
         await ctx.send(embed=build_entry_embed(entry))
+
+    @pm_group.command(name="origins", aliases=["origin", "literary"])  # type: ignore[arg-type]
+    async def pm_origins(self, ctx: commands.Context) -> None:
+        """Show every Sinner ↔ the literary work it is drawn from."""
+        await ctx.send(embed=build_origins_embed())
 
     @pm_group.command(name="sinner", aliases=["sinners"])  # type: ignore[arg-type]
     async def pm_sinner(self, ctx: commands.Context, *, name: str = "") -> None:

--- a/disbot/data/projmoon/limbus/README.md
+++ b/disbot/data/projmoon/limbus/README.md
@@ -16,7 +16,7 @@ domain shape can ship without the fragile exact-number ingest:
 
 | File | Entity kind | Contents |
 |---|---|---|
-| `sinners.json` | `sinner` | the 12 fixed LCB Sinners |
+| `sinners.json` | `sinner` | the 12 fixed LCB Sinners (+ each one's `literary_origin`) |
 | `sins.json` | `sin` | the 7 Sin affinities (+ colour) |
 | `damage_types.json` | `damage_type` | Slash / Pierce / Blunt |
 | `ego_grades.json` | `ego_grade` | ZAYIN → ALEPH (ranked) |
@@ -31,5 +31,6 @@ Treat the `statuses.json` mechanic descriptions as **verify-at-ingest** summarie
 
 Each file is `{ data_version, game_version, source, entity_kind, entries: [...] }`.
 Every entry has `id` (stable slug), `canonical` (display name), `aliases` (lowercased
-match tokens), and `description`. Some kinds add fields (`sins.color`, `ego_grades.rank`).
+match tokens), and `description`. Some kinds add fields (`sins.color`, `ego_grades.rank`,
+`sinners.literary_origin` — the `{work, author}` each Sinner is drawn from).
 Loaded + validated by `disbot/services/projmoon_data_service.py`.

--- a/disbot/data/projmoon/limbus/sinners.json
+++ b/disbot/data/projmoon/limbus/sinners.json
@@ -1,80 +1,92 @@
 {
-  "data_version": "2026-06-25",
+  "data_version": "2026-06-25b",
   "game_version": "Limbus Company (structural facts; roster stable)",
-  "source": "limbuscompany.wiki.gg (summarized; verify-at-ingest)",
+  "source": "limbuscompany.wiki.gg + the Sinners' source literature (summarized; verify-at-ingest)",
   "entity_kind": "sinner",
   "entries": [
     {
       "id": "yi_sang",
       "canonical": "Yi Sang",
       "aliases": ["yisang", "sang"],
-      "description": "LCB Sinner No. 1. The first of the twelve fixed roster members of Limbus Company."
+      "description": "LCB Sinner No. 1, drawn from the works of the Korean modernist poet Yi Sang.",
+      "literary_origin": {"work": "the poetry of Yi Sang (e.g. \"Crow's Eye View\")", "author": "Yi Sang"}
     },
     {
       "id": "faust",
       "canonical": "Faust",
       "aliases": [],
-      "description": "LCB Sinner No. 2. Limbus Company's knowledgeable strategist of the fixed roster."
+      "description": "LCB Sinner No. 2, Limbus Company's knowledgeable strategist, drawn from Goethe's Faust.",
+      "literary_origin": {"work": "Faust", "author": "Johann Wolfgang von Goethe"}
     },
     {
       "id": "don_quixote",
       "canonical": "Don Quixote",
       "aliases": ["don", "quixote", "donq"],
-      "description": "LCB Sinner No. 3. One of the twelve fixed roster Sinners of Limbus Company."
+      "description": "LCB Sinner No. 3, drawn from Cervantes' Don Quixote.",
+      "literary_origin": {"work": "Don Quixote", "author": "Miguel de Cervantes"}
     },
     {
       "id": "ryoshu",
       "canonical": "Ryōshū",
       "aliases": ["ryoshu", "ryshu"],
-      "description": "LCB Sinner No. 4. One of the twelve fixed roster Sinners of Limbus Company."
+      "description": "LCB Sinner No. 4, drawn from Akutagawa's Hell Screen (Jigokuhen).",
+      "literary_origin": {"work": "Hell Screen (Jigokuhen)", "author": "Ryūnosuke Akutagawa"}
     },
     {
       "id": "meursault",
       "canonical": "Meursault",
       "aliases": ["meur"],
-      "description": "LCB Sinner No. 5. One of the twelve fixed roster Sinners of Limbus Company."
+      "description": "LCB Sinner No. 5, drawn from Camus' The Stranger (L'Étranger).",
+      "literary_origin": {"work": "The Stranger (L'Étranger)", "author": "Albert Camus"}
     },
     {
       "id": "hong_lu",
       "canonical": "Hong Lu",
       "aliases": ["honglu", "hong"],
-      "description": "LCB Sinner No. 6. One of the twelve fixed roster Sinners of Limbus Company."
+      "description": "LCB Sinner No. 6, drawn from Cao Xueqin's Dream of the Red Chamber.",
+      "literary_origin": {"work": "Dream of the Red Chamber", "author": "Cao Xueqin"}
     },
     {
       "id": "heathcliff",
       "canonical": "Heathcliff",
       "aliases": ["heath", "cliff"],
-      "description": "LCB Sinner No. 7. One of the twelve fixed roster Sinners of Limbus Company."
+      "description": "LCB Sinner No. 7, drawn from Emily Brontë's Wuthering Heights.",
+      "literary_origin": {"work": "Wuthering Heights", "author": "Emily Brontë"}
     },
     {
       "id": "ishmael",
       "canonical": "Ishmael",
       "aliases": ["ish"],
-      "description": "LCB Sinner No. 8. One of the twelve fixed roster Sinners of Limbus Company."
+      "description": "LCB Sinner No. 8, drawn from Melville's Moby-Dick.",
+      "literary_origin": {"work": "Moby-Dick", "author": "Herman Melville"}
     },
     {
       "id": "rodion",
       "canonical": "Rodion",
       "aliases": ["rodya"],
-      "description": "LCB Sinner No. 9. One of the twelve fixed roster Sinners of Limbus Company."
+      "description": "LCB Sinner No. 9, drawn from Dostoevsky's Crime and Punishment.",
+      "literary_origin": {"work": "Crime and Punishment", "author": "Fyodor Dostoevsky"}
     },
     {
       "id": "sinclair",
       "canonical": "Sinclair",
       "aliases": ["sinc"],
-      "description": "LCB Sinner No. 10. One of the twelve fixed roster Sinners of Limbus Company."
+      "description": "LCB Sinner No. 10, drawn from Hermann Hesse's Demian.",
+      "literary_origin": {"work": "Demian", "author": "Hermann Hesse"}
     },
     {
       "id": "outis",
       "canonical": "Outis",
       "aliases": [],
-      "description": "LCB Sinner No. 11. One of the twelve fixed roster Sinners of Limbus Company."
+      "description": "LCB Sinner No. 11, drawn from Homer's Odyssey (\"Outis\" — \"Nobody\" — the name Odysseus gives the Cyclops).",
+      "literary_origin": {"work": "the Odyssey", "author": "Homer"}
     },
     {
       "id": "gregor",
       "canonical": "Gregor",
       "aliases": [],
-      "description": "LCB Sinner No. 12. One of the twelve fixed roster Sinners of Limbus Company."
+      "description": "LCB Sinner No. 12, drawn from Kafka's The Metamorphosis.",
+      "literary_origin": {"work": "The Metamorphosis", "author": "Franz Kafka"}
     }
   ]
 }

--- a/disbot/services/projmoon_data_service.py
+++ b/disbot/services/projmoon_data_service.py
@@ -53,6 +53,7 @@ KIND_LABELS: dict[str, str] = {
 
 # Non-core fields preserved per kind, surfaced as ``LimbusEntry.extra``.
 _EXTRA_FIELDS: dict[str, tuple[str, ...]] = {
+    "sinner": ("literary_origin",),
     "sin": ("color",),
     "ego_grade": ("rank",),
 }
@@ -143,6 +144,16 @@ def _load_file(filename: str, expected_kind: str) -> tuple[LimbusEntry, ...]:
             for key in _EXTRA_FIELDS.get(expected_kind, ())
             if key in item
         }
+        origin = extra.get("literary_origin")
+        if origin is not None and (
+            not isinstance(origin, dict)
+            or not origin.get("work")
+            or not origin.get("author")
+        ):
+            raise LimbusDataValidationError(
+                f"{filename}: entry {item['id']!r} literary_origin must be a "
+                "mapping with non-empty 'work' and 'author'",
+            )
         entries.append(
             LimbusEntry(
                 id=item["id"],
@@ -190,6 +201,35 @@ def all_entries() -> tuple[LimbusEntry, ...]:
     out: list[LimbusEntry] = []
     for kind in _FILES.values():
         out.extend(datasets[kind])
+    return tuple(out)
+
+
+@dataclass(frozen=True)
+class SinnerOrigin:
+    """A Sinner paired with the literary work it is drawn from."""
+
+    canonical: str
+    work: str
+    author: str
+
+
+def sinner_origins() -> tuple[SinnerOrigin, ...]:
+    """The 12 Sinners paired with their source work + author, roster order.
+
+    Sinners without a recorded ``literary_origin`` are skipped, so this is the
+    source of truth for the Origins cross-reference surface.
+    """
+    out: list[SinnerOrigin] = []
+    for entry in get_entries("sinner"):
+        origin = entry.extra.get("literary_origin")
+        if isinstance(origin, dict) and origin.get("work") and origin.get("author"):
+            out.append(
+                SinnerOrigin(
+                    canonical=entry.canonical,
+                    work=str(origin["work"]),
+                    author=str(origin["author"]),
+                ),
+            )
     return tuple(out)
 
 

--- a/disbot/views/projmoon/__init__.py
+++ b/disbot/views/projmoon/__init__.py
@@ -4,6 +4,7 @@ from views.projmoon.browse import (
     LimbusBrowseView,
     build_entry_embed,
     build_kind_embed,
+    build_origins_embed,
     build_overview_embed,
 )
 
@@ -11,5 +12,6 @@ __all__ = [
     "LimbusBrowseView",
     "build_entry_embed",
     "build_kind_embed",
+    "build_origins_embed",
     "build_overview_embed",
 ]

--- a/disbot/views/projmoon/browse.py
+++ b/disbot/views/projmoon/browse.py
@@ -91,12 +91,35 @@ def build_entry_embed(entry: data.LimbusEntry) -> discord.Embed:
             value=f"{entry.extra['rank']} of 5",
             inline=True,
         )
+    origin = entry.extra.get("literary_origin")
+    if isinstance(origin, dict) and origin.get("work") and origin.get("author"):
+        embed.add_field(
+            name="Literary origin",
+            value=f"*{origin['work']}* — {origin['author']}",
+            inline=False,
+        )
     if entry.aliases:
         embed.add_field(
             name="Also known as",
             value=", ".join(entry.aliases),
             inline=False,
         )
+    embed.set_footer(text=_provenance())
+    return embed
+
+
+def build_origins_embed() -> discord.Embed:
+    """A cross-reference card: every Sinner ↔ the literary work it is drawn from."""
+    origins = data.sinner_origins()
+    lines = [f"**{o.canonical}** — *{o.work}*, {o.author}" for o in origins]
+    embed = discord.Embed(
+        title="🌑 Limbus — Sinner literary origins",
+        description=(
+            "Each of the 12 Sinners is drawn from a work of world literature.\n\n"
+            + "\n".join(lines)
+        ),
+        color=GAME_COLOR,
+    )
     embed.set_footer(text=_provenance())
     return embed
 
@@ -131,6 +154,21 @@ class _OverviewButton(discord.ui.Button):
         )
 
 
+class _OriginsButton(discord.ui.Button):
+    def __init__(self) -> None:
+        super().__init__(
+            label="Origins",
+            emoji="📖",
+            style=discord.ButtonStyle.secondary,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await interaction.response.edit_message(
+            embed=build_origins_embed(),
+            view=self.view,
+        )
+
+
 class LimbusBrowseView(BaseView):
     """Public browse panel: one button per entity kind + an overview reset."""
 
@@ -139,3 +177,4 @@ class LimbusBrowseView(BaseView):
         self.add_item(_OverviewButton())
         for kind in data.entity_kinds():
             self.add_item(_KindButton(kind))
+        self.add_item(_OriginsButton())

--- a/docs/current-state/S1-bot.md
+++ b/docs/current-state/S1-bot.md
@@ -120,7 +120,11 @@
   Sinners · 7 Sins · 3 damage types · 5 E.G.O grades · status keywords, provenance-tagged), a typed
   `services/projmoon_data_service.py` (loader + resolver), `utils/projmoon/keywords.py`
   (`has_limbus_context`), and a browsable `!pm` / `/pm` surface (`views/projmoon/`, its own top-level
-  **Project Moon** Help hub like BTD6). Read-only, no DB, **no AI hot-path change**. ▶ **Next: PR 2** —
+  **Project Moon** Help hub like BTD6). Read-only, no DB, **no AI hot-path change**. **Lore-depth
+  follow-on SHIPPED 2026-06-25** (dispatch run, PR #1456): each of the 12 Sinners now carries its
+  canonical **`literary_origin`** (the work + author it is drawn from — Faust→Goethe, Outis→Homer,
+  Gregor→Kafka, …), rendered in the `!pm` detail card + a new **Origins** cross-reference view
+  (`!pm origins` + a panel button). Still read-only/offline. ▶ **Next: PR 2** —
   wire `AITask.PROJMOON_ANSWER` + grounding into `core/runtime/ai/natural_language_stage.py` (reuse the
   tag/cap/provenance render + faithfulness guard), **flagged for a Q-0086 runtime walk** (touches the
   gated AI stage). Then Slice B = extract the shared `KnowledgeDomain` seam from BTD6 + Limbus + exact

--- a/docs/owner/claims/claude-funny-franklin-pkauhr.md
+++ b/docs/owner/claims/claude-funny-franklin-pkauhr.md
@@ -1,6 +1,0 @@
-# Claim — claude/funny-franklin-pkauhr
-
-- branch `claude/funny-franklin-pkauhr` · scope: Project Moon (Limbus) Sinner lore depth — literary
-  origins + browse cross-reference · expected files: `disbot/data/projmoon/limbus/sinners.json`,
-  `disbot/services/projmoon_data_service.py`, `disbot/views/projmoon/browse.py`,
-  `disbot/cogs/project_moon_cog.py`, `tests/unit/.../projmoon` · 2026-06-25

--- a/docs/owner/claims/claude-funny-franklin-pkauhr.md
+++ b/docs/owner/claims/claude-funny-franklin-pkauhr.md
@@ -1,0 +1,6 @@
+# Claim — claude/funny-franklin-pkauhr
+
+- branch `claude/funny-franklin-pkauhr` · scope: Project Moon (Limbus) Sinner lore depth — literary
+  origins + browse cross-reference · expected files: `disbot/data/projmoon/limbus/sinners.json`,
+  `disbot/services/projmoon_data_service.py`, `disbot/views/projmoon/browse.py`,
+  `disbot/cogs/project_moon_cog.py`, `tests/unit/.../projmoon` · 2026-06-25

--- a/docs/planning/project-moon-knowledge-domain-plan-2026-06-21.md
+++ b/docs/planning/project-moon-knowledge-domain-plan-2026-06-21.md
@@ -77,6 +77,14 @@ argument: generalising from a single example tends to produce the wrong abstract
 > hot-path change** (deliberate: the StaticData numbers + the `natural_language_stage` grounding wiring
 > are PR 2, which wants prod creds / a runtime walk). **▶ Next = Slice A item 2 (the grounding path).**
 
+> **▶ Progress (2026-06-25 dispatch run, PR #1456): Slice A lore-depth follow-on SHIPPED.** Each of the
+> 12 Sinners now carries a provenanced **`literary_origin`** (`{work, author}` — the canonical literary
+> source each Sinner is drawn from: Faust→Goethe, Outis→Homer's *Odyssey*, Gregor→Kafka, Rodion→
+> Dostoevsky, …), validated by `projmoon_data_service`, exposed via a typed `sinner_origins()` accessor,
+> and surfaced in the `!pm` detail card + a new **Origins** cross-reference embed (`!pm origins` + a
+> browse-panel button). Read-only/offline, no AI hot-path change. **PR 2 (the grounding path) is still
+> the next slice** (needs the Q-0086 runtime walk).
+
 **Slice A (next session, 2–3 PRs):**
 1. **Ingestion:** a `scripts/fetch_pm_limbus.py` that parses the **StaticData identity JSON** (clean,
    bounded — Identities + Sinners + E.G.O index) into committed JSON under

--- a/tests/unit/cogs/test_project_moon_cog.py
+++ b/tests/unit/cogs/test_project_moon_cog.py
@@ -7,7 +7,12 @@ import pytest
 
 from cogs.project_moon_cog import ProjectMoonCog
 from services import projmoon_data_service as data
-from views.projmoon import build_entry_embed, build_kind_embed, build_overview_embed
+from views.projmoon import (
+    build_entry_embed,
+    build_kind_embed,
+    build_origins_embed,
+    build_overview_embed,
+)
 
 
 class _FakeCtx:
@@ -54,6 +59,22 @@ def test_entry_embed_shows_extra_fields():
     assert "Grade rank" in field_names
 
 
+def test_sinner_entry_embed_shows_literary_origin():
+    gregor = data.resolve("Gregor", kind="sinner")
+    embed = build_entry_embed(gregor)
+    origin = next(f for f in embed.fields if f.name == "Literary origin")
+    assert "Metamorphosis" in origin.value
+    assert "Kafka" in origin.value
+
+
+def test_origins_embed_lists_all_twelve_sinners():
+    embed = build_origins_embed()
+    for name in ("Yi Sang", "Faust", "Outis", "Gregor"):
+        assert name in embed.description
+    # one line per Sinner.
+    assert embed.description.count("**") == 12 * 2
+
+
 # ---- command callbacks -----------------------------------------------------
 
 
@@ -96,3 +117,12 @@ async def test_pm_lookup_unknown_is_honest():
     await cog.pm_lookup.callback(cog, ctx, query="not a real thing")
     embed: discord.Embed = ctx.sent[0]["embed"]
     assert "don't have" in embed.description.lower()
+
+
+@pytest.mark.asyncio
+async def test_pm_origins_command_sends_cross_reference():
+    cog, ctx = _cog(), _FakeCtx()
+    await cog.pm_origins.callback(cog, ctx)
+    embed: discord.Embed = ctx.sent[0]["embed"]
+    assert "literary origins" in embed.title.lower()
+    assert "Dostoevsky" in embed.description

--- a/tests/unit/services/projmoon/test_projmoon_data_service.py
+++ b/tests/unit/services/projmoon/test_projmoon_data_service.py
@@ -71,3 +71,34 @@ def test_extra_fields_preserved():
 def test_all_entries_spans_every_kind():
     everything = data.all_entries()
     assert len(everything) == sum(len(data.get_entries(k)) for k in data.entity_kinds())
+
+
+def test_every_sinner_has_a_literary_origin():
+    for sinner in data.get_entries("sinner"):
+        origin = sinner.extra.get("literary_origin")
+        assert isinstance(origin, dict), f"{sinner.canonical} missing literary_origin"
+        assert origin.get("work") and origin.get("author")
+
+
+def test_sinner_origins_accessor_covers_full_roster():
+    origins = data.sinner_origins()
+    assert len(origins) == 12
+    faust = next(o for o in origins if o.canonical == "Faust")
+    assert faust.author == "Johann Wolfgang von Goethe"
+    assert "Faust" in faust.work
+    # roster order is preserved (Yi Sang is Sinner No. 1).
+    assert origins[0].canonical == "Yi Sang"
+
+
+def test_malformed_literary_origin_is_rejected(tmp_path, monkeypatch):
+    bad = tmp_path / "sinners.json"
+    bad.write_text(
+        '{"data_version":"x","game_version":"x","source":"x",'
+        '"entity_kind":"sinner","entries":[{"id":"a","canonical":"A",'
+        '"description":"d","literary_origin":{"work":"W"}}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(data, "DATA_ROOT", tmp_path)
+    data.reset_cache()
+    with pytest.raises(data.LimbusDataValidationError, match="literary_origin"):
+        data.get_entries("sinner")


### PR DESCRIPTION
## What

Enriches the just-shipped Limbus knowledge domain (PR #1453) with each of the 12 Sinners' **canonical
literary origin** — the defining structural/lore fact for each Sinner (the work + author they are drawn
from). Surfaced in the `!pm`/`/pm` browse detail card and a new **Origins** cross-reference view.

Read-only, no DB, no AI hot-path change (the gated AI grounding path stays PR 2). Advances the Project
Moon program's "browsable structured lookups + lore" goal
([plan](../blob/main/docs/planning/project-moon-knowledge-domain-plan-2026-06-21.md)).

## Scope (born-red, Q-0133)

- New provenanced `literary_origin` field on each Sinner in `sinners.json` + enriched descriptions.
- Data-service validation + accessor exposure of the field.
- Browse rendering: detail card "Literary origin" line; a new `!pm origins` cross-reference embed +
  panel button.
- Tests.

Run type: routine · dispatch (empty-fire advance of the S1 ▶ Project Moon program).


---
_Generated by [Claude Code](https://claude.ai/code/session_01H48R44XatV4fspB5SZ7RVb)_