### PR TITLE
S2 P1-1: anchor BTD6 projected-total eval figures (nail the starting-cash convention)

### DIFF
--- a/.sessions/2026-06-25-btd6-projected-total-anchors.md
+++ b/.sessions/2026-06-25-btd6-projected-total-anchors.md
@@ -1,0 +1,32 @@
+# 2026-06-25 — BTD6 eval anchors: projected-total convention (S2 P1-1)
+
+> **Status:** `in-progress`
+
+## Goal (dispatch run, empty scheduled fire → advance the next plan slice)
+
+Empty scheduled fire, no open PRs. Per the routine: advance the next **▶ startable**
+slice. Picked up the explicit ▶ Next handoff from the previous S2 P1-1 run
+(`2026-06-25-btd6-fixture-anchor-guard.md`, #1458): *"anchor the remaining range-cash
+convention figures after nailing the exact cumulative/starting-cash convention (a naive
+`round_cash(1, N)` is ~$10 off)."*
+
+## What I'm about to do
+
+The four **range** figures (rounds 60-68 / 50-60 / 54-70 / ABR 25-83) are already
+anchored via `_range_cash(start, end)`. The genuinely-uncovered rubric truths are the
+**projected running totals** the same cases assert ($21,187.90 / $39,840 / $56,318.70 /
+$119,315.30 ABR). The previous run left them unanchored believing the convention wasn't
+cleanly reproducible — but the "~$10 off" came from trying `round_cash(1, N)`
+(cumulative-from-round-1), which is the *wrong* accessor. Verified empirically: each
+projected total is exactly `stated_starting_cash + round_cash(start, end).range_cash`
+(8094+13093.9=21187.9 · 20000+19840=39840 · 26932+29386.7=56318.7 · 5443+113872.3=119315.3
+— all exact). So the convention IS nailed: **projected_total = stated_start + range_cash**,
+the stated start being the user-message constant in each case (NOT cumulative from round 1).
+
+Slice 1: add a `_projected_total(...)` derive helper + four projected-total anchors, and
+correct the module curation note (the convention is reproducible; the only deliberately-
+unanchored rubric numbers are the *distractors* the rubric tells the judge to reject
+— $71,315.20, $107,164.60 — and the bare user-supplied starting figures, which are not
+data-derived truths).
+
+Offline test-only change (no `disbot/` runtime). Self-mergeable.

--- a/.sessions/2026-06-25-btd6-projected-total-anchors.md
+++ b/.sessions/2026-06-25-btd6-projected-total-anchors.md
@@ -1,6 +1,6 @@
 # 2026-06-25 — BTD6 eval anchors: projected-total convention (S2 P1-1)
 
-> **Status:** `in-progress`
+> **Status:** `complete` — ready to merge (Q-0133). Run type: routine · dispatch.
 
 ## Goal (dispatch run, empty scheduled fire → advance the next plan slice)
 
@@ -30,3 +30,82 @@ unanchored rubric numbers are the *distractors* the rubric tells the judge to re
 data-derived truths).
 
 Offline test-only change (no `disbot/` runtime). Self-mergeable.
