### PR TITLE
BTD6 grounding eval — fixture-drift anchor guard (S2 P1-1)

### DIFF
--- a/.sessions/2026-06-25-btd6-fixture-anchor-guard.md
+++ b/.sessions/2026-06-25-btd6-fixture-anchor-guard.md
@@ -1,0 +1,34 @@
+# 2026-06-25 — BTD6 grounding eval: fixture-drift anchor guard (S2 P1-1)
+
+> **Status:** `in-progress`
+
+## Goal (dispatch run, empty scheduled fire → advance the next plan slice)
+
+Empty scheduled fire, no open PRs. Per the routine: advance the next **▶ startable**
+plan slice. Picked **S2 P1-1 BTD6 eval cases** — "offline test assertions over
+already-grounded facts → offline-verifiable + self-mergeable" (roadmap S2 dispatch
+note). The existing grounding-anchor guard
+(`tests/evals/test_btd6_grounding_anchors.py`) pins every *`llm_judge`-rubric*
+number to a deterministic `btd6_data_service` re-derivation — but the BTD6
+**grounding** cases that use `contains(...)` graders bake their truth into the
+`tool_results` **fixture**, not a rubric, so those numbers have **no data-drift
+guard** at all. A re-seed that changes Navarch's income or a paragon cost would
+leave the eval silently testing against a stale fixture.
+
+## What I'm about to do
+
+**Slice 1 — fixture-drift anchor guard (offline tests, no runtime change).**
+Extend `test_btd6_grounding_anchors.py` with a `FixtureAnchor` table that pins each
+number baked into a grounding case's `tool_results` facts to its deterministic
+re-derivation, closing two directions for the `contains`-grader cases:
+1. **data drift** — the fixture number must come back from `btd6_stats_service`
+   (Navarch income `$3,200`, Navarch/Buccaneer paragon cost `$550,000`);
+2. **fixture drift** — that number must actually appear in the named case's
+   `tool_results` facts (so editing the fixture away from the grounded truth fails).
+Plus a guard-the-guard test. No `disbot/` runtime touched.
+
+## Status checklist
+- [ ] Slice 1 — fixture-drift anchor guard + tests green
+- [ ] CI mirror green (`check_quality.py --full`) + arch strict 0 errors
+- [ ] De-stale S2 sector doc
+- [ ] Session enders (idea / prev-review / doc audit / run-report footer)

--- a/.sessions/2026-06-25-btd6-fixture-anchor-guard.md
+++ b/.sessions/2026-06-25-btd6-fixture-anchor-guard.md
@@ -1,6 +1,6 @@
 # 2026-06-25 — BTD6 grounding eval: fixture-drift anchor guard (S2 P1-1)
 
-> **Status:** `in-progress`
+> **Status:** `complete`
 
 ## Goal (dispatch run, empty scheduled fire → advance the next plan slice)
 
@@ -11,24 +11,88 @@ note). The existing grounding-anchor guard
 (`tests/evals/test_btd6_grounding_anchors.py`) pins every *`llm_judge`-rubric*
 number to a deterministic `btd6_data_service` re-derivation — but the BTD6
 **grounding** cases that use `contains(...)` graders bake their truth into the
-`tool_results` **fixture**, not a rubric, so those numbers have **no data-drift
-guard** at all. A re-seed that changes Navarch's income or a paragon cost would
+`tool_results` **fixture**, not a rubric, so those numbers had **no data-drift
+guard** at all. A re-seed that changed Navarch's income or a paragon cost would
 leave the eval silently testing against a stale fixture.
 
-## What I'm about to do
+## What shipped (PR #1458)
 
 **Slice 1 — fixture-drift anchor guard (offline tests, no runtime change).**
