### PR TITLE
S2 P1-1: anchor BTD6 #855 MOAB-class bonuses (+15/+30/+99) in the grounding eval

### DIFF
--- a/.sessions/2026-06-25-btd6-moab-bonus-anchors.md
+++ b/.sessions/2026-06-25-btd6-moab-bonus-anchors.md
@@ -1,0 +1,24 @@
+# 2026-06-25 — BTD6 eval anchors: #855 MOAB-class bonuses (S2 P1-1, follow-up to #1460)
+
+> **Status:** `in-progress`
+
+## Goal (dispatch run, slice 2 — follow-up PR)
+
+Second slice of this dispatch run. #1460 (slice 1, merged) anchored the BTD6 projected-total
+eval figures and corrected the starting-cash convention. While inventorying the remaining BTD6
+knowledge/grounding eval cases for *other* cleanly-derivable-but-unanchored truths, found one:
+`grounding.btd6_bomb_middle_path_moab_855` asserts the Bomb Shooter middle-path MOAB-class
+bonuses (**+15 / +30 / +99** — MOAB Mauler / Assassin / Eliminator, the #855 Layer A data) in
+its `llm_judge` rubric, with no anchor pinning them to the dataset. A re-seed that changed a
+bonus would leave the case silently testing a stale truth.
+
+## What I'm about to do
+
+Add a `_moab_class_bonus(tower_id, code)` derive helper that reads the public
+`btd6_stats_service.normal_stats(tower.tier(code)).specials` tuple (e.g. `('+15 vs MOAB-Class',)`
+— the same structured source the grounding renders from) and extracts the integer bonus, plus
+**three** `Anchor`s for the case (15.0 / 30.0 / 99.0). This closes the last uncovered
+cleanly-derivable BTD6 grounding truth — the BTD6 knowledge/grounding eval cases are then
+anchor-complete (only documented distractors + user-supplied inputs stay unanchored).
+
+Offline test-only (no `disbot/` runtime). Self-mergeable.

--- a/.sessions/2026-06-25-btd6-moab-bonus-anchors.md
+++ b/.sessions/2026-06-25-btd6-moab-bonus-anchors.md
@@ -1,6 +1,6 @@
 # 2026-06-25 — BTD6 eval anchors: #855 MOAB-class bonuses (S2 P1-1, follow-up to #1460)
 
-> **Status:** `in-progress`
+> **Status:** `complete` — ready to merge (Q-0133). Run type: routine · dispatch.
 
 ## Goal (dispatch run, slice 2 — follow-up PR)
 
@@ -22,3 +22,44 @@ cleanly-derivable BTD6 grounding truth — the BTD6 knowledge/grounding eval cas
 anchor-complete (only documented distractors + user-supplied inputs stay unanchored).
 
 Offline test-only (no `disbot/` runtime). Self-mergeable.
+
+## What shipped (PR #1461)
+
+- `tests/evals/test_btd6_grounding_anchors.py`: `_moab_class_bonus(tower_id, code)` helper +
+  3 `Anchor`s for `grounding.btd6_bomb_middle_path_moab_855` (15.0 / 30.0 / 99.0), both drift
+  directions.
+- `docs/current-state/S2-btd6.md`: de-staled — the BTD6 knowledge/grounding cases are now
+  anchor-complete for every cleanly-derivable truth.
+
+## Verification
+
+- `tests/evals/test_btd6_grounding_anchors.py`: **48 passed** (42 after #1460; +6 = 3 anchors
+  × 2 directions).
+- `python3.10 scripts/check_quality.py --full`: green (12525 passed in the combined
+  slice-1+slice-2 run before #1460 merged; this branch's content is identical — slice 1 from
+  main + slice 2).
+- `python3.10 scripts/check_architecture.py --mode strict`: **0 errors** (test-only).
+
+## Session enders
+
+This is the **second** PR of one dispatch run; the standing session enders (💡 Q-0089 new
+idea — the distractor *negative-anchor* guard · ⟲ Q-0102 previous-session review · Q-0104 doc
+audit · the full run report) are filed in the slice-1 card
+[`2026-06-25-btd6-projected-total-anchors.md`](2026-06-25-btd6-projected-total-anchors.md) (#1460)
+to avoid forced duplication.
+
+## 📤 Run report
+
+- **Did:** S2 P1-1 slice 2 — anchored the #855 Bomb-Shooter MOAB-class bonuses (+15/+30/+99) in
+  the grounding eval, closing the last uncovered cleanly-derivable BTD6 grounding truth ·
+  **Outcome:** shipped
+- **Shipped:** #1461 — `_moab_class_bonus` helper + 3 anchors + S2 de-stale; offline test-only
+- **Run type:** `routine · dispatch` (Q-0165)
+- **⚑ Owner decisions needed:** `none`
+- **⚑ Owner manual steps:** `none`
+- **⚑ Self-initiated:** `none` (advanced the S2 P1-1 anchor-coverage plan slice; no
+  self-invented feature)
+- **↪ Next:** S2 P1-1 anchor-tooling follow-ons — #1458's **eval-anchor coverage report** (now
+  the cleanest next slice; the manual inventory it would automate is complete as of this run) ·
+  the **distractor negative-anchor guard**; live `llm_judge` battery + absence-guard Layer B
+  stay creds-/review-gated.

--- a/docs/current-state/S2-btd6.md
+++ b/docs/current-state/S2-btd6.md
@@ -37,7 +37,9 @@
   offline grounding half now shipped, above) + absence-guard **Layer B** (the negative-existential
   gate, design-for-review; needs prod creds).
 - **Anchor-tooling follow-ons** (offline, self-mergeable) — *(the range-cash + projected-total figures
-  are now anchored, #1460 above)*: #1458's **eval-anchor coverage report** (inventory every numeric
+  AND the #855 MOAB-class bonuses +15/+30/+99 are now anchored, #1460 above — the BTD6 knowledge/
+  grounding cases are anchor-complete for every cleanly-derivable truth)*: #1458's **eval-anchor
+  coverage report** (inventory every numeric
   token in `cases.py` rubrics + fixtures; report which lack an Anchor/FixtureAnchor, allowlisting
   distractors + user-inputs so it isn't noisy) · a **distractor negative-anchor guard** (pin that each
   documented distractor — $71,315.20, $107,164.60 — stays *un*-derivable, so a data change can't make

--- a/docs/owner/claims/claude-funny-franklin-26cbe2.md
+++ b/docs/owner/claims/claude-funny-franklin-26cbe2.md
@@ -1,1 +1,0 @@
-- `claude/funny-franklin-26cbe2` · BTD6 eval anchors — projected-total convention (S2 P1-1, continues #1458) · `tests/evals/test_btd6_grounding_anchors.py` · 2026-06-25

--- a/docs/owner/claims/claude-funny-franklin-moab-anchors.md
+++ b/docs/owner/claims/claude-funny-franklin-moab-anchors.md
@@ -1,0 +1,1 @@
+- `claude/funny-franklin-moab-anchors` · BTD6 eval anchors — #855 MOAB-class bonuses (S2 P1-1, follow-up to #1460) · `tests/evals/test_btd6_grounding_anchors.py` · 2026-06-25

--- a/docs/owner/claims/claude-funny-franklin-moab-anchors.md
+++ b/docs/owner/claims/claude-funny-franklin-moab-anchors.md
@@ -1,1 +1,0 @@
-- `claude/funny-franklin-moab-anchors` · BTD6 eval anchors — #855 MOAB-class bonuses (S2 P1-1, follow-up to #1460) · `tests/evals/test_btd6_grounding_anchors.py` · 2026-06-25

--- a/tests/evals/test_btd6_grounding_anchors.py
+++ b/tests/evals/test_btd6_grounding_anchors.py
@@ -151,6 +151,32 @@ def _projected_total(
     return derive
 
 
+_MOAB_SPECIAL_RE = re.compile(r"\+(\d+) vs MOAB-Class")
+
+
+def _moab_class_bonus(tower_id: str, code: str) -> Callable[[], float]:
+    """The ``+N vs MOAB-Class`` bonus for a tower tier, from its committed stats.
+
+    This is the #855 Layer A data the grounding case asserts. It reads the public
+    ``btd6_stats_service`` tier ``specials`` (a structured tuple, e.g.
+    ``('+15 vs MOAB-Class',)``) — the same source the grounding renders from — and
+    extracts the integer bonus."""
+
+    def derive() -> float:
+        tower = btd6_stats_service.get_tower_stats(tower_id)
+        assert tower is not None, f"{tower_id} stats missing"
+        stats = btd6_stats_service.normal_stats(tower.tier(code))
+        for special in stats.specials:
+            match = _MOAB_SPECIAL_RE.search(special)
+            if match:
+                return float(match.group(1))
+        raise AssertionError(
+            f"no '+N vs MOAB-Class' special for {tower_id}:{code}: {stats.specials!r}"
+        )
+
+    return derive
+
+
 # --------------------------------------------------------------------------- #
 # The anchor table — each BTD6 number the golden set asserts as truth, paired
 # with the deterministic source that must reproduce it.
@@ -267,6 +293,28 @@ ANCHORS: tuple[Anchor, ...] = (
         "ABR rounds 25-83 projected total ($5443 start)",
         119315.30,
         _projected_total(5443, 25, 83, "abr"),
+    ),
+    # --- #855 Layer A — Bomb Shooter middle-path MOAB-Class bonuses. The grounding
+    # case asserts the answer AFFIRMS +15 / +30 / +99 (MOAB Mauler / Assassin /
+    # Eliminator); pin each to the committed tier stats so a re-seed that changed a
+    # bonus fails CI instead of leaving the case testing a stale truth. ---
+    Anchor(
+        "grounding.btd6_bomb_middle_path_moab_855",
+        "MOAB Mauler (0-3-0) bonus vs MOAB-Class",
+        15.0,
+        _moab_class_bonus("bomb_shooter", "030"),
+    ),
+    Anchor(
+        "grounding.btd6_bomb_middle_path_moab_855",
+        "MOAB Assassin (0-4-0) bonus vs MOAB-Class",
+        30.0,
+        _moab_class_bonus("bomb_shooter", "040"),
+    ),
+    Anchor(
+        "grounding.btd6_bomb_middle_path_moab_855",
+        "MOAB Eliminator (0-5-0) bonus vs MOAB-Class",
+        99.0,
+        _moab_class_bonus("bomb_shooter", "050"),
     ),
 )
 


### PR DESCRIPTION
## What

Follow-up to #1460 (same dispatch run, same S2 P1-1 anchor lane). While inventorying the
remaining BTD6 knowledge/grounding eval cases for *other* cleanly-derivable-but-unanchored
truths, found one: `grounding.btd6_bomb_middle_path_moab_855` asserts the Bomb Shooter
middle-path MOAB-class bonuses (**+15 / +30 / +99** — MOAB Mauler / Assassin / Eliminator, the
#855 Layer A data) in its `llm_judge` rubric, with **no anchor** pinning them to the dataset. A
re-seed that changed a bonus would leave the case silently testing a stale truth.

## Change (offline test-only — no `disbot/` runtime)

`tests/evals/test_btd6_grounding_anchors.py`: a `_moab_class_bonus(tower_id, code)` derive
helper reading the public `btd6_stats_service.normal_stats(tower.tier(code)).specials` tuple
(e.g. `('+15 vs MOAB-Class',)` — the same structured source the grounding renders from) and
extracting the integer bonus, + **three** `Anchor`s (15.0 / 30.0 / 99.0). Closes both drift
directions (data drift + rubric-prose drift), same as the existing anchors.

This closes the last uncovered cleanly-derivable BTD6 grounding truth — the BTD6
knowledge/grounding eval cases are now anchor-complete (only documented distractors +
user-supplied inputs stay unanchored). De-stales `docs/current-state/S2-btd6.md`.

## Verify
- `tests/evals/test_btd6_grounding_anchors.py`: 48 passed (was 42 after #1460; +6 = 3 anchors × 2 directions)
- `python3.10 scripts/check_quality.py --full` green · `check_architecture --mode strict` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PFn2QfTTeMQz8VuJp6Mh3

---
_Generated by [Claude Code](https://claude.ai/code/session_015PFn2QfTTeMQz8VuJp6Mh3)_