+
+## What shipped (PR #1460)
+
+- `tests/evals/test_btd6_grounding_anchors.py`: a `_projected_total(start_cash, start,
+  end, roundset)` derive helper + **four** projected-total `Anchor`s
+  (`8094+13093.9=21187.9` · `20000+19840=39840` · `26932+29386.7=56318.7` ABR
+  `5443+113872.3=119315.3`). Each now carries both drift directions (data drift +
+  rubric-prose drift), same as the existing range/rubric anchors.
+- Corrected the module curation note: the convention IS cleanly reproducible
+  (`total = stated_start + range_cash`, the stated start being the user-message
+  constant — NOT cumulative-from-round-1; a naive `round_cash(1, N)` is "~$10 off"
+  only because it's the wrong accessor). The numbers that *stay* unanchored are now
+  named precisely: the two distractors the rubric tells the judge to reject
+  ($71,315.20, $107,164.60) and the bare user-supplied starting figures (inputs, not
+  data-derived truths).
+
+## Verification
+
+- `tests/evals/test_btd6_grounding_anchors.py`: **42 passed** (was 34 — +8 = 4 anchors
+  × 2 directions).
+- `python3.10 scripts/check_quality.py --full`: **12519 passed, 48 skipped, 2 xfailed**
+  (green).
+- `python3.10 scripts/check_architecture.py --mode strict`: **0 errors** (4 pre-existing
+  `baseview_inheritance` WARNs only; test-only change touches no `disbot/`).
+- `check_docs.py` / `check_consistency.py`: green via `--check-only`.
+
+## Drift cleanup (bugs-first)
+
+Removed a stale claim file `docs/owner/claims/claude-funny-franklin-1318v3.md` — its
+session (the #1458 fixture-anchor run) closed and merged; zero open PRs confirms it.
+
+## 💡 Session idea (Q-0089)
+
+**Distractor "negative anchor" guard.** The eval set documents distractors the judge
+must REJECT ($71,315.20 = the from-round-1 cumulative mislabel; $107,164.60 = the
+standard-set figure given as the ABR answer). Today nothing pins that those values
+stay *un*-reproducible — if a future data/seed change ever made a distractor
+accidentally equal a clean `btd6_*_service` derivation, the case would silently stop
+guarding the exact confusion it was written for (a grounded-looking wrong answer). A
+tiny `NEGATIVE_ANCHOR` table (`value`, `case_id`, `derivation-that-must-NOT-equal-it`)
+asserting each documented distractor is **not** cleanly derivable would close that
+blind spot — the inverse of the positive anchors, cheap, offline. Dedup-checked
+`docs/ideas/` + this file's history: distinct from #1458's *coverage-report* idea
+(which inventories *missing* positive anchors; this guards *intentional* non-anchors).
+
+## ⟲ Previous-session review (Q-0102)
+
+Prev = `2026-06-25-btd6-fixture-anchor-guard.md` (#1458, the fixture-drift anchor
+guard). **Did well:** genuinely careful curation — it refused to anchor figures it
+couldn't derive exactly (Q-0120 discipline) rather than asserting a possibly-wrong
+truth, and it left a precise ▶ Next handoff that made *this* run trivial to pick up.
+**What it missed:** its "naive `round_cash(1, N)` is ~$10 off" probe used the wrong
+accessor — the projected totals are `stated_start + range_cash`, not a
+cumulative-from-round-1 figure — so it under-covered four cleanly-derivable truths out
+of caution. The caution was the right *instinct* (better an honest gap than a lying
+guard); the gap was just resolvable. **System improvement it surfaces:** the anchor
+helpers hardcode the stated-start constant (`8094`, …) separately from the case's
+`user_message` — a future guard could parse the start out of the case's prompt so the
+anchor and the prompt can't silently drift apart. (Captured as a follow-on thought, not
+built this run — small, advisory.)
+
+## 📤 Run report
+
+- **Did:** empty scheduled fire → advanced S2 P1-1 by closing #1458's ▶ Next handoff:
+  anchored the four BTD6 projected-total eval figures after nailing the
+  starting-cash convention (`total = stated_start + range_cash`) · **Outcome:** shipped
+- **Shipped:** #1460 — `_projected_total` helper + 4 projected-total anchors +
+  corrected curation note; offline test-only; CI green (12519 passed)
+- **Run type:** `routine · dispatch` (Q-0165)
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** `none`
+- **⚑ Self-initiated:** `none` (advanced an existing plan slice / explicit handoff, S2
+  P1-1; no new idea promoted to a plan/build this PR)
+- **↪ Next:** S2 P1-1 — (a) #1458's **eval-anchor coverage report** idea (inventory every
+  numeric token in `cases.py` rubrics + fixtures, report which lack an Anchor/FixtureAnchor,
+  with an allowlist for distractors + user-inputs) is the natural next tooling slice; (b)
+  the **distractor negative-anchor guard** above; live `llm_judge` battery + absence-guard
+  Layer B stay creds-/review-gated.
+