-Extend `test_btd6_grounding_anchors.py` with a `FixtureAnchor` table that pins each
-number baked into a grounding case's `tool_results` facts to its deterministic
-re-derivation, closing two directions for the `contains`-grader cases:
-1. **data drift** — the fixture number must come back from `btd6_stats_service`
-   (Navarch income `$3,200`, Navarch/Buccaneer paragon cost `$550,000`);
-2. **fixture drift** — that number must actually appear in the named case's
-   `tool_results` facts (so editing the fixture away from the grounded truth fails).
-Plus a guard-the-guard test. No `disbot/` runtime touched.
+- New `FixtureAnchor` table in `test_btd6_grounding_anchors.py` pinning each number
+  baked into a grounding case's `tool_results` facts to its deterministic
+  re-derivation from `btd6_stats_service`:
+  - Navarch income `$3,200` (`get_paragon_stats("navarch_of_the_seas").income_per_round`)
+    — in both `grounding.btd6_navarch_income` and `grounding.btd6_carryover_followup`;
+  - Navarch/Buccaneer paragon cost `$550,000` (`.cost`) — in the navarch case.
+- Two test directions mirror the rubric anchors:
+  1. **data drift** — the fixture number must come back from the dataset;
+  2. **fixture drift** — that number must still appear in the named case's fixture
+     (editing the fixture away from the grounded truth fails).
+  Plus a stale-anchor guard and a guard-the-guard (`_fixture_numbers` actually
+  reads a known number).
+- **Curation principle documented** in the module docstring + an S2-sector handoff:
+  I empirically checked the *remaining* unanchored rubric figures (cumulative
+  range-cash, ABR boundaries) and they are **not** cleanly reproducible — a naive
+  `round_cash(1, N)` lands ~$10 off the rubric totals (a starting-cash/boundary
+  convention), and `$71,315.20` is a *distractor* BUG-0004 tells the judge to
+  reject. Anchoring those blindly would assert a wrong "truth" and make the guard
+  lie (CLAUDE.md Q-0120). So they stay deliberately unanchored, with a note + a
+  ▶ Next-startable handoff for a future slice that nails the convention first.
+- **Drift cleanup (bugs-first):** removed a stale claim file
+  (`docs/owner/claims/claude-funny-franklin-ry0ygk.md`) for the settle-once CI
+  guard that already merged as #1454 (zero open PRs confirms its session closed).
+
+## Verification
+- `tests/evals/test_btd6_grounding_anchors.py`: **34 passed** (the new fixture
+  anchors + the existing rubric anchors).
+- Full CI mirror `python3.10 scripts/check_quality.py --full`: **12511 passed,
+  48 skipped, 2 xfailed** (green).
+- `check_architecture.py --mode strict`: **0 errors** (49 known warnings; test-only
+  change touches no `disbot/`).
+- Doc audit: `check_current_state_ledger.py --strict` exit 0 (benign newest-merge
+  lag only); `check_docs.py --strict` green.
 
 ## Status checklist
-- [ ] Slice 1 — fixture-drift anchor guard + tests green
-- [ ] CI mirror green (`check_quality.py --full`) + arch strict 0 errors
-- [ ] De-stale S2 sector doc
-- [ ] Session enders (idea / prev-review / doc audit / run-report footer)
+- [x] Slice 1 — fixture-drift anchor guard + tests green
+- [x] CI mirror green + arch strict 0 errors
+- [x] De-stale S2 sector doc + stale-claim cleanup
+- [x] Session enders (idea / prev-review / doc audit / run-report footer)
+
+## 💡 Session idea (Q-0089)
+
+**Eval-anchor coverage report** — a small advisory script/test that inventories
+every numeric token asserted across `tests/evals/cases.py` (both `llm_judge`
+rubrics and `tool_results` fixtures) and reports which are **not** covered by an
+`Anchor`/`FixtureAnchor`. Today the coverage gap is buried in a prose comment
+(the range-cash convention figures); a measurable, advisory coverage readout would
+make "which asserted truths still have no drift guard?" answerable at a glance and
+turn the curation backlog into a visible, groomable list — the same observability
+win the bug-book root-fix-backlog checker gives. Genuinely useful (I hand-built
+exactly this inventory this run to decide what was safely anchorable); worth having
+because eval drift-guards silently *under*-covering is the failure mode they exist
+to prevent. Dedup-checked `docs/ideas/` — no existing eval-coverage idea.
+
+## ⟲ Previous-session review (Q-0102)
+
+Prev = `2026-06-24-syncslash-gated-unification.md` (PR #1426, route `!syncslash
+global` through the diff-gated auto-sync helper). **Did well:** noticed the
+`admin_cog.py` was at ~787 LOC and would breach the 800-LOC `test_cog_size`
+invariant if the new logic were inlined, and proactively extracted to
+`cogs/admin/_slash_sync.py` — fixing the constraint at the root rather than
+bumping the ceiling. Clean, exactly the "bugs-first / root-cause" instinct.
+**System improvement it surfaces:** the cog-size ceiling is only enforced by a
+*test* that fires at edit time — an author only learns they're near the 800 limit
+after writing the code. A cheap `pre-edit-check` readout ("this cog is at 787/800
+LOC — budget 13 lines") when a `cogs/*_cog.py` file is opened would surface the
+constraint *before* the work, not after. Small, advisory, in the spirit of the
+existing pre-edit tooling.
+
+## 📤 Run report
+
+- **Did:** empty scheduled fire → advanced S2 P1-1 with a fixture-drift anchor guard for the BTD6 grounding eval cases (closes a real, previously-uncovered drift class) · **Outcome:** shipped
+- **Shipped:** #1458 — `FixtureAnchor` table pinning Navarch income/cost fixtures to `btd6_stats_service` re-derivations; offline test-only; CI green
+- **Run type:** `routine · dispatch` (Q-0165)
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** `none`
+- **⚑ Self-initiated:** `none` (advanced an existing plan slice, S2 P1-1; no new idea promoted to plan/build)
+- **↪ Next:** S2 P1-1 — anchor the remaining range-cash convention figures *after* nailing the exact cumulative/starting-cash convention (a naive `round_cash(1, N)` is ~$10 off — see the curation note in `test_btd6_grounding_anchors.py`); live `llm_judge` battery + absence-guard Layer B stay creds-gated.

--- a/docs/current-state/S2-btd6.md
+++ b/docs/current-state/S2-btd6.md
@@ -13,6 +13,12 @@
   cash ranges) is now pinned to a deterministic `btd6_data_service` re-derivation **and** the case
   rubric, so a re-seed that changes a price *or* an edited rubric number fails CI; plus a
   capability/answerability-consistency guard (`tests/evals/test_btd6_grounding_anchors.py`).
+  **Fixture-drift extension (2026-06-25 dispatch run, PR #1458):** the BTD6 *grounding* cases that use
+  `contains(...)` graders bake their truth into the `tool_results` **fixture** (not a rubric), so those
+  numbers had no data-drift guard — now a `FixtureAnchor` table pins Navarch income ($3,200) + paragon
+  cost ($550,000) to `btd6_stats_service` re-derivations and asserts they still appear in the case
+  fixture (data-drift + fixture-drift), with the curation principle documented (only exactly-derivable
+  *truths* are anchored — not distractors or convention-dependent cumulative totals).
 - **Buff-uptime upgrade-detail model** — `btd6_upgrade_detail_service` + AI tool + `parse_gamedata`
   extraction, multi-target uptime (#1235/#1249/#1251).
 - **Data-lifecycle hardening** — auto-seed BTD6 blob data on boot (#1255), content-drift surface
@@ -24,6 +30,12 @@
 - **P1-1 live `llm_judge` battery** (the model actually using the grounded facts — creds-gated; the
   offline grounding half now shipped, above) + absence-guard **Layer B** (the negative-existential
   gate, design-for-review; needs prod creds).
+- **Anchor the remaining range-cash convention figures** (offline, but needs the *exact* cumulative
+  convention first): the `knowledge.btd6_round_cash_*` / `_abr_*` rubrics assert cumulative totals
+  ($56,318.70, ABR $119,315.30, $5,443, …) that a naive `round_cash(1, N)` re-derives ~$10 off — so
+  they are deliberately **unanchored** (see the curation note in `test_btd6_grounding_anchors.py`).
+  A future slice that nails the cumulative/starting-cash convention can add these anchors safely;
+  until then, anchoring them would assert a wrong "truth".
 
 **Gate:** the broad AI/BTD6 feature-expansion gate (stability + provider/provenance + caching + AI
 config) still applies — see [`../current-state.md`](../current-state.md) § Gates / blocked work.

--- a/docs/owner/claims/claude-funny-franklin-1318v3.md
+++ b/docs/owner/claims/claude-funny-franklin-1318v3.md
@@ -1,0 +1,1 @@
+- `claude/funny-franklin-1318v3` · BTD6 grounding eval — fixture-drift anchor guard (S2 P1-1) · `tests/evals/test_btd6_grounding_anchors.py` + docs · 2026-06-25

--- a/docs/owner/claims/claude-funny-franklin-ry0ygk.md
+++ b/docs/owner/claims/claude-funny-franklin-ry0ygk.md
@@ -1,1 +1,0 @@
-- `claude/funny-franklin-ry0ygk` · settle-once money-safety CI guard (check_consistency Rule 6) · `scripts/check_consistency.py` + tests + idea promotion · 2026-06-25

--- a/tests/evals/test_btd6_grounding_anchors.py
+++ b/tests/evals/test_btd6_grounding_anchors.py
@@ -28,6 +28,17 @@ Two directions are closed:
    in the named eval case's rubric (so editing a rubric number fails here).
 
 The anchor table is the single bridge between the data and the golden set's prose.
+
+Curation principle (why not every rubric/fixture number is anchored): an anchor is
+only added for a value that is BOTH an asserted *truth* AND cleanly reproducible
+from a public ``btd6_*_service`` accessor. Several rubric numbers are deliberately
+NOT anchored — some are *distractors* the rubric tells the judge to REJECT (e.g.
+BUG-0004's "$71,315.20" cumulative mislabel, truth "$56,318.70"), and the
+cumulative/range figures use a per-round-cash convention a naive ``round_cash(1, N)``
+does not reproduce (verified: it lands ~$10 off the rubric totals). Anchoring those
+without the exact convention would assert a wrong "truth" and make the guard lie —
+the opposite of its purpose (CLAUDE.md Q-0120: a green check that contradicts the
+evidence is a bug in the check). Add an anchor only when you can derive it exactly.
 """
 
 from __future__ import annotations
@@ -39,7 +50,7 @@ from dataclasses import dataclass
 import pytest
 from tests.evals.cases import CASES
 
-from services import ai_introspection_service, btd6_data_service
+from services import ai_introspection_service, btd6_data_service, btd6_stats_service
 
 # --------------------------------------------------------------------------- #
 # Rubric introspection — pull the asserted numbers out of a case's grader(s).
@@ -239,6 +250,131 @@ def test_rubric_introspection_actually_reads_a_known_number():
     (so a silently-broken extractor can't make the checks above vacuous)."""
     case = _CASES_BY_ID["knowledge.btd6_despo_bulk_cost_bug_0003"]
     assert 12025.0 in _rubric_numbers(case.grader)
+
+
+# --------------------------------------------------------------------------- #
+# Fixture-drift anchors — the BTD6 *grounding* cases use ``contains(...)`` graders
+# with their truth baked into the ``tool_results`` FIXTURE (the canned tool reply),
+# not an ``llm_judge`` rubric. The rubric-number anchors above never see those, so
+# the fixture numbers had no data-drift guard at all: a re-seed that changed
+# Navarch's income or a paragon cost would leave the eval silently testing against
+# a stale fixture. These anchors close the same two directions for the fixture
+# cases — data drift (the number must come back from the dataset) and fixture drift
+# (the number must still appear in the named case's fixture).
+# --------------------------------------------------------------------------- #
+def _fixture_numbers(case: object, tool_name: str) -> set[float]:
+    """All numeric tokens in ``case``'s ``tool_results`` facts for ``tool_name``.
+
+    Mirrors :func:`_rubric_numbers` but reads the canned tool reply (the
+    ``facts`` list) instead of an ``llm_judge`` rubric, normalizing ``$`` and
+    thousands separators so "3,200" and "3200" compare equal."""
+    payload = getattr(case, "tool_results", {}).get(tool_name, {})
+    facts = payload.get("facts", ()) if isinstance(payload, dict) else ()
+    nums: set[float] = set()
+    for fact in facts:
+        for token in _NUMBER_RE.findall(str(fact)):
+            cleaned = token.replace("$", "").replace(",", "")
+            try:
+                nums.add(round(float(cleaned), 2))
+            except ValueError:  # pragma: no cover - regex guarantees a number
+                continue
+    return nums
+
+
+def _navarch_income() -> float:
+    stats = btd6_stats_service.get_paragon_stats("navarch_of_the_seas")
+    assert stats is not None, "navarch_of_the_seas paragon stats missing"
+    assert stats.income_per_round is not None, "navarch income_per_round missing"
+    return float(stats.income_per_round)
+
+
+def _navarch_cost() -> float:
+    stats = btd6_stats_service.get_paragon_stats("navarch_of_the_seas")
+    assert stats is not None, "navarch_of_the_seas paragon stats missing"
+    assert stats.cost is not None, "navarch paragon cost missing"
+    return float(stats.cost)
+
+
+@dataclass(frozen=True)
+class FixtureAnchor:
+    case_id: str
+    tool_name: str
+    label: str
+    expected: float  # the truth baked into the case fixture (the bridge value)
+    derive: Callable[[], float]  # re-derivation from btd6_stats_service
+
+
+FIXTURE_ANCHORS: tuple[FixtureAnchor, ...] = (
+    # The 2026-06-10 "no coins" Navarch miss (PR #662): the income fact that now
+    # grounds the answer is baked into the grounding-case fixtures via contains().
+    FixtureAnchor(
+        "grounding.btd6_navarch_income",
+        "btd6_lookup",
+        "Navarch income per round (navarch case fixture)",
+        3200.0,
+        _navarch_income,
+    ),
+    FixtureAnchor(
+        "grounding.btd6_navarch_income",
+        "btd6_lookup",
+        "Navarch paragon cost (navarch case fixture)",
+        550000.0,
+        _navarch_cost,
+    ),
+    # The pronoun-followup turn (PR #668) carries the same income fact forward.
+    FixtureAnchor(
+        "grounding.btd6_carryover_followup",
+        "btd6_lookup",
+        "Navarch income per round (carryover case fixture)",
+        3200.0,
+        _navarch_income,
+    ),
+)
+
+
+def test_fixture_anchor_table_references_only_real_cases():
+    """A stale fixture anchor (renamed/removed case) is itself drift — fail loudly."""
+    missing = sorted({a.case_id for a in FIXTURE_ANCHORS} - set(_CASES_BY_ID))
+    assert not missing, (
+        f"Fixture anchor(s) reference eval case id(s) that no longer exist: {missing}. "
+        "Update tests/evals/test_btd6_grounding_anchors.py to the current case ids."
+    )
+
+
+@pytest.mark.parametrize(
+    "anchor", FIXTURE_ANCHORS, ids=lambda a: f"{a.case_id}:{a.label}"
+)
+def test_fixture_number_is_reproduced_by_the_dataset(anchor: FixtureAnchor):
+    """Direction 1 — data drift: the fixture value must come back from the data."""
+    derived = round(anchor.derive(), 2)
+    assert derived == round(anchor.expected, 2), (
+        f"{anchor.label}: dataset now yields {derived}, but the grounding-case "
+        f"fixture bakes {anchor.expected}. The BTD6 data drifted from the eval "
+        f"fixture — re-sync the case fixture (and this anchor) to the data, or fix "
+        f"the data."
+    )
+
+
+@pytest.mark.parametrize(
+    "anchor", FIXTURE_ANCHORS, ids=lambda a: f"{a.case_id}:{a.label}"
+)
+def test_fixture_number_appears_in_the_case_fixture(anchor: FixtureAnchor):
+    """Direction 2 — fixture drift: the bridge value must be in the case fixture."""
+    case = _CASES_BY_ID[anchor.case_id]
+    baked = _fixture_numbers(case, anchor.tool_name)
+    assert round(anchor.expected, 2) in baked, (
+        f"{anchor.label}: {anchor.expected} is grounded in the data but not present "
+        f"in the {anchor.tool_name!r} fixture of {anchor.case_id!r}. The fixture was "
+        f"edited away from the grounded truth (fixture numbers: {sorted(baked)})."
+    )
+
+
+def test_fixture_introspection_actually_reads_a_known_number():
+    """Guard the guard: a fixture case whose canned facts assert a number must
+    surface it, so a silently-broken extractor can't make the checks above
+    vacuous."""
+    case = _CASES_BY_ID["grounding.btd6_navarch_income"]
+    assert 3200.0 in _fixture_numbers(case, "btd6_lookup")
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

Extends the BTD6 grounding-anchor guard (`tests/evals/test_btd6_grounding_anchors.py`) to cover the **fixture-baked** numbers in the `contains`-grader grounding cases.

The existing anchor table pins every number asserted in an `llm_judge` **rubric** to a deterministic `btd6_data_service` re-derivation. But the BTD6 *grounding* cases that use `contains(...)` graders (e.g. `grounding.btd6_navarch_income`) bake their truth into the `tool_results` **fixture**, not a rubric — so those numbers currently have **no data-drift guard**. A re-seed that changed Navarch's income or a paragon cost would leave the eval silently testing against a stale fixture.

## Slice 1 — fixture-drift anchor guard (offline tests, no runtime change)

A `FixtureAnchor` table closes two directions for the fixture cases:
1. **data drift** — the fixture number must come back from `btd6_stats_service` (Navarch income `$3,200`, paragon cost `$550,000`);
2. **fixture drift** — that number must appear in the named case's `tool_results` facts (editing the fixture away from the grounded truth fails).

Plus a guard-the-guard test. No `disbot/` runtime touched — pure offline test coverage.

## Status

Born-red while in progress (session card `.sessions/2026-06-25-btd6-fixture-anchor-guard.md`). Flipped to `complete` as the final step so auto-merge fires on a complete PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RpeG4mKZUUSYuGez9tJueq)_