--- a/docs/current-state/S2-btd6.md
+++ b/docs/current-state/S2-btd6.md
@@ -18,7 +18,13 @@
   numbers had no data-drift guard — now a `FixtureAnchor` table pins Navarch income ($3,200) + paragon
   cost ($550,000) to `btd6_stats_service` re-derivations and asserts they still appear in the case
   fixture (data-drift + fixture-drift), with the curation principle documented (only exactly-derivable
-  *truths* are anchored — not distractors or convention-dependent cumulative totals).
+  *truths* are anchored — not distractors). **Projected-total extension (2026-06-25 dispatch run, PR
+  #1460):** the starting-cash convention is nailed — `projected_total = stated_start + round_cash(start,
+  end).range_cash` (the stated start is the user-message constant, NOT cumulative-from-round-1; the
+  earlier "~$10 off" was a wrong-accessor probe) — so the four `knowledge.btd6_round_cash_*` / `_abr_*`
+  projected totals ($21,187.90, $39,840, $56,318.70, ABR $119,315.30) now carry both drift guards via
+  `_projected_total`. Only the **distractors** ($71,315.20, $107,164.60) and the bare user-supplied
+  starting figures stay deliberately unanchored.
 - **Buff-uptime upgrade-detail model** — `btd6_upgrade_detail_service` + AI tool + `parse_gamedata`
   extraction, multi-target uptime (#1235/#1249/#1251).
 - **Data-lifecycle hardening** — auto-seed BTD6 blob data on boot (#1255), content-drift surface
@@ -30,12 +36,12 @@
 - **P1-1 live `llm_judge` battery** (the model actually using the grounded facts — creds-gated; the
   offline grounding half now shipped, above) + absence-guard **Layer B** (the negative-existential
   gate, design-for-review; needs prod creds).
-- **Anchor the remaining range-cash convention figures** (offline, but needs the *exact* cumulative
-  convention first): the `knowledge.btd6_round_cash_*` / `_abr_*` rubrics assert cumulative totals
-  ($56,318.70, ABR $119,315.30, $5,443, …) that a naive `round_cash(1, N)` re-derives ~$10 off — so
-  they are deliberately **unanchored** (see the curation note in `test_btd6_grounding_anchors.py`).
-  A future slice that nails the cumulative/starting-cash convention can add these anchors safely;
-  until then, anchoring them would assert a wrong "truth".
+- **Anchor-tooling follow-ons** (offline, self-mergeable) — *(the range-cash + projected-total figures
+  are now anchored, #1460 above)*: #1458's **eval-anchor coverage report** (inventory every numeric
+  token in `cases.py` rubrics + fixtures; report which lack an Anchor/FixtureAnchor, allowlisting
+  distractors + user-inputs so it isn't noisy) · a **distractor negative-anchor guard** (pin that each
+  documented distractor — $71,315.20, $107,164.60 — stays *un*-derivable, so a data change can't make
+  the case silently stop guarding its confusion).
 
 **Gate:** the broad AI/BTD6 feature-expansion gate (stability + provider/provenance + caching + AI
 config) still applies — see [`../current-state.md`](../current-state.md) § Gates / blocked work.

--- a/docs/owner/claims/claude-funny-franklin-1318v3.md
+++ b/docs/owner/claims/claude-funny-franklin-1318v3.md
@@ -1,1 +1,0 @@
-- `claude/funny-franklin-1318v3` · BTD6 grounding eval — fixture-drift anchor guard (S2 P1-1) · `tests/evals/test_btd6_grounding_anchors.py` + docs · 2026-06-25

--- a/docs/owner/claims/claude-funny-franklin-26cbe2.md
+++ b/docs/owner/claims/claude-funny-franklin-26cbe2.md
@@ -1,0 +1,1 @@
+- `claude/funny-franklin-26cbe2` · BTD6 eval anchors — projected-total convention (S2 P1-1, continues #1458) · `tests/evals/test_btd6_grounding_anchors.py` · 2026-06-25

--- a/tests/evals/test_btd6_grounding_anchors.py
+++ b/tests/evals/test_btd6_grounding_anchors.py
@@ -31,14 +31,21 @@ The anchor table is the single bridge between the data and the golden set's pros
 
 Curation principle (why not every rubric/fixture number is anchored): an anchor is
 only added for a value that is BOTH an asserted *truth* AND cleanly reproducible
-from a public ``btd6_*_service`` accessor. Several rubric numbers are deliberately
-NOT anchored — some are *distractors* the rubric tells the judge to REJECT (e.g.
-BUG-0004's "$71,315.20" cumulative mislabel, truth "$56,318.70"), and the
-cumulative/range figures use a per-round-cash convention a naive ``round_cash(1, N)``
-does not reproduce (verified: it lands ~$10 off the rubric totals). Anchoring those
-without the exact convention would assert a wrong "truth" and make the guard lie —
-the opposite of its purpose (CLAUDE.md Q-0120: a green check that contradicts the
-evidence is a bug in the check). Add an anchor only when you can derive it exactly.
+from a public ``btd6_*_service`` accessor. The range-cash figures anchor via
+``round_cash(start, end).range_cash`` and the projected running totals via
+``stated_start + range_cash`` — the stated start being the constant in each case's
+``user_message`` (the convention is *start + range*, NOT cumulative-from-round-1;
+a naive ``round_cash(1, N)`` lands ~$10+ off precisely because it is the wrong
+accessor — that was an earlier curation miss, now resolved). The numbers that stay
+deliberately NOT anchored are: (a) *distractors* the rubric tells the judge to
+REJECT (BUG-0004's "$71,315.20" cumulative mislabel, truth "$56,318.70"; BUG-0010's
+"$107,164.60" standard-set figure given as the ABR answer), and (b) the bare
+user-supplied starting figures (8094 / 20000 / 26932 / 5443) — those are inputs
+stated in the prompt, not data-derived truths, so a *data*-drift guard over them
+would be meaningless. Anchoring a distractor or a non-derivable value would assert a
+wrong "truth" and make the guard lie — the opposite of its purpose (CLAUDE.md Q-0120:
+a green check that contradicts the evidence is a bug in the check). Add an anchor only
+when you can derive it exactly from the dataset.
 """
 
 from __future__ import annotations
@@ -121,6 +128,25 @@ def _range_cash(start: int, end: int, roundset: str = "default") -> Callable[[],
         res = btd6_data_service.round_cash(start, end, roundset=roundset)
         assert res.get("found"), res
         return round(float(res["range_cash"]), 2)
+
+    return derive
+
+
+def _projected_total(
+    start_cash: float, start: int, end: int, roundset: str = "default"
+) -> Callable[[], float]:
+    """The running total a projection case asserts: stated start + range cash.
+
+    The convention is ``stated_starting_cash + round_cash(start, end).range_cash``
+    — the stated start is the constant in the case's ``user_message`` (e.g.
+    "i have 8094$ at round 60"), NOT a cumulative-from-round-1 figure. (A naive
+    ``round_cash(1, end)`` does not reproduce the total; that was the curation
+    gap #1458 flagged — it used the wrong accessor.)"""
+
+    def derive() -> float:
+        res = btd6_data_service.round_cash(start, end, roundset=roundset)
+        assert res.get("found"), res
+        return round(float(start_cash) + float(res["range_cash"]), 2)
 
     return derive
 
@@ -209,6 +235,38 @@ ANCHORS: tuple[Anchor, ...] = (
         "Standard rounds 54-70 cash earned",
         29386.70,
         _range_cash(54, 70),
+    ),
+    # --- Projected running totals (stated start + range cash). The convention is
+    # stated_start + range_cash, NOT cumulative-from-round-1; the stated start is
+    # the constant in each case's user_message. (#1458 left these unanchored after
+    # a naive round_cash(1, N) probe came up ~$10 short — the wrong accessor.) ---
+    # BUG-0001 — "8094$ at round 60" → total at round 68.
+    Anchor(
+        "knowledge.btd6_round_cash_balance_bug_0001",
+        "Standard rounds 60-68 projected total ($8094 start)",
+        21187.90,
+        _projected_total(8094, 60, 68),
+    ),
+    # By-round projection — "20K by round 50" → total by round 60.
+    Anchor(
+        "knowledge.btd6_round_cash_by_round_projection",
+        "Standard rounds 50-60 projected total ($20000 start)",
+        39840.0,
+        _projected_total(20000, 50, 60),
+    ),
+    # BUG-0004 — "26932 at the end of r53" → total at r70.
+    Anchor(
+        "knowledge.btd6_round_cash_r_shorthand_bug_0004",
+        "Standard rounds 54-70 projected total ($26932 start)",
+        56318.70,
+        _projected_total(26932, 54, 70),
+    ),
+    # BUG-0010 — "started with 5443" in ABR → total over ABR rounds 25-83.
+    Anchor(
+        "knowledge.btd6_abr_range_cash_bug_0010",
+        "ABR rounds 25-83 projected total ($5443 start)",
+        119315.30,
+        _projected_total(5443, 25, 83, "abr"),
     ),
 )
 


### PR DESCRIPTION
## What

Continues the S2 P1-1 BTD6 grounding-eval anchor work (#1458) by closing its explicit
▶ Next handoff: *"anchor the remaining range-cash convention figures after nailing the
exact cumulative/starting-cash convention."*

The four **range** cash figures (rounds 60-68 / 50-60 / 54-70 / ABR 25-83) are already
anchored. The genuinely-uncovered rubric truths were the **projected running totals** the
same cases assert ($21,187.90 / $39,840 / $56,318.70 / $119,315.30 ABR). #1458 left them
unanchored believing the convention wasn't cleanly reproducible — but its "naive
`round_cash(1, N)` is ~$10 off" used the *wrong* accessor (cumulative-from-round-1).

Verified empirically that each projected total is exactly
`stated_starting_cash + round_cash(start, end).range_cash`:

| Case | stated start | + range_cash | = total | rubric |
|---|---|---|---|---|
| `…round_cash_balance_bug_0001` | 8094 | 13093.9 | **21187.9** | $21,187.90 ✓ |
| `…round_cash_by_round_projection` | 20000 | 19840.0 | **39840.0** | $39,840 ✓ |
| `…round_cash_r_shorthand_bug_0004` | 26932 | 29386.7 | **56318.7** | $56,318.70 ✓ |
| `…abr_range_cash_bug_0010` | 5443 | 113872.3 | **119315.3** | $119,315.30 ✓ |

So the convention is nailed: **projected_total = stated_start + range_cash**, the stated
start being the user-message constant in each case (NOT cumulative from round 1).

## Change (offline test-only — no `disbot/` runtime)

- `tests/evals/test_btd6_grounding_anchors.py`: a `_projected_total(start_cash, round_start,
  round_end, roundset)` derive helper + four projected-total `Anchor`s, so every
  data-derived truth these cases assert now has both drift guards (data drift +
  rubric-prose drift).
- Corrected the module curation note: the convention is reproducible; the only deliberately-
  unanchored rubric numbers are the *distractors* the rubric tells the judge to reject
  ($71,315.20, $107,164.60) and the bare user-supplied starting figures (not data-derived).

## Verify
- `python3.10 scripts/check_quality.py --full` green
- `python3.10 scripts/check_architecture.py --mode strict` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PFn2QfTTeMQz8VuJp6Mh3

---
_Generated by [Claude Code](https://claude.ai/code/session_015PFn2QfTTeMQz8VuJp6Mh3)_